### PR TITLE
fix(core): treat duplicate provider tool-call ids as replays only when arguments match

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -625,7 +625,9 @@ describe('Session', () => {
       getHistoryTail: vi.fn(() => getHistoryMock()),
       getHistoryTailShallow: vi.fn(() => getHistoryMock()),
       getHistoryShallow: vi.fn().mockReturnValue([]),
-      getHistoryFunctionResponseIds: vi.fn().mockReturnValue(new Set<string>()),
+      getHistoryToolCallFingerprints: vi
+        .fn()
+        .mockReturnValue(new Map<string, string>()),
       getLastModelMessageText: vi.fn().mockReturnValue(''),
       setHistory: vi.fn(),
       truncateHistory: vi.fn(),
@@ -8436,9 +8438,16 @@ describe('Session', () => {
 
       it('stops an ACP prompt with a visible loop-detected error after a repeated duplicate provider id', async () => {
         mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
-        vi.mocked(mockChat.getHistoryFunctionResponseIds)
-          .mockReturnValueOnce(new Set<string>())
-          .mockReturnValue(new Set(['shell_1']));
+        vi.mocked(mockChat.getHistoryToolCallFingerprints)
+          .mockReturnValueOnce(new Map<string, string>())
+          .mockReturnValue(
+            new Map([
+              [
+                'shell_1',
+                core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+              ],
+            ]),
+          );
         const [duplicatePart] = core.normalizeModelToolCallIds(
           [
             {
@@ -10013,8 +10022,13 @@ describe('Session', () => {
 
       it('clears duplicate provider id tracking between ACP prompts', async () => {
         mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
-        vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
-          new Set(['shell_1']),
+        vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
+          new Map([
+            [
+              'shell_1',
+              core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+            ],
+          ]),
         );
         const [duplicatePart] = core.normalizeModelToolCallIds(
           [
@@ -25649,8 +25663,15 @@ describe('Session', () => {
         return mockAllowedTool(name, execute);
       });
       const historyIds = new Set(['duplicate_read']);
-      vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
-        historyIds,
+      vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
+        new Map([
+          [
+            'duplicate_read',
+            core.getToolCallFingerprint(core.ToolNames.READ_FILE, {
+              file_path: 'duplicate.ts',
+            }),
+          ],
+        ]),
       );
       const [duplicatePart] = core.normalizeModelToolCallIds(
         [
@@ -28088,8 +28109,13 @@ describe('Session', () => {
         canUpdateOutput: false,
         isOutputMarkdown: true,
       });
-      vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
-        new Set(['shell_1']),
+      vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
+        new Map([
+          [
+            'shell_1',
+            core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+          ],
+        ]),
       );
       const [duplicatePart] = core.normalizeModelToolCallIds(
         [
@@ -28164,6 +28190,64 @@ describe('Session', () => {
       );
     });
 
+    it('executes an id-colliding functionCall whose args differ from the handled call', async () => {
+      const execute = vi.fn().mockResolvedValue({
+        llmContent: 'fresh result',
+        returnDisplay: 'fresh result',
+      });
+      const build = vi.fn().mockReturnValue({
+        params: { file_path: 'c.ts' },
+        execute,
+        getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+        getDescription: vi.fn().mockReturnValue('Read file'),
+        toolLocations: vi.fn().mockReturnValue([]),
+      });
+      mockToolRegistry.getTool.mockReturnValue({
+        name: 'read_file',
+        kind: core.Kind.Read,
+        displayName: 'Read File',
+        description: 'Read file',
+        build,
+        canUpdateOutput: false,
+        isOutputMarkdown: true,
+      });
+      vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
+        new Map([
+          [
+            'shell_1',
+            core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+          ],
+        ]),
+      );
+      const [collidingPart] = core.normalizeModelToolCallIds(
+        [
+          {
+            functionCall: {
+              id: 'shell_1',
+              name: 'read_file',
+              args: { file_path: 'c.ts' },
+            },
+          },
+        ],
+        new Set(['shell_1']),
+        new Set<string>(),
+      );
+
+      const result = await (
+        session as unknown as ToolCallInternals
+      ).runToolCalls(new AbortController().signal, 'prompt-id-collision', [
+        collidingPart.functionCall!,
+      ]);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(result.loopDetected).toBeUndefined();
+      expect(result.parts).toHaveLength(1);
+      expect(result.parts[0].functionResponse?.id).toBe('shell_1__qwen_dup_2');
+      expect(result.parts[0].functionResponse?.response).toEqual({
+        output: 'fresh result',
+      });
+    });
+
     it('drops repeated duplicate provider functionCall ids after the first synthetic response', async () => {
       const execute = vi.fn().mockResolvedValue({
         llmContent: 'should not run',
@@ -28185,8 +28269,13 @@ describe('Session', () => {
         canUpdateOutput: false,
         isOutputMarkdown: true,
       });
-      vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
-        new Set(['shell_1']),
+      vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
+        new Map([
+          [
+            'shell_1',
+            core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+          ],
+        ]),
       );
       const [duplicatePart] = core.normalizeModelToolCallIds(
         [
@@ -28254,8 +28343,21 @@ describe('Session', () => {
     });
 
     it('suppresses duplicate TodoWrite calls without emitting plan updates', async () => {
-      vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
-        new Set(['todo_1']),
+      vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
+        new Map([
+          [
+            'todo_1',
+            core.getToolCallFingerprint(core.ToolNames.TODO_WRITE, {
+              todos: [
+                {
+                  id: 'task-1',
+                  content: 'Do not replay this',
+                  status: 'pending',
+                },
+              ],
+            }),
+          ],
+        ]),
       );
       const [duplicatePart] = core.normalizeModelToolCallIds(
         [
@@ -28339,9 +28441,13 @@ describe('Session', () => {
         canUpdateOutput: false,
         isOutputMarkdown: true,
       });
-      const historyIds = new Set(['dup_mid']);
-      vi.mocked(mockChat.getHistoryFunctionResponseIds).mockReturnValue(
-        historyIds,
+      vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
+        new Map([
+          [
+            'dup_mid',
+            core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+          ],
+        ]),
       );
       const [duplicatePart] = core.normalizeModelToolCallIds(
         [
@@ -28378,7 +28484,6 @@ describe('Session', () => {
           'Duplicate provider tool call id "dup_mid"',
         ),
       });
-      expect(historyIds).toEqual(new Set(['dup_mid']));
     });
 
     it('does not dedupe function calls with empty ids in one batch', async () => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -28441,13 +28441,14 @@ describe('Session', () => {
         canUpdateOutput: false,
         isOutputMarkdown: true,
       });
+      const seededFingerprints = new Map([
+        [
+          'dup_mid',
+          core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+        ],
+      ]);
       vi.mocked(mockChat.getHistoryToolCallFingerprints).mockReturnValue(
-        new Map([
-          [
-            'dup_mid',
-            core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
-          ],
-        ]),
+        seededFingerprints,
       );
       const [duplicatePart] = core.normalizeModelToolCallIds(
         [
@@ -28484,6 +28485,19 @@ describe('Session', () => {
           'Duplicate provider tool call id "dup_mid"',
         ),
       });
+      // The accessor-owned map must stay untouched: runToolCalls records
+      // admitted calls only into its own defensive copy. Without this pin,
+      // dropping the copy would silently leak admitted-call entries into
+      // the accessor's map (a real replay misclassification once the
+      // accessor is ever memoized) while every test stays green.
+      expect(seededFingerprints).toEqual(
+        new Map([
+          [
+            'dup_mid',
+            core.getToolCallFingerprint('read_file', { file_path: 'b.ts' }),
+          ],
+        ]),
+      );
     });
 
     it('does not dedupe function calls with empty ids in one batch', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -171,6 +171,8 @@ import {
   todoWorkChainContext,
   dedupeToolCallsById,
   getProviderToolCallId,
+  isReplayOfHandledToolCall,
+  recordHandledToolCall,
   parsePositiveIntegerEnv,
   DEFAULT_TOKEN_LIMIT,
   hasImageParts,
@@ -8940,13 +8942,26 @@ export class Session implements SessionContext {
     };
     type Batch = ExecutableBatch | DuplicateBatch;
     const batches: Batch[] = [];
-    const handledProviderToolCallIds = new Set(
-      this.#getCurrentChat().getHistoryFunctionResponseIds(),
+    // Copied so per-batch recordHandledToolCall never mutates the
+    // accessor-owned map.
+    const handledToolCallFingerprints = new Map(
+      this.#getCurrentChat().getHistoryToolCallFingerprints(),
     );
+    const isReplayOfHandledCall = (fc: FunctionCall): boolean => {
+      const providerCallId = getProviderToolCallId(fc) ?? fc.id;
+      return providerCallId
+        ? isReplayOfHandledToolCall(
+            handledToolCallFingerprints,
+            providerCallId,
+            fc.name,
+            fc.args,
+          )
+        : false;
+    };
     const repeatedDuplicateCall = findRepeatedDuplicateProviderToolCall(
       dedupedFunctionCalls,
       (fc) => getProviderToolCallId(fc) ?? fc.id,
-      handledProviderToolCallIds,
+      isReplayOfHandledCall,
       this.duplicateProviderToolCallResponseIds,
     );
     if (repeatedDuplicateCall) {
@@ -9060,7 +9075,7 @@ export class Session implements SessionContext {
     for (const fc of dedupedFunctionCalls) {
       const providerCallId = getProviderToolCallId(fc) ?? fc.id;
       if (providerCallId) {
-        if (handledProviderToolCallIds.has(providerCallId)) {
+        if (isReplayOfHandledCall(fc)) {
           const callId = executionCallIds.get(fc)!;
           pushDuplicateBatch(fc, {
             callId,
@@ -9072,7 +9087,12 @@ export class Session implements SessionContext {
           });
           continue;
         }
-        handledProviderToolCallIds.add(providerCallId);
+        recordHandledToolCall(
+          handledToolCallFingerprints,
+          providerCallId,
+          fc.name,
+          fc.args,
+        );
       }
 
       // Canonical names match core's isToolCallConcurrencySafe predicate,

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -170,6 +170,7 @@ import {
   promptIdContext,
   todoWorkChainContext,
   dedupeToolCallsById,
+  getFunctionCallFingerprint,
   getProviderToolCallId,
   isReplayOfHandledToolCall,
   recordHandledToolCall,
@@ -8953,8 +8954,7 @@ export class Session implements SessionContext {
         ? isReplayOfHandledToolCall(
             handledToolCallFingerprints,
             providerCallId,
-            fc.name,
-            fc.args,
+            getFunctionCallFingerprint(fc),
           )
         : false;
     };
@@ -9090,8 +9090,7 @@ export class Session implements SessionContext {
         recordHandledToolCall(
           handledToolCallFingerprints,
           providerCallId,
-          fc.name,
-          fc.args,
+          getFunctionCallFingerprint(fc),
         );
       }
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -8943,8 +8943,9 @@ export class Session implements SessionContext {
     };
     type Batch = ExecutableBatch | DuplicateBatch;
     const batches: Batch[] = [];
-    // Copied so per-batch recordHandledToolCall never mutates the
-    // accessor-owned map.
+    // The accessor returns a fresh map per call; copy anyway so a future
+    // cached accessor cannot turn per-batch recording into shared-state
+    // mutation.
     const handledToolCallFingerprints = new Map(
       this.#getCurrentChat().getHistoryToolCallFingerprints(),
     );

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -34,6 +34,7 @@ import {
   SendMessageType,
   SYSTEM_REMINDER_OPEN,
   LoopType,
+  getToolCallFingerprint,
   CronScheduler,
   AUTONOMOUS_SENTINEL_CRON,
   AUTONOMOUS_SENTINEL_DYNAMIC,
@@ -251,7 +252,7 @@ describe('runNonInteractive', () => {
     getChatRecordingService: Mock;
     getChat: Mock;
     stripOrphanedUserEntriesFromHistory: Mock;
-    getHistoryFunctionResponseIds: Mock;
+    getHistoryToolCallFingerprints: Mock;
     consumePendingMemoryTaskPromises: Mock;
     recordCompletedToolCall: Mock;
     addHistory: Mock;
@@ -329,7 +330,7 @@ describe('runNonInteractive', () => {
         recordToolCalls: vi.fn(),
       })),
       getChat: vi.fn(() => ({})),
-      getHistoryFunctionResponseIds: vi.fn(() => new Set<string>()),
+      getHistoryToolCallFingerprints: vi.fn(() => new Map<string, string>()),
     };
 
     let currentModel = 'test-model';
@@ -3283,8 +3284,10 @@ describe('runNonInteractive', () => {
 
   it('should stop repeated duplicate provider tool-call responses from drain items', async () => {
     setupMetricsMock();
-    mockGeminiClient.getHistoryFunctionResponseIds.mockReturnValue(
-      new Set(['tool-drain']),
+    mockGeminiClient.getHistoryToolCallFingerprints.mockReturnValue(
+      new Map([
+        ['tool-drain', getToolCallFingerprint('testTool', { arg1: 'value1' })],
+      ]),
     );
 
     const notificationXml =
@@ -3375,8 +3378,13 @@ describe('runNonInteractive', () => {
 
   it('should ignore duplicate provider tool-call ids already present in chat history', async () => {
     setupMetricsMock();
-    mockGeminiClient.getHistoryFunctionResponseIds.mockReturnValue(
-      new Set(['tool-history']),
+    mockGeminiClient.getHistoryToolCallFingerprints.mockReturnValue(
+      new Map([
+        [
+          'tool-history',
+          getToolCallFingerprint('testTool', { arg1: 'value1' }),
+        ],
+      ]),
     );
     const toolCallEvent: ServerGeminiStreamEvent = {
       type: GeminiEventType.ToolCallRequest,
@@ -3423,6 +3431,74 @@ describe('runNonInteractive', () => {
     expect(duplicateParts[0].functionResponse?.response?.['error']).toContain(
       'Duplicate provider tool call id "tool-history"',
     );
+    expect(processStdoutSpy).toHaveBeenCalledWith('Final answer\n');
+  });
+
+  it('executes an id-colliding tool call whose args differ from the handled call', async () => {
+    setupMetricsMock();
+    mockGeminiClient.getHistoryToolCallFingerprints.mockReturnValue(
+      new Map([
+        [
+          'tool-history',
+          getToolCallFingerprint('testTool', { arg1: 'value1' }),
+        ],
+      ]),
+    );
+    const toolCallEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.ToolCallRequest,
+      value: {
+        callId: 'tool-history__qwen_dup_2',
+        providerCallId: 'tool-history',
+        name: 'testTool',
+        args: { arg1: 'value2' },
+        isClientInitiated: false,
+        prompt_id: 'prompt-id-collision',
+      },
+    };
+    mockCoreExecuteToolCall.mockResolvedValueOnce({
+      callId: 'tool-history__qwen_dup_2',
+      responseParts: [
+        {
+          functionResponse: {
+            id: 'tool-history__qwen_dup_2',
+            name: 'testTool',
+            response: { output: 'fresh result' },
+          },
+        },
+      ],
+      resultDisplay: 'fresh result',
+      error: undefined,
+      errorType: undefined,
+    });
+
+    mockGeminiClient.sendMessageStream
+      .mockReturnValueOnce(createStreamFromEvents([toolCallEvent]))
+      .mockReturnValueOnce(
+        createStreamFromEvents([
+          { type: GeminiEventType.Content, value: 'Final answer' },
+          {
+            type: GeminiEventType.Finished,
+            value: {
+              reason: undefined,
+              usageMetadata: { totalTokenCount: 10 },
+            },
+          },
+        ]),
+      );
+
+    await runNonInteractive(
+      mockConfig,
+      mockSettings,
+      'Use a tool',
+      'prompt-id-collision',
+    );
+
+    expect(mockCoreExecuteToolCall).toHaveBeenCalledTimes(1);
+    expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(2);
+    const resultParts = mockGeminiClient.sendMessageStream.mock.calls[1][0];
+    expect(
+      JSON.stringify(resultParts[0].functionResponse?.response),
+    ).not.toContain('Duplicate provider tool call id');
     expect(processStdoutSpy).toHaveBeenCalledWith('Final answer\n');
   });
 
@@ -7226,7 +7302,10 @@ describe('runNonInteractive', () => {
           callId: 'tool-side',
           providerCallId: 'tool-side',
           name: 'side_effect_tool',
-          args: { path: '/tmp/second' },
+          // Same args as the first call: an exact replay of the handled
+          // provider id. A different-args collision would be a fresh call
+          // and no longer receives a duplicate response.
+          args: { path: '/tmp/first' },
           isClientInitiated: false,
           prompt_id: 'prompt-id-dup-structured',
         },

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -49,6 +49,8 @@ import {
   isSystemReminderContent,
   markDuplicateProviderToolCallResponseSent,
   findRepeatedDuplicateProviderToolCall,
+  isReplayOfHandledToolCall,
+  recordHandledToolCall,
   isToolCallConcurrencySafe,
   canonicalToolName,
   parsePositiveIntegerEnv,
@@ -1692,8 +1694,8 @@ export async function runNonInteractive(
        * helper returns (main-turn → emitStructuredSuccess(); drain-turn
        * → return so the post-drain code emits success).
        */
-      const handledProviderToolCallIds =
-        geminiClient.getHistoryFunctionResponseIds();
+      const handledToolCallFingerprints =
+        geminiClient.getHistoryToolCallFingerprints();
       // Tracks duplicate-error responses emitted during this headless run.
       // Once a provider id reaches this set, seeing it again is terminal for
       // the current tool batch so we do not send partial tool responses.
@@ -1748,10 +1750,23 @@ export async function runNonInteractive(
           }
           return true;
         });
+        const isReplayOfHandledRequest = (
+          request: ToolCallRequestInfo,
+        ): boolean => {
+          const providerCallId = getProviderResponseId(request);
+          return providerCallId
+            ? isReplayOfHandledToolCall(
+                handledToolCallFingerprints,
+                providerCallId,
+                request.name,
+                request.args,
+              )
+            : false;
+        };
         const repeatedDuplicateRequest = findRepeatedDuplicateProviderToolCall(
           [...uniqueBatchRequests, ...duplicateBatchRequests],
           getProviderResponseId,
-          handledProviderToolCallIds,
+          isReplayOfHandledRequest,
           duplicateProviderToolCallResponseIds,
         );
         if (repeatedDuplicateRequest) {
@@ -1777,8 +1792,13 @@ export async function runNonInteractive(
             continue;
           }
 
-          if (!handledProviderToolCallIds.has(providerCallId)) {
-            handledProviderToolCallIds.add(providerCallId);
+          if (!isReplayOfHandledRequest(requestInfo)) {
+            recordHandledToolCall(
+              handledToolCallFingerprints,
+              providerCallId,
+              requestInfo.name,
+              requestInfo.args,
+            );
             executableBatchRequests.push(requestInfo);
             continue;
           }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -1695,8 +1695,11 @@ export async function runNonInteractive(
        * helper returns (main-turn → emitStructuredSuccess(); drain-turn
        * → return so the post-drain code emits success).
        */
-      const handledToolCallFingerprints =
-        geminiClient.getHistoryToolCallFingerprints();
+      // Fresh map per call today; copy so a future cached accessor cannot
+      // turn this run's cross-turn recording into shared-state mutation.
+      const handledToolCallFingerprints = new Map(
+        geminiClient.getHistoryToolCallFingerprints(),
+      );
       // Tracks duplicate-error responses emitted during this headless run.
       // Once a provider id reaches this set, seeing it again is terminal for
       // the current tool batch so we do not send partial tool responses.

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -49,6 +49,7 @@ import {
   isSystemReminderContent,
   markDuplicateProviderToolCallResponseSent,
   findRepeatedDuplicateProviderToolCall,
+  getCachedToolCallFingerprint,
   isReplayOfHandledToolCall,
   recordHandledToolCall,
   isToolCallConcurrencySafe,
@@ -1758,8 +1759,11 @@ export async function runNonInteractive(
             ? isReplayOfHandledToolCall(
                 handledToolCallFingerprints,
                 providerCallId,
-                request.name,
-                request.args,
+                getCachedToolCallFingerprint(
+                  request,
+                  request.name,
+                  request.args,
+                ),
               )
             : false;
         };
@@ -1796,8 +1800,11 @@ export async function runNonInteractive(
             recordHandledToolCall(
               handledToolCallFingerprints,
               providerCallId,
-              requestInfo.name,
-              requestInfo.args,
+              getCachedToolCallFingerprint(
+                requestInfo,
+                requestInfo.name,
+                requestInfo.args,
+              ),
             );
             executableBatchRequests.push(requestInfo);
             continue;

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -36,6 +36,7 @@ import {
   ToolErrorType,
   ToolConfirmationOutcome,
   getRuntimeContentGenerator,
+  getToolCallFingerprint,
   runWithRuntimeContentGenerator,
 } from '@qwen-code/qwen-code-core';
 import type { Part, PartListUnion } from '@google/genai';
@@ -76,6 +77,11 @@ const MockedGeminiClientClass = vi.hoisted(() =>
     this.getHistoryFunctionResponseIds = vi
       .fn()
       .mockReturnValue(new Set<string>());
+    // Stream-side duplicate provider-id replay detection consults the
+    // fingerprint map; default to empty (no handled calls in history).
+    this.getHistoryToolCallFingerprints = vi
+      .fn()
+      .mockReturnValue(new Map<string, string>());
     this.getChatRecordingService = vi.fn().mockReturnValue({
       recordThought: vi.fn(),
       initialize: vi.fn(),
@@ -4782,7 +4788,10 @@ describe('useGeminiStream', () => {
               callId: 'tool-dup',
               providerCallId: 'tool-dup',
               name: 'shell',
-              args: { command: 'echo second' },
+              // Exact replay of the first call (same args): a
+              // different-args id collision would be a fresh call and
+              // no longer receives a duplicate response.
+              args: { command: 'echo first' },
               isClientInitiated: false,
               prompt_id: 'prompt-tui-dup',
             },
@@ -4924,9 +4933,16 @@ describe('useGeminiStream', () => {
 
   it('submits a synthetic response for history-paired duplicate provider ids without scheduling', async () => {
     const client = new MockedGeminiClientClass(mockConfig);
-    client.getHistoryFunctionResponseIds = vi
+    client.getHistoryToolCallFingerprints = vi
       .fn()
-      .mockReturnValue(new Set(['tool-history']));
+      .mockReturnValue(
+        new Map([
+          [
+            'tool-history',
+            getToolCallFingerprint('shell', { command: 'echo duplicate' }),
+          ],
+        ]),
+      );
 
     mockSendMessageStream
       .mockReturnValueOnce(
@@ -4969,11 +4985,66 @@ describe('useGeminiStream', () => {
     expect(client.recordCompletedToolCall).not.toHaveBeenCalled();
   });
 
+  it('schedules an id-colliding tool call whose args differ from the handled call', async () => {
+    const client = new MockedGeminiClientClass(mockConfig);
+    client.getHistoryToolCallFingerprints = vi
+      .fn()
+      .mockReturnValue(
+        new Map([
+          [
+            'tool-history',
+            getToolCallFingerprint('shell', { command: 'echo duplicate' }),
+          ],
+        ]),
+      );
+
+    mockSendMessageStream.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: ServerGeminiEventType.ToolCallRequest,
+          value: {
+            callId: 'tool-history__qwen_dup_2',
+            providerCallId: 'tool-history',
+            name: 'shell',
+            args: { command: 'echo fresh command' },
+            isClientInitiated: false,
+            prompt_id: 'prompt-tui-collision',
+          },
+        };
+      })(),
+    );
+
+    const { result } = renderTestHook([], client);
+
+    await act(async () => {
+      await result.current.submitQuery('run shell');
+    });
+
+    await waitFor(() => {
+      expect(mockScheduleToolCalls).toHaveBeenCalledTimes(1);
+    });
+    expect(mockScheduleToolCalls.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        callId: 'tool-history__qwen_dup_2',
+        providerCallId: 'tool-history',
+        args: { command: 'echo fresh command' },
+      }),
+    ]);
+    expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+  });
+
   it('drops repeated history-paired duplicate provider ids after the first synthetic response', async () => {
     const client = new MockedGeminiClientClass(mockConfig);
-    client.getHistoryFunctionResponseIds = vi
+    client.getHistoryToolCallFingerprints = vi
       .fn()
-      .mockReturnValue(new Set(['tool-history']));
+      .mockReturnValue(
+        new Map([
+          [
+            'tool-history',
+            getToolCallFingerprint('shell', { command: 'echo duplicate' }),
+          ],
+        ]),
+      );
 
     mockSendMessageStream
       .mockReturnValueOnce(
@@ -4999,7 +5070,9 @@ describe('useGeminiStream', () => {
               callId: 'tool-history',
               providerCallId: 'tool-history',
               name: 'shell',
-              args: { command: 'echo duplicate again' },
+              // Exact replay (same args as the handled call): only a
+              // replay trips the repeated-duplicate circuit breaker.
+              args: { command: 'echo duplicate' },
               isClientInitiated: false,
               prompt_id: 'prompt-tui-history-loop',
             },

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -65,6 +65,8 @@ import {
   createDuplicateProviderToolCallResponse,
   markDuplicateProviderToolCallResponseSent,
   findRepeatedDuplicateProviderToolCall,
+  isReplayOfHandledToolCall,
+  recordHandledToolCall,
   AutonomousLoopTickResolver,
   didWriteProjectContextFile,
   refreshMemoryAfterManagedWrite,
@@ -834,7 +836,10 @@ export const useGeminiStream = (
       (!current?.endsWith('\0') || current === model)
     );
   }, []);
-  const handledProviderToolCallIdsRef = useRef<Set<string>>(new Set());
+  // Provider tool-call id → (name, args) fingerprint of calls admitted for
+  // execution in the current submit; merged with the history-derived map for
+  // duplicate provider-id replay detection.
+  const handledToolCallFingerprintsRef = useRef<Map<string, string>>(new Map());
   // Scoped to a top-level submit and cleared below before a new user prompt.
   // Repeated duplicate provider ids within that submit are terminal/drop-only.
   const duplicateProviderToolCallResponseIdsRef = useRef<Set<string>>(
@@ -2826,17 +2831,34 @@ export const useGeminiStream = (
           response: ToolCallResponseInfo;
         }> = [];
         let duplicatePromptId: string | undefined;
-        const historyCallIdsWithResponse: Set<string> = geminiClient
-          ? geminiClient.getHistoryFunctionResponseIds()
-          : new Set<string>();
-        const handledProviderIds = new Set([
-          ...handledProviderToolCallIdsRef.current,
-          ...historyCallIdsWithResponse,
-        ]);
+        // Copied so per-batch recording never mutates the accessor-owned
+        // map; in-flight entries from this submit are merged on top.
+        const handledToolCallFingerprints = new Map(
+          geminiClient ? geminiClient.getHistoryToolCallFingerprints() : [],
+        );
+        for (const [
+          providerCallId,
+          fingerprint,
+        ] of handledToolCallFingerprintsRef.current) {
+          if (!handledToolCallFingerprints.has(providerCallId)) {
+            handledToolCallFingerprints.set(providerCallId, fingerprint);
+          }
+        }
+        const isReplayOfHandledRequest = (
+          request: ToolCallRequestInfo,
+        ): boolean =>
+          request.providerCallId
+            ? isReplayOfHandledToolCall(
+                handledToolCallFingerprints,
+                request.providerCallId,
+                request.name,
+                request.args,
+              )
+            : false;
         const repeatedDuplicateRequest = findRepeatedDuplicateProviderToolCall(
           toolCallRequests,
           (request) => request.providerCallId,
-          handledProviderIds,
+          isReplayOfHandledRequest,
           duplicateProviderToolCallResponseIdsRef.current,
         );
         if (repeatedDuplicateRequest?.providerCallId) {
@@ -2857,10 +2879,7 @@ export const useGeminiStream = (
             continue;
           }
 
-          if (
-            handledProviderToolCallIdsRef.current.has(providerCallId) ||
-            historyCallIdsWithResponse.has(providerCallId)
-          ) {
+          if (isReplayOfHandledRequest(request)) {
             markDuplicateProviderToolCallResponseSent(
               providerCallId,
               duplicateProviderToolCallResponseIdsRef.current,
@@ -2876,7 +2895,18 @@ export const useGeminiStream = (
             continue;
           }
 
-          handledProviderToolCallIdsRef.current.add(providerCallId);
+          recordHandledToolCall(
+            handledToolCallFingerprints,
+            providerCallId,
+            request.name,
+            request.args,
+          );
+          recordHandledToolCall(
+            handledToolCallFingerprintsRef.current,
+            providerCallId,
+            request.name,
+            request.args,
+          );
           executableToolCallRequests.push(request);
         }
 
@@ -3309,7 +3339,7 @@ export const useGeminiStream = (
         lastTurnUserItemRef.current = null;
         canUndoLastLoggedUserMessageRef.current = false;
         turnSawContentEventRef.current = false;
-        handledProviderToolCallIdsRef.current.clear();
+        handledToolCallFingerprintsRef.current.clear();
         duplicateProviderToolCallResponseIdsRef.current.clear();
         pendingDuplicateToolResponsesRef.current = [];
         immediateDuplicateToolResponsesRef.current = null;

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2832,8 +2832,10 @@ export const useGeminiStream = (
           response: ToolCallResponseInfo;
         }> = [];
         let duplicatePromptId: string | undefined;
-        // Copied so per-batch recording never mutates the accessor-owned
-        // map; in-flight entries from this submit are merged on top.
+        // The accessor returns a fresh map per call; copy anyway so a future
+        // cached accessor cannot turn per-batch recording into shared-state
+        // mutation. In-flight entries from this submit fill ids not already
+        // present in history (the history fingerprint for an id wins).
         const handledToolCallFingerprints = new Map(
           geminiClient ? geminiClient.getHistoryToolCallFingerprints() : [],
         );

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -65,6 +65,7 @@ import {
   createDuplicateProviderToolCallResponse,
   markDuplicateProviderToolCallResponseSent,
   findRepeatedDuplicateProviderToolCall,
+  getCachedToolCallFingerprint,
   isReplayOfHandledToolCall,
   recordHandledToolCall,
   AutonomousLoopTickResolver,
@@ -2851,8 +2852,11 @@ export const useGeminiStream = (
             ? isReplayOfHandledToolCall(
                 handledToolCallFingerprints,
                 request.providerCallId,
-                request.name,
-                request.args,
+                getCachedToolCallFingerprint(
+                  request,
+                  request.name,
+                  request.args,
+                ),
               )
             : false;
         const repeatedDuplicateRequest = findRepeatedDuplicateProviderToolCall(
@@ -2895,17 +2899,20 @@ export const useGeminiStream = (
             continue;
           }
 
-          recordHandledToolCall(
-            handledToolCallFingerprints,
-            providerCallId,
+          const requestFingerprint = getCachedToolCallFingerprint(
+            request,
             request.name,
             request.args,
           );
           recordHandledToolCall(
+            handledToolCallFingerprints,
+            providerCallId,
+            requestFingerprint,
+          );
+          recordHandledToolCall(
             handledToolCallFingerprintsRef.current,
             providerCallId,
-            request.name,
-            request.args,
+            requestFingerprint,
           );
           executableToolCallRequests.push(request);
         }

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -79,6 +79,8 @@ import { assembleSystemPrompt } from '../../core/prompts.js';
 import {
   dedupeToolCallsById,
   getProviderToolCallId,
+  isReplayOfHandledToolCall,
+  recordHandledToolCall,
 } from '../../core/toolCallIdUtils.js';
 import type {
   PromptConfig,
@@ -866,7 +868,7 @@ export class AgentCore {
     let turnCounter = 0;
     let finalText = '';
     let terminateMode: AgentTerminateMode | null = null;
-    const handledProviderToolCallIds = chat.getHistoryFunctionResponseIds();
+    const handledToolCallFingerprints = chat.getHistoryToolCallFingerprints();
     // Scoped to this reasoning loop. A second duplicate response for the same
     // provider id would keep deterministic providers in a tool-result loop.
     const duplicateProviderToolCallResponseIds = new Set<string>();
@@ -1135,7 +1137,7 @@ export class AgentCore {
             toolsList,
             currentResponseId,
             wasOutputTruncated,
-            handledProviderToolCallIds,
+            handledToolCallFingerprints,
             duplicateProviderToolCallResponseIds,
           );
           if (toolCallResult.repeatedDuplicateProviderToolCall) {
@@ -1543,7 +1545,7 @@ export class AgentCore {
     toolsList: FunctionDeclaration[],
     responseId?: string,
     wasOutputTruncated = false,
-    handledProviderToolCallIds = new Set<string>(),
+    handledToolCallFingerprints = new Map<string, string>(),
     duplicateProviderToolCallResponseIds = new Set<string>(),
   ): Promise<{
     messages: Content[];
@@ -1573,10 +1575,21 @@ export class AgentCore {
     // forks keep the parent's declaration prefix for cache sharing while
     // optionally narrowing which declared tools may actually run.
     const declaredToolNames = new Set(toolsList.map((t) => t.name));
+    const isReplayOfHandledCall = (fc: FunctionCall): boolean => {
+      const providerCallId = getProviderToolCallId(fc) ?? fc.id;
+      return providerCallId
+        ? isReplayOfHandledToolCall(
+            handledToolCallFingerprints,
+            providerCallId,
+            fc.name,
+            fc.args,
+          )
+        : false;
+    };
     const repeatedDuplicateCall = findRepeatedDuplicateProviderToolCall(
       uniqueFunctionCalls,
       (fc) => getProviderToolCallId(fc) ?? fc.id,
-      handledProviderToolCallIds,
+      isReplayOfHandledCall,
       duplicateProviderToolCallResponseIds,
     );
     if (repeatedDuplicateCall) {
@@ -1645,7 +1658,7 @@ export class AgentCore {
       }
 
       if (providerCallId) {
-        if (handledProviderToolCallIds.has(providerCallId)) {
+        if (isReplayOfHandledCall(fc)) {
           markDuplicateProviderToolCallResponseSent(
             providerCallId,
             duplicateProviderToolCallResponseIds,
@@ -1691,7 +1704,12 @@ export class AgentCore {
           });
           continue;
         }
-        handledProviderToolCallIds.add(providerCallId);
+        recordHandledToolCall(
+          handledToolCallFingerprints,
+          providerCallId,
+          fc.name,
+          fc.args,
+        );
       }
       authorizedCalls.push(fc);
     }

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -869,7 +869,11 @@ export class AgentCore {
     let turnCounter = 0;
     let finalText = '';
     let terminateMode: AgentTerminateMode | null = null;
-    const handledToolCallFingerprints = chat.getHistoryToolCallFingerprints();
+    // Fresh map per call today; copy so a future cached accessor cannot
+    // turn this loop's cross-round recording into shared-state mutation.
+    const handledToolCallFingerprints = new Map(
+      chat.getHistoryToolCallFingerprints(),
+    );
     // Scoped to this reasoning loop. A second duplicate response for the same
     // provider id would keep deterministic providers in a tool-result loop.
     const duplicateProviderToolCallResponseIds = new Set<string>();

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -78,6 +78,7 @@ import { GeminiChat } from '../../core/geminiChat.js';
 import { assembleSystemPrompt } from '../../core/prompts.js';
 import {
   dedupeToolCallsById,
+  getFunctionCallFingerprint,
   getProviderToolCallId,
   isReplayOfHandledToolCall,
   recordHandledToolCall,
@@ -1581,8 +1582,7 @@ export class AgentCore {
         ? isReplayOfHandledToolCall(
             handledToolCallFingerprints,
             providerCallId,
-            fc.name,
-            fc.args,
+            getFunctionCallFingerprint(fc),
           )
         : false;
     };
@@ -1707,8 +1707,7 @@ export class AgentCore {
         recordHandledToolCall(
           handledToolCallFingerprints,
           providerCallId,
-          fc.name,
-          fc.args,
+          getFunctionCallFingerprint(fc),
         );
       }
       authorizedCalls.push(fc);

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -2434,6 +2434,111 @@ describe('subagent.ts', () => {
         expect(scope.getTerminateMode()).toBe(AgentTerminateMode.GOAL);
       });
 
+      it('should keep suppressing replays of the original call after an id-colliding execution', async () => {
+        const listFilesToolDef: FunctionDeclaration = {
+          name: 'list_files',
+          description: 'Lists files',
+          parameters: { type: Type.OBJECT, properties: {} },
+        };
+
+        const { config } = await createMockConfig({
+          getFunctionDeclarationsFiltered: vi
+            .fn()
+            .mockReturnValue([listFilesToolDef]),
+          getTool: vi.fn().mockReturnValue(undefined),
+        });
+        const toolConfig: ToolConfig = { tools: ['list_files'] };
+        // Rounds share one usedIds set so the collisions get _2 and _3
+        // suffixes, mirroring how normalization accumulates across rounds.
+        const usedIds = new Set(['call_1']);
+        const [round2Part] = normalizeModelToolCallIds(
+          [
+            {
+              functionCall: {
+                id: 'call_1',
+                name: 'list_files',
+                args: { path: 'src' },
+              },
+            },
+          ],
+          usedIds,
+          new Set<string>(),
+        );
+        const [round3Part] = normalizeModelToolCallIds(
+          [
+            {
+              functionCall: {
+                id: 'call_1',
+                name: 'list_files',
+                args: { path: '.' },
+              },
+            },
+          ],
+          usedIds,
+          new Set<string>(),
+        );
+
+        mockSendMessageStream.mockImplementation(
+          createMockStream([
+            [{ id: 'call_1', name: 'list_files', args: { path: '.' } }],
+            [round2Part!.functionCall!],
+            [round3Part!.functionCall!],
+            'stop',
+          ]),
+        );
+
+        const listFilesInvocation = {
+          params: { path: '.' },
+          getDescription: vi.fn().mockReturnValue('List files'),
+          toolLocations: vi.fn().mockReturnValue([]),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          execute: vi.fn().mockResolvedValue({
+            llmContent: 'file1.txt',
+            returnDisplay: 'Listed 1 file',
+          }),
+        };
+        const listFilesTool = {
+          name: 'list_files',
+          displayName: 'List Files',
+          description: 'List files in directory',
+          kind: 'READ' as const,
+          schema: listFilesToolDef,
+          build: vi.fn().mockImplementation(() => listFilesInvocation),
+          canUpdateOutput: false,
+          isOutputMarkdown: true,
+        } as unknown as AnyDeclarativeTool;
+        vi.mocked(
+          (config.getToolRegistry() as unknown as ToolRegistry).getTool,
+        ).mockImplementation((name: string) =>
+          name === 'list_files' ? listFilesTool : undefined,
+        );
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          toolConfig,
+        );
+
+        await scope.execute(new ContextState());
+
+        // Round 1 (original) and round 2 (different-args collision) execute;
+        // round 3 replays the ORIGINAL call under the reused id and must be
+        // suppressed — first-occurrence recording keeps the id naming the
+        // round-1 call even after the collision executed.
+        expect(listFilesInvocation.execute).toHaveBeenCalledTimes(2);
+        expect(mockSendMessageStream).toHaveBeenCalledTimes(4);
+        const fourthCallArgs = mockSendMessageStream.mock.calls[3][1];
+        const parts = fourthCallArgs.message as Part[];
+        expect(parts[0].functionResponse?.id).toBe('call_1__qwen_dup_3');
+        expect(parts[0].functionResponse?.response?.['error']).toContain(
+          'Duplicate provider tool call id "call_1"',
+        );
+        expect(scope.getTerminateMode()).toBe(AgentTerminateMode.GOAL);
+      });
+
       it('should execute only the first duplicate functionCall id in one model turn', async () => {
         const listFilesToolDef: FunctionDeclaration = {
           name: 'list_files',

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -30,7 +30,10 @@ import {
   AuthType,
 } from '../../core/contentGenerator.js';
 import { GeminiChat } from '../../core/geminiChat.js';
-import { normalizeModelToolCallIds } from '../../core/toolCallIdUtils.js';
+import {
+  getToolCallFingerprint,
+  normalizeModelToolCallIds,
+} from '../../core/toolCallIdUtils.js';
 import { executeToolCall } from '../../core/nonInteractiveToolExecutor.js';
 import { getInitialChatHistory } from '../../utils/environmentContext.js';
 import type { ToolRegistry } from '../../tools/tool-registry.js';
@@ -311,7 +314,7 @@ describe('subagent.ts', () => {
 
   describe('AgentHeadless', () => {
     let mockSendMessageStream: Mock;
-    let mockGetHistoryFunctionResponseIds: Mock;
+    let mockGetHistoryToolCallFingerprints: Mock;
 
     const defaultModelConfig: ModelConfig = {
       model: 'qwen3-coder-plus',
@@ -343,13 +346,15 @@ describe('subagent.ts', () => {
       });
 
       mockSendMessageStream = vi.fn();
-      mockGetHistoryFunctionResponseIds = vi.fn(() => new Set<string>());
+      mockGetHistoryToolCallFingerprints = vi.fn(
+        () => new Map<string, string>(),
+      );
       vi.mocked(GeminiChat).mockImplementation(
         () =>
           ({
             sendMessageStream: mockSendMessageStream,
             setLastPromptTokenCount: vi.fn(),
-            getHistoryFunctionResponseIds: mockGetHistoryFunctionResponseIds,
+            getHistoryToolCallFingerprints: mockGetHistoryToolCallFingerprints,
           }) as unknown as GeminiChat,
       );
 
@@ -2258,7 +2263,11 @@ describe('subagent.ts', () => {
           new Set(['call_1']),
           new Set<string>(),
         );
-        mockGetHistoryFunctionResponseIds.mockReturnValue(new Set(['call_1']));
+        mockGetHistoryToolCallFingerprints.mockReturnValue(
+          new Map([
+            ['call_1', getToolCallFingerprint('list_files', { path: '.' })],
+          ]),
+        );
 
         mockSendMessageStream.mockImplementation(
           createMockStream([[duplicateNormalizedPart!.functionCall!], 'stop']),
@@ -2329,6 +2338,99 @@ describe('subagent.ts', () => {
         expect(parts[0].functionResponse?.response?.['error']).toContain(
           'Duplicate provider tool call id "call_1"',
         );
+        expect(scope.getTerminateMode()).toBe(AgentTerminateMode.GOAL);
+      });
+
+      it('should execute an id-colliding tool call whose args differ from the handled call', async () => {
+        const listFilesToolDef: FunctionDeclaration = {
+          name: 'list_files',
+          description: 'Lists files',
+          parameters: { type: Type.OBJECT, properties: {} },
+        };
+
+        const { config } = await createMockConfig({
+          getFunctionDeclarationsFiltered: vi
+            .fn()
+            .mockReturnValue([listFilesToolDef]),
+          getTool: vi.fn().mockReturnValue(undefined),
+        });
+        const toolConfig: ToolConfig = { tools: ['list_files'] };
+        const [collidingNormalizedPart] = normalizeModelToolCallIds(
+          [
+            {
+              functionCall: {
+                id: 'call_1',
+                name: 'list_files',
+                args: { path: 'src' },
+              },
+            },
+          ],
+          new Set(['call_1']),
+          new Set<string>(),
+        );
+        mockGetHistoryToolCallFingerprints.mockReturnValue(
+          new Map([
+            ['call_1', getToolCallFingerprint('list_files', { path: '.' })],
+          ]),
+        );
+
+        mockSendMessageStream.mockImplementation(
+          createMockStream([[collidingNormalizedPart!.functionCall!], 'stop']),
+        );
+
+        const listFilesInvocation = {
+          params: { path: 'src' },
+          getDescription: vi.fn().mockReturnValue('List files'),
+          toolLocations: vi.fn().mockReturnValue([]),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          execute: vi.fn().mockResolvedValue({
+            llmContent: 'src/main.ts',
+            returnDisplay: 'Listed 1 file',
+          }),
+        };
+        const listFilesTool = {
+          name: 'list_files',
+          displayName: 'List Files',
+          description: 'List files in directory',
+          kind: 'READ' as const,
+          schema: listFilesToolDef,
+          build: vi.fn().mockImplementation(() => listFilesInvocation),
+          canUpdateOutput: false,
+          isOutputMarkdown: true,
+        } as unknown as AnyDeclarativeTool;
+        vi.mocked(
+          (config.getToolRegistry() as unknown as ToolRegistry).getTool,
+        ).mockImplementation((name: string) =>
+          name === 'list_files' ? listFilesTool : undefined,
+        );
+
+        const toolResultEvents: AgentToolResultEvent[] = [];
+        const eventEmitter = new AgentEventEmitter();
+        eventEmitter.on(AgentEventType.TOOL_RESULT, (event: unknown) => {
+          toolResultEvents.push(event as AgentToolResultEvent);
+        });
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          promptConfig,
+          defaultModelConfig,
+          defaultRunConfig,
+          toolConfig,
+          eventEmitter,
+        );
+
+        await scope.execute(new ContextState());
+
+        expect(listFilesInvocation.execute).toHaveBeenCalledTimes(1);
+        expect(toolResultEvents).toHaveLength(1);
+        expect(toolResultEvents[0].callId).toBe('call_1__qwen_dup_2');
+        expect(toolResultEvents[0].error).toBeUndefined();
+
+        const secondCallArgs = mockSendMessageStream.mock.calls[1][1];
+        const parts = secondCallArgs.message as Part[];
+        expect(parts[0].functionResponse?.id).toBe('call_1__qwen_dup_2');
+        expect(parts[0].functionResponse?.response?.['error']).toBeUndefined();
         expect(scope.getTerminateMode()).toBe(AgentTerminateMode.GOAL);
       });
 
@@ -2670,7 +2772,9 @@ describe('subagent.ts', () => {
             ({
               sendMessageStream: mockSendMessageStream,
               setLastPromptTokenCount: vi.fn(),
-              getHistoryFunctionResponseIds: vi.fn(() => new Set<string>()),
+              getHistoryToolCallFingerprints: vi.fn(
+                () => new Map<string, string>(),
+              ),
             }) as unknown as GeminiChat,
         );
 
@@ -2764,7 +2868,9 @@ describe('subagent.ts', () => {
             ({
               sendMessageStream: mockSendMessageStream,
               setLastPromptTokenCount: vi.fn(),
-              getHistoryFunctionResponseIds: vi.fn(() => new Set<string>()),
+              getHistoryToolCallFingerprints: vi.fn(
+                () => new Map<string, string>(),
+              ),
             }) as unknown as GeminiChat,
         );
 
@@ -2830,7 +2936,9 @@ describe('subagent.ts', () => {
             ({
               sendMessageStream: mockSendMessageStream,
               setLastPromptTokenCount: vi.fn(),
-              getHistoryFunctionResponseIds: vi.fn(() => new Set<string>()),
+              getHistoryToolCallFingerprints: vi.fn(
+                () => new Map<string, string>(),
+              ),
             }) as unknown as GeminiChat,
         );
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -670,6 +670,16 @@ export class GeminiClient {
   }
 
   /**
+   * Walk-only accessor for the handled tool-call id → (name, args)
+   * fingerprint map used by duplicate provider-id replay detection. Same
+   * no-clone rationale as {@link getHistoryFunctionResponseIds}. See
+   * `GeminiChat.getHistoryToolCallFingerprints` for the implementation.
+   */
+  getHistoryToolCallFingerprints(): Map<string, string> {
+    return this.getChat().getHistoryToolCallFingerprints();
+  }
+
+  /**
    * Pop orphaned trailing user entries from the in-memory chat history.
    * Used by:
    *   - The Retry submit path (sendMessageStream below), which drops a

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -1158,6 +1158,46 @@ describe('CoreToolScheduler', () => {
     ).toBe(0);
   });
 
+  it('does not leak the path-unescape rewrite into the caller-owned request args', async () => {
+    const readExecute = vi.fn().mockResolvedValue({
+      llmContent: 'read',
+      returnDisplay: 'read',
+    });
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName: new Map([
+          [
+            ToolNames.READ_FILE,
+            new MockTool({ name: ToolNames.READ_FILE, execute: readExecute }),
+          ],
+        ]),
+      });
+    // Callers pass args that may alias the model-emitted functionCall part
+    // stored in chat history; the scheduler's in-place PATH_ARG_KEYS
+    // unescape must land on its own cloned copy, or the rewrite leaks into
+    // history and skews the duplicate-replay fingerprints derived from it.
+    const callerArgs = { file_path: '/tmp/my\\ docs/a.txt' };
+    const callerRequest = {
+      callId: 'escaped-path-call',
+      name: ToolNames.READ_FILE,
+      args: callerArgs,
+      isClientInitiated: false,
+      prompt_id: 'prompt-escaped-path',
+    };
+
+    await scheduler.schedule([callerRequest], new AbortController().signal);
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalledOnce();
+    });
+
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as CompletedToolCall[];
+    expect(completedCalls[0].request.args['file_path']).toBe(
+      '/tmp/my docs/a.txt',
+    );
+    expect(callerArgs.file_path).toBe('/tmp/my\\ docs/a.txt');
+  });
+
   it('marks the budget-exempt plan reminder unchanged in the scheduler pass', async () => {
     boundaryDiagnosticsEnabled.value = true;
     const reminder = getPlanModeSystemReminder(false);

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -2324,7 +2324,14 @@ export class CoreToolScheduler {
       }
       const requestsToProcess = dedupeRequestsByCallId(
         Array.isArray(request) ? request : [request],
-      );
+      ).map((item) => ({ ...item, args: structuredClone(item.args) }));
+      // args are cloned at intake: callers pass args that may alias the
+      // model-emitted functionCall part stored in chat history, and
+      // _executeToolCallBody later rewrites PATH_ARG_KEYS on request.args in
+      // place (a persistence the post-'ask' bounce re-execution relies on).
+      // Without the clone those rewrites would leak into history and skew
+      // the (name, args) fingerprints that duplicate-replay detection
+      // derives from it.
       const planModeEntryBoundaryIndex = findPlanModeEntryBatchBoundaryIndex(
         requestsToProcess.map((item) => canonicalToolName(item.name)),
       );

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -24,6 +24,7 @@ import {
   type StreamEvent,
 } from './geminiChat.js';
 import { RETRYABLE_STREAM_TRANSPORT_CODES } from './stream-transport-retry.js';
+import { getToolCallFingerprint } from './toolCallIdUtils.js';
 import { classifyRetryError } from '../utils/retryErrorClassification.js';
 import { StreamContentError } from './openaiContentGenerator/pipeline.js';
 import { OpenAIContentGenerator } from './openaiContentGenerator/openaiContentGenerator.js';
@@ -5658,6 +5659,55 @@ describe('GeminiChat', async () => {
       const second = chat.getHistoryFunctionResponseIds();
       expect(second.has('cid_immut')).toBe(true);
       expect(second.has('cid_FAKE')).toBe(false);
+    });
+  });
+
+  describe('getHistoryToolCallFingerprints', () => {
+    it('returns an empty Map for empty history', () => {
+      expect(chat.getHistoryToolCallFingerprints()).toEqual(new Map());
+    });
+
+    it('maps only responded functionCall ids to (name, args) fingerprints', () => {
+      chat.setHistory([
+        { role: 'user', parts: [{ text: 'go' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'cid_a',
+                name: 'read_file',
+                args: { file_path: 'a.ts' },
+              },
+            },
+            {
+              functionCall: {
+                id: 'cid_unanswered',
+                name: 'read_file',
+                args: { file_path: 'b.ts' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'cid_a',
+                name: 'read_file',
+                response: { output: 'a' },
+              },
+            },
+          ],
+        },
+      ]);
+
+      const fingerprints = chat.getHistoryToolCallFingerprints();
+      expect([...fingerprints.keys()]).toEqual(['cid_a']);
+      expect(fingerprints.get('cid_a')).toBe(
+        getToolCallFingerprint('read_file', { file_path: 'a.ts' }),
+      );
     });
   });
 

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -5709,6 +5709,76 @@ describe('GeminiChat', async () => {
         getToolCallFingerprint('read_file', { file_path: 'a.ts' }),
       );
     });
+
+    it('keeps the first answered call for an id reused across turns and skips orphan response ids', () => {
+      // The stored fingerprint is the replay oracle at every entry point:
+      // for providers that reuse ids across turns, the id must keep naming
+      // the call that first executed under it, and a functionResponse with
+      // no matching functionCall must contribute nothing.
+      chat.setHistory([
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'cid_reused',
+                name: 'read_file',
+                args: { file_path: 'a.ts' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'cid_reused',
+                name: 'read_file',
+                response: { output: 'a' },
+              },
+            },
+            {
+              functionResponse: {
+                id: 'cid_orphan',
+                name: 'read_file',
+                response: { output: 'x' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'cid_reused',
+                name: 'read_file',
+                args: { file_path: 'b.ts' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'cid_reused',
+                name: 'read_file',
+                response: { output: 'b' },
+              },
+            },
+          ],
+        },
+      ]);
+
+      const fingerprints = chat.getHistoryToolCallFingerprints();
+      expect([...fingerprints.keys()]).toEqual(['cid_reused']);
+      expect(fingerprints.get('cid_reused')).toBe(
+        getToolCallFingerprint('read_file', { file_path: 'a.ts' }),
+      );
+    });
   });
 
   describe('getHistoryTail', () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -117,6 +117,7 @@ import {
 import { RETRYABLE_STREAM_TRANSPORT_CODES } from './stream-transport-retry.js';
 import {
   collectToolCallIdsFromHistory,
+  getFunctionCallFingerprint,
   normalizeModelToolCallIds,
   reserveModelToolCallId,
 } from './toolCallIdUtils.js';
@@ -4148,6 +4149,42 @@ export class GeminiChat {
       }
     }
     return ids;
+  }
+
+  /**
+   * Map of handled tool-call id → (name, args) fingerprint for duplicate
+   * provider-id replay detection: model-turn `functionCall`s whose id has a
+   * matching user-turn `functionResponse`. Walk-only, no clone, same
+   * rationale as {@link getHistoryFunctionResponseIds}; fingerprints of
+   * large args are cached per part object (see getFunctionCallFingerprint).
+   */
+  getHistoryToolCallFingerprints(): Map<string, string> {
+    const fingerprintsById = new Map<string, string>();
+    const respondedIds = new Set<string>();
+    for (const entry of this.history) {
+      if (entry.role === 'user') {
+        for (const part of entry.parts ?? []) {
+          const id = part.functionResponse?.id;
+          if (id) respondedIds.add(id);
+        }
+        continue;
+      }
+      for (const part of entry.parts ?? []) {
+        const functionCall = part.functionCall;
+        if (functionCall?.id && !fingerprintsById.has(functionCall.id)) {
+          fingerprintsById.set(
+            functionCall.id,
+            getFunctionCallFingerprint(functionCall),
+          );
+        }
+      }
+    }
+    const handled = new Map<string, string>();
+    for (const id of respondedIds) {
+      const fingerprint = fingerprintsById.get(id);
+      if (fingerprint !== undefined) handled.set(id, fingerprint);
+    }
+    return handled;
   }
 
   /**

--- a/packages/core/src/core/toolCallIdUtils.test.ts
+++ b/packages/core/src/core/toolCallIdUtils.test.ts
@@ -10,7 +10,10 @@ import {
   collectToolCallIdsFromHistory,
   dedupeToolCallsById,
   getProviderToolCallId,
+  getToolCallFingerprint,
+  isReplayOfHandledToolCall,
   normalizeModelToolCallIds,
+  recordHandledToolCall,
   reserveModelToolCallId,
 } from './toolCallIdUtils.js';
 
@@ -160,5 +163,65 @@ describe('toolCallIdUtils', () => {
       calls[3],
       calls[4],
     ]);
+  });
+
+  describe('replay detection fingerprints', () => {
+    it('treats a handled id as a replay only when name and args match', () => {
+      const handled = new Map<string, string>();
+      recordHandledToolCall(handled, 'shell_0', 'run_shell_command', {
+        command: 'ls -la',
+      });
+
+      expect(
+        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
+          command: 'ls -la',
+        }),
+      ).toBe(true);
+      expect(
+        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
+          command: 'git status',
+        }),
+      ).toBe(false);
+      expect(
+        isReplayOfHandledToolCall(handled, 'shell_0', 'read_file', {
+          command: 'ls -la',
+        }),
+      ).toBe(false);
+      expect(
+        isReplayOfHandledToolCall(handled, 'shell_1', 'run_shell_command', {
+          command: 'ls -la',
+        }),
+      ).toBe(false);
+    });
+
+    it('ignores argument key order in fingerprints', () => {
+      expect(getToolCallFingerprint('edit', { a: 1, b: [2, 3] })).toBe(
+        getToolCallFingerprint('edit', { b: [2, 3], a: 1 }),
+      );
+      expect(getToolCallFingerprint('edit', { a: 1 })).not.toBe(
+        getToolCallFingerprint('edit', { a: 2 }),
+      );
+    });
+
+    it('keeps the first occurrence when recording a colliding id', () => {
+      const handled = new Map<string, string>();
+      recordHandledToolCall(handled, 'shell_0', 'run_shell_command', {
+        command: 'first',
+      });
+      recordHandledToolCall(handled, 'shell_0', 'run_shell_command', {
+        command: 'second',
+      });
+
+      expect(
+        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
+          command: 'first',
+        }),
+      ).toBe(true);
+      expect(
+        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
+          command: 'second',
+        }),
+      ).toBe(false);
+    });
   });
 });

--- a/packages/core/src/core/toolCallIdUtils.test.ts
+++ b/packages/core/src/core/toolCallIdUtils.test.ts
@@ -5,11 +5,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { Content, Part } from '@google/genai';
+import type { Content, FunctionCall, Part } from '@google/genai';
 import {
   collectToolCallIdsFromHistory,
   dedupeToolCallsById,
   getCachedToolCallFingerprint,
+  getFunctionCallFingerprint,
   getProviderToolCallId,
   getToolCallFingerprint,
   isReplayOfHandledToolCall,
@@ -237,6 +238,19 @@ describe('toolCallIdUtils', () => {
       expect(
         getCachedToolCallFingerprint(request, request.name, request.args),
       ).toBe(first);
+    });
+
+    it('serves getFunctionCallFingerprint cache hits without rehashing', () => {
+      const functionCall: FunctionCall = {
+        id: 'call_cache',
+        name: 'write_file',
+        args: { file_path: 'a.ts', content: 'original' },
+      };
+
+      const first = getFunctionCallFingerprint(functionCall);
+      (functionCall.args as Record<string, unknown>)['content'] = 'mutated';
+
+      expect(getFunctionCallFingerprint(functionCall)).toBe(first);
     });
 
     it('keeps the first occurrence when recording a colliding id', () => {

--- a/packages/core/src/core/toolCallIdUtils.test.ts
+++ b/packages/core/src/core/toolCallIdUtils.test.ts
@@ -9,6 +9,7 @@ import type { Content, Part } from '@google/genai';
 import {
   collectToolCallIdsFromHistory,
   dedupeToolCallsById,
+  getCachedToolCallFingerprint,
   getProviderToolCallId,
   getToolCallFingerprint,
   isReplayOfHandledToolCall,
@@ -168,29 +169,41 @@ describe('toolCallIdUtils', () => {
   describe('replay detection fingerprints', () => {
     it('treats a handled id as a replay only when name and args match', () => {
       const handled = new Map<string, string>();
-      recordHandledToolCall(handled, 'shell_0', 'run_shell_command', {
-        command: 'ls -la',
-      });
+      recordHandledToolCall(
+        handled,
+        'shell_0',
+        getToolCallFingerprint('run_shell_command', { command: 'ls -la' }),
+      );
 
       expect(
-        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
-          command: 'ls -la',
-        }),
+        isReplayOfHandledToolCall(
+          handled,
+          'shell_0',
+          getToolCallFingerprint('run_shell_command', { command: 'ls -la' }),
+        ),
       ).toBe(true);
       expect(
-        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
-          command: 'git status',
-        }),
+        isReplayOfHandledToolCall(
+          handled,
+          'shell_0',
+          getToolCallFingerprint('run_shell_command', {
+            command: 'git status',
+          }),
+        ),
       ).toBe(false);
       expect(
-        isReplayOfHandledToolCall(handled, 'shell_0', 'read_file', {
-          command: 'ls -la',
-        }),
+        isReplayOfHandledToolCall(
+          handled,
+          'shell_0',
+          getToolCallFingerprint('read_file', { command: 'ls -la' }),
+        ),
       ).toBe(false);
       expect(
-        isReplayOfHandledToolCall(handled, 'shell_1', 'run_shell_command', {
-          command: 'ls -la',
-        }),
+        isReplayOfHandledToolCall(
+          handled,
+          'shell_1',
+          getToolCallFingerprint('run_shell_command', { command: 'ls -la' }),
+        ),
       ).toBe(false);
     });
 
@@ -203,24 +216,55 @@ describe('toolCallIdUtils', () => {
       );
     });
 
+    it('caches the fingerprint per carrier object, hashing args once', () => {
+      const request = {
+        name: 'run_shell_command',
+        args: { command: 'echo once' },
+      };
+      const first = getCachedToolCallFingerprint(
+        request,
+        request.name,
+        request.args,
+      );
+      expect(first).toBe(
+        getToolCallFingerprint('run_shell_command', { command: 'echo once' }),
+      );
+
+      // Mutating the args afterwards must not change the cached identity:
+      // the cache assumes a carrier's call identity never changes, so the
+      // second lookup is a pure cache hit with no re-hash.
+      request.args.command = 'echo mutated';
+      expect(
+        getCachedToolCallFingerprint(request, request.name, request.args),
+      ).toBe(first);
+    });
+
     it('keeps the first occurrence when recording a colliding id', () => {
       const handled = new Map<string, string>();
-      recordHandledToolCall(handled, 'shell_0', 'run_shell_command', {
-        command: 'first',
-      });
-      recordHandledToolCall(handled, 'shell_0', 'run_shell_command', {
-        command: 'second',
-      });
+      recordHandledToolCall(
+        handled,
+        'shell_0',
+        getToolCallFingerprint('run_shell_command', { command: 'first' }),
+      );
+      recordHandledToolCall(
+        handled,
+        'shell_0',
+        getToolCallFingerprint('run_shell_command', { command: 'second' }),
+      );
 
       expect(
-        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
-          command: 'first',
-        }),
+        isReplayOfHandledToolCall(
+          handled,
+          'shell_0',
+          getToolCallFingerprint('run_shell_command', { command: 'first' }),
+        ),
       ).toBe(true);
       expect(
-        isReplayOfHandledToolCall(handled, 'shell_0', 'run_shell_command', {
-          command: 'second',
-        }),
+        isReplayOfHandledToolCall(
+          handled,
+          'shell_0',
+          getToolCallFingerprint('run_shell_command', { command: 'second' }),
+        ),
       ).toBe(false);
     });
   });

--- a/packages/core/src/core/toolCallIdUtils.ts
+++ b/packages/core/src/core/toolCallIdUtils.ts
@@ -6,11 +6,17 @@
 
 import type { Content, FunctionCall, Part } from '@google/genai';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { getToolCallRepeatKey } from '../utils/tool-call-repeat-key.js';
 
 const DUPLICATE_ID_SUFFIX = '__qwen_dup_';
 const GENERATED_ID_PREFIX = 'call_qwen_';
 const PROVIDER_TOOL_CALL_ID = Symbol('providerToolCallId');
 const debugLogger = createDebugLogger('TOOL_CALL_IDS');
+
+// History functionCall parts are stable objects (accessors walk history in
+// place, without cloning), so fingerprints of large args — e.g. write_file
+// content — are computed once per call instead of once per dedup pass.
+const functionCallFingerprintCache = new WeakMap<FunctionCall, string>();
 
 type FunctionCallWithProviderId = FunctionCall & {
   [PROVIDER_TOOL_CALL_ID]?: string;
@@ -55,6 +61,70 @@ export function collectToolCallIdsFromHistory(
     }
   }
   return ids;
+}
+
+/**
+ * Identity of a tool call for duplicate provider-id replay detection: the
+ * same canonical (name, args) key the loop guards use, so "replay" means
+ * the exact call the provider already saw answered — not merely a reused
+ * id. Providers whose ids are only unique within a single response (e.g.
+ * `{name}_{index}` schemes that restart at 0) legitimately reuse ids for
+ * different calls; those must not be treated as replays.
+ */
+export function getToolCallFingerprint(
+  name: string | undefined,
+  args: unknown,
+): string {
+  return getToolCallRepeatKey(name ?? '', args ?? {});
+}
+
+export function getFunctionCallFingerprint(functionCall: FunctionCall): string {
+  let fingerprint = functionCallFingerprintCache.get(functionCall);
+  if (fingerprint === undefined) {
+    fingerprint = getToolCallFingerprint(functionCall.name, functionCall.args);
+    functionCallFingerprintCache.set(functionCall, fingerprint);
+  }
+  return fingerprint;
+}
+
+/**
+ * True when an incoming provider tool call replays an already-handled call:
+ * the provider id was handled before AND the (name, args) fingerprint
+ * matches the call that first executed under that id. An id collision with
+ * a different fingerprint is a fresh call and must execute (under the
+ * unique suffixed id assigned by {@link normalizeModelToolCallIds}).
+ */
+export function isReplayOfHandledToolCall(
+  handledToolCallFingerprints: ReadonlyMap<string, string>,
+  providerCallId: string,
+  name: string | undefined,
+  args: unknown,
+): boolean {
+  const handledFingerprint = handledToolCallFingerprints.get(providerCallId);
+  return (
+    handledFingerprint !== undefined &&
+    handledFingerprint === getToolCallFingerprint(name, args)
+  );
+}
+
+/**
+ * Records a call admitted for execution. First-occurrence semantics: a
+ * provider id keeps naming the call that first executed under it, so a
+ * later id-colliding call (executed under its suffixed id) does not
+ * redefine what counts as a replay of the original.
+ */
+export function recordHandledToolCall(
+  handledToolCallFingerprints: Map<string, string>,
+  providerCallId: string,
+  name: string | undefined,
+  args: unknown,
+): void {
+  if (!handledToolCallFingerprints.has(providerCallId)) {
+    handledToolCallFingerprints.set(
+      providerCallId,
+      getToolCallFingerprint(name, args),
+    );
+  }
 }
 
 export function normalizeModelToolCallIds(

--- a/packages/core/src/core/toolCallIdUtils.ts
+++ b/packages/core/src/core/toolCallIdUtils.ts
@@ -13,10 +13,11 @@ const GENERATED_ID_PREFIX = 'call_qwen_';
 const PROVIDER_TOOL_CALL_ID = Symbol('providerToolCallId');
 const debugLogger = createDebugLogger('TOOL_CALL_IDS');
 
-// History functionCall parts are stable objects (accessors walk history in
-// place, without cloning), so fingerprints of large args — e.g. write_file
-// content — are computed once per call instead of once per dedup pass.
-const functionCallFingerprintCache = new WeakMap<FunctionCall, string>();
+// Fingerprints are cached against the stable carrier object — a history or
+// stream FunctionCall part, or a ToolCallRequestInfo — so the args of a
+// given call (e.g. write_file content) are hashed once, not once per dedup
+// pass over it (breaker scan, admission loop, recording).
+const toolCallFingerprintCache = new WeakMap<object, string>();
 
 type FunctionCallWithProviderId = FunctionCall & {
   [PROVIDER_TOOL_CALL_ID]?: string;
@@ -78,13 +79,31 @@ export function getToolCallFingerprint(
   return getToolCallRepeatKey(name ?? '', args ?? {});
 }
 
-export function getFunctionCallFingerprint(functionCall: FunctionCall): string {
-  let fingerprint = functionCallFingerprintCache.get(functionCall);
+/**
+ * WeakMap-cached variant of {@link getToolCallFingerprint}, keyed by the
+ * stable object carrying the call (a `FunctionCall` part or a
+ * `ToolCallRequestInfo`). Callers must pass the same `name`/`args` the
+ * carrier holds; the cache assumes a carrier's call identity never changes.
+ */
+export function getCachedToolCallFingerprint(
+  carrier: object,
+  name: string | undefined,
+  args: unknown,
+): string {
+  let fingerprint = toolCallFingerprintCache.get(carrier);
   if (fingerprint === undefined) {
-    fingerprint = getToolCallFingerprint(functionCall.name, functionCall.args);
-    functionCallFingerprintCache.set(functionCall, fingerprint);
+    fingerprint = getToolCallFingerprint(name, args);
+    toolCallFingerprintCache.set(carrier, fingerprint);
   }
   return fingerprint;
+}
+
+export function getFunctionCallFingerprint(functionCall: FunctionCall): string {
+  return getCachedToolCallFingerprint(
+    functionCall,
+    functionCall.name,
+    functionCall.args,
+  );
 }
 
 /**
@@ -93,18 +112,15 @@ export function getFunctionCallFingerprint(functionCall: FunctionCall): string {
  * matches the call that first executed under that id. An id collision with
  * a different fingerprint is a fresh call and must execute (under the
  * unique suffixed id assigned by {@link normalizeModelToolCallIds}).
+ * `fingerprint` is the incoming call's fingerprint, computed once per call
+ * object via {@link getCachedToolCallFingerprint}.
  */
 export function isReplayOfHandledToolCall(
   handledToolCallFingerprints: ReadonlyMap<string, string>,
   providerCallId: string,
-  name: string | undefined,
-  args: unknown,
+  fingerprint: string,
 ): boolean {
-  const handledFingerprint = handledToolCallFingerprints.get(providerCallId);
-  return (
-    handledFingerprint !== undefined &&
-    handledFingerprint === getToolCallFingerprint(name, args)
-  );
+  return handledToolCallFingerprints.get(providerCallId) === fingerprint;
 }
 
 /**
@@ -116,14 +132,10 @@ export function isReplayOfHandledToolCall(
 export function recordHandledToolCall(
   handledToolCallFingerprints: Map<string, string>,
   providerCallId: string,
-  name: string | undefined,
-  args: unknown,
+  fingerprint: string,
 ): void {
   if (!handledToolCallFingerprints.has(providerCallId)) {
-    handledToolCallFingerprints.set(
-      providerCallId,
-      getToolCallFingerprint(name, args),
-    );
+    handledToolCallFingerprints.set(providerCallId, fingerprint);
   }
 }
 

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -57,21 +57,26 @@ vi.mock('../utils/errorReporting', () => ({
 describe('findRepeatedDuplicateProviderToolCall', () => {
   const getProviderCallId = (item: { providerCallId?: string }) =>
     item.providerCallId;
+  const replayOf =
+    (...handledIds: string[]) =>
+    (item: { providerCallId?: string }) =>
+      item.providerCallId !== undefined &&
+      handledIds.includes(item.providerCallId);
 
-  it('finds a handled provider id that already received a synthetic response', () => {
+  it('finds a replayed provider id that already received a synthetic response', () => {
     const items = [{ providerCallId: 'fresh' }, { providerCallId: 'handled' }];
 
     expect(
       findRepeatedDuplicateProviderToolCall(
         items,
         getProviderCallId,
-        new Set(['handled']),
+        replayOf('handled'),
         new Set(['handled']),
       ),
     ).toBe(items[1]);
   });
 
-  it('finds a handled provider id repeated within the same batch', () => {
+  it('finds a replayed provider id repeated within the same batch', () => {
     const items = [
       { providerCallId: 'handled' },
       { providerCallId: 'fresh' },
@@ -82,7 +87,7 @@ describe('findRepeatedDuplicateProviderToolCall', () => {
       findRepeatedDuplicateProviderToolCall(
         items,
         getProviderCallId,
-        new Set(['handled']),
+        replayOf('handled'),
         new Set<string>(),
       ),
     ).toBe(items[0]);
@@ -95,8 +100,21 @@ describe('findRepeatedDuplicateProviderToolCall', () => {
       findRepeatedDuplicateProviderToolCall(
         items,
         getProviderCallId,
-        new Set(['handled']),
+        replayOf('handled'),
         new Set<string>(),
+      ),
+    ).toBeUndefined();
+  });
+
+  it('ignores id collisions the replay predicate rejects, even after a synthetic response', () => {
+    const items = [{ providerCallId: 'handled' }];
+
+    expect(
+      findRepeatedDuplicateProviderToolCall(
+        items,
+        getProviderCallId,
+        () => false,
+        new Set(['handled']),
       ),
     ).toBeUndefined();
   });

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -225,7 +225,7 @@ function duplicateProviderToolCallMessage(providerCallId: string): string {
     `Duplicate provider tool call id "${providerCallId}" was already handled. ` +
     `The duplicate tool call was ignored and not executed again. If you ` +
     `intended to run this tool again, re-issue the call with a new unique ` +
-    `tool-call id.`
+    `tool-call id (or explicitly different arguments).`
   );
 }
 

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -221,7 +221,12 @@ function buildApiErrorReportContext(chat: GeminiChat, req: PartListUnion) {
 }
 
 function duplicateProviderToolCallMessage(providerCallId: string): string {
-  return `Duplicate provider tool call id "${providerCallId}" was already handled. The duplicate tool call was ignored and not executed again.`;
+  return (
+    `Duplicate provider tool call id "${providerCallId}" was already handled. ` +
+    `The duplicate tool call was ignored and not executed again. If you ` +
+    `intended to run this tool again, re-issue the call with a new unique ` +
+    `tool-call id.`
+  );
 }
 
 export function createDuplicateProviderToolCallResponse(
@@ -254,16 +259,25 @@ export function markDuplicateProviderToolCallResponseSent(
   duplicateProviderToolCallResponseIds.add(providerCallId);
 }
 
+/**
+ * Finds the first tool call in `items` that must trip the repeated-duplicate
+ * circuit breaker. `isReplayOfHandled` decides whether an item replays an
+ * already-handled call (same provider id AND same (name, args) fingerprint
+ * — see `isReplayOfHandledToolCall`); an id collision with different args is
+ * not a replay and never trips the breaker. A replay trips it once a
+ * synthetic duplicate response was already sent for its provider id, or when
+ * the same handled id replays more than once within one batch.
+ */
 export function findRepeatedDuplicateProviderToolCall<T>(
   items: readonly T[],
   getProviderCallId: (item: T) => string | undefined,
-  handledProviderToolCallIds: ReadonlySet<string>,
+  isReplayOfHandled: (item: T) => boolean,
   duplicateProviderToolCallResponseIds: ReadonlySet<string>,
 ): T | undefined {
   const repeatedProviderIds = new Map<string, number>();
   for (const item of items) {
     const providerCallId = getProviderCallId(item);
-    if (!providerCallId || !handledProviderToolCallIds.has(providerCallId)) {
+    if (!providerCallId || !isReplayOfHandled(item)) {
       continue;
     }
     repeatedProviderIds.set(
@@ -276,7 +290,7 @@ export function findRepeatedDuplicateProviderToolCall<T>(
     const providerCallId = getProviderCallId(item);
     return (
       providerCallId !== undefined &&
-      handledProviderToolCallIds.has(providerCallId) &&
+      isReplayOfHandled(item) &&
       (duplicateProviderToolCallResponseIds.has(providerCallId) ||
         (repeatedProviderIds.get(providerCallId) ?? 0) > 1)
     );

--- a/packages/core/src/services/loopDetectionService.test.ts
+++ b/packages/core/src/services/loopDetectionService.test.ts
@@ -18,7 +18,6 @@ import { LoopType } from '../telemetry/types.js';
 import {
   DEFAULT_MAX_TOOL_CALLS_PER_TURN,
   LoopDetectionService,
-  getToolCallRepeatKey,
 } from './loopDetectionService.js';
 
 vi.mock('../telemetry/loggers.js', () => ({
@@ -2037,32 +2036,6 @@ describe('LoopDetectionService', () => {
         expect.objectContaining({
           loop_type: 'alternating_tool_call_pattern',
         }),
-      );
-    });
-  });
-
-  describe('getToolCallRepeatKey', () => {
-    it('resolves legacy aliases to the same key as the canonical name', () => {
-      // Extracting the repeat key also canonicalized legacy aliases, which
-      // widens every detector keyed off it — pin that equivalence so a
-      // future split between classification and keying cannot ship silent.
-      expect(getToolCallRepeatKey('task', { subagent_type: 'explore' })).toBe(
-        getToolCallRepeatKey('agent', { subagent_type: 'explore' }),
-      );
-      expect(getToolCallRepeatKey('replace', { file: 'a.ts' })).toBe(
-        getToolCallRepeatKey('edit', { file: 'a.ts' }),
-      );
-      expect(getToolCallRepeatKey('search_file_content', { q: 'x' })).toBe(
-        getToolCallRepeatKey('grep_search', { q: 'x' }),
-      );
-    });
-
-    it('is stable across object key order but not across different args', () => {
-      expect(getToolCallRepeatKey('read_file', { a: 1, b: 2 })).toBe(
-        getToolCallRepeatKey('read_file', { b: 2, a: 1 }),
-      );
-      expect(getToolCallRepeatKey('read_file', { a: 1 })).not.toBe(
-        getToolCallRepeatKey('read_file', { a: 2 }),
       );
     });
   });

--- a/packages/core/src/services/loopDetectionService.ts
+++ b/packages/core/src/services/loopDetectionService.ts
@@ -18,7 +18,13 @@ import {
   LoopType,
 } from '../telemetry/types.js';
 import type { Config } from '../config/config.js';
-import { canonicalToolName } from '../tools/tool-names.js';
+import { getToolCallRepeatKey } from '../utils/tool-call-repeat-key.js';
+
+// Re-exported for existing importers (daemon turn-loop guard); the
+// implementation lives in a leaf module so replay detection in
+// toolCallIdUtils can share it without an import cycle through this
+// service's turn.js dependency.
+export { getToolCallRepeatKey };
 
 // Consecutive identical tool calls (same name + identical args) tolerated
 // before the always-on guard halts the turn. Repeating an identical call
@@ -93,44 +99,6 @@ export const DEFAULT_MAX_TOOL_CALLS_PER_TURN = 100;
 // that modern models making hundreds of legitimate calls per task are not
 // false-positived, while still bounding a pathological runaway.
 const ADAPTIVE_CAP_HARD_MULTIPLIER = 10;
-
-/**
- * Recursively canonicalizes a JSON-compatible value for stable hashing: object
- * keys are sorted (so property insertion order does not change the identity)
- * while array order is preserved. Used by getToolCallKey so two semantically
- * identical tool-call arguments that differ only in field order hash to the
- * same key — otherwise a stuck model could evade the repeat guards just by
- * reordering fields.
- */
-function canonicalizeForHash(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(canonicalizeForHash);
-  }
-  if (value !== null && typeof value === 'object') {
-    const source = value as Record<string, unknown>;
-    const sorted: Record<string, unknown> = {};
-    for (const key of Object.keys(source).sort()) {
-      sorted[key] = canonicalizeForHash(source[key]);
-    }
-    return sorted;
-  }
-  return value;
-}
-
-/**
- * Stable identity of a (tool, args) call for repeat tracking: a sha256 over
- * the canonicalized name and args (legacy aliases resolved, sorted object
- * keys, preserved array order), so identical calls that differ only in
- * field order — or in a legacy alias such as `task` vs `agent` — hash to
- * the same key, and large payloads (e.g. write_file content) are retained
- * as a fixed-size digest rather than the raw JSON. Shared with the daemon's
- * turn-loop guard (ACP Session) so both runtimes key repeats the same way.
- */
-export function getToolCallRepeatKey(toolName: string, args: unknown): string {
-  const argsString = JSON.stringify(canonicalizeForHash(args));
-  const keyString = `${canonicalToolName(toolName)}:${argsString}`;
-  return createHash('sha256').update(keyString).digest('hex');
-}
 
 /**
  * Halt predicate of the per-turn tool-call cap, shared with the daemon's

--- a/packages/core/src/utils/tool-call-repeat-key.test.ts
+++ b/packages/core/src/utils/tool-call-repeat-key.test.ts
@@ -31,4 +31,18 @@ describe('getToolCallRepeatKey', () => {
       getToolCallRepeatKey('read_file', { a: 2 }),
     );
   });
+
+  it('distinguishes args that differ only in a literal __proto__ own key', () => {
+    // JSON.parse preserves '__proto__' as an own enumerable key; the
+    // canonicalization must keep it as a data property instead of routing
+    // through the inherited setter, or two different calls collide on the
+    // same key — which the replay oracle would turn into a wrongly
+    // suppressed execution.
+    const plain = JSON.parse('{"a":1}');
+    const withProto = JSON.parse('{"a":1,"__proto__":{"x":1}}');
+
+    expect(getToolCallRepeatKey('edit', plain)).not.toBe(
+      getToolCallRepeatKey('edit', withProto),
+    );
+  });
 });

--- a/packages/core/src/utils/tool-call-repeat-key.test.ts
+++ b/packages/core/src/utils/tool-call-repeat-key.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getToolCallRepeatKey } from './tool-call-repeat-key.js';
+
+describe('getToolCallRepeatKey', () => {
+  it('resolves legacy aliases to the same key as the canonical name', () => {
+    // Extracting the repeat key also canonicalized legacy aliases, which
+    // widens every detector keyed off it — pin that equivalence so a
+    // future split between classification and keying cannot ship silent.
+    expect(getToolCallRepeatKey('task', { subagent_type: 'explore' })).toBe(
+      getToolCallRepeatKey('agent', { subagent_type: 'explore' }),
+    );
+    expect(getToolCallRepeatKey('replace', { file: 'a.ts' })).toBe(
+      getToolCallRepeatKey('edit', { file: 'a.ts' }),
+    );
+    expect(getToolCallRepeatKey('search_file_content', { q: 'x' })).toBe(
+      getToolCallRepeatKey('grep_search', { q: 'x' }),
+    );
+  });
+
+  it('is stable across object key order but not across different args', () => {
+    expect(getToolCallRepeatKey('read_file', { a: 1, b: 2 })).toBe(
+      getToolCallRepeatKey('read_file', { b: 2, a: 1 }),
+    );
+    expect(getToolCallRepeatKey('read_file', { a: 1 })).not.toBe(
+      getToolCallRepeatKey('read_file', { a: 2 }),
+    );
+  });
+});

--- a/packages/core/src/utils/tool-call-repeat-key.ts
+++ b/packages/core/src/utils/tool-call-repeat-key.ts
@@ -21,7 +21,11 @@ function canonicalizeForHash(value: unknown): unknown {
   }
   if (value !== null && typeof value === 'object') {
     const source = value as Record<string, unknown>;
-    const sorted: Record<string, unknown> = {};
+    // Null prototype so a literal '__proto__' own key (JSON.parse preserves
+    // it) becomes a plain data property instead of routing through the
+    // inherited setter and vanishing — two args differing only in
+    // '__proto__' must not collide on the same repeat key.
+    const sorted = Object.create(null) as Record<string, unknown>;
     for (const key of Object.keys(source).sort()) {
       sorted[key] = canonicalizeForHash(source[key]);
     }

--- a/packages/core/src/utils/tool-call-repeat-key.ts
+++ b/packages/core/src/utils/tool-call-repeat-key.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHash } from 'node:crypto';
+import { canonicalToolName } from '../tools/tool-names.js';
+
+/**
+ * Recursively canonicalizes a JSON-compatible value for stable hashing: object
+ * keys are sorted (so property insertion order does not change the identity)
+ * while array order is preserved. Used by getToolCallRepeatKey so two
+ * semantically identical tool-call arguments that differ only in field order
+ * hash to the same key — otherwise a stuck model could evade the repeat
+ * guards just by reordering fields.
+ */
+function canonicalizeForHash(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeForHash);
+  }
+  if (value !== null && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      sorted[key] = canonicalizeForHash(source[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Stable identity of a (tool, args) call for repeat tracking: a sha256 over
+ * the canonicalized name and args (legacy aliases resolved, sorted object
+ * keys, preserved array order), so identical calls that differ only in
+ * field order — or in a legacy alias such as `task` vs `agent` — hash to
+ * the same key, and large payloads (e.g. write_file content) are retained
+ * as a fixed-size digest rather than the raw JSON. Shared by the loop
+ * detection service, the daemon's turn-loop guard (ACP Session), and the
+ * duplicate provider tool-call replay detection so every runtime keys
+ * repeats the same way.
+ */
+export function getToolCallRepeatKey(toolName: string, args: unknown): string {
+  const argsString = JSON.stringify(canonicalizeForHash(args));
+  const keyString = `${canonicalToolName(toolName)}:${argsString}`;
+  return createHash('sha256').update(keyString).digest('hex');
+}


### PR DESCRIPTION
## What this PR does

The duplicate provider tool-call guard now identifies a replay by the provider id **and** a canonical fingerprint of the tool name and arguments — the same repeat key the loop guards already use. An id collision whose arguments differ from the call that originally executed under that id is treated as a fresh call and executes normally under the unique suffixed id that normalization already assigns. Exact same-arguments replays keep the existing protection unchanged at all four entry points (subagent runtime, TUI stream, non-interactive CLI, ACP daemon session): the first replay is answered with a synthetic duplicate error and a recurrence trips the circuit breaker. The synthetic duplicate message additionally tells the model to re-issue the call with a fresh tool-call id when a new invocation was intended, giving models that generate their own id tokens a recovery path. The fingerprint key lives in a leaf utility module (moved out of the loop detection service, which re-exports it unchanged) so the id-normalization layer can share it without an import cycle; the history-derived fingerprint map is walk-only with per-part caching so large arguments are hashed once, not once per dedup pass.

## Why it's needed

Some models emit tool-call ids that are only unique within a single response — e.g. an id shaped like `{name}_{index}` whose index restarts at 0 on any round. With id-only matching, a fresh call that happened to reuse an old id was misclassified as a replay: the second collision received the synthetic duplicate error and the third killed the whole turn via the circuit breaker, so once a model entered this mode every turn died by round three. Live daemon sessions showed exactly this signature: the model emitted `run_shell_command_0` with a different command each round, and every prompt terminated after two failed rounds (silently before the stacked base PR). The original #5014 replay bug — and the regression fixtures guarding it — are same id **and** same arguments, so argument-aware matching preserves that protection at full strength while eliminating the false positive. Pathological repetition that slips past the id layer remains bounded by the id-independent guards (consecutive-identical threshold, global same-call threshold, per-turn cap).

Stacked on #9435 (visible daemon stop for this breaker); both implement the committed design doc.

## Reviewer Test Plan

### How to verify

With a deterministic mock OpenAI-compatible provider that returns the same tool-call id (`run_shell_command_0`) on every round:

1. Different arguments each round (the false-positive scenario): every call must execute and the turn must run to completion. Previously the run halted on round 3 with `global_tool_call_duplicate`.
2. Identical arguments each round (a true replay): round 2 must receive the synthetic duplicate-error result without executing, and round 3 must stop the run with the visible `global_tool_call_duplicate` halt — unchanged protection.

Focused suites:

```
cd packages/core && npx vitest run src/core/turn.test.ts src/core/toolCallIdUtils.test.ts src/core/geminiChat.test.ts src/services/loopDetectionService.test.ts src/agents/runtime/agent-headless.test.ts src/agents/runtime/agent-core.test.ts
cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx src/acp-integration/session/Session.test.ts
```

Each entry point now carries the suppression case and the new different-args execution case side by side, so the fingerprint consultation is pinned from both directions.

### Evidence (Before & After)

Verified end-to-end on the bundled CLI against the mock provider above (isolated HOME, headless `--approval-mode yolo`):

Before (qwen 0.21.13, the released build): different-args scenario — round 2's fresh command was answered with `Duplicate provider tool call id "run_shell_command_0" was already handled...`, round 3 halted the run with `Loop detection halted the run (global_tool_call_duplicate: ...)`; the round-2/3 commands never executed.

After (this branch's `dist/cli.js`): different-args scenario — all three rounds executed (each round's tool result is real shell output) and the run finished with the model's final text. Same-args scenario — round 2 suppressed with the duplicate error, round 3 halted visibly with `global_tool_call_duplicate`; round 4 was never reached.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local bundle (`node dist/cli.js`) against a local mock OpenAI-compatible SSE server with a fake API key; unit suites via vitest.

## Risk & Scope

- Main risk or tradeoff: a replay of a later id-colliding execution (same raw id, arguments equal to a suffixed execution rather than the id's first call) executes once more and is bounded by the id-independent guards; a legitimate re-run whose arguments exactly equal the id's first execution is still suppressed once and breaker-stopped visibly — the improved message gives the model a recovery path. Both residuals are documented in the design doc.
- Not validated / out of scope: provider-side id-uniqueness fixes; Windows/Linux local runs (CI covers).
- Breaking changes / migration notes: the shared breaker helper's third parameter changed from a handled-id set to a replay predicate (internal API, all in-repo callers migrated).

## Linked Issues

Design doc committed under `docs/design/2026-08-19-duplicate-provider-toolcall-id-guard.md` (this PR implements decisions D2 and D3). Related history: #5014, #5038, #5657.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

重复 provider tool-call 防护现在以 provider id **加** 工具名与参数的规范化指纹（与 loop 守卫使用的同一 repeat key）识别重放。同 id 但参数与该 id 首次执行不同的碰撞视为全新调用，在归一化已分配的唯一后缀 id 下正常执行。同 id 同参数的精确重放在四个入口（subagent 运行时、TUI 流、非交互 CLI、ACP daemon 会话）保持既有保护不变：首次重放回注合成 duplicate 错误，再次出现触发熔断。合成 duplicate 消息追加提示：若确为新调用，请以新的 tool-call id 重新发起——给自产 id token 的模型恢复路径。指纹函数移至叶子工具模块（loop 检测服务原位转发导出），使 id 归一化层可共享而不引入 import 环；历史指纹映射为免克隆遍历并带按部件缓存，大参数只哈希一次而非每次去重都算。

## 为什么需要

某些模型产出的 tool-call id 仅在单次响应内唯一——例如形如 `{name}_{index}`、index 随时归零的 id。仅按 id 匹配时，恰好复用旧 id 的全新调用被误判为重放：第二次碰撞收到合成 duplicate 错误，第三次经熔断杀死整个 turn，模型一旦进入该模式，每个 turn 都在第三轮死亡。本地 daemon 会话呈现的正是该特征：模型每轮都发 `run_shell_command_0` 但命令各不相同，每个 prompt 两轮失败后终止（在堆叠的基础 PR 之前还是静默终止）。最初的 #5014 重放 bug 及其回归用例都是同 id **且**同参数，因此参数感知匹配在完整保留该保护的同时消除误判。绕过 id 层的病态重复仍由与 id 无关的守卫兜底（连续相同阈值、全局同调用阈值、每 turn 上限）。

堆叠于 #9435（该熔断的 daemon 可见终止）；两者共同实现已提交的设计文档。

## Reviewer 测试计划

### 如何验证

使用每轮都返回同一 tool-call id（`run_shell_command_0`）的确定性 mock OpenAI 兼容 provider：

1. 每轮参数不同（误判场景）：所有调用必须执行、turn 必须完整跑完。修复前第 3 轮以 `global_tool_call_duplicate` 终止。
2. 每轮参数相同（真重放）：第 2 轮必须收到合成 duplicate 错误且不执行，第 3 轮必须以可见的 `global_tool_call_duplicate` 停止——保护不变。

回归套件见英文部分命令。每个入口现在同时具备"压制"与新的"异参数执行"成对用例，从两个方向钉住指纹判定。

### 证据（Before & After）

已在打包产物上对 mock provider 端到端验证（隔离 HOME、headless `--approval-mode yolo`）：

Before（已发布的 qwen 0.21.13）：异参数场景——第 2 轮的全新命令被回以 `Duplicate provider tool call id "run_shell_command_0" was already handled...`，第 3 轮以 `Loop detection halted the run (global_tool_call_duplicate: ...)` 终止；第 2/3 轮命令从未执行。

After（本分支 `dist/cli.js`）：异参数场景——三轮全部执行（每轮工具结果均为真实 shell 输出），运行以模型最终文本收尾。同参数场景——第 2 轮以 duplicate 错误压制，第 3 轮以 `global_tool_call_duplicate` 可见终止；从未到达第 4 轮。

### 测试平台

macOS ✅；Windows / Linux ⚠️ 未本地验证（依赖 CI）。

## 风险与范围

- 主要风险/权衡：对后续 id 碰撞执行（同原始 id、参数等于某次后缀执行而非该 id 首次调用）的重放会再执行一次，由与 id 无关的守卫兜底；参数恰好等于该 id 首次执行的合法重跑仍会被压制一次并在复发时可见熔断——改进后的消息给模型恢复路径。两项残留均已写入设计文档。
- 未验证/超出范围：provider 侧 id 唯一性修复；Windows/Linux 本地运行（CI 覆盖）。
- 破坏性变更/迁移说明：共享熔断帮助函数第三个参数由已处理 id 集合改为重放谓词（仓库内部 API，所有调用方已迁移）。

## 关联 Issue

设计文档见 `docs/design/2026-08-19-duplicate-provider-toolcall-id-guard.md`（本 PR 实现决策 D2 与 D3）。相关历史：#5014、#5038、#5657。

</details>
