### PR TITLE
fix(team): normalize blank task list filters

### DIFF
--- a/packages/core/src/tools/task-list.test.ts
+++ b/packages/core/src/tools/task-list.test.ts
@@ -97,6 +97,58 @@ describe('TaskListTool', () => {
     expect(result.llmContent).not.toContain('Pending');
   });
 
+  it('lists tasks when optional filters are omitted', async () => {
+    const pending = await createTask(TEAM, {
+      subject: 'Pending task',
+      description: 'desc',
+    });
+    const running = await createTask(TEAM, {
+      subject: 'Running task',
+      description: 'desc',
+    });
+    await updateTask(TEAM, running.id, {
+      status: 'in_progress',
+      owner: 'worker',
+    });
+
+    const pendingResult = await tool
+      .build({ status: 'pending' })
+      .execute(new AbortController().signal);
+    const ownerResult = await tool
+      .build({ owner: 'worker' })
+      .execute(new AbortController().signal);
+
+    expect(pendingResult.llmContent).toContain(pending.subject);
+    expect(ownerResult.llmContent).toContain(running.subject);
+    expect(ownerResult.llmContent).not.toContain(pending.subject);
+  });
+
+  it('treats a blank owner filter as omitted', async () => {
+    const pending = await createTask(TEAM, {
+      subject: 'Pending task',
+      description: 'desc',
+    });
+
+    const result = await tool
+      .build({ status: 'pending', owner: '' })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain(pending.subject);
+  });
+
+  it('treats a blank blockedBy filter as omitted', async () => {
+    const pending = await createTask(TEAM, {
+      subject: 'Pending task',
+      description: 'desc',
+    });
+
+    const result = await tool
+      .build({ status: 'pending', blockedBy: '' })
+      .execute(new AbortController().signal);
+
+    expect(result.llmContent).toContain(pending.subject);
+  });
+
   it('returns TaskListResultDisplay', async () => {
     await createTask(TEAM, {
       subject: 'Task X',

--- a/packages/core/src/tools/task-list.ts
+++ b/packages/core/src/tools/task-list.ts
@@ -170,6 +170,10 @@ export class TaskListTool extends BaseDeclarativeTool<
   protected createInvocation(
     params: TaskListParams,
   ): ToolInvocation<TaskListParams, ToolResult> {
-    return new TaskListInvocation(this.config, params);
+    return new TaskListInvocation(this.config, {
+      ...params,
+      owner: params.owner === '' ? undefined : params.owner,
+      blockedBy: params.blockedBy === '' ? undefined : params.blockedBy,
+    });
   }
 }


### PR DESCRIPTION
## What this PR does

Treats literal empty `owner` and `blockedBy` values passed to team task listing as omitted optional filters.

## Why it's needed

A model can serialize an optional task-list filter as an empty string. Previously that value reached exact storage filtering while the tool presentation treated it as absent, causing a populated task board to appear empty.

## Reviewer Test Plan

### How to verify

Create a team with a pending task. Request pending tasks with an empty `owner` value and separately with an empty `blockedBy` value. Both requests should list the pending task. A nonempty owner filter should remain selective.

### Evidence (Before & After)

Before: either blank optional filter returned `No tasks found.` for an otherwise matching pending task. After: literal blank filters are omitted and the matching task is listed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### Environment (optional)

macOS package-local Core typecheck and Vitest.

## Risk & Scope

- Main risk or tradeoff: only literal empty strings are normalized; whitespace-only values and storage-layer exact-match semantics remain unchanged.
- Not validated / out of scope: interactive model serialization and nonempty filter behavior beyond existing unit coverage.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9281

<details>
<summary>中文说明</summary>

## 此 PR 的改动

将团队任务列表中传入的字面量空 `owner` 和 `blockedBy` 值视为省略的可选过滤条件。

## 为什么需要它

模型可能把可选任务列表过滤条件序列化为空字符串。此前该值会进入精确的存储过滤逻辑，但工具展示又将其视为未提供，从而使有任务的看板显示为空。

## 审阅者测试计划

### 如何验证

创建一个包含 pending 任务的团队。分别使用空 `owner` 和空 `blockedBy` 请求 pending 任务。两种请求都应列出该 pending 任务。非空 owner 过滤条件仍应保持选择性。

### 证据（前后对比）

修复前：任一空可选过滤条件都会让原本匹配的 pending 任务返回 `No tasks found.`。修复后：字面量空过滤条件会被省略，并列出匹配任务。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ |
|  🐧 Linux  | ⚠️ |

### 环境（可选）

macOS 上的包级 Core typecheck 和 Vitest。

## 风险与范围

- 主要风险或权衡：仅归一化字面量空字符串；纯空白字符串和存储层的精确匹配语义保持不变。
- 未验证 / 超出范围：交互式模型序列化，以及现有单元覆盖范围之外的非空过滤行为。
- 破坏性变更 / 迁移说明：无。

## 关联问题

Fixes #9281

</details>