### PR TITLE
fix(cli): Keep transient runtime record I/O retryable

### DIFF
--- a/packages/cli/src/serve/conversations/conversation-runtime-ownership.test.ts
+++ b/packages/cli/src/serve/conversations/conversation-runtime-ownership.test.ts
@@ -21,6 +21,47 @@ import {
 } from '../live/discovery.js';
 import { LIVE_HOST_PROTOCOL_VERSION } from '../live/types.js';
 
+const recordReadFailure = vi.hoisted(() => ({
+  path: undefined as string | undefined,
+  operation: undefined as 'open' | 'readFile' | undefined,
+  code: undefined as string | undefined,
+  injected: false,
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    open: vi.fn(async (...args: Parameters<typeof actual.open>) => {
+      const matches = String(args[0]) === recordReadFailure.path;
+      if (
+        matches &&
+        !recordReadFailure.injected &&
+        recordReadFailure.operation === 'open'
+      ) {
+        recordReadFailure.injected = true;
+        throw Object.assign(new Error(recordReadFailure.code), {
+          code: recordReadFailure.code,
+        });
+      }
+      const handle = await actual.open(...args);
+      if (
+        matches &&
+        !recordReadFailure.injected &&
+        recordReadFailure.operation === 'readFile'
+      ) {
+        recordReadFailure.injected = true;
+        vi.spyOn(handle, 'readFile').mockRejectedValueOnce(
+          Object.assign(new Error(recordReadFailure.code), {
+            code: recordReadFailure.code,
+          }),
+        );
+      }
+      return handle;
+    }),
+  };
+});
+
 const temporaryDirectories: string[] = [];
 const childProcesses = new Set<ChildProcess>();
 const currentNonce = 'conversation_owner_nonce_current_01';
@@ -39,7 +80,47 @@ async function readRecord(stableBaseDir: string) {
   ) as { version: number; pid: number; instanceNonce: string };
 }
 
+function failRecordReadOnce(
+  recordPath: string,
+  operation: 'open' | 'readFile',
+  code: string,
+): void {
+  recordReadFailure.path = recordPath;
+  recordReadFailure.operation = operation;
+  recordReadFailure.code = code;
+  recordReadFailure.injected = false;
+}
+
+async function writeForeignRecord(
+  stableBaseDir: string,
+  kind: 'ownership' | 'Live discovery',
+): Promise<string> {
+  if (kind === 'ownership') {
+    const previous = createConversationRuntimeOwnership({
+      stableBaseDir,
+      pid: 999_998,
+      instanceNonce: 'conversation_owner_nonce_read_failure',
+      isProcessAlive: () => false,
+    });
+    await previous.acquire();
+    return getConversationRuntimeOwnerPath(stableBaseDir);
+  }
+  await fs.mkdir(stableBaseDir, { recursive: true, mode: 0o700 });
+  await writeLiveDiscoveryFile(stableBaseDir, {
+    url: 'http://127.0.0.1:3210',
+    protocolVersion: LIVE_HOST_PROTOCOL_VERSION,
+    pid: 999_997,
+    instanceNonce: 'legacy_live_owner_nonce_read_failure',
+  });
+  return getLiveDiscoveryPath(stableBaseDir);
+}
+
 afterEach(async () => {
+  vi.restoreAllMocks();
+  recordReadFailure.path = undefined;
+  recordReadFailure.operation = undefined;
+  recordReadFailure.code = undefined;
+  recordReadFailure.injected = false;
   for (const child of childProcesses) {
     child.kill('SIGKILL');
   }
@@ -312,6 +393,58 @@ try {
     await ownership.acquire();
     expect(wait).toHaveBeenCalledOnce();
   });
+
+  it.each([
+    ['ownership', 'open'],
+    ['ownership', 'readFile'],
+    ['Live discovery', 'open'],
+    ['Live discovery', 'readFile'],
+  ] as const)(
+    'recovers after a transient %s record %s failure',
+    async (kind, operation) => {
+      const stableBaseDir = await temporaryStableBase();
+      const recordPath = await writeForeignRecord(stableBaseDir, kind);
+      const ownership = createConversationRuntimeOwnership({
+        stableBaseDir,
+        pid: process.pid,
+        instanceNonce: currentNonce,
+        isProcessAlive: () => false,
+        handoffGraceMs: 0,
+      });
+
+      failRecordReadOnce(
+        recordPath,
+        operation,
+        operation === 'open' ? 'EMFILE' : 'EIO',
+      );
+      await expect(ownership.acquire()).rejects.toMatchObject({
+        code: 'conversation_runtime_unavailable',
+        retryable: true,
+      });
+
+      await expect(ownership.acquire()).resolves.toEqual({ reclaimed: true });
+    },
+  );
+
+  it.each(['ownership', 'Live discovery'] as const)(
+    'treats an ELOOP opening the %s record as terminal compromise',
+    async (kind) => {
+      const stableBaseDir = await temporaryStableBase();
+      const recordPath = await writeForeignRecord(stableBaseDir, kind);
+      const ownership = createConversationRuntimeOwnership({
+        stableBaseDir,
+        pid: process.pid,
+        instanceNonce: currentNonce,
+        isProcessAlive: () => false,
+      });
+
+      failRecordReadOnce(recordPath, 'open', 'ELOOP');
+      await expect(ownership.acquire()).rejects.toMatchObject({
+        code: 'conversation_runtime_ownership_compromised',
+        retryable: false,
+      });
+    },
+  );
 
   it('rejects an active foreign legacy Live owner before writing its record', async () => {
     const stableBaseDir = await temporaryStableBase();

--- a/packages/cli/src/serve/conversations/conversation-runtime-ownership.ts
+++ b/packages/cli/src/serve/conversations/conversation-runtime-ownership.ts
@@ -226,7 +226,10 @@ async function readOwnerRecord(
         : fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
     );
   } catch (error) {
-    throw new UnsafeOwnershipStateError(undefined, { cause: error });
+    if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+      throw new UnsafeOwnershipStateError(undefined, { cause: error });
+    }
+    throw error;
   }
   try {
     const handleStat = await handle.stat();
@@ -243,9 +246,10 @@ async function readOwnerRecord(
     ) {
       throw new UnsafeOwnershipStateError();
     }
+    const serialized = await handle.readFile('utf8');
     let parsed: unknown;
     try {
-      parsed = JSON.parse(await handle.readFile('utf8'));
+      parsed = JSON.parse(serialized);
     } catch (error) {
       throw new UnsafeOwnershipStateError(undefined, { cause: error });
     }

--- a/packages/cli/src/serve/live/discovery.ts
+++ b/packages/cli/src/serve/live/discovery.ts
@@ -188,8 +188,11 @@ async function readExistingRecord(
         ? fsConstants.O_RDONLY
         : fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
     );
-  } catch {
-    throw new LiveDiscoveryStateError();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ELOOP') {
+      throw new LiveDiscoveryStateError(error);
+    }
+    throw error;
   }
   try {
     const handleStat = await handle.stat();
@@ -206,11 +209,12 @@ async function readExistingRecord(
     ) {
       throw new LiveDiscoveryStateError();
     }
+    const serialized = await handle.readFile('utf8');
     let parsed: unknown;
     try {
-      parsed = JSON.parse(await handle.readFile('utf8'));
-    } catch {
-      throw new LiveDiscoveryStateError();
+      parsed = JSON.parse(serialized);
+    } catch (error) {
+      throw new LiveDiscoveryStateError(error);
     }
     if (
       typeof parsed !== 'object' ||


### PR DESCRIPTION
## What this PR does

This PR preserves fail-closed integrity checks while distinguishing transient ownership-record I/O failures from invalid persisted state. Resource-exhaustion and read I/O errors can now surface as retryable unavailability and recover on a later acquisition, while symlink loops, file identity changes, malformed JSON, and invalid record shapes remain terminal.

## Why it's needed

The secure record readers introduced by #9181 treated every open and read failure as evidence of corruption. A one-off `EMFILE` or `EIO` therefore latched `conversation_runtime_ownership_compromised` for the daemon lifetime even when the record was valid, preventing Conversations and Live recovery until restart. This follows up on two Critical review findings that arrived immediately before #9181 was merged.

## Reviewer Test Plan

### How to verify

Exercise ownership acquisition with an existing dead owner record and a stale Live discovery record. For each record type, inject `EMFILE` during open and `EIO` during file-handle read: the first acquisition should return `conversation_runtime_unavailable` with `retryable: true`, and the second should reclaim successfully after the injected fault clears. Injecting `ELOOP` during open should still return `conversation_runtime_ownership_compromised` with `retryable: false`. Existing malformed-record, unsafe-file, and identity-change cases should remain terminal and must not overwrite state.

Local validation passed 42/42 targeted tests together with the repository build, typecheck, lint, formatting, and diff checks. An independent probe reproduced all four permanent-latch paths on the base commit and confirmed recovery with this change.

### Evidence (Before & After)

N/A (non-UI daemon reliability fix).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js 22-compatible repository toolchain on macOS; local npm workspace build, typecheck, lint, and targeted Vitest tests.

## Risk & Scope

- Main risk or tradeoff: Reclassifying errors too broadly could weaken fail-closed handling; this is mitigated by keeping `ELOOP`, lock compromise, permission and identity changes, malformed content, and provisional ownership failures terminal.
- Not validated / out of scope: Kernel-level fault injection on Windows and Linux; repository CI is expected to provide cross-platform coverage.
- Breaking changes / migration notes: None. Persisted record formats, ownership ordering, routes, and public APIs are unchanged.

## Linked Issues

Follow-up to #9181. Addresses the [owner-record Critical finding](https://github.com/QwenLM/qwen-code/pull/9181#discussion_r3792290253) and the [Live discovery Critical finding](https://github.com/QwenLM/qwen-code/pull/9181#discussion_r3792290255).

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 在保留完整性校验 fail-closed 语义的同时，区分所有权记录的瞬时 I/O 失败与无效持久化状态。资源耗尽和读取 I/O 错误现在会表现为可重试的暂时不可用，并可在后续 acquisition 中恢复；符号链接循环、文件身份变化、JSON 损坏和记录结构无效仍保持终态。

## 为什么需要此改动

#9181 引入的安全记录读取逻辑把所有 open 和 read 失败都视为状态损坏。即使记录本身有效，一次瞬时 `EMFILE` 或 `EIO` 也会在整个守护进程生命周期内锁存 `conversation_runtime_ownership_compromised`，导致 Conversations 和 Live 必须重启才能恢复。本修复跟进 #9181 合并前最后出现的两条 Critical 评审意见。

## 审查者测试计划

### 验证方式

分别使用已有的失效 owner 记录和过期 Live discovery 记录执行所有权 acquisition。对每种记录，在 open 阶段注入 `EMFILE`，在文件句柄读取阶段注入 `EIO`：第一次 acquisition 应返回 `conversation_runtime_unavailable` 且 `retryable: true`，故障清除后的第二次 acquisition 应成功回收记录。open 阶段注入 `ELOOP` 时仍应返回 `conversation_runtime_ownership_compromised` 且 `retryable: false`。现有的记录损坏、不安全文件和身份变化场景仍应保持终态，且不得覆盖原状态。

本地验证已通过 42/42 个定向测试，以及仓库 build、typecheck、lint、格式和 diff 检查。独立探针在基线提交上复现了全部四条永久锁存路径，并确认本改动可以恢复。

### 证据（改动前后）

N/A（非 UI 的守护进程可靠性修复）。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      | ✅ 已测试 |
|    🪟 Windows     | ⚠️ 未测试 |
|     🐧 Linux      | ⚠️ 未测试 |

### 环境（可选）

macOS 上兼容 Node.js 22 的仓库工具链；本地 npm workspace build、typecheck、lint 和定向 Vitest 测试。

## 风险与范围

- 主要风险或权衡：错误分类放宽过度可能削弱 fail-closed 处理；本改动继续将 `ELOOP`、锁损坏、权限和身份变化、内容损坏以及 provisional 所有权阶段的失败视为终态，以降低该风险。
- 未验证或不在范围内：未在 Windows 和 Linux 上执行内核级故障注入；预期由仓库 CI 提供跨平台覆盖。
- 破坏性变更或迁移说明：无。持久化记录格式、所有权顺序、路由和公共 API 均未改变。

## 关联问题

本 PR 是 #9181 的后续修复，处理 [owner 记录的 Critical 评审意见](https://github.com/QwenLM/qwen-code/pull/9181#discussion_r3792290253)和 [Live discovery 的 Critical 评审意见](https://github.com/QwenLM/qwen-code/pull/9181#discussion_r3792290255)。

</details>
