### PR TITLE
fix(desktop): open remaining external links through the shell opener

### DIFF
--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -32,18 +32,12 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import { useI18n } from '../../i18n';
 import { extractErrorDetail } from '../../utils/errorDetail';
-import {
-  isDesktopShell,
-  isExternalOpenUrl,
-  openExternalUrl,
-} from '../../utils/externalOpen';
+import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import { formatRelativeTime } from '../../utils/formatRelativeTime';
-import { requestToast } from '../ToastHost';
 import { DialogShell } from '../dialogs/DialogShell';
 import { isSafeHref, Markdown } from '../messages/Markdown';
 import {
@@ -2344,26 +2338,9 @@ function ArtifactDetail({
   previewContent?: string;
 }) {
   const { t } = useI18n();
+  const openExternalLink = useExternalLinkOpener();
   const location = getArtifactLocation(artifact);
   const safeUrl = isSafeHref(artifact.url) ? artifact.url : undefined;
-  const isExternalUrl = isExternalOpenUrl(safeUrl);
-  const openExternal = () => {
-    if (!safeUrl || !isExternalUrl) return;
-    openExternalUrl(safeUrl).catch((error: unknown) => {
-      requestToast(
-        'error',
-        t('common.openFailed', { message: extractErrorDetail(error) }),
-      );
-    });
-  };
-  // The desktop webview's implicit `target="_blank"` handling silently drops
-  // failed new-window requests, so route external opens through the shell's
-  // explicit opener there; plain browsers keep native anchor behavior.
-  const handleLocationClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
-    if (!isExternalUrl || !isDesktopShell()) return;
-    event.preventDefault();
-    openExternal();
-  };
   const isAutomationSnapshot =
     artifact.metadata?.['artifactType'] === 'automation_snapshot';
   const isCodeReview = artifact.metadata?.['artifactType'] === 'code_review';
@@ -2462,7 +2439,7 @@ function ArtifactDetail({
                 href={safeUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={handleLocationClick}
+                onClick={(event) => openExternalLink(event, safeUrl)}
               >
                 {safeUrl}
               </a>
@@ -2471,7 +2448,7 @@ function ArtifactDetail({
                 href={safeUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={handleLocationClick}
+                onClick={(event) => openExternalLink(event, safeUrl)}
               >
                 {t('artifact.openLink')}
               </a>

--- a/packages/web-shell/client/components/artifacts/CodeReviewArtifactDetail.test.tsx
+++ b/packages/web-shell/client/components/artifacts/CodeReviewArtifactDetail.test.tsx
@@ -642,4 +642,35 @@ describe('CodeReviewArtifactDetail', () => {
       'truncated',
     );
   });
+
+  it('routes evidence link clicks through the desktop opener', async () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    (window as { __TAURI__?: unknown }).__TAURI__ = { core: { invoke } };
+    try {
+      const { container } = renderWith(JSON.stringify(reviewDocument));
+      await flush();
+
+      const link = Array.from(container.querySelectorAll('a')).find(
+        (anchor) =>
+          anchor.getAttribute('href') === 'https://example.com/evidence.png',
+      );
+      expect(link).toBeDefined();
+
+      const event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+      });
+      act(() => {
+        link!.dispatchEvent(event);
+      });
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(invoke).toHaveBeenCalledWith('plugin:opener|open_url', {
+        url: 'https://example.com/evidence.png',
+      });
+    } finally {
+      delete (window as { __TAURI__?: unknown }).__TAURI__;
+    }
+  });
 });

--- a/packages/web-shell/client/components/artifacts/CodeReviewArtifactDetail.tsx
+++ b/packages/web-shell/client/components/artifacts/CodeReviewArtifactDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useI18n } from '../../i18n';
+import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import { isSafeHref, Markdown } from '../messages/Markdown';
 import {
   getImageMimeTypeFromPath,
@@ -314,6 +315,7 @@ export function CodeReviewArtifactDetail({
   workspaceActions: ArtifactWorkspaceActions;
 }) {
   const { t } = useI18n();
+  const openExternalLink = useExternalLinkOpener();
   const [content, setContent] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [artifactTruncated, setArtifactTruncated] = useState(false);
@@ -645,6 +647,7 @@ export function CodeReviewArtifactDetail({
                             href={asset}
                             target="_blank"
                             rel="noopener noreferrer"
+                            onClick={(event) => openExternalLink(event, asset)}
                           >
                             {asset}
                           </a>

--- a/packages/web-shell/client/components/dialogs/GitDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/GitDialog.tsx
@@ -21,6 +21,7 @@ import {
   SearchIcon,
 } from 'lucide-react';
 import { useI18n } from '../../i18n';
+import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import { Markdown } from '../messages/Markdown';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { DialogShell } from './DialogShell';
@@ -63,6 +64,7 @@ export function GitDialog({
   onClose: () => void;
 }) {
   const { t } = useI18n();
+  const openExternalLink = useExternalLinkOpener();
   const { client, capabilities } = useWorkspace();
   const prsSupported =
     capabilities?.features?.includes(GITHUB_PRS_FEATURE) === true;
@@ -781,6 +783,7 @@ export function GitDialog({
                     href={prStatus.url}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={(event) => openExternalLink(event, prStatus.url)}
                   >
                     {prStatus.msg}
                   </a>

--- a/packages/web-shell/client/components/dialogs/GitHubPrsDialog.module.css
+++ b/packages/web-shell/client/components/dialogs/GitHubPrsDialog.module.css
@@ -29,6 +29,7 @@
   font: inherit;
   text-align: left;
   color: inherit;
+  text-decoration: none;
 }
 
 .prRow:hover {

--- a/packages/web-shell/client/components/dialogs/GitHubPrsDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/GitHubPrsDialog.test.tsx
@@ -116,7 +116,7 @@ describe('GitHubPrsContent', () => {
     await flush();
 
     const row = document.body.querySelector(
-      'button[aria-label*="pull request #42"]',
+      'a[aria-label*="pull request #42"]',
     );
     expect(row).toBeTruthy();
     let event: MouseEvent | undefined;
@@ -129,6 +129,25 @@ describe('GitHubPrsContent', () => {
     expect(invoke).toHaveBeenCalledWith('plugin:opener|open_url', {
       url: 'https://github.com/o/r/pull/42',
     });
+  });
+
+  it('keeps pull request rows as native links in plain browsers', async () => {
+    workspaceGitHubPullRequests.mockResolvedValue(listPayload([pr()]));
+    mount();
+    await flush();
+
+    const row = document.body.querySelector<HTMLAnchorElement>(
+      'a[aria-label*="pull request #42"]',
+    );
+    expect(row?.href).toBe('https://github.com/o/r/pull/42');
+    expect(row?.target).toBe('_blank');
+    let event: MouseEvent | undefined;
+    await act(async () => {
+      event = new MouseEvent('click', { bubbles: true, cancelable: true });
+      row?.dispatchEvent(event);
+    });
+
+    expect(event?.defaultPrevented).toBe(false);
   });
 
   it('renders draft and changes-requested pull requests', async () => {

--- a/packages/web-shell/client/components/dialogs/GitHubPrsDialog.test.tsx
+++ b/packages/web-shell/client/components/dialogs/GitHubPrsDialog.test.tsx
@@ -13,6 +13,8 @@ import { I18nProvider } from '../../i18n';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
+type TauriWindow = { __TAURI__?: { core?: { invoke?: unknown } } };
+
 if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
@@ -64,6 +66,7 @@ async function flush() {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  delete (window as TauriWindow).__TAURI__;
   vi.clearAllMocks();
   vi.unstubAllGlobals();
 });
@@ -105,10 +108,10 @@ describe('GitHubPrsContent', () => {
     expect(text).toContain('Approved');
   });
 
-  it('opens the pull request on GitHub when a row is clicked', async () => {
+  it('opens the pull request through the desktop opener when a row is clicked', async () => {
     workspaceGitHubPullRequests.mockResolvedValue(listPayload([pr()]));
-    const openSpy = vi.fn();
-    vi.stubGlobal('open', openSpy);
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    (window as TauriWindow).__TAURI__ = { core: { invoke } };
     mount();
     await flush();
 
@@ -116,15 +119,16 @@ describe('GitHubPrsContent', () => {
       'button[aria-label*="pull request #42"]',
     );
     expect(row).toBeTruthy();
+    let event: MouseEvent | undefined;
     await act(async () => {
-      row?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      event = new MouseEvent('click', { bubbles: true, cancelable: true });
+      row?.dispatchEvent(event);
     });
 
-    expect(openSpy).toHaveBeenCalledWith(
-      'https://github.com/o/r/pull/42',
-      '_blank',
-      'noopener,noreferrer',
-    );
+    expect(event?.defaultPrevented).toBe(true);
+    expect(invoke).toHaveBeenCalledWith('plugin:opener|open_url', {
+      url: 'https://github.com/o/r/pull/42',
+    });
   });
 
   it('renders draft and changes-requested pull requests', async () => {

--- a/packages/web-shell/client/components/dialogs/GitHubPrsDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/GitHubPrsDialog.tsx
@@ -19,6 +19,7 @@ import type {
   DaemonGitHubPullRequestList,
 } from '@qwen-code/sdk/daemon';
 import { useI18n } from '../../i18n';
+import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import { timeAgo } from '../../utils/timeAgo';
 import styles from './GitHubPrsDialog.module.css';
 
@@ -77,6 +78,7 @@ function PullRequestRow({
   now: number;
 }) {
   const { t, language } = useI18n();
+  const openExternalLink = useExternalLinkOpener();
   const StateIcon =
     pr.state === 'draft' ? GitPullRequestDraftIcon : GitPullRequestIcon;
   const reviewBadge =
@@ -99,9 +101,7 @@ function PullRequestRow({
       type="button"
       className={styles.prRow}
       aria-label={t('githubPrs.open', { number: pr.number })}
-      onClick={() => {
-        if (pr.url) window.open(pr.url, '_blank', 'noopener,noreferrer');
-      }}
+      onClick={(event) => openExternalLink(event, pr.url)}
     >
       <span className={styles.prLine}>
         <StateIcon

--- a/packages/web-shell/client/components/dialogs/GitHubPrsDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/GitHubPrsDialog.tsx
@@ -97,8 +97,10 @@ function PullRequestRow({
     ) : null;
 
   return (
-    <button
-      type="button"
+    <a
+      href={pr.url}
+      target="_blank"
+      rel="noopener noreferrer"
       className={styles.prRow}
       aria-label={t('githubPrs.open', { number: pr.number })}
       onClick={(event) => openExternalLink(event, pr.url)}
@@ -119,7 +121,7 @@ function PullRequestRow({
         {pr.author ? ` · ${pr.author}` : ''} ·{' '}
         {timeAgo(pr.updatedAt, now, language)}
       </span>
-    </button>
+    </a>
   );
 }
 

--- a/packages/web-shell/client/components/mcp/McpManagerPage.tsx
+++ b/packages/web-shell/client/components/mcp/McpManagerPage.tsx
@@ -21,6 +21,7 @@ import type {
 } from '@qwen-code/webui/daemon-react-sdk';
 import { useMcp, useSettings } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../../i18n';
+import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import { extractErrorDetail } from '../../utils/errorDetail';
 import styles from './McpManagerPage.module.css';
 import type { SerializedMcpStatusMessage } from '../messages/McpStatusMessage';
@@ -378,6 +379,7 @@ export function McpManagerPage({
   embedded,
 }: McpManagerPageProps) {
   const { t } = useI18n();
+  const openExternalLink = useExternalLinkOpener();
   const mcp = useMcp({ autoLoad: false });
   const settings = useSettings({ autoLoad: false });
   const [status, setStatus] = useState<McpStatus>(message.status);
@@ -1435,6 +1437,7 @@ export function McpManagerPage({
                     href={notice.authUrl}
                     target="_blank"
                     rel="noreferrer"
+                    onClick={(event) => openExternalLink(event, notice.authUrl)}
                   >
                     {t('mcp.oauth.open')}
                   </a>

--- a/packages/web-shell/client/components/messages/AuthMessage.tsx
+++ b/packages/web-shell/client/components/messages/AuthMessage.tsx
@@ -9,6 +9,9 @@ import { useI18n } from '../../i18n';
 import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import styles from './AuthMessage.module.css';
 
+const TOS_PRIVACY_URL =
+  'https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/';
+
 type AuthView = 'groups' | 'providers' | 'step' | 'review';
 type AuthGroupId = 'alibaba' | 'third-party' | 'custom';
 type AuthGroup = DaemonAuthProviderCatalog['groups'][number];
@@ -835,17 +838,12 @@ export function AuthMessage({ onMessage, onClose }: AuthMessageProps) {
             <div>{t('auth.termsTitle')}:</div>
             <a
               className={styles.link}
-              href="https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/"
+              href={TOS_PRIVACY_URL}
               target="_blank"
               rel="noreferrer"
-              onClick={(event) =>
-                openExternalLink(
-                  event,
-                  'https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/',
-                )
-              }
+              onClick={(event) => openExternalLink(event, TOS_PRIVACY_URL)}
             >
-              https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/
+              {TOS_PRIVACY_URL}
             </a>
           </div>
         </>

--- a/packages/web-shell/client/components/messages/AuthMessage.tsx
+++ b/packages/web-shell/client/components/messages/AuthMessage.tsx
@@ -6,6 +6,7 @@ import {
   type DaemonAuthProviderDescriptor,
 } from '@qwen-code/webui/daemon-react-sdk';
 import { useI18n } from '../../i18n';
+import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import styles from './AuthMessage.module.css';
 
 type AuthView = 'groups' | 'providers' | 'step' | 'review';
@@ -108,6 +109,7 @@ function normalizeModelIds(value: string): string[] {
 
 export function AuthMessage({ onMessage, onClose }: AuthMessageProps) {
   const { t } = useI18n();
+  const openExternalLink = useExternalLinkOpener();
   const workspaceActions = useWorkspaceActions();
   const [view, setView] = useState<AuthView>('groups');
   const [groupIndex, setGroupIndex] = useState(0);
@@ -601,6 +603,9 @@ export function AuthMessage({ onMessage, onClose }: AuthMessageProps) {
               href={provider.documentationUrl}
               target="_blank"
               rel="noreferrer"
+              onClick={(event) =>
+                openExternalLink(event, provider.documentationUrl)
+              }
             >
               {t('auth.documentation')}
             </a>
@@ -617,6 +622,9 @@ export function AuthMessage({ onMessage, onClose }: AuthMessageProps) {
               href={provider.documentationUrl}
               target="_blank"
               rel="noreferrer"
+              onClick={(event) =>
+                openExternalLink(event, provider.documentationUrl)
+              }
             >
               {t('auth.documentation')}: {provider.documentationUrl}
             </a>
@@ -830,6 +838,12 @@ export function AuthMessage({ onMessage, onClose }: AuthMessageProps) {
               href="https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/"
               target="_blank"
               rel="noreferrer"
+              onClick={(event) =>
+                openExternalLink(
+                  event,
+                  'https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/',
+                )
+              }
             >
               https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/
             </a>

--- a/packages/web-shell/client/components/messages/Markdown.tsx
+++ b/packages/web-shell/client/components/messages/Markdown.tsx
@@ -7,7 +7,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type MouseEvent as ReactMouseEvent,
   type ReactNode,
 } from 'react';
 import { useTheme } from '../../themeContext';
@@ -25,13 +24,7 @@ import {
   isTooLargeToHighlight,
 } from './codeHighlighter';
 import { useI18n } from '../../i18n';
-import { extractErrorDetail } from '../../utils/errorDetail';
-import {
-  isDesktopShell,
-  isExternalOpenUrl,
-  openExternalUrl,
-} from '../../utils/externalOpen';
-import { requestToast } from '../ToastHost';
+import { useExternalLinkOpener } from '../../hooks/useExternalLinkOpener';
 import {
   useWebShellCustomization,
   type MarkdownTableMode,
@@ -716,7 +709,7 @@ function MarkdownLink({
   children?: ReactNode;
 }) {
   const renderMode = useTranscriptRenderMode();
-  const { t } = useI18n();
+  const openExternalLink = useExternalLinkOpener();
   if (href && QWEN_SESSION_SCHEME.test(href.trim())) {
     if (renderMode === 'readonly') {
       return <span className={styles.link}>{children}</span>;
@@ -740,28 +733,13 @@ function MarkdownLink({
     );
   }
   const safeHref = isSafeHref(href) ? href : undefined;
-  const isExternalHref = isExternalOpenUrl(safeHref);
-  // In the packaged desktop shell the webview's implicit `target="_blank"`
-  // handling silently drops the request on failure, so route external clicks
-  // through the shell's explicit opener and surface errors as toasts. Plain
-  // browsers keep the native anchor behavior.
-  const handleClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
-    if (!isExternalHref || !safeHref || !isDesktopShell()) return;
-    event.preventDefault();
-    openExternalUrl(safeHref).catch((error: unknown) => {
-      requestToast(
-        'error',
-        t('common.openFailed', { message: extractErrorDetail(error) }),
-      );
-    });
-  };
   return (
     <a
       href={safeHref}
       target="_blank"
       rel="noopener noreferrer"
       className={styles.link}
-      onClick={isExternalHref ? handleClick : undefined}
+      onClick={(event) => openExternalLink(event, safeHref)}
     >
       {children}
     </a>

--- a/packages/web-shell/client/hooks/useExternalLinkOpener.test.ts
+++ b/packages/web-shell/client/hooks/useExternalLinkOpener.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { createElement, type MouseEvent as ReactMouseEvent } from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { I18nProvider } from '../i18n';
+import { TOAST_REQUEST_EVENT } from '../components/ToastHost';
+import { useExternalLinkOpener } from './useExternalLinkOpener';
+
+type TauriWindow = { __TAURI__?: { core?: { invoke?: unknown } } };
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+function TestLink({ url }: { url?: string }) {
+  const openExternalLink = useExternalLinkOpener();
+  return createElement(
+    'a',
+    {
+      href: url,
+      target: '_blank',
+      rel: 'noreferrer',
+      onClick: (event: ReactMouseEvent<HTMLAnchorElement>) =>
+        openExternalLink(event, url),
+    },
+    'link',
+  );
+}
+
+describe('useExternalLinkOpener', () => {
+  let container: HTMLDivElement;
+  let unmount: () => void;
+
+  function render(url?: string): HTMLAnchorElement {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        createElement(
+          I18nProvider,
+          { language: 'en' },
+          createElement(TestLink, { url }),
+        ),
+      );
+    });
+    unmount = () => {
+      act(() => root.unmount());
+      container.remove();
+    };
+    return container.querySelector('a')!;
+  }
+
+  function click(anchor: HTMLAnchorElement): MouseEvent {
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    });
+    act(() => {
+      anchor.dispatchEvent(event);
+    });
+    return event;
+  }
+
+  afterEach(() => {
+    delete (window as TauriWindow).__TAURI__;
+    vi.restoreAllMocks();
+    if (unmount) unmount();
+  });
+
+  it('opens external links through the desktop opener', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    (window as TauriWindow).__TAURI__ = { core: { invoke } };
+    const anchor = render('https://github.com/QwenLM/qwen-code/issues/9108');
+    const event = click(anchor);
+    expect(event.defaultPrevented).toBe(true);
+    expect(invoke).toHaveBeenCalledWith('plugin:opener|open_url', {
+      url: 'https://github.com/QwenLM/qwen-code/issues/9108',
+    });
+  });
+
+  it('normalizes mixed-case schemes before invoking the opener', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    (window as TauriWindow).__TAURI__ = { core: { invoke } };
+    const anchor = render('HTTPS://github.com/QwenLM/qwen-code');
+    const event = click(anchor);
+    expect(event.defaultPrevented).toBe(true);
+    expect(invoke).toHaveBeenCalledWith('plugin:opener|open_url', {
+      url: 'https://github.com/QwenLM/qwen-code',
+    });
+  });
+
+  it('leaves non-opener hrefs to native anchor behavior', () => {
+    const invoke = vi.fn().mockResolvedValue(undefined);
+    (window as TauriWindow).__TAURI__ = { core: { invoke } };
+    const anchor = render('#fragment');
+    const event = click(anchor);
+    expect(event.defaultPrevented).toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps native anchor behavior in plain browsers', () => {
+    const anchor = render('https://github.com/QwenLM/qwen-code');
+    const event = click(anchor);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('surfaces opener failures as error toasts', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('ForbiddenUrl'));
+    (window as TauriWindow).__TAURI__ = { core: { invoke } };
+    const toasts: Array<{ tone?: string; message?: string }> = [];
+    const listener = (event: Event) => {
+      toasts.push((event as CustomEvent).detail);
+    };
+    window.addEventListener(TOAST_REQUEST_EVENT, listener);
+    try {
+      const anchor = render('https://github.com/QwenLM/qwen-code');
+      click(anchor);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(toasts).toHaveLength(1);
+      expect(toasts[0].tone).toBe('error');
+      expect(toasts[0].message).toContain('Could not open link');
+    } finally {
+      window.removeEventListener(TOAST_REQUEST_EVENT, listener);
+    }
+  });
+});

--- a/packages/web-shell/client/hooks/useExternalLinkOpener.ts
+++ b/packages/web-shell/client/hooks/useExternalLinkOpener.ts
@@ -21,7 +21,7 @@ import {
 export function useExternalLinkOpener() {
   const { t } = useI18n();
   return useCallback(
-    (event: MouseEvent, url: string | undefined) => {
+    (event: MouseEvent<HTMLAnchorElement>, url: string | undefined) => {
       if (!url || !isExternalOpenUrl(url) || !isDesktopShell()) return;
       event.preventDefault();
       openExternalUrl(url).catch((error: unknown) => {

--- a/packages/web-shell/client/hooks/useExternalLinkOpener.ts
+++ b/packages/web-shell/client/hooks/useExternalLinkOpener.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import type { MouseEvent } from 'react';
+import { useI18n } from '../i18n';
+import { requestToast } from '../components/ToastHost';
+import { extractErrorDetail } from '../utils/errorDetail';
+import {
+  isDesktopShell,
+  isExternalOpenUrl,
+  openExternalUrl,
+} from '../utils/externalOpen';
+
+/**
+ * Opens external link clicks through the shell's explicit desktop opener.
+ *
+ * The desktop webview's implicit `target="_blank"` handling can silently
+ * drop new-window requests, so anchored external URLs should be routed
+ * through this handler in the packaged shell; failures surface as error
+ * toasts. Plain browsers keep native anchor behavior (the handler is a
+ * no-op there).
+ */
+export function useExternalLinkOpener() {
+  const { t } = useI18n();
+  return useCallback(
+    (event: MouseEvent, url: string | undefined) => {
+      if (!url || !isExternalOpenUrl(url) || !isDesktopShell()) return;
+      event.preventDefault();
+      openExternalUrl(url).catch((error: unknown) => {
+        requestToast(
+          'error',
+          t('common.openFailed', { message: extractErrorDetail(error) }),
+        );
+      });
+    },
+    [t],
+  );
+}


### PR DESCRIPTION
## What this PR does

The desktop webview can silently drop `target="_blank"` requests. #9069 fixed this for Markdown message links and `external_url` artifacts by routing them through the capability-scoped Tauri opener; four other link surfaces still relied on the unreliable implicit new-window path. This PR adds a single shared `useExternalLinkOpener` hook (gate on desktop + opener-supported scheme, `preventDefault`, open through the plugin, surface failures as error toasts) and routes the remaining surfaces through it: the MCP OAuth authorization link in the MCP manager, the created-PR link in the Git dialog, the evidence links in code review artifacts, and the documentation/terms links on the auth screens. Plain browsers keep native anchor behavior — the hook is a no-op outside the packaged shell. The two per-site click handlers introduced by #9069 are collapsed into the same hook.

## Why it's needed

Fixes #9108. The remaining surfaces fail open-ended and silently: clicking does nothing, with no browser window and no error. The MCP OAuth case is flow-critical — users cannot complete MCP server authorization on desktop, and the silent failure looks like a broken auth flow rather than a link problem.

## Reviewer Test Plan

### How to verify

1. Run the new hook tests plus the code-review surface test: `cd packages/web-shell && npx vitest run --config vitest.config.ts client/hooks/useExternalLinkOpener.test.ts client/components/artifacts/CodeReviewArtifactDetail.test.tsx`. The hook tests pin: desktop clicks open through `plugin:opener|open_url` with `preventDefault`, mixed-case schemes are normalized before invoke, non-opener hrefs (`#fragment`) and plain browsers keep native behavior (no `preventDefault`, no invoke), and opener failures dispatch an error toast.
2. In a desktop build, trigger an MCP server that requires OAuth and click the authorization link in the notice — the system browser should open; repeat for the Git dialog PR link, a code review finding's evidence link, and the auth-screen documentation links. Denying the opener capability should show an error toast instead of a silent drop.
3. Full suite and checks: `npx vitest run --config vitest.config.ts` in `packages/web-shell` passes 187 files / 3508 tests; `tsc --noEmit`, `eslint`, `prettier --check`, and `npm run build` are clean on the changed files.

### Evidence (Before & After)

N/A — desktop-only click routing; covered at the DOM/invoke level by the new jsdom tests. No packaged-desktop screenshots were produced.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node v22. Unit tests only (jsdom); `npm ci` in a dedicated worktree. No packaged desktop build was run.

## Risk & Scope

- Main risk or tradeoff: the four surfaces previously depended on the webview's implicit new-window fallback; they now fail visibly (error toast) when the opener rejects a URL, instead of silently. The hook attaches unconditionally and no-ops for non-external hrefs and plain browsers, matching the #9069 pattern.
- Not validated / out of scope: visual/E2E verification in packaged desktop apps (the MCP OAuth path needs a real OAuth-requiring MCP server); other desktop link behavior is unchanged.
- Breaking changes / migration notes: none; rendering/click-routing only, no API or capability changes (reuses the existing `web-shell-external-url` capability).

## Linked Issues

Fixes #9108

References #9069, #9060

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

桌面 webview 可能静默丢弃 `target="_blank"` 请求。#9069 已经把 Markdown 消息链接和 `external_url` 产物链接改为走 capability 受限的 Tauri opener；其余四处链接仍然依赖不可靠的隐式新窗口路径。本 PR 新增一个共享的 `useExternalLinkOpener` hook（桌面端 + opener 支持的 scheme 才拦截，`preventDefault` 后经插件打开，失败时弹错误 toast），并把这四处接入：MCP 管理器里的 OAuth 授权链接、Git 对话框里的新建 PR 链接、代码评审产物的证据链接、登录界面的文档/服务条款链接。普通浏览器保持原生锚点行为——hook 在打包外壳之外是空操作。#9069 引入的两处重复 click handler 也收敛到同一个 hook。

## 为什么需要

修复 #9108。这些残留面的失败是完全静默的：点击没有任何反应，没有浏览器窗口也没有报错。其中 MCP OAuth 是流程关键——桌面端用户无法完成 MCP server 授权，而且静默失败看起来像授权流程本身坏了，而不是链接问题。

## 评审测试计划

### 如何验证

1. 运行新增 hook 测试和代码评审 surface 测试：`cd packages/web-shell && npx vitest run --config vitest.config.ts client/hooks/useExternalLinkOpener.test.ts client/components/artifacts/CodeReviewArtifactDetail.test.tsx`。hook 测试钉住：桌面端点击经 `plugin:opener|open_url` 打开并 `preventDefault`；混合大小写 scheme 在 invoke 前归一化；非 opener href（`#fragment`）和普通浏览器保持原生行为（不 `preventDefault`、不 invoke）；opener 失败时派发错误 toast。
2. 在桌面构建中，触发一个需要 OAuth 的 MCP server 并点击提示里的授权链接——应打开系统浏览器；同样验证 Git 对话框 PR 链接、代码评审发现的证据链接、登录界面文档链接。拒绝 opener capability 时应显示错误 toast 而不是静默失败。
3. 全量套件与检查：`packages/web-shell` 中 `npx vitest run --config vitest.config.ts` 通过 187 个文件 / 3508 个用例；改动文件的 `tsc --noEmit`、`eslint`、`prettier --check`、`npm run build` 均通过。

### 证据（Before & After）

N/A——仅桌面端点击路由，由新增 jsdom 测试在 DOM/invoke 层面覆盖，未产出打包桌面端截图。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

macOS，Node v22。仅单元测试（jsdom），在独立 worktree 中 `npm ci`。未运行打包桌面构建。

## 风险与范围

- 主要风险或取舍：这四处此前依赖 webview 的隐式新窗口回退；现在 opener 拒绝 URL 时会可见地失败（错误 toast），而不是静默。hook 无条件挂载、对非外部 href 和普通浏览器是空操作，与 #9069 的模式一致。
- 未验证 / 超出范围：未在打包桌面应用中做视觉/E2E 验证（MCP OAuth 路径需要一个真实要求 OAuth 的 MCP server）；其他桌面链接行为不变。
- 破坏性变更 / 迁移说明：无；仅渲染/点击路由改动，无 API 或 capability 变化（复用现有 `web-shell-external-url` capability）。

## 关联 Issue

Fixes #9108

References #9069, #9060

</details>
