### PR TITLE
fix(sdk): raise the browser daemon bundle ceiling past the composer attachments

### DIFF
--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -87,7 +87,9 @@ const rootDir = join(__dirname, '..');
 // APIs merged in from main.
 // Bumped from 189KB to 190KB for historical branch sessions and transcript
 // branch-point projection merged with the upload and reasoning APIs.
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 190 * 1024;
+// Bumped from 190KB to 191KB for the composer's text file attachments (#9180),
+// which landed 47 bytes over the previous ceiling without moving it.
+const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 191 * 1024;
 // The opt-in `daemon/transports` browser bundle legitimately ships the concrete
 // ACP transports (AcpHttpTransport/AcpWsTransport/AutoReconnect + negotiate), so
 // it's larger than the default barrel — but still budgeted so a future PR can't


### PR DESCRIPTION
## What this PR does

Raises the browser daemon SDK bundle ceiling from 190KB to 191KB, and records why in the ledger of comments that constant carries.

## Why it's needed

The bundle has been 47 bytes over the ceiling since the composer's text file attachments landed, so `npm run build --workspace=packages/sdk-typescript` fails on `main` and on every branch cut from it. On a pull request that surfaces as two red gates — the Test job and the web-shell E2E smoke — neither of which has anything to do with the change under review.

The growth was bisected rather than assumed, because "a size gate is red" is exactly the kind of failure that gets attributed to whatever PR happens to be looking at it:

| commit | bundle |
| :----- | :----- |
| `5b125f0b89` — the commit before the attachments | passes |
| `34cc1c3ede` — the composer's text file attachments (#9180) | **194607 bytes** |
| every commit after it, including current `main` | 194607 bytes, byte-for-byte |

The identical byte count across unrelated later commits is itself the evidence that nothing since has contributed: the SDK package does not depend on what those changes touch. The ceiling is 194560.

Raising it is what the ledger above the constant records for every surface that legitimately grew — the same file-upload area is already the reason for the 186-to-188KB entry. This is a real surface, not something unintended pulled into a browser bundle.

The overshoot is 47 bytes, so 191KB leaves about 977 bytes of headroom. That is deliberately not generous: the next change to consume it should move the ceiling again and say what it bought, which is the whole point of keeping the ledger rather than a round number.

## Reviewer Test Plan

### How to verify

`npm run build --workspace=packages/sdk-typescript` fails on `main` and passes on this branch. Nothing else changes — the diff is one constant and two comment lines, and the bundle itself is untouched.

To confirm the attribution rather than take it on trust: check out `34cc1c3ede^`, build the SDK workspace, and it passes; check out `34cc1c3ede`, build again, and it reports 194607.

### Evidence (Before & After)

N/A — build-gate only, no user-visible change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local SDK workspace build under Node on Linux, at the four commits in the table above.

## Risk & Scope

- Main risk or tradeoff: a size ceiling exists to stop silent bloat, and raising it is the action that ceiling is designed to make deliberate. The mitigation is that the reason is recorded in the ledger and the headroom is small enough that the next growth has to be deliberate too.
- Not validated / out of scope: whether the attachments surface could be made smaller. That is worth asking of the feature, not of the gate that caught it, and it should not hold up unblocking every branch.
- Breaking changes / migration notes: none.

## Linked Issues

Unblocks CI on `main` and on every open branch cut from it. The growth came from #9180.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 daemon SDK 浏览器包的体积上限从 190KB 抬到 191KB,并在该常量所携带的那串历史记录里写明原因。

## 为什么需要

自从 composer 的文本文件附件合入以来,这个包一直**超出上限 47 字节**,因此 `npm run build --workspace=packages/sdk-typescript` 在 `main` 上以及所有从 main 切出的分支上都会失败。在 PR 上它表现为两个红色门禁——Test 作业和 web-shell E2E 冒烟——而两者都与被评审的改动毫无关系。

这次增长是**二分定位**出来的,而不是猜的,因为"体积门禁红了"恰恰是那种最容易被算到"正好在看的那个 PR"头上的失败:

| commit | 包体积 |
| :----- | :----- |
| `5b125f0b89` —— 附件功能之前的那个 commit | 通过 |
| `34cc1c3ede` —— composer 文本文件附件(#9180) | **194607 字节** |
| 其后每一个 commit,包括当前 `main` | 194607 字节,逐字节相同 |

在互不相关的后续 commit 上得到**完全相同**的字节数,本身就是"此后没有任何改动对它有贡献"的证据:SDK 包并不依赖那些改动所碰的文件。上限是 194560。

抬高上限正是该常量上方那串记录中,每一次"表面积合理增长"所采取的做法——同一块文件上传区域,本来就已经是 186→188KB 那一条的原因。这是真实的功能表面积,不是意外被拉进浏览器包的东西。

超出量是 47 字节,所以 191KB 留下约 977 字节余量。这个余量是**刻意不宽裕**的:下一个把它吃掉的改动应当再次移动上限并说明它换来了什么——这正是保留这串记录、而不是取一个整数的意义。

## 评审者测试计划

### 如何验证

`npm run build --workspace=packages/sdk-typescript` 在 `main` 上失败,在本分支通过。其余一切不变——diff 只有一个常量和两行注释,包本身未被触碰。

要核实归因而不是采信:检出 `34cc1c3ede^` 构建 SDK 工作区,通过;检出 `34cc1c3ede` 再构建,报 194607。

### 证据(前后对比)

N/A——仅构建门禁,无用户可见改动。

### 测试环境

|    操作系统    | 状态 |
| :------------: | :--: |
|  🍏 macOS      |  ⚠️  |
| 🪟 Windows     |  ⚠️  |
|  🐧 Linux      |  ✅  |

### 运行环境(可选)

Linux 上的 Node,在上表四个 commit 处分别构建 SDK 工作区。

## 风险与范围

- 主要风险或权衡:体积上限的存在就是为了阻止无声膨胀,而抬高它正是这个上限设计出来要求人**刻意为之**的那个动作。缓解方式是:原因写进了记录,且余量小到足以让下一次增长同样必须是刻意的。
- 未验证 / 范围之外:附件这块表面积能否做得更小。这个问题该向功能本身提,而不是向抓住它的门禁提,而且它不应该继续卡住所有分支。
- 破坏性改动 / 迁移说明:无。

## 关联 Issue

解除 `main` 及其所有开放分支的 CI 阻塞。增长来自 #9180。

</details>
