### PR TITLE
fix(cli): exclude disabled skills from context usage details

### DIFF
--- a/packages/cli/src/ui/commands/contextCommand.test.ts
+++ b/packages/cli/src/ui/commands/contextCommand.test.ts
@@ -52,6 +52,7 @@ function makeMockConfig(contextWindowSize = 32_000): Config {
     getSkillManager: vi.fn().mockReturnValue({
       listSkills: vi.fn().mockResolvedValue([]),
     }),
+    getDisabledSkillNames: vi.fn().mockReturnValue(new Set()),
     getChatCompression: vi.fn().mockReturnValue(undefined),
     getAutoCompactThreshold: vi.fn(),
     getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
@@ -83,6 +84,7 @@ describe('collectContextData (contextCommand)', () => {
       getSkillManager: vi.fn().mockReturnValue({
         listSkills: vi.fn().mockResolvedValue([]),
       }),
+      getDisabledSkillNames: vi.fn().mockReturnValue(new Set()),
       getChatCompression: vi.fn().mockReturnValue(undefined),
       getAutoCompactThreshold: vi.fn(),
       getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
@@ -205,6 +207,7 @@ describe('collectContextData (contextCommand)', () => {
       getSkillManager: vi.fn().mockReturnValue({
         listSkills: vi.fn().mockResolvedValue([]),
       }),
+      getDisabledSkillNames: vi.fn().mockReturnValue(new Set()),
       getChatCompression: vi.fn().mockReturnValue(undefined),
       getAutoCompactThreshold: vi.fn(),
       getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
@@ -250,6 +253,7 @@ describe('collectContextData (contextCommand)', () => {
       getSkillManager: vi.fn().mockReturnValue({
         listSkills: vi.fn().mockResolvedValue([]),
       }),
+      getDisabledSkillNames: vi.fn().mockReturnValue(new Set()),
       getChatCompression: vi.fn().mockReturnValue(undefined),
       getAutoCompactThreshold: vi.fn(),
       getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
@@ -280,6 +284,37 @@ describe('collectContextData (contextCommand)', () => {
     expect(data.memoryFiles).toHaveLength(1);
     expect(data.memoryFiles[0].path).toBe(t('auto memory'));
     expect(data.memoryFiles[0].tokens).toBeGreaterThan(0);
+  });
+
+  it('excludes disabled skills from the detail breakdown', async () => {
+    const config = {
+      ...makeMockConfig(),
+      getSkillManager: vi.fn().mockReturnValue({
+        listSkills: vi.fn().mockResolvedValue([
+          {
+            name: 'enabled-skill',
+            description: 'Enabled skill',
+            level: 'user',
+            filePath: '/skills/enabled-skill/SKILL.md',
+            body: 'Enabled body',
+          },
+          {
+            name: 'Disabled-Skill',
+            description: 'Disabled skill',
+            level: 'user',
+            filePath: '/skills/disabled-skill/SKILL.md',
+            body: 'Disabled body',
+          },
+        ]),
+      }),
+      getDisabledSkillNames: vi
+        .fn()
+        .mockReturnValue(new Set(['disabled-skill'])),
+    } as unknown as Config;
+
+    const data = await collectContextData(config, true);
+
+    expect(data.skills.map((skill) => skill.name)).toEqual(['enabled-skill']);
   });
 });
 

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -195,6 +195,7 @@ export async function collectContextData(
 
   const skillManager = config.getSkillManager();
   const skillConfigs = skillManager ? await skillManager.listSkills() : [];
+  const disabledSkillNames = config.getDisabledSkillNames();
   let loadedBodiesTokens = 0;
   const skills: ContextSkillDetail[] = skillConfigs.map((skill) => {
     const listingTokens = estimateTokens(
@@ -382,7 +383,11 @@ export async function collectContextData(
     builtinTools: showDetails ? detailBuiltinTools : [],
     mcpTools: showDetails ? detailMcpTools : [],
     memoryFiles: showDetails ? detailMemoryFiles : [],
-    skills: showDetails ? detailSkills : [],
+    skills: showDetails
+      ? detailSkills.filter(
+          (skill) => !disabledSkillNames.has(skill.name.toLowerCase()),
+        )
+      : [],
     isEstimated,
     showDetails,
   };


### PR DESCRIPTION
## What this PR does

Filters Skills configured in `skills.disabled` out of the detailed context-usage `skills[]` response. The comparison follows the existing case-insensitive disabled-Skill behavior used by runtime invocation checks.

## Why it's needed

The runtime already excludes disabled Skills from the model-facing available Skill list, but `/context-usage?detail=true` enumerated the full discovered catalog. This made a disabled, unloaded Skill appear to consume context even in a new session and made the endpoint misleading for context-cost analysis.

## Reviewer Test Plan

### How to verify

Configure Skill discovery to return one enabled Skill and one disabled Skill, using mixed case for the discovered disabled name and lowercase in `skills.disabled`. Request detailed context usage and confirm that `skills[]` contains only the enabled Skill. The focused context command test suite passes 14/14 tests, and an independent public-seam probe changed from `containsDisabled: true` before the fix to `containsDisabled: false` after it.

### Evidence (Before & After)

Before: a Skill present in `skills.disabled` was still returned in `skills[]` with `loaded: false`.

After: the disabled Skill is omitted from `skills[]`; enabled Skill details remain present.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Node.js 22 workspace. Focused Vitest suite and Prettier check passed. The full workspace build was attempted but is currently blocked before reaching this change by the existing Core error `Module 'sharp' has no exported member 'SharpConstructor'`.

## Risk & Scope

- Main risk or tradeoff: The detailed Skill array now follows the current disabled configuration, so it intentionally omits a disabled Skill even if historical messages from an earlier invocation remain in the conversation.
- Not validated / out of scope: This does not redefine aggregate `breakdown.skills` accounting or remove historical Skill body/tool-result content from existing chat history.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #9344

<details>
<summary>中文说明</summary>

## 本 PR 的改动

从上下文用量详情响应的 `skills[]` 中过滤通过 `skills.disabled` 配置关闭的 Skill。比较方式沿用运行时调用校验已有的大小写不敏感语义。

## 为什么需要这个改动

运行时已经会从模型可用 Skill 列表中排除已关闭的 Skill，但 `/context-usage?detail=true` 此前仍会枚举完整的已发现 Skill 目录。这会让一个已关闭且未加载的 Skill 在新会话中看起来仍在消耗上下文，也会误导对上下文成本的分析。

## Reviewer 测试计划

### 如何验证

让 Skill 发现结果包含一个开启的 Skill 和一个关闭的 Skill，并让发现结果中的关闭 Skill 名称使用混合大小写、`skills.disabled` 中使用小写。请求上下文用量详情，确认 `skills[]` 只包含开启的 Skill。聚焦的 context command 测试套件 14/14 通过；独立的公开入口探针也从修复前的 `containsDisabled: true` 变为修复后的 `containsDisabled: false`。

### 修复前后证据

修复前：`skills.disabled` 中的 Skill 仍会以 `loaded: false` 出现在 `skills[]` 中。

修复后：关闭的 Skill 会从 `skills[]` 中省略，开启的 Skill 详情仍会保留。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 Node.js 22 workspace。聚焦 Vitest 测试和 Prettier 检查通过。已尝试全 workspace 构建，但在到达本次改动前被 Core 中已有的 `Module 'sharp' has no exported member 'SharpConstructor'` 错误阻塞。

## 风险与范围

- 主要风险或权衡：Skill 详情数组现在遵循当前禁用配置，因此即使会话中仍保留更早调用产生的历史消息，已关闭的 Skill 也会按预期从详情数组中省略。
- 未验证或不在范围内：本 PR 不重新定义 `breakdown.skills` 的汇总口径，也不从现有聊天历史中移除 Skill body 或工具结果内容。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #9344

</details>
