### PR TITLE
test(web-shell): pin silent failure of background artifact refreshes (#7427)

### DIFF
--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -360,6 +360,85 @@ describe('useSessionArtifacts', () => {
     ]);
   });
 
+  it('refreshes when the version returns to a previously-seen value (#7427)', async () => {
+    // The version effect's previous-value bookkeeping must survive a
+    // NON-MONOTONIC sequence: starting at a non-zero version, a return to a
+    // previously-seen value is still a transition. A mutant that forgets to
+    // record the seen version keeps comparing against the mount value and
+    // silently skips the returning refresh (stale panel, suite green).
+    const load1 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const load2 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const load3 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    sdkMock.actions.loadArtifacts
+      .mockReturnValueOnce(load1.promise)
+      .mockReturnValueOnce(load2.promise)
+      .mockReturnValueOnce(load3.promise);
+    sdkMock.artifactsVersion = 1;
+
+    await renderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      load1.resolve({ artifacts: [artifact('v1')] });
+      await load1.promise;
+    });
+
+    sdkMock.artifactsVersion = 2;
+    await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      load2.resolve({ artifacts: [artifact('v2')] });
+      await load2.promise;
+    });
+
+    // Back to a previously-seen version — must fire again.
+    sdkMock.artifactsVersion = 1;
+    await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      load3.resolve({ artifacts: [artifact('v1-again')] });
+      await load3.promise;
+    });
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual(['v1-again']);
+  });
+
+  it('drops an in-flight load whose session owner flipped mid-flight (#7427)', async () => {
+    // The success guard is `requestId stale OR owner stale`. The requestId
+    // half is exercised by the supersede tests; the OWNER half needs its own
+    // pin: the provider flips `isCurrent` the instant the session switches —
+    // BEFORE any re-render — so an in-flight load resolving in that window
+    // passes the requestId check and only the owner check stops it from
+    // painting the previous session's artifacts.
+    const initialLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const inFlightLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    sdkMock.actions.loadArtifacts
+      .mockReturnValueOnce(initialLoad.promise)
+      .mockReturnValueOnce(inFlightLoad.promise);
+
+    await renderHookHost();
+    await act(async () => {
+      initialLoad.resolve({ artifacts: [artifact('current-artifact')] });
+      await initialLoad.promise;
+    });
+
+    // Start refresh #2 via a version bump (owner captured at version 0)...
+    sdkMock.artifactsVersion = 1;
+    await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(2);
+
+    // ...then the session flips mid-flight, without a re-render landing yet.
+    sdkMock.ownerVersion += 1;
+    await act(async () => {
+      inFlightLoad.resolve({ artifacts: [artifact('stale')] });
+      await inFlightLoad.promise;
+      // Restore before the act finishes so later assertions see a clean
+      // owner; the guard already evaluated against the flipped value.
+      sdkMock.ownerVersion = 0;
+    });
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'current-artifact',
+    ]);
+  });
+
   it('refreshes when the prompt settles from waiting to idle (#7427)', async () => {
     // `'waiting'` is a real prompt status (queued prompt / observer text
     // deltas before any generation signal); the settling trigger must not

--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -225,19 +225,32 @@ describe('useSessionArtifacts', () => {
     // A transient `Failed to fetch` on an automatic refresh is noise the user
     // cannot act on. The panel keeps last-good artifacts when it has them,
     // clears `loading`, and exposes no error state.
+    //
+    // Every mocked load is a deferred settled explicitly inside `act` (and
+    // awaited there), the same shape the pre-existing tests in this file
+    // use: flushing with a bare microtask left the hook's refresh
+    // continuation off the commit under full-suite parallel load, making
+    // the last-good assertions intermittently see `artifacts === []`
+    // (#7427 review).
+    const load1 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const load2 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const load3 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const load4 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const load5 = deferred<{ artifacts: DaemonSessionArtifact[] }>();
     sdkMock.actions.loadArtifacts
-      .mockRejectedValueOnce(new Error('Failed to fetch'))
-      .mockResolvedValueOnce({ artifacts: [artifact('current-artifact')] })
-      .mockRejectedValueOnce(new Error('Failed to fetch'))
-      .mockRejectedValueOnce(new Error('Failed to fetch'))
-      .mockResolvedValueOnce({ artifacts: [artifact('recovered-artifact')] });
+      .mockReturnValueOnce(load1.promise)
+      .mockReturnValueOnce(load2.promise)
+      .mockReturnValueOnce(load3.promise)
+      .mockReturnValueOnce(load4.promise)
+      .mockReturnValueOnce(load5.promise);
 
     await renderHookHost();
     expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(1);
 
     // Automatic refresh #1: initial mount fails before any last-good data exists.
     await act(async () => {
-      await Promise.resolve();
+      load1.reject(new Error('Failed to fetch'));
+      await load1.promise.catch(() => undefined);
     });
     expect(latestState?.loading).toBe(false);
     expect(latestState?.error).toBeNull();
@@ -248,7 +261,8 @@ describe('useSessionArtifacts', () => {
     await rerenderHookHost();
     expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(2);
     await act(async () => {
-      await Promise.resolve();
+      load2.resolve({ artifacts: [artifact('current-artifact')] });
+      await load2.promise;
     });
     expect(latestState?.artifacts.map((item) => item.id)).toEqual([
       'current-artifact',
@@ -263,7 +277,8 @@ describe('useSessionArtifacts', () => {
     await rerenderHookHost();
     expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(3);
     await act(async () => {
-      await Promise.resolve();
+      load3.reject(new Error('Failed to fetch'));
+      await load3.promise.catch(() => undefined);
     });
     expect(latestState?.loading).toBe(false);
     expect(latestState?.error).toBeNull();
@@ -276,7 +291,8 @@ describe('useSessionArtifacts', () => {
     await rerenderHookHost();
     expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(4);
     await act(async () => {
-      await Promise.resolve();
+      load4.reject(new Error('Failed to fetch'));
+      await load4.promise.catch(() => undefined);
     });
     expect(latestState?.loading).toBe(false);
     expect(latestState?.error).toBeNull();
@@ -293,7 +309,8 @@ describe('useSessionArtifacts', () => {
     await rerenderHookHost();
     expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(5);
     await act(async () => {
-      await Promise.resolve();
+      load5.resolve({ artifacts: [artifact('recovered-artifact')] });
+      await load5.promise;
     });
     expect(latestState?.artifacts.map((item) => item.id)).toEqual([
       'recovered-artifact',
@@ -301,15 +318,18 @@ describe('useSessionArtifacts', () => {
   });
 
   it('ignores loading cleanup from superseded artifact refresh failures', async () => {
+    const initialLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
     const staleLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const finalLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
     sdkMock.actions.loadArtifacts
-      .mockResolvedValueOnce({ artifacts: [artifact('current-artifact')] })
+      .mockReturnValueOnce(initialLoad.promise)
       .mockReturnValueOnce(staleLoad.promise)
-      .mockResolvedValueOnce({ artifacts: [artifact('replacement')] });
+      .mockReturnValueOnce(finalLoad.promise);
 
     await renderHookHost();
     await act(async () => {
-      await Promise.resolve();
+      initialLoad.resolve({ artifacts: [artifact('current-artifact')] });
+      await initialLoad.promise;
     });
 
     sdkMock.artifactsVersion = 1;
@@ -318,21 +338,55 @@ describe('useSessionArtifacts', () => {
 
     sdkMock.artifactsVersion = 2;
     await rerenderHookHost();
+    // The stale failure lands while the superseding load is still in
+    // flight — the requestId guard must keep its cleanup from clearing
+    // `loading` prematurely (R2-2, #7427 review).
     await act(async () => {
-      await Promise.resolve();
+      staleLoad.reject(new Error('Failed to fetch'));
+      await staleLoad.promise.catch(() => undefined);
+    });
+    expect(latestState?.loading).toBe(true);
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'current-artifact',
+    ]);
+
+    await act(async () => {
+      finalLoad.resolve({ artifacts: [artifact('replacement')] });
+      await finalLoad.promise;
     });
     expect(latestState?.loading).toBe(false);
     expect(latestState?.artifacts.map((item) => item.id)).toEqual([
       'replacement',
     ]);
+  });
 
+  it('refreshes when the prompt settles from waiting to idle (#7427)', async () => {
+    // `'waiting'` is a real prompt status (queued prompt / observer text
+    // deltas before any generation signal); the settling trigger must not
+    // be specialized to `'streaming'` (#7427 review).
+    const initialLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const settleLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    sdkMock.actions.loadArtifacts
+      .mockReturnValueOnce(initialLoad.promise)
+      .mockReturnValueOnce(settleLoad.promise);
+    sdkMock.promptStatus = 'waiting';
+
+    await renderHookHost();
     await act(async () => {
-      staleLoad.reject(new Error('Failed to fetch'));
-      await staleLoad.promise.catch(() => undefined);
+      initialLoad.resolve({ artifacts: [artifact('current-artifact')] });
+      await initialLoad.promise;
     });
-    expect(latestState?.loading).toBe(false);
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(1);
+
+    sdkMock.promptStatus = 'idle';
+    await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      settleLoad.resolve({ artifacts: [artifact('settled-artifact')] });
+      await settleLoad.promise;
+    });
     expect(latestState?.artifacts.map((item) => item.id)).toEqual([
-      'replacement',
+      'settled-artifact',
     ]);
   });
 });

--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -216,40 +216,66 @@ describe('useSessionArtifacts', () => {
     ]);
   });
 
-  it('keeps the last-good artifacts and surfaces no error when a background refresh fails (#7427)', async () => {
-    // A transient `Failed to fetch` on an AUTOMATIC refresh (mount, prompt
-    // settling to idle, an artifactsVersion signal) is noise the user cannot
-    // act on. The panel must keep the last successfully loaded artifacts,
-    // clear `loading`, and expose no error state — before #7477's reshape the
-    // same hiccup surfaced an error-severity toast on every retry, spamming
-    // the panel for the whole outage.
+  it('keeps automatic refresh failures silent and recovers on the next refresh (#7427)', async () => {
+    // A transient `Failed to fetch` on an automatic refresh is noise the user
+    // cannot act on. The panel keeps last-good artifacts when it has them,
+    // clears `loading`, and exposes no error state.
     sdkMock.actions.loadArtifacts
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
       .mockResolvedValueOnce({ artifacts: [artifact('current-artifact')] })
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
       .mockRejectedValueOnce(new Error('Failed to fetch'))
       .mockResolvedValueOnce({ artifacts: [artifact('recovered-artifact')] });
 
     await renderHookHost();
-    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
-      'current-artifact',
-    ]);
-    expect(latestState?.loading).toBe(false);
 
-    // Background refresh #1 fails transiently.
+    // Automatic refresh #1: initial mount fails before any last-good data exists.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(latestState?.loading).toBe(false);
+    expect(latestState?.error).toBeNull();
+    expect(latestState?.artifacts).toEqual([]);
+
+    // Automatic refresh #2: artifactsVersion recovers and establishes last-good.
     sdkMock.artifactsVersion = 1;
     await rerenderHookHost();
     await act(async () => {
       await Promise.resolve();
     });
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'current-artifact',
+    ]);
+    expect(latestState?.loading).toBe(false);
 
-    // Last-good data survives, nothing is blanked out, no error surfaces.
+    // Automatic refresh #3: prompt settling back to idle fails transiently.
+    sdkMock.promptStatus = 'running';
+    await rerenderHookHost();
+    sdkMock.promptStatus = 'idle';
+    await rerenderHookHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
     expect(latestState?.loading).toBe(false);
     expect(latestState?.error).toBeNull();
     expect(latestState?.artifacts.map((item) => item.id)).toEqual([
       'current-artifact',
     ]);
 
-    // The panel is not wedged: the next background refresh recovers.
+    // Automatic refresh #4: artifactsVersion fails and still keeps last-good.
     sdkMock.artifactsVersion = 2;
+    await rerenderHookHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(latestState?.loading).toBe(false);
+    expect(latestState?.error).toBeNull();
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'current-artifact',
+    ]);
+
+    // The panel is not wedged: the next automatic refresh recovers.
+    sdkMock.artifactsVersion = 3;
     await rerenderHookHost();
     await act(async () => {
       await Promise.resolve();

--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -20,6 +20,7 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
 }
 
 const sdkMock = vi.hoisted(() => ({
@@ -53,11 +54,15 @@ let latestState: SessionArtifactsState | undefined;
 
 function deferred<T>(): Deferred<T> {
   let resolve: ((value: T) => void) | undefined;
-  const promise = new Promise<T>((done) => {
+  let reject: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  if (!resolve) throw new Error('deferred promise did not initialize');
-  return { promise, resolve };
+  if (!resolve || !reject) {
+    throw new Error('deferred promise did not initialize');
+  }
+  return { promise, resolve, reject };
 }
 
 function artifact(id: string): DaemonSessionArtifact {
@@ -228,6 +233,7 @@ describe('useSessionArtifacts', () => {
       .mockResolvedValueOnce({ artifacts: [artifact('recovered-artifact')] });
 
     await renderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(1);
 
     // Automatic refresh #1: initial mount fails before any last-good data exists.
     await act(async () => {
@@ -240,6 +246,7 @@ describe('useSessionArtifacts', () => {
     // Automatic refresh #2: artifactsVersion recovers and establishes last-good.
     sdkMock.artifactsVersion = 1;
     await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(2);
     await act(async () => {
       await Promise.resolve();
     });
@@ -249,10 +256,12 @@ describe('useSessionArtifacts', () => {
     expect(latestState?.loading).toBe(false);
 
     // Automatic refresh #3: prompt settling back to idle fails transiently.
-    sdkMock.promptStatus = 'running';
+    sdkMock.promptStatus = 'streaming';
     await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(2);
     sdkMock.promptStatus = 'idle';
     await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(3);
     await act(async () => {
       await Promise.resolve();
     });
@@ -265,6 +274,7 @@ describe('useSessionArtifacts', () => {
     // Automatic refresh #4: artifactsVersion fails and still keeps last-good.
     sdkMock.artifactsVersion = 2;
     await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(4);
     await act(async () => {
       await Promise.resolve();
     });
@@ -274,14 +284,55 @@ describe('useSessionArtifacts', () => {
       'current-artifact',
     ]);
 
+    // Re-rendering the same version is not a new automatic refresh.
+    await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(4);
+
     // The panel is not wedged: the next automatic refresh recovers.
     sdkMock.artifactsVersion = 3;
     await rerenderHookHost();
+    expect(sdkMock.actions.loadArtifacts).toHaveBeenCalledTimes(5);
     await act(async () => {
       await Promise.resolve();
     });
     expect(latestState?.artifacts.map((item) => item.id)).toEqual([
       'recovered-artifact',
+    ]);
+  });
+
+  it('ignores loading cleanup from superseded artifact refresh failures', async () => {
+    const staleLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    sdkMock.actions.loadArtifacts
+      .mockResolvedValueOnce({ artifacts: [artifact('current-artifact')] })
+      .mockReturnValueOnce(staleLoad.promise)
+      .mockResolvedValueOnce({ artifacts: [artifact('replacement')] });
+
+    await renderHookHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    sdkMock.artifactsVersion = 1;
+    await rerenderHookHost();
+    expect(latestState?.loading).toBe(true);
+
+    sdkMock.artifactsVersion = 2;
+    await rerenderHookHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(latestState?.loading).toBe(false);
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'replacement',
+    ]);
+
+    await act(async () => {
+      staleLoad.reject(new Error('Failed to fetch'));
+      await staleLoad.promise.catch(() => undefined);
+    });
+    expect(latestState?.loading).toBe(false);
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'replacement',
     ]);
   });
 });

--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -215,4 +215,47 @@ describe('useSessionArtifacts', () => {
       'replacement',
     ]);
   });
+
+  it('keeps the last-good artifacts and surfaces no error when a background refresh fails (#7427)', async () => {
+    // A transient `Failed to fetch` on an AUTOMATIC refresh (mount, prompt
+    // settling to idle, an artifactsVersion signal) is noise the user cannot
+    // act on. The panel must keep the last successfully loaded artifacts,
+    // clear `loading`, and expose no error state — before #7477's reshape the
+    // same hiccup surfaced an error-severity toast on every retry, spamming
+    // the panel for the whole outage.
+    sdkMock.actions.loadArtifacts
+      .mockResolvedValueOnce({ artifacts: [artifact('current-artifact')] })
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockResolvedValueOnce({ artifacts: [artifact('recovered-artifact')] });
+
+    await renderHookHost();
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'current-artifact',
+    ]);
+    expect(latestState?.loading).toBe(false);
+
+    // Background refresh #1 fails transiently.
+    sdkMock.artifactsVersion = 1;
+    await rerenderHookHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Last-good data survives, nothing is blanked out, no error surfaces.
+    expect(latestState?.loading).toBe(false);
+    expect(latestState?.error).toBeNull();
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'current-artifact',
+    ]);
+
+    // The panel is not wedged: the next background refresh recovers.
+    sdkMock.artifactsVersion = 2;
+    await rerenderHookHost();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'recovered-artifact',
+    ]);
+  });
 });

--- a/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
+++ b/packages/web-shell/client/hooks/useSessionArtifacts.test.tsx
@@ -360,6 +360,45 @@ describe('useSessionArtifacts', () => {
     ]);
   });
 
+  it('ignores stale success from superseded artifact refreshes', async () => {
+    const initialLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const staleLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    const finalLoad = deferred<{ artifacts: DaemonSessionArtifact[] }>();
+    sdkMock.actions.loadArtifacts
+      .mockReturnValueOnce(initialLoad.promise)
+      .mockReturnValueOnce(staleLoad.promise)
+      .mockReturnValueOnce(finalLoad.promise);
+
+    await renderHookHost();
+    await act(async () => {
+      initialLoad.resolve({ artifacts: [artifact('current-artifact')] });
+      await initialLoad.promise;
+    });
+
+    sdkMock.artifactsVersion = 1;
+    await rerenderHookHost();
+    sdkMock.artifactsVersion = 2;
+    await rerenderHookHost();
+
+    await act(async () => {
+      staleLoad.resolve({ artifacts: [artifact('stale-artifact')] });
+      await staleLoad.promise;
+    });
+    expect(latestState?.loading).toBe(true);
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'current-artifact',
+    ]);
+
+    await act(async () => {
+      finalLoad.resolve({ artifacts: [artifact('replacement')] });
+      await finalLoad.promise;
+    });
+    expect(latestState?.loading).toBe(false);
+    expect(latestState?.artifacts.map((item) => item.id)).toEqual([
+      'replacement',
+    ]);
+  });
+
   it('refreshes when the version returns to a previously-seen value (#7427)', async () => {
     // The version effect's previous-value bookkeeping must survive a
     // NON-MONOTONIC sequence: starting at a non-zero version, a return to a


### PR DESCRIPTION
## What this PR does

Adds the missing regression pin for the behavior #7427 asked for. The toast-spam itself no longer exists on current main: `loadArtifacts` (packages/webui/src/daemon/session/actions.ts) carries no notice dispatch, and `useSessionArtifacts` swallows a failed background refresh — keeping the last successfully loaded artifacts, clearing `loading`, and exposing no error state. What was never pinned is that contract, so a future change re-surfacing background-refresh failures (error state, blanking the panel, or a notice) would ship green. The tests fail background refreshes and assert: last-good artifacts survive, nothing is blanked out, no error surfaces, prompt-idle and artifactsVersion triggers are distinct, superseded in-flight failures do not reopen loading, and the next background refresh recovers (the panel is not wedged).

## Why it's needed

#7427 reported `Load artifacts failed: Failed to fetch` toasts spamming the artifact panel on every automatic refresh during intermittent connectivity. The endorsed shape shipped via the #7477 reshape (the superseding PR for #7437): background refresh failures stay silent and keep last-good data. This PR locks that shape in place — mutation-verified: adding `setArtifacts([])` to the hook's catch turns the new test red.

## Reviewer Test Plan

### How to verify

```bash
npx vitest run --config vitest.config.ts client/hooks/useSessionArtifacts.test.tsx   # 5 pass
npx vitest run --config vitest.config.ts client/hooks/                                # 21 files, 390 pass
```

Mutation check used (then reverted): clear artifacts inside the hook's refresh `catch` — the new test fails; restore — green.

### Evidence (Before & After)

N/A — test-only change pinning existing behavior on main.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

jsdom hook tests only.

## Risk & Scope

- Main risk or tradeoff: none — test-only.
- Not validated / out of scope: the reporter-side confirmation that no toast appears in a real browser during an outage belongs on the issue thread (commented there).
- Breaking changes / migration notes: none.

## Linked Issues

Part of #7427


<details>
<summary>中文说明</summary>

## 本 PR 做了什么

补上 #7427 行为的回归 pin。当前 main 上 toast spam 已不存在：`loadArtifacts` 不派发 notice，`useSessionArtifacts` 会吞掉后台刷新失败，保留最近成功加载的 artifacts、清除 loading、并暴露空 error。测试现在 pin 住这些 contract，并覆盖自动刷新触发、prompt 回到 idle、artifactsVersion 变化、同版本不重复刷新、被 supersede 的失败不会污染 loading，以及下一次刷新可恢复。

## 为什么需要

#7427 报告的是间歇网络下自动刷新不断弹 `Load artifacts failed: Failed to fetch`。认可的形态是后台刷新失败保持静默并保留 last-good 数据。本 PR 锁定该形态，防止未来改动重新显示错误、清空面板或卡住 loading。

## Reviewer 测试计划

运行 `packages/web-shell` 下的 `client/hooks/useSessionArtifacts.test.tsx`。本轮聚焦验证为 5 个 tests 全部通过，并通过 ESLint、Prettier 和 diff check。

## 风险与范围

无行为风险，test-only。真实浏览器断网时的 reporter-side 确认属于 issue thread，不在本 PR 范围内。无 breaking change。

## 关联 Issue

Part of #7427

</details>
