### PR TITLE
docs: add ClawMetry to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you know Claude Code, you already know Qwen Code — and then some. We've put
 - [**Qwen Code Desktop**](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — Official desktop app for macOS, Windows, and Linux
 - [**AionUi**](https://github.com/iOfficeAI/AionUi) — A modern GUI for command-line AI tools including Qwen Code
 - [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop) — A cross-platform desktop/web/mobile UI for Qwen Code
-- [**ClawMetry**](https://github.com/vivekchand/clawmetry) — Open-source, zero-config observability dashboard that tracks Qwen Code sessions, tokens, and costs locally
+- [**ClawMetry**](https://github.com/vivekchand/clawmetry) ([website](https://clawmetry.com)) — Open-source, zero-config observability dashboard that tracks Qwen Code sessions, tokens, and costs locally
 
 - [**🦞 Qwen Code Claw**](https://github.com/openclaw/acpx) — Let other agents (Claude, Codex, etc.) delegate coding tasks to Qwen Code via ACP. Paste this prompt into your agent:
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ If you know Claude Code, you already know Qwen Code — and then some. We've put
 - [**Qwen Code Desktop**](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — Official desktop app for macOS, Windows, and Linux
 - [**AionUi**](https://github.com/iOfficeAI/AionUi) — A modern GUI for command-line AI tools including Qwen Code
 - [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop) — A cross-platform desktop/web/mobile UI for Qwen Code
+- [**ClawMetry**](https://github.com/vivekchand/clawmetry) — Open-source, zero-config observability dashboard that tracks Qwen Code sessions, tokens, and costs locally
 
 - [**🦞 Qwen Code Claw**](https://github.com/openclaw/acpx) — Let other agents (Claude, Codex, etc.) delegate coding tasks to Qwen Code via ACP. Paste this prompt into your agent:
 


### PR DESCRIPTION
## What this PR does

Adds one line to the README `## Ecosystem` section for ClawMetry, an open-source, zero-config dashboard that reads the Qwen Code chat JSONL under `~/.qwen/projects/<project>/chats/` and shows sessions, tokens, and costs in a local web UI. README only; no code changes.

**Disclosure:** I'm the maintainer of ClawMetry.

**Beta caveat:** ClawMetry's own compatibility table lists the Qwen Code integration as a Beta adapter (transcripts, model, tool calls, token usage), so the listing decision can be made with that in view.

## Why it's needed

Qwen Code users currently have no listed way to see what their sessions did and what they cost without wiring up a tracing stack. The Ecosystem section already lists third-party tools built around Qwen Code; this adds the local observability case. Proposed in #9294, where triage verified the integration claim against `chatRecordingService` and marked it ready-for-human.

## Reviewer Test Plan

### How to verify

Confirm the README diff renders correctly and matches the surrounding entry format. To verify the tool end to end: `pip install clawmetry && clawmetry`, open `http://localhost:8900` on a machine with Qwen Code history in `~/.qwen/projects`, and pick Qwen Code in the runtime switcher; sessions, tokens, and costs appear with no configuration.

### Evidence (Before & After)

Docs-only change. Dashboard with a Qwen Code session selected:

![ClawMetry showing a Qwen Code session](https://raw.githubusercontent.com/vivekchand/qwen-code/clawmetry-screenshots/.pr-assets/clawmetry-qwen-code-overview.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A (README-only change; dashboard verified locally on macOS with clawmetry 0.12.x)

## Risk & Scope

- Main risk or tradeoff: none beyond an external link in the README; the linked project is MIT licensed and actively maintained.
- Not validated / out of scope: no changes to Qwen Code code or docs beyond this line.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #9294

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 README 的 `## Ecosystem` 部分添加一行,介绍 ClawMetry:一个开源、零配置的本地仪表盘,它读取 `~/.qwen/projects/<project>/chats/` 下的 Qwen Code 会话 JSONL,在本地 Web 界面中展示会话、token 用量和成本。仅修改 README,不涉及任何代码。

**利益声明:** 我是 ClawMetry 的维护者。

**Beta 说明:** ClawMetry 自己的兼容性表格中将 Qwen Code 集成标注为 Beta 适配器(转写、模型、工具调用、token 用量),供评审时参考。

## 为什么需要

Qwen Code 用户目前没有列出的方式可以在不搭建追踪平台的情况下查看会话内容和成本。Ecosystem 部分已经列出了围绕 Qwen Code 构建的第三方工具;本条目补充了本地可观测性这一场景。已在 #9294 中提议,triage 已对照 `chatRecordingService` 验证了集成声明并标记为 ready-for-human。

## 评审验证方案

### 如何验证

确认 README diff 渲染正确且与周围条目格式一致。端到端验证:`pip install clawmetry && clawmetry`,在有 Qwen Code 历史记录(`~/.qwen/projects`)的机器上打开 `http://localhost:8900`,在运行时切换器中选择 Qwen Code,无需配置即可看到会话、token 和成本。

### 证据

纯文档变更。上方英文部分附有选中 Qwen Code 会话的仪表盘截图。

### 测试平台

macOS 已验证;Windows/Linux 不适用(仅 README 变更)。

## 风险与范围

- 主要风险:仅为 README 中的一个外部链接;所链接项目为 MIT 许可且在积极维护。
- 未验证/超出范围:除此行外不涉及 Qwen Code 代码或文档的任何更改。
- 破坏性变更:无。

## 关联 Issue

Closes #9294

</details>

Website: https://clawmetry.com
