### PR TITLE
fix(web-shell): use backend-authoritative queue state

### DIFF
--- a/docs/design/web-shell-backend-authoritative-queue-display.md
+++ b/docs/design/web-shell-backend-authoritative-queue-display.md
@@ -1,0 +1,25 @@
+# Web Shell backend-authoritative queue display
+
+## Problem
+
+The Web Shell keeps a local `unknown` queue row when a pending-prompt or
+mid-turn admission request may have reached the daemon but its response was
+lost. A later daemon refresh can then add the authoritative row beside the
+local copy, producing duplicate-looking entries and UI such as “delivery
+unknown” or “local copy discarded”.
+
+## Design
+
+Local rows exist only while an admission request is in flight. After the
+request settles, both admission paths query the daemon and render its queue
+snapshot. If the request or the follow-up query fails, the local row is
+removed; a later reconnect or queue event can restore it only if the daemon
+reports it.
+
+Failures after dispatch follow the same rule and do not restore the payload
+into the editor. Failures before either admission request is dispatched, such
+as media upload failure, restore the draft because the daemon could not have
+accepted it.
+
+The obsolete unknown-admission row state and its restore/discard UI are
+removed.

--- a/docs/design/web-shell/web-shell-image-drag-and-drop.md
+++ b/docs/design/web-shell/web-shell-image-drag-and-drop.md
@@ -4,6 +4,9 @@
 
 针对 [#8321](https://github.com/QwenLM/qwen-code/issues/8321) 的实现方案。初始实现由
 `48d1e1d69` 落地，review 修正由 `afb55ebae` 补齐 admission、恢复和资源边界。
+其中队列展示和 admission 失败语义已由
+[Web Shell backend-authoritative queue display](../web-shell-backend-authoritative-queue-display.md)
+取代；下文相关内容仅保留为历史记录。
 
 该功能只补齐 Web Shell composer 的图片拖放入口，并复用现有图片粘贴、
 附件预览、prompt 提交和多模态模型链路。daemon wire format、ACP、Core 和公开

--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -1019,12 +1019,6 @@
   color: var(--foreground);
 }
 
-.queuedPromptAmbiguity {
-  color: var(--secondary-foreground);
-  font-size: 12px;
-  line-height: 18px;
-}
-
 .queuedPrompt + .queuedPrompt {
   border-top: 0;
 }

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -6148,8 +6148,6 @@ export function App({
     editQueuedPrompt,
     editLastQueuedPrompt,
     clearQueuedPrompts,
-    restoreUnknownQueuedPrompt,
-    discardUnknownQueuedPrompt,
   } = useQueuedPrompts({
     connected,
     writeBlocked: sessionWriteBlocked,
@@ -12489,8 +12487,6 @@ export function App({
                           canMutateMidTurn={canMutateMidTurn}
                           onDelete={removeQueuedPrompt}
                           onEdit={editQueuedPrompt}
-                          onRestoreUnknown={restoreUnknownQueuedPrompt}
-                          onDiscardUnknown={discardUnknownQueuedPrompt}
                           onImagePreview={openImagePanel}
                         />
                         {CustomComposerHeader && (

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -532,8 +532,6 @@ export function ChatPane({
     editQueuedPrompt,
     editLastQueuedPrompt,
     clearQueuedPrompts,
-    restoreUnknownQueuedPrompt,
-    discardUnknownQueuedPrompt,
   } = useQueuedPrompts({
     connected: connection.status === 'connected',
     sessionId: connection.sessionId,
@@ -1054,8 +1052,6 @@ export function ChatPane({
           canMutateMidTurn={canMutateMidTurn}
           onDelete={removeQueuedPrompt}
           onEdit={editQueuedPrompt}
-          onRestoreUnknown={restoreUnknownQueuedPrompt}
-          onDiscardUnknown={discardUnknownQueuedPrompt}
           onImagePreview={handleImagePreview}
         />
         {unknownPromptAdmission && (

--- a/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.test.tsx
@@ -40,8 +40,6 @@ function setup(
   const handlers = {
     onDelete: vi.fn(),
     onEdit: vi.fn(),
-    onRestoreUnknown: vi.fn(),
-    onDiscardUnknown: vi.fn(),
   };
   const prompts: QueuedPrompt[] = overrides.prompts
     ? [...overrides.prompts]
@@ -253,61 +251,6 @@ describe('QueuedPromptDisplay', () => {
     expect(
       container.querySelector('[class*="queuedPromptSpinner"]'),
     ).toBeTruthy();
-  });
-
-  it('requires confirmation before restoring an unknown local payload', () => {
-    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
-    const { container, handlers } = setup({
-      prompts: [
-        {
-          id: 1,
-          text: '',
-          images: [{ data: 'cG5n', media_type: 'image/png' }],
-          admissionOutcome: 'unknown',
-          payloadCompleteness: 'complete',
-          payloadAvailable: true,
-        },
-      ],
-    });
-    const restore = container.querySelector<HTMLButtonElement>(
-      `[aria-label="${t('queue.restoreUnknown')}"]`,
-    );
-    const discard = container.querySelector<HTMLButtonElement>(
-      `[aria-label="${t('queue.discardUnknown')}"]`,
-    );
-
-    act(() => restore?.click());
-    expect(handlers.onRestoreUnknown).not.toHaveBeenCalled();
-    confirm.mockReturnValue(true);
-    act(() => restore?.click());
-    expect(handlers.onRestoreUnknown).toHaveBeenCalledWith(1);
-    act(() => discard?.click());
-    expect(handlers.onDiscardUnknown).toHaveBeenCalledWith(1);
-    expect(container.textContent).not.toContain(t('queue.footer'));
-    confirm.mockRestore();
-  });
-
-  it('warns when an unknown local copy may match a server summary', () => {
-    const { container } = setup({
-      prompts: [
-        {
-          id: 1,
-          text: 'uncertain',
-          admissionOutcome: 'unknown',
-          payloadCompleteness: 'complete',
-          payloadAvailable: true,
-        },
-        {
-          id: 2,
-          text: '[image]',
-          serverPromptId: 'server-1',
-          serverState: 'queued',
-          payloadCompleteness: 'summary-only',
-        },
-      ],
-    });
-
-    expect(container.textContent).toContain(t('queue.mayCorrespond'));
   });
 
   it('renders queued reference annotations as tags', () => {

--- a/packages/web-shell/client/components/QueuedPromptDisplay.tsx
+++ b/packages/web-shell/client/components/QueuedPromptDisplay.tsx
@@ -135,8 +135,6 @@ export interface QueuedPrompt {
   isEditing?: boolean;
   isRemoving?: boolean;
   payloadCompleteness?: 'complete' | 'summary-only';
-  admissionOutcome?: 'unknown';
-  payloadAvailable?: boolean;
 }
 
 export function QueuedPromptDisplay({
@@ -145,8 +143,6 @@ export function QueuedPromptDisplay({
   canMutateMidTurn = false,
   onDelete,
   onEdit,
-  onRestoreUnknown,
-  onDiscardUnknown,
   onImagePreview,
 }: {
   prompts: readonly QueuedPrompt[];
@@ -154,8 +150,6 @@ export function QueuedPromptDisplay({
   canMutateMidTurn?: boolean;
   onDelete: (id: number) => void;
   onEdit: (id: number) => void;
-  onRestoreUnknown?: (id: number) => void;
-  onDiscardUnknown?: (id: number) => void;
   onImagePreview?: (src: string, alt?: string) => void;
 }) {
   const {
@@ -174,23 +168,10 @@ export function QueuedPromptDisplay({
     latestPrompt.serverState !== 'running' &&
     !latestPrompt.isEditing &&
     !latestPrompt.isRemoving &&
-    latestPrompt.payloadCompleteness !== 'summary-only' &&
-    latestPrompt.admissionOutcome !== 'unknown';
-  const mayContainDuplicateAdmission =
-    prompts.some((prompt) => prompt.admissionOutcome === 'unknown') &&
-    prompts.some(
-      (prompt) =>
-        prompt.payloadCompleteness === 'summary-only' &&
-        prompt.serverPromptId !== undefined,
-    );
+    latestPrompt.payloadCompleteness !== 'summary-only';
 
   return (
     <div className={styles.queuedPrompts}>
-      {mayContainDuplicateAdmission ? (
-        <div className={styles.queuedPromptAmbiguity} role="status">
-          {t('queue.mayCorrespond')}
-        </div>
-      ) : null}
       {prompts.map((prompt) => {
         const preview = truncateQueuedPromptParts(
           getQueuedPromptParts(prompt, parseUserMessageContent),
@@ -209,9 +190,6 @@ export function QueuedPromptDisplay({
           prompt.midTurnState === 'submitting' ||
           (prompt.midTurnState === 'queued' && !prompt.midTurnMessageId);
         const isSummaryOnly = prompt.payloadCompleteness === 'summary-only';
-        const isAdmissionUnknown = prompt.admissionOutcome === 'unknown';
-        const hasUnknownPayload =
-          isAdmissionUnknown && prompt.payloadAvailable !== false;
         const showActions = !isMidTurnPending || canMutateMidTurn;
         const isRemoving = prompt.isRemoving === true;
         const hasStateSpinner =
@@ -223,7 +201,6 @@ export function QueuedPromptDisplay({
           isSubmitting ||
           isRunning ||
           isMidTurnLocked ||
-          isAdmissionUnknown ||
           prompt.isEditing === true ||
           isRemoving;
         const isEditDisabled = isBusy || isSummaryOnly;
@@ -231,9 +208,7 @@ export function QueuedPromptDisplay({
         if (isEditDisabled) {
           editTitle = isSummaryOnly
             ? t('queue.summaryEditDisabled')
-            : isAdmissionUnknown
-              ? t('queue.admissionUnknown')
-              : t('queue.submittingDisabled');
+            : t('queue.submittingDisabled');
         }
         const deleteTitle = isBusy
           ? t('queue.submittingDisabled')
@@ -265,9 +240,6 @@ export function QueuedPromptDisplay({
               {preview.truncated ? '...' : null}
               {fileCount > 0
                 ? ` ${t('queue.fileCount', { count: fileCount })}`
-                : ''}
-              {isAdmissionUnknown && !hasUnknownPayload
-                ? ` ${t('queue.localCopyDiscarded')}`
                 : ''}
             </span>
             {imageCount > 0 ? (
@@ -313,7 +285,6 @@ export function QueuedPromptDisplay({
             {isSubmitting ||
             isQueued ||
             isMidTurnPending ||
-            isAdmissionUnknown ||
             prompt.isEditing ||
             isRemoving ? (
               <span
@@ -332,41 +303,14 @@ export function QueuedPromptDisplay({
                       ? t('queue.editing')
                       : isMidTurnPending
                         ? t('queue.midTurnQueued')
-                        : isAdmissionUnknown
-                          ? t('queue.admissionUnknown')
-                          : isQueued
-                            ? t('queue.serverQueued')
-                            : t('queue.submitting')}
+                        : isQueued
+                          ? t('queue.serverQueued')
+                          : t('queue.submitting')}
                 </span>
               </span>
             ) : null}
             <span className={styles.queuedPromptActions}>
-              {hasUnknownPayload ? (
-                <>
-                  <button
-                    type="button"
-                    className={styles.queuedPromptAction}
-                    onClick={() => {
-                      if (window.confirm(t('queue.continueEditingConfirm'))) {
-                        onRestoreUnknown?.(prompt.id);
-                      }
-                    }}
-                    aria-label={t('queue.restoreUnknown')}
-                    title={t('queue.restoreUnknown')}
-                  >
-                    {t('queue.restoreUnknown')}
-                  </button>
-                  <button
-                    type="button"
-                    className={styles.queuedPromptAction}
-                    onClick={() => onDiscardUnknown?.(prompt.id)}
-                    aria-label={t('queue.discardUnknown')}
-                    title={t('queue.discardUnknown')}
-                  >
-                    {t('queue.discardUnknown')}
-                  </button>
-                </>
-              ) : showActions && !isAdmissionUnknown ? (
+              {showActions ? (
                 <>
                   <button
                     type="button"

--- a/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.dom.test.tsx
@@ -610,7 +610,7 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     expect(latest.queuedPrompts).toEqual([]);
   });
 
-  it('restores image-only payloads exactly once after definite rejection', async () => {
+  it('restores image-only payloads when submission never starts', async () => {
     const { actions, pendingSubmit } = createActions();
     const { editor } = mount('responding', actions);
     const images = [{ data: 'cG5n', media_type: 'image/png' }];
@@ -623,11 +623,10 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
 
     expect(latest.queuedPrompts).toEqual([]);
     expect(editor.setText).not.toHaveBeenCalled();
-    expect(editor.restoreImages).toHaveBeenCalledOnce();
     expect(editor.restoreImages).toHaveBeenCalledWith(images);
   });
 
-  it('does not change an existing draft when restoring image-only payloads', async () => {
+  it('restores image-only payloads alongside an existing draft', async () => {
     const { actions, pendingSubmit } = createActions();
     const { editor } = mount('responding', actions);
     vi.mocked(editor.getText).mockReturnValue('current draft');
@@ -678,52 +677,29 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     expect(editor.restoreInputAnnotations).not.toHaveBeenCalled();
   });
 
-  it('restores an uncertain local payload only after an explicit action', async () => {
+  it('drops a dispatched payload and refreshes from the backend', async () => {
     const { actions, pendingSubmit } = createActions();
-    const { editor, reportError } = mount('responding', actions);
+    const { editor, reportError } = mount('responding', actions, true, true);
     const images = [{ data: 'cG5n', media_type: 'image/png' }];
 
     act(() => latest.enqueuePrompt('', images));
+    vi.mocked(actions.submitPrompt).mock.calls[0]?.[1]?.onAdmissionStarted?.();
     await act(async () => {
       pendingSubmit.reject(new TypeError('network disconnected'));
       await Promise.resolve();
     });
 
-    expect(latest.queuedPrompts).toMatchObject([
-      {
-        text: '',
-        images,
-        admissionOutcome: 'unknown',
-        serverState: undefined,
-        payloadAvailable: true,
-      },
-    ]);
+    expect(latest.queuedPrompts).toEqual([]);
     expect(editor.restoreImages).not.toHaveBeenCalled();
     expect(actions.submitPrompt).toHaveBeenCalledTimes(1);
+    expect(actions.getPendingPrompts).toHaveBeenCalledTimes(2);
     expect(reportError).toHaveBeenCalledWith(
       expect.any(TypeError),
-      t('queue.admissionUnknown'),
+      t('queue.queueFailed'),
     );
-
-    act(() => {
-      expect(latest.restoreUnknownQueuedPrompt(1)).toBe(true);
-    });
-    expect(editor.restoreImages).toHaveBeenCalledOnce();
-    expect(editor.restoreImages).toHaveBeenCalledWith(images);
-    expect(latest.queuedPrompts).toMatchObject([
-      {
-        text: '',
-        images: undefined,
-        admissionOutcome: 'unknown',
-        payloadAvailable: false,
-      },
-    ]);
-    expect(latest.restoreUnknownQueuedPrompt(1)).toBe(false);
-    expect(editor.restoreImages).toHaveBeenCalledOnce();
-    expect(actions.submitPrompt).toHaveBeenCalledTimes(1);
   });
 
-  it('restores queued input annotations with the local payload', async () => {
+  it('restores queued input annotations when submission never starts', async () => {
     const { actions, pendingSubmit } = createActions();
     const { editor } = mount('responding', actions);
     const inputAnnotations = [
@@ -749,40 +725,11 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
       pendingSubmit.reject(new TypeError('response lost'));
       await Promise.resolve();
     });
-    act(() => {
-      expect(latest.restoreUnknownQueuedPrompt(1)).toBe(true);
-    });
-
+    expect(latest.queuedPrompts).toEqual([]);
+    expect(editor.setText).toHaveBeenCalledWith('@file.ts\n\nfix it');
     expect(editor.restoreInputAnnotations).toHaveBeenCalledWith(
       inputAnnotations,
     );
-  });
-
-  it('discards an uncertain local payload without sending it again', async () => {
-    const { actions, pendingSubmit } = createActions();
-    const { editor } = mount('responding', actions);
-    const images = [{ data: 'cG5n', media_type: 'image/png' }];
-
-    act(() => latest.enqueuePrompt('describe', images));
-    await act(async () => {
-      pendingSubmit.reject(new TypeError('network disconnected'));
-      await Promise.resolve();
-    });
-    act(() => {
-      expect(latest.discardUnknownQueuedPrompt(1)).toBe(true);
-    });
-
-    expect(editor.setText).not.toHaveBeenCalled();
-    expect(editor.restoreImages).not.toHaveBeenCalled();
-    expect(latest.queuedPrompts).toMatchObject([
-      {
-        text: '',
-        images: undefined,
-        admissionOutcome: 'unknown',
-        payloadAvailable: false,
-      },
-    ]);
-    expect(actions.submitPrompt).toHaveBeenCalledTimes(1);
   });
 
   it('keeps an accepted message queued until its injection event', async () => {
@@ -1257,7 +1204,7 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     expect(actions.enqueueMidTurnMessage).not.toHaveBeenCalled();
   });
 
-  it('retains mid-turn rows and marks in-flight admissions unknown on clear', async () => {
+  it('retains mid-turn rows and drops in-flight pending admissions on clear', async () => {
     const { actions } = createActions();
     vi.mocked(actions.enqueueMidTurnMessage).mockResolvedValue({
       accepted: true,
@@ -1275,11 +1222,6 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
     act(() => latest.clearQueuedPrompts());
 
     expect(latest.queuedPrompts).toMatchObject([
-      {
-        text: '普通排队',
-        admissionOutcome: 'unknown',
-        payloadAvailable: true,
-      },
       { text: '中途消息', midTurnState: 'queued', midTurnMessageId: 'mid-1' },
     ]);
     expect(actions.removeMidTurnMessage).not.toHaveBeenCalled();
@@ -1295,9 +1237,7 @@ describe('useQueuedPrompts default mid-turn insertion', () => {
       ]),
     );
     act(() => latest.clearQueuedPrompts());
-    expect(latest.queuedPrompts[0]).toMatchObject({
-      admissionOutcome: 'unknown',
-    });
+    expect(latest.queuedPrompts).toEqual([]);
 
     await act(async () => {
       pendingSubmit.resolve({

--- a/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
@@ -440,7 +440,9 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
   it('does not resend when a capable daemon reconciliation is unavailable', async () => {
     // An unavailable snapshot is unknown state, not proof that the daemon
     // rejected the message. Resending here could duplicate a committed POST.
-    sdkMock.actions.getMidTurnMessages.mockResolvedValue(undefined);
+    sdkMock.actions.getMidTurnMessages.mockRejectedValue(
+      new Error('reconciliation unavailable'),
+    );
     const harness = createHarness();
     try {
       await harness.render({ streamingState: 'responding' });
@@ -583,10 +585,85 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     }
   });
 
-  it('restores text after the daemon definitively rejects admission', async () => {
-    sdkMock.actions.enqueueMidTurnMessage.mockResolvedValueOnce({
-      accepted: false,
-    });
+  it('keeps a row restored by a newer reconcile', async () => {
+    let rejectAdmission: ((error: Error) => void) | undefined;
+    let resolveOldSnapshot: ((value: unknown) => void) | undefined;
+    const onComplete = vi.fn();
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectAdmission = reject;
+      }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      await act(async () => {
+        harness
+          .result()
+          .enqueuePrompt('committed', undefined, undefined, onComplete);
+        await Promise.resolve();
+      });
+      const messageId =
+        sdkMock.actions.enqueueMidTurnMessage.mock.calls[0]?.[1]?.messageId;
+      if (!messageId) throw new Error('missing stable message id');
+
+      sdkMock.actions.getMidTurnMessages.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveOldSnapshot = resolve;
+          }),
+      );
+      await act(async () => {
+        rejectAdmission?.(new Error('response lost'));
+        await Promise.resolve();
+      });
+      expect(resolveOldSnapshot).toBeTypeOf('function');
+
+      sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+        messages: [{ messageId, text: 'committed' }],
+        settledMessageIds: [],
+        promotedMessageIds: [],
+      });
+      await harness.render({ streamingState: 'idle' });
+      expect(harness.result().queuedPrompts).toEqual([
+        expect.objectContaining({
+          midTurnMessageId: messageId,
+          midTurnState: 'queued',
+        }),
+      ]);
+
+      await act(async () => {
+        resolveOldSnapshot?.({
+          messages: [],
+          settledMessageIds: [],
+          promotedMessageIds: [],
+        });
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts).toHaveLength(1);
+      expect(harness.reportError).not.toHaveBeenCalled();
+
+      sdkMock.injectedBatches = [
+        {
+          sessionId: 'session-a',
+          messages: ['committed'],
+          messageIds: [messageId],
+        },
+      ];
+      await harness.render({ streamingState: 'responding' });
+      expect(onComplete).toHaveBeenCalledOnce();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('drops the local row after the daemon definitively rejects admission', async () => {
+    sdkMock.actions.enqueueMidTurnMessage.mockImplementationOnce(
+      (_message: string, opts?: { onAdmissionStarted?: () => void }) => {
+        opts?.onAdmissionStarted?.();
+        return Promise.resolve({ accepted: false });
+      },
+    );
     sdkMock.actions.getMidTurnMessages.mockResolvedValue(undefined);
     const harness = createHarness();
     try {
@@ -595,8 +672,9 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         harness.result().enqueuePrompt('queue was full');
       });
 
-      expect(harness.editor.setText).toHaveBeenCalledWith('queue was full');
-      expect(harness.editor.focus).toHaveBeenCalled();
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.editor.setText).not.toHaveBeenCalled();
+      expect(harness.editor.focus).not.toHaveBeenCalled();
       expect(harness.reportError).toHaveBeenCalledTimes(1);
       expect(sdkMock.actions.submitPrompt).not.toHaveBeenCalled();
     } finally {
@@ -604,11 +682,13 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     }
   });
 
-  it('retains an unknown row when admission and reconciliation both fail', async () => {
+  it('drops the local row when admission and reconciliation both fail', async () => {
     sdkMock.actions.enqueueMidTurnMessage.mockRejectedValueOnce(
       new Error('response lost'),
     );
-    sdkMock.actions.getMidTurnMessages.mockResolvedValue(undefined);
+    sdkMock.actions.getMidTurnMessages.mockRejectedValue(
+      new Error('reconciliation unavailable'),
+    );
     const harness = createHarness();
     try {
       await harness.render({ streamingState: 'responding' });
@@ -622,14 +702,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
       expect(sdkMock.actions.submitPrompt).not.toHaveBeenCalled();
       const messageId =
         sdkMock.actions.enqueueMidTurnMessage.mock.calls[0]?.[1]?.messageId;
-      expect(harness.result().queuedPrompts).toEqual([
-        expect.objectContaining({
-          text: 'possibly accepted',
-          midTurnMessageId: messageId,
-          admissionOutcome: 'unknown',
-          payloadAvailable: true,
-        }),
-      ]);
+      expect(harness.result().queuedPrompts).toEqual([]);
 
       sdkMock.actions.getMidTurnMessages.mockResolvedValue({
         messages: [{ messageId, text: 'possibly accepted' }],
@@ -648,7 +721,6 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
           text: 'possibly accepted',
           midTurnMessageId: messageId,
           midTurnState: 'queued',
-          admissionOutcome: undefined,
         }),
       ]);
     } finally {
@@ -656,7 +728,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     }
   });
 
-  it('restores an unknown mid-turn payload without later completing it', async () => {
+  it('does not complete a dropped failed admission from a later snapshot', async () => {
     const onComplete = vi.fn();
     sdkMock.actions.enqueueMidTurnMessage.mockRejectedValueOnce(
       new Error('response lost'),
@@ -670,12 +742,10 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
           .result()
           .enqueuePrompt('recover me', undefined, undefined, onComplete);
       });
-      const row = harness.result().queuedPrompts[0]!;
-      const messageId = row.midTurnMessageId!;
-      await act(async () => {
-        expect(harness.result().restoreUnknownQueuedPrompt(row.id)).toBe(true);
-      });
-      expect(harness.editor.setText).toHaveBeenCalledWith('recover me');
+      const messageId =
+        sdkMock.actions.enqueueMidTurnMessage.mock.calls[0]?.[1]?.messageId;
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.editor.setText).not.toHaveBeenCalled();
 
       sdkMock.actions.getMidTurnMessages.mockResolvedValue({
         messages: [],
@@ -954,36 +1024,85 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     }
   });
 
-  it('preserves a stable-id admission across same-session owner replacement', async () => {
-    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
-      new Promise(() => {}),
+  it('does not restore an in-flight admission across owner replacement', async () => {
+    let resolveAdmission:
+      | ((value: { accepted: boolean; messageId?: string }) => void)
+      | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
+      (_message: string, opts?: { onAdmissionStarted?: () => void }) =>
+        new Promise((resolve) => {
+          opts?.onAdmissionStarted?.();
+          resolveAdmission = resolve;
+        }),
     );
     const harness = createHarness();
     try {
       await harness.render({ streamingState: 'responding' });
       await act(async () => {
-        harness.result().enqueuePrompt('survive reattach');
+        harness
+          .result()
+          .enqueuePrompt('survive reattach', [
+            { data: 'aW1n', media_type: 'image/png' },
+          ]);
+        await Promise.resolve();
       });
-      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(sdkMock.actions.enqueueMidTurnMessage).toHaveBeenCalledTimes(1);
 
       sdkMock.ownerVersion += 1;
       await harness.render({ streamingState: 'responding' });
 
-      expect(harness.result().queuedPrompts).toEqual([
-        expect.objectContaining({
-          sessionId: 'session-a',
-          text: 'survive reattach',
-          admissionOutcome: 'unknown',
-          payloadCompleteness: 'complete',
-        }),
-      ]);
+      expect(harness.result().queuedPrompts).toEqual([]);
       expect(harness.editor.setText).not.toHaveBeenCalled();
+      expect(harness.editor.restoreImages).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveAdmission?.({ accepted: true });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.editor.setText).not.toHaveBeenCalled();
+      expect(harness.editor.restoreImages).not.toHaveBeenCalled();
     } finally {
       await harness.dispose();
     }
   });
 
-  it('preserves an ambiguous stable-id admission across later reattachment', async () => {
+  it('does not restore an accepted admission missing from the backend snapshot', async () => {
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      await act(async () => {
+        harness
+          .result()
+          .enqueuePrompt('accepted but absent', [
+            { data: 'aW1n', media_type: 'image/png' },
+          ]);
+      });
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
+      expect(harness.result().queuedPrompts).toEqual([]);
+
+      sdkMock.ownerVersion += 1;
+      await harness.render({ streamingState: 'responding' });
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.editor.setText).not.toHaveBeenCalled();
+      expect(harness.editor.restoreImages).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not preserve an ambiguous stable-id admission across reattachment', async () => {
     let rejectAdmission: ((error: Error) => void) | undefined;
     sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
       new Promise((_resolve, reject) => {
@@ -1000,22 +1119,14 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         await Promise.resolve();
         await Promise.resolve();
       });
-      expect(harness.result().queuedPrompts).toEqual([
-        expect.objectContaining({
-          text: 'ambiguous input',
-          admissionOutcome: 'unknown',
-        }),
-      ]);
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.reportError).toHaveBeenCalledOnce();
+      expect(sdkMock.actions.getMidTurnMessages).toHaveBeenCalledTimes(2);
 
       sdkMock.ownerVersion += 1;
       await harness.render({ streamingState: 'responding' });
 
-      expect(harness.result().queuedPrompts).toEqual([
-        expect.objectContaining({
-          text: 'ambiguous input',
-          admissionOutcome: 'unknown',
-        }),
-      ]);
+      expect(harness.result().queuedPrompts).toEqual([]);
     } finally {
       await harness.dispose();
     }
@@ -1038,7 +1149,8 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         await Promise.resolve();
         await Promise.resolve();
       });
-      const messageId = harness.result().queuedPrompts[0]?.midTurnMessageId;
+      const messageId =
+        sdkMock.actions.enqueueMidTurnMessage.mock.calls[0]?.[1]?.messageId;
       if (!messageId) throw new Error('missing stable message id');
 
       sdkMock.actions.getMidTurnMessages.mockResolvedValue({
@@ -1084,12 +1196,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         streamingState: 'responding',
         workspaceCwd: '/workspace-a',
       });
-      expect(harness.result().queuedPrompts).toEqual([
-        expect.objectContaining({
-          text: 'workspace-a input',
-          admissionOutcome: 'unknown',
-        }),
-      ]);
+      expect(harness.result().queuedPrompts).toEqual([]);
     } finally {
       await harness.dispose();
     }
@@ -1099,10 +1206,12 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     let resolveAdmission:
       | ((value: { accepted: boolean; messageId?: string }) => void)
       | undefined;
-    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
-      new Promise((resolve) => {
-        resolveAdmission = resolve;
-      }),
+    sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
+      (_message: string, opts?: { onAdmissionStarted?: () => void }) =>
+        new Promise((resolve) => {
+          opts?.onAdmissionStarted?.();
+          resolveAdmission = resolve;
+        }),
     );
     const harness = createHarness();
     try {
@@ -1122,10 +1231,8 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         await Promise.resolve();
       });
 
-      expect(harness.editor.setText).toHaveBeenCalledWith(
-        'rejected in workspace-a',
-      );
-      expect(harness.reportError).toHaveBeenCalledTimes(1);
+      expect(harness.editor.setText).not.toHaveBeenCalled();
+      expect(harness.reportError).not.toHaveBeenCalled();
 
       await harness.render({
         streamingState: 'responding',
@@ -1133,6 +1240,152 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
       });
 
       expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not report a rejection after switching workspaces during reconciliation', async () => {
+    let resolveAdmission:
+      | ((value: { accepted: boolean; messageId?: string }) => void)
+      | undefined;
+    let resolveSnapshot: ((value: unknown) => void) | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
+      (_message: string, opts?: { onAdmissionStarted?: () => void }) =>
+        new Promise((resolve) => {
+          opts?.onAdmissionStarted?.();
+          resolveAdmission = resolve;
+        }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({ workspaceCwd: '/workspace-a' });
+      await act(async () => {
+        harness.result().enqueuePrompt('rejected in workspace-a');
+      });
+      sdkMock.actions.getMidTurnMessages.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+      );
+      await act(async () => {
+        resolveAdmission?.({ accepted: false });
+        await Promise.resolve();
+      });
+      expect(resolveSnapshot).toBeTypeOf('function');
+
+      await harness.render({ workspaceCwd: '/workspace-b' });
+      await act(async () => {
+        resolveSnapshot?.({
+          messages: [],
+          settledMessageIds: [],
+          promotedMessageIds: [],
+        });
+        await Promise.resolve();
+      });
+
+      expect(harness.reportError).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not report a transport failure after switching workspaces during reconciliation', async () => {
+    let rejectAdmission: ((error: Error) => void) | undefined;
+    let resolveSnapshot: ((value: unknown) => void) | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectAdmission = reject;
+      }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({ workspaceCwd: '/workspace-a' });
+      await act(async () => {
+        harness.result().enqueuePrompt('failed in workspace-a');
+      });
+      sdkMock.actions.getMidTurnMessages.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+      );
+      await act(async () => {
+        rejectAdmission?.(new Error('response lost'));
+        await Promise.resolve();
+      });
+      expect(resolveSnapshot).toBeTypeOf('function');
+
+      await harness.render({ workspaceCwd: '/workspace-b' });
+      await act(async () => {
+        resolveSnapshot?.({
+          messages: [],
+          settledMessageIds: [],
+          promotedMessageIds: [],
+        });
+        await Promise.resolve();
+      });
+
+      expect(harness.reportError).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('drops an accepted admission payload after switching workspaces', async () => {
+    let resolveAdmission:
+      | ((value: { accepted: boolean; messageId?: string }) => void)
+      | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAdmission = resolve;
+      }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-a',
+      });
+      await act(async () => {
+        harness
+          .result()
+          .enqueuePrompt('accepted in workspace-a', [
+            { data: 'aW1n', media_type: 'image/png' },
+          ]);
+        await Promise.resolve();
+      });
+      const messageId =
+        sdkMock.actions.enqueueMidTurnMessage.mock.calls[0]?.[1]?.messageId;
+      if (!messageId) throw new Error('missing stable message id');
+
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-b',
+      });
+      await act(async () => {
+        resolveAdmission?.({ accepted: true, messageId });
+        await Promise.resolve();
+      });
+
+      sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+        messages: [{ messageId, text: 'accepted in workspace-a' }],
+        settledMessageIds: [],
+        promotedMessageIds: [],
+      });
+      await harness.render({
+        streamingState: 'responding',
+        workspaceCwd: '/workspace-a',
+      });
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
+
+      expect(harness.result().queuedPrompts).toEqual([
+        expect.objectContaining({ midTurnMessageId: messageId }),
+      ]);
+      expect(harness.result().queuedPrompts[0]?.images).toBeUndefined();
     } finally {
       await harness.dispose();
     }
@@ -1364,8 +1617,12 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     const onComplete = vi.fn();
     let rejectedId: string | undefined;
     sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
-      (_message: string, opts?: { messageId?: string }) => {
+      (
+        _message: string,
+        opts?: { messageId?: string; onAdmissionStarted?: () => void },
+      ) => {
         rejectedId = opts?.messageId;
+        opts?.onAdmissionStarted?.();
         return Promise.resolve({ accepted: false });
       },
     );
@@ -1382,7 +1639,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
           await Promise.resolve();
         });
       }
-      expect(harness.editor.setText).toHaveBeenCalledWith('rejected');
+      expect(harness.editor.setText).not.toHaveBeenCalled();
       expect(harness.reportError).toHaveBeenCalledTimes(1);
       expect(onComplete).not.toHaveBeenCalled();
 
@@ -1406,7 +1663,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     }
   });
 
-  it('keeps an ambiguous enqueue when the first reconciliation snapshot is empty', async () => {
+  it('drops an ambiguous enqueue when the reconciliation snapshot is empty', async () => {
     const onComplete = vi.fn();
     let failedId: string | undefined;
     sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
@@ -1439,22 +1696,13 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         });
       }
 
-      // An empty snapshot cannot prove that the timed-out POST will not land
-      // after this read. Keep both the stable admission and its uploaded media
-      // until a later snapshot settles the id.
       expect(harness.editor.setText).not.toHaveBeenCalled();
       expect(sdkMock.actions.removeMedia).not.toHaveBeenCalled();
       expect(harness.reportError).toHaveBeenCalledTimes(1);
       expect(onComplete).not.toHaveBeenCalled();
-      expect(harness.result().queuedPrompts).toEqual([
-        expect.objectContaining({
-          text: 'lost in transit',
-          midTurnMessageId: failedId,
-          admissionOutcome: 'unknown',
-        }),
-      ]);
+      expect(harness.result().queuedPrompts).toEqual([]);
 
-      // A later authoritative snapshot settles the retained admission once.
+      // The failed local admission no longer owns a completion callback.
       sdkMock.actions.getMidTurnMessages.mockResolvedValue({
         messages: [],
         settledMessageIds: [failedId],
@@ -1467,7 +1715,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
           await Promise.resolve();
         });
       }
-      expect(onComplete).toHaveBeenCalledTimes(1);
+      expect(onComplete).not.toHaveBeenCalled();
     } finally {
       await harness.dispose();
     }
@@ -1707,6 +1955,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         'settled late',
         undefined,
         undefined,
+        undefined,
       );
     } finally {
       await harness.dispose();
@@ -1748,9 +1997,13 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
   });
 
   it('removes uploaded media when mid-turn admission is rejected', async () => {
-    sdkMock.actions.enqueueMidTurnMessage.mockResolvedValueOnce({
-      accepted: false,
-    });
+    sdkMock.actions.enqueueMidTurnMessage.mockImplementationOnce(
+      (_message: string, opts?: { onAdmissionStarted?: () => void }) => {
+        opts?.onAdmissionStarted?.();
+        return Promise.resolve({ accepted: false });
+      },
+    );
+    sdkMock.actions.removeMedia.mockReturnValueOnce(new Promise(() => {}));
     const harness = createHarness();
     try {
       await harness.render({ streamingState: 'responding' });
@@ -1766,9 +2019,9 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
       expect(sdkMock.actions.removeMedia).toHaveBeenCalledWith('media-1', {
         sessionId: 'session-a',
       });
-      expect(harness.editor.restoreImages).toHaveBeenCalledWith([
-        { data: 'aW1n', media_type: 'image/png' },
-      ]);
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.reportError).toHaveBeenCalledTimes(1);
+      expect(harness.editor.restoreImages).not.toHaveBeenCalled();
     } finally {
       await harness.dispose();
     }
@@ -1885,6 +2138,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         size: 3,
       })
       .mockRejectedValueOnce(new Error('second upload failed'));
+    sdkMock.actions.removeMedia.mockReturnValueOnce(new Promise(() => {}));
     const harness = createHarness();
     try {
       await harness.render({ streamingState: 'responding' });
@@ -1901,6 +2155,11 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         { sessionId: 'session-a' },
       );
       expect(sdkMock.actions.enqueueMidTurnMessage).not.toHaveBeenCalled();
+      expect(harness.editor.setText).toHaveBeenCalledWith('keep this');
+      expect(harness.editor.restoreImages).toHaveBeenCalledWith([
+        { data: 'aW1nMQ==', media_type: 'image/png' },
+        { data: 'aW1nMg==', media_type: 'image/png' },
+      ]);
     } finally {
       await harness.dispose();
     }
@@ -2044,6 +2303,64 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         text: 'promoted note',
         images: [{ data: 'aW1n', media_type: 'image/png' }],
       });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('keeps promoted media available when the pending-prompt refresh fails', async () => {
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      let messageId: string | undefined;
+      sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
+        (_message: string, opts?: { messageId?: string }) => {
+          messageId = opts?.messageId;
+          return Promise.resolve({ accepted: true, messageId });
+        },
+      );
+      sdkMock.actions.getMidTurnMessages.mockImplementation(async () => ({
+        messages: [],
+        settledMessageIds: [],
+        promotedMessageIds: messageId ? [messageId] : [],
+      }));
+      sdkMock.actions.getPendingPrompts.mockRejectedValueOnce(
+        new Error('pending snapshot unavailable'),
+      );
+
+      await act(async () => {
+        harness
+          .result()
+          .enqueuePrompt('', [{ data: 'aW1n', media_type: 'image/png' }]);
+      });
+      for (let i = 0; i < 4; i++) {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
+      expect(harness.result().queuedPrompts).toEqual([]);
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            promptId: messageId,
+            originatorClientId: CLIENT_ID,
+            data: {
+              sessionId: 'session-a',
+              promptId: messageId,
+              text: '',
+            },
+          },
+        ]);
+      });
+
+      expect(harness.store.appendLocalUserMessage).toHaveBeenCalledWith(
+        '',
+        [{ data: 'aW1n', mimeType: 'image/png' }],
+        undefined,
+        undefined,
+      );
     } finally {
       await harness.dispose();
     }

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -35,7 +35,6 @@ import type { PromptFile, PromptImage } from '../adapters/promptTypes';
 import type { EditorHandle } from './useComposerCore';
 import { removeInjectedFromQueue } from '../midTurnDedup';
 import { isCommandPrompt } from '../utils/localCommandQueue';
-import { isDefinitelyRejectedPromptAdmission } from '../utils/promptAdmission';
 import type { getTranslator } from '../i18n';
 import type { QueuedPrompt } from '../components/QueuedPromptDisplay';
 
@@ -121,8 +120,6 @@ function areQueuedPromptsEqual(
       prompt.isEditing === other.isEditing &&
       prompt.isRemoving === other.isRemoving &&
       prompt.payloadCompleteness === other.payloadCompleteness &&
-      prompt.admissionOutcome === other.admissionOutcome &&
-      prompt.payloadAvailable === other.payloadAvailable &&
       (prompt.images?.length ?? 0) === (other.images?.length ?? 0) &&
       (prompt.files?.length ?? 0) === (other.files?.length ?? 0) &&
       (prompt.inputAnnotations?.length ?? 0) ===
@@ -226,8 +223,6 @@ export interface UseQueuedPromptsResult {
   editQueuedPrompt: (id: number) => Promise<void>;
   editLastQueuedPrompt: () => boolean;
   clearQueuedPrompts: () => boolean;
-  restoreUnknownQueuedPrompt: (id: number) => boolean;
-  discardUnknownQueuedPrompt: (id: number) => boolean;
 }
 
 export function useQueuedPrompts({
@@ -395,7 +390,6 @@ export function useQueuedPrompts({
           (p) =>
             !p.serverPromptId &&
             p.serverState === 'submitting' &&
-            p.admissionOutcome !== 'unknown' &&
             (p.images?.length ?? 0) === 0 &&
             (p.files?.length ?? 0) === 0 &&
             p.text === serverPrompt.text,
@@ -420,7 +414,6 @@ export function useQueuedPrompts({
           (prompt) =>
             !prompt.serverPromptId &&
             prompt.serverState === 'submitting' &&
-            prompt.admissionOutcome !== 'unknown' &&
             ((prompt.images?.length ?? 0) > 0 ||
               (prompt.files?.length ?? 0) > 0),
         );
@@ -524,7 +517,12 @@ export function useQueuedPrompts({
         if (images && images.length > 0) {
           promotedImages.set(messageId, images);
         }
-        pendingMidTurnAdmissionsRef.current.delete(messageId);
+        // A failed pending-prompt refresh leaves no row for a later start
+        // event to recover media from, so retain the hidden payload until the
+        // server row is available.
+        if (applyPromoted) {
+          pendingMidTurnAdmissionsRef.current.delete(messageId);
+        }
       }
       const waitingIds = new Set(
         snapshot.messages.map((message) => message.messageId),
@@ -533,8 +531,7 @@ export function useQueuedPrompts({
       let next = current.filter(
         (prompt) =>
           !(
-            (prompt.midTurnState !== undefined ||
-              prompt.admissionOutcome === 'unknown') &&
+            prompt.midTurnState !== undefined &&
             prompt.midTurnMessageId !== undefined &&
             !prompt.isEditing &&
             !prompt.isRemoving &&
@@ -543,14 +540,12 @@ export function useQueuedPrompts({
           ),
       );
       next = next.map((prompt) =>
-        prompt.admissionOutcome === 'unknown' &&
+        prompt.midTurnState === 'submitting' &&
         prompt.midTurnMessageId !== undefined &&
         waitingIds.has(prompt.midTurnMessageId)
           ? {
               ...prompt,
               midTurnState: 'queued',
-              admissionOutcome: undefined,
-              payloadAvailable: undefined,
             }
           : prompt,
       );
@@ -684,9 +679,14 @@ export function useQueuedPrompts({
         latestSessionIdRef.current === targetSessionId &&
         expectedSeq === midTurnReconcileSeqRef.current;
       if (!isCurrent()) return undefined;
-      const snapshot = await sessionActions.getMidTurnMessages({
-        signal: opts?.signal,
-      });
+      let snapshot: DaemonMidTurnMessagesResult | undefined;
+      try {
+        snapshot = await sessionActions.getMidTurnMessages({
+          signal: opts?.signal,
+        });
+      } catch (error) {
+        console.warn('Failed to refresh mid-turn messages', error);
+      }
       if (!snapshot || !isCurrent()) {
         if (isCurrent()) await refreshPendingPrompts(targetSessionId);
         return undefined;
@@ -732,7 +732,6 @@ export function useQueuedPrompts({
     (
       prompts: readonly QueuedPrompt[],
       targetSessionId?: string,
-      allowUnknown = false,
       expectedOwnerToken = ownerTokenRef.current,
     ): boolean => {
       if (
@@ -747,8 +746,6 @@ export function useQueuedPrompts({
       const restorable = prompts.filter(
         (prompt) =>
           prompt.payloadCompleteness !== 'summary-only' &&
-          (allowUnknown || prompt.admissionOutcome !== 'unknown') &&
-          prompt.payloadAvailable !== false &&
           !restoredPromptIdsRef.current.has(prompt.id),
       );
       if (restorable.length === 0) return false;
@@ -818,16 +815,16 @@ export function useQueuedPrompts({
     );
     const interruptedPrompts = queuedPromptsRef.current.filter(
       (prompt) =>
-        prompt.midTurnState === 'submitting' ||
+        (prompt.midTurnState === 'submitting' &&
+          prompt.midTurnMessageId === undefined) ||
         prompt.midTurnFailedAction === 'edit',
     );
     if (interruptedPrompts.length > 0) {
       restoreQueuedPromptsToEditorRef.current(interruptedPrompts);
     }
     queuedPromptsOwnerRef.current = ownerToken;
-    const retainedPrompts = retainedAdmissions.map(([, entry]) => entry.prompt);
-    queuedPromptsRef.current = retainedPrompts;
-    setQueuedPrompts(retainedPrompts);
+    queuedPromptsRef.current = [];
+    setQueuedPrompts([]);
     completionCallbacksRef.current = retainedCompletionCallbacks;
     completedPromptIdsRef.current = new Set();
     completedPromptIdOrderRef.current = [];
@@ -921,6 +918,8 @@ export function useQueuedPrompts({
       handled.push(event);
       const promptId = event.data.promptId;
       if (!promptId) continue;
+      const pendingMidTurnPrompt =
+        pendingMidTurnAdmissionsRef.current.get(promptId)?.prompt;
       pendingMidTurnAdmissionsRef.current.delete(promptId);
       if (event.type === 'pending_prompt_started') {
         if (removingServerPromptIdsRef.current.has(promptId)) {
@@ -942,11 +941,11 @@ export function useQueuedPrompts({
             queuedPromptsRef.current.find(
               (item) => item.midTurnMessageId === promptId,
             ) ??
+            pendingMidTurnPrompt ??
             queuedPromptsRef.current.find(
               (item) =>
                 !item.serverPromptId &&
                 item.serverState === 'submitting' &&
-                item.admissionOutcome !== 'unknown' &&
                 (item.images?.length ?? 0) === 0 &&
                 (item.files?.length ?? 0) === 0 &&
                 item.text === eventText,
@@ -1038,6 +1037,7 @@ export function useQueuedPrompts({
       const ownerToken = ownerTokenRef.current;
       const submitAbort = new AbortController();
       submitAbortControllersRef.current.add(submitAbort);
+      let admissionStarted = false;
 
       sessionActions
         .submitPrompt(prompt.text, {
@@ -1047,6 +1047,9 @@ export function useQueuedPrompts({
           optimisticUserMessage: false,
           sessionId: targetSessionId,
           signal: submitAbort.signal,
+          onAdmissionStarted: () => {
+            admissionStarted = true;
+          },
         })
         .then((result) => {
           submitAbortControllersRef.current.delete(submitAbort);
@@ -1126,12 +1129,6 @@ export function useQueuedPrompts({
             if (prompt.onComplete) {
               settleCompletionCallback(result.promptId, prompt.onComplete);
             }
-            if (
-              (prompt.images?.length ?? 0) > 0 ||
-              (prompt.files?.length ?? 0) > 0
-            ) {
-              void refreshPendingPrompts(targetSessionId);
-            }
             return;
           }
           const current = queuedPromptsRef.current;
@@ -1158,22 +1155,11 @@ export function useQueuedPrompts({
             ...localPrompt,
             serverPromptId: result.promptId,
             serverState: 'queued',
-            admissionOutcome: undefined,
-            payloadAvailable: undefined,
-            ...(localPrompt.payloadAvailable === false
-              ? { payloadCompleteness: 'summary-only' }
-              : {}),
           };
           queuedPromptsRef.current = updated;
           setQueuedPrompts(updated);
           if (prompt.onComplete) {
             settleCompletionCallback(result.promptId, prompt.onComplete);
-          }
-          if (
-            (prompt.images?.length ?? 0) > 0 ||
-            (prompt.files?.length ?? 0) > 0
-          ) {
-            void refreshPendingPrompts(targetSessionId);
           }
         })
         .catch((error: unknown) => {
@@ -1185,31 +1171,23 @@ export function useQueuedPrompts({
             return;
           }
           if (!queuedPromptsRef.current.some((p) => p.id === localId)) return;
-          const definitelyRejected = isDefinitelyRejectedPromptAdmission(error);
-          if (!definitelyRejected) {
-            const uncertain = queuedPromptsRef.current.map((item) =>
-              item.id === localId
-                ? {
-                    ...item,
-                    serverState: undefined,
-                    admissionOutcome: 'unknown' as const,
-                    payloadAvailable: true,
-                  }
-                : item,
-            );
-            queuedPromptsRef.current = uncertain;
-            setQueuedPrompts(uncertain);
-            void refreshPendingPrompts(targetSessionId);
-            reportError(error, t('queue.admissionUnknown'));
-            return;
-          }
           const next = queuedPromptsRef.current.filter(
             (prompt) => prompt.id !== localId,
           );
           queuedPromptsRef.current = next;
           setQueuedPrompts(next);
-          restoreQueuedPromptsToEditor([prompt], targetSessionId);
+          if (!admissionStarted) {
+            restoreQueuedPromptsToEditor([prompt], targetSessionId);
+          }
           reportError(error, t('queue.queueFailed'));
+        })
+        .finally(() => {
+          if (
+            isCurrentOwnerTokenRef.current(ownerToken) &&
+            latestSessionIdRef.current === targetSessionId
+          ) {
+            void refreshPendingPrompts(targetSessionId);
+          }
         });
     },
     [
@@ -1294,16 +1272,24 @@ export function useQueuedPrompts({
             }`
           : undefined;
 
-      if (shouldInsertMidTurn && canQueryMidTurn && midTurnMessageId) {
+      if (
+        shouldInsertMidTurn &&
+        canQueryMidTurn &&
+        midTurnMessageId &&
+        targetSessionId
+      ) {
+        const targetIsCurrent = () =>
+          isCurrentOwnerTokenRef.current(ownerToken) &&
+          latestSessionIdRef.current === targetSessionId &&
+          latestWorkspaceCwdRef.current === targetWorkspaceCwd;
         const pendingAdmission: QueuedPrompt = {
           id: nextQueuedPromptIdRef.current++,
           sessionId: targetSessionId,
           text: trimmed,
           ...(imageList.length > 0 ? { images: [...imageList] } : {}),
           midTurnMessageId,
-          admissionOutcome: 'unknown',
+          midTurnState: 'submitting',
           payloadCompleteness: 'complete',
-          payloadAvailable: true,
         };
         pendingMidTurnAdmissionsRef.current.set(midTurnMessageId, {
           prompt: pendingAdmission,
@@ -1312,7 +1298,7 @@ export function useQueuedPrompts({
         if (imageList.length > 0) {
           queuedPromptsRef.current = [
             ...queuedPromptsRef.current,
-            { ...pendingAdmission, midTurnState: 'submitting' },
+            pendingAdmission,
           ];
           setQueuedPrompts(queuedPromptsRef.current);
         }
@@ -1322,6 +1308,7 @@ export function useQueuedPrompts({
         const abort = midTurnEnqueueAbortRef.current ?? new AbortController();
         midTurnEnqueueAbortRef.current = abort;
         let enqueueStarted = false;
+        let enqueueDispatched = false;
         let uploadedMediaReferences: DaemonSessionMediaReference[] = [];
         const removeUploadedMedia = async () => {
           if (!targetSessionId) return;
@@ -1355,7 +1342,7 @@ export function useQueuedPrompts({
                 result.status === 'rejected',
             );
             if (failure) {
-              await removeUploadedMedia();
+              void removeUploadedMedia();
               throw failure.reason;
             }
             if (
@@ -1363,13 +1350,16 @@ export function useQueuedPrompts({
               latestSessionIdRef.current !== targetSessionId ||
               latestWorkspaceCwdRef.current !== targetWorkspaceCwd
             ) {
-              await removeUploadedMedia();
+              void removeUploadedMedia();
               throw new DOMException('Session changed', 'AbortError');
             }
             enqueueStarted = true;
             return await sessionActions.enqueueMidTurnMessage(trimmed, {
               signal: abort.signal,
               messageId: midTurnMessageId,
+              onAdmissionStarted: () => {
+                enqueueDispatched = true;
+              },
               ...(uploadedMediaReferences.length > 0
                 ? { content: uploadedMediaReferences }
                 : {}),
@@ -1377,62 +1367,41 @@ export function useQueuedPrompts({
           })
           .then(async (result) => {
             if (!result.accepted) {
-              await removeUploadedMedia();
-              completionCallbacksRef.current.delete(midTurnMessageId);
-              const pendingAdmissionStillOwned =
-                pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
-              if (
-                latestSessionIdRef.current !== targetSessionId ||
-                latestWorkspaceCwdRef.current !== targetWorkspaceCwd
-              ) {
-                if (pendingAdmissionStillOwned) {
-                  restoreQueuedPromptsToEditor(
-                    [pendingAdmission],
-                    undefined,
-                    true,
-                  );
-                  reportError(
-                    new Error('Daemon rejected mid-turn message'),
-                    t('queue.queueFailed'),
-                  );
-                }
-                return;
+              if (!enqueueDispatched) {
+                enqueueStarted = false;
+                throw new Error('Mid-turn message was not dispatched');
               }
-              if (!pendingAdmissionStillOwned) return;
+              void removeUploadedMedia();
+              completionCallbacksRef.current.delete(midTurnMessageId);
+              pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
               const next = queuedPromptsRef.current.filter(
                 (prompt) => prompt.midTurnMessageId !== midTurnMessageId,
               );
               queuedPromptsRef.current = next;
               setQueuedPrompts(next);
-              restoreQueuedPromptsToEditor(
-                [pendingAdmission],
-                targetSessionId,
-                true,
-              );
+              if (!targetIsCurrent()) return;
+              await reconcileMidTurnMessages(targetSessionId);
+              if (!targetIsCurrent()) return;
               reportError(
                 new Error('Daemon rejected mid-turn message'),
                 t('queue.queueFailed'),
               );
               return;
             }
-            if (
-              latestSessionIdRef.current === targetSessionId &&
-              latestWorkspaceCwdRef.current === targetWorkspaceCwd &&
-              targetSessionId
-            ) {
+            const next = queuedPromptsRef.current.filter(
+              (prompt) => prompt.midTurnMessageId !== midTurnMessageId,
+            );
+            queuedPromptsRef.current = next;
+            setQueuedPrompts(next);
+            if (targetIsCurrent()) {
               await reconcileMidTurnMessages(targetSessionId);
+            } else {
+              pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
+              completionCallbacksRef.current.delete(midTurnMessageId);
             }
-            // Do NOT delete the pending admission here. `applyMidTurnSnapshot`
-            // deletes it atomically with salvaging its images; deleting early
-            // opens a race where a concurrent (e.g. streaming-driven) reconcile
-            // applies after this delete and rebuilds the row without the images.
           })
           .catch(async (error: unknown) => {
-            if (
-              latestSessionIdRef.current !== targetSessionId ||
-              latestWorkspaceCwdRef.current !== targetWorkspaceCwd ||
-              !targetSessionId
-            ) {
+            if (!targetIsCurrent()) {
               completionCallbacksRef.current.delete(midTurnMessageId);
               const pendingAdmissionStillOwned =
                 pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
@@ -1441,11 +1410,7 @@ export function useQueuedPrompts({
                 // return: restore it to the current editor instead of
                 // leaking it across the session switch.
                 if (pendingAdmissionStillOwned) {
-                  restoreQueuedPromptsToEditor(
-                    [pendingAdmission],
-                    undefined,
-                    true,
-                  );
+                  restoreQueuedPromptsToEditor([pendingAdmission], undefined);
                   reportError(error, t('queue.queueFailed'));
                 }
               }
@@ -1466,69 +1431,42 @@ export function useQueuedPrompts({
               );
               queuedPromptsRef.current = next;
               setQueuedPrompts(next);
-              restoreQueuedPromptsToEditor(
-                [pendingAdmission],
-                targetSessionId,
-                true,
-              );
+              restoreQueuedPromptsToEditor([pendingAdmission], targetSessionId);
               reportError(error, t('queue.queueFailed'));
               return;
             }
             const snapshot = await reconcileMidTurnMessages(targetSessionId);
-            if (!snapshot) {
-              if (!pendingMidTurnAdmissionsRef.current.has(midTurnMessageId)) {
-                return;
-              }
-              if (
-                !queuedPromptsRef.current.some(
-                  (prompt) =>
-                    prompt.midTurnMessageId === midTurnMessageId ||
-                    prompt.serverPromptId === midTurnMessageId,
-                )
-              ) {
-                const next = [
-                  ...queuedPromptsRef.current,
-                  {
-                    id: nextQueuedPromptIdRef.current++,
-                    sessionId: targetSessionId,
-                    text: trimmed,
-                    // Keep the images so resolving this unknown row restores
-                    // the full payload, not just the text.
-                    ...(imageList.length > 0 ? { images: [...imageList] } : {}),
-                    midTurnMessageId,
-                    admissionOutcome: 'unknown' as const,
-                    payloadCompleteness: 'complete' as const,
-                    payloadAvailable: true,
-                  },
-                ];
-                queuedPromptsRef.current = next;
-                setQueuedPrompts(next);
-              }
-              reportError(error, t('queue.admissionUnknown'));
+            if (!targetIsCurrent()) {
+              completionCallbacksRef.current.delete(midTurnMessageId);
+              pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
               return;
             }
             const known =
-              snapshot.messages.some(
+              snapshot?.messages.some(
                 (message) => message.messageId === midTurnMessageId,
-              ) ||
-              snapshot.settledMessageIds.includes(midTurnMessageId) ||
-              snapshot.promotedMessageIds.includes(midTurnMessageId);
+              ) === true ||
+              snapshot?.settledMessageIds.includes(midTurnMessageId) === true ||
+              snapshot?.promotedMessageIds.includes(midTurnMessageId) === true;
             if (known) return;
-            if (!pendingMidTurnAdmissionsRef.current.has(midTurnMessageId)) {
+            if (
+              snapshot === undefined &&
+              queuedPromptsRef.current.some(
+                (prompt) =>
+                  (prompt.midTurnMessageId === midTurnMessageId &&
+                    prompt.midTurnState === 'queued') ||
+                  prompt.serverPromptId === midTurnMessageId,
+              )
+            ) {
               return;
             }
-            const next = queuedPromptsRef.current.map((prompt) =>
-              prompt.midTurnMessageId === midTurnMessageId
-                ? {
-                    ...prompt,
-                    midTurnState: undefined,
-                    admissionOutcome: 'unknown' as const,
-                  }
-                : prompt,
+            completionCallbacksRef.current.delete(midTurnMessageId);
+            pendingMidTurnAdmissionsRef.current.delete(midTurnMessageId);
+            const next = queuedPromptsRef.current.filter(
+              (prompt) => prompt.midTurnMessageId !== midTurnMessageId,
             );
             queuedPromptsRef.current = next;
             setQueuedPrompts(next);
-            reportError(error, t('queue.admissionUnknown'));
+            reportError(error, t('queue.queueFailed'));
           });
         return true;
       }
@@ -1938,7 +1876,6 @@ export function useQueuedPrompts({
   const removeQueuedPrompt = useCallback(
     (id: number) => {
       const target = queuedPromptsRef.current.find((p) => p.id === id);
-      if (target?.admissionOutcome === 'unknown') return;
       if (
         target?.serverState === 'submitting' ||
         target?.midTurnState === 'submitting'
@@ -1970,69 +1907,11 @@ export function useQueuedPrompts({
     [removeMidTurnPromptForAction, removeServerPromptForAction, t],
   );
 
-  const resolveUnknownQueuedPrompt = useCallback(
-    (id: number, restore: boolean): boolean => {
-      const ownerToken = ownerTokenRef.current;
-      const target = queuedPromptsRef.current.find(
-        (prompt) => prompt.id === id,
-      );
-      if (
-        !target ||
-        target.admissionOutcome !== 'unknown' ||
-        target.payloadCompleteness === 'summary-only' ||
-        target.payloadAvailable === false ||
-        target.sessionId !== latestSessionIdRef.current
-      ) {
-        return false;
-      }
-      if (
-        restore &&
-        !restoreQueuedPromptsToEditor([target], target.sessionId, true)
-      ) {
-        return false;
-      }
-      if (!isCurrentOwnerTokenRef.current(ownerToken)) return false;
-      if (target.midTurnMessageId) {
-        completionCallbacksRef.current.delete(target.midTurnMessageId);
-        pendingMidTurnAdmissionsRef.current.delete(target.midTurnMessageId);
-      }
-      const next = queuedPromptsRef.current.map((prompt) =>
-        prompt.id === id
-          ? {
-              ...prompt,
-              text: '',
-              images: undefined,
-              files: undefined,
-              inputAnnotations: undefined,
-              onComplete: undefined,
-              payloadAvailable: false,
-            }
-          : prompt,
-      );
-      queuedPromptsRef.current = next;
-      setQueuedPrompts(next);
-      return true;
-    },
-    [restoreQueuedPromptsToEditor],
-  );
-
-  const restoreUnknownQueuedPrompt = useCallback(
-    (id: number) => resolveUnknownQueuedPrompt(id, true),
-    [resolveUnknownQueuedPrompt],
-  );
-  const discardUnknownQueuedPrompt = useCallback(
-    (id: number) => resolveUnknownQueuedPrompt(id, false),
-    [resolveUnknownQueuedPrompt],
-  );
-
   const editQueuedPrompt = useCallback(
     async (id: number) => {
       const target = queuedPromptsRef.current.find((p) => p.id === id);
       if (!target || target.serverState === 'submitting') return;
-      if (
-        target.payloadCompleteness === 'summary-only' ||
-        target.admissionOutcome === 'unknown'
-      ) {
+      if (target.payloadCompleteness === 'summary-only') {
         return;
       }
       if (target.isEditing || target.isRemoving) return;
@@ -2081,8 +1960,7 @@ export function useQueuedPrompts({
       (target.midTurnState === 'queued' && !target.midTurnMessageId) ||
       target.isEditing ||
       target.isRemoving ||
-      target.payloadCompleteness === 'summary-only' ||
-      target.admissionOutcome === 'unknown'
+      target.payloadCompleteness === 'summary-only'
     ) {
       return true;
     }
@@ -2130,31 +2008,22 @@ export function useQueuedPrompts({
     const submittingPrompts = queuedPromptsRef.current.filter(
       (prompt) =>
         prompt.midTurnState === undefined &&
-        prompt.serverState === 'submitting' &&
-        prompt.admissionOutcome !== 'unknown',
+        prompt.serverState === 'submitting',
     );
     const clearablePrompts = queuedPromptsRef.current.filter(
       (prompt) =>
         prompt.midTurnState === undefined &&
-        prompt.serverState !== 'submitting' &&
-        prompt.admissionOutcome !== 'unknown',
+        prompt.serverState !== 'submitting',
     );
     if (submittingPrompts.length > 0) {
       const submittingIds = new Set(
         submittingPrompts.map((prompt) => prompt.id),
       );
-      const uncertain = queuedPromptsRef.current.map((prompt) =>
-        submittingIds.has(prompt.id)
-          ? {
-              ...prompt,
-              serverState: undefined,
-              admissionOutcome: 'unknown' as const,
-              payloadAvailable: true,
-            }
-          : prompt,
+      const remaining = queuedPromptsRef.current.filter(
+        (prompt) => !submittingIds.has(prompt.id),
       );
-      queuedPromptsRef.current = uncertain;
-      setQueuedPrompts(uncertain);
+      queuedPromptsRef.current = remaining;
+      setQueuedPrompts(remaining);
     }
     for (const controller of submitAbortControllersRef.current) {
       controller.abort();
@@ -2164,9 +2033,8 @@ export function useQueuedPrompts({
     );
     if (serverPrompts.length === 0) {
       const retainedIds = new Set(midTurnPrompts.map((prompt) => prompt.id));
-      const retained = queuedPromptsRef.current.filter(
-        (prompt) =>
-          retainedIds.has(prompt.id) || prompt.admissionOutcome === 'unknown',
+      const retained = queuedPromptsRef.current.filter((prompt) =>
+        retainedIds.has(prompt.id),
       );
       queuedPromptsRef.current = retained;
       setQueuedPrompts(retained);
@@ -2256,7 +2124,5 @@ export function useQueuedPrompts({
     editQueuedPrompt,
     editLastQueuedPrompt,
     clearQueuedPrompts,
-    restoreUnknownQueuedPrompt,
-    discardUnknownQueuedPrompt,
   };
 }

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -1403,14 +1403,11 @@ const EN: Messages = {
     'This restored queue summary cannot recover its original attachments.',
   'queue.admissionUnknown':
     'Delivery is uncertain. Check the session before trying again.',
-  'queue.mayCorrespond':
-    'The uncertain local copy and server queue entry may be the same prompt.',
   'queue.restoreUnknown': 'Restore local copy',
   'queue.discardUnknown': 'Discard local copy',
   'queue.continueEditing': 'Continue editing',
   'queue.continueEditingConfirm':
     'The prompt may already be running. Continue editing only if you accept the risk of sending it twice.',
-  'queue.localCopyDiscarded': 'Local copy discarded',
   'queue.commandBlocked':
     "Slash commands can't be queued while a turn is running.",
   'queue.shellQueued':
@@ -4354,14 +4351,11 @@ const ZH: Messages = {
   'queue.submittingDisabled': '排队消息正在提交中...',
   'queue.summaryEditDisabled': '恢复的队列摘要无法还原原始附件。',
   'queue.admissionUnknown': '消息是否送达尚不确定，请先检查会话再重试。',
-  'queue.mayCorrespond':
-    '送达不确定的本地副本与服务器队列项可能对应同一条消息。',
   'queue.restoreUnknown': '恢复本地副本',
   'queue.discardUnknown': '丢弃本地副本',
   'queue.continueEditing': '继续编辑',
   'queue.continueEditingConfirm':
     '这条消息可能已经在执行。只有在接受重复发送风险时才继续编辑。',
-  'queue.localCopyDiscarded': '本地副本已丢弃',
   'queue.commandBlocked': '当前回合运行时，Slash 命令不能进入排队。',
   'queue.shellQueued': 'Shell 命令已排队，将在当前回合结束后执行。',
   'queue.shellDropped': (v) =>

--- a/packages/web-shell/client/midTurnDedup.test.ts
+++ b/packages/web-shell/client/midTurnDedup.test.ts
@@ -17,7 +17,6 @@ interface Item {
   files?: unknown[];
   midTurnState?: 'submitting' | 'queued';
   midTurnMessageId?: string;
-  admissionOutcome?: 'unknown';
 }
 
 let nextId = 1;
@@ -110,24 +109,6 @@ describe('removeInjectedFromQueue', () => {
     const next = removeInjectedFromQueue(
       prompts,
       [batchWithIds('s', ['with image'], [imageRow.midTurnMessageId!])],
-      's',
-    );
-    expect(next?.map((p) => p.text)).toEqual(['keep']);
-  });
-
-  it('removes an admission-unknown image row on a strict id match', () => {
-    // A row whose admission response was lost is re-added with
-    // `admissionOutcome: 'unknown'` and NO `midTurnState` (useQueuedPrompts
-    // catch path). When the daemon later drains it, the strict-id pass must
-    // still match — mirroring `applyMidTurnSnapshot`'s membership filter.
-    const unknown = {
-      ...q('lost ack', [{ data: 'x' }]),
-      midTurnState: undefined,
-      admissionOutcome: 'unknown' as const,
-    };
-    const next = removeInjectedFromQueue(
-      [unknown, q('keep')],
-      [batchWithIds('s', ['lost ack'], [unknown.midTurnMessageId!])],
       's',
     );
     expect(next?.map((p) => p.text)).toEqual(['keep']);

--- a/packages/web-shell/client/midTurnDedup.ts
+++ b/packages/web-shell/client/midTurnDedup.ts
@@ -10,7 +10,6 @@ export interface MidTurnQueueItem {
   files?: unknown[];
   midTurnState?: 'submitting' | 'queued';
   midTurnMessageId?: string;
-  admissionOutcome?: 'unknown';
 }
 
 export interface MidTurnInjectedBatch {
@@ -78,16 +77,11 @@ export function removeInjectedFromQueue<T extends MidTurnQueueItem>(
       // are not pushed mid-turn. The text fallback below only runs for rows
       // the id can't reach (no ids in the batch, or a row still awaiting its
       // admission id).
-      // An admission-unknown row carries no `midTurnState` (re-added from
-      // the catch path when the admission response was lost), but the daemon
-      // owns it exactly like a queued one — accept it here, mirroring
-      // `applyMidTurnSnapshot`'s membership filter.
       let index =
         messageId !== undefined
           ? remaining.findIndex(
               (prompt) =>
-                (prompt.midTurnState !== undefined ||
-                  prompt.admissionOutcome === 'unknown') &&
+                prompt.midTurnState !== undefined &&
                 prompt.midTurnMessageId === messageId &&
                 hasNoFiles(prompt),
             )

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -1039,6 +1039,7 @@ describe('createDaemonSessionActions', () => {
   });
 
   it('uploads prompt images and submits media references instead of base64', async () => {
+    const onAdmissionStarted = vi.fn();
     const session = createMockSession('session-a');
     const { actions } = createActionsHarness({
       session,
@@ -1056,6 +1057,7 @@ describe('createDaemonSessionActions', () => {
 
     await actions.submitPrompt('look', {
       images: [{ data: 'AQID', mimeType: 'image/png' }],
+      onAdmissionStarted,
     });
 
     expect(session.uploadMedia).toHaveBeenCalledWith(
@@ -1074,6 +1076,10 @@ describe('createDaemonSessionActions', () => {
         },
       ],
     });
+    expect(onAdmissionStarted).toHaveBeenCalledOnce();
+    expect(onAdmissionStarted.mock.invocationCallOrder[0]).toBeLessThan(
+      session.submitPrompt.mock.invocationCallOrder[0]!,
+    );
   });
 
   it('keeps images without a concrete mime type inline instead of uploading', async () => {
@@ -1127,7 +1133,7 @@ describe('createDaemonSessionActions', () => {
     });
 
     await expect(
-      actions.sendPrompt('look', {
+      actions.submitPrompt('look', {
         images: [{ data: 'AQID', mimeType: 'image/png' }],
         onAdmissionStarted,
       }),
@@ -1593,6 +1599,7 @@ describe('createDaemonSessionActions', () => {
   });
 
   it('preserves ambiguous stable-id admission failures for reconciliation', async () => {
+    const onAdmissionStarted = vi.fn();
     const session = {
       ...createMockSession('session-a'),
       enqueueMidTurnMessage: vi
@@ -1602,14 +1609,31 @@ describe('createDaemonSessionActions', () => {
     const { actions } = createActionsHarness({ session });
 
     await expect(
-      actions.enqueueMidTurnMessage('follow up', { messageId: 'stable-id' }),
+      actions.enqueueMidTurnMessage('follow up', {
+        messageId: 'stable-id',
+        onAdmissionStarted,
+      }),
     ).rejects.toThrow('response lost');
+    expect(onAdmissionStarted).toHaveBeenCalledOnce();
     // The stable id must reach the session client verbatim: the daemon's
     // messageId-keyed idempotency and the reconciliation rings never match
     // if this hop drops the option.
     expect(session.enqueueMidTurnMessage).toHaveBeenCalledWith('follow up', {
       messageId: 'stable-id',
     });
+  });
+
+  it('does not mark a stable-id admission started without a session', async () => {
+    const onAdmissionStarted = vi.fn();
+    const { actions } = createActionsHarness();
+
+    await expect(
+      actions.enqueueMidTurnMessage('follow up', {
+        messageId: 'stable-id',
+        onAdmissionStarted,
+      }),
+    ).resolves.toEqual({ accepted: false });
+    expect(onAdmissionStarted).not.toHaveBeenCalled();
   });
 
   it('keeps legacy mid-turn admission failures best-effort', async () => {

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -723,6 +723,7 @@ export function createDaemonSessionActions({
       }
       let accepted: Awaited<ReturnType<typeof session.submitPrompt>>;
       try {
+        options?.onAdmissionStarted?.();
         accepted = await session.submitPrompt(
           promptRequest as Parameters<typeof session.submitPrompt>[0],
         );
@@ -1564,6 +1565,7 @@ export function createDaemonSessionActions({
         signal?: AbortSignal;
         messageId?: string;
         content?: PromptContentBlock[];
+        onAdmissionStarted?: () => void;
       },
     ): Promise<DaemonMidTurnMessageResult> {
       // Calls without an id are the old-daemon compatibility path and fall back
@@ -1573,7 +1575,12 @@ export function createDaemonSessionActions({
       const session = sessionRef.current;
       if (!session) return { accepted: false };
       try {
-        return await session.enqueueMidTurnMessage(message, opts);
+        const { onAdmissionStarted, ...requestOptions } = opts ?? {};
+        onAdmissionStarted?.();
+        return await session.enqueueMidTurnMessage(
+          message,
+          opts ? requestOptions : undefined,
+        );
       } catch (err) {
         if (opts?.messageId) throw err;
         // An abort is the designed settle-time cancel (the message stays in the

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -464,6 +464,7 @@ export interface DaemonSessionActions {
       signal?: AbortSignal;
       messageId?: string;
       content?: PromptContentBlock[];
+      onAdmissionStarted?: () => void;
     },
   ): Promise<DaemonMidTurnMessageResult>;
   removeMidTurnMessage(


### PR DESCRIPTION
## What this PR does

- Makes pending and mid-turn queue display backend-authoritative after each admission attempt settles.
- Removes persistent client-only unknown queue rows and the restore/discard UI associated with them.
- Restores the complete draft payload only when a failure is proven to occur before daemon dispatch, including text, media, and annotations.
- Prevents stale overlapping reconciliations from deleting a newer authoritative row or losing its completion callback.

## Why it's needed

The client previously retained optimistic queue rows when delivery was uncertain, so one message could appear both as a local copy and as a server queue item, and users could see misleading “local copy discarded” states. At the same time, failures that happened before any request reached the daemon could discard recoverable draft content. The queue should converge to the backend after every settled admission attempt while preserving drafts only when non-delivery is known.

## Reviewer Test Plan

### How to verify

1. While a turn is running, enqueue a prompt with media or an `@` attachment through the ordinary queue path and force media upload to fail before prompt dispatch. Expect the local queue row to disappear, a backend refresh to run, and the complete text, media, and annotations to return to the editor.
2. Force an ordinary queue failure after daemon dispatch begins. Expect the local row to disappear and the editor not to be restored; only the next backend pending-message response may display the item.
3. Submit a mid-turn message with a stable ID while no active session exists. Expect the full draft to be restored. Then simulate a daemon rejection after dispatch and expect no local retention or restoration.
4. Overlap two mid-turn reconciliations so the newer snapshot contains the message and the older request finishes later. Expect the authoritative row to remain and its completion callback to run exactly once after injection.

### Evidence (Before & After)

- Before: client-only unknown rows could coexist with backend rows, pre-dispatch failures could lose draft payloads, and a stale reconciliation could delete a newer authoritative row.
- After: only backend-reported rows persist after settlement, known pre-dispatch failures restore the complete draft, and the newest reconciliation owns the displayed state. The affected behaviors are covered by 192 passing targeted tests.

### Tested on

| OS | Status |
| -- | -- |
| macOS | ✅ |
| Windows | Not tested |
| Linux | Not tested |

### Environment (optional)

Node.js 22+, local workspace, no sandbox.

## Risk & Scope

- Main risk or tradeoff: draft restoration depends on classifying the exact daemon-dispatch boundary; legacy daemon compatibility remains unchanged.
- Not validated / out of scope: adding file-insertion support and recovering attachment payloads across a page reload when the backend does not retain them.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

- 每次消息接纳流程结束后，待发送队列和中途插入队列均以后端返回为唯一展示依据。
- 移除长期保留的纯前端“状态未知”队列项，以及对应的恢复/丢弃界面。
- 仅当可以确定失败发生在请求发往守护进程之前时，才恢复完整草稿，包括文本、媒体和标注信息。
- 避免并发刷新中较旧的结果删除较新的后端权威队列项，或丢失其完成回调。

## 为什么需要

此前客户端会在消息是否送达不确定时保留乐观队列项，导致同一条消息可能同时显示为本地副本和服务端队列项，并出现误导性的“本地副本已丢弃”状态。另一方面，在请求尚未到达守护进程前发生的失败，也可能丢失本可恢复的草稿内容。新的行为是在每次接纳流程结束后统一以后端状态收敛，同时仅在确认消息未送达时恢复草稿。

## Reviewer 测试计划

### 如何验证

1. 在当前轮次运行期间，通过普通排队路径发送带媒体或 `@` 附件的消息，并让媒体上传在请求发送前失败。预期本地队列项消失、重新拉取后端状态，并将完整文本、媒体和标注恢复到编辑器。
2. 让普通排队请求在已开始发往守护进程后失败。预期本地队列项消失且编辑器不恢复；只有后续后端待处理消息接口返回该消息时才展示。
3. 在没有活动会话时，用稳定 ID 提交中途插入消息。预期恢复完整草稿。随后模拟请求发出后被守护进程拒绝，预期不保留本地项，也不恢复编辑器。
4. 制造两个并发的中途插入刷新：较新的快照包含目标消息，较旧请求更晚结束。预期后端权威队列项仍然存在，并且注入完成后回调只执行一次。

### 前后对比证据

- 修改前：纯前端未知队列项可能与后端队列项并存；发送前失败可能丢失草稿；过期刷新可能删除较新的权威队列项。
- 修改后：流程结束后只保留后端返回的队列项；已确认的发送前失败会恢复完整草稿；最新刷新结果决定展示状态。相关行为由 192 个定向测试覆盖并全部通过。

### 测试平台

| 操作系统 | 状态 |
| -- | -- |
| macOS | ✅ |
| Windows | 未测试 |
| Linux | 未测试 |

### 环境（可选）

Node.js 22+，本地工作区，无沙箱。

## 风险与范围

- 主要风险或权衡：草稿恢复依赖于准确区分请求是否已跨过守护进程发送边界；旧版守护进程兼容逻辑保持不变。
- 未验证/不在范围内：新增文件插入能力，以及页面刷新后在后端未保存附件载荷时恢复附件。
- 破坏性变更/迁移说明：无。

## 关联 Issue

无。

</details>
