### PR TITLE
fix(ci): gate the fork signal on fields the review payload delivers

### DIFF
--- a/.github/workflows/qwen-autofix-fork-signal.yml
+++ b/.github/workflows/qwen-autofix-fork-signal.yml
@@ -68,25 +68,41 @@ jobs:
     # In-repo PRs keep their secrets and reach the review lane directly, so
     # signalling them would only dispatch a duplicate scan. The remaining
     # conjuncts MIRROR route's fork admission (qwen-autofix.yml's
-    # pull_request_review path): maintainer edits on, and the PR bot-authored
-    # or takeover-labeled — so an ordinary contributor's fork PR burns no
-    # signal/bridge/dispatched runs per review, and a takeover PR whose
-    # author turned maintainer edits off is never pushed into the credentialed
-    # lane. SKIP wins here as it wins everywhere: a skip-labeled PR's reviews
-    # would otherwise burn a signal + bridge run and a PR read before being
-    # discarded, repeating known-useless work on every review. The
-    # association list mirrors TRUSTED_ASSOC, the review-bot login mirrors
+    # pull_request_review path): the PR is bot-authored or takeover-labeled —
+    # so an ordinary contributor's fork PR burns no signal/bridge/dispatched
+    # runs per review. SKIP wins here as it wins everywhere: a skip-labeled
+    # PR's reviews would otherwise burn a signal + bridge run and a PR read
+    # before being discarded, repeating known-useless work on every review.
+    # The association list mirrors TRUSTED_ASSOC, the review-bot login mirrors
     # REVIEW_BOT, and the two labels mirror TAKEOVER_LABEL / SKIP_LABEL — all
     # pinned by the fork-bridge workflow test. The association is a WHEN
     # filter only: MEMBER/COLLABORATOR does not guarantee LIVE write
     # permission, so the bridge re-checks the reviewer live before
     # dispatching.
+    #
+    # MAINTAINER EDITS ARE NOT CHECKED HERE, deliberately, and this is the one
+    # conjunct that cannot live in this job. `pull_request_review` delivers
+    # the SIMPLE pull-request object, which carries no `maintainer_can_modify`
+    # — that field ships only on the full object the `pull_request` event
+    # sends. Reading it here yielded null on every delivery, `null == true` is
+    # false, and the gate could never open: across the 300 runs between this
+    # bridge shipping (#8676, 2026-08-07) and this fix, 290 skipped, 7
+    # cancelled, 1 action_required, and NOT ONE reached the signal step — so
+    # fork reviews silently fell back to the throttled cron backstop this
+    # bridge exists to get ahead of, and when that backstop stalled they fell
+    # through entirely. The consent check itself is not lost: the bridge
+    # re-reads it LIVE (`gh pr view --json maintainerCanModify` and a
+    # `select(… .maintainerCanModify == true)`), which is the only place it
+    # can be read at all — this job holds `permissions: {}`, no secrets and no
+    # checkout, so it has no way to ask the API. Nor is it weakened by moving:
+    # consent can be withdrawn between the review and the dispatch, so the
+    # live read was always the authoritative one and a payload copy could only
+    # ever have been a stale early-out.
     if: |-
       ${{ github.repository == 'QwenLM/qwen-code'
       && github.event.pull_request.head.repo.full_name != github.repository
       && github.event.pull_request.base.ref == 'main'
       && github.event.pull_request.state == 'open'
-      && github.event.pull_request.maintainer_can_modify == true
       && (github.event.pull_request.user.login == (vars.AUTOFIX_BOT_LOGIN || 'qwen-code-dev-bot')
       || contains(toJSON(github.event.pull_request.labels.*.name), '"autofix/takeover"'))
       && !contains(toJSON(github.event.pull_request.labels.*.name), '"autofix/skip"')

--- a/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
+++ b/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
@@ -219,7 +219,6 @@ describe('qwen autofix fork bridge', () => {
         '&& github.event.pull_request.head.repo.full_name != github.repository',
         "&& github.event.pull_request.base.ref == 'main'",
         "&& github.event.pull_request.state == 'open'",
-        '&& github.event.pull_request.maintainer_can_modify == true',
         `&& (github.event.pull_request.user.login == (vars.AUTOFIX_BOT_LOGIN || '${BOT_FALLBACK}')`,
         `|| contains(toJSON(github.event.pull_request.labels.*.name), '"${TAKEOVER_LABEL}"'))`,
         `&& !contains(toJSON(github.event.pull_request.labels.*.name), '"${SKIP_LABEL}"')`,
@@ -254,6 +253,43 @@ describe('qwen autofix fork bridge', () => {
     expect(bridgeScript).toContain(
       'if [[ "${SIGNAL_REVIEWER}" != "${REVIEW_BOT}" ]]; then',
     );
+  });
+
+  it('gates the signal only on fields the review payload actually delivers', () => {
+    // `pull_request_review` delivers the SIMPLE pull-request object. These
+    // fields exist only on the FULL object the `pull_request` event sends, so
+    // in this gate each one evaluates to null — and `null == true` is false,
+    // which closes the gate for every delivery rather than for the case the
+    // author meant to exclude. That is not hypothetical: `maintainer_can_modify`
+    // sat in this gate from #8676 (2026-08-07) until this test was written, and
+    // across 300 signal runs not one reached the signal step.
+    //
+    // A silent always-false is the worst failure this file can have. The gate
+    // has no observable output when it holds — the whole job is one echo — so a
+    // gate that never opens is indistinguishable from a repository where no fork
+    // review happened to qualify. Fork reviews just quietly fall back to the
+    // cron backstop, and when THAT stalls they fall through entirely.
+    //
+    // Anything on this list that the chain genuinely needs belongs in the
+    // bridge, which reads live PR state with credentials this job deliberately
+    // does not hold (`permissions: {}`, no secrets, no checkout).
+    const fullObjectOnlyFields = [
+      'maintainer_can_modify',
+      'mergeable',
+      'mergeable_state',
+      'rebaseable',
+      'merged',
+      'merged_by',
+      'additions',
+      'deletions',
+      'changed_files',
+      'commits',
+      'comments',
+      'review_comments',
+    ];
+    for (const field of fullObjectOnlyFields) {
+      expect(signalJob.if).not.toContain(`pull_request.${field}`);
+    }
   });
 
   it('keeps every identity literal pinned to qwen-autofix.yml', () => {

--- a/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
+++ b/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
@@ -94,6 +94,17 @@ const expressionsIn = (text) => {
 const readsASecret = (text) =>
   expressionsIn(text).some((expression) => /\bsecrets\./.test(expression));
 
+// GitHub Actions reaches a property through the documented `[ ]` index
+// operator as readily as through `.`, on any segment of the path, so
+// `pull_request['maintainer_can_modify']` resolves to the same absent field
+// as the dot form and closes the gate just as permanently. Rewriting the
+// index form to the dot form first means one matcher covers every
+// combination of the two, at any depth, instead of enumerating spellings.
+// (A `fromJSON(toJSON(github.event.pull_request))` round-trip still evades
+// this — no textual guard catches that one; it needs a live payload.)
+const asDotAccess = (text) =>
+  text.replace(/\[\s*(['"])([A-Za-z_][A-Za-z0-9_]*)\1\s*\]/g, '.$2');
+
 // Four of the full-object-only names below are strict PREFIXES of fields the
 // simple object does deliver (`merged` ⊂ `merged_at`, `commits` ⊂ `commits_url`,
 // `comments` ⊂ `comments_url`, `review_comments` ⊂ `review_comments_url`), so a
@@ -296,9 +307,24 @@ describe('qwen autofix fork bridge', () => {
       'review_comments',
     ];
     for (const field of fullObjectOnlyFields) {
-      expect(signalJob.if).not.toMatch(fullObjectOnlyReference(field));
+      expect(asDotAccess(signalJob.if)).not.toMatch(
+        fullObjectOnlyReference(field),
+      );
     }
   });
+
+  // Every spelling GitHub Actions accepts for one field reference. The gate
+  // is written in the dot form today, but an edit in any of the others reaches
+  // the same absent field and closes the gate just as permanently, so the
+  // guard has to see through all of them — and through none of them reject a
+  // delivered field that a full-object name merely prefixes.
+  const referenceSpellings = (field) => [
+    `github.event.pull_request.${field}`,
+    `github.event.pull_request['${field}']`,
+    `github.event.pull_request["${field}"]`,
+    `github.event['pull_request'].${field}`,
+    `github.event['pull_request']['${field}']`,
+  ];
 
   it('rejects a full-object field without rejecting the fields it prefixes', () => {
     const prefixPairs = [
@@ -308,11 +334,26 @@ describe('qwen autofix fork bridge', () => {
       ['review_comments', 'review_comments_url'],
     ];
     for (const [fullObjectOnly, delivered] of prefixPairs) {
-      expect(`github.event.pull_request.${delivered} == null`).not.toMatch(
-        fullObjectOnlyReference(fullObjectOnly),
-      );
-      expect(`github.event.pull_request.${fullObjectOnly} == false`).toMatch(
-        fullObjectOnlyReference(fullObjectOnly),
+      for (const spelling of referenceSpellings(delivered)) {
+        expect(asDotAccess(`${spelling} == null`)).not.toMatch(
+          fullObjectOnlyReference(fullObjectOnly),
+        );
+      }
+      for (const spelling of referenceSpellings(fullObjectOnly)) {
+        expect(asDotAccess(`${spelling} == false`)).toMatch(
+          fullObjectOnlyReference(fullObjectOnly),
+        );
+      }
+    }
+  });
+
+  it('sees a full-object field through the index operator', () => {
+    // The incident field, in the four non-dot spellings. Each is a legal
+    // expression resolving to the same absent property, so a guard blind to
+    // any of them lets the always-false gate return with this file green.
+    for (const spelling of referenceSpellings('maintainer_can_modify')) {
+      expect(asDotAccess(`${spelling} == true`)).toMatch(
+        fullObjectOnlyReference('maintainer_can_modify'),
       );
     }
   });

--- a/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
+++ b/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
@@ -94,6 +94,14 @@ const expressionsIn = (text) => {
 const readsASecret = (text) =>
   expressionsIn(text).some((expression) => /\bsecrets\./.test(expression));
 
+// Four of the full-object-only names below are strict PREFIXES of fields the
+// simple object does deliver (`merged` ⊂ `merged_at`, `commits` ⊂ `commits_url`,
+// `comments` ⊂ `comments_url`, `review_comments` ⊂ `review_comments_url`), so a
+// substring test would also reject those legal conjuncts. Anchor on a word
+// boundary so only a reference to the field itself matches.
+const fullObjectOnlyReference = (field) =>
+  new RegExp(`pull_request\\.${field}\\b`);
+
 describe('qwen autofix fork bridge', () => {
   it('keeps the trigger name and dispatch target wired together', () => {
     // Cross-FILE contracts that no single file can be read to verify. Each
@@ -288,7 +296,24 @@ describe('qwen autofix fork bridge', () => {
       'review_comments',
     ];
     for (const field of fullObjectOnlyFields) {
-      expect(signalJob.if).not.toContain(`pull_request.${field}`);
+      expect(signalJob.if).not.toMatch(fullObjectOnlyReference(field));
+    }
+  });
+
+  it('rejects a full-object field without rejecting the fields it prefixes', () => {
+    const prefixPairs = [
+      ['merged', 'merged_at'],
+      ['commits', 'commits_url'],
+      ['comments', 'comments_url'],
+      ['review_comments', 'review_comments_url'],
+    ];
+    for (const [fullObjectOnly, delivered] of prefixPairs) {
+      expect(`github.event.pull_request.${delivered} == null`).not.toMatch(
+        fullObjectOnlyReference(fullObjectOnly),
+      );
+      expect(`github.event.pull_request.${fullObjectOnly} == false`).toMatch(
+        fullObjectOnlyReference(fullObjectOnly),
+      );
     }
   });
 

--- a/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
+++ b/scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
@@ -322,6 +322,11 @@ describe('qwen autofix fork bridge', () => {
     `github.event.pull_request.${field}`,
     `github.event.pull_request['${field}']`,
     `github.event.pull_request["${field}"]`,
+    // Actions tolerates whitespace inside the index brackets, and so does
+    // `asDotAccess`. Without a spelling that carries it, the helper's two
+    // `\s*` are unpinned: deleting them leaves this file green while a gate
+    // written in the spaced form reaches the same absent field again.
+    `github.event.pull_request[ '${field}' ]`,
     `github.event['pull_request'].${field}`,
     `github.event['pull_request']['${field}']`,
   ];
@@ -348,7 +353,7 @@ describe('qwen autofix fork bridge', () => {
   });
 
   it('sees a full-object field through the index operator', () => {
-    // The incident field, in the four non-dot spellings. Each is a legal
+    // The incident field, in the five non-dot spellings. Each is a legal
     // expression resolving to the same absent property, so a guard blind to
     // any of them lets the always-false gate return with this file green.
     for (const spelling of referenceSpellings('maintainer_can_modify')) {


### PR DESCRIPTION
## What this PR does

Removes one conjunct from the `Qwen Autofix Fork Signal` job's `if`, and adds a regression test that stops it — or anything like it — from coming back.

The conjunct was `github.event.pull_request.maintainer_can_modify == true`. That field is not present in a `pull_request_review` payload. The event carries the **simple** pull-request object; `maintainer_can_modify` — along with `mergeable`, `mergeable_state`, `additions`, `deletions`, `changed_files`, and the rest of that family — ships only on the **full** object the `pull_request` event sends. The expression therefore evaluated to `null` on every delivery, `null == true` is `false`, and the job's gate could never hold.

## Why it's needed

The gate has never once opened. Across the 300 runs of this workflow between the bridge shipping (#8676, 2026-08-07) and today:

| conclusion | runs |
| --- | ---: |
| `skipped` | 290 |
| `cancelled` | 7 |
| `action_required` | 1 |
| **`success`** | **0** |

Because the signal never completes `success`, the `workflow_run`-triggered half (`qwen-autofix-fork-bridge.yml`) has never fired either. The entire bridge has been inert for twelve days. Every fork-PR review in that window was served by the scheduled `*/10` scan alone — precisely the throttled backstop this bridge exists to get ahead of, and the one the design notes call out as insufficient for real-time pickup.

This is not a theoretical cost. It surfaced because a scheduled-scan stall left takeover-managed fork PRs sitting on unaddressed Critical findings for hours with nothing to pick them up: the direct `pull_request_review` lane declines fork events by design (no secrets — `route` logs `fork review noted … the next scheduled scan engages`), the bridge that exists to cover that decline was inert, and the cron backstop was the only remaining path. Three paths, and the two that were supposed to provide redundancy were the same path.

### Why removing it is not a weakened check

The consent check does not move and is not lost — **the bridge already re-reads it live**, and always has:

```
gh pr view "${SIGNAL_PR}" --repo "${REPO}" \
  --json number,author,labels,headRefOid,isCrossRepository,maintainerCanModify,state,baseRefName
…
| select(.headRefOid == $sha and .isCrossRepository == true and .maintainerCanModify == true)
```

That live read was always the authoritative one. Consent can be withdrawn between the review and the dispatch, so a value copied out of the review payload could only ever have been a stale early-out, never the decision. The bridge's own comment already frames these conjuncts as "cheap early-outs, not a security boundary: review-scan re-derives all of it", and the signal's own comment says its gate "decides **WHEN**, never whether". `scripts/tests/qwen-autofix-fork-bridge-workflow.test.js` already pins both the live read (`expect(bridgeScript).toContain('maintainerCanModify == true')`) and a behavioral case for edits turned off since the review.

The signal job also **cannot** make this call itself. It holds `permissions: {}`, no secrets and no checkout, deliberately — it runs on a fork-triggered event, so it is built to hold nothing worth stealing. It has no way to ask the API for a field the payload does not carry. Removal is the only correct direction; there is no "read it properly here" option.

### Why a regression test, not just the deletion

This class of bug fails silently and is invisible from outside. The job's entire body is one `echo`; when the gate holds, nothing observable happens beyond a run turning green. So "the gate never opens" and "no fork review happened to qualify this week" look identical in the Actions tab. That is how it survived twelve days and 300 runs. The verbatim gate pin already in this test file did not help — it pins the gate against *drift*, and this gate was wrong the day it was written.

The new test asserts the gate references no full-object-only field, so a future conjunct reaching for `mergeable` or `changed_files` fails here rather than silently closing the gate forever.

## Reviewer Test Plan

### How to verify

**1. Confirm the field is genuinely absent from the payload.** From GitHub's published webhook types:

```
$ npm pack @octokit/webhooks-types && tar -xzf octokit-webhooks-types-*.tgz
$ grep -A8 'interface PullRequestReviewSubmittedEvent' package/schema.d.ts
export interface PullRequestReviewSubmittedEvent {
  action: "submitted";
  review: PullRequestReview;
  pull_request: SimplePullRequest;     <-- simple, not full
  …
}
```

`SimplePullRequest` carries exactly these fields, and `maintainer_can_modify` is not among them:

```
url id node_id html_url diff_url patch_url issue_url number state locked title
user body created_at updated_at closed_at merged_at merge_commit_sha assignee
assignees requested_reviewers requested_teams labels milestone draft commits_url
review_comments_url review_comment_url comments_url statuses_url head base
_links author_association auto_merge active_lock_reason
```

The full `PullRequest` interface — what the `pull_request` event sends — does carry it, alongside `mergeable` and `additions`.

**2. Confirm the observed effect.** `Qwen Autofix Fork Signal`, all runs to date: 290 `skipped`, 7 `cancelled`, 1 `action_required`, **0 `success`**. Includes deliveries where every other conjunct is verifiably true — e.g. run titled `fork-signal: PR 9384 reviewed by qwen-code-ci-bot` at `2026-08-19T01:47:08Z`, on a PR that is cross-repo, targets `main`, is open, carries `autofix/takeover`, does not carry `autofix/skip`, has `maintainer_can_modify: true` on the REST object, and was reviewed by `REVIEW_BOT`. Skipped.

**3. Run the tests.**

```
$ npx vitest run scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

**4. Mutation-verify the new test.** Re-add the conjunct to the workflow and re-run: `2 failed | 8 passed` — the verbatim gate pin and the new payload-field test both catch it. Restore, and it is `10 passed` again.

`scripts/tests/qwen-autofix-workflow.test.js` has one failure, `behaviorally replays the stale-duplicate revalidation, including the conflict-only transition`, which is a 5s `Test timed out` — **pre-existing and unrelated**: it reproduces identically on a pristine `upstream/main` with these changes stashed (`1 failed | 179 passed`), and this PR does not touch `qwen-autofix.yml`.

### Evidence (Before & After)

N/A — CI plumbing, no user-visible surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`npx vitest run scripts/tests/…`). The behavioral proof is the workflow-run history cited above; the gate itself can only be exercised by a real fork-PR review, which lands the first time this merges.

## Risk & Scope

- **Main risk or tradeoff:** a takeover-labeled fork PR whose author has turned maintainer edits **off** now burns one signal run, one bridge run, and one `gh pr view` before the bridge rejects it, where the gate previously intended to spend nothing. That is the whole cost, it is bounded at one review, and it buys back a path that has never worked. Ordinary contributor fork PRs are unaffected — the bot-authored-or-takeover-labeled conjunct still excludes them, which is where the run-burn concern actually bites.
- **Not validated / out of scope:** the gate cannot be exercised locally; the first real proof is a fork-PR review after this merges. Also out of scope: the scheduled-scan stall that made this inertness visible — separate problem, and this PR is what makes it non-fatal rather than what fixes it.
- **Breaking changes / migration notes:** none. No inputs, outputs, permissions, or run-name contracts change.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

从 `Qwen Autofix Fork Signal` 这个 job 的 `if` 条件中删掉一个合取项，并新增一个回归测试，防止它——或任何同类问题——再次出现。

被删掉的是 `github.event.pull_request.maintainer_can_modify == true`。这个字段在 `pull_request_review` 的事件负载中并不存在：该事件携带的是**简化版**的 pull-request 对象；`maintainer_can_modify`——连同 `mergeable`、`mergeable_state`、`additions`、`deletions`、`changed_files` 等同一族字段——只出现在 `pull_request` 事件发送的**完整**对象上。因此该表达式在每一次投递中都求值为 `null`，而 `null == true` 为 `false`，这个 job 的门禁永远无法通过。

## 为什么需要

这个门禁从来没有打开过一次。从该 bridge 上线（#8676，2026-08-07）到今天，这个 workflow 的全部 300 次运行中：

| 结论 | 次数 |
| --- | ---: |
| `skipped` | 290 |
| `cancelled` | 7 |
| `action_required` | 1 |
| **`success`** | **0** |

由于 signal 从未以 `success` 结束，其后由 `workflow_run` 触发的另一半（`qwen-autofix-fork-bridge.yml`）也从未启动过。整条 bridge 已经失效十二天。这段时间内所有 fork PR 的评审，都只由每 10 分钟一次的定时扫描承担——而那正是这条 bridge 为了抢在其前面而存在的、受限流的兜底路径，也正是设计说明中指出的、不足以支撑实时接管的那一条。

这不是纸面上的代价。问题之所以浮现，是因为一次定时扫描停摆，导致处于 takeover 管理下的 fork PR 带着未处理的 Critical 发现搁置数小时无人接手：直连的 `pull_request_review` 通道按设计拒绝 fork 事件（无密钥——`route` 的日志写着 `fork review noted … the next scheduled scan engages`），本该覆盖这一拒绝的 bridge 处于失效状态，于是定时兜底成了唯一剩下的路径。名义上三条路，而本应互为冗余的两条其实是同一条。

### 为什么删除它并不等于放松检查

这项同意检查既没有移位，也没有丢失——**bridge 一直在用实时数据重新读取它**：

```
gh pr view "${SIGNAL_PR}" --repo "${REPO}" \
  --json number,author,labels,headRefOid,isCrossRepository,maintainerCanModify,state,baseRefName
…
| select(.headRefOid == $sha and .isCrossRepository == true and .maintainerCanModify == true)
```

这次实时读取始终是权威判据。同意可能在评审与派发之间被撤回，因此从评审事件负载里抄来的值，充其量只能是一个陈旧的提前退出条件，从来都不是决策本身。bridge 自己的注释已经将这些合取项定性为「cheap early-outs, not a security boundary: review-scan re-derives all of it」，而 signal 自己的注释也写明其门禁「decides **WHEN**, never whether」。`scripts/tests/qwen-autofix-fork-bridge-workflow.test.js` 中已经同时钉住了这次实时读取（`expect(bridgeScript).toContain('maintainerCanModify == true')`）以及「评审之后关闭了 maintainer edits」这一行为用例。

signal 这个 job 也**没有能力**自行做出该判断。它持有 `permissions: {}`，无密钥、无 checkout，这是刻意为之——它运行在 fork 触发的事件上，因此被设计成不持有任何值得窃取的东西。它无从向 API 索取一个事件负载并未携带的字段。删除是唯一正确的方向；不存在「在这里正确地读取它」这个选项。

### 为什么要加回归测试，而不只是删掉

这一类缺陷是静默失败的，从外部完全不可见。该 job 的全部主体只有一条 `echo`；当门禁通过时，除了一次运行变绿之外不会发生任何可观测的事情。因此「门禁永远不开」与「这周恰好没有符合条件的 fork 评审」在 Actions 页面上看起来一模一样。它正是这样存活了十二天、300 次运行。该测试文件中已有的逐字门禁钉死并没有帮上忙——它钉的是门禁的**漂移**，而这个门禁在写下的那天就是错的。

新增的测试断言该门禁不引用任何「仅存在于完整对象」的字段，这样将来若有合取项去取 `mergeable` 或 `changed_files`，会在此处失败，而不是悄无声息地把门永久关死。

## 评审者测试计划

### 如何验证

**1. 确认该字段在事件负载中确实不存在。** 取自 GitHub 公布的 webhook 类型定义：

```
$ npm pack @octokit/webhooks-types && tar -xzf octokit-webhooks-types-*.tgz
$ grep -A8 'interface PullRequestReviewSubmittedEvent' package/schema.d.ts
export interface PullRequestReviewSubmittedEvent {
  action: "submitted";
  review: PullRequestReview;
  pull_request: SimplePullRequest;     <-- 简化版，不是完整版
  …
}
```

`SimplePullRequest` 携带的字段恰好是以下这些，其中并无 `maintainer_can_modify`：

```
url id node_id html_url diff_url patch_url issue_url number state locked title
user body created_at updated_at closed_at merged_at merge_commit_sha assignee
assignees requested_reviewers requested_teams labels milestone draft commits_url
review_comments_url review_comment_url comments_url statuses_url head base
_links author_association auto_merge active_lock_reason
```

而完整的 `PullRequest` 接口——即 `pull_request` 事件所发送的那个——确实携带该字段，同时也携带 `mergeable` 与 `additions`。

**2. 确认实际观测到的效果。** `Qwen Autofix Fork Signal` 至今的全部运行：290 次 `skipped`、7 次 `cancelled`、1 次 `action_required`、**0 次 `success`**。其中包括其余每一个合取项都可验证为真的投递——例如 `2026-08-19T01:47:08Z` 那次标题为 `fork-signal: PR 9384 reviewed by qwen-code-ci-bot` 的运行，对应的 PR 跨仓库、目标为 `main`、处于 open、带有 `autofix/takeover`、不带 `autofix/skip`、REST 对象上 `maintainer_can_modify: true`、评审者为 `REVIEW_BOT`。结果仍是 skipped。

**3. 运行测试。**

```
$ npx vitest run scripts/tests/qwen-autofix-fork-bridge-workflow.test.js
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

**4. 对新测试做变异验证。** 把该合取项加回 workflow 后重跑：`2 failed | 8 passed`——逐字门禁钉死与新增的负载字段测试都会捕获它。恢复后重新变为 `10 passed`。

`scripts/tests/qwen-autofix-workflow.test.js` 中有一处失败，`behaviorally replays the stale-duplicate revalidation, including the conflict-only transition`，报的是 5 秒 `Test timed out`——**既有问题且与本 PR 无关**：将本次改动 stash 后在干净的 `upstream/main` 上可原样复现（`1 failed | 179 passed`），且本 PR 并未改动 `qwen-autofix.yml`。

### 证据（改动前后）

N/A —— CI 管道改动，无用户可见界面。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元测试（`npx vitest run scripts/tests/…`）。行为层面的证据是上文引用的 workflow 运行历史；门禁本身只能由一次真实的 fork PR 评审来触发，即本 PR 合入后的第一次。

## 风险与范围

- **主要风险或权衡：** 若某个带 `autofix/takeover` 标签的 fork PR，其作者已关闭 maintainer edits，那么现在会先消耗一次 signal 运行、一次 bridge 运行和一次 `gh pr view`，随后才被 bridge 拒绝——而原门禁的意图是在此情形下不消耗任何资源。这就是全部代价，其上界为每次评审一次，换回的是一条从未生效过的通路。普通贡献者的 fork PR 不受影响——「由 bot 创建或带 takeover 标签」这一合取项仍将其排除在外，而这才是「消耗运行次数」这一顾虑真正起作用的地方。
- **未验证 / 不在范围内：** 该门禁无法在本地触发；第一次真正的验证是本 PR 合入后的一次 fork PR 评审。同样不在范围内的是：使这一失效状态暴露出来的定时扫描停摆——那是另一个问题，本 PR 的作用是让它不再是致命的，而不是修复它。
- **破坏性变更 / 迁移说明：** 无。输入、输出、权限以及 run-name 契约均未改变。

## 关联 Issue

无。

</details>
