### PR TITLE
fix(core): widen the workflow stall watchdog past the transport retry ladder

### DIFF
--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -170,7 +170,7 @@ export function resolveConcurrencyLimit(
  * which apply valid overrides verbatim), clamped to a hard ceiling.
  *
  * Three time bounds act on a dispatch and they are NOT redundant:
- *  - `stallMs` (60s default) — no *progress* for this long ⇒ abort + retry.
+ *  - `stallMs` (3 min default) — no *progress* for this long ⇒ abort + retry.
  *    Held while a tool is in flight, so a slow tool is not a stall.
  *  - `max_time_minutes` (this) — total wall time for ONE attempt, stalled or
  *    not. Bounds the case the watchdog cannot see (a model that keeps

--- a/packages/core/src/agents/runtime/workflow-sandbox.ts
+++ b/packages/core/src/agents/runtime/workflow-sandbox.ts
@@ -415,7 +415,7 @@ export interface WorkflowAgentOpts {
   /**
    * P-stall: per-call stall-watchdog timeout in milliseconds. The dispatch
    * is aborted + retried (up to 3 attempts) after this many ms of no
-   * subagent progress (with no tool in flight). Defaults to 60_000 (env
+   * subagent progress (with no tool in flight). Defaults to 180_000 (env
    * override `QWEN_CODE_WORKFLOW_STALL_SECONDS`). `0` disables the watchdog
    * for this call.
    */

--- a/packages/core/src/agents/runtime/workflow-stall.test.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.test.ts
@@ -57,6 +57,12 @@ describe('resolveStallMs', () => {
   // Asserting the relationship rather than the literal keeps this meaningful if
   // either number is retuned later.
   it('outlasts the transport retry ladder it has to survive', () => {
+    // TODO: derive from DEFAULT_RETRY_OPTIONS once it (or a worst-case backoff
+    // helper) is exported from utils/retry.ts. Until then this literal is a
+    // hand-copy and must be retuned together with it — `toBe(76_500)` below
+    // only pins this copy, so a retune there would leave this green while the
+    // real ladder overtook the window. Nominal sleeps: the normal path also
+    // applies ±30% jitter (~89.25s worst case after the 30s cap).
     const RETRY_LADDER_MS = [1_500, 3_000, 6_000, 12_000, 24_000, 30_000];
     const ladderTotal = RETRY_LADDER_MS.reduce((a, b) => a + b, 0);
     expect(ladderTotal).toBe(76_500);
@@ -76,11 +82,15 @@ describe('attachStallWatchdog', () => {
     const emitter = new AgentEventEmitter();
     const controller = new AbortController();
     const wd = attachStallWatchdog(emitter, controller, 1000);
-    // #8: not armed until the first progress event (the time-to-first-response
-    // window is not a stall) — so advancing past stallMs here does nothing.
+    // Not armed until the first progress event — so advancing past stallMs
+    // here does nothing. In a real dispatch that event is ROUND_START, which
+    // fires before the request reaches the wire (see the doc comment on
+    // `attachStallWatchdog`), so this pre-arm silence is only round 1's
+    // pre-generator work, NOT the time-to-first-token window — that window is
+    // watched, and is pinned by the test below.
     vi.advanceTimersByTime(2000);
     expect(wd.stalled()).toBe(false);
-    // First response arrives → watchdog arms; then silence trips it.
+    // ROUND_START arrives → watchdog arms; then silence trips it.
     emitter.emit(AgentEventType.ROUND_START, {} as never);
     vi.advanceTimersByTime(999);
     expect(wd.stalled()).toBe(false);
@@ -194,8 +204,9 @@ describe('runStallResilient', () => {
       emitter: AgentEventEmitter,
     ): Promise<string> => {
       calls += 1;
-      // Emit a first response event so the watchdog arms (#8: the time-to-
-      // first-response window is not a stall), then go silent → it trips.
+      // Emit ROUND_START so the watchdog arms — in a real dispatch that fires
+      // before the request reaches the wire, so the time-to-first-token window
+      // IS watched — then go silent → it trips.
       emitter.emit(AgentEventType.ROUND_START, {} as never);
       await new Promise<void>((resolve) => {
         if (signal.aborted) return resolve();

--- a/packages/core/src/agents/runtime/workflow-stall.test.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.test.ts
@@ -46,6 +46,22 @@ describe('resolveStallMs', () => {
   it('ignores a negative per-call value (falls through to default)', () => {
     expect(resolveStallMs(-5, {})).toBe(DEFAULT_STALL_MS);
   });
+
+  // The default is not an arbitrary round number: it has to outlast the
+  // transport's own silent retry ladder, or a request that is retrying exactly
+  // as designed reads as a stall. `DEFAULT_RETRY_OPTIONS` in utils/retry.ts
+  // sleeps 1.5s, 3s, 6s, 12s, 24s, 30s between attempts, and agent-core
+  // consumes each `retry` stream event without emitting anything the watchdog
+  // counts as progress — so the whole ladder is one silent stretch.
+  //
+  // Asserting the relationship rather than the literal keeps this meaningful if
+  // either number is retuned later.
+  it('outlasts the transport retry ladder it has to survive', () => {
+    const RETRY_LADDER_MS = [1_500, 3_000, 6_000, 12_000, 24_000, 30_000];
+    const ladderTotal = RETRY_LADDER_MS.reduce((a, b) => a + b, 0);
+    expect(ladderTotal).toBe(76_500);
+    expect(DEFAULT_STALL_MS).toBeGreaterThan(ladderTotal);
+  });
 });
 
 describe('attachStallWatchdog', () => {
@@ -75,15 +91,36 @@ describe('attachStallWatchdog', () => {
     wd.dispose();
   });
 
-  it('does NOT fire during the time-to-first-response window (#8)', () => {
+  // Replaces a test that asserted the watchdog does not fire during the
+  // time-to-first-response window. That test never emitted ROUND_START, so it
+  // only proved that a silent emitter does not trip a watchdog that was never
+  // armed — and it encoded a model of the transport that is not true. In a real
+  // dispatch ROUND_START has already fired by this point: `sendMessageStream`
+  // returns a lazily iterated generator, so the `await` on it resolves before
+  // the request reaches the wire, and agent-core emits ROUND_START on the very
+  // next line. These two tests pin what actually happens.
+  it('does not arm before the first progress event', () => {
     const emitter = new AgentEventEmitter();
     const controller = new AbortController();
     const wd = attachStallWatchdog(emitter, controller, 1000);
-    // A reasoning model thinking for a long time before the first token emits
-    // no events; that must not be treated as a stall.
+    // Nothing emitted: the timer was never armed, so nothing can elapse.
     vi.advanceTimersByTime(10_000);
     expect(wd.stalled()).toBe(false);
     expect(controller.signal.aborted).toBe(false);
+    wd.dispose();
+  });
+
+  it('DOES count the time-to-first-token window, because ROUND_START precedes the request', () => {
+    const emitter = new AgentEventEmitter();
+    const controller = new AbortController();
+    const wd = attachStallWatchdog(emitter, controller, 1000);
+    // Exactly what agent-core does: emit ROUND_START immediately after
+    // `await sendMessageStream(...)` resolves — i.e. before any bytes are sent.
+    emitter.emit(AgentEventType.ROUND_START, {} as never);
+    // The provider is still connecting/queueing/thinking; no deltas yet.
+    vi.advanceTimersByTime(1001);
+    expect(wd.stalled()).toBe(true);
+    expect(controller.signal.reason).toBe('stalled');
     wd.dispose();
   });
 

--- a/packages/core/src/agents/runtime/workflow-stall.test.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.test.ts
@@ -14,6 +14,8 @@ import {
   MAX_STALL_ATTEMPTS,
   MAX_WORKFLOW_STALL_MS_ENV,
 } from './workflow-stall.js';
+import { DEFAULT_RETRY_OPTIONS } from '../../utils/retry.js';
+import { getRetryDelayMs } from '../../utils/retryPolicy.js';
 
 describe('resolveStallMs', () => {
   it('uses the per-call override when positive', () => {
@@ -56,17 +58,40 @@ describe('resolveStallMs', () => {
   //
   // Asserting the relationship rather than the literal keeps this meaningful if
   // either number is retuned later.
+  //
+  // The ladder is DERIVED from `DEFAULT_RETRY_OPTIONS`, not hand-copied: a
+  // local literal would keep this test green while a retune of the real
+  // options pushed the real ladder past the window — the exact false-stall
+  // regression this test exists to prevent. Mirrors retryWithBackoff's error
+  // path: `maxAttempts - 1` sleeps, `currentDelay` doubling from
+  // `initialDelayMs` under the `maxDelayMs` cap, each sleep run through
+  // `getRetryDelayMs` with the ±30% jitter that path applies.
+  const transportLadderMs = (random: () => number) => {
+    const { maxAttempts, initialDelayMs, maxDelayMs } = DEFAULT_RETRY_OPTIONS;
+    let currentDelay = initialDelayMs;
+    let total = 0;
+    for (let sleep = 1; sleep < maxAttempts; sleep++) {
+      total += getRetryDelayMs({
+        attempt: 1,
+        initialDelayMs: currentDelay,
+        maxDelayMs,
+        jitterRatio: 0.3,
+        random,
+      });
+      currentDelay = Math.min(maxDelayMs, currentDelay * 2);
+    }
+    return total;
+  };
+
   it('outlasts the transport retry ladder it has to survive', () => {
-    // TODO: derive from DEFAULT_RETRY_OPTIONS once it (or a worst-case backoff
-    // helper) is exported from utils/retry.ts. Until then this literal is a
-    // hand-copy and must be retuned together with it — `toBe(76_500)` below
-    // only pins this copy, so a retune there would leave this green while the
-    // real ladder overtook the window. Nominal sleeps: the normal path also
-    // applies ±30% jitter (~89.25s worst case after the 30s cap).
-    const RETRY_LADDER_MS = [1_500, 3_000, 6_000, 12_000, 24_000, 30_000];
-    const ladderTotal = RETRY_LADDER_MS.reduce((a, b) => a + b, 0);
-    expect(ladderTotal).toBe(76_500);
-    expect(DEFAULT_STALL_MS).toBeGreaterThan(ladderTotal);
+    const nominal = transportLadderMs(() => 0.5); // jitter cancels out
+    const worstCase = transportLadderMs(() => 1); // every sleep +30%, then capped
+    expect(nominal).toBe(76_500);
+    expect(worstCase).toBe(89_250);
+    // The window has to outlast the ladder on an UNLUCKY run, not just the
+    // nominal sum: a `DEFAULT_STALL_MS` retuned into the (76.5s, 89.25s] band
+    // would false-trip under jitter while a nominal-only assertion stayed green.
+    expect(DEFAULT_STALL_MS).toBeGreaterThan(worstCase);
   });
 });
 
@@ -78,7 +103,7 @@ describe('attachStallWatchdog', () => {
     vi.useRealTimers();
   });
 
-  it('fires after stallMs of no activity once the first response has arrived', () => {
+  it('fires after stallMs of silence once armed (ROUND_START)', () => {
     const emitter = new AgentEventEmitter();
     const controller = new AbortController();
     const wd = attachStallWatchdog(emitter, controller, 1000);
@@ -235,8 +260,9 @@ describe('runStallResilient', () => {
     ): Promise<string> => {
       calls += 1;
       if (calls < 2) {
-        // First attempt stalls: emit a first response event to arm the
-        // watchdog (#8), then go silent until it aborts.
+        // First attempt stalls: emit ROUND_START to arm the watchdog — in a
+        // real dispatch that fires before the request reaches the wire — then
+        // go silent until it aborts.
         emitter.emit(AgentEventType.ROUND_START, {} as never);
         await new Promise<void>((resolve) => {
           if (signal.aborted) return resolve();

--- a/packages/core/src/agents/runtime/workflow-stall.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.ts
@@ -44,8 +44,16 @@ import { parsePositiveIntegerEnv } from '../../utils/env.js';
  * Default stall timeout: no progress (with no tool in flight) for this long
  * ends the attempt.
  *
- * Sized against the transport's own silent retry ladder rather than against a
- * guess at model latency. `retryWithBackoff` sleeps 1.5s, 3s, 6s, 12s, 24s then
+ * Sized against the `retryWithBackoff` silent retry ladder rather than against
+ * a guess at model latency. That ladder is the binding case, not the only
+ * watchdog-invisible wait: stream-side rate-limit sleeps
+ * (`RATE_LIMIT_RETRY_OPTIONS` in geminiChat.ts — 60s/120s/240s/300s, so two
+ * consecutive sleeps already reach 180s), a provider `Retry-After` honored
+ * unclamped on the normal HTTP path, and unattended-mode persistent backoff
+ * (up to 5 min per sleep) can all exceed this window and read as a stall on a
+ * request that is retrying exactly as designed. Making transport retries
+ * visible to the watchdog is the follow-up; this window does not cover them.
+ * `retryWithBackoff` sleeps 1.5s, 3s, 6s, 12s, 24s then
  * 30s between attempts (`DEFAULT_RETRY_OPTIONS` in utils/retry.ts), and
  * `agent-core` consumes each `retry` stream event without emitting anything the
  * watchdog counts as progress. A plain 429/5xx ladder is therefore 76.5s of
@@ -112,8 +120,10 @@ export interface StallWatchdogHandle {
  * all elapse with the timer already running.
  *
  * So `stallMs` must be wide enough to cover a healthy first response, not just a
- * mid-stream gap. The binding case is the transport's silent retry ladder — see
- * `DEFAULT_STALL_MS`. Once the provider streams anything at all, including
+ * mid-stream gap. The binding case this window is sized against is the
+ * `retryWithBackoff` silent retry ladder — see `DEFAULT_STALL_MS`, which also
+ * names the longer waits (stream-side rate-limit sleeps, an unclamped
+ * `Retry-After`, unattended backoff) that remain invisible to it. Once the provider streams anything at all, including
  * thought deltas, `STREAM_TEXT` resets the timer.
  *
  * A `stallMs` of 0 means "no watchdog" — this returns an inert handle.

--- a/packages/core/src/agents/runtime/workflow-stall.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.ts
@@ -8,8 +8,8 @@
  * @fileoverview Stall watchdog + retry for workflow agent dispatches. A
  * workflow `agent()` can hang indefinitely if the model loops, the provider
  * stalls mid-stream, or a tool never returns. The subagent's own
- * `max_time_minutes` (10 min) is a coarse backstop; the stall watchdog is
- * finer-grained: it aborts a dispatch after `stallMs` (default 60s) of NO
+ * `max_time_minutes` (10 min, per attempt) is a coarse backstop; the stall
+ * watchdog is finer-grained: it aborts a dispatch after `stallMs` (default 3 min) of NO
  * observable progress, and the resilient wrapper retries up to
  * `MAX_STALL_ATTEMPTS` times before abandoning.
  *
@@ -40,8 +40,20 @@ import { AgentEventEmitter, AgentEventType } from './agent-events.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { parsePositiveIntegerEnv } from '../../utils/env.js';
 
-/** Default stall timeout: 60s of no progress (with no tool in flight). */
-export const DEFAULT_STALL_MS = 60_000;
+/**
+ * Default stall timeout: no progress (with no tool in flight) for this long
+ * ends the attempt.
+ *
+ * Sized against the transport's own silent retry ladder rather than against a
+ * guess at model latency. `retryWithBackoff` sleeps 1.5s, 3s, 6s, 12s, 24s then
+ * 30s between attempts (`DEFAULT_RETRY_OPTIONS` in utils/retry.ts), and
+ * `agent-core` consumes each `retry` stream event without emitting anything the
+ * watchdog counts as progress. A plain 429/5xx ladder is therefore 76.5s of
+ * watchdog-invisible silence on a request that is healthy and retrying exactly
+ * as designed — comfortably past the previous 60s value, which elapsed during
+ * the ladder's sixth sleep.
+ */
+export const DEFAULT_STALL_MS = 180_000;
 
 /** Total attempts (initial + retries) for a single `agent()` dispatch. */
 export const MAX_STALL_ATTEMPTS = 3;
@@ -89,13 +101,20 @@ export interface StallWatchdogHandle {
  * flight the timer is held (a long tool call is not a stall). When the
  * timer elapses with no in-flight tool, it fires `controller.abort('stalled')`.
  *
- * The watchdog arms on the FIRST progress event, not at attach time. The
- * time-to-first-response window — connection setup, server-side queueing, and
- * a reasoning model's pre-first-token thinking — emits no events (`ROUND_START`
- * fires only AFTER `await sendMessageStream` resolves), so counting it would
- * false-trip on a healthy-but-slow first response and waste 3× tokens on the
- * retry loop. That window is instead bounded by the subagent's own
- * `max_time_minutes`; the watchdog's job is post-first-response streaming stalls.
+ * The watchdog arms on the first progress event rather than at attach time, but
+ * that excludes far less than it appears to. `ROUND_START` is emitted as soon as
+ * `await sendMessageStream(...)` resolves — and that call returns a lazily
+ * iterated async generator, so it resolves BEFORE the request reaches the wire;
+ * the generator body issues it on first iteration. The deferred arm therefore
+ * only skips round 1's pre-generator work (the send-lock drain, route
+ * resolution, and any auto-compaction), not the request itself. Connection
+ * setup, server-side queueing, and a reasoning model's pre-first-token thinking
+ * all elapse with the timer already running.
+ *
+ * So `stallMs` must be wide enough to cover a healthy first response, not just a
+ * mid-stream gap. The binding case is the transport's silent retry ladder — see
+ * `DEFAULT_STALL_MS`. Once the provider streams anything at all, including
+ * thought deltas, `STREAM_TEXT` resets the timer.
  *
  * A `stallMs` of 0 means "no watchdog" — this returns an inert handle.
  */
@@ -161,10 +180,12 @@ export function attachStallWatchdog(
   emitter.on(AgentEventType.TOOL_CALL, onToolCall);
   emitter.on(AgentEventType.TOOL_RESULT, onToolResult);
 
-  // Intentionally NOT armed here. The first `onActivity` (the first response
-  // event of round 1) arms it, so time-to-first-response is not counted as a
-  // stall (see the doc comment); first-response hangs are bounded by the
-  // subagent's `max_time_minutes`.
+  // Intentionally NOT armed here — the first `onActivity` arms it. Note this
+  // defers arming only past round 1's pre-request work, NOT past the request:
+  // `ROUND_START` fires before the call is on the wire (see the doc comment).
+  // A first-response hang is therefore caught by this watchdog, not left to
+  // the subagent's `max_time_minutes` (which is per attempt and resets on
+  // every stall retry, so it never bounds the sequence).
 
   return {
     stalled: () => fired,

--- a/packages/core/src/agents/runtime/workflow-stall.ts
+++ b/packages/core/src/agents/runtime/workflow-stall.ts
@@ -50,7 +50,10 @@ import { parsePositiveIntegerEnv } from '../../utils/env.js';
  * (`RATE_LIMIT_RETRY_OPTIONS` in geminiChat.ts — 60s/120s/240s/300s, so two
  * consecutive sleeps already reach 180s), a provider `Retry-After` honored
  * unclamped on the normal HTTP path, and unattended-mode persistent backoff
- * (up to 5 min per sleep) can all exceed this window and read as a stall on a
+ * (up to 5 min per exponential sleep — but a provider `Retry-After` on that
+ * path is capped only at `PERSISTENT_CAP_MS`/6h, not at the 5 min
+ * `PERSISTENT_MAX_BACKOFF_MS`, so one 429 carrying `Retry-After: 7200` sleeps
+ * two hours) can all exceed this window and read as a stall on a
  * request that is retrying exactly as designed. Making transport retries
  * visible to the watchdog is the follow-up; this window does not cover them.
  * `retryWithBackoff` sleeps 1.5s, 3s, 6s, 12s, 24s then

--- a/packages/core/src/tools/workflow/workflow.ts
+++ b/packages/core/src/tools/workflow/workflow.ts
@@ -127,11 +127,9 @@ const WORKFLOW_PARAM_SCHEMA = {
         '`stallMs` (number, ms): a no-progress watchdog, not a wall-clock cap. ' +
         'The dispatch is aborted and retried (up to ' +
         `${MAX_STALL_ATTEMPTS} attempts total) after this many milliseconds ` +
-        'with no observable subagent progress once progress has begun ' +
-        '(a dispatch that produces no first response is bounded by the ' +
-        'subagent time cap, not this watchdog); the timer is suspended ' +
-        'while a tool is in flight, so a legitimately slow tool is not ' +
-        'a stall. ' +
+        'with no observable subagent progress — including before the first ' +
+        'response arrives; the timer is suspended while a tool is in flight, ' +
+        'so a legitimately slow tool is not a stall. ' +
         `Default ${DEFAULT_STALL_MS} (override via \`${MAX_WORKFLOW_STALL_MS_ENV}\`, whole seconds); \`0\` disables the watchdog. Wall time ` +
         'per attempt is bounded separately. ' +
         'Workflow subagents always have SendMessage / Monitor / EnterPlanMode / ExitPlanMode ' +

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -87,7 +87,12 @@ export interface RetryOptions {
   onRetry?: (info: RetryAttemptInfo) => void;
 }
 
-const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+/**
+ * Default ladder for the normal HTTP retry path. Exported so callers that
+ * must outlast it — the workflow stall watchdog sizes `DEFAULT_STALL_MS`
+ * against it — can derive the ladder rather than hand-copy it.
+ */
+export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
   maxAttempts: 7,
   initialDelayMs: 1500,
   maxDelayMs: 30000, // 30 seconds


### PR DESCRIPTION
## What this PR does

Raises the workflow stall watchdog's default window from 60s to 180s so it outlasts the transport's own silent retry ladder, and corrects the claim about how the watchdog is armed — including the version of it that ships to the model.

## Why it's needed

### The comment justifying 60s is wrong

`attachStallWatchdog` carries this rationale:

> The watchdog arms on the FIRST progress event, not at attach time. The time-to-first-response window — connection setup, server-side queueing, and a reasoning model's pre-first-token thinking — emits no events (`ROUND_START` fires only AFTER `await sendMessageStream` resolves), so counting it would false-trip on a healthy-but-slow first response

The parenthetical is true. The conclusion drawn from it is backwards.

`sendMessageStream` returns a **lazily iterated async generator** — its last statement is `return (async function* () {`, and the API call (`makeApiCallAndProcessStream`) sits inside that body. Nothing primes the generator, so the body is suspended until the caller's first iteration. `await sendMessageStream(...)` therefore resolves *before* the request reaches the wire, and `agent-core` emits `ROUND_START` on the very next line, before `for await (const streamEvent of responseStream)` triggers anything.

So the deferred arm skips only round 1's pre-request work — the send-lock drain, route resolution, auto-compaction. Connection setup, server-side queueing and pre-first-token thinking all elapse with the timer already running.

Verified against the real code rather than by reading: a temporary test drove the real `attachStallWatchdog` exactly as agent-core drives it — `await sendMessageStream(...)`, emit `ROUND_START`, then a 400ms simulated first response against a 200ms window:

```
t+   0ms  await chat.sendMessageStream(...)
t+   0ms  emit ROUND_START -> watchdog ARMED (stallMs=200)
t+ 400ms  first stream event: chunk
t+ 400ms  stalled()=true aborted=true reason=stalled
```

It aborts a perfectly healthy request. A companion case asserted the API call count at the moment the `await` resolves is `0`.

### The number is wrong too, for a different reason

Time-to-first-token is real but it is not the binding case. The transport's own retry ladder is: `DEFAULT_RETRY_OPTIONS` (`utils/retry.ts`) is `{ maxAttempts: 7, initialDelayMs: 1500, maxDelayMs: 30000 }`, doubling with a cap, so the sleeps are **1.5s + 3s + 6s + 12s + 24s + 30s = 76.5s**. And `agent-core` handles `streamEvent.type === 'retry'` by resetting round state and `continue`-ing, with no emit — so nothing in that ladder reaches the watchdog.

A plain 429/5xx ladder is therefore 76.5s of watchdog-invisible silence on a request that is retrying exactly as designed. 60s elapses during the ladder's sixth sleep. 180s clears it, and independently matches upstream's own default for the same watchdog.

### What 180s does not fix

The stream-side rate-limit ladder (`RATE_LIMIT_RETRY_OPTIONS`, `initialDelayMs: 60000`, `maxDelayMs: 300000`) sleeps 60s, 120s, 240s, then 300s × 7 — about 42 minutes worst case. 180s equals its first two sleeps exactly, so a throttled dispatch still trips the watchdog, just later. Widening further is not the answer; making retries visible to the watchdog is, and that belongs in its own change.

## What is deliberately not in this PR

**`MAX_STALL_ATTEMPTS` stays at 3.** The parity argument for 5 does not hold — upstream's 5 bounds *retries on top of* an initial attempt (6 total), while qwen's constant is the total by its own docstring, so 5 is neither number. Widening the window also removes the reason the extra attempts were wanted: the 76.5s ladder now completes inside a single attempt. And raising it would break two assertions that hardcode "stalled on all 3 attempts", for retries least likely to succeed — a provider that stalled three times at 180s will not come good on the fourth.

**No re-arm throttle.** Benchmarked at 114ns per re-arm — 0.41ms of CPU over a three-minute stream at 20 events/s. It buys timer churn, not capability, and it adds a correctness surface the existing tests are blind to: because `onToolResult` calls `arm()` immediately after `onToolCall` called `clear()`, a throttle placed in `arm()` leaves the watchdog permanently disarmed, and the whole suite still passes.

## Reviewer Test Plan

### How to verify

`cd packages/core && npx vitest run src/agents/runtime/ src/tools/workflow/` — 656 passed, 6 skipped.

The constant change needs **no edits to existing tests** — they reference `DEFAULT_STALL_MS` symbolically, and the per-call `stallMs` option, the `QWEN_CODE_WORKFLOW_STALL_SECONDS` override, `stallMs: 0` returning an inert handle, tool-call timer suspension and the abandoned-error wording all still pass untouched.

Two tests change:

- A new test pins the *relationship* the number depends on — `DEFAULT_STALL_MS` must exceed the 76.5s retry ladder — rather than the literal, so it stays meaningful if either value is retuned.
- The old `does NOT fire during the time-to-first-response window` test is replaced. It advanced 10s without ever emitting `ROUND_START`, so it only proved that a never-armed watchdog does not fire; in production `ROUND_START` has already fired by then. It is split into what is actually true: one test that the watchdog does not arm before the first progress event, and one that it **does** count the time-to-first-token window, emitting `ROUND_START` first exactly as agent-core does.

To see the mechanism yourself: `packages/core/src/core/geminiChat.ts` — note the `return (async function* () {` near the end of `sendMessageStream` and that `makeApiCallAndProcessStream` is inside it; then `packages/core/src/agents/runtime/agent-core.ts`, where `ROUND_START` is emitted immediately after that `await` and the stream is not iterated until the `for await` below.

### Evidence (Before & After)

N/A — no user-visible or TUI change. The model-facing tool description changes text (see below), not behaviour.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Unit tests only, Node 22.23.0 on Linux.

## Risk & Scope

- Main risk or tradeoff: a genuinely wedged dispatch now holds its concurrency slot for 3 minutes per attempt instead of 1. With attempts left at 3 the worst case is ~9 minutes against the 30-minute run wall clock, which is the real backstop — `max_time_minutes` is not, because it is per attempt and resets on every stall retry. The trade is deliberate: the previous value was aborting healthy requests, and an abort costs a full re-dispatch.
- Not validated / out of scope: the stream-side rate-limit ladder above; making `StreamEventType.RETRY` visible to the watchdog (the real fix, and a better PR on its own); `MAX_STALL_ATTEMPTS`; the re-arm throttle.
- Breaking changes / migration notes: none. `QWEN_CODE_WORKFLOW_STALL_SECONDS` still overrides, and `0` still disables.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 workflow stall watchdog 的默认窗口从 60s 提到 180s，使其能覆盖传输层自身的静默重试阶梯；并纠正关于 watchdog 何时装载的错误说明——包括那份**会发给模型**的版本。

## 为什么需要

### 为 60s 辩护的那段注释是错的

`attachStallWatchdog` 里写着：

> watchdog 在**第一个**进度事件时装载，而不是在 attach 时。首响应窗口——连接建立、服务端排队、推理模型吐出第一个 token 前的思考——不产生任何事件（`ROUND_START` 只在 `await sendMessageStream` resolve **之后**才触发），所以把它计入会对健康但缓慢的首响应误判

括号里那句是对的，从它推出的结论却是反的。

`sendMessageStream` 返回的是一个**惰性迭代的 async generator**——函数最后一句是 `return (async function* () {`，而 API 调用（`makeApiCallAndProcessStream`）就在这个生成器体内部。没有任何代码预先推进该生成器，因此其函数体在调用方第一次迭代前一直挂起。于是 `await sendMessageStream(...)` 在**请求上线之前**就 resolve 了，而 `agent-core` 紧接着下一行就发出 `ROUND_START`，此时下面的 `for await (const streamEvent of responseStream)` 还没开始触发任何东西。

所以"延迟装载"实际只跳过了第 1 轮的**请求前**工作——发送锁排空、路由解析、自动压缩。连接建立、服务端排队、首 token 前的思考，全都是在计时器**已经运行**的情况下流逝的。

这一点是跑出来验证的，不是读出来的：一个临时测试按 agent-core 的真实驱动方式驱动真实的 `attachStallWatchdog`——`await sendMessageStream(...)`、发出 `ROUND_START`，然后在 200ms 的窗口下模拟 400ms 首响应：

```
t+   0ms  await chat.sendMessageStream(...)
t+   0ms  emit ROUND_START -> watchdog ARMED (stallMs=200)
t+ 400ms  first stream event: chunk
t+ 400ms  stalled()=true aborted=true reason=stalled
```

它中止了一个完全健康的请求。配套用例断言了在 `await` resolve 的那一刻，API 调用次数为 `0`。

### 数值也不对，但原因是另一个

首 token 时延是真实存在的，但它不是决定性的那一个。真正决定性的是传输层自己的重试阶梯：`DEFAULT_RETRY_OPTIONS`（`utils/retry.ts`）为 `{ maxAttempts: 7, initialDelayMs: 1500, maxDelayMs: 30000 }`，按倍数增长并封顶，因此各次睡眠为 **1.5s + 3s + 6s + 12s + 24s + 30s = 76.5s**。而 `agent-core` 对 `streamEvent.type === 'retry'` 的处理是重置轮次状态并 `continue`，**不发出任何事件**——所以整条阶梯对 watchdog 完全不可见。

于是一次普通的 429/5xx 阶梯，就是 76.5s 的"watchdog 看不见的静默"，而请求本身正在完全按设计重试。60s 恰好在阶梯的第 6 次睡眠期间耗尽。180s 能盖住它，并且与上游同一 watchdog 的默认值独立吻合。

### 180s 解决不了什么

流式侧的限流阶梯（`RATE_LIMIT_RETRY_OPTIONS`，`initialDelayMs: 60000`，`maxDelayMs: 300000`）依次睡 60s、120s、240s，然后 300s × 7——最坏约 42 分钟。180s **恰好等于**它前两次睡眠之和，因此被限流的 dispatch 仍会触发 watchdog，只是更晚。继续加宽不是答案；让重试对 watchdog 可见才是，而那应当是独立的一次改动。

## 本 PR 刻意不做什么

**`MAX_STALL_ATTEMPTS` 保持 3。** "对齐上游"的理由站不住：上游的 5 约束的是初次尝试**之上的重试次数**（合计 6 次），而 qwen 这个常量按其自身文档是**总次数**，所以 5 既不是 3 也不是 6。加宽窗口本身也消解了想要更多次数的理由：76.5s 的阶梯现在能在**单次**尝试内跑完。而且改它会打破两处硬编码的 "stalled on all 3 attempts" 断言，代价是把 token 花在最不可能成功的那几次重试上——一个在 180s 窗口下连停三次的 provider，第四次也不会好转。

**不做重装载节流。** 实测每次重装载 114ns——三分钟流、20 事件/秒，总共 0.41ms CPU。它买到的是定时器开销的减少，不是能力；而且引入了现有测试完全看不见的正确性风险面：由于 `onToolResult` 会在 `onToolCall` 调用 `clear()` 之后立刻调用 `arm()`，把节流放进 `arm()` 会让 watchdog 在该次 dispatch 剩余时间里**永久失效**，而整个测试套件照样全绿。

## 审阅者验证方案

### 如何验证

`cd packages/core && npx vitest run src/agents/runtime/ src/tools/workflow/`——656 通过、6 跳过。

常量改动**不需要修改任何既有测试**——它们都是符号引用 `DEFAULT_STALL_MS`；每次调用的 `stallMs` 选项、`QWEN_CODE_WORKFLOW_STALL_SECONDS` 覆盖、`stallMs: 0` 返回惰性句柄、工具在飞时挂起计时器，以及最终放弃时的错误文案，全部原样通过。

有两处测试变化：

- 新增一个测试固定该数值所依赖的**关系**——`DEFAULT_STALL_MS` 必须大于 76.5s 的重试阶梯——而不是固定字面量，这样将来任一数值被重新调参时它依然有意义。
- 旧的 `does NOT fire during the time-to-first-response window` 被替换。它推进 10s 却从未发出 `ROUND_START`，因此只证明了"从未装载的 watchdog 不会触发"；而在生产中此时 `ROUND_START` 早已触发。它被拆成两个真实成立的断言：watchdog 在第一个进度事件之前不装载；以及它**确实**把首 token 窗口计入——测试会像 agent-core 那样先发出 `ROUND_START`。

想自己看机制：`packages/core/src/core/geminiChat.ts` 中 `sendMessageStream` 末尾的 `return (async function* () {`，注意 `makeApiCallAndProcessStream` 在其内部；再看 `packages/core/src/agents/runtime/agent-core.ts`，`ROUND_START` 紧跟在那个 `await` 之后发出，而流直到下面的 `for await` 才开始迭代。

### 证据（前后对比）

N/A——没有用户可见或 TUI 变化。面向模型的工具描述只是文案变化，不是行为变化。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### 环境（可选）

仅单元测试，Linux 上的 Node 22.23.0。

## 风险与范围

- 主要风险或取舍：真正卡死的 dispatch 现在每次尝试会占住并发槽位 3 分钟而非 1 分钟。次数保持 3 次时最坏约 9 分钟，对应 30 分钟的 run 墙钟上限——那才是真正的兜底，`max_time_minutes` 不是，因为它是**每次尝试**的且在每次 stall 重试后重置。这个取舍是有意的：此前的数值在中止健康请求，而一次中止的代价是完整重新派发。
- 未验证 / 不在范围内：上文的流式限流阶梯；让 `StreamEventType.RETRY` 对 watchdog 可见（真正的修复，更适合独立成一个 PR）；`MAX_STALL_ATTEMPTS`；重装载节流。
- 破坏性变更 / 迁移说明：无。`QWEN_CODE_WORKFLOW_STALL_SECONDS` 仍可覆盖，`0` 仍可关闭。

## 关联 Issue

无。

</details>
