### PR TITLE
fix(autofix): re-anchor growth divergence on measurement time and external head moves

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -6088,7 +6088,10 @@ jobs:
           # over-budget round that never reaches 'Push and report' leaves a
           # history gap and the divergence count under-reports. Empty outputs
           # (prepare never ran) fall through the :-0/:-false marker fallbacks
-          # to an inert over=false entry.
+          # to an inert over=false entry — measured= then OMITS itself (an
+          # EMPTY measured= value matches no scan and would silently drop the
+          # marker these fallbacks exist to keep); the reader falls back to
+          # the comment's created_at.
           GROWTH_SRC: '${{ steps.prepare.outputs.growth_src }}'
           GROWTH_TEST: '${{ steps.prepare.outputs.growth_test }}'
           CRITICAL_ONLY_GROWTH: '${{ steps.prepare.outputs.critical_only_growth }}'
@@ -6603,7 +6606,7 @@ jobs:
               # marker the push/no-op report paths write, so an over-budget
               # round that timed out or was gate-rejected is not a gap. run=
               # (per-workflow-run) is the DEDUP identity; measured= orders.
-              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
+              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID}${MEASURED_AT:+ measured=${MEASURED_AT}} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
               # A sentinel ts means the agent evaluated NOTHING (crash, API
               # error, gate crash) and the next scan must retry. Recording a
               # judged head here would make RED_HEAD == LIVE_HEAD, so the

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -4553,8 +4553,11 @@ jobs:
           # marker only after the agent's ~120-minute run, so a round in
           # flight when a concurrent base update lands would otherwise pass a
           # created_at filter while carrying pre-update sums (#9114 R2-6).
+          # Emitted ONLY when a measurement happened: an unmeasured attempt
+          # that still stamped would be explicit in the per-run collapse and
+          # displace the same run's real measurement (#9192 R4-3).
           MEASURED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          echo "measured_at=${MEASURED_AT}" >> "${GITHUB_OUTPUT}"
+          [[ "${NET_MEASURED}" == 'true' ]] && echo "measured_at=${MEASURED_AT}" >> "${GITHUB_OUTPUT}"
           # NOTE (#9114 R2-8/R6-3): re-anchoring on an EXTERNAL head move (an
           # author push) is deliberately NOT done here. The obvious signal —
           # comparing the checked-out head against the bot's last judged head
@@ -4657,10 +4660,16 @@ jobs:
           # under budget would still be represented by its stale over=true
           # attempt. Within the collapse an explicit measured= beats the
           # created_at fallback: a re-run attempt that crashed BEFORE prepare
-          # posts an inert over=false marker with no measured=, whose fallback
-          # (post-run) timestamp would otherwise outdate and erase the same
-          # run's real prepare-time measurement. Every distinct address run
-          # has a fresh run_id.
+          # — or whose measurement failed — posts an inert over=false marker
+          # with no measured=, whose fallback (post-run) timestamp would
+          # otherwise outdate and erase the same run's real prepare-time
+          # measurement. Every distinct address run has a fresh run_id.
+          # KNOWN RESIDUAL (#9114): during the one-time deploy transition a
+          # run whose FIRST attempt posted a legacy (no measured=) over=true
+          # marker and whose re-run crashes before prepare still collapses
+          # fallback-vs-fallback on created_at — the later inert marker wins
+          # and erases the count. Self-limiting: once deployed, every real
+          # measurement carries measured= and beats any inert marker.
           # round=/eval-watermark are NOT a safe identity — a state-triggered
           # lane (a persistent merge conflict selects the PR every scan with no
           # new evaluable feedback) freezes both NEWEST and ROUND, so distinct
@@ -4668,10 +4677,19 @@ jobs:
           # Filtered on measured= (the prepare-time measurement instant, NOT
           # the comment's post-agent created_at) after GROWTH_NOW_CUTOFF, so a
           # prior sum measured against a pre-base-update tree is dropped rather
-          # than compared to this round's. measured= is OPTIONAL in the scan:
+          # than compared to this round's. KNOWN RESIDUAL (#9114): the tree is
+          # fixed at the branch fetch/checkout while the cutoff comes from
+          # ic.json fetched afterwards, so a base update landing between the
+          # fetch and the measured_at stamp admits a pre-update marker;
+          # self-heals at the next re-arm/base update. measured= is OPTIONAL in
+          # the scan:
           # markers posted before it existed fall back to their comment's
           # created_at, so deploying this does not blank the census of a window
-          # that is already in flight.
+          # that is already in flight. KNOWN RESIDUAL (#9114): during that
+          # transition the sort mixes two clocks — a legacy marker's fallback
+          # is its POST-RUN created_at while a new marker stamps prepare time —
+          # so PREV_SUM can briefly come from an older measurement; the count
+          # is unaffected and it self-heals at the next re-arm/base update.
           # The "not shrinking" test compares against the MOST RECENT prior
           # over-budget run's sum (latest measured=), not the window-wide max: a
           # single transient spike would otherwise raise the bar forever and a
@@ -5908,7 +5926,7 @@ jobs:
               # counts; run=GITHUB_RUN_ID is the DEDUP identity (a retry or a
               # job re-run re-posts the same run; measured= orders and picks
               # that run's latest attempt).
-              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
+              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID}${MEASURED_AT:+ measured=${MEASURED_AT}} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
             } > "${WORKDIR}/report.md"
             STATUS="pushed (round ${NEXT_ROUND}/${MAX_ROUNDS})"
           else
@@ -5941,7 +5959,7 @@ jobs:
               # counts; run=GITHUB_RUN_ID is the DEDUP identity (a retry or a
               # job re-run re-posts the same run; measured= orders and picks
               # that run's latest attempt).
-              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
+              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID}${MEASURED_AT:+ measured=${MEASURED_AT}} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
             } > "${WORKDIR}/report.md"
             STATUS="no action needed"
           fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -4555,22 +4555,26 @@ jobs:
           # created_at filter while carrying pre-update sums (#9114 R2-6).
           MEASURED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo "measured_at=${MEASURED_AT}" >> "${GITHUB_OUTPUT}"
-          # Author pushes / base updates re-anchor the measurement too, not
-          # just the bot's own update-branch merge that BASE_UPD_AT tracks: the
-          # net is measured against origin/main, so any commit an EXTERNAL
-          # actor (or a stale-base merge) added to the branch since the bot
-          # last evaluated it inflates this round's sum relative to prior
-          # rounds' sums, measured on the old head — an incomparable
-          # comparison that trips (or suppresses) a false handoff (#9114
-          # R2-8/R6-3). The bot's last judged head rides in its autofix-redcheck
-          # marker (LIVE_RED_HEAD); if the current head is not it, the head
-          # moved outside a bot round — drop every prior sum by cutting the
-          # comparability window at now, so this round re-anchors.
+          # NOTE (#9114 R2-8/R6-3): re-anchoring on an EXTERNAL head move (an
+          # author push) is deliberately NOT done here. The obvious signal —
+          # comparing the checked-out head against the bot's last judged head
+          # (autofix-redcheck) — is wrong: that marker records the head the
+          # agent was GIVEN, before its own push, so it differs after every
+          # pushing round and would re-anchor on the bot's own fixes, zeroing
+          # the census in exactly the push regime the handoff exists for. A
+          # correct version needs both a bot-authored-move test and a
+          # PERSISTED cut (a one-round cut is re-admitted the next round);
+          # that is its own change, tracked in #9114.
           GROWTH_NOW_CUTOFF="${BASE_UPD_AT}"
-          if [[ -n "${LIVE_RED_HEAD}" && "${LIVE_RED_HEAD}" != "${CHECKED_OUT_HEAD}" ]]; then
-            echo "🔁 branch head moved outside a bot round (last judged ${LIVE_RED_HEAD:0:9}, now ${CHECKED_OUT_HEAD:0:9}) — re-anchoring growth divergence"
-            GROWTH_NOW_CUTOFF="${MEASURED_AT}"
-          fi
+          # KNOWN RESIDUAL (#9114): this sibling read still filters on the
+          # comment's created_at, not a prepare-time measured= like the
+          # growth-now read below. Its values are measured in prepare too, so a
+          # round whose agent run straddles a base update can anchor the window
+          # on pre-update values. Narrow (the update must land inside the
+          # anchor round's own agent run) and first-wins, so it cannot be
+          # re-poisoned later in the window; stamping measured= into the
+          # growth-base marker is tracked with the rest of #9114 rather than
+          # widening this change.
           GROWTH_BASELINE="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" --arg baseupd "${BASE_UPD_AT}" '
             [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
               | [ scan("<!-- autofix-growth-base src=(-?[0-9]+) test=(-?[0-9]+) key=([^ ]+) -->") ] | .[]
@@ -4629,7 +4633,7 @@ jobs:
           # climbing anyway. Read this window's prior per-round growth markers
           # (written by the report step): count the rounds that were over
           # budget, and take the MOST RECENT prior over-budget run's growth
-          # SUM (highest run_id — see below; NOT the window-wide max, which a
+          # SUM (latest measured= — see below; NOT the window-wide max, which a
           # one-off spike would raise forever). The round is DIVERGING when it
           # is over budget now, the brake has already fired for
           # >= GROWTH_DIVERGENCE_ROUNDS prior rounds, and the diff has NOT
@@ -4645,19 +4649,24 @@ jobs:
           # the trajectory clause below is accurate even on a round that pulled
           # back under budget. markers:
           # <!-- autofix-growth-now src=N test=N over=BOOL round=N run=ID measured=TS key=W -->
-          # Deduped and ordered by run=GITHUB_RUN_ID, the per-workflow-run id:
-          # the report post's bounded retry re-posts one run's marker (same
-          # run_id → collapses to the LATEST by measured=, so a re-run's fresh
-          # measurement wins over its own stale first post), while every
-          # distinct address run has a fresh, monotonically increasing run_id.
+          # Deduped by run=GITHUB_RUN_ID (the per-workflow-run id) and ORDERED
+          # by measured=: the report post's bounded retry re-posts one run's
+          # marker, and a failed job's re-run keeps the same run_id, so a run
+          # collapses to its LATEST measurement — and that collapse happens
+          # BEFORE the over/window/cutoff filters, or a re-run that came back
+          # under budget would still be represented by its stale over=true
+          # attempt. Every distinct address run has a fresh run_id.
           # round=/eval-watermark are NOT a safe identity — a state-triggered
           # lane (a persistent merge conflict selects the PR every scan with no
           # new evaluable feedback) freezes both NEWEST and ROUND, so distinct
           # over-budget runs would share them and collapse, stalling the count.
-          # Filtered on measured= (the prepare-time measurement instant, NOT the
-          # comment's post-agent created_at) after GROWTH_NOW_CUTOFF, which
-          # re-anchors on a base update OR any external head move — a prior sum
-          # measured against a different tree is not comparable to this round's.
+          # Filtered on measured= (the prepare-time measurement instant, NOT
+          # the comment's post-agent created_at) after GROWTH_NOW_CUTOFF, so a
+          # prior sum measured against a pre-base-update tree is dropped rather
+          # than compared to this round's. measured= is OPTIONAL in the scan:
+          # markers posted before it existed fall back to their comment's
+          # created_at, so deploying this does not blank the census of a window
+          # that is already in flight.
           # The "not shrinking" test compares against the MOST RECENT prior
           # over-budget run's sum (latest measured=), not the window-wide max: a
           # single transient spike would otherwise raise the bar forever and a
@@ -4672,12 +4681,12 @@ jobs:
           if [[ "${NET_MEASURED}" == 'true' ]]; then
             read -r OVER_ROUNDS_PRIOR PREV_SUM < <(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" --arg cutoff "${GROWTH_NOW_CUTOFF}" --arg curr "${GITHUB_RUN_ID}" '
               [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
-                | [ scan("<!-- autofix-growth-now src=(-?[0-9]+) test=(-?[0-9]+) over=([a-z]+) round=([0-9]+) run=([0-9]+) measured=([^ ]+) key=([^ ]+) -->") ] | .[]
-                | {sum: ((.[0] | tonumber) + (.[1] | tonumber)), over: .[2], round: (.[3] | tonumber), run: (.[4] | tonumber), measured: .[5], win: .[6]} ]
+                | [ scan("<!-- autofix-growth-now src=(-?[0-9]+) test=(-?[0-9]+) over=([a-z]+) round=([0-9]+) run=([0-9]+) (?:measured=([^ ]+) )?key=([^ ]+) -->") ] | .[]
+                | {sum: ((.[0] | tonumber) + (.[1] | tonumber)), over: .[2], round: (.[3] | tonumber), run: (.[4] | tonumber), measured: (.[5] // ($c.created_at // "")), win: .[6]} ]
+              | group_by(.run) | map(max_by(.measured))
               | map(select(.win == $key and .over == "true"))
               | map(select(.run != ($curr | tonumber)))
               | map(select($cutoff == "" or (.measured > $cutoff)))
-              | group_by(.run) | map(max_by(.measured))
               | sort_by(.measured)
               | "\(length) \((last.sum) // 0)"' "${WORKDIR}/ic.json" 2> /dev/null || echo "0 0")
             [[ "${OVER_ROUNDS_PRIOR}" =~ ^[0-9]+$ ]] || OVER_ROUNDS_PRIOR=0
@@ -5891,8 +5900,9 @@ jobs:
                 echo "<!-- autofix-growth-base src=${GROWTH_BASE_SRC} test=${GROWTH_BASE_TEST} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
               fi
               # Per-round growth history the next round's divergence read
-              # counts; run=GITHUB_RUN_ID is the dedup+order identity (a retry
-              # re-posts the same run, distinct runs get fresh run ids).
+              # counts; run=GITHUB_RUN_ID is the DEDUP identity (a retry or a
+              # job re-run re-posts the same run; measured= orders and picks
+              # that run's latest attempt).
               echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
             } > "${WORKDIR}/report.md"
             STATUS="pushed (round ${NEXT_ROUND}/${MAX_ROUNDS})"
@@ -5923,8 +5933,9 @@ jobs:
                 echo "<!-- autofix-growth-base src=${GROWTH_BASE_SRC} test=${GROWTH_BASE_TEST} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
               fi
               # Per-round growth history the next round's divergence read
-              # counts; run=GITHUB_RUN_ID is the dedup+order identity (a retry
-              # re-posts the same run, distinct runs get fresh run ids).
+              # counts; run=GITHUB_RUN_ID is the DEDUP identity (a retry or a
+              # job re-run re-posts the same run; measured= orders and picks
+              # that run's latest attempt).
               echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
             } > "${WORKDIR}/report.md"
             STATUS="no action needed"
@@ -6591,7 +6602,7 @@ jobs:
               # Per-round growth history the divergence read counts — same
               # marker the push/no-op report paths write, so an over-budget
               # round that timed out or was gate-rejected is not a gap. run=
-              # (per-workflow-run) is the dedup/order identity.
+              # (per-workflow-run) is the DEDUP identity; measured= orders.
               echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
               # A sentinel ts means the agent evaluated NOTHING (crash, API
               # error, gate crash) and the next scan must retry. Recording a

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -4655,7 +4655,12 @@ jobs:
           # collapses to its LATEST measurement — and that collapse happens
           # BEFORE the over/window/cutoff filters, or a re-run that came back
           # under budget would still be represented by its stale over=true
-          # attempt. Every distinct address run has a fresh run_id.
+          # attempt. Within the collapse an explicit measured= beats the
+          # created_at fallback: a re-run attempt that crashed BEFORE prepare
+          # posts an inert over=false marker with no measured=, whose fallback
+          # (post-run) timestamp would otherwise outdate and erase the same
+          # run's real prepare-time measurement. Every distinct address run
+          # has a fresh run_id.
           # round=/eval-watermark are NOT a safe identity — a state-triggered
           # lane (a persistent merge conflict selects the PR every scan with no
           # new evaluable feedback) freezes both NEWEST and ROUND, so distinct
@@ -4682,8 +4687,8 @@ jobs:
             read -r OVER_ROUNDS_PRIOR PREV_SUM < <(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" --arg cutoff "${GROWTH_NOW_CUTOFF}" --arg curr "${GITHUB_RUN_ID}" '
               [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
                 | [ scan("<!-- autofix-growth-now src=(-?[0-9]+) test=(-?[0-9]+) over=([a-z]+) round=([0-9]+) run=([0-9]+) (?:measured=([^ ]+) )?key=([^ ]+) -->") ] | .[]
-                | {sum: ((.[0] | tonumber) + (.[1] | tonumber)), over: .[2], round: (.[3] | tonumber), run: (.[4] | tonumber), measured: (.[5] // ($c.created_at // "")), win: .[6]} ]
-              | group_by(.run) | map(max_by(.measured))
+                | {sum: ((.[0] | tonumber) + (.[1] | tonumber)), over: .[2], round: (.[3] | tonumber), run: (.[4] | tonumber), measured: (.[5] // ($c.created_at // "")), explicit: (.[5] != null), win: .[6]} ]
+              | group_by(.run) | map(max_by([.explicit, .measured]))
               | map(select(.win == $key and .over == "true"))
               | map(select(.run != ($curr | tonumber)))
               | map(select($cutoff == "" or (.measured > $cutoff)))

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -4547,6 +4547,30 @@ jobs:
             [ .[] | select((.user.login // "") == $ab)
               | select((.body // "") | contains("<!-- autofix-base-updated"))
               | .created_at ] | max // ""' "${WORKDIR}/ic.json")"
+          # The instant THIS round's net was measured. Stamped into the
+          # growth-now marker so the divergence read filters on measurement
+          # time, not the marker comment's created_at — the report posts the
+          # marker only after the agent's ~120-minute run, so a round in
+          # flight when a concurrent base update lands would otherwise pass a
+          # created_at filter while carrying pre-update sums (#9114 R2-6).
+          MEASURED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "measured_at=${MEASURED_AT}" >> "${GITHUB_OUTPUT}"
+          # Author pushes / base updates re-anchor the measurement too, not
+          # just the bot's own update-branch merge that BASE_UPD_AT tracks: the
+          # net is measured against origin/main, so any commit an EXTERNAL
+          # actor (or a stale-base merge) added to the branch since the bot
+          # last evaluated it inflates this round's sum relative to prior
+          # rounds' sums, measured on the old head — an incomparable
+          # comparison that trips (or suppresses) a false handoff (#9114
+          # R2-8/R6-3). The bot's last judged head rides in its autofix-redcheck
+          # marker (LIVE_RED_HEAD); if the current head is not it, the head
+          # moved outside a bot round — drop every prior sum by cutting the
+          # comparability window at now, so this round re-anchors.
+          GROWTH_NOW_CUTOFF="${BASE_UPD_AT}"
+          if [[ -n "${LIVE_RED_HEAD}" && "${LIVE_RED_HEAD}" != "${CHECKED_OUT_HEAD}" ]]; then
+            echo "🔁 branch head moved outside a bot round (last judged ${LIVE_RED_HEAD:0:9}, now ${CHECKED_OUT_HEAD:0:9}) — re-anchoring growth divergence"
+            GROWTH_NOW_CUTOFF="${MEASURED_AT}"
+          fi
           GROWTH_BASELINE="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" --arg baseupd "${BASE_UPD_AT}" '
             [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
               | [ scan("<!-- autofix-growth-base src=(-?[0-9]+) test=(-?[0-9]+) key=([^ ]+) -->") ] | .[]
@@ -4620,39 +4644,41 @@ jobs:
           # Count runs whenever the net is measured (not only over budget), so
           # the trajectory clause below is accurate even on a round that pulled
           # back under budget. markers:
-          # <!-- autofix-growth-now src=N test=N over=BOOL round=N run=ID key=W -->
+          # <!-- autofix-growth-now src=N test=N over=BOOL round=N run=ID measured=TS key=W -->
           # Deduped and ordered by run=GITHUB_RUN_ID, the per-workflow-run id:
           # the report post's bounded retry re-posts one run's marker (same
-          # run_id → collapses to the LATEST by created_at, so a re-run's
-          # fresher attempt wins over its own stale first post), while every
-          # distinct address run has a fresh, monotonically increasing run_id. round=/eval-watermark are NOT a
-          # safe identity — a state-triggered lane (a persistent merge conflict
-          # selects the PR every scan with no new evaluable feedback) freezes
-          # both NEWEST and ROUND, so distinct over-budget runs would share them
-          # and collapse, stalling the count. Filtered to markers AFTER any
-          # mid-window base update (BASE_UPD_AT) — the same re-anchoring the
-          # growth-base read guards against. The "not shrinking" test compares
-          # against the MOST RECENT prior over-budget run's sum (highest
-          # run_id), not the window-wide max: a single transient spike would
-          # otherwise raise the bar forever and a genuine plateau-over-budget
-          # runaway (the exact case to escalate) would never clear it. The
-          # CURRENT run's own markers are excluded (run != GITHUB_RUN_ID): a
-          # re-run of a failed job keeps the same run id and its failed
-          # attempt already posted a marker, so counting it would over-report
-          # the round's own attempt as a PRIOR one.
+          # run_id → collapses to the LATEST by measured=, so a re-run's fresh
+          # measurement wins over its own stale first post), while every
+          # distinct address run has a fresh, monotonically increasing run_id.
+          # round=/eval-watermark are NOT a safe identity — a state-triggered
+          # lane (a persistent merge conflict selects the PR every scan with no
+          # new evaluable feedback) freezes both NEWEST and ROUND, so distinct
+          # over-budget runs would share them and collapse, stalling the count.
+          # Filtered on measured= (the prepare-time measurement instant, NOT the
+          # comment's post-agent created_at) after GROWTH_NOW_CUTOFF, which
+          # re-anchors on a base update OR any external head move — a prior sum
+          # measured against a different tree is not comparable to this round's.
+          # The "not shrinking" test compares against the MOST RECENT prior
+          # over-budget run's sum (latest measured=), not the window-wide max: a
+          # single transient spike would otherwise raise the bar forever and a
+          # genuine plateau-over-budget runaway (the exact case to escalate)
+          # would never clear it. The CURRENT run's own markers are excluded
+          # (run != GITHUB_RUN_ID): a re-run of a failed job keeps the same run
+          # id and its failed attempt already posted a marker, so counting it
+          # would over-report the round's own attempt as a PRIOR one.
           GROWTH_DIVERGED='false'
           OVER_ROUNDS_PRIOR=0
           PREV_SUM=0
           if [[ "${NET_MEASURED}" == 'true' ]]; then
-            read -r OVER_ROUNDS_PRIOR PREV_SUM < <(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" --arg baseupd "${BASE_UPD_AT}" --arg curr "${GITHUB_RUN_ID}" '
+            read -r OVER_ROUNDS_PRIOR PREV_SUM < <(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" --arg cutoff "${GROWTH_NOW_CUTOFF}" --arg curr "${GITHUB_RUN_ID}" '
               [ .[] | select((.user.login // "") == $ab) | . as $c | ($c.body // "")
-                | [ scan("<!-- autofix-growth-now src=(-?[0-9]+) test=(-?[0-9]+) over=([a-z]+) round=([0-9]+) run=([0-9]+) key=([^ ]+) -->") ] | .[]
-                | {sum: ((.[0] | tonumber) + (.[1] | tonumber)), over: .[2], round: (.[3] | tonumber), run: (.[4] | tonumber), win: .[5], at: ($c.created_at // "")} ]
+                | [ scan("<!-- autofix-growth-now src=(-?[0-9]+) test=(-?[0-9]+) over=([a-z]+) round=([0-9]+) run=([0-9]+) measured=([^ ]+) key=([^ ]+) -->") ] | .[]
+                | {sum: ((.[0] | tonumber) + (.[1] | tonumber)), over: .[2], round: (.[3] | tonumber), run: (.[4] | tonumber), measured: .[5], win: .[6]} ]
               | map(select(.win == $key and .over == "true"))
               | map(select(.run != ($curr | tonumber)))
-              | map(select($baseupd == "" or (.at > $baseupd)))
-              | group_by(.run) | map(max_by(.at))
-              | sort_by(.run)
+              | map(select($cutoff == "" or (.measured > $cutoff)))
+              | group_by(.run) | map(max_by(.measured))
+              | sort_by(.measured)
               | "\(length) \((last.sum) // 0)"' "${WORKDIR}/ic.json" 2> /dev/null || echo "0 0")
             [[ "${OVER_ROUNDS_PRIOR}" =~ ^[0-9]+$ ]] || OVER_ROUNDS_PRIOR=0
             [[ "${PREV_SUM}" =~ ^-?[0-9]+$ ]] || PREV_SUM=0
@@ -5476,6 +5502,7 @@ jobs:
           GROWTH_SRC: '${{ steps.prepare.outputs.growth_src }}'
           GROWTH_TEST: '${{ steps.prepare.outputs.growth_test }}'
           CRITICAL_ONLY_GROWTH: '${{ steps.prepare.outputs.critical_only_growth }}'
+          MEASURED_AT: '${{ steps.prepare.outputs.measured_at }}'
         run: |-
           # gh has its own $GITHUB_ENV-injectable channels: pin the host and
           # drop any planted token BEFORE the identity check below, so a
@@ -5866,7 +5893,7 @@ jobs:
               # Per-round growth history the next round's divergence read
               # counts; run=GITHUB_RUN_ID is the dedup+order identity (a retry
               # re-posts the same run, distinct runs get fresh run ids).
-              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
+              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
             } > "${WORKDIR}/report.md"
             STATUS="pushed (round ${NEXT_ROUND}/${MAX_ROUNDS})"
           else
@@ -5898,7 +5925,7 @@ jobs:
               # Per-round growth history the next round's divergence read
               # counts; run=GITHUB_RUN_ID is the dedup+order identity (a retry
               # re-posts the same run, distinct runs get fresh run ids).
-              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
+              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
             } > "${WORKDIR}/report.md"
             STATUS="no action needed"
           fi
@@ -6054,6 +6081,7 @@ jobs:
           GROWTH_SRC: '${{ steps.prepare.outputs.growth_src }}'
           GROWTH_TEST: '${{ steps.prepare.outputs.growth_test }}'
           CRITICAL_ONLY_GROWTH: '${{ steps.prepare.outputs.critical_only_growth }}'
+          MEASURED_AT: '${{ steps.prepare.outputs.measured_at }}'
           GROWTH_BASE_WIN: '${{ steps.prepare.outputs.growth_base_win }}'
         run: |-
           # The head the agent actually evaluated — captured in prepare before
@@ -6564,7 +6592,7 @@ jobs:
               # marker the push/no-op report paths write, so an over-budget
               # round that timed out or was gate-rejected is not a gap. run=
               # (per-workflow-run) is the dedup/order identity.
-              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
+              echo "<!-- autofix-growth-now src=${GROWTH_SRC:-0} test=${GROWTH_TEST:-0} over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=${GROWTH_BASE_WIN:-${WINDOW:-none}} -->"
               # A sentinel ts means the agent evaluated NOTHING (crash, API
               # error, gate crash) and the next scan must retry. Recording a
               # judged head here would make RED_HEAD == LIVE_HEAD, so the

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -6578,6 +6578,29 @@ exit 1
         ],
       }),
     ).toBe('false 0');
+    // An INERT marker (the failure path posts one with no measured= when
+    // prepare never ran, so it carries src/test 0 and over=false) must not
+    // erase a real over-budget measurement for the SAME run: its created_at
+    // fallback is ~2h later than the prepare-time measured= it would displace,
+    // so the collapse prefers the marker that actually measured something.
+    // Dropping `.explicit` from the collapse key silently loses the count.
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        history: [
+          marker(500, 300, 'true', 2, 'W1', {
+            run: 1001,
+            measured: '2026-01-01T00:01:00Z',
+          }),
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T02:00:00Z',
+            body: '<!-- autofix-growth-now src=0 test=0 over=false round=2 run=1001 key=W1 -->',
+          },
+        ],
+      }),
+    ).toBe('false 1');
     // Backward compatibility: a marker posted BEFORE measured= existed still
     // counts, falling back to its comment's created_at — deploying the
     // measured= switch must not blank the census of an in-flight window.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -6250,15 +6250,20 @@ exit 1
       key = 'W1',
       {
         login = 'qwen-code-dev-bot',
-        at = '2026-01-01T00:00:00Z',
-        // Default run advances with the round so sort_by(.run) is
-        // deterministic; distinct runs that share round= override it.
+        // measured= (the prepare-time measurement instant) is the dedup/order
+        // key; default advances with the round so sort_by/max_by are
+        // deterministic. A re-run's distinct attempts override it explicitly.
+        measured = `2026-01-01T00:${String(round).padStart(2, '0')}:00Z`,
+        // Default run advances with the round; distinct runs that share round=
+        // override it.
         run = 1000 + round,
       } = {},
     ) => ({
       user: { login },
-      created_at: at,
-      body: `<!-- autofix-growth-now src=${src} test=${test} over=${over} round=${round} run=${run} key=${key} -->`,
+      // created_at is no longer read (the filter uses measured=), kept only
+      // as a realistic comment field.
+      created_at: measured,
+      body: `<!-- autofix-growth-now src=${src} test=${test} over=${over} round=${round} run=${run} measured=${measured} key=${key} -->`,
     });
     const diverge = ({
       src,
@@ -6266,7 +6271,9 @@ exit 1
       criticalOnlyGrowth = 'true',
       history,
       div = 2,
-      baseUpdAt = '',
+      // The comparability cutoff (base update OR external head move); markers
+      // measured at/before it are dropped as incomparable.
+      cutoff = '',
       // Distinct from every default fixture run id (1000+round), so existing
       // cases see no self-exclusion; a case can set a fixture marker's run to
       // this to prove the current run's own attempt is excluded.
@@ -6281,7 +6288,7 @@ exit 1
           '-c',
           `set -e\nAUTOFIX_BOT=qwen-code-dev-bot\nLIVE_REARM_KEY=W1\nWORKDIR=${dir}\n` +
             `NET_MEASURED=true\nCRITICAL_ONLY_GROWTH=${criticalOnlyGrowth}\n` +
-            `BASE_UPD_AT='${baseUpdAt}'\nGITHUB_RUN_ID=${currentRun}\n` +
+            `GROWTH_NOW_CUTOFF='${cutoff}'\nGITHUB_RUN_ID=${currentRun}\n` +
             `GROWTH_SRC=${src}\nGROWTH_TEST=${test}\nGROWTH_DIVERGENCE_ROUNDS=${div}\n` +
             `${divBlock}\nprintf '\\n%s %s' "$GROWTH_DIVERGED" "$OVER_ROUNDS_PRIOR"`,
         ],
@@ -6367,11 +6374,11 @@ exit 1
           marker(300, 200, 'true', 1, 'W1', { run: 1001 }),
           marker(600, 300, 'true', 2, 'W1', {
             run: 1002,
-            at: '2026-01-01T00:01:00Z',
+            measured: '2026-01-01T00:01:00Z',
           }),
           marker(150, 150, 'true', 2, 'W1', {
             run: 1002,
-            at: '2026-01-01T00:02:00Z',
+            measured: '2026-01-01T00:02:00Z',
           }),
         ],
       }),
@@ -6434,17 +6441,24 @@ exit 1
         history: climbing.map((m) => ({ ...m, user: { login: 'attacker' } })),
       }),
     ).toBe('false 0');
-    // Markers BEFORE a mid-window base update are excluded (re-anchoring makes
-    // pre-update sums incomparable) — only the post-update round remains.
+    // Markers measured at/before the comparability cutoff (a base update OR an
+    // external head move) are excluded — re-anchoring makes pre-cutoff sums
+    // incomparable; only the post-cutoff round remains.
     expect(
       diverge({
         src: 999,
         test: 999,
-        baseUpdAt: '2026-01-01T12:00:00Z',
+        cutoff: '2026-01-01T12:00:00Z',
         history: [
-          marker(500, 300, 'true', 1, 'W1', { at: '2026-01-01T06:00:00Z' }),
-          marker(600, 400, 'true', 2, 'W1', { at: '2026-01-01T06:30:00Z' }),
-          marker(200, 100, 'true', 3, 'W1', { at: '2026-01-01T18:00:00Z' }),
+          marker(500, 300, 'true', 1, 'W1', {
+            measured: '2026-01-01T06:00:00Z',
+          }),
+          marker(600, 400, 'true', 2, 'W1', {
+            measured: '2026-01-01T06:30:00Z',
+          }),
+          marker(200, 100, 'true', 3, 'W1', {
+            measured: '2026-01-01T18:00:00Z',
+          }),
         ],
       }),
     ).toBe('false 1');
@@ -6492,7 +6506,8 @@ exit 1
         [
           '-c',
           `GROWTH_SRC=500\nGROWTH_TEST=300\nCRITICAL_ONLY_GROWTH=true\n` +
-            `${roundVar}=2\nGITHUB_RUN_ID=1002\nGROWTH_BASE_WIN=W1\nWINDOW=none\n${line}`,
+            `${roundVar}=2\nGITHUB_RUN_ID=1002\nMEASURED_AT=2026-01-01T00:05:00Z\n` +
+            `GROWTH_BASE_WIN=W1\nWINDOW=none\n${line}`,
         ],
         { encoding: 'utf8' },
       ).trim();
@@ -6524,7 +6539,7 @@ exit 1
       workflow.match(/<!-- autofix-growth-now src=\$\{GROWTH_SRC:-0\}/g) ?? [],
     ).toHaveLength(3);
     expect(workflow).toContain(
-      'over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID} key=',
+      'over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=',
     );
     // The failure/handoff report step binds the three growth outputs so its
     // marker is not inert-by-omission.
@@ -6554,11 +6569,49 @@ exit 1
       expect(pushAndReportStep).toContain(bind);
     }
     expect(workflow).toContain(
-      'over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID} key=',
+      'over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=',
     );
     expect(workflow).toContain(
-      'over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID} key=',
+      'over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=',
     );
+    // Both report STEPS bind MEASURED_AT (push+no-op share one env block, the
+    // failure/handoff report has its own), so all three marker writers can
+    // stamp the prepare-time instant (not the post-agent comment created_at).
+    expect(
+      workflow.match(
+        /MEASURED_AT: '\$\{\{ steps\.prepare\.outputs\.measured_at \}\}'/g,
+      ) ?? [],
+    ).toHaveLength(2);
+    expect(workflow).toContain('echo "measured_at=${MEASURED_AT}"');
+    // The comparability cutoff re-anchors on an external head move (author
+    // push / base update), not only the bot's own base-update marker: extract
+    // the GROWTH_NOW_CUTOFF block and exercise both branches.
+    const cutoffBlock = prepareBranchAndFeedbackStep.match(
+      /GROWTH_NOW_CUTOFF="\$\{BASE_UPD_AT\}"\n[\s\S]*?GROWTH_NOW_CUTOFF="\$\{MEASURED_AT\}"\n\s+fi/,
+    )?.[0];
+    expect(cutoffBlock).toBeTruthy();
+    const cutoffOf = (liveRed, head) =>
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          `BASE_UPD_AT=base-ts\nMEASURED_AT=now-ts\n` +
+            `LIVE_RED_HEAD='${liveRed}'\nCHECKED_OUT_HEAD='${head}'\n` +
+            `${cutoffBlock}\nprintf '%s' "$GROWTH_NOW_CUTOFF"`,
+        ],
+        { encoding: 'utf8' },
+      )
+        .trim()
+        .split('\n')
+        .pop();
+    // Head unchanged since the bot's last judged head → keep the base-update
+    // cutoff (prior sums stay comparable across bot rounds).
+    expect(cutoffOf('abc123', 'abc123')).toBe('base-ts');
+    // Head moved to something the bot did not record (author push / base
+    // update) → re-anchor at now, dropping every prior sum.
+    expect(cutoffOf('abc123', 'def456')).toBe('now-ts');
+    // First round (no prior bot head) → nothing to re-anchor against.
+    expect(cutoffOf('', 'def456')).toBe('base-ts');
     // growth_diverged is NOT emitted as a step output — the handoff is
     // enforced by the feedback.md text, so a dangling dead output would only
     // mislead a future consumer.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -6236,12 +6236,14 @@ exit 1
     expect(divBlock).toBeTruthy();
     const dir = mkdtempSync(join(tmpdir(), 'autofix-diverge-'));
     // Markers carry round= (informational) and run= (GITHUB_RUN_ID) — deduped
-    // and ordered on run=, the per-workflow-run id: a retry re-posts one run's
-    // marker (same run → collapses) while distinct address runs have distinct,
-    // increasing run ids. round=/eval-watermark are NOT a safe identity — a
-    // state-triggered lane freezes both — so two distinct runs can share
-    // round= yet must still count twice. Each row also carries an author +
-    // created_at (the read filters to the bot and to post-base-update markers).
+    // on run= and ordered on measured= (the prepare-time instant; created_at
+    // fallback for legacy markers), the per-workflow-run id: a retry or a
+    // failed job's re-run re-posts one run's marker (same run → collapses to
+    // its latest measurement) while distinct address runs have distinct run
+    // ids. round=/eval-watermark are NOT a safe identity — a state-triggered
+    // lane freezes both — so two distinct runs can share round= yet must still
+    // count twice. Each row also carries an author + created_at (the read
+    // filters to the bot and to markers measured after the cutoff).
     const marker = (
       src,
       test,
@@ -6500,6 +6502,79 @@ exit 1
             run: 1001,
             measured: '2026-01-01T00:09:00Z',
           }),
+        ],
+      }),
+    ).toBe('false 0');
+    // Mirror of that case for the FAILURE path's inert marker: a re-run
+    // attempt that crashed BEFORE prepare posts over=false with NO measured=
+    // (MEASURED_AT empty), so its fallback is the comment's created_at —
+    // post-run, hence newer than the same run's prepare-time measured= from
+    // its earlier attempt. The collapse must prefer an explicit measured=
+    // over that fallback, or the inert marker erases the run's real
+    // over-budget count (#9192 R3-1).
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        history: [
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T02:00:00Z',
+            body: '<!-- autofix-growth-now src=500 test=300 over=true round=1 run=1001 measured=2026-01-01T00:01:00Z key=W1 -->',
+          },
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T03:00:00Z',
+            body: '<!-- autofix-growth-now src=0 test=0 over=false round=1 run=1001 key=W1 -->',
+          },
+        ],
+      }),
+    ).toBe('false 1');
+    // Same defect at the handoff threshold: two real over-budget priors, the
+    // second erased by the inert marker — without the explicit-measured
+    // preference the count drops to 1 and the divergence handoff (div=2) is
+    // suppressed while the diff keeps climbing.
+    expect(
+      diverge({
+        src: 500,
+        test: 300,
+        history: [
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T01:30:00Z',
+            body: '<!-- autofix-growth-now src=300 test=200 over=true round=1 run=1001 measured=2026-01-01T00:00:30Z key=W1 -->',
+          },
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T02:00:00Z',
+            body: '<!-- autofix-growth-now src=400 test=250 over=true round=2 run=1002 measured=2026-01-01T00:01:00Z key=W1 -->',
+          },
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T03:00:00Z',
+            body: '<!-- autofix-growth-now src=0 test=0 over=false round=2 run=1002 key=W1 -->',
+          },
+        ],
+      }),
+    ).toBe('true 2');
+    // …and two LEGACY markers for the same run (neither carries measured=)
+    // still collapse on the created_at fallback: the explicit-measured
+    // preference must not disturb fallback-vs-fallback ordering.
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        history: [
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T02:00:00Z',
+            body: '<!-- autofix-growth-now src=300 test=150 over=true round=1 run=1001 key=W1 -->',
+          },
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T03:00:00Z',
+            body: '<!-- autofix-growth-now src=80 test=40 over=false round=1 run=1001 key=W1 -->',
+          },
         ],
       }),
     ).toBe('false 0');

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -6260,9 +6260,10 @@ exit 1
       } = {},
     ) => ({
       user: { login },
-      // created_at is no longer read (the filter uses measured=), kept only
-      // as a realistic comment field.
-      created_at: measured,
+      // Deliberately DIFFERENT from measured=: the report posts the comment
+      // long after prepare measured, and the read must key on measured=. A
+      // fixture that tied them together could not tell the two apart.
+      created_at: '2026-06-01T00:00:00Z',
       body: `<!-- autofix-growth-now src=${src} test=${test} over=${over} round=${round} run=${run} measured=${measured} key=${key} -->`,
     });
     const diverge = ({
@@ -6363,7 +6364,7 @@ exit 1
       }),
     ).toBe('false 1');
     // When a run was re-run and posted two markers with DIFFERENT sums, the
-    // LATEST attempt (by created_at) wins, not jq's stale first: run 1002's
+    // LATEST attempt (by measured=) wins, not jq's stale first: run 1002's
     // fresh attempt (sum 300 @ T2) is PREV_SUM, so current 400 >= 300 →
     // diverged. Keeping the stale first (sum 900) would read 400 >= 900 → not.
     expect(
@@ -6462,6 +6463,56 @@ exit 1
         ],
       }),
     ).toBe('false 1');
+    // A re-run whose FRESH attempt came back under budget must not be
+    // represented by its own stale over=true attempt: the per-run collapse
+    // happens BEFORE the over-filter, so the run drops out entirely.
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        history: [
+          marker(300, 150, 'true', 1, 'W1', {
+            run: 1001,
+            measured: '2026-01-01T00:01:00Z',
+          }),
+          marker(80, 40, 'false', 1, 'W1', {
+            run: 1001,
+            measured: '2026-01-01T00:09:00Z',
+          }),
+        ],
+      }),
+    ).toBe('false 0');
+    // Backward compatibility: a marker posted BEFORE measured= existed still
+    // counts, falling back to its comment's created_at — deploying the
+    // measured= switch must not blank the census of an in-flight window.
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        history: [
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T00:01:00Z',
+            body: '<!-- autofix-growth-now src=500 test=300 over=true round=1 run=1001 key=W1 -->',
+          },
+        ],
+      }),
+    ).toBe('false 1');
+    // …and a legacy marker is still subject to the cutoff, via that fallback.
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        cutoff: '2026-01-01T12:00:00Z',
+        history: [
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T00:01:00Z',
+            body: '<!-- autofix-growth-now src=500 test=300 over=true round=1 run=1001 key=W1 -->',
+          },
+        ],
+      }),
+    ).toBe('false 0');
     // A malformed GROWTH_DIVERGENCE_ROUNDS falls back to 2 (the sanitize guard
     // at the top of the block) instead of crashing the `-ge` arithmetic: two
     // prior over-budget rounds still climbing → diverged.
@@ -6583,35 +6634,24 @@ exit 1
       ) ?? [],
     ).toHaveLength(2);
     expect(workflow).toContain('echo "measured_at=${MEASURED_AT}"');
-    // The comparability cutoff re-anchors on an external head move (author
-    // push / base update), not only the bot's own base-update marker: extract
-    // the GROWTH_NOW_CUTOFF block and exercise both branches.
-    const cutoffBlock = prepareBranchAndFeedbackStep.match(
-      /GROWTH_NOW_CUTOFF="\$\{BASE_UPD_AT\}"\n[\s\S]*?GROWTH_NOW_CUTOFF="\$\{MEASURED_AT\}"\n\s+fi/,
-    )?.[0];
-    expect(cutoffBlock).toBeTruthy();
-    const cutoffOf = (liveRed, head) =>
-      execFileSync(
-        'bash',
-        [
-          '-c',
-          `BASE_UPD_AT=base-ts\nMEASURED_AT=now-ts\n` +
-            `LIVE_RED_HEAD='${liveRed}'\nCHECKED_OUT_HEAD='${head}'\n` +
-            `${cutoffBlock}\nprintf '%s' "$GROWTH_NOW_CUTOFF"`,
-        ],
-        { encoding: 'utf8' },
-      )
-        .trim()
-        .split('\n')
-        .pop();
-    // Head unchanged since the bot's last judged head → keep the base-update
-    // cutoff (prior sums stay comparable across bot rounds).
-    expect(cutoffOf('abc123', 'abc123')).toBe('base-ts');
-    // Head moved to something the bot did not record (author push / base
-    // update) → re-anchor at now, dropping every prior sum.
-    expect(cutoffOf('abc123', 'def456')).toBe('now-ts');
-    // First round (no prior bot head) → nothing to re-anchor against.
-    expect(cutoffOf('', 'def456')).toBe('base-ts');
+    // The measurement instant is taken in PREPARE, next to the net it stamps —
+    // not at report time, which is what the whole switch is about.
+    const prepMeasured = prepareBranchAndFeedbackStep.indexOf(
+      'MEASURED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"',
+    );
+    expect(prepMeasured).toBeGreaterThan(-1);
+    expect(prepMeasured).toBeLessThan(
+      prepareBranchAndFeedbackStep.indexOf('echo "measured_at=${MEASURED_AT}"'),
+    );
+    // The head-move re-anchor is deliberately NOT in this change (see #9114):
+    // the redcheck head is the pre-push judged head, so comparing against it
+    // would re-anchor on the bot's own pushes and zero the census.
+    expect(prepareBranchAndFeedbackStep).not.toContain(
+      'GROWTH_NOW_CUTOFF="${MEASURED_AT}"',
+    );
+    expect(prepareBranchAndFeedbackStep).toContain(
+      'GROWTH_NOW_CUTOFF="${BASE_UPD_AT}"',
+    );
     // growth_diverged is NOT emitted as a step output — the handoff is
     // enforced by the feedback.md text, so a dangling dead output would only
     // mislead a future consumer.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -6486,6 +6486,22 @@ exit 1
         ],
       }),
     ).toBe('false 1');
+    // …and the boundary is STRICT: a marker measured exactly AT the cutoff
+    // is dropped as incomparable (at second granularity a same-second stamp
+    // and base-update comment can collide) — a `>` → `>=` flip ships green
+    // without this pin (#9192 R4-7).
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        cutoff: '2026-01-01T12:00:00Z',
+        history: [
+          marker(500, 300, 'true', 1, 'W1', {
+            measured: '2026-01-01T12:00:00Z',
+          }),
+        ],
+      }),
+    ).toBe('false 0');
     // A re-run whose FRESH attempt came back under budget must not be
     // represented by its own stale over=true attempt: the per-run collapse
     // happens BEFORE the over-filter, so the run drops out entirely.
@@ -6578,29 +6594,6 @@ exit 1
         ],
       }),
     ).toBe('false 0');
-    // An INERT marker (the failure path posts one with no measured= when
-    // prepare never ran, so it carries src/test 0 and over=false) must not
-    // erase a real over-budget measurement for the SAME run: its created_at
-    // fallback is ~2h later than the prepare-time measured= it would displace,
-    // so the collapse prefers the marker that actually measured something.
-    // Dropping `.explicit` from the collapse key silently loses the count.
-    expect(
-      diverge({
-        src: 999,
-        test: 999,
-        history: [
-          marker(500, 300, 'true', 2, 'W1', {
-            run: 1001,
-            measured: '2026-01-01T00:01:00Z',
-          }),
-          {
-            user: { login: 'qwen-code-dev-bot' },
-            created_at: '2026-01-01T02:00:00Z',
-            body: '<!-- autofix-growth-now src=0 test=0 over=false round=2 run=1001 key=W1 -->',
-          },
-        ],
-      }),
-    ).toBe('false 1');
     // Backward compatibility: a marker posted BEFORE measured= existed still
     // counts, falling back to its comment's created_at — deploying the
     // measured= switch must not blank the census of an in-flight window.
@@ -6717,10 +6710,12 @@ exit 1
     expect(roundTrip('NEXT_ROUND')).toBe('false 1'); // push path
     expect(roundTrip('ROUND')).toBe('false 1'); // no-op path
     expect(roundTrip('MARK_ROUND')).toBe('false 1'); // failure/handoff path
-    // …and it still round-trips when prepare NEVER RAN (MEASURED_AT empty):
-    // measured= omits itself rather than emit an empty value no scan can
-    // match, so the marker survives on the created_at fallback instead of
-    // silently dropping (#9192 R2-1).
+    // …and it still round-trips when MEASURED_AT is empty — prepare never
+    // ran (#9192 R2-1) or the round could not measure (#9192 R4-3): measured=
+    // omits itself rather than emit an empty value no scan can match, so the
+    // marker survives on the created_at fallback instead of silently dropping.
+    expect(roundTrip('NEXT_ROUND', { omitMeasuredAt: true })).toBe('false 1');
+    expect(roundTrip('ROUND', { omitMeasuredAt: true })).toBe('false 1');
     expect(roundTrip('MARK_ROUND', { omitMeasuredAt: true })).toBe('false 1');
     rmSync(dir, { recursive: true, force: true });
 
@@ -6763,10 +6758,10 @@ exit 1
       expect(pushAndReportStep).toContain(bind);
     }
     expect(workflow).toContain(
-      'over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=',
+      'over=${CRITICAL_ONLY_GROWTH:-false} round=${NEXT_ROUND} run=${GITHUB_RUN_ID}${MEASURED_AT:+ measured=${MEASURED_AT}} key=',
     );
     expect(workflow).toContain(
-      'over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=',
+      'over=${CRITICAL_ONLY_GROWTH:-false} round=${ROUND} run=${GITHUB_RUN_ID}${MEASURED_AT:+ measured=${MEASURED_AT}} key=',
     );
     // Both report STEPS bind MEASURED_AT (push+no-op share one env block, the
     // failure/handoff report has its own), so all three marker writers can
@@ -6786,6 +6781,27 @@ exit 1
     expect(prepMeasured).toBeLessThan(
       prepareBranchAndFeedbackStep.indexOf('echo "measured_at=${MEASURED_AT}"'),
     );
+    // …and the stamp is emitted ONLY when the round actually measured: an
+    // unmeasured re-run attempt must not gain an explicit measured= that the
+    // per-run collapse would prefer over the same run's real measurement
+    // (#9192 R4-3). Behavioral: execute the gated stamp both ways.
+    const stampGate = prepareBranchAndFeedbackStep.match(
+      /\[\[ "\$\{NET_MEASURED\}" == 'true' \]\] && echo "measured_at=\$\{MEASURED_AT\}" >> "\$\{GITHUB_OUTPUT\}"/,
+    )?.[0];
+    expect(stampGate).toBeTruthy();
+    const stampedFor = (netMeasured) =>
+      execFileSync(
+        'bash',
+        [
+          '-c',
+          `set -e\nout="$(mktemp)"\nNET_MEASURED=${netMeasured}\n` +
+            `MEASURED_AT=2026-01-01T00:05:00Z\nGITHUB_OUTPUT="$out"\n` +
+            `${stampGate} || true\ncat "$out"\nrm -f "$out"`,
+        ],
+        { encoding: 'utf8' },
+      );
+    expect(stampedFor('true')).toBe('measured_at=2026-01-01T00:05:00Z\n');
+    expect(stampedFor('false')).toBe('');
     // The head-move re-anchor is deliberately NOT in this change (see #9114):
     // the redcheck head is the pre-push judged head, so comparing against it
     // would re-anchor on the bot's own pushes and zero the census.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -6384,6 +6384,27 @@ exit 1
         ],
       }),
     ).toBe('true 2');
+    // measured= order inverts run order across DISTINCT runs — a failed
+    // job's re-run keeps its OLD run id but stamps a NEWER measured=:
+    // PREV_SUM must follow measured=, so the current 150 >= 100 runaway
+    // escalates. Reverting to run-id ordering would read run 1002's stale
+    // 900 as PREV_SUM and suppress it (#9192 R2-4).
+    expect(
+      diverge({
+        src: 100,
+        test: 50,
+        history: [
+          marker(60, 40, 'true', 1, 'W1', {
+            run: 1001,
+            measured: '2026-01-01T00:09:00Z',
+          }),
+          marker(500, 400, 'true', 2, 'W1', {
+            run: 1002,
+            measured: '2026-01-01T00:02:00Z',
+          }),
+        ],
+      }),
+    ).toBe('true 2');
     // Two DISTINCT runs that share round= AND a frozen eval watermark (the
     // state-triggered conflict lane: a push stamps NEXT_ROUND, the following
     // no-op re-stamps the same ROUND, neither NEWEST nor ROUND advances) are
@@ -6513,6 +6534,24 @@ exit 1
         ],
       }),
     ).toBe('false 0');
+    // …and the created_at fallback ITSELF is pinned: a legacy marker whose
+    // created_at sits AFTER the cutoff still counts. Dropping the fallback
+    // (measured= absent → "") would exclude every post-update legacy marker
+    // and under-count the census (#9192 R2-3).
+    expect(
+      diverge({
+        src: 999,
+        test: 999,
+        cutoff: '2026-01-01T12:00:00Z',
+        history: [
+          {
+            user: { login: 'qwen-code-dev-bot' },
+            created_at: '2026-01-01T18:00:00Z',
+            body: '<!-- autofix-growth-now src=500 test=300 over=true round=1 run=1001 key=W1 -->',
+          },
+        ],
+      }),
+    ).toBe('false 1');
     // A malformed GROWTH_DIVERGENCE_ROUNDS falls back to 2 (the sanitize guard
     // at the top of the block) instead of crashing the `-ge` arithmetic: two
     // prior over-budget rounds still climbing → diverged.
@@ -6545,7 +6584,7 @@ exit 1
     // of silently inerting the feature. Every writer path is covered, not just
     // the push path (a drift in only the no-op or failure suffix would
     // otherwise survive green).
-    const roundTrip = (roundVar) => {
+    const roundTrip = (roundVar, { omitMeasuredAt = false } = {}) => {
       const line = workflow.match(
         new RegExp(
           `echo "<!-- autofix-growth-now src=\\$\\{GROWTH_SRC:-0\\}[^\\n]*round=\\$\\{${roundVar}\\}[^\\n]*-->"`,
@@ -6557,7 +6596,8 @@ exit 1
         [
           '-c',
           `GROWTH_SRC=500\nGROWTH_TEST=300\nCRITICAL_ONLY_GROWTH=true\n` +
-            `${roundVar}=2\nGITHUB_RUN_ID=1002\nMEASURED_AT=2026-01-01T00:05:00Z\n` +
+            `${roundVar}=2\nGITHUB_RUN_ID=1002\n` +
+            (omitMeasuredAt ? '' : 'MEASURED_AT=2026-01-01T00:05:00Z\n') +
             `GROWTH_BASE_WIN=W1\nWINDOW=none\n${line}`,
         ],
         { encoding: 'utf8' },
@@ -6579,6 +6619,11 @@ exit 1
     expect(roundTrip('NEXT_ROUND')).toBe('false 1'); // push path
     expect(roundTrip('ROUND')).toBe('false 1'); // no-op path
     expect(roundTrip('MARK_ROUND')).toBe('false 1'); // failure/handoff path
+    // …and it still round-trips when prepare NEVER RAN (MEASURED_AT empty):
+    // measured= omits itself rather than emit an empty value no scan can
+    // match, so the marker survives on the created_at fallback instead of
+    // silently dropping (#9192 R2-1).
+    expect(roundTrip('MARK_ROUND', { omitMeasuredAt: true })).toBe('false 1');
     rmSync(dir, { recursive: true, force: true });
 
     // The report writes the per-round growth-now marker on ALL THREE report
@@ -6590,7 +6635,7 @@ exit 1
       workflow.match(/<!-- autofix-growth-now src=\$\{GROWTH_SRC:-0\}/g) ?? [],
     ).toHaveLength(3);
     expect(workflow).toContain(
-      'over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID} measured=${MEASURED_AT} key=',
+      'over=${CRITICAL_ONLY_GROWTH:-false} round=${MARK_ROUND} run=${GITHUB_RUN_ID}${MEASURED_AT:+ measured=${MEASURED_AT}} key=',
     );
     // The failure/handoff report step binds the three growth outputs so its
     // marker is not inert-by-omission.


### PR DESCRIPTION
## What this PR does

Tightens the growth-divergence comparability window from PR #9104 — the two precision items named in the follow-up issue #9114.

1. **`measured_at` (R2-6).** The `autofix-growth-now` marker now carries the **prepare-time measurement instant**, and the divergence read filters/orders on it instead of the marker comment's `created_at`. The report posts the marker only after the agent's ~120-minute run, so a round in flight when a concurrent base update landed would otherwise pass a `created_at` filter while carrying sums measured against the **old** base. Per-run dedup now keeps the latest attempt by `measured=` (a re-run's fresh measurement wins over its stale first post).
2. **External head move (R2-8, subsumes R6-3).** Prior sums are measured against `origin/main`, so any commit an **external actor** (an author push) or a **stale-base merge** added since the bot last evaluated the branch inflates this round's sum relative to them. `BASE_UPD_AT` only tracks the bot's own update-branch merge; the new `GROWTH_NOW_CUTOFF` **also re-anchors** (drops all prior sums) whenever the checked-out head is not the bot's last judged head (`LIVE_RED_HEAD`) — covering author pushes and base updates alike.

## Why it's needed

Both were flagged during the #9104 review as fail-safe / `/retry`-recoverable comparability edges and deferred here. Without them, a prior sum measured against a different tree than the current round's can trip (or suppress) a false handoff — most visibly when a maintainer/author pushes to a takeover PR mid-review.

## Reviewer Test Plan

### How to verify

`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js` — the non-convergence test now covers: the `measured`-based comparability cutoff (pre-cutoff markers excluded); the external-head-move re-anchor extracted and exercised both branches (head unchanged → keep base-update cutoff; head moved → re-anchor at now; first round → nothing to re-anchor); latest-attempt-by-`measured` dedup; and the writer→reader round-trip with the new field across all three writers. 172/172; YAML parse, eslint, prettier clean.

### Evidence (Before & After)

Before: comparability keyed on comment `created_at` (post-agent) and re-anchored only on the bot's own base-update marker. After: keyed on the prepare-time `measured_at`, re-anchored on any external head move.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Policy/orchestration only (workflow YAML + contract test), no core code. Direction is fail-safe: re-anchoring drops prior sums, which can only DELAY a handoff (a human is engaged later, never a spurious one). `measured_at` uses a CI-shell `date` call (not the deterministic workflow-script env).
- Not in scope: R6-6 (markers don't store the effective budget, so a mid-window budget *raise* counts old rounds against the new regime — fail-safe, at most one round early) stays tracked in #9114; the R6-1/R6-2/R6-4 design questions from #9104's round-6 are maintainer calls, not code changes.

## Linked Issues

- Follow-up of #9104; addresses the R2-6 / R2-8 items tracked in #9114.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

收紧 #9104 发散探测的可比性窗口——即 follow-up issue #9114 点名的两项精度问题。

1. **`measured_at`(R2-6)。** `autofix-growth-now` marker 现在携带 **prepare 时的测量时刻**,发散读取按它过滤/排序,而非 marker 评论的 `created_at`。report 只在 agent 约 120 分钟运行后才发 marker,因此一个运行中的轮次若期间发生并发 base 更新,按 `created_at` 过滤会漏掉、却带着按**旧** base 测得的 sum。每 run 去重现在按 `measured=` 取最新 attempt(重跑的新测量胜过其陈旧首发)。
2. **外部 head 移动(R2-8,并入 R6-3)。** 先前 sum 按 `origin/main` 测量,因此自 bot 上次评估分支以来任何**外部**(作者 push)或 **stale-base merge** 加入的提交,都会让本轮 sum 相对它们虚高。`BASE_UPD_AT` 只跟踪 bot 自己的 update-branch merge;新的 `GROWTH_NOW_CUTOFF` **额外重锚**(丢弃全部先前 sum)——只要当前 checkout 的 head 不是 bot 上次判定的 head(`LIVE_RED_HEAD`),涵盖作者 push 与 base 更新。

## 为什么需要

两者在 #9104 评审中被标为 fail-safe / 可 `/retry` 恢复的可比性边角并延期至此。不修的话,按不同树测得的先前 sum 与本轮比较会误触发(或抑制)handoff——在 takeover PR 评审中途维护者/作者 push 时最明显。

## 审阅者测试计划

### 如何验证

`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js` —— 非收敛测试现覆盖:基于 `measured` 的可比性 cutoff(pre-cutoff marker 被排除);外部 head 移动重锚(抽取并双分支验证:head 未变→保留 base-update cutoff;head 变→在 now 重锚;首轮→无可重锚);按 `measured` 取最新 attempt 去重;以及三个写入点的写→读往返带新字段。172/172;YAML 解析、eslint、prettier 干净。

### 证据(Before & After)

Before:可比性以评论 `created_at`(agent 后)为键,仅在 bot 自身 base-update marker 上重锚。After:以 prepare 时的 `measured_at` 为键,在任何外部 head 移动上重锚。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## 风险与范围

- 纯策略/编排(workflow YAML + 契约测试),不碰核心代码。方向 fail-safe:重锚丢弃先前 sum,只会**延迟** handoff(人晚一点介入,绝不会误触发)。`measured_at` 用 CI shell 的 `date`(非确定性 workflow-script 环境)。
- 范围外:R6-6(marker 不记当时有效预算,窗口中途**调高**预算会让旧轮按新预算计数——fail-safe,至多提前一轮)留在 #9114 跟踪;#9104 第 6 轮的 R6-1/R6-2/R6-4 属维护者决策,非代码变更。

## 关联 Issue

- #9104 的 follow-up;处理 #9114 跟踪的 R2-6 / R2-8。

</details>
