### PR TITLE
fix(core): clamp max reasoning effort for OpenAI-compatible providers

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -81,6 +81,10 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
   static isDeepSeekProvider = isDeepSeekProvider;
   static isDeepSeekHostname = isDeepSeekHostname;
 
+  protected override supportsMaxReasoningEffort(): boolean {
+    return isDeepSeekHostname(this.contentGeneratorConfig);
+  }
+
   /**
    * DeepSeek's API requires message content to be a plain string, not an
    * array of content parts. Flatten any text-part arrays into joined

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -113,11 +113,49 @@ export class DefaultOpenAICompatibleProvider
       ? requestWithTokenLimits.messages.map(mirrorReasoningContentToReasoning)
       : requestWithTokenLimits.messages;
 
-    return {
+    const builtRequest = {
       ...requestWithTokenLimits,
       messages,
       ...(extraBody ? extraBody : {}),
     };
+
+    return this.clampReasoningEffortForWire(builtRequest);
+  }
+
+  /**
+   * Generic OpenAI-compatible endpoints accept reasoning effort up to `xhigh`.
+   * Provider adapters with a documented `max` tier override
+   * {@link supportsMaxReasoningEffort} and keep the value for their own wire
+   * reshaping. This prevents a persisted `/effort max` from sending an invalid
+   * value to otherwise-generic compatible endpoints.
+   */
+  protected clampReasoningEffortForWire<T extends { model: string }>(
+    request: T,
+  ): T {
+    if (this.supportsMaxReasoningEffort()) {
+      return request;
+    }
+
+    const record = request as unknown as Record<string, unknown>;
+    const reasoning = record['reasoning'] as
+      | Record<string, unknown>
+      | undefined;
+    if (reasoning?.['effort'] !== 'max') {
+      return request;
+    }
+
+    return {
+      ...request,
+      reasoning: {
+        ...reasoning,
+        effort: 'xhigh',
+      },
+    } as T;
+  }
+
+  /** Providers with a documented native `max` effort override this. */
+  protected supportsMaxReasoningEffort(): boolean {
+    return false;
   }
 
   getDefaultGenerationConfig(): GenerateContentConfig {
@@ -211,9 +249,9 @@ export class DefaultOpenAICompatibleProvider
       }
     }
 
-    return {
+    return this.clampReasoningEffortForWire({
       ...request,
       max_tokens: effectiveMaxTokens,
-    };
+    });
   }
 }

--- a/packages/core/src/core/openaiContentGenerator/provider/reasoning-effort-clamp.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/reasoning-effort-clamp.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type OpenAI from 'openai';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+import { DashScopeOpenAICompatibleProvider } from './dashscope.js';
+import { DeepSeekOpenAICompatibleProvider } from './deepseek.js';
+import { ZaiOpenAICompatibleProvider } from './zai.js';
+
+const cliConfig = {} as Config;
+
+function request(
+  effort: string,
+): OpenAI.Chat.ChatCompletionCreateParams {
+  return {
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 128,
+    reasoning: { effort, budget_tokens: 1024 },
+  } as unknown as OpenAI.Chat.ChatCompletionCreateParams;
+}
+
+function reasoningOf(
+  value: OpenAI.Chat.ChatCompletionCreateParams,
+): Record<string, unknown> | undefined {
+  return (value as unknown as Record<string, unknown>)['reasoning'] as
+    | Record<string, unknown>
+    | undefined;
+}
+
+class ProviderUsingInheritedOutputLimit extends DefaultOpenAICompatibleProvider {
+  override buildRequest(
+    value: OpenAI.Chat.ChatCompletionCreateParams,
+    _userPromptId: string,
+  ): OpenAI.Chat.ChatCompletionCreateParams {
+    return this.applyOutputTokenLimit(value);
+  }
+}
+
+class MaxCapableProvider extends DefaultOpenAICompatibleProvider {
+  protected override supportsMaxReasoningEffort(): boolean {
+    return true;
+  }
+}
+
+describe('OpenAI-compatible reasoning effort clamp', () => {
+  it('clamps max to xhigh for a generic compatible provider', () => {
+    const provider = new DefaultOpenAICompatibleProvider(
+      { model: 'test-model' } as ContentGeneratorConfig,
+      cliConfig,
+    );
+
+    const built = provider.buildRequest(request('max'), 'prompt');
+
+    expect(reasoningOf(built)).toEqual({
+      effort: 'xhigh',
+      budget_tokens: 1024,
+    });
+  });
+
+  it('clamps through the inherited output-limit path used by custom providers', () => {
+    const provider = new ProviderUsingInheritedOutputLimit(
+      { model: 'test-model' } as ContentGeneratorConfig,
+      cliConfig,
+    );
+
+    const built = provider.buildRequest(request('max'), 'prompt');
+
+    expect(reasoningOf(built)?.['effort']).toBe('xhigh');
+  });
+
+  it('clamps max on DashScope for non-Qwen compatible models', () => {
+    const provider = new DashScopeOpenAICompatibleProvider(
+      {
+        model: 'glm-5.2',
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        enableCacheControl: false,
+      } as ContentGeneratorConfig,
+      cliConfig,
+    );
+
+    const built = provider.buildRequest(
+      { ...request('max'), model: 'glm-5.2' },
+      'prompt',
+    );
+
+    expect(reasoningOf(built)?.['effort']).toBe('xhigh');
+  });
+
+  it('keeps max for providers that explicitly support it', () => {
+    const provider = new MaxCapableProvider(
+      { model: 'test-model' } as ContentGeneratorConfig,
+      cliConfig,
+    );
+
+    const built = provider.buildRequest(request('max'), 'prompt');
+
+    expect(reasoningOf(built)?.['effort']).toBe('max');
+  });
+
+  it('preserves max on the official DeepSeek wire shape', () => {
+    const provider = new DeepSeekOpenAICompatibleProvider(
+      {
+        model: 'deepseek-chat',
+        baseUrl: 'https://api.deepseek.com/v1',
+      } as ContentGeneratorConfig,
+      cliConfig,
+    );
+
+    const built = provider.buildRequest(request('max'), 'prompt') as unknown as Record<
+      string,
+      unknown
+    >;
+
+    expect(built['reasoning_effort']).toBe('max');
+  });
+
+  it('preserves max on the official Z.ai wire shape', () => {
+    const provider = new ZaiOpenAICompatibleProvider(
+      {
+        model: 'glm-5.2',
+        baseUrl: 'https://api.z.ai/v1',
+      } as ContentGeneratorConfig,
+      cliConfig,
+    );
+
+    const built = provider.buildRequest(request('max'), 'prompt') as unknown as Record<
+      string,
+      unknown
+    >;
+
+    expect(built['reasoning_effort']).toBe('max');
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/zai.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/zai.ts
@@ -62,6 +62,10 @@ export class ZaiOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider
   // Latch so the skipped-flatten warning fires once per provider lifetime.
   private nonZaiHostnameFlattenWarned = false;
 
+  protected override supportsMaxReasoningEffort(): boolean {
+    return isZaiHostname(this.contentGeneratorConfig);
+  }
+
   override buildRequest(
     request: OpenAI.Chat.ChatCompletionCreateParams,
     userPromptId: string,


### PR DESCRIPTION
## Summary

- clamp `reasoning.effort: max` to `xhigh` for generic OpenAI-compatible providers
- preserve native `max` support for official DeepSeek and Z.ai endpoints
- cover inherited provider paths such as DashScope
- add regression coverage for provider-specific behavior

Fixes #9459

## Testing

- `cd packages/core && npx vitest run src/core/openaiContentGenerator/provider/reasoning-effort-clamp.test.ts`
