### PR TITLE
fix(cli): bound string width and code point caches (#2128)

### DIFF
--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -10,11 +10,15 @@ import type {
   ToolEditConfirmationDetails,
 } from '@qwen-code/qwen-code-core';
 import {
+  TEXT_CACHE_MAX_ENTRIES,
+  __getTextUtilsCacheSizes,
   escapeAnsiCtrlCodes,
+  getCachedStringWidth,
   sanitizeFilenameForDisplay,
   sanitizeMultilineForDisplay,
   sanitizeSensitiveText,
   sliceTextByVisualHeight,
+  toCodePoints,
   truncateToWidth,
 } from './textUtils.js';
 
@@ -394,6 +398,45 @@ describe('textUtils', () => {
     it('bounds CJK text by display width, not character count', () => {
       // 5 CJK characters (10 cells) plus the ellipsis fit an 11-cell budget.
       expect(truncateToWidth('目标配置参数设置', 11)).toBe('目标配置参…');
+    });
+  });
+
+  describe('text cache bounds', () => {
+    it('bounds the code points cache and keeps results correct', () => {
+      const probe = (i: number) => `cache-bound-probe-${i}-é`;
+      for (let i = 0; i < TEXT_CACHE_MAX_ENTRIES + 50; i++) {
+        toCodePoints(probe(i));
+      }
+
+      expect(__getTextUtilsCacheSizes().codePoints).toBe(
+        TEXT_CACHE_MAX_ENTRIES,
+      );
+
+      const fresh = 'fresh-é-probe';
+      expect(toCodePoints(fresh)).toEqual(Array.from(fresh));
+      // An evicted key must recompute to the same result.
+      expect(toCodePoints(probe(0))).toEqual(Array.from(probe(0)));
+    });
+
+    it('bounds the string width cache and keeps widths correct', () => {
+      const probe = (i: number) => `width-bound-probe-${i}-é`;
+      for (let i = 0; i < TEXT_CACHE_MAX_ENTRIES + 50; i++) {
+        getCachedStringWidth(probe(i));
+      }
+
+      expect(__getTextUtilsCacheSizes().stringWidth).toBe(
+        TEXT_CACHE_MAX_ENTRIES,
+      );
+
+      expect(getCachedStringWidth('héllo')).toBe(5);
+      expect(getCachedStringWidth('目标')).toBe(4);
+    });
+
+    it('does not grow the caches for ASCII fast-path input', () => {
+      const before = __getTextUtilsCacheSizes();
+      getCachedStringWidth('plain-ascii-input');
+      toCodePoints('plain-ascii-input');
+      expect(__getTextUtilsCacheSizes()).toEqual(before);
     });
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -402,12 +402,20 @@ describe('textUtils', () => {
   });
 
   describe('text cache bounds', () => {
+    it('does not grow the caches for ASCII fast-path input', () => {
+      const before = __getTextUtilsCacheSizes();
+      getCachedStringWidth('plain-ascii-input');
+      toCodePoints('plain-ascii-input');
+      expect(__getTextUtilsCacheSizes()).toEqual(before);
+    });
+
     it('bounds the code points cache and keeps results correct', () => {
       const probe = (i: number) => `cache-bound-probe-${i}-é`;
       for (let i = 0; i < TEXT_CACHE_MAX_ENTRIES + 50; i++) {
         toCodePoints(probe(i));
       }
 
+      expect(TEXT_CACHE_MAX_ENTRIES).toBe(500);
       expect(__getTextUtilsCacheSizes().codePoints).toBe(
         TEXT_CACHE_MAX_ENTRIES,
       );
@@ -430,13 +438,6 @@ describe('textUtils', () => {
 
       expect(getCachedStringWidth('héllo')).toBe(5);
       expect(getCachedStringWidth('目标')).toBe(4);
-    });
-
-    it('does not grow the caches for ASCII fast-path input', () => {
-      const before = __getTextUtilsCacheSizes();
-      getCachedStringWidth('plain-ascii-input');
-      toCodePoints('plain-ascii-input');
-      expect(__getTextUtilsCacheSizes()).toEqual(before);
     });
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   TEXT_CACHE_MAX_ENTRIES,
   __getTextUtilsCacheSizes,
+  clearStringWidthCache,
   escapeAnsiCtrlCodes,
   getCachedStringWidth,
   sanitizeFilenameForDisplay,
@@ -438,6 +439,14 @@ describe('textUtils', () => {
 
       expect(getCachedStringWidth('héllo')).toBe(5);
       expect(getCachedStringWidth('目标')).toBe(4);
+    });
+
+    it('does not cache long string width keys', () => {
+      clearStringWidthCache();
+      const longCjk = '目'.repeat(1001);
+
+      expect(getCachedStringWidth(longCjk)).toBe(2002);
+      expect(__getTextUtilsCacheSizes().stringWidth).toBe(0);
     });
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -448,5 +448,13 @@ describe('textUtils', () => {
       expect(getCachedStringWidth(longCjk)).toBe(2002);
       expect(__getTextUtilsCacheSizes().stringWidth).toBe(0);
     });
+
+    it('caches string width keys at the length limit', () => {
+      clearStringWidthCache();
+      const limitCjk = '目'.repeat(1000);
+
+      expect(getCachedStringWidth(limitCjk)).toBe(2000);
+      expect(__getTextUtilsCacheSizes().stringWidth).toBe(1);
+    });
   });
 });

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -159,8 +159,10 @@ export const getCachedStringWidth = (str: string): number => {
   }
 
   const width = stringWidth(str);
-  evictOldestTextCacheEntry(stringWidthCache);
-  stringWidthCache.set(str, width);
+  if (str.length <= MAX_STRING_LENGTH_TO_CACHE) {
+    evictOldestTextCacheEntry(stringWidthCache);
+    stringWidthCache.set(str, width);
+  }
 
   return width;
 };

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -36,6 +36,23 @@ export const getAsciiArtWidth = (asciiArt: string): number => {
 const codePointsCache = new Map<string, string[]>();
 const MAX_STRING_LENGTH_TO_CACHE = 1000;
 
+/** Max entries in each text cache before eviction */
+export const TEXT_CACHE_MAX_ENTRIES = 500;
+
+/**
+ * Evict oldest entry if a cache reaches the soft cap.
+ * Uses single-entry eviction to preserve hot data. Map iteration order is
+ * insertion order, so the first key is the oldest.
+ */
+function evictOldestTextCacheEntry<K, V>(cache: Map<K, V>): void {
+  if (cache.size >= TEXT_CACHE_MAX_ENTRIES) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey !== undefined) {
+      cache.delete(firstKey);
+    }
+  }
+}
+
 export function toCodePoints(str: string): string[] {
   // ASCII fast path - check if all chars are ASCII (0-127)
   let isAscii = true;
@@ -59,8 +76,9 @@ export function toCodePoints(str: string): string[] {
 
   const result = Array.from(str);
 
-  // Cache result (unlimited like Ink)
+  // Cache result (bounded; oldest entry evicted at the cap)
   if (str.length <= MAX_STRING_LENGTH_TO_CACHE) {
+    evictOldestTextCacheEntry(codePointsCache);
     codePointsCache.set(str, result);
   }
 
@@ -127,8 +145,9 @@ export function stripUnsafeCharacters(str: string): string {
 const stringWidthCache = new Map<string, number>();
 
 /**
- * Cached version of stringWidth function for better performance
- * Follows Ink's approach with unlimited cache (no eviction)
+ * Cached version of stringWidth function for better performance.
+ * Bounded with oldest-entry eviction so long sessions cannot grow it
+ * without limit.
  */
 export const getCachedStringWidth = (str: string): number => {
   // ASCII printable chars have width 1
@@ -141,6 +160,7 @@ export const getCachedStringWidth = (str: string): number => {
   }
 
   const width = stringWidth(str);
+  evictOldestTextCacheEntry(stringWidthCache);
   stringWidthCache.set(str, width);
 
   return width;
@@ -281,6 +301,18 @@ export function sliceTextByVisualHeight(
 export const clearStringWidthCache = (): void => {
   stringWidthCache.clear();
 };
+
+/**
+ * Report current sizes of the module-level text caches.
+ * @internal — only used in tests to verify cache bounds.
+ */
+export const __getTextUtilsCacheSizes = (): {
+  codePoints: number;
+  stringWidth: number;
+} => ({
+  codePoints: codePointsCache.size,
+  stringWidth: stringWidthCache.size,
+});
 
 const regex = ansiRegex();
 

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -41,8 +41,7 @@ export const TEXT_CACHE_MAX_ENTRIES = 500;
 
 /**
  * Evict oldest entry if a cache reaches the soft cap.
- * Uses single-entry eviction to preserve hot data. Map iteration order is
- * insertion order, so the first key is the oldest.
+ * Map iteration order is insertion order, so the first key is the oldest.
  */
 function evictOldestTextCacheEntry<K, V>(cache: Map<K, V>): void {
   if (cache.size >= TEXT_CACHE_MAX_ENTRIES) {

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -154,15 +154,17 @@ export const getCachedStringWidth = (str: string): number => {
     return str.length;
   }
 
+  if (str.length > MAX_STRING_LENGTH_TO_CACHE) {
+    return stringWidth(str);
+  }
+
   if (stringWidthCache.has(str)) {
     return stringWidthCache.get(str)!;
   }
 
   const width = stringWidth(str);
-  if (str.length <= MAX_STRING_LENGTH_TO_CACHE) {
-    evictOldestTextCacheEntry(stringWidthCache);
-    stringWidthCache.set(str, width);
-  }
+  evictOldestTextCacheEntry(stringWidthCache);
+  stringWidthCache.set(str, width);
 
   return width;
 };


### PR DESCRIPTION
## What this PR does

This PR bounds the two module-level text caches in `packages/cli/src/ui/utils/textUtils.ts` (`codePointsCache` and `stringWidthCache`) with a soft cap of 500 entries and oldest-entry eviction, mirroring the pattern the word-boundary cache in `text-buffer.ts` already uses. Once a cache reaches the cap, each new insert evicts the oldest entry (Map insertion order). Results are unchanged — evicted strings are recomputed on next use. It also adds tests asserting both caches stay at the cap after 550 unique inserts, stay correct across eviction, and that the ASCII fast path keeps bypassing the caches.

## Why it's needed

#2128 tracks unbounded memory growth in long sessions and identifies these two caches as sub-cause #4: every unique non-ASCII string the UI renders is cached forever (the code comment even said "unlimited like Ink"), `clearStringWidthCache()` is never called, and over multi-hour sessions file contents and terminal output streamed through rendering grow the caches without limit. This is a first bounded slice of #2128; the larger sub-causes (unbounded history array, heavy payloads) are intentionally out of scope.

## Reviewer Test Plan

### How to verify

Reproduced first (red): with no eviction, 550 unique inserts through `getCachedStringWidth` grew the width cache to 558 entries and the new bound test failed with `expected 558 to be 500`. After the fix, in `packages/cli`: `npx vitest run src/ui/utils/textUtils.test.ts` → 40/40 pass; both caches report exactly 500 entries after 550 inserts; evicted keys recompute correctly (`héllo` → 5, `目标` → 4). Full suite `npx vitest run` in `packages/cli`: 20033 passed; the 21 failures in unrelated suites (serve routes, telemetry endpoints, EACCES permission tests) reproduce identically on clean `main` in this environment (verified via stash) and are not caused by this change. `npx tsc --noEmit` and `npx eslint` on the changed files are clean.

### Evidence (Before & After)

N/A (non-user-visible; memory/performance only). Before: the new bound test failed with `AssertionError: expected 558 to be 500`. After: `Tests 40 passed (40)` for `textUtils.test.ts`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (vitest, Node on Linux).

## Risk & Scope

- Main risk or tradeoff: once more than 500 unique strings are cached, hit rate drops and evicted entries recompute (`stringWidth`/`toCodePoints` are cheap); trades a little CPU for bounded memory. Cap value and eviction style match the existing `WORD_BOUNDARIES_CACHE_MAX = 500` precedent.
- Not validated / out of scope: the remaining #2128 sub-causes (unbounded `history` array, `FileDiff`/`AnsiOutputDisplay` payload retention, `userMessages` re-derivation, checkpoint serialization). `clearStringWidthCache` stays exported-but-uncalled, unchanged.
- Breaking changes / migration notes: none — behavior is identical; the only new exports are the cap constant and an `@internal` test-only accessor.

## Linked Issues

Part of #2128 (sub-cause #4: unbounded string caches). No closing keyword — the remaining sub-causes stay open.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 `packages/cli/src/ui/utils/textUtils.ts` 里的两个模块级文本缓存（`codePointsCache` 和 `stringWidthCache`）加上 500 条软上限和"最旧条目淘汰"，与 `text-buffer.ts` 中词边界缓存的既有模式保持一致。缓存达到上限后，每次新插入会淘汰最旧条目（Map 插入序）。计算结果完全不变——被淘汰的字符串下次使用时重新计算。同时新增测试：插入 550 个唯一字符串后两个缓存均保持在上限、淘汰后结果仍然正确、ASCII 快路径依旧不进缓存。

## 为什么需要

#2128 跟踪长会话内存无限增长，子原因 #4 正是这两个缓存：UI 渲染过的每个唯一非 ASCII 字符串都会被永久缓存（源码注释原本写着 "unlimited like Ink"），`clearStringWidthCache()` 从未被调用，数小时的会话里文件内容和终端输出流经渲染会把缓存撑到无限大。这是 #2128 的第一个有界修复切片；更大的子原因（无界 history 数组、重负载对象）明确不在本次范围。

## 评审验证方案

### 如何验证

先复现（红）：无淘汰时，550 次唯一插入经过 `getCachedStringWidth` 使宽度缓存涨到 558 条，新增的边界测试报 `expected 558 to be 500` 失败。修复后在 `packages/cli` 下：`npx vitest run src/ui/utils/textUtils.test.ts` → 40/40 通过；550 次插入后两个缓存恰好保持 500 条；被淘汰的键重算结果正确（`héllo` → 5，`目标` → 4）。完整 `npx vitest run`：20033 通过；不相关套件（serve 路由、telemetry 端点、EACCES 权限测试）的 21 个失败在本环境的干净 `main` 上同样复现（已用 stash 验证），与本改动无关。改动文件 `npx tsc --noEmit` 与 `npx eslint` 干净。

### 前后对比证据

N/A（无用户可见变化，仅内存/性能）。修复前：新边界测试报 `AssertionError: expected 558 to be 500`；修复后：`Tests 40 passed (40)`。

### 测试环境

Linux ✅；macOS / Windows 未测试。

### 环境（可选）

仅单元测试（vitest，Linux Node）。

## 风险与范围

- 主要风险/权衡：缓存的唯一字符串超过 500 后命中率下降，被淘汰条目需重算（`stringWidth`/`toCodePoints` 开销很小）；用少量 CPU 换有界内存。上限值与淘汰方式与既有先例 `WORD_BOUNDARIES_CACHE_MAX = 500` 一致。
- 未验证 / 超出范围：#2128 的其余子原因（无界 `history` 数组、`FileDiff`/`AnsiOutputDisplay` 重负载保留、`userMessages` 重复推导、checkpoint 序列化）。`clearStringWidthCache` 保持"已导出但未调用"原样，不动。
- 破坏性变更：无——行为完全一致；新增导出仅为上限常量和一个 `@internal` 测试访问器。

## 关联 Issue

Part of #2128（子原因 #4：无界字符串缓存）。不使用关闭关键字——其余子原因仍 open。

</details>