### PR TITLE
fix(review): keep the blocker in a COMMENT body every softening path reaches

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1564,6 +1564,28 @@ describe('composeReview — presubmit downgrades', () => {
     );
   });
 
+  it('keeps the presubmit downgrade reasons when a cap softens the Approve first', () => {
+    // The APPROVE→COMMENT cap runs before the presubmit arms, so a capped
+    // zero-finding Approve reached arm 1 as COMMENT — its `event === 'APPROVE'`
+    // gate failed, arm 2's REQUEST_CHANGES gate failed too, and the presubmit
+    // reasons vanished from the body and the verdict line while the identical
+    // uncapped run rendered both. The gate is derived from `baseEvent` — the
+    // row before every cap — exactly like its RC sibling.
+    const r = composeReview(
+      base({
+        contextUnavailable: true,
+        presubmit: { downgradeApprove: true, downgradeReasons: ['self-PR'] },
+      }),
+    );
+    expect(r.baseEvent).toBe('APPROVE');
+    expect(r.event).toBe('COMMENT');
+    expect(r.cappedBy).toContain('context-unavailable');
+    expect(r.downgraded).toBe(true);
+    expect(r.downgradedFrom).toBe('Approve');
+    expect(r.body).toContain('⚠️ Downgraded from Approve to Comment: self-PR.');
+    expect(verdictLine(r)).toContain('a presubmit check failed');
+  });
+
   it('a downgraded Approve never certifies "no blockers" in the same body (the downgrade names failing CI two clauses earlier)', () => {
     const r = composeReview(
       base({

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -478,6 +478,17 @@ function blindPlan(): string {
   return plan();
 }
 
+function findingsFile(content: string): string {
+  const f = join(dir, 'qwen-review-findings.md');
+  writeFileSync(f, content);
+  return f;
+}
+
+const TAGGED =
+  '- **File:** src/pay.ts:42\n' +
+  '- **Issue:** off-by-one in the retry cap\n' +
+  '- **Severity:** Critical — [unverified]\n';
+
 const FOOTER = `_— ${MODEL} via Qwen Code /review (vunknown)_`;
 
 function base(overrides: Partial<ComposeReviewInput>): ComposeReviewInput {
@@ -3548,6 +3559,32 @@ describe('the Step 4/5 gate — verify and reverse audit must have run (high eff
     expect(verdictLine(r)).toContain('its blockers were never verified');
   });
 
+  it('keeps the presubmit downgrade reasons when the findings-tag cap also holds', () => {
+    // The tag cap softens the event while setting NEITHER legacy flag, so the
+    // recovery arm's enumeration missed it: the presubmit reasons vanished
+    // from the body — the silent loss the arm's own comment forbids. Verdict
+    // keeps the tag sentence; the body's downgrade clause carries the reasons.
+    const r = composeReview({
+      criticalsInline: 1,
+      planPath: coveredPlan(['verify', 'reverse-audit']),
+      env: ENV,
+      findingsPath: findingsFile(TAGGED),
+      presubmit: {
+        downgradeRequestChanges: true,
+        downgradeReasons: ['self-PR'],
+      },
+      modelId: MODEL,
+    });
+    expect(r.event).toBe('COMMENT');
+    expect(r.cappedBy).toContain('findings-unverified-at-compose');
+    expect(r.body).toContain(
+      'Downgraded from Request changes to Comment: self-PR',
+    );
+    expect(verdictLine(r)).toContain(
+      'findings were still unverified when the loop ended',
+    );
+  });
+
   it('verify on record with the reverse audit absent still blocks — softening gates on verify alone', () => {
     const r = composeReview({
       criticalsInline: 1,
@@ -3581,13 +3618,6 @@ describe('the Step 4/5 gate — verify and reverse audit must have run (high eff
     // findings file still carrying `— [unverified]` at compose time. The
     // posted body was 239 characters of opener and disclosure with the
     // blocker — its only copy — nowhere in it.
-    const findings = join(dir, 'qwen-review-findings-tag.md');
-    writeFileSync(
-      findings,
-      '- **File:** src/pay.ts:42\n' +
-        '- **Issue:** off-by-one in the retry cap\n' +
-        '- **Severity:** Critical — [unverified]\n',
-    );
     const r = composeReview({
       planPath: coveredPlan(['verify', 'reverse-audit']),
       env: ENV,
@@ -3595,13 +3625,14 @@ describe('the Step 4/5 gate — verify and reverse audit must have run (high eff
       criticalsInline: 0,
       suggestionsInline: 0,
       bodyCriticals: ['whole-PR blocker X'],
-      findingsPath: findings,
+      findingsPath: findingsFile(TAGGED),
     });
     expect(r.baseEvent).toBe('REQUEST_CHANGES');
     expect(r.event).toBe('COMMENT');
     // Neither flag the old condition listed is set on this path.
     expect(r.downgradedFrom).toBeNull();
     expect(r.cappedBy).toContain('findings-unverified-at-compose');
+    expect(r.cappedBy).not.toContain('criticals-unverified');
     expect(r.body).toContain('**[Critical]** whole-PR blocker X');
   });
 
@@ -6732,9 +6763,9 @@ describe("composeReview — the composed body fits GitHub's limit", () => {
     // that qualify the verdict before it spent a single blocker.
     //
     // The cap here is the absent verifier, which still POSTS the blockers
-    // (clause 7 rides on `criticalsUnverified`); the findings-file tag route
-    // caps without that flag, so its body carries no blocker and cannot
-    // reach the cut at all.
+    // (clause 7 rides on the softened RC→COMMENT transition); the
+    // findings-file tag route softens the same way, so its body carries the
+    // blocker too and can reach the cut.
     const r = composeReview({
       planPath: coveredPlan(['reverse-audit']),
       env: ENV,
@@ -6990,16 +7021,6 @@ describe('composeReview — the findings file tag check', () => {
   // round's findings digest — so compose-review reads the cumulative
   // findings file itself and caps on any surviving tag.
 
-  function findingsFile(content: string): string {
-    const f = join(dir, 'qwen-review-findings.md');
-    writeFileSync(f, content);
-    return f;
-  }
-
-  const TAGGED =
-    '- **File:** src/pay.ts:42\n' +
-    '- **Issue:** off-by-one in the retry cap\n' +
-    '- **Severity:** Critical — [unverified]\n';
   const CLEAN =
     '- **File:** src/pay.ts:42\n' +
     '- **Issue:** off-by-one in the retry cap\n' +

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -3574,6 +3574,37 @@ describe('the Step 4/5 gate — verify and reverse audit must have run (high eff
     expect(r.body).toContain('**[Critical]** whole-PR blocker X');
   });
 
+  it('keeps the body Criticals when the FINDINGS-TAG cap softens the event', () => {
+    // The third softening path, and the one the enumerated condition missed:
+    // coverage is proven and the verifier ran, so `criticalsUnverified` is
+    // false and no presubmit downgrade fired — the cap comes from the
+    // findings file still carrying `— [unverified]` at compose time. The
+    // posted body was 239 characters of opener and disclosure with the
+    // blocker — its only copy — nowhere in it.
+    const findings = join(dir, 'qwen-review-findings-tag.md');
+    writeFileSync(
+      findings,
+      '- **File:** src/pay.ts:42\n' +
+        '- **Issue:** off-by-one in the retry cap\n' +
+        '- **Severity:** Critical — [unverified]\n',
+    );
+    const r = composeReview({
+      planPath: coveredPlan(['verify', 'reverse-audit']),
+      env: ENV,
+      modelId: MODEL,
+      criticalsInline: 0,
+      suggestionsInline: 0,
+      bodyCriticals: ['whole-PR blocker X'],
+      findingsPath: findings,
+    });
+    expect(r.baseEvent).toBe('REQUEST_CHANGES');
+    expect(r.event).toBe('COMMENT');
+    // Neither flag the old condition listed is set on this path.
+    expect(r.downgradedFrom).toBeNull();
+    expect(r.cappedBy).toContain('findings-unverified-at-compose');
+    expect(r.body).toContain('**[Critical]** whole-PR blocker X');
+  });
+
   it('a mixed review keeps its Request changes — the deterministic blocker is confirmed with or without a verifier', () => {
     // One [build] Critical (pre-confirmed) beside one non-deterministic
     // Critical with the verifier absent: softening the whole event would

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -3289,10 +3289,20 @@ function composeReviewBody(
   clauses.push(...continuityBlock);
 
   // 7. Body Criticals — on a COMMENT that stands where a REQUEST_CHANGES
-  //    would have been: the presubmit carve-out, and the unverified-blockers
-  //    cap. Either way the body copy is the ONLY copy of an unanchorable
+  //    would have been. The body copy is the ONLY copy of an unanchorable
   //    blocker, and softening the event must never erase it.
-  if (downgradedFrom === 'Request changes' || criticalsUnverified) {
+  //
+  //    DERIVED, not enumerated. The condition was a list of the two
+  //    softening flags known when it was written — the presubmit carve-out
+  //    and `criticalsUnverified` — and a third path shipped past it: the
+  //    findings-file `— [unverified]` tag softens a Request changes at the
+  //    event line above while setting NEITHER flag, so a run whose coverage
+  //    was proven posted a 239-character body carrying the opener and the
+  //    tag disclosure and no blocker at all. `baseEvent` is the row before
+  //    every cap and downgrade, so this comparison asks the question the
+  //    clause is actually about, and answers it for softening paths that do
+  //    not exist yet.
+  if (baseEvent === 'REQUEST_CHANGES' && event === 'COMMENT') {
     clauses.push(...bodyCriticalBlock);
   }
 

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -2153,10 +2153,10 @@ function composeReviewBody(
     downgradedFrom = 'Approve';
   } else if (
     (event === 'REQUEST_CHANGES' ||
-      (baseEvent === 'REQUEST_CHANGES' && criticalsUnverified)) &&
+      (baseEvent === 'REQUEST_CHANGES' && event === 'COMMENT')) &&
     downgradeRequestChanges
   ) {
-    // The unverified-blockers cap softened the event first, but the presubmit
+    // A softening cap moved the event first, but the presubmit
     // still ruled: without this arm its reasons (self-PR, failing CI) would
     // silently vanish from the body whenever both held. The verdict line
     // keeps the unverified sentence — the more fundamental defect — and the

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -2143,11 +2143,15 @@ function composeReviewBody(
     event = 'COMMENT';
   }
 
-  // Presubmit downgrades apply after the caps and only when the verdict
-  // they name is the one on the table.
+  // Presubmit downgrades apply after the caps and only when the verdict they
+  // name was the one on the table — `baseEvent` is the row before every cap,
+  // so a softening cap that ran first cannot erase the presubmit's reasons.
   let downgraded = false;
   let downgradedFrom: 'Approve' | 'Request changes' | null = null;
-  if (event === 'APPROVE' && downgradeApprove) {
+  if (
+    (event === 'APPROVE' || (baseEvent === 'APPROVE' && event === 'COMMENT')) &&
+    downgradeApprove
+  ) {
     event = 'COMMENT';
     downgraded = true;
     downgradedFrom = 'Approve';


### PR DESCRIPTION
## What this PR does

Makes `compose-review` render the body copy of a blocker on **every** COMMENT that stands where a REQUEST_CHANGES would have been, instead of on the two softening paths that were listed by name.

Clause 7 has always meant "this COMMENT replaced a Request changes, so the blocker's only copy must still reach the author". It asked that question as an enumeration of the flags known when it was written:

```ts
if (downgradedFrom === 'Request changes' || criticalsUnverified)
```

It now asks it as a derivation:

```ts
if (baseEvent === 'REQUEST_CHANGES' && event === 'COMMENT')
```

`baseEvent` is the row before every cap and downgrade, so this covers the softening paths that exist and the ones that do not exist yet.

## Why it's needed

A third softening path shipped past the enumeration. The findings-file `— [unverified]` tag softens a Request changes at the event line, and it sets **neither** flag the condition read — not `downgradedFrom` (only the presubmit carve-out sets that), and not `criticalsUnverified` (only the verification-delivery gate sets that).

So a run whose coverage was **proven** and whose verifier ran, holding one unanchorable blocker, posted this — 239 characters, no blocker anywhere in it:

```
Review incomplete — unverified findings disclosed.

⚠️ 1 finding(s) still carried the `— [unverified]` tag when the loop ended — the verifier never ruled on them, and they are not confirmed.

_— <model> via Qwen Code /review (v…)_
```

while `deferredCount`, the verdict line and the saved artifact all counted the blocker. The body copy is the only copy an unanchorable Critical has: nothing else on the PR page carries it. This is the failure the clause's own comment names — "softening the event must never erase it" — reached through the one door the condition did not name.

Same closure the module applied to the deferral channel after #9095: state the property, do not enumerate its instances.

## Reviewer Test Plan

### How to verify

- **The isolating shape**: covered plan (coverage proven), verifier on record, findings file still carrying `— [unverified]`, one `bodyCriticals` entry → `baseEvent` is `REQUEST_CHANGES`, `event` is `COMMENT`, `downgradedFrom` is `null`, `cappedBy` contains `findings-unverified-at-compose`, and the body carries `**[Critical]** …`. That is the new test.
- **The two paths that already worked** keep their tests: the presubmit RC→Comment carve-out, and the missing-verifier cap.
- `cd packages/cli && npx vitest run src/commands/review/`

### Evidence (Before & After)

N/A — pipeline behaviour, no TUI change. Before: the blocker was absent from the posted body on this path (probe output above). After: it rides, disclosed as unverified like its siblings.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests per package; typecheck and the review suites verified in a clean detached worktree. Both mutations of the new condition — reverting it to the enumeration, and dropping the clause — redden the tests that pin them.

## Risk & Scope

- Main risk or tradeoff: strictly more content in the posted body, on a path that previously dropped it. No event, count or artifact field changes.
- Not validated / out of scope: whether the findings-tag cap should soften a Request changes at all — that is the existing policy and this PR does not touch it.
- Breaking changes / migration notes: none.

## Linked Issues

Found while reviewing #9247.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `compose-review` 在**任何**「本该是 REQUEST_CHANGES 却被软化为 COMMENT」的情形下都渲染阻断项的正文副本，而不是只覆盖被逐个列名的两条路径。

clause 7 想问的一直是「这条 COMMENT 是否顶替了一个 Request changes」，但它此前用枚举当时已知的标志来回答：`downgradedFrom === 'Request changes' || criticalsUnverified`。现在改为推导：`baseEvent === 'REQUEST_CHANGES' && event === 'COMMENT'`——`baseEvent` 是所有 cap 与 downgrade 之前的那一行，因此既覆盖现有路径，也覆盖尚不存在的路径。

## 为什么需要

第三条软化路径绕过了该枚举：findings 文件仍带 `— [unverified]` 标签会在 event 处把 Request changes 软化为 COMMENT，而它**两个标志都不设**——`downgradedFrom` 只由 presubmit 分支设置，`criticalsUnverified` 只由验证交付闸设置。

于是一次**覆盖已被证明**、验证器也确实运行过、且持有一条不可锚定阻断项的运行，发出的正文只有 239 字符，其中没有任何阻断项，而 `deferredCount`、裁决行与已保存工件都把它计入了。不可锚定的 Critical 只有正文这一份副本，PR 页面上别无他处承载。这正是该子句注释自己所说的失败——「softening the event must never erase it」——从它没有点名的那扇门进来。

与 #9095 之后对延后通道所做的闭合同理：陈述性质，而不是枚举其实例。

## 评审验证计划

见上方英文部分：隔离形态（覆盖已证明 + 验证器在案 + findings 仍带标签 + 一条 body Critical）、两条既有路径的回归、以及套件命令。两个变异（改回枚举、删掉该子句）都会让对应测试变红。

## 风险与范围

- 主要权衡：在一条此前会丢弃内容的路径上，正文严格变多；event、计数与工件字段均不变。
- 范围外：findings 标签是否**应当**软化 Request changes——那是既有策略，本 PR 不触碰。
- 破坏性变更：无。

## 关联 Issue

在评审 #9247 期间发现。

</details>
