### PR TITLE
fix(ci): skip non-bot review_requested siblings before jobs spend compute

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -159,9 +159,17 @@ jobs:
           fi
 
   review-config:
+    # Bot-requested review_requested only: a CODEOWNERS-covered PR open
+    # auto-requests every owner individually (#8945), spawning one
+    # review_requested run per owner. Only the run where the bot itself is
+    # the requested reviewer can reach review-pr, so the human-requested
+    # siblings must skip here instead of each spending a runner. KEEP IN
+    # SYNC with the review_requested clauses in precheck-pr.if and
+    # authorize.if, and with the bot_login constant below.
     if: |-
       github.event_name == 'pull_request_target' &&
-      github.event.action == 'review_requested'
+      github.event.action == 'review_requested' &&
+      github.event.requested_reviewer.login == 'qwen-code-ci-bot'
     runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     permissions: {}
     outputs:
@@ -225,6 +233,11 @@ jobs:
     # Only run for PR-target events and supported command comments — not every
     # unrelated comment — to avoid spawning a job per comment. The downstream
     # `if`s still do the exact command body match; this prefix is just a filter.
+    # review_requested must additionally request the bot itself: a
+    # CODEOWNERS-covered PR open auto-requests every owner individually
+    # (#8945), and precheck-pr's identical predicate only covers fork PRs —
+    # without this clause each same-repo sibling run spends an authorize job
+    # (permission API + runner slot) before review-pr no-op exits.
     if: |-
       !cancelled() &&
       (github.event_name != 'pull_request_target' ||
@@ -232,6 +245,9 @@ jobs:
       (github.event_name != 'pull_request_target' ||
        github.event.pull_request.head.repo.full_name == github.repository ||
        needs.precheck-pr.outputs.decision == 'allow_triage') &&
+      (github.event_name != 'pull_request_target' ||
+       github.event.action != 'review_requested' ||
+       github.event.requested_reviewer.login == 'qwen-code-ci-bot') &&
       (github.event_name == 'pull_request_target' ||
        (github.event_name == 'workflow_dispatch' &&
         github.event.inputs.command == 'resolve') ||

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2517,3 +2517,47 @@ describe('bot comment markers', () => {
     expect(ackLine).toContain('"$RUN_URL"');
   });
 });
+
+describe('review_requested burst coalescing (#8945)', () => {
+  // Opening a same-repo PR that touches CODEOWNERS-covered paths auto-requests
+  // every owner individually, so one PR open emits one `review_requested` run
+  // per owner (observed: five within the same second on #8830/#9142). Only
+  // the bot-requested run can reach `review-pr`; the human-requested siblings
+  // used to spend an `authorize` job (permission API + runner slot) each
+  // before no-op exiting. `authorize` and `review-config` must filter those
+  // siblings at the job level so they complete as instant all-skipped runs.
+  const doc = parse(workflow);
+
+  const botLoginMatch = doc.jobs['review-config'].steps[0].run.match(
+    /bot_login=([A-Za-z0-9-]+)/,
+  );
+  const botLogin = botLoginMatch ? botLoginMatch[1] : '';
+
+  const botRequestedClause = new RegExp(
+    [
+      String.raw`\(\s*github\.event_name != 'pull_request_target' \|\|`,
+      String.raw`\s*github\.event\.action != 'review_requested' \|\|`,
+      String.raw`\s*github\.event\.requested_reviewer\.login == '${botLogin}'\s*\)`,
+    ].join(''),
+  );
+
+  it('resolves the bot login from review-config, not a paraphrase', () => {
+    expect(botLogin).toBe('qwen-code-ci-bot');
+  });
+
+  it('filters non-bot review_requested events before authorize spends compute', () => {
+    // The same disjunction precheck-pr already applies to fork PRs; mirroring
+    // it here covers same-repo PRs, which precheck-pr deliberately skips.
+    expect(doc.jobs['authorize'].if).toMatch(botRequestedClause);
+  });
+
+  it('keeps review-config from running for non-bot review_requested events', () => {
+    // review-config exists to feed bot_login into review-pr; only the
+    // bot-requested run can get there, so every other sibling is pure waste.
+    const cond = doc.jobs['review-config'].if;
+    expect(cond).toContain("github.event.action == 'review_requested'");
+    expect(cond).toContain(
+      `github.event.requested_reviewer.login == '${botLogin}'`,
+    );
+  });
+});


### PR DESCRIPTION
## What this PR does

Mirrors the `requested_reviewer` predicate that `precheck-pr` already applies to fork PRs into the job-level `if`s of `authorize` and `review-config` in `qwen-code-pr-review.yml`: a `review_requested` event now only spends those jobs when the bot itself is the requested reviewer. Human-requested sibling runs complete as instant all-skipped runs — no permission-API call, no runner slot — exactly option (2) from the issue discussion. The bot login literal stays sourced from `review-config`'s `bot_login` constant in the new pin test.

## Why it's needed

Opening a same-repo PR that touches CODEOWNERS-covered paths auto-requests every owner individually, so one PR open emits one `review_requested` run per owner — five within the same second on #8830, reproduced again on #9142's open (five human review_requested events at 08:12:39-40Z). `precheck-pr`'s identical predicate only fires for fork PRs, so on same-repo PRs each sibling run currently spends a `review-config` runner plus an `authorize` job (which loads CI_BOT_PAT and calls the collaborator-permission API) before `review-pr` no-op exits on its own `requested_reviewer == bot_login` check.

## Reviewer Test Plan

### How to verify

Behavior matrix (unchanged outcomes, less compute):

- same-repo `review_requested`, bot requested → `authorize` runs its permission check and `review-pr` proceeds as today.
- same-repo `review_requested`, human/team requested → `authorize` and `review-config` skip; `review-pr` skips because `needs.authorize.outputs.should_review` is empty (it skipped before too, just later).
- fork PR `review_requested` → `precheck-pr` keeps its existing predicate; `authorize`'s new clause passes for bot requests and adds a second skip reason for human requests (already skipped via the missing `allow_triage` decision).
- `opened`/`synchronize`/`reopened`/`ready_for_review`, comment and review commands, `workflow_dispatch` → the new clause is vacuously true (`action != 'review_requested'` or `event_name != 'pull_request_target'`); no routing change.

New pins in `scripts/tests/qwen-pr-review-workflow.test.js` (red before, green after): the `authorize` disjunction is present verbatim, `review-config` is gated on the bot login, and the literal is extracted from the `bot_login` step rather than paraphrased.

```bash
npm run test:scripts   # 54 files pass locally (see Risk & Scope for one env note)
```

### Evidence (Before & After)

Before: #8830's open produced six runs with five cancellations (issue body); #9142's timeline shows five same-second human review_requested events whose sibling runs each spent `authorize`. After: the same burst evaluates to all-skipped sibling runs; observable on the next same-repo bot PR open post-merge.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Workflow YAML pins via vitest (`scripts/tests`). actionlint runs in CI; the binary was not reachable from this machine while preparing the PR.

## Risk & Scope

- Main risk or tradeoff: the skipped siblings remain visible in the run list (runs are created per event by design — the issue's option 3 confirmed that lever is unreachable from the workflow side). The burst stops consuming compute but not list space.
- Not validated / out of scope: the push-time burst on #8830 (`1df9c5d` era) — CODEOWNERS requests don't re-fire on push, so that one needs re-observation on a future bot push, per the issue thread. Dismissing CODEOWNERS auto-requests at creation time (the CODEOWNERS-side lever) is deliberately not touched.
- Breaking changes / migration notes: none — every reachable path keeps its current outcome; only previously-wasted jobs move from "ran then no-op exited" to "skipped".
- Local note: `install-script.test.js` fails in a fresh worktree until `packages/audio-capture` is built (pre-existing on main, verified via stash baseline); passes here after `npm run build -w packages/audio-capture`.

## Linked Issues

Fixes #8945