### PR TITLE
fix(review): keep the presubmit overlap list out of the canonical findings artifact

### DIFF
--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -980,10 +980,10 @@ Use the **HEAD commit SHA** captured in Step 1. If not captured, fall back to `"
 
 **Run pre-submission checks**: the bundled `qwen review presubmit` subcommand performs self-PR detection, CI / build status classification, and existing-Qwen-comment classification in one pass — three deterministic gh-API queries collapsed into a single JSON report. Read the report to drive the rest of Step 7.
 
-Optionally write the `(path, line)` anchors of the comments you're about to post — every Critical and Suggestion finding headed for the `comments` array — so existing-comment Overlap can be detected. An entry for a **carried-forward** finding keeps the finding's ledger `id` (its `R<round>-<n>`); an entry for a **fresh** finding of THIS round omits `id` — a fresh id cannot appear in any comment posted before this round, and carrying one would let the new claim ride the re-post exemption into an unrelated thread, or crowd out a genuine re-post's single-id precondition. The carried `id` is what lets a Step 6 re-post be recognized and exempted from the overlap drop:
+Optionally write the `(path, line)` anchors of the comments you're about to post — every Critical and Suggestion finding headed for the `comments` array — so existing-comment Overlap can be detected. An entry for a **carried-forward** finding keeps the finding's ledger `id` (its `R<round>-<n>`); an entry for a **fresh** finding of THIS round omits `id` — a fresh id cannot appear in any comment posted before this round, and carrying one would let the new claim ride the re-post exemption into an unrelated thread, or crowd out a genuine re-post's single-id precondition. The carried `id` is what lets a Step 6 re-post be recognized and exempted from the overlap drop. This list is presubmit INPUT, not the canonical findings artifact — it gets its own file: writing it over `findings.json` replaces the artifact Step 8 archives with a flat shadow of it:
 
 ```bash
-echo '[{"path":"src/foo.ts","line":42,"id":"R3-2"}, ...]' > .qwen/tmp/qwen-review-{target}-findings.json
+echo '[{"path":"src/foo.ts","line":42,"id":"R3-2"}, ...]' > .qwen/tmp/qwen-review-{target}-new-findings.json
 ```
 
 Then run:
@@ -992,7 +992,7 @@ Then run:
 "${QWEN_CODE_CLI:-qwen}" review presubmit \
   {pr_number} {commit_sha} {owner}/{repo} \
   .qwen/tmp/qwen-review-{target}-presubmit.json \
-  [--new-findings .qwen/tmp/qwen-review-{target}-findings.json]
+  [--new-findings .qwen/tmp/qwen-review-{target}-new-findings.json]
 ```
 
 Read `.qwen/tmp/qwen-review-{target}-presubmit.json`. Schema:


### PR DESCRIPTION
## What this PR does

Step 7's presubmit section told the orchestrator to write the flat `{path, line, id?}` overlap list for `presubmit --new-findings` to `qwen-review-{target}-findings.json` — the very file that holds the canonical findings artifact produced in Step 6. A run that followed the instruction replaced the artifact with a flat shadow of it before Step 8 archived it, so the saved record of the review was the overlap list, not the findings. This PR gives the overlap list its own file (`qwen-review-{target}-new-findings.json`, named after the flag that consumes it) and says outright that it is presubmit input, not the artifact.

## Why it's needed

The presubmit input and the canonical artifact are different shapes with different consumers: the resolver input and the archive read the artifact, the drift intersection and the overlap drop read the flat list. Sharing one path means the later write silently wins, and nothing downstream reports the swap.

## Reviewer Test Plan

### How to verify

Prose-only change. Read the Step 7 presubmit section of the bundled review skill: the `echo` line and the `--new-findings` argument both point at `qwen-review-{target}-new-findings.json`, the canonical artifact path appears nowhere in that section, and the Step 9 cleanup glob (`qwen-review-{target}-*`) still covers the new file. No code reads a hardcoded path here — `presubmit` accepts whatever `--new-findings` is given.

### Evidence (Before & After)

N/A (skill prose; no behavior change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Read-through of the skill text; no build needed.

## Risk & Scope

- Main risk or tradeoff: none identified — the change renames a file the orchestrator writes and reads within the same step.
- Not validated / out of scope: runs already in flight at merge time will use whichever skill text they loaded.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up from the #9222 review run (observed during its audit).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Step 7 的 presubmit 一节曾让编排器把给 `presubmit --new-findings` 用的扁平 `{path, line, id?}` 重叠列表写到 `qwen-review-{target}-findings.json` —— 正是 Step 6 产出的规范发现工件所用的文件。照做的运行会在 Step 8 归档之前用扁平影子覆盖工件，评审的存档记录因此变成重叠列表而不是发现。本 PR 给重叠列表单独的文件（`qwen-review-{target}-new-findings.json`，随消费它的 flag 命名），并明说它是 presubmit 输入、不是工件。

## 为什么需要

presubmit 输入与规范工件是形状不同、消费者不同的两个东西：解析器输入与归档读工件，漂移交集与重叠丢弃读扁平列表。共用一个路径意味着后写的静默胜出，且下游没有任何环节报告这次替换。

## 审阅者测试计划

### 如何验证

纯行文改动。阅读 bundled review skill 的 Step 7 presubmit 一节：`echo` 行与 `--new-findings` 参数都指向 `qwen-review-{target}-new-findings.json`，该节不再出现规范工件路径，Step 9 清理 glob（`qwen-review-{target}-*`）仍覆盖新文件。代码不硬编码此路径——`presubmit` 接受 `--new-findings` 给定的任何路径。

### 证据（前后对比）

N/A（skill 行文；无行为变化）。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

通读 skill 文本即可；无需构建。

## 风险与范围

- 主要风险或权衡：未发现——改动只重命名编排器在同一步内写入并读取的文件。
- 未验证 / 范围之外：合并时已在途的运行使用其加载的 skill 文本。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

来自 #9222 评审运行的审计观察。

</details>
