### PR TITLE
fix(telemetry): Address main agent tracing edge cases

### DIFF
--- a/docs/design/telemetry-main-agent-spans-design.md
+++ b/docs/design/telemetry-main-agent-spans-design.md
@@ -35,6 +35,8 @@ The lifecycle deliberately uses terminal state plus idempotent finalization rath
 
 Successful and cancelled GenAI spans leave OpenTelemetry status `UNSET`. Failed spans set status `ERROR`, write a bounded and sanitized status description, and include a low-cardinality `error.type`. This applies to interaction, LLM, tool, tool-execution, hook, and subagent spans.
 
+For headless JSON Schema runs, the missing-output contract belongs to the user-origin `UserQuery` or `Retry` invocation and follows that owner across tool continuations. Automatic Cron, Notification, Teammate, and runtime Goal drain invocations may complete with plain text without being individually mislabeled `structured_output_missing`; the headless runner remains the authority for the session-level final verdict.
+
 ## Compatibility
 
 The longer lifecycle changes `interaction.duration_ms`: it now includes tool execution and approval wait time. Retry and Goal messages create additional interaction spans. CLI interactions remain trace roots, while ACP and daemon interactions continue to honor an explicit inbound parent context.

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -3611,7 +3611,7 @@ describe('runNonInteractive', () => {
 
   it('should exit with error if sendMessageStream throws initially', async () => {
     setupMetricsMock();
-    const apiError = new Error('API connection failed');
+    const apiError = new Error('API connection failed: token=secret');
     mockGeminiClient.sendMessageStream.mockImplementation(() => {
       throw apiError;
     });
@@ -3627,7 +3627,7 @@ describe('runNonInteractive', () => {
 
     expect(endInteractionSpanSpy).toHaveBeenCalledWith('error', {
       promptId: 'prompt-id-4',
-      errorMessage: 'API connection failed',
+      errorMessage: 'headless invocation failed',
       errorType: 'Error',
     });
   });

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1153,6 +1153,15 @@ describe('runNonInteractive', () => {
     setupMetricsMock();
     vi.mocked(mockConfig.getMaxWallTimeSeconds).mockReturnValue(0.01);
     const runAbortController = new AbortController();
+    let interactionOpen = true;
+    getActiveInteractionSpanSpy.mockImplementation(() =>
+      interactionOpen ? interactionSpan : undefined,
+    );
+    endInteractionSpanSpy.mockImplementation((_status, metadata) => {
+      if (metadata?.promptId === 'budget-stream-abort') {
+        interactionOpen = false;
+      }
+    });
     mockGeminiClient.sendMessageStream.mockReturnValueOnce(
       (async function* () {
         yield { type: GeminiEventType.Content, value: 'partial response' };
@@ -1160,7 +1169,17 @@ describe('runNonInteractive', () => {
           await new Promise<void>((_, reject) => {
             runAbortController.signal.addEventListener(
               'abort',
-              () => reject(new Error('stream aborted after budget expiry')),
+              () => {
+                if (
+                  getActiveInteractionSpanSpy('budget-stream-abort') ===
+                  interactionSpan
+                ) {
+                  endInteractionSpanSpy('cancelled', {
+                    promptId: 'budget-stream-abort',
+                  });
+                }
+                reject(new Error('stream aborted after budget expiry'));
+              },
               { once: true },
             );
           });
@@ -3605,6 +3624,12 @@ describe('runNonInteractive', () => {
         'prompt-id-4',
       ),
     ).rejects.toThrow(apiError);
+
+    expect(endInteractionSpanSpy).toHaveBeenCalledWith('error', {
+      promptId: 'prompt-id-4',
+      errorMessage: 'API connection failed',
+      errorType: 'Error',
+    });
   });
 
   it('should not exit if a tool is not found, and should send error back to model', async () => {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -3017,7 +3017,7 @@ export async function runNonInteractive(
             : abortController.signal.aborted
               ? {}
               : {
-                  errorMessage: failureMessage,
+                  errorMessage: 'headless invocation failed',
                   errorType: getErrorType(error),
                 }),
         },

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -763,6 +763,17 @@ export async function runNonInteractive(
       },
       abortController,
     );
+    const stampBudgetAbort = () => {
+      const exceeded = budgetEnforcer.getExceeded();
+      if (!exceeded) return;
+      endActiveInteraction('error', {
+        errorMessage: exceeded.message,
+        errorType: 'run_budget_exceeded',
+      });
+    };
+    abortController.signal.addEventListener('abort', stampBudgetAbort, {
+      once: true,
+    });
     budgetEnforcer.start();
 
     /**
@@ -2991,6 +3002,8 @@ export async function runNonInteractive(
       }
     } catch (error) {
       const budgetExceeded = budgetEnforcer.getExceeded();
+      const failureMessage =
+        error instanceof Error ? error.message : String(error);
       endActiveInteraction(
         budgetExceeded || !abortController.signal.aborted
           ? 'error'
@@ -3004,7 +3017,7 @@ export async function runNonInteractive(
             : abortController.signal.aborted
               ? {}
               : {
-                  errorMessage: 'headless invocation failed',
+                  errorMessage: failureMessage,
                   errorType: getErrorType(error),
                 }),
         },
@@ -3045,9 +3058,7 @@ export async function runNonInteractive(
         ? budgetExceeded.message
         : recoverableCancellation
           ? abortController.signal.reason.message
-          : error instanceof Error
-            ? error.message
-            : String(error);
+          : failureMessage;
       const metrics = uiTelemetryService.getMetrics();
       const usage = computeUsageFromMetrics(metrics);
       // Get stats for JSON format output
@@ -3134,6 +3145,7 @@ export async function runNonInteractive(
       // run completes — important for callers (e.g. the `qwen serve`
       // daemon, SDK) that reuse a single process across many runs.
       budgetEnforcer.stop();
+      abortController.signal.removeEventListener('abort', stampBudgetAbort);
 
       const reg = config.getBackgroundTaskRegistry();
       reg.setNotificationCallback(undefined);

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1867,9 +1867,62 @@ describe('AppContainer State Management', () => {
         '/btw quick side question',
         SendMessageType.UserQuery,
         undefined,
-        { submittedPrompt: '/btw quick side question' },
+        expect.objectContaining({
+          submittedPrompt: '/btw quick side question',
+          onAdmissionFailed: expect.any(Function),
+        }),
       );
       expect(mockQueueMessage).not.toHaveBeenCalled();
+    });
+
+    it('queues a responding ?btw submission when concurrent admission fails', () => {
+      const mockSubmitQuery = vi.fn();
+      const mockQueueMessage = vi.fn();
+
+      mockedUseGeminiStream.mockReturnValue({
+        streamingState: 'responding',
+        submitQuery: mockSubmitQuery,
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        removeGoalTurns: vi.fn().mockReturnValue([]),
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+        popNextTurn: vi.fn().mockReturnValue(null),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      capturedUIActions.handleFinalSubmit('?btw wait for the tool', {
+        submittedPrompt: '?btw wait for the tool',
+      });
+      const metadata = mockSubmitQuery.mock.calls[0]?.[3] as
+        | { onAdmissionFailed?: () => void }
+        | undefined;
+      metadata?.onAdmissionFailed?.();
+
+      expect(mockQueueMessage).toHaveBeenCalledWith(
+        '?btw wait for the tool',
+        true,
+        '?btw wait for the tool',
+      );
     });
 
     it('runs opted-in slash commands outside the active turn while responding', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2600,12 +2600,12 @@ export const AppContainer = (props: AppContainerProps) => {
         isBtwCommand(submittedValue)
       ) {
         void Promise.resolve(
-          submitQuery(
-            submittedValue,
-            SendMessageType.UserQuery,
-            undefined,
-            submittedPrompt === undefined ? undefined : { submittedPrompt },
-          ),
+          submitQuery(submittedValue, SendMessageType.UserQuery, undefined, {
+            ...(submittedPrompt === undefined ? {} : { submittedPrompt }),
+            onAdmissionFailed: () => {
+              addMessage(submittedValue, true, submittedPrompt);
+            },
+          }),
         ).catch((error) => {
           debugLogger.warn('Failed to admit /btw submission', error);
         });

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -12940,6 +12940,85 @@ describe('useGeminiStream', () => {
       }
     });
 
+    it('stays responding when a newer turn finishes before a surviving ?btw stream', async () => {
+      let resolveMain!: () => void;
+      let resolveBtw!: () => void;
+      const mainPending = new Promise<void>((resolve) => {
+        resolveMain = resolve;
+      });
+      const btwPending = new Promise<void>((resolve) => {
+        resolveBtw = resolve;
+      });
+      let callCount = 0;
+      mockSendMessageStream.mockImplementation((_query, signal) => {
+        callCount += 1;
+        if (callCount === 1) {
+          return (async function* () {
+            await mainPending;
+            if (signal.aborted) {
+              yield { type: ServerGeminiEventType.UserCancelled };
+            }
+          })();
+        }
+        if (callCount === 2) {
+          return (async function* () {
+            await btwPending;
+            yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+          })();
+        }
+        return (async function* () {
+          yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+        })();
+      });
+
+      const { result } = renderTestHook();
+      let mainRequest!: Promise<void>;
+      let btwRequest!: Promise<void>;
+      await act(async () => {
+        mainRequest = result.current.submitQuery('Main query');
+      });
+      await waitFor(() =>
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(1),
+      );
+      await act(async () => {
+        btwRequest = result.current.submitQuery('?btw side question');
+      });
+      await waitFor(() =>
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(2),
+      );
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+        resolveMain();
+      });
+      await act(async () => {
+        await mainRequest;
+      });
+      await waitFor(() =>
+        expect(result.current.streamingState).toBe(StreamingState.Idle),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery('Replacement query');
+      });
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
+      expect(result.current.streamingState).toBe(StreamingState.Responding);
+      await act(async () => {
+        await result.current.submitQuery('Must remain blocked');
+      });
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
+
+      act(() => {
+        resolveBtw();
+      });
+      await act(async () => {
+        await btwRequest;
+      });
+      await waitFor(() =>
+        expect(result.current.streamingState).toBe(StreamingState.Idle),
+      );
+    });
+
     it('continues a deferred main tool batch without leaking its mixed ?btw owner', async () => {
       const mainOwner = {};
       const btwOwner = {};

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2973,6 +2973,70 @@ describe('useGeminiStream', () => {
     );
   });
 
+  it('does not expose the main steer queue to detached tool continuations', async () => {
+    const drainSteer = vi
+      .fn<() => string[]>()
+      .mockReturnValue(['keep this follow-up on the main turn']);
+    mockSendMessageStream.mockImplementation(() => (async function* () {})());
+    const detachedController = new AbortController();
+
+    const { result } = renderHook(() =>
+      useGeminiStream(
+        new MockedGeminiClientClass(mockConfig),
+        [],
+        mockAddItem,
+        mockConfig,
+        true,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+        { current: drainSteer },
+      ),
+    );
+
+    await act(async () => {
+      await result.current.submitQuery(
+        [
+          {
+            functionResponse: {
+              id: 'detached-tool',
+              name: 'testTool',
+              response: { output: 'done' },
+            },
+          },
+        ],
+        SendMessageType.ToolResult,
+        'prompt-id-detached',
+        {
+          toolContinuationOwner: {
+            promptId: 'prompt-id-detached',
+            signal: detachedController.signal,
+            survivesGenerationChange: true,
+            detachedAbortController: detachedController,
+          },
+        },
+      );
+    });
+
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    const sendOptions = mockSendMessageStream.mock.calls[0][3] as {
+      getSteerInput?: (signal: AbortSignal) => Promise<SteerInput | undefined>;
+    };
+    expect(sendOptions.getSteerInput).toBeUndefined();
+    expect(drainSteer).not.toHaveBeenCalled();
+  });
+
   it('processes queued /goal clear at the next sampling boundary', async () => {
     const goalCommand = '/goal clear';
     const restoreSteer = vi.fn();

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -8946,7 +8946,7 @@ describe('useGeminiStream', () => {
       };
       mockHandleSlashCommand.mockResolvedValue(clientToolRequest);
 
-      const { result } = renderTestHook();
+      const { result, rerender, client } = renderTestHook();
 
       await act(async () => {
         await result.current.submitQuery('/save-test-fact "test fact"');
@@ -8965,6 +8965,42 @@ describe('useGeminiStream', () => {
         );
         expect(mockSendMessageStream).not.toHaveBeenCalled();
       });
+
+      const scheduledRequest = mockScheduleToolCalls.mock.calls[0]?.[0]?.[0];
+      const scheduledSignal = mockScheduleToolCalls.mock.calls[0]?.[1] as
+        | AbortSignal
+        | undefined;
+      rerender({
+        client,
+        history: [],
+        addItem: mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+        config: mockConfig,
+        onDebugMessage: mockOnDebugMessage,
+        handleSlashCommand: mockHandleSlashCommand as unknown as (
+          cmd: PartListUnion,
+        ) => Promise<SlashCommandProcessorResult | false>,
+        shellModeActive: false,
+        loadedSettings: mockLoadedSettings,
+        toolCalls: [
+          {
+            request: scheduledRequest,
+            status: 'executing',
+            responseSubmittedToGemini: false,
+            tool: { displayName: 'Save Memory' },
+            invocation: {
+              getDescription: () => 'Saving memory',
+            } as unknown as AnyToolInvocation,
+          } as TrackedExecutingToolCall,
+        ],
+      });
+      await waitFor(() =>
+        expect(result.current.streamingState).toBe(StreamingState.Responding),
+      );
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+      expect(scheduledSignal?.aborted).toBe(true);
     });
 
     it('should stop processing and not call Gemini when a command is handled without a tool call', async () => {
@@ -12949,7 +12985,12 @@ describe('useGeminiStream', () => {
       const btwPending = new Promise<void>((resolve) => {
         resolveBtw = resolve;
       });
+      let resolveContinuation!: () => void;
+      const continuationPending = new Promise<void>((resolve) => {
+        resolveContinuation = resolve;
+      });
       let mainSignal: AbortSignal | undefined;
+      let continuationSignal: AbortSignal | undefined;
       let mainPromptId: string | undefined;
       let btwPromptId: string | undefined;
       let callCount = 0;
@@ -12992,8 +13033,12 @@ describe('useGeminiStream', () => {
           expect(options).toEqual(
             expect.objectContaining({ type: SendMessageType.ToolResult }),
           );
+          continuationSignal = signal;
           return (async function* () {
-            yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+            await continuationPending;
+            yield signal.aborted
+              ? { type: ServerGeminiEventType.UserCancelled }
+              : { type: ServerGeminiEventType.Finished, value: 'STOP' };
           })();
         },
       );
@@ -13078,9 +13123,19 @@ describe('useGeminiStream', () => {
       act(() => {
         resolveBtw();
       });
+      await waitFor(() => expect(continuationSignal).toBeDefined());
+
+      expect(continuationSignal?.aborted).toBe(false);
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+      expect(continuationSignal?.aborted).toBe(true);
+
+      act(() => {
+        resolveContinuation();
+      });
       await act(async () => {
-        await btwRequest;
-        await btwCompletion;
+        await Promise.all([btwRequest, btwCompletion]);
       });
 
       expect(mockFinalizeToolResponses).toHaveBeenCalled();
@@ -13096,6 +13151,130 @@ describe('useGeminiStream', () => {
       ).not.toContain('main-tool');
     });
 
+    it('releases a detached ?btw controller after history repair deduplicates its tool', async () => {
+      let resolveMain!: () => void;
+      let resolveBtw!: () => void;
+      const mainPending = new Promise<void>((resolve) => {
+        resolveMain = resolve;
+      });
+      const btwPending = new Promise<void>((resolve) => {
+        resolveBtw = resolve;
+      });
+      let mainSignal: AbortSignal | undefined;
+      let btwSignal: AbortSignal | undefined;
+      let btwPromptId: string | undefined;
+      let callCount = 0;
+      mockSendMessageStream.mockImplementation((_query, signal, promptId) => {
+        callCount += 1;
+        if (callCount === 1) {
+          mainSignal = signal;
+          return (async function* () {
+            await mainPending;
+            if (signal.aborted) {
+              yield { type: ServerGeminiEventType.UserCancelled };
+            }
+          })();
+        }
+        btwSignal = signal;
+        btwPromptId = promptId;
+        return (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'repaired-btw-tool',
+              name: 'testTool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: promptId,
+            },
+          };
+          await btwPending;
+        })();
+      });
+
+      const { result, client } = renderTestHook();
+      let mainRequest!: Promise<void>;
+      let btwRequest!: Promise<void>;
+      await act(async () => {
+        mainRequest = result.current.submitQuery('Main query');
+      });
+      await waitFor(() => expect(mainSignal).toBeDefined());
+      await act(async () => {
+        btwRequest = result.current.submitQuery('?btw use a tool');
+      });
+      await waitFor(() => expect(btwSignal).toBeDefined());
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+      expect(mainSignal?.aborted).toBe(true);
+      expect(btwSignal?.aborted).toBe(false);
+      act(() => {
+        resolveMain();
+      });
+      await act(async () => {
+        await mainRequest;
+      });
+
+      client.getHistoryFunctionResponseIds = vi
+        .fn()
+        .mockReturnValue(new Set(['repaired-btw-tool']));
+      const onComplete = mockUseReactToolScheduler.mock.calls.at(-1)?.[0] as
+        | ((completedTools: TrackedToolCall[]) => Promise<void>)
+        | undefined;
+      let btwCompletion: Promise<void> | undefined;
+      mockScheduleToolCalls.mockImplementation((requests) => {
+        if (
+          requests.some((request) => request.callId === 'repaired-btw-tool')
+        ) {
+          btwCompletion = onComplete!([
+            {
+              request: {
+                callId: 'repaired-btw-tool',
+                name: 'testTool',
+                args: {},
+                isClientInitiated: false,
+                prompt_id: btwPromptId,
+              },
+              status: 'success',
+              response: {
+                callId: 'repaired-btw-tool',
+                responseParts: [
+                  {
+                    functionResponse: {
+                      id: 'repaired-btw-tool',
+                      name: 'testTool',
+                      response: { output: 'done' },
+                    },
+                  },
+                ],
+                errorType: undefined,
+              },
+              responseSubmittedToGemini: false,
+              tool: { displayName: 'mock tool' },
+              invocation: {
+                getDescription: () => 'Mock description',
+              } as unknown as AnyToolInvocation,
+            } as TrackedCompletedToolCall,
+          ]);
+        }
+      });
+
+      act(() => {
+        resolveBtw();
+      });
+      await waitFor(() => expect(btwCompletion).toBeDefined());
+      await act(async () => {
+        await Promise.all([btwRequest, btwCompletion]);
+      });
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+      expect(btwSignal?.aborted).toBe(false);
+    });
+
     it('stays responding when a newer turn finishes before a surviving ?btw stream', async () => {
       let resolveMain!: () => void;
       let resolveBtw!: () => void;
@@ -13105,8 +13284,10 @@ describe('useGeminiStream', () => {
       const btwPending = new Promise<void>((resolve) => {
         resolveBtw = resolve;
       });
+      let btwToolSignal: AbortSignal | undefined;
+      let btwPromptId: string | undefined;
       let callCount = 0;
-      mockSendMessageStream.mockImplementation((_query, signal) => {
+      mockSendMessageStream.mockImplementation((_query, signal, promptId) => {
         callCount += 1;
         if (callCount === 1) {
           return (async function* () {
@@ -13117,17 +13298,34 @@ describe('useGeminiStream', () => {
           })();
         }
         if (callCount === 2) {
+          btwPromptId = promptId;
           return (async function* () {
             await btwPending;
-            yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+            yield {
+              type: ServerGeminiEventType.ToolCallRequest,
+              value: {
+                callId: 'surviving-btw-tool',
+                name: 'testTool',
+                args: {},
+                isClientInitiated: false,
+                prompt_id: promptId,
+              },
+            };
           })();
         }
         return (async function* () {
           yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
         })();
       });
+      mockScheduleToolCalls.mockImplementation((requests, signal) => {
+        if (
+          requests.some((request) => request.callId === 'surviving-btw-tool')
+        ) {
+          btwToolSignal = signal;
+        }
+      });
 
-      const { result } = renderTestHook();
+      const { result, rerender, client } = renderTestHook();
       let mainRequest!: Promise<void>;
       let btwRequest!: Promise<void>;
       await act(async () => {
@@ -13169,6 +13367,59 @@ describe('useGeminiStream', () => {
       });
       await act(async () => {
         await btwRequest;
+      });
+      await waitFor(() => expect(btwToolSignal).toBeDefined());
+
+      rerender({
+        client,
+        history: [],
+        addItem: mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+        config: mockConfig,
+        onDebugMessage: mockOnDebugMessage,
+        handleSlashCommand: mockHandleSlashCommand as unknown as (
+          cmd: PartListUnion,
+        ) => Promise<SlashCommandProcessorResult | false>,
+        shellModeActive: false,
+        loadedSettings: mockLoadedSettings,
+        toolCalls: [
+          {
+            request: {
+              callId: 'surviving-btw-tool',
+              name: 'testTool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: btwPromptId,
+            },
+            status: 'executing',
+            responseSubmittedToGemini: false,
+            tool: { displayName: 'mock tool' },
+            invocation: {
+              getDescription: () => 'Mock description',
+            } as unknown as AnyToolInvocation,
+          } as TrackedExecutingToolCall,
+        ],
+      });
+      await waitFor(() =>
+        expect(result.current.streamingState).toBe(StreamingState.Responding),
+      );
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+      expect(btwToolSignal?.aborted).toBe(true);
+
+      rerender({
+        client,
+        history: [],
+        addItem: mockAddItem as unknown as UseHistoryManagerReturn['addItem'],
+        config: mockConfig,
+        onDebugMessage: mockOnDebugMessage,
+        handleSlashCommand: mockHandleSlashCommand as unknown as (
+          cmd: PartListUnion,
+        ) => Promise<SlashCommandProcessorResult | false>,
+        shellModeActive: false,
+        loadedSettings: mockLoadedSettings,
+        toolCalls: [],
       });
       await waitFor(() =>
         expect(result.current.streamingState).toBe(StreamingState.Idle),

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2253,7 +2253,9 @@ describe('useGeminiStream', () => {
     };
     const finishTurn = vi
       .fn()
-      .mockRejectedValue(new Error('goal journal is unavailable'));
+      .mockRejectedValue(
+        new Error('goal journal is unavailable: token=secret'),
+      );
     const runtime = {
       permitForTurn: vi.fn(() => permit),
       finishTurn,
@@ -2371,8 +2373,7 @@ describe('useGeminiStream', () => {
 
     expect(mockEndInteractionSpan).toHaveBeenCalledWith('error', {
       promptId: 'prompt-goal-finish-error',
-      errorMessage:
-        'Goal tool continuation could not finish: goal journal is unavailable',
+      errorMessage: 'Goal tool continuation could not finish',
       errorType: 'continuation_goal_finish_failed',
     });
     expect(mockSendMessageStream).toHaveBeenCalledOnce();
@@ -12942,6 +12943,15 @@ describe('useGeminiStream', () => {
     it('continues a deferred main tool batch without leaking its mixed ?btw owner', async () => {
       const mainOwner = {};
       const btwOwner = {};
+      const submissionInFlightRef = { current: false };
+      const waitForReservationSettlement = vi.fn().mockResolvedValue(undefined);
+      const goalQueueRef = {
+        current: {
+          peekNextUserBatchKey: () => undefined,
+          submissionInFlightRef,
+          waitForReservationSettlement,
+        },
+      };
       const ownersByPromptId = new Map<string, object>();
       mockGetActiveInteractionSpan.mockImplementation((promptId?: string) =>
         promptId ? ownersByPromptId.get(promptId) : undefined,
@@ -13020,6 +13030,12 @@ describe('useGeminiStream', () => {
           () => {},
           80,
           24,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          goalQueueRef,
         ),
       );
 
@@ -13109,8 +13125,53 @@ describe('useGeminiStream', () => {
       expect(mockEndInteractionSpan).not.toHaveBeenCalledWith('cancelled', {
         promptId: 'main-prompt',
       });
+      expect(submissionInFlightRef.current).toBe(true);
 
-      resolveMainStream();
+      let resolveMemoryRefresh!: (value: boolean) => void;
+      mockRefreshMemoryAfterManagedWrite.mockReturnValueOnce(
+        new Promise<boolean>((resolve) => {
+          resolveMemoryRefresh = resolve;
+        }),
+      );
+      act(() => {
+        resolveMainStream();
+      });
+      await waitFor(() =>
+        expect(mockRefreshMemoryAfterManagedWrite).toHaveBeenCalledOnce(),
+      );
+      await act(async () => {
+        await result.current.submitQuery(
+          'Too early',
+          SendMessageType.UserQuery,
+          'too-early-prompt',
+        );
+      });
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+      let resolveToolReservation!: () => void;
+      waitForReservationSettlement.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveToolReservation = resolve;
+          }),
+      );
+      act(() => {
+        resolveMemoryRefresh(false);
+      });
+      await waitFor(() =>
+        expect(waitForReservationSettlement).toHaveBeenCalledTimes(3),
+      );
+      await act(async () => {
+        await result.current.submitQuery(
+          '?btw still too early',
+          SendMessageType.UserQuery,
+          'btw-too-early-prompt',
+        );
+      });
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+      expect(submissionInFlightRef.current).toBe(true);
+      act(() => {
+        resolveToolReservation();
+      });
       await act(async () => {
         await mainRequest;
       });
@@ -13133,6 +13194,18 @@ describe('useGeminiStream', () => {
           functionResponse: expect.objectContaining({ id: 'main-tool' }),
         }),
       ]);
+      await act(async () => {
+        await result.current.submitQuery(
+          'After drain',
+          SendMessageType.UserQuery,
+          'after-drain-prompt',
+        );
+      });
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(4);
+      expect(mockSendMessageStream.mock.calls[3]?.[2]).toBe(
+        'after-drain-prompt',
+      );
+      expect(submissionInFlightRef.current).toBe(false);
     });
 
     it('should prevent concurrent submitQuery calls', async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2245,6 +2245,139 @@ describe('useGeminiStream', () => {
     });
   });
 
+  it('records the Goal finalization error on the owning interaction', async () => {
+    const permit: GoalTurnPermit = {
+      goalId: 'goal-finish-error',
+      revision: 1,
+      turnId: 'turn-finish-error',
+    };
+    const finishTurn = vi
+      .fn()
+      .mockRejectedValue(new Error('goal journal is unavailable'));
+    const runtime = {
+      permitForTurn: vi.fn(() => permit),
+      finishTurn,
+      getSnapshot: vi.fn(() => ({
+        v: 2 as const,
+        activity: 'running' as const,
+        goal: {
+          goalId: permit.goalId,
+          revision: permit.revision,
+          objective: 'finish with diagnostics',
+          status: 'active' as const,
+          evidenceCursor: { recordId: 'record-finish-error' },
+          turnCount: 1,
+          activeTimeMs: 20,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      })),
+      dispatch: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ReturnType<Config['getGoalRuntime']>;
+    mockConfig.getGoalRuntime = vi.fn(() => runtime);
+    mockConfig.getGoalRuntimeReady = vi.fn().mockResolvedValue(runtime);
+    mockConfig.getChatRecordingService = vi.fn().mockReturnValue({
+      flush: vi.fn().mockResolvedValue(undefined),
+    });
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+    });
+    const client = new MockedGeminiClientClass(mockConfig);
+    mockSendMessageStream.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: ServerGeminiEventType.ToolCallRequest,
+          value: {
+            callId: 'update-goal-error',
+            name: 'update_goal',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-goal-finish-error',
+            goalContext: permit,
+          },
+        };
+      })(),
+    );
+    const { result } = renderHook(() =>
+      useGeminiStream(
+        client,
+        [],
+        mockAddItem,
+        mockConfig,
+        true,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+      ),
+    );
+    await act(async () => {
+      await result.current.submitQuery(
+        'finish the Goal',
+        SendMessageType.UserQuery,
+        'prompt-goal-finish-error',
+      );
+    });
+    await waitFor(() => expect(mockScheduleToolCalls).toHaveBeenCalledOnce());
+
+    await act(async () => {
+      await capturedOnComplete?.([
+        {
+          request: {
+            callId: 'update-goal-error',
+            name: 'update_goal',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: 'prompt-goal-finish-error',
+            goalContext: permit,
+          },
+          status: 'success',
+          responseSubmittedToGemini: false,
+          response: {
+            callId: 'update-goal-error',
+            responseParts: [
+              {
+                functionResponse: {
+                  id: 'update-goal-error',
+                  name: 'update_goal',
+                  response: { output: 'proposal recorded' },
+                },
+              },
+            ],
+            errorType: undefined,
+            terminateTurn: true,
+          },
+          tool: { displayName: 'UpdateGoal' },
+          invocation: {
+            getDescription: () => 'complete Goal',
+          } as unknown as AnyToolInvocation,
+        } as TrackedCompletedToolCall,
+      ]);
+    });
+
+    expect(mockEndInteractionSpan).toHaveBeenCalledWith('error', {
+      promptId: 'prompt-goal-finish-error',
+      errorMessage:
+        'Goal tool continuation could not finish: goal journal is unavailable',
+      errorType: 'continuation_goal_finish_failed',
+    });
+    expect(mockSendMessageStream).toHaveBeenCalledOnce();
+  });
+
   it('does not let an old tool batch end a replacement interaction', async () => {
     let capturedOnComplete:
       | ((completedTools: TrackedToolCall[]) => Promise<void>)
@@ -12804,6 +12937,202 @@ describe('useGeminiStream', () => {
         resolveFirstCall();
         await mainRequest;
       }
+    });
+
+    it('continues a deferred main tool batch without leaking its mixed ?btw owner', async () => {
+      const mainOwner = {};
+      const btwOwner = {};
+      const ownersByPromptId = new Map<string, object>();
+      mockGetActiveInteractionSpan.mockImplementation((promptId?: string) =>
+        promptId ? ownersByPromptId.get(promptId) : undefined,
+      );
+
+      let resolveMainStream!: () => void;
+      const mainStream = new Promise<void>((resolve) => {
+        resolveMainStream = resolve;
+      });
+      let callCount = 0;
+      let btwPromptId: string | undefined;
+      mockSendMessageStream.mockImplementation((_query, _signal, promptId) => {
+        callCount += 1;
+        if (callCount === 1) {
+          ownersByPromptId.set(promptId, mainOwner);
+          return (async function* () {
+            yield {
+              type: ServerGeminiEventType.ToolCallRequest,
+              value: {
+                callId: 'main-tool',
+                name: 'testTool',
+                args: {},
+                isClientInitiated: false,
+                prompt_id: promptId,
+              },
+            };
+            await mainStream;
+          })();
+        }
+        if (callCount > 2) {
+          return (async function* () {})();
+        }
+        btwPromptId = promptId;
+        ownersByPromptId.set(promptId, btwOwner);
+        return (async function* () {
+          yield {
+            type: ServerGeminiEventType.ToolCallRequest,
+            value: {
+              callId: 'btw-cancelled-tool',
+              name: 'testTool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: promptId,
+            },
+          };
+        })();
+      });
+
+      let capturedOnComplete:
+        | ((completedTools: TrackedToolCall[]) => Promise<void>)
+        | undefined;
+      mockUseReactToolScheduler.mockImplementation((onComplete) => {
+        capturedOnComplete = onComplete;
+        return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+      });
+
+      const client = new MockedGeminiClientClass(mockConfig);
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          client,
+          [],
+          mockAddItem,
+          mockConfig,
+          true,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          () => {},
+          () => {},
+          () => {},
+          80,
+          24,
+        ),
+      );
+
+      let mainRequest!: Promise<void>;
+      await act(async () => {
+        mainRequest = result.current.submitQuery(
+          'Main query',
+          SendMessageType.UserQuery,
+          'main-prompt',
+          { submittedPrompt: 'Main query' },
+        );
+      });
+      await waitFor(() =>
+        expect(result.current.streamingState).toBe(StreamingState.Responding),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery(
+          '?btw use a tool',
+          SendMessageType.UserQuery,
+          undefined,
+          { submittedPrompt: '?btw use a tool' },
+        );
+      });
+      expect(btwPromptId).toBeDefined();
+      expect(mockScheduleToolCalls).toHaveBeenCalledWith(
+        [expect.objectContaining({ callId: 'btw-cancelled-tool' })],
+        expect.any(AbortSignal),
+        undefined,
+      );
+
+      const makeCancelledToolCall = (
+        callId: string,
+        promptId: string | undefined,
+      ) =>
+        ({
+          request: {
+            callId,
+            name: 'testTool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: promptId,
+          },
+          status: 'cancelled',
+          response: {
+            callId,
+            responseParts: [{ text: 'cancelled' }],
+            errorType: undefined,
+          },
+          responseSubmittedToGemini: false,
+          tool: { displayName: 'mock tool' },
+          invocation: {
+            getDescription: () => 'Mock description',
+          } as unknown as AnyToolInvocation,
+        }) as TrackedCancelledToolCall;
+      const mainCompletedToolCall = {
+        ...makeCancelledToolCall('main-tool', 'main-prompt'),
+        status: 'success',
+        response: {
+          callId: 'main-tool',
+          responseParts: [
+            {
+              functionResponse: {
+                id: 'main-tool',
+                name: 'testTool',
+                response: { output: 'done' },
+              },
+            },
+          ],
+          errorType: undefined,
+        },
+      } as unknown as TrackedCompletedToolCall;
+      const btwCancelledToolCall = makeCancelledToolCall(
+        'btw-cancelled-tool',
+        btwPromptId,
+      );
+
+      await act(async () => {
+        await capturedOnComplete?.([
+          mainCompletedToolCall,
+          btwCancelledToolCall,
+        ]);
+      });
+      expect(mockEndInteractionSpan).not.toHaveBeenCalledWith('cancelled', {
+        promptId: btwPromptId,
+      });
+      expect(mockEndInteractionSpan).not.toHaveBeenCalledWith('cancelled', {
+        promptId: 'main-prompt',
+      });
+
+      resolveMainStream();
+      await act(async () => {
+        await mainRequest;
+      });
+
+      expect(mockEndInteractionSpan).toHaveBeenCalledWith('cancelled', {
+        promptId: btwPromptId,
+      });
+      expect(mockEndInteractionSpan).not.toHaveBeenCalledWith('cancelled', {
+        promptId: 'main-prompt',
+      });
+      await waitFor(() =>
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(3),
+      );
+      expect(mockSendMessageStream.mock.calls[2]?.[2]).toBe('main-prompt');
+      expect(mockSendMessageStream.mock.calls[2]?.[3]).toEqual(
+        expect.objectContaining({ type: SendMessageType.ToolResult }),
+      );
+      expect(mockSendMessageStream.mock.calls[2]?.[0]).toEqual([
+        expect.objectContaining({
+          functionResponse: expect.objectContaining({ id: 'main-tool' }),
+        }),
+      ]);
     });
 
     it('should prevent concurrent submitQuery calls', async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -13208,6 +13208,327 @@ describe('useGeminiStream', () => {
       expect(submissionInFlightRef.current).toBe(false);
     });
 
+    it.each([
+      'drain-first',
+      'continuation-first',
+      'admission-first',
+      'handler-first',
+    ] as const)(
+      'keeps the submission lease while a continuation starts during a deferred drain (%s)',
+      async (completionOrder) => {
+        const owner = {};
+        const submissionInFlightRef = { current: false };
+        let resolveConcurrentAdmission!: () => void;
+        const concurrentAdmission = new Promise<void>((resolve) => {
+          resolveConcurrentAdmission = resolve;
+        });
+        let resolveConcurrentHandler!: (value: boolean) => void;
+        const concurrentHandler = new Promise<boolean>((resolve) => {
+          resolveConcurrentHandler = resolve;
+        });
+        let reservationCount = 0;
+        const waitForReservationSettlement = vi.fn(() => {
+          reservationCount += 1;
+          return completionOrder === 'admission-first' && reservationCount === 2
+            ? concurrentAdmission
+            : Promise.resolve();
+        });
+        const goalQueueRef = {
+          current: {
+            peekNextUserBatchKey: () => undefined,
+            submissionInFlightRef,
+            waitForReservationSettlement,
+          },
+        };
+        mockGetActiveInteractionSpan.mockReturnValue(owner);
+
+        let resolveMainStream!: () => void;
+        const mainStream = new Promise<void>((resolve) => {
+          resolveMainStream = resolve;
+        });
+        let resolveConcurrentContinuation!: () => void;
+        const concurrentContinuation = new Promise<void>((resolve) => {
+          resolveConcurrentContinuation = resolve;
+        });
+        let streamCount = 0;
+        mockSendMessageStream.mockImplementation((query) => {
+          streamCount += 1;
+          if (streamCount === 1) {
+            return (async function* () {
+              await mainStream;
+              yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+            })();
+          }
+          if (JSON.stringify(query).includes('second-tool')) {
+            return (async function* () {
+              await concurrentContinuation;
+              yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+            })();
+          }
+          return (async function* () {
+            yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+          })();
+        });
+
+        let capturedOnComplete:
+          | ((completedTools: TrackedToolCall[]) => Promise<void>)
+          | undefined;
+        mockUseReactToolScheduler.mockImplementation((onComplete) => {
+          capturedOnComplete = onComplete;
+          return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+        });
+
+        const completedToolCall = (callId: string) =>
+          ({
+            request: {
+              callId,
+              name: 'testTool',
+              args: {},
+              isClientInitiated: false,
+              prompt_id: 'main-prompt',
+            },
+            status: 'success',
+            response: {
+              callId,
+              responseParts: [
+                {
+                  functionResponse: {
+                    id: callId,
+                    name: 'testTool',
+                    response: { output: 'done' },
+                  },
+                },
+              ],
+              errorType: undefined,
+            },
+            responseSubmittedToGemini: false,
+            tool: { displayName: 'mock tool' },
+            invocation: {
+              getDescription: () => 'Mock description',
+            } as unknown as AnyToolInvocation,
+          }) as TrackedCompletedToolCall;
+
+        let resolveFirstRefresh!: (value: boolean) => void;
+        mockRefreshMemoryAfterManagedWrite.mockReturnValueOnce(
+          new Promise<boolean>((resolve) => {
+            resolveFirstRefresh = resolve;
+          }),
+        );
+        if (completionOrder === 'handler-first') {
+          mockRefreshMemoryAfterManagedWrite.mockReturnValueOnce(
+            concurrentHandler,
+          );
+        }
+
+        const client = new MockedGeminiClientClass(mockConfig);
+        const { result } = renderHook(() =>
+          useGeminiStream(
+            client,
+            [],
+            mockAddItem,
+            mockConfig,
+            true,
+            mockLoadedSettings,
+            mockOnDebugMessage,
+            mockHandleSlashCommand,
+            false,
+            () => 'vscode' as EditorType,
+            () => {},
+            () => Promise.resolve(),
+            false,
+            () => {},
+            () => {},
+            () => {},
+            () => {},
+            80,
+            24,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            goalQueueRef,
+          ),
+        );
+
+        let mainRequest!: Promise<void>;
+        await act(async () => {
+          mainRequest = result.current.submitQuery(
+            'Main query',
+            SendMessageType.UserQuery,
+            'main-prompt',
+            { submittedPrompt: 'Main query' },
+          );
+        });
+        await waitFor(() =>
+          expect(result.current.streamingState).toBe(StreamingState.Responding),
+        );
+
+        await act(async () => {
+          await capturedOnComplete?.([completedToolCall('first-tool')]);
+        });
+        act(() => {
+          resolveMainStream();
+        });
+        await waitFor(() =>
+          expect(mockRefreshMemoryAfterManagedWrite).toHaveBeenCalledOnce(),
+        );
+
+        let concurrentCompletion!: Promise<void>;
+        act(() => {
+          concurrentCompletion =
+            capturedOnComplete?.([completedToolCall('second-tool')]) ??
+            Promise.resolve();
+        });
+        if (completionOrder === 'handler-first') {
+          await waitFor(() =>
+            expect(mockRefreshMemoryAfterManagedWrite).toHaveBeenCalledTimes(2),
+          );
+          expect(mockSendMessageStream).toHaveBeenCalledOnce();
+        } else if (completionOrder === 'admission-first') {
+          await waitFor(() =>
+            expect(waitForReservationSettlement).toHaveBeenCalledTimes(2),
+          );
+          expect(mockSendMessageStream).toHaveBeenCalledOnce();
+        } else {
+          await waitFor(() =>
+            expect(mockSendMessageStream).toHaveBeenCalledTimes(2),
+          );
+        }
+        if (completionOrder === 'continuation-first') {
+          act(() => {
+            resolveConcurrentContinuation();
+          });
+          await act(async () => {
+            await concurrentCompletion;
+          });
+        } else {
+          act(() => {
+            resolveFirstRefresh(false);
+          });
+          await act(async () => {
+            await mainRequest;
+          });
+        }
+
+        expect(result.current.streamingState).toBe(StreamingState.Responding);
+        expect(submissionInFlightRef.current).toBe(true);
+        const streamCountBeforeRejectedSubmit =
+          mockSendMessageStream.mock.calls.length;
+        await act(async () => {
+          await result.current.submitQuery(
+            'Too early',
+            SendMessageType.UserQuery,
+            'too-early-prompt',
+          );
+        });
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(
+          streamCountBeforeRejectedSubmit,
+        );
+
+        if (completionOrder === 'drain-first') {
+          act(() => {
+            resolveConcurrentContinuation();
+          });
+          await act(async () => {
+            await concurrentCompletion;
+          });
+        } else if (completionOrder === 'continuation-first') {
+          act(() => {
+            resolveFirstRefresh(false);
+          });
+          await act(async () => {
+            await mainRequest;
+          });
+        } else if (completionOrder === 'admission-first') {
+          act(() => {
+            resolveConcurrentAdmission();
+          });
+          await waitFor(() =>
+            expect(mockSendMessageStream).toHaveBeenCalledTimes(
+              streamCountBeforeRejectedSubmit + 1,
+            ),
+          );
+          act(() => {
+            resolveConcurrentContinuation();
+          });
+          await act(async () => {
+            await concurrentCompletion;
+          });
+        } else {
+          act(() => {
+            resolveConcurrentHandler(false);
+          });
+          await waitFor(() =>
+            expect(mockSendMessageStream).toHaveBeenCalledTimes(
+              streamCountBeforeRejectedSubmit + 1,
+            ),
+          );
+          act(() => {
+            resolveConcurrentContinuation();
+          });
+          await act(async () => {
+            await concurrentCompletion;
+          });
+        }
+        await waitFor(() =>
+          expect(result.current.streamingState).toBe(StreamingState.Idle),
+        );
+        expect(submissionInFlightRef.current).toBe(false);
+      },
+    );
+
+    it('does not re-arm a cancelled submission lease while the stream unwinds', async () => {
+      const onSubmissionSettled = vi.fn();
+      const submissionInFlightRef = { current: false };
+      const goalQueueRef = {
+        current: {
+          peekNextUserBatchKey: () => undefined,
+          submissionInFlightRef,
+          onSubmissionSettled,
+          waitForReservationSettlement: vi.fn().mockResolvedValue(undefined),
+        },
+      };
+      let resolveStream!: () => void;
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          await new Promise<void>((resolve) => {
+            resolveStream = resolve;
+          });
+          yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+        })(),
+      );
+
+      const client = new MockedGeminiClientClass(mockConfig);
+      const { result } = renderTestHook(
+        [],
+        client,
+        undefined,
+        () => {},
+        undefined,
+        goalQueueRef,
+      );
+
+      let request!: Promise<void>;
+      await act(async () => {
+        request = result.current.submitQuery('Main query');
+      });
+      await waitFor(() =>
+        expect(result.current.streamingState).toBe(StreamingState.Responding),
+      );
+      act(() => {
+        result.current.cancelOngoingRequest();
+        resolveStream();
+      });
+      await act(async () => {
+        await request;
+      });
+
+      expect(result.current.streamingState).toBe(StreamingState.Idle);
+      expect(submissionInFlightRef.current).toBe(false);
+      expect(onSubmissionSettled).toHaveBeenCalledOnce();
+    });
+
     it('should prevent concurrent submitQuery calls', async () => {
       let resolveFirstCall!: () => void;
       let resolveSecondCall!: () => void;

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -12940,6 +12940,162 @@ describe('useGeminiStream', () => {
       }
     });
 
+    it('continues a legacy ?btw tool after a repaired main batch is cancelled', async () => {
+      let resolveMain!: () => void;
+      let resolveBtw!: () => void;
+      const mainPending = new Promise<void>((resolve) => {
+        resolveMain = resolve;
+      });
+      const btwPending = new Promise<void>((resolve) => {
+        resolveBtw = resolve;
+      });
+      let mainSignal: AbortSignal | undefined;
+      let mainPromptId: string | undefined;
+      let btwPromptId: string | undefined;
+      let callCount = 0;
+      mockSendMessageStream.mockImplementation(
+        (_query, signal, promptId, options) => {
+          callCount += 1;
+          if (callCount === 1) {
+            mainSignal = signal;
+            mainPromptId = promptId;
+            return (async function* () {
+              yield {
+                type: ServerGeminiEventType.ToolCallRequest,
+                value: {
+                  callId: 'main-tool',
+                  name: 'testTool',
+                  args: {},
+                  isClientInitiated: false,
+                  prompt_id: promptId,
+                },
+              };
+              await mainPending;
+            })();
+          }
+          if (callCount === 2) {
+            btwPromptId = promptId;
+            return (async function* () {
+              yield {
+                type: ServerGeminiEventType.ToolCallRequest,
+                value: {
+                  callId: 'btw-tool',
+                  name: 'testTool',
+                  args: {},
+                  isClientInitiated: false,
+                  prompt_id: promptId,
+                },
+              };
+              await btwPending;
+            })();
+          }
+          expect(options).toEqual(
+            expect.objectContaining({ type: SendMessageType.ToolResult }),
+          );
+          return (async function* () {
+            yield { type: ServerGeminiEventType.Finished, value: 'STOP' };
+          })();
+        },
+      );
+
+      const { result, client } = renderTestHook();
+      let mainRequest!: Promise<void>;
+      let btwRequest!: Promise<void>;
+      await act(async () => {
+        mainRequest = result.current.submitQuery('Main query');
+      });
+      await waitFor(() => {
+        expect(mainSignal).toBeDefined();
+        expect(result.current.streamingState).toBe(StreamingState.Responding);
+      });
+      await act(async () => {
+        btwRequest = result.current.submitQuery('?btw use a tool');
+      });
+      await waitFor(() => expect(btwPromptId).toBeDefined());
+
+      act(() => {
+        resolveMain();
+      });
+      await act(async () => {
+        await mainRequest;
+      });
+      const makeCompletedTool = (
+        callId: string,
+        promptId: string | undefined,
+      ) =>
+        ({
+          request: {
+            callId,
+            name: 'testTool',
+            args: {},
+            isClientInitiated: false,
+            prompt_id: promptId,
+          },
+          status: 'success',
+          response: {
+            callId,
+            responseParts: [
+              {
+                functionResponse: {
+                  id: callId,
+                  name: 'testTool',
+                  response: { output: `${callId} done` },
+                },
+              },
+            ],
+            errorType: undefined,
+          },
+          responseSubmittedToGemini: false,
+          tool: { displayName: 'mock tool' },
+          invocation: {
+            getDescription: () => 'Mock description',
+          } as unknown as AnyToolInvocation,
+        }) as TrackedCompletedToolCall;
+      const onComplete = mockUseReactToolScheduler.mock.calls.at(-1)?.[0] as
+        | ((completedTools: TrackedToolCall[]) => Promise<void>)
+        | undefined;
+      expect(onComplete).toBeDefined();
+      await act(async () => {
+        await onComplete!([makeCompletedTool('main-tool', mainPromptId)]);
+      });
+
+      act(() => {
+        result.current.cancelOngoingRequest();
+      });
+      expect(mainSignal?.aborted).toBe(true);
+
+      client.getHistoryFunctionResponseIds = vi
+        .fn()
+        .mockReturnValue(new Set(['main-tool']));
+      let btwCompletion: Promise<void> | undefined;
+      mockScheduleToolCalls.mockImplementation((requests) => {
+        if (requests.some((request) => request.callId === 'btw-tool')) {
+          btwCompletion = onComplete!([
+            makeCompletedTool('btw-tool', btwPromptId),
+          ]);
+        }
+      });
+      act(() => {
+        resolveBtw();
+      });
+      await act(async () => {
+        await btwRequest;
+        await btwCompletion;
+      });
+
+      expect(mockFinalizeToolResponses).toHaveBeenCalled();
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(3);
+      expect(mockSendMessageStream.mock.calls[2]?.[2]).toBe(btwPromptId);
+      expect(mockSendMessageStream.mock.calls[2]?.[0]).toEqual([
+        expect.objectContaining({
+          functionResponse: expect.objectContaining({ id: 'btw-tool' }),
+        }),
+      ]);
+      expect(
+        JSON.stringify(mockSendMessageStream.mock.calls[2]?.[0]),
+      ).not.toContain('main-tool');
+    });
+
     it('stays responding when a newer turn finishes before a surviving ?btw stream', async () => {
       let resolveMain!: () => void;
       let resolveBtw!: () => void;

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -692,6 +692,17 @@ export const useGeminiStream = (
   const activeModelStreamsRef = useRef(0);
   // A continuation may be admitted while an earlier submission is finalizing.
   const submissionActivitiesByGenerationRef = useRef(new Map<number, number>());
+  const settleSubmissionStateIfIdle = useCallback(() => {
+    const currentGeneration = submissionLeaseGenerationRef.current;
+    if (
+      (submissionActivitiesByGenerationRef.current.get(currentGeneration) ??
+        0) === 0 &&
+      activeModelStreamsRef.current === 0
+    ) {
+      setIsResponding(false);
+      setSubmissionInFlight(false);
+    }
+  }, [setSubmissionInFlight]);
   const retainSubmissionActivity = useCallback(
     (generation: number) => {
       submissionActivitiesByGenerationRef.current.set(
@@ -706,19 +717,16 @@ export const useGeminiStream = (
         );
         if (remainingActivities === 0) {
           submissionActivitiesByGenerationRef.current.delete(generation);
-          if (generation === submissionLeaseGenerationRef.current) {
-            setIsResponding(false);
-            setSubmissionInFlight(false);
-          }
         } else {
           submissionActivitiesByGenerationRef.current.set(
             generation,
             remainingActivities,
           );
         }
+        settleSubmissionStateIfIdle();
       };
     },
-    [setSubmissionInFlight],
+    [settleSubmissionStateIfIdle],
   );
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   // Hold the latest history in a ref so handleCompletedTools can read it

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -3136,6 +3136,7 @@ export const useGeminiStream = (
       const allowConcurrentBtwDuringResponse =
         submitType === SendMessageType.UserQuery &&
         streamingState === StreamingState.Responding &&
+        activeModelStreamsRef.current > 0 &&
         typeof query === 'string' &&
         isBtwCommand(query) &&
         !activeGoalAdmissionRef.current;
@@ -3789,7 +3790,7 @@ export const useGeminiStream = (
           const shouldDrainCompletedToolBatches =
             activeModelStreamsRef.current === 0;
           if (shouldDrainCompletedToolBatches) {
-            setIsResponding(false);
+            setSubmissionInFlight(true);
           }
           if (goalBinding) {
             let retainGoalBinding =
@@ -3822,20 +3823,26 @@ export const useGeminiStream = (
           ) {
             activeGoalAdmissionRef.current = null;
           }
-          releaseSubmissionLease();
-          if (shouldDrainCompletedToolBatches) {
-            const pendingCompletedToolBatches =
-              pendingCompletedToolBatchesRef.current.splice(0);
-            const pendingCompletedTools = new Map<string, TrackedToolCall>();
-            for (const pendingBatch of pendingCompletedToolBatches) {
-              for (const toolCall of pendingBatch) {
-                pendingCompletedTools.set(toolCall.request.callId, toolCall);
+          try {
+            if (shouldDrainCompletedToolBatches) {
+              const pendingCompletedToolBatches =
+                pendingCompletedToolBatchesRef.current.splice(0);
+              const pendingCompletedTools = new Map<string, TrackedToolCall>();
+              for (const pendingBatch of pendingCompletedToolBatches) {
+                for (const toolCall of pendingBatch) {
+                  pendingCompletedTools.set(toolCall.request.callId, toolCall);
+                }
+              }
+              if (pendingCompletedTools.size > 0) {
+                await handleCompletedToolsRef.current([
+                  ...pendingCompletedTools.values(),
+                ]);
               }
             }
-            if (pendingCompletedTools.size > 0) {
-              await handleCompletedToolsRef.current([
-                ...pendingCompletedTools.values(),
-              ]);
+          } finally {
+            if (shouldDrainCompletedToolBatches) {
+              setIsResponding(false);
+              setSubmissionInFlight(false);
             }
           }
         }
@@ -4625,7 +4632,7 @@ export const useGeminiStream = (
       );
       if (terminatesGoalTurn && toolGoalBinding) {
         geminiClient.addHistory({ role: 'user', parts: responsesToSend });
-        let goalFinishErrorMessage: string | undefined;
+        let goalFinishFailed = false;
         try {
           await config.getChatRecordingService()?.flush();
           const runtime = await config.getGoalRuntimeReady();
@@ -4654,7 +4661,7 @@ export const useGeminiStream = (
           }
         } catch (error) {
           const errorMessage = getErrorMessage(error);
-          goalFinishErrorMessage = `Goal tool continuation could not finish: ${errorMessage}`;
+          goalFinishFailed = true;
           await failClosedGoalTurn(
             toolGoalBinding,
             `Goal turn could not finish: ${errorMessage}`,
@@ -4663,10 +4670,10 @@ export const useGeminiStream = (
           // Idempotent with the release inside failClosedGoalTurn; also covers the success path.
           releaseGoalTurn(toolGoalBinding);
         }
-        if (goalFinishErrorMessage) {
+        if (goalFinishFailed) {
           endToolInteraction(
             'error',
-            goalFinishErrorMessage,
+            'Goal tool continuation could not finish',
             'continuation_goal_finish_failed',
           );
         } else {
@@ -4872,7 +4879,7 @@ export const useGeminiStream = (
         return;
       }
 
-      void submitQuery(responsesToSend, SendMessageType.ToolResult, promptId, {
+      await submitQuery(responsesToSend, SendMessageType.ToolResult, promptId, {
         steerInput: drainedSteer,
         onDelivered: drainedSteer?.accept,
         onAdmissionFailed: () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -800,6 +800,10 @@ export const useGeminiStream = (
   const interactionOwnersByToolCallIdRef = useRef(
     new Map<string, NonNullable<ReturnType<typeof getActiveInteractionSpan>>>(),
   );
+  const pendingCompletedToolBatchesRef = useRef<TrackedToolCall[][]>([]);
+  const handleCompletedToolsRef = useRef<
+    (completedTools: TrackedToolCall[]) => Promise<void>
+  >(async () => {});
   const immediateDuplicateToolResponsesRef = useRef<{
     promptId: string | undefined;
     responses: Array<{
@@ -2263,6 +2267,9 @@ export const useGeminiStream = (
         0,
       );
       const toolCallRequests: ToolCallRequestInfo[] = [];
+      let streamInteractionOwner = trackInteractionOwner
+        ? activeInteractionOwnerRef.current
+        : undefined;
       const bufferedEvents: BufferedStreamEvent[] = [];
       let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -2408,9 +2415,11 @@ export const useGeminiStream = (
       dualOutput?.startAssistantMessage();
       try {
         for await (const event of stream) {
-          if (trackInteractionOwner && promptId) {
-            activeInteractionOwnerRef.current ??=
-              getActiveInteractionSpan(promptId);
+          if (!streamInteractionOwner && promptId) {
+            streamInteractionOwner = getActiveInteractionSpan(promptId);
+            if (trackInteractionOwner && streamInteractionOwner) {
+              activeInteractionOwnerRef.current ??= streamInteractionOwner;
+            }
           }
           dualOutput?.processEvent(event);
           switch (event.type) {
@@ -2811,12 +2820,11 @@ export const useGeminiStream = (
         }
 
         if (executableToolCallRequests.length > 0) {
-          const interactionOwner = activeInteractionOwnerRef.current;
-          if (trackInteractionOwner && interactionOwner) {
+          if (streamInteractionOwner) {
             for (const request of executableToolCallRequests) {
               interactionOwnersByToolCallIdRef.current.set(
                 request.callId,
-                interactionOwner,
+                streamInteractionOwner,
               );
             }
           }
@@ -3778,7 +3786,9 @@ export const useGeminiStream = (
             0,
             activeModelStreamsRef.current - 1,
           );
-          if (activeModelStreamsRef.current === 0) {
+          const shouldDrainCompletedToolBatches =
+            activeModelStreamsRef.current === 0;
+          if (shouldDrainCompletedToolBatches) {
             setIsResponding(false);
           }
           if (goalBinding) {
@@ -3813,6 +3823,21 @@ export const useGeminiStream = (
             activeGoalAdmissionRef.current = null;
           }
           releaseSubmissionLease();
+          if (shouldDrainCompletedToolBatches) {
+            const pendingCompletedToolBatches =
+              pendingCompletedToolBatchesRef.current.splice(0);
+            const pendingCompletedTools = new Map<string, TrackedToolCall>();
+            for (const pendingBatch of pendingCompletedToolBatches) {
+              for (const toolCall of pendingBatch) {
+                pendingCompletedTools.set(toolCall.request.callId, toolCall);
+              }
+            }
+            if (pendingCompletedTools.size > 0) {
+              await handleCompletedToolsRef.current([
+                ...pendingCompletedTools.values(),
+              ]);
+            }
+          }
         }
       });
     },
@@ -4048,9 +4073,19 @@ export const useGeminiStream = (
           );
         }
         markToolsAsSubmitted(dedupedCallIds);
+        for (const callId of dedupedCallIds) {
+          interactionOwnersByToolCallIdRef.current.delete(callId);
+        }
       }
 
       if (activeModelStreamsRef.current > 0) {
+        const deferredTools = completedAndReadyToSubmitTools.filter(
+          (toolCall) =>
+            !historyCallIdsWithResponse.has(toolCall.request.callId),
+        );
+        if (deferredTools.length > 0) {
+          pendingCompletedToolBatchesRef.current.push(deferredTools);
+        }
         return;
       }
 
@@ -4076,7 +4111,7 @@ export const useGeminiStream = (
           !processedMemoryToolsRef.current.has(t.request.callId),
       );
 
-      const geminiTools = completedAndReadyToSubmitTools.filter(
+      let geminiTools = completedAndReadyToSubmitTools.filter(
         (t) =>
           !t.request.isClientInitiated &&
           !historyCallIdsWithResponse.has(t.request.callId),
@@ -4084,26 +4119,87 @@ export const useGeminiStream = (
       const terminalPromptId = completedAndReadyToSubmitTools.find(
         (toolCall) => !toolCall.request.isClientInitiated,
       )?.request.prompt_id;
+      const ownerForToolCall = (toolCall: TrackedToolCall) =>
+        interactionOwnersByToolCallIdRef.current.get(toolCall.request.callId) ??
+        (activeInteractionPromptIdRef.current === toolCall.request.prompt_id
+          ? activeInteractionOwnerRef.current
+          : undefined);
+      const liveOwnerForToolCall = (toolCall: TrackedToolCall) => {
+        const owner = ownerForToolCall(toolCall);
+        const ownerPromptId = toolCall.request.prompt_id;
+        return owner &&
+          ownerPromptId &&
+          getActiveInteractionSpan(ownerPromptId) === owner
+          ? owner
+          : undefined;
+      };
+      const liveActiveInteractionOwner =
+        activeInteractionPromptIdRef.current &&
+        activeInteractionOwnerRef.current &&
+        getActiveInteractionSpan(activeInteractionPromptIdRef.current) ===
+          activeInteractionOwnerRef.current
+          ? activeInteractionOwnerRef.current
+          : undefined;
       const ownerToolCall =
+        (liveActiveInteractionOwner
+          ? geminiTools.find(
+              (toolCall) =>
+                liveOwnerForToolCall(toolCall) === liveActiveInteractionOwner,
+            )
+          : undefined) ??
+        geminiTools.find((toolCall) => liveOwnerForToolCall(toolCall)) ??
         geminiTools[0] ??
         completedAndReadyToSubmitTools.find(
           (toolCall) => !toolCall.request.isClientInitiated,
         );
       const interactionOwner = ownerToolCall
-        ? (interactionOwnersByToolCallIdRef.current.get(
-            ownerToolCall.request.callId,
-          ) ??
-          (activeInteractionPromptIdRef.current ===
-          ownerToolCall.request.prompt_id
-            ? activeInteractionOwnerRef.current
-            : undefined))
+        ? liveOwnerForToolCall(ownerToolCall)
         : undefined;
+      const secondaryInteractionOwners = new Map<
+        NonNullable<ReturnType<typeof getActiveInteractionSpan>>,
+        string
+      >();
+      const secondaryTools = interactionOwner
+        ? geminiTools.filter(
+            (toolCall) => ownerForToolCall(toolCall) !== interactionOwner,
+          )
+        : [];
+      for (const toolCall of secondaryTools) {
+        const secondaryOwner = ownerForToolCall(toolCall);
+        if (secondaryOwner && toolCall.request.prompt_id) {
+          secondaryInteractionOwners.set(
+            secondaryOwner,
+            toolCall.request.prompt_id,
+          );
+        }
+        if (toolCall.status !== 'cancelled') {
+          geminiClient?.recordCompletedToolCall(
+            toolCall.request.name,
+            toolCall.request.args as Record<string, unknown>,
+          );
+        }
+        dualOutput?.emitToolResult(toolCall.request, toolCall.response);
+      }
+      if (secondaryTools.length > 0) {
+        const secondaryCallIds = new Set(
+          secondaryTools.map((toolCall) => toolCall.request.callId),
+        );
+        markToolsAsSubmitted([...secondaryCallIds]);
+        geminiTools = geminiTools.filter(
+          (toolCall) => !secondaryCallIds.has(toolCall.request.callId),
+        );
+      }
       for (const toolCall of completedAndReadyToSubmitTools) {
         interactionOwnersByToolCallIdRef.current.delete(
           toolCall.request.callId,
         );
       }
-      let promptId = geminiTools[0]?.request.prompt_id;
+      for (const [owner, ownerPromptId] of secondaryInteractionOwners) {
+        if (getActiveInteractionSpan(ownerPromptId) === owner) {
+          endInteractionSpan('cancelled', { promptId: ownerPromptId });
+        }
+      }
+      let promptId = ownerToolCall?.request.prompt_id;
       const endToolInteraction = (
         status: 'ok' | 'error' | 'cancelled',
         errorMessage?: string,
@@ -4279,9 +4375,10 @@ export const useGeminiStream = (
         );
       }
       const completedCallIds = new Set(
-        completedAndReadyToSubmitTools.map(
-          (toolCall) => toolCall.request.callId,
-        ),
+        geminiTools.map((toolCall) => toolCall.request.callId),
+      );
+      const secondaryCallIds = new Set(
+        secondaryTools.map((toolCall) => toolCall.request.callId),
       );
       const readyDuplicateBatches: PendingDuplicateToolResponses[] = [];
       pendingDuplicateToolResponsesRef.current =
@@ -4292,11 +4389,19 @@ export const useGeminiStream = (
           if (isReady) {
             readyDuplicateBatches.push(batch);
           }
-          return !isReady;
+          const belongsToSecondaryOwner = [...batch.executableCallIds].some(
+            (callId) => secondaryCallIds.has(callId),
+          );
+          return !isReady && !belongsToSecondaryOwner;
         });
-      const pendingDuplicateResponses = readyDuplicateBatches.flatMap(
-        (batch) => batch.duplicateResponses,
-      );
+      const pendingDuplicateResponses = readyDuplicateBatches
+        .flatMap((batch) => batch.duplicateResponses)
+        .filter(
+          ({ request }) =>
+            !interactionOwner ||
+            !request.prompt_id ||
+            request.prompt_id === promptId,
+        );
       const pendingDuplicatePromptId = readyDuplicateBatches[0]?.promptId;
       if (!promptId && pendingDuplicatePromptId) {
         promptId = pendingDuplicatePromptId;
@@ -4520,7 +4625,7 @@ export const useGeminiStream = (
       );
       if (terminatesGoalTurn && toolGoalBinding) {
         geminiClient.addHistory({ role: 'user', parts: responsesToSend });
-        let goalFinishFailed = false;
+        let goalFinishErrorMessage: string | undefined;
         try {
           await config.getChatRecordingService()?.flush();
           const runtime = await config.getGoalRuntimeReady();
@@ -4548,19 +4653,20 @@ export const useGeminiStream = (
             }
           }
         } catch (error) {
-          goalFinishFailed = true;
+          const errorMessage = getErrorMessage(error);
+          goalFinishErrorMessage = `Goal tool continuation could not finish: ${errorMessage}`;
           await failClosedGoalTurn(
             toolGoalBinding,
-            `Goal turn could not finish: ${getErrorMessage(error)}`,
+            `Goal turn could not finish: ${errorMessage}`,
           );
         } finally {
           // Idempotent with the release inside failClosedGoalTurn; also covers the success path.
           releaseGoalTurn(toolGoalBinding);
         }
-        if (goalFinishFailed) {
+        if (goalFinishErrorMessage) {
           endToolInteraction(
             'error',
-            'Goal tool continuation could not finish',
+            goalFinishErrorMessage,
             'continuation_goal_finish_failed',
           );
         } else {
@@ -4803,6 +4909,7 @@ export const useGeminiStream = (
       releaseGoalTurn,
     ],
   );
+  handleCompletedToolsRef.current = handleCompletedTools;
 
   const pendingHistoryItems = useMemo(
     () =>

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -4916,7 +4916,9 @@ export const useGeminiStream = (
       releaseGoalTurn,
     ],
   );
-  handleCompletedToolsRef.current = handleCompletedTools;
+  useLayoutEffect(() => {
+    handleCompletedToolsRef.current = handleCompletedTools;
+  }, [handleCompletedTools]);
 
   const pendingHistoryItems = useMemo(
     () =>

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -136,6 +136,12 @@ import {
 
 const debugLogger = createDebugLogger('GEMINI_STREAM');
 
+interface ToolContinuationOwner {
+  promptId: string;
+  signal: AbortSignal;
+  survivesGenerationChange: boolean;
+}
+
 // The per-turn model override is held in two coupled refs: the model id and a
 // flag marking whether it came from an explicit inline `/model <id> <prompt>`
 // (which must win over skill-tool overrides for the rest of the turn). The two
@@ -838,6 +844,9 @@ export const useGeminiStream = (
   const interactionOwnersByToolCallIdRef = useRef(
     new Map<string, NonNullable<ReturnType<typeof getActiveInteractionSpan>>>(),
   );
+  const continuationOwnersByToolCallIdRef = useRef(
+    new Map<string, ToolContinuationOwner>(),
+  );
   const pendingCompletedToolBatchesRef = useRef<TrackedToolCall[][]>([]);
   const handleCompletedToolsRef = useRef<
     (completedTools: TrackedToolCall[]) => Promise<void>
@@ -1314,7 +1323,7 @@ export const useGeminiStream = (
       queryToSend: PartListUnion | null;
       shouldProceed: boolean;
     }> => {
-      if (turnCancelledRef.current) {
+      if (turnCancelledRef.current && !preserveTurnOwnership) {
         return { queryToSend: null, shouldProceed: false };
       }
       if (typeof query === 'string' && query.trim().length === 0) {
@@ -2294,6 +2303,7 @@ export const useGeminiStream = (
       turnAdmission?: GoalTurnAdmission,
       promptId?: string,
       trackInteractionOwner = true,
+      toolContinuationOwner?: ToolContinuationOwner,
     ): Promise<StreamProcessingResult> => {
       let geminiMessageBuffer = '';
       let thoughtBuffer = '';
@@ -2865,6 +2875,14 @@ export const useGeminiStream = (
         }
 
         if (executableToolCallRequests.length > 0) {
+          if (toolContinuationOwner) {
+            for (const request of executableToolCallRequests) {
+              continuationOwnersByToolCallIdRef.current.set(
+                request.callId,
+                toolContinuationOwner,
+              );
+            }
+          }
           if (streamInteractionOwner) {
             for (const request of executableToolCallRequests) {
               interactionOwnersByToolCallIdRef.current.set(
@@ -3176,6 +3194,7 @@ export const useGeminiStream = (
         claimGoalTurn?: () => QueuedGoalTurn | undefined;
         userAdmission?: DirectUserAdmission;
         goalBinding?: GoalTurnBinding;
+        toolContinuationOwner?: ToolContinuationOwner;
       },
     ) => {
       const allowConcurrentBtwDuringResponse =
@@ -3367,10 +3386,13 @@ export const useGeminiStream = (
 
       const abortController = new AbortController();
       const abortSignal = abortController.signal;
+      const inheritedToolContinuationOwner = metadata?.toolContinuationOwner;
+      const isDetachedToolContinuation =
+        inheritedToolContinuationOwner?.survivesGenerationChange === true;
 
       // Keep the main stream's cancellation state intact while /btw is handled
       // in parallel. The side-question can use its own local abort signal.
-      if (!allowConcurrentBtwDuringResponse) {
+      if (!allowConcurrentBtwDuringResponse && !isDetachedToolContinuation) {
         abortControllerRef.current = abortController;
         turnCancelledRef.current = false;
       }
@@ -3425,7 +3447,8 @@ export const useGeminiStream = (
                     prompt_id!,
                     submitType,
                     submittedPrompt,
-                    allowConcurrentBtwDuringResponse,
+                    allowConcurrentBtwDuringResponse ||
+                      isDetachedToolContinuation,
                   );
         } catch (error) {
           await releaseUndeliveredGoalTurn(metadata?.userAdmission?.turnKey);
@@ -3484,9 +3507,24 @@ export const useGeminiStream = (
         const turnController =
           goalBinding?.controller ??
           (turnKey ? new AbortController() : undefined);
-        const processingSignal = turnController
-          ? AbortSignal.any([abortSignal, turnController.signal])
-          : abortSignal;
+        const processingSignals = [abortSignal];
+        if (turnController) {
+          processingSignals.push(turnController.signal);
+        }
+        if (inheritedToolContinuationOwner) {
+          processingSignals.push(inheritedToolContinuationOwner.signal);
+        }
+        const processingSignal =
+          processingSignals.length > 1
+            ? AbortSignal.any(processingSignals)
+            : abortSignal;
+        const toolContinuationOwner: ToolContinuationOwner = {
+          promptId: prompt_id!,
+          signal: processingSignal,
+          survivesGenerationChange:
+            allowConcurrentBtwDuringResponse ||
+            inheritedToolContinuationOwner?.survivesGenerationChange === true,
+        };
         const turnAdmission =
           turnKey && turnController
             ? {
@@ -3614,9 +3652,12 @@ export const useGeminiStream = (
               ? { getSteerInput: drainSteerAtBoundary }
               : {}),
           };
+          const providerSignal = inheritedToolContinuationOwner
+            ? processingSignal
+            : abortSignal;
           const stream = geminiClient.sendMessageStream(
             finalQueryToSend,
-            abortSignal,
+            providerSignal,
             prompt_id!,
             {
               ...sendOptions,
@@ -3649,6 +3690,7 @@ export const useGeminiStream = (
             turnAdmission,
             prompt_id,
             !allowConcurrentBtwDuringResponse,
+            toolContinuationOwner,
           );
           if (
             !goalBinding &&
@@ -4053,7 +4095,6 @@ export const useGeminiStream = (
             return false;
           },
         );
-
       // History-based dedup MUST run before the active-stream early-return.
       // If a synthetic `functionResponse` for this callId is already in
       // chat.history (planted on session-load by
@@ -4122,6 +4163,7 @@ export const useGeminiStream = (
         markToolsAsSubmitted(dedupedCallIds);
         for (const callId of dedupedCallIds) {
           interactionOwnersByToolCallIdRef.current.delete(callId);
+          continuationOwnersByToolCallIdRef.current.delete(callId);
         }
       }
 
@@ -4135,6 +4177,23 @@ export const useGeminiStream = (
         }
         return;
       }
+
+      const continuationOwner = completedAndReadyToSubmitTools
+        .filter(
+          (toolCall) =>
+            !historyCallIdsWithResponse.has(toolCall.request.callId),
+        )
+        .map((toolCall) =>
+          continuationOwnersByToolCallIdRef.current.get(
+            toolCall.request.callId,
+          ),
+        )
+        .find((owner) => owner !== undefined);
+      const continuationWasCancelled = () =>
+        continuationOwner
+          ? continuationOwner.signal.aborted
+          : turnCancelledRef.current ||
+            abortControllerRef.current?.signal.aborted === true;
 
       // Finalize any client-initiated tools as soon as they are done.
       // Skip ones whose callId already lives in chat history with a
@@ -4240,13 +4299,17 @@ export const useGeminiStream = (
         interactionOwnersByToolCallIdRef.current.delete(
           toolCall.request.callId,
         );
+        continuationOwnersByToolCallIdRef.current.delete(
+          toolCall.request.callId,
+        );
       }
       for (const [owner, ownerPromptId] of secondaryInteractionOwners) {
         if (getActiveInteractionSpan(ownerPromptId) === owner) {
           endInteractionSpan('cancelled', { promptId: ownerPromptId });
         }
       }
-      let promptId = ownerToolCall?.request.prompt_id;
+      let promptId =
+        ownerToolCall?.request.prompt_id ?? continuationOwner?.promptId;
       const endToolInteraction = (
         status: 'ok' | 'error' | 'cancelled',
         errorMessage?: string,
@@ -4573,10 +4636,7 @@ export const useGeminiStream = (
         );
       });
 
-      if (
-        turnCancelledRef.current ||
-        abortControllerRef.current?.signal.aborted
-      ) {
+      if (continuationWasCancelled()) {
         markToolsAsSubmitted(
           geminiTools.map((toolCall) => toolCall.request.callId),
         );
@@ -4865,7 +4925,8 @@ export const useGeminiStream = (
       // them after the tool responses as genuine user content.
       // Skip if the turn was cancelled — messages stay in queue for next turn.
       const drained =
-        turnCancelledRef.current || abortControllerRef.current?.signal.aborted
+        continuationOwner?.survivesGenerationChange ||
+        continuationWasCancelled()
           ? []
           : (midTurnDrainRef?.current?.(
               false,
@@ -4895,10 +4956,7 @@ export const useGeminiStream = (
         }
       }
 
-      if (
-        turnCancelledRef.current ||
-        abortControllerRef.current?.signal.aborted
-      ) {
+      if (continuationWasCancelled()) {
         drainedSteer?.restore();
         if (toolGoalBinding) {
           await failClosedGoalTurn(
@@ -4938,6 +4996,7 @@ export const useGeminiStream = (
           );
         },
         goalBinding: toolGoalBinding,
+        toolContinuationOwner: continuationOwner,
       });
     },
     [
@@ -4956,6 +5015,7 @@ export const useGeminiStream = (
       releaseGoalTurn,
     ],
   );
+
   useLayoutEffect(() => {
     handleCompletedToolsRef.current = handleCompletedTools;
   }, [handleCompletedTools]);

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -3700,7 +3700,9 @@ export const useGeminiStream = (
             modelOverride: modelOverrideRef.current,
             steerInput: metadata?.steerInput,
             ...(submittedPrompt !== undefined ? { submittedPrompt } : {}),
-            ...(!allowConcurrentBtwDuringResponse && midTurnDrainRef
+            ...(!allowConcurrentBtwDuringResponse &&
+            !isDetachedToolContinuation &&
+            midTurnDrainRef
               ? { getSteerInput: drainSteerAtBoundary }
               : {}),
           };

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -690,6 +690,36 @@ export const useGeminiStream = (
   const [isResponding, setIsResponding] = useState<boolean>(false);
   // React state can lag by one render; this tracks the actual stream lifetime.
   const activeModelStreamsRef = useRef(0);
+  // A continuation may be admitted while an earlier submission is finalizing.
+  const submissionActivitiesByGenerationRef = useRef(new Map<number, number>());
+  const retainSubmissionActivity = useCallback(
+    (generation: number) => {
+      submissionActivitiesByGenerationRef.current.set(
+        generation,
+        (submissionActivitiesByGenerationRef.current.get(generation) ?? 0) + 1,
+      );
+      return () => {
+        const remainingActivities = Math.max(
+          0,
+          (submissionActivitiesByGenerationRef.current.get(generation) ?? 1) -
+            1,
+        );
+        if (remainingActivities === 0) {
+          submissionActivitiesByGenerationRef.current.delete(generation);
+          if (generation === submissionLeaseGenerationRef.current) {
+            setIsResponding(false);
+            setSubmissionInFlight(false);
+          }
+        } else {
+          submissionActivitiesByGenerationRef.current.set(
+            generation,
+            remainingActivities,
+          );
+        }
+      };
+    },
+    [setSubmissionInFlight],
+  );
   const [thought, setThought] = useState<ThoughtSummary | null>(null);
   // Hold the latest history in a ref so handleCompletedTools can read it
   // without depending on `history` (which would recreate the tool scheduler
@@ -829,18 +859,25 @@ export const useGeminiStream = (
       async (completedToolCallsFromScheduler) => {
         // This onComplete is called when ALL scheduled tools for a given batch are done.
         if (completedToolCallsFromScheduler.length > 0) {
-          const projectRoot = config.getProjectRoot();
-          // Add the final state of these tools to the history for display.
-          const toolGroupDisplay = mapTrackedToolCallsToDisplay(
-            completedToolCallsFromScheduler as TrackedToolCall[],
-            projectRoot,
-          );
-          addItem(toolGroupDisplay, Date.now());
+          const releaseToolCompletionActivity = isSubmittingQueryRef.current
+            ? retainSubmissionActivity(submissionLeaseGenerationRef.current)
+            : undefined;
+          try {
+            const projectRoot = config.getProjectRoot();
+            // Add the final state of these tools to the history for display.
+            const toolGroupDisplay = mapTrackedToolCallsToDisplay(
+              completedToolCallsFromScheduler as TrackedToolCall[],
+              projectRoot,
+            );
+            addItem(toolGroupDisplay, Date.now());
 
-          // Handle tool response submission immediately when tools complete
-          await handleCompletedTools(
-            completedToolCallsFromScheduler as TrackedToolCall[],
-          );
+            // Handle tool response submission immediately when tools complete
+            await handleCompletedTools(
+              completedToolCallsFromScheduler as TrackedToolCall[],
+            );
+          } finally {
+            releaseToolCompletionActivity?.();
+          }
         }
       },
       config,
@@ -3194,6 +3231,7 @@ export const useGeminiStream = (
 
       // Set the flag to indicate we're now executing
       acquireSubmissionLease();
+      const submissionGeneration = submissionLeaseGenerationRef.current;
 
       // loopDetectedRef now gates tool-call scheduling (see processGeminiStream
       // events), so it must reflect only this turn's state. Reset it
@@ -3343,7 +3381,9 @@ export const useGeminiStream = (
         }
       }
 
-      return promptIdContext.run(prompt_id, async () => {
+      const releaseSubmissionActivity =
+        retainSubmissionActivity(submissionGeneration);
+      const submission = promptIdContext.run(prompt_id, async () => {
         let queuedGoal = metadata?.goal;
         let preparedQuery: {
           queryToSend: PartListUnion | null;
@@ -3789,9 +3829,6 @@ export const useGeminiStream = (
           );
           const shouldDrainCompletedToolBatches =
             activeModelStreamsRef.current === 0;
-          if (shouldDrainCompletedToolBatches) {
-            setSubmissionInFlight(true);
-          }
           if (goalBinding) {
             let retainGoalBinding =
               keepGoalBinding && !goalBinding.controller.signal.aborted;
@@ -3823,30 +3860,24 @@ export const useGeminiStream = (
           ) {
             activeGoalAdmissionRef.current = null;
           }
-          try {
-            if (shouldDrainCompletedToolBatches) {
-              const pendingCompletedToolBatches =
-                pendingCompletedToolBatchesRef.current.splice(0);
-              const pendingCompletedTools = new Map<string, TrackedToolCall>();
-              for (const pendingBatch of pendingCompletedToolBatches) {
-                for (const toolCall of pendingBatch) {
-                  pendingCompletedTools.set(toolCall.request.callId, toolCall);
-                }
-              }
-              if (pendingCompletedTools.size > 0) {
-                await handleCompletedToolsRef.current([
-                  ...pendingCompletedTools.values(),
-                ]);
+          if (shouldDrainCompletedToolBatches) {
+            const pendingCompletedToolBatches =
+              pendingCompletedToolBatchesRef.current.splice(0);
+            const pendingCompletedTools = new Map<string, TrackedToolCall>();
+            for (const pendingBatch of pendingCompletedToolBatches) {
+              for (const toolCall of pendingBatch) {
+                pendingCompletedTools.set(toolCall.request.callId, toolCall);
               }
             }
-          } finally {
-            if (shouldDrainCompletedToolBatches) {
-              setIsResponding(false);
-              setSubmissionInFlight(false);
+            if (pendingCompletedTools.size > 0) {
+              await handleCompletedToolsRef.current([
+                ...pendingCompletedTools.values(),
+              ]);
             }
           }
         }
       });
+      return submission.finally(releaseSubmissionActivity);
     },
     [
       streamingState,
@@ -3878,6 +3909,7 @@ export const useGeminiStream = (
       bindGoalTurn,
       failClosedGoalTurn,
       releaseUndeliveredGoalTurn,
+      retainSubmissionActivity,
       setSubmissionInFlight,
     ],
   );

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -140,6 +140,8 @@ interface ToolContinuationOwner {
   promptId: string;
   signal: AbortSignal;
   survivesGenerationChange: boolean;
+  detachedAbortController?: AbortController;
+  foregroundAbortController?: AbortController;
 }
 
 // The per-turn model override is held in two coupled refs: the model id and a
@@ -847,6 +849,9 @@ export const useGeminiStream = (
   const continuationOwnersByToolCallIdRef = useRef(
     new Map<string, ToolContinuationOwner>(),
   );
+  const detachedToolContinuationAbortControllersRef = useRef(
+    new Set<AbortController>(),
+  );
   const pendingCompletedToolBatchesRef = useRef<TrackedToolCall[][]>([]);
   const handleCompletedToolsRef = useRef<
     (completedTools: TrackedToolCall[]) => Promise<void>
@@ -1093,10 +1098,14 @@ export const useGeminiStream = (
   }, [streamingState, config, history]);
 
   const cancelOngoingRequest = useCallback(() => {
-    if (streamingState !== StreamingState.Responding) {
+    if (turnCancelledRef.current) {
+      for (const controller of detachedToolContinuationAbortControllersRef.current) {
+        controller.abort();
+      }
+      detachedToolContinuationAbortControllersRef.current.clear();
       return;
     }
-    if (turnCancelledRef.current) {
+    if (streamingState !== StreamingState.Responding) {
       return;
     }
     // Flush throttled stream chunks FIRST so anything sitting in the
@@ -1119,7 +1128,18 @@ export const useGeminiStream = (
     turnCancelledRef.current = true;
     submissionLeaseGenerationRef.current += 1;
     setSubmissionInFlight(false);
-    abortControllerRef.current?.abort();
+    const foregroundAbortController = abortControllerRef.current;
+    if (
+      foregroundAbortController &&
+      !foregroundAbortController.signal.aborted
+    ) {
+      foregroundAbortController.abort();
+    } else {
+      for (const controller of detachedToolContinuationAbortControllersRef.current) {
+        controller.abort();
+      }
+      detachedToolContinuationAbortControllersRef.current.clear();
+    }
     const activeInteractionPromptId = activeInteractionPromptIdRef.current;
     const activeInteractionOwner = activeInteractionOwnerRef.current;
     if (
@@ -1322,6 +1342,7 @@ export const useGeminiStream = (
     ): Promise<{
       queryToSend: PartListUnion | null;
       shouldProceed: boolean;
+      scheduledToolCallId?: string;
     }> => {
       if (turnCancelledRef.current && !preserveTurnOwnership) {
         return { queryToSend: null, shouldProceed: false };
@@ -1391,7 +1412,11 @@ export const useGeminiStream = (
                 prompt_id,
               };
               scheduleToolCalls([toolCallRequest], abortSignal);
-              return { queryToSend: null, shouldProceed: false };
+              return {
+                queryToSend: null,
+                shouldProceed: false,
+                scheduledToolCallId: toolCallRequest.callId,
+              };
             }
             case 'submit_prompt': {
               localQueryToSendToGemini = slashCommandResult.content;
@@ -3389,6 +3414,19 @@ export const useGeminiStream = (
       const inheritedToolContinuationOwner = metadata?.toolContinuationOwner;
       const isDetachedToolContinuation =
         inheritedToolContinuationOwner?.survivesGenerationChange === true;
+      const detachedAbortController =
+        inheritedToolContinuationOwner?.detachedAbortController ??
+        (allowConcurrentBtwDuringResponse ? abortController : undefined);
+      const foregroundAbortController =
+        allowConcurrentBtwDuringResponse || isDetachedToolContinuation
+          ? undefined
+          : abortController;
+      let keepToolContinuationAbortController = false;
+      if (detachedAbortController) {
+        detachedToolContinuationAbortControllersRef.current.add(
+          detachedAbortController,
+        );
+      }
 
       // Keep the main stream's cancellation state intact while /btw is handled
       // in parallel. The side-question can use its own local abort signal.
@@ -3418,6 +3456,7 @@ export const useGeminiStream = (
         let preparedQuery: {
           queryToSend: PartListUnion | null;
           shouldProceed: boolean;
+          scheduledToolCallId?: string;
         };
         try {
           preparedQuery =
@@ -3456,7 +3495,18 @@ export const useGeminiStream = (
           metadata?.onAdmissionFailed?.();
           throw error;
         }
-        const { queryToSend, shouldProceed } = preparedQuery;
+        const { queryToSend, shouldProceed, scheduledToolCallId } =
+          preparedQuery;
+
+        if (scheduledToolCallId && foregroundAbortController) {
+          keepToolContinuationAbortController = true;
+          continuationOwnersByToolCallIdRef.current.set(scheduledToolCallId, {
+            promptId: prompt_id!,
+            signal: abortSignal,
+            survivesGenerationChange: false,
+            foregroundAbortController,
+          });
+        }
 
         if (!shouldProceed || queryToSend === null) {
           await releaseUndeliveredGoalTurn(metadata?.userAdmission?.turnKey);
@@ -3524,6 +3574,8 @@ export const useGeminiStream = (
           survivesGenerationChange:
             allowConcurrentBtwDuringResponse ||
             inheritedToolContinuationOwner?.survivesGenerationChange === true,
+          detachedAbortController,
+          foregroundAbortController,
         };
         const turnAdmission =
           turnKey && turnController
@@ -3702,6 +3754,8 @@ export const useGeminiStream = (
             goalBinding = activeGoalTurnRef.current;
           }
           keepGoalBinding = processingResult.scheduledToolContinuation;
+          keepToolContinuationAbortController =
+            processingResult.scheduledToolContinuation;
 
           if (
             processingResult.status === StreamProcessingStatus.UserCancelled
@@ -3927,7 +3981,21 @@ export const useGeminiStream = (
           }
         }
       });
-      return submission.finally(releaseSubmissionActivity);
+      return submission.finally(() => {
+        releaseSubmissionActivity();
+        if (detachedAbortController && !keepToolContinuationAbortController) {
+          detachedToolContinuationAbortControllersRef.current.delete(
+            detachedAbortController,
+          );
+        }
+        if (
+          foregroundAbortController &&
+          !keepToolContinuationAbortController &&
+          abortControllerRef.current === foregroundAbortController
+        ) {
+          abortControllerRef.current = null;
+        }
+      });
     },
     [
       streamingState,
@@ -4161,9 +4229,41 @@ export const useGeminiStream = (
           );
         }
         markToolsAsSubmitted(dedupedCallIds);
+        const detachedAbortControllers = new Set<AbortController>();
+        const foregroundAbortControllers = new Set<AbortController>();
         for (const callId of dedupedCallIds) {
+          const continuationOwner =
+            continuationOwnersByToolCallIdRef.current.get(callId);
+          if (continuationOwner?.detachedAbortController) {
+            detachedAbortControllers.add(
+              continuationOwner.detachedAbortController,
+            );
+          }
+          if (continuationOwner?.foregroundAbortController) {
+            foregroundAbortControllers.add(
+              continuationOwner.foregroundAbortController,
+            );
+          }
           interactionOwnersByToolCallIdRef.current.delete(callId);
           continuationOwnersByToolCallIdRef.current.delete(callId);
+        }
+        for (const controller of detachedAbortControllers) {
+          const isStillOwned = [
+            ...continuationOwnersByToolCallIdRef.current.values(),
+          ].some((owner) => owner.detachedAbortController === controller);
+          if (!isStillOwned) {
+            detachedToolContinuationAbortControllersRef.current.delete(
+              controller,
+            );
+          }
+        }
+        for (const controller of foregroundAbortControllers) {
+          const isStillOwned = [
+            ...continuationOwnersByToolCallIdRef.current.values(),
+          ].some((owner) => owner.foregroundAbortController === controller);
+          if (!isStillOwned && abortControllerRef.current === controller) {
+            abortControllerRef.current = null;
+          }
         }
       }
 
@@ -4315,6 +4415,18 @@ export const useGeminiStream = (
         errorMessage?: string,
         errorType?: string,
       ) => {
+        if (continuationOwner?.detachedAbortController) {
+          detachedToolContinuationAbortControllersRef.current.delete(
+            continuationOwner.detachedAbortController,
+          );
+        }
+        if (
+          continuationOwner?.foregroundAbortController &&
+          abortControllerRef.current ===
+            continuationOwner.foregroundAbortController
+        ) {
+          abortControllerRef.current = null;
+        }
         if (
           !promptId ||
           !interactionOwner ||

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.test.tsx
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.test.tsx
@@ -4,9 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import type { Part } from '@google/genai';
-import { mapToDisplay, type TrackedToolCall } from './useReactToolScheduler.js';
+import type { Config } from '@qwen-code/qwen-code-core';
+import { CoreToolScheduler } from '@qwen-code/qwen-code-core';
+import {
+  mapToDisplay,
+  type TrackedToolCall,
+  useReactToolScheduler,
+} from './useReactToolScheduler.js';
 import { MAX_INLINE_IMAGES_PER_ITEM } from '../utils/inline-image-parts.js';
 
 // Build a minimal successful tracked tool call with the fields mapToDisplay's
@@ -102,5 +109,43 @@ describe('mapToDisplay — detailedDisplay (§4.9 live path)', () => {
         .map((part) => part.inlineData),
     );
     expect(tool.omittedImageCount).toBe(2);
+  });
+});
+
+describe('useReactToolScheduler', () => {
+  it('handles a queued tool cancellation at the fire-and-forget boundary', async () => {
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockRejectedValueOnce(new Error('Tool call cancelled while in queue.'));
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const { result } = renderHook(() =>
+      useReactToolScheduler(
+        vi.fn(),
+        { getToolRegistry: () => ({}) } as unknown as Config,
+        () => undefined,
+        vi.fn(),
+      ),
+    );
+
+    act(() => {
+      result.current[1](
+        {
+          callId: 'queued-call',
+          name: 'read_file',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'queued-prompt',
+        },
+        abortController.signal,
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(scheduleSpy).toHaveBeenCalledOnce();
+    scheduleSpy.mockRestore();
   });
 });

--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -226,7 +226,14 @@ export function useReactToolScheduler(
       modelOverride?: string,
     ) => {
       if (!modelOverride?.endsWith('\0')) {
-        void scheduler.schedule(request, signal);
+        void scheduler.schedule(request, signal).catch((error: unknown) => {
+          if (signal.aborted) return;
+          debugLogger.error(
+            `Tool scheduling failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        });
         return;
       }
       void (async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -9203,6 +9203,58 @@ Other open files:
       );
     });
 
+    it('reports a safe actionable Arena category for API errors', async () => {
+      const arenaAgentClient = {
+        checkControlSignal: vi.fn().mockResolvedValue(null),
+        reportCancelled: vi.fn().mockResolvedValue(undefined),
+        reportCompleted: vi.fn().mockResolvedValue(undefined),
+        reportError: vi.fn().mockResolvedValue(undefined),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(mockConfig.getArenaAgentClient).mockReturnValue(
+        arenaAgentClient as unknown as ReturnType<
+          Config['getArenaAgentClient']
+        >,
+      );
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield {
+            type: GeminiEventType.Error,
+            value: {
+              error: {
+                message: 'Bearer secret-token in /private/user/path',
+                status: 429,
+              },
+            },
+          };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'prompt-id-arena-error',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(arenaAgentClient.reportError).toHaveBeenCalledWith(
+        'Rate limit exceeded',
+      );
+      expect(
+        JSON.stringify(arenaAgentClient.reportError.mock.calls),
+      ).not.toContain('secret-token');
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'error',
+        {
+          promptId: 'prompt-id-arena-error',
+          errorMessage: 'unknown error',
+          errorType: 'api_error',
+        },
+      );
+    });
+
     it('should not call checkNextSpeaker when turn.run() yields a value then an error', async () => {
       // Arrange
       const { checkNextSpeaker } = await import(

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -9255,6 +9255,58 @@ Other open files:
       );
     });
 
+    it('preserves the provider error outcome when Arena reporting fails', async () => {
+      const arenaAgentClient = {
+        checkControlSignal: vi.fn().mockResolvedValue(null),
+        reportCancelled: vi.fn().mockResolvedValue(undefined),
+        reportCompleted: vi.fn().mockResolvedValue(undefined),
+        reportError: vi
+          .fn()
+          .mockRejectedValue(new Error('status write failed')),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(mockConfig.getArenaAgentClient).mockReturnValue(
+        arenaAgentClient as unknown as ReturnType<
+          Config['getArenaAgentClient']
+        >,
+      );
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield {
+            type: GeminiEventType.Error,
+            value: {
+              error: { message: 'provider failed', status: 500 },
+            },
+          };
+        })(),
+      );
+
+      const events = await fromAsync(
+        client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-id-arena-reporting-error',
+        ),
+      );
+
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.Error,
+          value: {
+            error: { message: 'provider failed', status: 500 },
+          },
+        },
+      ]);
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'error',
+        {
+          promptId: 'prompt-id-arena-reporting-error',
+          errorMessage: 'unknown error',
+          errorType: 'api_error',
+        },
+      );
+    });
+
     it('reports authentication failures to Arena when Turn rethrows them', async () => {
       const arenaAgentClient = {
         checkControlSignal: vi.fn().mockResolvedValue(null),
@@ -9289,6 +9341,37 @@ Other open files:
       expect(
         JSON.stringify(arenaAgentClient.reportError.mock.calls),
       ).not.toContain('secret-token');
+    });
+
+    it('rethrows authentication failures when Arena reporting fails', async () => {
+      const arenaAgentClient = {
+        checkControlSignal: vi.fn().mockResolvedValue(null),
+        reportCancelled: vi.fn().mockResolvedValue(undefined),
+        reportCompleted: vi.fn().mockResolvedValue(undefined),
+        reportError: vi
+          .fn()
+          .mockRejectedValue(new Error('status write failed')),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(mockConfig.getArenaAgentClient).mockReturnValue(
+        arenaAgentClient as unknown as ReturnType<
+          Config['getArenaAgentClient']
+        >,
+      );
+      mockTurnRunFn.mockImplementationOnce(async function* () {
+        yield* [];
+        throw new UnauthorizedError('Bearer secret-token');
+      });
+
+      await expect(
+        fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-id-arena-auth-reporting-error',
+          ),
+        ),
+      ).rejects.toThrow(UnauthorizedError);
     });
 
     it('should not call checkNextSpeaker when turn.run() yields a value then an error', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -5696,6 +5696,62 @@ hello
       expect(mockTurnRunFn).not.toHaveBeenCalled();
     });
 
+    it('attributes blocked Goal finalization failures separately from hook failures', async () => {
+      const owner = {};
+      const permit = { goalId: 'goal-1', revision: 1, turnId: 'turn-1' };
+      const finishTurn = vi.fn().mockResolvedValue(undefined);
+      const goalRuntime = {
+        getSnapshot: () => emptyGoalSnapshot(),
+        permitForTurn: vi.fn(() => permit),
+        subscribe: vi.fn(() => vi.fn()),
+        finishTurn,
+      } as unknown as GoalRuntime;
+      const messageBus = {
+        request: vi.fn().mockResolvedValue({
+          output: { decision: 'block', reason: 'blocked by hook' },
+        }),
+        response: vi.fn(),
+      };
+      mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue(owner);
+      mockConfig.getGoalRuntimeReady = vi.fn().mockResolvedValue(goalRuntime);
+      vi.mocked(mockConfig.getChatRecordingService).mockReturnValue({
+        flush: vi.fn().mockRejectedValue(new Error('recording unavailable')),
+      } as unknown as ReturnType<Config['getChatRecordingService']>);
+      vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+      vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+        messageBus as unknown as ReturnType<Config['getMessageBus']>,
+      );
+      vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+        (event: string) => event === 'UserPromptSubmit',
+      );
+
+      await expect(
+        fromAsync(
+          client.sendMessageStream(
+            [{ text: 'continue the goal' }],
+            new AbortController().signal,
+            'prompt-goal-finalization-failure',
+            {
+              type: SendMessageType.UserQuery,
+              goalPermit: permit,
+              goalTurnKey: 'goal-runtime:turn-1',
+            },
+          ),
+        ),
+      ).rejects.toThrow('recording unavailable');
+
+      expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
+        'error',
+        {
+          promptId: 'prompt-goal-finalization-failure',
+          errorMessage: 'Goal turn finalization failed',
+          errorType: 'Error',
+        },
+      );
+      expect(finishTurn).toHaveBeenCalledWith(permit);
+      expect(mockTurnRunFn).not.toHaveBeenCalled();
+    });
+
     it('captures only the final physical response for an agent invocation', async () => {
       const owner = {};
       mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue(owner);
@@ -5801,7 +5857,7 @@ hello
       expect(capture.commitResponse).toHaveBeenCalledWith(false);
     });
 
-    it('starts Goal as a fresh agent invocation', async () => {
+    it('starts Goal as a fresh invocation without assigning the session structured-output contract', async () => {
       const permit = { goalId: 'goal-1', revision: 1, turnId: 'turn-1' };
       const finishTurn = vi.fn().mockResolvedValue(undefined);
       const goalRuntime = {
@@ -5811,6 +5867,7 @@ hello
         finishTurn,
       } as unknown as GoalRuntime;
       mockConfig.getGoalRuntimeReady = vi.fn().mockResolvedValue(goalRuntime);
+      vi.mocked(mockConfig.getJsonSchema).mockReturnValue({ type: 'object' });
       mockTurnRunFn.mockReturnValue(
         (async function* () {
           yield { type: GeminiEventType.Content, value: 'goal progress' };
@@ -5847,6 +5904,8 @@ hello
     });
 
     it('keeps a Steer continuation in the original invocation', async () => {
+      const owner = {};
+      mockInteractionTelemetry.getActiveInteractionSpan.mockReturnValue(owner);
       mockTurnRunFn.mockImplementation(() =>
         (async function* () {
           yield { type: GeminiEventType.Content, value: 'response' };
@@ -5873,6 +5932,11 @@ hello
       expect(
         mockInteractionTelemetry.startInteractionSpan,
       ).toHaveBeenCalledTimes(1);
+      expect(getSteerInput).toHaveBeenCalledTimes(2);
+      expect(mockTurnRunFn).toHaveBeenCalledTimes(2);
+      expect(
+        mockInteractionTelemetry.outputCaptures[1]?.writeToSpan,
+      ).toHaveBeenCalledWith(owner);
       expect(mockInteractionTelemetry.endInteractionSpan).toHaveBeenCalledWith(
         'ok',
         { promptId: 'prompt-steer-continuation' },
@@ -5907,6 +5971,120 @@ hello
         },
       );
     });
+
+    it.each([
+      SendMessageType.Cron,
+      SendMessageType.Notification,
+      SendMessageType.Teammate,
+    ])(
+      'does not assign the session structured-output contract to a %s invocation',
+      async (messageType) => {
+        vi.mocked(mockConfig.getJsonSchema).mockReturnValue({
+          type: 'object',
+        });
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'drain complete' };
+          })(),
+        );
+
+        await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'automatic work' }],
+            new AbortController().signal,
+            `prompt-${messageType}`,
+            { type: messageType },
+          ),
+        );
+
+        expect(
+          mockInteractionTelemetry.endInteractionSpan,
+        ).toHaveBeenCalledWith('ok', {
+          promptId: `prompt-${messageType}`,
+        });
+        expect(
+          mockInteractionTelemetry.endInteractionSpan,
+        ).not.toHaveBeenCalledWith(
+          'error',
+          expect.objectContaining({ errorType: 'structured_output_missing' }),
+        );
+      },
+    );
+
+    it.each([
+      [SendMessageType.UserQuery, 'error'],
+      [SendMessageType.Notification, 'ok'],
+    ] as const)(
+      'preserves the %s structured-output ownership across a tool continuation',
+      async (messageType, expectedStatus) => {
+        const promptId = `prompt-schema-tool-${messageType}`;
+        const owner = {};
+        mockInteractionTelemetry.getActiveInteractionSpan.mockImplementation(
+          (id?: string) =>
+            id === undefined || id === promptId ? owner : undefined,
+        );
+        vi.mocked(mockConfig.getJsonSchema).mockReturnValue({
+          type: 'object',
+        });
+        mockTurnRunFn
+          .mockReturnValueOnce(
+            (async function* () {
+              yield {
+                type: GeminiEventType.ToolCallRequest,
+                value: {
+                  callId: `call-${messageType}`,
+                  name: 'read_file',
+                  args: {},
+                  isClientInitiated: false,
+                  prompt_id: promptId,
+                },
+              };
+            })(),
+          )
+          .mockReturnValueOnce(
+            (async function* () {
+              yield { type: GeminiEventType.Content, value: 'plain text' };
+            })(),
+          );
+
+        await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'start' }],
+            new AbortController().signal,
+            promptId,
+            { type: messageType },
+          ),
+        );
+        await fromAsync(
+          client.sendMessageStream(
+            [
+              {
+                functionResponse: {
+                  name: 'read_file',
+                  response: { ok: true },
+                },
+              },
+            ],
+            new AbortController().signal,
+            promptId,
+            { type: SendMessageType.ToolResult },
+          ),
+        );
+
+        expect(
+          mockInteractionTelemetry.endInteractionSpan,
+        ).toHaveBeenCalledWith(
+          expectedStatus,
+          expectedStatus === 'error'
+            ? {
+                promptId,
+                errorMessage: 'model did not produce structured output',
+                errorType: 'structured_output_missing',
+              }
+            : { promptId },
+        );
+      },
+    );
 
     it('should discard pending prefetch with no_safe_delivery_point on a no-tool turn', async () => {
       // Recall stays pending — never settles before the turn completes.

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -9255,6 +9255,42 @@ Other open files:
       );
     });
 
+    it('reports authentication failures to Arena when Turn rethrows them', async () => {
+      const arenaAgentClient = {
+        checkControlSignal: vi.fn().mockResolvedValue(null),
+        reportCancelled: vi.fn().mockResolvedValue(undefined),
+        reportCompleted: vi.fn().mockResolvedValue(undefined),
+        reportError: vi.fn().mockResolvedValue(undefined),
+        updateStatus: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(mockConfig.getArenaAgentClient).mockReturnValue(
+        arenaAgentClient as unknown as ReturnType<
+          Config['getArenaAgentClient']
+        >,
+      );
+      mockTurnRunFn.mockImplementationOnce(async function* () {
+        yield* [];
+        throw new UnauthorizedError('Bearer secret-token');
+      });
+
+      await expect(
+        fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-id-arena-auth-error',
+          ),
+        ),
+      ).rejects.toThrow(UnauthorizedError);
+
+      expect(arenaAgentClient.reportError).toHaveBeenCalledWith(
+        'Authentication failed',
+      );
+      expect(
+        JSON.stringify(arenaAgentClient.reportError.mock.calls),
+      ).not.toContain('secret-token');
+    });
+
     it('should not call checkNextSpeaker when turn.run() yields a value then an error', async () => {
       // Arrange
       const { checkNextSpeaker } = await import(

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -3427,7 +3427,18 @@ export class GeminiClient {
           if (event.type === GeminiEventType.Error) {
             this.forceFullIdeContext = true;
             if (arenaAgentClient) {
-              await arenaAgentClient.reportError('Unknown error');
+              const status = event.value.error?.status;
+              const arenaError =
+                status === 401 || status === 403
+                  ? 'Authentication failed'
+                  : status === 429
+                    ? 'Rate limit exceeded'
+                    : status !== undefined && status >= 500
+                      ? 'Provider service unavailable'
+                      : status !== undefined
+                        ? `API request failed (${status})`
+                        : 'Provider request failed';
+              await arenaAgentClient.reportError(arenaError);
             }
             this.lastApiCompletionTimestamp = Date.now();
             // Sanitize: do not pass raw API error messages to span status.

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -3442,7 +3442,13 @@ export class GeminiClient {
                       : status !== undefined
                         ? `API request failed (${status})`
                         : 'Provider request failed';
-              await arenaAgentClient.reportError(arenaError);
+              try {
+                await arenaAgentClient.reportError(arenaError);
+              } catch {
+                this.config
+                  .getDebugLogger()
+                  .warn('Failed to report Arena provider error');
+              }
             }
             this.lastApiCompletionTimestamp = Date.now();
             // Sanitize: do not pass raw API error messages to span status.
@@ -4003,9 +4009,15 @@ export class GeminiClient {
         messageType !== SendMessageType.Hook &&
         messageType !== SendMessageType.Steer
       ) {
-        await this.config
-          .getArenaAgentClient()
-          ?.reportError('Authentication failed');
+        try {
+          await this.config
+            .getArenaAgentClient()
+            ?.reportError('Authentication failed');
+        } catch {
+          this.config
+            .getDebugLogger()
+            .warn('Failed to report Arena authentication error');
+        }
       }
       throw error;
     } finally {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -328,6 +328,10 @@ export class GeminiClient {
   private readonly surfacedRelevantAutoMemoryPaths = new Set<string>();
   private shutdownRequested = false;
   private readonly settledSteerInputs = new WeakSet<SteerInput>();
+  private readonly interactionStartTypeByOwner = new WeakMap<
+    object,
+    SendMessageType
+  >();
 
   private readonly loopDetector: LoopDetectionService;
   private lastPromptId: string | undefined = undefined;
@@ -2178,7 +2182,16 @@ export class GeminiClient {
       ) {
         return;
       }
-      if (status === 'ok' && this.config.getJsonSchema?.()) {
+      const interactionStartType =
+        this.interactionStartTypeByOwner.get(interactionOwner);
+      const ownsStructuredOutputContract =
+        interactionStartType === SendMessageType.UserQuery ||
+        interactionStartType === SendMessageType.Retry;
+      if (
+        status === 'ok' &&
+        ownsStructuredOutputContract &&
+        this.config.getJsonSchema?.()
+      ) {
         endInteractionSpan('error', {
           promptId: prompt_id,
           errorMessage: 'model did not produce structured output',
@@ -2425,6 +2438,12 @@ export class GeminiClient {
       interactionOwner = getActiveInteractionSpan(prompt_id);
       if (
         interactionOwner &&
+        !this.interactionStartTypeByOwner.has(interactionOwner)
+      ) {
+        this.interactionStartTypeByOwner.set(interactionOwner, messageType);
+      }
+      if (
+        interactionOwner &&
         messageType === SendMessageType.UserQuery &&
         typeof options?.submittedPrompt === 'string'
       ) {
@@ -2438,6 +2457,7 @@ export class GeminiClient {
     let userPromptRecordPayload: UserPromptRecordPayload | undefined;
     let hooksEnabled: boolean;
     let messageBus: ReturnType<Config['getMessageBus']>;
+    let userPromptSubmitFailureMessage = 'UserPromptSubmit hook failed';
     try {
       hooksEnabled = !this.config.getDisableAllHooks();
       messageBus = this.config.getMessageBus();
@@ -2488,6 +2508,7 @@ export class GeminiClient {
           hookOutput?.shouldStopExecution()
         ) {
           if (goalPermit) {
+            userPromptSubmitFailureMessage = 'Goal turn finalization failed';
             const runtime = await loadGoalRuntime(true);
             if (!runtime || !goalTurnKey) {
               throw new Error('Goal turn admission is unavailable');
@@ -2544,7 +2565,7 @@ export class GeminiClient {
     } catch (error) {
       endCurrentInteraction(
         signal.aborted ? 'cancelled' : 'error',
-        signal.aborted ? undefined : 'UserPromptSubmit hook failed',
+        signal.aborted ? undefined : userPromptSubmitFailureMessage,
         signal.aborted ? undefined : getErrorType(error),
       );
       for (const goalEvent of await finalizeInterruptedGoalTurn()) {
@@ -3406,23 +3427,11 @@ export class GeminiClient {
           if (event.type === GeminiEventType.Error) {
             this.forceFullIdeContext = true;
             if (arenaAgentClient) {
-              const errorMsg =
-                event.value instanceof Error
-                  ? event.value.message
-                  : 'Unknown error';
-              await arenaAgentClient.reportError(errorMsg);
+              await arenaAgentClient.reportError('Unknown error');
             }
             this.lastApiCompletionTimestamp = Date.now();
             // Sanitize: do not pass raw API error messages to span status.
-            const errMsg =
-              event.value instanceof Error ? '[API error]' : 'unknown error';
-            endCurrentInteraction(
-              'error',
-              errMsg,
-              event.value instanceof Error
-                ? getErrorType(event.value)
-                : 'api_error',
-            );
+            endCurrentInteraction('error', 'unknown error', 'api_error');
             // finally cleanup catches this, but cancel explicitly to match
             // the cleanup pattern at other early-return sites.
             this.cancelPendingMemoryPrefetch('no_safe_delivery_point');

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -133,7 +133,11 @@ import {
   replayUiTelemetryFromConversation,
 } from '../services/sessionService.js';
 import { reportError } from '../utils/errorReporting.js';
-import { getErrorMessage, getErrorType } from '../utils/errors.js';
+import {
+  getErrorMessage,
+  getErrorType,
+  UnauthorizedError,
+} from '../utils/errors.js';
 import { checkNextSpeaker } from '../utils/nextSpeakerChecker.js';
 import {
   flatMapTextParts,
@@ -3993,6 +3997,15 @@ export class GeminiClient {
     } catch (error) {
       for (const goalEvent of await finalizeInterruptedGoalTurn()) {
         yield goalEvent;
+      }
+      if (
+        error instanceof UnauthorizedError &&
+        messageType !== SendMessageType.Hook &&
+        messageType !== SendMessageType.Steer
+      ) {
+        await this.config
+          .getArenaAgentClient()
+          ?.reportError('Authentication failed');
       }
       throw error;
     } finally {

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -761,6 +761,7 @@ describe('LoggingContentGenerator', () => {
       cancelled: true,
       error: 'API call aborted',
     });
+    expect(logApiResponse).not.toHaveBeenCalled();
     expect(
       genAiExchangeState.controllers.at(-1)?.finalize,
     ).toHaveBeenCalledWith(false);
@@ -1295,6 +1296,7 @@ describe('LoggingContentGenerator', () => {
       cancelled: true,
       error: 'API call aborted',
     });
+    expect(logApiResponse).not.toHaveBeenCalled();
   });
 
   it('forwards usage attached to the final response after it was yielded', async () => {
@@ -2291,6 +2293,7 @@ describe('LoggingContentGenerator', () => {
       cancelled: true,
       error: 'API call aborted',
     });
+    expect(logApiResponse).not.toHaveBeenCalled();
   });
 
   it('does not let an abort after stream completion rewrite success', async () => {
@@ -2405,6 +2408,11 @@ describe('LoggingContentGenerator', () => {
       }
       return realSetTimeout(...args);
     }) as typeof setTimeout);
+    const abortController = new AbortController();
+    const removeAbortListener = vi.spyOn(
+      abortController.signal,
+      'removeEventListener',
+    );
 
     try {
       let releaseStream: (() => void) | undefined;
@@ -2450,6 +2458,7 @@ describe('LoggingContentGenerator', () => {
       const request = {
         model: 'test-model',
         contents: 'Hello',
+        config: { abortSignal: abortController.signal },
       } as unknown as GenerateContentParameters;
 
       const stream = await generator.generateContentStream(
@@ -2464,6 +2473,10 @@ describe('LoggingContentGenerator', () => {
 
       // Fire the idle timeout — span should end as timed-out.
       idleCallback?.();
+      expect(removeAbortListener).toHaveBeenCalledWith(
+        'abort',
+        expect.any(Function),
+      );
 
       const spanRecord = getStreamSpanRecord();
       expect(spanRecord.attributes['stream.timed_out']).toBe(true);
@@ -2629,6 +2642,62 @@ describe('LoggingContentGenerator', () => {
       error: 'API call aborted',
     });
     expect(record.statuses).toHaveLength(0);
+  });
+
+  it('keeps an observed provider error when abort races blocked error logging', async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    let releaseErrorLog: (() => void) | undefined;
+    const errorLogGate = new Promise<void>((resolve) => {
+      releaseErrorLog = resolve;
+    });
+    const providerError = new Error('provider failed');
+    const wrapped = createWrappedGenerator(
+      vi.fn(),
+      vi.fn().mockResolvedValue(
+        (async function* () {
+          yield* [];
+          throw providerError;
+        })(),
+      ),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: true,
+    });
+    const openaiLoggerInstance = vi.mocked(OpenAILogger).mock.results.at(-1)
+      ?.value as { logInteraction: ReturnType<typeof vi.fn> };
+    openaiLoggerInstance.logInteraction.mockReturnValueOnce(errorLogGate);
+
+    const stream = await generator.generateContentStream(
+      {
+        model: 'test-model',
+        contents: 'Hello',
+        config: { abortSignal: abortController.signal },
+      } as unknown as GenerateContentParameters,
+      'prompt-error-abort-timeout',
+    );
+    const pendingNext = stream.next();
+    await vi.waitFor(() => expect(logApiError).toHaveBeenCalledTimes(1));
+
+    abortController.abort();
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+
+    const record = getStreamSpanRecord();
+    expect(record.attributes['stream.timed_out']).toBe(true);
+    expect(record.endMetadata).toMatchObject({
+      success: false,
+      cancelled: false,
+      error: 'API call failed',
+    });
+    expect(record.statuses).toEqual([
+      { code: SpanStatusCode.ERROR, message: 'API call failed' },
+    ]);
+
+    releaseErrorLog?.();
+    await expect(pendingNext).rejects.toThrow('provider failed');
+    vi.useRealTimers();
   });
 
   it('preserves stream errors when error logging fails', async () => {

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -419,6 +419,7 @@ describe('LoggingContentGenerator', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     convertGeminiRequestToOpenAISpy.mockClear();
     convertGeminiToolsToOpenAISpy.mockClear();
     convertGeminiResponseToOpenAISpy.mockClear();
@@ -723,6 +724,80 @@ describe('LoggingContentGenerator', () => {
     });
     expect(spanRecord.statuses).toEqual([]);
     expect(spanRecord.ended).toBe(true);
+    expect(
+      genAiExchangeState.controllers.at(-1)?.finalize,
+    ).toHaveBeenCalledWith(true);
+  });
+
+  it('records cancellation when a non-stream provider resolves after swallowing an abort', async () => {
+    const abortController = new AbortController();
+    const response = createResponse('resp-cancelled', 'test-model', [
+      { text: 'partial' },
+    ]);
+    const wrapped = createWrappedGenerator(
+      vi.fn().mockImplementation(async () => {
+        abortController.abort();
+        return response;
+      }),
+      vi.fn(),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+
+    await generator.generateContent(
+      {
+        model: 'test-model',
+        contents: 'Hello',
+        config: { abortSignal: abortController.signal },
+      } as unknown as GenerateContentParameters,
+      'prompt-swallowed-abort',
+    );
+
+    expect(getGenerateContentSpanRecord().endMetadata).toMatchObject({
+      success: false,
+      cancelled: true,
+      error: 'API call aborted',
+    });
+    expect(
+      genAiExchangeState.controllers.at(-1)?.finalize,
+    ).toHaveBeenCalledWith(false);
+  });
+
+  it('does not let a non-stream abort after provider completion rewrite success', async () => {
+    const abortController = new AbortController();
+    vi.mocked(logApiResponse).mockImplementationOnce(() =>
+      abortController.abort(),
+    );
+    const wrapped = createWrappedGenerator(
+      vi
+        .fn()
+        .mockResolvedValue(
+          createResponse('resp-complete', 'test-model', [{ text: 'done' }]),
+        ),
+      vi.fn(),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+
+    await generator.generateContent(
+      {
+        model: 'test-model',
+        contents: 'Hello',
+        config: { abortSignal: abortController.signal },
+      } as unknown as GenerateContentParameters,
+      'prompt-complete-before-abort',
+    );
+
+    expect(getGenerateContentSpanRecord().endMetadata).toMatchObject({
+      success: true,
+      cancelled: false,
+    });
     expect(
       genAiExchangeState.controllers.at(-1)?.finalize,
     ).toHaveBeenCalledWith(true);
@@ -2504,6 +2579,56 @@ describe('LoggingContentGenerator', () => {
     } finally {
       setTimeoutSpy.mockRestore();
     }
+  });
+
+  it('keeps an aborted hanging stream classified as cancelled when the idle timeout closes it', async () => {
+    vi.useFakeTimers();
+    const abortController = new AbortController();
+    let releaseStream: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    const wrapped = createWrappedGenerator(
+      vi.fn(),
+      vi.fn().mockResolvedValue(
+        (async function* () {
+          await gate;
+          yield createResponse('late', 'test-model', [{ text: 'late' }]);
+        })(),
+      ),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+
+    const stream = await generator.generateContentStream(
+      {
+        model: 'test-model',
+        contents: 'Hello',
+        config: { abortSignal: abortController.signal },
+      } as unknown as GenerateContentParameters,
+      'prompt-aborted-idle-timeout',
+    );
+    const iterator = stream[Symbol.asyncIterator]();
+    const pendingNext = iterator.next();
+
+    abortController.abort();
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+    releaseStream?.();
+    await pendingNext;
+    await iterator.return(undefined);
+    vi.useRealTimers();
+
+    const record = getStreamSpanRecord();
+    expect(record.attributes['stream.timed_out']).toBe(true);
+    expect(record.endMetadata).toMatchObject({
+      success: false,
+      cancelled: true,
+      error: 'API call aborted',
+    });
+    expect(record.statuses).toHaveLength(0);
   });
 
   it('preserves stream errors when error logging fails', async () => {

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -407,24 +407,26 @@ export class LoggingContentGenerator implements ContentGenerator {
         const responseText = isInternal
           ? undefined
           : this.extractResponseText(result, MAX_RESPONSE_TEXT_LENGTH);
-        this.safelyLogApiResponse(
-          result.responseId ?? '',
-          durationMs,
-          result.modelVersion || req.model,
-          userPromptId,
-          requestSessionId,
-          result.usageMetadata,
-          responseText,
-        );
-        try {
-          await this.safelyLogOpenAIInteraction(
-            await session.resolve(req),
-            result,
-            undefined,
+        if (!abortedBeforeResponseCompletion) {
+          this.safelyLogApiResponse(
+            result.responseId ?? '',
+            durationMs,
+            result.modelVersion || req.model,
             userPromptId,
+            requestSessionId,
+            result.usageMetadata,
+            responseText,
           );
-        } catch (loggingError) {
-          debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
+          try {
+            await this.safelyLogOpenAIInteraction(
+              await session.resolve(req),
+              result,
+              undefined,
+              userPromptId,
+            );
+          } catch (loggingError) {
+            debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
+          }
         }
         return result;
       });
@@ -738,7 +740,9 @@ export class LoggingContentGenerator implements ContentGenerator {
           if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
           spanEndTimeout = setTimeout(() => {
             refreshLateUsageMetadata();
-            const cancelled = abortedBeforeStreamCompletion;
+            const cancelled =
+              abortedBeforeStreamCompletion &&
+              (lastError === undefined || isAbortError(lastError));
             try {
               span.setAttribute('stream.timed_out', true);
             } catch {
@@ -752,7 +756,17 @@ export class LoggingContentGenerator implements ContentGenerator {
               durationMs: Date.now() - startTime,
               error: cancelled
                 ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
-                : 'Stream span timed out (idle)',
+                : lastError !== undefined
+                  ? API_CALL_FAILED_SPAN_STATUS_MESSAGE
+                  : 'Stream span timed out (idle)',
+              errorType:
+                lastError !== undefined && !cancelled
+                  ? getErrorType(lastError)
+                  : undefined,
+              errorStatusCode:
+                lastError !== undefined && !cancelled
+                  ? getErrorStatus(lastError)
+                  : undefined,
               responseId: firstResponseId || undefined,
               responseModel: firstModelVersion || undefined,
               finishReasons:
@@ -767,6 +781,7 @@ export class LoggingContentGenerator implements ContentGenerator {
               config: this.config,
             });
             spanEndedByTimeout = true;
+            abortSignal?.removeEventListener('abort', markStreamAborted);
           }, STREAM_IDLE_TIMEOUT_MS);
           spanEndTimeout.unref();
         }
@@ -861,7 +876,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       // The OpenAI interaction log is also skipped — telemetry already carries
       // the timeout signal and a parallel "success" record would be confusing
       // during incident response.
-      if (!spanEndedByTimeout) {
+      if (!spanEndedByTimeout && !abortedBeforeStreamCompletion) {
         this.safelyLogApiResponse(
           firstResponseId,
           durationMs,

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -376,6 +376,15 @@ export class LoggingContentGenerator implements ContentGenerator {
 
     const startTime = Date.now();
     const session = this.startCaptureSession();
+    let responseCompleted = false;
+    let abortedBeforeResponseCompletion =
+      req.config?.abortSignal?.aborted ?? false;
+    const markResponseAborted = () => {
+      if (!responseCompleted) abortedBeforeResponseCompletion = true;
+    };
+    req.config?.abortSignal?.addEventListener('abort', markResponseAborted, {
+      once: true,
+    });
     try {
       runtimeDiagnostics.recordGenerateContentRequest(req, {
         stream: false,
@@ -393,6 +402,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         const result = await session.wrap(() =>
           this.wrapped.generateContent(req, userPromptId),
         );
+        responseCompleted = true;
         const durationMs = Date.now() - startTime;
         const responseText = isInternal
           ? undefined
@@ -418,9 +428,11 @@ export class LoggingContentGenerator implements ContentGenerator {
         }
         return result;
       });
-      const observedFinishReasons = exchange.controller.finalize(true);
+      const cancelled = abortedBeforeResponseCompletion;
+      const observedFinishReasons = exchange.controller.finalize(!cancelled);
       endLLMRequestSpan(llmSpan, {
-        success: true,
+        success: !cancelled,
+        cancelled,
         ...usageSpanMetadata(response.usageMetadata),
         durationMs: Date.now() - startTime,
         responseId: response.responseId || undefined,
@@ -428,6 +440,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         finishReasons: observedFinishReasons ?? orderedFinishReasons(response),
         thoughtsTokenCount: response.usageMetadata?.thoughtsTokenCount,
         subagentName: subagentNameContext.getStore() || undefined,
+        error: cancelled ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE : undefined,
         ...retrySnapshot,
         config: this.config,
       });
@@ -477,6 +490,11 @@ export class LoggingContentGenerator implements ContentGenerator {
         }
       });
       throw error;
+    } finally {
+      req.config?.abortSignal?.removeEventListener(
+        'abort',
+        markResponseAborted,
+      );
     }
   }
 
@@ -720,6 +738,7 @@ export class LoggingContentGenerator implements ContentGenerator {
           if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
           spanEndTimeout = setTimeout(() => {
             refreshLateUsageMetadata();
+            const cancelled = abortedBeforeStreamCompletion;
             try {
               span.setAttribute('stream.timed_out', true);
             } catch {
@@ -728,9 +747,12 @@ export class LoggingContentGenerator implements ContentGenerator {
             const observedFinishReasons = exchangeController?.finalize(false);
             endLLMRequestSpan(span, {
               success: false,
+              cancelled,
               ...usageSpanMetadata(lastUsageMetadata),
               durationMs: Date.now() - startTime,
-              error: 'Stream span timed out (idle)',
+              error: cancelled
+                ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
+                : 'Stream span timed out (idle)',
               responseId: firstResponseId || undefined,
               responseModel: firstModelVersion || undefined,
               finishReasons:

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -712,6 +712,36 @@ describe('Turn', () => {
       ]);
     });
 
+    it.each([
+      [{ statusCode: 429 }, 429],
+      [{ response: { status: 503, data: {} } }, 503],
+      [new Error('upstream :HTTP_STATUS/429'), 429],
+    ])('normalizes supported provider status shapes', async (error, status) => {
+      mockSendMessageStream.mockRejectedValue(error);
+      mockMaybeIncludeSchemaDepthContext.mockResolvedValue(undefined);
+
+      const events = [];
+      for await (const event of turn.run(
+        'test-model',
+        [{ text: 'Trigger provider error' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.Error,
+          value: {
+            error: {
+              message: expect.any(String),
+              status,
+            },
+          },
+        },
+      ]);
+    });
+
     it('should report API errors with empty history summary', async () => {
       const error = new Error('API Error');
       const reqParts: Part[] = [{ text: 'Trigger error' }];

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -677,6 +677,41 @@ describe('Turn', () => {
       );
     });
 
+    it('preserves the status of friendly forbidden errors', async () => {
+      mockSendMessageStream.mockRejectedValue({
+        response: {
+          data: {
+            error: {
+              code: 403,
+              message: 'Code Assist is not enabled',
+            },
+          },
+        },
+      });
+      mockMaybeIncludeSchemaDepthContext.mockResolvedValue(undefined);
+
+      const events = [];
+      for await (const event of turn.run(
+        'test-model',
+        [{ text: 'Trigger forbidden error' }],
+        new AbortController().signal,
+      )) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.Error,
+          value: {
+            error: {
+              message: 'Code Assist is not enabled',
+              status: 403,
+            },
+          },
+        },
+      ]);
+    });
+
     it('should report API errors with empty history summary', async () => {
       const error = new Error('API Error');
       const reqParts: Part[] = [{ text: 'Trigger error' }];

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -25,6 +25,7 @@ import { getResponseText } from '../utils/partUtils.js';
 import { reportError } from '../utils/errorReporting.js';
 import {
   getErrorMessage,
+  getErrorStatus,
   UnauthorizedError,
   toFriendlyError,
 } from '../utils/errors.js';
@@ -673,6 +674,7 @@ export class Turn {
         return;
       }
 
+      const originalStatus = getErrorStatus(e);
       const error = toFriendlyError(e);
       if (error instanceof UnauthorizedError) {
         throw error;
@@ -700,16 +702,9 @@ export class Turn {
         'Turn.run-sendMessageStream',
         { contextAlreadySummarized: true },
       );
-      const status =
-        typeof error === 'object' &&
-        error !== null &&
-        'status' in error &&
-        typeof (error as { status: unknown }).status === 'number'
-          ? (error as { status: number }).status
-          : undefined;
       const structuredError: StructuredError = {
         message: getErrorMessage(error),
-        status,
+        status: getErrorStatus(error) ?? originalStatus,
       };
       await this.chat.maybeIncludeSchemaDepthContext(structuredError);
       yield { type: GeminiEventType.Error, value: { error: structuredError } };

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -510,6 +510,25 @@ describe('session-tracing', () => {
       expect(mockSpans[1]!.attributes['gen_ai.output.type']).toBe('json');
     });
 
+    it.each(['cron', 'notification', 'teammate', 'goal'])(
+      'does not assign the session JSON contract to %s interactions',
+      (messageType) => {
+        startInteractionSpan(
+          createMockConfig({ jsonSchema: { type: 'object' } }),
+          {
+            promptId: `automatic-${messageType}`,
+            model: 'm',
+            messageType,
+          },
+        );
+
+        expect(
+          mockSpans.at(-1)!.attributes['gen_ai.output.type'],
+        ).toBeUndefined();
+        endInteractionSpan('ok', { promptId: `automatic-${messageType}` });
+      },
+    );
+
     it('isolates concurrent prompts and ends only the requested interaction', () => {
       const config = createMockConfig();
       startInteractionSpan(config, {

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -475,13 +475,19 @@ function buildInteractionAttributes(
 ): Attributes {
   const sessionId = config.getSessionId();
   const userId = config.getTelemetryUserId();
+  const ownsStructuredOutputContract =
+    options.messageType === 'userQuery' ||
+    options.messageType === 'retry' ||
+    options.messageType === 'acp_prompt';
   return {
     'session.id': sessionId,
     ...(userId ? { 'gen_ai.user.id': userId } : {}),
     'gen_ai.operation.name': 'invoke_agent',
     'gen_ai.agent.name': 'qwen-code',
     'gen_ai.conversation.id': sessionId,
-    ...(config.getJsonSchema?.() ? { 'gen_ai.output.type': 'json' } : {}),
+    ...(ownsStructuredOutputContract && config.getJsonSchema?.()
+      ? { 'gen_ai.output.type': 'json' }
+      : {}),
     'qwen-code.prompt_id': options.promptId,
     'qwen-code.message_type': options.messageType,
     'qwen-code.model': options.model,

--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -365,9 +365,15 @@ export class FatalCancellationError extends FatalError {
   }
 }
 
-export class ForbiddenError extends Error {}
-export class UnauthorizedError extends Error {}
-export class BadRequestError extends Error {}
+export class ForbiddenError extends Error {
+  readonly status = 403;
+}
+export class UnauthorizedError extends Error {
+  readonly status = 401;
+}
+export class BadRequestError extends Error {
+  readonly status = 400;
+}
 
 interface ResponseData {
   error?: {


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item on one long line.
-->

## What this PR does

This follow-up to #9107 fixes review-confirmed edge cases in main-agent tracing. Budget-triggered aborts are classified before the core generator can close the interaction as a user cancellation; non-streaming calls and hanging streams now preserve cancellation semantics when providers swallow aborts; and deferred TUI tool batches retain their exact interaction owners so mixed main and legacy `?btw` work cannot leak tool results into the wrong continuation.

It also keeps the headless JSON Schema verdict scoped correctly: user-origin invocations retain the structured-output contract across tool continuations, while automatic Cron, Notification, Teammate, and runtime Goal drain invocations are not individually mislabeled when they return plain text. Goal-finalization and headless terminal failures now retain their bounded diagnostic message instead of an unrelated generic phase label, and the Steer regression test now proves the continuation actually ran and wrote to the original owner.

## Why it's needed

Without these fixes, traces could export a budget overrun as `cancelled`, export a swallowed user abort as `ERROR`, leave legacy `?btw` interactions open until TTL, submit a secondary tool result under the main prompt, or report successful automatic drain work as `structured_output_missing`. The remaining phase-label issues made valid failures materially harder to diagnose even though the real error was already available to the bounded telemetry finalizer.

## Reviewer Test Plan

### How to verify

Confirm that a wall-time budget abort wins over the core cancellation finalizer, non-stream and idle-timeout provider paths remain UNSET/cancelled after a swallowed abort, and an abort that occurs only after provider completion does not rewrite success. In the TUI regression, keep a main stream active while a legacy `?btw` tool batch completes, then verify the secondary interaction closes independently and only the main tool response is submitted under the main prompt. With a JSON Schema configured, verify plain-text automatic drain invocations end normally while a user-origin invocation still reports `structured_output_missing`, including after a tool continuation. Finally, force Goal finalization and headless terminal errors and confirm the owning span contains the accurate bounded message and stable low-cardinality `error.type`.

### Evidence (Before & After)

N/A — telemetry and lifecycle behavior only; no user-visible UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v22.22.3, npm 10.9.8, local bundle with sandbox disabled for the GenAI telemetry integration test.

## Risk & Scope

- Main risk or tradeoff: The TUI now defers completed tool batches until all active model streams settle and fails closed for secondary interaction owners in a mixed batch, so exact owner selection and queue draining are the highest-risk paths.
- Not validated / out of scope: Windows and Linux were not tested locally; workflow invocation and workflow dispatch tracing remain out of scope.
- Breaking changes / migration notes: None. No configuration or exported API changes.

## Linked Issues

Follow-up to #9107.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这是 #9107 的后续修复，处理评审确认的主 Agent tracing 边界问题。预算触发的 abort 会在 core generator 将 interaction 关闭为用户取消之前完成分类；非流式调用和挂起流在 provider 吞掉 abort 时会保留 cancellation 语义；TUI 延迟工具批次会保留精确 interaction owner，避免 main 与旧版 `?btw` 工作混合后把工具结果泄漏到错误 continuation。

同时修正 headless JSON Schema 判定的归属：用户来源 invocation 会跨工具 continuation 保留 structured-output contract，而自动 Cron、Notification、Teammate 与 runtime Goal drain invocation 返回纯文本时不会被单独误标。Goal finalization 和 headless 终止失败现在保留经过边界控制的真实诊断消息，不再写入无关的通用阶段标签；Steer 回归测试也会证明 continuation 确实执行并写回原 owner。

## 为什么需要

没有这些修复时，trace 可能把预算超限导出为 `cancelled`、把被 provider 吞掉的用户 abort 导出为 `ERROR`、让旧版 `?btw` interaction 泄漏到 TTL、把 secondary 工具结果提交到 main prompt，或把成功的自动 drain 工作误报为 `structured_output_missing`。其余阶段标签问题虽然真实错误已经存在于作用域中，但仍会显著降低故障诊断质量。

## Reviewer 测试计划

### 如何验证

确认 wall-time 预算 abort 优先于 core cancellation finalizer；non-stream 与 idle-timeout provider 路径在吞掉 abort 后保持 UNSET/cancelled；仅在 provider 完成后发生的 abort 不会改写成功状态。TUI 回归中保持 main stream 活跃，同时完成旧版 `?btw` 工具批次，然后验证 secondary interaction 独立关闭，并且只有 main 工具响应以 main prompt 提交。配置 JSON Schema 后，验证纯文本自动 drain invocation 正常结束，而用户来源 invocation（包括工具 continuation 后）仍报告 `structured_output_missing`。最后强制 Goal finalization 与 headless 终止错误，确认 owner span 包含准确的有界消息和稳定低基数 `error.type`。

### 证据（前后对比）

N/A——仅 telemetry 与生命周期行为变化，没有用户可见 UI 改动。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js v22.22.3、npm 10.9.8；使用本地 bundle，并在关闭 sandbox 的条件下运行 GenAI telemetry 集成测试。

## 风险与范围

- 主要风险或取舍：TUI 现在会等待所有活跃 model stream 结束后再处理已完成工具批次，并对混合批次中的 secondary interaction owner 采取 fail-closed，因此精确 owner 选择与队列 drain 是最高风险路径。
- 未验证 / 范围外：未在本地验证 Windows 与 Linux；workflow invocation 和 workflow dispatch tracing 仍不在本 PR 范围内。
- 破坏性变更 / 迁移说明：无。没有配置或导出 API 变更。

## 关联问题

#9107 的后续修复。

</details>
