### PR TITLE
feat(dingtalk): support outbound file delivery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28276,9 +28276,11 @@
       "version": "0.21.11",
       "dependencies": {
         "@qwen-code/channel-base": "0.21.11",
-        "dingtalk-stream-sdk-nodejs": "^2.0.4"
+        "dingtalk-stream-sdk-nodejs": "^2.0.4",
+        "markdown-it": "^14.2.0"
       },
       "devDependencies": {
+        "@types/markdown-it": "^14.1.2",
         "typescript": "^5.0.0"
       }
     },

--- a/packages/channels/base/src/BlockStreamer.ts
+++ b/packages/channels/base/src/BlockStreamer.ts
@@ -66,6 +66,11 @@ export class BlockStreamer {
     this.buffer = '';
   }
 
+  /** Await sends that were queued before this call. */
+  drain(): Promise<void> {
+    return this.sending;
+  }
+
   // ---------------------------------------------------------------------------
   // Internal
   // ---------------------------------------------------------------------------

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -13597,6 +13597,64 @@ describe('ChannelBase', () => {
       expect(ch.sent.map((message) => message.text)).toEqual(['final']);
     });
 
+    it('drains queued block sends before notifying a response boundary', async () => {
+      let releaseFirst!: () => void;
+      const firstSend = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const order: string[] = [];
+      class BoundaryDrainChannel extends TestChannel {
+        protected override async sendResponseMessage(
+          _chatId: string,
+          text: string,
+          _sessionId: string,
+        ): Promise<void> {
+          order.push(`send:${text}:start`);
+          if (text === 'first') await firstSend;
+          order.push(`send:${text}:end`);
+        }
+
+        protected override onResponseBoundary(): void {
+          order.push('boundary');
+        }
+      }
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+        (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'textChunk',
+            sid,
+            'first\n\n',
+          );
+          (bridge as unknown as EventEmitter).emit('responseBoundary', sid);
+          (bridge as unknown as EventEmitter).emit('textChunk', sid, 'second');
+          return Promise.resolve('second');
+        },
+      );
+      const ch = new BoundaryDrainChannel(
+        'test-chan',
+        defaultConfig({
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+
+      const running = ch.handleInbound(envelope());
+      await vi.waitFor(() => expect(order).toContain('send:first:start'));
+      expect(order).not.toContain('boundary');
+      releaseFirst();
+      await running;
+
+      expect(order).toEqual([
+        'send:first:start',
+        'send:first:end',
+        'boundary',
+        'send:second:start',
+        'send:second:end',
+      ]);
+    });
+
     it('preserves held chunks when response boundary fires during cancel', async () => {
       let resolvePrompt!: (v: string) => void;
       let rejectCancel!: (e: Error) => void;

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -13711,6 +13711,191 @@ describe('ChannelBase', () => {
       ]);
     });
 
+    it('ends a segment as cancelled when steer races the final flush', async () => {
+      let releaseFirstSend!: () => void;
+      const firstSend = new Promise<void>((resolve) => {
+        releaseFirstSend = resolve;
+      });
+      const reasons: ChannelOutputSegmentEndReason[] = [];
+      let sendCount = 0;
+      class FinalFlushRaceChannel extends TestChannel {
+        protected override async sendResponseMessage(): Promise<void> {
+          if (sendCount++ === 0) await firstSend;
+        }
+
+        protected override onOutputSegmentEnd(
+          _chatId: string,
+          _sessionId: string,
+          _segment: ChannelOutputSegmentContext,
+          reason: ChannelOutputSegmentEndReason,
+        ): void {
+          reasons.push(reason);
+        }
+      }
+      (bridge.prompt as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce((sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'textChunk',
+            sid,
+            'first\n\n',
+          );
+          return Promise.resolve('first');
+        })
+        .mockResolvedValueOnce('second');
+      const ch = new FinalFlushRaceChannel(
+        'test-chan',
+        defaultConfig({
+          dispatchMode: 'steer',
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+
+      const first = ch.handleInbound(envelope({ messageId: 'first' }));
+      await vi.waitFor(() => expect(sendCount).toBe(1));
+      const second = ch.handleInbound(envelope({ text: 'replacement' }));
+      await vi.waitFor(() => expect(bridge.cancelSession).toHaveBeenCalled());
+      releaseFirstSend();
+      await first;
+      await second;
+
+      expect(reasons).toEqual(['cancelled']);
+      expect(
+        ch.taskEvents
+          .filter(
+            (event) =>
+              event.messageId === 'first' &&
+              (event.type === 'cancelled' || event.type === 'completed'),
+          )
+          .map((event) => event.type),
+      ).toEqual(['cancelled']);
+    });
+
+    it('marks a drained response boundary as cancelled after steer', async () => {
+      let releaseSend!: () => void;
+      let resolveFirst!: (value: string) => void;
+      const pendingSend = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
+      const firstPrompt = new Promise<string>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const reasons: ChannelOutputSegmentEndReason[] = [];
+      class BoundaryCancelRaceChannel extends TestChannel {
+        protected override async sendResponseMessage(): Promise<void> {
+          await pendingSend;
+        }
+
+        protected override onOutputSegmentEnd(
+          _chatId: string,
+          _sessionId: string,
+          _segment: ChannelOutputSegmentContext,
+          reason: ChannelOutputSegmentEndReason,
+        ): void {
+          reasons.push(reason);
+        }
+      }
+      (bridge.prompt as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce((sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'textChunk',
+            sid,
+            'first\n\n',
+          );
+          (bridge as unknown as EventEmitter).emit('responseBoundary', sid);
+          return firstPrompt;
+        })
+        .mockResolvedValueOnce('second');
+      (bridge.cancelSession as ReturnType<typeof vi.fn>).mockImplementation(
+        () => {
+          resolveFirst('late');
+          return Promise.resolve();
+        },
+      );
+      const ch = new BoundaryCancelRaceChannel(
+        'test-chan',
+        defaultConfig({
+          dispatchMode: 'steer',
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+
+      const first = ch.handleInbound(envelope({ messageId: 'first' }));
+      await vi.waitFor(() => expect(bridge.prompt).toHaveBeenCalledOnce());
+      const second = ch.handleInbound(envelope({ text: 'replacement' }));
+      releaseSend();
+      await first;
+      await second;
+
+      expect(reasons[0]).toBe('cancelled');
+      expect(reasons).not.toContain('response_boundary');
+    });
+
+    it('does not complete after steer settles during segment notification', async () => {
+      let releaseNotification!: () => void;
+      const notification = new Promise<void>((resolve) => {
+        releaseNotification = resolve;
+      });
+      let notificationStarted = false;
+      class TerminalNotifyRaceChannel extends TestChannel {
+        protected override async onOutputSegmentEnd(
+          _chatId: string,
+          _sessionId: string,
+          _segment: ChannelOutputSegmentContext,
+          reason: ChannelOutputSegmentEndReason,
+        ): Promise<void> {
+          if (reason === 'completed' && !notificationStarted) {
+            notificationStarted = true;
+            await notification;
+          }
+        }
+      }
+      (bridge.prompt as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce((sid: string) => {
+          (bridge as unknown as EventEmitter).emit('textChunk', sid, 'first');
+          return Promise.resolve('first');
+        })
+        .mockResolvedValueOnce('second');
+      const ch = new TerminalNotifyRaceChannel(
+        'test-chan',
+        defaultConfig({
+          dispatchMode: 'steer',
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+
+      const first = ch.handleInbound(envelope({ messageId: 'first' }));
+      await vi.waitFor(() => expect(notificationStarted).toBe(true));
+      const second = ch.handleInbound(envelope({ text: 'replacement' }));
+      await vi.waitFor(() =>
+        expect(
+          ch.taskEvents.some(
+            (event) =>
+              event.type === 'cancelled' && event.messageId === 'first',
+          ),
+        ).toBe(true),
+      );
+      releaseNotification();
+      await first;
+      await second;
+
+      expect(
+        ch.taskEvents.filter(
+          (event) =>
+            event.messageId === 'first' &&
+            (event.type === 'cancelled' || event.type === 'completed'),
+        ),
+      ).toEqual([expect.objectContaining({ type: 'cancelled' })]);
+    });
+
     it('flushes idle-buffered block text before a failed segment and prompt end', async () => {
       let releaseSend!: () => void;
       const pendingSend = new Promise<void>((resolve) => {

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -13995,7 +13995,7 @@ describe('ChannelBase', () => {
       await expect(ch.cancelPromptForTest('s-1')).resolves.toBe(true);
       releaseSend();
 
-      await expect(running).rejects.toThrow('agent failed');
+      await running;
       expect(
         ch.taskEvents.filter((event) => event.type === 'cancelled'),
       ).toHaveLength(1);

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -1621,6 +1621,64 @@ describe('ChannelBase', () => {
       await active.finish();
     });
 
+    it('drains queued block sends before presenting user input', async () => {
+      let releaseSend!: () => void;
+      const pendingSend = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
+      const order: string[] = [];
+      class InputDrainChannel extends TestChannel {
+        protected override async sendResponseMessage(): Promise<void> {
+          order.push('send:start');
+          await pendingSend;
+          order.push('send:end');
+        }
+
+        protected override onOutputSegmentEnd(
+          _chatId: string,
+          _sessionId: string,
+          _segment: ChannelOutputSegmentContext,
+          reason: ChannelOutputSegmentEndReason,
+        ): void {
+          order.push(`segment:${reason}`);
+        }
+      }
+      const ch = new InputDrainChannel(
+        'test-chan',
+        defaultConfig({
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+      ch.userInputPresentationHandler = async () => {
+        order.push('present');
+        return { kind: 'presented' };
+      };
+      const active = await startActiveSession(ch);
+
+      (bridge as unknown as EventEmitter).emit(
+        'textChunk',
+        active.sessionId,
+        'first\n\n',
+      );
+      await vi.waitFor(() => expect(order).toContain('send:start'));
+      emitUserQuestion(active.sessionId, 'req-after-block');
+      await Promise.resolve();
+      expect(order).toEqual(['send:start']);
+      releaseSend();
+      await vi.waitFor(() => expect(ch.userInputPresentations).toHaveLength(1));
+
+      expect(order).toEqual([
+        'send:start',
+        'send:end',
+        'segment:input_requested',
+        'present',
+      ]);
+      await active.finish();
+    });
+
     it('presents identified legacy user input from rawInput questions', async () => {
       const ch = createChannel();
       ch.userInputPresentationResult = { kind: 'presented' };
@@ -13652,6 +13710,133 @@ describe('ChannelBase', () => {
         'boundary',
         'send:second:start',
         'send:second:end',
+      ]);
+    });
+
+    it('drains queued block sends before a failed segment and prompt end', async () => {
+      let releaseSend!: () => void;
+      const pendingSend = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
+      const order: string[] = [];
+      class FailedDrainChannel extends TestChannel {
+        protected override async sendResponseMessage(): Promise<void> {
+          order.push('send:start');
+          await pendingSend;
+          order.push('send:end');
+        }
+
+        protected override onOutputSegmentEnd(
+          _chatId: string,
+          _sessionId: string,
+          _segment: ChannelOutputSegmentContext,
+          reason: ChannelOutputSegmentEndReason,
+        ): void {
+          order.push(`segment:${reason}`);
+        }
+
+        protected override onPromptEnd(): void {
+          order.push('prompt:end');
+        }
+      }
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+        (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'textChunk',
+            sid,
+            'first\n\n',
+          );
+          return Promise.reject(new Error('agent failed'));
+        },
+      );
+      const ch = new FailedDrainChannel(
+        'test-chan',
+        defaultConfig({
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+
+      const running = ch.handleInbound(envelope());
+      await vi.waitFor(() => expect(order).toContain('send:start'));
+      expect(order).toEqual(['send:start']);
+      releaseSend();
+      await expect(running).rejects.toThrow('agent failed');
+
+      expect(order).toEqual([
+        'send:start',
+        'send:end',
+        'segment:failed',
+        'prompt:end',
+      ]);
+    });
+
+    it('drains queued block sends before a cancelled segment and prompt end', async () => {
+      let releaseSend!: () => void;
+      let finishPrompt!: (value: string) => void;
+      const pendingSend = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
+      const pendingPrompt = new Promise<string>((resolve) => {
+        finishPrompt = resolve;
+      });
+      const order: string[] = [];
+      class CancelledDrainChannel extends TestChannel {
+        protected override async sendResponseMessage(): Promise<void> {
+          order.push('send:start');
+          await pendingSend;
+          order.push('send:end');
+        }
+
+        protected override onOutputSegmentEnd(
+          _chatId: string,
+          _sessionId: string,
+          _segment: ChannelOutputSegmentContext,
+          reason: ChannelOutputSegmentEndReason,
+        ): void {
+          order.push(`segment:${reason}`);
+        }
+
+        protected override onPromptEnd(): void {
+          order.push('prompt:end');
+        }
+      }
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+        (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'textChunk',
+            sid,
+            'first\n\n',
+          );
+          return pendingPrompt;
+        },
+      );
+      const ch = new CancelledDrainChannel(
+        'test-chan',
+        defaultConfig({
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+
+      const running = ch.handleInbound(envelope());
+      await vi.waitFor(() => expect(order).toContain('send:start'));
+      await expect(ch.cancelPromptForTest('s-1')).resolves.toBe(true);
+      finishPrompt('ignored');
+      await Promise.resolve();
+      expect(order).toEqual(['send:start']);
+      releaseSend();
+      await running;
+
+      expect(order).toEqual([
+        'send:start',
+        'send:end',
+        'segment:cancelled',
+        'prompt:end',
       ]);
     });
 

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -1621,7 +1621,7 @@ describe('ChannelBase', () => {
       await active.finish();
     });
 
-    it('drains queued block sends before presenting user input', async () => {
+    it('flushes idle-buffered block text before presenting user input', async () => {
       let releaseSend!: () => void;
       const pendingSend = new Promise<void>((resolve) => {
         releaseSend = resolve;
@@ -1647,8 +1647,8 @@ describe('ChannelBase', () => {
         'test-chan',
         defaultConfig({
           blockStreaming: 'on',
-          blockStreamingChunk: { minChars: 1, maxChars: 100 },
-          blockStreamingCoalesce: { idleMs: 0 },
+          blockStreamingChunk: { minChars: 400, maxChars: 1000 },
+          blockStreamingCoalesce: { idleMs: 1500 },
         }),
         bridge,
       );
@@ -1661,12 +1661,10 @@ describe('ChannelBase', () => {
       (bridge as unknown as EventEmitter).emit(
         'textChunk',
         active.sessionId,
-        'first\n\n',
+        'x'.repeat(400),
       );
-      await vi.waitFor(() => expect(order).toContain('send:start'));
       emitUserQuestion(active.sessionId, 'req-after-block');
-      await Promise.resolve();
-      expect(order).toEqual(['send:start']);
+      await vi.waitFor(() => expect(order).toEqual(['send:start']));
       releaseSend();
       await vi.waitFor(() => expect(ch.userInputPresentations).toHaveLength(1));
 
@@ -13713,7 +13711,7 @@ describe('ChannelBase', () => {
       ]);
     });
 
-    it('drains queued block sends before a failed segment and prompt end', async () => {
+    it('flushes idle-buffered block text before a failed segment and prompt end', async () => {
       let releaseSend!: () => void;
       const pendingSend = new Promise<void>((resolve) => {
         releaseSend = resolve;
@@ -13744,7 +13742,7 @@ describe('ChannelBase', () => {
           (bridge as unknown as EventEmitter).emit(
             'textChunk',
             sid,
-            'first\n\n',
+            'x'.repeat(400),
           );
           return Promise.reject(new Error('agent failed'));
         },
@@ -13753,8 +13751,8 @@ describe('ChannelBase', () => {
         'test-chan',
         defaultConfig({
           blockStreaming: 'on',
-          blockStreamingChunk: { minChars: 1, maxChars: 100 },
-          blockStreamingCoalesce: { idleMs: 0 },
+          blockStreamingChunk: { minChars: 400, maxChars: 1000 },
+          blockStreamingCoalesce: { idleMs: 1500 },
         }),
         bridge,
       );
@@ -13771,6 +13769,54 @@ describe('ChannelBase', () => {
         'segment:failed',
         'prompt:end',
       ]);
+    });
+
+    it('does not emit failed when cancellation settles during the delivery drain', async () => {
+      let releaseSend!: () => void;
+      const pendingSend = new Promise<void>((resolve) => {
+        releaseSend = resolve;
+      });
+      class FailedCancelRaceChannel extends TestChannel {
+        protected override async sendResponseMessage(): Promise<void> {
+          await pendingSend;
+        }
+      }
+      (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(
+        (sid: string) => {
+          (bridge as unknown as EventEmitter).emit(
+            'textChunk',
+            sid,
+            'first\n\n',
+          );
+          return Promise.reject(new Error('agent failed'));
+        },
+      );
+      const ch = new FailedCancelRaceChannel(
+        'test-chan',
+        defaultConfig({
+          blockStreaming: 'on',
+          blockStreamingChunk: { minChars: 1, maxChars: 100 },
+          blockStreamingCoalesce: { idleMs: 0 },
+        }),
+        bridge,
+      );
+
+      const running = ch.handleInbound(envelope());
+      await vi.waitFor(() =>
+        expect(ch.taskEvents.some((event) => event.type === 'text_chunk')).toBe(
+          true,
+        ),
+      );
+      await expect(ch.cancelPromptForTest('s-1')).resolves.toBe(true);
+      releaseSend();
+
+      await expect(running).rejects.toThrow('agent failed');
+      expect(
+        ch.taskEvents.filter((event) => event.type === 'cancelled'),
+      ).toHaveLength(1);
+      expect(ch.taskEvents.some((event) => event.type === 'failed')).toBe(
+        false,
+      );
     });
 
     it('drains queued block sends before a cancelled segment and prompt end', async () => {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -5791,7 +5791,7 @@ export abstract class ChannelBase {
             `[${channel}] turn ${safeMessageId} threw after cancellation for session ${safeSessionId}: ${this.lifecycleError(err)}\n`,
           );
         }
-        if (cancelledBeforeFailure) {
+        if (promptState.cancelled || promptState.cancellationEmitted) {
           return;
         }
         throw err;

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -514,7 +514,7 @@ export abstract class ChannelBase {
       await this.pushProactive(target, text);
       return;
     }
-    await this.sendResponseMessage(target.chatId, text, sessionId);
+    await this.sendOneShotResponseMessage(target.chatId, text, sessionId);
   }
 
   async dispatchPermissionRequest(
@@ -2389,6 +2389,14 @@ export abstract class ChannelBase {
     const target = this.router.getTarget(sessionId);
     const threadId = active?.threadId ?? target?.threadId;
     await this.sendThreadMessage(chatId, threadId, text);
+  }
+
+  protected async sendOneShotResponseMessage(
+    chatId: string,
+    text: string,
+    sessionId: string,
+  ): Promise<void> {
+    await this.sendResponseMessage(chatId, text, sessionId);
   }
 
   /**
@@ -5638,13 +5646,17 @@ export abstract class ChannelBase {
         heldChunks.length = 0;
         hasStreamedText = false;
         const segment = this.closeOutputSegment(sessionId, promptState);
-        void this.notifyOutputSegmentEnd(
-          envelope.chatId,
-          sessionId,
-          segment,
-          'response_boundary',
-        );
         streamer?.stop();
+        const pendingSends = streamer?.drain();
+        void (async () => {
+          await pendingSends;
+          await this.notifyOutputSegmentEnd(
+            envelope.chatId,
+            sessionId,
+            segment,
+            'response_boundary',
+          );
+        })();
       };
       // Queue wait and memory recall can outlive a bridge crash. Capture the
       // bridge only after the latest recovery has restored session routing.

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -5680,7 +5680,9 @@ export abstract class ChannelBase {
             envelope.chatId,
             sessionId,
             segment,
-            'response_boundary',
+            promptState.cancelled || promptState.cancellationEmitted
+              ? 'cancelled'
+              : 'response_boundary',
           );
         })();
       };
@@ -5730,15 +5732,16 @@ export abstract class ChannelBase {
           await this.settleCancelRequested(promptState);
         }
         if (!promptState.cancelled && !promptState.cancellationEmitted) {
-          const segment = this.closeOutputSegment(sessionId, promptState);
           await streamer?.flush();
           if (promptState.cancelled || promptState.cancellationEmitted) return;
+          const segment = this.closeOutputSegment(sessionId, promptState);
           await this.notifyOutputSegmentEnd(
             envelope.chatId,
             sessionId,
             segment,
             'completed',
           );
+          if (promptState.cancelled || promptState.cancellationEmitted) return;
           this.emitTaskLifecycle({
             ...this.lifecycleBase(
               envelope.chatId,
@@ -5758,25 +5761,27 @@ export abstract class ChannelBase {
         const cancelledBeforeFailure = promptState.cancelled;
         if (!cancelledBeforeFailure) {
           releaseHeldChunks();
-          const segment = this.closeOutputSegment(sessionId, promptState);
           await streamer?.flush();
           if (!promptState.cancelled && !promptState.cancellationEmitted) {
+            const segment = this.closeOutputSegment(sessionId, promptState);
             await this.notifyOutputSegmentEnd(
               envelope.chatId,
               sessionId,
               segment,
               'failed',
             );
-            this.emitTaskLifecycle({
-              ...this.lifecycleBase(
-                envelope.chatId,
-                sessionId,
-                envelope.messageId,
-              ),
-              type: 'failed',
-              error: this.lifecycleError(err),
-              phase: promptState.deliveryStarted ? 'delivery' : 'agent',
-            });
+            if (!promptState.cancelled && !promptState.cancellationEmitted) {
+              this.emitTaskLifecycle({
+                ...this.lifecycleBase(
+                  envelope.chatId,
+                  sessionId,
+                  envelope.messageId,
+                ),
+                type: 'failed',
+                error: this.lifecycleError(err),
+                phase: promptState.deliveryStarted ? 'delivery' : 'agent',
+              });
+            }
           }
         } else {
           const channel = sanitizeLogText(this.name, 64);

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -5627,7 +5627,7 @@ export abstract class ChannelBase {
         : null;
       if (streamer) {
         promptState.stopStreaming = () => streamer.stop();
-        promptState.drainStreaming = () => streamer.drain();
+        promptState.drainStreaming = () => streamer.flush();
       }
 
       // Chunks arriving while a cancel is PENDING are held here: pushing them
@@ -5731,7 +5731,8 @@ export abstract class ChannelBase {
         }
         if (!promptState.cancelled && !promptState.cancellationEmitted) {
           const segment = this.closeOutputSegment(sessionId, promptState);
-          await streamer?.drain();
+          await streamer?.flush();
+          if (promptState.cancelled || promptState.cancellationEmitted) return;
           await this.notifyOutputSegmentEnd(
             envelope.chatId,
             sessionId,
@@ -5754,26 +5755,29 @@ export abstract class ChannelBase {
         if (!promptState.deliveryStarted) {
           await this.settleCancelRequested(promptState);
         }
-        if (!promptState.cancelled) {
+        const cancelledBeforeFailure = promptState.cancelled;
+        if (!cancelledBeforeFailure) {
           releaseHeldChunks();
           const segment = this.closeOutputSegment(sessionId, promptState);
-          await streamer?.drain();
-          await this.notifyOutputSegmentEnd(
-            envelope.chatId,
-            sessionId,
-            segment,
-            'failed',
-          );
-          this.emitTaskLifecycle({
-            ...this.lifecycleBase(
+          await streamer?.flush();
+          if (!promptState.cancelled && !promptState.cancellationEmitted) {
+            await this.notifyOutputSegmentEnd(
               envelope.chatId,
               sessionId,
-              envelope.messageId,
-            ),
-            type: 'failed',
-            error: this.lifecycleError(err),
-            phase: promptState.deliveryStarted ? 'delivery' : 'agent',
-          });
+              segment,
+              'failed',
+            );
+            this.emitTaskLifecycle({
+              ...this.lifecycleBase(
+                envelope.chatId,
+                sessionId,
+                envelope.messageId,
+              ),
+              type: 'failed',
+              error: this.lifecycleError(err),
+              phase: promptState.deliveryStarted ? 'delivery' : 'agent',
+            });
+          }
         } else {
           const channel = sanitizeLogText(this.name, 64);
           const safeSessionId = sanitizeLogText(sessionId, 64);
@@ -5782,7 +5786,7 @@ export abstract class ChannelBase {
             `[${channel}] turn ${safeMessageId} threw after cancellation for session ${safeSessionId}: ${this.lifecycleError(err)}\n`,
           );
         }
-        if (promptState.cancelled) {
+        if (cancelledBeforeFailure) {
           return;
         }
         throw err;

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -296,6 +296,8 @@ type ActivePrompt = {
   done: Promise<void>;
   resolve: () => void;
   stopStreaming?: () => void;
+  drainStreaming?: () => Promise<void>;
+  terminalDelivery?: Promise<void>;
   /** The originating turn's chat/message, so a clear-time eviction can run this
    * turn's own onPromptEnd (its finally may settle long after — or never). */
   chatId: string;
@@ -628,6 +630,7 @@ export abstract class ChannelBase {
     return (async () => {
       try {
         if (precedingSegment) {
+          await active.drainStreaming?.();
           await this.notifyOutputSegmentEnd(
             pending.target.chatId,
             pending.sessionId,
@@ -947,17 +950,37 @@ export abstract class ChannelBase {
     }
     active.cancellationEmitted = true;
     const segment = this.closeOutputSegment(sessionId, active);
-    void this.notifyOutputSegmentEnd(
-      active.chatId,
-      sessionId,
-      segment,
-      'cancelled',
-    );
-    this.emitTaskLifecycle({
-      ...this.lifecycleBase(active.chatId, sessionId, active.messageId),
-      type: 'cancelled',
-      reason,
-    });
+    const drainStreaming = active.drainStreaming;
+    if (!drainStreaming) {
+      void this.notifyOutputSegmentEnd(
+        active.chatId,
+        sessionId,
+        segment,
+        'cancelled',
+      );
+      this.emitTaskLifecycle({
+        ...this.lifecycleBase(active.chatId, sessionId, active.messageId),
+        type: 'cancelled',
+        reason,
+      });
+      return;
+    }
+    const terminalDelivery = (async () => {
+      await drainStreaming();
+      await this.notifyOutputSegmentEnd(
+        active.chatId,
+        sessionId,
+        segment,
+        'cancelled',
+      );
+      this.emitTaskLifecycle({
+        ...this.lifecycleBase(active.chatId, sessionId, active.messageId),
+        type: 'cancelled',
+        reason,
+      });
+    })();
+    active.terminalDelivery = terminalDelivery;
+    void terminalDelivery;
   }
 
   private resolveIdentity(
@@ -5602,7 +5625,10 @@ export abstract class ChannelBase {
               this.sendResponseMessage(envelope.chatId, text, sessionId),
           })
         : null;
-      promptState.stopStreaming = () => streamer?.stop();
+      if (streamer) {
+        promptState.stopStreaming = () => streamer.stop();
+        promptState.drainStreaming = () => streamer.drain();
+      }
 
       // Chunks arriving while a cancel is PENDING are held here: pushing them
       // to any visible sink could send output the cancel can't recall. On a
@@ -5705,7 +5731,8 @@ export abstract class ChannelBase {
         }
         if (!promptState.cancelled && !promptState.cancellationEmitted) {
           const segment = this.closeOutputSegment(sessionId, promptState);
-          void this.notifyOutputSegmentEnd(
+          await streamer?.drain();
+          await this.notifyOutputSegmentEnd(
             envelope.chatId,
             sessionId,
             segment,
@@ -5730,7 +5757,8 @@ export abstract class ChannelBase {
         if (!promptState.cancelled) {
           releaseHeldChunks();
           const segment = this.closeOutputSegment(sessionId, promptState);
-          void this.notifyOutputSegmentEnd(
+          await streamer?.drain();
+          await this.notifyOutputSegmentEnd(
             envelope.chatId,
             sessionId,
             segment,
@@ -5762,6 +5790,7 @@ export abstract class ChannelBase {
         promptBridge.off('textChunk', onChunk);
         promptBridge.off('responseBoundary', onResponseBoundary);
         streamer?.stop();
+        await promptState.terminalDelivery;
         // Identity guard: a turn that wedged past /clear's bounded wait gets
         // EVICTED — /clear gives up on active.done, deletes activePrompts, and a
         // turn the user starts AFTER the clear can re-seed activePrompts (and own

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -21,9 +21,11 @@
   },
   "dependencies": {
     "@qwen-code/channel-base": "0.21.11",
-    "dingtalk-stream-sdk-nodejs": "^2.0.4"
+    "dingtalk-stream-sdk-nodejs": "^2.0.4",
+    "markdown-it": "^14.2.0"
   },
   "devDependencies": {
+    "@types/markdown-it": "^14.1.2",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -784,6 +784,15 @@ function getResponseHook(
   return fn.bind(channel);
 }
 
+function getOneShotResponseHook(
+  channel: DingtalkChannelInstance,
+): (chatId: string, text: string, sessionId: string) => Promise<void> {
+  const fn = (channel as unknown as Record<string, unknown>)[
+    'sendOneShotResponseMessage'
+  ] as (chatId: string, text: string, sessionId: string) => Promise<void>;
+  return fn.bind(channel);
+}
+
 function getPromptBufferDropHook(
   channel: DingtalkChannelInstance,
 ): (chatId: string, sessionId: string, messageIds: string[]) => void {
@@ -4120,6 +4129,33 @@ describe('DingtalkChannel outbound file delivery', () => {
     }
   });
 
+  it('reassembles a file marker split immediately after its opening bracket', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ blockStreaming: 'on', cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await getResponseHook(channel)('cid123', '行为字[', 'session-1');
+      await getResponseHook(channel)(
+        'cid123',
+        `FILE: ${file.path}] 已完成。`,
+        'session-1',
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const markdown = markdownCalls()
+        .map((call) => JSON.parse(String((call[1] as RequestInit).body)))
+        .map((body) => String(body.markdown.text))
+        .join('\n');
+      expect(markdown).toContain('[File sent: report.txt] 已完成。');
+      expect(markdown).not.toContain(file.path);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
   it('reports an incomplete file marker when block streaming ends', async () => {
     const channel = createChannel({ blockStreaming: 'on' });
     seedWebhook(channel, 'cid123');
@@ -4153,6 +4189,88 @@ describe('DingtalkChannel outbound file delivery', () => {
     expect(body.markdown.text).toBe(
       '[File delivery failed: incomplete marker]',
     );
+  });
+
+  it('flushes a partial marker before resuming after an input request', async () => {
+    const channel = createChannel({ blockStreaming: 'on' });
+    seedWebhook(channel, 'cid123');
+    const { markdownCalls } = stubFileReplyFetch();
+    const segment = {
+      channelName: 'dingtalk',
+      sessionId: 'session-1',
+      runId: 'run-1',
+      segmentId: 'segment-1',
+      owner: { kind: 'channel_user', id: 'owner-1' },
+      target: {
+        channelName: 'dingtalk',
+        chatId: 'cid123',
+        senderId: 'owner-1',
+        isGroup: true,
+      },
+    } as ChannelOutputSegmentContext;
+
+    await getResponseHook(channel)(
+      'cid123',
+      'Answer follows. [FILE:',
+      'session-1',
+    );
+    await getOutputSegmentEndHook(channel)(
+      'cid123',
+      'session-1',
+      segment,
+      'input_requested',
+    );
+    await getResponseHook(channel)(
+      'cid123',
+      'The result is 42.\nDone.',
+      'session-1',
+    );
+
+    const bodies = markdownCalls().map((call) =>
+      String(
+        (
+          JSON.parse(String((call[1] as RequestInit).body)) as {
+            markdown: { text: string };
+          }
+        ).markdown.text,
+      ),
+    );
+    expect(bodies).toEqual([
+      'Answer follows. ',
+      '[File delivery failed: incomplete marker]',
+      'The result is 42.\nDone.',
+    ]);
+  });
+
+  it('flushes each one-shot partial marker without poisoning the next response', async () => {
+    const channel = createChannel({ blockStreaming: 'on' });
+    seedWebhook(channel, 'cid123');
+    const { markdownCalls } = stubFileReplyFetch();
+
+    await getOneShotResponseHook(channel)(
+      'cid123',
+      'Report attached. [FILE: /tmp/report.pdf',
+      'session-1',
+    );
+    await getOneShotResponseHook(channel)(
+      'cid123',
+      'Next answer.',
+      'session-1',
+    );
+
+    const bodies = markdownCalls().map(
+      (call) =>
+        (
+          JSON.parse(String((call[1] as RequestInit).body)) as {
+            markdown: { text: string };
+          }
+        ).markdown.text,
+    );
+    expect(bodies).toEqual([
+      'Report attached. ',
+      '[File delivery failed: incomplete marker]',
+      'Next answer.',
+    ]);
   });
 
   it('does not upload a file when the reply webhook is unavailable', async () => {
@@ -4241,6 +4359,79 @@ describe('DingtalkChannel outbound file delivery', () => {
       expect(markdownBody.markdown.text).toContain('[File sent: report.txt]');
       expect(markdownBody.markdown.text).not.toContain('/tmp/private-chart');
       expect(markdownBody.markdown.text).not.toContain(file.path);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes an abandoned file marker before processing an inner image marker', async () => {
+    const channel = createChannel();
+    seedWebhook(channel, 'cid123');
+    const { markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+    await channel.sendMessage('cid123', 'x [FILE: /a.pdf [IMAGE: /b.png');
+    await channel.sendMessage(
+      'cid123',
+      'See [FILE: draft and [IMAGE: /tmp/a.png] here',
+    );
+
+    expect(uploadCalls()).toHaveLength(0);
+    const markdown = markdownCalls()
+      .map((call) => JSON.parse(String((call[1] as RequestInit).body)))
+      .map((body) => String(body.markdown.text));
+    expect(markdown[0]).toBe('x [Image pending]');
+    expect(markdown[1]).not.toContain('[FILE:');
+    expect(markdown[1]).not.toContain('draft and');
+  });
+
+  it.each([
+    ['IMAGE', '[Image pending]'],
+    ['FILE', ''],
+  ] as const)(
+    'scrubs complete %s marker paths inside Markdown code',
+    async (markerName, replacement) => {
+      const channel = createChannel();
+      seedWebhook(channel, 'cid123');
+      const { markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `Log:\n\`\`\`\n[${markerName}: /Users/ben/private/leak.dat]\n\`\`\`\ndone`,
+      );
+
+      expect(uploadCalls()).toHaveLength(0);
+      const markdown = (
+        JSON.parse(String((markdownCalls()[0]![1] as RequestInit).body)) as {
+          markdown: { text: string };
+        }
+      ).markdown.text;
+      expect(markdown).toContain(`\`\`\`\n${replacement}\n\`\`\``);
+      expect(markdown).not.toContain('/Users/ben/private');
+    },
+  );
+
+  it('scrubs an outer file marker exposed by nested file replacement', async () => {
+    const file = createTempFile('inner.txt');
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `Report attached [FILE: /Users/ben/private/report [FILE: ${file.path}] notes.pdf] done`,
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const markdown = (
+        JSON.parse(String((markdownCalls()[0]![1] as RequestInit).body)) as {
+          markdown: { text: string };
+        }
+      ).markdown.text;
+      expect(markdown).not.toContain('[FILE:');
+      expect(markdown).not.toContain('/Users/ben/private');
+      expect(markdown).not.toContain(file.path);
     } finally {
       rmSync(file.dir, { recursive: true, force: true });
     }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -39,6 +39,16 @@ function createTempPng(): { dir: string; path: string } {
   return { dir, path };
 }
 
+function createTempFile(
+  fileName = 'report.txt',
+  contents = 'report',
+): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'dingtalk-outbound-file-'));
+  const path = join(dir, fileName);
+  writeFileSync(path, contents);
+  return { dir, path };
+}
+
 vi.mock('dingtalk-stream-sdk-nodejs', () => ({
   DWClient: class {
     debug = true;
@@ -253,6 +263,17 @@ it('adds outbound image instructions without replacing custom instructions', () 
 
   expect(instructions).toContain('Keep the answer concise.');
   expect(instructions).toContain('[IMAGE: /absolute/path/to/file.png]');
+  expect(instructions).toContain('[FILE: /absolute/path/to/file]');
+});
+
+it('does not advertise outbound files in block-streaming mode', () => {
+  const channel = createChannel({ blockStreaming: 'on' });
+  const instructions = (
+    channel as unknown as { config: { instructions: string } }
+  ).config.instructions;
+
+  expect(instructions).toContain('[IMAGE: /absolute/path/to/file.png]');
+  expect(instructions).not.toContain('[FILE: /absolute/path/to/file]');
 });
 
 it('validates interactive card config in the adapter', () => {
@@ -3876,6 +3897,498 @@ describe('DingtalkChannel outbound image delivery', () => {
   });
 });
 
+describe('DingtalkChannel outbound file delivery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubFileReplyFetch(options?: {
+    uploadTokenHandler?: (tokenCall: number) => Response;
+    uploadHandler?: (uploadCall: number) => Response;
+    fileHandler?: (fileCall: number) => Response;
+    markdownHandler?: (markdownCall: number) => Response;
+  }) {
+    let uploadCall = 0;
+    let uploadTokenCall = 0;
+    let robotTokenCall = 0;
+    let fileCall = 0;
+    let markdownCall = 0;
+    const events: string[] = [];
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.startsWith('https://oapi.dingtalk.com/gettoken')) {
+          events.push('upload-token');
+          return Promise.resolve(
+            options?.uploadTokenHandler?.(uploadTokenCall++) ??
+              new Response(
+                JSON.stringify({
+                  errcode: 0,
+                  access_token: 'upload-token',
+                  expires_in: 7200,
+                }),
+                { status: 200 },
+              ),
+          );
+        }
+        if (url.startsWith('https://oapi.dingtalk.com/media/upload')) {
+          events.push('upload');
+          const call = uploadCall++;
+          return Promise.resolve(
+            options?.uploadHandler?.(call) ??
+              new Response(
+                JSON.stringify({
+                  errcode: 0,
+                  media_id: `@lAL-file-media-${call + 1}`,
+                }),
+                { status: 200 },
+              ),
+          );
+        }
+        if (url === 'https://api.dingtalk.com/v1.0/oauth2/accessToken') {
+          events.push('robot-token');
+          robotTokenCall++;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                accessToken: `robot-token-${robotTokenCall}`,
+                expireIn: 7200,
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        const body = JSON.parse(String(init?.body)) as { msgtype?: string };
+        events.push(body.msgtype ?? 'unknown');
+        if (body.msgtype === 'file') {
+          return Promise.resolve(
+            options?.fileHandler?.(fileCall++) ??
+              new Response(JSON.stringify({ errcode: 0 }), { status: 200 }),
+          );
+        }
+        if (body.msgtype === 'markdown') {
+          return Promise.resolve(
+            options?.markdownHandler?.(markdownCall++) ??
+              new Response(JSON.stringify({ errcode: 0 }), { status: 200 }),
+          );
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ errcode: 0 }), { status: 200 }),
+        );
+      });
+    const webhookCalls = () =>
+      spy.mock.calls.filter((call) =>
+        String(call[0]).startsWith(
+          'https://oapi.dingtalk.com/robot/send?access_token=token',
+        ),
+      );
+    return {
+      events,
+      fileCalls: () =>
+        webhookCalls().filter((call) => {
+          const body = JSON.parse(String((call[1] as RequestInit).body)) as {
+            msgtype?: string;
+          };
+          return body.msgtype === 'file';
+        }),
+      markdownCalls: () =>
+        webhookCalls().filter((call) => {
+          const body = JSON.parse(String((call[1] as RequestInit).body)) as {
+            msgtype?: string;
+          };
+          return body.msgtype === 'markdown';
+        }),
+      robotTokenCalls: () =>
+        spy.mock.calls.filter(
+          (call) =>
+            String(call[0]) ===
+            'https://api.dingtalk.com/v1.0/oauth2/accessToken',
+        ),
+      uploadTokenCalls: () =>
+        spy.mock.calls.filter((call) =>
+          String(call[0]).startsWith('https://oapi.dingtalk.com/gettoken'),
+        ),
+      uploadCalls: () =>
+        spy.mock.calls.filter((call) =>
+          String(call[0]).startsWith('https://oapi.dingtalk.com/media/upload'),
+        ),
+    };
+  }
+
+  it('uploads and sends a native file after path-free Markdown', async () => {
+    const file = createTempFile('周报 final.PDF');
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { events, fileCalls, markdownCalls, robotTokenCalls, uploadCalls } =
+        stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `before\n[FILE: ${file.path}]\nafter`,
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      const uploadUrl = String(uploadCalls()[0]![0]);
+      expect(uploadUrl).toContain('type=file');
+      expect(robotTokenCalls()).toHaveLength(0);
+      const markdownBody = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(markdownBody.markdown.text).toContain('[File: 周报 final.PDF]');
+      expect(markdownBody.markdown.text).not.toContain(file.path);
+      expect(markdownBody.markdown.text).not.toContain('[FILE:');
+      const fileCall = fileCalls()[0]!;
+      expect(
+        (fileCall[1] as RequestInit).headers as Record<string, string>,
+      ).not.toHaveProperty('x-acs-dingtalk-access-token');
+      expect(JSON.parse(String((fileCall[1] as RequestInit).body))).toEqual({
+        msgtype: 'file',
+        file: {
+          mediaId: '@lAL-file-media-1',
+          fileName: '周报 final.PDF',
+          fileType: 'pdf',
+        },
+      });
+      expect(events).toEqual(['upload-token', 'upload', 'markdown', 'file']);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not upload a file when the reply webhook is unavailable', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      await channel.sendMessage('missing-chat', `[FILE: ${file.path}]`);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prepares a status-card file once and sends it after finalization', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid-1');
+      const { events, fileCalls, uploadCalls } = stubFileReplyFetch();
+      const closeOutput = vi.fn().mockImplementation(() => {
+        events.push('card');
+        return Promise.resolve(true);
+      });
+      (
+        channel as unknown as {
+          interactionPresenter: { closeOutput: typeof closeOutput };
+        }
+      ).interactionPresenter = { closeOutput };
+      const segment = {
+        channelName: 'dingtalk',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        segmentId: 'segment-1',
+        owner: { kind: 'channel_user', id: 'owner-1' },
+        target: {
+          channelName: 'dingtalk',
+          chatId: 'cid-1',
+          senderId: 'owner-1',
+          isGroup: true,
+        },
+      } as ChannelOutputSegmentContext;
+
+      await getCompleteHook(channel)(
+        'cid-1',
+        `[FILE: ${file.path}]`,
+        'session-1',
+        segment,
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      expect(closeOutput).toHaveBeenCalledWith(
+        'segment-1',
+        '[File: report.txt]',
+        'completed',
+        segment,
+      );
+      expect(events.indexOf('card')).toBeLessThan(events.indexOf('file'));
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses the prepared file when status-card finalization falls back', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid-1');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+      const closeOutput = vi.fn().mockResolvedValue(false);
+      (
+        channel as unknown as {
+          interactionPresenter: { closeOutput: typeof closeOutput };
+        }
+      ).interactionPresenter = { closeOutput };
+      const segment = {
+        channelName: 'dingtalk',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        segmentId: 'segment-1',
+        owner: { kind: 'channel_user', id: 'owner-1' },
+        target: {
+          channelName: 'dingtalk',
+          chatId: 'cid-1',
+          senderId: 'owner-1',
+          isGroup: true,
+        },
+      } as ChannelOutputSegmentContext;
+
+      await getCompleteHook(channel)(
+        'cid-1',
+        `[FILE: ${file.path}]`,
+        'session-1',
+        segment,
+      );
+
+      expect(closeOutput).toHaveBeenCalledOnce();
+      expect(uploadCalls()).toHaveLength(1);
+      expect(markdownCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes the upload token once on an explicit auth failure', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, uploadCalls, uploadTokenCalls } = stubFileReplyFetch({
+        uploadTokenHandler: (tokenCall) =>
+          new Response(
+            JSON.stringify({
+              errcode: 0,
+              access_token: `upload-token-${tokenCall + 1}`,
+              expires_in: 7200,
+            }),
+            { status: 200 },
+          ),
+        uploadHandler: (uploadCall) =>
+          uploadCall === 0
+            ? new Response(
+                JSON.stringify({ errcode: 42001, errmsg: 'token expired' }),
+                { status: 200 },
+              )
+            : new Response(
+                JSON.stringify({
+                  errcode: 0,
+                  media_id: '@lAL-file-media-refreshed',
+                }),
+                { status: 200 },
+              ),
+      });
+
+      await channel.sendMessage('cid123', `[FILE: ${file.path}]`);
+
+      expect(uploadTokenCalls()).toHaveLength(2);
+      expect(uploadCalls()).toHaveLength(2);
+      expect(String(uploadCalls()[0]![0])).toContain('upload-token-1');
+      expect(String(uploadCalls()[1]![0])).toContain('upload-token-2');
+      const fileBody = JSON.parse(
+        String((fileCalls()[0]![1] as RequestInit).body),
+      );
+      expect(fileBody.file.mediaId).toBe('@lAL-file-media-refreshed');
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes the robot token once on an explicit file-delivery 401', async () => {
+    const channel = createChannel();
+    let tokenCall = 0;
+    let deliveryCall = 0;
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation((input: RequestInfo | URL) => {
+        if (
+          String(input) === 'https://api.dingtalk.com/v1.0/oauth2/accessToken'
+        ) {
+          tokenCall++;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                accessToken: `robot-token-${tokenCall}`,
+                expireIn: 7200,
+              }),
+              { status: 200 },
+            ),
+          );
+        }
+        deliveryCall++;
+        return Promise.resolve(
+          deliveryCall === 1
+            ? new Response('expired', { status: 401 })
+            : new Response(JSON.stringify({ errcode: 0 }), { status: 200 }),
+        );
+      });
+
+    await (
+      channel as unknown as {
+        postRobotFileMessage(
+          url: string,
+          body: Record<string, unknown>,
+        ): Promise<Record<string, unknown>>;
+      }
+    ).postRobotFileMessage(
+      'https://api.dingtalk.com/v1.0/robot/groupMessages/send',
+      { msgKey: 'sampleFile' },
+    );
+
+    expect(tokenCall).toBe(2);
+    expect(deliveryCall).toBe(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not forward a robot token to an untrusted file endpoint', async () => {
+    const channel = createChannel();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await expect(
+      (
+        channel as unknown as {
+          postRobotFileMessage(
+            url: string,
+            body: Record<string, unknown>,
+          ): Promise<Record<string, unknown>>;
+        }
+      ).postRobotFileMessage('https://example.com/collect', {
+        msgtype: 'file',
+      }),
+    ).rejects.toThrow('untrusted endpoint');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not retry an ambiguous file failure and sends a safe notice', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const { fileCalls, markdownCalls } = stubFileReplyFetch({
+        fileHandler: () => {
+          throw new Error(`connection reset for ${file.path}`);
+        },
+      });
+
+      await channel.sendMessage('cid123', `[FILE: ${file.path}]`);
+
+      expect(fileCalls()).toHaveLength(1);
+      expect(markdownCalls()).toHaveLength(2);
+      const failure = JSON.parse(
+        String((markdownCalls()[1]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(failure.markdown.text).toContain(
+        '[File delivery failed: report.txt]',
+      );
+      expect(failure.markdown.text).not.toContain(file.path);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a nonzero DingTalk code in a successful HTTP response', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const { fileCalls, markdownCalls } = stubFileReplyFetch({
+        fileHandler: () =>
+          new Response(JSON.stringify({ errcode: 310000 }), { status: 200 }),
+      });
+
+      await channel.sendMessage('cid123', `[FILE: ${file.path}]`);
+
+      expect(fileCalls()).toHaveLength(1);
+      expect(markdownCalls()).toHaveLength(2);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('continues with later files when a failure notice cannot be sent', async () => {
+    const first = createTempFile('first.txt');
+    const secondPath = join(first.dir, 'second.txt');
+    writeFileSync(secondPath, 'second');
+    try {
+      const channel = createChannel({ cwd: first.dir });
+      seedWebhook(channel, 'cid123');
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const { fileCalls } = stubFileReplyFetch({
+        fileHandler: (fileCall) =>
+          fileCall === 0
+            ? new Response('rejected', { status: 500 })
+            : new Response(JSON.stringify({ errcode: 0 }), { status: 200 }),
+        markdownHandler: (markdownCall) => {
+          if (markdownCall === 1) throw new Error('notice unavailable');
+          return new Response(JSON.stringify({ errcode: 0 }), { status: 200 });
+        },
+      });
+
+      await channel.sendMessage(
+        'cid123',
+        `[FILE: ${first.path}]\n[FILE: ${secondPath}]`,
+      );
+
+      expect(fileCalls()).toHaveLength(2);
+    } finally {
+      rmSync(first.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('opens and uploads at most five files from one response', async () => {
+    const file = createTempFile('file-1.txt');
+    try {
+      const paths = [file.path];
+      for (let i = 2; i <= 5; i++) {
+        const path = join(file.dir, `file-${i}.txt`);
+        writeFileSync(path, String(i));
+        paths.push(path);
+      }
+      paths.push(join(file.dir, 'file-6-does-not-exist.txt'));
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        paths.map((path) => `[FILE: ${path}]`).join('\n'),
+      );
+
+      expect(uploadCalls()).toHaveLength(5);
+      expect(fileCalls()).toHaveLength(5);
+      const markdown = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(markdown.markdown.text).toContain(
+        '[File delivery failed: response file limit exceeded]',
+      );
+      expect(markdown.markdown.text).not.toContain(
+        '[File delivery failed: file-6-does-not-exist.txt]',
+      );
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('DingtalkChannel proactive send', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -3921,9 +4434,15 @@ describe('DingtalkChannel proactive send', () => {
         JSON.stringify({ errcode: 0, media_id: '@lAL-proactive-media-id' }),
         { status: 200 },
       ),
+    robotTokenHandler: (tokenCall: number) => Response = () =>
+      new Response(
+        JSON.stringify({ accessToken: 'robot-api-token', expireIn: 7200 }),
+        { status: 200 },
+      ),
   ) {
     let sendCall = 0;
     let uploadCall = 0;
+    let robotTokenCall = 0;
     const spy = vi
       .spyOn(globalThis, 'fetch')
       .mockImplementation((input: RequestInfo | URL) => {
@@ -3933,6 +4452,9 @@ describe('DingtalkChannel proactive send', () => {
         }
         if (url.startsWith('https://oapi.dingtalk.com/media/upload')) {
           return Promise.resolve(mediaHandler(uploadCall++));
+        }
+        if (url === 'https://api.dingtalk.com/v1.0/oauth2/accessToken') {
+          return Promise.resolve(robotTokenHandler(robotTokenCall++));
         }
         return Promise.resolve(sendHandler(sendCall++));
       });
@@ -3946,6 +4468,8 @@ describe('DingtalkChannel proactive send', () => {
         calls('https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend'),
       mediaCalls: () => calls('https://oapi.dingtalk.com/media/upload'),
       tokenCalls: () => calls('https://oapi.dingtalk.com/gettoken'),
+      robotTokenCalls: () =>
+        calls('https://api.dingtalk.com/v1.0/oauth2/accessToken'),
     };
   }
 
@@ -4074,6 +4598,153 @@ describe('DingtalkChannel proactive send', () => {
       );
     } finally {
       rmSync(image.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uploads and sends a native file to a proactive group target', async () => {
+    const file = createTempFile('group report.pdf');
+    try {
+      const channel = proactive(createChannel({ cwd: file.dir }));
+      const { mediaCalls, robotTokenCalls, sendCalls } = stubProactiveFetch(
+        (sendCall) =>
+          new Response(
+            JSON.stringify(
+              sendCall === 0 ? {} : { processQueryKey: 'file-key' },
+            ),
+            { status: 200 },
+          ),
+      );
+
+      await channel.pushProactive(groupTarget, `[FILE: ${file.path}]`);
+
+      expect(mediaCalls()).toHaveLength(1);
+      expect(String(mediaCalls()[0]![0])).toContain('type=file');
+      expect(robotTokenCalls()).toHaveLength(1);
+      const sends = sendCalls();
+      expect(sends).toHaveLength(2);
+      const fileInit = sends[1]![1] as RequestInit;
+      expect(
+        (fileInit.headers as Record<string, string>)[
+          'x-acs-dingtalk-access-token'
+        ],
+      ).toBe('robot-api-token');
+      const body = JSON.parse(String(fileInit.body));
+      expect(body).toMatchObject({
+        robotCode: 'client-id',
+        openConversationId: groupTarget.chatId,
+        msgKey: 'sampleFile',
+      });
+      expect(JSON.parse(body.msgParam)).toEqual({
+        mediaId: '@lAL-proactive-media-id',
+        fileName: 'group report.pdf',
+        fileType: 'pdf',
+      });
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('sends a native file to a proactive direct target', async () => {
+    const file = createTempFile();
+    try {
+      const channel = proactive(createChannel({ cwd: file.dir }));
+      const { directSendCalls, mediaCalls, robotTokenCalls } =
+        stubProactiveFetch(
+          (sendCall) =>
+            new Response(
+              JSON.stringify(
+                sendCall === 0 ? {} : { processQueryKey: 'direct-file-key' },
+              ),
+              { status: 200 },
+            ),
+        );
+
+      await channel.pushProactive(directTarget, `[FILE: ${file.path}]`);
+
+      const sends = directSendCalls();
+      expect(mediaCalls()).toHaveLength(1);
+      expect(robotTokenCalls()).toHaveLength(1);
+      expect(sends).toHaveLength(2);
+      const fileInit = sends[1]![1] as RequestInit;
+      expect(
+        (fileInit.headers as Record<string, string>)[
+          'x-acs-dingtalk-access-token'
+        ],
+      ).toBe('robot-api-token');
+      const body = JSON.parse(String(fileInit.body));
+      expect(body.userIds).toEqual([directTarget.chatId]);
+      expect(body.openConversationId).toBeUndefined();
+      expect(body.msgKey).toBe('sampleFile');
+      expect(JSON.parse(body.msgParam)).toEqual({
+        mediaId: '@lAL-proactive-media-id',
+        fileName: 'report.txt',
+        fileType: 'txt',
+      });
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not accept a proactive file response without processQueryKey', async () => {
+    const file = createTempFile();
+    try {
+      const channel = proactive(createChannel({ cwd: file.dir }));
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const { sendCalls } = stubProactiveFetch(
+        () => new Response('{}', { status: 200 }),
+      );
+
+      await expect(
+        channel.pushProactive(groupTarget, `[FILE: ${file.path}]`),
+      ).rejects.toThrow('missing processQueryKey');
+
+      expect(sendCalls()).toHaveLength(3);
+      const bodies = sendCalls().map((call) =>
+        JSON.parse(String((call[1] as RequestInit).body)),
+      );
+      expect(
+        bodies.filter((body) => body.msgKey === 'sampleFile'),
+      ).toHaveLength(1);
+      expect(
+        bodies.filter((body) => body.msgKey === 'sampleMarkdown'),
+      ).toHaveLength(2);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('continues with later proactive files after one delivery fails', async () => {
+    const first = createTempFile('first.txt');
+    const secondPath = join(first.dir, 'second.txt');
+    writeFileSync(secondPath, 'second');
+    try {
+      const channel = proactive(createChannel({ cwd: first.dir }));
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const { sendCalls } = stubProactiveFetch(
+        (sendCall) =>
+          new Response(
+            JSON.stringify(
+              sendCall === 3 ? { processQueryKey: 'second-file-key' } : {},
+            ),
+            { status: 200 },
+          ),
+      );
+
+      await expect(
+        channel.pushProactive(
+          groupTarget,
+          `[FILE: ${first.path}]\n[FILE: ${secondPath}]`,
+        ),
+      ).rejects.toThrow('missing processQueryKey');
+
+      const bodies = sendCalls().map((call) =>
+        JSON.parse(String((call[1] as RequestInit).body)),
+      );
+      const fileBodies = bodies.filter((body) => body.msgKey === 'sampleFile');
+      expect(fileBodies).toHaveLength(2);
+      expect(JSON.parse(fileBodies[1]!.msgParam).fileName).toBe('second.txt');
+    } finally {
+      rmSync(first.dir, { recursive: true, force: true });
     }
   });
 

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -3354,6 +3354,49 @@ describe('DingtalkChannel reply mentions', () => {
     });
   });
 
+  it('sanitizes a code-quoted image marker on the fallback hop', async () => {
+    const image = createTempPng();
+    try {
+      const channel = createChannel({ cwd: image.dir });
+      seedWebhook(channel, 'cid123');
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await (
+        channel as unknown as {
+          sendFallbackReply(
+            chatId: string,
+            text: string,
+            sessionId: string,
+          ): Promise<void>;
+        }
+      ).sendFallbackReply(
+        'cid123',
+        `\` a  [IMAGE: ${image.path}] \``,
+        'session-1',
+      );
+
+      expect(
+        fetchSpy.mock.calls.filter(([input]) =>
+          String(input).startsWith('https://oapi.dingtalk.com/media/upload'),
+        ),
+      ).toHaveLength(0);
+      const webhookCall = fetchSpy.mock.calls.find(([input]) =>
+        String(input).startsWith(
+          'https://oapi.dingtalk.com/robot/send?access_token=token',
+        ),
+      );
+      const body = JSON.parse(
+        String((webhookCall![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).toBe('` a  [Image pending] `');
+      expect(body.markdown.text).not.toContain(image.path);
+    } finally {
+      rmSync(image.dir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps the final answer mention after a mid-run card fallback', async () => {
     const channel = createChannel({ atSender: true });
     seedWebhook(channel, 'cid-1');
@@ -4475,6 +4518,122 @@ describe('DingtalkChannel outbound file delivery', () => {
       '[File delivery failed: incomplete marker]',
       'Next answer.',
     ]);
+  });
+
+  it('keeps an active response carry isolated from one-shot delivery', async () => {
+    const file = createTempFile('report.txt');
+    try {
+      const channel = createChannel({
+        blockStreaming: 'on',
+        cwd: file.dir,
+      });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+      const stem = file.path.slice(0, -'.txt'.length);
+
+      await getResponseHook(channel)(
+        'cid123',
+        `Answer [FILE: ${stem}`,
+        'session-1',
+      );
+      await getOneShotResponseHook(channel)(
+        'cid123',
+        'Background notice',
+        'session-1',
+      );
+      await getResponseHook(channel)('cid123', '.txt] done', 'session-1');
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const bodies = markdownCalls().map(
+        (call) =>
+          (
+            JSON.parse(String((call[1] as RequestInit).body)) as {
+              markdown: { text: string };
+            }
+          ).markdown.text,
+      );
+      expect(bodies).toEqual([
+        'Answer ',
+        'Background notice',
+        '[File sent: report.txt] done',
+      ]);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('validates the exact marker close before longer candidates', async () => {
+    const file = createTempFile('a.pdf');
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `文件[FILE: ${file.path}]、[链接](https://example.com)已发出`,
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const body = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).toBe(
+        '文件[File sent: a.pdf]、[链接](https://example.com)已发出',
+      );
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed when multiple bracketed file paths are valid', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dingtalk-ambiguous-file-'));
+    const shorter = join(root, 'a[1');
+    const longer = `${shorter}]foo`;
+    writeFileSync(shorter, 'wrong');
+    writeFileSync(longer, 'right');
+    try {
+      const channel = createChannel({ cwd: root });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage('cid123', `[FILE: ${longer}] done`);
+
+      expect(uploadCalls()).toHaveLength(0);
+      expect(fileCalls()).toHaveLength(0);
+      const body = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).toBe('[File delivery failed: a_1_foo] done');
+      expect(body.markdown.text).not.toContain(root);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not expose a code-quoted file marker through partial stripping', async () => {
+    const file = createTempFile('secret.pdf');
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `A [IMAGE: /tmp/x \`[FILE: ${file.path}]\` B`,
+      );
+
+      expect(uploadCalls()).toHaveLength(0);
+      expect(fileCalls()).toHaveLength(0);
+      const body = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).not.toContain(file.path);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
   });
 
   it('does not upload a file when the reply webhook is unavailable', async () => {

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { DWClientDownStream } from 'dingtalk-stream-sdk-nodejs';
@@ -4065,6 +4065,88 @@ describe('DingtalkChannel outbound file delivery', () => {
       expect(events).toEqual(['upload-token', 'upload', 'markdown', 'file']);
     } finally {
       rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the longest fully validated bracketed file path', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dingtalk-bracketed-file-'));
+    const directory = join(root, 'dir [1] copy');
+    const path = join(directory, 'report.txt');
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path, 'report');
+    try {
+      const channel = createChannel({ cwd: root });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage('cid123', `[FILE: ${path}]`);
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      expect(
+        JSON.parse(String((fileCalls()[0]![1] as RequestInit).body)),
+      ).toMatchObject({ file: { fileName: 'report.txt' } });
+      const markdown = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(markdown.markdown.text).not.toContain(directory);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a longer directory candidate and sends the valid file', async () => {
+    const file = createTempFile('file.txt');
+    mkdirSync(`${file.path}] tail`);
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage('cid123', `[FILE: ${file.path}] tail]`);
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      expect(
+        JSON.parse(String((fileCalls()[0]![1] as RequestInit).body)),
+      ).toMatchObject({ file: { fileName: 'file.txt' } });
+      const markdown = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(markdown.markdown.text).toContain('[File sent: file.txt] tail]');
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('holds an ambiguous bracketed stream until the full file path arrives', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dingtalk-stream-bracket-'));
+    const prefix = join(root, 'a[1');
+    const intended = `${prefix}].txt`;
+    writeFileSync(prefix, 'wrong');
+    writeFileSync(intended, 'right');
+    try {
+      const channel = createChannel({ blockStreaming: 'on', cwd: root });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, uploadCalls } = stubFileReplyFetch();
+
+      await getResponseHook(channel)(
+        'cid123',
+        `[FILE: ${prefix}]`,
+        'session-1',
+      );
+      expect(uploadCalls()).toHaveLength(0);
+      expect(fileCalls()).toHaveLength(0);
+
+      await getResponseHook(channel)('cid123', '.txt]', 'session-1');
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      expect(
+        JSON.parse(String((fileCalls()[0]![1] as RequestInit).body)),
+      ).toMatchObject({ file: { fileName: 'a_1_.txt' } });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -4059,6 +4059,102 @@ describe('DingtalkChannel outbound file delivery', () => {
     }
   });
 
+  it('detects adjacent image and file markers before replacing either', async () => {
+    const file = createTempFile();
+    const image = createTempPng();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `[FILE: ${file.path}][IMAGE: ${image.path}]`,
+      );
+
+      expect(uploadCalls()).toHaveLength(2);
+      expect(fileCalls()).toHaveLength(1);
+      const markdownBody = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(markdownBody.markdown.text).toContain('[File sent: report.txt]');
+      expect(markdownBody.markdown.text).toContain(
+        '![image](@lAL-file-media-1)',
+      );
+      expect(markdownBody.markdown.text).not.toContain(file.path);
+      expect(markdownBody.markdown.text).not.toContain(image.path);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+      rmSync(image.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reassembles a file marker split across block-streamed messages', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ blockStreaming: 'on', cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await getResponseHook(channel)(
+        'cid123',
+        'Answer follows. [FILE:',
+        'session-1',
+      );
+      await getResponseHook(channel)(
+        'cid123',
+        `${file.path}] done`,
+        'session-1',
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const markdown = markdownCalls()
+        .map((call) => JSON.parse(String((call[1] as RequestInit).body)))
+        .map((body) => String(body.markdown.text))
+        .join('\n');
+      expect(markdown).toContain('[File sent: report.txt]');
+      expect(markdown).not.toContain(file.path);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports an incomplete file marker when block streaming ends', async () => {
+    const channel = createChannel({ blockStreaming: 'on' });
+    seedWebhook(channel, 'cid123');
+    const { markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+    await getResponseHook(channel)('cid123', '[FILE:', 'session-1');
+    await getOutputSegmentEndHook(channel)(
+      'cid123',
+      'session-1',
+      {
+        channelName: 'dingtalk',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        segmentId: 'segment-1',
+        owner: { kind: 'channel_user', id: 'owner-1' },
+        target: {
+          channelName: 'dingtalk',
+          chatId: 'cid123',
+          senderId: 'owner-1',
+          isGroup: true,
+        },
+      },
+      'completed',
+    );
+
+    expect(uploadCalls()).toHaveLength(0);
+    expect(markdownCalls()).toHaveLength(1);
+    const body = JSON.parse(
+      String((markdownCalls()[0]![1] as RequestInit).body),
+    ) as { markdown: { text: string } };
+    expect(body.markdown.text).toBe(
+      '[File delivery failed: incomplete marker]',
+    );
+  });
+
   it('does not upload a file when the reply webhook is unavailable', async () => {
     const file = createTempFile();
     try {

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -4588,6 +4588,74 @@ describe('DingtalkChannel outbound file delivery', () => {
     expect(markdown[1]).not.toContain('draft and');
   });
 
+  it('delivers a nested image without exposing its file-wrapper path', async () => {
+    const image = createTempPng();
+    try {
+      const channel = createChannel({ cwd: image.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `[FILE: [IMAGE: ${image.path}] /Users/ben/private/report.pdf]`,
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(0);
+      const markdown = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(markdown.markdown.text).toContain('![image](');
+      expect(markdown.markdown.text).not.toContain('/Users/ben/private');
+      expect(markdown.markdown.text).not.toContain('report.pdf');
+    } finally {
+      rmSync(image.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('hides escaped marker paths without uploading them', async () => {
+    const channel = createChannel();
+    seedWebhook(channel, 'cid123');
+    const { markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+    await channel.sendMessage(
+      'cid123',
+      String.raw`Here: \[FILE: /Users/ben/private/report.pdf] done`,
+    );
+
+    expect(uploadCalls()).toHaveLength(0);
+    const markdown = JSON.parse(
+      String((markdownCalls()[0]![1] as RequestInit).body),
+    ) as { markdown: { text: string } };
+    expect(markdown.markdown.text).not.toContain('/Users/ben/private');
+  });
+
+  it('still delivers prepared files after a later text chunk fails', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls } = stubFileReplyFetch({
+        markdownHandler: (call) => {
+          if (call === 1) throw new Error('chunk unavailable');
+          return new Response(JSON.stringify({ errcode: 0 }), { status: 200 });
+        },
+      });
+
+      await expect(
+        channel.sendMessage(
+          'cid123',
+          `[FILE: ${file.path}]\n${'x'.repeat(50_000)}`,
+        ),
+      ).rejects.toThrow('chunk unavailable');
+
+      expect(markdownCalls().length).toBeGreaterThan(1);
+      expect(fileCalls()).toHaveLength(1);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     ['IMAGE', '[Image pending]'],
     ['FILE', ''],
@@ -4677,6 +4745,40 @@ describe('DingtalkChannel outbound file delivery', () => {
       expect(closeOutput).toHaveBeenCalledOnce();
       expect(uploadCalls()).toHaveLength(1);
       expect(markdownCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('still delivers a prepared file when status-card finalization fails', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid-1');
+      const { fileCalls } = stubFileReplyFetch();
+      const closeOutput = vi.fn().mockRejectedValue(new Error('card failed'));
+      (
+        channel as unknown as {
+          interactionPresenter: { closeOutput: typeof closeOutput };
+        }
+      ).interactionPresenter = { closeOutput };
+
+      await expect(
+        getCompleteHook(channel)('cid-1', `[FILE: ${file.path}]`, 'session-1', {
+          channelName: 'dingtalk',
+          sessionId: 'session-1',
+          runId: 'run-1',
+          segmentId: 'segment-1',
+          owner: { kind: 'channel_user', id: 'owner-1' },
+          target: {
+            channelName: 'dingtalk',
+            chatId: 'cid-1',
+            senderId: 'owner-1',
+            isGroup: true,
+          },
+        }),
+      ).rejects.toThrow('card failed');
       expect(fileCalls()).toHaveLength(1);
     } finally {
       rmSync(file.dir, { recursive: true, force: true });

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -4045,6 +4045,9 @@ describe('DingtalkChannel outbound file delivery', () => {
       const markdownBody = JSON.parse(
         String((markdownCalls()[0]![1] as RequestInit).body),
       ) as { markdown: { text: string } };
+      expect((markdownCalls()[0]![1] as RequestInit).signal).toBeInstanceOf(
+        AbortSignal,
+      );
       expect(markdownBody.markdown.text).toContain(
         '[File sent: 周报 final.PDF]',
       );
@@ -4116,6 +4119,51 @@ describe('DingtalkChannel outbound file delivery', () => {
       expect(markdown.markdown.text).toContain('[File sent: file.txt] tail]');
     } finally {
       rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not deliver a shorter file candidate inside a longer marker', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dingtalk-short-file-'));
+    const shortPath = join(root, 'a[1');
+    writeFileSync(shortPath, 'wrong');
+    try {
+      const channel = createChannel({ cwd: root });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage('cid123', `[FILE: ${shortPath}].txt]`);
+
+      expect(uploadCalls()).toHaveLength(0);
+      expect(fileCalls()).toHaveLength(0);
+      const body = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).toBe('[File delivery failed: a_1_.txt]');
+      expect(body.markdown.text).not.toContain('].txt]');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('does not deliver a shorter image candidate inside a longer marker', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dingtalk-short-image-'));
+    const shortPath = join(root, 'a[1].png');
+    writeFileSync(shortPath, PNG_DATA);
+    try {
+      const channel = createChannel({ cwd: root });
+      seedWebhook(channel, 'cid123');
+      const { markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage('cid123', `[IMAGE: ${shortPath}.txt]`);
+
+      expect(uploadCalls()).toHaveLength(0);
+      const body = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).toBe('[Image delivery failed: a_1_.png.txt]');
+      expect(body.markdown.text).not.toContain(shortPath);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
     }
   });
 
@@ -4273,10 +4321,11 @@ describe('DingtalkChannel outbound file delivery', () => {
     );
   });
 
-  it('flushes a partial marker before resuming after an input request', async () => {
-    const channel = createChannel({ blockStreaming: 'on' });
+  it('keeps a partial marker while resuming after an input request', async () => {
+    const file = createTempFile();
+    const channel = createChannel({ blockStreaming: 'on', cwd: file.dir });
     seedWebhook(channel, 'cid123');
-    const { markdownCalls } = stubFileReplyFetch();
+    const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
     const segment = {
       channelName: 'dingtalk',
       sessionId: 'session-1',
@@ -4291,37 +4340,110 @@ describe('DingtalkChannel outbound file delivery', () => {
       },
     } as ChannelOutputSegmentContext;
 
-    await getResponseHook(channel)(
-      'cid123',
-      'Answer follows. [FILE:',
-      'session-1',
-    );
-    await getOutputSegmentEndHook(channel)(
-      'cid123',
-      'session-1',
-      segment,
-      'input_requested',
-    );
-    await getResponseHook(channel)(
-      'cid123',
-      'The result is 42.\nDone.',
-      'session-1',
-    );
+    try {
+      const split = file.path.slice(0, -4);
+      await getResponseHook(channel)(
+        'cid123',
+        `Answer follows. [FILE: ${split}`,
+        'session-1',
+      );
+      await getOutputSegmentEndHook(channel)(
+        'cid123',
+        'session-1',
+        segment,
+        'input_requested',
+      );
+      await getResponseHook(channel)('cid123', '.txt] done', 'session-1');
 
-    const bodies = markdownCalls().map((call) =>
-      String(
-        (
-          JSON.parse(String((call[1] as RequestInit).body)) as {
-            markdown: { text: string };
-          }
-        ).markdown.text,
-      ),
-    );
-    expect(bodies).toEqual([
-      'Answer follows. ',
-      '[File delivery failed: incomplete marker]',
-      'The result is 42.\nDone.',
-    ]);
+      const bodies = markdownCalls().map((call) =>
+        String(
+          (
+            JSON.parse(String((call[1] as RequestInit).body)) as {
+              markdown: { text: string };
+            }
+          ).markdown.text,
+        ),
+      );
+      expect(bodies).toEqual([
+        'Answer follows. ',
+        '[File sent: report.txt] done',
+      ]);
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('holds a bracketed marker that ends mid-name', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dingtalk-stream-mid-name-'));
+    const prefix = join(root, 'a[1');
+    const intended = `${prefix}].txt`;
+    writeFileSync(prefix, 'wrong');
+    writeFileSync(intended, 'right');
+    try {
+      const channel = createChannel({ blockStreaming: 'on', cwd: root });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await getResponseHook(channel)(
+        'cid123',
+        `[FILE: ${prefix}].tx`,
+        'session-1',
+      );
+      expect(uploadCalls()).toHaveLength(0);
+
+      await getResponseHook(channel)('cid123', 't] done', 'session-1');
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const body = JSON.parse(
+        String((markdownCalls().at(-1)![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).toBe('[File sent: a_1_.txt] done');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('delivers a complete ambiguous carry when block streaming ends', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dingtalk-stream-complete-'));
+    const path = join(root, 'a[1');
+    writeFileSync(path, 'report');
+    try {
+      const channel = createChannel({ blockStreaming: 'on', cwd: root });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await getResponseHook(channel)('cid123', `[FILE: ${path}]`, 'session-1');
+      await getOutputSegmentEndHook(channel)(
+        'cid123',
+        'session-1',
+        {
+          channelName: 'dingtalk',
+          sessionId: 'session-1',
+          runId: 'run-1',
+          segmentId: 'segment-1',
+          owner: { kind: 'channel_user', id: 'owner-1' },
+          target: {
+            channelName: 'dingtalk',
+            chatId: 'cid123',
+            senderId: 'owner-1',
+            isGroup: true,
+          },
+        },
+        'completed',
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const body = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(body.markdown.text).toBe('[File sent: a_1]');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('flushes each one-shot partial marker without poisoning the next response', async () => {

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -4036,7 +4036,9 @@ describe('DingtalkChannel outbound file delivery', () => {
       const markdownBody = JSON.parse(
         String((markdownCalls()[0]![1] as RequestInit).body),
       ) as { markdown: { text: string } };
-      expect(markdownBody.markdown.text).toContain('[File: 周报 final.PDF]');
+      expect(markdownBody.markdown.text).toContain(
+        '[File sent: 周报 final.PDF]',
+      );
       expect(markdownBody.markdown.text).not.toContain(file.path);
       expect(markdownBody.markdown.text).not.toContain('[FILE:');
       const fileCall = fileCalls()[0]!;
@@ -4112,11 +4114,37 @@ describe('DingtalkChannel outbound file delivery', () => {
       expect(fileCalls()).toHaveLength(1);
       expect(closeOutput).toHaveBeenCalledWith(
         'segment-1',
-        '[File: report.txt]',
+        '[File sent: report.txt]',
         'completed',
         segment,
       );
       expect(events.indexOf('card')).toBeLessThan(events.indexOf('file'));
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('neutralizes an abandoned image marker before delivering a nested file', async () => {
+    const file = createTempFile('report.txt');
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const { fileCalls, markdownCalls, uploadCalls } = stubFileReplyFetch();
+
+      await channel.sendMessage(
+        'cid123',
+        `[IMAGE: /tmp/private-chart.png [FILE: ${file.path}] caption]`,
+      );
+
+      expect(uploadCalls()).toHaveLength(1);
+      expect(fileCalls()).toHaveLength(1);
+      const markdownBody = JSON.parse(
+        String((markdownCalls()[0]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(markdownBody.markdown.text).toContain('[Image pending]');
+      expect(markdownBody.markdown.text).toContain('[File sent: report.txt]');
+      expect(markdownBody.markdown.text).not.toContain('/tmp/private-chart');
+      expect(markdownBody.markdown.text).not.toContain(file.path);
     } finally {
       rmSync(file.dir, { recursive: true, force: true });
     }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -24,17 +24,23 @@ import {
   readValidatedImage,
   replaceImageMarkers,
   stripPartialImageMarker,
+  type ImageMarker,
   uploadDingTalkImage,
 } from './outbound-image.js';
 import {
   MAX_FILES_PER_RESPONSE,
   findFileMarkers,
   readValidatedFile,
-  replaceFileMarkers,
   safeFileName,
   stripPartialFileMarker,
+  type FileMarker,
   uploadDingTalkFile,
 } from './outbound-file.js';
+import {
+  findOutboundMediaMarkers,
+  findTrailingPartialOutboundMediaMarker,
+  replaceOutboundMediaMarkers,
+} from './outbound-markers.js';
 import {
   DingtalkConnectionManager,
   type DingtalkManagedSocket,
@@ -242,6 +248,10 @@ export class DingtalkChannel extends ChannelBase {
   private seenMessages: Map<string, number> = new Map();
   private mentionTargets = new Map<string, string>();
   private sessionMentionTargets = new Map<string, string>();
+  private blockStreamingMediaCarry = new Map<
+    string,
+    { text: string; markerName: 'IMAGE' | 'FILE' }
+  >();
   private bufferedMentionTargets = new Set<string>();
   private bufferedMentionTargetsBySession = new Map<string, Set<string>>();
   private dedupTimer?: ReturnType<typeof setInterval>;
@@ -625,10 +635,9 @@ export class DingtalkChannel extends ChannelBase {
     return isGroup && !conversationId;
   }
 
-  private async prepareOutgoingImages(text: string): Promise<string> {
-    const markers = findImageMarkers(text);
-    if (markers.length === 0) return stripPartialImageMarker(text);
-
+  private async prepareImageReplacements(
+    markers: readonly ImageMarker[],
+  ): Promise<string[]> {
     const replacements: string[] = [];
     for (const marker of markers) {
       const fileName =
@@ -674,21 +683,22 @@ export class DingtalkChannel extends ChannelBase {
         replacements.push(`[Image delivery failed: ${fileName}]`);
       }
     }
+    return replacements;
+  }
+
+  private async prepareOutgoingImages(text: string): Promise<string> {
+    const markers = findImageMarkers(text);
+    if (markers.length === 0) return stripPartialImageMarker(text);
+    const replacements = await this.prepareImageReplacements(markers);
 
     return stripPartialImageMarker(
       replaceImageMarkers(text, markers, replacements),
     );
   }
 
-  private async prepareOutgoingContent(
-    text: string,
-  ): Promise<PreparedDingTalkOutput> {
-    const imageText = await this.prepareOutgoingImages(text);
-    const markers = findFileMarkers(imageText);
-    if (markers.length === 0) {
-      return { text: stripPartialFileMarker(imageText), files: [] };
-    }
-
+  private async prepareFileReplacements(
+    markers: readonly FileMarker[],
+  ): Promise<{ files: PreparedDingTalkFile[]; replacements: string[] }> {
     const files: PreparedDingTalkFile[] = [];
     const replacements: string[] = [];
     for (const [index, marker] of markers.entries()) {
@@ -744,13 +754,76 @@ export class DingtalkChannel extends ChannelBase {
         replacements.push(`[File delivery failed: ${fileName}]`);
       }
     }
+    return { files, replacements };
+  }
+
+  private async prepareOutgoingContent(
+    text: string,
+  ): Promise<PreparedDingTalkOutput> {
+    const markerText = stripPartialImageMarker(text);
+    const imageMarkers = findImageMarkers(markerText);
+    const fileMarkers = findFileMarkers(markerText);
+    const imageReplacements = await this.prepareImageReplacements(imageMarkers);
+    const { files, replacements: fileReplacements } =
+      await this.prepareFileReplacements(fileMarkers);
+    const media = [
+      ...imageMarkers.map((marker, index) => ({
+        marker,
+        replacement: imageReplacements[index]!,
+      })),
+      ...fileMarkers.map((marker, index) => ({
+        marker,
+        replacement: fileReplacements[index]!,
+      })),
+    ].sort((left, right) => left.marker.start - right.marker.start);
+    const replaced = replaceOutboundMediaMarkers(
+      markerText,
+      media.map(({ marker }) => marker),
+      media.map(({ replacement }) => replacement),
+    );
 
     return {
       text: stripPartialFileMarker(
-        replaceFileMarkers(imageText, markers, replacements),
+        this.sanitizeSyntheticImageMarkers(markerText, replaced),
       ),
       files,
     };
+  }
+
+  private sanitizeSyntheticImageMarkers(
+    originalText: string,
+    preparedText: string,
+  ): string {
+    const deliverableStarts = new Set(
+      findImageMarkers(originalText).map(({ start }) => start),
+    );
+    const preserved = new Map<string, number>();
+    for (const marker of findOutboundMediaMarkers(
+      originalText,
+      'IMAGE',
+      true,
+    )) {
+      if (deliverableStarts.has(marker.start)) continue;
+      const source = originalText.slice(marker.start, marker.end);
+      preserved.set(source, (preserved.get(source) ?? 0) + 1);
+    }
+    let result = preparedText;
+    while (true) {
+      const retained = new Map(preserved);
+      const markers = findOutboundMediaMarkers(result, 'IMAGE', true);
+      const replacements = markers.map((marker) => {
+        const source = result.slice(marker.start, marker.end);
+        const remaining = retained.get(source) ?? 0;
+        if (remaining === 0) return '[Image pending]';
+        retained.set(source, remaining - 1);
+        return source;
+      });
+      const next = stripPartialImageMarker(
+        replaceOutboundMediaMarkers(result, markers, replacements),
+      );
+      if (next === result) return result;
+      result = next;
+    }
   }
 
   private async sendPreparedReply(
@@ -1600,6 +1673,7 @@ export class DingtalkChannel extends ChannelBase {
     sessionId: string,
     messageId?: string,
   ): void {
+    this.blockStreamingMediaCarry.delete(sessionId);
     if (messageId) {
       this.bufferedMentionTargets.delete(messageId);
       this.untrackBufferedMentionTarget(sessionId, messageId);
@@ -1672,8 +1746,42 @@ export class DingtalkChannel extends ChannelBase {
     sessionId: string,
     messageId?: string,
   ): void {
+    this.blockStreamingMediaCarry.delete(sessionId);
     this.sessionMentionTargets.delete(sessionId);
     this.stopReaction(chatId, messageId, sessionId);
+  }
+
+  private takeBlockStreamingText(
+    sessionId: string,
+    text: string,
+  ): string | undefined {
+    const combined =
+      (this.blockStreamingMediaCarry.get(sessionId)?.text ?? '') + text;
+    const partial = findTrailingPartialOutboundMediaMarker(combined);
+    if (!partial) {
+      this.blockStreamingMediaCarry.delete(sessionId);
+      return combined;
+    }
+    this.blockStreamingMediaCarry.set(sessionId, {
+      text: combined.slice(partial.start),
+      markerName: partial.markerName,
+    });
+    const ready = combined.slice(0, partial.start);
+    return ready.trim() ? ready : undefined;
+  }
+
+  private flushBlockStreamingMediaCarry(
+    chatId: string,
+    sessionId: string,
+  ): Promise<void> | undefined {
+    const pending = this.blockStreamingMediaCarry.get(sessionId);
+    if (!pending) return undefined;
+    this.blockStreamingMediaCarry.delete(sessionId);
+    const text =
+      pending.markerName === 'IMAGE'
+        ? '[Image delivery failed: incomplete marker]'
+        : '[File delivery failed: incomplete marker]';
+    return this.sendPreparedResponse(chatId, { text, files: [] }, sessionId);
   }
 
   protected override async sendResponseMessage(
@@ -1681,6 +1789,11 @@ export class DingtalkChannel extends ChannelBase {
     text: string,
     sessionId: string,
   ): Promise<void> {
+    if (this.config.blockStreaming === 'on') {
+      const ready = this.takeBlockStreamingText(sessionId, text);
+      if (ready === undefined) return;
+      text = ready;
+    }
     if (!this.webhooks.has(chatId)) {
       await this.sendPreparedResponse(chatId, { text, files: [] }, sessionId);
       return;
@@ -1747,15 +1860,25 @@ export class DingtalkChannel extends ChannelBase {
   }
 
   protected override onOutputSegmentEnd(
-    _chatId: string,
-    _sessionId: string,
+    chatId: string,
+    sessionId: string,
     segment: ChannelOutputSegmentContext,
     reason: ChannelOutputSegmentEndReason,
   ): void | Promise<void> {
-    if (!this.interactionPresenter) return;
-    return this.interactionPresenter
-      .closeOutput(segment.segmentId, '', reason, segment)
+    const carry =
+      reason === 'completed' || reason === 'response_boundary'
+        ? this.flushBlockStreamingMediaCarry(chatId, sessionId)
+        : undefined;
+    if (reason === 'failed' || reason === 'cancelled') {
+      this.blockStreamingMediaCarry.delete(sessionId);
+    }
+    const presentation = this.interactionPresenter
+      ?.closeOutput(segment.segmentId, '', reason, segment)
       .then(() => undefined);
+    if (carry && presentation) {
+      return Promise.all([carry, presentation]).then(() => undefined);
+    }
+    return carry ?? presentation;
   }
 
   protected override onResponseChunk(

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -26,6 +26,14 @@ import {
   uploadDingTalkImage,
 } from './outbound-image.js';
 import {
+  MAX_FILES_PER_RESPONSE,
+  findFileMarkers,
+  readValidatedFile,
+  replaceFileMarkers,
+  safeFileName,
+  uploadDingTalkFile,
+} from './outbound-file.js';
+import {
   DingtalkConnectionManager,
   type DingtalkManagedSocket,
 } from './DingtalkConnectionManager.js';
@@ -127,9 +135,12 @@ const EMOTION_RETRY_BASE_DELAY_MS = 250;
 const GROUP_MSG_API = 'https://api.dingtalk.com/v1.0/robot/groupMessages/send';
 const DIRECT_MSG_API =
   'https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend';
+const ROBOT_TOKEN_API = 'https://api.dingtalk.com/v1.0/oauth2/accessToken';
 const PROACTIVE_MSG_KEY = 'sampleMarkdown'; // DingTalk's built-in {title, text} markdown template key
+const PROACTIVE_FILE_MSG_KEY = 'sampleFile';
 const TOKEN_API = 'https://oapi.dingtalk.com/gettoken';
 const PROACTIVE_FETCH_TIMEOUT_MS = 15_000;
+const ROBOT_MESSAGE_HOSTS = new Set(['api.dingtalk.com', 'oapi.dingtalk.com']);
 const mentionTarget = Symbol('mentionTarget');
 const IMAGE_INSTRUCTIONS = [
   '',
@@ -139,6 +150,14 @@ const IMAGE_INSTRUCTIONS = [
   'The marker is stripped from text and the image is uploaded automatically.',
   '',
   'Only use a real image file inside the workspace or system temporary directory.',
+].join('\n');
+const FILE_INSTRUCTIONS = [
+  '',
+  'If the user explicitly asks you to send a file that exists inside the workspace or system temporary directory, include this in the final answer:',
+  '`[FILE: /absolute/path/to/file]` (without the backticks)',
+  '',
+  'Use the marker only after the file is complete. Do not use it in progress text, inside code, or before asking the user for input.',
+  'Do not claim that delivery succeeded; DingTalk will show the file as a separate attachment.',
 ].join('\n');
 
 type MentionTargetEnvelope = Envelope & {
@@ -182,6 +201,23 @@ interface DingTalkTokenResponse {
 interface DingTalkDirectMessageResponse {
   flowControlledStaffIdList?: string[];
   invalidStaffIdList?: string[];
+  processQueryKey?: string;
+}
+
+interface DingTalkRobotTokenResponse {
+  accessToken?: string;
+  expireIn?: number;
+}
+
+interface PreparedDingTalkFile {
+  mediaId: string;
+  fileName: string;
+  fileType: string;
+}
+
+interface PreparedDingTalkOutput {
+  text: string;
+  files: PreparedDingTalkFile[];
 }
 
 type DingTalkClientInternals = DWClient & {
@@ -226,6 +262,7 @@ export class DingtalkChannel extends ChannelBase {
    * on (re)connect, so a long-lived socket serves a stale one after ~2h.
    */
   private proactiveToken?: { token: string; expiresAt: number };
+  private robotApiToken?: { token: string; expiresAt: number };
   private readonly interactiveCardConfig: DingtalkInteractiveCardConfig;
   protected readonly interactiveCardClient?: DingtalkInteractiveCardClient;
   private statusCardController?: StatusCardController;
@@ -245,15 +282,23 @@ export class DingtalkChannel extends ChannelBase {
 
     this.atSender =
       (config as unknown as Record<string, unknown>)['atSender'] === true;
+    const fileInstructions =
+      config.blockStreaming === 'on' ? '' : FILE_INSTRUCTIONS;
     if (!this.config.instructions) {
       this.config.instructions = [
         '## DingTalk Channel',
         '',
         'You are responding through DingTalk.',
         IMAGE_INSTRUCTIONS,
+        fileInstructions,
       ].join('\n');
-    } else if (!this.config.instructions.includes('[IMAGE:')) {
-      this.config.instructions += IMAGE_INSTRUCTIONS;
+    } else {
+      if (!this.config.instructions.includes('[IMAGE:')) {
+        this.config.instructions += IMAGE_INSTRUCTIONS;
+      }
+      if (fileInstructions && !this.config.instructions.includes('[FILE:')) {
+        this.config.instructions += fileInstructions;
+      }
     }
     this.interactiveCardConfig = parseDingtalkInteractiveCardConfig(
       (config as DingtalkChannelConfig).interactiveCards,
@@ -578,7 +623,7 @@ export class DingtalkChannel extends ChannelBase {
     return isGroup && !conversationId;
   }
 
-  private async prepareOutgoingText(text: string): Promise<string> {
+  private async prepareOutgoingImages(text: string): Promise<string> {
     const markers = findImageMarkers(text);
     if (markers.length === 0) return text;
 
@@ -631,24 +676,92 @@ export class DingtalkChannel extends ChannelBase {
     return replaceImageMarkers(text, markers, replacements);
   }
 
-  private async sendReply(
+  private async prepareOutgoingContent(
+    text: string,
+  ): Promise<PreparedDingTalkOutput> {
+    const imageText = await this.prepareOutgoingImages(text);
+    const markers = findFileMarkers(imageText);
+    if (markers.length === 0) return { text: imageText, files: [] };
+
+    const files: PreparedDingTalkFile[] = [];
+    const replacements: string[] = [];
+    for (const [index, marker] of markers.entries()) {
+      if (index >= MAX_FILES_PER_RESPONSE) {
+        replacements.push(
+          '[File delivery failed: response file limit exceeded]',
+        );
+        continue;
+      }
+
+      const fileName = safeFileName(marker.path);
+      try {
+        const file = readValidatedFile(marker.path, {
+          workspaceDir: this.config.cwd,
+        });
+        let mediaId: string | undefined;
+        for (let attempt = 0; attempt < 2; attempt++) {
+          const token = await this.getProactiveToken();
+          try {
+            mediaId = await uploadDingTalkFile(file, token);
+            break;
+          } catch (error) {
+            if (
+              error instanceof DingTalkMediaUploadError &&
+              error.authFailure &&
+              attempt === 0
+            ) {
+              this.proactiveToken = undefined;
+              continue;
+            }
+            throw error;
+          }
+        }
+        if (!mediaId) {
+          throw new Error('DingTalk media upload returned no MediaID');
+        }
+        files.push({
+          mediaId,
+          fileName: file.fileName,
+          fileType: file.fileType,
+        });
+        replacements.push(`[File: ${file.fileName}]`);
+      } catch (error) {
+        process.stderr.write(
+          `[DingTalk:${this.name}] outbound file upload failed (${sanitizeLogText(
+            fileName,
+            255,
+          )}): ${sanitizeLogText(
+            error instanceof Error ? error.message : String(error),
+            300,
+          )}\n`,
+        );
+        replacements.push(`[File delivery failed: ${fileName}]`);
+      }
+    }
+
+    return {
+      text: replaceFileMarkers(imageText, markers, replacements),
+      files,
+    };
+  }
+
+  private async sendPreparedReply(
     chatId: string,
     text: string,
     atUserId?: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     // chatId is a conversationId — resolve to the latest sessionWebhook
     const webhook = this.webhooks.get(chatId);
     if (!webhook) {
       process.stderr.write(
         `[DingTalk:${this.name}] No webhook for chatId ${chatId}, cannot send.\n`,
       );
-      return;
+      return false;
     }
 
-    const outgoingText = await this.prepareOutgoingText(text);
     const mentionPrefix = atUserId ? `@${atUserId}\n\n` : '';
-    const chunks = normalizeDingTalkMarkdown(mentionPrefix + outgoingText);
-    const title = extractTitle(outgoingText);
+    const chunks = normalizeDingTalkMarkdown(mentionPrefix + text);
+    const title = extractTitle(text);
 
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i]!;
@@ -694,6 +807,22 @@ export class DingtalkChannel extends ChannelBase {
         );
       }
     }
+    return true;
+  }
+
+  private async sendReply(
+    chatId: string,
+    text: string,
+    atUserId?: string,
+  ): Promise<void> {
+    if (!this.webhooks.has(chatId)) {
+      await this.sendPreparedReply(chatId, text, atUserId);
+      return;
+    }
+    const prepared = await this.prepareOutgoingContent(text);
+    if (!(await this.sendPreparedReply(chatId, prepared.text, atUserId)))
+      return;
+    await this.sendReplyFiles(chatId, prepared.files);
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
@@ -744,9 +873,9 @@ export class DingtalkChannel extends ChannelBase {
   ): Promise<void> {
     if (!text.trim()) return;
 
-    const outgoingText = await this.prepareOutgoingText(text);
-    const chunks = normalizeDingTalkMarkdown(outgoingText);
-    const title = extractTitle(outgoingText);
+    const prepared = await this.prepareOutgoingContent(text);
+    const chunks = normalizeDingTalkMarkdown(prepared.text);
+    const title = extractTitle(prepared.text);
 
     for (let i = 0; i < chunks.length; i++) {
       await this.sendProactiveChunk(
@@ -756,6 +885,37 @@ export class DingtalkChannel extends ChannelBase {
         `chunk ${i + 1}/${chunks.length}`,
       );
     }
+
+    let firstError: Error | undefined;
+    for (const file of prepared.files) {
+      try {
+        await this.sendProactiveFile(target, file);
+      } catch (error) {
+        const deliveryError =
+          error instanceof Error ? error : new Error(String(error));
+        firstError ??= deliveryError;
+        process.stderr.write(
+          `[DingTalk:${this.name}] proactive file delivery failed (${sanitizeLogText(
+            file.fileName,
+            255,
+          )}): ${sanitizeLogText(deliveryError.message, 300)}\n`,
+        );
+        try {
+          await this.sendProactiveChunk(
+            target,
+            'File delivery failed',
+            `[File delivery failed: ${file.fileName}]`,
+            'file delivery failure notice',
+          );
+        } catch (noticeError) {
+          firstError ??=
+            noticeError instanceof Error
+              ? noticeError
+              : new Error(String(noticeError));
+        }
+      }
+    }
+    if (firstError) throw firstError;
   }
 
   private async getProactiveToken(): Promise<string> {
@@ -793,6 +953,226 @@ export class DingtalkChannel extends ChannelBase {
         Date.now() + Math.max(60, (data.expires_in ?? 7200) - 60) * 1000,
     };
     return data.access_token;
+  }
+
+  private async getRobotApiToken(): Promise<string> {
+    const cached = this.robotApiToken;
+    if (cached && Date.now() < cached.expiresAt) return cached.token;
+
+    let response: Response;
+    try {
+      response = await fetch(ROBOT_TOKEN_API, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          appKey: this.config.clientId!,
+          appSecret: this.config.clientSecret!,
+        }),
+        signal: AbortSignal.timeout(PROACTIVE_FETCH_TIMEOUT_MS),
+      });
+    } catch {
+      throw new Error('DingTalk robot access token fetch failed');
+    }
+
+    let data: DingTalkRobotTokenResponse;
+    try {
+      data = (await response.json()) as DingTalkRobotTokenResponse;
+    } catch {
+      throw new Error(
+        `DingTalk robot access token request failed: HTTP ${response.status} invalid JSON response`,
+      );
+    }
+    if (!response.ok || !data.accessToken) {
+      throw new Error(
+        `DingTalk robot access token request failed: HTTP ${response.status}`,
+      );
+    }
+
+    this.robotApiToken = {
+      token: data.accessToken,
+      expiresAt: Date.now() + Math.max(60, (data.expireIn ?? 7200) - 60) * 1000,
+    };
+    return data.accessToken;
+  }
+
+  private async postRobotFileMessage(
+    url: string,
+    body: Record<string, unknown>,
+    authentication: 'robot-api' | 'session-webhook' = 'robot-api',
+  ): Promise<Record<string, unknown>> {
+    let endpoint: URL;
+    try {
+      endpoint = new URL(url);
+    } catch {
+      throw new Error('DingTalk file delivery failed: invalid endpoint');
+    }
+    if (
+      endpoint.protocol !== 'https:' ||
+      endpoint.port !== '' ||
+      !ROBOT_MESSAGE_HOSTS.has(endpoint.hostname)
+    ) {
+      throw new Error('DingTalk file delivery failed: untrusted endpoint');
+    }
+
+    const usesRobotApiToken = authentication === 'robot-api';
+    const attempts = usesRobotApiToken ? 2 : 1;
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const token = usesRobotApiToken
+        ? await this.getRobotApiToken()
+        : undefined;
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            ...(token ? { 'x-acs-dingtalk-access-token': token } : undefined),
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(PROACTIVE_FETCH_TIMEOUT_MS),
+        });
+      } catch {
+        throw new Error(
+          'DingTalk file delivery failed: network request failed',
+        );
+      }
+
+      if (usesRobotApiToken && response.status === 401 && attempt === 0) {
+        this.robotApiToken = undefined;
+        await response.body?.cancel();
+        continue;
+      }
+
+      const responseText = await response.text().catch(() => '');
+      if (!response.ok) {
+        throw new Error(
+          `DingTalk file delivery failed: HTTP ${response.status}`,
+        );
+      }
+
+      let data: Record<string, unknown> = {};
+      if (responseText.trim()) {
+        try {
+          const parsed = JSON.parse(responseText) as unknown;
+          if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new Error('invalid response');
+          }
+          data = parsed as Record<string, unknown>;
+        } catch {
+          throw new Error(
+            'DingTalk file delivery failed: invalid JSON response',
+          );
+        }
+      }
+
+      for (const value of [data['errcode'], data['code']]) {
+        if (value !== undefined && String(value) !== '0') {
+          throw new Error(
+            `DingTalk file delivery failed: API code ${sanitizeLogText(
+              String(value),
+              80,
+            )}`,
+          );
+        }
+      }
+      return data;
+    }
+    throw new Error('DingTalk file delivery failed: unauthorized');
+  }
+
+  private async sendReplyFiles(
+    chatId: string,
+    files: readonly PreparedDingTalkFile[],
+  ): Promise<void> {
+    if (files.length === 0) return;
+    const webhook = this.webhooks.get(chatId);
+    if (!webhook) return;
+
+    for (const file of files) {
+      try {
+        await this.postRobotFileMessage(
+          webhook,
+          {
+            msgtype: 'file',
+            file: {
+              mediaId: file.mediaId,
+              fileName: file.fileName,
+              fileType: file.fileType,
+            },
+          },
+          'session-webhook',
+        );
+      } catch (error) {
+        process.stderr.write(
+          `[DingTalk:${this.name}] outbound file delivery failed (${sanitizeLogText(
+            file.fileName,
+            255,
+          )}): ${sanitizeLogText(
+            error instanceof Error ? error.message : String(error),
+            300,
+          )}\n`,
+        );
+        try {
+          await this.sendPreparedReply(
+            chatId,
+            `[File delivery failed: ${file.fileName}]`,
+          );
+        } catch (noticeError) {
+          process.stderr.write(
+            `[DingTalk:${this.name}] file failure notice failed: ${sanitizeLogText(
+              noticeError instanceof Error
+                ? noticeError.message
+                : String(noticeError),
+              300,
+            )}\n`,
+          );
+        }
+      }
+    }
+  }
+
+  private async sendProactiveFile(
+    target: SessionTarget,
+    file: PreparedDingTalkFile,
+  ): Promise<void> {
+    const targetBody =
+      target.isGroup === true
+        ? { openConversationId: target.chatId }
+        : { userIds: [target.chatId] };
+    const data = await this.postRobotFileMessage(
+      target.isGroup === true ? GROUP_MSG_API : DIRECT_MSG_API,
+      {
+        robotCode: this.config.clientId!,
+        ...targetBody,
+        msgKey: PROACTIVE_FILE_MSG_KEY,
+        msgParam: JSON.stringify(file),
+      },
+    );
+
+    if (
+      target.isGroup === false &&
+      Array.isArray(data['invalidStaffIdList']) &&
+      data['invalidStaffIdList'].includes(target.chatId)
+    ) {
+      throw new Error(
+        'DingTalk file delivery failed: invalid direct recipient',
+      );
+    }
+    if (
+      target.isGroup === false &&
+      Array.isArray(data['flowControlledStaffIdList']) &&
+      data['flowControlledStaffIdList'].includes(target.chatId)
+    ) {
+      throw new Error(
+        'DingTalk file delivery failed: direct recipient rate limited',
+      );
+    }
+    if (
+      typeof data['processQueryKey'] !== 'string' ||
+      !data['processQueryKey'].trim()
+    ) {
+      throw new Error('DingTalk file delivery failed: missing processQueryKey');
+    }
   }
 
   private sendCardInteractionFeedback(
@@ -1293,11 +1673,26 @@ export class DingtalkChannel extends ChannelBase {
     text: string,
     sessionId: string,
   ): Promise<void> {
+    if (!this.webhooks.has(chatId)) {
+      await this.sendPreparedResponse(chatId, { text, files: [] }, sessionId);
+      return;
+    }
+    const prepared = await this.prepareOutgoingContent(text);
+    await this.sendPreparedResponse(chatId, prepared, sessionId);
+  }
+
+  private async sendPreparedResponse(
+    chatId: string,
+    prepared: PreparedDingTalkOutput,
+    sessionId: string,
+  ): Promise<void> {
     const atUserId = this.atSender
       ? this.sessionMentionTargets.get(sessionId)
       : undefined;
     if (atUserId) this.sessionMentionTargets.delete(sessionId);
-    await this.sendReply(chatId, text, atUserId);
+    if (!(await this.sendPreparedReply(chatId, prepared.text, atUserId)))
+      return;
+    await this.sendReplyFiles(chatId, prepared.files);
   }
 
   private async sendFallbackReply(
@@ -1310,7 +1705,12 @@ export class DingtalkChannel extends ChannelBase {
     const atUserId = this.atSender
       ? this.sessionMentionTargets.get(sessionId)
       : undefined;
-    await this.sendReply(chatId, text, atUserId);
+    if (!this.webhooks.has(chatId)) {
+      await this.sendPreparedReply(chatId, text, atUserId);
+      return;
+    }
+    const outgoingText = await this.prepareOutgoingImages(text);
+    await this.sendPreparedReply(chatId, outgoingText, atUserId);
   }
 
   protected override async onResponseComplete(
@@ -1320,17 +1720,20 @@ export class DingtalkChannel extends ChannelBase {
     segment?: ChannelOutputSegmentContext,
   ): Promise<void> {
     if (segment && this.interactionPresenter) {
-      const outgoingText = await this.prepareOutgoingText(text);
+      const prepared = await this.prepareOutgoingContent(text);
       if (
         await this.interactionPresenter.closeOutput(
           segment.segmentId,
-          outgoingText,
+          prepared.text,
           'completed',
           segment,
         )
       ) {
+        await this.sendReplyFiles(chatId, prepared.files);
         return;
       }
+      await this.sendPreparedResponse(chatId, prepared, sessionId);
+      return;
     }
     await this.sendResponseMessage(chatId, text, sessionId);
   }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -638,17 +638,36 @@ export class DingtalkChannel extends ChannelBase {
 
   private async prepareImageReplacements(
     markers: readonly ImageMarker[],
-  ): Promise<string[]> {
+  ): Promise<{ markers: ImageMarker[]; replacements: string[] }> {
+    const resolvedMarkers: ImageMarker[] = [];
     const replacements: string[] = [];
     for (const marker of markers) {
-      const fileName =
+      let resolvedMarker = marker;
+      let fileName =
         basename(marker.path)
           .replace(/[\r\n[\]]+/g, '_')
           .slice(0, 100) || 'image';
       try {
-        const image = readValidatedImage(marker.path, {
-          workspaceDir: this.config.cwd,
-        });
+        let image: ReturnType<typeof readValidatedImage> | undefined;
+        let validationError: unknown;
+        for (const candidate of [
+          ...(marker.candidates ?? [{ end: marker.end, path: marker.path }]),
+        ].sort((left, right) => right.end - left.end)) {
+          try {
+            image = readValidatedImage(candidate.path, {
+              workspaceDir: this.config.cwd,
+            });
+            resolvedMarker = { ...marker, ...candidate, candidates: undefined };
+            fileName =
+              basename(candidate.path)
+                .replace(/[\r\n[\]]+/g, '_')
+                .slice(0, 100) || 'image';
+            break;
+          } catch (error) {
+            validationError = error;
+          }
+        }
+        if (!image) throw validationError ?? new Error('Invalid image path');
         let mediaId: string | undefined;
         for (let attempt = 0; attempt < 2; attempt++) {
           const token = await this.getProactiveToken();
@@ -683,38 +702,60 @@ export class DingtalkChannel extends ChannelBase {
         );
         replacements.push(`[Image delivery failed: ${fileName}]`);
       }
+      resolvedMarkers.push(resolvedMarker);
     }
-    return replacements;
+    return { markers: resolvedMarkers, replacements };
   }
 
   private async prepareOutgoingImages(text: string): Promise<string> {
     const markers = findImageMarkers(text);
     if (markers.length === 0) return stripPartialImageMarker(text);
-    const replacements = await this.prepareImageReplacements(markers);
+    const prepared = await this.prepareImageReplacements(markers);
 
     return stripPartialImageMarker(
-      replaceImageMarkers(text, markers, replacements),
+      replaceImageMarkers(text, prepared.markers, prepared.replacements),
     );
   }
 
   private async prepareFileReplacements(
     markers: readonly FileMarker[],
-  ): Promise<{ files: PreparedDingTalkFile[]; replacements: string[] }> {
+  ): Promise<{
+    files: PreparedDingTalkFile[];
+    markers: FileMarker[];
+    replacements: string[];
+  }> {
     const files: PreparedDingTalkFile[] = [];
+    const resolvedMarkers: FileMarker[] = [];
     const replacements: string[] = [];
     for (const [index, marker] of markers.entries()) {
       if (index >= MAX_FILES_PER_RESPONSE) {
+        resolvedMarkers.push(marker);
         replacements.push(
           '[File delivery failed: response file limit exceeded]',
         );
         continue;
       }
 
-      const fileName = safeFileName(marker.path);
+      let resolvedMarker = marker;
+      let fileName = safeFileName(marker.path);
       try {
-        const file = readValidatedFile(marker.path, {
-          workspaceDir: this.config.cwd,
-        });
+        let file: ReturnType<typeof readValidatedFile> | undefined;
+        let validationError: unknown;
+        for (const candidate of [
+          ...(marker.candidates ?? [{ end: marker.end, path: marker.path }]),
+        ].sort((left, right) => right.end - left.end)) {
+          try {
+            file = readValidatedFile(candidate.path, {
+              workspaceDir: this.config.cwd,
+            });
+            resolvedMarker = { ...marker, ...candidate, candidates: undefined };
+            fileName = safeFileName(candidate.path);
+            break;
+          } catch (error) {
+            validationError = error;
+          }
+        }
+        if (!file) throw validationError ?? new Error('Invalid file path');
         let mediaId: string | undefined;
         for (let attempt = 0; attempt < 2; attempt++) {
           const token = await this.getProactiveToken();
@@ -754,8 +795,9 @@ export class DingtalkChannel extends ChannelBase {
         );
         replacements.push(`[File delivery failed: ${fileName}]`);
       }
+      resolvedMarkers.push(resolvedMarker);
     }
-    return { files, replacements };
+    return { files, markers: resolvedMarkers, replacements };
   }
 
   private async prepareOutgoingContent(
@@ -767,11 +809,15 @@ export class DingtalkChannel extends ChannelBase {
       if (next === markerText) break;
       markerText = next;
     }
-    const imageMarkers = findImageMarkers(markerText);
-    const fileMarkers = findFileMarkers(markerText);
-    const imageReplacements = await this.prepareImageReplacements(imageMarkers);
-    const { files, replacements: fileReplacements } =
-      await this.prepareFileReplacements(fileMarkers);
+    const foundImageMarkers = findImageMarkers(markerText);
+    const foundFileMarkers = findFileMarkers(markerText);
+    const { markers: imageMarkers, replacements: imageReplacements } =
+      await this.prepareImageReplacements(foundImageMarkers);
+    const {
+      files,
+      markers: fileMarkers,
+      replacements: fileReplacements,
+    } = await this.prepareFileReplacements(foundFileMarkers);
     const media = [
       ...imageMarkers.map((marker, index) => ({
         marker,

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -22,7 +22,6 @@ import {
   DingTalkMediaUploadError,
   findImageMarkers,
   readValidatedImage,
-  replaceImageMarkers,
   sanitizeStreamingImageMarkers,
   stripPartialImageMarker,
   type ImageMarker,
@@ -41,6 +40,7 @@ import {
 import {
   findTrailingPartialOutboundMediaMarker,
   replaceOutboundMediaMarkers,
+  type OutboundMediaMarker,
   unwrapFileMarkersAroundImages,
 } from './outbound-markers.js';
 import {
@@ -650,30 +650,46 @@ export class DingtalkChannel extends ChannelBase {
           .replace(/[\r\n[\]]+/g, '_')
           .slice(0, 100) || 'image';
       try {
-        let image: ReturnType<typeof readValidatedImage> | undefined;
+        const validated: Array<{
+          candidate: { end: number; path: string };
+          image: ReturnType<typeof readValidatedImage>;
+        }> = [];
         let validationError: unknown;
-        for (const candidate of [
-          ...(marker.candidates ?? [{ end: marker.end, path: marker.path }]),
-        ].sort((left, right) => right.end - left.end)) {
+        for (const candidate of this.orderedMarkerCandidates(marker)) {
           if (candidate.end < marker.end) {
             validationError = new Error('Image marker path is incomplete');
             continue;
           }
           try {
-            image = readValidatedImage(candidate.path, {
-              workspaceDir: this.config.cwd,
+            validated.push({
+              candidate,
+              image: readValidatedImage(candidate.path, {
+                workspaceDir: this.config.cwd,
+              }),
             });
-            resolvedMarker = { ...marker, ...candidate, candidates: undefined };
-            fileName =
-              basename(candidate.path)
-                .replace(/[\r\n[\]]+/g, '_')
-                .slice(0, 100) || 'image';
-            break;
           } catch (error) {
             validationError = error;
           }
         }
-        if (!image) throw validationError ?? new Error('Invalid image path');
+        if (validated.length > 1) {
+          const longest = validated.reduce((left, right) =>
+            left.candidate.end >= right.candidate.end ? left : right,
+          ).candidate;
+          resolvedMarker = { ...marker, ...longest, candidates: undefined };
+          fileName =
+            basename(longest.path)
+              .replace(/[\r\n[\]]+/g, '_')
+              .slice(0, 100) || 'image';
+          throw new Error('Image marker path is ambiguous');
+        }
+        const match = validated[0];
+        if (!match) throw validationError ?? new Error('Invalid image path');
+        const { candidate, image } = match;
+        resolvedMarker = { ...marker, ...candidate, candidates: undefined };
+        fileName =
+          basename(candidate.path)
+            .replace(/[\r\n[\]]+/g, '_')
+            .slice(0, 100) || 'image';
         let mediaId: string | undefined;
         for (let attempt = 0; attempt < 2; attempt++) {
           const token = await this.getProactiveToken();
@@ -713,16 +729,6 @@ export class DingtalkChannel extends ChannelBase {
     return { markers: resolvedMarkers, replacements };
   }
 
-  private async prepareOutgoingImages(text: string): Promise<string> {
-    const markers = findImageMarkers(text);
-    if (markers.length === 0) return stripPartialImageMarker(text);
-    const prepared = await this.prepareImageReplacements(markers);
-
-    return stripPartialImageMarker(
-      replaceImageMarkers(text, prepared.markers, prepared.replacements),
-    );
-  }
-
   private async prepareFileReplacements(
     markers: readonly FileMarker[],
   ): Promise<{
@@ -745,27 +751,40 @@ export class DingtalkChannel extends ChannelBase {
       let resolvedMarker = marker;
       let fileName = safeFileName(marker.path);
       try {
-        let file: ReturnType<typeof readValidatedFile> | undefined;
+        const validated: Array<{
+          candidate: { end: number; path: string };
+          file: ReturnType<typeof readValidatedFile>;
+        }> = [];
         let validationError: unknown;
-        for (const candidate of [
-          ...(marker.candidates ?? [{ end: marker.end, path: marker.path }]),
-        ].sort((left, right) => right.end - left.end)) {
+        for (const candidate of this.orderedMarkerCandidates(marker)) {
           if (candidate.end < marker.end) {
             validationError = new Error('File marker path is incomplete');
             continue;
           }
           try {
-            file = readValidatedFile(candidate.path, {
-              workspaceDir: this.config.cwd,
+            validated.push({
+              candidate,
+              file: readValidatedFile(candidate.path, {
+                workspaceDir: this.config.cwd,
+              }),
             });
-            resolvedMarker = { ...marker, ...candidate, candidates: undefined };
-            fileName = safeFileName(candidate.path);
-            break;
           } catch (error) {
             validationError = error;
           }
         }
-        if (!file) throw validationError ?? new Error('Invalid file path');
+        if (validated.length > 1) {
+          const longest = validated.reduce((left, right) =>
+            left.candidate.end >= right.candidate.end ? left : right,
+          ).candidate;
+          resolvedMarker = { ...marker, ...longest, candidates: undefined };
+          fileName = safeFileName(longest.path);
+          throw new Error('File marker path is ambiguous');
+        }
+        const match = validated[0];
+        if (!match) throw validationError ?? new Error('Invalid file path');
+        const { candidate, file } = match;
+        resolvedMarker = { ...marker, ...candidate, candidates: undefined };
+        fileName = safeFileName(candidate.path);
         let mediaId: string | undefined;
         for (let attempt = 0; attempt < 2; attempt++) {
           const token = await this.getProactiveToken();
@@ -854,6 +873,16 @@ export class DingtalkChannel extends ChannelBase {
     }
 
     return { text: result, files };
+  }
+
+  private orderedMarkerCandidates(marker: OutboundMediaMarker) {
+    return [
+      ...(marker.candidates ?? [{ end: marker.end, path: marker.path }]),
+    ].sort((left, right) => {
+      if (left.end === marker.end) return -1;
+      if (right.end === marker.end) return 1;
+      return right.end - left.end;
+    });
   }
 
   private async sendPreparedReplyWithFiles(
@@ -1859,12 +1888,30 @@ export class DingtalkChannel extends ChannelBase {
       await this.sendResponseText(chatId, text, sessionId);
       return;
     }
-    await this.flushBlockStreamingMediaCarry(chatId, sessionId);
-    const ready = this.takeBlockStreamingText(sessionId, text);
-    if (ready !== undefined) {
+    const partial = findTrailingPartialOutboundMediaMarker(text);
+    if (!partial) {
+      await this.sendResponseText(chatId, text, sessionId);
+      return;
+    }
+    const ready = text.slice(0, partial.start);
+    if (ready.trim()) {
       await this.sendResponseText(chatId, ready, sessionId);
     }
-    await this.flushBlockStreamingMediaCarry(chatId, sessionId);
+    const pending = text.slice(partial.start);
+    if (partial.complete) {
+      await this.sendResponseText(chatId, pending, sessionId);
+      return;
+    }
+    const failure = partial.markerName
+      ? partial.markerName === 'IMAGE'
+        ? '[Image delivery failed: incomplete marker]'
+        : '[File delivery failed: incomplete marker]'
+      : pending;
+    await this.sendPreparedResponse(
+      chatId,
+      { text: failure, files: [] },
+      sessionId,
+    );
   }
 
   private async sendResponseText(
@@ -1906,8 +1953,8 @@ export class DingtalkChannel extends ChannelBase {
       await this.sendPreparedReply(chatId, text, atUserId);
       return;
     }
-    const outgoingText = await this.prepareOutgoingImages(text);
-    await this.sendPreparedReply(chatId, outgoingText, atUserId);
+    const prepared = await this.prepareOutgoingContent(text);
+    await this.sendPreparedReplyWithFiles(chatId, prepared, atUserId);
   }
 
   protected override async onResponseComplete(

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -23,6 +23,7 @@ import {
   findImageMarkers,
   readValidatedImage,
   replaceImageMarkers,
+  stripPartialImageMarker,
   uploadDingTalkImage,
 } from './outbound-image.js';
 import {
@@ -31,6 +32,7 @@ import {
   readValidatedFile,
   replaceFileMarkers,
   safeFileName,
+  stripPartialFileMarker,
   uploadDingTalkFile,
 } from './outbound-file.js';
 import {
@@ -625,7 +627,7 @@ export class DingtalkChannel extends ChannelBase {
 
   private async prepareOutgoingImages(text: string): Promise<string> {
     const markers = findImageMarkers(text);
-    if (markers.length === 0) return text;
+    if (markers.length === 0) return stripPartialImageMarker(text);
 
     const replacements: string[] = [];
     for (const marker of markers) {
@@ -673,7 +675,9 @@ export class DingtalkChannel extends ChannelBase {
       }
     }
 
-    return replaceImageMarkers(text, markers, replacements);
+    return stripPartialImageMarker(
+      replaceImageMarkers(text, markers, replacements),
+    );
   }
 
   private async prepareOutgoingContent(
@@ -681,7 +685,9 @@ export class DingtalkChannel extends ChannelBase {
   ): Promise<PreparedDingTalkOutput> {
     const imageText = await this.prepareOutgoingImages(text);
     const markers = findFileMarkers(imageText);
-    if (markers.length === 0) return { text: imageText, files: [] };
+    if (markers.length === 0) {
+      return { text: stripPartialFileMarker(imageText), files: [] };
+    }
 
     const files: PreparedDingTalkFile[] = [];
     const replacements: string[] = [];
@@ -724,7 +730,7 @@ export class DingtalkChannel extends ChannelBase {
           fileName: file.fileName,
           fileType: file.fileType,
         });
-        replacements.push(`[File: ${file.fileName}]`);
+        replacements.push(`[File sent: ${file.fileName}]`);
       } catch (error) {
         process.stderr.write(
           `[DingTalk:${this.name}] outbound file upload failed (${sanitizeLogText(
@@ -740,7 +746,9 @@ export class DingtalkChannel extends ChannelBase {
     }
 
     return {
-      text: replaceFileMarkers(imageText, markers, replacements),
+      text: stripPartialFileMarker(
+        replaceFileMarkers(imageText, markers, replacements),
+      ),
       files,
     };
   }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -41,6 +41,7 @@ import {
 import {
   findTrailingPartialOutboundMediaMarker,
   replaceOutboundMediaMarkers,
+  unwrapFileMarkersAroundImages,
 } from './outbound-markers.js';
 import {
   DingtalkConnectionManager,
@@ -812,7 +813,7 @@ export class DingtalkChannel extends ChannelBase {
   private async prepareOutgoingContent(
     text: string,
   ): Promise<PreparedDingTalkOutput> {
-    let markerText = text;
+    let markerText = unwrapFileMarkersAroundImages(text);
     while (true) {
       const next = stripPartialImageMarker(stripPartialFileMarker(markerText));
       if (next === markerText) break;
@@ -853,6 +854,25 @@ export class DingtalkChannel extends ChannelBase {
     }
 
     return { text: result, files };
+  }
+
+  private async sendPreparedReplyWithFiles(
+    chatId: string,
+    prepared: PreparedDingTalkOutput,
+    atUserId?: string,
+  ): Promise<void> {
+    let replyFailed = false;
+    let replyError: unknown;
+    try {
+      if (!(await this.sendPreparedReply(chatId, prepared.text, atUserId))) {
+        return;
+      }
+    } catch (error) {
+      replyFailed = true;
+      replyError = error;
+    }
+    await this.sendReplyFiles(chatId, prepared.files);
+    if (replyFailed) throw replyError;
   }
 
   private async sendPreparedReply(
@@ -931,9 +951,7 @@ export class DingtalkChannel extends ChannelBase {
       return;
     }
     const prepared = await this.prepareOutgoingContent(text);
-    if (!(await this.sendPreparedReply(chatId, prepared.text, atUserId)))
-      return;
-    await this.sendReplyFiles(chatId, prepared.files);
+    await this.sendPreparedReplyWithFiles(chatId, prepared, atUserId);
   }
 
   async sendMessage(chatId: string, text: string): Promise<void> {
@@ -1871,9 +1889,7 @@ export class DingtalkChannel extends ChannelBase {
       ? this.sessionMentionTargets.get(sessionId)
       : undefined;
     if (atUserId) this.sessionMentionTargets.delete(sessionId);
-    if (!(await this.sendPreparedReply(chatId, prepared.text, atUserId)))
-      return;
-    await this.sendReplyFiles(chatId, prepared.files);
+    await this.sendPreparedReplyWithFiles(chatId, prepared, atUserId);
   }
 
   private async sendFallbackReply(
@@ -1902,15 +1918,23 @@ export class DingtalkChannel extends ChannelBase {
   ): Promise<void> {
     if (segment && this.interactionPresenter) {
       const prepared = await this.prepareOutgoingContent(text);
-      if (
-        await this.interactionPresenter.closeOutput(
+      let closeFailed = false;
+      let closeError: unknown;
+      let closed = false;
+      try {
+        closed = await this.interactionPresenter.closeOutput(
           segment.segmentId,
           prepared.text,
           'completed',
           segment,
-        )
-      ) {
+        );
+      } catch (error) {
+        closeFailed = true;
+        closeError = error;
+      }
+      if (closed || closeFailed) {
         await this.sendReplyFiles(chatId, prepared.files);
+        if (closeFailed) throw closeError;
         return;
       }
       await this.sendPreparedResponse(chatId, prepared, sessionId);

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -149,6 +149,7 @@ const PROACTIVE_MSG_KEY = 'sampleMarkdown'; // DingTalk's built-in {title, text}
 const PROACTIVE_FILE_MSG_KEY = 'sampleFile';
 const TOKEN_API = 'https://oapi.dingtalk.com/gettoken';
 const PROACTIVE_FETCH_TIMEOUT_MS = 15_000;
+const WEBHOOK_FETCH_TIMEOUT_MS = 30_000;
 const ROBOT_MESSAGE_HOSTS = new Set(['api.dingtalk.com', 'oapi.dingtalk.com']);
 const mentionTarget = Symbol('mentionTarget');
 const IMAGE_INSTRUCTIONS = [
@@ -251,7 +252,7 @@ export class DingtalkChannel extends ChannelBase {
   private sessionMentionTargets = new Map<string, string>();
   private blockStreamingMediaCarry = new Map<
     string,
-    { text: string; markerName?: 'IMAGE' | 'FILE' }
+    { text: string; markerName?: 'IMAGE' | 'FILE'; complete?: boolean }
   >();
   private bufferedMentionTargets = new Set<string>();
   private bufferedMentionTargetsBySession = new Map<string, Set<string>>();
@@ -653,6 +654,10 @@ export class DingtalkChannel extends ChannelBase {
         for (const candidate of [
           ...(marker.candidates ?? [{ end: marker.end, path: marker.path }]),
         ].sort((left, right) => right.end - left.end)) {
+          if (candidate.end < marker.end) {
+            validationError = new Error('Image marker path is incomplete');
+            continue;
+          }
           try {
             image = readValidatedImage(candidate.path, {
               workspaceDir: this.config.cwd,
@@ -744,6 +749,10 @@ export class DingtalkChannel extends ChannelBase {
         for (const candidate of [
           ...(marker.candidates ?? [{ end: marker.end, path: marker.path }]),
         ].sort((left, right) => right.end - left.end)) {
+          if (candidate.end < marker.end) {
+            validationError = new Error('File marker path is incomplete');
+            continue;
+          }
           try {
             file = readValidatedFile(candidate.path, {
               workspaceDir: this.config.cwd,
@@ -880,6 +889,7 @@ export class DingtalkChannel extends ChannelBase {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(WEBHOOK_FETCH_TIMEOUT_MS),
       });
 
       if (isMention && process.env['QWEN_CHANNEL_DEBUG_MENTIONS'] === '1') {
@@ -1785,6 +1795,7 @@ export class DingtalkChannel extends ChannelBase {
     this.blockStreamingMediaCarry.set(sessionId, {
       text: combined.slice(partial.start),
       markerName: partial.markerName,
+      complete: partial.complete,
     });
     const ready = combined.slice(0, partial.start);
     return ready.trim() ? ready : undefined;
@@ -1797,6 +1808,9 @@ export class DingtalkChannel extends ChannelBase {
     const pending = this.blockStreamingMediaCarry.get(sessionId);
     if (!pending) return undefined;
     this.blockStreamingMediaCarry.delete(sessionId);
+    if (pending.complete) {
+      return this.sendResponseText(chatId, pending.text, sessionId);
+    }
     const text = pending.markerName
       ? pending.markerName === 'IMAGE'
         ? '[Image delivery failed: incomplete marker]'
@@ -1912,9 +1926,7 @@ export class DingtalkChannel extends ChannelBase {
     reason: ChannelOutputSegmentEndReason,
   ): void | Promise<void> {
     const carry =
-      reason === 'completed' ||
-      reason === 'response_boundary' ||
-      reason === 'input_requested'
+      reason === 'completed' || reason === 'response_boundary'
         ? this.flushBlockStreamingMediaCarry(chatId, sessionId)
         : undefined;
     if (reason === 'failed' || reason === 'cancelled') {

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -23,6 +23,7 @@ import {
   findImageMarkers,
   readValidatedImage,
   replaceImageMarkers,
+  sanitizeStreamingImageMarkers,
   stripPartialImageMarker,
   type ImageMarker,
   uploadDingTalkImage,
@@ -32,12 +33,12 @@ import {
   findFileMarkers,
   readValidatedFile,
   safeFileName,
+  sanitizeStreamingFileMarkers,
   stripPartialFileMarker,
   type FileMarker,
   uploadDingTalkFile,
 } from './outbound-file.js';
 import {
-  findOutboundMediaMarkers,
   findTrailingPartialOutboundMediaMarker,
   replaceOutboundMediaMarkers,
 } from './outbound-markers.js';
@@ -250,7 +251,7 @@ export class DingtalkChannel extends ChannelBase {
   private sessionMentionTargets = new Map<string, string>();
   private blockStreamingMediaCarry = new Map<
     string,
-    { text: string; markerName: 'IMAGE' | 'FILE' }
+    { text: string; markerName?: 'IMAGE' | 'FILE' }
   >();
   private bufferedMentionTargets = new Set<string>();
   private bufferedMentionTargetsBySession = new Map<string, Set<string>>();
@@ -760,7 +761,12 @@ export class DingtalkChannel extends ChannelBase {
   private async prepareOutgoingContent(
     text: string,
   ): Promise<PreparedDingTalkOutput> {
-    const markerText = stripPartialImageMarker(text);
+    let markerText = text;
+    while (true) {
+      const next = stripPartialImageMarker(stripPartialFileMarker(markerText));
+      if (next === markerText) break;
+      markerText = next;
+    }
     const imageMarkers = findImageMarkers(markerText);
     const fileMarkers = findFileMarkers(markerText);
     const imageReplacements = await this.prepareImageReplacements(imageMarkers);
@@ -782,48 +788,16 @@ export class DingtalkChannel extends ChannelBase {
       media.map(({ replacement }) => replacement),
     );
 
-    return {
-      text: stripPartialFileMarker(
-        this.sanitizeSyntheticImageMarkers(markerText, replaced),
-      ),
-      files,
-    };
-  }
-
-  private sanitizeSyntheticImageMarkers(
-    originalText: string,
-    preparedText: string,
-  ): string {
-    const deliverableStarts = new Set(
-      findImageMarkers(originalText).map(({ start }) => start),
-    );
-    const preserved = new Map<string, number>();
-    for (const marker of findOutboundMediaMarkers(
-      originalText,
-      'IMAGE',
-      true,
-    )) {
-      if (deliverableStarts.has(marker.start)) continue;
-      const source = originalText.slice(marker.start, marker.end);
-      preserved.set(source, (preserved.get(source) ?? 0) + 1);
-    }
-    let result = preparedText;
+    let result = replaced;
     while (true) {
-      const retained = new Map(preserved);
-      const markers = findOutboundMediaMarkers(result, 'IMAGE', true);
-      const replacements = markers.map((marker) => {
-        const source = result.slice(marker.start, marker.end);
-        const remaining = retained.get(source) ?? 0;
-        if (remaining === 0) return '[Image pending]';
-        retained.set(source, remaining - 1);
-        return source;
-      });
-      const next = stripPartialImageMarker(
-        replaceOutboundMediaMarkers(result, markers, replacements),
+      const next = sanitizeStreamingFileMarkers(
+        sanitizeStreamingImageMarkers(result),
       );
-      if (next === result) return result;
+      if (next === result) break;
       result = next;
     }
+
+    return { text: result, files };
   }
 
   private async sendPreparedReply(
@@ -1777,10 +1751,11 @@ export class DingtalkChannel extends ChannelBase {
     const pending = this.blockStreamingMediaCarry.get(sessionId);
     if (!pending) return undefined;
     this.blockStreamingMediaCarry.delete(sessionId);
-    const text =
-      pending.markerName === 'IMAGE'
+    const text = pending.markerName
+      ? pending.markerName === 'IMAGE'
         ? '[Image delivery failed: incomplete marker]'
-        : '[File delivery failed: incomplete marker]';
+        : '[File delivery failed: incomplete marker]'
+      : pending.text;
     return this.sendPreparedResponse(chatId, { text, files: [] }, sessionId);
   }
 
@@ -1794,6 +1769,31 @@ export class DingtalkChannel extends ChannelBase {
       if (ready === undefined) return;
       text = ready;
     }
+    await this.sendResponseText(chatId, text, sessionId);
+  }
+
+  protected override async sendOneShotResponseMessage(
+    chatId: string,
+    text: string,
+    sessionId: string,
+  ): Promise<void> {
+    if (this.config.blockStreaming !== 'on') {
+      await this.sendResponseText(chatId, text, sessionId);
+      return;
+    }
+    await this.flushBlockStreamingMediaCarry(chatId, sessionId);
+    const ready = this.takeBlockStreamingText(sessionId, text);
+    if (ready !== undefined) {
+      await this.sendResponseText(chatId, ready, sessionId);
+    }
+    await this.flushBlockStreamingMediaCarry(chatId, sessionId);
+  }
+
+  private async sendResponseText(
+    chatId: string,
+    text: string,
+    sessionId: string,
+  ): Promise<void> {
     if (!this.webhooks.has(chatId)) {
       await this.sendPreparedResponse(chatId, { text, files: [] }, sessionId);
       return;
@@ -1866,7 +1866,9 @@ export class DingtalkChannel extends ChannelBase {
     reason: ChannelOutputSegmentEndReason,
   ): void | Promise<void> {
     const carry =
-      reason === 'completed' || reason === 'response_boundary'
+      reason === 'completed' ||
+      reason === 'response_boundary' ||
+      reason === 'input_requested'
         ? this.flushBlockStreamingMediaCarry(chatId, sessionId)
         : undefined;
     if (reason === 'failed' || reason === 'cancelled') {

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -790,6 +790,18 @@ describe('DingtalkInteractionPresenter', () => {
     );
   });
 
+  it('reassembles a file marker split across streamed chunks', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(segment('segment-1'), 'A [FILE: /tm');
+    presenter.appendOutput(segment('segment-1'), 'p/x.pdf] B');
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith('cid-1', 'A  B', 'session-1');
+  });
+
   it('neutralizes an image marker orphaned by file sanitization', async () => {
     const sendFallback = vi.fn().mockResolvedValue(undefined);
     const presenter = new DingtalkInteractionPresenter({ sendFallback });

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -914,6 +914,24 @@ describe('DingtalkInteractionPresenter', () => {
     );
   });
 
+  it('keeps bracketed text after a nested image wrapper', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      '[FILE: [IMAGE: /tmp/chart.png]] As shown in [1]',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      '[IMAGE: /tmp/chart.png] As shown in [1]',
+      'session-1',
+    );
+  });
+
   it('removes a complete outer file suffix around a nested image', async () => {
     const sendFallback = vi.fn().mockResolvedValue(undefined);
     const presenter = new DingtalkInteractionPresenter({ sendFallback });

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -950,7 +950,7 @@ describe('DingtalkInteractionPresenter', () => {
     );
   });
 
-  it('keeps trailing text from an unclosed file wrapper around an image', async () => {
+  it('drops ambiguous trailing text from an unclosed file wrapper', async () => {
     const sendFallback = vi.fn().mockResolvedValue(undefined);
     const presenter = new DingtalkInteractionPresenter({ sendFallback });
     presenter.registerRun('run-1', 'owner-1', target);
@@ -963,7 +963,7 @@ describe('DingtalkInteractionPresenter', () => {
 
     expect(sendFallback).toHaveBeenCalledWith(
       'cid-1',
-      'Report [IMAGE: /tmp/chart.png] summary',
+      'Report [IMAGE: /tmp/chart.png]',
       'session-1',
     );
   });

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -828,7 +828,7 @@ describe('DingtalkInteractionPresenter', () => {
       'multiline inline code',
       '`example\n[FILE: /Users/ben/private/report.pdf]\ncontinued`',
     ],
-  ])('preserves file-like text inside %s', async (_label, output) => {
+  ])('scrubs file marker paths inside %s', async (_label, output) => {
     const sendFallback = vi.fn().mockResolvedValue(undefined);
     const presenter = new DingtalkInteractionPresenter({ sendFallback });
     presenter.registerRun('run-1', 'owner-1', target);
@@ -836,7 +836,29 @@ describe('DingtalkInteractionPresenter', () => {
 
     await presenter.closeOutput('segment-1', '', 'response_boundary');
 
-    expect(sendFallback).toHaveBeenCalledWith('cid-1', output, 'session-1');
+    const fallback = vi.mocked(sendFallback).mock.calls[0]?.[1];
+    expect(fallback).not.toContain('[FILE:');
+    expect(fallback).not.toContain('/Users/ben/private');
+  });
+
+  it('scrubs markers after chunked windowing drops a fence opener', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      `\`\`\`text\n${'x'.repeat(CONTENT_LIMIT + 100)}`,
+    );
+    presenter.appendOutput(
+      segment('segment-1'),
+      '\n```\n[FILE: /Users/ben/private/report.pdf]',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    const fallback = vi.mocked(sendFallback).mock.calls[0]?.[1];
+    expect(fallback).not.toContain('[FILE:');
+    expect(fallback).not.toContain('/Users/ben/private');
   });
 
   it('does not expose a file path when truncation splits its marker', async () => {

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -790,6 +790,22 @@ describe('DingtalkInteractionPresenter', () => {
     );
   });
 
+  it('neutralizes an image marker orphaned by file sanitization', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      'x [IMAGE: /Users/ben/private/report.png [FILE: /tmp/b]',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    const fallbackText = vi.mocked(sendFallback).mock.calls[0]?.[1];
+    expect(fallbackText).toBe('x [Image pending]');
+    expect(fallbackText).not.toContain('/Users/ben/private');
+  });
+
   it.each([
     [
       'tilde-fenced code',
@@ -826,7 +842,25 @@ describe('DingtalkInteractionPresenter', () => {
     await presenter.closeOutput('segment-1', '', 'response_boundary');
 
     const fallbackText = vi.mocked(sendFallback).mock.calls[0]?.[1];
-    expect(fallbackText).toBe(`${TRUNCATION_MARKER}${suffix}`);
+    expect(fallbackText).toBe(`${prefix}${suffix}`);
+    expect(fallbackText).not.toContain('/Users/ben/private');
+  });
+
+  it('sanitizes markers before truncating across a code fence', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    const output = [
+      '```text',
+      'x'.repeat(CONTENT_LIMIT),
+      '```',
+      '[FILE: /Users/ben/private/report.pdf]',
+    ].join('\n');
+    presenter.appendOutput(segment('segment-1'), output);
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    const fallbackText = vi.mocked(sendFallback).mock.calls[0]?.[1];
     expect(fallbackText).not.toContain('/Users/ben/private');
   });
 

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -11,7 +11,11 @@ import {
 } from './interactive-card-client.js';
 import { DingtalkInteractionPresenter } from './interaction-presenter.js';
 import { QuestionCardController } from './question-card-controller.js';
-import { StatusCardController } from './status-card-controller.js';
+import {
+  CONTENT_LIMIT,
+  StatusCardController,
+  TRUNCATION_MARKER,
+} from './status-card-controller.js';
 
 type ExpectedCallbackResult =
   | { kind: 'accepted'; execute: () => Promise<void> }
@@ -764,6 +768,66 @@ describe('DingtalkInteractionPresenter', () => {
       'photo [Image pending]',
       'session-1',
     );
+  });
+
+  it('neutralizes complete file markers in text fallbacks', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      'file [FILE: /Users/ben/private/report.pdf] ready',
+    );
+
+    await expect(
+      presenter.closeOutput('segment-1', '', 'response_boundary'),
+    ).resolves.toBe(true);
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      'file  ready',
+      'session-1',
+    );
+  });
+
+  it.each([
+    [
+      'tilde-fenced code',
+      ['~~~text', '[FILE: /Users/ben/private/report.pdf]', '~~~'].join('\n'),
+    ],
+    ['indented code', '    [FILE: /Users/ben/private/report.pdf]'],
+    [
+      'multiline inline code',
+      '`example\n[FILE: /Users/ben/private/report.pdf]\ncontinued`',
+    ],
+  ])('preserves file-like text inside %s', async (_label, output) => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(segment('segment-1'), output);
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith('cid-1', output, 'session-1');
+  });
+
+  it('does not expose a file path when truncation splits its marker', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    const marker = '[FILE: /Users/ben/private/report.pdf]';
+    const splitOffset = '[FILE: '.length;
+    const prefix = 'x'.repeat(TRUNCATION_MARKER.length + 10);
+    const suffix = 'z'.repeat(
+      CONTENT_LIMIT - TRUNCATION_MARKER.length + splitOffset - marker.length,
+    );
+    presenter.appendOutput(segment('segment-1'), `${prefix}${marker}${suffix}`);
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    const fallbackText = vi.mocked(sendFallback).mock.calls[0]?.[1];
+    expect(fallbackText).toBe(`${TRUNCATION_MARKER}${suffix}`);
+    expect(fallbackText).not.toContain('/Users/ben/private');
   });
 
   it('keeps a bare trailing bracket out of text fallbacks', async () => {

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -834,6 +834,22 @@ describe('DingtalkInteractionPresenter', () => {
     expect(fallbackText).not.toContain('/Users/ben/private');
   });
 
+  it('neutralizes an image marker assembled inside Markdown code', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      '```\n[IMAGE[FILE: /decoy]: /Users/ben/private/leak.png]\n```',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    const fallbackText = vi.mocked(sendFallback).mock.calls[0]?.[1];
+    expect(fallbackText).toBe('```\n[Image pending]\n```');
+    expect(fallbackText).not.toContain('/Users/ben/private');
+  });
+
   it.each([
     [
       'tilde-fenced code',

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -770,6 +770,59 @@ describe('DingtalkInteractionPresenter', () => {
     );
   });
 
+  it('neutralizes escaped image markers in text fallbacks', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      String.raw`see \[IMAGE: /Users/ben/private/leak.png] done`,
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      String.raw`see \[Image pending] done`,
+      'session-1',
+    );
+  });
+
+  it('protects live image markers while neutralizing malformed syntax', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      '` a [FILE: x`] [IMAGE: /tmp/i.png] `',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      '` a  [IMAGE: /tmp/i.png] `',
+      'session-1',
+    );
+  });
+
+  it('does not let neutralization consume protected images or trailing prose', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    const output =
+      '格式如 `[IMAGE: demo.png]` 所示，实际输出 [IMAGE: /tmp/out.png]，引用[2]';
+    presenter.appendOutput(segment('segment-1'), output);
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      '格式如 `[Image pending]` 所示，实际输出 [IMAGE: /tmp/out.png]，引用[2]',
+      'session-1',
+    );
+  });
+
   it('neutralizes complete file markers in text fallbacks', async () => {
     const sendFallback = vi.fn().mockResolvedValue(undefined);
     const presenter = new DingtalkInteractionPresenter({ sendFallback });

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -850,6 +850,106 @@ describe('DingtalkInteractionPresenter', () => {
     expect(fallbackText).not.toContain('/Users/ben/private');
   });
 
+  it('restores image markers with replacement metacharacters literally', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    const marker = `[IMAGE: /tmp/$&-$'.png]`;
+    presenter.appendOutput(segment('segment-1'), marker);
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith('cid-1', marker, 'session-1');
+  });
+
+  it.each([
+    ['fenced image', '```text\n[IMAGE: /Users/ben/private/image.png\n```'],
+    ['indented file', '    [FILE: /Users/ben/private/report.pdf'],
+  ])('scrubs an unclosed marker inside %s', async (_label, output) => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(segment('segment-1'), output);
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    const fallback = vi.mocked(sendFallback).mock.calls[0]?.[1];
+    expect(fallback).not.toContain('/Users/ben/private');
+    expect(fallback).not.toMatch(/\[(?:IMAGE|FILE):/u);
+  });
+
+  it('keeps a nested image available when stripping an outer file marker', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      'Report [FILE: unfinished [IMAGE: /tmp/chart.png]',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      'Report [IMAGE: /tmp/chart.png]',
+      'session-1',
+    );
+  });
+
+  it('keeps a nested image when a complete outer file marker wraps it', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      '[FILE: report [IMAGE: /tmp/chart.png]]',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      '[IMAGE: /tmp/chart.png]',
+      'session-1',
+    );
+  });
+
+  it('removes a complete outer file suffix around a nested image', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      '[FILE: /outer [IMAGE: /tmp/chart.png] /Users/ben/private/report.pdf]',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      '[IMAGE: /tmp/chart.png]',
+      'session-1',
+    );
+  });
+
+  it('keeps trailing text from an unclosed file wrapper around an image', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      'Report [FILE: [IMAGE: /tmp/chart.png] summary',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    expect(sendFallback).toHaveBeenCalledWith(
+      'cid-1',
+      'Report [IMAGE: /tmp/chart.png] summary',
+      'session-1',
+    );
+  });
+
   it.each([
     [
       'tilde-fenced code',

--- a/packages/channels/dingtalk/src/interaction-presenter.test.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.test.ts
@@ -818,6 +818,22 @@ describe('DingtalkInteractionPresenter', () => {
     expect(fallbackText).not.toContain('/Users/ben/private');
   });
 
+  it('neutralizes an image marker assembled by file sanitization', async () => {
+    const sendFallback = vi.fn().mockResolvedValue(undefined);
+    const presenter = new DingtalkInteractionPresenter({ sendFallback });
+    presenter.registerRun('run-1', 'owner-1', target);
+    presenter.appendOutput(
+      segment('segment-1'),
+      'x [IMAGE[FILE: /decoy]: /Users/ben/private/leak.png] y',
+    );
+
+    await presenter.closeOutput('segment-1', '', 'response_boundary');
+
+    const fallbackText = vi.mocked(sendFallback).mock.calls[0]?.[1];
+    expect(fallbackText).toBe('x [Image pending] y');
+    expect(fallbackText).not.toContain('/Users/ben/private');
+  });
+
   it.each([
     [
       'tilde-fenced code',

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -44,7 +44,9 @@ export interface DingtalkInteractionPresenterOptions {
 }
 
 function sanitizeFallbackOutput(text: string): string {
-  return sanitizeStreamingFileMarkers(stripPartialImageMarker(text));
+  return stripPartialImageMarker(
+    sanitizeStreamingFileMarkers(stripPartialImageMarker(text)),
+  );
 }
 
 export interface DingtalkCardSender {
@@ -393,7 +395,11 @@ export class DingtalkInteractionPresenter {
   }
 
   private boundContent(content: string, limit = CONTENT_LIMIT): string {
-    return truncateOutboundMediaText(content, limit, TRUNCATION_MARKER);
+    return truncateOutboundMediaText(
+      sanitizeFallbackOutput(content),
+      limit,
+      TRUNCATION_MARKER,
+    );
   }
 
   private withSenderPrefix(run: RunPresentation, content: string): string {

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -8,6 +8,8 @@ import type {
   UserInputPresentationResult,
 } from '@qwen-code/channel-base';
 import { stripPartialImageMarker } from './outbound-image.js';
+import { sanitizeStreamingFileMarkers } from './outbound-file.js';
+import { truncateOutboundMediaText } from './outbound-markers.js';
 import type { QuestionCardController } from './question-card-controller.js';
 import {
   CONTENT_LIMIT,
@@ -39,6 +41,10 @@ export interface DingtalkInteractionPresenterOptions {
   statusCards?: StatusCardController;
   questionCards?: QuestionCardController;
   sendFallback?(chatId: string, text: string, sessionId: string): Promise<void>;
+}
+
+function sanitizeFallbackOutput(text: string): string {
+  return sanitizeStreamingFileMarkers(stripPartialImageMarker(text));
 }
 
 export interface DingtalkCardSender {
@@ -185,13 +191,13 @@ export class DingtalkInteractionPresenter {
           (await statusCards.flushPending(statusContext.segmentId));
         if (deliveredViaCard) {
           run.cardDelivered = {
-            text: stripPartialImageMarker(text || presentation.content),
+            text: sanitizeFallbackOutput(text || presentation.content),
             chatId: presentation.context.target.chatId,
             sessionId: presentation.context.sessionId,
           };
           return true;
         }
-        const fallbackText = stripPartialImageMarker(
+        const fallbackText = sanitizeFallbackOutput(
           text || presentation.content,
         );
         if (!fallbackText || !this.options.sendFallback) return false;
@@ -211,7 +217,7 @@ export class DingtalkInteractionPresenter {
           ));
         run.statusContext = undefined;
         if (completed) return true;
-        const fallbackText = stripPartialImageMarker(
+        const fallbackText = sanitizeFallbackOutput(
           text || presentation.content,
         );
         if (!fallbackText || !this.options.sendFallback) return false;
@@ -230,9 +236,7 @@ export class DingtalkInteractionPresenter {
           this.withSenderPrefix(run, text || presentation.content),
         ));
       if (completed) return true;
-      const fallbackText = stripPartialImageMarker(
-        text || presentation.content,
-      );
+      const fallbackText = sanitizeFallbackOutput(text || presentation.content);
       if (!fallbackText || !this.options.sendFallback) return false;
       await this.options.sendFallback(
         presentation.context.target.chatId,
@@ -389,12 +393,7 @@ export class DingtalkInteractionPresenter {
   }
 
   private boundContent(content: string, limit = CONTENT_LIMIT): string {
-    if (content.length <= limit) return content;
-    if (limit === 0) return '';
-    if (limit <= TRUNCATION_MARKER.length) return content.slice(-limit);
-    return `${TRUNCATION_MARKER}${content.slice(
-      content.length - (limit - TRUNCATION_MARKER.length),
-    )}`;
+    return truncateOutboundMediaText(content, limit, TRUNCATION_MARKER);
   }
 
   private withSenderPrefix(run: RunPresentation, content: string): string {

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -13,7 +13,11 @@ import {
   stripPartialImageMarker,
 } from './outbound-image.js';
 import { sanitizeStreamingFileMarkers } from './outbound-file.js';
-import { truncateOutboundMediaText } from './outbound-markers.js';
+import {
+  findOutboundMediaMarkers,
+  replaceOutboundMediaMarkers,
+  truncateOutboundMediaText,
+} from './outbound-markers.js';
 import type { QuestionCardController } from './question-card-controller.js';
 import {
   CONTENT_LIMIT,
@@ -49,32 +53,33 @@ export interface DingtalkInteractionPresenterOptions {
 }
 
 function sanitizeFallbackOutput(text: string): string {
-  const originalImages = new Map<string, number>();
-  for (const marker of findImageMarkers(text)) {
-    const source = text.slice(marker.start, marker.end);
-    originalImages.set(source, (originalImages.get(source) ?? 0) + 1);
-  }
-
-  let result = text;
+  const imageMarkers = findImageMarkers(text);
+  const sentinels = imageMarkers.map((_, index) => {
+    let sentinel = `\u{e000}QWEN_FALLBACK_IMAGE_${index}\u{e001}`;
+    while (text.includes(sentinel)) sentinel += '\u{e002}';
+    return sentinel;
+  });
+  const images = imageMarkers.map((marker) =>
+    text.slice(marker.start, marker.end),
+  );
+  let result = replaceImageMarkers(text, imageMarkers, sentinels);
   while (true) {
-    const withoutFiles = sanitizeStreamingFileMarkers(
-      stripPartialImageMarker(result),
-    );
-    const retainedImages = new Map(originalImages);
-    const markers = findImageMarkers(withoutFiles);
-    const replacements = markers.map((marker) => {
-      const source = withoutFiles.slice(marker.start, marker.end);
-      const remaining = retainedImages.get(source) ?? 0;
-      if (remaining === 0) return '[Image pending]';
-      retainedImages.set(source, remaining - 1);
-      return source;
-    });
+    const withoutFiles = sanitizeStreamingFileMarkers(result);
+    const markers = findOutboundMediaMarkers(withoutFiles, 'IMAGE', true);
     const next = stripPartialImageMarker(
-      replaceImageMarkers(withoutFiles, markers, replacements),
+      replaceOutboundMediaMarkers(
+        withoutFiles,
+        markers,
+        markers.map(() => '[Image pending]'),
+      ),
     );
-    if (next === result) return result;
+    if (next === result) break;
     result = next;
   }
+  for (const [index, sentinel] of sentinels.entries()) {
+    result = result.replace(sentinel, images[index]!);
+  }
+  return result;
 }
 
 export interface DingtalkCardSender {

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -59,9 +59,7 @@ function sanitizeFallbackOutput(text: string): string {
     const image = text.slice(marker.start, marker.end);
     originalImageCounts.set(image, (originalImageCounts.get(image) ?? 0) + 1);
   }
-  let result = sanitizeStreamingFileMarkers(
-    unwrapFileMarkersAroundImages(text),
-  );
+  let result = unwrapFileMarkersAroundImages(text);
   const imageMarkers = findImageMarkers(result).flatMap((marker) => {
     const image = result.slice(marker.start, marker.end);
     const count = originalImageCounts.get(image) ?? 0;
@@ -76,15 +74,27 @@ function sanitizeFallbackOutput(text: string): string {
   });
   const images = imageMarkers.map((marker) => marker.replacementImage);
   result = replaceImageMarkers(result, imageMarkers, sentinels);
+  result = sanitizeStreamingFileMarkers(result);
   while (true) {
     const withoutFiles = sanitizeStreamingFileMarkers(result);
-    const markers = findOutboundMediaMarkers(withoutFiles, 'IMAGE', true);
+    const markers = findOutboundMediaMarkers(
+      withoutFiles,
+      'IMAGE',
+      true,
+      true,
+    ).filter(
+      (marker) =>
+        !sentinels.some((sentinel) =>
+          withoutFiles.slice(marker.start, marker.end).includes(sentinel),
+        ),
+    );
     const next = stripPartialImageMarker(
       replaceOutboundMediaMarkers(
         withoutFiles,
         markers,
         markers.map(() => '[Image pending]'),
       ),
+      true,
       true,
     );
     if (next === result) break;

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -17,6 +17,7 @@ import {
   findOutboundMediaMarkers,
   replaceOutboundMediaMarkers,
   truncateOutboundMediaText,
+  unwrapFileMarkersAroundImages,
 } from './outbound-markers.js';
 import type { QuestionCardController } from './question-card-controller.js';
 import {
@@ -52,65 +53,6 @@ export interface DingtalkInteractionPresenterOptions {
   sendFallback?(chatId: string, text: string, sessionId: string): Promise<void>;
 }
 
-function isEscapedMarker(text: string, index: number): boolean {
-  let backslashes = 0;
-  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor--) {
-    backslashes++;
-  }
-  return backslashes % 2 === 1;
-}
-
-function stripFileWrappersAroundImages(text: string): string {
-  const images = findImageMarkers(text);
-  const openings = [...text.matchAll(/\[FILE:\s*/giu)].filter(
-    (opening) =>
-      opening.index !== undefined && !isEscapedMarker(text, opening.index),
-  );
-  const wrappers = openings.flatMap((opening) => {
-    const start = opening.index!;
-    const pathStart = start + opening[0].length;
-    const lineBreak = text.slice(pathStart).search(/[\r\n]/u);
-    const lineEnd = lineBreak === -1 ? text.length : pathStart + lineBreak;
-    const nested = images.filter(
-      (image) => image.start >= pathStart && image.end <= lineEnd,
-    );
-    if (
-      nested.length === 0 ||
-      text.slice(pathStart, nested[0]!.start).includes(']')
-    ) {
-      return [];
-    }
-    const lastImage = nested.at(-1)!;
-    const lastClose = text.lastIndexOf(']', lineEnd - 1);
-    if (lastClose < lastImage.end) {
-      return [{ start, end: nested[0]!.start, replacement: '' }];
-    }
-    return [
-      {
-        start,
-        end: lastClose + 1,
-        replacement: nested
-          .map((image) => text.slice(image.start, image.end))
-          .join(' '),
-      },
-    ];
-  });
-  const nonOverlapping = wrappers
-    .sort((left, right) => left.start - right.start)
-    .filter(
-      (wrapper, index, sorted) =>
-        index === 0 || wrapper.start >= sorted[index - 1]!.end,
-    );
-  let result = text;
-  for (const wrapper of nonOverlapping.reverse()) {
-    result =
-      result.slice(0, wrapper.start) +
-      wrapper.replacement +
-      result.slice(wrapper.end);
-  }
-  return result;
-}
-
 function sanitizeFallbackOutput(text: string): string {
   const originalImageCounts = new Map<string, number>();
   for (const marker of findImageMarkers(text)) {
@@ -118,7 +60,7 @@ function sanitizeFallbackOutput(text: string): string {
     originalImageCounts.set(image, (originalImageCounts.get(image) ?? 0) + 1);
   }
   let result = sanitizeStreamingFileMarkers(
-    stripFileWrappersAroundImages(text),
+    unwrapFileMarkersAroundImages(text),
   );
   const imageMarkers = findImageMarkers(result).flatMap((marker) => {
     const image = result.slice(marker.start, marker.end);

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -7,7 +7,11 @@ import type {
   SessionTarget,
   UserInputPresentationResult,
 } from '@qwen-code/channel-base';
-import { stripPartialImageMarker } from './outbound-image.js';
+import {
+  findImageMarkers,
+  replaceImageMarkers,
+  stripPartialImageMarker,
+} from './outbound-image.js';
 import { sanitizeStreamingFileMarkers } from './outbound-file.js';
 import { truncateOutboundMediaText } from './outbound-markers.js';
 import type { QuestionCardController } from './question-card-controller.js';
@@ -45,9 +49,32 @@ export interface DingtalkInteractionPresenterOptions {
 }
 
 function sanitizeFallbackOutput(text: string): string {
-  return stripPartialImageMarker(
-    sanitizeStreamingFileMarkers(stripPartialImageMarker(text)),
-  );
+  const originalImages = new Map<string, number>();
+  for (const marker of findImageMarkers(text)) {
+    const source = text.slice(marker.start, marker.end);
+    originalImages.set(source, (originalImages.get(source) ?? 0) + 1);
+  }
+
+  let result = text;
+  while (true) {
+    const withoutFiles = sanitizeStreamingFileMarkers(
+      stripPartialImageMarker(result),
+    );
+    const retainedImages = new Map(originalImages);
+    const markers = findImageMarkers(withoutFiles);
+    const replacements = markers.map((marker) => {
+      const source = withoutFiles.slice(marker.start, marker.end);
+      const remaining = retainedImages.get(source) ?? 0;
+      if (remaining === 0) return '[Image pending]';
+      retainedImages.set(source, remaining - 1);
+      return source;
+    });
+    const next = stripPartialImageMarker(
+      replaceImageMarkers(withoutFiles, markers, replacements),
+    );
+    if (next === result) return result;
+    result = next;
+  }
 }
 
 export interface DingtalkCardSender {

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -52,17 +52,88 @@ export interface DingtalkInteractionPresenterOptions {
   sendFallback?(chatId: string, text: string, sessionId: string): Promise<void>;
 }
 
+function isEscapedMarker(text: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function stripFileWrappersAroundImages(text: string): string {
+  const images = findImageMarkers(text);
+  const openings = [...text.matchAll(/\[FILE:\s*/giu)].filter(
+    (opening) =>
+      opening.index !== undefined && !isEscapedMarker(text, opening.index),
+  );
+  const wrappers = openings.flatMap((opening) => {
+    const start = opening.index!;
+    const pathStart = start + opening[0].length;
+    const lineBreak = text.slice(pathStart).search(/[\r\n]/u);
+    const lineEnd = lineBreak === -1 ? text.length : pathStart + lineBreak;
+    const nested = images.filter(
+      (image) => image.start >= pathStart && image.end <= lineEnd,
+    );
+    if (
+      nested.length === 0 ||
+      text.slice(pathStart, nested[0]!.start).includes(']')
+    ) {
+      return [];
+    }
+    const lastImage = nested.at(-1)!;
+    const lastClose = text.lastIndexOf(']', lineEnd - 1);
+    if (lastClose < lastImage.end) {
+      return [{ start, end: nested[0]!.start, replacement: '' }];
+    }
+    return [
+      {
+        start,
+        end: lastClose + 1,
+        replacement: nested
+          .map((image) => text.slice(image.start, image.end))
+          .join(' '),
+      },
+    ];
+  });
+  const nonOverlapping = wrappers
+    .sort((left, right) => left.start - right.start)
+    .filter(
+      (wrapper, index, sorted) =>
+        index === 0 || wrapper.start >= sorted[index - 1]!.end,
+    );
+  let result = text;
+  for (const wrapper of nonOverlapping.reverse()) {
+    result =
+      result.slice(0, wrapper.start) +
+      wrapper.replacement +
+      result.slice(wrapper.end);
+  }
+  return result;
+}
+
 function sanitizeFallbackOutput(text: string): string {
-  const imageMarkers = findImageMarkers(text);
+  const originalImageCounts = new Map<string, number>();
+  for (const marker of findImageMarkers(text)) {
+    const image = text.slice(marker.start, marker.end);
+    originalImageCounts.set(image, (originalImageCounts.get(image) ?? 0) + 1);
+  }
+  let result = sanitizeStreamingFileMarkers(
+    stripFileWrappersAroundImages(text),
+  );
+  const imageMarkers = findImageMarkers(result).flatMap((marker) => {
+    const image = result.slice(marker.start, marker.end);
+    const count = originalImageCounts.get(image) ?? 0;
+    if (count === 0) return [];
+    originalImageCounts.set(image, count - 1);
+    return [{ ...marker, replacementImage: image }];
+  });
   const sentinels = imageMarkers.map((_, index) => {
     let sentinel = `\u{e000}QWEN_FALLBACK_IMAGE_${index}\u{e001}`;
-    while (text.includes(sentinel)) sentinel += '\u{e002}';
+    while (result.includes(sentinel)) sentinel += '\u{e002}';
     return sentinel;
   });
-  const images = imageMarkers.map((marker) =>
-    text.slice(marker.start, marker.end),
-  );
-  let result = replaceImageMarkers(text, imageMarkers, sentinels);
+  const images = imageMarkers.map((marker) => marker.replacementImage);
+  result = replaceImageMarkers(result, imageMarkers, sentinels);
   while (true) {
     const withoutFiles = sanitizeStreamingFileMarkers(result);
     const markers = findOutboundMediaMarkers(withoutFiles, 'IMAGE', true);
@@ -72,12 +143,13 @@ function sanitizeFallbackOutput(text: string): string {
         markers,
         markers.map(() => '[Image pending]'),
       ),
+      true,
     );
     if (next === result) break;
     result = next;
   }
   for (const [index, sentinel] of sentinels.entries()) {
-    result = result.replace(sentinel, images[index]!);
+    result = result.replace(sentinel, () => images[index]!);
   }
   return result;
 }

--- a/packages/channels/dingtalk/src/interaction-presenter.ts
+++ b/packages/channels/dingtalk/src/interaction-presenter.ts
@@ -35,6 +35,7 @@ interface SegmentPresentation {
   run: RunPresentation;
   context: ChannelOutputSegmentContext;
   content: string;
+  displayContent: string;
 }
 
 export interface DingtalkInteractionPresenterOptions {
@@ -135,8 +136,11 @@ export class DingtalkInteractionPresenter {
       run,
       context: segment,
       content: '',
+      displayContent: '',
     };
-    presentation.content = this.boundContent(presentation.content + chunk);
+    const accumulated = presentation.content + chunk;
+    presentation.content = this.boundContent(accumulated);
+    presentation.displayContent = this.boundDisplayContent(accumulated);
     this.segments.set(segment.segmentId, presentation);
     run.activeSegmentId = segment.segmentId;
     const statusContext = this.ensureStatusContext(run, segment);
@@ -144,7 +148,7 @@ export class DingtalkInteractionPresenter {
       this.options.statusCards?.replace(
         statusContext,
         this.cardTarget(statusContext.target),
-        presentation.content,
+        accumulated,
       );
     });
   }
@@ -193,15 +197,17 @@ export class DingtalkInteractionPresenter {
           (await statusCards.flushPending(statusContext.segmentId));
         if (deliveredViaCard) {
           run.cardDelivered = {
-            text: sanitizeFallbackOutput(text || presentation.content),
+            text: text
+              ? this.boundDisplayContent(text)
+              : presentation.displayContent,
             chatId: presentation.context.target.chatId,
             sessionId: presentation.context.sessionId,
           };
           return true;
         }
-        const fallbackText = sanitizeFallbackOutput(
-          text || presentation.content,
-        );
+        const fallbackText = text
+          ? this.boundDisplayContent(text)
+          : presentation.displayContent;
         if (!fallbackText || !this.options.sendFallback) return false;
         await this.options.sendFallback(
           presentation.context.target.chatId,
@@ -215,13 +221,13 @@ export class DingtalkInteractionPresenter {
           statusCards !== undefined &&
           (await statusCards.complete(
             statusContext.segmentId,
-            this.withSenderPrefix(run, text || presentation.content),
+            this.withSenderPrefix(run, text || presentation.displayContent),
           ));
         run.statusContext = undefined;
         if (completed) return true;
-        const fallbackText = sanitizeFallbackOutput(
-          text || presentation.content,
-        );
+        const fallbackText = text
+          ? this.boundDisplayContent(text)
+          : presentation.displayContent;
         if (!fallbackText || !this.options.sendFallback) return false;
         await this.options.sendFallback(
           presentation.context.target.chatId,
@@ -235,10 +241,12 @@ export class DingtalkInteractionPresenter {
         statusCards !== undefined &&
         (await statusCards.complete(
           statusContext.segmentId,
-          this.withSenderPrefix(run, text || presentation.content),
+          this.withSenderPrefix(run, text || presentation.displayContent),
         ));
       if (completed) return true;
-      const fallbackText = sanitizeFallbackOutput(text || presentation.content);
+      const fallbackText = text
+        ? this.boundDisplayContent(text)
+        : presentation.displayContent;
       if (!fallbackText || !this.options.sendFallback) return false;
       await this.options.sendFallback(
         presentation.context.target.chatId,
@@ -395,6 +403,10 @@ export class DingtalkInteractionPresenter {
   }
 
   private boundContent(content: string, limit = CONTENT_LIMIT): string {
+    return truncateOutboundMediaText(content, limit, TRUNCATION_MARKER);
+  }
+
+  private boundDisplayContent(content: string, limit = CONTENT_LIMIT): string {
     return truncateOutboundMediaText(
       sanitizeFallbackOutput(content),
       limit,
@@ -403,7 +415,7 @@ export class DingtalkInteractionPresenter {
   }
 
   private withSenderPrefix(run: RunPresentation, content: string): string {
-    if (!run.senderPrefix) return this.boundContent(content);
+    if (!run.senderPrefix) return this.boundDisplayContent(content);
     const body = this.withoutExistingSenderPrefix(run, content);
     if (!body) return run.senderPrefix;
     const separator = '\n\n';
@@ -411,7 +423,7 @@ export class DingtalkInteractionPresenter {
       0,
       CONTENT_LIMIT - run.senderPrefix.length - separator.length,
     );
-    return `${run.senderPrefix}${separator}${this.boundContent(
+    return `${run.senderPrefix}${separator}${this.boundDisplayContent(
       body,
       bodyLimit,
     )}`;

--- a/packages/channels/dingtalk/src/outbound-file.test.ts
+++ b/packages/channels/dingtalk/src/outbound-file.test.ts
@@ -84,6 +84,9 @@ describe('outbound file markers', () => {
         '`\u{e000}QWEN_MEDIA_MARKER_0\u{e001}`\n[FILE: /workspace/live.txt]',
       ).map(({ path }) => path),
     ).toEqual(['/workspace/live.txt']);
+    expect(
+      findFileMarkers('Send files with [FILE:\n\n \t[FILE: report.pdf]\n'),
+    ).toEqual([]);
   });
 
   it('hides complete and partial visible file paths while streaming', () => {
@@ -117,6 +120,7 @@ describe('outbound file markers', () => {
       'A [FILE: /Users/ben/secret [FILE: x]] B',
       '[FILE:[FILE: /a.pdf] /b.pdf]',
       '[FILE: /hid[FILE: /a] den /x]',
+      '[FILE[FILE[FILE: /a]: /b]: /c]',
     ]) {
       const sanitized = sanitizeStreamingFileMarkers(text);
       expect(findFileMarkers(sanitized)).toEqual([]);

--- a/packages/channels/dingtalk/src/outbound-file.test.ts
+++ b/packages/channels/dingtalk/src/outbound-file.test.ts
@@ -1,0 +1,276 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  truncateSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  findFileMarkers,
+  readValidatedFile,
+  replaceFileMarkers,
+  safeFileName,
+  sanitizeStreamingFileMarkers,
+  stripPartialFileMarker,
+  uploadDingTalkFile,
+} from './outbound-file.js';
+
+const testDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  testDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('outbound file markers', () => {
+  it('finds markers outside fenced and inline code', () => {
+    const text = [
+      'before',
+      '[FILE: /tmp/report.pdf]',
+      '```text',
+      '[FILE: /tmp/fenced.pdf]',
+      '```',
+      '`[FILE: /tmp/inline.pdf]`',
+      'after',
+    ].join('\n');
+
+    const markers = findFileMarkers(text);
+
+    expect(markers).toEqual([
+      expect.objectContaining({ path: '/tmp/report.pdf' }),
+    ]);
+    expect(replaceFileMarkers(text, markers, ['[File: report.pdf]'])).toBe(
+      [
+        'before',
+        '[File: report.pdf]',
+        '```text',
+        '[FILE: /tmp/fenced.pdf]',
+        '```',
+        '`[FILE: /tmp/inline.pdf]`',
+        'after',
+      ].join('\n'),
+    );
+  });
+
+  it('hides complete and partial visible file paths while streaming', () => {
+    expect(
+      sanitizeStreamingFileMarkers(
+        'before [FILE: /Users/ben/private/report.pdf] after',
+      ),
+    ).toBe('before  after');
+    expect(
+      sanitizeStreamingFileMarkers('before [FILE: /Users/ben/private/report'),
+    ).toBe('before ');
+    expect(stripPartialFileMarker('before [F')).toBe('before ');
+    expect(stripPartialFileMarker('array[')).toBe('array[');
+  });
+
+  it('preserves file-like text inside code', () => {
+    const text = [
+      '`[FILE: /Users/ben/inline.pdf]`',
+      '```text',
+      '[FILE: /Users/ben/fenced.pdf]',
+      '```',
+    ].join('\n');
+
+    expect(sanitizeStreamingFileMarkers(text)).toBe(text);
+  });
+});
+
+describe('readValidatedFile', () => {
+  it('sanitizes control characters and brackets in display names', () => {
+    expect(safeFileName('/tmp/report\n[private].txt')).toBe(
+      'report_private_.txt',
+    );
+    expect(safeFileName('/tmp/invoice\u202efdp.exe')).toBe('invoice_fdp.exe');
+  });
+
+  it('reads a regular file and derives safe DingTalk metadata', () => {
+    const workspace = makeTempDir('dingtalk-file-workspace-');
+    const filePath = join(workspace, '周报 final.PDF');
+    const data = Buffer.from('report');
+    writeFileSync(filePath, data);
+
+    expect(
+      readValidatedFile(filePath, {
+        workspaceDir: workspace,
+        temporaryDir: workspace,
+      }),
+    ).toMatchObject({
+      data,
+      fileName: '周报 final.PDF',
+      fileType: 'pdf',
+      mimeType: 'application/octet-stream',
+    });
+  });
+
+  it('uses the generic file type for a name without an extension', () => {
+    const workspace = makeTempDir('dingtalk-file-workspace-');
+    const filePath = join(workspace, 'LICENSE');
+    writeFileSync(filePath, 'license');
+
+    expect(
+      readValidatedFile(filePath, {
+        workspaceDir: workspace,
+        temporaryDir: workspace,
+      }),
+    ).toMatchObject({
+      fileName: 'LICENSE',
+      fileType: 'file',
+      mimeType: 'application/octet-stream',
+    });
+  });
+
+  it('allows files in the system temporary directory', () => {
+    const workspace = makeTempDir('dingtalk-file-workspace-');
+    const temporary = makeTempDir('dingtalk-file-temporary-');
+    const filePath = join(temporary, 'report.txt');
+    writeFileSync(filePath, 'report');
+
+    expect(
+      readValidatedFile(filePath, { workspaceDir: workspace }),
+    ).toMatchObject({
+      fileName: 'report.txt',
+      data: Buffer.from('report'),
+    });
+  });
+
+  it('rejects relative paths, empty files, and directories', () => {
+    const workspace = makeTempDir('dingtalk-file-workspace-');
+    const emptyPath = join(workspace, 'empty.txt');
+    const directoryPath = join(workspace, 'directory.txt');
+    writeFileSync(emptyPath, '');
+    mkdirSync(directoryPath);
+
+    expect(() =>
+      readValidatedFile('relative.txt', {
+        workspaceDir: workspace,
+        temporaryDir: workspace,
+      }),
+    ).toThrow('File path must be absolute');
+    expect(() =>
+      readValidatedFile(emptyPath, {
+        workspaceDir: workspace,
+        temporaryDir: workspace,
+      }),
+    ).toThrow('File is empty');
+    expect(() =>
+      readValidatedFile(directoryPath, {
+        workspaceDir: workspace,
+        temporaryDir: workspace,
+      }),
+    ).toThrow('Not a regular file');
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects named pipes without waiting for a writer',
+    () => {
+      const workspace = makeTempDir('dingtalk-file-workspace-');
+      const pipePath = join(workspace, 'report.pipe');
+      execFileSync('mkfifo', [pipePath]);
+
+      expect(() =>
+        readValidatedFile(pipePath, {
+          workspaceDir: workspace,
+          temporaryDir: workspace,
+        }),
+      ).toThrow('Not a regular file');
+    },
+  );
+
+  it('rejects a symlink that escapes the allowed directories', () => {
+    const workspace = makeTempDir('dingtalk-file-workspace-');
+    const outside = makeTempDir('dingtalk-file-outside-');
+    const outsideFile = join(outside, 'outside.txt');
+    const linkedFile = join(workspace, 'linked.txt');
+    writeFileSync(outsideFile, 'private');
+    symlinkSync(outsideFile, linkedFile);
+
+    expect(() =>
+      readValidatedFile(linkedFile, {
+        workspaceDir: workspace,
+        temporaryDir: workspace,
+      }),
+    ).toThrow('outside allowed directories');
+  });
+
+  it('does not expose an unavailable allowed directory in the error', () => {
+    const workspace = makeTempDir('dingtalk-file-workspace-');
+    const filePath = join(workspace, 'report.txt');
+    const missingRoot = join(workspace, 'missing-root');
+    writeFileSync(filePath, 'report');
+
+    let message = '';
+    try {
+      readValidatedFile(filePath, {
+        workspaceDir: missingRoot,
+        temporaryDir: missingRoot,
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toBe('File allowed directory unavailable');
+    expect(message).not.toContain(missingRoot);
+  });
+
+  it('rejects files larger than the upload limit before reading them', () => {
+    const workspace = makeTempDir('dingtalk-file-workspace-');
+    const filePath = join(workspace, 'large.bin');
+    writeFileSync(filePath, 'x');
+    truncateSync(filePath, 20 * 1024 * 1024 + 1);
+
+    expect(() =>
+      readValidatedFile(filePath, {
+        workspaceDir: workspace,
+        temporaryDir: workspace,
+      }),
+    ).toThrow('File too large');
+  });
+});
+
+describe('uploadDingTalkFile', () => {
+  it('uploads a file with type=file and preserves the MediaID', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ errcode: 0, media_id: '@lAL-file-media-id' }),
+          { status: 200 },
+        ),
+      );
+
+    await expect(
+      uploadDingTalkFile(
+        {
+          data: Buffer.from('report'),
+          fileName: 'report.pdf',
+          fileType: 'pdf',
+          mimeType: 'application/octet-stream',
+        },
+        'access-token',
+      ),
+    ).resolves.toBe('@lAL-file-media-id');
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain('/media/upload?');
+    expect(String(url)).toContain('type=file');
+    expect(init?.method).toBe('POST');
+    const media = (init?.body as FormData).get('media');
+    expect(media).toBeInstanceOf(Blob);
+    expect((media as File).name).toBe('report.pdf');
+  });
+});

--- a/packages/channels/dingtalk/src/outbound-file.test.ts
+++ b/packages/channels/dingtalk/src/outbound-file.test.ts
@@ -65,6 +65,27 @@ describe('outbound file markers', () => {
     );
   });
 
+  it('uses parsed markdown code regions to classify markers', () => {
+    expect(
+      findFileMarkers('Example:\n\n \t[FILE: /workspace/code.txt]\n'),
+    ).toEqual([]);
+    expect(
+      findFileMarkers('Run `echo [FILE: /workspace/live.txt] to send').map(
+        ({ path }) => path,
+      ),
+    ).toEqual(['/workspace/live.txt']);
+    expect(
+      findFileMarkers(
+        '```text [FILE: /workspace/fence-info.txt]\ncontent\n```',
+      ),
+    ).toEqual([]);
+    expect(
+      findFileMarkers(
+        '`\u{e000}QWEN_MEDIA_MARKER_0\u{e001}`\n[FILE: /workspace/live.txt]',
+      ).map(({ path }) => path),
+    ).toEqual(['/workspace/live.txt']);
+  });
+
   it('hides complete and partial visible file paths while streaming', () => {
     expect(
       sanitizeStreamingFileMarkers(
@@ -78,7 +99,7 @@ describe('outbound file markers', () => {
     expect(stripPartialFileMarker('array[')).toBe('array[');
   });
 
-  it('preserves file-like text inside code', () => {
+  it('scrubs file marker paths inside code', () => {
     const text = [
       '`[FILE: /Users/ben/inline.pdf]`',
       '```text',
@@ -86,7 +107,21 @@ describe('outbound file markers', () => {
       '```',
     ].join('\n');
 
-    expect(sanitizeStreamingFileMarkers(text)).toBe(text);
+    expect(sanitizeStreamingFileMarkers(text)).toBe(
+      ['``', '```text', '', '```'].join('\n'),
+    );
+  });
+
+  it('sanitizes nested markers to a fixed point', () => {
+    for (const text of [
+      'A [FILE: /Users/ben/secret [FILE: x]] B',
+      '[FILE:[FILE: /a.pdf] /b.pdf]',
+      '[FILE: /hid[FILE: /a] den /x]',
+    ]) {
+      const sanitized = sanitizeStreamingFileMarkers(text);
+      expect(findFileMarkers(sanitized)).toEqual([]);
+      expect(sanitized).not.toMatch(/\[FILE:/iu);
+    }
   });
 });
 

--- a/packages/channels/dingtalk/src/outbound-file.ts
+++ b/packages/channels/dingtalk/src/outbound-file.ts
@@ -3,6 +3,7 @@ import { readValidatedLocalFile } from './outbound-local-file.js';
 import {
   findOutboundMediaMarkers,
   replaceOutboundMediaMarkers,
+  sanitizeOutboundMediaMarkers,
   stripPartialOutboundMediaMarker,
   type OutboundMediaMarker,
 } from './outbound-markers.js';
@@ -36,14 +37,7 @@ export function stripPartialFileMarker(text: string): string {
 }
 
 export function sanitizeStreamingFileMarkers(text: string): string {
-  const markers = findFileMarkers(text);
-  return stripPartialFileMarker(
-    replaceFileMarkers(
-      text,
-      markers,
-      markers.map(() => ''),
-    ),
-  );
+  return sanitizeOutboundMediaMarkers(text, 'FILE', '');
 }
 
 export function safeFileName(filePath: string): string {

--- a/packages/channels/dingtalk/src/outbound-file.ts
+++ b/packages/channels/dingtalk/src/outbound-file.ts
@@ -1,0 +1,83 @@
+import { basename, extname } from 'node:path';
+import { readValidatedLocalFile } from './outbound-local-file.js';
+import {
+  findOutboundMediaMarkers,
+  replaceOutboundMediaMarkers,
+  stripPartialOutboundMediaMarker,
+  type OutboundMediaMarker,
+} from './outbound-markers.js';
+import { uploadDingTalkMedia } from './outbound-media.js';
+
+export const MAX_FILES_PER_RESPONSE = 5;
+
+export type FileMarker = OutboundMediaMarker;
+
+export interface ValidatedFile {
+  data: Buffer;
+  fileName: string;
+  fileType: string;
+  mimeType: string;
+}
+
+export function findFileMarkers(text: string): FileMarker[] {
+  return findOutboundMediaMarkers(text, 'FILE');
+}
+
+export function replaceFileMarkers(
+  text: string,
+  markers: readonly FileMarker[],
+  replacements: readonly string[],
+): string {
+  return replaceOutboundMediaMarkers(text, markers, replacements);
+}
+
+export function stripPartialFileMarker(text: string): string {
+  return stripPartialOutboundMediaMarker(text, 'FILE', '');
+}
+
+export function sanitizeStreamingFileMarkers(text: string): string {
+  const markers = findFileMarkers(text);
+  return stripPartialFileMarker(
+    replaceFileMarkers(
+      text,
+      markers,
+      markers.map(() => ''),
+    ),
+  );
+}
+
+export function safeFileName(filePath: string): string {
+  return (
+    basename(filePath)
+      .replace(
+        /[\p{Cc}\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069[\]]+/gu,
+        '_',
+      )
+      .slice(0, 255) || 'file'
+  );
+}
+
+export function readValidatedFile(
+  filePath: string,
+  options: { workspaceDir: string; temporaryDir?: string },
+): ValidatedFile {
+  const file = readValidatedLocalFile(filePath, {
+    ...options,
+    label: 'File',
+  });
+  const fileName = safeFileName(file.fileName);
+  const extension = extname(fileName).slice(1).toLowerCase();
+  return {
+    data: file.data,
+    fileName,
+    fileType: extension || 'file',
+    mimeType: 'application/octet-stream',
+  };
+}
+
+export function uploadDingTalkFile(
+  file: ValidatedFile,
+  accessToken: string,
+): Promise<string> {
+  return uploadDingTalkMedia(file, accessToken, 'file');
+}

--- a/packages/channels/dingtalk/src/outbound-image.test.ts
+++ b/packages/channels/dingtalk/src/outbound-image.test.ts
@@ -111,6 +111,11 @@ describe('streaming image markers', () => {
     expect(
       sanitizeStreamingImageMarkers('before [IMAGE: /Users/ben/[private/image'),
     ).toBe('before [Image pending]');
+    expect(
+      sanitizeStreamingImageMarkers(
+        'before [IMAGE:\n/Users/ben/private/image.png] after',
+      ),
+    ).toBe('before [Image pending] after');
   });
 
   it('scrubs image marker paths inside code', () => {

--- a/packages/channels/dingtalk/src/outbound-image.test.ts
+++ b/packages/channels/dingtalk/src/outbound-image.test.ts
@@ -113,7 +113,7 @@ describe('streaming image markers', () => {
     ).toBe('before [Image pending]');
   });
 
-  it('preserves image-like text inside code', () => {
+  it('scrubs image marker paths inside code', () => {
     expect(
       sanitizeStreamingImageMarkers(
         [
@@ -124,12 +124,7 @@ describe('streaming image markers', () => {
         ].join('\n'),
       ),
     ).toBe(
-      [
-        '`[IMAGE: /Users/ben/inline.png]`',
-        '```text',
-        '[IMAGE: /Users/ben/fenced.png]',
-        '```',
-      ].join('\n'),
+      ['`[Image pending]`', '```text', '[Image pending]', '```'].join('\n'),
     );
   });
 });

--- a/packages/channels/dingtalk/src/outbound-image.ts
+++ b/packages/channels/dingtalk/src/outbound-image.ts
@@ -1,25 +1,20 @@
+import { extname } from 'node:path';
+import { readValidatedLocalFile } from './outbound-local-file.js';
 import {
-  closeSync,
-  fstatSync,
-  openSync,
-  readFileSync,
-  readSync,
-  realpathSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { basename, extname, isAbsolute, relative } from 'node:path';
+  findOutboundMediaMarkers,
+  replaceOutboundMediaMarkers,
+  stripPartialOutboundMediaMarker,
+  type OutboundMediaMarker,
+} from './outbound-markers.js';
+import {
+  DingTalkMediaUploadError,
+  uploadDingTalkMedia,
+} from './outbound-media.js';
 
-const MEDIA_UPLOAD_API = 'https://oapi.dingtalk.com/media/upload';
-const MEDIA_UPLOAD_TIMEOUT_MS = 30_000;
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.bmp']);
-const AUTH_ERROR_CODES = new Set([40014, 42001]);
 
-export interface ImageMarker {
-  start: number;
-  end: number;
-  path: string;
-}
+export { DingTalkMediaUploadError };
+export type ImageMarker = OutboundMediaMarker;
 
 export interface ValidatedImage {
   data: Buffer;
@@ -27,66 +22,8 @@ export interface ValidatedImage {
   mimeType: string;
 }
 
-export class DingTalkMediaUploadError extends Error {
-  constructor(
-    message: string,
-    readonly authFailure: boolean,
-  ) {
-    super(message);
-    this.name = 'DingTalkMediaUploadError';
-  }
-}
-
-function maskCode(text: string): string {
-  const masked = text.split('');
-  const blank = (start: number, end: number) => {
-    for (let i = start; i < end; i++) {
-      if (masked[i] !== '\n') masked[i] = ' ';
-    }
-  };
-
-  let offset = 0;
-  while (offset < text.length) {
-    if (text[offset] === '`') {
-      let runLength = 1;
-      while (text[offset + runLength] === '`') runLength++;
-      const delimiter = '`'.repeat(runLength);
-      const closing = text.indexOf(delimiter, offset + runLength);
-      const newline =
-        runLength >= 3 ? -1 : text.indexOf('\n', offset + runLength);
-      const closesBeforeNewline =
-        closing !== -1 && (newline === -1 || closing < newline);
-      const end = closesBeforeNewline
-        ? closing + runLength
-        : newline === -1
-          ? text.length
-          : newline;
-      blank(offset, end);
-      offset = end;
-      continue;
-    }
-    offset++;
-  }
-
-  return masked.join('');
-}
-
 export function findImageMarkers(text: string): ImageMarker[] {
-  const visibleText = maskCode(text);
-  const markerPattern = /\[IMAGE:\s*([^\]\r\n]+)\]/gi;
-  const markers: ImageMarker[] = [];
-
-  for (const match of visibleText.matchAll(markerPattern)) {
-    const path = match[1]?.trim();
-    if (!path || match.index === undefined) continue;
-    markers.push({
-      start: match.index,
-      end: match.index + match[0].length,
-      path,
-    });
-  }
-
-  return markers;
+  return findOutboundMediaMarkers(text, 'IMAGE');
 }
 
 export function replaceImageMarkers(
@@ -94,31 +31,11 @@ export function replaceImageMarkers(
   markers: readonly ImageMarker[],
   replacements: readonly string[],
 ): string {
-  if (markers.length !== replacements.length) {
-    throw new Error('Image marker replacement count mismatch');
-  }
-
-  let result = text;
-  for (let i = markers.length - 1; i >= 0; i--) {
-    const marker = markers[i]!;
-    result =
-      result.slice(0, marker.start) +
-      replacements[i]! +
-      result.slice(marker.end);
-  }
-  return result;
+  return replaceOutboundMediaMarkers(text, markers, replacements);
 }
 
 export function stripPartialImageMarker(text: string): string {
-  const visibleText = maskCode(text);
-  // Require at least the 'I' of 'IMAGE' so a bare trailing '[' (code output,
-  // a link split mid-stream) survives instead of becoming a false
-  // '[Image pending]' claim in final user-visible text.
-  const partialMarker = /\[I(?:M(?:A(?:G(?:E(?::[^\]\r\n]*)?)?)?)?)?$/i.exec(
-    visibleText,
-  );
-  if (partialMarker?.index === undefined) return text;
-  return `${text.slice(0, partialMarker.index)}[Image pending]`;
+  return stripPartialOutboundMediaMarker(text, 'IMAGE', '[Image pending]');
 }
 
 export function sanitizeStreamingImageMarkers(text: string): string {
@@ -129,14 +46,6 @@ export function sanitizeStreamingImageMarkers(text: string): string {
       markers,
       markers.map(() => '[Image pending]'),
     ),
-  );
-}
-
-function isInside(realPath: string, directory: string): boolean {
-  const pathFromDirectory = relative(directory, realPath);
-  return (
-    pathFromDirectory === '' ||
-    (!pathFromDirectory.startsWith('..') && !isAbsolute(pathFromDirectory))
   );
 }
 
@@ -168,140 +77,40 @@ export function readValidatedImage(
     temporaryDir?: string;
   },
 ): ValidatedImage {
-  if (!isAbsolute(imagePath)) {
-    throw new Error(`Image path must be absolute: ${imagePath}`);
-  }
-
   const extension = extname(imagePath).toLowerCase();
   if (!IMAGE_EXTENSIONS.has(extension)) {
     throw new Error(`Image extension not allowed: ${extension}`);
   }
 
-  let realPath: string;
-  try {
-    realPath = realpathSync(imagePath);
-  } catch {
-    throw new Error(`Image file not found: ${imagePath}`);
-  }
-  const allowedDirectories = [
-    realpathSync(options.workspaceDir),
-    realpathSync(options.temporaryDir ?? tmpdir()),
-  ];
-  if (!allowedDirectories.some((directory) => isInside(realPath, directory))) {
-    throw new Error(`Image path outside allowed directories: ${realPath}`);
+  const image = readValidatedLocalFile(imagePath, {
+    ...options,
+    label: 'Image',
+    allowEmpty: true,
+  });
+  const mimeType = detectImageMime(image.data.subarray(0, 16));
+  const expectedMime: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.bmp': 'image/bmp',
+  };
+  if (mimeType !== expectedMime[extension]) {
+    throw new Error(
+      `Image type mismatch: ${extension} expects ${expectedMime[extension]} but got ${mimeType}`,
+    );
   }
 
-  const descriptor = openSync(realPath, 'r');
-  try {
-    const stats = fstatSync(descriptor);
-    if (!stats.isFile()) {
-      throw new Error(`Not a regular file: ${realPath}`);
-    }
-    if (stats.size > MAX_IMAGE_BYTES) {
-      throw new Error(
-        `Image too large: ${stats.size} bytes (max ${MAX_IMAGE_BYTES})`,
-      );
-    }
-
-    const header = Buffer.alloc(16);
-    const bytesRead = readSync(descriptor, header, 0, header.length, 0);
-    const mimeType = detectImageMime(header.subarray(0, bytesRead));
-    const expectedMime: Record<string, string> = {
-      '.png': 'image/png',
-      '.jpg': 'image/jpeg',
-      '.jpeg': 'image/jpeg',
-      '.gif': 'image/gif',
-      '.bmp': 'image/bmp',
-    };
-    if (mimeType !== expectedMime[extension]) {
-      throw new Error(
-        `Image type mismatch: ${extension} expects ${expectedMime[extension]} but got ${mimeType}`,
-      );
-    }
-
-    return {
-      data: readFileSync(descriptor),
-      fileName: basename(realPath),
-      mimeType,
-    };
-  } finally {
-    closeSync(descriptor);
-  }
+  return {
+    data: image.data,
+    fileName: image.fileName,
+    mimeType,
+  };
 }
 
-function sanitizeApiMessage(message: unknown, accessToken: string): string {
-  const value = String(message ?? '');
-  return (accessToken ? value.replaceAll(accessToken, '[redacted]') : value)
-    .replace(/[\r\n\t]+/g, ' ')
-    .slice(0, 200);
-}
-
-export async function uploadDingTalkImage(
+export function uploadDingTalkImage(
   image: ValidatedImage,
   accessToken: string,
 ): Promise<string> {
-  const form = new FormData();
-  form.append(
-    'media',
-    new Blob([image.data], { type: image.mimeType }),
-    image.fileName,
-  );
-
-  let response: Response;
-  try {
-    const url = new URL(MEDIA_UPLOAD_API);
-    url.searchParams.set('access_token', accessToken);
-    url.searchParams.set('type', 'image');
-    response = await fetch(url, {
-      method: 'POST',
-      body: form,
-      signal: AbortSignal.timeout(MEDIA_UPLOAD_TIMEOUT_MS),
-    });
-  } catch {
-    throw new DingTalkMediaUploadError(
-      'DingTalk media upload failed: network request failed',
-      false,
-    );
-  }
-
-  let payload: Record<string, unknown>;
-  try {
-    const parsed = (await response.json()) as unknown;
-    payload =
-      parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {};
-  } catch {
-    throw new DingTalkMediaUploadError(
-      `DingTalk media upload failed: HTTP ${response.status} invalid JSON response`,
-      response.status === 401,
-    );
-  }
-
-  const errcode =
-    typeof payload['errcode'] === 'number' ? payload['errcode'] : undefined;
-  if (!response.ok || (errcode !== undefined && errcode !== 0)) {
-    const detail = sanitizeApiMessage(payload['errmsg'], accessToken);
-    throw new DingTalkMediaUploadError(
-      `DingTalk media upload failed: HTTP ${response.status}${
-        errcode === undefined ? '' : ` errcode=${errcode}`
-      }${detail ? ` ${detail}` : ''}`,
-      response.status === 401 ||
-        (errcode !== undefined && AUTH_ERROR_CODES.has(errcode)),
-    );
-  }
-
-  const mediaId =
-    typeof payload['media_id'] === 'string'
-      ? payload['media_id']
-      : typeof payload['mediaId'] === 'string'
-        ? payload['mediaId']
-        : undefined;
-  if (!mediaId) {
-    throw new DingTalkMediaUploadError(
-      'DingTalk media upload failed: response did not include a MediaID',
-      false,
-    );
-  }
-  return mediaId;
+  return uploadDingTalkMedia(image, accessToken, 'image');
 }

--- a/packages/channels/dingtalk/src/outbound-image.ts
+++ b/packages/channels/dingtalk/src/outbound-image.ts
@@ -35,8 +35,16 @@ export function replaceImageMarkers(
   return replaceOutboundMediaMarkers(text, markers, replacements);
 }
 
-export function stripPartialImageMarker(text: string): string {
-  return stripPartialOutboundMediaMarker(text, 'IMAGE', '[Image pending]');
+export function stripPartialImageMarker(
+  text: string,
+  includeCode = false,
+): string {
+  return stripPartialOutboundMediaMarker(
+    text,
+    'IMAGE',
+    '[Image pending]',
+    includeCode,
+  );
 }
 
 export function sanitizeStreamingImageMarkers(text: string): string {

--- a/packages/channels/dingtalk/src/outbound-image.ts
+++ b/packages/channels/dingtalk/src/outbound-image.ts
@@ -38,12 +38,14 @@ export function replaceImageMarkers(
 export function stripPartialImageMarker(
   text: string,
   includeCode = false,
+  includeEscaped = false,
 ): string {
   return stripPartialOutboundMediaMarker(
     text,
     'IMAGE',
     '[Image pending]',
     includeCode,
+    includeEscaped,
   );
 }
 

--- a/packages/channels/dingtalk/src/outbound-image.ts
+++ b/packages/channels/dingtalk/src/outbound-image.ts
@@ -3,6 +3,7 @@ import { readValidatedLocalFile } from './outbound-local-file.js';
 import {
   findOutboundMediaMarkers,
   replaceOutboundMediaMarkers,
+  sanitizeOutboundMediaMarkers,
   stripPartialOutboundMediaMarker,
   type OutboundMediaMarker,
 } from './outbound-markers.js';
@@ -39,14 +40,7 @@ export function stripPartialImageMarker(text: string): string {
 }
 
 export function sanitizeStreamingImageMarkers(text: string): string {
-  const markers = findImageMarkers(text);
-  return stripPartialImageMarker(
-    replaceImageMarkers(
-      text,
-      markers,
-      markers.map(() => '[Image pending]'),
-    ),
-  );
+  return sanitizeOutboundMediaMarkers(text, 'IMAGE', '[Image pending]');
 }
 
 function detectImageMime(data: Buffer): string {

--- a/packages/channels/dingtalk/src/outbound-local-file.ts
+++ b/packages/channels/dingtalk/src/outbound-local-file.ts
@@ -1,0 +1,105 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, isAbsolute, relative } from 'node:path';
+
+export const MAX_OUTBOUND_MEDIA_BYTES = 20 * 1024 * 1024;
+
+export interface ValidatedLocalFile {
+  data: Buffer;
+  fileName: string;
+}
+
+function isInside(realPath: string, directory: string): boolean {
+  const pathFromDirectory = relative(directory, realPath);
+  return (
+    pathFromDirectory === '' ||
+    (!pathFromDirectory.startsWith('..') && !isAbsolute(pathFromDirectory))
+  );
+}
+
+export function readValidatedLocalFile(
+  filePath: string,
+  options: {
+    workspaceDir: string;
+    temporaryDir?: string;
+    label: 'File' | 'Image';
+    allowEmpty?: boolean;
+  },
+): ValidatedLocalFile {
+  const { label } = options;
+  if (!isAbsolute(filePath)) {
+    throw new Error(`${label} path must be absolute`);
+  }
+
+  let realPath: string;
+  try {
+    realPath = realpathSync(filePath);
+  } catch {
+    throw new Error(`${label} file not found`);
+  }
+  let allowedDirectories: string[];
+  try {
+    allowedDirectories = [
+      realpathSync(options.workspaceDir),
+      realpathSync(options.temporaryDir ?? tmpdir()),
+    ];
+  } catch {
+    throw new Error(`${label} allowed directory unavailable`);
+  }
+  if (!allowedDirectories.some((directory) => isInside(realPath, directory))) {
+    throw new Error(`${label} path outside allowed directories`);
+  }
+
+  let descriptor: number;
+  try {
+    descriptor = openSync(realPath, constants.O_RDONLY | constants.O_NONBLOCK);
+  } catch {
+    throw new Error(`${label} could not be opened`);
+  }
+  try {
+    const stats = fstatSync(descriptor);
+    if (!stats.isFile()) {
+      throw new Error('Not a regular file');
+    }
+    if (stats.size === 0 && options.allowEmpty !== true) {
+      throw new Error(`${label} is empty`);
+    }
+    if (stats.size > MAX_OUTBOUND_MEDIA_BYTES) {
+      throw new Error(
+        `${label} too large: ${stats.size} bytes (max ${MAX_OUTBOUND_MEDIA_BYTES})`,
+      );
+    }
+
+    const data = Buffer.alloc(stats.size);
+    let offset = 0;
+    try {
+      while (offset < data.length) {
+        const bytesRead = readSync(
+          descriptor,
+          data,
+          offset,
+          data.length - offset,
+          offset,
+        );
+        if (bytesRead === 0) break;
+        offset += bytesRead;
+      }
+    } catch {
+      throw new Error(`${label} could not be read`);
+    }
+    if (offset === 0 && options.allowEmpty !== true) {
+      throw new Error(`${label} is empty`);
+    }
+
+    return { data: data.subarray(0, offset), fileName: basename(realPath) };
+  } finally {
+    closeSync(descriptor);
+  }
+}

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findOutboundMediaMarkers,
+  stripPartialOutboundMediaMarker,
+  truncateOutboundMediaText,
+} from './outbound-markers.js';
+
+describe('outbound media markers', () => {
+  it('parses bracketed paths without combining adjacent markers', () => {
+    expect(
+      findOutboundMediaMarkers(
+        '[FILE: /workspace/report [final].pdf] [FILE: /workspace/next.txt]',
+        'FILE',
+      ).map(({ path }) => path),
+    ).toEqual(['/workspace/report [final].pdf', '/workspace/next.txt']);
+    expect(
+      findOutboundMediaMarkers('[FILE: /workspace/report]final.csv]', 'FILE')[0]
+        ?.path,
+    ).toBe('/workspace/report]final.csv');
+    expect(
+      findOutboundMediaMarkers(
+        '[FILE: /workspace/report.pdf][IMAGE: /workspace/chart.png]',
+        'FILE',
+      )[0]?.path,
+    ).toBe('/workspace/report.pdf');
+  });
+
+  it('walks past index zero and strips the earliest partial marker', () => {
+    expect(
+      stripPartialOutboundMediaMarker('[1] hello', 'FILE', '[File pending]'),
+    ).toBe('[1] hello');
+    expect(
+      stripPartialOutboundMediaMarker(
+        'see [FILE: /tmp/a [FILE: /tmp/b',
+        'FILE',
+        '[File pending]',
+      ),
+    ).toBe('see [File pending]');
+  });
+
+  it('keeps truncation boundaries outside partial markers', () => {
+    const marker = '[FILE: /Users/ben/private/report.pdf]';
+    const truncationMarker = '[truncated]\n';
+    const suffix = 'z'.repeat(80 - truncationMarker.length + 1 - marker.length);
+    const result = truncateOutboundMediaText(
+      `${'x'.repeat(20)}${marker}${suffix}`,
+      80,
+      truncationMarker,
+    );
+    expect(result).toBe(`${truncationMarker}${suffix}`);
+    expect(
+      truncateOutboundMediaText(`[${'a'.repeat(200)}`, 100, truncationMarker),
+    ).toHaveLength(100);
+  });
+});

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -52,6 +52,16 @@ describe('outbound media markers', () => {
     expect(
       findTrailingPartialOutboundMediaMarker('The format is `[IMAGE: '),
     ).toBeUndefined();
+    expect(
+      findTrailingPartialOutboundMediaMarker(
+        'Use `first line\n[FILE: /tmp/report.txt]` here',
+      ),
+    ).toBeUndefined();
+    expect(
+      findTrailingPartialOutboundMediaMarker(
+        'Use `first line\n[FILE: /tmp/report.txt]',
+      ),
+    ).toEqual({ start: 4, markerName: 'FILE', complete: true });
   });
 
   it('parks a trailing bare bracket without assigning a marker type', () => {
@@ -185,6 +195,16 @@ describe('outbound media markers', () => {
     expect(
       unwrapFileMarkersAroundImages('```\n[FILE: [IMAGE: /tmp/a.png]]\n```'),
     ).toBe('```\n[IMAGE: /tmp/a.png]\n```');
+    expect(
+      unwrapFileMarkersAroundImages(
+        '[FILE: [IMAGE: /tmp/a.png] docs/report.pdf]',
+      ),
+    ).toBe('[IMAGE: /tmp/a.png]');
+    expect(
+      unwrapFileMarkersAroundImages(
+        '[FILE: [IMAGE: /tmp/a.png] /Users/ben/private/report.pdf',
+      ),
+    ).toBe('[IMAGE: /tmp/a.png]');
   });
 
   it('treats escaped marker syntax as literal text', () => {
@@ -195,6 +215,16 @@ describe('outbound media markers', () => {
       stripPartialOutboundMediaMarker(partial, 'FILE', '[File pending]'),
     ).toBe(partial);
     expect(findTrailingPartialOutboundMediaMarker(partial)).toBeUndefined();
+    expect(sanitizeOutboundMediaMarkers(complete, 'IMAGE', '[pending]')).toBe(
+      String.raw`\[pending]`,
+    );
+    expect(
+      sanitizeOutboundMediaMarkers(
+        String.raw`\[FILE: /Users/ben/private/report.pdf]`,
+        'FILE',
+        '',
+      ),
+    ).not.toContain('/Users/ben/private');
   });
 
   it('keeps truncation boundaries outside partial markers', () => {
@@ -223,6 +253,24 @@ describe('outbound media markers', () => {
         20_000,
         '[Earlier output truncated]\n',
       ),
-    ).toContain('B');
+    ).not.toContain('B');
+    expect(
+      truncateOutboundMediaText(
+        `${'A'.repeat(80)}[FILE: [IMAGE: /tmp/a.png] /Users/ben/private/report.pdf]`,
+        40,
+        truncationMarker,
+      ),
+    ).not.toContain('private');
+  });
+
+  it('parks the earliest pending marker across nested openings and brackets', () => {
+    expect(
+      findTrailingPartialOutboundMediaMarker(
+        '[FILE: [IMAGE: /tmp/a.png] /tmp/report.pdf',
+      ),
+    ).toEqual({ start: 0, markerName: 'FILE' });
+    expect(
+      findTrailingPartialOutboundMediaMarker('[FILE: /tmp/report ['),
+    ).toEqual({ start: 0, markerName: 'FILE' });
   });
 });

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -66,6 +66,26 @@ describe('outbound media markers', () => {
         '[Image pending]',
       ),
     ).toBe('[IMAGE: processing [1/2] done]');
+    expect(
+      stripPartialOutboundMediaMarker(
+        'before [IMAGE:\n/tmp/private.png] after',
+        'IMAGE',
+        '[Image pending]',
+      ),
+    ).toBe('before [IMAGE:\n/tmp/private.png] after');
+  });
+
+  it('does not throw on Unicode lookalikes of marker names', () => {
+    expect(
+      stripPartialOutboundMediaMarker(
+        'see [ımage: /tmp/a',
+        'IMAGE',
+        '[Image pending]',
+      ),
+    ).toBe('see [ımage: /tmp/a');
+    expect(
+      stripPartialOutboundMediaMarker('see [fıle: /tmp/a', 'FILE', ''),
+    ).toBe('see [fıle: /tmp/a');
   });
 
   it('keeps truncation boundaries outside partial markers', () => {
@@ -88,5 +108,12 @@ describe('outbound media markers', () => {
         truncationMarker,
       ),
     ).toHaveLength(80);
+    expect(
+      truncateOutboundMediaText(
+        `${'A'.repeat(500)}[FILE: ${'B'.repeat(20_500)}`,
+        20_000,
+        '[Earlier output truncated]\n',
+      ),
+    ).toContain('B');
   });
 });

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -51,7 +51,7 @@ describe('outbound media markers', () => {
     expect(stripPartialOutboundMediaMarker(inline, 'FILE', '')).toBe(inline);
     expect(
       findTrailingPartialOutboundMediaMarker('The format is `[IMAGE: '),
-    ).toBeUndefined();
+    ).toEqual({ start: 14 });
     expect(
       findTrailingPartialOutboundMediaMarker(
         'Use `first line\n[FILE: /tmp/report.txt]` here',
@@ -272,5 +272,94 @@ describe('outbound media markers', () => {
     expect(
       findTrailingPartialOutboundMediaMarker('[FILE: /tmp/report ['),
     ).toEqual({ start: 0, markerName: 'FILE' });
+  });
+
+  it('closes markers before prose and Markdown followers', () => {
+    const cjk = '文件[FILE: /tmp/a.pdf]、[链接](https://example.com)已发出';
+    expect(findOutboundMediaMarkers(cjk, 'FILE')[0]?.path).toBe('/tmp/a.pdf');
+    expect(sanitizeOutboundMediaMarkers(cjk, 'FILE', '')).toBe(
+      '文件、[链接](https://example.com)已发出',
+    );
+    expect(findOutboundMediaMarkers('[FILE: a]𠮷]', 'FILE')[0]?.path).toBe('a');
+    expect(
+      findOutboundMediaMarkers('[FILE: a.pdf][link](url)', 'FILE')[0]?.path,
+    ).toBe('a.pdf');
+  });
+
+  it('preserves prose around nested image wrappers', () => {
+    expect(
+      unwrapFileMarkersAroundImages('[FILE: [IMAGE: a.png]] x [IMAGE: b.png]'),
+    ).toBe('[IMAGE: a.png] x [IMAGE: b.png]');
+    expect(
+      unwrapFileMarkersAroundImages('[FILE: [IMAGE: a.png]，请查收]'),
+    ).toBe('[IMAGE: a.png]，请查收');
+    expect(unwrapFileMarkersAroundImages('[FILE: [IMAGE: a.png] thanks]')).toBe(
+      '[IMAGE: a.png] thanks',
+    );
+    expect(unwrapFileMarkersAroundImages('[FILE: [IMAGE: a.png] summary')).toBe(
+      '[IMAGE: a.png]',
+    );
+  });
+
+  it('parks uncertain code and trailing escape state across chunks', () => {
+    expect(
+      findTrailingPartialOutboundMediaMarker(
+        'see `x [IMAGE: /Users/ben/private/',
+      ),
+    ).toEqual({ start: 4 });
+    expect(findTrailingPartialOutboundMediaMarker('see \\')).toEqual({
+      start: 4,
+    });
+    expect(
+      findTrailingPartialOutboundMediaMarker('\\``` [IMAGE: /tmp/a.png]'),
+    ).toEqual({ start: 2, markerName: 'IMAGE', complete: true });
+  });
+
+  it('does not park malformed wrappers from earlier lines', () => {
+    expect(
+      findTrailingPartialOutboundMediaMarker(
+        '[FILE: [IMAGE: a.png]\nmore text',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('does not rewrite newline-terminated marker prefixes', () => {
+    expect(
+      stripPartialOutboundMediaMarker(
+        'see [im\nmore',
+        'IMAGE',
+        '[Image pending]',
+      ),
+    ).toBe('see [im\nmore');
+    expect(stripPartialOutboundMediaMarker('A [f\nB', 'FILE', '')).toBe(
+      'A [f\nB',
+    );
+  });
+
+  it('keeps the next line after an unclosed marker opening', () => {
+    expect(
+      stripPartialOutboundMediaMarker(
+        'You can use [file:\nto attach documents.',
+        'FILE',
+        '',
+      ),
+    ).toBe('You can use \nto attach documents.');
+  });
+
+  it('does not unwrap escaped file wrappers', () => {
+    const text = String.raw`\[FILE: [IMAGE: /tmp/a.png]]`;
+    expect(unwrapFileMarkersAroundImages(text)).toBe(text);
+    expect(findOutboundMediaMarkers(text, 'IMAGE')).toHaveLength(1);
+  });
+
+  it('does not strip through protected marker openings', () => {
+    const inCode = 'A [IMAGE: /tmp/x `[FILE: /workspace/secret.pdf]` B';
+    const escaped = String.raw`A [IMAGE: /tmp/x \[FILE: /workspace/secret.pdf]`;
+    expect(
+      stripPartialOutboundMediaMarker(inCode, 'IMAGE', '[Image pending]'),
+    ).toBe(inCode);
+    expect(
+      stripPartialOutboundMediaMarker(escaped, 'IMAGE', '[Image pending]'),
+    ).toBe(escaped);
   });
 });

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -48,7 +48,24 @@ describe('outbound media markers', () => {
         'IMAGE',
         '[Image pending]',
       ),
-    ).toBe('see [Image pending]');
+    ).toBe('see [Image pending][FILE: /tmp/b]');
+  });
+
+  it('does not mistake complete bracketed markers for partial markers', () => {
+    expect(
+      stripPartialOutboundMediaMarker(
+        'done [IMAGE: /a/b[1].png] sent',
+        'IMAGE',
+        '[Image pending]',
+      ),
+    ).toBe('done [IMAGE: /a/b[1].png] sent');
+    expect(
+      stripPartialOutboundMediaMarker(
+        '[IMAGE: processing [1/2] done]',
+        'IMAGE',
+        '[Image pending]',
+      ),
+    ).toBe('[IMAGE: processing [1/2] done]');
   });
 
   it('keeps truncation boundaries outside partial markers', () => {

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   findTrailingPartialOutboundMediaMarker,
@@ -110,6 +113,43 @@ describe('outbound media markers', () => {
     expect(
       stripPartialOutboundMediaMarker('see [fıle: /tmp/a', 'FILE', ''),
     ).toBe('see [fıle: /tmp/a');
+    expect(
+      stripPartialOutboundMediaMarker('see [ım', 'IMAGE', '[Image pending]'),
+    ).toBe('see [ım');
+    expect(
+      stripPartialOutboundMediaMarker('a[ıma', 'IMAGE', '[Image pending]'),
+    ).toBe('a[ıma');
+  });
+
+  it('uses an existing bracketed path as the marker close oracle', () => {
+    const root = mkdtempSync(join(tmpdir(), 'qwen-marker-'));
+    const directory = join(root, 'dir [1] copy');
+    const file = join(directory, 'x.png');
+    try {
+      mkdirSync(directory, { recursive: true });
+      writeFileSync(file, 'image');
+      expect(
+        findOutboundMediaMarkers(`[IMAGE: ${file}]`, 'IMAGE')[0]?.candidates,
+      ).toContainEqual({ end: `[IMAGE: ${file}]`.length, path: file });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps an ambiguous bracketed path in streaming carry', () => {
+    expect(findTrailingPartialOutboundMediaMarker('[IMAGE: /tmp/a[1]')).toEqual(
+      { start: 0, markerName: 'IMAGE' },
+    );
+  });
+
+  it('treats escaped marker syntax as literal text', () => {
+    const complete = String.raw`\[IMAGE: /tmp/private.png]`;
+    const partial = String.raw`\[FILE: /tmp/private`;
+    expect(findOutboundMediaMarkers(complete, 'IMAGE')).toEqual([]);
+    expect(
+      stripPartialOutboundMediaMarker(partial, 'FILE', '[File pending]'),
+    ).toBe(partial);
+    expect(findTrailingPartialOutboundMediaMarker(partial)).toBeUndefined();
   });
 
   it('keeps truncation boundaries outside partial markers', () => {

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  findTrailingPartialOutboundMediaMarker,
   findOutboundMediaMarkers,
   stripPartialOutboundMediaMarker,
   truncateOutboundMediaText,
@@ -29,6 +30,29 @@ describe('outbound media markers', () => {
         'IMAGE',
       )[0]?.path,
     ).toBe('/tmp/chart.png');
+    expect(
+      findOutboundMediaMarkers(
+        '好的 [FILE: /workspace/报告.pdf]，请查收 [1]',
+        'FILE',
+      )[0]?.path,
+    ).toBe('/workspace/报告.pdf');
+  });
+
+  it('leaves partial marker syntax inside Markdown code untouched', () => {
+    const fenced = 'Log:\n```\n[FILE: /workspace/report.csv\n```';
+    const inline = 'Run `cat [FILE: /etc/hosts` to inspect';
+
+    expect(stripPartialOutboundMediaMarker(fenced, 'FILE', '')).toBe(fenced);
+    expect(stripPartialOutboundMediaMarker(inline, 'FILE', '')).toBe(inline);
+    expect(
+      findTrailingPartialOutboundMediaMarker('The format is `[IMAGE: '),
+    ).toBeUndefined();
+  });
+
+  it('parks a trailing bare bracket without assigning a marker type', () => {
+    expect(findTrailingPartialOutboundMediaMarker('行为字[')).toEqual({
+      start: 3,
+    });
   });
 
   it('walks past index zero and strips the earliest partial marker', () => {

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -23,6 +23,12 @@ describe('outbound media markers', () => {
         'FILE',
       )[0]?.path,
     ).toBe('/workspace/report.pdf');
+    expect(
+      findOutboundMediaMarkers(
+        'Chart [IMAGE: /tmp/chart.png] as shown [1].',
+        'IMAGE',
+      )[0]?.path,
+    ).toBe('/tmp/chart.png');
   });
 
   it('walks past index zero and strips the earliest partial marker', () => {
@@ -36,6 +42,13 @@ describe('outbound media markers', () => {
         '[File pending]',
       ),
     ).toBe('see [File pending]');
+    expect(
+      stripPartialOutboundMediaMarker(
+        'see [IMAGE: /Users/ben/private/a [FILE: /tmp/b]',
+        'IMAGE',
+        '[Image pending]',
+      ),
+    ).toBe('see [Image pending]');
   });
 
   it('keeps truncation boundaries outside partial markers', () => {
@@ -51,5 +64,12 @@ describe('outbound media markers', () => {
     expect(
       truncateOutboundMediaText(`[${'a'.repeat(200)}`, 100, truncationMarker),
     ).toHaveLength(100);
+    expect(
+      truncateOutboundMediaText(
+        `${'a'.repeat(114)}[${'b'.repeat(53)}`,
+        80,
+        truncationMarker,
+      ),
+    ).toHaveLength(80);
   });
 });

--- a/packages/channels/dingtalk/src/outbound-markers.test.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it } from 'vitest';
 import {
   findTrailingPartialOutboundMediaMarker,
   findOutboundMediaMarkers,
+  sanitizeOutboundMediaMarkers,
   stripPartialOutboundMediaMarker,
   truncateOutboundMediaText,
+  unwrapFileMarkersAroundImages,
 } from './outbound-markers.js';
 
 describe('outbound media markers', () => {
@@ -138,8 +140,51 @@ describe('outbound media markers', () => {
 
   it('keeps an ambiguous bracketed path in streaming carry', () => {
     expect(findTrailingPartialOutboundMediaMarker('[IMAGE: /tmp/a[1]')).toEqual(
-      { start: 0, markerName: 'IMAGE' },
+      { start: 0, markerName: 'IMAGE', complete: true },
     );
+    expect(
+      findTrailingPartialOutboundMediaMarker('[FILE: /tmp/a[1].tx'),
+    ).toEqual({ start: 0, markerName: 'FILE' });
+  });
+
+  it('sanitizes the full authoritative marker span', () => {
+    expect(
+      sanitizeOutboundMediaMarkers(
+        '[FILE: [v2] /Users/ben/private/leak.pdf]',
+        'FILE',
+        '',
+      ),
+    ).toBe('');
+    expect(
+      sanitizeOutboundMediaMarkers(
+        'sending [FILE: /tmp/report[1].pdf',
+        'FILE',
+        '',
+      ),
+    ).toBe('sending ');
+    expect(
+      sanitizeOutboundMediaMarkers(
+        '[FILE: /tmp/report.pdf] As shown in [1]',
+        'FILE',
+        '',
+      ),
+    ).toBe(' As shown in [1]');
+  });
+
+  it('unwraps nested image markers without consuming following brackets', () => {
+    expect(
+      unwrapFileMarkersAroundImages(
+        '[FILE: [IMAGE: /tmp/a.png]] As shown in [1]',
+      ),
+    ).toBe('[IMAGE: /tmp/a.png] As shown in [1]');
+    expect(
+      unwrapFileMarkersAroundImages(
+        '[FILE: [IMAGE: /tmp/a.png] As shown in [1]',
+      ),
+    ).toBe('[IMAGE: /tmp/a.png] As shown in [1]');
+    expect(
+      unwrapFileMarkersAroundImages('```\n[FILE: [IMAGE: /tmp/a.png]]\n```'),
+    ).toBe('```\n[IMAGE: /tmp/a.png]\n```');
   });
 
   it('treats escaped marker syntax as literal text', () => {

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -93,11 +93,17 @@ function unclosedBacktickStart(
   let delimiterLength = 0;
   let delimiterStart = -1;
   for (const match of text.slice(0, before).matchAll(/`+/gu)) {
-    if (isEscaped(text, match.index!)) continue;
+    let runStart = match.index!;
+    let runLength = match[0].length;
+    if (isEscaped(text, runStart)) {
+      runStart++;
+      runLength--;
+    }
+    if (runLength === 0) continue;
     if (delimiterLength === 0) {
-      delimiterLength = match[0].length;
-      delimiterStart = match.index!;
-    } else if (delimiterLength === match[0].length) {
+      delimiterLength = runLength;
+      delimiterStart = runStart;
+    } else if (delimiterLength === runLength) {
       delimiterLength = 0;
       delimiterStart = -1;
     }
@@ -109,33 +115,8 @@ function previousOpenBracket(text: string, open: number): number {
   return open === 0 ? -1 : text.lastIndexOf('[', open - 1);
 }
 
-function isMarkerCloseBoundary(
-  text: string,
-  close: number,
-  boundary: number,
-): boolean {
-  let cursor = close + 1;
-  if (
-    cursor >= boundary ||
-    /[\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(
-      text[cursor]!,
-    )
-  ) {
-    return true;
-  }
-  while (
-    cursor < boundary &&
-    /[.,;:!?)}\]，。；：！？）】]/u.test(text[cursor]!)
-  ) {
-    cursor++;
-  }
-  return (
-    cursor > close + 1 &&
-    (cursor >= boundary ||
-      /[\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(
-        text[cursor]!,
-      ))
-  );
+function isLikelyMarkerPathContinuation(suffix: string): boolean {
+  return /^(?:\.[^\s[\]]+|[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)+)$/u.test(suffix);
 }
 
 function findMarkerClose(
@@ -151,8 +132,18 @@ function findMarkerClose(
     closes.push(close);
     close = text.indexOf(']', close + 1);
   }
-  for (const candidate of closes) {
-    if (isMarkerCloseBoundary(text, candidate, boundary)) return candidate;
+  for (let index = 0; index < closes.length - 1; index++) {
+    const candidate = closes[index]!;
+    const next = closes[index + 1]!;
+    if (!isLikelyMarkerPathContinuation(text.slice(candidate + 1, next))) {
+      return candidate;
+    }
+  }
+  if (
+    lastClose !== -1 &&
+    isLikelyMarkerPathContinuation(text.slice(lastClose + 1, boundary))
+  ) {
+    return -1;
   }
   return lastClose;
 }
@@ -212,22 +203,18 @@ function markerSanitizationEnd(
   text: string,
   marker: OutboundMediaMarker,
 ): number {
-  if (/\[IMAGE$/iu.test(text.slice(0, marker.start))) return marker.end;
-  const opening = text.slice(marker.start).match(/^\[(IMAGE|FILE):\s*/iu);
-  if (!opening) return marker.end;
-  const pathStart = marker.start + opening[0].length;
-  const nextOpeningOffset = text.slice(pathStart).search(MEDIA_MARKER_PATTERN);
-  const boundary = markerBoundary(
-    text,
-    pathStart,
-    nextOpeningOffset === -1 ? undefined : pathStart + nextOpeningOffset,
-  );
-  const primaryPath = text.slice(pathStart, marker.end - 1);
-  const end = primaryPath.includes('[')
-    ? (marker.candidates?.at(-1)?.end ?? marker.end)
-    : marker.end;
-  if (isMarkerCloseBoundary(text, end - 1, boundary)) return end;
-  return primaryPath.includes('[') ? boundary : end;
+  const lastCandidate = marker.candidates?.at(-1);
+  if (
+    marker.path.includes('[') &&
+    lastCandidate &&
+    lastCandidate.end > marker.end &&
+    /^\s+(?:[~./\\]|[A-Za-z]:[\\/])[^\r\n]*$/u.test(
+      text.slice(marker.end, lastCandidate.end - 1),
+    )
+  ) {
+    return lastCandidate.end;
+  }
+  return marker.end;
 }
 
 export function truncateOutboundMediaText(
@@ -353,6 +340,10 @@ export function stripPartialOutboundMediaMarker(
         searchFrom = open + 1;
         continue;
       }
+      if (lineEnd !== text.length) {
+        searchFrom = open + 1;
+        continue;
+      }
     } else {
       const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
       if (!opening) {
@@ -363,16 +354,22 @@ export function stripPartialOutboundMediaMarker(
       const nextMarkerOffset = text
         .slice(pathStart)
         .search(MEDIA_MARKER_PATTERN);
-      const boundary = markerBoundary(
-        text,
-        pathStart,
-        nextMarkerOffset === -1 ? undefined : pathStart + nextMarkerOffset,
-      );
+      const nextMarkerOpen =
+        nextMarkerOffset === -1 ? undefined : pathStart + nextMarkerOffset;
+      const boundary = markerBoundary(text, pathStart, nextMarkerOpen);
+      if (
+        nextMarkerOpen === boundary &&
+        ((!includeEscaped && isEscaped(text, nextMarkerOpen)) ||
+          codeOpenings.has(nextMarkerOpen))
+      ) {
+        searchFrom = open + 1;
+        continue;
+      }
       if (findMarkerClose(text, pathStart, boundary) !== -1) {
         searchFrom = open + 1;
         continue;
       }
-      end = boundary;
+      end = Math.min(boundary, lineEnd);
     }
     const nextMarker = text.slice(end).match(/^\[(IMAGE|FILE):\s*/iu);
     const replacement =
@@ -483,10 +480,17 @@ export function findTrailingPartialOutboundMediaMarker(
             markerName,
             complete: true,
           };
+        } else {
+          pending = { start: uncertainCodeStart };
         }
         continue;
       }
-      if (wrapper && !wrapper.complete && wrapper.end === lineEnd) {
+      if (
+        wrapper &&
+        !wrapper.complete &&
+        wrapper.end === lineEnd &&
+        lineEnd === text.length
+      ) {
         pending = { start: open, markerName };
         continue;
       }
@@ -497,7 +501,7 @@ export function findTrailingPartialOutboundMediaMarker(
       const trailingBracketedPath =
         close !== -1 &&
         text.slice(pathStart, close).includes('[') &&
-        !isMarkerCloseBoundary(text, close, boundary);
+        isLikelyMarkerPathContinuation(text.slice(close + 1, boundary));
       if (
         boundary === text.length &&
         (close === -1 || ambiguousBracketedPath || trailingBracketedPath)
@@ -510,6 +514,13 @@ export function findTrailingPartialOutboundMediaMarker(
       }
     }
     open = previousOpenBracket(text, open);
+  }
+  const trailingBackslashes = text.match(/\\+$/u);
+  if (
+    trailingBackslashes?.index !== undefined &&
+    (!pending || trailingBackslashes.index < pending.start)
+  ) {
+    pending = { start: trailingBackslashes.index };
   }
   return pending;
 }
@@ -524,20 +535,23 @@ interface FileMarkerAroundImages {
 function isWrapperPathSuffix(suffix: string): boolean {
   if (!suffix) return true;
   if (/^(?:[~/\\]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/u.test(suffix)) return true;
-  return !/[\s[\]]/u.test(suffix);
+  return /^(?:[^\s[\]]+[\\/])+[^\s[\]]+$|^.+\.[A-Za-z0-9]{1,16}$/u.test(suffix);
 }
 
 function fileMarkersAroundImages(text: string): FileMarkerAroundImages[] {
   const images = findOutboundMediaMarkers(text, 'IMAGE', true, true);
   const openings = markerOpenings(text, true).filter(
-    (opening) => opening[1]?.toLowerCase() === 'file',
+    (opening) =>
+      opening.index !== undefined &&
+      !isEscaped(text, opening.index) &&
+      opening[1]?.toLowerCase() === 'file',
   );
   return openings.flatMap((opening) => {
     const start = opening.index!;
     const pathStart = start + opening[0].length;
     const lineBreak = text.slice(pathStart).search(/[\r\n]/u);
     const lineEnd = lineBreak === -1 ? text.length : pathStart + lineBreak;
-    const nested = images.filter(
+    let nested = images.filter(
       (image) => image.start >= pathStart && image.end <= lineEnd,
     );
     if (
@@ -546,6 +560,12 @@ function fileMarkersAroundImages(text: string): FileMarkerAroundImages[] {
     ) {
       return [];
     }
+    const wrapperCloseGap = nested.findIndex(
+      (image, index) =>
+        index > 0 &&
+        text.slice(nested[index - 1]!.end, image.start).includes(']'),
+    );
+    if (wrapperCloseGap !== -1) nested = nested.slice(0, wrapperCloseGap);
     const lastImage = nested.at(-1)!;
     const nextClose = text.indexOf(']', lastImage.end);
     const closedSuffix =
@@ -555,9 +575,14 @@ function fileMarkersAroundImages(text: string): FileMarkerAroundImages[] {
     const complete =
       nextClose !== -1 &&
       nextClose < lineEnd &&
-      isWrapperPathSuffix(closedSuffix ?? '');
+      !(closedSuffix ?? '').includes('[');
     const trailingSuffix = text.slice(lastImage.end, lineEnd).trim();
-    const hidesTrailingSuffix = complete || isWrapperPathSuffix(trailingSuffix);
+    const hidesTrailingSuffix = complete
+      ? isWrapperPathSuffix(closedSuffix ?? '')
+      : !/[\s[\]]/u.test(trailingSuffix);
+    const replacement = nested
+      .map((image) => text.slice(image.start, image.end))
+      .join(' ');
     return [
       {
         start,
@@ -566,9 +591,13 @@ function fileMarkersAroundImages(text: string): FileMarkerAroundImages[] {
           : hidesTrailingSuffix
             ? lineEnd
             : nested[0]!.start,
-        replacement: hidesTrailingSuffix
-          ? nested.map((image) => text.slice(image.start, image.end)).join(' ')
-          : '',
+        replacement: complete
+          ? `${replacement}${
+              hidesTrailingSuffix ? '' : text.slice(lastImage.end, nextClose)
+            }`
+          : hidesTrailingSuffix
+            ? replacement
+            : '',
         complete,
       },
     ];

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -23,10 +23,11 @@ function markerOpeningsInCode(
   let instrumented = text;
   for (let index = openings.length - 1; index >= 0; index--) {
     const opening = openings[index]!;
+    const markerPrefixLength = opening[0].trimEnd().length;
     instrumented =
       instrumented.slice(0, opening.index) +
       sentinels[index] +
-      instrumented.slice(opening.index! + opening[0].length);
+      instrumented.slice(opening.index! + markerPrefixLength);
   }
 
   const codeOpenings = new Set<number>();
@@ -114,7 +115,9 @@ function markerSafeTruncationStart(text: string, start: number): number {
       );
       const close = findMarkerClose(text, pathStart, boundary);
       if (close >= start) return close + 1;
-      if (close === -1 && boundary >= start) return boundary;
+      if (close === -1 && boundary >= start && boundary < text.length) {
+        return boundary;
+      }
     }
     open = previousOpenBracket(before, open);
   }
@@ -221,13 +224,20 @@ export function stripPartialOutboundMediaMarker(
         continue;
       }
     } else {
-      const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu)!;
+      const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
+      if (!opening) {
+        searchFrom = open + 1;
+        continue;
+      }
       const pathStart = open + opening[0].length;
       const nextMarkerOffset = text
-        .slice(pathStart, lineEnd)
+        .slice(pathStart)
         .search(MEDIA_MARKER_PATTERN);
-      const boundary =
-        nextMarkerOffset === -1 ? lineEnd : pathStart + nextMarkerOffset;
+      const boundary = markerBoundary(
+        text,
+        pathStart,
+        nextMarkerOffset === -1 ? undefined : pathStart + nextMarkerOffset,
+      );
       if (findMarkerClose(text, pathStart, boundary) !== -1) {
         searchFrom = open + 1;
         continue;
@@ -250,8 +260,7 @@ export function sanitizeOutboundMediaMarkers(
   replacement: string,
 ): string {
   let result = text;
-  const passes = [...text.matchAll(MEDIA_MARKER_PATTERN)].length + 1;
-  for (let pass = 0; pass < passes; pass++) {
+  while (true) {
     const markers = findOutboundMediaMarkers(result, markerName, true);
     const next = stripPartialOutboundMediaMarker(
       replaceOutboundMediaMarkers(
@@ -265,5 +274,49 @@ export function sanitizeOutboundMediaMarkers(
     if (next === result) return result;
     result = next;
   }
-  return result;
+}
+
+export interface TrailingPartialOutboundMediaMarker {
+  start: number;
+  markerName: 'IMAGE' | 'FILE';
+}
+
+export function findTrailingPartialOutboundMediaMarker(
+  text: string,
+): TrailingPartialOutboundMediaMarker | undefined {
+  let open = text.lastIndexOf('[');
+  while (open !== -1) {
+    const lineBreak = text.slice(open + 1).search(/[\r\n]/u);
+    const lineEnd = lineBreak === -1 ? text.length : open + 1 + lineBreak;
+    const candidate = text.slice(open + 1, lineEnd);
+    for (const markerName of ['IMAGE', 'FILE'] as const) {
+      const prefix = `${markerName}:`;
+      if (
+        lineEnd === text.length &&
+        candidate &&
+        prefix.toLowerCase().startsWith(candidate.toLowerCase())
+      ) {
+        return { start: open, markerName };
+      }
+      const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
+      if (opening?.[1]?.toUpperCase() !== markerName) continue;
+      const pathStart = open + opening[0].length;
+      const nextMarkerOffset = text
+        .slice(pathStart)
+        .search(MEDIA_MARKER_PATTERN);
+      const boundary = markerBoundary(
+        text,
+        pathStart,
+        nextMarkerOffset === -1 ? undefined : pathStart + nextMarkerOffset,
+      );
+      if (
+        boundary === text.length &&
+        findMarkerClose(text, pathStart, boundary) === -1
+      ) {
+        return { start: open, markerName };
+      }
+    }
+    open = previousOpenBracket(text, open);
+  }
+  return undefined;
 }

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -162,6 +162,12 @@ function markerBoundary(
 }
 
 function markerSafeTruncationStart(text: string, start: number): number {
+  for (const markerName of ['IMAGE', 'FILE'] as const) {
+    for (const marker of findOutboundMediaMarkers(text, markerName, true)) {
+      const end = markerSanitizationEnd(text, marker);
+      if (marker.start < start && end >= start) return end;
+    }
+  }
   const before = text.slice(0, start);
   let open = before.lastIndexOf('[');
   while (open !== -1) {
@@ -185,6 +191,28 @@ function markerSafeTruncationStart(text: string, start: number): number {
     open = previousOpenBracket(before, open);
   }
   return start;
+}
+
+function markerSanitizationEnd(
+  text: string,
+  marker: OutboundMediaMarker,
+): number {
+  if (/\[IMAGE$/iu.test(text.slice(0, marker.start))) return marker.end;
+  const opening = text.slice(marker.start).match(/^\[(IMAGE|FILE):\s*/iu);
+  if (!opening) return marker.end;
+  const pathStart = marker.start + opening[0].length;
+  const nextOpeningOffset = text.slice(pathStart).search(MEDIA_MARKER_PATTERN);
+  const boundary = markerBoundary(
+    text,
+    pathStart,
+    nextOpeningOffset === -1 ? undefined : pathStart + nextOpeningOffset,
+  );
+  const primaryPath = text.slice(pathStart, marker.end - 1);
+  const end = primaryPath.includes('[')
+    ? (marker.candidates?.at(-1)?.end ?? marker.end)
+    : marker.end;
+  if (isMarkerCloseBoundary(text, end - 1, boundary)) return end;
+  return primaryPath.includes('[') ? boundary : end;
 }
 
 export function truncateOutboundMediaText(
@@ -348,7 +376,12 @@ export function sanitizeOutboundMediaMarkers(
 ): string {
   let result = text;
   while (true) {
-    const markers = findOutboundMediaMarkers(result, markerName, true);
+    const markers = findOutboundMediaMarkers(result, markerName, true).map(
+      (marker) => ({
+        ...marker,
+        end: markerSanitizationEnd(result, marker),
+      }),
+    );
     const next = stripPartialOutboundMediaMarker(
       replaceOutboundMediaMarkers(
         result,
@@ -367,6 +400,7 @@ export function sanitizeOutboundMediaMarkers(
 export interface TrailingPartialOutboundMediaMarker {
   start: number;
   markerName?: 'IMAGE' | 'FILE';
+  complete?: boolean;
 }
 
 export function findTrailingPartialOutboundMediaMarker(
@@ -412,14 +446,80 @@ export function findTrailingPartialOutboundMediaMarker(
         close === text.length - 1 &&
         text.slice(pathStart, close).includes('[') &&
         text.indexOf(']', pathStart) === close;
+      const trailingBracketedPath =
+        close !== -1 &&
+        text.slice(pathStart, close).includes('[') &&
+        !isMarkerCloseBoundary(text, close, boundary);
       if (
         boundary === text.length &&
-        (close === -1 || ambiguousBracketedPath)
+        (close === -1 || ambiguousBracketedPath || trailingBracketedPath)
       ) {
-        return { start: open, markerName };
+        return {
+          start: open,
+          markerName,
+          ...(ambiguousBracketedPath ? { complete: true } : {}),
+        };
       }
     }
     open = previousOpenBracket(text, open);
   }
   return undefined;
+}
+
+export function unwrapFileMarkersAroundImages(text: string): string {
+  const images = findOutboundMediaMarkers(text, 'IMAGE', true);
+  const openings = markerOpenings(text).filter(
+    (opening) => opening[1]?.toLowerCase() === 'file',
+  );
+  const wrappers = openings.flatMap((opening) => {
+    const start = opening.index!;
+    const pathStart = start + opening[0].length;
+    const lineBreak = text.slice(pathStart).search(/[\r\n]/u);
+    const lineEnd = lineBreak === -1 ? text.length : pathStart + lineBreak;
+    const nested = images.filter(
+      (image) => image.start >= pathStart && image.end <= lineEnd,
+    );
+    if (
+      nested.length === 0 ||
+      text.slice(pathStart, nested[0]!.start).includes(']')
+    ) {
+      return [];
+    }
+    const lastImage = nested.at(-1)!;
+    let wrapperClose = lastImage.end;
+    if (text[wrapperClose] !== ']') {
+      const nextClose = text.indexOf(']', wrapperClose);
+      const suffix = text.slice(wrapperClose, nextClose).trim();
+      wrapperClose =
+        nextClose < lineEnd && /^(?:[~/\\]|[A-Za-z]:[\\/])/u.test(suffix)
+          ? nextClose
+          : -1;
+    }
+    if (wrapperClose === -1 || wrapperClose >= lineEnd) {
+      return [{ start, end: nested[0]!.start, replacement: '' }];
+    }
+    return [
+      {
+        start,
+        end: wrapperClose + 1,
+        replacement: nested
+          .map((image) => text.slice(image.start, image.end))
+          .join(' '),
+      },
+    ];
+  });
+  const nonOverlapping = wrappers
+    .sort((left, right) => left.start - right.start)
+    .filter(
+      (wrapper, index, sorted) =>
+        index === 0 || wrapper.start >= sorted[index - 1]!.end,
+    );
+  let result = text;
+  for (const wrapper of nonOverlapping.reverse()) {
+    result =
+      result.slice(0, wrapper.start) +
+      wrapper.replacement +
+      result.slice(wrapper.end);
+  }
+  return result;
 }

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -1,91 +1,53 @@
+import MarkdownIt from 'markdown-it';
+
 export interface OutboundMediaMarker {
   start: number;
   end: number;
   path: string;
 }
 
-function maskCode(text: string): string {
-  const masked = text.split('');
-  const blank = (start: number, end: number) => {
-    for (let i = start; i < end; i++) {
-      if (masked[i] !== '\n') masked[i] = ' ';
-    }
-  };
-
-  const withoutQuotePrefix = (line: string): string => {
-    let offset = 0;
-    while (offset < line.length) {
-      let spaces = 0;
-      while (spaces < 4 && line[offset + spaces] === ' ') spaces++;
-      if (spaces > 3 || line[offset + spaces] !== '>') break;
-      offset += spaces + 1;
-      if (line[offset] === ' ') offset++;
-    }
-    return line.slice(offset);
-  };
-
-  let fence: { character: '`' | '~'; length: number } | undefined;
-  let lineStart = 0;
-  while (lineStart < text.length) {
-    const newline = text.indexOf('\n', lineStart);
-    const lineEnd = newline === -1 ? text.length : newline;
-    const line = text.slice(lineStart, lineEnd).replace(/\r$/u, '');
-    const body = withoutQuotePrefix(line);
-    if (fence) {
-      blank(lineStart, lineEnd);
-      const closing = body.match(/^ {0,3}(`+|~+)[\t ]*$/u)?.[1];
-      if (closing?.[0] === fence.character && closing.length >= fence.length) {
-        fence = undefined;
-      }
-    } else {
-      const opening = body.match(/^ {0,3}(`{3,}|~{3,})(.*)$/u);
-      const delimiter = opening?.[1];
-      const info = opening?.[2] ?? '';
-      if (delimiter && (delimiter[0] !== '`' || !info.includes('`'))) {
-        fence = {
-          character: delimiter[0] as '`' | '~',
-          length: delimiter.length,
-        };
-        blank(lineStart, lineEnd);
-      } else if (/^(?: {4}|\t)/u.test(body)) {
-        blank(lineStart, lineEnd);
-      }
-    }
-    if (newline === -1) break;
-    lineStart = newline + 1;
-  }
-
-  let offset = 0;
-  while (offset < text.length) {
-    if (masked[offset] === '`') {
-      let runLength = 1;
-      while (masked[offset + runLength] === '`') runLength++;
-      let closing = offset + runLength;
-      while (closing < text.length) {
-        while (closing < text.length && masked[closing] !== '`') closing++;
-        let closingLength = 0;
-        while (masked[closing + closingLength] === '`') closingLength++;
-        if (closingLength === runLength) break;
-        closing += Math.max(1, closingLength);
-      }
-      const newline = text.indexOf('\n', offset + runLength);
-      const end =
-        closing < text.length
-          ? closing + runLength
-          : newline === -1
-            ? text.length
-            : newline;
-      blank(offset, end);
-      offset = end;
-      continue;
-    }
-    offset++;
-  }
-
-  return masked.join('');
-}
-
 const MEDIA_MARKER_PATTERN = /\[(IMAGE|FILE):\s*/giu;
+const CODE_TOKEN_TYPES = new Set(['code_block', 'code_inline', 'fence']);
+const markdown = new MarkdownIt();
+type MarkdownToken = ReturnType<typeof markdown.parse>[number];
+
+function markerOpeningsInCode(
+  text: string,
+  openings: readonly RegExpMatchArray[],
+): Set<number> {
+  const sentinels = openings.map((_, index) => {
+    let sentinel = `\u{e000}QWEN_MEDIA_MARKER_${index}\u{e001}`;
+    while (text.includes(sentinel)) sentinel += '\u{e002}';
+    return sentinel;
+  });
+  let instrumented = text;
+  for (let index = openings.length - 1; index >= 0; index--) {
+    const opening = openings[index]!;
+    instrumented =
+      instrumented.slice(0, opening.index) +
+      sentinels[index] +
+      instrumented.slice(opening.index! + opening[0].length);
+  }
+
+  const codeOpenings = new Set<number>();
+  const visit = (tokens: readonly MarkdownToken[]) => {
+    for (const token of tokens) {
+      if (CODE_TOKEN_TYPES.has(token.type)) {
+        for (const [index, sentinel] of sentinels.entries()) {
+          if (
+            token.content.includes(sentinel) ||
+            token.info.includes(sentinel)
+          ) {
+            codeOpenings.add(openings[index]!.index!);
+          }
+        }
+      }
+      if (token.children) visit(token.children);
+    }
+  };
+  visit(markdown.parse(instrumented, {}));
+  return codeOpenings;
+}
 
 function previousOpenBracket(text: string, open: number): number {
   return open === 0 ? -1 : text.lastIndexOf('[', open - 1);
@@ -136,22 +98,21 @@ function markerBoundary(
 }
 
 function markerSafeTruncationStart(text: string, start: number): number {
-  const visibleText = maskCode(text);
-  const before = visibleText.slice(0, start);
+  const before = text.slice(0, start);
   let open = before.lastIndexOf('[');
   while (open !== -1) {
-    const opening = visibleText.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
+    const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
     if (opening) {
       const pathStart = open + opening[0].length;
-      const nextOpeningOffset = visibleText
+      const nextOpeningOffset = text
         .slice(pathStart)
         .search(MEDIA_MARKER_PATTERN);
       const boundary = markerBoundary(
-        visibleText,
+        text,
         pathStart,
         nextOpeningOffset === -1 ? undefined : pathStart + nextOpeningOffset,
       );
-      const close = findMarkerClose(visibleText, pathStart, boundary);
+      const close = findMarkerClose(text, pathStart, boundary);
       if (close >= start) return close + 1;
       if (close === -1 && boundary >= start) return boundary;
     }
@@ -180,23 +141,26 @@ export function truncateOutboundMediaText(
 export function findOutboundMediaMarkers(
   text: string,
   markerName: 'IMAGE' | 'FILE',
+  includeCode = false,
 ): OutboundMediaMarker[] {
-  const visibleText = maskCode(text);
-  const openings = [...visibleText.matchAll(MEDIA_MARKER_PATTERN)];
+  const openings = [...text.matchAll(MEDIA_MARKER_PATTERN)];
+  const codeOpenings = includeCode
+    ? new Set<number>()
+    : markerOpeningsInCode(text, openings);
   const markers: OutboundMediaMarker[] = [];
 
   for (let i = 0; i < openings.length; i++) {
     const match = openings[i]!;
-    if (match.index === undefined || match[1]?.toUpperCase() !== markerName) {
+    if (
+      match.index === undefined ||
+      match[1]?.toUpperCase() !== markerName ||
+      codeOpenings.has(match.index)
+    ) {
       continue;
     }
     const pathStart = match.index + match[0].length;
-    const boundary = markerBoundary(
-      visibleText,
-      pathStart,
-      openings[i + 1]?.index,
-    );
-    const close = findMarkerClose(visibleText, pathStart, boundary);
+    const boundary = markerBoundary(text, pathStart, openings[i + 1]?.index);
+    const close = findMarkerClose(text, pathStart, boundary);
     if (close === -1) continue;
     const path = text.slice(pathStart, close).trim();
     if (!path) continue;
@@ -235,31 +199,71 @@ export function stripPartialOutboundMediaMarker(
   markerName: 'IMAGE' | 'FILE',
   pendingText: string,
 ): string {
-  const visibleText = maskCode(text);
   const prefix = `${markerName}:`;
-  let open = visibleText.lastIndexOf('[');
-  let stripAt: number | undefined;
-  while (open !== -1) {
-    const candidate = visibleText.slice(open + 1);
-    if (/[\r\n]/u.test(candidate)) break;
-    const nextOpen = visibleText.indexOf('[', open + 1);
-    const ownSegment =
-      nextOpen === -1 ? candidate : candidate.slice(0, nextOpen - open - 1);
-    if (ownSegment.includes(']')) {
-      open = previousOpenBracket(visibleText, open);
+  let cursor = 0;
+  let searchFrom = 0;
+  let result = '';
+  while (searchFrom < text.length) {
+    const open = text.indexOf('[', searchFrom);
+    if (open === -1) break;
+    const lineEndMatch = text.slice(open + 1).search(/[\r\n]/u);
+    const lineEnd = lineEndMatch === -1 ? text.length : open + 1 + lineEndMatch;
+    const candidate = text.slice(open + 1, lineEnd);
+    const normalizedCandidate = candidate.toUpperCase();
+    if (!normalizedCandidate) {
+      searchFrom = open + 1;
       continue;
     }
-    const normalizedCandidate = candidate.toUpperCase();
-    if (
-      normalizedCandidate &&
-      (prefix.startsWith(normalizedCandidate) ||
-        normalizedCandidate.startsWith(prefix))
-    ) {
-      stripAt = open;
+    let end = lineEnd;
+    if (!normalizedCandidate.startsWith(prefix)) {
+      if (!prefix.startsWith(normalizedCandidate)) {
+        searchFrom = open + 1;
+        continue;
+      }
+    } else {
+      const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu)!;
+      const pathStart = open + opening[0].length;
+      const nextMarkerOffset = text
+        .slice(pathStart, lineEnd)
+        .search(MEDIA_MARKER_PATTERN);
+      const boundary =
+        nextMarkerOffset === -1 ? lineEnd : pathStart + nextMarkerOffset;
+      if (findMarkerClose(text, pathStart, boundary) !== -1) {
+        searchFrom = open + 1;
+        continue;
+      }
+      end = boundary;
     }
-    open = previousOpenBracket(visibleText, open);
+    const nextMarker = text.slice(end).match(/^\[(IMAGE|FILE):\s*/iu);
+    const replacement =
+      nextMarker?.[1]?.toUpperCase() === markerName ? '' : pendingText;
+    result += `${text.slice(cursor, open)}${replacement}`;
+    cursor = end;
+    searchFrom = end;
   }
-  return stripAt === undefined
-    ? text
-    : `${text.slice(0, stripAt)}${pendingText}`;
+  return cursor === 0 ? text : result + text.slice(cursor);
+}
+
+export function sanitizeOutboundMediaMarkers(
+  text: string,
+  markerName: 'IMAGE' | 'FILE',
+  replacement: string,
+): string {
+  let result = text;
+  const passes = [...text.matchAll(MEDIA_MARKER_PATTERN)].length + 1;
+  for (let pass = 0; pass < passes; pass++) {
+    const markers = findOutboundMediaMarkers(result, markerName, true);
+    const next = stripPartialOutboundMediaMarker(
+      replaceOutboundMediaMarkers(
+        result,
+        markers,
+        markers.map(() => replacement),
+      ),
+      markerName,
+      replacement,
+    );
+    if (next === result) return result;
+    result = next;
+  }
+  return result;
 }

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -27,9 +27,14 @@ function isEscaped(text: string, index: number): boolean {
   return backslashes % 2 === 1;
 }
 
-function markerOpenings(text: string): RegExpMatchArray[] {
+function markerOpenings(
+  text: string,
+  includeEscaped = false,
+): RegExpMatchArray[] {
   return [...text.matchAll(MEDIA_MARKER_PATTERN)].filter(
-    (opening) => opening.index !== undefined && !isEscaped(text, opening.index),
+    (opening) =>
+      opening.index !== undefined &&
+      (includeEscaped || !isEscaped(text, opening.index)),
   );
 }
 
@@ -78,24 +83,26 @@ function bracketOpeningsInCode(text: string): Set<number> {
   ].filter(
     (opening) => opening.index !== undefined && !isEscaped(text, opening.index),
   );
-  const codeOpenings = markerOpeningsInCode(text, openings);
-  for (const opening of openings) {
-    const lineStart = text.lastIndexOf('\n', opening.index! - 1) + 1;
-    const prefix = text.slice(lineStart, opening.index);
-    let delimiter = 0;
-    for (const match of prefix.matchAll(/`+/gu)) {
-      let escapes = 0;
-      for (let index = match.index! - 1; index >= 0; index--) {
-        if (prefix[index] !== '\\') break;
-        escapes++;
-      }
-      if (escapes % 2 === 1) continue;
-      if (delimiter === 0) delimiter = match[0].length;
-      else if (delimiter === match[0].length) delimiter = 0;
+  return markerOpeningsInCode(text, openings);
+}
+
+function unclosedBacktickStart(
+  text: string,
+  before: number,
+): number | undefined {
+  let delimiterLength = 0;
+  let delimiterStart = -1;
+  for (const match of text.slice(0, before).matchAll(/`+/gu)) {
+    if (isEscaped(text, match.index!)) continue;
+    if (delimiterLength === 0) {
+      delimiterLength = match[0].length;
+      delimiterStart = match.index!;
+    } else if (delimiterLength === match[0].length) {
+      delimiterLength = 0;
+      delimiterStart = -1;
     }
-    if (delimiter !== 0) codeOpenings.add(opening.index!);
   }
-  return codeOpenings;
+  return delimiterStart === -1 ? undefined : delimiterStart;
 }
 
 function previousOpenBracket(text: string, open: number): number {
@@ -162,8 +169,16 @@ function markerBoundary(
 }
 
 function markerSafeTruncationStart(text: string, start: number): number {
+  for (const wrapper of fileMarkersAroundImages(text)) {
+    if (wrapper.start < start && wrapper.end >= start) return wrapper.end;
+  }
   for (const markerName of ['IMAGE', 'FILE'] as const) {
-    for (const marker of findOutboundMediaMarkers(text, markerName, true)) {
+    for (const marker of findOutboundMediaMarkers(
+      text,
+      markerName,
+      true,
+      true,
+    )) {
       const end = markerSanitizationEnd(text, marker);
       if (marker.start < start && end >= start) return end;
     }
@@ -184,7 +199,7 @@ function markerSafeTruncationStart(text: string, start: number): number {
       );
       const close = findMarkerClose(text, pathStart, boundary);
       if (close >= start) return close + 1;
-      if (close === -1 && boundary >= start && boundary < text.length) {
+      if (close === -1 && boundary >= start) {
         return boundary;
       }
     }
@@ -236,8 +251,9 @@ export function findOutboundMediaMarkers(
   text: string,
   markerName: 'IMAGE' | 'FILE',
   includeCode = false,
+  includeEscaped = false,
 ): OutboundMediaMarker[] {
-  const openings = markerOpenings(text);
+  const openings = markerOpenings(text, includeEscaped);
   const codeOpenings = includeCode
     ? new Set<number>()
     : markerOpeningsInCode(text, openings);
@@ -303,6 +319,7 @@ export function stripPartialOutboundMediaMarker(
   markerName: 'IMAGE' | 'FILE',
   pendingText: string,
   includeCode = false,
+  includeEscaped = false,
 ): string {
   const prefix = `${markerName.toLowerCase()}:`;
   const codeOpenings = includeCode
@@ -314,7 +331,7 @@ export function stripPartialOutboundMediaMarker(
   while (searchFrom < text.length) {
     const open = text.indexOf('[', searchFrom);
     if (open === -1) break;
-    if (isEscaped(text, open)) {
+    if (!includeEscaped && isEscaped(text, open)) {
       searchFrom = open + 1;
       continue;
     }
@@ -376,12 +393,15 @@ export function sanitizeOutboundMediaMarkers(
 ): string {
   let result = text;
   while (true) {
-    const markers = findOutboundMediaMarkers(result, markerName, true).map(
-      (marker) => ({
-        ...marker,
-        end: markerSanitizationEnd(result, marker),
-      }),
-    );
+    const markers = findOutboundMediaMarkers(
+      result,
+      markerName,
+      true,
+      true,
+    ).map((marker) => ({
+      ...marker,
+      end: markerSanitizationEnd(result, marker),
+    }));
     const next = stripPartialOutboundMediaMarker(
       replaceOutboundMediaMarkers(
         result,
@@ -390,6 +410,7 @@ export function sanitizeOutboundMediaMarkers(
       ),
       markerName,
       replacement,
+      true,
       true,
     );
     if (next === result) return result;
@@ -407,6 +428,8 @@ export function findTrailingPartialOutboundMediaMarker(
   text: string,
 ): TrailingPartialOutboundMediaMarker | undefined {
   const codeOpenings = bracketOpeningsInCode(text);
+  const wrappers = fileMarkersAroundImages(text);
+  let pending: TrailingPartialOutboundMediaMarker | undefined;
   let open = text.lastIndexOf('[');
   while (open !== -1) {
     if (isEscaped(text, open)) {
@@ -420,7 +443,11 @@ export function findTrailingPartialOutboundMediaMarker(
     const lineBreak = text.slice(open + 1).search(/[\r\n]/u);
     const lineEnd = lineBreak === -1 ? text.length : open + 1 + lineBreak;
     const candidate = text.slice(open + 1, lineEnd);
-    if (lineEnd === text.length && candidate === '') return { start: open };
+    if (lineEnd === text.length && candidate === '') {
+      pending = { start: open };
+      open = previousOpenBracket(text, open);
+      continue;
+    }
     for (const markerName of ['IMAGE', 'FILE'] as const) {
       const prefix = `${markerName}:`;
       if (
@@ -428,7 +455,8 @@ export function findTrailingPartialOutboundMediaMarker(
         candidate &&
         prefix.toLowerCase().startsWith(candidate.toLowerCase())
       ) {
-        return { start: open, markerName };
+        pending = { start: open, markerName };
+        continue;
       }
       const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
       if (opening?.[1]?.toLowerCase() !== markerName.toLowerCase()) continue;
@@ -442,6 +470,26 @@ export function findTrailingPartialOutboundMediaMarker(
         nextMarkerOffset === -1 ? undefined : pathStart + nextMarkerOffset,
       );
       const close = findMarkerClose(text, pathStart, boundary);
+      const wrapper = wrappers.find((candidate) => candidate.start === open);
+      const uncertainCodeStart = unclosedBacktickStart(text, text.length);
+      if (
+        uncertainCodeStart !== undefined &&
+        uncertainCodeStart < open &&
+        lineEnd === text.length
+      ) {
+        if (close !== -1) {
+          pending = {
+            start: uncertainCodeStart,
+            markerName,
+            complete: true,
+          };
+        }
+        continue;
+      }
+      if (wrapper && !wrapper.complete && wrapper.end === lineEnd) {
+        pending = { start: open, markerName };
+        continue;
+      }
       const ambiguousBracketedPath =
         close === text.length - 1 &&
         text.slice(pathStart, close).includes('[') &&
@@ -454,7 +502,7 @@ export function findTrailingPartialOutboundMediaMarker(
         boundary === text.length &&
         (close === -1 || ambiguousBracketedPath || trailingBracketedPath)
       ) {
-        return {
+        pending = {
           start: open,
           markerName,
           ...(ambiguousBracketedPath ? { complete: true } : {}),
@@ -463,15 +511,28 @@ export function findTrailingPartialOutboundMediaMarker(
     }
     open = previousOpenBracket(text, open);
   }
-  return undefined;
+  return pending;
 }
 
-export function unwrapFileMarkersAroundImages(text: string): string {
-  const images = findOutboundMediaMarkers(text, 'IMAGE', true);
-  const openings = markerOpenings(text).filter(
+interface FileMarkerAroundImages {
+  start: number;
+  end: number;
+  replacement: string;
+  complete: boolean;
+}
+
+function isWrapperPathSuffix(suffix: string): boolean {
+  if (!suffix) return true;
+  if (/^(?:[~/\\]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/u.test(suffix)) return true;
+  return !/[\s[\]]/u.test(suffix);
+}
+
+function fileMarkersAroundImages(text: string): FileMarkerAroundImages[] {
+  const images = findOutboundMediaMarkers(text, 'IMAGE', true, true);
+  const openings = markerOpenings(text, true).filter(
     (opening) => opening[1]?.toLowerCase() === 'file',
   );
-  const wrappers = openings.flatMap((opening) => {
+  return openings.flatMap((opening) => {
     const start = opening.index!;
     const pathStart = start + opening[0].length;
     const lineBreak = text.slice(pathStart).search(/[\r\n]/u);
@@ -486,28 +547,36 @@ export function unwrapFileMarkersAroundImages(text: string): string {
       return [];
     }
     const lastImage = nested.at(-1)!;
-    let wrapperClose = lastImage.end;
-    if (text[wrapperClose] !== ']') {
-      const nextClose = text.indexOf(']', wrapperClose);
-      const suffix = text.slice(wrapperClose, nextClose).trim();
-      wrapperClose =
-        nextClose < lineEnd && /^(?:[~/\\]|[A-Za-z]:[\\/])/u.test(suffix)
-          ? nextClose
-          : -1;
-    }
-    if (wrapperClose === -1 || wrapperClose >= lineEnd) {
-      return [{ start, end: nested[0]!.start, replacement: '' }];
-    }
+    const nextClose = text.indexOf(']', lastImage.end);
+    const closedSuffix =
+      nextClose !== -1 && nextClose < lineEnd
+        ? text.slice(lastImage.end, nextClose).trim()
+        : undefined;
+    const complete =
+      nextClose !== -1 &&
+      nextClose < lineEnd &&
+      isWrapperPathSuffix(closedSuffix ?? '');
+    const trailingSuffix = text.slice(lastImage.end, lineEnd).trim();
+    const hidesTrailingSuffix = complete || isWrapperPathSuffix(trailingSuffix);
     return [
       {
         start,
-        end: wrapperClose + 1,
-        replacement: nested
-          .map((image) => text.slice(image.start, image.end))
-          .join(' '),
+        end: complete
+          ? nextClose + 1
+          : hidesTrailingSuffix
+            ? lineEnd
+            : nested[0]!.start,
+        replacement: hidesTrailingSuffix
+          ? nested.map((image) => text.slice(image.start, image.end)).join(' ')
+          : '',
+        complete,
       },
     ];
   });
+}
+
+export function unwrapFileMarkersAroundImages(text: string): string {
+  const wrappers = fileMarkersAroundImages(text);
   const nonOverlapping = wrappers
     .sort((left, right) => left.start - right.start)
     .filter(

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -87,6 +87,10 @@ function maskCode(text: string): string {
 
 const MEDIA_MARKER_PREFIXES = ['IMAGE:', 'FILE:'];
 
+function previousOpenBracket(text: string, open: number): number {
+  return open === 0 ? -1 : text.lastIndexOf('[', open - 1);
+}
+
 function markerSafeTruncationStart(text: string, start: number): number {
   const before = text.slice(0, start);
   const lastClose = before.lastIndexOf(']');
@@ -96,7 +100,6 @@ function markerSafeTruncationStart(text: string, start: number): number {
     if (!/[\r\n]/u.test(candidate)) {
       const normalized = candidate.toUpperCase();
       if (
-        normalized &&
         MEDIA_MARKER_PREFIXES.some(
           (prefix) =>
             prefix.startsWith(normalized) || normalized.startsWith(prefix),
@@ -110,7 +113,7 @@ function markerSafeTruncationStart(text: string, start: number): number {
         return close + 1;
       }
     }
-    open = before.lastIndexOf('[', open - 1);
+    open = previousOpenBracket(before, open);
   }
   return start;
 }
@@ -137,18 +140,26 @@ export function findOutboundMediaMarkers(
   markerName: 'IMAGE' | 'FILE',
 ): OutboundMediaMarker[] {
   const visibleText = maskCode(text);
-  const markerPattern = new RegExp(
-    `\\[${markerName}:\\s*([^\\]\\r\\n]+)\\]`,
-    'gi',
-  );
+  const markerPattern = /\[(IMAGE|FILE):\s*/giu;
+  const openings = [...visibleText.matchAll(markerPattern)];
   const markers: OutboundMediaMarker[] = [];
 
-  for (const match of visibleText.matchAll(markerPattern)) {
-    const path = match[1]?.trim();
-    if (!path || match.index === undefined) continue;
+  for (let i = 0; i < openings.length; i++) {
+    const match = openings[i]!;
+    if (match.index === undefined || match[1]?.toUpperCase() !== markerName) {
+      continue;
+    }
+    const pathStart = match.index + match[0].length;
+    let boundary = openings[i + 1]?.index ?? visibleText.length;
+    const lineBreak = visibleText.slice(pathStart, boundary).search(/[\r\n]/u);
+    if (lineBreak !== -1) boundary = pathStart + lineBreak;
+    const close = visibleText.lastIndexOf(']', boundary - 1);
+    if (close < pathStart) continue;
+    const path = text.slice(pathStart, close).trim();
+    if (!path) continue;
     markers.push({
       start: match.index,
-      end: match.index + match[0].length,
+      end: close + 1,
       path,
     });
   }
@@ -184,11 +195,12 @@ export function stripPartialOutboundMediaMarker(
   const visibleText = maskCode(text);
   const prefix = `${markerName}:`;
   let open = visibleText.lastIndexOf('[');
+  let stripAt: number | undefined;
   while (open !== -1) {
     const candidate = visibleText.slice(open + 1);
-    if (/[\r\n]/u.test(candidate)) return text;
+    if (/[\r\n]/u.test(candidate)) break;
     if (candidate.includes(']')) {
-      open = visibleText.lastIndexOf('[', open - 1);
+      open = previousOpenBracket(visibleText, open);
       continue;
     }
     const normalizedCandidate = candidate.toUpperCase();
@@ -197,9 +209,11 @@ export function stripPartialOutboundMediaMarker(
       (prefix.startsWith(normalizedCandidate) ||
         normalizedCandidate.startsWith(prefix))
     ) {
-      return `${text.slice(0, open)}${pendingText}`;
+      stripAt = open;
     }
-    open = visibleText.lastIndexOf('[', open - 1);
+    open = previousOpenBracket(visibleText, open);
   }
-  return text;
+  return stripAt === undefined
+    ? text
+    : `${text.slice(0, stripAt)}${pendingText}`;
 }

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -7,6 +7,8 @@ export interface OutboundMediaMarker {
 }
 
 const MEDIA_MARKER_PATTERN = /\[(IMAGE|FILE):\s*/giu;
+const PARTIAL_MEDIA_MARKER_OPENING_PATTERN =
+  /\[(?:(?:IMAGE|FILE):\s*|(?:I(?:M(?:A(?:G(?:E)?)?)?)?|F(?:I(?:L(?:E)?)?)?)?(?=[\r\n]|$))/giu;
 const CODE_TOKEN_TYPES = new Set(['code_block', 'code_inline', 'fence']);
 const markdown = new MarkdownIt();
 type MarkdownToken = ReturnType<typeof markdown.parse>[number];
@@ -50,6 +52,28 @@ function markerOpeningsInCode(
   return codeOpenings;
 }
 
+function bracketOpeningsInCode(text: string): Set<number> {
+  const openings = [...text.matchAll(PARTIAL_MEDIA_MARKER_OPENING_PATTERN)];
+  const codeOpenings = markerOpeningsInCode(text, openings);
+  for (const opening of openings) {
+    const lineStart = text.lastIndexOf('\n', opening.index! - 1) + 1;
+    const prefix = text.slice(lineStart, opening.index);
+    let delimiter = 0;
+    for (const match of prefix.matchAll(/`+/gu)) {
+      let escapes = 0;
+      for (let index = match.index! - 1; index >= 0; index--) {
+        if (prefix[index] !== '\\') break;
+        escapes++;
+      }
+      if (escapes % 2 === 1) continue;
+      if (delimiter === 0) delimiter = match[0].length;
+      else if (delimiter === match[0].length) delimiter = 0;
+    }
+    if (delimiter !== 0) codeOpenings.add(opening.index!);
+  }
+  return codeOpenings;
+}
+
 function previousOpenBracket(text: string, open: number): number {
   return open === 0 ? -1 : text.lastIndexOf('[', open - 1);
 }
@@ -60,7 +84,14 @@ function isMarkerCloseBoundary(
   boundary: number,
 ): boolean {
   let cursor = close + 1;
-  if (cursor >= boundary || /\s/u.test(text[cursor]!)) return true;
+  if (
+    cursor >= boundary ||
+    /[\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(
+      text[cursor]!,
+    )
+  ) {
+    return true;
+  }
   while (
     cursor < boundary &&
     /[.,;:!?)}\]，。；：！？）】]/u.test(text[cursor]!)
@@ -68,7 +99,11 @@ function isMarkerCloseBoundary(
     cursor++;
   }
   return (
-    cursor > close + 1 && (cursor >= boundary || /\s/u.test(text[cursor]!))
+    cursor > close + 1 &&
+    (cursor >= boundary ||
+      /[\s\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(
+        text[cursor]!,
+      ))
   );
 }
 
@@ -203,12 +238,17 @@ export function stripPartialOutboundMediaMarker(
   pendingText: string,
 ): string {
   const prefix = `${markerName}:`;
+  const codeOpenings = bracketOpeningsInCode(text);
   let cursor = 0;
   let searchFrom = 0;
   let result = '';
   while (searchFrom < text.length) {
     const open = text.indexOf('[', searchFrom);
     if (open === -1) break;
+    if (codeOpenings.has(open)) {
+      searchFrom = open + 1;
+      continue;
+    }
     const lineEndMatch = text.slice(open + 1).search(/[\r\n]/u);
     const lineEnd = lineEndMatch === -1 ? text.length : open + 1 + lineEndMatch;
     const candidate = text.slice(open + 1, lineEnd);
@@ -278,17 +318,23 @@ export function sanitizeOutboundMediaMarkers(
 
 export interface TrailingPartialOutboundMediaMarker {
   start: number;
-  markerName: 'IMAGE' | 'FILE';
+  markerName?: 'IMAGE' | 'FILE';
 }
 
 export function findTrailingPartialOutboundMediaMarker(
   text: string,
 ): TrailingPartialOutboundMediaMarker | undefined {
+  const codeOpenings = bracketOpeningsInCode(text);
   let open = text.lastIndexOf('[');
   while (open !== -1) {
+    if (codeOpenings.has(open)) {
+      open = previousOpenBracket(text, open);
+      continue;
+    }
     const lineBreak = text.slice(open + 1).search(/[\r\n]/u);
     const lineEnd = lineBreak === -1 ? text.length : open + 1 + lineBreak;
     const candidate = text.slice(open + 1, lineEnd);
+    if (lineEnd === text.length && candidate === '') return { start: open };
     for (const markerName of ['IMAGE', 'FILE'] as const) {
       const prefix = `${markerName}:`;
       if (

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -1,9 +1,15 @@
 import MarkdownIt from 'markdown-it';
 
+export interface OutboundMediaMarkerCandidate {
+  end: number;
+  path: string;
+}
+
 export interface OutboundMediaMarker {
   start: number;
   end: number;
   path: string;
+  candidates?: OutboundMediaMarkerCandidate[];
 }
 
 const MEDIA_MARKER_PATTERN = /\[(IMAGE|FILE):\s*/giu;
@@ -12,6 +18,20 @@ const PARTIAL_MEDIA_MARKER_OPENING_PATTERN =
 const CODE_TOKEN_TYPES = new Set(['code_block', 'code_inline', 'fence']);
 const markdown = new MarkdownIt();
 type MarkdownToken = ReturnType<typeof markdown.parse>[number];
+
+function isEscaped(text: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function markerOpenings(text: string): RegExpMatchArray[] {
+  return [...text.matchAll(MEDIA_MARKER_PATTERN)].filter(
+    (opening) => opening.index !== undefined && !isEscaped(text, opening.index),
+  );
+}
 
 function markerOpeningsInCode(
   text: string,
@@ -53,7 +73,11 @@ function markerOpeningsInCode(
 }
 
 function bracketOpeningsInCode(text: string): Set<number> {
-  const openings = [...text.matchAll(PARTIAL_MEDIA_MARKER_OPENING_PATTERN)];
+  const openings = [
+    ...text.matchAll(PARTIAL_MEDIA_MARKER_OPENING_PATTERN),
+  ].filter(
+    (opening) => opening.index !== undefined && !isEscaped(text, opening.index),
+  );
   const codeOpenings = markerOpeningsInCode(text, openings);
   for (const opening of openings) {
     const lineStart = text.lastIndexOf('\n', opening.index! - 1) + 1;
@@ -114,10 +138,14 @@ function findMarkerClose(
 ): number {
   let close = text.indexOf(']', pathStart);
   let lastClose = -1;
+  const closes: number[] = [];
   while (close !== -1 && close < boundary) {
     lastClose = close;
-    if (isMarkerCloseBoundary(text, close, boundary)) return close;
+    closes.push(close);
     close = text.indexOf(']', close + 1);
+  }
+  for (const candidate of closes) {
+    if (isMarkerCloseBoundary(text, candidate, boundary)) return candidate;
   }
   return lastClose;
 }
@@ -181,7 +209,7 @@ export function findOutboundMediaMarkers(
   markerName: 'IMAGE' | 'FILE',
   includeCode = false,
 ): OutboundMediaMarker[] {
-  const openings = [...text.matchAll(MEDIA_MARKER_PATTERN)];
+  const openings = markerOpenings(text);
   const codeOpenings = includeCode
     ? new Set<number>()
     : markerOpeningsInCode(text, openings);
@@ -191,7 +219,7 @@ export function findOutboundMediaMarkers(
     const match = openings[i]!;
     if (
       match.index === undefined ||
-      match[1]?.toUpperCase() !== markerName ||
+      match[1]?.toLowerCase() !== markerName.toLowerCase() ||
       codeOpenings.has(match.index)
     ) {
       continue;
@@ -202,10 +230,20 @@ export function findOutboundMediaMarkers(
     if (close === -1) continue;
     const path = text.slice(pathStart, close).trim();
     if (!path) continue;
+    const candidates: OutboundMediaMarkerCandidate[] = [];
+    let candidateClose = text.indexOf(']', pathStart);
+    while (candidateClose !== -1 && candidateClose < boundary) {
+      const candidatePath = text.slice(pathStart, candidateClose).trim();
+      if (candidatePath) {
+        candidates.push({ end: candidateClose + 1, path: candidatePath });
+      }
+      candidateClose = text.indexOf(']', candidateClose + 1);
+    }
     markers.push({
       start: match.index,
       end: close + 1,
       path,
+      ...(candidates.length > 1 ? { candidates } : {}),
     });
   }
 
@@ -236,15 +274,22 @@ export function stripPartialOutboundMediaMarker(
   text: string,
   markerName: 'IMAGE' | 'FILE',
   pendingText: string,
+  includeCode = false,
 ): string {
-  const prefix = `${markerName}:`;
-  const codeOpenings = bracketOpeningsInCode(text);
+  const prefix = `${markerName.toLowerCase()}:`;
+  const codeOpenings = includeCode
+    ? new Set<number>()
+    : bracketOpeningsInCode(text);
   let cursor = 0;
   let searchFrom = 0;
   let result = '';
   while (searchFrom < text.length) {
     const open = text.indexOf('[', searchFrom);
     if (open === -1) break;
+    if (isEscaped(text, open)) {
+      searchFrom = open + 1;
+      continue;
+    }
     if (codeOpenings.has(open)) {
       searchFrom = open + 1;
       continue;
@@ -252,7 +297,7 @@ export function stripPartialOutboundMediaMarker(
     const lineEndMatch = text.slice(open + 1).search(/[\r\n]/u);
     const lineEnd = lineEndMatch === -1 ? text.length : open + 1 + lineEndMatch;
     const candidate = text.slice(open + 1, lineEnd);
-    const normalizedCandidate = candidate.toUpperCase();
+    const normalizedCandidate = candidate.toLowerCase();
     if (!normalizedCandidate) {
       searchFrom = open + 1;
       continue;
@@ -286,7 +331,9 @@ export function stripPartialOutboundMediaMarker(
     }
     const nextMarker = text.slice(end).match(/^\[(IMAGE|FILE):\s*/iu);
     const replacement =
-      nextMarker?.[1]?.toUpperCase() === markerName ? '' : pendingText;
+      nextMarker?.[1]?.toLowerCase() === markerName.toLowerCase()
+        ? ''
+        : pendingText;
     result += `${text.slice(cursor, open)}${replacement}`;
     cursor = end;
     searchFrom = end;
@@ -310,6 +357,7 @@ export function sanitizeOutboundMediaMarkers(
       ),
       markerName,
       replacement,
+      true,
     );
     if (next === result) return result;
     result = next;
@@ -327,6 +375,10 @@ export function findTrailingPartialOutboundMediaMarker(
   const codeOpenings = bracketOpeningsInCode(text);
   let open = text.lastIndexOf('[');
   while (open !== -1) {
+    if (isEscaped(text, open)) {
+      open = previousOpenBracket(text, open);
+      continue;
+    }
     if (codeOpenings.has(open)) {
       open = previousOpenBracket(text, open);
       continue;
@@ -345,7 +397,7 @@ export function findTrailingPartialOutboundMediaMarker(
         return { start: open, markerName };
       }
       const opening = text.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
-      if (opening?.[1]?.toUpperCase() !== markerName) continue;
+      if (opening?.[1]?.toLowerCase() !== markerName.toLowerCase()) continue;
       const pathStart = open + opening[0].length;
       const nextMarkerOffset = text
         .slice(pathStart)
@@ -355,9 +407,14 @@ export function findTrailingPartialOutboundMediaMarker(
         pathStart,
         nextMarkerOffset === -1 ? undefined : pathStart + nextMarkerOffset,
       );
+      const close = findMarkerClose(text, pathStart, boundary);
+      const ambiguousBracketedPath =
+        close === text.length - 1 &&
+        text.slice(pathStart, close).includes('[') &&
+        text.indexOf(']', pathStart) === close;
       if (
         boundary === text.length &&
-        findMarkerClose(text, pathStart, boundary) === -1
+        (close === -1 || ambiguousBracketedPath)
       ) {
         return { start: open, markerName };
       }

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -1,0 +1,205 @@
+export interface OutboundMediaMarker {
+  start: number;
+  end: number;
+  path: string;
+}
+
+function maskCode(text: string): string {
+  const masked = text.split('');
+  const blank = (start: number, end: number) => {
+    for (let i = start; i < end; i++) {
+      if (masked[i] !== '\n') masked[i] = ' ';
+    }
+  };
+
+  const withoutQuotePrefix = (line: string): string => {
+    let offset = 0;
+    while (offset < line.length) {
+      let spaces = 0;
+      while (spaces < 4 && line[offset + spaces] === ' ') spaces++;
+      if (spaces > 3 || line[offset + spaces] !== '>') break;
+      offset += spaces + 1;
+      if (line[offset] === ' ') offset++;
+    }
+    return line.slice(offset);
+  };
+
+  let fence: { character: '`' | '~'; length: number } | undefined;
+  let lineStart = 0;
+  while (lineStart < text.length) {
+    const newline = text.indexOf('\n', lineStart);
+    const lineEnd = newline === -1 ? text.length : newline;
+    const line = text.slice(lineStart, lineEnd).replace(/\r$/u, '');
+    const body = withoutQuotePrefix(line);
+    if (fence) {
+      blank(lineStart, lineEnd);
+      const closing = body.match(/^ {0,3}(`+|~+)[\t ]*$/u)?.[1];
+      if (closing?.[0] === fence.character && closing.length >= fence.length) {
+        fence = undefined;
+      }
+    } else {
+      const opening = body.match(/^ {0,3}(`{3,}|~{3,})(.*)$/u);
+      const delimiter = opening?.[1];
+      const info = opening?.[2] ?? '';
+      if (delimiter && (delimiter[0] !== '`' || !info.includes('`'))) {
+        fence = {
+          character: delimiter[0] as '`' | '~',
+          length: delimiter.length,
+        };
+        blank(lineStart, lineEnd);
+      } else if (/^(?: {4}|\t)/u.test(body)) {
+        blank(lineStart, lineEnd);
+      }
+    }
+    if (newline === -1) break;
+    lineStart = newline + 1;
+  }
+
+  let offset = 0;
+  while (offset < text.length) {
+    if (masked[offset] === '`') {
+      let runLength = 1;
+      while (masked[offset + runLength] === '`') runLength++;
+      let closing = offset + runLength;
+      while (closing < text.length) {
+        while (closing < text.length && masked[closing] !== '`') closing++;
+        let closingLength = 0;
+        while (masked[closing + closingLength] === '`') closingLength++;
+        if (closingLength === runLength) break;
+        closing += Math.max(1, closingLength);
+      }
+      const newline = text.indexOf('\n', offset + runLength);
+      const end =
+        closing < text.length
+          ? closing + runLength
+          : newline === -1
+            ? text.length
+            : newline;
+      blank(offset, end);
+      offset = end;
+      continue;
+    }
+    offset++;
+  }
+
+  return masked.join('');
+}
+
+const MEDIA_MARKER_PREFIXES = ['IMAGE:', 'FILE:'];
+
+function markerSafeTruncationStart(text: string, start: number): number {
+  const before = text.slice(0, start);
+  const lastClose = before.lastIndexOf(']');
+  let open = before.lastIndexOf('[');
+  while (open > lastClose) {
+    const candidate = before.slice(open + 1);
+    if (!/[\r\n]/u.test(candidate)) {
+      const normalized = candidate.toUpperCase();
+      if (
+        normalized &&
+        MEDIA_MARKER_PREFIXES.some(
+          (prefix) =>
+            prefix.startsWith(normalized) || normalized.startsWith(prefix),
+        )
+      ) {
+        const close = text.indexOf(']', start);
+        const newline = text
+          .slice(start, close === -1 ? undefined : close)
+          .search(/[\r\n]/u);
+        if (close === -1 || newline !== -1) return text.length;
+        return close + 1;
+      }
+    }
+    open = before.lastIndexOf('[', open - 1);
+  }
+  return start;
+}
+
+export function truncateOutboundMediaText(
+  text: string,
+  limit: number,
+  truncationMarker: string,
+): string {
+  if (text.length <= limit) return text;
+  if (limit === 0) return '';
+  if (limit <= truncationMarker.length) {
+    return text.slice(markerSafeTruncationStart(text, text.length - limit));
+  }
+  const start = markerSafeTruncationStart(
+    text,
+    text.length - (limit - truncationMarker.length),
+  );
+  return `${truncationMarker}${text.slice(start)}`;
+}
+
+export function findOutboundMediaMarkers(
+  text: string,
+  markerName: 'IMAGE' | 'FILE',
+): OutboundMediaMarker[] {
+  const visibleText = maskCode(text);
+  const markerPattern = new RegExp(
+    `\\[${markerName}:\\s*([^\\]\\r\\n]+)\\]`,
+    'gi',
+  );
+  const markers: OutboundMediaMarker[] = [];
+
+  for (const match of visibleText.matchAll(markerPattern)) {
+    const path = match[1]?.trim();
+    if (!path || match.index === undefined) continue;
+    markers.push({
+      start: match.index,
+      end: match.index + match[0].length,
+      path,
+    });
+  }
+
+  return markers;
+}
+
+export function replaceOutboundMediaMarkers(
+  text: string,
+  markers: readonly OutboundMediaMarker[],
+  replacements: readonly string[],
+): string {
+  if (markers.length !== replacements.length) {
+    throw new Error('Media marker replacement count mismatch');
+  }
+
+  let result = text;
+  for (let i = markers.length - 1; i >= 0; i--) {
+    const marker = markers[i]!;
+    result =
+      result.slice(0, marker.start) +
+      replacements[i]! +
+      result.slice(marker.end);
+  }
+  return result;
+}
+
+export function stripPartialOutboundMediaMarker(
+  text: string,
+  markerName: 'IMAGE' | 'FILE',
+  pendingText: string,
+): string {
+  const visibleText = maskCode(text);
+  const prefix = `${markerName}:`;
+  let open = visibleText.lastIndexOf('[');
+  while (open !== -1) {
+    const candidate = visibleText.slice(open + 1);
+    if (/[\r\n]/u.test(candidate)) return text;
+    if (candidate.includes(']')) {
+      open = visibleText.lastIndexOf('[', open - 1);
+      continue;
+    }
+    const normalizedCandidate = candidate.toUpperCase();
+    if (
+      normalizedCandidate &&
+      (prefix.startsWith(normalizedCandidate) ||
+        normalizedCandidate.startsWith(prefix))
+    ) {
+      return `${text.slice(0, open)}${pendingText}`;
+    }
+    open = visibleText.lastIndexOf('[', open - 1);
+  }
+  return text;
+}

--- a/packages/channels/dingtalk/src/outbound-markers.ts
+++ b/packages/channels/dingtalk/src/outbound-markers.ts
@@ -85,33 +85,75 @@ function maskCode(text: string): string {
   return masked.join('');
 }
 
-const MEDIA_MARKER_PREFIXES = ['IMAGE:', 'FILE:'];
+const MEDIA_MARKER_PATTERN = /\[(IMAGE|FILE):\s*/giu;
 
 function previousOpenBracket(text: string, open: number): number {
   return open === 0 ? -1 : text.lastIndexOf('[', open - 1);
 }
 
+function isMarkerCloseBoundary(
+  text: string,
+  close: number,
+  boundary: number,
+): boolean {
+  let cursor = close + 1;
+  if (cursor >= boundary || /\s/u.test(text[cursor]!)) return true;
+  while (
+    cursor < boundary &&
+    /[.,;:!?)}\]，。；：！？）】]/u.test(text[cursor]!)
+  ) {
+    cursor++;
+  }
+  return (
+    cursor > close + 1 && (cursor >= boundary || /\s/u.test(text[cursor]!))
+  );
+}
+
+function findMarkerClose(
+  text: string,
+  pathStart: number,
+  boundary: number,
+): number {
+  let close = text.indexOf(']', pathStart);
+  let lastClose = -1;
+  while (close !== -1 && close < boundary) {
+    lastClose = close;
+    if (isMarkerCloseBoundary(text, close, boundary)) return close;
+    close = text.indexOf(']', close + 1);
+  }
+  return lastClose;
+}
+
+function markerBoundary(
+  visibleText: string,
+  pathStart: number,
+  nextOpening: number | undefined,
+): number {
+  let boundary = nextOpening ?? visibleText.length;
+  const lineBreak = visibleText.slice(pathStart, boundary).search(/[\r\n]/u);
+  if (lineBreak !== -1) boundary = pathStart + lineBreak;
+  return boundary;
+}
+
 function markerSafeTruncationStart(text: string, start: number): number {
-  const before = text.slice(0, start);
-  const lastClose = before.lastIndexOf(']');
+  const visibleText = maskCode(text);
+  const before = visibleText.slice(0, start);
   let open = before.lastIndexOf('[');
-  while (open > lastClose) {
-    const candidate = before.slice(open + 1);
-    if (!/[\r\n]/u.test(candidate)) {
-      const normalized = candidate.toUpperCase();
-      if (
-        MEDIA_MARKER_PREFIXES.some(
-          (prefix) =>
-            prefix.startsWith(normalized) || normalized.startsWith(prefix),
-        )
-      ) {
-        const close = text.indexOf(']', start);
-        const newline = text
-          .slice(start, close === -1 ? undefined : close)
-          .search(/[\r\n]/u);
-        if (close === -1 || newline !== -1) return text.length;
-        return close + 1;
-      }
+  while (open !== -1) {
+    const opening = visibleText.slice(open).match(/^\[(IMAGE|FILE):\s*/iu);
+    if (opening) {
+      const pathStart = open + opening[0].length;
+      const nextOpeningOffset = visibleText
+        .slice(pathStart)
+        .search(MEDIA_MARKER_PATTERN);
+      const boundary = markerBoundary(
+        visibleText,
+        pathStart,
+        nextOpeningOffset === -1 ? undefined : pathStart + nextOpeningOffset,
+      );
+      const close = findMarkerClose(visibleText, pathStart, boundary);
+      if (close >= start) return close + 1;
+      if (close === -1 && boundary >= start) return boundary;
     }
     open = previousOpenBracket(before, open);
   }
@@ -140,8 +182,7 @@ export function findOutboundMediaMarkers(
   markerName: 'IMAGE' | 'FILE',
 ): OutboundMediaMarker[] {
   const visibleText = maskCode(text);
-  const markerPattern = /\[(IMAGE|FILE):\s*/giu;
-  const openings = [...visibleText.matchAll(markerPattern)];
+  const openings = [...visibleText.matchAll(MEDIA_MARKER_PATTERN)];
   const markers: OutboundMediaMarker[] = [];
 
   for (let i = 0; i < openings.length; i++) {
@@ -150,11 +191,13 @@ export function findOutboundMediaMarkers(
       continue;
     }
     const pathStart = match.index + match[0].length;
-    let boundary = openings[i + 1]?.index ?? visibleText.length;
-    const lineBreak = visibleText.slice(pathStart, boundary).search(/[\r\n]/u);
-    if (lineBreak !== -1) boundary = pathStart + lineBreak;
-    const close = visibleText.lastIndexOf(']', boundary - 1);
-    if (close < pathStart) continue;
+    const boundary = markerBoundary(
+      visibleText,
+      pathStart,
+      openings[i + 1]?.index,
+    );
+    const close = findMarkerClose(visibleText, pathStart, boundary);
+    if (close === -1) continue;
     const path = text.slice(pathStart, close).trim();
     if (!path) continue;
     markers.push({
@@ -199,7 +242,10 @@ export function stripPartialOutboundMediaMarker(
   while (open !== -1) {
     const candidate = visibleText.slice(open + 1);
     if (/[\r\n]/u.test(candidate)) break;
-    if (candidate.includes(']')) {
+    const nextOpen = visibleText.indexOf('[', open + 1);
+    const ownSegment =
+      nextOpen === -1 ? candidate : candidate.slice(0, nextOpen - open - 1);
+    if (ownSegment.includes(']')) {
       open = previousOpenBracket(visibleText, open);
       continue;
     }

--- a/packages/channels/dingtalk/src/outbound-media.ts
+++ b/packages/channels/dingtalk/src/outbound-media.ts
@@ -1,0 +1,97 @@
+const MEDIA_UPLOAD_API = 'https://oapi.dingtalk.com/media/upload';
+const MEDIA_UPLOAD_TIMEOUT_MS = 30_000;
+const AUTH_ERROR_CODES = new Set([40014, 42001]);
+
+export interface DingTalkUploadMedia {
+  data: Buffer;
+  fileName: string;
+  mimeType: string;
+}
+
+export class DingTalkMediaUploadError extends Error {
+  constructor(
+    message: string,
+    readonly authFailure: boolean,
+  ) {
+    super(message);
+    this.name = 'DingTalkMediaUploadError';
+  }
+}
+
+function sanitizeApiMessage(message: unknown, accessToken: string): string {
+  const value = String(message ?? '');
+  return (accessToken ? value.replaceAll(accessToken, '[redacted]') : value)
+    .replace(/[\r\n\t]+/g, ' ')
+    .slice(0, 200);
+}
+
+export async function uploadDingTalkMedia(
+  media: DingTalkUploadMedia,
+  accessToken: string,
+  mediaType: 'image' | 'file',
+): Promise<string> {
+  const form = new FormData();
+  form.append(
+    'media',
+    new Blob([media.data], { type: media.mimeType }),
+    media.fileName,
+  );
+
+  let response: Response;
+  try {
+    const url = new URL(MEDIA_UPLOAD_API);
+    url.searchParams.set('access_token', accessToken);
+    url.searchParams.set('type', mediaType);
+    response = await fetch(url, {
+      method: 'POST',
+      body: form,
+      signal: AbortSignal.timeout(MEDIA_UPLOAD_TIMEOUT_MS),
+    });
+  } catch {
+    throw new DingTalkMediaUploadError(
+      'DingTalk media upload failed: network request failed',
+      false,
+    );
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    const parsed = (await response.json()) as unknown;
+    payload =
+      parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+  } catch {
+    throw new DingTalkMediaUploadError(
+      `DingTalk media upload failed: HTTP ${response.status} invalid JSON response`,
+      response.status === 401,
+    );
+  }
+
+  const errcode =
+    typeof payload['errcode'] === 'number' ? payload['errcode'] : undefined;
+  if (!response.ok || (errcode !== undefined && errcode !== 0)) {
+    const detail = sanitizeApiMessage(payload['errmsg'], accessToken);
+    throw new DingTalkMediaUploadError(
+      `DingTalk media upload failed: HTTP ${response.status}${
+        errcode === undefined ? '' : ` errcode=${errcode}`
+      }${detail ? ` ${detail}` : ''}`,
+      response.status === 401 ||
+        (errcode !== undefined && AUTH_ERROR_CODES.has(errcode)),
+    );
+  }
+
+  const mediaId =
+    typeof payload['media_id'] === 'string'
+      ? payload['media_id']
+      : typeof payload['mediaId'] === 'string'
+        ? payload['mediaId']
+        : undefined;
+  if (!mediaId) {
+    throw new DingTalkMediaUploadError(
+      'DingTalk media upload failed: response did not include a MediaID',
+      false,
+    );
+  }
+  return mediaId;
+}

--- a/packages/channels/dingtalk/src/status-card-controller.test.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.test.ts
@@ -306,6 +306,27 @@ describe('StatusCardController', () => {
     ).not.toContain('/Users/ben/private');
   });
 
+  it('hides unclosed markers in code from every card payload', async () => {
+    vi.useFakeTimers();
+    const { client, controller } = createHarness();
+    const output =
+      '```text\n[IMAGE: /Users/ben/private/image.png\n```\n' +
+      '    [FILE: /Users/ben/private/report.pdf';
+
+    controller.replace(segment(), target, output);
+    await vi.advanceTimersByTimeAsync(500);
+    controller.cancelRun('run-1', 'cancel_command');
+    await vi.advanceTimersByTimeAsync(500);
+
+    const payloads = JSON.stringify({
+      create: vi.mocked(client.createAndDeliver).mock.calls,
+      stream: vi.mocked(client.openOrUpdateStream).mock.calls,
+      terminal: vi.mocked(client.updateInstance).mock.calls,
+    });
+    expect(payloads).not.toContain('/Users/ben/private');
+    expect(payloads).not.toMatch(/\[(?:IMAGE|FILE):/u);
+  });
+
   it('shows the configured model and refreshes elapsed time while idle', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/packages/channels/dingtalk/src/status-card-controller.test.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.test.ts
@@ -206,7 +206,26 @@ describe('StatusCardController', () => {
     );
     const content = vi.mocked(client.createAndDeliver).mock.calls[0]?.[0]
       .cardParamMap.content;
-    expect(content).toBe(`${TRUNCATION_MARKER}${suffix}`);
+    expect(content).toBe(`${prefix}${suffix}`);
+    expect(content).not.toContain('/Users/ben/private');
+  });
+
+  it('sanitizes markers before truncating across a code fence', async () => {
+    const { client, controller } = createHarness();
+    const output = [
+      '```text',
+      'x'.repeat(CONTENT_LIMIT),
+      '```',
+      '[FILE: /Users/ben/private/report.pdf]',
+    ].join('\n');
+
+    controller.replace(segment(), target, output);
+
+    await vi.waitFor(() =>
+      expect(client.createAndDeliver).toHaveBeenCalledOnce(),
+    );
+    const content = vi.mocked(client.createAndDeliver).mock.calls[0]?.[0]
+      .cardParamMap.content;
     expect(content).not.toContain('/Users/ben/private');
   });
 

--- a/packages/channels/dingtalk/src/status-card-controller.test.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChannelOutputSegmentContext } from '@qwen-code/channel-base';
 import type { DingtalkInteractiveCardClient } from './interactive-card-client.js';
-import { StatusCardController } from './status-card-controller.js';
+import {
+  CONTENT_LIMIT,
+  StatusCardController,
+  TRUNCATION_MARKER,
+} from './status-card-controller.js';
 
 type ExpectedCallbackResult =
   | { kind: 'accepted'; execute: () => Promise<void> }
@@ -168,6 +172,44 @@ describe('StatusCardController', () => {
     expect(streamContents.at(-1)).toBe('before [Image pending] after');
   });
 
+  it('hides streamed file paths in status snapshots', async () => {
+    vi.useFakeTimers();
+    const { client, controller } = createHarness();
+
+    controller.replace(
+      segment(),
+      target,
+      'before [FILE: /Users/ben/private/report.pdf] after',
+    );
+    await vi.advanceTimersByTimeAsync(500);
+
+    const streamContents = vi
+      .mocked(client.openOrUpdateStream)
+      .mock.calls.map(([request]) => request.content);
+    expect(streamContents.join('\n')).not.toContain('/Users/ben/private');
+    expect(streamContents.at(-1)).toBe('before  after');
+  });
+
+  it('does not expose a file path when truncation splits its marker', async () => {
+    const { client, controller } = createHarness();
+    const marker = '[FILE: /Users/ben/private/report.pdf]';
+    const splitOffset = '[FILE: '.length;
+    const prefix = 'x'.repeat(TRUNCATION_MARKER.length + 10);
+    const suffix = 'z'.repeat(
+      CONTENT_LIMIT - TRUNCATION_MARKER.length + splitOffset - marker.length,
+    );
+
+    controller.replace(segment(), target, `${prefix}${marker}${suffix}`);
+
+    await vi.waitFor(() =>
+      expect(client.createAndDeliver).toHaveBeenCalledOnce(),
+    );
+    const content = vi.mocked(client.createAndDeliver).mock.calls[0]?.[0]
+      .cardParamMap.content;
+    expect(content).toBe(`${TRUNCATION_MARKER}${suffix}`);
+    expect(content).not.toContain('/Users/ben/private');
+  });
+
   it('hides image paths when a streaming card is cancelled', async () => {
     const { client, controller } = createHarness();
 
@@ -196,6 +238,35 @@ describe('StatusCardController', () => {
       vi.mocked(client.updateInstance).mock.calls.at(-1)?.[0].cardParamMap,
     );
     expect(terminalPayload).not.toContain('/Users/ben/private');
+  });
+
+  it('hides file paths when a streaming card is cancelled', async () => {
+    const { client, controller } = createHarness();
+
+    controller.replace(
+      segment(),
+      target,
+      'before [FILE: /Users/ben/private/report.pdf] after',
+    );
+    await vi.waitFor(() =>
+      expect(client.createAndDeliver).toHaveBeenCalledOnce(),
+    );
+
+    controller.cancelRun('run-1', 'cancel_command');
+
+    await vi.waitFor(() =>
+      expect(client.updateInstance).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cardParamMap: expect.objectContaining({
+            content: 'before  after',
+            copy_content: 'before  after',
+          }),
+        }),
+      ),
+    );
+    expect(
+      JSON.stringify(vi.mocked(client.updateInstance).mock.calls),
+    ).not.toContain('/Users/ben/private');
   });
 
   it('shows the configured model and refreshes elapsed time while idle', async () => {
@@ -470,6 +541,32 @@ describe('StatusCardController', () => {
     controller.replace(segment(), target, 'late');
     expect(client.createAndDeliver).toHaveBeenCalledOnce();
     expect(client.openOrUpdateStream).toHaveBeenCalledTimes(2);
+  });
+
+  it('omits delivered file markers from the terminal card', async () => {
+    const { client, controller } = createHarness();
+    controller.replace(
+      segment(),
+      target,
+      'before [FILE: /Users/ben/private/report.txt] after',
+    );
+
+    await expect(
+      controller.complete('segment-1', 'before [File: report.txt] after'),
+    ).resolves.toBe(true);
+
+    expect(client.updateInstance).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        cardParamMap: expect.objectContaining({
+          blockList: '[{"type":0,"markdown":"before  after"}]',
+          content: 'before  after',
+          copy_content: 'before  after',
+        }),
+      }),
+    );
+    expect(
+      JSON.stringify(vi.mocked(client.updateInstance).mock.calls.at(-1)?.[0]),
+    ).not.toMatch(/File pending|File:|\/Users\/ben\/private/u);
   });
 
   it('retains streamed content when completion has no response body', async () => {

--- a/packages/channels/dingtalk/src/status-card-controller.test.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.test.ts
@@ -190,6 +190,33 @@ describe('StatusCardController', () => {
     expect(streamContents.at(-1)).toBe('before  after');
   });
 
+  it.each(['IMAGE', 'FILE'] as const)(
+    'hides escaped %s paths from streaming and terminal cards',
+    async (markerName) => {
+      vi.useFakeTimers();
+      const { client, controller } = createHarness();
+
+      controller.replace(
+        segment(),
+        target,
+        String.raw`before \[${markerName}: /Users/ben/private/value.dat] after`,
+      );
+      await vi.advanceTimersByTimeAsync(500);
+      controller.cancelRun('run-1', 'cancel_command');
+      await vi.runAllTimersAsync();
+
+      expect(
+        JSON.stringify(vi.mocked(client.createAndDeliver).mock.calls),
+      ).not.toContain('/Users/ben/private');
+      expect(
+        JSON.stringify(vi.mocked(client.openOrUpdateStream).mock.calls),
+      ).not.toContain('/Users/ben/private');
+      expect(
+        JSON.stringify(vi.mocked(client.updateInstance).mock.calls),
+      ).not.toContain('/Users/ben/private');
+    },
+  );
+
   it.each([
     ['plain text', 'before [FILE: [IMAGE: /tmp/a.png]] after'],
     ['Markdown code', '```\n[FILE: [IMAGE: /tmp/a.png]]\n```'],

--- a/packages/channels/dingtalk/src/status-card-controller.test.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.test.ts
@@ -562,7 +562,7 @@ describe('StatusCardController', () => {
     expect(client.openOrUpdateStream).toHaveBeenCalledTimes(2);
   });
 
-  it('omits delivered file markers from the terminal card', async () => {
+  it('keeps a successful file receipt in the terminal card', async () => {
     const { client, controller } = createHarness();
     controller.replace(
       segment(),
@@ -571,21 +571,22 @@ describe('StatusCardController', () => {
     );
 
     await expect(
-      controller.complete('segment-1', 'before [File: report.txt] after'),
+      controller.complete('segment-1', 'before [File sent: report.txt] after'),
     ).resolves.toBe(true);
 
     expect(client.updateInstance).toHaveBeenLastCalledWith(
       expect.objectContaining({
         cardParamMap: expect.objectContaining({
-          blockList: '[{"type":0,"markdown":"before  after"}]',
-          content: 'before  after',
-          copy_content: 'before  after',
+          blockList:
+            '[{"type":0,"markdown":"before [File sent: report.txt] after"}]',
+          content: 'before [File sent: report.txt] after',
+          copy_content: 'before [File sent: report.txt] after',
         }),
       }),
     );
     expect(
       JSON.stringify(vi.mocked(client.updateInstance).mock.calls.at(-1)?.[0]),
-    ).not.toMatch(/File pending|File:|\/Users\/ben\/private/u);
+    ).not.toMatch(/File pending|\[FILE:|\/Users\/ben\/private/iu);
   });
 
   it('retains streamed content when completion has no response body', async () => {

--- a/packages/channels/dingtalk/src/status-card-controller.test.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.test.ts
@@ -190,6 +190,24 @@ describe('StatusCardController', () => {
     expect(streamContents.at(-1)).toBe('before  after');
   });
 
+  it('sanitizes marker kinds to a combined fixed point', async () => {
+    vi.useFakeTimers();
+    const { client, controller } = createHarness();
+
+    controller.replace(
+      segment(),
+      target,
+      'x [IMAGE[FILE: /decoy]: /Users/ben/private/leak.png] y',
+    );
+    await vi.advanceTimersByTimeAsync(500);
+
+    const content = vi
+      .mocked(client.openOrUpdateStream)
+      .mock.calls.at(-1)?.[0].content;
+    expect(content).not.toContain('/Users/ben/private');
+    expect(content).not.toMatch(/\[IMAGE:/iu);
+  });
+
   it('does not expose a file path when truncation splits its marker', async () => {
     const { client, controller } = createHarness();
     const marker = '[FILE: /Users/ben/private/report.pdf]';

--- a/packages/channels/dingtalk/src/status-card-controller.test.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.test.ts
@@ -190,6 +190,24 @@ describe('StatusCardController', () => {
     expect(streamContents.at(-1)).toBe('before  after');
   });
 
+  it.each([
+    ['plain text', 'before [FILE: [IMAGE: /tmp/a.png]] after'],
+    ['Markdown code', '```\n[FILE: [IMAGE: /tmp/a.png]]\n```'],
+  ])('unwraps nested image wrappers in %s', async (_label, content) => {
+    vi.useFakeTimers();
+    const { client, controller } = createHarness();
+
+    controller.replace(segment(), target, content);
+    await vi.advanceTimersByTimeAsync(500);
+
+    const snapshot = vi
+      .mocked(client.openOrUpdateStream)
+      .mock.calls.at(-1)?.[0].content;
+    expect(snapshot).toContain('[Image pending]');
+    expect(snapshot).not.toContain('[FILE:');
+    expect(snapshot).not.toContain(']]');
+  });
+
   it('sanitizes marker kinds to a combined fixed point', async () => {
     vi.useFakeTimers();
     const { client, controller } = createHarness();

--- a/packages/channels/dingtalk/src/status-card-controller.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.ts
@@ -65,7 +65,14 @@ function boundDisplayContent(content: string): string {
 }
 
 function sanitizeStreamingMediaMarkers(content: string): string {
-  return sanitizeStreamingFileMarkers(sanitizeStreamingImageMarkers(content));
+  let result = content;
+  while (true) {
+    const next = sanitizeStreamingFileMarkers(
+      sanitizeStreamingImageMarkers(result),
+    );
+    if (next === result) return result;
+    result = next;
+  }
 }
 
 export class StatusCardController {

--- a/packages/channels/dingtalk/src/status-card-controller.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.ts
@@ -53,6 +53,10 @@ export interface StatusCardControllerOptions {
 }
 
 function boundContent(content: string): string {
+  return truncateOutboundMediaText(content, CONTENT_LIMIT, TRUNCATION_MARKER);
+}
+
+function boundDisplayContent(content: string): string {
   return truncateOutboundMediaText(
     sanitizeStreamingMediaMarkers(content),
     CONTENT_LIMIT,
@@ -96,7 +100,7 @@ export class StatusCardController {
     if (record.terminal) return;
     record.content = boundContent(content);
     if (record.streamFailed) return;
-    record.pendingSnapshot = sanitizeStreamingMediaMarkers(record.content);
+    record.pendingSnapshot = boundDisplayContent(content);
     this.scheduleFlush(record);
   }
 
@@ -140,6 +144,7 @@ export class StatusCardController {
     initialContent = '',
   ): StatusRecord {
     const outTrackId = `qwen-status-${randomUUID()}`;
+    const initialSnapshot = boundDisplayContent(initialContent);
     const record: StatusRecord = {
       segmentId: segment.segmentId,
       runId: segment.runId,
@@ -165,7 +170,7 @@ export class StatusCardController {
       this.segmentIdsByRun.get(record.runId) ?? new Set<string>();
     segmentIds.add(record.segmentId);
     this.segmentIdsByRun.set(record.runId, segmentIds);
-    record.ready = this.create(record, target);
+    record.ready = this.create(record, target, initialSnapshot);
     void record.ready.then((ready) => {
       if (ready) this.scheduleStatusRefresh(record);
     });
@@ -177,17 +182,11 @@ export class StatusCardController {
     text: string,
     retainedContent?: (content: string) => string,
   ): Promise<boolean> {
-    return this.finalize(
-      segmentId,
-      boundContent(text),
-      'Completed',
-      false,
-      retainedContent,
-    );
+    return this.finalize(segmentId, text, 'Completed', false, retainedContent);
   }
 
   fail(segmentId: string, error: string): void {
-    void this.finalize(segmentId, boundContent(error), 'Failed', true);
+    void this.finalize(segmentId, error, 'Failed', true);
   }
 
   cancelRun(runId: string, reason: ChannelTaskCancellationReason): void {
@@ -241,9 +240,9 @@ export class StatusCardController {
   private async create(
     record: StatusRecord,
     target: { chatId: string; isGroup: boolean },
+    initialContent: string,
   ): Promise<boolean> {
     try {
-      const initialContent = sanitizeStreamingMediaMarkers(record.content);
       await this.options.client.createAndDeliver({
         templateId: STATUS_CARD_TEMPLATE_ID,
         outTrackId: record.outTrackId,
@@ -360,9 +359,7 @@ export class StatusCardController {
       const retained =
         content ||
         (retainedContent ? retainedContent(record.content) : record.content);
-      const finalContent = boundContent(
-        sanitizeStreamingMediaMarkers(retained),
-      );
+      const finalContent = boundDisplayContent(retained);
       await this.options.client.openOrUpdateStream({
         outTrackId: record.outTrackId,
         key: 'content',

--- a/packages/channels/dingtalk/src/status-card-controller.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.ts
@@ -53,7 +53,11 @@ export interface StatusCardControllerOptions {
 }
 
 function boundContent(content: string): string {
-  return truncateOutboundMediaText(content, CONTENT_LIMIT, TRUNCATION_MARKER);
+  return truncateOutboundMediaText(
+    sanitizeStreamingMediaMarkers(content),
+    CONTENT_LIMIT,
+    TRUNCATION_MARKER,
+  );
 }
 
 function sanitizeStreamingMediaMarkers(content: string): string {

--- a/packages/channels/dingtalk/src/status-card-controller.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.ts
@@ -10,7 +10,10 @@ import {
 import type { DingtalkCardCallbackResult } from './interactive-card-types.js';
 import { sanitizeStreamingImageMarkers } from './outbound-image.js';
 import { sanitizeStreamingFileMarkers } from './outbound-file.js';
-import { truncateOutboundMediaText } from './outbound-markers.js';
+import {
+  truncateOutboundMediaText,
+  unwrapFileMarkersAroundImages,
+} from './outbound-markers.js';
 
 const FLUSH_INTERVAL_MS = 500;
 const STATUS_REFRESH_INTERVAL_MS = 1_000;
@@ -68,7 +71,7 @@ function sanitizeStreamingMediaMarkers(content: string): string {
   let result = content;
   while (true) {
     const next = sanitizeStreamingFileMarkers(
-      sanitizeStreamingImageMarkers(result),
+      sanitizeStreamingImageMarkers(unwrapFileMarkersAroundImages(result)),
     );
     if (next === result) return result;
     result = next;

--- a/packages/channels/dingtalk/src/status-card-controller.ts
+++ b/packages/channels/dingtalk/src/status-card-controller.ts
@@ -9,6 +9,8 @@ import {
 } from './interactive-card-client.js';
 import type { DingtalkCardCallbackResult } from './interactive-card-types.js';
 import { sanitizeStreamingImageMarkers } from './outbound-image.js';
+import { sanitizeStreamingFileMarkers } from './outbound-file.js';
+import { truncateOutboundMediaText } from './outbound-markers.js';
 
 const FLUSH_INTERVAL_MS = 500;
 const STATUS_REFRESH_INTERVAL_MS = 1_000;
@@ -51,10 +53,11 @@ export interface StatusCardControllerOptions {
 }
 
 function boundContent(content: string): string {
-  if (content.length <= CONTENT_LIMIT) return content;
-  return `${TRUNCATION_MARKER}${content.slice(
-    content.length - (CONTENT_LIMIT - TRUNCATION_MARKER.length),
-  )}`;
+  return truncateOutboundMediaText(content, CONTENT_LIMIT, TRUNCATION_MARKER);
+}
+
+function sanitizeStreamingMediaMarkers(content: string): string {
+  return sanitizeStreamingFileMarkers(sanitizeStreamingImageMarkers(content));
 }
 
 export class StatusCardController {
@@ -89,7 +92,7 @@ export class StatusCardController {
     if (record.terminal) return;
     record.content = boundContent(content);
     if (record.streamFailed) return;
-    record.pendingSnapshot = sanitizeStreamingImageMarkers(record.content);
+    record.pendingSnapshot = sanitizeStreamingMediaMarkers(record.content);
     this.scheduleFlush(record);
   }
 
@@ -189,7 +192,7 @@ export class StatusCardController {
       if (!record) continue;
       void this.finalize(
         segmentId,
-        sanitizeStreamingImageMarkers(record.content),
+        sanitizeStreamingMediaMarkers(record.content),
         reason === 'cancel_command' ? 'Stopped' : 'Cancelled',
         false,
       );
@@ -236,7 +239,7 @@ export class StatusCardController {
     target: { chatId: string; isGroup: boolean },
   ): Promise<boolean> {
     try {
-      const initialContent = sanitizeStreamingImageMarkers(record.content);
+      const initialContent = sanitizeStreamingMediaMarkers(record.content);
       await this.options.client.createAndDeliver({
         templateId: STATUS_CARD_TEMPLATE_ID,
         outTrackId: record.outTrackId,
@@ -354,7 +357,7 @@ export class StatusCardController {
         content ||
         (retainedContent ? retainedContent(record.content) : record.content);
       const finalContent = boundContent(
-        sanitizeStreamingImageMarkers(retained),
+        sanitizeStreamingMediaMarkers(retained),
       );
       await this.options.client.openOrUpdateStream({
         outTrackId: record.outTrackId,


### PR DESCRIPTION
## What this PR does

This adds native outbound file delivery to the DingTalk channel. When the agent emits an explicit local-file marker in its final response, the channel validates a file under the workspace or system temporary directory, uploads it through DingTalk's media API, and sends a native file attachment for session replies and proactive group or direct messages. It caps each response at five files and each file at 20 MB.

Streaming, terminal cards, cancellation, and text fallbacks now suppress file markers and local paths. File upload and delivery failures produce an explicit failure notice instead of a false success claim. The outbound image path now shares the same local-file validation, media upload, marker parsing, and truncation safety primitives.

## Why it's needed

The DingTalk channel could return text and images but could not deliver generated reports, archives, source files, or other non-image artifacts as downloadable attachments. Users could receive a textual claim that a file had been sent without receiving a native DingTalk file message.

## Reviewer Test Plan

### How to verify

Configure a DingTalk Stream robot with streaming enabled, mention the bot in a group, and ask it to send an existing file from the current workspace rather than pasting its contents. Expect the response card to omit the internal marker and local path, followed by a native DingTalk file card whose download opens the original file. Also verify that an outside-workspace path, oversized file, empty file, or sixth file produces a bounded failure notice without an attachment or path disclosure.

### Evidence (Before & After)

Before: the channel could describe a file but did not deliver a downloadable non-image attachment.

After: a live macOS DingTalk Stream run delivered the workspace `package.json` as a native 9.6 KB file card, and the downloaded file opened successfully. Automated terminal-card coverage verifies that the final content, copy text, and rendered block contain neither `File pending` nor the internal file marker or local path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local source checkout with a DingTalk Stream robot and interactive status cards enabled.

## Risk & Scope

- Main risk or tradeoff: outbound files use DingTalk's upload and robot-message APIs, so delivery depends on the app's permissions and DingTalk's availability; credentials remain scoped to their matching official API boundary.
- Not validated / out of scope: inbound file handling and file-marker prompting in block-streaming mode; CI should provide Windows and Linux coverage.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9166

<details>
<summary>中文说明</summary>

## 此 PR 的作用

此 PR 为钉钉 channel 增加原生的出站文件发送能力。当 Agent 在最终回复中输出明确的本地文件标记时，channel 会校验工作区或系统临时目录内的文件，通过钉钉媒体接口上传，并在会话回复、主动群聊消息或主动私聊消息中发送原生文件附件。每次回复最多发送五个文件，每个文件最大 20 MB。

流式输出、终态卡片、取消流程和文本降级路径现在都会隐藏文件标记和本地路径。文件上传或发送失败时会给出明确的失败提示，不会错误宣称发送成功。出站图片链路现在也复用了相同的本地文件校验、媒体上传、标记解析和安全截断逻辑。

## 为什么需要

钉钉 channel 之前可以返回文本和图片，但无法把生成的报告、压缩包、源文件或其他非图片产物作为可下载附件发送。用户可能看到“文件已发送”的文字，却收不到钉钉原生文件消息。

## Reviewer Test Plan

### 如何验证

配置一个启用流式输出的钉钉 Stream 机器人，在群里 @机器人并要求它发送当前工作区中已经存在的文件，而不是粘贴文件内容。预期回复卡片不展示内部标记和本地路径，随后出现钉钉原生文件卡片，下载后可以打开原文件。还应验证工作区外路径、超大文件、空文件或第六个文件只产生受控的失败提示，不发送附件，也不泄露路径。

### 证据（修改前与修改后）

修改前：channel 可以描述文件，但不会发送可下载的非图片附件。

修改后：在 macOS 上通过真实钉钉 Stream 验证，工作区的 `package.json` 被发送为 9.6 KB 的钉钉原生文件卡片，下载后可以正常打开。终态卡片的自动化测试进一步确认最终正文、复制文本和渲染块均不包含 `File pending`、内部文件标记或本地路径。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地源码检出，配置钉钉 Stream 机器人并启用交互式状态卡片。

## 风险与范围

- 主要风险或权衡：出站文件依赖钉钉上传和机器人消息接口，因此发送结果取决于应用权限和钉钉服务可用性；凭据只会发送到与其匹配的钉钉官方 API 边界。
- 未验证或不在范围内：入站文件处理，以及 block-streaming 模式下的文件标记提示；Windows 和 Linux 覆盖由 CI 验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #9166

</details>
