### PR TITLE
fix(daemon): Preserve sessions when active-work close is refused

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -134,6 +134,21 @@ function deferred<T>(): {
   return { promise, resolve, reject };
 }
 
+describe('sessionCloseDrainBudgetMs', () => {
+  it('stays strictly under the outer wait and clamps to >=1ms', () => {
+    // Literal pin: the documented invariants must not drift with the
+    // implementation — a ratio at or above 1.0 lets the daemon's outer wait
+    // fire first (unknown close outcome), and a missing clamp yields 0,
+    // which the child rejects as invalidParams.
+    expect(sessionCloseDrainBudgetMs(10_000)).toBe(8_000);
+    expect(sessionCloseDrainBudgetMs(1)).toBe(1);
+    for (const outer of [2, 3, 7, 100, 1_000, 30_000]) {
+      expect(sessionCloseDrainBudgetMs(outer)).toBeGreaterThanOrEqual(1);
+      expect(sessionCloseDrainBudgetMs(outer)).toBeLessThan(outer);
+    }
+  });
+});
+
 /**
  * Test-local fake of the daemon-wide growth aggregator `runQwenServe` wires
  * every bridge to: one shared provider set plus the register/read pair.
@@ -528,6 +543,45 @@ describe('createAcpSessionBridge', () => {
 
         closeGate.resolve({ closed: true, holds: [] });
         await close;
+        expect(bridge.sessionCount).toBe(0);
+      } finally {
+        await bridge.shutdown();
+      }
+    });
+
+    it('spares the channel when a kill meets a definitive close refusal', async () => {
+      // A child holding its own close gate (cd/restore in flight — child-side
+      // state the daemon cannot see) answers the kill's forced close with a
+      // definitive RequestError. Escalating that to a channel kill would take
+      // every sibling session down for a close that is already proceeding.
+      let refuseClose = true;
+      const handle = makeChannel({
+        extMethodImpl: async (method) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          if (refuseClose) {
+            throw new RequestError(
+              -32603,
+              'Session close is already in progress',
+            );
+          }
+          return { closed: true, holds: [] };
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      try {
+        const owner = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+        await expect(bridge.killSession(owner.sessionId)).resolves.toBe(false);
+        expect(handle.killed).toBe(false);
+        expect(bridge.sessionCount).toBe(1);
+
+        // The refusal resets `closing`, so the kill completes once the
+        // child-side gate is gone instead of latching the entry closed.
+        refuseClose = false;
+        await expect(bridge.killSession(owner.sessionId)).resolves.toBe(true);
         expect(bridge.sessionCount).toBe(0);
       } finally {
         await bridge.shutdown();

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -392,6 +392,37 @@ describe('createAcpSessionBridge', () => {
       await bridge.shutdown();
     });
 
+    it('honors a deferred spawn-owner kill for an incomplete child', async () => {
+      const handle = makeChannel({
+        initializeImpl: () =>
+          activeWorkInitializeResponse({
+            categories: [...ACTIVE_WORK_LEGACY_HOLD_CATEGORIES],
+          }),
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      try {
+        const owner = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        const attacher = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        await sendActiveWorkSnapshot(handle, 1, [
+          { sessionId: owner.sessionId, holds: [] },
+        ]);
+
+        await expect(
+          bridge.killSession(owner.sessionId, {
+            requireZeroAttaches: true,
+          }),
+        ).resolves.toBe(false);
+        await bridge.detachClient(attacher.sessionId, attacher.clientId);
+
+        expect(bridge.sessionCount).toBe(0);
+      } finally {
+        await bridge.shutdown();
+      }
+    });
+
     it('accepts the aggregate shell hold as active work', async () => {
       const handle = makeChannel({
         initializeImpl: () => activeWorkInitializeResponse(),
@@ -743,7 +774,11 @@ describe('createAcpSessionBridge', () => {
       await bridge.detachClient(session.sessionId, session.clientId);
 
       await vi.waitFor(() => expect(closeCalls.length).toBe(1));
-      expect(closeCalls[0]?.['sessionId']).toBe(session.sessionId);
+      expect(closeCalls[0]).toMatchObject({
+        sessionId: session.sessionId,
+        [ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM]: true,
+        drainTimeoutMs: Math.floor(ACTIVE_WORK_CLOSE_TIMEOUT_MS * 0.8),
+      });
       await vi.waitFor(() => expect(bridge.sessionCount).toBe(0));
 
       await bridge.shutdown();
@@ -10617,13 +10652,17 @@ describe('createAcpSessionBridge', () => {
     vi.useFakeTimers();
     const lateRestore = deferred<LoadSessionResponse>();
     const first = makeChannel({
+      initializeImpl: () =>
+        activeWorkInitializeResponse({
+          categories: [...ACTIVE_WORK_LEGACY_HOLD_CATEGORIES],
+        }),
       loadSessionImpl: () => lateRestore.promise,
       extMethodImpl: (method, params) => {
-        if (
-          method === SERVE_CONTROL_EXT_METHODS.sessionClose &&
-          params['sessionId'] === 'restore-cleanup-fails'
-        ) {
-          throw new Error('late close failed');
+        if (method === SERVE_CONTROL_EXT_METHODS.sessionClose) {
+          if (params['sessionId'] === 'restore-cleanup-fails') {
+            throw new Error('late close failed');
+          }
+          return { closed: true, holds: [] };
         }
         return {};
       },
@@ -10699,8 +10738,16 @@ describe('createAcpSessionBridge', () => {
         }),
       ).resolves.toMatchObject({ stopReason: 'end_turn' });
 
-      await bridge.closeSession(sibling.sessionId);
+      await bridge.detachClient(sibling.sessionId, sibling.clientId);
       await vi.advanceTimersByTimeAsync(0);
+      expect(first.agent.extMethodCalls).toContainEqual({
+        method: SERVE_CONTROL_EXT_METHODS.sessionClose,
+        params: {
+          sessionId: sibling.sessionId,
+          drainTimeoutMs: 8_000,
+        },
+      });
+      expect(bridge.sessionCount).toBe(0);
       expect(first.killed).toBe(true);
       await vi.advanceTimersByTimeAsync(0);
       await expect(

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -117,6 +117,7 @@ import {
   PROMPT_CANCEL_METHOD,
   TODO_STOP_GUARD_CONTINUATION_CLAIM_METHOD,
   TODO_STOP_GUARD_QUEUE_RELEASE_METHOD,
+  sessionCloseDrainBudgetMs,
 } from './bridgeTypes.js';
 
 function deferred<T>(): {
@@ -417,6 +418,116 @@ describe('createAcpSessionBridge', () => {
         ).resolves.toBe(false);
         await bridge.detachClient(attacher.sessionId, attacher.clientId);
 
+        expect(bridge.sessionCount).toBe(0);
+      } finally {
+        await bridge.shutdown();
+      }
+    });
+
+    it('defers a tombstoned kill while a conditional close probe is in flight', async () => {
+      // The reaper ignores clientIds, so it can start a conditional-close
+      // probe on a tombstoned entry whose stale attacher never detached. The
+      // probe holds the child's close gate for up to the round-trip timeout;
+      // a kill fired in that window reaches the child as 'Session close is
+      // already in progress' and `killSession` escalates any close error to a
+      // channel kill, taking every sibling session down with it.
+      const probe = deferred<Record<string, unknown>>();
+      let conditionalCloseCalls = 0;
+      let forcedCloseCalls = 0;
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          if (params[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] === true) {
+            conditionalCloseCalls++;
+            return await probe.promise;
+          }
+          forcedCloseCalls++;
+          return { closed: true, holds: [] };
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 10,
+        sessionIdleTimeoutMs: 10,
+      });
+      try {
+        const owner = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        const attacher = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        await sendActiveWorkSnapshot(handle, 1, [
+          { sessionId: owner.sessionId, holds: [] },
+        ]);
+
+        await expect(
+          bridge.killSession(owner.sessionId, {
+            requireZeroAttaches: true,
+          }),
+        ).resolves.toBe(false);
+        await vi.waitFor(() => expect(conditionalCloseCalls).toBe(1));
+
+        // The stale attacher's late teardown detach must not fire the
+        // deferred kill into the in-flight probe.
+        await bridge.detachClient(attacher.sessionId, attacher.clientId);
+        await new Promise((resolve) => setTimeout(resolve, 40));
+        expect(forcedCloseCalls).toBe(0);
+        expect(handle.killed).toBe(false);
+        expect(bridge.sessionCount).toBe(1);
+
+        // The probe refuses: the entry is retained and the in-flight flag
+        // clears, so the tombstone is not stuck — the next idle report
+        // completes the kill through the ordinary deferred path.
+        probe.resolve({ closed: false, holds: [agentHold('turn-1')] });
+        await new Promise((resolve) => setTimeout(resolve, 40));
+        expect(forcedCloseCalls).toBe(0);
+        expect(bridge.sessionCount).toBe(1);
+
+        await sendActiveWorkSnapshot(handle, 2, [
+          { sessionId: owner.sessionId, holds: [] },
+        ]);
+        await vi.waitFor(() => expect(bridge.sessionCount).toBe(0));
+        expect(forcedCloseCalls).toBe(1);
+      } finally {
+        await bridge.shutdown();
+      }
+    });
+
+    it('does not escalate a deferred kill while a force close is in flight', async () => {
+      // A close already under way holds `entry.closing`; a deferred kill
+      // fired into it takes killSession's closing branch, which force-kills
+      // the whole channel. The detach that completes the tombstone must
+      // leave the in-flight close alone.
+      const closeGate = deferred<Record<string, unknown>>();
+      let forcedCloseCalls = 0;
+      const handle = makeChannel({
+        extMethodImpl: async (method) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          forcedCloseCalls++;
+          return await closeGate.promise;
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      try {
+        const owner = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        const attacher = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        await expect(
+          bridge.killSession(owner.sessionId, {
+            requireZeroAttaches: true,
+          }),
+        ).resolves.toBe(false);
+
+        const close = bridge.closeSession(owner.sessionId);
+        await vi.waitFor(() => expect(forcedCloseCalls).toBe(1));
+
+        await bridge.detachClient(attacher.sessionId, attacher.clientId);
+        await new Promise((resolve) => setTimeout(resolve, 40));
+        expect(handle.killed).toBe(false);
+        expect(bridge.sessionCount).toBe(1);
+
+        closeGate.resolve({ closed: true, holds: [] });
+        await close;
         expect(bridge.sessionCount).toBe(0);
       } finally {
         await bridge.shutdown();
@@ -777,7 +888,7 @@ describe('createAcpSessionBridge', () => {
       expect(closeCalls[0]).toMatchObject({
         sessionId: session.sessionId,
         [ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM]: true,
-        drainTimeoutMs: Math.floor(ACTIVE_WORK_CLOSE_TIMEOUT_MS * 0.8),
+        drainTimeoutMs: sessionCloseDrainBudgetMs(ACTIVE_WORK_CLOSE_TIMEOUT_MS),
       });
       await vi.waitFor(() => expect(bridge.sessionCount).toBe(0));
 
@@ -10692,7 +10803,7 @@ describe('createAcpSessionBridge', () => {
         method: SERVE_CONTROL_EXT_METHODS.sessionClose,
         params: {
           sessionId: 'restore-cleanup-fails',
-          drainTimeoutMs: 8_000,
+          drainTimeoutMs: sessionCloseDrainBudgetMs(10_000),
         },
       });
       // An uncertain cleanup is the outcome an operator most needs to see,
@@ -10744,7 +10855,7 @@ describe('createAcpSessionBridge', () => {
         method: SERVE_CONTROL_EXT_METHODS.sessionClose,
         params: {
           sessionId: sibling.sessionId,
-          drainTimeoutMs: 8_000,
+          drainTimeoutMs: sessionCloseDrainBudgetMs(10_000),
         },
       });
       expect(bridge.sessionCount).toBe(0);
@@ -23286,7 +23397,7 @@ describe('createAcpSessionBridge', () => {
         method: 'qwen/control/session/close',
         params: {
           sessionId: session.sessionId,
-          drainTimeoutMs: 8_000,
+          drainTimeoutMs: sessionCloseDrainBudgetMs(10_000),
           requireFlush: true,
         },
       });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2517,8 +2517,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // tombstone completes on the next settle event.
     if (
       byId.get(entry.sessionId) === entry &&
-      !entry.closing &&
-      !entry.activeWorkCloseInFlight &&
+      !isClosingOrAuthorizingClose(entry) &&
       entry.spawnOwnerWantedKill &&
       entry.attachCount === 0
     ) {
@@ -5025,7 +5024,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         SERVE_CONTROL_EXT_METHODS.sessionClose,
         {
           sessionId: entry.sessionId,
-          drainTimeoutMs: sessionCloseDrainBudgetMs(initTimeoutMs),
+          drainTimeoutMs: sessionCloseDrainBudgetMs(
+            opts?.timeoutMs ?? initTimeoutMs,
+          ),
           ...(opts?.requireFlush === true ? { requireFlush: true } : {}),
         },
       );
@@ -8655,6 +8656,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                       {
                         sessionId: result.newSessionId,
                         cwd: boundWorkspace,
+                        drainTimeoutMs:
+                          sessionCloseDrainBudgetMs(initTimeoutMs),
                       },
                     ),
                     channelUnavailableReject(

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2521,6 +2521,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       entry.spawnOwnerWantedKill &&
       entry.attachCount === 0
     ) {
+      writeStderrLine(
+        `qwen serve: completing deferred kill of session ${JSON.stringify(entry.sessionId)} (${reason})`,
+      );
       await bridgeApi.killSession(entry.sessionId).catch(() => {
         /* best-effort; channel.exited will eventually reap anyway */
       });
@@ -11192,6 +11195,16 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           timeoutMs: initTimeoutMs,
         });
       } catch (error) {
+        // A definitive refusal means the child is alive and kept the session:
+        // it already holds its own close gate (a cd or restore in progress —
+        // child-side state the daemon cannot see). Escalating that to a
+        // channel kill would take every sibling session down for a close
+        // that is already proceeding. Leave the kill pending instead; the
+        // deferred tombstone completes it on the next settle event.
+        if (isDefinitiveAcpRequestError(error)) {
+          entry.closing = false;
+          return false;
+        }
         if (ci) {
           await killChannelWithLog(
             ci,

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2499,17 +2499,24 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     entry: SessionEntry,
     reason: string,
   ): Promise<void> {
-    if (!entryIsAutoCloseCandidate(entry)) return;
     // Note the asymmetry, preserved from the call sites this replaces: the
     // kill path keys off `attachCount`, the close path off `clientIds`. A
     // spawn owner that asked for a kill gets one once nothing is attached,
-    // even if some client id is still registered.
-    if (entry.spawnOwnerWantedKill && entry.attachCount === 0) {
+    // even if some client id is still registered. This is a deferred explicit
+    // kill, so incomplete child reporting must not turn it into ordinary
+    // cleanup or leave it pending forever.
+    if (
+      byId.get(entry.sessionId) === entry &&
+      !entry.closing &&
+      entry.spawnOwnerWantedKill &&
+      entry.attachCount === 0
+    ) {
       await bridgeApi.killSession(entry.sessionId).catch(() => {
         /* best-effort; channel.exited will eventually reap anyway */
       });
       return;
     }
+    if (!entryIsAutoCloseCandidate(entry)) return;
     if (entry.clientIds.size > 0) return;
     await closeIfChildUnheld(entry, {
       trigger: reason,
@@ -2610,6 +2617,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         entry.connection.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
           sessionId: entry.sessionId,
           [ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM]: true,
+          drainTimeoutMs: Math.max(
+            1,
+            Math.floor(ACTIVE_WORK_CLOSE_TIMEOUT_MS * 0.8),
+          ),
         }),
         ACTIVE_WORK_CLOSE_TIMEOUT_MS,
         SERVE_CONTROL_EXT_METHODS.sessionClose,

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -149,6 +149,7 @@ import {
   TODO_STOP_GUARD_QUEUE_RELEASE_METHOD,
   WORKTREE_MCP_DEFER_META_KEY,
   isValidTrustedModelPrompt,
+  sessionCloseDrainBudgetMs,
 } from './bridgeTypes.js';
 import { getChannelStartupProfileAttributes } from './channel-startup-profile.js';
 import type {
@@ -2505,9 +2506,19 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // even if some client id is still registered. This is a deferred explicit
     // kill, so incomplete child reporting must not turn it into ordinary
     // cleanup or leave it pending forever.
+    //
+    // `activeWorkCloseInFlight` must stay excluded (the auto-close candidacy
+    // gate used to cover it): the reaper can be mid-probe on this same entry,
+    // holding the child's close gate for up to `ACTIVE_WORK_CLOSE_TIMEOUT_MS`.
+    // A kill fired in that window reaches `beginClose()` as 'Session close is
+    // already in progress', and `killSession` escalates any close error to a
+    // channel kill — taking down every sibling session with it. The in-flight
+    // probe resolves this entry one way or the other; if it retains, the
+    // tombstone completes on the next settle event.
     if (
       byId.get(entry.sessionId) === entry &&
       !entry.closing &&
+      !entry.activeWorkCloseInFlight &&
       entry.spawnOwnerWantedKill &&
       entry.attachCount === 0
     ) {
@@ -2617,9 +2628,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         entry.connection.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
           sessionId: entry.sessionId,
           [ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM]: true,
-          drainTimeoutMs: Math.max(
-            1,
-            Math.floor(ACTIVE_WORK_CLOSE_TIMEOUT_MS * 0.8),
+          drainTimeoutMs: sessionCloseDrainBudgetMs(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS,
           ),
         }),
         ACTIVE_WORK_CLOSE_TIMEOUT_MS,
@@ -5015,7 +5025,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         SERVE_CONTROL_EXT_METHODS.sessionClose,
         {
           sessionId: entry.sessionId,
-          drainTimeoutMs: Math.max(1, Math.floor(initTimeoutMs * 0.8)),
+          drainTimeoutMs: sessionCloseDrainBudgetMs(initTimeoutMs),
           ...(opts?.requireFlush === true ? { requireFlush: true } : {}),
         },
       );
@@ -6298,7 +6308,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 SERVE_CONTROL_EXT_METHODS.sessionClose,
                 {
                   sessionId: req.sessionId,
-                  drainTimeoutMs: Math.max(1, Math.floor(initTimeoutMs * 0.8)),
+                  drainTimeoutMs: sessionCloseDrainBudgetMs(initTimeoutMs),
                 },
               ),
               initTimeoutMs,

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -216,6 +216,18 @@ export const ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM = 'onlyIfUnheld';
  *  longer buys nothing — an unanswered request is simply left for the next
  *  snapshot to settle. */
 export const ACTIVE_WORK_CLOSE_TIMEOUT_MS = 10_000;
+
+/**
+ * The child's drain budget for a `sessionClose` round trip: strictly under
+ * the daemon's outer wait so the child deadline always fires first, clamped
+ * to ≥1ms so a tiny outer wait still yields a usable budget. An outer wait
+ * that fires first leaves the close outcome unknown, which the close path
+ * recovers by killing the whole channel — the coupling lives here exactly
+ * once so the ratio cannot drift between call sites.
+ */
+export function sessionCloseDrainBudgetMs(outerWaitMs: number): number {
+  return Math.max(1, Math.floor(outerWaitMs * 0.8));
+}
 /** Bounds on a single snapshot. Generous next to any real deployment — they
  *  exist so a version-skewed or buggy child cannot make the daemon walk an
  *  unbounded structure per report, not to constrain legitimate use. A packet

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2782,6 +2782,20 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  /** Installs a beginClose mock that tracks gate hold state; the returned
+   *  getter is asserted false after refusal/timeout paths to pin that the
+   *  close gate is always released. */
+  const trackCloseGateHeld = (): (() => boolean) => {
+    let held = false;
+    lastSessionMock?.beginClose.mockImplementation(() => {
+      held = true;
+      return () => {
+        held = false;
+      };
+    });
+    return () => held;
+  };
+
   it('uses the pre-category v1 baseline when initialize omits categories', async () => {
     await setupSessionMocks('legacy-active-work-session');
     const extNotification = vi.fn().mockResolvedValue(undefined);
@@ -2829,13 +2843,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(snapshots.at(-1)?.[1]).toMatchObject({
       sessions: [{ sessionId: 'legacy-active-work-session', holds: [] }],
     });
-    let closeGateHeld = false;
-    lastSessionMock?.beginClose.mockImplementation(() => {
-      closeGateHeld = true;
-      return () => {
-        closeGateHeld = false;
-      };
-    });
+    const closeGateHeld = trackCloseGateHeld();
     await expect(
       agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
         sessionId: 'legacy-active-work-session',
@@ -2848,7 +2856,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
     expect(lastSessionMock?.waitForActiveTurnsToSettle).not.toHaveBeenCalled();
     expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
-    expect(closeGateHeld).toBe(false);
+    expect(closeGateHeld()).toBe(false);
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -2870,19 +2878,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     await agent.initialize({ clientCapabilities: {} });
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    let closeGateHeld = false;
+    const closeGateHeld = trackCloseGateHeld();
     let turnsSettled = false;
-    lastSessionMock?.beginClose.mockImplementation(() => {
-      closeGateHeld = true;
-      return () => {
-        closeGateHeld = false;
-      };
-    });
     lastSessionMock?.waitForActiveTurnsToSettle.mockImplementation(async () => {
       turnsSettled = true;
     });
     lastSessionMock?.collectActiveWorkHolds.mockImplementation(() =>
-      closeGateHeld && turnsSettled
+      closeGateHeld() && turnsSettled
         ? [{ category: 'shell', id: 'background-shells' }]
         : [],
     );
@@ -2917,7 +2919,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
     expect(abort).not.toHaveBeenCalled();
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
-    expect(closeGateHeld).toBe(false);
+    expect(closeGateHeld()).toBe(false);
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -2939,13 +2941,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     await agent.initialize({ clientCapabilities: {} });
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    let closeGateHeld = false;
-    lastSessionMock?.beginClose.mockImplementation(() => {
-      closeGateHeld = true;
-      return () => {
-        closeGateHeld = false;
-      };
-    });
+    const closeGateHeld = trackCloseGateHeld();
     lastSessionMock?.collectActiveWorkHolds.mockReturnValue([]);
     lastSessionMock?.waitForActiveTurnsToSettle
       .mockImplementationOnce(
@@ -2970,7 +2966,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
     expect(lastSessionMock?.cancelPendingPrompt).toHaveBeenCalledOnce();
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
-    expect(closeGateHeld).toBe(false);
+    expect(closeGateHeld()).toBe(false);
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -2992,13 +2988,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     await agent.initialize({ clientCapabilities: {} });
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    let closeGateHeld = false;
-    lastSessionMock?.beginClose.mockImplementation(() => {
-      closeGateHeld = true;
-      return () => {
-        closeGateHeld = false;
-      };
-    });
+    const closeGateHeld = trackCloseGateHeld();
     lastSessionMock?.collectActiveWorkHolds.mockReturnValue([]);
     // A turn that never settles must not hang the close forever: the phase-1
     // cap rejects it and releases the gate, leaving queued work untouched.
@@ -3024,7 +3014,61 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
     expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
-    expect(closeGateHeld).toBe(false);
+    expect(closeGateHeld()).toBe(false);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('completes a conditional close when no holds appear at any re-check', async () => {
+    await setupSessionMocks('active-work-close-success');
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await agent.initialize({ clientCapabilities: {} });
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    lastSessionMock?.collectActiveWorkHolds.mockReturnValue([]);
+    // A turn in flight when the close begins: it must be aborted only after
+    // the settle + re-check authorize teardown, never before.
+    const controller = new AbortController();
+    const abort = vi.spyOn(controller, 'abort');
+    (
+      agent as unknown as {
+        generationControllers: Map<
+          string,
+          { sessionId: string; controller: AbortController }
+        >;
+      }
+    ).generationControllers.set('active-generation', {
+      sessionId: 'active-work-close-success',
+      controller,
+    });
+
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
+        sessionId: 'active-work-close-success',
+        onlyIfUnheld: true,
+      }),
+    ).resolves.toEqual({
+      sessionId: 'active-work-close-success',
+      closed: true,
+    });
+    expect(lastSessionMock?.waitForActiveTurnsToSettle).toHaveBeenCalled();
+    expect(lastSessionMock?.cancelPendingPrompt).toHaveBeenCalledOnce();
+    expect(abort).toHaveBeenCalledOnce();
+    const firstSettleOrder =
+      lastSessionMock!.waitForActiveTurnsToSettle.mock.invocationCallOrder[0];
+    expect(abort.mock.invocationCallOrder[0]).toBeGreaterThan(firstSettleOrder);
+    expect(lastSessionMock?.dispose).toHaveBeenCalledOnce();
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2829,6 +2829,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(snapshots.at(-1)?.[1]).toMatchObject({
       sessions: [{ sessionId: 'legacy-active-work-session', holds: [] }],
     });
+    let closeGateHeld = false;
+    lastSessionMock?.beginClose.mockImplementation(() => {
+      closeGateHeld = true;
+      return () => {
+        closeGateHeld = false;
+      };
+    });
     await expect(
       agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
         sessionId: 'legacy-active-work-session',
@@ -2841,6 +2848,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
     expect(lastSessionMock?.waitForActiveTurnsToSettle).not.toHaveBeenCalled();
     expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
+    expect(closeGateHeld).toBe(false);
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -2878,6 +2886,22 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         ? [{ category: 'shell', id: 'background-shells' }]
         : [],
     );
+    // A refusal must leave the retained Session's in-flight generation
+    // untouched: the abort loop runs only after the re-check authorizes
+    // teardown.
+    const controller = new AbortController();
+    const abort = vi.spyOn(controller, 'abort');
+    (
+      agent as unknown as {
+        generationControllers: Map<
+          string,
+          { sessionId: string; controller: AbortController }
+        >;
+      }
+    ).generationControllers.set('active-generation', {
+      sessionId: 'active-work-close-race',
+      controller,
+    });
 
     await expect(
       agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
@@ -2891,6 +2915,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
     expect(lastSessionMock?.waitForActiveTurnsToSettle).toHaveBeenCalledOnce();
     expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
+    expect(abort).not.toHaveBeenCalled();
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
     expect(closeGateHeld).toBe(false);
 
@@ -2914,6 +2939,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     await agent.initialize({ clientCapabilities: {} });
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    let closeGateHeld = false;
+    lastSessionMock?.beginClose.mockImplementation(() => {
+      closeGateHeld = true;
+      return () => {
+        closeGateHeld = false;
+      };
+    });
     lastSessionMock?.collectActiveWorkHolds.mockReturnValue([]);
     lastSessionMock?.waitForActiveTurnsToSettle
       .mockImplementationOnce(
@@ -2929,7 +2961,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         drainTimeoutMs: 1_000,
       });
       await Promise.all([
-        expect(close).rejects.toThrow('Session close timed out after 400ms'),
+        // The message reports the shared budget, not the phase-2 residue.
+        expect(close).rejects.toThrow('Session close timed out after 1000ms'),
         vi.advanceTimersByTimeAsync(1_000),
       ]);
     } finally {
@@ -2937,6 +2970,61 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
     expect(lastSessionMock?.cancelPendingPrompt).toHaveBeenCalledOnce();
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
+    expect(closeGateHeld).toBe(false);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('rejects a conditional close when the settle phase exceeds the shared budget', async () => {
+    await setupSessionMocks('active-work-close-settle-timeout');
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await agent.initialize({ clientCapabilities: {} });
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    let closeGateHeld = false;
+    lastSessionMock?.beginClose.mockImplementation(() => {
+      closeGateHeld = true;
+      return () => {
+        closeGateHeld = false;
+      };
+    });
+    lastSessionMock?.collectActiveWorkHolds.mockReturnValue([]);
+    // A turn that never settles must not hang the close forever: the phase-1
+    // cap rejects it and releases the gate, leaving queued work untouched.
+    // Once-only: the end-of-test dispose must fall back to the default
+    // (resolving) mock or `agentPromise` never completes.
+    lastSessionMock?.waitForActiveTurnsToSettle.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const close = agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
+        sessionId: 'active-work-close-settle-timeout',
+        onlyIfUnheld: true,
+        drainTimeoutMs: 1_000,
+      });
+      await Promise.all([
+        expect(close).rejects.toThrow('Session close timed out after 1000ms'),
+        vi.advanceTimersByTimeAsync(1_000),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
+    expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
+    expect(closeGateHeld).toBe(false);
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2839,6 +2839,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       closed: false,
       holds: [{ category: 'shell', id: 'background-shells' }],
     });
+    expect(lastSessionMock?.waitForActiveTurnsToSettle).not.toHaveBeenCalled();
+    expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -2888,8 +2890,53 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       holds: [{ category: 'shell', id: 'background-shells' }],
     });
     expect(lastSessionMock?.waitForActiveTurnsToSettle).toHaveBeenCalledOnce();
+    expect(lastSessionMock?.cancelPendingPrompt).not.toHaveBeenCalled();
     expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
     expect(closeGateHeld).toBe(false);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('shares one timeout budget across conditional close drain phases', async () => {
+    await setupSessionMocks('active-work-close-timeout');
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    await agent.initialize({ clientCapabilities: {} });
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    lastSessionMock?.collectActiveWorkHolds.mockReturnValue([]);
+    lastSessionMock?.waitForActiveTurnsToSettle
+      .mockImplementationOnce(
+        () => new Promise((resolve) => setTimeout(resolve, 600)),
+      )
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    vi.useFakeTimers();
+    try {
+      const close = agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionClose, {
+        sessionId: 'active-work-close-timeout',
+        onlyIfUnheld: true,
+        drainTimeoutMs: 1_000,
+      });
+      await Promise.all([
+        expect(close).rejects.toThrow('Session close timed out after 400ms'),
+        vi.advanceTimersByTimeAsync(1_000),
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(lastSessionMock?.cancelPendingPrompt).toHaveBeenCalledOnce();
+    expect(lastSessionMock?.dispose).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -3894,6 +3894,7 @@ class QwenAgent implements Agent {
     sessionId: string,
     operation: () => Promise<T>,
     waitTimeoutMs?: number,
+    waitDisplayTimeoutMs?: number,
   ): Promise<T> {
     const previous =
       this.historyMutationTails.get(sessionId) ?? Promise.resolve();
@@ -3907,7 +3908,12 @@ class QwenAgent implements Agent {
       if (waitTimeoutMs === undefined) {
         await previous;
       } else {
-        await waitForSessionDrain(previous, waitTimeoutMs, 'close');
+        await waitForSessionDrain(
+          previous,
+          waitTimeoutMs,
+          'close',
+          waitDisplayTimeoutMs,
+        );
       }
     } catch (error) {
       release();
@@ -4685,6 +4691,14 @@ class QwenAgent implements Agent {
           removedFromStore = true;
           return undefined;
         },
+        // The mutation wait shares the conditional close's budget too, or
+        // the whole round trip can outlast the daemon's outer wait — the
+        // coupling the drain budget exists to keep. The mutation body
+        // itself stays untimed, so the guarantee remains approximate. The
+        // message reports the shared budget, not the residue.
+        conditionalDrainDeadline === undefined
+          ? drainTimeoutMs
+          : Math.max(1, conditionalDrainDeadline - Date.now()),
         drainTimeoutMs,
       );
       if (blockedByHolds) return blockedByHolds;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -581,11 +581,17 @@ async function waitForSessionDrain(
   operation: Promise<void>,
   timeoutMs: number,
   kind: 'close' | 'restore',
+  displayTimeoutMs?: number,
 ): Promise<void> {
   let timer: NodeJS.Timeout | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(
-      () => reject(new Error(`Session ${kind} timed out after ${timeoutMs}ms`)),
+      () =>
+        reject(
+          new Error(
+            `Session ${kind} timed out after ${displayTimeoutMs ?? timeoutMs}ms`,
+          ),
+        ),
       timeoutMs,
     );
     timer.unref();
@@ -4619,6 +4625,10 @@ class QwenAgent implements Agent {
           ? drainTimeoutMs
           : Math.max(1, conditionalDrainDeadline - Date.now()),
         'close',
+        // Report the shared budget, not the phase-2 residue — a residue like
+        // "1ms" hides that the settle phase consumed the budget and sends
+        // oncall grepping for a timeout setting that does not exist.
+        drainTimeoutMs,
       );
 
       const blockedByHolds = await this.runExclusiveHistoryMutation(

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4566,6 +4566,9 @@ class QwenAgent implements Agent {
     const cancelClose = opts?.waitForCloseGate
       ? await beginSessionCloseAfterCurrentGate(session, drainTimeoutMs)
       : session.beginClose();
+    const conditionalDrainDeadline = opts?.onlyIfUnheld
+      ? Date.now() + drainTimeoutMs
+      : undefined;
     // Reject known work before disturbing any active turn. The close gate
     // prevents new turns, but a turn that was already running can still settle
     // into a new hold while the drain below is in progress, so this early read
@@ -4577,13 +4580,28 @@ class QwenAgent implements Agent {
         return { closed: false, holds };
       }
     }
-    for (const [requestId, generation] of this.generationControllers) {
-      if (generation.sessionId !== sessionId) continue;
-      generation.controller.abort();
-      this.generationControllers.delete(requestId);
-    }
     let removedFromStore = false;
     try {
+      if (opts?.onlyIfUnheld) {
+        // Let the turn that already owned the gate settle without cancelling
+        // queues or stopping schedulers. It may create a hold while settling;
+        // a refusal must leave the retained Session untouched.
+        await waitForSessionDrain(
+          session.waitForActiveTurnsToSettle(),
+          drainTimeoutMs,
+          'close',
+        );
+        const holds = session.collectActiveWorkHolds();
+        if (holds.length > 0) {
+          return { closed: false, holds };
+        }
+      }
+
+      for (const [requestId, generation] of this.generationControllers) {
+        if (generation.sessionId !== sessionId) continue;
+        generation.controller.abort();
+        this.generationControllers.delete(requestId);
+      }
       await waitForSessionDrain(
         (async () => {
           try {
@@ -4597,7 +4615,9 @@ class QwenAgent implements Agent {
           }
           await session.waitForActiveTurnsToSettle();
         })(),
-        drainTimeoutMs,
+        conditionalDrainDeadline === undefined
+          ? drainTimeoutMs
+          : Math.max(1, conditionalDrainDeadline - Date.now()),
         'close',
       );
 


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This follow-up makes automatic active-work close authorization non-destructive. The child rejects known holds immediately, lets an already-running turn settle naturally under the close gate, checks holds again, and only then cancels queued work and tears the Session down. Both drain phases share one child-side deadline, and the daemon supplies an 8-second drain budget inside its existing 10-second round-trip deadline.

It also completes a previously deferred spawn-owner kill as soon as the final attacher leaves, before ordinary cleanup evaluates active-work reporting completeness. The deferred request therefore keeps the same force semantics as an immediate explicit kill, including with an older v1 child that reports only the legacy categories.

## Why it's needed

Post-merge review of #9042 found two lifecycle races. First, a conditional close could cancel cron, goal, and notification queues before an already-running turn registered a shell hold; the close would then be refused, retaining a Session whose queued work and scheduler had already been destroyed. Second, a spawn-owner kill deferred while another client was attached could remain pending forever when the child negotiated active-work reporting without the newer `shell` category.

The new ordering preserves retained Sessions exactly as they were when authorization is refused, while still keeping explicit kill forceful and bounded.

## Reviewer Test Plan

### How to verify

Exercise a conditional close whose initial hold set is empty and whose running turn registers a shell while naturally settling. Confirm the close returns `closed: false`, does not cancel pending work, does not dispose the Session, and releases the close gate. Also exercise a 1,000 ms close budget with a 600 ms natural-settlement phase and confirm the destructive phase receives only the remaining 400 ms.

Pair the daemon with a child that negotiates only the legacy `agent` and `notification` categories. Create a spawn owner and an attacher, request a zero-attacher owner kill, detach the final attacher, and confirm the Session is removed. Confirm separately that quarantined channels still reap detached Sessions despite incomplete category reporting, while healthy incomplete children remain protected from ordinary cleanup.

The complete ACP bridge suite passes with 642 tests. The three focused ACP child tests pass, and independent pre-fix/post-fix harnesses confirm zero destructive cancellations on refusal, `sessionCount=0` after the deferred kill, and the shared 600 ms + 400 ms drain budget.

### Evidence (Before & After)

N/A — daemon lifecycle behavior with no UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node.js 26.0.0, package-level Vitest without sandboxing.

## Risk & Scope

- Main risk or tradeoff: Automatic cleanup now waits for an already-running child turn to settle naturally before destructive teardown. A wedged turn is retained when the bounded authorization fails, which is the intended fail-closed direction.
- Not validated / out of scope: Windows and Linux were not tested locally. Channel liveness, Agent watchdogs, shell stall detection, and retry behavior remain out of scope. Full repository build/typecheck was blocked by the existing shared dependency tree resolving Ajv 6 without `ajv/dist/2020.js`, missing `fdir` and `mime/lite`, and leaving core declaration outputs unavailable; formatting, lint, the full ACP bridge suite, and focused child lifecycle tests passed.
- Breaking changes / migration notes: None. Public health fields, persistence, protocol version, and explicit close/kill/shutdown semantics are unchanged.

## Linked Issues

Refs #8586

Follow-up to #9042

<details>
<summary>中文说明</summary>

## 本 PR 的变更

这个 follow-up 将 active-work 自动关闭授权调整为非破坏性流程。child 会立即拒绝已有 hold；如果没有已有 hold，则在 close gate 下让已经运行的 turn 自然结束，再次检查 hold，只有两次检查都为空时才取消排队工作并拆除 Session。两个 drain 阶段共用一个 child 侧总截止时间，daemon 在现有 10 秒往返超时内提供 8 秒 drain 预算。

本 PR 还会在最后一个 attacher 离开后、普通清理检查 active-work 上报完整性之前，完成此前延迟的 spawn-owner kill。因此，即使旧 v1 child 只上报 legacy 类别，延迟请求仍与立即执行的显式 kill 保持相同的强制语义。

## 为什么需要

#9042 合并后的审查发现了两个生命周期竞态。第一，conditional close 可能先清空 cron、goal 和 notification 队列，而已经运行的 turn 随后登记 shell hold；关闭因此被拒绝，但保留下来的 Session 已经丢失排队工作，scheduler 也已被停止。第二，当 child 已协商 active-work 但不包含新的 `shell` 类别时，spawn owner 在其他 client attached 期间延迟的 kill 可能永远无法完成。

新的顺序保证授权被拒绝时 Session 保持原样，同时维持显式 kill 的强制和有界语义。

## Reviewer 测试计划

### 验证方式

构造初始 hold 集合为空、但正在运行的 turn 在自然结束时登记 shell 的 conditional close。确认返回 `closed: false`，不取消排队工作、不 dispose Session，并释放 close gate。同时以 1,000 ms 关闭预算验证：自然结束阶段使用 600 ms 后，破坏性阶段只能使用剩余 400 ms。

让 daemon 与仅协商 legacy `agent` 和 `notification` 类别的 child 配对。创建一个 spawn owner 和一个 attacher，请求仅在零 attacher 时执行 owner kill，随后 detach 最后一个 attacher，并确认 Session 被移除。另行确认 quarantined channel 即使类别上报不完整仍能回收 detached Session，而健康但类别不完整的 child 继续受到普通清理保护。

ACP bridge 完整测试 642 项全部通过。3 项 ACP child 定向测试全部通过；独立的修复前/修复后 harness 还确认：拒绝前破坏性取消次数为 0、延迟 kill 后 `sessionCount=0`，以及 600 ms + 400 ms 共用同一个 drain 预算。

### 证据（Before & After）

N/A —— daemon 生命周期行为变更，不涉及 UI。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS、Node.js 26.0.0，未启用 sandbox，运行 package 级 Vitest。

## 风险与范围

- 主要风险或取舍：普通自动清理现在会先等待已运行的 child turn 自然结束，再进行破坏性 teardown。若 turn 卡死，有界授权会失败并保留 Session；这是有意的 fail-closed 方向。
- 未验证 / 范围外：未在本地测试 Windows 和 Linux。channel 活性、Agent watchdog、shell 卡死检测和重试行为仍不在范围内。完整仓库 build/typecheck 被现有共享依赖树阻塞：Ajv 6 不包含 `ajv/dist/2020.js`，同时缺少 `fdir` 和 `mime/lite`，core declaration 输出也不可用；格式检查、lint、ACP bridge 完整测试和 child 生命周期定向测试均已通过。
- 破坏性变更 / 迁移说明：无。公开 health 字段、持久化格式、协议版本以及显式 close/kill/shutdown 语义均未改变。

## 关联 Issue

Refs #8586

#9042 的 follow-up

</details>
