### PR TITLE
refactor(review): route the certification path atoms through one needle

### DIFF
--- a/packages/cli/src/commands/review/lib/certification.test.ts
+++ b/packages/cli/src/commands/review/lib/certification.test.ts
@@ -111,6 +111,20 @@ describe('openedBrief / readBrief', () => {
   const needle = JSON.stringify(briefPath(PLAN, key));
   const arg = `{"absolute_path":${needle}}`;
 
+  it('does not credit a shell command that merely MENTIONS the brief', () => {
+    // The trap a prose matcher walks into: `utils/findings.ts` has a
+    // same-purpose-looking `namesPath` that matches on a name boundary, and
+    // it credits this arg. Deleting a brief is not opening it — so this atom
+    // matches the whole JSON string value instead, and keeps a different
+    // name so no future consolidation unifies the two the wrong way.
+    const r = rec({
+      successfulCallArgs: [
+        JSON.stringify({ command: `rm ${briefPath(PLAN, key)}` }),
+      ],
+    });
+    expect(openedBrief(r, PLAN, key)).toBe(false);
+  });
+
   it('credits any successful tool whose args name the exact brief path', () => {
     const r = rec({ successfulCallArgs: [arg] });
     expect(openedBrief(r, PLAN, key)).toBe(true);

--- a/packages/cli/src/commands/review/lib/certification.test.ts
+++ b/packages/cli/src/commands/review/lib/certification.test.ts
@@ -130,6 +130,22 @@ describe('openedBrief / readBrief', () => {
     expect(openedBrief(r, PLAN, key)).toBe(true);
   });
 
+  it('credits a match anywhere in the call list, not just the first call', () => {
+    // The shared `argsNameExactPath` wrapper is an existential over the whole
+    // list. Every other fixture here has 0 or 1 arg, so a first-element-only
+    // regression (`args.length > 0 && …(args[0]!, path)`) ships green while
+    // refusing an agent whose first successful call named another file and
+    // whose LATER call opened the brief — its work re-owed. Match in the
+    // second position pins the quantifier for all three atoms.
+    const other = `{"absolute_path":${JSON.stringify(`${PLAN}-other.txt`)}}`;
+    expect(
+      openedBrief(rec({ successfulCallArgs: [other, arg] }), PLAN, key),
+    ).toBe(true);
+    expect(
+      readBrief(rec({ successfulReadFileArgs: [other, arg] }), PLAN, key),
+    ).toBe(true);
+  });
+
   it('does not credit a record that made zero successful tool calls', () => {
     // `[].every(...)` is true: the existential quantifier needs its own
     // negative, like its two sibling atoms already have.

--- a/packages/cli/src/commands/review/lib/certification.ts
+++ b/packages/cli/src/commands/review/lib/certification.ts
@@ -22,6 +22,7 @@
  */
 
 import type { AgentRecord } from './transcripts.js';
+import { serializedArgsNamePath } from './transcripts.js';
 import { briefPath } from './prompt-record.js';
 
 /**
@@ -61,18 +62,23 @@ export function declaresOwnUncoverable(
 }
 
 /**
- * Does any of these serialized tool-call args name the EXACT `path`? The
- * comparison is against the whole JSON string value (`JSON.stringify(path)`
- * carries the closing quote), so a `${path}.bak` — or any longer path that
- * merely contains this one as a prefix — is NOT credited: the same trap
- * `parseTranscript` avoids for the diff path. This one needle is what the
- * bar's "exact path, not a look-alike" guarantee rests on; every path atom
- * below routes through it, so a fix to the match reaches all of them at once
- * (the drift this module exists to eliminate, applied to its own internals).
+ * Does ANY of these serialized tool-call args name the EXACT `path`?
+ *
+ * The match itself lives in `transcripts.ts` beside the code that serializes
+ * the args, and `parseTranscript`'s diff-read half calls the same function —
+ * so the bar's "exact path, not a look-alike" guarantee has ONE definition,
+ * not one per half. This wrapper only spreads it over a record's call list;
+ * every path atom below routes through it.
+ *
+ * The name is deliberately not `namesPath`: `utils/findings.ts` has a
+ * module-private `namesPath` that matches a path named in PROSE on a name
+ * boundary — it credits `rm /plan/chunk-3.brief.md` for naming the brief.
+ * Unifying these two would make `openedBrief` credit an agent for deleting a
+ * file it never opened, so they keep distinct names to stop a future reader
+ * treating either as THE path matcher.
  */
-function namesPath(args: readonly string[], path: string): boolean {
-  const needle = JSON.stringify(path);
-  return args.some((a) => a.includes(needle));
+function argsNameExactPath(args: readonly string[], path: string): boolean {
+  return args.some((a) => serializedArgsNamePath(a, path));
 }
 
 /**
@@ -86,7 +92,7 @@ export function openedBrief(
   planPath: string,
   key: string,
 ): boolean {
-  return namesPath(rec.successfulCallArgs, briefPath(planPath, key));
+  return argsNameExactPath(rec.successfulCallArgs, briefPath(planPath, key));
 }
 
 /**
@@ -100,7 +106,10 @@ export function readBrief(
   planPath: string,
   key: string,
 ): boolean {
-  return namesPath(rec.successfulReadFileArgs, briefPath(planPath, key));
+  return argsNameExactPath(
+    rec.successfulReadFileArgs,
+    briefPath(planPath, key),
+  );
 }
 
 /**
@@ -116,5 +125,5 @@ export function readFindingsPointer(
   pointer: string | null,
 ): boolean {
   if (pointer === null) return true;
-  return namesPath(rec.successfulReadFileArgs, pointer);
+  return argsNameExactPath(rec.successfulReadFileArgs, pointer);
 }

--- a/packages/cli/src/commands/review/lib/certification.ts
+++ b/packages/cli/src/commands/review/lib/certification.ts
@@ -61,19 +61,32 @@ export function declaresOwnUncoverable(
 }
 
 /**
+ * Does any of these serialized tool-call args name the EXACT `path`? The
+ * comparison is against the whole JSON string value (`JSON.stringify(path)`
+ * carries the closing quote), so a `${path}.bak` — or any longer path that
+ * merely contains this one as a prefix — is NOT credited: the same trap
+ * `parseTranscript` avoids for the diff path. This one needle is what the
+ * bar's "exact path, not a look-alike" guarantee rests on; every path atom
+ * below routes through it, so a fix to the match reaches all of them at once
+ * (the drift this module exists to eliminate, applied to its own internals).
+ */
+function namesPath(args: readonly string[], path: string): boolean {
+  const needle = JSON.stringify(path);
+  return args.some((a) => a.includes(needle));
+}
+
+/**
  * Did this record's agent open the brief recorded under `key`? Compared as a
  * whole JSON string value (`successfulCallArgs` are serialized args), so a
- * `${brief}.bak` cannot be credited for the brief — the same trap
- * `parseTranscript` avoids for the diff path. "Open" is mention-level: any
- * successful tool whose args name the exact path.
+ * `${brief}.bak` cannot be credited for the brief. "Open" is mention-level:
+ * any successful tool whose args name the exact path.
  */
 export function openedBrief(
   rec: AgentRecord,
   planPath: string,
   key: string,
 ): boolean {
-  const needle = JSON.stringify(briefPath(planPath, key));
-  return rec.successfulCallArgs.some((a) => a.includes(needle));
+  return namesPath(rec.successfulCallArgs, briefPath(planPath, key));
 }
 
 /**
@@ -87,8 +100,7 @@ export function readBrief(
   planPath: string,
   key: string,
 ): boolean {
-  const needle = JSON.stringify(briefPath(planPath, key));
-  return rec.successfulReadFileArgs.some((a) => a.includes(needle));
+  return namesPath(rec.successfulReadFileArgs, briefPath(planPath, key));
 }
 
 /**
@@ -104,6 +116,5 @@ export function readFindingsPointer(
   pointer: string | null,
 ): boolean {
   if (pointer === null) return true;
-  const needle = JSON.stringify(pointer);
-  return rec.successfulReadFileArgs.some((a) => a.includes(needle));
+  return namesPath(rec.successfulReadFileArgs, pointer);
 }

--- a/packages/cli/src/commands/review/lib/transcripts.test.ts
+++ b/packages/cli/src/commands/review/lib/transcripts.test.ts
@@ -267,7 +267,7 @@ describe('readTranscripts — defensive parsing', () => {
           type: 'user',
           message: { role: 'user', parts: [{ text: 'chunk 1 of 1' }] },
         }),
-        ...call('read_file', { file_path: '/d.txt' }),
+        ...call('read_file', { file_path: '/d.txt', offset: 0, limit: 40 }),
         ...call('read_file', { file_path: '/d.txt.bak' }),
         ...call('run_shell_command', { command: 'rm /d.txt' }),
       ]
@@ -276,6 +276,11 @@ describe('readTranscripts — defensive parsing', () => {
     );
     const [rec] = readTranscripts(undefined, ENV, '/d.txt');
     expect(rec.diffToolCalls).toBe(1);
+    // The RANGE too, not only the count: `range` is wired through the same
+    // `namedTheDiff` decision, so dropping that wiring leaves the count
+    // right and every chunk-coverage ruling — which reads the lines, not
+    // the tally — with nothing to rule on.
+    expect(rec.diffReads).toEqual([[1, 40]]);
     // And with no diffPath the field stays 0, whatever was read.
     expect(readTranscripts(undefined, ENV)[0].diffToolCalls).toBe(0);
   });

--- a/packages/cli/src/commands/review/lib/transcripts.test.ts
+++ b/packages/cli/src/commands/review/lib/transcripts.test.ts
@@ -30,6 +30,7 @@ import {
   transcriptDir,
   TranscriptsUnavailableError,
   type AgentRecord,
+  serializedArgsNamePath,
 } from './transcripts.js';
 import { appendRunSession, recordResume } from './run-ledger.js';
 
@@ -728,5 +729,34 @@ describe('the incomplete-transcript shapes the resume path reads', () => {
       ].join('\n') + '\n',
     );
     expect(readTranscripts(undefined, ENV)).toHaveLength(1);
+  });
+});
+
+describe('serializedArgsNamePath — the one needle both halves use', () => {
+  const brief = '/plan/chunk-3.brief.md';
+
+  it('matches the path as a whole JSON string value', () => {
+    expect(
+      serializedArgsNamePath(JSON.stringify({ absolute_path: brief }), brief),
+    ).toBe(true);
+  });
+
+  it('does not credit a longer path holding this one as a prefix', () => {
+    expect(
+      serializedArgsNamePath(
+        JSON.stringify({ absolute_path: `${brief}.bak` }),
+        brief,
+      ),
+    ).toBe(false);
+  });
+
+  it('does not credit a shell command that merely mentions the path', () => {
+    // The divergence the review measured between this and the prose-boundary
+    // `namesPath` in `utils/findings.ts`, which returns true here. Both the
+    // diff-read half and the brief atoms route through THIS one, so the
+    // certification bar cannot credit `rm <file>` as opening it.
+    expect(
+      serializedArgsNamePath(JSON.stringify({ command: `rm ${brief}` }), brief),
+    ).toBe(false);
   });
 });

--- a/packages/cli/src/commands/review/lib/transcripts.test.ts
+++ b/packages/cli/src/commands/review/lib/transcripts.test.ts
@@ -234,6 +234,51 @@ describe('readTranscripts — defensive parsing', () => {
     expect(rec.successfulReadFileArgs[0]).toContain('/r/f.findings.md');
     expect(rec.successfulReadFileArgs[0]).not.toContain('search_file_content');
   });
+
+  it('counts a diff read via serializedArgsNamePath, not a look-alike', () => {
+    // The diff-read half of the shared needle: `diffToolCalls` is populated
+    // only when `diffPath` is passed, and no other test passes one. A swap of
+    // the two args at the `serializedArgsNamePath(JSON.stringify(args), path)`
+    // call site (both strings, so it compiles) ships green and every coverage
+    // gate then reads `diffToolCalls: 0`. Pin it with the exact read counted
+    // and two look-alikes — a `.bak` sibling and a shell command that only
+    // NAMES the diff — refused.
+    const b = { agentId: 'a1', agentName: 'general-purpose', sessionId: 'S1' };
+    const call = (name: string, args: object): object[] => [
+      {
+        ...b,
+        type: 'assistant',
+        message: { role: 'model', parts: [{ functionCall: { name, args } }] },
+      },
+      {
+        ...b,
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [{ functionResponse: { name, response: { output: 'ok' } } }],
+        },
+      },
+    ];
+    file(
+      'agent-a1.jsonl',
+      [
+        JSON.stringify({
+          ...b,
+          type: 'user',
+          message: { role: 'user', parts: [{ text: 'chunk 1 of 1' }] },
+        }),
+        ...call('read_file', { file_path: '/d.txt' }),
+        ...call('read_file', { file_path: '/d.txt.bak' }),
+        ...call('run_shell_command', { command: 'rm /d.txt' }),
+      ]
+        .map((r) => JSON.stringify(r))
+        .join('\n') + '\n',
+    );
+    const [rec] = readTranscripts(undefined, ENV, '/d.txt');
+    expect(rec.diffToolCalls).toBe(1);
+    // And with no diffPath the field stays 0, whatever was read.
+    expect(readTranscripts(undefined, ENV)[0].diffToolCalls).toBe(0);
+  });
 });
 
 describe('wasGivenTheDiff', () => {

--- a/packages/cli/src/commands/review/lib/transcripts.ts
+++ b/packages/cli/src/commands/review/lib/transcripts.ts
@@ -253,12 +253,6 @@ function rangeOf(args: Record<string, unknown>): [number, number] | null {
 }
 
 /**
- * Parse one transcript. Returns null for a file that is not one.
- *
- * `diffPath` is what makes a call "a read of the diff" rather than "a call". Pass
- * it and `diffToolCalls` is populated; omit it and the field stays 0.
- */
-/**
  * Do these serialized tool-call args name the EXACT `path`?
  *
  * The comparison is against the whole JSON string value — `JSON.stringify`
@@ -283,6 +277,12 @@ export function serializedArgsNamePath(
   return serializedArgs.includes(JSON.stringify(path));
 }
 
+/**
+ * Parse one transcript. Returns null for a file that is not one.
+ *
+ * `diffPath` is what makes a call "a read of the diff" rather than "a call". Pass
+ * it and `diffToolCalls` is populated; omit it and the field stays 0.
+ */
 function parseTranscript(file: string, diffPath?: string): AgentRecord | null {
   let raw: string;
   try {

--- a/packages/cli/src/commands/review/lib/transcripts.ts
+++ b/packages/cli/src/commands/review/lib/transcripts.ts
@@ -258,6 +258,31 @@ function rangeOf(args: Record<string, unknown>): [number, number] | null {
  * `diffPath` is what makes a call "a read of the diff" rather than "a call". Pass
  * it and `diffToolCalls` is populated; omit it and the field stays 0.
  */
+/**
+ * Do these serialized tool-call args name the EXACT `path`?
+ *
+ * The comparison is against the whole JSON string value — `JSON.stringify`
+ * carries the closing quote — so a `${path}.bak`, or any longer path holding
+ * this one as a prefix, is NOT credited. Every certification atom that asks
+ * "did the agent name this file" routes here: the diff-read half in
+ * `parseTranscript` below, and the brief / findings atoms in
+ * `certification.ts`. One copy, so a fix to the match semantics
+ * (normalisation, escaping, a stricter compare) reaches the whole bar at once
+ * rather than half of it.
+ *
+ * NOT `namesPath` in `utils/findings.ts`: that one matches a path mentioned in
+ * PROSE on a name boundary, so it credits `rm /plan/chunk-3.brief.md` for
+ * naming the brief. Crediting an agent for deleting a file it never opened is
+ * precisely what this predicate must not do, which is why the two keep
+ * separate names.
+ */
+export function serializedArgsNamePath(
+  serializedArgs: string,
+  path: string,
+): boolean {
+  return serializedArgs.includes(JSON.stringify(path));
+}
+
 function parseTranscript(file: string, diffPath?: string): AgentRecord | null {
   let raw: string;
   try {
@@ -342,10 +367,8 @@ function parseTranscript(file: string, diffPath?: string): AgentRecord | null {
       // to open; a tool *result* that quotes it (a grep over `.qwen/tmp`, this
       // file in a diff) says nothing about what the agent opened.
       const args = (fc.args ?? {}) as Record<string, unknown>;
-      // Match the path as a whole JSON string value, quotes included: a bare
-      // substring credits `…/diff.txt.bak` for `…/diff.txt`.
       const namedTheDiff = diffPath
-        ? JSON.stringify(args).includes(JSON.stringify(diffPath))
+        ? serializedArgsNamePath(JSON.stringify(args), diffPath)
         : false;
       const pending: Pending = {
         namedTheDiff,


### PR DESCRIPTION
## What this PR does

Extracts the one predicate the certification bar's path atoms all shared — "does any serialized tool-call arg name this exact path (and not a `${path}.bak` look-alike)?" — into a private `namesPath(args, path)` helper, and routes `openedBrief`, `readBrief` and `readFindingsPointer` through it. Small follow-up to #9473 (`lib/certification.ts`), addressing the deferred R1-1 suggestion.

## Why it's needed

Those three atoms each inlined the same two lines (`JSON.stringify(path)` then `args.some(a => a.includes(...))`), which is the single mechanism enforcing the bar's "exact path, not a look-alike" guarantee across the module. Three copies is the exact drift class `certification.ts` was created to eliminate, turned on the module itself: a future fix to the match (a serialization edge, path normalization, a stricter compare) would have to land in all three in lockstep, and missing one would leave a single atom silently weaker than its siblings.

## Reviewer Test Plan

### How to verify

`cd packages/cli && npx vitest run src/commands/review/lib/certification.test.ts src/commands/review/check-coverage.test.ts src/commands/review/recover-findings.test.ts src/commands/review/lib/layer-audit-gate.test.ts` — 188 pass. The suites written against the pre-extraction atoms pass unchanged; in particular the `${brief}.bak` / `${path}.bak` trap pins (one per atom) still hold, which is the proof the extracted needle preserves the exact-path semantics.

### Evidence (Before & After)

N/A — non-user-visible pure refactor, zero behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: none of substance — one private helper, three call sites, identical predicate.
- Not validated / out of scope: unchanged behavior of the consumers (coverage walk, layer-audit gate, retirement, recover-findings) — covered by their existing suites.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #9473 (deferred R1-1).

<details>
<summary>中文说明</summary>

把认证 bar 的三个路径 atom（`openedBrief` / `readBrief` / `readFindingsPointer`）共用的同一判定——「某条序列化工具参数是否命名了这个**精确**路径（而非 `${path}.bak` 之类的近似）」——抽成私有 helper `namesPath(args, path)`，三处都改走它。这是 #9473 的小跟进，收掉 defer 的 R1-1 建议。

原来三处各自内联了同两行（`JSON.stringify(path)` + `args.some(a => a.includes(...))`），而这正是整个模块「精确路径、非近似」保证的唯一实现机制。三份拷贝正是 `certification.ts` 存在本身要消灭的漂移，如今出现在模块自己内部：日后要修这条匹配（序列化边界、路径规范化、更严格比较）必须三处同步改，漏一处就让某个 atom 静默弱于兄弟。

纯重构、零行为变化：针对旧内联写法的全部测试原样通过，尤其每个 atom 各自的 `.bak` 陷阱钉子仍然成立——这就是抽出的 needle 保持精确路径语义的证明。`cd packages/cli && npx vitest run …certification.test.ts …check-coverage.test.ts …recover-findings.test.ts …layer-audit-gate.test.ts` 共 188 通过。

</details>
