### PR TITLE
refactor: anchor rewind mapping to stable prompt identity

### DIFF
--- a/docs/design/rewind-stable-prompt-identity.md
+++ b/docs/design/rewind-stable-prompt-identity.md
@@ -1,0 +1,76 @@
+# Stable prompt identity for rewind mapping
+
+## Problem
+
+TUI rewind currently maps a UI user item to `Content[]` by independently
+counting UI turns and model-facing user entries. ACP and fork-history selection
+carry related classifiers with different exclusions. Compression, resume, and
+microcompaction can change either representation, so another content shape can
+silently shift the computed truncation point.
+
+## Decision
+
+Use the existing `promptId` as the stable identity of a real user turn.
+
+- Persist `promptId` on the user `ChatRecord`.
+- Attach the same value to the corresponding in-memory API `Content` through an
+  internal Symbol. Symbol properties survive the shallow copies used by live
+  history mutation, but are omitted by JSON serialization and therefore never
+  become provider API fields.
+- Compression checkpoints persist identities in parallel metadata so fast
+  compression can restore them without changing the API `Content` shape.
+- Restore the Symbol from `ChatRecord.promptId` when rebuilding API history and
+  restore `HistoryItemUser.promptId` from the same record.
+- Resolve rewind boundaries by identity. A target with a persisted identity
+  that is absent from current API history is unreachable and fails closed.
+- Keep the existing shape-based classifiers only when reading legacy sessions
+  that have no persisted prompt identities.
+
+This reuses the prompt identity already shared by UI history, file-history
+snapshots, telemetry, and tool continuations. It does not introduce a second
+turn counter or a new provider-visible content field.
+
+## Compatibility and trust boundary
+
+Session JSONL is untrusted input. Readers accept only non-empty string
+`promptId` values. The value is used only for equality and never as a path,
+command, or authorization key.
+
+New records carry `promptId`; old records remain readable. Legacy histories
+without identities use the current counting behavior. Partially identified
+histories use identities as authoritative: an identified UI target that no
+longer exists in API history is treated as compressed rather than guessed.
+Duplicate identities are ambiguous and fail closed.
+
+Summarizing compression intentionally discards identities for absorbed turns.
+`/compress-fast` and microcompaction preserve them because their shallow
+history transformations retain the internal Symbol. New post-compression turns
+receive new identities normally.
+
+Forked sessions rewrite the session-prefixed identity on both user records and
+file-history snapshots so their rewind boundaries stay aligned.
+
+## Affected paths
+
+- TUI `/rewind`: `HistoryItemUser.promptId` locates the matching API entry.
+- ACP rewind/count: identified histories count and locate marked user prompts;
+  legacy histories retain the existing ACP classifier.
+- Fork turn selection: identified histories count marked prompts; legacy
+  histories retain the existing content-shape classifier.
+- Session resume: both UI and API projections are rebuilt from the same
+  persisted `ChatRecord.promptId`.
+
+Recording rewind and file rollback keep their current APIs. They already use
+the same logical user-turn order and file snapshots already key on `promptId`;
+changing those contracts is unnecessary for fixing UI/API alignment.
+
+## Verification
+
+- A focused mapping test proves that text shape, reminders, and cleared media
+  cannot shift an identified target.
+- API-history reconstruction proves persisted identity reaches the rebuilt
+  `Content` while JSON serialization stays provider-safe.
+- Resume-history reconstruction proves the UI item receives the same identity.
+- ACP and fork tests prove identified histories bypass their legacy classifiers
+  while legacy behavior remains covered.
+- Existing rewind, compression, recording, and resume tests remain green.

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -3154,6 +3154,28 @@ describe('Session', () => {
       expect(session.getRewindableUserTurnCount()).toBe(1);
     });
 
+    it('uses stable identities instead of classifying user-shaped entries', () => {
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'first' }] },
+        { role: 'model', parts: [{ text: 'first reply' }] },
+        {
+          role: 'user',
+          parts: [{ text: '[Old inline media cleared: image/png]' }],
+        },
+        { role: 'model', parts: [{ text: 'media reply' }] },
+        { role: 'user', parts: [{ text: 'second' }] },
+      ];
+      core.markApiHistoryPrompt(history[0]!, 'prompt-1');
+      core.markApiHistoryPrompt(history[4]!, 'prompt-2');
+      vi.mocked(mockChat.getHistoryShallow).mockReturnValue(history);
+
+      expect(session.getRewindableUserTurnCount()).toBe(2);
+      expect(session.rewindToTurn(1)).toEqual({
+        targetTurnIndex: 1,
+        apiTruncateIndex: 4,
+      });
+    });
+
     it('rejects unreachable user turns', () => {
       const history: Content[] = [{ role: 'user', parts: [{ text: 'first' }] }];
       vi.mocked(mockChat.getHistory).mockReturnValue(history);

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -103,6 +103,8 @@ import {
   getPlanModeSystemReminder,
   getArenaSystemReminder,
   getStartupContextLength,
+  getApiHistoryPromptId,
+  getApiHistoryPromptIndexes,
   isSystemReminderContent,
   buildSessionRecoveryPlanFromApiHistory,
   TURN_INTERRUPTION_HISTORY_TAIL_COUNT,
@@ -3495,6 +3497,13 @@ export class Session implements SessionContext {
 
   getRewindableUserTurnCount(): number {
     const apiHistory = this.captureHistorySnapshot();
+    const identifiedTurns = getApiHistoryPromptIndexes(apiHistory);
+    if (identifiedTurns === undefined) {
+      return 0;
+    }
+    if (identifiedTurns.length > 0) {
+      return identifiedTurns.length;
+    }
     const startIndex = getStartupContextLength(apiHistory, {
       includeCompressed: true,
     });
@@ -3529,6 +3538,14 @@ export class Session implements SessionContext {
     apiHistory: Content[],
     targetTurnIndex: number,
   ): number {
+    const identifiedTurns = getApiHistoryPromptIndexes(apiHistory);
+    if (identifiedTurns === undefined) {
+      return -1;
+    }
+    if (identifiedTurns.length > 0) {
+      return identifiedTurns[targetTurnIndex] ?? -1;
+    }
+
     const startIndex = getStartupContextLength(apiHistory, {
       includeCompressed: true,
     });
@@ -4416,6 +4433,7 @@ export class Session implements SessionContext {
             // throws before re-pushing it, the orphan would be permanently lost
             // — so hold it (and a push-count snapshot) to restore on that path.
             let strippedOrphanEntries: Content[] | null = null;
+            let continuedPromptIdentity: string | undefined;
             let orphanPushCountSnapshot = 0;
             if (goalTurn?.origin === 'runtime') {
               this.config.getChatRecordingService()?.recordGoalRuntimeMessage(
@@ -4452,6 +4470,16 @@ export class Session implements SessionContext {
                 strippedOrphanEntries =
                   this.#getCurrentChat().stripOrphanedUserEntriesFromHistory() ??
                   null;
+                const promptIdentities = new Set(
+                  strippedOrphanEntries
+                    ?.map(getApiHistoryPromptId)
+                    .filter((value): value is string => value !== undefined),
+                );
+                if (promptIdentities.size === 1) {
+                  continuedPromptIdentity = promptIdentities
+                    .values()
+                    .next().value;
+                }
                 orphanPushCountSnapshot =
                   this.#getCurrentChat().getUserContentPushCount?.() ?? 0;
                 continuationParts = recoveryPlan.continuation.parts;
@@ -4480,15 +4508,30 @@ export class Session implements SessionContext {
               );
               const recorder = this.config.getChatRecordingService();
               if (promptDisplayText !== undefined || mediaReferences) {
-                recorder?.recordUserMessage(promptText, goalTurn?.permit, {
-                  displayText: promptDisplayText ?? promptText,
-                  hookContext: '',
-                  ...(mediaReferences ? { mediaReferences } : {}),
-                });
+                recorder?.recordUserMessage(
+                  promptText,
+                  goalTurn?.permit,
+                  {
+                    displayText: promptDisplayText ?? promptText,
+                    hookContext: '',
+                    ...(mediaReferences ? { mediaReferences } : {}),
+                  },
+                  promptId,
+                );
               } else if (goalTurn) {
-                recorder?.recordUserMessage(promptText, goalTurn.permit);
+                recorder?.recordUserMessage(
+                  promptText,
+                  goalTurn.permit,
+                  undefined,
+                  promptId,
+                );
               } else {
-                recorder?.recordUserMessage(promptText);
+                recorder?.recordUserMessage(
+                  promptText,
+                  undefined,
+                  undefined,
+                  promptId,
+                );
               }
             }
 
@@ -4562,14 +4605,29 @@ export class Session implements SessionContext {
               ) {
                 const recorder = this.config.getChatRecordingService();
                 if (promptDisplayText !== undefined) {
-                  recorder?.recordUserMessage(promptText, goalTurn?.permit, {
-                    displayText: promptDisplayText,
-                    hookContext: '',
-                  });
+                  recorder?.recordUserMessage(
+                    promptText,
+                    goalTurn?.permit,
+                    {
+                      displayText: promptDisplayText,
+                      hookContext: '',
+                    },
+                    promptId,
+                  );
                 } else if (goalTurn) {
-                  recorder?.recordUserMessage(promptText, goalTurn.permit);
+                  recorder?.recordUserMessage(
+                    promptText,
+                    goalTurn.permit,
+                    undefined,
+                    promptId,
+                  );
                 } else {
-                  recorder?.recordUserMessage(promptText);
+                  recorder?.recordUserMessage(
+                    promptText,
+                    undefined,
+                    undefined,
+                    promptId,
+                  );
                 }
               }
 
@@ -4835,7 +4893,15 @@ export class Session implements SessionContext {
                       promptId,
                       nextMessage?.parts ?? [],
                       pendingSend.signal,
-                      { modelOverride: fullTurnModelOverride },
+                      {
+                        modelOverride: fullTurnModelOverride,
+                        promptIdentity:
+                          turnCount === 1 && goalTurn?.origin !== 'runtime'
+                            ? isContinue
+                              ? continuedPromptIdentity
+                              : promptId
+                            : undefined,
+                      },
                     );
                   if (!sendResult.responseStream) {
                     this.todoStopGuard.suspend();
@@ -6393,6 +6459,7 @@ export class Session implements SessionContext {
       beforeSend?: (
         context: BeforeModelSendContext,
       ) => Promise<BeforeModelSendDecision>;
+      promptIdentity?: string;
     } = {},
   ): Promise<AutoCompressionSendResult> {
     const geminiClient = this.config.getGeminiClient()!;
@@ -6532,9 +6599,13 @@ export class Session implements SessionContext {
       },
     };
     const goalPermit = goalTurnContext.getStore();
-    const responseStream = goalPermit
-      ? await chat.sendMessageStream(model, request, promptId, goalPermit)
-      : await chat.sendMessageStream(model, request, promptId);
+    const responseStream = await chat.sendMessageStream(
+      model,
+      request,
+      promptId,
+      goalPermit,
+      options.promptIdentity ? { promptId: options.promptIdentity } : undefined,
+    );
     return { responseStream };
   }
 

--- a/packages/cli/src/ui/utils/historyMapping.test.ts
+++ b/packages/cli/src/ui/utils/historyMapping.test.ts
@@ -10,6 +10,7 @@ import type { HistoryItem } from '../types.js';
 import type { Content, Part } from '@google/genai';
 import {
   CompressionStatus,
+  markApiHistoryPrompt,
   SYSTEM_REMINDER_OPEN,
   SYSTEM_REMINDER_CLOSE,
 } from '@qwen-code/qwen-code-core';
@@ -47,12 +48,14 @@ function userItem(
   id: number,
   text = `prompt ${id}`,
   sentToModel?: boolean,
+  promptId?: string,
 ): HistoryItem {
   return {
     type: 'user',
     id,
     text,
     ...(sentToModel === undefined ? {} : { sentToModel }),
+    ...(promptId ? { promptId } : {}),
   } as HistoryItem;
 }
 
@@ -683,6 +686,39 @@ describe('computeApiTruncationIndex', () => {
       expect(computeApiTruncationIndex(ui, 3, api)).toBe(5);
       // …while every later target fails loud (-1).
       expect(computeApiTruncationIndex(ui, 5, api)).toBe(-1);
+    });
+  });
+
+  describe('with stable prompt identities', () => {
+    it('maps ambiguous UI and API shapes by identity', () => {
+      const placeholder = '[Old inline media cleared: image/png]';
+      const ui: HistoryItem[] = [
+        userItem(1, 'hello', undefined, 'prompt-1'),
+        geminiItem(2),
+        userItem(3, placeholder, undefined, 'prompt-2'),
+        geminiItem(4),
+        userItem(5, 'world', undefined, 'prompt-3'),
+      ];
+      const api: Content[] = [
+        startupEntry(),
+        userContent('hello'),
+        modelContent('response hello'),
+        userContent(placeholder),
+        modelContent('response placeholder'),
+        userContent('world'),
+      ];
+      markApiHistoryPrompt(api[1]!, 'prompt-1');
+      markApiHistoryPrompt(api[3]!, 'prompt-2');
+      markApiHistoryPrompt(api[5]!, 'prompt-3');
+
+      expect(computeApiTruncationIndex(ui, 3, api)).toBe(3);
+      expect(computeApiTruncationIndex(ui, 5, api)).toBe(5);
+    });
+
+    it('fails closed when an identified target is absent from API history', () => {
+      const ui = [userItem(1, 'hello', undefined, 'prompt-1')];
+
+      expect(computeApiTruncationIndex(ui, 1, [userContent('hello')])).toBe(-1);
     });
   });
 

--- a/packages/cli/src/ui/utils/historyMapping.ts
+++ b/packages/cli/src/ui/utils/historyMapping.ts
@@ -8,6 +8,7 @@ import type { HistoryItem, HistoryItemUser } from '../types.js';
 import type { Content } from '@google/genai';
 import {
   CompressionStatus,
+  findApiHistoryPromptIndex,
   getStartupContextLength,
   isClearedMediaPlaceholder,
   isSystemReminderContent,
@@ -153,7 +154,12 @@ export function computeApiTruncationIndex(
   const compressionIndex = findLastSuccessfulCompressionIndex(uiHistory);
   if (compressionIndex !== -1 && targetIndex <= compressionIndex) return -1;
 
-  // Count how many UI user turns exist before the target
+  const target = uiHistory[targetIndex]!;
+  if (isRealUserTurn(target) && target.promptId) {
+    return findApiHistoryPromptIndex(apiHistory, target.promptId);
+  }
+
+  // Legacy sessions have no promptId and still need the positional fallback.
   let uiUserTurnCount = 0;
   for (
     let i = compressionIndex === -1 ? 0 : compressionIndex + 1;

--- a/packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
+++ b/packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
@@ -729,6 +729,7 @@ describe('resumeHistoryUtils', () => {
       messages: [
         {
           type: 'user',
+          promptId: 'prompt-1',
           message: {
             parts: [
               { text: 'expanded model prompt' } as Part,
@@ -755,7 +756,14 @@ describe('resumeHistoryUtils', () => {
 
     const items = buildResumedHistoryItems(session, makeConfig({}), 30);
 
-    expect(items).toEqual([{ id: 31, type: 'user', text: 'raw @file prompt' }]);
+    expect(items).toEqual([
+      {
+        id: 31,
+        type: 'user',
+        text: 'raw @file prompt',
+        promptId: 'prompt-1',
+      },
+    ]);
   });
 
   it('projects the user turn when legacy @-command metadata has no userText', () => {

--- a/packages/cli/src/ui/utils/resumeHistoryUtils.ts
+++ b/packages/cli/src/ui/utils/resumeHistoryUtils.ts
@@ -264,6 +264,10 @@ function convertToHistoryItems(
   };
 
   for (const record of conversation.messages) {
+    const promptId =
+      typeof record.promptId === 'string' && record.promptId.length > 0
+        ? record.promptId
+        : undefined;
     // A detected history gap begins at this record — surface a visible divider
     // so the surviving turns below are not read as contiguous across the lost
     // segment. Flush any pending tool group first so the divider is not
@@ -417,7 +421,11 @@ function convertToHistoryItems(
             payload.userText ||
             (projection.displayText ?? extractTextFromParts(projection.parts));
           if (text) {
-            items.push({ type: 'user', text });
+            items.push({
+              type: 'user',
+              text,
+              ...(promptId ? { promptId } : {}),
+            });
           }
 
           const toolDisplays = buildAtCommandDisplays(payload);
@@ -451,7 +459,11 @@ function convertToHistoryItems(
             ? '[User message with attachments]'
             : extractTextFromParts(projection.parts));
         if (text) {
-          items.push({ type: 'user', text });
+          items.push({
+            type: 'user',
+            text,
+            ...(promptId ? { promptId } : {}),
+          });
         }
         break;
       }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1186,7 +1186,7 @@ export class GeminiClient {
       return;
     }
 
-    const currentHistory = this.getChat().getHistory();
+    const currentHistory = this.getChat().getHistoryShallow();
     const startupLength = getStartupContextLength(currentHistory);
     if (startupLength === 0) {
       return;
@@ -1227,7 +1227,7 @@ export class GeminiClient {
       return;
     }
 
-    const currentHistory = this.getChat().getHistory();
+    const currentHistory = this.getChat().getHistoryShallow();
     if (getStartupContextLength(currentHistory) !== 0) {
       return;
     }
@@ -2997,9 +2997,15 @@ export class GeminiClient {
               request,
               goalPermit,
               userPromptRecordPayload,
+              prompt_id,
             );
           } else {
-            recorder?.recordUserMessage(request, goalPermit);
+            recorder?.recordUserMessage(
+              request,
+              goalPermit,
+              undefined,
+              prompt_id,
+            );
           }
         }
       }
@@ -3213,7 +3219,13 @@ export class GeminiClient {
         }
       }
 
-      const turn = new Turn(this.getChat(), prompt_id, goalPermit);
+      const turn = new Turn(
+        this.getChat(),
+        prompt_id,
+        goalPermit,
+        messageType === SendMessageType.UserQuery ||
+          messageType === SendMessageType.Retry,
+      );
 
       // Determine the model to use for this turn
       const model = options?.modelOverride ?? this.config.getModel();

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -69,6 +69,7 @@ import {
 } from '../telemetry/loggers.js';
 import { subagentNameContext } from '../utils/subagentNameContext.js';
 import { type ChatRecordingService } from '../services/chatRecordingService.js';
+import { markApiHistoryPrompt } from '../services/session-api-history.js';
 import {
   ChatCompressionService,
   computeThresholds,
@@ -446,6 +447,8 @@ export type StreamEvent =
 export interface GeminiChatSendOptions {
   /** Skip only the configured model fallback chain for this request. */
   disableModelFallbacks?: boolean;
+  /** Stable identity for a real user turn; omitted from provider payloads. */
+  promptId?: string;
 }
 
 interface TryCompressOptions {
@@ -2486,6 +2489,7 @@ export class GeminiChat {
       }
 
       // Add user content to history ONCE before any attempts.
+      markApiHistoryPrompt(userContent, options?.promptId);
       this.history.push(userContent);
       currentUserContent = userContent;
       userContentAdded = true;

--- a/packages/core/src/core/turn.test.ts
+++ b/packages/core/src/core/turn.test.ts
@@ -191,12 +191,41 @@ describe('Turn', () => {
         },
         'prompt-id-1',
         undefined,
+        undefined,
       );
 
       expect(events).toEqual([
         { type: GeminiEventType.Content, value: 'Hello' },
         { type: GeminiEventType.Content, value: ' world' },
       ]);
+    });
+
+    it('passes the stable user-turn identity to chat history', async () => {
+      const identifiedTurn = new Turn(
+        mockChatInstance as unknown as GeminiChat,
+        'prompt-id-1',
+        undefined,
+        true,
+      );
+
+      for await (const _ of identifiedTurn.run(
+        'test-model',
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+      )) {
+        // Drain the stream.
+      }
+
+      expect(mockSendMessageStream).toHaveBeenCalledWith(
+        'test-model',
+        {
+          message: [{ text: 'Hi' }],
+          config: { abortSignal: expect.any(AbortSignal) },
+        },
+        'prompt-id-1',
+        undefined,
+        { promptId: 'prompt-id-1' },
+      );
     });
 
     it('should preserve ordered image parts in content events', async () => {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -523,6 +523,7 @@ export class Turn {
     private readonly chat: GeminiChat,
     private readonly prompt_id: string,
     goalContext?: GoalTurnPermit,
+    private readonly identifiesUserTurn = false,
   ) {
     this.goalContext = goalContext ? { ...goalContext } : undefined;
   }
@@ -545,6 +546,7 @@ export class Turn {
         },
         this.prompt_id,
         this.goalContext,
+        this.identifiesUserTurn ? { promptId: this.prompt_id } : undefined,
       );
 
       for await (const streamEvent of responseStream) {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -189,7 +189,12 @@ describe('ChatRecordingService', () => {
   describe('recordUserMessage', () => {
     it('should record a user message immediately', async () => {
       const userParts: Part[] = [{ text: 'Hello, world!' }];
-      chatRecordingService.recordUserMessage(userParts);
+      chatRecordingService.recordUserMessage(
+        userParts,
+        undefined,
+        undefined,
+        'prompt-1',
+      );
       await chatRecordingService.flush();
 
       expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
@@ -205,6 +210,7 @@ describe('ChatRecordingService', () => {
       expect(record.version).toBe('1.0.0');
       expect(record.gitBranch).toBe('main');
       expect(record.provenance).toBe('real_user');
+      expect(record.promptId).toBe('prompt-1');
     });
 
     it('preserves model-bound parts and records clean display text', async () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -62,6 +62,7 @@ import {
   type BranchPoint,
   type BranchToolCallIdentity,
 } from './branch-points.js';
+import { getApiHistoryPromptId } from './session-api-history.js';
 
 const debugLogger = createDebugLogger('CHAT_RECORDING');
 
@@ -318,6 +319,8 @@ export interface ChatRecord {
     | 'goal_runtime'
     | 'realtime_message'
     | 'turn_result';
+  /** Stable identity shared by the UI and API representation of a user turn. */
+  promptId?: string;
   /** Explicit source classification used by Goal evidence validation. */
   provenance?: ChatRecordProvenance;
   /** Goal identity and logical turn that owned this model-facing record. */
@@ -497,6 +500,8 @@ export interface ChatCompressionRecordPayload {
    * resume reconstruction.
    */
   compressedHistory: Content[];
+  /** Stable prompt identities aligned with compressedHistory by index. */
+  promptIds?: Array<string | null>;
 }
 
 export interface SlashCommandRecordPayload {
@@ -1748,6 +1753,7 @@ export class ChatRecordingService {
     message: PartListUnion,
     goalContext?: GoalTurnPermit,
     promptPayload?: UserPromptRecordPayload,
+    promptId?: string,
   ): void {
     try {
       this.trackUserDisplayTextForTitle(promptPayload?.displayText);
@@ -1755,6 +1761,7 @@ export class ChatRecordingService {
       const record: ChatRecord = {
         ...this.createBaseRecord('user'),
         ...(goalContext ? { goalContext: copyGoalContext(goalContext) } : {}),
+        ...(promptId ? { promptId } : {}),
         message: createUserContent(message),
         ...(promptPayload ? { systemPayload: promptPayload } : {}),
       };
@@ -2217,11 +2224,16 @@ export class ChatRecordingService {
    */
   recordChatCompression(payload: ChatCompressionRecordPayload): void {
     try {
+      const promptIds = payload.compressedHistory.map(
+        (content) => getApiHistoryPromptId(content) ?? null,
+      );
       const record: ChatRecord = {
         ...this.createBaseRecord('system'),
         type: 'system',
         subtype: 'chat_compression',
-        systemPayload: payload,
+        systemPayload: promptIds.some(Boolean)
+          ? { ...payload, promptIds }
+          : payload,
       };
 
       this.appendRecord(record);

--- a/packages/core/src/services/session-api-history.ts
+++ b/packages/core/src/services/session-api-history.ts
@@ -10,6 +10,58 @@ import type {
   ChatRecord,
 } from './chatRecordingService.js';
 
+const API_HISTORY_PROMPT_ID = Symbol('apiHistoryPromptId');
+
+type IdentifiedContent = Content & {
+  [API_HISTORY_PROMPT_ID]?: string;
+};
+
+export function markApiHistoryPrompt(
+  content: Content,
+  promptId: unknown,
+): void {
+  if (typeof promptId === 'string' && promptId.length > 0) {
+    (content as IdentifiedContent)[API_HISTORY_PROMPT_ID] = promptId;
+  }
+}
+
+export function getApiHistoryPromptId(content: Content): string | undefined {
+  return (content as IdentifiedContent)[API_HISTORY_PROMPT_ID];
+}
+
+export function getApiHistoryPromptIndexes(
+  history: readonly Content[],
+): number[] | undefined {
+  const seen = new Set<string>();
+  const indexes: number[] = [];
+
+  for (let index = 0; index < history.length; index++) {
+    const content = history[index]!;
+    const promptId = getApiHistoryPromptId(content);
+    if (!promptId) continue;
+    if (seen.has(promptId)) {
+      return undefined;
+    }
+    seen.add(promptId);
+    indexes.push(index);
+  }
+
+  return indexes;
+}
+
+export function findApiHistoryPromptIndex(
+  history: readonly Content[],
+  promptId: string,
+): number {
+  let match = -1;
+  for (let index = 0; index < history.length; index++) {
+    if (getApiHistoryPromptId(history[index]!) !== promptId) continue;
+    if (match !== -1) return -1;
+    match = index;
+  }
+  return match;
+}
+
 export interface BuildApiHistoryOptions {
   /**
    * Whether to strip thought parts from the history.
@@ -59,6 +111,9 @@ function appendApiHistoryRecord(history: Content[], record: ChatRecord): void {
   if (!record.message || record.subtype === 'realtime_message') return;
 
   const message = copyContentForApiHistory(record.message);
+  if (record.type === 'user' && !record.subtype) {
+    markApiHistoryPrompt(message, record.promptId);
+  }
   if (record.subtype === 'mid_turn_user_message') {
     const previous = history.at(-1);
     if (previous?.role === 'user') {
@@ -80,7 +135,11 @@ export class SessionApiHistoryAccumulator {
       const payload = record.systemPayload as ChatCompressionRecordPayload;
       this.compressionCandidate = payload.compressedHistory;
       this.history = Array.isArray(payload.compressedHistory)
-        ? payload.compressedHistory.map(copyContentForApiHistory)
+        ? payload.compressedHistory.map((content, index) => {
+            const copy = copyContentForApiHistory(content);
+            markApiHistoryPrompt(copy, payload.promptIds?.[index]);
+            return copy;
+          })
         : [];
       return;
     }

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -22,6 +22,7 @@ import { readRuntimeStatus } from '../utils/runtimeStatus.js';
 import {
   SessionService,
   buildApiHistoryFromConversation,
+  getApiHistoryPromptId,
   getResumePromptTokenCount,
   getResumeTokenCounts,
   type ConversationRecord,
@@ -2897,6 +2898,21 @@ describe('SessionService', () => {
   });
 
   describe('buildApiHistoryFromConversation', () => {
+    it('restores the stable prompt identity without exposing it in JSON', () => {
+      const prompt: ChatRecord = {
+        ...recordA1,
+        promptId: 'prompt-1',
+      };
+      const conversation = {
+        messages: [prompt],
+      } as ConversationRecord;
+
+      const [content] = buildApiHistoryFromConversation(conversation);
+
+      expect(getApiHistoryPromptId(content!)).toBe('prompt-1');
+      expect(JSON.stringify(content)).not.toContain('prompt-1');
+    });
+
     it('should return linear messages when no compression checkpoint exists', () => {
       const assistantA1: ChatRecord = {
         ...recordB2,

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -16,6 +16,7 @@ import * as jsonl from '../utils/jsonl-utils.js';
 import type { HistoryGap } from '../utils/conversation-chain.js';
 import { prepareTranscriptRecords } from '../utils/transcript-records.js';
 import type {
+  ChatCompressionRecordPayload,
   ChatRecord,
   FileHistorySnapshotRecordPayload,
   TitleSource,
@@ -63,6 +64,10 @@ import {
 } from './branch-points.js';
 export {
   buildApiHistoryFromConversation,
+  findApiHistoryPromptIndex,
+  getApiHistoryPromptId,
+  getApiHistoryPromptIndexes,
+  markApiHistoryPrompt,
   type BuildApiHistoryOptions,
 } from './session-api-history.js';
 import {
@@ -2026,6 +2031,15 @@ export class SessionService {
         const next: ChatRecord = {
           ...record,
           sessionId: newSessionId,
+          ...(record.promptId
+            ? {
+                promptId: remapPromptId(
+                  record.promptId,
+                  sourceSessionId,
+                  newSessionId,
+                ),
+              }
+            : {}),
           cwd: this.projectRoot,
           systemPayload,
           parentUuid:
@@ -2465,14 +2479,21 @@ function remapSnapshotPromptId(
   sourceSessionId: string,
   newSessionId: string,
 ): FileHistorySnapshot {
-  const sourcePrefix = `${sourceSessionId}########`;
-  if (!snapshot.promptId.startsWith(sourcePrefix)) {
-    return snapshot;
-  }
   return {
     ...snapshot,
-    promptId: `${newSessionId}########${snapshot.promptId.slice(sourcePrefix.length)}`,
+    promptId: remapPromptId(snapshot.promptId, sourceSessionId, newSessionId),
   };
+}
+
+function remapPromptId(
+  promptId: string,
+  sourceSessionId: string,
+  newSessionId: string,
+): string {
+  const sourcePrefix = `${sourceSessionId}########`;
+  return promptId.startsWith(sourcePrefix)
+    ? `${newSessionId}########${promptId.slice(sourcePrefix.length)}`
+    : promptId;
 }
 
 function remapFileHistorySnapshotPayload(
@@ -2509,6 +2530,20 @@ function remapSystemPayloadForFork(
       sourceSessionId,
       newSessionId,
     );
+  }
+  if (record.subtype === 'chat_compression') {
+    const payload = record.systemPayload as
+      | ChatCompressionRecordPayload
+      | undefined;
+    if (!payload?.promptIds) return record.systemPayload;
+    return {
+      ...payload,
+      promptIds: payload.promptIds.map((promptId) =>
+        typeof promptId === 'string'
+          ? remapPromptId(promptId, sourceSessionId, newSessionId)
+          : null,
+      ),
+    };
   }
   if (
     record.subtype === 'session_artifact_event' ||

--- a/packages/core/src/tools/agent/fork-subagent.test.ts
+++ b/packages/core/src/tools/agent/fork-subagent.test.ts
@@ -7,6 +7,7 @@
 import type { Content } from '@google/genai';
 import { describe, expect, it } from 'vitest';
 import { ToolNames } from '../tool-names.js';
+import { markApiHistoryPrompt } from '../../services/session-api-history.js';
 import {
   buildForkedMessages,
   FORK_PLACEHOLDER_RESULT,
@@ -142,6 +143,31 @@ describe('selectForkHistory', () => {
           toolResult,
           firstModel,
           secondUser,
+          secondModel,
+        ],
+        1,
+      ),
+    ).toEqual([secondUser, secondModel]);
+  });
+
+  it('uses stable identities instead of classifying user-shaped entries', () => {
+    const identifiedFirst = structuredClone(firstUser);
+    const identifiedSecond = structuredClone(secondUser);
+    const placeholder: Content = {
+      role: 'user',
+      parts: [{ text: '[Old inline media cleared: image/png]' }],
+    };
+    markApiHistoryPrompt(identifiedFirst, 'prompt-1');
+    markApiHistoryPrompt(identifiedSecond, 'prompt-2');
+
+    expect(
+      selectForkHistory(
+        [
+          startup,
+          identifiedFirst,
+          firstModel,
+          placeholder,
+          identifiedSecond,
           secondModel,
         ],
         1,

--- a/packages/core/src/tools/agent/fork-subagent.ts
+++ b/packages/core/src/tools/agent/fork-subagent.ts
@@ -8,6 +8,7 @@ import {
   getStartupContextLength,
   isSystemReminderContent,
 } from '../../utils/environmentContext.js';
+import { getApiHistoryPromptIndexes } from '../../services/session-api-history.js';
 
 export const FORK_SUBAGENT_TYPE = 'fork';
 
@@ -237,15 +238,21 @@ export function selectForkHistory(
     const syntheticPrefixLength = getStartupContextLength(history, {
       includeCompressed: true,
     });
-    const realUserTurnIndexes: number[] = [];
-    for (let index = syntheticPrefixLength; index < history.length; index++) {
-      const content = history[index]!;
-      if (isRealUserTurn(content)) {
-        realUserTurnIndexes.push(index);
+    const identifiedTurns = getApiHistoryPromptIndexes(history);
+    const realUserTurnIndexes =
+      identifiedTurns?.filter((index) => index >= syntheticPrefixLength) ?? [];
+    if (identifiedTurns === undefined) {
+      selected = [];
+    } else if (realUserTurnIndexes.length === 0) {
+      for (let index = syntheticPrefixLength; index < history.length; index++) {
+        const content = history[index]!;
+        if (isRealUserTurn(content)) {
+          realUserTurnIndexes.push(index);
+        }
       }
     }
 
-    if (realUserTurnIndexes.length === 0) {
+    if (identifiedTurns === undefined || realUserTurnIndexes.length === 0) {
       selected = [];
     } else {
       selected = history.slice(


### PR DESCRIPTION
## What this PR does

This PR makes the existing prompt identity the single authoritative link between visible user turns, model-facing history, persisted sessions, ACP rewind, and bounded fork history. New user turns persist that identity once, model history carries it as symbol-keyed metadata that is omitted from provider payloads, and session resume restores both projections from the same record.

Fast-compression checkpoints preserve identities in parallel metadata, forked sessions remap session-prefixed identities together with file snapshots, and ambiguous duplicate identities fail closed. Legacy sessions without identities keep the existing positional fallback.

This PR is based directly on `main` after #9331 merged and supersedes the earlier stacked PR #9466.

## Why it's needed

Before this change, the TUI, ACP, and fork paths independently inferred a logical user turn from content shape and positional counts. Those classifiers already disagreed on cleared-media placeholders, and a real prompt equal to a generated placeholder could make rewind retain the selected model context or make a later turn unreachable.

After this change, current sessions resolve rewind boundaries by stable identity rather than re-deriving alignment from two representations. Missing or duplicated identities are treated as unreachable instead of guessing a destructive truncation point.

## Reviewer Test Plan

### How to verify

1. Create several turns where the middle prompt is exactly `[Old inline media cleared: image/png]`, then rewind to the middle and following turns. Each selection should truncate immediately before the matching model-facing prompt.
2. Resume a persisted session, including one that ran fast compression, and verify that the same visible turns remain rewindable at the same boundaries.
3. Fork a persisted session and verify that inherited turn identities remain aligned with inherited file snapshots.
4. Load a legacy session without identities and verify that existing positional behavior remains available. Load malformed history with duplicate identities and verify that rewind fails closed without mutating conversation or files.

### Evidence (Before & After)

Before: the middle placeholder-shaped prompt resolved to boundary `4` instead of `2`, while the following prompt returned `-1`.

After: the same targets resolve to `2` and `4`; a duplicate identity returns `-1`. Focused checks for identity persistence, resume reconstruction, TUI/ACP mapping, turn propagation, and fork selection passed on the isolated implementation branch. The final main-based patch passes `git diff --check`; a fresh local core build is blocked before reaching changed code by unresolved checkout dependencies (`fdir`, `mime`, `ajv`, and `@lydell/node-pty`), so clean-environment CI is the remaining build gate.

UI verification: N/A — this changes rewind identity and persistence logic, not rendering or layout.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 and package-local Vitest checks on macOS; final clean build delegated to CI because of local dependency skew.

## Risk & Scope

- Main risk or tradeoff: this adds optional session metadata and changes current-session rewind selection from positional inference to identity lookup; missing or ambiguous current identities intentionally fail closed.
- Not validated / out of scope: Windows and Linux were not tested locally. The final main-based checkout could not complete a local build because of unrelated dependency-resolution errors listed above.
- Breaking changes / migration notes: none. Existing session records remain readable and continue through the legacy fallback.

## Linked Issues

Closes #9437

Supersedes #9466

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这个 PR 使用现有的 prompt identity，作为可见用户轮次、模型历史、持久化会话、ACP rewind 和受限 fork 历史之间唯一权威的关联。新用户轮次只持久化一次该身份；模型历史通过 Symbol 键元数据携带它，因此不会进入 provider 请求；会话恢复则从同一条记录重建 UI 和 API 两种投影。

快速压缩检查点通过并行元数据保留身份；fork 会话会把带会话前缀的身份与文件快照一起重映射；重复身份存在歧义时会 fail closed。没有身份的旧会话继续使用现有的位置回退逻辑。

本 PR 在 #9331 合并后直接基于 `main`，并替代之前的 stacked PR #9466。

## 为什么需要它

修改前，TUI、ACP 和 fork 路径会分别通过内容形态和位置计数推导逻辑用户轮次。这些分类器对已清除媒体占位符已经存在分歧；当真实提示词恰好等于生成的占位符时，rewind 可能保留本应删除的模型上下文，也可能让后续轮次不可达。

修改后，当前会话通过稳定身份解析 rewind 边界，不再从两套表示重新推导对齐关系。身份缺失或重复时会把目标视为不可达，而不是猜测一个可能造成破坏的截断点。

## Reviewer Test Plan

### 如何验证

1. 创建多个轮次，让中间提示词恰好为 `[Old inline media cleared: image/png]`，然后分别 rewind 到中间轮次和后续轮次。每次都应在匹配的模型提示词之前精确截断。
2. 恢复一个持久化会话，包括执行过快速压缩的会话，确认相同的可见轮次仍能在相同边界 rewind。
3. fork 一个持久化会话，确认继承的轮次身份仍与继承的文件快照对齐。
4. 加载没有身份的旧会话，确认原有位置回退仍可用；加载包含重复身份的异常历史，确认 rewind fail closed，且不会修改会话或文件。

### 证据（修改前后）

修改前：中间的占位符形态提示词被解析到边界 `4`，而不是 `2`；后续提示词返回 `-1`。

修改后：相同目标分别解析到 `2` 和 `4`；重复身份返回 `-1`。稳定身份持久化、恢复重建、TUI/ACP 映射、轮次传递和 fork 选择的定向检查已在隔离实现分支通过。最终基于 main 的 patch 通过 `git diff --check`；新的本地 core build 在到达改动代码前被当前 checkout 中未解析的依赖（`fdir`、`mime`、`ajv` 和 `@lydell/node-pty`）阻断，因此干净环境 CI 是剩余的构建门禁。

UI 验证：N/A——本 PR 修改 rewind 身份与持久化逻辑，不涉及渲染或布局。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Node.js 22；在 macOS 上运行了 package-local Vitest 检查。由于本地依赖偏差，最终干净构建交由 CI 验证。

## 风险与范围

- 主要风险或取舍：新增了可选会话元数据，并把当前会话的 rewind 选择从位置推导改为身份查找；当前身份缺失或有歧义时会有意 fail closed。
- 未验证 / 范围外：未在 Windows 和 Linux 本地测试。最终基于 main 的 checkout 因上述无关依赖解析错误而无法完成本地构建。
- 破坏性变更 / 迁移说明：无。旧会话记录仍可读取，并继续使用 legacy fallback。

## 关联 Issue

Closes #9437

Supersedes #9466

</details>
