### PR TITLE
fix(ci): no-op touch to re-register the autofix workflow triggers

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -47,6 +47,8 @@ name: 'Qwen Autofix'
 # through CI_DEV_BOT_PAT so the bot acts as the configured autofix identity.
 # PAT label writes can emit issues:labeled events; the route guards below make
 # those runs exit unless the label, issue state, and ready label all match.
+# 2026-08-19: no-op comment forcing Actions to re-parse this file — dispatch of
+# issue_comment/schedule/pull_request events had been silently dead ~12 hours.
 on:
   issues:
     types:


### PR DESCRIPTION
## What this PR does

Adds a single comment line to the autofix workflow so merging forces GitHub Actions to re-parse and re-register the workflow. No behavior change: the trigger block, jobs, gates, and steps are all byte-identical except the comment.

## Why it's needed

Starting around 2026-08-19 00:00 UTC, three of the workflow's five triggers stopped producing runs: the ten-minute schedule ticks stopped after 2026-08-18 23:51 UTC, issue-comment events stopped matching after 00:16 UTC even though sibling workflows received the same events seconds later, and label toggles stopped routing. Meanwhile dispatch runs were created but never expanded into jobs — three sat queued with zero jobs for 4 to 11 hours. The review-event lane kept working throughout, which is why the loop looked half alive. The trigger block was unchanged across this window (the last two merges touching the workflow only modified step bodies), and a disable/re-enable cycle at 12:28 UTC did not restore the dead triggers either — later comment events created runs for every other issue-comment workflow except this one. The pattern points at a stale trigger registration for this specific workflow on the Actions backend, and the standard remedy is any content change forcing a re-parse.

## Reviewer Test Plan

### How to verify

After merge, watch the Actions tab: the next ten-minute tick should create a schedule run of this workflow, and any new PR/issue comment should create an issue-comment run (almost always `skipped` — that still proves dispatch). End-to-end: re-issue `@qwen-code /takeover` on a PR and confirm the label toggles.

### Evidence (Before & After)

Before (Actions API): latest issue_comment run 2026-08-19T00:16:07Z despite continuous comment traffic; latest schedule run 2026-08-18T23:51:23Z despite the */10 cron; dispatch runs 32203631619 / 32206055039 / 32217861831 queued with zero jobs for 4–11 hours; the 06:06:55Z comment created runs in the four sibling workflows but not in this one. After: to be filled post-merge.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — workflow-metadata-only change; verified the YAML still parses and the trigger block is intact after the change.

## Risk & Scope

- Main risk or tradeoff: none functional — one comment line. If the backend anomaly is not a stale registration, this merge will not fix it; the next step is GitHub Support with the run IDs above.
- Not validated / out of scope: root-causing the Actions backend behavior; cleaning up the three stranded dispatch runs.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 autofix workflow 增加一行注释，使合入时强制 GitHub Actions 重新解析并重新注册该 workflow。无行为变化：触发器块、jobs、门禁与步骤除注释外逐字节一致。

## 为什么需要

自 2026-08-19 约 00:00 UTC 起，该 workflow 五个触发器中的三个停止产生 run：每 10 分钟的 schedule 在 2026-08-18 23:51 UTC 后不再创建 run；issue comment 事件在 00:16 UTC 后不再匹配（而同类 workflow 数秒后仍能收到同样的事件）；label 变更也不再路由。同时 dispatch run 能创建但从不展开成 job——三个 run 以 0 个 job 的状态排队卡了 4 到 11 小时。review 事件通道全程正常，因此整个循环看起来"半活"。这段时间触发器块没有任何变化（最近两次触及该 workflow 的合入只改了 step 内的 bash 内容），12:28 UTC 的禁用/重新启用也未能恢复死掉的触发器——之后的评论事件为其他所有 issue_comment workflow 创建了 run，唯独没有这个。这些迹象指向 Actions 后端对这个特定 workflow 的触发器注册状态过期，标准补救方式是用一次内容变更强制重新解析。

## 审阅者测试计划

### 如何验证

合入后观察 Actions 页面：下一个 10 分钟整点应为该 workflow 创建 schedule run；任何新的 PR/issue 评论应创建 issue-comment run（几乎总是 `skipped`——但这仍证明事件派发已恢复）。端到端验证：对某个 PR 重新发送 `@qwen-code /takeover`，确认标签被切换。

### 证据（改动前后）

改动前（Actions API 查询）：issue_comment 最新 run 为 2026-08-19T00:16:07Z，而评论一直持续；schedule 最新 run 为 2026-08-18T23:51:23Z，而 cron 是 */10；dispatch run 32203631619 / 32206055039 / 32217861831 以 0 个 job 排队 4–11 小时；06:06:55Z 的评论为其他 4 个同类 workflow 创建了 run，唯独没有这个。改动后：合入后补充。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  N/A |
|  🐧 Linux  |  N/A |

### 运行环境（可选）

N/A——仅 workflow 元数据变更；已验证改动后 YAML 仍可解析、触发器块完整。

## 风险与范围

- 主要风险或权衡：无功能差异，仅一行注释。若后端异常不是注册状态过期，本合入不会修复问题，届时下一步是携带上述 run ID 联系 GitHub Support。
- 未验证 / 不在范围内：Actions 后端行为的根因分析；三个卡死 dispatch run 的清理。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
