### PR TITLE
fix(ci): minimize spam inline review comments

### DIFF
--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -70,3 +70,17 @@ describe('auto-minimize-spam: credential scoping', () => {
     );
   });
 });
+
+describe('auto-minimize-spam: comment coverage', () => {
+  it('scans inline PR review comments without re-minimizing them', () => {
+    assert.ok(minimizeStep, 'minimize step must exist');
+    assert.match(minimizeStep.run, /pulls\/comments/);
+    assert.match(minimizeStep.run, /--paginate/);
+    assert.match(minimizeStep.run, /ALL_CANDIDATES=.*REVIEW_CANDIDATES/);
+    assert.match(minimizeStep.run, /on Minimizable \{ isMinimized \}/);
+    assert.match(
+      minimizeStep.run,
+      /\[ "\$is_minimized" = "true" \] && continue/,
+    );
+  });
+});

--- a/.github/workflows/auto-minimize-spam.yml
+++ b/.github/workflows/auto-minimize-spam.yml
@@ -10,12 +10,11 @@ name: 'Auto-minimize spam comments'
 # line, case-insensitive, # for comments. No special API scopes
 # needed beyond issues:write + pull-requests:write.
 #
-# Note: the lookback window (LOOKBACK_HOURS) only filters issues —
-# the GraphQL pullRequests connection has no `since` filter, so PRs
-# are always scoped to the 100 most recently updated.
+# Note: the lookback window (LOOKBACK_HOURS) filters issues and inline
+# review comments. The GraphQL pullRequests connection has no `since`
+# filter, so PRs are always scoped to the 100 most recently updated.
 #
-# Coverage limits: only issue-style comments are scanned — PR review
-# (inline) comments, review bodies, and Discussions are not.
+# Coverage limits: review bodies and Discussions are not scanned.
 # comments(last: 30) means a >30-comment flood on a single thread is
 # only partially cleaned per run.
 
@@ -129,17 +128,40 @@ jobs:
             '
           )"
 
+          REVIEW_CANDIDATES="$(
+            gh api --method GET --paginate \
+              "repos/${REPO}/pulls/comments" \
+              -f since="$SINCE" \
+              -F per_page=100 \
+              --jq '
+                .[]
+                | select(.user != null and .node_id != null)
+                | "\(.user.login)\t\(.node_id)"
+              '
+          )"
+          ALL_CANDIDATES="${ALL_UNMINIMIZED}"$'\n'"${REVIEW_CANDIDATES}"
+
           MATCHED_IDS=""
           MATCHED_COUNT=0
           while IFS=$'\t' read -r login node_id; do
             [ -z "$login" ] && continue
             login_lc="$(printf '%s' "$login" | tr '[:upper:]' '[:lower:]')"
             if printf '%s\n' "$BLOCKED_USERS" | grep -qxF "$login_lc"; then
+              is_minimized="$(
+                gh api graphql -F id="$node_id" -f query="
+                  query(\$id: ID!) {
+                    node(id: \$id) {
+                      ... on Minimizable { isMinimized }
+                    }
+                  }
+                " --jq '.data.node.isMinimized'
+              )"
+              [ "$is_minimized" = "true" ] && continue
               MATCHED_IDS="${MATCHED_IDS}${node_id}"$'\n'
               MATCHED_COUNT=$((MATCHED_COUNT + 1))
               echo "  matched: @${login} → ${node_id}"
             fi
-          done <<< "$ALL_UNMINIMIZED"
+          done <<< "$ALL_CANDIDATES"
 
           echo "Unminimized comments from blocklisted users: ${MATCHED_COUNT}"
           if [ "$MATCHED_COUNT" -eq 0 ]; then


### PR DESCRIPTION
## What this PR does

Extends the existing hourly spam-minimization sweep to include inline pull request review comments. Recent inline comments are read through the repository-wide paginated API, matched against the existing blocklist, and sent through the same minimization mutation as conversation comments. Comments that are already minimized are skipped.

## Why it's needed

The current sweep only reads issue-style conversation comments, so a blocklisted user can still leave inline review comments that are never considered. This happened on #9202. Using the repository-wide review-comment listing avoids nested GraphQL limits while keeping the existing schedule, token, permissions, and reversible minimize behavior.

## Reviewer Test Plan

### How to verify

Confirm that a recent inline review comment from a blocklisted user appears in the paginated candidate scan, that an already-minimized comment is skipped, and that an unminimized comment reaches the existing minimization path. The focused workflow regression suite reports six passing tests; `actionlint` and Prettier both pass. A read-only live API probe found the example comment on #9202 and returned its review-comment node ID.

### Evidence (Before & After)

N/A — workflow-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22.22.0 and the live GitHub API in read-only mode.

## Risk & Scope

- Main risk or tradeoff: The sweep now paginates all inline review comments updated within the existing lookback window and performs one state lookup for each blocklisted candidate.
- Not validated / out of scope: Review bodies, Discussions, and immediate event-driven enforcement remain outside this workflow. No live minimization was triggered from the branch.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #8767 and the inline spam example on #9202.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

扩展现有的每小时垃圾评论折叠任务，使其同时覆盖 PR 行内 Review 评论。任务通过仓库级分页 API 读取最近的行内评论，沿用现有黑名单匹配和评论折叠 mutation，并跳过已经折叠的评论。

## 为什么需要

当前扫描只读取 Issue 风格的普通对话评论，因此黑名单用户仍可留下永远不会被任务处理的行内 Review 评论，#9202 已出现该情况。仓库级 Review 评论列表避免了嵌套 GraphQL 的数量限制，同时保持原有调度、token、权限和可恢复的折叠行为不变。

## 复核测试计划

### 如何验证

确认分页候选扫描能够发现黑名单用户最近发布的行内 Review 评论，已经折叠的评论会被跳过，未折叠的评论会进入现有折叠路径。聚焦 workflow 回归套件 6 项全部通过，`actionlint` 和 Prettier 均通过。只读线上 API 探针成功发现 #9202 中的示例评论并返回其 Review 评论节点 ID。

### 证据（前后对比）

N/A —— 仅修改 workflow。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Node.js 22.22.0，并以只读方式访问线上 GitHub API。

## 风险与范围

- 主要风险 / 取舍：扫描会分页读取现有回看窗口内更新的全部行内 Review 评论，并为每个命中黑名单的候选项查询一次折叠状态。
- 未验证 / 范围之外：Review 正文、Discussions 和即时事件驱动处理仍不在本 workflow 范围内；当前分支未触发线上折叠操作。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8767 以及 #9202 中的行内垃圾评论示例。

</details>
