### PR TITLE
fix(cli): keep slash menu selection stable while a response streams

### DIFF
--- a/packages/cli/src/ui/hooks/useCommandCompletion.slashChurn.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.slashChurn.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @vitest-environment jsdom */
+
+// Regression tests for #9494: while a response streams, AppContainer state
+// (session stats, pending item) changes identity, which rebuilds
+// `commandContext`. That churn must NOT rebuild the slash suggestion list —
+// rebuilding replaces the suggestions array, and the reset effect in
+// useCommandCompletion then snaps the user's menu selection back to the
+// first item.
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCommandCompletion } from './useCommandCompletion.js';
+import type { CommandContext, SlashCommand } from '../commands/types.js';
+import { CommandKind } from '../commands/types.js';
+import { useTextBuffer } from '../components/shared/text-buffer.js';
+
+vi.mock('./useAtCompletion', () => ({
+  useAtCompletion: vi.fn(),
+}));
+
+function createTestCommand(command: Partial<SlashCommand>): SlashCommand {
+  return {
+    kind: CommandKind.BUILT_IN,
+    name: 'test',
+    description: 'test command',
+    ...command,
+  } as SlashCommand;
+}
+
+const defaultCommands: readonly SlashCommand[] = [
+  createTestCommand({ name: 'memory', description: 'Manage memory' }),
+  createTestCommand({ name: 'model', description: 'Switch the model' }),
+  createTestCommand({ name: 'stats', description: 'Show session stats' }),
+];
+
+function makeContext(marker: string): CommandContext {
+  return { services: { marker } } as unknown as CommandContext;
+}
+
+interface HarnessProps {
+  ctx: CommandContext;
+  commands?: readonly SlashCommand[];
+}
+
+function useHarness({ ctx, commands }: HarnessProps) {
+  const buffer = useTextBuffer({
+    initialText: '/',
+    initialCursorOffset: 1,
+    viewport: { width: 80, height: 20 },
+    isValidPath: () => false,
+    onChange: () => {},
+  });
+  const completion = useCommandCompletion(
+    buffer,
+    '/',
+    commands ?? defaultCommands,
+    ctx,
+    false,
+  );
+  return { completion, buffer };
+}
+
+// Wait long enough for the async fuzzy-search pipeline (AsyncFzf) triggered
+// by a dep change to settle.
+async function flushCompletionPipeline() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  });
+}
+
+type HarnessResult = ReturnType<typeof useHarness>;
+
+describe('slash completion during commandContext churn (#9494)', () => {
+  it('keeps the suggestions array stable when only commandContext identity changes', async () => {
+    const { result, rerender } = renderHook<HarnessResult, HarnessProps>(
+      useHarness,
+      {
+        initialProps: { ctx: makeContext('A') },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.completion.suggestions.length).toBeGreaterThan(1);
+    });
+
+    const before = result.current.completion.suggestions;
+
+    // Simulate streaming churn: the query is untouched, but the context
+    // object is rebuilt (session stats / pending item changed upstream).
+    rerender({ ctx: makeContext('B') });
+    await flushCompletionPipeline();
+
+    expect(result.current.completion.suggestions).toBe(before);
+  });
+
+  it('preserves the user menu selection across commandContext rebuilds', async () => {
+    const { result, rerender } = renderHook<HarnessResult, HarnessProps>(
+      useHarness,
+      {
+        initialProps: { ctx: makeContext('A') },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.completion.suggestions.length).toBeGreaterThan(1);
+    });
+
+    act(() => {
+      result.current.completion.navigateDown();
+    });
+    expect(result.current.completion.activeSuggestionIndex).toBe(1);
+
+    rerender({ ctx: makeContext('B') });
+    await flushCompletionPipeline();
+
+    expect(result.current.completion.activeSuggestionIndex).toBe(1);
+  });
+
+  it('still resets the selection when the query actually changes', async () => {
+    const { result } = renderHook<HarnessResult, HarnessProps>(useHarness, {
+      initialProps: { ctx: makeContext('A') },
+    });
+
+    await waitFor(() => {
+      expect(result.current.completion.suggestions.length).toBeGreaterThan(1);
+    });
+
+    act(() => {
+      result.current.completion.navigateDown();
+    });
+    expect(result.current.completion.activeSuggestionIndex).toBe(1);
+
+    act(() => {
+      result.current.buffer.setText('/s');
+    });
+    // "/s" only matches the 'stats' command — wait for the rebuilt list.
+    await waitFor(() => {
+      expect(result.current.completion.suggestions.length).toBe(1);
+    });
+
+    expect(result.current.completion.activeSuggestionIndex).toBe(0);
+  });
+
+  it('still rebuilds suggestions when the command list changes', async () => {
+    const { result, rerender } = renderHook<HarnessResult, HarnessProps>(
+      useHarness,
+      {
+        initialProps: { ctx: makeContext('A') },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.completion.suggestions.length).toBeGreaterThan(1);
+    });
+    const before = result.current.completion.suggestions;
+
+    rerender({
+      ctx: makeContext('A'),
+      commands: [
+        createTestCommand({ name: 'memory', description: 'Manage memory' }),
+      ],
+    });
+    await waitFor(() => {
+      expect(result.current.completion.suggestions).not.toBe(before);
+    });
+    expect(result.current.completion.suggestions.length).toBe(1);
+  });
+
+  it('argument completion still receives the latest commandContext', async () => {
+    const completionSpy = vi.fn<
+      (context: CommandContext, argString: string) => Promise<string[]>
+    >().mockResolvedValue(['arg-a', 'arg-b']);
+    const markerOf = (callIndex: number): string =>
+      (
+        completionSpy.mock.calls[callIndex]![0] as unknown as {
+          services: { marker: string };
+        }
+      ).services.marker;
+    const commands = [
+      createTestCommand({
+        name: 'deploy',
+        description: 'Deploy things',
+        completion: completionSpy,
+      }),
+    ];
+
+    const { result, rerender } = renderHook<HarnessResult, HarnessProps>(
+      useHarness,
+      {
+        initialProps: { ctx: makeContext('A'), commands },
+      },
+    );
+
+    // Switch to an argument-completion query ("/deploy ").
+    act(() => {
+      result.current.buffer.setText('/deploy ');
+    });
+
+    await waitFor(() => {
+      expect(completionSpy).toHaveBeenCalled();
+    });
+    expect(markerOf(0)).toBe('A');
+
+    completionSpy.mockClear();
+    // New context identity AND a changed argument query: the async
+    // completion must observe the new context, not a stale one.
+    rerender({ ctx: makeContext('B'), commands });
+    act(() => {
+      result.current.buffer.setText('/deploy x');
+    });
+    await waitFor(() => {
+      expect(completionSpy).toHaveBeenCalled();
+    });
+    expect(markerOf(0)).toBe('B');
+  });
+});

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef, useLayoutEffect } from 'react';
 import { AsyncFzf } from 'fzf';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import type { Suggestion } from '../components/SuggestionsDisplay.js';
@@ -336,6 +336,17 @@ function useCommandSuggestions(
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
+  // The context is only consumed by the async argument-completion callback.
+  // Reading it through a ref keeps unrelated context churn (session stats /
+  // pending item updates while a response streams rebuild commandContext)
+  // out of the effect deps below: re-running this effect replaces the
+  // suggestions array, which snaps the user's menu selection back to the
+  // first item (#9494). Same historyRef pattern as slashCommandProcessor.
+  const commandContextRef = useRef(commandContext);
+  useLayoutEffect(() => {
+    commandContextRef.current = commandContext;
+  }, [commandContext]);
+
   useEffect(() => {
     const abortController = new AbortController();
     const { signal } = abortController;
@@ -369,7 +380,7 @@ function useCommandSuggestions(
           const results =
             (await leafCommand.completion(
               {
-                ...commandContext,
+                ...commandContextRef.current,
                 invocation: {
                   raw: `/${rawParts.join(' ')}`,
                   name: leafCommand.name,
@@ -508,13 +519,10 @@ function useCommandSuggestions(
 
     setSuggestions([]);
     return () => abortController.abort();
-  }, [
-    parserResult,
-    commandContext,
-    getFzfForCommands,
-    getPrefixSuggestions,
-    recentCommands,
-  ]);
+    // commandContext is deliberately absent: it is read through
+    // commandContextRef so context-identity churn alone never re-runs the
+    // search and rebuilds the suggestions array (#9494).
+  }, [parserResult, getFzfForCommands, getPrefixSuggestions, recentCommands]);
 
   return { suggestions, isLoading };
 }


### PR DESCRIPTION
## What this PR does

Keeps the slash-command menu selection stable while a response is streaming. The suggestion search no longer re-runs when `commandContext` is rebuilt for unrelated reasons: the context is now read through a ref inside the async argument-completion callback (the same pattern `slashCommandProcessor.ts` already uses for `history`), and `commandContext` is removed from the suggestion effect's dependency list. Only real completion inputs — the query, the command list, and recent commands — can rebuild the suggestion list now.

## Why it's needed

Fixes #9494. While a response streams, session-stats updates (telemetry `update` events) and pending-item changes give `commandContext` a new object identity. `useCommandSuggestions` listed `commandContext` in its effect deps even though only the argument-completion path consumes it, so every context rebuild re-ran the search and replaced the suggestions array with an identical-content copy. `useCommandCompletion` resets the active index to 0 whenever the suggestions array identity changes, which snapped the user's highlight back to the first command mid-navigation — exactly the "only while streaming, not every time" symptom in the report.

## Reviewer Test Plan

### How to verify

- New hook-level regression suite `packages/cli/src/ui/hooks/useCommandCompletion.slashChurn.test.ts` wires the real `useCommandCompletion` + `useSlashCompletion` (no mocks on the slash path): it waits for suggestions on query `/`, moves the highlight down, then rerenders with a new `commandContext` object identity while the query stays `/`.
- Before the fix this goes red: the suggestions array is replaced (`Object.is` fails) and `activeSuggestionIndex` resets from 1 to 0. After the fix both stay put.
- Regression guards in the same file: changing the query (`/` → `/s`) still resets the selection to the first item, changing the command list still rebuilds suggestions, and argument completion still receives the latest context after a context rebuild.
- Run: `cd packages/cli && npx vitest run src/ui/hooks/useCommandCompletion.slashChurn.test.ts` — 5/5 pass with the fix; tests 1-2 fail without it.
- Broader: `npx vitest run src/ui/hooks` — 70 files, 1528 tests pass. `npm run typecheck` in `packages/cli` passes.
- Manual path for a reviewer with a live model: send a prompt that streams for a while, type `/` during streaming, arrow down past the first entry — the highlight should stay where you put it.

### Evidence (Before & After)

Hook-level red→green capture (live TUI capture not performed — the trigger is timing-dependent on streaming state churn):

Before (on `main`, fix reverted):

```text
× keeps the suggestions array stable when only commandContext identity changes
  → expected [ { label: 'model', …(11) }, …(2) ] to be [ { label: 'model', …(11) }, …(2) ] // Object.is equality
× preserves the user menu selection across commandContext rebuilds
  → expected +0 to be 1 // Object.is equality
```

After (this branch):

```text
✓ src/ui/hooks/useCommandCompletion.slashChurn.test.ts (5 tests) 541ms
Test Files  1 passed (1)
     Tests  5 passed (5)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

✅ = hook-level tests + typecheck on this OS. Live in-stream TUI navigation was not screen-captured on any OS.

### Environment (optional)

Node v24.19.0, vitest jsdom hook tests only (no sandbox, no live model calls).

## Risk & Scope

- Main risk or tradeoff: argument completion now reads the context at callback time via a ref, so it always sees the latest context rather than the one captured when the effect ran — strictly fresher, and covered by the marker test. Context churn also no longer triggers redundant fzf re-searches, which is a small perf win during streaming.
- Not validated / out of scope: live TUI screen capture during a real streaming response; `@`-completion producers (`useAtCompletion`) are untouched.
- Breaking changes / migration notes: none; suggestion behavior for real input changes (typing, command reloads) is unchanged and regression-tested.

## Linked Issues

Fixes #9494

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让流式输出期间 slash 命令菜单的选中项保持稳定。建议列表搜索不再因为无关原因重建的 `commandContext` 而重新执行：现在上下文通过 ref 在异步参数补全回调里读取（与 `slashCommandProcessor.ts` 里 `history` 已有的做法一致），并把 `commandContext` 从建议 effect 的依赖列表中移除。现在只有真正的补全输入——查询内容、命令列表、最近使用命令——才会重建建议列表。

## 为什么需要

修复 #9494。响应流式输出时，session 统计更新（telemetry 的 `update` 事件）和 pending item 的变化会让 `commandContext` 获得新的对象身份。`useCommandSuggestions` 把 `commandContext` 放在 effect 依赖里，但实际只有参数补全路径会用到它，于是每次上下文重建都会重跑搜索，并用一个内容相同的新数组替换建议列表。而 `useCommandCompletion` 在建议数组身份变化时会把 active index 重置为 0，导致用户在导航途中高亮被弹回第一个命令——正是 issue 里「只在流式时出现、且不是每次」的现象。

## Reviewer 测试计划

### 如何验证

- 新增 hook 级回归测试 `packages/cli/src/ui/hooks/useCommandCompletion.slashChurn.test.ts`，接入真实的 `useCommandCompletion` + `useSlashCompletion`（slash 路径不 mock）：先等待查询 `/` 的建议出现，把高亮下移一项，然后在查询保持 `/` 不变的情况下用新的 `commandContext` 对象身份重渲染。
- 修复前该测试为红：建议数组被替换（`Object.is` 不相等），`activeSuggestionIndex` 从 1 被重置为 0；修复后两者保持不变。
- 同文件中的回归保护：查询变化（`/` → `/s`）仍会把选中重置到第一项；命令列表变化仍会重建建议；参数补全在上下文重建后仍能拿到最新上下文。
- 运行：`cd packages/cli && npx vitest run src/ui/hooks/useCommandCompletion.slashChurn.test.ts`——修复后 5/5 通过；不带修复时第 1-2 条失败。
- 更大范围：`npx vitest run src/ui/hooks`——70 个文件、1528 条测试全部通过；`packages/cli` 下 `npm run typecheck` 通过。
- 有可用模型的 reviewer 可手动验证：发一个会流式输出较久的 prompt，流式过程中输入 `/`，用方向键移到第一项以后——高亮应停留在你移动到的位置。

### 证据（修复前后）

hook 级红转绿记录（未做真实 TUI 录屏——触发时机依赖流式状态变化）：

修复前（`main` 上回退本修复）：

```text
× keeps the suggestions array stable when only commandContext identity changes
  → expected [ { label: 'model', …(11) }, …(2) ] to be [ { label: 'model', …(11) }, …(2) ] // Object.is equality
× preserves the user menu selection across commandContext rebuilds
  → expected +0 to be 1 // Object.is equality
```

修复后（本分支）：

```text
✓ src/ui/hooks/useCommandCompletion.slashChurn.test.ts (5 tests) 541ms
Test Files  1 passed (1)
     Tests  5 passed (5)
```

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

✅ = 在该平台完成了 hook 级测试 + typecheck；任何平台都未做流式中的真实 TUI 录屏。

### 环境（可选）

Node v24.19.0，仅 vitest jsdom hook 测试（无沙箱、无真实模型调用）。

## 风险与范围

- 主要风险/权衡：参数补全现在在回调执行时通过 ref 读取上下文，拿到的是最新上下文而不是 effect 运行时的快照——信息只会更新，并有 marker 测试覆盖。上下文抖动也不再触发多余的 fzf 重搜，对流式期间是小幅性能收益。
- 未验证/超出范围：真实流式响应下的 TUI 录屏；`@` 补全（`useAtCompletion`）未改动。
- 破坏性变更/迁移说明：无；真实输入变化（打字、命令重载）下的建议行为不变，且有回归测试保护。

## 关联 Issue

Fixes #9494

</details>
