### PR TITLE
fix(review): clamp the posting volume at its origin, not only where it is written

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -28,7 +28,11 @@ import {
 } from './lib/deadline.js';
 import { getGhHost, setGhHost } from './lib/gh.js';
 import { BRIEFS } from './lib/agent-briefs.js';
-import { LEDGER_MAX_ROUND, parseLedger } from './lib/ledger.js';
+import {
+  LEDGER_MAX_ROUND,
+  LEDGER_MAX_VOLUME,
+  parseLedger,
+} from './lib/ledger.js';
 import { countInlineFindings } from './lib/inline-counts.js';
 import {
   composeReview,
@@ -8748,6 +8752,22 @@ describe('convergence telemetry — volume, carried in the marker', () => {
     });
     expect(r.postedInline).toBe(3);
     expect(parseLedger(r.body)?.posted).toBe(3);
+  });
+
+  it('clamps the count at its origin, so every surface agrees', () => {
+    // The terminal line, the marker and the artifact must never disagree
+    // about one round's count. This is the defensive over-cap case: the
+    // reader is applied where the number is derived, not only where it is
+    // written, so no surface can see the raw value.
+    const r = composeReview({
+      planPath: plan(),
+      modelId: 'm',
+      criticalsInline: 0,
+      suggestionsInline: LEDGER_MAX_VOLUME + 5,
+      draftedComments: drafts(LEDGER_MAX_VOLUME + 5),
+    });
+    expect(r.postedInline).toBe(LEDGER_MAX_VOLUME);
+    expect(parseLedger(r.body)?.posted).toBe(LEDGER_MAX_VOLUME);
   });
 
   it('counts the POST-enforcement set — what submit actually sends', () => {

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -1543,8 +1543,14 @@ function composeReviewBody(
 ): ComposeReviewResult {
   // The posting set this body describes — `input` here is already the
   // post-enforcement one, so the count needs no second derivation and
-  // cannot disagree with the marker's.
-  const postedInline = (input.draftedComments ?? []).length;
+  // cannot disagree with the marker's. Clamped AT THE ORIGIN through the
+  // shared reader: every other site that reads a volume applies it, and the
+  // one that did not was this count on its way to the terminal line, which
+  // in the defensive over-cap case would have printed the raw number beside
+  // a marker recording the capped one — the two-outputs-disagree failure
+  // the shared reader's own docstring exists to prevent. `?? 0` is
+  // unreachable for an array length; it keeps the type honest.
+  const postedInline = volumeOf((input.draftedComments ?? []).length) ?? 0;
   const criticalsInline = toCount(input.criticalsInline, 'criticalsInline');
   const suggestionsInline = toCount(
     input.suggestionsInline,

--- a/packages/cli/src/commands/review/save-artifact.test.ts
+++ b/packages/cli/src/commands/review/save-artifact.test.ts
@@ -74,7 +74,12 @@ const verdict = {
   // proves passthrough against a validator that would otherwise omit the
   // field entirely.
   postedInline: 3,
-  // Also non-default on purpose, for the same reason.
+  // Also non-default on purpose — and on the DEFAULTING side, with
+  // `deferredCount` and `floorEnforced`: an absent `bodyTrim` reads as an
+  // untrimmed one and the field is always emitted. Spelled out rather than
+  // said as "the same reason", which would now resolve against the
+  // preserved-absence block above it and teach the opposite of what
+  // `save-artifact.ts` does.
   bodyTrim: { sections: 2, deferralList: true, fold: true, truncated: true },
   lowSignal: { agents: 4, srcDiffLines: 120 },
   verdictLine: 'Verdict: Comment — Request changes was downgraded',

--- a/packages/cli/src/commands/review/save-artifact.test.ts
+++ b/packages/cli/src/commands/review/save-artifact.test.ts
@@ -69,7 +69,10 @@ const verdict = {
   deferredCount: 2,
   // Non-empty for the same reason — absent defaults to [].
   floorEnforced: [1],
-  // Non-zero for the same reason — absent defaults to 0.
+  // Non-zero on purpose too, but for the OPPOSITE reason to its siblings:
+  // this field's absence is preserved, not defaulted, so the fixture value
+  // proves passthrough against a validator that would otherwise omit the
+  // field entirely.
   postedInline: 3,
   // Also non-default on purpose, for the same reason.
   bodyTrim: { sections: 2, deferralList: true, fold: true, truncated: true },


### PR DESCRIPTION
## What this PR does

Applies the shared volume reader at the one site that was still missing it, and corrects a fixture comment that outlived the semantics it described.

The round's posting count reaches four surfaces: the ledger marker, the persisted artifact, the terminal `VOLUME:` line, and the next round through the side file. Three of them read it through the shared reader that validates and clamps in one place; the fourth — the count as the body composer derives it — carried the raw drafted-comment length. In the defensive over-cap case the terminal line would therefore print an unclamped number beside a marker recording the clamped one, which is precisely the two-outputs-disagree failure that reader's own docstring cites as its reason for existing. Clamping once where the count is derived puts every surface on the same value by construction rather than by four boundaries agreeing to do the same thing.

The fixture comment is smaller but the same species: `postedInline`'s absence is preserved rather than defaulted, decided a few rounds into the previous PR, and the comment beside the fixture still told the reader that absence defaults to zero — the opposite of what the validator, the type and two tests all assert.

## Why it's needed

Neither is reachable with a real producer: no review round drafts a hundred thousand inline comments, and a comment misleads only the next person to read it. They are worth closing because the value they protect is agreement between surfaces — a convergence trend is only as good as its points, and a count that reads differently depending on which output you look at is exactly the kind of quiet disagreement the shared reader was introduced to make impossible. Leaving one site outside it also leaves the invariant resting on nobody adding a fifth.

## Reviewer Test Plan

### How to verify

- `cd packages/cli && npx vitest run src/commands/review/compose-review.test.ts` — the convergence-telemetry block gains a case driving the over-cap shape and asserting the result field and the marker report the same clamped value. The existing cases continue to pin the ordinary path, so a regression that clamps only at the write side still fails.
- Read the fixture in `save-artifact.test.ts`: its comment now states the preserved-absence contract the surrounding tests assert, rather than the defaulting one they refute.
- Full `src/commands/review` suite: 3901 pass. `tsc --noEmit` clean after a workspace build (a stale `core`/`acp-bridge` `dist` reports unrelated errors in `serve/`; rebuilding clears them).

### Evidence (Before & After)

N/A — one clamp and one comment; the observable difference is asserted directly in the new test.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only; `tsc --noEmit`, eslint and prettier clean.

## Risk & Scope

- Main risk or tradeoff: none identified. The clamp is a no-op for every count a real round produces, and it cannot lower a value below what the marker already recorded, so no surface loses information it previously had.
- Not validated / out of scope: the remaining work items of the convergence-advisory design (the diagnosis that consumes this telemetry, and the increment fields still gated on the anchor chain).
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #9413 (raised in a maintainer's independent pass over that PR's head, marked non-blocking there). Refs #9278.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在唯一遗漏的读取点应用共享音量读取器，并修正一处比它所描述的语义活得更久的夹具注释。

本轮的发布计数会到达四个界面：台账标记、持久化产物、终端 `VOLUME:` 行，以及经由侧文件到达的下一轮。其中三个通过共享读取器读取——该读取器在一处完成校验与钳制；第四个（正文组合器推导出该计数的地方）携带的是未经处理的草稿评论数。于是在防御性的超上限场景下，终端行会打印未钳制的数字，而同一轮的标记记录的是钳制后的值——这恰恰是该读取器自身 docstring 用以论证其存在理由的「同一轮两个输出互相矛盾」的失败形态。在计数被推导处钳制一次，使所有界面在构造上取得一致，而不是依赖四个边界各自记得做同一件事。

夹具注释这条更小，但属于同一类：`postedInline` 的缺失是被保留而非默认填零的（这是上一个 PR 中途确定的语义），而夹具旁的注释仍然告诉读者「缺失默认为 0」——与校验器、类型以及两个测试所断言的正好相反。

## 为什么需要

两者对真实生产者都不可达：没有哪一轮评审会起草十万条行内评论，而注释只会误导下一个阅读它的人。值得关闭它们，是因为它们保护的是界面之间的一致：收敛趋势的价值不高于其数据点的可信度，而一个「取决于你看哪个输出」的计数，正是引入共享读取器所要杜绝的那种静默分歧。把一个站点留在读取器之外，也就把不变量寄托在「没人添加第五个站点」上。

## 审查者测试计划

验证方式：`cd packages/cli && npx vitest run src/commands/review/compose-review.test.ts`——收敛遥测测试块新增一个用例，驱动超上限形态并断言结果字段与标记报告同一个钳制后的值；既有用例继续钉住常规路径，因此「只在写入侧钳制」的回归仍会失败。另请阅读 `save-artifact.test.ts` 中的夹具：其注释现在陈述的是周围测试所断言的「保留缺失」契约，而非它们所否定的「默认填零」。完整 `src/commands/review` 套件 3901 通过；工作区构建后 `tsc --noEmit` 干净（陈旧的 `core`/`acp-bridge` `dist` 会在 `serve/` 报出无关错误，重建即可消除）。

证据：N/A——一处钳制与一条注释，可观测差异已在新测试中直接断言。已在 macOS 验证；Windows/Linux 未本地验证（CI 覆盖）。环境：仅单元测试；`tsc --noEmit`、eslint、prettier 干净。

## 风险与范围

- 主要风险/权衡：未发现。对任何真实轮次产生的计数而言该钳制都是空操作，且它不会把值降到标记已记录值之下，因此没有界面会失去原本拥有的信息。
- 未验证/超出范围：收敛建议设计的其余工作项（消费该遥测的诊断，以及仍受锚点链阻塞的增量字段）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

#9413 的后续（由维护者对该 PR head 的独立评审提出，在那里标记为非阻断）。参考 #9278。

</details>
