### PR TITLE
ci(vscode): gate sync publish on RELEASE_VSCODE_SYNC_PUBLISH variable

### DIFF
--- a/.github/workflows/release-vscode-companion.yml
+++ b/.github/workflows/release-vscode-companion.yml
@@ -38,12 +38,16 @@ jobs:
   # First job: Determine version and run tests once
   prepare:
     runs-on: 'ubuntu-latest'
+    # The release-event (sync-with-CLI) path can be paused by setting the
+    # repository variable RELEASE_VSCODE_SYNC_PUBLISH=false; manual
+    # workflow_dispatch releases keep working either way.
     if: |-
       ${{
         github.repository == 'QwenLM/qwen-code' &&
         (
           github.event_name != 'release' ||
           (
+            vars.RELEASE_VSCODE_SYNC_PUBLISH != 'false' &&
             startsWith(github.event.release.tag_name, 'v') &&
             github.event.release.prerelease == false
           )


### PR DESCRIPTION
## What this PR does

Adds a repository-variable switch to the VSCode IDE Companion release workflow: the sync-with-CLI path (`release: published` trigger) now also requires `vars.RELEASE_VSCODE_SYNC_PUBLISH != 'false'`. Setting the variable to `false` pauses synced publishing for a period; deleting it (or any other value) restores today's behavior. Manual `workflow_dispatch` releases are unaffected in both states.

## Why it's needed

Today every stable CLI release automatically triggers a companion release. The maintainer needs to decouple the two for a period; a repository variable gives a one-time, reversible switch without editing the workflow each time. The gate sits on `prepare`, so `build`/`publish` (and the failure reporter) skip transitively.

## Reviewer Test Plan

### How to verify

- YAML parses; the `if` expression is a pure conjunction addition — with the variable unset the expression reduces to the current condition.
- Behavior matrix: (variable unset, release published) → runs as today; (variable=false, release published) → prepare skipped, build/publish skipped; (variable=false, workflow_dispatch) → runs; (variable=true, release published) → runs.
- Safe to validate live: the next stable release after merge exercises the default path; a dry-run `workflow_dispatch` on this branch exercises the dispatch path.

### Evidence (Before & After)

N/A — workflow gating change; matrix above is the evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ |

(Workflow-only; YAML validated locally, real validation on next release run.)

## Risk & Scope

- Main risk or tradeoff: if the variable is left `false` and nobody remembers, companion releases silently stop on CLI releases — mitigated by the comment in the workflow and this PR's paper trail; the failure reporter also skips, which is correct (nothing ran).
- Not validated / out of scope: preview releases (already excluded by the prerelease condition), other release workflows.
- Breaking changes / migration notes: none; default (unset) = current behavior.

## Linked Issues

Requested by the release owner to decouple companion publishing from CLI releases for a period.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 VSCode IDE Companion 发布 workflow 加仓库变量开关：同步发布路径（`release: published` 触发）增加条件 `vars.RELEASE_VSCODE_SYNC_PUBLISH != 'false'`。变量设为 `false` 即暂停同步发布一段时间；删除变量（或任何其他值）恢复现状。手动 `workflow_dispatch` 发布两种状态下都不受影响。

## 为什么需要

现在每次 CLI 稳定发布都会自动触发 companion 发布；需要一段时间断开同步。用仓库变量做一次性可逆开关，不用每次改 workflow。开关放在 `prepare`，`build`/`publish` 级联跳过。

## Reviewer 测试计划

### 如何验证

- YAML 可解析；`if` 为纯合取追加，变量未设时等价于现条件。
- 行为矩阵：未设+release → 现状；false+release → 全跳过；false+dispatch → 跑；true+release → 跑。

### 证据（Before & After）

N/A —— workflow 门控改动，以上矩阵即证据。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ |

（仅 workflow；YAML 本地校验，真实验证在下次发布。）

## 风险与范围

- 主要风险：变量留 `false` 忘了删会静默停同步——workflow 内注释和本 PR 记录可缓解；failure reporter 一并跳过是正确行为（没跑就没法失败）。
- 未验证 / 超出范围：preview 发布（本就排除）、其他 release workflow。
- 破坏性变更 / 迁移：无；未设=现状。

## 关联 Issue

发布负责人要求一段时间断开 companion 与 CLI 的同步发布。
</details>
