### PR TITLE
test(review): close confirmed pin gaps from #9194 (batch 1)

### DIFF
--- a/packages/cli/src/commands/review/comment-body.test.ts
+++ b/packages/cli/src/commands/review/comment-body.test.ts
@@ -170,6 +170,7 @@ describe('commentBodyCommand handler', () => {
         repo: 'QwenLM/qwen-code',
       });
       expect(stdoutSpy).toHaveBeenCalledWith('the body');
+      expect(setGhHostMock).toHaveBeenCalledWith(undefined);
       // And never the newline-appending line writer for the body.
       expect(writeStdoutLineMock).not.toHaveBeenCalledWith('the body');
       expect(process.exitCode).toBeUndefined();

--- a/packages/cli/src/commands/review/comment-body.test.ts
+++ b/packages/cli/src/commands/review/comment-body.test.ts
@@ -196,6 +196,10 @@ describe('commentBodyCommand handler', () => {
     // status`), so the ordering must hold against it too, not just the
     // data call.
     expect(hostOrder).toBeLessThan(Math.min(authOrder, ghOrder));
+    // The other half of the invariant (#9194): the data fetch must not
+    // precede authentication — a gh call that beats `gh auth status` races
+    // the very credential it depends on.
+    expect(authOrder).toBeLessThan(ghOrder);
   });
 
   it('exits 2 for --kind review without --pr', () => {
@@ -248,6 +252,32 @@ describe('commentBodyCommand handler', () => {
       kind: 'review',
       repo: 'QwenLM/qwen-code',
       pr: -3,
+    });
+    expect(process.exitCode).toBe(2);
+    expect(ghApiMock).not.toHaveBeenCalled();
+    expect(ensureAuthenticatedMock).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 on a fractional id or --pr — the isInteger half of the guard (#9194)', () => {
+    // The non-positive cases above exercise `<= 0`; the `Number.isInteger`
+    // half used to be untested, so a guard that only checked positivity
+    // would ship green and let `1.5` reach the gh call.
+    (commentBodyCommand.handler as (a: unknown) => void)({
+      _: [],
+      $0: 'qwen',
+      id: 1.5,
+      kind: 'inline',
+      repo: 'QwenLM/qwen-code',
+    });
+    expect(process.exitCode).toBe(2);
+    process.exitCode = undefined;
+    (commentBodyCommand.handler as (a: unknown) => void)({
+      _: [],
+      $0: 'qwen',
+      id: 5,
+      kind: 'review',
+      repo: 'QwenLM/qwen-code',
+      pr: 9073.25,
     });
     expect(process.exitCode).toBe(2);
     expect(ghApiMock).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/review/fetch-diff.test.ts
+++ b/packages/cli/src/commands/review/fetch-diff.test.ts
@@ -138,6 +138,7 @@ describe('fetchDiffCommand handler', () => {
       out: OUT,
     });
     expect(process.exitCode).toBeUndefined();
+    expect(setGhHostMock).toHaveBeenCalledWith(undefined);
     expect(writeStdoutLineMock).toHaveBeenCalledWith(
       JSON.stringify({
         diffPath: resolve(OUT),

--- a/packages/cli/src/commands/review/fetch-diff.test.ts
+++ b/packages/cli/src/commands/review/fetch-diff.test.ts
@@ -165,6 +165,10 @@ describe('fetchDiffCommand handler', () => {
     // status`), so the ordering must hold against it too, not just the
     // data call.
     expect(hostOrder).toBeLessThan(Math.min(authOrder, ghOrder));
+    // The other half of the invariant (#9194): the data fetch must not
+    // precede authentication — a gh call that beats `gh auth status` races
+    // the very credential it depends on.
+    expect(authOrder).toBeLessThan(ghOrder);
   });
 
   it('exits 1 when the fetch fails', () => {

--- a/packages/cli/src/commands/review/issue-context.test.ts
+++ b/packages/cli/src/commands/review/issue-context.test.ts
@@ -131,6 +131,11 @@ describe('runIssueContext', () => {
       dirname(resolve('/tmp/issue-context.md')),
       { recursive: true },
     );
+    // The write TARGET, not just the content: a redirected write that still
+    // reported the right body used to ship green (#9194).
+    expect(writeFileSyncMock.mock.calls[0][0]).toBe(
+      resolve('/tmp/issue-context.md'),
+    );
     expect(written).toContain('untrusted user input');
     expect(written).toContain('## Issue #9078 of QwenLM/qwen-code: the bug');
     expect(written).toContain('repro steps');
@@ -279,7 +284,12 @@ describe('runIssueContext', () => {
       'title,body,comments',
     );
     const written = writeFileSyncMock.mock.calls[0][1] as string;
-    expect(written).toContain('Additionally fetched issues');
+    // Pin the FULL header wording, not a prefix: the 'NOT in the closing
+    // set' clause is the claim a reader acts on, and only the negative
+    // (discovery-failed) case used to be asserted (#9194).
+    expect(written).toContain(
+      'Additionally fetched issues (referenced by the PR context, NOT in the closing set)',
+    );
     expect(written).toContain(
       '## Issue #555 of QwenLM/qwen-code: referenced only',
     );
@@ -492,6 +502,10 @@ describe('issueContextCommand handler', () => {
     // status`), so the ordering must hold against it too, not just the
     // data call.
     expect(hostOrder).toBeLessThan(Math.min(authOrder, ghOrder));
+    // The other half of the invariant (#9194): the data fetch must not
+    // precede authentication — a gh call that beats `gh auth status` races
+    // the very credential it depends on.
+    expect(authOrder).toBeLessThan(ghOrder);
   });
 
   it('exits 2 on a usage error (malformed --repo)', () => {
@@ -614,6 +628,22 @@ describe('issueContextCommand handler', () => {
       repo: 'QwenLM/qwen-code',
       out: '/tmp/ic.md',
       issue: [0],
+    });
+    expect(process.exitCode).toBe(2);
+    expect(ghMock).not.toHaveBeenCalled();
+    expect(ensureAuthenticatedMock).not.toHaveBeenCalled();
+  });
+
+  it('exits 2 on a fractional pr_number — the isInteger half of the guard (#9194)', () => {
+    // The non-positive cases above exercise `<= 0`; the `Number.isInteger`
+    // half used to be untested, so a guard that only checked positivity
+    // would ship green and let `1.5` reach the gh call.
+    (issueContextCommand.handler as (a: unknown) => void)({
+      _: [],
+      $0: 'qwen',
+      pr_number: 1.5,
+      repo: 'QwenLM/qwen-code',
+      out: '/tmp/ic.md',
     });
     expect(process.exitCode).toBe(2);
     expect(ghMock).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/review/issue-context.test.ts
+++ b/packages/cli/src/commands/review/issue-context.test.ts
@@ -537,6 +537,7 @@ describe('issueContextCommand handler', () => {
       out: '/tmp/ic.md',
     });
     expect(process.exitCode).toBeUndefined();
+    expect(setGhHostMock).toHaveBeenCalledWith(undefined);
     expect(writeStdoutLineMock).toHaveBeenCalledWith(
       expect.stringContaining('"discoveryError":"HTTP 500"'),
     );

--- a/packages/cli/src/commands/review/issue-context.test.ts
+++ b/packages/cli/src/commands/review/issue-context.test.ts
@@ -255,7 +255,9 @@ describe('runIssueContext', () => {
     mockIssue('five');
     runIssueContext({ ...ARGS, extraIssues: ex(555) });
     const written = writeFileSyncMock.mock.calls[0][1] as string;
-    expect(written).toContain('the closing set could not be checked');
+    expect(written).toContain(
+      'Additionally fetched issues (referenced by the PR context; the closing set could not be checked)',
+    );
     expect(written).not.toContain('NOT in the closing set');
   });
 

--- a/packages/cli/src/commands/review/meta.test.ts
+++ b/packages/cli/src/commands/review/meta.test.ts
@@ -272,6 +272,7 @@ describe('metaCommand handler', () => {
     // status`), so the ordering must hold against it too, not just the
     // data call.
     expect(hostOrder).toBeLessThan(Math.min(authOrder, ghOrder));
+    expect(authOrder).toBeLessThan(ghOrder);
   });
 
   it('prints the result as one JSON object', () => {

--- a/packages/cli/src/commands/review/meta.test.ts
+++ b/packages/cli/src/commands/review/meta.test.ts
@@ -109,8 +109,12 @@ describe('runMeta', () => {
     // The discovered host is applied as routing (the handler's flag/env
     // would win if set — neither is set here).
     expect(setGhHostMock).toHaveBeenLastCalledWith('ghe.example.com');
+    const authOrder = ensureAuthenticatedMock.mock.invocationCallOrder[0];
+    const repoViewOrder = ghMock.mock.invocationCallOrder[0];
     const hostOrder = setGhHostMock.mock.invocationCallOrder[0];
     const prViewOrder = ghMock.mock.invocationCallOrder[1];
+    expect(authOrder).toBeLessThan(repoViewOrder);
+    expect(authOrder).toBeLessThan(prViewOrder);
     expect(hostOrder).toBeLessThan(prViewOrder);
   });
 

--- a/packages/cli/src/commands/review/meta.test.ts
+++ b/packages/cli/src/commands/review/meta.test.ts
@@ -285,6 +285,7 @@ describe('metaCommand handler', () => {
     );
     (metaCommand.handler as (a: unknown) => void)({ _: [], $0: 'qwen' });
     expect(process.exitCode).toBeUndefined();
+    expect(setGhHostMock).toHaveBeenCalledWith(undefined);
     expect(writeStdoutLineMock).toHaveBeenCalledWith(
       '{"platform":"github","host":"github.com","ownerRepo":"QwenLM/qwen-code"}',
     );


### PR DESCRIPTION
## What this PR does

First batch of the #9194 pin-completeness checklist — the gaps confirmed still open on current main, closed test-side only (no production behavior changes):

1. **Ordering invariant, other half** — the `threads --host …` tests pinned `host < min(auth, gh)` but not `auth < gh`; a data fetch that beat `gh auth status` would have shipped green. Now pinned in issue-context, comment-body, and fetch-diff.
2. **Write-target path** — issue-context's write assertions read the written content (`calls[0][1]`) but never the target path; a redirected write reporting the right body shipped green. `calls[0][0]` is now asserted against the resolved `--out` path.
3. **'NOT in the closing set' header** — only the negative (discovery-failed) case was asserted; the success-path extras header wording is now pinned in full.
4. **`Number.isInteger` guard halves** — the non-positive cases were tested but not the integrality half: fractional `pr_number` (issue-context) and fractional `id`/`--pr` (comment-body) now exit 2 before any gh/auth call. Mutation-verified: stripping `Number.isInteger` from comment-body's guard turns the new test red; restoring it goes green.

Also audited and confirmed already covered (no change needed): fetch-diff's non-integer `pr_number` case, `setGhHost` whitespace-only/flag-shaped rejection in `lib/gh.test.ts`, comment-body's write path via `toHaveBeenCalledWith`, and pr-context's host-routing + omitted-host (`setGhHost(undefined)`) pins.

## Why it's needed

Each item is a test that under-pins its stated contract — a mutation in the production code ships the suite green (the reviewer mutation-verified the class on PR #9096 rounds 5–6). The gaps are non-blocking for behavior but defeat the purpose of the pins.

## Reviewer Test Plan

### How to verify

```bash
npx vitest run src/commands/review/issue-context.test.ts src/commands/review/comment-body.test.ts src/commands/review/fetch-diff.test.ts src/commands/review/meta.test.ts
```

Mutation check used for item 4 (then reverted): remove `Number.isInteger` from comment-body's usage guard — the fractional test fails; restore — green.

### Evidence (Before & After)

N/A — test-only change; the new assertions pass against current production behavior and fail when the pinned invariant is mutated (demonstrated for the guard half).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Unit tests only (mocked gh/fs boundary).

## Risk & Scope

- Main risk or tradeoff: none behavioral — tests only.
- Not validated / out of scope (remaining #9194 items for follow-up batches): rule-4 `not.toContain('gh issue view')` and 422 `headRefOid` negative assertions; stderr error-message pins; pr-context write-target/mkdir ordering pins; the remaining meta HOSTNAME_RE exit-1 classification + GH_HOST env attribution; all code-hygiene items; the round-9 additions.
- Breaking changes / migration notes: none.

## Linked Issues

Part of #9194



<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这是 #9194 pin 完整性清单的第一批：只补测试，不改生产行为。已补齐 host/auth/gh 调用顺序的另一半、issue-context 写入目标路径、extras header 的完整措辞、整数校验分支，以及本轮新增的 discovery 分支 auth-before-gh 与 failed-discovery header 完整措辞。

## 为什么需要

这些测试原本没有完整 pin 住自己声称保护的 contract；生产代码的某些 mutation 可以让套件保持绿色。补断言是为了让这些 pin 真正能防回归。

## Reviewer 测试计划

运行 review command 的聚焦单测，包括 issue-context、comment-body、fetch-diff 和 meta。部分 guard 分支做过 mutation check：移除对应校验会让新增测试变红，恢复后变绿。

## 风险与范围

无行为风险，test-only。剩余 #9194 项目留给后续批次；本 PR 不改生产逻辑、不引入 breaking change。

## 关联 Issue

Part of #9194

</details>
