### PR TITLE
fix(cli): surface the daemon duplicate tool-call breaker as a visible loop-detected stop

### DIFF
--- a/docs/design/2026-08-19-duplicate-provider-toolcall-id-guard.md
+++ b/docs/design/2026-08-19-duplicate-provider-toolcall-id-guard.md
@@ -1,0 +1,173 @@
+# Duplicate provider tool-call id guard: args-aware replay detection and visible daemon stop
+
+- **Status**: approved
+- **Date**: 2026-08-19
+- **Related**: issue #5014, PR #5038 (first-level suppression), PR #5657
+  (repeated-duplicate circuit breaker)
+
+## Background
+
+PR #5038 made provider-supplied tool-call ids idempotent: when a provider
+replays an already-handled id, the duplicate is answered with a synthetic
+error response instead of executing again (issue #5014 showed the same shell
+command executing hundreds of times). PR #5657 added a circuit breaker on
+top: once a synthetic duplicate response has been sent for a provider id,
+seeing that id again drops the whole tool batch and terminates the turn.
+The breaker is shared by four entry points via
+`findRepeatedDuplicateProviderToolCall` (`packages/core/src/core/turn.ts`):
+AgentCore, the TUI stream hook, the non-interactive CLI, and the ACP daemon
+`Session`.
+
+## Problems
+
+### P1: id-only matching misfires on per-response id schemes
+
+Both guard levels key on the provider id **alone**. Some models emit
+tool-call ids that are only unique within a single response — e.g. Kimi K3
+emits `functions.{name}:{index}` which surfaces as `run_shell_command_0`,
+and the index can restart at 0 on any round. A fresh call (different
+command) that happens to reuse an old id is then treated as a replay:
+
+- round 1: `run_shell_command_0` (cmd A) → executes;
+- round 2: `run_shell_command_0` (cmd B) → synthetic duplicate error;
+- round 3: `run_shell_command_0` (cmd C) → circuit breaker, batch dropped,
+  turn ends.
+
+Once the model is in this mode every turn dies by round 3. Observed live in
+daemon sessions `e73e9c10` and `0c4ebdb4` (the latter looped through the
+two-round failure cycle on three consecutive prompts after the model's
+counter reset).
+
+The original #5014 replay — and the regression fixtures that guard it — are
+**same id and same arguments**. Id collisions with different arguments are a
+distinct, benign case that the guard should let through.
+
+### P2: the daemon drop is silent
+
+PR #5657 required user-visible termination and delivered it on three of the
+four paths: AgentCore terminates with `LOOP_DETECTED`, the TUI sets its
+loop-detected flag and posts the loop message, the non-interactive CLI emits
+a `LoopType.GLOBAL_TOOL_CALL_DUPLICATE` loop result. The ACP daemon
+`Session` is the outlier: `runToolCalls` returns an empty-parts result whose
+only consumer returns `message: null`, so the turn ends as a normal
+`end_turn` with nothing in the transcript, no telemetry, and only a
+`debugLogger.debug` line. To the user the session looks hung.
+
+## Decisions
+
+### D1 (P2): route the daemon breaker through the loop-detected machinery
+
+In `Session.runToolCalls`, when `findRepeatedDuplicateProviderToolCall`
+fires, call `recordDaemonLoopDetected(config, promptId,
+LoopType.GLOBAL_TOOL_CALL_DUPLICATE, message, toolLoopState)` and return
+`loopDetected: true` instead of the bespoke
+`repeatedDuplicateProviderToolCall` flag. Every `runToolCalls` caller
+already handles `loopDetected`: it preserves the
+`LOOP_DETECTED_CONTEXT_MESSAGE` into unsent history, suspends the todo stop
+guard, and — on foreground turns — fails the prompt with the
+`LOOP_DETECTED` turn error (`loopType` carried in the error data), which the
+client renders. Cron and background-notification turns keep their graceful
+end-turn semantics, matching how daemon loop detection already behaves.
+
+The `repeatedDuplicateProviderToolCall` field on `RunToolResult` and its
+dead consumer branch are removed. `GLOBAL_TOOL_CALL_DUPLICATE` is the same
+loop type the non-interactive CLI reports for this breaker, and
+`recordDaemonLoopDetected` is idempotent per turn and emits the
+`LoopDetectedEvent` telemetry the silent path was missing.
+
+### D2 (P1): a duplicate is a replay only if name+args match the original
+
+Replace the id-membership test with a fingerprint test at all four entry
+points, both guard levels:
+
+- **fingerprint** = tool name + canonical JSON of `args` (sorted keys,
+  stable serialization).
+- A handled-id map replaces the handled-id set: provider id → fingerprint
+  of the call that first executed under that id. History-derived entries
+  come from a new `GeminiChat.getHistoryToolCallFingerprints()` (model-turn
+  `functionCall`s whose id has a matching user-turn `functionResponse`),
+  replacing `getHistoryFunctionResponseIds()` at the dedup sites. In-flight
+  tracking (per-turn refs/sets at each entry point) records the same
+  mapping when a call is admitted for execution.
+- Incoming call with a handled id **and equal fingerprint** → replay:
+  synthetic duplicate response first, circuit breaker on recurrence
+  (unchanged #5038/#5657 behavior).
+- Incoming call with a handled id but a **different fingerprint** → not a
+  replay: it executes under the suffixed unique id that
+  `normalizeModelToolCallIds` already assigns (`__qwen_dup_N`). The map keeps
+  the first occurrence's fingerprint (first-occurrence semantics — the raw
+  id keeps naming its original call; suffixed executions live in history
+  under their suffixed ids).
+- `duplicateProviderToolCallResponseIds` (ids already answered with a
+  synthetic response) stays id-keyed; since synthetic responses are now only
+  sent for true replays, the breaker condition becomes "incoming item is a
+  replay AND (a synthetic response was already sent for that id OR the same
+  replay appears more than once in the batch)".
+- The same-response duplicate drop inside `normalizeModelToolCallIds`
+  (`rawIdsInCurrentTurn`) is unchanged: two identical raw ids inside one
+  streamed response remain pathological (Kimi emits distinct indices for
+  parallel calls in one response).
+
+Residual risks, accepted:
+
+- A replay of a _suffixed_ execution (same raw id, args equal to a later
+  collision call rather than the first) executes again; unbounded repetition
+  is stopped by the id-independent guards (consecutive-identical threshold
+  5, global same-(tool,args) threshold 6, turn tool-call cap).
+- A legitimate re-run whose args exactly equal the raw id's first execution
+  is still suppressed once and circuit-breaks on recurrence — now visibly
+  (D1), and with a recovery hint (D3).
+
+### D3: make the synthetic duplicate message actionable
+
+Append guidance to `duplicateProviderToolCallMessage` telling the model
+that, if a new invocation was intended, it must re-issue the call with a
+fresh tool-call id (or explicitly different arguments). Kimi-class models
+generate the index token themselves and can comply. Existing assertions use
+`toContain` on the leading sentence and remain valid.
+
+## Alternatives rejected
+
+- **Scope provider ids to a single response** (always execute cross-round
+  collisions): reverts #5014 — a true replay would execute up to the loop
+  thresholds (≤5 times), unacceptable for side-effect tools.
+- **Adapter-level id rewriting for `^{tool}_\d+$`-shaped ids**: fragile
+  provider-specific heuristic; disables replay protection wholesale for
+  matching providers.
+- **Family-wide fingerprint matching** (compare against the raw id _and_
+  all its suffixed executions): strictly stronger replay suppression, but
+  blocks legitimate identical re-runs (build/test/status loops) for
+  broken-numbering models — the dominant workflow for the model class this
+  fix targets.
+- **Waiting for an upstream provider fix**: id uniqueness is outside our
+  control; the client must be robust regardless.
+
+## Delivery
+
+Two PRs sharing this doc:
+
+1. **Visible daemon stop (D1)** — `Session.ts` only, plus tests. Ships
+   first: turns the silent hang into a diagnosable loop-detected stop even
+   before the root cause lands.
+2. **Args-aware replay detection (D2 + D3)** — core helpers
+   (`turn.ts`, `toolCallIdUtils.ts`, `geminiChat.ts`, `client.ts`) and the
+   four entry points, plus tests.
+
+## Test matrix
+
+| Case                                     | Expected                                                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Same id, same args, second occurrence    | synthetic duplicate response, no execution (unchanged)                                                        |
+| Same id, same args, third occurrence     | batch dropped; visible loop-detected stop on every path, `GLOBAL_TOOL_CALL_DUPLICATE` telemetry (daemon: new) |
+| Same id, different args, any round       | executes under `__qwen_dup_N` id; no synthetic response; turn continues                                       |
+| Same raw id twice within one response    | second call dropped by `normalizeModelToolCallIds` (unchanged)                                                |
+| Id without history collision             | executes (unchanged)                                                                                          |
+| Daemon foreground turn hits breaker      | prompt fails with `LOOP_DETECTED` turn error; context message preserved for next turn                         |
+| Daemon cron/background turn hits breaker | graceful end-turn; context message preserved (parity with existing daemon loop stops)                         |
+
+Regression suites: `packages/core` `turn.test.ts`,
+`toolCallIdUtils.test.ts`, `agent-headless.test.ts`; `packages/cli`
+`useGeminiStream.test.tsx`, `nonInteractiveCli.test.ts`,
+`acp-integration/session/Session.test.ts`. E2E: mock OpenAI-compatible
+provider replaying `{name}_0`-style ids with differing args per round
+(must complete all rounds), and with identical args (must stop visibly).

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -7492,7 +7492,7 @@ describe('Session', () => {
         expect(finishedSpy).toHaveBeenCalled();
       });
 
-      it('stops an ACP prompt after a repeated duplicate provider id without sending an empty follow-up', async () => {
+      it('stops an ACP prompt with a visible loop-detected error after a repeated duplicate provider id', async () => {
         mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
         vi.mocked(mockChat.getHistoryFunctionResponseIds)
           .mockReturnValueOnce(new Set<string>())
@@ -7575,9 +7575,17 @@ describe('Session', () => {
             ]),
           );
 
-        await session.prompt({
-          sessionId: 'test-session-id',
-          prompt: [{ type: 'text', text: 'read the file' }],
+        await expect(
+          session.prompt({
+            sessionId: 'test-session-id',
+            prompt: [{ type: 'text', text: 'read the file' }],
+          }),
+        ).rejects.toMatchObject({
+          data: {
+            code: 'LOOP_DETECTED',
+            errorKind: 'loop_detected',
+            loopType: core.LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
+          },
         });
 
         expect(mockChat.sendMessageStream).toHaveBeenCalledTimes(3);
@@ -7588,6 +7596,21 @@ describe('Session', () => {
         expect(
           duplicateFollowUp.message[0].functionResponse?.response?.['error'],
         ).toContain('Duplicate provider tool call id "shell_1"');
+        expect(debugLoggerWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Stopping ACP turn after repeated duplicate provider tool-call id: shell_1',
+          ),
+        );
+        expect(mockChat.addHistory).toHaveBeenCalledWith({
+          role: 'user',
+          parts: [
+            expect.objectContaining({
+              text: expect.stringContaining(
+                'terminated because the model exceeded tool-call safety limits',
+              ),
+            }),
+          ],
+        });
       });
 
       it('stops an ACP prompt after repeated invalid tool parameters with fresh ids', async () => {
@@ -22780,7 +22803,6 @@ describe('Session', () => {
         parts: Part[];
         stopAfterPermissionCancel: boolean;
         loopDetected?: boolean;
-        repeatedDuplicateProviderToolCall?: boolean;
         repeatedToolFailureBatch?: {
           complete: boolean;
           observations: Array<{
@@ -27177,12 +27199,26 @@ describe('Session', () => {
       ).runToolCalls(new AbortController().signal, 'prompt-history-dup', [
         duplicateCall,
       ]);
+      const toolLoopState: DaemonToolLoopState = {
+        totalToolCalls: 0,
+        invalidToolParamErrors: new Map<string, number>(),
+        toolCallKeyCounts: new Map<string, number>(),
+        maxToolCallKeyRepeat: 0,
+        loopDetected: false,
+        repeatedToolFailureMode: 'off',
+        repeatedToolFailureState: createRepeatedToolFailureGuardState(),
+      };
       const secondResult = await (
         session as unknown as ToolCallInternals
-      ).runToolCalls(new AbortController().signal, 'prompt-history-dup', [
-        duplicateCall,
-        { id: 'fresh_shell', name: 'read_file', args: { file_path: 'c.ts' } },
-      ]);
+      ).runToolCalls(
+        new AbortController().signal,
+        'prompt-history-dup',
+        [
+          duplicateCall,
+          { id: 'fresh_shell', name: 'read_file', args: { file_path: 'c.ts' } },
+        ],
+        toolLoopState,
+      );
 
       expect(mockToolRegistry.getTool).not.toHaveBeenCalled();
       expect(build).not.toHaveBeenCalled();
@@ -27197,7 +27233,11 @@ describe('Session', () => {
         ),
       });
       expect(secondResult.parts).toHaveLength(0);
-      expect(secondResult.repeatedDuplicateProviderToolCall).toBe(true);
+      expect(secondResult.loopDetected).toBe(true);
+      expect(toolLoopState.loopDetected).toBe(true);
+      expect(toolLoopState.loopType).toBe(
+        core.LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
+      );
       expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledTimes(
         1,
       );

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -474,7 +474,6 @@ function getAbortAwareEndTurnStopReason(
 type RunToolResult = {
   parts: Part[];
   stopAfterPermissionCancel: boolean;
-  repeatedDuplicateProviderToolCall?: boolean;
   loopDetected?: boolean;
   repeatedToolFailureBatch?: RepeatedToolFailureBatch;
   memoryWriteCandidates?: MemoryWriteCandidate[];
@@ -6361,13 +6360,6 @@ export class Session implements SessionContext {
       debugLogger.debug('Stopping ACP turn after daemon loop detection.');
       return { message: null, hadMidTurnUserInput: false };
     }
-    if (toolRun.repeatedDuplicateProviderToolCall) {
-      this.todoStopGuard.suspend();
-      debugLogger.debug(
-        'Stopping ACP turn after dropping repeated duplicate provider tool-call response.',
-      );
-      return { message: null, hadMidTurnUserInput: false };
-    }
     const drained = await this.#drainMidTurnInput(abortSignal, {
       watchQueuedPrompt: toolLoopState.repeatedToolFailureMode !== 'off',
       onFullTurnModel,
@@ -8714,14 +8706,24 @@ export class Session implements SessionContext {
       const providerCallId =
         getProviderToolCallId(repeatedDuplicateCall) ??
         repeatedDuplicateCall.id;
-      debugLogger.debug(
-        `[Session.runToolCalls] Dropping batch after repeated duplicate provider tool-call id: ` +
-          `${providerCallId} (tool: ${repeatedDuplicateCall.name ?? 'unknown_tool'})`,
-      );
+      const message =
+        `Stopping ACP turn after repeated duplicate provider tool-call id: ` +
+        `${providerCallId} (tool: ${repeatedDuplicateCall.name ?? 'unknown_tool'}).`;
+      if (toolLoopState) {
+        recordDaemonLoopDetected(
+          this.config,
+          promptId,
+          LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
+          message,
+          toolLoopState,
+        );
+      } else {
+        debugLogger.warn(message);
+      }
       return await finalizeRunToolResult({
         parts: [],
         stopAfterPermissionCancel: false,
-        repeatedDuplicateProviderToolCall: true,
+        loopDetected: true,
       });
     }
 
@@ -9111,7 +9113,6 @@ export class Session implements SessionContext {
             return await finalizeRunToolResult({
               parts,
               stopAfterPermissionCancel: true,
-              repeatedDuplicateProviderToolCall: false,
               memoryWriteCandidates,
             });
           }
@@ -9149,7 +9150,6 @@ export class Session implements SessionContext {
               return await finalizeRunToolResult({
                 parts,
                 stopAfterPermissionCancel: true,
-                repeatedDuplicateProviderToolCall: false,
                 memoryWriteCandidates,
               });
             }
@@ -9159,7 +9159,6 @@ export class Session implements SessionContext {
       return await finalizeRunToolResult({
         parts,
         stopAfterPermissionCancel: false,
-        repeatedDuplicateProviderToolCall: false,
         memoryWriteCandidates,
       });
     } finally {


### PR DESCRIPTION
## What this PR does

When the repeated-duplicate provider tool-call circuit breaker (added in #5657) fires inside an ACP daemon session, the turn now terminates the same way as every other daemon loop-protection stop: a foreground prompt fails with the standard loop-detected error carrying the `global_tool_call_duplicate` loop type, the loop-context note is preserved into unsent history for the next turn, and the loop-detected telemetry event is emitted. Cron and background-notification turns keep their existing graceful end-turn semantics, matching how daemon loop detection already behaves. The bespoke result flag this path used internally is removed in favor of the existing loop-detected plumbing.

## Why it's needed

PR #5657's review required user-visible termination for this circuit breaker and delivered it on three of the four entry points: the subagent runtime terminates with a loop-detected mode, the TUI posts the loop message, and the non-interactive CLI emits a `global_tool_call_duplicate` loop result. The ACP daemon session was the outlier: the tool batch was dropped with only a debug log — no transcript output, no telemetry, and the prompt resolved as a normal end of turn. To the user the session simply looked hung mid-turn. This was observed live in local daemon sessions where a model kept reusing a provider tool-call id: each prompt died silently by its third round, with the transcript ending on a thought fragment. This PR makes the stop diagnosable on its own; the root cause of the false-positive id collisions is fixed separately in the stacked follow-up PR.

## Reviewer Test Plan

### How to verify

Drive a daemon session (`qwen serve` + any ACP client) with an OpenAI-compatible provider that replays an already-answered tool-call id with identical arguments on consecutive rounds — a deterministic mock provider works. Expected: round 1 executes; round 2 receives the synthetic duplicate-error tool result; round 3 fails the prompt with the visible loop-protection error ("Tool-call loop protection stopped this turn. The session is still available; send a more specific instruction to continue.", error data carrying `loopType: global_tool_call_duplicate`) instead of silently ending, and the session stays usable for the next prompt.

Focused regression suite (639→640 tests, includes the updated prompt-level case asserting the rejection, the preserved context message, and the warn log):

```
cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts
```

### Evidence (Before & After)

Before: the breaker path returned an empty tool run and the prompt resolved `end_turn` with nothing user-visible — daemon transcripts end mid-turn on a thought fragment with no tool result and no assistant text (observed on v0.21.13 daemon sessions).

After: the prompt rejects with the `LOOP_DETECTED` turn error (loop type included), `System: this turn was terminated because the model exceeded tool-call safety limits...` is preserved for the next turn, and `LoopDetectedEvent` telemetry is recorded. N/A for screenshots (headless/daemon protocol behavior).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit suites via vitest; behavior also exercised end-to-end on the bundled CLI as part of the stacked follow-up PR's mock-provider verification.

## Risk & Scope

- Main risk or tradeoff: foreground daemon prompts that hit this breaker now fail with a loop-detected error instead of silently succeeding with an empty turn — intended parity with the other daemon loop guards; clients already handle this error shape for existing loop stops.
- Not validated / out of scope: the false-positive id collisions that made this breaker fire for healthy calls — fixed in the stacked follow-up PR.
- Breaking changes / migration notes: none.

## Linked Issues

Design doc committed under `docs/design/2026-08-19-duplicate-provider-toolcall-id-guard.md` (this PR implements decision D1).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 #5657 引入的重复 provider tool-call 熔断在 ACP daemon 会话中触发时，turn 现在与 daemon 其他 loop 保护停止走完全相同的通路终止：前台 prompt 以标准 loop-detected 错误失败（携带 `global_tool_call_duplicate` loop 类型）、loop 上下文提示保留进未发送历史供下一轮使用、并发出 loop-detected 遥测事件。cron 与后台通知 turn 保持既有的优雅 end-turn 语义，与 daemon 现有 loop 检测行为一致。该路径内部使用的专用结果标志被移除，改用既有 loop-detected 管线。

## 为什么需要

PR #5657 的 review 要求该熔断必须用户可见地终止，四个入口中有三个做到了：subagent 运行时以 loop-detected 模式终止、TUI 落 loop 消息、非交互 CLI 输出 `global_tool_call_duplicate` loop 结果。ACP daemon 会话是遗漏项：整批工具调用被丢弃时只有一行 debug 日志——transcript 无输出、无遥测，prompt 以正常 end-turn 结束。对用户来说会话就像卡死在 turn 中间。本地 daemon 会话已实际观察到该现象：模型持续复用 provider tool-call id 时，每个 prompt 都在第三轮静默死亡，transcript 停在一段思考文本上。本 PR 使该停止自身可诊断；误判 id 碰撞的根因由堆叠的后续 PR 修复。

## Reviewer 测试计划

### 如何验证

用会在连续轮次重放同 id 同参数工具调用的 OpenAI 兼容 provider（确定性 mock 即可）驱动 daemon 会话（`qwen serve` + 任意 ACP 客户端）。预期：第 1 轮执行；第 2 轮收到合成 duplicate 错误工具结果；第 3 轮 prompt 以可见的 loop 保护错误失败（错误数据携带 `loopType: global_tool_call_duplicate`）而非静默结束，会话对下一个 prompt 仍可用。

回归套件（639→640 测试，含更新后的 prompt 级用例，断言拒绝、保留的上下文消息与 warn 日志）：`cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts`

### 证据（Before & After）

Before：熔断路径返回空工具结果、prompt 以 `end_turn` 正常结束，用户不可见——daemon transcript 停在思考片段上，无工具结果、无助手正文（v0.21.13 daemon 会话实测）。

After：prompt 以 `LOOP_DETECTED` turn 错误拒绝（含 loop 类型），"System: this turn was terminated because the model exceeded tool-call safety limits..." 保留给下一轮，并记录 `LoopDetectedEvent` 遥测。无 UI 截图（headless/daemon 协议行为）。

### 测试平台

macOS ✅；Windows / Linux ⚠️ 未本地验证（依赖 CI）。

## 风险与范围

- 主要风险/权衡：命中该熔断的前台 daemon prompt 现在以 loop-detected 错误失败，而非静默的空 turn 成功——这是与其他 daemon loop 守卫对齐的预期行为，客户端已处理该错误形态。
- 未验证/超出范围：使该熔断对健康调用误触发的 id 碰撞——由堆叠的后续 PR 修复。
- 破坏性变更/迁移说明：无。

## 关联 Issue

设计文档见 `docs/design/2026-08-19-duplicate-provider-toolcall-id-guard.md`（本 PR 实现其中决策 D1）。

</details>
