### PR TITLE
fix(cli): suppress Homebrew update notification when brew has nothing newer (#9493)

### DIFF
--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -20,6 +20,16 @@ import { performStandaloneUpdate } from './standalone-update.js';
 import { MessageType } from '../ui/types.js';
 import os from 'node:os';
 
+const { mockT, identityT } = vi.hoisted(() => {
+  const identityT = (message: string, values?: Record<string, unknown>) =>
+    message.replace(/\{\{(\w+)\}\}/g, (placeholder, key: string) =>
+      values?.[key] === undefined ? placeholder : String(values[key]),
+    );
+  return { identityT, mockT: vi.fn(identityT) };
+});
+
+vi.mock('../i18n/index.js', () => ({ t: mockT }));
+
 vi.mock('./installationInfo.js', async () => {
   const actual = await vi.importActual('./installationInfo.js');
   return {
@@ -726,6 +736,7 @@ describe('handleAutoUpdate — Homebrew installs (#9493)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockT.mockImplementation(identityT);
     emitSpy = vi.spyOn(updateEventEmitter, 'emit');
     mockSettings = {
       merged: { general: { enableAutoUpdate: true } },
@@ -768,13 +779,18 @@ describe('handleAutoUpdate — Homebrew installs (#9493)', () => {
 
   it('still notifies when Homebrew offers a newer version', async () => {
     mockGetHomebrewLatestVersion.mockResolvedValue('0.21.14');
+    mockT.mockImplementation((message: string) =>
+      message.startsWith('Installed via Homebrew')
+        ? 'translated Homebrew guidance'
+        : message,
+    );
 
     await handleAutoUpdate(mockUpdateInfo, mockSettings, '/root');
 
     expect(emitSpy).toHaveBeenCalledWith('update-received', {
       message:
         'Qwen Code update available! 0.21.13 → 0.21.14\n' +
-        'Installed via Homebrew. Please update with "brew upgrade".',
+        'translated Homebrew guidance',
     });
   });
 
@@ -790,7 +806,7 @@ describe('handleAutoUpdate — Homebrew installs (#9493)', () => {
     });
   });
 
-  it('does not query Homebrew for non-Homebrew installs', () => {
+  it('does not query Homebrew for non-Homebrew installs', async () => {
     mockGetInstallationInfo.mockReturnValue({
       updateCommand: undefined,
       updateMessage: 'Cannot determine update command.',
@@ -798,7 +814,7 @@ describe('handleAutoUpdate — Homebrew installs (#9493)', () => {
       packageManager: PackageManager.NPM,
     });
 
-    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root');
+    await handleAutoUpdate(mockUpdateInfo, mockSettings, '/root');
 
     expect(mockGetHomebrewLatestVersion).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -6,7 +6,11 @@
 
 import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getInstallationInfo, PackageManager } from './installationInfo.js';
+import {
+  getInstallationInfo,
+  getHomebrewLatestVersion,
+  PackageManager,
+} from './installationInfo.js';
 import { updateEventEmitter } from './updateEventEmitter.js';
 import type { UpdateObject } from '../ui/utils/updateCheck.js';
 import type { LoadedSettings } from '../config/settings.js';
@@ -21,6 +25,7 @@ vi.mock('./installationInfo.js', async () => {
   return {
     ...actual,
     getInstallationInfo: vi.fn(),
+    getHomebrewLatestVersion: vi.fn(),
   };
 });
 
@@ -44,6 +49,7 @@ interface MockChildProcess extends EventEmitter {
 }
 
 const mockGetInstallationInfo = vi.mocked(getInstallationInfo);
+const mockGetHomebrewLatestVersion = vi.mocked(getHomebrewLatestVersion);
 const mockPerformStandaloneUpdate = vi.mocked(performStandaloneUpdate);
 
 describe('handleAutoUpdate', () => {
@@ -710,5 +716,90 @@ describe('setUpdateHandler', () => {
     );
 
     cleanup();
+  });
+});
+
+describe('handleAutoUpdate — Homebrew installs (#9493)', () => {
+  let mockSettings: LoadedSettings;
+  let mockUpdateInfo: UpdateObject;
+  let emitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    emitSpy = vi.spyOn(updateEventEmitter, 'emit');
+    mockSettings = {
+      merged: { general: { enableAutoUpdate: true } },
+    } as LoadedSettings;
+    // npm registry reports a newer version than the installed one...
+    mockUpdateInfo = {
+      update: {
+        latest: '0.21.14',
+        current: '0.21.13',
+        type: 'patch',
+        name: '@qwen-code/qwen-code',
+      },
+      message: 'Qwen Code update available! 0.21.13 → 0.21.14',
+    };
+    mockGetInstallationInfo.mockReturnValue({
+      packageManager: PackageManager.HOMEBREW,
+      isGlobal: true,
+      updateMessage:
+        'Installed via Homebrew. Please update with "brew upgrade".',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not notify when Homebrew offers nothing newer than the installed version', async () => {
+    // ...but the Homebrew formula is still at the installed version, so
+    // `brew upgrade` is a no-op and the npm-based notification can never be
+    // cleared (#9493). It must be suppressed.
+    mockGetHomebrewLatestVersion.mockResolvedValue('0.21.13');
+
+    await handleAutoUpdate(mockUpdateInfo, mockSettings, '/root');
+
+    expect(emitSpy).not.toHaveBeenCalledWith(
+      'update-received',
+      expect.anything(),
+    );
+  });
+
+  it('still notifies when Homebrew offers a newer version', async () => {
+    mockGetHomebrewLatestVersion.mockResolvedValue('0.21.14');
+
+    await handleAutoUpdate(mockUpdateInfo, mockSettings, '/root');
+
+    expect(emitSpy).toHaveBeenCalledWith('update-received', {
+      message:
+        'Qwen Code update available! 0.21.13 → 0.21.14\n' +
+        'Installed via Homebrew. Please update with "brew upgrade".',
+    });
+  });
+
+  it('still notifies when the Homebrew version cannot be determined', async () => {
+    mockGetHomebrewLatestVersion.mockResolvedValue(null);
+
+    await handleAutoUpdate(mockUpdateInfo, mockSettings, '/root');
+
+    expect(emitSpy).toHaveBeenCalledWith('update-received', {
+      message:
+        'Qwen Code update available! 0.21.13 → 0.21.14\n' +
+        'Installed via Homebrew. Please update with "brew upgrade".',
+    });
+  });
+
+  it('does not query Homebrew for non-Homebrew installs', () => {
+    mockGetInstallationInfo.mockReturnValue({
+      updateCommand: undefined,
+      updateMessage: 'Cannot determine update command.',
+      isGlobal: false,
+      packageManager: PackageManager.NPM,
+    });
+
+    handleAutoUpdate(mockUpdateInfo, mockSettings, '/root');
+
+    expect(mockGetHomebrewLatestVersion).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import semver from 'semver';
 import type { UpdateObject } from '../ui/utils/updateCheck.js';
 import type { LoadedSettings } from '../config/settings.js';
 import {
+  getHomebrewLatestVersion,
   getInstallationInfo,
   PackageManager,
   resolveUpdateCommand,
@@ -28,12 +30,12 @@ const UPDATE_SUCCESS_MESSAGE =
 const UPDATE_FAILED_MESSAGE =
   'Automatic update failed. Please try updating manually.';
 
-export function handleAutoUpdate(
+export async function handleAutoUpdate(
   info: UpdateObject | null,
   settings: LoadedSettings,
   projectRoot: string,
   spawnFn: typeof spawn = spawnWrapper,
-) {
+): Promise<boolean | undefined> {
   if (!info) {
     return;
   }
@@ -48,9 +50,30 @@ export function handleAutoUpdate(
     isAutoUpdateEnabled,
   );
 
+  if (installationInfo.packageManager === PackageManager.HOMEBREW) {
+    const installedVersion = semver.coerce(info.update.current)?.version;
+    const brewLatestVersion = semver.coerce(
+      (await getHomebrewLatestVersion()) ?? undefined,
+    )?.version;
+    // The startup check resolves "latest" from the npm registry regardless of
+    // installation type, but a Homebrew install can only be updated through
+    // Homebrew. While the formula lags npm `latest`, `brew upgrade` is a
+    // no-op and this notification would repeat on every startup with no way
+    // to clear it (#9493) — notify only when Homebrew actually offers
+    // something newer than the installed version. When the Homebrew version
+    // cannot be determined, fall through and keep the previous behavior.
+    if (
+      installedVersion &&
+      brewLatestVersion &&
+      !semver.gt(brewLatestVersion, installedVersion)
+    ) {
+      return;
+    }
+  }
+
   let combinedMessage = info.message;
   if (installationInfo.updateMessage) {
-    combinedMessage += `\n${installationInfo.updateMessage}`;
+    combinedMessage += `\n${t(installationInfo.updateMessage)}`;
   }
 
   updateEventEmitter.emit('update-received', {

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -59,7 +59,7 @@ export async function handleAutoUpdate(
     // installation type, but a Homebrew install can only be updated through
     // Homebrew. While the formula lags npm `latest`, `brew upgrade` is a
     // no-op and this notification would repeat on every startup with no way
-    // to clear it (#9493) — notify only when Homebrew actually offers
+    // to clear it (#9493) — notify only when local Homebrew metadata reports
     // something newer than the installed version. When the Homebrew version
     // cannot be determined, fall through and keep the previous behavior.
     if (

--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -7,6 +7,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   formatUpdateInstructions,
+  getHomebrewLatestVersion,
   getInstallationInfo,
   getNpmCliPath,
   PackageManager,
@@ -799,5 +800,69 @@ describe('getNpmCliPath', () => {
       'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
     );
     expect(mockedRealPathSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('getHomebrewLatestVersion', () => {
+  const brewInfoOutput = (stable: unknown) =>
+    JSON.stringify({
+      formulae: [{ name: 'qwen-code', versions: { stable } }],
+      casks: [],
+    });
+
+  it('returns the stable version from brew info --json=v2', async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: brewInfoOutput('0.21.13'),
+      stderr: '',
+    });
+
+    await expect(getHomebrewLatestVersion('qwen-code', run)).resolves.toBe(
+      '0.21.13',
+    );
+    expect(run).toHaveBeenCalledWith(
+      'brew',
+      ['info', '--json=v2', '--formula', 'qwen-code'],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it('returns null when brew fails (missing brew, timeout, non-zero exit)', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('command not found'));
+
+    await expect(
+      getHomebrewLatestVersion('qwen-code', run),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when the output is not valid JSON', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: 'not json', stderr: '' });
+
+    await expect(
+      getHomebrewLatestVersion('qwen-code', run),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when the formula is not in the output', async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ formulae: [], casks: [] }),
+      stderr: '',
+    });
+
+    await expect(
+      getHomebrewLatestVersion('qwen-code', run),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when stable is not a non-empty string', async () => {
+    for (const stable of [undefined, null, 42, '']) {
+      const run = vi.fn().mockResolvedValue({
+        stdout: brewInfoOutput(stable),
+        stderr: '',
+      });
+
+      await expect(
+        getHomebrewLatestVersion('qwen-code', run),
+      ).resolves.toBeNull();
+    }
   });
 });

--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -816,7 +816,7 @@ describe('getHomebrewLatestVersion', () => {
       stderr: '',
     });
 
-    await expect(getHomebrewLatestVersion('qwen-code', run)).resolves.toBe(
+    await expect(getHomebrewLatestVersion(undefined, run)).resolves.toBe(
       '0.21.13',
     );
     expect(run).toHaveBeenCalledWith(

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -8,6 +8,7 @@ import { createDebugLogger, isGitRepository } from '@qwen-code/qwen-code-core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as childProcess from 'node:child_process';
+import { promisify } from 'node:util';
 
 export enum PackageManager {
   NPM = 'npm',
@@ -141,6 +142,45 @@ export interface InstallationInfo {
   standaloneDir?: string;
   updateCommand?: string;
   updateMessage?: string;
+}
+
+const execFileAsync = promisify(childProcess.execFile);
+
+// Same budget as the npm-registry update check (see FETCH_TIMEOUT_MS in
+// ui/utils/updateCheck.ts): slow hosts must not hang startup on this lookup.
+const HOMEBREW_INFO_TIMEOUT_MS = 5000;
+
+/**
+ * Best-effort lookup of the newest version Homebrew currently offers for a
+ * formula. While the homebrew-core formula lags the npm `latest` tag,
+ * `brew upgrade` is a no-op, and an npm-based "update available"
+ * notification would repeat on every startup with no way to clear it
+ * (#9493). Callers use this to decide whether a Homebrew install can
+ * actually be updated before notifying.
+ *
+ * Returns null when the version cannot be determined (brew missing,
+ * timeout, unexpected output); callers keep the legacy notify behavior in
+ * that case rather than silently hiding a real update.
+ */
+export async function getHomebrewLatestVersion(
+  formula = 'qwen-code',
+  run: typeof execFileAsync = execFileAsync,
+): Promise<string | null> {
+  try {
+    const { stdout } = await run(
+      'brew',
+      ['info', '--json=v2', '--formula', formula],
+      { encoding: 'utf8', timeout: HOMEBREW_INFO_TIMEOUT_MS },
+    );
+    const parsed = JSON.parse(String(stdout)) as {
+      formulae?: Array<{ versions?: { stable?: unknown } }>;
+    };
+    const stable = parsed.formulae?.[0]?.versions?.stable;
+    return typeof stable === 'string' && stable.length > 0 ? stable : null;
+  } catch (error) {
+    debugLogger.warn('Failed to query Homebrew formula version:', error);
+    return null;
+  }
 }
 
 export function getInstallationInfo(

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -150,8 +150,8 @@ const execFileAsync = promisify(childProcess.execFile);
 const HOMEBREW_INFO_TIMEOUT_MS = 5000;
 
 /**
- * Best-effort lookup of the newest version Homebrew currently offers for a
- * formula. While the homebrew-core formula lags the npm `latest` tag,
+ * Best-effort lookup of the newest formula version visible in local Homebrew
+ * metadata. While the homebrew-core formula lags the npm `latest` tag,
  * `brew upgrade` is a no-op, and an npm-based "update available"
  * notification would repeat on every startup with no way to clear it
  * (#9493). Callers use this to decide whether a Homebrew install can

--- a/packages/cli/src/utils/installationInfo.ts
+++ b/packages/cli/src/utils/installationInfo.ts
@@ -146,8 +146,7 @@ export interface InstallationInfo {
 
 const execFileAsync = promisify(childProcess.execFile);
 
-// Same budget as the npm-registry update check (see FETCH_TIMEOUT_MS in
-// ui/utils/updateCheck.ts): slow hosts must not hang startup on this lookup.
+// Slow hosts must not hang startup on this lookup.
 const HOMEBREW_INFO_TIMEOUT_MS = 5000;
 
 /**


### PR DESCRIPTION
## What this PR does

For Homebrew installs, the startup auto-update flow now asks Homebrew itself what version is visible in local Homebrew metadata (`brew info --json=v2 --formula qwen-code`, bounded by a 5s timeout) before showing the "update available" notification. When local Homebrew metadata reports nothing newer than the installed version, the npm-based notification is skipped entirely; when local Homebrew metadata reports a newer version, the notification is shown as before. If the Homebrew version cannot be determined (brew missing, timeout, unexpected output), the previous notify behavior is kept rather than silently hiding a real update. The added installation hint line is also routed through `t()` so the translations that already exist in all locale files actually apply (the reporter's secondary observation about the English line under a Chinese locale).

## Why it's needed

The startup update check always resolves "latest" from the npm registry regardless of how the CLI was installed. For a Homebrew install there is no `updateCommand`, so `handleAutoUpdate()` can only emit the notification and never installs anything — and while the homebrew-core formula lags npm `latest` (e.g. formula 0.21.13 vs npm 0.21.14), `brew upgrade` is a no-op. The result reported in #9493: the notification appears on every startup, the suggested command cannot clear it, and the only suppression is disabling auto-update entirely (`general.enableAutoUpdate: false`), which also turns off legitimate update checks. Notifying only when local Homebrew metadata reports something newer makes the notification actionable again.

## Reviewer Test Plan

### How to verify

Reproduced at unit level against `main` (red test): with the installation detected as Homebrew, npm reporting 0.21.13 → 0.21.14, and the Homebrew formula still at 0.21.13, `handleAutoUpdate()` emitted `update-received` with the combined notification — exactly the un-clearable startup message from the report. After the fix the same scenario emits nothing, while a newer Homebrew version or an undeterminable one still notifies. To verify manually: run `npx vitest run src/utils/handleAutoUpdate.test.ts src/utils/installationInfo.test.ts` in `packages/cli` — the `handleAutoUpdate — Homebrew installs (#9493)` block pins all four branches (suppress, notify-newer, notify-unknown, non-Homebrew never queries brew), and the `getHomebrewLatestVersion` block pins the `brew info` parsing and its null fallbacks. A live macOS Homebrew end-to-end run was not possible in this environment (Linux host); the install-type and brew-response seams are mocked at the same boundaries the startup path uses.

### Evidence (Before & After)

Unit-level before/after (live Homebrew startup screenshots not producible on this Linux host):

Before (test pinning the reported scenario fails on unpatched `main`):

```text
FAIL  handleAutoUpdate — Homebrew installs (#9493) > does not notify when Homebrew offers nothing newer than the installed version
AssertionError: expected "emit" to not be called with arguments: [ 'update-received', Anything ]
Received:
  1st emit call:
  [ "update-received", { "message": "Qwen Code update available! 0.21.13 → 0.21.14\nInstalled via Homebrew. Please update with \"brew upgrade\"." } ]
Tests  1 failed | 31 passed (32)
```

After (same scenario suppressed; all guards green):

```text
✓ src/utils/installationInfo.test.ts (41 tests) 35ms
✓ src/utils/handleAutoUpdate.test.ts (32 tests) 246ms
Test Files  2 passed (2)
Tests  73 passed (73)
```

Neighboring update-flow suites also pass unchanged: `update.test.ts`, `startup-prefetch.test.ts`, `update-command.test.ts`, `update-relaunch.test.ts`, `updateCheck.test.ts` — 106/106.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

macOS: Homebrew detection is darwin-only; the changed logic is covered by unit tests with mocked install type and brew output, but no live `brew` run was performed here. Windows: the Homebrew branch is unreachable. Linux: unit tests, typecheck, eslint, prettier all run here.

### Environment (optional)

Unit tests only: `npx vitest run` on the affected files plus `tsc --noEmit` and `eslint` for `packages/cli` on Linux (Node v24).

## Risk & Scope

- Main risk or tradeoff: local Homebrew metadata can be stale, so a Homebrew install may not see the startup notification until that metadata refreshes; a formula that genuinely lags npm also remains silent until the formula catches up — this is the intended behavior (the previous notification was unactionable), but it means npm-side release announcements are no longer surfaced to brew users during the lag window; also one bounded (5s) `brew info` call is added to the update path for Homebrew installs only, and only after a newer npm version was already found.
- Not validated / out of scope: live end-to-end run on a macOS Homebrew install (no macOS host here); the explicitly invoked `/update` command intentionally keeps showing the check result; other installation types are untouched (non-Homebrew paths never query brew — pinned by a test).
- Breaking changes / migration notes: none; `handleAutoUpdate` becomes async but its callers already use `void handleAutoUpdate(...)` and its return contract is unchanged.

## Linked Issues

Fixes #9493

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

对 Homebrew 安装，启动时的自动更新流程现在会先查询本地 Homebrew 元数据中可见的版本（`brew info --json=v2 --formula qwen-code`，5 秒超时兜底），再决定是否显示"有可用更新"提示。当本地 Homebrew 元数据没有报告比已安装版本更新的版本时，完全跳过基于 npm 的提示；当本地 Homebrew 元数据报告有更新版本时，提示照常显示。如果无法确定 Homebrew 的版本（brew 缺失、超时、输出异常），则保留原有提示行为，而不是把真实可用的更新静默藏掉。顺带把附加的安装提示行用 `t()` 包裹，使各语言包里已有的译文真正生效（即报告者顺带提到的"中文界面下仍显示英文"的问题）。

## 为什么需要

启动时的更新检查无论 CLI 以何种方式安装，都一律从 npm registry 解析 "latest"。对 Homebrew 安装而言没有 `updateCommand`，`handleAutoUpdate()` 只能发出提示、从不执行更新——而在 homebrew-core formula 落后于 npm `latest` 期间（如 formula 0.21.13 对 npm 0.21.14），`brew upgrade` 是无效操作。这正是 #9493 报告的现象：每次启动都出现提示，按提示操作也无法消除，唯一的抑制方式是彻底关闭自动更新（`general.enableAutoUpdate: false`），而这会同时关掉正常的更新检查。只在本地 Homebrew 元数据报告有更新版本时才提示，可以让提示重新变得可操作。

## 评审者测试计划

### 如何验证

已在单测层面复现（红测试）：安装方式识别为 Homebrew、npm 报告 0.21.13 → 0.21.14、而 Homebrew formula 仍停留在 0.21.13 时，未修复的 `main` 上 `handleAutoUpdate()` 会发出 `update-received` 及合成后的提示——与报告中的无法消除的启动提示完全一致。修复后同样的场景不再发出任何提示，而 Homebrew 有更新版本或版本无法确定时仍会提示。手动验证：在 `packages/cli` 下运行 `npx vitest run src/utils/handleAutoUpdate.test.ts src/utils/installationInfo.test.ts` —— `handleAutoUpdate — Homebrew installs (#9493)` 一组固化了全部四个分支（抑制、有更新时提示、未知时提示、非 Homebrew 不查询 brew），`getHomebrewLatestVersion` 一组固化了 `brew info` 的解析及各种返回 null 的兜底。本环境为 Linux，无法进行 macOS Homebrew 实机端到端验证；安装类型与 brew 响应两个接缝均按启动路径实际使用的边界做了 mock。

### 证据（修复前/修复后）

单测层面的前后对比（本 Linux 主机无法产出 Homebrew 实机启动截图）：

修复前（固化报告场景的测试在未修复的 `main` 上失败）：

```text
FAIL  handleAutoUpdate — Homebrew installs (#9493) > does not notify when Homebrew offers nothing newer than the installed version
AssertionError: expected "emit" to not be called with arguments: [ 'update-received', Anything ]
Received:
  1st emit call:
  [ "update-received", { "message": "Qwen Code update available! 0.21.13 → 0.21.14\nInstalled via Homebrew. Please update with \"brew upgrade\"." } ]
Tests  1 failed | 31 passed (32)
```

修复后（同样场景被抑制，全部守卫测试通过）：

```text
✓ src/utils/installationInfo.test.ts (41 tests) 35ms
✓ src/utils/handleAutoUpdate.test.ts (32 tests) 246ms
Test Files  2 passed (2)
Tests  73 passed (73)
```

相邻的更新流程测试套件也原样通过：`update.test.ts`、`startup-prefetch.test.ts`、`update-command.test.ts`、`update-relaunch.test.ts`、`updateCheck.test.ts` —— 106/106。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

macOS：Homebrew 检测仅在 darwin 上生效；改动逻辑已由 mock 安装类型与 brew 输出的单测覆盖，但此处未做 `brew` 实机运行。Windows：Homebrew 分支不可达。Linux：单测、typecheck、eslint、prettier 均在此运行。

### 环境（可选）

仅单测：对受影响文件运行 `npx vitest run`，并在 Linux（Node v24）上对 `packages/cli` 运行 `tsc --noEmit` 与 `eslint`。

## 风险与范围

- 主要风险或权衡：本地 Homebrew 元数据可能过期，因此 Homebrew 安装可能要等元数据刷新后才看到启动提示；若 formula 确实落后于 npm，也会在 formula 追上之前保持静默——这是预期行为（此前的提示本就不可操作），但意味着 brew 用户在滞后窗口内不会再看到 npm 侧的发布提示；同时仅在 Homebrew 安装、且已发现 npm 有更新版本之后，才会额外执行一次有 5 秒兜底的 `brew info` 调用。
- 未验证 / 超出范围：macOS Homebrew 实机端到端运行（此处无 macOS 主机）；用户显式执行的 `/update` 命令有意保留显示检查结果；其他安装类型不受影响（非 Homebrew 路径从不查询 brew——已有测试固化）。
- 破坏性变更 / 迁移说明：无；`handleAutoUpdate` 变为 async，但调用方均已使用 `void handleAutoUpdate(...)`，返回约定不变。

## 关联 Issue

Fixes #9493

</details>

