### PR TITLE
fix(review): refuse a separators-only run target; anchor the composed-name oracle

### DIFF
--- a/packages/cli/src/commands/review/run-skill-parity.test.ts
+++ b/packages/cli/src/commands/review/run-skill-parity.test.ts
@@ -58,12 +58,14 @@ describe('run pins match the bundled skill templates', () => {
   itWithSkill('composedNameFor renders Step 6’s --out template', () => {
     // The template as the skill writes it, e.g.
     //   --out .qwen/tmp/qwen-review-{target}-composed.json
-    // Anchored at the end of the filename: an unanchored capture matches a
-    // skill edit that APPENDS to the artifact name (`…composed.json.tmp` for
-    // an atomic write-then-rename) as a prefix, leaving this oracle green
-    // while the pin drifts — one direction of the drift it exists to catch.
+    // The filename must END the token: an unanchored capture matches a skill
+    // edit that APPENDS to the artifact name (`…composed.json.tmp` for an
+    // atomic write-then-rename, `…json-v2` for a rename) as a prefix,
+    // leaving this oracle green while the pin drifts — one direction of the
+    // drift it exists to catch. Whitespace-or-end, not a rejected character
+    // class, so no future suffix character has to be foreseen.
     const m =
-      /--out\s+\.qwen\/tmp\/(qwen-review-\{target\}-composed\.json)(?![\w.])/.exec(
+      /--out\s+\.qwen\/tmp\/(qwen-review-\{target\}-composed\.json)(?=\s|$)/.exec(
         skill as string,
       );
     // A null here means SKILL.md no longer writes that `--out` line: update

--- a/packages/cli/src/commands/review/run-skill-parity.test.ts
+++ b/packages/cli/src/commands/review/run-skill-parity.test.ts
@@ -58,8 +58,12 @@ describe('run pins match the bundled skill templates', () => {
   itWithSkill('composedNameFor renders Step 6’s --out template', () => {
     // The template as the skill writes it, e.g.
     //   --out .qwen/tmp/qwen-review-{target}-composed.json
+    // Anchored at the end of the filename: an unanchored capture matches a
+    // skill edit that APPENDS to the artifact name (`…composed.json.tmp` for
+    // an atomic write-then-rename) as a prefix, leaving this oracle green
+    // while the pin drifts — one direction of the drift it exists to catch.
     const m =
-      /--out\s+\.qwen\/tmp\/(qwen-review-\{target\}-composed\.json)/.exec(
+      /--out\s+\.qwen\/tmp\/(qwen-review-\{target\}-composed\.json)(?![\w.])/.exec(
         skill as string,
       );
     // A null here means SKILL.md no longer writes that `--out` line: update

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -87,6 +87,17 @@ describe('buildReviewPrompt', () => {
     );
   });
 
+  it('rejects a separators-only target', () => {
+    // `/` names no file: it survives basename extraction as the empty
+    // string, pinning the unmatchable `qwen-review--composed.json` — a whole
+    // child review burned before the parent reports "no composed verdict".
+    for (const target of ['/', '//', '\\']) {
+      expect(() => buildReviewPrompt({ target })).toThrow(
+        /Invalid review target/,
+      );
+    }
+  });
+
   it('rejects a target carrying quote characters', () => {
     // tokenizeArgs strips quotes, so `src/it's-a-file.ts` would re-tokenize
     // to `src/its-a-file.ts` — silently re-targeting a file never named.

--- a/packages/cli/src/commands/review/run.test.ts
+++ b/packages/cli/src/commands/review/run.test.ts
@@ -87,7 +87,7 @@ describe('buildReviewPrompt', () => {
     );
   });
 
-  it('rejects a separators-only target', () => {
+  it('rejects a separators-only or empty target', () => {
     // `/` names no file: it survives basename extraction as the empty
     // string, pinning the unmatchable `qwen-review--composed.json` — a whole
     // child review burned before the parent reports "no composed verdict".
@@ -96,6 +96,25 @@ describe('buildReviewPrompt', () => {
         /Invalid review target/,
       );
     }
+    // An empty target is a target the caller named and got wrong (an unset
+    // `"$TARGET"`); read as "no target given" it silently becomes a full
+    // local review at the 120-minute default, not an error.
+    for (const target of ['', '   ']) {
+      expect(() => buildReviewPrompt({ target })).toThrow(
+        /Invalid review target/,
+      );
+    }
+  });
+
+  it('keeps accepting separator-bearing paths — the guard is not over-broad', () => {
+    // The rejection cases alone leave over-rejection mutants green: dropping
+    // the `$` from `/^[\\/]+$/` kills every absolute path, dropping the `^`
+    // kills every tab-completed trailing slash. Both shapes are valid
+    // targets and reach the child unchanged.
+    expect(buildReviewPrompt({ target: '/repo/src/foo.ts' })).toBe(
+      '/review /repo/src/foo.ts',
+    );
+    expect(buildReviewPrompt({ target: 'src/' })).toBe('/review src/');
   });
 
   it('rejects a target carrying quote characters', () => {

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -226,7 +226,12 @@ export function buildReviewPrompt(args: {
     if (
       /\s/.test(args.target) ||
       args.target.startsWith('-') ||
-      /['"]/.test(args.target)
+      /['"]/.test(args.target) ||
+      // A separators-only path (`/`, `//`, `\`) names no file: it survives
+      // basename extraction as the empty string, which pins the unmatchable
+      // `qwen-review--composed.json` and burns a whole child review before
+      // reporting "no composed verdict". Refuse it here instead.
+      /^[\\/]+$/.test(args.target)
     ) {
       throw new Error(
         `Invalid review target ${JSON.stringify(args.target)}: expected a single PR number, PR URL, or file path`,

--- a/packages/cli/src/commands/review/run.ts
+++ b/packages/cli/src/commands/review/run.ts
@@ -217,13 +217,19 @@ export function buildReviewPrompt(args: {
   comment?: boolean;
 }): string {
   const parts = ['/review'];
-  if (args.target) {
+  // Presence, not truthiness: an EMPTY target is a target the caller named
+  // and got wrong — `qwen review run "$TARGET"` with `TARGET` unset — and
+  // treating it as "no target given" silently launches a full local review
+  // on the caller's tree, at the 120-minute default timeout and real model
+  // spend, instead of the error its siblings `/`, `//`, `\` now get.
+  if (args.target !== undefined) {
     // The child re-tokenizes this string; a target carrying whitespace or a
     // leading dash would split into extra tokens (`123 --comment` would
     // silently authorise posting), and a quote is stripped by the tokenizer
     // (`src/it's.ts` would re-target to `src/its.ts`) — refuse anything but a
     // single clean token.
     if (
+      args.target.trim() === '' ||
       /\s/.test(args.target) ||
       args.target.startsWith('-') ||
       /['"]/.test(args.target) ||


### PR DESCRIPTION
## What this PR does

Carries the last two review findings from #9086, which were pushed 42 seconds after that PR was squash-merged and so did not land. The commit is cherry-picked unchanged onto current `main`. `review run` now refuses a target made only of path separators, and the SKILL.md parity oracle anchors its capture at the end of the artifact filename.

## Why it's needed

Both were Suggestions from #9086's seventh review round, and both were answered there with "Fixed in da50ceba73" — a commit that is not an ancestor of the squash merge, so the replies currently point at work that is not in the tree.

The separators-only target is a real fail-slow path: `qwen review run /` passes every guard `buildReviewPrompt` had (no whitespace, no leading dash, no quotes), then survives basename extraction as the empty string, so `composedNameFor` pins `qwen-review--composed.json` — a filename no child artifact can ever carry. A whole child review runs before the parent reports `no composed verdict was produced (expected .qwen/tmp/qwen-review--composed.json)` and exits 1, which is exactly the invariant the comment three lines above that code claims holds.

The oracle gap is one direction of the drift that test exists to catch: the capture was an unanchored prefix, so a skill edit that APPENDS to the artifact name — `--out .qwen/tmp/qwen-review-{target}-composed.json.tmp` for an atomic write-then-rename, say — still matches, the test stays green against the stale literal, the child writes the suffixed artifact, and the parent pins the unsuffixed name. Every affected `review run` would then report no verdict after the review had completed.

## Reviewer Test Plan

### How to verify

`cd packages/cli && npx vitest run src/commands/review/run.test.ts src/commands/review/run-skill-parity.test.ts` → 43 passed. Both guards are mutation-verified on top of current `main`: deleting the `/^[\\/]+$/` clause from `buildReviewPrompt` fails `rejects a separators-only target`, and rewriting SKILL.md Step 6 to `…composed.json.tmp` fails `composedNameFor renders Step 6's --out template` (before the anchor it passed 2/2 under that same drift). Restoring both leaves the suites green.

### Evidence (Before & After)

Before, on `main` at `b286875e72`: `buildReviewPrompt({target: '/'})` returns the prompt `/review /`, `classifyRunTarget('/')` yields `{kind: 'file', base: ''}`, and `composedNameFor` renders `qwen-review--composed.json`; applying the `.tmp` drift to SKILL.md leaves `run-skill-parity.test.ts` green at 2/2. After: the target is refused with `Invalid review target "/"` before any child is spawned, and the same drift turns the oracle red.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS (darwin 25.6), Node v24.18.1, npm 11.16.0. Unit tests only.

## Risk & Scope

- Main risk or tradeoff: `review run` now rejects an input it previously accepted. The rejected shapes (`/`, `//`, `\`) never produced a usable review — they burned a child run and exited 1 — so nothing that worked stops working.
- Not validated / out of scope: the `env node` question #9086 surfaced for vendored `dist/` trees is tracked in #9117 and untouched here.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #9086 (carries its round-7 findings; does not close anything).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

补上 #9086 最后两条审查结论——它们在该 PR 被 squash 合并后 42 秒才推送，因此没有进入主干。提交原样 cherry-pick 到当前 `main`。`review run` 现在会拒绝仅由路径分隔符组成的 target，SKILL.md 对照 oracle 也为工件文件名的捕获加上了尾锚。

## 为什么需要

两条都是 #9086 第七轮审查的 Suggestion，且都已在那里回复"Fixed in da50ceba73"——而该提交并非 squash 合并的祖先，所以这两条回复目前指向的是不在代码树里的改动。

纯分隔符 target 是一条真实的慢失败路径：`qwen review run /` 能通过 `buildReviewPrompt` 原有的全部守卫（无空白、无前导连字符、无引号），随后在 basename 提取中变成空串，于是 `composedNameFor` 钉出 `qwen-review--composed.json`——一个任何子进程工件都不可能携带的文件名。结果是白跑一整个 child review，父进程才报告 `no composed verdict was produced (expected .qwen/tmp/qwen-review--composed.json)` 并 exit 1，而这恰恰违反了该代码上方三行注释所声称的不变量。

oracle 的缺口是该测试要消灭的漂移的一个方向：捕获是未加尾锚的前缀，因此给工件名追加后缀的 skill 修改——比如为原子性先写后改名而改成 `--out .qwen/tmp/qwen-review-{target}-composed.json.tmp`——仍会匹配成功，测试继续拿着过期字面量通过，子进程写出带后缀的工件，父进程却钉着不带后缀的名字。每次受影响的 `review run` 都会在 review 实际完成后报告没有 verdict。

## Reviewer 测试计划

### 如何验证

`cd packages/cli && npx vitest run src/commands/review/run.test.ts src/commands/review/run-skill-parity.test.ts` → 43 条通过。两个守卫都在当前 `main` 之上做了突变验证：从 `buildReviewPrompt` 删除 `/^[\\/]+$/` 分支会让 `rejects a separators-only target` 失败；把 SKILL.md Step 6 改成 `…composed.json.tmp` 会让 `composedNameFor renders Step 6's --out template` 失败（加尾锚之前，同样的漂移下它 2/2 通过）。两者恢复后套件继续全绿。

### 证据（Before & After）

Before（`main` 于 `b286875e72`）：`buildReviewPrompt({target: '/'})` 返回提示词 `/review /`，`classifyRunTarget('/')` 得到 `{kind: 'file', base: ''}`，`composedNameFor` 渲染出 `qwen-review--composed.json`；对 SKILL.md 施加 `.tmp` 漂移后 `run-skill-parity.test.ts` 仍 2/2 通过。After：该 target 在派生任何子进程之前就以 `Invalid review target "/"` 被拒绝，同样的漂移会让 oracle 变红。

### 已测试系统

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS（darwin 25.6）、Node v24.18.1、npm 11.16.0。仅单元测试。

## 风险与范围

- 主要风险或取舍：`review run` 现在会拒绝一类此前接受的输入。被拒绝的形态（`/`、`//`、`\`）本来也产生不了可用的 review——它们只会白跑一次子进程并 exit 1——因此没有原本能用的用法被破坏。
- 未验证/范围外：#9086 提出的 vendored `dist/` 的 `env node` 问题由 #9117 跟踪，本 PR 不涉及。
- 破坏性变更/迁移说明：无。

## 关联 Issue

#9086 的后续（承接其第七轮审查结论；不关闭任何 issue）。

</details>