### PR TITLE
feat(telemetry): Trace main agent invocations

### DIFF
--- a/docs/design/gen-ai-arms-field-alignment.md
+++ b/docs/design/gen-ai-arms-field-alignment.md
@@ -4,8 +4,9 @@
 
 This design aligns the first set of Qwen Code span attributes whose names,
 types, and meanings agree between OpenTelemetry GenAI semantic conventions and
-Alibaba Cloud ARMS LLM Trace. It does not change span names, span kinds,
-parenting, or retry topology.
+Alibaba Cloud ARMS LLM Trace. It retains framework span names and kinds. The
+main-agent extension makes the existing interaction span the parent of the
+complete tool-continuation topology.
 It also documents the opt-in ARMS-only end-user identity extension.
 
 The OpenTelemetry GenAI convention is still Development status. This change is
@@ -15,6 +16,10 @@ pinned to commit
 - [Inference spans](https://raw.githubusercontent.com/open-telemetry/semantic-conventions-genai/2e994c6d59a93bb4fc1752c5378eedb9b8e14d6b/docs/gen-ai/gen-ai-spans.md)
 - [Agent spans](https://raw.githubusercontent.com/open-telemetry/semantic-conventions-genai/2e994c6d59a93bb4fc1752c5378eedb9b8e14d6b/docs/gen-ai/gen-ai-agent-spans.md)
 - [GenAI registry](https://raw.githubusercontent.com/open-telemetry/semantic-conventions-genai/2e994c6d59a93bb4fc1752c5378eedb9b8e14d6b/model/gen-ai/registry.yaml)
+
+Main-agent invocation and error-status behavior additionally follow the Agent
+span and recording-errors documents at semantic-conventions-genai commit
+[`8d3e4a0f3c34a46f6edb9c71e8666e02e6bf3958`](https://github.com/open-telemetry/semantic-conventions-genai/tree/8d3e4a0f3c34a46f6edb9c71e8666e02e6bf3958).
 
 The streaming attributes are a narrow supplement pinned to
 [OpenTelemetry Semantic Conventions v1.41.0](https://github.com/open-telemetry/semantic-conventions/blob/v1.41.0/docs/gen-ai/gen-ai-spans.md).
@@ -27,41 +32,42 @@ An upgrade to either baseline requires regenerating and reviewing this matrix.
 
 ## Field contract
 
-| Span         | Standard attributes emitted in this phase                                                                                                                                                                                | Source and omission rule                                                                                                                                                  |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| LLM          | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.conversation.id`, `gen_ai.request.model`                                                                                                                        | Written at span creation. Conversation ID is the existing session ID.                                                                                                     |
-| LLM request  | `gen_ai.request.choice.count`, `gen_ai.request.max_tokens`, `gen_ai.request.temperature`, `gen_ai.request.top_p`, `gen_ai.request.frequency_penalty`, `gen_ai.request.presence_penalty`, `gen_ai.request.stop_sequences` | Read from the first provider-final SDK request object. Invalid or unavailable values are omitted; no SDK or server defaults are inferred.                                 |
-| LLM stream   | `gen_ai.request.stream`, `gen_ai.response.time_to_first_chunk`                                                                                                                                                           | Streaming requests emit `true`; non-streaming requests omit the standard stream flag. First-chunk time is emitted in seconds after the first normalized response arrives. |
-| LLM input    | `gen_ai.input.messages`, `gen_ai.system_instructions`, `gen_ai.tool.definitions`                                                                                                                                         | Sensitive compact JSON from the same first provider-final request. Each complete value is independently omitted if invalid or oversized.                                  |
-| LLM response | `gen_ai.response.id`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`                                                                                                                                          | Provider response data only. Missing response model is omitted rather than replaced with the request model. All candidate finish reasons are ordered by candidate index.  |
-| LLM output   | `gen_ai.output.type`, `gen_ai.output.messages`                                                                                                                                                                           | Output type is emitted for supported Gemini/Vertex request settings. Sensitive output messages come from the final physical request attempt and preserve every candidate. |
-| LLM usage    | `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`                                                                            | Only provider-reported non-negative safe integers. Explicit zero is retained. When only a total is reported, input/output are omitted instead of estimated.               |
-| Tool         | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `gen_ai.tool.description`, `gen_ai.tool.type=function`, `gen_ai.tool.call.id`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`                         | Description is non-sensitive static registry metadata. Sensitive arguments reflect the executed invocation; result is emitted only for a successful tool call.            |
-| Agent        | `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name`, `gen_ai.agent.description`, `gen_ai.conversation.id`, optional `gen_ai.request.model`                                                                         | Description uses the existing 1024-UTF-16-code-unit truncation threshold and never splits surrogate pairs. Internal invocation IDs remain private.                        |
+| Span         | Standard attributes emitted in this phase                                                                                                                                                                                         | Source and omission rule                                                                                                                                                                                                         |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LLM          | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.conversation.id`, `gen_ai.request.model`                                                                                                                                 | Written at span creation. Conversation ID is the existing session ID.                                                                                                                                                            |
+| LLM request  | `gen_ai.request.choice.count`, `gen_ai.request.max_tokens`, `gen_ai.request.temperature`, `gen_ai.request.top_p`, `gen_ai.request.frequency_penalty`, `gen_ai.request.presence_penalty`, `gen_ai.request.stop_sequences`          | Read from the first provider-final SDK request object. Invalid or unavailable values are omitted; no SDK or server defaults are inferred.                                                                                        |
+| LLM stream   | `gen_ai.request.stream`, `gen_ai.response.time_to_first_chunk`                                                                                                                                                                    | Streaming requests emit `true`; non-streaming requests omit the standard stream flag. First-chunk time is emitted in seconds after the first normalized response arrives.                                                        |
+| LLM input    | `gen_ai.input.messages`, `gen_ai.system_instructions`, `gen_ai.tool.definitions`                                                                                                                                                  | Sensitive compact JSON from the same first provider-final request. Each complete value is independently omitted if invalid or oversized.                                                                                         |
+| LLM response | `gen_ai.response.id`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`                                                                                                                                                   | Provider response data only. Missing response model is omitted rather than replaced with the request model. All candidate finish reasons are ordered by candidate index.                                                         |
+| LLM output   | `gen_ai.output.type`, `gen_ai.output.messages`                                                                                                                                                                                    | Output type is emitted for supported Gemini/Vertex request settings. Sensitive output messages come from the final physical request attempt and preserve every candidate.                                                        |
+| LLM usage    | `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`                                                                                     | Only provider-reported non-negative safe integers. Explicit zero is retained. When only a total is reported, input/output are omitted instead of estimated.                                                                      |
+| Tool         | `gen_ai.operation.name=execute_tool`, conditional `gen_ai.agent.name`, `gen_ai.tool.name`, `gen_ai.tool.description`, `gen_ai.tool.type=function`, `gen_ai.tool.call.id`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` | Agent name is copied from the actual parent agent. Description is static metadata; sensitive arguments reflect the executed invocation and result is success-only.                                                               |
+| Main agent   | `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name=qwen-code`, `gen_ai.conversation.id`, optional `gen_ai.output.type=json`, sensitive `gen_ai.input.messages`, sensitive `gen_ai.output.messages`                          | Uses the existing interaction span. Input is one original user-prompt projection; output is one final user-visible answer. Request model, provider, agent ID/version/description, instructions, and aggregate usage are omitted. |
+| Subagent     | `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name`, `gen_ai.agent.description`, `gen_ai.conversation.id`, optional `gen_ai.request.model`                                                                                  | Description is bounded to 1024 UTF-16 code units. Internal invocation IDs remain private.                                                                                                                                        |
 
 Private attributes without an exact standard equivalent remain available for
 compatibility unless explicitly listed for removal below. Exact-equivalent
 private aliases and invalid GenAI aliases are removed without a dual-write
 period:
 
-| Removed attribute                                      | Replacement                                                                                                           |
-| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| LLM `qwen-code.model`                                  | `gen_ai.request.model`; interaction spans continue using `qwen-code.model` because they are not GenAI inference spans |
-| LLM `response_id`                                      | `gen_ai.response.id`; API response/error logs retain their existing `response_id` schema                              |
-| LLM `input_tokens`                                     | `gen_ai.usage.input_tokens` when the provider reports an input breakdown                                              |
-| LLM `output_tokens`                                    | `gen_ai.usage.output_tokens` when the provider reports an output breakdown                                            |
-| LLM `cached_input_tokens`                              | `gen_ai.usage.cache_read.input_tokens` when the provider reports cache reads                                          |
-| `qwen-code.tool` Span `tool.name`                      | `gen_ai.tool.name`; blocked-on-user and hook spans continue using `tool.name`                                         |
-| `gen_ai.usage.cached_tokens`                           | `gen_ai.usage.cache_read.input_tokens` when the provider reports cache reads                                          |
-| LLM `llm_request.stream`                               | `gen_ai.request.stream`; streaming emits `true`, non-streaming omits the attribute per the semantic convention        |
-| `gen_ai.server.time_to_first_token`                    | Not emitted; it is not equivalent to the standard first-chunk attribute                                               |
-| `gen_ai.usage.reasoning_tokens`                        | No ARMS/GenAI common attribute in this baseline; continue querying private `thoughts_token_count`                     |
-| LLM `system_prompt*`                                   | `gen_ai.system_instructions`; OpenAI system/developer messages are represented in `gen_ai.input.messages`             |
-| LLM `tools`, `tool_schema` events                      | `gen_ai.tool.definitions`                                                                                             |
-| LLM `response.model_output*`                           | `gen_ai.output.messages`                                                                                              |
-| Tool `tool_input*`                                     | `gen_ai.tool.call.arguments`                                                                                          |
-| Tool `tool_result*`                                    | `gen_ai.tool.call.result`                                                                                             |
-| `tools_count`, hash/preview/length/truncation metadata | No standard equivalent; removed                                                                                       |
+| Removed attribute                                      | Replacement                                                                                                                                                     |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LLM `qwen-code.model`                                  | `gen_ai.request.model`; main-agent interactions retain `qwen-code.model` and omit the standard request model because selection can change during the invocation |
+| LLM `response_id`                                      | `gen_ai.response.id`; API response/error logs retain their existing `response_id` schema                                                                        |
+| LLM `input_tokens`                                     | `gen_ai.usage.input_tokens` when the provider reports an input breakdown                                                                                        |
+| LLM `output_tokens`                                    | `gen_ai.usage.output_tokens` when the provider reports an output breakdown                                                                                      |
+| LLM `cached_input_tokens`                              | `gen_ai.usage.cache_read.input_tokens` when the provider reports cache reads                                                                                    |
+| `qwen-code.tool` Span `tool.name`                      | `gen_ai.tool.name`; blocked-on-user and hook spans continue using `tool.name`                                                                                   |
+| `gen_ai.usage.cached_tokens`                           | `gen_ai.usage.cache_read.input_tokens` when the provider reports cache reads                                                                                    |
+| LLM `llm_request.stream`                               | `gen_ai.request.stream`; streaming emits `true`, non-streaming omits the attribute per the semantic convention                                                  |
+| `gen_ai.server.time_to_first_token`                    | Not emitted; it is not equivalent to the standard first-chunk attribute                                                                                         |
+| `gen_ai.usage.reasoning_tokens`                        | No ARMS/GenAI common attribute in this baseline; continue querying private `thoughts_token_count`                                                               |
+| LLM `system_prompt*`                                   | `gen_ai.system_instructions`; OpenAI system/developer messages are represented in `gen_ai.input.messages`                                                       |
+| LLM `tools`, `tool_schema` events                      | `gen_ai.tool.definitions`                                                                                                                                       |
+| LLM `response.model_output*`                           | `gen_ai.output.messages`                                                                                                                                        |
+| Tool `tool_input*`                                     | `gen_ai.tool.call.arguments`                                                                                                                                    |
+| Tool `tool_result*`                                    | `gen_ai.tool.call.result`                                                                                                                                       |
+| `tools_count`, hash/preview/length/truncation metadata | No standard equivalent; removed                                                                                                                                 |
 
 `gen_ai.response.finish_reasons` now preserves the provider's raw strings for
 all candidates instead of the previous Gemini-normalized values. Existing
@@ -160,6 +166,8 @@ canonical parts rather than raw chunks. Partial failures mark unfinished
 candidates with `error`; a successful response with a candidate that lacks an
 explicit finish reason omits the complete output-message attribute.
 
+The main-agent interaction uses a separate projection rather than the provider accumulator. Its input is one reliable original user text before model-context expansion. Its output is the single final user-visible text after tool, retry, fallback, Hook, Steer, and next-speaker continuations settle. ACP channel delivery retains its independent full-text buffer and is not truncated by the telemetry limit. Structured output is compact JSON text with `finish_reason=tool_call`.
+
 Each JSON attribute is compactly serialized and independently limited by
 `telemetry.sensitiveSpanAttributeMaxLength`. Invalid, cyclic, incomplete, or
 oversized attribute values are omitted as a whole; JSON is never truncated.
@@ -170,8 +178,9 @@ normalized to Draft-07, only that optional property is omitted while the
 ordered tool identity list is retained. Empty arrays and objects are retained
 when the provider explicitly sends or returns them. With the default 1 MiB
 limit, the application-side theoretical maximum is about 4 MiB of sensitive
-attributes per LLM span and 2 MiB per Tool span. Collectors and backends can
-impose lower limits.
+attributes per LLM span, 2 MiB per Tool span, and 3 MiB per interaction across
+Agent input, Agent output, and the compatibility `new_context` attribute.
+Collectors and backends can impose lower limits.
 
 Tool arguments are captured from the final invocation parameters immediately
 before execution, after permission and edit hooks. A tool result is captured
@@ -226,9 +235,9 @@ OpenTelemetry GenAI baseline above. Qwen Code emits it only when the operator
 explicitly configures `telemetry.userId` or `QWEN_TELEMETRY_USER_ID`. The value
 is placed on the interaction Span at creation and propagated through the
 existing in-process context to LLM, Tool, and Agent spans, including linked-root
-fork/background agents. Tool-result continuations resolve the same logical
-interaction by prompt ID without changing Span parenting; that minimal identity
-entry expires with the existing 30-minute Span safety-net TTL.
+fork/background agents. Tool-result continuations resolve the same active
+interaction by exact prompt ID and remain its children. The active registry and
+retained identity entry expire with the existing 30-minute Span safety-net TTL.
 
 The value is never inferred, generated, written to Resource/logs/metrics, or
 placed in outbound Baggage. Qwen Code does not dual-write `enduser.id` or

--- a/docs/design/telemetry-main-agent-spans-design.md
+++ b/docs/design/telemetry-main-agent-spans-design.md
@@ -1,0 +1,46 @@
+# Main agent invocation tracing
+
+## Goal
+
+Represent one logical Qwen Code main-agent invocation with the existing `qwen-code.interaction` span. The span covers every LLM request, tool approval and execution, and model continuation that belongs to the same prompt. This avoids a second wrapper span while making the trace compliant with the OpenTelemetry GenAI Agent span convention.
+
+## Semantic contract
+
+The interaction span keeps its framework-defined name, `SpanKind.INTERNAL`, and existing compatibility attributes. At creation it adds:
+
+- `gen_ai.operation.name=invoke_agent`
+- `gen_ai.agent.name=qwen-code`
+- `gen_ai.conversation.id=<session id>`
+- `gen_ai.output.type=json` only when a JSON Schema constrains the model output
+
+`qwen-code.model` remains available for compatibility. `gen_ai.request.model` is omitted because the main agent can use model overrides, fallback, and dynamic selection. The main span also omits `gen_ai.provider.name` and `gen_ai.agent.id`, `gen_ai.agent.version`, and `gen_ai.agent.description`: Qwen Code has no hosted-agent identity or canonical runtime description for those fields.
+
+LLM spans do not receive `gen_ai.agent.name`. Execute-tool spans copy `gen_ai.agent.name` from their actual parent context, so main-agent tools use `qwen-code`, subagent tools use the subagent name, and standalone tools omit the field.
+
+When `telemetry.includeSensitiveSpanAttributes` is enabled, a user-origin invocation may also record `gen_ai.input.messages` as one user text message containing the original prompt before `@file`, IDE, hook, system-reminder, or tool-result expansion. Automatic Retry, Continue, Notification, Teammate, Cron, and runtime Goal invocations do not synthesize user input. ACP prefers its validated display text over its internal model prompt.
+
+A successful invocation may record `gen_ai.output.messages` as one assistant text message containing only the final user-visible answer. The capture excludes thought parts, alternate candidates, tool prefaces and calls, tool results, Stop-hook instructions, and obsolete retry or continuation attempts. `MAX_TOKENS` maps to `length`, filtered output maps to `content_filter`, and structured JSON success is compact JSON text with `finish_reason=tool_call`. Failed, cancelled, incomplete, tool-pending, loop-detected, and structured-output-missing invocations omit partial output. These two attributes are independently omitted rather than truncated when their complete compact JSON exceeds `telemetry.sensitiveSpanAttributeMaxLength`.
+
+## Lifecycle
+
+Active main-agent interactions are stored in a strong `promptId -> SpanContext` registry. Explicit prompt IDs resolve only an exact owner; they never fall back to a process-global "last interaction". Calls without a prompt ID may use only the current AsyncLocalStorage interaction.
+
+`UserQuery`, `Retry`, `Cron`, `Notification`, `Teammate`, and `Goal` start a new invocation. `ToolResult`, `Hook`, and `Steer` continue an existing invocation only when their prompt ID resolves to an active owner. Starting another invocation with the same prompt ID first cancels the unfinished span instead of silently replacing it.
+
+An interaction remains open while the model has pending tool calls. The TUI and headless runners explicitly close it when they will not submit the tool result, including cancellation, Goal termination, structured output, model-switch termination, background-capacity exhaustion, continuation admission failure, and invocation handoff. Shutdown closes every registered interaction. The existing 30-minute TTL remains a final leak safety net and removes the corresponding registry entry.
+
+The lifecycle deliberately uses terminal state plus idempotent finalization rather than reference counting. Hook and steer continuations are synchronously nested, while tool-result continuations are correlated by prompt ID.
+
+## Status and errors
+
+Successful and cancelled GenAI spans leave OpenTelemetry status `UNSET`. Failed spans set status `ERROR`, write a bounded and sanitized status description, and include a low-cardinality `error.type`. This applies to interaction, LLM, tool, tool-execution, hook, and subagent spans.
+
+## Compatibility
+
+The longer lifecycle changes `interaction.duration_ms`: it now includes tool execution and approval wait time. Retry and Goal messages create additional interaction spans. CLI interactions remain trace roots, while ACP and daemon interactions continue to honor an explicit inbound parent context.
+
+This phase does not aggregate token usage on agent spans, capture system instructions or tool definitions on the agent span, add configuration switches, or trace workflow invocations and workflow dispatches.
+
+## Verification
+
+Unit tests cover both interaction creation APIs, exact attributes and omissions, JSON Schema output type, status/error behavior, prompt isolation, duplicate prompt handling, TTL and shutdown cleanup, external parents, tool agent-name inheritance, original-input provenance, bounded final-output capture, retries, tool loops, Stop/Steer continuations, and exact span ownership. The GenAI integration test verifies that one interaction parents two LLM requests and one tool span in the same trace while recording only the original user prompt and final answer on the interaction.

--- a/docs/design/telemetry-subagent-spans-design.md
+++ b/docs/design/telemetry-subagent-spans-design.md
@@ -2,8 +2,9 @@
 
 > **GenAI attribute migration:**
 > [`gen-ai-arms-field-alignment.md`](./gen-ai-arms-field-alignment.md) supersedes
-> this document's use of `gen_ai.provider.name=qwen-code` and the temporary
-> `gen_ai.agent.id`. The `qwen-code.subagent.*` lifecycle, identity, parenting,
+> the historical proposal to emit `gen_ai.provider.name=qwen-code` and the
+> temporary `gen_ai.agent.id`. Neither field is emitted. The
+> `qwen-code.subagent.*` lifecycle, identity, parenting,
 > and linking design described here remains valid.
 
 > Issue #3731 — Phase 3 of hierarchical session tracing. Adds a `qwen-code.subagent` span so subagent invocations get isolated, queryable trace structure instead of interleaving silently under the parent `qwen-code.interaction` span.
@@ -41,7 +42,7 @@ Today every `AgentTool.execute` invocation runs under the parent's `qwen-code.in
 | Source                                                                                                                 | Key takeaway                                                                                                                                                                                                                                                                                                                 |
 | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [OTel Trace Spec — Links between spans](https://opentelemetry.io/docs/specs/otel/overview/#links-between-spans)        | Verbatim: "The new linked Trace may also represent a long running asynchronous data processing operation that was initiated by one of many fast incoming requests." → fork/background should be linked roots, not children.                                                                                                  |
-| [OTel GenAI Agent Spans](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) (status: Development) | Span name `invoke_agent {gen_ai.agent.name}`; required attrs `gen_ai.operation.name`, `gen_ai.provider.name`; recommended: `gen_ai.agent.id`, `gen_ai.agent.name`, `gen_ai.conversation.id`.                                                                                                                                 |
+| [OTel GenAI Agent Spans](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) (status: Development) | Frameworks may define their own span name. `gen_ai.operation.name` identifies invocation; agent name and conversation ID are conditional. Provider is not required for an in-process agent.                                                                                                                                  |
 | LangSmith — 25,000 runs / trace cap                                                                                    | Long agent sessions force trace splitting eventually; favors hybrid traceId design.                                                                                                                                                                                                                                          |
 | [Sentry — distributed tracing](https://docs.sentry.io/concepts/key-terms/tracing/distributed-tracing/)                 | "Child transactions may outlive the transactions containing their parent spans" — child-with-outliving-life is supported.                                                                                                                                                                                                    |
 | claude-code (Anthropic)                                                                                                | Has subagent hierarchy in local Perfetto JSON file only; OTel export is flat. No portable code.                                                                                                                                                                                                                              |
@@ -171,8 +172,8 @@ OTel GenAI spec says the canonical span name is `invoke_agent {gen_ai.agent.name
 | Category                                                         | Attribute                                       | Source                                                               | Notes                                                                                                                                                                            |
 | ---------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Required spec**                                                | `gen_ai.operation.name='invoke_agent'`          | literal                                                              | spec-required                                                                                                                                                                    |
-| **Required spec**                                                | `gen_ai.provider.name='qwen-code'`              | literal                                                              | spec-required; ambiguous for in-process agents (spec wrote it for LLM provider). Setting to `'qwen-code'` is the most honest interpretation                                      |
-| **Required (dual-emit)**                                         | `gen_ai.agent.id` + `qwen-code.subagent.id`     | `agentContext.agentId`                                               | dual-emit until spec reaches Stable; remove vendor key later                                                                                                                     |
+| **Omitted**                                                      | `gen_ai.provider.name`                          | —                                                                    | no hosted provider identity exists for the in-process agent                                                                                                                      |
+| **Vendor only**                                                  | `qwen-code.subagent.id`                         | `agentContext.agentId`                                               | per-invocation identity is not a stable `gen_ai.agent.id`                                                                                                                        |
 | **Required (dual-emit)**                                         | `gen_ai.agent.name` + `qwen-code.subagent.name` | `agentConfig.subagentType` (e.g. `Explore`, `code-reviewer`, `fork`) | same dual-emit                                                                                                                                                                   |
 | **Recommended spec**                                             | `gen_ai.conversation.id`                        | `config.getSessionId()`                                              | enables cross-trace queries by session; co-exists with the existing `session.id` span attr (set globally per #4367) — both point at the same UUID, drop one when spec stabilises |
 | **Recommended spec**                                             | `gen_ai.request.model`                          | model override if any                                                | only when subagent overrides parent model                                                                                                                                        |
@@ -193,11 +194,11 @@ OTel GenAI spec says the canonical span name is `invoke_agent {gen_ai.agent.name
 
 **SpanStatus mapping**:
 
-- `status === 'completed'` → `SpanStatus { code: OK }`
+- `status === 'completed'` → `SpanStatus { code: UNSET }`
 - `status === 'failed'` → `SpanStatus { code: ERROR, message: truncated(error.message) }`
 - `status === 'cancelled'` or `'aborted'` → `SpanStatus { code: UNSET }` (matches Phase 2 convention)
 
-**Why dual-emit on `id` + `name`**: spec is in Development (one step earlier than Experimental). `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` exists for opt-in. Spec attr names may rename before Stable. Dual-emit is the same pattern Phase 2 used for `call_id` → `tool.call_id`; remove the vendor key when spec reaches Stable.
+**Why retain vendor identity attributes**: the per-invocation `qwen-code.subagent.id` is not a stable Agent identity, so it is not copied to `gen_ai.agent.id`. The stable agent name is dual-emitted under the standard and vendor keys while the GenAI convention remains in Development; remove the vendor name key when the convention reaches Stable.
 
 **Why `qwen-code.subagent.*` (not `qwen.subagent.*`)**: every existing vendor-prefixed key in `constants.ts` uses `qwen-code.*` (`qwen-code.user_prompt`, `qwen-code.tool_call`, etc.). Internal consistency > OTel naming-convention preference, since operators query ARMS by prefix.
 
@@ -453,7 +454,7 @@ If review pushes back on size: split into 2 PRs — (A) telemetry helpers + test
 | `3 concurrent subagent spans don't share children`                           | Headline concurrency guarantee                                  |
 | `nested subagent records depth + parentAgentId`                              | Nesting metadata                                                |
 | `endSubagentSpan status mapping (completed / failed / cancelled / aborted)`  | Status taxonomy                                                 |
-| `endSubagentSpan dual-emits gen_ai.agent.id + qwen-code.subagent.id`         | Spec-compliance dual-emit                                       |
+| `subagent ID stays vendor-only; agent name dual-emits`                       | Stable Agent identity and compatibility boundaries              |
 | `fork lifecycle: span survives AgentTool.execute return`                     | Fire-and-forget correctness                                     |
 | `TTL: subagent fork stays past 30min, gets stamped + ended at 4h`            | Type-aware TTL                                                  |
 | `TTL: foreground subagent at 30min gets default sweep`                       | TTL doesn't over-extend                                         |
@@ -524,7 +525,7 @@ These are all already gated; #4097's pattern is to call `addSubagentSensitiveAtt
 
 ## Open questions
 
-1. **`gen_ai.provider.name`**: spec requires it but writes the description for LLM provider, not agent framework. Setting to `'qwen-code'` is best interpretation; if a future spec revision adds an `agent.provider.name` variant we should switch.
+1. **`gen_ai.provider.name`**: omitted because an in-process subagent has no hosted-agent provider identity. Revisit only if the convention defines a matching identity.
 2. **Span name `qwen-code.subagent` vs spec `invoke_agent {name}`**: chose internal consistency. If GenAI-aware tooling adoption grows and `invoke_agent ${name}` becomes critical for auto-discovery, we can switch — span name is the most rebrandable thing in OTel.
 3. **Soft-warn at depth ≥ 5**: arbitrary number. Could be a config knob. Defer until production data shows a need.
 4. **`SubagentExecutionEvent.result`'s full LLM output is large**: today it bloats LogRecord volume. The migration plan (LogRecord → span events) is deferred but worth doing once token-usage aggregation lands in Phase 4.

--- a/docs/developers/development/telemetry.md
+++ b/docs/developers/development/telemetry.md
@@ -102,18 +102,21 @@ details.
 two things happen:
 
 1. **Native span attributes** carry standard OpenTelemetry GenAI JSON:
-   - LLM input messages (`gen_ai.input.messages`)
+   - Main-agent and LLM input messages (`gen_ai.input.messages`)
    - System instructions (`gen_ai.system_instructions`)
    - Tool definitions (`gen_ai.tool.definitions`)
-   - LLM output messages (`gen_ai.output.messages`)
+   - Main-agent and LLM output messages (`gen_ai.output.messages`)
    - Final executed tool arguments (`gen_ai.tool.call.arguments`)
    - Successful tool results (`gen_ai.tool.call.result`)
-   - Interaction spans continue to use `new_context` because they are not GenAI
-     inference spans.
+   - Interaction spans retain the compatibility `new_context` attribute.
 
-   LLM values come from provider-final SDK request objects and raw provider
-   responses, not the original logical configuration. Tool values come from
-   the final invocation parameters and successful model-facing result. Each
+   Main-agent input is one original user-text projection before context
+   expansion, and main-agent output is one final user-visible answer after all
+   tool and continuation work settles. LLM values still come from provider-final
+   SDK request objects and raw provider responses, so their input can include
+   history, expanded files, system instructions, and tool results, and their
+   output can include every provider candidate. Tool values come from the final
+   invocation parameters and successful model-facing result. Each
    standard GenAI value is compact JSON and must be complete and schema-valid.
    A value that is invalid, cyclic, or longer than
    `sensitiveSpanAttributeMaxLength` is omitted as a whole; JSON is never
@@ -134,13 +137,7 @@ secrets in env vars or arguments), and model responses to the configured OTLP
 backend. Treat the backend as a privileged data sink. The flag defaults to
 `false`.
 
-**Cost / payload size:** At the default limit, one LLM span can carry at most
-about 4 MiB across input, output, system instructions, and tool definitions;
-one Tool span can carry about 2 MiB across arguments and result. This is Qwen
-Code's application-side cap, not a guarantee that every collector or backend
-accepts a single attribute that large. If spans are rejected or dropped, lower
-`sensitiveSpanAttributeMaxLength` (for example, to `61440`) and monitor exporter
-throughput.
+**Cost / payload size:** At the default limit, one LLM span can carry at most about 4 MiB across input, output, system instructions, and tool definitions; one Tool span can carry about 2 MiB across arguments and result; and one interaction can carry about 3 MiB across Agent input, Agent output, and compatibility `new_context`. This is Qwen Code's application-side cap, not a guarantee that every collector or backend accepts a single attribute that large. If spans are rejected or dropped, lower `sensitiveSpanAttributeMaxLength` (for example, to `61440`) and monitor exporter throughput.
 
 This setting does not disable sensitive data in OTel logs or other telemetry
 sinks; non-internal API response telemetry can populate `response_text`, so
@@ -862,7 +859,7 @@ The daemon process (long-running HTTP server mode) exposes its own metrics.
 
 ### Spans
 
-Distributed tracing spans form a tree rooted at `qwen-code.interaction`. Each interaction is a trace root with its own `traceId`; cross-prompt correlation uses the `session.id` attribute.
+Distributed tracing spans form a tree rooted at `qwen-code.interaction`. In the CLI, each interaction is a trace root with its own `traceId`; ACP and daemon paths may inherit an inbound parent context. Cross-prompt correlation uses the `session.id` attribute.
 
 Session lifecycle is also exported through the OpenTelemetry General Session
 semantic conventions. When the OTel logs pipeline is enabled, Qwen Code emits
@@ -878,8 +875,11 @@ The existing Qwen-specific `qwen-code.config`/`cli_config` and RUM
 `session_start` records remain available for compatibility. GenAI request
 spans continue to use `gen_ai.conversation.id` for the same owning session ID.
 
-- `qwen-code.interaction`: Root span for each user prompt turn.
-  - **Attributes**: `session.id`, optional ARMS extension `gen_ai.user.id`, `qwen-code.prompt_id`, `qwen-code.message_type`, `qwen-code.model`, `qwen-code.approval_mode`, `interaction.sequence`, `interaction.duration_ms`, `qwen-code.turn_status` ("ok"/"error"/"cancelled")
+- `qwen-code.interaction`: Main-agent invocation span. It covers all LLM requests, tool approval/execution, and continuations for one logical prompt. User queries, retries, cron prompts, notifications, teammate messages, and Goal turns create invocations; tool results, hooks, and steering reuse the exact active prompt ID.
+  - **GenAI attributes**: `gen_ai.operation.name` (`invoke_agent`), `gen_ai.agent.name` (`qwen-code`), `gen_ai.conversation.id`, optional `gen_ai.output.type` (`json` only with a configured JSON Schema), sensitive `gen_ai.input.messages`, sensitive `gen_ai.output.messages`, and optional ARMS extension `gen_ai.user.id`
+  - **Compatibility attributes**: `session.id`, `qwen-code.prompt_id`, `qwen-code.message_type`, `qwen-code.model`, `qwen-code.approval_mode`, `interaction.sequence`, `interaction.duration_ms`, `qwen-code.turn_status` ("ok"/"error"/"cancelled")
+  - `gen_ai.request.model` is intentionally omitted because the agent supports overrides, fallback, and dynamic model selection. `gen_ai.provider.name` and agent ID/version/description are also omitted.
+  - Agent input is one original user prompt, not the expanded model request. Agent output is one final user-visible text projection; structured JSON uses compact JSON text with `finish_reason=tool_call`. Both are omitted unless sensitive span attributes are enabled and the complete JSON fits the per-attribute limit.
 
 - `qwen-code.llm_request`: Wraps a single LLM API call.
   - **GenAI attributes**: `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.conversation.id`, optional ARMS extension `gen_ai.user.id`, `gen_ai.request.model`, `gen_ai.request.stream`, `gen_ai.request.choice.count`, `gen_ai.request.max_tokens`, `gen_ai.request.temperature`, `gen_ai.request.top_p`, `gen_ai.request.frequency_penalty`, `gen_ai.request.presence_penalty`, `gen_ai.request.stop_sequences`, optional `gen_ai.output.type`, `gen_ai.response.id`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`, `gen_ai.response.time_to_first_chunk`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`
@@ -889,7 +889,7 @@ spans continue to use `gen_ai.conversation.id` for the same owning session ID.
   - Streaming requests emit `gen_ai.request.stream=true`. `gen_ai.response.time_to_first_chunk` measures seconds from the provider call to the first normalized response yielded by the provider adapter, which may differ from the first raw network frame. Non-streaming requests omit both standard streaming attributes because an absent `gen_ai.request.stream` means non-streaming in the semantic convention.
 
 - `qwen-code.tool`: Wraps the full tool lifecycle (approval wait + execution).
-  - **Attributes**: `session.id`, optional ARMS extension `gen_ai.user.id`, `gen_ai.operation.name` (`execute_tool`), `gen_ai.tool.name`, `gen_ai.tool.type` (`function`), `gen_ai.tool.call.id`, `tool.call_id`, `duration_ms`, `success`, `error`, `tool.failure_kind` (string, optional — the specific failure reason, e.g. "cancelled", "tool_error", "tool_exception", "timeout", "permission_denied", "pre_hook_blocked")
+  - **Attributes**: `session.id`, optional ARMS extension `gen_ai.user.id`, `gen_ai.operation.name` (`execute_tool`), optional inherited `gen_ai.agent.name`, `gen_ai.tool.name`, `gen_ai.tool.type` (`function`), `gen_ai.tool.call.id`, `tool.call_id`, `duration_ms`, `success`, `error`, `error.type` on failure, `tool.failure_kind` (string, optional — the specific failure reason, e.g. "cancelled", "tool_error", "tool_exception", "timeout", "permission_denied", "pre_hook_blocked")
 
 - `qwen-code.tool.execution`: Wraps the tool execution phase (after approval). Emitted only for attempted executions.
   - **Attributes**: `session.id`, `gen_ai.tool.name` (optional), `tool.call_id` (optional), `duration_ms`, `success`, `error`, `execution_status` ("success"/"error"/"cancelled"), `error_type`, `error.type`
@@ -902,6 +902,8 @@ spans continue to use `gen_ai.conversation.id` for the same owning session ID.
 
 - `qwen-code.subagent`: Wraps a single subagent invocation.
   - **Attributes**: `gen_ai.operation.name` (`invoke_agent`), `gen_ai.agent.name`, `gen_ai.agent.description`, `gen_ai.conversation.id`, optional ARMS extension `gen_ai.user.id`, optional `gen_ai.request.model`, `qwen-code.subagent.id`, `qwen-code.subagent.name`, `qwen-code.subagent.invocation_kind` ("foreground"/"fork"/"background"), `qwen-code.subagent.is_built_in`, `qwen-code.subagent.depth`, `qwen-code.subagent.status`, `qwen-code.subagent.terminate_reason`, `qwen-code.subagent.duration_ms`
+
+Successful and cancelled GenAI spans leave `SpanStatus` as `UNSET`. Failures set `ERROR`, a bounded status description, and low-cardinality `error.type`.
 
 #### GenAI field migration and ARMS recognition
 

--- a/integration-tests/cli/gen-ai-telemetry.test.ts
+++ b/integration-tests/cli/gen-ai-telemetry.test.ts
@@ -16,6 +16,9 @@ import {
 type TelemetryRecord = {
   name?: string;
   attributes?: Record<string, unknown>;
+  _spanContext?: { traceId?: string; spanId?: string };
+  parentSpanContext?: { traceId?: string; spanId?: string };
+  status?: { code?: number; message?: string };
   events?: Array<{ name?: string }>;
   resource?: {
     _rawAttributes?: Array<[string, unknown]>;
@@ -81,6 +84,7 @@ describeLocal('GenAI telemetry fields', () => {
       requestIndex === 0
         ? {
             model: 'provider-model-tool',
+            content: 'I will run the tool.',
             toolCalls: [
               fakeToolCall(
                 'run_shell_command',
@@ -178,12 +182,60 @@ describeLocal('GenAI telemetry fields', () => {
 
     const firstLlm = llmSpans[0]!.attributes!;
     const secondLlm = llmSpans[1]!.attributes!;
-    const interactionSpan = records.find(
+    const interactionSpans = records.filter(
       (record) => record.name === 'qwen-code.interaction',
     );
+    expect(interactionSpans).toHaveLength(1);
+    const interactionSpan = interactionSpans[0]!;
     expect(interactionSpan?.attributes?.['gen_ai.user.id']).toBe(
       'integration-user-079458',
     );
+    expect(interactionSpan.attributes).toMatchObject({
+      'gen_ai.operation.name': 'invoke_agent',
+      'gen_ai.agent.name': 'qwen-code',
+      'gen_ai.conversation.id': expect.any(String),
+      'qwen-code.model': 'request-model',
+    });
+    expect(interactionSpan.attributes).not.toHaveProperty(
+      'gen_ai.request.model',
+    );
+    expect(interactionSpan.attributes).not.toHaveProperty(
+      'gen_ai.provider.name',
+    );
+    expect(interactionSpan.attributes).not.toHaveProperty('gen_ai.output.type');
+    expect(
+      JSON.parse(
+        interactionSpan.attributes?.['gen_ai.input.messages'] as string,
+      ),
+    ).toEqual([
+      {
+        role: 'user',
+        parts: [
+          {
+            type: 'text',
+            content: 'Run the requested tool and then report completion.',
+          },
+        ],
+      },
+    ]);
+    expect(
+      JSON.parse(
+        interactionSpan.attributes?.['gen_ai.output.messages'] as string,
+      ),
+    ).toEqual([
+      {
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'Tool completed.' }],
+        finish_reason: 'stop',
+      },
+    ]);
+    const interactionMessages = JSON.stringify({
+      input: interactionSpan.attributes?.['gen_ai.input.messages'],
+      output: interactionSpan.attributes?.['gen_ai.output.messages'],
+    });
+    expect(interactionMessages).not.toContain('I will run the tool.');
+    expect(interactionMessages).not.toContain('Alternative final answer.');
+    expect(interactionMessages).not.toContain('provider-call-123');
     expect(firstLlm).toMatchObject({
       'gen_ai.user.id': 'integration-user-079458',
       'gen_ai.operation.name': 'chat',
@@ -279,6 +331,7 @@ describeLocal('GenAI telemetry fields', () => {
       {
         role: 'assistant',
         parts: [
+          { type: 'text', content: 'I will run the tool.' },
           {
             type: 'tool_call',
             id: 'provider-call-123',
@@ -303,6 +356,7 @@ describeLocal('GenAI telemetry fields', () => {
     ]);
 
     for (const attributes of [firstLlm, secondLlm]) {
+      expect(attributes).not.toHaveProperty('gen_ai.agent.name');
       expect(attributes).not.toHaveProperty('qwen-code.model');
       expect(attributes).not.toHaveProperty('response_id');
       expect(attributes).not.toHaveProperty('input_tokens');
@@ -350,6 +404,7 @@ describeLocal('GenAI telemetry fields', () => {
     expect(toolSpan?.attributes).toMatchObject({
       'gen_ai.user.id': 'integration-user-079458',
       'gen_ai.operation.name': 'execute_tool',
+      'gen_ai.agent.name': 'qwen-code',
       'gen_ai.tool.name': 'run_shell_command',
       'gen_ai.tool.type': 'function',
       'gen_ai.tool.call.id': 'provider-call-123',
@@ -369,6 +424,20 @@ describeLocal('GenAI telemetry fields', () => {
     expect(toolSpan?.attributes).not.toHaveProperty('tool.name');
     expect(toolSpan?.attributes).not.toHaveProperty('tool_input');
     expect(toolSpan?.attributes).not.toHaveProperty('tool_result');
+
+    const interactionContext = interactionSpan._spanContext!;
+    expect(interactionContext.traceId).toEqual(expect.any(String));
+    expect(interactionContext.spanId).toEqual(expect.any(String));
+    for (const child of [...llmSpans, toolSpan!]) {
+      expect(child._spanContext?.traceId).toBe(interactionContext.traceId);
+      expect(child.parentSpanContext).toMatchObject({
+        traceId: interactionContext.traceId,
+        spanId: interactionContext.spanId,
+      });
+    }
+    for (const span of [interactionSpan, ...llmSpans, toolSpan!]) {
+      expect(span.status?.code).toBe(0);
+    }
 
     const canonicalSpanNames = new Set([
       'qwen-code.interaction',
@@ -531,6 +600,15 @@ describeLocal('GenAI telemetry fields', () => {
     }
 
     const records = parseTelemetry(rig.readFile('telemetry.log'));
+    const interactionSpan = records.find(
+      (record) => record.name === 'qwen-code.interaction',
+    );
+    expect(interactionSpan?.attributes).not.toHaveProperty(
+      'gen_ai.input.messages',
+    );
+    expect(interactionSpan?.attributes).not.toHaveProperty(
+      'gen_ai.output.messages',
+    );
     const llmSpans = records.filter(
       (record) => record.name === 'qwen-code.llm_request',
     );

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -73,6 +73,19 @@ const addToolArgumentsAttributesSpy = vi.hoisted(() => vi.fn());
 const addToolCallResultAttributesSpy = vi.hoisted(() => vi.fn());
 const logLoopDetectedSpy = vi.hoisted(() => vi.fn());
 const logRepeatedToolFailureGuardSpy = vi.hoisted(() => vi.fn());
+const agentTelemetry = vi.hoisted(() => ({
+  span: {},
+  getActiveInteractionSpan: vi.fn(),
+  addAgentInputMessageAttributes: vi.fn(),
+  captures: [] as Array<{
+    beginResponse: ReturnType<typeof vi.fn>;
+    appendText: ReturnType<typeof vi.fn>;
+    observeFinishReason: ReturnType<typeof vi.fn>;
+    restartAttempt: ReturnType<typeof vi.fn>;
+    commitResponse: ReturnType<typeof vi.fn>;
+    writeToSpan: ReturnType<typeof vi.fn>;
+  }>,
+}));
 const TODO_STOP_GUARD_CONTINUATION_CLAIM_METHOD =
   'craft/claimTodoStopGuardContinuation';
 // Records every LoopTickResolver construction's deps so a test can assert what
@@ -96,6 +109,21 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     bridgeToolResultImages: bridgeToolResultImagesSpy,
     refreshMemoryAfterManagedWrite: refreshMemoryAfterManagedWriteSpy,
     refreshMemoryInstruction: refreshMemoryInstructionSpy,
+    getActiveInteractionSpan: agentTelemetry.getActiveInteractionSpan,
+    addAgentInputMessageAttributes:
+      agentTelemetry.addAgentInputMessageAttributes,
+    AgentOutputMessageCapture: class {
+      beginResponse = vi.fn();
+      appendText = vi.fn();
+      observeFinishReason = vi.fn();
+      restartAttempt = vi.fn();
+      commitResponse = vi.fn();
+      writeToSpan = vi.fn();
+
+      constructor(_config?: unknown) {
+        agentTelemetry.captures.push(this);
+      }
+    },
     startToolSpan: (...args: Parameters<typeof actual.startToolSpan>) => {
       startToolSpanSpy(...args);
       return actual.startToolSpan(...args);
@@ -558,6 +586,9 @@ describe('Session', () => {
     addToolCallResultAttributesSpy.mockClear();
     logLoopDetectedSpy.mockReset();
     logRepeatedToolFailureGuardSpy.mockReset();
+    agentTelemetry.getActiveInteractionSpan.mockReset();
+    agentTelemetry.addAgentInputMessageAttributes.mockReset();
+    agentTelemetry.captures.length = 0;
     runVisionBridgeSpy.mockReset();
     bridgeToolResultImagesSpy.mockReset();
     bridgeToolResultImagesSpy.mockImplementation(
@@ -5853,6 +5884,9 @@ describe('Session', () => {
     });
 
     it('records daemon prompt display text separately from model context', async () => {
+      agentTelemetry.getActiveInteractionSpan.mockReturnValue(
+        agentTelemetry.span,
+      );
       mockChat.sendMessageStream = vi
         .fn()
         .mockResolvedValue(createEmptyStream());
@@ -5869,6 +5903,16 @@ describe('Session', () => {
         'internal channel instructions\n\nhello',
         undefined,
         { displayText: 'hello', hookContext: '' },
+      );
+      expect(
+        agentTelemetry.addAgentInputMessageAttributes,
+      ).toHaveBeenCalledWith(mockConfig, agentTelemetry.span, 'hello');
+      expect(
+        agentTelemetry.addAgentInputMessageAttributes,
+      ).not.toHaveBeenCalledWith(
+        mockConfig,
+        agentTelemetry.span,
+        expect.stringContaining('internal channel instructions'),
       );
     });
 
@@ -11357,6 +11401,9 @@ describe('Session', () => {
       });
 
       it('stops Stop-hook continuation before sending when the session token limit is exceeded', async () => {
+        agentTelemetry.getActiveInteractionSpan.mockReturnValue(
+          agentTelemetry.span,
+        );
         const messageBus = {
           request: vi
             .fn()
@@ -11397,9 +11444,21 @@ describe('Session', () => {
         mockChat.getLastModelMessageText = vi
           .fn()
           .mockReturnValue('response text');
-        mockChat.sendMessageStream = vi
-          .fn()
-          .mockResolvedValue(createEmptyStream());
+        mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+          createStreamWithChunks([
+            {
+              type: core.StreamEventType.CHUNK,
+              value: {
+                candidates: [
+                  {
+                    content: { parts: [{ text: 'response text' }] },
+                    finishReason: 'STOP',
+                  },
+                ],
+              },
+            },
+          ]),
+        );
 
         await expect(
           session.prompt({
@@ -11416,6 +11475,9 @@ describe('Session', () => {
           expect.any(AbortSignal),
         );
         expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(1);
+        const capture = agentTelemetry.captures[0]!;
+        expect(capture.beginResponse).toHaveBeenCalledOnce();
+        expect(capture.writeToSpan).toHaveBeenCalledWith(agentTelemetry.span);
         expect(mockClient.sessionUpdate).toHaveBeenCalledWith({
           sessionId: 'test-session-id',
           update: {
@@ -11480,7 +11542,52 @@ describe('Session', () => {
         );
       });
 
+      it('captures a successful prompt without channel delivery metadata', async () => {
+        agentTelemetry.getActiveInteractionSpan.mockReturnValue(
+          agentTelemetry.span,
+        );
+        mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+          createStreamWithChunks([
+            {
+              type: core.StreamEventType.CHUNK,
+              value: {
+                candidates: [
+                  {
+                    content: { parts: [{ text: 'final answer' }] },
+                    finishReason: 'STOP',
+                  },
+                ],
+              },
+            },
+          ]),
+        );
+
+        await expect(
+          session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [{ type: 'text', text: 'hello' }],
+          }),
+        ).resolves.toEqual({ stopReason: 'end_turn' });
+
+        expect(
+          agentTelemetry.addAgentInputMessageAttributes,
+        ).toHaveBeenCalledWith(mockConfig, agentTelemetry.span, 'hello');
+        const capture = agentTelemetry.captures[0]!;
+        expect(capture.beginResponse).toHaveBeenCalledOnce();
+        expect(capture.appendText).toHaveBeenCalledWith('final answer');
+        expect(capture.observeFinishReason).toHaveBeenCalledWith('STOP');
+        expect(capture.commitResponse).toHaveBeenCalledWith(false);
+        expect(capture.writeToSpan).toHaveBeenCalledWith(agentTelemetry.span);
+        expect(mockClient.extMethod).not.toHaveBeenCalledWith(
+          'qwen/control/channel-delivery',
+          expect.anything(),
+        );
+      });
+
       it('submits a successful prompt final once through the reverse delivery control', async () => {
+        agentTelemetry.getActiveInteractionSpan.mockReturnValue(
+          agentTelemetry.span,
+        );
         mockChat.sendMessageStream = vi.fn().mockResolvedValue(
           createStreamWithChunks([
             {
@@ -11496,7 +11603,10 @@ describe('Session', () => {
               type: core.StreamEventType.CHUNK,
               value: {
                 candidates: [
-                  { content: { parts: [{ text: 'final answer' }] } },
+                  {
+                    content: { parts: [{ text: 'final answer' }] },
+                    finishReason: 'STOP',
+                  },
                 ],
               },
             },
@@ -11537,9 +11647,15 @@ describe('Session', () => {
             },
           );
         });
+        const capture = agentTelemetry.captures[0]!;
+        expect(capture.restartAttempt).toHaveBeenCalledWith(false);
+        expect(capture.writeToSpan).toHaveBeenCalledWith(agentTelemetry.span);
       });
 
       it('delivers only the final tool-free response block for a prompt', async () => {
+        agentTelemetry.getActiveInteractionSpan.mockReturnValue(
+          agentTelemetry.span,
+        );
         mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
         mockToolRegistry.getTool.mockReturnValue({
           name: 'read_file',
@@ -11613,7 +11729,10 @@ describe('Session', () => {
                 type: core.StreamEventType.CHUNK,
                 value: {
                   candidates: [
-                    { content: { parts: [{ text: 'final answer' }] } },
+                    {
+                      content: { parts: [{ text: 'final answer' }] },
+                      finishReason: 'STOP',
+                    },
                   ],
                 },
               },
@@ -11644,9 +11763,18 @@ describe('Session', () => {
             }),
           );
         });
+        const capture = agentTelemetry.captures[0]!;
+        expect(capture.beginResponse).toHaveBeenCalledTimes(3);
+        expect(capture.commitResponse).toHaveBeenNthCalledWith(1, true);
+        expect(capture.commitResponse).toHaveBeenNthCalledWith(2, true);
+        expect(capture.commitResponse).toHaveBeenNthCalledWith(3, false);
+        expect(capture.writeToSpan).toHaveBeenCalledWith(agentTelemetry.span);
       });
 
       it('replaces the prompt candidate with a Stop-hook continuation final', async () => {
+        agentTelemetry.getActiveInteractionSpan.mockReturnValue(
+          agentTelemetry.span,
+        );
         const messageBus = {
           request: vi
             .fn()
@@ -11692,7 +11820,10 @@ describe('Session', () => {
                 type: core.StreamEventType.CHUNK,
                 value: {
                   candidates: [
-                    { content: { parts: [{ text: 'continued final' }] } },
+                    {
+                      content: { parts: [{ text: 'continued final' }] },
+                      finishReason: 'STOP',
+                    },
                   ],
                 },
               },
@@ -11723,6 +11854,13 @@ describe('Session', () => {
             }),
           );
         });
+        const capture = agentTelemetry.captures[0]!;
+        expect(capture.beginResponse).toHaveBeenCalledTimes(2);
+        expect(capture.appendText.mock.calls).toEqual([
+          ['initial answer'],
+          ['continued final'],
+        ]);
+        expect(capture.writeToSpan).toHaveBeenCalledWith(agentTelemetry.span);
       });
 
       it('keeps continuation retry text in the delivered prompt final', async () => {
@@ -22953,6 +23091,10 @@ describe('Session', () => {
             { role: 'user', parts: [{ text: 'unanswered question' }] },
           ]);
         }
+        agentTelemetry.getActiveInteractionSpan.mockReturnValue(
+          agentTelemetry.span,
+        );
+        agentTelemetry.addAgentInputMessageAttributes.mockClear();
 
         await session.prompt({
           sessionId: 'test-session-id',
@@ -22965,6 +23107,9 @@ describe('Session', () => {
         // recovery-plan classifier change could make the turn return before
         // the intent-clearing gate while this test stays green.
         expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(2);
+        expect(
+          agentTelemetry.addAgentInputMessageAttributes,
+        ).not.toHaveBeenCalled();
 
         allowAcpWriteFile();
         await runAcpWriteFile(

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -133,6 +133,9 @@ import {
   shouldFirePermissionDeniedForAutoMode,
   shouldRunAutoModeForCall,
   extractDaemonTraceContext,
+  addAgentInputMessageAttributes,
+  AgentOutputMessageCapture,
+  getActiveInteractionSpan,
   withInteractionSpan,
   SessionWriterError,
   startToolSpan,
@@ -1170,25 +1173,30 @@ interface PromptChannelDelivery {
   target: CronTaskDelivery['target'];
 }
 
-interface ChannelDeliveryCapture {
-  finalText: string;
+interface AgentResponseCapture {
+  channelDelivery?: {
+    finalText: string;
+  };
+  agentOutput: AgentOutputMessageCapture;
 }
 
 function beginChannelDeliveryResponseBlock(
-  capture: ChannelDeliveryCapture | undefined,
+  capture: AgentResponseCapture | undefined,
 ): string[] | undefined {
-  if (!capture) return undefined;
-  capture.finalText = '';
+  capture?.agentOutput.beginResponse();
+  if (!capture?.channelDelivery) return undefined;
+  capture.channelDelivery.finalText = '';
   return [];
 }
 
 function commitChannelDeliveryResponseBlock(
-  capture: ChannelDeliveryCapture | undefined,
+  capture: AgentResponseCapture | undefined,
   responseBlock: string[] | undefined,
   hasFunctionCalls: boolean,
 ): void {
-  if (capture && responseBlock && !hasFunctionCalls) {
-    capture.finalText = responseBlock.join('');
+  capture?.agentOutput.commitResponse(hasFunctionCalls);
+  if (capture?.channelDelivery && responseBlock && !hasFunctionCalls) {
+    capture.channelDelivery.finalText = responseBlock.join('');
   }
 }
 
@@ -3567,9 +3575,10 @@ export class Session implements SessionContext {
 
     this.duplicateProviderToolCallResponseIds.clear();
     const channelDelivery = parsePromptChannelDelivery(params);
-    const channelDeliveryCapture = channelDelivery
-      ? { finalText: '' }
-      : undefined;
+    const responseCapture: AgentResponseCapture = {
+      ...(channelDelivery ? { channelDelivery: { finalText: '' } } : {}),
+      agentOutput: new AgentOutputMessageCapture(this.config),
+    };
 
     // Track this prompt's completion for the next prompt to await
     let resolveCompletion!: () => void;
@@ -3583,7 +3592,7 @@ export class Session implements SessionContext {
       const result = await this.#executePrompt(
         params,
         pendingSend,
-        channelDeliveryCapture,
+        responseCapture,
         invocationContext,
         modelPrompt,
         goalTurn,
@@ -3601,7 +3610,7 @@ export class Session implements SessionContext {
           source: 'prompt',
           target: channelDelivery.target,
           text: normalizeChannelDeliveryText(
-            channelDeliveryCapture?.finalText ?? '',
+            responseCapture.channelDelivery?.finalText ?? '',
           ),
           promptId: channelDelivery.deliveryId,
         });
@@ -3810,7 +3819,7 @@ export class Session implements SessionContext {
   async #executePrompt(
     params: PromptRequest,
     pendingSend: AbortController,
-    channelDeliveryCapture?: ChannelDeliveryCapture,
+    responseCapture: AgentResponseCapture,
     invocationContext?: InvocationContextV1,
     modelPrompt?: string,
     goalTurn?: AcpGoalTurn,
@@ -3835,7 +3844,7 @@ export class Session implements SessionContext {
           this.#executePromptInner(
             params,
             pendingSend,
-            channelDeliveryCapture,
+            responseCapture,
             modelPrompt,
             goalTurn,
           ),
@@ -3849,7 +3858,7 @@ export class Session implements SessionContext {
   async #executePromptInner(
     params: PromptRequest,
     pendingSend: AbortController,
-    channelDeliveryCapture?: ChannelDeliveryCapture,
+    responseCapture: AgentResponseCapture,
     modelPrompt?: string,
     goalTurn?: AcpGoalTurn,
   ): Promise<PromptResponse> {
@@ -3940,6 +3949,16 @@ export class Session implements SessionContext {
               (params as { _meta?: Record<string, unknown> })._meta?.[
                 DAEMON_CONTINUE_META_KEY
               ] === true;
+            if (!isRetry && !isContinue && goalTurn?.origin !== 'runtime') {
+              const interactionSpan = getActiveInteractionSpan();
+              if (interactionSpan) {
+                addAgentInputMessageAttributes(
+                  this.config,
+                  interactionSpan,
+                  promptDisplayText ?? promptText,
+                );
+              }
+            }
             let continuationParts: Part[] | null = null;
             // For an `interrupted_prompt` continuation we strip the orphaned
             // user run from history before re-sending it. If the send then
@@ -4279,6 +4298,7 @@ export class Session implements SessionContext {
                   pendingSend.signal,
                 );
                 let channelDeliveryResponseBlock: string[] | undefined;
+                let channelDeliveryCheckpoint = 0;
 
                 try {
                   // Set where the model request is actually issued, not at
@@ -4316,8 +4336,8 @@ export class Session implements SessionContext {
                   const responseStream = sendResult.responseStream;
                   nextMessage = null;
                   channelDeliveryResponseBlock =
-                    beginChannelDeliveryResponseBlock(channelDeliveryCapture);
-                  const channelDeliveryCheckpoint =
+                    beginChannelDeliveryResponseBlock(responseCapture);
+                  channelDeliveryCheckpoint =
                     channelDeliveryResponseBlock?.length ?? 0;
 
                   let streamFailed = false;
@@ -4345,10 +4365,14 @@ export class Session implements SessionContext {
                             part.thought,
                           );
                           if (!part.thought) {
+                            responseCapture.agentOutput.appendText(part.text);
                             channelDeliveryResponseBlock?.push(part.text);
                             messageDisplay?.addChunk(part.text);
                           }
                         }
+                        responseCapture.agentOutput.observeFinishReason(
+                          candidate.finishReason,
+                        );
                       }
 
                       if (
@@ -4369,6 +4393,10 @@ export class Session implements SessionContext {
                         resp.type === StreamEventType.RETRY ||
                         resp.type === StreamEventType.MODEL_FALLBACK
                       ) {
+                        responseCapture.agentOutput.restartAttempt(
+                          resp.type === StreamEventType.RETRY &&
+                            resp.isContinuation === true,
+                        );
                         if (
                           resp.type === StreamEventType.MODEL_FALLBACK ||
                           !resp.isContinuation
@@ -4471,7 +4499,7 @@ export class Session implements SessionContext {
                 }
 
                 commitChannelDeliveryResponseBlock(
-                  channelDeliveryCapture,
+                  responseCapture,
                   channelDeliveryResponseBlock,
                   functionCalls.length > 0,
                 );
@@ -4556,15 +4584,21 @@ export class Session implements SessionContext {
 
               // Fire Stop hook loop (aligned with core path in client.ts)
               // This is triggered after model response completes with no pending tool calls
-              return await this.#handleStopHookLoop(
+              const result = await this.#handleStopHookLoop(
                 pendingSend,
                 promptId,
                 hooksEnabled,
                 messageBus,
                 true,
                 fullTurnModelOverride,
-                channelDeliveryCapture,
+                responseCapture,
               );
+              if (result.stopReason !== 'cancelled') {
+                responseCapture.agentOutput.writeToSpan(
+                  getActiveInteractionSpan(),
+                );
+              }
+              return result;
             } finally {
               logConversationFinishedEvent(
                 this.config,
@@ -4602,7 +4636,7 @@ export class Session implements SessionContext {
     messageBus: MessageBus | undefined,
     allowExternalHooks = true,
     modelOverride?: string,
-    channelDeliveryCapture?: ChannelDeliveryCapture,
+    responseCapture?: AgentResponseCapture,
   ): Promise<{ stopReason: PromptResponse['stopReason'] }> {
     const stopHookBlockingCap = this.config.getStopHookBlockingCap();
     let stopHookIterationCount = 0;
@@ -4667,7 +4701,7 @@ export class Session implements SessionContext {
             {
               onFullTurnModel,
               getModelOverride: () => modelOverride,
-              channelDeliveryCapture,
+              responseCapture,
             },
           );
           if (continuation.kind === 'terminal') {
@@ -4766,7 +4800,7 @@ export class Session implements SessionContext {
               {
                 onFullTurnModel,
                 getModelOverride: () => modelOverride,
-                channelDeliveryCapture,
+                responseCapture,
               },
             );
             if (continuation.kind === 'terminal') {
@@ -4900,7 +4934,7 @@ export class Session implements SessionContext {
             : {}),
           onFullTurnModel,
           getModelOverride: () => modelOverride,
-          channelDeliveryCapture,
+          responseCapture,
         },
       );
       if (continuation.supersededAutomaticContinuation && externalReason) {
@@ -4925,7 +4959,7 @@ export class Session implements SessionContext {
       onAutomaticContinuationValidated?: () => Promise<void>;
       onFullTurnModel?: (model: string) => boolean;
       getModelOverride?: () => string | undefined;
-      channelDeliveryCapture?: ChannelDeliveryCapture;
+      responseCapture?: AgentResponseCapture;
     } = {},
   ): Promise<StopContinuationResult> {
     let nextMessage: Content | null = { role: 'user', parts };
@@ -4996,6 +5030,7 @@ export class Session implements SessionContext {
         pendingSend.signal,
       );
       let channelDeliveryResponseBlock: string[] | undefined;
+      let channelDeliveryCheckpoint = 0;
       let providerSendChat: GeminiChat | undefined;
       let userContentPushCountBeforeSend = 0;
 
@@ -5294,10 +5329,9 @@ export class Session implements SessionContext {
         const responseStream = sendResult.responseStream;
         nextMessage = null;
         channelDeliveryResponseBlock = beginChannelDeliveryResponseBlock(
-          options.channelDeliveryCapture,
+          options.responseCapture,
         );
-        const channelDeliveryCheckpoint =
-          channelDeliveryResponseBlock?.length ?? 0;
+        channelDeliveryCheckpoint = channelDeliveryResponseBlock?.length ?? 0;
         initialSend = false;
         if (guardForThisSend) {
           const guardCommitted = this.todoStopGuard.commitContinuation(
@@ -5337,10 +5371,14 @@ export class Session implements SessionContext {
                 part.thought,
               );
               if (!part.thought) {
+                options.responseCapture?.agentOutput.appendText(part.text);
                 channelDeliveryResponseBlock?.push(part.text);
                 messageDisplay?.addChunk(part.text);
               }
             }
+            options.responseCapture?.agentOutput.observeFinishReason(
+              candidate.finishReason,
+            );
           }
 
           if (
@@ -5360,6 +5398,10 @@ export class Session implements SessionContext {
             response.type === StreamEventType.RETRY ||
             response.type === StreamEventType.MODEL_FALLBACK
           ) {
+            options.responseCapture?.agentOutput.restartAttempt(
+              response.type === StreamEventType.RETRY &&
+                response.isContinuation === true,
+            );
             if (
               response.type === StreamEventType.MODEL_FALLBACK ||
               !response.isContinuation
@@ -5443,7 +5485,7 @@ export class Session implements SessionContext {
       }
 
       commitChannelDeliveryResponseBlock(
-        options.channelDeliveryCapture,
+        options.responseCapture,
         channelDeliveryResponseBlock,
         functionCalls.length > 0,
       );
@@ -6634,9 +6676,10 @@ export class Session implements SessionContext {
           this.config.getSessionId() + '########cron' + Date.now();
         let cronHadError = false;
         let cronCompleted = false;
-        const channelDeliveryCapture = item.delivery
-          ? { finalText: '' }
-          : undefined;
+        const responseCapture: AgentResponseCapture = {
+          ...(item.delivery ? { channelDelivery: { finalText: '' } } : {}),
+          agentOutput: new AgentOutputMessageCapture(this.config),
+        };
         await withInteractionSpan(
           this.config,
           {
@@ -6813,7 +6856,6 @@ export class Session implements SessionContext {
                 let usageMetadata: GenerateContentResponseUsageMetadata | null =
                   null;
                 const streamStartTime = Date.now();
-
                 const sendResult =
                   await this.#sendMessageStreamWithAutoCompression(
                     promptId,
@@ -6833,7 +6875,7 @@ export class Session implements SessionContext {
                 }
                 const responseStream = sendResult.responseStream;
                 const channelDeliveryResponseBlock =
-                  beginChannelDeliveryResponseBlock(channelDeliveryCapture);
+                  beginChannelDeliveryResponseBlock(responseCapture);
                 const channelDeliveryCheckpoint =
                   channelDeliveryResponseBlock?.length ?? 0;
                 if (loopTick && turnCount === 1) {
@@ -6870,10 +6912,14 @@ export class Session implements SessionContext {
                           part.thought,
                         );
                         if (!part.thought) {
+                          responseCapture.agentOutput.appendText(part.text);
                           channelDeliveryResponseBlock?.push(part.text);
                           messageDisplay?.addChunk(part.text);
                         }
                       }
+                      responseCapture.agentOutput.observeFinishReason(
+                        candidate.finishReason,
+                      );
                     }
 
                     if (
@@ -6894,6 +6940,10 @@ export class Session implements SessionContext {
                       resp.type === StreamEventType.RETRY ||
                       resp.type === StreamEventType.MODEL_FALLBACK
                     ) {
+                      responseCapture.agentOutput.restartAttempt(
+                        resp.type === StreamEventType.RETRY &&
+                          resp.isContinuation === true,
+                      );
                       if (
                         resp.type === StreamEventType.MODEL_FALLBACK ||
                         !resp.isContinuation
@@ -6929,7 +6979,7 @@ export class Session implements SessionContext {
                 }
 
                 commitChannelDeliveryResponseBlock(
-                  channelDeliveryCapture,
+                  responseCapture,
                   channelDeliveryResponseBlock,
                   functionCalls.length > 0,
                 );
@@ -6983,7 +7033,7 @@ export class Session implements SessionContext {
                   undefined,
                   false,
                   undefined,
-                  channelDeliveryCapture,
+                  responseCapture,
                 );
                 stopReason = guardStop.stopReason;
                 if (guardStop.stopReason === 'max_tokens') {
@@ -7020,6 +7070,11 @@ export class Session implements SessionContext {
                 ),
               );
             }
+            if (!ac.signal.aborted && !cronHadError) {
+              responseCapture.agentOutput.writeToSpan(
+                getActiveInteractionSpan(),
+              );
+            }
           },
           () =>
             ac.signal.aborted ? 'cancelled' : cronHadError ? 'error' : 'ok',
@@ -7036,7 +7091,7 @@ export class Session implements SessionContext {
             source: 'scheduled',
             target: item.delivery.target,
             text: normalizeChannelDeliveryText(
-              channelDeliveryCapture?.finalText ?? '',
+              responseCapture.channelDelivery?.finalText ?? '',
             ),
             taskId: item.taskId,
             firedAt: item.firedAt,

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -71,6 +71,10 @@ import {
 
 // Mock core modules
 const runVisionBridgeSpy = vi.hoisted(() => vi.fn());
+const endInteractionSpanSpy = vi.hoisted(() => vi.fn());
+const getActiveInteractionSpanSpy = vi.hoisted(() => vi.fn());
+const addAgentOutputMessageAttributesSpy = vi.hoisted(() => vi.fn());
+const interactionSpan = vi.hoisted(() => ({}));
 vi.mock('./ui/hooks/atCommandProcessor.js');
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const original =
@@ -87,6 +91,9 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     ...original,
     executeToolCall: vi.fn(),
     runVisionBridge: runVisionBridgeSpy,
+    addAgentOutputMessageAttributes: addAgentOutputMessageAttributesSpy,
+    endInteractionSpan: endInteractionSpanSpy,
+    getActiveInteractionSpan: getActiveInteractionSpanSpy,
     shutdownTelemetry: vi.fn(),
     isTelemetrySdkInitialized: vi.fn().mockReturnValue(true),
     ChatRecordingService: MockChatRecordingService,
@@ -261,6 +268,10 @@ describe('runNonInteractive', () => {
 
     mockCoreExecuteToolCall = vi.mocked(executeToolCall);
     runVisionBridgeSpy.mockReset();
+    endInteractionSpanSpy.mockReset();
+    addAgentOutputMessageAttributesSpy.mockReset();
+    getActiveInteractionSpanSpy.mockReset();
+    getActiveInteractionSpanSpy.mockReturnValue(interactionSpan);
     mockShutdownTelemetry = vi.mocked(shutdownTelemetry);
     vi.mocked(isTelemetrySdkInitialized).mockReturnValue(true);
     mockGetDebugResponses = vi.fn().mockReturnValue([]);
@@ -763,6 +774,94 @@ describe('runNonInteractive', () => {
     expect(secondOptions.goalSignal).toBe(firstOptions.goalSignal);
   });
 
+  it('starts a teammate invocation when a message joins a Goal tool continuation', async () => {
+    setupMetricsMock();
+    mockGetCommands.mockReturnValue([goalCommand]);
+    await prepareGoalState('paused');
+    vi.spyOn(goalRuntime, 'finishTurn').mockResolvedValue(undefined);
+
+    let leaderMessageCallback: ((formatted: string) => void) | null = null;
+    const teamEvents = new EventEmitter();
+    const teamManager = {
+      setLeaderMessageCallback: vi.fn(
+        (callback: ((formatted: string) => void) | null) => {
+          leaderMessageCallback = callback;
+        },
+      ),
+      getEventEmitter: () => teamEvents,
+      hasActiveTeammates: () => false,
+      drainLeaderInbox: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(mockConfig.getTeamManager).mockReturnValue(teamManager as never);
+
+    mockCoreExecuteToolCall.mockImplementation(async () => {
+      leaderMessageCallback?.('Teammate finished the delegated task.');
+      return {
+        responseParts: [{ text: 'tool response' }],
+      };
+    });
+    let requestCount = 0;
+    mockGeminiClient.sendMessageStream.mockImplementation(
+      (
+        _parts: Part[],
+        _signal: AbortSignal,
+        _promptId: string,
+        sendOptions: { goalPermit?: GoalTurnPermit },
+      ) => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          return createStreamFromEvents([
+            {
+              type: GeminiEventType.ToolCallRequest,
+              value: {
+                callId: 'goal-tool-with-teammate',
+                name: 'testTool',
+                args: {},
+                isClientInitiated: false,
+                prompt_id: 'goal-teammate-handoff',
+                goalContext: sendOptions.goalPermit,
+              },
+            },
+          ]);
+        }
+        return createStreamFromEvents([
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 0 },
+            },
+          },
+        ]);
+      },
+    );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      '/goal resume',
+      'goal-teammate-handoff',
+    );
+
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(2);
+    const firstOptions = mockGeminiClient.sendMessageStream.mock.calls[0]![3];
+    const [, , secondPromptId, secondOptions] =
+      mockGeminiClient.sendMessageStream.mock.calls[1]!;
+    expect(secondPromptId).toBe('goal-teammate-handoff/teammate/2');
+    expect(secondOptions).toMatchObject({
+      type: SendMessageType.Teammate,
+      goalPermit: firstOptions.goalPermit,
+      goalTurnKey: firstOptions.goalTurnKey,
+      goalOrigin: 'runtime',
+    });
+    expect(endInteractionSpanSpy).toHaveBeenCalledWith('ok', {
+      promptId: 'goal-teammate-handoff',
+    });
+    expect(endInteractionSpanSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      mockGeminiClient.sendMessageStream.mock.invocationCallOrder[1]!,
+    );
+  });
+
   it('ends a Goal turn without another model call after update_goal', async () => {
     setupMetricsMock();
     mockGetCommands.mockReturnValue([goalCommand]);
@@ -814,6 +913,9 @@ describe('runNonInteractive', () => {
       parts: [{ text: 'proposal recorded' }],
     });
     expect(finishTurn).toHaveBeenCalledOnce();
+    expect(endInteractionSpanSpy).toHaveBeenCalledWith('ok', {
+      promptId: 'goal-terminal-tool-result',
+    });
   });
 
   it('streams Goal state changes that happen while a headless turn settles', async () => {
@@ -1027,6 +1129,16 @@ describe('runNonInteractive', () => {
         ),
       ),
     );
+    expect(endInteractionSpanSpy).toHaveBeenCalledWith('error', {
+      promptId: 'goal-explicit-budget',
+      errorMessage:
+        'Run aborted: tool-call budget of 0 exceeded (--max-tool-calls); observed 1.',
+      errorType: 'run_budget_exceeded',
+    });
+    expect(endInteractionSpanSpy).not.toHaveBeenCalledWith(
+      'cancelled',
+      expect.objectContaining({ promptId: 'goal-explicit-budget' }),
+    );
 
     expect(mockCoreExecuteToolCall).not.toHaveBeenCalled();
     expect(goalRuntime.getSnapshot()).toMatchObject({
@@ -1035,6 +1147,48 @@ describe('runNonInteractive', () => {
     });
 
     void run;
+  });
+
+  it('records a budget error when an in-flight model stream rejects after abort', async () => {
+    setupMetricsMock();
+    vi.mocked(mockConfig.getMaxWallTimeSeconds).mockReturnValue(0.01);
+    const runAbortController = new AbortController();
+    mockGeminiClient.sendMessageStream.mockReturnValueOnce(
+      (async function* () {
+        yield { type: GeminiEventType.Content, value: 'partial response' };
+        if (!runAbortController.signal.aborted) {
+          await new Promise<void>((_, reject) => {
+            runAbortController.signal.addEventListener(
+              'abort',
+              () => reject(new Error('stream aborted after budget expiry')),
+              { once: true },
+            );
+          });
+        }
+        throw new Error('stream aborted after budget expiry');
+      })(),
+    );
+
+    await expect(
+      runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'wait for the model',
+        'budget-stream-abort',
+        { abortController: runAbortController },
+      ),
+    ).rejects.toThrow('process.exit(55) called');
+
+    expect(endInteractionSpanSpy).toHaveBeenCalledWith('error', {
+      promptId: 'budget-stream-abort',
+      errorMessage:
+        'Run aborted: wall-clock budget of 0.01s exceeded (--max-wall-time).',
+      errorType: 'run_budget_exceeded',
+    });
+    expect(endInteractionSpanSpy).not.toHaveBeenCalledWith(
+      'cancelled',
+      expect.objectContaining({ promptId: 'budget-stream-abort' }),
+    );
   });
 
   it('interrupts Goal settlement when the explicit wall-clock budget expires', async () => {
@@ -1257,7 +1411,11 @@ describe('runNonInteractive', () => {
       [{ text: 'Test input' }],
       expect.any(AbortSignal),
       'prompt-id-1',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'Test input',
+      },
     );
     expect(processStdoutSpy).toHaveBeenCalledWith('Hello World\n');
     expect(mockShutdownTelemetry).toHaveBeenCalled();
@@ -2130,7 +2288,11 @@ describe('runNonInteractive', () => {
       [{ text: 'Use a tool' }],
       expect.any(AbortSignal),
       'prompt-id-2',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'Use a tool',
+      },
     );
     // Verify second call (after tool execution) has type: ToolResult
     expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
@@ -3547,7 +3709,11 @@ describe('runNonInteractive', () => {
       processedParts,
       expect.any(AbortSignal),
       'prompt-id-7',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'Summarize @file.txt',
+      },
     );
 
     // 6. Assert the final output is correct
@@ -3615,7 +3781,11 @@ describe('runNonInteractive', () => {
       headlessImageParts,
       expect.any(AbortSignal),
       'prompt-vision-route',
-      { type: SendMessageType.UserQuery, modelOverride: selector },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: selector,
+        submittedPrompt: 'inspect @image.png',
+      },
     );
     expect(mockGeminiClient.sendMessageStream).toHaveBeenNthCalledWith(
       2,
@@ -3735,7 +3905,11 @@ describe('runNonInteractive', () => {
       [{ text: 'machine transcription' }],
       expect.any(AbortSignal),
       'prompt-vision-bridge',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'inspect @image.png',
+      },
     );
     expect(processStderrSpy).toHaveBeenCalledWith(
       expect.stringContaining('Converted 1 image(s)'),
@@ -3812,7 +3986,11 @@ describe('runNonInteractive', () => {
       [{ text: 'inspect this image' }],
       expect.any(AbortSignal),
       'prompt-vision-bridge-failed',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'inspect @image.png',
+      },
     );
     expect(processStderrSpy).toHaveBeenCalledWith(
       'Vision bridge failed; proceeding without the image(s).\n',
@@ -3846,7 +4024,11 @@ describe('runNonInteractive', () => {
       [{ text: 'inspect this image' }],
       expect.any(AbortSignal),
       'prompt-vision-bridge-skipped',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'inspect @image.png',
+      },
     );
     expect(processStderrSpy).toHaveBeenCalledWith(
       expect.stringContaining('Vision bridge cancelled.'),
@@ -3889,7 +4071,11 @@ describe('runNonInteractive', () => {
       ],
       expect.any(AbortSignal),
       'prompt-oversized-image',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'inspect @image.png',
+      },
     );
   });
 
@@ -3942,7 +4128,11 @@ describe('runNonInteractive', () => {
       [{ text: 'Test input' }],
       expect.any(AbortSignal),
       'prompt-id-1',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'Test input',
+      },
     );
 
     // JSON adapter emits array of messages, last one is result with stats
@@ -4097,7 +4287,11 @@ describe('runNonInteractive', () => {
       [{ text: 'Empty response test' }],
       expect.any(AbortSignal),
       'prompt-id-empty',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'Empty response test',
+      },
     );
 
     // JSON adapter emits array of messages, last one is result with stats
@@ -4360,7 +4554,11 @@ describe('runNonInteractive', () => {
       [{ text: 'Prompt from command' }],
       expect.any(AbortSignal),
       'prompt-id-slash',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: '/testcommand',
+      },
     );
 
     expect(processStdoutSpy).toHaveBeenCalledWith('Response from command\n');
@@ -4420,7 +4618,11 @@ describe('runNonInteractive', () => {
       [{ text: '/unknowncommand' }],
       expect.any(AbortSignal),
       'prompt-id-unknown',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: '/unknowncommand',
+      },
     );
 
     expect(processStdoutSpy).toHaveBeenCalledWith('Response to unknown\n');
@@ -4616,6 +4818,9 @@ describe('runNonInteractive', () => {
       type: 'result',
       is_error: true,
       error: { message: 'Operation cancelled.' },
+    });
+    expect(endInteractionSpanSpy).toHaveBeenCalledWith('cancelled', {
+      promptId: 'prompt-recoverable-interrupt',
     });
   });
 
@@ -5531,7 +5736,11 @@ describe('runNonInteractive', () => {
       [{ text: 'Message from stream-json input' }],
       expect.any(AbortSignal),
       'prompt-envelope',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'Message from stream-json input',
+      },
     );
   });
 
@@ -6205,7 +6414,11 @@ describe('runNonInteractive', () => {
       [{ text: 'Simple string content' }],
       expect.any(AbortSignal),
       'prompt-string-content',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'Simple string content',
+      },
     );
 
     // UserMessage with array of text blocks
@@ -6238,7 +6451,11 @@ describe('runNonInteractive', () => {
       [{ text: 'First part' }, { text: 'Second part' }],
       expect.any(AbortSignal),
       'prompt-blocks-content',
-      { type: SendMessageType.UserQuery },
+      {
+        type: SendMessageType.UserQuery,
+        modelOverride: undefined,
+        submittedPrompt: 'First part Second part',
+      },
     );
   });
 
@@ -6388,6 +6605,18 @@ describe('runNonInteractive', () => {
       // abortAll() must be called so any in-flight background agents are
       // torn down before we emit the terminal result.
       expect(abortAllSpy).toHaveBeenCalledTimes(1);
+      expect(endInteractionSpanSpy).toHaveBeenCalledWith('ok', {
+        promptId: 'prompt-id-structured',
+      });
+      expect(addAgentOutputMessageAttributesSpy).toHaveBeenCalledWith(
+        mockConfig,
+        interactionSpan,
+        JSON.stringify(structuredArgs),
+        'tool_call',
+      );
+      expect(
+        addAgentOutputMessageAttributesSpy.mock.invocationCallOrder[0],
+      ).toBeLessThan(endInteractionSpanSpy.mock.invocationCallOrder[0]!);
 
       const events = writes
         .join('')
@@ -6799,6 +7028,11 @@ describe('runNonInteractive', () => {
         );
       expect(result?.is_error).toBe(true);
       expect(result?.error?.message).toMatch(/structured_output/);
+      expect(endInteractionSpanSpy).toHaveBeenCalledWith('error', {
+        promptId: 'prompt-id-plaintext',
+        errorMessage: 'model did not produce structured output',
+        errorType: 'structured_output_missing',
+      });
     });
 
     it('synthesises tool_result for suppressed sibling calls when structured_output fails validation', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -65,6 +65,10 @@ import {
   shouldRunVisionBridge,
   splitImageParts,
   GoalPersistenceUnavailableError,
+  addAgentOutputMessageAttributes,
+  endInteractionSpan,
+  getErrorType,
+  getActiveInteractionSpan,
 } from '@qwen-code/qwen-code-core';
 import type { Content, Part, PartListUnion } from '@google/genai';
 import type { CLIUserMessage, PermissionMode } from './nonInteractive/types.js';
@@ -550,6 +554,42 @@ export async function runNonInteractive(
     let limitedTurnCount = 0;
     let totalApiDurationMs = 0;
     const startTime = Date.now();
+    let activeInteractionPromptId = prompt_id;
+    let activeInteractionOwner: ReturnType<typeof getActiveInteractionSpan>;
+    const selectActiveInteraction = (
+      promptId: string,
+      startsInteraction = false,
+    ) => {
+      if (startsInteraction || activeInteractionPromptId !== promptId) {
+        activeInteractionOwner = undefined;
+      }
+      activeInteractionPromptId = promptId;
+    };
+    const captureActiveInteractionOwner = () => {
+      activeInteractionOwner ??= getActiveInteractionSpan(
+        activeInteractionPromptId,
+      );
+      return activeInteractionOwner;
+    };
+    const endActiveInteraction = (
+      status: 'ok' | 'error' | 'cancelled',
+      metadata: {
+        errorMessage?: string;
+        errorType?: string;
+      } = {},
+    ) => {
+      const owner = captureActiveInteractionOwner();
+      if (
+        !owner ||
+        getActiveInteractionSpan(activeInteractionPromptId) !== owner
+      ) {
+        return;
+      }
+      endInteractionSpan(status, {
+        promptId: activeInteractionPromptId,
+        ...metadata,
+      });
+    };
 
     const geminiClient = config.getGeminiClient();
     const abortController = options.abortController ?? new AbortController();
@@ -735,6 +775,14 @@ export async function runNonInteractive(
      */
     const routeAbort = async (): Promise<never> => {
       const exceeded = budgetEnforcer.getExceeded();
+      endActiveInteraction(exceeded ? 'error' : 'cancelled', {
+        ...(exceeded
+          ? {
+              errorMessage: exceeded.message,
+              errorType: 'run_budget_exceeded',
+            }
+          : {}),
+      });
       await failClosedActiveGoalTurn(
         exceeded?.message ?? 'Headless Goal execution was cancelled',
       );
@@ -1000,6 +1048,16 @@ export async function runNonInteractive(
       let initialPartList: PartListUnion | null = extractPartsFromUserMessage(
         options.userMessage,
       );
+      const userMessageContent = options.userMessage?.message.content;
+      const submittedPrompt =
+        typeof userMessageContent === 'string'
+          ? userMessageContent
+          : Array.isArray(userMessageContent)
+            ? userMessageContent
+                .filter((block) => block.type === 'text')
+                .map((block) => (block.type === 'text' ? block.text : ''))
+                .join(' ')
+            : input;
       // Per-turn model override captured from an inline `/model <id> <prompt>`
       // slash command; seeds the loop-scoped `modelOverride` below so the
       // submitted prompt runs on the chosen model without a session switch.
@@ -1509,6 +1567,27 @@ export async function runNonInteractive(
       // no-op), so unconditional invocation is safe even when the drain
       // path already finalized monitors before reaching here.
       const emitStructuredSuccess = async (): Promise<0> => {
+        const owner = captureActiveInteractionOwner();
+        if (
+          owner &&
+          getActiveInteractionSpan(activeInteractionPromptId) === owner
+        ) {
+          let responseText: string | undefined;
+          try {
+            responseText = JSON.stringify(structuredSubmission);
+          } catch {
+            responseText = undefined;
+          }
+          if (responseText !== undefined) {
+            addAgentOutputMessageAttributes(
+              config,
+              owner,
+              responseText,
+              'tool_call',
+            );
+          }
+          endActiveInteraction('ok');
+        }
         await failClosedActiveGoalTurn(
           'Headless Goal ended with structured output',
         );
@@ -1548,6 +1627,10 @@ export async function runNonInteractive(
       };
 
       const emitLoopDetectedResult = async (): Promise<1> => {
+        endActiveInteraction('error', {
+          errorMessage: 'loop detected',
+          errorType: 'loop_detected',
+        });
         await failClosedActiveGoalTurn(
           'Headless Goal stopped after loop detection',
         );
@@ -2182,25 +2265,32 @@ export async function runNonInteractive(
         await enforceSessionTurnLimit(goalTurn?.origin === 'runtime');
 
         let sendType: SendMessageType;
-        if (goalTurn) {
-          sendType = isFirstGoalSegment
-            ? goalTurn.origin === 'runtime'
+        if (goalTurn && isFirstGoalSegment) {
+          sendType =
+            goalTurn.origin === 'runtime'
               ? SendMessageType.Goal
-              : SendMessageType.UserQuery
-            : SendMessageType.ToolResult;
+              : SendMessageType.UserQuery;
+        } else if (isTeammateTurn) {
+          sendType = SendMessageType.Teammate;
+        } else if (goalTurn) {
+          sendType = SendMessageType.ToolResult;
         } else if (isFirstTurn) {
           sendType =
             continueSendType ??
             options.sendMessageType ??
             SendMessageType.UserQuery;
-        } else if (isTeammateTurn) {
-          sendType = SendMessageType.Teammate;
         } else {
           sendType = SendMessageType.ToolResult;
         }
         if (isTeammateTurn) {
+          selectActiveInteraction(currentPromptId);
+          endActiveInteraction('ok');
           currentPromptId = `${prompt_id}/teammate/${turnCount}`;
         }
+        selectActiveInteraction(
+          currentPromptId,
+          sendType !== SendMessageType.ToolResult,
+        );
 
         const toolCallRequests: ToolCallRequestInfo[] = [];
         const apiStartTime = Date.now();
@@ -2211,6 +2301,10 @@ export async function runNonInteractive(
           {
             type: sendType,
             modelOverride,
+            ...(isFirstTurn &&
+              sendType === SendMessageType.UserQuery &&
+              !options.continueInterrupted &&
+              submittedPrompt.trim().length > 0 && { submittedPrompt }),
             ...(isFirstTurn &&
               options.notificationDisplayText && {
                 notificationDisplayText: options.notificationDisplayText,
@@ -2232,6 +2326,7 @@ export async function runNonInteractive(
         adapter.startAssistantMessage();
 
         for await (const event of responseStream) {
+          captureActiveInteractionOwner();
           if (abortController.signal.aborted) {
             // Pair the startAssistantMessage() above so stream-json mode
             // doesn't leave an unterminated message_start when a budget /
@@ -2281,6 +2376,7 @@ export async function runNonInteractive(
             throw new AlreadyReportedError(errorText);
           }
         }
+        captureActiveInteractionOwner();
 
         // Finalize assistant message
         adapter.finalizeAssistantMessage();
@@ -2349,6 +2445,8 @@ export async function runNonInteractive(
             await config.getChatRecordingService?.()?.flush();
             await finishGoalTurn(activeGoalTurn);
             activeGoalTurn = undefined;
+            selectActiveInteraction(currentPromptId);
+            endActiveInteraction('ok');
             const nextGoalTurn = queuedGoalTurns.shift();
             if (nextGoalTurn) {
               activeGoalTurn = nextGoalTurn;
@@ -2377,6 +2475,8 @@ export async function runNonInteractive(
             if (activeGoalTurn === completedGoalTurn) {
               activeGoalTurn = undefined;
             }
+            selectActiveInteraction(currentPromptId);
+            endActiveInteraction('ok');
             const nextGoalTurn = queuedGoalTurns.shift();
             if (nextGoalTurn) {
               activeGoalTurn = nextGoalTurn;
@@ -2519,6 +2619,7 @@ export async function runNonInteractive(
             while (true) {
               const itemToolCallRequests: ToolCallRequestInfo[] = [];
               const itemApiStartTime = Date.now();
+              selectActiveInteraction(itemPromptId, itemIsFirstTurn);
               const itemStream = geminiClient.sendMessageStream(
                 itemMessages[0]?.parts || [],
                 abortController.signal,
@@ -2539,6 +2640,7 @@ export async function runNonInteractive(
               adapter.startAssistantMessage();
 
               for await (const event of itemStream) {
+                captureActiveInteractionOwner();
                 if (abortController.signal.aborted) {
                   // Pair the startAssistantMessage() above so stream-json
                   // mode doesn't leave an unterminated message_start, then
@@ -2587,6 +2689,7 @@ export async function runNonInteractive(
                   throw new AlreadyReportedError(errorText);
                 }
               }
+              captureActiveInteractionOwner();
 
               adapter.finalizeAssistantMessage();
               totalApiDurationMs += Date.now() - itemApiStartTime;
@@ -2859,6 +2962,10 @@ export async function runNonInteractive(
             const errorMessage =
               `Model produced plain text instead of calling the structured_output tool as required by --json-schema after ${turnCount} turn(s).` +
               previewSuffix;
+            endActiveInteraction('error', {
+              errorMessage: 'model did not produce structured output',
+              errorType: 'structured_output_missing',
+            });
             await emitResult({
               isError: true,
               durationMs: Date.now() - startTime,
@@ -2883,6 +2990,25 @@ export async function runNonInteractive(
         }
       }
     } catch (error) {
+      const budgetExceeded = budgetEnforcer.getExceeded();
+      endActiveInteraction(
+        budgetExceeded || !abortController.signal.aborted
+          ? 'error'
+          : 'cancelled',
+        {
+          ...(budgetExceeded
+            ? {
+                errorMessage: budgetExceeded.message,
+                errorType: 'run_budget_exceeded',
+              }
+            : abortController.signal.aborted
+              ? {}
+              : {
+                  errorMessage: 'headless invocation failed',
+                  errorType: getErrorType(error),
+                }),
+        },
+      );
       await failClosedActiveGoalTurn(
         error instanceof Error
           ? error.message
@@ -2909,7 +3035,6 @@ export async function runNonInteractive(
       // depend on that envelope to close the stream cleanly) and (b)
       // exit with the budget handler's exit code 55 instead of the
       // generic `handleError` exit code 1 from a raw "AbortError".
-      const budgetExceeded = budgetEnforcer.getExceeded();
       const recoverableCancellation =
         !budgetExceeded &&
         options.recoverableCancellation === true &&

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -108,6 +108,9 @@ const mockRefreshMemoryAfterManagedWrite = vi.hoisted(() => vi.fn());
 const mockRefreshMemoryInstruction = vi.hoisted(() => vi.fn());
 const mockCleanupReviewWorktreeLeases = vi.hoisted(() => vi.fn());
 const mockLogConversationFinishedEvent = vi.hoisted(() => vi.fn());
+const mockEndInteractionSpan = vi.hoisted(() => vi.fn());
+const mockGetActiveInteractionSpan = vi.hoisted(() => vi.fn());
+const mockInteractionSpan = vi.hoisted(() => ({}));
 const mockUseDualOutput = vi.hoisted(() => vi.fn());
 const mockDualOutput = vi.hoisted(() => ({
   startAssistantMessage: vi.fn(),
@@ -147,6 +150,8 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     refreshMemoryInstruction: mockRefreshMemoryInstruction,
     logConversationFinishedEvent: mockLogConversationFinishedEvent,
     finalizeToolResponses: mockFinalizeToolResponses,
+    endInteractionSpan: mockEndInteractionSpan,
+    getActiveInteractionSpan: mockGetActiveInteractionSpan,
   };
 });
 
@@ -223,6 +228,7 @@ describe('useGeminiStream', () => {
 
   beforeEach(() => {
     vi.clearAllMocks(); // Clear mocks before each test
+    mockGetActiveInteractionSpan.mockReturnValue(mockInteractionSpan);
     mockRefreshMemoryAfterManagedWrite.mockResolvedValue(false);
     mockRefreshMemoryInstruction.mockResolvedValue(undefined);
     mockGetActiveGoal.mockReturnValue(undefined);
@@ -1950,6 +1956,11 @@ describe('useGeminiStream', () => {
     });
     expect(finishTurn).toHaveBeenCalledWith(permit);
     expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    expect(mockEndInteractionSpan).toHaveBeenCalledWith('error', {
+      promptId: 'prompt-goal-missing',
+      errorMessage: 'missing Goal tool context',
+      errorType: 'continuation_goal_context_missing',
+    });
   });
 
   it('fails close when a ToolResult batch has a stale Goal context', async () => {
@@ -2084,6 +2095,11 @@ describe('useGeminiStream', () => {
     });
     expect(finishTurn).toHaveBeenCalledWith(permit);
     expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    expect(mockEndInteractionSpan).toHaveBeenCalledWith('error', {
+      promptId: 'prompt-goal-stale',
+      errorMessage: 'stale Goal tool context',
+      errorType: 'continuation_goal_context_stale',
+    });
   });
 
   it('finishes a Goal turn without another model call after update_goal', async () => {
@@ -2125,7 +2141,22 @@ describe('useGeminiStream', () => {
       return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
     });
     const client = new MockedGeminiClientClass(mockConfig);
-    renderHook(() =>
+    mockSendMessageStream.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: ServerGeminiEventType.ToolCallRequest,
+          value: {
+            callId: 'update-goal-1',
+            name: 'update_goal',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-goal-complete',
+            goalContext: permit,
+          },
+        };
+      })(),
+    );
+    const { result } = renderHook(() =>
       useGeminiStream(
         client,
         [],
@@ -2148,6 +2179,14 @@ describe('useGeminiStream', () => {
         24,
       ),
     );
+    await act(async () => {
+      await result.current.submitQuery(
+        'finish the Goal',
+        SendMessageType.UserQuery,
+        'prompt-goal-complete',
+      );
+    });
+    await waitFor(() => expect(mockScheduleToolCalls).toHaveBeenCalledOnce());
     const responseParts: Part[] = [
       {
         functionResponse: {
@@ -2200,7 +2239,100 @@ describe('useGeminiStream', () => {
       },
       expect.any(Number),
     );
-    expect(mockSendMessageStream).not.toHaveBeenCalled();
+    expect(mockSendMessageStream).toHaveBeenCalledOnce();
+    expect(mockEndInteractionSpan).toHaveBeenCalledWith('ok', {
+      promptId: 'prompt-goal-complete',
+    });
+  });
+
+  it('does not let an old tool batch end a replacement interaction', async () => {
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+    });
+    const originalOwner = {};
+    const replacementOwner = {};
+    mockGetActiveInteractionSpan.mockReturnValue(originalOwner);
+    const client = new MockedGeminiClientClass(mockConfig);
+    const { result } = renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockConfig,
+        true,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+    mockSendMessageStream.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: ServerGeminiEventType.ToolCallRequest,
+          value: {
+            callId: 'replacement-tool',
+            name: 'testTool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-replaced',
+          },
+        };
+      })(),
+    );
+
+    await act(async () => {
+      await result.current.submitQuery(
+        'run the tool',
+        SendMessageType.UserQuery,
+        'prompt-replaced',
+      );
+    });
+    await waitFor(() => expect(mockScheduleToolCalls).toHaveBeenCalledOnce());
+    mockGetActiveInteractionSpan.mockReturnValue(replacementOwner);
+
+    await act(async () => {
+      await capturedOnComplete?.([
+        {
+          request: {
+            callId: 'replacement-tool',
+            name: 'testTool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-replaced',
+          },
+          status: 'cancelled',
+          responseSubmittedToGemini: false,
+          response: {
+            callId: 'replacement-tool',
+            responseParts: [{ text: 'cancelled' }],
+            errorType: undefined,
+          },
+          tool: { displayName: 'TestTool' },
+          invocation: {
+            getDescription: () => 'replacement test',
+          } as unknown as AnyToolInvocation,
+        } as TrackedCancelledToolCall,
+      ]);
+    });
+
+    expect(mockEndInteractionSpan).not.toHaveBeenCalledWith('cancelled', {
+      promptId: 'prompt-replaced',
+    });
   });
 
   it('records tool results with goalContext during a Goal turn', async () => {
@@ -2365,7 +2497,21 @@ describe('useGeminiStream', () => {
     });
 
     const client = new MockedGeminiClientClass(mockConfig);
-    renderHook(() =>
+    mockSendMessageStream.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: ServerGeminiEventType.ToolCallRequest,
+          value: {
+            callId: 'agent-call',
+            name: 'agent',
+            args: { run_in_background: true },
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-agent',
+          },
+        };
+      })(),
+    );
+    const { result } = renderHook(() =>
       useGeminiStream(
         client,
         [],
@@ -2390,6 +2536,14 @@ describe('useGeminiStream', () => {
     );
 
     await waitFor(() => expect(notificationCallback).toBeDefined());
+    await act(async () => {
+      await result.current.submitQuery(
+        'launch the agent',
+        SendMessageType.UserQuery,
+        'prompt-id-agent',
+      );
+    });
+    await waitFor(() => expect(mockScheduleToolCalls).toHaveBeenCalledOnce());
     await act(async () => {
       await capturedOnComplete?.([
         {
@@ -2427,7 +2581,12 @@ describe('useGeminiStream', () => {
       role: 'user',
       parts: responseParts,
     });
-    expect(mockSendMessageStream).not.toHaveBeenCalled();
+    expect(mockSendMessageStream).toHaveBeenCalledOnce();
+    expect(mockEndInteractionSpan).toHaveBeenCalledWith('error', {
+      promptId: 'prompt-id-agent',
+      errorMessage: 'tool continuation capacity exhausted',
+      errorType: 'continuation_capacity_exhausted',
+    });
 
     act(() => {
       notificationCallback?.(
@@ -2436,8 +2595,8 @@ describe('useGeminiStream', () => {
       );
     });
 
-    await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalledOnce());
-    expect(mockSendMessageStream).toHaveBeenCalledWith(
+    await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalledTimes(2));
+    expect(mockSendMessageStream).toHaveBeenLastCalledWith(
       '<task-notification>done</task-notification>',
       expect.any(AbortSignal),
       expect.any(String),
@@ -4102,6 +4261,20 @@ describe('useGeminiStream', () => {
       } as TrackedCancelledToolCall,
     ];
     const client = new MockedGeminiClientClass(mockConfig);
+    mockSendMessageStream.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: ServerGeminiEventType.ToolCallRequest,
+          value: {
+            callId: '1',
+            name: 'testTool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-id-3',
+          },
+        };
+      })(),
+    );
 
     // Capture the onComplete callback
     let capturedOnComplete:
@@ -4113,7 +4286,7 @@ describe('useGeminiStream', () => {
       return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
     });
 
-    renderHook(() =>
+    const { result } = renderHook(() =>
       useGeminiStream(
         client,
         [],
@@ -4137,6 +4310,15 @@ describe('useGeminiStream', () => {
       ),
     );
 
+    await act(async () => {
+      await result.current.submitQuery(
+        'run the tool',
+        SendMessageType.UserQuery,
+        'prompt-id-3',
+      );
+    });
+    await waitFor(() => expect(mockScheduleToolCalls).toHaveBeenCalledOnce());
+
     // Trigger the onComplete callback with cancelled tools
     await act(async () => {
       if (capturedOnComplete) {
@@ -4150,8 +4332,11 @@ describe('useGeminiStream', () => {
         role: 'user',
         parts: [{ text: 'cancelled' }],
       });
-      // Ensure we do NOT call back to the API
-      expect(mockSendMessageStream).not.toHaveBeenCalled();
+      expect(mockEndInteractionSpan).toHaveBeenCalledWith('cancelled', {
+        promptId: 'prompt-id-3',
+      });
+      // Ensure we do NOT call back to the API after the initial tool request.
+      expect(mockSendMessageStream).toHaveBeenCalledOnce();
     });
   });
 
@@ -7892,6 +8077,9 @@ describe('useGeminiStream', () => {
 
       // Verify state is reset
       expect(result.current.streamingState).toBe(StreamingState.Idle);
+      expect(mockEndInteractionSpan).toHaveBeenCalledWith('cancelled', {
+        promptId: 'test-session-id########5',
+      });
     });
 
     it('should call onCancelSubmit handler when cancelOngoingRequest is called', async () => {
@@ -9767,6 +9955,12 @@ describe('useGeminiStream', () => {
         ],
         { logContext: 'interactive memory tool batch' },
       );
+      await waitFor(() => expect(mockSendMessageStream).toHaveBeenCalled());
+      const continuationCall = mockSendMessageStream.mock.calls.at(-1);
+      expect(continuationCall?.[2]).toBe('prompt-id-memory-write');
+      expect(continuationCall?.[3]).toMatchObject({
+        type: SendMessageType.ToolResult,
+      });
       expect(mockPerformMemoryRefresh).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -70,6 +70,8 @@ import {
   refreshMemoryAfterManagedWrite,
   refreshMemoryInstruction,
   finalizeToolResponses,
+  endInteractionSpan,
+  getActiveInteractionSpan,
 } from '@qwen-code/qwen-code-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -510,6 +512,10 @@ export const useGeminiStream = (
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const activeInteractionPromptIdRef = useRef<string | undefined>(undefined);
+  const activeInteractionOwnerRef = useRef<
+    NonNullable<ReturnType<typeof getActiveInteractionSpan>> | undefined
+  >(undefined);
   const activeGoalTurnRef = useRef<GoalTurnBinding | null>(null);
   const activeGoalAdmissionRef = useRef<GoalTurnAdmission | null>(null);
   const goalTurnBindingsRef = useRef(new Map<string, GoalTurnBinding>());
@@ -791,6 +797,9 @@ export const useGeminiStream = (
   const pendingDuplicateToolResponsesRef = useRef<
     PendingDuplicateToolResponses[]
   >([]);
+  const interactionOwnersByToolCallIdRef = useRef(
+    new Map<string, NonNullable<ReturnType<typeof getActiveInteractionSpan>>>(),
+  );
   const immediateDuplicateToolResponsesRef = useRef<{
     promptId: string | undefined;
     responses: Array<{
@@ -1053,6 +1062,19 @@ export const useGeminiStream = (
     submissionLeaseGenerationRef.current += 1;
     setSubmissionInFlight(false);
     abortControllerRef.current?.abort();
+    const activeInteractionPromptId = activeInteractionPromptIdRef.current;
+    const activeInteractionOwner = activeInteractionOwnerRef.current;
+    if (
+      activeInteractionPromptId &&
+      activeInteractionOwner &&
+      getActiveInteractionSpan(activeInteractionPromptId) ===
+        activeInteractionOwner
+    ) {
+      endInteractionSpan('cancelled', {
+        promptId: activeInteractionPromptId,
+      });
+      activeInteractionOwnerRef.current = undefined;
+    }
     // Aborting a tick-in-flight ends any self-paced /loop: drop pending loop
     // wakeups so the loop doesn't resume after the cancelled tick. Only clears
     // session wakeups (never cron jobs); lazily-creating an empty scheduler
@@ -2221,6 +2243,8 @@ export const useGeminiStream = (
       signal: AbortSignal,
       submitType: SendMessageType,
       turnAdmission?: GoalTurnAdmission,
+      promptId?: string,
+      trackInteractionOwner = true,
     ): Promise<StreamProcessingResult> => {
       let geminiMessageBuffer = '';
       let thoughtBuffer = '';
@@ -2384,6 +2408,10 @@ export const useGeminiStream = (
       dualOutput?.startAssistantMessage();
       try {
         for await (const event of stream) {
+          if (trackInteractionOwner && promptId) {
+            activeInteractionOwnerRef.current ??=
+              getActiveInteractionSpan(promptId);
+          }
           dualOutput?.processEvent(event);
           switch (event.type) {
             case ServerGeminiEventType.Thought:
@@ -2783,6 +2811,15 @@ export const useGeminiStream = (
         }
 
         if (executableToolCallRequests.length > 0) {
+          const interactionOwner = activeInteractionOwnerRef.current;
+          if (trackInteractionOwner && interactionOwner) {
+            for (const request of executableToolCallRequests) {
+              interactionOwnersByToolCallIdRef.current.set(
+                request.callId,
+                interactionOwner,
+              );
+            }
+          }
           scheduledToolContinuation = true;
           scheduleToolCalls(
             executableToolCallRequests,
@@ -3286,6 +3323,16 @@ export const useGeminiStream = (
       if (!prompt_id) {
         prompt_id = config.getSessionId() + '########' + getPromptCount();
       }
+      if (!allowConcurrentBtwDuringResponse) {
+        activeInteractionPromptIdRef.current = prompt_id;
+        if (
+          submitType !== SendMessageType.ToolResult &&
+          submitType !== SendMessageType.Hook &&
+          submitType !== SendMessageType.Steer
+        ) {
+          activeInteractionOwnerRef.current = undefined;
+        }
+      }
 
       return promptIdContext.run(prompt_id, async () => {
         let queuedGoal = metadata?.goal;
@@ -3543,6 +3590,8 @@ export const useGeminiStream = (
             processingSignal,
             submitType,
             turnAdmission,
+            prompt_id,
+            !allowConcurrentBtwDuringResponse,
           );
           if (
             !goalBinding &&
@@ -4032,6 +4081,50 @@ export const useGeminiStream = (
           !t.request.isClientInitiated &&
           !historyCallIdsWithResponse.has(t.request.callId),
       );
+      const terminalPromptId = completedAndReadyToSubmitTools.find(
+        (toolCall) => !toolCall.request.isClientInitiated,
+      )?.request.prompt_id;
+      const ownerToolCall =
+        geminiTools[0] ??
+        completedAndReadyToSubmitTools.find(
+          (toolCall) => !toolCall.request.isClientInitiated,
+        );
+      const interactionOwner = ownerToolCall
+        ? (interactionOwnersByToolCallIdRef.current.get(
+            ownerToolCall.request.callId,
+          ) ??
+          (activeInteractionPromptIdRef.current ===
+          ownerToolCall.request.prompt_id
+            ? activeInteractionOwnerRef.current
+            : undefined))
+        : undefined;
+      for (const toolCall of completedAndReadyToSubmitTools) {
+        interactionOwnersByToolCallIdRef.current.delete(
+          toolCall.request.callId,
+        );
+      }
+      let promptId = geminiTools[0]?.request.prompt_id;
+      const endToolInteraction = (
+        status: 'ok' | 'error' | 'cancelled',
+        errorMessage?: string,
+        errorType?: string,
+      ) => {
+        if (
+          !promptId ||
+          !interactionOwner ||
+          getActiveInteractionSpan(promptId) !== interactionOwner
+        ) {
+          return;
+        }
+        endInteractionSpan(status, {
+          promptId,
+          ...(errorMessage ? { errorMessage } : {}),
+          ...(errorType ? { errorType } : {}),
+        });
+        if (activeInteractionOwnerRef.current === interactionOwner) {
+          activeInteractionOwnerRef.current = undefined;
+        }
+      };
       let toolGoalPermit: GoalTurnPermit | undefined;
       const toolGoalContexts = geminiTools.map(
         (toolCall) => toolCall.request.goalContext,
@@ -4070,6 +4163,11 @@ export const useGeminiStream = (
           },
           Date.now(),
         );
+        endToolInteraction(
+          'error',
+          'invalid Goal tool context',
+          'continuation_goal_context_invalid',
+        );
         return;
       }
       if (!toolGoalPermit && toolGoalContexts.length > 0) {
@@ -4099,6 +4197,11 @@ export const useGeminiStream = (
             },
             Date.now(),
           );
+          endToolInteraction(
+            'error',
+            'missing Goal tool context',
+            'continuation_goal_context_missing',
+          );
           return;
         }
       }
@@ -4117,6 +4220,11 @@ export const useGeminiStream = (
               text: reason,
             },
             Date.now(),
+          );
+          endToolInteraction(
+            'error',
+            'stale Goal tool context',
+            'continuation_goal_context_stale',
           );
           return;
         }
@@ -4190,6 +4298,9 @@ export const useGeminiStream = (
         (batch) => batch.duplicateResponses,
       );
       const pendingDuplicatePromptId = readyDuplicateBatches[0]?.promptId;
+      if (!promptId && pendingDuplicatePromptId) {
+        promptId = pendingDuplicatePromptId;
+      }
 
       for (const toolCall of geminiTools) {
         geminiClient?.recordCompletedToolCall(
@@ -4199,11 +4310,34 @@ export const useGeminiStream = (
       }
 
       if (geminiTools.length === 0 && pendingDuplicateResponses.length === 0) {
+        if (!promptId && terminalPromptId) {
+          promptId = terminalPromptId;
+        }
         if (toolGoalBinding) {
           await failClosedGoalTurn(
             toolGoalBinding,
             'Goal tool continuation ended without a result',
           );
+        }
+        if (
+          completedAndReadyToSubmitTools.length > 0 &&
+          completedAndReadyToSubmitTools.every(
+            (toolCall) => toolCall.status === 'cancelled',
+          )
+        ) {
+          endToolInteraction('cancelled');
+        } else if (
+          completedAndReadyToSubmitTools.some(
+            (toolCall) => toolCall.status === 'error',
+          )
+        ) {
+          endToolInteraction(
+            'error',
+            'tool continuation ended with an error',
+            'continuation_tool_error',
+          );
+        } else {
+          endToolInteraction('ok');
         }
         return;
       }
@@ -4300,6 +4434,7 @@ export const useGeminiStream = (
             'Goal tool continuation was cancelled',
           );
         }
+        endToolInteraction('cancelled');
         return;
       }
 
@@ -4331,17 +4466,13 @@ export const useGeminiStream = (
             'Goal tool continuation was cancelled',
           );
         }
+        endToolInteraction('cancelled');
         return;
       }
 
       const callIdsToMarkAsSubmitted = geminiTools.map(
         (toolCall) => toolCall.request.callId,
       );
-
-      const prompt_ids = geminiTools.map(
-        (toolCall) => toolCall.request.prompt_id,
-      );
-      const promptId = prompt_ids[0] ?? pendingDuplicatePromptId;
 
       // Persist model override from skill tool results (last one wins).
       // Uses `in` so that undefined (from inherit/no-model skills) clears a
@@ -4389,6 +4520,7 @@ export const useGeminiStream = (
       );
       if (terminatesGoalTurn && toolGoalBinding) {
         geminiClient.addHistory({ role: 'user', parts: responsesToSend });
+        let goalFinishFailed = false;
         try {
           await config.getChatRecordingService()?.flush();
           const runtime = await config.getGoalRuntimeReady();
@@ -4416,6 +4548,7 @@ export const useGeminiStream = (
             }
           }
         } catch (error) {
+          goalFinishFailed = true;
           await failClosedGoalTurn(
             toolGoalBinding,
             `Goal turn could not finish: ${getErrorMessage(error)}`,
@@ -4423,6 +4556,15 @@ export const useGeminiStream = (
         } finally {
           // Idempotent with the release inside failClosedGoalTurn; also covers the success path.
           releaseGoalTurn(toolGoalBinding);
+        }
+        if (goalFinishFailed) {
+          endToolInteraction(
+            'error',
+            'Goal tool continuation could not finish',
+            'continuation_goal_finish_failed',
+          );
+        } else {
+          endToolInteraction('ok');
         }
         return;
       }
@@ -4530,6 +4672,7 @@ export const useGeminiStream = (
             'Goal tool continuation stopped after a model switch',
           );
         }
+        endToolInteraction('cancelled');
         return;
       }
 
@@ -4557,6 +4700,11 @@ export const useGeminiStream = (
             'Goal tool continuation stopped: background capacity exhausted',
           );
         }
+        endToolInteraction(
+          'error',
+          'tool continuation capacity exhausted',
+          'continuation_capacity_exhausted',
+        );
         return;
       }
 
@@ -4605,6 +4753,7 @@ export const useGeminiStream = (
             'Goal tool continuation was cancelled',
           );
         }
+        endToolInteraction('cancelled');
         return;
       }
       if (toolGoalBinding?.controller.signal.aborted) {
@@ -4613,13 +4762,28 @@ export const useGeminiStream = (
           toolGoalBinding,
           'Goal tool continuation was preempted',
         );
+        endToolInteraction('cancelled');
         return;
       }
 
       void submitQuery(responsesToSend, SendMessageType.ToolResult, promptId, {
         steerInput: drainedSteer,
         onDelivered: drainedSteer?.accept,
-        onDeliveryFailed: drainedSteer?.restore,
+        onAdmissionFailed: () => {
+          endToolInteraction(
+            'error',
+            'tool continuation admission failed',
+            'continuation_admission_failed',
+          );
+        },
+        onDeliveryFailed: () => {
+          drainedSteer?.restore();
+          endToolInteraction(
+            'error',
+            'tool continuation delivery failed',
+            'continuation_delivery_failed',
+          );
+        },
         goalBinding: toolGoalBinding,
       });
     },

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -100,6 +100,8 @@ import {
   setActiveGoal,
 } from '../goals/activeGoalStore.js';
 import { GOAL_HOOK_ID_OUTPUT_KEY } from '../goals/goalHook.js';
+import { emptyGoalSnapshot } from '../goals/goal-protocol.js';
+import type { GoalRuntime } from '../goals/goal-runtime.js';
 import type { FileHistorySnapshot } from '../services/fileHistoryService.js';
 import { runWithAgentContext } from '../agents/runtime/agent-context.js';
 import {
@@ -322,8 +324,19 @@ const mockUiTelemetryService = vi.hoisted(() => ({
 }));
 const mockLogMemoryRecallDelivery = vi.hoisted(() => vi.fn());
 const mockInteractionTelemetry = vi.hoisted(() => ({
+  startInteractionSpan: vi.fn(),
+  endInteractionSpan: vi.fn(),
   getActiveInteractionSpan: vi.fn(),
+  addAgentInputMessageAttributes: vi.fn(),
   addUserPromptAttributes: vi.fn(),
+  outputCaptures: [] as Array<{
+    beginResponse: ReturnType<typeof vi.fn>;
+    appendText: ReturnType<typeof vi.fn>;
+    observeFinishReason: ReturnType<typeof vi.fn>;
+    restartAttempt: ReturnType<typeof vi.fn>;
+    commitResponse: ReturnType<typeof vi.fn>;
+    writeToSpan: ReturnType<typeof vi.fn>;
+  }>,
 }));
 vi.mock('../telemetry/tracer.js', () => ({
   API_CALL_ABORTED_SPAN_STATUS_MESSAGE: 'API call aborted',
@@ -336,8 +349,24 @@ vi.mock('../telemetry/index.js', async (importOriginal) => {
     ...actual,
     uiTelemetryService: mockUiTelemetryService,
     logMemoryRecallDelivery: mockLogMemoryRecallDelivery,
+    startInteractionSpan: mockInteractionTelemetry.startInteractionSpan,
+    endInteractionSpan: mockInteractionTelemetry.endInteractionSpan,
     getActiveInteractionSpan: mockInteractionTelemetry.getActiveInteractionSpan,
+    addAgentInputMessageAttributes:
+      mockInteractionTelemetry.addAgentInputMessageAttributes,
     addUserPromptAttributes: mockInteractionTelemetry.addUserPromptAttributes,
+    AgentOutputMessageCapture: class {
+      beginResponse = vi.fn();
+      appendText = vi.fn();
+      observeFinishReason = vi.fn();
+      restartAttempt = vi.fn();
+      commitResponse = vi.fn();
+      writeToSpan = vi.fn();
+
+      constructor() {
+        mockInteractionTelemetry.outputCaptures.push(this);
+      }
+    },
     // We keep the real implementations of logChatCompression, etc.
     // but we can spy on QwenLogger if needed
   };
@@ -465,6 +494,8 @@ describe('Gemini Client (client.ts)', () => {
   };
   beforeEach(async () => {
     vi.resetAllMocks();
+    mockInteractionTelemetry.outputCaptures.length = 0;
+    mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue({});
     // The client concatenates these with the auto-memory suffix, so the
     // default mock must return a string, not undefined.
     vi.mocked(getCoreSystemPrompt).mockReturnValue('');
@@ -644,6 +675,7 @@ describe('Gemini Client (client.ts)', () => {
         getResolvedModel: vi.fn().mockReturnValue(undefined),
       }),
       getAllConfiguredModels: vi.fn().mockReturnValue([]),
+      getJsonSchema: vi.fn().mockReturnValue(undefined),
       getDisableAllHooks: vi.fn().mockReturnValue(true),
       getStopHookBlockingCap: vi.fn().mockReturnValue(8),
       getArenaManager: vi.fn().mockReturnValue(null),
@@ -5481,6 +5513,390 @@ hello
       );
     });
 
+    it('keeps one interaction open across multiple tool-result continuations', async () => {
+      const promptId = 'prompt-tool-loop';
+      mockTurnRunFn.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: GeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'call-1',
+              name: 'read_file',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: promptId,
+            },
+          };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'use a tool' }],
+          new AbortController().signal,
+          promptId,
+          { type: SendMessageType.UserQuery },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.startInteractionSpan,
+      ).toHaveBeenCalledWith(mockConfig, expect.objectContaining({ promptId }));
+      expect(
+        mockInteractionTelemetry.endInteractionSpan,
+      ).not.toHaveBeenCalled();
+
+      mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue({});
+      mockTurnRunFn.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: GeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'call-2',
+              name: 'write_file',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: promptId,
+            },
+          };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ functionResponse: { name: 'read_file', response: { ok: true } } }],
+          new AbortController().signal,
+          promptId,
+          { type: SendMessageType.ToolResult },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.startInteractionSpan,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockInteractionTelemetry.endInteractionSpan,
+      ).not.toHaveBeenCalled();
+
+      mockTurnRunFn.mockReturnValueOnce(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'done' };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [
+            {
+              functionResponse: { name: 'write_file', response: { ok: true } },
+            },
+          ],
+          new AbortController().signal,
+          promptId,
+          { type: SendMessageType.ToolResult },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.startInteractionSpan,
+      ).toHaveBeenCalledTimes(1);
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'ok',
+        { promptId },
+      );
+    });
+
+    it('starts Retry as a fresh agent invocation', async () => {
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'retried' };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'retry' }],
+          new AbortController().signal,
+          'retry-prompt',
+          { type: SendMessageType.Retry },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.startInteractionSpan,
+      ).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          promptId: 'retry-prompt',
+          messageType: SendMessageType.Retry,
+        }),
+      );
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'ok',
+        { promptId: 'retry-prompt' },
+      );
+      expect(
+        mockInteractionTelemetry.addAgentInputMessageAttributes,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('traces a UserQuery that is blocked before model admission', async () => {
+      const owner = {};
+      mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue(owner);
+      const messageBus = {
+        request: vi.fn().mockResolvedValue({
+          output: { decision: 'block', reason: 'blocked by hook' },
+        }),
+        response: vi.fn(),
+      };
+      vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+      vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+        messageBus as unknown as ReturnType<Config['getMessageBus']>,
+      );
+      vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+        (event: string) => event === 'UserPromptSubmit',
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'expanded prompt' }],
+          new AbortController().signal,
+          'prompt-blocked-before-model',
+          {
+            type: SendMessageType.UserQuery,
+            submittedPrompt: 'raw prompt',
+          },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.startInteractionSpan,
+      ).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({ promptId: 'prompt-blocked-before-model' }),
+      );
+      expect(
+        mockInteractionTelemetry.addAgentInputMessageAttributes,
+      ).toHaveBeenCalledWith(mockConfig, owner, 'raw prompt');
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'cancelled',
+        { promptId: 'prompt-blocked-before-model' },
+      );
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
+    it('captures only the final physical response for an agent invocation', async () => {
+      const owner = {};
+      mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue(owner);
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'final answer' };
+          yield {
+            type: GeminiEventType.Finished,
+            value: { reason: 'STOP' },
+          };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'expanded request' }],
+          new AbortController().signal,
+          'prompt-agent-messages',
+          {
+            type: SendMessageType.UserQuery,
+            submittedPrompt: 'raw @file prompt',
+          },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.addAgentInputMessageAttributes,
+      ).toHaveBeenCalledWith(mockConfig, owner, 'raw @file prompt');
+      const capture = mockInteractionTelemetry.outputCaptures[0]!;
+      expect(capture.beginResponse).toHaveBeenCalledOnce();
+      expect(capture.appendText).toHaveBeenCalledWith('final answer');
+      expect(capture.observeFinishReason).toHaveBeenCalledWith('STOP');
+      expect(capture.commitResponse).toHaveBeenCalledWith(false);
+      expect(capture.writeToSpan).toHaveBeenCalledWith(owner);
+    });
+
+    it('does not write to a replacement interaction with the same prompt id', async () => {
+      const owner = {};
+      const replacement = {};
+      mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue(owner);
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'stale answer' };
+          mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue(
+            replacement,
+          );
+          yield {
+            type: GeminiEventType.Finished,
+            value: { reason: 'STOP' },
+          };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'request' }],
+          new AbortController().signal,
+          'reused-prompt-id',
+          { type: SendMessageType.UserQuery, submittedPrompt: 'request' },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.outputCaptures[0]!.writeToSpan,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockInteractionTelemetry.endInteractionSpan,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('resets failed provider attempts while preserving continuation retries', async () => {
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'discarded' };
+          yield { type: GeminiEventType.Retry, isContinuation: false };
+          yield { type: GeminiEventType.Content, value: 'kept ' };
+          yield { type: GeminiEventType.Retry, isContinuation: true };
+          yield { type: GeminiEventType.Content, value: 'continuation' };
+          yield {
+            type: GeminiEventType.Finished,
+            value: { reason: 'STOP' },
+          };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'request' }],
+          new AbortController().signal,
+          'provider-retry-prompt',
+          { type: SendMessageType.UserQuery, submittedPrompt: 'request' },
+        ),
+      );
+
+      const capture = mockInteractionTelemetry.outputCaptures[0]!;
+      expect(capture.restartAttempt).toHaveBeenNthCalledWith(1, false);
+      expect(capture.restartAttempt).toHaveBeenNthCalledWith(2, true);
+      expect(capture.appendText.mock.calls).toEqual([
+        ['discarded'],
+        ['kept '],
+        ['continuation'],
+      ]);
+      expect(capture.commitResponse).toHaveBeenCalledWith(false);
+    });
+
+    it('starts Goal as a fresh agent invocation', async () => {
+      const permit = { goalId: 'goal-1', revision: 1, turnId: 'turn-1' };
+      const finishTurn = vi.fn().mockResolvedValue(undefined);
+      const goalRuntime = {
+        getSnapshot: () => emptyGoalSnapshot(),
+        permitForTurn: vi.fn(() => permit),
+        subscribe: vi.fn(() => vi.fn()),
+        finishTurn,
+      } as unknown as GoalRuntime;
+      mockConfig.getGoalRuntimeReady = vi.fn().mockResolvedValue(goalRuntime);
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'goal progress' };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'continue the goal' }],
+          new AbortController().signal,
+          'goal-prompt',
+          {
+            type: SendMessageType.Goal,
+            goalPermit: permit,
+            goalTurnKey: 'goal-runtime:turn-1',
+          },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.startInteractionSpan,
+      ).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          promptId: 'goal-prompt',
+          messageType: SendMessageType.Goal,
+        }),
+      );
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'ok',
+        { promptId: 'goal-prompt' },
+      );
+      expect(finishTurn).toHaveBeenCalledWith(permit);
+    });
+
+    it('keeps a Steer continuation in the original invocation', async () => {
+      mockTurnRunFn.mockImplementation(() =>
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'response' };
+        })(),
+      );
+      const getSteerInput = vi
+        .fn<() => Promise<SteerInput | undefined>>()
+        .mockResolvedValueOnce({
+          parts: [{ text: 'steer prompt' }],
+          accept: vi.fn(),
+          restore: vi.fn(),
+        })
+        .mockResolvedValue(undefined);
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'initial prompt' }],
+          new AbortController().signal,
+          'prompt-steer-continuation',
+          { type: SendMessageType.UserQuery, getSteerInput },
+        ),
+      );
+
+      expect(
+        mockInteractionTelemetry.startInteractionSpan,
+      ).toHaveBeenCalledTimes(1);
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'ok',
+        { promptId: 'prompt-steer-continuation' },
+      );
+    });
+
+    it('marks a JSON Schema invocation as failed when no structured output is produced', async () => {
+      vi.mocked(mockConfig.getJsonSchema).mockReturnValue({
+        type: 'object',
+      });
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'plain text' };
+        })(),
+      );
+
+      await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'return structured output' }],
+          new AbortController().signal,
+          'prompt-schema-missing',
+          { type: SendMessageType.UserQuery },
+        ),
+      );
+
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'error',
+        {
+          promptId: 'prompt-schema-missing',
+          errorMessage: 'model did not produce structured output',
+          errorType: 'structured_output_missing',
+        },
+      );
+    });
+
     it('should discard pending prefetch with no_safe_delivery_point on a no-tool turn', async () => {
       // Recall stays pending — never settles before the turn completes.
       mockMemoryManager.recall.mockReturnValue(new Promise(() => {}));
@@ -8588,6 +9004,14 @@ Other open files:
 
       // Assert
       expect(mockCheckNextSpeaker).not.toHaveBeenCalled();
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'error',
+        {
+          promptId: 'prompt-id-error',
+          errorMessage: 'unknown error',
+          errorType: 'api_error',
+        },
+      );
     });
 
     it('should not call checkNextSpeaker when turn.run() yields a value then an error', async () => {
@@ -9853,6 +10277,12 @@ Other open files:
         expect(events).not.toContainEqual(
           expect.objectContaining({ type: GeminiEventType.LoopDetected }),
         );
+        expect(
+          mockInteractionTelemetry.startInteractionSpan,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          mockInteractionTelemetry.endInteractionSpan,
+        ).toHaveBeenCalledWith('ok', { promptId: 'prompt-stop-hook-budget' });
       });
 
       it('emits one active_goal null when the blocking cap aborts an active goal', async () => {
@@ -10892,6 +11322,12 @@ Other open files:
 
       it('restores an attached ToolResult steer when UserPromptSubmit blocks it', async () => {
         client.getChat().getUserContentPushCount = vi.fn().mockReturnValue(0);
+        const activeSpanSpy = vi
+          .spyOn(telemetryIndex, 'getActiveInteractionSpan')
+          .mockReturnValue({} as never);
+        const endSpanSpy = vi
+          .spyOn(telemetryIndex, 'endInteractionSpan')
+          .mockImplementation(() => {});
         const mockMessageBus = {
           request: vi.fn().mockResolvedValue({
             output: { decision: 'block', reason: 'blocked by hook' },
@@ -10927,6 +11363,50 @@ Other open files:
         expect(mockTurnRunFn).not.toHaveBeenCalled();
         expect(accept).not.toHaveBeenCalled();
         expect(restore).toHaveBeenCalledOnce();
+        expect(activeSpanSpy).toHaveBeenCalledWith(
+          'prompt-attached-steer-blocked',
+        );
+        expect(endSpanSpy).toHaveBeenCalledWith('cancelled', {
+          promptId: 'prompt-attached-steer-blocked',
+        });
+      });
+
+      it('ends an attached ToolResult interaction when UserPromptSubmit throws', async () => {
+        vi.spyOn(telemetryIndex, 'getActiveInteractionSpan').mockReturnValue(
+          {} as never,
+        );
+        const endSpanSpy = vi
+          .spyOn(telemetryIndex, 'endInteractionSpan')
+          .mockImplementation(() => {});
+        const mockMessageBus = {
+          request: vi.fn().mockRejectedValue(new Error('sensitive hook error')),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'UserPromptSubmit',
+        );
+
+        await expect(
+          fromAsync(
+            client.sendMessageStream(
+              [{ text: 'tool result' }],
+              new AbortController().signal,
+              'prompt-tool-result-hook-error',
+              { type: SendMessageType.ToolResult },
+            ),
+          ),
+        ).rejects.toThrow('sensitive hook error');
+
+        expect(mockTurnRunFn).not.toHaveBeenCalled();
+        expect(endSpanSpy).toHaveBeenCalledWith('error', {
+          promptId: 'prompt-tool-result-hook-error',
+          errorMessage: 'UserPromptSubmit hook failed',
+          errorType: 'Error',
+        });
       });
 
       it('forwards steerInput through the Steer continuation for early settling', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -327,6 +327,7 @@ const mockInteractionTelemetry = vi.hoisted(() => ({
   startInteractionSpan: vi.fn(),
   endInteractionSpan: vi.fn(),
   getActiveInteractionSpan: vi.fn(),
+  recordInteractionActivity: vi.fn(),
   addAgentInputMessageAttributes: vi.fn(),
   addUserPromptAttributes: vi.fn(),
   outputCaptures: [] as Array<{
@@ -352,6 +353,8 @@ vi.mock('../telemetry/index.js', async (importOriginal) => {
     startInteractionSpan: mockInteractionTelemetry.startInteractionSpan,
     endInteractionSpan: mockInteractionTelemetry.endInteractionSpan,
     getActiveInteractionSpan: mockInteractionTelemetry.getActiveInteractionSpan,
+    recordInteractionActivity:
+      mockInteractionTelemetry.recordInteractionActivity,
     addAgentInputMessageAttributes:
       mockInteractionTelemetry.addAgentInputMessageAttributes,
     addUserPromptAttributes: mockInteractionTelemetry.addUserPromptAttributes,
@@ -5515,6 +5518,11 @@ hello
 
     it('keeps one interaction open across multiple tool-result continuations', async () => {
       const promptId = 'prompt-tool-loop';
+      const owner = {};
+      mockInteractionTelemetry.getActiveInteractionSpan.mockImplementation(
+        (id?: string) =>
+          id === undefined || id === promptId ? owner : undefined,
+      );
       mockTurnRunFn.mockReturnValueOnce(
         (async function* () {
           yield {
@@ -5546,7 +5554,6 @@ hello
         mockInteractionTelemetry.endInteractionSpan,
       ).not.toHaveBeenCalled();
 
-      mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue({});
       mockTurnRunFn.mockReturnValueOnce(
         (async function* () {
           yield {
@@ -5570,6 +5577,10 @@ hello
           { type: SendMessageType.ToolResult },
         ),
       );
+
+      expect(
+        mockInteractionTelemetry.recordInteractionActivity,
+      ).toHaveBeenCalledWith(promptId, owner);
 
       expect(
         mockInteractionTelemetry.startInteractionSpan,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -94,7 +94,9 @@ import {
   startInteractionSpan,
   endInteractionSpan,
   getActiveInteractionSpan,
+  addAgentInputMessageAttributes,
   addUserPromptAttributes,
+  AgentOutputMessageCapture,
   MemoryRecallDeliveryEvent,
 } from '../telemetry/index.js';
 import type {
@@ -130,7 +132,7 @@ import {
   replayUiTelemetryFromConversation,
 } from '../services/sessionService.js';
 import { reportError } from '../utils/errorReporting.js';
-import { getErrorMessage } from '../utils/errors.js';
+import { getErrorMessage, getErrorType } from '../utils/errors.js';
 import { checkNextSpeaker } from '../utils/nextSpeakerChecker.js';
 import {
   flatMapTextParts,
@@ -2150,6 +2152,45 @@ export class GeminiClient {
     turns: number = MAX_TURNS,
   ): AsyncGenerator<ServerGeminiStreamEvent, Turn> {
     const messageType = options?.type ?? SendMessageType.UserQuery;
+    const startsInteraction =
+      messageType === SendMessageType.UserQuery ||
+      messageType === SendMessageType.Retry ||
+      messageType === SendMessageType.Cron ||
+      messageType === SendMessageType.Notification ||
+      messageType === SendMessageType.Teammate ||
+      messageType === SendMessageType.Goal;
+    let interactionOwner = startsInteraction
+      ? undefined
+      : getActiveInteractionSpan(prompt_id);
+    const agentOutput = new AgentOutputMessageCapture(this.config);
+    const endCurrentInteraction = (
+      status: 'ok' | 'error' | 'cancelled',
+      errorMessage?: string,
+      errorType?: string,
+    ) => {
+      if (
+        !interactionOwner ||
+        getActiveInteractionSpan(prompt_id) !== interactionOwner
+      ) {
+        return;
+      }
+      if (status === 'ok' && this.config.getJsonSchema?.()) {
+        endInteractionSpan('error', {
+          promptId: prompt_id,
+          errorMessage: 'model did not produce structured output',
+          errorType: 'structured_output_missing',
+        });
+        return;
+      }
+      if (status === 'ok') {
+        agentOutput.writeToSpan(interactionOwner);
+      }
+      endInteractionSpan(status, {
+        promptId: prompt_id,
+        ...(errorMessage ? { errorMessage } : {}),
+        ...(errorType ? { errorType } : {}),
+      });
+    };
     if (
       messageType === SendMessageType.UserQuery ||
       messageType === SendMessageType.Cron ||
@@ -2369,6 +2410,27 @@ export class GeminiClient {
       messageType === SendMessageType.UserQuery
         ? partToString(request)
         : undefined;
+    if (startsInteraction) {
+      this.loopDetector.reset(prompt_id);
+      this.lastPromptId = prompt_id;
+      startInteractionSpan(this.config, {
+        promptId: prompt_id,
+        model: options?.modelOverride ?? this.config.getModel(),
+        messageType,
+      });
+      interactionOwner = getActiveInteractionSpan(prompt_id);
+      if (
+        interactionOwner &&
+        messageType === SendMessageType.UserQuery &&
+        typeof options?.submittedPrompt === 'string'
+      ) {
+        addAgentInputMessageAttributes(
+          this.config,
+          interactionOwner,
+          options.submittedPrompt,
+        );
+      }
+    }
     let userPromptRecordPayload: UserPromptRecordPayload | undefined;
     let hooksEnabled: boolean;
     let messageBus: ReturnType<Config['getMessageBus']>;
@@ -2435,9 +2497,12 @@ export class GeminiClient {
             await runtime.finishTurn(goalPermit);
             goalPermitReleased = true;
             closeGoalStateEvents();
+            endCurrentInteraction('cancelled');
             for (const goalEvent of takePendingGoalEvents()) {
               yield goalEvent;
             }
+          } else {
+            endCurrentInteraction('cancelled');
           }
           yield {
             type: GeminiEventType.UserPromptSubmitBlocked,
@@ -2473,6 +2538,11 @@ export class GeminiClient {
         }
       }
     } catch (error) {
+      endCurrentInteraction(
+        signal.aborted ? 'cancelled' : 'error',
+        signal.aborted ? undefined : 'UserPromptSubmit hook failed',
+        signal.aborted ? undefined : getErrorType(error),
+      );
       for (const goalEvent of await finalizeInterruptedGoalTurn()) {
         yield goalEvent;
       }
@@ -2536,6 +2606,11 @@ export class GeminiClient {
       }
       if (goalRuntime) bindGoalStateEvents(goalRuntime);
     } catch (error) {
+      endCurrentInteraction(
+        signal.aborted ? 'cancelled' : 'error',
+        signal.aborted ? undefined : 'Goal turn admission failed',
+        signal.aborted ? undefined : getErrorType(error),
+      );
       for (const goalEvent of await finalizeInterruptedGoalTurn()) {
         yield goalEvent;
       }
@@ -2589,24 +2664,12 @@ export class GeminiClient {
       );
       this.activeAutomaticTodoWorkChainPromptIds.add(prompt_id);
     }
-    const isTopLevelInteraction =
-      messageType === SendMessageType.UserQuery ||
-      messageType === SendMessageType.Cron ||
-      messageType === SendMessageType.Notification ||
-      messageType === SendMessageType.Teammate;
     if (messageType === SendMessageType.Goal) {
       this.loopDetector.reset(prompt_id);
       this.lastPromptId = prompt_id;
     }
-    if (isTopLevelInteraction) {
-      this.loopDetector.reset(prompt_id);
-      this.lastPromptId = prompt_id;
-      startInteractionSpan(this.config, {
-        promptId: prompt_id,
-        model: options?.modelOverride ?? this.config.getModel(),
-        messageType,
-      });
-      const interactionSpan = getActiveInteractionSpan();
+    if (startsInteraction) {
+      const interactionSpan = interactionOwner;
       if (
         interactionSpan &&
         this.config.getTelemetryIncludeSensitiveSpanAttributes?.()
@@ -2620,7 +2683,6 @@ export class GeminiClient {
         );
       }
     }
-
     // Tracks whether the generator reached its natural end (the bottom-of-try
     // `return turn`). Only on that path do we want to preserve the pending
     // memory prefetch so the next ToolResult turn can consume it. Any other
@@ -2820,10 +2882,11 @@ export class GeminiClient {
         ) {
           this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
           yield { type: GeminiEventType.MaxSessionTurns };
-          if (isTopLevelInteraction)
-            endInteractionSpan('error', {
-              errorMessage: 'max session turns exceeded',
-            });
+          endCurrentInteraction(
+            'error',
+            'max session turns exceeded',
+            'max_session_turns',
+          );
           return new Turn(this.getChat(), prompt_id);
         }
       }
@@ -2835,8 +2898,7 @@ export class GeminiClient {
           : Math.min(turns, MAX_TURNS);
       if (!boundedTurns) {
         this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
-        if (isTopLevelInteraction)
-          endInteractionSpan('error', { errorMessage: 'max turns exhausted' });
+        endCurrentInteraction('error', 'max turns exhausted', 'max_turns');
         return new Turn(this.getChat(), prompt_id);
       }
 
@@ -2890,10 +2952,11 @@ export class GeminiClient {
                 'Please start a new session or increase the sessionTokenLimit in your settings.json.',
             },
           };
-          if (isTopLevelInteraction)
-            endInteractionSpan('error', {
-              errorMessage: 'session token limit exceeded',
-            });
+          endCurrentInteraction(
+            'error',
+            'session token limit exceeded',
+            'session_token_limit',
+          );
           return new Turn(this.getChat(), prompt_id);
         }
       }
@@ -2939,7 +3002,7 @@ export class GeminiClient {
           );
           await arenaAgentClient.reportCancelled();
           this.cancelPendingMemoryPrefetch('abort');
-          if (isTopLevelInteraction) endInteractionSpan('cancelled');
+          endCurrentInteraction('cancelled');
           return new Turn(this.getChat(), prompt_id);
         }
       }
@@ -3176,6 +3239,7 @@ export class GeminiClient {
             )
           : null;
 
+      agentOutput.beginResponse();
       const resultStream = turn.run(model, requestToSend, signal);
       let didUpdateIdeContextState = false;
       let steerInputSettled = false;
@@ -3198,6 +3262,15 @@ export class GeminiClient {
             event.type === GeminiEventType.ModelFallback
           ) {
             hasToolCalls = false;
+            agentOutput.restartAttempt(
+              event.type === GeminiEventType.Retry &&
+                event.isContinuation === true,
+            );
+          }
+          if (event.type === GeminiEventType.Content) {
+            agentOutput.appendText(event.value);
+          } else if (event.type === GeminiEventType.Finished) {
+            agentOutput.observeFinishReason(event.value?.reason);
           }
           if (messageDisplay && event.type === GeminiEventType.Content) {
             messageDisplay.addChunk(event.value);
@@ -3233,8 +3306,7 @@ export class GeminiClient {
               await arenaAgentClient.reportError('Loop detected');
             }
             this.lastApiCompletionTimestamp = Date.now();
-            if (isTopLevelInteraction)
-              endInteractionSpan('error', { errorMessage: 'loop detected' });
+            endCurrentInteraction('error', 'loop detected', 'loop_detected');
             this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
             this.fireLoopDetectedStopFailure(loopType);
             return turn;
@@ -3266,8 +3338,7 @@ export class GeminiClient {
               await arenaAgentClient.reportError('Loop detected');
             }
             this.lastApiCompletionTimestamp = Date.now();
-            if (isTopLevelInteraction)
-              endInteractionSpan('error', { errorMessage: 'loop detected' });
+            endCurrentInteraction('error', 'loop detected', 'loop_detected');
             // finally cleanup catches this, but cancel explicitly to match
             // the cleanup pattern at other early-return sites.
             this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
@@ -3338,12 +3409,16 @@ export class GeminiClient {
               await arenaAgentClient.reportError(errorMsg);
             }
             this.lastApiCompletionTimestamp = Date.now();
-            if (isTopLevelInteraction) {
-              // Sanitize: do not pass raw API error messages to span status
-              const errMsg =
-                event.value instanceof Error ? '[API error]' : 'unknown error';
-              endInteractionSpan('error', { errorMessage: errMsg });
-            }
+            // Sanitize: do not pass raw API error messages to span status.
+            const errMsg =
+              event.value instanceof Error ? '[API error]' : 'unknown error';
+            endCurrentInteraction(
+              'error',
+              errMsg,
+              event.value instanceof Error
+                ? getErrorType(event.value)
+                : 'api_error',
+            );
             // finally cleanup catches this, but cancel explicitly to match
             // the cleanup pattern at other early-return sites.
             this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
@@ -3361,6 +3436,9 @@ export class GeminiClient {
         // a no-op.
         await messageDisplay?.finish();
       }
+      agentOutput.commitResponse(
+        hasToolCalls || turn.pendingToolCalls.length > 0,
+      );
       for (const goalEvent of signal.aborted
         ? await finalizeInterruptedGoalTurn()
         : takePendingGoalEvents()) {
@@ -3392,9 +3470,10 @@ export class GeminiClient {
           } finally {
             settleSteerInput(steerInput, pushCountBefore);
           }
-          if (isTopLevelInteraction)
-            endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
           hasToolCalls = steeredTurn.pendingToolCalls.length > 0;
+          if (!hasToolCalls) {
+            endCurrentInteraction(signal.aborted ? 'cancelled' : 'ok');
+          }
           normalCompletion = true;
           return steeredTurn;
         }
@@ -3456,7 +3535,7 @@ export class GeminiClient {
           if (activeGoalEvent) {
             yield activeGoalEvent;
           }
-          if (isTopLevelInteraction) endInteractionSpan('cancelled');
+          endCurrentInteraction('cancelled');
           return turn;
         }
 
@@ -3501,7 +3580,7 @@ export class GeminiClient {
             for (const goalEvent of await finalizeInterruptedGoalTurn()) {
               yield goalEvent;
             }
-            if (isTopLevelInteraction) endInteractionSpan('ok');
+            endCurrentInteraction('ok');
             return turn;
           } else {
             for (const goalEvent of takePendingGoalEvents()) {
@@ -3526,7 +3605,7 @@ export class GeminiClient {
               for (const goalEvent of await finalizeInterruptedGoalTurn()) {
                 yield goalEvent;
               }
-              if (isTopLevelInteraction) endInteractionSpan('cancelled');
+              endCurrentInteraction('cancelled');
               return turn;
             }
             const continueRequest: Part[] = [{ text: continueReason }];
@@ -3555,8 +3634,9 @@ export class GeminiClient {
             } finally {
               settleSteerInput(pendingSteer, pushCountBefore);
             }
-            if (isTopLevelInteraction) {
-              endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
+            hasToolCalls = hookTurn.pendingToolCalls.length > 0;
+            if (!hasToolCalls) {
+              endCurrentInteraction(signal.aborted ? 'cancelled' : 'ok');
             }
             normalCompletion = true;
             return hookTurn;
@@ -3577,7 +3657,7 @@ export class GeminiClient {
             if (activeGoalEvent) {
               yield activeGoalEvent;
             }
-            if (isTopLevelInteraction) endInteractionSpan('cancelled');
+            endCurrentInteraction('cancelled');
             return turn;
           }
 
@@ -3619,7 +3699,7 @@ export class GeminiClient {
               value: warning,
             };
             debugLogger.warn(warning);
-            if (isTopLevelInteraction) endInteractionSpan('ok');
+            endCurrentInteraction('ok');
             return turn;
           }
 
@@ -3681,7 +3761,7 @@ export class GeminiClient {
               ? response.nonGoalBlockingStopReason || 'No reason provided'
               : continueReason;
           if (!continuationReasonAfterSteer && !pendingSteer) {
-            if (isTopLevelInteraction) endInteractionSpan('ok');
+            endCurrentInteraction('ok');
             normalCompletion = true;
             return turn;
           }
@@ -3725,9 +3805,10 @@ export class GeminiClient {
           } finally {
             settleSteerInput(pendingSteer, pushCountBefore);
           }
-          if (isTopLevelInteraction)
-            endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
           hasToolCalls = hookTurn.pendingToolCalls.length > 0;
+          if (!hasToolCalls) {
+            endCurrentInteraction(signal.aborted ? 'cancelled' : 'ok');
+          }
           // Preserve the pending prefetch: the inner Hook turn we just
           // yielded may have produced tool calls, and the caller's next
           // ToolResult turn still needs to consume the recall result.
@@ -3762,6 +3843,7 @@ export class GeminiClient {
         for (const goalEvent of takePendingGoalEvents()) {
           yield goalEvent;
         }
+        endCurrentInteraction('ok');
         normalCompletion = true;
         return turn;
       }
@@ -3797,7 +3879,7 @@ export class GeminiClient {
           if (arenaAgentClient) {
             await arenaAgentClient.reportCompleted();
           }
-          if (isTopLevelInteraction) endInteractionSpan('ok');
+          endCurrentInteraction('ok');
           return turn;
         }
 
@@ -3841,9 +3923,10 @@ export class GeminiClient {
           } finally {
             settleSteerInput(pendingSteer, pushCountBefore);
           }
-          if (isTopLevelInteraction)
-            endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
           hasToolCalls = continueTurn.pendingToolCalls.length > 0;
+          if (!hasToolCalls) {
+            endCurrentInteraction(signal.aborted ? 'cancelled' : 'ok');
+          }
           // Preserve the pending prefetch: same reasoning as the
           // `return hookTurn` site above — the recursive Hook turn may
           // have produced tool calls whose ToolResult turn still needs
@@ -3867,8 +3950,8 @@ export class GeminiClient {
         await arenaAgentClient.reportCancelled();
       }
 
-      if (isTopLevelInteraction) {
-        endInteractionSpan(signal?.aborted ? 'cancelled' : 'ok');
+      if (!hasToolCalls) {
+        endCurrentInteraction(signal?.aborted ? 'cancelled' : 'ok');
       }
       // Reached the bottom of the try — this turn ended cleanly. If the
       // model did not request tool calls, no future ToolResult will arrive
@@ -3916,10 +3999,12 @@ export class GeminiClient {
           signal?.aborted ? 'abort' : 'no_safe_delivery_point',
         );
       }
-      if (isTopLevelInteraction) {
-        endInteractionSpan(signal?.aborted ? 'cancelled' : 'error', {
-          errorMessage: 'unexpected exit',
-        });
+      if (!normalCompletion) {
+        endCurrentInteraction(
+          signal?.aborted ? 'cancelled' : 'error',
+          signal?.aborted ? undefined : 'unexpected exit',
+          signal?.aborted ? undefined : 'unexpected_exit',
+        );
       }
     }
   }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -94,6 +94,7 @@ import {
   startInteractionSpan,
   endInteractionSpan,
   getActiveInteractionSpan,
+  recordInteractionActivity,
   addAgentInputMessageAttributes,
   addUserPromptAttributes,
   AgentOutputMessageCapture,
@@ -2162,6 +2163,9 @@ export class GeminiClient {
     let interactionOwner = startsInteraction
       ? undefined
       : getActiveInteractionSpan(prompt_id);
+    if (interactionOwner) {
+      recordInteractionActivity(prompt_id, interactionOwner);
+    }
     const agentOutput = new AgentOutputMessageCapture(this.config);
     const endCurrentInteraction = (
       status: 'ok' | 'error' | 'cancelled',

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -265,11 +265,12 @@ vi.mock('../telemetry/session-tracing.js', () => ({
     ) => {
       if (metadata) {
         span.endMetadata = metadata;
-        const status =
-          metadata.success !== false
-            ? { code: 1 }
-            : { code: 2, message: metadata.error ?? 'tool error' };
-        span.statusCalls.push(status);
+        if (metadata.success === false) {
+          span.statusCalls.push({
+            code: 2,
+            message: metadata.error ?? 'tool error',
+          });
+        }
       }
       span.ended = true;
     },
@@ -10714,6 +10715,7 @@ describe('CoreToolScheduler telemetry spans', () => {
       { code: SpanStatusCode.ERROR, message },
     ]);
     expect(spanRecord.spanAttributes['tool.failure_kind']).toBe(failureKind);
+    expect(spanRecord.spanAttributes['error.type']).toBe(failureKind);
     expect(JSON.stringify(spanRecord.statusCalls)).not.toContain('/secret');
     expect(JSON.stringify(spanRecord.statusCalls)).not.toContain('sensitive');
     expect(spanRecord.ended).toBe(true);
@@ -11535,11 +11537,11 @@ describe('CoreToolScheduler telemetry spans', () => {
     ).toBeUndefined();
   });
 
-  it('marks successful tool calls with OK status via endToolSpan', async () => {
+  it('leaves successful tool calls with UNSET status via endToolSpan', async () => {
     const { spanRecord, completedCalls } = await runSingleTool();
 
     expect(completedCalls[0].status).toBe('success');
-    expect(spanRecord.statusCalls).toEqual([{ code: SpanStatusCode.OK }]);
+    expect(spanRecord.statusCalls).toHaveLength(0);
     expect(spanRecord.spanAttributes).not.toHaveProperty('tool.failure_kind');
     expect(spanRecord.ended).toBe(true);
   });

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -346,6 +346,7 @@ function setToolSpanFailure(
 ): void {
   try {
     span.setAttribute(TOOL_FAILURE_KIND_ATTRIBUTE, failureKind);
+    span.setAttribute('error.type', failureKind);
     // Always write `success: false` so trace backends can filter tool
     // failures with the same query they use for llm_request spans —
     // mirrors the unconditional `success` attribute on llm_request.
@@ -1758,7 +1759,8 @@ export class CoreToolScheduler {
    * second call for the same callId is a no-op.
    *
    * No `metadata` parameter: every caller pre-sets span status via
-   * `setToolSpan{Failure,Cancelled,Ok}` before this call (#4321 review).
+   * `setToolSpan{Failure,Cancelled}` or the success path before this call
+   * (#4321 review).
    */
   private finalizeToolSpan(callId: string, force = false): void {
     // Terminal-state cleanup: drop any PreToolUse 'ask' bounce markers so
@@ -4181,10 +4183,10 @@ export class CoreToolScheduler {
     } catch (error) {
       this.bouncedAwaitingApproval.delete(callId);
       this.bouncedToolUseId.delete(callId);
-      // _executeToolCallBody pre-sets span status (OK / FAILURE /
-      // CANCELLED) only AFTER its main try/catch is entered. Throws
-      // from the prelude — for example getMessageBus — happen BEFORE
-      // the `scheduled → executing` transition, so the span would end
+      // _executeToolCallBody records the span outcome only AFTER its main
+      // try/catch is entered: ERROR or CANCELLED, while success remains
+      // UNSET. Throws from the prelude — for example getMessageBus — happen
+      // BEFORE the `scheduled → executing` transition, so the span would end
       // UNSET with no failure_kind AND the tool call would stay in
       // `scheduled` forever (checkAndNotifyCompletion never sees a
       // terminal state). Set failure status + error response here so
@@ -4226,8 +4228,8 @@ export class CoreToolScheduler {
       // a race where a STREAM_JSON client answers the confirmation
       // synchronously and flips status to 'scheduled' before this runs.
       if (!this.bouncedAwaitingApproval.has(callId)) {
-        // _executeToolCallBody pre-sets status (OK / FAILURE / CANCELLED)
-        // via setToolSpan*; finalize without metadata to preserve that.
+        // _executeToolCallBody records the outcome via setToolSpan*; finalize
+        // without metadata to preserve ERROR / UNSET status semantics.
         this.finalizeToolSpan(callId);
       }
       this.memoryMonitor?.scheduleCheck();
@@ -5310,7 +5312,6 @@ export class CoreToolScheduler {
           return;
         }
         this.setStatusInternal(callId, 'success', successResponse);
-        safeSetStatus(span, { code: SpanStatusCode.OK });
         // Mirrors setToolSpanFailure/setToolSpanCancelled — every tool span
         // ends with an explicit `success` attribute so backends can filter
         // failures the same way they filter llm_request failures.

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -42,6 +42,7 @@ const loggingSpanRecords = vi.hoisted(
      */
     endMetadata?: {
       success?: boolean;
+      cancelled?: boolean;
       inputTokens?: number;
       outputTokens?: number;
       cachedInputTokens?: number;
@@ -163,6 +164,7 @@ vi.mock('../../telemetry/index.js', () => {
         },
         metadata?: {
           success: boolean;
+          cancelled?: boolean;
           inputTokens?: number;
           outputTokens?: number;
           cachedInputTokens?: number;
@@ -187,15 +189,11 @@ vi.mock('../../telemetry/index.js', () => {
           record.endMetadata = metadata;
         }
         try {
-          if (metadata) {
-            if (metadata.success) {
-              span.setStatus({ code: 1 }); // OK
-            } else {
-              span.setStatus({
-                code: 2,
-                message: metadata.error ?? 'unknown error',
-              }); // ERROR
-            }
+          if (metadata && !metadata.success && !metadata.cancelled) {
+            span.setStatus({
+              code: 2,
+              message: metadata.error ?? 'unknown error',
+            }); // ERROR
           }
           span.end();
         } catch {
@@ -723,7 +721,7 @@ describe('LoggingContentGenerator', () => {
       model: 'test-model',
       prompt_id: 'prompt-span',
     });
-    expect(spanRecord.statuses).toEqual([{ code: SpanStatusCode.OK }]);
+    expect(spanRecord.statuses).toEqual([]);
     expect(spanRecord.ended).toBe(true);
     expect(
       genAiExchangeState.controllers.at(-1)?.finalize,
@@ -967,6 +965,13 @@ describe('LoggingContentGenerator', () => {
     ).rejects.toBeInstanceOf(APIUserAbortError);
 
     expect(logApiError).not.toHaveBeenCalled();
+    const spanRecord = getGenerateContentSpanRecord();
+    expect(spanRecord.endMetadata).toMatchObject({
+      success: false,
+      cancelled: true,
+      error: 'API call aborted',
+    });
+    expect(spanRecord.statuses).toHaveLength(0);
   });
 
   it('still emits an api_error event for a real failure that is not a cancel', async () => {
@@ -1116,6 +1121,13 @@ describe('LoggingContentGenerator', () => {
     ).rejects.toBeInstanceOf(APIUserAbortError);
 
     expect(logApiError).not.toHaveBeenCalled();
+    const spanRecord = getStreamSpanRecord();
+    expect(spanRecord.endMetadata).toMatchObject({
+      success: false,
+      cancelled: true,
+      error: 'API call aborted',
+    });
+    expect(spanRecord.statuses).toHaveLength(0);
   });
 
   it('does not emit an api_error event when the user cancels mid-stream', async () => {
@@ -1203,6 +1215,11 @@ describe('LoggingContentGenerator', () => {
     ).rejects.toMatchObject({ name: 'AbortError' });
 
     expect(logApiError).not.toHaveBeenCalled();
+    expect(getStreamSpanRecord().endMetadata).toMatchObject({
+      success: false,
+      cancelled: true,
+      error: 'API call aborted',
+    });
   });
 
   it('forwards usage attached to the final response after it was yielded', async () => {
@@ -1577,9 +1594,7 @@ describe('LoggingContentGenerator', () => {
     expect(response.responseId).toBe('resp-safe');
     expect(logApiResponse).toHaveBeenCalledTimes(1);
     expect(openaiLoggerInstance.logInteraction).toHaveBeenCalledTimes(1);
-    expect(getGenerateContentSpanRecord().statuses).toEqual([
-      { code: SpanStatusCode.OK },
-    ]);
+    expect(getGenerateContentSpanRecord().statuses).toEqual([]);
   });
 
   it('truncates long response text in API response telemetry', async () => {
@@ -1821,7 +1836,7 @@ describe('LoggingContentGenerator', () => {
     expect(consolidatedResponse.candidates?.[0]?.finishReason).toBe('STOP');
 
     const spanRecord = getStreamSpanRecord();
-    expect(spanRecord.statuses).toEqual([{ code: SpanStatusCode.OK }]);
+    expect(spanRecord.statuses).toEqual([]);
     expect(spanRecord.ended).toBe(true);
     expect(
       genAiExchangeState.controllers.at(-1)?.finalize,
@@ -1928,8 +1943,7 @@ describe('LoggingContentGenerator', () => {
     expect(getStreamSpanRecord().ended).toBe(true);
   });
 
-  it('preserves stream success when the OK status update fails', async () => {
-    loggingSpanNamesWithSetStatusFailure.add('qwen-code.llm_request');
+  it('leaves stream success status unset', async () => {
     const response = createResponse('resp-status', 'model-stream', [
       { text: 'ok' },
     ]);
@@ -2110,7 +2124,7 @@ describe('LoggingContentGenerator', () => {
     expect(spanRecord.ended).toBe(true);
   });
 
-  it('classifies an aborted partial stream and retains known response data', async () => {
+  it('keeps a real partial-stream failure as an error when it races an abort', async () => {
     const abortController = new AbortController();
     const response = createResponse(
       'resp-abort',
@@ -2157,11 +2171,90 @@ describe('LoggingContentGenerator', () => {
     ).toBeGreaterThanOrEqual(0);
     expect(spanRecord.endMetadata).toMatchObject({
       success: false,
-      error: 'API call aborted',
+      cancelled: false,
+      error: 'API call failed',
       responseModel: 'model-stream',
       inputTokens: 9,
       outputTokens: 2,
       finishReasons: ['STOP'],
+    });
+  });
+
+  it('records cancellation when a provider ends normally after swallowing an abort', async () => {
+    const abortController = new AbortController();
+    const response = createResponse('resp-cancelled', 'model-stream', [
+      { text: 'partial' },
+    ]);
+    const wrapped = createWrappedGenerator(
+      vi.fn(),
+      vi.fn().mockResolvedValue(
+        (async function* () {
+          yield response;
+          abortController.abort();
+        })(),
+      ),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'request-model',
+      authType: AuthType.USE_OPENAI,
+    });
+    const stream = await generator.generateContentStream(
+      {
+        model: 'request-model',
+        contents: 'Hello',
+        config: { abortSignal: abortController.signal },
+      } as never,
+      'prompt-swallowed-abort',
+    );
+
+    for await (const _ of stream) {
+      // Consume until the provider ends the stream normally.
+    }
+
+    expect(getStreamSpanRecord().endMetadata).toMatchObject({
+      success: false,
+      cancelled: true,
+      error: 'API call aborted',
+    });
+  });
+
+  it('does not let an abort after stream completion rewrite success', async () => {
+    const abortController = new AbortController();
+    const response = createResponse('resp-complete', 'model-stream', [
+      { text: 'done' },
+    ]);
+    vi.mocked(logApiResponse).mockImplementationOnce(() =>
+      abortController.abort(),
+    );
+    const wrapped = createWrappedGenerator(
+      vi.fn(),
+      vi.fn().mockResolvedValue(
+        (async function* () {
+          yield response;
+        })(),
+      ),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'request-model',
+      authType: AuthType.USE_OPENAI,
+    });
+    const stream = await generator.generateContentStream(
+      {
+        model: 'request-model',
+        contents: 'Hello',
+        config: { abortSignal: abortController.signal },
+      } as never,
+      'prompt-late-abort',
+    );
+
+    for await (const _ of stream) {
+      // Consume the successful stream.
+    }
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect(getStreamSpanRecord().endMetadata).toMatchObject({
+      success: true,
+      cancelled: false,
     });
   });
 
@@ -2541,7 +2634,7 @@ describe('LoggingContentGenerator', () => {
     expect(
       spanRecord.attributes['gen_ai.response.time_to_first_chunk'],
     ).toBeGreaterThanOrEqual(0);
-    expect(spanRecord.statuses).toEqual([{ code: SpanStatusCode.OK }]);
+    expect(spanRecord.statuses).toEqual([]);
     expect(spanRecord.ended).toBe(true);
     expect(
       genAiExchangeState.controllers.at(-1)?.finalize,

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -437,18 +437,19 @@ export class LoggingContentGenerator implements ContentGenerator {
       const observedFinishReasons = exchange.controller.finalize(false);
       // End the span BEFORE the (potentially-throwing) logging block, so a
       // logging-side rejection cannot prevent span finalization. Mirrors the
-      // streaming path order. Use abort-specific status message when the
-      // caller's abortSignal fired, so trace backends can distinguish user
-      // cancellations from real upstream failures.
-      const aborted = req.config?.abortSignal?.aborted ?? false;
+      // streaming path order. A caller-driven abort is a cancellation, while
+      // a real upstream failure that merely races an abort remains an error.
+      const cancelled =
+        (req.config?.abortSignal?.aborted ?? false) && isAbortError(error);
       endLLMRequestSpan(llmSpan, {
         success: false,
+        cancelled,
         durationMs,
-        error: aborted
+        error: cancelled
           ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
           : API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-        errorType: getErrorType(error),
-        errorStatusCode: getErrorStatus(error),
+        errorType: cancelled ? undefined : getErrorType(error),
+        errorStatusCode: cancelled ? undefined : getErrorStatus(error),
         finishReasons: observedFinishReasons,
         subagentName: subagentNameContext.getStore() || undefined,
         ...retrySnapshot,
@@ -565,15 +566,17 @@ export class LoggingContentGenerator implements ContentGenerator {
           req.config?.abortSignal,
         ),
       );
-      const aborted = req.config?.abortSignal?.aborted ?? false;
+      const cancelled =
+        (req.config?.abortSignal?.aborted ?? false) && isAbortError(error);
       endLLMRequestSpan(llmSpan, {
         success: false,
+        cancelled,
         durationMs,
-        error: aborted
+        error: cancelled
           ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
           : API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-        errorType: getErrorType(error),
-        errorStatusCode: getErrorStatus(error),
+        errorType: cancelled ? undefined : getErrorType(error),
+        errorStatusCode: cancelled ? undefined : getErrorStatus(error),
         finishReasons: observedFinishReasons,
         subagentName: subagentNameContext.getStore() || undefined,
         ...retrySnapshot,
@@ -680,6 +683,11 @@ export class LoggingContentGenerator implements ContentGenerator {
     };
     let errorOccurred = false;
     let streamCompleted = false;
+    let abortedBeforeStreamCompletion = abortSignal?.aborted ?? false;
+    const markStreamAborted = () => {
+      if (!streamCompleted) abortedBeforeStreamCompletion = true;
+    };
+    abortSignal?.addEventListener('abort', markStreamAborted, { once: true });
     const finishReasons = new Map<number, string>();
     let lastError: unknown;
     const subagentName = subagentNameContext.getStore();
@@ -879,6 +887,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       }
       throw error;
     } finally {
+      abortSignal?.removeEventListener('abort', markStreamAborted);
       if (spanEndTimeout !== undefined) {
         clearTimeout(spanEndTimeout);
       }
@@ -888,20 +897,23 @@ export class LoggingContentGenerator implements ContentGenerator {
       // own ended guard, but we want to avoid pretending the final token
       // counts were recorded — they weren't, the span is the timeout one.
       if (span && !spanEndedByTimeout) {
-        const aborted = abortSignal?.aborted ?? false;
+        const cancelled =
+          abortedBeforeStreamCompletion &&
+          (lastError === undefined || isAbortError(lastError));
         const observedFinishReasons = exchangeController?.finalize(
-          !errorOccurred && streamCompleted,
+          !errorOccurred && !cancelled && streamCompleted,
         );
         endLLMRequestSpan(span, {
-          success: !errorOccurred,
+          success: !errorOccurred && !cancelled,
+          cancelled,
           ...usageSpanMetadata(lastUsageMetadata),
           ttftMs,
           durationMs: Date.now() - startTime,
-          error: errorOccurred
-            ? aborted
-              ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
-              : API_CALL_FAILED_SPAN_STATUS_MESSAGE
-            : undefined,
+          error: cancelled
+            ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
+            : errorOccurred
+              ? API_CALL_FAILED_SPAN_STATUS_MESSAGE
+              : undefined,
           responseId: firstResponseId || undefined,
           responseModel: firstModelVersion || undefined,
           finishReasons:
@@ -913,8 +925,10 @@ export class LoggingContentGenerator implements ContentGenerator {
               : undefined),
           thoughtsTokenCount: lastUsageMetadata?.thoughtsTokenCount,
           subagentName: subagentName || undefined,
-          errorType: lastError ? getErrorType(lastError) : undefined,
-          errorStatusCode: lastError ? getErrorStatus(lastError) : undefined,
+          errorType:
+            lastError && !cancelled ? getErrorType(lastError) : undefined,
+          errorStatusCode:
+            lastError && !cancelled ? getErrorStatus(lastError) : undefined,
           ...retrySnapshot,
           config: this.config,
         });

--- a/packages/core/src/telemetry/detailed-span-attributes.test.ts
+++ b/packages/core/src/telemetry/detailed-span-attributes.test.ts
@@ -8,6 +8,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Attributes, Span, SpanContext } from '@opentelemetry/api';
 import type { Config } from '../config/config.js';
 import {
+  addAgentInputMessageAttributes,
+  addAgentOutputMessageAttributes,
   addModelOutputAttributes,
   addSystemPromptAttributes,
   addToolArgumentsAttributes,
@@ -16,6 +18,7 @@ import {
   addToolResultAttributes,
   addToolSchemaAttributes,
   addUserPromptAttributes,
+  AgentOutputMessageCapture,
   clearDetailedSpanState,
   truncateContent,
 } from './detailed-span-attributes.js';
@@ -151,6 +154,182 @@ describe('detailed span attributes', () => {
     expect(target.attrs['new_context']).toBe('[USER PROMPT]\nhello');
   });
 
+  it('writes one raw user message for an agent invocation', () => {
+    const target = span();
+    addAgentInputMessageAttributes(config(), target, 'raw @file prompt');
+    expect(JSON.parse(target.attrs['gen_ai.input.messages'] as string)).toEqual(
+      [
+        {
+          role: 'user',
+          parts: [{ type: 'text', content: 'raw @file prompt' }],
+        },
+      ],
+    );
+  });
+
+  it('writes one normalized final agent output message', () => {
+    const target = span();
+    addAgentOutputMessageAttributes(config(), target, '{"ok":true}', 'STOP');
+    expect(
+      JSON.parse(target.attrs['gen_ai.output.messages'] as string),
+    ).toEqual([
+      {
+        role: 'assistant',
+        parts: [{ type: 'text', content: '{"ok":true}' }],
+        finish_reason: 'stop',
+      },
+    ]);
+  });
+
+  it.each([
+    ['MAX_TOKENS', 'length'],
+    ['SAFETY', 'content_filter'],
+    ['RECITATION', 'content_filter'],
+    ['LANGUAGE', 'content_filter'],
+    ['BLOCKLIST', 'content_filter'],
+    ['PROHIBITED_CONTENT', 'content_filter'],
+    ['SPII', 'content_filter'],
+    ['IMAGE_SAFETY', 'content_filter'],
+    ['IMAGE_PROHIBITED_CONTENT', 'content_filter'],
+    ['IMAGE_RECITATION', 'content_filter'],
+    ['IMAGE_OTHER', 'content_filter'],
+    ['tool_calls', 'tool_call'],
+    ['function_call', 'tool_call'],
+    ['MALFORMED_FUNCTION_CALL', 'malformed_function_call'],
+  ])('normalizes agent finish reason %s to %s', (input, expected) => {
+    const target = span();
+    addAgentOutputMessageAttributes(config(), target, 'answer', input);
+    expect(
+      JSON.parse(target.attrs['gen_ai.output.messages'] as string),
+    ).toMatchObject([{ finish_reason: expected }]);
+  });
+
+  it('omits empty or incomplete agent messages', () => {
+    const target = span();
+    addAgentInputMessageAttributes(config(), target, ' \n\t ');
+    addAgentOutputMessageAttributes(config(), target, 'answer', '');
+    addAgentOutputMessageAttributes(
+      config(),
+      target,
+      'answer',
+      'FINISH_REASON_UNSPECIFIED',
+    );
+    addAgentOutputMessageAttributes(config(), target, ' \n\t ', 'STOP');
+    expect(target.attrs).toEqual({});
+  });
+
+  it('omits complete agent message JSON when it exceeds the limit', () => {
+    mockState.maxLength = 20;
+    const target = span();
+    addAgentInputMessageAttributes(config(), target, 'raw prompt');
+    addAgentOutputMessageAttributes(config(), target, 'answer', 'stop');
+    expect(target.attrs).toEqual({});
+  });
+
+  it('captures only a completed response without pending tools', () => {
+    const target = span();
+    const capture = new AgentOutputMessageCapture(config());
+    capture.beginResponse();
+    capture.appendText('final ');
+    capture.appendText('answer');
+    capture.observeFinishReason('STOP');
+    capture.commitResponse(false);
+    capture.writeToSpan(target);
+    expect(
+      JSON.parse(target.attrs['gen_ai.output.messages'] as string),
+    ).toEqual([
+      {
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'final answer' }],
+        finish_reason: 'stop',
+      },
+    ]);
+  });
+
+  it('resets failed attempts and preserves continuation fragments', () => {
+    const target = span();
+    const capture = new AgentOutputMessageCapture(config());
+    capture.beginResponse();
+    capture.appendText('discarded');
+    capture.restartAttempt(false);
+    capture.appendText('kept ');
+    capture.restartAttempt(true);
+    capture.appendText('continuation');
+    capture.observeFinishReason('MAX_TOKENS');
+    capture.commitResponse(false);
+    capture.writeToSpan(target);
+    expect(
+      JSON.parse(target.attrs['gen_ai.output.messages'] as string),
+    ).toMatchObject([
+      {
+        parts: [{ content: 'kept continuation' }],
+        finish_reason: 'length',
+      },
+    ]);
+  });
+
+  it('invalidates stale, tool, and incomplete captures', () => {
+    const target = span();
+    const capture = new AgentOutputMessageCapture(config());
+    capture.beginResponse();
+    capture.appendText('old');
+    capture.observeFinishReason('STOP');
+    capture.commitResponse(false);
+    capture.beginResponse();
+    capture.appendText('new');
+    capture.observeFinishReason('STOP');
+    capture.commitResponse(true);
+    capture.writeToSpan(target);
+    expect(target.attrs).toEqual({});
+  });
+
+  it('bounds oversized output capture in memory', () => {
+    mockState.maxLength = 10;
+    const target = span();
+    const capture = new AgentOutputMessageCapture(config());
+    capture.beginResponse();
+    capture.appendText('01234567890');
+    capture.observeFinishReason('STOP');
+    capture.commitResponse(false);
+    capture.writeToSpan(target);
+    expect(target.attrs).toEqual({});
+  });
+
+  it('omits agent messages when sensitive telemetry is disabled or inactive', () => {
+    const target = span();
+    mockState.sensitiveEnabled = false;
+    addAgentInputMessageAttributes(config(), target, 'disabled input');
+    addAgentOutputMessageAttributes(
+      config(),
+      target,
+      'disabled output',
+      'STOP',
+    );
+    mockState.sensitiveEnabled = true;
+    mockState.sdkInitialized = false;
+    addAgentInputMessageAttributes(config(), target, 'inactive input');
+    addAgentOutputMessageAttributes(
+      config(),
+      target,
+      'inactive output',
+      'STOP',
+    );
+    expect(target.attrs).toEqual({});
+  });
+
+  it('does not let agent-message Span API failures affect the caller', () => {
+    const target = span();
+    target.setAttribute = () => {
+      throw new Error('cannot set');
+    };
+    expect(() =>
+      addAgentInputMessageAttributes(config(), target, 'input'),
+    ).not.toThrow();
+    expect(() =>
+      addAgentOutputMessageAttributes(config(), target, 'output', 'STOP'),
+    ).not.toThrow();
+  });
+
   it('keeps interaction truncation metadata', () => {
     mockState.maxLength = 20;
     const target = span();
@@ -208,6 +387,21 @@ describe('detailed span attributes', () => {
         'tool_result',
       ]),
     );
+  });
+
+  it('retains an explicit finish reason across later incomplete chunks', () => {
+    const target = span();
+    const capture = new AgentOutputMessageCapture(config());
+    capture.beginResponse();
+    capture.appendText('answer');
+    capture.observeFinishReason('STOP');
+    capture.observeFinishReason(undefined);
+    capture.observeFinishReason('FINISH_REASON_UNSPECIFIED');
+    capture.commitResponse(false);
+    capture.writeToSpan(target);
+    expect(
+      JSON.parse(target.attrs['gen_ai.output.messages'] as string),
+    ).toMatchObject([{ finish_reason: 'stop' }]);
   });
 
   it('does not synthesize output without a finish reason', () => {

--- a/packages/core/src/telemetry/detailed-span-attributes.ts
+++ b/packages/core/src/telemetry/detailed-span-attributes.ts
@@ -90,6 +90,162 @@ function truncatePrefixedContent(
 
 // --- Interaction Span: User Prompt ---
 
+export function addAgentInputMessageAttributes(
+  config: Config,
+  span: Span,
+  promptText: string,
+): void {
+  if (
+    !areSensitiveSpanAttributesEnabled(config) ||
+    promptText.trim().length === 0
+  ) {
+    return;
+  }
+  writeJsonAttribute(config, span, 'gen_ai.input.messages', [
+    {
+      role: 'user',
+      parts: [{ type: 'text', content: promptText }],
+    },
+  ]);
+}
+
+export function addAgentOutputMessageAttributes(
+  config: Config,
+  span: Span,
+  responseText: string,
+  finishReason: string,
+): void {
+  if (
+    !areSensitiveSpanAttributesEnabled(config) ||
+    responseText.trim().length === 0
+  ) {
+    return;
+  }
+  const reason = normalizeAgentFinishReason(finishReason);
+  if (!reason) return;
+  writeJsonAttribute(config, span, 'gen_ai.output.messages', [
+    {
+      role: 'assistant',
+      parts: [{ type: 'text', content: responseText }],
+      finish_reason: reason,
+    },
+  ]);
+}
+
+function normalizeAgentFinishReason(
+  finishReason: string | undefined,
+): string | undefined {
+  const reason = finishReason?.trim().toLowerCase();
+  if (!reason || reason === 'finish_reason_unspecified') return undefined;
+  if (reason === 'stop') return 'stop';
+  if (reason === 'max_tokens') return 'length';
+  if (
+    reason === 'tool_calls' ||
+    reason === 'function_call' ||
+    reason === 'tool_call'
+  ) {
+    return 'tool_call';
+  }
+  if (
+    reason === 'safety' ||
+    reason === 'recitation' ||
+    reason === 'language' ||
+    reason === 'blocklist' ||
+    reason === 'prohibited_content' ||
+    reason === 'spii' ||
+    reason === 'image_safety' ||
+    reason === 'image_prohibited_content' ||
+    reason === 'image_recitation' ||
+    reason === 'image_other'
+  ) {
+    return 'content_filter';
+  }
+  return reason;
+}
+
+export class AgentOutputMessageCapture {
+  private readonly enabled: boolean;
+  private readonly maxLength: number;
+  private responseText = '';
+  private finishReason: string | undefined;
+  private overflow = false;
+  private committed: { responseText: string; finishReason: string } | undefined;
+
+  constructor(private readonly config: Config) {
+    this.enabled = areSensitiveSpanAttributesEnabled(config);
+    this.maxLength = this.enabled
+      ? config.getTelemetrySensitiveSpanAttributeMaxLength()
+      : 0;
+  }
+
+  beginResponse(): void {
+    if (!this.enabled) return;
+    this.clearResponse();
+    this.committed = undefined;
+  }
+
+  appendText(text: string): void {
+    if (!this.enabled || !text || this.overflow) return;
+    const remaining = this.maxLength - this.responseText.length;
+    if (text.length > remaining) {
+      this.responseText = '';
+      this.overflow = true;
+      this.committed = undefined;
+      return;
+    }
+    this.responseText += text;
+  }
+
+  observeFinishReason(finishReason: string | undefined): void {
+    if (!this.enabled) return;
+    const normalized = normalizeAgentFinishReason(finishReason);
+    if (normalized) this.finishReason = normalized;
+  }
+
+  restartAttempt(preserveText: boolean): void {
+    if (!this.enabled) return;
+    if (!preserveText) {
+      this.clearResponse();
+    } else {
+      this.finishReason = undefined;
+    }
+    this.committed = undefined;
+  }
+
+  commitResponse(hasToolCalls: boolean): void {
+    if (
+      !this.enabled ||
+      hasToolCalls ||
+      this.overflow ||
+      this.responseText.trim().length === 0 ||
+      !this.finishReason
+    ) {
+      this.committed = undefined;
+      return;
+    }
+    this.committed = {
+      responseText: this.responseText,
+      finishReason: this.finishReason,
+    };
+  }
+
+  writeToSpan(span: Span | undefined): void {
+    if (!span || !this.committed) return;
+    addAgentOutputMessageAttributes(
+      this.config,
+      span,
+      this.committed.responseText,
+      this.committed.finishReason,
+    );
+  }
+
+  private clearResponse(): void {
+    this.responseText = '';
+    this.finishReason = undefined;
+    this.overflow = false;
+  }
+}
+
 export function addUserPromptAttributes(
   config: Config,
   span: Span,
@@ -171,13 +327,7 @@ export function addModelOutputAttributes(
       ? originalLengthOrFinishReason
       : finishReason;
   if (!reason) return;
-  writeJsonAttribute(config, span, 'gen_ai.output.messages', [
-    {
-      role: 'assistant',
-      parts: [{ type: 'text', content: responseText }],
-      finish_reason: reason,
-    },
-  ]);
+  addAgentOutputMessageAttributes(config, span, responseText, reason);
 }
 
 /**

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -240,6 +240,9 @@ export {
   registerAcpEventLoopLagGauge,
 } from './event-loop-lag-metrics.js';
 export {
+  addAgentInputMessageAttributes,
+  addAgentOutputMessageAttributes,
+  AgentOutputMessageCapture,
   addUserPromptAttributes,
   addSystemPromptAttributes,
   addToolSchemaAttributes,

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -175,6 +175,7 @@ export {
   endSubagentSpan,
   runInSubagentSpanContext,
   getActiveInteractionSpan,
+  recordInteractionActivity,
   truncateSpanError,
 } from './session-tracing.js';
 export type {

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -30,6 +30,8 @@ import {
   setDebugLogSession,
 } from '../utils/debugLogger.js';
 
+const mockEndAllInteractionSpans = vi.hoisted(() => vi.fn());
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -62,6 +64,9 @@ vi.mock('./session-events.js', () => ({
 }));
 vi.mock('./session-context.js');
 vi.mock('./trace-context.js');
+vi.mock('./session-tracing.js', () => ({
+  endAllInteractionSpans: mockEndAllInteractionSpans,
+}));
 vi.mock('./tracer.js', () => ({
   createSessionRootContext: vi.fn((id: string) => ({ __sessionId: id })),
 }));
@@ -411,7 +416,13 @@ describe('Telemetry SDK', () => {
 
       await shutdownTelemetry();
 
+      expect(mockEndAllInteractionSpans).toHaveBeenCalledWith('cancelled');
       expect(emitSessionEnd).toHaveBeenCalledWith('active-session');
+      expect(
+        mockEndAllInteractionSpans.mock.invocationCallOrder[0],
+      ).toBeLessThan(
+        vi.mocked(NodeSDK.prototype.shutdown).mock.invocationCallOrder[0],
+      );
       expect(
         vi.mocked(emitSessionEnd).mock.invocationCallOrder[0],
       ).toBeLessThan(

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -26,7 +26,7 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { createSessionRootContext } from './tracer.js';
 import { getCurrentSessionId, setSessionContext } from './session-context.js';
 import { setShellTracePropagation } from './trace-context.js';
-import { endInteractionSpan } from './session-tracing.js';
+import { endAllInteractionSpans } from './session-tracing.js';
 import { emitSessionEnd, emitSessionStart } from './session-events.js';
 
 function createTelemetryDiagLogger(): DiagLogger {
@@ -178,7 +178,7 @@ export function shutdownTelemetry(): Promise<void> {
       telemetryShutdownPromise = undefined;
       return;
     }
-    endInteractionSpan('cancelled');
+    endAllInteractionSpans('cancelled');
     const currentSessionId = getCurrentSessionId();
     if (currentSessionId) {
       emitSessionEnd(currentSessionId);

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -212,6 +212,7 @@ import type { Config } from '../config/config.js';
 import {
   startInteractionSpan,
   endInteractionSpan,
+  endAllInteractionSpans,
   withInteractionSpan,
   startLLMRequestSpan,
   startLLMRequestSpanWithContext,
@@ -245,12 +246,14 @@ function createMockConfig(
     sessionId: string;
     approvalMode: string;
     userId: string;
+    jsonSchema: Record<string, unknown>;
   }> = {},
 ): Config {
   return {
     getSessionId: () => overrides.sessionId ?? 'test-session-id',
     getApprovalMode: () => overrides.approvalMode ?? 'suggest',
     getTelemetryUserId: () => overrides.userId,
+    getJsonSchema: () => overrides.jsonSchema,
   } as unknown as Config;
 }
 
@@ -272,7 +275,7 @@ describe('session-tracing', () => {
   });
 
   describe('interaction spans', () => {
-    it('starts and ends an interaction span with ok status', () => {
+    it('starts and ends a main agent interaction with UNSET status', () => {
       const config = createMockConfig({ userId: 'user-1' });
       startInteractionSpan(config, {
         promptId: 'prompt-1',
@@ -286,12 +289,23 @@ describe('session-tracing', () => {
       expect(mockSpans[0]!.attributes['gen_ai.user.id']).toBe('user-1');
       expect(mockSpans[0]!.attributes['qwen-code.prompt_id']).toBe('prompt-1');
       expect(mockSpans[0]!.attributes['qwen-code.model']).toBe('test-model');
+      expect(mockSpans[0]!.attributes).toMatchObject({
+        'gen_ai.operation.name': 'invoke_agent',
+        'gen_ai.agent.name': 'qwen-code',
+        'gen_ai.conversation.id': 'test-session-id',
+      });
+      expect(mockSpans[0]!.attributes['gen_ai.request.model']).toBeUndefined();
+      expect(mockSpans[0]!.attributes['gen_ai.provider.name']).toBeUndefined();
+      expect(mockSpans[0]!.attributes['gen_ai.agent.id']).toBeUndefined();
+      expect(mockSpans[0]!.attributes['gen_ai.agent.version']).toBeUndefined();
+      expect(
+        mockSpans[0]!.attributes['gen_ai.agent.description'],
+      ).toBeUndefined();
 
       endInteractionSpan('ok');
 
       expect(mockSpans[0]!.ended).toBe(true);
-      expect(mockSpans[0]!.statuses).toHaveLength(1);
-      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
     });
 
     it('defaults to ROOT_CONTEXT when no parentContext is provided', async () => {
@@ -310,6 +324,7 @@ describe('session-tracing', () => {
       const config = createMockConfig({
         sessionId: 'scoped-session',
         userId: 'scoped-user',
+        jsonSchema: { type: 'object' },
       });
       const parentContext = ROOT_CONTEXT.setValue(
         createContextKey('daemon-parent'),
@@ -335,8 +350,14 @@ describe('session-tracing', () => {
       expect(mockSpans[0]!.attributes['qwen-code.message_type']).toBe(
         'acp_prompt',
       );
+      expect(mockSpans[0]!.attributes).toMatchObject({
+        'gen_ai.operation.name': 'invoke_agent',
+        'gen_ai.agent.name': 'qwen-code',
+        'gen_ai.conversation.id': 'scoped-session',
+        'gen_ai.output.type': 'json',
+      });
       expect(mockSpans[0]!.ended).toBe(true);
-      expect(mockSpans[0]!.statuses.at(-1)?.code).toBe(SpanStatusCode.OK);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
       expect(getSessionIdFromContext(contextWithSpy.mock.calls[0]![0])).toBe(
         'scoped-session',
       );
@@ -354,6 +375,7 @@ describe('session-tracing', () => {
       const span = mockSpans.find((s) => s.name === 'qwen-code.interaction');
       expect(span?.attributes['qwen-code.turn_status']).toBe('error');
       expect(span?.statuses.at(-1)?.code).toBe(SpanStatusCode.ERROR);
+      expect(span?.attributes['error.type']).toBe('interaction_error');
     });
 
     it('keeps a thrown error message instead of the generic error-status message', async () => {
@@ -371,6 +393,7 @@ describe('session-tracing', () => {
       const span = mockSpans.find((s) => s.name === 'qwen-code.interaction');
       expect(span?.statuses.at(-1)?.code).toBe(SpanStatusCode.ERROR);
       expect(span?.statuses.at(-1)?.message).toBe('boom from fn');
+      expect(span?.attributes['error.type']).toBe('Error');
     });
 
     it('ends interaction span with error status', () => {
@@ -381,13 +404,17 @@ describe('session-tracing', () => {
         messageType: 'userQuery',
       });
 
-      endInteractionSpan('error', { errorMessage: 'something went wrong' });
+      endInteractionSpan('error', {
+        errorMessage: 'something went wrong',
+        errorType: 'api_error',
+      });
 
       expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
       expect(mockSpans[0]!.statuses[0]!.message).toBe('something went wrong');
+      expect(mockSpans[0]!.attributes['error.type']).toBe('api_error');
     });
 
-    it('ends interaction span with cancelled status as OK', () => {
+    it('ends a cancelled interaction with UNSET status', () => {
       const config = createMockConfig();
       startInteractionSpan(config, {
         promptId: 'prompt-3',
@@ -397,7 +424,7 @@ describe('session-tracing', () => {
 
       endInteractionSpan('cancelled');
 
-      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
     });
 
     it('is idempotent — ending twice does not double-end', () => {
@@ -411,7 +438,7 @@ describe('session-tracing', () => {
       endInteractionSpan('ok');
       endInteractionSpan('error');
 
-      expect(mockSpans[0]!.statuses).toHaveLength(1);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
     });
 
     it('no-ops when SDK is not initialized', () => {
@@ -460,6 +487,126 @@ describe('session-tracing', () => {
       const setAttrs = mockSpans[0]!.setAttributesCalls[0]!;
       expect(setAttrs).toHaveProperty('interaction.duration_ms');
       expect(setAttrs['qwen-code.turn_status']).toBe('ok');
+    });
+
+    it('sets json output type only when a JSON schema is configured', () => {
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'plain-json-output',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      expect(mockSpans[0]!.attributes['gen_ai.output.type']).toBeUndefined();
+      endInteractionSpan('ok', { promptId: 'plain-json-output' });
+
+      startInteractionSpan(
+        createMockConfig({ jsonSchema: { type: 'object' } }),
+        {
+          promptId: 'schema-output',
+          model: 'm',
+          messageType: 'userQuery',
+        },
+      );
+      expect(mockSpans[1]!.attributes['gen_ai.output.type']).toBe('json');
+    });
+
+    it('isolates concurrent prompts and ends only the requested interaction', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-a',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      startInteractionSpan(config, {
+        promptId: 'prompt-b',
+        model: 'm',
+        messageType: 'notification',
+      });
+
+      expect(getActiveInteractionSpan('prompt-a')).toBe(mockSpans[0]);
+      expect(getActiveInteractionSpan('prompt-b')).toBe(mockSpans[1]);
+      endInteractionSpan('ok', { promptId: 'prompt-a' });
+
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[1]!.ended).toBe(false);
+      expect(getActiveInteractionSpan('prompt-a')).toBeUndefined();
+      expect(getActiveInteractionSpan('prompt-b')).toBe(mockSpans[1]);
+    });
+
+    it('keeps a mismatched prompt standalone inside an ACP interaction context', async () => {
+      await withInteractionSpan(
+        createMockConfig(),
+        {
+          promptId: 'owner-prompt',
+          model: 'm',
+          messageType: 'acp_prompt',
+        },
+        async () => {
+          mockState.activeOtelSpan = mockSpans[0];
+          const llm = startLLMRequestSpan('m', 'wrong-prompt');
+          const tool = startToolSpan(
+            'ReadFile',
+            undefined,
+            undefined,
+            'wrong-prompt',
+          );
+
+          const llmRecord = mockSpans.find(
+            (span) => span.name === 'qwen-code.llm_request',
+          );
+          const toolRecord = mockSpans.find(
+            (span) => span.name === 'qwen-code.tool',
+          );
+          expect(llmRecord?.parentContext).toBe(ROOT_CONTEXT);
+          expect(llmRecord?.attributes['llm_request.context']).toBe(
+            'standalone',
+          );
+          expect(toolRecord?.parentContext).toBe(ROOT_CONTEXT);
+          expect(toolRecord?.attributes['gen_ai.agent.name']).toBeUndefined();
+
+          endLLMRequestSpan(llm, { success: true });
+          endToolSpan(tool, { success: true });
+        },
+      );
+    });
+
+    it('does not silently overwrite an unfinished interaction with the same prompt id', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'same-prompt',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      startInteractionSpan(config, {
+        promptId: 'same-prompt',
+        model: 'm',
+        messageType: 'retry',
+      });
+
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.attributes['qwen-code.turn_status']).toBe(
+        'cancelled',
+      );
+      expect(getActiveInteractionSpan('same-prompt')).toBe(mockSpans[1]);
+    });
+
+    it('ends every registered interaction during shutdown', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'p1',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      startInteractionSpan(config, {
+        promptId: 'p2',
+        model: 'm',
+        messageType: 'notification',
+      });
+
+      endAllInteractionSpans();
+
+      expect(mockSpans.every((span) => span.ended)).toBe(true);
+      expect(getActiveInteractionSpan('p1')).toBeUndefined();
+      expect(getActiveInteractionSpan('p2')).toBeUndefined();
     });
   });
 
@@ -531,7 +678,7 @@ describe('session-tracing', () => {
       });
 
       expect(mockSpans[0]!.ended).toBe(true);
-      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
     });
 
     it('records error status on failure', () => {
@@ -544,6 +691,22 @@ describe('session-tracing', () => {
 
       expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
       expect(mockSpans[0]!.statuses[0]!.message).toBe('rate limited');
+    });
+
+    it('keeps a cancelled LLM request UNSET without error.type', () => {
+      const span = startLLMRequestSpan('test-model', 'prompt-cancelled');
+
+      endLLMRequestSpan(span, {
+        success: false,
+        cancelled: true,
+        error: 'API call aborted',
+        errorType: 'AbortError',
+      });
+
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
+      expect(mockSpans[0]!.attributes['success']).toBe(false);
+      expect(mockSpans[0]!.attributes['error']).toBe('API call aborted');
+      expect(mockSpans[0]!.attributes['error.type']).toBeUndefined();
     });
 
     it('parents under interaction span when one is active', () => {
@@ -638,6 +801,7 @@ describe('session-tracing', () => {
         );
         expect(record?.attributes['session.id']).toBe('parent-session');
         expect(record?.attributes['gen_ai.user.id']).toBe('parent-user');
+        expect(trace.getSpan(record?.parentContext as never)).toBe(toolSpan);
         expect(getSessionIdFromContext(context)).toBe('parent-session');
         endLLMRequestSpan(span, { success: true });
       });
@@ -724,13 +888,13 @@ describe('session-tracing', () => {
       expect(llmSpan?.attributes['llm_request.context']).toBe('standalone');
     });
 
-    it('treats missing metadata as OK status', () => {
+    it('treats missing metadata as UNSET status', () => {
       const span = startLLMRequestSpan('test-model', 'prompt-no-meta');
 
       endLLMRequestSpan(span);
 
       expect(mockSpans[0]!.ended).toBe(true);
-      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
     });
 
     it('returns NOOP span when SDK is not initialized', () => {
@@ -1143,6 +1307,14 @@ describe('session-tracing', () => {
       expect(attrs['error_status_code']).toBe(429);
     });
 
+    it('endLLMRequestSpan supplies a default error.type for unclassified failures', () => {
+      const span = startLLMRequestSpan('m', 'p');
+      endLLMRequestSpan(span, { success: false, error: 'failed' });
+
+      expect(mockSpans[0]!.attributes['error.type']).toBe('llm_error');
+      expect(mockSpans[0]!.statuses[0]?.code).toBe(SpanStatusCode.ERROR);
+    });
+
     it('endLLMRequestSpan omits error_type/error_status_code on success spans', () => {
       const span = startLLMRequestSpan('m', 'p');
       endLLMRequestSpan(span, { success: true });
@@ -1320,7 +1492,59 @@ describe('session-tracing', () => {
       endToolSpan(span, { success: true });
 
       expect(mockSpans[0]!.ended).toBe(true);
-      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
+    });
+
+    it('inherits the main agent name from its exact prompt parent', () => {
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'main-prompt',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      const span = startToolSpan(
+        'ReadFile',
+        undefined,
+        undefined,
+        'main-prompt',
+      );
+      const tool = mockSpans.find((record) => record.name === 'qwen-code.tool');
+
+      expect(tool?.attributes['gen_ai.agent.name']).toBe('qwen-code');
+      endToolSpan(span, { success: true });
+    });
+
+    it('inherits a subagent name from the actual subagent parent', async () => {
+      const subagent = startSubagentSpan({
+        agentId: 'explore-1',
+        subagentName: 'Explore',
+        invocationKind: 'foreground',
+        isBuiltIn: true,
+        depth: 0,
+        sessionId: 'session',
+      });
+
+      await runInSubagentSpanContext(subagent, async () => {
+        const span = startToolSpan('ReadFile', undefined, undefined, 'p');
+        const tool = mockSpans.find(
+          (record) => record.name === 'qwen-code.tool',
+        );
+        expect(tool?.attributes['gen_ai.agent.name']).toBe('Explore');
+        endToolSpan(span, { success: true });
+      });
+      endSubagentSpan(subagent, { status: 'completed' });
+    });
+
+    it('omits the agent name for a standalone tool', () => {
+      const span = startToolSpan(
+        'ReadFile',
+        { 'gen_ai.agent.name': 'spoofed' },
+        undefined,
+        'unknown',
+      );
+
+      expect(mockSpans[0]!.attributes['gen_ai.agent.name']).toBeUndefined();
+      endToolSpan(span, { success: true });
     });
 
     it('records and surrogate-safely bounds static tool descriptions', () => {
@@ -1348,6 +1572,7 @@ describe('session-tracing', () => {
 
       expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
       expect(mockSpans[0]!.statuses[0]!.message).toBe('command failed');
+      expect(mockSpans[0]!.attributes['error.type']).toBe('tool_error');
     });
 
     it('records cancellation without marking the tool span as an error', () => {
@@ -1358,7 +1583,7 @@ describe('session-tracing', () => {
         success: false,
         'tool.failure_kind': 'cancelled',
       });
-      expect(mockSpans[0]!.statuses).toEqual([{ code: SpanStatusCode.UNSET }]);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
     });
 
     it('does not set status when no metadata is passed', () => {
@@ -1407,7 +1632,7 @@ describe('session-tracing', () => {
         (s) => s.attributes['gen_ai.tool.name'] === 'Bash',
       );
 
-      expect(bashSpan?.statuses[0]?.code).toBe(SpanStatusCode.OK);
+      expect(bashSpan?.statuses).toHaveLength(0);
       expect(readSpan?.statuses[0]?.code).toBe(SpanStatusCode.ERROR);
       expect(readSpan?.statuses[0]?.message).toBe('timeout');
     });
@@ -1426,6 +1651,9 @@ describe('session-tracing', () => {
           (candidate) => candidate.attributes['gen_ai.tool.name'] === 'nested',
         );
         expect(nestedRecord?.attributes['session.id']).toBe('tool-session');
+        expect(trace.getSpan(nestedRecord?.parentContext as never)).toBe(
+          outerTool,
+        );
         endToolSpan(nestedTool, { success: true });
       });
 
@@ -1816,6 +2044,7 @@ describe('session-tracing', () => {
         success: false,
         error: 'Tool execution cancelled by user',
         cancelled: true,
+        errorType: 'AbortError',
       });
 
       const record = mockSpans.find(
@@ -1832,6 +2061,8 @@ describe('session-tracing', () => {
       expect(record?.attributes['error']).toBe(
         'Tool execution cancelled by user',
       );
+      expect(record?.attributes['error_type']).toBe('AbortError');
+      expect(record?.attributes['error.type']).toBeUndefined();
     });
 
     it('cancelled: false (default) still maps success: false to ERROR status', () => {
@@ -1847,6 +2078,7 @@ describe('session-tracing', () => {
       expect(record?.statuses).toHaveLength(1);
       expect(record?.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
       expect(record?.statuses[0]!.message).toBe('Tool execution failed');
+      expect(record?.attributes['error.type']).toBe('tool_execution_error');
     });
 
     it('records canonical execution outcome and structured error type', () => {
@@ -2108,6 +2340,7 @@ describe('session-tracing', () => {
       const hookRecord = mockSpans.find((s) => s.name === 'qwen-code.hook');
       expect(hookRecord?.statuses[0]?.code).toBe(SpanStatusCode.ERROR);
       expect(hookRecord?.statuses[0]?.message).toBe('hook crashed');
+      expect(hookRecord?.attributes['error.type']).toBe('hook_error');
       expect(hookRecord?.attributes['is_interrupt']).toBe(true);
 
       endToolSpan(toolSpan, { success: false, error: 'cancelled' });
@@ -2202,21 +2435,19 @@ describe('session-tracing', () => {
       expect(getActiveInteractionSpan()).toBeUndefined();
     });
 
-    it('falls back to lastInteractionCtx outside the AsyncLocalStorage context', async () => {
+    it('resolves an interaction exactly by prompt id', async () => {
       const config = createMockConfig();
       startInteractionSpan(config, {
         promptId: 'p-fallback',
         model: 'm',
         messageType: 'userQuery',
       });
-      // Yield via setImmediate to schedule the continuation on a separate
-      // async resource — best-effort attempt to leave the ALS scope so
-      // getActiveInteractionSpan must rely on lastInteractionCtx.
       await new Promise<void>((resolve) => setImmediate(resolve));
 
-      const span = getActiveInteractionSpan();
+      const span = getActiveInteractionSpan('p-fallback');
       expect(span).toBeDefined();
       expect(span).toBe(mockSpans[0]);
+      expect(getActiveInteractionSpan('another-prompt')).toBeUndefined();
     });
 
     it('returns undefined when no interaction has ever started', () => {
@@ -2329,6 +2560,19 @@ describe('session-tracing', () => {
   });
 
   describe('TTL safety net (#4321 review)', () => {
+    it('removes a stale interaction from the prompt registry', () => {
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'stale-interaction',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      runTTLSweepForTesting(Date.now() + 31 * 60 * 1000);
+
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.attributes['qwen-code.span.ttl_expired']).toBe(true);
+      expect(getActiveInteractionSpan('stale-interaction')).toBeUndefined();
+    });
     it('marks stale spans with ttl_expired + duration_ms before ending them', () => {
       const toolSpan = startToolSpan('staleTool');
       const record = mockSpans.find((s) => s.name === 'qwen-code.tool')!;
@@ -2391,6 +2635,14 @@ describe('session-tracing', () => {
     it('returns short strings unchanged', () => {
       expect(truncateSpanError('short message')).toBe('short message');
       expect(truncateSpanError('')).toBe('');
+    });
+
+    it('redacts credentials and strips control sequences', () => {
+      expect(
+        truncateSpanError(
+          '\u001b[31mfailed via https://user:secret@example.com\u0007',
+        ),
+      ).toBe('failed via https://***REDACTED***@example.com');
     });
 
     it('truncates strings over 1024 chars and appends a sentinel suffix', () => {
@@ -2653,7 +2905,7 @@ describe('session-tracing', () => {
       endSubagentSpan(span, { status: 'completed' });
     });
 
-    it('endSubagentSpan: completed → SpanStatus OK + duration recorded', () => {
+    it('endSubagentSpan: completed → SpanStatus UNSET + duration recorded', () => {
       const span = startSubagentSpan({
         ...baseOpts,
         invocationKind: 'foreground',
@@ -2662,7 +2914,7 @@ describe('session-tracing', () => {
 
       const record = mockSpans.find((s) => s.name === 'qwen-code.subagent')!;
       expect(record.ended).toBe(true);
-      expect(record.statuses).toContainEqual({ code: SpanStatusCode.OK });
+      expect(record.statuses).toHaveLength(0);
       expect(record.attributes['qwen-code.subagent.status']).toBe('completed');
       expect(
         record.attributes['qwen-code.subagent.duration_ms'] as number,
@@ -2704,7 +2956,7 @@ describe('session-tracing', () => {
       expect(record.statuses[0].code).toBe(SpanStatusCode.ERROR);
       expect(record.statuses[0].message).toBe('subagent failed');
       expect(record.attributes['exception.message']).toBeUndefined();
-      expect(record.attributes['error.type']).toBeUndefined();
+      expect(record.attributes['error.type']).toBe('subagent_error');
     });
 
     it.each(['cancelled', 'aborted'] as const)(
@@ -2714,11 +2966,17 @@ describe('session-tracing', () => {
           ...baseOpts,
           invocationKind: 'foreground',
         });
-        endSubagentSpan(span, { status });
+        endSubagentSpan(span, {
+          status,
+          error: 'abort detail',
+          errorType: 'AbortError',
+        });
         const record = mockSpans.find((s) => s.name === 'qwen-code.subagent')!;
         // No SpanStatus calls means UNSET stays UNSET.
         expect(record.statuses).toHaveLength(0);
         expect(record.attributes['qwen-code.subagent.status']).toBe(status);
+        expect(record.attributes['exception.message']).toBeUndefined();
+        expect(record.attributes['error.type']).toBeUndefined();
       },
     );
 
@@ -2731,8 +2989,8 @@ describe('session-tracing', () => {
       endSubagentSpan(span, { status: 'failed', error: 'should not record' });
 
       const record = mockSpans.find((s) => s.name === 'qwen-code.subagent')!;
-      // Only the first end ran — status is still OK, not ERROR.
-      expect(record.statuses).toEqual([{ code: SpanStatusCode.OK }]);
+      // Only the first end ran — status is still UNSET, not ERROR.
+      expect(record.statuses).toHaveLength(0);
       expect(record.attributes['qwen-code.subagent.status']).toBe('completed');
     });
 

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -230,6 +230,7 @@ import {
   endSubagentSpan,
   runInSubagentSpanContext,
   getActiveInteractionSpan,
+  recordInteractionActivity,
   clearSessionTracingForTesting,
   runTTLSweepForTesting,
   truncateSpanError,
@@ -1909,6 +1910,39 @@ describe('session-tracing', () => {
       endLLMRequestSpan(llmSpan, { success: true });
     });
 
+    it('retains identity for one TTL after a long interaction ends', () => {
+      const startedAt = Date.now();
+      const now = vi.spyOn(Date, 'now').mockReturnValue(startedAt);
+      startInteractionSpan(createMockConfig({ userId: 'long-lived-user' }), {
+        promptId: 'long-lived-prompt',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      const owner = getActiveInteractionSpan('long-lived-prompt')!;
+
+      now.mockReturnValue(startedAt + 29 * 60 * 1000);
+      expect(recordInteractionActivity('long-lived-prompt', owner)).toBe(true);
+      runTTLSweepForTesting(startedAt + 31 * 60 * 1000);
+      now.mockReturnValue(startedAt + 35 * 60 * 1000);
+      endInteractionSpan('ok', { promptId: 'long-lived-prompt' });
+
+      runTTLSweepForTesting(startedAt + 64 * 60 * 1000);
+      now.mockReturnValue(startedAt + 64 * 60 * 1000);
+      const retainedSpan = startLLMRequestSpan('m', 'long-lived-prompt');
+      const retainedRecord = mockSpans.at(-1)!;
+      expect(retainedRecord.attributes['gen_ai.user.id']).toBe(
+        'long-lived-user',
+      );
+      endLLMRequestSpan(retainedSpan, { success: true });
+
+      runTTLSweepForTesting(startedAt + 66 * 60 * 1000);
+      now.mockReturnValue(startedAt + 66 * 60 * 1000);
+      const expiredSpan = startLLMRequestSpan('m', 'long-lived-prompt');
+      const expiredRecord = mockSpans.at(-1)!;
+      expect(expiredRecord.attributes).not.toHaveProperty('gen_ai.user.id');
+      endLLMRequestSpan(expiredSpan, { success: true });
+    });
+
     it('keeps the creation-time user ID across failures and repeated endings', () => {
       startInteractionSpan(createMockConfig({ userId: 'stable-user' }), {
         promptId: 'failure-prompt',
@@ -2572,6 +2606,117 @@ describe('session-tracing', () => {
       expect(mockSpans[0]!.ended).toBe(true);
       expect(mockSpans[0]!.attributes['qwen-code.span.ttl_expired']).toBe(true);
       expect(getActiveInteractionSpan('stale-interaction')).toBeUndefined();
+    });
+
+    it('expires interactions after inactivity instead of absolute lifetime', () => {
+      const startedAt = Date.now();
+      const now = vi.spyOn(Date, 'now').mockReturnValue(startedAt);
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'active-interaction',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      const owner = getActiveInteractionSpan('active-interaction')!;
+
+      now.mockReturnValue(startedAt + 11 * 60 * 1000);
+      const llmSpan = startLLMRequestSpan('m', 'active-interaction');
+      endLLMRequestSpan(llmSpan, { success: true });
+      runTTLSweepForTesting(startedAt + 31 * 60 * 1000);
+      expect(getActiveInteractionSpan('active-interaction')).toBe(owner);
+
+      now.mockReturnValue(startedAt + 29 * 60 * 1000);
+      const toolSpan = startToolSpan(
+        'Read',
+        undefined,
+        undefined,
+        'active-interaction',
+      );
+      now.mockReturnValue(startedAt + 58 * 60 * 1000);
+      endToolSpan(toolSpan, { success: true });
+      runTTLSweepForTesting(startedAt + 60 * 60 * 1000);
+      expect(getActiveInteractionSpan('active-interaction')).toBe(owner);
+      expect(mockSpans[0]!.ended).toBe(false);
+
+      now.mockReturnValue(startedAt + 60 * 60 * 1000);
+      mockSpans[0]!.attributes['gen_ai.output.messages'] = 'final output';
+      endInteractionSpan('ok', { promptId: 'active-interaction' });
+      expect(getActiveInteractionSpan('active-interaction')).toBeUndefined();
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.attributes['interaction.duration_ms']).toBe(
+        60 * 60 * 1000,
+      );
+      expect(mockSpans[0]!.attributes['qwen-code.turn_status']).toBe('ok');
+      expect(mockSpans[0]!.attributes['gen_ai.output.messages']).toBe(
+        'final output',
+      );
+    });
+
+    it('expires an interaction after 30 minutes without activity', () => {
+      const startedAt = Date.now();
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'idle-interaction',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      runTTLSweepForTesting(startedAt + 31 * 60 * 1000);
+
+      expect(getActiveInteractionSpan('idle-interaction')).toBeUndefined();
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.attributes['qwen-code.span.ttl_expired']).toBe(true);
+    });
+
+    it('does not let an old child refresh a replacement interaction', () => {
+      const startedAt = Date.now();
+      const now = vi.spyOn(Date, 'now').mockReturnValue(startedAt);
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'child-replacement',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      now.mockReturnValue(startedAt + 4 * 60 * 1000);
+      const oldChild = startLLMRequestSpan('m', 'child-replacement');
+
+      now.mockReturnValue(startedAt + 5 * 60 * 1000);
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'child-replacement',
+        model: 'm',
+        messageType: 'retry',
+      });
+      now.mockReturnValue(startedAt + 34 * 60 * 1000);
+      endLLMRequestSpan(oldChild, { success: true });
+
+      runTTLSweepForTesting(startedAt + 36 * 60 * 1000);
+      expect(getActiveInteractionSpan('child-replacement')).toBeUndefined();
+      expect(mockSpans[2]!.ended).toBe(true);
+    });
+
+    it('does not let a replaced owner refresh the current interaction', () => {
+      const startedAt = Date.now();
+      const now = vi.spyOn(Date, 'now').mockReturnValue(startedAt);
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'replaced-interaction',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+      const oldOwner = getActiveInteractionSpan('replaced-interaction')!;
+
+      now.mockReturnValue(startedAt + 5 * 60 * 1000);
+      startInteractionSpan(createMockConfig(), {
+        promptId: 'replaced-interaction',
+        model: 'm',
+        messageType: 'retry',
+      });
+      const currentOwner = getActiveInteractionSpan('replaced-interaction')!;
+      now.mockReturnValue(startedAt + 34 * 60 * 1000);
+      expect(recordInteractionActivity('replaced-interaction', oldOwner)).toBe(
+        false,
+      );
+
+      runTTLSweepForTesting(startedAt + 36 * 60 * 1000);
+      expect(getActiveInteractionSpan('replaced-interaction')).toBeUndefined();
+      expect(currentOwner).not.toBe(oldOwner);
+      expect(mockSpans[1]!.ended).toBe(true);
     });
     it('marks stale spans with ttl_expired + duration_ms before ending them', () => {
       const toolSpan = startToolSpan('staleTool');

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -37,6 +37,9 @@ import {
   setSessionIdOnContext,
 } from './session-context.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { getErrorType } from '../utils/errors.js';
+import { stripAnsiAndControl } from '../utils/textUtils.js';
+import { redactUrlCredentials } from '../extension/redaction.js';
 import type { ToolExecutionStatus } from '../core/turn.js';
 import { sessionIdContext } from '../utils/sessionIdContext.js';
 
@@ -51,7 +54,9 @@ export interface StartInteractionOptions {
 }
 
 export interface EndInteractionOptions {
+  promptId?: string;
   errorMessage?: string;
+  errorType?: string;
 }
 
 export type InteractionSpanResultStatus = 'ok' | 'error' | 'cancelled';
@@ -77,6 +82,7 @@ export interface LLMRequestMetadata {
   cacheCreationInputTokens?: number;
   cachedInputTokensReported?: boolean;
   success: boolean;
+  cancelled?: boolean;
   durationMs?: number;
   error?: string;
   /**
@@ -205,9 +211,9 @@ const toolContext = new AsyncLocalStorage<SpanContext | undefined>();
  * Review wenshao @ #4410.
  */
 const subagentContext = new AsyncLocalStorage<SpanContext | undefined>();
-// The interaction span ends before a ToolResult continuation starts. Retain
-// only its identity attributes so later spans can inherit the user without
-// re-parenting to an ended span or keeping the Span object alive.
+const activeInteractionsByPromptId = new Map<string, SpanContext>();
+// Retain only identity attributes after an interaction ends so a late
+// standalone span can still be attributed without parenting to an ended span.
 const interactionIdentityByPromptId = new Map<
   string,
   Pick<SpanContext, 'startTime' | 'attributes'>
@@ -262,7 +268,6 @@ const activeSpans = new Map<string, WeakRef<SpanContext>>();
 const strongSpans = new Map<string, SpanContext>();
 
 let interactionSequence = 0;
-let lastInteractionCtx: SpanContext | undefined;
 let cleanupIntervalStarted = false;
 const SPAN_TTL_MS_DEFAULT = 30 * 60 * 1000; //   30 min — user walk-away
 const SPAN_TTL_MS_LONG = 4 * 60 * 60 * 1000; //   4 h  — long fire-and-forget subagent
@@ -325,6 +330,15 @@ function sweepStaleSpans(now: number): void {
 
     if (!ctx.ended) {
       ctx.ended = true;
+      if (ctx.type === 'interaction') {
+        const promptId = ctx.attributes['qwen-code.prompt_id'];
+        if (
+          typeof promptId === 'string' &&
+          activeInteractionsByPromptId.get(promptId) === ctx
+        ) {
+          activeInteractionsByPromptId.delete(promptId);
+        }
+      }
       // Mark the span so backends can distinguish "abandoned and
       // garbage-collected by the TTL safety net" from "deliberately
       // ended without setting status / attrs" (#4321 review).
@@ -437,7 +451,7 @@ function truncateSpanText(s: string, maxChars = SPAN_TEXT_MAX_CHARS): string {
 }
 
 export function truncateSpanError(s: string): string {
-  return truncateSpanText(s);
+  return truncateSpanText(redactUrlCredentials(stripAnsiAndControl(s)));
 }
 
 function getTracer() {
@@ -445,6 +459,120 @@ function getTracer() {
 }
 
 // --- Interaction Spans ---
+
+function buildInteractionAttributes(
+  config: Config,
+  options: StartInteractionOptions,
+): Attributes {
+  const sessionId = config.getSessionId();
+  const userId = config.getTelemetryUserId();
+  return {
+    'session.id': sessionId,
+    ...(userId ? { 'gen_ai.user.id': userId } : {}),
+    'gen_ai.operation.name': 'invoke_agent',
+    'gen_ai.agent.name': 'qwen-code',
+    'gen_ai.conversation.id': sessionId,
+    ...(config.getJsonSchema?.() ? { 'gen_ai.output.type': 'json' } : {}),
+    'qwen-code.prompt_id': options.promptId,
+    'qwen-code.message_type': options.messageType,
+    'qwen-code.model': options.model,
+    'qwen-code.approval_mode': config.getApprovalMode(),
+    'interaction.sequence': interactionSequence,
+  };
+}
+
+function finalizeInteractionContext(
+  spanCtx: SpanContext,
+  status: InteractionStatus,
+  metadata?: EndInteractionOptions,
+): void {
+  if (spanCtx.ended) return;
+  spanCtx.ended = true;
+
+  const promptId = spanCtx.attributes['qwen-code.prompt_id'];
+  if (
+    typeof promptId === 'string' &&
+    activeInteractionsByPromptId.get(promptId) === spanCtx
+  ) {
+    activeInteractionsByPromptId.delete(promptId);
+  }
+
+  try {
+    const duration = Date.now() - spanCtx.startTime;
+    const attributes: Attributes = {
+      'interaction.duration_ms': duration,
+      'qwen-code.turn_status': status,
+    };
+    if (status === 'error') {
+      attributes['error.type'] = metadata?.errorType || 'interaction_error';
+    }
+    spanCtx.span.setAttributes(attributes);
+
+    if (status === 'error') {
+      spanCtx.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: truncateSpanError(metadata?.errorMessage ?? 'unknown error'),
+      });
+    }
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to update interaction span attributes/status: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
+    spanCtx.span.end();
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to end interaction span: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const spanId = getSpanId(spanCtx.span);
+  activeSpans.delete(spanId);
+  strongSpans.delete(spanId);
+}
+
+function registerInteractionContext(
+  promptId: string,
+  spanContextObj: SpanContext,
+): void {
+  const existing = activeInteractionsByPromptId.get(promptId);
+  if (existing && !existing.ended) {
+    debugLogger.warn(
+      `Replacing unfinished interaction for promptId=${promptId}; ending the previous span as cancelled`,
+    );
+    finalizeInteractionContext(existing, 'cancelled', { promptId });
+  }
+
+  const spanId = getSpanId(spanContextObj.span);
+  activeSpans.set(spanId, new WeakRef(spanContextObj));
+  strongSpans.set(spanId, spanContextObj);
+  activeInteractionsByPromptId.set(promptId, spanContextObj);
+
+  const userId = spanContextObj.attributes['gen_ai.user.id'];
+  if (typeof userId === 'string' && userId) {
+    interactionIdentityByPromptId.set(promptId, {
+      startTime: spanContextObj.startTime,
+      attributes: { 'gen_ai.user.id': userId },
+    });
+  } else {
+    interactionIdentityByPromptId.delete(promptId);
+  }
+}
+
+function getInteractionContext(promptId?: string): SpanContext | undefined {
+  if (promptId !== undefined) {
+    const exact = activeInteractionsByPromptId.get(promptId);
+    return exact && !exact.ended ? exact : undefined;
+  }
+  const current = interactionContext.getStore();
+  return current && !current.ended ? current : undefined;
+}
+
+function resolveGenAiParentContext(parent: SpanContext | undefined): Context {
+  if (!parent && interactionContext.getStore()) return ROOT_CONTEXT;
+  return resolveParentContext(parent);
+}
 
 export function startInteractionSpan(
   config: Config,
@@ -454,17 +582,7 @@ export function startInteractionSpan(
 
   ensureCleanupInterval();
   interactionSequence++;
-
-  const userId = config.getTelemetryUserId();
-  const attributes: Attributes = {
-    'session.id': config.getSessionId(),
-    ...(userId ? { 'gen_ai.user.id': userId } : {}),
-    'qwen-code.prompt_id': options.promptId,
-    'qwen-code.message_type': options.messageType,
-    'qwen-code.model': options.model,
-    'qwen-code.approval_mode': config.getApprovalMode(),
-    'interaction.sequence': interactionSequence,
-  };
+  const attributes = buildInteractionAttributes(config, options);
 
   // Each interaction is a trace root with its own traceId so that traces
   // stay bounded and renderable in trace viewers (ARMS / Jaeger).
@@ -475,24 +593,13 @@ export function startInteractionSpan(
     ROOT_CONTEXT,
   );
 
-  const spanId = getSpanId(span);
   const spanContextObj: SpanContext = {
     span,
     startTime: Date.now(),
     attributes: attributes as Record<string, string | number | boolean>,
     type: 'interaction',
   };
-  activeSpans.set(spanId, new WeakRef(spanContextObj));
-  strongSpans.set(spanId, spanContextObj);
-  if (userId) {
-    interactionIdentityByPromptId.set(options.promptId, {
-      startTime: spanContextObj.startTime,
-      attributes: { 'gen_ai.user.id': userId },
-    });
-  } else {
-    interactionIdentityByPromptId.delete(options.promptId);
-  }
-  lastInteractionCtx = spanContextObj;
+  registerInteractionContext(options.promptId, spanContextObj);
   interactionContext.enterWith(spanContextObj);
 }
 
@@ -500,7 +607,7 @@ export function endInteractionSpan(
   status: InteractionStatus,
   metadata?: EndInteractionOptions,
 ): void {
-  const spanCtx = interactionContext.getStore() ?? lastInteractionCtx;
+  const spanCtx = getInteractionContext(metadata?.promptId);
   if (!spanCtx) return;
   if (spanCtx.ended) {
     debugLogger.debug(
@@ -509,28 +616,17 @@ export function endInteractionSpan(
     return;
   }
 
-  spanCtx.ended = true;
-  lastInteractionCtx = undefined;
+  const current = interactionContext.getStore();
+  finalizeInteractionContext(spanCtx, status, metadata);
+  if (current === spanCtx) interactionContext.enterWith(undefined);
+}
 
-  const duration = Date.now() - spanCtx.startTime;
-  spanCtx.span.setAttributes({
-    'interaction.duration_ms': duration,
-    'qwen-code.turn_status': status,
-  });
-
-  if (status === 'error') {
-    spanCtx.span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: metadata?.errorMessage ?? 'unknown error',
-    });
-  } else {
-    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
+export function endAllInteractionSpans(
+  status: InteractionStatus = 'cancelled',
+): void {
+  for (const spanCtx of [...activeInteractionsByPromptId.values()]) {
+    finalizeInteractionContext(spanCtx, status);
   }
-
-  spanCtx.span.end();
-  const spanId = getSpanId(spanCtx.span);
-  activeSpans.delete(spanId);
-  strongSpans.delete(spanId);
   interactionContext.enterWith(undefined);
 }
 
@@ -544,18 +640,8 @@ export async function withInteractionSpan<T>(
 
   ensureCleanupInterval();
   interactionSequence++;
-
   const sessionId = config.getSessionId();
-  const userId = config.getTelemetryUserId();
-  const attributes: Attributes = {
-    'session.id': sessionId,
-    ...(userId ? { 'gen_ai.user.id': userId } : {}),
-    'qwen-code.prompt_id': options.promptId,
-    'qwen-code.message_type': options.messageType,
-    'qwen-code.model': options.model,
-    'qwen-code.approval_mode': config.getApprovalMode(),
-    'interaction.sequence': interactionSequence,
-  };
+  const attributes = buildInteractionAttributes(config, options);
 
   const parentContext = options.parentContext ?? ROOT_CONTEXT;
   const span = getTracer().startSpan(
@@ -566,23 +652,13 @@ export async function withInteractionSpan<T>(
     },
     parentContext,
   );
-  const spanId = getSpanId(span);
   const spanContextObj: SpanContext = {
     span,
     startTime: Date.now(),
     attributes: attributes as Record<string, string | number | boolean>,
     type: 'interaction',
   };
-  activeSpans.set(spanId, new WeakRef(spanContextObj));
-  strongSpans.set(spanId, spanContextObj);
-  if (userId) {
-    interactionIdentityByPromptId.set(options.promptId, {
-      startTime: spanContextObj.startTime,
-      attributes: { 'gen_ai.user.id': userId },
-    });
-  } else {
-    interactionIdentityByPromptId.delete(options.promptId);
-  }
+  registerInteractionContext(options.promptId, spanContextObj);
 
   const activeContext = trace.setSpan(
     setSessionIdOnContext(parentContext, sessionId),
@@ -591,45 +667,29 @@ export async function withInteractionSpan<T>(
   return await otelContext.with(activeContext, async () =>
     interactionContext.run(spanContextObj, async () => {
       let terminalStatus: InteractionStatus = 'ok';
-      let errorStatusSet = false;
+      let errorMetadata: EndInteractionOptions | undefined;
       try {
         const result = await fn();
         terminalStatus = getResultStatus?.(result) ?? 'ok';
         return result;
       } catch (error) {
         terminalStatus = 'error';
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: truncateSpanError(
-            error instanceof Error ? error.message : String(error),
-          ),
-        });
-        errorStatusSet = true;
+        errorMetadata = {
+          promptId: options.promptId,
+          errorMessage: error instanceof Error ? error.message : String(error),
+          errorType: getErrorType(error),
+        };
         throw error;
       } finally {
-        if (!spanContextObj.ended) {
-          spanContextObj.ended = true;
-          const duration = Date.now() - spanContextObj.startTime;
-          span.setAttributes({
-            'interaction.duration_ms': duration,
-            'qwen-code.turn_status': terminalStatus,
-          });
-          if (terminalStatus === 'ok') {
-            span.setStatus({ code: SpanStatusCode.OK });
-          } else if (terminalStatus === 'error' && !errorStatusSet) {
-            // getResultStatus reported 'error' on a non-throwing path (e.g. the
-            // cron path swallows API errors and surfaces them via status), so
-            // the catch above didn't run. Mark the span ERROR here, guarded so
-            // a thrown error's specific message is never overwritten.
-            span.setStatus({
-              code: SpanStatusCode.ERROR,
-              message: 'interaction error',
-            });
-          }
-          span.end();
-          activeSpans.delete(spanId);
-          strongSpans.delete(spanId);
-        }
+        finalizeInteractionContext(spanContextObj, terminalStatus, {
+          promptId: options.promptId,
+          ...(terminalStatus === 'error' && !errorMetadata
+            ? {
+                errorMessage: 'interaction error',
+                errorType: 'interaction_error',
+              }
+            : errorMetadata),
+        });
       }
     }),
   );
@@ -660,36 +720,28 @@ export function startLLMRequestSpanWithContext(
   // Prefer subagentContext over interactionContext so LLM spans inside a
   // foreground subagent nest under the subagent span instead of escaping
   // back to the outer interaction. wenshao @ #4410.
-  const parentCtx = subagentContext.getStore() ?? interactionContext.getStore();
-  const identityParentCtx =
+  const interactionParentCtx = getInteractionContext(promptId);
+  const parentCtx =
     subagentContext.getStore() ??
     toolContext.getStore() ??
-    interactionContext.getStore();
-  // resolveParentContext() also re-parents to the active OTel span when
-  // present, so a side-query LLM call nested inside a tool span still
-  // attaches to the tool span instead of becoming a separate trace root.
-  const ctx = resolveParentContext(parentCtx);
+    interactionParentCtx;
+  // Active-OTel fallback preserves nested side queries only when no
+  // interaction ALS owner exists. A mismatched prompt must stay standalone.
+  const ctx = resolveGenAiParentContext(parentCtx);
 
-  const sessionId = resolveSessionId(
-    identityParentCtx,
-    options?.sessionId,
-    ctx,
-  );
-  const userId = resolveGenAiUserId(
-    identityParentCtx,
-    promptId,
-    options?.userId,
-  );
+  const sessionId = resolveSessionId(parentCtx, options?.sessionId, ctx);
+  const userId = resolveGenAiUserId(parentCtx, promptId, options?.userId);
   const attributes: Attributes = {
     ...(sessionId ? { 'session.id': sessionId } : {}),
     ...(sessionId ? { 'gen_ai.conversation.id': sessionId } : {}),
     ...(userId ? { 'gen_ai.user.id': userId } : {}),
     'qwen-code.prompt_id': promptId,
-    'llm_request.context': subagentContext.getStore()
-      ? 'subagent'
-      : interactionContext.getStore()
-        ? 'interaction'
-        : 'standalone',
+    'llm_request.context':
+      parentCtx?.type === 'subagent'
+        ? 'subagent'
+        : interactionParentCtx
+          ? 'interaction'
+          : 'standalone',
     // Emit the version-pinned OTel GenAI semantic convention.
     'gen_ai.request.model': model,
     ...(options?.operationName
@@ -844,9 +896,16 @@ export function endLLMRequestSpan(
       if (metadata.subagentName !== undefined) {
         endAttributes['subagent_name'] = metadata.subagentName;
       }
-      if (metadata.errorType !== undefined) {
+      if (metadata.errorType && !metadata.cancelled) {
         endAttributes['error_type'] = metadata.errorType;
         endAttributes['error.type'] = metadata.errorType;
+      }
+      if (
+        !metadata.success &&
+        !metadata.cancelled &&
+        endAttributes['error.type'] === undefined
+      ) {
+        endAttributes['error.type'] = 'llm_error';
       }
       if (metadata.errorStatusCode !== undefined) {
         endAttributes['error_status_code'] = metadata.errorStatusCode;
@@ -889,9 +948,7 @@ export function endLLMRequestSpan(
       );
     }
 
-    if (metadata === undefined || metadata.success) {
-      spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-    } else {
+    if (metadata !== undefined && !metadata.success && !metadata.cancelled) {
       spanCtx.span.setStatus({
         code: SpanStatusCode.ERROR,
         message: metadata.error
@@ -933,18 +990,18 @@ export function startToolSpan(
   try {
     // Prefer subagentContext over interactionContext (see startLLMRequestSpan
     // for rationale; wenshao @ #4410).
+    const interactionParentCtx = getInteractionContext(promptId);
     const parentCtx =
-      subagentContext.getStore() ?? interactionContext.getStore();
-    const identityParentCtx =
       subagentContext.getStore() ??
       toolContext.getStore() ??
-      interactionContext.getStore();
-    // Same fallback as startLLMRequestSpan: prefer active OTel span for
-    // tools-inside-tools cases before becoming a trace root.
-    const ctx = resolveParentContext(parentCtx);
+      interactionParentCtx;
+    // Same guarded active-OTel fallback as startLLMRequestSpan.
+    const ctx = resolveGenAiParentContext(parentCtx);
 
-    const sessionId = resolveSessionId(identityParentCtx);
-    const userId = resolveGenAiUserId(identityParentCtx, promptId);
+    const sessionId = resolveSessionId(parentCtx, undefined, ctx);
+    const userId = resolveGenAiUserId(parentCtx, promptId);
+    const agentName = (subagentContext.getStore() ?? interactionParentCtx)
+      ?.attributes['gen_ai.agent.name'];
     const attributes: Attributes = {
       ...(sessionId ? { 'session.id': sessionId } : {}),
       ...attrs,
@@ -952,6 +1009,9 @@ export function startToolSpan(
       'gen_ai.operation.name': 'execute_tool',
       'gen_ai.tool.name': toolName,
       'gen_ai.tool.type': 'function',
+      ...(typeof agentName === 'string'
+        ? { 'gen_ai.agent.name': agentName }
+        : {}),
       ...(description
         ? {
             'gen_ai.tool.description': truncateSpanText(
@@ -961,6 +1021,9 @@ export function startToolSpan(
           }
         : {}),
     };
+    if (typeof agentName !== 'string') {
+      delete attributes['gen_ai.agent.name'];
+    }
 
     span = getTracer().startSpan(
       SPAN_TOOL,
@@ -1016,8 +1079,8 @@ export function runInToolSpanContext<T>(span: Span, fn: () => T): T {
 /**
  * When metadata is omitted, span status is NOT set — callers on failure paths
  * must pre-set status via setToolSpanFailure/setToolSpanCancelled before calling
- * this. This asymmetry with endLLMRequestSpan (which defaults to OK) is intentional:
- * tool spans have multiple failure modes that set status before endToolSpan runs.
+ * this. Tool spans have multiple failure modes that set status before
+ * endToolSpan runs.
  */
 export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
   const spanId = getSpanId(span);
@@ -1044,6 +1107,9 @@ export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
       }
       if (metadata.error !== undefined)
         endAttributes['error'] = truncateSpanError(metadata.error);
+      if (metadata.success === false && !metadata.cancelled) {
+        endAttributes['error.type'] = 'tool_error';
+      }
       if (metadata.cancelled) {
         endAttributes[TOOL_FAILURE_KIND_ATTRIBUTE] =
           TOOL_FAILURE_KIND_CANCELLED;
@@ -1053,11 +1119,7 @@ export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
     spanCtx.span.setAttributes(endAttributes);
 
     if (metadata) {
-      if (metadata.cancelled) {
-        spanCtx.span.setStatus({ code: SpanStatusCode.UNSET });
-      } else if (metadata.success !== false) {
-        spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-      } else {
+      if (!metadata.cancelled && metadata.success === false) {
         spanCtx.span.setStatus({
           code: SpanStatusCode.ERROR,
           message: metadata.error
@@ -1184,6 +1246,9 @@ export function endToolExecutionSpan(
 
   try {
     const duration = Date.now() - spanCtx.startTime;
+    const executionStatus = metadata?.executionStatus;
+    const cancelled =
+      metadata?.cancelled === true || executionStatus === 'cancelled';
     // Apply caller-supplied attributes FIRST so the canonical keys written
     // below (duration_ms, success, error) always win a key collision — a
     // passthrough attribute must never mask the span's own outcome fields.
@@ -1201,9 +1266,20 @@ export function endToolExecutionSpan(
       if (metadata.executionStatus !== undefined) {
         endAttributes['execution_status'] = metadata.executionStatus;
       }
-      if (metadata.errorType !== undefined) {
+      if (metadata.errorType) {
         endAttributes['error_type'] = metadata.errorType;
-        endAttributes['error.type'] = metadata.errorType;
+        if (!cancelled) {
+          endAttributes['error.type'] = metadata.errorType;
+        }
+      }
+      const failed =
+        !cancelled &&
+        executionStatus !== 'not_started' &&
+        (executionStatus === undefined
+          ? metadata.success === false
+          : executionStatus !== 'success');
+      if (failed && endAttributes['error.type'] === undefined) {
+        endAttributes['error.type'] = 'tool_execution_error';
       }
     }
 
@@ -1213,9 +1289,6 @@ export function endToolExecutionSpan(
     // status (e.g. via setToolSpanCancelled) and then call this without
     // metadata get their pre-set status preserved. Cancellation also
     // preserves UNSET so the child agrees with the cancelled parent.
-    const executionStatus = metadata?.executionStatus;
-    const cancelled =
-      metadata?.cancelled === true || executionStatus === 'cancelled';
     // The not_started guard is unreachable by construction (the span only
     // exists once execution is attempted); kept as defence-in-depth.
     if (metadata && !cancelled && executionStatus !== 'not_started') {
@@ -1223,9 +1296,7 @@ export function endToolExecutionSpan(
         executionStatus === undefined
           ? metadata.success !== false
           : executionStatus === 'success';
-      if (succeeded) {
-        spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-      } else {
+      if (!succeeded) {
         spanCtx.span.setStatus({
           code: SpanStatusCode.ERROR,
           message: metadata.error
@@ -1503,6 +1574,8 @@ export function endHookSpan(span: Span, metadata?: HookSpanMetadata): void {
         );
       if (metadata.error !== undefined)
         endAttributes['error'] = truncateSpanError(metadata.error);
+      if (metadata.error !== undefined)
+        endAttributes['error.type'] = 'hook_error';
     }
 
     spanCtx.span.setAttributes(endAttributes);
@@ -1739,7 +1812,7 @@ export function runInSubagentSpanContext<T>(
 
 /**
  * Finalize a subagent span. Status mapping:
- *  - `completed` → SpanStatus OK
+ *  - `completed` → SpanStatus UNSET
  *  - `failed`    → SpanStatus ERROR, sets `exception.message` + `error.type`
  *  - `cancelled` / `aborted` → SpanStatus UNSET (matches Phase 2 cancellation)
  *
@@ -1795,19 +1868,17 @@ export function endSubagentSpan(
       endAttributes['qwen-code.subagent.result_summary_present'] =
         metadata.resultSummaryPresent;
     }
-    if (metadata.error !== undefined) {
+    if (metadata.status === 'failed' && metadata.error !== undefined) {
       const truncated = truncateSpanError(metadata.error);
       endAttributes['exception.message'] = truncated;
     }
-    if (metadata.errorType !== undefined) {
-      endAttributes['error.type'] = metadata.errorType;
+    if (metadata.status === 'failed') {
+      endAttributes['error.type'] = metadata.errorType || 'subagent_error';
     }
 
     spanCtx.span.setAttributes(endAttributes);
 
-    if (metadata.status === 'completed') {
-      spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-    } else if (metadata.status === 'failed') {
+    if (metadata.status === 'failed') {
       spanCtx.span.setStatus({
         code: SpanStatusCode.ERROR,
         message: metadata.error
@@ -1836,10 +1907,8 @@ export function endSubagentSpan(
 
 // --- Interaction Span Attribute Access ---
 
-export function getActiveInteractionSpan(): Span | undefined {
-  const ctx = interactionContext.getStore() ?? lastInteractionCtx;
-  if (!ctx || ctx.ended) return undefined;
-  return ctx.span;
+export function getActiveInteractionSpan(promptId?: string): Span | undefined {
+  return getInteractionContext(promptId)?.span;
 }
 
 // --- Testing Utilities ---
@@ -1847,6 +1916,7 @@ export function getActiveInteractionSpan(): Span | undefined {
 export function clearSessionTracingForTesting(): void {
   activeSpans.clear();
   strongSpans.clear();
+  activeInteractionsByPromptId.clear();
   interactionIdentityByPromptId.clear();
   interactionContext.enterWith(undefined);
   toolContext.enterWith(undefined);
@@ -1855,7 +1925,6 @@ export function clearSessionTracingForTesting(): void {
   // test's spans. wenshao @ #4410.
   subagentContext.enterWith(undefined);
   interactionSequence = 0;
-  lastInteractionCtx = undefined;
   // Reach into session-context module to prevent cross-test leakage.
   setSessionContext(undefined);
 }

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -156,6 +156,8 @@ export interface ToolSpanMetadata {
 interface SpanContext {
   span: Span;
   startTime: number;
+  lastActivityTime?: number;
+  interactionOwner?: SpanContext;
   attributes: Record<string, string | number | boolean>;
   ended?: boolean;
   type:
@@ -216,7 +218,10 @@ const activeInteractionsByPromptId = new Map<string, SpanContext>();
 // standalone span can still be attributed without parenting to an ended span.
 const interactionIdentityByPromptId = new Map<
   string,
-  Pick<SpanContext, 'startTime' | 'attributes'>
+  {
+    lastActivityTime: number;
+    attributes: Record<string, string | number | boolean>;
+  }
 >();
 
 export function isInNativeSubagentSpan(): boolean {
@@ -314,7 +319,7 @@ function ttlFor(ctx: SpanContext): number {
 
 function sweepStaleSpans(now: number): void {
   for (const [promptId, ctx] of interactionIdentityByPromptId) {
-    if (now - ctx.startTime >= SPAN_TTL_MS_DEFAULT) {
+    if (now - ctx.lastActivityTime >= SPAN_TTL_MS_DEFAULT) {
       interactionIdentityByPromptId.delete(promptId);
     }
   }
@@ -326,7 +331,11 @@ function sweepStaleSpans(now: number): void {
       strongSpans.delete(spanId);
       continue;
     }
-    if (now - ctx.startTime < ttlFor(ctx)) continue;
+    const ttlReferenceTime =
+      ctx.type === 'interaction'
+        ? (ctx.lastActivityTime ?? ctx.startTime)
+        : ctx.startTime;
+    if (now - ttlReferenceTime < ttlFor(ctx)) continue;
 
     if (!ctx.ended) {
       ctx.ended = true;
@@ -495,6 +504,8 @@ function finalizeInteractionContext(
     activeInteractionsByPromptId.get(promptId) === spanCtx
   ) {
     activeInteractionsByPromptId.delete(promptId);
+    const identity = interactionIdentityByPromptId.get(promptId);
+    if (identity) identity.lastActivityTime = Date.now();
   }
 
   try {
@@ -552,7 +563,8 @@ function registerInteractionContext(
   const userId = spanContextObj.attributes['gen_ai.user.id'];
   if (typeof userId === 'string' && userId) {
     interactionIdentityByPromptId.set(promptId, {
-      startTime: spanContextObj.startTime,
+      lastActivityTime:
+        spanContextObj.lastActivityTime ?? spanContextObj.startTime,
       attributes: { 'gen_ai.user.id': userId },
     });
   } else {
@@ -567,6 +579,23 @@ function getInteractionContext(promptId?: string): SpanContext | undefined {
   }
   const current = interactionContext.getStore();
   return current && !current.ended ? current : undefined;
+}
+
+function touchInteractionContext(spanCtx: SpanContext | undefined): boolean {
+  if (!spanCtx || spanCtx.type !== 'interaction' || spanCtx.ended) return false;
+  const promptId = spanCtx.attributes['qwen-code.prompt_id'];
+  if (
+    typeof promptId !== 'string' ||
+    activeInteractionsByPromptId.get(promptId) !== spanCtx
+  ) {
+    return false;
+  }
+
+  const now = Date.now();
+  spanCtx.lastActivityTime = now;
+  const identity = interactionIdentityByPromptId.get(promptId);
+  if (identity) identity.lastActivityTime = now;
+  return true;
 }
 
 function resolveGenAiParentContext(parent: SpanContext | undefined): Context {
@@ -596,6 +625,7 @@ export function startInteractionSpan(
   const spanContextObj: SpanContext = {
     span,
     startTime: Date.now(),
+    lastActivityTime: Date.now(),
     attributes: attributes as Record<string, string | number | boolean>,
     type: 'interaction',
   };
@@ -655,6 +685,7 @@ export async function withInteractionSpan<T>(
   const spanContextObj: SpanContext = {
     span,
     startTime: Date.now(),
+    lastActivityTime: Date.now(),
     attributes: attributes as Record<string, string | number | boolean>,
     type: 'interaction',
   };
@@ -721,6 +752,7 @@ export function startLLMRequestSpanWithContext(
   // foreground subagent nest under the subagent span instead of escaping
   // back to the outer interaction. wenshao @ #4410.
   const interactionParentCtx = getInteractionContext(promptId);
+  touchInteractionContext(interactionParentCtx);
   const parentCtx =
     subagentContext.getStore() ??
     toolContext.getStore() ??
@@ -766,6 +798,7 @@ export function startLLMRequestSpanWithContext(
   const spanContextObj: SpanContext = {
     span,
     startTime: Date.now(),
+    ...(interactionParentCtx ? { interactionOwner: interactionParentCtx } : {}),
     attributes: attributes as Record<string, string | number | boolean>,
     type: 'llm_request',
   };
@@ -972,6 +1005,7 @@ export function endLLMRequestSpan(
   }
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
+  touchInteractionContext(spanCtx.interactionOwner);
 }
 
 // --- Tool Spans ---
@@ -991,6 +1025,7 @@ export function startToolSpan(
     // Prefer subagentContext over interactionContext (see startLLMRequestSpan
     // for rationale; wenshao @ #4410).
     const interactionParentCtx = getInteractionContext(promptId);
+    touchInteractionContext(interactionParentCtx);
     const parentCtx =
       subagentContext.getStore() ??
       toolContext.getStore() ??
@@ -1035,6 +1070,9 @@ export function startToolSpan(
     const spanContextObj: SpanContext = {
       span,
       startTime: Date.now(),
+      ...(interactionParentCtx
+        ? { interactionOwner: interactionParentCtx }
+        : {}),
       attributes: attributes as Record<string, string | number | boolean>,
       type: 'tool',
     };
@@ -1143,6 +1181,7 @@ export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
   }
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
+  touchInteractionContext(spanCtx.interactionOwner);
 }
 
 // --- Tool Execution Sub-Spans ---
@@ -1501,6 +1540,7 @@ export function startHookSpan(opts: StartHookSpanOptions): Span {
     subagentContext.getStore() ??
     interactionContext.getStore() ??
     undefined;
+  touchInteractionContext(interactionContext.getStore());
   const ctx = resolveParentContext(parentCtx);
   const sessionId = resolveSessionId(parentCtx);
 
@@ -1523,6 +1563,9 @@ export function startHookSpan(opts: StartHookSpanOptions): Span {
   const spanContextObj: SpanContext = {
     span,
     startTime: Date.now(),
+    ...(interactionContext.getStore()
+      ? { interactionOwner: interactionContext.getStore() }
+      : {}),
     attributes: attributes as Record<string, string | number | boolean>,
     type: 'hook',
   };
@@ -1600,6 +1643,7 @@ export function endHookSpan(span: Span, metadata?: HookSpanMetadata): void {
   }
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
+  touchInteractionContext(spanCtx.interactionOwner);
 }
 
 // --- Subagent Spans (#3731 Phase 3) ---
@@ -1909,6 +1953,15 @@ export function endSubagentSpan(
 
 export function getActiveInteractionSpan(promptId?: string): Span | undefined {
   return getInteractionContext(promptId)?.span;
+}
+
+export function recordInteractionActivity(
+  promptId: string,
+  expectedOwner: Span,
+): boolean {
+  const spanCtx = getInteractionContext(promptId);
+  if (!spanCtx || spanCtx.span !== expectedOwner) return false;
+  return touchInteractionContext(spanCtx);
 }
 
 // --- Testing Utilities ---


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR aligns the existing `qwen-code.interaction` span with the OpenTelemetry GenAI agent conventions and makes it represent one complete main-agent invocation. It adds the `invoke_agent` operation, stable main-agent and conversation identity, prompt-scoped ownership, correct parentage for LLM and tool spans, and OpenTelemetry-compliant success, cancellation, and error status semantics.

The interaction now remains open across tool approval, execution, and model continuations, including TUI, headless, and ACP entry points. Concurrent prompts are isolated by prompt ID, stale owners cannot end or mutate replacement spans, shutdown and TTL cleanup close registered spans, and tools inherit the actual parent agent name while standalone tools omit it.

When sensitive span attributes are enabled, the main-agent span records one bounded `gen_ai.input.messages` value containing only the trusted original user prompt and one bounded `gen_ai.output.messages` value containing only the final user-visible assistant response. Expanded context, history, reasoning, tool prefaces, tool results, system instructions, images, failed attempts, and intermediate continuations are excluded; structured JSON output is represented as compact JSON text with `finish_reason=tool_call`.

The telemetry design, developer documentation, ARMS alignment guidance, and integration coverage are updated to describe and verify the resulting trace contract.

## Why it's needed

Previously, the interaction span ended after the first model response in a tool turn. The tool and follow-up model call therefore became unrelated root traces, successful spans used `OK` instead of the recommended unset status, and the interaction lacked standard agent identity and operation fields. This made a single user invocation impossible to reconstruct reliably in OpenTelemetry backends.

The new lifecycle and attributes make the full main-agent invocation observable as one trace while preserving privacy defaults. Operators can correlate the user prompt and final answer when they explicitly enable sensitive attributes without duplicating the provider-level request, leaking expanded context, or recording partial and superseded outputs.

## Reviewer Test Plan

### How to verify

1. Enable telemetry with sensitive span attributes, run a prompt that requires one tool followed by a final answer, and confirm there is exactly one `qwen-code.interaction`, two `qwen-code.llm_request`, and one `qwen-code.tool` span. All four spans should share a trace ID, both LLM spans and the tool span should be children of the interaction, and their operations should be `invoke_agent`, `chat`, and `execute_tool` respectively.
2. Confirm the interaction carries `gen_ai.agent.name=qwen-code`, the current session as `gen_ai.conversation.id`, one input message containing only the original user prompt, and one output message containing only the final assistant answer. The output must not contain the tool preface, reasoning, tool result, historical messages, or alternate candidates.
3. Repeat with sensitive span attributes disabled and confirm Agent, LLM, and tool payload attributes are omitted while the trace hierarchy and non-sensitive semantic attributes remain intact.
4. Exercise direct answers, tool continuations, retry, cancellation, and API failure. Successful and cancelled spans should keep an unset status; failures should use `ERROR` with a low-cardinality `error.type`; no partial output should be written for failed or cancelled invocations.
5. Exercise JSON Schema structured output and confirm `gen_ai.output.type=json` and an output message containing compact JSON with `finish_reason=tool_call`. Using only `--output-format json` must not set the model output type.

Local verification on the rebased branch completed successfully: Core telemetry/client tests (551 passed), CLI headless/TUI/ACP tests (940 passed, 1 skipped), GenAI telemetry integration tests (3 passed), build, bundle, typecheck, and lint.

### Evidence (Before & After)

N/A — this changes exported telemetry and documentation, not the user-visible TUI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1, Node.js v22.22.3, npm 10.9.8; the telemetry integration test used the locally built bundle with sandboxing disabled and the file exporter.

## Risk & Scope

- Main risk or tradeoff: Interaction lifetime now includes tool execution and approval waiting, so interaction duration and span counts differ from earlier releases; lifecycle behavior is shared across TUI, headless, and ACP and is covered by targeted and integration tests.
- Not validated / out of scope: Windows and Linux were not tested locally; workflow invocation/dispatch spans, agent-level token aggregation, system instructions, tool definitions, provider request aggregation, and hosted-agent identity remain out of scope.
- Breaking changes / migration notes: No configuration migration is required. Existing telemetry consumers should account for successful and cancelled GenAI spans using unset status instead of `OK`, longer interaction durations across tool turns, additional Retry/Goal interactions, and the two optional sensitive message attributes when sensitive capture is enabled.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

### 本 PR 做了什么

本 PR 将现有的 `qwen-code.interaction` span 与 OpenTelemetry GenAI Agent 规范对齐，并使其表示一次完整的主 Agent invocation。它新增 `invoke_agent` operation、稳定的主 Agent 与会话身份、基于 prompt 的归属关系、LLM 与工具 span 的正确父子关系，以及符合 OpenTelemetry 规范的成功、取消和错误状态语义。

Interaction 现在会跨越工具审批、执行和模型 continuation 保持打开，并覆盖 TUI、headless 与 ACP 入口。并发 prompt 按 prompt ID 隔离，过期 owner 不能结束或修改替代 span，shutdown 与 TTL 清理会关闭 registry 中的 span，工具继承真实父 Agent 名称，而 standalone 工具不写 Agent 名称。

启用敏感 span 属性后，主 Agent span 会记录一个有界的 `gen_ai.input.messages`，其中只包含可信的原始用户 prompt；并记录一个有界的 `gen_ai.output.messages`，其中只包含最终用户可见的 assistant 回答。展开上下文、历史、reasoning、工具前言、工具结果、system instructions、图片、失败 attempt 和中间 continuation 都不会进入这些属性；结构化 JSON 输出以紧凑 JSON 文本表示，并使用 `finish_reason=tool_call`。

本 PR 同步更新 telemetry 设计、开发者文档、ARMS 字段对齐说明与集成测试，以描述并验证最终 trace 契约。

### 为什么需要

此前，interaction span 会在工具轮次的第一次模型响应后结束，因此工具和后续模型调用会成为互不关联的 root trace；成功 span 使用 `OK`，而不是规范建议的 unset 状态；interaction 也缺少标准 Agent 身份与 operation 字段。这使得 OpenTelemetry 后端无法可靠重建一次完整的用户 invocation。

新的生命周期和属性让完整的主 Agent invocation 能够作为一条 trace 被观测，同时保留默认隐私保护。运维人员仅在显式启用敏感属性时才能关联用户 prompt 与最终回答，同时不会重复 provider 级请求、泄漏展开上下文，或记录部分输出与已被替代的输出。

### Reviewer 测试计划

#### 验证方法

1. 启用 telemetry 与敏感 span 属性，执行一个需要调用一次工具并返回最终回答的 prompt，确认恰好产生一个 `qwen-code.interaction`、两个 `qwen-code.llm_request` 和一个 `qwen-code.tool` span。四个 span 应共享同一个 trace ID，两个 LLM span 和工具 span 都应以 interaction 为父节点，operation 应分别为 `invoke_agent`、`chat` 和 `execute_tool`。
2. 确认 interaction 包含 `gen_ai.agent.name=qwen-code`、以当前 session 作为 `gen_ai.conversation.id`、一个只包含原始用户 prompt 的输入消息，以及一个只包含最终 assistant 回答的输出消息。输出中不得包含工具前言、reasoning、工具结果、历史消息或备选 candidate。
3. 关闭敏感 span 属性后重复验证，确认 Agent、LLM 与工具 payload 属性均被省略，同时 trace 层级和非敏感语义属性保持不变。
4. 覆盖直接回答、工具 continuation、Retry、取消和 API 失败。成功与取消 span 应保持 unset 状态；失败应使用 `ERROR` 并写入低基数 `error.type`；失败或取消 invocation 不得写入部分输出。
5. 覆盖 JSON Schema 结构化输出，确认 `gen_ai.output.type=json`，并且输出消息包含紧凑 JSON 和 `finish_reason=tool_call`。仅使用 `--output-format json` 时不得设置模型输出类型。

在 rebase 后的分支上，本地验证全部成功：Core telemetry/client 测试（551 passed）、CLI headless/TUI/ACP 测试（940 passed，1 skipped）、GenAI telemetry 集成测试（3 passed）、build、bundle、typecheck 和 lint。

#### 证据（Before & After）

N/A — 本 PR 修改导出的 telemetry 与文档，不涉及用户可见的 TUI。

#### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

#### 环境（可选）

macOS 26.4.1、Node.js v22.22.3、npm 10.9.8；telemetry 集成测试使用本地构建 bundle、关闭 sandbox，并使用 file exporter。

### 风险与范围

- 主要风险或取舍：Interaction 生命周期现在包含工具执行与审批等待，因此 interaction duration 和 span 数量会与旧版本不同；生命周期逻辑由 TUI、headless 与 ACP 共享，并已由针对性测试和集成测试覆盖。
- 未验证 / 范围外：未在本地验证 Windows 与 Linux；workflow invocation/dispatch span、Agent 级 token 聚合、system instructions、tool definitions、provider 请求聚合和 hosted-agent identity 不在本 PR 范围内。
- 破坏性变更 / 迁移说明：不需要配置迁移。现有 telemetry 消费方需要适配成功与取消的 GenAI span 使用 unset 而不是 `OK`、工具轮次带来的更长 interaction duration、额外的 Retry/Goal interaction，以及启用敏感采集时新增的两个可选敏感消息属性。

### 关联 Issue

N/A

</details>
