### PR TITLE
fix(web-shell): keep the legacy session provider mounted during host catch-up

### DIFF
--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -97,7 +97,7 @@ describe('WorkspaceSessionProvider transactional targets', () => {
   });
 
   async function renderTarget(
-    sessionId: string,
+    sessionId: string | undefined,
     workspaceCwd: string,
     onSessionIdChange = vi.fn(),
   ) {
@@ -357,6 +357,74 @@ describe('WorkspaceSessionProvider transactional targets', () => {
     expect(mocks.appProps.at(-1)).toMatchObject({
       initialSelectedWorkspaceCwd: '/work/b',
     });
+  });
+
+  it('does not remount the legacy provider when the host catches up to a created session', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: [],
+        workspaces: [
+          { id: 'a', cwd: '/work/a', primary: true, trusted: true },
+          { id: 'b', cwd: '/work/b', primary: false, trusted: true },
+        ],
+      },
+    };
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    expect(mocks.providerMounts).toBe(1);
+
+    mocks.connection = { status: 'connected', workspaceCwd: '/work/a' };
+    await renderTarget(undefined, '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(2);
+    expect(mocks.providerUnmounts).toBe(1);
+
+    mocks.connection = {
+      status: 'connected',
+      sessionId: 'session-created',
+      workspaceCwd: '/work/b',
+    };
+    await renderTarget(undefined, '/work/b', onSessionIdChange);
+
+    await renderTarget('session-created', '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(2);
+    expect(mocks.providerUnmounts).toBe(1);
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-created',
+      workspaceCwd: '/work/b',
+    });
+
+    await renderTarget('session-b', '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(3);
+    expect(mocks.providerUnmounts).toBe(2);
+  });
+
+  it('does not suppress a legacy remount with a previous provider observation', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: [],
+        workspaces: [
+          { id: 'a', cwd: '/work/a', primary: true, trusted: true },
+          { id: 'b', cwd: '/work/b', primary: false, trusted: true },
+        ],
+      },
+    };
+    const onSessionIdChange = await renderTarget('session-a', '/work/a');
+    expect(mocks.providerMounts).toBe(1);
+
+    mocks.connection = { status: 'connected', workspaceCwd: '/work/a' };
+    await renderTarget(undefined, '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(2);
+    expect(mocks.providerUnmounts).toBe(1);
+
+    // The host pairs the session observed under the previous provider with
+    // the new workspace before the fresh provider reports any connection.
+    // The stale observation must not suppress this remount.
+    await renderTarget('session-a', '/work/b', onSessionIdChange);
+    expect(mocks.providerMounts).toBe(3);
+    expect(mocks.providerUnmounts).toBe(2);
   });
 
   it('does not remount when an unknown daemon resolves as modern', async () => {

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -124,6 +124,13 @@ export function WorkspaceSessionProvider({
     );
   }
   const transactional = transactionalRef.current === true;
+  // Legacy daemons remount DaemonSessionProvider whenever the controlled
+  // target identity changes. These refs suppress that remount when the host
+  // is merely catching up to a session the mounted provider itself created:
+  // remounting mid-admission would detach the session that the in-flight
+  // attach/prompt chain is still adopting and drop the prompt.
+  const observedLegacySessionIdRef = useRef<string | undefined>(undefined);
+  const lastLegacyProviderKeyRef = useRef<string | undefined>(undefined);
   const desiredKey = `${effectiveSessionId ?? ''}\0${effectiveWorkspaceCwd ?? effectiveWorkspaceId ?? ''}`;
   const [, setCommittedTarget] = useState<CommittedSessionTarget>();
   const committedTargetRef = useRef<CommittedSessionTarget | undefined>(
@@ -196,15 +203,15 @@ export function WorkspaceSessionProvider({
   }, [onSessionIdChange, workspace.capabilities?.workspaces]);
   const observeSessionState = useCallback(
     (connection: DaemonConnectionState) => {
-      if (
-        transactional &&
-        connection.status === 'connected' &&
-        connection.sessionId
-      ) {
-        installCommittedTarget({
-          sessionId: connection.sessionId,
-          workspaceCwd: connection.workspaceCwd,
-        });
+      if (connection.status === 'connected' && connection.sessionId) {
+        if (transactional) {
+          installCommittedTarget({
+            sessionId: connection.sessionId,
+            workspaceCwd: connection.workspaceCwd,
+          });
+        } else {
+          observedLegacySessionIdRef.current = connection.sessionId;
+        }
       }
       const transition = connection.sessionTransition;
       if (
@@ -266,6 +273,21 @@ export function WorkspaceSessionProvider({
     (registeredLockedWorkspace?.cwd === visibleWorkspaceCwd
       ? registeredLockedWorkspace
       : undefined);
+
+  const legacyProviderKeyCandidate = `${targetWorkspace?.id ?? effectiveWorkspaceId ?? 'primary'}:${effectiveSessionId ?? 'new'}`;
+  const suppressLegacyCatchUpRemount =
+    transactionalRef.current === false &&
+    effectiveSessionId !== undefined &&
+    observedLegacySessionIdRef.current === effectiveSessionId;
+  const legacyProviderKey = suppressLegacyCatchUpRemount
+    ? (lastLegacyProviderKeyRef.current ?? legacyProviderKeyCandidate)
+    : legacyProviderKeyCandidate;
+  if (legacyProviderKey !== lastLegacyProviderKeyRef.current) {
+    // A real target switch: the mounted provider is left behind, so its
+    // observed session no longer describes the next provider instance.
+    observedLegacySessionIdRef.current = undefined;
+    lastLegacyProviderKeyRef.current = legacyProviderKey;
+  }
 
   useEffect(() => {
     if (!lockWorkspaceCwd || !workspace.capabilities || pathWorkspace) return;
@@ -413,7 +435,7 @@ export function WorkspaceSessionProvider({
       key={
         transactionalRef.current !== false
           ? 'transactional-main-session'
-          : `${targetWorkspace?.id ?? effectiveWorkspaceId ?? 'primary'}:${effectiveSessionId ?? 'new'}`
+          : legacyProviderKey
       }
       sessionId={providerSessionId}
       workspaceCwd={providerWorkspaceCwd}

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -8,7 +8,6 @@ import {
   type DaemonChannelTypeCatalog,
   type DaemonEvent,
   type DaemonRestoredSession,
-  type DaemonSession,
   type DaemonSessionArtifact,
   type DaemonSessionArtifactsEnvelope,
   type DaemonSessionGroup,
@@ -87,6 +86,17 @@ export interface WebShellDaemonScenario {
   gitLog?: unknown;
   /** Response for `POST /session/:id/btw`. */
   btwAnswer?: string;
+  /**
+   * Session ids whose load/resume envelope reports `hasActivePrompt: true`,
+   * modeling a session with a prompt still in flight (no `turn_complete`).
+   */
+  busySessionIds: readonly string[];
+  /**
+   * Sessions created through `POST /session` during the test, mapped to the
+   * workspace cwd they were created in. Runtime state maintained by the mock
+   * so later load/resume calls resolve the owning workspace correctly.
+   */
+  createdSessions: Record<string, string>;
 }
 
 export interface MockDaemonController {
@@ -94,6 +104,12 @@ export interface MockDaemonController {
   sse: SseTransport<DaemonEvent>;
   requests: readonly DaemonRequestRecord[];
   sendEvent(event: DaemonEvent): Promise<void>;
+  /**
+   * Deliver an event only to SSE streams connected for `sessionId`,
+   * mirroring the real daemon's per-session event scoping. No-op when the
+   * client holds no stream for that session (e.g. after detach).
+   */
+  sendEventTo(sessionId: string, event: DaemonEvent): Promise<void>;
   burstEvents(events: readonly DaemonEvent[]): Promise<void>;
   promptRequests(): DaemonRequestRecord[];
   permissionRequests(): DaemonRequestRecord[];
@@ -120,6 +136,7 @@ type ScenarioOverrides = Partial<
     | 'sessions'
     | 'sessionGroups'
     | 'state'
+    | 'createdSessions'
   >
 > & {
   capabilities?: Partial<DaemonCapabilities>;
@@ -363,13 +380,23 @@ export function createWebShellDaemonScenario(
     gitDiff: overrides.gitDiff,
     gitLog: overrides.gitLog,
     btwAnswer: overrides.btwAnswer,
+    busySessionIds: overrides.busySessionIds ?? [],
+    createdSessions: {},
   };
 }
 
 export async function installMockDaemon(
   page: Page,
   scenario: WebShellDaemonScenario,
-  options: { baseURL?: string } = {},
+  options: {
+    baseURL?: string;
+    /**
+     * Optional per-route server latency in milliseconds, applied after the
+     * request is recorded and before the response is fulfilled — modeling a
+     * slow daemon so race windows (create/load/detach) widen deterministically.
+     */
+    routeDelay?: (method: string, path: string) => number;
+  } = {},
 ): Promise<MockDaemonController> {
   const baseURL = options.baseURL ?? getPlaywrightBaseURL();
   const baseOrigin = new URL(baseURL).origin;
@@ -405,6 +432,11 @@ export async function installMockDaemon(
       return;
     }
 
+    const delayMs = options.routeDelay?.(method, path) ?? 0;
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
     await handleDaemonRoute(
       route,
       method,
@@ -420,6 +452,7 @@ export async function installMockDaemon(
     sse,
     requests,
     sendEvent: (event) => sse.send(event),
+    sendEventTo: (sessionId, event) => sse.sendTo(sessionId, event),
     burstEvents: (events) => sse.burst(events),
     promptRequests: () =>
       requests.filter((request) =>
@@ -883,8 +916,13 @@ async function handleDaemonRoute(
     (/^\/workspace\/.+\/sessions\/?$/.test(path) ||
       /^\/workspaces\/[^/]+\/sessions\/?$/.test(path))
   ) {
+    // The daemon scopes the catalog to the workspace in the path; mirror that
+    // so multi-workspace scenarios render the right sessions per section.
+    const requestedCwd = decodeURIComponent(path.split('/')[2] ?? '');
     await json(route, {
-      sessions: filterScenarioSessions(scenario, searchParams),
+      sessions: filterScenarioSessions(scenario, searchParams).filter(
+        (session) => session.workspaceCwd === requestedCwd,
+      ),
     });
     return;
   }
@@ -1261,7 +1299,25 @@ async function handleDaemonRoute(
     return;
   }
   if (method === 'POST' && path === '/session') {
-    await json(route, sessionEnvelope(scenario, { attached: false }));
+    // Honor the requested workspace (wire field `cwd`) and allocate a fresh
+    // session id so tests can tell created sessions apart from the seeded one.
+    const requestedCwd = readStringField(body, 'cwd');
+    const workspaceCwd = requestedCwd ?? scenario.workspaceCwd;
+    const sessionId = `created-session-${
+      Object.keys(scenario.createdSessions).length + 1
+    }`;
+    scenario.createdSessions = {
+      ...scenario.createdSessions,
+      [sessionId]: workspaceCwd,
+    };
+    await json(route, {
+      sessionId,
+      workspaceCwd,
+      attached: false,
+      clientId: scenario.clientId,
+      createdAt: now,
+      hasActivePrompt: false,
+    });
     return;
   }
 
@@ -1412,31 +1468,17 @@ async function handleDaemonRoute(
   );
 }
 
-function sessionEnvelope(
-  scenario: WebShellDaemonScenario,
-  options: { attached: boolean },
-): DaemonSession {
-  return {
-    sessionId: scenario.sessionId,
-    workspaceCwd: scenario.workspaceCwd,
-    attached: options.attached,
-    clientId: scenario.clientId,
-    createdAt: now,
-    hasActivePrompt: false,
-  };
-}
-
 function restoredSessionEnvelope(
   scenario: WebShellDaemonScenario,
   sessionId: string,
 ): DaemonRestoredSession {
   return {
     sessionId,
-    workspaceCwd: scenario.workspaceCwd,
+    workspaceCwd: scenario.createdSessions[sessionId] ?? scenario.workspaceCwd,
     attached: true,
     clientId: scenario.clientId,
     createdAt: now,
-    hasActivePrompt: false,
+    hasActivePrompt: scenario.busySessionIds.includes(sessionId),
     state: scenario.state,
     compactedReplay: scenario.events,
     liveJournal: [],

--- a/packages/web-shell/client/e2e/utils/sseTransport.ts
+++ b/packages/web-shell/client/e2e/utils/sseTransport.ts
@@ -14,6 +14,12 @@ export interface SseTransport<TEvent> {
   ): Promise<SseConnectionRecord>;
   connections(): Promise<SseConnectionRecord[]>;
   send(event: TEvent): Promise<void>;
+  /**
+   * Deliver an event only to streams connected for `sessionId`, mirroring the
+   * real daemon's per-session event scoping (a session's stream never carries
+   * another session's events). No-op when no stream for that session is open.
+   */
+  sendTo(sessionId: string, event: TEvent): Promise<void>;
   burst(events: readonly TEvent[]): Promise<void>;
   split(event: TEvent, chunkSizes?: readonly number[]): Promise<void>;
   close(): Promise<void>;
@@ -23,6 +29,7 @@ export interface SseTransport<TEvent> {
 interface BrowserSseHarness {
   connections: SseConnectionRecord[];
   writeFrame: (frame: string) => void;
+  writeFrameTo: (sessionId: string, frame: string) => void;
   writeSplitFrame: (frame: string, chunkSizes: readonly number[]) => void;
   close: () => void;
   error: (message: string) => void;
@@ -43,6 +50,10 @@ export async function installSseTransport<TEvent>(
     const originalFetch = window.fetch.bind(window);
     const encoder = new TextEncoder();
     const controllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    const recordByController = new Map<
+      ReadableStreamDefaultController<Uint8Array>,
+      SseConnectionRecord
+    >();
     const connections: SseConnectionRecord[] = [];
 
     function removeController(
@@ -52,6 +63,7 @@ export async function installSseTransport<TEvent>(
       if (index >= 0) {
         controllers.splice(index, 1);
       }
+      recordByController.delete(target);
     }
 
     function removeConnection(target: SseConnectionRecord) {
@@ -68,6 +80,7 @@ export async function installSseTransport<TEvent>(
           const _desiredSize = controller.desiredSize;
           active.push(controller);
         } catch {
+          recordByController.delete(controller);
           continue;
         }
       }
@@ -83,12 +96,22 @@ export async function installSseTransport<TEvent>(
       }
     }
 
+    function writeBytesTo(sessionId: string, bytes: Uint8Array) {
+      for (const controller of activeControllers()) {
+        const record = recordByController.get(controller);
+        if (record && record.sessionId === sessionId) {
+          controller.enqueue(bytes);
+        }
+      }
+    }
+
     function finishActiveStreams(
       finish: (controller: ReadableStreamDefaultController<Uint8Array>) => void,
     ) {
       const active = activeControllers();
       controllers.length = 0;
       connections.length = 0;
+      recordByController.clear();
       for (const controller of active) {
         finish(controller);
       }
@@ -98,6 +121,9 @@ export async function installSseTransport<TEvent>(
       connections,
       writeFrame(frame: string) {
         writeBytes(encoder.encode(frame));
+      },
+      writeFrameTo(sessionId: string, frame: string) {
+        writeBytesTo(sessionId, encoder.encode(frame));
       },
       writeSplitFrame(frame: string, chunkSizes: readonly number[]) {
         const bytes = encoder.encode(frame);
@@ -143,6 +169,7 @@ export async function installSseTransport<TEvent>(
             headers: Object.fromEntries(request.headers.entries()),
             connectedAt: Date.now(),
           };
+          recordByController.set(controller, connectionRecord);
           connections.push(connectionRecord);
         },
         cancel() {
@@ -199,6 +226,14 @@ export async function installSseTransport<TEvent>(
       return page.evaluate((frame) => {
         window.__webShellSseHarness?.writeFrame(frame);
       }, frameFor(event));
+    },
+    sendTo(sessionId, event) {
+      return page.evaluate(
+        ({ target, frame }) => {
+          window.__webShellSseHarness?.writeFrameTo(target, frame);
+        },
+        { target: sessionId, frame: frameFor(event) },
+      );
     },
     async burst(events) {
       for (const event of events) {

--- a/packages/web-shell/client/e2e/web-shell.multi-workspace-new-session.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.multi-workspace-new-session.spec.ts
@@ -1,0 +1,833 @@
+/**
+ * Reproduction for a user-reported bug on multi-workspace daemons:
+ *
+ * With workspace A running a session that has an active prompt ("running
+ * task"), clicking the "New task" button on workspace B's sidebar section
+ * should make the next lazily-created session belong to workspace B. The
+ * report says the FIRST click lands in workspace A instead (or on session A
+ * itself), while a SECOND click produces the correct workspace-B session.
+ *
+ * The daemon session is created lazily on first prompt (`POST /session` with
+ * a `cwd` field), so the test drives the real UI flow — sidebar click,
+ * composer input, submit — and asserts which workspace the recorded
+ * `POST /session` request targeted (or whether the prompt was admitted to
+ * the still-running session A instead of creating a new session).
+ *
+ * Both provider modes are exercised: legacy daemons (no `client_identity`
+ * feature) and transactional daemons (`client_identity` advertised), because
+ * `WorkspaceSessionProvider` keys `DaemonSessionProvider` differently in each.
+ */
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import {
+  assistantTextEvent,
+  createWebShellDaemonScenario,
+  installMockDaemon,
+  replayCompleteEvent,
+  turnCompleteEvent,
+  userTextEvent,
+  type DaemonRequestRecord,
+  type MockDaemonController,
+  type WebShellDaemonScenario,
+} from './utils/mockDaemon';
+
+const WS_A = '/tmp/ws-a';
+const WS_B = '/tmp/ws-b';
+const SESSION_A = 'session-a-busy';
+const SESSION_B = 'session-b-idle';
+
+const SUBMIT_BUTTON = '[data-web-shell-composer-submit]';
+const SEND_LABEL = 'Send message';
+const CANCEL_LABEL = 'esc to cancel';
+const NEW_TASK_LABEL = 'New task';
+
+type DaemonMode = 'legacy' | 'transactional';
+
+function buildTwoWorkspaceScenario(
+  mode: DaemonMode,
+  options: { sessionABusy: boolean },
+): WebShellDaemonScenario {
+  return createWebShellDaemonScenario({
+    workspaceCwd: WS_A,
+    sessionId: SESSION_A,
+    displayName: 'Task in workspace A',
+    capabilities: {
+      workspaceCwd: WS_A,
+      features: [
+        'session_events',
+        'permission_vote',
+        'session_permission_vote',
+        'session_scope_override',
+        'session_source_metadata',
+        'workspace_settings',
+        'workspace_voice',
+        ...(mode === 'transactional' ? ['client_identity'] : []),
+      ],
+      workspaces: [
+        { id: 'ws-a', cwd: WS_A, primary: true, trusted: true },
+        { id: 'ws-b', cwd: WS_B, primary: false, trusted: true },
+      ],
+    },
+    sessions: [
+      {
+        sessionId: SESSION_A,
+        workspaceCwd: WS_A,
+        createdAt: '2026-08-14T00:00:00.000Z',
+        updatedAt: '2026-08-14T00:05:00.000Z',
+        displayName: 'Task in workspace A',
+        clientCount: 1,
+        hasActivePrompt: options.sessionABusy,
+      },
+      {
+        sessionId: SESSION_B,
+        workspaceCwd: WS_B,
+        createdAt: '2026-08-13T00:00:00.000Z',
+        updatedAt: '2026-08-13T00:10:00.000Z',
+        displayName: 'Idle task in workspace B',
+        clientCount: 0,
+        hasActivePrompt: false,
+      },
+    ],
+    // Replayed turn of workspace A's task. When A is busy there is
+    // deliberately no `turn_complete` — the prompt stays in flight.
+    events: options.sessionABusy
+      ? [
+          userTextEvent('Long-running task in workspace A', {
+            id: 1,
+            sessionId: SESSION_A,
+          }),
+          assistantTextEvent('Still working on it...', {
+            id: 2,
+            sessionId: SESSION_A,
+          }),
+        ]
+      : [
+          userTextEvent('Finished task in workspace A', {
+            id: 1,
+            sessionId: SESSION_A,
+          }),
+          assistantTextEvent('Done with it.', {
+            id: 2,
+            sessionId: SESSION_A,
+          }),
+          turnCompleteEvent('prompt-a-done', { id: 3, sessionId: SESSION_A }),
+        ],
+    busySessionIds: options.sessionABusy ? [SESSION_A] : [],
+  });
+}
+
+async function installScenario(
+  page: Page,
+  scenario: WebShellDaemonScenario,
+  testInfo: TestInfo,
+  routeDelay?: (method: string, path: string) => number,
+): Promise<MockDaemonController> {
+  return installMockDaemon(page, scenario, {
+    baseURL: String(testInfo.project.use.baseURL),
+    routeDelay,
+  });
+}
+
+async function loadSessionA(
+  page: Page,
+  scenario: WebShellDaemonScenario,
+  daemon: MockDaemonController,
+  sessionABusy: boolean,
+): Promise<void> {
+  await page.goto(`/session/${encodeURIComponent(SESSION_A)}`);
+  await expect(page.locator('[data-web-shell-root]')).toBeVisible();
+  await daemon.sse.waitForConnection(SESSION_A);
+  // Keep completing the replay until the loading indicator clears: dev-mode
+  // StrictMode remounts can resubscribe the event stream after a single
+  // broadcast landed, dropping the one-shot `replay_complete`.
+  const loading = page.getByText('Loading...');
+  const deadline = Date.now() + 15_000;
+  for (;;) {
+    await daemon.sendEvent(
+      replayCompleteEvent({
+        sessionId: SESSION_A,
+        replayedCount: scenario.events.length,
+      }),
+    );
+    try {
+      await expect(loading).toHaveCount(0, { timeout: 1_000 });
+      break;
+    } catch {
+      if (Date.now() > deadline) {
+        throw new Error('Session A loading indicator never cleared');
+      }
+    }
+  }
+  // Sanity: an in-flight prompt of session A is visible as the running
+  // (cancel) state of the composer; an idle session shows the send state.
+  await expect(page.locator(SUBMIT_BUTTON)).toHaveAttribute(
+    'aria-label',
+    sessionABusy ? CANCEL_LABEL : SEND_LABEL,
+  );
+}
+
+async function clickWorkspaceNewTask(page: Page, label: string): Promise<void> {
+  const header = page.getByRole('button', { name: label, exact: true });
+  await expect(header).toBeVisible();
+  const headerRow = header.locator('xpath=..');
+  // The header actions render visibility:hidden until the row is hovered.
+  await headerRow.hover();
+  await headerRow.getByRole('button', { name: NEW_TASK_LABEL }).click();
+}
+
+async function waitForSessionDetach(
+  daemon: MockDaemonController,
+  sessionId: string,
+): Promise<void> {
+  await expect
+    .poll(() =>
+      daemon.requests.some(
+        (request) =>
+          request.method === 'POST' &&
+          request.path === `/session/${sessionId}/detach`,
+      ),
+    )
+    .toBe(true);
+}
+
+async function fillComposer(page: Page, text: string): Promise<void> {
+  const editor = page.locator('[data-web-shell-composer-editor] .cm-content');
+  await editor.click();
+  await page.keyboard.press(
+    process.platform === 'darwin' ? 'Meta+A' : 'Control+A',
+  );
+  await page.keyboard.type(text);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Set QC_E2E_TRACE=1 to print intermediate observations on stdout. */
+const TRACE = process.env['QC_E2E_TRACE'] === '1';
+
+function trace(label: string, data: Record<string, unknown>): void {
+  if (TRACE) {
+    console.log(`[trace] ${label}: ${JSON.stringify(data)}`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isCreateRequest(request: DaemonRequestRecord): boolean {
+  return request.method === 'POST' && request.path === '/session';
+}
+
+function isPromptRequest(request: DaemonRequestRecord): boolean {
+  return (
+    request.method === 'POST' &&
+    /^\/session\/[^/]+\/prompt\/?$/.test(request.path)
+  );
+}
+
+function promptSessionId(request: DaemonRequestRecord): string {
+  return decodeURIComponent(request.path.split('/')[2] ?? '');
+}
+
+function extractPromptText(body: unknown): string | undefined {
+  if (!isRecord(body)) return undefined;
+  const prompt = body['prompt'];
+  if (!Array.isArray(prompt)) return undefined;
+  const block = prompt.find(
+    (item) => isRecord(item) && item['type'] === 'text',
+  );
+  return isRecord(block) ? String(block['text']) : undefined;
+}
+
+/** The composer's workspace chip reflects `selectedWorkspaceCwd` state. */
+async function composerWorkspaceChip(page: Page): Promise<string | null> {
+  const chip = page.locator(
+    '[data-toolbar-measure="workspaceSelect:collapsed"]',
+  );
+  if ((await chip.count()) === 0) return null;
+  return chip.textContent();
+}
+
+/** The header banner shows the display name of the session the UI believes is active. */
+async function headerTitle(page: Page): Promise<string | null> {
+  const banner = page.locator('header > div').first();
+  if ((await banner.count()) === 0) return null;
+  return banner.textContent();
+}
+
+interface AdmissionOutcome {
+  /** Number of `POST /session` requests in the round. */
+  creates: number;
+  /** The `cwd` field of each create body, in order. */
+  createdCwds: Array<string | undefined>;
+  /** Every `POST /session/:id/prompt` in the round. */
+  prompts: Array<{ sessionId: string; text: string | undefined }>;
+  /** Composer workspace chip sampled just before the submit click. */
+  chipLabel: string | null;
+  /** SSE streams open just before the submit click (session ids). */
+  streamsBeforeSubmit: string[];
+  /** Header session title sampled after the round settled. */
+  headerLabel: string | null;
+  summary: string;
+}
+
+function summarizeRequests(requests: readonly DaemonRequestRecord[]): string {
+  const lines = requests.map((request) => {
+    let detail = '';
+    if (isCreateRequest(request) && isRecord(request.body)) {
+      detail = ` cwd=${JSON.stringify(request.body['cwd'])}`;
+    } else if (isPromptRequest(request)) {
+      detail = ` text=${JSON.stringify(extractPromptText(request.body))}`;
+    }
+    return `  ${request.method} ${request.path}${detail}`;
+  });
+  return `\n--- daemon requests this round ---\n${lines.join('\n')}\n---`;
+}
+
+/**
+ * Drives the lazy create -> attach -> prompt chain until the prompt is
+ * admitted (a `POST /session/:id/prompt` lands) or the deadline passes.
+ * Completes the (empty) replay of the created session whenever a new SSE
+ * connection for it appears — a real daemon finishes that replay instantly,
+ * but the mock waits for an explicit `replay_complete`. The event is scoped
+ * to the created session's own stream, matching the daemon's per-session
+ * delivery (another session's stream never carries it).
+ */
+async function waitForPromptAdmission(
+  daemon: MockDaemonController,
+  scenario: WebShellDaemonScenario,
+  fromIndex: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  const replayedConnections = new Set<string>();
+  const promptAdmitted = () =>
+    daemon.requests.slice(fromIndex).some(isPromptRequest);
+  while (Date.now() < deadline) {
+    if (promptAdmitted()) return true;
+    const createdIds = Object.keys(scenario.createdSessions);
+    const latestCreatedId = createdIds[createdIds.length - 1];
+    if (latestCreatedId) {
+      const connections = await daemon.sse.connections();
+      for (const connection of connections) {
+        if (connection.sessionId !== latestCreatedId) continue;
+        const key = `${connection.connectedAt}:${connection.url}`;
+        if (replayedConnections.has(key)) continue;
+        replayedConnections.add(key);
+        await daemon.sendEventTo(
+          latestCreatedId,
+          replayCompleteEvent({
+            sessionId: latestCreatedId,
+            replayedCount: 0,
+          }),
+        );
+      }
+    }
+    await sleep(200);
+  }
+  return promptAdmitted();
+}
+
+async function openStreamIds(daemon: MockDaemonController): Promise<string[]> {
+  return (await daemon.sse.connections()).map(
+    (connection) => connection.sessionId,
+  );
+}
+
+function admissionOutcome(
+  daemon: MockDaemonController,
+  fromIndex: number,
+  chipLabel: string | null,
+  streamsBeforeSubmit: string[],
+  headerLabel: string | null,
+): AdmissionOutcome {
+  const requests = daemon.requests.slice(fromIndex);
+  const createRequests = requests.filter(isCreateRequest);
+  const prompts = requests.filter(isPromptRequest).map((request) => ({
+    sessionId: promptSessionId(request),
+    text: extractPromptText(request.body),
+  }));
+  return {
+    creates: createRequests.length,
+    createdCwds: createRequests.map((request) =>
+      isRecord(request.body)
+        ? (request.body['cwd'] as string | undefined)
+        : undefined,
+    ),
+    prompts,
+    chipLabel,
+    streamsBeforeSubmit,
+    headerLabel,
+    summary:
+      `composer workspace chip before submit: ${JSON.stringify(chipLabel)}; ` +
+      `open SSE streams before submit: ${JSON.stringify(streamsBeforeSubmit)}; ` +
+      `header session after round: ${JSON.stringify(headerLabel)}` +
+      summarizeRequests(requests),
+  };
+}
+
+type TurnCompleteTiming = 'never' | 'after-click' | 'during-admission';
+
+/**
+ * Round-2 realism axes for the transactional scenario. Round 1 ran with zero
+ * traffic from session A after its replay; a real running task keeps emitting
+ * SSE events while the user clicks New task, types, and submits.
+ */
+interface TrafficOptions {
+  /** When session A's in-flight turn completes relative to the flow. */
+  turnComplete: TurnCompleteTiming;
+  /**
+   * Slow the mock daemon's POST /session (400ms), .../load (300ms) and
+   * .../detach (250ms) routes to widen admission race windows.
+   */
+  slowDaemon?: boolean;
+}
+
+/** Assistant text delta cadence for session A (ms). */
+const TRICKLE_INTERVAL_MS = 150;
+
+interface TrickleHandle {
+  stop(): void;
+}
+
+/**
+ * Emits a steady trickle of assistant text deltas for `sessionId` on that
+ * session's own SSE stream, modeling a running task. The daemon scopes
+ * events per session stream, so delivery is targeted via `sendEventTo`.
+ */
+function startTrickle(
+  daemon: MockDaemonController,
+  sessionId: string,
+  intervalMs: number,
+): TrickleHandle {
+  let counter = 0;
+  const timer = setInterval(() => {
+    counter += 1;
+    void daemon.sendEventTo(
+      sessionId,
+      assistantTextEvent(` still working ${counter}...`, {
+        id: 100 + counter,
+        sessionId,
+      }),
+    );
+  }, intervalMs);
+  return {
+    stop() {
+      clearInterval(timer);
+    },
+  };
+}
+
+function slowDaemonDelay(method: string, path: string): number {
+  if (method !== 'POST') return 0;
+  if (path === '/session') return 400;
+  if (/^\/session\/[^/]+\/load\/?$/.test(path)) return 300;
+  if (/^\/session\/[^/]+\/detach\/?$/.test(path)) return 250;
+  return 0;
+}
+
+/**
+ * The two-round contract under test, shared by every scenario runner: click
+ * workspace B's New-task button while session A is the connected session,
+ * submit a prompt, then do it again. Both rounds assert the same outcome —
+ * one fresh session created in workspace B, and the prompt admitted to it.
+ */
+async function runWorkspaceBRounds(
+  page: Page,
+  daemon: MockDaemonController,
+  scenario: WebShellDaemonScenario,
+  traffic: TrafficOptions | undefined,
+  finishSessionA: () => Promise<void>,
+): Promise<void> {
+  // ---- Round 1: first click on workspace B's "New task" button.
+  await clickWorkspaceNewTask(page, 'ws-b');
+  if (traffic?.turnComplete === 'after-click') {
+    // The task finishes while the user is about to type.
+    await finishSessionA();
+  }
+  // Wait for the clear of session A to land (detach ack) and the composer
+  // to return to its idle send state before typing, like a user.
+  await waitForSessionDetach(daemon, SESSION_A);
+  await expect(page.locator(SUBMIT_BUTTON)).toHaveAttribute(
+    'aria-label',
+    SEND_LABEL,
+  );
+
+  const round1Start = daemon.requests.length;
+  const round1Chip = await composerWorkspaceChip(page);
+  const round1Streams = await openStreamIds(daemon);
+  trace('round1 after-click', {
+    chip: round1Chip,
+    streams: round1Streams,
+    header: await headerTitle(page),
+  });
+  await fillComposer(page, 'First prompt after clicking workspace B');
+  await page.locator(SUBMIT_BUTTON).click();
+  if (traffic?.turnComplete === 'during-admission') {
+    // The task finishes while the new session's admission chain runs.
+    await expect
+      .poll(() => daemon.requests.some(isCreateRequest), {
+        timeout: 15_000,
+      })
+      .toBe(true);
+    await finishSessionA();
+  }
+
+  // Let the admission chain settle: the create request lands before attach
+  // finishes, so wait (bounded) for the prompt itself.
+  const round1Admitted = await waitForPromptAdmission(
+    daemon,
+    scenario,
+    round1Start,
+    15_000,
+  );
+  const round1 = admissionOutcome(
+    daemon,
+    round1Start,
+    round1Chip,
+    round1Streams,
+    await headerTitle(page),
+  );
+  trace('round1 outcome', {
+    admitted: round1Admitted,
+    createdCwds: round1.createdCwds,
+    prompts: round1.prompts,
+    header: round1.headerLabel,
+    streams: await openStreamIds(daemon),
+  });
+
+  // Expected behavior: one fresh session, created in workspace B, and the
+  // prompt admitted to it. Bug variants: the prompt is admitted to session
+  // A instead of a create (S2), the create targets workspace A / omits cwd
+  // (S1), or the prompt is dropped entirely. Soft assertions so both
+  // rounds run and the full picture lands in the failure output.
+  expect
+    .soft(
+      round1.prompts.filter((prompt) => prompt.sessionId === SESSION_A),
+      `round 1: the prompt must not be admitted to session A\n${round1.summary}`,
+    )
+    .toHaveLength(0);
+  expect
+    .soft(
+      round1.creates,
+      `round 1: the submission must create a new session\n${round1.summary}`,
+    )
+    .toBe(1);
+  expect
+    .soft(
+      round1.createdCwds,
+      `round 1: the created session must belong to workspace B (${WS_B})\n${round1.summary}`,
+    )
+    .toEqual([WS_B]);
+  expect
+    .soft(
+      round1Admitted,
+      `round 1: the submitted prompt must be admitted after session creation\n${round1.summary}`,
+    )
+    .toBe(true);
+
+  // ---- Settle before round two. When the prompt was admitted, finish its
+  // turn; when it was dropped, just wait for the composer to come back to
+  // an idle send state.
+  const createdSessionId = round1.prompts[0]?.sessionId;
+  if (round1Admitted && createdSessionId) {
+    await daemon.sendEventTo(
+      createdSessionId,
+      turnCompleteEvent('prompt-e2e', {
+        id: 11,
+        sessionId: createdSessionId,
+      }),
+    );
+  }
+  await expect(page.locator(SUBMIT_BUTTON)).toHaveAttribute(
+    'aria-label',
+    SEND_LABEL,
+  );
+
+  // ---- Round 2: second click on workspace B's "New task" button.
+  await clickWorkspaceNewTask(page, 'ws-b');
+  if (createdSessionId) {
+    await waitForSessionDetach(daemon, createdSessionId);
+  }
+  await expect(page.locator(SUBMIT_BUTTON)).toHaveAttribute(
+    'aria-label',
+    SEND_LABEL,
+  );
+
+  const round2Start = daemon.requests.length;
+  const round2Chip = await composerWorkspaceChip(page);
+  const round2Streams = await openStreamIds(daemon);
+  await fillComposer(page, 'Second prompt after clicking workspace B again');
+  await page.locator(SUBMIT_BUTTON).click();
+
+  const round2Admitted = await waitForPromptAdmission(
+    daemon,
+    scenario,
+    round2Start,
+    15_000,
+  );
+  const round2 = admissionOutcome(
+    daemon,
+    round2Start,
+    round2Chip,
+    round2Streams,
+    await headerTitle(page),
+  );
+
+  expect
+    .soft(
+      round2.prompts.filter(
+        (prompt) =>
+          prompt.sessionId === SESSION_A ||
+          prompt.sessionId === createdSessionId,
+      ),
+      `round 2: the prompt must not reuse an existing session\n${round2.summary}`,
+    )
+    .toHaveLength(0);
+  expect
+    .soft(
+      round2.creates,
+      `round 2: the submission must create a new session\n${round2.summary}`,
+    )
+    .toBe(1);
+  expect
+    .soft(
+      round2.createdCwds,
+      `round 2: the created session must belong to workspace B (${WS_B})\n${round2.summary}`,
+    )
+    .toEqual([WS_B]);
+  expect
+    .soft(
+      round2Admitted,
+      `round 2: the submitted prompt must be admitted\n${round2.summary}`,
+    )
+    .toBe(true);
+}
+
+async function runNewSessionScenario(
+  page: Page,
+  testInfo: TestInfo,
+  mode: DaemonMode,
+  sessionABusy: boolean,
+  traffic?: TrafficOptions,
+): Promise<void> {
+  const scenario = buildTwoWorkspaceScenario(mode, { sessionABusy });
+  const daemon = await installScenario(
+    page,
+    scenario,
+    testInfo,
+    traffic?.slowDaemon ? slowDaemonDelay : undefined,
+  );
+
+  await loadSessionA(page, scenario, daemon, sessionABusy);
+  // Session A's replay is consumed; lazily created sessions load empty.
+  scenario.events = [];
+
+  // The running task keeps streaming while the user clicks, types, submits.
+  let trickle: TrickleHandle | undefined;
+  if (traffic && sessionABusy) {
+    trickle = startTrickle(daemon, SESSION_A, TRICKLE_INTERVAL_MS);
+  }
+  const finishSessionA = async () => {
+    trickle?.stop();
+    trickle = undefined;
+    await daemon.sendEventTo(
+      SESSION_A,
+      turnCompleteEvent('prompt-a-done', { id: 200, sessionId: SESSION_A }),
+    );
+  };
+
+  try {
+    await runWorkspaceBRounds(page, daemon, scenario, traffic, finishSessionA);
+  } finally {
+    trickle?.stop();
+  }
+}
+
+for (const mode of ['legacy', 'transactional'] as const) {
+  test(`new task on workspace B targets B while session A has a running task (${mode} daemon)`, async ({
+    page,
+  }, testInfo) => {
+    await runNewSessionScenario(page, testInfo, mode, true);
+  });
+}
+
+// Control: does the outcome depend on session A being busy (suspect S3)?
+test('new task on workspace B targets B while session A is idle (legacy daemon control)', async ({
+  page,
+}, testInfo) => {
+  await runNewSessionScenario(page, testInfo, 'legacy', false);
+});
+
+/**
+ * Marks session A's busy state in the catalog the sidebar reads, so the
+ * section renders the way it does while a task is genuinely in flight.
+ */
+function setSessionABusy(
+  scenario: WebShellDaemonScenario,
+  busy: boolean,
+): void {
+  scenario.sessions = scenario.sessions.map((session) =>
+    session.sessionId === SESSION_A
+      ? { ...session, hasActivePrompt: busy }
+      : session,
+  );
+}
+
+/**
+ * Same flow as `runNewSessionScenario`, but session A's running task is a
+ * prompt submitted FROM THIS TAB (a locally active prompt waiting on its
+ * turn), rather than a busy state restored from the load envelope. This is
+ * the most common real-world shape of "session A has a running task": the
+ * composer sat in cancel state because the user's own prompt is in flight
+ * and SSE deltas keep arriving for it.
+ */
+async function runLocalPromptScenario(
+  page: Page,
+  testInfo: TestInfo,
+  traffic: TrafficOptions,
+): Promise<void> {
+  const scenario = buildTwoWorkspaceScenario('transactional', {
+    sessionABusy: false,
+  });
+  const daemon = await installScenario(
+    page,
+    scenario,
+    testInfo,
+    traffic.slowDaemon ? slowDaemonDelay : undefined,
+  );
+
+  await loadSessionA(page, scenario, daemon, false);
+  // Session A's replay is consumed; lazily created sessions load empty.
+  scenario.events = [];
+
+  // ---- Start a real running task in session A from this tab.
+  await fillComposer(page, 'Long-running task in workspace A');
+  await page.locator(SUBMIT_BUTTON).click();
+  await expect
+    .poll(
+      () =>
+        daemon.requests.some(
+          (request) =>
+            isPromptRequest(request) && promptSessionId(request) === SESSION_A,
+        ),
+      { timeout: 15_000 },
+    )
+    .toBe(true);
+  setSessionABusy(scenario, true);
+  // The locally active prompt puts the composer in its cancel state.
+  await expect(page.locator(SUBMIT_BUTTON)).toHaveAttribute(
+    'aria-label',
+    CANCEL_LABEL,
+  );
+
+  // The running task keeps streaming while the user clicks, types, submits.
+  let trickle: TrickleHandle | undefined = startTrickle(
+    daemon,
+    SESSION_A,
+    TRICKLE_INTERVAL_MS,
+  );
+  const finishSessionA = async () => {
+    trickle?.stop();
+    trickle = undefined;
+    setSessionABusy(scenario, false);
+    await daemon.sendEventTo(
+      SESSION_A,
+      turnCompleteEvent('prompt-a-done', { id: 200, sessionId: SESSION_A }),
+    );
+  };
+
+  try {
+    await runWorkspaceBRounds(page, daemon, scenario, traffic, finishSessionA);
+  } finally {
+    trickle?.stop();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Round 2: realistic traffic from the busy session A (transactional daemon).
+//
+// A real running task keeps emitting SSE events while the user clicks New
+// task, types, and submits, and eventually sends `turn_complete`. These
+// variants add that traffic — plus daemon latency — to the scenario that
+// passed silently in round 1.
+// ---------------------------------------------------------------------------
+
+test('traffic: steady trickle from busy session A, turn never completes (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runNewSessionScenario(page, testInfo, 'transactional', true, {
+    turnComplete: 'never',
+  });
+});
+
+test('traffic: steady trickle, turn completes right after the new-task click (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runNewSessionScenario(page, testInfo, 'transactional', true, {
+    turnComplete: 'after-click',
+  });
+});
+
+test('traffic: steady trickle, turn completes during the admission chain (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runNewSessionScenario(page, testInfo, 'transactional', true, {
+    turnComplete: 'during-admission',
+  });
+});
+
+test('traffic: steady trickle + slow daemon routes, turn never completes (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runNewSessionScenario(page, testInfo, 'transactional', true, {
+    turnComplete: 'never',
+    slowDaemon: true,
+  });
+});
+
+// The remount-suppression fix targets legacy daemons specifically; widen its
+// admission race windows with daemon latency too, not just transactional's.
+test('traffic: steady trickle + slow daemon routes, turn never completes (legacy daemon)', async ({
+  page,
+}, testInfo) => {
+  await runNewSessionScenario(page, testInfo, 'legacy', true, {
+    turnComplete: 'never',
+    slowDaemon: true,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local-prompt variants: the running task in session A was submitted from
+// this tab (a locally active prompt), the most common real-world shape.
+// ---------------------------------------------------------------------------
+
+test('local prompt in A: steady trickle, turn never completes (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runLocalPromptScenario(page, testInfo, { turnComplete: 'never' });
+});
+
+test('local prompt in A: turn completes right after the new-task click (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runLocalPromptScenario(page, testInfo, { turnComplete: 'after-click' });
+});
+
+test('local prompt in A: turn completes during the admission chain (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runLocalPromptScenario(page, testInfo, {
+    turnComplete: 'during-admission',
+  });
+});
+
+test('local prompt in A: steady trickle + slow daemon routes, turn never completes (transactional daemon)', async ({
+  page,
+}, testInfo) => {
+  await runLocalPromptScenario(page, testInfo, {
+    turnComplete: 'never',
+    slowDaemon: true,
+  });
+});


### PR DESCRIPTION
## What this PR does

On daemons that do not advertise the client identity feature, the Web Shell remounts its session provider whenever the controlled session/workspace target identity changes. When a new session is lazily created for the first prompt, the shell reports that session to the host, and the host's prop update lands while the attach chain for the very same session is still in flight — changing the target identity and remounting the provider mid-admission. The remount detaches the freshly created session, silently drops the first prompt, and snaps the UI back to the previous session's workspace. This PR tracks which session the mounted provider is actually serving and keeps it mounted when the host is merely catching up to that session; genuine target switches still remount exactly as before. The change is scoped to the legacy path — daemons with client identity keep the existing single-provider behavior.

## Why it's needed

With more than one workspace registered, clicking "New task" on workspace B while workspace A's session is connected (for example, running a task) and submitting the first prompt visibly produced workspace A's state: the created session was torn down, the typed prompt vanished, and the shell snapped back to A, while a second click behaved differently. Legacy daemons are old but still supported for compatibility, and this made cross-workspace session creation unreliable on them.

## Reviewer Test Plan

### How to verify

The regression is covered by a new Playwright spec against the mock daemon plus unit tests for the provider key behavior:

- `cd packages/web-shell && npx playwright test client/e2e/web-shell.multi-workspace-new-session.spec.ts --project=chromium` — 12 tests covering legacy and transactional daemons across busy/idle sessions, SSE traffic, turn-completion timings, and daemon latency. Without the provider change, the two legacy tests fail with the created session double-loaded and double-detached, no prompt request ever sent, and the header snapping back to workspace A; with the change all 12 pass.
- `cd packages/web-shell && npx vitest run client/components/WorkspaceSessionProvider.test.tsx` — includes a test asserting the host catch-up does not remount the provider, and one asserting a stale observation from a previous provider instance cannot suppress a genuine remount. Both were mutation-verified to fail when the fix is removed.

Behavior a reviewer can confirm manually against a legacy daemon (no client_identity): open the standalone Web Shell on a session in workspace A, click "New task" on workspace B in the sidebar, submit a prompt — the new session should be created under B and admit the prompt, instead of snapping back to A.

### Evidence (Before & After)

Before (legacy mock daemon, request trace for the first New-task click on B): `POST /session` correctly targets B, but the created session then receives two `load` and two `detach` requests, `POST /session/<new>/prompt` never fires, and the header falls back to workspace A's session identity. After: a single create → load → attach chain, the prompt admitted to the created session under B, and the second round repeats the same clean sequence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
| 🐧 Linux | ⚠️ not tested |

### Environment (optional)

Playwright e2e against the vite dev server with the in-browser mock daemon; unit tests via vitest. The flow was also exercised against a real built daemon (`node dist/cli.js serve`) with two registered workspaces.

## Risk & Scope

- Main risk or tradeoff: the legacy remount key now stays stable while the host catches up to a session the mounted provider created; the recorded observation is cleared on every real key change, so genuine switches still remount. Transactional daemons (all current daemons) are untouched — the suppression applies only when the client identity feature is absent.
- Not validated / out of scope: embedded hosts that never write onSessionIdChange values back into their controlled props; the separate standalone-host state-sync fix that already shipped for modern daemons.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在不广播 client identity 特性的 daemon 上，Web Shell 会在受控的会话/工作区目标身份变化时 remount 会话 provider。当首条 prompt 懒创建新会话时，shell 会把该会话报告给宿主，而宿主的 prop 回传恰好发生在同一个会话的 attach 链路还在进行中的时候——目标身份随之变化，provider 在 admission 进行到一半时被 remount。这次 remount 会 detach 刚创建的会话、静默丢弃首条 prompt，并把 UI 弹回之前会话所在的 workspace。本 PR 记录已挂载 provider 实际服务的会话，当宿主只是"追上"该会话时保持 provider 不动；真正的目标切换仍按原逻辑 remount。改动只作用于 legacy 路径——支持 client identity 的 daemon 保持现有单 provider 行为不变。

## 为什么需要

注册了多个 workspace 时，如果 workspace A 的会话处于连接状态（例如正在运行任务），点击 workspace B 的"新建任务"并提交首条 prompt，界面会呈现出 workspace A 的状态：刚创建的会话被拆掉、输入的消息消失、页面弹回 A，而第二次点击的行为又不一样。Legacy daemon 虽然老旧但仍受兼容支持，这个问题让它们上面的跨 workspace 新建会话不可靠。

## Reviewer 测试计划

### 如何验证

回归由针对 mock daemon 的新 Playwright spec 和针对 provider key 行为的单测共同覆盖：

- `cd packages/web-shell && npx playwright test client/e2e/web-shell.multi-workspace-new-session.spec.ts --project=chromium` —— 12 个测试，覆盖 legacy 与 transactional daemon、busy/idle 会话、SSE 流量、turn 完成时机与 daemon 延迟。不带本修复时，两个 legacy 测试会失败：创建的会话被双重 load/detach、没有任何 prompt 请求发出、标题栏弹回 workspace A；带上修复后 12 个全部通过。
- `cd packages/web-shell && npx vitest run client/components/WorkspaceSessionProvider.test.tsx` —— 包含"宿主 catch-up 不触发 remount"和"上一个 provider 实例的陈旧观察不能抑制真正的 remount"两个测试，二者均做过变异验证（移除修复即失败）。

Reviewer 也可以在 legacy daemon（无 client_identity）上手工确认：在 workspace A 的会话里打开 standalone Web Shell，点击侧边栏 workspace B 的"新建任务"，发送一条 prompt——新会话应建在 B 下并收到该 prompt，而不是弹回 A。

### 前后对比证据

修复前（legacy mock daemon，第一次点击 B 新建任务的请求轨迹）：`POST /session` 正确指向 B，但随后创建的会话收到两次 `load` 和两次 `detach`，`POST /session/<new>/prompt` 从未发出，标题栏退回 workspace A 的会话身份。修复后：单次 create → load → attach 链路，prompt 正常进入 B 下新建的会话，第二轮重复同样干净的序列。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

### 环境（可选）

Playwright e2e 跑在 vite dev server + 浏览器内 mock daemon 上；单测用 vitest。该流程也在真实构建的 daemon（`node dist/cli.js serve`，注册两个 workspace）上跑过。

## 风险与范围

- 主要风险或权衡：legacy remount key 现在会在宿主追上 provider 自己创建的会话期间保持稳定；观察记录在每次真正的 key 变化时清空，因此真正的切换仍会 remount。Transactional daemon（所有现役 daemon）完全不受影响——该抑制只在缺少 client identity 特性时生效。
- 未验证 / 超出范围：不把 onSessionIdChange 返回值写回自身受控 props 的嵌入式宿主；面向现代 daemon 的 standalone 宿主状态同步修复已单独合入。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>
