### PR TITLE
test(review): single-encode the diff-read fixture and pin the failed-read gate

### DIFF
--- a/packages/cli/src/commands/review/lib/transcripts.test.ts
+++ b/packages/cli/src/commands/review/lib/transcripts.test.ts
@@ -244,7 +244,11 @@ describe('readTranscripts — defensive parsing', () => {
     // and two look-alikes — a `.bak` sibling and a shell command that only
     // NAMES the diff — refused.
     const b = { agentId: 'a1', agentName: 'general-purpose', sessionId: 'S1' };
-    const call = (name: string, args: object): object[] => [
+    const call = (
+      name: string,
+      args: object,
+      response: object = { output: 'ok' },
+    ): object[] => [
       {
         ...b,
         type: 'assistant',
@@ -255,31 +259,47 @@ describe('readTranscripts — defensive parsing', () => {
         type: 'tool_result',
         message: {
           role: 'user',
-          parts: [{ functionResponse: { name, response: { output: 'ok' } } }],
+          parts: [{ functionResponse: { name, response } }],
         },
       },
     ];
     file(
       'agent-a1.jsonl',
       [
-        JSON.stringify({
+        // A plain object literal like its siblings — pre-stringifying it here
+        // would let the trailing `.map` encode it twice, so `parseTranscript`
+        // parses a bare string and silently drops the launch line.
+        {
           ...b,
           type: 'user',
           message: { role: 'user', parts: [{ text: 'chunk 1 of 1' }] },
-        }),
+        },
         ...call('read_file', { file_path: '/d.txt', offset: 0, limit: 40 }),
         ...call('read_file', { file_path: '/d.txt.bak' }),
         ...call('run_shell_command', { command: 'rm /d.txt' }),
+        // A FAILED read of the diff: names it, but the response is an error.
+        // Hoisting the `diffToolCalls++` / `diffReads.push` out of the
+        // `!isErrorPart` branch would count this as a diff read.
+        ...call(
+          'read_file',
+          { file_path: '/d.txt', offset: 40, limit: 40 },
+          { error: 'denied' },
+        ),
       ]
         .map((r) => JSON.stringify(r))
         .join('\n') + '\n',
     );
     const [rec] = readTranscripts(undefined, ENV, '/d.txt');
+    // The launch line survived — proof the fixture is single-encoded.
+    expect(rec.launchPrompt).toBe('chunk 1 of 1');
+    // Only the ONE successful, exact-path read counts: not the `.bak`
+    // sibling, not the shell mention, not the denied read.
     expect(rec.diffToolCalls).toBe(1);
     // The RANGE too, not only the count: `range` is wired through the same
     // `namedTheDiff` decision, so dropping that wiring leaves the count
     // right and every chunk-coverage ruling — which reads the lines, not
-    // the tally — with nothing to rule on.
+    // the tally — with nothing to rule on. The denied read's [41, 80] is
+    // absent, pinning the success gate on `diffReads` as well.
     expect(rec.diffReads).toEqual([[1, 40]]);
     // And with no diffPath the field stays 0, whatever was read.
     expect(readTranscripts(undefined, ENV)[0].diffToolCalls).toBe(0);

--- a/packages/cli/src/commands/review/lib/transcripts.test.ts
+++ b/packages/cli/src/commands/review/lib/transcripts.test.ts
@@ -301,6 +301,11 @@ describe('readTranscripts — defensive parsing', () => {
     // the tally — with nothing to rule on. The denied read's [41, 80] is
     // absent, pinning the success gate on `diffReads` as well.
     expect(rec.diffReads).toEqual([[1, 40]]);
+    // The same gate guards the evidence lists the certification atoms read
+    // (`openedBrief`, `readBrief`, `readFindingsPointer`): the denied read
+    // must stay out of them too, not only out of the diff fields.
+    expect(rec.successfulCallArgs).toHaveLength(3);
+    expect(rec.successfulReadFileArgs).toHaveLength(2);
     // And with no diffPath the field stays 0, whatever was read.
     expect(readTranscripts(undefined, ENV)[0].diffToolCalls).toBe(0);
   });


### PR DESCRIPTION
## What this PR does

Two follow-up fixes to the diff-read test added in #9484 (`transcripts.test.ts`): single-encode the fixture's launch line, and pin the success-gating of `diffToolCalls`/`diffReads` against a failed diff read.

## Why it's needed

The fixture's first JSONL entry was `JSON.stringify({...})` before the trailing `.map((r) => JSON.stringify(r))` encoded every line a second time, so `parseTranscript` parsed a bare string and silently dropped the launch line — the record's `launchPrompt` was `''`, unlike every sibling fixture. The test passed only because it read `diffToolCalls`/`diffReads`; anyone extending or copying the pattern would hit an invisible `expected '' to be 'chunk 1 of 1'`. Separately, no fixture combined a diff-naming `read_file` with an error response, so a mutation hoisting `diffToolCalls++` / `diffReads.push` out of the `!isErrorPart` branch would ship green — a denied read of the diff would then count as a diff read, and retirement / layer-audit / coverage would credit chunk territory to an agent that read nothing.

## Reviewer Test Plan

### How to verify

`cd packages/cli && npx vitest run src/commands/review/lib/transcripts.test.ts src/commands/review/lib/certification.test.ts` — 60 pass. The launch line is now a plain object literal (`.map` encodes it once), and `rec.launchPrompt` is asserted `'chunk 1 of 1'`. A fourth call — `read_file` of `/d.txt` answered with `{ error: 'denied' }` — is added, with `diffToolCalls` asserted `1` and `diffReads` asserted `[[1, 40]]` (the denied read's `[41, 80]` absent). Both assertions flip red under the respective mutations the #9484 review witnessed.

### Evidence (Before & After)

N/A — test-only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: none — test-only, strengthens an existing test.
- Not validated / out of scope: N/A.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #9484.

<details>
<summary>中文说明</summary>

#9484 里加的 diff-read 测试的两处跟进修复（`transcripts.test.ts`）：把 fixture 的 launch 行改成单次编码，并补上「失败的 diff 读取不计入」的 success-gating 钉子。

原来 fixture 第一条 JSONL 是 `JSON.stringify({...})`，又被结尾的 `.map((r) => JSON.stringify(r))` 二次编码，于是 `parseTranscript` 解析出一个裸字符串并静默丢弃这条 launch 行——`launchPrompt` 变成 `''`，和其它兄弟 fixture 不一致。测试之所以通过，只因为它读的是 `diffToolCalls`/`diffReads`；任何扩展或照抄此模式的人都会撞上看不出原因的 `expected '' to be 'chunk 1 of 1'`。另外，没有任何 fixture 把「命名 diff 的 read_file」与错误响应组合，于是把 `diffToolCalls++` / `diffReads.push` 从 `!isErrorPart` 分支里提出去的变异能全绿通过——一次被拒绝的 diff 读取就会被算作 diff 读取，retirement / layer-audit / coverage 会把 chunk territory 记给一个什么都没读的 agent。

改法：launch 行改成普通对象字面量（`.map` 只编码一次）并断言 `launchPrompt`；新增第四个调用——`read_file` 读 `/d.txt` 但响应 `{ error: 'denied' }`——断言 `diffToolCalls` 仍为 `1`、`diffReads` 仍为 `[[1, 40]]`（被拒读取的 `[41, 80]` 不出现）。两条断言分别在 #9484 评审验证过的变异下翻红。`cd packages/cli && npx vitest run …transcripts.test.ts …certification.test.ts` 共 60 通过。

</details>
