### PR TITLE
fix(ci): keep no-op review requests out of the PR review concurrency group

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -50,21 +50,23 @@ on:
 
 concurrency:
   # PR lifecycle events share a PR-scoped group so new pushes restart the delay
-  # and closed PRs stop any in-flight lifecycle review. A bot-directed
-  # review_requested joins that group too: it is an explicit review ask and
-  # must coalesce with the lifecycle run for the same head. Any OTHER
-  # review_requested (a human or team reviewer) gets a per-run group: it no-ops
-  # at review-pr by design, but as a member of the shared group it can
-  # supersede a lifecycle run that sits PENDING behind a still-terminating
-  # review — a pending run is replaced by any newer run in the group,
-  # cancel-in-progress notwithstanding. That race lost the automatic review
-  # entirely on PR #9091: a push plus three human review requests in the same
-  # minute cancelled the in-flight review and left only the no-op request run.
-  # Comment/review events use per-run groups to avoid cancelling active reviews.
+  # and closed PRs stop any in-flight lifecycle review. Every review_requested
+  # run — the bot-directed one included — gets a per-run group: membership is
+  # decided here, before `authorize` runs, but whether a bot request reviews
+  # anything is `authorize`'s call on the REQUESTER's write permission. A
+  # requester without write produces a guaranteed all-skipped run, and as a
+  # shared-group member that no-op can supersede a lifecycle run sitting
+  # PENDING behind a still-terminating review — a pending run is replaced by
+  # any newer run in the group, cancel-in-progress notwithstanding. That is
+  # the exact race that lost the automatic review on PR #9091, left open for
+  # anyone who can request the bot without write permission. The per-run group
+  # costs only an occasional duplicate review when an authorized bot request
+  # lands while the lifecycle run for the same head still queues: compute,
+  # never a lost review. Comment/review events use per-run groups to avoid
+  # cancelling active reviews.
   group: >-
     ${{ github.event_name == 'pull_request_target' &&
-    (github.event.action != 'review_requested' ||
-    github.event.requested_reviewer.login == 'qwen-code-ci-bot') &&
+    github.event.action != 'review_requested' &&
     format('qwen-pr-review-pr-{0}', github.event.pull_request.number) ||
     format('qwen-pr-review-run-{0}', github.run_id) }}
   cancel-in-progress: "${{ github.event_name == 'pull_request_target' && (github.event.action == 'synchronize' || github.event.action == 'closed') }}"

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -50,10 +50,21 @@ on:
 
 concurrency:
   # PR lifecycle events share a PR-scoped group so new pushes restart the delay
-  # and closed PRs stop any in-flight lifecycle review.
+  # and closed PRs stop any in-flight lifecycle review. A bot-directed
+  # review_requested joins that group too: it is an explicit review ask and
+  # must coalesce with the lifecycle run for the same head. Any OTHER
+  # review_requested (a human or team reviewer) gets a per-run group: it no-ops
+  # at review-pr by design, but as a member of the shared group it can
+  # supersede a lifecycle run that sits PENDING behind a still-terminating
+  # review — a pending run is replaced by any newer run in the group,
+  # cancel-in-progress notwithstanding. That race lost the automatic review
+  # entirely on PR #9091: a push plus three human review requests in the same
+  # minute cancelled the in-flight review and left only the no-op request run.
   # Comment/review events use per-run groups to avoid cancelling active reviews.
   group: >-
     ${{ github.event_name == 'pull_request_target' &&
+    (github.event.action != 'review_requested' ||
+    github.event.requested_reviewer.login == 'qwen-code-ci-bot') &&
     format('qwen-pr-review-pr-{0}', github.event.pull_request.number) ||
     format('qwen-pr-review-run-{0}', github.run_id) }}
   cancel-in-progress: "${{ github.event_name == 'pull_request_target' && (github.event.action == 'synchronize' || github.event.action == 'closed') }}"

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2517,3 +2517,48 @@ describe('bot comment markers', () => {
     expect(ackLine).toContain('"$RUN_URL"');
   });
 });
+
+describe('qwen pr review concurrency routing', () => {
+  // A PENDING run in a concurrency group is replaced by any newer run of the
+  // same group — cancel-in-progress does not protect it. On PR #9091 a push
+  // and three human review requests landed in the same minute: the
+  // synchronize run cancelled the in-flight review but queued behind it while
+  // it terminated, and the review_requested runs — guaranteed no-ops, since
+  // review-pr only runs when the bot itself is the requested reviewer —
+  // superseded it while pending. The sole survivor skipped review-pr, so the
+  // push was never reviewed. The fix routes non-bot review_requested runs to
+  // a per-run group where they can supersede nothing, while lifecycle events
+  // and bot-directed requests keep sharing the PR group so an explicit bot
+  // ask still coalesces with the automatic run for the same head.
+  const group = parse(workflow).concurrency.group;
+
+  it('keeps no-op review requests out of the shared PR group', () => {
+    // Verbatim, like the cancel-in-progress pin in the resolve suite: the
+    // shape IS the fix — `&&` binds tighter than `||`, so exactly the
+    // lifecycle actions and the bot-directed request reach the PR group, and
+    // every other review_requested (human or team reviewer) falls through to
+    // the per-run group. Moving the gate behind the fallback, or dropping the
+    // parentheses around the disjunction, silently re-ships the race.
+    expect(group).toBe(
+      "${{ github.event_name == 'pull_request_target' && " +
+        "(github.event.action != 'review_requested' || " +
+        "github.event.requested_reviewer.login == 'qwen-code-ci-bot') && " +
+        "format('qwen-pr-review-pr-{0}', github.event.pull_request.number) || " +
+        "format('qwen-pr-review-run-{0}', github.run_id) }}",
+    );
+  });
+
+  it('gates on the same bot login the workflow publishes', () => {
+    // The group expression cannot read review-config's bot_login output, so
+    // it carries the literal; pin it against the constant it mirrors so a
+    // rename of the bot cannot desync the two.
+    const botLogin = parse(workflow)
+      .jobs['review-config'].steps.find(
+        (s) => s.name === 'Set review constants',
+      )
+      .run.match(/bot_login=([a-zA-Z0-9-]+)/)[1];
+    expect(group).toContain(
+      `github.event.requested_reviewer.login == '${botLogin}'`,
+    );
+  });
+});

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2551,13 +2551,16 @@ describe('qwen pr review concurrency routing', () => {
   it('gates on the same bot login the workflow publishes', () => {
     // The group expression cannot read review-config's bot_login output, so
     // it carries the literal; pin it against the constant it mirrors so a
-    // rename of the bot cannot desync the two.
+    // rename of the bot cannot desync all three sites.
     const botLogin = parse(workflow)
       .jobs['review-config'].steps.find(
         (s) => s.name === 'Set review constants',
       )
       .run.match(/bot_login=([a-zA-Z0-9-]+)/)[1];
     expect(group).toContain(
+      `github.event.requested_reviewer.login == '${botLogin}'`,
+    );
+    expect(parse(workflow).jobs['precheck-pr'].if).toContain(
       `github.event.requested_reviewer.login == '${botLogin}'`,
     );
   });

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -31,6 +31,13 @@ const workflowFiles = readdirSync(workflowsDir).filter((f) =>
   /\.ya?ml$/.test(f),
 );
 
+// Single shared recipe for the review-config bot login; every suite that pins
+// it reads this constant so the extraction cannot drift between call sites.
+const botLogin =
+  parse(workflow)
+    .jobs['review-config'].steps.find((s) => s.name === 'Set review constants')
+    ?.run.match(/bot_login=([A-Za-z0-9-]+)/)?.[1] ?? '';
+
 function runReviewStep() {
   const doc = parse(workflow);
   const step = doc.jobs['review-pr'].steps.find((s) => s.name === 'Run review');
@@ -2552,11 +2559,6 @@ describe('qwen pr review concurrency routing', () => {
     // The group expression cannot read review-config's bot_login output, so
     // it carries the literal; pin it against the constant it mirrors so a
     // rename of the bot cannot desync all three sites.
-    const botLogin = parse(workflow)
-      .jobs['review-config'].steps.find(
-        (s) => s.name === 'Set review constants',
-      )
-      .run.match(/bot_login=([a-zA-Z0-9-]+)/)[1];
     expect(group).toContain(
       `github.event.requested_reviewer.login == '${botLogin}'`,
     );
@@ -2575,11 +2577,6 @@ describe('review_requested burst coalescing (#8945)', () => {
   // before no-op exiting. `authorize` and `review-config` must filter those
   // siblings at the job level so they complete as instant all-skipped runs.
   const doc = parse(workflow);
-
-  const botLoginMatch = doc.jobs['review-config'].steps[0].run.match(
-    /bot_login=([A-Za-z0-9-]+)/,
-  );
-  const botLogin = botLoginMatch ? botLoginMatch[1] : '';
 
   const botRequestedClause = new RegExp(
     [

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2530,38 +2530,39 @@ describe('qwen pr review concurrency routing', () => {
   // same group — cancel-in-progress does not protect it. On PR #9091 a push
   // and three human review requests landed in the same minute: the
   // synchronize run cancelled the in-flight review but queued behind it while
-  // it terminated, and the review_requested runs — guaranteed no-ops, since
-  // review-pr only runs when the bot itself is the requested reviewer —
-  // superseded it while pending. The sole survivor skipped review-pr, so the
-  // push was never reviewed. The fix routes non-bot review_requested runs to
-  // a per-run group where they can supersede nothing, while lifecycle events
-  // and bot-directed requests keep sharing the PR group so an explicit bot
-  // ask still coalesces with the automatic run for the same head.
+  // it terminated, and the review_requested runs — no-ops, since review-pr
+  // only runs when the bot itself is the requested reviewer — superseded it
+  // while pending. The sole survivor skipped review-pr, so the push was never
+  // reviewed. Routing only the human-requested siblings to a per-run group
+  // leaves the race open: group membership is fixed here, before `authorize`
+  // runs, but whether a bot-directed request reviews anything is `authorize`'s
+  // call on the REQUESTER's write permission — a requester without write
+  // produces a guaranteed all-skipped run, and as a shared-group member that
+  // no-op can supersede the pending lifecycle run, losing the review the same
+  // way. Every review_requested run therefore gets a per-run group; an
+  // authorized bot request still reviews immediately, it just can no longer
+  // supersede the lifecycle run for the same head.
   const group = parse(workflow).concurrency.group;
 
-  it('keeps no-op review requests out of the shared PR group', () => {
+  it('keeps every review_requested run out of the shared PR group', () => {
     // Verbatim, like the cancel-in-progress pin in the resolve suite: the
     // shape IS the fix — `&&` binds tighter than `||`, so exactly the
-    // lifecycle actions and the bot-directed request reach the PR group, and
-    // every other review_requested (human or team reviewer) falls through to
-    // the per-run group. Moving the gate behind the fallback, or dropping the
-    // parentheses around the disjunction, silently re-ships the race.
+    // lifecycle actions reach the PR group and every review_requested (bot
+    // included) falls through to the per-run group. Any requested_reviewer
+    // clause here re-admits the unauthorized-requester no-op and silently
+    // re-ships the race.
     expect(group).toBe(
       "${{ github.event_name == 'pull_request_target' && " +
-        "(github.event.action != 'review_requested' || " +
-        "github.event.requested_reviewer.login == 'qwen-code-ci-bot') && " +
+        "github.event.action != 'review_requested' && " +
         "format('qwen-pr-review-pr-{0}', github.event.pull_request.number) || " +
         "format('qwen-pr-review-run-{0}', github.run_id) }}",
     );
   });
 
-  it('gates on the same bot login the workflow publishes', () => {
-    // The group expression cannot read review-config's bot_login output, so
-    // it carries the literal; pin it against the constant it mirrors so a
-    // rename of the bot cannot desync all three sites.
-    expect(group).toContain(
-      `github.event.requested_reviewer.login == '${botLogin}'`,
-    );
+  it('gates the review_requested jobs on the published bot login', () => {
+    // The group expression no longer names the requested reviewer; the
+    // job-level gates still must. Pin the surviving literal against the
+    // review-config constant so a bot rename cannot desync the sites.
     expect(parse(workflow).jobs['precheck-pr'].if).toContain(
       `github.event.requested_reviewer.login == '${botLogin}'`,
     );


### PR DESCRIPTION
## What this PR does

Changes the review workflow's concurrency routing so a `review_requested` event for a human or team reviewer no longer joins the shared PR-scoped group. Such runs get a per-run group instead, the same treatment the comment and review command events already have. Lifecycle events (opened, synchronize, reopened, ready_for_review, closed) and bot-directed review requests keep sharing the PR group, so a new push still restarts the delayed automatic review, closing a PR still stops an in-flight review, and an explicit request of the bot still coalesces with the automatic run for the same head. The routing carries a comment recording the incident that motivated it, and the change is pinned by a verbatim expression test plus a sync pin tying the gate's bot literal to the constant the workflow publishes.

## Why it's needed

A pending run in a concurrency group is replaced by any newer run of the same group — `cancel-in-progress` does not protect it. PR #9091 hit exactly that: a push and three human review requests landed within the same minute. The synchronize run cancelled the in-flight review of the previous head, then queued behind it while it terminated; the three `review_requested` runs — guaranteed no-ops, since the review job only runs when the bot itself is the requested reviewer — replaced the synchronize run while it was still pending. The sole survivor skipped the review job by design, the in-flight review round was cancelled, and the push was never reviewed at all. This is the #8945 burst family, but the cost there was bounded startup waste; here a real review silently evaporated, and the triggering flow — push the last fix, then request teammates' review — is an everyday one.

## Reviewer Test Plan

### How to verify

Run the workflow pin suites: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js` — the new describe block pins the group expression verbatim (the shape IS the fix: dropping the parentheses around the disjunction or moving the gate behind the fallback silently re-ships the race), and the resolve suite's existing concurrency pins (closed-cancellation, verbatim `cancel-in-progress`) stay green. The live concurrency semantics cannot be exercised pre-merge because `pull_request_target` evaluates the workflow from the base ref; post-merge, the check is that on a PR receiving a human "Request review" next to a push, the synchronize run survives the delay gate and reaches the review job, while the request runs complete as instant all-skipped runs in their own groups, and a bot-directed request burst still coalesces to one survivor exactly as today.

### Evidence (Before & After)

N/A — CI workflow change; the incident evidence is the run history on PR #9091 (synchronize run cancelled with zero jobs, no-op request run as sole survivor, in-flight review killed).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests via vitest against the parsed workflow; the pre-existing local failures in the autofix suites reproduce identically on the untouched base (macOS bash 3.2 lacks `mapfile`) and are unrelated.

## Risk & Scope

- Main risk or tradeoff: a bot-directed review request entering the shared group while a synchronize run sits pending can still supersede it; the review then happens via the explicit request instead of the delayed automatic path, so no review is lost. Human/team request runs are no longer cancelled by a `closed` event, but they complete within seconds as all-skipped runs, so there is nothing to stop.
- Not validated / out of scope: the live race itself (base-ref limitation above); the #8945 burst waste is unchanged, and the sibling PR that skips non-bot request jobs earlier complements this change rather than conflicting with it.
- Breaking changes / migration notes: none; routing of bot-directed requests, lifecycle events and command events is unchanged.

## Linked Issues

Related: #8945 (review_requested burst family; this closes its data-loss variant, not the startup-waste one).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修改评审 workflow 的并发路由：指向人类 reviewer 或团队的 `review_requested` 事件不再进入 PR 共享并发组，改用每 run 独立的组——与评论/review 命令事件已有的待遇一致。生命周期事件（opened、synchronize、reopened、ready_for_review、closed）与指向 bot 的 review 请求继续共享 PR 组，因此新 push 仍会重启延迟自动评审、关闭 PR 仍会中止在跑评审、显式请求 bot 仍会与同一 head 的自动评审合并。路由处附有记录事故动机的注释，改动本身由逐字表达式 pin 测试与一个把门控中的 bot 字面量同 workflow 发布常量绑定的同步 pin 保护。

## 为什么需要

并发组里 pending 状态的 run 会被同组任何更新的 run 顶掉——`cancel-in-progress` 保护不了它。PR #9091 恰好踩中：一次 push 与三个人类 review 请求落在同一分钟内。synchronize run 取消了上一 head 的在跑评审，随后在其退出组之前排队等待；三个 `review_requested` run——必然的空跑，因为评审 job 只在 bot 自己被请求时才运行——在 synchronize run 仍处 pending 时将其逐一顶掉。唯一幸存者按设计跳过评审 job，在跑的评审轮被取消，这次 push 完全没有被评审。这属于 #8945 burst 家族，但那里的代价有界（仅启动开销），这里却是一次真实评审无声蒸发，而触发流程——推最后一个修复、随即请队友 review——是日常操作。

## 审阅者验证方案

### 如何验证

运行 workflow pin 套件：`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js scripts/tests/qwen-resolve-workflow.test.js`——新增 describe 块逐字 pin 了组表达式（形状本身就是修复：丢掉析取式的括号或把门控挪到 fallback 之后都会无声地重现竞态），resolve 套件既有的并发 pin（closed 取消、逐字 `cancel-in-progress`）保持绿色。合并前无法实测真实并发语义，因为 `pull_request_target` 取 base 分支的 workflow 文件；合并后的检验标准是：某 PR 在 push 旁收到人类 "Request review" 时，synchronize run 能穿过延迟门进入评审 job，而请求 run 各自在自己的组里瞬间全 skip 完成；指向 bot 的请求 burst 仍与现状完全一致地合并为一个幸存者。

### 证据（前后对比）

N/A——CI workflow 变更；事故证据在 PR #9091 的 run 历史里（synchronize run 零 job 被取消、空跑请求 run 成为唯一幸存者、在跑评审被杀）。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

vitest 对解析后的 workflow 做单元测试；autofix 套件的本地预存失败在未改动的基线上同样复现（macOS bash 3.2 缺 `mapfile`），与本 PR 无关。

## 风险与范围

- 主要风险或取舍：当 synchronize run 处于 pending 时，指向 bot 的 review 请求进入共享组仍可能顶掉它；此时评审改由显式请求路径执行，不会丢评审。人类/团队请求 run 不再被 `closed` 事件取消，但它们秒级全 skip 完成，本就无需中止。
- 未验证 / 范围外：竞态本身无法合并前实测（base-ref 限制）；#8945 的启动浪费不变；跳过非 bot 请求 job 的姊妹 PR 与本改动互补而非冲突。
- 破坏性变更 / 迁移说明：无；bot 请求、生命周期事件与命令事件的路由均不变。

## 关联 Issue

相关：#8945（review_requested burst 家族；本 PR 关闭其丢评审变体，不解决启动浪费变体）。

</details>
