### PR TITLE
fix(triage): diff the flake-gate file list against the pinned base OID

### DIFF
--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -1014,8 +1014,13 @@ describe('qwen-triage: flakiness gate (#9125)', () => {
     // executes, so it is a changed test file exactly like M.
     assert.match(
       recordStep.run,
-      /^\s*git -c core\.quotePath=false diff -z --name-only --diff-filter=ACMRT 'HEAD\^1' HEAD \\\n\s*> "\$GATE_HOME\/files-all"$/m,
+      /^\s*git -c core\.quotePath=false diff -z --name-only --diff-filter=ACMRT "\$BASE_OID" HEAD \\\n\s*> "\$GATE_HOME\/files-all"$/m,
       'the NUL diff must flow straight into its file — $( ) strips NUL bytes, a pipeline swallows the exit status',
+    );
+    assert.match(
+      recordStep.run,
+      /^\s*BASE_OID="\$\(cat "\$\{RUNNER_TEMP:\?\}\/verify-base-oid"\)"$/m,
+      'the record step must diff against the base OID captured while .git was root-owned, not re-resolve HEAD^1',
     );
     assert.ok(
       recordStep.run.includes(

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -2975,7 +2975,20 @@ jobs:
           # T (typechange) included: a symlink->regular flip changes what
           # the runner executes, so it is a changed test file exactly
           # like M — excluding it silently drops the file from the gate.
-          git -c core.quotePath=false diff -z --name-only --diff-filter=ACMRT 'HEAD^1' HEAD \
+          # Diff against the base OID the "Pin agent inputs" step recorded
+          # while .git was still root-owned, never `HEAD^1` again: this
+          # step runs in the env -i scrubbed child, and resolving the `^1`
+          # parent there intermittently fails with "Could not access
+          # 'HEAD^1'" on the persistent pool — the shallow merge-ref object
+          # store is left in a state prior --depth=2 fetches made
+          # unreadable. The OID is content-addressed and needs no parent
+          # walk, so the diff works from the already-captured value.
+          BASE_OID="$(cat "${RUNNER_TEMP:?}/verify-base-oid")"
+          case "$BASE_OID" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
+            *) echo "::error::No trusted base OID recorded; refusing to record the flakiness-gate file list."; exit 1 ;;
+          esac
+          git -c core.quotePath=false diff -z --name-only --diff-filter=ACMRT "$BASE_OID" HEAD \
             > "$GATE_HOME/files-all"
           # .mts/.cts included: vitest's default include set collects them.
           # Only a no-match (status 1) may yield an empty list: a grep


### PR DESCRIPTION
## What this PR does

The "Record changed test files for the flakiness gate" step runs `git diff 'HEAD^1' HEAD` inside the `env -i` scrubbed child. On the persistent pool, resolving the `^1` parent there intermittently fails with `error: Could not access 'HEAD^1'`, which takes down the whole verify lane (observed on #9432: runs [32222732873](https://github.com/QwenLM/qwen-code/actions/runs/32222732873) and [32222952508](https://github.com/QwenLM/qwen-code/actions/runs/32222952508)).

The "Pin agent inputs" step already captures the base OID to `$RUNNER_TEMP/verify-base-oid` while `.git` is still root-owned. This PR diffs against that content-addressed OID instead of re-resolving `HEAD^1` — no parent walk, and it's the exact value the workflow already trusts for its post-build re-pin. The OID is guarded by a hex-shape check (mirroring the existing post-build re-pin), and the test pins are updated to match.

## Why it's needed

The step runs after the one-shot `env -i` re-exec (the startup-channel scrub). Resolving `HEAD^1` requires re-reading the merge commit's parents off the shallow object store; prior `--depth=2` fetches on the persistent pool leave that store intermittently unreadable, so the parent walk fails. The OID needs no walk.

## Reviewer Test Plan

### How to verify

Run `node --test .github/scripts/qwen-triage-workflow.test.mjs`. The structural suite `qwen-triage: flakiness gate (#9125)` should pass, including `records the changed-test list BEFORE the workspace is handed to the build user` (the test containing both pins).

### Evidence (Before & After)

Non-user-visible CI/workflow change.

- Before: the record step ran `git diff 'HEAD^1' HEAD` and intermittently failed with `error: Could not access 'HEAD^1'` (see #9432 runs [32222732873](https://github.com/QwenLM/qwen-code/actions/runs/32222732873) and [32222952508](https://github.com/QwenLM/qwen-code/actions/runs/32222952508)).
- After: the record step reads the pinned base OID and diffs `"$BASE_OID" HEAD`; the structural suite passes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   ✅    |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: the record step now fails closed if the pinned base OID is missing or malformed (the hex-shape guard exits with an error instead of silently recording an empty list). That is intended — a missing OID means the earlier "Pin agent inputs" step did not run, and proceeding would silently skip the flakiness gate.
- Not validated / out of scope: the underlying persistent-pool shallow-object-store corruption that makes `HEAD^1` unreadable. This PR only stops re-resolving the parent; it does not fix the pool.
- Breaking changes / migration notes: none. The workflow reads the same `verify-base-oid` value it already captured for the post-build re-pin.

## Linked Issues

No dedicated tracking issue. Fixes the flakiness-gate failure observed on #9432 (runs [32222732873](https://github.com/QwenLM/qwen-code/actions/runs/32222732873), [32222952508](https://github.com/QwenLM/qwen-code/actions/runs/32222952508)).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

"Record changed test files for the flakiness gate" 步骤在 `env -i` 清理过的子进程里执行 `git diff 'HEAD^1' HEAD`。在持久化 pool 上，在那里解析 `^1` 父提交会间歇性失败并报 `error: Could not access 'HEAD^1'`，进而拖垮整个 verify lane（在 #9432 上观察到：运行 [32222732873](https://github.com/QwenLM/qwen-code/actions/runs/32222732873) 和 [32222952508](https://github.com/QwenLM/qwen-code/actions/runs/32222952508)）。

"Pin agent inputs" 步骤在 `.git` 仍由 root 拥有时就已经把 base OID 捕获到 `$RUNNER_TEMP/verify-base-oid`。本 PR 改为对这个内容寻址的 OID 做 diff，而不是重新解析 `HEAD^1` —— 不需要父提交遍历，而且用的正是 workflow 在 post-build re-pin 时已经信任的那个值。OID 增加了一个十六进制形状的校验（对齐现有的 post-build re-pin），测试的精确匹配也同步更新。

## 为什么需要

该步骤在一次性 `env -i` 重新 exec（startup-channel scrub）之后运行。解析 `HEAD^1` 需要从 shallow object store 重新读取 merge commit 的父提交；持久化 pool 上先前的 `--depth=2` fetch 会让那个 store 间歇性地不可读，于是父提交遍历失败。而 OID 不需要遍历。

## Reviewer 测试计划

### 如何验证

运行 `node --test .github/scripts/qwen-triage-workflow.test.mjs`。结构化套件 `qwen-triage: flakiness gate (#9125)` 应通过，包括 `records the changed-test list BEFORE the workspace is handed to the build user`（包含两个 pin 的那个测试）。

### 证据（前后对比）

非用户可见的 CI/workflow 改动。

- 之前：record 步骤执行 `git diff 'HEAD^1' HEAD`，间歇性失败并报 `error: Could not access 'HEAD^1'`（见 #9432 的运行 [32222732873](https://github.com/QwenLM/qwen-code/actions/runs/32222732873) 和 [32222952508](https://github.com/QwenLM/qwen-code/actions/runs/32222952508)）。
- 之后：record 步骤读取已固定的 base OID 并对 `"$BASE_OID" HEAD` 做 diff；结构化套件通过。

### 测试环境

|     操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   N/A   |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   ✅    |

### 环境（可选）

N/A —— 仅单元测试。

## 风险与范围

- 主要风险/权衡：如果已固定的 base OID 缺失或格式不对，record 步骤现在会 fail closed（十六进制形状校验会报错退出，而不是静默记录空列表）。这是有意为之：OID 缺失意味着前面的 "Pin agent inputs" 步骤没跑，继续下去会静默跳过 flakiness gate。
- 未验证/超出范围：导致 `HEAD^1` 不可读的持久化 pool 底层 shallow object store 损坏问题。本 PR 只是不再重新解析父提交，并没有修复 pool。
- 破坏性变更/迁移说明：无。workflow 仍然读取它原本就为 post-build re-pin 捕获的同一个 `verify-base-oid` 值。

## 关联 Issue

没有专门的追踪 issue。修复了在 #9432 上观察到的 flakiness-gate 失败（运行 [32222732873](https://github.com/QwenLM/qwen-code/actions/runs/32222732873)、[32222952508](https://github.com/QwenLM/qwen-code/actions/runs/32222952508)）。

</details>
