### PR TITLE
fix(sdk-python): support large stream-json messages

### DIFF
--- a/packages/sdk-python/src/qwen_code_sdk/transport.py
+++ b/packages/sdk-python/src/qwen_code_sdk/transport.py
@@ -16,6 +16,8 @@ from .errors import ProcessExitError
 from .json_lines import parse_json_line
 from .types import QueryOptions
 
+_PROCESS_STREAM_LIMIT = 4 * 1024 * 1024
+
 
 @dataclass(frozen=True)
 class SpawnInfo:
@@ -83,6 +85,7 @@ class ProcessTransport:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=stderr_target,
+            limit=_PROCESS_STREAM_LIMIT,
         )
 
         if self._options.debug or self._options.stderr is not None:

--- a/packages/sdk-python/tests/unit/test_transport.py
+++ b/packages/sdk-python/tests/unit/test_transport.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+
 from qwen_code_sdk.transport import build_cli_arguments, prepare_spawn_info
 from qwen_code_sdk.types import QueryOptions, TimeoutOptions
 
@@ -145,6 +146,56 @@ def test_prepare_spawn_info_uses_node_for_javascript_files(tmp_path: Path) -> No
 
     assert spawn_info.command == "node"
     assert spawn_info.args == [str(script_path.resolve())]
+
+
+@pytest.mark.asyncio
+async def test_transport_reads_stream_json_lines_larger_than_64_kib(
+    tmp_path: Path,
+) -> None:
+    script_path = tmp_path / "large-stream-json.py"
+    script_path.write_text(
+        "import json\n"
+        "message = {\n"
+        '    "type": "user",\n'
+        f'    "uuid": "{VALID_UUID}",\n'
+        '    "session_id": "223e4567-e89b-12d3-a456-426614174000",\n'
+        '    "parent_tool_use_id": None,\n'
+        '    "message": {\n'
+        '        "role": "user",\n'
+        '        "content": [{\n'
+        '            "type": "tool_result",\n'
+        '            "tool_use_id": "test-tool-call",\n'
+        '            "content": "x" * (128 * 1024),\n'
+        '            "is_error": False,\n'
+        "        }],\n"
+        "    },\n"
+        "}\n"
+        "print(json.dumps(message))\n",
+        encoding="utf-8",
+    )
+
+    transport_module = __import__(
+        "qwen_code_sdk.transport",
+        fromlist=["ProcessTransport"],
+    )
+    transport = transport_module.ProcessTransport(
+        QueryOptions(
+            path_to_qwen_executable=str(script_path),
+            timeout=TimeoutOptions(),
+        )
+    )
+
+    await transport.start()
+    try:
+        messages = [message async for message in transport.read_messages()]
+    finally:
+        await transport.close()
+
+    assert len(messages) == 1
+    assert messages[0]["type"] == "user"
+    tool_result = messages[0]["message"]["content"][0]
+    assert tool_result["type"] == "tool_result"
+    assert tool_result["content"] == "x" * (128 * 1024)
 
 
 def test_prepare_spawn_info_keeps_plain_command_names() -> None:


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Raises the Python SDK subprocess stream reader limit from asyncio's 64 KiB default to 4 MiB and adds a regression test using a valid single-line stream-json tool result larger than 64 KiB. The limit applies to both stdout and stderr readers.

## Why it's needed

Large tool results can produce stream-json messages longer than asyncio's default reader limit. Reading such a message with `readline()` raises a `ValueError` and terminates the SDK query instead of returning the completed result.

## Reviewer Test Plan

<!--
How a reviewer can confirm this PR: reproduction steps, expected vs observed behavior, and evidence. CI runs on macOS, Windows, and Linux — Tested on is what you verified locally.

User-visible / TUI: Before/After with tmux-real-user-testing skill, screenshots, or a short recording.
Non–user-visible (refactor, types, docs): commands and output below; write N/A under Before/After.
-->

### How to verify

Run the Python SDK transport unit tests. The regression test starts a real subprocess that writes a valid stream-json message containing a 128 KiB tool result on a single line. Confirm that the complete message is read and parsed without raising a stream limit error.


### Evidence (Before & After)

Before: Python SDK queries terminated with a `ValueError` when the CLI emitted a single-line stream-json message larger than asyncio's default 64 KiB limit.

After: the same messages are read successfully with a 4 MiB stream limit, allowing large tool results to be delivered without terminating the query.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Python 3.13.3 and pytest 9.1.1 on Windows.

## Risk & Scope

- Main risk or tradeoff: Individual stream lines remain bounded at 4 MiB, while the larger limit does not pre-allocate that amount of memory.
- Not validated / out of scope: Stream lines larger than 4 MiB and local verification on macOS or Linux.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #9298


<details>
<summary>中文说明</summary>

## 本 PR 的改动

将 Python SDK 子进程流读取器的限制从 asyncio 默认的 64 KiB 提高到 4 MiB，并新增一个回归测试，使用超过 64 KiB 的合法单行 stream-json 工具结果进行验证。该限制同时应用于 stdout 和 stderr 读取器。

## 为什么需要此改动

较大的工具结果可能生成超过 asyncio 默认读取限制的 stream-json 消息。通过 `readline()` 读取这类消息时会抛出 `ValueError`，导致 SDK 查询直接终止，而不是正常返回完整结果。

## Reviewer 测试计划

### 验证方式

运行 Python SDK 的 transport 单元测试。回归测试会启动一个真实子进程，由该进程输出一条合法的 stream-json 消息，其中包含一个 128 KiB 的单行工具结果。确认消息能够被完整读取和解析，且不会抛出流读取限制错误。

### 修复前后证据

修复前：当 CLI 输出超过 asyncio 默认 64 KiB 限制的单行 stream-json 消息时，Python SDK 查询会因 `ValueError` 异常终止。

修复后：在 4 MiB 的流读取限制下，同类消息能够被正常读取，较大的工具结果不会再导致查询异常终止。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ✅ 已测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 测试环境（可选）

Windows，Python 3.13.3，pytest 9.1.1。

## 风险与范围

- 主要风险或权衡：单行流消息仍限制为不超过 4 MiB，但提高限制不会预先分配对应大小的内存。
- 未验证或不在本次范围内：超过 4 MiB 的单行消息，以及 macOS 和 Linux 上的本地验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #9298

</details>
