### PR TITLE
fix(ci): route the autofix convergence-brake handoff through failure.md

### DIFF
--- a/.qwen/skills/autofix/SKILL.md
+++ b/.qwen/skills/autofix/SKILL.md
@@ -355,12 +355,17 @@ silently overriding or silently complying.
   section, the growth brake has been over budget across rounds and the diff is
   still not shrinking — the findings themselves are driving the growth, so
   Critical-only cannot help (the Criticals ARE the growth). Do NOT apply more
-  code fixes this round. This is a `defer-to-human` item: STOP `BLOCKED` with a
-  handoff that names the decision and lays out the options — split the PR (land
-  the core, track the remaining findings as follow-up issues), redesign, or
-  accept the current state with the tail deferred — plus your recommendation.
-  Continuing to patch, or deciding the split yourself, is exactly the wrong
-  move; the call is the maintainer's.
+  code fixes this round. This is a `defer-to-human` item: STOP `BLOCKED` and
+  write the handoff into `<workdir>/failure.md` — name the decision, lay out
+  the options (split the PR: land the core and track the remaining findings
+  as follow-up issues; redesign; or accept the current state with the tail
+  deferred) and give your recommendation. `failure.md` is the one stop file
+  the round's output contract accepts; run-agent.mjs wraps it into the
+  workflow's handoff comment. Do not write `handoff.md` yourself — that file
+  belongs to run-agent.mjs, and a bare handoff.md satisfies no output
+  contract, so a correct defer-to-human would still be reported as a round
+  that produced nothing. Continuing to patch, or deciding the split yourself,
+  is exactly the wrong move; the call is the maintainer's.
 - Needs a maintainer's decision: a finding that turns on a judgment that is
   NOT yours to make — a product or scope tradeoff (is this acceptable for v1?
   should the PR be split?), two reviewers asking for opposite things, or whether

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -7378,6 +7378,12 @@ exit 1
     const skill = readAutofixSkill();
     expect(skill).toContain('this PR is not converging');
     expect(skill).toContain('Diff-growth trajectory');
+    // The brake's handoff must land in failure.md — the one stop file the
+    // run-agent verdict gate accepts. Telling the agent to write handoff.md
+    // instead reproduces run 32076785809: a correct defer-to-human reported
+    // as "finished without required output file(s)".
+    expect(skill).toContain('write the handoff into `<workdir>/failure.md`');
+    expect(skill).toContain('Do not write `handoff.md` yourself');
   });
 
   it('anchors a per-window growth baseline and splits src/test nets against a real repo', () => {


### PR DESCRIPTION
## What this PR does

When the autofix loop's growth brake decides a PR's diff is not converging, the round feedback tells the agent to stop patching and hand the decision to a maintainer. This change makes that instruction name the exact output file the agent must write its handoff into, and forbids it from writing the wrapper file that the runner-side harness owns. The workflow contract test now pins the instruction so a future edit cannot silently flip it back.

## Why it's needed

On PR #9184 round 14 ([run 32076785809](https://github.com/QwenLM/qwen-code/actions/runs/32076785809)) the convergence brake fired and the agent did exactly what the feedback asked: no code changes, verified the remaining Critical finding by direct code reading, and wrote a handoff naming the decision, the options (split the PR, redesign, or accept with the tail deferred), and a recommendation. But it wrote that handoff into `handoff.md` — a file the runner-side harness generates, not one the round's verdict gate accepts (only `address-summary.md` or `no-action.md` as success verdicts, plus `failure.md` as the sole stop verdict). The round was therefore reported as "finished without required output file(s)": a correct defer-to-human burned a round as a failure, and the PR comment carried the generic gate error instead of the agent's handoff analysis.

Writing `failure.md` is already the established stop path — the runner wraps it into the workflow's handoff comment and exits zero, and the verification gate treats it as a deliberate abort. This change simply routes the brake's handoff through that existing path end to end.

## Reviewer Test Plan

### How to verify

- Read the updated non-convergence bullet in the autofix skill: it now tells the agent to write the handoff into `failure.md`, explains that this is the one stop file the round's output contract accepts, and forbids the agent from writing `handoff.md` itself (with the reason).
- Run the workflow contract test filtered on the non-convergence case (test name ends with "escalates to a maintainer-decision handoff when the diff keeps growing past budget"): it pins both directives. Reverting either directive back to the old wording fails the test.
- Expected behavior on the next brake-triggered round: the runner wraps the agent's `failure.md`, exits zero, the verification gate reports a deliberate abort, and the handoff comment's "What I found before stopping" section carries the agent's decision analysis instead of the missing-output gate error.

### Evidence (Before & After)

N/A — agent-behavior policy text and its contract test; no user-visible/TUI change. Before: see the round-14 comment on PR #9184 ("Could not produce a passing fix ... finished without required output file(s)"). After: the same situation routes through the existing `failure.md` handoff path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Contract test only: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js`. The 2 unrelated failures in that file (`bite check`, `keeps the green path intact`) also fail on the clean base tree in this local environment.

## Risk & Scope

- Main risk or tradeoff: the change is agent-facing policy wording; an ambiguous phrasing could still let a model pick the wrong file — mitigated by naming the file explicitly, stating the reason, and pinning the directive in the contract test.
- Not validated / out of scope: a live end-to-end brake round (needs a genuinely over-budget PR window to occur); the `failure.md` path itself is pre-existing and already exercised. Posting inline `comment-replies.json` replies on the handoff path remains unposted (unchanged by this PR).
- Breaking changes / migration notes: none.

## Linked Issues

Observed on PR #9184 round 14 ([run 32076785809](https://github.com/QwenLM/qwen-code/actions/runs/32076785809)); no issue filed.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 autofix 循环的增长刹车判定某个 PR 的 diff 不收敛时，该轮的 feedback 会指示 agent 停止打补丁、把决策交还给维护者。本次改动让这条指示明确写出 agent 必须把交接内容写入的具体输出文件，并禁止 agent 去写那个由 runner 侧脚本自己生成的包装文件。workflow 契约测试现在把这条指令钉住，防止未来的修改把它悄悄改回去。

## 为什么需要

在 PR #9184 第 14 轮（[run 32076785809](https://github.com/QwenLM/qwen-code/actions/runs/32076785809)）中，收敛刹车触发，agent 完全按 feedback 要求执行：不改代码、通过直接读码核实了剩余的 Critical finding、并写了一份交接，指明决策点、列出选项（拆分 PR、重新设计、或接受现状并把尾巴延后）以及推荐意见。但它把交接写进了 `handoff.md` —— 这个文件是 runner 侧脚本生成的，并不在该轮 verdict gate 接受的范围内（gate 只接受 `address-summary.md` 或 `no-action.md` 作为成功结论，外加 `failure.md` 作为唯一的停止结论）。于是该轮被上报为 "finished without required output file(s)"：一次正确的 defer-to-human 以失败姿态烧掉了一轮，PR 评论里也只有干巴巴的 gate 报错，而不是 agent 的交接分析。

写 `failure.md` 本来就是既有的停止路径 —— runner 会把它包装进 workflow 的交接评论并以零码退出，验证 gate 也将其视为有意中止。本次改动只是让刹车的交接走这条既有路径，端到端打通。

## 审阅者测试计划

### 如何验证

- 阅读 autofix skill 中更新后的 non-convergence 条目：它现在要求 agent 把交接写入 `failure.md`，说明这是该轮输出契约接受的唯一停止文件，并禁止 agent 自己写 `handoff.md`（附原因）。
- 运行按 non-convergence 用例过滤的 workflow 契约测试（测试名以 "escalates to a maintainer-decision handoff when the diff keeps growing past budget" 结尾）：它钉住了上述两条指令。把任何一条改回旧措辞都会让测试失败。
- 下一次刹车触发时的预期行为：runner 包装 agent 的 `failure.md`、零码退出，验证 gate 上报有意中止，交接评论的 "What I found before stopping" 部分呈现 agent 的决策分析，而不是 missing-output gate 报错。

### 证据（前后对比）

N/A —— agent 行为策略文本及其契约测试，无用户可见/TUI 变化。Before：见 PR #9184 第 14 轮评论（"Could not produce a passing fix ... finished without required output file(s)"）。After：同样情形将走既有的 `failure.md` 交接路径。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 运行环境（可选）

仅契约测试：`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js`。该文件中 2 个不相关的失败（`bite check`、`keeps the green path intact`）在本机干净基线树上同样失败，与本 PR 无关。

## 风险与范围

- 主要风险或权衡：改动是面向 agent 的策略措辞；含糊的表述仍可能让模型选错文件 —— 通过明确点名文件、说明原因、并在契约测试中钉住指令来缓解。
- 未验证 / 超出范围：真实的端到端刹车轮次（需要真正出现超预算的 PR 窗口）；`failure.md` 路径本身是既有的且已被使用过。交接路径下不发布内联 `comment-replies.json` 回复的行为维持不变（本 PR 未改动）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

观察于 PR #9184 第 14 轮（[run 32076785809](https://github.com/QwenLM/qwen-code/actions/runs/32076785809)）；未建 issue。

</details>
