### PR TITLE
fix(install): avoid Get-FileHash for Windows checksums

### DIFF
--- a/scripts/installation/install-qwen-standalone.bat
+++ b/scripts/installation/install-qwen-standalone.bat
@@ -784,45 +784,9 @@ if "!EXPECTED_HASH!"=="" (
 
 set "ACTUAL_HASH="
 set "QWEN_HASH_FILE=!ARCHIVE_FILE!"
-REM Keep the hashing logic readable without adding a second distributed file.
-REM A temporary script also avoids fragile nested cmd.exe/PowerShell escaping.
-call :CreateTempFile "qwen-hash" ".ps1"
-if !ERRORLEVEL! NEQ 0 (
-    set "QWEN_HASH_FILE="
-    if not "!TEMP_CHECKSUM!"=="" del /F /Q "!TEMP_CHECKSUM!" >nul 2>&1
-    exit /b 1
+for /f "delims=" %%H in ('powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; $stream = $null; $sha256 = $null; try { $stream = [IO.File]::OpenRead($env:QWEN_HASH_FILE); $sha256 = [Security.Cryptography.SHA256]::Create(); if ($null -eq $sha256) { throw 'SHA-256 provider unavailable.' }; $hash = [BitConverter]::ToString($sha256.ComputeHash($stream)).Replace('-', ''); if ($hash -cnotmatch '\A[0-9A-F]{64}\z') { throw 'Invalid SHA-256 result.' } } catch { [Console]::Error.WriteLine('SHA-256 calculation failed: ' + $_.Exception.Message); exit 1 } finally { if ($null -ne $stream) { $stream.Dispose() }; if ($null -ne $sha256) { $sha256.Dispose() } }; [Console]::Write($hash)"') do (
+    if "!ACTUAL_HASH!"=="" set "ACTUAL_HASH=%%H"
 )
-set "QWEN_HASH_SCRIPT=!TEMP_FILE!"
-set "QWEN_HASH_OUTPUT=!QWEN_HASH_SCRIPT!.out"
-
-> "!QWEN_HASH_SCRIPT!" echo $ErrorActionPreference = 'Stop'
->> "!QWEN_HASH_SCRIPT!" echo $stream = $null
->> "!QWEN_HASH_SCRIPT!" echo $sha256 = $null
->> "!QWEN_HASH_SCRIPT!" echo try {
->> "!QWEN_HASH_SCRIPT!" echo   $stream = [IO.File]::OpenRead($env:QWEN_HASH_FILE)
->> "!QWEN_HASH_SCRIPT!" echo   $sha256 = [Security.Cryptography.SHA256]::Create()
->> "!QWEN_HASH_SCRIPT!" echo   if ($null -eq $sha256) { throw 'SHA-256 provider unavailable.' }
->> "!QWEN_HASH_SCRIPT!" echo   $hashBytes = $sha256.ComputeHash($stream)
->> "!QWEN_HASH_SCRIPT!" echo   $hash = [BitConverter]::ToString($hashBytes).Replace('-', '')
->> "!QWEN_HASH_SCRIPT!" echo   if ($hash -cnotmatch '\A[0-9A-F]{64}\z') { throw 'Invalid SHA-256 result.' }
->> "!QWEN_HASH_SCRIPT!" echo } catch {
->> "!QWEN_HASH_SCRIPT!" echo   [Console]::Error.WriteLine('SHA-256 calculation failed: ' + $_.Exception.Message)
->> "!QWEN_HASH_SCRIPT!" echo   exit 1
->> "!QWEN_HASH_SCRIPT!" echo } finally {
->> "!QWEN_HASH_SCRIPT!" echo   if ($null -ne $stream) { $stream.Dispose() }
->> "!QWEN_HASH_SCRIPT!" echo   if ($null -ne $sha256) { $sha256.Dispose() }
->> "!QWEN_HASH_SCRIPT!" echo }
->> "!QWEN_HASH_SCRIPT!" echo [Console]::Write($hash)
-
-powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "!QWEN_HASH_SCRIPT!" > "!QWEN_HASH_OUTPUT!"
-set "PS_STATUS=!ERRORLEVEL!"
-if !PS_STATUS! EQU 0 (
-    for /f "usebackq delims=" %%H in ("!QWEN_HASH_OUTPUT!") do if "!ACTUAL_HASH!"=="" set "ACTUAL_HASH=%%H"
-)
-del /F /Q "!QWEN_HASH_SCRIPT!" >nul 2>&1
-del /F /Q "!QWEN_HASH_OUTPUT!" >nul 2>&1
-set "QWEN_HASH_SCRIPT="
-set "QWEN_HASH_OUTPUT="
 set "QWEN_HASH_FILE="
 
 if not "!TEMP_CHECKSUM!"=="" del /F /Q "!TEMP_CHECKSUM!" >nul 2>&1

--- a/scripts/installation/install-qwen-standalone.bat
+++ b/scripts/installation/install-qwen-standalone.bat
@@ -784,9 +784,45 @@ if "!EXPECTED_HASH!"=="" (
 
 set "ACTUAL_HASH="
 set "QWEN_HASH_FILE=!ARCHIVE_FILE!"
-for /f "delims=" %%H in ('powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference = 'Stop'; (Get-FileHash -Algorithm SHA256 -LiteralPath $env:QWEN_HASH_FILE).Hash" 2^>nul') do (
-    if "!ACTUAL_HASH!"=="" set "ACTUAL_HASH=%%H"
+REM Keep the hashing logic readable without adding a second distributed file.
+REM A temporary script also avoids fragile nested cmd.exe/PowerShell escaping.
+call :CreateTempFile "qwen-hash" ".ps1"
+if !ERRORLEVEL! NEQ 0 (
+    set "QWEN_HASH_FILE="
+    if not "!TEMP_CHECKSUM!"=="" del /F /Q "!TEMP_CHECKSUM!" >nul 2>&1
+    exit /b 1
 )
+set "QWEN_HASH_SCRIPT=!TEMP_FILE!"
+set "QWEN_HASH_OUTPUT=!QWEN_HASH_SCRIPT!.out"
+
+> "!QWEN_HASH_SCRIPT!" echo $ErrorActionPreference = 'Stop'
+>> "!QWEN_HASH_SCRIPT!" echo $stream = $null
+>> "!QWEN_HASH_SCRIPT!" echo $sha256 = $null
+>> "!QWEN_HASH_SCRIPT!" echo try {
+>> "!QWEN_HASH_SCRIPT!" echo   $stream = [IO.File]::OpenRead($env:QWEN_HASH_FILE)
+>> "!QWEN_HASH_SCRIPT!" echo   $sha256 = [Security.Cryptography.SHA256]::Create()
+>> "!QWEN_HASH_SCRIPT!" echo   if ($null -eq $sha256) { throw 'SHA-256 provider unavailable.' }
+>> "!QWEN_HASH_SCRIPT!" echo   $hashBytes = $sha256.ComputeHash($stream)
+>> "!QWEN_HASH_SCRIPT!" echo   $hash = [BitConverter]::ToString($hashBytes).Replace('-', '')
+>> "!QWEN_HASH_SCRIPT!" echo   if ($hash -cnotmatch '\A[0-9A-F]{64}\z') { throw 'Invalid SHA-256 result.' }
+>> "!QWEN_HASH_SCRIPT!" echo } catch {
+>> "!QWEN_HASH_SCRIPT!" echo   [Console]::Error.WriteLine('SHA-256 calculation failed: ' + $_.Exception.Message)
+>> "!QWEN_HASH_SCRIPT!" echo   exit 1
+>> "!QWEN_HASH_SCRIPT!" echo } finally {
+>> "!QWEN_HASH_SCRIPT!" echo   if ($null -ne $stream) { $stream.Dispose() }
+>> "!QWEN_HASH_SCRIPT!" echo   if ($null -ne $sha256) { $sha256.Dispose() }
+>> "!QWEN_HASH_SCRIPT!" echo }
+>> "!QWEN_HASH_SCRIPT!" echo [Console]::Write($hash)
+
+powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "!QWEN_HASH_SCRIPT!" > "!QWEN_HASH_OUTPUT!"
+set "PS_STATUS=!ERRORLEVEL!"
+if !PS_STATUS! EQU 0 (
+    for /f "usebackq delims=" %%H in ("!QWEN_HASH_OUTPUT!") do if "!ACTUAL_HASH!"=="" set "ACTUAL_HASH=%%H"
+)
+del /F /Q "!QWEN_HASH_SCRIPT!" >nul 2>&1
+del /F /Q "!QWEN_HASH_OUTPUT!" >nul 2>&1
+set "QWEN_HASH_SCRIPT="
+set "QWEN_HASH_OUTPUT="
 set "QWEN_HASH_FILE="
 
 if not "!TEMP_CHECKSUM!"=="" del /F /Q "!TEMP_CHECKSUM!" >nul 2>&1

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -279,6 +279,8 @@ describe('installation scripts', () => {
     const script = readScript(
       'scripts/installation/install-qwen-standalone.bat',
     );
+    const verifyChecksum = readBatchRoutine(script, 'VerifyChecksum');
+    const installStandalone = readBatchRoutine(script, 'InstallStandalone');
 
     expect(script).toContain('--method METHOD');
     expect(script).toContain('--mirror MIRROR');
@@ -290,7 +292,7 @@ describe('installation scripts', () => {
     expect(script).toContain(
       'SHA256SUMS not found at !CHECKSUM_FILE!; cannot verify archive',
     );
-    expect(script).toContain('Get-FileHash -Algorithm SHA256');
+    expect(script).not.toContain('Get-FileHash');
     expect(script).toContain('tokens=1,2');
     expect(script).toContain('CHECKSUM_NAME');
     expect(script).toContain('if "!CHECKSUM_NAME!"=="!ARCHIVE_NAME!"');
@@ -313,6 +315,36 @@ describe('installation scripts', () => {
       'installer options contain unsafe command characters',
     );
     expect(script).not.toContain('-EncodedCommand');
+    expect(verifyChecksum).toContain('[IO.File]::OpenRead');
+    expect(verifyChecksum).toContain(
+      '[Security.Cryptography.SHA256]::Create()',
+    );
+    expect(verifyChecksum).toContain('.ComputeHash($stream)');
+    expect(verifyChecksum).toContain("-cnotmatch '\\A[0-9A-F]{64}\\z'");
+    expect(verifyChecksum).toContain('[Console]::Write($hash)');
+    expect(verifyChecksum).not.toMatch(/ReadAllBytes|ReadToEnd/);
+    expect(verifyChecksum).toContain('call :CreateTempFile "qwen-hash" ".ps1"');
+    expect(verifyChecksum).toContain(
+      'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "!QWEN_HASH_SCRIPT!" > "!QWEN_HASH_OUTPUT!"',
+    );
+    expect(verifyChecksum.indexOf('finally')).toBeGreaterThan(-1);
+    expect(verifyChecksum.indexOf('$stream.Dispose()')).toBeLessThan(
+      verifyChecksum.indexOf('$sha256.Dispose()'),
+    );
+    expect(
+      verifyChecksum.indexOf('echo [Console]::Write($hash)'),
+    ).toBeGreaterThan(verifyChecksum.indexOf('finally'));
+    expect(verifyChecksum).toContain('del /F /Q "!QWEN_HASH_SCRIPT!"');
+    expect(verifyChecksum).toContain('del /F /Q "!QWEN_HASH_OUTPUT!"');
+
+    const verifyIndex = installStandalone.indexOf('call :VerifyChecksum');
+    const validateIndex = installStandalone.indexOf(
+      'call :ValidateArchiveContents',
+    );
+    const extractIndex = installStandalone.indexOf('Expand-Archive');
+    expect(verifyIndex).toBeGreaterThan(-1);
+    expect(validateIndex).toBeGreaterThan(verifyIndex);
+    expect(extractIndex).toBeGreaterThan(validateIndex);
     expect(script).toContain('QWEN_VALIDATE_OPTIONS_SCRIPT');
     expect(script).toContain('$unsafe = [char[]](10,13,33,34');
     expect(script).toContain(
@@ -456,23 +488,25 @@ describe('installation scripts', () => {
     }
   });
 
-  it('injects Windows processor overrides directly into cmd commands', () => {
+  it('injects Windows command overrides case-insensitively', () => {
     const prepared = prepareWindowsCommand(
       'call "C:\\tools\\install-qwen-standalone.bat"',
       {
         Path: 'C:\\fake-bin',
         PROCESSOR_ARCHITECTURE: 'AMD64',
         PROCESSOR_ARCHITEW6432: '',
+        PSModulePath: 'C:\\PowerShell\\7\\Modules',
       },
       {
         Path: 'C:\\Windows\\System32',
         processor_architecture: 'ARM64',
         PROCESSOR_ARCHITEW6432: 'ARM64',
+        psmodulepath: 'C:\\WindowsPowerShell\\Modules',
       },
     );
 
     expect(prepared.command).toBe(
-      'set "PROCESSOR_ARCHITECTURE=AMD64" && set "PROCESSOR_ARCHITEW6432=" && call "C:\\tools\\install-qwen-standalone.bat"',
+      'set "PROCESSOR_ARCHITECTURE=AMD64" && set "PROCESSOR_ARCHITEW6432=" && set "PSModulePath=C:\\PowerShell\\7\\Modules" && call "C:\\tools\\install-qwen-standalone.bat"',
     );
     expect(prepared.env).toEqual({ Path: 'C:\\fake-bin' });
   });
@@ -3891,9 +3925,9 @@ describe('Linux/macOS installer end-to-end', { timeout: 15000 }, () => {
   });
 });
 
-// Windows runners are slower at spawning cmd.exe + node.exe, so the
-// default 5s vitest timeout is too tight for these end-to-end installs.
-describe('Windows installer end-to-end', { timeout: 30000 }, () => {
+// Windows runners are slower at spawning cmd.exe, powershell.exe, and
+// node.exe, so the default 5s vitest timeout is too tight for these E2E tests.
+describe('Windows installer end-to-end', { timeout: 60_000 }, () => {
   itOnWindows(
     'installs a local standalone archive with checksum verification',
     () => {
@@ -3928,20 +3962,216 @@ describe('Windows installer end-to-end', { timeout: 30000 }, () => {
     },
   );
 
+  itOnWindows(
+    '#7118 installs when Windows PowerShell cannot resolve Get-FileHash',
+    ({ skip }) => {
+      const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
+
+      try {
+        const nativeModulePath = getNativeWindowsPowerShellModulePath();
+        const powerShell7ModuleRoot = findPowerShell7ModuleRoot();
+        if (!powerShell7ModuleRoot) {
+          skip('PowerShell 7 modules are unavailable on this Windows host.');
+          return;
+        }
+
+        const probeFile = path.join(tmpDir, 'hash-probe.txt');
+        writeFileSync(probeFile, 'qwen-code #7118 regression probe\n');
+        const expectedProbeHash = crypto
+          .createHash('sha256')
+          .update(readFileSync(probeFile))
+          .digest('hex')
+          .toUpperCase();
+        const candidates = uniqueCaseInsensitive([
+          [powerShell7ModuleRoot, nativeModulePath].join(path.delimiter),
+          powerShell7ModuleRoot,
+        ]);
+        const rejectedCandidates = [];
+        let acceptedModulePath = null;
+
+        for (const candidate of candidates) {
+          const probeEnv = {
+            PSModulePath: candidate,
+            QWEN_HASH_PROBE_FILE: probeFile,
+          };
+          const getFileHashProbe = runWindowsPowerShellProbe(
+            "$command = Get-Command 'Get-FileHash' -ErrorAction SilentlyContinue; if ($null -eq $command) { [Console]::Write('absent') } else { [Console]::Write('present') }",
+            probeEnv,
+          );
+          assertProbeCompleted(getFileHashProbe, 'Get-FileHash');
+          const getFileHashState = getFileHashProbe.stdout.trim();
+          if (!['absent', 'present'].includes(getFileHashState)) {
+            throw new Error(
+              `Malformed Get-FileHash probe output: ${getFileHashState}`,
+            );
+          }
+          if (getFileHashState !== 'absent') {
+            rejectedCandidates.push(
+              `${candidate}: Get-FileHash remained available`,
+            );
+            continue;
+          }
+
+          const hashProbe = runWindowsPowerShellProbe(
+            "$stream = [IO.File]::OpenRead($env:QWEN_HASH_PROBE_FILE); try { $sha = [Security.Cryptography.SHA256]::Create(); try { [Console]::Write([BitConverter]::ToString($sha.ComputeHash($stream)).Replace('-', '')) } finally { if ($null -ne $sha) { $sha.Dispose() } } } finally { $stream.Dispose() }",
+            probeEnv,
+          );
+          assertProbeCompleted(hashProbe, 'direct .NET SHA-256');
+          if (hashProbe.status !== 0) {
+            rejectedCandidates.push(
+              `${candidate}: direct .NET SHA-256 was unavailable`,
+            );
+            continue;
+          }
+          const actualProbeHash = hashProbe.stdout.trim();
+          if (!/^[0-9A-F]{64}$/.test(actualProbeHash)) {
+            throw new Error(
+              `Malformed direct .NET SHA-256 probe output: ${actualProbeHash}`,
+            );
+          }
+          expect(actualProbeHash).toBe(expectedProbeHash);
+
+          const commandProbe = runWindowsPowerShellProbe(
+            `Get-Command ${WINDOWS_INSTALLER_POWERSHELL_COMMANDS.map((command) => `'${command}'`).join(',')} -ErrorAction Stop | Out-Null`,
+            probeEnv,
+          );
+          assertProbeCompleted(commandProbe, 'installer PowerShell commands');
+          if (commandProbe.status !== 0) {
+            const missingCommands = [];
+            for (const command of WINDOWS_INSTALLER_POWERSHELL_COMMANDS) {
+              const commandProbe = runWindowsPowerShellProbe(
+                `Get-Command '${command}' -ErrorAction Stop | Out-Null`,
+                probeEnv,
+              );
+              assertProbeCompleted(commandProbe, command);
+              if (commandProbe.status !== 0) missingCommands.push(command);
+            }
+            rejectedCandidates.push(
+              `${candidate}: missing ${missingCommands.join(', ')}`,
+            );
+            continue;
+          }
+
+          acceptedModulePath = candidate;
+          break;
+        }
+
+        if (!acceptedModulePath) {
+          skip(
+            `No PowerShell 7-first module path reproduced #7118 while preserving installer prerequisites. ${rejectedCandidates.join('; ')}`,
+          );
+          return;
+        }
+
+        const archive = createFakeWindowsStandaloneArchive(tmpDir);
+        const installRoot = path.join(tmpDir, 'install');
+        const home = path.join(tmpDir, 'home');
+        const output = runWindowsInstaller(
+          archive,
+          installRoot,
+          home,
+          'standalone',
+          { PSModulePath: acceptedModulePath },
+        ).toString();
+
+        expect(output).not.toMatch(
+          /Could not calculate SHA-256|SHA-256 calculation failed|Get-FileHash/,
+        );
+        expect(existsSync(path.join(installRoot, 'bin', 'qwen.cmd'))).toBe(
+          true,
+        );
+        expect(
+          existsSync(path.join(installRoot, 'qwen-code', 'node', 'node.exe')),
+        ).toBe(true);
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   itOnWindows('rejects a tampered local archive', () => {
     const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
 
     try {
       const archive = createFakeWindowsStandaloneArchive(tmpDir);
+      const installRoot = path.join(tmpDir, 'install');
+      const home = path.join(tmpDir, 'home');
       appendFileSync(archive, 'tamper');
 
-      expect(() =>
-        runWindowsInstaller(
-          archive,
-          path.join(tmpDir, 'install'),
-          path.join(tmpDir, 'home'),
-        ),
-      ).toThrow(/Checksum mismatch/);
+      expect(() => runWindowsInstaller(archive, installRoot, home)).toThrow(
+        /Checksum mismatch/,
+      );
+      expectNoStandaloneInstallSideEffects(installRoot, home);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnWindows('rejects a local archive when SHA256SUMS is missing', () => {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
+
+    try {
+      const archive = createFakeWindowsStandaloneArchive(tmpDir);
+      const installRoot = path.join(tmpDir, 'install');
+      const home = path.join(tmpDir, 'home');
+      rmSync(path.join(path.dirname(archive), 'SHA256SUMS'));
+
+      expect(() => runWindowsInstaller(archive, installRoot, home)).toThrow(
+        /SHA256SUMS not found/,
+      );
+      expectNoStandaloneInstallSideEffects(installRoot, home);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnWindows('rejects a local archive missing its checksum entry', () => {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
+
+    try {
+      const archive = createFakeWindowsStandaloneArchive(tmpDir);
+      const installRoot = path.join(tmpDir, 'install');
+      const home = path.join(tmpDir, 'home');
+      writeFileSync(
+        path.join(path.dirname(archive), 'SHA256SUMS'),
+        `${'0'.repeat(64)}  another-archive.zip\n`,
+      );
+
+      expect(() => runWindowsInstaller(archive, installRoot, home)).toThrow(
+        /Checksum entry for qwen-code-win-x64\.zip not found/,
+      );
+      expectNoStandaloneInstallSideEffects(installRoot, home);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  itOnWindows('reports an underlying checksum calculation error', () => {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
+
+    try {
+      const archive = path.join(tmpDir, 'qwen-code-win-x64.zip');
+      const installRoot = path.join(tmpDir, 'install');
+      const home = path.join(tmpDir, 'home');
+      mkdirSync(archive);
+      writeFileSync(
+        path.join(tmpDir, 'SHA256SUMS'),
+        `${'0'.repeat(64)}  ${path.basename(archive)}\n`,
+      );
+
+      const failureMessage = captureFailure(() =>
+        runWindowsInstaller(archive, installRoot, home),
+      );
+      expect(failureMessage).toContain(
+        'ERROR: Could not calculate SHA-256 checksum for archive.',
+      );
+      expect(failureMessage).toMatch(/SHA-256 calculation failed: .+/);
+      expect(failureMessage).not.toContain('Checksum mismatch');
+      expect(failureMessage).not.toContain('Failed to inspect archive');
+      expect(failureMessage).not.toContain(
+        'Failed to extract standalone archive',
+      );
+      expectNoStandaloneInstallSideEffects(installRoot, home);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -4726,6 +4956,128 @@ function runWindowsCommand(command, env = {}) {
   }
 }
 
+function spawnWindowsCommand(command, env = {}, baseEnv = process.env) {
+  const prepared = prepareWindowsCommand(command, env, baseEnv);
+  return spawnSync(
+    process.env.ComSpec || 'cmd.exe',
+    ['/d', '/c', prepared.command],
+    {
+      env: prepared.env,
+      encoding: 'utf8',
+      stdio: 'pipe',
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    },
+  );
+}
+
+function runWindowsPowerShellProbe(script, env = {}) {
+  return spawnWindowsCommand(
+    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "${script}"`,
+    env,
+  );
+}
+
+function assertProbeCompleted(result, name) {
+  if (result.error) {
+    throw new Error(`${name} probe failed to start: ${result.error.message}`);
+  }
+  if (result.status === null) {
+    throw new Error(`${name} probe ended without an exit status.`);
+  }
+}
+
+function getNativeWindowsPowerShellModulePath() {
+  const result = spawnSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      '[Console]::Write($env:PSModulePath)',
+    ],
+    {
+      env: withoutEnvironmentKey(process.env, 'PSModulePath'),
+      encoding: 'utf8',
+      stdio: 'pipe',
+      windowsHide: true,
+    },
+  );
+  assertProbeCompleted(result, 'native Windows PowerShell module path');
+  if (result.status !== 0) {
+    throw new Error(
+      `Native Windows PowerShell module-path probe failed: ${result.stderr.trim()}`,
+    );
+  }
+
+  const modulePath = result.stdout.trim();
+  const entries = modulePath.split(path.delimiter).filter(Boolean);
+  if (
+    !modulePath ||
+    /[\r\n]/.test(modulePath) ||
+    entries.length === 0 ||
+    entries.some((entry) => !path.isAbsolute(entry))
+  ) {
+    throw new Error(
+      `Native Windows PowerShell returned a malformed module path: ${modulePath}`,
+    );
+  }
+  return modulePath;
+}
+
+function findPowerShell7ModuleRoot() {
+  const result = spawnSync(
+    'pwsh.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      "[Console]::Write((Join-Path $PSHOME 'Modules'))",
+    ],
+    { encoding: 'utf8', stdio: 'pipe', windowsHide: true },
+  );
+  if (result.error && result.error.code !== 'ENOENT') {
+    throw new Error(
+      `PowerShell 7 module-path probe failed to start: ${result.error.message}`,
+    );
+  }
+  if (!result.error) {
+    assertProbeCompleted(result, 'PowerShell 7 module path');
+    if (result.status !== 0) {
+      throw new Error(
+        `PowerShell 7 module-path probe failed: ${result.stderr.trim()}`,
+      );
+    }
+    const moduleRoot = result.stdout.trim();
+    if (
+      !moduleRoot ||
+      /[\r\n]/.test(moduleRoot) ||
+      !path.isAbsolute(moduleRoot) ||
+      !existsSync(moduleRoot) ||
+      !lstatSync(moduleRoot).isDirectory()
+    ) {
+      throw new Error(
+        `PowerShell 7 returned a malformed module root: ${moduleRoot}`,
+      );
+    }
+    return moduleRoot;
+  }
+
+  const programFiles = uniqueCaseInsensitive(
+    ['ProgramW6432', 'ProgramFiles']
+      .map((key) => getEnvironmentValue(process.env, key))
+      .filter(Boolean),
+  );
+  return (
+    programFiles
+      .map((root) => path.join(root, 'PowerShell', '7', 'Modules'))
+      .find(
+        (moduleRoot) =>
+          existsSync(moduleRoot) && lstatSync(moduleRoot).isDirectory(),
+      ) || null
+  );
+}
+
 function runWindowsPowerShellScript(scriptPath, args = [], env = {}) {
   try {
     return execFileSync(
@@ -4761,6 +5113,25 @@ function runWindowsPowerShellScript(scriptPath, args = [], env = {}) {
 const WINDOWS_COMMAND_ENV_OVERRIDES = [
   'PROCESSOR_ARCHITECTURE',
   'PROCESSOR_ARCHITEW6432',
+  'PSModulePath',
+];
+
+const WINDOWS_INSTALLER_POWERSHELL_COMMANDS = [
+  'Write-Host',
+  'Select-Object',
+  'Invoke-WebRequest',
+  'Add-Type',
+  'ConvertFrom-Json',
+  'Get-Date',
+  'Expand-Archive',
+  'Test-Path',
+  'New-Item',
+  'Join-Path',
+  'Get-Content',
+  'Get-ChildItem',
+  'Get-Command',
+  'Where-Object',
+  'Out-Null',
 ];
 
 function prepareWindowsCommand(command, env = {}, baseEnv = process.env) {
@@ -4784,6 +5155,72 @@ function prepareWindowsCommand(command, env = {}, baseEnv = process.env) {
     command: [...commandPrefix, command].join(' && '),
     env: commandEnv,
   };
+}
+
+function withoutEnvironmentKey(baseEnv, key) {
+  const env = { ...baseEnv };
+  for (const existingKey of Object.keys(env)) {
+    if (existingKey.toLowerCase() === key.toLowerCase()) {
+      delete env[existingKey];
+    }
+  }
+  return env;
+}
+
+function getEnvironmentValue(env, key) {
+  const match = Object.keys(env).find(
+    (existingKey) => existingKey.toLowerCase() === key.toLowerCase(),
+  );
+  return match ? env[match] : undefined;
+}
+
+function uniqueCaseInsensitive(values) {
+  const seen = new Set();
+  return values.filter((value) => {
+    const normalized = value.toLowerCase();
+    if (seen.has(normalized)) return false;
+    seen.add(normalized);
+    return true;
+  });
+}
+
+function captureFailure(action) {
+  try {
+    action();
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error('Expected command to fail.');
+}
+
+function expectNoStandaloneInstallSideEffects(installRoot, home) {
+  const installDir = path.join(installRoot, 'qwen-code');
+  const wrapper = path.join(installRoot, 'bin', 'qwen.cmd');
+  const unexpectedPaths = [
+    installDir,
+    `${installDir}.new`,
+    `${installDir}.old`,
+    wrapper,
+    `${wrapper}.new`,
+    path.join(installDir, 'bin', 'qwen.cmd'),
+    path.join(installDir, 'node', 'node.exe'),
+    path.join(home, '.qwen', 'source.json'),
+  ];
+  for (const unexpectedPath of unexpectedPaths) {
+    expect(existsSync(unexpectedPath), unexpectedPath).toBe(false);
+  }
+}
+
+function readBatchRoutine(script, label) {
+  const normalized = script.replaceAll('\r\n', '\n');
+  const marker = `:${label}\n`;
+  const labelMatch = new RegExp(`(?:^|\\n)${marker}`).exec(normalized);
+  if (!labelMatch) throw new Error(`Batch label not found: ${label}`);
+  const start = labelMatch.index + (labelMatch[0].startsWith('\n') ? 1 : 0);
+  const rest = normalized.slice(start + marker.length);
+  const nextLabel = /\n:[A-Za-z0-9_]+\n/.exec(rest);
+  if (!nextLabel) throw new Error(`Next batch label not found after: ${label}`);
+  return normalized.slice(start, start + marker.length + nextLabel.index);
 }
 
 function createSymlinkStandaloneArchive(tmpDir) {

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -327,6 +327,8 @@ describe('installation scripts', () => {
       'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command',
     );
     expect(verifyChecksum.indexOf('finally')).toBeGreaterThan(-1);
+    expect(verifyChecksum).toContain('$stream.Dispose()');
+    expect(verifyChecksum).toContain('$sha256.Dispose()');
     expect(verifyChecksum.indexOf('$stream.Dispose()')).toBeLessThan(
       verifyChecksum.indexOf('$sha256.Dispose()'),
     );

--- a/scripts/tests/install-script.test.js
+++ b/scripts/tests/install-script.test.js
@@ -280,7 +280,6 @@ describe('installation scripts', () => {
       'scripts/installation/install-qwen-standalone.bat',
     );
     const verifyChecksum = readBatchRoutine(script, 'VerifyChecksum');
-    const installStandalone = readBatchRoutine(script, 'InstallStandalone');
 
     expect(script).toContain('--method METHOD');
     expect(script).toContain('--mirror MIRROR');
@@ -322,29 +321,16 @@ describe('installation scripts', () => {
     expect(verifyChecksum).toContain('.ComputeHash($stream)');
     expect(verifyChecksum).toContain("-cnotmatch '\\A[0-9A-F]{64}\\z'");
     expect(verifyChecksum).toContain('[Console]::Write($hash)');
+    expect(verifyChecksum).toContain('SHA-256 calculation failed: ');
     expect(verifyChecksum).not.toMatch(/ReadAllBytes|ReadToEnd/);
-    expect(verifyChecksum).toContain('call :CreateTempFile "qwen-hash" ".ps1"');
     expect(verifyChecksum).toContain(
-      'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "!QWEN_HASH_SCRIPT!" > "!QWEN_HASH_OUTPUT!"',
+      'powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command',
     );
     expect(verifyChecksum.indexOf('finally')).toBeGreaterThan(-1);
     expect(verifyChecksum.indexOf('$stream.Dispose()')).toBeLessThan(
       verifyChecksum.indexOf('$sha256.Dispose()'),
     );
-    expect(
-      verifyChecksum.indexOf('echo [Console]::Write($hash)'),
-    ).toBeGreaterThan(verifyChecksum.indexOf('finally'));
-    expect(verifyChecksum).toContain('del /F /Q "!QWEN_HASH_SCRIPT!"');
-    expect(verifyChecksum).toContain('del /F /Q "!QWEN_HASH_OUTPUT!"');
-
-    const verifyIndex = installStandalone.indexOf('call :VerifyChecksum');
-    const validateIndex = installStandalone.indexOf(
-      'call :ValidateArchiveContents',
-    );
-    const extractIndex = installStandalone.indexOf('Expand-Archive');
-    expect(verifyIndex).toBeGreaterThan(-1);
-    expect(validateIndex).toBeGreaterThan(verifyIndex);
-    expect(extractIndex).toBeGreaterThan(validateIndex);
+    expect(verifyChecksum).not.toContain('2^>nul');
     expect(script).toContain('QWEN_VALIDATE_OPTIONS_SCRIPT');
     expect(script).toContain('$unsafe = [char[]](10,13,33,34');
     expect(script).toContain(
@@ -3968,97 +3954,47 @@ describe('Windows installer end-to-end', { timeout: 60_000 }, () => {
       const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
 
       try {
-        const nativeModulePath = getNativeWindowsPowerShellModulePath();
-        const powerShell7ModuleRoot = findPowerShell7ModuleRoot();
-        if (!powerShell7ModuleRoot) {
+        const programFiles =
+          process.env.ProgramW6432 || process.env.ProgramFiles;
+        const systemRoot = process.env.SystemRoot;
+        const userProfile = process.env.USERPROFILE;
+        if (!programFiles || !systemRoot || !userProfile) {
+          throw new Error('Windows environment paths are unavailable.');
+        }
+
+        const powerShell7ModuleRoot = path.join(
+          programFiles,
+          'PowerShell',
+          '7',
+          'Modules',
+        );
+        if (!existsSync(powerShell7ModuleRoot)) {
           skip('PowerShell 7 modules are unavailable on this Windows host.');
           return;
         }
 
-        const probeFile = path.join(tmpDir, 'hash-probe.txt');
-        writeFileSync(probeFile, 'qwen-code #7118 regression probe\n');
-        const expectedProbeHash = crypto
-          .createHash('sha256')
-          .update(readFileSync(probeFile))
-          .digest('hex')
-          .toUpperCase();
-        const candidates = uniqueCaseInsensitive([
-          [powerShell7ModuleRoot, nativeModulePath].join(path.delimiter),
+        const modulePath = [
           powerShell7ModuleRoot,
-        ]);
-        const rejectedCandidates = [];
-        let acceptedModulePath = null;
-
-        for (const candidate of candidates) {
-          const probeEnv = {
-            PSModulePath: candidate,
-            QWEN_HASH_PROBE_FILE: probeFile,
-          };
-          const getFileHashProbe = runWindowsPowerShellProbe(
-            "$command = Get-Command 'Get-FileHash' -ErrorAction SilentlyContinue; if ($null -eq $command) { [Console]::Write('absent') } else { [Console]::Write('present') }",
-            probeEnv,
-          );
-          assertProbeCompleted(getFileHashProbe, 'Get-FileHash');
-          const getFileHashState = getFileHashProbe.stdout.trim();
-          if (!['absent', 'present'].includes(getFileHashState)) {
-            throw new Error(
-              `Malformed Get-FileHash probe output: ${getFileHashState}`,
-            );
-          }
-          if (getFileHashState !== 'absent') {
-            rejectedCandidates.push(
-              `${candidate}: Get-FileHash remained available`,
-            );
-            continue;
-          }
-
-          const hashProbe = runWindowsPowerShellProbe(
-            "$stream = [IO.File]::OpenRead($env:QWEN_HASH_PROBE_FILE); try { $sha = [Security.Cryptography.SHA256]::Create(); try { [Console]::Write([BitConverter]::ToString($sha.ComputeHash($stream)).Replace('-', '')) } finally { if ($null -ne $sha) { $sha.Dispose() } } } finally { $stream.Dispose() }",
-            probeEnv,
-          );
-          assertProbeCompleted(hashProbe, 'direct .NET SHA-256');
-          if (hashProbe.status !== 0) {
-            rejectedCandidates.push(
-              `${candidate}: direct .NET SHA-256 was unavailable`,
-            );
-            continue;
-          }
-          const actualProbeHash = hashProbe.stdout.trim();
-          if (!/^[0-9A-F]{64}$/.test(actualProbeHash)) {
-            throw new Error(
-              `Malformed direct .NET SHA-256 probe output: ${actualProbeHash}`,
-            );
-          }
-          expect(actualProbeHash).toBe(expectedProbeHash);
-
-          const commandProbe = runWindowsPowerShellProbe(
-            `Get-Command ${WINDOWS_INSTALLER_POWERSHELL_COMMANDS.map((command) => `'${command}'`).join(',')} -ErrorAction Stop | Out-Null`,
-            probeEnv,
-          );
-          assertProbeCompleted(commandProbe, 'installer PowerShell commands');
-          if (commandProbe.status !== 0) {
-            const missingCommands = [];
-            for (const command of WINDOWS_INSTALLER_POWERSHELL_COMMANDS) {
-              const commandProbe = runWindowsPowerShellProbe(
-                `Get-Command '${command}' -ErrorAction Stop | Out-Null`,
-                probeEnv,
-              );
-              assertProbeCompleted(commandProbe, command);
-              if (commandProbe.status !== 0) missingCommands.push(command);
-            }
-            rejectedCandidates.push(
-              `${candidate}: missing ${missingCommands.join(', ')}`,
-            );
-            continue;
-          }
-
-          acceptedModulePath = candidate;
-          break;
-        }
-
-        if (!acceptedModulePath) {
+          path.join(userProfile, 'Documents', 'WindowsPowerShell', 'Modules'),
+          path.join(programFiles, 'WindowsPowerShell', 'Modules'),
+          path.join(
+            systemRoot,
+            'system32',
+            'WindowsPowerShell',
+            'v1.0',
+            'Modules',
+          ),
+        ].join(path.delimiter);
+        const getFileHashState = runWindowsCommand(
+          `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$command = Get-Command 'Get-FileHash' -ErrorAction SilentlyContinue; if ($null -eq $command) { [Console]::Write('absent') } else { [Console]::Write('present') }"`,
+          { PSModulePath: modulePath },
+        )
+          .toString()
+          .trim();
+        expect(['absent', 'present']).toContain(getFileHashState);
+        if (getFileHashState === 'present') {
           skip(
-            `No PowerShell 7-first module path reproduced #7118 while preserving installer prerequisites. ${rejectedCandidates.join('; ')}`,
+            'This Windows host does not reproduce #7118 with PowerShell 7 modules first.',
           );
           return;
         }
@@ -4071,7 +4007,7 @@ describe('Windows installer end-to-end', { timeout: 60_000 }, () => {
           installRoot,
           home,
           'standalone',
-          { PSModulePath: acceptedModulePath },
+          { PSModulePath: modulePath },
         ).toString();
 
         expect(output).not.toMatch(
@@ -4100,45 +4036,6 @@ describe('Windows installer end-to-end', { timeout: 60_000 }, () => {
 
       expect(() => runWindowsInstaller(archive, installRoot, home)).toThrow(
         /Checksum mismatch/,
-      );
-      expectNoStandaloneInstallSideEffects(installRoot, home);
-    } finally {
-      rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  itOnWindows('rejects a local archive when SHA256SUMS is missing', () => {
-    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
-
-    try {
-      const archive = createFakeWindowsStandaloneArchive(tmpDir);
-      const installRoot = path.join(tmpDir, 'install');
-      const home = path.join(tmpDir, 'home');
-      rmSync(path.join(path.dirname(archive), 'SHA256SUMS'));
-
-      expect(() => runWindowsInstaller(archive, installRoot, home)).toThrow(
-        /SHA256SUMS not found/,
-      );
-      expectNoStandaloneInstallSideEffects(installRoot, home);
-    } finally {
-      rmSync(tmpDir, { recursive: true, force: true });
-    }
-  });
-
-  itOnWindows('rejects a local archive missing its checksum entry', () => {
-    const tmpDir = mkdtempSync(path.join(tmpdir(), 'qwen-install-test-'));
-
-    try {
-      const archive = createFakeWindowsStandaloneArchive(tmpDir);
-      const installRoot = path.join(tmpDir, 'install');
-      const home = path.join(tmpDir, 'home');
-      writeFileSync(
-        path.join(path.dirname(archive), 'SHA256SUMS'),
-        `${'0'.repeat(64)}  another-archive.zip\n`,
-      );
-
-      expect(() => runWindowsInstaller(archive, installRoot, home)).toThrow(
-        /Checksum entry for qwen-code-win-x64\.zip not found/,
       );
       expectNoStandaloneInstallSideEffects(installRoot, home);
     } finally {
@@ -4956,128 +4853,6 @@ function runWindowsCommand(command, env = {}) {
   }
 }
 
-function spawnWindowsCommand(command, env = {}, baseEnv = process.env) {
-  const prepared = prepareWindowsCommand(command, env, baseEnv);
-  return spawnSync(
-    process.env.ComSpec || 'cmd.exe',
-    ['/d', '/c', prepared.command],
-    {
-      env: prepared.env,
-      encoding: 'utf8',
-      stdio: 'pipe',
-      windowsHide: true,
-      windowsVerbatimArguments: true,
-    },
-  );
-}
-
-function runWindowsPowerShellProbe(script, env = {}) {
-  return spawnWindowsCommand(
-    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "${script}"`,
-    env,
-  );
-}
-
-function assertProbeCompleted(result, name) {
-  if (result.error) {
-    throw new Error(`${name} probe failed to start: ${result.error.message}`);
-  }
-  if (result.status === null) {
-    throw new Error(`${name} probe ended without an exit status.`);
-  }
-}
-
-function getNativeWindowsPowerShellModulePath() {
-  const result = spawnSync(
-    'powershell.exe',
-    [
-      '-NoProfile',
-      '-NonInteractive',
-      '-Command',
-      '[Console]::Write($env:PSModulePath)',
-    ],
-    {
-      env: withoutEnvironmentKey(process.env, 'PSModulePath'),
-      encoding: 'utf8',
-      stdio: 'pipe',
-      windowsHide: true,
-    },
-  );
-  assertProbeCompleted(result, 'native Windows PowerShell module path');
-  if (result.status !== 0) {
-    throw new Error(
-      `Native Windows PowerShell module-path probe failed: ${result.stderr.trim()}`,
-    );
-  }
-
-  const modulePath = result.stdout.trim();
-  const entries = modulePath.split(path.delimiter).filter(Boolean);
-  if (
-    !modulePath ||
-    /[\r\n]/.test(modulePath) ||
-    entries.length === 0 ||
-    entries.some((entry) => !path.isAbsolute(entry))
-  ) {
-    throw new Error(
-      `Native Windows PowerShell returned a malformed module path: ${modulePath}`,
-    );
-  }
-  return modulePath;
-}
-
-function findPowerShell7ModuleRoot() {
-  const result = spawnSync(
-    'pwsh.exe',
-    [
-      '-NoProfile',
-      '-NonInteractive',
-      '-Command',
-      "[Console]::Write((Join-Path $PSHOME 'Modules'))",
-    ],
-    { encoding: 'utf8', stdio: 'pipe', windowsHide: true },
-  );
-  if (result.error && result.error.code !== 'ENOENT') {
-    throw new Error(
-      `PowerShell 7 module-path probe failed to start: ${result.error.message}`,
-    );
-  }
-  if (!result.error) {
-    assertProbeCompleted(result, 'PowerShell 7 module path');
-    if (result.status !== 0) {
-      throw new Error(
-        `PowerShell 7 module-path probe failed: ${result.stderr.trim()}`,
-      );
-    }
-    const moduleRoot = result.stdout.trim();
-    if (
-      !moduleRoot ||
-      /[\r\n]/.test(moduleRoot) ||
-      !path.isAbsolute(moduleRoot) ||
-      !existsSync(moduleRoot) ||
-      !lstatSync(moduleRoot).isDirectory()
-    ) {
-      throw new Error(
-        `PowerShell 7 returned a malformed module root: ${moduleRoot}`,
-      );
-    }
-    return moduleRoot;
-  }
-
-  const programFiles = uniqueCaseInsensitive(
-    ['ProgramW6432', 'ProgramFiles']
-      .map((key) => getEnvironmentValue(process.env, key))
-      .filter(Boolean),
-  );
-  return (
-    programFiles
-      .map((root) => path.join(root, 'PowerShell', '7', 'Modules'))
-      .find(
-        (moduleRoot) =>
-          existsSync(moduleRoot) && lstatSync(moduleRoot).isDirectory(),
-      ) || null
-  );
-}
-
 function runWindowsPowerShellScript(scriptPath, args = [], env = {}) {
   try {
     return execFileSync(
@@ -5116,24 +4891,6 @@ const WINDOWS_COMMAND_ENV_OVERRIDES = [
   'PSModulePath',
 ];
 
-const WINDOWS_INSTALLER_POWERSHELL_COMMANDS = [
-  'Write-Host',
-  'Select-Object',
-  'Invoke-WebRequest',
-  'Add-Type',
-  'ConvertFrom-Json',
-  'Get-Date',
-  'Expand-Archive',
-  'Test-Path',
-  'New-Item',
-  'Join-Path',
-  'Get-Content',
-  'Get-ChildItem',
-  'Get-Command',
-  'Where-Object',
-  'Out-Null',
-];
-
 function prepareWindowsCommand(command, env = {}, baseEnv = process.env) {
   const commandEnv = { ...baseEnv, ...env };
   const commandPrefix = [];
@@ -5155,33 +4912,6 @@ function prepareWindowsCommand(command, env = {}, baseEnv = process.env) {
     command: [...commandPrefix, command].join(' && '),
     env: commandEnv,
   };
-}
-
-function withoutEnvironmentKey(baseEnv, key) {
-  const env = { ...baseEnv };
-  for (const existingKey of Object.keys(env)) {
-    if (existingKey.toLowerCase() === key.toLowerCase()) {
-      delete env[existingKey];
-    }
-  }
-  return env;
-}
-
-function getEnvironmentValue(env, key) {
-  const match = Object.keys(env).find(
-    (existingKey) => existingKey.toLowerCase() === key.toLowerCase(),
-  );
-  return match ? env[match] : undefined;
-}
-
-function uniqueCaseInsensitive(values) {
-  const seen = new Set();
-  return values.filter((value) => {
-    const normalized = value.toLowerCase();
-    if (seen.has(normalized)) return false;
-    seen.add(normalized);
-    return true;
-  });
 }
 
 function captureFailure(action) {


### PR DESCRIPTION
## What this PR does

Replaces `Get-FileHash` in the Windows standalone batch installer with an inline, streaming .NET SHA-256 calculation. The command validates its hash output, disposes the file stream and hash provider, preserves underlying diagnostics, and creates no temporary helper or output files. Regression and checksum failure-path coverage are included.

## Why it's needed

When PowerShell 7 module paths are inherited by the Windows PowerShell process launched by the batch installer, `Get-FileHash` may be unavailable. The installer then fails before archive verification and extraction. Direct .NET hashing removes that module dependency while keeping verification fail-closed.

## Reviewer Test Plan

### How to verify

Run `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/install-script.test.js --pool=threads --poolOptions.threads.singleThread`. The dedicated `#7118` case recreates a PowerShell-7-first module path, confirms `Get-FileHash` is unavailable, and completes a standalone installation. Checksum mismatches and hash-calculation failures must stop before installation side effects.

### Evidence (Before & After)

Before: the reproduced environment failed with `ERROR: Could not calculate SHA-256 checksum for archive.` After: the official README PowerShell entrypoint downloaded and installed the real Windows standalone archive under the same affected environment; Qwen Code 0.21.11 installed successfully.

### Tested on

| OS | Status |
| :---: | :---: |
| 🍏 macOS | N/A |
| 🪟 Windows | ✅ tested |
| 🐧 Linux | N/A |

### Environment (optional)

Windows 10, PowerShell 7.6.3, Windows PowerShell 5.1.26100.9168. Focused installer suite: 87 passed, 34 platform skips.

## Risk & Scope

- Main risk or tradeoff: the inline command requires nested `cmd.exe`/PowerShell quoting; static assertions and Windows end-to-end tests cover the command and its failure paths. It creates no temporary helper or output files.
- Not validated / out of scope: every Windows SKU, native ARM64 host, FIPS/security policy, and third-party PowerShell host.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #7118

<details>
<summary>中文说明</summary>

## 本 PR 的作用

将 Windows 独立安装批处理脚本中的 `Get-FileHash` 替换为内联的 .NET 流式 SHA-256 计算。该命令会验证哈希输出、释放文件流和哈希提供程序、保留底层错误诊断，并且不会创建临时辅助脚本或输出文件。同时补充了回归测试和校验失败路径测试。

## 为什么需要此修改

当批处理安装程序启动的 Windows PowerShell 继承 PowerShell 7 的模块路径时，`Get-FileHash` 可能不可用，导致安装程序在归档校验和解压之前失败。直接使用 .NET 计算哈希可以消除该模块依赖，同时继续保持校验失败即停止安装。

## 审阅者测试计划

### 验证方法

运行 `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/install-script.test.js --pool=threads --poolOptions.threads.singleThread`。专用的 `#7118` 测试会重现 PowerShell 7 模块路径优先的环境，确认 `Get-FileHash` 不可用，并完成独立安装。校验和不匹配或哈希计算失败时，安装程序必须在产生安装副作用之前停止。

### 修改前后证据

修改前：复现环境报错 `ERROR: Could not calculate SHA-256 checksum for archive.`。修改后：官方 README 中的 PowerShell 安装入口在同一受影响环境中成功下载并安装真实的 Windows 独立归档，Qwen Code 0.21.11 安装成功。

### 测试平台

| 操作系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | N/A |
| 🪟 Windows | ✅ 已测试 |
| 🐧 Linux | N/A |

### 环境（可选）

Windows 10、PowerShell 7.6.3、Windows PowerShell 5.1.26100.9168。聚焦安装程序测试套件：87 项通过，34 项因平台原因跳过。

## 风险与范围

- 主要风险或权衡：内联命令需要嵌套的 `cmd.exe`/PowerShell 引号转义；静态断言和 Windows 端到端测试覆盖了该命令及其失败路径。该实现不会创建临时辅助脚本或输出文件。
- 未验证或不在范围内：所有 Windows SKU、原生 ARM64 主机、FIPS/安全策略以及第三方 PowerShell 主机。
- 破坏性变更或迁移说明：无。

## 关联问题

Fixes #7118

</details>