### PR TITLE
fix(sdk): raise daemon browser bundle budget to 191KB

### DIFF
--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -87,7 +87,9 @@ const rootDir = join(__dirname, '..');
 // APIs merged in from main.
 // Bumped from 189KB to 190KB for historical branch sessions and transcript
 // branch-point projection merged with the upload and reasoning APIs.
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 190 * 1024;
+// Bumped from 190KB to 191KB for the composer text-file attachment metadata
+// (#9180) on the local optimistic user transcript surface.
+const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 191 * 1024;
 // The opt-in `daemon/transports` browser bundle legitimately ships the concrete
 // ACP transports (AcpHttpTransport/AcpWsTransport/AutoReconnect + negotiate), so
 // it's larger than the default barrel — but still budgeted so a future PR can't


### PR DESCRIPTION
## What this PR does

Raises the browser daemon SDK bundle size budget from 190 KiB to 191 KiB, following the existing bump-comment convention in the SDK build script.

## Why it's needed

Main is currently red. The composer text-file attachment feature (#9180) added attachment metadata to the SDK's local optimistic user transcript surface, which grew the browser daemon bundle to 194607 bytes — 47 bytes over the 190 KiB (194560 bytes) budget. The SDK build assertion has failed on every build since that merge, which breaks `npm ci` on main and makes every open PR's sandboxed verification report "the PR could not be built" (e.g. #8960's verify run, workflow run 31896086234, whose failure log shows the identical 194607-byte size).

## Reviewer Test Plan

### How to verify

Run `npm run build --workspace=packages/sdk-typescript` on this branch: the build completes and `wc -c packages/sdk-typescript/dist/daemon/index.js` reports 194607 bytes, which passes the new 191 KiB (195584 bytes) budget with 977 bytes of headroom. The transports (40029 bytes) and transcript (84485 bytes) bundles are unaffected and remain within their own budgets.

### Evidence (Before & After)

N/A — build-script constant change, no user-visible behavior.

Before: `Error: Browser daemon SDK bundle is 194607 bytes; expected <= 194560` (main CI E2E runs 31895887804, 31896289341, and every PR sandboxed verification since #9180 merged).
After: SDK build passes locally with the measured 194607-byte bundle.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local `npm run build --workspace=packages/sdk-typescript` against origin/main (90f754e73e) plus this change.

## Risk & Scope

- Main risk or tradeoff: the budget grows by 1 KiB; the guard still catches future silent bloat.
- Not validated / out of scope: trimming the bundle to reclaim the 47 bytes — can be done in a follow-up if desired.
- Breaking changes / migration notes: none.

## Linked Issues

Related: #9180 (introduced the growth), #8960 (verify casualty example).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

按照 SDK 构建脚本中已有的预算上调注释惯例，将浏览器 daemon SDK bundle 的体积预算从 190 KiB 提升到 191 KiB。

## 为什么需要

main 当前是红的。composer 文本附件功能（#9180）在 SDK 的本地乐观用户 transcript 面上增加了附件元数据，使浏览器 daemon bundle 增长到 194607 字节，超出 190 KiB（194560 字节）预算 47 字节。自该 PR 合并后，SDK 构建断言在每次构建中都会失败，导致 main 上 `npm ci` 失败，所有 open PR 的沙箱验证都会报告 "the PR could not be built"（例如 #8960 的 verify 运行 31896086234，其失败日志显示的正是同样的 194607 字节）。

## 审阅者测试计划

### 如何验证

在本分支运行 `npm run build --workspace=packages/sdk-typescript`：构建成功，`wc -c packages/sdk-typescript/dist/daemon/index.js` 输出 194607 字节，在新的 191 KiB（195584 字节）预算下通过，余量 977 字节。transports（40029 字节）与 transcript（84485 字节）bundle 不受影响，仍在各自预算内。

### 前后对比证据

N/A —— 构建脚本常量修改，无用户可见行为变化。

修改前：`Error: Browser daemon SDK bundle is 194607 bytes; expected <= 194560`（main E2E 运行 31895887804、31896289341，以及 #9180 合并后所有 PR 的沙箱验证）。
修改后：实测 194607 字节的 bundle 在本地构建中通过。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 运行环境（可选）

在 origin/main（90f754e73e）加本改动的本地 `npm run build --workspace=packages/sdk-typescript`。

## 风险与范围

- 主要风险或权衡：预算增加 1 KiB，守卫仍能拦截未来的隐性膨胀。
- 未验证 / 不在范围内：精简 bundle 以收回这 47 字节——如需要可另开后续 PR。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

相关：#9180（引入体积增长）、#8960（verify 受牵连示例）。

</details>
