### PR TITLE
fix(ci): fall back to REST review delete when GraphQL minimize is unavailable

### DIFF
--- a/.github/scripts/spam-blocklist-enforce.test.mjs
+++ b/.github/scripts/spam-blocklist-enforce.test.mjs
@@ -337,6 +337,16 @@ class HttpError extends Error {
   }
 }
 
+// GraphQL permission denials surface as an `errors` array carrying per-entry
+// `type`s instead of an HTTP status; model the class the minimize fallback
+// keys on.
+class GraphqlError extends Error {
+  constructor(type, message) {
+    super(message);
+    this.errors = [{ type, message }];
+  }
+}
+
 const makeCore = () => {
   const logs = {
     info: [],
@@ -393,6 +403,7 @@ const makeGithub = ({ calls, fail = () => null, pages = {}, replies = {} }) => {
       },
       pulls: {
         deleteReviewComment: record('pulls.deleteReviewComment'),
+        deleteReview: record('pulls.deleteReview'),
         update: record('pulls.update'),
         get: record('pulls.get'),
         listReviewCommentsForRepo: 'pulls.listReviewCommentsForRepo',
@@ -1268,6 +1279,133 @@ describe('spam-blocklist-enforce: enforce lane behaviour', () => {
     );
     assert.equal(core.logs.failed.length, 1);
     assert.match(core.logs.failed[0], /minimize review 7: 422/);
+  });
+
+  it('falls back to REST review delete when the minimize 403s', async () => {
+    // The permission/scope class that red-ran the predecessor workflow on
+    // every hit: the token cannot perform the mutation. REST-deleting the
+    // whole review is covered by pull-requests:write, so the lane takes it
+    // and stays green with a warning instead of red-running.
+    const { calls, core } = await enforce(
+      'pull_request_review',
+      {
+        review: { id: 7, node_id: 'PRR_spam', user: { login: 'spamuser' } },
+        pull_request: {
+          number: 60,
+          user: { login: 'legit' },
+          state: 'open',
+          head: { repo: { full_name: 'QwenLM/qwen-code' } },
+        },
+      },
+      {
+        fail: (name) =>
+          name === 'graphql.minimizeComment'
+            ? new HttpError(403, 'Forbidden')
+            : null,
+      },
+    );
+    assert.deepEqual(names(calls), [
+      'graphql.minimizeComment',
+      'pulls.deleteReview',
+    ]);
+    assert.equal(calls[1].params.pull_number, 60);
+    assert.equal(calls[1].params.review_id, 7);
+    assert.deepEqual(core.logs.failed, []);
+    assert.ok(core.logs.warning.some((m) => /minimize unavailable/.test(m)));
+    assert.ok(summaryItems(core).some((item) => /delete review 7/.test(item)));
+  });
+
+  it('falls back to REST review delete on a GraphQL FORBIDDEN error', async () => {
+    // The GraphQL-shaped twin: GITHUB_TOKEN permission denials surface as
+    // `errors` entries carrying a type, not as an HTTP status.
+    const { calls, core } = await enforce(
+      'pull_request_review',
+      {
+        review: { id: 7, node_id: 'PRR_spam', user: { login: 'spamuser' } },
+        pull_request: {
+          number: 60,
+          user: { login: 'legit' },
+          state: 'open',
+          head: { repo: { full_name: 'QwenLM/qwen-code' } },
+        },
+      },
+      {
+        fail: (name) =>
+          name === 'graphql.minimizeComment'
+            ? new GraphqlError(
+                'FORBIDDEN',
+                'Resource not accessible by integration',
+              )
+            : null,
+      },
+    );
+    assert.deepEqual(names(calls), [
+      'graphql.minimizeComment',
+      'pulls.deleteReview',
+    ]);
+    assert.deepEqual(core.logs.failed, []);
+    assert.ok(core.logs.warning.some((m) => /minimize unavailable/.test(m)));
+  });
+
+  it('falls back to REST review delete on INSUFFICIENT_SCOPES', async () => {
+    // The exact error class the predecessor red-ran on for as long as the
+    // blocklist was non-empty.
+    const { calls, core } = await enforce(
+      'pull_request_review',
+      {
+        review: { id: 7, node_id: 'PRR_spam', user: { login: 'spamuser' } },
+        pull_request: {
+          number: 60,
+          user: { login: 'legit' },
+          state: 'open',
+          head: { repo: { full_name: 'QwenLM/qwen-code' } },
+        },
+      },
+      {
+        fail: (name) =>
+          name === 'graphql.minimizeComment'
+            ? new GraphqlError('INSUFFICIENT_SCOPES', 'Insufficient scopes')
+            : null,
+      },
+    );
+    assert.deepEqual(names(calls), [
+      'graphql.minimizeComment',
+      'pulls.deleteReview',
+    ]);
+    assert.deepEqual(core.logs.failed, []);
+  });
+
+  it('fails the run when the minimize 403s and the fallback delete fails too', async () => {
+    // Both paths exhausted: the body stays visible and no sweep backstop
+    // exists for review bodies, so the run failure is the manual-cleanup
+    // flag. Only the delete failure collects — the 403 minimize itself was
+    // handled by taking the fallback.
+    const { calls, core } = await enforce(
+      'pull_request_review',
+      {
+        review: { id: 7, node_id: 'PRR_spam', user: { login: 'spamuser' } },
+        pull_request: {
+          number: 60,
+          user: { login: 'legit' },
+          state: 'open',
+          head: { repo: { full_name: 'QwenLM/qwen-code' } },
+        },
+      },
+      {
+        fail: (name) =>
+          name === 'graphql.minimizeComment'
+            ? new HttpError(403, 'Forbidden')
+            : name === 'pulls.deleteReview'
+              ? new HttpError(422, 'Validation Failed')
+              : null,
+      },
+    );
+    assert.deepEqual(names(calls), [
+      'graphql.minimizeComment',
+      'pulls.deleteReview',
+    ]);
+    assert.equal(core.logs.failed.length, 1);
+    assert.match(core.logs.failed[0], /delete review 7 .*422/);
   });
 
   it('keeps closing the thread after a delete 404s', async () => {

--- a/.github/workflows/spam-blocklist-enforce.yml
+++ b/.github/workflows/spam-blocklist-enforce.yml
@@ -27,9 +27,11 @@ name: 'Spam blocklist enforcement'
 # was ever hidden. REST delete needs nothing beyond issues:write +
 # pull-requests:write, which GITHUB_TOKEN grants.
 #
-# Coverage limit: a review BODY (as opposed to an inline review comment) has no
-# REST delete endpoint, so the event lane minimizes it as SPAM instead and the
-# sweep skips it — there is no repo-wide "list reviews" endpoint to sweep with.
+# Coverage limit: a review BODY (as opposed to an inline review comment) has
+# no REST delete endpoint of its own, so the event lane minimizes it as SPAM
+# instead — falling back to deleting the whole review via REST when the token
+# cannot perform the mutation — and the sweep skips it: there is no repo-wide
+# "list reviews" endpoint to sweep with.
 # A review BODY on a fork PR has no lane at all: the review events run on a
 # read-only token there and the sweep cannot list reviews, so it needs manual
 # minimization. A closed+locked PR's body also stays editable by its author —
@@ -354,10 +356,15 @@ jobs:
                 return;
               }
               if (isBlocked(review?.user?.login)) {
-                // No REST delete for a review body; SPAM-classify it instead.
-                // The minimize tolerates no status: a failed minimize leaves
-                // the body visible with no sweep backstop, so it must
-                // red-run.
+                // No REST delete for a review body alone; SPAM-classify it
+                // instead. The minimize tolerates no status: a failed
+                // minimize leaves the body visible with no sweep backstop,
+                // so it must red-run. One carve-out: when the token cannot
+                // perform the mutation at all — the permission/scope class
+                // that red-ran the predecessor workflow (INSUFFICIENT_SCOPES
+                // / FORBIDDEN / 403) — fall back to REST-deleting the whole
+                // review, which pull-requests:write covers, and warn loudly.
+                // A failed fallback delete still red-runs.
                 const minimize = () =>
                   github.graphql(
                     `mutation MinimizeComment($id: ID!) {
@@ -367,7 +374,44 @@ jobs:
                     }`,
                     { id: review.node_id },
                   );
-                await run(`minimize review ${review.id}`, minimize, []);
+                // Permission failures surface either as a REST-style status
+                // on the error or as GraphQL `errors` entries carrying a
+                // type. A rate-limit 403 misclassifies as a permission
+                // failure, but its fallback delete is doomed the same way
+                // and the run still red-runs.
+                const isPermissionFailure = (error) =>
+                  error?.status === 403 ||
+                  (error?.errors ?? []).some(
+                    (entry) =>
+                      entry?.type === 'FORBIDDEN' ||
+                      entry?.type === 'INSUFFICIENT_SCOPES',
+                  ) ||
+                  /INSUFFICIENT_SCOPES|Resource not accessible by integration/.test(
+                    String(error?.message ?? ''),
+                  );
+                try {
+                  await minimize();
+                  actions.push(`minimize review ${review.id}`);
+                  core.info(`ok: minimize review ${review.id}`);
+                } catch (error) {
+                  if (!isPermissionFailure(error)) {
+                    // Same fail-closed collection run() performs.
+                    failures.push(`minimize review ${review.id}: ${error?.status ?? ''} ${error?.message ?? error}`);
+                    core.warning(`failed: minimize review ${review.id} — ${error?.message ?? error}`);
+                  } else {
+                    core.warning(
+                      `minimize unavailable for review ${review.id} (${error?.message ?? error}); deleting the review via REST instead`,
+                    );
+                    await run(`delete review ${review.id} (minimize unavailable)`, () =>
+                      github.rest.pulls.deleteReview({
+                        owner,
+                        repo,
+                        pull_number: pull?.number,
+                        review_id: review.id,
+                      }),
+                    );
+                  }
+                }
               }
               if (
                 pull &&


### PR DESCRIPTION
## What this PR does

Follow-up to #8767. The review-BODY spam path in the enforce lane still uses the GraphQL `minimizeComment` mutation — the one mutation in that workflow that was never actually exercised under the default GITHUB_TOKEN (the enforce job only ever ran its no-op path). This PR wraps the minimize call: when the token cannot perform the mutation at all — the permission/scope failure class (a REST-style `403` status, GraphQL `errors` entries with type `FORBIDDEN`/`INSUFFICIENT_SCOPES`, or a `Resource not accessible by integration` message) — the lane logs a clear warning and falls back to `DELETE /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}`, which the workflow's existing `pull-requests:write` permission covers. Any other minimize error, and a failed fallback delete, keep the existing fail-closed behaviour: collect the failure and `setFailed`.

## Why it's needed

#8767 moved enforcement off a broken PAT onto GITHUB_TOKEN, but the workflow's single GraphQL mutation has never run against that token in a real hit — nobody knows whether `minimizeComment` works under GITHUB_TOKEN until a blocklisted review body shows up. If it is rejected with a permission/scope error on first real hit, the run goes red and the spam stays visible. The fallback gives the lane a removal path that is provably covered by the permissions it already declares, while every non-permission failure stays fail-closed red.

## Reviewer Test Plan

### How to verify

Run the fixture-driven harness exactly as CI does: `node --test .github/scripts/spam-blocklist-enforce.test.mjs` (only external dep is `yaml`). New cases: minimize 403 → `pulls.deleteReview` invoked with the payload's `pull_number`/`review_id`, run stays green with a `minimize unavailable … deleting the review via REST instead` warning and a `delete review N (minimize unavailable)` summary entry; the GraphQL-shaped twins (`FORBIDDEN` and `INSUFFICIENT_SCOPES` error entries) take the same fallback; minimize 403 + delete 422 → exactly one collected failure and the run red. The minimize-success and fail-closed-on-422 paths are pinned by the pre-existing tests, which pass unchanged.

### Evidence (Before & After)

N/A — workflow script + test harness change, no user-visible UI. Before: 116/116 harness tests pass. After: 120/120 pass locally (Node 22), `prettier --check` clean on both touched files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Unit-test harness only: `node --test` on Node v22.20.0 with `yaml` installed; prettier checked against the repo's `.prettierrc.json`.

## Risk & Scope

- Main risk or tradeoff: a rate-limit 403 misclassifies as a permission failure and triggers a fallback delete that is doomed the same way — the run still red-runs (fail-closed), just with one extra doomed call logged. The fallback deletes the whole review rather than hiding only its body; acceptable because the author is blocklisted.
- Not validated / out of scope: whether GITHUB_TOKEN can actually perform `minimizeComment` on QwenLM/qwen-code — only a first real hit proves that. The sweep lane and every other path of #8767 are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8767
Depends on #8767 — stacked on the `spam-blocklist-enforce` branch; please retarget to `main` once #8767 merges.

<details>
<summary>中文说明</summary>

#8767 的后续修复。enforce 通道里 review 正文的 spam 处理仍走 GraphQL `minimizeComment` mutation，这是该 workflow 里唯一一个从未在默认 GITHUB_TOKEN 下真实执行过的 mutation。本 PR 增加兜底：当 mutation 因权限/scope 失败（403 / GraphQL errors 里的 FORBIDDEN、INSUFFICIENT_SCOPES、`Resource not accessible by integration`）时，打 warning 并改用 REST 删除整个 review（`pull-requests:write` 已覆盖）；其他任何 minimize 错误以及兜底删除失败，保持原有 fail-closed 行为（收集失败 + setFailed 红掉）。测试新增 4 个用例：403 兜底成功（HTTP 状态与 GraphQL errors 两种形态）、INSUFFICIENT_SCOPES 兜底成功、403 + 删除也失败 → 红。本地 `node --test` 120/120 通过，prettier 校验通过。

</details>