### PR TITLE
fix(cli): honour the declared enableCacheSharing default in both suggestion gates

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -33338,6 +33338,7 @@ describe('Session', () => {
 
     it('fires prompt-suggestion extNotification after end_turn when enabled', async () => {
       generateMock.mockResolvedValue({ suggestion: 'Run the tests next?' });
+      vi.mocked(mockChat.getHistoryTail).mockClear();
 
       await session.prompt({
         sessionId: 'test-session-id',
@@ -33355,6 +33356,12 @@ describe('Session', () => {
           },
         );
       });
+
+      // Pin the curated-history tail: a revert to `chat.getHistory(true)`
+      // (full structuredClone per end_turn, the #4624 heap-peak shape) or a
+      // dropped curated argument (`getHistoryTail(40)` defaults
+      // curated=false) must not pass silently (#9233).
+      expect(vi.mocked(mockChat.getHistoryTail)).toHaveBeenCalledWith(40, true);
 
       // The generator received an AbortSignal so the daemon can cancel
       // mid-flight if the next prompt arrives first. `merged.ui` above leaves

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -33357,12 +33357,37 @@ describe('Session', () => {
       });
 
       // The generator received an AbortSignal so the daemon can cancel
-      // mid-flight if the next prompt arrives first.
+      // mid-flight if the next prompt arrives first. `merged.ui` above leaves
+      // `enableCacheSharing` UNSET, so the gate must honour the schema's
+      // declared `default: true` — `mergeSettings` never applies schema
+      // defaults, and gating on `=== true` turned the cache-aware fork into
+      // dead code unless the user explicitly set the flag (#9230).
       expect(generateMock).toHaveBeenCalledWith(
         mockConfig,
         expect.any(Array),
         expect.any(AbortSignal),
-        expect.objectContaining({ enableCacheSharing: expect.any(Boolean) }),
+        expect.objectContaining({ enableCacheSharing: true }),
+      );
+    });
+
+    it('forwards an explicit enableCacheSharing=false opt-out', async () => {
+      (mockSettings as unknown as { merged: { ui: unknown } }).merged.ui = {
+        enableFollowupSuggestions: true,
+        enableCacheSharing: false,
+      };
+      generateMock.mockResolvedValue({ suggestion: null });
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'hello' }],
+      });
+
+      await vi.waitFor(() => expect(generateMock).toHaveBeenCalled());
+      expect(generateMock).toHaveBeenCalledWith(
+        mockConfig,
+        expect.any(Array),
+        expect.any(AbortSignal),
+        expect.objectContaining({ enableCacheSharing: false }),
       );
     });
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -3929,16 +3929,14 @@ export class Session implements SessionContext {
 
     void (async () => {
       try {
-        const fullHistory = chat.getHistory(true);
-        const lastEntry = fullHistory[fullHistory.length - 1];
+        const conversationHistory = chat.getHistoryTail(40, true);
+        const lastEntry = conversationHistory[conversationHistory.length - 1];
         if (!lastEntry || lastEntry.role !== 'model') {
           debugLogger.debug(
             'Skipping followup suggestion: last history entry is not model',
           );
           return;
         }
-        const conversationHistory =
-          fullHistory.length > 40 ? fullHistory.slice(-40) : fullHistory;
 
         const r = await generatePromptSuggestion(
           this.config,

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -3889,7 +3889,7 @@ export class Session implements SessionContext {
    * `qwen/notify/session/prompt-suggestion` extNotification. Mirrors
    * the CLI's `AppContainer.tsx` integration: same `generatePromptSuggestion`
    * call, same `enableCacheSharing` flag forwarding, same curated
-   * history slice (`getHistory(true).slice(-40)`).
+   * history tail (`getHistoryTail(40, true)`).
    *
    * Differences from the CLI:
    *   - Triggers only on `stopReason === 'end_turn'` (the daemon

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -3945,8 +3945,13 @@ export class Session implements SessionContext {
           conversationHistory,
           ac.signal,
           {
+            // On by default: the schema declares `default: true`, but
+            // `mergeSettings` doesn't apply schema defaults, so an unset value
+            // is `undefined` and a `=== true` gate left the cache-aware fork
+            // as dead code unless the flag was explicitly set (#9230). Mirrors
+            // AppContainer — only an explicit `false` opts out.
             enableCacheSharing:
-              this.settings.merged.ui?.enableCacheSharing === true,
+              this.settings.merged.ui?.enableCacheSharing !== false,
           },
         );
         if (ac.signal.aborted) return;

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3153,7 +3153,13 @@ export const AppContainer = (props: AppContainerProps) => {
       // causes transient heap peaks that trigger OOM (#4624).
       const conversationHistory = geminiClient.getHistoryTail(40, true);
       generatePromptSuggestion(config, conversationHistory, ac.signal, {
-        enableCacheSharing: settings.merged.ui?.enableCacheSharing === true,
+        // On by default: the schema declares `default: true`, but
+        // `mergeSettings` doesn't apply schema defaults, so an unset value is
+        // `undefined` and a `=== true` gate left the cache-aware fork as dead
+        // code unless the flag was explicitly set (#9230). Same treatment as
+        // `enableFollowupSuggestions` above — only an explicit `false` opts
+        // out.
+        enableCacheSharing: settings.merged.ui?.enableCacheSharing !== false,
       })
         .then((result) => {
           if (ac.signal.aborted) return;

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4809,6 +4809,7 @@ describe('Gemini Client (client.ts)', () => {
       const history = JSON.stringify(getCacheSafeParams()?.history);
       expect(history).not.toContain('image-bytes');
       expect(history).toContain('pdf-bytes');
+      expect(getCacheSafeParams()?.sessionId).toBe('test-session-id');
     });
 
     it.each([

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -3871,6 +3871,7 @@ export class GeminiClient {
             chat.getGenerationConfig(),
             cachedHistory,
             this.config.getModel(),
+            this.config.getSessionId(),
           );
         } catch {
           // Best-effort — don't block the main flow

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -184,6 +184,38 @@ describe('generatePromptSuggestion', () => {
     expect(result.suggestion).toBe('from base llm');
   });
 
+  it('does not use the cache-safe fork when cache sharing is disabled', async () => {
+    mockGetCacheSafeParams.mockReturnValue({
+      generationConfig: {},
+      history: conversationHistory,
+      model: 'main-model',
+      version: 1,
+      sessionId: 'test-session',
+    });
+    mockRunSideQuery.mockResolvedValue({
+      text: '{"suggestion":"from base llm"}',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+    const config = {
+      getFastModel: vi.fn(() => undefined),
+      getModel: vi.fn(() => 'main-model'),
+      getSessionId: vi.fn(() => 'test-session'),
+    } as unknown as Config;
+
+    const result = await generatePromptSuggestion(
+      config,
+      conversationHistory,
+      new AbortController().signal,
+      { enableCacheSharing: false },
+    );
+
+    expect(mockGetCacheSafeParamsSessionId).not.toHaveBeenCalled();
+    expect(mockGetCacheSafeParams).not.toHaveBeenCalled();
+    expect(mockRunForkedAgent).not.toHaveBeenCalled();
+    expect(mockRunSideQuery).toHaveBeenCalled();
+    expect(result.suggestion).toBe('from base llm');
+  });
+
   it('passes preserveTools: false when fast model differs from cache-safe model', async () => {
     mockGetCacheSafeParams.mockReturnValue({
       generationConfig: {},

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -59,15 +59,13 @@ describe('generatePromptSuggestion', () => {
       getModel: vi.fn(() => 'main-model'),
     } as unknown as Config;
 
-    await generatePromptSuggestion(
-      config,
-      conversationHistory,
-      new AbortController().signal,
-      { enableCacheSharing: true },
-    );
+    const signal = new AbortController().signal;
+    await generatePromptSuggestion(config, conversationHistory, signal, {
+      enableCacheSharing: true,
+    });
 
     expect(mockRunForkedAgent).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'main-model' }),
+      expect.objectContaining({ model: 'main-model', abortSignal: signal }),
     );
   });
 

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -8,12 +8,17 @@ import type { Content } from '@google/genai';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import type { Config } from '../config/config.js';
 
-const { mockGetCacheSafeParams, mockRunForkedAgent, mockRunSideQuery } =
-  vi.hoisted(() => ({
-    mockGetCacheSafeParams: vi.fn(),
-    mockRunForkedAgent: vi.fn(),
-    mockRunSideQuery: vi.fn(),
-  }));
+const {
+  mockGetCacheSafeParams,
+  mockGetCacheSafeParamsSessionId,
+  mockRunForkedAgent,
+  mockRunSideQuery,
+} = vi.hoisted(() => ({
+  mockGetCacheSafeParams: vi.fn(),
+  mockGetCacheSafeParamsSessionId: vi.fn(),
+  mockRunForkedAgent: vi.fn(),
+  mockRunSideQuery: vi.fn(),
+}));
 
 vi.mock('../utils/sideQuery.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../utils/sideQuery.js')>();
@@ -29,6 +34,7 @@ vi.mock('../utils/forkedAgent.js', async (importOriginal) => {
   return {
     ...actual,
     getCacheSafeParams: mockGetCacheSafeParams,
+    getCacheSafeParamsSessionId: mockGetCacheSafeParamsSessionId,
     runForkedAgent: mockRunForkedAgent,
   };
 });
@@ -49,6 +55,8 @@ const conversationHistory: Content[] = [
 describe('generatePromptSuggestion', () => {
   beforeEach(() => {
     mockGetCacheSafeParams.mockReset();
+    mockGetCacheSafeParamsSessionId.mockReset();
+    mockGetCacheSafeParamsSessionId.mockReturnValue('test-session');
     mockRunForkedAgent.mockReset();
     mockRunSideQuery.mockReset();
   });
@@ -149,13 +157,7 @@ describe('generatePromptSuggestion', () => {
     // suggestion must NOT fork from a foreign session's params (cross-session
     // content leak) — it falls back to the session-safe base-LLM path
     // (#9233).
-    mockGetCacheSafeParams.mockReturnValue({
-      generationConfig: {},
-      history: conversationHistory,
-      model: 'main-model',
-      version: 1,
-      sessionId: 'session-B', // another session saved these params
-    });
+    mockGetCacheSafeParamsSessionId.mockReturnValue('session-B');
     mockRunSideQuery.mockResolvedValue({
       text: '{"suggestion":"from base llm"}',
       usage: { inputTokens: 1, outputTokens: 1 },
@@ -173,6 +175,8 @@ describe('generatePromptSuggestion', () => {
       { enableCacheSharing: true },
     );
 
+    // The foreign slot is rejected before cloning the full cached payload.
+    expect(mockGetCacheSafeParams).not.toHaveBeenCalled();
     // The fork must NOT be used for a foreign session's params.
     expect(mockRunForkedAgent).not.toHaveBeenCalled();
     // The session-safe base-LLM path is used instead.

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -8,10 +8,20 @@ import type { Content } from '@google/genai';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import type { Config } from '../config/config.js';
 
-const { mockGetCacheSafeParams, mockRunForkedAgent } = vi.hoisted(() => ({
-  mockGetCacheSafeParams: vi.fn(),
-  mockRunForkedAgent: vi.fn(),
-}));
+const { mockGetCacheSafeParams, mockRunForkedAgent, mockRunSideQuery } =
+  vi.hoisted(() => ({
+    mockGetCacheSafeParams: vi.fn(),
+    mockRunForkedAgent: vi.fn(),
+    mockRunSideQuery: vi.fn(),
+  }));
+
+vi.mock('../utils/sideQuery.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/sideQuery.js')>();
+  return {
+    ...actual,
+    runSideQuery: mockRunSideQuery,
+  };
+});
 
 vi.mock('../utils/forkedAgent.js', async (importOriginal) => {
   const actual =
@@ -40,6 +50,7 @@ describe('generatePromptSuggestion', () => {
   beforeEach(() => {
     mockGetCacheSafeParams.mockReset();
     mockRunForkedAgent.mockReset();
+    mockRunSideQuery.mockReset();
   });
 
   it('passes cache-safe model in cache mode when no explicit or fast model exists', async () => {
@@ -48,6 +59,7 @@ describe('generatePromptSuggestion', () => {
       history: conversationHistory,
       model: 'main-model',
       version: 1,
+      sessionId: 'test-session',
     });
     mockRunForkedAgent.mockResolvedValue({
       text: null,
@@ -57,6 +69,7 @@ describe('generatePromptSuggestion', () => {
     const config = {
       getFastModel: vi.fn(() => undefined),
       getModel: vi.fn(() => 'main-model'),
+      getSessionId: vi.fn(() => 'test-session'),
     } as unknown as Config;
 
     const signal = new AbortController().signal;
@@ -75,6 +88,7 @@ describe('generatePromptSuggestion', () => {
       history: conversationHistory,
       model: 'main-model',
       version: 1,
+      sessionId: 'test-session',
     });
     mockRunForkedAgent.mockResolvedValue({
       text: null,
@@ -84,6 +98,7 @@ describe('generatePromptSuggestion', () => {
     const config = {
       getFastModel: vi.fn(() => 'openai:fast-model'),
       getModel: vi.fn(() => 'main-model'),
+      getSessionId: vi.fn(() => 'test-session'),
     } as unknown as Config;
 
     await generatePromptSuggestion(
@@ -103,6 +118,7 @@ describe('generatePromptSuggestion', () => {
       history: conversationHistory,
       model: 'main-model',
       version: 1,
+      sessionId: 'test-session',
     });
     mockRunForkedAgent.mockResolvedValue({
       text: null,
@@ -112,6 +128,7 @@ describe('generatePromptSuggestion', () => {
     const config = {
       getFastModel: vi.fn(() => undefined),
       getModel: vi.fn(() => 'main-model'),
+      getSessionId: vi.fn(() => 'test-session'),
     } as unknown as Config;
 
     await generatePromptSuggestion(
@@ -126,12 +143,50 @@ describe('generatePromptSuggestion', () => {
     );
   });
 
+  it('falls back to the base LLM when the cache-safe slot belongs to another session', async () => {
+    // The cache-safe slot is a process-global: in a multi-session daemon it
+    // can hold ANOTHER session's transcript + systemInstruction. The
+    // suggestion must NOT fork from a foreign session's params (cross-session
+    // content leak) — it falls back to the session-safe base-LLM path
+    // (#9233).
+    mockGetCacheSafeParams.mockReturnValue({
+      generationConfig: {},
+      history: conversationHistory,
+      model: 'main-model',
+      version: 1,
+      sessionId: 'session-B', // another session saved these params
+    });
+    mockRunSideQuery.mockResolvedValue({
+      text: '{"suggestion":"from base llm"}',
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+    const config = {
+      getFastModel: vi.fn(() => undefined),
+      getModel: vi.fn(() => 'main-model'),
+      getSessionId: vi.fn(() => 'session-A'), // this session is different
+    } as unknown as Config;
+
+    const result = await generatePromptSuggestion(
+      config,
+      conversationHistory,
+      new AbortController().signal,
+      { enableCacheSharing: true },
+    );
+
+    // The fork must NOT be used for a foreign session's params.
+    expect(mockRunForkedAgent).not.toHaveBeenCalled();
+    // The session-safe base-LLM path is used instead.
+    expect(mockRunSideQuery).toHaveBeenCalled();
+    expect(result.suggestion).toBe('from base llm');
+  });
+
   it('passes preserveTools: false when fast model differs from cache-safe model', async () => {
     mockGetCacheSafeParams.mockReturnValue({
       generationConfig: {},
       history: conversationHistory,
       model: 'main-model',
       version: 1,
+      sessionId: 'test-session',
     });
     mockRunForkedAgent.mockResolvedValue({
       text: null,
@@ -141,6 +196,7 @@ describe('generatePromptSuggestion', () => {
     const config = {
       getFastModel: vi.fn(() => 'different-fast-model'),
       getModel: vi.fn(() => 'main-model'),
+      getSessionId: vi.fn(() => 'test-session'),
     } as unknown as Config;
 
     await generatePromptSuggestion(

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -13,6 +13,7 @@ import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
 import {
   getCacheSafeParams,
+  getCacheSafeParamsSessionId,
   runForkedAgent,
   type CacheSafeParams,
 } from '../utils/forkedAgent.js';
@@ -105,7 +106,12 @@ export async function generatePromptSuggestion(
 
   try {
     // Try cache-aware forked query if enabled and params available
-    const cacheSafe = options?.enableCacheSharing ? getCacheSafeParams() : null;
+    const sessionId = config.getSessionId();
+    const cacheSafeSessionId = options?.enableCacheSharing
+      ? getCacheSafeParamsSessionId()
+      : undefined;
+    const cacheSafe =
+      cacheSafeSessionId === sessionId ? getCacheSafeParams() : null;
     // The cache-safe slot is a process-global: in a multi-session daemon it
     // can hold ANOTHER session's transcript + systemInstruction. Only use it
     // when it belongs to THIS session; otherwise fall back to the
@@ -115,8 +121,13 @@ export async function generatePromptSuggestion(
         ? cacheSafe
         : null;
     const modelOverride = options?.model;
+    const cacheSharingState = sessionCacheSafe
+      ? 'true'
+      : cacheSafeSessionId
+        ? 'session_mismatch'
+        : 'false';
     debugLogger.debug(
-      `Generating suggestion: cacheSharing=${!!sessionCacheSafe}, model=${modelOverride || '(default)'}`,
+      `Generating suggestion: cacheSharing=${cacheSharingState}, model=${modelOverride || '(default)'}`,
     );
     const raw = sessionCacheSafe
       ? await generateViaForkedQuery(

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -157,6 +157,7 @@ async function generateViaForkedQuery(
     jsonSchema: SUGGESTION_SCHEMA,
     model,
     preserveTools: model === cacheSafeParams.model,
+    abortSignal,
   });
 
   if (result.jsonResult) {

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -11,7 +11,11 @@
 
 import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
-import { getCacheSafeParams, runForkedAgent } from '../utils/forkedAgent.js';
+import {
+  getCacheSafeParams,
+  runForkedAgent,
+  type CacheSafeParams,
+} from '../utils/forkedAgent.js';
 import { runSideQuery } from '../utils/sideQuery.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
@@ -102,12 +106,25 @@ export async function generatePromptSuggestion(
   try {
     // Try cache-aware forked query if enabled and params available
     const cacheSafe = options?.enableCacheSharing ? getCacheSafeParams() : null;
+    // The cache-safe slot is a process-global: in a multi-session daemon it
+    // can hold ANOTHER session's transcript + systemInstruction. Only use it
+    // when it belongs to THIS session; otherwise fall back to the
+    // session-safe base-LLM path (#9233).
+    const sessionCacheSafe =
+      cacheSafe && cacheSafe.sessionId === config.getSessionId()
+        ? cacheSafe
+        : null;
     const modelOverride = options?.model;
     debugLogger.debug(
-      `Generating suggestion: cacheSharing=${!!cacheSafe}, model=${modelOverride || '(default)'}`,
+      `Generating suggestion: cacheSharing=${!!sessionCacheSafe}, model=${modelOverride || '(default)'}`,
     );
-    const raw = cacheSafe
-      ? await generateViaForkedQuery(config, abortSignal, modelOverride)
+    const raw = sessionCacheSafe
+      ? await generateViaForkedQuery(
+          config,
+          sessionCacheSafe,
+          abortSignal,
+          modelOverride,
+        )
       : await generateViaBaseLlm(
           config,
           conversationHistory,
@@ -144,11 +161,10 @@ export async function generatePromptSuggestion(
 /** Generate suggestion via cache-aware forked query */
 async function generateViaForkedQuery(
   config: Config,
+  cacheSafeParams: CacheSafeParams,
   abortSignal: AbortSignal,
   modelOverride?: string,
 ): Promise<string | null> {
-  const cacheSafeParams = getCacheSafeParams();
-  if (!cacheSafeParams) return null;
   const model = modelOverride ?? config.getFastModel() ?? cacheSafeParams.model;
   const result = await runForkedAgent({
     config,

--- a/packages/core/src/utils/forkedAgent.cache.test.ts
+++ b/packages/core/src/utils/forkedAgent.cache.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   saveCacheSafeParams,
   getCacheSafeParams,
+  getCacheSafeParamsSessionId,
   clearCacheSafeParams,
   runForkedAgent,
 } from './forkedAgent.js';
@@ -72,6 +73,14 @@ describe('CacheSafeParams', () => {
       saveCacheSafeParams({}, [], 'model', 'session-a');
 
       expect(getCacheSafeParams()?.sessionId).toBe('session-a');
+    });
+
+    it('returns the current session id without reading full params', () => {
+      saveCacheSafeParams({}, [], 'model', 'session-a');
+
+      expect(getCacheSafeParamsSessionId()).toBe('session-a');
+      clearCacheSafeParams();
+      expect(getCacheSafeParamsSessionId()).toBeUndefined();
     });
 
     it('deep clones generationConfig', () => {

--- a/packages/core/src/utils/forkedAgent.cache.test.ts
+++ b/packages/core/src/utils/forkedAgent.cache.test.ts
@@ -68,6 +68,12 @@ describe('CacheSafeParams', () => {
       expect(params!.version).toBeGreaterThan(0);
     });
 
+    it('stores session id', () => {
+      saveCacheSafeParams({}, [], 'model', 'session-a');
+
+      expect(getCacheSafeParams()?.sessionId).toBe('session-a');
+    });
+
     it('deep clones generationConfig', () => {
       const config: GenerateContentConfig = {
         systemInstruction: 'test',

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -153,6 +153,10 @@ export function getCacheSafeParams(): CacheSafeParams | null {
   };
 }
 
+export function getCacheSafeParamsSessionId(): string | undefined {
+  return currentCacheSafeParams?.sessionId;
+}
+
 /**
  * Clear cache-safe params (e.g., on session reset).
  */

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -86,6 +86,14 @@ export interface CacheSafeParams {
   model: string;
   /** Version number — increments when systemInstruction or tools change */
   version: number;
+  /**
+   * The session that saved these params. The slot is a process-global, so
+   * in a multi-session daemon it can hold another session's params; readers
+   * must match this against their own session id before trusting it, or a
+   * forked query could be built from a different session's transcript
+   * (cross-session content leak) (#9233).
+   */
+  sessionId?: string;
 }
 
 // Module-level slot written after each successful main turn.
@@ -107,6 +115,7 @@ export function saveCacheSafeParams(
   generationConfig: GenerateContentConfig,
   history: Content[],
   model: string,
+  sessionId?: string,
 ): void {
   const prevConfig = currentCacheSafeParams?.generationConfig;
   const sysChanged =
@@ -126,6 +135,7 @@ export function saveCacheSafeParams(
     history: copyHistoryContainers(history),
     model,
     version: currentVersion,
+    sessionId,
   };
 }
 
@@ -139,6 +149,7 @@ export function getCacheSafeParams(): CacheSafeParams | null {
     history: copyHistoryContainers(currentCacheSafeParams.history),
     model: currentCacheSafeParams.model,
     version: currentCacheSafeParams.version,
+    sessionId: currentCacheSafeParams.sessionId,
   };
 }
 


### PR DESCRIPTION
## What this PR does

Fixes the default-value bug from #9230: `enableCacheSharing` declares `default: true` in the settings schema (`settingsSchema.ts`), but `mergeSettings` never applies schema defaults, and both runtime gates compared with `=== true` — so an unset value read as `undefined === true` → false, and the cache-aware forked suggestion query was dead code unless the user explicitly set the flag. Both gates now use `!== false`, the exact treatment the adjacent `enableFollowupSuggestions` gate already applies for the same documented quirk:

- `packages/cli/src/ui/AppContainer.tsx` (TUI suggestion generation)
- `packages/cli/src/acp-integration/session/Session.ts` (daemon/ACP suggestion push)

## Why it's needed

With the fork dead by default, every follow-up suggestion goes through the prefix-hostile base-LLM side query, which on prefix-caching servers (e.g. llama.cpp `--parallel 1`) evicts the main session's cached prefix between turns — the ~0% prompt-cache reuse measured in #9200/#9230. Honoring the declared default turns the cache-aware path back on for everyone instead of only users who found and set the hidden flag.

## Reviewer Test Plan

### How to verify

New/updated pins in `Session.test.ts` (follow-up suggestion describe):

- unset `enableCacheSharing` → generator receives `enableCacheSharing: true` (the strengthened assertion fails on the old `=== true` gate — red before, green after);
- explicit `enableCacheSharing: false` → generator receives `false` (opt-out preserved).

```bash
npx vitest run src/acp-integration/session/Session.test.ts -t "follow-up suggestion"   # 8 pass
npx vitest run src/followup/                                                            # core, 124 pass
```

Full-file Session.test.ts run: 622 pass; the 2 failures (`runs prompt inside runtime output dir context`, `pins durable cron startup…`) reproduce on clean main — pre-existing, unrelated.

### Evidence (Before & After)

Before: with `merged.ui` leaving the flag unset, the daemon path forwarded `enableCacheSharing: false` (assertion evidence above), so `generatePromptSuggestion` always took `generateViaBaseLlm`. After: the same state forwards `true`, enabling `getCacheSafeParams()`/`generateViaForkedQuery` per the schema's declared default. Runtime cache-hit-rate improvement itself is observable only against a prefix-caching server (the #9200 setup).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Unit tests + `tsc --noEmit` (clean) + eslint/prettier (clean).

## Risk & Scope

- Main risk or tradeoff: re-enables the forked suggestion path by default — the behavior the schema always advertised. Users who never set the flag move from the base-LLM side query to the cache-aware fork; explicit `false` restores the old behavior.
- Not validated / out of scope (all tracked on #9230): making the side query share the main session's system instruction/tools so it extends the same prefix, the forked path's 40-entry history truncation and `NO_TOOLS` default (which cap how much prefix the fork can reuse), and pre-send microcompaction destabilizing mid-history prefixes. This PR is the gate fix only.
- Breaking changes / migration notes: none; config schema unchanged.

## Linked Issues

Part of #9230

<details>
<summary>中文说明</summary>

修复 #9230 中的默认值 bug：`enableCacheSharing` 在 settings schema 声明 `default: true`，但 `mergeSettings` 不应用 schema 默认值，两处运行时门控（交互式 CLI 的 AppContainer、ACP session 的 daemon 推送路径）又都用 `=== true` 判断，未设置时 `undefined === true` 为 false，cache-aware 分叉建议查询沦为死代码。两处改为 `!== false`，与相邻 `enableFollowupSuggestions` 门控对同一已知问题的处理一致。

修复前每个 follow-up suggestion 都走不带 system instruction、不带 tools 的 base-LLM 侧查询，在 llama.cpp 等前缀缓存服务端（`--parallel 1`）上会挤掉主会话的缓存前缀，即 #9200/#9230 测得的约 0% prompt-cache 复用。本 PR 让 cache-aware 路径按 schema 声明对所有用户默认生效，而非只有手动配置了该隐藏 flag 的用户。

测试：收紧 `Session.test.ts` 中既有的宽松断言为 `enableCacheSharing: true`（改前红、改后绿），另加显式 false opt-out 用例；follow-up suggestion 相关 8 个测试通过，`tsc --noEmit` 与 eslint/prettier 干净。范围之外（均在 #9230 追踪）：侧查询共享主会话 system instruction/tools、forked 路径 40 条历史截断与 `NO_TOOLS` 默认值、微压缩破坏历史中段前缀。无破坏性变更，配置 schema 未动。

</details>
