### PR TITLE
test(review): realpath the skill-parity fixture root

### DIFF
--- a/packages/cli/src/commands/review/lib/stale-bundle.test.ts
+++ b/packages/cli/src/commands/review/lib/stale-bundle.test.ts
@@ -9,6 +9,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   utimesSync,
@@ -458,7 +459,13 @@ describe('the bundled skill stops on what this module prints', () => {
     ].map((m) => m[1]);
     expect(quotes.length).toBeGreaterThan(0);
 
-    const root = mkdtempSync(join(tmpdir(), 'skill-parity-'));
+    // realpath the fixture root: `bundleStalenessNotices` resolves the entry
+    // with `realpathSync` before deriving the tree, and the mock's fault
+    // injection matches by exact path. On a platform where `tmpdir()` is a
+    // symlink (macOS: /var -> /private/var) an unresolved fixture sits in a
+    // different namespace from every path the walk produces, the read-fault
+    // stage never fires, and its notice silently drops out of the pin.
+    const root = realpathSync(mkdtempSync(join(tmpdir(), 'skill-parity-')));
     try {
       const distDir = join(root, 'dist');
       mkdirSync(distDir, { recursive: true });


### PR DESCRIPTION
## What this PR does

The skill-parity test in the stale-bundle suite builds its fixture tree under `os.tmpdir()` and injects a read fault by exact path match, while the code under test resolves the bundle entry with `realpathSync` before deriving the tree. On a platform where `tmpdir()` is a symlink — macOS, where `/var` links to `/private/var` — the fixture lives in a different path namespace from every path the walk produces, the fault never fires, and the read-fault stage of the parity pin silently prints nothing: the suite fails with `expected [...] to have a length of 6 but got 5`. This PR realpaths the fixture root so every derived path (entry, roots, fault injection) is in the same canonical namespace as the walk.

## Why it's needed

The failure reproduces at the base commit on macOS runners/machines — it is not caused by any pending change — and it turns a suite that pins real notice wording into a platform-dependent red.

## Reviewer Test Plan

### How to verify

On this (or any macOS) checkout: run the stale-bundle suite — 28/28 pass; revert the one-line change and the parity test fails again with the 6-vs-5 count. On Linux (`/tmp` not a symlink) the suite passes either way, which is why the drift survived: the fix makes the test platform-independent rather than platform-lucky.

### Evidence (Before & After)

Before (base commit, this machine): `FAIL … expected [...] to have a length of 6 but got 5`. After: `Test Files 1 passed (1) / Tests 28 passed (28)`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npx vitest run src/commands/review/lib/stale-bundle.test.ts` in `packages/cli`.

## Risk & Scope

- Main risk or tradeoff: none identified — test-only change; the realpath of a fresh `mkdtemp` directory is the directory itself on platforms without the symlink.
- Not validated / out of scope: Windows leg not run locally (no symlink divergence there by construction).
- Breaking changes / migration notes: none.

## Linked Issues

Observed while verifying #9222 (failed there at the base commit; unrelated to that change).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

stale-bundle 套件中的 skill-parity 测试把 fixture 树建在 `os.tmpdir()` 下，并按精确路径匹配注入读取故障；被测代码则在推导目录树之前先用 `realpathSync` 解析 bundle 入口。在 `tmpdir()` 是符号链接的平台（macOS：`/var` 指向 `/private/var`），fixture 与遍历产生的所有路径处于不同的路径命名空间，故障注入永远不触发，parity 钉扎的"读取故障"阶段静默无输出：套件以 `expected [...] to have a length of 6 but got 5` 失败。本 PR 对 fixture 根做 realpath，使所有派生路径（入口、根、故障注入）与遍历处于同一规范命名空间。

## 为什么需要

该失败在 macOS 机器/runner 的基线提交上即可复现——与任何待定改动无关——它把一个钉扎真实提示措辞的套件变成了平台相关的红。

## 审阅者测试计划

### 如何验证

在本机（或任何 macOS checkout）：运行 stale-bundle 套件——28/28 通过；回退这一行改动，parity 测试会再次以 6 对 5 的计数失败。在 Linux（`/tmp` 非符号链接）上两种写法都通过——这正是该漂移存活的原因；本修复让测试平台无关，而非平台侥幸。

### 证据（前后对比）

修复前（基线提交，本机）：`FAIL … expected [...] to have a length of 6 but got 5`。修复后：`Test Files 1 passed (1) / Tests 28 passed (28)`。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

在 `packages/cli` 下运行 `npx vitest run src/commands/review/lib/stale-bundle.test.ts`。

## 风险与范围

- 主要风险或权衡：未发现——纯测试改动；在没有该符号链接的平台，新建 `mkdtemp` 目录的 realpath 即其本身。
- 未验证 / 范围之外：Windows 腿未在本机运行（按构造无符号链接分歧）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

验证 #9222 时发现（在基线提交上失败；与该改动无关）。

</details>
