### PR TITLE
feat(autofix): defer verified out-of-footprint findings to a surviving follow-up queue

### DIFF
--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -62,7 +62,13 @@ lost() {
   echo "::warning::$1 — these findings are LOST (watermark-gated — no later round re-derives them). Raw deferrals follow for manual recovery:"
   for f in "${FINDINGS}" "${CARRY}"; do
     [[ -s "${f}" ]] || continue
-    echo "--- ${f}"
+    local size
+    size="$(wc -c < "${f}" 2> /dev/null | tr -d ' ')"
+    if [[ -n "${size}" ]] && (( size > 4000 )); then
+      echo "--- ${f} (first 4000 of ${size} bytes — TRUNCATED; the full file is in this run's artifact dump)"
+    else
+      echo "--- ${f}"
+    fi
     head -c 4000 "${f}" | sed 's/::/;;/g'
     echo
   done
@@ -77,7 +83,12 @@ if [[ -s "${CARRY}" ]]; then
     if jq -s 'add' "${FINDINGS}" "${CARRY}" > "${MERGED}" 2> /dev/null; then
       FINDINGS="${MERGED}"
     else
-      echo "::warning::could not merge the carried deferrals; persisting only this round's (the carried ones are dumped below)"
+      CARRY_SIZE="$(wc -c < "${CARRY}" 2> /dev/null | tr -d ' ')"
+      if [[ -n "${CARRY_SIZE}" ]] && (( CARRY_SIZE > 4000 )); then
+        echo "::warning::could not merge the carried deferrals; persisting only this round's. The carried set follows, TRUNCATED at 4000 of ${CARRY_SIZE} bytes (full file in the artifact dump):"
+      else
+        echo "::warning::could not merge the carried deferrals; persisting only this round's (the carried ones are dumped below)"
+      fi
       head -c 4000 "${CARRY}" | sed 's/::/;;/g'
       echo
     fi
@@ -212,19 +223,30 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLV
     | map(sub("^rc:"; "") | sub("\r$"; "")
       | select(test("^[0-9]+$")) | tonumber)) as $done
   | ($known | split("\n")) as $klines
-  | unique_by([(.source // "review_comment"), .id])
   | map(.id as $id
     | ((.source // "review_comment")) as $src
     | (if $src == "review" then "rv"
        elif $src == "issue_comment" then "ic"
        else "rc" end) as $pfx
     | select(($src != "review_comment") or (($done | index($id)) | not))
-    | select(($klines | any(test("^- " + $pfx + ":" + ($id | tostring) + " "))) | not)
-    | "- \($pfx):\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason
+    | {src: $src, id: $id,
+       line: "- \($pfx):\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason
         | gsub("[\r\n]+"; " ")
         | gsub("&(?<ent>#0*(?:64|[xX]0*40);|commat;)"; "&amp;\(.ent)")
         | gsub("@"; "@\u200b")
-        | .[0:500])")
+        | .[0:500])",
+       anchor: ("^- " + $pfx + ":" + ($id | tostring) + " ")})
+  # An inline comment is one finding, so its id IS the identity (and the
+  # anchor keeps working across rounds). A review body or an issue-level
+  # comment can raise SEVERAL findings under one id, so there the identity —
+  # and the corpus check — is the rendered line itself; keying those on the
+  # id alone silently ate every sibling but the first.
+  | unique_by(if .src == "review_comment" then [.src, .id] else [.src, .id, .line] end)
+  | map(. as $r
+    | select(if $r.src == "review_comment"
+        then ($klines | any(test($r.anchor))) | not
+        else ($klines | index($r.line)) == null end)
+    | $r.line)
   | .[]' "${FINDINGS}" 2> /dev/null |
   sed 's/<!--/<!\\-\\-/g')"; then
   # The only remaining silent-exit path: a jq/sed failure here would leave

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -347,7 +347,10 @@ fi
 # every later round, so the agent never re-derives the clipped ids. The
 # warning names them for a maintainer to persist by hand (or raise the cap);
 # it must not imply a later round will re-defer them.
-TOTAL_NEW="$(printf '%s\n' "${NEW_LINES}" | wc -l)"
+# tr -d ' ': BSD/macOS wc pads its count with leading spaces, which would be
+# interpolated verbatim into the cap warning and the success message (the
+# sibling `wc -c` above already strips it).
+TOTAL_NEW="$(printf '%s\n' "${NEW_LINES}" | wc -l | tr -d ' ')"
 if (( TOTAL_NEW > 20 )); then
   DROPPED="$(printf '%s\n' "${NEW_LINES}" | tail -n +21)"
   NEW_LINES="$(printf '%s\n' "${NEW_LINES}" | head -n 20)"

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -75,7 +75,13 @@ dump_file() {
   local size
   size="$(wc -c < "$1" 2> /dev/null | tr -d ' ')"
   if [[ -n "${size}" ]] && (( size > 4000 )); then
-    echo "--- $1 (first 4000 of ${size} bytes — TRUNCATED; the full file is in this run's artifact dump)"
+    if [[ "$1" == "${WORKDIR}/"* ]]; then
+      echo "--- $1 (first 4000 of ${size} bytes — TRUNCATED; the full file is in this run's artifact dump)"
+    else
+      # A merge temp lives outside WORKDIR, so it is NOT uploaded — say so
+      # rather than point at an artifact that will not contain it.
+      echo "--- $1 (first 4000 of ${size} bytes — TRUNCATED; this file is a temporary merge product and is NOT in the artifact dump)"
+    fi
   else
     echo "--- $1"
   fi
@@ -291,7 +297,7 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --rawfile resolved "${RE
     ascii_downcase | gsub("[[:punct:]]+"; " ") | gsub("\\s+"; " ")
     | sub("^ "; "") | sub(" $"; "");
   ($resolved | split("\n")
-    | map(sub("^rc:"; "") | sub("\r$"; "")
+    | map(sub("^\\s+"; "") | sub("\\s+$"; "") | sub("^rc:"; "")
       | select(test("^[0-9]+$")) | tonumber)) as $done
   | ($known | split("\n")) as $klines
   | map(.id as $id
@@ -301,6 +307,7 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --rawfile resolved "${RE
        else "rc" end) as $pfx
     | select(($src != "review_comment") or (($done | index($id)) | not))
     | {src: $src, id: $id,
+       raw: ((.path // "?") + " " + .reason),
        # The path charset filter already excludes `<`, so the comment opener
        # cannot survive there; the reason is escaped explicitly below.
        line: "- \($pfx):\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason
@@ -321,13 +328,18 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --rawfile resolved "${RE
     # of path+reason — case-folded, punctuation-collapsed, capped — which
     # absorbs whitespace and phrasing churn while keeping genuinely distinct
     # findings apart. Erring toward a visible duplicate over a silent loss.
-    | . + {key: (.line | normkey)})
+    # Intra-batch identity from the UNCAPPED text: deriving it from the
+    # rendered line let two siblings that differ only past the 500-char reason
+    # cap collide and one vanish. The corpus check below still compares
+    # rendered forms — that is all the issue stores — so cross-round the cap
+    # can cost a duplicate, never a loss.
+    | . + {key: (.line | normkey), fullkey: (.raw | normkey)})
   # An inline comment is one finding, so its id IS the identity (and the
   # anchor keeps working across rounds). A review body or an issue-level
   # comment can raise SEVERAL findings under one id, so there the identity —
   # and the corpus check — is the rendered line itself; keying those on the
   # id alone silently ate every sibling but the first.
-  | unique_by(if .src == "review_comment" then [.src, .id] else [.src, .id, .key] end)
+  | unique_by(if .src == "review_comment" then [.src, .id] else [.src, .id, .fullkey] end)
   | map(. as $r
     | select(if $r.src == "review_comment"
         then ($klines | any(test($r.anchor))) | not

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -24,6 +24,50 @@ set -uo pipefail
 set +C
 
 FINDINGS="${WORKDIR}/deferred-findings.json"
+# Both temp files are released by ONE EXIT trap: a later `trap ... EXIT`
+# would replace an earlier one and leak the first file.
+MERGED=''
+KNOWN_FILE=''
+trap 'rm -f "${MERGED}" "${KNOWN_FILE}"' EXIT
+# A repair re-run rebuilds the workspace: 'Repair deterministic rejection'
+# moves run 1's deferrals to this sidecar so they are not lost when run 2
+# writes its own file. Both are unioned below (the line builder dedupes).
+CARRY="${WORKDIR}/deferred-findings.carry.json"
+
+# Every abort below is PERMANENT for these findings: the eval watermark
+# filters this round's feedback out of every later round, and the next run's
+# workspace reset deletes the file — nothing re-derives them. So each abort
+# says so and dumps what it had, for manual recovery from the run log.
+# `::` is neutralized in the dump: the content is agent-influenced and a
+# raw `::` at line start would be parsed as a workflow command (same reason
+# `<!--` is neutralized at every publish site).
+lost() {
+  echo "::warning::$1 — these findings are LOST (watermark-gated — no later round re-derives them). Raw deferrals follow for manual recovery:"
+  for f in "${FINDINGS}" "${CARRY}"; do
+    [[ -s "${f}" ]] || continue
+    echo "--- ${f}"
+    head -c 4000 "${f}" | sed 's/::/;;/g'
+    echo
+  done
+}
+
+if [[ -s "${CARRY}" ]]; then
+  if [[ -s "${FINDINGS}" ]]; then
+    if ! MERGED="$(mktemp)"; then
+      lost 'could not create a temp file to merge the carried deferrals'
+      exit 0
+    fi
+    if jq -s 'add' "${FINDINGS}" "${CARRY}" > "${MERGED}" 2> /dev/null; then
+      FINDINGS="${MERGED}"
+    else
+      echo "::warning::could not merge the carried deferrals; persisting only this round's (the carried ones are dumped below)"
+      head -c 4000 "${CARRY}" | sed 's/::/;;/g'
+      echo
+    fi
+  else
+    FINDINGS="${CARRY}"
+  fi
+fi
 [[ -s "${FINDINGS}" ]] || exit 0
 
 # An empty array is the contract-valid "nothing to defer" rendering (SKILL
@@ -44,8 +88,14 @@ if ! jq -e 'type == "array" and length > 0 and all(.[];
     (.id | type == "number" and . == floor and . > 0 and . < 9007199254740992
       and (tostring | test("^[0-9]+$")))
     and (.reason | type == "string")
-    and ((.path // "?") | type == "string"))' "${FINDINGS}" > /dev/null 2>&1; then
-  echo "::warning::deferred-findings.json is malformed; skipping the follow-up upsert"
+    and ((.source | type) as $t | $t == "null"
+      or ($t == "string"
+        and (.source | IN("review_comment", "review", "issue_comment"))))
+    and (.path | type | . == "null" or . == "string"))' "${FINDINGS}" > /dev/null 2>&1; then
+  # `.path | type` (not `.path // "?"`): `//` treats false as absent, so a
+  # present-but-non-string `false` would otherwise be coerced to "?" against
+  # this gate's own "fail loudly" contract.
+  lost 'deferred findings are malformed (this round and/or the carried sidecar)'
   exit 0
 fi
 
@@ -60,7 +110,7 @@ if ! ISSUE_NUM="$(gh api "repos/${REPO}/issues?state=all&creator=${AUTOFIX_BOT}&
   jq -rs --arg m "${MARKER}" '
     add // [] | map(select((.pull_request | not)
       and ((.body // "") | contains($m)))) | (.[0].number // "") | tostring')"; then
-  echo "::warning::deferred-findings lookup failed; skipping the follow-up upsert this round"
+  lost 'the tracking-issue lookup failed'
   exit 0
 fi
 
@@ -68,16 +118,15 @@ if ! KNOWN_FILE="$(mktemp)"; then
   # A silent exit here would violate the header contract (every failure
   # warns) and is exactly when visibility matters — /tmp exhaustion is a
   # known CI state.
-  echo "::warning::could not create a temp file for the deferred-findings corpus; skipping this round"
+  lost 'could not create a temp file for the dedupe corpus'
   exit 0
 fi
-trap 'rm -f "${KNOWN_FILE}"' EXIT
 if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
   # Known-id corpus = issue body + every comment. Any fetch failure skips
   # the round: treating it as empty would re-append history (or, under
   # the old PATCH design, erase it).
   if ! BODY_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.body // ""' 2> /dev/null)"; then
-    echo "::warning::could not read deferred-findings issue #${ISSUE_NUM}; skipping this round"
+    lost "could not read deferred-findings issue #${ISSUE_NUM}"
     exit 0
   fi
   # Bot-authored comments only: the tracking issue is public, and an
@@ -86,7 +135,7 @@ if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
   if ! COMMENT_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments?per_page=100" \
     --paginate 2> /dev/null | jq -rs --arg bot "${AUTOFIX_BOT}" \
       'add // [] | map(select((.user.login // "") == $bot) | .body // "") | join("\n")')"; then
-    echo "::warning::could not read deferred-findings comments on #${ISSUE_NUM}; skipping this round"
+    lost "could not read the deferred-findings comments on #${ISSUE_NUM}"
     exit 0
   fi
   printf '%s\n%s' "${BODY_TEXT}" "${COMMENT_TEXT}" > "${KNOWN_FILE}"
@@ -114,11 +163,15 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLV
     | map(sub("^rc:"; "") | sub("\r$"; "")
       | select(test("^[0-9]+$")) | tonumber)) as $done
   | ($known | split("\n")) as $klines
-  | unique_by(.id)
+  | unique_by([(.source // "review_comment"), .id])
   | map(.id as $id
-    | select(($done | index($id)) | not)
-    | select(($klines | any(test("^- rc:" + ($id | tostring) + " "))) | not)
-    | "- rc:\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason
+    | ((.source // "review_comment")) as $src
+    | (if $src == "review" then "rv"
+       elif $src == "issue_comment" then "ic"
+       else "rc" end) as $pfx
+    | select(($src != "review_comment") or (($done | index($id)) | not))
+    | select(($klines | any(test("^- " + $pfx + ":" + ($id | tostring) + " "))) | not)
+    | "- \($pfx):\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason
         | gsub("[\r\n]+"; " ")
         | gsub("&(?<ent>#0*(?:64|[xX]0*40);|commat;)"; "&amp;\(.ent)")
         | gsub("@"; "@\u200b")
@@ -127,7 +180,7 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLV
   sed 's/<!--/<!\\-\\-/g')"; then
   # The only remaining silent-exit path: a jq/sed failure here would leave
   # NEW_LINES empty and read as "nothing new". Warn, per the header contract.
-  echo "::warning::could not build the deferred-findings lines; skipping this round"
+  lost 'could not build the deferred-findings lines'
   exit 0
 fi
 [[ -n "${NEW_LINES}" ]] || exit 0

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -28,7 +28,24 @@ FINDINGS="${WORKDIR}/deferred-findings.json"
 # would replace an earlier one and leak the first file.
 MERGED=''
 KNOWN_FILE=''
-trap 'rm -f "${MERGED}" "${KNOWN_FILE}"' EXIT
+GH_ERR=''
+trap 'rm -f "${MERGED}" "${KNOWN_FILE}" "${GH_ERR}"' EXIT
+# Every gh call writes its stderr here so the warnings can NAME the cause:
+# a rate limit, an expired/rotated PAT, a transport error and a 404 are
+# indistinguishable when stderr goes to /dev/null, and these warnings are
+# the feature's only signal. Best-effort: with no sink the calls still run,
+# they just report "no stderr captured".
+GH_ERR="$(mktemp 2> /dev/null || true)"
+gh_reason() {
+  local r=''
+  [[ -n "${GH_ERR}" && -s "${GH_ERR}" ]] &&
+    r="$(tr '\r\n\t' '   ' < "${GH_ERR}" | head -c 200)"
+  # `::` neutralized like every other agent/API-derived echo: an API error
+  # body is not trusted to be free of workflow-command syntax.
+  r="$(printf '%s' "${r}" | sed 's/::/;;/g')"
+  [[ -n "${r// /}" ]] && printf '%s' "${r}" || printf 'no stderr captured'
+}
+gh_err_reset() { [[ -n "${GH_ERR}" ]] && : > "${GH_ERR}"; }
 # A repair re-run rebuilds the workspace: 'Repair deterministic rejection'
 # moves run 1's deferrals to this sidecar so they are not lost when run 2
 # writes its own file. Both are unioned below (the line builder dedupes).
@@ -105,12 +122,41 @@ MARKER="<!-- autofix-deferred pr=${PR} -->"
 # request, marker matched against the real body (no line-joining), first
 # match wins. A lookup failure is a skip, not "no issue" — creating a
 # duplicate is worse than deferring persistence one round.
-if ! ISSUE_NUM="$(gh api "repos/${REPO}/issues?state=all&creator=${AUTOFIX_BOT}&per_page=100" \
-  --paginate 2> /dev/null |
-  jq -rs --arg m "${MARKER}" '
-    add // [] | map(select((.pull_request | not)
-      and ((.body // "") | contains($m)))) | (.[0].number // "") | tostring')"; then
-  lost 'the tracking-issue lookup failed'
+# Bounded and newest-first, stopping at the first marker match: the
+# tracking issue for THIS PR is created during its life, so the common case
+# costs ONE request. A full --paginate here re-downloaded every issue the
+# bot has ever opened, on every round that defers anything, and that set
+# only grows. The page cap bounds the worst case; reaching it without a
+# match SKIPS rather than creating a second tracking issue.
+LOOKUP_MAX_PAGES=10
+ISSUE_NUM=''
+lookup_page=1
+while (( lookup_page <= LOOKUP_MAX_PAGES )); do
+  gh_err_reset
+  if ! PAGE_JSON="$(gh api "repos/${REPO}/issues?state=all&creator=${AUTOFIX_BOT}&per_page=100&sort=created&direction=desc&page=${lookup_page}" \
+    2> "${GH_ERR:-/dev/null}")"; then
+    lost "the tracking-issue lookup failed on page ${lookup_page} ($(gh_reason))"
+    exit 0
+  fi
+  HIT="$(jq -r --arg m "${MARKER}" '
+    map(select((.pull_request | not)
+      and ((.body // "") | contains($m)))) | (.[0].number // "") | tostring' \
+    <<< "${PAGE_JSON}" 2> /dev/null)" || HIT=''
+  if [[ -n "${HIT}" && "${HIT}" != 'null' ]]; then
+    ISSUE_NUM="${HIT}"
+    break
+  fi
+  # A short page means the corpus is exhausted: no issue exists, so the
+  # create path below is correct (not a cap miss).
+  PAGE_COUNT="$(jq -r 'length' <<< "${PAGE_JSON}" 2> /dev/null)" || PAGE_COUNT=0
+  (( PAGE_COUNT < 100 )) && break
+  lookup_page=$(( lookup_page + 1 ))
+done
+if [[ -z "${ISSUE_NUM}" ]] && (( lookup_page > LOOKUP_MAX_PAGES )); then
+  # Scanned the cap without a match and without exhausting the corpus: an
+  # older tracking issue may exist beyond it, and a duplicate is worse than
+  # deferring persistence.
+  lost "the tracking-issue lookup hit its ${LOOKUP_MAX_PAGES}-page cap without finding the marker"
   exit 0
 fi
 
@@ -125,17 +171,20 @@ if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
   # Known-id corpus = issue body + every comment. Any fetch failure skips
   # the round: treating it as empty would re-append history (or, under
   # the old PATCH design, erase it).
-  if ! BODY_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.body // ""' 2> /dev/null)"; then
-    lost "could not read deferred-findings issue #${ISSUE_NUM}"
+  gh_err_reset
+  if ! BODY_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.body // ""' \
+    2> "${GH_ERR:-/dev/null}")"; then
+    lost "could not read deferred-findings issue #${ISSUE_NUM} ($(gh_reason))"
     exit 0
   fi
   # Bot-authored comments only: the tracking issue is public, and an
   # arbitrary commenter posting a line-start "- rc:<id> " bullet must not
   # be able to permanently suppress a deferred finding from the corpus.
+  gh_err_reset
   if ! COMMENT_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments?per_page=100" \
-    --paginate 2> /dev/null | jq -rs --arg bot "${AUTOFIX_BOT}" \
+    --paginate 2> "${GH_ERR:-/dev/null}" | jq -rs --arg bot "${AUTOFIX_BOT}" \
       'add // [] | map(select((.user.login // "") == $bot) | .body // "") | join("\n")')"; then
-    lost "could not read the deferred-findings comments on #${ISSUE_NUM}"
+    lost "could not read the deferred-findings comments on #${ISSUE_NUM} ($(gh_reason))"
     exit 0
   fi
   printf '%s\n%s' "${BODY_TEXT}" "${COMMENT_TEXT}" > "${KNOWN_FILE}"
@@ -202,22 +251,24 @@ fi
 
 if [[ -z "${ISSUE_NUM}" || "${ISSUE_NUM}" == 'null' ]]; then
   BODY="${MARKER}"$'\n\n'"Verified review findings from PR #${PR} whose fixes lie outside that PR's footprint, deferred by the autofix loop for follow-up. A maintainer can turn any item into its own issue/PR (or apply the ready-for-agent flow) — nothing here is scheduled automatically."$'\n\n'"${NEW_LINES}"
+  gh_err_reset
   if NUM="$(gh api "repos/${REPO}/issues" \
     -f title="Deferred review findings from PR #${PR}" \
-    -f body="${BODY}" --jq '.number' 2> /dev/null)"; then
+    -f body="${BODY}" --jq '.number' 2> "${GH_ERR:-/dev/null}")"; then
     echo "🗂 deferred findings tracked in new issue #${NUM} (${KEPT} of ${TOTAL_NEW} new)"
   else
     # Not "this round": the eval watermark filters this round's feedback out
     # of every later round, so nothing retries. Name the lost items.
-    echo "::warning::could not create the deferred-findings issue for PR #${PR}; these findings are LOST (watermark-gated — no later round re-derives them). A maintainer should file them:"
+    echo "::warning::could not create the deferred-findings issue for PR #${PR} ($(gh_reason)); these findings are LOST (watermark-gated — no later round re-derives them). A maintainer should file them:"
     printf '%s\n' "${NEW_LINES}"
   fi
 else
+  gh_err_reset
   if gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
-    -f body="${NEW_LINES}" > /dev/null 2>&1; then
+    -f body="${NEW_LINES}" > /dev/null 2> "${GH_ERR:-/dev/null}"; then
     echo "🗂 deferred findings appended to issue #${ISSUE_NUM} (${KEPT} of ${TOTAL_NEW} new)"
   else
-    echo "::warning::could not append to deferred-findings issue #${ISSUE_NUM}; these findings are LOST (watermark-gated — no later round re-derives them). A maintainer should add them:"
+    echo "::warning::could not append to deferred-findings issue #${ISSUE_NUM} ($(gh_reason)); these findings are LOST (watermark-gated — no later round re-derives them). A maintainer should add them:"
     printf '%s\n' "${NEW_LINES}"
   fi
 fi

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -23,7 +23,7 @@ FINDINGS="${WORKDIR}/deferred-findings.json"
 # present, a string (one malformed sibling must not drop the batch — it
 # fails the whole file loudly instead of being silently formatted away).
 if ! jq -e 'type == "array" and length > 0 and all(.[];
-    (.id | type == "number") and (.reason | type == "string")
+    (.id | type == "number" and . == floor and . > 0) and (.reason | type == "string")
     and ((.path // "?") | type == "string"))' "${FINDINGS}" > /dev/null 2>&1; then
   echo "::warning::deferred-findings.json is malformed; skipping the follow-up upsert"
   exit 0
@@ -35,7 +35,7 @@ MARKER="<!-- autofix-deferred pr=${PR} -->"
 # request, marker matched against the real body (no line-joining), first
 # match wins. A lookup failure is a skip, not "no issue" — creating a
 # duplicate is worse than deferring persistence one round.
-if ! ISSUE_NUM="$(gh api "repos/${REPO}/issues?state=open&creator=${AUTOFIX_BOT}&per_page=100" \
+if ! ISSUE_NUM="$(gh api "repos/${REPO}/issues?state=all&creator=${AUTOFIX_BOT}&per_page=100" \
   --paginate 2> /dev/null |
   jq -rs --arg m "${MARKER}" '
     add // [] | map(select((.pull_request | not)
@@ -44,7 +44,8 @@ if ! ISSUE_NUM="$(gh api "repos/${REPO}/issues?state=open&creator=${AUTOFIX_BOT}
   exit 0
 fi
 
-KNOWN=''
+KNOWN_FILE="$(mktemp)"
+trap 'rm -f "${KNOWN_FILE}"' EXIT
 if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
   # Known-id corpus = issue body + every comment. Any fetch failure skips
   # the round: treating it as empty would re-append history (or, under
@@ -58,7 +59,7 @@ if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
     echo "::warning::could not read deferred-findings comments on #${ISSUE_NUM}; skipping this round"
     exit 0
   fi
-  KNOWN="${BODY_TEXT}"$'\n'"${COMMENT_TEXT}"
+  printf '%s\n%s' "${BODY_TEXT}" "${COMMENT_TEXT}" > "${KNOWN_FILE}"
 fi
 
 # Build this round's lines: intra-batch dedupe by id, drop ids the round
@@ -68,7 +69,10 @@ fi
 # neutralization matches every other agent-derived publish site.
 RESOLVED_RAW=''
 [[ -f "${WORKDIR}/resolved-comments.txt" ]] && RESOLVED_RAW="$(cat "${WORKDIR}/resolved-comments.txt")"
-NEW_LINES="$(jq -r --arg known "${KNOWN}" --arg resolved "${RESOLVED_RAW}" '
+# --rawfile, not --arg: a large corpus in one argv element hits Linux
+# MAX_ARG_STRLEN and the exec failure would be swallowed into a silent
+# "nothing new" exit.
+NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLVED_RAW}" '
   ($resolved | split("\n")
     | map(sub("^rc:"; "") | sub("\r$"; "")
       | select(test("^[0-9]+$")) | tonumber)) as $done
@@ -78,23 +82,33 @@ NEW_LINES="$(jq -r --arg known "${KNOWN}" --arg resolved "${RESOLVED_RAW}" '
     | select(($done | index($id)) | not)
     | select(($klines | any(test("^- rc:" + ($id | tostring) + " "))) | not)
     | "- rc:\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason | gsub("[\r\n]+"; " ") | .[0:500])")
-  | .[0:20] | .[]' "${FINDINGS}" 2> /dev/null |
+  | .[]' "${FINDINGS}" 2> /dev/null |
   sed 's/<!--/<!\\-\\-/g')" || NEW_LINES=''
 [[ -n "${NEW_LINES}" ]] || exit 0
+# Cap in bash, loudly: clipped items are never retried (the workdir is
+# deleted at job end), so a silent clip would read as full persistence.
+TOTAL_NEW="$(printf '%s\n' "${NEW_LINES}" | wc -l)"
+if (( TOTAL_NEW > 20 )); then
+  NEW_LINES="$(printf '%s\n' "${NEW_LINES}" | head -n 20)"
+  echo "::warning::deferred-findings cap: persisting 20 of ${TOTAL_NEW} new findings; the remaining $(( TOTAL_NEW - 20 )) are NOT persisted (re-defer them in a later round)"
+  KEPT=20
+else
+  KEPT="${TOTAL_NEW}"
+fi
 
 if [[ -z "${ISSUE_NUM}" || "${ISSUE_NUM}" == 'null' ]]; then
   BODY="${MARKER}"$'\n\n'"Verified review findings from PR #${PR} whose fixes lie outside that PR's footprint, deferred by the autofix loop for follow-up. A maintainer can turn any item into its own issue/PR (or apply the ready-for-agent flow) — nothing here is scheduled automatically."$'\n\n'"${NEW_LINES}"
   if NUM="$(gh api "repos/${REPO}/issues" \
     -f title="Deferred review findings from PR #${PR}" \
     -f body="${BODY}" --jq '.number' 2> /dev/null)"; then
-    echo "🗂 deferred findings tracked in new issue #${NUM}"
+    echo "🗂 deferred findings tracked in new issue #${NUM} (${KEPT} of ${TOTAL_NEW} new)"
   else
     echo "::warning::could not create the deferred-findings issue for PR #${PR}; findings NOT persisted this round"
   fi
 else
   if gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
     -f body="${NEW_LINES}" > /dev/null 2>&1; then
-    echo "🗂 deferred findings appended to issue #${ISSUE_NUM}"
+    echo "🗂 deferred findings appended to issue #${ISSUE_NUM} (${KEPT} of ${TOTAL_NEW} new)"
   else
     echo "::warning::could not append to deferred-findings issue #${ISSUE_NUM}; findings NOT persisted this round"
   fi

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -102,7 +102,14 @@ RESOLVED_RAW=''
 # --rawfile, not --arg: a large corpus in one argv element hits Linux
 # MAX_ARG_STRLEN and the exec failure would be swallowed into a silent
 # "nothing new" exit.
-NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLVED_RAW}" '
+#
+# The reason is agent-influenced prose published under the bot identity, so
+# it is mention-defused before rendering: `@` gets a trailing ZWSP, and the
+# entity spellings GitHub decodes BEFORE its mention filter (&#64; &#x40;
+# &#0064; &commat;) get their `&` escaped — both measured inert against the
+# real renderer; `\@` and bare entity-escaping are NOT. Paths are already
+# reduced to a safe charset (no `@` survives).
+if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLVED_RAW}" '
   ($resolved | split("\n")
     | map(sub("^rc:"; "") | sub("\r$"; "")
       | select(test("^[0-9]+$")) | tonumber)) as $done
@@ -111,9 +118,18 @@ NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLVED_RA
   | map(.id as $id
     | select(($done | index($id)) | not)
     | select(($klines | any(test("^- rc:" + ($id | tostring) + " "))) | not)
-    | "- rc:\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason | gsub("[\r\n]+"; " ") | .[0:500])")
+    | "- rc:\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason
+        | gsub("[\r\n]+"; " ")
+        | gsub("&(?<ent>#0*(?:64|[xX]0*40);|commat;)"; "&amp;\(.ent)")
+        | gsub("@"; "@\u200b")
+        | .[0:500])")
   | .[]' "${FINDINGS}" 2> /dev/null |
-  sed 's/<!--/<!\\-\\-/g')" || NEW_LINES=''
+  sed 's/<!--/<!\\-\\-/g')"; then
+  # The only remaining silent-exit path: a jq/sed failure here would leave
+  # NEW_LINES empty and read as "nothing new". Warn, per the header contract.
+  echo "::warning::could not build the deferred-findings lines; skipping this round"
+  exit 0
+fi
 [[ -n "${NEW_LINES}" ]] || exit 0
 # Cap in bash, loudly. Clipped items are NOT recoverable automatically: the
 # eval-watermark permanently filters this round's evaluated feedback out of
@@ -138,13 +154,17 @@ if [[ -z "${ISSUE_NUM}" || "${ISSUE_NUM}" == 'null' ]]; then
     -f body="${BODY}" --jq '.number' 2> /dev/null)"; then
     echo "🗂 deferred findings tracked in new issue #${NUM} (${KEPT} of ${TOTAL_NEW} new)"
   else
-    echo "::warning::could not create the deferred-findings issue for PR #${PR}; findings NOT persisted this round"
+    # Not "this round": the eval watermark filters this round's feedback out
+    # of every later round, so nothing retries. Name the lost items.
+    echo "::warning::could not create the deferred-findings issue for PR #${PR}; these findings are LOST (watermark-gated — no later round re-derives them). A maintainer should file them:"
+    printf '%s\n' "${NEW_LINES}"
   fi
 else
   if gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
     -f body="${NEW_LINES}" > /dev/null 2>&1; then
     echo "🗂 deferred findings appended to issue #${ISSUE_NUM} (${KEPT} of ${TOTAL_NEW} new)"
   else
-    echo "::warning::could not append to deferred-findings issue #${ISSUE_NUM}; findings NOT persisted this round"
+    echo "::warning::could not append to deferred-findings issue #${ISSUE_NUM}; these findings are LOST (watermark-gated — no later round re-derives them). A maintainer should add them:"
+    printf '%s\n' "${NEW_LINES}"
   fi
 fi

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -16,8 +16,21 @@ set -uo pipefail
 # reads the body plus the bot's own comments, anchored to the bullet form
 # "- rc:<id> " at line start (free-text mentions of an id do not count).
 
+# Defensive: a $GITHUB_ENV-planted SHELLOPTS=noclobber is imported by every
+# child bash and is read-only (no unset removes it), which would make the
+# KNOWN_FILE `>` redirect below fail and silently empty the dedupe corpus.
+# The workflow runs this via a clean `env -i` child (SHELLOPTS dropped), but
+# clear it here too so the script is safe under any caller.
+set +C
+
 FINDINGS="${WORKDIR}/deferred-findings.json"
 [[ -s "${FINDINGS}" ]] || exit 0
+
+# An empty array is the contract-valid "nothing to defer" rendering (SKILL
+# defines the file as a JSON array): a clean no-op, not a corruption alarm.
+if jq -e 'type == "array" and length == 0' "${FINDINGS}" > /dev/null 2>&1; then
+  exit 0
+fi
 
 # Shape gate: non-empty array; id numeric; reason string; path, when
 # present, a string (one malformed sibling must not drop the batch — it

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Upserts the round's verified-but-out-of-footprint findings into one
+# per-PR tracking issue. Invoked from the review-address report AND
+# failure/handoff paths (a failed round must not lose verified findings),
+# with WORKDIR/PR/REPO/AUTOFIX_BOT in env and the PAT on gh. Best-effort
+# throughout: every failure path warns and exits 0 — persistence must
+# never fail a round — but success is only LOGGED when the write call
+# actually succeeded.
+#
+# Durability design: the tracking issue's BODY is written once at
+# creation; every later round appends by POSTING A COMMENT — atomic and
+# append-only, so no read-modify-write can race a maintainer's edits and
+# a lost GET can never be mistaken for an empty history. Deduplication
+# reads the body plus all comments, anchored to the bullet form
+# "- rc:<id> " at line start (free-text mentions of an id do not count).
+
+FINDINGS="${WORKDIR}/deferred-findings.json"
+[[ -s "${FINDINGS}" ]] || exit 0
+
+# Shape gate: non-empty array; id numeric; reason string; path, when
+# present, a string (one malformed sibling must not drop the batch — it
+# fails the whole file loudly instead of being silently formatted away).
+if ! jq -e 'type == "array" and length > 0 and all(.[];
+    (.id | type == "number") and (.reason | type == "string")
+    and ((.path // "?") | type == "string"))' "${FINDINGS}" > /dev/null 2>&1; then
+  echo "::warning::deferred-findings.json is malformed; skipping the follow-up upsert"
+  exit 0
+fi
+
+MARKER="<!-- autofix-deferred pr=${PR} -->"
+
+# Locate the tracking issue with structured filtering: never a pull
+# request, marker matched against the real body (no line-joining), first
+# match wins. A lookup failure is a skip, not "no issue" — creating a
+# duplicate is worse than deferring persistence one round.
+if ! ISSUE_NUM="$(gh api "repos/${REPO}/issues?state=open&creator=${AUTOFIX_BOT}&per_page=100" \
+  --paginate 2> /dev/null |
+  jq -rs --arg m "${MARKER}" '
+    add // [] | map(select((.pull_request | not)
+      and ((.body // "") | contains($m)))) | (.[0].number // "") | tostring')"; then
+  echo "::warning::deferred-findings lookup failed; skipping the follow-up upsert this round"
+  exit 0
+fi
+
+KNOWN=''
+if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
+  # Known-id corpus = issue body + every comment. Any fetch failure skips
+  # the round: treating it as empty would re-append history (or, under
+  # the old PATCH design, erase it).
+  if ! BODY_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" --jq '.body // ""' 2> /dev/null)"; then
+    echo "::warning::could not read deferred-findings issue #${ISSUE_NUM}; skipping this round"
+    exit 0
+  fi
+  if ! COMMENT_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments?per_page=100" \
+    --paginate 2> /dev/null | jq -rs 'add // [] | map(.body // "") | join("\n")')"; then
+    echo "::warning::could not read deferred-findings comments on #${ISSUE_NUM}; skipping this round"
+    exit 0
+  fi
+  KNOWN="${BODY_TEXT}"$'\n'"${COMMENT_TEXT}"
+fi
+
+# Build this round's lines: intra-batch dedupe by id, drop ids the round
+# RESOLVED in code (a finding cannot be both implemented and outstanding),
+# drop ids already tracked (line-anchored), sanitize path and flatten
+# reason (both agent/branch-influenced), cap the batch. The marker
+# neutralization matches every other agent-derived publish site.
+RESOLVED_RAW=''
+[[ -f "${WORKDIR}/resolved-comments.txt" ]] && RESOLVED_RAW="$(cat "${WORKDIR}/resolved-comments.txt")"
+NEW_LINES="$(jq -r --arg known "${KNOWN}" --arg resolved "${RESOLVED_RAW}" '
+  ($resolved | split("\n")
+    | map(sub("^rc:"; "") | sub("\r$"; "")
+      | select(test("^[0-9]+$")) | tonumber)) as $done
+  | ($known | split("\n")) as $klines
+  | unique_by(.id)
+  | map(.id as $id
+    | select(($done | index($id)) | not)
+    | select(($klines | any(test("^- rc:" + ($id | tostring) + " "))) | not)
+    | "- rc:\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason | gsub("[\r\n]+"; " ") | .[0:500])")
+  | .[0:20] | .[]' "${FINDINGS}" 2> /dev/null |
+  sed 's/<!--/<!\\-\\-/g')" || NEW_LINES=''
+[[ -n "${NEW_LINES}" ]] || exit 0
+
+if [[ -z "${ISSUE_NUM}" || "${ISSUE_NUM}" == 'null' ]]; then
+  BODY="${MARKER}"$'\n\n'"Verified review findings from PR #${PR} whose fixes lie outside that PR's footprint, deferred by the autofix loop for follow-up. A maintainer can turn any item into its own issue/PR (or apply the ready-for-agent flow) — nothing here is scheduled automatically."$'\n\n'"${NEW_LINES}"
+  if NUM="$(gh api "repos/${REPO}/issues" \
+    -f title="Deferred review findings from PR #${PR}" \
+    -f body="${BODY}" --jq '.number' 2> /dev/null)"; then
+    echo "🗂 deferred findings tracked in new issue #${NUM}"
+  else
+    echo "::warning::could not create the deferred-findings issue for PR #${PR}; findings NOT persisted this round"
+  fi
+else
+  if gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" \
+    -f body="${NEW_LINES}" > /dev/null 2>&1; then
+    echo "🗂 deferred findings appended to issue #${ISSUE_NUM}"
+  else
+    echo "::warning::could not append to deferred-findings issue #${ISSUE_NUM}; findings NOT persisted this round"
+  fi
+fi

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -23,6 +23,14 @@ set -uo pipefail
 # clear it here too so the script is safe under any caller.
 set +C
 
+# `jq -e` without -s evaluates each document of a multi-document file in turn
+# and its exit status reflects only the LAST one, so a second document can
+# hide findings from these gates or smuggle them past. Require exactly one.
+single_doc() {
+  local n
+  n="$(jq -s 'length' "$1" 2> /dev/null)" || return 1
+  [[ "${n}" == '1' ]]
+}
 FINDINGS="${WORKDIR}/deferred-findings.json"
 # Both temp files are released by ONE EXIT trap: a later `trap ... EXIT`
 # would replace an earlier one and leak the first file.
@@ -80,7 +88,20 @@ lost() {
   dump_file "${CARRY}"
 }
 
-if [[ -s "${CARRY}" ]]; then
+# A bad OWN file is a total abort; a bad CARRY only costs the carry — the
+# same asymmetry the merge-failure path settled on, because this round's
+# verified findings must not go down with a corrupt sidecar.
+if [[ -s "${FINDINGS}" ]] && ! single_doc "${FINDINGS}"; then
+  lost "this round's deferred findings are not a single JSON document"
+  exit 0
+fi
+CARRY_SKIP=''
+if [[ -s "${CARRY}" ]] && ! single_doc "${CARRY}"; then
+  echo "::warning::the carried deferrals are not a single JSON document; persisting only this round's. The carried set is LOST — raw content follows:"
+  dump_file "${CARRY}"
+  CARRY_SKIP=1
+fi
+if [[ -s "${CARRY}" && -z "${CARRY_SKIP}" ]]; then
   if [[ -s "${FINDINGS}" ]]; then
     if ! MERGED="$(mktemp)"; then
       lost 'could not create a temp file to merge the carried deferrals'
@@ -89,7 +110,10 @@ if [[ -s "${CARRY}" ]]; then
     # This round FIRST: jq's unique_by keeps the first element of each group
     # in original order, so a finding re-emitted by run 2 wins over run 1's
     # carried copy. Swapping these two arguments silently pins the stale text.
-    if jq -s 'add' "${FINDINGS}" "${CARRY}" > "${MERGED}" 2> /dev/null; then
+    # Both inputs must BE arrays: `add` on two non-arrays yields whatever
+    # they add to (or null), which the gate would then judge on its own.
+    if jq -se 'if (map(type == "array") | all) then add else empty end' \
+      "${FINDINGS}" "${CARRY}" > "${MERGED}" 2> /dev/null; then
       FINDINGS="${MERGED}"
     else
       echo "::warning::could not merge this round's deferrals with the carried sidecar (one of the two is unparseable); persisting only this round's. The carried set is LOST — raw content follows:"
@@ -236,7 +260,9 @@ fi
 # the exact failure the note below describes — passing it as --arg left the
 # same hole this script already closed once.
 RESOLVED_FILE="${WORKDIR}/resolved-comments.txt"
-if [[ ! -f "${RESOLVED_FILE}" ]]; then
+# -f/-r, not just presence: a directory or FIFO planted at this path is
+# "there" but unusable as a corpus, and jq --rawfile would fail or block.
+if [[ ! -f "${RESOLVED_FILE}" || ! -r "${RESOLVED_FILE}" ]]; then
   if ! RESOLVED_FILE="$(mktemp)"; then
     lost 'could not create a temp file for the resolved-id corpus'
     exit 0

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -246,25 +246,45 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLV
        else "rc" end) as $pfx
     | select(($src != "review_comment") or (($done | index($id)) | not))
     | {src: $src, id: $id,
+       # The path charset filter already excludes `<`, so the comment opener
+       # cannot survive there; the reason is escaped explicitly below.
        line: "- \($pfx):\($id) `\(.path // "?" | gsub("[^A-Za-z0-9._/ -]"; "?") | .[0:200])`: \(.reason
         | gsub("[\r\n]+"; " ")
         | gsub("&(?<ent>#0*(?:64|[xX]0*40);|commat;)"; "&amp;\(.ent)")
         | gsub("@"; "@\u200b")
+        # Escape the comment opener HERE, not in a sed after the corpus
+        # comparison: the rv/ic identity IS the rendered line, so comparing a
+        # raw rendering against the escaped stored form never matches and
+        # re-publishes the finding every round.
+        | gsub("<!--"; "<!\\-\\-")
         | .[0:500])",
-       anchor: ("^- " + $pfx + ":" + ($id | tostring) + " ")})
+       anchor: ("^- " + $pfx + ":" + ($id | tostring) + " ")}
+    # Identity key for the multi-finding sources. NOT the exact line: a
+    # reworded re-emission (the repair flow re-runs the agent, so this is
+    # routine) would publish a permanent duplicate. NOT the id either — that
+    # is what silently ate sibling findings. So: id plus a normalized digest
+    # of path+reason — case-folded, punctuation-collapsed, capped — which
+    # absorbs whitespace and phrasing churn while keeping genuinely distinct
+    # findings apart. Erring toward a visible duplicate over a silent loss.
+    | . + {key: ((.line | ascii_downcase | gsub("[^a-z0-9]+"; " ")
+        | gsub("^ +| +$"; "") | .[0:160]))})
   # An inline comment is one finding, so its id IS the identity (and the
   # anchor keeps working across rounds). A review body or an issue-level
   # comment can raise SEVERAL findings under one id, so there the identity —
   # and the corpus check — is the rendered line itself; keying those on the
   # id alone silently ate every sibling but the first.
-  | unique_by(if .src == "review_comment" then [.src, .id] else [.src, .id, .line] end)
+  | unique_by(if .src == "review_comment" then [.src, .id] else [.src, .id, .key] end)
   | map(. as $r
     | select(if $r.src == "review_comment"
         then ($klines | any(test($r.anchor))) | not
-        else ($klines | index($r.line)) == null end)
+        # Corpus check on the same normalized key, so a reworded sibling of an
+        # already-tracked finding is recognised as tracked.
+        else ($klines
+          | map(ascii_downcase | gsub("[^a-z0-9]+"; " ")
+            | gsub("^ +| +$"; "") | .[0:160])
+          | index($r.key)) == null end)
     | $r.line)
-  | .[]' "${FINDINGS}" 2> /dev/null |
-  sed 's/<!--/<!\\-\\-/g')"; then
+  | .[]' "${FINDINGS}" 2> /dev/null)"; then
   # The only remaining silent-exit path: a jq/sed failure here would leave
   # NEW_LINES empty and read as "nothing new". Warn, per the header contract.
   lost 'could not build the deferred-findings lines'

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -32,11 +32,18 @@ if jq -e 'type == "array" and length == 0' "${FINDINGS}" > /dev/null 2>&1; then
   exit 0
 fi
 
-# Shape gate: non-empty array; id numeric; reason string; path, when
-# present, a string (one malformed sibling must not drop the batch — it
-# fails the whole file loudly instead of being silently formatted away).
+# Shape gate: non-empty array; id a positive integer that renders as PLAIN
+# digits; reason string; path, when present, a string (one malformed sibling
+# must not drop the batch — it fails the whole file loudly instead of being
+# silently formatted away). The `tostring | test("^[0-9]+$")` belt rejects
+# integer-valued floats that jq renders in scientific notation past 2^53
+# (e.g. 1e21 -> "1e+21"): the "+" is a regex-active byte in the line-anchored
+# dedupe below and never index-matches an integer resolved id. Comment ids
+# are ~10 digits, far under the bound.
 if ! jq -e 'type == "array" and length > 0 and all(.[];
-    (.id | type == "number" and . == floor and . > 0) and (.reason | type == "string")
+    (.id | type == "number" and . == floor and . > 0 and . < 9007199254740992
+      and (tostring | test("^[0-9]+$")))
+    and (.reason | type == "string")
     and ((.path // "?") | type == "string"))' "${FINDINGS}" > /dev/null 2>&1; then
   echo "::warning::deferred-findings.json is malformed; skipping the follow-up upsert"
   exit 0
@@ -57,7 +64,13 @@ if ! ISSUE_NUM="$(gh api "repos/${REPO}/issues?state=all&creator=${AUTOFIX_BOT}&
   exit 0
 fi
 
-KNOWN_FILE="$(mktemp)"
+if ! KNOWN_FILE="$(mktemp)"; then
+  # A silent exit here would violate the header contract (every failure
+  # warns) and is exactly when visibility matters — /tmp exhaustion is a
+  # known CI state.
+  echo "::warning::could not create a temp file for the deferred-findings corpus; skipping this round"
+  exit 0
+fi
 trap 'rm -f "${KNOWN_FILE}"' EXIT
 if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
   # Known-id corpus = issue body + every comment. Any fetch failure skips
@@ -102,12 +115,17 @@ NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLVED_RA
   | .[]' "${FINDINGS}" 2> /dev/null |
   sed 's/<!--/<!\\-\\-/g')" || NEW_LINES=''
 [[ -n "${NEW_LINES}" ]] || exit 0
-# Cap in bash, loudly: clipped items are never retried (the workdir is
-# deleted at job end), so a silent clip would read as full persistence.
+# Cap in bash, loudly. Clipped items are NOT recoverable automatically: the
+# eval-watermark permanently filters this round's evaluated feedback out of
+# every later round, so the agent never re-derives the clipped ids. The
+# warning names them for a maintainer to persist by hand (or raise the cap);
+# it must not imply a later round will re-defer them.
 TOTAL_NEW="$(printf '%s\n' "${NEW_LINES}" | wc -l)"
 if (( TOTAL_NEW > 20 )); then
+  DROPPED="$(printf '%s\n' "${NEW_LINES}" | tail -n +21)"
   NEW_LINES="$(printf '%s\n' "${NEW_LINES}" | head -n 20)"
-  echo "::warning::deferred-findings cap: persisting 20 of ${TOTAL_NEW} new findings; the remaining $(( TOTAL_NEW - 20 )) are NOT persisted (re-defer them in a later round)"
+  echo "::warning::deferred-findings cap: persisting 20 of ${TOTAL_NEW} new findings; the remaining $(( TOTAL_NEW - 20 )) will NOT be re-evaluated (watermark-gated) — a maintainer should persist them or raise the cap. Dropped:"
+  printf '%s\n' "${DROPPED}"
   KEPT=20
 else
   KEPT="${TOTAL_NEW}"

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -13,7 +13,7 @@ set -uo pipefail
 # creation; every later round appends by POSTING A COMMENT — atomic and
 # append-only, so no read-modify-write can race a maintainer's edits and
 # a lost GET can never be mistaken for an empty history. Deduplication
-# reads the body plus all comments, anchored to the bullet form
+# reads the body plus the bot's own comments, anchored to the bullet form
 # "- rc:<id> " at line start (free-text mentions of an id do not count).
 
 FINDINGS="${WORKDIR}/deferred-findings.json"
@@ -54,8 +54,12 @@ if [[ -n "${ISSUE_NUM}" && "${ISSUE_NUM}" != 'null' ]]; then
     echo "::warning::could not read deferred-findings issue #${ISSUE_NUM}; skipping this round"
     exit 0
   fi
+  # Bot-authored comments only: the tracking issue is public, and an
+  # arbitrary commenter posting a line-start "- rc:<id> " bullet must not
+  # be able to permanently suppress a deferred finding from the corpus.
   if ! COMMENT_TEXT="$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments?per_page=100" \
-    --paginate 2> /dev/null | jq -rs 'add // [] | map(.body // "") | join("\n")')"; then
+    --paginate 2> /dev/null | jq -rs --arg bot "${AUTOFIX_BOT}" \
+      'add // [] | map(select((.user.login // "") == $bot) | .body // "") | join("\n")')"; then
     echo "::warning::could not read deferred-findings comments on #${ISSUE_NUM}; skipping this round"
     exit 0
   fi

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -29,7 +29,8 @@ FINDINGS="${WORKDIR}/deferred-findings.json"
 MERGED=''
 KNOWN_FILE=''
 GH_ERR=''
-trap 'rm -f "${MERGED}" "${KNOWN_FILE}" "${GH_ERR}"' EXIT
+EMPTY_RESOLVED=''
+trap 'rm -f "${MERGED}" "${KNOWN_FILE}" "${GH_ERR}" "${EMPTY_RESOLVED}"' EXIT
 # Every gh call writes its stderr here so the warnings can NAME the cause:
 # a rate limit, an expired/rotated PAT, a transport error and a 404 are
 # indistinguishable when stderr goes to /dev/null, and these warnings are
@@ -230,8 +231,18 @@ fi
 # drop ids already tracked (line-anchored), sanitize path and flatten
 # reason (both agent/branch-influenced), cap the batch. The marker
 # neutralization matches every other agent-derived publish site.
-RESOLVED_RAW=''
-[[ -f "${WORKDIR}/resolved-comments.txt" ]] && RESOLVED_RAW="$(cat "${WORKDIR}/resolved-comments.txt")"
+# --rawfile for BOTH corpora, not just `known`: resolved-comments.txt grows
+# with the round's resolutions and one argv element caps at MAX_ARG_STRLEN,
+# the exact failure the note below describes — passing it as --arg left the
+# same hole this script already closed once.
+RESOLVED_FILE="${WORKDIR}/resolved-comments.txt"
+if [[ ! -f "${RESOLVED_FILE}" ]]; then
+  if ! RESOLVED_FILE="$(mktemp)"; then
+    lost 'could not create a temp file for the resolved-id corpus'
+    exit 0
+  fi
+  EMPTY_RESOLVED="${RESOLVED_FILE}"
+fi
 # --rawfile, not --arg: a large corpus in one argv element hits Linux
 # MAX_ARG_STRLEN and the exec failure would be swallowed into a silent
 # "nothing new" exit.
@@ -242,7 +253,7 @@ RESOLVED_RAW=''
 # &#0064; &commat;) get their `&` escaped — both measured inert against the
 # real renderer; `\@` and bare entity-escaping are NOT. Paths are already
 # reduced to a safe charset (no `@` survives).
-if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLVED_RAW}" '
+if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --rawfile resolved "${RESOLVED_FILE}" '
   # Identity for the multi-finding sources. LOSSLESS on content: only case
   # and PUNCTUATION are normalized, so the tolerance for rewording survives
   # while every letter of every script does too. The earlier form stripped

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -50,6 +50,9 @@ gh_err_reset() { [[ -n "${GH_ERR}" ]] && : > "${GH_ERR}"; }
 # moves run 1's deferrals to this sidecar so they are not lost when run 2
 # writes its own file. Both are unioned below (the line builder dedupes).
 CARRY="${WORKDIR}/deferred-findings.carry.json"
+# This round's own file, kept under its own name: FINDINGS is repointed at the
+# merged set below, and the shape gate needs a valid fallback to retry with.
+OWN_FINDINGS="${WORKDIR}/deferred-findings.json"
 
 # Every abort below is PERMANENT for these findings: the eval watermark
 # filters this round's feedback out of every later round, and the next run's
@@ -58,20 +61,22 @@ CARRY="${WORKDIR}/deferred-findings.carry.json"
 # `::` is neutralized in the dump: the content is agent-influenced and a
 # raw `::` at line start would be parsed as a workflow command (same reason
 # `<!--` is neutralized at every publish site).
+dump_file() {
+  [[ -s "$1" ]] || return 0
+  local size
+  size="$(wc -c < "$1" 2> /dev/null | tr -d ' ')"
+  if [[ -n "${size}" ]] && (( size > 4000 )); then
+    echo "--- $1 (first 4000 of ${size} bytes — TRUNCATED; the full file is in this run's artifact dump)"
+  else
+    echo "--- $1"
+  fi
+  head -c 4000 "$1" | sed 's/::/;;/g'
+  echo
+}
 lost() {
   echo "::warning::$1 — these findings are LOST (watermark-gated — no later round re-derives them). Raw deferrals follow for manual recovery:"
-  for f in "${FINDINGS}" "${CARRY}"; do
-    [[ -s "${f}" ]] || continue
-    local size
-    size="$(wc -c < "${f}" 2> /dev/null | tr -d ' ')"
-    if [[ -n "${size}" ]] && (( size > 4000 )); then
-      echo "--- ${f} (first 4000 of ${size} bytes — TRUNCATED; the full file is in this run's artifact dump)"
-    else
-      echo "--- ${f}"
-    fi
-    head -c 4000 "${f}" | sed 's/::/;;/g'
-    echo
-  done
+  dump_file "${FINDINGS}"
+  dump_file "${CARRY}"
 }
 
 if [[ -s "${CARRY}" ]]; then
@@ -80,17 +85,14 @@ if [[ -s "${CARRY}" ]]; then
       lost 'could not create a temp file to merge the carried deferrals'
       exit 0
     fi
+    # This round FIRST: jq's unique_by keeps the first element of each group
+    # in original order, so a finding re-emitted by run 2 wins over run 1's
+    # carried copy. Swapping these two arguments silently pins the stale text.
     if jq -s 'add' "${FINDINGS}" "${CARRY}" > "${MERGED}" 2> /dev/null; then
       FINDINGS="${MERGED}"
     else
-      CARRY_SIZE="$(wc -c < "${CARRY}" 2> /dev/null | tr -d ' ')"
-      if [[ -n "${CARRY_SIZE}" ]] && (( CARRY_SIZE > 4000 )); then
-        echo "::warning::could not merge the carried deferrals; persisting only this round's. The carried set follows, TRUNCATED at 4000 of ${CARRY_SIZE} bytes (full file in the artifact dump):"
-      else
-        echo "::warning::could not merge the carried deferrals; persisting only this round's (the carried ones are dumped below)"
-      fi
-      head -c 4000 "${CARRY}" | sed 's/::/;;/g'
-      echo
+      echo "::warning::could not merge the carried deferrals; persisting only this round's. The carried set is LOST — raw content follows:"
+      dump_file "${CARRY}"
     fi
   else
     FINDINGS="${CARRY}"
@@ -112,19 +114,33 @@ fi
 # (e.g. 1e21 -> "1e+21"): the "+" is a regex-active byte in the line-anchored
 # dedupe below and never index-matches an integer resolved id. Comment ids
 # are ~10 digits, far under the bound.
-if ! jq -e 'type == "array" and length > 0 and all(.[];
+shape_ok() {
+  jq -e 'type == "array" and length > 0 and all(.[];
     (.id | type == "number" and . == floor and . > 0 and . < 9007199254740992
       and (tostring | test("^[0-9]+$")))
     and (.reason | type == "string")
     and ((.source | type) as $t | $t == "null"
       or ($t == "string"
         and (.source | IN("review_comment", "review", "issue_comment"))))
-    and (.path | type | . == "null" or . == "string"))' "${FINDINGS}" > /dev/null 2>&1; then
+    and (.path | type | . == "null" or . == "string"))' "$1" > /dev/null 2>&1
+}
+if ! shape_ok "${FINDINGS}"; then
+  # A carried sidecar that parses but fails the gate must not take THIS
+  # round's valid deferrals down with it — the unparseable-carry branch above
+  # already persists this round only, and this is the same situation one step
+  # later. Retry with this round's own file when the merged set is the one at
+  # fault.
+  if [[ "${FINDINGS}" != "${OWN_FINDINGS}" ]] && shape_ok "${OWN_FINDINGS}"; then
+    echo "::warning::the carried deferrals are malformed; persisting only this round's. The carried set is LOST — raw content follows:"
+    dump_file "${CARRY}"
+    FINDINGS="${OWN_FINDINGS}"
+  else
   # `.path | type` (not `.path // "?"`): `//` treats false as absent, so a
   # present-but-non-string `false` would otherwise be coerced to "?" against
   # this gate's own "fail loudly" contract.
-  lost 'deferred findings are malformed (this round and/or the carried sidecar)'
-  exit 0
+    lost 'deferred findings are malformed (this round and/or the carried sidecar)'
+    exit 0
+  fi
 fi
 
 MARKER="<!-- autofix-deferred pr=${PR} -->"

--- a/.github/scripts/upsert-deferred-issue.sh
+++ b/.github/scripts/upsert-deferred-issue.sh
@@ -91,7 +91,7 @@ if [[ -s "${CARRY}" ]]; then
     if jq -s 'add' "${FINDINGS}" "${CARRY}" > "${MERGED}" 2> /dev/null; then
       FINDINGS="${MERGED}"
     else
-      echo "::warning::could not merge the carried deferrals; persisting only this round's. The carried set is LOST — raw content follows:"
+      echo "::warning::could not merge this round's deferrals with the carried sidecar (one of the two is unparseable); persisting only this round's. The carried set is LOST — raw content follows:"
       dump_file "${CARRY}"
     fi
   else
@@ -144,6 +144,7 @@ if ! shape_ok "${FINDINGS}"; then
 fi
 
 MARKER="<!-- autofix-deferred pr=${PR} -->"
+TITLE="Deferred review findings from PR #${PR}"
 
 # Locate the tracking issue with structured filtering: never a pull
 # request, marker matched against the real body (no line-joining), first
@@ -165,9 +166,16 @@ while (( lookup_page <= LOOKUP_MAX_PAGES )); do
     lost "the tracking-issue lookup failed on page ${lookup_page} ($(gh_reason))"
     exit 0
   fi
-  HIT="$(jq -r --arg m "${MARKER}" '
-    map(select((.pull_request | not)
-      and ((.body // "") | contains($m)))) | (.[0].number // "") | tostring' \
+  # Two identity anchors: the body marker first, the derived title as a
+  # fallback. The marker lives on the one surface maintainers are invited to
+  # edit, so an edit that drops it would orphan the issue and the next round
+  # would open a duplicate; the title is derived, never authored.
+  HIT="$(jq -r --arg m "${MARKER}" --arg t "${TITLE}" '
+    (map(select((.pull_request | not)
+      and ((.body // "") | contains($m)))) | .[0].number)
+    // (map(select((.pull_request | not)
+      and ((.title // "") == $t))) | .[0].number)
+    // "" | tostring' \
     <<< "${PAGE_JSON}" 2> /dev/null)" || HIT=''
   if [[ -n "${HIT}" && "${HIT}" != 'null' ]]; then
     ISSUE_NUM="${HIT}"
@@ -235,6 +243,16 @@ RESOLVED_RAW=''
 # real renderer; `\@` and bare entity-escaping are NOT. Paths are already
 # reduced to a safe charset (no `@` survives).
 if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLVED_RAW}" '
+  # Identity for the multi-finding sources. LOSSLESS on content: only case
+  # and PUNCTUATION are normalized, so the tolerance for rewording survives
+  # while every letter of every script does too. The earlier form stripped
+  # all non-[a-z0-9] bytes and capped at 160 chars, which silently merged
+  # CJK siblings (this repo is bilingual) and, on a long path, cut the
+  # reason out of the identity altogether — silent loss, the one outcome
+  # this feature exists to prevent.
+  def normkey:
+    ascii_downcase | gsub("[[:punct:]]+"; " ") | gsub("\\s+"; " ")
+    | sub("^ "; "") | sub(" $"; "");
   ($resolved | split("\n")
     | map(sub("^rc:"; "") | sub("\r$"; "")
       | select(test("^[0-9]+$")) | tonumber)) as $done
@@ -266,8 +284,7 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLV
     # of path+reason — case-folded, punctuation-collapsed, capped — which
     # absorbs whitespace and phrasing churn while keeping genuinely distinct
     # findings apart. Erring toward a visible duplicate over a silent loss.
-    | . + {key: ((.line | ascii_downcase | gsub("[^a-z0-9]+"; " ")
-        | gsub("^ +| +$"; "") | .[0:160]))})
+    | . + {key: (.line | normkey)})
   # An inline comment is one finding, so its id IS the identity (and the
   # anchor keeps working across rounds). A review body or an issue-level
   # comment can raise SEVERAL findings under one id, so there the identity —
@@ -279,10 +296,7 @@ if ! NEW_LINES="$(jq -r --rawfile known "${KNOWN_FILE}" --arg resolved "${RESOLV
         then ($klines | any(test($r.anchor))) | not
         # Corpus check on the same normalized key, so a reworded sibling of an
         # already-tracked finding is recognised as tracked.
-        else ($klines
-          | map(ascii_downcase | gsub("[^a-z0-9]+"; " ")
-            | gsub("^ +| +$"; "") | .[0:160])
-          | index($r.key)) == null end)
+        else ($klines | map(normkey) | index($r.key)) == null end)
     | $r.line)
   | .[]' "${FINDINGS}" 2> /dev/null)"; then
   # The only remaining silent-exit path: a jq/sed failure here would leave
@@ -311,7 +325,7 @@ if [[ -z "${ISSUE_NUM}" || "${ISSUE_NUM}" == 'null' ]]; then
   BODY="${MARKER}"$'\n\n'"Verified review findings from PR #${PR} whose fixes lie outside that PR's footprint, deferred by the autofix loop for follow-up. A maintainer can turn any item into its own issue/PR (or apply the ready-for-agent flow) — nothing here is scheduled automatically."$'\n\n'"${NEW_LINES}"
   gh_err_reset
   if NUM="$(gh api "repos/${REPO}/issues" \
-    -f title="Deferred review findings from PR #${PR}" \
+    -f title="${TITLE}" \
     -f body="${BODY}" --jq '.number' 2> "${GH_ERR:-/dev/null}")"; then
     echo "🗂 deferred findings tracked in new issue #${NUM} (${KEPT} of ${TOTAL_NEW} new)"
   else

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5351,8 +5351,11 @@ jobs:
           # unions in; merge if a previous repair already left one.
           if [[ -s "${WORKDIR}/deferred-findings.json" ]]; then
             if [[ -s "${WORKDIR}/deferred-findings.carry.json" ]]; then
-              if jq -s 'add' "${WORKDIR}/deferred-findings.carry.json" \
-                "${WORKDIR}/deferred-findings.json" \
+              # This round FIRST: unique_by keeps first-of-group in original
+              # order, so a finding re-emitted with fresher text wins — the
+              # same precedence the upsert script documents for its own union.
+              if jq -s 'add' "${WORKDIR}/deferred-findings.json" \
+                "${WORKDIR}/deferred-findings.carry.json" \
                 > "${WORKDIR}/deferred-findings.carry.next" 2> /dev/null; then
                 mv "${WORKDIR}/deferred-findings.carry.next" \
                   "${WORKDIR}/deferred-findings.carry.json"
@@ -5783,7 +5786,7 @@ jobs:
                 fi
                 export GH_CONFIG_DIR
                 bash -c "${UPSERT_SRC}" ||
-                  echo "::warning::deferred-findings upsert failed; continuing"
+                  echo "__upsert_trusted__::warning::deferred-findings upsert failed; continuing"
               ' > /dev/null 2>&1 ; } 3>&1 )" || true
             # INSPECTION uses bash builtins only ([[ ]], read, printf — no
             # exec): under loader trace mode every external binary, grep
@@ -6780,7 +6783,7 @@ jobs:
                     exit 0
                   fi
                   bash -c "${UPSERT_SRC}" ||
-                    echo "::warning::deferred-findings upsert failed; continuing"
+                    echo "__upsert_trusted__::warning::deferred-findings upsert failed; continuing"
                 ' > /dev/null 2>&1 ; } 3>&1 )" || true
               # Builtin-only inspection, same rationale as the twin.
               if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5690,7 +5690,13 @@ jobs:
             # GH_CONFIG_DIR. RUNNER_TEMP stays agent-writable between staging
             # and here, so the digest is verified INSIDE the child; a
             # mismatch skips persistence, never the round.
-            /usr/bin/env -i \
+            # LD_* is the one channel env -i cannot block: ld.so maps a
+            # planted library into /usr/bin/env ITSELF at execve, before -i
+            # runs. Neutralize it with a command-prefix assignment (pure
+            # shell parameter assignment — no function/alias lookup, so no
+            # BASH_FUNC can shadow it — applied to env's own environment).
+            LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+              /usr/bin/env -i \
               PATH="${TRUSTED_PATH}" \
               GITHUB_TOKEN="${GITHUB_TOKEN}" \
               GH_HOST=github.com \
@@ -6659,7 +6665,11 @@ jobs:
               # gate, the PAT bot-identity check (POST_HANDOFF's own check is
               # skipped on the fixed/noop-outcome path that also reaches here)
               # and the staged script all run in a clean allow-listed shell.
-              /usr/bin/env -i \
+              # LD_* is the one channel env -i cannot block (ld.so preloads
+              # into /usr/bin/env itself at execve): neutralize it with a
+              # command-prefix assignment, unshadowable by any BASH_FUNC.
+              LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+                /usr/bin/env -i \
                 PATH="${TRUSTED_PATH}" \
                 GITHUB_TOKEN="${GITHUB_TOKEN}" \
                 GH_HOST=github.com \

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3970,7 +3970,6 @@ jobs:
           cp .github/scripts/check-autofix-contracts.sh "${RUNNER_TEMP}/check-autofix-contracts.sh"
           cp .github/scripts/resolve-owning-packages.sh "${RUNNER_TEMP}/resolve-owning-packages.sh"
           cp .github/scripts/run-autofix-review-verification.sh "${RUNNER_TEMP}/run-autofix-review-verification.sh"
-          cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"
           cp .github/scripts/resanitize-git-config.sh "${RUNNER_TEMP}/resanitize-git-config.sh"
           # The staged copies' trusted-base provenance holds at cp time only:
           # RUNNER_TEMP is writable by the branch/agent code later steps run
@@ -3985,7 +3984,17 @@ jobs:
           # gate itself).
           echo "resanitize_sha256=$(sha256sum "${RUNNER_TEMP}/resanitize-git-config.sh" | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
           echo "verify_runner_sha256=$(sha256sum "${RUNNER_TEMP}/run-autofix-review-verification.sh" | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
-          echo "upsert_sha256=$(sha256sum "${RUNNER_TEMP}/upsert-deferred-issue.sh" | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
+          # The upsert script travels as CONTENT, not as a staged copy: it
+          # runs in a clean child that reads it from this expression-context
+          # output, so there is no agent-writable copy to protect and no
+          # digest to verify. The delimiter is random per run, so script text
+          # cannot close the heredoc.
+          _upsert_delim="EOF_$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+          {
+            echo "upsert_src<<${_upsert_delim}"
+            cat .github/scripts/upsert-deferred-issue.sh
+            echo "${_upsert_delim}"
+          } >> "${GITHUB_OUTPUT}"
           echo "trusted_path=${PATH}" >> "${GITHUB_OUTPUT}"
           # The agent step runs AFTER prepare checks out the PR branch, so
           # invoking the runner from the working tree would execute
@@ -5510,7 +5519,7 @@ jobs:
           CHECKED_OUT_HEAD: '${{ steps.prepare.outputs.checked_out_head }}'
           VERIFIED_HEAD: '${{ steps.final_verify.outputs.verified_head }}'
           RESANITIZE_SHA256: '${{ steps.stage.outputs.resanitize_sha256 }}'
-          UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'
+          UPSERT_SRC: '${{ steps.stage.outputs.upsert_src }}'
           TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
           # Growth-brake baseline: written into this window's FIRST report
           # comment only (growth_base_new), so later rounds' first-wins parse
@@ -5720,63 +5729,35 @@ jobs:
               echo "🧵 replied on ${REPLIED_N} thread(s) the agent left open"
             fi
           }
-          # Deferred-findings persistence, shared by both arms below (the
-          # pasted twin diverged once already in review). Verify the staged
-          # copy's digest (recorded in expression context at stage time)
-          # before executing: RUNNER_TEMP is writable by the branch/agent
-          # code that ran in between. Best-effort like the upsert itself —
-          # a mismatch skips persistence, never the round.
+          # Deferred-findings persistence, shared by both arms below.
+          #
+          # No agent-writable path takes part in this. The script CONTENT
+          # travels in expression context — captured at stage time from the
+          # trusted checkout — so there is no staged copy to verify, and with
+          # it go the digest gate, its check-then-use window, and the
+          # planted-FIFO/huge-file reads that a path-based read invites. The
+          # child's own messages travel on fd 3, which the parent captures,
+          # while fd 1/2 are discarded; every loader side channel (auxv dumps,
+          # ldd traces, whatever is next) writes there and cannot reach the
+          # parsed output, and there is no log file to plant, race or bound.
+          #
+          # /usr/bin/env is invoked by ABSOLUTE PATH: bash never does
+          # function/alias lookup on a slash-bearing word, so a planted
+          # BASH_FUNC_env%% cannot intercept the bootstrap. `-i` then drops
+          # every BASH_FUNC_* import, BASH_ENV, SHELLOPTS, alias and trap.
+          # LD_* is the one family env -i cannot block (ld.so acts while
+          # loading env itself), so the ones that MATTER are cleared by
+          # command-prefix assignment and the rest are caught by verifying the
+          # RESULT: the child prints a liveness sentinel first, and its
+          # absence — trace mode, exec failure, a missing interpreter — is
+          # reported rather than passing silently for a successful round.
           run_deferred_upsert() {
-            # Sound isolation, not an in-shell denylist. /usr/bin/env is
-            # invoked by ABSOLUTE PATH: bash never does function/alias lookup
-            # on a slash-bearing word, so a $GITHUB_ENV-planted
-            # BASH_FUNC_env%% cannot intercept it. `-i` then drops every
-            # BASH_FUNC_* import, BASH_ENV, SHELLOPTS, sourced aliases and
-            # traps, so the digest gate and the staged script run in a shell
-            # with only the allow-listed vars below — a clean namespace an
-            # in-shell sweep could never bootstrap from the tainted one. PATH
-            # is the trusted staged value; the child mints its own throwaway
-            # GH_CONFIG_DIR. RUNNER_TEMP stays agent-writable between staging
-            # and here, so the digest is verified INSIDE the child; a
-            # mismatch skips persistence, never the round.
-            # LD_* is the one channel env -i cannot block: ld.so maps a
-            # planted library into /usr/bin/env ITSELF at execve, before -i
-            # runs. Neutralize it with a command-prefix assignment (pure
-            # shell parameter assignment — no function/alias lookup, so no
-            # BASH_FUNC can shadow it — applied to env's own environment).
-            # Enumerating LD_* names cannot be complete: LD_TRACE_LOADED_OBJECTS
-            # and LD_SHOW_AUXV are presence-tested, so even an empty assignment
-            # leaves them ON (measured). Two structural answers instead of a
-            # longer list. (1) SEPARATE THE STREAMS: every loader side channel
-            # writes to the launch process's own stdout, so that stdout is
-            # discarded and the child writes its messages to a private log —
-            # auxv dumps and ldd traces cannot reach the parsed output, with no
-            # content filter to get wrong. (2) VERIFY THE RESULT: the child's
-            # first act is a liveness sentinel, and its absence — trace mode,
-            # exec failure, a missing interpreter — is reported rather than
-            # passing silently for a successful persistence.
-            # The staged script is read ONCE and executed from those exact
-            # bytes: a check-then-use gate (hash the path, then re-open it to
-            # run) loses to a rename(2) between the two opens on this
-            # agent-writable path.
-            # Path from a plain expansion and read back with bash's $(<file)
-            # builtin — no fork on either side. A planted loader channel makes
-            # every EXTERNAL command in this (parent) shell print to stdout, so
-            # $(mktemp) / $(cat) would return that noise inside the value.
-            UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"
-            # This step runs under `bash -eo pipefail`. A watcher can
-            # pre-plant this predictable path, and `rm -f` on a DIRECTORY
-            # exits 1 — fatal — while `-rf` clears any planted shape.
-            # Creating under `set -C` then refuses to follow a symlink
-            # planted between the two, and a creation failure warns
-            # instead of killing the round.
-            rm -rf "${UPSERT_LOG}" 2> /dev/null || true
-            if ! (set -C; : > "${UPSERT_LOG}") 2> /dev/null; then
-              echo '::warning::could not create the upsert log file; deferred findings NOT persisted this round'
-              UPSERT_LOG=''
+            if [[ -z "${UPSERT_SRC:-}" ]]; then
+              # Stage never ran: nothing was deferred either.
+              echo 'deferred-findings upsert skipped: stage step never ran'
+              return 0
             fi
-            if [[ -n "${UPSERT_LOG}" ]]; then
-            LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+            UPSERT_OUT="$( { LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
               LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
               /usr/bin/env -i \
               PATH="${TRUSTED_PATH}" \
@@ -5787,53 +5768,32 @@ jobs:
               PR="${PR}" \
               REPO="${REPO}" \
               AUTOFIX_BOT="${AUTOFIX_BOT}" \
-              UPSERT_SHA256="${UPSERT_SHA256}" \
-              UPSERT_LOG="${UPSERT_LOG}" \
+              UPSERT_SRC="${UPSERT_SRC}" \
               bash --norc -c '
                 set -uo pipefail
-                exec > "${UPSERT_LOG}" 2>&1
+                exec >&3
                 printf "%s\n" "__upsert_child_live__"
                 if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
                   echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
                   exit 0
                 fi
                 export GH_CONFIG_DIR
-                UPSERT_SRC="$(cat "${RUNNER_TEMP}/upsert-deferred-issue.sh"; printf x)"
-                UPSERT_SRC="${UPSERT_SRC%x}"
-                if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then
-                  echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
-                  exit 0
-                fi
                 bash -c "${UPSERT_SRC}" ||
                   echo "::warning::deferred-findings upsert failed; continuing"
-              ' > /dev/null 2>&1 || true
-            # `$(<missing)` is FATAL under -e and neither `|| true` nor
-            # `if !` rescues it (measured), so the file is TESTED first.
-            # Still fork-free: a planted loader channel makes every
-            # external command in this shell print to stdout, so
-            # $(cat …) would carry that noise into the value.
-            UPSERT_OUT=''
-            if [[ -f "${UPSERT_LOG}" && -r "${UPSERT_LOG}" ]]; then
-              UPSERT_OUT="$(<"${UPSERT_LOG}")"
-            fi
-            rm -rf "${UPSERT_LOG}" 2> /dev/null || true
+              ' > /dev/null 2>&1 ; } 3>&1 )" || true
             # INSPECTION uses bash builtins only ([[ ]], read, printf — no
-            # exec; the surrounding setup does run rm/mktemp, which is fine):
-            # under loader trace mode every external binary, grep included,
-            # would itself print-and-exit-0, so a grep-based check would be
-            # neutered by the very condition it is meant to detect.
+            # exec): under loader trace mode every external binary, grep
+            # included, would itself print-and-exit-0, so a grep-based check
+            # would be neutered by the very condition it must detect.
             if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then
               echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"
             fi
-            # The log lives in agent-writable RUNNER_TEMP, so a line-start
-            # `::` reaching this step's stdout would be a workflow command.
-            # Neutralized with the same parameter expansion the rest of the
-            # feature uses a sed for — builtin, no fork.
+            # The child's output is agent-reachable content, so a line-start
+            # `::` is neutralized before it reaches this step's stdout.
             while IFS= read -r _upsert_line; do
               [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
                 printf '%s\n' "${_upsert_line//::/;;}"
             done <<< "${UPSERT_OUT}"
-            fi
           }
 
                     # Take this PAT-bearing step off every mutable host git surface —
@@ -6231,7 +6191,7 @@ jobs:
           GROWTH_TEST: '${{ steps.prepare.outputs.growth_test }}'
           CRITICAL_ONLY_GROWTH: '${{ steps.prepare.outputs.critical_only_growth }}'
           GROWTH_BASE_WIN: '${{ steps.prepare.outputs.growth_base_win }}'
-          UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'
+          UPSERT_SRC: '${{ steps.stage.outputs.upsert_src }}'
           TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
         run: |-
           # NOTE: the deferred-findings upsert below runs its digest gate,
@@ -6770,42 +6730,16 @@ jobs:
           # push loop's exit paths), this block is the only persistence
           # route left.
           if [[ "${DRY_RUN}" != "true" && "${STALE:-}" != "true" && -n "${GITHUB_TOKEN:-}" ]]; then
-            if [[ -z "${UPSERT_SHA256:-}" ]]; then
-              # Stage never ran (pre-stage failure): no staged copy exists
-              # and nothing was deferred — a digest "mismatch" here would be
-              # a false tamper alarm, not a signal.
+            if [[ -z "${UPSERT_SRC:-}" ]]; then
+              # Stage never ran (pre-stage failure): nothing was deferred.
               echo 'deferred-findings upsert skipped: stage step never ran'
             else
-              # Sound isolation, same rationale as run_deferred_upsert in
-              # 'Push and report': /usr/bin/env (absolute path — unshadowable
-              # by a planted BASH_FUNC_env%%) with -i drops every BASH_FUNC_*
-              # import, BASH_ENV, SHELLOPTS, alias and trap, so the digest
-              # gate, the PAT bot-identity check (POST_HANDOFF's own check is
-              # skipped on the fixed/noop-outcome path that also reaches here)
-              # and the staged script all run in a clean allow-listed shell.
-              # LD_* enumeration cannot be complete — LD_TRACE_LOADED_OBJECTS and
-              # LD_SHOW_AUXV are presence-tested, so an empty assignment leaves
-              # them ON (measured). Same two structural answers as the twin:
-              # the launch's stdout (where every loader side channel writes) is
-              # discarded while the child logs to a private file, and the
-              # child's liveness is VERIFIED by a sentinel. The staged script is
-              # read ONCE and run from those exact bytes, so a rename(2) between
-              # a hash-the-path check and a re-open cannot swap the payload.
-              # Fork-free path + read-back, same rationale as the twin.
-              UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"
-              # This step runs under `bash -eo pipefail`. A watcher can
-              # pre-plant this predictable path, and `rm -f` on a DIRECTORY
-              # exits 1 — fatal — while `-rf` clears any planted shape.
-              # Creating under `set -C` then refuses to follow a symlink
-              # planted between the two, and a creation failure warns
-              # instead of killing the round.
-              rm -rf "${UPSERT_LOG}" 2> /dev/null || true
-              if ! (set -C; : > "${UPSERT_LOG}") 2> /dev/null; then
-                echo '::warning::could not create the upsert log file; deferred findings NOT persisted this round'
-                UPSERT_LOG=''
-              fi
-              if [[ -n "${UPSERT_LOG}" ]]; then
-              LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+              # Same shape as run_deferred_upsert in 'Push and report' — no
+              # agent-writable path, content from expression context, child
+              # messages on fd 3 — plus the PAT bot-identity check, because
+              # POST_HANDOFF's own check is skipped on the fixed/noop-outcome
+              # path that also reaches here.
+              UPSERT_OUT="$( { LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
               LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
                 /usr/bin/env -i \
                 PATH="${TRUSTED_PATH}" \
@@ -6816,23 +6750,16 @@ jobs:
                 PR="${PR}" \
                 REPO="${REPO}" \
                 AUTOFIX_BOT="${AUTOFIX_BOT}" \
-                UPSERT_SHA256="${UPSERT_SHA256}" \
-                UPSERT_LOG="${UPSERT_LOG}" \
+                UPSERT_SRC="${UPSERT_SRC}" \
                 bash --norc -c '
                   set -uo pipefail
-                  exec > "${UPSERT_LOG}" 2>&1
+                  exec >&3
                   printf "%s\n" "__upsert_child_live__"
                   if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
                     echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
                     exit 0
                   fi
                   export GH_CONFIG_DIR
-                  UPSERT_SRC="$(cat "${RUNNER_TEMP}/upsert-deferred-issue.sh"; printf x)"
-                  UPSERT_SRC="${UPSERT_SRC%x}"
-                  if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then
-                    echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
-                    exit 0
-                  fi
                   UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq .login 2> /dev/null || true)"
                   if [[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
                     echo "::warning::CI_DEV_BOT_PAT identity check failed for the deferred-findings upsert (got ${UPSERT_ACTOR:-none}); NOT persisted this round"
@@ -6840,27 +6767,15 @@ jobs:
                   fi
                   bash -c "${UPSERT_SRC}" ||
                     echo "::warning::deferred-findings upsert failed; continuing"
-                ' > /dev/null 2>&1 || true
-              # `$(<missing)` is FATAL under -e and neither `|| true` nor
-              # `if !` rescues it (measured), so the file is TESTED first.
-              # Still fork-free: a planted loader channel makes every
-              # external command in this shell print to stdout, so
-              # $(cat …) would carry that noise into the value.
-              UPSERT_OUT=''
-              if [[ -f "${UPSERT_LOG}" && -r "${UPSERT_LOG}" ]]; then
-                UPSERT_OUT="$(<"${UPSERT_LOG}")"
-              fi
-              rm -rf "${UPSERT_LOG}" 2> /dev/null || true
+                ' > /dev/null 2>&1 ; } 3>&1 )" || true
               # Builtin-only inspection, same rationale as the twin.
               if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then
                 echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"
               fi
-              # Same neutralization as the twin: the log is agent-reachable.
               while IFS= read -r _upsert_line; do
                 [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
                   printf '%s\n' "${_upsert_line//::/;;}"
               done <<< "${UPSERT_OUT}"
-              fi
             fi
           fi
 

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5349,7 +5349,12 @@ jobs:
                 # nothing re-derives it, so print it before deleting. `::` is
                 # neutralized because the content is agent-written and a raw
                 # `::` at line start would be parsed as a workflow command.
-                echo '::warning::could not merge carried deferrals across the repair; keeping the earlier set. This run'"'"'s deferrals are LOST — raw content follows for manual recovery:'
+                _dfsize="$(wc -c < "${WORKDIR}/deferred-findings.json" 2> /dev/null | tr -d ' ')"
+                if [[ -n "${_dfsize}" ]] && (( _dfsize > 4000 )); then
+                  echo "::warning::could not merge carried deferrals across the repair; keeping the earlier set. This run's deferrals are LOST — raw content follows, TRUNCATED at 4000 of ${_dfsize} bytes (the full file is in this run's artifact dump):"
+                else
+                  echo "::warning::could not merge carried deferrals across the repair; keeping the earlier set. This run's deferrals are LOST — raw content follows for manual recovery:"
+                fi
                 head -c 4000 "${WORKDIR}/deferred-findings.json" | sed 's/::/;;/g'
                 echo
                 rm -f "${WORKDIR}/deferred-findings.carry.next"
@@ -5746,8 +5751,18 @@ jobs:
             # every EXTERNAL command in this (parent) shell print to stdout, so
             # $(mktemp) / $(cat) would return that noise inside the value.
             UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"
-            rm -f "${UPSERT_LOG}"
-            : > "${UPSERT_LOG}"
+            # This step runs under `bash -eo pipefail`. A watcher can
+            # pre-plant this predictable path, and `rm -f` on a DIRECTORY
+            # exits 1 — fatal — while `-rf` clears any planted shape.
+            # Creating under `set -C` then refuses to follow a symlink
+            # planted between the two, and a creation failure warns
+            # instead of killing the round.
+            rm -rf "${UPSERT_LOG}" 2> /dev/null || true
+            if ! (set -C; : > "${UPSERT_LOG}") 2> /dev/null; then
+              echo '::warning::could not create the upsert log file; deferred findings NOT persisted this round'
+              UPSERT_LOG=''
+            fi
+            if [[ -n "${UPSERT_LOG}" ]]; then
             LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
               LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
               /usr/bin/env -i \
@@ -5779,8 +5794,16 @@ jobs:
                 bash -c "${UPSERT_SRC}" ||
                   echo "::warning::deferred-findings upsert failed; continuing"
               ' > /dev/null 2>&1 || true
-            UPSERT_OUT="$(<"${UPSERT_LOG}")"
-            rm -f "${UPSERT_LOG}"
+            # `$(<missing)` is FATAL under -e and neither `|| true` nor
+            # `if !` rescues it (measured), so the file is TESTED first.
+            # Still fork-free: a planted loader channel makes every
+            # external command in this shell print to stdout, so
+            # $(cat …) would carry that noise into the value.
+            UPSERT_OUT=''
+            if [[ -f "${UPSERT_LOG}" && -r "${UPSERT_LOG}" ]]; then
+              UPSERT_OUT="$(<"${UPSERT_LOG}")"
+            fi
+            rm -rf "${UPSERT_LOG}" 2> /dev/null || true
             # Inspect with bash BUILTINS only ([[ ]], read, printf — no exec):
             # under loader trace mode every external binary, grep included,
             # would itself print-and-exit-0, so a grep-based check would be
@@ -5788,10 +5811,15 @@ jobs:
             if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then
               echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"
             fi
+            # The log lives in agent-writable RUNNER_TEMP, so a line-start
+            # `::` reaching this step's stdout would be a workflow command.
+            # Neutralized with the same parameter expansion the rest of the
+            # feature uses a sed for — builtin, no fork.
             while IFS= read -r _upsert_line; do
               [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
-                printf '%s\n' "${_upsert_line}"
+                printf '%s\n' "${_upsert_line//::/;;}"
             done <<< "${UPSERT_OUT}"
+            fi
           }
 
                     # Take this PAT-bearing step off every mutable host git surface —
@@ -6751,8 +6779,18 @@ jobs:
               # a hash-the-path check and a re-open cannot swap the payload.
               # Fork-free path + read-back, same rationale as the twin.
               UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"
-              rm -f "${UPSERT_LOG}"
-              : > "${UPSERT_LOG}"
+              # This step runs under `bash -eo pipefail`. A watcher can
+              # pre-plant this predictable path, and `rm -f` on a DIRECTORY
+              # exits 1 — fatal — while `-rf` clears any planted shape.
+              # Creating under `set -C` then refuses to follow a symlink
+              # planted between the two, and a creation failure warns
+              # instead of killing the round.
+              rm -rf "${UPSERT_LOG}" 2> /dev/null || true
+              if ! (set -C; : > "${UPSERT_LOG}") 2> /dev/null; then
+                echo '::warning::could not create the upsert log file; deferred findings NOT persisted this round'
+                UPSERT_LOG=''
+              fi
+              if [[ -n "${UPSERT_LOG}" ]]; then
               LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
               LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
                 /usr/bin/env -i \
@@ -6789,16 +6827,26 @@ jobs:
                   bash -c "${UPSERT_SRC}" ||
                     echo "::warning::deferred-findings upsert failed; continuing"
                 ' > /dev/null 2>&1 || true
-              UPSERT_OUT="$(<"${UPSERT_LOG}")"
-              rm -f "${UPSERT_LOG}"
+              # `$(<missing)` is FATAL under -e and neither `|| true` nor
+              # `if !` rescues it (measured), so the file is TESTED first.
+              # Still fork-free: a planted loader channel makes every
+              # external command in this shell print to stdout, so
+              # $(cat …) would carry that noise into the value.
+              UPSERT_OUT=''
+              if [[ -f "${UPSERT_LOG}" && -r "${UPSERT_LOG}" ]]; then
+                UPSERT_OUT="$(<"${UPSERT_LOG}")"
+              fi
+              rm -rf "${UPSERT_LOG}" 2> /dev/null || true
               # Builtin-only inspection, same rationale as the twin.
               if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then
                 echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"
               fi
+              # Same neutralization as the twin: the log is agent-reachable.
               while IFS= read -r _upsert_line; do
                 [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
-                  printf '%s\n' "${_upsert_line}"
+                  printf '%s\n' "${_upsert_line//::/;;}"
               done <<< "${UPSERT_OUT}"
+              fi
             fi
           fi
 

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5778,7 +5778,7 @@ jobs:
                 exec >&3
                 printf "%s\n" "__upsert_child_live__"
                 if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
-                  echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
+                  echo "__upsert_trusted__::warning::could not create a gh config dir; deferred findings NOT persisted this round"
                   exit 0
                 fi
                 export GH_CONFIG_DIR
@@ -5795,8 +5795,16 @@ jobs:
             # The child's output is agent-reachable content, so a line-start
             # `::` is neutralized before it reaches this step's stdout.
             while IFS= read -r _upsert_line; do
-              [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
+              # Wrapper-authored lines carry a marker and are emitted
+              # VERBATIM so they still render as GitHub annotations; the
+              # script's own output is agent-reachable and stays neutralized.
+              if [[ "${_upsert_line}" == '__upsert_child_live__' ]]; then
+                :
+              elif [[ "${_upsert_line}" == __upsert_trusted__* ]]; then
+                printf '%s\n' "${_upsert_line#__upsert_trusted__}"
+              else
                 printf '%s\n' "${_upsert_line//::/;;}"
+              fi
             done <<< "${UPSERT_OUT}"
           }
 
@@ -6762,13 +6770,13 @@ jobs:
                   exec >&3
                   printf "%s\n" "__upsert_child_live__"
                   if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
-                    echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
+                    echo "__upsert_trusted__::warning::could not create a gh config dir; deferred findings NOT persisted this round"
                     exit 0
                   fi
                   export GH_CONFIG_DIR
                   UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq .login 2> /dev/null || true)"
                   if [[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
-                    echo "::warning::CI_DEV_BOT_PAT identity check failed for the deferred-findings upsert (got ${UPSERT_ACTOR:-none}); NOT persisted this round"
+                    echo "__upsert_trusted__::warning::CI_DEV_BOT_PAT identity check failed for the deferred-findings upsert (got ${UPSERT_ACTOR:-none}); NOT persisted this round"
                     exit 0
                   fi
                   bash -c "${UPSERT_SRC}" ||
@@ -6779,8 +6787,13 @@ jobs:
                 echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"
               fi
               while IFS= read -r _upsert_line; do
-                [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
+                if [[ "${_upsert_line}" == '__upsert_child_live__' ]]; then
+                  :
+                elif [[ "${_upsert_line}" == __upsert_trusted__* ]]; then
+                  printf '%s\n' "${_upsert_line#__upsert_trusted__}"
+                else
                   printf '%s\n' "${_upsert_line//::/;;}"
+                fi
               done <<< "${UPSERT_OUT}"
             fi
           fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1657,27 +1657,6 @@ jobs:
           # reroutes no sweep here touches. mktemp -d gives an
           # unpredictable path a watcher cannot pre-seed.
           export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
-          # Two more $GITHUB_ENV-plantable channel families no sweep above
-          # touches: bash startup (BASH_ENV is sourced at every child-bash
-          # start; BASH_FUNC_*%% exported functions are imported by child
-          # bash and outrank PATH lookup) and gh-side transport (proxy env
-          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
-          # PAT-bearing HTTPS calls — the git twins are swept in the
-          # hermetic preamble).
-          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
-            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
-          while IFS='=' read -r _envname _; do
-            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
-              _fn="${_envname#BASH_FUNC_}"
-              unset -f "${_fn%\%\%}" 2> /dev/null || true
-            fi
-          done < <(env)
-          # A planted BASH_ENV was already sourced at THIS shell's startup
-          # (nothing in-step undoes arbitrary in-shell tampering), so also
-          # de-shadow the gate-critical names it could have redefined as
-          # plain functions and re-resolve them from the pinned PATH.
-          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
-          hash -r
           MODEL_DISPLAY="${MODEL:-default}"
           if [[ -z "${GITHUB_TOKEN}" ]]; then
             echo '::error::CI_DEV_BOT_PAT is required to publish the PR as the autofix bot.'
@@ -4168,27 +4147,6 @@ jobs:
           # reroutes no sweep here touches. mktemp -d gives an
           # unpredictable path a watcher cannot pre-seed.
           export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
-          # Two more $GITHUB_ENV-plantable channel families no sweep above
-          # touches: bash startup (BASH_ENV is sourced at every child-bash
-          # start; BASH_FUNC_*%% exported functions are imported by child
-          # bash and outrank PATH lookup) and gh-side transport (proxy env
-          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
-          # PAT-bearing HTTPS calls — the git twins are swept in the
-          # hermetic preamble).
-          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
-            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
-          while IFS='=' read -r _envname _; do
-            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
-              _fn="${_envname#BASH_FUNC_}"
-              unset -f "${_fn%\%\%}" 2> /dev/null || true
-            fi
-          done < <(env)
-          # A planted BASH_ENV was already sourced at THIS shell's startup
-          # (nothing in-step undoes arbitrary in-shell tampering), so also
-          # de-shadow the gate-critical names it could have redefined as
-          # plain functions and re-resolve them from the pinned PATH.
-          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
-          hash -r
           # This PAT-bearing step runs git (status/restore/fetch/checkout and a
           # push preflight) on the shared host BEFORE the agent/gate, so it
           # takes the same hermetic preamble the push steps do — the contract
@@ -5536,27 +5494,6 @@ jobs:
           # reroutes no sweep here touches. mktemp -d gives an
           # unpredictable path a watcher cannot pre-seed.
           export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
-          # Two more $GITHUB_ENV-plantable channel families no sweep above
-          # touches: bash startup (BASH_ENV is sourced at every child-bash
-          # start; BASH_FUNC_*%% exported functions are imported by child
-          # bash and outrank PATH lookup) and gh-side transport (proxy env
-          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
-          # PAT-bearing HTTPS calls — the git twins are swept in the
-          # hermetic preamble).
-          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
-            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
-          while IFS='=' read -r _envname _; do
-            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
-              _fn="${_envname#BASH_FUNC_}"
-              unset -f "${_fn%\%\%}" 2> /dev/null || true
-            fi
-          done < <(env)
-          # A planted BASH_ENV was already sourced at THIS shell's startup
-          # (nothing in-step undoes arbitrary in-shell tampering), so also
-          # de-shadow the gate-critical names it could have redefined as
-          # plain functions and re-resolve them from the pinned PATH.
-          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
-          hash -r
           # The head the agent actually evaluated — captured in prepare before
           # any mutation, not the report-time remote head (which can move
           # during the run). Empty when prepare exited early, which matches
@@ -5741,12 +5678,38 @@ jobs:
           # code that ran in between. Best-effort like the upsert itself —
           # a mismatch skips persistence, never the round.
           run_deferred_upsert() {
-            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
-              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
-                echo "::warning::deferred-findings upsert failed; continuing"
-            else
-              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
-            fi
+            # Sound isolation, not an in-shell denylist. /usr/bin/env is
+            # invoked by ABSOLUTE PATH: bash never does function/alias lookup
+            # on a slash-bearing word, so a $GITHUB_ENV-planted
+            # BASH_FUNC_env%% cannot intercept it. `-i` then drops every
+            # BASH_FUNC_* import, BASH_ENV, SHELLOPTS, sourced aliases and
+            # traps, so the digest gate and the staged script run in a shell
+            # with only the allow-listed vars below — a clean namespace an
+            # in-shell sweep could never bootstrap from the tainted one. PATH
+            # is the trusted staged value; the child mints its own throwaway
+            # GH_CONFIG_DIR. RUNNER_TEMP stays agent-writable between staging
+            # and here, so the digest is verified INSIDE the child; a
+            # mismatch skips persistence, never the round.
+            /usr/bin/env -i \
+              PATH="${TRUSTED_PATH}" \
+              GITHUB_TOKEN="${GITHUB_TOKEN}" \
+              GH_HOST=github.com \
+              RUNNER_TEMP="${RUNNER_TEMP}" \
+              WORKDIR="${WORKDIR}" \
+              PR="${PR}" \
+              REPO="${REPO}" \
+              AUTOFIX_BOT="${AUTOFIX_BOT}" \
+              UPSERT_SHA256="${UPSERT_SHA256}" \
+              bash --norc -c '
+                set -uo pipefail
+                export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+                if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+                  echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
+                  exit 0
+                fi
+                bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                  echo "::warning::deferred-findings upsert failed; continuing"
+              ' || echo "::warning::deferred-findings upsert child failed to launch; continuing"
           }
 
                     # Take this PAT-bearing step off every mutable host git surface —
@@ -6147,45 +6110,14 @@ jobs:
           UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'
           TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
         run: |-
-          # Pin PATH to the staged trusted value (and drop the loader trio)
-          # before anything below runs: this step executes a staged script
-          # under a digest gate, and an ambient $GITHUB_ENV-planted
-          # PATH/LD_PRELOAD would defeat that gate (a swapped sha256sum or
-          # bash). Empty TRUSTED_PATH means stage never ran — then no staged
-          # copy exists either and the digest gate below skips explicitly.
-          if [[ -n "${TRUSTED_PATH:-}" ]]; then
-            export PATH="${TRUSTED_PATH}"
-          fi
-          unset LD_PRELOAD LD_AUDIT LD_LIBRARY_PATH
-          # gh has its own $GITHUB_ENV-injectable channels: pin the host, drop
-          # any planted token and point gh at a fresh config dir BEFORE the
-          # PAT-bearing gh calls below (handoff/report comment + deferred
-          # upsert) — this step runs after agent/branch code, same exposure as
-          # the workflow's other PAT-bearing gh sites.
-          export GH_HOST=github.com
-          unset GH_ENTERPRISE_TOKEN GH_TOKEN
-          export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
-          # Two more $GITHUB_ENV-plantable channel families no sweep above
-          # touches: bash startup (BASH_ENV is sourced at every child-bash
-          # start; BASH_FUNC_*%% exported functions are imported by child
-          # bash and outrank PATH lookup) and gh-side transport (proxy env
-          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
-          # PAT-bearing HTTPS calls — the git twins are swept in the
-          # hermetic preamble).
-          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
-            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
-          while IFS='=' read -r _envname _; do
-            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
-              _fn="${_envname#BASH_FUNC_}"
-              unset -f "${_fn%\%\%}" 2> /dev/null || true
-            fi
-          done < <(env)
-          # A planted BASH_ENV was already sourced at THIS shell's startup
-          # (nothing in-step undoes arbitrary in-shell tampering), so also
-          # de-shadow the gate-critical names it could have redefined as
-          # plain functions and re-resolve them from the pinned PATH.
-          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
-          hash -r
+          # NOTE: the deferred-findings upsert below runs its digest gate,
+          # PAT identity check and staged-script execution in a sound
+          # /usr/bin/env -i child (see the block near the end of this step),
+          # so this step body needs no in-shell hardening preamble for it.
+          # The handoff `gh pr comment` here is pre-existing surface at the
+          # workflow's baseline posture; hardening every pre-existing PAT gh
+          # call against BASH_FUNC/transport plants (via the same clean-child
+          # pattern) is tracked separately, out of this feature's scope.
           # The head the agent actually evaluated — captured in prepare before
           # any mutation, not the report-time remote head (which can move
           # during the run). Empty when prepare exited early, which matches
@@ -6719,20 +6651,39 @@ jobs:
               # and nothing was deferred — a digest "mismatch" here would be
               # a false tamper alarm, not a signal.
               echo 'deferred-findings upsert skipped: stage step never ran'
-            elif ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
-              # Same digest gate as the report-path invocations: RUNNER_TEMP
-              # is agent-writable, and this path runs after the agent too.
-              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
-            elif ! UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login' 2> /dev/null)" ||
-              [[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
-              # The POST_HANDOFF identity check above is skipped on the
-              # fixed/noop-outcome path through this step, so this PAT write
-              # site verifies the identity itself — warn+skip, not exit:
-              # persistence is best-effort.
-              echo "::warning::CI_DEV_BOT_PAT identity check failed for the deferred-findings upsert (got '${UPSERT_ACTOR:-}'); NOT persisted this round"
             else
-              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
-                echo "::warning::deferred-findings upsert failed; continuing"
+              # Sound isolation, same rationale as run_deferred_upsert in
+              # 'Push and report': /usr/bin/env (absolute path — unshadowable
+              # by a planted BASH_FUNC_env%%) with -i drops every BASH_FUNC_*
+              # import, BASH_ENV, SHELLOPTS, alias and trap, so the digest
+              # gate, the PAT bot-identity check (POST_HANDOFF's own check is
+              # skipped on the fixed/noop-outcome path that also reaches here)
+              # and the staged script all run in a clean allow-listed shell.
+              /usr/bin/env -i \
+                PATH="${TRUSTED_PATH}" \
+                GITHUB_TOKEN="${GITHUB_TOKEN}" \
+                GH_HOST=github.com \
+                RUNNER_TEMP="${RUNNER_TEMP}" \
+                WORKDIR="${WORKDIR}" \
+                PR="${PR}" \
+                REPO="${REPO}" \
+                AUTOFIX_BOT="${AUTOFIX_BOT}" \
+                UPSERT_SHA256="${UPSERT_SHA256}" \
+                bash --norc -c '
+                  set -uo pipefail
+                  export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+                  if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+                    echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
+                    exit 0
+                  fi
+                  UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq .login 2> /dev/null || true)"
+                  if [[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
+                    echo "::warning::CI_DEV_BOT_PAT identity check failed for the deferred-findings upsert (got ${UPSERT_ACTOR:-none}); NOT persisted this round"
+                    exit 0
+                  fi
+                  bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                    echo "::warning::deferred-findings upsert failed; continuing"
+                ' || echo "::warning::deferred-findings upsert child failed to launch; continuing"
             fi
           fi
 

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5343,7 +5343,15 @@ jobs:
                 > "${WORKDIR}/deferred-findings.carry.next" 2> /dev/null; then
                 mv "${WORKDIR}/deferred-findings.carry.next" \
                   "${WORKDIR}/deferred-findings.carry.json"
+                # Merged: this round's copy lives on inside the sidecar.
+                rm -f "${WORKDIR}/deferred-findings.json"
               else
+                # Which side is corrupt is NOT known here — jq -s fails if
+                # EITHER input is unparseable, and today's topology cannot
+                # even produce a pre-existing carry (WORKDIR is wiped at run
+                # start and there is exactly one repair step), so this branch
+                # is defensive. Say what is certain: the merge failed, the
+                # earlier set is kept, this round's is preserved unmerged.
                 # The only loss path in this feature without a raw dump: the
                 # newer set is discarded here and the eval watermark means
                 # nothing re-derives it, so print it before deleting. `::` is
@@ -5351,15 +5359,20 @@ jobs:
                 # `::` at line start would be parsed as a workflow command.
                 _dfsize="$(wc -c < "${WORKDIR}/deferred-findings.json" 2> /dev/null | tr -d ' ')"
                 if [[ -n "${_dfsize}" ]] && (( _dfsize > 4000 )); then
-                  echo "::warning::could not merge carried deferrals across the repair; keeping the earlier set. This run's deferrals are LOST — raw content follows, TRUNCATED at 4000 of ${_dfsize} bytes (the full file is in this run's artifact dump):"
+                  echo "::warning::could not merge carried deferrals across the repair (one of the two sets is unparseable); keeping the carried set and preserving this round's as deferred-findings.unmerged.json. Raw content follows, TRUNCATED at 4000 of ${_dfsize} bytes — the full file rides this run's artifact dump:"
                 else
-                  echo "::warning::could not merge carried deferrals across the repair; keeping the earlier set. This run's deferrals are LOST — raw content follows for manual recovery:"
+                  echo "::warning::could not merge carried deferrals across the repair (one of the two sets is unparseable); keeping the carried set and preserving this round's as deferred-findings.unmerged.json. Raw content follows:"
                 fi
                 head -c 4000 "${WORKDIR}/deferred-findings.json" | sed 's/::/;;/g'
                 echo
                 rm -f "${WORKDIR}/deferred-findings.carry.next"
+                # Keep the discarded set ON DISK so the warning's pointer at
+                # the artifact dump is true past the 4000-byte clip. Renamed,
+                # not left in place: the upsert would otherwise union it back
+                # in as if it had merged.
+                mv "${WORKDIR}/deferred-findings.json" \
+                  "${WORKDIR}/deferred-findings.unmerged.json"
               fi
-              rm -f "${WORKDIR}/deferred-findings.json"
             else
               mv "${WORKDIR}/deferred-findings.json" \
                 "${WORKDIR}/deferred-findings.carry.json"
@@ -5458,7 +5471,7 @@ jobs:
           if git rev-parse --verify "${BRANCH}" > /dev/null 2>&1; then
             git diff "origin/main...${BRANCH}" > "${WORKDIR}/pr.diff" || true
           fi
-          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md gate-advisories.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt comment-replies.json deferred-findings.json deferred-findings.carry.json pr.diff; do
+          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md gate-advisories.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt comment-replies.json deferred-findings.json deferred-findings.carry.json deferred-findings.unmerged.json pr.diff; do
             if [[ -f "${WORKDIR}/${f}" ]]; then
               echo "=============== ${f} ==============="
               # Agent-written content: a line-start `::` would be parsed as a
@@ -5804,7 +5817,8 @@ jobs:
               UPSERT_OUT="$(<"${UPSERT_LOG}")"
             fi
             rm -rf "${UPSERT_LOG}" 2> /dev/null || true
-            # Inspect with bash BUILTINS only ([[ ]], read, printf — no exec):
+            # INSPECTION uses bash builtins only ([[ ]], read, printf — no
+            # exec; the surrounding setup does run rm/mktemp, which is fine):
             # under loader trace mode every external binary, grep included,
             # would itself print-and-exit-0, so a grep-based check would be
             # neutered by the very condition it is meant to detect.

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -4881,7 +4881,7 @@ jobs:
                   or (((.user.login // "") != $rb) and (((.user.login // "") | IN($over[])) | not))
                   or (.state // "") == "CHANGES_REQUESTED"
                   or ((.body // "") | contains("**[Critical]**")))
-              | "- [\(.state)] @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
+              | "- [rv:\(.id)] [\(.state)] @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/rv.json"
             echo
             echo "## Inline comments"
@@ -4925,7 +4925,7 @@ jobs:
               | select(($critical_only | not)
                   or (((.user.login // "") != $rb) and (((.user.login // "") | IN($over[])) | not))
                   or ((.body // "") | contains("**[Critical]**")))
-              | "- @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
+              | "- [ic:\(.id)] @\(.user.login): \(.body // "" | gsub("\r"; ""))"' \
               "${WORKDIR}/ic.json"
             if [[ -s "${WORKDIR}/deferred-feedback.md" ]]; then
               echo
@@ -5330,8 +5330,29 @@ jobs:
             "${WORKDIR}/agent-api-error-kind" \
             "${WORKDIR}/agent-timeout" \
             "${WORKDIR}/resolved-comments.txt" \
-            "${WORKDIR}/deferred-findings.json" \
             "${WORKDIR}/comment-replies.json"
+          # NOT deleted with its siblings: run 2 writes its own
+          # deferred-findings.json, and a deferral dropped here is gone for
+          # good (the eval watermark filters this round's feedback out of
+          # every later round). Carry run 1's into a sidecar the upsert
+          # unions in; merge if a previous repair already left one.
+          if [[ -s "${WORKDIR}/deferred-findings.json" ]]; then
+            if [[ -s "${WORKDIR}/deferred-findings.carry.json" ]]; then
+              if jq -s 'add' "${WORKDIR}/deferred-findings.carry.json" \
+                "${WORKDIR}/deferred-findings.json" \
+                > "${WORKDIR}/deferred-findings.carry.next" 2> /dev/null; then
+                mv "${WORKDIR}/deferred-findings.carry.next" \
+                  "${WORKDIR}/deferred-findings.carry.json"
+              else
+                echo '::warning::could not merge carried deferrals across the repair; keeping the earlier set'
+                rm -f "${WORKDIR}/deferred-findings.carry.next"
+              fi
+              rm -f "${WORKDIR}/deferred-findings.json"
+            else
+              mv "${WORKDIR}/deferred-findings.json" \
+                "${WORKDIR}/deferred-findings.carry.json"
+            fi
+          fi
           rm -rf "${QWEN_HOME}"
           mkdir -p .qwen "${QWEN_HOME}"
           printf '%s\n' "${SETTINGS_JSON}" > .qwen/settings.json
@@ -5425,7 +5446,7 @@ jobs:
           if git rev-parse --verify "${BRANCH}" > /dev/null 2>&1; then
             git diff "origin/main...${BRANCH}" > "${WORKDIR}/pr.diff" || true
           fi
-          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md gate-advisories.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt comment-replies.json deferred-findings.json pr.diff; do
+          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md gate-advisories.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt comment-replies.json deferred-findings.json deferred-findings.carry.json pr.diff; do
             if [[ -f "${WORKDIR}/${f}" ]]; then
               echo "=============== ${f} ==============="
               cat "${WORKDIR}/${f}"
@@ -5703,6 +5724,7 @@ jobs:
             # mode, exec failure, a missing interpreter — is reported instead of
             # passing silently for a successful persistence.
             UPSERT_OUT="$(LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+              LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
               /usr/bin/env -i \
               PATH="${TRUSTED_PATH}" \
               GITHUB_TOKEN="${GITHUB_TOKEN}" \
@@ -6694,6 +6716,7 @@ jobs:
               # is VERIFIED via a sentinel rather than assumed — same shape as
               # run_deferred_upsert in 'Push and report'.
               UPSERT_OUT="$(LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+              LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
                 /usr/bin/env -i \
                 PATH="${TRUSTED_PATH}" \
                 GITHUB_TOKEN="${GITHUB_TOKEN}" \

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5695,7 +5695,14 @@ jobs:
             # runs. Neutralize it with a command-prefix assignment (pure
             # shell parameter assignment — no function/alias lookup, so no
             # BASH_FUNC can shadow it — applied to env's own environment).
-            LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+            # Enumerating LD_* names cannot be complete (LD_TRACE_LOADED_OBJECTS
+            # is presence-tested, so even an empty assignment still makes the
+            # loader print and exit 0 without ever running the child), so the
+            # result is VERIFIED instead: the child's first act is to print a
+            # liveness sentinel, and its absence — for any reason, loader trace
+            # mode, exec failure, a missing interpreter — is reported instead of
+            # passing silently for a successful persistence.
+            UPSERT_OUT="$(LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
               /usr/bin/env -i \
               PATH="${TRUSTED_PATH}" \
               GITHUB_TOKEN="${GITHUB_TOKEN}" \
@@ -5708,14 +5715,30 @@ jobs:
               UPSERT_SHA256="${UPSERT_SHA256}" \
               bash --norc -c '
                 set -uo pipefail
-                export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+                printf "%s\n" "__upsert_child_live__"
+                if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
+                  echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
+                  exit 0
+                fi
+                export GH_CONFIG_DIR
                 if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
                   echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
                   exit 0
                 fi
                 bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
                   echo "::warning::deferred-findings upsert failed; continuing"
-              ' || echo "::warning::deferred-findings upsert child failed to launch; continuing"
+              ' 2>&1)" || true
+            # Inspect with bash BUILTINS only ([[ ]], read, printf — no exec):
+            # under loader trace mode every external binary, grep included,
+            # would itself print-and-exit-0, so a grep-based check would be
+            # neutered by the very condition it is meant to detect.
+            if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then
+              echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"
+            fi
+            while IFS= read -r _upsert_line; do
+              [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
+                printf '%s\n' "${_upsert_line}"
+            done <<< "${UPSERT_OUT}"
           }
 
                     # Take this PAT-bearing step off every mutable host git surface —
@@ -6665,10 +6688,12 @@ jobs:
               # gate, the PAT bot-identity check (POST_HANDOFF's own check is
               # skipped on the fixed/noop-outcome path that also reaches here)
               # and the staged script all run in a clean allow-listed shell.
-              # LD_* is the one channel env -i cannot block (ld.so preloads
-              # into /usr/bin/env itself at execve): neutralize it with a
-              # command-prefix assignment, unshadowable by any BASH_FUNC.
-              LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+              # LD_* enumeration cannot be complete (LD_TRACE_LOADED_OBJECTS is
+              # presence-tested: even an empty assignment makes the loader print
+              # and exit 0 without running the child), so the child's liveness
+              # is VERIFIED via a sentinel rather than assumed — same shape as
+              # run_deferred_upsert in 'Push and report'.
+              UPSERT_OUT="$(LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
                 /usr/bin/env -i \
                 PATH="${TRUSTED_PATH}" \
                 GITHUB_TOKEN="${GITHUB_TOKEN}" \
@@ -6681,7 +6706,12 @@ jobs:
                 UPSERT_SHA256="${UPSERT_SHA256}" \
                 bash --norc -c '
                   set -uo pipefail
-                  export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+                  printf "%s\n" "__upsert_child_live__"
+                  if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
+                    echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
+                    exit 0
+                  fi
+                  export GH_CONFIG_DIR
                   if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
                     echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
                     exit 0
@@ -6693,7 +6723,15 @@ jobs:
                   fi
                   bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
                     echo "::warning::deferred-findings upsert failed; continuing"
-                ' || echo "::warning::deferred-findings upsert child failed to launch; continuing"
+                ' 2>&1)" || true
+              # Builtin-only inspection, same rationale as the twin.
+              if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then
+                echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"
+              fi
+              while IFS= read -r _upsert_line; do
+                [[ "${_upsert_line}" == '__upsert_child_live__' ]] ||
+                  printf '%s\n' "${_upsert_line}"
+              done <<< "${UPSERT_OUT}"
             fi
           fi
 

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3970,6 +3970,7 @@ jobs:
           cp .github/scripts/check-autofix-contracts.sh "${RUNNER_TEMP}/check-autofix-contracts.sh"
           cp .github/scripts/resolve-owning-packages.sh "${RUNNER_TEMP}/resolve-owning-packages.sh"
           cp .github/scripts/run-autofix-review-verification.sh "${RUNNER_TEMP}/run-autofix-review-verification.sh"
+          cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"
           cp .github/scripts/resanitize-git-config.sh "${RUNNER_TEMP}/resanitize-git-config.sh"
           # The staged copies' trusted-base provenance holds at cp time only:
           # RUNNER_TEMP is writable by the branch/agent code later steps run
@@ -5518,57 +5519,6 @@ jobs:
             exit 1
           fi
 
-          # Deferred-to-follow-up findings must SURVIVE the PR: a reason
-          # that lives only in a review thread dies at merge (nobody
-          # re-reads merged PRs' threads). The agent records verified but
-          # out-of-footprint findings in deferred-findings.json; this
-          # upserts them into one per-PR tracking issue, appending only ids
-          # not already listed. Best-effort: a failure here must never fail
-          # a good round. Deliberately NO ready-for-agent label — feeding
-          # the bot's own deferrals back into its issue queue is a human
-          # authorization, not a default.
-          upsert_deferred_issue() {
-            [[ -s "${WORKDIR}/deferred-findings.json" ]] || return 0
-            if ! jq -e 'type == "array" and length > 0 and all(.[];
-                (.id | type == "number") and (.reason | type == "string"))' \
-              "${WORKDIR}/deferred-findings.json" > /dev/null 2>&1; then
-              echo "::warning::deferred-findings.json is malformed; skipping the follow-up upsert"
-              return 0
-            fi
-            local marker existing_num existing_body new_lines body
-            marker="<!-- autofix-deferred pr=${PR} -->"
-            existing_num="$(gh api "repos/${REPO}/issues?state=open&creator=${AUTOFIX_BOT}&per_page=100" \
-              --paginate --jq '.[] | "\(.number)\t\(.body // "")"' 2> /dev/null |
-              awk -F'\t' -v m="${marker}" 'index($0, m) { print $1; exit }')" || existing_num=''
-            existing_body=''
-            if [[ -n "${existing_num}" ]]; then
-              existing_body="$(gh api "repos/${REPO}/issues/${existing_num}" --jq '.body // ""' 2> /dev/null)" || existing_body=''
-            fi
-            # Append only rc ids the issue does not already carry; item text
-            # is agent-authored, so it gets the same token-breaking
-            # neutralization as every other published agent output.
-            new_lines="$(jq -r --arg body "${existing_body}" '
-              .[] | .id as $id
-              | select(($body | contains("rc:" + ($id | tostring) + " ")) | not)
-              | "- rc:\($id) `\(.path // "?" | .[0:200])`: \(.reason | gsub("[\r\n]+"; " ") | .[0:500])"' \
-              "${WORKDIR}/deferred-findings.json" 2> /dev/null |
-              sed 's/<!--/<!\\-\\-/g')" || new_lines=''
-            [[ -n "${new_lines}" ]] || return 0
-            if [[ -n "${existing_num}" ]]; then
-              body="${existing_body}"$'\n'"${new_lines}"
-              gh api --method PATCH "repos/${REPO}/issues/${existing_num}" \
-                -f body="${body}" > /dev/null 2>&1 ||
-                echo "::warning::could not update the deferred-findings issue #${existing_num}"
-              echo "🗂 deferred findings appended to issue #${existing_num}"
-            else
-              body="${marker}"$'\n\n'"Verified review findings from PR #${PR} whose fixes lie outside that PR's footprint, deferred by the autofix loop for follow-up. A maintainer can turn any item into its own issue/PR (or apply the ready-for-agent flow) — nothing here is scheduled automatically."$'\n\n'"${new_lines}"
-              gh api "repos/${REPO}/issues" \
-                -f title="Deferred review findings from PR #${PR}" \
-                -f body="${body}" --jq '.number' 2> /dev/null ||
-                echo "::warning::could not create the deferred-findings issue for PR #${PR}"
-            fi
-          }
-
           # Shared by the pushed and no-op outcomes: a no-op round may
           # resolve re-verified findings (verified_head is the unchanged,
           # previously verified origin head) and must post its declines'
@@ -5873,7 +5823,11 @@ jobs:
               fi
             done
             resolve_and_reply_threads
-            upsert_deferred_issue
+            # Best-effort: verified out-of-footprint findings persist into
+            # the per-PR tracking issue (trusted staged copy; append-only
+            # comment design — see the script).
+            bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+              echo "::warning::deferred-findings upsert failed; continuing"
             {
               echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on: · 已处理最新评审反馈（第 ${NEXT_ROUND}/${MAX_ROUNDS} 轮）。改动内容与我反驳保留之处如下："
               echo
@@ -5927,7 +5881,11 @@ jobs:
             # origin head; resolution's own live-head guards still apply.
             PUSH_RACE_MERGED='false'
             resolve_and_reply_threads
-            upsert_deferred_issue
+            # Best-effort: verified out-of-footprint findings persist into
+            # the per-PR tracking issue (trusted staged copy; append-only
+            # comment design — see the script).
+            bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+              echo "::warning::deferred-findings upsert failed; continuing"
             # noop: evaluated, nothing worth doing. Report once and advance the
             # watermark so the next scan does not re-evaluate the same feedback.
             {
@@ -6629,6 +6587,13 @@ jobs:
               fi
             } > "${WORKDIR}/report.md"
             gh pr comment "${PR}" --repo "${REPO}" --body-file "${WORKDIR}/report.md" || echo "::warning::Failed to post handoff comment on PR #${PR}"
+          fi
+          # A failed round must not lose verified deferred findings: the
+          # agent's analysis is independent of whether this round's commit
+          # survived verification. Same guards as the handoff itself.
+          if [[ "${DRY_RUN}" != "true" && "${STALE:-}" != "true" && -n "${GITHUB_TOKEN:-}" ]]; then
+            bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+              echo "::warning::deferred-findings upsert failed; continuing"
           fi
 
       # Flip the status comment out of "working" so a finished round never

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5456,7 +5456,10 @@ jobs:
           for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md gate-advisories.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt comment-replies.json deferred-findings.json deferred-findings.carry.json pr.diff; do
             if [[ -f "${WORKDIR}/${f}" ]]; then
               echo "=============== ${f} ==============="
-              cat "${WORKDIR}/${f}"
+              # Agent-written content: a line-start `::` would be parsed as a
+              # workflow command (::error::, ::add-mask::), the same reason
+              # every other echo of these files neutralizes it.
+              sed 's/::/;;/g' "${WORKDIR}/${f}"
               echo
             fi
           done
@@ -5723,14 +5726,29 @@ jobs:
             # runs. Neutralize it with a command-prefix assignment (pure
             # shell parameter assignment — no function/alias lookup, so no
             # BASH_FUNC can shadow it — applied to env's own environment).
-            # Enumerating LD_* names cannot be complete (LD_TRACE_LOADED_OBJECTS
-            # is presence-tested, so even an empty assignment still makes the
-            # loader print and exit 0 without ever running the child), so the
-            # result is VERIFIED instead: the child's first act is to print a
-            # liveness sentinel, and its absence — for any reason, loader trace
-            # mode, exec failure, a missing interpreter — is reported instead of
+            # Enumerating LD_* names cannot be complete: LD_TRACE_LOADED_OBJECTS
+            # and LD_SHOW_AUXV are presence-tested, so even an empty assignment
+            # leaves them ON (measured). Two structural answers instead of a
+            # longer list. (1) SEPARATE THE STREAMS: every loader side channel
+            # writes to the launch process's own stdout, so that stdout is
+            # discarded and the child writes its messages to a private log —
+            # auxv dumps and ldd traces cannot reach the parsed output, with no
+            # content filter to get wrong. (2) VERIFY THE RESULT: the child's
+            # first act is a liveness sentinel, and its absence — trace mode,
+            # exec failure, a missing interpreter — is reported rather than
             # passing silently for a successful persistence.
-            UPSERT_OUT="$(LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+            # The staged script is read ONCE and executed from those exact
+            # bytes: a check-then-use gate (hash the path, then re-open it to
+            # run) loses to a rename(2) between the two opens on this
+            # agent-writable path.
+            # Path from a plain expansion and read back with bash's $(<file)
+            # builtin — no fork on either side. A planted loader channel makes
+            # every EXTERNAL command in this (parent) shell print to stdout, so
+            # $(mktemp) / $(cat) would return that noise inside the value.
+            UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"
+            rm -f "${UPSERT_LOG}"
+            : > "${UPSERT_LOG}"
+            LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
               LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
               /usr/bin/env -i \
               PATH="${TRUSTED_PATH}" \
@@ -5742,21 +5760,27 @@ jobs:
               REPO="${REPO}" \
               AUTOFIX_BOT="${AUTOFIX_BOT}" \
               UPSERT_SHA256="${UPSERT_SHA256}" \
+              UPSERT_LOG="${UPSERT_LOG}" \
               bash --norc -c '
                 set -uo pipefail
+                exec > "${UPSERT_LOG}" 2>&1
                 printf "%s\n" "__upsert_child_live__"
                 if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
                   echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
                   exit 0
                 fi
                 export GH_CONFIG_DIR
-                if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+                UPSERT_SRC="$(cat "${RUNNER_TEMP}/upsert-deferred-issue.sh"; printf x)"
+                UPSERT_SRC="${UPSERT_SRC%x}"
+                if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then
                   echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
                   exit 0
                 fi
-                bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                bash -c "${UPSERT_SRC}" ||
                   echo "::warning::deferred-findings upsert failed; continuing"
-              ' 2>&1)" || true
+              ' > /dev/null 2>&1 || true
+            UPSERT_OUT="$(<"${UPSERT_LOG}")"
+            rm -f "${UPSERT_LOG}"
             # Inspect with bash BUILTINS only ([[ ]], read, printf — no exec):
             # under loader trace mode every external binary, grep included,
             # would itself print-and-exit-0, so a grep-based check would be
@@ -6717,12 +6741,19 @@ jobs:
               # gate, the PAT bot-identity check (POST_HANDOFF's own check is
               # skipped on the fixed/noop-outcome path that also reaches here)
               # and the staged script all run in a clean allow-listed shell.
-              # LD_* enumeration cannot be complete (LD_TRACE_LOADED_OBJECTS is
-              # presence-tested: even an empty assignment makes the loader print
-              # and exit 0 without running the child), so the child's liveness
-              # is VERIFIED via a sentinel rather than assumed — same shape as
-              # run_deferred_upsert in 'Push and report'.
-              UPSERT_OUT="$(LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
+              # LD_* enumeration cannot be complete — LD_TRACE_LOADED_OBJECTS and
+              # LD_SHOW_AUXV are presence-tested, so an empty assignment leaves
+              # them ON (measured). Same two structural answers as the twin:
+              # the launch's stdout (where every loader side channel writes) is
+              # discarded while the child logs to a private file, and the
+              # child's liveness is VERIFIED by a sentinel. The staged script is
+              # read ONCE and run from those exact bytes, so a rename(2) between
+              # a hash-the-path check and a re-open cannot swap the payload.
+              # Fork-free path + read-back, same rationale as the twin.
+              UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"
+              rm -f "${UPSERT_LOG}"
+              : > "${UPSERT_LOG}"
+              LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \
               LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \
                 /usr/bin/env -i \
                 PATH="${TRUSTED_PATH}" \
@@ -6734,15 +6765,19 @@ jobs:
                 REPO="${REPO}" \
                 AUTOFIX_BOT="${AUTOFIX_BOT}" \
                 UPSERT_SHA256="${UPSERT_SHA256}" \
+                UPSERT_LOG="${UPSERT_LOG}" \
                 bash --norc -c '
                   set -uo pipefail
+                  exec > "${UPSERT_LOG}" 2>&1
                   printf "%s\n" "__upsert_child_live__"
                   if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then
                     echo "::warning::could not create a gh config dir; deferred findings NOT persisted this round"
                     exit 0
                   fi
                   export GH_CONFIG_DIR
-                  if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+                  UPSERT_SRC="$(cat "${RUNNER_TEMP}/upsert-deferred-issue.sh"; printf x)"
+                  UPSERT_SRC="${UPSERT_SRC%x}"
+                  if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then
                     echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
                     exit 0
                   fi
@@ -6751,9 +6786,11 @@ jobs:
                     echo "::warning::CI_DEV_BOT_PAT identity check failed for the deferred-findings upsert (got ${UPSERT_ACTOR:-none}); NOT persisted this round"
                     exit 0
                   fi
-                  bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                  bash -c "${UPSERT_SRC}" ||
                     echo "::warning::deferred-findings upsert failed; continuing"
-                ' 2>&1)" || true
+                ' > /dev/null 2>&1 || true
+              UPSERT_OUT="$(<"${UPSERT_LOG}")"
+              rm -f "${UPSERT_LOG}"
               # Builtin-only inspection, same rationale as the twin.
               if [[ "${UPSERT_OUT}" != *'__upsert_child_live__'* ]]; then
                 echo "::warning::deferred-findings upsert child never started (loader trace mode or exec failure); NOT persisted this round"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3985,6 +3985,7 @@ jobs:
           # gate itself).
           echo "resanitize_sha256=$(sha256sum "${RUNNER_TEMP}/resanitize-git-config.sh" | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
           echo "verify_runner_sha256=$(sha256sum "${RUNNER_TEMP}/run-autofix-review-verification.sh" | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
+          echo "upsert_sha256=$(sha256sum "${RUNNER_TEMP}/upsert-deferred-issue.sh" | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
           echo "trusted_path=${PATH}" >> "${GITHUB_OUTPUT}"
           # The agent step runs AFTER prepare checks out the PR branch, so
           # invoking the runner from the working tree would execute
@@ -5460,6 +5461,7 @@ jobs:
           CHECKED_OUT_HEAD: '${{ steps.prepare.outputs.checked_out_head }}'
           VERIFIED_HEAD: '${{ steps.final_verify.outputs.verified_head }}'
           RESANITIZE_SHA256: '${{ steps.stage.outputs.resanitize_sha256 }}'
+          UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'
           TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
           # Growth-brake baseline: written into this window's FIRST report
           # comment only (growth_base_new), so later rounds' first-wins parse
@@ -5826,8 +5828,16 @@ jobs:
             # Best-effort: verified out-of-footprint findings persist into
             # the per-PR tracking issue (trusted staged copy; append-only
             # comment design — see the script).
-            bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
-              echo "::warning::deferred-findings upsert failed; continuing"
+            # Verify the staged copy's digest (recorded in expression context
+            # at stage time) before executing: RUNNER_TEMP is writable by the
+            # branch/agent code that ran in between. Best-effort like the
+            # upsert itself — a mismatch skips persistence, never the round.
+            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                echo "::warning::deferred-findings upsert failed; continuing"
+            else
+              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
+            fi
             {
               echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on: · 已处理最新评审反馈（第 ${NEXT_ROUND}/${MAX_ROUNDS} 轮）。改动内容与我反驳保留之处如下："
               echo
@@ -5884,8 +5894,16 @@ jobs:
             # Best-effort: verified out-of-footprint findings persist into
             # the per-PR tracking issue (trusted staged copy; append-only
             # comment design — see the script).
-            bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
-              echo "::warning::deferred-findings upsert failed; continuing"
+            # Verify the staged copy's digest (recorded in expression context
+            # at stage time) before executing: RUNNER_TEMP is writable by the
+            # branch/agent code that ran in between. Best-effort like the
+            # upsert itself — a mismatch skips persistence, never the round.
+            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                echo "::warning::deferred-findings upsert failed; continuing"
+            else
+              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
+            fi
             # noop: evaluated, nothing worth doing. Report once and advance the
             # watermark so the next scan does not re-evaluate the same feedback.
             {
@@ -6067,7 +6085,16 @@ jobs:
           GROWTH_TEST: '${{ steps.prepare.outputs.growth_test }}'
           CRITICAL_ONLY_GROWTH: '${{ steps.prepare.outputs.critical_only_growth }}'
           GROWTH_BASE_WIN: '${{ steps.prepare.outputs.growth_base_win }}'
+          UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'
         run: |-
+          # gh has its own $GITHUB_ENV-injectable channels: pin the host, drop
+          # any planted token and point gh at a fresh config dir BEFORE the
+          # PAT-bearing gh calls below (handoff/report comment + deferred
+          # upsert) — this step runs after agent/branch code, same exposure as
+          # the workflow's other PAT-bearing gh sites.
+          export GH_HOST=github.com
+          unset GH_ENTERPRISE_TOKEN GH_TOKEN
+          export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
           # The head the agent actually evaluated — captured in prepare before
           # any mutation, not the report-time remote head (which can move
           # during the run). Empty when prepare exited early, which matches
@@ -6592,8 +6619,14 @@ jobs:
           # agent's analysis is independent of whether this round's commit
           # survived verification. Same guards as the handoff itself.
           if [[ "${DRY_RUN}" != "true" && "${STALE:-}" != "true" && -n "${GITHUB_TOKEN:-}" ]]; then
-            bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
-              echo "::warning::deferred-findings upsert failed; continuing"
+            # Same digest gate as the report-path invocations: RUNNER_TEMP is
+            # agent-writable, and this path runs after the agent too.
+            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                echo "::warning::deferred-findings upsert failed; continuing"
+            else
+              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
+            fi
           fi
 
       # Flip the status comment out of "working" so a finished round never

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -3992,7 +3992,11 @@ jobs:
           _upsert_delim="EOF_$(head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n')"
           {
             echo "upsert_src<<${_upsert_delim}"
-            cat .github/scripts/upsert-deferred-issue.sh
+            # Absent from the trusted base until this PR merges, and this
+            # step runs under -e: a hard failure here would kill every
+            # pre-merge round. An empty value reaches the consumers' own
+            # `-z` guard, which skips with "stage step never ran".
+            cat .github/scripts/upsert-deferred-issue.sh 2> /dev/null || true
             echo "${_upsert_delim}"
           } >> "${GITHUB_OUTPUT}"
           echo "trusted_path=${PATH}" >> "${GITHUB_OUTPUT}"
@@ -5950,8 +5954,8 @@ jobs:
             done
             resolve_and_reply_threads
             # Best-effort: verified out-of-footprint findings persist into
-            # the per-PR tracking issue (trusted staged copy; append-only
-            # comment design — see the script).
+            # the per-PR tracking issue (script content from expression
+            # context; append-only comment design — see the script).
             run_deferred_upsert
             {
               echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on: · 已处理最新评审反馈（第 ${NEXT_ROUND}/${MAX_ROUNDS} 轮）。改动内容与我反驳保留之处如下："
@@ -6007,8 +6011,8 @@ jobs:
             PUSH_RACE_MERGED='false'
             resolve_and_reply_threads
             # Best-effort: verified out-of-footprint findings persist into
-            # the per-PR tracking issue (trusted staged copy; append-only
-            # comment design — see the script).
+            # the per-PR tracking issue (script content from expression
+            # context; append-only comment design — see the script).
             run_deferred_upsert
             # noop: evaluated, nothing worth doing. Report once and advance the
             # watermark so the next scan does not re-evaluate the same feedback.
@@ -6194,10 +6198,12 @@ jobs:
           UPSERT_SRC: '${{ steps.stage.outputs.upsert_src }}'
           TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
         run: |-
-          # NOTE: the deferred-findings upsert below runs its digest gate,
-          # PAT identity check and staged-script execution in a sound
-          # /usr/bin/env -i child (see the block near the end of this step),
-          # so this step body needs no in-shell hardening preamble for it.
+          # NOTE: the deferred-findings upsert below runs its PAT identity
+          # check and the script itself in a sound /usr/bin/env -i child (see
+          # the block near the end of this step) — the script arrives as
+          # content from expression context, so there is no staged copy and
+          # no digest gate. This step body needs no in-shell hardening
+          # preamble for it.
           # The handoff `gh pr comment` here is pre-existing surface at the
           # workflow's baseline posture; hardening every pre-existing PAT gh
           # call against BASH_FUNC/transport plants (via the same clean-child

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -1657,6 +1657,27 @@ jobs:
           # reroutes no sweep here touches. mktemp -d gives an
           # unpredictable path a watcher cannot pre-seed.
           export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+          # Two more $GITHUB_ENV-plantable channel families no sweep above
+          # touches: bash startup (BASH_ENV is sourced at every child-bash
+          # start; BASH_FUNC_*%% exported functions are imported by child
+          # bash and outrank PATH lookup) and gh-side transport (proxy env
+          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
+          # PAT-bearing HTTPS calls — the git twins are swept in the
+          # hermetic preamble).
+          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
+            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
+          while IFS='=' read -r _envname _; do
+            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
+              _fn="${_envname#BASH_FUNC_}"
+              unset -f "${_fn%\%\%}" 2> /dev/null || true
+            fi
+          done < <(env)
+          # A planted BASH_ENV was already sourced at THIS shell's startup
+          # (nothing in-step undoes arbitrary in-shell tampering), so also
+          # de-shadow the gate-critical names it could have redefined as
+          # plain functions and re-resolve them from the pinned PATH.
+          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
+          hash -r
           MODEL_DISPLAY="${MODEL:-default}"
           if [[ -z "${GITHUB_TOKEN}" ]]; then
             echo '::error::CI_DEV_BOT_PAT is required to publish the PR as the autofix bot.'
@@ -4147,6 +4168,27 @@ jobs:
           # reroutes no sweep here touches. mktemp -d gives an
           # unpredictable path a watcher cannot pre-seed.
           export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+          # Two more $GITHUB_ENV-plantable channel families no sweep above
+          # touches: bash startup (BASH_ENV is sourced at every child-bash
+          # start; BASH_FUNC_*%% exported functions are imported by child
+          # bash and outrank PATH lookup) and gh-side transport (proxy env
+          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
+          # PAT-bearing HTTPS calls — the git twins are swept in the
+          # hermetic preamble).
+          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
+            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
+          while IFS='=' read -r _envname _; do
+            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
+              _fn="${_envname#BASH_FUNC_}"
+              unset -f "${_fn%\%\%}" 2> /dev/null || true
+            fi
+          done < <(env)
+          # A planted BASH_ENV was already sourced at THIS shell's startup
+          # (nothing in-step undoes arbitrary in-shell tampering), so also
+          # de-shadow the gate-critical names it could have redefined as
+          # plain functions and re-resolve them from the pinned PATH.
+          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
+          hash -r
           # This PAT-bearing step runs git (status/restore/fetch/checkout and a
           # push preflight) on the shared host BEFORE the agent/gate, so it
           # takes the same hermetic preamble the push steps do — the contract
@@ -5494,6 +5536,27 @@ jobs:
           # reroutes no sweep here touches. mktemp -d gives an
           # unpredictable path a watcher cannot pre-seed.
           export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+          # Two more $GITHUB_ENV-plantable channel families no sweep above
+          # touches: bash startup (BASH_ENV is sourced at every child-bash
+          # start; BASH_FUNC_*%% exported functions are imported by child
+          # bash and outrank PATH lookup) and gh-side transport (proxy env
+          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
+          # PAT-bearing HTTPS calls — the git twins are swept in the
+          # hermetic preamble).
+          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
+            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
+          while IFS='=' read -r _envname _; do
+            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
+              _fn="${_envname#BASH_FUNC_}"
+              unset -f "${_fn%\%\%}" 2> /dev/null || true
+            fi
+          done < <(env)
+          # A planted BASH_ENV was already sourced at THIS shell's startup
+          # (nothing in-step undoes arbitrary in-shell tampering), so also
+          # de-shadow the gate-critical names it could have redefined as
+          # plain functions and re-resolve them from the pinned PATH.
+          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
+          hash -r
           # The head the agent actually evaluated — captured in prepare before
           # any mutation, not the report-time remote head (which can move
           # during the run). Empty when prepare exited early, which matches
@@ -5671,6 +5734,20 @@ jobs:
               echo "🧵 replied on ${REPLIED_N} thread(s) the agent left open"
             fi
           }
+          # Deferred-findings persistence, shared by both arms below (the
+          # pasted twin diverged once already in review). Verify the staged
+          # copy's digest (recorded in expression context at stage time)
+          # before executing: RUNNER_TEMP is writable by the branch/agent
+          # code that ran in between. Best-effort like the upsert itself —
+          # a mismatch skips persistence, never the round.
+          run_deferred_upsert() {
+            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
+                echo "::warning::deferred-findings upsert failed; continuing"
+            else
+              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
+            fi
+          }
 
                     # Take this PAT-bearing step off every mutable host git surface —
           # both the shared config FILES and git's ENV channels — keep this
@@ -5828,16 +5905,7 @@ jobs:
             # Best-effort: verified out-of-footprint findings persist into
             # the per-PR tracking issue (trusted staged copy; append-only
             # comment design — see the script).
-            # Verify the staged copy's digest (recorded in expression context
-            # at stage time) before executing: RUNNER_TEMP is writable by the
-            # branch/agent code that ran in between. Best-effort like the
-            # upsert itself — a mismatch skips persistence, never the round.
-            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
-              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
-                echo "::warning::deferred-findings upsert failed; continuing"
-            else
-              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
-            fi
+            run_deferred_upsert
             {
               echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on: · 已处理最新评审反馈（第 ${NEXT_ROUND}/${MAX_ROUNDS} 轮）。改动内容与我反驳保留之处如下："
               echo
@@ -5894,16 +5962,7 @@ jobs:
             # Best-effort: verified out-of-footprint findings persist into
             # the per-PR tracking issue (trusted staged copy; append-only
             # comment design — see the script).
-            # Verify the staged copy's digest (recorded in expression context
-            # at stage time) before executing: RUNNER_TEMP is writable by the
-            # branch/agent code that ran in between. Best-effort like the
-            # upsert itself — a mismatch skips persistence, never the round.
-            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
-              bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
-                echo "::warning::deferred-findings upsert failed; continuing"
-            else
-              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
-            fi
+            run_deferred_upsert
             # noop: evaluated, nothing worth doing. Report once and advance the
             # watermark so the next scan does not re-evaluate the same feedback.
             {
@@ -6086,7 +6145,18 @@ jobs:
           CRITICAL_ONLY_GROWTH: '${{ steps.prepare.outputs.critical_only_growth }}'
           GROWTH_BASE_WIN: '${{ steps.prepare.outputs.growth_base_win }}'
           UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'
+          TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'
         run: |-
+          # Pin PATH to the staged trusted value (and drop the loader trio)
+          # before anything below runs: this step executes a staged script
+          # under a digest gate, and an ambient $GITHUB_ENV-planted
+          # PATH/LD_PRELOAD would defeat that gate (a swapped sha256sum or
+          # bash). Empty TRUSTED_PATH means stage never ran — then no staged
+          # copy exists either and the digest gate below skips explicitly.
+          if [[ -n "${TRUSTED_PATH:-}" ]]; then
+            export PATH="${TRUSTED_PATH}"
+          fi
+          unset LD_PRELOAD LD_AUDIT LD_LIBRARY_PATH
           # gh has its own $GITHUB_ENV-injectable channels: pin the host, drop
           # any planted token and point gh at a fresh config dir BEFORE the
           # PAT-bearing gh calls below (handoff/report comment + deferred
@@ -6095,6 +6165,27 @@ jobs:
           export GH_HOST=github.com
           unset GH_ENTERPRISE_TOKEN GH_TOKEN
           export GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"
+          # Two more $GITHUB_ENV-plantable channel families no sweep above
+          # touches: bash startup (BASH_ENV is sourced at every child-bash
+          # start; BASH_FUNC_*%% exported functions are imported by child
+          # bash and outrank PATH lookup) and gh-side transport (proxy env
+          # reroutes, and SSL_CERT_* re-roots the CA trust of, the
+          # PAT-bearing HTTPS calls — the git twins are swept in the
+          # hermetic preamble).
+          unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \
+            https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR
+          while IFS='=' read -r _envname _; do
+            if [[ "${_envname}" == BASH_FUNC_*%% ]]; then
+              _fn="${_envname#BASH_FUNC_}"
+              unset -f "${_fn%\%\%}" 2> /dev/null || true
+            fi
+          done < <(env)
+          # A planted BASH_ENV was already sourced at THIS shell's startup
+          # (nothing in-step undoes arbitrary in-shell tampering), so also
+          # de-shadow the gate-critical names it could have redefined as
+          # plain functions and re-resolve them from the pinned PATH.
+          unset -f sha256sum bash gh git jq mktemp cut tr env 2> /dev/null || true
+          hash -r
           # The head the agent actually evaluated — captured in prepare before
           # any mutation, not the report-time remote head (which can move
           # during the run). Empty when prepare exited early, which matches
@@ -6617,15 +6708,31 @@ jobs:
           fi
           # A failed round must not lose verified deferred findings: the
           # agent's analysis is independent of whether this round's commit
-          # survived verification. Same guards as the handoff itself.
+          # survived verification. Guarded like the handoff MINUS its
+          # outcome!=fixed/noop condition — deliberately: when the outcome IS
+          # fixed/noop but "Push and report" died before its own upsert (the
+          # push loop's exit paths), this block is the only persistence
+          # route left.
           if [[ "${DRY_RUN}" != "true" && "${STALE:-}" != "true" && -n "${GITHUB_TOKEN:-}" ]]; then
-            # Same digest gate as the report-path invocations: RUNNER_TEMP is
-            # agent-writable, and this path runs after the agent too.
-            if echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+            if [[ -z "${UPSERT_SHA256:-}" ]]; then
+              # Stage never ran (pre-stage failure): no staged copy exists
+              # and nothing was deferred — a digest "mismatch" here would be
+              # a false tamper alarm, not a signal.
+              echo 'deferred-findings upsert skipped: stage step never ran'
+            elif ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then
+              # Same digest gate as the report-path invocations: RUNNER_TEMP
+              # is agent-writable, and this path runs after the agent too.
+              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
+            elif ! UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq '.login' 2> /dev/null)" ||
+              [[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]; then
+              # The POST_HANDOFF identity check above is skipped on the
+              # fixed/noop-outcome path through this step, so this PAT write
+              # site verifies the identity itself — warn+skip, not exit:
+              # persistence is best-effort.
+              echo "::warning::CI_DEV_BOT_PAT identity check failed for the deferred-findings upsert (got '${UPSERT_ACTOR:-}'); NOT persisted this round"
+            else
               bash "${RUNNER_TEMP}/upsert-deferred-issue.sh" ||
                 echo "::warning::deferred-findings upsert failed; continuing"
-            else
-              echo "::warning::staged upsert-deferred-issue.sh failed digest verification; deferred findings NOT persisted this round"
             fi
           fi
 

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5328,6 +5328,7 @@ jobs:
             "${WORKDIR}/agent-api-error-kind" \
             "${WORKDIR}/agent-timeout" \
             "${WORKDIR}/resolved-comments.txt" \
+            "${WORKDIR}/deferred-findings.json" \
             "${WORKDIR}/comment-replies.json"
           rm -rf "${QWEN_HOME}"
           mkdir -p .qwen "${QWEN_HOME}"
@@ -5422,7 +5423,7 @@ jobs:
           if git rev-parse --verify "${BRANCH}" > /dev/null 2>&1; then
             git diff "origin/main...${BRANCH}" > "${WORKDIR}/pr.diff" || true
           fi
-          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md gate-advisories.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt comment-replies.json pr.diff; do
+          for f in feedback.md address-summary.md no-action.md failure.md handoff.md gate-rejection.md gate-advisories.md agent-api-error agent-api-error-kind agent-timeout resolved-comments.txt comment-replies.json deferred-findings.json pr.diff; do
             if [[ -f "${WORKDIR}/${f}" ]]; then
               echo "=============== ${f} ==============="
               cat "${WORKDIR}/${f}"
@@ -5516,6 +5517,57 @@ jobs:
             echo "::error::CI_DEV_BOT_PAT authenticates as ${bot_actor}; expected ${AUTOFIX_BOT}."
             exit 1
           fi
+
+          # Deferred-to-follow-up findings must SURVIVE the PR: a reason
+          # that lives only in a review thread dies at merge (nobody
+          # re-reads merged PRs' threads). The agent records verified but
+          # out-of-footprint findings in deferred-findings.json; this
+          # upserts them into one per-PR tracking issue, appending only ids
+          # not already listed. Best-effort: a failure here must never fail
+          # a good round. Deliberately NO ready-for-agent label — feeding
+          # the bot's own deferrals back into its issue queue is a human
+          # authorization, not a default.
+          upsert_deferred_issue() {
+            [[ -s "${WORKDIR}/deferred-findings.json" ]] || return 0
+            if ! jq -e 'type == "array" and length > 0 and all(.[];
+                (.id | type == "number") and (.reason | type == "string"))' \
+              "${WORKDIR}/deferred-findings.json" > /dev/null 2>&1; then
+              echo "::warning::deferred-findings.json is malformed; skipping the follow-up upsert"
+              return 0
+            fi
+            local marker existing_num existing_body new_lines body
+            marker="<!-- autofix-deferred pr=${PR} -->"
+            existing_num="$(gh api "repos/${REPO}/issues?state=open&creator=${AUTOFIX_BOT}&per_page=100" \
+              --paginate --jq '.[] | "\(.number)\t\(.body // "")"' 2> /dev/null |
+              awk -F'\t' -v m="${marker}" 'index($0, m) { print $1; exit }')" || existing_num=''
+            existing_body=''
+            if [[ -n "${existing_num}" ]]; then
+              existing_body="$(gh api "repos/${REPO}/issues/${existing_num}" --jq '.body // ""' 2> /dev/null)" || existing_body=''
+            fi
+            # Append only rc ids the issue does not already carry; item text
+            # is agent-authored, so it gets the same token-breaking
+            # neutralization as every other published agent output.
+            new_lines="$(jq -r --arg body "${existing_body}" '
+              .[] | .id as $id
+              | select(($body | contains("rc:" + ($id | tostring) + " ")) | not)
+              | "- rc:\($id) `\(.path // "?" | .[0:200])`: \(.reason | gsub("[\r\n]+"; " ") | .[0:500])"' \
+              "${WORKDIR}/deferred-findings.json" 2> /dev/null |
+              sed 's/<!--/<!\\-\\-/g')" || new_lines=''
+            [[ -n "${new_lines}" ]] || return 0
+            if [[ -n "${existing_num}" ]]; then
+              body="${existing_body}"$'\n'"${new_lines}"
+              gh api --method PATCH "repos/${REPO}/issues/${existing_num}" \
+                -f body="${body}" > /dev/null 2>&1 ||
+                echo "::warning::could not update the deferred-findings issue #${existing_num}"
+              echo "🗂 deferred findings appended to issue #${existing_num}"
+            else
+              body="${marker}"$'\n\n'"Verified review findings from PR #${PR} whose fixes lie outside that PR's footprint, deferred by the autofix loop for follow-up. A maintainer can turn any item into its own issue/PR (or apply the ready-for-agent flow) — nothing here is scheduled automatically."$'\n\n'"${new_lines}"
+              gh api "repos/${REPO}/issues" \
+                -f title="Deferred review findings from PR #${PR}" \
+                -f body="${body}" --jq '.number' 2> /dev/null ||
+                echo "::warning::could not create the deferred-findings issue for PR #${PR}"
+            fi
+          }
 
           # Shared by the pushed and no-op outcomes: a no-op round may
           # resolve re-verified findings (verified_head is the unchanged,
@@ -5821,6 +5873,7 @@ jobs:
               fi
             done
             resolve_and_reply_threads
+            upsert_deferred_issue
             {
               echo "🤖 Addressed the latest review feedback (round ${NEXT_ROUND}/${MAX_ROUNDS}). What changed, and what I pushed back on: · 已处理最新评审反馈（第 ${NEXT_ROUND}/${MAX_ROUNDS} 轮）。改动内容与我反驳保留之处如下："
               echo
@@ -5874,6 +5927,7 @@ jobs:
             # origin head; resolution's own live-head guards still apply.
             PUSH_RACE_MERGED='false'
             resolve_and_reply_threads
+            upsert_deferred_issue
             # noop: evaluated, nothing worth doing. Report once and advance the
             # watermark so the next scan does not re-evaluate the same feedback.
             {

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -5344,7 +5344,14 @@ jobs:
                 mv "${WORKDIR}/deferred-findings.carry.next" \
                   "${WORKDIR}/deferred-findings.carry.json"
               else
-                echo '::warning::could not merge carried deferrals across the repair; keeping the earlier set'
+                # The only loss path in this feature without a raw dump: the
+                # newer set is discarded here and the eval watermark means
+                # nothing re-derives it, so print it before deleting. `::` is
+                # neutralized because the content is agent-written and a raw
+                # `::` at line start would be parsed as a workflow command.
+                echo '::warning::could not merge carried deferrals across the repair; keeping the earlier set. This run'"'"'s deferrals are LOST — raw content follows for manual recovery:'
+                head -c 4000 "${WORKDIR}/deferred-findings.json" | sed 's/::/;;/g'
+                echo
                 rm -f "${WORKDIR}/deferred-findings.carry.next"
               fi
               rm -f "${WORKDIR}/deferred-findings.json"

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -374,6 +374,18 @@ silently overriding or silently complying.
   answer arrives as ordinary new feedback the next round). Distinguish it from
   Decline: you decline when the CHANGE is not worth doing; you escalate when the
   CALL is not yours to make.
+- Defer to follow-up: a finding you VERIFIED as real whose fix lies outside
+  the PR's footprint or its mainline purpose. Do not implement it in this PR
+  (that is scope drift) and do not decline it (the finding is real): record
+  it in `<workdir>/deferred-findings.json` — a JSON array of
+  `{"id": <inline comment id>, "path": "<file>", "reason": "<verified
+finding + why it is out of scope, one or two sentences>"}` — and reply on
+  its thread via `comment-replies.json` that it is deferred to the
+  follow-up queue, leaving the thread open. The workflow upserts these into
+  a per-PR "Deferred review findings" issue that survives the merge; a
+  maintainer schedules them from there. Distinguish from Decline: you
+  decline what is not worth doing anywhere; you defer what is worth doing
+  elsewhere.
 
 Workflow-prepared feedback can also include retry context:
 
@@ -422,7 +434,9 @@ workspace, top-level directory, or root file) a round touches that the PR
 itself never touched is surfaced in a gate advisory — and rejected outright
 when the repository has footprint enforcement set to reject. Staying inside
 the PR's own footprint is the default-correct shape; expansion needs the
-feedback to genuinely require it, and doubt goes to a maintainer question.
+feedback to genuinely require it; a verified finding whose fix lives outside
+the footprint is a Defer-to-follow-up, and doubt goes to a maintainer
+question.
 
 If `--conflict true`, merge `origin/<base>` and resolve conflicts by
 understanding both sides, never blindly taking one side. If false, do not merge

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -378,11 +378,19 @@ silently overriding or silently complying.
   the PR's footprint or its mainline purpose. Do not implement it in this PR
   (that is scope drift) and do not decline it (the finding is real): record
   it in `<workdir>/deferred-findings.json` — a JSON array of
-  `{"id": <inline comment id>, "path": "<file>", "reason": "<verified
-finding + why it is out of scope, one or two sentences>"}` — and reply on
-  its thread via `comment-replies.json` that it is deferred to the
-  follow-up queue, leaving the thread open. The workflow upserts these into
-  a per-PR "Deferred review findings" issue that survives the merge; a
+  `{"id": <id>, "source": "<source>", "path": "<file>", "reason": "<verified
+finding + why it is out of scope, one or two sentences>"}`. This applies to
+  a finding from ANY of the three feedback sources, each of which carries its
+  id in the feedback: an inline comment (`[rc:<id>]`, `"source":
+"review_comment"`, the default when omitted), a review body (`[rv:<id>]`,
+  `"source": "review"`), or an issue-level PR comment (`[ic:<id>]`,
+  `"source": "issue_comment"`). A verified out-of-footprint finding from a
+  review body or an issue-level comment is deferred exactly like an inline
+  one — leaving it out means it is lost at merge. For an inline finding also
+  reply on its thread via `comment-replies.json` that it is deferred to the
+  follow-up queue, leaving the thread open; the other two sources have no
+  thread, so say it in the round summary instead. The workflow upserts these
+  into a per-PR "Deferred review findings" issue that survives the merge; a
   maintainer schedules them from there. Distinguish from Decline: you
   decline what is not worth doing anywhere; you defer what is worth doing
   elsewhere.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8229,12 +8229,16 @@ exit 1
       expect(step.indexOf(firstGh)).toBeGreaterThan(-1);
       expect(ghPin).toBeLessThan(step.indexOf(firstGh));
     }
-    // The in-shell BASH_FUNC/proxy denylist sweep an earlier round added to
-    // these steps was removed: an in-shell sweep bootstraps trust from the
-    // very namespace it sanitizes (a planted BASH_FUNC_env%%/unset%%/alias/
-    // DEBUG-trap defeats it). Nothing re-introduces it. The failure/handoff
-    // step (reviewAddressReportStep) demonstrably carried the sweep in round
-    // 3, so it is covered too — round 3 re-introduced the pattern once.
+    // DRIFT ALARM, NOT A BOUNDARY. The guarantee that a planted channel
+    // cannot reach the privileged work is the `env -i` clean child, pinned
+    // separately below; no regex over source text can be that guarantee,
+    // because the space of sweep spellings is unbounded (round 4 learned this
+    // about the sweep itself, and the same logic applies to a test that
+    // enumerates its spellings). What this loop buys is an alarm when someone
+    // reintroduces the PATTERN — round 3 did exactly that once — so it aims
+    // at the ENUMERATION PRIMITIVES a sweep needs (walking the environment,
+    // clearing functions/aliases/traps) rather than at any particular
+    // vocabulary of variable names.
     for (const step of [
       publishPrStep,
       pushAndReportStep,
@@ -8262,9 +8266,13 @@ exit 1
       expect(code).not.toMatch(/\bunalias\b/);
       expect(code).not.toMatch(/expand_aliases/);
       expect(code).not.toMatch(/\btrap -/);
-      expect(code).not.toMatch(
-        /\bunset [A-Z_ ]*\b(?:HTTPS?_PROXY|SSL_CERT_[A-Z]+|BASH_ENV)\b/,
-      );
+      // The enumeration primitives: a sweep has to WALK the environment to
+      // decide what to clear, whatever vocabulary it then uses.
+      expect(code).not.toMatch(/\bcompgen -[ev]/);
+      expect(code).not.toMatch(/\bdeclare -x\b/);
+      expect(code).not.toMatch(/<\s*<\(\s*env\s*\)/);
+      expect(code).not.toMatch(/\benv\s*\|/);
+      expect(code).not.toMatch(/\bexport -n\b/);
     }
     // The fork fetch and salvage fetch cannot recurse into a planted
     // submodule and execute an ext:: URL with the PAT (env-level
@@ -10517,6 +10525,19 @@ exit 1
       expect(step).toContain(
         'UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"',
       );
+      // R10-22: the step runs under `bash -eo pipefail`, where `rm -f` on a
+      // planted DIRECTORY exits 1 and kills it; `-rf` clears any shape, and
+      // `set -C` then refuses a symlink planted in between.
+      expect(step).toContain('rm -rf "${UPSERT_LOG}" 2> /dev/null || true');
+      expect(step).toMatch(
+        /if ! \(set -C; : > "\$\{UPSERT_LOG\}"\) 2> \/dev\/null; then/,
+      );
+      expect(step).not.toMatch(/rm -f "\$\{UPSERT_LOG\}"/);
+      // R10-19: `$(<missing)` is fatal under -e and no `|| true` / `if !`
+      // form rescues it (measured), so the file is TESTED before the read.
+      expect(step).toMatch(
+        /if \[\[ -f "\$\{UPSERT_LOG\}" && -r "\$\{UPSERT_LOG\}" \]\]; then\n\s*UPSERT_OUT="\$\(<"\$\{UPSERT_LOG\}"\)"/,
+      );
       expect(step).toContain('exec > "${UPSERT_LOG}" 2>&1');
       expect(step).toContain('UPSERT_OUT="$(<"${UPSERT_LOG}")"');
       expect(step).toMatch(/' > \/dev\/null 2>&1 \|\| true/);
@@ -10547,7 +10568,7 @@ exit 1
       // R8-5: the captured output is re-emitted, so the child's warnings
       // actually reach the log (deleting both loops was invisible).
       expect(step).toMatch(
-        /while IFS= read -r _upsert_line; do\n\s*\[\[ "\$\{_upsert_line\}" == '__upsert_child_live__' \]\] \|\|\n\s*printf '%s\\n' "\$\{_upsert_line\}"\n\s*done <<< "\$\{UPSERT_OUT\}"/,
+        /while IFS= read -r _upsert_line; do\n\s*\[\[ "\$\{_upsert_line\}" == '__upsert_child_live__' \]\] \|\|\n\s*printf '%s\\n' "\$\{_upsert_line\/\/::\/;;\}"\n\s*done <<< "\$\{UPSERT_OUT\}"/,
       );
       // Ordering: the digest gate runs, and ONLY on a match does the staged
       // script execute — both inside the same clean child. A reordering or a
@@ -10806,7 +10827,10 @@ exit 1
           [
             '#!/usr/bin/env bash',
             'for a in "$@"; do [[ "$a" == "--rawfile" ]] && exit 3; done',
-            'exec /usr/bin/jq "$@"',
+            // Resolve the real jq through the ORIGINAL PATH (this stub shadows
+            // it): /usr/bin/jq does not exist on macOS, where jq lives in
+            // /opt/homebrew/bin or /usr/local/bin.
+            `exec env PATH="${process.env.PATH}" jq "$@"`,
           ].join('\n'),
         );
         chmodSync(join(bin, 'jq'), 0o755);
@@ -12158,15 +12182,21 @@ exit 1
     const escapeSites = workflow.match(/sed 's\/<!--\/[^']*\/g'/g) ?? [];
     expect(escapeSites).toHaveLength(9);
     // The tenth agent-derived publish site lives in the staged
-    // upsert-deferred-issue.sh (line builder). Same treatment as its
-    // siblings — count AND canonical spelling, not mere presence: a no-op
-    // `\-\-` spelling once shipped past a presence-only pin.
+    // upsert-deferred-issue.sh (line builder). It escapes INSIDE jq, not in a
+    // sed afterwards: the rv/ic dedupe identity is the rendered line, so
+    // escaping after the corpus comparison meant a reason containing `<!--`
+    // never matched its stored form and republished every round (R10-5).
     const scriptEscapeSites =
-      upsertDeferredScript.match(/sed 's\/<!--\/[^']*\/g'/g) ?? [];
+      upsertDeferredScript.match(/gsub\("<!--"; "[^"]*"\)/g) ?? [];
     expect(scriptEscapeSites).toHaveLength(1);
     for (const site of scriptEscapeSites) {
-      expect(site).toBe("sed 's/<!--/<!\\\\-\\\\-/g'");
+      expect(site).toBe('gsub("<!--"; "<!\\\\-\\\\-")');
     }
+    expect(upsertDeferredScript).not.toMatch(/sed 's\/<!--/);
+    // …and it precedes the dedupe comparison, not follows it.
+    expect(upsertDeferredScript.indexOf('gsub("<!--"')).toBeLessThan(
+      upsertDeferredScript.indexOf('index($r.key)'),
+    );
     for (const site of escapeSites) {
       expect(site).toBe("sed 's/<!--/<!\\\\-\\\\-/g'");
     }

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8232,8 +8232,15 @@ exit 1
     // The in-shell BASH_FUNC/proxy denylist sweep an earlier round added to
     // these steps was removed: an in-shell sweep bootstraps trust from the
     // very namespace it sanitizes (a planted BASH_FUNC_env%%/unset%%/alias/
-    // DEBUG-trap defeats it). Nothing re-introduces it.
-    for (const step of [publishPrStep, pushAndReportStep, prepareStep]) {
+    // DEBUG-trap defeats it). Nothing re-introduces it. The failure/handoff
+    // step (reviewAddressReportStep) demonstrably carried the sweep in round
+    // 3, so it is covered too — round 3 re-introduced the pattern once.
+    for (const step of [
+      publishPrStep,
+      pushAndReportStep,
+      prepareStep,
+      reviewAddressReportStep,
+    ]) {
       expect(step).not.toContain('BASH_FUNC_*%%');
       expect(step).not.toContain('done < <(env)');
     }
@@ -10400,13 +10407,48 @@ exit 1
     // 'Push and report' share run_deferred_upsert; the failure path has its
     // own).
     for (const step of [pushAndReportStep, reviewAddressReportStep]) {
-      expect(step).toContain('/usr/bin/env -i \\');
+      // LD_* is stripped by a command-prefix assignment BEFORE /usr/bin/env,
+      // the one channel env -i cannot block (ld.so preloads into the env
+      // binary itself at execve). Pin the assignment immediately precedes
+      // the launch (indent-agnostic across the two call sites).
+      expect(step).toMatch(
+        /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\\n\s*\/usr\/bin\/env -i \\/,
+      );
       expect(step).toContain('bash --norc -c');
       // GH_CONFIG_DIR is minted INSIDE the clean child (its mktemp cannot be
-      // shadowed there), and PATH is the trusted staged value passed in.
+      // shadowed there); PATH is the trusted staged value and GH_HOST is
+      // pinned in the allow-list (a reroute cannot spoof the identity check).
       expect(step).toContain('PATH="${TRUSTED_PATH}"');
+      expect(step).toContain('GH_HOST=github.com');
+      // Ordering: the digest gate runs, and ONLY on a match does the staged
+      // script execute — both inside the same clean child. A reordering or a
+      // gate-condition flip must fail here.
+      const gateIdx = step.indexOf(
+        'if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+      );
+      const execIdx = step.indexOf(
+        'bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
+      );
+      const launchIdx = step.indexOf('/usr/bin/env -i');
+      expect(gateIdx).toBeGreaterThan(launchIdx);
+      expect(execIdx).toBeGreaterThan(gateIdx);
     }
     expect(workflow.split('/usr/bin/env -i \\').length - 1).toBe(2);
+    // R5-6: the failure-path child is near-verbatim of run_deferred_upsert's
+    // child — tie their shared security scaffold together so drift in one is
+    // caught. Compare the allow-list + prelude + digest gate (everything up
+    // to where the failure path inserts its identity check), whitespace-
+    // normalized to absorb the one-level indent difference.
+    const childCore = (step) =>
+      step
+        .match(
+          /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\[\s\S]*?sha256sum -c - > \/dev\/null 2>&1; then[\s\S]*?NOT persisted this round"\n\s*exit 0\n\s*fi/,
+        )?.[0]
+        .replace(/\s+/g, ' ');
+    expect(childCore(pushAndReportStep)).toBeTruthy();
+    expect(childCore(reviewAddressReportStep)).toBe(
+      childCore(pushAndReportStep),
+    );
     // The failure-path clean-child launch sits INSIDE the DRY_RUN/STALE/token
     // guard (deleting the guard or relocating the call breaks this slice).
     expect(reviewAddressReportStep).toMatch(
@@ -10443,9 +10485,13 @@ exit 1
     );
     expect(
       workflow.split(
-        '"${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+        'if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
       ).length - 1,
     ).toBe(2);
+    // R5-5: both --paginate sites are pinned at the source (the recording gh
+    // stub ignores the flag). Dropping either silently truncates the lookup
+    // or the dedupe corpus.
+    expect(upsertDeferredScript.match(/--paginate/g) ?? []).toHaveLength(2);
     for (const step of [pushAndReportStep, reviewAddressReportStep]) {
       expect(step).toContain(
         "UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'",
@@ -10474,12 +10520,19 @@ exit 1
       comments = '[]',
       commentsFail = false,
       writeFail = false,
+      mktempFail = false,
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-upsert-'));
       const bin = join(dir, 'bin');
       mkdirSync(bin);
       writeFileSync(join(dir, 'deferred-findings.json'), findings);
       if (resolved) writeFileSync(join(dir, 'resolved-comments.txt'), resolved);
+      if (mktempFail) {
+        // Shadow mktemp on PATH with a failing stub (simulates /tmp
+        // exhaustion): the script must warn+skip, not silently exit 0.
+        writeFileSync(join(bin, 'mktemp'), '#!/usr/bin/env bash\nexit 1\n');
+        chmodSync(join(bin, 'mktemp'), 0o755);
+      }
       writeFileSync(
         join(bin, 'gh'),
         [
@@ -10722,6 +10775,43 @@ exit 1
     // it (`set +C`), and the workflow additionally runs it in an env -i
     // child that drops the read-only SHELLOPTS entirely.
     expect(upsertDeferredScript).toContain('set +C');
+    // R5-3: an integer-valued float that jq renders in scientific notation
+    // past 2^53 (1e21 -> "1E+21") carries a regex-active byte into the
+    // anchored dedupe. The shape gate's plain-digits belt rejects it loudly.
+    const sci = runUpsert({ findings: '[{"id":1e21,"reason":"r"}]' });
+    expect(sci.out).toContain('malformed');
+    expect(sci.calls).toBe('');
+    // R5-4: an unguarded mktemp failure would turn the whole upsert into a
+    // silent exit 0 — the one failure path that skips the header contract.
+    // Now it warns and makes no gh call.
+    const mktempFailed = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      mktempFail: true,
+    });
+    expect(mktempFailed.out).toContain('could not create a temp file');
+    expect(mktempFailed.calls).not.toContain('-f title=');
+    // R5-10: the anchored dedupe's trailing-space boundary. A corpus bullet
+    // `- rc:70 …` must NOT suppress this round's id 7 (space-less prefix
+    // match would); removing the `+ " "` in the script would flip this.
+    const prefixCollide = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+      comments: JSON.stringify([
+        { user: { login: 'bot' }, body: '- rc:70 `x`: unrelated' },
+      ]),
+    });
+    expect(prefixCollide.calls).toContain('- rc:7 ');
+    // R5-2: the cap warning names the dropped bullets (they are NOT
+    // re-evaluated — watermark-gated) instead of promising a later re-defer.
+    const capped2 = runUpsert({
+      findings: JSON.stringify(
+        Array.from({ length: 22 }, (_, i) => ({ id: i + 1, reason: 'r' })),
+      ),
+    });
+    expect(capped2.out).toContain('will NOT be re-evaluated');
+    expect(capped2.out).not.toContain('re-defer them in a later round');
+    expect(capped2.out).toContain('- rc:21 ');
+    expect(capped2.out).toContain('- rc:22 ');
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8232,6 +8232,20 @@ exit 1
       );
       expect(step.indexOf(firstGh)).toBeGreaterThan(-1);
       expect(ghPin).toBeLessThan(step.indexOf(firstGh));
+      // bash startup channels (BASH_ENV sourced by every child bash;
+      // BASH_FUNC_*%% exported functions outrank PATH in children) and
+      // gh-side transport channels (proxy reroute, SSL_CERT_* CA re-root)
+      // are $GITHUB_ENV-plantable too — swept before the first gh call.
+      const bashSweep = step.indexOf(
+        'unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \\',
+      );
+      expect(bashSweep).toBeGreaterThan(-1);
+      expect(bashSweep).toBeLessThan(step.indexOf(firstGh));
+      expect(step).toContain(
+        'https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR',
+      );
+      expect(step).toContain('BASH_FUNC_*%%');
+      expect(step).toContain('unset -f');
     }
     // The fork fetch and salvage fetch cannot recurse into a planted
     // submodule and execute an ext:: URL with the PAT (env-level
@@ -10374,7 +10388,49 @@ exit 1
     expect(
       workflow.split('bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"').length -
         1,
-    ).toBe(3);
+    ).toBe(2);
+    // Placement, not just counts: the digest-gated invocation is a step-local
+    // function defined ONCE in 'Push and report' and called immediately after
+    // resolve_and_reply_threads in BOTH arms; the failure/handoff step keeps
+    // its own gated copy.
+    expect(pushAndReportStep.split('run_deferred_upsert() {').length - 1).toBe(
+      1,
+    );
+    expect(
+      pushAndReportStep.match(
+        /resolve_and_reply_threads\n(?:\s*#[^\n]*\n)*\s*run_deferred_upsert\n/g,
+      ) ?? [],
+    ).toHaveLength(2);
+    // The failure-path invocation sits INSIDE the DRY_RUN/STALE/token guard
+    // (deleting the guard or relocating the call would break this slice).
+    expect(reviewAddressReportStep).toMatch(
+      /if \[\[ "\$\{DRY_RUN\}" != "true" && "\$\{STALE:-\}" != "true" && -n "\$\{GITHUB_TOKEN:-\}" \]\]; then(?:(?!\n {10}fi\n)[\s\S])*upsert-deferred-issue\.sh(?:(?!\n {10}fi\n)[\s\S])*\n {10}fi\n/,
+    );
+    // Pre-stage failures leave UPSERT_SHA256 empty: that skips with a plain
+    // notice instead of imitating a tamper alarm.
+    expect(reviewAddressReportStep).toContain(
+      'deferred-findings upsert skipped: stage step never ran',
+    );
+    // The failure path can run without POST_HANDOFF's identity check
+    // (OUTCOME=fixed/noop), so it verifies the PAT identity itself.
+    expect(reviewAddressReportStep).toContain(
+      'UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user',
+    );
+    expect(reviewAddressReportStep).toContain(
+      '[[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]',
+    );
+    // The failure step pins PATH to the staged trusted value (guarded for
+    // pre-stage crashes) BEFORE its digest gate runs.
+    expect(reviewAddressReportStep).toContain(
+      "TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'",
+    );
+    const failPathPin = reviewAddressReportStep.indexOf(
+      'export PATH="${TRUSTED_PATH}"',
+    );
+    expect(failPathPin).toBeGreaterThan(-1);
+    expect(failPathPin).toBeLessThan(
+      reviewAddressReportStep.indexOf('sha256sum -c'),
+    );
     expect(workflow).toContain(
       'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
     );
@@ -10386,9 +10442,9 @@ exit 1
     );
     expect(
       workflow.split(
-        'echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+        '"${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
       ).length - 1,
-    ).toBe(3);
+    ).toBe(2);
     for (const step of [pushAndReportStep, reviewAddressReportStep]) {
       expect(step).toContain(
         "UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'",
@@ -10487,7 +10543,9 @@ exit 1
         { number: 42, body: `x\n${marker}`, pull_request: null },
       ]),
       body: 'intro\n- rc:8 `x`: dup',
-      comments: JSON.stringify([{ body: '- rc:9 `y`: in-comment' }]),
+      comments: JSON.stringify([
+        { user: { login: 'bot' }, body: '- rc:9 `y`: in-comment' },
+      ]),
     });
     expect(appended.calls).toContain(
       'api repos/o/r/issues/42/comments -f body=',
@@ -10606,6 +10664,47 @@ exit 1
     });
     expect(appendFail.out).toContain('could not append');
     expect(appendFail.out).toContain('NOT persisted');
+    // The dedupe corpus is BOT-authored comments only: a third party posting
+    // a line-start bullet on the public tracking issue cannot permanently
+    // suppress a deferred finding.
+    const foreign = runUpsert({
+      findings: '[{"id":9,"reason":"real"}]',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+      comments: JSON.stringify([
+        { user: { login: 'mallory' }, body: '- rc:9 `y`: squatted' },
+      ]),
+    });
+    expect(foreign.calls).toContain('issues/42/comments -f body=');
+    expect(foreign.calls).toContain('- rc:9 ');
+    // Intra-batch dedupe: duplicate ids collapse to one bullet.
+    const dup = runUpsert({
+      findings: '[{"id":7,"reason":"a"},{"id":7,"reason":"b"}]',
+    });
+    expect(dup.calls.split('- rc:7 ').length - 1).toBe(1);
+    expect(dup.out).toContain('(1 of 1 new)');
+    // Identity anchors: only a MARKER-carrying issue is adopted (an
+    // unrelated bot issue falls through to the create path), and the source
+    // pins the creator= authorship filter the stub cannot observe.
+    const markerless = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      list: JSON.stringify([
+        { number: 41, body: 'no marker here', pull_request: null },
+      ]),
+    });
+    expect(markerless.calls).toContain('-f title=');
+    expect(markerless.calls).not.toContain('issues/41/comments');
+    expect(upsertDeferredScript).toContain('creator=${AUTOFIX_BOT}');
+    expect(upsertDeferredScript).toContain('contains($m)');
+    // Marker neutralization is behavioural, not just a source pin: a comment
+    // opener in agent-influenced content reaches the write call defused.
+    // (Append path: the create path's own body legitimately carries the raw
+    // tracking marker.)
+    const neutralized = runUpsert({
+      findings: '[{"id":11,"reason":"see <!-- autofix-eval ts=x --> marker"}]',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+    });
+    expect(neutralized.calls).toContain('<!\\-\\-');
+    expect(neutralized.calls).not.toContain('<!--');
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10392,10 +10392,12 @@ exit 1
     // verified findings); it is staged from the trusted base; the agent
     // file rides the artifact dump and the repair cleanup; SKILL documents
     // the fourth disposition.
-    expect(
-      workflow.split('bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"').length -
-        1,
-    ).toBe(2);
+    // The staged script is executed from the bytes read and hashed in the
+    // child, never re-opened by path (R9-1), at both call sites.
+    expect(workflow.split('bash -c "${UPSERT_SRC}"').length - 1).toBe(2);
+    expect(workflow).not.toContain(
+      'bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
+    );
     // Placement, not just counts: the digest-gated invocation is a step-local
     // function defined ONCE in 'Push and report' and called immediately after
     // resolve_and_reply_threads in BOTH arms; the failure/handoff step keeps
@@ -10434,11 +10436,41 @@ exit 1
       // The entries must live INSIDE the `env -i` argument list (between the
       // launch and `bash --norc -c`): a symmetric relocation out of the
       // child's environment keeps a bare toContain — and childCore — green.
-      const argList = step.slice(
-        step.indexOf('/usr/bin/env -i'),
-        step.indexOf('bash --norc -c'),
-      );
+      // Anchor on the launch LINE, not the first textual mention: a comment
+      // elsewhere in the step names `/usr/bin/env -i` too, and slicing from
+      // there swallowed the whole step (which quietly weakened these pins).
+      const argStart = step.indexOf('LD_PRELOAD= LD_AUDIT=');
+      expect(argStart).toBeGreaterThan(-1);
+      const argList = step.slice(argStart, step.indexOf('bash --norc -c'));
       expect(argList.length).toBeGreaterThan(0);
+      // R9-10: contains-only pins accept a symmetric ADDITION that widens the
+      // child's environment. Enumerate what is actually passed and compare
+      // against the sanctioned set.
+      const passed = (argList.match(/[A-Z_][A-Z0-9_]*=/g) ?? []).map((m) =>
+        m.replace('=', ''),
+      );
+      expect(new Set(passed)).toEqual(
+        new Set([
+          // the LD_* command-prefix assignments lead the launch line
+          'LD_PRELOAD',
+          'LD_AUDIT',
+          'LD_LIBRARY_PATH',
+          'LD_PROFILE',
+          'LD_PROFILE_OUTPUT',
+          'LD_DEBUG',
+          'LD_DEBUG_OUTPUT',
+          'PATH',
+          'GITHUB_TOKEN',
+          'GH_HOST',
+          'RUNNER_TEMP',
+          'WORKDIR',
+          'PR',
+          'REPO',
+          'AUTOFIX_BOT',
+          'UPSERT_SHA256',
+          'UPSERT_LOG',
+        ]),
+      );
       for (const entry of [
         'PATH="${TRUSTED_PATH}"',
         'GITHUB_TOKEN="${GITHUB_TOKEN}"',
@@ -10452,10 +10484,34 @@ exit 1
       ]) {
         expect(argList).toContain(entry);
       }
-      // R6-8: LD_* cannot be enumerated (LD_TRACE_LOADED_OBJECTS is
-      // presence-tested — even an empty assignment makes the loader print and
-      // exit 0 without running the child), so liveness is VERIFIED: the child
-      // prints a sentinel first, and its absence is reported.
+      // R9-1: the bytes that are HASHED are the bytes that RUN. A gate that
+      // hashes a path and then re-opens it to execute loses to a rename(2)
+      // between the two opens (measured: 20/20 payload executions against the
+      // old shape, 0/20 against this one).
+      expect(step).toContain(
+        'UPSERT_SRC="$(cat "${RUNNER_TEMP}/upsert-deferred-issue.sh"; printf x)"',
+      );
+      expect(step).toContain('UPSERT_SRC="${UPSERT_SRC%x}"');
+      expect(step).toContain('bash -c "${UPSERT_SRC}"');
+      expect(step).not.toMatch(
+        /bash "\$\{RUNNER_TEMP\}\/upsert-deferred-issue\.sh"/,
+      );
+      // R8-4: loader side channels (auxv dumps, ldd traces) write to the
+      // LAUNCH's stdout, which is discarded — the child logs to a private
+      // file instead, so no content filter is needed to keep them out of the
+      // parsed output. Path and read-back are fork-free: under a planted
+      // channel every external command in the parent prints to stdout, so
+      // $(mktemp)/$(cat) would return that noise inside the value.
+      expect(step).toContain(
+        'UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"',
+      );
+      expect(step).toContain('exec > "${UPSERT_LOG}" 2>&1');
+      expect(step).toContain('UPSERT_OUT="$(<"${UPSERT_LOG}")"');
+      expect(step).toMatch(/' > \/dev\/null 2>&1 \|\| true/);
+      // R6-8: LD_* cannot be enumerated (LD_TRACE_LOADED_OBJECTS and
+      // LD_SHOW_AUXV are presence-tested — even an empty assignment leaves
+      // them on), so liveness is VERIFIED: the child prints a sentinel
+      // first, and its absence is reported.
       expect(step).toContain('printf "%s\\n" "__upsert_child_live__"');
       expect(step).toContain(
         '::warning::deferred-findings upsert child never started',
@@ -10479,17 +10535,15 @@ exit 1
       // R8-5: the captured output is re-emitted, so the child's warnings
       // actually reach the log (deleting both loops was invisible).
       expect(step).toMatch(
-        /while IFS= read -r _upsert_line; do[\s\S]*?printf '%s\\n' "\$\{_upsert_line\}"[\s\S]*?done <<< "\$\{UPSERT_OUT\}"/,
+        /while IFS= read -r _upsert_line; do\n\s*\[\[ "\$\{_upsert_line\}" == '__upsert_child_live__' \]\] \|\|\n\s*printf '%s\\n' "\$\{_upsert_line\}"\n\s*done <<< "\$\{UPSERT_OUT\}"/,
       );
       // Ordering: the digest gate runs, and ONLY on a match does the staged
       // script execute — both inside the same clean child. A reordering or a
       // gate-condition flip must fail here.
       const gateIdx = step.indexOf(
-        'if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+        'if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then',
       );
-      const execIdx = step.indexOf(
-        'bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
-      );
+      const execIdx = step.indexOf('bash -c "${UPSERT_SRC}"');
       const launchIdx = step.indexOf('/usr/bin/env -i');
       expect(gateIdx).toBeGreaterThan(launchIdx);
       expect(execIdx).toBeGreaterThan(gateIdx);
@@ -10503,7 +10557,7 @@ exit 1
     const childCore = (step) =>
       step
         .match(
-          /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\[\s\S]*?sha256sum -c - > \/dev\/null 2>&1; then[\s\S]*?NOT persisted this round"\n\s*exit 0\n\s*fi/,
+          /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\[\s\S]*?sha256sum \| cut -d" " -f1\)" != "\$\{UPSERT_SHA256\}" \]\]; then[\s\S]*?NOT persisted this round"\n\s*exit 0\n\s*fi/,
         )?.[0]
         .replace(/\s+/g, ' ');
     expect(childCore(pushAndReportStep)).toBeTruthy();
@@ -10536,13 +10590,16 @@ exit 1
     );
     expect(idIdx).toBeGreaterThan(
       reviewAddressReportStep.indexOf(
-        'if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+        'if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then',
       ),
     );
     expect(idIdx).toBeLessThan(
-      reviewAddressReportStep.indexOf(
-        'bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
-      ),
+      reviewAddressReportStep.indexOf('bash -c "${UPSERT_SRC}"'),
+    );
+    // R9-9: and the mismatch branch must ENFORCE — presence and ordering say
+    // nothing about whether a mismatch actually stops the write.
+    expect(reviewAddressReportStep).toMatch(
+      /\[\[ "\$\{UPSERT_ACTOR\}" != "\$\{AUTOFIX_BOT\}" \]\]; then\n[^\n]*identity check failed[^\n]*\n\s*exit 0\n/,
     );
     // The failure step carries TRUSTED_PATH in env so the clean child gets a
     // trusted PATH; the in-shell BASH_FUNC/proxy sweep and the in-step PATH
@@ -10573,7 +10630,7 @@ exit 1
     );
     expect(
       workflow.split(
-        'if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+        'if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then',
       ).length - 1,
     ).toBe(2);
     // R5-5: both --paginate sites are pinned at the source (the recording gh
@@ -10596,6 +10653,12 @@ exit 1
     }
     expect(reviewAddressJob).toContain(
       'comment-replies.json deferred-findings.json deferred-findings.carry.json pr.diff',
+    );
+    // R9-11: that dump prints agent-written files, so it neutralizes `::`
+    // like every other echo of them (a line-start `::error::` in the raw file
+    // would otherwise be a workflow command).
+    expect(reviewAddressJob).toMatch(
+      /=============== \$\{f\} ==============="\n(?:\s*#[^\n]*\n)*\s*sed 's\/::\/;;\/g' "\$\{WORKDIR\}\/\$\{f\}"/,
     );
     expect(reviewAddressJob).toContain(
       '"${WORKDIR}/deferred-findings.json" \\',
@@ -11095,11 +11158,45 @@ exit 1
       resolved: 'rc:21\n',
       list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
       comments: JSON.stringify([
-        { user: { login: 'bot' }, body: '- rv:21 `x`: already tracked' },
+        { user: { login: 'bot' }, body: '- rv:21 `?`: dup' },
       ]),
     });
-    expect(perSource.calls).not.toContain('- rv:21 ');
+    // Suppression for the multi-finding sources is per RENDERED LINE, not per
+    // id: the corpus carries this exact bullet, so the review item is already
+    // tracked while the issue-comment sibling is new. (Keying those on the id
+    // alone silently ate every sibling but the first — R9-2.)
+    expect(perSource.calls).not.toContain('`?`: dup');
     expect(perSource.calls).toContain('- ic:21 ');
+    // A DIFFERENT finding under the same review id is still appended.
+    const siblingFinding = runUpsert({
+      findings:
+        '[{"id":21,"source":"review","reason":"a second, distinct finding"}]',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+      comments: JSON.stringify([
+        { user: { login: 'bot' }, body: '- rv:21 `?`: dup' },
+      ]),
+    });
+    expect(siblingFinding.calls).toContain('a second, distinct finding');
+    // R9-2: a review body / issue comment carries ONE id but can raise
+    // several findings. Keying the intra-batch dedupe on the id collapsed
+    // them and reported success ("2 of 2 new") while losing one for good.
+    const multiPerId = runUpsert({
+      findings:
+        '[{"id":77,"source":"review","reason":"first"},' +
+        '{"id":77,"source":"review","reason":"second"},' +
+        '{"id":78,"source":"review","reason":"third"}]',
+    });
+    expect(multiPerId.calls.split('- rv:77 ').length - 1).toBe(2);
+    expect(multiPerId.calls).toContain('first');
+    expect(multiPerId.calls).toContain('second');
+    expect(multiPerId.out).toContain('(3 of 3 new)');
+    // Byte-identical records still collapse — the dedupe is per finding, not
+    // per record.
+    const identicalTwice = runUpsert({
+      findings:
+        '[{"id":77,"source":"review","reason":"same"},{"id":77,"source":"review","reason":"same"}]',
+    });
+    expect(identicalTwice.calls.split('- rv:77 ').length - 1).toBe(1);
     // An unknown source value fails the gate loudly rather than silently
     // rendering under the default prefix.
     const badSource = runUpsert({

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10712,8 +10712,11 @@ exit 1
     // R9-20: the script-side union is the freshness guarantee — this round
     // first, so unique_by (first-of-group, original order) keeps the fresh
     // text when run 2 re-emits a carried id.
-    expect(upsertDeferredScript).toContain(
-      'jq -s \'add\' "${FINDINGS}" "${CARRY}" > "${MERGED}"',
+    // Argument order is the freshness guarantee (unique_by keeps
+    // first-of-group in original order), and both inputs must BE arrays —
+    // `add` on two non-arrays yields whatever they add to.
+    expect(upsertDeferredScript).toMatch(
+      /if \(map\(type == "array"\) \| all\) then add else empty end'[\s\S]{0,40}"\$\{FINDINGS\}" "\$\{CARRY\}" > "\$\{MERGED\}"/,
     );
     expect(repairStep).toContain(
       'mv "${WORKDIR}/deferred-findings.carry.next" \\\n                  "${WORKDIR}/deferred-findings.carry.json"',
@@ -11279,12 +11282,13 @@ exit 1
       findings: '[{"id":7,"reason":"this round is fine"}]',
       carry: 'not json at all',
     });
-    // The message no longer claims to know WHICH side is corrupt — jq -s
-    // fails if either input is unparseable (R10-12).
+    // An unparseable carry is now caught by the single-document gate, which
+    // names it precisely — and still costs only the carry: this round's
+    // valid findings are published (the asymmetry R9-18 settled on).
     expect(unparseableCarry.out).toContain(
-      "could not merge this round's deferrals with the carried sidecar",
+      'the carried deferrals are not a single JSON document',
     );
-    expect(unparseableCarry.out).toContain('one of the two is unparseable');
+    expect(unparseableCarry.out).toContain('The carried set is LOST');
     expect(unparseableCarry.calls).toContain('- rc:7 ');
     // But a bad set of OUR OWN is still a loud, total abort.
     const poisonedOwn = runUpsert({
@@ -11328,6 +11332,24 @@ exit 1
         '[{"id":21,"source":"review","reason":"修复内存泄漏问题"},' +
         '{"id":21,"source":"review","reason":"修复资源泄漏"}]',
     });
+    // A multi-document file: `jq -e` without -s judges only the LAST
+    // document, so `[valid]\n[]` used to exit 0 silently (findings lost, no
+    // warning) and `[bad]\n[valid]` used to pass the shape gate. Both are
+    // now rejected loudly, before any write.
+    for (const bad of [
+      '[{"id":7,"reason":"r"}]\n[]',
+      '[{"id":"x","reason":"r"}]\n[{"id":8,"reason":"r"}]',
+    ]) {
+      const multi = runUpsert({ findings: bad });
+      expect(multi.out).toContain('not a single JSON document');
+      expect(multi.calls).toBe('');
+    }
+    // The stage step must tolerate the script being absent from the trusted
+    // base (it only exists there after this PR merges) — the consumers' own
+    // empty-content guard then skips the round instead of killing the step.
+    expect(workflow).toContain(
+      'cat .github/scripts/upsert-deferred-issue.sh 2> /dev/null || true',
+    );
     // RC-1: the resolved-id corpus grows with the round's resolutions, and
     // one argv element caps at MAX_ARG_STRLEN — the same failure `known`
     // already avoided. Both corpora go in via --rawfile now.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10418,8 +10418,43 @@ exit 1
       // GH_CONFIG_DIR is minted INSIDE the clean child (its mktemp cannot be
       // shadowed there); PATH is the trusted staged value and GH_HOST is
       // pinned in the allow-list (a reroute cannot spoof the identity check).
-      expect(step).toContain('PATH="${TRUSTED_PATH}"');
-      expect(step).toContain('GH_HOST=github.com');
+      // R6-7: every allow-list entry that mints the child's environment is
+      // pinned by name — a symmetric deletion from both children (invisible
+      // to the childCore equality below) must fail here.
+      for (const entry of [
+        'PATH="${TRUSTED_PATH}"',
+        'GITHUB_TOKEN="${GITHUB_TOKEN}"',
+        'GH_HOST=github.com',
+        'RUNNER_TEMP="${RUNNER_TEMP}"',
+        'WORKDIR="${WORKDIR}"',
+        'PR="${PR}"',
+        'REPO="${REPO}"',
+        'AUTOFIX_BOT="${AUTOFIX_BOT}"',
+        'UPSERT_SHA256="${UPSERT_SHA256}"',
+      ]) {
+        expect(step).toContain(entry);
+      }
+      // R6-8: LD_* cannot be enumerated (LD_TRACE_LOADED_OBJECTS is
+      // presence-tested — even an empty assignment makes the loader print and
+      // exit 0 without running the child), so liveness is VERIFIED: the child
+      // prints a sentinel first, and its absence is reported.
+      expect(step).toContain('printf "%s\\n" "__upsert_child_live__"');
+      expect(step).toContain(
+        '::warning::deferred-findings upsert child never started',
+      );
+      // The inspection uses bash BUILTINS only: under trace mode an external
+      // grep would itself print-and-exit-0, neutering the very check meant to
+      // detect it (measured).
+      expect(step).toMatch(
+        /if \[\[ "\$\{UPSERT_OUT\}" != \*'__upsert_child_live__'\* \]\]; then/,
+      );
+      expect(step).not.toMatch(/UPSERT_OUT\}" \| grep/);
+      // R6-4: the child's own GH_CONFIG_DIR mktemp is guarded — an empty value
+      // would silently fall back to the shared ~/.config/gh.
+      expect(step).toContain(
+        'if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then',
+      );
+      expect(step).toContain('::warning::could not create a gh config dir');
       // Ordering: the digest gate runs, and ONLY on a match does the staged
       // script execute — both inside the same clean child. A reordering or a
       // gate-condition flip must fail here.
@@ -10466,6 +10501,22 @@ exit 1
     );
     expect(reviewAddressReportStep).toContain(
       '[[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]',
+    );
+    // R6-5: and it runs AFTER the digest gate but BEFORE the staged script —
+    // presence alone would survive a reordering that writes with an unverified
+    // identity.
+    const idIdx = reviewAddressReportStep.indexOf(
+      'UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user',
+    );
+    expect(idIdx).toBeGreaterThan(
+      reviewAddressReportStep.indexOf(
+        'if ! echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+      ),
+    );
+    expect(idIdx).toBeLessThan(
+      reviewAddressReportStep.indexOf(
+        'bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
+      ),
     );
     // The failure step carries TRUSTED_PATH in env so the clean child gets a
     // trusted PATH; the in-shell BASH_FUNC/proxy sweep and the in-step PATH
@@ -10521,12 +10572,26 @@ exit 1
       commentsFail = false,
       writeFail = false,
       mktempFail = false,
+      jqFail = false,
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-upsert-'));
       const bin = join(dir, 'bin');
       mkdirSync(bin);
       writeFileSync(join(dir, 'deferred-findings.json'), findings);
       if (resolved) writeFileSync(join(dir, 'resolved-comments.txt'), resolved);
+      if (jqFail) {
+        // Fail ONLY the line-builder jq (the sole call passing --rawfile), so
+        // the shape gate still passes and the failure lands where intended.
+        writeFileSync(
+          join(bin, 'jq'),
+          [
+            '#!/usr/bin/env bash',
+            'for a in "$@"; do [[ "$a" == "--rawfile" ]] && exit 3; done',
+            'exec /usr/bin/jq "$@"',
+          ].join('\n'),
+        );
+        chmodSync(join(bin, 'jq'), 0o755);
+      }
       if (mktempFail) {
         // Shadow mktemp on PATH with a failing stub (simulates /tmp
         // exhaustion): the script must warn+skip, not silently exit 0.
@@ -10647,12 +10712,18 @@ exit 1
     });
     expect(badShape.out).toContain('malformed');
     expect(badShape.calls).toBe('');
-    // A failed write logs NOT persisted — success is never claimed.
+    // A failed write never claims success, and says the findings are LOST —
+    // the watermark filters this round's feedback out of every later round, so
+    // "NOT persisted this round" would wrongly imply a retry. The lost bullets
+    // are named for a maintainer.
     const writeFail = runUpsert({
       findings: '[{"id":7,"reason":"r"}]',
       writeFail: true,
     });
-    expect(writeFail.out).toContain('NOT persisted');
+    expect(writeFail.out).toContain('are LOST');
+    expect(writeFail.out).toContain('watermark-gated');
+    expect(writeFail.out).toContain('- rc:7 ');
+    expect(writeFail.out).not.toContain('NOT persisted this round');
     // Path bytes are sanitized before rendering (no forged bullet lines).
     const forged = runUpsert({
       findings: '[{"id":4,"path":"a`\\n- rc:999 `z","reason":"r"}]',
@@ -10717,7 +10788,8 @@ exit 1
       writeFail: true,
     });
     expect(appendFail.out).toContain('could not append');
-    expect(appendFail.out).toContain('NOT persisted');
+    expect(appendFail.out).toContain('are LOST');
+    expect(appendFail.out).toContain('- rc:7 ');
     // The dedupe corpus is BOT-authored comments only: a third party posting
     // a line-start bullet on the public tracking issue cannot permanently
     // suppress a deferred finding.
@@ -10812,6 +10884,38 @@ exit 1
     expect(capped2.out).not.toContain('re-defer them in a later round');
     expect(capped2.out).toContain('- rc:21 ');
     expect(capped2.out).toContain('- rc:22 ');
+    // R6-9: the reason is agent-influenced prose published under the bot
+    // identity, so mentions are defused before rendering. Bare `@` gets a
+    // ZWSP; the entity spellings GitHub decodes BEFORE its mention filter
+    // (&#64; &#x40; &#0064; &commat;) get their `&` escaped. Both measured
+    // inert against the real renderer — `\@` and leaving `&` alone are NOT.
+    const mentions = runUpsert({
+      findings:
+        '[{"id":12,"reason":"ping @wenshao &#64;bot &#x40;x &commat;y &#0064;z"}]',
+    });
+    expect(mentions.calls).toContain('@\u200bwenshao');
+    expect(mentions.calls).not.toMatch(/@wenshao/);
+    for (const ent of ['&#64;', '&#x40;', '&commat;', '&#0064;']) {
+      expect(mentions.calls).toContain(`&amp;${ent.slice(1)}`);
+    }
+    // R6-2: the shape gate's reason-type clause and the `. > 0` id bound.
+    // id 0 is the discriminator for the latter — "0" passes the plain-digits
+    // belt, so only `. > 0` rejects it.
+    for (const bad of ['[{"id":7,"reason":5}]', '[{"id":0,"reason":"r"}]']) {
+      const r = runUpsert({ findings: bad });
+      expect(r.out).toContain('malformed');
+      expect(r.calls).toBe('');
+    }
+    // R6-6: a line-builder failure warns instead of exiting silently as
+    // "nothing new" (the last path that skipped the header contract).
+    const builderFail = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      jqFail: true,
+    });
+    expect(builderFail.out).toContain(
+      'could not build the deferred-findings lines',
+    );
+    expect(builderFail.calls).not.toContain('-f title=');
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10542,7 +10542,16 @@ exit 1
     // R5-5: both --paginate sites are pinned at the source (the recording gh
     // stub ignores the flag). Dropping either silently truncates the lookup
     // or the dedupe corpus.
-    expect(upsertDeferredScript.match(/--paginate/g) ?? []).toHaveLength(2);
+    // Only the tracking issue's OWN comments are paginated now; the issue
+    // lookup is a bounded, early-exit page loop (a full --paginate there
+    // re-downloaded the bot's entire lifetime corpus every defer round).
+    expect(
+      upsertDeferredScript
+        .split('\n')
+        .filter(
+          (l) => !l.trimStart().startsWith('#') && l.includes('--paginate'),
+        ),
+    ).toHaveLength(1);
     for (const step of [pushAndReportStep, reviewAddressReportStep]) {
       expect(step).toContain(
         "UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'",
@@ -10603,6 +10612,8 @@ exit 1
       mktempFail = false,
       jqFail = false,
       carry = '',
+      listPages = null,
+      listErr = '',
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-upsert-'));
       const bin = join(dir, 'bin');
@@ -10610,6 +10621,13 @@ exit 1
       writeFileSync(join(dir, 'deferred-findings.json'), findings);
       if (carry)
         writeFileSync(join(dir, 'deferred-findings.carry.json'), carry);
+      const pagesDir = join(dir, 'pages');
+      if (listPages) {
+        mkdirSync(pagesDir);
+        listPages.forEach((body, i) =>
+          writeFileSync(join(pagesDir, `${i + 1}.json`), body),
+        );
+      }
       if (resolved) writeFileSync(join(dir, 'resolved-comments.txt'), resolved);
       if (jqFail) {
         // Fail ONLY the line-builder jq (the sole call passing --rawfile), so
@@ -10636,7 +10654,13 @@ exit 1
           '#!/usr/bin/env bash',
           'printf "%s\\n" "$*" >> "$GHLOG"',
           'case "$2" in',
-          '  *"issues?state=all"*) [[ "$LIST_FAIL" == 1 ]] && exit 1; printf "%s" "$LIST_JSON";;',
+          '  *"issues?state=all"*)',
+          '    if [[ "$LIST_FAIL" == 1 ]]; then printf "%s" "$LIST_ERR" >&2; exit 1; fi',
+          '    page="${2##*&page=}"',
+          '    if [[ -n "$LIST_PAGES_DIR" && -f "$LIST_PAGES_DIR/$page.json" ]]; then',
+          '      cat "$LIST_PAGES_DIR/$page.json"; exit 0',
+          '    fi',
+          '    printf "%s" "$LIST_JSON";;',
           '  */comments?per_page=100*) [[ "$COMMENTS_FAIL" == 1 ]] && exit 1; printf "%s" "$COMMENTS_JSON";;',
           '  */comments) [[ "$WRITE_FAIL" == 1 ]] && exit 1; echo ok;;',
           '  repos/*/issues) [[ "$WRITE_FAIL" == 1 ]] && exit 1; echo 77;;',
@@ -10661,6 +10685,8 @@ exit 1
             GHLOG: join(dir, 'gh.log'),
             LIST_JSON: list,
             LIST_FAIL: listFail ? '1' : '0',
+            LIST_ERR: listErr,
+            LIST_PAGES_DIR: listPages ? pagesDir : '',
             BODY_TEXT: body,
             BODY_FAIL: bodyFail ? '1' : '0',
             COMMENTS_JSON: comments,
@@ -11024,6 +11050,70 @@ exit 1
     expect(carryMerged.calls).toContain('- rc:31 ');
     expect(carryMerged.calls).toContain('- rc:32 ');
     expect(carryMerged.calls.split('- rc:32 ').length - 1).toBe(1);
+    // R2-6: the lookup is bounded and newest-first, stopping at the first
+    // marker match — the common case costs ONE request instead of paginating
+    // every issue the bot has ever opened.
+    const lookupReqs = (r) =>
+      r.calls.split('\n').filter((l) => l.includes('issues?state=all')).length;
+    const fullPage = JSON.stringify(
+      Array.from({ length: 100 }, (_, i) => ({
+        number: 1000 + i,
+        body: 'filler',
+        pull_request: null,
+      })),
+    );
+    const hitPage = JSON.stringify([
+      { number: 42, body: marker, pull_request: null },
+    ]);
+    const firstPageHit = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      listPages: [hitPage],
+    });
+    expect(lookupReqs(firstPageHit)).toBe(1);
+    expect(firstPageHit.calls).toContain('issues/42/comments -f body=');
+    // A short page means the corpus is exhausted: create, still one request.
+    const emptyCorpus = runUpsert({ findings: '[{"id":7,"reason":"r"}]' });
+    expect(lookupReqs(emptyCorpus)).toBe(1);
+    expect(emptyCorpus.calls).toContain('-f title=');
+    // A full page without a match walks to the next one and stops there.
+    const secondPageHit = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      listPages: [fullPage, hitPage],
+    });
+    expect(lookupReqs(secondPageHit)).toBe(2);
+    expect(secondPageHit.calls).toContain('issues/42/comments -f body=');
+    // Cap reached with the corpus never exhausted: SKIP rather than create a
+    // second tracking issue for the same PR.
+    const cappedLookup = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      listPages: Array.from({ length: 12 }, () => fullPage),
+    });
+    expect(lookupReqs(cappedLookup)).toBe(10);
+    expect(cappedLookup.out).toContain('10-page cap');
+    expect(cappedLookup.calls).not.toContain('-f title=');
+    // R2-10: warnings NAME the cause — a rate limit, a bad credential and a
+    // transport error were indistinguishable while stderr went to /dev/null.
+    const rateLimited = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      listFail: true,
+      listErr: 'HTTP 403: API rate limit exceeded for user ID 1',
+    });
+    expect(rateLimited.out).toContain('API rate limit exceeded');
+    const badCreds = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      listPages: [hitPage],
+      writeFail: true,
+    });
+    expect(badCreds.out).toContain('could not append');
+    // The captured stderr is `::`-neutralized like every other echoed
+    // API/agent content — an error body is not trusted to be command-free.
+    const forgedErr = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      listFail: true,
+      listErr: '::error::forged from an API body',
+    });
+    expect(forgedErr.out).toContain(';;error;;forged');
+    expect(forgedErr.out).not.toContain('::error::forged');
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10480,8 +10480,10 @@ exit 1
         argList.match(/[A-Z_][A-Z0-9_]*=(?:"[^"]*"|[^\s\\]*)/g) ?? []
       ).map((m) => m.trim());
       const passed = assignments.map((m) => m.split('=')[0]);
-      expect(new Set(passed)).toEqual(
-        new Set([
+      // Sorted multiset, not a Set: a symmetric duplicate entry is exactly
+      // the mutation this check exists to catch, and a Set hides it.
+      expect([...passed].sort()).toEqual(
+        [
           // the LD_* command-prefix assignments lead the launch line
           'LD_PRELOAD',
           'LD_AUDIT',
@@ -10499,7 +10501,7 @@ exit 1
           'REPO',
           'AUTOFIX_BOT',
           'UPSERT_SRC',
-        ]),
+        ].sort(),
       );
       // Every entry pinned by its exact token, including UPSERT_SRC — the
       // script CONTENT, which is what makes the staged copy (and its digest
@@ -10567,7 +10569,7 @@ exit 1
       // R8-5: the captured output is re-emitted, so the child's warnings
       // actually reach the log (deleting both loops was invisible).
       expect(step).toMatch(
-        /while IFS= read -r _upsert_line; do\n\s*\[\[ "\$\{_upsert_line\}" == '__upsert_child_live__' \]\] \|\|\n\s*printf '%s\\n' "\$\{_upsert_line\/\/::\/;;\}"\n\s*done <<< "\$\{UPSERT_OUT\}"/,
+        /while IFS= read -r _upsert_line; do[\s\S]*?== __upsert_trusted__\*[\s\S]*?printf '%s\\n' "\$\{_upsert_line#__upsert_trusted__\}"[\s\S]*?printf '%s\\n' "\$\{_upsert_line\/\/::\/;;\}"[\s\S]*?done <<< "\$\{UPSERT_OUT\}"/,
       );
       // Ordering: the script executes INSIDE the clean child, after the
       // launch — a relocation outside it must fail here.
@@ -10644,6 +10646,11 @@ exit 1
     expect(stageStep).toContain('cat .github/scripts/upsert-deferred-issue.sh');
     expect(stageStep).toMatch(
       /_upsert_delim="EOF_\$\(head -c 16 \/dev\/urandom/,
+    );
+    // …and the CLOSING delimiter: an unterminated heredoc would swallow the
+    // rest of GITHUB_OUTPUT into the value.
+    expect(stageStep).toMatch(
+      /echo "upsert_src<<\$\{_upsert_delim\}"\n(?:\s*#[^\n]*\n)*\s*cat [^\n]*\n\s*echo "\$\{_upsert_delim\}"/,
     );
     expect(workflow).not.toMatch(/upsert_sha256/);
     expect(workflow).not.toMatch(
@@ -10722,6 +10729,11 @@ exit 1
     expect(repairStep).toContain(
       '::warning::could not merge carried deferrals across the repair',
     );
+    // The merge-failure path QUARANTINES this round's set instead of deleting
+    // it, which is what makes the warning's artifact pointer true.
+    expect(repairStep).toContain(
+      'mv "${WORKDIR}/deferred-findings.json" \\\n                  "${WORKDIR}/deferred-findings.unmerged.json"',
+    );
     // R8-3: that branch discards THIS run's set, so it dumps it first —
     // `::` neutralized, like every other echo of agent-written content.
     expect(repairStep).toMatch(
@@ -10768,6 +10780,7 @@ exit 1
       writeFail = false,
       mktempFail = false,
       jqFail = false,
+      bsdWc = false,
       carry = '',
       listPages = null,
       listErr = '',
@@ -10801,6 +10814,15 @@ exit 1
           ].join('\n'),
         );
         chmodSync(join(bin, 'jq'), 0o755);
+      }
+      if (bsdWc) {
+        // BSD/macOS `wc` pads its count with leading spaces; GNU does not, so
+        // the padding bug is invisible on Linux CI without this stub.
+        writeFileSync(
+          join(bin, 'wc'),
+          '#!/usr/bin/env bash\nprintf "%8s\\n" "$(/usr/bin/wc "$@" | tr -d \' \')"\n',
+        );
+        chmodSync(join(bin, 'wc'), 0o755);
       }
       if (mktempFail) {
         // Shadow mktemp on PATH with a failing stub (simulates /tmp
@@ -11303,6 +11325,17 @@ exit 1
     });
     expect(freshWins.calls).toContain('fresh');
     expect(freshWins.calls).not.toContain('stale');
+    // BSD/macOS `wc -l` pads with leading spaces, and the count is
+    // interpolated into the cap warning and the success line — so the script
+    // strips it. Driven with a padding `wc` stub, since GNU wc never pads and
+    // the regression is invisible on Linux otherwise.
+    const padded = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      bsdWc: true,
+    });
+    expect(padded.out).toContain('(1 of 1 new)');
+    expect(padded.out).not.toMatch(/\(\s+1 of/);
+    expect(padded.out).not.toMatch(/of\s{2,}1 new/);
     // R10-4: the 200-char path cap and 500-char reason cap are behaviour, so
     // they get behavioural coverage rather than a static pin.
     const cappedFields = runUpsert({

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2917,7 +2917,7 @@ describe('qwen-autofix workflow', () => {
     // forces a deliberate test update, however it is spaced or line-wrapped:
     // bump this count AND pipe the new site through the normalizer (bumping
     // the count below too) — bumping this pin alone leaves toBe(9) green.
-    expect(workflow.split('--paginate').length - 1).toBe(15);
+    expect(workflow.split('--paginate').length - 1).toBe(16);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites. The
     // blocked-takeover status lookup is deliberately NOT among them: like the
@@ -10357,6 +10357,63 @@ exit 1
     expect(fuzz.advisory).toContain('outside the PR footprint');
   });
 
+  it('upserts deferred findings into a per-PR issue that survives the merge', () => {
+    // Wiring: the upsert runs for BOTH outcomes (after each shared
+    // resolve/reply call), the agent file rides the artifact dump and the
+    // repair cleanup, and SKILL documents the fourth disposition.
+    expect(
+      pushAndReportStep.split(
+        'resolve_and_reply_threads\n            upsert_deferred_issue',
+      ).length - 1,
+    ).toBe(2);
+    expect(reviewAddressJob).toContain(
+      'comment-replies.json deferred-findings.json pr.diff',
+    );
+    expect(reviewAddressJob).toContain(
+      '"${WORKDIR}/deferred-findings.json" \\',
+    );
+    const skill = readAutofixSkill();
+    expect(skill).toContain('Defer to follow-up');
+    expect(skill).toContain('deferred-findings.json');
+    expect(skill).toContain('you defer what is worth doing');
+
+    // Shape validation: only a non-empty array of {id:number,
+    // reason:string} passes.
+    const validateJq = pushAndReportStep.match(
+      /jq -e 'type == "array" and length > 0 and all\(\.\[\];[\s\S]*?\(\.reason \| type == "string"\)\)'/,
+    )?.[0];
+    expect(validateJq).toBeTruthy();
+    const prog = validateJq.match(/'([\s\S]*)'/)?.[1];
+    const validates = (json) =>
+      spawnSync('jq', ['-e', prog], { input: json, encoding: 'utf8' })
+        .status === 0;
+    expect(validates('[{"id":1,"reason":"r"}]')).toBe(true);
+    expect(validates('[]')).toBe(false);
+    expect(validates('[{"id":"1","reason":"r"}]')).toBe(false);
+    expect(validates('{"id":1}')).toBe(false);
+
+    // Line building: dedupe against the existing issue body by rc id,
+    // flatten newlines, truncate, and neutralize markers.
+    const linesJq = pushAndReportStep.match(
+      /jq -r --arg body "\$\{existing_body\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/deferred-findings\.json"/,
+    )?.[1];
+    expect(linesJq).toBeTruthy();
+    const lines = (items, body) =>
+      spawnSync('jq', ['-r', '--arg', 'body', body, linesJq], {
+        input: JSON.stringify(items),
+        encoding: 'utf8',
+      }).stdout;
+    const built = lines(
+      [
+        { id: 7, path: 'src/a.ts', reason: 'real\nbut out of\r\nscope' },
+        { id: 8, reason: 'already tracked' },
+      ],
+      'existing…\n- rc:8 `x`: already tracked',
+    );
+    expect(built).toContain('- rc:7 `src/a.ts`: real but out of scope');
+    expect(built).not.toContain('rc:8');
+  });
+
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {
     const block = reviewVerificationRunner.match(
       /(# Bite check:[\s\S]*?)\nassert_verification_tree\necho "verified_head/,
@@ -11095,7 +11152,7 @@ exit 1
       '::warning::Failed to post handoff comment on PR #${PR}',
     );
     expect(reviewAddressReportStep).toContain('human should take over');
-    // Token-breaking neutralization at ALL EIGHT agent-derived publish sites
+    // Token-breaking neutralization at ALL TEN agent-derived publish sites
     // (address-summary, no-action, DETAIL_FILE, API_ERROR_DETAIL, the
     // gate-rejection body, the comment-reply body whose content is agent
     // stdout that can echo external comment text, the two
@@ -11110,7 +11167,7 @@ exit 1
     // backslashes — a NO-OP on both GNU and BSD sed, verified) left the count
     // at four and this test green, shipping an unescaped publish site.
     const escapeSites = workflow.match(/sed 's\/<!--\/[^']*\/g'/g) ?? [];
-    expect(escapeSites).toHaveLength(9);
+    expect(escapeSites).toHaveLength(10);
     for (const site of escapeSites) {
       expect(site).toBe("sed 's/<!--/<!\\\\-\\\\-/g'");
     }

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10411,13 +10411,12 @@ exit 1
   });
 
   it('upserts deferred findings into a per-PR issue that survives the merge', () => {
-    // Wiring: the staged script runs after both shared resolve/reply call
-    // sites AND on the failure/handoff path (a failed round must not lose
-    // verified findings); it is staged from the trusted base; the agent
-    // file rides the artifact dump and the repair cleanup; SKILL documents
-    // the fourth disposition.
-    // The staged script is executed from the bytes read and hashed in the
-    // child, never re-opened by path (R9-1), at both call sites.
+    // Wiring: the upsert runs after both shared resolve/reply call sites
+    // AND on the failure/handoff path (a failed round must not lose verified
+    // findings); its content is captured from the trusted base at stage
+    // time; the agent file rides the artifact dump and the repair cleanup;
+    // SKILL documents the fourth disposition. The script is executed from
+    // that content, never opened by path, at both call sites.
     expect(workflow.split('bash -c "${UPSERT_SRC}"').length - 1).toBe(2);
     // R10-8: bound EVERY execution of the staged path, not one spelling —
     // `sh …`, `bash -- …`, `source …`, `. …`, `exec bash …` all re-open it.
@@ -10440,7 +10439,7 @@ exit 1
       ) ?? [],
     ).toHaveLength(2);
     // Sound isolation, NOT an in-shell denylist: both upsert sites run the
-    // digest gate + staged script in a fresh `/usr/bin/env -i` child. The
+    // script in a fresh `/usr/bin/env -i` child. The
     // absolute path is load-bearing — bash never does function/alias lookup
     // on a slash-bearing word, so a planted BASH_FUNC_env%% cannot intercept
     // it — and `-i` drops every BASH_FUNC_*/BASH_ENV/SHELLOPTS/alias/trap
@@ -10570,9 +10569,8 @@ exit 1
       expect(step).toMatch(
         /while IFS= read -r _upsert_line; do\n\s*\[\[ "\$\{_upsert_line\}" == '__upsert_child_live__' \]\] \|\|\n\s*printf '%s\\n' "\$\{_upsert_line\/\/::\/;;\}"\n\s*done <<< "\$\{UPSERT_OUT\}"/,
       );
-      // Ordering: the digest gate runs, and ONLY on a match does the staged
-      // script execute — both inside the same clean child. A reordering or a
-      // gate-condition flip must fail here.
+      // Ordering: the script executes INSIDE the clean child, after the
+      // launch — a relocation outside it must fail here.
       const execIdx = step.indexOf('bash -c "${UPSERT_SRC}"');
       const launchIdx = argStart;
       expect(execIdx).toBeGreaterThan(launchIdx);
@@ -10580,9 +10578,9 @@ exit 1
     expect(workflow.split('/usr/bin/env -i \\').length - 1).toBe(2);
     // R5-6: the failure-path child is near-verbatim of run_deferred_upsert's
     // child — tie their shared security scaffold together so drift in one is
-    // caught. Compare the allow-list + prelude + digest gate (everything up
-    // to where the failure path inserts its identity check), whitespace-
-    // normalized to absorb the one-level indent difference.
+    // caught. Compare the allow-list + prelude (everything up to where the
+    // failure path inserts its identity check), whitespace-normalized to
+    // absorb the one-level indent difference.
     const childCore = (step) =>
       step
         .match(
@@ -10611,9 +10609,9 @@ exit 1
     expect(reviewAddressReportStep).toContain(
       '[[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]',
     );
-    // R6-5: and it runs AFTER the digest gate but BEFORE the staged script —
-    // presence alone would survive a reordering that writes with an unverified
-    // identity.
+    // The identity check runs after the child launches but BEFORE the script
+    // — presence alone would survive a reordering that writes with an
+    // unverified identity.
     const idIdx = reviewAddressReportStep.indexOf(
       'UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user',
     );
@@ -12266,7 +12264,7 @@ exit 1
     // at four and this test green, shipping an unescaped publish site.
     const escapeSites = workflow.match(/sed 's\/<!--\/[^']*\/g'/g) ?? [];
     expect(escapeSites).toHaveLength(9);
-    // The tenth agent-derived publish site lives in the staged
+    // The tenth agent-derived publish site lives in
     // upsert-deferred-issue.sh (line builder). It escapes INSIDE jq, not in a
     // sed afterwards: the rv/ic dedupe identity is the rendered line, so
     // escaping after the corpus comparison meant a reason containing `<!--`

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8217,10 +8217,6 @@ exit 1
       [publishPrStep, 'GH_TOKEN="${GITHUB_TOKEN}" gh api user'],
       [pushAndReportStep, 'GH_TOKEN="${GITHUB_TOKEN}" gh api user'],
       [prepareStep, 'PR_LIVE="$(gh pr view'],
-      // The review-address failure/handoff report step makes PAT-bearing gh
-      // calls after agent/branch code too (handoff comment + deferred
-      // upsert), so it carries the same hygiene preamble.
-      [reviewAddressReportStep, 'GH_TOKEN="${GITHUB_TOKEN}" gh api user'],
     ]) {
       const ghPin = step.indexOf('export GH_HOST=github.com');
       expect(ghPin).toBeGreaterThan(-1);
@@ -8232,20 +8228,14 @@ exit 1
       );
       expect(step.indexOf(firstGh)).toBeGreaterThan(-1);
       expect(ghPin).toBeLessThan(step.indexOf(firstGh));
-      // bash startup channels (BASH_ENV sourced by every child bash;
-      // BASH_FUNC_*%% exported functions outrank PATH in children) and
-      // gh-side transport channels (proxy reroute, SSL_CERT_* CA re-root)
-      // are $GITHUB_ENV-plantable too — swept before the first gh call.
-      const bashSweep = step.indexOf(
-        'unset BASH_ENV ENV HTTPS_PROXY HTTP_PROXY ALL_PROXY \\',
-      );
-      expect(bashSweep).toBeGreaterThan(-1);
-      expect(bashSweep).toBeLessThan(step.indexOf(firstGh));
-      expect(step).toContain(
-        'https_proxy http_proxy all_proxy SSL_CERT_FILE SSL_CERT_DIR',
-      );
-      expect(step).toContain('BASH_FUNC_*%%');
-      expect(step).toContain('unset -f');
+    }
+    // The in-shell BASH_FUNC/proxy denylist sweep an earlier round added to
+    // these steps was removed: an in-shell sweep bootstraps trust from the
+    // very namespace it sanitizes (a planted BASH_FUNC_env%%/unset%%/alias/
+    // DEBUG-trap defeats it). Nothing re-introduces it.
+    for (const step of [publishPrStep, pushAndReportStep, prepareStep]) {
+      expect(step).not.toContain('BASH_FUNC_*%%');
+      expect(step).not.toContain('done < <(env)');
     }
     // The fork fetch and salvage fetch cannot recurse into a planted
     // submodule and execute an ext:: URL with the PAT (env-level
@@ -10401,10 +10391,26 @@ exit 1
         /resolve_and_reply_threads\n(?:\s*#[^\n]*\n)*\s*run_deferred_upsert\n/g,
       ) ?? [],
     ).toHaveLength(2);
-    // The failure-path invocation sits INSIDE the DRY_RUN/STALE/token guard
-    // (deleting the guard or relocating the call would break this slice).
+    // Sound isolation, NOT an in-shell denylist: both upsert sites run the
+    // digest gate + staged script in a fresh `/usr/bin/env -i` child. The
+    // absolute path is load-bearing — bash never does function/alias lookup
+    // on a slash-bearing word, so a planted BASH_FUNC_env%% cannot intercept
+    // it — and `-i` drops every BASH_FUNC_*/BASH_ENV/SHELLOPTS/alias/trap
+    // before any gated work. Exactly two clean-child launches (both arms of
+    // 'Push and report' share run_deferred_upsert; the failure path has its
+    // own).
+    for (const step of [pushAndReportStep, reviewAddressReportStep]) {
+      expect(step).toContain('/usr/bin/env -i \\');
+      expect(step).toContain('bash --norc -c');
+      // GH_CONFIG_DIR is minted INSIDE the clean child (its mktemp cannot be
+      // shadowed there), and PATH is the trusted staged value passed in.
+      expect(step).toContain('PATH="${TRUSTED_PATH}"');
+    }
+    expect(workflow.split('/usr/bin/env -i \\').length - 1).toBe(2);
+    // The failure-path clean-child launch sits INSIDE the DRY_RUN/STALE/token
+    // guard (deleting the guard or relocating the call breaks this slice).
     expect(reviewAddressReportStep).toMatch(
-      /if \[\[ "\$\{DRY_RUN\}" != "true" && "\$\{STALE:-\}" != "true" && -n "\$\{GITHUB_TOKEN:-\}" \]\]; then(?:(?!\n {10}fi\n)[\s\S])*upsert-deferred-issue\.sh(?:(?!\n {10}fi\n)[\s\S])*\n {10}fi\n/,
+      /if \[\[ "\$\{DRY_RUN\}" != "true" && "\$\{STALE:-\}" != "true" && -n "\$\{GITHUB_TOKEN:-\}" \]\]; then(?:(?!\n {10}fi\n)[\s\S])*\/usr\/bin\/env -i(?:(?!\n {10}fi\n)[\s\S])*\n {10}fi\n/,
     );
     // Pre-stage failures leave UPSERT_SHA256 empty: that skips with a plain
     // notice instead of imitating a tamper alarm.
@@ -10412,24 +10418,19 @@ exit 1
       'deferred-findings upsert skipped: stage step never ran',
     );
     // The failure path can run without POST_HANDOFF's identity check
-    // (OUTCOME=fixed/noop), so it verifies the PAT identity itself.
+    // (OUTCOME=fixed/noop), so the clean child verifies the PAT identity.
     expect(reviewAddressReportStep).toContain(
       'UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user',
     );
     expect(reviewAddressReportStep).toContain(
       '[[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]',
     );
-    // The failure step pins PATH to the staged trusted value (guarded for
-    // pre-stage crashes) BEFORE its digest gate runs.
+    // The failure step carries TRUSTED_PATH in env so the clean child gets a
+    // trusted PATH; the in-shell BASH_FUNC/proxy sweep and the in-step PATH
+    // pin an earlier round added here were removed with the rest of the
+    // unsound denylist.
     expect(reviewAddressReportStep).toContain(
       "TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'",
-    );
-    const failPathPin = reviewAddressReportStep.indexOf(
-      'export PATH="${TRUSTED_PATH}"',
-    );
-    expect(failPathPin).toBeGreaterThan(-1);
-    expect(failPathPin).toBeLessThan(
-      reviewAddressReportStep.indexOf('sha256sum -c'),
     );
     expect(workflow).toContain(
       'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
@@ -10705,6 +10706,22 @@ exit 1
     });
     expect(neutralized.calls).toContain('<!\\-\\-');
     expect(neutralized.calls).not.toContain('<!--');
+    // The common case — nothing deferred this round — is a clean exit 0 with
+    // no gh call and no warning (empty file: the -s guard). Deleting that
+    // guard would send an empty file into the shape gate and warn falsely.
+    const empty = runUpsert({ findings: '' });
+    expect(empty.calls).toBe('');
+    expect(empty.out).not.toContain('malformed');
+    expect(empty.out).not.toContain('::warning');
+    // A contract-valid empty array is a no-op too, NOT a corruption alarm:
+    // `[]` passes the -s check (3 bytes) yet must not warn "malformed".
+    const emptyArray = runUpsert({ findings: '[]' });
+    expect(emptyArray.calls).toBe('');
+    expect(emptyArray.out).not.toContain('malformed');
+    // noclobber cannot silently empty the dedupe corpus: the script clears
+    // it (`set +C`), and the workflow additionally runs it in an env -i
+    // child that drops the read-only SHELLOPTS entirely.
+    expect(upsertDeferredScript).toContain('set +C');
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10499,15 +10499,15 @@ exit 1
           'PR',
           'REPO',
           'AUTOFIX_BOT',
-          'UPSERT_SHA256',
-          'UPSERT_LOG',
+          'UPSERT_SRC',
         ]),
       );
-      // Every entry pinned by its exact token, including UPSERT_LOG (the one
-      // isolation entry whose value was unpinned).
+      // Every entry pinned by its exact token, including UPSERT_SRC — the
+      // script CONTENT, which is what makes the staged copy (and its digest
+      // gate, and its check-then-use window) unnecessary.
       for (const entry of [
         'LD_PRELOAD=',
-        'UPSERT_LOG="${UPSERT_LOG}"',
+        'UPSERT_SRC="${UPSERT_SRC}"',
         'PATH="${TRUSTED_PATH}"',
         'GITHUB_TOKEN="${GITHUB_TOKEN}"',
         'GH_HOST=github.com',
@@ -10516,47 +10516,31 @@ exit 1
         'PR="${PR}"',
         'REPO="${REPO}"',
         'AUTOFIX_BOT="${AUTOFIX_BOT}"',
-        'UPSERT_SHA256="${UPSERT_SHA256}"',
       ]) {
         expect(assignments).toContain(entry.replace(/=$/, '='));
       }
-      // R9-1: the bytes that are HASHED are the bytes that RUN. A gate that
-      // hashes a path and then re-opens it to execute loses to a rename(2)
-      // between the two opens (measured: 20/20 payload executions against the
-      // old shape, 0/20 against this one).
-      expect(step).toContain(
-        'UPSERT_SRC="$(cat "${RUNNER_TEMP}/upsert-deferred-issue.sh"; printf x)"',
-      );
-      expect(step).toContain('UPSERT_SRC="${UPSERT_SRC%x}"');
+      // NO AGENT-WRITABLE PATH takes part in the privileged work. The
+      // script content arrives in expression context, so there is nothing
+      // staged to verify: no digest gate, no check-then-use window, no
+      // planted-FIFO or huge-file read. Rounds 9-12 each closed one hole in
+      // the path-based shape; removing the path closes the class.
       expect(step).toContain('bash -c "${UPSERT_SRC}"');
-      expect(step).not.toMatch(
-        /bash "\$\{RUNNER_TEMP\}\/upsert-deferred-issue\.sh"/,
+      expect(step).not.toMatch(/RUNNER_TEMP\}\/upsert-deferred-issue\.sh/);
+      // …scoped to the upsert child: the step still runs the pre-existing
+      // resanitize digest gate, which is a different staged script.
+      const childBlock = step.slice(
+        step.indexOf('LD_PRELOAD= LD_AUDIT='),
+        step.indexOf("' > /dev/null 2>&1 ; } 3>&1 )"),
       );
-      // R8-4: loader side channels (auxv dumps, ldd traces) write to the
-      // LAUNCH's stdout, which is discarded — the child logs to a private
-      // file instead, so no content filter is needed to keep them out of the
-      // parsed output. Path and read-back are fork-free: under a planted
-      // channel every external command in the parent prints to stdout, so
-      // $(mktemp)/$(cat) would return that noise inside the value.
-      expect(step).toContain(
-        'UPSERT_LOG="${RUNNER_TEMP}/autofix-upsert-log.$$"',
-      );
-      // R10-22: the step runs under `bash -eo pipefail`, where `rm -f` on a
-      // planted DIRECTORY exits 1 and kills it; `-rf` clears any shape, and
-      // `set -C` then refuses a symlink planted in between.
-      expect(step).toContain('rm -rf "${UPSERT_LOG}" 2> /dev/null || true');
-      expect(step).toMatch(
-        /if ! \(set -C; : > "\$\{UPSERT_LOG\}"\) 2> \/dev\/null; then/,
-      );
-      expect(step).not.toMatch(/rm -f "\$\{UPSERT_LOG\}"/);
-      // R10-19: `$(<missing)` is fatal under -e and no `|| true` / `if !`
-      // form rescues it (measured), so the file is TESTED before the read.
-      expect(step).toMatch(
-        /if \[\[ -f "\$\{UPSERT_LOG\}" && -r "\$\{UPSERT_LOG\}" \]\]; then\n\s*UPSERT_OUT="\$\(<"\$\{UPSERT_LOG\}"\)"/,
-      );
-      expect(step).toContain('exec > "${UPSERT_LOG}" 2>&1');
-      expect(step).toContain('UPSERT_OUT="$(<"${UPSERT_LOG}")"');
-      expect(step).toMatch(/' > \/dev\/null 2>&1 \|\| true/);
+      expect(childBlock.length).toBeGreaterThan(0);
+      expect(childBlock).not.toMatch(/sha256sum/);
+      // The child's own messages travel on fd 3, which the parent captures,
+      // while fd 1/2 — where every loader side channel writes — are
+      // discarded. No log file to plant, race, or bound.
+      expect(step).toContain('exec >&3');
+      expect(step).toMatch(/' > \/dev\/null 2>&1 ; \} 3>&1 \)"/);
+      expect(step).not.toMatch(/UPSERT_LOG/);
+      expect(step).not.toMatch(/autofix-upsert-log/);
       // R6-8: LD_* cannot be enumerated (LD_TRACE_LOADED_OBJECTS and
       // LD_SHOW_AUXV are presence-tested — even an empty assignment leaves
       // them on), so liveness is VERIFIED: the child prints a sentinel
@@ -10589,16 +10573,9 @@ exit 1
       // Ordering: the digest gate runs, and ONLY on a match does the staged
       // script execute — both inside the same clean child. A reordering or a
       // gate-condition flip must fail here.
-      const gateIdx = step.indexOf(
-        'if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then',
-      );
       const execIdx = step.indexOf('bash -c "${UPSERT_SRC}"');
-      // Anchor on the launch line: in the failure step the first textual
-      // `/usr/bin/env -i` is a NOTE comment ~560 lines earlier, which made
-      // the gate-after-launch check vacuous there.
       const launchIdx = argStart;
-      expect(gateIdx).toBeGreaterThan(launchIdx);
-      expect(execIdx).toBeGreaterThan(gateIdx);
+      expect(execIdx).toBeGreaterThan(launchIdx);
     }
     expect(workflow.split('/usr/bin/env -i \\').length - 1).toBe(2);
     // R5-6: the failure-path child is near-verbatim of run_deferred_upsert's
@@ -10609,7 +10586,7 @@ exit 1
     const childCore = (step) =>
       step
         .match(
-          /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\[\s\S]*?sha256sum \| cut -d" " -f1\)" != "\$\{UPSERT_SHA256\}" \]\]; then[\s\S]*?NOT persisted this round"\n\s*exit 0\n\s*fi/,
+          /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\[\s\S]*?could not create a gh config dir[^\n]*\n\s*exit 0\n\s*fi\n\s*export GH_CONFIG_DIR/,
         )?.[0]
         .replace(/\s+/g, ' ');
     expect(childCore(pushAndReportStep)).toBeTruthy();
@@ -10621,10 +10598,10 @@ exit 1
     expect(reviewAddressReportStep).toMatch(
       /if \[\[ "\$\{DRY_RUN\}" != "true" && "\$\{STALE:-\}" != "true" && -n "\$\{GITHUB_TOKEN:-\}" \]\]; then(?:(?!\n {10}fi\n)[\s\S])*\/usr\/bin\/env -i(?:(?!\n {10}fi\n)[\s\S])*\n {10}fi\n/,
     );
-    // Pre-stage failures leave UPSERT_SHA256 empty: that skips with a plain
+    // Pre-stage failures leave UPSERT_SRC empty: that skips with a plain
     // notice instead of imitating a tamper alarm.
     expect(reviewAddressReportStep).toMatch(
-      /if \[\[ -z "\$\{UPSERT_SHA256:-\}" \]\]; then[\s\S]*?deferred-findings upsert skipped: stage step never ran[\s\S]*?else[\s\S]*?\/usr\/bin\/env -i/,
+      /if \[\[ -z "\$\{UPSERT_SRC:-\}" \]\]; then[\s\S]*?deferred-findings upsert skipped: stage step never ran[\s\S]*?else[\s\S]*?\/usr\/bin\/env -i/,
     );
     // The failure path can run without POST_HANDOFF's identity check
     // (OUTCOME=fixed/noop), so the clean child verifies the PAT identity.
@@ -10641,9 +10618,7 @@ exit 1
       'UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user',
     );
     expect(idIdx).toBeGreaterThan(
-      reviewAddressReportStep.indexOf(
-        'if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then',
-      ),
+      reviewAddressReportStep.indexOf('LD_PRELOAD= LD_AUDIT='),
     );
     expect(idIdx).toBeLessThan(
       reviewAddressReportStep.indexOf('bash -c "${UPSERT_SRC}"'),
@@ -10664,49 +10639,21 @@ exit 1
       reviewAddressJob.match(
         /- name: 'Stage trusted schema gate and agent runner'[\s\S]*?(?=\n {6}- name: ')/,
       )?.[0] ?? '';
-    expect(stageStep).toContain(
-      'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
+    // The script travels as CONTENT captured from the trusted checkout into
+    // expression context — no staged copy on an agent-writable path, hence
+    // no digest to record or verify.
+    expect(stageStep).toContain('echo "upsert_src<<${_upsert_delim}"');
+    expect(stageStep).toContain('cat .github/scripts/upsert-deferred-issue.sh');
+    expect(stageStep).toMatch(
+      /_upsert_delim="EOF_\$\(head -c 16 \/dev\/urandom/,
     );
-    // The digest must be taken AFTER the trusted copy lands, or it records
-    // whatever was already at that path — the gate's whole premise.
-    expect(
-      stageStep.indexOf(
-        'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
-      ),
-    ).toBeLessThan(stageStep.indexOf('echo "upsert_sha256='));
-    // RUNNER_TEMP is agent-writable between staging and invocation, so every
-    // invocation verifies the digest the stage step recorded in expression
-    // context; a mismatch skips persistence (best-effort), never the round.
-    expect(stageStep).toContain(
-      'echo "upsert_sha256=$(sha256sum "${RUNNER_TEMP}/upsert-deferred-issue.sh" | cut -d\' \' -f1)" >> "${GITHUB_OUTPUT}"',
-    );
-    expect(
-      workflow.split(
-        'if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then',
-      ).length - 1,
-    ).toBe(2);
-    // R5-5: both --paginate sites are pinned at the source (the recording gh
-    // stub ignores the flag). Dropping either silently truncates the lookup
-    // or the dedupe corpus.
-    // Exactly ONE paginated call remains — the tracking issue's own comments,
-    // which is bounded by that issue. The lookup is a bounded, early-exit page
-    // loop instead (a full --paginate there re-downloaded the bot's entire
-    // lifetime corpus on every defer round). The flag is anchored to the
-    // comments call, so relocating it to the lookup fails even though the
-    // count is unchanged.
-    expect(
-      upsertDeferredScript
-        .split('\n')
-        .filter(
-          (l) => !l.trimStart().startsWith('#') && l.includes('--paginate'),
-        ),
-    ).toHaveLength(1);
-    expect(upsertDeferredScript).toMatch(
-      /issues\/\$\{ISSUE_NUM\}\/comments\?per_page=100"[\s\S]{0,40}--paginate/,
+    expect(workflow).not.toMatch(/upsert_sha256/);
+    expect(workflow).not.toMatch(
+      /cp \.github\/scripts\/upsert-deferred-issue\.sh/,
     );
     for (const step of [pushAndReportStep, reviewAddressReportStep]) {
       expect(step).toContain(
-        "UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'",
+        "UPSERT_SRC: '${{ steps.stage.outputs.upsert_src }}'",
       );
     }
     expect(reviewAddressJob).toContain(
@@ -11381,6 +11328,20 @@ exit 1
         '[{"id":21,"source":"review","reason":"修复内存泄漏问题"},' +
         '{"id":21,"source":"review","reason":"修复资源泄漏"}]',
     });
+    // RC-1: the resolved-id corpus grows with the round's resolutions, and
+    // one argv element caps at MAX_ARG_STRLEN — the same failure `known`
+    // already avoided. Both corpora go in via --rawfile now.
+    expect(
+      upsertDeferredScript.match(/--rawfile \w+ "\$\{[A-Z_]+\}"/g) ?? [],
+    ).toHaveLength(2);
+    expect(upsertDeferredScript).not.toMatch(/--arg resolved/);
+    const bigResolved = runUpsert({
+      findings: '[{"id":999999,"reason":"not resolved"}]',
+      resolved: Array.from({ length: 40000 }, (_, i) => `rc:${i + 1}`).join(
+        '\n',
+      ),
+    });
+    expect(bigResolved.calls).toContain('- rc:999999 ');
     expect(cjkSiblings.out).toContain('(2 of 2 new)');
     expect(cjkSiblings.calls).toContain('修复内存泄漏问题');
     expect(cjkSiblings.calls).toContain('修复资源泄漏');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8241,8 +8241,18 @@ exit 1
       prepareStep,
       reviewAddressReportStep,
     ]) {
-      expect(step).not.toContain('BASH_FUNC_*%%');
-      expect(step).not.toContain('done < <(env)');
+      // Property, not spelling: any in-shell sweep has to name BASH_FUNC and
+      // unset functions. Round 3's exact form is one of many spellings, and
+      // pinning only that form let a rewritten sweep back in (probed).
+      // Comment lines are excluded — the clean-child rationale legitimately
+      // names the channels it defends against.
+      const code = step
+        .split('\n')
+        .filter((l) => !l.trimStart().startsWith('#'))
+        .join('\n');
+      expect(code).not.toMatch(/BASH_FUNC/);
+      expect(code).not.toMatch(/\bunset -f\b/);
+      expect(code).not.toMatch(/\bhash -r\b/);
     }
     // The fork fetch and salvage fetch cannot recurse into a planted
     // submodule and execute an ext:: URL with the PAT (env-level
@@ -10421,6 +10431,14 @@ exit 1
       // R6-7: every allow-list entry that mints the child's environment is
       // pinned by name — a symmetric deletion from both children (invisible
       // to the childCore equality below) must fail here.
+      // The entries must live INSIDE the `env -i` argument list (between the
+      // launch and `bash --norc -c`): a symmetric relocation out of the
+      // child's environment keeps a bare toContain — and childCore — green.
+      const argList = step.slice(
+        step.indexOf('/usr/bin/env -i'),
+        step.indexOf('bash --norc -c'),
+      );
+      expect(argList.length).toBeGreaterThan(0);
       for (const entry of [
         'PATH="${TRUSTED_PATH}"',
         'GITHUB_TOKEN="${GITHUB_TOKEN}"',
@@ -10432,7 +10450,7 @@ exit 1
         'AUTOFIX_BOT="${AUTOFIX_BOT}"',
         'UPSERT_SHA256="${UPSERT_SHA256}"',
       ]) {
-        expect(step).toContain(entry);
+        expect(argList).toContain(entry);
       }
       // R6-8: LD_* cannot be enumerated (LD_TRACE_LOADED_OBJECTS is
       // presence-tested — even an empty assignment makes the loader print and
@@ -10455,6 +10473,14 @@ exit 1
         'if ! GH_CONFIG_DIR="$(mktemp -d "${RUNNER_TEMP}/autofix-gh-config.XXXXXX")"; then',
       );
       expect(step).toContain('::warning::could not create a gh config dir');
+      // R8-8: and the propagation half — without the export, gh never sees
+      // the throwaway dir and falls back to the shared ~/.config/gh.
+      expect(step).toMatch(/\n\s*export GH_CONFIG_DIR\n/);
+      // R8-5: the captured output is re-emitted, so the child's warnings
+      // actually reach the log (deleting both loops was invisible).
+      expect(step).toMatch(
+        /while IFS= read -r _upsert_line; do[\s\S]*?printf '%s\\n' "\$\{_upsert_line\}"[\s\S]*?done <<< "\$\{UPSERT_OUT\}"/,
+      );
       // Ordering: the digest gate runs, and ONLY on a match does the staged
       // script execute — both inside the same clean child. A reordering or a
       // gate-condition flip must fail here.
@@ -10491,13 +10517,13 @@ exit 1
     );
     // Pre-stage failures leave UPSERT_SHA256 empty: that skips with a plain
     // notice instead of imitating a tamper alarm.
-    expect(reviewAddressReportStep).toContain(
-      'deferred-findings upsert skipped: stage step never ran',
+    expect(reviewAddressReportStep).toMatch(
+      /if \[\[ -z "\$\{UPSERT_SHA256:-\}" \]\]; then[\s\S]*?deferred-findings upsert skipped: stage step never ran[\s\S]*?else[\s\S]*?\/usr\/bin\/env -i/,
     );
     // The failure path can run without POST_HANDOFF's identity check
     // (OUTCOME=fixed/noop), so the clean child verifies the PAT identity.
     expect(reviewAddressReportStep).toContain(
-      'UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user',
+      'UPSERT_ACTOR="$(GH_TOKEN="${GITHUB_TOKEN}" gh api user --jq .login 2> /dev/null || true)"',
     );
     expect(reviewAddressReportStep).toContain(
       '[[ "${UPSERT_ACTOR}" != "${AUTOFIX_BOT}" ]]',
@@ -10525,13 +10551,24 @@ exit 1
     expect(reviewAddressReportStep).toContain(
       "TRUSTED_PATH: '${{ steps.stage.outputs.trusted_path }}'",
     );
-    expect(workflow).toContain(
+    const stageStep =
+      reviewAddressJob.match(
+        /- name: 'Stage trusted schema gate and agent runner'[\s\S]*?(?=\n {6}- name: ')/,
+      )?.[0] ?? '';
+    expect(stageStep).toContain(
       'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
     );
+    // The digest must be taken AFTER the trusted copy lands, or it records
+    // whatever was already at that path — the gate's whole premise.
+    expect(
+      stageStep.indexOf(
+        'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
+      ),
+    ).toBeLessThan(stageStep.indexOf('echo "upsert_sha256='));
     // RUNNER_TEMP is agent-writable between staging and invocation, so every
     // invocation verifies the digest the stage step recorded in expression
     // context; a mismatch skips persistence (best-effort), never the round.
-    expect(workflow).toContain(
+    expect(stageStep).toContain(
       'echo "upsert_sha256=$(sha256sum "${RUNNER_TEMP}/upsert-deferred-issue.sh" | cut -d\' \' -f1)" >> "${GITHUB_OUTPUT}"',
     );
     expect(
@@ -10567,8 +10604,39 @@ exit 1
     // writes its own file and the watermark means nothing re-derives them.
     // They are carried in a sidecar the upsert unions in, and the sidecar
     // rides the artifact dump.
-    expect(reviewAddressJob).not.toMatch(
-      /rm -f \\\n(?:\s+"\$\{WORKDIR\}\/[^"]+" \\\n)*\s+"\$\{WORKDIR\}\/deferred-findings\.json"/,
+    const repairStep =
+      reviewAddressJob.match(
+        /- name: 'Repair deterministic rejection'[\s\S]*?(?=\n {6}- name: ')/,
+      )?.[0] ?? '';
+    expect(repairStep.length).toBeGreaterThan(0);
+    // Spelling-independent: the sibling cleanup list must not name the file
+    // in ANY form, and the file may be removed exactly once — inside the
+    // merge branch, after its content was folded into the carry sidecar.
+    const cleanupList =
+      repairStep.match(/rm -f \\\n(?:[^\n]*\\\n)*[^\n]*\n/)?.[0] ?? '';
+    expect(cleanupList).toContain('resolved-comments.txt');
+    expect(cleanupList).not.toContain('deferred-findings.json');
+    const deletions =
+      repairStep.match(/rm -f[^\n]*deferred-findings\.json/g) ?? [];
+    expect(deletions).toHaveLength(1);
+    expect(repairStep.indexOf('deferred-findings.carry.next')).toBeLessThan(
+      repairStep.search(/rm -f[^\n]*deferred-findings\.json/),
+    );
+    // R8-2: the merge internals themselves (a one-token retarget of the
+    // redirect silently truncated the carried set).
+    expect(repairStep).toContain(
+      '> "${WORKDIR}/deferred-findings.carry.next" 2> /dev/null; then',
+    );
+    expect(repairStep).toContain(
+      'mv "${WORKDIR}/deferred-findings.carry.next" \\\n                  "${WORKDIR}/deferred-findings.carry.json"',
+    );
+    expect(repairStep).toContain(
+      '::warning::could not merge carried deferrals across the repair',
+    );
+    // R8-3: that branch discards THIS run's set, so it dumps it first —
+    // `::` neutralized, like every other echo of agent-written content.
+    expect(repairStep).toMatch(
+      /could not merge carried deferrals[\s\S]*?head -c 4000 "\$\{WORKDIR\}\/deferred-findings\.json" \| sed 's\/::\/;;\/g'/,
     );
     expect(reviewAddressJob).toContain(
       'mv "${WORKDIR}/deferred-findings.json" \\\n                "${WORKDIR}/deferred-findings.carry.json"',
@@ -10749,6 +10817,10 @@ exit 1
     });
     expect(anchored.calls).toContain('api repos/o/r/issues/42/comments');
     expect(anchored.calls).toContain('- rc:3');
+    // Negative half: PR #9 carries the same marker and must never be adopted
+    // as the tracking issue (positive-only assertions passed an
+    // adopt-and-append-to-everything mutation).
+    expect(anchored.calls).not.toContain('issues/9/comments');
     // A failed body read SKIPS the round — never treated as empty history.
     const readFail = runUpsert({
       findings: '[{"id":7,"reason":"r"}]',
@@ -10883,6 +10955,13 @@ exit 1
     expect(markerless.calls).toContain('-f title=');
     expect(markerless.calls).not.toContain('issues/41/comments');
     expect(upsertDeferredScript).toContain('creator=${AUTOFIX_BOT}');
+    // The page loop's correctness rests on these: newest-first ordering makes
+    // "first match wins" find THIS PR's issue, and per_page=100 is what the
+    // short-page-means-exhausted test compares against. The recording stub
+    // serves pages by index and cannot see query parameters.
+    expect(upsertDeferredScript).toContain(
+      'per_page=100&sort=created&direction=desc&page=${lookup_page}',
+    );
     expect(upsertDeferredScript).toContain('contains($m)');
     // Marker neutralization is behavioural, not just a source pin: a comment
     // opener in agent-influenced content reaches the write call defused.
@@ -11871,8 +11950,15 @@ exit 1
     const escapeSites = workflow.match(/sed 's\/<!--\/[^']*\/g'/g) ?? [];
     expect(escapeSites).toHaveLength(9);
     // The tenth agent-derived publish site lives in the staged
-    // upsert-deferred-issue.sh (line builder) and is pinned there.
-    expect(upsertDeferredScript).toContain("sed 's/<!--/<!\\\\-\\\\-/g'");
+    // upsert-deferred-issue.sh (line builder). Same treatment as its
+    // siblings — count AND canonical spelling, not mere presence: a no-op
+    // `\-\-` spelling once shipped past a presence-only pin.
+    const scriptEscapeSites =
+      upsertDeferredScript.match(/sed 's\/<!--\/[^']*\/g'/g) ?? [];
+    expect(scriptEscapeSites).toHaveLength(1);
+    for (const site of scriptEscapeSites) {
+      expect(site).toBe("sed 's/<!--/<!\\\\-\\\\-/g'");
+    }
     for (const site of escapeSites) {
       expect(site).toBe("sed 's/<!--/<!\\\\-\\\\-/g'");
     }

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -33,6 +33,10 @@ const reviewVerificationRunner = readFileSync(
   reviewVerificationRunnerPath,
   'utf8',
 );
+const upsertDeferredScript = readFileSync(
+  '.github/scripts/upsert-deferred-issue.sh',
+  'utf8',
+);
 const autofixContractsScriptPath = '.github/scripts/check-autofix-contracts.sh';
 const autofixContractsScript = readFileSync(autofixContractsScriptPath, 'utf8');
 const autofixRunnerScriptPath = '.qwen/skills/autofix/scripts/run-agent.mjs';
@@ -2917,7 +2921,7 @@ describe('qwen-autofix workflow', () => {
     // forces a deliberate test update, however it is spaced or line-wrapped:
     // bump this count AND pipe the new site through the normalizer (bumping
     // the count below too) — bumping this pin alone leaves toBe(9) green.
-    expect(workflow.split('--paginate').length - 1).toBe(16);
+    expect(workflow.split('--paginate').length - 1).toBe(15);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback = nine normalized fetch sites. The
     // blocked-takeover status lookup is deliberately NOT among them: like the
@@ -10358,14 +10362,18 @@ exit 1
   });
 
   it('upserts deferred findings into a per-PR issue that survives the merge', () => {
-    // Wiring: the upsert runs for BOTH outcomes (after each shared
-    // resolve/reply call), the agent file rides the artifact dump and the
-    // repair cleanup, and SKILL documents the fourth disposition.
+    // Wiring: the staged script runs after both shared resolve/reply call
+    // sites AND on the failure/handoff path (a failed round must not lose
+    // verified findings); it is staged from the trusted base; the agent
+    // file rides the artifact dump and the repair cleanup; SKILL documents
+    // the fourth disposition.
     expect(
-      pushAndReportStep.split(
-        'resolve_and_reply_threads\n            upsert_deferred_issue',
-      ).length - 1,
-    ).toBe(2);
+      workflow.split('bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"').length -
+        1,
+    ).toBe(3);
+    expect(workflow).toContain(
+      'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
+    );
     expect(reviewAddressJob).toContain(
       'comment-replies.json deferred-findings.json pr.diff',
     );
@@ -10377,41 +10385,144 @@ exit 1
     expect(skill).toContain('deferred-findings.json');
     expect(skill).toContain('you defer what is worth doing');
 
-    // Shape validation: only a non-empty array of {id:number,
-    // reason:string} passes.
-    const validateJq = pushAndReportStep.match(
-      /jq -e 'type == "array" and length > 0 and all\(\.\[\];[\s\S]*?\(\.reason \| type == "string"\)\)'/,
-    )?.[0];
-    expect(validateJq).toBeTruthy();
-    const prog = validateJq.match(/'([\s\S]*)'/)?.[1];
-    const validates = (json) =>
-      spawnSync('jq', ['-e', prog], { input: json, encoding: 'utf8' })
-        .status === 0;
-    expect(validates('[{"id":1,"reason":"r"}]')).toBe(true);
-    expect(validates('[]')).toBe(false);
-    expect(validates('[{"id":"1","reason":"r"}]')).toBe(false);
-    expect(validates('{"id":1}')).toBe(false);
-
-    // Line building: dedupe against the existing issue body by rc id,
-    // flatten newlines, truncate, and neutralize markers.
-    const linesJq = pushAndReportStep.match(
-      /jq -r --arg body "\$\{existing_body\}" '([\s\S]*?)' \\\n\s+"\$\{WORKDIR\}\/deferred-findings\.json"/,
-    )?.[1];
-    expect(linesJq).toBeTruthy();
-    const lines = (items, body) =>
-      spawnSync('jq', ['-r', '--arg', 'body', body, linesJq], {
-        input: JSON.stringify(items),
-        encoding: 'utf8',
-      }).stdout;
-    const built = lines(
-      [
-        { id: 7, path: 'src/a.ts', reason: 'real\nbut out of\r\nscope' },
-        { id: 8, reason: 'already tracked' },
-      ],
-      'existing…\n- rc:8 `x`: already tracked',
+    // End-to-end boundary: run the real script against a recording gh
+    // stub. Every case asserts the CALLS, not just the strings.
+    const runUpsert = ({
+      findings,
+      resolved = '',
+      list = '[]',
+      body = '',
+      bodyFail = false,
+      comments = '[]',
+      writeFail = false,
+    }) => {
+      const dir = mkdtempSync(join(tmpdir(), 'autofix-upsert-'));
+      const bin = join(dir, 'bin');
+      mkdirSync(bin);
+      writeFileSync(join(dir, 'deferred-findings.json'), findings);
+      if (resolved) writeFileSync(join(dir, 'resolved-comments.txt'), resolved);
+      writeFileSync(
+        join(bin, 'gh'),
+        [
+          '#!/usr/bin/env bash',
+          'printf "%s\\n" "$*" >> "$GHLOG"',
+          'case "$2" in',
+          '  *"issues?state=open"*) printf "%s" "$LIST_JSON";;',
+          '  */comments?per_page=100*) printf "%s" "$COMMENTS_JSON";;',
+          '  */comments) [[ "$WRITE_FAIL" == 1 ]] && exit 1; echo ok;;',
+          '  repos/*/issues) [[ "$WRITE_FAIL" == 1 ]] && exit 1; echo 77;;',
+          '  repos/*/issues/*) [[ "$BODY_FAIL" == 1 ]] && exit 1; printf "%s" "$BODY_TEXT";;',
+          'esac',
+          'exit 0',
+        ].join('\n'),
+      );
+      chmodSync(join(bin, 'gh'), 0o755);
+      const res = spawnSync(
+        'bash',
+        ['.github/scripts/upsert-deferred-issue.sh'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${bin}:${process.env.PATH}`,
+            WORKDIR: dir,
+            PR: '5',
+            REPO: 'o/r',
+            AUTOFIX_BOT: 'bot',
+            GHLOG: join(dir, 'gh.log'),
+            LIST_JSON: list,
+            BODY_TEXT: body,
+            BODY_FAIL: bodyFail ? '1' : '0',
+            COMMENTS_JSON: comments,
+            WRITE_FAIL: writeFail ? '1' : '0',
+          },
+        },
+      );
+      const calls = existsSync(join(dir, 'gh.log'))
+        ? readFileSync(join(dir, 'gh.log'), 'utf8')
+        : '';
+      rmSync(dir, { recursive: true, force: true });
+      return { out: `${res.stdout}\n${res.stderr}`, status: res.status, calls };
+    };
+    const marker = '<!-- autofix-deferred pr=5 -->';
+    // Create path: no existing issue → POST /issues with marker + item.
+    const created = runUpsert({
+      findings: '[{"id":7,"path":"src/a.ts","reason":"real, out of scope"}]',
+    });
+    expect(created.status).toBe(0);
+    expect(created.calls).toContain('api repos/o/r/issues -f title=');
+    expect(created.calls).toContain(marker);
+    expect(created.calls).toContain('- rc:7 `src/a.ts`: real, out of scope');
+    expect(created.out).toContain('tracked in new issue #77');
+    // Append path: existing issue found → dedupe against body+comments,
+    // then POST an issue COMMENT (append-only; no body PATCH anywhere).
+    const appended = runUpsert({
+      findings:
+        '[{"id":7,"reason":"new"},{"id":8,"reason":"dup"},{"id":9,"reason":"in-comment"}]',
+      list: JSON.stringify([
+        { number: 42, body: `x\n${marker}`, pull_request: null },
+      ]),
+      body: 'intro\n- rc:8 `x`: dup',
+      comments: JSON.stringify([{ body: '- rc:9 `y`: in-comment' }]),
+    });
+    expect(appended.calls).toContain(
+      'api repos/o/r/issues/42/comments -f body=',
     );
-    expect(built).toContain('- rc:7 `src/a.ts`: real but out of scope');
-    expect(built).not.toContain('rc:8');
+    expect(appended.calls).toContain('- rc:7');
+    expect(appended.calls).not.toContain('- rc:8 ');
+    expect(appended.calls).not.toContain('- rc:9 ');
+    expect(appended.calls).not.toContain('PATCH');
+    expect(appended.out).toContain('appended to issue #42');
+    // Free-text mentions do not suppress (line-anchored dedupe), and a PULL
+    // REQUEST carrying the marker is never selected as the tracking issue.
+    const anchored = runUpsert({
+      findings: '[{"id":3,"reason":"r"}]',
+      list: JSON.stringify([
+        { number: 9, body: `pr body ${marker}`, pull_request: { url: 'x' } },
+        {
+          number: 42,
+          body: `x\n${marker}\nprose mentioning rc:3 casually`,
+          pull_request: null,
+        },
+      ]),
+      body: 'prose mentioning rc:3 casually',
+      comments: '[]',
+    });
+    expect(anchored.calls).toContain('api repos/o/r/issues/42/comments');
+    expect(anchored.calls).toContain('- rc:3');
+    // A failed body read SKIPS the round — never treated as empty history.
+    const readFail = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+      bodyFail: true,
+    });
+    expect(readFail.out).toContain('skipping this round');
+    expect(readFail.calls).not.toContain('/comments -f body=');
+    // An id resolved in code this round is never deferred (contradiction).
+    const resolvedOut = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      resolved: 'rc:7\r\n',
+    });
+    expect(resolvedOut.calls).not.toContain('-f title=');
+    // Malformed path type fails the shape gate loudly, dropping nothing
+    // silently.
+    const badShape = runUpsert({
+      findings: '[{"id":7,"reason":"r","path":5}]',
+    });
+    expect(badShape.out).toContain('malformed');
+    expect(badShape.calls).toBe('');
+    // A failed write logs NOT persisted — success is never claimed.
+    const writeFail = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      writeFail: true,
+    });
+    expect(writeFail.out).toContain('NOT persisted');
+    // Path bytes are sanitized before rendering (no forged bullet lines).
+    const forged = runUpsert({
+      findings: '[{"id":4,"path":"a`\\n- rc:999 `z","reason":"r"}]',
+    });
+    expect(forged.calls).toContain('- rc:4');
+    expect(forged.calls).not.toContain('- rc:999');
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {
@@ -11152,7 +11263,7 @@ exit 1
       '::warning::Failed to post handoff comment on PR #${PR}',
     );
     expect(reviewAddressReportStep).toContain('human should take over');
-    // Token-breaking neutralization at ALL TEN agent-derived publish sites
+    // Token-breaking neutralization at ALL NINE workflow publish sites
     // (address-summary, no-action, DETAIL_FILE, API_ERROR_DETAIL, the
     // gate-rejection body, the comment-reply body whose content is agent
     // stdout that can echo external comment text, the two
@@ -11167,7 +11278,10 @@ exit 1
     // backslashes — a NO-OP on both GNU and BSD sed, verified) left the count
     // at four and this test green, shipping an unescaped publish site.
     const escapeSites = workflow.match(/sed 's\/<!--\/[^']*\/g'/g) ?? [];
-    expect(escapeSites).toHaveLength(10);
+    expect(escapeSites).toHaveLength(9);
+    // The tenth agent-derived publish site lives in the staged
+    // upsert-deferred-issue.sh (line builder) and is pinned there.
+    expect(upsertDeferredScript).toContain("sed 's/<!--/<!\\\\-\\\\-/g'");
     for (const site of escapeSites) {
       expect(site).toBe("sed 's/<!--/<!\\\\-\\\\-/g'");
     }

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8253,6 +8253,15 @@ exit 1
       expect(code).not.toMatch(/BASH_FUNC/);
       expect(code).not.toMatch(/\bunset -f\b/);
       expect(code).not.toMatch(/\bhash -r\b/);
+      // The other enumeration families a sweep gets rewritten into: alias
+      // clearing, trap resets, and per-name proxy/loader unsets. Isolation is
+      // the clean child's job, not a list maintained in the tainted shell.
+      expect(code).not.toMatch(/\bunalias\b/);
+      expect(code).not.toMatch(/expand_aliases/);
+      expect(code).not.toMatch(/\btrap -\b/);
+      expect(code).not.toMatch(
+        /\bunset [A-Z_ ]*\b(?:HTTPS?_PROXY|SSL_CERT_[A-Z]+|BASH_ENV)\b/,
+      );
     }
     // The fork fetch and salvage fetch cannot recurse into a planted
     // submodule and execute an ext:: URL with the PAT (env-level
@@ -10636,9 +10645,12 @@ exit 1
     // R5-5: both --paginate sites are pinned at the source (the recording gh
     // stub ignores the flag). Dropping either silently truncates the lookup
     // or the dedupe corpus.
-    // Only the tracking issue's OWN comments are paginated now; the issue
-    // lookup is a bounded, early-exit page loop (a full --paginate there
-    // re-downloaded the bot's entire lifetime corpus every defer round).
+    // Exactly ONE paginated call remains — the tracking issue's own comments,
+    // which is bounded by that issue. The lookup is a bounded, early-exit page
+    // loop instead (a full --paginate there re-downloaded the bot's entire
+    // lifetime corpus on every defer round). The flag is anchored to the
+    // comments call, so relocating it to the lookup fails even though the
+    // count is unchanged.
     expect(
       upsertDeferredScript
         .split('\n')
@@ -10646,6 +10658,9 @@ exit 1
           (l) => !l.trimStart().startsWith('#') && l.includes('--paginate'),
         ),
     ).toHaveLength(1);
+    expect(upsertDeferredScript).toMatch(
+      /issues\/\$\{ISSUE_NUM\}\/comments\?per_page=100"[\s\S]{0,40}--paginate/,
+    );
     for (const step of [pushAndReportStep, reviewAddressReportStep]) {
       expect(step).toContain(
         "UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'",
@@ -10679,16 +10694,36 @@ exit 1
       repairStep.match(/rm -f \\\n(?:[^\n]*\\\n)*[^\n]*\n/)?.[0] ?? '';
     expect(cleanupList).toContain('resolved-comments.txt');
     expect(cleanupList).not.toContain('deferred-findings.json');
+    // Any rm spelling, single- or multi-line, -f or -rf: the file may be
+    // removed exactly once, and only after its content reached the sidecar.
     const deletions =
-      repairStep.match(/rm -f[^\n]*deferred-findings\.json/g) ?? [];
+      repairStep.match(
+        /rm -[rf]+(?:[^\n]*\\\n)*[^\n]*deferred-findings\.json/g,
+      ) ?? [];
     expect(deletions).toHaveLength(1);
+    // …and no OTHER multi-line rm list may name it either (cleanupList only
+    // inspects the first such list).
+    for (const list of repairStep.match(
+      /rm -[rf]+ \\\n(?:[^\n]*\\\n)*[^\n]*\n/g,
+    ) ?? []) {
+      expect(list).not.toContain('deferred-findings.json');
+    }
     expect(repairStep.indexOf('deferred-findings.carry.next')).toBeLessThan(
       repairStep.search(/rm -f[^\n]*deferred-findings\.json/),
     );
     // R8-2: the merge internals themselves (a one-token retarget of the
     // redirect silently truncated the carried set).
-    expect(repairStep).toContain(
-      '> "${WORKDIR}/deferred-findings.carry.next" 2> /dev/null; then',
+    // Both inputs of the repair-side union, in order: carry first, then this
+    // round's (the sidecar is the accumulated history there). The old
+    // assertion was also satisfied by the else-branch `mv` line.
+    expect(repairStep).toMatch(
+      /jq -s 'add' "\$\{WORKDIR\}\/deferred-findings\.carry\.json" \\\n\s*"\$\{WORKDIR\}\/deferred-findings\.json" \\\n\s*> "\$\{WORKDIR\}\/deferred-findings\.carry\.next" 2> \/dev\/null; then/,
+    );
+    // R9-20: the script-side union is the freshness guarantee — this round
+    // first, so unique_by (first-of-group, original order) keeps the fresh
+    // text when run 2 re-emits a carried id.
+    expect(upsertDeferredScript).toContain(
+      'jq -s \'add\' "${FINDINGS}" "${CARRY}" > "${MERGED}"',
     );
     expect(repairStep).toContain(
       'mv "${WORKDIR}/deferred-findings.carry.next" \\\n                  "${WORKDIR}/deferred-findings.carry.json"',
@@ -10806,6 +10841,9 @@ exit 1
         ['.github/scripts/upsert-deferred-issue.sh'],
         {
           encoding: 'utf8',
+          // spawnSync blocks the event loop, so vitest's async timeout cannot
+          // fire — bound each subprocess directly against a hung runner.
+          timeout: 30_000,
           env: {
             ...process.env,
             PATH: `${bin}:${process.env.PATH}`,
@@ -11197,6 +11235,76 @@ exit 1
         '[{"id":77,"source":"review","reason":"same"},{"id":77,"source":"review","reason":"same"}]',
     });
     expect(identicalTwice.calls.split('- rv:77 ').length - 1).toBe(1);
+    // R9-19: the SKILL documents review_comment as the default when omitted,
+    // so the explicit spelling must be accepted too (and is pinned in SKILL).
+    const explicitDefault = runUpsert({
+      findings: '[{"id":41,"source":"review_comment","reason":"explicit"}]',
+    });
+    expect(explicitDefault.calls).toContain('- rc:41 ');
+    expect(skill).toContain('review_comment');
+    // R9-14: which findings survive the 20-item cap is decided by the sort
+    // order of the dedupe, not the agent's write order. Feed DESCENDING ids
+    // across two sources so the two orders disagree, and pin the survivors.
+    const capOrder = runUpsert({
+      findings: JSON.stringify(
+        Array.from({ length: 12 }, (_, i) => ({
+          id: 100 - i,
+          source: 'review',
+          reason: `r${100 - i}`,
+        })).concat(
+          Array.from({ length: 12 }, (_, i) => ({
+            id: 200 - i,
+            reason: `c${200 - i}`,
+          })),
+        ),
+      ),
+    });
+    expect(capOrder.out).toContain('persisting 20 of 24');
+    // MEASURED, not assumed: unique_by sorts by [source, id] ("review" <
+    // "review_comment"), so the survivors are all 12 rv plus rc:189-196 —
+    // the four rc records written FIRST (197-200) are the ones dropped, and
+    // rc:189, written LAST, survives. Input order and survivor order really
+    // do disagree.
+    expect(capOrder.calls).toContain('- rc:189 ');
+    expect(capOrder.calls).not.toContain('- rc:200 ');
+    expect(capOrder.out).toContain('- rc:200 ');
+    expect(capOrder.calls).toContain('- rv:89 ');
+    expect(capOrder.calls).toContain('- rv:100 ');
+    // R9-15 / R9-18: a carried sidecar that PARSES but fails the shape gate
+    // must not take this round's valid deferrals with it — the unparseable
+    // branch already persists this round only, and this is the same
+    // situation one step later.
+    const poisonedCarry = runUpsert({
+      findings: '[{"id":7,"reason":"this round is fine"}]',
+      carry: '[{"id":-1,"reason":"carried but invalid"}]',
+    });
+    expect(poisonedCarry.out).toContain('the carried deferrals are malformed');
+    expect(poisonedCarry.out).toContain('carried but invalid');
+    expect(poisonedCarry.calls).toContain('- rc:7 ');
+    // An UNPARSEABLE carry takes the same route through the merge branch.
+    const unparseableCarry = runUpsert({
+      findings: '[{"id":7,"reason":"this round is fine"}]',
+      carry: 'not json at all',
+    });
+    expect(unparseableCarry.out).toContain(
+      'could not merge the carried deferrals',
+    );
+    expect(unparseableCarry.calls).toContain('- rc:7 ');
+    // But a bad set of OUR OWN is still a loud, total abort.
+    const poisonedOwn = runUpsert({
+      findings: '[{"id":-1,"reason":"bad"}]',
+      carry: '[{"id":8,"reason":"carried ok"}]',
+    });
+    expect(poisonedOwn.out).toContain('are LOST');
+    expect(poisonedOwn.calls).toBe('');
+    // R9-20 behaviourally: a duplicate id in both files keeps THIS round's
+    // text (the union puts it first and unique_by keeps first-of-group).
+    const freshWins = runUpsert({
+      findings: '[{"id":9,"reason":"fresh"}]',
+      carry: '[{"id":9,"reason":"stale"}]',
+    });
+    expect(freshWins.calls).toContain('fresh');
+    expect(freshWins.calls).not.toContain('stale');
     // An unknown source value fails the gate loudly rather than silently
     // rendering under the default prefix.
     const badSource = runUpsert({

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8251,14 +8251,17 @@ exit 1
         .filter((l) => !l.trimStart().startsWith('#'))
         .join('\n');
       expect(code).not.toMatch(/BASH_FUNC/);
-      expect(code).not.toMatch(/\bunset -f\b/);
-      expect(code).not.toMatch(/\bhash -r\b/);
+      // No trailing \b on a flag: it sits between `-f` and a space (both
+      // non-word), so it fails on the standard spellings — `unset -fv name`
+      // and `trap - ERR EXIT` slipped straight through.
+      expect(code).not.toMatch(/\bunset -f/);
+      expect(code).not.toMatch(/\bhash -r/);
       // The other enumeration families a sweep gets rewritten into: alias
       // clearing, trap resets, and per-name proxy/loader unsets. Isolation is
       // the clean child's job, not a list maintained in the tainted shell.
       expect(code).not.toMatch(/\bunalias\b/);
       expect(code).not.toMatch(/expand_aliases/);
-      expect(code).not.toMatch(/\btrap -\b/);
+      expect(code).not.toMatch(/\btrap -/);
       expect(code).not.toMatch(
         /\bunset [A-Z_ ]*\b(?:HTTPS?_PROXY|SSL_CERT_[A-Z]+|BASH_ENV)\b/,
       );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8244,6 +8244,10 @@ exit 1
       pushAndReportStep,
       prepareStep,
       reviewAddressReportStep,
+      // The issue-autofix job's own PAT-bearing failure paths: the comment
+      // claims a workflow-wide invariant, so the loop has to cover them.
+      issueAutofixReportStep,
+      withdrawClaimStep,
     ]) {
       // Property, not spelling: any in-shell sweep has to name BASH_FUNC and
       // unset functions. Round 3's exact form is one of many spellings, and
@@ -10415,8 +10419,13 @@ exit 1
     // The staged script is executed from the bytes read and hashed in the
     // child, never re-opened by path (R9-1), at both call sites.
     expect(workflow.split('bash -c "${UPSERT_SRC}"').length - 1).toBe(2);
-    expect(workflow).not.toContain(
-      'bash "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
+    // R10-8: bound EVERY execution of the staged path, not one spelling —
+    // `sh …`, `bash -- …`, `source …`, `. …`, `exec bash …` all re-open it.
+    expect(workflow).not.toMatch(
+      /(?:^|\s)(?:exec\s+)?(?:ba|da|k|z)?sh\b[^\n|]*\$\{RUNNER_TEMP\}\/upsert-deferred-issue\.sh/m,
+    );
+    expect(workflow).not.toMatch(
+      /(?:^|\s)(?:source|\.)\s+"?\$\{RUNNER_TEMP\}\/upsert-deferred-issue\.sh/m,
     );
     // Placement, not just counts: the digest-gated invocation is a step-local
     // function defined ONCE in 'Push and report' and called immediately after
@@ -10466,9 +10475,12 @@ exit 1
       // R9-10: contains-only pins accept a symmetric ADDITION that widens the
       // child's environment. Enumerate what is actually passed and compare
       // against the sanctioned set.
-      const passed = (argList.match(/[A-Z_][A-Z0-9_]*=/g) ?? []).map((m) =>
-        m.replace('=', ''),
-      );
+      // Delimited tokens, not substrings: match `NAME=value` up to the line
+      // continuation, so a value swap or an extra entry is visible.
+      const assignments = (
+        argList.match(/[A-Z_][A-Z0-9_]*=(?:"[^"]*"|[^\s\\]*)/g) ?? []
+      ).map((m) => m.trim());
+      const passed = assignments.map((m) => m.split('=')[0]);
       expect(new Set(passed)).toEqual(
         new Set([
           // the LD_* command-prefix assignments lead the launch line
@@ -10491,7 +10503,11 @@ exit 1
           'UPSERT_LOG',
         ]),
       );
+      // Every entry pinned by its exact token, including UPSERT_LOG (the one
+      // isolation entry whose value was unpinned).
       for (const entry of [
+        'LD_PRELOAD=',
+        'UPSERT_LOG="${UPSERT_LOG}"',
         'PATH="${TRUSTED_PATH}"',
         'GITHUB_TOKEN="${GITHUB_TOKEN}"',
         'GH_HOST=github.com',
@@ -10502,7 +10518,7 @@ exit 1
         'AUTOFIX_BOT="${AUTOFIX_BOT}"',
         'UPSERT_SHA256="${UPSERT_SHA256}"',
       ]) {
-        expect(argList).toContain(entry);
+        expect(assignments).toContain(entry.replace(/=$/, '='));
       }
       // R9-1: the bytes that are HASHED are the bytes that RUN. A gate that
       // hashes a path and then re-opens it to execute loses to a rename(2)
@@ -10577,7 +10593,10 @@ exit 1
         'if [[ "$(printf "%s" "${UPSERT_SRC}" | sha256sum | cut -d" " -f1)" != "${UPSERT_SHA256}" ]]; then',
       );
       const execIdx = step.indexOf('bash -c "${UPSERT_SRC}"');
-      const launchIdx = step.indexOf('/usr/bin/env -i');
+      // Anchor on the launch line: in the failure step the first textual
+      // `/usr/bin/env -i` is a NOTE comment ~560 lines earlier, which made
+      // the gate-after-launch check vacuous there.
+      const launchIdx = argStart;
       expect(gateIdx).toBeGreaterThan(launchIdx);
       expect(execIdx).toBeGreaterThan(gateIdx);
     }
@@ -10691,7 +10710,7 @@ exit 1
       );
     }
     expect(reviewAddressJob).toContain(
-      'comment-replies.json deferred-findings.json deferred-findings.carry.json pr.diff',
+      'comment-replies.json deferred-findings.json deferred-findings.carry.json deferred-findings.unmerged.json pr.diff',
     );
     // R9-11: that dump prints agent-written files, so it neutralizes `::`
     // like every other echo of them (a line-start `::error::` in the raw file
@@ -10722,13 +10741,13 @@ exit 1
     // removed exactly once, and only after its content reached the sidecar.
     const deletions =
       repairStep.match(
-        /rm -[rf]+(?:[^\n]*\\\n)*[^\n]*deferred-findings\.json/g,
+        /\brm\b(?:\s+-[a-z]+)*(?:[^\n]*\\\n)*[^\n]*deferred-findings\.json(?!\.)/g,
       ) ?? [];
     expect(deletions).toHaveLength(1);
     // …and no OTHER multi-line rm list may name it either (cleanupList only
     // inspects the first such list).
     for (const list of repairStep.match(
-      /rm -[rf]+ \\\n(?:[^\n]*\\\n)*[^\n]*\n/g,
+      /\brm\b(?:\s+-[a-z]+)* \\\n(?:[^\n]*\\\n)*[^\n]*\n/g,
     ) ?? []) {
       expect(list).not.toContain('deferred-findings.json');
     }
@@ -10767,7 +10786,7 @@ exit 1
       'CARRY="${WORKDIR}/deferred-findings.carry.json"',
     );
     expect(reviewAddressJob).toContain(
-      'deferred-findings.json deferred-findings.carry.json pr.diff',
+      'deferred-findings.json deferred-findings.carry.json deferred-findings.unmerged.json pr.diff',
     );
     // R7-1: all three feedback sources carry an id the agent can defer
     // against — a review-body or issue-level finding was undeferrable (and
@@ -11313,9 +11332,12 @@ exit 1
       findings: '[{"id":7,"reason":"this round is fine"}]',
       carry: 'not json at all',
     });
+    // The message no longer claims to know WHICH side is corrupt — jq -s
+    // fails if either input is unparseable (R10-12).
     expect(unparseableCarry.out).toContain(
-      'could not merge the carried deferrals',
+      "could not merge this round's deferrals with the carried sidecar",
     );
+    expect(unparseableCarry.out).toContain('one of the two is unparseable');
     expect(unparseableCarry.calls).toContain('- rc:7 ');
     // But a bad set of OUR OWN is still a loud, total abort.
     const poisonedOwn = runUpsert({
@@ -11332,6 +11354,86 @@ exit 1
     });
     expect(freshWins.calls).toContain('fresh');
     expect(freshWins.calls).not.toContain('stale');
+    // R10-4: the 200-char path cap and 500-char reason cap are behaviour, so
+    // they get behavioural coverage rather than a static pin.
+    const cappedFields = runUpsert({
+      findings: JSON.stringify([
+        {
+          id: 51,
+          path: 'src/' + 'a'.repeat(300) + '.ts',
+          reason: 'b'.repeat(700),
+        },
+      ]),
+    });
+    const bullet =
+      cappedFields.calls.split('\n').find((l) => l.includes('- rc:51 ')) ?? '';
+    expect(bullet).toContain('a'.repeat(190));
+    expect(bullet).not.toContain('a'.repeat(210));
+    expect(bullet).toContain('b'.repeat(490));
+    expect(bullet).not.toContain('b'.repeat(510));
+    // The rv/ic identity must be LOSSLESS on content: an earlier version
+    // stripped every non-[a-z0-9] byte and capped at 160 chars, which merged
+    // CJK siblings (this repo is bilingual) and, on a long path, cut the
+    // reason out of the identity altogether — silent loss, the one outcome
+    // this feature exists to prevent.
+    const cjkSiblings = runUpsert({
+      findings:
+        '[{"id":21,"source":"review","reason":"修复内存泄漏问题"},' +
+        '{"id":21,"source":"review","reason":"修复资源泄漏"}]',
+    });
+    expect(cjkSiblings.out).toContain('(2 of 2 new)');
+    expect(cjkSiblings.calls).toContain('修复内存泄漏问题');
+    expect(cjkSiblings.calls).toContain('修复资源泄漏');
+    const longPath = 'src/' + 'a'.repeat(200) + '.ts';
+    const longPathSiblings = runUpsert({
+      findings: JSON.stringify([
+        {
+          id: 22,
+          source: 'review',
+          path: longPath,
+          reason: 'first distinct finding',
+        },
+        {
+          id: 22,
+          source: 'review',
+          path: longPath,
+          reason: 'second distinct finding',
+        },
+      ]),
+    });
+    expect(longPathSiblings.out).toContain('(2 of 2 new)');
+    expect(longPathSiblings.calls).toContain('first distinct finding');
+    expect(longPathSiblings.calls).toContain('second distinct finding');
+    // R10-18: the marker lives in the maintainer-editable BODY, so the title
+    // is a second identity anchor — an issue whose body lost the marker is
+    // still adopted instead of forking a duplicate.
+    const markerStripped = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      list: JSON.stringify([
+        {
+          number: 42,
+          title: 'Deferred review findings from PR #5',
+          body: 'a maintainer edited this body and dropped the marker',
+          pull_request: null,
+        },
+      ]),
+    });
+    expect(markerStripped.calls).toContain('issues/42/comments -f body=');
+    expect(markerStripped.calls).not.toContain('-f title=');
+    // …but a same-titled PULL REQUEST is still never adopted.
+    const titledPr = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      list: JSON.stringify([
+        {
+          number: 9,
+          title: 'Deferred review findings from PR #5',
+          body: 'x',
+          pull_request: { url: 'u' },
+        },
+      ]),
+    });
+    expect(titledPr.calls).toContain('-f title=');
+    expect(titledPr.calls).not.toContain('issues/9/comments');
     // An unknown source value fails the gate loudly rather than silently
     // rendering under the default prefix.
     const badSource = runUpsert({

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10412,7 +10412,7 @@ exit 1
       // binary itself at execve). Pin the assignment immediately precedes
       // the launch (indent-agnostic across the two call sites).
       expect(step).toMatch(
-        /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\\n\s*\/usr\/bin\/env -i \\/,
+        /LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= \\\n\s*LD_PROFILE= LD_PROFILE_OUTPUT= LD_DEBUG= LD_DEBUG_OUTPUT= \\\n\s*\/usr\/bin\/env -i \\/,
       );
       expect(step).toContain('bash --norc -c');
       // GH_CONFIG_DIR is minted INSIDE the clean child (its mktemp cannot be
@@ -10549,15 +10549,44 @@ exit 1
       );
     }
     expect(reviewAddressJob).toContain(
-      'comment-replies.json deferred-findings.json pr.diff',
+      'comment-replies.json deferred-findings.json deferred-findings.carry.json pr.diff',
     );
     expect(reviewAddressJob).toContain(
       '"${WORKDIR}/deferred-findings.json" \\',
+    );
+    // R7-3: the repair re-run must not delete run 1's deferrals — run 2
+    // writes its own file and the watermark means nothing re-derives them.
+    // They are carried in a sidecar the upsert unions in, and the sidecar
+    // rides the artifact dump.
+    expect(reviewAddressJob).not.toMatch(
+      /rm -f \\\n(?:\s+"\$\{WORKDIR\}\/[^"]+" \\\n)*\s+"\$\{WORKDIR\}\/deferred-findings\.json"/,
+    );
+    expect(reviewAddressJob).toContain(
+      'mv "${WORKDIR}/deferred-findings.json" \\\n                "${WORKDIR}/deferred-findings.carry.json"',
+    );
+    expect(upsertDeferredScript).toContain(
+      'CARRY="${WORKDIR}/deferred-findings.carry.json"',
+    );
+    expect(reviewAddressJob).toContain(
+      'deferred-findings.json deferred-findings.carry.json pr.diff',
+    );
+    // R7-1: all three feedback sources carry an id the agent can defer
+    // against — a review-body or issue-level finding was undeferrable (and
+    // therefore lost at merge) while only inline comments had one.
+    expect(prepareBranchAndFeedbackStep).toContain(
+      '"- [rv:\\(.id)] [\\(.state)]',
+    );
+    expect(prepareBranchAndFeedbackStep).toContain(
+      '"- [ic:\\(.id)] @\\(.user.login)',
     );
     const skill = readAutofixSkill();
     expect(skill).toContain('Defer to follow-up');
     expect(skill).toContain('deferred-findings.json');
     expect(skill).toContain('you defer what is worth doing');
+    expect(skill).toContain('"source": "review"');
+    expect(skill).toContain('"source": "issue_comment"');
+    expect(skill).toContain('[rv:<id>]');
+    expect(skill).toContain('[ic:<id>]');
 
     // End-to-end boundary: run the real script against a recording gh
     // stub. Every case asserts the CALLS, not just the strings.
@@ -10573,11 +10602,14 @@ exit 1
       writeFail = false,
       mktempFail = false,
       jqFail = false,
+      carry = '',
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-upsert-'));
       const bin = join(dir, 'bin');
       mkdirSync(bin);
       writeFileSync(join(dir, 'deferred-findings.json'), findings);
+      if (carry)
+        writeFileSync(join(dir, 'deferred-findings.carry.json'), carry);
       if (resolved) writeFileSync(join(dir, 'resolved-comments.txt'), resolved);
       if (jqFail) {
         // Fail ONLY the line-builder jq (the sole call passing --rawfile), so
@@ -10697,7 +10729,8 @@ exit 1
       list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
       bodyFail: true,
     });
-    expect(readFail.out).toContain('skipping this round');
+    expect(readFail.out).toContain('could not read deferred-findings issue');
+    expect(readFail.out).toContain('are LOST');
     expect(readFail.calls).not.toContain('/comments -f body=');
     // An id resolved in code this round is never deferred (contradiction).
     const resolvedOut = runUpsert({
@@ -10710,7 +10743,7 @@ exit 1
     const badShape = runUpsert({
       findings: '[{"id":7,"reason":"r","path":5}]',
     });
-    expect(badShape.out).toContain('malformed');
+    expect(badShape.out).toContain('are malformed');
     expect(badShape.calls).toBe('');
     // A failed write never claims success, and says the findings are LOST —
     // the watermark filters this round's feedback out of every later round, so
@@ -10748,7 +10781,7 @@ exit 1
       '[{"id":-3,"reason":"r"}]',
     ]) {
       const r = runUpsert({ findings: bad });
-      expect(r.out).toContain('malformed');
+      expect(r.out).toContain('are malformed');
       expect(r.calls).toBe('');
     }
     // The 20-item cap clips LOUDLY and success is qualified — clipped items
@@ -10768,7 +10801,8 @@ exit 1
       findings: '[{"id":7,"reason":"r"}]',
       listFail: true,
     });
-    expect(listFailed.out).toContain('lookup failed');
+    expect(listFailed.out).toContain('the tracking-issue lookup failed');
+    expect(listFailed.out).toContain('are LOST');
     expect(listFailed.calls).not.toContain('-f title=');
     expect(listFailed.calls).not.toContain('/comments -f body=');
     // A failed COMMENTS fetch skips too: the dedupe corpus would be
@@ -10778,7 +10812,10 @@ exit 1
       list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
       commentsFail: true,
     });
-    expect(commentsFailed.out).toContain('skipping this round');
+    expect(commentsFailed.out).toContain(
+      'could not read the deferred-findings comments',
+    );
+    expect(commentsFailed.out).toContain('are LOST');
     expect(commentsFailed.calls).not.toContain('/comments -f body=');
     // A failed APPEND write (existing issue) logs NOT persisted — the sole
     // create-path writeFail case above never reaches this branch.
@@ -10851,7 +10888,7 @@ exit 1
     // past 2^53 (1e21 -> "1E+21") carries a regex-active byte into the
     // anchored dedupe. The shape gate's plain-digits belt rejects it loudly.
     const sci = runUpsert({ findings: '[{"id":1e21,"reason":"r"}]' });
-    expect(sci.out).toContain('malformed');
+    expect(sci.out).toContain('are malformed');
     expect(sci.calls).toBe('');
     // R5-4: an unguarded mktemp failure would turn the whole upsert into a
     // silent exit 0 — the one failure path that skips the header contract.
@@ -10861,6 +10898,7 @@ exit 1
       mktempFail: true,
     });
     expect(mktempFailed.out).toContain('could not create a temp file');
+    expect(mktempFailed.out).toContain('are LOST');
     expect(mktempFailed.calls).not.toContain('-f title=');
     // R5-10: the anchored dedupe's trailing-space boundary. A corpus bullet
     // `- rc:70 …` must NOT suppress this round's id 7 (space-less prefix
@@ -10903,7 +10941,7 @@ exit 1
     // belt, so only `. > 0` rejects it.
     for (const bad of ['[{"id":7,"reason":5}]', '[{"id":0,"reason":"r"}]']) {
       const r = runUpsert({ findings: bad });
-      expect(r.out).toContain('malformed');
+      expect(r.out).toContain('are malformed');
       expect(r.calls).toBe('');
     }
     // R6-6: a line-builder failure warns instead of exiting silently as
@@ -10916,6 +10954,76 @@ exit 1
       'could not build the deferred-findings lines',
     );
     expect(builderFail.calls).not.toContain('-f title=');
+    // R7-2: an abort is PERMANENT for these findings (watermark + the next
+    // run's workspace reset), so every abort path says LOST and dumps the raw
+    // deferrals for manual recovery — with `::` neutralized, since the dump is
+    // agent-influenced and a raw `::` at line start is a workflow command.
+    const lostDump = runUpsert({
+      findings:
+        '[{"id":7,"reason":"r","path":5},{"id":8,"reason":"::error::forged"}]',
+    });
+    expect(lostDump.out).toContain('are LOST');
+    expect(lostDump.out).toContain('watermark-gated');
+    expect(lostDump.out).toContain('"id":8');
+    expect(lostDump.out).toContain(';;error;;forged');
+    expect(lostDump.out).not.toContain('::error::forged');
+    expect(lostDump.calls).toBe('');
+    // R7-1: a review-body / issue-level finding is deferrable, anchored under
+    // its own prefix so id spaces cannot collide across sources.
+    const sources = runUpsert({
+      findings:
+        '[{"id":21,"source":"review","reason":"from a review body"},' +
+        '{"id":21,"source":"issue_comment","reason":"from an issue comment"},' +
+        '{"id":21,"reason":"from an inline comment"}]',
+    });
+    expect(sources.calls).toContain('- rv:21 ');
+    expect(sources.calls).toContain('- ic:21 ');
+    expect(sources.calls).toContain('- rc:21 ');
+    expect(sources.out).toContain('(3 of 3 new)');
+    // Dedupe is per source: an existing `- rv:21` bullet suppresses only the
+    // review-body item, and resolved-comment ids (inline only) never suppress
+    // a same-numbered finding from another source.
+    const perSource = runUpsert({
+      findings:
+        '[{"id":21,"source":"review","reason":"dup"},' +
+        '{"id":21,"source":"issue_comment","reason":"fresh"}]',
+      resolved: 'rc:21\n',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+      comments: JSON.stringify([
+        { user: { login: 'bot' }, body: '- rv:21 `x`: already tracked' },
+      ]),
+    });
+    expect(perSource.calls).not.toContain('- rv:21 ');
+    expect(perSource.calls).toContain('- ic:21 ');
+    // An unknown source value fails the gate loudly rather than silently
+    // rendering under the default prefix.
+    const badSource = runUpsert({
+      findings: '[{"id":7,"reason":"r","source":"nope"}]',
+    });
+    expect(badSource.out).toContain('are LOST');
+    expect(badSource.calls).toBe('');
+    // R7-4: a present-but-non-string path fails the gate — `//` treats false
+    // as absent, so `false` used to be coerced to "?" against the gate's own
+    // fail-loudly contract.
+    const pathFalse = runUpsert({
+      findings: '[{"id":7,"reason":"r","path":false}]',
+    });
+    expect(pathFalse.out).toContain('are LOST');
+    expect(pathFalse.calls).toBe('');
+    // R7-3: deferrals carried across a repair re-run are persisted — both
+    // when run 2 defers nothing (carry only) and merged with run 2's own.
+    const carryOnly = runUpsert({
+      findings: '',
+      carry: '[{"id":31,"reason":"carried"}]',
+    });
+    expect(carryOnly.calls).toContain('- rc:31 ');
+    const carryMerged = runUpsert({
+      findings: '[{"id":32,"reason":"this round"}]',
+      carry: '[{"id":31,"reason":"carried"},{"id":32,"reason":"dup"}]',
+    });
+    expect(carryMerged.calls).toContain('- rc:31 ');
+    expect(carryMerged.calls).toContain('- rc:32 ');
+    expect(carryMerged.calls.split('- rc:32 ').length - 1).toBe(1);
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -8217,6 +8217,10 @@ exit 1
       [publishPrStep, 'GH_TOKEN="${GITHUB_TOKEN}" gh api user'],
       [pushAndReportStep, 'GH_TOKEN="${GITHUB_TOKEN}" gh api user'],
       [prepareStep, 'PR_LIVE="$(gh pr view'],
+      // The review-address failure/handoff report step makes PAT-bearing gh
+      // calls after agent/branch code too (handoff comment + deferred
+      // upsert), so it carries the same hygiene preamble.
+      [reviewAddressReportStep, 'GH_TOKEN="${GITHUB_TOKEN}" gh api user'],
     ]) {
       const ghPin = step.indexOf('export GH_HOST=github.com');
       expect(ghPin).toBeGreaterThan(-1);
@@ -10374,6 +10378,22 @@ exit 1
     expect(workflow).toContain(
       'cp .github/scripts/upsert-deferred-issue.sh "${RUNNER_TEMP}/upsert-deferred-issue.sh"',
     );
+    // RUNNER_TEMP is agent-writable between staging and invocation, so every
+    // invocation verifies the digest the stage step recorded in expression
+    // context; a mismatch skips persistence (best-effort), never the round.
+    expect(workflow).toContain(
+      'echo "upsert_sha256=$(sha256sum "${RUNNER_TEMP}/upsert-deferred-issue.sh" | cut -d\' \' -f1)" >> "${GITHUB_OUTPUT}"',
+    );
+    expect(
+      workflow.split(
+        'echo "${UPSERT_SHA256}  ${RUNNER_TEMP}/upsert-deferred-issue.sh" | sha256sum -c - > /dev/null 2>&1; then',
+      ).length - 1,
+    ).toBe(3);
+    for (const step of [pushAndReportStep, reviewAddressReportStep]) {
+      expect(step).toContain(
+        "UPSERT_SHA256: '${{ steps.stage.outputs.upsert_sha256 }}'",
+      );
+    }
     expect(reviewAddressJob).toContain(
       'comment-replies.json deferred-findings.json pr.diff',
     );
@@ -10391,9 +10411,11 @@ exit 1
       findings,
       resolved = '',
       list = '[]',
+      listFail = false,
       body = '',
       bodyFail = false,
       comments = '[]',
+      commentsFail = false,
       writeFail = false,
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-upsert-'));
@@ -10407,8 +10429,8 @@ exit 1
           '#!/usr/bin/env bash',
           'printf "%s\\n" "$*" >> "$GHLOG"',
           'case "$2" in',
-          '  *"issues?state=open"*) printf "%s" "$LIST_JSON";;',
-          '  */comments?per_page=100*) printf "%s" "$COMMENTS_JSON";;',
+          '  *"issues?state=all"*) [[ "$LIST_FAIL" == 1 ]] && exit 1; printf "%s" "$LIST_JSON";;',
+          '  */comments?per_page=100*) [[ "$COMMENTS_FAIL" == 1 ]] && exit 1; printf "%s" "$COMMENTS_JSON";;',
           '  */comments) [[ "$WRITE_FAIL" == 1 ]] && exit 1; echo ok;;',
           '  repos/*/issues) [[ "$WRITE_FAIL" == 1 ]] && exit 1; echo 77;;',
           '  repos/*/issues/*) [[ "$BODY_FAIL" == 1 ]] && exit 1; printf "%s" "$BODY_TEXT";;',
@@ -10431,9 +10453,11 @@ exit 1
             AUTOFIX_BOT: 'bot',
             GHLOG: join(dir, 'gh.log'),
             LIST_JSON: list,
+            LIST_FAIL: listFail ? '1' : '0',
             BODY_TEXT: body,
             BODY_FAIL: bodyFail ? '1' : '0',
             COMMENTS_JSON: comments,
+            COMMENTS_FAIL: commentsFail ? '1' : '0',
             WRITE_FAIL: writeFail ? '1' : '0',
           },
         },
@@ -10523,6 +10547,65 @@ exit 1
     });
     expect(forged.calls).toContain('- rc:4');
     expect(forged.calls).not.toContain('- rc:999');
+    // The lookup queries state=all: a maintainer-closed tracking issue is
+    // still found and appended to (commenting on a closed issue works), so
+    // closure cannot fork a duplicate issue.
+    expect(created.calls).toContain('issues?state=all');
+    // Multiline reason bytes are flattened before rendering (a raw newline
+    // in agent-influenced content would forge extra bullet lines).
+    const flat = runUpsert({
+      findings: '[{"id":6,"reason":"line1\\nline2"}]',
+    });
+    expect(flat.calls).toContain('- rc:6 `?`: line1 line2');
+    // Non-integer / non-positive ids fail the shape gate: a float id's dot
+    // would be a regex wildcard in the anchored dedupe and never
+    // index()-match resolved-comments ids.
+    for (const bad of [
+      '[{"id":7.5,"reason":"r"}]',
+      '[{"id":-3,"reason":"r"}]',
+    ]) {
+      const r = runUpsert({ findings: bad });
+      expect(r.out).toContain('malformed');
+      expect(r.calls).toBe('');
+    }
+    // The 20-item cap clips LOUDLY and success is qualified — clipped items
+    // are never retried, so a silent clip would read as full persistence.
+    const capped = runUpsert({
+      findings: JSON.stringify(
+        Array.from({ length: 25 }, (_, i) => ({ id: i + 1, reason: 'r' })),
+      ),
+    });
+    expect(capped.out).toContain('persisting 20 of 25');
+    expect(capped.out).toContain('(20 of 25 new)');
+    expect(capped.calls).toContain('- rc:20 ');
+    expect(capped.calls).not.toContain('- rc:21 ');
+    // A failed tracking-issue LOOKUP skips the round (creating a duplicate
+    // is worse than deferring persistence) — no write call of either kind.
+    const listFailed = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      listFail: true,
+    });
+    expect(listFailed.out).toContain('lookup failed');
+    expect(listFailed.calls).not.toContain('-f title=');
+    expect(listFailed.calls).not.toContain('/comments -f body=');
+    // A failed COMMENTS fetch skips too: the dedupe corpus would be
+    // incomplete and history would be re-appended.
+    const commentsFailed = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+      commentsFail: true,
+    });
+    expect(commentsFailed.out).toContain('skipping this round');
+    expect(commentsFailed.calls).not.toContain('/comments -f body=');
+    // A failed APPEND write (existing issue) logs NOT persisted — the sole
+    // create-path writeFail case above never reaches this branch.
+    const appendFail = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      list: JSON.stringify([{ number: 42, body: marker, pull_request: null }]),
+      writeFail: true,
+    });
+    expect(appendFail.out).toContain('could not append');
+    expect(appendFail.out).toContain('NOT persisted');
   });
 
   it('bite check: rejects a round whose changed tests pass on the pre-round tree', () => {

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -10433,6 +10433,11 @@ exit 1
     expect(pushAndReportStep.split('run_deferred_upsert() {').length - 1).toBe(
       1,
     );
+    // Its empty-content skip: without it an absent stage output would send an
+    // empty script into the child and read as a successful round.
+    expect(pushAndReportStep).toMatch(
+      /if \[\[ -z "\$\{UPSERT_SRC:-\}" \]\]; then\n(?:\s*#[^\n]*\n)*\s*echo 'deferred-findings upsert skipped: stage step never ran'\n\s*return 0/,
+    );
     expect(
       pushAndReportStep.match(
         /resolve_and_reply_threads\n(?:\s*#[^\n]*\n)*\s*run_deferred_upsert\n/g,
@@ -10539,7 +10544,7 @@ exit 1
       // while fd 1/2 — where every loader side channel writes — are
       // discarded. No log file to plant, race, or bound.
       expect(step).toContain('exec >&3');
-      expect(step).toMatch(/' > \/dev\/null 2>&1 ; \} 3>&1 \)"/);
+      expect(step).toMatch(/' > \/dev\/null 2>&1 ; \} 3>&1 \)" \|\| true/);
       expect(step).not.toMatch(/UPSERT_LOG/);
       expect(step).not.toMatch(/autofix-upsert-log/);
       // R6-8: LD_* cannot be enumerated (LD_TRACE_LOADED_OBJECTS and
@@ -10642,6 +10647,10 @@ exit 1
     // The script travels as CONTENT captured from the trusted checkout into
     // expression context — no staged copy on an agent-writable path, hence
     // no digest to record or verify.
+    // The consumers read `steps.stage.outputs.*`, so the producing step must
+    // actually be identified as `stage` — the one link whose break makes
+    // every UPSERT_SRC silently empty.
+    expect(stageStep).toMatch(/\n\s*id: 'stage'\n/);
     expect(stageStep).toContain('echo "upsert_src<<${_upsert_delim}"');
     expect(stageStep).toContain('cat .github/scripts/upsert-deferred-issue.sh');
     expect(stageStep).toMatch(
@@ -10711,8 +10720,11 @@ exit 1
     // Both inputs of the repair-side union, in order: carry first, then this
     // round's (the sidecar is the accumulated history there). The old
     // assertion was also satisfied by the else-branch `mv` line.
+    // This round FIRST, matching the script's own union precedence: unique_by
+    // keeps first-of-group, so a re-emitted finding wins with its fresher
+    // text. The old order let the carried copy win (R14-7).
     expect(repairStep).toMatch(
-      /jq -s 'add' "\$\{WORKDIR\}\/deferred-findings\.carry\.json" \\\n\s*"\$\{WORKDIR\}\/deferred-findings\.json" \\\n\s*> "\$\{WORKDIR\}\/deferred-findings\.carry\.next" 2> \/dev\/null; then/,
+      /jq -s 'add' "\$\{WORKDIR\}\/deferred-findings\.json" \\\n\s*"\$\{WORKDIR\}\/deferred-findings\.carry\.json" \\\n\s*> "\$\{WORKDIR\}\/deferred-findings\.carry\.next" 2> \/dev\/null; then/,
     );
     // R9-20: the script-side union is the freshness guarantee — this round
     // first, so unique_by (first-of-group, original order) keeps the fresh
@@ -11325,6 +11337,41 @@ exit 1
     });
     expect(freshWins.calls).toContain('fresh');
     expect(freshWins.calls).not.toContain('stale');
+    // R14-13: the intra-batch identity comes from the UNCAPPED text —
+    // deriving it from the rendered line let two siblings that differ only
+    // past the 500-char reason cap collide, and one vanished silently.
+    const past = 'x'.repeat(520);
+    const beyondCap = runUpsert({
+      findings: JSON.stringify([
+        { id: 21, source: 'review', reason: past + 'AAA' },
+        { id: 21, source: 'review', reason: past + 'BBB' },
+      ]),
+    });
+    expect(beyondCap.out).toContain('(2 of 2 new)');
+    // R14-14: a resolved id survives stray surrounding whitespace.
+    const paddedResolved = runUpsert({
+      findings: '[{"id":7,"reason":"r"}]',
+      resolved: '  rc:7  \n',
+    });
+    // (the lookup still runs; what must not happen is a write)
+    expect(paddedResolved.calls).not.toContain('-f title=');
+    expect(paddedResolved.calls).not.toContain('/comments -f body=');
+    // R14-1: EVERY wrapper-authored warning carries the trusted marker, so
+    // none of them is demoted to plain text by the `::` neutralization.
+    for (const step of [pushAndReportStep, reviewAddressReportStep]) {
+      // …scoped to the clean child: warnings elsewhere in the step reach the
+      // log directly and never pass through the neutralizing replay.
+      const child = step.slice(
+        step.indexOf('LD_PRELOAD= LD_AUDIT='),
+        step.indexOf("' > /dev/null 2>&1 ; } 3>&1 )"),
+      );
+      const wrapperWarnings =
+        child.match(/echo "(?:__upsert_trusted__)?::warning::[^"]*"/g) ?? [];
+      expect(wrapperWarnings.length).toBeGreaterThan(0);
+      for (const w of wrapperWarnings) {
+        expect(w).toContain('__upsert_trusted__');
+      }
+    }
     // BSD/macOS `wc -l` pads with leading spaces, and the count is
     // interpolated into the cap warning and the success line — so the script
     // strips it. Driven with a padding `wc` stub, since GNU wc never pads and


### PR DESCRIPTION
## What this PR does

Adds the missing anti-drift disposition to the autofix review loop. SKILL's address-review gains a fourth outcome, **Defer to follow-up**: a finding the agent VERIFIED as real but whose fix lies outside the PR's footprint (or its mainline purpose) is recorded in a machine-readable `deferred-findings.json` (`{id, path, reason}`), answered on its thread, and left open — neither implemented in-PR (scope drift) nor declined (finding lost). The report step upserts these into one per-PR **"Deferred review findings from PR #N"** issue — marker-keyed, append-only by rc id, agent text token-neutralized and length-capped — for both pushed and no-op outcomes, so verified off-mainline findings survive the merge as a schedulable queue. Deliberately no `ready-for-agent` label: routing the bot's own deferrals back into its issue phase is a human authorization, not a default.

## Why it's needed

The footprint gates (#8996/#9156) tell a round WHERE it may change code; nothing said what happens to a real finding that lands outside that boundary. All three existing dispositions were wrong for it: implementing drifts the PR off its mainline, declining loses the finding the moment the PR merges (nobody re-reads merged PRs' threads — our own #8996 backlog living in open threads is the case study), and escalating pushes triage onto a maintainer for something the agent already verified. This closes the loop: 防膨胀 (growth brake) bounds how much a round adds, 防跑偏 now has an exit ramp — verified off-mainline work becomes a surviving follow-up queue instead of in-PR drift.

## Reviewer Test Plan

### How to verify

`npm run test:scripts` (54 files, 1164 passed / 13 skipped) or `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow` (173). The new suite validates the shape gate (only a non-empty array of numeric-id items passes), replays the line-building jq (dedupe against the existing issue body by rc id, newline flattening, truncation, marker neutralization), and pins the wiring: the upsert runs after both shared resolve/reply call sites, the JSON rides the artifact dump and repair cleanup, and the neutralization ledger counts ten sites.

### Evidence (Before & After)

N/A — CI workflow/skill logic. Before: a verified out-of-footprint finding either drifted the PR or evaporated at merge. After: it lands in a per-PR tracking issue with its verification reason, and the thread reply says so.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: issue noise if agents over-defer — bounded by the existing verification protocol (defer requires a VERIFIED finding), the per-PR single-issue upsert (no issue spam), and append-only dedupe. The upsert is best-effort and can never fail a round.
- Not validated / out of scope: automatic scheduling of deferred items (deliberately manual); the queued marker-grammar/resolver-digest backlog is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #8981 (防膨胀) and #8996/#9156 (footprint boundaries) — this adds the disposition those boundaries imply.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 autofix 评审循环补上缺失的防跑偏处置。SKILL 的 address-review 新增第四种结局 **Defer to follow-up**:agent 已验证为真、但修复位于 PR 足迹(或主线目的)之外的 finding,记录进机读的 `deferred-findings.json`(`{id, path, reason}`),在原线程回复并保持 open——既不在本 PR 实现(跑偏),也不 decline(丢失)。报告步骤将其 upsert 到**每 PR 一个**的 "Deferred review findings from PR #N" issue——按 marker 定位、按 rc id 追加去重、agent 文本经 token 中和与长度封顶——pushed 与 no-op 两种结局都执行,让已验证的离主线 finding 以可排期队列的形式**在合并后存活**。刻意不打 `ready-for-agent` 标签:把 bot 自己的延后项回流进其 issue 阶段属于人类授权,不是默认行为。

## 为什么需要

足迹门(#8996/#9156)规定了轮次**可以在哪里**改代码;但对落在边界之外的真实 finding,原有三种处置都不对:实现会使 PR 偏离主线,decline 会让 finding 在合并瞬间失联(没人回头读已合 PR 的线程——我们自己 #8996 的 backlog 活在开放线程里就是现成案例),escalate 则把 agent 已验证过的东西又压回维护者。本 PR 闭环:防膨胀(增长刹车)限制轮次加多少,防跑偏现在有了出口——已验证的离主线工作变成存活的 follow-up 队列,而非 PR 内漂移。

## 评审验证方案

### 如何验证

`npm run test:scripts`(54 文件,1164 通过/13 跳过)或单文件(173)。新套件验证形状门(仅接受数字 id 的非空数组)、回放行构建 jq(对既有 issue 正文按 rc id 去重、换行拍平、截断、marker 中和),并钉住接线:upsert 在两个共享 resolve/reply 调用点之后执行、JSON 进工件转储与 repair 清理、中和台账计十处。

### 证据(Before & After)

N/A —— CI workflow/skill 逻辑。Before:已验证的足迹外 finding 要么带偏 PR、要么随合并蒸发。After:它带着验证理由落入每 PR 追踪 issue,线程回复注明去向。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

## 风险与范围

- 主要风险/权衡:agent 过度延后会造成 issue 噪音——受既有验证协议(defer 需已验证)、每 PR 单 issue upsert(不刷屏)与追加去重约束;upsert 尽力而为,永不使轮次失败。
- 未验证/范围外:延后项的自动排期(刻意保持人工);marker 语法常量/resolver digest 等既有 backlog 不变。
- 破坏性变更/迁移说明:无。

## 关联 Issue

#8981(防膨胀)与 #8996/#9156(足迹边界)的 follow-up——补上边界所隐含的处置出口。

</details>
