### PR TITLE
fix(core): deliver teammate send_message with shutdown enum as ordinary message

### DIFF
--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -125,15 +125,20 @@ describe('SendMessageTool — team mode', () => {
     expect(requestShutdown).toHaveBeenCalledWith('bob');
   });
 
-  it('rejects shutdown_request from a teammate (leader-only)', async () => {
-    // A teammate calling shutdown_request would impersonate the
-    // leader, since requestShutdown writes the mailbox entry with
-    // `from: LEADER_NAME` and arms shutdown_approved tracking.
+  it('delivers a teammate shutdown_request as an ordinary message (leader-only guard)', async () => {
+    // Only the leader may request shutdowns — requestShutdown writes
+    // the mailbox entry with `from: LEADER_NAME` and arms
+    // shutdown_approved tracking for the target. But the schema
+    // exposes the `type` enum to every caller, so teammates sometimes
+    // attach it to ordinary messages (#9276); erroring bounced their
+    // reports in a retry loop. Deliver the text normally and note the
+    // control part was ignored instead.
     const requestShutdown = vi.fn().mockResolvedValue(undefined);
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
     const tool = new SendMessageTool(
       makeTeamConfig({
         teamManager: {
-          sendMessage: vi.fn(),
+          sendMessage,
           broadcast: vi.fn(),
           requestShutdown,
         },
@@ -141,22 +146,62 @@ describe('SendMessageTool — team mode', () => {
     );
 
     const invocation = tool.build({
-      to: 'bob',
-      message: 'Please shut down.',
+      to: 'leader',
+      message: 'Task completed and verified',
       type: 'shutdown_request',
     });
     const result = await runWithTeammateIdentity(
       {
-        agentName: 'attacker',
+        agentName: 'worker',
         teamName: 'team',
-        agentId: 'attacker@team',
+        agentId: 'worker@team',
         isTeamLead: false,
       },
       () => invocation.execute(new AbortController().signal),
     );
-    expect(result.error).toBeDefined();
-    expect(result.llmContent).toContain('Only the team leader');
+    expect(result.error).toBeUndefined();
     expect(requestShutdown).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith(
+      'leader',
+      'Task completed and verified',
+      'worker',
+      undefined,
+    );
+    expect(result.llmContent).toContain('leader-only');
+    expect(result.llmContent).toContain('ordinary message');
+  });
+
+  it('broadcasts a teammate message that carries the shutdown enum', async () => {
+    const requestShutdown = vi.fn().mockResolvedValue(undefined);
+    const broadcast = vi.fn().mockResolvedValue(undefined);
+    const tool = new SendMessageTool(
+      makeTeamConfig({
+        teamManager: {
+          sendMessage: vi.fn(),
+          broadcast,
+          requestShutdown,
+        },
+      }),
+    );
+
+    const invocation = tool.build({
+      to: '*',
+      message: 'status update',
+      type: 'shutdown_request',
+    });
+    const result = await runWithTeammateIdentity(
+      {
+        agentName: 'worker',
+        teamName: 'team',
+        agentId: 'worker@team',
+        isTeamLead: false,
+      },
+      () => invocation.execute(new AbortController().signal),
+    );
+    expect(result.error).toBeUndefined();
+    expect(requestShutdown).not.toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith('status update', 'worker');
+    expect(result.llmContent).toContain('leader-only');
   });
 
   it('blocks plan-required teammates before leader approval', async () => {

--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -44,7 +44,12 @@ export interface SendMessageParams {
   message: string;
   /** Optional 5-10 word summary for UI display (team mode). */
   summary?: string;
-  /** Structured control message type (team mode). */
+  /**
+   * Structured control message type (team mode). Leader-only: honored
+   * solely for shutdown requests issued by the leader; for teammates
+   * the field is ignored and the text is delivered as an ordinary
+   * message.
+   */
   type?: 'shutdown_request';
 }
 
@@ -241,30 +246,33 @@ class SendMessageInvocation extends BaseToolInvocation<
     }
 
     try {
-      // Structured control messages route through mailbox.
-      if (this.params.type === 'shutdown_request') {
-        // Only the leader can request shutdowns. A teammate
-        // calling this would be impersonating the leader, since
-        // requestShutdown writes the mailbox entry with
-        // `from: LEADER_NAME` and arms shutdown_approved tracking
-        // for the target.
-        if (isTeammate()) {
-          const msg = 'Only the team leader can request shutdowns.';
-          return {
-            llmContent: msg,
-            returnDisplay: msg,
-            error: { message: msg },
-          };
-        }
+      const isShutdownRequest = this.params.type === 'shutdown_request';
+
+      // Structured control messages route through mailbox. Only the
+      // leader can request shutdowns: requestShutdown writes the
+      // mailbox entry with `from: LEADER_NAME` and arms
+      // shutdown_approved tracking for the target, so a teammate
+      // issuing one would be impersonating the leader.
+      if (isShutdownRequest && !isTeammate()) {
         await teamManager.requestShutdown(to);
         const msg = `Shutdown requested for "${to}".`;
         return { llmContent: msg, returnDisplay: msg };
       }
 
+      // The schema exposes the `type` enum to every caller, so models
+      // running as teammates sometimes attach `shutdown_request` to an
+      // ordinary message (see #9276). Erroring on that bounced their
+      // reports back in a retry loop and the leader never received
+      // them; instead drop the control semantics, deliver the text as
+      // an ordinary message, and tell the caller it was ignored.
+      const shutdownIgnoredNote = isShutdownRequest
+        ? ' Note: `type: "shutdown_request"` is leader-only and was ignored — the text was delivered as an ordinary message.'
+        : '';
+
       if (to === '*') {
         const sender = getAgentName() ?? LEADER_NAME;
         await teamManager.broadcast(this.params.message, sender);
-        const msg = 'Message broadcast to all teammates.';
+        const msg = `Message broadcast to all teammates.${shutdownIgnoredNote}`;
         return { llmContent: msg, returnDisplay: msg };
       }
 
@@ -274,7 +282,7 @@ class SendMessageInvocation extends BaseToolInvocation<
         getAgentName() ?? LEADER_NAME,
         this.params.summary,
       );
-      const msg = `Message sent to "${to}".`;
+      const msg = `Message sent to "${to}".${shutdownIgnoredNote}`;
       return { llmContent: msg, returnDisplay: msg };
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
@@ -330,9 +338,8 @@ export class SendMessageTool extends BaseDeclarativeTool<
             type: 'string',
             enum: ['shutdown_request'],
             description:
-              'Structured message type for control flow. ' +
-              'When set, routes through the mailbox ' +
-              'instead of plain text delivery.',
+              'Leader-only control message type. Set it only when, as the team leader, you are requesting a teammate to shut down. ' +
+              'Never set it on ordinary messages; teammates cannot request shutdowns and the field is ignored for them.',
           },
         },
         required: ['message'],


### PR DESCRIPTION
## What this PR does

When `send_message` is called by a teammate with `type: "shutdown_request"`, the call no longer errors out. The control semantics are dropped, the message text is delivered as an ordinary message (direct send or broadcast), and the tool result tells the caller that the shutdown part was ignored because it is leader-only. Leader-initiated shutdowns are unchanged: a non-teammate caller with `type: "shutdown_request"` still routes through `TeamManager.requestShutdown`. The schema description of the `type` field is also updated to say explicitly that it is leader-only and must not be set on ordinary messages.

## Why it's needed

Fixes #9276. The `send_message` schema exposes `type: enum ['shutdown_request']` to every caller, so models running as teammates sometimes attach the enum to ordinary messages (the issue shows a completion report serialized as `{"type": "shutdown_request", "to": "leader", "message": "Task completed and verified"}`). The previous handler then bounced every such call with "Only the team leader can request shutdowns.", so teammates retried their required final report forever while the leader received neither the report nor the completion summary. Since teammates can never legitimately request shutdowns (`requestShutdown` writes the mailbox entry with `from: LEADER_NAME` and arms `shutdown_approved` tracking for the target), delivering the text normally is strictly better than erroring — no privilege is granted, and the loop is broken.

## Reviewer Test Plan

### How to verify

The repro in #9276 is a non-leader teammate sending a normal message to the leader via `send_message`; observe that the call previously failed with the leader-only shutdown error. With this change the same call delivers the message to the leader inbox and returns a success result noting the enum was ignored. Covered by unit tests: `cd packages/core && npx vitest run src/tools/send-message.test.ts src/agents/team/` — 293 tests pass (13 files), including the new `delivers a teammate shutdown_request as an ordinary message (leader-only guard)` and `broadcasts a teammate message that carries the shutdown enum` cases, the unchanged leader-path `routes shutdown_request via requestShutdown` case, and the full coordination-harness shutdown-protocol suite. `npx tsc --noEmit -p packages/core/tsconfig.json`, eslint, and prettier are clean.

### Evidence (Before & After)

N/A — non-user-visible logic change, covered by the unit tests above. Before: `send_message({to: 'leader', message: '...', type: 'shutdown_request'})` from a teammate returned `error: Only the team leader can request shutdowns.`. After: message delivered via `TeamManager.sendMessage`, result contains the leader-only-ignored note.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Unit tests only (`npx vitest` in `packages/core` on a fresh worktree after `npm ci && npm run build`).

## Risk & Scope

- Main risk or tradeoff: a teammate call that previously errored now succeeds and delivers its text; that is the intended behavior change. The security invariant is preserved — `requestShutdown` is still only reachable from the leader path.
- Not validated / out of scope: end-to-end multi-agent runs; other team tools that expose leader-only actions (`team-delete`, `team-plan-approval`) are untouched.
- Breaking changes / migration notes: none for leaders; the removed error message string was not referenced elsewhere.

## Linked Issues

Fixes #9276

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 teammate 调用 `send_message` 且带上 `type: "shutdown_request"` 时，不再直接报错：控制语义被丢弃，消息文本按普通消息正常投递（点对点或广播），工具返回结果中告知调用方 shutdown 部分因仅限 leader 而被忽略。leader 主动发起的 shutdown 路径不变：非 teammate 上下文中带 `type: "shutdown_request"` 仍走 `TeamManager.requestShutdown`。同时更新了 `type` 字段的 schema 描述，明确其仅限 leader、普通消息不得携带。

## 为什么需要

修复 #9276。`send_message` 的 schema 把 `type: enum ['shutdown_request']` 暴露给所有调用方，导致以 teammate 身份运行的模型有时会把该枚举附加到普通消息上（issue 中的完成报告被序列化为 `{"type": "shutdown_request", "to": "leader", "message": "Task completed and verified"}`）。旧逻辑对这类调用一律返回 "Only the team leader can request shutdowns."，于是 teammate 反复重试必需的最终汇报，leader 既收不到报告也收不到完成摘要。由于 teammate 本来就不可能合法发起 shutdown（`requestShutdown` 会以 `from: LEADER_NAME` 写 mailbox 条目并为目标挂上 `shutdown_approved` 跟踪），正常投递文本严格优于报错——不授予任何权限，同时打破重试死循环。

## 评审验证计划

### 如何验证

#9276 的复现路径是：非 leader teammate 通过 `send_message` 向 leader 发送普通消息，旧行为是以 leader-only shutdown 错误失败；本改动后同样的调用会把消息投递到 leader 收件箱，并在结果中注明枚举被忽略。已用单测覆盖：`cd packages/core && npx vitest run src/tools/send-message.test.ts src/agents/team/` —— 293 个测试通过（13 个文件），包括新增的 `delivers a teammate shutdown_request as an ordinary message (leader-only guard)`、`broadcasts a teammate message that carries the shutdown enum`，未改动的 leader 路径用例 `routes shutdown_request via requestShutdown`，以及完整的 coordination-harness shutdown 协议套件。`npx tsc --noEmit -p packages/core/tsconfig.json`、eslint、prettier 均通过。

### 前后证据

N/A —— 非用户可见的逻辑变更，由上述单测覆盖。改动前：teammate 调用 `send_message({to: 'leader', message: '...', type: 'shutdown_request'})` 返回 `error: Only the team leader can request shutdowns.`；改动后：消息经 `TeamManager.sendMessage` 投递成功，结果包含 leader-only 忽略说明。

### 测试环境

Linux ✅（macOS/Windows 未测）；仅单测（全新 worktree 中 `npm ci && npm run build` 后运行 `npx vitest`）。

## 风险与范围

- 主要风险/权衡：此前会报错的 teammate 调用现在成功投递文本，这是预期的行为变化；安全不变式保持不变——`requestShutdown` 仍只能由 leader 路径触达。
- 未验证/超出范围：端到端多 agent 运行；其他暴露 leader-only 动作的团队工具（`team-delete`、`team-plan-approval`）未改动。
- 破坏性变更/迁移说明：对 leader 无影响；被移除的错误文案在仓库中无其他引用。

## 关联 Issue

Fixes #9276

</details>