### PR TITLE
fix(web-shell): show a boot fallback instead of a white screen

### DIFF
--- a/packages/web-shell/client/boot-watchdog.test.ts
+++ b/packages/web-shell/client/boot-watchdog.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function installBootWatchdog(): void {
+  const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
+  const script = Array.from(
+    html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
+  )
+    .map((match) => match[1] ?? '')
+    .find((source) => source.includes('data-boot-fallback'));
+
+  if (!script) throw new Error('Boot watchdog script not found');
+  new Function(script)();
+}
+
+function fallback(): Element | null {
+  return document.querySelector('[data-boot-fallback]');
+}
+
+describe('boot watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  it('shows the fallback when a module script fails to load', () => {
+    installBootWatchdog();
+    const script = document.createElement('script');
+    script.src = 'http://localhost:5173/main.tsx';
+    document.body.appendChild(script);
+
+    script.dispatchEvent(
+      new ErrorEvent('error', {
+        message: 'Failed to load resource: 504 (Outdated Optimize Dep)',
+        bubbles: true,
+      }),
+    );
+
+    const box = fallback();
+    expect(box).not.toBeNull();
+    expect(box?.textContent).toContain('Web Shell 加载失败');
+    expect(box?.textContent).toContain('504 (Outdated Optimize Dep)');
+    expect(box?.querySelector('button')?.textContent).toContain('Reload');
+  });
+
+  it('shows the fallback when the app never mounts within the grace period', () => {
+    installBootWatchdog();
+    expect(fallback()).toBeNull();
+
+    vi.advanceTimersByTime(15_001);
+
+    const box = fallback();
+    expect(box).not.toBeNull();
+    expect(box?.textContent).toContain('did not start');
+  });
+
+  it('stays silent once the app has mounted', () => {
+    installBootWatchdog();
+    const app = document.createElement('div');
+    app.setAttribute('data-app', '');
+    document.getElementById('root')?.appendChild(app);
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(fallback()).toBeNull();
+  });
+});

--- a/packages/web-shell/client/boot-watchdog.test.ts
+++ b/packages/web-shell/client/boot-watchdog.test.ts
@@ -1,22 +1,26 @@
 // @vitest-environment jsdom
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractInlineScript } from './index-html-test-utils';
 
 function installBootWatchdog(): void {
-  const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
-  const script = Array.from(
-    html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
-  )
-    .map((match) => match[1] ?? '')
-    .find((source) => source.includes('data-boot-fallback'));
-
-  if (!script) throw new Error('Boot watchdog script not found');
-  new Function(script)();
+  new Function(extractInlineScript('data-boot-fallback'))();
 }
 
 function fallback(): Element | null {
   return document.querySelector('[data-boot-fallback]');
+}
+
+function resourceErrorEvent(src: string, message?: string): Event {
+  const script = document.createElement('script');
+  script.src = src;
+  document.body.appendChild(script);
+  // Real resource-load failures fire a bare, non-bubbling Event; the
+  // watchdog listens in the capture phase precisely so it still sees them.
+  const event = message
+    ? new ErrorEvent('error', { message })
+    : new Event('error');
+  script.dispatchEvent(event);
+  return event;
 }
 
 describe('boot watchdog', () => {
@@ -27,22 +31,60 @@ describe('boot watchdog', () => {
 
   it('shows the fallback when a module script fails to load', () => {
     installBootWatchdog();
-    const script = document.createElement('script');
-    script.src = 'http://localhost:5173/main.tsx';
-    document.body.appendChild(script);
-
-    script.dispatchEvent(
-      new ErrorEvent('error', {
-        message: 'Failed to load resource: 504 (Outdated Optimize Dep)',
-        bubbles: true,
-      }),
+    resourceErrorEvent(
+      'http://localhost:5173/main.tsx',
+      'Failed to load resource: 504 (Outdated Optimize Dep)',
     );
 
     const box = fallback();
     expect(box).not.toBeNull();
     expect(box?.textContent).toContain('Web Shell 加载失败');
     expect(box?.textContent).toContain('504 (Outdated Optimize Dep)');
+    expect(box?.textContent).toContain('http://localhost:5173/main.tsx');
     expect(box?.querySelector('button')?.textContent).toContain('Reload');
+  });
+
+  it('shows the fallback for a message-less resource error event', () => {
+    installBootWatchdog();
+    resourceErrorEvent('http://localhost:5173/main.tsx');
+
+    const box = fallback();
+    expect(box).not.toBeNull();
+    expect(box?.textContent).toContain('http://localhost:5173/main.tsx');
+  });
+
+  it('captures pre-fallback errors and rejections in the panel', () => {
+    installBootWatchdog();
+    window.dispatchEvent(
+      new ErrorEvent('error', { message: 'second failure' }),
+    );
+    const rejection = new Event('unhandledrejection');
+    Object.defineProperty(rejection, 'reason', {
+      value: new Error('rejection reason'),
+    });
+    window.dispatchEvent(rejection);
+    resourceErrorEvent('http://localhost:5173/main.tsx');
+
+    const pre = fallback()?.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('second failure');
+    expect(pre?.textContent).toContain('rejection reason');
+  });
+
+  it('keeps the specific early reason when the grace timer later fires', () => {
+    installBootWatchdog();
+    resourceErrorEvent(
+      'http://localhost:5173/main.tsx',
+      'Failed to load resource: 504 (Outdated Optimize Dep)',
+    );
+    expect(fallback()?.textContent).toContain('504 (Outdated Optimize Dep)');
+
+    vi.advanceTimersByTime(15_001);
+
+    // The specific resource reason must not be overwritten by the generic
+    // timeout copy.
+    expect(fallback()?.textContent).toContain('504 (Outdated Optimize Dep)');
+    expect(fallback()?.textContent).not.toContain('did not start within');
   });
 
   it('shows the fallback when the app never mounts within the grace period', () => {
@@ -54,6 +96,18 @@ describe('boot watchdog', () => {
     const box = fallback();
     expect(box).not.toBeNull();
     expect(box?.textContent).toContain('did not start');
+  });
+
+  it('does not clobber the app when a resource fails after mount', () => {
+    installBootWatchdog();
+    const app = document.createElement('div');
+    app.setAttribute('data-app', '');
+    document.getElementById('root')?.appendChild(app);
+
+    resourceErrorEvent('http://localhost:5173/lazy-chunk.tsx');
+
+    expect(fallback()).toBeNull();
+    expect(document.getElementById('root')?.firstElementChild).toBe(app);
   });
 
   it('stays silent once the app has mounted', () => {

--- a/packages/web-shell/client/index-html-test-utils.ts
+++ b/packages/web-shell/client/index-html-test-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Extract an inline `<script>` body from `client/index.html` by a marker
+ * substring. Shared by the inline-script unit tests so the HTML-parsing
+ * logic lives in one place.
+ */
+export function extractInlineScript(marker: string): string {
+  const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
+  const script = Array.from(
+    html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
+  )
+    .map((match) => match[1] ?? '')
+    .find((source) => source.includes(marker));
+
+  if (!script) throw new Error(`Inline script not found: ${marker}`);
+  return script;
+}

--- a/packages/web-shell/client/index-html.test.ts
+++ b/packages/web-shell/client/index-html.test.ts
@@ -1,19 +1,10 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { extractInlineScript } from './index-html-test-utils';
 
 function installMeasureGuard(
   measure: (...args: unknown[]) => unknown,
 ): Performance {
-  const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
-  const script = Array.from(
-    html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
-  )
-    .map((match) => match[1] ?? '')
-    .find((source) => source.includes('performance.measure ='));
-
-  if (!script) throw new Error('Performance measure guard not found');
-
+  const script = extractInlineScript('performance.measure =');
   const performance = { measure };
   Function('performance', 'DOMException', script)(performance, DOMException);
   return performance as Performance;

--- a/packages/web-shell/client/index.html
+++ b/packages/web-shell/client/index.html
@@ -27,7 +27,27 @@
       THEME_STORAGE_KEY in main.tsx.
     -->
     <script>
-      !function(){try{var k='qwen-code-web-shell-theme',p=new URLSearchParams(location.search),t=p.get('theme');if(t!=='dark'&&t!=='light'){try{t=localStorage.getItem(k)}catch(_){t=null}}if(t!=='dark'&&t!=='light')t='dark';document.documentElement.classList.add('theme-'+t);var m=document.querySelector('meta[name=theme-color]');if(m)m.setAttribute('content',t==='light'?'#ffffff':'#0d0d0d')}catch(e){console.warn('theme-init:',e)}}();
+      !(function () {
+        try {
+          var k = 'qwen-code-web-shell-theme',
+            p = new URLSearchParams(location.search),
+            t = p.get('theme');
+          if (t !== 'dark' && t !== 'light') {
+            try {
+              t = localStorage.getItem(k);
+            } catch (_) {
+              t = null;
+            }
+          }
+          if (t !== 'dark' && t !== 'light') t = 'dark';
+          document.documentElement.classList.add('theme-' + t);
+          var m = document.querySelector('meta[name=theme-color]');
+          if (m)
+            m.setAttribute('content', t === 'light' ? '#ffffff' : '#0d0d0d');
+        } catch (e) {
+          console.warn('theme-init:', e);
+        }
+      })();
     </script>
     <!--
       Favicon is inlined as a data: URI rather than a /favicon.svg file because
@@ -71,6 +91,108 @@
           }
           return m.apply(this, arguments);
         };
+      })();
+    </script>
+    <!--
+      Boot watchdog: when the app never mounts (a dev-server restart
+      invalidating module URLs mid-load, the daemon unreachable, a rotated
+      auth token, ...) the page would otherwise stay blank with no way to
+      recover. After a grace period — or immediately when a script/module
+      resource fails — render a visible, theme-aware fallback that shows the
+      captured errors and a reload action. Kept dependency-free ES5 so it
+      runs even if every module import fails.
+    -->
+    <script>
+      !(function () {
+        var GRACE_MS = 15000;
+        var errors = [];
+        function rootEl() {
+          return document.getElementById('root');
+        }
+        function appMounted() {
+          var r = rootEl();
+          return !!(
+            r &&
+            r.firstElementChild &&
+            !r.firstElementChild.hasAttribute('data-boot-fallback')
+          );
+        }
+        function show(reason) {
+          var r = rootEl();
+          if (!r || appMounted()) return;
+          var dark = document.documentElement.classList.contains('theme-dark');
+          var box = document.createElement('div');
+          box.setAttribute('data-boot-fallback', '');
+          box.style.cssText =
+            'min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;padding:24px;box-sizing:border-box;font-family:system-ui,sans-serif;text-align:center;background:' +
+            (dark ? '#0d0d0d' : '#ffffff') +
+            ';color:' +
+            (dark ? '#e5e5e5' : '#1a1a1a');
+          var h = document.createElement('h1');
+          h.style.cssText = 'font-size:18px;margin:0';
+          h.textContent = 'Web Shell 加载失败 / failed to load';
+          var p = document.createElement('p');
+          p.style.cssText =
+            'margin:0;font-size:13px;opacity:.75;max-width:560px';
+          p.textContent = reason;
+          box.appendChild(h);
+          box.appendChild(p);
+          if (errors.length) {
+            var pre = document.createElement('pre');
+            pre.style.cssText =
+              'margin:0;font-size:11px;opacity:.6;max-width:720px;max-height:160px;overflow:auto;text-align:left;white-space:pre-wrap';
+            pre.textContent = errors.slice(0, 5).join('\n');
+            box.appendChild(pre);
+          }
+          var btn = document.createElement('button');
+          btn.textContent = '重新加载 / Reload';
+          btn.style.cssText =
+            'padding:8px 20px;border-radius:8px;border:1px solid ' +
+            (dark ? '#444' : '#ccc') +
+            ';background:' +
+            (dark ? '#222' : '#f5f5f5') +
+            ';color:inherit;font-size:14px;cursor:pointer';
+          btn.addEventListener('click', function () {
+            location.reload();
+          });
+          box.appendChild(btn);
+          r.textContent = '';
+          r.appendChild(box);
+        }
+        window.addEventListener(
+          'error',
+          function (e) {
+            var t = e && e.target;
+            var msg = (e && e.message) || 'unknown error';
+            if (t && (t.tagName === 'SCRIPT' || t.tagName === 'LINK')) {
+              msg += ' (' + (t.src || t.href || '') + ')';
+              show(
+                'A required resource failed to load: ' +
+                  msg +
+                  '. This usually happens right after a dev-server or daemon restart — reload the page.',
+              );
+            }
+            errors.push(msg);
+          },
+          true,
+        );
+        window.addEventListener('unhandledrejection', function (e) {
+          var reason = e && e.reason;
+          errors.push(
+            String(
+              (reason && reason.message) || reason || 'unhandled rejection',
+            ),
+          );
+        });
+        setTimeout(function () {
+          if (!appMounted()) {
+            show(
+              'The app did not start within ' +
+                GRACE_MS / 1000 +
+                's. The daemon may be restarting or its access token may have rotated — reload the page.',
+            );
+          }
+        }, GRACE_MS);
       })();
     </script>
     <div id="root"></div>

--- a/packages/web-shell/client/index.html
+++ b/packages/web-shell/client/index.html
@@ -98,16 +98,31 @@
       invalidating module URLs mid-load, the daemon unreachable, a rotated
       auth token, ...) the page would otherwise stay blank with no way to
       recover. After a grace period — or immediately when a script/module
-      resource fails — render a visible, theme-aware fallback that shows the
-      captured errors and a reload action. Kept dependency-free ES5 so it
-      runs even if every module import fails.
+      resource fails or boot throws — render a visible, theme-aware fallback
+      that shows the captured errors and a reload action. Kept
+      dependency-free ES5 so it runs even if every module import fails.
+
+      Invariant: #root must stay empty until React mounts. Mount detection
+      keys off "first child that is not the fallback box", so a static child
+      (e.g. a boot spinner) would read as mounted and disable the watchdog;
+      keep #root empty in index.html. Once a real mount is observed the
+      watchdog uninstalls itself (listeners, timer, observer) and releases
+      its captured errors; the fallback box, once shown, is sticky so a late
+      timer never overwrites a more specific earlier reason.
     -->
     <script>
       !(function () {
         var GRACE_MS = 15000;
+        var MAX_ERRORS = 5;
         var errors = [];
+        var timer = null;
+        var observer = null;
         function rootEl() {
           return document.getElementById('root');
+        }
+        function fallbackPresent() {
+          var r = rootEl();
+          return !!(r && r.querySelector('[data-boot-fallback]'));
         }
         function appMounted() {
           var r = rootEl();
@@ -117,9 +132,25 @@
             !r.firstElementChild.hasAttribute('data-boot-fallback')
           );
         }
+        function pushError(msg) {
+          if (errors.length < MAX_ERRORS) errors.push(msg);
+        }
+        function uninstall() {
+          if (timer !== null) {
+            clearTimeout(timer);
+            timer = null;
+          }
+          if (observer) {
+            observer.disconnect();
+            observer = null;
+          }
+          window.removeEventListener('error', onError, true);
+          window.removeEventListener('unhandledrejection', onRejection);
+          errors.length = 0;
+        }
         function show(reason) {
           var r = rootEl();
-          if (!r || appMounted()) return;
+          if (!r || appMounted() || fallbackPresent()) return;
           var dark = document.documentElement.classList.contains('theme-dark');
           var box = document.createElement('div');
           box.setAttribute('data-boot-fallback', '');
@@ -141,7 +172,7 @@
             var pre = document.createElement('pre');
             pre.style.cssText =
               'margin:0;font-size:11px;opacity:.6;max-width:720px;max-height:160px;overflow:auto;text-align:left;white-space:pre-wrap';
-            pre.textContent = errors.slice(0, 5).join('\n');
+            pre.textContent = errors.slice(0, MAX_ERRORS).join('\n');
             box.appendChild(pre);
           }
           var btn = document.createElement('button');
@@ -159,32 +190,47 @@
           r.textContent = '';
           r.appendChild(box);
         }
-        window.addEventListener(
-          'error',
-          function (e) {
-            var t = e && e.target;
-            var msg = (e && e.message) || 'unknown error';
-            if (t && (t.tagName === 'SCRIPT' || t.tagName === 'LINK')) {
-              msg += ' (' + (t.src || t.href || '') + ')';
-              show(
-                'A required resource failed to load: ' +
-                  msg +
-                  '. This usually happens right after a dev-server or daemon restart — reload the page.',
-              );
-            }
-            errors.push(msg);
-          },
-          true,
-        );
-        window.addEventListener('unhandledrejection', function (e) {
+        function onError(e) {
+          var t = e && e.target;
+          var isResource = !!(
+            t &&
+            (t.tagName === 'SCRIPT' || t.tagName === 'LINK')
+          );
+          var msg = (e && e.message) || 'unknown error';
+          if (isResource) msg += ' (' + (t.src || t.href || '') + ')';
+          pushError(msg);
+          if (appMounted()) return;
+          // Only a resource/module failure proves boot is impossible right
+          // now, so show immediately for those. Runtime errors and
+          // rejections are captured and surfaced by the grace timer (or by
+          // a later resource failure) so a burst of boot errors accumulates
+          // in the panel instead of being truncated to the first one.
+          if (isResource) {
+            show(
+              'A required resource failed to load: ' +
+                msg +
+                '. This usually happens right after a dev-server or daemon restart — reload the page.',
+            );
+          }
+        }
+        function onRejection(e) {
           var reason = e && e.reason;
-          errors.push(
+          pushError(
             String(
               (reason && reason.message) || reason || 'unhandled rejection',
             ),
           );
-        });
-        setTimeout(function () {
+        }
+        window.addEventListener('error', onError, true);
+        window.addEventListener('unhandledrejection', onRejection);
+        var root = rootEl();
+        if (root && typeof MutationObserver !== 'undefined') {
+          observer = new MutationObserver(function () {
+            if (appMounted()) uninstall();
+          });
+          observer.observe(root, { childList: true });
+        }
+        timer = setTimeout(function () {
           if (!appMounted()) {
             show(
               'The app did not start within ' +
@@ -192,6 +238,7 @@
                 's. The daemon may be restarting or its access token may have rotated — reload the page.',
             );
           }
+          if (appMounted()) uninstall();
         }, GRACE_MS);
       })();
     </script>


### PR DESCRIPTION
## What this PR does

Adds a dependency-free boot watchdog to the Web Shell's `index.html`. If a script or stylesheet resource fails to load, it immediately renders a visible, theme-aware, bilingual fallback ("Web Shell 加载失败 / failed to load") showing the captured error and a reload button; the same fallback appears if the React app has not mounted into `#root` within a 15-second grace period. Once the app mounts, the watchdog never interferes.

## Why it's needed

Long-open dev tabs frequently white-screen after the dev daemon / Vite dev server restarts (#9253): the Vite client triggers a full reload on server restart, and when a module request races the restart (or the daemon is still booting / its token rotated) the app never mounts, leaving a blank page with no diagnostic and no recovery affordance — users only recover by knowing to reload manually. Reproduced live with Playwright (vite restart under an open tab leaves `#root` empty) and against the real dev server (a forced module 504 now shows the fallback instead of white).

## Reviewer Test Plan

### How to verify

- Unit: `cd packages/web-shell && npx vitest run client/boot-watchdog.test.ts client/index-html.test.ts` — covers immediate fallback on script resource error (with the failing URL surfaced), grace-period fallback when the app never mounts, and silence once the app has mounted.
- Manual (dev): run the web-shell dev server, open it, and block `/main.tsx` in DevTools (or restart the dev server while a tab is open). Before: indefinite white page. After: the bilingual fallback with the error text and a working reload button, matching the active theme.

### Evidence (Before & After)

Before: stuck tab rendered a pure white page (empty `#root`, confirmed via accessibility tree); after the fix, the same failure mode renders the fallback (verified via Playwright screenshot against the live dev server with `/main.tsx` forced to 504).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Vite dev server on :5173 proxying a live `qwen serve` daemon; Playwright (chromium) for the forced-504 verification.

## Risk & Scope

- Main risk or tradeoff: on very slow machines a legitimate first mount taking >15s would show the fallback; when React later mounts it replaces the fallback (createRoot clears it), so the worst case is a transient notice rather than a stuck page. The grace period (15s) is well above the observed ~6s cold-render window for large sessions.
- Not validated / out of scope: the underlying dev-restart race itself and the large-transcript cold-render cost (#7271, #7272, #7274, #7275) — this PR turns the failure into a visible, recoverable state instead of fixing those roots.
- Breaking changes / migration notes: none; the watchdog is inline ES5 and runs under the existing CSP (`script-src` already allows `'unsafe-inline'`).

## Linked Issues

Fixes #9253

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Web Shell 的 `index.html` 增加零依赖的启动 watchdog：脚本/样式资源加载失败时立即渲染可见的、跟随主题的双语兜底页（"Web Shell 加载失败 / failed to load"），展示捕获到的错误和重载按钮；若 React 应用在 15 秒宽限期内仍未挂载进 `#root`，同样渲染该兜底。应用一旦挂载，watchdog 绝不干扰。

## 为什么需要

长时间打开的 dev 标签页在 dev daemon / Vite dev server 重启后经常白屏（#9253）：vite 客户端在服务端重启时触发整页 reload，若模块请求与重启竞态（或 daemon 尚在启动、token 已轮换），应用永远不挂载，页面成为无诊断、无恢复入口的白画布——用户只能靠"知道要手动刷新"恢复。已用 Playwright 真实复现（open tab 下重启 vite，`#root` 为空），并在真实 dev server 上验证（强制 /main.tsx 504 后显示兜底而非白屏）。

## 评审测试计划

### 如何验证

- 单测：`cd packages/web-shell && npx vitest run client/boot-watchdog.test.ts client/index-html.test.ts`——覆盖脚本资源错误时立即兜底（含失败 URL）、宽限期兜底、应用挂载后保持沉默。
- 手工（dev）：启动 web-shell dev server，在 DevTools 里 block `/main.tsx`（或在 tab 打开时重启 dev server）。修复前：无限白屏；修复后：双语兜底页 + 可用重载按钮，跟随当前主题。

### 证据（修复前后）

修复前：卡死 tab 纯白（`#root` 为空，无障碍树确认）；修复后同样失败模式渲染兜底页（Playwright 对真实 dev server 强制 504 截图验证）。

### 测试环境

macOS ✅；Windows/Linux ⚠️（纯前端内联脚本，无平台相关逻辑）。

### 环境（可选）

:5173 Vite dev server 代理运行中的 `qwen serve`；Playwright (chromium) 做强制 504 验证。

## 风险与范围

- 主要风险/权衡：极慢机器上超过 15 秒的合法首渲会先看到兜底页；React 随后挂载时会替换它（createRoot 清空），最坏情况是瞬时提示而非卡死。宽限期（15s）远高于实测大会话约 6 秒的冷渲染窗口。
- 未验证/不在范围：dev 重启竞态本身与大会话冷渲染成本（#7271、#7272、#7274、#7275）——本 PR 把失败变成可见可恢复状态，而非修复这些根因。
- 破坏性变更/迁移说明：无；watchdog 为内联 ES5，现有 CSP 已允许 `'unsafe-inline'`。

## 关联 Issue

Fixes #9253

</details>