### PR TITLE
fix(goal): summarise the last Goal when a turn holds no permit

### DIFF
--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -218,6 +218,16 @@ describe('GetGoalTool', () => {
 
     expect(String(result.llmContent)).not.toContain('SECRET_OBJECTIVE');
     expect(String(result.llmContent)).not.toContain('SECRET_CLAIM');
+    expect(JSON.parse(String(result.llmContent))).toEqual({
+      active: false,
+      lastGoal: {
+        goalId: 'goal-1',
+        revision: 1,
+        status: 'complete',
+        turnCount: 2,
+        activeTimeMs: 10,
+      },
+    });
   });
 
   it('reports no Goal when the session never had one', async () => {

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -21,6 +21,8 @@ import {
 } from './goal-tools.js';
 import { goalTurnContext } from './goal-turn-context.js';
 import {
+  emptyGoalSnapshot,
+  GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   GOAL_PROPOSAL_REASON_MAX_BYTES,
   GOAL_PROPOSAL_REASON_MAX_CHARACTERS,
   type GoalTurnPermit,
@@ -124,6 +126,125 @@ describe('GetGoalTool', () => {
       'No active Goal is available for this turn.',
     );
     expect(getGoalForWorker).not.toHaveBeenCalled();
+  });
+
+  it('summarises the last Goal once it has stopped issuing permits', async () => {
+    const getGoalForWorker = vi.fn();
+    const config = makeConfig({
+      getGoalForWorker,
+      getSnapshot: () => ({
+        v: 2 as const,
+        activity: 'idle' as const,
+        goal: {
+          goalId: 'goal-1',
+          revision: 3,
+          objective: 'Ship Goal v3',
+          status: 'usage_limited' as const,
+          evidenceCursor: { recordId: 'record-1' },
+          turnCount: 27,
+          activeTimeMs: 1_763_705,
+          createdAt: 1,
+          updatedAt: 2,
+          lastReason: GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+          evidenceCheckpoint: {
+            checkpointId: 'checkpoint-1',
+            createdAt: 2,
+            claims: [
+              {
+                id: 'checkpoint-1:1',
+                proofKind: 'external_fact' as const,
+                claim: 'note-01.md exists',
+                sourceRefs: ['record-1'],
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    const result = await execute(new GetGoalTool(config));
+
+    expect(result.error).toBeUndefined();
+    expect(JSON.parse(String(result.llmContent))).toEqual({
+      active: false,
+      lastGoal: {
+        goalId: 'goal-1',
+        revision: 3,
+        status: 'usage_limited',
+        turnCount: 27,
+        activeTimeMs: 1_763_705,
+        lastReason: GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+      },
+    });
+    expect(result.returnDisplay).toBe(
+      'No Goal turn is permitted · last Goal usage_limited after 27 turns',
+    );
+    expect(getGoalForWorker).not.toHaveBeenCalled();
+  });
+
+  it('keeps the objective and the evidence checkpoint behind the permit', async () => {
+    const config = makeConfig({
+      getGoalForWorker: vi.fn(),
+      getSnapshot: () => ({
+        v: 2 as const,
+        activity: 'idle' as const,
+        goal: {
+          goalId: 'goal-1',
+          revision: 1,
+          objective: 'SECRET_OBJECTIVE',
+          status: 'complete' as const,
+          evidenceCursor: { recordId: 'record-1' },
+          turnCount: 2,
+          activeTimeMs: 10,
+          createdAt: 1,
+          updatedAt: 2,
+          evidenceCheckpoint: {
+            checkpointId: 'checkpoint-1',
+            createdAt: 2,
+            claims: [
+              {
+                id: 'checkpoint-1:1',
+                proofKind: 'delivered_output' as const,
+                claim: 'SECRET_CLAIM',
+                sourceRefs: ['record-1'],
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    const result = await execute(new GetGoalTool(config));
+
+    expect(String(result.llmContent)).not.toContain('SECRET_OBJECTIVE');
+    expect(String(result.llmContent)).not.toContain('SECRET_CLAIM');
+  });
+
+  it('reports no Goal when the session never had one', async () => {
+    const config = makeConfig({
+      getGoalForWorker: vi.fn(),
+      getSnapshot: () => emptyGoalSnapshot(),
+    });
+
+    const result = await execute(new GetGoalTool(config));
+
+    expect(JSON.parse(String(result.llmContent))).toEqual({ active: false });
+  });
+
+  it('reports no Goal when Goal persistence is unreachable', async () => {
+    const config = {
+      getGoalRuntime: vi.fn(() => {
+        throw new Error('Goal persistence is unavailable');
+      }),
+    };
+
+    const result = await execute(new GetGoalTool(config));
+
+    expect(result.error).toBeUndefined();
+    expect(JSON.parse(String(result.llmContent))).toEqual({ active: false });
+    expect(result.returnDisplay).toBe(
+      'No active Goal is available for this turn.',
+    );
   });
 
   it('returns only the bounded worker view for the captured permit', async () => {

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -182,6 +182,43 @@ describe('GetGoalTool', () => {
     expect(getGoalForWorker).not.toHaveBeenCalled();
   });
 
+  it('summarises a paused Goal outside a permitted turn', async () => {
+    const config = makeConfig({
+      getGoalForWorker: vi.fn(),
+      getSnapshot: () => ({
+        v: 2 as const,
+        activity: 'idle' as const,
+        goal: {
+          goalId: 'goal-1',
+          revision: 2,
+          objective: 'Ship Goal v3',
+          status: 'paused' as const,
+          evidenceCursor: { recordId: 'record-1' },
+          turnCount: 1,
+          activeTimeMs: 750,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      }),
+    });
+
+    const result = await execute(new GetGoalTool(config));
+
+    expect(JSON.parse(String(result.llmContent))).toEqual({
+      active: false,
+      lastGoal: {
+        goalId: 'goal-1',
+        revision: 2,
+        status: 'paused',
+        turnCount: 1,
+        activeTimeMs: 750,
+      },
+    });
+    expect(result.returnDisplay).toBe(
+      'No Goal turn is permitted · last Goal paused after 1 turn',
+    );
+  });
+
   it('keeps the objective and the evidence checkpoint behind the permit', async () => {
     const config = makeConfig({
       getGoalForWorker: vi.fn(),

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -172,20 +172,8 @@ function unpermittedGoalResult(lastGoal: LastGoalSummary | undefined) {
     };
   }
   return {
-    llmContent: JSON.stringify({
-      active: false,
-      lastGoal: {
-        goalId: lastGoal.goalId,
-        revision: lastGoal.revision,
-        status: lastGoal.status,
-        turnCount: lastGoal.turnCount,
-        activeTimeMs: lastGoal.activeTimeMs,
-        ...(lastGoal.lastReason === undefined
-          ? {}
-          : { lastReason: lastGoal.lastReason }),
-      },
-    }),
-    returnDisplay: `No Goal turn is permitted · last Goal ${lastGoal.status} after ${lastGoal.turnCount} turns`,
+    llmContent: JSON.stringify({ active: false, lastGoal }),
+    returnDisplay: `No Goal turn is permitted · last Goal ${lastGoal.status} after ${lastGoal.turnCount} ${lastGoal.turnCount === 1 ? 'turn' : 'turns'}`,
   };
 }
 

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -43,6 +43,11 @@ export interface UpdateGoalToolParams {
 
 export type GoalToolResult = ToolResult;
 
+type LastGoalSummary = Pick<
+  GoalRecord,
+  'goalId' | 'revision' | 'status' | 'turnCount' | 'activeTimeMs' | 'lastReason'
+>;
+
 type GetGoalRuntime = Pick<GoalRuntime, 'getGoalForWorker'> & {
   getSnapshotForPermit?: GoalRuntime['getSnapshotForPermit'];
 };
@@ -62,7 +67,7 @@ class GetGoalInvocation extends BaseToolInvocation<
     params: GetGoalToolParams,
     private readonly runtime: GetGoalRuntime | undefined,
     private readonly permit: GoalTurnPermit | undefined,
-    private readonly lastGoal: GoalRecord | undefined,
+    private readonly lastGoal: LastGoalSummary | undefined,
   ) {
     super(params);
   }
@@ -103,7 +108,7 @@ export class GetGoalTool extends BaseDeclarativeTool<
     super(
       GetGoalTool.Name,
       ToolDisplayNames.GET_GOAL,
-      'Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. Outside a permitted Goal turn it reports "active": false together with "lastGoal", a scalar summary (status, turnCount, activeTimeMs, lastReason) of the session\'s most recent Goal, so a Goal that has already stopped can still be inspected. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.',
+      'Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. Outside a permitted Goal turn it reports "active": false together with "lastGoal", a scalar summary (goalId, revision, status, turnCount, activeTimeMs, and lastReason when one was recorded) of the session\'s most recent Goal, so a Goal that has already stopped can still be inspected. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.',
       Kind.Read,
       {
         type: 'object',
@@ -137,7 +142,7 @@ export class GetGoalTool extends BaseDeclarativeTool<
    * needs no permit, so report it. Scalars only: the objective and the
    * evidence checkpoint stay behind the permit.
    */
-  private lastGoal(): GoalRecord | undefined {
+  private lastGoal(): LastGoalSummary | undefined {
     let runtime: GoalRuntime;
     try {
       runtime = this.config.getGoalRuntime();
@@ -146,11 +151,20 @@ export class GetGoalTool extends BaseDeclarativeTool<
       return undefined;
     }
     if (typeof runtime?.getSnapshot !== 'function') return undefined;
-    return runtime.getSnapshot().goal ?? undefined;
+    const goal = runtime.getSnapshot().goal;
+    if (!goal) return undefined;
+    return {
+      goalId: goal.goalId,
+      revision: goal.revision,
+      status: goal.status,
+      turnCount: goal.turnCount,
+      activeTimeMs: goal.activeTimeMs,
+      ...(goal.lastReason === undefined ? {} : { lastReason: goal.lastReason }),
+    };
   }
 }
 
-function unpermittedGoalResult(lastGoal: GoalRecord | undefined) {
+function unpermittedGoalResult(lastGoal: LastGoalSummary | undefined) {
   if (!lastGoal) {
     return {
       llmContent: JSON.stringify({ active: false }),

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -21,6 +21,7 @@ import {
 import { goalTurnContext } from './goal-turn-context.js';
 import {
   GOAL_PROPOSAL_REASON_MAX_CHARACTERS,
+  type GoalRecord,
   type GoalSnapshotV2,
   type GoalTerminalProposal,
   type GoalTurnPermit,
@@ -61,6 +62,7 @@ class GetGoalInvocation extends BaseToolInvocation<
     params: GetGoalToolParams,
     private readonly runtime: GetGoalRuntime | undefined,
     private readonly permit: GoalTurnPermit | undefined,
+    private readonly lastGoal: GoalRecord | undefined,
   ) {
     super(params);
   }
@@ -71,11 +73,7 @@ class GetGoalInvocation extends BaseToolInvocation<
 
   async execute(signal: AbortSignal): Promise<GoalToolResult> {
     if (!this.runtime || !this.permit) {
-      const message = 'No active Goal is available for this turn.';
-      return {
-        llmContent: JSON.stringify({ active: false }),
-        returnDisplay: message,
-      };
+      return unpermittedGoalResult(this.lastGoal);
     }
 
     const view = await workerViewForPermit(this.runtime, this.permit, signal);
@@ -105,7 +103,7 @@ export class GetGoalTool extends BaseDeclarativeTool<
     super(
       GetGoalTool.Name,
       ToolDisplayNames.GET_GOAL,
-      'Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.',
+      'Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. Outside a permitted Goal turn it reports "active": false together with "lastGoal", a scalar summary (status, turnCount, activeTimeMs, lastReason) of the session\'s most recent Goal, so a Goal that has already stopped can still be inspected. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.',
       Kind.Read,
       {
         type: 'object',
@@ -121,8 +119,60 @@ export class GetGoalTool extends BaseDeclarativeTool<
     const contextPermit = goalTurnContext.getStore();
     const permit = contextPermit ? structuredClone(contextPermit) : undefined;
     const runtime = permit ? this.config.getGoalRuntime() : undefined;
-    return new GetGoalInvocation(params, runtime, permit);
+    return new GetGoalInvocation(
+      params,
+      runtime,
+      permit,
+      permit ? undefined : this.lastGoal(),
+    );
   }
+
+  /**
+   * The session's most recent Goal, for a turn that holds no Goal permit.
+   *
+   * A Goal that reached a terminal status stops issuing permits, so every
+   * later `get_goal` answered `{ active: false }` — the run's own turn count,
+   * elapsed time and stop reason became unreadable at exactly the moment
+   * someone wanted them. The runtime still holds that record and reading it
+   * needs no permit, so report it. Scalars only: the objective and the
+   * evidence checkpoint stay behind the permit.
+   */
+  private lastGoal(): GoalRecord | undefined {
+    let runtime: GoalRuntime;
+    try {
+      runtime = this.config.getGoalRuntime();
+    } catch {
+      // A session with no reachable Goal persistence has no Goal to summarise.
+      return undefined;
+    }
+    if (typeof runtime?.getSnapshot !== 'function') return undefined;
+    return runtime.getSnapshot().goal ?? undefined;
+  }
+}
+
+function unpermittedGoalResult(lastGoal: GoalRecord | undefined) {
+  if (!lastGoal) {
+    return {
+      llmContent: JSON.stringify({ active: false }),
+      returnDisplay: 'No active Goal is available for this turn.',
+    };
+  }
+  return {
+    llmContent: JSON.stringify({
+      active: false,
+      lastGoal: {
+        goalId: lastGoal.goalId,
+        revision: lastGoal.revision,
+        status: lastGoal.status,
+        turnCount: lastGoal.turnCount,
+        activeTimeMs: lastGoal.activeTimeMs,
+        ...(lastGoal.lastReason === undefined
+          ? {}
+          : { lastReason: lastGoal.lastReason }),
+      },
+    }),
+    returnDisplay: `No Goal turn is permitted · last Goal ${lastGoal.status} after ${lastGoal.turnCount} turns`,
+  };
 }
 
 class UpdateGoalInvocation extends BaseToolInvocation<


### PR DESCRIPTION
## What this PR does

`get_goal` now reports a scalar summary of the session's most recent Goal whenever the current turn holds no Goal permit. The reply keeps its existing `"active": false` shape and gains a `lastGoal` object carrying the goal id, revision, status, turn count, active time and stop reason. The objective and the evidence checkpoint stay behind the permit, and a session that never had a Goal — or one whose Goal persistence is unreachable — still answers the bare `{ "active": false }`.

## Why it's needed

A Goal that reaches a terminal status stops issuing turn permits. Every `get_goal` after that point answered a bare `{ "active": false }`, which is true about the turn but says nothing about the Goal, so the run's own turn count, elapsed time and stop reason became unreadable at exactly the moment someone wanted them. In a reported local session an automatic Goal ran 27 turns and then stopped as `usage_limited`; when the user asked how many turns it had completed, the number could not be read back from the runtime at all and had to be reconstructed from the assistant's own per-turn narration, which is a claim about the transcript rather than a reading of Goal state. The runtime still holds the record and reading it needs no permit, so the honest answer is available and was simply not being returned.

## Reviewer Test Plan

### How to verify

Start a Goal, drive it to any terminal status, then call `get_goal` from a turn that holds no permit. Confirm the reply is `{"active": false, "lastGoal": {...}}` with the status, turn count, active time and stop reason of the Goal that just ended, and confirm that neither the objective text nor any evidence checkpoint claim appears anywhere in the payload. Then confirm the two unchanged paths: a session that never set a Goal, and a session whose Goal persistence is unavailable, both still return the bare `{"active": false}` with the original display line.

Automated coverage adds four cases to the existing `GetGoalTool` suite: the terminal-Goal summary and its display line, an assertion that a `SECRET_OBJECTIVE` objective and a `SECRET_CLAIM` checkpoint claim are absent from the payload, an empty-snapshot session, and a `getGoalRuntime()` that throws. `npx vitest run packages/core/src/goals/` passes 361 tests across 15 files. `npx tsc --noEmit` in `packages/core` reports only a pre-existing `sharp` typing error in `src/utils/image-view.ts` that reproduces identically on the unmodified head. `prettier` and `eslint` are clean on both changed files.

### Evidence (Before & After)

Before, from the reported session: after the Goal stopped, `get_goal` returned `{"active":false}` and the final turn count was unavailable; the answer given to the user was derived from earlier assistant reports rather than from Goal state.

After: the same call returns `{"active":false,"lastGoal":{"goalId":"…","revision":3,"status":"usage_limited","turnCount":27,"activeTimeMs":1763705,"lastReason":"The current Goal revision exceeded the bounded evidence catalog. …"}}`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, Node.js 22, unit tests only.

## Risk & Scope

- Main risk or tradeoff: the unpermitted reply grows by one small object on sessions that have a Goal, which costs a few tokens per call; the alternative — leaving the state unreadable — costs a reconstruction from narration, which is exactly the kind of claim Goal state exists to replace.
- Not validated / out of scope: this does not change when permits are issued, what `usage_limited` means, or whether a stopped Goal can resume; it only makes the record readable. Windows and macOS were not exercised locally and remain covered by CI.
- Breaking changes / migration notes: none. The payload change is additive and the pre-existing shape is returned unchanged whenever there is no Goal to summarise.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当前轮次没有 Goal permit 时，`get_goal` 现在会返回本会话最近一个 Goal 的标量摘要。返回值保持原有的 `"active": false` 形状，并新增一个 `lastGoal` 对象，携带 goal id、revision、状态、轮数、活跃时长和终止原因。objective 和 evidence checkpoint 仍然留在 permit 之后，从未设置过 Goal 的会话、以及 Goal 持久化不可达的会话，仍然返回原样的 `{ "active": false }`。

## 为什么需要

Goal 一旦进入终止状态就不再发放轮次 permit，此后每次 `get_goal` 都只返回一个裸的 `{ "active": false }`。这句话描述的是轮次而不是 Goal，于是这次运行自己的轮数、耗时和终止原因，恰好在有人需要它们的那一刻变得不可读。在一份已报告的本地 session 中，一个自动 Goal 跑了 27 轮后以 `usage_limited` 停止；当用户问它一共跑了多少轮时，这个数字根本无法从运行时读回，只能靠助手自己每轮的汇报去反推——那是对转录的一种主张，而不是对 Goal 状态的读取。运行时其实仍然保存着这条记录，而且读取它不需要 permit，所以这个诚实的答案本来就在，只是没有被返回。

## 评审者测试计划

### 如何验证

创建一个 Goal，把它推进到任意终止状态，然后从一个没有 permit 的轮次调用 `get_goal`。确认返回的是 `{"active": false, "lastGoal": {...}}`，其中带有刚刚结束的那个 Goal 的状态、轮数、活跃时长和终止原因；并确认 objective 文本和任何 evidence checkpoint claim 都没有出现在 payload 的任何位置。然后确认两条未变的路径：从未设置过 Goal 的会话，以及 Goal 持久化不可用的会话，都仍然返回裸的 `{"active": false}` 和原来的展示文案。

自动化覆盖在既有的 `GetGoalTool` 套件中新增四个用例：终止 Goal 的摘要及其展示文案；断言 `SECRET_OBJECTIVE` objective 和 `SECRET_CLAIM` checkpoint claim 不出现在 payload 中；空快照会话；以及会抛异常的 `getGoalRuntime()`。`npx vitest run packages/core/src/goals/` 通过 15 个文件共 361 个测试。`packages/core` 下 `npx tsc --noEmit` 只报告 `src/utils/image-view.ts` 中一个预先存在的 `sharp` 类型错误，该错误在未修改的 head 上可原样复现。两个改动文件的 `prettier` 与 `eslint` 均干净。

### 证据（修复前后）

修复前，来自已报告的 session：Goal 停止后，`get_goal` 返回 `{"active":false}`，最终轮数无法获得；当时给用户的答案是从此前的助手汇报里推出来的，而不是从 Goal 状态读出来的。

修复后：同一次调用返回 `{"active":false,"lastGoal":{"goalId":"…","revision":3,"status":"usage_limited","turnCount":27,"activeTimeMs":1763705,"lastReason":"The current Goal revision exceeded the bounded evidence catalog. …"}}`。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Linux、Node.js 22，仅单元测试。

## 风险与范围

- 主要风险或取舍：在有 Goal 的会话里，无 permit 的返回值会多出一个小对象，每次调用多花几个 token；而另一种选择——让这份状态保持不可读——的代价是从叙述中反推，而这正是 Goal 状态本该取代的那类主张。
- 未验证/不在范围：本 PR 不改变 permit 的发放时机、不改变 `usage_limited` 的含义，也不改变一个已停止的 Goal 能否恢复；它只让这条记录可读。Windows 和 macOS 未在本地验证，仍由 CI 覆盖。
- 破坏性变更/迁移说明：无。payload 的变化是纯新增的，在没有 Goal 可摘要时返回的仍是原有形状。

## 关联 Issue

无。

</details>
