### PR TITLE
fix(cli): honor enableCacheSharing schema default for suggestion queries

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -33405,6 +33405,49 @@ describe('Session', () => {
       });
     });
 
+    it('forwards enableCacheSharing as enabled when unset (schema default)', async () => {
+      // Regression for #9230: the schema declares `default: true`, but
+      // mergeSettings doesn't apply schema defaults — an unset value must be
+      // forwarded as enabled so the cache-aware forked path actually runs.
+      (mockSettings as unknown as { merged: { ui: unknown } }).merged.ui = {};
+      generateMock.mockResolvedValue({ suggestion: 'Run the tests next?' });
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'hello' }],
+      });
+
+      await vi.waitFor(() => {
+        expect(generateMock).toHaveBeenCalledWith(
+          mockConfig,
+          expect.any(Array),
+          expect.any(AbortSignal),
+          expect.objectContaining({ enableCacheSharing: true }),
+        );
+      });
+    });
+
+    it('forwards enableCacheSharing as disabled only on explicit false', async () => {
+      (mockSettings as unknown as { merged: { ui: unknown } }).merged.ui = {
+        enableCacheSharing: false,
+      };
+      generateMock.mockResolvedValue({ suggestion: 'Run the tests next?' });
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'hello' }],
+      });
+
+      await vi.waitFor(() => {
+        expect(generateMock).toHaveBeenCalledWith(
+          mockConfig,
+          expect.any(Array),
+          expect.any(AbortSignal),
+          expect.objectContaining({ enableCacheSharing: false }),
+        );
+      });
+    });
+
     it('does not emit in PLAN approval mode', async () => {
       mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
       generateMock.mockResolvedValue({ suggestion: 'something' });

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -3945,8 +3945,11 @@ export class Session implements SessionContext {
           conversationHistory,
           ac.signal,
           {
+            // Schema default is `true`, but `mergeSettings` doesn't apply
+            // schema defaults — treat unset as enabled; only an explicit
+            // `false` opts out.
             enableCacheSharing:
-              this.settings.merged.ui?.enableCacheSharing === true,
+              this.settings.merged.ui?.enableCacheSharing !== false,
           },
         );
         if (ac.signal.aborted) return;

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3153,7 +3153,10 @@ export const AppContainer = (props: AppContainerProps) => {
       // causes transient heap peaks that trigger OOM (#4624).
       const conversationHistory = geminiClient.getHistoryTail(40, true);
       generatePromptSuggestion(config, conversationHistory, ac.signal, {
-        enableCacheSharing: settings.merged.ui?.enableCacheSharing === true,
+        // Schema default is `true`, but `mergeSettings` doesn't apply schema
+        // defaults — treat unset as enabled; only an explicit `false` opts
+        // out (same convention as `followupSuggestionsEnabled` above).
+        enableCacheSharing: settings.merged.ui?.enableCacheSharing !== false,
       })
         .then((result) => {
           if (ac.signal.aborted) return;


### PR DESCRIPTION
## What

Fix the runtime gates for `ui.enableCacheSharing` in its two consumers — the interactive CLI (`AppContainer.tsx`) and the ACP session path (`Session.ts`): `=== true` → `!== false`. Adds regression tests for the ACP path.

## Why

The schema declares `default: true` for `enableCacheSharing` (mirrored by the VS Code settings schema and `docs/users/features/followup-suggestions.md`), but `mergeSettings` does not apply schema defaults and both runtime gates used `=== true` — so the cache-aware forked suggestion path never ran unless the user explicitly set the flag. Every follow-up-suggestion query fell back to the base-LLM path, which carries no system instruction and no tools.

That fallback request differs from the main conversation starting at token 0. On prefix-caching servers (e.g. llama.cpp) it interleaves with the main session on the same endpoint and evicts the main session's cached prefix between turns, forcing every main turn to re-prefill the full context. #9200 shows this on a single llama.cpp instance: qwen-code is always scheduled `by LRU` (prefix similarity < 0.10) while two other clients reuse 90–98% of their prefix.

With cache sharing enabled, the forked query shares the main conversation's system instruction (and tools, when the query runs on the same model — i.e. no fast model configured), so it extends the same prefix instead of starting a different one.

This also matches the adjacent `enableFollowupSuggestions` gate, which already uses `!== false` for exactly this reason (see the comment above it).

## Reviewer Test Plan

1. `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts -t 'follow-up suggestion'` — 9 tests pass, including the two new ones (unset → forwarded `true`; explicit `false` → forwarded `false`).
2. Full file: `npx vitest run src/acp-integration/session/Session.test.ts` — 625 pass.
3. `npx tsc --noEmit` in `packages/cli` — clean.

## Risk & Scope

Two one-line behavior changes plus comments and tests; only suggestion generation is affected. Explicit `"ui": { "enableCacheSharing": false }` is still respected. The forked path already existed behind the flag, so this enables existing code by default rather than adding new logic.

## Linked Issues

Ref #9230 (fixes the default-value bug; the broader side-query prefix discussion continues there). Evidence: #9200.

<details>
<summary>中文说明</summary>

修复 `ui.enableCacheSharing` 的两个运行时消费点（交互式 CLI 与 ACP session 路径）：`=== true` → `!== false`，并补充 ACP 路径回归测试。schema 声明 `default: true`（VS Code settings schema 与用户文档同样如此），但 `mergeSettings` 不应用 schema 默认值，两处门控又都用 `=== true`，导致 cache-aware 分叉建议路径除非显式配置否则从不运行，每个建议查询都回落到不带 system instruction、不带 tools 的 base-LLM 路径。该回落请求从第 0 位 token 起就与主会话不同，在 llama.cpp 等前缀缓存服务端上会挤掉主会话的缓存前缀，迫使每轮全量重新 prefill（#9200 在同一实例上观察到 qwen-code 始终 LRU 调度、其他客户端复用 90–98%）。生效后分叉查询共享主会话的 system instruction（未配 fast model 时也共享 tools），扩展同一前缀而非开启不同前缀。风险与范围：两处单行改动 + 注释 + 测试，仅影响建议生成；显式 false 仍受尊重；分叉路径为既有代码默认启用，非新逻辑。

</details>
