### PR TITLE
fix(web-shell): show create-group tooltip

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -5166,6 +5166,7 @@ export function WebShellSidebar({
                                       <button
                                         className={styles.workspaceHeaderAction}
                                         type="button"
+                                        title={t('sidebar.groupCreate')}
                                         aria-label={t('sidebar.groupCreate')}
                                         onClick={(event) => {
                                           event.preventDefault();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -1524,6 +1524,21 @@ describe('WebShellSidebar workspace removal', () => {
     expect(onNewSession).toHaveBeenCalledWith('/tmp/other');
   });
 
+  it('shows a native tooltip for the workspace create-group action', async () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    renderSidebar({ lockedWorkspaceCwd: '/tmp/other' });
+    await expandWorkspace('other');
+
+    const createGroupButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Create group"]',
+    );
+    expect(createGroupButton).not.toBeNull();
+    expect(createGroupButton?.getAttribute('title')).toBe('Create group');
+  });
+
   it('applies items and inlineItems consistently to locked normal, pinned, and archived rows', async () => {
     connection.capabilities = {
       ...capabilities,


### PR DESCRIPTION
## What this PR does

Adds a localized browser-native hover tooltip to the workspace-level create-group icon in Web Shell. It reuses the button's existing accessible label and adds a regression test, without changing the action, layout, or visual styling.

## Why it's needed

The icon-only `+` action is ambiguous to pointer users because it is the only workspace-header action without a visible hover explanation. Screen readers can already identify it through its accessible label; this change gives mouse users the same functional description and makes it consistent with the adjacent **New task** action.

## Reviewer Test Plan

### How to verify

1. Start Web Shell with session organization enabled and show the actions for a trusted workspace.
2. Hover the workspace-level `+` icon and confirm that the localized **Create group** native tooltip appears.
3. Hover the adjacent **New task** icon and confirm the two actions now behave consistently.
4. Click the `+` icon and confirm the existing create-group flow still opens.

### Evidence (Before & After)

Before: the button had the localized accessible label but no `title`; the added regression test failed with `expected "Create group", received null` (79 existing tests passed and 1 new test failed).

After: the native tooltip text matches the localized accessible label, and the focused sidebar suite passes all 80 tests. Native browser tooltips are rendered by browser/OS chrome rather than the page, so a page screenshot cannot reliably capture the popup itself.

Additional validation: focused formatting and lint checks passed, Web Shell type checking passed, and the repository build passed. The full repository test command was also attempted; service tests that require binding local ports or Unix sockets could not run in the restricted sandbox and failed with `EPERM`, unrelated to this UI-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.3, source worktree based on upstream `main` at `a18b080387f3da1f01b8d1129b805268c0eb9f43`.

## Risk & Scope

- Main risk or tradeoff: browser-native tooltip timing and appearance remain controlled by each browser and operating system.
- Not validated / out of scope: replacing native tooltips with a custom tooltip component or changing other sidebar actions.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #9398

<details>
<summary>中文说明</summary>

## 此 PR 的改动

为 Web Shell 工作区级别的新建分组图标增加本地化的浏览器原生悬浮提示。该提示复用按钮已有的无障碍标签，并增加一条回归测试，不改变操作行为、布局或视觉样式。

## 为什么需要此改动

仅显示 `+` 图标的操作对鼠标用户含义不够明确，因为它是工作区标题操作中唯一没有可见悬浮说明的按钮。屏幕阅读器已经可以通过无障碍标签识别它；本次改动让鼠标用户获得相同的功能说明，并使其与相邻的**新建任务**操作保持一致。

## Reviewer 测试计划

### 如何验证

1. 启动启用了会话组织功能的 Web Shell，并显示一个可信工作区的操作按钮。
2. 将鼠标悬浮在工作区级别的 `+` 图标上，确认出现本地化的**新建分组**原生提示。
3. 将鼠标悬浮在相邻的**新建任务**图标上，确认两个操作现在具有一致的行为。
4. 点击 `+` 图标，确认原有的新建分组流程仍然正常打开。

### 证据（改动前与改动后）

改动前：按钮有本地化的无障碍标签，但没有 `title`；新增的回归测试失败，结果为 `expected "Create group", received null`（79 条既有测试通过，1 条新增测试失败）。

改动后：原生提示文字与本地化无障碍标签一致，相关侧边栏测试全部 80 条通过。浏览器原生提示由浏览器或操作系统界面渲染，而不是由页面渲染，因此页面截图无法可靠捕获提示浮层本身。

其他验证：定向格式检查与 lint 通过，Web Shell 类型检查通过，全仓构建通过。也尝试了全仓测试命令；需要绑定本地端口或 Unix socket 的服务测试无法在受限沙盒中运行，并以 `EPERM` 失败，与此次纯 UI 改动无关。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ⚠️  |

### 环境（可选）

Node.js 22.22.3，源码工作树基于上游 `main` 的 `a18b080387f3da1f01b8d1129b805268c0eb9f43`。

## 风险与范围

- 主要风险或取舍：浏览器原生提示的出现时机和外观仍由各浏览器与操作系统控制。
- 未验证或不在范围内：用自定义 Tooltip 组件替换原生提示，或修改其他侧边栏操作。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Closes #9398

</details>
