### PR TITLE
feat(review): review shell and CI scripts against the lanes that run them

### DIFF
--- a/packages/cli/src/commands/review/lib/path-rules.test.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.test.ts
@@ -60,9 +60,9 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     ['tools/win/build.bat', true],
     ['tools/win/setup.cmd', true],
     ['.github/scripts/label-pr.mjs', true],
-    // py/rb/pl are governed by the scripts arm alone — no lane rule
-    // reaches them — so each spelling is pinned here; the composite-action
-    // rows pin the same extension filter under .github/actions/.
+    // py/rb/pl are matched by no lane branch of their own — they reach the
+    // lane syllabus only through the rule's composition with the
+    // GITHUB_ACTIONS arm; these rows pin each spelling of the filter.
     ['.github/scripts/triage.py', true],
     ['.github/scripts/hook.rb', true],
     ['.github/scripts/tool.pl', true],
@@ -76,6 +76,7 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     // The suite config decides which lanes collect the script tests, and it
     // carries a live platform gate — the lane-inventory question applies.
     ['scripts/tests/vitest.config.ts', true],
+    ['scripts/tests/vitest.config.mts', true],
     // The scripts-test branch is anchored to a scripts/ directory, not to a
     // directory that merely ends in the word.
     ['myscripts/install.test.ts', false],
@@ -213,12 +214,15 @@ describe('pathRulesFor — the shell/CI-lane rule', () => {
     '.github/scripts/pr-safety-precheck.mjs',
     '.github/scripts/cleanup.sh',
     '.github/scripts/deploy.ps1',
+    '.github/scripts/release.ts',
+    '.github/actions/setup/helper.py',
   ])('pairs both checklists on a script-only diff (%s)', (path) => {
     // The security checklist says the scripts a workflow calls are part of
     // the workflow, so a diff touching only such a script needs the
     // expression-injection eyes and the lane eyes together — in every
     // extension the arm admits, not just .mjs: the .sh variant pins the
-    // shell family and the .ps1 variant the Windows lane.
+    // shell family, .ps1 the Windows lane, .ts the node-runtime family,
+    // and .py the composite-action arm's non-shell extensions.
     const out = pathRulesFor([path]);
     expect(out).toContain('GitHub Actions workflows');
     expect(out).toContain('Shell and CI scripts — the lanes that run them');

--- a/packages/cli/src/commands/review/lib/path-rules.test.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.test.ts
@@ -51,10 +51,29 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     ['docs/notes.java.md', false],
     ['scripts/build.sh', true],
     ['tools/release.bash', true],
+    // pathTool routes .ksh/.dash to shellcheck, so the lane syllabus is owed
+    // to the same files; the rest pin every remaining extension alternative.
+    ['scripts/deploy.ksh', true],
+    ['tools/setup.dash', true],
     ['scripts/win/setup.ps1', true],
+    ['ci/cleanup.zsh', true],
+    ['tools/win/build.bat', true],
+    ['tools/win/setup.cmd', true],
     ['.github/scripts/label-pr.mjs', true],
+    // A document under .github/scripts has no lanes and no shell.
+    ['.github/scripts/README.md', false],
     ['scripts/tests/install-script.test.js', true],
+    ['scripts/tests/install-script.test.mts', true],
     ['packages/cli/scripts/tests/pack.spec.ts', true],
+    // The suite config decides which lanes collect the script tests, and it
+    // carries a live platform gate — the lane-inventory question applies.
+    ['scripts/tests/vitest.config.ts', true],
+    // A Dockerfile's RUN lines are shell in the image's userland; every
+    // spelling pathTool's hadolint branch recognises is governed.
+    ['Dockerfile', true],
+    ['docker/build.dockerfile', true],
+    ['ci/Dockerfile.alpine', true],
+    ['src/mydockerfile', false],
     // A test outside the script layer is not handed a shell syllabus, and a
     // document that merely talks about one is not code.
     ['src/pay.test.ts', false],
@@ -157,6 +176,47 @@ describe('pathRulesFor — the shell/CI-lane rule', () => {
     // workflow diff needs both, and neither subsumes the other.
     const out = pathRulesFor(['.github/workflows/ci.yml']);
     expect(out).toContain('GitHub Actions workflows');
+    expect(out).toContain('Shell and CI scripts — the lanes that run them');
+  });
+
+  it('pins the composite-action branch of the shell rule itself', () => {
+    // A table row only proves SOME rule matched; this pins that the lane
+    // syllabus itself reaches a diff touching only a composite action, whose
+    // `run:` blocks are the miss this rule exists to catch.
+    expect(pathRulesFor(['.github/actions/setup/action.yml'])).toContain(
+      'Shell and CI scripts — the lanes that run them',
+    );
+  });
+
+  it('pairs both checklists on a script-only diff', () => {
+    // The security checklist says the scripts a workflow calls are part of
+    // the workflow, so a diff touching only such a script needs the
+    // expression-injection eyes and the lane eyes together.
+    const out = pathRulesFor(['.github/scripts/pr-safety-precheck.mjs']);
+    expect(out).toContain('GitHub Actions workflows');
+    expect(out).toContain('Shell and CI scripts — the lanes that run them');
+  });
+
+  it('does not govern non-script files under .github/scripts', () => {
+    // The scripts arm filters on script extensions: a README or JSON fixture
+    // there has no lanes and no shell, so it draws neither checklist.
+    expect(pathRulesFor(['.github/scripts/README.md'])).toBe('');
+  });
+
+  it('attaches to Dockerfiles, and only to the lane checklist', () => {
+    // A RUN line is shell executing in the image's userland — the
+    // Alpine/busybox lane the GNU-ism bullet is written about — but a
+    // Dockerfile is not a workflow, so the security checklist stays absent.
+    const out = pathRulesFor(['Dockerfile']);
+    expect(out).toContain('Shell and CI scripts — the lanes that run them');
+    expect(out).not.toContain('GitHub Actions workflows');
+  });
+
+  it('attaches to the suite config that decides which lanes collect the tests', () => {
+    // scripts/tests/vitest.config.ts carries the suite's platform gate; a
+    // diff editing that gate is exactly what the lane-inventory question is
+    // for.
+    const out = pathRulesFor(['scripts/tests/vitest.config.ts']);
     expect(out).toContain('Shell and CI scripts — the lanes that run them');
   });
 

--- a/packages/cli/src/commands/review/lib/path-rules.test.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.test.ts
@@ -91,11 +91,20 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     // file UNDER a directory merely named Dockerfile.* is not a Dockerfile.
     ['Dockerfile.d/README.md', false],
     ['docker/Dockerfile.prod/app.conf', false],
+    // The hadolint arm narrows pathTool's basename-prefix branch for the
+    // brief: a document about Dockerfiles is prose, not a build recipe.
+    ['docs/dockerfile.md', false],
+    ['docs/dockerfile.best-practices.md', false],
     // A test outside the script layer is not handed a shell syllabus, and a
     // document that merely talks about one is not code.
     ['src/pay.test.ts', false],
     ['scripts/build.js', false],
     ['docs/how-to-run.sh.md', false],
+    // The security checklist's script arm stops at the two workflow-helper
+    // conventions under .github: which scripts a workflow calls beyond them
+    // is content-defined, and a path matcher that cannot see run: lines
+    // must not pretend otherwise.
+    ['scripts/triage.py', false],
     // Extensionless hooks are shellchecked by toolFor's shebang branch,
     // which reads content; matches() sees the path alone and cannot tell a
     // hook from a README, so it declines to guess — a visible decision.
@@ -318,6 +327,65 @@ describe('pathRulesFor — the shell/CI-lane rule', () => {
     // The receipt: a lane and a mechanism, or it is a worry, not a finding.
     expect(out).toMatch(/If you cannot name the lane, you do not have one/);
   });
+
+  it('keeps the lane heading in diff order — no JVM-layout demotion', () => {
+    // The demotion that pushes src/test paths past the heading cap belongs
+    // to the JAVA rule's own scoping. The lane rule's first blocker bullet
+    // is written ABOUT the test scripts, so its heading must keep showing
+    // them — under the cap they are the first files owed the inventory
+    // question, not the first elided.
+    const fixtures = [
+      'src/test/resources/scripts/deploy.sh',
+      'src/test/resources/scripts/provision.sh',
+      'src/test/resources/scripts/teardown.sh',
+    ];
+    const prod = Array.from({ length: 10 }, (_, i) => `scripts/s${i}.sh`);
+    const out = pathRulesFor([...fixtures, ...prod]);
+    const heading =
+      out.split('\n').find((l) => l.startsWith('### Shell and CI scripts')) ??
+      '';
+    for (const f of fixtures) {
+      expect(heading).toContain(f);
+    }
+  });
+});
+
+describe('pathRulesFor — matcher cost stays linear on attacker-shaped paths', () => {
+  // A pull request's file paths are attacker-controlled and flow uncapped
+  // into matches() — git accepts a 96,481-character path — so a matcher
+  // that backtracks quadratically stalls every agent-brief build of the
+  // review synchronously: the JAVA checklist in this file grades exactly
+  // that shape Critical. The bound is generous to slow runners; linear
+  // matchers finish these inputs in microseconds.
+  const BOUND_MS = 250;
+
+  const msOf = (fn: () => unknown): number => {
+    const t0 = performance.now();
+    fn();
+    return performance.now() - t0;
+  };
+
+  it("the workflow rule's script arm pays no nested-quantifier cost", () => {
+    // Many segments and no dot anywhere: the arm never matches, and a
+    // nested pair of unbounded quantifiers pays that failed match once per
+    // split point — quadratic in the path length.
+    const path = `.github/actions/${'a/'.repeat(48_000)}a`;
+    expect(msOf(() => pathRulesFor([path]))).toBeLessThan(BOUND_MS);
+  }, 60_000);
+
+  it("the lane rule's scripts-test arm pays no per-anchor cost", () => {
+    // A scripts/ directory at every level: a leading anchor followed by a
+    // backtracking suffix pays the failed suffix once per anchor.
+    const path = `scripts/${'scripts/'.repeat(40_000)}x`;
+    expect(msOf(() => pathRulesFor([path]))).toBeLessThan(BOUND_MS);
+  }, 60_000);
+
+  it('pathTool pays no per-anchor cost on a repeated workflows prefix', () => {
+    // The lane rule routes every path through pathTool, whose workflow
+    // regex pays its failed suffix once per anchor whose prefix matches.
+    const path = `.github/workflows/${'.github/workflows/'.repeat(16_000)}x`;
+    expect(msOf(() => pathRulesFor([path]))).toBeLessThan(BOUND_MS);
+  }, 60_000);
 });
 
 describe('pathRulesFor — the Java/JVM rule', () => {

--- a/packages/cli/src/commands/review/lib/path-rules.test.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.test.ts
@@ -60,6 +60,14 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     ['tools/win/build.bat', true],
     ['tools/win/setup.cmd', true],
     ['.github/scripts/label-pr.mjs', true],
+    // py/rb/pl are governed by the scripts arm alone — no lane rule
+    // reaches them — so each spelling is pinned here; the composite-action
+    // rows pin the same extension filter under .github/actions/.
+    ['.github/scripts/triage.py', true],
+    ['.github/scripts/hook.rb', true],
+    ['.github/scripts/tool.pl', true],
+    ['.github/actions/setup/entrypoint.sh', true],
+    ['.github/actions/setup/README.md', false],
     // A document under .github/scripts has no lanes and no shell.
     ['.github/scripts/README.md', false],
     ['scripts/tests/install-script.test.js', true],
@@ -68,17 +76,30 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     // The suite config decides which lanes collect the script tests, and it
     // carries a live platform gate — the lane-inventory question applies.
     ['scripts/tests/vitest.config.ts', true],
+    // The scripts-test branch is anchored to a scripts/ directory, not to a
+    // directory that merely ends in the word.
+    ['myscripts/install.test.ts', false],
+    ['prescripts/tests/vitest.config.ts', false],
     // A Dockerfile's RUN lines are shell in the image's userland; every
     // spelling pathTool's hadolint branch recognises is governed.
     ['Dockerfile', true],
     ['docker/build.dockerfile', true],
     ['ci/Dockerfile.alpine', true],
     ['src/mydockerfile', false],
+    // The lane rule composes pathTool's basename-based hadolint branch: a
+    // file UNDER a directory merely named Dockerfile.* is not a Dockerfile.
+    ['Dockerfile.d/README.md', false],
+    ['docker/Dockerfile.prod/app.conf', false],
     // A test outside the script layer is not handed a shell syllabus, and a
     // document that merely talks about one is not code.
     ['src/pay.test.ts', false],
     ['scripts/build.js', false],
     ['docs/how-to-run.sh.md', false],
+    // Extensionless hooks are shellchecked by toolFor's shebang branch,
+    // which reads content; matches() sees the path alone and cannot tell a
+    // hook from a README, so it declines to guess — a visible decision.
+    ['.husky/pre-commit', false],
+    ['hooks/prepush', false],
   ])('%s → governed by a rule: %s', (path, governed) => {
     expect(PATH_RULES.some((r) => r.matches(path))).toBe(governed);
   });
@@ -188,11 +209,26 @@ describe('pathRulesFor — the shell/CI-lane rule', () => {
     );
   });
 
-  it('pairs both checklists on a script-only diff', () => {
+  it.each([
+    '.github/scripts/pr-safety-precheck.mjs',
+    '.github/scripts/cleanup.sh',
+    '.github/scripts/deploy.ps1',
+  ])('pairs both checklists on a script-only diff (%s)', (path) => {
     // The security checklist says the scripts a workflow calls are part of
     // the workflow, so a diff touching only such a script needs the
-    // expression-injection eyes and the lane eyes together.
-    const out = pathRulesFor(['.github/scripts/pr-safety-precheck.mjs']);
+    // expression-injection eyes and the lane eyes together — in every
+    // extension the arm admits, not just .mjs: the .sh variant pins the
+    // shell family and the .ps1 variant the Windows lane.
+    const out = pathRulesFor([path]);
+    expect(out).toContain('GitHub Actions workflows');
+    expect(out).toContain('Shell and CI scripts — the lanes that run them');
+  });
+
+  it('pairs both checklists on a composite-action script', () => {
+    // A script under a composite action is as much "a script the workflow
+    // calls" as one under .github/scripts — the action's shell invokes it
+    // with the same interpolated arguments — so it draws the same pairing.
+    const out = pathRulesFor(['.github/actions/setup/entrypoint.sh']);
     expect(out).toContain('GitHub Actions workflows');
     expect(out).toContain('Shell and CI scripts — the lanes that run them');
   });

--- a/packages/cli/src/commands/review/lib/path-rules.test.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.test.ts
@@ -66,6 +66,11 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     ['.github/scripts/triage.py', true],
     ['.github/scripts/hook.rb', true],
     ['.github/scripts/tool.pl', true],
+    // The node spellings the script arm admits that no lane arm rescues:
+    // js pins the bare [cm]? form, cjs the c-branch, tsx the x-suffix.
+    ['.github/scripts/helper.js', true],
+    ['.github/scripts/helper.cjs', true],
+    ['.github/scripts/helper.tsx', true],
     ['.github/actions/setup/entrypoint.sh', true],
     ['.github/actions/setup/README.md', false],
     // A document under .github/scripts has no lanes and no shell.
@@ -77,6 +82,9 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     // carries a live platform gate — the lane-inventory question applies.
     ['scripts/tests/vitest.config.ts', true],
     ['scripts/tests/vitest.config.mts', true],
+    // Mid-path form: the anchor is a scripts/tests directory wherever it
+    // sits, not the repo root.
+    ['packages/cli/scripts/tests/vitest.config.ts', true],
     // The scripts-test branch is anchored to a scripts/ directory, not to a
     // directory that merely ends in the word.
     ['myscripts/install.test.ts', false],
@@ -92,9 +100,20 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     ['Dockerfile.d/README.md', false],
     ['docker/Dockerfile.prod/app.conf', false],
     // The hadolint arm narrows pathTool's basename-prefix branch for the
-    // brief: a document about Dockerfiles is prose, not a build recipe.
+    // brief: a document about Dockerfiles is prose, not a build recipe —
+    // every extension the guard names is pinned, or a narrowing of the
+    // list ships green.
     ['docs/dockerfile.md', false],
     ['docs/dockerfile.best-practices.md', false],
+    ['docs/dockerfile.txt', false],
+    ['docs/dockerfile.rst', false],
+    ['docs/dockerfile.adoc', false],
+    ['docs/dockerfile.html', false],
+    ['docs/dockerfile.org', false],
+    ['docs/dockerfile.yaml', false],
+    ['docs/dockerfile.json', false],
+    ['Dockerfile.swp', false],
+    ['docker/Dockerfile.lock', false],
     // A test outside the script layer is not handed a shell syllabus, and a
     // document that merely talks about one is not code.
     ['src/pay.test.ts', false],
@@ -213,10 +232,14 @@ describe('pathRulesFor — the shell/CI-lane rule', () => {
   it('pins the composite-action branch of the shell rule itself', () => {
     // A table row only proves SOME rule matched; this pins that the lane
     // syllabus itself reaches a diff touching only a composite action, whose
-    // `run:` blocks are the miss this rule exists to catch.
-    expect(pathRulesFor(['.github/actions/setup/action.yml'])).toContain(
-      'Shell and CI scripts — the lanes that run them',
-    );
+    // `run:` blocks are the miss this rule exists to catch — per rule, and
+    // in both metadata spellings GitHub accepts: nothing else rescues an
+    // actions/ path, so a narrowing to one spelling fails here.
+    for (const name of ['action.yml', 'action.yaml']) {
+      const out = pathRulesFor([`.github/actions/setup/${name}`]);
+      expect(out).toContain('Shell and CI scripts — the lanes that run them');
+      expect(out).toContain('GitHub Actions workflows');
+    }
   });
 
   it.each([
@@ -225,13 +248,26 @@ describe('pathRulesFor — the shell/CI-lane rule', () => {
     '.github/scripts/deploy.ps1',
     '.github/scripts/release.ts',
     '.github/actions/setup/helper.py',
+    // Spellings the lane rule rescues through its own arms — only these
+    // per-rule assertions can pin them for the workflow arm.
+    '.github/scripts/provision.bash',
+    '.github/scripts/ci/lint.zsh',
+    '.github/scripts/provision.ksh',
+    '.github/scripts/provision.dash',
+    '.github/scripts/win/build.bat',
+    '.github/scripts/win/setup.cmd',
+    // The node spellings the arm admits beyond mjs/ts.
+    '.github/scripts/helper.js',
+    '.github/scripts/helper.cjs',
+    '.github/scripts/helper.tsx',
   ])('pairs both checklists on a script-only diff (%s)', (path) => {
     // The security checklist says the scripts a workflow calls are part of
     // the workflow, so a diff touching only such a script needs the
-    // expression-injection eyes and the lane eyes together — in every
-    // extension the arm admits, not just .mjs: the .sh variant pins the
-    // shell family, .ps1 the Windows lane, .ts the node-runtime family,
-    // and .py the composite-action arm's non-shell extensions.
+    // expression-injection eyes and the lane eyes together — asserted per
+    // rule, because the lane rule rescues bash/ksh/dash through pathTool's
+    // shellcheck branch and zsh/ps1/bat/cmd through its own suffix arm: a
+    // `.some()` row then stays green when the workflow arm alone drops a
+    // spelling, and only these assertions can see the deletion.
     const out = pathRulesFor([path]);
     expect(out).toContain('GitHub Actions workflows');
     expect(out).toContain('Shell and CI scripts — the lanes that run them');
@@ -370,6 +406,14 @@ describe('pathRulesFor — matcher cost stays linear on attacker-shaped paths', 
     // nested pair of unbounded quantifiers pays that failed match once per
     // split point — quadratic in the path length.
     const path = `.github/actions/${'a/'.repeat(48_000)}a`;
+    expect(msOf(() => pathRulesFor([path]))).toBeLessThan(BOUND_MS);
+  }, 60_000);
+
+  it("the workflow rule's scripts sub-alternative stays linear too", () => {
+    // The symmetric `.github/scripts/` side of the same arm, on the same
+    // many-segments-no-dot shape: a future edit that re-anchors it with an
+    // unbounded suffix must not ship with every timing test green.
+    const path = `.github/scripts/${'a/'.repeat(48_000)}a`;
     expect(msOf(() => pathRulesFor([path]))).toBeLessThan(BOUND_MS);
   }, 60_000);
 

--- a/packages/cli/src/commands/review/lib/path-rules.test.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.test.ts
@@ -49,6 +49,17 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     ['Main.java', true],
     ['src/main/kotlin/Main.kt', false],
     ['docs/notes.java.md', false],
+    ['scripts/build.sh', true],
+    ['tools/release.bash', true],
+    ['scripts/win/setup.ps1', true],
+    ['.github/scripts/label-pr.mjs', true],
+    ['scripts/tests/install-script.test.js', true],
+    ['packages/cli/scripts/tests/pack.spec.ts', true],
+    // A test outside the script layer is not handed a shell syllabus, and a
+    // document that merely talks about one is not code.
+    ['src/pay.test.ts', false],
+    ['scripts/build.js', false],
+    ['docs/how-to-run.sh.md', false],
   ])('%s → governed by a rule: %s', (path, governed) => {
     expect(PATH_RULES.some((r) => r.matches(path))).toBe(governed);
   });
@@ -118,6 +129,94 @@ describe('pathRulesFor — scoped, or it is noise', () => {
     expect(out).toContain('…and 5 more');
     expect(out).toContain('.github/workflows/ci9.yml');
     expect(out).not.toContain('.github/workflows/ci10.yml');
+  });
+});
+
+describe('pathRulesFor — the shell/CI-lane rule', () => {
+  // The gap it closes, measured on a real PR (#9220): eight review rounds on
+  // Linux runners hardened a workflow's wipe script, added `realpath -m` to
+  // canonicalize its path guard, and added a test pinning that line. `-m` is a
+  // GNU coreutils extension — Darwin's realpath(1) exits 1 on it — so the
+  // script's `|| printf` fallback silently keeps the raw path and the new test
+  // is red on the `test_macos` lane. Nothing caught it: every agent ran on a
+  // GNU host, and no dimension asks which lanes execute a file. A human
+  // reviewer running the suite on a Mac found it in one round.
+  it('attaches to shell, CI scripts, and the tests that drive them', () => {
+    const out = pathRulesFor([
+      'scripts/tests/qwen-pr-review-workflow.test.js',
+      'src/pay.ts',
+    ]);
+    expect(out).toContain('Shell and CI scripts — the lanes that run them');
+    expect(out).toContain('scripts/tests/qwen-pr-review-workflow.test.js');
+    expect(out).not.toContain('src/pay.ts');
+  });
+
+  it('stacks with the workflow rule on a diff that changes embedded shell', () => {
+    // The security checklist owns what the workflow does with its token; this
+    // one owns whether its `run:` block works on the hosts it runs on. A
+    // workflow diff needs both, and neither subsumes the other.
+    const out = pathRulesFor(['.github/workflows/ci.yml']);
+    expect(out).toContain('GitHub Actions workflows');
+    expect(out).toContain('Shell and CI scripts — the lanes that run them');
+  });
+
+  it('makes the lane inventory the first question, including the skipped ones', () => {
+    // The trap is structural, not linguistic: a merge_group-only job reports as
+    // "skipped" on the PR page, so a fully green PR is not evidence about it,
+    // and the first red lands in the queue where it ejects the whole batch.
+    const out = pathRulesFor(['scripts/build.sh']);
+    expect(out).toContain('which lanes execute this file');
+    expect(out).toContain('merge_group');
+    expect(out).toMatch(/reports as \*\*skipped\*\*|reports as \*\*skipped/);
+    expect(out).toContain('merge-queue failure');
+    // A suite excluded on one platform is not excluded on the others — the
+    // exact shape of the miss on #9220 (vitest.config.ts gated win32 only).
+    expect(out).toMatch(/gated off Windows is \*\*not\*\* gated off macOS/);
+  });
+
+  it('names the non-GNU userlands and the flags that differ', () => {
+    const out = pathRulesFor(['scripts/build.sh']);
+    expect(out).toContain('realpath -m');
+    expect(out).toContain('busybox');
+    expect(out).toContain('sed -i');
+    // The silent-degradation shape: the fallback means nothing fails, the
+    // guard just stops happening.
+    expect(out).toContain('silently skips the canonicalization');
+  });
+
+  it('separates the two findings a GNU-ism produces, at different severities', () => {
+    // A Linux-only production script with a GNU-ism is not a bug; the test that
+    // asserts the GNU behaviour on a macOS lane is. Collapsing the two produces
+    // either a false alarm on the script or a missed red lane.
+    const out = pathRulesFor(['scripts/build.sh']);
+    expect(out).toMatch(/not the same severity/);
+    expect(out).toMatch(/gate the \*\*test\*\*, not to weaken the script/);
+  });
+
+  it('pins the path-identity and privilege traps', () => {
+    const out = pathRulesFor(['scripts/build.sh']);
+    expect(out).toContain('/private/var/folders');
+    expect(out).toContain('realpathSync');
+    expect(out).toContain('CAP_DAC_OVERRIDE');
+    // A vacuously-passing test is the failure mode root hides behind.
+    expect(out).toMatch(/assertion vacuous/);
+  });
+
+  it('prescribes a capability probe rather than a platform check', () => {
+    // `skipIf(platform === 'darwin')` is wrong in both directions, so the fix
+    // shape has to be named — it is the part the model does not supply itself.
+    const out = pathRulesFor(['scripts/build.sh']);
+    expect(out).toContain('probe the capability, not the platform');
+    expect(out).toContain("spawnSync('realpath'");
+    expect(out).toContain('busybox lane');
+  });
+
+  it('keeps the severity and scoping discipline of the skill', () => {
+    const out = pathRulesFor(['scripts/build.sh']);
+    expect(out).toContain('reviewing this diff, not auditing this file');
+    expect(out).toContain('Favour precision over recall');
+    // The receipt: a lane and a mechanism, or it is a worry, not a finding.
+    expect(out).toMatch(/If you cannot name the lane, you do not have one/);
   });
 });
 

--- a/packages/cli/src/commands/review/lib/path-rules.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.ts
@@ -44,8 +44,14 @@ export interface PathRule {
 
 const GITHUB_ACTIONS: PathRule = {
   title: 'GitHub Actions workflows',
+  // `.github/scripts/**` is included — with a script-extension filter, so a
+  // README or data file there is not governed — because the checklist's
+  // "scripts the workflow calls are part of the workflow" paragraph is owed
+  // to a script-only diff just as much as to the workflow that calls it.
   matches: (p) =>
-    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml)$/i.test(p),
+    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml|scripts\/.+\.(?:[cm]?[jt]sx?|py|sh|bash|rb|pl))$/i.test(
+      p,
+    ),
   checklist: `A workflow is not configuration. It is code that runs on the project's own runners, with the repository's credentials, and some of its inputs come from strangers. The classes below are invisible to a reader looking for "bugs" in YAML.
 
 **You are reviewing this diff, not auditing this file.** A weakness the workflow already had, on a line this change does not touch, is out of scope — the same rule as everywhere else. What is in scope: a line this diff **adds or changes**, and a guard this diff **removes**.
@@ -72,12 +78,16 @@ const GITHUB_ACTIONS: PathRule = {
 
 const SHELL_LANES: PathRule = {
   title: 'Shell and CI scripts — the lanes that run them',
+  // Composes GITHUB_ACTIONS.matches instead of re-spelling its regex: a
+  // workflow diff must stack both checklists, and composing keeps that
+  // invariant structural rather than two literals kept identical by hand.
   matches: (p) =>
-    /\.(sh|bash|zsh|ps1|bat|cmd)$/i.test(p) ||
-    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml|scripts\/.+)$/i.test(
+    /\.(sh|bash|zsh|ksh|dash|ps1|bat|cmd)$/i.test(p) ||
+    GITHUB_ACTIONS.matches(p) ||
+    /(?:^|\/)dockerfile$|\.dockerfile$|(?:^|\/)dockerfile\./i.test(p) ||
+    /(?:^|\/)scripts\/(?:.+\.(?:test|spec)\.[cm]?[jt]sx?|tests\/vitest\.config\.[cm]?[jt]sx?)$/i.test(
       p,
-    ) ||
-    /(?:^|\/)scripts\/.+\.(?:test|spec)\.[cm]?[jt]sx?$/i.test(p),
+    ),
   checklist: `A shell script's behaviour is a property of the **host** that runs it, and a test's greenness is a property of the **lanes** that run it. Neither is in the diff, and neither is in your own shell: you are one host, and this pull request's checks are a subset of the lanes. No dimension asks which lanes exist, so a change that is green everywhere you can see it lands red where nobody looked.
 
 **You are reviewing this diff, not auditing this file.** A portability weakness on a line this change does not touch is out of scope — the same rule as everywhere else. What is in scope: a line this diff **adds or changes**, and a lane this diff **newly reaches**.

--- a/packages/cli/src/commands/review/lib/path-rules.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.ts
@@ -98,7 +98,8 @@ const SHELL_LANES: PathRule = {
   // extensions stay a deliberate superset of pathTool: shellcheck refuses
   // zsh, but the lanes that run these files are what this syllabus exists
   // for. The hadolint arm drops pathTool's basename-prefix over-match on
-  // documents (`dockerfile.md`): prose about a Dockerfile has no lanes.
+  // documents and stray artifacts (`dockerfile.rst`, `Dockerfile.swp`,
+  // `Dockerfile.lock`): prose about a Dockerfile has no lanes.
   // The scripts arm is spelled as end-anchored suffix checks plus a
   // directory check, not one leading-anchored regex: PR paths are
   // attacker-controlled, and a `(?:^|\/)scripts\/` anchor followed by a
@@ -107,7 +108,8 @@ const SHELL_LANES: PathRule = {
     const tool = pathTool(p);
     return (
       tool === 'shellcheck' ||
-      (tool === 'hadolint' && !/\.(?:md|txt|ya?ml|json)$/i.test(p)) ||
+      (tool === 'hadolint' &&
+        !/\.(?:md|rst|adoc|html?|org|txt|ya?ml|json|lock|swp)$/i.test(p)) ||
       /\.(zsh|ps1|bat|cmd)$/i.test(p) ||
       GITHUB_ACTIONS.matches(p) ||
       /(?:^|\/)scripts\/tests\/vitest\.config\.[cm]?[jt]sx?$/i.test(p) ||

--- a/packages/cli/src/commands/review/lib/path-rules.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.ts
@@ -40,20 +40,27 @@ export interface PathRule {
   title: string;
   /** Does this rule govern `path`? */
   matches(path: string): boolean;
+  /**
+   * Paths the rule's own checklist scopes out. `describePaths` lists them
+   * after the rest so a capped heading spends its names on the paths the
+   * checklist is written for; a rule without one keeps diff order.
+   */
+  outOfScope?(path: string): boolean;
   /** The checklist, agent-facing. */
   checklist: string;
 }
 
 const GITHUB_ACTIONS: PathRule = {
   title: 'GitHub Actions workflows',
-  // Scripts the workflow calls are included — under `.github/scripts/**`
-  // and under the composite actions that invoke them, with one
-  // script-extension class for both so a README or data file there is not
-  // governed — because the checklist's "scripts the workflow calls are
-  // part of the workflow" paragraph is owed to a script-only diff just as
-  // much as to the workflow that calls it.
+  // Scripts under the two workflow-helper conventions — `.github/scripts/**`
+  // and `.github/actions/*/**` — are included, with one script-extension
+  // class for both so a README or data file there is not governed. That is
+  // deliberately narrower than "the scripts the workflow calls": the full
+  // class is content-defined (this repository's own workflows call root
+  // `scripts/*.js`), and a path matcher that cannot see `run:` lines must
+  // not approximate it further than the conventions.
   matches: (p) =>
-    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml|(?:actions\/.+\/|scripts\/).+\.(?:[cm]?[jt]sx?|py|sh|bash|zsh|ksh|dash|ps1|bat|cmd|rb|pl))$/i.test(
+    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml|(?:actions\/(?:[^/]+\/)+|scripts\/(?:[^/]+\/)*)[^/]+\.(?:[cm]?[jt]sx?|py|sh|bash|zsh|ksh|dash|ps1|bat|cmd|rb|pl))$/i.test(
       p,
     ),
   checklist: `A workflow is not configuration. It is code that runs on the project's own runners, with the repository's credentials, and some of its inputs come from strangers. The classes below are invisible to a reader looking for "bugs" in YAML.
@@ -90,17 +97,22 @@ const SHELL_LANES: PathRule = {
   // the lane syllabus too — only add such classes there. The zsh/PowerShell
   // extensions stay a deliberate superset of pathTool: shellcheck refuses
   // zsh, but the lanes that run these files are what this syllabus exists
-  // for.
+  // for. The hadolint arm drops pathTool's basename-prefix over-match on
+  // documents (`dockerfile.md`): prose about a Dockerfile has no lanes.
+  // The scripts arm is spelled as end-anchored suffix checks plus a
+  // directory check, not one leading-anchored regex: PR paths are
+  // attacker-controlled, and a `(?:^|\/)scripts\/` anchor followed by a
+  // backtracking `.+` suffix is quadratic on `scripts/scripts/…` paths.
   matches: (p) => {
     const tool = pathTool(p);
     return (
       tool === 'shellcheck' ||
-      tool === 'hadolint' ||
+      (tool === 'hadolint' && !/\.(?:md|txt|ya?ml|json)$/i.test(p)) ||
       /\.(zsh|ps1|bat|cmd)$/i.test(p) ||
       GITHUB_ACTIONS.matches(p) ||
-      /(?:^|\/)scripts\/(?:.+\.(?:test|spec)\.[cm]?[jt]sx?|tests\/vitest\.config\.[cm]?[jt]sx?)$/i.test(
-        p,
-      )
+      /(?:^|\/)scripts\/tests\/vitest\.config\.[cm]?[jt]sx?$/i.test(p) ||
+      (/(?:^|\/)scripts\//i.test(p) &&
+        /(?:^|\/)[^/]+\.(?:test|spec)\.[cm]?[jt]sx?$/i.test(p))
     );
   },
   checklist: `A shell script's behaviour is a property of the **host** that runs it, and a test's greenness is a property of the **lanes** that run it. Neither is in the diff, and neither is in your own shell: you are one host, and this pull request's checks are a subset of the lanes. No dimension asks which lanes exist, so a change that is green everywhere you can see it lands red where nobody looked.
@@ -122,6 +134,7 @@ const SHELL_LANES: PathRule = {
 const JAVA: PathRule = {
   title: 'Java / JVM performance',
   matches: (p) => /\.java$/i.test(p),
+  outOfScope: isOutOfScope,
   checklist: `A Java change's most expensive regressions are decided by the JVM, not by anything a reader can see in the source: HotSpot chooses what to inline, what to scalar-replace, and what to compile at all — and a one-line change can flip each of those on a hot path. The general performance lens (N+1, repeated work, data structures) sees none of it.
 
 **You are reviewing this diff, not auditing this file.** A JVM-cost weakness the code already had, on a line this change does not touch, is out of scope — the same rule as everywhere else. What is in scope: a line this diff **adds or changes**, and a cheap path this diff **makes hot** (a new caller in a request loop, a call moved inside a loop). Test sources (\`src/test/**\`), \`package-info\`/\`module-info\`, and generated sources are out of scope for the hot-path items — nothing there is hot.
@@ -195,14 +208,16 @@ function isOutOfScope(p: string): boolean {
  * few and a count; the checklist, not the path list, is what the heading is
  * for.
  */
-function describePaths(which: readonly string[]): string {
+function describePaths(rule: PathRule, which: readonly string[]): string {
   const CAP = 10;
-  // Production paths before out-of-scope paths: the hot-path items this heading
-  // exists to introduce do not apply to test, generated, or info-only sources,
-  // so a PR that is mostly such files must not fill the heading with paths the
-  // rule explicitly scopes out.
-  const prod = which.filter((p) => !isOutOfScope(p));
-  const rest = which.filter((p) => isOutOfScope(p));
+  // Paths a rule's own checklist scopes out (the JAVA rule's test, generated,
+  // and info-only sources) go after the paths the checklist is written for, so
+  // a PR that is mostly such files must not fill the capped heading with them.
+  // A rule without such a scoping keeps diff order — the lane rule's test
+  // scripts are its primary subject, not noise to demote.
+  const demoted = rule.outOfScope ?? (() => false);
+  const prod = which.filter((p) => !demoted(p));
+  const rest = which.filter((p) => demoted(p));
   const ordered = [...prod, ...rest];
   if (ordered.length <= CAP) {
     return ordered.join(', ');
@@ -223,7 +238,12 @@ export function pathRulesFor(paths: readonly string[]): string {
   const parts = ['## Rules for the files in front of you', ''];
   for (const r of hit) {
     const which = paths.filter((p) => r.matches(p));
-    parts.push(`### ${r.title} — ${describePaths(which)}`, '', r.checklist, '');
+    parts.push(
+      `### ${r.title} — ${describePaths(r, which)}`,
+      '',
+      r.checklist,
+      '',
+    );
   }
   return parts.join('\n').trimEnd();
 }

--- a/packages/cli/src/commands/review/lib/path-rules.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.ts
@@ -53,7 +53,7 @@ const GITHUB_ACTIONS: PathRule = {
   // part of the workflow" paragraph is owed to a script-only diff just as
   // much as to the workflow that calls it.
   matches: (p) =>
-    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/(?:action\.ya?ml|.+\.(?:[cm]?[jt]sx?|py|sh|bash|zsh|ksh|dash|ps1|bat|cmd|rb|pl))|scripts\/.+\.(?:[cm]?[jt]sx?|py|sh|bash|zsh|ksh|dash|ps1|bat|cmd|rb|pl))$/i.test(
+    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml|(?:actions\/.+\/|scripts\/).+\.(?:[cm]?[jt]sx?|py|sh|bash|zsh|ksh|dash|ps1|bat|cmd|rb|pl))$/i.test(
       p,
     ),
   checklist: `A workflow is not configuration. It is code that runs on the project's own runners, with the repository's credentials, and some of its inputs come from strangers. The classes below are invisible to a reader looking for "bugs" in YAML.
@@ -86,8 +86,8 @@ const SHELL_LANES: PathRule = {
   // GITHUB_ACTIONS.matches instead of re-spelling them: a workflow diff
   // must stack both checklists, and composing keeps that invariant
   // structural rather than literals kept identical by hand. Precondition:
-  // every path class GITHUB_ACTIONS governs runs shell, so it is owed the
-  // lane syllabus too — only add such classes there. The zsh/PowerShell
+  // every path class GITHUB_ACTIONS governs runs on CI lanes and is owed
+  // the lane syllabus too — only add such classes there. The zsh/PowerShell
   // extensions stay a deliberate superset of pathTool: shellcheck refuses
   // zsh, but the lanes that run these files are what this syllabus exists
   // for.

--- a/packages/cli/src/commands/review/lib/path-rules.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.ts
@@ -33,6 +33,8 @@
 // pays a cost: the checklist rides in the brief of every matching agent, so a rule
 // that does not earn its tokens on the median matching diff is not a rule.
 
+import { pathTool } from '../script-lint.js';
+
 export interface PathRule {
   /** Named in the brief, so an agent can say which rule it applied. */
   title: string;
@@ -44,12 +46,14 @@ export interface PathRule {
 
 const GITHUB_ACTIONS: PathRule = {
   title: 'GitHub Actions workflows',
-  // `.github/scripts/**` is included — with a script-extension filter, so a
-  // README or data file there is not governed — because the checklist's
-  // "scripts the workflow calls are part of the workflow" paragraph is owed
-  // to a script-only diff just as much as to the workflow that calls it.
+  // Scripts the workflow calls are included — under `.github/scripts/**`
+  // and under the composite actions that invoke them, with one
+  // script-extension class for both so a README or data file there is not
+  // governed — because the checklist's "scripts the workflow calls are
+  // part of the workflow" paragraph is owed to a script-only diff just as
+  // much as to the workflow that calls it.
   matches: (p) =>
-    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml|scripts\/.+\.(?:[cm]?[jt]sx?|py|sh|bash|rb|pl))$/i.test(
+    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/(?:action\.ya?ml|.+\.(?:[cm]?[jt]sx?|py|sh|bash|zsh|ksh|dash|ps1|bat|cmd|rb|pl))|scripts\/.+\.(?:[cm]?[jt]sx?|py|sh|bash|zsh|ksh|dash|ps1|bat|cmd|rb|pl))$/i.test(
       p,
     ),
   checklist: `A workflow is not configuration. It is code that runs on the project's own runners, with the repository's credentials, and some of its inputs come from strangers. The classes below are invisible to a reader looking for "bugs" in YAML.
@@ -78,16 +82,27 @@ const GITHUB_ACTIONS: PathRule = {
 
 const SHELL_LANES: PathRule = {
   title: 'Shell and CI scripts — the lanes that run them',
-  // Composes GITHUB_ACTIONS.matches instead of re-spelling its regex: a
-  // workflow diff must stack both checklists, and composing keeps that
-  // invariant structural rather than two literals kept identical by hand.
-  matches: (p) =>
-    /\.(sh|bash|zsh|ksh|dash|ps1|bat|cmd)$/i.test(p) ||
-    GITHUB_ACTIONS.matches(p) ||
-    /(?:^|\/)dockerfile$|\.dockerfile$|(?:^|\/)dockerfile\./i.test(p) ||
-    /(?:^|\/)scripts\/(?:.+\.(?:test|spec)\.[cm]?[jt]sx?|tests\/vitest\.config\.[cm]?[jt]sx?)$/i.test(
-      p,
-    ),
+  // Composes pathTool's executable-script detectors and
+  // GITHUB_ACTIONS.matches instead of re-spelling them: a workflow diff
+  // must stack both checklists, and composing keeps that invariant
+  // structural rather than literals kept identical by hand. Precondition:
+  // every path class GITHUB_ACTIONS governs runs shell, so it is owed the
+  // lane syllabus too — only add such classes there. The zsh/PowerShell
+  // extensions stay a deliberate superset of pathTool: shellcheck refuses
+  // zsh, but the lanes that run these files are what this syllabus exists
+  // for.
+  matches: (p) => {
+    const tool = pathTool(p);
+    return (
+      tool === 'shellcheck' ||
+      tool === 'hadolint' ||
+      /\.(zsh|ps1|bat|cmd)$/i.test(p) ||
+      GITHUB_ACTIONS.matches(p) ||
+      /(?:^|\/)scripts\/(?:.+\.(?:test|spec)\.[cm]?[jt]sx?|tests\/vitest\.config\.[cm]?[jt]sx?)$/i.test(
+        p,
+      )
+    );
+  },
   checklist: `A shell script's behaviour is a property of the **host** that runs it, and a test's greenness is a property of the **lanes** that run it. Neither is in the diff, and neither is in your own shell: you are one host, and this pull request's checks are a subset of the lanes. No dimension asks which lanes exist, so a change that is green everywhere you can see it lands red where nobody looked.
 
 **You are reviewing this diff, not auditing this file.** A portability weakness on a line this change does not touch is out of scope — the same rule as everywhere else. What is in scope: a line this diff **adds or changes**, and a lane this diff **newly reaches**.

--- a/packages/cli/src/commands/review/lib/path-rules.ts
+++ b/packages/cli/src/commands/review/lib/path-rules.ts
@@ -70,6 +70,30 @@ const GITHUB_ACTIONS: PathRule = {
 **Favour precision over recall here.** A false alarm on a workflow costs more reviewer trust than a missed minor nit, because a YAML finding is the easiest kind for an author to dismiss. Every finding needs the concrete trigger and the concrete outcome, like any other.`,
 };
 
+const SHELL_LANES: PathRule = {
+  title: 'Shell and CI scripts — the lanes that run them',
+  matches: (p) =>
+    /\.(sh|bash|zsh|ps1|bat|cmd)$/i.test(p) ||
+    /^\.github\/(workflows\/.+\.ya?ml|actions\/.+\/action\.ya?ml|scripts\/.+)$/i.test(
+      p,
+    ) ||
+    /(?:^|\/)scripts\/.+\.(?:test|spec)\.[cm]?[jt]sx?$/i.test(p),
+  checklist: `A shell script's behaviour is a property of the **host** that runs it, and a test's greenness is a property of the **lanes** that run it. Neither is in the diff, and neither is in your own shell: you are one host, and this pull request's checks are a subset of the lanes. No dimension asks which lanes exist, so a change that is green everywhere you can see it lands red where nobody looked.
+
+**You are reviewing this diff, not auditing this file.** A portability weakness on a line this change does not touch is out of scope — the same rule as everywhere else. What is in scope: a line this diff **adds or changes**, and a lane this diff **newly reaches**.
+
+**Blockers (Critical):**
+
+- **A test that will be red on a lane this pull request does not run.** Before you accept a new or changed test that shells out, drives a CLI, or touches the filesystem, answer *which lanes execute this file*: the runner's own \`exclude\`/skip list (a suite gated off Windows is **not** gated off macOS — the gate names the platform it was written for, not the platform it is safe on), and the CI matrix, including jobs gated on \`merge_group\`, \`schedule\`, \`push\`, or a label. Those are required checks whose result the pull request page reports as **skipped**, so a green pull request is not evidence about them, and the first red is a merge-queue failure — which ejects the entry and stalls the queue for every pull request batched with it, not just this one. Name the lane, the job's test command, and the assertion in the finding. (A "Tested on" table that ticks a platform whose lane never ran is the same defect, stated by the author.)
+- **GNU-only tooling on a lane without a GNU userland.** macOS ships BSD tools and Alpine ships busybox: \`realpath -m\`, \`readlink -f\`, \`sed -i\` (BSD requires an argument), \`date -d\`, \`stat -c\`, \`find -printf\`, \`grep -P\`, \`xargs -r\`, \`base64 -w\`, \`cp --parents\`, \`sort -h\`, \`mktemp -p\`, and \`timeout\`/\`nproc\`/\`sha256sum\` (absent outright) fail or mean something else there. Two different findings fall out of this, and they are not the same severity: the **script** needs the flag on a lane that lacks it — a real bug — or the script is legitimately single-platform but a **test** asserts the flag's effect, which is a red lane for a defect that cannot exist there. Watch what a fallback does to both: \`x="$(realpath -m -- "$x" 2>/dev/null || printf '%s' "$x")"\` does not fail off-GNU, it silently skips the canonicalization — so every guard downstream is matching the raw string, and the test that was written to pin the canonicalization is the only thing that goes red.
+- **Two spellings of one path, compared as strings.** \`os.tmpdir()\` on macOS is \`/var/folders/…\` whose real path is \`/private/var/folders/…\`; a container's \`/tmp\` is often a symlink; Windows has 8.3 short names. A fixture that resolves one side (\`fs.realpathSync\`) and leaves the other raw passes only where the two spellings coincide, and if the code under test reconciles them by shelling out to a tool, that reconciliation has to exist on every lane too. The fix is to spell both sides the same way, not to resolve one more.
+- **Privilege and environment assumed from the reviewer's own shell.** root ignores a \`chmod 0o500\` fixture (\`CAP_DAC_OVERRIDE\`) so the permission failure the test needs never happens; CI containers commonly run as root; Windows has no POSIX mode bits at all; \`sudo\` may be absent or password-gated; \`$HOME\`, \`$TMPDIR\`, and \`$PATH\` are lane properties. A test that needs a real failure has to skip where it cannot get one — and a test that *passes* because the environment made the assertion vacuous is worse than one that fails.
+
+**The fix to suggest: probe the capability, not the platform.** \`skipIf(process.platform === 'darwin')\` is wrong in both directions — it skips a Mac that has coreutils on \`PATH\`, and stays green on a busybox lane that lacks the flag too. \`spawnSync('realpath', ['-m', '--', '/'], { stdio: 'ignore' }).status === 0\` gates on the thing that actually decides the outcome and keeps the coverage wherever the capability exists. Where the production code is genuinely single-platform, say so in the finding: the fix is to gate the **test**, not to weaken the script.
+
+**A finding here needs the lane and the mechanism.** "This may not work on macOS" is a worry; "\`test_macos\` is \`merge_group\`-only and runs \`npm run test:ci\` → \`test:scripts\`, Darwin's \`realpath(1)\` exits 1 on \`-m\`, so the \`|| printf\` fallback keeps the path raw and the assertion at line 2902 fails" is a finding. If you cannot name the lane, you do not have one. **Favour precision over recall here** — a portability guess is the easiest kind for an author to dismiss, and one dismissal teaches them to skip the rest of the review.`,
+};
+
 const JAVA: PathRule = {
   title: 'Java / JVM performance',
   matches: (p) => /\.java$/i.test(p),
@@ -124,7 +148,7 @@ A finding that a method "can no longer be inlined" needs the **dynamic** tier �
 };
 
 /** Every rule, in the order their checklists are appended. */
-export const PATH_RULES: PathRule[] = [GITHUB_ACTIONS, JAVA];
+export const PATH_RULES: PathRule[] = [GITHUB_ACTIONS, SHELL_LANES, JAVA];
 
 function isOutOfScope(p: string): boolean {
   return (

--- a/packages/cli/src/commands/review/script-lint.test.ts
+++ b/packages/cli/src/commands/review/script-lint.test.ts
@@ -74,6 +74,14 @@ function setup(
 describe('toolFor — dispatch by file type, not by GitHub', () => {
   it.each([
     ['.github/workflows/ci.yml', '', 'actionlint'],
+    // The long `.yaml` workflow spelling — GitHub accepts both.
+    ['.github/workflows/ci.yaml', '', 'actionlint'],
+    // The directory alone must not route: a non-YAML file under
+    // .github/workflows/ is not a workflow (pins the suffix conjunct).
+    ['.github/workflows/README.md', '', null],
+    // A stemless `.yml` dotfile in a NESTED workflows/ directory is
+    // deliberately unrouted — the pathTool comment names the divergence.
+    ['.github/workflows/nested/.yml', '', null],
     ['deploy.sh', '', 'shellcheck'],
     ['scripts/build.bash', '', 'shellcheck'],
     ['Dockerfile', '', 'hadolint'],

--- a/packages/cli/src/commands/review/script-lint.ts
+++ b/packages/cli/src/commands/review/script-lint.ts
@@ -139,7 +139,14 @@ interface PlanFile {
 export function pathTool(path: string): LintTool | null {
   const p = path.toLowerCase();
   const base = basename(p);
-  if (/(^|\/)\.github\/workflows\/.+\.ya?ml$/.test(p)) {
+  // Two linear checks — a directory test plus an end-anchored suffix — not
+  // one anchored-then-unbounded regex: PR paths are attacker-controlled,
+  // and a repeatable anchor followed by a backtracking quantifier is
+  // quadratic on `.github/workflows/.github/workflows/…` inputs.
+  if (
+    /(?:^|\/)\.github\/workflows\//.test(p) &&
+    /(?:^|\/)[^/]+\.ya?ml$/.test(p)
+  ) {
     return 'actionlint';
   }
   if (

--- a/packages/cli/src/commands/review/script-lint.ts
+++ b/packages/cli/src/commands/review/script-lint.ts
@@ -142,7 +142,10 @@ export function pathTool(path: string): LintTool | null {
   // Two linear checks — a directory test plus an end-anchored suffix — not
   // one anchored-then-unbounded regex: PR paths are attacker-controlled,
   // and a repeatable anchor followed by a backtracking quantifier is
-  // quadratic on `.github/workflows/.github/workflows/…` inputs.
+  // quadratic on `.github/workflows/.github/workflows/…` inputs. The suffix
+  // requires a stem before `.ya?ml`: a stemless `.yml`/`.yaml` dotfile in a
+  // nested workflows/ directory is deliberately unrouted even though the
+  // GITHUB_ACTIONS checklist arm still governs that path.
   if (
     /(?:^|\/)\.github\/workflows\//.test(p) &&
     /(?:^|\/)[^/]+\.ya?ml$/.test(p)


### PR DESCRIPTION
## What this PR does

Adds a third path rule to the review skill, scoped to shell scripts, workflow and composite-action files, the scripts a workflow calls, and the tests that live in a script directory. The rule asks for the lane inventory before anything else — which CI jobs actually execute the file in front of you, including the ones gated on the merge queue or a schedule, whose results a pull request reports as *skipped* — and then names four traps that a reviewer on one host cannot see: GNU-only tooling on a BSD or busybox userland (and the silent degradation a `|| fallback` gives it, where nothing fails and the guard simply stops happening), two spellings of one path compared as strings, and privilege or environment assumed from the reviewer's own shell. It separates the two findings a GNU-ism produces — a script that needs the flag on a lane that lacks it, versus a script that is legitimately single-platform while a test asserts the flag's effect — because they are not the same severity, and collapsing them yields either a false alarm on the script or a missed red lane. The fix it prescribes is a capability probe rather than a platform check, and it demands the lane and the mechanism in the finding, the way the other rules demand their receipts.

## Why it's needed

The review's dimensions are domain-blind by design, and the path rules exist for the defect classes that blindness cannot reach. This one has been open the whole time: a change that is correct on the host the review runs on and broken on a lane nobody looked at. Every review agent runs on Linux with a GNU userland, so a script that depends on a GNU-only flag, a test that asserts one, and a fixture that compares two spellings of the same path all read as green — and the lane that would have contradicted them is skipped on the pull request page, so its silence reads as agreement.

It was found the way it had to be, by a human running the suite where CI does not. A workflow-hardening pull request added a canonicalization call to a wipe guard's path match, plus a test pinning that line; the flag it uses is a GNU coreutils extension, so on macOS the call fails, the fallback keeps the path raw, and the test is red. Eight review rounds on Linux runners introduced that flag, blessed it, and never once asked which hosts run the assertion — mutation probes can only prove that a line matters, never that it exists elsewhere. The rule turns that question into part of the brief for exactly the agents whose territory contains such a file.

## Reviewer Test Plan

### How to verify

The rule is scoped, so the first thing to confirm is that it stays silent: a diff of ordinary application code and its tests gets no checklist at all, and a diff touching a script or a workflow gets this one alongside the rules that already applied. The unit tests assert both directions, including the exact phrases the checklist has to keep (the lane question, the non-GNU userlands, the path-identity and privilege traps, the capability probe, and the receipt requirement), so a mangled or truncated checklist fails rather than degrading quietly. Run the review command's suite — `npx vitest run --root packages/cli src/commands/review` — which is 76 files and 2781 tests, and the rule's own file for a faster loop.

Worth reading the checklist itself with a reviewer's eye rather than only its tests: this text rides in the brief of every agent whose territory holds a matching file, so it is judged the way the existing rules are — it must earn its tokens on the median matching diff. It measures at roughly 1.2k tokens, next to about 1.7k for the GitHub Actions rule, and costs nothing on a review that touches no matching file.

### Evidence (Before & After)

N/A — no user-visible output; the change is a checklist appended to an agent brief, plus its tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only, on Linux; the change is platform-independent TypeScript with no shell or filesystem behaviour of its own.

## Risk & Scope

- Main risk or tradeoff: the checklist is additive prompt text, so its cost is tokens in the briefs of matching agents and its risk is noise on repositories whose maintainers never asked for it. Both are bounded by the matcher, which deliberately excludes ordinary test files — a rule that fires on every review is a rule that gets skimmed.
- Not validated / out of scope: the rule's effect on real findings has not been A/B measured against a live model; the reasoning is the mechanism it names, and the missed defect that motivated it. Nothing here changes the review's plumbing, its roster, or any other rule.
- Breaking changes / migration notes: none.

## Linked Issues

None — the gap was observed on a pull request of this repository's own CI, not tracked by an issue.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 review skill 增加了第三条 path rule，作用范围是 shell 脚本、workflow 与 composite action 文件、workflow 调用的脚本，以及位于脚本目录下的测试。这条规则要求首先回答 lane 清单——到底哪些 CI job 会真正执行眼前这个文件，包括那些以 merge queue 或定时任务为触发条件、在 PR 页面上显示为 *skipped* 的 job——然后点名四类只在一台主机上评审时看不见的陷阱：在 BSD 或 busybox userland 上使用 GNU 独有的工具参数（以及 `|| fallback` 带来的静默降级：没有任何东西失败，只是那道保护不再发生）、把同一路径的两种拼法当字符串比较、以及从评审者自己的 shell 想当然推断出的权限与环境假设。它把一个 GNU-ism 会产生的两种结论区分开——脚本在缺少该参数的 lane 上确实需要它，与脚本本就合法地只跑单一平台、而某个测试却断言了该参数的效果——因为两者严重度不同，混为一谈的结果要么是对脚本的误报，要么是漏掉一条变红的 lane。它给出的修法是探测能力而非探测平台，并且和其他规则一样，要求 finding 必须点名 lane 与机制作为收据。

## 为什么需要

review 的各个维度在设计上就是领域无关的，而 path rules 正是为这种"无关性"够不到的缺陷类别而存在。这一类一直是空白：改动在评审所在的主机上是正确的，却在没人看过的 lane 上是坏的。所有 review agent 都跑在带 GNU userland 的 Linux 上，于是依赖 GNU 独有参数的脚本、断言这种参数效果的测试、以及比较同一路径两种拼法的 fixture，读起来全都是绿的——而本该反驳它们的那条 lane 在 PR 页面上是 skipped，于是它的沉默被当成了同意。

它最终是以唯一可能的方式被发现的：一个人在 CI 不覆盖的环境里跑了这套测试。一个加固 workflow 的 PR 给 wipe guard 的路径匹配加了一次规范化调用，并补了一个测试钉住这行；它用的参数是 GNU coreutils 的扩展，因此在 macOS 上该调用失败、fallback 保留原始路径、测试变红。八轮跑在 Linux runner 上的 review 亲手引入了这个参数、放行了它，却从没问过"哪些主机会执行这条断言"——变异测试只能证明某一行有用，永远证明不了它在别处也存在。这条规则把这个问题变成了 brief 的一部分，且只发给territory 中真的含有这类文件的 agent。

## Reviewer 测试计划

### 如何验证

这条规则是有作用域的，所以第一件要确认的事是它保持沉默：一个只改普通应用代码及其测试的 diff 完全拿不到任何 checklist，而一个改到脚本或 workflow 的 diff 会在原有规则之外拿到这一条。单元测试对两个方向都做了断言，并且钉住了 checklist 必须保留的关键措辞（lane 问题、非 GNU userland、路径同一性与权限陷阱、能力探测、收据要求），因此 checklist 被改坏或被截断会直接失败，而不是悄悄退化。运行 review 命令的测试套件 `npx vitest run --root packages/cli src/commands/review`，共 76 个文件、2781 个测试；快速迭代时可只跑该规则自己的测试文件。

也值得用评审者的眼光直接读一遍 checklist 本身，而不只是看它的测试：这段文字会进入每一个 territory 含匹配文件的 agent 的 brief，因此评判标准和现有规则一样——它必须在"典型的匹配 diff"上对得起自己占用的 token。实测约 1.2k tokens，作为对照，GitHub Actions 那条约 1.7k；而在不含匹配文件的 review 上它的成本为零。

### 证据（Before & After）

N/A——没有用户可见输出；这个改动是追加到 agent brief 的一段 checklist，外加它的测试。

### 测试平台

|    OS    | 状态 |
| :------: | :--: |
| 🍏 macOS |  ⚠️  |
| 🪟 Windows |  ⚠️  |
| 🐧 Linux |  ✅  |

### 环境（可选）

仅单元测试，运行在 Linux 上；改动是与平台无关的 TypeScript，本身没有任何 shell 或文件系统行为。

## 风险与范围

- 主要风险或权衡：checklist 是纯追加的 prompt 文本，所以它的成本是匹配 agent brief 中的 token，风险是对那些从没要求过它的仓库造成噪音。两者都由 matcher 兜住，而 matcher 刻意排除了普通测试文件——一条每次 review 都触发的规则等于一条会被略读的规则。
- 未验证 / 不在范围内：这条规则对真实 finding 的效果没有对着线上模型做 A/B 度量；依据是它点名的机制，以及催生它的那次漏检。本 PR 不改动 review 的任何管道、roster 或其他规则。
- 破坏性变更 / 迁移说明：无。

</details>
