### PR TITLE
fix(serve): redact skill bodies from the Web Shell event surface

### DIFF
--- a/packages/cli/src/serve/acp-http/transport.test.ts
+++ b/packages/cli/src/serve/acp-http/transport.test.ts
@@ -6296,6 +6296,56 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
     // (takeFrames already locked + aborted `sess`; afterEach force-closes.)
   });
 
+  it('keeps availableSkillDetails verbatim on pumped session_update frames (#9234)', async () => {
+    // Mirror of the SSE redaction tests: the SDK/browser surface strips
+    // `_meta.availableSkillDetails`, but the /acp surface must keep
+    // delivering it untouched — desktop clients parse the skill bodies
+    // for display/editing.
+    const connId = await initialize();
+    await newSession(connId);
+    const sess = await openStream(connId, 'sess-1');
+    const got = takeFrames(sess, 1);
+    await new Promise((r) => setTimeout(r, 50));
+    const skillDetails = [
+      { name: 'bugfix', body: 'skill body', filePath: '/skills/bugfix' },
+    ];
+    bridge.queues.get('sess-1')?.push({
+      type: 'session_update',
+      data: {
+        sessionId: 'sess-1',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [{ name: 'help', description: 'Help' }],
+          _meta: {
+            availableSkills: ['bugfix'],
+            availableSkillDetails: skillDetails,
+          },
+        },
+      },
+    });
+    const frames = (await got) as Array<{
+      method: string;
+      params: {
+        sessionId: string;
+        update: { _meta?: { availableSkillDetails?: unknown } };
+      };
+    }>;
+    expect(frames[0]).toMatchObject({
+      method: 'session/update',
+      params: {
+        sessionId: 'sess-1',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [{ name: 'help', description: 'Help' }],
+          _meta: {
+            availableSkills: ['bugfix'],
+            availableSkillDetails: skillDetails,
+          },
+        },
+      },
+    });
+  });
+
   it('session/load while a session/close is in-flight → rejected (TOCTOU guard)', async () => {
     let releaseClose: () => void = () => {};
     bridge.closeGate = new Promise<void>((r) => (releaseClose = r));

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -2599,7 +2599,19 @@ export function registerSessionRoutes(
           }
         }
         if (!res.writable) return;
-        res.status(201).json(result);
+        // Branch/side-task responses carry the same replay snapshot shape as
+        // load; apply the same redaction (#9234). Checkpoint branches
+        // (`atRecordId` set) return no replay arrays, so only the restored
+        // variant needs shaping.
+        res
+          .status(201)
+          .json(
+            atRecordId === undefined
+              ? omitSkillDetailsFromReplayArrays(
+                  result as BridgeBranchedSession,
+                )
+              : result,
+          );
       },
     ),
   );
@@ -2663,7 +2675,7 @@ export function registerSessionRoutes(
           }
           return;
         }
-        res.status(201).json(result);
+        res.status(201).json(omitSkillDetailsFromReplayArrays(result));
       },
     ),
   );

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -93,6 +93,7 @@ import {
 } from '../server/session-export.js';
 import { setDaemonTelemetryWorkspace } from '../server/telemetry.js';
 import { createSessionOrganizationService } from '../session-organization-helpers.js';
+import { omitSkillDetailsFromReplayArrays } from '../skill-details-redaction.js';
 import { replayTranscriptRecordPage } from '../../acp-integration/session/history-replay-page.js';
 import { GENERATION_MAX_PROMPT_BYTES } from '../../acp-integration/generation.js';
 import {
@@ -2413,7 +2414,9 @@ export function registerSessionRoutes(
             }
           }
         }
-        res.status(200).json(session);
+        // The load response embeds the replay snapshot inline; redact the
+        // skill bodies there just like the SSE egress does (#9234).
+        res.status(200).json(omitSkillDetailsFromReplayArrays(session));
       } catch (err) {
         sendBridgeError(res, err, {
           route,

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -93,7 +93,10 @@ import {
 } from '../server/session-export.js';
 import { setDaemonTelemetryWorkspace } from '../server/telemetry.js';
 import { createSessionOrganizationService } from '../session-organization-helpers.js';
-import { omitSkillDetailsFromReplayArrays } from '../skill-details-redaction.js';
+import {
+  omitSkillDetailsForSdkSurface,
+  omitSkillDetailsFromReplayArrays,
+} from '../skill-details-redaction.js';
 import { replayTranscriptRecordPage } from '../../acp-integration/session/history-replay-page.js';
 import { GENERATION_MAX_PROMPT_BYTES } from '../../acp-integration/generation.js';
 import {
@@ -2101,7 +2104,9 @@ export function registerSessionRoutes(
             });
             return;
           }
-          res.status(200).json(session);
+          // Same replay-array shape as the load response; redact skill
+          // bodies for the browser surface (#9234).
+          res.status(200).json(omitSkillDetailsFromReplayArrays(session));
         } catch (err) {
           sendBridgeError(res, err, { route, sessionId });
         }
@@ -2840,7 +2845,13 @@ export function registerSessionRoutes(
         },
       );
       if (result === undefined) return;
-      res.status(200).set('Cache-Control', 'no-store').json(result);
+      res
+        .status(200)
+        .set('Cache-Control', 'no-store')
+        .json({
+          ...result,
+          events: result.events.map(omitSkillDetailsForSdkSurface),
+        });
     } catch (err) {
       sendBridgeError(res, err, {
         route,
@@ -2960,11 +2971,13 @@ export function registerSessionRoutes(
             return {
               v: 1 as const,
               sessionId,
-              events: replay.updates.map((update) => ({
-                v: 1 as const,
-                type: 'session_update' as const,
-                data: update,
-              })),
+              events: replay.updates.map((update) =>
+                omitSkillDetailsForSdkSurface({
+                  v: 1 as const,
+                  type: 'session_update' as const,
+                  data: update,
+                }),
+              ),
               ...(replay.nextCursor && !cursorTooLarge
                 ? { nextCursor: replay.nextCursor }
                 : {}),

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -2850,7 +2850,7 @@ export function registerSessionRoutes(
         .set('Cache-Control', 'no-store')
         .json({
           ...result,
-          events: result.events.map(omitSkillDetailsForSdkSurface),
+          events: (result.events ?? []).map(omitSkillDetailsForSdkSurface),
         });
     } catch (err) {
       sendBridgeError(res, err, {

--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -2600,17 +2600,14 @@ export function registerSessionRoutes(
         }
         if (!res.writable) return;
         // Branch/side-task responses carry the same replay snapshot shape as
-        // load; apply the same redaction (#9234). Checkpoint branches
-        // (`atRecordId` set) return no replay arrays, so only the restored
-        // variant needs shaping.
+        // load; apply the same redaction (#9234). The helper returns its
+        // input unchanged when no replay arrays are present (checkpoint
+        // branches), so apply it unconditionally rather than re-deriving the
+        // bridge's variant discrimination here.
         res
           .status(201)
           .json(
-            atRecordId === undefined
-              ? omitSkillDetailsFromReplayArrays(
-                  result as BridgeBranchedSession,
-                )
-              : result,
+            omitSkillDetailsFromReplayArrays(result as BridgeBranchedSession),
           );
       },
     ),

--- a/packages/cli/src/serve/routes/sse-events.ts
+++ b/packages/cli/src/serve/routes/sse-events.ts
@@ -33,6 +33,7 @@ import {
   parseMaxQueuedQuery,
 } from '../server/request-helpers.js';
 import { parseEventEpochHeader } from '../sse-last-event-id.js';
+import { omitSkillDetailsForSdkSurface } from '../skill-details-redaction.js';
 import type { WorkspaceRegistry } from '../workspace-registry.js';
 import { requireSessionRuntime } from './session-runtime.js';
 import {
@@ -125,6 +126,7 @@ interface RegisterSseEventsRoutesDeps {
 type OmitId<T> = Omit<T, 'id'>;
 
 function formatSseFrame(event: BridgeEvent | OmitId<BridgeEvent>): string {
+  const shaped = omitSkillDetailsForSdkSurface(event);
   // SSE format: id (optional), event (optional), data, blank line.
   // The `id:` line is intentionally omitted when `event.id` is absent —
   // terminal/synthetic frames (e.g. daemon-side `stream_error`) must not
@@ -142,7 +144,7 @@ function formatSseFrame(event: BridgeEvent | OmitId<BridgeEvent>): string {
   // `_meta.serverTimestamp`: EventBus stamps normal session frames when they
   // are published so SSE and load/replay share the same event time. Keep this
   // fallback for synthetic frames that do not pass through EventBus.
-  const existingMeta = (event as { _meta?: Record<string, unknown> })._meta;
+  const existingMeta = (shaped as { _meta?: Record<string, unknown> })._meta;
   const existingServerTimestamp = existingMeta?.['serverTimestamp'];
   const serverTimestamp =
     typeof existingServerTimestamp === 'number' &&
@@ -150,13 +152,13 @@ function formatSseFrame(event: BridgeEvent | OmitId<BridgeEvent>): string {
       ? existingServerTimestamp
       : Date.now();
   const stamped = {
-    ...event,
+    ...shaped,
     _meta: { ...(existingMeta ?? {}), serverTimestamp },
   };
   const dataJson = JSON.stringify(stamped);
   const idLine =
-    'id' in event && event.id !== undefined ? `id: ${event.id}\n` : '';
-  return `${idLine}event: ${event.type}\ndata: ${dataJson}\n\n`;
+    'id' in shaped && shaped.id !== undefined ? `id: ${shaped.id}\n` : '';
+  return `${idLine}event: ${shaped.type}\ndata: ${dataJson}\n\n`;
 }
 
 export function registerSseEventsRoutes(

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -11912,6 +11912,26 @@ describe('createServeApp', () => {
           },
         },
       } satisfies BridgeEvent;
+      // The in-flight journal can hold a fresher snapshot than the compacted
+      // turns (mid-turn load); it must be redacted too.
+      const journalCommandsEvent = {
+        id: 3,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'persisted-replay',
+          update: {
+            sessionUpdate: 'available_commands_update',
+            availableCommands: [{ name: 'help', description: 'Help' }],
+            _meta: {
+              availableSkills: ['bugfix'],
+              availableSkillDetails: [
+                { name: 'bugfix', body: 'y'.repeat(600_000) },
+              ],
+            },
+          },
+        },
+      } satisfies BridgeEvent;
       const bridge = fakeBridge({
         loadImpl: async (req) => ({
           sessionId: req.sessionId,
@@ -11920,7 +11940,7 @@ describe('createServeApp', () => {
           clientId: 'client-load',
           state: {},
           compactedReplay: [commandsEvent],
-          liveJournal: [textEvent],
+          liveJournal: [journalCommandsEvent, textEvent],
         }),
       });
       const app = createServeApp(baseOpts, undefined, { bridge });
@@ -11941,8 +11961,20 @@ describe('createServeApp', () => {
       const meta = update['_meta'] as Record<string, unknown>;
       expect(meta['availableSkills']).toEqual(['bugfix']);
       expect(meta).not.toHaveProperty('availableSkillDetails');
-      expect(res.body.liveJournal).toEqual([textEvent]);
+      const journal = res.body.liveJournal as Array<{
+        data: { update: Record<string, unknown> };
+      }>;
+      const journalUpdate = journal[0]!.data.update;
+      expect(journalUpdate['sessionUpdate']).toBe('available_commands_update');
+      expect(journalUpdate['availableCommands']).toEqual([
+        { name: 'help', description: 'Help' },
+      ]);
+      const journalMeta = journalUpdate['_meta'] as Record<string, unknown>;
+      expect(journalMeta['availableSkills']).toEqual(['bugfix']);
+      expect(journalMeta).not.toHaveProperty('availableSkillDetails');
+      expect(journal[1]).toEqual(textEvent);
       expect(JSON.stringify(res.body)).not.toContain('x'.repeat(64));
+      expect(JSON.stringify(res.body)).not.toContain('y'.repeat(64));
       // Bus events are shared with other subscribers (e.g. the /acp pump);
       // the redaction must reshape immutably, never mutate the source.
       expect(
@@ -17441,6 +17473,132 @@ describe('createServeApp', () => {
         removeSpy.mockRestore();
         await fsp.rm(runtimeDir, { recursive: true, force: true });
       }
+    });
+
+    it('redacts skill bodies from the branch response replay arrays (#9234)', async () => {
+      const commandsEvent = {
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'branched-session',
+          update: {
+            sessionUpdate: 'available_commands_update',
+            availableCommands: [{ name: 'help', description: 'Help' }],
+            _meta: {
+              availableSkills: ['bugfix'],
+              availableSkillDetails: [
+                { name: 'bugfix', body: 'x'.repeat(600_000) },
+              ],
+            },
+          },
+        },
+      } satisfies BridgeEvent;
+      const bridge = fakeBridge();
+      bridge.branchSession = vi.fn(async (sessionId) => ({
+        sessionId: 'branched-session',
+        workspaceCwd: WS_BOUND,
+        attached: false,
+        clientId: 'client-branch',
+        state: {},
+        displayName: 'Branched',
+        forkedFrom: { sessionId, displayName: 'Source' },
+        compactedReplay: [commandsEvent],
+      }));
+      const runtime = makeWorkspaceRuntimeForTest({
+        workspaceId: 'branch-redaction',
+        workspaceCwd: WS_BOUND,
+        primary: true,
+        bridge,
+        generationGuard: createWorkspaceGenerationGuard(),
+      });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { workspaceRegistry: createWorkspaceRegistry([runtime]) },
+      );
+
+      const res = await request(app)
+        .post('/session/source-session/branch')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({});
+
+      expect(res.status).toBe(201);
+      const replay = res.body.compactedReplay as Array<{
+        data: { update: Record<string, unknown> };
+      }>;
+      const update = replay[0]!.data.update;
+      expect(update['sessionUpdate']).toBe('available_commands_update');
+      expect(update['availableCommands']).toEqual([
+        { name: 'help', description: 'Help' },
+      ]);
+      const meta = update['_meta'] as Record<string, unknown>;
+      expect(meta['availableSkills']).toEqual(['bugfix']);
+      expect(meta).not.toHaveProperty('availableSkillDetails');
+      expect(JSON.stringify(res.body)).not.toContain('x'.repeat(64));
+    });
+  });
+
+  describe('POST /session/:id/side-task (skill-detail redaction, #9234)', () => {
+    it('redacts skill bodies from the side-task response replay arrays', async () => {
+      const commandsEvent = {
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'side-task-session',
+          update: {
+            sessionUpdate: 'available_commands_update',
+            availableCommands: [{ name: 'help', description: 'Help' }],
+            _meta: {
+              availableSkills: ['bugfix'],
+              availableSkillDetails: [
+                { name: 'bugfix', body: 'x'.repeat(600_000) },
+              ],
+            },
+          },
+        },
+      } satisfies BridgeEvent;
+      const bridge = fakeBridge();
+      bridge.createSideTaskSession = vi.fn(async () => ({
+        sessionId: 'side-task-session',
+        workspaceCwd: WS_BOUND,
+        attached: false,
+        clientId: 'client-side-task',
+        state: {},
+        liveJournal: [commandsEvent],
+      }));
+      const runtime = makeWorkspaceRuntimeForTest({
+        workspaceId: 'side-task-redaction',
+        workspaceCwd: WS_BOUND,
+        primary: true,
+        bridge,
+        generationGuard: createWorkspaceGenerationGuard(),
+      });
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { workspaceRegistry: createWorkspaceRegistry([runtime]) },
+      );
+
+      const res = await request(app)
+        .post('/session/source-session/side-task')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ name: 'follow-up' });
+
+      expect(res.status).toBe(201);
+      const journal = res.body.liveJournal as Array<{
+        data: { update: Record<string, unknown> };
+      }>;
+      const update = journal[0]!.data.update;
+      expect(update['sessionUpdate']).toBe('available_commands_update');
+      expect(update['availableCommands']).toEqual([
+        { name: 'help', description: 'Help' },
+      ]);
+      const meta = update['_meta'] as Record<string, unknown>;
+      expect(meta['availableSkills']).toEqual(['bugfix']);
+      expect(meta).not.toHaveProperty('availableSkillDetails');
+      expect(JSON.stringify(res.body)).not.toContain('x'.repeat(64));
     });
   });
 

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -11950,28 +11950,35 @@ describe('createServeApp', () => {
         .send({});
 
       expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ sessionId: 'persisted-replay' });
       const replay = res.body.compactedReplay as Array<{
         data: { update: Record<string, unknown> };
       }>;
-      const update = replay[0]!.data.update;
-      expect(update['sessionUpdate']).toBe('available_commands_update');
-      expect(update['availableCommands']).toEqual([
-        { name: 'help', description: 'Help' },
-      ]);
-      const meta = update['_meta'] as Record<string, unknown>;
-      expect(meta['availableSkills']).toEqual(['bugfix']);
-      expect(meta).not.toHaveProperty('availableSkillDetails');
+      // Pin the full envelope (id/v/type/data.sessionId) so envelope-level
+      // regressions in the reshape cannot ship green (review R3-2).
+      expect(replay[0]).toEqual({
+        ...commandsEvent,
+        data: {
+          ...commandsEvent.data,
+          update: {
+            ...commandsEvent.data.update,
+            _meta: { availableSkills: ['bugfix'] },
+          },
+        },
+      });
       const journal = res.body.liveJournal as Array<{
         data: { update: Record<string, unknown> };
       }>;
-      const journalUpdate = journal[0]!.data.update;
-      expect(journalUpdate['sessionUpdate']).toBe('available_commands_update');
-      expect(journalUpdate['availableCommands']).toEqual([
-        { name: 'help', description: 'Help' },
-      ]);
-      const journalMeta = journalUpdate['_meta'] as Record<string, unknown>;
-      expect(journalMeta['availableSkills']).toEqual(['bugfix']);
-      expect(journalMeta).not.toHaveProperty('availableSkillDetails');
+      expect(journal[0]).toEqual({
+        ...journalCommandsEvent,
+        data: {
+          ...journalCommandsEvent.data,
+          update: {
+            ...journalCommandsEvent.data.update,
+            _meta: { availableSkills: ['bugfix'] },
+          },
+        },
+      });
       expect(journal[1]).toEqual(textEvent);
       expect(JSON.stringify(res.body)).not.toContain('x'.repeat(64));
       expect(JSON.stringify(res.body)).not.toContain('y'.repeat(64));
@@ -11982,6 +11989,54 @@ describe('createServeApp', () => {
           'availableSkillDetails'
         ],
       ).toBeDefined();
+    });
+
+    it('redacts flat persisted-transcript frames in replay arrays (#9234)', async () => {
+      // Persisted-transcript frames carry the ACP update flat under `data`
+      // (no `update` wrapper); the redactor must handle both shapes.
+      const flatCommandsEvent = {
+        id: 7,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [{ name: 'help', description: 'Help' }],
+          _meta: {
+            availableSkills: ['bugfix'],
+            availableSkillDetails: [
+              { name: 'bugfix', body: 'LEAK-CANARY-SKILL-BODY'.repeat(100) },
+            ],
+          },
+        },
+      } satisfies BridgeEvent;
+      const bridge = fakeBridge({
+        loadImpl: async (req) => ({
+          sessionId: req.sessionId,
+          workspaceCwd: req.workspaceCwd,
+          attached: false,
+          clientId: 'client-load',
+          state: {},
+          compactedReplay: [flatCommandsEvent],
+        }),
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/persisted-flat/load')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({});
+
+      expect(res.status).toBe(200);
+      const replay = res.body.compactedReplay as Array<{
+        data: Record<string, unknown>;
+      }>;
+      expect(replay[0]).toEqual({
+        ...flatCommandsEvent,
+        data: {
+          ...flatCommandsEvent.data,
+          _meta: { availableSkills: ['bugfix'] },
+        },
+      });
+      expect(JSON.stringify(res.body)).not.toContain('LEAK-CANARY-SKILL-BODY');
     });
 
     it('passes client identity headers through to load/resume bridge calls', async () => {
@@ -25850,6 +25905,14 @@ describe('GET /session/:id/events (SSE)', () => {
         } => payload !== undefined,
       );
     expect(payloads).toHaveLength(2);
+    // Pin the envelope the reshape must preserve (SSE id line, schema
+    // version, session attribution) — review R3-2 mutant M1.
+    expect(payloads[0]).toMatchObject({
+      id: 1,
+      v: 1,
+      type: 'session_update',
+      data: { sessionId: 'sess-A' },
+    });
     const commandsUpdate = payloads[0]!.data!.update!;
     expect(commandsUpdate['sessionUpdate']).toBe('available_commands_update');
     expect(commandsUpdate['availableCommands']).toEqual([

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -11617,6 +11617,63 @@ describe('createServeApp', () => {
       expect(bridge.resumeCalls).toEqual([]);
     });
 
+    it('redacts skill bodies from virtual subagent load replay (#9234)', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(
+        { ...baseOpts, workspace: WS_BOUND },
+        undefined,
+        { bridge },
+      );
+      const sessionId = createVirtualSubagentSessionId('parent-1', 'agent-1');
+      const commandsEvent = {
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'parent-1',
+          update: {
+            sessionUpdate: 'available_commands_update',
+            availableCommands: [{ name: 'help', description: 'Help' }],
+            _meta: {
+              availableSkills: ['bugfix'],
+              availableSkillDetails: [
+                { name: 'bugfix', body: 'x'.repeat(600_000) },
+              ],
+            },
+          },
+        },
+      };
+      const loadSpy = vi
+        .spyOn(VirtualSubagentSessions.prototype, 'load')
+        .mockResolvedValue({
+          sessionId,
+          workspaceCwd: WS_BOUND,
+          attached: true,
+          clientId: 'client-v',
+          state: {},
+          compactedReplay: [commandsEvent],
+          liveJournal: [],
+        });
+
+      try {
+        const res = await request(app)
+          .post(`/session/${sessionId}/load`)
+          .set('Host', `127.0.0.1:${baseOpts.port}`)
+          .send({});
+
+        expect(res.status).toBe(200);
+        const replay = res.body.compactedReplay as Array<{
+          data: { update: Record<string, unknown> };
+        }>;
+        const meta = replay[0]!.data.update['_meta'] as Record<string, unknown>;
+        expect(meta['availableSkills']).toEqual(['bugfix']);
+        expect(meta).not.toHaveProperty('availableSkillDetails');
+        expect(JSON.stringify(res.body)).not.toContain('x'.repeat(64));
+      } finally {
+        loadSpy.mockRestore();
+      }
+    });
+
     it('passes the requested initial history page size to load', async () => {
       const bridge = fakeBridge();
       const app = createServeApp(
@@ -21290,6 +21347,50 @@ describe('createServeApp', () => {
       ]);
       expect(bridge.loadCalls).toHaveLength(0);
       expect(bridge.resumeCalls).toHaveLength(0);
+    });
+
+    it('redacts skill bodies from flat transcript events (#9234)', async () => {
+      const sid = '55555555-bbbb-cccc-dddd-aaaaaaaaaaab';
+      const bridge = fakeBridge({
+        sessionTranscriptImpl: async (req) => ({
+          v: 1,
+          sessionId: req.sessionId,
+          events: [
+            {
+              v: 1,
+              type: 'session_update',
+              data: {
+                sessionUpdate: 'available_commands_update',
+                availableCommands: [{ name: 'help', description: 'Help' }],
+                _meta: {
+                  availableSkills: ['bugfix'],
+                  availableSkillDetails: [
+                    { name: 'bugfix', body: 'x'.repeat(600_000) },
+                  ],
+                },
+              },
+            },
+          ],
+          hasMore: false,
+        }),
+      });
+      await writeTranscriptSession(sid);
+      const app = createServeApp({ ...baseOpts, workspace: wsDir }, undefined, {
+        bridge,
+        boundWorkspace: wsDir,
+      });
+
+      const res = await request(app)
+        .get(`/session/${sid}/transcript`)
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+      expect(res.status).toBe(200);
+      const event = res.body.events[0] as { data: Record<string, unknown> };
+      expect(event.data['sessionUpdate']).toBe('available_commands_update');
+      const meta = event.data['_meta'] as Record<string, unknown>;
+      expect(meta['availableSkills']).toEqual(['bugfix']);
+      expect(meta).not.toHaveProperty('availableSkillDetails');
+      expect(JSON.stringify(res.body)).not.toContain('x'.repeat(64));
     });
 
     it('forwards an exclusive persisted-record boundary', async () => {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -11881,6 +11881,77 @@ describe('createServeApp', () => {
       ]);
     });
 
+    it('redacts skill bodies from the load response replay arrays (#9234)', async () => {
+      const commandsEvent = {
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'persisted-replay',
+          update: {
+            sessionUpdate: 'available_commands_update',
+            availableCommands: [{ name: 'help', description: 'Help' }],
+            _meta: {
+              availableSkills: ['bugfix'],
+              availableSkillDetails: [
+                { name: 'bugfix', body: 'x'.repeat(600_000) },
+              ],
+            },
+          },
+        },
+      } satisfies BridgeEvent;
+      const textEvent = {
+        id: 2,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'persisted-replay',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'hi' },
+          },
+        },
+      } satisfies BridgeEvent;
+      const bridge = fakeBridge({
+        loadImpl: async (req) => ({
+          sessionId: req.sessionId,
+          workspaceCwd: req.workspaceCwd,
+          attached: false,
+          clientId: 'client-load',
+          state: {},
+          compactedReplay: [commandsEvent],
+          liveJournal: [textEvent],
+        }),
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/persisted-replay/load')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({});
+
+      expect(res.status).toBe(200);
+      const replay = res.body.compactedReplay as Array<{
+        data: { update: Record<string, unknown> };
+      }>;
+      const update = replay[0]!.data.update;
+      expect(update['sessionUpdate']).toBe('available_commands_update');
+      expect(update['availableCommands']).toEqual([
+        { name: 'help', description: 'Help' },
+      ]);
+      const meta = update['_meta'] as Record<string, unknown>;
+      expect(meta['availableSkills']).toEqual(['bugfix']);
+      expect(meta).not.toHaveProperty('availableSkillDetails');
+      expect(res.body.liveJournal).toEqual([textEvent]);
+      expect(JSON.stringify(res.body)).not.toContain('x'.repeat(64));
+      // Bus events are shared with other subscribers (e.g. the /acp pump);
+      // the redaction must reshape immutably, never mutate the source.
+      expect(
+        (commandsEvent.data.update._meta as Record<string, unknown>)[
+          'availableSkillDetails'
+        ],
+      ).toBeDefined();
+    });
+
     it('passes client identity headers through to load/resume bridge calls', async () => {
       for (const action of ['load', 'resume'] as const) {
         const bridge = fakeBridge();
@@ -25547,6 +25618,133 @@ describe('GET /session/:id/events (SSE)', () => {
     });
     expect(frames[1]?.id).toBe('2');
     expect(JSON.parse(frames[1]!.data!)).not.toHaveProperty('promptId');
+  });
+
+  it('omits skill bodies from available_commands_update frames (#9234)', async () => {
+    // The daemon-side snapshot embeds every skill's full SKILL.md body for
+    // ACP clients; the SSE surface must strip it while keeping the command
+    // entries and the skill name list.
+    const sharedUpdate = {
+      sessionUpdate: 'available_commands_update',
+      availableCommands: [{ name: 'help', description: 'Help' }],
+      _meta: {
+        availableSkills: ['bugfix'],
+        availableSkillDetails: [
+          {
+            name: 'bugfix',
+            description: 'Fix a bug',
+            body: 'x'.repeat(600_000),
+            filePath: '/skills/bugfix/SKILL.md',
+            level: 'project',
+            modelInvocable: true,
+          },
+        ],
+      },
+    };
+    const bridge = fakeBridge({
+      async *subscribeImpl() {
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: { sessionId: 'sess-A', update: sharedUpdate },
+        };
+        yield {
+          id: 2,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'sess-A',
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'hi' },
+            },
+          },
+        };
+      },
+    });
+    const app = createServeApp(baseOpts, undefined, { bridge });
+
+    const res = await request(app)
+      .get('/session/sess-A/events')
+      .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+    expect(res.status).toBe(200);
+    const payloads = res.text
+      .split('\n\n')
+      .map((raw) => {
+        const dataLine = raw
+          .split('\n')
+          .find((line) => line.startsWith('data: '));
+        // Skip non-frame prelude lines such as `retry: 3000`.
+        if (!dataLine) return undefined;
+        return JSON.parse(dataLine.slice('data: '.length)) as {
+          id?: number;
+          data?: { update?: Record<string, unknown> };
+        };
+      })
+      .filter(
+        (
+          payload,
+        ): payload is {
+          id?: number;
+          data?: { update?: Record<string, unknown> };
+        } => payload !== undefined,
+      );
+    expect(payloads).toHaveLength(2);
+    const commandsUpdate = payloads[0]!.data!.update!;
+    expect(commandsUpdate['sessionUpdate']).toBe('available_commands_update');
+    expect(commandsUpdate['availableCommands']).toEqual([
+      { name: 'help', description: 'Help' },
+    ]);
+    const meta = commandsUpdate['_meta'] as Record<string, unknown>;
+    expect(meta['availableSkills']).toEqual(['bugfix']);
+    expect(meta).not.toHaveProperty('availableSkillDetails');
+    expect(payloads[1]!.data!.update).toMatchObject({
+      sessionUpdate: 'agent_message_chunk',
+      content: { type: 'text', text: 'hi' },
+    });
+    expect(res.text).not.toContain('x'.repeat(64));
+    // Bus events are shared with other subscribers (e.g. the /acp pump);
+    // the strip must reshape immutably, never mutate the source event.
+    expect(sharedUpdate._meta).toHaveProperty('availableSkillDetails');
+  });
+
+  it('drops an available_commands_update _meta left empty by skill-detail stripping (#9234)', async () => {
+    const bridge = fakeBridge({
+      async *subscribeImpl() {
+        yield {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'sess-A',
+            update: {
+              sessionUpdate: 'available_commands_update',
+              availableCommands: [{ name: 'help', description: 'Help' }],
+              _meta: {
+                availableSkillDetails: [{ name: 'bugfix', body: 'body' }],
+              },
+            },
+          },
+        };
+      },
+    });
+    const app = createServeApp(baseOpts, undefined, { bridge });
+
+    const res = await request(app)
+      .get('/session/sess-A/events')
+      .set('Host', `127.0.0.1:${baseOpts.port}`);
+
+    expect(res.status).toBe(200);
+    const dataLine = res.text
+      .split('\n')
+      .find((line) => line.startsWith('data: '));
+    expect(dataLine).toBeDefined();
+    const payload = JSON.parse(dataLine!.slice('data: '.length)) as {
+      data?: { update?: Record<string, unknown> };
+    };
+    expect(payload.data!.update).not.toHaveProperty('_meta');
   });
 
   it('correlates the SSE response, daemon lifecycle log, and request span', async () => {

--- a/packages/cli/src/serve/skill-details-redaction.test.ts
+++ b/packages/cli/src/serve/skill-details-redaction.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
+import {
+  omitSkillDetailsForSdkSurface,
+  omitSkillDetailsFromReplayArrays,
+} from './skill-details-redaction.js';
+
+interface CommandsData {
+  sessionUpdate: string;
+  availableCommands: Array<{ name: string; description: string }>;
+  _meta?: Record<string, unknown>;
+}
+interface WrappedEvent extends BridgeEvent {
+  data: { sessionId: string; update: CommandsData };
+}
+interface FlatEvent extends BridgeEvent {
+  data: CommandsData;
+}
+
+function wrappedCommandsEvent(): WrappedEvent {
+  return {
+    id: 1,
+    v: 1,
+    type: 'session_update',
+    data: {
+      sessionId: 'sess-1',
+      update: {
+        sessionUpdate: 'available_commands_update',
+        availableCommands: [{ name: 'help', description: 'Help' }],
+        _meta: {
+          availableSkills: ['bugfix'],
+          availableSkillDetails: [{ name: 'bugfix', body: 'skill body' }],
+          other: 'kept',
+        },
+      },
+    },
+  };
+}
+
+function flatCommandsEvent(): FlatEvent {
+  return {
+    id: 2,
+    v: 1,
+    type: 'session_update',
+    data: {
+      sessionUpdate: 'available_commands_update',
+      availableCommands: [{ name: 'help', description: 'Help' }],
+      _meta: {
+        availableSkills: ['bugfix'],
+        availableSkillDetails: [{ name: 'bugfix', body: 'skill body' }],
+      },
+    },
+  };
+}
+
+describe('omitSkillDetailsForSdkSurface', () => {
+  it('strips availableSkillDetails from wrapped frames, keeping the rest', () => {
+    const shaped = omitSkillDetailsForSdkSurface(wrappedCommandsEvent());
+    expect(shaped).toEqual({
+      id: 1,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'sess-1',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [{ name: 'help', description: 'Help' }],
+          _meta: { availableSkills: ['bugfix'], other: 'kept' },
+        },
+      },
+    });
+  });
+
+  it('strips availableSkillDetails from flat persisted-transcript frames', () => {
+    const shaped = omitSkillDetailsForSdkSurface(flatCommandsEvent());
+    expect(shaped).toEqual({
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionUpdate: 'available_commands_update',
+        availableCommands: [{ name: 'help', description: 'Help' }],
+        _meta: { availableSkills: ['bugfix'] },
+      },
+    });
+  });
+
+  it('drops _meta entirely when stripping leaves it empty', () => {
+    const event = wrappedCommandsEvent();
+    event.data.update._meta = {
+      availableSkillDetails: [{ name: 'bugfix', body: 'skill body' }],
+    };
+    const shaped = omitSkillDetailsForSdkSurface(event);
+    expect(shaped.data.update).not.toHaveProperty('_meta');
+  });
+
+  it('passes through non-available_commands_update events unchanged', () => {
+    const event: BridgeEvent = {
+      id: 3,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'sess-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hi' },
+        },
+      },
+    };
+    expect(omitSkillDetailsForSdkSurface(event)).toBe(event);
+  });
+
+  it('passes through commands frames without availableSkillDetails unchanged', () => {
+    const event = wrappedCommandsEvent();
+    event.data.update._meta = { availableSkills: ['bugfix'] };
+    expect(omitSkillDetailsForSdkSurface(event)).toBe(event);
+  });
+
+  it('never mutates the source event', () => {
+    const event = wrappedCommandsEvent();
+    omitSkillDetailsForSdkSurface(event);
+    expect(event.data.update._meta?.['availableSkillDetails']).toEqual([
+      { name: 'bugfix', body: 'skill body' },
+    ]);
+  });
+});
+
+describe('omitSkillDetailsFromReplayArrays', () => {
+  it('redacts both arrays when both are present', () => {
+    const shaped = omitSkillDetailsFromReplayArrays({
+      sessionId: 'sess-1',
+      compactedReplay: [wrappedCommandsEvent()],
+      liveJournal: [flatCommandsEvent()],
+    });
+    expect(shaped.sessionId).toBe('sess-1');
+    expect(shaped.compactedReplay[0].data.update._meta).not.toHaveProperty(
+      'availableSkillDetails',
+    );
+    expect(shaped.liveJournal[0].data._meta).not.toHaveProperty(
+      'availableSkillDetails',
+    );
+  });
+
+  it('redacts a single present array', () => {
+    const shaped = omitSkillDetailsFromReplayArrays({
+      sessionId: 'sess-1',
+      liveJournal: [wrappedCommandsEvent()],
+    });
+    expect(shaped.liveJournal[0].data.update._meta).toEqual({
+      availableSkills: ['bugfix'],
+      other: 'kept',
+    });
+  });
+
+  it('returns its input unchanged when no replay arrays are present', () => {
+    const session = {
+      sessionId: 'sess-1',
+      displayName: 'Branch',
+      compactedReplay: undefined,
+    };
+    expect(omitSkillDetailsFromReplayArrays(session)).toBe(session);
+  });
+});

--- a/packages/cli/src/serve/skill-details-redaction.ts
+++ b/packages/cli/src/serve/skill-details-redaction.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
+
+/**
+ * `available_commands_update` snapshots embed every installed skill's full
+ * SKILL.md body under `update._meta.availableSkillDetails` for ACP clients
+ * that display or edit skill files (e.g. desktop). The SDK/browser surface
+ * (SSE streams and REST responses) only reads the command entries and the
+ * `availableSkills` name list, so with many skills installed the bodies are
+ * hundreds of kilobytes of dead weight that every browser tab parses and
+ * discards on each snapshot (#9234). The `/acp` surface keeps delivering the
+ * full snapshot; apply this at every SDK/browser egress point. Frames are
+ * shared with other bus subscribers, so reshape immutably instead of
+ * mutating.
+ */
+export function omitSkillDetailsForSdkSurface<
+  T extends { type: string; data: unknown },
+>(event: T): T {
+  if (event.type !== 'session_update') return event;
+  const data = asRecord(event.data);
+  if (!data) return event;
+  const update = asRecord(data['update']);
+  if (!update || update['sessionUpdate'] !== 'available_commands_update') {
+    return event;
+  }
+  const meta = asRecord(update['_meta']);
+  if (!meta || !('availableSkillDetails' in meta)) return event;
+  const trimmedMeta: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(meta)) {
+    if (key !== 'availableSkillDetails') trimmedMeta[key] = value;
+  }
+  const nextUpdate: Record<string, unknown> = { ...update };
+  if (Object.keys(trimmedMeta).length > 0) {
+    nextUpdate['_meta'] = trimmedMeta;
+  } else {
+    delete nextUpdate['_meta'];
+  }
+  return { ...event, data: { ...data, update: nextUpdate } };
+}
+
+/**
+ * `POST /session/:id/load` embeds the replay snapshot (compacted turns plus
+ * the in-flight journal) directly in the response body; apply the same
+ * redaction to those frames as the SSE egress does.
+ */
+export function omitSkillDetailsFromReplayArrays<
+  T extends {
+    compactedReplay?: BridgeEvent[];
+    liveJournal?: BridgeEvent[];
+  },
+>(session: T): T {
+  if (!session.compactedReplay && !session.liveJournal) return session;
+  return {
+    ...session,
+    ...(session.compactedReplay
+      ? {
+          compactedReplay: session.compactedReplay.map(
+            omitSkillDetailsForSdkSurface,
+          ),
+        }
+      : {}),
+    ...(session.liveJournal
+      ? {
+          liveJournal: session.liveJournal.map(omitSkillDetailsForSdkSurface),
+        }
+      : {}),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/packages/cli/src/serve/skill-details-redaction.ts
+++ b/packages/cli/src/serve/skill-details-redaction.ts
@@ -24,23 +24,32 @@ export function omitSkillDetailsForSdkSurface<
   if (event.type !== 'session_update') return event;
   const data = asRecord(event.data);
   if (!data) return event;
-  const update = asRecord(data['update']);
-  if (!update || update['sessionUpdate'] !== 'available_commands_update') {
+  // Two documented frame shapes: eventBus-wrapped (`data.update.*`) and
+  // persisted-transcript flat (`data.*`); the bridge's
+  // `transcriptEventRecordId` accepts both, so the redactor must too.
+  const wrapped = asRecord(data['update']);
+  const flat = !wrapped && data['sessionUpdate'] !== undefined;
+  const candidate = flat ? data : wrapped;
+  if (
+    !candidate ||
+    candidate['sessionUpdate'] !== 'available_commands_update'
+  ) {
     return event;
   }
-  const meta = asRecord(update['_meta']);
+  const meta = asRecord(candidate['_meta']);
   if (!meta || !('availableSkillDetails' in meta)) return event;
   const trimmedMeta: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(meta)) {
     if (key !== 'availableSkillDetails') trimmedMeta[key] = value;
   }
-  const nextUpdate: Record<string, unknown> = { ...update };
+  const nextCandidate: Record<string, unknown> = { ...candidate };
   if (Object.keys(trimmedMeta).length > 0) {
-    nextUpdate['_meta'] = trimmedMeta;
+    nextCandidate['_meta'] = trimmedMeta;
   } else {
-    delete nextUpdate['_meta'];
+    delete nextCandidate['_meta'];
   }
-  return { ...event, data: { ...data, update: nextUpdate } };
+  if (flat) return { ...event, data: nextCandidate };
+  return { ...event, data: { ...data, update: nextCandidate } };
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Daemon session snapshots for slash commands and skills embed every installed skill's full SKILL.md body, because native clients that display or edit skill files need it. That full snapshot was also delivered verbatim to the browser-facing event surface even though nothing there reads the bodies — consumers only use the command entries and the skill name list. This PR strips the skill-detail payload from the frames and response fields the browser/SDK surface receives (the live event stream and the session-load replay arrays), while the native ACP surface keeps getting the complete snapshot. The strip reshapes frames immutably because the same in-memory events are shared with other subscribers, and it drops the snapshot metadata entirely when stripping leaves it empty.

## Why it's needed

With many skills installed, each command/skill snapshot weighed ~640 KB on this machine (project-level skill bodies alone total ~233 KB), and a snapshot is re-delivered on every session cold load and on skill/settings refreshes. Every browser tab parsed and discarded most of that JSON, compounding the known transcript-rendering cost (#7271, #7272, #7274, #7275) and driving the renderer into sustained memory pressure — observed as Web Shell tabs becoming unresponsive and crashing while the daemon stayed healthy (#9234). macOS resource diagnostics showed Chrome renderers dirtying 2–8.5 GB over hours, and daemon logs showed SSE streams reconnecting every few seconds with a flat cursor, consistent with crash → reload → cold replay loops.

## Reviewer Test Plan

### How to verify

- Run the targeted unit tests, which exercise the real HTTP routes: `cd packages/cli && npx vitest run src/serve/server.test.ts -t "skill"` — the three new tests assert the stream frames and the load-response replay arrays keep `availableCommands` and the `availableSkills` name list, no longer carry the skill-detail payload, leave unrelated frames untouched, and never mutate the shared source events.
- Manual (optional): start `qwen serve` in a workspace with several skills installed, open the Web Shell, and inspect the `events` stream and the `load` response in DevTools. Before: command/skill snapshots carry every skill's full body. After: the same frames omit the skill-detail payload while slash-command autocomplete and the skill list still work. Desktop clients receive the full snapshot unchanged over the ACP surface.

### Evidence (Before & After)

Non-UI change (wire payload): daemon log before the fix shows `available_commands_update` frames at `bytes=640432` (large-frame observer threshold 256 KB); after the fix the same frames are a few KB on the browser surface. Unit-test output:

```text
 ✓ src/serve/server.test.ts (945 tests)
   ✓ redacts skill bodies from the load response replay arrays (#9234)
   ✓ omits skill bodies from available_commands_update frames (#9234)
   ✓ drops an available_commands_update _meta left empty by skill-detail stripping (#9234)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via `npx vitest` (no daemon needed); evidence logs from a local `tsx` dev daemon (`qwen serve`).

## Risk & Scope

- Main risk or tradeoff: any third-party consumer of the browser/SDK surface that read the skill-detail payload loses it there; it remains available on the ACP surface. No first-party consumer reads it on the stripped surface.
- Not validated / out of scope: the other oversized-frame contributor recorded in #9234 (large `tool_call_update` raw outputs from subagents) and the client-side rendering pipeline issues (#7271, #7272, #7274, #7275) are untouched and tracked separately. Eight pre-existing failures in `virtual-subagent-sessions.test.ts` and `scheduled-tasks.test.ts` reproduce on a clean checkout of the base branch and are unrelated.
- Breaking changes / migration notes: none; the stripped field is an `_meta` extension that SDK/browser consumers never surfaced.

## Linked Issues

Fixes #9234

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

daemon 的斜杠命令/技能快照会内嵌每个已安装 skill 的完整 SKILL.md 正文，因为需要展示或编辑 skill 文件的原生客户端要用到它。但这份完整快照此前也原样下发到了浏览器面——而浏览器面没有任何消费方读取这些正文，它们只用命令条目和 skill 名称列表。本 PR 在浏览器/SDK 面接收到的帧与响应字段（实时事件流、session 冷加载响应里的回放数组）中剥离 skill 详情负载；原生 ACP 面仍然收到完整快照。由于同一份内存内事件会被其他订阅者共享，剥离采用不可变重塑；当剥离后快照元数据为空时整体省略该字段。

## 为什么需要

在安装了较多 skill 的机器上，每个命令/技能快照约 640 KB（本机仅项目级 skill 正文合计约 233 KB），且每次 session 冷加载、skill/设置刷新都会全量重发。每个浏览器标签页都要解析这些 JSON 后丢弃大部分内容，叠加已知的 transcript 渲染成本（#7271、#7272、#7274、#7275），把渲染进程推入持续内存压力——表现为 Web Shell 标签页卡死、崩溃，而 daemon 本身健康（#9234）。macOS 资源诊断显示 Chrome 渲染进程在数小时内写入 2–8.5 GB，daemon 日志显示 SSE 流每隔几秒以游标原地踏步的方式重连，符合"崩溃 → 刷新 → 冷回放"循环。

## 评审测试计划

### 如何验证

- 运行触达真实 HTTP 路由的定向单测：`cd packages/cli && npx vitest run src/serve/server.test.ts -t "skill"`——三个新测试断言：事件流帧与 load 响应的回放数组保留 `availableCommands` 与 `availableSkills` 名称列表、不再携带 skill 详情负载、不影响其他帧、且绝不改动共享的源事件对象。
- 手工验证（可选）：在安装多个 skill 的工作区启动 `qwen serve`，打开 Web Shell，在 DevTools 中查看 `events` 流与 `load` 响应。修复前：命令/技能快照携带每个 skill 的完整正文；修复后：同样的帧不再携带 skill 详情，同时斜杠命令自动补全与 skill 列表功能正常。desktop 客户端经 ACP 面仍收到完整快照。

### 证据（修复前后）

非 UI 改动（线上负载）：修复前 daemon 日志中 `available_commands_update` 帧 `bytes=640432`（大帧观察阈值 256 KB）；修复后浏览器面同样的帧只有几 KB。单测输出：

```text
 ✓ src/serve/server.test.ts (945 tests)
   ✓ redacts skill bodies from the load response replay arrays (#9234)
   ✓ omits skill bodies from available_commands_update frames (#9234)
   ✓ drops an available_commands_update _meta left empty by skill-detail stripping (#9234)
```

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

单测通过 `npx vitest` 运行（无需 daemon）；证据日志来自本地 `tsx` 开发 daemon（`qwen serve`）。

## 风险与范围

- 主要风险/权衡：若有第三方消费方在浏览器/SDK 面读取 skill 详情负载，将无法再读到；该数据在 ACP 面仍然可用。没有任何第一方消费方在被剥离的面上读取它。
- 未验证/不在本 PR 范围：#9234 记录的另一个大帧来源（subagent 的超大 `tool_call_update` rawOutput）以及客户端渲染管线问题（#7271、#7272、#7274、#7275）不在本 PR 处理，分别有独立 issue 跟踪。`virtual-subagent-sessions.test.ts` 与 `scheduled-tasks.test.ts` 中 8 个失败在基线分支的干净检出上同样复现，与本改动无关。
- 破坏性变更/迁移说明：无；被剥离的字段是 `_meta` 扩展字段，SDK/浏览器消费方从未暴露过它。

## 关联 Issue

Fixes #9234

</details>
