### PR TITLE
feat(autofix): deny-by-default footprint gate and positional window censuses

### DIFF
--- a/.github/scripts/run-autofix-review-verification.sh
+++ b/.github/scripts/run-autofix-review-verification.sh
@@ -84,6 +84,10 @@ git checkout "${BRANCH}"
 GATE_LOG="${WORKDIR}/gate-output.log"
 : > "${GATE_LOG}"
 rm -f "${GATE_LOG}.bite"
+# Single reset point for the gate-authored advisory file: every writer
+# below APPENDS, so no later section can wipe an earlier section's
+# advisory (the footprint advisory used to die to the shrink section's rm).
+rm -f "${WORKDIR}/gate-advisories.md"
 reject_fix() {
   local label="${1}"
   local preexisting="${2:-false}"
@@ -618,21 +622,38 @@ not_merge_freight() {
 # workspaces degrade to their top-level segment (conservative: mismatch
 # surfaces rather than hides).
 list_areas() {
-  local wss f matched w
-  wss="$(tr '\0' '\n' < "${1}" | bash "${RUNNER_TEMP}/resolve-owning-packages.sh" 2> /dev/null || true)"
+  # $1: NUL-separated path file; $2: the REF whose recorded workspaces
+  # globs define membership. Ref-anchored on purpose: the round's on-disk
+  # manifest must not redefine its own footprint boundary (same doctrine
+  # as was_workspace_dir), and a resolver failure must not silently
+  # degrade both sides. Longest ancestor wins (nested workspaces);
+  # non-workspace paths under packages/ keep TWO segments so sibling
+  # projects stay distinct areas; emitted areas are newline-sanitized so a
+  # newline-bearing path cannot mint phantom areas in the line pipeline.
+  local ref="${2}" f d a
   while IFS= read -r -d '' f; do
     [[ -n "${f}" ]] || continue
-    matched=''
-    while IFS= read -r w; do
-      [[ -n "${w}" && "${f}" == "${w}"/* ]] && { matched="${w}"; break; }
-    done <<< "${wss}"
-    if [[ -n "${matched}" ]]; then
-      echo "${matched}"
-    elif [[ "${f}" == */* ]]; then
-      echo "${f%%/*}"
-    else
-      echo "/${f}"
+    a=''
+    d="${f%/*}"
+    while [[ "${d}" == */* || ( -n "${d}" && "${d}" != "${f}" ) ]]; do
+      if was_workspace_dir "${ref}" "${d}"; then
+        a="${d}"
+        break
+      fi
+      [[ "${d}" == */* ]] || break
+      d="${d%/*}"
+    done
+    if [[ -z "${a}" ]]; then
+      if [[ "${f}" == packages/*/* ]]; then
+        a="${f#packages/}"
+        a="packages/${a%%/*}"
+      elif [[ "${f}" == */* ]]; then
+        a="${f%%/*}"
+      else
+        a="/${f}"
+      fi
     fi
+    printf '%s\n' "${a//[^A-Za-z0-9._\/ -]/?}"
   done < "${1}" | sort -u
 }
 FOOTPRINT_ENFORCE="${FOOTPRINT_ENFORCE:-advisory}"
@@ -641,7 +662,7 @@ ROUND_FILES_Z="$(mktemp)"
 PR_FILES_Z="$(mktemp)"
 git diff --name-only -z --no-renames "${ROUND_RANGE}" 2> /dev/null | not_merge_freight > "${ROUND_FILES_Z}" || true
 git diff --name-only -z --no-renames "${PR_RANGE}" 2> /dev/null > "${PR_FILES_Z}" || true
-OUT_AREAS="$(comm -23 <(list_areas "${ROUND_FILES_Z}") <(list_areas "${PR_FILES_Z}"))" || OUT_AREAS=''
+OUT_AREAS="$(comm -23 <(list_areas "${ROUND_FILES_Z}" "origin/${BRANCH}") <(list_areas "${PR_FILES_Z}" "origin/${BRANCH}"))" || OUT_AREAS=''
 rm -f "${ROUND_FILES_Z}" "${PR_FILES_Z}"
 if [[ -n "${OUT_AREAS}" ]]; then
   if [[ "${FOOTPRINT_ENFORCE}" == 'reject' ]]; then
@@ -683,7 +704,6 @@ NET_TEST_LINES="$(git diff --numstat -z --no-renames "${ROUND_RANGE}" -- "${TEST
       [[ "${del}" != '-' ]] && total=$(( total - del ))
     done
     echo "${total}"; })"
-rm -f "${WORKDIR}/gate-advisories.md"
 if [[ -n "${DELETED_TESTS}" || "${NET_TEST_LINES}" -le -25 ]]; then
   {
     echo '⚖️ **Gate advisory — test coverage shrank this round** (machine-measured, not agent-authored): '"net ${NET_TEST_LINES} test lines."
@@ -701,7 +721,7 @@ if [[ -n "${DELETED_TESTS}" || "${NET_TEST_LINES}" -le -25 ]]; then
     fi
     echo
     echo 'The justification must be in the round summary above; a deletion is only sound when the pinned behavior itself was wrong (evidence shown) or the coverage demonstrably survives elsewhere. · 本轮测试覆盖净减少（门自动测量，非 agent 文本）；删除是否成立请对照上方轮次摘要中的理由——仅当被钉住的行为本身有误（需给出证据）或覆盖确有替代时才合理。'
-  } > "${WORKDIR}/gate-advisories.md"
+  } >> "${WORKDIR}/gate-advisories.md"
   echo '⚖️ test coverage shrank this round — advisory written for the report' | tee -a "${GATE_LOG}"
 fi
 
@@ -863,15 +883,18 @@ if [[ -s "${WORKDIR}/resolved-comments.txt" && -s "${WORKDIR}/rc.json" ]]; then
       | ($ids | split("\n")
           | map(sub("^rc:"; "") | sub("\r$"; "")
             | select(test("^[0-9]+$")) | tonumber)) as $resolved
-      | def critical($c):
+      | def cr_attached($x):
+          (($x.pull_request_review_id // null) as $review
+            | $review != null
+            and any($reviews[]; .id == $review and ((.state // "") == "CHANGES_REQUESTED")));
+        def critical($c):
           (($c.body // "") | contains("**[Critical]**"))
           or (($c.in_reply_to_id // null) as $root
             | $root != null
             and any($comments[];
-              .id == $root and ((.body // "") | contains("**[Critical]**"))))
-          or (($c.pull_request_review_id // null) as $review
-            | $review != null
-            and any($reviews[]; .id == $review and ((.state // "") == "CHANGES_REQUESTED")));
+              .id == $root
+              and (((.body // "") | contains("**[Critical]**")) or cr_attached(.))))
+          or cr_attached($c);
       [ $comments[]
         | select(.id as $id | $resolved | index($id) != null)
         | select(critical(.)) | (.path // "") ]

--- a/.github/scripts/run-autofix-review-verification.sh
+++ b/.github/scripts/run-autofix-review-verification.sh
@@ -606,6 +606,61 @@ not_merge_freight() {
     git diff --quiet origin/main "${BRANCH}" -- "${f}" 2> /dev/null || printf '%s\0' "${f}"
   done
 }
+# --- Deny-by-default footprint areas ----------------------------------------
+# The class gate above protects an ENUMERATED surface, and enumeration is
+# never complete (a denylist is not a boundary). This check inverts the
+# default: every file a round touches is mapped to an AREA — its declared
+# workspace, else its top-level directory, else the root file itself — and
+# any area outside the PR's own footprint is surfaced. Consequence is
+# staged via QWEN_AUTOFIX_FOOTPRINT_ENFORCE: 'advisory' (default) writes a
+# gate-authored report section; 'reject' turns expansions into a retryable
+# rejection. Merge freight is excluded from the round side; deleted
+# workspaces degrade to their top-level segment (conservative: mismatch
+# surfaces rather than hides).
+list_areas() {
+  local wss f matched w
+  wss="$(tr '\0' '\n' < "${1}" | bash "${RUNNER_TEMP}/resolve-owning-packages.sh" 2> /dev/null || true)"
+  while IFS= read -r -d '' f; do
+    [[ -n "${f}" ]] || continue
+    matched=''
+    while IFS= read -r w; do
+      [[ -n "${w}" && "${f}" == "${w}"/* ]] && { matched="${w}"; break; }
+    done <<< "${wss}"
+    if [[ -n "${matched}" ]]; then
+      echo "${matched}"
+    elif [[ "${f}" == */* ]]; then
+      echo "${f%%/*}"
+    else
+      echo "/${f}"
+    fi
+  done < "${1}" | sort -u
+}
+FOOTPRINT_ENFORCE="${FOOTPRINT_ENFORCE:-advisory}"
+[[ "${FOOTPRINT_ENFORCE}" == 'reject' ]] || FOOTPRINT_ENFORCE='advisory'
+ROUND_FILES_Z="$(mktemp)"
+PR_FILES_Z="$(mktemp)"
+git diff --name-only -z --no-renames "${ROUND_RANGE}" 2> /dev/null | not_merge_freight > "${ROUND_FILES_Z}" || true
+git diff --name-only -z --no-renames "${PR_RANGE}" 2> /dev/null > "${PR_FILES_Z}" || true
+OUT_AREAS="$(comm -23 <(list_areas "${ROUND_FILES_Z}") <(list_areas "${PR_FILES_Z}"))" || OUT_AREAS=''
+rm -f "${ROUND_FILES_Z}" "${PR_FILES_Z}"
+if [[ -n "${OUT_AREAS}" ]]; then
+  if [[ "${FOOTPRINT_ENFORCE}" == 'reject' ]]; then
+    {
+      echo 'This round modified areas entirely outside the PR footprint:'
+      printf '%s\n' "${OUT_AREAS//[^A-Za-z0-9._\/ -]/?}"
+      echo 'Footprint enforcement is set to reject: revert these files, or escalate the feedback that requires them to a maintainer as an open question.'
+    } >> "${GATE_LOG}"
+    reject_fix 'round expands into areas outside the PR footprint'
+  else
+    {
+      echo '🧭 **Gate advisory — this round modified areas outside the PR footprint** (machine-measured, not agent-authored):'
+      printf -- '- %s\n' "${OUT_AREAS//[^A-Za-z0-9._\/ -]/?}"
+      echo 'Review the expansion deliberately; the footprint gate is in advisory mode. · 本轮改动了 PR 足迹之外的区域（门自动测量，非 agent 文本），当前足迹门为 advisory 模式，请有意识地审阅该扩张。'
+    } >> "${WORKDIR}/gate-advisories.md"
+    echo "🧭 footprint expansion (advisory): $(tr '\n' ' ' <<< "${OUT_AREAS}")" | tee -a "${GATE_LOG}"
+  fi
+fi
+
 # Test-deletion advisory: deleting or shrinking tests is sometimes right
 # (the pinned behavior was wrong, or coverage is duplicated) and the agent
 # is required to justify it in its summary — but the SURFACING must not be
@@ -781,15 +836,18 @@ if [[ -s "${WORKDIR}/resolved-comments.txt" && -s "${WORKDIR}/rc.json" ]]; then
     | ($ids | split("\n")
         | map(sub("^rc:"; "") | sub("\r$"; "")
           | select(test("^[0-9]+$")) | tonumber)) as $resolved
-    | def critical($c):
+    | def cr_attached($x):
+        (($x.pull_request_review_id // null) as $review
+          | $review != null
+          and any($reviews[]; .id == $review and ((.state // "") == "CHANGES_REQUESTED")));
+      def critical($c):
         (($c.body // "") | contains("**[Critical]**"))
         or (($c.in_reply_to_id // null) as $root
           | $root != null
           and any($comments[];
-            .id == $root and ((.body // "") | contains("**[Critical]**"))))
-        or (($c.pull_request_review_id // null) as $review
-          | $review != null
-          and any($reviews[]; .id == $review and ((.state // "") == "CHANGES_REQUESTED")));
+            .id == $root
+            and (((.body // "") | contains("**[Critical]**")) or cr_attached(.))))
+        or cr_attached($c);
     any($comments[]; (.id as $id | $resolved | index($id) != null) and critical(.))' \
     "${WORKDIR}/rc.json" 2> /dev/null)" || BITE_ENFORCE='false'
   [[ "${BITE_ENFORCE}" == 'true' ]] || BITE_ENFORCE='false'

--- a/.github/scripts/run-autofix-review-verification.sh
+++ b/.github/scripts/run-autofix-review-verification.sh
@@ -624,22 +624,32 @@ not_merge_freight() {
 list_areas() {
   # $1: NUL-separated path file; $2: the REF whose recorded workspaces
   # globs define membership. Ref-anchored on purpose: the round's on-disk
-  # manifest must not redefine its own footprint boundary (same doctrine
-  # as was_workspace_dir), and a resolver failure must not silently
-  # degrade both sides. Longest ancestor wins (nested workspaces);
-  # non-workspace paths under packages/ keep TWO segments so sibling
-  # projects stay distinct areas; emitted areas are newline-sanitized so a
-  # newline-bearing path cannot mint phantom areas in the line pipeline.
-  local ref="${2}" f d a
+  # manifest must not redefine its own footprint boundary. The ref's globs
+  # are read and translated ONCE per invocation (the per-file ancestor
+  # walk then matches in-bash — was_workspace_dir per (file×dir) re-ran
+  # git+jq+sed each time, ~21 ms a call). Longest ancestor wins (nested
+  # workspaces); non-workspace paths under packages/ keep TWO segments so
+  # sibling projects stay distinct areas. Emitted keys are printf %q —
+  # line-safe AND injective, so two distinct areas can never collapse
+  # into one comparison key (a lossy charset map hid expansions).
+  local ref="${2}" f d a g re
+  local -a ws_res=()
+  while IFS= read -r g; do
+    [[ -n "${g}" && "${g}" != '!'* ]] || continue
+    re="$(printf '%s' "${g}" | sed -e 's/[.^$+(){}|[]/\\&/g' -e 's/]/\\]/g' -e 's/\*\*/\x01/g' -e 's/\*/[^\/]*/g' -e 's/?/[^\/]/g' -e 's/\x01/.*/g')"
+    ws_res+=("${re}")
+  done < <(git show "${ref}:package.json" 2> /dev/null | jq -r '.workspaces[]?' 2> /dev/null)
   while IFS= read -r -d '' f; do
     [[ -n "${f}" ]] || continue
     a=''
     d="${f%/*}"
-    while [[ "${d}" == */* || ( -n "${d}" && "${d}" != "${f}" ) ]]; do
-      if was_workspace_dir "${ref}" "${d}"; then
-        a="${d}"
-        break
-      fi
+    while [[ -n "${d}" && "${d}" != "${f}" ]]; do
+      for re in "${ws_res[@]}"; do
+        if [[ "${d}" =~ ^${re}$ ]]; then
+          a="${d}"
+          break 2
+        fi
+      done
       [[ "${d}" == */* ]] || break
       d="${d%/*}"
     done
@@ -653,29 +663,37 @@ list_areas() {
         a="/${f}"
       fi
     fi
-    printf '%s\n' "${a//[^A-Za-z0-9._\/ -]/?}"
+    printf '%q\n' "${a}"
   done < "${1}" | sort -u
 }
 FOOTPRINT_ENFORCE="${FOOTPRINT_ENFORCE:-advisory}"
 [[ "${FOOTPRINT_ENFORCE}" == 'reject' ]] || FOOTPRINT_ENFORCE='advisory'
 ROUND_FILES_Z="$(mktemp)"
 PR_FILES_Z="$(mktemp)"
-git diff --name-only -z --no-renames "${ROUND_RANGE}" 2> /dev/null | not_merge_freight > "${ROUND_FILES_Z}" || true
-git diff --name-only -z --no-renames "${PR_RANGE}" 2> /dev/null > "${PR_FILES_Z}" || true
+# Unmeasurable is a STATE here too: a failed producer (no merge base on an
+# orphan-history takeover, a transient git error) must skip the check
+# loudly, not shrink one side into a verdict — an empty PR side would
+# read as "every round area is an expansion".
+FOOTPRINT_MEASURED='true'
+git diff --name-only -z --no-renames "${ROUND_RANGE}" 2> /dev/null | not_merge_freight > "${ROUND_FILES_Z}" || FOOTPRINT_MEASURED='false'
+git diff --name-only -z --no-renames "${PR_RANGE}" 2> /dev/null > "${PR_FILES_Z}" || FOOTPRINT_MEASURED='false'
+if [[ "${FOOTPRINT_MEASURED}" != 'true' ]]; then
+  echo "🧭 footprint measurement UNAVAILABLE this round (diff producer failed) — check skipped" | tee -a "${GATE_LOG}"
+fi
 OUT_AREAS="$(comm -23 <(list_areas "${ROUND_FILES_Z}" "origin/${BRANCH}") <(list_areas "${PR_FILES_Z}" "origin/${BRANCH}"))" || OUT_AREAS=''
 rm -f "${ROUND_FILES_Z}" "${PR_FILES_Z}"
-if [[ -n "${OUT_AREAS}" ]]; then
+if [[ "${FOOTPRINT_MEASURED}" == 'true' && -n "${OUT_AREAS}" ]]; then
   if [[ "${FOOTPRINT_ENFORCE}" == 'reject' ]]; then
     {
       echo 'This round modified areas entirely outside the PR footprint:'
-      printf '%s\n' "${OUT_AREAS//[^A-Za-z0-9._\/ -]/?}"
+      while IFS= read -r a; do [[ -n "${a}" ]] && echo "- ${a}"; done <<< "${OUT_AREAS}"
       echo 'Footprint enforcement is set to reject: revert these files, or escalate the feedback that requires them to a maintainer as an open question.'
     } >> "${GATE_LOG}"
     reject_fix 'round expands into areas outside the PR footprint'
   else
     {
       echo '🧭 **Gate advisory — this round modified areas outside the PR footprint** (machine-measured, not agent-authored):'
-      printf -- '- %s\n' "${OUT_AREAS//[^A-Za-z0-9._\/ -]/?}"
+      while IFS= read -r a; do [[ -n "${a}" ]] && echo "- ${a}"; done <<< "${OUT_AREAS}"
       echo 'Review the expansion deliberately; the footprint gate is in advisory mode. · 本轮改动了 PR 足迹之外的区域（门自动测量，非 agent 文本），当前足迹门为 advisory 模式，请有意识地审阅该扩张。'
     } >> "${WORKDIR}/gate-advisories.md"
     echo "🧭 footprint expansion (advisory): $(tr '\n' ' ' <<< "${OUT_AREAS}")" | tee -a "${GATE_LOG}"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -163,6 +163,14 @@ env:
   # tripping engages the brake.
   # TUNABLE WITHOUT A CODE CHANGE like the scan budgets above; a malformed
   # value falls back to its default at the read site.
+  # Staged-rollout switch for the verification gate's deny-by-default
+  # footprint check: a round touching AREAS (declared workspace, else
+  # top-level dir, else root file) outside the PR's own footprint is
+  # surfaced as a gate advisory by default; setting the repo variable to
+  # 'reject' turns expansions into a retryable rejection once advisory
+  # observation shows an acceptable false-positive rate. The class gate's
+  # enumerated protections reject regardless of this switch.
+  FOOTPRINT_ENFORCE: "${{ vars.QWEN_AUTOFIX_FOOTPRINT_ENFORCE || 'advisory' }}"
   GROWTH_BUDGET_SRC_LINES: '${{ vars.QWEN_AUTOFIX_GROWTH_BUDGET_SRC_LINES || 400 }}'
   GROWTH_BUDGET_TEST_LINES: '${{ vars.QWEN_AUTOFIX_GROWTH_BUDGET_TEST_LINES || 400 }}'
   # Non-convergence handoff: once the growth brake has been over budget for
@@ -4993,8 +5001,8 @@ jobs:
             PRIOR_TIMEOUTS="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" '
               [ .[] | select((.user.login // "") == $ab)
                 | select((.body // "") | contains("<!-- autofix-eval "))
-                | select(((.body // "") | contains("win=" + $key + " -->"))
-                    or ($key == "none" and (((.body // "") | contains("win=")) | not)))
+                | select(([ ((.body // "") | scan("<!-- autofix-eval ts=[^ ]+ acted=[^ ]+ round=[0-9]+(?: win=([^ ]+))? -->")) ] | map(.[0] // "none")) as $wins
+                    | ($wins | length) > 0 and any($wins[]; . == $key))
               ] | sort_by(.created_at)
               | map((.body | gsub("\r"; "") | split("\n")[0]))
               | (map(test("Addressed the latest review feedback|no changes needed")) | rindex(true) // -1) as $lastok
@@ -5950,8 +5958,8 @@ jobs:
                 [.[] | select((.user.login // "") == $ab)
                      | select((.body // "") | contains("<!-- autofix-eval "))
                      | select(
-                         ((.body // "") | contains("win=" + $win + " -->"))
-                         or ($win == "none" and (((.body // "") | contains("win=")) | not)))]
+                         ([ ((.body // "") | scan("<!-- autofix-eval ts=[^ ]+ acted=[^ ]+ round=[0-9]+(?: win=([^ ]+))? -->")) ] | map(.[0] // "none")) as $wins
+                         | ($wins | length) > 0 and any($wins[]; . == $win))]
                 | sort_by(.created_at) | .[]
                 | (.body | gsub("\r"; "") | split("\n")[0])' "${WORKDIR}/ic.json" 2> /dev/null || true)"
               if [[ -z "${WIN_HEADS}" ]]; then
@@ -6423,8 +6431,8 @@ jobs:
                 [.[] | select((.user.login // "") == $ab)
                      | select((.body // "") | contains("<!-- autofix-eval "))
                      | select(
-                         ((.body // "") | contains("win=" + $win + " -->"))
-                         or ($win == "none" and (((.body // "") | contains("win=")) | not)))]
+                         ([ ((.body // "") | scan("<!-- autofix-eval ts=[^ ]+ acted=[^ ]+ round=[0-9]+(?: win=([^ ]+))? -->")) ] | map(.[0] // "none")) as $wins
+                         | ($wins | length) > 0 and any($wins[]; . == $win))]
                 | sort_by(.created_at) | .[]
                 | (.body | gsub("\r"; "") | split("\n")[0])' <<< "${COMMENTS_JSON}" 2> /dev/null || true)"
               while IFS= read -r H; do

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -163,14 +163,6 @@ env:
   # tripping engages the brake.
   # TUNABLE WITHOUT A CODE CHANGE like the scan budgets above; a malformed
   # value falls back to its default at the read site.
-  # Staged-rollout switch for the verification gate's deny-by-default
-  # footprint check: a round touching AREAS (declared workspace, else
-  # top-level dir, else root file) outside the PR's own footprint is
-  # surfaced as a gate advisory by default; setting the repo variable to
-  # 'reject' turns expansions into a retryable rejection once advisory
-  # observation shows an acceptable false-positive rate. The class gate's
-  # enumerated protections reject regardless of this switch.
-  FOOTPRINT_ENFORCE: "${{ vars.QWEN_AUTOFIX_FOOTPRINT_ENFORCE || 'advisory' }}"
   GROWTH_BUDGET_SRC_LINES: '${{ vars.QWEN_AUTOFIX_GROWTH_BUDGET_SRC_LINES || 400 }}'
   GROWTH_BUDGET_TEST_LINES: '${{ vars.QWEN_AUTOFIX_GROWTH_BUDGET_TEST_LINES || 400 }}'
   # Non-convergence handoff: once the growth brake has been over budget for

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -4537,14 +4537,13 @@ jobs:
           NET_SRC=$(( NET_TOTAL - NET_TEST ))
           [[ "${NET_MEASURED}" != 'true' ]] &&
             echo "📏 growth measurement UNAVAILABLE this round (no merge base or shadowed base) — brake skipped, no anchor written"
-          # The marker's window field is spelled `key=`, NOT `win=`, on
-          # purpose: three censuses (PRIOR_TIMEOUTS, the milestone WIN_HEADS,
-          # the breaker PRIOR_HEADS) attribute comments to windows by the
-          # WHOLE-BODY substring `win=<key> -->`, and this marker can
-          # legitimately carry a different window key than its comment's
-          # autofix-eval marker (a supersede-exempt conflict round reporting
-          # after a re-arm). Any token embedding "win=" would double-attribute
-          # that comment to both windows.
+          # The marker's window field is spelled `key=`, NOT `win=`: this
+          # marker can legitimately carry a different window key than its
+          # comment's autofix-eval marker (a supersede-exempt conflict round
+          # reporting after a re-arm). The window censuses attribute
+          # positionally (last-wins) over their own scan-parsed eval
+          # markers, and the distinct token stays as defense in depth for
+          # any future substring consumer.
           # A stale-base auto-update merges current main into the branch,
           # moving the merge base the nets are measured against: overlap
           # resolutions then shift the measurement with no agent push. An
@@ -5002,7 +5001,7 @@ jobs:
               [ .[] | select((.user.login // "") == $ab)
                 | select((.body // "") | contains("<!-- autofix-eval "))
                 | select(([ ((.body // "") | scan("<!-- autofix-eval ts=[^ ]+ acted=[^ ]+ round=[0-9]+(?: win=([^ ]+))? -->")) ] | map(.[0] // "none")) as $wins
-                    | ($wins | length) > 0 and any($wins[]; . == $key))
+                    | ($wins | length) > 0 and (($wins | last) == $key))
               ] | sort_by(.created_at)
               | map((.body | gsub("\r"; "") | split("\n")[0]))
               | (map(test("Addressed the latest review feedback|no changes needed")) | rindex(true) // -1) as $lastok
@@ -5237,6 +5236,10 @@ jobs:
         env:
           TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
           VERIFY_RUNNER_SHA256: '${{ steps.stage.outputs.verify_runner_sha256 }}'
+          # Step-level env outranks $GITHUB_ENV: an earlier shell-capable
+          # step (the agent runs branch code on the host) must not be able
+          # to downgrade a repo-variable 'reject' back to 'advisory'.
+          FOOTPRINT_ENFORCE: "${{ vars.QWEN_AUTOFIX_FOOTPRINT_ENFORCE || 'advisory' }}"
         run: |-
           # The gate decides whether the PAT push runs, and the first pass
           # executes the branch's own build/test on the host before the
@@ -5356,6 +5359,10 @@ jobs:
         env:
           TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
           VERIFY_RUNNER_SHA256: '${{ steps.stage.outputs.verify_runner_sha256 }}'
+          # Step-level env outranks $GITHUB_ENV: an earlier shell-capable
+          # step (the agent runs branch code on the host) must not be able
+          # to downgrade a repo-variable 'reject' back to 'advisory'.
+          FOOTPRINT_ENFORCE: "${{ vars.QWEN_AUTOFIX_FOOTPRINT_ENFORCE || 'advisory' }}"
         run: |-
           # The gate decides whether the PAT push runs, and the first pass
           # executes the branch's own build/test on the host before the
@@ -5959,7 +5966,7 @@ jobs:
                      | select((.body // "") | contains("<!-- autofix-eval "))
                      | select(
                          ([ ((.body // "") | scan("<!-- autofix-eval ts=[^ ]+ acted=[^ ]+ round=[0-9]+(?: win=([^ ]+))? -->")) ] | map(.[0] // "none")) as $wins
-                         | ($wins | length) > 0 and any($wins[]; . == $win))]
+                         | ($wins | length) > 0 and (($wins | last) == $win))]
                 | sort_by(.created_at) | .[]
                 | (.body | gsub("\r"; "") | split("\n")[0])' "${WORKDIR}/ic.json" 2> /dev/null || true)"
               if [[ -z "${WIN_HEADS}" ]]; then
@@ -6432,7 +6439,7 @@ jobs:
                      | select((.body // "") | contains("<!-- autofix-eval "))
                      | select(
                          ([ ((.body // "") | scan("<!-- autofix-eval ts=[^ ]+ acted=[^ ]+ round=[0-9]+(?: win=([^ ]+))? -->")) ] | map(.[0] // "none")) as $wins
-                         | ($wins | length) > 0 and any($wins[]; . == $win))]
+                         | ($wins | length) > 0 and (($wins | last) == $win))]
                 | sort_by(.created_at) | .[]
                 | (.body | gsub("\r"; "") | split("\n")[0])' <<< "${COMMENTS_JSON}" 2> /dev/null || true)"
               while IFS= read -r H; do

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -389,6 +389,12 @@ gate`, fix that exact rejection before other feedback; repeating the rejected
   rejected commit and add one verified follow-up commit that fixes the supplied
   deterministic rejection.
 
+Bound each round's implemented batch: implement at most ~8 findings per
+round — Critical/Required first — and explicitly defer the remainder to the
+next round through `comment-replies.json`. Large fix batches trade depth for
+speed and breed fix-of-fix defects; a deferred optional finding costs one
+round of latency, a defective fix costs a rejection plus a repair.
+
 Two boundaries hold regardless of what any feedback asks for:
 
 - Never modify CI or verification machinery the PR itself was not already
@@ -410,6 +416,13 @@ Two boundaries hold regardless of what any feedback asks for:
   survives in a named surviving test. State that evidence in the summary —
   the gate appends its own machine-measured advisory listing every deleted
   test to the round report, and a maintainer will read the two side by side.
+
+The gate also measures a deny-by-default FOOTPRINT: any area (declared
+workspace, top-level directory, or root file) a round touches that the PR
+itself never touched is surfaced in a gate advisory — and rejected outright
+when the repository has footprint enforcement set to reject. Staying inside
+the PR's own footprint is the default-correct shape; expansion needs the
+feedback to genuinely require it, and doubt goes to a maintainer question.
 
 If `--conflict true`, merge `origin/<base>` and resolve conflicts by
 understanding both sides, never blindly taking one side. If false, do not merge

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5358,6 +5358,23 @@ exit 1
       }
     };
     const K = '2026-07-29T03:00:00Z';
+    // Attribution is POSITIONAL over the comment's own scan-parsed eval
+    // markers: a neutralized marker QUOTED in a handoff excerpt carries the
+    // raw substring `win=<key> -->` but must not attribute the comment to
+    // the window (whole-body contains() did).
+    expect(
+      runCensus(
+        [
+          mk(TIMEOUT_HEADLINE, K, '2026-07-29T04:00:00Z'),
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-07-29T05:00:00Z',
+            body: `${PUSH_HEADLINE}\nquoted: <!\\-\\- autofix-eval ts=x acted=true round=9 win=${K} -->`,
+          },
+        ],
+        K,
+      ),
+    ).toBe('1');
     // A push RESETS the narrowing (the breaker stays cumulative — this
     // census feeds only the prompt): timeout, push, timeout → 1.
     expect(
@@ -9757,6 +9774,14 @@ exit 1
     git('add', '-A');
     git('commit', '-qm', 'pr', '--allow-empty');
     git('update-ref', 'refs/remotes/origin/feat', 'feat');
+    if (build.afterPr) {
+      git('checkout', '-q', 'main');
+      build.afterPr({ git, write, dir });
+      git('add', '-A');
+      git('commit', '-qm', 'main-advances', '--allow-empty');
+      git('update-ref', 'refs/remotes/origin/main', 'main');
+      git('checkout', '-q', 'feat');
+    }
     build.round({ git, write, dir });
     git('add', '-A');
     git('commit', '-qm', 'round', '--allow-empty');
@@ -9911,6 +9936,24 @@ exit 1
           write('x.yml', 'on: push\n');
           git('add', '-A');
         },
+      }),
+    ).toContain('REJECT:round expands into CI/verification machinery');
+    // Footprint content compares anchor at the MERGE BASE: main drifting a
+    // manifest's scripts after the branch point must not mint a grant.
+    expect(
+      run({
+        base: ({ write }) => {
+          write('package.json', '{"scripts":{"lint":"eslint ."},"x":1}\n');
+          write('src/a.ts', 'a\n');
+        },
+        pr: ({ write }) => {
+          write('package.json', '{"scripts":{"lint":"eslint ."},"x":2}\n');
+          write('src/a.ts', 'b\n');
+        },
+        afterPr: ({ write }) =>
+          write('package.json', '{"scripts":{"lint":"biome ."},"x":1}\n'),
+        round: ({ write }) =>
+          write('package.json', '{"scripts":{"lint":"true"},"x":2}\n'),
       }),
     ).toContain('REJECT:round expands into CI/verification machinery');
     // The gate's transitive executable surface: repo scripts are a class,
@@ -10143,6 +10186,104 @@ exit 1
     expect(forged).not.toContain('`](x)');
   });
 
+  it('surfaces deny-by-default footprint expansions, rejecting only when enforcement says so', () => {
+    const block = reviewVerificationRunner.match(
+      /(list_areas\(\) \{[\s\S]*?footprint expansion \(advisory\)[^\n]*\n {2}fi\nfi)/,
+    )?.[1];
+    expect(block).toBeTruthy();
+    const run = (build, { enforce = 'advisory' } = {}) => {
+      const { dir } = validityFixture(build);
+      const tools = mkdtempSync(join(tmpdir(), 'autofix-area-'));
+      writeFileSync(
+        join(tools, 'resolve-owning-packages.sh'),
+        'while read f; do case "$f" in packages/*/*) d="${f#packages/}"; echo "packages/${d%%/*}";; esac; done | sort -u\n',
+      );
+      const res = spawnSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -eo pipefail',
+            'cd "$1"',
+            'BRANCH=feat',
+            'WORKDIR="$2"',
+            'RUNNER_TEMP="$2"',
+            'GATE_LOG="$2/gate.log"',
+            ': > "$GATE_LOG"',
+            'ROUND_RANGE="origin/feat...feat"',
+            'PR_RANGE="origin/main...origin/feat"',
+            `FOOTPRINT_ENFORCE='${enforce}'`,
+            freightHelper(),
+            'reject_fix() { echo "REJECT:${1}"; exit 1; }',
+            block,
+            'echo SURVIVED',
+          ].join('\n'),
+          'bash',
+          dir,
+          tools,
+        ],
+        { encoding: 'utf8', env: isolatedGitEnv },
+      );
+      expect(res.error).toBeUndefined();
+      const advisoryPath = join(tools, 'gate-advisories.md');
+      const advisory = existsSync(advisoryPath)
+        ? readFileSync(advisoryPath, 'utf8')
+        : '';
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(tools, { recursive: true, force: true });
+      return { out: `${res.stdout}\n${res.stderr}`, advisory };
+    };
+    const crossWorkspace = {
+      base: ({ write }) => {
+        write('packages/cli/src/a.ts', 'a\n');
+        write('packages/core/src/b.ts', 'b\n');
+      },
+      pr: ({ write }) => write('packages/cli/src/a.ts', 'a2\n'),
+      round: ({ write }) => write('packages/core/src/b.ts', 'b2\n'),
+    };
+    // Default: an out-of-footprint area is SURFACED, never rejected.
+    const advisory = run(crossWorkspace);
+    expect(advisory.out).toContain('SURVIVED');
+    expect(advisory.out).not.toContain('REJECT:');
+    expect(advisory.advisory).toContain('outside the PR footprint');
+    expect(advisory.advisory).toContain('packages/core');
+    // The repo variable stages the consequence up to rejection.
+    const rejected = run(crossWorkspace, { enforce: 'reject' });
+    expect(rejected.out).toContain(
+      'REJECT:round expands into areas outside the PR footprint',
+    );
+    // Inside the footprint (same workspace, or same top-level dir for
+    // unowned paths) nothing fires.
+    expect(
+      run({
+        base: ({ write }) => {
+          write('packages/cli/src/a.ts', 'a\n');
+          write('docs/x.md', 'x\n');
+        },
+        pr: ({ write }) => {
+          write('packages/cli/src/a.ts', 'a2\n');
+          write('docs/y.md', 'y\n');
+        },
+        round: ({ write }) => {
+          write('packages/cli/src/z.ts', 'z\n');
+          write('docs/z.md', 'z\n');
+        },
+      }).advisory,
+    ).toBe('');
+    // Root files are each their own area.
+    expect(
+      run({
+        base: ({ write }) => write('src/a.ts', 'a\n'),
+        pr: ({ write }) => write('src/a.ts', 'b\n'),
+        round: ({ write }) => write('README.md', 'r\n'),
+      }).advisory,
+    ).toContain('/README.md');
+    // A garbage enforcement value degrades to advisory, never reject.
+    const fuzz = run(crossWorkspace, { enforce: 'terminate' });
+    expect(fuzz.out).toContain('SURVIVED');
+    expect(fuzz.advisory).toContain('outside the PR footprint');
+  });
+
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {
     const block = reviewVerificationRunner.match(
       /(# Bite check:[\s\S]*?)\nassert_verification_tree\necho "verified_head/,
@@ -10150,7 +10291,7 @@ exit 1
     expect(block).toBeTruthy();
     const run = (
       build,
-      { runnerExit, runnerScript, resolverLines, workdir },
+      { runnerExit, runnerScript, resolverLines, workdir, prelude = '' },
     ) => {
       const { dir, git } = validityFixture(build);
       const tools = mkdtempSync(join(tmpdir(), 'autofix-validity-tools-'));
@@ -10186,6 +10327,7 @@ exit 1
             ': > "$GATE_LOG"',
             'ROUND_RANGE="origin/feat...feat"',
             freightHelper(),
+            prelude,
             'BITE_RUNNER="$2/bite-runner"',
             'reject_fix() { echo "REJECT:${1}"; exit 1; }',
             block,
@@ -10204,6 +10346,10 @@ exit 1
       const advisory = existsSync(advisoryPath)
         ? readFileSync(advisoryPath, 'utf8')
         : '';
+      const rejectionPath = join(tools, 'gate-rejection.md');
+      const rejection = existsSync(rejectionPath)
+        ? readFileSync(rejectionPath, 'utf8')
+        : '';
       rmSync(dir, { recursive: true, force: true });
       rmSync(tools, { recursive: true, force: true });
       return {
@@ -10211,6 +10357,7 @@ exit 1
         status,
         head,
         advisory,
+        rejection,
       };
     };
     const srcAndTest = {
@@ -10475,6 +10622,62 @@ exit 1
     expect(coverageOnly.out).toContain('SURVIVED');
     expect(coverageOnly.out).not.toContain('REJECT:');
     expect(coverageOnly.advisory).toContain('test-only changes');
+
+    // Restore-failure crash contract: when the tree cannot come back to
+    // the branch, the gate crashes VERDICT-LESS — rejection document
+    // written, exit 1, and reject_fix (which would advance the watermark)
+    // never runs.
+    const crash = run(srcAndTest, {
+      runnerScript: [
+        '#!/usr/bin/env bash',
+        'git update-ref -d refs/heads/feat',
+        'exit 0',
+      ].join('\n'),
+      resolverLines: ['packages/cli'],
+      workdir: criticalClaim,
+    });
+    expect(crash.out).toContain(
+      'could not restore the verification tree after the bite check',
+    );
+    expect(crash.out).toContain('[spawn status=1]');
+    expect(crash.out).not.toContain('REJECT:');
+    expect(crash.rejection).toContain('could not restore');
+
+    // Append order: a shrink advisory (truncating write) followed by the
+    // bite advisory (append) must leave BOTH in the report file.
+    const advisoryBlock2 = reviewVerificationRunner.match(
+      /(TEST_PATHSPEC=\(':\(glob\)[\s\S]*?advisory written for the report' \| tee -a "\$\{GATE_LOG\}"\nfi)/,
+    )?.[1];
+    expect(advisoryBlock2).toBeTruthy();
+    const combined = run(
+      {
+        base: ({ write }) => {
+          write(
+            'packages/cli/package.json',
+            '{"name":"@fixture/cli","scripts":{"test":"vitest run"}}\n',
+          );
+          write('packages/cli/src/a.ts', 'a\n');
+          write('packages/cli/src/a.test.ts', 't\n');
+          write(
+            'packages/cli/src/big.test.ts',
+            `${Array.from({ length: 40 }, (_, i) => `b${i}`).join('\n')}\n`,
+          );
+        },
+        pr: ({ write }) => write('packages/cli/src/a.ts', 'b\n'),
+        round: ({ write, dir }) => {
+          write('packages/cli/src/a.ts', 'c\n');
+          write('packages/cli/src/a.test.ts', 't2\n');
+          rmSync(join(dir, 'packages/cli/src/big.test.ts'));
+        },
+      },
+      {
+        runnerExit: 0,
+        resolverLines: ['packages/cli'],
+        prelude: advisoryBlock2,
+      },
+    );
+    expect(combined.advisory).toContain('test coverage shrank');
+    expect(combined.advisory).toContain('pass on the pre-round tree');
 
     // Contract pins: the rejection is non-retryable (a repair pass cannot
     // make a nonexistent defect reproduce), and the report step embeds the
@@ -11462,7 +11665,7 @@ exit 1
             return {
               user: { login: 'qwen-code-dev-bot' },
               created_at: `2026-01-01T00:${String(i).padStart(2, '0')}:00Z`,
-              body: `${headline}\n<!-- autofix-eval ts=x acted=y round=z${win ? ` win=${win}` : ''} -->`,
+              body: `${headline}\n<!-- autofix-eval ts=x acted=y round=1${win ? ` win=${win}` : ''} -->`,
             };
           }),
         ),

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -5358,10 +5358,12 @@ exit 1
       }
     };
     const K = '2026-07-29T03:00:00Z';
-    // Attribution is POSITIONAL over the comment's own scan-parsed eval
-    // markers: a neutralized marker QUOTED in a handoff excerpt carries the
-    // raw substring `win=<key> -->` but must not attribute the comment to
-    // the window (whole-body contains() did).
+    // Attribution is POSITIONAL and LAST-WINS over the comment's own
+    // scan-parsed eval markers: a comment whose body carries a stray
+    // earlier marker for THIS window plus its own authoritative marker for
+    // another window must not attribute here. Whole-body `win=<key> -->`
+    // matching counted it (a push in this window ⇒ census resets to 0);
+    // last-wins ignores it (count stays 1) — the fixture discriminates.
     expect(
       runCensus(
         [
@@ -5369,7 +5371,7 @@ exit 1
           {
             user: { login: 'qwen-code-dev-bot' },
             created_at: '2026-07-29T05:00:00Z',
-            body: `${PUSH_HEADLINE}\nquoted: <!\\-\\- autofix-eval ts=x acted=true round=9 win=${K} -->`,
+            body: `${PUSH_HEADLINE}\nstray: <!-- autofix-eval ts=x acted=true round=9 win=${K} -->\n<!-- autofix-eval ts=x acted=true round=9 win=OTHER -->`,
           },
         ],
         K,

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10148,6 +10148,50 @@ exit 1
       return advisory;
     };
     const manyLines = Array.from({ length: 40 }, (_, i) => `t${i}`).join('\n');
+    // Lifecycle discriminator: the advisory file is reset ONCE at gate
+    // start and every writer appends — a footprint advisory written by an
+    // earlier section must survive the shrink section (the pre-fix shrink
+    // section rm'd the file and truncated on write).
+    {
+      const { dir } = validityFixture({
+        base: ({ write }) => write('src/a.test.ts', `${manyLines}\n`),
+        pr: () => {},
+        round: ({ dir: d }) => rmSync(join(d, 'src', 'a.test.ts')),
+      });
+      const workdir = mkdtempSync(join(tmpdir(), 'autofix-adv-order-'));
+      writeFileSync(
+        join(workdir, 'gate-advisories.md'),
+        'EARLIER-SECTION-ADVISORY\n',
+      );
+      const res = spawnSync(
+        'bash',
+        [
+          '-c',
+          [
+            'set -eo pipefail',
+            'cd "$1"',
+            'BRANCH=feat',
+            'WORKDIR="$2"',
+            'GATE_LOG="$(mktemp)"',
+            'ROUND_RANGE="origin/feat...feat"',
+            freightHelper(),
+            block,
+            'echo DONE',
+          ].join('\n'),
+          'bash',
+          dir,
+          workdir,
+        ],
+        { encoding: 'utf8', env: isolatedGitEnv },
+      );
+      expect(res.error).toBeUndefined();
+      expect(`${res.stdout}\n${res.stderr}`).toContain('DONE');
+      const out = readFileSync(join(workdir, 'gate-advisories.md'), 'utf8');
+      expect(out).toContain('EARLIER-SECTION-ADVISORY');
+      expect(out).toContain('Gate advisory');
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(workdir, { recursive: true, force: true });
+    }
     // Deleting a test file is surfaced by name.
     const deleted = run({
       base: ({ write }) => write('src/a.test.ts', `${manyLines}\n`),
@@ -10235,6 +10279,14 @@ exit 1
       rmSync(tools, { recursive: true, force: true });
       return { out: `${res.stdout}\n${res.stderr}`, advisory };
     };
+    // Workflow wiring pins: the knob rides step-level env at both verify
+    // gates (outranking $GITHUB_ENV), sourced from the repo variable; no
+    // dead workflow-level copy shadows it.
+    expect(
+      workflow.split(
+        `FOOTPRINT_ENFORCE: "\${{ vars.QWEN_AUTOFIX_FOOTPRINT_ENFORCE || 'advisory' }}"`,
+      ).length - 1,
+    ).toBe(2);
     const crossWorkspace = {
       base: ({ write }) => {
         write('packages/cli/src/a.ts', 'a\n');
@@ -10272,6 +10324,25 @@ exit 1
         },
       }).advisory,
     ).toBe('');
+    // Declared-workspace membership beats the packages/ two-segment
+    // fallback: with nested workspaces declared, sibling NESTED workspaces
+    // are distinct areas (fallback would fuse them into packages/channels
+    // and hide the expansion).
+    expect(
+      run({
+        base: ({ write }) => {
+          write(
+            'package.json',
+            '{"workspaces":["packages/*","packages/channels/*"]}\n',
+          );
+          write('packages/channels/github/src/a.ts', 'a\n');
+          write('packages/channels/gitlab/src/b.ts', 'b\n');
+        },
+        pr: ({ write }) => write('packages/channels/github/src/a.ts', 'a2\n'),
+        round: ({ write }) =>
+          write('packages/channels/gitlab/src/b.ts', 'b2\n'),
+      }).advisory,
+    ).toContain('packages/channels/gitlab');
     // Root files are each their own area.
     expect(
       run({


### PR DESCRIPTION
## What this PR does

Inverts the review-round protection model to deny-by-default: every file a round touches is mapped to an area — its declared workspace (resolver-backed, nested included), else its top-level directory, else the root file itself — and any area outside the PR's own footprint is surfaced in a gate-authored advisory, escalating to a retryable rejection once the repo variable `QWEN_AUTOFIX_FOOTPRINT_ENFORCE` is staged from `advisory` (default) to `reject`. The enumerated sensitive-class gate from #8996 keeps rejecting regardless of the switch. Also: the three window censuses attribute comments positionally over their own scan-parsed eval markers instead of whole-body `win=` substrings; `BITE_ENFORCE`'s reply arm inherits the thread root's CHANGES_REQUESTED membership; SKILL caps each round's implemented batch (~8 findings, Critical first); and four queued backlog tests land (bite restore-crash contract, merge-base footprint under an advanced main, advisory append order, census decoy).

## Why it's needed

#8996's nine review rounds demonstrated two structural problems this PR closes. First, a denylist-style protected-surface taxonomy generates unbounded "you missed surface X" findings — the enumeration can never complete because the repo's execution graph keeps growing; deny-by-default retires that finding class by construction while keeping consequences staged (advisory first, evidence before enforcement). Second, whole-body `win=` census attribution could double-attribute a comment carrying two window keys or a quoted, neutralized marker in a handoff excerpt — probe-shown against PRIOR_TIMEOUTS/WIN_HEADS/PRIOR_HEADS in #8981's review. The SKILL batch cap encodes the measured process lesson: 8–16 fixes per round bred fix-of-fix Criticals across both parent PRs.

## Reviewer Test Plan

### How to verify

`npm run test:scripts` (54 files, 1163 passed / 13 skipped) or the single file via `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow` (172). New behavioral replays: the footprint gate runs the real extracted block against fixture repos (cross-workspace expansion → advisory listing the area; `reject` mode → retryable rejection; in-footprint and same-top-dir rounds → silent; root files as their own areas; garbage enforcement value degrades to advisory); the census replay adds a quoted-neutralized-marker decoy that old whole-body matching mis-attributed (old → '0', new → '1'); the bite suite adds a ref-deleting runner that proves the verdict-less crash contract; the footprint-class suite adds an advanced-main fixture proving merge-base anchoring; the advisory suite proves shrink+bite advisories co-exist in one report.

### Evidence (Before & After)

N/A — CI workflow/gate logic; behavior exercised by the replays above. Before: surfaces outside the enumerated classes were silently free for any round. After: expansions outside the PR footprint are machine-surfaced (or rejected under staged enforcement).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: footprint granularity (workspace/top-dir) may flag legitimate cross-cutting fixes — which is why the default consequence is an advisory, with `reject` gated behind a repo variable after observation. Deleted workspaces degrade to their top-level segment (mismatch surfaces rather than hides).
- Not validated / out of scope: per-behavior probe binding and the other recorded KNOWN-LIMIT stands from #8996 are unchanged.
- Breaking changes / migration notes: none; the enforcement default is advisory.

## Linked Issues

Follow-up to #8981 and #8996 (the census hazard and the enumeration-gap class were reviewed there and queued to this change).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把评审轮次的保护模型反转为 deny-by-default:轮次触碰的每个文件映射到一个区域——其声明的 workspace(经 resolver,含嵌套),否则顶层目录,否则根文件本身——PR 自身足迹之外的区域以门亲笔 advisory 上浮,当仓库变量 `QWEN_AUTOFIX_FOOTPRINT_ENFORCE` 从默认 `advisory` 调到 `reject` 时升级为可重试拒绝。#8996 的枚举类门不受开关影响照常拒绝。另含:三个窗口 census 改为按各自 scan 解析的 eval 标记做位置化归属(不再整体匹配 `win=` 子串);`BITE_ENFORCE` 的回复臂继承线程根的 CHANGES_REQUESTED 成员资格;SKILL 给每轮实现批量设上限(约 8 条,Critical 优先);四项排队的 backlog 测试落地(bite 恢复失败 crash 契约、main 推进下的 merge-base 足迹比较、advisory 追加顺序、census 诱饵)。

## 为什么需要

#8996 的九轮评审暴露了本 PR 关闭的两个结构性问题。其一,denylist 式保护面分类法会产生无界的"你漏了面 X"finding——仓库执行图在增长,枚举永不完备;deny-by-default 按构造退役该 finding 类,同时后果分级(先 advisory、有证据再执法)。其二,整体 `win=` 匹配可能把携带两个窗口键、或引用了已中和标记的评论重复归属——已在 #8981 评审中对三个 census 逐一 probe 证实。SKILL 批量上限编码的是实测流程教训:每轮 8–16 条修复在两个父 PR 中都催生了"修复的修复"级 Critical。

## 评审验证方案

### 如何验证

`npm run test:scripts`(54 文件,1163 通过/13 跳过)或单文件 `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow`(172)。新增行为回放:足迹门以真实抽取代码块驱动 fixture 仓库(跨 workspace 扩张 → advisory 列出区域;`reject` 模式 → 可重试拒绝;足迹内与同顶层目录 → 静默;根文件各为独立区域;非法执法值退化为 advisory);census 回放加入"引用已中和标记"诱饵,旧整体匹配误归属(旧 → '0',新 → '1');bite 套件用删 ref 的 runner 证明无判定 crash 契约;足迹类套件用推进 main 的 fixture 证明 merge-base 锚定;advisory 套件证明收缩与 bite 两条 advisory 并存。

### 证据(Before & After)

N/A —— CI workflow/gate 逻辑,行为由上述回放覆盖。Before:枚举类之外的面对任何轮次静默放行。After:PR 足迹外的扩张被机器上浮(或在分级执法下拒绝)。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

## 风险与范围

- 主要风险/权衡:足迹粒度(workspace/顶层目录)可能标记合法的横切修复——因此默认后果是 advisory,`reject` 需观察后经仓库变量启用。删除的 workspace 退化为顶层段(不匹配会上浮而非隐藏)。
- 未验证/范围外:逐行为探针绑定及 #8996 其余已记录 KNOWN-LIMIT 维持不变。
- 破坏性变更/迁移说明:无;执法默认 advisory。

## 关联 Issue

#8981 与 #8996 的 follow-up(census 隐患与枚举缺口类在彼处评审并排队至本改动)。

</details>
