### PR TITLE
refactor(cli): remove superseded settings dialog helpers

### DIFF
--- a/packages/cli/src/utils/settingsUtils.test.ts
+++ b/packages/cli/src/utils/settingsUtils.test.ts
@@ -7,33 +7,20 @@
 import { describe, it, expect } from 'vitest';
 import {
   // Schema utilities
-  getSettingsByCategory,
   getSettingDefinition,
   requiresRestart,
   getDefaultValue,
   getRestartRequiredSettings,
   getEffectiveValue,
   getAllSettingKeys,
-  getSettingsByType,
-  getSettingsRequiringRestart,
-  isValidSettingKey,
-  getSettingCategory,
-  shouldShowInDialog,
-  getDialogSettingsByCategory,
-  getDialogSettingsByType,
   getDialogSettingKeys,
   // Business logic utilities
-  getSettingValue,
-  isSettingModified,
   TEST_ONLY,
   settingExistsInScope,
   setPendingSettingValue,
-  hasRestartRequiredSettings,
   getRestartRequiredFromModified,
   getDisplayValue,
   isDefaultValue,
-  isValueInherited,
-  getEffectiveDisplayValue,
   setNestedPropertySafe,
   setNestedPropertyForce,
   validateSettingValue,
@@ -212,24 +199,6 @@ describe('SettingsUtils', () => {
   });
 
   describe('Schema Utilities', () => {
-    describe('getSettingsByCategory', () => {
-      it('should group settings by category', () => {
-        const categories = getSettingsByCategory();
-        expect(categories).toHaveProperty('Advanced');
-        expect(categories).toHaveProperty('Basic');
-      });
-
-      it('should include key property in grouped settings', () => {
-        const categories = getSettingsByCategory();
-
-        Object.entries(categories).forEach(([_category, settings]) => {
-          settings.forEach((setting) => {
-            expect(setting.key).toBeDefined();
-          });
-        });
-      });
-    });
-
     describe('getSettingDefinition', () => {
       it('should return definition for valid setting', () => {
         const definition = getSettingDefinition('ui.theme');
@@ -397,133 +366,6 @@ describe('SettingsUtils', () => {
       });
     });
 
-    describe('getSettingsByType', () => {
-      it('should return only boolean settings', () => {
-        const booleanSettings = getSettingsByType('boolean');
-        expect(booleanSettings.length).toBeGreaterThan(0);
-        booleanSettings.forEach((setting) => {
-          expect(setting.type).toBe('boolean');
-        });
-      });
-    });
-
-    describe('getSettingsRequiringRestart', () => {
-      it('should return only settings that require restart', () => {
-        const restartSettings = getSettingsRequiringRestart();
-        expect(restartSettings.length).toBeGreaterThan(0);
-        restartSettings.forEach((setting) => {
-          expect(setting.requiresRestart).toBe(true);
-        });
-      });
-    });
-
-    describe('isValidSettingKey', () => {
-      it('should return true for valid setting keys', () => {
-        expect(isValidSettingKey('ui.requiresRestart')).toBe(true);
-        expect(isValidSettingKey('ui.accessibility.enableLoadingPhrases')).toBe(
-          true,
-        );
-      });
-
-      it('should return false for invalid setting keys', () => {
-        expect(isValidSettingKey('invalidSetting')).toBe(false);
-        expect(isValidSettingKey('')).toBe(false);
-      });
-    });
-
-    describe('getSettingCategory', () => {
-      it('should return correct category for valid settings', () => {
-        expect(getSettingCategory('ui.requiresRestart')).toBe('UI');
-        expect(
-          getSettingCategory('ui.accessibility.enableLoadingPhrases'),
-        ).toBe('UI');
-      });
-
-      it('should return undefined for invalid settings', () => {
-        expect(getSettingCategory('invalidSetting')).toBeUndefined();
-      });
-    });
-
-    describe('shouldShowInDialog', () => {
-      it('should return true for settings marked to show in dialog', () => {
-        expect(shouldShowInDialog('ui.requiresRestart')).toBe(true);
-        expect(shouldShowInDialog('general.vimMode')).toBe(true);
-        expect(shouldShowInDialog('ui.hideWindowTitle')).toBe(true);
-      });
-
-      it('should return false for settings marked to hide from dialog', () => {
-        expect(shouldShowInDialog('ui.theme')).toBe(false);
-      });
-
-      it('should return true for invalid settings (default behavior)', () => {
-        expect(shouldShowInDialog('invalidSetting')).toBe(true);
-      });
-    });
-
-    describe('getDialogSettingsByCategory', () => {
-      it('should only return settings marked for dialog display', async () => {
-        const categories = getDialogSettingsByCategory();
-
-        // Should include UI settings that are marked for dialog
-        expect(categories['UI']).toBeDefined();
-        const uiSettings = categories['UI'];
-        const uiKeys = uiSettings.map((s) => s.key);
-        expect(uiKeys).toContain('ui.requiresRestart');
-        expect(uiKeys).toContain('ui.accessibility.enableLoadingPhrases');
-        expect(uiKeys).not.toContain('ui.theme'); // This is now marked false
-      });
-
-      it('should not include Advanced category settings', () => {
-        const categories = getDialogSettingsByCategory();
-
-        // Advanced settings should be filtered out
-        expect(categories['Advanced']).toBeUndefined();
-      });
-
-      it('should include settings with showInDialog=true', () => {
-        const categories = getDialogSettingsByCategory();
-
-        const allSettings = Object.values(categories).flat();
-        const allKeys = allSettings.map((s) => s.key);
-
-        expect(allKeys).toContain('test');
-        expect(allKeys).toContain('ui.requiresRestart');
-        expect(allKeys).not.toContain('ui.theme'); // Now hidden
-        expect(allKeys).not.toContain('general.preferredEditor'); // Now hidden
-      });
-    });
-
-    describe('getDialogSettingsByType', () => {
-      it('should return only boolean dialog settings', () => {
-        const booleanSettings = getDialogSettingsByType('boolean');
-
-        const keys = booleanSettings.map((s) => s.key);
-        expect(keys).toContain('ui.requiresRestart');
-        expect(keys).toContain('ui.accessibility.enableLoadingPhrases');
-        expect(keys).not.toContain('privacy.usageStatisticsEnabled');
-        expect(keys).not.toContain('security.auth.selectedType'); // Advanced setting
-        expect(keys).not.toContain('security.auth.useExternal'); // Advanced setting
-      });
-
-      it('should return only string dialog settings', () => {
-        const stringSettings = getDialogSettingsByType('string');
-
-        const keys = stringSettings.map((s) => s.key);
-        // Note: theme and preferredEditor are now hidden from dialog
-        expect(keys).not.toContain('ui.theme'); // Now marked false
-        expect(keys).not.toContain('general.preferredEditor'); // Now marked false
-        expect(keys).not.toContain('security.auth.selectedType'); // Advanced setting
-
-        // Check that user-facing tool settings are included
-        expect(keys).toContain('tools.shell.pager');
-
-        // Check that advanced/hidden tool settings are excluded
-        expect(keys).not.toContain('tools.discoveryCommand');
-        expect(keys).not.toContain('tools.callCommand');
-        expect(keys.every((key) => !key.startsWith('advanced.'))).toBe(true);
-      });
-    });
-
     describe('getDialogSettingKeys', () => {
       it('should return only settings marked for dialog display', () => {
         const dialogKeys = getDialogSettingKeys();
@@ -601,7 +443,7 @@ describe('SettingsUtils', () => {
         expect(existsInPending).toBe(true);
 
         // Get the value from pending settings
-        const valueFromPending = getSettingValue(
+        const valueFromPending = getEffectiveValue(
           key,
           updatedPendingSettings,
           {},
@@ -633,64 +475,6 @@ describe('SettingsUtils', () => {
   });
 
   describe('Business Logic Utilities', () => {
-    describe('getSettingValue', () => {
-      it('should return value from settings when set', () => {
-        const settings = makeMockSettings({ ui: { requiresRestart: true } });
-        const mergedSettings = makeMockSettings({
-          ui: { requiresRestart: false },
-        });
-
-        const value = getSettingValue(
-          'ui.requiresRestart',
-          settings,
-          mergedSettings,
-        );
-        expect(value).toBe(true);
-      });
-
-      it('should return value from merged settings when not set in current scope', () => {
-        const settings = makeMockSettings({});
-        const mergedSettings = makeMockSettings({
-          ui: { requiresRestart: true },
-        });
-
-        const value = getSettingValue(
-          'ui.requiresRestart',
-          settings,
-          mergedSettings,
-        );
-        expect(value).toBe(true);
-      });
-
-      it('should return default value for invalid setting', () => {
-        const settings = makeMockSettings({});
-        const mergedSettings = makeMockSettings({});
-
-        const value = getSettingValue(
-          'invalidSetting',
-          settings,
-          mergedSettings,
-        );
-        expect(value).toBe(false); // Default fallback
-      });
-    });
-
-    describe('isSettingModified', () => {
-      it('should return true when value differs from default', () => {
-        expect(isSettingModified('ui.requiresRestart', true)).toBe(true);
-        expect(
-          isSettingModified('ui.accessibility.enableLoadingPhrases', true),
-        ).toBe(true);
-      });
-
-      it('should return false when value matches default', () => {
-        expect(isSettingModified('ui.requiresRestart', false)).toBe(false);
-        expect(
-          isSettingModified('ui.accessibility.enableLoadingPhrases', false),
-        ).toBe(false);
-      });
-    });
-
     describe('settingExistsInScope', () => {
       it('should return true for top-level settings that exist', () => {
         const settings = makeMockSettings({ ui: { requiresRestart: true } });
@@ -778,26 +562,6 @@ describe('SettingsUtils', () => {
         setPendingSettingValue('ui.requiresRestart', true, pendingSettings);
 
         expect(pendingSettings).toEqual({});
-      });
-    });
-
-    describe('hasRestartRequiredSettings', () => {
-      it('should return true when modified settings require restart', () => {
-        const modifiedSettings = new Set<string>([
-          'advanced.autoConfigureMemory',
-          'ui.requiresRestart',
-        ]);
-        expect(hasRestartRequiredSettings(modifiedSettings)).toBe(true);
-      });
-
-      it('should return false when no modified settings require restart', () => {
-        const modifiedSettings = new Set<string>(['test']);
-        expect(hasRestartRequiredSettings(modifiedSettings)).toBe(false);
-      });
-
-      it('should return false for empty set', () => {
-        const modifiedSettings = new Set<string>();
-        expect(hasRestartRequiredSettings(modifiedSettings)).toBe(false);
       });
     });
 
@@ -1157,108 +921,6 @@ describe('SettingsUtils', () => {
           settings,
         );
         expect(result).toBe(false);
-      });
-    });
-
-    describe('isValueInherited', () => {
-      it('should return false for top-level settings that exist in scope', () => {
-        const settings = makeMockSettings({ ui: { requiresRestart: true } });
-        const mergedSettings = makeMockSettings({
-          ui: { requiresRestart: true },
-        });
-
-        const result = isValueInherited(
-          'ui.requiresRestart',
-          settings,
-          mergedSettings,
-        );
-        expect(result).toBe(false);
-      });
-
-      it('should return true for top-level settings that do not exist in scope', () => {
-        const settings = makeMockSettings({});
-        const mergedSettings = makeMockSettings({
-          ui: { requiresRestart: true },
-        });
-
-        const result = isValueInherited(
-          'ui.requiresRestart',
-          settings,
-          mergedSettings,
-        );
-        expect(result).toBe(true);
-      });
-
-      it('should return false for nested settings that exist in scope', () => {
-        const settings = makeMockSettings({
-          ui: { accessibility: { enableLoadingPhrases: true } },
-        });
-        const mergedSettings = makeMockSettings({
-          ui: { accessibility: { enableLoadingPhrases: true } },
-        });
-
-        const result = isValueInherited(
-          'ui.accessibility.enableLoadingPhrases',
-          settings,
-          mergedSettings,
-        );
-        expect(result).toBe(false);
-      });
-
-      it('should return true for nested settings that do not exist in scope', () => {
-        const settings = makeMockSettings({});
-        const mergedSettings = makeMockSettings({
-          ui: { accessibility: { enableLoadingPhrases: true } },
-        });
-
-        const result = isValueInherited(
-          'ui.accessibility.enableLoadingPhrases',
-          settings,
-          mergedSettings,
-        );
-        expect(result).toBe(true);
-      });
-    });
-
-    describe('getEffectiveDisplayValue', () => {
-      it('should return value from settings when available', () => {
-        const settings = makeMockSettings({ ui: { requiresRestart: true } });
-        const mergedSettings = makeMockSettings({
-          ui: { requiresRestart: false },
-        });
-
-        const result = getEffectiveDisplayValue(
-          'ui.requiresRestart',
-          settings,
-          mergedSettings,
-        );
-        expect(result).toBe(true);
-      });
-
-      it('should return value from merged settings when not in scope', () => {
-        const settings = makeMockSettings({});
-        const mergedSettings = makeMockSettings({
-          ui: { requiresRestart: true },
-        });
-
-        const result = getEffectiveDisplayValue(
-          'ui.requiresRestart',
-          settings,
-          mergedSettings,
-        );
-        expect(result).toBe(true);
-      });
-
-      it('should return default value for undefined values', () => {
-        const settings = makeMockSettings({});
-        const mergedSettings = makeMockSettings({});
-
-        const result = getEffectiveDisplayValue(
-          'ui.requiresRestart',
-          settings,
-          mergedSettings,
-        );
-        expect(result).toBe(false); // Default value
       });
     });
   });

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -13,7 +13,6 @@ import type {
 import type {
   SettingDefinition,
   SettingsSchema,
-  SettingsType,
   SettingsValue,
 } from '../config/settingsSchema.js';
 import { getSettingsSchema } from '../config/settingsSchema.js';
@@ -51,29 +50,6 @@ export function getFlattenedSchema() {
 
 function clearFlattenedSchema() {
   _FLATTENED_SCHEMA = undefined;
-}
-
-/**
- * Get all settings grouped by category
- */
-export function getSettingsByCategory(): Record<
-  string,
-  Array<SettingDefinition & { key: string }>
-> {
-  const categories: Record<
-    string,
-    Array<SettingDefinition & { key: string }>
-  > = {};
-
-  Object.values(getFlattenedSchema()).forEach((definition) => {
-    const category = definition.category;
-    if (!categories[category]) {
-      categories[category] = [];
-    }
-    categories[category].push(definition);
-  });
-
-  return categories;
 }
 
 /**
@@ -173,88 +149,6 @@ export function getEffectiveValue(
  */
 export function getAllSettingKeys(): string[] {
   return Object.keys(getFlattenedSchema());
-}
-
-/**
- * Get settings by type
- */
-export function getSettingsByType(
-  type: SettingsType,
-): Array<SettingDefinition & { key: string }> {
-  return Object.values(getFlattenedSchema()).filter(
-    (definition) => definition.type === type,
-  );
-}
-
-/**
- * Get settings that require restart
- */
-export function getSettingsRequiringRestart(): Array<
-  SettingDefinition & {
-    key: string;
-  }
-> {
-  return Object.values(getFlattenedSchema()).filter(
-    (definition) => definition.requiresRestart,
-  );
-}
-
-/**
- * Validate if a setting key exists in the schema
- */
-export function isValidSettingKey(key: string): boolean {
-  return key in getFlattenedSchema();
-}
-
-/**
- * Get the category for a setting
- */
-export function getSettingCategory(key: string): string | undefined {
-  return getFlattenedSchema()[key]?.category;
-}
-
-/**
- * Check if a setting should be shown in the settings dialog
- */
-export function shouldShowInDialog(key: string): boolean {
-  return getFlattenedSchema()[key]?.showInDialog ?? true; // Default to true for backward compatibility
-}
-
-/**
- * Get all settings that should be shown in the dialog, grouped by category
- */
-export function getDialogSettingsByCategory(): Record<
-  string,
-  Array<SettingDefinition & { key: string }>
-> {
-  const categories: Record<
-    string,
-    Array<SettingDefinition & { key: string }>
-  > = {};
-
-  Object.values(getFlattenedSchema())
-    .filter((definition) => definition.showInDialog !== false)
-    .forEach((definition) => {
-      const category = definition.category;
-      if (!categories[category]) {
-        categories[category] = [];
-      }
-      categories[category].push(definition);
-    });
-
-  return categories;
-}
-
-/**
- * Get settings by type that should be shown in the dialog
- */
-export function getDialogSettingsByType(
-  type: SettingsType,
-): Array<SettingDefinition & { key: string }> {
-  return Object.values(getFlattenedSchema()).filter(
-    (definition) =>
-      definition.type === type && definition.showInDialog !== false,
-  );
 }
 
 /**
@@ -388,46 +282,6 @@ export function getDialogSettingKeys(): string[] {
 // ============================================================================
 
 /**
- * Get the current value for a setting in a specific scope
- * Always returns a value (never undefined) - falls back to default if not set anywhere
- */
-export function getSettingValue(
-  key: string,
-  settings: Settings,
-  mergedSettings: Settings,
-): boolean {
-  const definition = getSettingDefinition(key);
-  if (!definition) {
-    return false; // Default fallback for invalid settings
-  }
-
-  const value = getEffectiveValue(key, settings, mergedSettings);
-  // Ensure we return a boolean value, converting from the more general type
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  // Fall back to default value, ensuring it's a boolean
-  const defaultValue = definition.default;
-  if (typeof defaultValue === 'boolean') {
-    return defaultValue;
-  }
-  return false; // Final fallback
-}
-
-/**
- * Check if a setting value is modified from its default
- */
-export function isSettingModified(key: string, value: boolean): boolean {
-  const defaultValue = getDefaultValue(key);
-  // Handle type comparison properly
-  if (typeof defaultValue === 'boolean') {
-    return value !== defaultValue;
-  }
-  // If default is not a boolean, consider it modified if value is true
-  return value === true;
-}
-
-/**
  * Check if a setting exists in the original settings file for a scope
  */
 export function settingExistsInScope(
@@ -555,15 +409,6 @@ export function setPendingSettingValueAny(
 }
 
 /**
- * Check if any modified settings require a restart
- */
-export function hasRestartRequiredSettings(
-  modifiedSettings: Set<string>,
-): boolean {
-  return Array.from(modifiedSettings).some((key) => requiresRestart(key));
-}
-
-/**
  * Get the restart required settings from a set of modified settings
  */
 export function getRestartRequiredFromModified(
@@ -671,29 +516,6 @@ export function getDisplayValue(
  */
 export function isDefaultValue(key: string, settings: Settings): boolean {
   return !settingExistsInScope(key, settings);
-}
-
-/**
- * Check if a setting value is inherited (not set at current scope)
- */
-export function isValueInherited(
-  key: string,
-  settings: Settings,
-  _mergedSettings: Settings,
-): boolean {
-  return !settingExistsInScope(key, settings);
-}
-
-/**
- * Get the effective value for display, considering inheritance
- * Always returns a boolean value (never undefined)
- */
-export function getEffectiveDisplayValue(
-  key: string,
-  settings: Settings,
-  mergedSettings: Settings,
-): boolean {
-  return getSettingValue(key, settings, mergedSettings);
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Removes thirteen exported helpers from the settings utility module, together with the tests that existed only to cover them. Every one of them was reachable from nothing but its own unit test: no runtime code path, in this repository or any package it publishes, called them.

They are the remains of an earlier generation of the settings-dialog API. The dialog was rebuilt on a different set of helpers in the same module and the old set was never removed, so the two generations have been sitting side by side. One of the removed predicates was a character-for-character duplicate of a helper the dialog does use; another was a one-line wrapper around a second wrapper.

Three neighbouring helpers that a naive search also flags were deliberately kept: one is still called by a live function, one is named by an in-flight design document as an API it intends to reuse, and one was needed by a surviving test as an assertion helper, so that test now calls the live function it delegated to anyway. Behaviour is unchanged — nothing that runs today loses a code path.

## Why it's needed

`AGENTS.md` opens with Simplicity First: minimum code that solves the problem, nothing speculative. A superseded API generation that only its own tests exercise is the opposite — it costs every future reader a decision about which of two near-identical helpers to call, and it costs every future refactor a set of tests that pin behaviour nothing depends on. Deleting it makes the module's real surface visible.

This is the first candidate filed on #9375 and the first PR produced by that sweep. It is deliberately one candidate, not a batch.

## Reviewer Test Plan

### How to verify

The claim to check is that nothing outside the module used these helpers. Search the repository for any of the removed names — `packages/`, `integration-tests/`, `scripts/`, `docs/`, and `.github/` — and confirm every hit is inside this diff. There is no star re-export of the module and no namespace import of it, so a name search is complete.

Then confirm the settings dialog is untouched in behaviour: it imports a different set of helpers from the same module, and its suite still passes in full.

```
cd packages/cli && npm run typecheck                       # clean
cd packages/cli && npx vitest run src/utils/settingsUtils.test.ts
    ✓ 52 tests
cd packages/cli && npx vitest run $(rg -l settingsUtils src --glob '*.test.*')
    ✓ 6 files, 188 tests — includes SettingsDialog (61)
npm run lint:ci                                            # exit 0
```

Type checking is the gate that matters most here: it is what proves no surviving code referenced a removed symbol, and it does not run in CI.

### Evidence (Before & After)

N/A — no user-visible or TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests, typecheck and lint only; no runtime invocation needed.

## Risk & Scope

- Main risk or tradeoff: an out-of-repository consumer importing these helpers by deep path. The CLI package publishes only its binary entry point and an `export` subpath, neither of which reaches this module, so the risk is theoretical rather than semver-visible.
- Not validated / out of scope: the other two candidates on #9375 — the orphaned locale keys and a three-line unused wrapper in the i18n module — are left for separate PRs. macOS and Windows were not exercised locally; the change is platform-independent.
- Breaking changes / migration notes: none.

## Linked Issues

Candidate `settings-utils-generation-a` from #9375.

<details>
<summary>Removed symbols and their evidence</summary>

<!-- find-simplifications:id=settings-utils-generation-a -->

Removed from `packages/cli/src/utils/settingsUtils.ts` (177 lines) and `packages/cli/src/utils/settingsUtils.test.ts` (336 lines), plus one now-unused type import:

`getSettingsByCategory`, `getSettingsByType`, `getSettingsRequiringRestart`, `isValidSettingKey`, `getSettingCategory`, `shouldShowInDialog`, `getDialogSettingsByCategory`, `getDialogSettingsByType`, `getSettingValue`, `isSettingModified`, `hasRestartRequiredSettings`, `isValueInherited`, `getEffectiveDisplayValue`

Consumers found for each, before removal: exactly one file, `packages/cli/src/utils/settingsUtils.test.ts`. No production file, no other package, no integration test, no documentation, no dynamic or string-keyed lookup, no `export *` re-export, no namespace import.

Kept deliberately:

- `setNestedPropertyForce` — called by the live `setPendingSettingValue`.
- `getRestartRequiredSettings` — named at `docs/design/hot-reload/settings-change-detection.md:426` as an API that design intends to reuse; that design has no implementation in the tree yet, so the helper is reserved, not dead.
- `isDefaultValue` — the surviving twin of the removed `isValueInherited`; the two had identical bodies and the dialog imports this one.

The single added line replaces a deleted helper used as an assertion aid in a surviving test with `getEffectiveValue`, which the deleted helper delegated to.

</details>

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

从设置工具模块中移除十三个导出的辅助函数，以及仅为覆盖它们而存在的测试。这些函数的唯一可达路径就是它们自己的单元测试：本仓库以及它发布的任何 package 中，都没有任何运行时代码调用它们。

它们是上一代设置对话框 API 的遗留物。对话框已在同一模块中基于另一组辅助函数重建，而旧的一组从未被移除，因此两代 API 一直并存。被移除的其中一个判定函数与对话框实际使用的某个函数逐字符完全相同；另一个则是对另一层包装的一行包装。

有三个相邻的辅助函数虽然也会被朴素搜索标记出来，但被刻意保留：一个仍被在用的函数调用；一个被一份尚在推进中的设计文档列为将要复用的 API；还有一个是某个存活测试用作断言辅助的，现在该测试改为直接调用它本就委托的那个在用函数。行为没有变化——今天在运行的代码没有失去任何路径。

## 为什么需要

`AGENTS.md` 开篇即是 Simplicity First：解决问题的最小代码量，不做任何投机性设计。一代仅由自身测试驱动的、已被取代的 API 恰恰相反——它让每位后来的读者都要判断两个近乎相同的函数该调用哪个，也让每次重构都要面对一批固定着无人依赖之行为的测试。删除它能让该模块真实的代码面显现出来。

这是 #9375 上记录的第一个候选，也是该轮扫描产出的第一个 PR。它刻意只包含一个候选，而非一批。

## 审阅测试计划

### 如何验证

需要核实的论断是：模块之外没有任何地方使用这些辅助函数。在仓库中搜索任一被移除的名称——`packages/`、`integration-tests/`、`scripts/`、`docs/`、`.github/`——确认所有命中都在本 diff 之内。该模块没有星号再导出，也没有命名空间导入，因此按名称搜索是完备的。

然后确认设置对话框的行为未受影响：它从同一模块导入的是另一组辅助函数，其测试套件仍全部通过。

```
cd packages/cli && npm run typecheck                       # 通过
cd packages/cli && npx vitest run src/utils/settingsUtils.test.ts
    ✓ 52 个测试
cd packages/cli && npx vitest run $(rg -l settingsUtils src --glob '*.test.*')
    ✓ 6 个文件，188 个测试——含 SettingsDialog 的 61 个
npm run lint:ci                                            # exit 0
```

这里最关键的门禁是类型检查：它才是"没有存活代码引用被删符号"的证明，而它并不在 CI 中运行。

### 证据（前后对比）

N/A——无用户可见或 TUI 变化。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元测试、类型检查与 lint，无需运行时调用。

## 风险与范围

- 主要风险或权衡：仓库之外可能有消费者通过深路径导入这些辅助函数。CLI package 只发布其二进制入口点和一个 `export` 子路径，二者都无法触及该模块，因此这一风险是理论上的，而非 semver 层面的破坏。
- 未验证 / 不在范围内：#9375 上的另外两个候选——孤儿语言键，以及 i18n 模块中一个三行的未使用包装函数——留待各自独立的 PR。macOS 与 Windows 未在本地验证；该改动与平台无关。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

来自 #9375 的候选 `settings-utils-generation-a`。

</details>
