### PR TITLE
fix(ci): stop triaging the autofix bot's own deferred-finding tracking issues (#9264)

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -449,7 +449,10 @@ jobs:
     concurrency:
       # GitHub evaluates concurrency before the job `if`, but after `needs`.
       # Keep non-runnable PR/comment triggers out of the shared per-number
-      # group so they cannot cancel or replace an authorized run.
+      # group so they cannot cancel or replace an authorized run — including
+      # bot-created issues runs (#9264): the job `if` skips them, but a run
+      # left in the shared group would still cancel an in-progress triage of
+      # the same issue before its own skip is evaluated.
       group: >-
         ${{
           (
@@ -459,7 +462,10 @@ jobs:
             (github.event_name == 'issue_comment' &&
              (github.event.issue.state != 'open' ||
               needs.authorize.outputs.should_run != 'true' ||
-              !startsWith(github.event.comment.body, '@qwen-code /triage')))
+              !startsWith(github.event.comment.body, '@qwen-code /triage'))) ||
+            (github.event_name == 'issues' &&
+             github.event.issue.user.login ==
+               (vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot'))
           ) &&
           format('{0}-run-{1}', github.workflow, github.run_id) ||
           format('{0}-{1}', github.workflow, github.event.issue.number || github.event.pull_request.number || github.event.inputs.number)
@@ -501,9 +507,17 @@ jobs:
     # mention the phrase in quoted text or mid-sentence descriptions.
     # always() so the job still evaluates when the upstream `authorize` job is
     # skipped (issues / workflow_dispatch paths, which need no permission gate).
+    # The issues clause is conditioned on the creator NOT being the autofix
+    # bot (#9264): every PR that defers findings for the first time opens a
+    # tracking issue upserted by that bot, and the open issues trigger triaged
+    # the bookkeeping issue with a full agent run per deferral. The identity
+    # is the same one qwen-autofix.yml upserts under (AUTOFIX_BOT), so the
+    # guard tracks a rename on either side via the shared variable.
     if: >-
       always() && (
-        github.event_name == 'issues' ||
+        (github.event_name == 'issues' &&
+         github.event.issue.user.login !=
+           (vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot')) ||
         (github.event_name == 'workflow_dispatch' &&
          github.event.inputs.number != '' &&
          github.event.inputs.tmux_pr == '') ||

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -5982,3 +5982,44 @@ describe('triage job budget', () => {
     }
   });
 });
+
+describe('triage skips the autofix bot’s own bookkeeping issues (#9264)', () => {
+  // Every PR that defers findings for the first time opens a tracking issue
+  // upserted by the autofix bot, and `issues: [opened, edited, reopened]`
+  // triaged that bookkeeping issue with a full agent run per deferral. The
+  // guard keys on the same identity qwen-autofix.yml upserts under, so a
+  // rename on one side without the other silently re-opens the waste.
+  const botIdentity = "(vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot')";
+
+  // The parsed expressions keep their YAML line breaks, so whitespace is
+  // normalized before matching — the pin must survive a re-wrap, not test it.
+  const flat = (value) => String(value).replace(/\s+/g, ' ');
+
+  it('conditions the triage job’s issues clause on the creator not being the bot', () => {
+    // Parsed, not raw-text containment: a commented-out guard would still
+    // match a substring pin.
+    const doc = parse(workflow);
+    expect(flat(doc.jobs.triage.if)).toContain(
+      `github.event_name == 'issues' && github.event.issue.user.login != ${botIdentity}`,
+    );
+  });
+
+  it('routes bot-created issues runs to a per-run concurrency group', () => {
+    // GitHub evaluates concurrency BEFORE the job `if`: a bot bookkeeping run
+    // inside the shared per-number group cancels an in-progress triage of the
+    // same issue even though its own job skips.
+    const doc = parse(workflow);
+    expect(flat(doc.jobs.triage.concurrency.group)).toContain(
+      `github.event_name == 'issues' && github.event.issue.user.login == ${botIdentity}`,
+    );
+  });
+
+  it('keeps the guard identity in sync with the autofix workflow', () => {
+    // qwen-autofix.yml defines AUTOFIX_BOT as the same variable-with-fallback
+    // (inside a bare `${{ }}`, so without the expression's parentheses).
+    const botIdentityCore = "vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot'";
+    expect(botIdentity).toContain(botIdentityCore);
+    const autofix = readFileSync('.github/workflows/qwen-autofix.yml', 'utf8');
+    expect(autofix).toContain(botIdentityCore);
+  });
+});

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -6000,7 +6000,7 @@ describe('triage skips the autofix bot’s own bookkeeping issues (#9264)', () =
     // match a substring pin.
     const doc = parse(workflow);
     expect(flat(doc.jobs.triage.if)).toContain(
-      `github.event_name == 'issues' && github.event.issue.user.login != ${botIdentity}`,
+      `(github.event_name == 'issues' && github.event.issue.user.login != ${botIdentity}) || (github.event_name == 'workflow_dispatch'`,
     );
   });
 
@@ -6010,7 +6010,7 @@ describe('triage skips the autofix bot’s own bookkeeping issues (#9264)', () =
     // same issue even though its own job skips.
     const doc = parse(workflow);
     expect(flat(doc.jobs.triage.concurrency.group)).toContain(
-      `github.event_name == 'issues' && github.event.issue.user.login == ${botIdentity}`,
+      `!startsWith(github.event.comment.body, '@qwen-code /triage'))) || (github.event_name == 'issues' && github.event.issue.user.login == ${botIdentity}`,
     );
   });
 

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -5989,7 +5989,8 @@ describe('triage skips the autofix bot’s own bookkeeping issues (#9264)', () =
   // triaged that bookkeeping issue with a full agent run per deferral. The
   // guard keys on the same identity qwen-autofix.yml upserts under, so a
   // rename on one side without the other silently re-opens the waste.
-  const botIdentity = "(vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot')";
+  const botIdentityCore = "vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot'";
+  const botIdentity = `(${botIdentityCore})`;
 
   // The parsed expressions keep their YAML line breaks, so whitespace is
   // normalized before matching — the pin must survive a re-wrap, not test it.
@@ -6010,16 +6011,17 @@ describe('triage skips the autofix bot’s own bookkeeping issues (#9264)', () =
     // same issue even though its own job skips.
     const doc = parse(workflow);
     expect(flat(doc.jobs.triage.concurrency.group)).toContain(
-      `!startsWith(github.event.comment.body, '@qwen-code /triage'))) || (github.event_name == 'issues' && github.event.issue.user.login == ${botIdentity}`,
+      `!startsWith(github.event.comment.body, '@qwen-code /triage'))) || (github.event_name == 'issues' && github.event.issue.user.login == ${botIdentity}) ) && format('{0}-run-{1}', github.workflow, github.run_id)`,
     );
   });
 
   it('keeps the guard identity in sync with the autofix workflow', () => {
     // qwen-autofix.yml defines AUTOFIX_BOT as the same variable-with-fallback
     // (inside a bare `${{ }}`, so without the expression's parentheses).
-    const botIdentityCore = "vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot'";
     expect(botIdentity).toContain(botIdentityCore);
-    const autofix = readFileSync('.github/workflows/qwen-autofix.yml', 'utf8');
-    expect(autofix).toContain(botIdentityCore);
+    const autofixDoc = parse(
+      readFileSync('.github/workflows/qwen-autofix.yml', 'utf8'),
+    );
+    expect(autofixDoc.env.AUTOFIX_BOT).toBe(`\${{ ${botIdentityCore} }}`);
   });
 });


### PR DESCRIPTION
## What this PR does

Implements item 1 of #9264 (the one cross-workflow effect that could not land in #9189): every PR that defers findings for the first time opens a tracking issue upserted by the autofix bot, and `qwen-triage.yml`'s `issues: [opened, edited, reopened]` trigger ran a full triage agent on that bookkeeping issue on every deferral — the authorize gate deliberately exempts the issues path ("triage is read-only"), so nothing stopped it.

Two changes, both keyed on the same identity `qwen-autofix.yml` upserts under (`vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot'`):

1. **Job guard** — the triage job's `issues` clause now requires `github.event.issue.user.login != (vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot')`. Human-opened issues triage exactly as before.
2. **Concurrency routing** — bot-created issues runs are routed to the per-run concurrency group alongside the other non-runnable triggers. GitHub evaluates concurrency before the job `if`, so a bot bookkeeping run left in the shared per-number group would still cancel an in-progress triage of the same issue before its own skip is evaluated.

## Why it's needed

Each deferral spawned a full triage-agent run against its own bookkeeping issue — model budget and a runner spent on an issue whose content is a deferral ledger, with a triage verdict nobody acts on. The autofix workflow itself is unaffected (it triggers on `issues: [labeled, assigned]`, which the unlabeled/unassigned tracking issues never fire).

## Reviewer Test Plan

### How to verify

Three new pins in `scripts/tests/qwen-triage-workflow.test.js`, asserted on the parsed document (a commented-out guard cannot satisfy them), with whitespace normalized so a re-wrap cannot defeat them:

- the triage job's issues clause carries the creator guard;
- the concurrency group routes bot-created issues runs to the per-run group;
- the guard identity stays in sync with `qwen-autofix.yml`'s `AUTOFIX_BOT` definition.

```bash
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-triage-workflow.test.js   # 134 pass
```

Mutation-verified both ways: removing the issues-clause guard turns the first pin red; replacing the group clause turns the second red.

### Evidence (Before & After)

Before: bot-opened tracking issues (e.g. the ones this very backlog series is filed under) match `issues: [opened]` and run the triage agent. After: the job skips them at the `if`, and their runs cannot cancel an authorized triage of the same number. Observable on the next first-deferral of any PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Full scripts suite: 1201 pass; the 3 failures are pre-existing on clean main (stash-baselined: install-script audio-capture packaging, and the two unwritable-directory tests that cannot fail for root).

## Risk & Scope

- Main risk or tradeoff: if the deferred-issue bot identity ever changes away from `vars.AUTOFIX_BOT_LOGIN` on the autofix side without updating this guard, the waste silently returns — the identity-sync pin exists to catch the rename on either side.
- Not validated / out of scope: the rest of #9264 (the 35+ assertion-strength and comment-accuracy items) — separate follow-up batches.
- Breaking changes / migration notes: none; human-opened issues and all other triggers unchanged.

## Linked Issues

Part of #9264