### PR TITLE
fix(serve): allow preinstall skill batch toggles

### DIFF
--- a/docs/design/daemon-skill-batch-toggle.md
+++ b/docs/design/daemon-skill-batch-toggle.md
@@ -24,11 +24,16 @@ The request body is:
 
 `skillNames` is a non-empty string array with at most 100 entries. Names are
 trimmed and deduplicated case-insensitively while preserving first-seen order.
-The response is best-effort for expected target errors: valid targets are
-validated against one status snapshot, persisted in one locked write, and
-applied with one live-session refresh. Unknown, hidden, inactive-extension,
-and locked targets are returned without blocking the valid targets. Unexpected
-persistence and runtime-generation failures fail the whole request.
+The response is best-effort for expected target errors: installed targets are
+validated against one status snapshot, all valid names are persisted in one
+locked write, and changes are applied with one live-session refresh. Names
+that are not installed remain valid so callers can declare their state before
+installation. Enabling one removes a matching workspace `skills.disabled`
+entry and is otherwise a no-op, except for the existing `defaultDisabled`
+override behavior; disabling one writes `skills.disabled`. Hidden,
+inactive-extension, and locked targets are returned without blocking valid
+targets. Unexpected persistence and runtime-generation failures fail the whole
+request.
 
 ```json
 {
@@ -46,15 +51,14 @@ persistence and runtime-generation failures fail the whole request.
       "skillName": "deploy",
       "enabled": false,
       "changed": true
-    }
-  ],
-  "errors": [
+    },
     {
       "skillName": "missing",
-      "code": "skill_not_found",
-      "error": "Skill not found: missing"
+      "enabled": false,
+      "changed": true
     }
-  ]
+  ],
+  "errors": []
 }
 ```
 

--- a/packages/cli/src/serve/routes/workspace-skills.test.ts
+++ b/packages/cli/src/serve/routes/workspace-skills.test.ts
@@ -173,20 +173,18 @@ describe('workspace Skill management routes', () => {
     expect(harness.deleteWorkspaceSkill).not.toHaveBeenCalled();
   });
 
-  it('toggles a deduplicated Skill batch and returns per-target errors', async () => {
+  it('toggles a deduplicated Skill batch and returns per-target outcomes', async () => {
     const harness = createHarness();
     harness.setWorkspaceSkillsEnabled.mockResolvedValueOnce({
       enabled: false,
       activation: 'applied',
       sessionsRefreshed: 1,
       sessionsFailed: 0,
-      results: [{ skillName: 'review', enabled: false, changed: true }],
+      results: [
+        { skillName: 'review', enabled: false, changed: true },
+        { skillName: 'missing', enabled: false, changed: true },
+      ],
       errors: [
-        {
-          skillName: 'missing',
-          code: 'skill_not_found',
-          error: 'Skill not found: missing',
-        },
         {
           skillName: 'locked',
           code: 'skill_not_toggleable',
@@ -216,13 +214,13 @@ describe('workspace Skill management routes', () => {
           enabled: false,
           changed: true,
         },
-      ],
-      errors: [
         {
           skillName: 'missing',
-          code: 'skill_not_found',
-          error: 'Skill not found: missing',
+          enabled: false,
+          changed: true,
         },
+      ],
+      errors: [
         {
           skillName: 'locked',
           code: 'skill_not_toggleable',

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -914,6 +914,30 @@ describe('workspace skill settings persistence', () => {
     expect(savedUser.skills.disabled).toEqual(['locked-skill']);
     expect(savedUser.skills.enabled).toBeUndefined();
 
+    const preinstallNoop = await persistDisabledSkillsBatch!(
+      workspace,
+      ['future-skill'],
+      true,
+    );
+    expect(preinstallNoop.outcomes).toEqual([
+      { skillName: 'future-skill', changed: false },
+    ]);
+    expect(preinstallNoop.settingsChanges).toEqual([]);
+    expect(setValues).toHaveBeenCalledOnce();
+
+    const preinstallEnable = await persistDisabledSkillsBatch!(
+      workspace,
+      ['orphan'],
+      true,
+    );
+    expect(preinstallEnable.outcomes).toEqual([
+      { skillName: 'orphan', changed: true },
+    ]);
+    expect(preinstallEnable.settingsChanges).toEqual([
+      { key: 'skills.disabled', value: ['review', 'alpha'] },
+    ]);
+    expect(setValues).toHaveBeenCalledTimes(2);
+
     const enableResult = await persistDisabledSkillsBatch!(
       workspace,
       ['opt-in'],
@@ -929,16 +953,12 @@ describe('workspace skill settings persistence', () => {
         value: ['opt-in'],
       },
     ]);
-    expect(setValues).toHaveBeenCalledTimes(2);
+    expect(setValues).toHaveBeenCalledTimes(3);
 
     const savedAfterEnable = JSON.parse(
       fs.readFileSync(path.join(workspace, '.qwen', 'settings.json'), 'utf8'),
     ) as { skills: { disabled: string[]; enabled: string[] } };
-    expect(savedAfterEnable.skills.disabled).toEqual([
-      'orphan',
-      'review',
-      'alpha',
-    ]);
+    expect(savedAfterEnable.skills.disabled).toEqual(['review', 'alpha']);
     expect(savedAfterEnable.skills.enabled).toEqual(['opt-in']);
 
     const guard = vi.fn();

--- a/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
+++ b/packages/cli/src/serve/workspace-service/__tests__/facade.test.ts
@@ -2098,6 +2098,38 @@ describe('createDaemonWorkspaceService', () => {
       },
     ];
 
+    it('accepts enabling a Skill before installation as an idempotent result', async () => {
+      const persistDisabledSkillsBatch = vi.fn().mockResolvedValue({
+        outcomes: [{ skillName: 'future-skill', changed: false }],
+        settingsChanges: [],
+      });
+      const svc = createDaemonWorkspaceService(
+        makeDeps({
+          queryWorkspaceStatus: vi.fn().mockResolvedValue({
+            v: 1,
+            workspaceCwd: '/workspace',
+            initialized: true,
+            skills,
+          }),
+          persistDisabledSkillsBatch,
+          isChannelLive: () => false,
+        }),
+      );
+
+      await expect(
+        svc.setWorkspaceSkillsEnabled(makeCtx(), ['future-skill'], true),
+      ).resolves.toMatchObject({
+        results: [{ skillName: 'future-skill', enabled: true, changed: false }],
+        errors: [],
+      });
+      expect(persistDisabledSkillsBatch).toHaveBeenCalledWith(
+        '/workspace',
+        ['future-skill'],
+        true,
+        undefined,
+      );
+    });
+
     it('persists and refreshes once while preserving ordered target outcomes', async () => {
       const queryWorkspaceStatus = vi.fn().mockResolvedValue({
         v: 1,
@@ -2108,6 +2140,7 @@ describe('createDaemonWorkspaceService', () => {
       const persistDisabledSkillsBatch = vi.fn().mockResolvedValue({
         outcomes: [
           { skillName: 'review', changed: true },
+          { skillName: 'missing', changed: true },
           {
             skillName: 'locked',
             error: new WorkspaceSkillNotToggleableError(
@@ -2119,7 +2152,10 @@ describe('createDaemonWorkspaceService', () => {
           { skillName: 'deploy', changed: true },
         ],
         settingsChanges: [
-          { key: 'skills.disabled', value: ['review', 'deploy'] },
+          {
+            key: 'skills.disabled',
+            value: ['review', 'missing', 'deploy'],
+          },
         ],
       });
       const invokeWorkspaceCommand = vi.fn().mockResolvedValue({
@@ -2147,7 +2183,7 @@ describe('createDaemonWorkspaceService', () => {
       expect(persistDisabledSkillsBatch).toHaveBeenCalledOnce();
       expect(persistDisabledSkillsBatch).toHaveBeenCalledWith(
         '/workspace',
-        ['review', 'locked', 'deploy'],
+        ['review', 'missing', 'locked', 'deploy'],
         false,
         undefined,
       );
@@ -2163,14 +2199,10 @@ describe('createDaemonWorkspaceService', () => {
         sessionsFailed: 0,
         results: [
           { skillName: 'review', enabled: false, changed: true },
+          { skillName: 'missing', enabled: false, changed: true },
           { skillName: 'deploy', enabled: false, changed: true },
         ],
         errors: [
-          {
-            skillName: 'missing',
-            code: 'skill_not_found',
-            error: 'Skill not found: missing',
-          },
           {
             skillName: 'hidden',
             code: 'skill_not_toggleable',
@@ -2197,7 +2229,7 @@ describe('createDaemonWorkspaceService', () => {
         type: 'settings_changed',
         data: {
           key: 'skills.disabled',
-          value: ['review', 'deploy'],
+          value: ['review', 'missing', 'deploy'],
           scope: 'workspace',
         },
         originatorClientId: 'client-1',
@@ -2225,6 +2257,7 @@ describe('createDaemonWorkspaceService', () => {
                 ),
               },
               { skillName: 'review', changed: true },
+              { skillName: 'missing', changed: true },
             ],
             settingsChanges: [],
           }),
@@ -2240,6 +2273,7 @@ describe('createDaemonWorkspaceService', () => {
 
       expect(result.results).toEqual([
         { skillName: 'review', enabled: false, changed: true },
+        { skillName: 'missing', enabled: false, changed: true },
         { skillName: 'deploy', enabled: false, changed: true },
       ]);
       expect(result.errors).toEqual([
@@ -2249,11 +2283,6 @@ describe('createDaemonWorkspaceService', () => {
           error: 'Skill locked is locked by user settings',
           reason: 'locked',
           lockedScope: 'user',
-        },
-        {
-          skillName: 'missing',
-          code: 'skill_not_found',
-          error: 'Skill not found: missing',
         },
       ]);
     });
@@ -2329,18 +2358,13 @@ describe('createDaemonWorkspaceService', () => {
       );
 
       await expect(
-        svc.setWorkspaceSkillsEnabled(
-          makeCtx(),
-          ['missing', 'hidden', 'inactive'],
-          false,
-        ),
+        svc.setWorkspaceSkillsEnabled(makeCtx(), ['hidden', 'inactive'], false),
       ).resolves.toMatchObject({
         activation: 'applied',
         sessionsRefreshed: 0,
         sessionsFailed: 0,
         results: [],
         errors: [
-          { skillName: 'missing', code: 'skill_not_found' },
           { skillName: 'hidden', code: 'skill_not_toggleable' },
           { skillName: 'inactive', code: 'skill_inactive_extension' },
         ],

--- a/packages/cli/src/serve/workspace-service/index.ts
+++ b/packages/cli/src/serve/workspace-service/index.ts
@@ -959,10 +959,12 @@ export function createDaemonWorkspaceService(
       for (const requestedName of requestedSkillNames) {
         const normalizedName = requestedName.trim().toLowerCase();
         const skill = skillsByName.get(normalizedName);
-        let domainError: unknown;
         if (!skill) {
-          domainError = new WorkspaceSkillNotFoundError(requestedName);
-        } else if (skill.userInvocable === false) {
+          targets.push({ requestedName, skillName: requestedName });
+          continue;
+        }
+        let domainError: unknown;
+        if (skill.userInvocable === false) {
           domainError = new WorkspaceSkillNotToggleableError(
             skill.name,
             'not_user_invocable',
@@ -990,7 +992,7 @@ export function createDaemonWorkspaceService(
           if (!error) throw domainError;
           targets.push({ requestedName, error });
         } else {
-          targets.push({ requestedName, skillName: skill!.name });
+          targets.push({ requestedName, skillName: skill.name });
         }
       }
 


### PR DESCRIPTION
## What this PR does

The workspace batch Skill toggle now accepts valid Skill names that are not currently installed, allowing callers to declare disabled state before installation. Enabling an uninstalled Skill follows the existing disabled-list semantics: it removes a matching workspace disable declaration, or returns an unchanged no-op when no declaration exists; it does not create a `skills.enabled` entry solely because the Skill is absent.

Installed Skills keep their existing validation and activation behavior. Hidden, inactive-extension, and higher-scope-locked Skills still return per-target errors without blocking valid targets in the same batch.

## Why it's needed

The batch endpoint previously treated the installed Skill snapshot as an existence gate, so a caller could not predeclare state for a Skill that would be installed later. This made configuration order-dependent and prevented provisioning workflows from writing the desired workspace state ahead of installation.

## Reviewer Test Plan

### How to verify

Start the daemon with an isolated workspace and submit a valid uninstalled Skill name to the batch enable endpoint. With `enabled: true` and no prior declaration, expect HTTP 200, `errors: []`, and `changed: false`, with no settings file write and no `skills.enabled` entry. Submit `enabled: false` and expect the name in workspace `skills.disabled`; submit `enabled: true` again and expect only that disabled declaration to be removed. In a mixed batch, confirm installed valid Skills still refresh once while hidden, inactive-extension, and higher-scope-locked Skills retain their existing per-target errors.

### Evidence (Before & After)

Before: a valid uninstalled target returned `skill_not_found` and was omitted from the persistence batch. After: the built daemon accepts the target, preserves the no-op/remove-disabled/write-disabled semantics above, and leaves authentication and input validation unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v22.17.0; rebuilt `dist/cli.js` daemon on an ephemeral loopback port with isolated workspace and home directories.

## Risk & Scope

- Main risk or tradeoff: Unknown valid names now reach the existing workspace persistence path, so the regression coverage verifies no-op enable, disable creation, disable removal, mixed batches, and higher-scope locks.
- Not validated / out of scope: Windows and Linux runtime smoke tests; the single-Skill toggle endpoint remains unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

workspace 批量 Skill 开关现在接受当前尚未安装的合法 Skill 名称，因此调用方可以在安装前声明禁用状态。对未安装 Skill 执行启用仍遵循现有的 disabled-list 语义：如果 workspace 已有对应的禁用声明则移除；如果没有任何声明则返回未变更的 no-op；不会仅仅因为 Skill 尚未安装就创建 `skills.enabled` 条目。

已安装 Skill 的既有校验与生效行为保持不变。隐藏 Skill、扩展未激活 Skill、以及被更高层级锁定的 Skill 仍返回逐目标错误，并且不会阻塞同一批次中的合法目标。

## 为什么需要

此前批量接口把已安装 Skill 快照当作存在性门槛，因此调用方无法为稍后才会安装的 Skill 预先声明状态。这使配置流程依赖执行顺序，也阻止了部署流程在安装前写入期望的 workspace 状态。

## Reviewer 测试计划

### 如何验证

使用隔离 workspace 启动 daemon，并向批量启用接口提交一个合法但未安装的 Skill 名称。当 `enabled: true` 且此前没有声明时，应返回 HTTP 200、`errors: []` 和 `changed: false`，不写 settings 文件，也不创建 `skills.enabled`。提交 `enabled: false` 后，应在 workspace `skills.disabled` 中看到该名称；随后再次提交 `enabled: true`，应只移除这条禁用声明。在混合批次中，还应确认已安装的合法 Skill 仍只刷新一次，而隐藏 Skill、扩展未激活 Skill、以及被更高层级锁定的 Skill 继续返回既有逐目标错误。

### 证据（修复前后）

修复前：合法但未安装的目标返回 `skill_not_found`，并被排除在持久化批次之外。修复后：重新构建的 daemon 接受该目标，保持上述 no-op 启用、写入禁用、移除禁用语义，同时鉴权与输入校验保持不变。

### 已测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Node.js v22.17.0；使用隔离 workspace 与 home 目录，在临时 loopback 端口运行重新构建的 `dist/cli.js` daemon。

## 风险与范围

- 主要风险或权衡：未知但合法的名称现在会进入现有 workspace 持久化路径，因此回归覆盖了 no-op 启用、写入禁用、移除禁用、混合批次和更高层级锁定。
- 未验证 / 不在范围内：Windows 和 Linux 运行时冒烟测试；单个 Skill 的开关接口保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无

</details>
