### PR TITLE
fix(ci): keep a fallback comment when the PR review runner dies

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -71,6 +71,13 @@ concurrency:
     format('qwen-pr-review-run-{0}', github.run_id) }}
   cancel-in-progress: "${{ github.event_name == 'pull_request_target' && (github.event.action == 'synchronize' || github.event.action == 'closed') }}"
 
+env:
+  # Dedup marker for the review-failure fallback comments. The in-job step
+  # and the fallback-comment job both build their body from it, and the
+  # cross-job dedup matches it — the sites must stay byte-identical or the
+  # dedup silently posts duplicates, so the literal is defined once here.
+  FALLBACK_MARKER: '<!-- qwen-review-fallback -->'
+
 jobs:
   precheck-pr:
     if: |-
@@ -428,11 +435,18 @@ jobs:
           set -uo pipefail
           RUNNER_UID="$(id -u)"
           RUNNER_GID="$(id -g)"
-          # Two levels above the workspace (_work/owner/repo) is the runner
+          # Three levels above the workspace (_work/owner/repo) is the runner
           # root, whose _diag/pages dir is what FinalizeJob creates in.
-          RUNNER_ROOT="$(cd "$GITHUB_WORKSPACE/../.." && pwd)"
+          RUNNER_ROOT="$(cd "$GITHUB_WORKSPACE/../../.." && pwd)"
+          dirs=("$HOME" "${RUNNER_TEMP:?}" "$RUNNER_ROOT")
+          # A writable runner root does not prove an existing _diag writable
+          # (ownership is per-directory), so probe it too; when absent, it is
+          # created by FinalizeJob, which only needs the runner root.
+          if [ -d "$RUNNER_ROOT/_diag" ]; then
+            dirs+=("$RUNNER_ROOT/_diag")
+          fi
           status=0
-          for dir in "$HOME" "${RUNNER_TEMP:?}" "$RUNNER_ROOT"; do
+          for dir in "${dirs[@]}"; do
             probe="$(mktemp -u "$dir/.qwen-health-XXXXXX")"
             if touch "$probe" 2>/dev/null; then
               rm -f "$probe"
@@ -1683,7 +1697,7 @@ jobs:
           # Blank line after the marker or the prose renders as raw source —
           # same HTML-block quirk as the ack marker. The fallback-comment job
           # dedupes on this marker plus this run's URL.
-          body="$(printf '<!-- qwen-review-fallback -->\n\n%s' "$body")"
+          body="$(printf '%s\n\n%s' "$FALLBACK_MARKER" "$body")"
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
             --body "$body"
@@ -1743,17 +1757,23 @@ jobs:
   # 'Post fallback comment on failure' step, leaving the PR with no review and
   # no explanation. This dependent job runs on an ephemeral hosted runner, so
   # it survives whatever killed the review job, and posts the retry guidance
-  # itself. It skips when a fallback comment for this run already exists —
-  # matched by the qwen-review-fallback marker plus this run's URL, since the
-  # ack comment also links the run and must not suppress this one; the same
-  # check dedupes re-runs, which keep the same run id. The PR number comes
-  # from the event payload, not the dead job's outputs, which do not survive
-  # a crash.
+  # itself. The incident's trigger can kill the chain's earlier self-hosted
+  # jobs first (authorize / review-config), and a failed dependency marks
+  # review-pr 'skipped', so those failures open the gate too — a skipped
+  # review is just as unexplained as a dead one. It skips when a fallback
+  # comment for this run already exists — matched by the qwen-review-fallback
+  # marker plus this run's URL, since the ack comment also links the run and
+  # must not suppress this one; the same check dedupes re-runs, which keep
+  # the same run id. The PR number comes from the event payload, not the dead
+  # job's outputs, which do not survive a crash.
   fallback-comment:
-    needs: ['review-pr']
+    needs: ['review-config', 'authorize', 'review-pr']
     if: |-
       always() &&
-      needs.review-pr.result == 'failure' &&
+      (needs.review-pr.result == 'failure' ||
+       needs.authorize.result == 'failure' ||
+       needs.review-config.result == 'failure') &&
+      github.event.inputs.command != 'resolve' &&
       github.repository == 'QwenLM/qwen-code' &&
       (github.event_name != 'workflow_dispatch' ||
        github.event.inputs.review_mode == 'comment')
@@ -1773,8 +1793,46 @@ jobs:
             echo "Could not determine the PR number; skipping fallback comment." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          fallback_bodies="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
-            --jq '.comments[] | select(.body | contains("<!-- qwen-review-fallback -->")) | .body' 2>/dev/null)" || fallback_bodies=""
+          # A push landing mid-review leaves this comment pointing at a dead
+          # run while a fresh review of the new head already queues (per-run
+          # concurrency groups are not cancelled by pushes). The run's head
+          # is comparable only on pull_request_target events — comment and
+          # review runs report main's tip as headSha — so guard only there,
+          # and when the comparison is unavailable or fails, posting wins
+          # over silence.
+          if [ "${GITHUB_EVENT_NAME:-}" = "pull_request_target" ]; then
+            run_head="$(gh run view "${GITHUB_RUN_ID:?}" --repo "$GITHUB_REPOSITORY" --json headSha --jq '.headSha' 2>/dev/null)" || run_head=""
+            current_head="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq '.headRefOid' 2>/dev/null)" || current_head=""
+            if [ -n "$run_head" ] && [ -n "$current_head" ] && [ "$run_head" != "$current_head" ]; then
+              echo "Skipping fallback comment: PR #${PR_NUMBER} moved from ${run_head} to ${current_head} since this run started." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+          fi
+          # Dedup lookup with bounded retry: a FAILED lookup is never treated
+          # as an EMPTY result — posting on a failed listing is how a
+          # transient 5xx mints a permanent duplicate (same norm as
+          # upsert-bot-comment.sh). The author scope resolves the
+          # authenticated login dynamically so a participant posting the
+          # marker can never capture the lookup, and the filter cannot drift
+          # from the account CI_BOT_PAT posts as.
+          bot_login=""
+          fallback_bodies=""
+          for _attempt in 1 2 3; do
+            if bot_login="$(gh api user --jq '.login')" \
+              && [ -n "$bot_login" ] \
+              && fallback_bodies="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
+                --jq ".comments[] | select(.author.login == \"$bot_login\") | select(.body | contains(\"$FALLBACK_MARKER\")) | .body")"; then
+              break
+            fi
+            bot_login=""
+            fallback_bodies=""
+            sleep 10
+          done
+          if [ -z "$bot_login" ]; then
+            echo "::error::fallback comment dedup lookup failed after retries; refusing to post on a failed listing"
+            echo "Fallback comment lookup failed after retries; skipping to avoid a duplicate." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
           case "$fallback_bodies" in
             *"actions/runs/${GITHUB_RUN_ID}"*)
               echo "A fallback comment for this run already exists; skipping." >> "$GITHUB_STEP_SUMMARY"
@@ -1782,15 +1840,16 @@ jobs:
               ;;
           esac
           pr_state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')" || {
-            echo "Could not verify PR #${PR_NUMBER}; skipping fallback comment." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            echo "::error::could not verify PR #${PR_NUMBER} state; refusing to post on a failed lookup"
+            echo "Could not verify PR #${PR_NUMBER} (API error); failing instead of guessing." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           }
           if [ "$pr_state" != "OPEN" ]; then
             echo "Skipping fallback comment: PR #${PR_NUMBER} is ${pr_state}." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           body="**Qwen Code review did not complete successfully.** The review job failed before it could post details. A transient error is retried automatically; if you are seeing this, retry with \`@qwen-code /review\`. See [workflow logs](${RUN_URL})."
-          body="$(printf '<!-- qwen-review-fallback -->\n\n%s' "$body")"
+          body="$(printf '%s\n\n%s' "$FALLBACK_MARKER" "$body")"
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
             --body "$body"

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -412,6 +412,48 @@ jobs:
       pull-requests: 'write'
       issues: 'write'
     steps:
+      # The runner worker dies in FinalizeJob with EACCES when it loses write
+      # access to its own directories (observed: '/home/github-runner' no
+      # longer creatable), taking the whole job down with no fallback comment
+      # and no cleanup — see the PR #8894 incident. The known trigger on this
+      # shared pool is a prior containerised job running as root. Probe every
+      # directory the review must create files in, repair single-directory
+      # ownership with the same sudo pattern as 'Restore workspace ownership',
+      # and fail fast with a clear message when repair is impossible — cheaper
+      # than burning hours of review budget to die at finalize. Only catches
+      # corruption already present at job start; mid-run corruption is covered
+      # by the fallback-comment job instead.
+      - name: 'Verify runner directory health'
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          # Two levels above the workspace (_work/owner/repo) is the runner
+          # root, whose _diag/pages dir is what FinalizeJob creates in.
+          RUNNER_ROOT="$(cd "$GITHUB_WORKSPACE/../.." && pwd)"
+          status=0
+          for dir in "$HOME" "${RUNNER_TEMP:?}" "$RUNNER_ROOT"; do
+            probe="$(mktemp -u "$dir/.qwen-health-XXXXXX")"
+            if touch "$probe" 2>/dev/null; then
+              rm -f "$probe"
+              continue
+            fi
+            echo "::warning::no write access to $dir; attempting single-directory repair"
+            sudo -n chown "$RUNNER_UID:$RUNNER_GID" "$dir" 2>/dev/null || true
+            sudo -n chmod u+rwx "$dir" 2>/dev/null || true
+            if touch "$probe" 2>/dev/null; then
+              rm -f "$probe"
+              echo "repaired write access to $dir"
+            else
+              echo "::error::runner directory still unusable after repair: $dir"
+              status=1
+            fi
+          done
+          if [ "$status" != 0 ]; then
+            echo "::error::runner directories unhealthy; failing fast instead of dying at job finalize"
+          fi
+          exit "$status"
+
       # Self-hosted runners reuse the workspace; a prior containerised job can
       # leave root-owned, read-only files anywhere in it. Restore ownership and
       # write permission unconditionally before checkout — probing only .qwen
@@ -1638,6 +1680,10 @@ jobs:
           else
             body="**Qwen Code review did not complete successfully.** ${FAILURE_REASON} A transient error is retried automatically; if you are seeing this, retry with \`@qwen-code /review\`. See [workflow logs](${RUN_URL})."
           fi
+          # Blank line after the marker or the prose renders as raw source —
+          # same HTML-block quirk as the ack marker. The fallback-comment job
+          # dedupes on this marker plus this run's URL.
+          body="$(printf '<!-- qwen-review-fallback -->\n\n%s' "$body")"
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
             --body "$body"
@@ -1691,6 +1737,63 @@ jobs:
               done || true
           rm -f .qwen/tmp/qwen-review-lease-pr-*.json 2>/dev/null || true
           echo "review worktrees cleaned"
+
+  # A review job that dies abnormally — runner crash, host loss, or the
+  # FinalizeJob EACCES from the PR #8894 incident — never reaches its in-job
+  # 'Post fallback comment on failure' step, leaving the PR with no review and
+  # no explanation. This dependent job runs on an ephemeral hosted runner, so
+  # it survives whatever killed the review job, and posts the retry guidance
+  # itself. It skips when a fallback comment for this run already exists —
+  # matched by the qwen-review-fallback marker plus this run's URL, since the
+  # ack comment also links the run and must not suppress this one; the same
+  # check dedupes re-runs, which keep the same run id. The PR number comes
+  # from the event payload, not the dead job's outputs, which do not survive
+  # a crash.
+  fallback-comment:
+    needs: ['review-pr']
+    if: |-
+      always() &&
+      needs.review-pr.result == 'failure' &&
+      github.repository == 'QwenLM/qwen-code' &&
+      (github.event_name != 'workflow_dispatch' ||
+       github.event.inputs.review_mode == 'comment')
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 5
+    permissions:
+      pull-requests: 'write'
+    steps:
+      - name: 'Post fallback comment'
+        env:
+          GH_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          PR_NUMBER: '${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}'
+          RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+        run: |-
+          set -uo pipefail
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Could not determine the PR number; skipping fallback comment." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          fallback_bodies="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
+            --jq '.comments[] | select(.body | contains("<!-- qwen-review-fallback -->")) | .body' 2>/dev/null)" || fallback_bodies=""
+          case "$fallback_bodies" in
+            *"actions/runs/${GITHUB_RUN_ID}"*)
+              echo "A fallback comment for this run already exists; skipping." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+          esac
+          pr_state="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')" || {
+            echo "Could not verify PR #${PR_NUMBER}; skipping fallback comment." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+          if [ "$pr_state" != "OPEN" ]; then
+            echo "Skipping fallback comment: PR #${PR_NUMBER} is ${pr_state}." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          body="**Qwen Code review did not complete successfully.** The review job failed before it could post details. A transient error is retried automatically; if you are seeing this, retry with \`@qwen-code /review\`. See [workflow logs](${RUN_URL})."
+          body="$(printf '<!-- qwen-review-fallback -->\n\n%s' "$body")"
+          gh pr comment "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "$body"
 
   resolve-pr:
     needs: ['authorize']

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1680,6 +1680,27 @@ jobs:
             echo "Skipping fallback comment: PR #${PR_NUMBER} moved from ${EXPECTED_HEAD_SHA} to ${current_head}." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          # Re-runs of failed jobs keep the same run id: a prior attempt that
+          # died before reaching this step already got a fallback comment for
+          # this run from the fallback-comment job. Dedup on the marker plus
+          # this run's URL exactly as that job does; a FAILED lookup defers to
+          # it (it retries and fails closed) instead of risking a duplicate —
+          # posting on a failed listing is how a transient 5xx mints one.
+          bot_login="$(gh api user --jq '.login' 2>/dev/null)" || bot_login=""
+          fallback_bodies=""
+          if [ -n "$bot_login" ] \
+            && fallback_bodies="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json comments \
+              --jq ".comments[] | select(.author.login == \"$bot_login\") | select(.body | contains(\"$FALLBACK_MARKER\")) | .body")"; then
+            case "$fallback_bodies" in
+              *"actions/runs/${GITHUB_RUN_ID})"*)
+                echo "A fallback comment for this run already exists; skipping." >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+                ;;
+            esac
+          else
+            echo "Fallback comment dedup lookup failed; deferring to the fallback-comment job." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           MAX_TIMEOUT_MINUTES="${{ vars.QWEN_REVIEW_MAX_TIMEOUT_MINUTES }}"
           if [ "$FAILURE_KIND" = "timeout" ]; then
             if [ "$TIMEOUT_MINUTES" -lt "$MAX_TIMEOUT_MINUTES" ]; then
@@ -1765,8 +1786,15 @@ jobs:
   # fallback comment for this run already exists — matched by the
   # qwen-review-fallback marker plus this run's URL, since the ack comment
   # also links the run and must not suppress this one; the same check dedupes
-  # re-runs, which keep the same run id. The PR number comes from the event
-  # payload, not the dead job's outputs, which do not survive a crash.
+  # re-runs, which keep the same run id. A review-pr that dies to its own
+  # job-level timeout is auto-CANCELLED by GitHub — result 'cancelled' and
+  # failure() false — which opens neither a failure-only gate nor the in-job
+  # step, so the gate admits 'cancelled' too; a run-level cancel cancels this
+  # queued job with it, so a live gate evaluation seeing 'cancelled' is
+  # overwhelmingly the timeout case, and the residual manual single-job
+  # cancel just gets a benign retry-guidance comment. The PR number comes
+  # from the event payload, not the dead job's outputs, which do not survive
+  # a crash.
   fallback-comment:
     needs:
       [
@@ -1779,6 +1807,7 @@ jobs:
     if: |-
       always() &&
       (needs.review-pr.result == 'failure' ||
+       needs.review-pr.result == 'cancelled' ||
        needs.authorize.result == 'failure' ||
        needs.review-config.result == 'failure' ||
        needs.delay-automatic-review.result == 'failure' ||
@@ -1860,7 +1889,7 @@ jobs:
             echo "Skipping fallback comment: PR #${PR_NUMBER} is ${pr_state}." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          body="**Qwen Code review did not complete successfully.** The review job failed before it could post details. A transient error is retried automatically; if you are seeing this, retry with \`@qwen-code /review\`. See [workflow logs](${RUN_URL})."
+          body="**Qwen Code review did not complete successfully.** The review pipeline failed before a review could be posted. A transient error is retried automatically; if you are seeing this, retry with \`@qwen-code /review\`. See [workflow logs](${RUN_URL})."
           body="$(printf '%s\n\n%s' "$FALLBACK_MARKER" "$body")"
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1757,23 +1757,35 @@ jobs:
   # 'Post fallback comment on failure' step, leaving the PR with no review and
   # no explanation. This dependent job runs on an ephemeral hosted runner, so
   # it survives whatever killed the review job, and posts the retry guidance
-  # itself. The incident's trigger can kill the chain's earlier self-hosted
-  # jobs first (authorize / review-config), and a failed dependency marks
-  # review-pr 'skipped', so those failures open the gate too — a skipped
-  # review is just as unexplained as a dead one. It skips when a fallback
-  # comment for this run already exists — matched by the qwen-review-fallback
-  # marker plus this run's URL, since the ack comment also links the run and
-  # must not suppress this one; the same check dedupes re-runs, which keep
-  # the same run id. The PR number comes from the event payload, not the dead
-  # job's outputs, which do not survive a crash.
+  # itself. Every upstream job whose failure marks review-pr 'skipped' opens
+  # the gate — the incident's trigger can kill the chain's earlier
+  # self-hosted jobs first (authorize / review-config), and a transient API
+  # failure can kill the hosted ones (precheck-pr / delay-automatic-review) —
+  # a skipped review is just as unexplained as a dead one. It skips when a
+  # fallback comment for this run already exists — matched by the
+  # qwen-review-fallback marker plus this run's URL, since the ack comment
+  # also links the run and must not suppress this one; the same check dedupes
+  # re-runs, which keep the same run id. The PR number comes from the event
+  # payload, not the dead job's outputs, which do not survive a crash.
   fallback-comment:
-    needs: ['review-config', 'authorize', 'review-pr']
+    needs:
+      [
+        'precheck-pr',
+        'review-config',
+        'authorize',
+        'delay-automatic-review',
+        'review-pr',
+      ]
     if: |-
       always() &&
       (needs.review-pr.result == 'failure' ||
        needs.authorize.result == 'failure' ||
-       needs.review-config.result == 'failure') &&
+       needs.review-config.result == 'failure' ||
+       needs.delay-automatic-review.result == 'failure' ||
+       needs.precheck-pr.result == 'failure') &&
       github.event.inputs.command != 'resolve' &&
+      !(github.event_name == 'issue_comment' &&
+       startsWith(github.event.comment.body, '@qwen-code /resolve')) &&
       github.repository == 'QwenLM/qwen-code' &&
       (github.event_name != 'workflow_dispatch' ||
        github.event.inputs.review_mode == 'comment')
@@ -1834,7 +1846,7 @@ jobs:
             exit 1
           fi
           case "$fallback_bodies" in
-            *"actions/runs/${GITHUB_RUN_ID}"*)
+            *"actions/runs/${GITHUB_RUN_ID})"*)
               echo "A fallback comment for this run already exists; skipping." >> "$GITHUB_STEP_SUMMARY"
               exit 0
               ;;

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2636,12 +2636,16 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     }
   });
 
-  it('keeps every in-job failure body linked to the run and marker-prepended', () => {
+  it('keeps every failure body linked to the run and marker-prepended', () => {
     // All four FAILURE_KIND bodies carry the workflow-logs link — dropping it
     // from a variant ships a dead-end comment on exactly that failure path.
     expect(
       inJobStep.run.match(/See \[workflow logs\]\(\$\{RUN_URL\}\)\./g),
     ).toHaveLength(4);
+    // Same invariant for the fallback job's body: the cross-job dedup
+    // matches `actions/runs/<id>)`, anchored on the markdown link's closing
+    // paren — a body that rendered the URL differently would escape it.
+    expect(step.run).toContain('See [workflow logs](${RUN_URL}).');
     expect(inJobStep.run).toContain(
       `body="$(printf '%s\\n\\n%s' "$FALLBACK_MARKER" "$body")"`,
     );
@@ -2657,18 +2661,48 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
   });
 
   it('opens the gate on any upstream failure but never on skip or resolve', () => {
-    expect(job.needs).toEqual(['review-config', 'authorize', 'review-pr']);
+    // Every job whose failure marks review-pr 'skipped' is enumerated: the
+    // incident's trigger can kill the chain's self-hosted jobs first
+    // (authorize / review-config), and a transient API failure can kill the
+    // hosted ones (precheck-pr / delay-automatic-review).
+    expect(job.needs).toEqual([
+      'precheck-pr',
+      'review-config',
+      'authorize',
+      'delay-automatic-review',
+      'review-pr',
+    ]);
     // Failure-keyed, not != 'success': resolve dispatch runs skip review-pr
     // BY DESIGN and would otherwise mint false-alarm fallbacks.
     expect(job.if).toContain("needs.review-pr.result == 'failure'");
     expect(job.if).toContain("needs.authorize.result == 'failure'");
     expect(job.if).toContain("needs.review-config.result == 'failure'");
+    expect(job.if).toContain(
+      "needs.delay-automatic-review.result == 'failure'",
+    );
+    expect(job.if).toContain("needs.precheck-pr.result == 'failure'");
     expect(job.if).not.toContain("!= 'success'");
-    // Resolve dispatch runs never review, and only there can authorize fail
-    // while review-pr is skipped by design.
-    expect(job.if).toContain("github.event.inputs.command != 'resolve'");
     expect(job.if).toContain("github.repository == 'QwenLM/qwen-code'");
+    // On pull_request_target and issue_comment events review_mode is null,
+    // so collapsing this disjunction would skip the job exactly where dead
+    // review runs happen.
+    expect(job.if).toContain("(github.event_name != 'workflow_dispatch' ||");
     expect(job.if).toContain("github.event.inputs.review_mode == 'comment'");
+    // The job exists to survive whatever killed the review job; routing it
+    // onto the self-hosted ECS pool would die the same death.
+    expect(job['runs-on']).toBe('ubuntu-latest');
+  });
+
+  it('never opens the gate on a /resolve run, dispatch- or comment-driven', () => {
+    // /resolve is a first-class issue_comment command too: authorize runs on
+    // `@qwen-code /resolve` comments, and github.event.inputs is empty on
+    // issue_comment, so the dispatch exclusion alone misdiagnoses a failed
+    // resolve run as a dead review and recommends the wrong command.
+    expect(job.if).toContain("github.event.inputs.command != 'resolve'");
+    expect(job.if).toContain(
+      "!(github.event_name == 'issue_comment' &&\n" +
+        " startsWith(github.event.comment.body, '@qwen-code /resolve')) &&",
+    );
   });
 
   it('probes the runner root three levels up and _diag when present', () => {
@@ -2681,6 +2715,9 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     expect(run).toContain('"$HOME"');
     expect(run).toContain('"${RUNNER_TEMP:?}"');
     expect(run).toContain('"$RUNNER_ROOT/_diag"');
+    // Polarity: _diag is probed only when it EXISTS — an inverted guard
+    // probes a nonexistent directory and fails fast on a healthy runner.
+    expect(run).toContain('if [ -d "$RUNNER_ROOT/_diag" ]; then');
     expect(run).toContain('status=1');
     expect(run.trim()).toMatch(/exit "\$status"$/);
   });
@@ -2797,12 +2834,25 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
   });
 
   it('dedupes on the marker plus this run URL', () => {
+    // Mirrors a prior fallback comment's rendered shape: the run URL is a
+    // markdown link, so the run id is always immediately followed by ')'.
     const r = runFallbackStep('already', {
-      comments: `${marker}\n\nretry actions/runs/12345 now`,
+      comments: `${marker}\n\nSee [workflow logs](https://github.com/QwenLM/qwen-code/actions/runs/12345).`,
     });
     expect(r.status).toBe(0);
     expect(r.posted).toBe('');
     expect(r.summary).toContain('already exists');
+  });
+
+  it("still posts when only another run's fallback exists", () => {
+    // Run ids grow digits over time, so a later run's id (123450) contains
+    // this run's (12345) as a substring — the match must stay anchored to
+    // this run's URL or a distinct run's death is silently suppressed.
+    const r = runFallbackStep('other_run', {
+      comments: `${marker}\n\nSee [workflow logs](https://github.com/QwenLM/qwen-code/actions/runs/123450).`,
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).not.toBe('');
   });
 
   it('fails closed when the dedup lookup keeps failing', () => {
@@ -2858,6 +2908,26 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
   it('degrades to POSTING when the head comparison lookups fail', () => {
     const r = runFallbackStep('runview_fail', {
       eventName: 'pull_request_target',
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).not.toBe('');
+  });
+
+  it('still posts on pull_request_target when only the run-head lookup fails', () => {
+    // A transient gh-run-view failure while gh-pr-view succeeds must not
+    // suppress the fallback: comparison unavailable means posting wins.
+    const r = runFallbackStep('runview_fail', {
+      eventName: 'pull_request_target',
+      prHead: 'newsha',
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).not.toBe('');
+  });
+
+  it('still posts on pull_request_target when only the PR-head lookup fails', () => {
+    const r = runFallbackStep('prview_fail', {
+      eventName: 'pull_request_target',
+      runHead: 'oldsha',
     });
     expect(r.status).toBe(0);
     expect(r.posted).not.toBe('');

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2649,6 +2649,14 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     expect(inJobStep.run).toContain(
       `body="$(printf '%s\\n\\n%s' "$FALLBACK_MARKER" "$body")"`,
     );
+    // ...and it must precede the post: moving the printf below the comment
+    // keeps every existence assertion green yet ships in-job fallbacks
+    // without the marker, breaking the dedup that keys on it.
+    expect(
+      inJobStep.run.indexOf(
+        `body="$(printf '%s\\n\\n%s' "$FALLBACK_MARKER" "$body")"`,
+      ),
+    ).toBeLessThan(inJobStep.run.indexOf('gh pr comment'));
   });
 
   it('scopes the dedup to the authenticated bot login, resolved dynamically', () => {
@@ -2658,6 +2666,24 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     // the filter to the account CI_BOT_PAT posts as.
     expect(step.run).toContain('bot_login="$(gh api user --jq \'.login\')"');
     expect(step.run).toContain('select(.author.login == \\"$bot_login\\")');
+    // The agreement is load-bearing: the in-job comment must be posted by
+    // the same account this lookup resolves via `gh api user`, or the
+    // author-scoped filter never sees it and the fallback double-posts.
+    expect(inJobStep.env.GH_TOKEN).toBe('${{ secrets.CI_BOT_PAT }}');
+    expect(step.env.GH_TOKEN).toBe('${{ secrets.CI_BOT_PAT }}');
+  });
+
+  it('pins the run-URL shape the dedup anchors on', () => {
+    // The dedup matches `actions/runs/<id>)` — anchored on the markdown
+    // link's closing paren — so RUN_URL must END at the run id; a suffix
+    // (an /attempts/N deep-link, plausibly) escapes the match and every
+    // re-run of a dead review silently double-posts. Both steps must also
+    // render the same shape, or the in-job comment's URL never matches the
+    // fallback job's pattern.
+    expect(step.env.RUN_URL).toMatch(
+      /\/actions\/runs\/\$\{\{ github\.run_id \}\}$/,
+    );
+    expect(inJobStep.env.RUN_URL).toBe(step.env.RUN_URL);
   });
 
   it('opens the gate on any upstream failure but never on skip or resolve', () => {
@@ -2675,6 +2701,11 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     // Failure-keyed, not != 'success': resolve dispatch runs skip review-pr
     // BY DESIGN and would otherwise mint false-alarm fallbacks.
     expect(job.if).toContain("needs.review-pr.result == 'failure'");
+    // A review-pr that dies to its own job-level timeout is auto-cancelled
+    // (result 'cancelled', failure() false), which would open neither this
+    // gate nor the in-job step; a run-level cancel cancels this queued job
+    // too, so a live evaluation seeing 'cancelled' is the timeout case.
+    expect(job.if).toContain("needs.review-pr.result == 'cancelled'");
     expect(job.if).toContain("needs.authorize.result == 'failure'");
     expect(job.if).toContain("needs.review-config.result == 'failure'");
     expect(job.if).toContain(
@@ -2722,6 +2753,103 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     expect(run.trim()).toMatch(/exit "\$status"$/);
   });
 
+  // Executed shape for the health probe: run the step's REAL bash against
+  // a fake runner tree with a stub sudo, so the repair-vs-fail-fast
+  // decision is exercised, not just textually pinned.
+  function runHealthProbe({
+    breakDir = '',
+    sudoMode = 'repair',
+    diag = true,
+  } = {}) {
+    const root = mkdtempSync(join(tmpdir(), 'health-probe-'));
+    const home = join(root, 'home');
+    const temp = join(root, 'temp');
+    const runnerRoot = join(root, 'runner');
+    const workspace = join(runnerRoot, '_work', 'owner', 'repo');
+    const broken = breakDir
+      ? {
+          home,
+          temp,
+          root: runnerRoot,
+          diag: join(runnerRoot, '_diag'),
+        }[breakDir]
+      : '';
+    try {
+      mkdirSync(home);
+      mkdirSync(temp);
+      mkdirSync(workspace, { recursive: true });
+      if (diag) mkdirSync(join(runnerRoot, '_diag'));
+      if (broken) chmodSync(broken, 0o555);
+      const bin = join(root, 'bin');
+      mkdirSync(bin);
+      const sudo = join(bin, 'sudo');
+      writeFileSync(
+        sudo,
+        [
+          '#!/bin/bash',
+          '[ "${SUDO_MODE:-repair}" = repair ] || exit 1',
+          'for last in "$@"; do :; done',
+          '[ "$2" = chmod ] && chmod u+rwx "$last"',
+          'exit 0',
+        ].join('\n') + '\n',
+      );
+      chmodSync(sudo, 0o755);
+      let status = 0;
+      let stdout = '';
+      try {
+        stdout = execFileSync('bash', ['-c', health.run], {
+          encoding: 'utf8',
+          env: {
+            PATH: `${bin}:${process.env.PATH}`,
+            SUDO_MODE: sudoMode,
+            HOME: home,
+            RUNNER_TEMP: temp,
+            GITHUB_WORKSPACE: workspace,
+          },
+        });
+      } catch (e) {
+        status = e.status ?? 1;
+        stdout = `${e.stdout ?? ''}`;
+      }
+      return { status, stdout };
+    } finally {
+      if (broken && existsSync(broken)) chmodSync(broken, 0o755);
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  it('passes a healthy runner without repair noise', () => {
+    const r = runHealthProbe();
+    expect(r.status).toBe(0);
+    expect(r.stdout).not.toContain('::warning::');
+    expect(r.stdout).not.toContain('repaired');
+  });
+
+  it('repairs a single unwritable directory instead of failing fast', () => {
+    // Mutant control: a status=1 right after the first failed touch would
+    // abort this repairable runner (exit 1) — a false fail-fast.
+    const r = runHealthProbe({ breakDir: 'home' });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('repaired write access');
+  });
+
+  it('fails fast when repair is impossible', () => {
+    // Mutant control: dropping the post-repair re-probe would report this
+    // unusable directory as repaired (exit 0) and die at FinalizeJob — the
+    // exact PR #8894 death the probe exists to prevent.
+    const r = runHealthProbe({ breakDir: 'home', sudoMode: 'fail' });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain('still unusable after repair');
+    expect(r.stdout).toContain('failing fast instead of dying at job finalize');
+  });
+
+  it('does not probe _diag when it does not exist', () => {
+    // Polarity: an inverted `[ -d ]` guard probes the missing directory,
+    // cannot create its probe file, and fails fast on a healthy runner.
+    const r = runHealthProbe({ diag: false });
+    expect(r.status).toBe(0);
+  });
+
   // Executed shape: run the step's REAL bash with a stub gh that logs every
   // call. The stub pre-applies the dedup filter's semantics to the fixture
   // (the filter's author scope is pinned by the text test above).
@@ -2732,6 +2860,7 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
       comments = '',
       runHead = '',
       prHead = '',
+      useInJobStep = false,
     } = {},
   ) {
     const dir = mkdtempSync(join(tmpdir(), 'fallback-comment-'));
@@ -2769,8 +2898,11 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
           'if [ "$cmd" = "pr" ] && [ "$sub" = "view" ]; then',
           '  case "$*" in',
           '    *comments*)',
-          '      [ "${SCENARIO:-}" = "lookup_fail" ] && exit 1',
+          '      case "${SCENARIO:-}" in lookup_fail | comments_lookup_fail) exit 1 ;; esac',
           '      cat "$COMMENTS_FILE"; exit 0 ;;',
+          '    *state,headRefOid*)',
+          '      [ "${SCENARIO:-}" = "state_fail" ] && exit 1',
+          '      printf "OPEN\\t%s\\n" "${PR_HEAD:-}"; exit 0 ;;',
           '    *headRefOid*)',
           '      [ "${SCENARIO:-}" = "prview_fail" ] && exit 1',
           '      echo "${PR_HEAD:-}"; exit 0 ;;',
@@ -2791,25 +2923,34 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
       let status = 0;
       let stdout = '';
       try {
-        stdout = execFileSync('bash', ['-c', step.run], {
-          encoding: 'utf8',
-          env: {
-            PATH: `${bin}:${process.env.PATH}`,
-            SCENARIO: scenario,
-            GITHUB_REPOSITORY: 'QwenLM/qwen-code',
-            GITHUB_RUN_ID: '12345',
-            GITHUB_EVENT_NAME: eventName,
-            GITHUB_STEP_SUMMARY: summary,
-            PR_NUMBER: '42',
-            RUN_URL: 'https://github.com/QwenLM/qwen-code/actions/runs/12345',
-            FALLBACK_MARKER: marker,
-            RUN_HEAD: runHead,
-            PR_HEAD: prHead,
-            CALLS: calls,
-            COMMENTS_FILE: commentsFile,
-            POSTED: posted,
+        stdout = execFileSync(
+          'bash',
+          ['-c', useInJobStep ? inJobStep.run : step.run],
+          {
+            encoding: 'utf8',
+            env: {
+              PATH: `${bin}:${process.env.PATH}`,
+              SCENARIO: scenario,
+              GITHUB_REPOSITORY: 'QwenLM/qwen-code',
+              GITHUB_RUN_ID: '12345',
+              GITHUB_EVENT_NAME: eventName,
+              GITHUB_STEP_SUMMARY: summary,
+              PR_NUMBER: '42',
+              RUN_URL: 'https://github.com/QwenLM/qwen-code/actions/runs/12345',
+              EXPECTED_HEAD_SHA: '',
+              FAILURE_KIND: '',
+              FAILURE_REASON:
+                'Run review failed. See workflow logs for details.',
+              TIMEOUT_MINUTES: '60',
+              FALLBACK_MARKER: marker,
+              RUN_HEAD: runHead,
+              PR_HEAD: prHead,
+              CALLS: calls,
+              COMMENTS_FILE: commentsFile,
+              POSTED: posted,
+            },
           },
-        });
+        );
       } catch (e) {
         status = e.status ?? 1;
         stdout = `${e.stdout ?? ''}`;
@@ -2863,6 +3004,16 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     expect(r.posted).toBe('');
     expect(r.stdout).toContain('::error::');
     expect((r.calls.match(/^gh api user --jq/gm) ?? []).length).toBe(3);
+  });
+
+  it('fails closed when only the comments listing keeps failing', () => {
+    // gh api user succeeds here, so only the loop's post-failure resets
+    // keep bot_login empty; deleting them posts on a failed listing — the
+    // permanent duplicate the step's comment forbids.
+    const r = runFallbackStep('comments_lookup_fail');
+    expect(r.status).toBe(1);
+    expect(r.posted).toBe('');
+    expect(r.stdout).toContain('::error::');
   });
 
   it('fails closed when the PR state check itself fails', () => {
@@ -2931,5 +3082,32 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     });
     expect(r.status).toBe(0);
     expect(r.posted).not.toBe('');
+  });
+
+  it('in-job step dedupes on a fallback comment this run already has', () => {
+    // Re-runs of failed jobs keep the run id: when a prior attempt died
+    // before its in-job step, the fallback-comment job already posted for
+    // this run, so the in-job step must not add a second comment.
+    const r = runFallbackStep('already', {
+      useInJobStep: true,
+      comments: `${marker}\n\nSee [workflow logs](https://github.com/QwenLM/qwen-code/actions/runs/12345).`,
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).toBe('');
+    expect(r.summary).toContain('already exists');
+  });
+
+  it('in-job step still posts when no fallback comment exists', () => {
+    const r = runFallbackStep('default', { useInJobStep: true });
+    expect(r.status).toBe(0);
+    expect(r.posted.startsWith(`${marker}\n\n`)).toBe(true);
+    expect(r.posted).toContain('actions/runs/12345');
+  });
+
+  it('in-job step defers to the fallback job when its dedup lookup fails', () => {
+    const r = runFallbackStep('lookup_fail', { useInJobStep: true });
+    expect(r.status).toBe(0);
+    expect(r.posted).toBe('');
+    expect(r.summary).toContain('deferring to the fallback-comment job');
   });
 });

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2607,3 +2607,259 @@ describe('review_requested burst coalescing (#8945)', () => {
     );
   });
 });
+
+describe('fallback comment resilience (PR #8894 incident class)', () => {
+  // The health-probe fail-fast, the fallback-comment job, and the cross-job
+  // marker dedup are the incident's three defenses; reverting any hunk must
+  // fail here, since nothing outside this workflow references the marker.
+  const doc = parse(workflow);
+  const job = doc.jobs['fallback-comment'];
+  const step = job.steps.find((s) => s.name === 'Post fallback comment');
+  const inJobStep = doc.jobs['review-pr'].steps.find(
+    (s) => s.name === 'Post fallback comment on failure',
+  );
+  const health = doc.jobs['review-pr'].steps.find(
+    (s) => s.name === 'Verify runner directory health',
+  );
+  const marker = doc.env?.FALLBACK_MARKER;
+
+  it('defines the fallback marker once and every site references the env', () => {
+    expect(marker).toBe('<!-- qwen-review-fallback -->');
+    // Both comment bodies are built from the variable, and the dedup filter
+    // interpolates it — a hardcoded copy surviving in any run block could be
+    // renamed on one side only, silently breaking cross-job dedup.
+    expect(inJobStep.run).toContain(`printf '%s\\n\\n%s' "$FALLBACK_MARKER"`);
+    expect(step.run).toContain(`printf '%s\\n\\n%s' "$FALLBACK_MARKER"`);
+    expect(step.run).toContain('contains(\\"$FALLBACK_MARKER\\")');
+    for (const run of [inJobStep.run, step.run, health.run]) {
+      expect(run).not.toContain('<!-- qwen-review-fallback -->');
+    }
+  });
+
+  it('keeps every in-job failure body linked to the run and marker-prepended', () => {
+    // All four FAILURE_KIND bodies carry the workflow-logs link — dropping it
+    // from a variant ships a dead-end comment on exactly that failure path.
+    expect(
+      inJobStep.run.match(/See \[workflow logs\]\(\$\{RUN_URL\}\)\./g),
+    ).toHaveLength(4);
+    expect(inJobStep.run).toContain(
+      `body="$(printf '%s\\n\\n%s' "$FALLBACK_MARKER" "$body")"`,
+    );
+  });
+
+  it('scopes the dedup to the authenticated bot login, resolved dynamically', () => {
+    // upsert-bot-comment.sh protocol: only comments by the authenticated
+    // login are dedup targets, or a participant posting the marker suppresses
+    // the fallback. Resolving the login dynamically (as upsert does) locks
+    // the filter to the account CI_BOT_PAT posts as.
+    expect(step.run).toContain('bot_login="$(gh api user --jq \'.login\')"');
+    expect(step.run).toContain('select(.author.login == \\"$bot_login\\")');
+  });
+
+  it('opens the gate on any upstream failure but never on skip or resolve', () => {
+    expect(job.needs).toEqual(['review-config', 'authorize', 'review-pr']);
+    // Failure-keyed, not != 'success': resolve dispatch runs skip review-pr
+    // BY DESIGN and would otherwise mint false-alarm fallbacks.
+    expect(job.if).toContain("needs.review-pr.result == 'failure'");
+    expect(job.if).toContain("needs.authorize.result == 'failure'");
+    expect(job.if).toContain("needs.review-config.result == 'failure'");
+    expect(job.if).not.toContain("!= 'success'");
+    // Resolve dispatch runs never review, and only there can authorize fail
+    // while review-pr is skipped by design.
+    expect(job.if).toContain("github.event.inputs.command != 'resolve'");
+    expect(job.if).toContain("github.repository == 'QwenLM/qwen-code'");
+    expect(job.if).toContain("github.event.inputs.review_mode == 'comment'");
+  });
+
+  it('probes the runner root three levels up and _diag when present', () => {
+    const run = health.run;
+    // The workspace sits at <runner-root>/_work/<owner>/<repo>; two levels
+    // resolves to _work and never probes the directory whose _diag/pages
+    // corruption killed the PR #8894 run.
+    expect(run).toContain('GITHUB_WORKSPACE/../../..');
+    expect(run).not.toMatch(/GITHUB_WORKSPACE\/\.\.\/\.\."/);
+    expect(run).toContain('"$HOME"');
+    expect(run).toContain('"${RUNNER_TEMP:?}"');
+    expect(run).toContain('"$RUNNER_ROOT/_diag"');
+    expect(run).toContain('status=1');
+    expect(run.trim()).toMatch(/exit "\$status"$/);
+  });
+
+  // Executed shape: run the step's REAL bash with a stub gh that logs every
+  // call. The stub pre-applies the dedup filter's semantics to the fixture
+  // (the filter's author scope is pinned by the text test above).
+  function runFallbackStep(
+    scenario,
+    {
+      eventName = 'issue_comment',
+      comments = '',
+      runHead = '',
+      prHead = '',
+    } = {},
+  ) {
+    const dir = mkdtempSync(join(tmpdir(), 'fallback-comment-'));
+    try {
+      const bin = join(dir, 'bin');
+      mkdirSync(bin);
+      const calls = join(dir, 'calls');
+      const summary = join(dir, 'summary');
+      const posted = join(dir, 'posted');
+      const commentsFile = join(dir, 'comments');
+      writeFileSync(calls, '');
+      writeFileSync(summary, '');
+      writeFileSync(posted, '');
+      writeFileSync(commentsFile, comments);
+      const stub = (name, body) => {
+        const p = join(bin, name);
+        writeFileSync(p, body);
+        chmodSync(p, 0o755);
+      };
+      stub('sleep', '#!/bin/bash\nexit 0\n');
+      stub(
+        'gh',
+        [
+          '#!/bin/bash',
+          'echo "gh $*" >> "$CALLS"',
+          'cmd="$1"; sub="${2:-}"',
+          'if [ "$cmd" = "api" ] && [ "$sub" = "user" ]; then',
+          '  [ "${SCENARIO:-}" = "lookup_fail" ] && exit 1',
+          '  echo "qwen-code-ci-bot"; exit 0',
+          'fi',
+          'if [ "$cmd" = "run" ] && [ "$sub" = "view" ]; then',
+          '  [ "${SCENARIO:-}" = "runview_fail" ] && exit 1',
+          '  echo "${RUN_HEAD:-}"; exit 0',
+          'fi',
+          'if [ "$cmd" = "pr" ] && [ "$sub" = "view" ]; then',
+          '  case "$*" in',
+          '    *comments*)',
+          '      [ "${SCENARIO:-}" = "lookup_fail" ] && exit 1',
+          '      cat "$COMMENTS_FILE"; exit 0 ;;',
+          '    *headRefOid*)',
+          '      [ "${SCENARIO:-}" = "prview_fail" ] && exit 1',
+          '      echo "${PR_HEAD:-}"; exit 0 ;;',
+          '    *state*)',
+          '      [ "${SCENARIO:-}" = "state_fail" ] && exit 1',
+          '      [ "${SCENARIO:-}" = "pr_closed" ] && echo "MERGED" || echo "OPEN"; exit 0 ;;',
+          '  esac',
+          'fi',
+          'if [ "$cmd" = "pr" ] && [ "$sub" = "comment" ]; then',
+          '  prev=""; body=""',
+          '  for a in "$@"; do [ "$prev" = "--body" ] && body="$a"; prev="$a"; done',
+          '  printf \'%s\' "$body" > "$POSTED"',
+          '  exit 0',
+          'fi',
+          'exit 1',
+        ].join('\n') + '\n',
+      );
+      let status = 0;
+      let stdout = '';
+      try {
+        stdout = execFileSync('bash', ['-c', step.run], {
+          encoding: 'utf8',
+          env: {
+            PATH: `${bin}:${process.env.PATH}`,
+            SCENARIO: scenario,
+            GITHUB_REPOSITORY: 'QwenLM/qwen-code',
+            GITHUB_RUN_ID: '12345',
+            GITHUB_EVENT_NAME: eventName,
+            GITHUB_STEP_SUMMARY: summary,
+            PR_NUMBER: '42',
+            RUN_URL: 'https://github.com/QwenLM/qwen-code/actions/runs/12345',
+            FALLBACK_MARKER: marker,
+            RUN_HEAD: runHead,
+            PR_HEAD: prHead,
+            CALLS: calls,
+            COMMENTS_FILE: commentsFile,
+            POSTED: posted,
+          },
+        });
+      } catch (e) {
+        status = e.status ?? 1;
+        stdout = `${e.stdout ?? ''}`;
+      }
+      return {
+        status,
+        stdout,
+        calls: readFileSync(calls, 'utf8'),
+        summary: readFileSync(summary, 'utf8'),
+        posted: readFileSync(posted, 'utf8'),
+      };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('posts the marker-headed retry comment when no fallback exists', () => {
+    const r = runFallbackStep('default');
+    expect(r.status).toBe(0);
+    expect(r.posted.startsWith(`${marker}\n\n`)).toBe(true);
+    expect(r.posted).toContain('actions/runs/12345');
+  });
+
+  it('dedupes on the marker plus this run URL', () => {
+    const r = runFallbackStep('already', {
+      comments: `${marker}\n\nretry actions/runs/12345 now`,
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).toBe('');
+    expect(r.summary).toContain('already exists');
+  });
+
+  it('fails closed when the dedup lookup keeps failing', () => {
+    // A failed listing must never be treated as an empty result — posting
+    // on it is how a transient 5xx mints a permanent duplicate.
+    const r = runFallbackStep('lookup_fail');
+    expect(r.status).toBe(1);
+    expect(r.posted).toBe('');
+    expect(r.stdout).toContain('::error::');
+    expect((r.calls.match(/^gh api user --jq/gm) ?? []).length).toBe(3);
+  });
+
+  it('fails closed when the PR state check itself fails', () => {
+    const r = runFallbackStep('state_fail');
+    expect(r.status).toBe(1);
+    expect(r.posted).toBe('');
+    expect(r.stdout).toContain('::error::');
+  });
+
+  it('skips a non-OPEN PR with exit 0', () => {
+    const r = runFallbackStep('pr_closed');
+    expect(r.status).toBe(0);
+    expect(r.posted).toBe('');
+    expect(r.summary).toContain('MERGED');
+  });
+
+  it('skips a stale run whose head moved on pull_request_target', () => {
+    const r = runFallbackStep('moved', {
+      eventName: 'pull_request_target',
+      runHead: 'oldsha',
+      prHead: 'newsha',
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).toBe('');
+    // The skip happens before the dedup lookup is even attempted.
+    expect(r.calls).not.toContain('--json comments');
+  });
+
+  it('still posts on comment/review runs where the head is not comparable', () => {
+    // Comment and review runs report main's tip as headSha, so a naive
+    // comparison would suppress the fallback on the very path the job
+    // exists for; posting wins over silence there.
+    const r = runFallbackStep('moved_comment', {
+      eventName: 'issue_comment',
+      runHead: 'oldsha',
+      prHead: 'newsha',
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).not.toBe('');
+    expect(r.calls).not.toContain('run view');
+  });
+
+  it('degrades to POSTING when the head comparison lookups fail', () => {
+    const r = runFallbackStep('runview_fail', {
+      eventName: 'pull_request_target',
+    });
+    expect(r.status).toBe(0);
+    expect(r.posted).not.toBe('');
+  });
+});


### PR DESCRIPTION
## What this PR does

This PR makes the PR-review workflow resilient to a class of failures where the review job dies abnormally and the PR is left with no review and no explanation. It adds two defenses: a preflight health probe at job start verifies that the runner user can still create files in its own directories, attempts a narrowly scoped ownership repair using the same passwordless-sudo pattern already established in the workflow, and fails fast with a clear diagnostic when repair is impossible; and a new lightweight dependent job on an ephemeral hosted runner posts the usual retry-guidance fallback comment whenever the review job fails, deriving the PR number from the event payload (a dead job's outputs do not survive a crash) and skipping when a fallback comment for the same run already exists. To make that dedup reliable, fallback comments now carry a hidden HTML marker, following the convention the acknowledgement comment already uses.

## Why it's needed

The review run for PR #8894 ([job 95028756485](https://github.com/QwenLM/qwen-code/actions/runs/31891414261/job/95028756485)) died when the self-hosted runner worker crashed in its job-finalization phase with a permission-denied error creating files under the runner user's home directory. Because the crash happened outside the normal step flow, none of the remaining steps ever ran: no fallback comment was posted, no worktree cleanup happened, and the PR sat silently with no review and no indication of what went wrong. The known trigger on the shared self-hosted pool is a prior containerised job running as root leaving root-owned or mode-broken directories behind — the workflow already documents and defends against this pattern for the workspace, but not for the runner's own directories. Even when the root cause cannot be prevented (for example, corruption that happens mid-run), the PR should still get an explanatory comment, and a job that starts on an already-broken runner should fail in seconds with a clear message instead of burning hours of review budget.

## Reviewer Test Plan

### How to verify

The two new pieces of shell were extracted from the workflow and exercised locally on macOS. The health probe was run against a directory made read-only: it detected the missing write access, attempted repair, and exited non-zero with a clear error when repair was unavailable. The fallback job's script was run against a mock `gh` across four comment scenarios: an acknowledgement comment carrying the run URL but not the marker (must not suppress posting), a fallback comment with the marker and the same run URL (must suppress), a fallback comment with the marker and a different run URL (must not suppress), and no comments at all (must post). All four behaved as designed. The full workflow passes yamllint at the same version CI uses, actionlint, and a plain YAML parse. End to end, the fallback job fires on any failed review run once this merges; the marker plus run-URL dedup is what keeps ordinary failures (where the in-job fallback step already posted) and re-runs quiet. A natural first live check is the next review failure: the PR should receive exactly one explanatory comment.

### Evidence (Before & After)

N/A (workflow change, no user-visible UI)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local simulation of the embedded scripts with mocked `gh`; yamllint 1.35.1 (same as CI), actionlint, PyYAML parse. No live end-to-end run yet — the real path activates on the next failed review run after merge.

## Risk & Scope

- Main risk or tradeoff: the preflight probe adds a few seconds to every review job, and a probe failure now fails the whole job early (deliberate — the job could not have succeeded anyway). In a crash → re-run → normal-failure sequence the PR may carry one extra fallback-style comment versus today, matching existing re-run posting behavior.
- Not validated / out of scope: repairing corruption that appears mid-run (covered only by the fallback comment, not by repair), and fixing the poisoned directory on the affected self-hosted runner host, which is an ops task. Other workflows on the same runner pool are untouched.
- Breaking changes / migration notes: none; the marker is a hidden HTML comment and existing fallback messages are unchanged apart from gaining it.

## Linked Issues

Incident reference: PR #8894 review run 31891414261 (no auto-close).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 让 PR review workflow 对一类故障具备容忍能力：review job 异常死亡时,PR 不再落得"既没有 review、也没有任何解释"的状态。具体加了两种防御:一是在 job 启动时做前置健康探测,验证 runner 用户仍能在自己的目录中创建文件,发现不可写时先用 workflow 中既有的免密 sudo 模式做范围受限的单目录属主修复,修不好就带着清晰的诊断信息快速失败;二是新增一个跑在临时托管 runner 上的轻量依赖 job,只要 review job 失败就由它兜底发布常规的重试指引评论——PR 号从事件载荷推导(死掉的 job 的 outputs 无法幸存),并且当同一 run 的兜底评论已存在时跳过。为了让去重可靠,兜底评论现在带一个隐藏的 HTML 标记,沿用确认评论已在使用的惯例。

## 为什么需要

PR #8894 的 review 运行([job 95028756485](https://github.com/QwenLM/qwen-code/actions/runs/31891414261/job/95028756485))死于 self-hosted runner worker 在 job 收尾阶段的崩溃:在 runner 用户 home 目录下创建文件时权限被拒。由于崩溃发生在正常步骤流之外,后续步骤一个都没跑:兜底评论没发、worktree 清理没做,PR 悄无声息地搁置着,没有 review 也没有任何说明。共享 self-hosted 池上的已知诱因是先前以 root 运行的容器化 job 留下 root 属主或权限损坏的目录——workflow 对 workspace 已有文档和防御,但对 runner 自身目录没有。即便根因无法预防(比如运行中途发生的损坏),PR 也应该收到一条解释性评论;而落在已损坏 runner 上的 job 应该在几秒内带着清晰信息失败,而不是烧掉几小时的 review 预算后才死掉。

## Reviewer 测试计划

### 如何验证

两段新增 shell 已从 workflow 中提取出来,在 macOS 上本地演练:健康探测对着一个只读目录运行——检测到不可写、尝试修复、修复不可用时以清晰报错非零退出。兜底 job 脚本用 mock `gh` 跑了四种评论场景:只带 run URL 但不带标记的确认评论(不得抑制发布)、带标记且同 run URL 的兜底评论(必须抑制)、带标记但 run URL 不同的兜底评论(不得抑制)、完全没有评论(必须发布),四种行为均符合设计。整个 workflow 通过与 CI 相同版本的 yamllint、actionlint 以及 YAML 解析检查。端到端地,合并后任何一次失败的 review 运行都会触发兜底 job;"标记 + run URL"去重保证普通失败(job 内兜底步骤已发过)和重跑保持安静。第一个自然的线上验证是下一次 review 失败:PR 应当恰好收到一条解释性评论。

### 证据(Before & After)

N/A(workflow 改动,无用户可见 UI)

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### 环境(可选)

用 mock `gh` 对内嵌脚本做本地模拟;yamllint 1.35.1(与 CI 相同)、actionlint、PyYAML 解析。尚无真实端到端运行——真实路径在合并后的下一次 review 失败时激活。

## 风险与范围

- 主要风险或权衡:前置探测给每个 review job 增加几秒;探测失败会让整个 job 提前失败(刻意为之——该 job 本来也不可能成功)。在"崩溃 → 重跑 → 正常失败"的序列中,PR 可能比现在多一条兜底类评论,与既有的重跑发布行为一致。
- 未验证 / 超出范围:运行中途出现的权限损坏(只由兜底评论覆盖,不做修复);修复受影响 self-hosted runner 主机上已被污染的目录属于运维操作。同池上的其他 workflow 未改动。
- 破坏性变更 / 迁移说明:无;标记是隐藏 HTML 注释,现有兜底消息除新增该标记外不变。

## 关联 Issue

事故引用:PR #8894 的 review 运行 31891414261(不自动关闭)。

</details>
