### PR TITLE
fix(ci): minimize new spam comments on creation

### DIFF
--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -90,6 +90,10 @@ describe('auto-minimize-spam: event fast path', () => {
       /comment\.user\.type != 'Bot'[\s\S]*!contains\([\s\S]*OWNER[\s\S]*MEMBER[\s\S]*COLLABORATOR[\s\S]*github\.event\.comment\.author_association/,
     );
     assert.match(jobGuard, /head\.repo\.full_name == github\.repository/);
+    assert.match(
+      jobGuard,
+      /github\.event_name != 'pull_request_review_comment' \|\|/,
+    );
     assert.match(String(doc.concurrency.group), /comment\.node_id/);
     assert.equal(
       checkoutStep.with.ref,
@@ -103,14 +107,22 @@ describe('auto-minimize-spam: event fast path', () => {
       minimizeStep.env?.EVENT_COMMENT_NODE_ID,
       '${{ github.event.comment.node_id }}',
     );
-    assert.match(minimizeStep.run, /\[ -n "\$EVENT_COMMENT_NODE_ID" \]/);
+    assert.equal(
+      minimizeStep.run.match(/\[ -n "\$EVENT_COMMENT_NODE_ID" \]/g)?.length,
+      2,
+    );
     assert.match(
       minimizeStep.run,
       /ALL_CANDIDATES="\$\{EVENT_COMMENT_LOGIN\}"\$'\\t'"\$\{EVENT_COMMENT_NODE_ID\}"/,
     );
     assert.match(
       minimizeStep.run,
-      /--jq '\.data\.node\.isMinimized \/\/ "missing"'[\s\S]*\|\| printf 'missing'/,
+      /--jq 'if \.data\.node == null then "missing" else \.data\.node\.isMinimized end'[\s\S]*\|\| printf 'missing'/,
+    );
+    assert.doesNotMatch(minimizeStep.run, /2>\/dev\/null/);
+    assert.match(
+      minimizeStep.run,
+      /\[ "\$is_minimized" = "missing" \] && continue/,
     );
   });
 });

--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -85,10 +85,10 @@ describe('auto-minimize-spam: event fast path', () => {
 
   it('processes the triggering comment without dropping bursts', () => {
     const jobGuard = String(minimizeJob.if);
-    assert.match(jobGuard, /comment\.user\.type != 'Bot'/);
-    assert.match(jobGuard, /OWNER/);
-    assert.match(jobGuard, /MEMBER/);
-    assert.match(jobGuard, /COLLABORATOR/);
+    assert.match(
+      jobGuard,
+      /comment\.user\.type != 'Bot'[\s\S]*!contains\([\s\S]*OWNER[\s\S]*MEMBER[\s\S]*COLLABORATOR[\s\S]*github\.event\.comment\.author_association/,
+    );
     assert.match(jobGuard, /head\.repo\.full_name == github\.repository/);
     assert.match(String(doc.concurrency.group), /comment\.node_id/);
     assert.equal(
@@ -106,7 +106,11 @@ describe('auto-minimize-spam: event fast path', () => {
     assert.match(minimizeStep.run, /\[ -n "\$EVENT_COMMENT_NODE_ID" \]/);
     assert.match(
       minimizeStep.run,
-      /ALL_CANDIDATES=.*EVENT_COMMENT_LOGIN.*EVENT_COMMENT_NODE_ID/,
+      /ALL_CANDIDATES="\$\{EVENT_COMMENT_LOGIN\}"\$'\\t'"\$\{EVENT_COMMENT_NODE_ID\}"/,
+    );
+    assert.match(
+      minimizeStep.run,
+      /--jq '\.data\.node\.isMinimized \/\/ "missing"'[\s\S]*\|\| printf 'missing'/,
     );
   });
 });

--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -4,6 +4,7 @@
 // guard, widens permissions, moves GH_TOKEN to job-level env, or drops
 // persist-credentials would ship without any other test to catch it.
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -21,6 +22,18 @@ const minimizeJob = doc.jobs.minimize;
 const steps = minimizeJob.steps;
 const checkoutStep = steps.find((s) => s.uses?.startsWith('actions/checkout'));
 const minimizeStep = steps.find((s) => s.name?.includes('Minimize comments'));
+
+function runMinimizableStateFilter(payload) {
+  assert.ok(minimizeStep, 'minimize step must exist');
+  const filter = [...minimizeStep.run.matchAll(/--jq '([^']+)'/g)]
+    .map((match) => match[1])
+    .find((candidate) => candidate.includes('.data.node'));
+  assert.ok(filter, 'minimizable state jq filter must exist');
+  return execFileSync('jq', ['-c', filter], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  }).trim();
+}
 
 describe('auto-minimize-spam: repository guard', () => {
   it('gates the job on the canonical repository', () => {
@@ -115,10 +128,23 @@ describe('auto-minimize-spam: event fast path', () => {
       minimizeStep.run,
       /ALL_CANDIDATES="\$\{EVENT_COMMENT_LOGIN\}"\$'\\t'"\$\{EVENT_COMMENT_NODE_ID\}"/,
     );
-    assert.match(
-      minimizeStep.run,
-      /--jq 'if \.data\.node == null then "missing" else \.data\.node\.isMinimized end'[\s\S]*\|\| printf 'missing'/,
+    assert.equal(
+      runMinimizableStateFilter({ data: { node: null } }),
+      '"missing"',
     );
+    assert.equal(
+      runMinimizableStateFilter({
+        data: { node: { isMinimized: false } },
+      }),
+      'false',
+    );
+    assert.equal(
+      runMinimizableStateFilter({
+        data: { node: { isMinimized: true } },
+      }),
+      'true',
+    );
+    assert.match(minimizeStep.run, /\|\| printf 'missing'/);
     assert.doesNotMatch(minimizeStep.run, /2>\/dev\/null/);
     assert.match(
       minimizeStep.run,

--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -71,6 +71,46 @@ describe('auto-minimize-spam: credential scoping', () => {
   });
 });
 
+describe('auto-minimize-spam: event fast path', () => {
+  it('handles new comments and blocklist changes with an hourly fallback', () => {
+    assert.equal(doc.on.schedule[0].cron, '30 * * * *');
+    assert.deepEqual(doc.on.issue_comment.types, ['created']);
+    assert.deepEqual(doc.on.pull_request_review_comment.types, ['created']);
+    assert.deepEqual(doc.on.push, {
+      branches: ['main'],
+      paths: ['.github/spam-blocklist.txt'],
+    });
+    assert.match(String(minimizeJob.if), /github\.event_name == 'push'/);
+  });
+
+  it('processes the triggering comment without dropping bursts', () => {
+    const jobGuard = String(minimizeJob.if);
+    assert.match(jobGuard, /comment\.user\.type != 'Bot'/);
+    assert.match(jobGuard, /OWNER/);
+    assert.match(jobGuard, /MEMBER/);
+    assert.match(jobGuard, /COLLABORATOR/);
+    assert.match(jobGuard, /head\.repo\.full_name == github\.repository/);
+    assert.match(String(doc.concurrency.group), /comment\.node_id/);
+    assert.equal(
+      checkoutStep.with.ref,
+      '${{ github.event.repository.default_branch }}',
+    );
+    assert.equal(
+      minimizeStep.env?.EVENT_COMMENT_LOGIN,
+      '${{ github.event.comment.user.login }}',
+    );
+    assert.equal(
+      minimizeStep.env?.EVENT_COMMENT_NODE_ID,
+      '${{ github.event.comment.node_id }}',
+    );
+    assert.match(minimizeStep.run, /\[ -n "\$EVENT_COMMENT_NODE_ID" \]/);
+    assert.match(
+      minimizeStep.run,
+      /ALL_CANDIDATES=.*EVENT_COMMENT_LOGIN.*EVENT_COMMENT_NODE_ID/,
+    );
+  });
+});
+
 describe('auto-minimize-spam: comment coverage', () => {
   it('scans inline PR review comments without re-minimizing them', () => {
     assert.ok(minimizeStep, 'minimize step must exist');

--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -107,7 +107,10 @@ describe('auto-minimize-spam: event fast path', () => {
       jobGuard,
       /github\.event_name != 'pull_request_review_comment' \|\|/,
     );
-    assert.match(String(doc.concurrency.group), /comment\.node_id/);
+    assert.equal(
+      String(doc.concurrency.group),
+      "auto-minimize-spam-${{ github.event.comment.node_id || 'scan' }}",
+    );
     assert.equal(
       checkoutStep.with.ref,
       '${{ github.event.repository.default_branch }}',
@@ -129,10 +132,6 @@ describe('auto-minimize-spam: event fast path', () => {
       /ALL_CANDIDATES="\$\{EVENT_COMMENT_LOGIN\}"\$'\\t'"\$\{EVENT_COMMENT_NODE_ID\}"/,
     );
     assert.equal(
-      runMinimizableStateFilter({ data: { node: null } }),
-      '"missing"',
-    );
-    assert.equal(
       runMinimizableStateFilter({
         data: { node: { isMinimized: false } },
       }),
@@ -144,7 +143,13 @@ describe('auto-minimize-spam: event fast path', () => {
       }),
       'true',
     );
-    assert.match(minimizeStep.run, /\|\| printf 'missing'/);
+    assert.match(
+      minimizeStep.env?.LOOKBACK_HOURS,
+      /github\.event_name == 'push' && '72'/,
+    );
+    assert.match(minimizeStep.run, /if ! is_minimized="\$\(/);
+    assert.match(minimizeStep.run, /then\n\s+is_minimized="missing"\n\s+fi/);
+    assert.doesNotMatch(minimizeStep.run, /\|\| printf 'missing'/);
     assert.doesNotMatch(minimizeStep.run, /2>\/dev\/null/);
     assert.match(
       minimizeStep.run,

--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -29,7 +29,7 @@ function runMinimizableStateFilter(payload) {
     .map((match) => match[1])
     .find((candidate) => candidate.includes('.data.node'));
   assert.ok(filter, 'minimizable state jq filter must exist');
-  return execFileSync('jq', ['-c', filter], {
+  return execFileSync('jq', ['-r', filter], {
     input: JSON.stringify(payload),
     encoding: 'utf8',
   }).trim();
@@ -123,6 +123,7 @@ describe('auto-minimize-spam: event fast path', () => {
       minimizeStep.env?.EVENT_COMMENT_NODE_ID,
       '${{ github.event.comment.node_id }}',
     );
+    assert.doesNotMatch(minimizeStep.run, /\$\{\{\s*github\.event\./);
     assert.equal(
       minimizeStep.run.match(/\[ -n "\$EVENT_COMMENT_NODE_ID" \]/g)?.length,
       2,
@@ -143,9 +144,15 @@ describe('auto-minimize-spam: event fast path', () => {
       }),
       'true',
     );
-    assert.match(
+    assert.equal(
       minimizeStep.env?.LOOKBACK_HOURS,
-      /github\.event_name == 'push' && '72'/,
+      "${{ inputs.hours || (github.event_name == 'push' && '72') || '2' }}",
+    );
+    assert.equal(
+      runMinimizableStateFilter({
+        data: { node: null },
+      }),
+      'missing',
     );
     assert.match(minimizeStep.run, /if ! is_minimized="\$\(/);
     assert.match(minimizeStep.run, /then\n\s+is_minimized="missing"\n\s+fi/);

--- a/.github/scripts/auto-minimize-spam.test.mjs
+++ b/.github/scripts/auto-minimize-spam.test.mjs
@@ -98,9 +98,14 @@ describe('auto-minimize-spam: event fast path', () => {
 
   it('processes the triggering comment without dropping bursts', () => {
     const jobGuard = String(minimizeJob.if);
+    const flatJobGuard = jobGuard.replace(/\s+/g, ' ');
     assert.match(
       jobGuard,
       /comment\.user\.type != 'Bot'[\s\S]*!contains\([\s\S]*OWNER[\s\S]*MEMBER[\s\S]*COLLABORATOR[\s\S]*github\.event\.comment\.author_association/,
+    );
+    assert.match(
+      flatJobGuard,
+      /author_association \) && \( github\.event_name != 'pull_request_review_comment' \|\| github\.event\.pull_request\.head\.repo\.full_name == github\.repository \)/,
     );
     assert.match(jobGuard, /head\.repo\.full_name == github\.repository/);
     assert.match(

--- a/.github/workflows/auto-minimize-spam.yml
+++ b/.github/workflows/auto-minimize-spam.yml
@@ -20,7 +20,7 @@ name: 'Auto-minimize spam comments'
 
 on:
   schedule:
-    - cron: '30 * * * *' # Every hour at :30
+    - cron: '3/5 * * * *' # Every 5 minutes, avoiding :00
   workflow_dispatch:
     inputs:
       hours:

--- a/.github/workflows/auto-minimize-spam.yml
+++ b/.github/workflows/auto-minimize-spam.yml
@@ -190,8 +190,10 @@ jobs:
                       ... on Minimizable { isMinimized }
                     }
                   }
-                " --jq '.data.node.isMinimized'
+                " --jq '.data.node.isMinimized // "missing"' 2>/dev/null \
+                  || printf 'missing'
               )"
+              [ "$is_minimized" = "missing" ] && continue
               [ "$is_minimized" = "true" ] && continue
               MATCHED_IDS="${MATCHED_IDS}${node_id}"$'\n'
               MATCHED_COUNT=$((MATCHED_COUNT + 1))

--- a/.github/workflows/auto-minimize-spam.yml
+++ b/.github/workflows/auto-minimize-spam.yml
@@ -190,7 +190,7 @@ jobs:
                       ... on Minimizable { isMinimized }
                     }
                   }
-                " --jq '.data.node.isMinimized // "missing"' 2>/dev/null \
+                " --jq 'if .data.node == null then "missing" else .data.node.isMinimized end' \
                   || printf 'missing'
               )"
               [ "$is_minimized" = "missing" ] && continue

--- a/.github/workflows/auto-minimize-spam.yml
+++ b/.github/workflows/auto-minimize-spam.yml
@@ -79,7 +79,7 @@ jobs:
       - name: 'Minimize comments from blocklisted users'
         env:
           GH_TOKEN: '${{ github.token }}'
-          LOOKBACK_HOURS: "${{ inputs.hours || '2' }}"
+          LOOKBACK_HOURS: "${{ inputs.hours || (github.event_name == 'push' && '72') || '2' }}"
           EVENT_COMMENT_LOGIN: '${{ github.event.comment.user.login }}'
           EVENT_COMMENT_NODE_ID: '${{ github.event.comment.node_id }}'
         run: |-
@@ -183,16 +183,17 @@ jobs:
             [ -z "$login" ] && continue
             login_lc="$(printf '%s' "$login" | tr '[:upper:]' '[:lower:]')"
             if printf '%s\n' "$BLOCKED_USERS" | grep -qxF "$login_lc"; then
-              is_minimized="$(
+              if ! is_minimized="$(
                 gh api graphql -F id="$node_id" -f query="
                   query(\$id: ID!) {
                     node(id: \$id) {
                       ... on Minimizable { isMinimized }
                     }
                   }
-                " --jq 'if .data.node == null then "missing" else .data.node.isMinimized end' \
-                  || printf 'missing'
-              )"
+                " --jq 'if .data.node == null then "missing" else .data.node.isMinimized end'
+              )"; then
+                is_minimized="missing"
+              fi
               [ "$is_minimized" = "missing" ] && continue
               [ "$is_minimized" = "true" ] && continue
               MATCHED_IDS="${MATCHED_IDS}${node_id}"$'\n'

--- a/.github/workflows/auto-minimize-spam.yml
+++ b/.github/workflows/auto-minimize-spam.yml
@@ -1,10 +1,9 @@
 name: 'Auto-minimize spam comments'
 
-# Periodically scan recent issue/PR comments and minimize any from
-# users listed in .github/spam-blocklist.txt. This cleans up spam
-# comments that were posted before a block was applied, and catches
-# any that slip through during the window between a spam comment
-# and the manual block action.
+# Minimize new issue/PR comments from users listed in
+# .github/spam-blocklist.txt. Comment events check only the triggering
+# comment; blocklist updates and the hourly scan clean up older comments
+# and cover events that run with a read-only token.
 #
 # The blocklist is a plain-text file in the repo — one username per
 # line, case-insensitive, # for comments. No special API scopes
@@ -20,7 +19,14 @@ name: 'Auto-minimize spam comments'
 
 on:
   schedule:
-    - cron: '3/5 * * * *' # Every 5 minutes, avoiding :00
+    - cron: '30 * * * *' # Every hour at :30
+  issue_comment:
+    types: ['created']
+  pull_request_review_comment:
+    types: ['created']
+  push:
+    branches: ['main']
+    paths: ['.github/spam-blocklist.txt']
   workflow_dispatch:
     inputs:
       hours:
@@ -35,12 +41,31 @@ permissions:
   pull-requests: 'write'
 
 concurrency:
-  group: 'auto-minimize-spam'
+  group: "auto-minimize-spam-${{ github.event.comment.node_id || 'scan' }}"
   cancel-in-progress: false
 
 jobs:
   minimize:
-    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    if: >-
+      ${{
+        github.repository == 'QwenLM/qwen-code' &&
+        (
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'push' ||
+          (
+            github.event.comment.user.type != 'Bot' &&
+            !contains(
+              fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+              github.event.comment.author_association
+            ) &&
+            (
+              github.event_name != 'pull_request_review_comment' ||
+              github.event.pull_request.head.repo.full_name == github.repository
+            )
+          )
+        )
+      }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 10
     steps:
@@ -48,12 +73,15 @@ jobs:
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:
           sparse-checkout: '.github/spam-blocklist.txt'
+          ref: '${{ github.event.repository.default_branch }}'
           persist-credentials: false
 
       - name: 'Minimize comments from blocklisted users'
         env:
           GH_TOKEN: '${{ github.token }}'
           LOOKBACK_HOURS: "${{ inputs.hours || '2' }}"
+          EVENT_COMMENT_LOGIN: '${{ github.event.comment.user.login }}'
+          EVENT_COMMENT_NODE_ID: '${{ github.event.comment.node_id }}'
         run: |-
           set -euo pipefail
 
@@ -64,7 +92,11 @@ jobs:
           write_summary() {
             {
               echo "## Summary"
-              echo "- Scanned comments since: ${SINCE}"
+              if [ -n "$EVENT_COMMENT_NODE_ID" ]; then
+                echo "- Scanned comment: ${EVENT_COMMENT_NODE_ID}"
+              else
+                echo "- Scanned comments since: ${SINCE}"
+              fi
               echo "- Blocklisted users: ${BLOCKED_COUNT}"
               echo "- Comments minimized: $1"
             } >> "$GITHUB_STEP_SUMMARY"
@@ -95,51 +127,55 @@ jobs:
             exit 0
           fi
 
-          # ── 2. Fetch recent unminimized comments via GraphQL ──────────
-          ALL_UNMINIMIZED="$(
-            gh api graphql -f query="
-              query {
-                repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
-                  issues(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, filterBy: {since: \"${SINCE}\"}) {
-                    nodes {
-                      number
-                      comments(last: 30) {
-                        nodes { id author { login } isMinimized }
+          # ── 2. Select the triggering comment or scan recent comments ────
+          if [ -n "$EVENT_COMMENT_NODE_ID" ]; then
+            ALL_CANDIDATES="${EVENT_COMMENT_LOGIN}"$'\t'"${EVENT_COMMENT_NODE_ID}"
+          else
+            ALL_UNMINIMIZED="$(
+              gh api graphql -f query="
+                query {
+                  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+                    issues(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}, filterBy: {since: \"${SINCE}\"}) {
+                      nodes {
+                        number
+                        comments(last: 30) {
+                          nodes { id author { login } isMinimized }
+                        }
                       }
                     }
-                  }
-                  pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
-                    nodes {
-                      number
-                      comments(last: 30) {
-                        nodes { id author { login } isMinimized }
+                    pullRequests(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                      nodes {
+                        number
+                        comments(last: 30) {
+                          nodes { id author { login } isMinimized }
+                        }
                       }
                     }
                   }
                 }
-              }
-            " --jq '
-              [
-                .data.repository.issues.nodes[].comments.nodes[],
-                .data.repository.pullRequests.nodes[].comments.nodes[]
-              ]
-              | map(select(.isMinimized == false and .author != null))
-              | .[] | "\(.author.login)\t\(.id)"
-            '
-          )"
-
-          REVIEW_CANDIDATES="$(
-            gh api --method GET --paginate \
-              "repos/${REPO}/pulls/comments" \
-              -f since="$SINCE" \
-              -F per_page=100 \
-              --jq '
-                .[]
-                | select(.user != null and .node_id != null)
-                | "\(.user.login)\t\(.node_id)"
+              " --jq '
+                [
+                  .data.repository.issues.nodes[].comments.nodes[],
+                  .data.repository.pullRequests.nodes[].comments.nodes[]
+                ]
+                | map(select(.isMinimized == false and .author != null))
+                | .[] | "\(.author.login)\t\(.id)"
               '
-          )"
-          ALL_CANDIDATES="${ALL_UNMINIMIZED}"$'\n'"${REVIEW_CANDIDATES}"
+            )"
+
+            REVIEW_CANDIDATES="$(
+              gh api --method GET --paginate \
+                "repos/${REPO}/pulls/comments" \
+                -f since="$SINCE" \
+                -F per_page=100 \
+                --jq '
+                  .[]
+                  | select(.user != null and .node_id != null)
+                  | "\(.user.login)\t\(.node_id)"
+                '
+            )"
+            ALL_CANDIDATES="${ALL_UNMINIMIZED}"$'\n'"${REVIEW_CANDIDATES}"
+          fi
 
           MATCHED_IDS=""
           MATCHED_COUNT=0


### PR DESCRIPTION
## What this PR does

Listens for newly created issue/PR conversation comments and inline review comments, then checks only the triggering comment against the existing repository blocklist and minimizes it when matched. A blocklist update on the default branch immediately scans recent comments, while the hourly scan and manual dispatch remain as fallback paths for older comments and inline comments on fork pull requests, whose event token is read-only.

## Why it's needed

#9229 added inline review comment coverage, but the hourly schedule can leave disruptive comments visible for more than an hour; the longest observed gap after that merge was 76 minutes. Increasing the full scan to every five minutes would create twelve times as many repository-wide scans and still depend on GitHub's delayed scheduling, so this follow-up uses comment events for known blocked users, scans when the blocklist changes, and keeps the existing hourly scan for recovery.

## Reviewer Test Plan

### How to verify

Confirm that a newly created conversation comment or same-repository inline review comment from a blocklisted external user is minimized without scanning other comments. Confirm that a blocklist change merged to the default branch scans recent comments, separate comments use separate concurrency groups, trusted collaborators and bots do not start the event job, and hourly/manual runs still scan recent conversation and inline review comments.

### Evidence (Before & After)

N/A — workflow-only change. Before: cleanup depended on one scheduled repository scan per hour. After: eligible new comments are checked individually when created, newly blocked users trigger a recovery scan, and the hourly scan remains as a fallback.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

The workflow regression test passes (8/8), along with `actionlint`, Prettier, and `git diff --check`. The event path was also executed locally with mocked GitHub API responses for both blocklisted and unlisted users.

## Risk & Scope

- Main risk or tradeoff: An untrusted, non-bot comment starts a short runner before the repository blocklist can be read; trusted collaborators and bots are filtered before runner allocation.
- Not validated / out of scope: Inline review comments on fork pull requests use the hourly fallback because their event token is read-only. GitHub may delay scheduled workflows, and minimization cannot prevent the original comment notification.
- Breaking changes / migration notes: None. Existing permissions, blocklist format, hourly schedule, lookback window, and manual dispatch remain in place.

## Linked Issues

Follow-up to #9229.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

监听新建的 Issue/PR 对话评论和内联 Review 评论，仅将触发事件的这一条评论与仓库现有黑名单进行匹配，命中后立即折叠。黑名单变更合入默认分支时会立即扫描最近评论；每小时扫描和手动触发继续保留，作为更早评论以及 fork PR 内联评论的兜底路径，后者的事件令牌只有只读权限。

## 为什么需要

#9229 增加了内联 Review 评论覆盖，但每小时调度仍可能让干扰性评论暴露超过一小时；该修改合并后观察到的最长相邻执行间隔为 76 分钟。把整库扫描提高到每五分钟会产生十二倍的扫描次数，并且仍受 GitHub 调度延迟影响，因此本次对已拉黑用户使用评论事件快速路径，在黑名单变化时补扫，并保留现有小时扫描用于恢复补漏。

## Reviewer Test Plan

### 如何验证

确认黑名单外部用户新建对话评论或同仓库内联 Review 评论时，只处理触发事件的评论，无需扫描其他评论。确认黑名单变更合入默认分支时会扫描最近评论，不同评论使用不同的并发组，可信协作者和机器人不会启动事件任务，并且每小时及手动任务仍会扫描最近的对话评论和内联 Review 评论。

### 证据（修改前后）

不适用——仅修改 workflow。修改前：清理依赖每小时一次的仓库扫描。修改后：符合条件的新评论会在创建时被单独检查，新拉黑用户会触发补扫，同时保留每小时扫描作为兜底。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

workflow 回归测试（8/8）、`actionlint`、Prettier 和 `git diff --check` 均已通过；同时使用模拟的 GitHub API 响应分别执行了黑名单用户和非黑名单用户的事件路径。

## 风险与范围

- 主要风险或权衡：不可信的非机器人评论需要先启动一个短任务才能读取仓库黑名单；可信协作者和机器人会在分配 runner 前被过滤。
- 未验证 / 范围外：fork PR 的内联 Review 评论由于事件令牌只读，会使用每小时兜底扫描。GitHub 仍可能延迟定时任务，并且折叠无法阻止原始评论通知。
- 破坏性变更 / 迁移说明：无。现有权限、黑名单格式、每小时调度、回看窗口和手动触发均保持不变。

## 关联事项

#9229 的后续修改。

</details>
