### PR TITLE
fix(web-shell): keep foreground agent status on SSE

### DIFF
--- a/packages/web-shell/client/adapters/toolClassification.test.ts
+++ b/packages/web-shell/client/adapters/toolClassification.test.ts
@@ -28,6 +28,16 @@ describe('isActiveToolStatus', () => {
 });
 
 describe('isBackgroundSubAgentToolCall', () => {
+  it('waits for agent args before inferring the default background mode', () => {
+    expect(
+      isBackgroundSubAgentToolCall({
+        callId: 'agent-1',
+        toolName: 'agent',
+        status: 'pending',
+      }),
+    ).toBe(false);
+  });
+
   it('treats an ordinary agent as background when the flag is omitted', () => {
     expect(isBackgroundSubAgentToolCall(agentTool())).toBe(true);
   });

--- a/packages/web-shell/client/adapters/toolClassification.ts
+++ b/packages/web-shell/client/adapters/toolClassification.ts
@@ -50,6 +50,7 @@ export function isBackgroundSubAgentToolCall(tool: ACPToolCall): boolean {
     name === 'agent' && tool.parentToolCallId === undefined;
   const defaultsToBackground =
     isTopLevelQwenAgent &&
+    args !== undefined &&
     args?.run_in_background === undefined &&
     args?.working_dir === undefined &&
     args?.name === undefined &&

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.subagent.test.ts
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.subagent.test.ts
@@ -100,4 +100,31 @@ describe('on-demand subagent transcript projection', () => {
       rawOutput: undefined,
     });
   });
+
+  it('preserves fields used to classify foreground agents', () => {
+    const [result] = projectMainTranscriptEventsForTesting([
+      {
+        type: 'tool.update',
+        toolCallId: 'agent-1',
+        toolName: 'agent',
+        status: 'in_progress',
+        rawInput: {
+          description: 'Review the change',
+          prompt: 'Review the change.',
+          subagent_type: 'general-purpose',
+          run_in_background: false,
+          working_dir: '.qwen/tmp/review-pr-1',
+          name: 'reviewer',
+        },
+      },
+    ]);
+
+    expect(result).toMatchObject({
+      rawInput: {
+        run_in_background: false,
+        working_dir: '.qwen/tmp/review-pr-1',
+        name: 'reviewer',
+      },
+    });
+  });
 });

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -344,6 +344,8 @@ function projectSubagentToolUpdate(
   const subagentType = boundedString(rawInput?.['subagent_type'], 120);
   const prompt = boundedString(rawInput?.['prompt'], 240);
   const description = boundedString(rawInput?.['description'], 240);
+  const workingDir = boundedString(rawInput?.['working_dir'], 240);
+  const agentName = boundedString(rawInput?.['name'], 120);
   const todoId =
     typeof rawInput?.['todo_id'] === 'string' ? rawInput['todo_id'] : undefined;
   const subagentName = boundedString(rawOutput?.['subagentName'], 120);
@@ -357,9 +359,11 @@ function projectSubagentToolUpdate(
         ...(prompt ? { prompt } : {}),
         ...(description ? { description } : {}),
         ...(todoId ? { todo_id: todoId } : {}),
-        ...(rawInput['run_in_background'] === true
-          ? { run_in_background: true }
+        ...(typeof rawInput['run_in_background'] === 'boolean'
+          ? { run_in_background: rawInput['run_in_background'] }
           : {}),
+        ...(workingDir ? { working_dir: workingDir } : {}),
+        ...(agentName ? { name: agentName } : {}),
       }
     : undefined;
   const projectedOutput = rawOutput


### PR DESCRIPTION
## What this PR does

Keeps the routing fields required to distinguish foreground and background agents in summarized SSE events. It also avoids treating an Agent event as background while its arguments are still unknown.

## Why it's needed

Foreground agents could be mistaken for background agents when the Web Shell received an initial argument-less pending event or a summarized event that omitted `run_in_background: false`, `working_dir`, and `name`. That started background reconciliation requests, and repeated registration-time 404 responses could mark newly started foreground agents as failed even though their SSE stream showed them running.

## Reviewer Test Plan

### How to verify

Start multiple foreground agents whose initial SSE event has no arguments and whose next update includes `run_in_background: false` and `working_dir`. Confirm they remain pending or running according to SSE, do not request the background-agent status endpoint, and do not briefly appear failed. Also confirm a normal top-level Agent with loaded arguments and no foreground markers still uses the default background behavior.

### Evidence (Before & After)

Before: eight newly started foreground agents were displayed as failed after background reconciliation received registration-time 404 responses.

After: both the argument-less pending event and the populated foreground update stay on the SSE-driven path; focused regression tests pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local Node.js workspace. Verified with focused WebUI and Web Shell tests, ESLint, the full build, and the full typecheck.

## Risk & Scope

- Main risk or tradeoff: an Agent event with arguments not yet available is treated as foreground until a later SSE update provides enough information to classify it.
- Not validated / out of scope: manual browser verification on Windows and Linux; background-agent reconciliation behavior itself is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

在精简后的 SSE 事件中保留区分前台与后台 Agent 所需的路由字段，并且在 Agent 参数尚未到达时不再将其推断为后台任务。

## 为什么需要

当 Web Shell 收到不含参数的首个 pending 事件，或者精简事件遗漏 `run_in_background: false`、`working_dir` 和 `name` 时，前台 Agent 会被误判为后台 Agent。这会启动后台状态补偿查询，而 Agent 注册阶段连续出现的 404 响应可能把刚启动的前台 Agent 标记为失败，即使 SSE 显示它们仍在运行。

## Reviewer 测试计划

### 验证方法

启动多个前台 Agent，使其首个 SSE 事件没有参数，后续更新包含 `run_in_background: false` 和 `working_dir`。确认它们按照 SSE 保持 pending 或 running，不请求后台 Agent 状态接口，也不会短暂显示失败。同时确认参数已经加载且没有前台标记的普通顶层 Agent 仍采用默认后台行为。

### 证据（修复前后）

修复前：八个刚启动的前台 Agent 在后台补偿查询收到注册阶段的 404 后被显示为失败。

修复后：无参数的 pending 事件和包含完整前台参数的后续更新都会保持在 SSE 驱动路径；针对性回归测试通过。

### 测试平台

|     系统    | 状态 |
| :---------: | :--: |
|  🍏 macOS   |  ✅  |
| 🪟 Windows  |  ⚠️  |
|  🐧 Linux   |  ⚠️  |

### 环境（可选）

本地 Node.js 工作区。已通过 WebUI 和 Web Shell 针对性测试、ESLint、全量构建和全量类型检查。

## 风险与范围

- 主要风险或取舍：参数尚未到达的 Agent 事件会暂时按前台处理，直到后续 SSE 更新提供足够的分类信息。
- 未验证或不在范围内：未在 Windows 和 Linux 上进行手动浏览器验证；后台 Agent 补偿查询本身的行为未修改。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
