### PR TITLE
fix(channel-weixin): preserve 64-bit message IDs from getupdates

### DIFF
--- a/packages/channels/weixin/src/api.test.ts
+++ b/packages/channels/weixin/src/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { uploadToCdn } from './api.js';
+import { getUpdates, quoteUnsafeIntegerLiterals, uploadToCdn } from './api.js';
 
 describe('uploadToCdn', () => {
   afterEach(() => {
@@ -47,5 +47,85 @@ describe('uploadToCdn', () => {
     ).rejects.toThrow('CDN upload URL must use HTTPS');
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('quoteUnsafeIntegerLiterals', () => {
+  it('quotes integers above Number.MAX_SAFE_INTEGER', () => {
+    expect(quoteUnsafeIntegerLiterals('{"message_id": 9007199254740993}')).toBe(
+      '{"message_id": "9007199254740993"}',
+    );
+  });
+
+  it('quotes negative integers beyond the safe range', () => {
+    expect(quoteUnsafeIntegerLiterals('[-9007199254740993]')).toBe(
+      '["-9007199254740993"]',
+    );
+  });
+
+  it('leaves safe integers untouched, including the boundary value', () => {
+    const raw = '{"ret": 0, "seq": 42, "max": 9007199254740991}';
+    expect(quoteUnsafeIntegerLiterals(raw)).toBe(raw);
+  });
+
+  it('quotes MAX_SAFE_INTEGER + 1, which native parsing cannot distinguish', () => {
+    expect(quoteUnsafeIntegerLiterals('[9007199254740992]')).toBe(
+      '["9007199254740992"]',
+    );
+  });
+
+  it('leaves fractional and exponent numbers untouched', () => {
+    const raw = '{"a": 1.5, "b": 9007199254740993.5, "c": 1e21, "d": -2.5e-3}';
+    expect(quoteUnsafeIntegerLiterals(raw)).toBe(raw);
+  });
+
+  it('does not touch digit sequences inside string values', () => {
+    const raw = '{"text": "id 9007199254740993 stays", "n": 9007199254740993}';
+    expect(quoteUnsafeIntegerLiterals(raw)).toBe(
+      '{"text": "id 9007199254740993 stays", "n": "9007199254740993"}',
+    );
+  });
+
+  it('tracks escaped quotes inside strings', () => {
+    const raw = '{"text": "say \\" then 9007199254740993", "n": 1}';
+    expect(quoteUnsafeIntegerLiterals(raw)).toBe(raw);
+  });
+
+  it('handles large integers nested in arrays and leading zeros', () => {
+    expect(
+      quoteUnsafeIntegerLiterals(
+        '{"ids": [1, 18446744073709551615], "z": 007}',
+      ),
+    ).toBe('{"ids": [1, "18446744073709551615"], "z": 007}');
+  });
+});
+
+describe('getUpdates large message IDs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('preserves message_id values above the safe integer limit as exact strings', async () => {
+    const rawBody =
+      '{"ret": 0, "msgs": [' +
+      '{"message_id": 9007199254740993, "message_type": 1, "create_time_ms": 1755400000000},' +
+      '{"message_id": 123, "message_type": 1}' +
+      '], "get_updates_buf": "cursor-1", "longpolling_timeout_ms": 40000}';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => rawBody,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resp = await getUpdates('https://ilink.example', 'token', 'cursor-0');
+
+    expect(resp.msgs?.[0]?.message_id).toBe('9007199254740993');
+    // Safe-range numerics keep their native representation.
+    expect(resp.msgs?.[1]?.message_id).toBe(123);
+    expect(resp.ret).toBe(0);
+    expect(resp.get_updates_buf).toBe('cursor-1');
+    expect(resp.longpolling_timeout_ms).toBe(40000);
+    expect(resp.msgs?.[0]?.create_time_ms).toBe(1755400000000);
   });
 });

--- a/packages/channels/weixin/src/api.ts
+++ b/packages/channels/weixin/src/api.ts
@@ -12,6 +12,107 @@ import type {
   BaseInfo,
 } from './types.js';
 
+// ── Large-integer-safe JSON parsing ───────────────────────────────
+
+/** String form of Number.MAX_SAFE_INTEGER (9007199254740991). */
+const MAX_SAFE_INTEGER_DIGITS = '9007199254740991';
+
+/** True when an unsigned decimal digit string exceeds Number.MAX_SAFE_INTEGER. */
+function exceedsMaxSafeInteger(digits: string): boolean {
+  const stripped = digits.replace(/^0+/, '') || '0';
+  return (
+    stripped.length > MAX_SAFE_INTEGER_DIGITS.length ||
+    (stripped.length === MAX_SAFE_INTEGER_DIGITS.length &&
+      stripped > MAX_SAFE_INTEGER_DIGITS)
+  );
+}
+
+/**
+ * Quote integer literals whose magnitude exceeds Number.MAX_SAFE_INTEGER so
+ * the native JSON parser cannot silently round them. String contents are
+ * skipped (including escaped quotes), and fractional/exponent numbers are
+ * left untouched. All other values pass through unchanged, so a subsequent
+ * `JSON.parse` yields the same result as before except that out-of-range
+ * integers become strings carrying the exact decimal representation.
+ */
+export function quoteUnsafeIntegerLiterals(rawJson: string): string {
+  let out = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < rawJson.length; ) {
+    const ch = rawJson[i] as string;
+
+    if (inString) {
+      out += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      i++;
+      continue;
+    }
+
+    const isDigit = ch >= '0' && ch <= '9';
+    if (ch === '-' || isDigit) {
+      let j = i;
+      if (rawJson[j] === '-') j++;
+      const intStart = j;
+      while (j < rawJson.length && rawJson[j] >= '0' && rawJson[j] <= '9') {
+        j++;
+      }
+      const intDigits = rawJson.slice(intStart, j);
+
+      if (intDigits.length === 0) {
+        // Lone '-' or malformed token; emit unchanged and let JSON.parse
+        // surface the syntax error, matching native behavior.
+        out += ch;
+        i++;
+        continue;
+      }
+
+      // Consume a possible fractional/exponent suffix.
+      let k = j;
+      while (k < rawJson.length && '+-.eE0123456789'.includes(rawJson[k]!)) {
+        k++;
+      }
+      const isPlainInteger = k === j;
+
+      if (isPlainInteger && exceedsMaxSafeInteger(intDigits)) {
+        out += `"${rawJson.slice(i, j)}"`;
+      } else {
+        out += rawJson.slice(i, k);
+      }
+      i = k;
+      continue;
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out;
+}
+
+/**
+ * Parse JSON while preserving integers above Number.MAX_SAFE_INTEGER as
+ * exact decimal strings (native `JSON.parse` rounds them, and a reviver
+ * cannot help because it receives the already-rounded values).
+ */
+export function parseJsonPreservingLargeIntegers<T>(rawJson: string): T {
+  return JSON.parse(quoteUnsafeIntegerLiterals(rawJson)) as T;
+}
+
 // ── Error handling ────────────────────────────────────────────────
 
 /** Structured error from WeChat iLink Bot API. */
@@ -123,6 +224,7 @@ async function post<T>(
   token?: string,
   timeoutMs = 40000,
   signal?: AbortSignal,
+  preserveLargeIntegers = false,
 ): Promise<T> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -160,7 +262,10 @@ async function post<T>(
         : `WeChat API error (HTTP ${resp.status})`;
       throw new WeixinApiError(message, resp.status, ret, errcode);
     }
-    return (await resp.json()) as T;
+    const rawBody = await resp.text();
+    return preserveLargeIntegers
+      ? parseJsonPreservingLargeIntegers<T>(rawBody)
+      : (JSON.parse(rawBody) as T);
   } finally {
     clearTimeout(timeout);
   }
@@ -178,6 +283,8 @@ export async function getUpdates(
     base_info: baseInfo(),
   };
   try {
+    // message_id can exceed Number.MAX_SAFE_INTEGER; parse it losslessly so
+    // the platform identifier is not rounded before dedup/tracing uses it.
     return await post<GetUpdatesResp>(
       baseUrl,
       '/ilink/bot/getupdates',
@@ -185,6 +292,7 @@ export async function getUpdates(
       token,
       timeoutMs,
       signal,
+      true,
     );
   } catch (err: unknown) {
     if (err instanceof Error && err.name === 'AbortError') {

--- a/packages/channels/weixin/src/types.ts
+++ b/packages/channels/weixin/src/types.ts
@@ -79,7 +79,12 @@ export interface MessageItem {
 
 export interface WeixinMessage {
   seq?: number;
-  message_id?: number;
+  /**
+   * Platform message identifier. Values above Number.MAX_SAFE_INTEGER arrive
+   * as exact decimal strings (see parseJsonPreservingLargeIntegers); smaller
+   * values stay numbers.
+   */
+  message_id?: string | number;
   from_user_id?: string;
   to_user_id?: string;
   client_id?: string;


### PR DESCRIPTION
## What this PR does

The Weixin channel now parses `getupdates` responses without losing precision on 64-bit message IDs. A small transport-level helper quotes integer literals whose magnitude exceeds `Number.MAX_SAFE_INTEGER` in the raw response text before the native JSON parser runs, so those values arrive as exact decimal strings while every safe-range value keeps its native representation. The lossless parse is enabled only for `/ilink/bot/getupdates`; the other Weixin endpoints (`sendmessage`, `getconfig`, `sendtyping`, upload URL) keep native parsing unchanged. `WeixinMessage.message_id` is widened to `string | number`, which the existing `String(...)` normalization in the poll loop already handles.

## Why it's needed

Weixin `getupdates` can return `message_id` values above `Number.MAX_SAFE_INTEGER` (2^53−1). The shared `post()` helper parsed bodies with the native JSON parser, which rounds such values before the channel ever sees them — e.g. `9007199254740993` becomes `9007199254740992`. The envelope then carries a platform identifier that (1) no longer matches the platform's (tracing breaks) and (2) can collide with a different ID in the same rounding bucket (false deduplication). A plain `JSON.parse` reviver cannot fix this because the reviver receives already-rounded numbers; the raw text must be handled before parsing.

## Reviewer Test Plan

### How to verify

1. Reproduce the original rounding: `node -e 'console.log(JSON.parse("{\"message_id\": 9007199254740993}").message_id)'` prints `9007199254740992` — the same code path `post()` used.
2. Run the Weixin channel suite: `cd packages/channels/weixin && npx vitest run` — 80 tests pass, including 9 new ones:
   - `quoteUnsafeIntegerLiterals` unit tests: quotes unsafe integers (positive, negative, nested, `MAX_SAFE_INTEGER + 1`, u64 max), leaves safe integers (including the exact boundary `9007199254740991`), fractional/exponent numbers, and digit sequences inside string values (including escaped quotes) untouched.
   - `getUpdates` integration test with a mocked fetch returning a raw body containing `message_id: 9007199254740993`: asserts the exact decimal string survives while `ret`, `longpolling_timeout_ms`, `create_time_ms`, and a safe-range `message_id` stay native numbers.
3. Typecheck: `cd packages/channels/weixin && npx tsc --noEmit -p tsconfig.json` exits 0.

### Evidence (Before & After)

N/A (transport-level change, no UI).

Before: `JSON.parse('{"message_id": 9007199254740993}').message_id` → `9007199254740992` (rounded).
After: `getUpdates` returns `message_id === '9007199254740993'` (exact), covered by the new regression test.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest run` in `packages/channels/weixin`), Node v22 on Linux.

## Risk & Scope

- Main risk or tradeoff: the response-text pre-pass adds one linear scan over `getupdates` bodies; it is string-state aware (skips string contents including escaped quotes) and leaves all safe values byte-for-byte identical.
- Not validated / out of scope: live Weixin endpoint behavior (no credentials); other endpoints intentionally keep native parsing.
- Breaking changes / migration notes: none for consumers — `ParsedMessage.messageId` was already a string; `WeixinMessage.message_id` type widened from `number` to `string | number`, and the only in-repo reader (`monitor.ts`) normalizes via `String(...)`.

## Linked Issues

Fixes #9307

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Weixin channel 现在解析 `getupdates` 响应时不再丢失 64 位消息 ID 的精度。新增一个传输层小工具：在原生 JSON 解析之前，把原始响应文本中绝对值超过 `Number.MAX_SAFE_INTEGER` 的整数字面量加上引号，使其以精确十进制字符串的形式进入解析结果；安全范围内的所有值保持原生表示不变。无损解析仅对 `/ilink/bot/getupdates` 启用，其余 Weixin 端点（`sendmessage`、`getconfig`、`sendtyping`、上传 URL）维持原生解析。`WeixinMessage.message_id` 类型放宽为 `string | number`，轮询循环中现有的 `String(...)` 归一化无需改动即可兼容。

## 为什么需要

Weixin `getupdates` 可能返回超过 `Number.MAX_SAFE_INTEGER`（2^53−1）的 `message_id`。共享的 `post()` 助手用原生 JSON 解析器处理响应体，channel 代码拿到值之前就已经被舍入——例如 `9007199254740993` 变成 `9007199254740992`。消息信封因此携带了 (1) 与平台不一致的标识（追踪失效），(2) 可能与落在同一舍入区间的其他 ID 碰撞（误去重）。普通 `JSON.parse` reviver 无法修复此问题，因为 reviver 收到的已是舍入后的数值，必须在解析前处理原始文本。

## 评审验证计划

### 如何验证

1. 复现原始舍入：`node -e 'console.log(JSON.parse("{\"message_id\": 9007199254740993}").message_id)'` 输出 `9007199254740992`——即 `post()` 原先走的代码路径。
2. 运行 Weixin channel 测试：`cd packages/channels/weixin && npx vitest run`——80 个测试全部通过，其中新增 9 个：
   - `quoteUnsafeIntegerLiterals` 单元测试：对超范围整数（正数、负数、嵌套、`MAX_SAFE_INTEGER + 1`、u64 最大值）加引号；安全整数（含边界值 `9007199254740991`）、小数/科学计数法数字、字符串内容中的数字序列（含转义引号场景）均保持原样。
   - `getUpdates` 集成测试：mock fetch 返回包含 `message_id: 9007199254740993` 的原始响应体，断言精确十进制字符串完整保留，同时 `ret`、`longpolling_timeout_ms`、`create_time_ms` 及安全范围内的 `message_id` 仍为原生数字。
3. 类型检查：`cd packages/channels/weixin && npx tsc --noEmit -p tsconfig.json` 退出码为 0。

### 前后证据

N/A（传输层改动，无 UI）。

改动前：`JSON.parse('{"message_id": 9007199254740993}').message_id` → `9007199254740992`（被舍入）。
改动后：`getUpdates` 返回 `message_id === '9007199254740993'`（精确值），由新增回归测试覆盖。

### 测试环境

|   操作系统   | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

仅单元测试（`packages/channels/weixin` 下 `vitest run`），Linux，Node v22。

## 风险与范围

- 主要风险/权衡：响应文本预处理对 `getupdates` 响应体增加一次线性扫描；扫描感知字符串状态（跳过字符串内容，含转义引号），对所有安全值保持逐字节不变。
- 未验证/超出范围：Weixin 线上端点行为（无凭据）；其余端点有意保持原生解析。
- 破坏性变更/迁移说明：对使用方无破坏——`ParsedMessage.messageId` 本来就是字符串；`WeixinMessage.message_id` 类型由 `number` 放宽为 `string | number`，仓库内唯一读取处（`monitor.ts`）通过 `String(...)` 归一化。

## 关联 Issue

Fixes #9307

</details>
