### PR TITLE
feat(web-shell): Consume workspace session live-state

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -85,7 +85,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { formatRelativeTime } from '../../utils/formatRelativeTime';
 import { DialogShell } from '../dialogs/DialogShell';
-import { WorkspaceSection } from './WorkspaceSection';
+import { WorkspaceSection, isAbsolutePath } from './WorkspaceSection';
 import {
   hasWorkspaceExpansionPreference,
   migrateWorkspaceExpansionPreference,
@@ -157,12 +157,6 @@ function getSessionIdentity(
   workspaceCwd: string | undefined,
 ): string {
   return `${workspaceCwd ?? ''}\0${sessionId}`;
-}
-
-function isAbsoluteWorkspaceCwd(cwd: string): boolean {
-  return (
-    cwd.startsWith('/') || cwd.startsWith('\\') || /^[a-zA-Z]:[\\/]/.test(cwd)
-  );
 }
 
 export type WebShellSidebarFooterItem =
@@ -942,7 +936,7 @@ export function WebShellSidebar({
   const liveStateWorkspaceCwds = useMemo(
     () =>
       displayedWorkspaces
-        .filter((entry) => entry.trusted && isAbsoluteWorkspaceCwd(entry.cwd))
+        .filter((entry) => entry.trusted && isAbsolutePath(entry.cwd))
         .map((entry) => entry.cwd),
     [displayedWorkspaces],
   );
@@ -958,7 +952,7 @@ export function WebShellSidebar({
               (entry) =>
                 entry.kind !== 'live' &&
                 entry.trusted &&
-                isAbsoluteWorkspaceCwd(entry.cwd),
+                isAbsolutePath(entry.cwd),
             )
             .map((entry) => entry.cwd)
         : [],
@@ -1099,6 +1093,10 @@ export function WebShellSidebar({
   const [deleteCandidate, setDeleteCandidate] =
     useState<DaemonSessionSummary | null>(null);
   const [groupMenu, setGroupMenu] = useState<GroupMenuState | null>(null);
+  const groupMenuOpenRef = useRef(groupMenu !== null);
+  useEffect(() => {
+    groupMenuOpenRef.current = groupMenu !== null;
+  }, [groupMenu]);
   const [groupEditor, setGroupEditor] = useState<GroupEditorState | null>(null);
   const [groupName, setGroupName] = useState('');
   const [groupColor, setGroupColor] = useState<DaemonSessionGroupColor>('blue');
@@ -1839,8 +1837,14 @@ export function WebShellSidebar({
       setGroupsCatalogReady(false);
       if (!primaryLiveStateGroupCatalog) return;
       setGroups(primaryLiveStateGroupCatalog.groups);
-      setMenuGroups(primaryLiveStateGroupCatalog.groups);
-      setColorOptions(primaryLiveStateGroupCatalog.colorOptions);
+      // The open group menu may be anchored to a session from a different
+      // workspace (openGroupMenuFromAnchor loads menuGroups from the
+      // session's own workspace) — don't clobber it with the primary
+      // workspace's catalog on every reconcile.
+      if (!groupMenuOpenRef.current) {
+        setMenuGroups(primaryLiveStateGroupCatalog.groups);
+        setColorOptions(primaryLiveStateGroupCatalog.colorOptions);
+      }
       setGroupsCatalogReady(true);
       return;
     }
@@ -3573,9 +3577,7 @@ export function WebShellSidebar({
     groupMenuSelectedGroupId === null && groupMenuSelectedColor === null;
   const deleteGroupCandidateLabel = deleteGroupCandidate?.group.name ?? '';
   const groupColorChoices =
-    colorOptions.length > 0
-      ? colorOptions
-      : (['blue'] as DaemonSessionGroupPresetColor[]);
+    colorOptions.length > 0 ? colorOptions : SESSION_GROUP_COLORS;
   const normalizedGroupColor = normalizeGroupColorInput(
     groupColor,
     groupColorChoices,

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -114,6 +114,7 @@ import {
   useWebShellSessions,
 } from '../../session-catalog/session-catalog-hooks';
 import type { SessionCatalogQuery } from '../../session-catalog/session-catalog-store';
+import { useWorkspaceSessionLiveState } from '../../session-catalog/workspace-session-live-state';
 
 const SIDEBAR_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-sidebar-width';
 const SIDEBAR_DEFAULT_WIDTH = 260;
@@ -156,6 +157,12 @@ function getSessionIdentity(
   workspaceCwd: string | undefined,
 ): string {
   return `${workspaceCwd ?? ''}\0${sessionId}`;
+}
+
+function isAbsoluteWorkspaceCwd(cwd: string): boolean {
+  return (
+    cwd.startsWith('/') || cwd.startsWith('\\') || /^[a-zA-Z]:[\\/]/.test(cwd)
+  );
 }
 
 export type WebShellSidebarFooterItem =
@@ -883,6 +890,12 @@ export function WebShellSidebar({
       'workspace_qualified_rest_core',
     ),
   );
+  const workspaceSessionLiveStateSupported = Boolean(
+    connection.capabilities?.features?.includes(
+      'workspace_session_live_state',
+    ) && typeof workspace.client.getWorkspaceSessionLiveState === 'function',
+  );
+  const sessionCatalogRequestsEnabled = connection.capabilities !== undefined;
   const workspaceSessionMetadataEnabled = Boolean(
     connection.capabilities?.features?.includes('workspace_session_metadata'),
   );
@@ -908,6 +921,72 @@ export function WebShellSidebar({
     : undefined;
   const includePrimaryWorkspaceSessions =
     !lockedWorkspaceCwd || lockedWorkspace?.primary === true;
+  const projectName =
+    getWorkspaceName(connection.workspaceCwd) || t('sidebar.projectFallback');
+  const displayedWorkspaces = useMemo<DaemonWorkspaceCapability[]>(() => {
+    const availableWorkspaces =
+      workspaces.length > 0
+        ? workspaces
+        : [
+            {
+              id: 'primary',
+              cwd: connection.workspaceCwd || projectName,
+              primary: true,
+              trusted: true,
+            },
+          ];
+    return lockedWorkspaceCwd
+      ? availableWorkspaces.filter((entry) => entry.cwd === lockedWorkspaceCwd)
+      : availableWorkspaces;
+  }, [connection.workspaceCwd, lockedWorkspaceCwd, projectName, workspaces]);
+  const liveStateWorkspaceCwds = useMemo(
+    () =>
+      displayedWorkspaces
+        .filter((entry) => entry.trusted && isAbsoluteWorkspaceCwd(entry.cwd))
+        .map((entry) => entry.cwd),
+    [displayedWorkspaces],
+  );
+  const liveStateWorkspaceCwdSet = useMemo(
+    () => new Set(liveStateWorkspaceCwds),
+    [liveStateWorkspaceCwds],
+  );
+  const liveStateGroupWorkspaceCwds = useMemo(
+    () =>
+      organizationEnabled && !channelGroupingEnabled
+        ? displayedWorkspaces
+            .filter(
+              (entry) =>
+                entry.kind !== 'live' &&
+                entry.trusted &&
+                isAbsoluteWorkspaceCwd(entry.cwd),
+            )
+            .map((entry) => entry.cwd)
+        : [],
+    [channelGroupingEnabled, displayedWorkspaces, organizationEnabled],
+  );
+  const workspaceSessionLiveStateEnabled =
+    workspaceSessionLiveStateSupported && liveStateWorkspaceCwds.length > 0;
+  const primaryWorkspaceSessionLiveStateEnabled = Boolean(
+    workspaceSessionLiveStateEnabled &&
+      primaryWorkspaceCwd &&
+      liveStateWorkspaceCwdSet.has(primaryWorkspaceCwd),
+  );
+  const primaryWorkspaceLiveStateGroupsEnabled = Boolean(
+    primaryWorkspaceSessionLiveStateEnabled &&
+      primaryWorkspaceCwd &&
+      liveStateGroupWorkspaceCwds.includes(primaryWorkspaceCwd),
+  );
+  const secondaryWorkspaceCwds = useMemo(
+    () =>
+      displayedWorkspaces
+        .filter((entry) => !entry.primary && entry.trusted)
+        .map((entry) => entry.cwd),
+    [displayedWorkspaces],
+  );
+  const secondaryWorkspaceSessionLiveStateEnabled =
+    workspaceSessionLiveStateEnabled &&
+    secondaryWorkspaceCwds.length > 0 &&
+    secondaryWorkspaceCwds.every((cwd) => liveStateWorkspaceCwdSet.has(cwd));
   const {
     sessions,
     loading,
@@ -919,7 +998,8 @@ export function WebShellSidebar({
     archiveSession,
     catalogQuery,
   } = useWebShellSessions({
-    autoLoad: true,
+    autoLoad:
+      sessionCatalogRequestsEnabled && !primaryWorkspaceSessionLiveStateEnabled,
     enabled: includePrimaryWorkspaceSessions,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'active',
@@ -956,7 +1036,10 @@ export function WebShellSidebar({
   const loadPinnedSessions =
     organizationEnabled && selectedSessionSource !== 'channel';
   const { sessions: primaryPinnedSessions } = useWebShellSessions({
-    autoLoad: loadPinnedSessions,
+    autoLoad:
+      sessionCatalogRequestsEnabled &&
+      loadPinnedSessions &&
+      !primaryWorkspaceSessionLiveStateEnabled,
     enabled: loadPinnedSessions && includePrimaryWorkspaceSessions,
     pageSize: SESSION_LIST_PAGE_SIZE,
     archiveState: 'active',
@@ -975,7 +1058,8 @@ export function WebShellSidebar({
     unarchiveSession,
     catalogQuery: archivedCatalogQuery,
   } = useWebShellSessions({
-    autoLoad: true,
+    autoLoad:
+      sessionCatalogRequestsEnabled && !primaryWorkspaceSessionLiveStateEnabled,
     enabled:
       sessionArchiveEnabled &&
       archivedExpanded &&
@@ -1182,31 +1266,17 @@ export function WebShellSidebar({
         connection.workspaceCwd || primaryWorkspaceCwd,
       )
     : null;
-  const projectName =
-    getWorkspaceName(connection.workspaceCwd) || t('sidebar.projectFallback');
-  const displayedWorkspaces = useMemo<DaemonWorkspaceCapability[]>(() => {
-    const availableWorkspaces =
-      workspaces.length > 0
-        ? workspaces
-        : [
-            {
-              id: 'primary',
-              cwd: connection.workspaceCwd || projectName,
-              primary: true,
-              trusted: true,
-            },
-          ];
-    return lockedWorkspaceCwd
-      ? availableWorkspaces.filter((entry) => entry.cwd === lockedWorkspaceCwd)
-      : availableWorkspaces;
-  }, [connection.workspaceCwd, lockedWorkspaceCwd, projectName, workspaces]);
-  const secondaryWorkspaceCwds = useMemo(
-    () =>
-      displayedWorkspaces
-        .filter((entry) => !entry.primary && entry.trusted)
-        .map((entry) => entry.cwd),
-    [displayedWorkspaces],
+  const liveStateGroupCatalogs = useWorkspaceSessionLiveState(
+    workspace.client,
+    {
+      enabled: workspaceSessionLiveStateEnabled,
+      workspaceCwds: liveStateWorkspaceCwds,
+      groupWorkspaceCwds: liveStateGroupWorkspaceCwds,
+    },
   );
+  const primaryLiveStateGroupCatalog = primaryWorkspaceCwd
+    ? liveStateGroupCatalogs.get(primaryWorkspaceCwd)
+    : undefined;
   const secondaryActiveQueries = useMemo<SessionCatalogQuery[]>(
     () =>
       secondaryWorkspaceCwds.map((workspaceCwd) => ({
@@ -1229,8 +1299,16 @@ export function WebShellSidebar({
     workspace.client,
     secondaryActiveQueries,
     {
-      autoLoad: collapsed,
-      pollIntervalMs: collapsed ? ACTIVE_SESSION_POLL_INTERVAL_MS : undefined,
+      autoLoad:
+        sessionCatalogRequestsEnabled &&
+        collapsed &&
+        !secondaryWorkspaceSessionLiveStateEnabled,
+      pollIntervalMs:
+        sessionCatalogRequestsEnabled &&
+        collapsed &&
+        !secondaryWorkspaceSessionLiveStateEnabled
+          ? ACTIVE_SESSION_POLL_INTERVAL_MS
+          : undefined,
     },
   );
   const secondaryActiveSessions = useMemo(
@@ -1261,7 +1339,9 @@ export function WebShellSidebar({
     workspace.client,
     secondaryPinnedQueries,
     {
-      autoLoad: true,
+      autoLoad:
+        sessionCatalogRequestsEnabled &&
+        !secondaryWorkspaceSessionLiveStateEnabled,
       enabled: organizationEnabled && selectedSessionSource !== 'channel',
     },
   );
@@ -1297,7 +1377,12 @@ export function WebShellSidebar({
   const secondaryArchivedSnapshots = useSessionCatalogQueries(
     workspace.client,
     secondaryArchivedQueries,
-    { autoLoad: true, enabled: secondaryArchivedEnabled },
+    {
+      autoLoad:
+        sessionCatalogRequestsEnabled &&
+        !secondaryWorkspaceSessionLiveStateEnabled,
+      enabled: secondaryArchivedEnabled,
+    },
   );
   const secondaryArchivedSessions = useMemo(
     () =>
@@ -1706,12 +1791,14 @@ export function WebShellSidebar({
   );
 
   const reloadGroups = useCallback(async () => {
-    if (!organizationEnabled) {
+    if (!organizationEnabled || channelGroupingEnabled) {
       setGroups([]);
+      setMenuGroups([]);
       setColorOptions([]);
       setGroupsCatalogReady(true);
       return;
     }
+    if (primaryWorkspaceLiveStateGroupsEnabled) return;
     try {
       const catalog = await workspaceActions.listSessionGroups();
       setGroups(catalog.groups);
@@ -1724,18 +1811,49 @@ export function WebShellSidebar({
     } catch (err) {
       onError(err, t('sidebar.groupsLoadFailed'));
     }
-  }, [onError, organizationEnabled, t, workspaceActions]);
+  }, [
+    channelGroupingEnabled,
+    onError,
+    organizationEnabled,
+    primaryWorkspaceLiveStateGroupsEnabled,
+    t,
+    workspaceActions,
+  ]);
 
   useEffect(() => {
-    if (!organizationEnabled) {
+    if (!organizationEnabled || channelGroupingEnabled) {
       setGroups([]);
+      setMenuGroups([]);
       setColorOptions([]);
+      setGroupsCatalogReady(true);
+      return;
+    }
+    if (!includePrimaryWorkspaceSessions) {
+      setGroups([]);
+      setMenuGroups([]);
+      setColorOptions([]);
+      setGroupsCatalogReady(true);
+      return;
+    }
+    if (primaryWorkspaceLiveStateGroupsEnabled) {
+      setGroupsCatalogReady(false);
+      if (!primaryLiveStateGroupCatalog) return;
+      setGroups(primaryLiveStateGroupCatalog.groups);
+      setMenuGroups(primaryLiveStateGroupCatalog.groups);
+      setColorOptions(primaryLiveStateGroupCatalog.colorOptions);
       setGroupsCatalogReady(true);
       return;
     }
     setGroupsCatalogReady(false);
     void reloadGroups();
-  }, [organizationEnabled, reloadGroups]);
+  }, [
+    includePrimaryWorkspaceSessions,
+    channelGroupingEnabled,
+    organizationEnabled,
+    primaryLiveStateGroupCatalog,
+    reloadGroups,
+    primaryWorkspaceLiveStateGroupsEnabled,
+  ]);
 
   useEffect(() => {
     if (!groupMenu) return;
@@ -1867,7 +1985,9 @@ export function WebShellSidebar({
   useSessionCatalogPolling(
     workspace.client,
     includePrimaryWorkspaceSessions ? catalogQuery : undefined,
-    sessionPollInterval,
+    sessionCatalogRequestsEnabled && !primaryWorkspaceSessionLiveStateEnabled
+      ? sessionPollInterval
+      : undefined,
   );
   // Channel grouping rides the session poll cadence: instances added or
   // removed while the channel source is active must reach the grouping logic
@@ -4850,6 +4970,11 @@ export function WebShellSidebar({
                 noSessionsLabel={t('sidebar.noSessions')}
                 loadErrorLabel={t('sidebar.loadFailed')}
                 organizationEnabled={false}
+                sessionCatalogRequestsEnabled={sessionCatalogRequestsEnabled}
+                sessionLiveStateEnabled={
+                  workspaceSessionLiveStateEnabled &&
+                  liveStateWorkspaceCwdSet.has(ws.cwd)
+                }
                 sourceType={sourceMetadataEnabled ? 'default' : undefined}
                 channelGroupingEnabled={false}
                 ungroupedLabel={t('sidebar.groupUngrouped')}
@@ -4953,6 +5078,19 @@ export function WebShellSidebar({
                           noSessionsLabel={t('sidebar.noSessions')}
                           loadErrorLabel={t('sidebar.loadFailed')}
                           organizationEnabled={organizationEnabled}
+                          sessionCatalogRequestsEnabled={
+                            sessionCatalogRequestsEnabled
+                          }
+                          sessionGroupCatalog={
+                            workspaceSessionLiveStateEnabled &&
+                            liveStateWorkspaceCwdSet.has(ws.cwd)
+                              ? liveStateGroupCatalogs.get(ws.cwd)
+                              : undefined
+                          }
+                          sessionLiveStateEnabled={
+                            workspaceSessionLiveStateEnabled &&
+                            liveStateWorkspaceCwdSet.has(ws.cwd)
+                          }
                           sourceType={selectedSessionSource}
                           channelGroupingEnabled={channelGroupingEnabled}
                           ungroupedLabel={t('sidebar.groupUngrouped')}

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import type { ReactNode } from 'react';
 import type {
   DaemonClient,
+  DaemonSessionGroupCatalog,
   DaemonSessionSummary,
   DaemonWorkspaceCapability,
   DaemonWorkspaceGitStatus,
@@ -129,6 +130,9 @@ function renderSection(
     sourceType: string;
     channelGroupingEnabled: boolean;
     organizationEnabled: boolean;
+    sessionCatalogRequestsEnabled: boolean;
+    sessionGroupCatalog: DaemonSessionGroupCatalog;
+    sessionLiveStateEnabled: boolean;
   }> = {},
 ): void {
   act(() => {
@@ -145,6 +149,11 @@ function renderSection(
           noSessionsLabel="No sessions"
           loadErrorLabel="Load failed"
           organizationEnabled={overrides.organizationEnabled ?? false}
+          sessionCatalogRequestsEnabled={
+            overrides.sessionCatalogRequestsEnabled
+          }
+          sessionGroupCatalog={overrides.sessionGroupCatalog}
+          sessionLiveStateEnabled={overrides.sessionLiveStateEnabled}
           sourceType={overrides.sourceType}
           channelGroupingEnabled={overrides.channelGroupingEnabled}
           ungroupedLabel="Ungrouped"
@@ -481,6 +490,75 @@ describe('WorkspaceSection label', () => {
     // Channel mode discards the organization sections, so the catalog fetch
     // must be skipped too, mirroring the sidebar's own org prefetch gates.
     expect(listSessionGroups).not.toHaveBeenCalled();
+  });
+
+  it('never bypasses a fenced group catalog for a global reload token', async () => {
+    const listSessionGroups = vi
+      .fn()
+      .mockResolvedValue({ groups: [], colorOptions: [] });
+    const client = {
+      workspaceByCwd: vi.fn(() => ({
+        workspaceGit,
+        listWorkspaceSessionsPage: vi.fn().mockResolvedValue({ sessions: [] }),
+        listSessionGroups,
+      })),
+    } as unknown as DaemonClient;
+
+    renderSection({
+      client,
+      expanded: true,
+      organizationEnabled: true,
+      sessionLiveStateEnabled: true,
+      reloadToken: 0,
+    });
+    await flush();
+    expect(listSessionGroups).not.toHaveBeenCalled();
+
+    renderSection({
+      client,
+      expanded: true,
+      organizationEnabled: true,
+      sessionLiveStateEnabled: true,
+      reloadToken: 1,
+    });
+    await flush();
+    expect(listSessionGroups).not.toHaveBeenCalled();
+  });
+
+  it('defers legacy catalog requests until capability discovery completes', async () => {
+    const listWorkspaceSessionsPage = vi
+      .fn()
+      .mockResolvedValue({ sessions: [] });
+    const listSessionGroups = vi
+      .fn()
+      .mockResolvedValue({ groups: [], colorOptions: [] });
+    const client = {
+      workspaceByCwd: vi.fn(() => ({
+        workspaceGit,
+        listWorkspaceSessionsPage,
+        listSessionGroups,
+      })),
+    } as unknown as DaemonClient;
+
+    renderSection({
+      client,
+      expanded: true,
+      organizationEnabled: true,
+      sessionCatalogRequestsEnabled: false,
+    });
+    await flush();
+    expect(listWorkspaceSessionsPage).not.toHaveBeenCalled();
+    expect(listSessionGroups).not.toHaveBeenCalled();
+
+    renderSection({
+      client,
+      expanded: true,
+      organizationEnabled: true,
+      sessionCatalogRequestsEnabled: true,
+    });
+    await flush();
+    expect(listWorkspaceSessionsPage).toHaveBeenCalledTimes(1);
+    expect(listSessionGroups).toHaveBeenCalledTimes(1);
   });
 
   it('renders channel sessions flat while the channel catalog failed to load', async () => {
@@ -833,6 +911,43 @@ describe('WorkspaceSection session loading', () => {
 
     expect(listWorkspaceSessionsPage).toHaveBeenCalledTimes(2);
     expect(container.textContent).toContain('Updated session');
+  });
+
+  it('does not refresh a retained catalog when live-state owns freshness', async () => {
+    const listWorkspaceSessionsPage = vi.fn().mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'session-1',
+          displayName: 'Initial session',
+        } as DaemonSessionSummary,
+      ],
+    });
+    const client = {
+      workspaceByCwd: vi.fn(() => ({
+        workspaceGit,
+        listWorkspaceSessionsPage,
+        listSessionGroups: vi.fn().mockResolvedValue({ groups: [] }),
+      })),
+    } as unknown as DaemonClient;
+
+    renderSection({ client, expanded: true });
+    await flush();
+    expect(listWorkspaceSessionsPage).toHaveBeenCalledTimes(1);
+
+    renderSection({
+      client,
+      expanded: false,
+      sessionLiveStateEnabled: true,
+    });
+    await flush();
+    renderSection({
+      client,
+      expanded: true,
+      sessionLiveStateEnabled: true,
+    });
+    await flush();
+
+    expect(listWorkspaceSessionsPage).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -1140,3 +1140,14 @@ describe('WorkspaceSection git chip', () => {
     expect(gitChip()).toBeNull();
   });
 });
+
+describe('isAbsolutePath', () => {
+  it('accepts unix, Windows and UNC absolute paths and rejects relative ones', async () => {
+    const { isAbsolutePath } = await import('./WorkspaceSection');
+    expect(isAbsolutePath('/x')).toBe(true);
+    expect(isAbsolutePath('C:\\x')).toBe(true);
+    expect(isAbsolutePath('\\\\server\\share')).toBe(true);
+    expect(isAbsolutePath('relative/path')).toBe(false);
+    expect(isAbsolutePath('name')).toBe(false);
+  });
+});

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -6,7 +6,10 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import type { DaemonClient } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonClient,
+  DaemonSessionGroupCatalog,
+} from '@qwen-code/sdk/daemon';
 import type {
   DaemonChannelsSnapshot,
   DaemonChannelTypeCatalog,
@@ -85,6 +88,9 @@ interface WorkspaceSectionProps {
   noSessionsLabel: string;
   loadErrorLabel: string;
   organizationEnabled: boolean;
+  sessionCatalogRequestsEnabled?: boolean;
+  sessionGroupCatalog?: DaemonSessionGroupCatalog;
+  sessionLiveStateEnabled?: boolean;
   sourceType?: string;
   channelGroupingEnabled?: boolean;
   ungroupedLabel: string;
@@ -129,6 +135,9 @@ export function WorkspaceSection({
   noSessionsLabel,
   loadErrorLabel,
   organizationEnabled,
+  sessionCatalogRequestsEnabled = true,
+  sessionGroupCatalog,
+  sessionLiveStateEnabled = false,
   sourceType,
   channelGroupingEnabled = false,
   ungroupedLabel,
@@ -219,9 +228,14 @@ export function WorkspaceSection({
     [organizationEnabled, sourceType, workspace.cwd],
   );
   const sessionsResult = useSessionCatalogQuery(client, sessionsQuery, {
-    autoLoad: true,
+    autoLoad: sessionCatalogRequestsEnabled && !sessionLiveStateEnabled,
     enabled: sessionsEnabled && sessionsVisible,
-    ...(sessionsVisible && !readOnly ? { pollIntervalMs: 10_000 } : {}),
+    ...(sessionCatalogRequestsEnabled &&
+    sessionsVisible &&
+    !readOnly &&
+    !sessionLiveStateEnabled
+      ? { pollIntervalMs: 10_000 }
+      : {}),
   });
   const {
     page: sessionsPage,
@@ -238,6 +252,8 @@ export function WorkspaceSection({
     previousSessionsActiveRef.current = sessionsActive;
     previousReadOnlyRef.current = readOnly;
     if (
+      sessionCatalogRequestsEnabled &&
+      !sessionLiveStateEnabled &&
       sessionsActive &&
       (!wasActive || wasReadOnly !== readOnly) &&
       sessionsPage &&
@@ -245,7 +261,15 @@ export function WorkspaceSection({
     ) {
       void reloadSessions().catch(() => undefined);
     }
-  }, [readOnly, reloadSessions, sessionsActive, sessionsPage, sessionsStale]);
+  }, [
+    readOnly,
+    reloadSessions,
+    sessionCatalogRequestsEnabled,
+    sessionLiveStateEnabled,
+    sessionsActive,
+    sessionsPage,
+    sessionsStale,
+  ]);
   const sessions = sessionsResult.sessions;
   const loadError = Boolean(sessionsResult.error);
 
@@ -265,6 +289,11 @@ export function WorkspaceSection({
       channelGroupingEnabled
     ) {
       setGroups([]);
+      return;
+    }
+    if (!sessionCatalogRequestsEnabled) return;
+    if (sessionLiveStateEnabled) {
+      if (sessionGroupCatalog) setGroups(sessionGroupCatalog.groups);
       return;
     }
     let cancelled = false;
@@ -287,6 +316,9 @@ export function WorkspaceSection({
     organizationEnabled,
     reloadToken,
     renderSessions,
+    sessionCatalogRequestsEnabled,
+    sessionGroupCatalog,
+    sessionLiveStateEnabled,
     workspace.cwd,
   ]);
 

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -54,7 +54,7 @@ function cx(...classes: Array<string | false | undefined>): string {
 // A synthetic fallback workspace (daemon reports no workspaces and the
 // connection has no cwd) carries a display name in `cwd`, which is neither, so
 // qualifying a request with it would only ever 400.
-function isAbsolutePath(cwd: string): boolean {
+export function isAbsolutePath(cwd: string): boolean {
   return (
     cwd.startsWith('/') || cwd.startsWith('\\') || /^[a-zA-Z]:[\\/]/.test(cwd)
   );
@@ -293,7 +293,9 @@ export function WorkspaceSection({
     }
     if (!sessionCatalogRequestsEnabled) return;
     if (sessionLiveStateEnabled) {
-      if (sessionGroupCatalog) setGroups(sessionGroupCatalog.groups);
+      // Live-state owns group freshness here; while its catalog is pending
+      // there is no valid group data, so clear rather than render stale.
+      setGroups(sessionGroupCatalog?.groups ?? []);
       return;
     }
     let cancelled = false;

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -14,6 +14,7 @@ import {
   type DaemonSessionArtifactsEnvelope,
   type DaemonSessionGroup,
   type DaemonSessionGroupCatalog,
+  type DaemonSessionCatalogVersion,
   type DaemonSessionState,
   type DaemonSessionSummary,
   type DaemonWorkspaceExtensionsStatus,
@@ -64,6 +65,7 @@ export interface WebShellDaemonScenario {
   pairingGroupApprovals: Record<string, string[]>;
   sessions: DaemonSessionSummary[];
   sessionGroups: DaemonSessionGroup[];
+  sessionCatalogVersion: DaemonSessionCatalogVersion;
   events: DaemonEvent[];
   state: DaemonSessionState;
   /** Artifact list returned by `GET /session/:id/artifacts`. */
@@ -128,6 +130,7 @@ type ScenarioOverrides = Partial<
     | 'pairingGroupApprovals'
     | 'sessions'
     | 'sessionGroups'
+    | 'sessionCatalogVersion'
     | 'state'
   >
 > & {
@@ -146,6 +149,7 @@ type ScenarioOverrides = Partial<
   pairingGroupApprovals?: Record<string, string[]>;
   sessions?: DaemonSessionSummary[];
   sessionGroups?: DaemonSessionGroup[];
+  sessionCatalogVersion?: DaemonSessionCatalogVersion;
   state?: Partial<DaemonSessionState>;
 };
 
@@ -362,6 +366,10 @@ export function createWebShellDaemonScenario(
     pairingGroupApprovals: overrides.pairingGroupApprovals ?? {},
     sessions,
     sessionGroups: overrides.sessionGroups ?? [],
+    sessionCatalogVersion: overrides.sessionCatalogVersion ?? {
+      generation: 'web-shell-e2e',
+      revision: 0,
+    },
     events: overrides.events ?? [],
     state,
     artifacts: overrides.artifacts ?? [],
@@ -617,7 +625,9 @@ function isDaemonPath(path: string): boolean {
     /^\/workspaces\/[^/]+\/channels\/[^/]+\/?$/.test(path) ||
     /^\/workspace\/.+\/sessions\/?$/.test(path) ||
     /^\/workspaces\/[^/]+\/sessions\/?$/.test(path) ||
+    /^\/workspaces\/[^/]+\/sessions\/live-state\/?$/.test(path) ||
     /^\/workspace\/.+\/session-groups\/?$/.test(path) ||
+    /^\/workspaces\/[^/]+\/session-groups\/?$/.test(path) ||
     /^\/workspaces\/.+\/git\/?$/.test(path) ||
     /^\/workspaces\/.+\/git\/(branches|checkout|branch|push|pull|commit|diff|log)\/?$/.test(
       path,
@@ -690,12 +700,22 @@ function isDaemonRoute(method: string, path: string): boolean {
   }
   if (
     method === 'GET' &&
+    /^\/workspaces\/[^/]+\/sessions\/live-state\/?$/.test(path)
+  ) {
+    return true;
+  }
+  if (
+    method === 'GET' &&
     (/^\/workspace\/.+\/sessions\/?$/.test(path) ||
       /^\/workspaces\/[^/]+\/sessions\/?$/.test(path))
   ) {
     return true;
   }
-  if (method === 'GET' && /^\/workspace\/.+\/session-groups\/?$/.test(path)) {
+  if (
+    method === 'GET' &&
+    (/^\/workspace\/.+\/session-groups\/?$/.test(path) ||
+      /^\/workspaces\/[^/]+\/session-groups\/?$/.test(path))
+  ) {
     return true;
   }
   if (
@@ -905,6 +925,31 @@ async function handleDaemonRoute(
   }
   if (
     method === 'GET' &&
+    /^\/workspaces\/[^/]+\/sessions\/live-state\/?$/.test(path)
+  ) {
+    await json(route, {
+      v: 1,
+      catalogVersion: scenario.sessionCatalogVersion,
+      sessions: scenario.sessions
+        .filter(
+          (session) =>
+            (session.clientCount ?? 0) > 0 ||
+            session.hasActivePrompt === true ||
+            session.isWaitingForPermission === true ||
+            session.isWaitingForUserQuestion === true,
+        )
+        .map((session) => ({
+          sessionId: session.sessionId,
+          clientCount: session.clientCount ?? 0,
+          hasActivePrompt: session.hasActivePrompt ?? false,
+          isWaitingForPermission: session.isWaitingForPermission ?? false,
+          isWaitingForUserQuestion: session.isWaitingForUserQuestion ?? false,
+        })),
+    });
+    return;
+  }
+  if (
+    method === 'GET' &&
     (/^\/workspace\/.+\/sessions\/?$/.test(path) ||
       /^\/workspaces\/[^/]+\/sessions\/?$/.test(path))
   ) {
@@ -913,7 +958,11 @@ async function handleDaemonRoute(
     });
     return;
   }
-  if (method === 'GET' && /^\/workspace\/.+\/session-groups\/?$/.test(path)) {
+  if (
+    method === 'GET' &&
+    (/^\/workspace\/.+\/session-groups\/?$/.test(path) ||
+      /^\/workspaces\/[^/]+\/session-groups\/?$/.test(path))
+  ) {
     const catalog: DaemonSessionGroupCatalog = {
       groups: scenario.sessionGroups,
       colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],

--- a/packages/web-shell/client/e2e/web-shell.session-live-state.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.session-live-state.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import {
+  createWebShellDaemonScenario,
+  installMockDaemon,
+} from './utils/mockDaemon';
+
+test('uses live-state instead of polling the full session catalog @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    capabilities: {
+      features: [
+        'session_events',
+        'session_source_metadata',
+        'workspace_session_live_state',
+      ],
+    },
+  });
+  const daemon = await installMockDaemon(page, scenario, {
+    baseURL: String(testInfo.project.use.baseURL),
+  });
+  const fullCatalogRequests = () =>
+    daemon.requests.filter(
+      (request) =>
+        request.method === 'GET' &&
+        (/^\/workspace\/.+\/sessions\/?$/.test(request.path) ||
+          /^\/workspaces\/[^/]+\/sessions\/?$/.test(request.path)),
+    ).length;
+  const liveStateRequests = () =>
+    daemon.requests.filter(
+      (request) =>
+        request.method === 'GET' &&
+        /^\/workspaces\/[^/]+\/sessions\/live-state\/?$/.test(request.path),
+    ).length;
+
+  await page.goto(`/session/${encodeURIComponent(scenario.sessionId)}`);
+  await expect(page.locator('[data-web-shell-root]')).toBeVisible();
+  await expect.poll(liveStateRequests).toBeGreaterThanOrEqual(2);
+  const settledCatalogRequests = fullCatalogRequests();
+  const settledLiveStateRequests = liveStateRequests();
+  expect(settledCatalogRequests).toBe(1);
+
+  await expect
+    .poll(liveStateRequests)
+    .toBeGreaterThan(settledLiveStateRequests);
+  expect(fullCatalogRequests()).toBe(settledCatalogRequests);
+
+  await page.getByRole('tab', { name: 'Channels' }).click();
+  await expect.poll(fullCatalogRequests).toBe(settledCatalogRequests + 1);
+  const requestsAfterSourceChange = fullCatalogRequests();
+  const liveRequestsAfterSourceChange = liveStateRequests();
+
+  await expect
+    .poll(liveStateRequests)
+    .toBeGreaterThan(liveRequestsAfterSourceChange);
+  expect(fullCatalogRequests()).toBe(requestsAfterSourceChange);
+});

--- a/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
@@ -191,6 +191,7 @@ export function useSessionCatalogController(client: DaemonClient) {
       sessionCreated(workspaceCwd: string, _sessionId: string) {
         update(() => {
           store.invalidateWorkspace(workspaceCwd);
+          if (store.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
           store.scheduleWorkspaceRefresh(workspaceCwd);
         });
       },
@@ -199,6 +200,7 @@ export function useSessionCatalogController(client: DaemonClient) {
           store.patchSession(workspaceCwd, sessionId, {
             hasActivePrompt: true,
           });
+          if (store.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
           store.invalidateWorkspace(workspaceCwd);
           store.scheduleWorkspaceRefresh(workspaceCwd);
         });
@@ -206,6 +208,7 @@ export function useSessionCatalogController(client: DaemonClient) {
       promptAdmissionUncertain(workspaceCwd: string) {
         update(() => {
           store.invalidateWorkspace(workspaceCwd);
+          if (store.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
           store.scheduleWorkspaceRefresh(workspaceCwd);
         });
       },
@@ -217,6 +220,7 @@ export function useSessionCatalogController(client: DaemonClient) {
       },
       turnCompleted(workspaceCwd: string) {
         update(() => {
+          if (store.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
           store.invalidateWorkspace(workspaceCwd);
           store.scheduleWorkspaceRefresh(workspaceCwd);
         });

--- a/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
@@ -220,7 +220,13 @@ export function useSessionCatalogController(client: DaemonClient) {
       },
       turnCompleted(workspaceCwd: string) {
         update(() => {
-          if (store.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
+          if (store.isWorkspaceLiveStateEnabled(workspaceCwd)) {
+            // The catalog revision doesn't advance on turn completion and
+            // the live-state overlay carries no updatedAt — flag a
+            // rate-limited reconcile so activity stamps keep refreshing.
+            store.requestWorkspaceLiveStateInvalidation(workspaceCwd);
+            return;
+          }
           store.invalidateWorkspace(workspaceCwd);
           store.scheduleWorkspaceRefresh(workspaceCwd);
         });

--- a/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
@@ -496,6 +496,243 @@ describe('SessionCatalogStore', () => {
     );
   });
 
+  it('overlays live state and clears volatile fields for persisted-only sessions', async () => {
+    legacy.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'live',
+          workspaceCwd: '/work',
+          displayName: 'Live session',
+          clientCount: 0,
+          hasActivePrompt: false,
+        },
+        {
+          sessionId: 'persisted',
+          workspaceCwd: '/work',
+          displayName: 'Persisted session',
+          clientCount: 2,
+          hasActivePrompt: true,
+          isWaitingForPermission: true,
+          isWaitingForUserQuestion: true,
+        },
+      ],
+    });
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'live',
+        clientCount: 1,
+        hasActivePrompt: true,
+        isWaitingForPermission: true,
+        isWaitingForUserQuestion: false,
+      },
+    ]);
+
+    expect(store.getSnapshot(target).page?.sessions).toEqual([
+      expect.objectContaining({
+        sessionId: 'live',
+        displayName: 'Live session',
+        clientCount: 1,
+        hasActivePrompt: true,
+        isWaitingForPermission: true,
+        isWaitingForUserQuestion: false,
+      }),
+      expect.objectContaining({
+        sessionId: 'persisted',
+        displayName: 'Persisted session',
+        clientCount: 0,
+        hasActivePrompt: false,
+        isWaitingForPermission: false,
+        isWaitingForUserQuestion: false,
+      }),
+    ]);
+  });
+
+  it('stages active queries through the qualified route and stales retained pages', async () => {
+    legacy.mockImplementation(async (cwd: string) => page(cwd, cwd));
+    const active = query('/work');
+    const pinned = {
+      ...query('/work'),
+      options: { ...query('/work').options, view: 'organized' as const },
+    };
+    const other = query('/other');
+    await store.loadOnce(active, { fresh: true });
+    await store.loadOnce(pinned, { fresh: true });
+    await store.loadOnce(other, { fresh: true });
+    const unsubscribe = store.subscribe(active, vi.fn());
+    const activeBefore = store.getSnapshot(active).page;
+    const pinnedBefore = store.getSnapshot(pinned).page;
+    qualified.mockResolvedValue(page('fresh'));
+
+    const staged = await store.stageWorkspaceRefresh('/work');
+
+    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(3);
+    expect(store.getSnapshot(active).page).toBe(activeBefore);
+    expect(store.getSnapshot(pinned).page).toBe(pinnedBefore);
+    expect(store.getSnapshot(active).stale).toBe(true);
+    expect(store.commitWorkspaceRefresh(staged)).toBe(true);
+    expect(store.getSnapshot(active).stale).toBe(false);
+    expect(store.getSnapshot(pinned).stale).toBe(true);
+    expect(store.getSnapshot(other).stale).toBe(false);
+    expect(store.getSnapshot(active).page?.sessions[0]?.sessionId).toBe(
+      'fresh',
+    );
+    unsubscribe();
+  });
+
+  it('routes live workspace invalidations and new queries through reconciliation', async () => {
+    legacy.mockResolvedValue(page('cached'));
+    const active = query('/work');
+    await store.loadOnce(active, { fresh: true });
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+
+    store.invalidateWorkspace('/work');
+    const unsubscribeActive = store.subscribe(active, vi.fn(), {
+      autoLoad: true,
+    });
+
+    expect(legacy).toHaveBeenCalledTimes(1);
+    expect(qualified).not.toHaveBeenCalled();
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(true);
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(false);
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushMicrotasks();
+    expect(legacy).toHaveBeenCalledTimes(1);
+
+    const channel = {
+      ...active,
+      options: { ...active.options, sourceType: 'channel' },
+    };
+    const unsubscribeChannel = store.subscribe(channel, vi.fn());
+
+    expect(legacy).toHaveBeenCalledTimes(1);
+    expect(qualified).not.toHaveBeenCalled();
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(true);
+
+    unsubscribeChannel();
+    releaseLiveState();
+    unsubscribeActive();
+  });
+
+  it('resolves an explicit live-state refresh only from a staged commit', async () => {
+    legacy.mockResolvedValue(page('cached'));
+    qualified.mockResolvedValue(page('refreshed'));
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+
+    const refresh = store.refresh(target);
+
+    expect(legacy).toHaveBeenCalledTimes(1);
+    expect(qualified).not.toHaveBeenCalled();
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(true);
+
+    const staged = await store.stageWorkspaceRefresh('/work');
+    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot(target).page).toEqual(page('cached'));
+    expect(store.commitWorkspaceRefresh(staged)).toBe(true);
+    await expect(refresh).resolves.toEqual(page('refreshed'));
+
+    releaseLiveState();
+  });
+
+  it('resumes an explicit refresh when live-state ownership is released', async () => {
+    legacy
+      .mockResolvedValueOnce(page('cached'))
+      .mockResolvedValueOnce(page('legacy-refresh'));
+    const stagedResponse = deferred<DaemonSessionListPage>();
+    qualified.mockReturnValueOnce(stagedResponse.promise);
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+    const refresh = store.refresh(target);
+    const stagedPromise = store.stageWorkspaceRefresh('/work');
+    expect(qualified).toHaveBeenCalledTimes(1);
+
+    releaseLiveState();
+    stagedResponse.resolve(page('staged'));
+    await stagedPromise;
+    await flushMicrotasks();
+
+    expect(legacy).toHaveBeenCalledTimes(2);
+    await expect(refresh).resolves.toEqual(page('legacy-refresh'));
+  });
+
+  it('does not publish an older request or a staged page before commit', async () => {
+    const initial = deferred<DaemonSessionListPage>();
+    const stagedResponse = deferred<DaemonSessionListPage>();
+    legacy.mockReturnValueOnce(initial.promise);
+    qualified.mockReturnValueOnce(stagedResponse.promise);
+    const target = query('/work');
+    const unsubscribe = store.subscribe(target, vi.fn(), { autoLoad: true });
+
+    const stagedPromise = store.stageWorkspaceRefresh('/work');
+    initial.resolve(page('superseded'));
+    await flushMicrotasks();
+    expect(legacy).toHaveBeenCalledTimes(1);
+    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot(target).page).toBeUndefined();
+
+    stagedResponse.resolve(page('staged'));
+    const staged = await stagedPromise;
+    expect(store.getSnapshot(target).page).toBeUndefined();
+    expect(store.commitWorkspaceRefresh(staged)).toBe(true);
+    expect(store.getSnapshot(target).page).toEqual(page('staged'));
+    unsubscribe();
+  });
+
+  it('queues an explicit refresh behind staging and rejects the stale commit', async () => {
+    legacy.mockResolvedValueOnce(page('cached'));
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+    const unsubscribe = store.subscribe(target, vi.fn());
+    const stagedResponse = deferred<DaemonSessionListPage>();
+    const refreshedResponse = deferred<DaemonSessionListPage>();
+    qualified.mockReturnValueOnce(stagedResponse.promise);
+    legacy.mockReturnValueOnce(refreshedResponse.promise);
+
+    const stagedPromise = store.stageWorkspaceRefresh('/work');
+    const refreshPromise = store.refresh(target);
+    expect(qualified).toHaveBeenCalledTimes(1);
+    stagedResponse.resolve(page('staged'));
+    const staged = await stagedPromise;
+
+    expect(store.commitWorkspaceRefresh(staged)).toBe(false);
+    expect(store.getSnapshot(target).page).toEqual(page('cached'));
+    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(2);
+    refreshedResponse.resolve(page('refreshed'));
+    await expect(refreshPromise).resolves.toEqual(page('refreshed'));
+    unsubscribe();
+  });
+
+  it('does not supersede an explicit request that started before staging', async () => {
+    const response = deferred<DaemonSessionListPage>();
+    legacy.mockReturnValueOnce(response.promise);
+    const target = query('/work');
+    const request = store.loadOnce(target, { fresh: true });
+
+    const staged = await store.stageWorkspaceRefresh('/work');
+
+    expect(staged.complete).toBe(false);
+    expect(qualified).not.toHaveBeenCalled();
+    response.resolve(page('explicit'));
+    await expect(request).resolves.toEqual(page('explicit'));
+  });
+
   it('uses the qualified client only for qualified queries', async () => {
     qualified.mockResolvedValue({
       sessions: [{ sessionId: 'qualified' }],

--- a/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
@@ -550,7 +550,7 @@ describe('SessionCatalogStore', () => {
     ]);
   });
 
-  it('stages active queries through the qualified route and stales retained pages', async () => {
+  it('stages active queries through their own route kind and stales retained pages', async () => {
     legacy.mockImplementation(async (cwd: string) => page(cwd, cwd));
     const active = query('/work');
     const pinned = {
@@ -568,8 +568,8 @@ describe('SessionCatalogStore', () => {
 
     const staged = await store.stageWorkspaceRefresh('/work');
 
-    expect(qualified).toHaveBeenCalledTimes(1);
-    expect(legacy).toHaveBeenCalledTimes(3);
+    expect(qualified).not.toHaveBeenCalled();
+    expect(legacy).toHaveBeenCalledTimes(4);
     expect(store.getSnapshot(active).page).toBe(activeBefore);
     expect(store.getSnapshot(pinned).page).toBe(pinnedBefore);
     expect(store.getSnapshot(active).stale).toBe(true);
@@ -578,7 +578,7 @@ describe('SessionCatalogStore', () => {
     expect(store.getSnapshot(pinned).stale).toBe(true);
     expect(store.getSnapshot(other).stale).toBe(false);
     expect(store.getSnapshot(active).page?.sessions[0]?.sessionId).toBe(
-      'fresh',
+      '/work',
     );
     unsubscribe();
   });
@@ -596,8 +596,12 @@ describe('SessionCatalogStore', () => {
 
     expect(legacy).toHaveBeenCalledTimes(1);
     expect(qualified).not.toHaveBeenCalled();
-    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(true);
-    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(false);
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(
+      'interactive',
+    );
+    expect(
+      store.consumeWorkspaceLiveStateRefreshRequest('/work'),
+    ).toBeUndefined();
 
     Object.defineProperty(document, 'hidden', {
       configurable: true,
@@ -620,7 +624,9 @@ describe('SessionCatalogStore', () => {
 
     expect(legacy).toHaveBeenCalledTimes(1);
     expect(qualified).not.toHaveBeenCalled();
-    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(true);
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(
+      'interactive',
+    );
 
     unsubscribeChannel();
     releaseLiveState();
@@ -628,8 +634,9 @@ describe('SessionCatalogStore', () => {
   });
 
   it('resolves an explicit live-state refresh only from a staged commit', async () => {
-    legacy.mockResolvedValue(page('cached'));
-    qualified.mockResolvedValue(page('refreshed'));
+    legacy
+      .mockResolvedValueOnce(page('cached'))
+      .mockResolvedValueOnce(page('refreshed'));
     const target = query('/work');
     await store.loadOnce(target, { fresh: true });
     const releaseLiveState = store.retainWorkspaceLiveState('/work');
@@ -638,10 +645,13 @@ describe('SessionCatalogStore', () => {
 
     expect(legacy).toHaveBeenCalledTimes(1);
     expect(qualified).not.toHaveBeenCalled();
-    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(true);
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(
+      'interactive',
+    );
 
     const staged = await store.stageWorkspaceRefresh('/work');
-    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(2);
+    expect(qualified).not.toHaveBeenCalled();
     expect(store.getSnapshot(target).page).toEqual(page('cached'));
     expect(store.commitWorkspaceRefresh(staged)).toBe(true);
     await expect(refresh).resolves.toEqual(page('refreshed'));
@@ -650,40 +660,42 @@ describe('SessionCatalogStore', () => {
   });
 
   it('resumes an explicit refresh when live-state ownership is released', async () => {
+    const stagedResponse = deferred<DaemonSessionListPage>();
     legacy
       .mockResolvedValueOnce(page('cached'))
+      .mockReturnValueOnce(stagedResponse.promise)
       .mockResolvedValueOnce(page('legacy-refresh'));
-    const stagedResponse = deferred<DaemonSessionListPage>();
-    qualified.mockReturnValueOnce(stagedResponse.promise);
     const target = query('/work');
     await store.loadOnce(target, { fresh: true });
     const releaseLiveState = store.retainWorkspaceLiveState('/work');
     const refresh = store.refresh(target);
     const stagedPromise = store.stageWorkspaceRefresh('/work');
-    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(2);
+    expect(qualified).not.toHaveBeenCalled();
 
     releaseLiveState();
     stagedResponse.resolve(page('staged'));
     await stagedPromise;
     await flushMicrotasks();
 
-    expect(legacy).toHaveBeenCalledTimes(2);
+    expect(legacy).toHaveBeenCalledTimes(3);
     await expect(refresh).resolves.toEqual(page('legacy-refresh'));
   });
 
   it('does not publish an older request or a staged page before commit', async () => {
     const initial = deferred<DaemonSessionListPage>();
     const stagedResponse = deferred<DaemonSessionListPage>();
-    legacy.mockReturnValueOnce(initial.promise);
-    qualified.mockReturnValueOnce(stagedResponse.promise);
+    legacy
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(stagedResponse.promise);
     const target = query('/work');
     const unsubscribe = store.subscribe(target, vi.fn(), { autoLoad: true });
 
     const stagedPromise = store.stageWorkspaceRefresh('/work');
     initial.resolve(page('superseded'));
     await flushMicrotasks();
-    expect(legacy).toHaveBeenCalledTimes(1);
-    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(2);
+    expect(qualified).not.toHaveBeenCalled();
     expect(store.getSnapshot(target).page).toBeUndefined();
 
     stagedResponse.resolve(page('staged'));
@@ -701,19 +713,20 @@ describe('SessionCatalogStore', () => {
     const unsubscribe = store.subscribe(target, vi.fn());
     const stagedResponse = deferred<DaemonSessionListPage>();
     const refreshedResponse = deferred<DaemonSessionListPage>();
-    qualified.mockReturnValueOnce(stagedResponse.promise);
-    legacy.mockReturnValueOnce(refreshedResponse.promise);
+    legacy
+      .mockReturnValueOnce(stagedResponse.promise)
+      .mockReturnValueOnce(refreshedResponse.promise);
 
     const stagedPromise = store.stageWorkspaceRefresh('/work');
     const refreshPromise = store.refresh(target);
-    expect(qualified).toHaveBeenCalledTimes(1);
+    expect(legacy).toHaveBeenCalledTimes(2);
+    expect(qualified).not.toHaveBeenCalled();
     stagedResponse.resolve(page('staged'));
     const staged = await stagedPromise;
 
     expect(store.commitWorkspaceRefresh(staged)).toBe(false);
     expect(store.getSnapshot(target).page).toEqual(page('cached'));
-    expect(qualified).toHaveBeenCalledTimes(1);
-    expect(legacy).toHaveBeenCalledTimes(2);
+    expect(legacy).toHaveBeenCalledTimes(3);
     refreshedResponse.resolve(page('refreshed'));
     await expect(refreshPromise).resolves.toEqual(page('refreshed'));
     unsubscribe();
@@ -731,6 +744,93 @@ describe('SessionCatalogStore', () => {
     expect(qualified).not.toHaveBeenCalled();
     response.resolve(page('explicit'));
     await expect(request).resolves.toEqual(page('explicit'));
+  });
+
+  it('resolves a non-coordinated waiter after a live-mode invalidation', async () => {
+    const initial = deferred<DaemonSessionListPage>();
+    legacy
+      .mockReturnValueOnce(initial.promise)
+      .mockResolvedValueOnce(page('rescued'));
+    const target = query('/work');
+    const request = store.loadOnce(target, { fresh: true });
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+
+    store.invalidateWorkspace('/work');
+
+    initial.resolve(page('stale'));
+    await flushMicrotasks();
+    // The invalidation bumped the revision past the in-flight job; a real
+    // follow-up job must settle the pre-live waiter.
+    await expect(request).resolves.toEqual(page('rescued'));
+    expect(legacy).toHaveBeenCalledTimes(2);
+    releaseLiveState();
+  });
+
+  it('scopes a staged failure to the failing entry', async () => {
+    legacy.mockResolvedValue(page('cached'));
+    const active = query('/work');
+    const pinned = {
+      ...query('/work'),
+      options: { ...query('/work').options, view: 'organized' as const },
+    };
+    await store.loadOnce(active, { fresh: true });
+    await store.loadOnce(pinned, { fresh: true });
+    const unsubscribeActive = store.subscribe(active, vi.fn());
+    const unsubscribePinned = store.subscribe(pinned, vi.fn());
+    let calls = 0;
+    legacy.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 2) throw new Error('pinned blip');
+      return page('fresh');
+    });
+
+    await expect(store.stageWorkspaceRefresh('/work')).rejects.toThrow(
+      'pinned blip',
+    );
+
+    expect(store.getSnapshot(active).error).toBeUndefined();
+    expect(store.getSnapshot(active).loading).toBe(false);
+    expect(store.getSnapshot(pinned).error?.message).toBe('pinned blip');
+    expect(store.getSnapshot(pinned).loading).toBe(false);
+    unsubscribeActive();
+    unsubscribePinned();
+  });
+
+  it('flags an interactive refresh when a live-mode subscriber maxAge expires', async () => {
+    legacy.mockResolvedValue(page('cached'));
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+
+    vi.advanceTimersByTime(2_000);
+    const unsubscribe = store.subscribe(target, vi.fn(), {
+      autoLoad: true,
+      maxAgeMs: 1_000,
+    });
+
+    expect(store.consumeWorkspaceLiveStateRefreshRequest('/work')).toBe(
+      'interactive',
+    );
+    unsubscribe();
+    releaseLiveState();
+  });
+
+  it('wakes live-state listeners for interactive refreshes only', () => {
+    const wake = vi.fn();
+    const stopWake = store.onLiveStateWake(wake);
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+    legacy.mockResolvedValue(page('cached'));
+
+    store.invalidateWorkspace('/work');
+    expect(wake).not.toHaveBeenCalled();
+
+    // The waiter settles via a later staged commit (not exercised here), so
+    // drop the promise; the wake fires synchronously inside refresh().
+    void store.refresh(query('/work')).catch(() => undefined);
+    expect(wake).toHaveBeenCalledWith('/work');
+
+    stopWake();
+    releaseLiveState();
   });
 
   it('uses the qualified client only for qualified queries', async () => {

--- a/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
@@ -833,6 +833,40 @@ describe('SessionCatalogStore', () => {
     releaseLiveState();
   });
 
+  it('does not let a trailing non-staged job settle staged-revision waiters', async () => {
+    const initial = deferred<DaemonSessionListPage>();
+    const trailing = deferred<DaemonSessionListPage>();
+    const stagedResponse = deferred<DaemonSessionListPage>();
+    legacy
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(trailing.promise)
+      .mockReturnValueOnce(stagedResponse.promise);
+    const target = query('/work');
+    // A legacy background job is in flight when live-state takes over.
+    const unsubscribe = store.subscribe(target, vi.fn(), { autoLoad: true });
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+
+    // Staging begins while the legacy job runs; the follower loadOnce arms
+    // a trailing non-staged job at the staging-target revision.
+    const stagedPromise = store.stageWorkspaceRefresh('/work');
+    const followUp = store.loadOnce(target);
+    initial.resolve(page('initial'));
+    await flushMicrotasks();
+
+    // The trailing job fails at the staged revision: it must not reject
+    // the waiters the staged commit is about to resolve.
+    trailing.reject(new Error('trailing blip'));
+    stagedResponse.resolve(page('staged'));
+    const staged = await stagedPromise;
+    expect(staged.complete).toBe(true);
+    expect(store.commitWorkspaceRefresh(staged)).toBe(true);
+    await expect(followUp).resolves.toEqual(page('staged'));
+    expect(store.getSnapshot(target).error).toBeUndefined();
+
+    unsubscribe();
+    releaseLiveState();
+  });
+
   it('uses the qualified client only for qualified queries', async () => {
     qualified.mockResolvedValue({
       sessions: [{ sessionId: 'qualified' }],

--- a/packages/web-shell/client/session-catalog/session-catalog-store.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.ts
@@ -148,7 +148,13 @@ export class SessionCatalogStore {
     ReturnType<typeof setTimeout>
   >();
   private readonly liveStateWorkspaceUsers = new Map<string, number>();
-  private readonly liveStateWorkspaceRefreshRequests = new Set<string>();
+  private readonly liveStateWorkspaceRefreshRequests = new Map<
+    string,
+    'interactive' | 'invalidated'
+  >();
+  private readonly liveStateWakeHandlers = new Set<
+    (workspaceCwd: string) => void
+  >();
   private activeRequests = 0;
   private activeBackgroundRequests = 0;
   private queueSequence = 0;
@@ -201,8 +207,41 @@ export class SessionCatalogStore {
     return this.liveStateWorkspaceUsers.has(workspaceCwd);
   }
 
-  consumeWorkspaceLiveStateRefreshRequest(workspaceCwd: string): boolean {
-    return this.liveStateWorkspaceRefreshRequests.delete(workspaceCwd);
+  consumeWorkspaceLiveStateRefreshRequest(
+    workspaceCwd: string,
+  ): 'interactive' | 'invalidated' | undefined {
+    const kind = this.liveStateWorkspaceRefreshRequests.get(workspaceCwd);
+    if (kind !== undefined) {
+      this.liveStateWorkspaceRefreshRequests.delete(workspaceCwd);
+    }
+    return kind;
+  }
+
+  onLiveStateWake(handler: (workspaceCwd: string) => void): () => void {
+    this.liveStateWakeHandlers.add(handler);
+    return () => {
+      this.liveStateWakeHandlers.delete(handler);
+    };
+  }
+
+  requestWorkspaceLiveStateRefresh(workspaceCwd: string): void {
+    if (!this.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
+    this.requestLiveStateRefresh(workspaceCwd, 'interactive');
+  }
+
+  private requestLiveStateRefresh(
+    workspaceCwd: string,
+    kind: 'interactive' | 'invalidated',
+  ): void {
+    if (
+      this.liveStateWorkspaceRefreshRequests.get(workspaceCwd) === 'interactive'
+    ) {
+      return;
+    }
+    this.liveStateWorkspaceRefreshRequests.set(workspaceCwd, kind);
+    if (kind === 'interactive') {
+      for (const handler of this.liveStateWakeHandlers) handler(workspaceCwd);
+    }
   }
 
   subscribe(
@@ -226,21 +265,22 @@ export class SessionCatalogStore {
     const liveStateEnabled = this.isWorkspaceLiveStateEnabled(
       query.workspaceCwd,
     );
-    if (
-      liveStateEnabled &&
-      (entry.snapshot.page === undefined || entry.snapshot.stale)
-    ) {
-      this.liveStateWorkspaceRefreshRequests.add(query.workspaceCwd);
-    }
-    this.updateVisibilityListener();
-    this.resetPollSchedule(entry);
-
     const retainedPageExpired =
       subscriber.autoLoad &&
       options.maxAgeMs !== undefined &&
       entry.snapshot.page !== undefined &&
       (entry.snapshot.updatedAt === undefined ||
         Date.now() - entry.snapshot.updatedAt >= options.maxAgeMs);
+    if (
+      liveStateEnabled &&
+      (entry.snapshot.page === undefined ||
+        entry.snapshot.stale ||
+        retainedPageExpired)
+    ) {
+      this.requestLiveStateRefresh(query.workspaceCwd, 'interactive');
+    }
+    this.updateVisibilityListener();
+    this.resetPollSchedule(entry);
 
     if (
       !liveStateEnabled &&
@@ -319,7 +359,7 @@ export class SessionCatalogStore {
     const hidden = this.isHidden();
     const liveStateEnabled = this.isWorkspaceLiveStateEnabled(workspaceCwd);
     if (liveStateEnabled) {
-      this.liveStateWorkspaceRefreshRequests.add(workspaceCwd);
+      this.requestLiveStateRefresh(workspaceCwd, 'invalidated');
     }
     for (const entry of this.entries.values()) {
       if (entry.query.workspaceCwd !== workspaceCwd) continue;
@@ -335,6 +375,13 @@ export class SessionCatalogStore {
             ...entry.snapshot,
             loading: entry.runningRevision !== undefined,
           });
+        }
+        // Non-coordinated waiters (e.g. a pre-live `loadOnce` still in
+        // flight) can never be resolved by the live-state reconcile path,
+        // and their presence blocks `stageWorkspaceRefresh` for the whole
+        // workspace — schedule a real job so they settle.
+        if (entry.waiters.some((waiter) => !waiter.liveStateCoordinated)) {
+          this.ensureScheduled(entry, PRIORITY.interactive, false);
         }
         continue;
       }
@@ -391,6 +438,12 @@ export class SessionCatalogStore {
       }
       let changed = false;
       const sessions = entry.snapshot.page.sessions.map((session) => {
+        // A page can hold sessions from another workspace (the daemon merges
+        // live runtime state); a workspace-scoped live-state response cannot
+        // list them, so applying it would zero their volatile state.
+        if (session.workspaceCwd && session.workspaceCwd !== workspaceCwd) {
+          return session;
+        }
         const live = liveById.get(session.sessionId);
         const clientCount = live?.clientCount ?? 0;
         const hasActivePrompt = live?.hasActivePrompt ?? false;
@@ -462,34 +515,75 @@ export class SessionCatalogStore {
       entry.retryAt = undefined;
       this.setSnapshot(entry, { ...entry.snapshot, stale: true });
     }
-    const pages: StagedCatalogPage[] = [];
-    try {
-      for (const { entry, revision } of targets) {
-        if (entry.runningPromise) await entry.runningPromise;
-        if (entry.desiredRevision !== revision) {
-          return { workspaceCwd, pages, complete: false };
-        }
-        pages.push({
-          key: entry.key,
+    const results = await Promise.all(
+      targets.map(
+        async ({
+          entry,
           revision,
-          page: await this.fetchStagedPage(entry, revision),
+        }): Promise<
+          | {
+              entry: CatalogEntry;
+              revision: number;
+              page: DaemonSessionListPage;
+            }
+          | { entry: CatalogEntry; revision: number; superseded: true }
+          | { entry: CatalogEntry; revision: number; error: Error }
+        > => {
+          if (entry.runningPromise) await entry.runningPromise;
+          if (entry.desiredRevision !== revision) {
+            return { entry, revision, superseded: true };
+          }
+          try {
+            return {
+              entry,
+              revision,
+              page: await this.fetchStagedPage(entry, revision),
+            };
+          } catch (error) {
+            return { entry, revision, error: normalizeError(error) };
+          }
+        },
+      ),
+    );
+    const pages: StagedCatalogPage[] = [];
+    let complete = true;
+    let firstFailure: Error | undefined;
+    for (const result of results) {
+      if ('page' in result) {
+        pages.push({
+          key: result.entry.key,
+          revision: result.revision,
+          page: result.page,
         });
+        continue;
       }
-    } catch (error) {
-      const normalized = normalizeError(error);
-      for (const { entry, revision } of targets) {
-        if (entry.desiredRevision !== revision) continue;
-        this.setSnapshot(entry, {
-          ...entry.snapshot,
-          loading: false,
-          stale: true,
-          error: normalized,
-        });
-        this.rejectWaiters(entry, revision, normalized);
-      }
-      throw normalized;
+      complete = false;
+      if ('superseded' in result) continue;
+      firstFailure ??= result.error;
+      if (result.entry.desiredRevision !== result.revision) continue;
+      // Scope the failure to the entry whose own fetch rejected; entries
+      // that already staged successfully keep their old page and commit on
+      // the next reconcile.
+      this.setSnapshot(result.entry, {
+        ...result.entry.snapshot,
+        loading: false,
+        stale: true,
+        error: result.error,
+      });
+      this.rejectWaiters(result.entry, result.revision, result.error);
     }
-    return { workspaceCwd, pages, complete: true };
+    if (firstFailure) {
+      for (const result of results) {
+        if ('page' in result && result.entry.snapshot.loading) {
+          this.setSnapshot(result.entry, {
+            ...result.entry.snapshot,
+            loading: false,
+          });
+        }
+      }
+      throw firstFailure;
+    }
+    return { workspaceCwd, pages, complete };
   }
 
   commitWorkspaceRefresh(staged: StagedWorkspaceSessionCatalog): boolean {
@@ -590,7 +684,10 @@ export class SessionCatalogStore {
     );
     const promise = this.createWaiter(entry, revision, liveStateCoordinated);
     if (liveStateCoordinated) {
-      this.liveStateWorkspaceRefreshRequests.add(entry.query.workspaceCwd);
+      this.requestLiveStateRefresh(entry.query.workspaceCwd, 'interactive');
+      if (entry.waiters.some((waiter) => !waiter.liveStateCoordinated)) {
+        this.ensureScheduled(entry, PRIORITY.interactive, false);
+      }
       return promise;
     }
     this.ensureScheduled(entry, PRIORITY.interactive, false);
@@ -723,7 +820,7 @@ export class SessionCatalogStore {
     this.activeRequests += 1;
     if (job.background) this.activeBackgroundRequests += 1;
 
-    const request = this.fetchPage(entry.query, job.staged !== undefined);
+    const request = this.fetchPage(entry.query);
     let completion: Promise<void>;
     if (job.staged) {
       const staged = job.staged;
@@ -840,10 +937,8 @@ export class SessionCatalogStore {
 
   private async fetchPage(
     query: SessionCatalogQuery,
-    forceWorkspaceQualified = false,
   ): Promise<DaemonSessionListPage> {
-    const page = await (forceWorkspaceQualified ||
-    query.routeKind === 'qualified'
+    const page = await (query.routeKind === 'qualified'
       ? this.client
           .workspaceByCwd(query.workspaceCwd)
           .listWorkspaceSessionsPage(query.options)

--- a/packages/web-shell/client/session-catalog/session-catalog-store.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.ts
@@ -1,5 +1,6 @@
 import type {
   DaemonClient,
+  DaemonSessionLiveState,
   DaemonSessionListPage,
   DaemonSessionListPageOptions,
   DaemonSessionSummary,
@@ -37,6 +38,7 @@ interface Subscriber {
 
 interface Waiter {
   revision: number;
+  liveStateCoordinated: boolean;
   resolve: (page: DaemonSessionListPage) => void;
   reject: (error: Error) => void;
 }
@@ -46,6 +48,11 @@ interface QueueJob {
   priority: number;
   background: boolean;
   sequence: number;
+  staged?: {
+    revision: number;
+    resolve: (page: DaemonSessionListPage) => void;
+    reject: (error: Error) => void;
+  };
 }
 
 interface CatalogEntry {
@@ -56,6 +63,8 @@ interface CatalogEntry {
   desiredRevision: number;
   acceptedRevision: number;
   runningRevision?: number;
+  runningPromise?: Promise<void>;
+  runningStaged?: boolean;
   queuedJob?: QueueJob;
   trailingPriority?: number;
   trailingBackground?: boolean;
@@ -65,6 +74,18 @@ interface CatalogEntry {
   pollTimer?: ReturnType<typeof setTimeout>;
   nextPollAt?: number;
   cleanupTimer?: ReturnType<typeof setTimeout>;
+}
+
+interface StagedCatalogPage {
+  key: string;
+  revision: number;
+  page: DaemonSessionListPage;
+}
+
+export interface StagedWorkspaceSessionCatalog {
+  workspaceCwd: string;
+  pages: StagedCatalogPage[];
+  complete: boolean;
 }
 
 const PRIORITY: Record<RequestPriority, number> = {
@@ -126,6 +147,8 @@ export class SessionCatalogStore {
     string,
     ReturnType<typeof setTimeout>
   >();
+  private readonly liveStateWorkspaceUsers = new Map<string, number>();
+  private readonly liveStateWorkspaceRefreshRequests = new Set<string>();
   private activeRequests = 0;
   private activeBackgroundRequests = 0;
   private queueSequence = 0;
@@ -139,6 +162,47 @@ export class SessionCatalogStore {
 
   getEmptySnapshot(): SessionCatalogSnapshot {
     return EMPTY_SNAPSHOT;
+  }
+
+  retainWorkspaceLiveState(workspaceCwd: string): () => void {
+    this.liveStateWorkspaceUsers.set(
+      workspaceCwd,
+      (this.liveStateWorkspaceUsers.get(workspaceCwd) ?? 0) + 1,
+    );
+    return () => {
+      const remaining =
+        (this.liveStateWorkspaceUsers.get(workspaceCwd) ?? 1) - 1;
+      if (remaining > 0)
+        this.liveStateWorkspaceUsers.set(workspaceCwd, remaining);
+      else {
+        this.liveStateWorkspaceUsers.delete(workspaceCwd);
+        this.liveStateWorkspaceRefreshRequests.delete(workspaceCwd);
+        for (const entry of this.entries.values()) {
+          if (entry.query.workspaceCwd !== workspaceCwd) continue;
+          this.resetPollSchedule(entry);
+          if (entry.waiters.length > 0) {
+            entry.desiredRevision += 1;
+            if (entry.queuedJob?.staged) this.removeQueuedJob(entry);
+            this.ensureScheduled(entry, PRIORITY.interactive, false);
+          } else if (
+            entry.subscribers.size > 0 &&
+            (entry.invalidated ||
+              (hasAutoLoadSubscriber(entry) &&
+                (entry.snapshot.page === undefined || entry.snapshot.stale)))
+          ) {
+            this.requestBackground(entry, 'initial');
+          }
+        }
+      }
+    };
+  }
+
+  isWorkspaceLiveStateEnabled(workspaceCwd: string): boolean {
+    return this.liveStateWorkspaceUsers.has(workspaceCwd);
+  }
+
+  consumeWorkspaceLiveStateRefreshRequest(workspaceCwd: string): boolean {
+    return this.liveStateWorkspaceRefreshRequests.delete(workspaceCwd);
   }
 
   subscribe(
@@ -159,6 +223,15 @@ export class SessionCatalogStore {
         : {}),
     };
     entry.subscribers.add(subscriber);
+    const liveStateEnabled = this.isWorkspaceLiveStateEnabled(
+      query.workspaceCwd,
+    );
+    if (
+      liveStateEnabled &&
+      (entry.snapshot.page === undefined || entry.snapshot.stale)
+    ) {
+      this.liveStateWorkspaceRefreshRequests.add(query.workspaceCwd);
+    }
     this.updateVisibilityListener();
     this.resetPollSchedule(entry);
 
@@ -170,10 +243,11 @@ export class SessionCatalogStore {
         Date.now() - entry.snapshot.updatedAt >= options.maxAgeMs);
 
     if (
-      entry.invalidated ||
-      (subscriber.autoLoad &&
-        (entry.snapshot.page === undefined || entry.snapshot.stale)) ||
-      retainedPageExpired
+      !liveStateEnabled &&
+      (entry.invalidated ||
+        (subscriber.autoLoad &&
+          (entry.snapshot.page === undefined || entry.snapshot.stale)) ||
+        retainedPageExpired)
     ) {
       this.requestBackground(entry, 'initial');
     }
@@ -215,9 +289,15 @@ export class SessionCatalogStore {
     }
     let request: Promise<DaemonSessionListPage>;
     const reusableRunningRequest =
-      entry.runningRevision !== undefined && entry.snapshot.loading;
-    if (options.fresh !== true && (reusableRunningRequest || entry.queuedJob)) {
-      request = this.createWaiter(entry, entry.desiredRevision);
+      entry.runningRevision !== undefined &&
+      entry.snapshot.loading &&
+      !entry.runningStaged;
+    const reusableQueuedRequest = entry.queuedJob && !entry.queuedJob.staged;
+    if (
+      options.fresh !== true &&
+      (reusableRunningRequest || reusableQueuedRequest)
+    ) {
+      request = this.createWaiter(entry, entry.desiredRevision, false);
       if (entry.queuedJob || entry.runningRevision !== entry.desiredRevision) {
         this.ensureScheduled(entry, PRIORITY.interactive, false);
       }
@@ -237,6 +317,10 @@ export class SessionCatalogStore {
   ): void {
     const background = options.background === true;
     const hidden = this.isHidden();
+    const liveStateEnabled = this.isWorkspaceLiveStateEnabled(workspaceCwd);
+    if (liveStateEnabled) {
+      this.liveStateWorkspaceRefreshRequests.add(workspaceCwd);
+    }
     for (const entry of this.entries.values()) {
       if (entry.query.workspaceCwd !== workspaceCwd) continue;
       entry.desiredRevision += 1;
@@ -244,6 +328,16 @@ export class SessionCatalogStore {
       entry.retryAt = undefined;
       this.setSnapshot(entry, { ...entry.snapshot, stale: true });
       if (background && hidden) entry.nextPollAt = Date.now();
+      if (liveStateEnabled) {
+        if (entry.queuedJob?.background) {
+          this.removeQueuedJob(entry);
+          this.setSnapshot(entry, {
+            ...entry.snapshot,
+            loading: entry.runningRevision !== undefined,
+          });
+        }
+        continue;
+      }
       if (entry.waiters.length > 0) {
         this.ensureScheduled(entry, PRIORITY.interactive, false);
       } else if (entry.subscribers.size > 0 && (!background || !hidden)) {
@@ -284,6 +378,155 @@ export class SessionCatalogStore {
     }
   }
 
+  applyLiveState(
+    workspaceCwd: string,
+    liveSessions: readonly DaemonSessionLiveState[],
+  ): void {
+    const liveById = new Map(
+      liveSessions.map((session) => [session.sessionId, session]),
+    );
+    for (const entry of this.entries.values()) {
+      if (entry.query.workspaceCwd !== workspaceCwd || !entry.snapshot.page) {
+        continue;
+      }
+      let changed = false;
+      const sessions = entry.snapshot.page.sessions.map((session) => {
+        const live = liveById.get(session.sessionId);
+        const clientCount = live?.clientCount ?? 0;
+        const hasActivePrompt = live?.hasActivePrompt ?? false;
+        const isWaitingForPermission = live?.isWaitingForPermission ?? false;
+        const isWaitingForUserQuestion =
+          live?.isWaitingForUserQuestion ?? false;
+        if (
+          session.clientCount === clientCount &&
+          session.hasActivePrompt === hasActivePrompt &&
+          session.isWaitingForPermission === isWaitingForPermission &&
+          session.isWaitingForUserQuestion === isWaitingForUserQuestion
+        ) {
+          return session;
+        }
+        changed = true;
+        return {
+          ...session,
+          clientCount,
+          hasActivePrompt,
+          isWaitingForPermission,
+          isWaitingForUserQuestion,
+        };
+      });
+      if (!changed) continue;
+      this.setSnapshot(entry, {
+        ...entry.snapshot,
+        page: { ...entry.snapshot.page, sessions },
+      });
+    }
+  }
+
+  async stageWorkspaceRefresh(
+    workspaceCwd: string,
+  ): Promise<StagedWorkspaceSessionCatalog> {
+    const workspaceEntries = [...this.entries.values()].filter(
+      (entry) => entry.query.workspaceCwd === workspaceCwd,
+    );
+    if (
+      workspaceEntries.some((entry) =>
+        entry.waiters.some((waiter) => !waiter.liveStateCoordinated),
+      )
+    ) {
+      return { workspaceCwd, pages: [], complete: false };
+    }
+    const targets: Array<{ entry: CatalogEntry; revision: number }> = [];
+    for (const entry of workspaceEntries) {
+      if (
+        entry.subscribers.size > 0 ||
+        entry.snapshot.loading ||
+        entry.waiters.length > 0
+      ) {
+        this.clearPollTimer(entry);
+        this.removeQueuedJob(entry);
+        entry.trailingPriority = undefined;
+        entry.trailingBackground = undefined;
+        entry.desiredRevision += 1;
+        entry.invalidated = true;
+        entry.retryAt = undefined;
+        this.setSnapshot(entry, {
+          ...entry.snapshot,
+          loading: true,
+          stale: true,
+        });
+        targets.push({ entry, revision: entry.desiredRevision });
+        continue;
+      }
+      entry.desiredRevision += 1;
+      entry.invalidated = true;
+      entry.retryAt = undefined;
+      this.setSnapshot(entry, { ...entry.snapshot, stale: true });
+    }
+    const pages: StagedCatalogPage[] = [];
+    try {
+      for (const { entry, revision } of targets) {
+        if (entry.runningPromise) await entry.runningPromise;
+        if (entry.desiredRevision !== revision) {
+          return { workspaceCwd, pages, complete: false };
+        }
+        pages.push({
+          key: entry.key,
+          revision,
+          page: await this.fetchStagedPage(entry, revision),
+        });
+      }
+    } catch (error) {
+      const normalized = normalizeError(error);
+      for (const { entry, revision } of targets) {
+        if (entry.desiredRevision !== revision) continue;
+        this.setSnapshot(entry, {
+          ...entry.snapshot,
+          loading: false,
+          stale: true,
+          error: normalized,
+        });
+        this.rejectWaiters(entry, revision, normalized);
+      }
+      throw normalized;
+    }
+    return { workspaceCwd, pages, complete: true };
+  }
+
+  commitWorkspaceRefresh(staged: StagedWorkspaceSessionCatalog): boolean {
+    if (!staged.complete) return false;
+    const entries: Array<{
+      entry: CatalogEntry;
+      stagedPage: StagedCatalogPage;
+    }> = [];
+    for (const stagedPage of staged.pages) {
+      const entry = this.entries.get(stagedPage.key);
+      if (
+        !entry ||
+        entry.query.workspaceCwd !== staged.workspaceCwd ||
+        entry.desiredRevision !== stagedPage.revision
+      ) {
+        return false;
+      }
+      entries.push({ entry, stagedPage });
+    }
+    for (const { entry, stagedPage } of entries) {
+      entry.acceptedRevision = stagedPage.revision;
+      entry.invalidated = false;
+      entry.retryAt = undefined;
+      entry.snapshot = {
+        page: stagedPage.page,
+        loading: false,
+        stale: false,
+        updatedAt: Date.now(),
+      };
+    }
+    for (const { entry, stagedPage } of entries) {
+      for (const subscriber of entry.subscribers) subscriber.listener();
+      this.resolveWaiters(entry, stagedPage.page);
+    }
+    return true;
+  }
+
   scheduleWorkspaceRefresh(
     workspaceCwd: string,
     delayMs = SESSION_CATALOG_TRAILING_REFRESH_MS,
@@ -298,16 +541,19 @@ export class SessionCatalogStore {
   }
 
   dispose(): void {
+    const error = new Error('Session catalog store disposed');
     for (const entry of this.entries.values()) {
       this.clearPollTimer(entry);
       if (entry.cleanupTimer !== undefined) clearTimeout(entry.cleanupTimer);
-      const error = new Error('Session catalog store disposed');
       for (const waiter of entry.waiters) waiter.reject(error);
       entry.waiters = [];
     }
+    for (const job of this.queue) job.staged?.reject(error);
     for (const timer of this.trailingRefreshTimers.values())
       clearTimeout(timer);
     this.trailingRefreshTimers.clear();
+    this.liveStateWorkspaceUsers.clear();
+    this.liveStateWorkspaceRefreshRequests.clear();
     this.entries.clear();
     this.queue.length = 0;
     this.removeVisibilityListener();
@@ -339,7 +585,14 @@ export class SessionCatalogStore {
     entry.desiredRevision += 1;
     const revision = entry.desiredRevision;
     this.setSnapshot(entry, { ...entry.snapshot, stale: true });
-    const promise = this.createWaiter(entry, revision);
+    const liveStateCoordinated = this.isWorkspaceLiveStateEnabled(
+      entry.query.workspaceCwd,
+    );
+    const promise = this.createWaiter(entry, revision, liveStateCoordinated);
+    if (liveStateCoordinated) {
+      this.liveStateWorkspaceRefreshRequests.add(entry.query.workspaceCwd);
+      return promise;
+    }
     this.ensureScheduled(entry, PRIORITY.interactive, false);
     return promise;
   }
@@ -347,9 +600,15 @@ export class SessionCatalogStore {
   private createWaiter(
     entry: CatalogEntry,
     revision: number,
+    liveStateCoordinated: boolean,
   ): Promise<DaemonSessionListPage> {
     return new Promise<DaemonSessionListPage>((resolve, reject) => {
-      entry.waiters.push({ revision, resolve, reject });
+      entry.waiters.push({
+        revision,
+        liveStateCoordinated,
+        resolve,
+        reject,
+      });
     });
   }
 
@@ -357,6 +616,7 @@ export class SessionCatalogStore {
     entry: CatalogEntry,
     priority: 'initial' | 'poll',
   ): void {
+    if (this.isWorkspaceLiveStateEnabled(entry.query.workspaceCwd)) return;
     if (this.isHidden()) {
       entry.nextPollAt = Date.now();
       this.setSnapshot(entry, { ...entry.snapshot, stale: true });
@@ -404,6 +664,18 @@ export class SessionCatalogStore {
       return;
     }
     if (entry.queuedJob) {
+      if (
+        entry.queuedJob.staged &&
+        entry.desiredRevision > entry.queuedJob.staged.revision
+      ) {
+        entry.trailingPriority = Math.min(
+          entry.trailingPriority ?? priority,
+          priority,
+        );
+        entry.trailingBackground =
+          (entry.trailingBackground ?? true) && background;
+        return;
+      }
       entry.queuedJob.priority = Math.min(entry.queuedJob.priority, priority);
       entry.queuedJob.background = entry.queuedJob.background && background;
       this.sortQueue();
@@ -445,76 +717,133 @@ export class SessionCatalogStore {
 
   private startJob(job: QueueJob): void {
     const entry = job.entry;
-    const revision = entry.desiredRevision;
+    const revision = job.staged?.revision ?? entry.desiredRevision;
     entry.runningRevision = revision;
+    entry.runningStaged = job.staged !== undefined;
     this.activeRequests += 1;
     if (job.background) this.activeBackgroundRequests += 1;
 
-    void this.fetchPage(entry.query)
-      .then((page) => {
-        if (entry.desiredRevision === revision) {
-          entry.acceptedRevision = revision;
-          entry.invalidated = false;
-          entry.retryAt = undefined;
-          this.setSnapshot(entry, {
-            page,
-            loading: false,
-            stale: false,
-            updatedAt: Date.now(),
-          });
-          this.resolveWaiters(entry, page);
-        }
-      })
-      .catch((error: unknown) => {
-        if (entry.desiredRevision !== revision) return;
-        const normalized = normalizeError(error);
-        entry.retryAt = Date.now() + SESSION_CATALOG_ERROR_RETRY_MS;
-        this.setSnapshot(entry, {
-          ...entry.snapshot,
-          loading: false,
-          stale: true,
-          error: normalized,
+    const request = this.fetchPage(entry.query, job.staged !== undefined);
+    let completion: Promise<void>;
+    if (job.staged) {
+      const staged = job.staged;
+      let result: DaemonSessionListPage | undefined;
+      let failure: Error | undefined;
+      completion = request
+        .then(
+          (page) => {
+            result = page;
+          },
+          (error: unknown) => {
+            failure = normalizeError(error);
+          },
+        )
+        .finally(() => this.finishJob(entry, job, revision))
+        .then(() => {
+          if (failure) staged.reject(failure);
+          else staged.resolve(result!);
         });
-        this.rejectWaiters(entry, revision, normalized);
-      })
-      .finally(() => {
-        entry.runningRevision = undefined;
-        this.activeRequests -= 1;
-        if (job.background) this.activeBackgroundRequests -= 1;
-        if (
-          entry.desiredRevision > revision &&
-          entry.trailingPriority !== undefined
-        ) {
-          const priority = entry.trailingPriority;
-          const background = entry.trailingBackground ?? true;
-          entry.trailingPriority = undefined;
-          entry.trailingBackground = undefined;
-          if (!background || (!this.isHidden() && entry.subscribers.size > 0)) {
-            this.ensureScheduled(entry, priority, background);
-          } else {
-            if (entry.snapshot.loading) {
-              this.setSnapshot(entry, { ...entry.snapshot, loading: false });
+    } else {
+      completion = request
+        .then(
+          (page) => {
+            if (entry.desiredRevision === revision) {
+              entry.acceptedRevision = revision;
+              entry.invalidated = false;
+              entry.retryAt = undefined;
+              this.setSnapshot(entry, {
+                page,
+                loading: false,
+                stale: false,
+                updatedAt: Date.now(),
+              });
+              this.resolveWaiters(entry, page);
             }
-            this.schedulePollFromNow(entry);
-            if (entry.subscribers.size === 0) this.scheduleCleanup(entry);
-          }
-        } else {
-          entry.trailingPriority = undefined;
-          entry.trailingBackground = undefined;
-          if (entry.snapshot.loading) {
-            this.setSnapshot(entry, { ...entry.snapshot, loading: false });
-          }
-          this.schedulePollFromNow(entry);
-          if (entry.subscribers.size === 0) this.scheduleCleanup(entry);
+          },
+          (error: unknown) => {
+            if (entry.desiredRevision !== revision) return;
+            const normalized = normalizeError(error);
+            entry.retryAt = Date.now() + SESSION_CATALOG_ERROR_RETRY_MS;
+            this.setSnapshot(entry, {
+              ...entry.snapshot,
+              loading: false,
+              stale: true,
+              error: normalized,
+            });
+            this.rejectWaiters(entry, revision, normalized);
+          },
+        )
+        .finally(() => this.finishJob(entry, job, revision));
+    }
+    entry.runningPromise = completion;
+    void completion;
+  }
+
+  private finishJob(
+    entry: CatalogEntry,
+    job: QueueJob,
+    revision: number,
+  ): void {
+    entry.runningRevision = undefined;
+    entry.runningPromise = undefined;
+    entry.runningStaged = undefined;
+    this.activeRequests -= 1;
+    if (job.background) this.activeBackgroundRequests -= 1;
+    if (
+      entry.desiredRevision > revision &&
+      entry.trailingPriority !== undefined
+    ) {
+      const priority = entry.trailingPriority;
+      const background = entry.trailingBackground ?? true;
+      entry.trailingPriority = undefined;
+      entry.trailingBackground = undefined;
+      if (!background || (!this.isHidden() && entry.subscribers.size > 0)) {
+        this.ensureScheduled(entry, priority, background);
+      } else {
+        if (entry.snapshot.loading) {
+          this.setSnapshot(entry, { ...entry.snapshot, loading: false });
         }
-        this.drainQueue();
-      });
+        this.schedulePollFromNow(entry);
+        if (entry.subscribers.size === 0) this.scheduleCleanup(entry);
+      }
+    } else {
+      entry.trailingPriority = undefined;
+      entry.trailingBackground = undefined;
+      if (entry.snapshot.loading) {
+        this.setSnapshot(entry, { ...entry.snapshot, loading: false });
+      }
+      this.schedulePollFromNow(entry);
+      if (entry.subscribers.size === 0) this.scheduleCleanup(entry);
+    }
+    this.drainQueue();
+  }
+
+  private fetchStagedPage(
+    entry: CatalogEntry,
+    revision: number,
+  ): Promise<DaemonSessionListPage> {
+    return new Promise((resolve, reject) => {
+      const job: QueueJob = {
+        entry,
+        priority: PRIORITY.interactive,
+        background: false,
+        sequence: this.queueSequence++,
+        staged: { revision, resolve, reject },
+      };
+      entry.queuedJob = job;
+      this.queue.push(job);
+      this.setSnapshot(entry, { ...entry.snapshot, loading: true });
+      this.sortQueue();
+      this.drainQueue();
+    });
   }
 
   private async fetchPage(
     query: SessionCatalogQuery,
+    forceWorkspaceQualified = false,
   ): Promise<DaemonSessionListPage> {
-    const page = await (query.routeKind === 'qualified'
+    const page = await (forceWorkspaceQualified ||
+    query.routeKind === 'qualified'
       ? this.client
           .workspaceByCwd(query.workspaceCwd)
           .listWorkspaceSessionsPage(query.options)
@@ -627,6 +956,7 @@ export class SessionCatalogStore {
     const index = this.queue.indexOf(job);
     if (index >= 0) this.queue.splice(index, 1);
     entry.queuedJob = undefined;
+    job.staged?.reject(new Error('Staged session catalog request superseded'));
   }
 
   private scheduleCleanup(entry: CatalogEntry): void {

--- a/packages/web-shell/client/session-catalog/session-catalog-store.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.ts
@@ -229,6 +229,11 @@ export class SessionCatalogStore {
     this.requestLiveStateRefresh(workspaceCwd, 'interactive');
   }
 
+  requestWorkspaceLiveStateInvalidation(workspaceCwd: string): void {
+    if (!this.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
+    this.requestLiveStateRefresh(workspaceCwd, 'invalidated');
+  }
+
   private requestLiveStateRefresh(
     workspaceCwd: string,
     kind: 'interactive' | 'invalidated',
@@ -841,10 +846,18 @@ export class SessionCatalogStore {
           else staged.resolve(result!);
         });
     } else {
+      // A staged job at the same revision owns it: a trailing non-staged
+      // job materialized by finishJob for a staged-owned revision must not
+      // publish a page or settle waiters ahead of (or against) the staged
+      // commit.
+      const stagedOwnsRevision = (): boolean =>
+        entry.queuedJob?.staged?.revision === revision ||
+        (entry.runningStaged === true && entry.runningRevision === revision);
       completion = request
         .then(
           (page) => {
             if (entry.desiredRevision === revision) {
+              if (stagedOwnsRevision()) return;
               entry.acceptedRevision = revision;
               entry.invalidated = false;
               entry.retryAt = undefined;
@@ -859,6 +872,7 @@ export class SessionCatalogStore {
           },
           (error: unknown) => {
             if (entry.desiredRevision !== revision) return;
+            if (stagedOwnsRevision()) return;
             const normalized = normalizeError(error);
             entry.retryAt = Date.now() + SESSION_CATALOG_ERROR_RETRY_MS;
             this.setSnapshot(entry, {
@@ -920,6 +934,11 @@ export class SessionCatalogStore {
     revision: number,
   ): Promise<DaemonSessionListPage> {
     return new Promise((resolve, reject) => {
+      // A staged fetch supersedes a pending non-staged job for the same
+      // entry — its waiters settle via the fenced commit instead.
+      if (entry.queuedJob && !entry.queuedJob.staged) {
+        this.removeQueuedJob(entry);
+      }
       const job: QueueJob = {
         entry,
         priority: PRIORITY.interactive,

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
@@ -207,17 +207,20 @@ describe('useWorkspaceSessionLiveState', () => {
     await renderProbe();
     expect(listSessions).toHaveBeenCalledTimes(1);
 
+    // The new source subscription raises an interactive refresh request,
+    // which wakes the loop immediately rather than waiting for a tick.
     await renderProbe(false, 'channel');
-    expect(listSessions).toHaveBeenCalledTimes(1);
+    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(listSessions).toHaveBeenLastCalledWith(
+      '/work',
+      expect.objectContaining({ sourceType: 'channel' }),
+    );
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
     });
 
     expect(listSessions).toHaveBeenCalledTimes(2);
-    expect(listSessions).toHaveBeenLastCalledWith(
-      expect.objectContaining({ sourceType: 'channel' }),
-    );
   });
 
   it('uses one trailing reconciliation for an A/B mismatch and publishes only the stable groups', async () => {
@@ -340,5 +343,125 @@ describe('useWorkspaceSessionLiveState', () => {
     expect(listGroups).toHaveBeenCalledTimes(2);
     expect(listSessions).toHaveBeenCalledTimes(catalogRequestsAfterFailure);
     expect(container.textContent).toBe('true:true:no-group');
+  });
+
+  it('retries the initial catalog fallback until it commits', async () => {
+    getLiveState.mockRejectedValue(new Error('live down'));
+    listSessions.mockRejectedValueOnce(new Error('catalog blip'));
+    await renderProbe();
+    expect(listSessions).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toBe('undefined:undefined:no-group');
+
+    // The failed fallback must not consume the one-shot latch: the next
+    // live-state failure cycle retries it and the catalog renders.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_ERROR_RETRY_MS + SESSION_LIVE_STATE_POLL_MS,
+      );
+    });
+    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toBe('false:undefined:no-group');
+  });
+
+  it('rate-limits sustained lifecycle invalidations to one reconcile per window', async () => {
+    await renderProbe();
+    const initialCatalogRequests = listSessions.mock.calls.length;
+
+    // A single local change still reconciles immediately.
+    act(() => controller.sessionCreated('/work', 'session-b'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 1);
+
+    // Sustained invalidations inside the cooldown window coalesce instead
+    // of one full catalog rescan per event.
+    act(() => {
+      controller.sessionCreated('/work', 'session-c');
+      controller.renamed('/work', 'session-b', 'Renamed');
+      controller.promptAdmissionUncertain('/work');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS * 3);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS,
+      );
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 2);
+  });
+
+  it('reconciles when the catalog generation changes at the same revision', async () => {
+    await renderProbe();
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    getLiveState.mockImplementation(async () => ({
+      ...liveState(1),
+      catalogVersion: { generation: 'generation-b', revision: 1 },
+    }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS,
+      );
+    });
+    expect(listSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it('pauses polling while hidden and polls immediately on visibility return', async () => {
+    await renderProbe();
+    const liveCallsAfterMount = getLiveState.mock.calls.length;
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true,
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS * 3);
+    });
+    expect(getLiveState).toHaveBeenCalledTimes(liveCallsAfterMount);
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false,
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getLiveState.mock.calls.length).toBeGreaterThan(liveCallsAfterMount);
+  });
+
+  it('applies the promptAdmitted optimistic patch immediately in live mode', async () => {
+    await renderProbe();
+    expect(container.textContent).toBe('false:false:no-group');
+
+    // The optimistic patch must apply synchronously — the sidebar's active
+    // indicator cannot wait for the next live-state poll.
+    act(() => controller.promptAdmitted('/work', 'session-a'));
+    expect(container.textContent).toBe('true:false:no-group');
+  });
+
+  it('stays inert when disabled', async () => {
+    function DisabledProbe() {
+      useWorkspaceSessionLiveState(client, {
+        enabled: false,
+        workspaceCwds: ['/work'],
+        groupWorkspaceCwds: [],
+      });
+      return null;
+    }
+    await act(async () => {
+      root.render(<DisabledProbe />);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS * 3);
+    });
+    expect(getLiveState).not.toHaveBeenCalled();
+    expect(listSessions).not.toHaveBeenCalled();
   });
 });

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
@@ -169,19 +169,32 @@ describe('useWorkspaceSessionLiveState', () => {
     expect(container.textContent).toBe('true:true:no-group');
   });
 
-  it('does not rescan the catalog for prompt admission or turn completion', async () => {
+  it('does not rescan the catalog for prompt admission, and coalesces turn completions', async () => {
     await renderProbe();
     const catalogRequests = listSessions.mock.calls.length;
 
+    act(() => controller.promptAdmitted('/work', 'session-a'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+
+    // Turn completions refresh recency data (updatedAt) through the
+    // rate-limited invalidation path: one rescan per cooldown window.
     act(() => {
-      controller.promptAdmitted('/work', 'session-a');
+      controller.turnCompleted('/work');
       controller.turnCompleted('/work');
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
     });
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
 
-    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+    act(() => controller.turnCompleted('/work'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
   });
 
   it('does not schedule a second catalog scan after a local session creation', async () => {
@@ -443,6 +456,38 @@ describe('useWorkspaceSessionLiveState', () => {
     // indicator cannot wait for the next live-state poll.
     act(() => controller.promptAdmitted('/work', 'session-a'));
     expect(container.textContent).toBe('true:false:no-group');
+  });
+
+  it('does not hot-loop when a staged commit is persistently refused', async () => {
+    await renderProbe();
+    const initialCatalogRequests = listSessions.mock.calls.length;
+
+    // Every staged fetch bumps the revision mid-flight, so every commit
+    // misses its fence. The give-up path must clear the request flags —
+    // otherwise an interactive refresh spins a full reconcile every tick.
+    listSessions.mockImplementation(async () => {
+      controller.invalidateWorkspace('/work');
+      return sessionPage();
+    });
+    act(() => controller.refreshQueries([query]));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const callsAfterGiveUp = listSessions.mock.calls.length;
+    expect(callsAfterGiveUp).toBeGreaterThan(initialCatalogRequests);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS * 4);
+    });
+    // One invalidation-gated retry per cooldown window at most — without
+    // the fix every 2s tick re-runs two catalog fetches.
+    expect(listSessions.mock.calls.length).toBeLessThanOrEqual(
+      callsAfterGiveUp + 2,
+    );
   });
 
   it('stays inert when disabled', async () => {

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
@@ -1,0 +1,344 @@
+// @vitest-environment jsdom
+
+import { act, useMemo } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  DaemonClient,
+  DaemonSessionGroupCatalog,
+  DaemonSessionListPage,
+  DaemonWorkspaceSessionLiveState,
+} from '@qwen-code/sdk/daemon';
+import {
+  useSessionCatalogController,
+  useSessionCatalogQuery,
+} from './session-catalog-hooks';
+import type { SessionCatalogQuery } from './session-catalog-store';
+import {
+  SESSION_LIVE_STATE_ERROR_RETRY_MS,
+  SESSION_LIVE_STATE_POLL_MS,
+  SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS,
+  useWorkspaceSessionLiveState,
+} from './workspace-session-live-state';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function liveState(
+  revision: number,
+  hasActivePrompt = false,
+): DaemonWorkspaceSessionLiveState {
+  return {
+    v: 1,
+    catalogVersion: { generation: 'generation-a', revision },
+    sessions: [
+      {
+        sessionId: 'session-a',
+        clientCount: 1,
+        hasActivePrompt,
+        isWaitingForPermission: hasActivePrompt,
+        isWaitingForUserQuestion: false,
+      },
+    ],
+  };
+}
+
+function sessionPage(): DaemonSessionListPage {
+  return {
+    sessions: [
+      {
+        sessionId: 'session-a',
+        workspaceCwd: '/work',
+        displayName: 'Session A',
+        clientCount: 0,
+        hasActivePrompt: false,
+      },
+    ],
+  };
+}
+
+const query: SessionCatalogQuery = {
+  routeKind: 'legacy',
+  workspaceCwd: '/work',
+  options: { pageSize: 100, archiveState: 'active' },
+};
+
+describe('useWorkspaceSessionLiveState', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let listSessions: ReturnType<typeof vi.fn>;
+  let getLiveState: ReturnType<typeof vi.fn>;
+  let listGroups: ReturnType<typeof vi.fn>;
+  let client: DaemonClient;
+  let controller: ReturnType<typeof useSessionCatalogController>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-17T00:00:00.000Z'));
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    listSessions = vi.fn().mockResolvedValue(sessionPage());
+    getLiveState = vi.fn().mockResolvedValue(liveState(1));
+    listGroups = vi.fn().mockResolvedValue({
+      groups: [],
+      colorOptions: [],
+    } satisfies DaemonSessionGroupCatalog);
+    client = {
+      listWorkspaceSessionsPage: listSessions,
+      getWorkspaceSessionLiveState: getLiveState,
+      workspaceByCwd: vi.fn(() => ({
+        listWorkspaceSessionsPage: listSessions,
+        listSessionGroups: listGroups,
+      })),
+    } as unknown as DaemonClient;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function Probe({
+    organizationEnabled = false,
+    sourceType,
+  }: {
+    organizationEnabled?: boolean;
+    sourceType?: string;
+  }) {
+    const activeQuery = useMemo<SessionCatalogQuery>(
+      () => ({
+        ...query,
+        options: { ...query.options, sourceType },
+      }),
+      [sourceType],
+    );
+    const catalog = useSessionCatalogQuery(client, activeQuery);
+    controller = useSessionCatalogController(client);
+    const groupCatalogs = useWorkspaceSessionLiveState(client, {
+      enabled: true,
+      workspaceCwds: ['/work'],
+      groupWorkspaceCwds: organizationEnabled ? ['/work'] : [],
+    });
+    const session = catalog.sessions[0];
+    return (
+      <span>
+        {String(session?.hasActivePrompt)}:
+        {String(session?.isWaitingForPermission)}:
+        {groupCatalogs.get('/work')?.groups[0]?.name ?? 'no-group'}
+      </span>
+    );
+  }
+
+  async function renderProbe(
+    organizationEnabled = false,
+    sourceType?: string,
+  ): Promise<void> {
+    await act(async () => {
+      root.render(
+        <Probe
+          organizationEnabled={organizationEnabled}
+          sourceType={sourceType}
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('polls only live-state after the initial version-fenced catalog load', async () => {
+    let active = false;
+    getLiveState.mockImplementation(async () => liveState(1, active));
+    await renderProbe();
+    const initialCatalogRequests = listSessions.mock.calls.length;
+    expect(initialCatalogRequests).toBe(1);
+    expect(getLiveState).toHaveBeenCalledTimes(2);
+
+    active = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS * 3);
+    });
+
+    expect(getLiveState).toHaveBeenCalledTimes(5);
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests);
+    expect(listGroups).not.toHaveBeenCalled();
+    expect(container.textContent).toBe('true:true:no-group');
+  });
+
+  it('does not rescan the catalog for prompt admission or turn completion', async () => {
+    await renderProbe();
+    const catalogRequests = listSessions.mock.calls.length;
+
+    act(() => {
+      controller.promptAdmitted('/work', 'session-a');
+      controller.turnCompleted('/work');
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+  });
+
+  it('does not schedule a second catalog scan after a local session creation', async () => {
+    await renderProbe();
+    const initialCatalogRequests = listSessions.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS / 2);
+    });
+
+    act(() => controller.sessionCreated('/work', 'session-b'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS / 2);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 1);
+  });
+
+  it('reconciles a newly selected source through the live-state handshake', async () => {
+    await renderProbe();
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    await renderProbe(false, 'channel');
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+
+    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(listSessions).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sourceType: 'channel' }),
+    );
+  });
+
+  it('uses one trailing reconciliation for an A/B mismatch and publishes only the stable groups', async () => {
+    const states = [liveState(1), liveState(2), liveState(2)];
+    getLiveState.mockImplementation(async () => states.shift() ?? liveState(2));
+    listGroups
+      .mockResolvedValueOnce({
+        groups: [{ id: 'old', name: 'Old', color: 'red' }],
+        colorOptions: ['red'],
+      })
+      .mockResolvedValueOnce({
+        groups: [{ id: 'new', name: 'New', color: 'blue' }],
+        colorOptions: ['blue'],
+      });
+
+    await renderProbe(true);
+
+    expect(getLiveState).toHaveBeenCalledTimes(3);
+    expect(listGroups).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toBe('false:false:New');
+  });
+
+  it('rate-limits full reconciliation during sustained catalog churn', async () => {
+    let revision = 1;
+    let churning = false;
+    getLiveState.mockImplementation(async () =>
+      liveState(churning ? ++revision : revision),
+    );
+    await renderProbe();
+    const initialCatalogRequests = listSessions.mock.calls.length;
+
+    churning = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS,
+      );
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 2);
+    const catalogRequestsAfterTrailingReload = listSessions.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS - SESSION_LIVE_STATE_POLL_MS,
+      );
+    });
+    expect(listSessions).toHaveBeenCalledTimes(
+      catalogRequestsAfterTrailingReload,
+    );
+  });
+
+  it('restores the cooldown after an explicit refresh meets sustained churn', async () => {
+    let revision = 1;
+    let churning = false;
+    getLiveState.mockImplementation(async () =>
+      liveState(churning ? ++revision : revision),
+    );
+    await renderProbe();
+    const initialCatalogRequests = listSessions.mock.calls.length;
+
+    churning = true;
+    act(() => controller.invalidateWorkspace('/work'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(initialCatalogRequests + 2);
+  });
+
+  it('backs off after a live-state failure without dropping the catalog', async () => {
+    getLiveState.mockRejectedValueOnce(new Error('offline'));
+    await renderProbe();
+    expect(container.textContent).toBe('false:undefined:no-group');
+    expect(getLiveState).toHaveBeenCalledTimes(1);
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_ERROR_RETRY_MS - SESSION_LIVE_STATE_POLL_MS,
+      );
+    });
+    expect(getLiveState).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(getLiveState.mock.calls.length).toBeGreaterThan(1);
+    expect(container.textContent).toBe('false:false:no-group');
+  });
+
+  it('keeps polling volatile state while catalog reconciliation is backed off', async () => {
+    let revision = 1;
+    let active = false;
+    getLiveState.mockImplementation(async () => liveState(revision, active));
+    listGroups
+      .mockResolvedValueOnce({ groups: [], colorOptions: [] })
+      .mockRejectedValue(new Error('groups unavailable'));
+    await renderProbe(true);
+    revision = 2;
+    active = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS,
+      );
+    });
+    const catalogRequestsAfterFailure = listSessions.mock.calls.length;
+    expect(listGroups).toHaveBeenCalledTimes(2);
+    const liveRequestsAfterFailure = getLiveState.mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+
+    expect(getLiveState.mock.calls.length).toBeGreaterThan(
+      liveRequestsAfterFailure,
+    );
+    expect(listGroups).toHaveBeenCalledTimes(2);
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequestsAfterFailure);
+    expect(container.textContent).toBe('true:true:no-group');
+  });
+});

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
@@ -218,7 +218,16 @@ export function useWorkspaceSessionLiveState(
       catalogStore.applyLiveState(state.workspaceCwd, liveB.sessions);
       if (versionsEqual(liveA.catalogVersion, liveB.catalogVersion)) {
         if (!catalogStore.commitWorkspaceRefresh(stagedCatalog)) {
-          if (allowTrailing) await reconcile(state, liveB, false);
+          if (allowTrailing) {
+            await reconcile(state, liveB, false);
+            return;
+          }
+          // A persistently refused commit (e.g. revision bumped mid-staging
+          // every time) must clear the request flags — otherwise they keep
+          // bypassing the cooldown and the loop re-runs a full reconcile on
+          // every 2s tick with no decay.
+          state.reconcileRequested = false;
+          state.invalidationRequested = false;
           return;
         }
         catalogStore.applyLiveState(state.workspaceCwd, liveB.sessions);

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useState } from 'react';
+import type {
+  DaemonClient,
+  DaemonSessionCatalogVersion,
+  DaemonSessionGroupCatalog,
+  DaemonWorkspaceSessionLiveState,
+} from '@qwen-code/sdk/daemon';
+import {
+  getSessionCatalogStore,
+  type StagedWorkspaceSessionCatalog,
+} from './session-catalog-store';
+
+export const SESSION_LIVE_STATE_POLL_MS = 2_000;
+export const SESSION_LIVE_STATE_ERROR_RETRY_MS = 30_000;
+export const SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS = 10_000;
+
+interface WorkspacePollState {
+  workspaceCwd: string;
+  acceptedVersion?: DaemonSessionCatalogVersion;
+  inFlight: boolean;
+  liveRetryAt: number;
+  reconcileRetryAt: number;
+  lastReconcileAt: number;
+  fallbackAttempted: boolean;
+  reconcileRequested: boolean;
+}
+
+interface WorkspaceSessionLiveStateOptions {
+  enabled: boolean;
+  workspaceCwds: readonly string[];
+  groupWorkspaceCwds: readonly string[];
+}
+
+function versionsEqual(
+  left: DaemonSessionCatalogVersion | undefined,
+  right: DaemonSessionCatalogVersion,
+): boolean {
+  return (
+    left?.generation === right.generation && left.revision === right.revision
+  );
+}
+
+export function useWorkspaceSessionLiveState(
+  client: DaemonClient,
+  {
+    enabled,
+    workspaceCwds,
+    groupWorkspaceCwds,
+  }: WorkspaceSessionLiveStateOptions,
+): ReadonlyMap<string, DaemonSessionGroupCatalog> {
+  const catalogStore = useMemo(() => getSessionCatalogStore(client), [client]);
+  const targetsKey = JSON.stringify([...new Set(workspaceCwds)].sort());
+  const targets = useMemo(
+    () => JSON.parse(targetsKey) as string[],
+    [targetsKey],
+  );
+  const groupTargetsKey = JSON.stringify(
+    [...new Set(groupWorkspaceCwds)].sort(),
+  );
+  const groupTargets = useMemo(
+    () => new Set(JSON.parse(groupTargetsKey) as string[]),
+    [groupTargetsKey],
+  );
+  const [groupCatalogs, setGroupCatalogs] = useState<
+    ReadonlyMap<string, DaemonSessionGroupCatalog>
+  >(() => new Map());
+
+  useEffect(() => {
+    const activeTargets = new Set(targets);
+    setGroupCatalogs((current) => {
+      if (!enabled) {
+        return current.size === 0 ? current : new Map();
+      }
+      if (
+        [...current.keys()].every(
+          (cwd) => activeTargets.has(cwd) && groupTargets.has(cwd),
+        )
+      ) {
+        return current;
+      }
+      const next = new Map<string, DaemonSessionGroupCatalog>();
+      for (const [cwd, catalog] of current) {
+        if (activeTargets.has(cwd) && groupTargets.has(cwd)) {
+          next.set(cwd, catalog);
+        }
+      }
+      return next;
+    });
+  }, [enabled, groupTargets, targets]);
+
+  useEffect(() => {
+    if (!enabled || targets.length === 0) return;
+    let disposed = false;
+    const releaseLiveState = targets.map((workspaceCwd) =>
+      catalogStore.retainWorkspaceLiveState(workspaceCwd),
+    );
+    const states = targets.map<WorkspacePollState>((workspaceCwd) => ({
+      workspaceCwd,
+      inFlight: false,
+      liveRetryAt: 0,
+      reconcileRetryAt: 0,
+      lastReconcileAt: Number.NEGATIVE_INFINITY,
+      fallbackAttempted: false,
+      reconcileRequested: false,
+    }));
+
+    const publishGroups = (
+      workspaceCwd: string,
+      catalog: DaemonSessionGroupCatalog | undefined,
+    ) => {
+      if (!catalog || disposed) return;
+      setGroupCatalogs((current) => {
+        if (current.get(workspaceCwd) === catalog) return current;
+        const next = new Map(current);
+        next.set(workspaceCwd, catalog);
+        return next;
+      });
+    };
+
+    const readLiveState = async (
+      workspaceCwd: string,
+    ): Promise<DaemonWorkspaceSessionLiveState> => {
+      return await client.getWorkspaceSessionLiveState(workspaceCwd);
+    };
+
+    const stageCatalogBundle = async (
+      state: WorkspacePollState,
+    ): Promise<
+      [StagedWorkspaceSessionCatalog, DaemonSessionGroupCatalog | undefined]
+    > => {
+      const groupRequest = groupTargets.has(state.workspaceCwd)
+        ? client.workspaceByCwd(state.workspaceCwd).listSessionGroups()
+        : Promise.resolve(undefined);
+      return await Promise.all([
+        catalogStore.stageWorkspaceRefresh(state.workspaceCwd),
+        groupRequest,
+      ]);
+    };
+
+    const loadFallbackBundle = async (
+      state: WorkspacePollState,
+    ): Promise<void> => {
+      const [stagedCatalog, groups] = await stageCatalogBundle(state);
+      if (disposed || !catalogStore.commitWorkspaceRefresh(stagedCatalog)) {
+        return;
+      }
+      publishGroups(state.workspaceCwd, groups);
+    };
+
+    const reconcile = async (
+      state: WorkspacePollState,
+      liveA: DaemonWorkspaceSessionLiveState,
+      allowTrailing: boolean,
+    ): Promise<void> => {
+      state.reconcileRequested =
+        state.reconcileRequested ||
+        catalogStore.consumeWorkspaceLiveStateRefreshRequest(
+          state.workspaceCwd,
+        );
+      state.lastReconcileAt = Date.now();
+      const [stagedCatalog, groups] = await stageCatalogBundle(state);
+      if (disposed) return;
+      const liveB = await readLiveState(state.workspaceCwd);
+      if (disposed) return;
+      catalogStore.applyLiveState(state.workspaceCwd, liveB.sessions);
+      if (versionsEqual(liveA.catalogVersion, liveB.catalogVersion)) {
+        if (!catalogStore.commitWorkspaceRefresh(stagedCatalog)) {
+          if (allowTrailing) await reconcile(state, liveB, false);
+          return;
+        }
+        catalogStore.applyLiveState(state.workspaceCwd, liveB.sessions);
+        state.acceptedVersion = liveB.catalogVersion;
+        state.reconcileRequested = false;
+        publishGroups(state.workspaceCwd, groups);
+        return;
+      }
+      if (allowTrailing) await reconcile(state, liveB, false);
+      else state.reconcileRequested = false;
+    };
+
+    const poll = async (state: WorkspacePollState): Promise<void> => {
+      if (
+        disposed ||
+        state.inFlight ||
+        Date.now() < state.liveRetryAt ||
+        (typeof document !== 'undefined' && document.hidden)
+      ) {
+        return;
+      }
+      state.inFlight = true;
+      let live: DaemonWorkspaceSessionLiveState;
+      try {
+        live = await readLiveState(state.workspaceCwd);
+      } catch (error) {
+        if (disposed) return;
+        state.liveRetryAt = Date.now() + SESSION_LIVE_STATE_ERROR_RETRY_MS;
+        console.warn('[session-live-state] request failed:', error);
+        if (!state.acceptedVersion && !state.fallbackAttempted) {
+          state.fallbackAttempted = true;
+          try {
+            await loadFallbackBundle(state);
+          } catch (fallbackError) {
+            if (!disposed) {
+              console.warn(
+                '[session-live-state] initial catalog fallback failed:',
+                fallbackError,
+              );
+            }
+          }
+        }
+        state.inFlight = false;
+        return;
+      }
+      if (disposed) {
+        state.inFlight = false;
+        return;
+      }
+      catalogStore.applyLiveState(state.workspaceCwd, live.sessions);
+      state.liveRetryAt = 0;
+      state.reconcileRequested =
+        state.reconcileRequested ||
+        catalogStore.consumeWorkspaceLiveStateRefreshRequest(
+          state.workspaceCwd,
+        );
+      if (
+        !state.reconcileRequested &&
+        versionsEqual(state.acceptedVersion, live.catalogVersion)
+      ) {
+        state.inFlight = false;
+        return;
+      }
+      if (
+        Date.now() < state.reconcileRetryAt ||
+        (!state.reconcileRequested &&
+          Date.now() - state.lastReconcileAt <
+            SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS)
+      ) {
+        state.inFlight = false;
+        return;
+      }
+      try {
+        await reconcile(state, live, true);
+        state.reconcileRetryAt = 0;
+      } catch (error) {
+        if (!disposed) {
+          state.reconcileRetryAt =
+            Date.now() + SESSION_LIVE_STATE_ERROR_RETRY_MS;
+          console.warn('[session-live-state] reconciliation failed:', error);
+        }
+      } finally {
+        state.inFlight = false;
+      }
+    };
+
+    for (const state of states) void poll(state);
+    const interval = window.setInterval(() => {
+      for (const state of states) void poll(state);
+    }, SESSION_LIVE_STATE_POLL_MS);
+    return () => {
+      disposed = true;
+      window.clearInterval(interval);
+      for (const release of releaseLiveState) release();
+    };
+  }, [catalogStore, client, enabled, groupTargets, targets]);
+
+  return groupCatalogs;
+}

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   DaemonClient,
   DaemonSessionCatalogVersion,
@@ -23,6 +23,8 @@ interface WorkspacePollState {
   lastReconcileAt: number;
   fallbackAttempted: boolean;
   reconcileRequested: boolean;
+  invalidationRequested: boolean;
+  invalidationReconcileAt: number;
 }
 
 interface WorkspaceSessionLiveStateOptions {
@@ -33,10 +35,33 @@ interface WorkspaceSessionLiveStateOptions {
 
 function versionsEqual(
   left: DaemonSessionCatalogVersion | undefined,
-  right: DaemonSessionCatalogVersion,
+  right: DaemonSessionCatalogVersion | undefined,
 ): boolean {
   return (
-    left?.generation === right.generation && left.revision === right.revision
+    left?.generation === right?.generation && left?.revision === right?.revision
+  );
+}
+
+function groupCatalogsEqual(
+  left: DaemonSessionGroupCatalog,
+  right: DaemonSessionGroupCatalog,
+): boolean {
+  if (left.groups.length !== right.groups.length) return false;
+  if (left.colorOptions.length !== right.colorOptions.length) return false;
+  const rightById = new Map(right.groups.map((group) => [group.id, group]));
+  for (const group of left.groups) {
+    const other = rightById.get(group.id);
+    if (
+      !other ||
+      other.name !== group.name ||
+      other.color !== group.color ||
+      other.order !== group.order
+    ) {
+      return false;
+    }
+  }
+  return left.colorOptions.every(
+    (color, index) => color === right.colorOptions[index],
   );
 }
 
@@ -49,18 +74,20 @@ export function useWorkspaceSessionLiveState(
   }: WorkspaceSessionLiveStateOptions,
 ): ReadonlyMap<string, DaemonSessionGroupCatalog> {
   const catalogStore = useMemo(() => getSessionCatalogStore(client), [client]);
-  const targetsKey = JSON.stringify([...new Set(workspaceCwds)].sort());
+  const targetsKey = [...new Set(workspaceCwds)].sort().join('\n');
   const targets = useMemo(
-    () => JSON.parse(targetsKey) as string[],
+    () => targetsKey.split('\n').filter(Boolean),
     [targetsKey],
   );
-  const groupTargetsKey = JSON.stringify(
-    [...new Set(groupWorkspaceCwds)].sort(),
-  );
+  const groupTargetsKey = [...new Set(groupWorkspaceCwds)].sort().join('\n');
   const groupTargets = useMemo(
-    () => new Set(JSON.parse(groupTargetsKey) as string[]),
+    () => new Set(groupTargetsKey.split('\n').filter(Boolean)),
     [groupTargetsKey],
   );
+  const groupTargetsRef = useRef(groupTargets);
+  useEffect(() => {
+    groupTargetsRef.current = groupTargets;
+  }, [groupTargets]);
   const [groupCatalogs, setGroupCatalogs] = useState<
     ReadonlyMap<string, DaemonSessionGroupCatalog>
   >(() => new Map());
@@ -86,7 +113,16 @@ export function useWorkspaceSessionLiveState(
       }
       return next;
     });
-  }, [enabled, groupTargets, targets]);
+    // Group-membership growth (e.g. toggling the session source back to
+    // Tasks) must fetch groups for newly covered workspaces; the polling
+    // loop below intentionally does not restart on groupTargets changes.
+    if (!enabled) return;
+    for (const cwd of groupTargets) {
+      if (activeTargets.has(cwd)) {
+        catalogStore.requestWorkspaceLiveStateRefresh(cwd);
+      }
+    }
+  }, [catalogStore, enabled, groupTargets, targets]);
 
   useEffect(() => {
     if (!enabled || targets.length === 0) return;
@@ -102,6 +138,8 @@ export function useWorkspaceSessionLiveState(
       lastReconcileAt: Number.NEGATIVE_INFINITY,
       fallbackAttempted: false,
       reconcileRequested: false,
+      invalidationRequested: false,
+      invalidationReconcileAt: Number.NEGATIVE_INFINITY,
     }));
 
     const publishGroups = (
@@ -110,7 +148,10 @@ export function useWorkspaceSessionLiveState(
     ) => {
       if (!catalog || disposed) return;
       setGroupCatalogs((current) => {
-        if (current.get(workspaceCwd) === catalog) return current;
+        const previous = current.get(workspaceCwd);
+        if (previous && groupCatalogsEqual(previous, catalog)) {
+          return current;
+        }
         const next = new Map(current);
         next.set(workspaceCwd, catalog);
         return next;
@@ -128,8 +169,13 @@ export function useWorkspaceSessionLiveState(
     ): Promise<
       [StagedWorkspaceSessionCatalog, DaemonSessionGroupCatalog | undefined]
     > => {
-      const groupRequest = groupTargets.has(state.workspaceCwd)
-        ? client.workspaceByCwd(state.workspaceCwd).listSessionGroups()
+      // Groups and sessions are independent failure domains: a failing
+      // groups endpoint must not discard a committable staged catalog.
+      const groupRequest = groupTargetsRef.current.has(state.workspaceCwd)
+        ? client
+            .workspaceByCwd(state.workspaceCwd)
+            .listSessionGroups()
+            .catch(() => undefined)
         : Promise.resolve(undefined);
       return await Promise.all([
         catalogStore.stageWorkspaceRefresh(state.workspaceCwd),
@@ -139,12 +185,23 @@ export function useWorkspaceSessionLiveState(
 
     const loadFallbackBundle = async (
       state: WorkspacePollState,
-    ): Promise<void> => {
+    ): Promise<boolean> => {
       const [stagedCatalog, groups] = await stageCatalogBundle(state);
       if (disposed || !catalogStore.commitWorkspaceRefresh(stagedCatalog)) {
-        return;
+        return false;
       }
       publishGroups(state.workspaceCwd, groups);
+      return true;
+    };
+
+    const consumeRefreshRequest = (state: WorkspacePollState): void => {
+      const request = catalogStore.consumeWorkspaceLiveStateRefreshRequest(
+        state.workspaceCwd,
+      );
+      state.reconcileRequested =
+        state.reconcileRequested || request === 'interactive';
+      state.invalidationRequested =
+        state.invalidationRequested || request === 'invalidated';
     };
 
     const reconcile = async (
@@ -152,11 +209,7 @@ export function useWorkspaceSessionLiveState(
       liveA: DaemonWorkspaceSessionLiveState,
       allowTrailing: boolean,
     ): Promise<void> => {
-      state.reconcileRequested =
-        state.reconcileRequested ||
-        catalogStore.consumeWorkspaceLiveStateRefreshRequest(
-          state.workspaceCwd,
-        );
+      consumeRefreshRequest(state);
       state.lastReconcileAt = Date.now();
       const [stagedCatalog, groups] = await stageCatalogBundle(state);
       if (disposed) return;
@@ -171,11 +224,15 @@ export function useWorkspaceSessionLiveState(
         catalogStore.applyLiveState(state.workspaceCwd, liveB.sessions);
         state.acceptedVersion = liveB.catalogVersion;
         state.reconcileRequested = false;
+        state.invalidationRequested = false;
         publishGroups(state.workspaceCwd, groups);
         return;
       }
       if (allowTrailing) await reconcile(state, liveB, false);
-      else state.reconcileRequested = false;
+      else {
+        state.reconcileRequested = false;
+        state.invalidationRequested = false;
+      }
     };
 
     const poll = async (state: WorkspacePollState): Promise<void> => {
@@ -196,9 +253,10 @@ export function useWorkspaceSessionLiveState(
         state.liveRetryAt = Date.now() + SESSION_LIVE_STATE_ERROR_RETRY_MS;
         console.warn('[session-live-state] request failed:', error);
         if (!state.acceptedVersion && !state.fallbackAttempted) {
-          state.fallbackAttempted = true;
           try {
-            await loadFallbackBundle(state);
+            // Only a committed fallback latches; a failed or uncommitted
+            // attempt stays retryable on the next live-state failure.
+            state.fallbackAttempted = await loadFallbackBundle(state);
           } catch (fallbackError) {
             if (!disposed) {
               console.warn(
@@ -217,28 +275,34 @@ export function useWorkspaceSessionLiveState(
       }
       catalogStore.applyLiveState(state.workspaceCwd, live.sessions);
       state.liveRetryAt = 0;
-      state.reconcileRequested =
-        state.reconcileRequested ||
-        catalogStore.consumeWorkspaceLiveStateRefreshRequest(
-          state.workspaceCwd,
-        );
+      consumeRefreshRequest(state);
       if (
         !state.reconcileRequested &&
+        !state.invalidationRequested &&
         versionsEqual(state.acceptedVersion, live.catalogVersion)
       ) {
         state.inFlight = false;
         return;
       }
+      // Interactive requests bypass the reconcile cooldown. Lifecycle
+      // invalidations get one prompt reconcile per cooldown window — tracked
+      // on a separate timestamp so a single local create stays immediate
+      // while sustained event churn stays rate-limited.
       if (
         Date.now() < state.reconcileRetryAt ||
         (!state.reconcileRequested &&
-          Date.now() - state.lastReconcileAt <
+          (state.invalidationRequested
+            ? Date.now() - state.invalidationReconcileAt
+            : Date.now() - state.lastReconcileAt) <
             SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS)
       ) {
         state.inFlight = false;
         return;
       }
       try {
+        if (state.invalidationRequested && !state.reconcileRequested) {
+          state.invalidationReconcileAt = Date.now();
+        }
         await reconcile(state, live, true);
         state.reconcileRetryAt = 0;
       } catch (error) {
@@ -252,16 +316,36 @@ export function useWorkspaceSessionLiveState(
       }
     };
 
+    // Interactive refresh requests (explicit refresh(), expiring
+    // maxAgeMs subscriptions, group-membership growth) wake the loop
+    // immediately instead of waiting for the next 2s tick.
+    const stopWake = catalogStore.onLiveStateWake((workspaceCwd) => {
+      const state = states.find(
+        (candidate) => candidate.workspaceCwd === workspaceCwd,
+      );
+      if (state) void poll(state);
+    });
+    const onVisibilityWake = (): void => {
+      if (typeof document !== 'undefined' && document.hidden) return;
+      for (const state of states) void poll(state);
+    };
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibilityWake);
+    }
     for (const state of states) void poll(state);
     const interval = window.setInterval(() => {
       for (const state of states) void poll(state);
     }, SESSION_LIVE_STATE_POLL_MS);
     return () => {
       disposed = true;
+      stopWake();
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', onVisibilityWake);
+      }
       window.clearInterval(interval);
       for (const release of releaseLiveState) release();
     };
-  }, [catalogStore, client, enabled, groupTargets, targets]);
+  }, [catalogStore, client, enabled, targets]);
 
   return groupCatalogs;
 }


### PR DESCRIPTION
## What this PR does

This PR updates WebShell to consume the workspace-scoped session live-state protocol introduced by #9261. When the daemon advertises the capability, WebShell polls the lightweight live-state endpoint for volatile session activity and performs a full session catalog refresh only for initial loading, catalog version changes, source changes, or explicit local invalidation. Full catalog and session-group updates are staged and committed only after a stable `live A → catalog → live B` handshake, while daemons without the capability retain the existing catalog loading and polling behavior.

## Why it's needed

The sidebar previously used the full `/sessions` catalog as a frequent liveness poll. That endpoint may scan persisted sessions and merge live runtime state, so concurrent sidebar consumers could repeatedly trigger expensive scans and time out. Consuming the dedicated live-state protocol keeps the two-second activity refresh lightweight, prevents capability discovery and secondary workspace views from launching duplicate catalog requests, and ensures session and group catalogs are not published from an unfenced refresh.

## Reviewer Test Plan

### How to verify

Start WebShell against a daemon that advertises `workspace_session_live_state`, open the sidebar, and observe that initial loading performs exactly one full session catalog request bracketed by two live-state reads. Leave the sidebar open and confirm subsequent two-second polls call only the live-state endpoint. Switch the session source or trigger a local catalog mutation and confirm one version-fenced full catalog refresh occurs without a trailing duplicate. Exercise primary and secondary workspace groups, archived-session expansion, and retry behavior; capability-enabled workspaces must use the coordinated catalog while capability-disabled daemons must continue using the legacy request path.

### Evidence (Before & After)

N/A — behavior and request scheduling change only; there is no visual UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local checkout with Node.js v24.12.0 and npm 10.9.8. Validation included the complete WebShell Vitest suite, focused concurrency and compatibility tests, Playwright Chromium E2E, production build, TypeScript type checking, ESLint, Prettier for changed files, and `git diff --check`.

## Risk & Scope

- Main risk or tradeoff: The client-side catalog coordinator now owns scheduling while live-state is enabled, so incorrect ownership handoff could suppress a required refresh or publish a stale page; focused race tests cover subscription changes, explicit refreshes, version churn, and fallback to legacy scheduling.
- Not validated / out of scope: Windows and Linux were not tested locally; CI provides cross-platform coverage. This PR does not change the daemon protocol, the live-state polling interval, the full catalog deadline, or the first-load failure UI. If the first live-state request fails, WebShell performs one unfenced catalog fallback before retrying live-state with backoff.
- Breaking changes / migration notes: None. Capability detection preserves the existing behavior for older or unsupported daemons.

## Linked Issues

Follow-up to #9261.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 让 WebShell 消费 #9261 引入的 workspace-scoped session live-state 协议。当 daemon 声明该能力时，WebShell 通过轻量 live-state 接口轮询会话的易变活动状态，仅在首次加载、catalog 版本变化、source 变化或本地显式失效时刷新完整 session catalog。完整 catalog 和 session group 更新只有在稳定的 `live A → catalog → live B` 握手后才会暂存并原子发布；未声明该能力的 daemon 继续保持现有 catalog 加载和轮询行为。

## 为什么需要

此前侧边栏将完整 `/sessions` catalog 用作高频存活状态轮询。该接口可能扫描持久化 session 并合并 live runtime 状态，因此多个侧边栏消费者并发时会反复触发昂贵扫描并导致超时。消费专用 live-state 协议后，两秒一次的活动状态刷新只走轻量接口，避免 capability 探测阶段和 secondary workspace 视图产生重复 catalog 请求，并确保 session 与 group catalog 不会从未经过 fencing 的刷新结果中发布。

## Reviewer 测试计划

### 如何验证

将 WebShell 连接到声明 `workspace_session_live_state` 的 daemon，打开侧边栏，确认首次加载只发起一次完整 session catalog 请求，且前后各有一次 live-state 读取。保持侧边栏打开，确认后续两秒轮询只调用 live-state 接口。切换 session source 或触发本地 catalog mutation，确认只发生一次经过版本 fencing 的完整 catalog 刷新，没有额外 trailing 重复请求。验证 primary 和 secondary workspace group、归档 session 展开及重试行为；启用 capability 的 workspace 必须使用协调后的 catalog，不支持 capability 的 daemon 必须继续使用 legacy 请求路径。

### 证据（修改前后）

N/A — 仅改变行为和请求调度，没有可视化 UI 变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 本地检出，Node.js v24.12.0，npm 10.9.8。验证范围包括完整 WebShell Vitest 测试、针对并发与兼容性的重点测试、Playwright Chromium E2E、生产构建、TypeScript 类型检查、ESLint、改动文件 Prettier 检查以及 `git diff --check`。

## 风险与范围

- 主要风险或权衡：启用 live-state 时由客户端 catalog coordinator 负责请求调度，错误的 ownership 交接可能抑制必要刷新或发布旧页面；重点竞态测试已覆盖订阅变化、显式刷新、版本持续变化和恢复 legacy 调度。
- 未验证 / 范围外：未在本地验证 Windows 与 Linux，由 CI 提供跨平台覆盖。本 PR 不修改 daemon 协议、live-state 轮询周期、完整 catalog deadline 或首次加载失败 UI。若第一次 live-state 请求失败，WebShell 会执行一次未经过 fencing 的 catalog fallback，然后以退避策略重试 live-state。
- Breaking change / 迁移说明：无。capability 探测会为旧版或不支持该能力的 daemon 保留现有行为。

## 关联 Issue

#9261 的后续实现。

</details>
