### PR TITLE
fix(serve): Harden standalone conversation primitives

### DIFF
--- a/docs/plans/2026-08-14-standalone-pr2-core.md
+++ b/docs/plans/2026-08-14-standalone-pr2-core.md
@@ -159,7 +159,7 @@ interface ConversationDirectoryIdentity {
 `ConversationWorkspace` 新增窄方法：
 
 - `prepareStandaloneDirectory(sessionId)`：返回 `{ identity, created }`；valid existing empty child 可复用，existing non-empty 返回 conflict。
-- `ensureStandaloneDirectory(sessionId, expected?)`：load/repair 使用；与expected同identity的existing返回`ready`，missing创建后返回`recreated`，existing replacement返回compromised。
+- `ensureStandaloneDirectory(sessionId, expected?)`：load/repair 使用；与expected同identity的existing返回`ready`；missing后首次创建（无expected）返回`created`，已捕获identity后重建（有expected）返回`recreated`；existing replacement返回compromised。
 - `inspectStandaloneDirectory(sessionId, expected?)`：区分 `ready`、`missing`、`compromised`；给 prompt preflight 使用。
 - 现有`discardEmptyConversationDirectory(sessionId)`保持Live-only兼容实现；standalone路径不调用它。路径式删除无法原子绑定到前一次`lstat`得到的identity，PR2A不增加一个名为exact但仍有replacement race的overload。
 

--- a/packages/cli/src/serve/conversations/conversation-workspace.test.ts
+++ b/packages/cli/src/serve/conversations/conversation-workspace.test.ts
@@ -345,29 +345,29 @@ describe('Live conversation workspace root', () => {
     }
   });
 
-  it('inspects, recreates, and rejects replaced standalone child identities', async () => {
+  it('inspects, creates, and rejects replaced standalone child identities', async () => {
     const home = await tempHome();
     const workspace = new ConversationWorkspace({ homeDir: home });
 
     await expect(
       workspace.inspectStandaloneDirectory('standalone'),
     ).resolves.toEqual({ status: 'missing' });
-    const recreated = await workspace.ensureStandaloneDirectory('standalone');
-    expect(recreated.status).toBe('recreated');
-    if (recreated.status !== 'recreated') throw new Error('expected recreate');
+    const created = await workspace.ensureStandaloneDirectory('standalone');
+    expect(created.status).toBe('created');
+    if (created.status !== 'created') throw new Error('expected creation');
 
     await expect(
-      workspace.inspectStandaloneDirectory('standalone', recreated.identity),
+      workspace.inspectStandaloneDirectory('standalone', created.identity),
     ).resolves.toMatchObject({ status: 'ready' });
 
     // Keep the original inode alive under a sibling name so the replacement
     // cannot reuse it (ext4/overlayfs recycle freed inodes immediately).
-    const preserved = `${recreated.identity.canonicalPath}.preserved`;
-    await rename(recreated.identity.canonicalPath, preserved);
-    await mkdir(recreated.identity.canonicalPath, { mode: 0o700 });
+    const preserved = `${created.identity.canonicalPath}.preserved`;
+    await rename(created.identity.canonicalPath, preserved);
+    await mkdir(created.identity.canonicalPath, { mode: 0o700 });
     const compromised = await workspace.inspectStandaloneDirectory(
       'standalone',
-      recreated.identity,
+      created.identity,
     );
     expect(compromised.status).toBe('compromised');
     if (compromised.status !== 'compromised') {
@@ -377,6 +377,29 @@ describe('Live conversation workspace root', () => {
       ConversationDirectoryIdentityError,
     );
     expect(compromised.error.reason).toBe('unexpected_identity');
+  });
+
+  it('reports recreated only when a known identity vanished', async () => {
+    const home = await tempHome();
+    const workspace = new ConversationWorkspace({ homeDir: home });
+    const prepared = await workspace.prepareStandaloneDirectory('standalone');
+    // Keep the original inode alive under a sibling name so the replacement
+    // cannot reuse it and accidentally satisfy the expected identity.
+    await rename(
+      prepared.identity.canonicalPath,
+      `${prepared.identity.canonicalPath}.preserved`,
+    );
+
+    const ensured = await workspace.ensureStandaloneDirectory(
+      'standalone',
+      prepared.identity,
+    );
+    expect(ensured.status).toBe('recreated');
+    if (ensured.status !== 'recreated') throw new Error('expected recreate');
+    expect(ensured.identity.canonicalPath).toBe(
+      prepared.identity.canonicalPath,
+    );
+    expect(ensured.identity.inode).not.toBe(prepared.identity.inode);
   });
 
   it('returns the raced inspection when a concurrent creator wins the ensure race', async () => {
@@ -443,6 +466,44 @@ describe('Live conversation workspace root', () => {
     }
     // A narrowed `raced.status === 'ready'` pass-through would instead
     // surface a fresh identity_changed here; the raced reason must survive.
+    expect(ensured.error).toBe(racedError);
+  });
+
+  it('re-inspects a raced standalone directory even without an expected identity', async () => {
+    const home = await tempHome();
+    const workspace = new ConversationWorkspace({ homeDir: home });
+    const prepared = await workspace.prepareStandaloneDirectory('standalone');
+
+    const inspect = vi.spyOn(workspace, 'inspectStandaloneDirectory');
+    inspect.mockResolvedValueOnce({ status: 'missing' });
+
+    const ensured = await workspace.ensureStandaloneDirectory('standalone');
+    expect(ensured).toMatchObject({
+      status: 'ready',
+      identity: prepared.identity,
+    });
+    expect(inspect).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates a raced compromised verdict when no identity is expected', async () => {
+    const home = await tempHome();
+    const workspace = new ConversationWorkspace({ homeDir: home });
+    await workspace.prepareStandaloneDirectory('standalone');
+
+    const racedError = new ConversationDirectoryIdentityError(
+      'child',
+      'wrong_mode',
+    );
+    const inspect = vi.spyOn(workspace, 'inspectStandaloneDirectory');
+    inspect
+      .mockResolvedValueOnce({ status: 'missing' })
+      .mockResolvedValueOnce({ status: 'compromised', error: racedError });
+
+    const ensured = await workspace.ensureStandaloneDirectory('standalone');
+    expect(ensured.status).toBe('compromised');
+    if (ensured.status !== 'compromised') {
+      throw new Error('expected compromised');
+    }
     expect(ensured.error).toBe(racedError);
   });
 });

--- a/packages/cli/src/serve/conversations/conversation-workspace.ts
+++ b/packages/cli/src/serve/conversations/conversation-workspace.ts
@@ -35,6 +35,7 @@ export type StandaloneDirectoryInspection =
 
 export type StandaloneDirectoryEnsureResult =
   | { status: 'ready'; identity: ConversationDirectoryIdentity }
+  | { status: 'created'; identity: ConversationDirectoryIdentity }
   | { status: 'recreated'; identity: ConversationDirectoryIdentity }
   | {
       status: 'compromised';
@@ -297,7 +298,11 @@ export class ConversationWorkspace {
         root,
         storageSessionId,
       );
-      if (!materialized.created && expected) {
+      if (!materialized.created) {
+        // The directory appeared inside the race window, so it is adopted
+        // only through the same inspection verdict as one found up front —
+        // never as a blind 'ready' carrying whatever the racing creator put
+        // there.
         const raced = await this.inspectStandaloneDirectory(
           storageSessionId,
           expected,
@@ -308,8 +313,10 @@ export class ConversationWorkspace {
           'identity_changed',
         );
       }
+      // 'recreated' is reserved for a directory that vanished after its
+      // identity was captured; a first-ever creation reports 'created'.
       return {
-        status: materialized.created ? 'recreated' : 'ready',
+        status: expected ? 'recreated' : 'created',
         identity: materialized.identity,
       };
     } catch (error) {

--- a/packages/cli/src/utils/conversation-directory-identity.test.ts
+++ b/packages/cli/src/utils/conversation-directory-identity.test.ts
@@ -69,6 +69,22 @@ describe('conversation directory identity', () => {
     );
   });
 
+  it('exposes an error cause only when one was provided', () => {
+    const bare = new ConversationDirectoryIdentityError('child', 'not_empty');
+    expect('cause' in bare).toBe(false);
+    expect(Object.keys(bare)).not.toContain('cause');
+
+    const cause = new Error('boom');
+    const wrapped = new ConversationDirectoryIdentityError(
+      'child',
+      'io_error',
+      cause,
+    );
+    expect(wrapped.cause).toBe(cause);
+    expect('cause' in wrapped).toBe(true);
+    expect(Object.keys(wrapped)).not.toContain('cause');
+  });
+
   it('pins root and direct-child device and inode identity', async () => {
     const { root } = await tempRoot();
     const result = await materializeConversationDirectoryIdentity(

--- a/packages/cli/src/utils/conversation-directory-identity.ts
+++ b/packages/cli/src/utils/conversation-directory-identity.ts
@@ -67,21 +67,20 @@ export type ConversationDirectoryIdentityFailureReason =
 
 export class ConversationDirectoryIdentityError extends Error {
   override readonly name = 'ConversationDirectoryIdentityError';
-  override readonly cause?: unknown;
 
   constructor(
     readonly scope: ConversationDirectoryIdentityScope,
     readonly reason: ConversationDirectoryIdentityFailureReason,
     cause?: unknown,
   ) {
-    super(`Conversation ${scope} identity validation failed: ${reason}`);
-    if (cause !== undefined) {
-      Object.defineProperty(this, 'cause', {
-        configurable: true,
-        enumerable: false,
-        value: cause,
-      });
-    }
+    // Passing the options bag through to Error keeps `cause` a non-enumerable
+    // own property that exists only when one was provided; a class field
+    // declaration would define an enumerable `cause: undefined` on every
+    // instance instead.
+    super(
+      `Conversation ${scope} identity validation failed: ${reason}`,
+      cause !== undefined ? { cause } : undefined,
+    );
   }
 }
 

--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -284,6 +284,15 @@ describe('read() / readLines() with malformed lines', () => {
     ).resolves.toEqual({ records: [{ i: 1 }, { i: 2 }], complete: true });
   });
 
+  it('keeps the plain reader on a record budget after zero-record lines', async () => {
+    const file = tmpFile('{"i":\nnull\n{"i":1}\n{"i":2}\n');
+
+    await expect(readLines<{ i: number }>(file, 2)).resolves.toEqual([
+      { i: 1 },
+      { i: 2 },
+    ]);
+  });
+
   it('skips blank lines', async () => {
     const file = tmpFile('{"a":1}\n\n{"a":2}\n');
     expect(await read<{ a: number }>(file)).toEqual([{ a: 1 }, { a: 2 }]);

--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -266,6 +266,24 @@ describe('read() / readLines() with malformed lines', () => {
     ).resolves.toMatchObject({ complete: false });
   });
 
+  it('measures completeness against a line budget, not a record budget', async () => {
+    // Line 1 alone satisfies a 2-record budget; the corrupt line 2 must still
+    // be scanned because the budget counts physical lines.
+    const file = tmpFile('{"i":1}{"i":2}\n{"i":\n');
+
+    await expect(
+      readLinesWithIntegrity<{ i: number }>(file, 2),
+    ).resolves.toMatchObject({ complete: false });
+  });
+
+  it('returns every record recovered from the scanned lines', async () => {
+    const file = tmpFile('{"i":1}{"i":2}\n{"i":3}\n');
+
+    await expect(
+      readLinesWithIntegrity<{ i: number }>(file, 1),
+    ).resolves.toEqual({ records: [{ i: 1 }, { i: 2 }], complete: true });
+  });
+
   it('skips blank lines', async () => {
     const file = tmpFile('{"a":1}\n\n{"a":2}\n');
     expect(await read<{ a: number }>(file)).toEqual([{ a: 1 }, { a: 2 }]);
@@ -357,7 +375,7 @@ describe('reader resource cleanup', () => {
       readLinesWithIntegrity<{ i: number }>(file, 1),
     );
 
-    expect(result).toEqual({ records: [{ i: 1 }], complete: true });
+    expect(result).toEqual({ records: [{ i: 1 }, { i: 2 }], complete: true });
   });
 
   it('closes the file stream after read consumes all lines', async () => {

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -8,7 +8,7 @@
  * Efficient JSONL (JSON Lines) file utilities.
  *
  * Reading operations:
- * - readLines() - Reads the first N lines efficiently using buffered I/O
+ * - readLines() - Reads the first N records efficiently using buffered I/O
  * - read() - Reads entire file into memory as array
  *
  * Writing operations:
@@ -194,16 +194,11 @@ async function closeLineReader(
   await closed;
 }
 
-/**
- * Reads every record recovered from the first `count` non-empty lines of a
- * JSONL file. The budget counts physical lines, not records, so `complete`
- * always covers a fixed prefix of the file regardless of how many records a
- * glued line recovers.
- */
 async function readLinesWithIntegrityInternal<T = unknown>(
   filePath: string,
   count: number,
   options: JsonlReadLinesOptions = {},
+  budget: 'records' | 'lines' = 'records',
 ): Promise<{ records: T[]; complete: boolean }> {
   let fileStream: fs.ReadStream | undefined;
   let rl: readline.Interface | undefined;
@@ -221,13 +216,19 @@ async function readLinesWithIntegrityInternal<T = unknown>(
     let complete = true;
     let scannedLines = 0;
     for await (const line of rl) {
-      if (scannedLines >= count) break;
+      if (
+        (budget === 'records' && results.length >= count) ||
+        (budget === 'lines' && scannedLines >= count)
+      ) {
+        break;
+      }
       const trimmed = line.trim();
       if (trimmed.length === 0) continue;
       scannedLines++;
       const parsed = parseLineTolerantWithIntegrity<T>(trimmed, filePath);
       complete &&= parsed.complete;
       for (const obj of parsed.records) {
+        if (budget === 'records' && results.length >= count) break;
         results.push(obj);
       }
     }
@@ -238,7 +239,7 @@ async function readLinesWithIntegrityInternal<T = unknown>(
     options.signal?.throwIfAborted();
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       debugLogger.error(
-        `Error reading first ${count} lines from ${filePath}:`,
+        `Error reading up to ${count} ${budget} from ${filePath}:`,
         error,
       );
     }
@@ -272,7 +273,7 @@ export async function readLinesWithIntegrity<T = unknown>(
   count: number,
   options: JsonlReadLinesOptions = {},
 ): Promise<{ records: T[]; complete: boolean }> {
-  return readLinesWithIntegrityInternal<T>(filePath, count, options);
+  return readLinesWithIntegrityInternal<T>(filePath, count, options, 'lines');
 }
 
 /**

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -195,8 +195,10 @@ async function closeLineReader(
 }
 
 /**
- * Reads the first N lines from a JSONL file efficiently.
- * Returns an array of parsed objects.
+ * Reads every record recovered from the first `count` non-empty lines of a
+ * JSONL file. The budget counts physical lines, not records, so `complete`
+ * always covers a fixed prefix of the file regardless of how many records a
+ * glued line recovers.
  */
 async function readLinesWithIntegrityInternal<T = unknown>(
   filePath: string,
@@ -217,14 +219,15 @@ async function readLinesWithIntegrityInternal<T = unknown>(
 
     const results: T[] = [];
     let complete = true;
+    let scannedLines = 0;
     for await (const line of rl) {
-      if (results.length >= count) break;
+      if (scannedLines >= count) break;
       const trimmed = line.trim();
       if (trimmed.length === 0) continue;
+      scannedLines++;
       const parsed = parseLineTolerantWithIntegrity<T>(trimmed, filePath);
       complete &&= parsed.complete;
       for (const obj of parsed.records) {
-        if (results.length >= count) break;
         results.push(obj);
       }
     }
@@ -251,11 +254,19 @@ export async function readLines<T = unknown>(
   count: number,
   options: JsonlReadLinesOptions = {},
 ): Promise<T[]> {
-  return (await readLinesWithIntegrityInternal<T>(filePath, count, options))
-    .records;
+  // The slice preserves this reader's record-budget contract: at most `count`
+  // records even when a glued line recovers several.
+  return (
+    await readLinesWithIntegrityInternal<T>(filePath, count, options)
+  ).records.slice(0, count);
 }
 
-/** Reports whether every scanned non-empty line was fully recoverable. */
+/**
+ * Reads every record from the first `count` non-empty lines. `complete`
+ * reports whether each of those lines was fully recoverable, so fail-closed
+ * callers get a deterministic line-prefix coverage rather than one that
+ * shrinks when early lines are `}{`-glued.
+ */
 export async function readLinesWithIntegrity<T = unknown>(
   filePath: string,
   count: number,


### PR DESCRIPTION
## What this PR does

Fixes items 3, 4, and 5 tracked in #9490 from the review of the standalone conversation isolation primitives:

1. **Directory race adoption (item 3).** When a standalone directory is created by a concurrent actor inside the ensure race window, it is now adopted only after passing the same inspection used for a directory found up front. A first-ever creation reports `created`, while `recreated` is reserved for a directory that vanished after its identity was captured.
2. **Integrity and record budgets (item 4).** The integrity-aware JSONL head reader measures its budget in physical non-empty lines, so its fail-closed verdict always covers a fixed prefix even when one malformed line contains multiple recoverable records. The plain head reader keeps its separate record-budget contract: malformed, scalar, and blank lines do not consume the budget, glued records do, and the result never exceeds the requested record count.
3. **Error cause serialization (item 5).** Directory-identity errors pass their cause through the native ES2022 error options bag. Instances without a cause no longer expose an enumerable `cause: undefined`, while an actual cause remains readable and non-enumerable.

## Why it's needed

These defects were reported during the review of #9341 and deferred to keep that PR bounded; #9490 tracks the follow-up work. The directory ensure and inspection primitives do not yet have production consumers, but PR2B will build directly on their race and status contracts. The integrity reader already gates session-head classification, so its coverage must be deterministic without changing the long-standing behavior of the plain record-limited reader.

## Reviewer Test Plan

### How to verify

- Raced adoption: when the first inspection reports missing and a concurrent creator wins before materialization, a second inspection must run even without an expected identity, and any compromised verdict must be propagated.
- Status semantics: a first creation reports `created`; recreation after a captured identity disappears reports `recreated`.
- Integrity budget: corruption within the first N non-empty lines reports incomplete even when an earlier glued line already recovered N records, and every record recovered from those scanned lines is returned.
- Plain reader compatibility: malformed and scalar lines that recover no records do not consume its record budget, and glued lines never make it return more than N records.
- Cause behavior: without a cause there is no own `cause` key; with a cause the value is readable but absent from `Object.keys` and `JSON.stringify`.

The targeted suites pass locally: `cd packages/cli && npx vitest run src/utils/conversation-directory-identity.test.ts src/serve/conversations/conversation-workspace.test.ts` (29 tests) and `cd packages/core && npx vitest run src/utils/jsonl-utils.test.ts src/services/sessionService.test.ts src/services/sessionService.corruption.test.ts` (226 tests). `npm run typecheck --workspace=packages/core`, Prettier, ESLint, and `git diff --check` also pass for the changed scope.

### Evidence (Before & After)

N/A — non-UI behavioral fixes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 26.4.1, Node.js v22.22.3, npm 10.9.8; unit tests only.

## Risk & Scope

- Main risk or tradeoff: the ensure result union gains a `created` member, but that primitive has no production consumers yet. The integrity-aware reader can return more records than its numeric line budget when one physical line contains glued records; its single production consumer treats the result as a scan window, while the plain reader retains an explicit record cap.
- Not validated / out of scope: #9490 item 1 belongs with PR2B's trusted reserved-source write seam; item 2 requires lock identity derived from persisted storage spelling, rather than global lowercasing, and is expected to align with #9488. This PR also keeps the existing aggregate fail-closed metadata policy: corruption later in the inspected prefix can still make earlier creation metadata unreadable. Full-workspace build and typecheck were not used as local evidence because this shared checkout has unrelated Ink and WebUI dependency-resolution mismatches; GitHub CI remains the workspace-wide signal.
- Breaking changes / migration notes: none.

## Linked Issues

- Part of #9490 (fixes items 3, 4, and 5; items 1 and 2 remain open).
- Follow-up to #9341.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 #9490 中追踪的 item 3、4、5，这些问题来自对 standalone conversation 隔离原语的评审：

1. **目录竞态收养（item 3）。** 当 standalone 目录在 ensure 竞态窗口内被并发创建者抢先创建时，现在只有通过与“初始即存在的目录”相同的检查后才会被采纳。首次创建返回 `created`，`recreated` 只用于身份已捕获后目录消失并被重建的场景。
2. **完整性与记录预算（item 4）。** 完整性感知的 JSONL 头部读取器按物理非空行计量预算，因此即使一条损坏行包含多条可恢复记录，其 fail-closed 裁决也始终覆盖固定文件前缀。普通头部读取器继续保持独立的记录预算契约：malformed、scalar 和空行不消耗预算，粘连记录会消耗预算，返回结果永远不会超过请求的记录数。
3. **错误 cause 序列化（item 5）。** 目录身份错误通过 ES2022 原生 error options bag 传递 cause。没有 cause 的实例不再暴露可枚举的 `cause: undefined`，实际 cause 则保持可读且不可枚举。

## 为什么需要

这些缺陷在 #9341 评审期间被报告，为控制该 PR 的范围而推迟，由 #9490 跟踪后续工作。目录 ensure 和 inspection 原语尚无生产消费者，但 PR2B 将直接依赖其竞态和状态契约。完整性读取器已经用于 session head 分类，因此其覆盖范围必须保持确定，同时不能改变普通记录限额读取器的长期行为。

## 审阅者测试计划

### 如何验证

- 竞态收养：首次检查报告 missing、并发创建者在 materialization 前抢先创建时，即使没有 expected identity 也必须执行第二次检查，并传播任何 compromised 裁决。
- 状态语义：首次创建报告 `created`；已捕获 identity 消失后的重建报告 `recreated`。
- 完整性预算：只要损坏位于前 N 个非空物理行内，即使更早的粘连行已经恢复出 N 条记录，也必须报告 incomplete，并返回扫描窗口内恢复出的全部记录。
- 普通读取器兼容性：没有恢复出记录的 malformed 和 scalar 行不消耗记录预算，粘连行也不能让结果超过 N 条记录。
- Cause 行为：不传 cause 时没有自有 `cause` 键；传入 cause 时值可读，但不会出现在 `Object.keys` 和 `JSON.stringify` 中。

定向测试在本地通过：`cd packages/cli && npx vitest run src/utils/conversation-directory-identity.test.ts src/serve/conversations/conversation-workspace.test.ts`（29 个测试）和 `cd packages/core && npx vitest run src/utils/jsonl-utils.test.ts src/services/sessionService.test.ts src/services/sessionService.corruption.test.ts`（226 个测试）。变更范围内的 `npm run typecheck --workspace=packages/core`、Prettier、ESLint 和 `git diff --check` 也均通过。

### 证据（Before & After）

N/A —— 非 UI 行为修复。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 26.4.1、Node.js v22.22.3、npm 10.9.8；仅运行单元测试。

## 风险与范围

- 主要风险或取舍：ensure 结果联合类型新增 `created` 成员，但该原语尚无生产消费者。当一个物理行包含粘连记录时，完整性感知读取器返回的记录数可能超过数值形式的行预算；它唯一的生产消费者将结果视为扫描窗口，普通读取器则继续保留明确的记录上限。
- 未验证 / 范围之外：#9490 item 1 应与 PR2B 的可信 reserved-source 写入通道一起解决；item 2 需要从持久化存储 spelling 派生锁 identity，而不能全局转小写，预计应与 #9488 对齐。本 PR 也保留现有 aggregate fail-closed metadata policy：检查前缀中较后的损坏仍可能使较早的 creation metadata 不可读。本地没有把全仓 build 和 typecheck 作为证据，因为这个共享 checkout 存在与本变更无关的 Ink 和 WebUI 依赖解析不匹配；全仓结果以 GitHub CI 为准。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

- #9490 的一部分（修复 item 3、4、5；item 1、2 仍保持开放）。
- #9341 的 follow-up。

</details>
