### PR TITLE
chore(ci): Add --provenance to npm publish and id-token permission

### DIFF
--- a/.github/workflows/cd-mobile-mcp.yml
+++ b/.github/workflows/cd-mobile-mcp.yml
@@ -22,6 +22,7 @@ jobs:
       name: 'production-release'
     permissions:
       contents: 'read'
+      id-token: 'write'
     steps:
       - uses: 'actions/checkout@v4'
 
@@ -67,6 +68,6 @@ jobs:
       - name: 'Publish'
         if: '${{ !inputs.dry_run }}'
         working-directory: 'packages/mobile-mcp'
-        run: 'npm publish --access public'
+        run: 'npm publish --provenance --access public'
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -294,7 +294,7 @@ jobs:
       - name: 'Publish @qwen-code/sdk'
         working-directory: 'packages/sdk-typescript'
         run: |-
-          npm publish --access public --tag=${{ steps.version.outputs.NPM_TAG }} ${{ steps.vars.outputs.is_dry_run == 'true' && '--dry-run' || '' }}
+          npm publish --provenance --access public --tag=${{ steps.version.outputs.NPM_TAG }} ${{ steps.vars.outputs.is_dry_run == 'true' && '--dry-run' || '' }}
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -529,7 +529,7 @@ jobs:
             echo "::notice::${PACKAGE_NAME}@${RELEASE_VERSION} already published; skipping"
             exit 0
           fi
-          npm publish "${PUBLISH_ARGS[@]}"
+          npm publish --provenance "${PUBLISH_ARGS[@]}"
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
@@ -547,7 +547,7 @@ jobs:
             echo "::notice::${PACKAGE_NAME}@${RELEASE_VERSION} already published; skipping"
             exit 0
           fi
-          npm publish "${PUBLISH_ARGS[@]}"
+          npm publish --provenance "${PUBLISH_ARGS[@]}"
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
@@ -565,7 +565,7 @@ jobs:
             echo "::notice::${PACKAGE_NAME}@${RELEASE_VERSION} already published; skipping"
             exit 0
           fi
-          npm publish "${PUBLISH_ARGS[@]}"
+          npm publish --provenance "${PUBLISH_ARGS[@]}"
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
@@ -589,7 +589,7 @@ jobs:
                 echo "::notice::${PACKAGE_NAME}@${RELEASE_VERSION} already published; skipping"
                 exit 0
               fi
-              npm publish "${PUBLISH_ARGS[@]}"
+              npm publish --provenance "${PUBLISH_ARGS[@]}"
               echo "${channel}" >> "${PUBLISH_MARKER}"
             )
             echo "::endgroup::"

--- a/scripts/tests/package-scripts.test.js
+++ b/scripts/tests/package-scripts.test.js
@@ -459,7 +459,9 @@ describe('package scripts', () => {
       );
       expect(publishStep).toContain('already published; skipping');
       expect(publishStep).toContain('exit 0');
-      expect(publishStep).toContain('npm publish "${PUBLISH_ARGS[@]}"');
+      expect(publishStep).toContain(
+        'npm publish --provenance "${PUBLISH_ARGS[@]}"',
+      );
     }
 
     // The channel loop must wrap each iteration in a subshell so that


### PR DESCRIPTION
## What this PR does

Every `npm publish` in the release pipelines now passes `--provenance`, so each published package carries an npm-signed attestation of where and how it was built. The mobile-mcp publish job also gains the `id-token: write` permission that provenance attestation requires; the main release and SDK release jobs already declare it. Authentication still uses the existing npm token — nothing about how publishing authenticates changes in this PR.

## Why it's needed

The internal npm supply-chain audit flags our releases as unverifiable: without provenance, consumers cannot confirm a package really came from this repository's CI, and a compromised registry account or stolen token could ship a tampered build that looks identical. Provenance closes that gap and is also the required first half of the Trusted Publishing migration (the token removal lands in a follow-up PR, after Trusted Publishers are bound on npmjs.com, so there is no window where publishing could break).

## Reviewer Test Plan

### How to verify

- Confirm all six `npm publish` call sites (four in the main release workflow, one in the SDK release workflow, one in the mobile-mcp workflow) now include `--provenance` and that no other publish site exists.
- Confirm each publishing job declares `id-token: write` (main release and SDK release already did; mobile-mcp gains it here).
- After merge, trigger the release workflow with `dry_run: true` and confirm the publish steps complete; the first real release afterwards should show a Provenance badge on the published packages on npmjs.com.

### Evidence (Before & After)

N/A (CI workflow change, no user-visible behavior)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

YAML validity verified locally for all three changed workflows; full behavior verification happens in CI via a dry-run release.

## Risk & Scope

- Main risk or tradeoff: `--provenance` requires the job to hold `id-token: write`; all three publishing jobs now declare it, so this is satisfied. Publishing still authenticates with the existing token, so this PR cannot break a release on its own.
- Not validated / out of scope: removing the long-lived npm token and binding Trusted Publishers on npmjs.com — intentionally deferred to a follow-up PR so the token remains a working fallback until the OIDC path is proven.
- Breaking changes / migration notes: none.

## Linked Issues

Part of the internal npm package supply-chain security audit remediation.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

发布流水线中的每一处 `npm publish` 现在都带上了 `--provenance` 参数，使每个发布的包都附带一份由 npm 签名的来源证明（attestation），记录它是在哪里、如何构建的。mobile-mcp 的发布 job 同时补上了 provenance 签名所需的 `id-token: write` 权限；主发布和 SDK 发布的 job 此前已声明该权限。认证方式仍然使用现有的 npm token——本 PR 不改变发布的任何认证行为。

## 为什么需要

内部 npm 供应链审计指出我们的发布不可验证：没有 provenance，使用方无法确认一个包确实来自本仓库的 CI，一旦 registry 账号被入侵或 token 泄漏，攻击者可以发布外观完全一致的篡改版本。Provenance 堵上了这个缺口，同时也是 Trusted Publishing 迁移必需的前半段（删除 token 会在后续 PR 中进行，前提是 npmjs.com 上先绑定好 Trusted Publisher，确保不存在发布中断的窗口期）。

## 评审测试计划

### 如何验证

- 确认全部 6 处 `npm publish`（主发布 workflow 4 处、SDK 发布 workflow 1 处、mobile-mcp workflow 1 处）都已加上 `--provenance`，且不存在其他发布点。
- 确认每个发布 job 都声明了 `id-token: write`（主发布和 SDK 发布原本就有；mobile-mcp 在本 PR 中补上）。
- 合并后用 `dry_run: true` 触发一次发布 workflow，确认发布步骤正常完成；之后第一次真实发布后，npmjs.com 上的包应出现 Provenance 徽章。

### 前后对比证据

N/A（CI workflow 变更，无用户可见行为）

### 测试环境

三个改动 workflow 均已在本地验证 YAML 合法性；完整行为验证通过 CI 的 dry-run 发布完成。

## 风险与范围

- 主要风险或权衡：`--provenance` 要求 job 持有 `id-token: write`，三个发布 job 现在都已声明，条件满足。发布仍用现有 token 认证，因此本 PR 单独不会导致发布失败。
- 未验证 / 范围外：删除长期 npm token 与在 npmjs.com 绑定 Trusted Publisher——有意推迟到后续 PR，让 token 在 OIDC 链路被验证之前继续作为兜底。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

内部 npm 包供应链安全审计整改的一部分。

</details>
