### PR TITLE
fix(core): isolate fork cache readers by session

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -4037,8 +4037,8 @@ export class GeminiClient {
 
       if (!turn.pendingToolCalls.length && signal && !signal.aborted) {
         // Save cache-safe params here — before any early return — so that
-        // background extract/dream agents calling getCacheSafeParams() always
-        // see the current turn's history regardless of which path exits below.
+        // background readers calling getCacheSafeParams(sessionId) can see the
+        // current turn's history regardless of which path exits below.
         try {
           const chat = this.getChat();
           const maxHistoryForCache = 40;

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -12,15 +12,19 @@ import {
 } from './speculation.js';
 import type { Content } from '@google/genai';
 import { ApprovalMode, type Config } from '../config/config.js';
+import type { CacheSafeParams } from '../utils/forkedAgent.js';
 import type { ToolResultBoundaryObservation } from '../utils/tool-result-boundary-diagnostics.js';
 
 const forkedAgentMocks = vi.hoisted(() => ({
-  getCacheSafeParams: vi.fn(() => ({
+  getCacheSafeParams: vi.fn<
+    (expectedSessionId?: string) => CacheSafeParams | null
+  >(() => ({
     generationConfig: {},
     history: [],
     model: 'qwen-fast',
     version: 1,
   })),
+  createForkedChat: vi.fn(),
   runForkedAgent: vi.fn(),
   sendMessageStream: vi.fn(),
 }));
@@ -40,9 +44,11 @@ vi.mock(
 
 vi.mock('../utils/forkedAgent.js', () => ({
   getCacheSafeParams: forkedAgentMocks.getCacheSafeParams,
-  createForkedChat: vi.fn(() => ({
-    sendMessageStream: forkedAgentMocks.sendMessageStream,
-  })),
+  createForkedChat: forkedAgentMocks.createForkedChat.mockImplementation(
+    () => ({
+      sendMessageStream: forkedAgentMocks.sendMessageStream,
+    }),
+  ),
   runForkedAgent: forkedAgentMocks.runForkedAgent,
   runWithForkedChatModel: vi.fn(
     async (
@@ -58,6 +64,20 @@ afterEach(() => {
 });
 
 describe('startSpeculation', () => {
+  it('does not start when the session-scoped lookup returns null', async () => {
+    const config = {
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
+    } as unknown as Config;
+    forkedAgentMocks.getCacheSafeParams.mockReturnValueOnce(null);
+
+    await expect(startSpeculation(config, 'read a.ts')).rejects.toThrow(
+      'CacheSafeParams not available for speculation',
+    );
+
+    expect(forkedAgentMocks.createForkedChat).not.toHaveBeenCalled();
+    expect(forkedAgentMocks.runForkedAgent).not.toHaveBeenCalled();
+  });
+
   it('stops at a boundary when the host guard denies a speculative invocation', async () => {
     const execute = vi.fn();
     const guard = vi.fn().mockResolvedValue({
@@ -599,6 +619,42 @@ describe('startSpeculation', () => {
       /omitted during speculative execution/i,
     );
     expect(speculativeResponse).not.toHaveProperty('parts');
+
+    await abortSpeculation(state);
+  });
+
+  it('does not generate a pipelined suggestion when its scoped lookup returns null', async () => {
+    const config = {
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getCwd: vi.fn().mockReturnValue(process.cwd()),
+      getFastModel: vi.fn().mockReturnValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
+    } as unknown as Config;
+    forkedAgentMocks.getCacheSafeParams
+      .mockReturnValueOnce({
+        generationConfig: {},
+        history: [],
+        model: 'qwen-fast',
+        version: 1,
+      })
+      .mockReturnValueOnce(null);
+    forkedAgentMocks.sendMessageStream.mockImplementation(async function* () {
+      yield {
+        type: 'chunk',
+        value: {
+          candidates: [{ content: { parts: [{ text: 'done' }] } }],
+        },
+      };
+    });
+
+    const state = await startSpeculation(config, 'do something');
+    await vi.waitFor(() => expect(state.status).toBe('completed'));
+    await vi.waitFor(() =>
+      expect(forkedAgentMocks.getCacheSafeParams).toHaveBeenCalledTimes(2),
+    );
+
+    expect(forkedAgentMocks.runForkedAgent).not.toHaveBeenCalled();
+    expect(state.pipelinedSuggestion).toBeUndefined();
 
     await abortSpeculation(state);
   });

--- a/packages/core/src/followup/speculation.test.ts
+++ b/packages/core/src/followup/speculation.test.ts
@@ -15,6 +15,12 @@ import { ApprovalMode, type Config } from '../config/config.js';
 import type { ToolResultBoundaryObservation } from '../utils/tool-result-boundary-diagnostics.js';
 
 const forkedAgentMocks = vi.hoisted(() => ({
+  getCacheSafeParams: vi.fn(() => ({
+    generationConfig: {},
+    history: [],
+    model: 'qwen-fast',
+    version: 1,
+  })),
   runForkedAgent: vi.fn(),
   sendMessageStream: vi.fn(),
 }));
@@ -33,12 +39,7 @@ vi.mock(
 );
 
 vi.mock('../utils/forkedAgent.js', () => ({
-  getCacheSafeParams: vi.fn(() => ({
-    generationConfig: {},
-    history: [],
-    model: 'qwen-fast',
-    version: 1,
-  })),
+  getCacheSafeParams: forkedAgentMocks.getCacheSafeParams,
   createForkedChat: vi.fn(() => ({
     sendMessageStream: forkedAgentMocks.sendMessageStream,
   })),
@@ -112,6 +113,9 @@ describe('startSpeculation', () => {
     const state = await startSpeculation(config, 'read a.ts');
     await vi.waitFor(() => expect(state.status).toBe('boundary'));
 
+    expect(forkedAgentMocks.getCacheSafeParams).toHaveBeenCalledWith(
+      'spec-session',
+    );
     expect(guard).toHaveBeenCalledWith({
       callId: 'call-speculation-guard',
       toolName: 'read_file',
@@ -179,7 +183,14 @@ describe('startSpeculation', () => {
 
     const state = await startSpeculation(config, 'read a.ts');
     await vi.waitFor(() => expect(state.status).toBe('completed'));
+    await vi.waitFor(() =>
+      expect(forkedAgentMocks.getCacheSafeParams).toHaveBeenCalledTimes(2),
+    );
 
+    expect(forkedAgentMocks.getCacheSafeParams).toHaveBeenNthCalledWith(
+      2,
+      'spec-session',
+    );
     expect(guard).toHaveBeenCalledWith({
       callId: 'call-speculation-guard-allow',
       toolName: 'read_file',
@@ -212,6 +223,7 @@ describe('startSpeculation', () => {
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getCwd: vi.fn().mockReturnValue(process.cwd()),
       getFastModel: vi.fn().mockReturnValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
       getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
     } as unknown as Config;
 
@@ -295,6 +307,7 @@ describe('startSpeculation', () => {
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getCwd: vi.fn().mockReturnValue(process.cwd()),
       getFastModel: vi.fn().mockReturnValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
       getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
     } as unknown as Config;
 
@@ -357,6 +370,7 @@ describe('startSpeculation', () => {
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getCwd: vi.fn().mockReturnValue(process.cwd()),
       getFastModel: vi.fn().mockReturnValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
       getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
     } as unknown as Config;
 
@@ -418,6 +432,7 @@ describe('startSpeculation', () => {
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getCwd: vi.fn().mockReturnValue(process.cwd()),
       getFastModel: vi.fn().mockReturnValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
       getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
     } as unknown as Config;
 
@@ -481,6 +496,7 @@ describe('startSpeculation', () => {
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getCwd: vi.fn().mockReturnValue(process.cwd()),
       getFastModel: vi.fn().mockReturnValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
       getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
       getToolOutputBatchBudget: vi.fn().mockReturnValue(10_000),
     } as unknown as Config;
@@ -544,6 +560,7 @@ describe('startSpeculation', () => {
       getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       getCwd: vi.fn().mockReturnValue(process.cwd()),
       getFastModel: vi.fn().mockReturnValue(undefined),
+      getSessionId: vi.fn().mockReturnValue('spec-session'),
       getToolRegistry: vi.fn().mockReturnValue(toolRegistry),
     } as unknown as Config;
     forkedAgentMocks.runForkedAgent.mockResolvedValue({
@@ -606,6 +623,7 @@ describe.each([
         getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
         getCwd: vi.fn().mockReturnValue(process.cwd()),
         getFastModel: vi.fn().mockReturnValue(fastModel),
+        getSessionId: vi.fn().mockReturnValue('spec-session'),
         getToolRegistry: vi.fn().mockReturnValue({
           ensureTool: vi.fn().mockResolvedValue({
             build: vi.fn().mockReturnValue({

--- a/packages/core/src/followup/speculation.ts
+++ b/packages/core/src/followup/speculation.ts
@@ -141,7 +141,7 @@ export async function startSpeculation(
   parentSignal?: AbortSignal,
   options?: { model?: string },
 ): Promise<SpeculationState> {
-  const cacheSafe = getCacheSafeParams();
+  const cacheSafe = getCacheSafeParams(config.getSessionId());
   if (!cacheSafe) {
     throw new Error('CacheSafeParams not available for speculation');
   }
@@ -718,7 +718,7 @@ The assistant responded: ${speculatedSummary || '(tool calls executed)'}
 
 ${SUGGESTION_PROMPT}`;
 
-    const cacheSafeParams = getCacheSafeParams();
+    const cacheSafeParams = getCacheSafeParams(config.getSessionId());
     if (!cacheSafeParams) return null;
     const model = modelOverride ?? config.getFastModel();
     const resolvedModel = model ?? cacheSafeParams.model;

--- a/packages/core/src/followup/suggestionGenerator.test.ts
+++ b/packages/core/src/followup/suggestionGenerator.test.ts
@@ -85,6 +85,7 @@ describe('generatePromptSuggestion', () => {
       enableCacheSharing: true,
     });
 
+    expect(mockGetCacheSafeParams).toHaveBeenCalledWith('test-session');
     expect(mockRunForkedAgent).toHaveBeenCalledWith(
       expect.objectContaining({ model: 'main-model', abortSignal: signal }),
     );
@@ -175,8 +176,8 @@ describe('generatePromptSuggestion', () => {
       { enableCacheSharing: true },
     );
 
-    // The foreign slot is rejected before cloning the full cached payload.
-    expect(mockGetCacheSafeParams).not.toHaveBeenCalled();
+    // The cache API rejects the foreign slot before cloning its payload.
+    expect(mockGetCacheSafeParams).toHaveBeenCalledWith('session-A');
     // The fork must NOT be used for a foreign session's params.
     expect(mockRunForkedAgent).not.toHaveBeenCalled();
     // The session-safe base-LLM path is used instead.

--- a/packages/core/src/followup/suggestionGenerator.ts
+++ b/packages/core/src/followup/suggestionGenerator.ts
@@ -110,18 +110,15 @@ export async function generatePromptSuggestion(
     const cacheSafeSessionId = options?.enableCacheSharing
       ? getCacheSafeParamsSessionId()
       : undefined;
-    const cacheSafe =
-      cacheSafeSessionId === sessionId ? getCacheSafeParams() : null;
+    const cacheSafe = options?.enableCacheSharing
+      ? getCacheSafeParams(sessionId)
+      : null;
     // The cache-safe slot is a process-global: in a multi-session daemon it
     // can hold ANOTHER session's transcript + systemInstruction. Only use it
     // when it belongs to THIS session; otherwise fall back to the
     // session-safe base-LLM path (#9233).
-    const sessionCacheSafe =
-      cacheSafe && cacheSafe.sessionId === config.getSessionId()
-        ? cacheSafe
-        : null;
     const modelOverride = options?.model;
-    const cacheSharingState = sessionCacheSafe
+    const cacheSharingState = cacheSafe
       ? 'true'
       : cacheSafeSessionId
         ? 'session_mismatch'
@@ -129,10 +126,10 @@ export async function generatePromptSuggestion(
     debugLogger.debug(
       `Generating suggestion: cacheSharing=${cacheSharingState}, model=${modelOverride || '(default)'}`,
     );
-    const raw = sessionCacheSafe
+    const raw = cacheSafe
       ? await generateViaForkedQuery(
           config,
-          sessionCacheSafe,
+          cacheSafe,
           abortSignal,
           modelOverride,
         )

--- a/packages/core/src/memory/extract.test.ts
+++ b/packages/core/src/memory/extract.test.ts
@@ -19,9 +19,15 @@ import {
   rebuildUserAutoMemoryIndex,
 } from './indexer.js';
 import { refreshMemoryInstruction } from './refresh.js';
+import { getCacheSafeParamsSessionId } from '../utils/forkedAgent.js';
 
 vi.mock('./extractionAgentPlanner.js', () => ({
   runAutoMemoryExtractionByAgent: vi.fn(),
+}));
+
+vi.mock('../utils/forkedAgent.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/forkedAgent.js')>()),
+  getCacheSafeParamsSessionId: vi.fn(),
 }));
 
 vi.mock('./indexer.js', () => ({
@@ -75,6 +81,7 @@ describe('auto-memory extraction', () => {
       getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
     } as unknown as Config;
     vi.clearAllMocks();
+    vi.mocked(getCacheSafeParamsSessionId).mockReturnValue('session-1');
   });
 
   afterEach(async () => {
@@ -123,6 +130,45 @@ describe('auto-memory extraction', () => {
 
     expect(cursor.sessionId).toBe('session-1');
     expect(cursor.processedOffset).toBe(2);
+  });
+
+  it('skips a session mismatch without advancing the cursor', async () => {
+    vi.mocked(getCacheSafeParamsSessionId).mockReturnValue('session-2');
+    const cursorBefore = await fs.readFile(
+      getAutoMemoryExtractCursorPath(projectRoot),
+      'utf-8',
+    );
+
+    const result = await runAutoMemoryExtract({
+      projectRoot,
+      sessionId: 'session-1',
+      config: mockConfig,
+      history: [{ role: 'user', parts: [{ text: 'Remember this.' }] }],
+    });
+
+    expect(result.skippedReason).toBe('session_mismatch');
+    expect(result.cursor.processedOffset).toBeUndefined();
+    expect(runAutoMemoryExtractionByAgent).not.toHaveBeenCalled();
+    expect(
+      await fs.readFile(getAutoMemoryExtractCursorPath(projectRoot), 'utf-8'),
+    ).toBe(cursorBefore);
+  });
+
+  it('preserves the empty-cache failure path', async () => {
+    vi.mocked(getCacheSafeParamsSessionId).mockReturnValue(undefined);
+    vi.mocked(runAutoMemoryExtractionByAgent).mockRejectedValueOnce(
+      new Error('no cache-safe params'),
+    );
+
+    await expect(
+      runAutoMemoryExtract({
+        projectRoot,
+        sessionId: 'session-1',
+        config: mockConfig,
+        history: [{ role: 'user', parts: [{ text: 'Remember this.' }] }],
+      }),
+    ).rejects.toThrow('no cache-safe params');
+    expect(runAutoMemoryExtractionByAgent).toHaveBeenCalledOnce();
   });
 
   it('throws when config is missing because heuristic fallback was removed', async () => {

--- a/packages/core/src/memory/extract.test.ts
+++ b/packages/core/src/memory/extract.test.ts
@@ -133,7 +133,9 @@ describe('auto-memory extraction', () => {
   });
 
   it('skips a session mismatch without advancing the cursor', async () => {
-    vi.mocked(getCacheSafeParamsSessionId).mockReturnValue('session-2');
+    vi.mocked(getCacheSafeParamsSessionId)
+      .mockReturnValueOnce('session-1')
+      .mockReturnValueOnce('session-2');
     const cursorBefore = await fs.readFile(
       getAutoMemoryExtractCursorPath(projectRoot),
       'utf-8',
@@ -152,6 +154,24 @@ describe('auto-memory extraction', () => {
     expect(
       await fs.readFile(getAutoMemoryExtractCursorPath(projectRoot), 'utf-8'),
     ).toBe(cursorBefore);
+  });
+
+  it('skips an existing session mismatch before scaffold IO', async () => {
+    vi.mocked(getCacheSafeParamsSessionId).mockReturnValue('session-2');
+    const uncreatedProjectRoot = path.join(tempDir, 'not-created');
+
+    const result = await runAutoMemoryExtract({
+      projectRoot: uncreatedProjectRoot,
+      sessionId: 'session-1',
+      config: mockConfig,
+      history: [{ role: 'user', parts: [{ text: 'Remember this.' }] }],
+    });
+
+    expect(result.skippedReason).toBe('session_mismatch');
+    await expect(fs.stat(uncreatedProjectRoot)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    expect(runAutoMemoryExtractionByAgent).not.toHaveBeenCalled();
   });
 
   it('preserves the empty-cache failure path', async () => {

--- a/packages/core/src/memory/extract.ts
+++ b/packages/core/src/memory/extract.ts
@@ -23,6 +23,7 @@ import {
   rebuildManagedAutoMemoryIndex,
   rebuildUserAutoMemoryIndex,
 } from './indexer.js';
+import { getCacheSafeParamsSessionId } from '../utils/forkedAgent.js';
 import { refreshMemoryInstruction } from './refresh.js';
 import {
   type AutoMemoryExtractCursor,
@@ -38,7 +39,8 @@ export interface AutoMemoryExtractResult {
     | 'already_running'
     | 'queued'
     | 'memory_tool'
-    | 'memory_pressure';
+    | 'memory_pressure'
+    | 'session_mismatch';
   systemMessage?: string;
   cursor: AutoMemoryExtractCursor;
 }
@@ -157,6 +159,22 @@ export async function runAutoMemoryExtract(params: {
     };
     await writeExtractCursor(params.projectRoot, cursor);
     return { touchedTopics: [], cursor };
+  }
+
+  const cachedSessionId = getCacheSafeParamsSessionId();
+  if (
+    cachedSessionId !== undefined &&
+    cachedSessionId !== params.config.getSessionId()
+  ) {
+    debugLogger.debug('Skipping auto-memory extract: session_mismatch.');
+    return {
+      touchedTopics: [],
+      skippedReason: 'session_mismatch',
+      cursor: {
+        sessionId: params.sessionId,
+        updatedAt: now.toISOString(),
+      },
+    };
   }
 
   const agentResult = await runAutoMemoryExtractionByAgent(

--- a/packages/core/src/memory/extract.ts
+++ b/packages/core/src/memory/extract.ts
@@ -45,6 +45,26 @@ export interface AutoMemoryExtractResult {
   cursor: AutoMemoryExtractCursor;
 }
 
+function getSessionMismatchResult(
+  sessionId: string,
+  expectedSessionId: string,
+  now: Date,
+): AutoMemoryExtractResult | null {
+  const cachedSessionId = getCacheSafeParamsSessionId();
+  if (cachedSessionId === undefined || cachedSessionId === expectedSessionId) {
+    return null;
+  }
+  debugLogger.debug('Skipping auto-memory extract: session_mismatch.');
+  return {
+    touchedTopics: [],
+    skippedReason: 'session_mismatch',
+    cursor: {
+      sessionId,
+      updatedAt: now.toISOString(),
+    },
+  };
+}
+
 async function readExtractCursor(
   projectRoot: string,
 ): Promise<AutoMemoryExtractCursor> {
@@ -110,6 +130,19 @@ export async function runAutoMemoryExtract(params: {
   config?: Config;
 }): Promise<AutoMemoryExtractResult> {
   const now = params.now ?? new Date();
+  if (!params.config) {
+    throw new Error(
+      'Managed auto-memory extraction requires config for forked-agent execution.',
+    );
+  }
+  const expectedSessionId = params.config.getSessionId();
+  const earlyMismatch = getSessionMismatchResult(
+    params.sessionId,
+    expectedSessionId,
+    now,
+  );
+  if (earlyMismatch) return earlyMismatch;
+
   // Per-project scaffold is required (extraction cursor + metadata live
   // there). User-level scaffold is optional — a brand-new user without
   // write access to `~/.qwen/memories/` should still be able to use
@@ -120,12 +153,6 @@ export async function runAutoMemoryExtract(params: {
   } catch (error) {
     debugLogger.warn(
       `User-level auto-memory scaffold failed (non-critical, will skip user-level writes this run): ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  if (!params.config) {
-    throw new Error(
-      'Managed auto-memory extraction requires config for forked-agent execution.',
     );
   }
 
@@ -161,21 +188,12 @@ export async function runAutoMemoryExtract(params: {
     return { touchedTopics: [], cursor };
   }
 
-  const cachedSessionId = getCacheSafeParamsSessionId();
-  if (
-    cachedSessionId !== undefined &&
-    cachedSessionId !== params.config.getSessionId()
-  ) {
-    debugLogger.debug('Skipping auto-memory extract: session_mismatch.');
-    return {
-      touchedTopics: [],
-      skippedReason: 'session_mismatch',
-      cursor: {
-        sessionId: params.sessionId,
-        updatedAt: now.toISOString(),
-      },
-    };
-  }
+  const lateMismatch = getSessionMismatchResult(
+    params.sessionId,
+    expectedSessionId,
+    now,
+  );
+  if (lateMismatch) return lateMismatch;
 
   const agentResult = await runAutoMemoryExtractionByAgent(
     params.config,

--- a/packages/core/src/memory/extract.ts
+++ b/packages/core/src/memory/extract.ts
@@ -129,7 +129,8 @@ export async function runAutoMemoryExtract(params: {
 
   // Read the cursor first, then scan only the unprocessed slice. The old
   // code ran partToString().replace() over EVERY message but the resulting
-  // text was never read — fork agent context comes from getCacheSafeParams().
+  // text was never read — fork agent context comes from the session-scoped
+  // cache-safe params lookup.
   const currentCursor = await readExtractCursor(params.projectRoot);
   const rawOffset =
     currentCursor.sessionId === params.sessionId

--- a/packages/core/src/memory/extractAgent.test.ts
+++ b/packages/core/src/memory/extractAgent.test.ts
@@ -22,7 +22,9 @@ vi.mock('./extractionAgentPlanner.js', () => ({
 describe('auto-memory extraction with agent planner', () => {
   let tempDir: string;
   let projectRoot: string;
-  const mockConfig = {} as Config;
+  const mockConfig = {
+    getSessionId: () => 'session-1',
+  } as Config;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(

--- a/packages/core/src/memory/extractionAgentPlanner.test.ts
+++ b/packages/core/src/memory/extractionAgentPlanner.test.ts
@@ -94,6 +94,7 @@ describe('runAutoMemoryExtractionByAgent', () => {
       hasToolActivity: true,
       systemMessage: 'Managed auto-memory updated: user.md',
     });
+    expect(getCacheSafeParams).toHaveBeenCalledWith('session-1');
     expect(runForkedAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         tools: [

--- a/packages/core/src/memory/extractionAgentPlanner.ts
+++ b/packages/core/src/memory/extractionAgentPlanner.ts
@@ -247,7 +247,7 @@ export async function runAutoMemoryExtractionByAgent(
   config: Config,
   projectRoot: string,
 ): Promise<AutoMemoryExtractionExecutionResult> {
-  const cacheSafe = getCacheSafeParams();
+  const cacheSafe = getCacheSafeParams(config.getSessionId());
   if (!cacheSafe) {
     throw new Error(
       'runAutoMemoryExtractionByAgent: no cache-safe params available; ' +

--- a/packages/core/src/memory/manager.test.ts
+++ b/packages/core/src/memory/manager.test.ts
@@ -19,6 +19,15 @@ import type { Config } from '../config/config.js';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
+const telemetryMocks = vi.hoisted(() => ({
+  logMemoryExtract: vi.fn(),
+}));
+
+vi.mock('../telemetry/index.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../telemetry/index.js')>()),
+  logMemoryExtract: telemetryMocks.logMemoryExtract,
+}));
+
 vi.mock('./extract.js', () => ({
   runAutoMemoryExtract: vi.fn(),
 }));
@@ -135,6 +144,38 @@ describe('MemoryManager', () => {
       await mgr.drain();
       const tasks = mgr.listTasksByType('extract', projectRoot);
       expect(tasks.some((t) => t.status === 'completed')).toBe(true);
+    });
+
+    it('records a session mismatch as skipped', async () => {
+      vi.mocked(runAutoMemoryExtract).mockResolvedValue({
+        touchedTopics: [],
+        skippedReason: 'session_mismatch',
+        cursor: { sessionId: 'sess-1', updatedAt: new Date().toISOString() },
+      });
+      const config = makeMockConfig();
+
+      const mgr = new MemoryManager();
+      const result = await mgr.scheduleExtract({
+        projectRoot,
+        sessionId: 'sess-1',
+        config,
+        history: [{ role: 'user', parts: [{ text: 'hi' }] }],
+      });
+
+      expect(result.skippedReason).toBe('session_mismatch');
+      expect(mgr.listTasksByType('extract', projectRoot)[0]).toMatchObject({
+        status: 'skipped',
+        progressText: 'Skipped: session mismatch.',
+        metadata: { skippedReason: 'session_mismatch' },
+      });
+      const event = telemetryMocks.logMemoryExtract.mock.calls[0]?.[1] as {
+        status: string;
+        skipped_reason?: string;
+      };
+      expect(event).toMatchObject({
+        status: 'skipped',
+        skipped_reason: 'session_mismatch',
+      });
     });
 
     it.each([

--- a/packages/core/src/memory/manager.ts
+++ b/packages/core/src/memory/manager.ts
@@ -762,17 +762,21 @@ export class MemoryManager {
 
       const result = await runAutoMemoryExtract(params);
       const durationMs = Date.now() - t0;
+      const skippedReason = result.skippedReason;
+      const status = skippedReason ? 'skipped' : 'completed';
       this.update(record, {
-        status: result.skippedReason ? 'skipped' : 'completed',
+        status,
         progressText:
           result.systemMessage ??
-          (result.touchedTopics.length > 0
-            ? `Managed auto-memory updated: ${result.touchedTopics.join(', ')}.`
-            : 'Managed auto-memory extraction completed without durable changes.'),
+          (skippedReason
+            ? `Skipped: ${skippedReason.replaceAll('_', ' ')}.`
+            : result.touchedTopics.length > 0
+              ? `Managed auto-memory updated: ${result.touchedTopics.join(', ')}.`
+              : 'Managed auto-memory extraction completed without durable changes.'),
         metadata: {
           touchedTopics: result.touchedTopics,
           processedOffset: result.cursor.processedOffset,
-          skippedReason: result.skippedReason,
+          skippedReason,
         },
       });
       if (params.config) {
@@ -780,7 +784,8 @@ export class MemoryManager {
           params.config,
           new MemoryExtractEvent({
             trigger: 'auto',
-            status: 'completed',
+            status,
+            ...(skippedReason ? { skipped_reason: skippedReason } : {}),
             patches_count: result.touchedTopics.length,
             touched_topics: result.touchedTopics,
             duration_ms: durationMs,

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -1521,7 +1521,8 @@ export class MemoryExtractEvent implements BaseTelemetryEvent {
     | 'already_running'
     | 'queued'
     | 'memory_tool'
-    | 'memory_pressure';
+    | 'memory_pressure'
+    | 'session_mismatch';
   patches_count: number;
   touched_topics: string;
   duration_ms: number;
@@ -1533,7 +1534,8 @@ export class MemoryExtractEvent implements BaseTelemetryEvent {
       | 'already_running'
       | 'queued'
       | 'memory_tool'
-      | 'memory_pressure';
+      | 'memory_pressure'
+      | 'session_mismatch';
     patches_count: number;
     touched_topics: string[];
     duration_ms: number;

--- a/packages/core/src/utils/forkedAgent.cache.test.ts
+++ b/packages/core/src/utils/forkedAgent.cache.test.ts
@@ -75,6 +75,13 @@ describe('CacheSafeParams', () => {
       expect(getCacheSafeParams()?.sessionId).toBe('session-a');
     });
 
+    it('rejects params owned by another session', () => {
+      saveCacheSafeParams({}, [], 'model', 'session-b');
+
+      expect(getCacheSafeParams('session-a')).toBeNull();
+      expect(getCacheSafeParams('session-b')?.sessionId).toBe('session-b');
+    });
+
     it('returns the current session id without reading full params', () => {
       saveCacheSafeParams({}, [], 'model', 'session-a');
 

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -152,6 +152,9 @@ export function getCacheSafeParams(
     expectedSessionId !== undefined &&
     currentCacheSafeParams.sessionId !== expectedSessionId
   ) {
+    debugLogger.debug(
+      `CacheSafeParams session_mismatch: requested=${expectedSessionId}, cached=${currentCacheSafeParams.sessionId ?? '(none)'}`,
+    );
     return null;
   }
   return {

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -140,10 +140,20 @@ export function saveCacheSafeParams(
 }
 
 /**
- * Get the current cache-safe params, or null if not yet captured.
+ * Get the current cache-safe params, or null if not yet captured or owned by
+ * another session. Production readers must pass their session id; omitting it
+ * is retained for tests and callers that inspect the raw process-global slot.
  */
-export function getCacheSafeParams(): CacheSafeParams | null {
+export function getCacheSafeParams(
+  expectedSessionId?: string,
+): CacheSafeParams | null {
   if (!currentCacheSafeParams) return null;
+  if (
+    expectedSessionId !== undefined &&
+    currentCacheSafeParams.sessionId !== expectedSessionId
+  ) {
+    return null;
+  }
   return {
     generationConfig: structuredClone(currentCacheSafeParams.generationConfig),
     history: copyHistoryContainers(currentCacheSafeParams.history),


### PR DESCRIPTION
## What this PR does

This change makes cached fork snapshots session-owned at every background read boundary. A reader now receives a snapshot only when its session ID matches the session that last saved it; otherwise the optional background operation fails closed without creating a forked chat or invoking an agent. Same-session suggestion, speculative generation, pipelined speculation, and automatic memory extraction keep their existing behavior.

## Why it's needed

An ACP channel can multiplex multiple sessions in one process, while the cached fork snapshot is held in one process-global slot. If session B saves after session A, an unscoped background reader for A can consume B's history. This can generate follow-up work from the wrong conversation and can send another session's transcript to a model. Fixes #9470.

## Reviewer Test Plan

### How to verify

Save a cached snapshot for session B, then invoke speculative generation or automatic memory extraction using a configuration for session A. Confirm that the lookup returns no snapshot and that neither a forked chat nor a forked agent is invoked. Repeat with session B as the reader and confirm that initial speculation, pipelined speculation, and memory extraction still receive B's history. The focused unit tests also assert that every production background reader supplies its active session ID.

### Evidence (Before & After)

Before: a function-level dynamic probe saved B's history and then invoked readers configured for A. Initial speculation created a forked chat from B's history, pipelined speculation reused B's history, and automatic memory extraction passed B's history to its agent.

After: the same probe reports no snapshot for B-to-A reads and zero downstream forked-chat or agent calls. B-to-B reads continue successfully for initial speculation, pipelined speculation, and memory extraction. The post-fix probe passed 3/3 scenarios, and the focused unit suite passed 153/153 tests. Review follow-up coverage also confirms both speculation readers fail closed, records a foreign auto-memory cache owner as a benign skip without advancing the extraction cursor, and short-circuits an existing mismatch before scaffold and cursor I/O while retaining a second check for ownership changes during that asynchronous work.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.3 on macOS. Verified with a function-level dynamic integration probe, focused unit tests, the core lint task, the repository build, and TypeScript type checking. No provider credentials or model network calls were used.

## Risk & Scope

- Main risk or tradeoff: if another session overwrites the single cached slot before optional background work reads it, that work is skipped instead of using a foreign snapshot.
- Not validated / out of scope: full ACP daemon and live-model end-to-end testing; replacing the single slot with a per-session cache; unrelated cache-prefix behavior.
- Breaking changes / migration notes: none. Same-session reads are unchanged.

## Linked Issues

Fixes #9470

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本改动让所有后台读取边界都按 session 校验缓存的 fork 快照。只有读取方的 session ID 与最近一次保存快照的 session 一致时，读取方才能获得快照；否则可选的后台操作会安全终止，不会创建 fork chat，也不会调用 agent。同一 session 内的后续建议、推测生成、流水线推测和自动记忆提取保持原有行为。

## 为什么需要

一个 ACP channel 进程可以复用来承载多个 session，但缓存的 fork 快照只保存在一个进程级全局槽中。如果 session B 在 session A 之后保存，A 的未限定后台读取就可能消费 B 的历史。这会基于错误会话生成后续任务，也可能把另一 session 的对话记录发送给模型。修复 #9470。

## Reviewer 测试计划

### 如何验证

先为 session B 保存缓存快照，再用 session A 的配置调用推测生成或自动记忆提取。确认读取不到快照，而且 fork chat 和 fork agent 都没有被调用。然后改用 session B 读取，确认初次推测、流水线推测和记忆提取仍能正常收到 B 的历史。聚焦单元测试还会断言每个生产后台读取方都传入其当前 session ID。

### 证据（修复前后）

修复前：函数级动态探针保存 B 的历史后，调用配置为 A 的读取方。初次推测使用 B 的历史创建了 fork chat，流水线推测复用了 B 的历史，自动记忆提取也把 B 的历史传给了 agent。

修复后：同一个探针显示 B 到 A 的读取无法获得快照，下游 fork chat 和 agent 调用数均为零。B 到 B 的读取在初次推测、流水线推测和记忆提取中继续成功。修复后探针的 3/3 个场景通过，聚焦单元测试 153/153 通过。审查跟进测试还确认两条推测读取路径都会安全失败，将外来 auto-memory 缓存所有者记录为良性跳过且不推进提取游标，并在脚手架和游标 IO 前快速跳过已存在的不匹配，同时保留第二次检查以捕获异步工作期间的所有权变化。

### 已测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

macOS 上的 Node.js 22.22.3。已通过函数级动态集成探针、聚焦单元测试、core lint、仓库构建和 TypeScript 类型检查验证。未使用 provider 凭据或模型网络调用。

## 风险与范围

- 主要风险或取舍：如果可选后台任务读取前，单一缓存槽已被另一 session 覆盖，该后台任务会被跳过，而不会使用外来快照。
- 未验证 / 范围外：完整 ACP daemon 加真实模型的端到端测试；把单一槽改造成按 session 存储的缓存；无关的缓存前缀行为。
- 破坏性变更 / 迁移说明：无。同一 session 的读取行为不变。

## 关联 Issue

修复 #9470

</details>

