### PR TITLE
fix(ci): use repository token for spam minimization

### DIFF
--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -20,9 +20,7 @@ const doc = parse(readFileSync(workflowPath, 'utf8'));
 const minimizeJob = doc.jobs.minimize;
 const steps = minimizeJob.steps;
 const checkoutStep = steps.find((s) => s.uses?.startsWith('actions/checkout'));
-const minimizeStep = steps.find((s) =>
-  s.name?.includes('Minimize comments'),
-);
+const minimizeStep = steps.find((s) => s.name?.includes('Minimize comments'));
 
 describe('auto-minimize-spam: repository guard', () => {
   it('gates the job on the canonical repository', () => {
@@ -58,16 +56,17 @@ describe('auto-minimize-spam: credential scoping', () => {
     assert.equal(checkoutStep.with['persist-credentials'], false);
   });
 
-  it('scopes GH_TOKEN to step-level env, not job-level', () => {
+  it('uses the repository-scoped GitHub token in the minimize step', () => {
     assert.equal(
       minimizeJob.env,
       undefined,
       'job-level env would expose GH_TOKEN to every step',
     );
     assert.ok(minimizeStep, 'minimize step must exist');
-    assert.ok(
+    assert.equal(
       minimizeStep.env?.GH_TOKEN,
-      'GH_TOKEN must be set in the minimize step env',
+      '${{ github.token }}',
+      'the classic bot PAT lacks the scope required by minimizeComment',
     );
   });
 });

--- a/.github/workflows/auto-minimize-spam.yml
+++ b/.github/workflows/auto-minimize-spam.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: 'Minimize comments from blocklisted users'
         env:
-          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          GH_TOKEN: '${{ github.token }}'
           LOOKBACK_HOURS: "${{ inputs.hours || '2' }}"
         run: |-
           set -euo pipefail


### PR DESCRIPTION
## What this PR does

Uses the workflow's repository-scoped `GITHUB_TOKEN` for spam minimization instead of the shared bot PAT. It also tightens the existing regression guard so switching back to the under-scoped PAT fails locally.

## Why it's needed

The scheduled workflow correctly finds comments from blocklisted users, but every `minimizeComment` mutation fails with `INSUFFICIENT_SCOPES`. The shared PAT has only `public_repo`, while the workflow already grants `issues: write` and `pull-requests: write` to its native repository token. Using that token removes the broken credential override without broadening the workflow permissions.

The latest failed run matched seven comments and minimized none: https://github.com/QwenLM/qwen-code/actions/runs/31778078141

## Reviewer Test Plan

### How to verify

Confirm the API step authenticates with the repository-scoped token. The focused regression suite should report five passing tests; replacing the token with the shared PAT should fail the credential assertion.

### Evidence (Before & After)

N/A — workflow-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22.22.0.

## Risk & Scope

- Main risk or tradeoff: The GraphQL write path has not been dispatched from this branch because doing so would modify live repository comments.
- Not validated / out of scope: The existing hourly schedule and coverage limits are unchanged; review bodies and inline review comments remain outside this workflow.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #8767. This PR intentionally isolates only the credential fix needed to restore the current workflow.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把反垃圾折叠任务从共享机器人 PAT 切换到 workflow 自带的仓库级 `GITHUB_TOKEN`。同时收紧已有回归护栏，今后如果再次换回权限不足的 PAT，本地测试会直接失败。

## 为什么需要

定时任务能够正确找到黑名单用户的评论，但每次执行 `minimizeComment` 都因 `INSUFFICIENT_SCOPES` 失败。共享 PAT 只有 `public_repo`，而 workflow 已经为原生仓库 token 声明了 `issues: write` 和 `pull-requests: write`。直接使用原生 token 可以移除错误的凭证覆盖，同时不扩大 workflow 权限。

最近一次失败运行命中 7 条评论，实际折叠 0 条：https://github.com/QwenLM/qwen-code/actions/runs/31778078141

## 复核测试计划

### 如何验证

确认 API 步骤使用仓库级原生 token。聚焦回归测试应为 5 条全部通过；如果将 token 换回共享 PAT，凭证断言应失败。

### 证据（前后对比）

N/A —— 仅修改 workflow。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Node.js 22.22.0。

## 风险与范围

- 主要风险 / 取舍：没有从当前分支触发 GraphQL 写操作，因为这样会修改线上仓库评论。
- 未验证 / 范围之外：现有每小时扫描频率和覆盖范围保持不变；Review 正文和行内 Review 评论仍不在本 workflow 的处理范围内。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8767。本 PR 有意只保留恢复当前 workflow 所需的凭证修复。

</details>