### PR TITLE
fix(web-shell): keep sidebar sessions synchronized

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -415,6 +415,7 @@ const {
     qualifiedSetWorkspaceSetting,
     sessionCatalogController: {
       invalidateWorkspace: vi.fn(),
+      refreshWorkspace: vi.fn(),
       sessionCreated: vi.fn(),
       promptAdmitted: vi.fn(),
       promptAdmissionUncertain: vi.fn(),

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
@@ -126,6 +126,7 @@ vi.mock('../../session-catalog/session-catalog-hooks', () => ({
   useSessionCatalogController: () => ({
     refreshQueries: refreshSessionCatalogQueries,
     invalidateWorkspace: vi.fn(),
+    refreshWorkspace: vi.fn(),
     renamed: vi.fn(),
   }),
   useSessionCatalogPolling: () => undefined,

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -947,6 +947,12 @@
   justify-content: flex-end;
 }
 
+.sessionMetaSlot:not(
+  :has(.sessionLoading, .sessionAttention, .sessionGitIcon)
+) {
+  padding-right: 10px;
+}
+
 .sessionAttention {
   height: 22px;
   display: inline-flex;
@@ -964,10 +970,6 @@
 .sessionAttentionUserInput {
   background: color-mix(in srgb, var(--agent-blue-500) 10%, transparent);
   color: color-mix(in srgb, var(--agent-blue-500) 95%, var(--foreground));
-}
-
-.sessionAttention + .sessionLoading {
-  margin-left: 10px;
 }
 
 .sessionRow:hover .sessionMetaSlot,
@@ -993,7 +995,7 @@
 }
 
 .sessionLoading {
-  margin-right: 10px;
+  margin: 0 10px;
   width: 12px;
   height: 12px;
   display: inline-flex;

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -2335,7 +2335,7 @@ export function WebShellSidebar({
             bumpWorkspaceReload();
             const ownerCwd = workspaceCwd ?? primaryWorkspaceCwd;
             if (ownerCwd) {
-              sessionCatalogController.invalidateWorkspace(ownerCwd);
+              sessionCatalogController.refreshWorkspace(ownerCwd);
             }
           }
         } catch (err) {
@@ -2495,6 +2495,7 @@ export function WebShellSidebar({
               effectiveName,
             );
           }
+          sessionCatalogController.refreshWorkspace(workspaceCwd);
         }
         // A late settle must not close an editor the user moved to another
         // session with while this request was in flight.
@@ -2511,7 +2512,7 @@ export function WebShellSidebar({
       })
       .finally(() => {
         if (!renamed && workspaceCwd) {
-          sessionCatalogController.invalidateWorkspace(workspaceCwd);
+          sessionCatalogController.refreshWorkspace(workspaceCwd);
         }
         setSessionBusy(sessionId, false, workspaceCwd);
       });
@@ -2667,7 +2668,7 @@ export function WebShellSidebar({
         const workspaceCwd =
           deleteCandidate.workspaceCwd ?? primaryWorkspaceCwd;
         if (scope.kind !== 'primary' && workspaceCwd) {
-          sessionCatalogController.invalidateWorkspace(workspaceCwd);
+          sessionCatalogController.refreshWorkspace(workspaceCwd);
         }
         setSessionBusy(sessionId, false, deleteCandidate.workspaceCwd);
       });
@@ -2870,7 +2871,7 @@ export function WebShellSidebar({
       } finally {
         const workspaceCwd = groupEditor.workspaceCwd ?? primaryWorkspaceCwd;
         if (workspaceCwd) {
-          sessionCatalogController.invalidateWorkspace(workspaceCwd);
+          sessionCatalogController.refreshWorkspace(workspaceCwd);
         }
         setGroupBusy(false);
       }
@@ -2938,7 +2939,7 @@ export function WebShellSidebar({
         const workspaceCwd =
           deleteGroupCandidate.workspaceCwd ?? primaryWorkspaceCwd;
         if (workspaceCwd) {
-          sessionCatalogController.invalidateWorkspace(workspaceCwd);
+          sessionCatalogController.refreshWorkspace(workspaceCwd);
         }
         setGroupBusy(false);
       });
@@ -3016,7 +3017,7 @@ export function WebShellSidebar({
         .finally(() => {
           const workspaceCwd = session.workspaceCwd ?? primaryWorkspaceCwd;
           if (workspaceCwd) {
-            sessionCatalogController.invalidateWorkspace(workspaceCwd);
+            sessionCatalogController.refreshWorkspace(workspaceCwd);
           }
           setSessionBusy(sessionId, false, session.workspaceCwd);
         });
@@ -3067,7 +3068,7 @@ export function WebShellSidebar({
           bumpWorkspaceReload();
           const workspaceCwd = session.workspaceCwd ?? primaryWorkspaceCwd;
           if (scope.kind !== 'primary' && workspaceCwd) {
-            sessionCatalogController.invalidateWorkspace(workspaceCwd);
+            sessionCatalogController.refreshWorkspace(workspaceCwd);
           }
           setSessionBusy(sessionId, false, session.workspaceCwd);
         }
@@ -3119,7 +3120,7 @@ export function WebShellSidebar({
           bumpWorkspaceReload();
           const workspaceCwd = session.workspaceCwd ?? primaryWorkspaceCwd;
           if (scope.kind !== 'primary' && workspaceCwd) {
-            sessionCatalogController.invalidateWorkspace(workspaceCwd);
+            sessionCatalogController.refreshWorkspace(workspaceCwd);
           }
           setSessionBusy(sessionId, false, session.workspaceCwd);
         }
@@ -3219,7 +3220,7 @@ export function WebShellSidebar({
         .finally(() => {
           const workspaceCwd = session.workspaceCwd ?? primaryWorkspaceCwd;
           if (workspaceCwd) {
-            sessionCatalogController.invalidateWorkspace(workspaceCwd);
+            sessionCatalogController.refreshWorkspace(workspaceCwd);
           }
           setSessionBusy(sessionId, false, session.workspaceCwd);
         });
@@ -3267,7 +3268,7 @@ export function WebShellSidebar({
         .finally(() => {
           const workspaceCwd = session.workspaceCwd ?? primaryWorkspaceCwd;
           if (workspaceCwd) {
-            sessionCatalogController.invalidateWorkspace(workspaceCwd);
+            sessionCatalogController.refreshWorkspace(workspaceCwd);
           }
           setSessionBusy(sessionId, false, session.workspaceCwd);
         });
@@ -4180,7 +4181,11 @@ export function WebShellSidebar({
     }
     if (error && sessionsPage === undefined) {
       return (
-        <button className={styles.retry} type="button" onClick={reload}>
+        <button
+          className={styles.retry}
+          type="button"
+          onClick={() => void reload({ interactive: true })}
+        >
           {t('sidebar.loadFailed')}
         </button>
       );
@@ -4307,9 +4312,9 @@ export function WebShellSidebar({
         className={styles.retry}
         type="button"
         onClick={() => {
-          void reloadArchived().catch(() => undefined);
+          void reloadArchived({ interactive: true }).catch(() => undefined);
           for (const workspaceCwd of secondaryWorkspaceCwds) {
-            sessionCatalogController.invalidateWorkspace(workspaceCwd);
+            sessionCatalogController.refreshWorkspace(workspaceCwd);
           }
         }}
       >

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -29,6 +29,7 @@ const {
   sessionActions,
   channelState,
   invalidateSessionCatalog,
+  refreshWorkspaceSessionCatalog,
   renameSessionCatalog,
   refreshSessionCatalogQueries,
   useSessionCatalogPollingSpy,
@@ -99,6 +100,7 @@ const {
   };
   const useChannels = vi.fn(() => channelState);
   const invalidateSessionCatalog = vi.fn();
+  const refreshWorkspaceSessionCatalog = vi.fn();
   const renameSessionCatalog = vi.fn();
   const refreshSessionCatalogQueries = vi.fn();
   const useSessionCatalogPollingSpy = vi.fn();
@@ -161,6 +163,7 @@ const {
     sessionActions,
     channelState,
     invalidateSessionCatalog,
+    refreshWorkspaceSessionCatalog,
     renameSessionCatalog,
     refreshSessionCatalogQueries,
     useSessionCatalogPollingSpy,
@@ -209,6 +212,10 @@ vi.mock('../../session-catalog/session-catalog-hooks', () => {
       refreshQueries: refreshSessionCatalogQueries,
       invalidateWorkspace: (workspaceCwd: string) => {
         invalidateSessionCatalog(workspaceCwd);
+        for (const listener of catalogListeners) listener(workspaceCwd);
+      },
+      refreshWorkspace: (workspaceCwd: string) => {
+        refreshWorkspaceSessionCatalog(workspaceCwd);
         for (const listener of catalogListeners) listener(workspaceCwd);
       },
       renamed: (
@@ -776,6 +783,7 @@ beforeEach(() => {
   workspaceActions.addWorkspace.mockReset();
   workspaceActions.addWorkspace.mockResolvedValue({ persisted: true });
   invalidateSessionCatalog.mockReset();
+  refreshWorkspaceSessionCatalog.mockReset();
   renameSessionCatalog.mockReset();
   refreshSessionCatalogQueries.mockReset();
   useSessionCatalogPollingSpy.mockReset();
@@ -1370,6 +1378,7 @@ describe('WebShellSidebar workspace removal', () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
+    refreshWorkspaceSessionCatalog.mockClear();
 
     await selectSessionMenuItem('Locked delete', 'Delete');
     await act(async () => {
@@ -1377,12 +1386,20 @@ describe('WebShellSidebar workspace removal', () => {
       await secondaryDelete.mock.results.at(-1)?.value;
     });
     expect(secondaryDelete).toHaveBeenCalledWith(['locked-delete']);
+    expect(refreshWorkspaceSessionCatalog).toHaveBeenLastCalledWith(
+      '/tmp/other',
+    );
+    refreshWorkspaceSessionCatalog.mockClear();
 
     await selectSessionMenuItem('Locked archive', 'Archive');
     await act(async () => {
       await secondaryArchive.mock.results.at(-1)?.value;
     });
     expect(secondaryArchive).toHaveBeenCalledWith(['locked-archive']);
+    expect(refreshWorkspaceSessionCatalog).toHaveBeenLastCalledWith(
+      '/tmp/other',
+    );
+    refreshWorkspaceSessionCatalog.mockClear();
 
     await selectSessionMenuItem('Locked color', 'Group');
     const blue = Array.from(
@@ -1397,6 +1414,10 @@ describe('WebShellSidebar workspace removal', () => {
       color: 'blue',
       groupId: null,
     });
+    expect(refreshWorkspaceSessionCatalog).toHaveBeenLastCalledWith(
+      '/tmp/other',
+    );
+    refreshWorkspaceSessionCatalog.mockClear();
 
     await selectSessionMenuItem('Locked color', 'Group');
     const namedGroup = Array.from(
@@ -1411,6 +1432,10 @@ describe('WebShellSidebar workspace removal', () => {
       groupId: 'secondary-group',
       color: null,
     });
+    expect(refreshWorkspaceSessionCatalog).toHaveBeenLastCalledWith(
+      '/tmp/other',
+    );
+    refreshWorkspaceSessionCatalog.mockClear();
 
     await act(async () => {
       click(inlineSessionAction('Locked pinned', 'Unpin')!);
@@ -1419,6 +1444,9 @@ describe('WebShellSidebar workspace removal', () => {
     expect(secondaryOrganization).toHaveBeenCalledWith('locked-pinned', {
       isPinned: false,
     });
+    expect(refreshWorkspaceSessionCatalog).toHaveBeenLastCalledWith(
+      '/tmp/other',
+    );
     expect(primaryDelete).not.toHaveBeenCalled();
     expect(primaryArchive).not.toHaveBeenCalled();
     expect(primaryOrganization).not.toHaveBeenCalled();
@@ -2351,6 +2379,9 @@ describe('WebShellSidebar workspace removal', () => {
     expect(updateSessionMetadata).toHaveBeenCalledWith('other-session', {
       displayName: 'Renamed other session',
     });
+    expect(refreshWorkspaceSessionCatalog).toHaveBeenLastCalledWith(
+      '/tmp/project',
+    );
     expect(sessionActions.renameSession).not.toHaveBeenCalled();
     expect(onLoadSession).not.toHaveBeenCalled();
   });

--- a/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-hooks.ts
@@ -82,10 +82,13 @@ export function useSessionCatalogQuery(
     getSnapshot,
     getServerSnapshot,
   );
-  const reload = useCallback(() => {
-    if (!enabled || !stableQuery) return Promise.resolve(undefined);
-    return store.refresh(stableQuery);
-  }, [enabled, stableQuery, store]);
+  const reload = useCallback(
+    (options: { interactive?: boolean } = {}) => {
+      if (!enabled || !stableQuery) return Promise.resolve(undefined);
+      return store.refresh(stableQuery, options);
+    },
+    [enabled, stableQuery, store],
+  );
 
   return {
     ...snapshot,
@@ -187,6 +190,11 @@ export function useSessionCatalogController(client: DaemonClient) {
       },
       invalidateWorkspace(workspaceCwd: string) {
         update(() => store.invalidateWorkspace(workspaceCwd));
+      },
+      refreshWorkspace(workspaceCwd: string) {
+        update(() =>
+          store.invalidateWorkspace(workspaceCwd, { interactive: true }),
+        );
       },
       sessionCreated(workspaceCwd: string, _sessionId: string) {
         update(() => {
@@ -304,15 +312,18 @@ export function useWebShellSessions(options: WebShellSessionsOptions = {}) {
     ...(pollIntervalMs !== undefined ? { pollIntervalMs } : {}),
   });
   const reloadPage = result.reload;
-  const reload = useCallback(async () => {
-    try {
-      return (await reloadPage())?.sessions;
-    } catch {
-      return undefined;
-    }
-  }, [reloadPage]);
+  const reload = useCallback(
+    async (reloadOptions: { interactive?: boolean } = {}) => {
+      try {
+        return (await reloadPage(reloadOptions))?.sessions;
+      } catch {
+        return undefined;
+      }
+    },
+    [reloadPage],
+  );
   const invalidate = useCallback(() => {
-    if (workspaceCwd) controller.invalidateWorkspace(workspaceCwd);
+    if (workspaceCwd) controller.refreshWorkspace(workspaceCwd);
   }, [controller, workspaceCwd]);
   const deleteSession = useCallback(
     async (sessionId: string) => {

--- a/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.test.ts
@@ -1180,7 +1180,12 @@ describe('SessionCatalogStore', () => {
     // The waiter settles via a later staged commit (not exercised here), so
     // drop the promise; the wake fires synchronously inside refresh().
     void store.refresh(query('/work')).catch(() => undefined);
-    expect(wake).toHaveBeenCalledWith('/work');
+    expect(wake).toHaveBeenCalledWith('/work', false);
+
+    void store
+      .refresh(query('/work'), { interactive: true })
+      .catch(() => undefined);
+    expect(wake).toHaveBeenLastCalledWith('/work', true);
 
     stopWake();
     releaseLiveState();

--- a/packages/web-shell/client/session-catalog/session-catalog-store.ts
+++ b/packages/web-shell/client/session-catalog/session-catalog-store.ts
@@ -184,7 +184,7 @@ export class SessionCatalogStore {
     'interactive' | 'invalidated'
   >();
   private readonly liveStateWakeHandlers = new Set<
-    (workspaceCwd: string) => void
+    (workspaceCwd: string, bypassRetry?: boolean) => void
   >();
   private liveStateActivitySequence = 0;
   private readonly liveStatePendingActivity = new Map<
@@ -254,7 +254,9 @@ export class SessionCatalogStore {
     return kind;
   }
 
-  onLiveStateWake(handler: (workspaceCwd: string) => void): () => void {
+  onLiveStateWake(
+    handler: (workspaceCwd: string, bypassRetry?: boolean) => void,
+  ): () => void {
     this.liveStateWakeHandlers.add(handler);
     return () => {
       this.liveStateWakeHandlers.delete(handler);
@@ -301,15 +303,19 @@ export class SessionCatalogStore {
   private requestLiveStateRefresh(
     workspaceCwd: string,
     kind: 'interactive' | 'invalidated',
+    bypassRetry = false,
   ): void {
     if (
+      kind !== 'interactive' &&
       this.liveStateWorkspaceRefreshRequests.get(workspaceCwd) === 'interactive'
     ) {
       return;
     }
     this.liveStateWorkspaceRefreshRequests.set(workspaceCwd, kind);
     if (kind === 'interactive') {
-      for (const handler of this.liveStateWakeHandlers) handler(workspaceCwd);
+      for (const handler of this.liveStateWakeHandlers) {
+        handler(workspaceCwd, bypassRetry);
+      }
     }
   }
 
@@ -380,8 +386,14 @@ export class SessionCatalogStore {
     };
   }
 
-  async refresh(query: SessionCatalogQuery): Promise<DaemonSessionListPage> {
-    return this.requestFresh(this.getOrCreateEntry(query));
+  async refresh(
+    query: SessionCatalogQuery,
+    options: { interactive?: boolean } = {},
+  ): Promise<DaemonSessionListPage> {
+    return this.requestFresh(
+      this.getOrCreateEntry(query),
+      options.interactive === true,
+    );
   }
 
   async loadOnce(
@@ -422,13 +434,17 @@ export class SessionCatalogStore {
 
   invalidateWorkspace(
     workspaceCwd: string,
-    options: { background?: boolean } = {},
+    options: { background?: boolean; interactive?: boolean } = {},
   ): void {
     const background = options.background === true;
     const hidden = this.isHidden();
     const liveStateEnabled = this.isWorkspaceLiveStateEnabled(workspaceCwd);
     if (liveStateEnabled) {
-      this.requestLiveStateRefresh(workspaceCwd, 'invalidated');
+      this.requestLiveStateRefresh(
+        workspaceCwd,
+        options.interactive === true ? 'interactive' : 'invalidated',
+        options.interactive === true,
+      );
     }
     for (const entry of this.entries.values()) {
       if (entry.query.workspaceCwd !== workspaceCwd) continue;
@@ -781,7 +797,10 @@ export class SessionCatalogStore {
     return entry;
   }
 
-  private requestFresh(entry: CatalogEntry): Promise<DaemonSessionListPage> {
+  private requestFresh(
+    entry: CatalogEntry,
+    bypassRetry = false,
+  ): Promise<DaemonSessionListPage> {
     entry.desiredRevision += 1;
     const revision = entry.desiredRevision;
     this.setSnapshot(entry, { ...entry.snapshot, stale: true });
@@ -790,7 +809,11 @@ export class SessionCatalogStore {
     );
     const promise = this.createWaiter(entry, revision, liveStateCoordinated);
     if (liveStateCoordinated) {
-      this.requestLiveStateRefresh(entry.query.workspaceCwd, 'interactive');
+      this.requestLiveStateRefresh(
+        entry.query.workspaceCwd,
+        'interactive',
+        bypassRetry,
+      );
       if (entry.waiters.some((waiter) => !waiter.liveStateCoordinated)) {
         this.ensureScheduled(entry, PRIORITY.interactive, false);
       }

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.test.tsx
@@ -554,6 +554,157 @@ describe('useWorkspaceSessionLiveState', () => {
     expect(container.textContent).toBe('false:false:no-group');
   });
 
+  it('lets an explicit refresh bypass live-state error backoff', async () => {
+    await renderProbe();
+    getLiveState.mockRejectedValueOnce(new Error('offline'));
+
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getLiveState).toHaveBeenCalledTimes(3);
+    expect(listSessions).toHaveBeenCalledTimes(1);
+
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLiveState).toHaveBeenCalledTimes(5);
+    expect(listSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps internal fresh loads behind live-state error backoff', async () => {
+    getLiveState.mockRejectedValueOnce(new Error('offline'));
+    await renderProbe();
+    const liveRequests = getLiveState.mock.calls.length;
+    const catalogRequests = listSessions.mock.calls.length;
+
+    act(() => {
+      void getSessionCatalogStore(client)
+        .refresh(query)
+        .catch(() => undefined);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLiveState).toHaveBeenCalledTimes(liveRequests);
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+  });
+
+  it('preserves an explicit refresh while a live-state request is in flight', async () => {
+    await renderProbe();
+    let rejectInFlight!: (error: Error) => void;
+    getLiveState.mockImplementationOnce(
+      () =>
+        new Promise<DaemonWorkspaceSessionLiveState>((_resolve, reject) => {
+          rejectInFlight = reject;
+        }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      rejectInFlight(new Error('offline'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLiveState).toHaveBeenCalledTimes(5);
+    expect(listSessions).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets an explicit refresh bypass reconciliation error backoff', async () => {
+    await renderProbe();
+    listSessions.mockRejectedValueOnce(new Error('catalog offline'));
+
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(listSessions).toHaveBeenCalledTimes(2);
+
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getLiveState).toHaveBeenCalledTimes(5);
+    expect(listSessions).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps internal fresh loads behind reconciliation error backoff', async () => {
+    await renderProbe();
+    listSessions.mockRejectedValueOnce(new Error('catalog offline'));
+
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const catalogRequests = listSessions.mock.calls.length;
+
+    act(() => {
+      void getSessionCatalogStore(client)
+        .refresh(query)
+        .catch(() => undefined);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests);
+  });
+
+  it('preserves an explicit refresh during an in-flight live request', async () => {
+    await renderProbe();
+    listSessions.mockRejectedValueOnce(new Error('catalog offline'));
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const catalogRequests = listSessions.mock.calls.length;
+
+    let resolveInFlight!: (value: DaemonWorkspaceSessionLiveState) => void;
+    getLiveState.mockImplementationOnce(
+      () =>
+        new Promise<DaemonWorkspaceSessionLiveState>((resolve) => {
+          resolveInFlight = resolve;
+        }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SESSION_LIVE_STATE_POLL_MS);
+    });
+    act(() => controller.refreshWorkspace('/work'));
+    await act(async () => {
+      resolveInFlight(liveState(1));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(listSessions).toHaveBeenCalledTimes(catalogRequests + 1);
+  });
+
   it('keeps polling volatile state while catalog reconciliation is backed off', async () => {
     let revision = 1;
     let active = false;

--- a/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
+++ b/packages/web-shell/client/session-catalog/workspace-session-live-state.ts
@@ -22,6 +22,7 @@ interface WorkspacePollState {
   reconcileRetryAt: number;
   lastReconcileAt: number;
   fallbackAttempted: boolean;
+  interactiveRefreshRequested: boolean;
   reconcileRequested: boolean;
   invalidationRequested: boolean;
   invalidationReconcileAt: number;
@@ -137,6 +138,7 @@ export function useWorkspaceSessionLiveState(
       reconcileRetryAt: 0,
       lastReconcileAt: Number.NEGATIVE_INFINITY,
       fallbackAttempted: false,
+      interactiveRefreshRequested: false,
       reconcileRequested: false,
       invalidationRequested: false,
       invalidationReconcileAt: Number.NEGATIVE_INFINITY,
@@ -198,8 +200,8 @@ export function useWorkspaceSessionLiveState(
       const request = catalogStore.consumeWorkspaceLiveStateRefreshRequest(
         state.workspaceCwd,
       );
-      state.reconcileRequested =
-        state.reconcileRequested || request === 'interactive';
+      const interactive = request === 'interactive';
+      state.reconcileRequested = state.reconcileRequested || interactive;
       state.invalidationRequested =
         state.invalidationRequested || request === 'invalidated';
     };
@@ -248,12 +250,18 @@ export function useWorkspaceSessionLiveState(
       if (
         disposed ||
         state.inFlight ||
-        Date.now() < state.liveRetryAt ||
         (typeof document !== 'undefined' && document.hidden)
       ) {
         return;
       }
+      const bypassRetry = state.interactiveRefreshRequested;
+      if (!bypassRetry && Date.now() < state.liveRetryAt) return;
+      state.interactiveRefreshRequested = false;
       state.inFlight = true;
+      const finish = (): void => {
+        state.inFlight = false;
+        if (state.interactiveRefreshRequested) void poll(state);
+      };
       // Contract: only a response from a request started after a completion
       // was recorded may settle it, so the pending set is snapshotted before
       // the request goes out. Completions recorded mid-flight keep their
@@ -282,11 +290,11 @@ export function useWorkspaceSessionLiveState(
             }
           }
         }
-        state.inFlight = false;
+        finish();
         return;
       }
       if (disposed) {
-        state.inFlight = false;
+        finish();
         return;
       }
       const absorbedActivity = catalogStore.applyLiveState(
@@ -311,12 +319,15 @@ export function useWorkspaceSessionLiveState(
         }
       }
       consumeRefreshRequest(state);
+      const bypassReconcileRetry =
+        bypassRetry || state.interactiveRefreshRequested;
+      state.interactiveRefreshRequested = false;
       if (
         !state.reconcileRequested &&
         !state.invalidationRequested &&
         versionsEqual(state.acceptedVersion, live.catalogVersion)
       ) {
-        state.inFlight = false;
+        finish();
         return;
       }
       // Interactive requests bypass the reconcile cooldown. Lifecycle
@@ -324,14 +335,14 @@ export function useWorkspaceSessionLiveState(
       // on a separate timestamp so a single local create stays immediate
       // while sustained event churn stays rate-limited.
       if (
-        Date.now() < state.reconcileRetryAt ||
+        (!bypassReconcileRetry && Date.now() < state.reconcileRetryAt) ||
         (!state.reconcileRequested &&
           (state.invalidationRequested
             ? Date.now() - state.invalidationReconcileAt
             : Date.now() - state.lastReconcileAt) <
             SESSION_LIVE_STATE_RECONCILE_COOLDOWN_MS)
       ) {
-        state.inFlight = false;
+        finish();
         return;
       }
       try {
@@ -347,7 +358,7 @@ export function useWorkspaceSessionLiveState(
           console.warn('[session-live-state] reconciliation failed:', error);
         }
       } finally {
-        state.inFlight = false;
+        finish();
       }
     };
 
@@ -355,12 +366,16 @@ export function useWorkspaceSessionLiveState(
     // maxAgeMs subscriptions, group-membership growth) and recorded turn
     // completions wake the loop immediately instead of waiting for the
     // next 2s tick.
-    const stopWake = catalogStore.onLiveStateWake((workspaceCwd) => {
-      const state = states.find(
-        (candidate) => candidate.workspaceCwd === workspaceCwd,
-      );
-      if (state) void poll(state);
-    });
+    const stopWake = catalogStore.onLiveStateWake(
+      (workspaceCwd, bypassRetry) => {
+        const state = states.find(
+          (candidate) => candidate.workspaceCwd === workspaceCwd,
+        );
+        if (!state) return;
+        if (bypassRetry) state.interactiveRefreshRequested = true;
+        void poll(state);
+      },
+    );
     const onVisibilityWake = (): void => {
       if (typeof document !== 'undefined' && document.hidden) return;
       for (const state of states) void poll(state);


### PR DESCRIPTION
## What this PR does

This change makes Web Shell sidebar mutations reconcile the affected workspace immediately after creating, renaming, deleting, archiving, pinning, grouping, or recoloring sessions. User-triggered retries can bypass transient catalog backoff, while background refreshes continue to respect error backoff and coalesce repeated work. It also adds spacing around the session loading indicator and right-side padding when no status icon is present.

## Why it's needed

Sidebar state could remain stale when another client changed the same workspace or when a mutation updated data outside the currently cached page. Treating every internal refresh as a manual retry also caused avoidable request bursts during daemon failures. The new distinction keeps explicit user actions responsive without weakening background rate limiting.

## Reviewer Test Plan

### How to verify

Perform sidebar operations such as rename, pin or unpin, archive or unarchive, delete, group assignment, and color changes, then confirm the affected workspace is fully refreshed. Simulate live-state and catalog failures and confirm background refreshes wait for the retry window while clicking a visible Retry control triggers an immediate attempt. Trigger a refresh while a live-state request is already in flight and confirm the refresh is neither lost nor duplicated. Verify loading rows and rows without right-side icons retain comfortable right spacing.

### Evidence (Before & After)

Before: mutation results could remain stale until a later poll, internal refreshes could bypass failure backoff, and session metadata could sit too close to the loading indicator or right edge.

After: sidebar mutations and explicit retries reconcile immediately, background refreshes remain rate-limited during failures, and the session metadata spacing is consistent.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local workspace with the Web Shell Vitest suite, repository lint, typecheck, and build.

## Risk & Scope

- Main risk or tradeoff: Explicit sidebar mutations perform an additional workspace reconciliation by design; background and lifecycle-driven refreshes remain rate-limited.
- Not validated / out of scope: Visual confirmation on Windows and Linux; non-sidebar session management flows are unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此改动让 Web Shell 侧边栏在新建、重命名、删除、归档、置顶、分组或修改会话颜色后立即对受影响的工作区执行完整同步。用户主动点击重试时可以绕过临时的目录退避，而后台刷新仍会遵守错误退避并合并重复工作。同时调整会话 loading 图标周围的间距，并在右侧没有状态图标时增加留白。

## 为什么需要

当其他客户端修改同一工作区，或一次操作更新了当前缓存分页之外的数据时，侧边栏状态可能一直过期到后续轮询。此前把所有内部刷新都视为手动重试，也会在 daemon 故障时产生不必要的请求突发。新的区分让用户操作保持即时响应，同时不削弱后台限流。

## Reviewer Test Plan

### 如何验证

执行重命名、置顶或取消置顶、归档或取消归档、删除、分组和颜色修改等侧边栏操作，确认受影响的工作区会被完整刷新。模拟 live-state 和目录请求失败，确认后台刷新会等待重试窗口，而点击可见的 Retry 控件会立即发起请求。在 live-state 请求进行中触发刷新，确认该刷新既不会丢失也不会重复执行。确认 loading 行以及右侧没有图标的行都保留合适的右侧间距。

### 证据（Before & After）

Before：操作结果可能在后续轮询前保持过期，内部刷新可能绕过故障退避，会话内容也可能靠 loading 图标或右边缘过近。

After：侧边栏操作和显式重试会立即同步，后台刷新在故障期间仍受限流保护，会话内容间距保持一致。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地工作区，运行 Web Shell Vitest 完整测试、仓库 lint、typecheck 和 build。

## 风险与范围

- 主要风险或权衡：显式的侧边栏变更会按设计额外执行一次工作区同步；后台和生命周期驱动的刷新仍然受限流保护。
- 未验证或范围外：未在 Windows 和 Linux 上进行视觉确认；非侧边栏的会话管理流程保持不变。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
