### PR TITLE
fix(ci): stop dropping agent settings in resolve and follow-up workflows

### DIFF
--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -81,6 +81,20 @@ const prReviewJob = prReviewDoc.jobs['review-pr'];
 const prReviewOwnershipStep = prReviewJob.steps.find(
   (s) => s.name === 'Restore workspace ownership',
 );
+const resolvePrJob = prReviewDoc.jobs['resolve-pr'];
+const resolveConflictsStep = resolvePrJob.steps.find(
+  (s) => s.id === 'resolve_conflicts',
+);
+const followupWorkflowPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'workflows',
+  'qwen-issue-followup-bot.yml',
+);
+const followupDoc = parse(readFileSync(followupWorkflowPath, 'utf8'));
+const followupStep = followupDoc.jobs['follow-up-issues'].steps.find(
+  (s) => s.name === 'Run Qwen issue follow-up',
+);
 const ciWebShellJob = ciDoc.jobs.web_shell_e2e_smoke;
 const ciWebShellOwnershipStep = ciWebShellJob.steps.find(
   (s) => s.name === 'Restore workspace ownership',
@@ -197,6 +211,104 @@ describe('qwen-triage: agent tool/permission settings', () => {
   });
 });
 
+// The same settings_json → settings bug survived in two more workflows after
+// the triage fix. An unknown action input is dropped without error, so the
+// /resolve agent ran every time with no turn cap, no tool allowlist, and no
+// sandbox — on a runner pool its runs-on comment chose specifically because
+// `sandbox: true` needs docker — and the follow-up bot ran uncapped too.
+// These blocks were therefore never validated by anything; parse them here.
+describe('qwen-code-pr-review.yml resolve-pr: agent settings', () => {
+  it('passes `settings:` (not the silently-dropped `settings_json:`)', () => {
+    assert.ok(
+      resolveConflictsStep,
+      'resolve-pr job must keep its resolve_conflicts agent step',
+    );
+    assert.ok(
+      typeof resolveConflictsStep.with.settings === 'string',
+      'resolve_conflicts must pass a `settings` string',
+    );
+    assert.equal(
+      resolveConflictsStep.with.settings_json,
+      undefined,
+      '`settings_json` is silently ignored by the action — never use it',
+    );
+  });
+
+  it('settings is valid JSON pinning the turn cap, allowlist, and sandbox', () => {
+    const settings = JSON.parse(resolveConflictsStep.with.settings);
+    assert.equal(
+      settings.model?.maxSessionTurns,
+      400,
+      'model.maxSessionTurns must stay 400',
+    );
+    const core = settings.tools?.core;
+    assert.ok(
+      Array.isArray(core),
+      'tools.core must be an array (registration allowlist)',
+    );
+    for (const t of [
+      'read_file',
+      'write_file',
+      'run_shell_command(git merge)',
+    ]) {
+      assert.ok(core.includes(t), `tools.core must include ${t}`);
+    }
+    // The runs-on comment pins this job to hosted runners because the sandbox
+    // needs docker; dropping the key would pay that routing cost for nothing.
+    assert.equal(
+      settings.tools?.sandbox,
+      true,
+      'tools.sandbox must stay true — the runs-on routing depends on it',
+    );
+    // v1 top-level keys only work through runtime migration; write the native
+    // v2 shape (qwen-triage.yml convention).
+    assert.equal(settings.coreTools, undefined);
+    assert.equal(settings.maxSessionTurns, undefined);
+    assert.equal(settings.sandbox, undefined);
+  });
+});
+
+describe('qwen-issue-followup-bot.yml: agent settings', () => {
+  it('passes `settings:` (not the silently-dropped `settings_json:`)', () => {
+    assert.ok(
+      followupStep,
+      'follow-up-issues job must keep its "Run Qwen issue follow-up" step',
+    );
+    assert.ok(
+      typeof followupStep.with.settings === 'string',
+      'the follow-up step must pass a `settings` string',
+    );
+    assert.equal(
+      followupStep.with.settings_json,
+      undefined,
+      '`settings_json` is silently ignored by the action — never use it',
+    );
+  });
+
+  it('settings is valid JSON pinning the turn cap and gh allowlist', () => {
+    const settings = JSON.parse(followupStep.with.settings);
+    assert.equal(
+      settings.model?.maxSessionTurns,
+      50,
+      'model.maxSessionTurns must stay 50',
+    );
+    const core = settings.tools?.core;
+    assert.ok(
+      Array.isArray(core),
+      'tools.core must be an array (registration allowlist)',
+    );
+    for (const t of [
+      'run_shell_command(gh issue view)',
+      'run_shell_command(gh issue comment)',
+    ]) {
+      assert.ok(core.includes(t), `tools.core must include ${t}`);
+    }
+    assert.equal(settings.coreTools, undefined);
+    assert.equal(settings.maxSessionTurns, undefined);
+    assert.equal(settings.sandbox, undefined);
+  });
+});
+
 describe('qwen-triage: fork-PR runner routing', () => {
   const runsOn = String(triageJob['runs-on']);
   const authorizeJob = doc.jobs.authorize;
@@ -219,7 +331,10 @@ describe('qwen-triage: fork-PR runner routing', () => {
   it('keeps the authorize gate itself on the same-repo guard', () => {
     // authorize IS the permission check (and loads CI_BOT_PAT); it cannot
     // route on its own output and must not widen to association-based trust.
-    assert.match(authorizeRunsOn, /head\.repo\.full_name == github\.repository/);
+    assert.match(
+      authorizeRunsOn,
+      /head\.repo\.full_name == github\.repository/,
+    );
     assert.doesNotMatch(authorizeRunsOn, /author_association/);
     assert.doesNotMatch(authorizeRunsOn, /needs\./);
   });
@@ -651,8 +766,14 @@ describe('qwen-triage: npm cache restore-only invariant', () => {
       const restoreIdx = jobDef.steps.findIndex(
         (s) => s.name === 'Restore npm cache',
       );
-      assert.ok(clearIdx !== -1, `'Clear stale npm cache' step must exist in ${jobName}`);
-      assert.ok(restoreIdx !== -1, `'Restore npm cache' step must exist in ${jobName}`);
+      assert.ok(
+        clearIdx !== -1,
+        `'Clear stale npm cache' step must exist in ${jobName}`,
+      );
+      assert.ok(
+        restoreIdx !== -1,
+        `'Restore npm cache' step must exist in ${jobName}`,
+      );
       assert.ok(
         clearIdx < restoreIdx,
         'clear step must come before restore step',
@@ -708,8 +829,8 @@ describe('qwen-triage: npm cache producer workflow', () => {
   });
 
   it('saves with the same key and path the triage lanes restore', () => {
-    const saveStep = saveJob.steps.find(
-      (s) => s.uses?.startsWith('actions/cache/save@'),
+    const saveStep = saveJob.steps.find((s) =>
+      s.uses?.startsWith('actions/cache/save@'),
     );
     assert.ok(saveStep, 'must have an actions/cache/save step');
     for (const [jobName, jobDef] of [
@@ -733,8 +854,8 @@ describe('qwen-triage: npm cache producer workflow', () => {
   });
 
   it('populates the cache directory it saves', () => {
-    const saveStep = saveJob.steps.find(
-      (s) => s.uses?.startsWith('actions/cache/save@'),
+    const saveStep = saveJob.steps.find((s) =>
+      s.uses?.startsWith('actions/cache/save@'),
     );
     assert.ok(saveStep, 'must have an actions/cache/save step');
     const dir = saveStep.with.path.replace(

--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -145,22 +145,41 @@ const assertUnconditional = (jobSteps, step, label) => {
   );
 };
 
+// Unknown action inputs are dropped without error — that is how the
+// settings_json bug survived in three workflows. Every agent step must pass
+// this contract before its settings are even read; callers pin their own
+// values on the returned object.
+const assertSettingsContract = (step, label) => {
+  assert.ok(step, `${label} must keep its agent step`);
+  assert.ok(
+    typeof step.with?.settings === 'string',
+    `${label} must pass a \`settings\` string`,
+  );
+  assert.equal(
+    step.with.settings_json,
+    undefined,
+    `${label}: \`settings_json\` is silently ignored by the action — never use it`,
+  );
+  const settings = JSON.parse(step.with.settings);
+  // v1 top-level keys only work through runtime migration; write the native
+  // v2 shape (the qwen-triage.yml convention).
+  for (const key of ['coreTools', 'maxSessionTurns', 'sandbox']) {
+    assert.equal(
+      settings[key],
+      undefined,
+      `${label}: v1 top-level \`${key}\` is a legacy key — use the v2 shape`,
+    );
+  }
+  return settings;
+};
+
 describe('qwen-triage: agent tool/permission settings', () => {
   it('passes `settings:` (not the silently-dropped `settings_json:`)', () => {
-    assert.ok(triageStep, 'triage step (id: triage) must exist');
-    assert.ok(
-      typeof triageStep.with.settings === 'string',
-      'triage step must pass a `settings` string',
-    );
-    assert.equal(
-      triageStep.with.settings_json,
-      undefined,
-      '`settings_json` is silently ignored by the action — never use it',
-    );
+    assertSettingsContract(triageStep, 'triage step (id: triage)');
   });
 
   it('settings is valid JSON that restricts the toolset', () => {
-    const settings = JSON.parse(triageStep.with.settings);
+    const settings = assertSettingsContract(triageStep, 'triage settings');
     const core = settings.tools?.core;
     assert.ok(
       Array.isArray(core),
@@ -189,7 +208,8 @@ describe('qwen-triage: agent tool/permission settings', () => {
   });
 
   it('settings denies interpreters, network, and PR-code-materializing git/gh', () => {
-    const deny = JSON.parse(triageStep.with.settings).permissions?.deny ?? [];
+    const settings = assertSettingsContract(triageStep, 'triage settings');
+    const deny = settings.permissions?.deny ?? [];
     for (const d of [
       'run_shell_command(node)',
       'run_shell_command(npm)',
@@ -204,7 +224,7 @@ describe('qwen-triage: agent tool/permission settings', () => {
     // No sandbox key: the ECS pool ships no container runtime, and adding one
     // would silently disable the step.
     assert.equal(
-      JSON.parse(triageStep.with.settings).sandbox,
+      settings.sandbox,
       undefined,
       'settings must not set a sandbox key',
     );
@@ -219,23 +239,14 @@ describe('qwen-triage: agent tool/permission settings', () => {
 // These blocks were therefore never validated by anything; parse them here.
 describe('qwen-code-pr-review.yml resolve-pr: agent settings', () => {
   it('passes `settings:` (not the silently-dropped `settings_json:`)', () => {
-    assert.ok(
-      resolveConflictsStep,
-      'resolve-pr job must keep its resolve_conflicts agent step',
-    );
-    assert.ok(
-      typeof resolveConflictsStep.with.settings === 'string',
-      'resolve_conflicts must pass a `settings` string',
-    );
-    assert.equal(
-      resolveConflictsStep.with.settings_json,
-      undefined,
-      '`settings_json` is silently ignored by the action — never use it',
-    );
+    assertSettingsContract(resolveConflictsStep, 'resolve_conflicts');
   });
 
   it('settings is valid JSON pinning the turn cap, allowlist, and sandbox', () => {
-    const settings = JSON.parse(resolveConflictsStep.with.settings);
+    const settings = assertSettingsContract(
+      resolveConflictsStep,
+      'resolve_conflicts',
+    );
     assert.equal(
       settings.model?.maxSessionTurns,
       400,
@@ -248,6 +259,9 @@ describe('qwen-code-pr-review.yml resolve-pr: agent settings', () => {
     );
     for (const t of [
       'read_file',
+      'read_many_files',
+      'glob',
+      'search_file_content',
       'write_file',
       'run_shell_command(git merge)',
     ]) {
@@ -260,33 +274,26 @@ describe('qwen-code-pr-review.yml resolve-pr: agent settings', () => {
       true,
       'tools.sandbox must stay true — the runs-on routing depends on it',
     );
-    // v1 top-level keys only work through runtime migration; write the native
-    // v2 shape (qwen-triage.yml convention).
-    assert.equal(settings.coreTools, undefined);
-    assert.equal(settings.maxSessionTurns, undefined);
-    assert.equal(settings.sandbox, undefined);
+  });
+
+  it('keeps resolve-pr on hosted runners (sandbox: true needs docker)', () => {
+    // The routing half of the sandbox coupling: the ECS pool ships no
+    // container runtime, so an ECS-routed sandboxed agent dies at startup.
+    assert.equal(
+      resolvePrJob['runs-on'],
+      'ubuntu-latest',
+      'resolve-pr must stay on hosted runners — sandbox: true needs docker, absent on the ECS pool',
+    );
   });
 });
 
 describe('qwen-issue-followup-bot.yml: agent settings', () => {
   it('passes `settings:` (not the silently-dropped `settings_json:`)', () => {
-    assert.ok(
-      followupStep,
-      'follow-up-issues job must keep its "Run Qwen issue follow-up" step',
-    );
-    assert.ok(
-      typeof followupStep.with.settings === 'string',
-      'the follow-up step must pass a `settings` string',
-    );
-    assert.equal(
-      followupStep.with.settings_json,
-      undefined,
-      '`settings_json` is silently ignored by the action — never use it',
-    );
+    assertSettingsContract(followupStep, 'the follow-up step');
   });
 
   it('settings is valid JSON pinning the turn cap and gh allowlist', () => {
-    const settings = JSON.parse(followupStep.with.settings);
+    const settings = assertSettingsContract(followupStep, 'the follow-up step');
     assert.equal(
       settings.model?.maxSessionTurns,
       50,
@@ -303,9 +310,14 @@ describe('qwen-issue-followup-bot.yml: agent settings', () => {
     ]) {
       assert.ok(core.includes(t), `tools.core must include ${t}`);
     }
-    assert.equal(settings.coreTools, undefined);
-    assert.equal(settings.maxSessionTurns, undefined);
-    assert.equal(settings.sandbox, undefined);
+    // follow-up-issues routes to the self-hosted ECS pool by default, which
+    // ships no container runtime; sandbox: true would kill the agent at
+    // startup (exit 44) on every ECS-routed run.
+    assert.equal(
+      settings.tools?.sandbox,
+      false,
+      'tools.sandbox must stay false — the ECS pool has no container runtime',
+    );
   });
 });
 

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1934,31 +1934,40 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
-          # coreTools specifiers (e.g. `run_shell_command(git add)`) are advisory:
+          # The input name is `settings` — this action version has no
+          # `settings_json` input, and an unknown input is silently dropped.
+          # That is exactly what happened to this block: every /resolve run so
+          # far ignored it, and the agent ran without the turn cap, toolset
+          # allowlist, or the sandbox the runs-on comment above assumes.
+          # tools.core specifiers (e.g. `run_shell_command(git add)`) are advisory:
           # the permission manager keys on the tool name and drops the parenthesised
           # command. Real containment = sandbox + write authorization + no agent token.
-          settings_json: |-
+          settings: |-
             {
-              "maxSessionTurns": 400,
-              "coreTools": [
-                "read_file",
-                "read_many_files",
-                "glob",
-                "search_file_content",
-                "write_file",
-                "run_shell_command(cat)",
-                "run_shell_command(git add)",
-                "run_shell_command(git checkout)",
-                "run_shell_command(git commit)",
-                "run_shell_command(git diff)",
-                "run_shell_command(git log)",
-                "run_shell_command(git merge)",
-                "run_shell_command(git status)",
-                "run_shell_command(ls)",
-                "run_shell_command(mkdir)",
-                "run_shell_command(pwd)"
-              ],
-              "sandbox": true
+              "model": {
+                "maxSessionTurns": 400
+              },
+              "tools": {
+                "core": [
+                  "read_file",
+                  "read_many_files",
+                  "glob",
+                  "search_file_content",
+                  "write_file",
+                  "run_shell_command(cat)",
+                  "run_shell_command(git add)",
+                  "run_shell_command(git checkout)",
+                  "run_shell_command(git commit)",
+                  "run_shell_command(git diff)",
+                  "run_shell_command(git log)",
+                  "run_shell_command(git merge)",
+                  "run_shell_command(git status)",
+                  "run_shell_command(ls)",
+                  "run_shell_command(mkdir)",
+                  "run_shell_command(pwd)"
+                ],
+                "sandbox": true
+              }
             }
           prompt: |-
             ## Role

--- a/.github/workflows/qwen-issue-followup-bot.yml
+++ b/.github/workflows/qwen-issue-followup-bot.yml
@@ -297,17 +297,24 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
-          settings_json: |-
+          # The input name is `settings` — this action version has no
+          # `settings_json` input, and an unknown input is silently dropped,
+          # which is what happened to this block until the rename.
+          settings: |-
             {
-              "maxSessionTurns": 50,
-              "coreTools": [
-                "run_shell_command(gh issue view)",
-                "run_shell_command(gh issue list)",
-                "run_shell_command(gh label list)",
-                "run_shell_command(gh issue edit)",
-                "run_shell_command(gh issue comment)"
-              ],
-              "sandbox": false
+              "model": {
+                "maxSessionTurns": 50
+              },
+              "tools": {
+                "core": [
+                  "run_shell_command(gh issue view)",
+                  "run_shell_command(gh issue list)",
+                  "run_shell_command(gh label list)",
+                  "run_shell_command(gh issue edit)",
+                  "run_shell_command(gh issue comment)"
+                ],
+                "sandbox": false
+              }
             }
           prompt: |-
             ## Role

--- a/scripts/tests/ci-flaky-rerun-workflow.test.js
+++ b/scripts/tests/ci-flaky-rerun-workflow.test.js
@@ -116,6 +116,23 @@ describe('ci failure patrol workflow', () => {
     expect(JSON.stringify(yml.jobs.act)).toContain('CI_BOT_PAT');
   });
 
+  it('passes `settings:` pinning the sandbox and the two-tool allowlist', () => {
+    // Unknown `with:` keys (like the old `settings_json`) are dropped by the
+    // action without error, which would silently strip the patrol agent's
+    // sandbox and two-tool allowlist.
+    const classifier = yml.jobs.classify.steps.find((step) =>
+      step.uses?.includes('qwen-code-action'),
+    );
+    expect(typeof classifier.with.settings).toBe('string');
+    expect(classifier.with.settings_json).toBeUndefined();
+    const settings = JSON.parse(classifier.with.settings);
+    for (const key of ['coreTools', 'maxSessionTurns', 'sandbox']) {
+      expect(settings[key]).toBeUndefined();
+    }
+    expect(settings.tools?.sandbox).toBe(true);
+    expect(settings.tools?.core).toEqual(['read_file', 'write_file']);
+  });
+
   it('passes a decision batch through a trusted act job and always resets', () => {
     expect(yml.jobs.classify.outputs).toHaveProperty('bot_login');
     expect(workflow).toContain('ci-flaky-decisions.json');


### PR DESCRIPTION
## What this PR does

Two automation workflows configure their agents through an input that the pinned action version does not declare, so every run silently dropped the configuration. This PR passes the configuration through the input the action actually declares, rewrites it in the current settings shape, and pins the fix with regression tests. The same class of bug was already fixed in the triage workflow; this cleans up the two survivors.

## Why it's needed

The action ignores unknown inputs with only a log annotation, so nothing ever failed: the conflict-resolution agent ran every time with no turn cap, no tool allowlist, and no sandbox — on a runner pool its own routing comment chose specifically because the sandbox needs docker — and the issue follow-up bot ran uncapped too. Because the blocks were never consumed, they were never validated by anything either; they were written in a legacy settings shape that only works through runtime migration.

Observed in the wild: the `Unexpected input(s) 'settings_json'` annotation on [run 31914459221](https://github.com/QwenLM/qwen-code/actions/runs/31914459221).

## Reviewer Test Plan

### How to verify

Run the workflow regression suite from the repo root: `node --test .github/scripts/qwen-triage-workflow.test.mjs` — 60 tests pass, four of them new: they pin that both agent steps pass the declared input, never the dropped one, and that the JSON parses with the turn caps, allowlists, and sandbox flag intact. Mutation check: renaming the input back makes the new suites fail. `actionlint` is clean on both workflows. Behaviorally, the next real conflict-resolution run is the first time these settings take effect — the agent starts inside a sandbox; if sandbox startup fails it reports exit 44 loudly with a PR comment rather than degrading silently.

### Evidence (Before & After)

N/A (workflow plumbing; no user-visible UI)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment

Local `node --test` for the workflow regression suite; actionlint for workflow syntax.

## Risk & Scope

- Main risk or tradeoff: the settings take effect for the first time — conflict resolution now runs sandboxed, turn-capped, and allowlisted as originally designed. The next /resolve run is the sandbox path's first live exercise; a startup problem surfaces as an explicit failure comment instead of the old silent no-config run.
- Not validated / out of scope: a full live /resolve run (needs a PR with real conflicts); other workflows write their settings file directly in shell and use a different mechanism, unaffected.
- Breaking changes / migration notes: none.

## Linked Issues

Spotted while investigating the npm registry blip in run 31914459221; no tracking issue.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

有两个自动化工作流通过 pin 的 action 版本并未声明的输入来配置其 agent，导致每次运行都静默丢弃了这份配置。本 PR 改为通过 action 实际声明的输入传递配置，将其改写为当前的 settings 结构，并用回归测试锁定该修复。同类 bug 此前已在 triage 工作流中修复过，本次清理的是剩余的两处。

## 为什么需要

action 对未知输入只打一条日志 annotation 而不报错，因此从未有任何东西失败过：冲突解决 agent 每次运行都没有 turn 上限、没有工具白名单、也没有 sandbox——而它所在 runner 池的路由注释恰恰是专门为了 sandbox 需要 docker 而选定的；issue 跟进 bot 也同样在没有上限的情况下运行。由于这些配置块从未被消费，它们也从未被任何东西校验过：其内容是旧版 settings 结构，只有依赖运行时迁移才能生效。

线上实例：[run 31914459221](https://github.com/QwenLM/qwen-code/actions/runs/31914459221) 中的 `Unexpected input(s) 'settings_json'` annotation。

### 如何验证

从仓库根目录运行工作流回归测试套件：`node --test .github/scripts/qwen-triage-workflow.test.mjs` —— 60 个测试全部通过，其中 4 个为新增：锁定两个 agent step 必须使用已声明的输入、绝不使用被丢弃的那个，且 JSON 可解析、turn 上限、白名单与 sandbox 标志保持不变。变异验证：把输入名改回去，新增套件会失败。两个工作流文件的 actionlint 检查干净。行为上，下一次真实的冲突解决运行将是这些配置首次生效——agent 会在 sandbox 中启动；若 sandbox 启动失败，会以 exit 44 显式报错并在 PR 上评论，而不是静默降级。

### 证据（Before & After）

N/A（工作流管道改动，无用户可见 UI）

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境

本地用 `node --test` 运行工作流回归测试套件；用 actionlint 校验工作流语法。

## 风险与范围

- 主要风险或权衡：这些配置首次真正生效——冲突解决现在按原始设计在 sandbox 中、带 turn 上限和工具白名单运行。下一次 /resolve 运行将是 sandbox 路径的首次实战；若启动出现问题，会以显式失败评论呈现，而非旧有的静默无配置运行。
- 未验证 / 超出范围：完整的 /resolve 实战运行（需要一个真实存在冲突的 PR）；其他工作流通过 shell 直接写 settings 文件，机制不同，不受影响。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

在排查 run 31914459221 的 npm registry 瞬时故障时发现；无对应跟踪 issue。

</details>
