### PR TITLE
feat(providers): add qwen3.8-max to Token Plan model list

### DIFF
--- a/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
+++ b/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
@@ -74,9 +74,13 @@ describe('token plan provider', () => {
         ?.modalities,
     ).toEqual({ image: true, video: true });
     expect(
-      template.find((model) => model.id === 'qwen3.8-max')?.generationConfig
-        ?.modalities,
-    ).toEqual({ image: true, video: true });
+      template.find((model) => model.id === 'qwen3.8-max')?.generationConfig,
+    ).toEqual({
+      extra_body: { enable_thinking: true },
+      thinkingMandatory: true,
+      contextWindowSize: 1000000,
+      modalities: { image: true, video: true },
+    });
     expect(
       template.find((model) => model.id === 'qwen3.8-max-preview')
         ?.generationConfig?.modalities,

--- a/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
+++ b/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
@@ -38,6 +38,7 @@ describe('token plan provider', () => {
       'qwen3.7-plus',
       'qwen3.6-plus',
       'qwen3.7-max',
+      'qwen3.8-max',
       'qwen3.8-max-preview',
       'qwen3.6-flash',
       'deepseek-v4-pro',
@@ -70,6 +71,10 @@ describe('token plan provider', () => {
     // Plus/2.5 variants are genuinely multimodal and stay that way.
     expect(
       template.find((model) => model.id === 'qwen3.6-plus')?.generationConfig
+        ?.modalities,
+    ).toEqual({ image: true, video: true });
+    expect(
+      template.find((model) => model.id === 'qwen3.8-max')?.generationConfig
         ?.modalities,
     ).toEqual({ image: true, video: true });
     expect(

--- a/packages/core/src/providers/presets/alibaba-token-plan.ts
+++ b/packages/core/src/providers/presets/alibaba-token-plan.ts
@@ -33,6 +33,13 @@ const TOKEN_PLAN_MODELS: ModelSpec[] = [
   },
   { id: 'qwen3.7-max', contextWindowSize: 1000000, enableThinking: true },
   {
+    id: 'qwen3.8-max',
+    contextWindowSize: 1000000,
+    enableThinking: true,
+    thinkingMandatory: true,
+    modalities: { image: true, video: true },
+  },
+  {
     id: 'qwen3.8-max-preview',
     contextWindowSize: 1000000,
     enableThinking: true,


### PR DESCRIPTION
## What this PR does

Adds the stable `qwen3.8-max` model to the ModelStudio Token Plan preset model list, placed right before the existing `qwen3.8-max-preview` entry, and extends the preset unit test to pin the new id and its multimodal capabilities.

## Why it's needed

`qwen3.8-max` has graduated from preview and is listed in the Bailian model catalog (https://help.aliyun.com/zh/model-studio/models), but the Token Plan preset still only ships the preview, so Token Plan users cannot select the stable model from `/model`. The wire layer already fully supports the family (tiered `reasoning_effort` via `isTieredEffortWireModel`, modality defaults, and the ACP model-configuration manifest), so only the preset list was out of sync.

## Reviewer Test Plan

### How to verify

- In `packages/core`: `npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts` — expects the template id list to contain `qwen3.8-max` before the preview entry and its modalities to equal `{ image: true, video: true }`.
- `npm run typecheck` at the repo root and `npx eslint` on both changed files pass.
- Optionally sign in with a Token Plan key and confirm `/model` shows `[ModelStudio Token Plan] qwen3.8-max`.

### Evidence (Before & After)

N/A — preset data change covered by unit tests; no live Token Plan key available for TUI verification.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

npm ci + vitest on macOS (node v25).

## Risk & Scope

- Main risk or tradeoff: accounts whose Token Plan endpoint does not expose `qwen3.8-max` yet would get a provider-side error if they select it; the list entry itself is additive and the default model stays `qwen3.7-plus` (first entry unchanged).
- Not validated / out of scope: live requests against the Token Plan endpoint; the Coding Plan preset is intentionally untouched.
- Breaking changes / migration notes: none; existing installs receive the standard model-list update prompt via `computeModelListVersion`.

## Linked Issues

Closes #9376. Related: #8432, #9368.

<details>
<summary>中文说明</summary>

## What this PR does

在 ModelStudio Token Plan 预置模型列表中加入正式版 `qwen3.8-max`，位置放在现有 `qwen3.8-max-preview` 之前，并扩展预置单元测试以固定新模型 id 及其多模态能力。

## Why it's needed

`qwen3.8-max` 已从 preview 转正并列入百炼模型大全，但 Token Plan 预置仍只带 preview，导致 Token Plan 用户无法在 `/model` 中选择正式版。wire 层已完整支持该模型族（`isTieredEffortWireModel` 的分档 `reasoning_effort`、模态默认值、ACP 模型配置 manifest），只有预置列表没跟上。

## Reviewer Test Plan

### How to verify

- 在 `packages/core` 下运行 `npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts`，预期模板 id 列表在 preview 之前包含 `qwen3.8-max`，且其 modalities 为 `{ image: true, video: true }`。
- 仓库根 `npm run typecheck` 与对两个改动文件的 `npx eslint` 均通过。
- 可选：用 Token Plan key 登录后确认 `/model` 显示 `[ModelStudio Token Plan] qwen3.8-max`。

### Evidence (Before & After)

N/A —— 预置数据变更，由单元测试覆盖；无可用 Token Plan key，未做 TUI 实测。

### Tested on

macOS ✅；Windows ⚠️ 未测；Linux ⚠️ 未测。

### Environment (optional)

macOS 上 npm ci + vitest（node v25）。

## Risk & Scope

- 主要风险：若个别账号的 Token Plan 端点尚未开放 `qwen3.8-max`，选择后会收到服务端报错；列表条目本身是纯新增，默认模型仍为 `qwen3.7-plus`（首条目未变）。
- 未验证/超出范围：对 Token Plan 端点的真实请求；Coding Plan 预置本次不动。
- 破坏性变更：无；已有安装通过 `computeModelListVersion` 机制收到常规模型列表更新提示。

## Linked Issues

Closes #9376。相关：#8432、#9368。

</details>
