### PR TITLE
feat(web-shell): share HTML artifacts to a configurable endpoint

### DIFF
--- a/docs/design/web-shell/web-shell-artifact-share.md
+++ b/docs/design/web-shell/web-shell-artifact-share.md
@@ -1,0 +1,149 @@
+# Web Shell HTML artifact sharing
+
+## Goal
+
+Give an HTML artifact card a third action, next to Download and Open, that
+uploads the artifact to a user-supplied host and hands back a link the user can
+send to someone who does not have the workspace.
+
+## Problem
+
+An HTML artifact is only viewable by whoever can reach the daemon. Sharing one
+today means downloading the file and uploading it somewhere by hand. The
+artifact card already knows how to read the file out of the workspace — that is
+what Download does — so the missing piece is the upload and the link, not the
+data path.
+
+The upload target cannot be baked in. Qwen Code has no hosting service of its
+own, and silently posting a user's artifacts to a third party would be a
+privacy failure. So the endpoint is configuration, and it ships empty.
+
+## Design
+
+### Endpoint contract
+
+The endpoint is a single URL. Web Shell sends:
+
+```
+POST <endpoint>
+content-type: text/html; charset=utf-8
+authorization: Bearer <token>        # only when a token is configured
+
+<the artifact's HTML>
+```
+
+and expects `2xx` with a JSON body:
+
+```json
+{ "url": "https://host.example/s/abc123" }
+```
+
+Anything else is surfaced as a failure. The contract carries nothing
+provider-specific, so any host that can answer it works — a Cloudflare Worker,
+an S3-backed uploader, an intranet service, or a script on localhost.
+
+### Configuration
+
+Endpoint and token live in `localStorage`
+(`qwen-web-shell-share-endpoint`, `qwen-web-shell-share-token`), alongside the
+existing theme and language preferences. There is no daemon round-trip and no
+new settings-schema entry: the target is a property of the browser the user
+shares from, and keeping the token out of the daemon's settings file means it is
+never written to disk on a shared host.
+
+The endpoint must be `https://`. Plain `http://` is accepted only for loopback
+hosts, where there is no wire to intercept — otherwise the bearer token and the
+artifact would travel in the clear.
+
+### Flow
+
+The Share button appears on an artifact card when the artifact is HTML
+(`kind === 'html'`, an `.html`/`.htm` path, or a `text/html` MIME type) and is
+readable from the workspace — the same availability rule Download uses.
+
+Clicking it opens a dialog:
+
+- **Nothing configured** — an endpoint field and an optional token field.
+  Saving publishes in the same step.
+- **Already configured** — a confirmation naming the endpoint, because
+  publishing puts the artifact on the public internet and the returned link
+  authorizes whoever holds it.
+- **Published** — the returned URL, selectable and copyable.
+
+Uploads are capped at 5 MB and are abandoned if the dialog closes mid-flight.
+
+### Security
+
+The artifact is model-generated HTML, so the published page can run arbitrary
+script under the endpoint's origin. The endpoint should therefore serve shared
+artifacts from an origin that hosts nothing else — a dedicated domain or
+subdomain — so a shared artifact cannot reach another application's cookies or
+storage. Web Shell's own preview sandbox (`withArtifactPreviewCsp`) does not
+apply to the published copy; the host is responsible for whatever headers it
+wants to serve.
+
+Only the returned URL is trusted as far as `http:`/`https:` — any other scheme
+in the response is rejected rather than rendered as a link.
+
+## Reference endpoint
+
+A Cloudflare Worker satisfying the contract, for a user who wants one:
+
+```js
+// wrangler.toml: kv_namespaces = [{ binding = "SHARES", id = "..." }]
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+    // The upload is cross-origin and carries an Authorization header and a
+    // text/html body, so the browser preflights it.
+    const cors = {
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': 'POST, OPTIONS',
+      'access-control-allow-headers': 'authorization, content-type',
+      'access-control-max-age': '86400',
+    };
+
+    if (req.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors });
+    }
+
+    if (req.method === 'POST' && url.pathname === '/publish') {
+      if (req.headers.get('authorization') !== `Bearer ${env.PUBLISH_TOKEN}`) {
+        return new Response('unauthorized', { status: 401, headers: cors });
+      }
+      const html = await req.text();
+      if (html.length > 5_000_000) {
+        return new Response('too large', { status: 413, headers: cors });
+      }
+      const id = crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+      await env.SHARES.put(id, html, { expirationTtl: 60 * 60 * 24 * 30 });
+      return Response.json({ url: `${url.origin}/s/${id}` }, { headers: cors });
+    }
+
+    const id = url.pathname.match(/^\/s\/([a-f0-9]{16})$/)?.[1];
+    if (!id) return new Response('not found', { status: 404 });
+    const html = await env.SHARES.get(id);
+    return html
+      ? new Response(html, {
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        })
+      : new Response('expired or not found', { status: 404 });
+  },
+};
+```
+
+The endpoint must answer the CORS preflight and allow the `authorization` and
+`content-type` request headers; a handler that only sets
+`access-control-allow-origin` on the `POST` response will fail before the upload
+is ever sent.
+
+## Alternatives considered
+
+**Upload through the daemon.** Keeps the token off the browser, but needs a new
+daemon route plus SDK and client plumbing, and writes the token into the
+daemon's settings file. Rejected as disproportionate: the browser already holds
+a daemon token of comparable value.
+
+**A built-in default endpoint.** Would make the button work out of the box, at
+the cost of uploading users' artifacts to a service the project would have to
+run and pay for, by default. Rejected.

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -63,6 +63,7 @@ import {
   getArtifactImageMimeType,
   getImageMimeTypeFromPath,
   getReviewDownloadMimeType,
+  isHtmlArtifact,
   normalizePath,
   readWorkspaceFileAsBlob,
   withArtifactPreviewCsp,
@@ -2477,17 +2478,6 @@ function CodeReviewWorkspaceRequired() {
     <div className={styles.previewError} role="alert">
       {t('codeReview.workspaceRequired')}
     </div>
-  );
-}
-
-function isHtmlArtifact(artifact: DaemonSessionArtifact) {
-  const path = artifact.workspacePath?.toLowerCase() ?? '';
-  const mimeType = artifact.mimeType?.toLowerCase() ?? '';
-  return (
-    artifact.kind === 'html' ||
-    path.endsWith('.html') ||
-    path.endsWith('.htm') ||
-    mimeType === 'text/html'
   );
 }
 

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.dom.test.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.dom.test.tsx
@@ -641,3 +641,140 @@ describe('TurnOutputs artifact downloads', () => {
     act(() => root.unmount());
   });
 });
+
+describe('TurnOutputs artifact sharing', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  const renderArtifacts = (artifacts: DaemonSessionArtifact[]) => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <TurnOutputs
+            turnId="turn-1"
+            workspaceCwd="/primary"
+            changes={[]}
+            artifacts={artifacts}
+            scheduledTasks={[]}
+            onReviewChanges={() => {}}
+            onOpenArtifact={() => {}}
+            onOpenScheduledTask={() => {}}
+          />
+        </I18nProvider>,
+      );
+    });
+    return { container, root };
+  };
+
+  const shareButtons = (scope: ParentNode) =>
+    Array.from(scope.querySelectorAll('button')).filter(
+      (button) => button.textContent?.trim() === 'Share',
+    );
+
+  it.each([
+    [{ kind: 'html', workspacePath: 'output/report' }, true],
+    [{ kind: 'file', workspacePath: 'output/page.html' }, true],
+    [{ kind: 'file', workspacePath: 'output/page.HTML' }, true],
+    [{ kind: 'file', workspacePath: 'output/page.htm' }, true],
+    [
+      { kind: 'file', workspacePath: 'output/notes', mimeType: 'text/html' },
+      true,
+    ],
+    [{ kind: 'file', workspacePath: 'output/notes.md' }, false],
+    [{ kind: 'file', workspacePath: 'output/htmlish.txt' }, false],
+    [{ kind: 'image', workspacePath: 'output/chart.png' }, false],
+    [
+      { kind: 'file', workspacePath: 'output/data', mimeType: 'text/plain' },
+      false,
+    ],
+  ])('offers Share for %o only when it is HTML', (fields, shareable) => {
+    const { container, root } = renderArtifacts([
+      {
+        id: 'artifact-0',
+        storage: 'workspace',
+        status: 'available',
+        title: 'artifact',
+        ...fields,
+      } as DaemonSessionArtifact,
+    ]);
+
+    expect(shareButtons(container)).toHaveLength(shareable ? 1 : 0);
+
+    act(() => root.unmount());
+  });
+
+  it('hides Share for an artifact that is not readable from the workspace', () => {
+    const { container, root } = renderArtifacts([
+      {
+        id: 'artifact-pending',
+        kind: 'html',
+        storage: 'workspace',
+        status: 'pending',
+        title: 'pending report',
+        workspacePath: 'output/report.html',
+      } as DaemonSessionArtifact,
+    ]);
+
+    expect(shareButtons(container)).toHaveLength(0);
+
+    act(() => root.unmount());
+  });
+
+  it('uploads the artifact to the configured endpoint and shows the link', async () => {
+    window.localStorage.setItem(
+      'qwen-web-shell-share-endpoint',
+      'https://share.example.com/publish',
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"url":"https://share.example.com/s/abc"}', {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    readFileBytes.mockResolvedValue({
+      contentBase64: btoa('<h1>report</h1>'),
+      offset: 0,
+      returnedBytes: 15,
+      sizeBytes: 15,
+    });
+    stat.mockResolvedValue({ sizeBytes: 15, modifiedMs: 1 });
+
+    const { container, root } = renderArtifacts([
+      {
+        id: 'artifact-html',
+        kind: 'html',
+        storage: 'workspace',
+        status: 'available',
+        title: 'report',
+        workspacePath: 'output/report.html',
+      } as DaemonSessionArtifact,
+    ]);
+
+    await act(async () => {
+      shareButtons(container)[0]?.click();
+    });
+
+    const confirm = shareButtons(document.body).at(-1);
+    expect(confirm).toBeDefined();
+
+    await act(async () => {
+      confirm?.click();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://share.example.com/publish',
+    );
+    expect(fetchMock.mock.calls[0][1].body).toBe('<h1>report</h1>');
+    expect(
+      document.body.querySelector<HTMLInputElement>('#share-result-url')?.value,
+    ).toBe('https://share.example.com/s/abc');
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
+++ b/packages/web-shell/client/components/artifacts/TurnOutputs.tsx
@@ -10,17 +10,20 @@ import {
   FileVideoIcon,
   LinkIcon,
   NotebookTabsIcon,
+  Share2Icon,
   type LucideIcon,
 } from 'lucide-react';
 import { memo, useEffect, useRef, useState } from 'react';
 import { useI18n } from '../../i18n';
 import { extractErrorDetail } from '../../utils/errorDetail';
 import { describeCron } from '../dialogs/scheduledTasksSchedule';
+import { ShareArtifactDialog } from '../dialogs/ShareArtifactDialog';
 import {
   formatArtifactSize,
   downloadWorkspaceFile,
   getArtifactTypeLabel,
   getImageMimeTypeFromPath,
+  isHtmlArtifact,
   isSamePath,
   normalizePath,
   stripWorkspacePath,
@@ -152,6 +155,8 @@ function TurnOutputsComponent({
   const workspaceTarget = useArtifactWorkspaceTarget(workspaceCwd);
   const workspaceActions = workspaceTarget?.actions;
   const [showAllChanges, setShowAllChanges] = useState(false);
+  const [sharedArtifact, setSharedArtifact] =
+    useState<DaemonSessionArtifact | null>(null);
   if (
     changes.length === 0 &&
     artifacts.length === 0 &&
@@ -361,6 +366,11 @@ function TurnOutputsComponent({
                   )
               : undefined
           }
+          onShare={
+            canShareArtifact(artifact) && workspaceActions
+              ? () => setSharedArtifact(artifact)
+              : undefined
+          }
         />
       ))}
 
@@ -372,6 +382,15 @@ function TurnOutputsComponent({
           onOpen={() => openScheduledTask(task)}
         />
       ))}
+
+      {sharedArtifact?.workspacePath && workspaceActions && (
+        <ShareArtifactDialog
+          workspacePath={sharedArtifact.workspacePath}
+          title={sharedArtifact.title}
+          workspaceActions={workspaceActions}
+          onClose={() => setSharedArtifact(null)}
+        />
+      )}
     </div>
   );
 }
@@ -380,11 +399,13 @@ function ArtifactCard({
   artifact,
   onOpen,
   onDownload,
+  onShare,
   onError,
 }: {
   artifact: DaemonSessionArtifact;
   onOpen?: () => void;
   onDownload?: (isCancelled: () => boolean) => Promise<void>;
+  onShare?: () => void;
   onError?: (error: unknown, fallback: string) => void;
 }) {
   const { t } = useI18n();
@@ -461,6 +482,17 @@ function ArtifactCard({
           >
             {t('common.open')}
           </button>
+          {onShare && (
+            <button
+              type="button"
+              className={styles.reviewButton}
+              onClick={onShare}
+              title={`${t('share.action')} ${downloadName}`}
+            >
+              <Share2Icon size={16} strokeWidth={1.8} aria-hidden="true" />
+              {t('share.action')}
+            </button>
+          )}
         </div>
       </div>
     </div>
@@ -685,6 +717,10 @@ export function getWorkspaceArtifactOpenBlockReason(
   return artifact.workspacePath
     ? t('turnOutputs.artifactUnavailable', { path: artifact.workspacePath })
     : t('turnOutputs.artifactMissing');
+}
+
+function canShareArtifact(artifact: DaemonSessionArtifact): boolean {
+  return canDownloadArtifact(artifact) && isHtmlArtifact(artifact);
 }
 
 export function displayPath(path: string, workspaceCwd?: string) {

--- a/packages/web-shell/client/components/artifacts/artifactUtils.ts
+++ b/packages/web-shell/client/components/artifacts/artifactUtils.ts
@@ -70,26 +70,67 @@ export function getReviewDownloadMimeType(value: string): string {
   return /\.html?$/i.test(value) ? 'text/html' : 'text/markdown';
 }
 
-export async function readWorkspaceFileAsBlob(
-  readFileBytes: (
+type WorkspaceFileByteReader = (
+  filePath: string,
+  opts?: { offset?: number; maxBytes?: number },
+) => Promise<
+  Pick<
+    DaemonWorkspaceFileBytes,
+    'contentBase64' | 'offset' | 'returnedBytes' | 'sizeBytes'
+  >
+>;
+
+interface WorkspaceFileReadOptions {
+  statFile: (
     filePath: string,
-    opts?: { offset?: number; maxBytes?: number },
-  ) => Promise<
-    Pick<
-      DaemonWorkspaceFileBytes,
-      'contentBase64' | 'offset' | 'returnedBytes' | 'sizeBytes'
-    >
-  >,
+  ) => Promise<{ sizeBytes: number; modifiedMs: number }>;
+  isCancelled?: () => boolean;
+  maxBytes?: number;
+}
+
+export async function readWorkspaceFileAsBlob(
+  readFileBytes: WorkspaceFileByteReader,
   filePath: string,
   mimeType: string,
-  options: {
-    statFile: (
-      filePath: string,
-    ) => Promise<{ sizeBytes: number; modifiedMs: number }>;
-    isCancelled?: () => boolean;
-    maxBytes?: number;
-  },
+  options: WorkspaceFileReadOptions,
 ): Promise<Blob> {
+  const chunks = await readWorkspaceFileChunks(
+    readFileBytes,
+    filePath,
+    options,
+  );
+  return new Blob(chunks, { type: mimeType });
+}
+
+/**
+ * Decodes the chunks directly rather than routing through a Blob, which would
+ * only be built to be taken apart again.
+ */
+export async function readWorkspaceFileAsText(
+  readFileBytes: WorkspaceFileByteReader,
+  filePath: string,
+  options: WorkspaceFileReadOptions,
+): Promise<string> {
+  const chunks = await readWorkspaceFileChunks(
+    readFileBytes,
+    filePath,
+    options,
+  );
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const bytes = new Uint8Array(total);
+  let written = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, written);
+    written += chunk.length;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+async function readWorkspaceFileChunks(
+  readFileBytes: WorkspaceFileByteReader,
+  filePath: string,
+  options: WorkspaceFileReadOptions,
+): Promise<Uint8Array[]> {
   const chunks: Uint8Array[] = [];
   const maxBytes = options.maxBytes ?? MAX_WORKSPACE_FILE_BLOB_BYTES;
   const initialStat = await options.statFile(filePath);
@@ -135,7 +176,7 @@ export async function readWorkspaceFileAsBlob(
       ) {
         throw new Error('File changed while loading. Please retry.');
       }
-      return new Blob(chunks, { type: mimeType });
+      return chunks;
     }
   }
 }
@@ -250,4 +291,15 @@ function stripUnsafePreviewMarkup(html: string) {
       /<meta\b(?=[^>]*\bhttp-equiv\s*=\s*["']?Content-Security-Policy["']?)[^>]*>/gi,
       '',
     );
+}
+
+export function isHtmlArtifact(artifact: DaemonSessionArtifact): boolean {
+  const path = artifact.workspacePath?.toLowerCase() ?? '';
+  const mimeType = artifact.mimeType?.toLowerCase() ?? '';
+  return (
+    artifact.kind === 'html' ||
+    path.endsWith('.html') ||
+    path.endsWith('.htm') ||
+    mimeType === 'text/html'
+  );
 }

--- a/packages/web-shell/client/components/artifacts/shareArtifact.test.ts
+++ b/packages/web-shell/client/components/artifacts/shareArtifact.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  parseShareEndpoint,
+  parseShareResponseUrl,
+  publishHtmlArtifact,
+  readShareTarget,
+  storeShareTarget,
+} from './shareArtifact';
+
+function workspaceActionsReturning(html: string) {
+  return {
+    stat: vi.fn().mockResolvedValue({
+      sizeBytes: html.length,
+      modifiedMs: 1,
+    }),
+    readFileBytes: vi.fn().mockResolvedValue({
+      contentBase64: btoa(html),
+      offset: 0,
+      returnedBytes: html.length,
+      sizeBytes: html.length,
+    }),
+  };
+}
+
+describe('parseShareEndpoint', () => {
+  it('accepts https endpoints', () => {
+    expect(parseShareEndpoint('  https://share.example.com/publish  ')).toBe(
+      'https://share.example.com/publish',
+    );
+  });
+
+  it('accepts plain http only on loopback hosts', () => {
+    expect(parseShareEndpoint('http://localhost:8787/publish')).toBe(
+      'http://localhost:8787/publish',
+    );
+    expect(parseShareEndpoint('http://127.0.0.1:8787/publish')).toBe(
+      'http://127.0.0.1:8787/publish',
+    );
+    expect(parseShareEndpoint('http://[::1]:8787/publish')).toBe(
+      'http://[::1]:8787/publish',
+    );
+  });
+
+  it('rejects plain http to a remote host', () => {
+    expect(parseShareEndpoint('http://share.example.com/publish')).toBe(
+      undefined,
+    );
+  });
+
+  it('rejects non-http schemes and unparseable input', () => {
+    expect(parseShareEndpoint('javascript:alert(1)')).toBe(undefined);
+    expect(parseShareEndpoint('file:///etc/passwd')).toBe(undefined);
+    expect(parseShareEndpoint('share.example.com')).toBe(undefined);
+    expect(parseShareEndpoint('')).toBe(undefined);
+  });
+});
+
+describe('parseShareResponseUrl', () => {
+  it('reads the url field from a JSON body', () => {
+    expect(
+      parseShareResponseUrl('{"url":"https://share.example.com/s/abc"}'),
+    ).toBe('https://share.example.com/s/abc');
+  });
+
+  it('rejects bodies that are not usable share URLs', () => {
+    expect(parseShareResponseUrl('not json')).toBe(undefined);
+    expect(parseShareResponseUrl('{"link":"https://example.com"}')).toBe(
+      undefined,
+    );
+    expect(parseShareResponseUrl('{"url":42}')).toBe(undefined);
+    expect(parseShareResponseUrl('{"url":"javascript:alert(1)"}')).toBe(
+      undefined,
+    );
+    expect(parseShareResponseUrl('null')).toBe(undefined);
+  });
+});
+
+describe('share target storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips an endpoint and token', () => {
+    storeShareTarget({
+      endpoint: 'https://share.example.com/publish',
+      token: 's3cret',
+    });
+
+    expect(readShareTarget()).toEqual({
+      endpoint: 'https://share.example.com/publish',
+      token: 's3cret',
+    });
+  });
+
+  it('drops a previously stored token when saved without one', () => {
+    storeShareTarget({
+      endpoint: 'https://share.example.com/publish',
+      token: 's3cret',
+    });
+    storeShareTarget({ endpoint: 'https://share.example.com/publish' });
+
+    expect(readShareTarget()).toEqual({
+      endpoint: 'https://share.example.com/publish',
+    });
+  });
+
+  it('ignores an endpoint that is no longer acceptable', () => {
+    window.localStorage.setItem(
+      'qwen-web-shell-share-endpoint',
+      'http://share.example.com/publish',
+    );
+
+    expect(readShareTarget()).toBe(undefined);
+  });
+
+  it('reports no target when nothing is configured', () => {
+    expect(readShareTarget()).toBe(undefined);
+  });
+});
+
+describe('publishHtmlArtifact', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts the artifact and returns the reported URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"url":"https://share.example.com/s/abc"}', {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const url = await publishHtmlArtifact(
+      workspaceActionsReturning('<h1>report</h1>'),
+      'out/report.html',
+      { endpoint: 'https://share.example.com/publish', token: 's3cret' },
+    );
+
+    expect(url).toBe('https://share.example.com/s/abc');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchMock.mock.calls[0];
+    expect(endpoint).toBe('https://share.example.com/publish');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('<h1>report</h1>');
+    expect(init.headers).toMatchObject({
+      'content-type': 'text/html; charset=utf-8',
+      authorization: 'Bearer s3cret',
+    });
+  });
+
+  it('omits the authorization header when no token is configured', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"url":"https://share.example.com/s/abc"}', {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await publishHtmlArtifact(
+      workspaceActionsReturning('<h1>report</h1>'),
+      'out/report.html',
+      { endpoint: 'https://share.example.com/publish' },
+    );
+
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty(
+      'authorization',
+    );
+  });
+
+  it('surfaces a rejected upload', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('nope', { status: 401 })),
+    );
+
+    await expect(
+      publishHtmlArtifact(
+        workspaceActionsReturning('<h1>report</h1>'),
+        'out/report.html',
+        { endpoint: 'https://share.example.com/publish' },
+      ),
+    ).rejects.toThrow('401');
+  });
+
+  it('rejects a response that carries no usable URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{"url":"javascript:alert(1)"}')),
+    );
+
+    await expect(
+      publishHtmlArtifact(
+        workspaceActionsReturning('<h1>report</h1>'),
+        'out/report.html',
+        { endpoint: 'https://share.example.com/publish' },
+      ),
+    ).rejects.toThrow('did not return a usable URL');
+  });
+
+  it('refuses to upload an artifact past the size limit', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const actions = {
+      stat: vi.fn().mockResolvedValue({
+        sizeBytes: 5 * 1024 * 1024 + 1,
+        modifiedMs: 1,
+      }),
+      readFileBytes: vi.fn(),
+    };
+
+    await expect(
+      publishHtmlArtifact(actions, 'out/report.html', {
+        endpoint: 'https://share.example.com/publish',
+      }),
+    ).rejects.toThrow('too large');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web-shell/client/components/artifacts/shareArtifact.ts
+++ b/packages/web-shell/client/components/artifacts/shareArtifact.ts
@@ -1,0 +1,124 @@
+import type { DaemonWorkspaceActions } from '@qwen-code/webui/daemon-react-sdk';
+import { readWorkspaceFileAsText } from './artifactUtils';
+
+const ENDPOINT_STORAGE_KEY = 'qwen-web-shell-share-endpoint';
+const TOKEN_STORAGE_KEY = 'qwen-web-shell-share-token';
+
+const MAX_SHARE_BYTES = 5 * 1024 * 1024;
+
+export interface ShareTarget {
+  endpoint: string;
+  token?: string;
+}
+
+function isLoopbackHttp(url: URL): boolean {
+  return (
+    url.protocol === 'http:' &&
+    (url.hostname === 'localhost' ||
+      url.hostname === '127.0.0.1' ||
+      url.hostname === '[::1]')
+  );
+}
+
+/**
+ * Plain http would put the bearer token and the artifact on the wire in the
+ * clear, so only https survives — except on loopback, where there is no wire.
+ */
+export function parseShareEndpoint(value: string): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'https:' && !isLoopbackHttp(url)) return undefined;
+  return url.toString();
+}
+
+export function readShareTarget(): ShareTarget | undefined {
+  try {
+    const endpoint = parseShareEndpoint(
+      window.localStorage.getItem(ENDPOINT_STORAGE_KEY) ?? '',
+    );
+    if (!endpoint) return undefined;
+    return {
+      endpoint,
+      token: window.localStorage.getItem(TOKEN_STORAGE_KEY) || undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function storeShareTarget(target: ShareTarget): void {
+  try {
+    window.localStorage.setItem(ENDPOINT_STORAGE_KEY, target.endpoint);
+    if (target.token) {
+      window.localStorage.setItem(TOKEN_STORAGE_KEY, target.token);
+    } else {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures in private browsing or locked-down browsers.
+  }
+}
+
+export function parseShareResponseUrl(body: string): string | undefined {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  const value = (payload as { url?: unknown } | null)?.url;
+  if (typeof value !== 'string') return undefined;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return undefined;
+  }
+  return url.protocol === 'https:' || url.protocol === 'http:'
+    ? url.toString()
+    : undefined;
+}
+
+/**
+ * Uploads the artifact to the configured endpoint and returns the public URL
+ * it reports back. The endpoint contract is deliberately generic — POST the
+ * HTML, answer with `{"url": "..."}` — so any host can serve it.
+ */
+export async function publishHtmlArtifact(
+  workspaceActions: Pick<DaemonWorkspaceActions, 'readFileBytes' | 'stat'>,
+  workspacePath: string,
+  target: ShareTarget,
+  isCancelled?: () => boolean,
+): Promise<string> {
+  const html = await readWorkspaceFileAsText(
+    (filePath, opts) => workspaceActions.readFileBytes(filePath, opts),
+    workspacePath,
+    {
+      statFile: (filePath) => workspaceActions.stat(filePath),
+      isCancelled,
+      maxBytes: MAX_SHARE_BYTES,
+    },
+  );
+  const response = await fetch(target.endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      ...(target.token ? { authorization: `Bearer ${target.token}` } : {}),
+    },
+    body: html,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Share endpoint returned ${response.status} ${response.statusText}`.trim(),
+    );
+  }
+  const url = parseShareResponseUrl(await response.text());
+  if (!url) {
+    throw new Error('Share endpoint did not return a usable URL.');
+  }
+  return url;
+}

--- a/packages/web-shell/client/components/dialogs/ShareArtifactDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/ShareArtifactDialog.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from 'react';
+import type { DaemonWorkspaceActions } from '@qwen-code/webui/daemon-react-sdk';
+import { useI18n } from '../../i18n';
+import { extractErrorDetail } from '../../utils/errorDetail';
+import { DialogShell } from './DialogShell';
+import { Button } from '../ui/button';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '../ui/field';
+import { Input } from '../ui/input';
+import {
+  parseShareEndpoint,
+  publishHtmlArtifact,
+  readShareTarget,
+  storeShareTarget,
+  type ShareTarget,
+} from '../artifacts/shareArtifact';
+
+const ENDPOINT_HINT_ID = 'share-endpoint-hint';
+const ENDPOINT_ERROR_ID = 'share-endpoint-error';
+const TOKEN_HINT_ID = 'share-token-hint';
+
+interface ShareArtifactDialogProps {
+  workspacePath: string;
+  title: string;
+  workspaceActions: Pick<DaemonWorkspaceActions, 'readFileBytes' | 'stat'>;
+  onClose: () => void;
+}
+
+export function ShareArtifactDialog({
+  workspacePath,
+  title,
+  workspaceActions,
+  onClose,
+}: ShareArtifactDialogProps) {
+  const { t } = useI18n();
+  const [target, setTarget] = useState<ShareTarget | undefined>(
+    readShareTarget,
+  );
+  const [editing, setEditing] = useState(target === undefined);
+  const [endpointInput, setEndpointInput] = useState(target?.endpoint ?? '');
+  const [tokenInput, setTokenInput] = useState(target?.token ?? '');
+  const [sharing, setSharing] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    // StrictMode replays setup -> cleanup -> setup without re-running useRef's
+    // initializer, so restore the flag or every upload looks cancelled.
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const publish = async (activeTarget: ShareTarget) => {
+    setSharing(true);
+    setError(null);
+    try {
+      const url = await publishHtmlArtifact(
+        workspaceActions,
+        workspacePath,
+        activeTarget,
+        () => !mountedRef.current,
+      );
+      if (!mountedRef.current) return;
+      setShareUrl(url);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setError(t('share.failed', { message: extractErrorDetail(err) }));
+    } finally {
+      if (mountedRef.current) setSharing(false);
+    }
+  };
+
+  const saveAndShare = () => {
+    const endpoint = parseShareEndpoint(endpointInput);
+    if (!endpoint) {
+      setError(t('share.endpointInvalid'));
+      return;
+    }
+    const next: ShareTarget = {
+      endpoint,
+      token: tokenInput.trim() || undefined,
+    };
+    storeShareTarget(next);
+    setTarget(next);
+    setEditing(false);
+    void publish(next);
+  };
+
+  const copy = async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      if (mountedRef.current) setCopied(true);
+    } catch {
+      // Clipboard access can be blocked; the URL stays selectable in the field.
+    }
+  };
+
+  return (
+    <DialogShell
+      title={t('share.title')}
+      subtitle={title}
+      size="md"
+      onClose={onClose}
+    >
+      {shareUrl ? (
+        <div className="flex flex-col gap-6">
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="share-result-url">
+                {t('share.resultLabel')}
+              </FieldLabel>
+              <Input
+                id="share-result-url"
+                type="text"
+                readOnly
+                value={shareUrl}
+                onFocus={(event) => event.currentTarget.select()}
+              />
+              <FieldDescription>{t('share.resultHint')}</FieldDescription>
+            </Field>
+          </FieldGroup>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => void copy()}>
+              {t(copied ? 'share.copied' : 'common.copy')}
+            </Button>
+            <Button type="button" onClick={onClose}>
+              {t('common.close')}
+            </Button>
+          </div>
+        </div>
+      ) : editing ? (
+        <form
+          className="flex flex-col gap-6"
+          onSubmit={(event) => {
+            event.preventDefault();
+            saveAndShare();
+          }}
+        >
+          <FieldGroup>
+            <Field data-invalid={error ? true : undefined}>
+              <FieldLabel htmlFor="share-endpoint">
+                {t('share.endpointLabel')}
+              </FieldLabel>
+              <Input
+                id="share-endpoint"
+                type="text"
+                placeholder="https://example.com/publish"
+                value={endpointInput}
+                onChange={(event) => {
+                  setEndpointInput(event.target.value);
+                  if (error) setError(null);
+                }}
+                disabled={sharing}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
+                aria-describedby={
+                  error
+                    ? `${ENDPOINT_ERROR_ID} ${ENDPOINT_HINT_ID}`
+                    : ENDPOINT_HINT_ID
+                }
+                aria-invalid={error ? true : undefined}
+              />
+              <FieldDescription id={ENDPOINT_HINT_ID}>
+                {t('share.endpointHint')}
+              </FieldDescription>
+              {error && <FieldError id={ENDPOINT_ERROR_ID}>{error}</FieldError>}
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="share-token">
+                {t('share.tokenLabel')}
+              </FieldLabel>
+              <Input
+                id="share-token"
+                type="password"
+                value={tokenInput}
+                onChange={(event) => setTokenInput(event.target.value)}
+                disabled={sharing}
+                autoComplete="off"
+                aria-describedby={TOKEN_HINT_ID}
+              />
+              <FieldDescription id={TOKEN_HINT_ID}>
+                {t('share.tokenHint')}
+              </FieldDescription>
+            </Field>
+          </FieldGroup>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={sharing}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={sharing}>
+              {t(sharing ? 'share.sharing' : 'share.saveAndShare')}
+            </Button>
+          </div>
+        </form>
+      ) : (
+        target && (
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-2">
+              <p className="text-sm">{t('share.confirmWarning')}</p>
+              <p className="break-all text-sm text-muted-foreground">
+                {target.endpoint}
+              </p>
+            </div>
+            {error && <FieldError>{error}</FieldError>}
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setError(null);
+                  setEditing(true);
+                }}
+                disabled={sharing}
+              >
+                {t('share.reconfigure')}
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void publish(target)}
+                disabled={sharing}
+              >
+                {t(sharing ? 'share.sharing' : 'share.action')}
+              </Button>
+            </div>
+          </div>
+        )
+      )}
+    </DialogShell>
+  );
+}

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -394,6 +394,26 @@ const EN: Messages = {
   'common.downloadFailed': (v) => `Download failed: ${v?.message ?? ''}`,
   'common.open': 'Open',
   'common.openFailed': (v) => `Could not open link: ${v?.message ?? ''}`,
+  'share.action': 'Share',
+  'share.title': 'Share HTML artifact',
+  'share.sharing': 'Sharing…',
+  'share.saveAndShare': 'Save and share',
+  'share.reconfigure': 'Change endpoint',
+  'share.endpointLabel': 'Share endpoint',
+  'share.endpointHint':
+    'Web Shell POSTs the HTML to this URL and expects a JSON reply of {"url": "..."}. No endpoint is configured by default — point it at a host you control.',
+  'share.endpointInvalid':
+    'Enter an https:// URL. http:// is accepted only for localhost.',
+  'share.tokenLabel': 'Access token (optional)',
+  'share.tokenHint':
+    'Sent as an Authorization: Bearer header. Stored in this browser only.',
+  'share.confirmWarning':
+    'This uploads the full artifact to the endpoint below. Anyone with the returned link can read it.',
+  'share.resultLabel': 'Share link',
+  'share.resultHint':
+    'The endpoint decides how long this link stays reachable.',
+  'share.copied': 'Copied',
+  'share.failed': (v) => `Share failed: ${v?.message ?? ''}`,
   'artifact.openLink': 'Open link',
   'common.na': 'N/A',
   'common.server': 'Server',
@@ -3397,6 +3417,24 @@ const ZH: Messages = {
   'common.downloadFailed': (v) => `下载失败：${v?.message ?? ''}`,
   'common.open': '打开',
   'common.openFailed': (v) => `无法打开链接：${v?.message ?? ''}`,
+  'share.action': '分享',
+  'share.title': '分享 HTML 产物',
+  'share.sharing': '正在分享…',
+  'share.saveAndShare': '保存并分享',
+  'share.reconfigure': '更改地址',
+  'share.endpointLabel': '分享服务地址',
+  'share.endpointHint':
+    'Web Shell 会将 HTML POST 到该地址，并期待返回 {"url": "..."} 格式的 JSON。默认不配置任何地址 —— 请填写你自己控制的服务。',
+  'share.endpointInvalid': '请输入 https:// 地址；仅 localhost 允许 http://。',
+  'share.tokenLabel': '访问令牌（可选）',
+  'share.tokenHint':
+    '以 Authorization: Bearer 请求头发送，仅保存在当前浏览器。',
+  'share.confirmWarning':
+    '这将把产物完整上传到下方地址，任何拿到链接的人都能访问。',
+  'share.resultLabel': '分享链接',
+  'share.resultHint': '链接的有效期由分享服务决定。',
+  'share.copied': '已复制',
+  'share.failed': (v) => `分享失败：${v?.message ?? ''}`,
   'artifact.openLink': '打开链接',
   'common.na': '不适用',
   'common.server': '服务器',


### PR DESCRIPTION
## What this PR does

Adds a third action to HTML artifact cards in Web Shell, alongside Download and Open. Choosing it uploads the artifact to an endpoint the user supplies and returns a link that can be sent to someone who has no access to the workspace or the daemon.

The endpoint is a single URL and the contract carries nothing provider-specific: Web Shell POSTs the HTML, and the endpoint answers with a JSON body of `{"url": "..."}`. Any host that can satisfy that works — a small serverless function, an object-store uploader, an intranet service, or a script on localhost — so nothing about a particular hosting provider is baked into the client.

No endpoint ships as a default. The first time the action is used it opens a dialog to configure one; once a target is saved, the action shows a confirmation naming the endpoint before it uploads anything. The endpoint and an optional bearer token are kept in `localStorage` next to the existing theme and language preferences, so no daemon route and no settings-schema entry are involved. An `https://` endpoint is required, with plain `http://` accepted only for loopback addresses.

The action appears only for artifacts that are actually HTML and readable from the workspace, using the same availability rule Download already applies. A design document covering the endpoint contract, the security considerations, and a reference implementation is included.

## Why it's needed

An HTML artifact is currently viewable only by whoever can reach the daemon that produced it. Sharing one with a colleague, attaching it to an issue, or opening it on a phone means downloading the file and uploading it somewhere by hand every time. The artifact card already knows how to read the file out of the workspace, which is exactly what Download does, so the missing piece was the upload and the resulting link rather than any new data path.

The upload target deliberately cannot be baked in. Qwen Code operates no hosting service of its own, and quietly posting a user's artifacts to a third party would be a privacy failure, so the target is configuration and it starts empty. This does mean the action is inert until a user points it somewhere, which is the intended trade-off rather than an oversight.

## Reviewer Test Plan

### How to verify

Open a session in Web Shell that produced an HTML artifact and look at the artifact card. Before this change the card offers Download and Open; after it, a Share action sits to their right. Confirm the action is absent on artifacts that are not HTML — a Markdown file, an image — and absent on an HTML artifact whose status is not available, matching where Download is already hidden.

Choose Share on an HTML artifact with nothing configured and confirm a dialog asks for an endpoint. Enter a plain `http://` URL for a remote host and confirm it is rejected; `https://`, or `http://localhost`, is accepted. Point it at any service that accepts a POST and replies with `{"url": "https://..."}` and confirm the returned link is shown and can be copied. Reopen Share afterwards and confirm it now asks for confirmation and names the saved endpoint instead of asking again for the URL.

The unit tests cover endpoint and response validation, the storage round-trip, the upload request shape with and without a token, the failure paths, and the rule deciding which artifacts offer the action:

```
cd packages/web-shell && npx vitest run client/components/artifacts/
Test Files  12 passed (12)
     Tests  184 passed (184)
```

The full package suite was also run: 3801 of 3802 pass. The one failure is `build-artifact.test.ts`, which reads built `dist/` output and fails identically on an unmodified checkout of this base, so it is unrelated to this change.

### Evidence (Before & After)

Before — the artifact card offers Download and Open:

![before](https://raw.githubusercontent.com/qqqys/qwen-code/assets/artifact-share/docs/assets/artifact-share/before-artifact-card.png)

After — Share sits to the right of them:

![after](https://raw.githubusercontent.com/qqqys/qwen-code/assets/artifact-share/docs/assets/artifact-share/after-artifact-card.png)

Choosing Share with nothing configured:

![dialog](https://raw.githubusercontent.com/qqqys/qwen-code/assets/artifact-share/docs/assets/artifact-share/after-share-dialog.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment

Unit tests under vitest, plus the Web Shell dev server driven through Playwright against the existing mock daemon harness for the screenshots above.

## Risk & Scope

- Main risk or tradeoff: publishing puts model-generated HTML on the public internet, where it can run arbitrary script under the endpoint's origin. The client cannot control that, so the dialog confirms and names the endpoint before uploading, and the design document states that an endpoint should serve shared artifacts from an origin that hosts nothing else. Shipping without a default endpoint is the other deliberate trade-off: the action does nothing until a user configures a target, which is preferred over uploading artifacts anywhere by default.
- Not validated / out of scope: no endpoint implementation is shipped or run by this project, so the contract is verified against test doubles rather than a live service; the reference implementation in the design document is illustrative and untested here. Only macOS and Windows were left unverified locally. Published links are not tracked or listed anywhere — reopening Share uploads again rather than recalling a previous link, which would require persisting the URL on the artifact and a daemon change.
- Breaking changes / migration notes: none. The action is additive and inert until configured, and an internal helper for reading a workspace file was split so it can also return decoded text; its existing behaviour is unchanged.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 Web Shell 的 HTML 产物卡片上，于「下载」和「打开」之外新增第三个操作。使用它会把产物上传到用户自行提供的服务地址，并返回一个链接，可以发给没有工作区或 daemon 访问权限的人。

该地址就是一个 URL，契约中不包含任何特定服务商的内容：Web Shell 将 HTML 以 POST 发出，服务端返回 `{"url": "..."}` 格式的 JSON。任何能满足该契约的服务都可以使用——一个小型 serverless 函数、一个对象存储上传器、一个内网服务，或者本机上的一个脚本——因此客户端里没有写死任何特定托管服务商的东西。

默认不附带任何地址。首次使用该操作时会弹出对话框让用户配置；保存目标之后，该操作会在上传任何内容之前先显示一个确认，并写明目标地址。地址和可选的 bearer token 保存在 `localStorage` 中，与现有的主题和语言偏好并列，因此不涉及任何 daemon 路由，也不涉及设置 schema 条目。地址必须是 `https://`，仅回环地址允许使用普通的 `http://`。

该操作仅在确实是 HTML、且可从工作区读取的产物上出现，采用与「下载」已有的可用性规则相同的判断。本 PR 附带一份设计文档，涵盖服务端契约、安全考量以及一份参考实现。

## 为什么需要它

目前 HTML 产物只有能访问到生成它的 daemon 的人才能查看。要把它分享给同事、附到 issue 上，或者在手机上打开，每次都意味着手动下载文件再上传到别处。产物卡片本来就知道如何从工作区读取该文件——「下载」做的正是这件事——所以缺的是上传动作和由此得到的链接，而不是任何新的数据通路。

上传目标是有意不写死的。Qwen Code 自身并不运营任何托管服务，而在用户无感知的情况下把产物发送给第三方会构成隐私事故，因此目标是配置项，并且初始为空。这确实意味着在用户指定目标之前该操作是不起作用的，这是有意为之的取舍，而非疏漏。

## 审阅者测试计划

### 如何验证

在 Web Shell 中打开一个产生了 HTML 产物的会话，查看产物卡片。改动之前卡片提供「下载」和「打开」；改动之后，「分享」位于它们右侧。确认该操作在非 HTML 产物上不出现——例如 Markdown 文件、图片——并且在状态不是 available 的 HTML 产物上也不出现，与「下载」已有的隐藏条件一致。

在未配置任何地址的情况下对一个 HTML 产物选择「分享」，确认弹出的对话框会询问服务地址。为远程主机输入普通的 `http://` 地址，确认会被拒绝；`https://` 或 `http://localhost` 会被接受。将其指向任何接受 POST 并返回 `{"url": "https://..."}` 的服务，确认返回的链接会显示出来并且可以复制。之后重新打开「分享」，确认它现在会显示确认并写明已保存的地址，而不是再次询问 URL。

单元测试覆盖了地址与响应的校验、存储的往返读写、带 token 与不带 token 时的上传请求形态、各条失败路径，以及决定哪些产物提供该操作的规则：

```
cd packages/web-shell && npx vitest run client/components/artifacts/
Test Files  12 passed (12)
     Tests  184 passed (184)
```

也运行了整个包的测试套件：3802 项中 3801 项通过。唯一失败的是 `build-artifact.test.ts`，它读取构建产物 `dist/`，在未经修改的同一基线检出上同样失败，因此与本次改动无关。

### 证据（改动前后）

改动前——产物卡片提供「下载」和「打开」：

![before](https://raw.githubusercontent.com/qqqys/qwen-code/assets/artifact-share/docs/assets/artifact-share/before-artifact-card.png)

改动后——「分享」位于它们右侧：

![after](https://raw.githubusercontent.com/qqqys/qwen-code/assets/artifact-share/docs/assets/artifact-share/after-artifact-card.png)

在未配置任何地址时选择「分享」：

![dialog](https://raw.githubusercontent.com/qqqys/qwen-code/assets/artifact-share/docs/assets/artifact-share/after-share-dialog.png)

### 测试环境

|    操作系统    |  状态  |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境

vitest 下的单元测试，以及通过 Playwright 驱动 Web Shell 开发服务器、配合现有 mock daemon 测试装置得到的上述截图。

## 风险与范围

- 主要风险或取舍：发布会把模型生成的 HTML 放到公网上，它可以在该服务地址的源下执行任意脚本。客户端无法控制这一点，因此对话框会在上传前进行确认并写明地址，设计文档中也说明了服务端应当从一个不承载其他任何内容的源来提供被分享的产物。不附带默认地址是另一处有意的取舍：在用户配置目标之前该操作不做任何事，这优于默认把产物上传到任何地方。
- 未验证 / 范围之外：本项目不附带也不运行任何服务端实现，因此该契约是针对测试替身验证的，而非针对一个真实运行的服务；设计文档中的参考实现仅作示例，未在此处经过测试。本地未验证 macOS 与 Windows。已发布的链接不会被记录或列出——重新打开「分享」会再次上传，而不是取回之前的链接；要做到后者需要把 URL 持久化到产物上，并涉及 daemon 改动。
- 破坏性变更 / 迁移说明：无。该操作是纯新增的，且在配置之前不起作用；一个用于读取工作区文件的内部辅助函数被拆分，以便它也能返回解码后的文本，其既有行为未发生变化。

## 关联 Issue

无。

</details>
