### PR TITLE
refactor(goal): type the limit that stopped a Goal

### DIFF
--- a/packages/core/src/goals/goal-protocol.ts
+++ b/packages/core/src/goals/goal-protocol.ts
@@ -16,6 +16,33 @@ export const GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON =
 export const GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON =
   'The current Goal revision exceeded the checkpoint verifier request limit. Automatic retries cannot recover. Edit or replace the Goal before resuming it.';
 
+/**
+ * Which bound a `usage_limited` Goal ran into.
+ *
+ * Only the evidence bounds are enumerated: they are the ones a caller has to
+ * branch on, because they are the ones a plain resume cannot clear. Every other
+ * route to `usage_limited` is an operational failure that carries prose in
+ * `lastReason` and nothing to key off.
+ */
+export type GoalLimitKind = 'evidence_catalog' | 'checkpoint_request';
+
+export function isGoalLimitKind(value: unknown): value is GoalLimitKind {
+  return value === 'evidence_catalog' || value === 'checkpoint_request';
+}
+
+/** The limit a `usage_limited` reason denotes, for reasons that denote one. */
+export function goalLimitKindForReason(
+  reason: string,
+): GoalLimitKind | undefined {
+  if (reason === GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON) {
+    return 'evidence_catalog';
+  }
+  if (reason === GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON) {
+    return 'checkpoint_request';
+  }
+  return undefined;
+}
+
 export const PAUSED_GOAL_SYSTEM_REMINDER =
   '<system-reminder>\nThe Goal is paused. Do not continue its objective unless the user resumes it. Treat this message as ordinary conversation.\n</system-reminder>';
 
@@ -81,6 +108,12 @@ export interface GoalRecord {
   updatedAt: number;
   evidenceCheckpoint?: GoalEvidenceCheckpoint;
   lastReason?: string;
+  /**
+   * Set alongside `lastReason` whenever the runtime stops a Goal at one of the
+   * enumerated bounds. `lastReason` stays the human-readable half; this is the
+   * half state transitions are allowed to read.
+   */
+  limitKind?: GoalLimitKind;
 }
 
 export interface GoalSnapshotV2 {

--- a/packages/core/src/goals/goal-reducer.test.ts
+++ b/packages/core/src/goals/goal-reducer.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
+  GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   goalRequiresExactPermit,
   type GoalControlRequest,
   type GoalRecord,
@@ -305,6 +307,80 @@ describe('goal reducer', () => {
     });
   });
 
+  it('refuses to resume a Goal that carries an evidence limitKind', () => {
+    expect(() =>
+      reduceGoalControl(
+        goalRecord({
+          status: 'usage_limited',
+          revision: 4,
+          limitKind: 'evidence_catalog',
+          lastReason: 'a reason the guard no longer has to recognise',
+        }),
+        {
+          request: {
+            action: 'resume',
+            expectedGoalId: 'g-1',
+            expectedRevision: 4,
+          },
+          now: 200,
+          nextGoalId: 'unused',
+          cursor: { recordId: 'r-200' },
+        },
+      ),
+    ).toThrow(
+      'An evidence-limited Goal cannot be resumed; edit or replace the Goal first',
+    );
+  });
+
+  it.each([
+    GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+    GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
+  ])(
+    'still refuses to resume a pre-limitKind Goal stopped by the sentinel prose',
+    (lastReason) => {
+      expect(() =>
+        reduceGoalControl(
+          goalRecord({ status: 'usage_limited', revision: 4, lastReason }),
+          {
+            request: {
+              action: 'resume',
+              expectedGoalId: 'g-1',
+              expectedRevision: 4,
+            },
+            now: 200,
+            nextGoalId: 'unused',
+            cursor: { recordId: 'r-200' },
+          },
+        ),
+      ).toThrow(GoalInvalidTransitionError);
+    },
+  );
+
+  it('clears limitKind when the objective is edited', () => {
+    const edited = reduceGoalControl(
+      goalRecord({
+        status: 'usage_limited',
+        revision: 4,
+        limitKind: 'evidence_catalog',
+        lastReason: GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+      }),
+      {
+        request: {
+          action: 'edit',
+          objective: 'ship something else',
+          expectedGoalId: 'g-1',
+          expectedRevision: 4,
+        },
+        now: 200,
+        nextGoalId: 'unused',
+        cursor: { recordId: 'r-200' },
+      },
+    );
+
+    expect(edited?.limitKind).toBeUndefined();
+    expect(edited?.lastReason).toBeUndefined();
+  });
+
   it('rejects an unsupported control action instead of resuming', () => {
     expect(() =>
       reduceGoalControl(goalRecord({ status: 'paused' }), {
@@ -533,6 +609,28 @@ describe('goal reducer', () => {
       expect(parseGoalSnapshotV2(value)).toEqual(value);
     },
   );
+
+  it.each(['evidence_catalog', 'checkpoint_request'] as const)(
+    'round-trips a %s limitKind through a persisted snapshot',
+    (limitKind) => {
+      const value = snapshot(
+        goalRecord({ status: 'usage_limited', limitKind }),
+      );
+
+      expect(parseGoalSnapshotV2(value)).toEqual(value);
+    },
+  );
+
+  it('rejects a snapshot carrying an unknown limitKind', () => {
+    const value = snapshot(
+      goalRecord({
+        status: 'usage_limited',
+        limitKind: 'something_else' as never,
+      }),
+    );
+
+    expect(parseGoalSnapshotV2(value)).toBeUndefined();
+  });
 
   it.each([
     ['zero count', { fingerprint: 'same', count: 0, turnIds: [] }],

--- a/packages/core/src/goals/goal-reducer.test.ts
+++ b/packages/core/src/goals/goal-reducer.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
   GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+  goalLimitKindForReason,
   goalRequiresExactPermit,
   type GoalControlRequest,
   type GoalRecord,
@@ -307,30 +308,44 @@ describe('goal reducer', () => {
     });
   });
 
-  it('refuses to resume a Goal that carries an evidence limitKind', () => {
-    expect(() =>
-      reduceGoalControl(
-        goalRecord({
-          status: 'usage_limited',
-          revision: 4,
-          limitKind: 'evidence_catalog',
-          lastReason: 'a reason the guard no longer has to recognise',
-        }),
-        {
-          request: {
-            action: 'resume',
-            expectedGoalId: 'g-1',
-            expectedRevision: 4,
+  it.each(['evidence_catalog', 'checkpoint_request'] as const)(
+    'refuses to resume a Goal that carries limitKind %s',
+    (limitKind) => {
+      expect(() =>
+        reduceGoalControl(
+          goalRecord({
+            status: 'usage_limited',
+            revision: 4,
+            limitKind,
+            lastReason: 'a reason the guard no longer has to recognise',
+          }),
+          {
+            request: {
+              action: 'resume',
+              expectedGoalId: 'g-1',
+              expectedRevision: 4,
+            },
+            now: 200,
+            nextGoalId: 'unused',
+            cursor: { recordId: 'r-200' },
           },
-          now: 200,
-          nextGoalId: 'unused',
-          cursor: { recordId: 'r-200' },
-        },
-      ),
-    ).toThrow(
-      'An evidence-limited Goal cannot be resumed; edit or replace the Goal first',
-    );
-  });
+        ),
+      ).toThrow(
+        'An evidence-limited Goal cannot be resumed; edit or replace the Goal first',
+      );
+    },
+  );
+
+  it.each([
+    [GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON, 'evidence_catalog'],
+    [GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON, 'checkpoint_request'],
+    ['An operational limit', undefined],
+  ] as const)(
+    'maps a Goal limit reason only to its canonical kind',
+    (reason, expected) => {
+      expect(goalLimitKindForReason(reason)).toBe(expected);
+    },
+  );
 
   it.each([
     GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,

--- a/packages/core/src/goals/goal-reducer.test.ts
+++ b/packages/core/src/goals/goal-reducer.test.ts
@@ -647,6 +647,17 @@ describe('goal reducer', () => {
     expect(parseGoalSnapshotV2(value)).toBeUndefined();
   });
 
+  it.each(['active', 'paused', 'blocked', 'complete'] as const)(
+    'rejects a %s snapshot carrying a limitKind',
+    (status) => {
+      const value = snapshot(
+        goalRecord({ status, limitKind: 'evidence_catalog' }),
+      );
+
+      expect(parseGoalSnapshotV2(value)).toBeUndefined();
+    },
+  );
+
   it.each([
     ['zero count', { fingerprint: 'same', count: 0, turnIds: [] }],
     [

--- a/packages/core/src/goals/goal-reducer.ts
+++ b/packages/core/src/goals/goal-reducer.ts
@@ -13,6 +13,7 @@ import {
   GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   GOAL_STATE_VERSION,
   isGoalEvidenceProofKind,
+  isGoalLimitKind,
   type GoalControlRequest,
   type GoalEvidenceCheckpoint,
   type GoalRecord,
@@ -106,6 +107,7 @@ export function reduceGoalControl(
       evidenceCursor: copyCursor(transition.cursor),
       evidenceCheckpoint: undefined,
       lastReason: undefined,
+      limitKind: undefined,
     });
   }
 
@@ -131,11 +133,7 @@ export function reduceGoalControl(
       snapshotOf(current),
     );
   }
-  if (
-    current.status === 'usage_limited' &&
-    (current.lastReason === GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON ||
-      current.lastReason === GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON)
-  ) {
+  if (current.status === 'usage_limited' && isEvidenceLimited(current)) {
     throw new GoalInvalidTransitionError(
       'An evidence-limited Goal cannot be resumed; edit or replace the Goal first',
       snapshotOf(current),
@@ -343,6 +341,21 @@ function normalizeObjective(
   return normalized;
 }
 
+/**
+ * Whether a stopped Goal was stopped by one of the evidence bounds.
+ *
+ * `limitKind` is the field of record. The `lastReason` comparison behind it
+ * reads Goals persisted before `limitKind` existed, where the sentinel prose
+ * was the only marker a transition could key off.
+ */
+function isEvidenceLimited(goal: GoalRecord): boolean {
+  return (
+    goal.limitKind !== undefined ||
+    goal.lastReason === GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON ||
+    goal.lastReason === GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON
+  );
+}
+
 function transitionGoal(
   goal: GoalRecord,
   now: number,
@@ -399,6 +412,7 @@ function parseGoalRecord(value: unknown): GoalRecord | undefined {
       'updatedAt',
       'evidenceCheckpoint',
       'lastReason',
+      'limitKind',
     ]) ||
     typeof value['goalId'] !== 'string' ||
     !value['goalId'] ||
@@ -414,7 +428,8 @@ function parseGoalRecord(value: unknown): GoalRecord | undefined {
     !isFiniteNumber(value['updatedAt']) ||
     !isGoalEvidenceCheckpoint(value['evidenceCheckpoint']) ||
     (value['lastReason'] !== undefined &&
-      typeof value['lastReason'] !== 'string')
+      typeof value['lastReason'] !== 'string') ||
+    (value['limitKind'] !== undefined && !isGoalLimitKind(value['limitKind']))
   ) {
     return undefined;
   }
@@ -443,6 +458,9 @@ function parseGoalRecord(value: unknown): GoalRecord | undefined {
     ...(value['lastReason'] === undefined
       ? {}
       : { lastReason: value['lastReason'] }),
+    ...(value['limitKind'] === undefined
+      ? {}
+      : { limitKind: value['limitKind'] }),
   };
 }
 

--- a/packages/core/src/goals/goal-reducer.ts
+++ b/packages/core/src/goals/goal-reducer.ts
@@ -9,9 +9,8 @@ import {
   GOAL_CHECKPOINT_CLAIM_MAX_BYTES,
   GOAL_CHECKPOINT_CLAIM_MAX_CHARACTERS,
   GOAL_CHECKPOINT_SOURCE_REFERENCE_LIMIT,
-  GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
-  GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   GOAL_STATE_VERSION,
+  goalLimitKindForReason,
   isGoalEvidenceProofKind,
   isGoalLimitKind,
   type GoalControlRequest,
@@ -351,8 +350,8 @@ function normalizeObjective(
 function isEvidenceLimited(goal: GoalRecord): boolean {
   return (
     goal.limitKind !== undefined ||
-    goal.lastReason === GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON ||
-    goal.lastReason === GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON
+    (goal.lastReason !== undefined &&
+      goalLimitKindForReason(goal.lastReason) !== undefined)
   );
 }
 

--- a/packages/core/src/goals/goal-reducer.ts
+++ b/packages/core/src/goals/goal-reducer.ts
@@ -428,7 +428,9 @@ function parseGoalRecord(value: unknown): GoalRecord | undefined {
     !isGoalEvidenceCheckpoint(value['evidenceCheckpoint']) ||
     (value['lastReason'] !== undefined &&
       typeof value['lastReason'] !== 'string') ||
-    (value['limitKind'] !== undefined && !isGoalLimitKind(value['limitKind']))
+    (value['limitKind'] !== undefined &&
+      (!isGoalLimitKind(value['limitKind']) ||
+        value['status'] !== 'usage_limited'))
   ) {
     return undefined;
   }

--- a/packages/core/src/goals/goal-runtime.test.ts
+++ b/packages/core/src/goals/goal-runtime.test.ts
@@ -968,6 +968,7 @@ describe('goal runtime', () => {
     expect(runtime.getSnapshot().goal).toMatchObject({
       status: 'usage_limited',
       lastReason: GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
+      limitKind: 'checkpoint_request',
     });
     // The oversized request cannot shrink on its own, so resume must stay
     // blocked instead of re-limiting on every resumed turn.
@@ -1080,9 +1081,10 @@ describe('goal runtime', () => {
       expect(host.started).toHaveLength(1);
       expect(checkpointVerifier).toHaveBeenCalledTimes(0);
       if (failurePoint === 'truncated') {
-        expect(runtime.getSnapshot().goal?.lastReason).toBe(
-          GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
-        );
+        expect(runtime.getSnapshot().goal).toMatchObject({
+          lastReason: GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+          limitKind: 'evidence_catalog',
+        });
         await expect(
           runtime.dispatch({
             action: 'resume',

--- a/packages/core/src/goals/goal-runtime.test.ts
+++ b/packages/core/src/goals/goal-runtime.test.ts
@@ -434,6 +434,7 @@ describe('goal runtime', () => {
       goal: {
         status: 'usage_limited',
         lastReason: expect.stringContaining('bounded evidence catalog'),
+        limitKind: 'evidence_catalog',
       },
     });
     expect(journal.appended.map((payload) => payload.cause)).toEqual([
@@ -507,6 +508,7 @@ describe('goal runtime', () => {
       goal: {
         status: 'usage_limited',
         lastReason: expect.stringContaining('bounded evidence catalog'),
+        limitKind: 'evidence_catalog',
       },
     });
     expect(journal.appended.map((payload) => payload.cause)).toEqual([

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -24,7 +24,6 @@ import {
   GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
   GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   GOAL_STATE_VERSION,
-  goalLimitKindForReason,
   isRepeatedBlockerProposal,
   type GoalControlRequest,
   type GoalEvidenceCheckpoint,
@@ -149,17 +148,6 @@ export interface GoalRuntime {
   ): GoalProposalReceipt;
   takePendingTerminalProposal(): GoalPendingProposal | undefined;
   dispose(): void;
-}
-
-/**
- * The typed limit to persist beside a `usage_limited` reason.
- *
- * Spreads to nothing for the operational failures that also land on
- * `usage_limited`, so only the enumerated bounds get a `limitKind`.
- */
-function limitKindFor(reason: string): { limitKind?: GoalLimitKind } {
-  const limitKind = goalLimitKindForReason(reason);
-  return limitKind === undefined ? {} : { limitKind };
 }
 
 function normalizeRecoveredBlockedAudit(
@@ -507,7 +495,11 @@ export function createGoalRuntime(
     attempt: VerificationAttempt,
     outcome:
       | { kind: 'decision'; result: GoalVerificationResult }
-      | { kind: 'usage_limited'; reason: string },
+      | {
+          kind: 'usage_limited';
+          reason: string;
+          limitKind?: GoalLimitKind;
+        },
   ): Promise<CheckpointAttempt | undefined> =>
     enqueue(async () => {
       if (!isCurrentVerificationAttempt(attempt) || !snapshot.goal) return;
@@ -565,7 +557,9 @@ export function createGoalRuntime(
             activeTimeMs: elapsedActiveTime(snapshot.goal, now),
             updatedAt: now,
             lastReason: outcome.reason,
-            ...limitKindFor(outcome.reason),
+            ...(outcome.limitKind === undefined
+              ? {}
+              : { limitKind: outcome.limitKind }),
           },
           activity: 'idle',
         };
@@ -669,7 +663,11 @@ export function createGoalRuntime(
 
     let outcome:
       | { kind: 'decision'; result: GoalVerificationResult }
-      | { kind: 'usage_limited'; reason: string };
+      | {
+          kind: 'usage_limited';
+          reason: string;
+          limitKind?: GoalLimitKind;
+        };
     try {
       await evidenceSource.flush();
       if (attempt.controller.signal.aborted) return;
@@ -692,7 +690,11 @@ export function createGoalRuntime(
       if (error instanceof InvalidGoalEvidenceReferenceError) {
         outcome =
           error.code === 'catalog_truncated'
-            ? { kind: 'usage_limited', reason: error.message }
+            ? {
+                kind: 'usage_limited',
+                reason: error.message,
+                limitKind: 'evidence_catalog',
+              }
             : {
                 kind: 'decision',
                 result: { decision: 'reject', reason: error.message },
@@ -757,6 +759,7 @@ export function createGoalRuntime(
   const recordCheckpointFailure = async (
     attempt: CheckpointAttempt,
     reason: string,
+    limitKind?: GoalLimitKind,
   ): Promise<void> => {
     await enqueue(async () => {
       if (!isCurrentCheckpointAttempt(attempt) || !snapshot.goal) return;
@@ -769,7 +772,7 @@ export function createGoalRuntime(
           activeTimeMs: elapsedActiveTime(snapshot.goal, now),
           updatedAt: now,
           lastReason: reason,
-          ...limitKindFor(reason),
+          ...(limitKind === undefined ? {} : { limitKind }),
         },
         activity: 'idle',
       };
@@ -860,6 +863,7 @@ export function createGoalRuntime(
         await recordCheckpointFailure(
           attempt,
           GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+          'evidence_catalog',
         );
         return;
       }
@@ -895,6 +899,7 @@ export function createGoalRuntime(
           await recordCheckpointFailure(
             attempt,
             GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
+            'checkpoint_request',
           );
           return;
         }

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -24,9 +24,11 @@ import {
   GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
   GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   GOAL_STATE_VERSION,
+  goalLimitKindForReason,
   isRepeatedBlockerProposal,
   type GoalControlRequest,
   type GoalEvidenceCheckpoint,
+  type GoalLimitKind,
   type GoalSnapshotV2,
   type GoalStateCause,
   type GoalStateRecordPayloadV2,
@@ -147,6 +149,17 @@ export interface GoalRuntime {
   ): GoalProposalReceipt;
   takePendingTerminalProposal(): GoalPendingProposal | undefined;
   dispose(): void;
+}
+
+/**
+ * The typed limit to persist beside a `usage_limited` reason.
+ *
+ * Spreads to nothing for the operational failures that also land on
+ * `usage_limited`, so only the enumerated bounds get a `limitKind`.
+ */
+function limitKindFor(reason: string): { limitKind?: GoalLimitKind } {
+  const limitKind = goalLimitKindForReason(reason);
+  return limitKind === undefined ? {} : { limitKind };
 }
 
 function normalizeRecoveredBlockedAudit(
@@ -552,6 +565,7 @@ export function createGoalRuntime(
             activeTimeMs: elapsedActiveTime(snapshot.goal, now),
             updatedAt: now,
             lastReason: outcome.reason,
+            ...limitKindFor(outcome.reason),
           },
           activity: 'idle',
         };
@@ -755,6 +769,7 @@ export function createGoalRuntime(
           activeTimeMs: elapsedActiveTime(snapshot.goal, now),
           updatedAt: now,
           lastReason: reason,
+          ...limitKindFor(reason),
         },
         activity: 'idle',
       };


### PR DESCRIPTION
## What this PR does

`GoalRecord` gains an optional `limitKind` field, written beside `lastReason` wherever the runtime stops a Goal at one of the two enumerated evidence bounds, and `reduceGoalResume` now reads that field instead of comparing `lastReason` against two exact sentence constants. `lastReason` keeps its current text and remains the human-readable half. Goals persisted before this field existed still refuse to resume, through the sentinel comparison retained behind the new check, so recovery from an older transcript is unchanged. There is no behavior change: the same Goals resume and the same Goals refuse.

## Why it's needed

Whether a `usage_limited` Goal may resume is currently decided by `current.lastReason === GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON || current.lastReason === GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON` — a state transition keyed on prose. That makes a display string load-bearing in two directions. Any future path that wants to raise a limit and then resume must reproduce one of those sentences byte for byte or fail silently against a guard that compares English, and any edit to the wording of a user-facing message silently changes which Goals are resumable. Neither failure is visible at the call site, and neither is caught by a type. Separating the machine-readable half from the human-readable half removes both hazards and leaves the guard saying what it means.

This is groundwork rather than a fix on its own: it is a prerequisite for the evidence-catalog salvage and resume work, and for any budget that a user can raise, all of which need to branch on why a Goal stopped.

## Reviewer Test Plan

### How to verify

Confirm the guard still refuses in both directions. A Goal stopped by the runtime now carries `limitKind`, so drive a Goal to a checkpoint-exhaustion stop and confirm `/goal resume` is refused with the unchanged message `An evidence-limited Goal cannot be resumed; edit or replace the Goal first`. Then confirm the compatibility path: a Goal recovered from a transcript written before this change has no `limitKind` and must still be refused on the strength of its `lastReason` alone. Finally confirm that a `usage_limited` Goal stopped for an operational reason — one that maps to no `limitKind` — still resumes as it does today, and that `/goal edit` clears the field along with `lastReason`.

Automated coverage adds seven cases to the reducer suite: refusal driven by `limitKind` alone with a `lastReason` the guard no longer recognises, refusal driven by each of the two legacy sentinels with no `limitKind`, `limitKind` cleared by an edit, a round trip of each valid `limitKind` through `parseGoalSnapshotV2`, and rejection of a snapshot carrying an unknown `limitKind`. Two existing runtime tests now also assert that a catalog-exhaustion stop persists `limitKind: 'evidence_catalog'` beside the reason it already asserted. `npx vitest run packages/core/src/goals/` passes 364 tests across 15 files, and the CLI-side Goal suites (`restoreGoal`, `goalCommand`, `serve/routes/goals`) pass 133 tests. `npx tsc --noEmit` in `packages/core` reports only a pre-existing `sharp` typing error in `src/utils/image-view.ts` that reproduces identically on the unmodified head; `packages/cli` typechecks with no Goal-related error. `prettier` and `eslint` are clean on every changed file.

### Evidence (Before & After)

N/A — no user-visible change. The refused-resume message, the `usage_limited` status and the `lastReason` text are all unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, Node.js 22, unit tests only.

## Risk & Scope

- Main risk or tradeoff: this adds a second representation of one fact, so the two halves can drift. The mitigation is that only `goalLimitKindForReason` writes the new field and only the reducer reads it, and the legacy comparison stays as the fallback rather than being duplicated at new call sites.
- Not validated / out of scope: nothing yet consumes `limitKind` beyond the resume guard. The daemon and web-shell projections still expose `lastReason` only, and are deliberately untouched here. Windows and macOS were not exercised locally and remain covered by CI.
- Breaking changes / migration notes: none. `limitKind` is optional, absent on every existing persisted Goal, additive to the wire snapshot, and rejected by `parseGoalSnapshotV2` only when present and not one of the two enumerated values. Scope for the core triage gate: 72 added and 6 deleted production lines across three files in `packages/core/src/goals`, with no cross-package change.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`GoalRecord` 新增一个可选字段 `limitKind`，在运行时因两个枚举的证据上限之一而停止 Goal 的每个位置，都与 `lastReason` 一起写入；`reduceGoalResume` 现在读取该字段，而不再把 `lastReason` 与两个完整句子常量做比较。`lastReason` 文本保持不变，继续充当供人阅读的那一半。在该字段出现之前持久化的 Goal 仍然会被拒绝恢复——通过保留在新判断之后的哨兵字符串比较——因此从旧转录恢复的行为未变。本 PR 没有行为变化：同样的 Goal 可以恢复，同样的 Goal 被拒绝。

## 为什么需要

一个 `usage_limited` 的 Goal 能否恢复，目前由 `current.lastReason === GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON || current.lastReason === GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON` 决定——也就是把状态转移建立在散文之上。这让一个展示字符串在两个方向上承重。任何未来「抬高上限再恢复」的路径，都必须逐字节复现其中一句话，否则会在一个比较英文的守卫面前静默失败；而任何对这条用户可见文案的措辞改动，都会静默改变哪些 Goal 可以恢复。这两种失败在调用点都看不出来，也都不会被类型系统拦住。把机器可读的那一半和供人阅读的那一半分开，就同时消除了这两个隐患，并让守卫说出它真正的意思。

这本身不是一个修复，而是铺路：它是证据目录抢救与恢复工作的前置条件，也是任何「用户可以抬高的预算」的前置条件——它们都需要根据 Goal 因何停止来分支。

## 评审者测试计划

### 如何验证

确认守卫在两个方向上仍然拒绝。运行时停止的 Goal 现在会携带 `limitKind`，所以把一个 Goal 推进到 checkpoint 耗尽而停止，确认 `/goal resume` 仍以未变的文案 `An evidence-limited Goal cannot be resumed; edit or replace the Goal first` 被拒绝。然后确认兼容路径：从本次改动之前写入的转录中恢复的 Goal 没有 `limitKind`，必须仅凭其 `lastReason` 仍被拒绝。最后确认：因操作性原因（不映射到任何 `limitKind`）而 `usage_limited` 的 Goal 仍像今天一样可以恢复，并且 `/goal edit` 会把该字段连同 `lastReason` 一起清除。

自动化覆盖在 reducer 套件中新增七个用例：仅凭 `limitKind` 触发的拒绝（其 `lastReason` 是守卫不再识别的文本）、仅凭两个旧哨兵各自触发的拒绝（无 `limitKind`）、编辑后 `limitKind` 被清除、两个合法 `limitKind` 各自经 `parseGoalSnapshotV2` 的往返、以及携带未知 `limitKind` 的快照被拒绝。另有两个既有的 runtime 测试，现在在其原本断言的原因之外，同时断言目录耗尽停止会持久化 `limitKind: 'evidence_catalog'`。`npx vitest run packages/core/src/goals/` 通过 15 个文件共 364 个测试，CLI 侧的 Goal 套件（`restoreGoal`、`goalCommand`、`serve/routes/goals`）通过 133 个测试。`packages/core` 下 `npx tsc --noEmit` 只报告 `src/utils/image-view.ts` 中一个预先存在的 `sharp` 类型错误，该错误在未修改的 head 上可原样复现；`packages/cli` 的类型检查没有任何与 Goal 相关的错误。所有改动文件的 `prettier` 与 `eslint` 均干净。

### 证据（修复前后）

N/A —— 无用户可见变化。拒绝恢复的文案、`usage_limited` 状态和 `lastReason` 文本全部未变。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Linux、Node.js 22，仅单元测试。

## 风险与范围

- 主要风险或取舍：这为同一个事实引入了第二种表示，两半之间可能漂移。缓解方式是：只有 `goalLimitKindForReason` 写入新字段，只有 reducer 读取它，并且旧的字符串比较作为回退保留，而不是在新的调用点上被复制。
- 未验证/不在范围：除恢复守卫外，目前还没有任何地方消费 `limitKind`。daemon 与 web-shell 的投影仍然只暴露 `lastReason`，本 PR 有意不去触碰。Windows 和 macOS 未在本地验证，仍由 CI 覆盖。
- 破坏性变更/迁移说明：无。`limitKind` 是可选字段，在所有既有持久化 Goal 上都不存在，对 wire 快照是纯新增，并且仅在它存在且不属于两个枚举值之一时才会被 `parseGoalSnapshotV2` 拒绝。供 core triage gate 参考的规模：`packages/core/src/goals` 下三个文件，新增 72 行、删除 6 行生产代码，无跨包改动。

## 关联 Issue

无。

</details>
