### PR TITLE
feat(autofix): seed the takeover round counter with `/takeover from N`

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -554,7 +554,13 @@ jobs:
                   # conditional relies on evaluation order this must not bet on.
                   if [[ "${BASH_REMATCH[1]}" == "${TAKEOVER_COMMAND}" ]]; then
                     CMD='add'
-                    TAKEOVER_FROM="${BASH_REMATCH[2]}"
+                    # 10# canonicalizes the capture to decimal: the value ends
+                    # up in bare-context bash arithmetic downstream (the
+                    # toggle's remainder, the read-site clamps' -ge), where a
+                    # zero-padded spelling is octal — '08'/'09' even error
+                    # outright and drop the seed note. '00' lands on '0', the
+                    # explicit no-seed spelling.
+                    TAKEOVER_FROM="$((10#${BASH_REMATCH[2]}))"
                   fi
                 fi
                 # Re-arm shares the takeover command's authorization exactly:
@@ -2040,7 +2046,18 @@ jobs:
               # a PR that exhausted its rounds continues under management —
               # no label churn needed. The watermark is untouched: feedback
               # already addressed is never replayed.
-              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🔄 Takeover re-armed: the round counter starts a fresh window%s; management continues.%s\n\n<details>\n<summary>中文说明</summary>\n\n🔄 已重新武装：轮次计数开启新窗口%s，托管继续。%s\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${REARM_FRESH_CLAUSE}" "${FROM_NOTE_REARM}" "${REARM_FRESH_CLAUSE_ZH}" "${FROM_NOTE_REARM_ZH}" "${FROM_MARKER}")"
+              # Body built ONCE so the retry posts byte-identical text.
+              # Same one-retry shape as the engage post below — the seed
+              # marker's only copy rides in this body too — but the final
+              # fallback is LOUD: nothing heals a missing re-arm (the scan
+              # heals only engage-less PRs, and the pre-existing engage ack
+              # suppresses the dedup), and a 're-armed' claim plus the
+              # stale-escalation cleanup must not follow a window reset that
+              # never landed (R7-7).
+              REARM_BODY="$(printf '🔄 Takeover re-armed: the round counter starts a fresh window%s; management continues.%s\n\n<details>\n<summary>中文说明</summary>\n\n🔄 已重新武装：轮次计数开启新窗口%s，托管继续。%s\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${REARM_FRESH_CLAUSE}" "${FROM_NOTE_REARM}" "${REARM_FRESH_CLAUSE_ZH}" "${FROM_NOTE_REARM_ZH}" "${FROM_MARKER}")"
+              gh pr comment "${PR}" --repo "${REPO}" --body "${REARM_BODY}" \
+                || { sleep 5; gh pr comment "${PR}" --repo "${REPO}" --body "${REARM_BODY}"; } \
+                || { echo "::error::re-arm ack comment failed on #${PR} after one retry — the round window was NOT reset and no seed landed; re-run the command"; exit 1; }
               echo "🔄 re-armed ${TAKEOVER_LABEL} window on #${PR}"
               # Management resumed — the escalation label is stale. 404 is
               # the common case (the PR was never paused).

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2014,10 +2014,23 @@ jobs:
           FROM_MARKER=''
           FROM_NOTE=''
           FROM_NOTE_ZH=''
+          FROM_NOTE_REARM=''
+          FROM_NOTE_REARM_ZH=''
+          # A seeded RE-ARM must not keep the unseeded fresh-window clause:
+          # the seed makes the earlier rounds count toward the cap (they ARE
+          # the seed), and on a re-arm they were typically already-managed
+          # rounds, not pre-takeover review — both wordings flip below.
+          REARM_FRESH_CLAUSE=' (previous rounds no longer count toward the cap)'
+          REARM_FRESH_CLAUSE_ZH='（此前轮次不再计入上限）'
           if [[ -n "${CMD_FROM}" && "${CMD_FROM}" =~ ^[0-9]{1,2}$ && "${CMD_FROM}" != '0' ]]; then
             FROM_MARKER="$(printf '\n<!-- autofix-round-start %s -->' "${CMD_FROM}")"
-            FROM_NOTE="$(printf ' This window'"'"'s round counter starts at %s (the rounds this PR spent in review before takeover), so the Critical-only brake engages after %s more change-producing round(s) instead of a full fresh %s.' "${CMD_FROM}" "$(( CRITICAL_ONLY_AFTER_ROUND > CMD_FROM ? CRITICAL_ONLY_AFTER_ROUND - CMD_FROM : 0 ))" "${CRITICAL_ONLY_AFTER_ROUND}")"
-            FROM_NOTE_ZH="$(printf '本窗口轮次计数从 %s 起算（即本 PR 托管前已进行的评审轮数），因此再经过 %s 个产生改动的轮次即进入 Critical-only，而非重新计满 %s 轮。' "${CMD_FROM}" "$(( CRITICAL_ONLY_AFTER_ROUND > CMD_FROM ? CRITICAL_ONLY_AFTER_ROUND - CMD_FROM : 0 ))" "${CRITICAL_ONLY_AFTER_ROUND}")"
+            REARM_FRESH_CLAUSE=' (earlier rounds count toward the cap only via this seed)'
+            REARM_FRESH_CLAUSE_ZH='（此前轮次仅通过该种子计入上限）'
+            FROM_REMAIN="$(( CRITICAL_ONLY_AFTER_ROUND > CMD_FROM ? CRITICAL_ONLY_AFTER_ROUND - CMD_FROM : 0 ))"
+            FROM_NOTE="$(printf ' This window'"'"'s round counter starts at %s (the rounds this PR spent in review before takeover), so the Critical-only brake engages after %s more change-producing round(s) instead of a full fresh %s.' "${CMD_FROM}" "${FROM_REMAIN}" "${CRITICAL_ONLY_AFTER_ROUND}")"
+            FROM_NOTE_ZH="$(printf '本窗口轮次计数从 %s 起算（即本 PR 托管前已进行的评审轮数），因此再经过 %s 个产生改动的轮次即进入 Critical-only，而非重新计满 %s 轮。' "${CMD_FROM}" "${FROM_REMAIN}" "${CRITICAL_ONLY_AFTER_ROUND}")"
+            FROM_NOTE_REARM="$(printf ' This window'"'"'s round counter restarts at %s (rounds already spent on this PR), so the Critical-only brake engages after %s more change-producing round(s) instead of a full fresh %s.' "${CMD_FROM}" "${FROM_REMAIN}" "${CRITICAL_ONLY_AFTER_ROUND}")"
+            FROM_NOTE_REARM_ZH="$(printf '本窗口轮次计数从 %s 重启（即本 PR 已消耗的轮次），因此再经过 %s 个产生改动的轮次即进入 Critical-only，而非重新计满 %s 轮。' "${CMD_FROM}" "${FROM_REMAIN}" "${CRITICAL_ONLY_AFTER_ROUND}")"
           fi
           if [[ "${CMD}" == 'add' ]]; then
             if [[ "${HAS}" == 'true' ]]; then
@@ -2027,7 +2040,7 @@ jobs:
               # a PR that exhausted its rounds continues under management —
               # no label churn needed. The watermark is untouched: feedback
               # already addressed is never replayed.
-              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🔄 Takeover re-armed: the round counter starts a fresh window (previous rounds no longer count toward the cap); management continues.%s\n\n<details>\n<summary>中文说明</summary>\n\n🔄 已重新武装：轮次计数开启新窗口（此前轮次不再计入上限），托管继续。%s\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${FROM_NOTE}" "${FROM_NOTE_ZH}" "${FROM_MARKER}")"
+              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🔄 Takeover re-armed: the round counter starts a fresh window%s; management continues.%s\n\n<details>\n<summary>中文说明</summary>\n\n🔄 已重新武装：轮次计数开启新窗口%s，托管继续。%s\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${REARM_FRESH_CLAUSE}" "${FROM_NOTE_REARM}" "${REARM_FRESH_CLAUSE_ZH}" "${FROM_NOTE_REARM_ZH}" "${FROM_MARKER}")"
               echo "🔄 re-armed ${TAKEOVER_LABEL} window on #${PR}"
               # Management resumed — the escalation label is stale. 404 is
               # the common case (the PR was never paused).
@@ -2069,7 +2082,14 @@ jobs:
                 FORK_NOTE=' This is a fork PR, so the first round comes from the next scheduled scan (usually within minutes).'
                 FORK_NOTE_ZH='本 PR 来自 fork，首轮处理将由下一次定时扫描执行（通常几分钟内）。'
               fi
-              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached.%s%s Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。%s%s移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${FORK_NOTE}" "${FROM_NOTE}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${FORK_NOTE_ZH}" "${FROM_NOTE_ZH}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${FROM_MARKER}")" \
+              # Body built ONCE so the retry posts byte-identical text.
+              # One retry before the heal-path warning: the seed marker's
+              # only copy lives in this body, and the heal ack has no slot
+              # to recover it — a transient 5xx must not silently un-seed
+              # the window.
+              ENGAGE_BODY="$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached.%s%s Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。%s%s移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${FORK_NOTE}" "${FROM_NOTE}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${FORK_NOTE_ZH}" "${FROM_NOTE_ZH}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${FROM_MARKER}")"
+              gh pr comment "${PR}" --repo "${REPO}" --body "${ENGAGE_BODY}" \
+                || { sleep 5; gh pr comment "${PR}" --repo "${REPO}" --body "${ENGAGE_BODY}"; } \
                 || echo "::warning::engage ack comment failed on #${PR}; the scan's first-pickup ack heals it"
               # Engaged (possibly re-engaging an auto-released PR) — the
               # escalation label is stale. 404 is the common case.
@@ -4754,6 +4774,10 @@ jobs:
               | ((.body // "") | [ scan("<!-- autofix-round-start ([0-9]{1,2}) -->") ] | .[] | .[0]) ]
             | last // "0"' "${WORKDIR}/ic.json" 2> /dev/null || echo '0')"
           [[ "${LIVE_ROUND_START}" =~ ^[0-9]{1,2}$ ]] || LIVE_ROUND_START=0
+          # The PRE-clamp value is what the maintainer typed; the Critical-only
+          # audit clause cites it so a clamped seed never renders a command
+          # nobody sent while the engage ack still shows the original number.
+          LIVE_ROUND_START_RAW="${LIVE_ROUND_START}"
           if [[ "${MAX_ROUNDS:-0}" -gt 0 && "${LIVE_ROUND_START}" -ge "${MAX_ROUNDS}" ]]; then
             LIVE_ROUND_START=$(( MAX_ROUNDS - 1 ))
           fi
@@ -5163,6 +5187,7 @@ jobs:
           fi
           echo "stale=${STALE}" >> "${GITHUB_OUTPUT}"
           echo "effective_round=${ROUND}" >> "${GITHUB_OUTPUT}"
+          echo "round_start=${LIVE_ROUND_START}" >> "${GITHUB_OUTPUT}"
 
           rm -f "${WORKDIR}/deferred-feedback.md"
           if [[ "${CRITICAL_ONLY}" == "true" ]]; then
@@ -5185,8 +5210,18 @@ jobs:
             # '0' under string comparison, so a bare `!= '0'` renders the
             # seeded wording on every ordinary PR.
             if [[ "${LIVE_ROUND_START:-0}" != '0' ]]; then
-              ROUNDS_CLAUSE_EN="the round counter reached ${CRITICAL_ONLY_AFTER_ROUND} (this window was seeded at round ${LIVE_ROUND_START} by \`${TAKEOVER_COMMAND} from ${LIVE_ROUND_START}\`, plus $(( ROUND - LIVE_ROUND_START )) change-producing round(s) since)"
-              ROUNDS_CLAUSE_ZH="轮次计数已达 ${CRITICAL_ONLY_AFTER_ROUND}（本窗口由 \`${TAKEOVER_COMMAND} from ${LIVE_ROUND_START}\` 从第 ${LIVE_ROUND_START} 轮起算，此后又完成 $(( ROUND - LIVE_ROUND_START )) 个产生改动的轮次）"
+              # Cite the seed as TYPED, not as clamped: when the read-site
+              # clamp fired, quoting the clamped value renders a command
+              # nobody sent while the engage ack still shows the original.
+              SEED_AS_TYPED="${LIVE_ROUND_START_RAW:-${LIVE_ROUND_START}}"
+              CLAMP_NOTE_EN=''
+              CLAMP_NOTE_ZH=''
+              if [[ "${SEED_AS_TYPED}" != "${LIVE_ROUND_START}" ]]; then
+                CLAMP_NOTE_EN=", clamped to ${LIVE_ROUND_START} under the effective cap ${MAX_ROUNDS}"
+                CLAMP_NOTE_ZH="，已按有效上限 ${MAX_ROUNDS} 收敛为 ${LIVE_ROUND_START}"
+              fi
+              ROUNDS_CLAUSE_EN="the round counter reached ${CRITICAL_ONLY_AFTER_ROUND} (this window was seeded at round ${SEED_AS_TYPED} by \`${TAKEOVER_COMMAND} from ${SEED_AS_TYPED}\`${CLAMP_NOTE_EN}, plus $(( ROUND - LIVE_ROUND_START )) change-producing round(s) since)"
+              ROUNDS_CLAUSE_ZH="轮次计数已达 ${CRITICAL_ONLY_AFTER_ROUND}（本窗口由 \`${TAKEOVER_COMMAND} from ${SEED_AS_TYPED}\` 从第 ${SEED_AS_TYPED} 轮起算${CLAMP_NOTE_ZH}，此后又完成 $(( ROUND - LIVE_ROUND_START )) 个产生改动的轮次）"
             fi
             if [[ "${CRITICAL_ONLY_ROUNDS}" == 'true' && "${CRITICAL_ONLY_GROWTH}" == 'true' ]]; then
               CAUSE_EN="${ROUNDS_CLAUSE_EN} and ${GROWTH_CLAUSE_EN}"
@@ -5944,6 +5979,10 @@ jobs:
           CONFLICT: '${{ steps.prepare.outputs.conflict }}'
           NEWEST: '${{ steps.prepare.outputs.newest }}'
           EFFECTIVE_ROUND: '${{ steps.prepare.outputs.effective_round }}'
+          # The seed the window opened at (prepare's clamped read; 0 when
+          # unseeded): the milestone crossing trigger counts rounds
+          # accumulated in the window, not seed-inflated absolute ones.
+          ROUND_START: '${{ steps.prepare.outputs.round_start }}'
           # Surfaced in the report footer for diagnosis + attribution; a repo
           # variable (not a secret), already the agent's OPENAI_MODEL.
           MODEL: '${{ vars.QWEN_AUTOFIX_MODEL || vars.QWEN_PR_REVIEW_MODEL }}'
@@ -6524,12 +6563,16 @@ jobs:
             # would skip an exact %10 check forever — and a failure-heavy
             # PR is the very PR the digest exists for. Post on the first
             # PUSHED round once 10+ rounds have accumulated since the last
-            # digest in THIS window (or since the window opened).
-            MS_LAST="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" '
+            # digest in THIS window (or since the window opened). The
+            # window opens at the round SEED, not at zero: a '/takeover
+            # from 60' counter starts at 60, so the no-digest-yet baseline
+            # is the seed — otherwise the seed-inflated counter digests on
+            # the window's first push with a 1-2 round census.
+            MS_LAST="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" --argjson start "${ROUND_START:-0}" '
               [ .[] | select((.user.login // "") == $ab) | (.body // "")
                 | [ scan("<!-- autofix-milestone round=([0-9]+) win=([^ ]+) -->") ] | .[]
                 | select(.[1] == $win) | (.[0] | tonumber) ]
-              | max // 0' "${WORKDIR}/ic.json" 2> /dev/null || echo 0)"
+              | max // $start' "${WORKDIR}/ic.json" 2> /dev/null || echo "${ROUND_START:-0}")"
             if [[ "$(( NEXT_ROUND - MS_LAST ))" -ge 10 ]]; then
               WIN_HEADS="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg win "${WINDOW:-none}" '
                 [.[] | select((.user.login // "") == $ab)

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -27,7 +27,10 @@ name: 'Qwen Autofix'
 #                             they are the bot's own generated work, trust-
 #                             equal to an in-repo bot PR; autofix/skip still
 #                             opts them out.
-#   • issue_comment         → '@qwen-code /takeover' (apply the label) and
+#   • issue_comment         → '@qwen-code /takeover' (apply the label),
+#                             '@qwen-code /takeover from N' (apply it and
+#                             seed this window's round counter at N, for a
+#                             PR that already spent N rounds in review), and
 #                             '@qwen-code /takeover stop' (remove it) — sugar
 #                             for people without label access: the PR author,
 #                             or write+ collaborators. Exact-match constants,
@@ -125,6 +128,19 @@ env:
   # only ever bound takeover PRs (the strict cap discards a plain PR at round
   # 10 before Critical-only could engage), so long-running managed PRs spent
   # ten rounds growing their diff on suggestions before the brake applied.
+  # Counted from the window's SEED, not always from zero: '@qwen-code
+  # /takeover from N' starts the window's counter at N so a PR taken over
+  # after N rounds of ordinary review reaches this threshold in the
+  # REMAINDER rather than a fresh five. Without a seed the counter starts at
+  # 0 exactly as before, so a PR that spent nine human rounds getting to
+  # "almost mergeable" no longer restarts the suggestion valve at full
+  # travel the moment it is managed. The seed is window-scoped like every
+  # other census: '@qwen-code /retry' or a bare re-takeover opens a window
+  # with no seed and the counter returns to 0 (that IS what re-arming
+  # means), so a late-stage PR is re-seeded by re-issuing the command with
+  # its number. It does NOT seed the GROWTH brake below, which anchors its
+  # baseline at the window's first measured round — a pre-takeover baseline
+  # is not recoverable, so growth is always measured from engagement.
   CRITICAL_ONLY_AFTER_ROUND: '5'
   # Per-author tail budget inside Critical-only mode. An account is an
   # ACCOUNTABILITY unit, not a throttle: a human login can host an automated
@@ -232,7 +248,12 @@ env:
   TAKEOVER_LABEL: 'autofix/takeover'
   SKIP_LABEL: 'autofix/skip'
   # Comment-command sugar over TAKEOVER_LABEL ('<cmd>' applies it, '<cmd>
-  # stop' removes it). Matched EXACTLY against the trimmed comment body.
+  # stop' removes it). Matched EXACTLY against the trimmed comment body —
+  # with ONE parameterized form, '<cmd> from N', which applies the label and
+  # additionally seeds this window's round counter at N (see
+  # CRITICAL_ONLY_AFTER_ROUND). The literal prefix still has to match this
+  # constant byte-for-byte; only a bounded 1-2 digit integer is read out of
+  # the body, and it reaches nothing but an integer comparison.
   TAKEOVER_COMMAND: '@qwen-code /takeover'
   # Escalation label: applied when the loop STOPS on a PR (round cap,
   # consecutive-failure or time-budget breaker) and a human must act —
@@ -349,6 +370,7 @@ jobs:
       ack_pr: '${{ steps.decide.outputs.ack_pr }}'
       ack_base: '${{ steps.decide.outputs.ack_base }}'
       takeover_cmd: '${{ steps.decide.outputs.takeover_cmd }}'
+      takeover_from: '${{ steps.decide.outputs.takeover_from }}'
       retry_pr: '${{ steps.decide.outputs.retry_pr }}'
       cmd_pr: '${{ steps.decide.outputs.cmd_pr }}'
       review_sender: '${{ github.event.review.user.login }}'
@@ -388,6 +410,10 @@ jobs:
           TAKEOVER_ACK=''
           ACK_BASE=''
           TAKEOVER_CMD=''
+          # Round-counter seed carried by '<cmd> from N' (see the command
+          # parser below). Empty on every other path, which reads as "start
+          # this window at round 0" — the pre-existing behaviour.
+          TAKEOVER_FROM=''
           CMD_PR=''
           RETRY_PR=''
           DRY_RUN="${DRY_RUN_INPUT:-false}"
@@ -508,6 +534,29 @@ jobs:
                 CMD=''
                 [[ "${BODY_TRIMMED}" == "${TAKEOVER_COMMAND}" ]] && CMD='add'
                 [[ "${BODY_TRIMMED}" == "${TAKEOVER_COMMAND} stop" ]] && CMD='remove'
+                # '<cmd> from N' — the ONE parameterized form, and the only
+                # place this workflow reads a value out of a comment body.
+                # Kept inside the constants discipline above: the literal
+                # prefix must still match TAKEOVER_COMMAND byte-for-byte, the
+                # tail is a bounded integer, and the captured value only ever
+                # reaches an integer comparison and a printf '%s' of a
+                # re-validated number — never an unquoted shell word, a jq
+                # program, or an API path. Seeds the round counter so a PR
+                # that already burned N review rounds before takeover reaches
+                # CRITICAL_ONLY_AFTER_ROUND after the remainder rather than a
+                # full fresh five. 1..99: a seed at or past the effective cap
+                # is clamped at the read sites, but rejecting 3-digit input
+                # here keeps the obvious typo out entirely.
+                if [[ "${BODY_TRIMMED}" =~ ^(.*)\ from\ ([0-9]{1,2})$ ]]; then
+                  # Two statements, not one `[[ ... && ... ]]`: BASH_REMATCH is
+                  # only guaranteed populated once the =~ test has completed,
+                  # and reading it from the right-hand operand of the same
+                  # conditional relies on evaluation order this must not bet on.
+                  if [[ "${BASH_REMATCH[1]}" == "${TAKEOVER_COMMAND}" ]]; then
+                    CMD='add'
+                    TAKEOVER_FROM="${BASH_REMATCH[2]}"
+                  fi
+                fi
                 # Re-arm shares the takeover command's authorization exactly:
                 # both summon bot activity on a managed PR, so inventing a
                 # second policy would only add surface.
@@ -713,6 +762,11 @@ jobs:
           echo "ack_pr=$(sanitize_number "${PR_NUMBER_EVENT}")" >> "${GITHUB_OUTPUT}"
           echo "ack_base=${ACK_BASE}" >> "${GITHUB_OUTPUT}"
           echo "takeover_cmd=${TAKEOVER_CMD}" >> "${GITHUB_OUTPUT}"
+          # Re-validated on the way out, not just on the way in: this value
+          # crosses a job boundary into a printf that writes a PR comment, and
+          # the only shape the marker reader accepts is a bare 1-2 digit
+          # integer. sanitize_number rejects (and warns about) anything else.
+          echo "takeover_from=$(sanitize_number "${TAKEOVER_FROM}")" >> "${GITHUB_OUTPUT}"
           echo "retry_pr=${RETRY_PR}" >> "${GITHUB_OUTPUT}"
           echo "cmd_pr=${CMD_PR}" >> "${GITHUB_OUTPUT}"
           echo "🧭 phase='${PHASE:-auto}' event='${EVENT_NAME}' issue='#${ISSUE_NUMBER:-n/a}' pr='#${PR_NUMBER_EVENT:-n/a}' schedule='${SCHEDULE:-n/a}' dry_run=${DRY_RUN} → issue=${DO_ISSUE} review=${DO_REVIEW}"
@@ -1853,6 +1907,7 @@ jobs:
     env:
       REPO: '${{ github.repository }}'
       CMD: '${{ needs.route.outputs.takeover_cmd }}'
+      CMD_FROM: '${{ needs.route.outputs.takeover_from }}'
       PR: '${{ needs.route.outputs.cmd_pr }}'
       GITHUB_TOKEN: '${{ secrets.CI_DEV_BOT_PAT }}'
     steps:
@@ -1943,6 +1998,27 @@ jobs:
             esac
           fi
           HAS="$(jq -r --arg t "${TAKEOVER_LABEL}" '[.labels[].name] | index($t) != null' <<< "${PR_INFO}")"
+          # The round seed rides as its OWN marker on a separate line, NEVER as
+          # a field inside '<!-- takeover-ack engaged -->'. That literal is
+          # matched with jq `contains()` — closing '-->' included — at seven
+          # read sites: four here (the ack dedup, the scan's first-pickup
+          # dedup, and the two REARM_KEY window readers) and three in
+          # qwen-fleet-shepherd.yml (the paused/resume detector). Appending a
+          # field would silently break all seven: the window key would fall
+          # back to an OLDER engage ack, so the round counter would read a dead
+          # window, and the shepherd would stop seeing the engage as a resume
+          # signal and age out a PR that was just re-armed. Same reasoning, and
+          # the same shape, as the autofix-redcheck marker.
+          # Rendered EN/ZH too, because the ack otherwise reports
+          # "round 4/100" on its first managed round and reads like a bug.
+          FROM_MARKER=''
+          FROM_NOTE=''
+          FROM_NOTE_ZH=''
+          if [[ -n "${CMD_FROM}" && "${CMD_FROM}" =~ ^[0-9]{1,2}$ && "${CMD_FROM}" != '0' ]]; then
+            FROM_MARKER="$(printf '\n<!-- autofix-round-start %s -->' "${CMD_FROM}")"
+            FROM_NOTE="$(printf ' This window'"'"'s round counter starts at %s (the rounds this PR spent in review before takeover), so the Critical-only brake engages after %s more change-producing round(s) instead of a full fresh %s.' "${CMD_FROM}" "$(( CRITICAL_ONLY_AFTER_ROUND > CMD_FROM ? CRITICAL_ONLY_AFTER_ROUND - CMD_FROM : 0 ))" "${CRITICAL_ONLY_AFTER_ROUND}")"
+            FROM_NOTE_ZH="$(printf '本窗口轮次计数从 %s 起算（即本 PR 托管前已进行的评审轮数），因此再经过 %s 个产生改动的轮次即进入 Critical-only，而非重新计满 %s 轮。' "${CMD_FROM}" "$(( CRITICAL_ONLY_AFTER_ROUND > CMD_FROM ? CRITICAL_ONLY_AFTER_ROUND - CMD_FROM : 0 ))" "${CRITICAL_ONLY_AFTER_ROUND}")"
+          fi
           if [[ "${CMD}" == 'add' ]]; then
             if [[ "${HAS}" == 'true' ]]; then
               # Already managed: repeating the command is the ROUND-COUNTER
@@ -1951,7 +2027,7 @@ jobs:
               # a PR that exhausted its rounds continues under management —
               # no label churn needed. The watermark is untouched: feedback
               # already addressed is never replayed.
-              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🔄 Takeover re-armed: the round counter starts a fresh window (previous rounds no longer count toward the cap); management continues.\n\n<details>\n<summary>中文说明</summary>\n\n🔄 已重新武装：轮次计数开启新窗口（此前轮次不再计入上限），托管继续。\n\n</details>\n\n<!-- takeover-ack engaged -->')"
+              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🔄 Takeover re-armed: the round counter starts a fresh window (previous rounds no longer count toward the cap); management continues.%s\n\n<details>\n<summary>中文说明</summary>\n\n🔄 已重新武装：轮次计数开启新窗口（此前轮次不再计入上限），托管继续。%s\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${FROM_NOTE}" "${FROM_NOTE_ZH}" "${FROM_MARKER}")"
               echo "🔄 re-armed ${TAKEOVER_LABEL} window on #${PR}"
               # Management resumed — the escalation label is stale. 404 is
               # the common case (the PR was never paused).
@@ -1993,7 +2069,7 @@ jobs:
                 FORK_NOTE=' This is a fork PR, so the first round comes from the next scheduled scan (usually within minutes).'
                 FORK_NOTE_ZH='本 PR 来自 fork，首轮处理将由下一次定时扫描执行（通常几分钟内）。'
               fi
-              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached.%s Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。%s移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->' "${FORK_NOTE}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${FORK_NOTE_ZH}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}")" \
+              gh pr comment "${PR}" --repo "${REPO}" --body "$(printf '🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached.%s%s Remove the `%s` label (or comment `%s stop`) to release.\n\n<details>\n<summary>中文说明</summary>\n\n🤝 已接管：autofix 循环现在管理此 PR —— 将持续处理新的评审反馈与 base 冲突，直到移除标签或达到轮次上限。%s%s移除 `%s` 标签（或评论 `%s stop`）即可释放。\n\n</details>\n\n<!-- takeover-ack engaged -->%s' "${FORK_NOTE}" "${FROM_NOTE}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${FORK_NOTE_ZH}" "${FROM_NOTE_ZH}" "${TAKEOVER_LABEL}" "${TAKEOVER_COMMAND}" "${FROM_MARKER}")" \
                 || echo "::warning::engage ack comment failed on #${PR}; the scan's first-pickup ack heals it"
               # Engaged (possibly re-engaging an auto-released PR) — the
               # escalation label is stale. 404 is the common case.
@@ -3229,7 +3305,39 @@ jobs:
                 | select(((.body // "") | contains("<!-- takeover-ack engaged -->"))
                     or ((.body // "") | contains("<!-- autofix-rearm -->")))
                 | .created_at ] | max // "none"' "${WORKDIR}/ic.json")"
-            ROUND="$(jq -r --arg key "${REARM_KEY}" 'map(select(.win == $key)) | map(.round) | max // 0' <<< "${MARKERS}")"
+            # Seed for THIS window, from the '<cmd> from N' marker carried by
+            # the comment that IS the window key — so it is window-scoped for
+            # free, exactly like the key itself: a later /retry or a bare
+            # /takeover opens a window whose anchor has no marker and the seed
+            # returns to 0. Read by created_at equality against REARM_KEY, so a
+            # seed from a SUPERSEDED window can never leak into the live one.
+            # `scan` (not `capture`, which errors when absent) and `last`
+            # (a hand-written marker further down a bot comment loses to the
+            # workflow's own, which is always the final line).
+            ROUND_START="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${REARM_KEY}" '
+              [ .[] | select((.user.login // "") == $ab)
+                | select((.created_at // "") == $key)
+                | ((.body // "") | [ scan("<!-- autofix-round-start ([0-9]{1,2}) -->") ] | .[] | .[0]) ]
+              | last // "0"' "${WORKDIR}/ic.json" 2> /dev/null || echo '0')"
+            [[ "${ROUND_START}" =~ ^[0-9]{1,2}$ ]] || ROUND_START=0
+            # Clamp strictly below the effective cap. The seed must be able to
+            # bring the Critical-only brake forward; it must NEVER be able to
+            # park a PR at its round cap on the very round it is taken over
+            # (which would stop the loop instead of starting it), and a seed
+            # is honoured on any PR whose window anchor carries the marker —
+            # including one whose takeover label was later removed, dropping
+            # EFF_MAX_ROUNDS back to the strict 10.
+            if [[ "${EFF_MAX_ROUNDS:-0}" -gt 0 && "${ROUND_START}" -ge "${EFF_MAX_ROUNDS}" ]]; then
+              echo "🔢 #${PR}: round seed ${ROUND_START} clamped to $(( EFF_MAX_ROUNDS - 1 )) (effective cap ${EFF_MAX_ROUNDS})"
+              ROUND_START=$(( EFF_MAX_ROUNDS - 1 ))
+            fi
+            ROUND="$(jq -r --arg key "${REARM_KEY}" --argjson start "${ROUND_START}" 'map(select(.win == $key)) | map(.round) | max // $start' <<< "${MARKERS}")"
+            # No mention of the Critical-only threshold here, deliberately: the
+            # scan must stay ignorant of that brake. It keeps SELECTING fresh
+            # suggestions so a no-op report can still advance the watermark;
+            # only prepare hides them from the agent. A test pins the scan
+            # against the string.
+            [[ "${ROUND_START}" != '0' ]] && echo "🔢 #${PR}: window seeded at round ${ROUND_START} → effective round ${ROUND}/${EFF_MAX_ROUNDS}"
 
             # Effective watermark = what the agent has actually evaluated (its last
             # eval marker's newest-feedback timestamp), NOT the last push. A bot
@@ -4636,7 +4744,20 @@ jobs:
               | select(((.body // "") | contains("<!-- takeover-ack engaged -->"))
                     or ((.body // "") | contains("<!-- autofix-rearm -->")))
               | .created_at ] | max // "none"' "${WORKDIR}/ic.json")"
-          LIVE_MAX_ROUND="$(jq -r --arg key "${LIVE_REARM_KEY}" 'map(select(.win == $key)) | map(.round) | max // 0' <<< "${LIVE_MARKS}")"
+          # …and so does the round seed: same marker, same created_at-equality
+          # read against the live window key, same clamp. MAX_ROUNDS is the
+          # matrix-shadowed EFFECTIVE cap here (see the address job's env), so
+          # the clamp is against the same ceiling the scan used.
+          LIVE_ROUND_START="$(jq -r --arg ab "${AUTOFIX_BOT}" --arg key "${LIVE_REARM_KEY}" '
+            [ .[] | select((.user.login // "") == $ab)
+              | select((.created_at // "") == $key)
+              | ((.body // "") | [ scan("<!-- autofix-round-start ([0-9]{1,2}) -->") ] | .[] | .[0]) ]
+            | last // "0"' "${WORKDIR}/ic.json" 2> /dev/null || echo '0')"
+          [[ "${LIVE_ROUND_START}" =~ ^[0-9]{1,2}$ ]] || LIVE_ROUND_START=0
+          if [[ "${MAX_ROUNDS:-0}" -gt 0 && "${LIVE_ROUND_START}" -ge "${MAX_ROUNDS}" ]]; then
+            LIVE_ROUND_START=$(( MAX_ROUNDS - 1 ))
+          fi
+          LIVE_MAX_ROUND="$(jq -r --arg key "${LIVE_REARM_KEY}" --argjson start "${LIVE_ROUND_START}" 'map(select(.win == $key)) | map(.round) | max // $start' <<< "${LIVE_MARKS}")"
           # The head a sibling last judged, mirrored from the scan's RED_HEAD
           # parse. A no-op sibling records this marker while leaving BOTH ts and
           # round UNCHANGED — so the watermark/round triggers below never fire,
@@ -5054,8 +5175,19 @@ jobs:
             # the cause line reads like a misfire to exactly its audience.
             GROWTH_CLAUSE_EN="the PR's diff grew src ${GROWTH_SRC} / test ${GROWTH_TEST} net lines beyond this counting window's baseline (budgets: ${GROWTH_BUDGET_SRC_LINES}/${GROWTH_BUDGET_TEST_LINES})"
             GROWTH_CLAUSE_ZH="本计数窗口内 diff 净增长已达 源码 ${GROWTH_SRC} / 测试 ${GROWTH_TEST} 行（预算 ${GROWTH_BUDGET_SRC_LINES}/${GROWTH_BUDGET_TEST_LINES}）"
+            # Name the seed when there is one. Without this the audit record
+            # claims "5 change-producing rounds are complete" on a PR the loop
+            # has run twice — true of the counter, visibly false of the PR, and
+            # unfalsifiable for the maintainer reading it.
             ROUNDS_CLAUSE_EN="${CRITICAL_ONLY_AFTER_ROUND} change-producing rounds are complete"
             ROUNDS_CLAUSE_ZH="已完成 ${CRITICAL_ONLY_AFTER_ROUND} 个产生改动的轮次"
+            # :-0 is load-bearing, not defensive habit: an UNSET seed is not
+            # '0' under string comparison, so a bare `!= '0'` renders the
+            # seeded wording on every ordinary PR.
+            if [[ "${LIVE_ROUND_START:-0}" != '0' ]]; then
+              ROUNDS_CLAUSE_EN="the round counter reached ${CRITICAL_ONLY_AFTER_ROUND} (this window was seeded at round ${LIVE_ROUND_START} by \`${TAKEOVER_COMMAND} from ${LIVE_ROUND_START}\`, plus $(( ROUND - LIVE_ROUND_START )) change-producing round(s) since)"
+              ROUNDS_CLAUSE_ZH="轮次计数已达 ${CRITICAL_ONLY_AFTER_ROUND}（本窗口由 \`${TAKEOVER_COMMAND} from ${LIVE_ROUND_START}\` 从第 ${LIVE_ROUND_START} 轮起算，此后又完成 $(( ROUND - LIVE_ROUND_START )) 个产生改动的轮次）"
+            fi
             if [[ "${CRITICAL_ONLY_ROUNDS}" == 'true' && "${CRITICAL_ONLY_GROWTH}" == 'true' ]]; then
               CAUSE_EN="${ROUNDS_CLAUSE_EN} and ${GROWTH_CLAUSE_EN}"
               CAUSE_ZH="${ROUNDS_CLAUSE_ZH}，且${GROWTH_CLAUSE_ZH}"

--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -329,10 +329,14 @@ silently overriding or silently complying.
   drop one silently.
 - Critical-only mode: when `feedback.md` contains a
   `Deferred non-Critical feedback` section, the workflow's deterministic brake
-  has engaged — the PR has completed five suggestion-capable, change-producing
-  rounds, or its diff has grown past the counting window's net-growth budget
-  (source and test lines are budgeted separately; the section's preamble names
-  the cause). That section is an audit record,
+  has engaged — the window's round counter has reached five, or its diff has
+  grown past the counting window's net-growth budget (source and test lines are
+  budgeted separately; the section's preamble names the cause). The counter is
+  not always the count of rounds YOU have run: a maintainer taking over a PR
+  that already spent N rounds in ordinary review can seed the window at N
+  (`@qwen-code /takeover from N`), so the brake can engage on your second or
+  third round. The preamble says so when it applies; treat it exactly the same
+  either way. That section is an audit record,
   not work: do not modify code, resolve threads, or write comment replies for
   those items. Everything rendered in the actionable sections IS in scope —
   the deterministic filter defers the automated reviewer's non-Critical

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3774,6 +3774,7 @@ describe('qwen-autofix workflow', () => {
       deleteFails = '',
       cmdFrom = '',
       commentFails = '',
+      commentFailTimes = '',
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-toggle-'));
       try {
@@ -3799,7 +3800,7 @@ describe('qwen-autofix workflow', () => {
             // universally exiting 0.
             `elif [[ "$1" == "label" && "$2" == "create" ]]; then echo "LABEL-CREATE $*" >> '${join(dir, 'writes.log')}';`,
             `elif [[ "$1" == "api" ]]; then echo "API $*" >> '${join(dir, 'writes.log')}'; if [[ "$2" == "-X" && "$3" == "POST" && -n "\${TOGGLE_POST_FAILS:-}" ]]; then printf '%s' "\${TOGGLE_POST_FAILS}" >&2; exit 1; fi; if [[ "$2" == "-X" && "$3" == "DELETE" && -n "\${TOGGLE_DELETE_FAILS:-}" ]]; then printf '%s' "\${TOGGLE_DELETE_FAILS}" >&2; exit 1; fi; if [[ "$2" == "-X" && "$3" == "DELETE" ]]; then printf '%s' '[{"name":"Tracks HTTP 5xx flakes"}]'; fi`,
-            `elif [[ "$1" == "pr" && "$2" == "comment" ]]; then echo "COMMENT-ATTEMPT" >> '${join(dir, 'writes.log')}'; if [[ -n "\${TOGGLE_COMMENT_FAILS:-}" && ! -f '${join(dir, 'comment-failed')}' ]]; then touch '${join(dir, 'comment-failed')}'; printf '%s' "\${TOGGLE_COMMENT_FAILS}" >&2; exit 1; fi; echo "COMMENT $*" >> '${join(dir, 'writes.log')}';`,
+            `elif [[ "$1" == "pr" && "$2" == "comment" ]]; then echo "COMMENT-ATTEMPT" >> '${join(dir, 'writes.log')}'; if [[ -n "\${TOGGLE_COMMENT_FAILS:-}" ]]; then CF=0; if [[ -f '${join(dir, 'comment-fails')}' ]]; then CF="$(< '${join(dir, 'comment-fails')}')"; fi; if (( CF < \${TOGGLE_COMMENT_FAIL_TIMES:-1} )); then printf '%s' "$(( CF + 1 ))" > '${join(dir, 'comment-fails')}'; printf '%s' "\${TOGGLE_COMMENT_FAILS}" >&2; exit 1; fi; fi; echo "COMMENT $*" >> '${join(dir, 'writes.log')}';`,
             'fi',
           ].join('\n'),
         );
@@ -3833,6 +3834,7 @@ describe('qwen-autofix workflow', () => {
               TOGGLE_POST_FAILS: postFails,
               TOGGLE_DELETE_FAILS: deleteFails,
               TOGGLE_COMMENT_FAILS: commentFails,
+              TOGGLE_COMMENT_FAIL_TIMES: commentFailTimes,
               CMD_FROM: cmdFrom,
               CRITICAL_ONLY_AFTER_ROUND: '5',
             },
@@ -3851,6 +3853,7 @@ describe('qwen-autofix workflow', () => {
         error.writes = existsSync(join(dir, 'writes.log'))
           ? readFileSync(join(dir, 'writes.log'), 'utf8')
           : '';
+        error.log = error.stdout ?? '';
         throw error;
       } finally {
         rmSync(dir, { recursive: true, force: true });
@@ -4116,6 +4119,34 @@ describe('qwen-autofix workflow', () => {
     );
     expect(transientRearmFailure.log).toContain('re-armed');
     expect(transientRearmFailure.log).not.toContain('::error::');
+    // …but a DOUBLE re-arm ack failure must abort instead: nothing heals a
+    // missing re-arm (the scan heals only engage-less PRs, and the
+    // pre-existing engage ack suppresses the dedup), so the 're-armed'
+    // claim and the stale-escalation cleanup must never follow a window
+    // reset that never landed. The stub's fail-once guard above can never
+    // reach this arm — TOGGLE_COMMENT_FAIL_TIMES=2 makes both POSTs fail.
+    let rearmDoubleFailure;
+    try {
+      runToggle({
+        cmd: 'add',
+        labels: ['autofix/takeover'],
+        cmdFrom: '7',
+        commentFails: 'HTTP 502',
+        commentFailTimes: 2,
+      });
+    } catch (error) {
+      rearmDoubleFailure = error;
+    }
+    expect(rearmDoubleFailure).toBeTruthy();
+    expect(
+      rearmDoubleFailure.writes.match(/^COMMENT-ATTEMPT$/gm) ?? [],
+    ).toHaveLength(2);
+    expect(rearmDoubleFailure.writes).not.toContain('takeover-ack engaged');
+    expect(rearmDoubleFailure.writes).not.toContain(
+      'labels/autofix%2Fneeds-human',
+    );
+    expect(rearmDoubleFailure.log).toContain('::error::');
+    expect(rearmDoubleFailure.log).not.toContain('re-armed');
     // The release DELETE tolerates the 404 race (a concurrent removal
     // already reached the end state): the release ack still posts, no
     // warning.
@@ -5557,11 +5588,15 @@ exit 1
     ]) {
       expect(seedOf(body)).toBe('|');
     }
-    // The captured value crosses two job-boundary wires no behavioral
-    // harness exercises — every replay injects CMD_FROM directly, starting
-    // inside a single job — so pin them verbatim like the suite's other
-    // wires: a deleted or typo'd wire would silently degrade 'from N' to a
-    // bare '/takeover' with the whole suite still green.
+    // The captured value crosses a GITHUB_OUTPUT write and two
+    // job-boundary wires no behavioral harness exercises — every replay
+    // injects CMD_FROM directly, starting inside a single job — so pin
+    // them verbatim like the suite's other wires: a deleted or typo'd
+    // link would silently degrade 'from N' to a bare '/takeover' with the
+    // whole suite still green.
+    expect(workflow).toContain(
+      'echo "takeover_from=$(sanitize_number "${TAKEOVER_FROM}")" >> "${GITHUB_OUTPUT}"',
+    );
     expect(workflow).toContain(
       "takeover_from: '${{ steps.decide.outputs.takeover_from }}'",
     );

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -535,8 +535,10 @@ describe('qwen-autofix workflow', () => {
     // caught, not just a removed constant.
     expect(reviewScanJob).toContain('.startedAt // $cut) > $cut');
     // Round is the max across markers so a terminal handoff marker is honored
-    // regardless of its timestamp.
-    expect(reviewScanJob).toContain('map(.round) | max // 0');
+    // regardless of its timestamp; the fallback is the window's SEED (0 unless
+    // '@qwen-code /takeover from N' anchored this window at N), never a
+    // hardcoded 0.
+    expect(reviewScanJob).toContain('map(.round) | max // $start');
     // Never fall back to the mutable head commit date for the pre-first-eval
     // floor (a base-sync HEAD would recreate feedback burial); use the immutable
     // createdAt, or an empty floor if the metadata query failed.
@@ -2997,7 +2999,7 @@ describe('qwen-autofix workflow', () => {
     )?.[1];
     expect(markersProgram).toBeTruthy();
     const roundProgram = reviewScanJob.match(
-      /ROUND="\$\(jq -r --arg key "\$\{REARM_KEY\}" '([\s\S]*?)' <<< "\$\{MARKERS\}"\)"/,
+      /ROUND="\$\(jq -r --arg key "\$\{REARM_KEY\}" --argjson start "\$\{ROUND_START\}" '([\s\S]*?)' <<< "\$\{MARKERS\}"\)"/,
     )?.[1];
     expect(roundProgram).toBeTruthy();
     const pageOne = JSON.stringify([
@@ -3032,7 +3034,7 @@ describe('qwen-autofix workflow', () => {
     expect(markers.split('\n')).toHaveLength(1);
     const round = execFileSync(
       'jq',
-      ['-r', '--arg', 'key', 'none', roundProgram],
+      ['-r', '--arg', 'key', 'none', '--argjson', 'start', '0', roundProgram],
       { encoding: 'utf8', input: markers },
     ).trim();
     expect(round).toBe('7'); // max round crosses the page boundary
@@ -4201,6 +4203,105 @@ describe('qwen-autofix workflow', () => {
     expect(prepareBranchAndFeedbackStep).toContain('LIVE_REARM_KEY');
   });
 
+  it('behaviorally seeds the round counter from the window anchor and only from it', () => {
+    // '@qwen-code /takeover from N' rides as its OWN marker on the engage
+    // ack, never as a field inside '<!-- takeover-ack engaged -->' — that
+    // literal is matched with jq contains(), closing '-->' included, at four
+    // sites here and three in qwen-fleet-shepherd.yml, and a field would
+    // silently break all seven. Replay the scan's real trio to prove the
+    // marker survives alongside the untouched ack, and that the seed is
+    // scoped exactly like the window key it is read from.
+    const trio = reviewScanJob.match(
+      /(MARKERS="\$\(jq -c[\s\S]*?ROUND="\$\(jq -r --arg key "\$\{REARM_KEY\}"[^\n]*)/,
+    )?.[1];
+    expect(trio).toBeTruthy();
+    const BOT = 'qwen-code-dev-bot';
+    const roundOf = (comments) => {
+      const dir = mkdtempSync(join(tmpdir(), 'autofix-seed-'));
+      try {
+        writeFileSync(join(dir, 'ic.json'), JSON.stringify(comments));
+        return execFileSync(
+          'bash',
+          [
+            '-c',
+            `set -uo pipefail\nWORKDIR='${dir}'\n${trio.replace(/\n {12}/g, '\n')}\nprintf '\\n%s' "$ROUND"`,
+          ],
+          { env: { ...process.env, AUTOFIX_BOT: BOT }, encoding: 'utf8' },
+        )
+          .split('\n')
+          .at(-1);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+    const ack = (at, seed) => ({
+      user: { login: BOT },
+      created_at: at,
+      body: `🤝 …\n<!-- takeover-ack engaged -->${seed === undefined ? '' : `\n<!-- autofix-round-start ${seed} -->`}`,
+    });
+    const evalMarker = (at, round, win) => ({
+      user: { login: BOT },
+      created_at: at,
+      body: `<!-- autofix-eval ts=${at} acted=true round=${round} win=${win} -->`,
+    });
+    const K1 = '2026-08-03T00:00:00Z';
+    const K0 = '2026-08-01T00:00:00Z';
+    // The whole point: a PR taken over at round 3 starts there, so with
+    // CRITICAL_ONLY_AFTER_ROUND=5 the brake is two managed rounds away
+    // instead of five.
+    expect(roundOf([ack(K1, 3)])).toBe('3');
+    // Real markers outrank the seed as soon as one exists — the seed is a
+    // FLOOR for an empty window, not an offset added to every round.
+    expect(
+      roundOf([ack(K1, 3), evalMarker('2026-08-04T00:00:00Z', 4, K1)]),
+    ).toBe('4');
+    // Window scoping, in both directions. A superseded window's seed cannot
+    // leak forward…
+    expect(roundOf([ack(K0, 7), ack(K1, 3)])).toBe('3');
+    // …and a bare re-arm (no marker) drops the seed to 0, which is what
+    // per-window scoping MEANS: re-arming a late-stage PR reopens the
+    // suggestion valve unless the number is supplied again.
+    expect(roundOf([ack(K0, 7), ack(K1)])).toBe('0');
+    // Unseeded acks behave exactly as before this feature existed.
+    expect(roundOf([ack(K1)])).toBe('0');
+    expect(roundOf([])).toBe('0');
+    // Trust boundary: the seed is read from the bot-authored comment whose
+    // created_at IS the window key. Both halves of that predicate carry
+    // weight, so both are exercised against a payload that would otherwise
+    // park the PR at its round cap. The stranger here posts AT the window
+    // key — GitHub stamps created_at to the second, so a comment landing in
+    // the same second as the engage ack is a real collision and the author
+    // filter is the only thing that rejects it. (Dating the impostor
+    // anywhere else tests the key check twice and the author check not at
+    // all: with the author filter deleted such a case still passes.)
+    expect(
+      roundOf([
+        ack(K1),
+        {
+          user: { login: 'mallory' },
+          created_at: K1,
+          body: 'lgtm <!-- autofix-round-start 99 -->',
+        },
+      ]),
+    ).toBe('0');
+    expect(
+      roundOf([
+        ack(K1),
+        {
+          user: { login: BOT },
+          created_at: '2026-08-05T00:00:00Z',
+          body: 'report <!-- autofix-round-start 99 -->',
+        },
+      ]),
+    ).toBe('0');
+    // Shape gate: the marker reader takes 1-2 digits, so a longer number is
+    // not silently truncated to its first two digits.
+    expect(roundOf([ack(K1, 100)])).toBe('0');
+    // The ack literal the other seven read sites match must survive verbatim
+    // next to the seed marker.
+    expect(ack(K1, 3).body).toContain('<!-- takeover-ack engaged -->');
+  });
+
   it('behaviorally validates forced targets against author, takeover, and skip', () => {
     // Extract the forced-PR classifier VERBATIM and replay it: the bot's
     // own PRs pass; a human PR passes only with the takeover label; skip
@@ -5124,7 +5225,7 @@ exit 1
           'bash',
           [
             '-c',
-            `${sanitize.replace(/\n {10}/g, '\n')}\nEVENT_NAME=issue_comment\nTAKEOVER_CMD=''\nCMD_PR=''\n${cmdBranch.replace(/\n {14}/g, '\n')}\nprintf '%s|%s' "$TAKEOVER_CMD" "$CMD_PR"`,
+            `${sanitize.replace(/\n {10}/g, '\n')}\nEVENT_NAME=issue_comment\nTAKEOVER_CMD=''\nTAKEOVER_FROM=''\nCMD_PR=''\n${cmdBranch.replace(/\n {14}/g, '\n')}\nprintf '%s|%s' "$TAKEOVER_CMD" "$CMD_PR"`,
           ],
           {
             env: {
@@ -5231,6 +5332,97 @@ exit 1
         headRepo: 'human-a/qwen-code',
       }),
     ).toBe('add|7165');
+  });
+
+  it('behaviorally parses the takeover round seed and keeps every other body closed', () => {
+    // '@qwen-code /takeover from N' is the ONE parameterized command form, so
+    // it is also the one place a value is read out of a comment body. Replay
+    // the issue_comment branch VERBATIM (drift fails) and pin both halves:
+    // the literal prefix must still match TAKEOVER_COMMAND byte-for-byte, and
+    // the tail must be a bounded integer. Everything else — a prefixed body, a
+    // 'stop from N' hybrid, double spaces, a 3-digit number, a shell/command
+    // substitution payload — must fail CLOSED to "not an exact command", which
+    // is the property the constants-only discipline bought in the first place.
+    const sanitize = routeStep.match(
+      /(sanitize_number\(\) \{[\s\S]*?\n {10}\})/,
+    )?.[1];
+    const cmdBranch = routeStep.match(
+      /(if \[\[ "\$\{EVENT_NAME\}" == 'issue_comment' \]\]; then[\s\S]*?\n {14}fi)/,
+    )?.[1];
+    expect(sanitize).toBeTruthy();
+    expect(cmdBranch).toBeTruthy();
+    const seedOf = (body) => {
+      const dir = mkdtempSync(join(tmpdir(), 'autofix-from-'));
+      try {
+        writeFileSync(
+          join(dir, 'gh'),
+          `#!/bin/bash\nif [[ "$*" == *"/pulls/"* ]]; then printf '%s' 'QwenLM/qwen-code'; else printf '%s' 'write'; fi\n`,
+        );
+        chmodSync(join(dir, 'gh'), 0o755);
+        // TAKEOVER_FROM is echoed through sanitize_number exactly as the
+        // route step's own output line does, so a value that survives the
+        // parser but not the re-validation shows up here as empty.
+        const out = execFileSync(
+          'bash',
+          [
+            '-c',
+            `${sanitize.replace(/\n {10}/g, '\n')}\nEVENT_NAME=issue_comment\nTAKEOVER_CMD=''\nTAKEOVER_FROM=''\nCMD_PR=''\n${cmdBranch.replace(/\n {14}/g, '\n')}\nprintf '%s|%s' "$TAKEOVER_CMD" "$(sanitize_number "$TAKEOVER_FROM")"`,
+          ],
+          {
+            env: {
+              ...process.env,
+              PATH: `${dir}:${process.env.PATH}`,
+              COMMENT_BODY: body,
+              SENDER_LOGIN: 'maintainer-b',
+              COMMENT_PR_AUTHOR: 'human-a',
+              HAS_PR_URL: 'url',
+              ISSUE_STATE: 'open',
+              ISSUE_NUMBER: '7165',
+              AUTOFIX_BOT: 'qwen-code-dev-bot',
+              TAKEOVER_COMMAND: '@qwen-code /takeover',
+              TAKEOVER_LABEL: 'autofix/takeover',
+              REPO: 'QwenLM/qwen-code',
+              GITHUB_TOKEN: 'x',
+            },
+            encoding: 'utf8',
+          },
+        ).split('\n');
+        return out.at(-1);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    };
+    // Seeded engagement, including surrounding whitespace (the body is
+    // trimmed before matching) and the two-digit upper end.
+    expect(seedOf('@qwen-code /takeover from 3')).toBe('add|3');
+    expect(seedOf('  @qwen-code /takeover from 12  ')).toBe('add|12');
+    expect(seedOf('@qwen-code /takeover from 99')).toBe('add|99');
+    // 'from 0' is the explicit no-seed spelling: it must engage exactly like
+    // the bare command rather than being rejected, so a maintainer who types
+    // it gets management, not silence.
+    expect(seedOf('@qwen-code /takeover from 0')).toBe('add|0');
+    // The unparameterized forms are untouched.
+    expect(seedOf('@qwen-code /takeover')).toBe('add|');
+    expect(seedOf('@qwen-code /takeover stop')).toBe('remove|');
+    // Fail-closed set. 'stop from 3' is the interesting one: it must NOT
+    // release (the exact-'stop' match misses) and must NOT engage (the
+    // prefix is not TAKEOVER_COMMAND) — an ambiguous body does nothing.
+    for (const body of [
+      '@qwen-code /takeover stop from 3',
+      '@qwen-code /takeover from 100',
+      '@qwen-code /takeover from 3x',
+      '@qwen-code /takeover from -1',
+      '@qwen-code /takeover from',
+      '@qwen-code /takeover  from 3',
+      '@qwen-code /takeoverfrom 3',
+      'please @qwen-code /takeover from 3',
+      '@qwen-code /takeover from 3 please',
+      '@qwen-code /takeover from 3; rm -rf /',
+      '@qwen-code /takeover from $(id)',
+      '@qwen-code /takeover from `id`',
+    ]) {
+      expect(seedOf(body)).toBe('|');
+    }
   });
 
   it('gates real-time review triggers on bot author, trusted sender, and in-repo PR', () => {
@@ -7671,12 +7863,12 @@ exit 1
       /(GROWTH_CLAUSE_EN="the PR's diff grew[\s\S]*?CAUSE_ZH="\$\{ROUNDS_CLAUSE_ZH\}"\n\s+fi)/,
     )?.[1];
     expect(causeBlock).toBeTruthy();
-    const causeFor = (rounds, growth, growthSrc, growthTest) =>
+    const causeFor = (rounds, growth, growthSrc, growthTest, seed = '') =>
       execFileSync(
         'bash',
         [
           '-c',
-          `CRITICAL_ONLY_ROUNDS=${rounds}\nCRITICAL_ONLY_GROWTH=${growth}\nGROWTH_SRC=${growthSrc}\nGROWTH_TEST=${growthTest}\nGROWTH_BUDGET_SRC_LINES=400\nGROWTH_BUDGET_TEST_LINES=400\nCRITICAL_ONLY_AFTER_ROUND=5\n${causeBlock}\nprintf '%s\\n%s' "$CAUSE_EN" "$CAUSE_ZH"`,
+          `CRITICAL_ONLY_ROUNDS=${rounds}\nCRITICAL_ONLY_GROWTH=${growth}\nGROWTH_SRC=${growthSrc}\nGROWTH_TEST=${growthTest}\nGROWTH_BUDGET_SRC_LINES=400\nGROWTH_BUDGET_TEST_LINES=400\nCRITICAL_ONLY_AFTER_ROUND=5\nTAKEOVER_COMMAND='@qwen-code /takeover'\n${seed}\n${causeBlock}\nprintf '%s\\n%s' "$CAUSE_EN" "$CAUSE_ZH"`,
         ],
         { encoding: 'utf8' },
       ).split('\n');
@@ -7694,6 +7886,26 @@ exit 1
     expect(both[0]).toContain('rounds are complete and');
     expect(both[0]).toContain('src 900 / test 20');
     expect(both[1]).toContain('轮次，且');
+    // A SEEDED window must not claim five completed rounds: this PR reached
+    // the threshold from `@qwen-code /takeover from 3` plus two managed
+    // rounds, and the audit record has to say so or a maintainer reading
+    // "5 change-producing rounds are complete" on a twice-run PR cannot tell
+    // the brake from a misfire. An UNSET seed (every ordinary PR, and the
+    // roundsOnly case above) must keep the plain wording — `!= '0'` without
+    // the :-0 default renders the seeded text for everyone.
+    const seeded = causeFor(
+      'true',
+      'false',
+      0,
+      0,
+      'LIVE_ROUND_START=3\nROUND=5',
+    );
+    expect(seeded[0]).toContain('seeded at round 3');
+    expect(seeded[0]).toContain('@qwen-code /takeover from 3');
+    expect(seeded[0]).toContain('plus 2 change-producing round(s) since');
+    expect(seeded[0]).not.toBe('5 change-producing rounds are complete');
+    expect(seeded[1]).toContain('从第 3 轮起算');
+    expect(seeded[1]).toContain('又完成 2 个产生改动的轮次');
 
     // The batch-budget sentence must describe the policy actually in force:
     // the OVER_BUDGET census only builds spans in round-brake territory, so

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -4094,6 +4094,28 @@ describe('qwen-autofix workflow', () => {
       '<!-- takeover-ack engaged -->\n<!-- autofix-round-start 12 -->',
     );
     expect(transientAckFailure.log).not.toContain('::warning::');
+    // A TRANSIENT re-arm ack failure gets the same one-retry shape — the
+    // seed marker's only copy rides in the re-arm body too, and nothing
+    // heals a missing re-arm (the scan heals only engage-less PRs, and the
+    // pre-existing engage ack suppresses the dedup), so a single 5xx must
+    // not drop the window reset AND the seed. The fallback stays loud
+    // (there is no heal path to warn-and-lean on): a double failure aborts
+    // before the 're-armed' claim and the stale-escalation cleanup.
+    const transientRearmFailure = runToggle({
+      cmd: 'add',
+      labels: ['autofix/takeover'],
+      cmdFrom: '7',
+      commentFails: 'HTTP 502',
+    });
+    expect(transientRearmFailure.done).toBe(true);
+    expect(
+      transientRearmFailure.writes.match(/^COMMENT-ATTEMPT$/gm) ?? [],
+    ).toHaveLength(2);
+    expect(transientRearmFailure.writes).toContain(
+      '<!-- takeover-ack engaged -->\n<!-- autofix-round-start 7 -->',
+    );
+    expect(transientRearmFailure.log).toContain('re-armed');
+    expect(transientRearmFailure.log).not.toContain('::error::');
     // The release DELETE tolerates the 404 race (a concurrent removal
     // already reached the end state): the release ack still posts, no
     // warning.
@@ -5506,6 +5528,13 @@ exit 1
     // the bare command rather than being rejected, so a maintainer who types
     // it gets management, not silence.
     expect(seedOf('@qwen-code /takeover from 0')).toBe('add|0');
+    // Zero-padded spellings canonicalize to decimal at capture: the seed
+    // reaches bare-context bash arithmetic downstream, where a leading zero
+    // means octal — '08'/'09' error outright and silently drop the seed
+    // note — and '00' lands on the explicit no-seed spelling '0'.
+    expect(seedOf('@qwen-code /takeover from 08')).toBe('add|8');
+    expect(seedOf('@qwen-code /takeover from 01')).toBe('add|1');
+    expect(seedOf('@qwen-code /takeover from 00')).toBe('add|0');
     // The unparameterized forms are untouched.
     expect(seedOf('@qwen-code /takeover')).toBe('add|');
     expect(seedOf('@qwen-code /takeover stop')).toBe('remove|');
@@ -5528,6 +5557,17 @@ exit 1
     ]) {
       expect(seedOf(body)).toBe('|');
     }
+    // The captured value crosses two job-boundary wires no behavioral
+    // harness exercises — every replay injects CMD_FROM directly, starting
+    // inside a single job — so pin them verbatim like the suite's other
+    // wires: a deleted or typo'd wire would silently degrade 'from N' to a
+    // bare '/takeover' with the whole suite still green.
+    expect(workflow).toContain(
+      "takeover_from: '${{ steps.decide.outputs.takeover_from }}'",
+    );
+    expect(workflow).toContain(
+      "CMD_FROM: '${{ needs.route.outputs.takeover_from }}'",
+    );
   });
 
   it('gates real-time review triggers on bot author, trusted sender, and in-repo PR', () => {
@@ -8030,6 +8070,16 @@ exit 1
     expect(clampedSeed[0]).not.toContain('from 9');
     expect(clampedSeed[1]).toContain('从第 12 轮起算');
     expect(clampedSeed[1]).toContain('收敛为 9');
+    // The seed crosses two more job-boundary wires no behavioral harness
+    // exercises — the cause replay above injects LIVE_ROUND_START and the
+    // digest replay injects ROUND_START, both starting inside a single job
+    // — so pin them verbatim like the suite's other wires.
+    expect(workflow).toContain(
+      'echo "round_start=${LIVE_ROUND_START}" >> "${GITHUB_OUTPUT}"',
+    );
+    expect(workflow).toContain(
+      "ROUND_START: '${{ steps.prepare.outputs.round_start }}'",
+    );
 
     // The batch-budget sentence must describe the policy actually in force:
     // the OVER_BUDGET census only builds spans in round-brake territory, so

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3772,6 +3772,8 @@ describe('qwen-autofix workflow', () => {
       author = 'fork-owner',
       postFails = '',
       deleteFails = '',
+      cmdFrom = '',
+      commentFails = '',
     }) => {
       const dir = mkdtempSync(join(tmpdir(), 'autofix-toggle-'));
       try {
@@ -3797,7 +3799,7 @@ describe('qwen-autofix workflow', () => {
             // universally exiting 0.
             `elif [[ "$1" == "label" && "$2" == "create" ]]; then echo "LABEL-CREATE $*" >> '${join(dir, 'writes.log')}';`,
             `elif [[ "$1" == "api" ]]; then echo "API $*" >> '${join(dir, 'writes.log')}'; if [[ "$2" == "-X" && "$3" == "POST" && -n "\${TOGGLE_POST_FAILS:-}" ]]; then printf '%s' "\${TOGGLE_POST_FAILS}" >&2; exit 1; fi; if [[ "$2" == "-X" && "$3" == "DELETE" && -n "\${TOGGLE_DELETE_FAILS:-}" ]]; then printf '%s' "\${TOGGLE_DELETE_FAILS}" >&2; exit 1; fi; if [[ "$2" == "-X" && "$3" == "DELETE" ]]; then printf '%s' '[{"name":"Tracks HTTP 5xx flakes"}]'; fi`,
-            `elif [[ "$1" == "pr" && "$2" == "comment" ]]; then echo "COMMENT $*" >> '${join(dir, 'writes.log')}';`,
+            `elif [[ "$1" == "pr" && "$2" == "comment" ]]; then echo "COMMENT-ATTEMPT" >> '${join(dir, 'writes.log')}'; if [[ -n "\${TOGGLE_COMMENT_FAILS:-}" && ! -f '${join(dir, 'comment-failed')}' ]]; then touch '${join(dir, 'comment-failed')}'; printf '%s' "\${TOGGLE_COMMENT_FAILS}" >&2; exit 1; fi; echo "COMMENT $*" >> '${join(dir, 'writes.log')}';`,
             'fi',
           ].join('\n'),
         );
@@ -3813,7 +3815,7 @@ describe('qwen-autofix workflow', () => {
             '-eo',
             'pipefail',
             '-c',
-            `${toggle.replace(/\n {10}/g, '\n')}\nprintf 'DONE'`,
+            `sleep() { :; }\n${toggle.replace(/\n {10}/g, '\n')}\nprintf 'DONE'`,
           ],
           {
             env: {
@@ -3830,6 +3832,9 @@ describe('qwen-autofix workflow', () => {
               GITHUB_TOKEN: 'x',
               TOGGLE_POST_FAILS: postFails,
               TOGGLE_DELETE_FAILS: deleteFails,
+              TOGGLE_COMMENT_FAILS: commentFails,
+              CMD_FROM: cmdFrom,
+              CRITICAL_ONLY_AFTER_ROUND: '5',
             },
             encoding: 'utf8',
           },
@@ -3893,6 +3898,58 @@ describe('qwen-autofix workflow', () => {
     );
     expect(rearm.writes.match(/^API /gm) ?? []).toHaveLength(1);
     expect(rearm.log).toContain('re-armed');
+    // The seed marker's WRITE side: a valid 'from N' appends the marker on
+    // its own line after the untouched engage literal on BOTH ack paths, so
+    // the seed reads see exactly what the parser captured.
+    const seededEngage = runToggle({ cmd: 'add', cmdFrom: '3' });
+    expect(seededEngage.writes).toContain(
+      '<!-- takeover-ack engaged -->\n<!-- autofix-round-start 3 -->',
+    );
+    // Engage wording stays before-takeover (there it is true), and the
+    // remainder arithmetic reads the harness's CRITICAL_ONLY_AFTER_ROUND=5.
+    expect(seededEngage.writes).toContain(
+      'the rounds this PR spent in review before takeover',
+    );
+    expect(seededEngage.writes).toContain(
+      'engages after 2 more change-producing round(s) instead of a full fresh 5',
+    );
+    // A seeded RE-ARM must not contradict itself: the earlier rounds DO
+    // count toward the cap (they are the seed), so the unseeded "previous
+    // rounds no longer count" clause cannot ship next to the seed note, and
+    // the note names rounds already spent on the PR, not pre-takeover
+    // review (from 60 leaves zero remainder before the brake).
+    const seededRearm = runToggle({
+      cmd: 'add',
+      labels: ['autofix/takeover'],
+      cmdFrom: '60',
+    });
+    expect(seededRearm.writes).toContain(
+      '<!-- takeover-ack engaged -->\n<!-- autofix-round-start 60 -->',
+    );
+    expect(seededRearm.writes).toContain(
+      'earlier rounds count toward the cap only via this seed',
+    );
+    expect(seededRearm.writes).not.toContain(
+      'previous rounds no longer count toward the cap',
+    );
+    expect(seededRearm.writes).toContain('rounds already spent on this PR');
+    expect(seededRearm.writes).not.toContain(
+      'the rounds this PR spent in review before takeover',
+    );
+    expect(seededRearm.writes).toContain(
+      'engages after 0 more change-producing round(s) instead of a full fresh 5',
+    );
+    // The unseeded re-arm keeps the original fresh-window clause…
+    expect(rearm.writes).toContain(
+      'previous rounds no longer count toward the cap',
+    );
+    // …and no path emits a marker for the guard values: the explicit
+    // no-seed spelling '0', empty, or a non-number.
+    for (const from of ['', '0', 'abc']) {
+      expect(runToggle({ cmd: 'add', cmdFrom: from }).writes).not.toContain(
+        'autofix-round-start',
+      );
+    }
     // remove + present → label removed, through the URI-encoded path segment
     // (real jq runs in the substitution, so the %2F is the executed truth).
     const removePresent = runToggle({
@@ -4020,6 +4077,23 @@ describe('qwen-autofix workflow', () => {
     }
     expect(engageFailure).toBeTruthy();
     expect(engageFailure.writes).not.toContain('takeover-ack engaged');
+    // A TRANSIENT engage-ack failure retries once before the heal-path
+    // warning: the seed marker's only copy lives in the failed body, and
+    // the heal ack has no slot to recover it — the retry is the only thing
+    // that keeps a 'from N' seed alive across a 5xx.
+    const transientAckFailure = runToggle({
+      cmd: 'add',
+      cmdFrom: '12',
+      commentFails: 'HTTP 502',
+    });
+    expect(transientAckFailure.done).toBe(true);
+    expect(
+      transientAckFailure.writes.match(/^COMMENT-ATTEMPT$/gm) ?? [],
+    ).toHaveLength(2);
+    expect(transientAckFailure.writes).toContain(
+      '<!-- takeover-ack engaged -->\n<!-- autofix-round-start 12 -->',
+    );
+    expect(transientAckFailure.log).not.toContain('::warning::');
     // The release DELETE tolerates the 404 race (a concurrent removal
     // already reached the end state): the release ack still posts, no
     // warning.
@@ -4226,7 +4300,18 @@ describe('qwen-autofix workflow', () => {
             '-c',
             `set -uo pipefail\nWORKDIR='${dir}'\n${trio.replace(/\n {12}/g, '\n')}\nprintf '\\n%s' "$ROUND"`,
           ],
-          { env: { ...process.env, AUTOFIX_BOT: BOT }, encoding: 'utf8' },
+          {
+            // EFF_MAX_ROUNDS is SET so both clamp branches execute in the
+            // fixtures below; PR is the clamp echo's only other expansion
+            // under set -u.
+            env: {
+              ...process.env,
+              AUTOFIX_BOT: BOT,
+              EFF_MAX_ROUNDS: '10',
+              PR: '1',
+            },
+            encoding: 'utf8',
+          },
         )
           .split('\n')
           .at(-1);
@@ -4250,6 +4335,18 @@ describe('qwen-autofix workflow', () => {
     // CRITICAL_ONLY_AFTER_ROUND=5 the brake is two managed rounds away
     // instead of five.
     expect(roundOf([ack(K1, 3)])).toBe('3');
+    // Last marker wins: a hand-written marker prepended by an edit loses to
+    // the workflow's own final-line marker (GitHub edits preserve user.login
+    // and created_at, so the edited ack still passes both filter halves).
+    expect(
+      roundOf([
+        {
+          user: { login: BOT },
+          created_at: K1,
+          body: 'edited <!-- autofix-round-start 99 -->\n<!-- takeover-ack engaged -->\n<!-- autofix-round-start 3 -->',
+        },
+      ]),
+    ).toBe('3');
     // Real markers outrank the seed as soon as one exists — the seed is a
     // FLOOR for an empty window, not an offset added to every round.
     expect(
@@ -4297,6 +4394,14 @@ describe('qwen-autofix workflow', () => {
     // Shape gate: the marker reader takes 1-2 digits, so a longer number is
     // not silently truncated to its first two digits.
     expect(roundOf([ack(K1, 100)])).toBe('0');
+    // Read-site clamp (cap 10 from the harness env): a seed at or past the
+    // cap lands strictly below it…
+    expect(roundOf([ack(K1, 15)])).toBe('9');
+    // …and a seed just under the cap passes through unclamped. Same value
+    // out, different path — together they pin both clamp branches against
+    // deletion and against a -ge→-le flip (which would clamp every seeded
+    // window to cap−1).
+    expect(roundOf([ack(K1, 9)])).toBe('9');
     // The ack literal the other seven read sites match must survive verbatim
     // next to the seed marker.
     expect(ack(K1, 3).body).toContain('<!-- takeover-ack engaged -->');
@@ -7906,6 +8011,25 @@ exit 1
     expect(seeded[0]).not.toBe('5 change-producing rounds are complete');
     expect(seeded[1]).toContain('从第 3 轮起算');
     expect(seeded[1]).toContain('又完成 2 个产生改动的轮次');
+    // A seed that hit the read-site clamp must still cite the number as
+    // TYPED: quoting the post-clamp value renders a command nobody sent
+    // while the engage ack above still shows the original (from 12,
+    // clamped to 9 under cap 10 — the label-removal path the clamp's own
+    // comment names).
+    const clampedSeed = causeFor(
+      'true',
+      'false',
+      0,
+      0,
+      'LIVE_ROUND_START_RAW=12\nLIVE_ROUND_START=9\nROUND=14\nMAX_ROUNDS=10',
+    );
+    expect(clampedSeed[0]).toContain('seeded at round 12');
+    expect(clampedSeed[0]).toContain('@qwen-code /takeover from 12');
+    expect(clampedSeed[0]).toContain('clamped to 9 under the effective cap 10');
+    expect(clampedSeed[0]).toContain('plus 5 change-producing round(s) since');
+    expect(clampedSeed[0]).not.toContain('from 9');
+    expect(clampedSeed[1]).toContain('从第 12 轮起算');
+    expect(clampedSeed[1]).toContain('收敛为 9');
 
     // The batch-budget sentence must describe the policy actually in force:
     // the OVER_BUDGET census only builds spans in round-brake territory, so
@@ -10199,6 +10323,7 @@ exit 1
         outcome = 'fixed',
         maxRounds = '100',
         commentExit = 0,
+        roundStart = '',
       } = {},
     ) => {
       const dir = mkdtempSync(join(tmpdir(), 'milestone-'));
@@ -10233,6 +10358,7 @@ exit 1
               PR: '1',
               TAKEOVER_LABEL: 'autofix/takeover',
               TAKEOVER_COMMAND: '@qwen-code /takeover',
+              ROUND_START: roundStart,
             },
             encoding: 'utf8',
           },
@@ -10320,6 +10446,29 @@ exit 1
       { nextRound: 11 },
     );
     expect(freshWindow.body).toContain('round 11/100');
+    // Seeded windows count rounds IN THE WINDOW: the window opens at the
+    // seed, so "10+ accumulated" is measured from the seed — a takeover
+    // 'from 60' must not digest on its first managed rounds just because
+    // the absolute counter already reads 61+…
+    expect(
+      runDigest([evalC(HEADS.noop, K, '2026-07-02T00:00:00Z')], {
+        nextRound: 61,
+        roundStart: '60',
+      }).body,
+    ).toBe('');
+    expect(
+      runDigest([evalC(HEADS.noop, K, '2026-07-02T00:00:00Z')], {
+        nextRound: 10,
+        roundStart: '8',
+      }).body,
+    ).toBe('');
+    // …and once 10 managed rounds HAVE accumulated past the seed, it posts.
+    expect(
+      runDigest([evalC(HEADS.push, K, '2026-07-02T00:00:00Z')], {
+        nextRound: 70,
+        roundStart: '60',
+      }).body,
+    ).toContain('round 70/100');
 
     // WINDOW=none says what it counts instead of claiming a window.
     const noWindow = runDigest(
@@ -14475,7 +14624,7 @@ exit 1
       created_at: at,
       body: `<!-- autofix-eval ts=${ts} acted=false round=${round} win=none -->`,
     });
-    const run = (comments) => {
+    const run = (comments, { maxRounds } = {}) => {
       const dir = mkdtempSync(join(tmpdir(), 'rearm-live-'));
       writeFileSync(join(dir, 'ic.json'), JSON.stringify(comments));
       const out = execFileSync(
@@ -14485,7 +14634,12 @@ exit 1
           `set -uo pipefail\n${block}\nprintf '%s|%s|%s' "$LIVE_EVAL_WM" "$LIVE_REARM_KEY" "$LIVE_MAX_ROUND"`,
         ],
         {
-          env: { ...process.env, WORKDIR: dir, AUTOFIX_BOT: BOT },
+          env: {
+            ...process.env,
+            WORKDIR: dir,
+            AUTOFIX_BOT: BOT,
+            ...(maxRounds === undefined ? {} : { MAX_ROUNDS: maxRounds }),
+          },
           encoding: 'utf8',
         },
       );
@@ -14534,6 +14688,20 @@ exit 1
       },
     ]);
     expect(wmSpoof).toBe('2026-07-20T08:30:00Z');
+
+    // Seeded windows compare too: the LIVE copy honors a marker on the
+    // window anchor and clamps a seed at/past the cap exactly like the
+    // scan-side twin (cap 10: 15 clamps to 9; 9 passes through), so the two
+    // copies cannot drift on a seeded window.
+    const seededAck = (at, seed) => ({
+      user: { login: BOT },
+      created_at: at,
+      body: `🤝 … <!-- takeover-ack engaged -->\n<!-- autofix-round-start ${seed} -->`,
+    });
+    const SEEDED_AT = '2026-07-20T12:00:00Z';
+    expect(run([seededAck(SEEDED_AT, 3)], { maxRounds: '10' })[2]).toBe('3');
+    expect(run([seededAck(SEEDED_AT, 15)], { maxRounds: '10' })[2]).toBe('9');
+    expect(run([seededAck(SEEDED_AT, 9)], { maxRounds: '10' })[2]).toBe('9');
   });
 
   it('routes @qwen-code /retry through the takeover command authorization', () => {


### PR DESCRIPTION
## What this PR does

Adds one parameterized takeover command, `@qwen-code /takeover from N`, which engages the loop on a PR and seeds that counting window's round counter at N instead of 0. `CRITICAL_ONLY_AFTER_ROUND` is then reached in the remainder — a PR taken over at `from 3` gets two more suggestion-capable rounds and enters Critical-only on the third, rather than five fresh ones. The bare `@qwen-code /takeover`, `@qwen-code /takeover stop`, and every unparameterized path behave exactly as before.

The seed rides as its own `<!-- autofix-round-start N -->` marker on a separate line of the engage ack, never as a field inside `<!-- takeover-ack engaged -->`. That literal is matched with jq `contains()` — closing `-->` included — at seven read sites: four in this workflow (the ack dedup, the scan's first-pickup dedup, and the two `REARM_KEY` window readers) and three in `qwen-fleet-shepherd.yml` (the paused/resume detector). An inline field would silently break all seven: the window key would fall back to an older engage ack, so the round counter would read a dead window, and the shepherd would stop seeing the engage as a resume signal and age out a PR that was just re-armed. This is the same sibling-marker shape, for the same reason, as the existing `autofix-redcheck` marker.

Both round readers (scan and prepare) now fall back to the seed rather than a hardcoded `0`. The seed is read by `created_at` equality against the window key, so it is window-scoped for free — a superseded window's seed cannot leak into the live one, and `@qwen-code /retry` or a bare re-takeover opens a window with no marker and returns the counter to 0. It is clamped strictly below the effective cap so a seed can never park a PR at its round cap on the very round it is taken over, which would stop the loop instead of starting it.

Both engage acks and the Critical-only audit record name the seed when there is one. Without that, the ack reports "round 4/100" on its first managed round and reads like a bug, and the audit record claims "5 change-producing rounds are complete" on a PR the loop has run twice — true of the counter, visibly false of the PR. `SKILL.md` tells the agent the same thing, so it does not read a second-round Critical-only engagement as a misfire.

The growth brake is deliberately **not** seeded: its baseline anchors at the window's first measured round, and a pre-takeover baseline is not recoverable, so diff growth stays measured from engagement. This is stated in the env comment so it is not later filed as a bug.

## Why it's needed

The round counter is window-scoped, and engaging takeover opens a fresh window. That is correct for re-arming, but it means taking over a PR that has *already* been through several rounds of ordinary review restarts the Critical-only brake from zero. A PR that spent nine human rounds getting to "almost mergeable" then got five more suggestion-capable rounds the moment it was managed — the loop grew the diff on nice-to-haves at exactly the point it should have been converging on Criticals and letting the rest ride to follow-up.

Re-issuing takeover on an already-managed PR made this worse rather than better: it is the documented round-counter reset, so a PR that had just reached the brake had the suggestion valve reopened at full travel.

`from N` lets the maintainer state what the loop cannot infer — how much review this PR has already absorbed — and the existing brake does the rest. No second threshold, no parallel mode flag.

## Reviewer Test Plan

### How to verify

Run the workflow test file:

```
npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow
```

`176 passed (176)`. Two tests are new and both replay real workflow fragments extracted verbatim (drift fails the test), so they are behavioral rather than string assertions:

- `behaviorally parses the takeover round seed and keeps every other body closed` — replays the route step's `issue_comment` branch with a PATH-stubbed `gh`. Confirms `from 3` / `from 12` / `from 99` engage with the seed, surrounding whitespace is trimmed, `from 0` engages as the explicit no-seed spelling, and twelve fail-closed bodies produce nothing: `stop from 3` (neither releases nor engages), `from 100`, `from 3x`, `from -1`, `from`, a double space, `takeoverfrom 3`, a prefixed body, a suffixed body, `; rm -rf /`, `$(id)`, and a backtick payload.
- `behaviorally seeds the round counter from the window anchor and only from it` — replays the scan's real `MARKERS`/`REARM_KEY`/`ROUND` trio. Confirms an empty seeded window reports round 3; a real eval marker outranks the seed as soon as one exists (the seed is a floor, not an offset added to every round); a superseded window's seed cannot leak forward; a bare re-arm drops it to 0; unseeded acks behave exactly as before; and the seed is rejected both from a non-bot comment posted **at the window key** and from a bot comment that is not the anchor.

Mutation-tested — four single-edit mutations, each applied to the workflow and reverted:

| Mutation | Result |
| --- | --- |
| seed read drops the window-key scoping | caught (`expected '7' to be '0'`) |
| seed read drops the bot-author trust filter | caught (`expected '99' to be '0'`) |
| `max // $start` reverted to `max // 0` at both readers | caught (`expected '0' to be '3'`) |
| exact-prefix check loosened from equality to substring | caught (`expected 'add\|3' to be '\|'`) |

The author-filter mutation **survived on the first attempt**: the impostor comment in that test was dated away from the window key, so the case exercised the key check twice and the author check not at all. The test now dates it *at* the window key — GitHub stamps `created_at` to the second, so a comment landing in the same second as the engage ack is a real collision and the author filter is the only thing that rejects it — and the mutation is caught.

Also verified: `node scripts/lint.js --actionlint` exits 0, `npm run check-i18n` passes, `npx eslint scripts/tests/qwen-autofix-workflow.test.js` exits 0, and `qwen-fleet-shepherd` workflow tests stay at 17/17 (that file is untouched, but it holds three of the seven `takeover-ack engaged` read sites).

### Evidence (Before & After)

Not user-visible in the TUI, but the bot's PR comment is the user-facing surface, so the ack text was rendered by executing the actual `FROM_MARKER`/`FROM_NOTE` block extracted from the workflow.

**Before** (unchanged for every unparameterized path — `CMD_FROM` empty or `0`):

```
🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `autofix/takeover` label (or comment `@qwen-code /takeover stop`) to release.

<!-- takeover-ack engaged -->
```

**After** (`@qwen-code /takeover from 3`):

```
🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. This window's round counter starts at 3 (the rounds this PR spent in review before takeover), so the Critical-only brake engages after 2 more change-producing round(s) instead of a full fresh 5. Remove the `autofix/takeover` label (or comment `@qwen-code /takeover stop`) to release.

<!-- takeover-ack engaged -->
<!-- autofix-round-start 3 -->
```

The `<!-- takeover-ack engaged -->` line is byte-identical in both, on its own line, with the seed marker below it — which is the property the other seven read sites depend on. `from 7` (past the threshold) renders "after 0 more change-producing round(s)", i.e. Critical-only engages on the first managed round, which is accurate.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Workflow tests only (`vitest run --config ./scripts/tests/vitest.config.ts`), plus `actionlint` and `prettier`/`eslint` locally on macOS. No runtime or sandbox involved.

## Risk & Scope

- **Main risk or tradeoff:** this reopens a parsing surface the route step had deliberately closed ("constants, never user-input parsing"). It is kept as narrow as the constraint allows — the literal prefix is still compared for byte equality, the tail is a bounded 1-2 digit integer, the value is re-validated through the existing `sanitize_number` on the way out of the job, and it reaches nothing but an integer comparison and a `printf '%s'` of a re-validated number. The twelve fail-closed cases in the new test are the guard against drift here.
- **Not validated / out of scope:** no end-to-end run against a live PR — the verification is workflow-fragment replay plus mutation testing, not a real takeover cycle. The `run-agent idle watchdog` tests in this file are flaky on this machine independent of the change (interleaved A/B: 3/12 failures on this branch vs 5/12 on a clean tree), so they are not a signal either way here. Routing suggestions to follow-up issues — the natural companion to this brake — is **not** in this PR; the deferred Critical-only feedback still goes only to the round report, not to the per-PR tracking issue.
- **Breaking changes / migration notes:** none. Every existing command body, marker, and read site is unchanged; a window with no `autofix-round-start` marker behaves exactly as it does today, so nothing in flight is affected by the deploy.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增一个带参数的托管命令 `@qwen-code /takeover from N`：接管 PR 的同时，把本计数窗口的轮次计数从 N 起算，而不是从 0。这样 `CRITICAL_ONLY_AFTER_ROUND` 是在**剩余轮次**内达到的 —— 以 `from 3` 接管的 PR 再经过 2 个可含 suggestion 的轮次，第 3 轮即进入 Critical-only，而不是重新计满 5 轮。裸的 `@qwen-code /takeover`、`@qwen-code /takeover stop` 以及所有无参数路径行为完全不变。

种子以独立的 `<!-- autofix-round-start N -->` 标记单独占一行写在 engage ack 中，**绝不**作为字段塞进 `<!-- takeover-ack engaged -->`。后者是用 jq `contains()` 按全字面量（含闭合 `-->`）匹配的，读取点共有七处：本 workflow 四处（ack 去重、扫描首次接管去重、两处 `REARM_KEY` 窗口读取），以及 `qwen-fleet-shepherd.yml` 三处（暂停/恢复探测）。内联字段会静默打断全部七处：窗口 key 会回落到更旧的 engage ack，导致轮次计数读到一个已失效的窗口；而且 shepherd 将不再把这次 engage 识别为恢复信号，会把一个刚刚重新武装的 PR 判为无人应答并 age out。这与现有 `autofix-redcheck` 标记是同一种 sibling marker 形态，理由也相同。

两处轮次读取（scan 与 prepare）现在回落到种子，而非硬编码的 `0`。种子按 `created_at` 与窗口 key 相等来读取，因此天然具有窗口作用域 —— 被取代的旧窗口的种子无法泄漏到当前窗口；`@qwen-code /retry` 或裸的重新接管会开启一个没有该标记的新窗口，计数回到 0。种子被 clamp 在有效上限之下，因此绝不可能出现"刚被接管的那一轮就把 PR 顶到轮次上限"——那会是停止循环而不是启动循环。

两处 engage ack 与 Critical-only 的审计记录在存在种子时都会点明。否则 ack 会在首个托管轮次显示 "round 4/100"，看起来像 bug；而审计记录会对一个循环只跑过两轮的 PR 声称"已完成 5 个产生改动的轮次"——对计数器为真，对 PR 显然为假。`SKILL.md` 同步告知 agent，使其不会把第二轮就触发的 Critical-only 误判为刹车失灵。

增长刹车**刻意不**种子化：它的基线锚定在窗口首个完成测量的轮次，而托管前的基线不可恢复，因此 diff 增长始终从接管时刻起算。这一点写进了 env 注释，以免日后被当作 bug 提报。

## 为什么需要

轮次计数是窗口作用域的，而接管会开启一个新窗口。这对"重新武装"是正确语义，但也意味着：接管一个**已经**经历过多轮常规评审的 PR，会把 Critical-only 刹车从零重启。一个花了九轮人工评审才走到"接近可合入"的 PR，在被托管的瞬间又获得五个可含 suggestion 的轮次 —— 循环恰恰在本该收敛于 Critical、把其余留给后续跟进的时点，把 diff growth 花在了锦上添花的改动上。

对已托管的 PR 重新下达接管命令只会让情况更糟：那是有文档记载的轮次计数重置，于是一个刚刚触及刹车的 PR，suggestion 阀门被重新开到最大。

`from N` 让维护者说出循环无法推断的信息 —— 这个 PR 已经吸收了多少轮评审 —— 剩下的交给现有刹车。不引入第二个阈值，也不引入并行的模式开关。

## 评审者测试计划

### 如何验证

运行 workflow 测试文件：

```
npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow
```

`176 passed (176)`。其中两个测试为新增，且都逐字提取真实 workflow 片段回放（片段漂移会导致测试失败），因此是行为测试而非字符串断言：

- `behaviorally parses the takeover round seed and keeps every other body closed` —— 用 PATH 打桩的 `gh` 回放 route 步骤的 `issue_comment` 分支。验证 `from 3` / `from 12` / `from 99` 带种子接管、首尾空白被裁剪、`from 0` 作为显式无种子写法照常接管，以及十二种必须 fail-closed 的输入均无任何效果：`stop from 3`（既不释放也不接管）、`from 100`、`from 3x`、`from -1`、`from`、双空格、`takeoverfrom 3`、带前缀正文、带后缀正文、`; rm -rf /`、`$(id)`、反引号 payload。
- `behaviorally seeds the round counter from the window anchor and only from it` —— 回放扫描步骤真实的 `MARKERS`/`REARM_KEY`/`ROUND` 三元组。验证：空的带种子窗口报告第 3 轮；一旦出现真实 eval 标记即覆盖种子（种子是空窗口的下界，而不是叠加到每一轮上的偏移量）；被取代窗口的种子无法向前泄漏；裸的重新武装使其归零；无种子的 ack 行为与本特性存在前完全一致；以及种子会被拒绝——无论它来自**恰好落在窗口 key 上**的非 bot 评论，还是来自并非窗口锚点的 bot 评论。

已做变异测试 —— 四个单点变异，逐个施加到 workflow 后还原：

| 变异 | 结果 |
| --- | --- |
| 种子读取去掉窗口 key 作用域 | 被捕获（`expected '7' to be '0'`） |
| 种子读取去掉 bot 作者信任过滤 | 被捕获（`expected '99' to be '0'`） |
| 两处读取的 `max // $start` 还原为 `max // 0` | 被捕获（`expected '0' to be '3'`） |
| 精确前缀比较放宽为子串匹配 | 被捕获（`expected 'add\|3' to be '\|'`） |

作者过滤那个变异**第一次施加时存活了**：该测试中的伪造评论时间戳偏离了窗口 key，因此这个用例把 key 检查测了两遍、把作者检查一遍也没测到。现已把它改为**恰好落在**窗口 key 上 —— GitHub 的 `created_at` 精确到秒，因此一条与 engage ack 落在同一秒的评论是真实可能的碰撞，而作者过滤是唯一能拒绝它的东西 —— 之后该变异被捕获。

另外验证：`node scripts/lint.js --actionlint` 退出码 0，`npm run check-i18n` 通过，`npx eslint scripts/tests/qwen-autofix-workflow.test.js` 退出码 0，`qwen-fleet-shepherd` 的 workflow 测试保持 17/17（该文件未被改动，但它持有七个 `takeover-ack engaged` 读取点中的三个）。

### 证据（改动前后）

本改动在 TUI 中不可见，但 bot 的 PR 评论就是面向用户的界面，因此 ack 文案是通过执行从 workflow 中提取的真实 `FROM_MARKER`/`FROM_NOTE` 代码块渲染出来的。

**改动前**（所有无参数路径均保持不变 —— `CMD_FROM` 为空或为 `0`）：

```
🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. Remove the `autofix/takeover` label (or comment `@qwen-code /takeover stop`) to release.

<!-- takeover-ack engaged -->
```

**改动后**（`@qwen-code /takeover from 3`）：

```
🤝 Takeover engaged: the autofix loop now manages this PR — it will address new review feedback and resolve base conflicts until the label is removed or the round cap is reached. This window's round counter starts at 3 (the rounds this PR spent in review before takeover), so the Critical-only brake engages after 2 more change-producing round(s) instead of a full fresh 5. Remove the `autofix/takeover` label (or comment `@qwen-code /takeover stop`) to release.

<!-- takeover-ack engaged -->
<!-- autofix-round-start 3 -->
```

两者中 `<!-- takeover-ack engaged -->` 一行字节完全相同、独占一行，种子标记位于其下方 —— 这正是另外七个读取点所依赖的性质。`from 7`（超过阈值）会渲染为 "after 0 more change-producing round(s)"，即 Critical-only 在首个托管轮次即生效，描述是准确的。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅 workflow 测试（`vitest run --config ./scripts/tests/vitest.config.ts`），外加在 macOS 本机运行的 `actionlint` 与 `prettier`/`eslint`。不涉及运行时或沙箱。

## 风险与范围

- **主要风险或权衡：** 本改动重新打开了 route 步骤刻意关闭的一处解析面（"constants, never user-input parsing"）。开口已收窄到约束允许的最小程度 —— 字面量前缀仍做字节相等比较，尾部是有界的 1-2 位整数，该值在离开 job 时会再次经过既有的 `sanitize_number` 复验，且它只会流向一次整数比较和一个对已复验数字的 `printf '%s'`。新测试中的十二个 fail-closed 用例即是防止此处退化的护栏。
- **未验证 / 不在范围内：** 没有针对线上真实 PR 的端到端跑通 —— 验证手段是 workflow 片段回放加变异测试，而非一次真实的托管周期。本文件中的 `run-agent idle watchdog` 测试在本机与本改动无关地抖动（交替 A/B：本分支 3/12 失败，干净树 5/12 失败），因此它在这里不构成任何方向的信号。把 suggestion 路由到后续跟进 issue —— 这个刹车天然的搭档 —— **不在**本 PR 内；Critical-only 延后的反馈目前仍只进入轮次报告，不进入 per-PR 追踪 issue。
- **破坏性变更 / 迁移说明：** 无。所有既有的命令正文、标记与读取点均未改变；没有 `autofix-round-start` 标记的窗口行为与今天完全一致，因此部署不会影响任何在飞的流程。

## 关联 Issue

无。

</details>
