### PR TITLE
fix(ci): drop pull_request_review events on closed PRs at the route gate

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -11,6 +11,9 @@ name: 'Qwen Autofix'
 #   • every 10m            → review phase; issue phase only if no PR needs work
 #   • issues:labeled        → issue phase when ready label, state, and sender match
 #   • pull_request_review   → review phase for submitted feedback on bot PRs
+#                             (open PRs only: reviews on closed/merged PRs
+#                             drop at the route gate; the scheduled scan is
+#                             the backstop for anything missed)
 #   • pull_request:labeled  → maintainer applies autofix/takeover → the loop
 #                             manages that PR (human-authored included, and
 #                             maintainer FORKS too: the fork's author must
@@ -289,8 +292,16 @@ jobs:
     # branch would trim it — fail closed, command must start the comment.
     # Both commands are prefiltered here (/takeover toggles the label, /retry
     # re-arms a stranded PR); everything else never starts a job.
+    # The pull_request_review clause drops reviews on closed/merged PRs at the
+    # gate: a PR that can no longer receive commits has nothing to address.
+    # Finding-reply bursts on just-merged PRs otherwise start one no-op run
+    # per reply (observed 2026-08-16: 24+ reply reviews on merged #9222 and
+    # 26 runs on merged #9189 within minutes — issue #9296). The fleet never
+    # loses a legitimate target from this: the schedule scan engages any open
+    # PR with review context on its next tick, and address-time revalidation
+    # already drops targets whose PR closed after dispatch.
     if: |-
-      ${{ github.repository == 'QwenLM/qwen-code' && (github.event_name != 'issue_comment' || (github.event.issue.pull_request && (startsWith(github.event.comment.body, '@qwen-code /takeover') || startsWith(github.event.comment.body, '@qwen-code /retry')))) && (github.event_name != 'pull_request' || github.event.label.name == 'autofix/takeover') }}
+      ${{ github.repository == 'QwenLM/qwen-code' && (github.event_name != 'issue_comment' || (github.event.issue.pull_request && (startsWith(github.event.comment.body, '@qwen-code /takeover') || startsWith(github.event.comment.body, '@qwen-code /retry')))) && (github.event_name != 'pull_request' || github.event.label.name == 'autofix/takeover') && (github.event_name != 'pull_request_review' || github.event.pull_request.state == 'open') }}
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     concurrency:


### PR DESCRIPTION
## What this PR does

Adds one clause to the autofix router job's expression-level prefilter gate: review-submission events for closed or merged pull requests are dropped before any runner starts. Only review events on open PRs route. The workflow's contract comments are updated to document the gate.

## Why it's needed

Reviews on merged/closed PRs have nothing to address, yet each one currently starts an autofix run that spins up a runner only to exit — for fork PRs via the no-secrets exit branch, consuming a job slot for nothing. When findings are replied to in a burst after merge (each reply posted as its own standalone review submission), this produces a storm of no-op runs that then cancel each other through the per-PR concurrency group.

Measured on 2026-08-16 (full details in #9296): a merged PR received 24+ finding-reply reviews within 2.5 minutes (~5s apart), spawning 24 runs; another merged PR spawned 26 runs in 69 seconds. The workflow saw ~500 runs in about 3 hours with a 59% cancellation rate, and this storm pattern is a major contributor.

Nothing is lost by dropping these events: the scheduled scan engages any open PR with review context on its next tick, and targets whose PR closes after dispatch are already dropped by address-time revalidation.

## Reviewer Test Plan

### How to verify

This is a CI-workflow gate change; behavior is observable in run statistics rather than CLI output:

1. Confirm the new clause constrains only review events: schedule, pull-request label, issue-comment, and dispatch paths are untouched (the clause is `event_name != 'pull_request_review' || ...`).
2. Submit a review (or a reply-as-review) on a merged PR: no Qwen Autofix run should start. Before this change each such review starts a run that exits through the no-secrets fork branch.
3. Review events on open PRs still route exactly as before.

Local verification performed: the full workflow parses as YAML; a truth-table simulation of the gate expression across nine event combinations produced the expected routing decisions, including fail-closed when the PR state is absent from the payload.

### Evidence (Before & After)

Before: 2026-08-16 11:47–11:49Z — review events on merged PR #9222 triggered 24 Qwen Autofix runs (23 cancelled, 1 success that exited through the no-op fork branch); merged PR #9189 triggered 26 runs within 69 seconds. After: such events are expected to produce zero runs (dropped at the job gate, no runner provisioned).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — workflow gate change; no runtime code touched. The workflow itself runs on ubuntu-latest.

## Risk & Scope

- Main risk or tradeoff: review events on closed PRs no longer produce any route run — intended; there is nothing to address on a PR that cannot receive commits, and the scheduled scan is the backstop for anything genuinely actionable.
- Not validated / out of scope: the remaining #9296 items (busy-detection hardening, batching finding replies, cron-group semantics, resolve-pr diagnostics) are untouched; this PR is only the P0 gate.
- Breaking changes / migration notes: none.

## Linked Issues

Part of #9296 (the P0 item). No closing keyword — the issue tracks further work beyond this PR.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 autofix 路由 job 的表达式级预过滤门上加一个子句：针对已关闭/已合并 PR 的 review 提交事件在任何 runner 启动之前就被丢弃，只有 open PR 上的 review 事件会被路由。同时更新了工作流的契约注释以记录该门。

## 为什么需要

已合并/已关闭 PR 上的 review 没有任何可处理的内容，但目前每条都会启动一个 autofix run——拉起 runner 后空转退出（fork PR 走 no-secrets 退出分支），白白消耗一个 job 槽位。当合并后出现逐条回复 findings 的爆发（每条回复作为独立 review 提交）时，会产生大量空转 run，并通过 per-PR 并发组互相取消。

2026-08-16 实测（完整细节见 #9296）：一个已合并 PR 在 2.5 分钟内收到 24+ 条 finding 回复型 review（间隔约 5 秒），产生 24 个 run；另一个已合并 PR 在 69 秒内产生 26 个 run。该工作流约 3 小时内有 ~500 个 run，取消率 59%，此风暴模式是主要贡献者。

丢弃这些事件不会丢失任何东西：schedule scan 会在下一个 tick 接手任何有 review 上下文的 open PR；dispatch 后才关闭的 PR 目标已由 address-time revalidation 兜底丢弃。

## Reviewer 测试计划

### 如何验证

这是 CI 工作流的门变更，行为体现在 run 统计而非 CLI 输出：

1. 确认新子句只约束 review 事件：schedule、pull_request label、issue_comment、workflow_dispatch 路径均不受影响（子句为 `event_name != 'pull_request_review' || ...`）。
2. 在一个已合并 PR 上提交 review（或回复型 review）：不应再启动 Qwen Autofix run。改动前每条此类 review 都会启动一个 run，然后走 no-secrets fork 分支退出。
3. open PR 上的 review 事件仍按原有逻辑路由。

已完成的本地验证：完整工作流 YAML 解析通过；对门表达式做了 9 组事件组合的真值表模拟，路由决策全部符合预期，包括 payload 缺少 PR state 时 fail-closed。

### 证据（改动前后）

改动前：2026-08-16 11:47–11:49Z——已合并 PR #9222 的 review 事件触发 24 个 Qwen Autofix run（23 个 cancelled，1 个 success 但走空转 fork 分支退出）；已合并 PR #9189 在 69 秒内触发 26 个 run。改动后：此类事件预期产生零 run（在 job 门处丢弃，不分配 runner）。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

N/A——工作流门变更，未触碰任何运行时代码。工作流本身运行在 ubuntu-latest。

## 风险与范围

- 主要风险或权衡：closed PR 上的 review 事件不再产生任何 route run——这是预期行为：无法接收 commit 的 PR 没有可处理的内容，schedule scan 是真正可处理事项的兜底。
- 未验证 / 超出范围：#9296 的其余项（busy 检测加固、finding 回复批量化、cron 组语义、resolve-pr 诊断）不在本 PR 内；本 PR 只做 P0 门。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

属于 #9296（P0 项）。不使用关闭关键字——该 issue 还跟踪本 PR 之外的后续工作。

</details>
