### PR TITLE
fix(core): reject run_in_background: false for named teammates

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -530,6 +530,12 @@ describe('AgentTool', () => {
       expect(properties.properties.run_in_background.description).toContain(
         'Nested agents run in the foreground unless run_in_background is explicitly true',
       );
+      expect(properties.properties.run_in_background.description).toContain(
+        'Named teammates are always concurrent',
+      );
+      expect(properties.properties.run_in_background.description).toContain(
+        'an explicit false is rejected',
+      );
     });
 
     it('declares the optional todo association', () => {
@@ -662,6 +668,12 @@ describe('AgentTool', () => {
       };
 
       expect(parameters.properties.name?.description).toContain('active team');
+      expect(parameters.properties.name?.description).toContain(
+        'always run concurrently',
+      );
+      expect(parameters.properties.name?.description).toContain(
+        'run_in_background: false instead',
+      );
     });
 
     it('exposes plan_mode_required only when teams are enabled', async () => {
@@ -817,6 +829,46 @@ describe('AgentTool', () => {
           model: 'high',
         }),
       ).toMatch(/not supported for a named teammate/i);
+    });
+
+    it('rejects run_in_background: false for a named teammate with an active team', () => {
+      vi.mocked(config.getTeamManager).mockReturnValue({
+        spawnTeammate: vi.fn(),
+      } as never);
+
+      expect(
+        agentTool.validateToolParams({
+          ...validParams,
+          name: 'helper',
+          run_in_background: false,
+        }),
+      ).toMatch(/cannot be false for a named teammate/i);
+    });
+
+    it('accepts run_in_background: true for a named teammate', () => {
+      vi.mocked(config.getTeamManager).mockReturnValue({
+        spawnTeammate: vi.fn(),
+      } as never);
+
+      expect(
+        agentTool.validateToolParams({
+          ...validParams,
+          name: 'helper',
+          run_in_background: true,
+        }),
+      ).toBeNull();
+    });
+
+    it('accepts run_in_background: false with a name when no team is active', () => {
+      // Without an active team the name falls through to a regular agent,
+      // where the foreground request stays valid.
+      expect(
+        agentTool.validateToolParams({
+          ...validParams,
+          name: 'helper',
+          run_in_background: false,
+        }),
+      ).toBeNull();
     });
 
     it.each(['all', '1', '12'] as const)(
@@ -1594,6 +1646,28 @@ describe('AgentTool', () => {
 
       expect(partToString(result.llmContent)).toMatch(
         /isolation.*named teammate/i,
+      );
+      expect(spawnTeammate).not.toHaveBeenCalled();
+    });
+
+    it('blocks run_in_background: false if a team becomes active after validation', async () => {
+      const spawnTeammate = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(config.getTeamManager).mockReturnValue({
+        spawnTeammate,
+      } as never);
+
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation({
+        description: 'Search files',
+        prompt: 'Find the config',
+        name: 'searcher',
+        run_in_background: false,
+      });
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(partToString(result.llmContent)).toMatch(
+        /cannot be false for a named teammate/i,
       );
       expect(spawnTeammate).not.toHaveBeenCalled();
     });

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -271,7 +271,11 @@ const TEAM_AGENT_NAME_PROPERTY = {
   type: 'string',
   description:
     'When provided, spawn as a named teammate via the active team ' +
-    'instead of a one-shot subagent. Requires an active team context.',
+    'instead of a one-shot subagent. Requires an active team context. ' +
+    'Teammates always run concurrently and report through team messaging; ' +
+    'omit run_in_background for them — an explicit false is rejected. For ' +
+    'an inline blocking result, omit name and use a regular agent with ' +
+    'run_in_background: false instead.',
 };
 
 const TEAM_AGENT_PLAN_REQUIRED_PROPERTY = {
@@ -734,7 +738,7 @@ export class AgentTool extends BaseDeclarativeTool<AgentParams, ToolResult> {
           type: 'boolean',
           default: true,
           description:
-            'Defaults to true for top-level regular subagents. Set to false to run a regular agent in the foreground and return its result inline. Set to true for an interactive fork to receive its completion notification; headless forks always run in the background. Nested agents run in the foreground unless run_in_background is explicitly true, which is rejected because they cannot receive background completion notifications. Unnamed caller-owned working_dir launches default to foreground. Named teammates may run in the background, but must be shut down before their caller-owned worktree is removed.',
+            'Defaults to true for top-level regular subagents. Set to false to run a regular agent in the foreground and return its result inline. Set to true for an interactive fork to receive its completion notification; headless forks always run in the background. Nested agents run in the foreground unless run_in_background is explicitly true, which is rejected because they cannot receive background completion notifications. Unnamed caller-owned working_dir launches default to foreground. Named teammates are always concurrent and report through team messaging: omit run_in_background when spawning one — an explicit false is rejected; for an inline blocking result, omit "name" and run a regular agent with run_in_background: false. A teammate pinned to a caller-owned worktree must be shut down before that worktree is removed.',
         },
         ...(config.isAgentTeamEnabled()
           ? {
@@ -822,7 +826,7 @@ export class AgentTool extends BaseDeclarativeTool<AgentParams, ToolResult> {
     // feature is on; otherwise the model is steered toward a
     // `team_create` tool that isn't registered.
     const teamGuidance = this.config.isAgentTeamEnabled()
-      ? `**For tasks requiring multiple agents to coordinate, communicate, or work as a team**: Use ${ToolNames.TEAM_CREATE} first to create a team, then spawn teammates using the Agent tool with explicit \`name\` and \`subagent_type\` parameters (the active team is selected automatically). Set \`read_only: true\` for investigation teammates. A single writer teammate may be pinned to a leader-owned Git worktree with \`working_dir\`; shut it down before removing that worktree. Teams enable message passing between agents, shared task lists, and coordinated workflows. If the user asks for agents to collaborate, review each other's work, or produce a consolidated result — create a team.`
+      ? `**For tasks requiring multiple agents to coordinate, communicate, or work as a team**: Use ${ToolNames.TEAM_CREATE} first to create a team, then spawn teammates using the Agent tool with explicit \`name\` and \`subagent_type\` parameters (the active team is selected automatically). Named teammates always run concurrently and report through team messaging; omit \`run_in_background\` when spawning one — an explicit \`run_in_background: false\` is rejected, so for an inline blocking result omit \`name\` and use a regular agent instead. Set \`read_only: true\` for investigation teammates. A single writer teammate may be pinned to a leader-owned Git worktree with \`working_dir\`; shut it down before removing that worktree. Teams enable message passing between agents, shared task lists, and coordinated workflows. If the user asks for agents to collaborate, review each other's work, or produce a consolidated result — create a team.`
       : '';
     const baseDescription = `Launch a new agent to handle complex, multi-step tasks autonomously.
 The Agent tool launches specialized agents (subprocesses) that autonomously handle complex tasks. Each agent type has specific capabilities and tools available to it.
@@ -1151,6 +1155,24 @@ assistant: Uses the ${ToolNames.AGENT} tool to launch the test-runner agent
       ) {
         return 'Parameter "working_dir" requires an explicit subagent_type (and cannot be "fork").';
       }
+    }
+
+    // Named teammates are inherently concurrent: persistent team identity,
+    // messaging, and automatic final-report delivery leave no room for
+    // foreground/inline semantics. Reject the explicitly-foreground
+    // combination before spawning instead of silently ignoring it — an
+    // accepted-but-ignored flag wastes the launch and every token the
+    // teammate spends. The gate mirrors the team-routing branch in
+    // `execute`: without an active team, `name` falls through to a regular
+    // agent, where `run_in_background: false` is a valid foreground request.
+    if (
+      params.run_in_background === false &&
+      params.name &&
+      !isTeammate() &&
+      isTopLevelSession() &&
+      this.config.getTeamManager()
+    ) {
+      return 'Parameter "run_in_background" cannot be false for a named teammate: teammates always run concurrently and report through team messaging. Omit "run_in_background" when spawning a teammate, or omit "name" and keep run_in_background: false to run a regular agent in the foreground and get its result inline.';
     }
 
     if (params.plan_mode_required !== undefined) {
@@ -2264,6 +2286,14 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         return this.buildSpawnBlockedResult(
           'Error: "isolation" cannot be used for a named teammate. Create a leader-owned worktree first, then pass it with "working_dir".',
           'isolation is incompatible with a named teammate',
+        );
+      } else if (this.params.run_in_background === false) {
+        // Defense in depth behind validateToolParams: a hallucinated or
+        // wildcard-list call must not spawn a teammate that the caller
+        // believes is running inline.
+        return this.buildSpawnBlockedResult(
+          'Error: "run_in_background" cannot be false for a named teammate: teammates always run concurrently and report through team messaging. Omit "run_in_background" when spawning a teammate, or omit "name" and keep run_in_background: false to run a regular agent in the foreground and get its result inline.',
+          'run_in_background: false is incompatible with a named teammate',
         );
       } else {
         return this.executeTeammate(this.params.name, signal, updateOutput);


### PR DESCRIPTION
## What changed?

A named Agent Team teammate accepted `run_in_background: false` but silently ignored it: the named-team route runs before the regular foreground/background classification and always returns right after spawn. The reported run launched five named teammates through an active team — three with `run_in_background: true`, two with `false` — and all five returned `Teammate "<name>" is now running concurrently.` while the two "foreground" launches kept working and consuming model tokens.

Named teammates are inherently concurrent (persistent team identity, messaging, automatic final-report delivery), so foreground/inline semantics cannot apply. This PR makes the incompatible combination hard to generate and impossible to spawn:

- **Tool prose.** The team guidance, the `name` property, and the `run_in_background` schema description now state that named teammates always run concurrently and report through team messaging, that callers should omit `run_in_background` for them, that an explicit `false` is rejected, and that an inline blocking result requires omitting `name` and using a regular agent with `run_in_background: false`.
- **Validation.** `validateToolParams` rejects `run_in_background: false` when `name` routes to an active team, before any spawn. The gate mirrors the `execute()` team-routing branch exactly: without an active team, `name` falls through to a regular agent, where the foreground request remains valid.
- **Runtime defense in depth.** The `execute()` team-routing branch carries the same rejection as a `buildSpawnBlockedResult` block, mirroring the existing `model`/`isolation` blocks, so a hallucinated or wildcard-list call cannot spawn a teammate the caller believes is running inline.

## Risk & Scope

This changes the tool contract from silently ignoring `run_in_background: false` on a named teammate to rejecting it. Any caller or model-generated invocation that passes `name` + `run_in_background: false` while a team is active will now receive a validation rejection (or an execute-time block) instead of a concurrent teammate — intended hardening, but a behavior change. When no team is active, `name` falls through to a regular agent and the foreground request remains valid, so regular-agent workflows are unaffected. The concurrent teammate lifecycle itself is unchanged; `run_in_background: true` (or omitting it) with a teammate stays accepted.

Fixes #9430

## Verification

- `vitest run src/tools/agent/agent.test.ts` — 262/262 passed, including four new cases:
  - validation rejects `name` + `run_in_background: false` with an active team;
  - validation accepts `name` + `run_in_background: true`;
  - validation accepts `name` + `run_in_background: false` when no team is active (regular-agent fall-through);
  - execute-time block when a team becomes active after validation (spawnTeammate not called).
- Schema/description assertions added for the `name` property and the `run_in_background` description.
- `tsc --noEmit` clean for `packages/core`; `prettier --check` and `eslint` clean on both changed files.
