### PR TITLE
fix(autofix): paginate review threads instead of reaching the oldest 100

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -6259,8 +6259,11 @@ jobs:
             # load-bearing for the same reason: the scanner carries its flags
             # across pageInfo objects and breaks at the first one yielding
             # both, so alphabetizing to pageInfo{endCursor hasNextPage} makes
-            # it break on the outer endCursor with hasNextPage already true
-            # from the last inner page — the same silent stop after page one.
+            # it break on the outer endCursor while hasNextPage still carries
+            # the last INNER page's value (almost always false — thread comment
+            # pages rarely truncate, and the outer page's own hasNextPage is
+            # read only after the break) — gh then returns no cursor and the
+            # walk silently stops after page one.
             if [[ -s "${WORKDIR}/resolved-comments.txt" || -s "${WORKDIR}/comment-replies.json" ]]; then
               THREADS_FETCH_OK='true'
               THREADS_RAW="$(gh api graphql --paginate -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -6266,6 +6266,19 @@ jobs:
             # walk silently stops after page one.
             if [[ -s "${WORKDIR}/resolved-comments.txt" || -s "${WORKDIR}/comment-replies.json" ]]; then
               THREADS_FETCH_OK='true'
+              # gh's stderr goes to a fresh mktemp regular file, never a named
+              # WORKDIR path: WORKDIR is bind-mounted read-write into the agent
+              # sandbox, so branch code from the round that just ran can plant
+              # anything it likes at a predictable name here. A planted FIFO
+              # blocks bash's O_WRONLY open before gh even execs, and the only
+              # reader is the tail below gh — so the step would hang to the job
+              # timeout AFTER the push landed, losing the report and the round
+              # markers and breaking this block's own invariant that a resolve
+              # failure must never fail a good push. A planted symlink would
+              # instead truncate its target and fold 300 bytes of it into a
+              # public ::warning::. Same reasoning, same shape as the `gh api
+              # user` checks elsewhere in this file.
+              threads_err_file="$(mktemp)"
               THREADS_RAW="$(gh api graphql --paginate -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
                 query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
                   repository(owner:$owner,name:$name){
@@ -6276,7 +6289,7 @@ jobs:
                       }
                     }
                   }
-                }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]' 2> "${WORKDIR}/threads-fetch.err")" || THREADS_FETCH_OK='false'
+                }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]' 2> "${threads_err_file}")" || THREADS_FETCH_OK='false'
               # gh emits one node per line across every page; slurp them
               # into the flat array both blocks below already expect. The
               # stream is consumed inline into a shell variable and never
@@ -6298,8 +6311,9 @@ jobs:
                 # stopped, and only this says WHY — a transient rate limit
                 # (back off) reads identically to an expired PAT (rotate) or a
                 # network failure without it.
-                echo "::warning::review-thread pagination did not complete; $(jq 'length' <<< "${THREADS_JSON}") thread(s) fetched, and any thread past them will not be resolved or answered in-thread: $(tail -c 300 "${WORKDIR}/threads-fetch.err" 2> /dev/null | tr '\r\n' '  ')"
+                echo "::warning::review-thread pagination did not complete; $(jq 'length' <<< "${THREADS_JSON}") thread(s) fetched, and any thread past them will not be resolved or answered in-thread: $(tail -c 300 "${threads_err_file}" 2> /dev/null | tr '\r\n' '  ')"
               fi
+              rm -f "${threads_err_file}"
               if [[ "$(jq -r 'map(select(.comments.pageInfo.hasNextPage)) | length' <<< "${THREADS_JSON}")" != "0" ]]; then
                 echo "::warning::a review thread carries more than 100 comments; a comment past that page is not mapped to its thread"
               fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -6236,20 +6236,44 @@ jobs:
             # inline-comment id to its review thread, so the threads are
             # fetched once here and shared. Hoisted above both so a round that
             # only replies (no resolved-comments.txt) still has them.
-            # first-100 page cap: a comment in a thread past this page is not
-            # mapped, and each block falls back to the id as given.
+            # Paginated, because GitHub returns reviewThreads in ASCENDING
+            # creation order: a single first-100 page is the OLDEST hundred,
+            # which on a long-running PR is precisely not the threads this
+            # round is answering. Measured on #8403 (1256 threads): one page
+            # reached 8% of them, so an implemented Critical past it stayed
+            # open and read as unaddressed, and a decline past it was answered
+            # by silence — the two outcomes this function exists to prevent.
+            # A partial fetch is USED, not discarded: losing twelve good pages
+            # to a rate limit on the thirteenth would resolve nothing at all,
+            # so the failure is announced and the threads in hand still map.
+            # Residual: a thread with more than 100 comments still truncates,
+            # so a comment past that page is unmapped and each block falls
+            # back to the id as given; announced below, and unobserved so far.
             if [[ -s "${WORKDIR}/resolved-comments.txt" || -s "${WORKDIR}/comment-replies.json" ]]; then
-              THREADS_RAW="$(gh api graphql -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
-                query($owner:String!,$name:String!,$pr:Int!){
+              THREADS_FETCH_OK='true'
+              THREADS_RAW="$(gh api graphql --paginate -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
+                query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
                   repository(owner:$owner,name:$name){
                     pullRequest(number:$pr){
-                      reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{databaseId}}} pageInfo{hasNextPage}}
+                      reviewThreads(first:100, after:$endCursor){
+                        nodes{id isResolved comments(first:100){nodes{databaseId} pageInfo{hasNextPage}}}
+                        pageInfo{hasNextPage endCursor}
+                      }
                     }
                   }
-                }' --jq '(.data.repository.pullRequest.reviewThreads // {nodes:[]})' 2> /dev/null || echo '{"nodes":[]}')"
-              THREADS_JSON="$(jq '.nodes' <<< "${THREADS_RAW}")"
-              if [[ "$(jq -r '.pageInfo.hasNextPage // false' <<< "${THREADS_RAW}")" == "true" ]]; then
-                echo "::warning::PR has more than 100 review threads; threads past the first page will not be resolved or answered in-thread"
+                }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]' 2> /dev/null)" || THREADS_FETCH_OK='false'
+              # gh emits one node per line across every page; slurp them
+              # into the flat array both blocks below already expect. The
+              # stream is consumed inline into a shell variable and never
+              # lands in a WORKDIR json file, so it takes no part in the
+              # slurp normalizer the paginated WORKDIR fetches share.
+              THREADS_JSON="$(jq -s '.' <<< "${THREADS_RAW}" 2> /dev/null)" || THREADS_JSON='[]'
+              [[ -n "${THREADS_JSON}" ]] || THREADS_JSON='[]'
+              if [[ "${THREADS_FETCH_OK}" != 'true' ]]; then
+                echo "::warning::review-thread pagination did not complete; $(jq 'length' <<< "${THREADS_JSON}") thread(s) fetched, and any thread past them will not be resolved or answered in-thread"
+              fi
+              if [[ "$(jq -r 'map(select(.comments.pageInfo.hasNextPage)) | length' <<< "${THREADS_JSON}")" != "0" ]]; then
+                echo "::warning::a review thread carries more than 100 comments; a comment past that page is not mapped to its thread"
               fi
             fi
             if [[ "${CAN_RESOLVE_THREADS}" == 'true' ]]; then
@@ -6338,8 +6362,9 @@ jobs:
                 # replies are not supported"), and rc_id can itself be a reply
                 # id — the feedback step lists every review comment, replies
                 # included. Map to the thread's top-level comment (the one
-                # valid target), falling back to rc_id when the thread is past
-                # the first-100 page cap and so absent from THREADS_JSON.
+                # valid target), falling back to rc_id when the comment is
+                # absent from THREADS_JSON — a thread past a partial fetch, or
+                # a comment past its own thread's first-100 comment page.
                 root_id="$(jq -r --argjson id "${rc_id}" \
                   'map(select(any(.comments.nodes[]; .databaseId == $id)))
                    | .[0].comments.nodes[0].databaseId // $id' <<< "${THREADS_JSON}")"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -6255,7 +6255,12 @@ jobs:
             # hijack the thread-page cursor and stop after page one (exit 0, no
             # warning) — silently restoring the oldest-hundred bug this fetch
             # exists to fix. The outer cursor wins only because the inner
-            # pageInfo asks for hasNextPage alone.
+            # pageInfo asks for hasNextPage alone. The outer field ORDER is
+            # load-bearing for the same reason: the scanner carries its flags
+            # across pageInfo objects and breaks at the first one yielding
+            # both, so alphabetizing to pageInfo{endCursor hasNextPage} makes
+            # it break on the outer endCursor with hasNextPage already true
+            # from the last inner page — the same silent stop after page one.
             if [[ -s "${WORKDIR}/resolved-comments.txt" || -s "${WORKDIR}/comment-replies.json" ]]; then
               THREADS_FETCH_OK='true'
               THREADS_RAW="$(gh api graphql --paginate -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
@@ -6274,14 +6279,23 @@ jobs:
               # stream is consumed inline into a shell variable and never
               # lands in a WORKDIR json file, so it takes no part in the
               # slurp normalizer the paginated WORKDIR fetches share.
-              THREADS_JSON="$(jq -s '.' <<< "${THREADS_RAW}" 2> /dev/null)" || THREADS_JSON='[]'
+              # Keep only thread-shaped documents: on a failing page gh skips
+              # --jq and appends that page's raw response body (a rate-limit
+              # message, or a GraphQL error envelope) to stdout after the good
+              # nodes. Slurped unfiltered it becomes a stray element, and the
+              # consumers below iterate .comments.nodes[] over it and exit 5 —
+              # which under errexit aborts this step AFTER a good push, losing
+              # the report and the markers. Both invariants above forbid that:
+              # a resolve failure must never fail a good push, and a partial
+              # fetch is used rather than discarded.
+              THREADS_JSON="$(jq -s '[.[] | select(type == "object" and has("id") and has("comments"))]' <<< "${THREADS_RAW}" 2> /dev/null)" || THREADS_JSON='[]'
               [[ -n "${THREADS_JSON}" ]] || THREADS_JSON='[]'
               if [[ "${THREADS_FETCH_OK}" != 'true' ]]; then
                 # Fold in gh's stderr: the warning announces THAT pagination
                 # stopped, and only this says WHY — a transient rate limit
                 # (back off) reads identically to an expired PAT (rotate) or a
                 # network failure without it.
-                echo "::warning::review-thread pagination did not complete; $(jq 'length' <<< "${THREADS_JSON}") thread(s) fetched, and any thread past them will not be resolved or answered in-thread: $(tail -c 300 "${WORKDIR}/threads-fetch.err" 2> /dev/null)"
+                echo "::warning::review-thread pagination did not complete; $(jq 'length' <<< "${THREADS_JSON}") thread(s) fetched, and any thread past them will not be resolved or answered in-thread: $(tail -c 300 "${WORKDIR}/threads-fetch.err" 2> /dev/null | tr '\r\n' '  ')"
               fi
               if [[ "$(jq -r 'map(select(.comments.pageInfo.hasNextPage)) | length' <<< "${THREADS_JSON}")" != "0" ]]; then
                 echo "::warning::a review thread carries more than 100 comments; a comment past that page is not mapped to its thread"

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -6249,6 +6249,13 @@ jobs:
             # Residual: a thread with more than 100 comments still truncates,
             # so a comment past that page is unmapped and each block falls
             # back to the id as given; announced below, and unobserved so far.
+            # Do NOT close that residual by adding endCursor to the inner
+            # comments pageInfo: gh's paginator adopts the FIRST pageInfo
+            # carrying both hasNextPage and endCursor, so the inner one would
+            # hijack the thread-page cursor and stop after page one (exit 0, no
+            # warning) — silently restoring the oldest-hundred bug this fetch
+            # exists to fix. The outer cursor wins only because the inner
+            # pageInfo asks for hasNextPage alone.
             if [[ -s "${WORKDIR}/resolved-comments.txt" || -s "${WORKDIR}/comment-replies.json" ]]; then
               THREADS_FETCH_OK='true'
               THREADS_RAW="$(gh api graphql --paginate -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="${PR}" -f query='
@@ -6261,7 +6268,7 @@ jobs:
                       }
                     }
                   }
-                }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]' 2> /dev/null)" || THREADS_FETCH_OK='false'
+                }' --jq '.data.repository.pullRequest.reviewThreads.nodes[]' 2> "${WORKDIR}/threads-fetch.err")" || THREADS_FETCH_OK='false'
               # gh emits one node per line across every page; slurp them
               # into the flat array both blocks below already expect. The
               # stream is consumed inline into a shell variable and never
@@ -6270,7 +6277,11 @@ jobs:
               THREADS_JSON="$(jq -s '.' <<< "${THREADS_RAW}" 2> /dev/null)" || THREADS_JSON='[]'
               [[ -n "${THREADS_JSON}" ]] || THREADS_JSON='[]'
               if [[ "${THREADS_FETCH_OK}" != 'true' ]]; then
-                echo "::warning::review-thread pagination did not complete; $(jq 'length' <<< "${THREADS_JSON}") thread(s) fetched, and any thread past them will not be resolved or answered in-thread"
+                # Fold in gh's stderr: the warning announces THAT pagination
+                # stopped, and only this says WHY — a transient rate limit
+                # (back off) reads identically to an expired PAT (rotate) or a
+                # network failure without it.
+                echo "::warning::review-thread pagination did not complete; $(jq 'length' <<< "${THREADS_JSON}") thread(s) fetched, and any thread past them will not be resolved or answered in-thread: $(tail -c 300 "${WORKDIR}/threads-fetch.err" 2> /dev/null)"
               fi
               if [[ "$(jq -r 'map(select(.comments.pageInfo.hasNextPage)) | length' <<< "${THREADS_JSON}")" != "0" ]]; then
                 echo "::warning::a review thread carries more than 100 comments; a comment past that page is not mapped to its thread"

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -15641,9 +15641,14 @@ exit 1
         'if [[ "$query" == *"reviewThreads(first:100, after:\\$endCursor)"* ]]; then',
         '  [[ " $* " == *" --paginate "* ]] || exit 3',
         '  printf \'%s\' "$THREADS_RAW_STUB"',
-        '  # Real gh writes the reason to stderr; the workflow folds its tail',
-        '  # into the warning, so the stub must produce one to assert on.',
-        '  [[ "${THREADS_FETCH_EXIT:-0}" == 0 ]] || echo "threads-fetch stub failure" >&2',
+        '  if [[ "${THREADS_FETCH_EXIT:-0}" != 0 ]]; then',
+        "    # On a failing page real gh skips --jq and appends that page's raw",
+        '    # response body to stdout, after the good nodes.',
+        '    [[ -z "${THREADS_ERROR_BODY_STUB:-}" ]] || printf \'\\n%s\' "$THREADS_ERROR_BODY_STUB"',
+        '    # Real gh writes the reason to stderr; the workflow folds its tail',
+        '    # into the warning, so the stub must produce one to assert on.',
+        '    printf \'%s\\n\' "${THREADS_STDERR_STUB:-threads-fetch stub failure}" >&2',
+        '  fi',
         '  exit "${THREADS_FETCH_EXIT:-0}"',
         'fi',
         'if [[ "$query" == *PullRequestReviewThread* ]]; then',
@@ -15769,6 +15774,12 @@ exit 1
     // (an $endCursor variable plus pageInfo), or the stub gh exits 3.
     expect(block).toContain('--paginate');
     expect(block).toContain('reviewThreads(first:100, after:$endCursor)');
+    // Field order, not just presence: gh's cursor scanner carries its flags
+    // across pageInfo objects and breaks at the first one yielding both
+    // fields, so pageInfo{endCursor hasNextPage} would break on the outer
+    // endCursor with hasNextPage already true from the last inner page — gh
+    // then stops after page one with exit 0 and no warning, restoring the
+    // oldest-hundred bug silently. Do not "fix" this pin by reordering it.
     expect(block).toContain('pageInfo{hasNextPage endCursor}');
 
     const matching = runResolve();
@@ -15946,6 +15957,49 @@ exit 1
     // …and carries gh's own stderr, the only text that separates a transient
     // rate limit (back off) from an expired PAT (rotate credentials).
     expect(partialFetch.out).toContain('threads-fetch stub failure');
+
+    // …and the failing page's own response body, which gh appends to stdout
+    // after the good nodes (it skips --jq on an error response), must not
+    // survive the slurp as a stray thread: both consumers below iterate
+    // .comments.nodes[], so a stray element exits 5 and — under errexit —
+    // aborts this step AFTER a good push, dropping the report and markers.
+    for (const errorBody of [
+      '{"message": "API rate limit exceeded for user \'x\'."}',
+      '{"data": null, "errors": [{"message": "Something went wrong while executing your query."}]}',
+    ]) {
+      const poisoned = runResolve({
+        THREADS_FETCH_EXIT: '1',
+        THREADS_ERROR_BODY_STUB: errorBody,
+      });
+      expect(poisoned.status).toBe(0);
+      expect(poisoned.resolved).toEqual(['resolve:T_open_1']);
+      // 4 stub threads, not 5: the error body was dropped, not counted.
+      expect(poisoned.out).toContain(
+        'review-thread pagination did not complete; 4 thread(s) fetched',
+      );
+    }
+
+    // The folded reason must land ON the annotation. Actions parses workflow
+    // commands line by line, and gh's stderr for a secondary rate limit spans
+    // two lines, so an unflattened fold keeps only the first — cutting off
+    // the very words that separate a back-off from a credential rotation.
+    const multiLineReason = runResolve({
+      THREADS_FETCH_EXIT: '1',
+      THREADS_STDERR_STUB:
+        "gh: API rate limit exceeded for user 'x'.\nYou have exceeded a secondary rate limit. Please wait a few minutes.",
+    });
+    expect(multiLineReason.status).toBe(0);
+    const paginationWarning = multiLineReason.out
+      .split('\n')
+      .find((line) =>
+        line.includes('review-thread pagination did not complete'),
+      );
+    expect(paginationWarning).toContain(
+      "gh: API rate limit exceeded for user 'x'.",
+    );
+    expect(paginationWarning).toContain(
+      'You have exceeded a secondary rate limit.',
+    );
 
     // The residual cap the fix does NOT close: a thread carrying more than
     // 100 comments still truncates, so a comment past that page is unmapped.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -15777,9 +15777,11 @@ exit 1
     // Field order, not just presence: gh's cursor scanner carries its flags
     // across pageInfo objects and breaks at the first one yielding both
     // fields, so pageInfo{endCursor hasNextPage} would break on the outer
-    // endCursor with hasNextPage already true from the last inner page — gh
-    // then stops after page one with exit 0 and no warning, restoring the
-    // oldest-hundred bug silently. Do not "fix" this pin by reordering it.
+    // endCursor while hasNextPage still carries the last INNER page's value —
+    // almost always false, and the outer page's own hasNextPage is read only
+    // after the break. gh then returns no cursor and stops after page one with
+    // exit 0 and no warning, restoring the oldest-hundred bug silently. Do not
+    // "fix" this pin by reordering it.
     expect(block).toContain('pageInfo{hasNextPage endCursor}');
 
     const matching = runResolve();

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -3045,7 +3045,7 @@ describe('qwen-autofix workflow', () => {
     // forces a deliberate test update, however it is spaced or line-wrapped:
     // bump this count AND pipe the new site through the normalizer (bumping
     // the count below too) — bumping this pin alone leaves toBe(10) green.
-    expect(workflow.split('--paginate').length - 1).toBe(18);
+    expect(workflow.split('--paginate').length - 1).toBe(19);
     // scan ic + pr-events + ic re-fetch + scan rv/rc + prepare rv/rc/ic +
     // report COMMENTS_JSON fallback + the cap-branch release-evidence events
     // fetch (R4-1) = ten normalized fetch sites. The
@@ -3059,7 +3059,11 @@ describe('qwen-autofix workflow', () => {
     // The R11-2 engaged-stale guard's comments/events reads in
     // takeover-ack are the same class too: captured into shell variables
     // and consumed by slurp-style `jq -rs 'add // [] | …'` (idempotent
-    // over a single flat array), never a WORKDIR file.
+    // over a single flat array), never a WORKDIR file. The review-thread
+    // fetch in resolve_and_reply_threads is the same class again — a GraphQL
+    // paginate whose `--jq '…nodes[]'` stream is slurped straight into
+    // THREADS_JSON — so it bumps the total pin above without joining the
+    // normalizer count below.
     expect(workflow.split("jq -s 'add // []'").length - 1).toBe(10);
     // Empty-input semantics: a total gh failure feeds the fallback an EMPTY
     // stream, where the normalizer filter must yield '[]' and not 'null' —
@@ -15634,9 +15638,10 @@ exit 1
         '  [[ "$a" == query=* ]] && query="${a#query=}"',
         '  [[ "$a" == threadId=* ]] && thread_id="${a#threadId=}"',
         'done',
-        'if [[ "$query" == *"reviewThreads(first:100)"* ]]; then',
+        'if [[ "$query" == *"reviewThreads(first:100, after:\\$endCursor)"* ]]; then',
+        '  [[ " $* " == *" --paginate "* ]] || exit 3',
         '  printf \'%s\' "$THREADS_RAW_STUB"',
-        '  exit 0',
+        '  exit "${THREADS_FETCH_EXIT:-0}"',
         'fi',
         'if [[ "$query" == *PullRequestReviewThread* ]]; then',
         '  saw_jq=false; saw_guard_filter=false',
@@ -15673,31 +15678,45 @@ exit 1
     const localHead = execFileSync('git', ['rev-parse', 'HEAD'], {
       encoding: 'utf8',
     }).trim();
-    const threadsRaw = JSON.stringify({
-      nodes: [
-        {
-          id: 'T_open_1',
-          isResolved: false,
-          comments: { nodes: [{ databaseId: 111 }] },
+    // The real `gh --paginate --jq '...nodes[]'` emits ONE node per line,
+    // concatenated across every page — so the stub stands in for gh's output
+    // after its own jq, not for the raw GraphQL envelope. Two "pages" worth
+    // are interleaved deliberately: the block must treat them as one stream.
+    const threadNodes = [
+      {
+        id: 'T_open_1',
+        isResolved: false,
+        comments: {
+          nodes: [{ databaseId: 111 }],
+          pageInfo: { hasNextPage: false },
         },
-        {
-          id: 'T_open_2',
-          isResolved: false,
-          comments: { nodes: [{ databaseId: 222 }] },
+      },
+      {
+        id: 'T_open_2',
+        isResolved: false,
+        comments: {
+          nodes: [{ databaseId: 222 }],
+          pageInfo: { hasNextPage: false },
         },
-        {
-          id: 'T_open_3',
-          isResolved: false,
-          comments: { nodes: [{ databaseId: 444 }] },
+      },
+      {
+        id: 'T_open_3',
+        isResolved: false,
+        comments: {
+          nodes: [{ databaseId: 444 }],
+          pageInfo: { hasNextPage: false },
         },
-        {
-          id: 'T_done',
-          isResolved: true,
-          comments: { nodes: [{ databaseId: 333 }] },
+      },
+      {
+        id: 'T_done',
+        isResolved: true,
+        comments: {
+          nodes: [{ databaseId: 333 }],
+          pageInfo: { hasNextPage: false },
         },
-      ],
-      pageInfo: { hasNextPage: false },
-    });
+      },
+    ];
+    const threadsRaw = threadNodes.map((n) => JSON.stringify(n)).join('\n');
     const headReadCount = join(dir, 'head-read-count');
     const threadStateFile = join(dir, 'thread-state');
     const runResolve = (env = {}) => {
@@ -15739,6 +15758,15 @@ exit 1
     expect(block).toContain(
       'node(id:$threadId){... on PullRequestReviewThread{isResolved}}',
     );
+
+    // The fix this block exists for: GitHub returns reviewThreads in
+    // ASCENDING creation order, so an unpaginated first-100 page is the
+    // OLDEST hundred — precisely not the threads the current round answers.
+    // Ask for pagination, and ask for it in the shape gh's --paginate needs
+    // (an $endCursor variable plus pageInfo), or the stub gh exits 3.
+    expect(block).toContain('--paginate');
+    expect(block).toContain('reviewThreads(first:100, after:$endCursor)');
+    expect(block).toContain('pageInfo{hasNextPage endCursor}');
 
     const matching = runResolve();
     expect(matching.status).toBe(0);
@@ -15871,6 +15899,67 @@ exit 1
     );
     expect(movedBeforeSecondMutation.out).toContain(
       'confirmed 1 selected review thread(s) resolved',
+    );
+
+    // A thread far past the old first-100 cap must resolve like any other:
+    // #8403 carries 1256 threads, and one page reached 8% of them. The target
+    // sits at index 400 of the stream, so any surviving hundred-item ceiling
+    // in the slurp would drop it.
+    writeFileSync(join(dir, 'resolved-comments.txt'), 'rc:900001\n');
+    const deepStream = [
+      ...Array.from({ length: 400 }, (_, i) => ({
+        id: `T_filler_${i}`,
+        isResolved: false,
+        comments: {
+          nodes: [{ databaseId: 800000 + i }],
+          pageInfo: { hasNextPage: false },
+        },
+      })),
+      {
+        id: 'T_page_five',
+        isResolved: false,
+        comments: {
+          nodes: [{ databaseId: 900001 }],
+          pageInfo: { hasNextPage: false },
+        },
+      },
+    ]
+      .map((n) => JSON.stringify(n))
+      .join('\n');
+    const pastFirstPage = runResolve({ THREADS_RAW_STUB: deepStream });
+    expect(pastFirstPage.status).toBe(0);
+    expect(pastFirstPage.resolved).toEqual(['resolve:T_page_five']);
+
+    // A pagination that dies partway (rate limit on a later page) USES what it
+    // got rather than discarding it — throwing away twelve good pages to fail
+    // on the thirteenth would resolve nothing at all — and says so.
+    writeFileSync(join(dir, 'resolved-comments.txt'), 'rc:111\n');
+    const partialFetch = runResolve({ THREADS_FETCH_EXIT: '1' });
+    expect(partialFetch.status).toBe(0);
+    expect(partialFetch.resolved).toEqual(['resolve:T_open_1']);
+    expect(partialFetch.out).toContain(
+      'review-thread pagination did not complete',
+    );
+
+    // The residual cap the fix does NOT close: a thread carrying more than
+    // 100 comments still truncates, so a comment past that page is unmapped.
+    // Unobserved in the live pool, and announced rather than hidden.
+    const innerTruncated = [
+      {
+        id: 'T_open_1',
+        isResolved: false,
+        comments: {
+          nodes: [{ databaseId: 111 }],
+          pageInfo: { hasNextPage: true },
+        },
+      },
+    ]
+      .map((n) => JSON.stringify(n))
+      .join('\n');
+    const deepThread = runResolve({ THREADS_RAW_STUB: innerTruncated });
+    expect(deepThread.status).toBe(0);
+    expect(deepThread.out).toContain(
+      'carries more than 100 comments; a comment past that page is not mapped',
     );
     writeFileSync(join(dir, 'resolved-comments.txt'), 'rc:111\r\n333\n999\n');
 

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -12,6 +12,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -16002,6 +16003,46 @@ exit 1
     expect(paginationWarning).toContain(
       'You have exceeded a secondary rate limit.',
     );
+
+    // R4-1: gh's stderr must not go to a NAMED path under WORKDIR. WORKDIR is
+    // bind-mounted read-write into the agent sandbox, and the round that just
+    // ran executes branch code inside it, so anything at a predictable name
+    // here is attacker-chosen by the time this step runs. A planted FIFO makes
+    // bash block on the O_WRONLY open before gh execs — and the only reader is
+    // the tail AFTER gh returns — so the step hangs to the job timeout with
+    // the push already landed, losing the report and the round markers. A
+    // planted symlink instead truncates its target and folds 300 bytes of it
+    // into a public ::warning::. Probe both plants; the fix (a fresh mktemp
+    // regular file) makes the named path irrelevant, so neither can bite.
+    const canaryTarget = join(dir, 'canary-secret');
+    writeFileSync(canaryTarget, 'CANARY-MUST-SURVIVE\n');
+    const plantedPath = join(dir, 'threads-fetch.err');
+    rmSync(plantedPath, { force: true });
+    symlinkSync(canaryTarget, plantedPath);
+    const symlinkPlant = runResolve({ THREADS_FETCH_EXIT: '1' });
+    expect(symlinkPlant.status).toBe(0);
+    // Still reports, and still carries gh's own reason — the plant changed
+    // nothing about the diagnostic.
+    expect(symlinkPlant.out).toContain(
+      'review-thread pagination did not complete',
+    );
+    expect(symlinkPlant.out).toContain('threads-fetch stub failure');
+    // …and the symlink's target was never opened for write. Under the
+    // pre-fix `2> "${WORKDIR}/threads-fetch.err"` this file is truncated and
+    // overwritten with gh's stderr.
+    expect(readFileSync(canaryTarget, 'utf8')).toBe('CANARY-MUST-SURVIVE\n');
+    // …and the canary's bytes were never read back out into the annotation.
+    expect(symlinkPlant.out).not.toContain('CANARY-MUST-SURVIVE');
+    rmSync(plantedPath, { force: true });
+
+    // The named path is not written at all — the assertion that kills the
+    // mutation directly, and the same property that defuses the FIFO plant
+    // (a FIFO test cannot be written as a plain assertion: under the pre-fix
+    // code it hangs rather than fails).
+    const noNamedFile = runResolve({ THREADS_FETCH_EXIT: '1' });
+    expect(noNamedFile.status).toBe(0);
+    expect(noNamedFile.out).toContain('threads-fetch stub failure');
+    expect(existsSync(plantedPath)).toBe(false);
 
     // The residual cap the fix does NOT close: a thread carrying more than
     // 100 comments still truncates, so a comment past that page is unmapped.

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -15641,6 +15641,9 @@ exit 1
         'if [[ "$query" == *"reviewThreads(first:100, after:\\$endCursor)"* ]]; then',
         '  [[ " $* " == *" --paginate "* ]] || exit 3',
         '  printf \'%s\' "$THREADS_RAW_STUB"',
+        '  # Real gh writes the reason to stderr; the workflow folds its tail',
+        '  # into the warning, so the stub must produce one to assert on.',
+        '  [[ "${THREADS_FETCH_EXIT:-0}" == 0 ]] || echo "threads-fetch stub failure" >&2',
         '  exit "${THREADS_FETCH_EXIT:-0}"',
         'fi',
         'if [[ "$query" == *PullRequestReviewThread* ]]; then',
@@ -15940,6 +15943,9 @@ exit 1
     expect(partialFetch.out).toContain(
       'review-thread pagination did not complete',
     );
+    // …and carries gh's own stderr, the only text that separates a transient
+    // rate limit (back off) from an expired PAT (rotate credentials).
+    expect(partialFetch.out).toContain('threads-fetch stub failure');
 
     // The residual cap the fix does NOT close: a thread carrying more than
     // 100 comments still truncates, so a comment past that page is unmapped.
@@ -15959,6 +15965,19 @@ exit 1
     const deepThread = runResolve({ THREADS_RAW_STUB: innerTruncated });
     expect(deepThread.status).toBe(0);
     expect(deepThread.out).toContain(
+      'carries more than 100 comments; a comment past that page is not mapped',
+    );
+
+    // Both warnings must be ABSENT on a clean run. Asserted only in the
+    // positive, either could be made unconditional and ship green — and a
+    // warning that always fires is a warning nobody reads.
+    writeFileSync(join(dir, 'resolved-comments.txt'), 'rc:111\n');
+    const cleanRun = runResolve();
+    expect(cleanRun.status).toBe(0);
+    expect(cleanRun.out).not.toContain(
+      'review-thread pagination did not complete',
+    );
+    expect(cleanRun.out).not.toContain(
       'carries more than 100 comments; a comment past that page is not mapped',
     );
     writeFileSync(join(dir, 'resolved-comments.txt'), 'rc:111\r\n333\n999\n');


### PR DESCRIPTION
## What this PR does

Paginates the review-thread fetch in `resolve_and_reply_threads`, so a round can resolve and reply to the threads it actually addressed rather than only the oldest hundred on the PR.

## Why it's needed

The fetch was `reviewThreads(first:100)` with no pagination. GitHub returns review threads in **ascending creation order**, so a single page is the *oldest* hundred — on a long-running PR, precisely not the threads the current round is answering.

Both blocks downstream map an inline-comment id to its thread. A thread past that page is absent from `THREADS_JSON`, so:

- an implemented Critical is never resolved and reads as still open, and
- a declined finding's reply is answered by silence.

Those are the two outcomes the function's own comment says it exists to prevent.

Measured on the live pool: **8 of the 22 open takeover PRs exceed the cap.** #8403 carries **1256 threads**, so one page reached 8% of them — and all 1256 are currently unresolved.

The code already detected the condition. It requested `pageInfo{hasNextPage}` and emitted a `::warning::` when it was true; it simply never fetched the next page. This closes that gap rather than adding a new signal.

## How

`gh api graphql --paginate`, which exists for this shape: the query gains an `$endCursor` variable and `pageInfo{hasNextPage endCursor}`, and gh walks the pages itself. Its `--jq '…nodes[]'` stream is slurped into the same flat array both blocks already consume, so nothing downstream changes.

On #8403 that is 13 requests in about 10 seconds.

Two deliberate choices worth reviewing:

**A partial fetch is used, not discarded.** If pagination dies partway — a rate limit on a later page — the threads already in hand still map, and the incompleteness is announced. Discarding them would mean losing twelve good pages to a failure on the thirteenth and resolving nothing at all, which is strictly worse than today's behaviour. The step runs under `bash -e -o pipefail`, so the fetch and the slurp each carry an explicit `||` fallback and the assignment cannot abort the step.

**One residual stays open, and is now announced rather than implied.** A thread carrying more than 100 comments still truncates its `comments` page, so a comment past it is unmapped and each block falls back to the id as given — the same fallback as before. A new warning names it. No thread in the live pool comes close: across #8403's 1256 threads, zero have more than 100 comments.

## Reviewer Test Plan

### How to verify

```bash
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js
```

179 passed. The suite extracts the real bash block from the workflow and executes it against a stub `gh`.

What the new coverage pins, and what it honestly cannot:

- **Structural** — the block asks for `--paginate`, the `reviewThreads(first:100, after:$endCursor)` shape, and `pageInfo{hasNextPage endCursor}`. The stub `gh` exits 3 if `--paginate` is absent, so the request shape cannot silently regress. Verified to bite: removing `--paginate` from the workflow turns the test red.
- **Behavioural, deep stream** — a 401-node stream resolves a target sitting at index 400, so any surviving hundred-item ceiling in the consumer drops it.
- **Behavioural, partial fetch** — a pagination that exits non-zero still resolves the threads it got and prints `review-thread pagination did not complete`.
- **Behavioural, residual** — a thread reporting `comments.pageInfo.hasNextPage` produces the new warning.
- **Cannot be proven here** — that GitHub actually returns every page. The stub replaces `gh` wholesale, so page-walking is gh's contract, not this suite's. That is why the request shape is pinned structurally and why the live check below is worth running.

Live end-to-end against the worst PR in the repo:

```
gh api graphql --paginate -f owner=QwenLM -f name=qwen-code -F pr=8403 \
  -f query='query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
    repository(owner:$owner,name:$name){pullRequest(number:$pr){
      reviewThreads(first:100, after:$endCursor){
        nodes{id isResolved comments(first:100){nodes{databaseId} pageInfo{hasNextPage}}}
        pageInfo{hasNextPage endCursor}}}}}' \
  --jq '.data.repository.pullRequest.reviewThreads.nodes[]' | jq -s 'length'
```

Returns `1256` in ~10s, against `100` before this change.

Two contract pins in the suite move with this diff and both are deliberate: the `--paginate` site count goes 18 → 19, and the pin's comment gains a sentence placing this site in the existing "consumed inline into a shell variable, never lands in a WORKDIR json file" class — so it does **not** join the `jq -s 'add // []'` normalizer count, which stays at 10.

### Evidence (Before & After)

N/A — CI machinery, no user-visible surface. The observable change is on the PR page: threads the round addressed get resolved and replied to instead of staying open.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Contract suite on Node 22.23.0, plus the live `gh` query above against PR #8403.

## Risk & Scope

- Main risk or tradeoff: a PR with very many threads now costs several GraphQL requests where it cost one. #8403 — the largest in the repo — is 13 requests in ~10s, inside a round that already budgets ~2 agent-hours. The cost scales with thread count, which is bounded by real review activity.
- Second risk: the partial-fetch path is new behaviour rather than a strict improvement, since today's code cannot fail partway. It is pinned by test and announced at runtime, and the alternative (discard everything) is worse.
- Not validated / out of scope: the >100-comments-per-thread residual is announced, not closed — nested pagination inside the thread loop is a materially larger change for a case with no live instance. The warning makes it visible if that ever changes.
- Breaking changes / migration notes: none. `THREADS_JSON` keeps its shape and both consumers are untouched.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

给 `resolve_and_reply_threads` 里的评审 thread 拉取加上分页，让一轮能够解决并回复它**真正处理过**的那些 thread，而不是只够得着 PR 上最老的一百条。

## 为什么需要

原来的拉取是 `reviewThreads(first:100)`，没有分页。GitHub 返回评审 thread 是**按创建时间升序**的，所以单页拿到的是**最老的**一百条——在一个长期运行的 PR 上，恰恰不是当前这一轮在回应的那些。

下游两个代码块都要把 inline 评论 id 映射到它所属的 thread。落在这一页之外的 thread 不在 `THREADS_JSON` 里，于是：

- 已经实现的 Critical 永远不会被标记解决，看起来像还没人管；
- 被驳回的发现，它的回复变成了沉默。

而这两点正是该函数自己的注释里写明"存在就是为了防止"的后果。

线上实测：**22 个托管中的 PR 里有 8 个超过该上限。** #8403 有 **1256 条 thread**，一页只够得着其中 8%——而且这 1256 条目前全部处于未解决状态。

代码其实早就检测到了这个情况：它请求了 `pageInfo{hasNextPage}`，为 true 时还会打一条 `::warning::`；只是从来没有去取下一页。本 PR 补的就是这个缺口，而不是新增一个信号。

## 怎么改的

用 `gh api graphql --paginate`——它就是为这种形态设计的：查询增加一个 `$endCursor` 变量和 `pageInfo{hasNextPage endCursor}`，由 gh 自己走完所有页。它 `--jq '…nodes[]'` 的输出流被 slurp 成两个代码块本来就在消费的那个扁平数组，因此下游没有任何改动。

在 #8403 上，这是 13 次请求、约 10 秒。

有两处刻意的取舍值得评审关注：

**部分拉取会被"使用"，而不是丢弃。** 如果分页中途失败（比如在靠后的某页遇到限流），已经拿到手的 thread 仍然参与映射，同时把"不完整"这件事播报出来。丢弃它们意味着为了第 13 页的失败而扔掉前 12 页的成果、最终一条都解决不了，那比现状严格更差。该步骤运行在 `bash -e -o pipefail` 下，因此拉取与 slurp 各自都带了显式的 `||` 兜底，赋值不会中断整个步骤。

**有一处残留没有关闭，现在改为明确播报而非默认。** 一条 thread 若携带超过 100 条评论，其 `comments` 页仍会被截断，因此超出的评论无法映射，两个代码块都会回落到"按原样使用该 id"——与改动前的回落路径一致。新增了一条 warning 点名这一点。线上没有任何 thread 接近该上限：#8403 的 1256 条里，超过 100 条评论的有 0 条。

## 审阅者验证方案

### 如何验证

```bash
npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-autofix-workflow.test.js
```

179 项通过。该套件会从工作流里抽出真实的 bash 块，并对着一个 stub 版 `gh` 执行。

新增覆盖钉住了什么、以及诚实地说它钉不住什么：

- **结构层** —— 该块必须请求 `--paginate`、`reviewThreads(first:100, after:$endCursor)` 这一形态，以及 `pageInfo{hasNextPage endCursor}`。stub 版 `gh` 在缺少 `--paginate` 时以 3 退出，因此请求形态不可能悄悄回退。已验证它真的会咬：把 `--paginate` 从工作流里去掉，测试即转红。
- **行为层，深流** —— 一个 401 个节点的流中，目标位于第 400 个索引位；消费端若还残留任何"一百条上限"，它就会被丢掉。
- **行为层，部分拉取** —— 分页以非零码退出时，仍然解决了已取到的 thread，并打印 `review-thread pagination did not complete`。
- **行为层，残留** —— 一条报告 `comments.pageInfo.hasNextPage` 的 thread 会触发新增的那条 warning。
- **这里证明不了的** —— GitHub 是否真的返回了每一页。stub 完全替换了 `gh`，因此"走完分页"属于 gh 的契约而非本套件的。这正是要在结构层钉住请求形态、并建议跑一次下面这条线上验证的原因。

对着仓库里最糟的那个 PR 做线上端到端验证：

```
gh api graphql --paginate -f owner=QwenLM -f name=qwen-code -F pr=8403 \
  -f query='query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
    repository(owner:$owner,name:$name){pullRequest(number:$pr){
      reviewThreads(first:100, after:$endCursor){
        nodes{id isResolved comments(first:100){nodes{databaseId} pageInfo{hasNextPage}}}
        pageInfo{hasNextPage endCursor}}}}}' \
  --jq '.data.repository.pullRequest.reviewThreads.nodes[]' | jq -s 'length'
```

返回 `1256`，耗时约 10 秒；改动前是 `100`。

套件里有两条契约钉子随本 diff 变动，均为刻意：`--paginate` 站点计数由 18 变为 19；该钉子的注释新增一句，把本站点归入既有的"就地消费进 shell 变量、从不落入 WORKDIR json 文件"那一类——因此它**不**加入 `jq -s 'add // []'` 归一化计数，后者保持为 10。

### 证据（前后对比）

N/A —— CI 机制，无用户可见界面。可观察到的变化在 PR 页面上：本轮处理过的 thread 会被解决和回复，而不是一直挂着。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### 环境（可选）

Node 22.23.0 上的契约套件，外加对 PR #8403 执行上述线上 `gh` 查询。

## 风险与范围

- 主要风险或取舍：thread 极多的 PR 现在要发若干次 GraphQL 请求，而以前只发一次。#8403——仓库里最大的那个——是 13 次请求、约 10 秒，而它所在的这一轮本身就预算了约 2 个 agent 小时。开销随 thread 数量增长，而后者受真实评审活动约束。
- 第二个风险：部分拉取路径是**新增行为**而非严格改进，因为今天的代码根本不会中途失败。它已被测试钉住并在运行时播报，而备选方案（全部丢弃）更差。
- 未验证 / 不在范围内：单条 thread 超过 100 条评论的残留只做播报、未做关闭——在 thread 循环内部再做一层嵌套分页是明显更大的改动，而线上并无实例。那条 warning 会在情况改变时让它显形。
- 破坏性变更 / 迁移说明：无。`THREADS_JSON` 形状不变，两个消费方均未改动。

## 关联 Issue

无。

</details>
