### PR TITLE
fix(cli): contain agent-tab render errors instead of exiting the session

### DIFF
--- a/packages/cli/src/ui/components/agent-view/AgentChatView.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatView.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * AgentChatView error containment (#9290).
+ *
+ * The interactive session wraps the whole app in a single FATAL error
+ * boundary: any render error logs [FATAL_RENDER_ERROR] and exits the
+ * session ~5s later. The agent-tab view sits under it with no boundary
+ * of its own, so one errored/incomplete teammate whose transcript
+ * throws during render takes down the entire session when its tab is
+ * opened. These tests pin the per-tab non-fatal boundary: the failing
+ * tab degrades to a recoverable panel, the session (and other tabs)
+ * keep running.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { AgentChatView } from './AgentChatView.js';
+
+// The transcript renderer is replaced by a stand-in that throws for the
+// crashed teammate only — simulating an errored, incomplete member whose
+// transcript render path raises — and renders normally otherwise. The
+// boundary under test wraps this component, so the stand-in isolates the
+// containment behavior from the real renderer's context needs.
+vi.mock('./AgentChatContent.js', () => ({
+  AgentChatContent: ({ instanceKey }: { instanceKey: string }) => {
+    if (instanceKey === 'crashed@team') {
+      throw new Error('teammate transcript boom');
+    }
+    return <Text>content:{instanceKey}</Text>;
+  },
+  AgentChatMissing: ({ label }: { label: string }) => <Text>{label}</Text>,
+}));
+
+vi.mock('../../contexts/AgentViewContext.js', () => ({
+  useAgentViewState: () => ({
+    agents: new Map<string, unknown>([
+      ['crashed@team', { interactiveAgent: { getCore: () => ({}) } }],
+      ['healthy@team', { interactiveAgent: { getCore: () => ({}) } }],
+    ]),
+  }),
+}));
+
+describe('AgentChatView error containment (#9290)', () => {
+  // React logs caught render errors to console.error; silence it so the
+  // test output stays clean (the boundary catching the error is the
+  // point).
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('renders a healthy teammate transcript normally', () => {
+    const { lastFrame } = render(<AgentChatView agentId="healthy@team" />);
+    expect(lastFrame()).toContain('content:healthy@team');
+  });
+
+  it('degrades a crashing teammate tab to a recoverable panel instead of propagating', () => {
+    // Without the per-tab boundary this render propagates the throw to
+    // the fatal top-level boundary, which exits the whole session —
+    // exactly the reported crash.
+    const { lastFrame } = render(<AgentChatView agentId="crashed@team" />);
+    const output = lastFrame() ?? '';
+    expect(output).toContain('teammate transcript boom');
+    expect(output.toLowerCase()).toContain('agent');
+    // The panel must read as recoverable state, not a session death.
+    expect(output).not.toContain('content:crashed@team');
+  });
+
+  it('recovers when switching from a crashed tab to a healthy one', () => {
+    // The boundary state must be keyed per agent: with a shared boundary
+    // instance the crashed tab's error state would keep every later tab
+    // stuck in the fallback even though its transcript renders fine.
+    const view = render(<AgentChatView agentId="crashed@team" />);
+    expect(view.lastFrame()).toContain('teammate transcript boom');
+
+    view.rerender(<AgentChatView agentId="healthy@team" />);
+    expect(view.lastFrame()).toContain('content:healthy@team');
+  });
+
+  it('still renders the missing-agent panel for an unknown id', () => {
+    const { lastFrame } = render(<AgentChatView agentId="ghost@team" />);
+    expect(lastFrame()).toContain('Agent "ghost@team" not found.');
+  });
+});

--- a/packages/cli/src/ui/components/agent-view/AgentChatView.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatView.test.tsx
@@ -37,12 +37,17 @@ vi.mock('./AgentChatContent.js', () => ({
   AgentChatMissing: ({ label }: { label: string }) => <Text>{label}</Text>,
 }));
 
+const setAgentShellFocusedSpy = vi.hoisted(() => vi.fn());
+
 vi.mock('../../contexts/AgentViewContext.js', () => ({
   useAgentViewState: () => ({
     agents: new Map<string, unknown>([
       ['crashed@team', { interactiveAgent: { getCore: () => ({}) } }],
       ['healthy@team', { interactiveAgent: { getCore: () => ({}) } }],
     ]),
+  }),
+  useAgentViewActions: () => ({
+    setAgentShellFocused: setAgentShellFocusedSpy,
   }),
 }));
 
@@ -53,6 +58,7 @@ describe('AgentChatView error containment (#9290)', () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
   beforeEach(() => {
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setAgentShellFocusedSpy.mockClear();
   });
   afterEach(() => {
     errorSpy.mockRestore();
@@ -73,6 +79,22 @@ describe('AgentChatView error containment (#9290)', () => {
     expect(output.toLowerCase()).toContain('agent');
     // The panel must read as recoverable state, not a session death.
     expect(output).not.toContain('content:crashed@team');
+  });
+
+  it('clears the embedded-shell focus flag when a tab crashes', () => {
+    // The crashing content is the only production writer of
+    // agentShellFocused and never clears it on unmount (React error
+    // #185); while the flag is stale the tab bar swallows left/right —
+    // the only escape — so the boundary's componentDidCatch is the one
+    // place that can still release the lock. The tab-switch resets cover
+    // normal navigation but are unreachable once locked (#9290 review).
+    render(<AgentChatView agentId="crashed@team" />);
+    expect(setAgentShellFocusedSpy).toHaveBeenCalledWith(false);
+  });
+
+  it('does not touch the focus flag for a healthy tab', () => {
+    render(<AgentChatView agentId="healthy@team" />);
+    expect(setAgentShellFocusedSpy).not.toHaveBeenCalled();
   });
 
   it('recovers when switching from a crashed tab to a healthy one', () => {

--- a/packages/cli/src/ui/components/agent-view/AgentChatView.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatView.test.tsx
@@ -77,6 +77,7 @@ describe('AgentChatView error containment (#9290)', () => {
     const output = lastFrame() ?? '';
     expect(output).toContain('teammate transcript boom');
     expect(output.toLowerCase()).toContain('agent');
+    expect(output).toContain('QWEN_DEBUG_LOG_FILE=1');
     // The panel must read as recoverable state, not a session death.
     expect(output).not.toContain('content:crashed@team');
   });

--- a/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
@@ -10,8 +10,15 @@
  * and the Ctrl+F embedded-shell toggle.
  */
 
+import { Box, Text } from 'ink';
+import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import { useAgentViewState } from '../../contexts/AgentViewContext.js';
+import { ErrorBoundary } from '../shared/ErrorBoundary.js';
+import { theme } from '../../semantic-colors.js';
+import { sanitizeTerminalText } from '../../utils/textUtils.js';
 import { AgentChatContent, AgentChatMissing } from './AgentChatContent.js';
+
+const debugLogger = createDebugLogger('AGENT_TAB_RENDER');
 
 interface AgentChatViewProps {
   agentId: string;
@@ -29,11 +36,40 @@ export const AgentChatView = ({ agentId }: AgentChatViewProps) => {
   }
 
   return (
-    <AgentChatContent
-      core={core}
-      interactiveAgent={interactiveAgent}
-      instanceKey={agentId}
-      modelName={agent.modelName}
-    />
+    // Non-fatal per-tab containment (#9290): the app-level boundary is
+    // FATAL — a render error that reaches it logs [FATAL_RENDER_ERROR]
+    // and exits the whole session. An errored or incomplete teammate
+    // whose transcript throws during render must degrade THIS tab only,
+    // keeping the session and the other tabs alive. Keyed by agentId so
+    // switching tabs starts from fresh boundary state: one crashed tab
+    // must not strand every later tab in its fallback.
+    <ErrorBoundary
+      key={agentId}
+      fallback={(error) => (
+        <Box flexDirection="column" paddingX={1}>
+          <Text color={theme.status.error} bold>
+            Something went wrong while rendering this agent tab.
+          </Text>
+          <Text color={theme.text.secondary}>
+            {sanitizeTerminalText(error.message)}
+          </Text>
+          <Text color={theme.text.secondary} dimColor>
+            The session is still running; other tabs are unaffected.
+          </Text>
+        </Box>
+      )}
+      onError={(error, info) => {
+        debugLogger.error(
+          `[AGENT_TAB_RENDER_ERROR] agentId=${agentId} ${error.message}\n${info.componentStack ?? ''}\n${error.stack ?? ''}`,
+        );
+      }}
+    >
+      <AgentChatContent
+        core={core}
+        interactiveAgent={interactiveAgent}
+        instanceKey={agentId}
+        modelName={agent.modelName}
+      />
+    </ErrorBoundary>
   );
 };

--- a/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
@@ -63,6 +63,9 @@ export const AgentChatView = ({ agentId }: AgentChatViewProps) => {
           <Text color={theme.text.secondary} dimColor>
             Switch to another tab and back to retry rendering this tab.
           </Text>
+          <Text color={theme.text.secondary} dimColor>
+            Set QWEN_DEBUG_LOG_FILE=1 and reproduce for a full log.
+          </Text>
         </Box>
       )}
       onError={(error, info) => {

--- a/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
@@ -12,7 +12,10 @@
 
 import { Box, Text } from 'ink';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
-import { useAgentViewState } from '../../contexts/AgentViewContext.js';
+import {
+  useAgentViewState,
+  useAgentViewActions,
+} from '../../contexts/AgentViewContext.js';
 import { ErrorBoundary } from '../shared/ErrorBoundary.js';
 import { theme } from '../../semantic-colors.js';
 import { sanitizeTerminalText } from '../../utils/textUtils.js';
@@ -26,6 +29,7 @@ interface AgentChatViewProps {
 
 export const AgentChatView = ({ agentId }: AgentChatViewProps) => {
   const { agents } = useAgentViewState();
+  const { setAgentShellFocused } = useAgentViewActions();
   const agent = agents.get(agentId);
 
   const interactiveAgent = agent?.interactiveAgent;
@@ -62,6 +66,15 @@ export const AgentChatView = ({ agentId }: AgentChatViewProps) => {
         </Box>
       )}
       onError={(error, info) => {
+        // The crashed content can no longer own the embedded-shell focus:
+        // it is the only production writer of the flag and it deliberately
+        // never clears it on unmount (React error #185). Clear it here —
+        // componentDidCatch runs in the commit phase, so this update is
+        // safe. The tab-switch resets cover normal navigation, but while
+        // the flag is stale the tab bar swallows left/right — the only
+        // escape — so a crash is exactly when only this hook can release
+        // the lock (#9290 review).
+        setAgentShellFocused(false);
         debugLogger.error(
           `[AGENT_TAB_RENDER_ERROR] agentId=${agentId} ${error.message}\n${info.componentStack ?? ''}\n${error.stack ?? ''}`,
         );

--- a/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentChatView.tsx
@@ -56,6 +56,9 @@ export const AgentChatView = ({ agentId }: AgentChatViewProps) => {
           <Text color={theme.text.secondary} dimColor>
             The session is still running; other tabs are unaffected.
           </Text>
+          <Text color={theme.text.secondary} dimColor>
+            Switch to another tab and back to retry rendering this tab.
+          </Text>
         </Box>
       )}
       onError={(error, info) => {

--- a/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
@@ -5,9 +5,19 @@
  */
 
 import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { useEffect, useRef } from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import type { Config } from '@qwen-code/qwen-code-core';
-import { AgentViewProvider } from './AgentViewContext.js';
+import {
+  ApprovalMode,
+  type AgentInteractive,
+  type Config,
+} from '@qwen-code/qwen-code-core';
+import {
+  AgentViewProvider,
+  useAgentViewActions,
+  useAgentViewState,
+} from './AgentViewContext.js';
 
 /**
  * Minimal Config stub exposing only the manager-subscription surface the
@@ -45,5 +55,50 @@ describe('AgentViewProvider in-process bridges', () => {
     render(<AgentViewProvider config={config}>{null}</AgentViewProvider>);
 
     expect(config.onArenaManagerChange).toHaveBeenCalled();
+  });
+
+  it('clears embedded shell focus when switching agent tabs', async () => {
+    const config = makeConfig();
+    const interactiveAgent = {
+      getCore: () => ({
+        runtimeContext: { getApprovalMode: () => ApprovalMode.DEFAULT },
+      }),
+    } as AgentInteractive;
+
+    function Probe() {
+      const state = useAgentViewState();
+      const actions = useAgentViewActions();
+      const seeded = useRef(false);
+
+      useEffect(() => {
+        if (seeded.current) return;
+        seeded.current = true;
+        actions.registerAgent('mate@team', interactiveAgent, 'model', 'cyan');
+        actions.setAgentShellFocused(true);
+      }, [actions]);
+
+      useEffect(() => {
+        if (state.agentShellFocused) {
+          actions.switchToAgent('mate@team');
+        }
+      }, [actions, state.agentShellFocused]);
+
+      return (
+        <Text>
+          {state.activeView}:{String(state.agentShellFocused)}
+        </Text>
+      );
+    }
+
+    const { lastFrame } = render(
+      <AgentViewProvider config={config}>
+        <Probe />
+      </AgentViewProvider>,
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(lastFrame()).toContain('mate@team:false');
   });
 });

--- a/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
@@ -6,7 +6,7 @@
 
 import { render } from 'ink-testing-library';
 import { Text } from 'ink';
-import { useEffect, useRef } from 'react';
+import { act, useEffect, useRef } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import {
   ApprovalMode,
@@ -98,7 +98,75 @@ describe('AgentViewProvider in-process bridges', () => {
 
     await new Promise((resolve) => setImmediate(resolve));
     await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
 
     expect(lastFrame()).toContain('mate@team:false');
+  });
+
+  it('clears embedded shell focus when the focused agent unregisters', async () => {
+    // unregisterAgent bounces activeView back to 'main' without going
+    // through switchToAgent/Next/Previous — the switch resets alone never
+    // run, so the view-change effect is the only reset on this path.
+    // Without it a stale true would keyboard-lock the tab bar on main
+    // (#9290 review). Stages are driven imperatively via act() so each
+    // state change lands in its own commit (the production focus seed is
+    // a keypress in a commit well after the tab switch).
+    const config = makeConfig();
+    const interactiveAgent = {
+      getCore: () => ({
+        runtimeContext: { getApprovalMode: () => ApprovalMode.DEFAULT },
+      }),
+    } as AgentInteractive;
+
+    const probeActions: {
+      registerAgent?: (
+        agentId: string,
+        agent: AgentInteractive,
+        modelId: string,
+        color: string,
+      ) => void;
+      switchToAgent?: (agentId: string) => void;
+      setAgentShellFocused?: (focused: boolean) => void;
+      unregisterAgent?: (agentId: string) => void;
+    } = {};
+
+    function Probe() {
+      const state = useAgentViewState();
+      const actions = useAgentViewActions();
+      probeActions.registerAgent = actions.registerAgent;
+      probeActions.switchToAgent = actions.switchToAgent;
+      probeActions.setAgentShellFocused = actions.setAgentShellFocused;
+      probeActions.unregisterAgent = actions.unregisterAgent;
+      return (
+        <Text>
+          {state.activeView}:{String(state.agentShellFocused)}
+        </Text>
+      );
+    }
+
+    const { lastFrame } = render(
+      <AgentViewProvider config={config}>
+        <Probe />
+      </AgentViewProvider>,
+    );
+
+    await act(async () => {
+      probeActions.registerAgent?.('mate@team', interactiveAgent, 'm', 'c');
+    });
+    await act(async () => {
+      probeActions.switchToAgent?.('mate@team');
+    });
+    expect(lastFrame()).toContain('mate@team:false');
+    await act(async () => {
+      probeActions.setAgentShellFocused?.(true);
+    });
+    expect(lastFrame()).toContain('mate@team:true');
+
+    await act(async () => {
+      probeActions.unregisterAgent?.('mate@team');
+    });
+
+    expect(lastFrame()).toContain('main:false');
   });
 });

--- a/packages/cli/src/ui/contexts/AgentViewContext.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.tsx
@@ -145,6 +145,7 @@ export function AgentViewProvider({
   const switchToAgent = useCallback(
     (agentId: string) => {
       if (agents.has(agentId)) {
+        setAgentShellFocused(false);
         setActiveView(agentId);
       }
     },
@@ -155,6 +156,7 @@ export function AgentViewProvider({
     const ids = ['main', ...agents.keys()];
     const currentIndex = ids.indexOf(activeView);
     const nextIndex = (currentIndex + 1) % ids.length;
+    setAgentShellFocused(false);
     setActiveView(ids[nextIndex]!);
   }, [agents, activeView]);
 
@@ -162,6 +164,7 @@ export function AgentViewProvider({
     const ids = ['main', ...agents.keys()];
     const currentIndex = ids.indexOf(activeView);
     const prevIndex = (currentIndex - 1 + ids.length) % ids.length;
+    setAgentShellFocused(false);
     setActiveView(ids[prevIndex]!);
   }, [agents, activeView]);
 

--- a/packages/cli/src/ui/contexts/AgentViewContext.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.tsx
@@ -19,7 +19,9 @@ import {
   createContext,
   useContext,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -167,6 +169,22 @@ export function AgentViewProvider({
     setAgentShellFocused(false);
     setActiveView(ids[prevIndex]!);
   }, [agents, activeView]);
+
+  // Belt and braces for the switch resets above: the embedded-shell focus
+  // belongs to the active tab's content, so ANY view change — including
+  // unregisterAgent/unregisterAll bouncing activeView back to 'main'
+  // without going through a switch — must drop a flag the unmounted
+  // content can no longer clear (#9290 review). Skip the mount run: the
+  // flag starts false there, and resetting it in the mount commit would
+  // clobber a same-commit seed from the active tab's content.
+  const initialViewRef = useRef(true);
+  useEffect(() => {
+    if (initialViewRef.current) {
+      initialViewRef.current = false;
+      return;
+    }
+    setAgentShellFocused(false);
+  }, [activeView]);
 
   // ── Registration ──
 


### PR DESCRIPTION
## What this PR does

The interactive UI has exactly one FATAL error boundary around the whole app: any render error that reaches it logs `[FATAL_RENDER_ERROR]` and exits the session about five seconds later. The main transcript's think blocks already sit behind non-fatal boundaries that degrade per-error; the agent-team tab view had none. So one errored or incomplete teammate whose transcript threw during render took down the entire session the moment its tab was opened — the reported behavior. This wraps `AgentChatContent` in a non-fatal `ErrorBoundary` (the shared one): the failing tab degrades to a recoverable panel stating the session is still running, an `[AGENT_TAB_RENDER_ERROR]` with the component stack goes to the debug log for diagnosis, and the boundary is keyed by `agentId` so switching away from a crashed tab starts from fresh state instead of stranding every later tab in the fallback.

## Why it's needed

The containment gap is confirmed statically (no boundary anywhere under `agent-view/`, while the fatal top-level one exits the session) and matches the report exactly: "opening a team member tab should keep the interactive session running and show a recoverable failure state for that member." The triage analysis directed this fix explicitly, regardless of the cause of the throw. What is NOT yet known is which component threw in the reporter's session — the reporter didn't capture `[FATAL_RENDER_ERROR]` output or a stack trace, and triage has asked for them. With this PR merged, the next occurrence lands in the debug log with a component stack instead of killing the session, which is also how the underlying throw gets found.

This PR is the containment half of the linked issue; the still-open root-throw question is noted in the risk section below.

## Reviewer Test Plan

### How to verify

```
cd packages/cli
npx vitest run src/ui/components/agent-view/AgentChatView.test.tsx
```

Four new tests, red before the fix: a transcript stand-in that throws for one agent id renders the recoverable panel instead of propagating (before the fix the throw escapes to the fatal boundary — that is the crash); switching from the crashed tab to a healthy one recovers (pins the per-agent `key`); the healthy path and the missing-agent panel are controls. Both load-bearing pins were mutation-verified red (boundary removed → 2 red; `key` removed → 1 red).

Wider runs:

```
agent-view directory: 49 passed (4 files)
cli src/ui suite: 6286 passed, 1 failed + 6 load errors — all 7 files
  fail identically on the clean commit without this change
  (stash-verified; AuthDialog flake and stale-env collection errors,
  none in the agent-view area)
eslint + prettier: clean on both touched files; tsc shows no errors in
  the changed files (the worktree's remaining tsc noise is unrelated
  stale-dist artifacts from sibling packages, present without the change)
```

Manual repro of the original crash is not possible yet — no minimal sequence or stack trace exists (the reporter says so too); the mechanism-level repro above is what this PR is verified against.

### Evidence (Before & After)

N/A — error-path rendering; before = session exits, after = the tab shows the recoverable panel (asserted in tests).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested (reporter's platform; no minimal repro exists to run) |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested (unit level) |

### Environment (optional)

Local package-level Vitest on Linux plus eslint and prettier on the touched files. Manual reproduction of the original crash is not possible yet (no minimal sequence or stack trace exists).

## Risk & Scope

- Main risk or tradeoff: the tab now stays alive after a render failure, so stale focus state must be cleared when navigating away from the failed content.
- Not validated / out of scope: the original root throw still needs a reporter stack or follow-up repro.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9290.

<details>
<summary>中文说明</summary>

修复 #9290 的隔离部分：交互式 UI 只有覆盖全局的 FATAL 错误边界，agent-team 标签页没有任何非致命边界，一个渲染抛错的队友标签页一打开就杀掉整个会话。本 PR 给 `AgentChatContent` 套上共享的非致命 ErrorBoundary：出错的标签页降级为可恢复面板（说明会话仍在运行），组件栈写入调试日志便于定位根因，边界按 agentId 建 key，切走再切回从全新状态开始。原始根因抛错仍待报告者提供堆栈。验证：4 个新测试（修前红）+ 变异验证，agent-view 49 过，tsc/eslint/prettier 在改动文件上干净。

</details>
