### PR TITLE
feat(web-shell): Consume live-state session activity timestamps

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -14079,6 +14079,7 @@ describe('App session callbacks', () => {
     });
     expect(sessionCatalogController.turnCompleted).toHaveBeenCalledWith(
       '/tmp/project',
+      'session-1',
     );
 
     onSessionChange.mockClear();
@@ -14133,6 +14134,7 @@ describe('App session callbacks', () => {
 
     expect(sessionCatalogController.turnCompleted).toHaveBeenCalledWith(
       '/tmp/project',
+      'session-late',
     );
     expect(onSessionChange).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -7262,7 +7262,7 @@ export function App({
           ? new Error(`Turn error (block ${lastTurnErrorIdRef.current})`)
           : undefined;
       if (workspaceCwd) {
-        sessionCatalogController.turnCompleted(workspaceCwd);
+        sessionCatalogController.turnCompleted(workspaceCwd, sessionId);
         if (!connectionRef.current.displayName) {
           scheduleDelayedActiveSessionDisplayNameRefresh(
             sessionId,

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -1154,7 +1154,10 @@ describe('ChatPane', () => {
     streamingStateValue = 'idle';
     rerender();
 
-    expect(catalogController.turnCompleted).toHaveBeenCalledWith('/w');
+    expect(catalogController.turnCompleted).toHaveBeenCalledWith(
+      '/w',
+      'sess-1',
+    );
   });
 
   it('does not duplicate turn completion owned by the outer session', () => {
@@ -1188,7 +1191,10 @@ describe('ChatPane', () => {
     streamingStateValue = 'idle';
     rerender();
 
-    expect(catalogController.turnCompleted).toHaveBeenCalledWith('/w');
+    expect(catalogController.turnCompleted).toHaveBeenCalledWith(
+      '/w',
+      'sess-late',
+    );
   });
 
   it('captures a pane workspace that becomes available mid-turn', () => {
@@ -1202,9 +1208,13 @@ describe('ChatPane', () => {
     rerender();
 
     expect(catalogController.turnCompleted).toHaveBeenCalledTimes(1);
-    expect(catalogController.turnCompleted).toHaveBeenCalledWith('/secondary');
+    expect(catalogController.turnCompleted).toHaveBeenCalledWith(
+      '/secondary',
+      'sess-1',
+    );
     expect(catalogController.turnCompleted).not.toHaveBeenCalledWith(
       '/primary',
+      'sess-1',
     );
   });
 

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -357,7 +357,10 @@ export function ChatPane({
       catalogOwnerCwd === catalogStreamingWorkspaceCwdRef.current &&
       reportCatalogTurnCompletion
     ) {
-      sessionCatalogController.turnCompleted(catalogOwnerCwd);
+      sessionCatalogController.turnCompleted(
+        catalogOwnerCwd,
+        connection.sessionId,
+      );
     }
   }, [
     catalogOwnerCwd,

--- a/packages/web-shell/client/session-catalog/session-catalog-hooks.test.tsx
+++ b/packages/web-shell/client/session-catalog/session-catalog-hooks.test.tsx
@@ -9,6 +9,7 @@ import type {
   DaemonSessionListPage,
 } from '@qwen-code/sdk/daemon';
 import type { SessionCatalogQuery } from './session-catalog-store';
+import { getSessionCatalogStore } from './session-catalog-store';
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -52,9 +53,11 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
   useWorkspace: () => mocks.workspace,
 }));
 
-const { useSessionCatalogQuery, useWebShellSessions } = await import(
-  './session-catalog-hooks'
-);
+const {
+  useSessionCatalogQuery,
+  useSessionCatalogController,
+  useWebShellSessions,
+} = await import('./session-catalog-hooks');
 
 let root: Root;
 let container: HTMLDivElement;
@@ -213,5 +216,37 @@ describe('session catalog hooks', () => {
       result = await facade!.reload();
     });
     expect(result).toBeUndefined();
+  });
+
+  it('routes turn completions by live-state ownership', () => {
+    const client = mocks.workspace.client as DaemonClient;
+    const store = getSessionCatalogStore(client);
+    let controller: ReturnType<typeof useSessionCatalogController> | undefined;
+
+    function ControllerProbe() {
+      controller = useSessionCatalogController(client);
+      return null;
+    }
+
+    act(() => root.render(<ControllerProbe />));
+    const record = vi.spyOn(store, 'recordSessionActivity');
+    const invalidate = vi.spyOn(store, 'invalidateWorkspace');
+    const schedule = vi.spyOn(store, 'scheduleWorkspaceRefresh');
+
+    // Without live-state ownership the legacy rescan path stays.
+    act(() => controller!.turnCompleted('/w', 'sess-1'));
+    expect(invalidate).toHaveBeenCalledWith('/w');
+    expect(schedule).toHaveBeenCalledWith('/w');
+    expect(store.snapshotSessionActivity('/w')).toBeUndefined();
+
+    invalidate.mockClear();
+    schedule.mockClear();
+    const releaseLiveState = store.retainWorkspaceLiveState('/w');
+    act(() => controller!.turnCompleted('/w', 'sess-1'));
+    expect(record).toHaveBeenCalledWith('/w', 'sess-1');
+    expect(store.snapshotSessionActivity('/w')?.get('sess-1')).toBeDefined();
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(schedule).not.toHaveBeenCalled();
+    releaseLiveState();
   });
 });

--- a/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
@@ -218,13 +218,13 @@ export function useSessionCatalogController(client: DaemonClient) {
           store.invalidateWorkspace(workspaceCwd);
         });
       },
-      turnCompleted(workspaceCwd: string) {
+      turnCompleted(workspaceCwd: string, sessionId: string) {
         update(() => {
           if (store.isWorkspaceLiveStateEnabled(workspaceCwd)) {
-            // The catalog revision doesn't advance on turn completion and
-            // the live-state overlay carries no updatedAt — flag a
-            // rate-limited reconcile so activity stamps keep refreshing.
-            store.requestWorkspaceLiveStateInvalidation(workspaceCwd);
+            // The catalog revision doesn't advance on turn completion; record
+            // the completion so the live-state loop can settle it from the
+            // response's updatedAt watermark instead of a full catalog scan.
+            store.recordSessionActivity(workspaceCwd, sessionId);
             return;
           }
           store.invalidateWorkspace(workspaceCwd);

--- a/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
@@ -774,7 +774,7 @@ describe('SessionCatalogStore', () => {
     stopWake();
   });
 
-  it('reports loaded active sessions only from reorder-owning pages', async () => {
+  it('absorbs watermarks only for rows on reorder-owning pages', async () => {
     legacy.mockImplementation(
       async (_cwd: string, options: { archiveState?: string }) => ({
         sessions:
@@ -787,6 +787,8 @@ describe('SessionCatalogStore', () => {
                   workspaceCwd: '/work',
                   isArchived: true,
                 },
+                { sessionId: 'foreign-row', workspaceCwd: '/elsewhere' },
+                { sessionId: 'no-watermark', workspaceCwd: '/work' },
               ],
       }),
     );
@@ -798,12 +800,107 @@ describe('SessionCatalogStore', () => {
       },
       { fresh: true },
     );
+    // The cursored page holds the only copy of a distinct session id, so a
+    // watermark for it must not be reported as absorbed.
+    legacy.mockResolvedValue({
+      sessions: [{ sessionId: 'cursor-only', workspaceCwd: '/work' }],
+    });
+    await store.loadOnce(
+      {
+        ...query('/work'),
+        options: { ...query('/work').options, cursor: 'cursor-1' },
+      },
+      { fresh: true },
+    );
 
-    expect(store.hasLoadedActiveSession('/work', 'a')).toBe(true);
-    expect(store.hasLoadedActiveSession('/work', 'row-archived')).toBe(false);
-    expect(store.hasLoadedActiveSession('/work', 'archived-only')).toBe(false);
-    expect(store.hasLoadedActiveSession('/work', 'unknown')).toBe(false);
-    expect(store.hasLoadedActiveSession('/other', 'a')).toBe(false);
+    const volatileState = {
+      clientCount: 0,
+      hasActivePrompt: false,
+      isWaitingForPermission: false,
+      isWaitingForUserQuestion: false,
+    };
+    const stamp = '2026-08-17T00:00:09.000Z';
+    const absorbed = store.applyLiveState('/work', [
+      { sessionId: 'a', ...volatileState, updatedAt: stamp },
+      { sessionId: 'row-archived', ...volatileState, updatedAt: stamp },
+      { sessionId: 'foreign-row', ...volatileState, updatedAt: stamp },
+      { sessionId: 'archived-only', ...volatileState, updatedAt: stamp },
+      { sessionId: 'cursor-only', ...volatileState, updatedAt: stamp },
+      { sessionId: 'unknown', ...volatileState, updatedAt: stamp },
+      { sessionId: 'no-watermark', ...volatileState },
+    ]);
+
+    expect([...absorbed]).toEqual(['a']);
+  });
+
+  it('orders unstamped rows by createdAt and bounds stamps by createdAt', async () => {
+    legacy.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'm',
+          workspaceCwd: '/work',
+          updatedAt: '2026-08-17T00:00:03.000Z',
+        },
+        {
+          sessionId: 'zzz',
+          workspaceCwd: '/work',
+          createdAt: '2026-08-17T00:00:02.000Z',
+        },
+        {
+          sessionId: 'aaa',
+          workspaceCwd: '/work',
+          createdAt: '2026-08-17T00:00:01.000Z',
+        },
+      ],
+    });
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+
+    const volatileState = {
+      clientCount: 0,
+      hasActivePrompt: false,
+      isWaitingForPermission: false,
+      isWaitingForUserQuestion: false,
+    };
+    // A live stamp older than a row's createdAt lower bound is rejected.
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'zzz',
+        ...volatileState,
+        updatedAt: '2026-08-17T00:00:01.500Z',
+      },
+    ]);
+    expect(
+      store
+        .getSnapshot(target)
+        .page?.sessions.find((session) => session.sessionId === 'zzz')
+        ?.updatedAt,
+    ).toBeUndefined();
+
+    // A fresher stamp on another row triggers a re-sort; the unstamped rows
+    // must order by their createdAt lower bound, not the id tie-break.
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'm',
+        ...volatileState,
+        updatedAt: '2026-08-17T00:00:04.000Z',
+      },
+    ]);
+    expect(
+      store.getSnapshot(target).page?.sessions.map((s) => s.sessionId),
+    ).toEqual(['m', 'zzz', 'aaa']);
+
+    // A stamp above the createdAt lower bound is accepted.
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'zzz',
+        ...volatileState,
+        updatedAt: '2026-08-17T00:00:05.000Z',
+      },
+    ]);
+    expect(
+      store.getSnapshot(target).page?.sessions.map((s) => s.sessionId),
+    ).toEqual(['zzz', 'm', 'aaa']);
   });
 
   it('stages active queries through their own route kind and stales retained pages', async () => {

--- a/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
@@ -550,6 +550,262 @@ describe('SessionCatalogStore', () => {
     ]);
   });
 
+  it('stamps a fresher live watermark and reorders the active page', async () => {
+    legacy.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'b',
+          workspaceCwd: '/work',
+          updatedAt: '2026-08-17T00:00:02.000Z',
+        },
+        {
+          sessionId: 'a',
+          workspaceCwd: '/work',
+          updatedAt: '2026-08-17T00:00:01.000Z',
+        },
+      ],
+    });
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'a',
+        clientCount: 1,
+        hasActivePrompt: false,
+        isWaitingForPermission: false,
+        isWaitingForUserQuestion: false,
+        updatedAt: '2026-08-17T00:00:03.000Z',
+      },
+    ]);
+
+    expect(
+      store.getSnapshot(target).page?.sessions.map((session) => ({
+        sessionId: session.sessionId,
+        updatedAt: session.updatedAt,
+      })),
+    ).toEqual([
+      { sessionId: 'a', updatedAt: '2026-08-17T00:00:03.000Z' },
+      { sessionId: 'b', updatedAt: '2026-08-17T00:00:02.000Z' },
+    ]);
+  });
+
+  it('ignores stale, invalid, or archived-row watermarks', async () => {
+    legacy.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'a',
+          workspaceCwd: '/work',
+          updatedAt: '2026-08-17T00:00:02.000Z',
+        },
+        {
+          sessionId: 'gone',
+          workspaceCwd: '/work',
+          isArchived: true,
+          updatedAt: '2026-08-17T00:00:01.000Z',
+        },
+      ],
+    });
+    const target = query('/work');
+    await store.loadOnce(target, { fresh: true });
+
+    const volatileState = {
+      clientCount: 0,
+      hasActivePrompt: false,
+      isWaitingForPermission: false,
+      isWaitingForUserQuestion: false,
+    };
+    // Each case applies separately — live-state rows are indexed by session
+    // id, so batching duplicate ids would drop all but the last entry.
+    // Stale and unparsable stamps must not regress or corrupt the row.
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'a',
+        ...volatileState,
+        updatedAt: '2026-08-17T00:00:01.000Z',
+      },
+    ]);
+    store.applyLiveState('/work', [
+      { sessionId: 'a', ...volatileState, updatedAt: 'not-a-timestamp' },
+    ]);
+    // An archived row never accepts a live activity stamp.
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'gone',
+        ...volatileState,
+        updatedAt: '2026-08-17T00:00:09.000Z',
+      },
+    ]);
+
+    expect(
+      store.getSnapshot(target).page?.sessions.map((session) => ({
+        sessionId: session.sessionId,
+        updatedAt: session.updatedAt,
+      })),
+    ).toEqual([
+      { sessionId: 'a', updatedAt: '2026-08-17T00:00:02.000Z' },
+      { sessionId: 'gone', updatedAt: '2026-08-17T00:00:01.000Z' },
+    ]);
+  });
+
+  it('never stamps archived or cursored pages', async () => {
+    legacy.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'a',
+          workspaceCwd: '/work',
+          updatedAt: '2026-08-17T00:00:01.000Z',
+        },
+      ],
+    });
+    const archived = {
+      ...query('/work'),
+      options: { pageSize: 1000, archiveState: 'archived' as const },
+    };
+    const cursored = {
+      ...query('/work'),
+      options: { ...query('/work').options, cursor: 'cursor-1' },
+    };
+    await store.loadOnce(archived, { fresh: true });
+    await store.loadOnce(cursored, { fresh: true });
+
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'a',
+        clientCount: 3,
+        hasActivePrompt: false,
+        isWaitingForPermission: false,
+        isWaitingForUserQuestion: false,
+        updatedAt: '2026-08-17T00:00:09.000Z',
+      },
+    ]);
+
+    for (const target of [archived, cursored]) {
+      const row = store.getSnapshot(target).page?.sessions[0];
+      // The volatile overlay still applies; only the activity stamp is
+      // rejected outside reorder-owning pages.
+      expect(row).toMatchObject({
+        sessionId: 'a',
+        clientCount: 3,
+        updatedAt: '2026-08-17T00:00:01.000Z',
+      });
+    }
+  });
+
+  it('keeps pinned rows ahead when reordering an organized page', async () => {
+    legacy.mockResolvedValue({
+      sessions: [
+        {
+          sessionId: 'pinned',
+          workspaceCwd: '/work',
+          isPinned: true,
+          updatedAt: '2026-08-17T00:00:01.000Z',
+        },
+        {
+          sessionId: 'b',
+          workspaceCwd: '/work',
+          updatedAt: '2026-08-17T00:00:03.000Z',
+        },
+        {
+          sessionId: 'a',
+          workspaceCwd: '/work',
+          updatedAt: '2026-08-17T00:00:02.000Z',
+        },
+      ],
+    });
+    const organized = {
+      ...query('/work'),
+      options: {
+        ...query('/work').options,
+        view: 'organized' as const,
+        group: 'all',
+      },
+    };
+    await store.loadOnce(organized, { fresh: true });
+
+    store.applyLiveState('/work', [
+      {
+        sessionId: 'a',
+        clientCount: 0,
+        hasActivePrompt: false,
+        isWaitingForPermission: false,
+        isWaitingForUserQuestion: false,
+        updatedAt: '2026-08-17T00:00:04.000Z',
+      },
+    ]);
+
+    expect(
+      store
+        .getSnapshot(organized)
+        .page?.sessions.map((session) => session.sessionId),
+    ).toEqual(['pinned', 'a', 'b']);
+  });
+
+  it('records, snapshots, and resolves pending session activity', () => {
+    const wake = vi.fn();
+    const stopWake = store.onLiveStateWake(wake);
+
+    // Without live-state ownership the record is a no-op.
+    store.recordSessionActivity('/work', 'a');
+    expect(store.snapshotSessionActivity('/work')).toBeUndefined();
+    expect(wake).not.toHaveBeenCalled();
+
+    const releaseLiveState = store.retainWorkspaceLiveState('/work');
+    store.recordSessionActivity('/work', 'a');
+    expect(wake).toHaveBeenCalledWith('/work');
+    const first = store.snapshotSessionActivity('/work');
+    const firstSequence = first?.get('a');
+    expect(firstSequence).toBeDefined();
+
+    // A completion recorded mid-flight bumps the sequence; settling with
+    // the stale sequence must keep the newer pending entry.
+    store.recordSessionActivity('/work', 'a');
+    store.resolveSessionActivity('/work', 'a', firstSequence!);
+    const second = store.snapshotSessionActivity('/work');
+    expect(second?.get('a')).toBeGreaterThan(firstSequence!);
+
+    store.resolveSessionActivity('/work', 'a', second!.get('a')!);
+    expect(store.snapshotSessionActivity('/work')).toBeUndefined();
+
+    // Releasing the last live-state user drops pending completions.
+    store.recordSessionActivity('/work', 'b');
+    releaseLiveState();
+    expect(store.snapshotSessionActivity('/work')).toBeUndefined();
+    stopWake();
+  });
+
+  it('reports loaded active sessions only from reorder-owning pages', async () => {
+    legacy.mockImplementation(
+      async (_cwd: string, options: { archiveState?: string }) => ({
+        sessions:
+          options.archiveState === 'archived'
+            ? [{ sessionId: 'archived-only', workspaceCwd: '/work' }]
+            : [
+                { sessionId: 'a', workspaceCwd: '/work' },
+                {
+                  sessionId: 'row-archived',
+                  workspaceCwd: '/work',
+                  isArchived: true,
+                },
+              ],
+      }),
+    );
+    await store.loadOnce(query('/work'), { fresh: true });
+    await store.loadOnce(
+      {
+        ...query('/work'),
+        options: { pageSize: 1000, archiveState: 'archived' as const },
+      },
+      { fresh: true },
+    );
+
+    expect(store.hasLoadedActiveSession('/work', 'a')).toBe(true);
+    expect(store.hasLoadedActiveSession('/work', 'row-archived')).toBe(false);
+    expect(store.hasLoadedActiveSession('/work', 'archived-only')).toBe(false);
+    expect(store.hasLoadedActiveSession('/work', 'unknown')).toBe(false);
+    expect(store.hasLoadedActiveSession('/other', 'a')).toBe(false);
+  });
+
   it('stages active queries through their own route kind and stales retained pages', async () => {
     legacy.mockImplementation(async (cwd: string) => page(cwd, cwd));
     const active = query('/work');

--- a/packages/web-shell/client/session-catalog/session-catalog-store.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.ts
@@ -298,26 +298,6 @@ export class SessionCatalogStore {
     if (pending.size === 0) this.liveStatePendingActivity.delete(workspaceCwd);
   }
 
-  hasLoadedActiveSession(workspaceCwd: string, sessionId: string): boolean {
-    for (const entry of this.entries.values()) {
-      if (entry.query.workspaceCwd !== workspaceCwd || !entry.snapshot.page) {
-        continue;
-      }
-      if (!ownsActivityReorder(entry)) continue;
-      if (
-        entry.snapshot.page.sessions.some(
-          (session) =>
-            session.sessionId === sessionId &&
-            session.isArchived !== true &&
-            (!session.workspaceCwd || session.workspaceCwd === workspaceCwd),
-        )
-      ) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private requestLiveStateRefresh(
     workspaceCwd: string,
     kind: 'interactive' | 'invalidated',
@@ -517,10 +497,15 @@ export class SessionCatalogStore {
   applyLiveState(
     workspaceCwd: string,
     liveSessions: readonly DaemonSessionLiveState[],
-  ): void {
+  ): ReadonlySet<string> {
     const liveById = new Map(
       liveSessions.map((session) => [session.sessionId, session]),
     );
+    // Session ids whose live activity watermark was usable on a loaded,
+    // reorder-owning page (stamped or already at least as fresh). The settle
+    // loop consumes this instead of re-deriving the index and acceptance
+    // rules, so the two sites cannot drift apart.
+    const absorbed = new Set<string>();
     for (const entry of this.entries.values()) {
       if (entry.query.workspaceCwd !== workspaceCwd || !entry.snapshot.page) {
         continue;
@@ -550,6 +535,7 @@ export class SessionCatalogStore {
             : undefined;
         const liveActivityTime =
           liveUpdatedAt !== undefined ? Date.parse(liveUpdatedAt) : Number.NaN;
+        if (Number.isFinite(liveActivityTime)) absorbed.add(session.sessionId);
         const updatedAt =
           liveUpdatedAt !== undefined &&
           Number.isFinite(liveActivityTime) &&
@@ -591,6 +577,7 @@ export class SessionCatalogStore {
         page: { ...entry.snapshot.page, sessions },
       });
     }
+    return absorbed;
   }
 
   async stageWorkspaceRefresh(

--- a/packages/web-shell/client/session-catalog/session-catalog-store.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.ts
@@ -129,6 +129,37 @@ function hasAutoLoadSubscriber(entry: CatalogEntry): boolean {
   );
 }
 
+// Mirrors the server's getSummaryActivityTime: activity is updatedAt with a
+// createdAt lower bound fallback, and an unparsable stamp sorts last.
+function getSessionActivityTime(session: DaemonSessionSummary): number {
+  const time = Date.parse(session.updatedAt ?? session.createdAt ?? '');
+  return Number.isFinite(time) ? time : 0;
+}
+
+function compareSessionsByActivity(
+  organized: boolean,
+  a: DaemonSessionSummary,
+  b: DaemonSessionSummary,
+): number {
+  if (organized) {
+    const byPinned = Number(b.isPinned === true) - Number(a.isPinned === true);
+    if (byPinned !== 0) return byPinned;
+  }
+  const byTime = getSessionActivityTime(b) - getSessionActivityTime(a);
+  if (byTime !== 0) return byTime;
+  return a.sessionId.localeCompare(b.sessionId);
+}
+
+// Only cursor-less, non-archived pages own an activity reorder: an archived
+// page never accepts a live activity stamp, and a cursored page's rows are
+// fenced by the cursor boundary, so a fresher row belongs to an earlier page.
+function ownsActivityReorder(entry: CatalogEntry): boolean {
+  return (
+    entry.query.options.archiveState !== 'archived' &&
+    entry.query.options.cursor === undefined
+  );
+}
+
 function getPollInterval(entry: CatalogEntry): number | undefined {
   let interval: number | undefined;
   for (const subscriber of entry.subscribers) {
@@ -154,6 +185,11 @@ export class SessionCatalogStore {
   >();
   private readonly liveStateWakeHandlers = new Set<
     (workspaceCwd: string) => void
+  >();
+  private liveStateActivitySequence = 0;
+  private readonly liveStatePendingActivity = new Map<
+    string,
+    Map<string, number>
   >();
   private activeRequests = 0;
   private activeBackgroundRequests = 0;
@@ -183,6 +219,7 @@ export class SessionCatalogStore {
       else {
         this.liveStateWorkspaceUsers.delete(workspaceCwd);
         this.liveStateWorkspaceRefreshRequests.delete(workspaceCwd);
+        this.liveStatePendingActivity.delete(workspaceCwd);
         for (const entry of this.entries.values()) {
           if (entry.query.workspaceCwd !== workspaceCwd) continue;
           this.resetPollSchedule(entry);
@@ -229,9 +266,56 @@ export class SessionCatalogStore {
     this.requestLiveStateRefresh(workspaceCwd, 'interactive');
   }
 
-  requestWorkspaceLiveStateInvalidation(workspaceCwd: string): void {
+  recordSessionActivity(workspaceCwd: string, sessionId: string): void {
     if (!this.isWorkspaceLiveStateEnabled(workspaceCwd)) return;
-    this.requestLiveStateRefresh(workspaceCwd, 'invalidated');
+    let pending = this.liveStatePendingActivity.get(workspaceCwd);
+    if (!pending) {
+      pending = new Map();
+      this.liveStatePendingActivity.set(workspaceCwd, pending);
+    }
+    pending.set(sessionId, ++this.liveStateActivitySequence);
+    for (const handler of this.liveStateWakeHandlers) handler(workspaceCwd);
+  }
+
+  snapshotSessionActivity(
+    workspaceCwd: string,
+  ): ReadonlyMap<string, number> | undefined {
+    const pending = this.liveStatePendingActivity.get(workspaceCwd);
+    if (!pending || pending.size === 0) return undefined;
+    return new Map(pending);
+  }
+
+  resolveSessionActivity(
+    workspaceCwd: string,
+    sessionId: string,
+    sequence: number,
+  ): void {
+    const pending = this.liveStatePendingActivity.get(workspaceCwd);
+    // A completion recorded while the settling request was in flight bumps
+    // the sequence; that newer pending entry must survive this settle.
+    if (pending?.get(sessionId) !== sequence) return;
+    pending.delete(sessionId);
+    if (pending.size === 0) this.liveStatePendingActivity.delete(workspaceCwd);
+  }
+
+  hasLoadedActiveSession(workspaceCwd: string, sessionId: string): boolean {
+    for (const entry of this.entries.values()) {
+      if (entry.query.workspaceCwd !== workspaceCwd || !entry.snapshot.page) {
+        continue;
+      }
+      if (!ownsActivityReorder(entry)) continue;
+      if (
+        entry.snapshot.page.sessions.some(
+          (session) =>
+            session.sessionId === sessionId &&
+            session.isArchived !== true &&
+            (!session.workspaceCwd || session.workspaceCwd === workspaceCwd),
+        )
+      ) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private requestLiveStateRefresh(
@@ -441,7 +525,9 @@ export class SessionCatalogStore {
       if (entry.query.workspaceCwd !== workspaceCwd || !entry.snapshot.page) {
         continue;
       }
+      const acceptsActivity = ownsActivityReorder(entry);
       let changed = false;
+      let activityAdvanced = false;
       const sessions = entry.snapshot.page.sessions.map((session) => {
         // A page can hold sessions from another workspace (the daemon merges
         // live runtime state); a workspace-scoped live-state response cannot
@@ -455,24 +541,51 @@ export class SessionCatalogStore {
         const isWaitingForPermission = live?.isWaitingForPermission ?? false;
         const isWaitingForUserQuestion =
           live?.isWaitingForUserQuestion ?? false;
+        // The daemon watermark only ever advances recency; an equal or older
+        // stamp (e.g. a staged page committed fresher data mid-flight) must
+        // not regress the row.
+        const liveUpdatedAt =
+          acceptsActivity && session.isArchived !== true
+            ? live?.updatedAt
+            : undefined;
+        const liveActivityTime =
+          liveUpdatedAt !== undefined ? Date.parse(liveUpdatedAt) : Number.NaN;
+        const updatedAt =
+          liveUpdatedAt !== undefined &&
+          Number.isFinite(liveActivityTime) &&
+          liveActivityTime > getSessionActivityTime(session)
+            ? liveUpdatedAt
+            : session.updatedAt;
         if (
           session.clientCount === clientCount &&
           session.hasActivePrompt === hasActivePrompt &&
           session.isWaitingForPermission === isWaitingForPermission &&
-          session.isWaitingForUserQuestion === isWaitingForUserQuestion
+          session.isWaitingForUserQuestion === isWaitingForUserQuestion &&
+          session.updatedAt === updatedAt
         ) {
           return session;
         }
         changed = true;
+        if (session.updatedAt !== updatedAt) activityAdvanced = true;
         return {
           ...session,
           clientCount,
           hasActivePrompt,
           isWaitingForPermission,
           isWaitingForUserQuestion,
+          ...(updatedAt !== undefined ? { updatedAt } : {}),
         };
       });
       if (!changed) continue;
+      if (activityAdvanced) {
+        sessions.sort((a, b) =>
+          compareSessionsByActivity(
+            entry.query.options.view === 'organized',
+            a,
+            b,
+          ),
+        );
+      }
       this.setSnapshot(entry, {
         ...entry.snapshot,
         page: { ...entry.snapshot.page, sessions },
@@ -653,6 +766,7 @@ export class SessionCatalogStore {
     this.trailingRefreshTimers.clear();
     this.liveStateWorkspaceUsers.clear();
     this.liveStateWorkspaceRefreshRequests.clear();
+    this.liveStatePendingActivity.clear();
     this.entries.clear();
     this.queue.length = 0;
     this.removeVisibilityListener();

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
@@ -13,7 +13,10 @@ import {
   useSessionCatalogController,
   useSessionCatalogQuery,
 } from './session-catalog-hooks';
-import type { SessionCatalogQuery } from './session-catalog-store';
+import {
+  getSessionCatalogStore,
+  type SessionCatalogQuery,
+} from './session-catalog-store';
 import {
   SESSION_LIVE_STATE_ERROR_RETRY_MS,
   SESSION_LIVE_STATE_POLL_MS,
@@ -26,6 +29,7 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 function liveState(
   revision: number,
   hasActivePrompt = false,
+  updatedAt?: string,
 ): DaemonWorkspaceSessionLiveState {
   return {
     v: 1,
@@ -37,6 +41,7 @@ function liveState(
         hasActivePrompt,
         isWaitingForPermission: hasActivePrompt,
         isWaitingForUserQuestion: false,
+        ...(updatedAt !== undefined ? { updatedAt } : {}),
       },
     ],
   };
@@ -169,7 +174,7 @@ describe('useWorkspaceSessionLiveState', () => {
     expect(container.textContent).toBe('true:true:no-group');
   });
 
-  it('does not rescan the catalog for prompt admission, and coalesces turn completions', async () => {
+  it('does not rescan the catalog for prompt admission, and rate-limits unusable-watermark completions', async () => {
     await renderProbe();
     const catalogRequests = listSessions.mock.calls.length;
 
@@ -179,22 +184,210 @@ describe('useWorkspaceSessionLiveState', () => {
     });
     expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
 
-    // Turn completions refresh recency data (updatedAt) through the
-    // rate-limited invalidation path: one rescan per cooldown window.
+    // The live rows carry no updatedAt (old server / no running terminal
+    // yet), so completions fall back to the rate-limited reconcile path:
+    // one rescan per cooldown window.
     act(() => {
-      controller.turnCompleted('/work');
-      controller.turnCompleted('/work');
+      controller.turnCompleted('/work', 'session-a');
+      controller.turnCompleted('/work', 'session-a');
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
     });
     expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
 
-    act(() => controller.turnCompleted('/work'));
+    act(() => controller.turnCompleted('/work', 'session-a'));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
     });
     expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
+  });
+
+  it('settles a turn completion from the live watermark without a catalog scan', async () => {
+    let stamp = '2026-08-17T00:00:01.000Z';
+    getLiveState.mockImplementation(async () => liveState(1, false, stamp));
+    await renderProbe();
+    const catalogRequests = listSessions.mock.calls.length;
+    const store = getSessionCatalogStore(client);
+
+    stamp = '2026-08-17T00:00:05.000Z';
+    act(() => controller.turnCompleted('/work', 'session-a'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+    expect(store.snapshotSessionActivity('/work')).toBeUndefined();
+    expect(store.getSnapshot(query).page?.sessions[0]?.updatedAt).toBe(
+      '2026-08-17T00:00:05.000Z',
+    );
+
+    // Repeated completions keep settling in place — the full catalog scan
+    // stays retired for the recency path.
+    stamp = '2026-08-17T00:00:07.000Z';
+    act(() => controller.turnCompleted('/work', 'session-a'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+    expect(store.getSnapshot(query).page?.sessions[0]?.updatedAt).toBe(
+      '2026-08-17T00:00:07.000Z',
+    );
+  });
+
+  it('does not let an in-flight response settle a newer completion', async () => {
+    getLiveState.mockImplementation(async () =>
+      liveState(1, false, '2026-08-17T00:00:01.000Z'),
+    );
+    await renderProbe();
+    const catalogRequests = listSessions.mock.calls.length;
+    const store = getSessionCatalogStore(client);
+
+    let resolveInFlight!: (state: DaemonWorkspaceSessionLiveState) => void;
+    getLiveState.mockImplementationOnce(
+      () =>
+        new Promise<DaemonWorkspaceSessionLiveState>((resolve) => {
+          resolveInFlight = resolve;
+        }),
+    );
+    // The wake-driven request snapshots the first completion, then a second
+    // completion lands while that request is in flight.
+    act(() => controller.turnCompleted('/work', 'session-a'));
+    act(() => controller.turnCompleted('/work', 'session-a'));
+    await act(async () => {
+      resolveInFlight(liveState(1, false, '2026-08-17T00:00:02.000Z'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The stale response must leave the newer completion pending.
+    expect(
+      store.snapshotSessionActivity('/work')?.get('session-a'),
+    ).toBeDefined();
+
+    getLiveState.mockImplementation(async () =>
+      liveState(1, false, '2026-08-17T00:00:03.000Z'),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(store.snapshotSessionActivity('/work')).toBeUndefined();
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+  });
+
+  it('falls back to the rate-limited reconcile when the completed session is not loaded', async () => {
+    getLiveState.mockImplementation(async () => ({
+      ...liveState(1),
+      sessions: [
+        ...liveState(1).sessions,
+        {
+          sessionId: 'session-unloaded',
+          clientCount: 1,
+          hasActivePrompt: false,
+          isWaitingForPermission: false,
+          isWaitingForUserQuestion: false,
+          updatedAt: '2026-08-17T00:00:05.000Z',
+        },
+      ],
+    }));
+    await renderProbe();
+    const catalogRequests = listSessions.mock.calls.length;
+
+    // The row carries a valid watermark but is absent from the loaded
+    // active page, so recency must come from a full reconcile.
+    act(() => controller.turnCompleted('/work', 'session-unloaded'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
+  });
+
+  it('keeps a completion pending across a reconcile and settles on the next poll', async () => {
+    let revision = 1;
+    let stamp: string | undefined = undefined;
+    getLiveState.mockImplementation(async () =>
+      liveState(revision, false, stamp),
+    );
+    await renderProbe();
+    const store = getSessionCatalogStore(client);
+
+    // A version bump past the cooldown window starts a reconcile whose
+    // staged catalog fetch is held open.
+    let releaseStaged!: (page: DaemonSessionListPage) => void;
+    listSessions.mockImplementationOnce(
+      () =>
+        new Promise<DaemonSessionListPage>((resolve) => {
+          releaseStaged = resolve;
+        }),
+    );
+    revision = 2;
+    stamp = '2026-08-17T00:00:05.000Z';
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS,
+      );
+    });
+
+    // The completion lands while the reconcile is in flight; its liveB read
+    // must not settle it (the staged page it commits may be staler than the
+    // liveB watermark).
+    act(() => controller.turnCompleted('/work', 'session-a'));
+    const liveReadsBeforeRelease = getLiveState.mock.calls.length;
+    await act(async () => {
+      releaseStaged(sessionPage());
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+    });
+    // The reconcile's liveB read has happened, yet the completion is still
+    // pending — only a direct poll read may settle it.
+    expect(getLiveState.mock.calls.length).toBeGreaterThan(
+      liveReadsBeforeRelease,
+    );
+    expect(
+      store.snapshotSessionActivity('/work')?.get('session-a'),
+    ).toBeDefined();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(store.snapshotSessionActivity('/work')).toBeUndefined();
+    expect(store.getSnapshot(query).page?.sessions[0]?.updatedAt).toBe(
+      '2026-08-17T00:00:05.000Z',
+    );
+  });
+
+  it('keeps a completion pending across a live-state failure and settles after recovery', async () => {
+    getLiveState.mockImplementation(async () =>
+      liveState(1, false, '2026-08-17T00:00:01.000Z'),
+    );
+    await renderProbe();
+    const catalogRequests = listSessions.mock.calls.length;
+    const store = getSessionCatalogStore(client);
+
+    getLiveState.mockRejectedValueOnce(new Error('offline'));
+    act(() => controller.turnCompleted('/work', 'session-a'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // The failed request settles nothing; the completion waits out the
+    // error backoff.
+    expect(
+      store.snapshotSessionActivity('/work')?.get('session-a'),
+    ).toBeDefined();
+
+    getLiveState.mockImplementation(async () =>
+      liveState(1, false, '2026-08-17T00:00:06.000Z'),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_ERROR_RETRY_MS + SESSION_LIVE_STATE_POLL_MS,
+      );
+    });
+    expect(store.snapshotSessionActivity('/work')).toBeUndefined();
+    expect(store.getSnapshot(query).page?.sessions[0]?.updatedAt).toBe(
+      '2026-08-17T00:00:06.000Z',
+    );
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
   });
 
   it('does not schedule a second catalog scan after a local session creation', async () => {

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
@@ -201,6 +201,12 @@ describe('useWorkspaceSessionLiveState', () => {
       await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
     });
     expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
+    // Falling back must still resolve the pending completion — a leaked
+    // entry would re-flag the invalidation on every poll and re-run a full
+    // rescan once per cooldown window, forever.
+    expect(
+      getSessionCatalogStore(client).snapshotSessionActivity('/work'),
+    ).toBeUndefined();
   });
 
   it('settles a turn completion from the live watermark without a catalog scan', async () => {
@@ -300,6 +306,34 @@ describe('useWorkspaceSessionLiveState', () => {
       await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
     });
     expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
+    expect(
+      getSessionCatalogStore(client).snapshotSessionActivity('/work'),
+    ).toBeUndefined();
+
+    // With the completion resolved, an idle cooldown window must stay quiet
+    // — no further rescan may be re-triggered by leaked pending state.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS,
+      );
+    });
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
+  });
+
+  it('falls back when the completed session is absent from the live response', async () => {
+    await renderProbe();
+    const catalogRequests = listSessions.mock.calls.length;
+
+    // The live response only ever lists session-a; a completion for a
+    // session the daemon no longer reports live must fall back.
+    act(() => controller.turnCompleted('/work', 'session-ghost'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
+    expect(
+      getSessionCatalogStore(client).snapshotSessionActivity('/work'),
+    ).toBeUndefined();
   });
 
   it('keeps a completion pending across a reconcile and settles on the next poll', async () => {

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
@@ -289,27 +289,18 @@ export function useWorkspaceSessionLiveState(
         state.inFlight = false;
         return;
       }
-      catalogStore.applyLiveState(state.workspaceCwd, live.sessions);
+      const absorbedActivity = catalogStore.applyLiveState(
+        state.workspaceCwd,
+        live.sessions,
+      );
       state.liveRetryAt = 0;
       if (pendingActivity) {
-        const liveById = new Map(
-          live.sessions.map((session) => [session.sessionId, session]),
-        );
         for (const [sessionId, sequence] of pendingActivity) {
-          const row = liveById.get(sessionId);
-          const activityTime =
-            row?.updatedAt !== undefined
-              ? Date.parse(row.updatedAt)
-              : Number.NaN;
-          // applyLiveState already stamped the row; a completion is settled
-          // in place only when the watermark is usable and the session sits
-          // on a loaded active page. Anything else (missing row, absent or
+          // applyLiveState reports which sessions absorbed a usable watermark
+          // on a loaded active page; anything else (missing row, absent or
           // invalid stamp, row outside the loaded catalog) falls back to the
           // rate-limited full reconcile.
-          if (
-            !Number.isFinite(activityTime) ||
-            !catalogStore.hasLoadedActiveSession(state.workspaceCwd, sessionId)
-          ) {
+          if (!absorbedActivity.has(sessionId)) {
             state.invalidationRequested = true;
           }
           catalogStore.resolveSessionActivity(

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
@@ -254,6 +254,13 @@ export function useWorkspaceSessionLiveState(
         return;
       }
       state.inFlight = true;
+      // Contract: only a response from a request started after a completion
+      // was recorded may settle it, so the pending set is snapshotted before
+      // the request goes out. Completions recorded mid-flight keep their
+      // newer sequence and settle on the next tick.
+      const pendingActivity = catalogStore.snapshotSessionActivity(
+        state.workspaceCwd,
+      );
       let live: DaemonWorkspaceSessionLiveState;
       try {
         live = await readLiveState(state.workspaceCwd);
@@ -284,6 +291,34 @@ export function useWorkspaceSessionLiveState(
       }
       catalogStore.applyLiveState(state.workspaceCwd, live.sessions);
       state.liveRetryAt = 0;
+      if (pendingActivity) {
+        const liveById = new Map(
+          live.sessions.map((session) => [session.sessionId, session]),
+        );
+        for (const [sessionId, sequence] of pendingActivity) {
+          const row = liveById.get(sessionId);
+          const activityTime =
+            row?.updatedAt !== undefined
+              ? Date.parse(row.updatedAt)
+              : Number.NaN;
+          // applyLiveState already stamped the row; a completion is settled
+          // in place only when the watermark is usable and the session sits
+          // on a loaded active page. Anything else (missing row, absent or
+          // invalid stamp, row outside the loaded catalog) falls back to the
+          // rate-limited full reconcile.
+          if (
+            !Number.isFinite(activityTime) ||
+            !catalogStore.hasLoadedActiveSession(state.workspaceCwd, sessionId)
+          ) {
+            state.invalidationRequested = true;
+          }
+          catalogStore.resolveSessionActivity(
+            state.workspaceCwd,
+            sessionId,
+            sequence,
+          );
+        }
+      }
       consumeRefreshRequest(state);
       if (
         !state.reconcileRequested &&
@@ -326,8 +361,9 @@ export function useWorkspaceSessionLiveState(
     };
 
     // Interactive refresh requests (explicit refresh(), expiring
-    // maxAgeMs subscriptions, group-membership growth) wake the loop
-    // immediately instead of waiting for the next 2s tick.
+    // maxAgeMs subscriptions, group-membership growth) and recorded turn
+    // completions wake the loop immediately instead of waiting for the
+    // next 2s tick.
     const stopWake = catalogStore.onLiveStateWake((workspaceCwd) => {
       const state = states.find(
         (candidate) => candidate.workspaceCwd === workspaceCwd,


### PR DESCRIPTION
## What this PR does

After a normal turn completes, the Web Shell now refreshes that session's recency and re-sorts the loaded active list directly from the activity watermark already carried by the existing two-second live-state poll, instead of flagging a rate-limited full catalog rescan. Each completion is recorded with a per-session sequence, and only a live-state response whose request started after the completion was recorded may settle it, so a stale in-flight response can never mask a newer completion. A watermark is applied only when strictly fresher, only to rows already present on loaded, cursor-less, non-archived pages (unknown sessions are never inserted and archived pages are never touched), and the page is re-sorted with the same ordering the server uses (pinned block first in organized views, then activity, with a stable id tie-break). Whenever the watermark is unusable (old server, or no prompt has reached the running state in the current daemon generation) or the completed session is not on a loaded active page, the previous version-fenced, rate-limited full-catalog fallback still runs with its 10-second coalescing. The two-second polling cadence, the live→catalog→live version handshake, initial load, and the create/archive/delete/rename paths are unchanged, and workspaces without live-state keep the legacy invalidate-and-refresh behavior.

## Why it's needed

The server side of the live-state activity protocol shipped in #9396: every live session row can now carry a daemon-observed activity timestamp. The Web Shell, however, still ran the interim behavior from #9366, where every turn completion scheduled a rate-limited full session-catalog rescan just to refresh ordering timestamps — a disk-backed directory scan per cooldown window for data the client already polls every two seconds. This PR implements the consumer side exactly as specified by the follow-up consumption contract in docs/design/2026-08-18-workspace-session-live-state-updated-at.md, retiring steady-state catalog scans from the turn-completion path while keeping every degraded scenario on the previous conservative behavior.

## Reviewer Test Plan

### How to verify

- Against a current daemon, open the Web Shell in a workspace with several sessions and complete a turn in a session lower down the active list: the row should move to the top (below any pinned block) within about two seconds, its relative timestamp should refresh, and the network log should show only the ongoing live-state polls — no full session-list request attributable to the completion. Consecutive turns keep settling the same way.
- Complete a second turn while a live-state request is still in flight: the newer completion must still be reflected once the next poll lands (a stale response must not satisfy it).
- Degraded paths: when live rows carry no activity stamp (old daemon) or the completed session is not on the loaded active page, expect exactly one rate-limited full catalog refresh (10s coalescing) — the pre-PR behavior.
- The archived section and group/source-filtered pages never gain rows or reorder from live activity; creating, renaming, archiving, and deleting sessions still refresh the catalog as on main.
- Unit suites: `cd packages/web-shell && npx vitest run client/session-catalog client/components/ChatPane.test.tsx client/App.test.tsx`

### Evidence (Before & After)

Before: every turn completion scheduled a rate-limited full `/sessions` rescan to refresh ordering. After: completions settle from the live-state response in place (E2E against a real daemon: completed bottom-most session moved to the top within one poll, daemon catalog version unchanged throughout, confirming recency no longer rides the version-fenced rescan). Screenshots and the full E2E report follow in a separate comment.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests via vitest (Node 22). E2E via a locally built daemon (`npm run build`, `node packages/cli/dist/index.js serve`) driving the built Web Shell with Playwright.

## Risk & Scope

- Main risk or tradeoff: client-side reordering must agree with server ordering. Mitigated by mirroring the server comparator (pinned → activity time → stable id tie-break), only ever advancing a row's stamp (never regressing on stale or invalid data), and falling back to the previous full-refresh behavior whenever anything is uncertain.
- Not validated / out of scope: a pre-existing per-turn catalog fetch from the display-name fallback (byte-identical on main; this PR strictly reduces per-turn scan volume) — recorded as a follow-up candidate, as are #9396's deferred non-blocking hardening items.
- Breaking changes / migration notes: none. The protocol change is additive; old servers keep the fallback path, old clients ignore the new field.

## Linked Issues

Consumer follow-up to #9396 (server-side activity watermark) and #9366 (interim Web Shell live-state consumption).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

普通 turn 完成后，Web Shell 现在直接使用既有 2 秒 live-state 轮询响应中携带的活动水位来刷新该会话的时间戳并原地重排已加载的活动列表，而不再触发限频的全量目录重扫。每次完成会以会话级序号记录，只有在记录之后才发起的 live-state 请求的响应才可以确认该次完成，因此飞行中的旧响应永远不会掩盖更新的完成。水位仅在严格更新时应用，且只应用于已加载、无分页游标、非归档页面中已存在的行（绝不插入未知会话、绝不触碰归档页面），随后按服务端一致的排序规则（organized 视图 pinned 块优先，其后按活动时间，最后按稳定 id 决胜）重排该页。当水位不可用（旧服务端，或当前守护进程代际内尚无 prompt 进入运行态）或完成的会话不在已加载活动页时，仍走此前的版本围栏、10 秒限频全量目录回退。2 秒轮询节奏、live→catalog→live 版本握手、首次加载以及创建/归档/删除/重命名路径均保持不变；未启用 live-state 的工作区继续沿用旧的失效加刷新路径。

## 为什么需要

live-state 活动协议的服务端已随 #9396 合入：每个 live 会话行可携带守护进程观测到的活动时间戳。但 Web Shell 仍运行 #9366 的过渡行为：每次 turn 完成都会安排一次限频的全量会话目录重扫，仅为刷新排序时间戳——即每个冷却窗口一次磁盘目录扫描，而这些数据客户端本来每两秒就在轮询。本 PR 严格按照 docs/design/2026-08-18-workspace-session-live-state-updated-at.md 中的后续消费契约实现消费端，把稳态目录扫描从 turn 完成路径中移除，同时让所有降级场景保持此前的保守行为。

## 评审验证计划

### 如何验证

- 对当前守护进程：在包含多个会话的工作区打开 Web Shell，在活动列表靠下的会话完成一个 turn：该行应在约两秒内移动到列表顶部（pinned 块之下），相对时间刷新，网络日志中只有持续的 live-state 轮询——没有可归因于该次完成的全量会话列表请求。连续多个 turn 保持同样的原地更新。
- 在上一个 live-state 请求仍在飞行时完成第二个 turn：下一次轮询落地后新的完成仍必须被反映（旧响应不得确认它）。
- 降级路径：当 live 行不携带活动水位（旧守护进程）或完成的会话不在已加载活动页时，预期恰好一次限频全量目录刷新（10 秒合并）——即本 PR 之前的行为。
- 归档区与分组/来源过滤页不会因 live 活动新增行或重排；创建、重命名、归档、删除会话仍与 main 一致地刷新目录。
- 单元测试：`cd packages/web-shell && npx vitest run client/session-catalog client/components/ChatPane.test.tsx client/App.test.tsx`

### 证据（前后对比）

之前：每次 turn 完成都会安排一次限频全量 `/sessions` 重扫来刷新排序。之后：完成从 live-state 响应原地确认（对真实守护进程的 E2E：位于底部的会话完成后在一个轮询周期内升至顶部，全程守护进程目录版本号不变，证明时间戳刷新不再依赖版本围栏重扫）。截图与完整 E2E 报告见后续评论。

### 已测试平台

macOS ✅；Windows ⚠️；Linux ⚠️。

### 环境（可选）

单元测试使用 vitest（Node 22）。E2E 使用本地构建的守护进程（`npm run build` 后 `node packages/cli/dist/index.js serve`）配合 Playwright 驱动构建产物中的 Web Shell。

## 风险与范围

- 主要风险或权衡：客户端重排必须与服务端排序一致。缓解措施：逐位镜像服务端比较器（pinned → 活动时间 → 稳定 id 决胜）、行时间戳只前进不回退（陈旧或非法数据不生效）、任何不确定情况都回退到此前的全量刷新行为。
- 未验证/超出范围：turn 完成后既有的显示名兜底目录请求（与 main 逐字相同；本 PR 严格减少每 turn 扫描量），已记录为后续改进候选；#9396 遗留的非阻塞加固项同样另行处理。
- 破坏性变更/迁移说明：无。协议为增量扩展；旧服务端保持回退路径，旧客户端忽略新字段。

## 关联 Issue

作为 #9396（服务端活动水位）与 #9366（Web Shell 过渡消费）的消费端后续。

</details>
