### PR TITLE
fix(triage): compute the flake-gate diff before the env -i re-exec

### DIFF
--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -1014,18 +1014,26 @@ describe('qwen-triage: flakiness gate (#9125)', () => {
     // executes, so it is a changed test file exactly like M.
     assert.match(
       recordStep.run,
-      /^\s*git -c core\.quotePath=false diff -z --name-only --diff-filter=ACMRT "\$BASE_OID" HEAD \\\n\s*> "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all"$/m,
+      /^\s*\/usr\/bin\/git -c core\.quotePath=false diff -z --name-only --diff-filter=ACMRT "\$BASE_OID" HEAD \\\n\s*> "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all"$/m,
       'the NUL diff must flow straight into its file — $( ) strips NUL bytes, a pipeline swallows the exit status',
     );
     assert.match(
       recordStep.run,
-      /^\s*BASE_OID="\$\(cat "\$\{RUNNER_TEMP:\?\}\/verify-base-oid"\)"$/m,
+      /^\s*BASE_OID="\$\(\/usr\/bin\/cat "\$\{RUNNER_TEMP:\?\}\/verify-base-oid"\)"$/m,
       'the record step must diff against the base OID captured while .git was root-owned, not re-resolve HEAD^1',
     );
     assert.match(
       recordStep.run,
       /^\s*cp "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all" "\$GATE_HOME\/files-all"$/m,
       'the scrubbed child must copy the parent-recorded diff, never re-run git under env -i',
+    );
+    const recordDiffAt = recordStep.run.search(/^\s*\/usr\/bin\/git -c core\.quotePath=false diff -z/m);
+    const recordReExecAt = recordStep.run.search(/exec \/usr\/bin\/env -i/);
+    const recordCpAt = recordStep.run.search(/^\s*cp "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all" "\$GATE_HOME\/files-all"$/m);
+    assert.ok(
+      recordDiffAt !== -1 && recordReExecAt !== -1 && recordCpAt !== -1 &&
+        recordDiffAt < recordReExecAt && recordReExecAt < recordCpAt,
+      'the diff must be recorded in the parent arm before the env -i re-exec, and copied by the scrubbed child',
     );
     assert.ok(
       recordStep.run.includes(

--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -1014,13 +1014,18 @@ describe('qwen-triage: flakiness gate (#9125)', () => {
     // executes, so it is a changed test file exactly like M.
     assert.match(
       recordStep.run,
-      /^\s*git -c core\.quotePath=false diff -z --name-only --diff-filter=ACMRT "\$BASE_OID" HEAD \\\n\s*> "\$GATE_HOME\/files-all"$/m,
+      /^\s*git -c core\.quotePath=false diff -z --name-only --diff-filter=ACMRT "\$BASE_OID" HEAD \\\n\s*> "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all"$/m,
       'the NUL diff must flow straight into its file — $( ) strips NUL bytes, a pipeline swallows the exit status',
     );
     assert.match(
       recordStep.run,
       /^\s*BASE_OID="\$\(cat "\$\{RUNNER_TEMP:\?\}\/verify-base-oid"\)"$/m,
       'the record step must diff against the base OID captured while .git was root-owned, not re-resolve HEAD^1',
+    );
+    assert.match(
+      recordStep.run,
+      /^\s*cp "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all" "\$GATE_HOME\/files-all"$/m,
+      'the scrubbed child must copy the parent-recorded diff, never re-run git under env -i',
     );
     assert.ok(
       recordStep.run.includes(

--- a/.github/scripts/qwen-triage-workflow.test.mjs
+++ b/.github/scripts/qwen-triage-workflow.test.mjs
@@ -1019,8 +1019,23 @@ describe('qwen-triage: flakiness gate (#9125)', () => {
     );
     assert.match(
       recordStep.run,
+      /^\s*rm -rf -- "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all"\n\s*\/usr\/bin\/git -c core\.quotePath=false diff -z/m,
+      'the staging path must be unlinked immediately before the redirect — a planted symlink or directory there makes root write through it or hard-fail the record step',
+    );
+    assert.match(
+      recordStep.run,
       /^\s*BASE_OID="\$\(\/usr\/bin\/cat "\$\{RUNNER_TEMP:\?\}\/verify-base-oid"\)"$/m,
       'the record step must diff against the base OID captured while .git was root-owned, not re-resolve HEAD^1',
+    );
+    assert.match(
+      recordStep.run,
+      /^\s*case "\$BASE_OID" in$/m,
+      'the base OID must be shape-validated in the parent arm before the diff',
+    );
+    assert.match(
+      recordStep.run,
+      /^\s*\[0-9a-f\]\[0-9a-f\]\[0-9a-f\]\[0-9a-f\]\[0-9a-f\]\[0-9a-f\]\[0-9a-f\]\[0-9a-f\]\*\) ;;/m,
+      'the base OID shape must be an 8+-hex prefix — a planted valid OID would yield an empty diff and starve the gate into n/a',
     );
     assert.match(
       recordStep.run,
@@ -1030,10 +1045,20 @@ describe('qwen-triage: flakiness gate (#9125)', () => {
     const recordDiffAt = recordStep.run.search(/^\s*\/usr\/bin\/git -c core\.quotePath=false diff -z/m);
     const recordReExecAt = recordStep.run.search(/exec \/usr\/bin\/env -i/);
     const recordCpAt = recordStep.run.search(/^\s*cp "\$\{RUNNER_TEMP:\?\}\/flake-record-files-all" "\$GATE_HOME\/files-all"$/m);
+    const recordInstallAt = recordStep.run.search(/^\s*install -d -m 0700 -o root -g root "\$GATE_HOME"$/m);
     assert.ok(
-      recordDiffAt !== -1 && recordReExecAt !== -1 && recordCpAt !== -1 &&
-        recordDiffAt < recordReExecAt && recordReExecAt < recordCpAt,
-      'the diff must be recorded in the parent arm before the env -i re-exec, and copied by the scrubbed child',
+      recordDiffAt !== -1 && recordReExecAt !== -1 && recordCpAt !== -1 && recordInstallAt !== -1 &&
+        recordDiffAt < recordReExecAt && recordReExecAt < recordInstallAt && recordInstallAt < recordCpAt,
+      'the diff must be recorded in the parent arm before the env -i re-exec, and copied into the recreated root-only home',
+    );
+    // The scrubbed child must never re-run git under env -i: the ordering
+    // pin uses first-match semantics, so it cannot by itself forbid a
+    // second git in the child. Strip comments first (the child's own docs
+    // name `git diff` when describing what NOT to do) before asserting.
+    assert.doesNotMatch(
+      recordStep.run.slice(recordReExecAt).replace(/^\s*#.*$/gm, '').replace(/\\\n/g, ' '),
+      /\bgit\b[^\n]*\b(diff|log|show|whatchanged)\b/,
+      'the scrubbed child must never re-run git under env -i — that is the failure shape of run 32227155960',
     );
     assert.ok(
       recordStep.run.includes(

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -2914,12 +2914,13 @@ jobs:
               # the base. Write the NUL-delimited list under RUNNER_TEMP, which
               # the re-exec forwards; the clean child copies it into the gate
               # home below.
-              BASE_OID="$(cat "${RUNNER_TEMP:?}/verify-base-oid")"
+              BASE_OID="$(/usr/bin/cat "${RUNNER_TEMP:?}/verify-base-oid")"
               case "$BASE_OID" in
                 [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
-                *) echo "::error::No trusted base OID recorded; refusing to record the flakiness-gate file list."; exit 1 ;;
+                *) /usr/bin/printf '::error::No trusted base OID recorded; refusing to record the flakiness-gate file list.\n'; exit 1 ;;
               esac
-              git -c core.quotePath=false diff -z --name-only --diff-filter=ACMRT "$BASE_OID" HEAD \
+              rm -f -- "${RUNNER_TEMP:?}/flake-record-files-all"
+              /usr/bin/git -c core.quotePath=false diff -z --name-only --diff-filter=ACMRT "$BASE_OID" HEAD \
                 > "${RUNNER_TEMP:?}/flake-record-files-all"
               LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= exec /usr/bin/env -i \
                 PATH="$PATH" RUNNER_TEMP="${RUNNER_TEMP:-}" \

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -2903,6 +2903,24 @@ jobs:
                 /usr/bin/printf '::error::flake-gate record: step script changed between open and re-exec snapshot — refusing to run\n'
                 exit 1
               fi
+              # Record the changed-test list in the PARENT's normal environment,
+              # before the env -i re-exec: the scrubbed child cannot read the
+              # shallow merge-ref objects — git's `safe.directory` global config
+              # lives under HOME, which `env -i` strips, so git refuses to read
+              # the base commit object and the diff fails with
+              # "Could not access <base-oid>". The diff reads git metadata only
+              # and executes no PR code, so running it here is safe, and the
+              # "Pin agent inputs" step already proved this environment reads
+              # the base. Write the NUL-delimited list under RUNNER_TEMP, which
+              # the re-exec forwards; the clean child copies it into the gate
+              # home below.
+              BASE_OID="$(cat "${RUNNER_TEMP:?}/verify-base-oid")"
+              case "$BASE_OID" in
+                [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
+                *) echo "::error::No trusted base OID recorded; refusing to record the flakiness-gate file list."; exit 1 ;;
+              esac
+              git -c core.quotePath=false diff -z --name-only --diff-filter=ACMRT "$BASE_OID" HEAD \
+                > "${RUNNER_TEMP:?}/flake-record-files-all"
               LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= exec /usr/bin/env -i \
                 PATH="$PATH" RUNNER_TEMP="${RUNNER_TEMP:-}" \
                 GITHUB_OUTPUT="${GITHUB_OUTPUT:-}" GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY:-}" \
@@ -2975,21 +2993,11 @@ jobs:
           # T (typechange) included: a symlink->regular flip changes what
           # the runner executes, so it is a changed test file exactly
           # like M — excluding it silently drops the file from the gate.
-          # Diff against the base OID the "Pin agent inputs" step recorded
-          # while .git was still root-owned, never `HEAD^1` again: this
-          # step runs in the env -i scrubbed child, and resolving the `^1`
-          # parent there intermittently fails with "Could not access
-          # 'HEAD^1'" on the persistent pool — the shallow merge-ref object
-          # store is left in a state prior --depth=2 fetches made
-          # unreadable. The OID is content-addressed and needs no parent
-          # walk, so the diff works from the already-captured value.
-          BASE_OID="$(cat "${RUNNER_TEMP:?}/verify-base-oid")"
-          case "$BASE_OID" in
-            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
-            *) echo "::error::No trusted base OID recorded; refusing to record the flakiness-gate file list."; exit 1 ;;
-          esac
-          git -c core.quotePath=false diff -z --name-only --diff-filter=ACMRT "$BASE_OID" HEAD \
-            > "$GATE_HOME/files-all"
+          # The diff was already computed in the parent (before the env -i
+          # re-exec, where git can read the shallow merge-ref objects) and
+          # staged under RUNNER_TEMP; this scrubbed child only copies it
+          # into the root-only gate home.
+          cp "${RUNNER_TEMP:?}/flake-record-files-all" "$GATE_HOME/files-all"
           # .mts/.cts included: vitest's default include set collects them.
           # Only a no-match (status 1) may yield an empty list: a grep
           # error (status 2, e.g. ENOSPC opening the output) is

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -2919,7 +2919,7 @@ jobs:
                 [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) ;;
                 *) /usr/bin/printf '::error::No trusted base OID recorded; refusing to record the flakiness-gate file list.\n'; exit 1 ;;
               esac
-              rm -f -- "${RUNNER_TEMP:?}/flake-record-files-all"
+              rm -rf -- "${RUNNER_TEMP:?}/flake-record-files-all"
               /usr/bin/git -c core.quotePath=false diff -z --name-only --diff-filter=ACMRT "$BASE_OID" HEAD \
                 > "${RUNNER_TEMP:?}/flake-record-files-all"
               LD_PRELOAD= LD_AUDIT= LD_LIBRARY_PATH= exec /usr/bin/env -i \


### PR DESCRIPTION
## What this PR does

Fix the flake-gate "Record changed test files" step so it no longer runs `git diff` inside the `env -i` scrubbed child. The step now computes the NUL-delimited changed-test list in the parent (before the re-exec, where git can read the shallow merge-ref objects) and stages it under `RUNNER_TEMP`; the scrubbed child only copies it into the root-only gate home.

## Why it's needed

PR #9464 changed `git diff 'HEAD^1' HEAD` to `git diff "$BASE_OID" HEAD`, but that only renamed the failure: the verify lane still fails with `error: Could not access '577f719…'` (run 32227155960). The root cause is the `env -i` re-exec — git's global `safe.directory '*'` lives under `HOME`, which `env -i` strips, so git's ownership check refuses to read the base commit object. The same object is readable one step earlier in the normal environment.

## Reviewer Test Plan

### How to verify

Run the workflow structural suite and confirm the record-step pins pass:

```
node --test .github/scripts/qwen-triage-workflow.test.mjs
```

The suite `qwen-triage: flakiness gate (#9125)` passes, including `records the changed-test list…` and `the gate home sits at the container root…`. Confirm the record step's `git diff` now redirects to `${RUNNER_TEMP}/flake-record-files-all` and the scrubbed child does `cp` rather than re-running git.

### Evidence (Before & After)

N/A — non-UI CI workflow change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️   |
| 🪟 Windows | ⚠️   |
|  🐧 Linux  | ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: the changed-test list is now staged under `RUNNER_TEMP` (uid-1000-writable) before the re-exec. It is written by the parent and copied by the child immediately after, before any PR lifecycle code runs, so there is no window for a swap.
- Not validated / out of scope: whether the end-to-end `Could not access` failure is gone can only be observed after merge, when the next `/triage` runs the updated main-branch workflow.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes the flake-gate verify-lane failure observed in #9432 triage (run 32227155960).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 flake-gate「Record changed test files」步骤，使其不再在 `env -i` 清空后的子进程里跑 `git diff`。该步骤现在在 re-exec 之前（正常环境，能读到浅克隆 merge-ref 对象）计算出 NUL 分隔的改动测试文件列表，暂存到 `RUNNER_TEMP`；清空后的子进程只把它拷贝进根目录的 gate home。

## 为什么需要

#9464 把 `git diff 'HEAD^1' HEAD` 改成 `git diff "$BASE_OID" HEAD`，但只是把报错换了个名字：verify lane 仍报 `error: Could not access '577f719…'`（run 32227155960）。根因是 `env -i` 清空环境 —— git 的全局 `safe.directory '*'` 存在 `HOME` 下，`env -i` 把 `HOME` 也清了，git 的 ownership 检查就拒绝读 base commit 对象。同一个对象在前一步正常环境里是可读的。

## 审阅测试计划

### 如何验证

运行 workflow 结构测试并确认 record 步骤的 pin 通过：

```
node --test .github/scripts/qwen-triage-workflow.test.mjs
```

套件 `qwen-triage: flakiness gate (#9125)` 通过，包括 `records the changed-test list…` 和 `the gate home sits at the container root…`。确认 record 步骤的 `git diff` 现在重定向到 `${RUNNER_TEMP}/flake-record-files-all`，且清空后的子进程用 `cp` 而不是重跑 git。

### 证据（前后对比）

N/A —— 非 UI 的 CI workflow 改动。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️   |
| 🪟 Windows | ⚠️   |
|  🐧 Linux  | ✅   |

### 环境（可选）

N/A —— 仅单元测试。

## 风险与范围

- 主要风险或权衡：改动测试文件列表现在在 re-exec 前暂存到 `RUNNER_TEMP`（uid-1000 可写）。它由父进程写入、子进程随后立即拷贝，此时任何 PR 生命周期代码都还没跑，所以没有可被替换的窗口。
- 未验证 / 范围外：端到端的 `Could not access` 是否消失，只能在合并后、下次 `/triage` 跑更新后的 main 分支 workflow 时观察到。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

修复 #9432 triage 中观察到的 flake-gate verify-lane 失败（run 32227155960）。

</details>
