### PR TITLE
fix(core): allow hook-bounced workflow reapproval

### DIFF
--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -434,7 +434,7 @@ describe('AgentCore.runInAgentFrames', () => {
 });
 
 describe('AgentCore approval response deduplication', () => {
-  it('allows one response for each hook-bounced approval emission', async () => {
+  it('emits once per approval incarnation and allows each response', async () => {
     const config = {
       getToolRegistry: vi.fn().mockReturnValue({
         getTool: vi.fn(),
@@ -501,6 +501,7 @@ describe('AgentCore approval response deduplication', () => {
           onToolCallsUpdate?: (calls: ToolCall[]) => void;
         };
         scheduler.onToolCallsUpdate?.([firstWaiting]);
+        scheduler.onToolCallsUpdate?.([firstWaiting]);
       });
     const abortController = new AbortController();
 
@@ -511,22 +512,25 @@ describe('AgentCore approval response deduplication', () => {
       1,
       [{ name: request.name } as FunctionDeclaration],
     );
-    await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
-    await Promise.all([
-      approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
-      approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
-    ]);
-    await vi.waitFor(() => expect(approvalEvents).toHaveLength(2));
-    await Promise.all([
-      approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce),
-      approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce),
-    ]);
-    abortController.abort();
-    await processing;
+    try {
+      await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
+      await Promise.all([
+        approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
+        approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
+      ]);
+      await vi.waitFor(() => expect(approvalEvents).toHaveLength(2));
+      await Promise.all([
+        approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce),
+        approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce),
+      ]);
 
-    expect(firstOnConfirm).toHaveBeenCalledOnce();
-    expect(secondOnConfirm).toHaveBeenCalledOnce();
-    scheduleSpy.mockRestore();
+      expect(firstOnConfirm).toHaveBeenCalledOnce();
+      expect(secondOnConfirm).toHaveBeenCalledOnce();
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -462,7 +462,7 @@ describe('AgentCore approval response deduplication', () => {
     return { core, errorSpy };
   }
 
-  it('retries an approval incarnation when event delivery throws', async () => {
+  it('automatically retries an approval after transient delivery failure', async () => {
     const { core, errorSpy } = buildApprovalCore();
     const deliveryError = new Error('approval listener failed');
     let shouldThrow = true;
@@ -502,7 +502,6 @@ describe('AgentCore approval response deduplication', () => {
           onToolCallsUpdate?: (calls: ToolCall[]) => void;
         };
         scheduler.onToolCallsUpdate?.([waiting]);
-        scheduler.onToolCallsUpdate?.([waiting]);
       });
     const abortController = new AbortController();
 
@@ -516,9 +515,354 @@ describe('AgentCore approval response deduplication', () => {
     try {
       await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
       expect(errorSpy).toHaveBeenCalledWith(
-        'Approval event delivery failed for call-retry; will retry on next tool update',
+        expect.stringContaining(
+          'Approval event delivery failed for call-retry',
+        ),
         deliveryError,
       );
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+    }
+  });
+
+  it('bounds automatic approval delivery retries', async () => {
+    vi.useFakeTimers();
+    const { core } = buildApprovalCore();
+    const deliveryError = new Error('approval listener always fails');
+    let attempts = 0;
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
+      attempts++;
+      throw deliveryError;
+    });
+
+    const request = {
+      callId: 'call-bounded-retry',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-bounded-retry',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: vi.fn(async () => {}),
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      await vi.runAllTimersAsync();
+      expect(attempts).toBe(3);
+      const scheduler = scheduleSpy.mock.instances[0] as unknown as {
+        onToolCallsUpdate?: (calls: ToolCall[]) => void;
+      };
+      const siblingRequest = {
+        callId: 'call-sibling',
+        name: 'Shell',
+        args: { command: 'pwd' },
+        isClientInitiated: true,
+        prompt_id: 'prompt-bounded-retry',
+      };
+      scheduler.onToolCallsUpdate?.([
+        waiting,
+        {
+          status: 'scheduled',
+          request: siblingRequest,
+        } as unknown as ToolCall,
+      ]);
+      scheduler.onToolCallsUpdate?.([
+        waiting,
+        {
+          status: 'executing',
+          request: siblingRequest,
+        } as unknown as ToolCall,
+      ]);
+      expect(attempts).toBe(3);
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels a pending delivery retry when the approval settles', async () => {
+    vi.useFakeTimers();
+    const { core } = buildApprovalCore();
+    let attempts = 0;
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
+      attempts++;
+      throw new Error('approval listener failed');
+    });
+
+    const request = {
+      callId: 'call-settled-retry',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-settled-retry',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: vi.fn(async () => {}),
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+        scheduler.onToolCallsUpdate?.([]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      await vi.runAllTimersAsync();
+      expect(attempts).toBe(1);
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('shares one response latch across partial delivery retries', async () => {
+    const { core } = buildApprovalCore();
+    const retainedEvents: AgentApprovalRequestEvent[] = [];
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
+      retainedEvents.push(event);
+    });
+    let shouldThrow = true;
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
+      if (shouldThrow) {
+        shouldThrow = false;
+        throw new Error('later listener failed');
+      }
+    });
+    let retryEvent: AgentApprovalRequestEvent | undefined;
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
+      retryEvent = event;
+    });
+
+    const onConfirm = vi.fn(async () => {});
+    const request = {
+      callId: 'call-partial-delivery',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-partial-delivery',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm,
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      await vi.waitFor(() => expect(retryEvent).toBeDefined());
+      expect(retainedEvents).toHaveLength(2);
+      await Promise.all([
+        retainedEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
+        retryEvent!.respond(ToolConfirmationOutcome.ProceedOnce),
+      ]);
+      expect(onConfirm).toHaveBeenCalledOnce();
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+    }
+  });
+
+  it('rejects an old approval after the call bounces to a new incarnation', async () => {
+    const { core } = buildApprovalCore();
+    const approvalEvents: AgentApprovalRequestEvent[] = [];
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
+      approvalEvents.push(event);
+    });
+
+    const firstOnConfirm = vi.fn(async () => {});
+    const secondOnConfirm = vi.fn(async () => {});
+    const request = {
+      callId: 'call-stale-approval',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-stale-approval',
+    };
+    const firstWaiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: firstOnConfirm,
+      },
+    } as unknown as WaitingToolCall;
+    const secondWaiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'info',
+        title: 'Hook confirmation',
+        prompt: 'Approve bounced execution?',
+        onConfirm: secondOnConfirm,
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([firstWaiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
+      const scheduler = scheduleSpy.mock.instances[0] as unknown as {
+        onToolCallsUpdate?: (calls: ToolCall[]) => void;
+      };
+      scheduler.onToolCallsUpdate?.([secondWaiting]);
+      await vi.waitFor(() => expect(approvalEvents).toHaveLength(2));
+
+      await approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce);
+      await approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce);
+
+      expect(firstOnConfirm).not.toHaveBeenCalled();
+      expect(secondOnConfirm).toHaveBeenCalledOnce();
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+    }
+  });
+
+  it('creates a new approval when the same details become active again', async () => {
+    const { core } = buildApprovalCore();
+    const approvalEvents: AgentApprovalRequestEvent[] = [];
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
+      approvalEvents.push(event);
+    });
+
+    const onConfirm = vi.fn(async () => {});
+    const request = {
+      callId: 'call-reused-details',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-reused-details',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm,
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      expect(approvalEvents).toHaveLength(1);
+      const scheduler = scheduleSpy.mock.instances[0] as unknown as {
+        onToolCallsUpdate?: (calls: ToolCall[]) => void;
+      };
+      scheduler.onToolCallsUpdate?.([]);
+      scheduler.onToolCallsUpdate?.([waiting]);
+      expect(approvalEvents).toHaveLength(2);
+
+      await approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce);
+      await approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce);
+
+      expect(onConfirm).toHaveBeenCalledOnce();
     } finally {
       abortController.abort();
       await processing;

--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -462,16 +462,19 @@ describe('AgentCore approval response deduplication', () => {
     return { core, errorSpy };
   }
 
-  it('automatically retries an approval after transient delivery failure', async () => {
+  it('retries only a transiently failed listener', async () => {
     const { core, errorSpy } = buildApprovalCore();
     const deliveryError = new Error('approval listener failed');
     let shouldThrow = true;
-    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
+    const transientListener = vi.fn(() => {
       if (shouldThrow) {
         shouldThrow = false;
         throw deliveryError;
       }
     });
+    core
+      .getEventEmitter()
+      .on(AgentEventType.TOOL_WAITING_APPROVAL, transientListener);
     const approvalEvents: AgentApprovalRequestEvent[] = [];
     core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
       approvalEvents.push(event);
@@ -513,7 +516,11 @@ describe('AgentCore approval response deduplication', () => {
       [{ name: request.name } as FunctionDeclaration],
     );
     try {
-      await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
+      await vi.waitFor(() =>
+        expect(transientListener).toHaveBeenCalledTimes(2),
+      );
+      expect(approvalEvents).toHaveLength(1);
+      expect(transientListener).toHaveBeenCalledTimes(2);
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining(
           'Approval event delivery failed for call-retry',
@@ -527,15 +534,74 @@ describe('AgentCore approval response deduplication', () => {
     }
   });
 
-  it('bounds automatic approval delivery retries', async () => {
-    vi.useFakeTimers();
+  it('continues past a thrower before a healthy listener', async () => {
     const { core } = buildApprovalCore();
     const deliveryError = new Error('approval listener always fails');
-    let attempts = 0;
-    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
-      attempts++;
+    const thrower = vi.fn(() => {
       throw deliveryError;
     });
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, thrower);
+    const healthyListener = vi.fn();
+    core
+      .getEventEmitter()
+      .on(AgentEventType.TOOL_WAITING_APPROVAL, healthyListener);
+
+    const request = {
+      callId: 'call-bounded-retry',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-bounded-retry',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: vi.fn(async () => {}),
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      expect(thrower).toHaveBeenCalledOnce();
+      expect(healthyListener).toHaveBeenCalledOnce();
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+    }
+  });
+
+  it('bounds persistent listener retries and reports exhaustion', async () => {
+    vi.useFakeTimers();
+    const { core, errorSpy } = buildApprovalCore();
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const deliveryError = new Error('approval listener always fails');
+    const thrower = vi.fn(() => {
+      throw deliveryError;
+    });
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, thrower);
 
     const request = {
       callId: 'call-bounded-retry',
@@ -574,7 +640,14 @@ describe('AgentCore approval response deduplication', () => {
     );
     try {
       await vi.runAllTimersAsync();
-      expect(attempts).toBe(3);
+      expect(thrower).toHaveBeenCalledTimes(3);
+      expect(errorSpy).toHaveBeenCalledTimes(3);
+      expect(consoleErrorSpy).toHaveBeenCalledOnce();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Approval event delivery for call-bounded-retry exhausted 3 attempts for 1 listener',
+        ),
+      );
       const scheduler = scheduleSpy.mock.instances[0] as unknown as {
         onToolCallsUpdate?: (calls: ToolCall[]) => void;
       };
@@ -599,11 +672,12 @@ describe('AgentCore approval response deduplication', () => {
           request: siblingRequest,
         } as unknown as ToolCall,
       ]);
-      expect(attempts).toBe(3);
+      expect(thrower).toHaveBeenCalledTimes(3);
     } finally {
       abortController.abort();
       await processing;
       scheduleSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
       vi.useRealTimers();
     }
   });
@@ -664,19 +738,22 @@ describe('AgentCore approval response deduplication', () => {
     }
   });
 
-  it('shares one response latch across partial delivery retries', async () => {
+  it('does not duplicate a healthy listener before a failed listener', async () => {
     const { core } = buildApprovalCore();
     const retainedEvents: AgentApprovalRequestEvent[] = [];
     core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
       retainedEvents.push(event);
     });
     let shouldThrow = true;
-    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
+    const transientListener = vi.fn(() => {
       if (shouldThrow) {
         shouldThrow = false;
         throw new Error('later listener failed');
       }
     });
+    core
+      .getEventEmitter()
+      .on(AgentEventType.TOOL_WAITING_APPROVAL, transientListener);
     let retryEvent: AgentApprovalRequestEvent | undefined;
     core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
       retryEvent = event;
@@ -719,8 +796,12 @@ describe('AgentCore approval response deduplication', () => {
       [{ name: request.name } as FunctionDeclaration],
     );
     try {
-      await vi.waitFor(() => expect(retryEvent).toBeDefined());
-      expect(retainedEvents).toHaveLength(2);
+      await vi.waitFor(() =>
+        expect(transientListener).toHaveBeenCalledTimes(2),
+      );
+      expect(retryEvent).toBeDefined();
+      expect(retainedEvents).toHaveLength(1);
+      expect(transientListener).toHaveBeenCalledTimes(2);
       await Promise.all([
         retainedEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
         retryEvent!.respond(ToolConfirmationOutcome.ProceedOnce),
@@ -730,6 +811,123 @@ describe('AgentCore approval response deduplication', () => {
       abortController.abort();
       await processing;
       scheduleSpy.mockRestore();
+    }
+  });
+
+  it('cancels a pending delivery retry on abort', async () => {
+    vi.useFakeTimers();
+    const { core } = buildApprovalCore();
+    const thrower = vi.fn(() => {
+      throw new Error('approval listener failed');
+    });
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, thrower);
+
+    const request = {
+      callId: 'call-aborted-retry',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-aborted-retry',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: vi.fn(async () => {}),
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      expect(thrower).toHaveBeenCalledOnce();
+      abortController.abort();
+      await processing;
+      await vi.runAllTimersAsync();
+      expect(thrower).toHaveBeenCalledOnce();
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels a pending delivery retry when all tool calls complete', async () => {
+    vi.useFakeTimers();
+    const { core } = buildApprovalCore();
+    const thrower = vi.fn(() => {
+      throw new Error('approval listener failed');
+    });
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, thrower);
+
+    const request = {
+      callId: 'call-completed-retry',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-completed-retry',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: vi.fn(async () => {}),
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      expect(thrower).toHaveBeenCalledOnce();
+      const scheduler = scheduleSpy.mock.instances[0] as unknown as {
+        onAllToolCallsComplete?: (calls: ToolCall[]) => Promise<void>;
+      };
+      await scheduler.onAllToolCallsComplete?.([]);
+      await processing;
+      await vi.runAllTimersAsync();
+      expect(thrower).toHaveBeenCalledOnce();
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+      vi.useRealTimers();
     }
   });
 

--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -434,6 +434,82 @@ describe('AgentCore.runInAgentFrames', () => {
 });
 
 describe('AgentCore approval response deduplication', () => {
+  it('retries an approval incarnation when event delivery throws', async () => {
+    const config = {
+      getToolRegistry: vi.fn().mockReturnValue({
+        getTool: vi.fn(),
+      }),
+      getDebugLogger: vi.fn().mockReturnValue({ debug: vi.fn() }),
+      getToolOutputBatchBudget: vi
+        .fn()
+        .mockReturnValue(Number.POSITIVE_INFINITY),
+      getToolResultBytesWritten: vi.fn().mockReturnValue(0),
+      getSessionId: vi.fn().mockReturnValue('approval-session'),
+    } as unknown as Config;
+    const core = new AgentCore(
+      'approval-agent',
+      config,
+      { systemPrompt: '' },
+      { model: 'test-model' },
+      { max_turns: 1 },
+    );
+    let shouldThrow = true;
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
+      if (shouldThrow) {
+        shouldThrow = false;
+        throw new Error('approval listener failed');
+      }
+    });
+    const approvalEvents: AgentApprovalRequestEvent[] = [];
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
+      approvalEvents.push(event);
+    });
+
+    const request = {
+      callId: 'call-retry',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-retry',
+    };
+    const waiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: vi.fn(async () => {}),
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([waiting]);
+        scheduler.onToolCallsUpdate?.([waiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    try {
+      await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
+    } finally {
+      abortController.abort();
+      await processing;
+      scheduleSpy.mockRestore();
+    }
+  });
+
   it('emits once per approval incarnation and allows each response', async () => {
     const config = {
       getToolRegistry: vi.fn().mockReturnValue({

--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -434,12 +434,18 @@ describe('AgentCore.runInAgentFrames', () => {
 });
 
 describe('AgentCore approval response deduplication', () => {
-  it('retries an approval incarnation when event delivery throws', async () => {
+  function buildApprovalCore(): {
+    core: AgentCore;
+    errorSpy: ReturnType<typeof vi.fn>;
+  } {
+    const errorSpy = vi.fn();
     const config = {
       getToolRegistry: vi.fn().mockReturnValue({
         getTool: vi.fn(),
       }),
-      getDebugLogger: vi.fn().mockReturnValue({ debug: vi.fn() }),
+      getDebugLogger: vi
+        .fn()
+        .mockReturnValue({ debug: vi.fn(), error: errorSpy }),
       getToolOutputBatchBudget: vi
         .fn()
         .mockReturnValue(Number.POSITIVE_INFINITY),
@@ -453,11 +459,17 @@ describe('AgentCore approval response deduplication', () => {
       { model: 'test-model' },
       { max_turns: 1 },
     );
+    return { core, errorSpy };
+  }
+
+  it('retries an approval incarnation when event delivery throws', async () => {
+    const { core, errorSpy } = buildApprovalCore();
+    const deliveryError = new Error('approval listener failed');
     let shouldThrow = true;
     core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, () => {
       if (shouldThrow) {
         shouldThrow = false;
-        throw new Error('approval listener failed');
+        throw deliveryError;
       }
     });
     const approvalEvents: AgentApprovalRequestEvent[] = [];
@@ -503,6 +515,10 @@ describe('AgentCore approval response deduplication', () => {
     );
     try {
       await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Approval event delivery failed for call-retry; will retry on next tool update',
+        deliveryError,
+      );
     } finally {
       abortController.abort();
       await processing;
@@ -511,24 +527,7 @@ describe('AgentCore approval response deduplication', () => {
   });
 
   it('emits once per approval incarnation and allows each response', async () => {
-    const config = {
-      getToolRegistry: vi.fn().mockReturnValue({
-        getTool: vi.fn(),
-      }),
-      getDebugLogger: vi.fn().mockReturnValue({ debug: vi.fn() }),
-      getToolOutputBatchBudget: vi
-        .fn()
-        .mockReturnValue(Number.POSITIVE_INFINITY),
-      getToolResultBytesWritten: vi.fn().mockReturnValue(0),
-      getSessionId: vi.fn().mockReturnValue('approval-session'),
-    } as unknown as Config;
-    const core = new AgentCore(
-      'approval-agent',
-      config,
-      { systemPrompt: '' },
-      { model: 'test-model' },
-      { max_turns: 1 },
-    );
+    const { core } = buildApprovalCore();
     const approvalEvents: AgentApprovalRequestEvent[] = [];
     core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
       approvalEvents.push(event);

--- a/packages/core/src/agents/runtime/agent-core.test.ts
+++ b/packages/core/src/agents/runtime/agent-core.test.ts
@@ -52,6 +52,16 @@ import {
 import { GeminiChat } from '../../core/geminiChat.js';
 import { ContextState } from './agent-headless.js';
 import type { ToolResultBoundaryObservation } from '../../utils/tool-result-boundary-diagnostics.js';
+import {
+  CoreToolScheduler,
+  type ToolCall,
+  type WaitingToolCall,
+} from '../../core/coreToolScheduler.js';
+import { ToolConfirmationOutcome } from '../../tools/tools.js';
+import {
+  AgentEventType,
+  type AgentApprovalRequestEvent,
+} from './agent-events.js';
 
 const boundaryObserveMock = vi.hoisted(() =>
   vi.fn((_observation: ToolResultBoundaryObservation) => false),
@@ -420,6 +430,103 @@ describe('AgentCore.runInAgentFrames', () => {
     }, otherView);
 
     expect(observed).toBe(ownView);
+  });
+});
+
+describe('AgentCore approval response deduplication', () => {
+  it('allows one response for each hook-bounced approval emission', async () => {
+    const config = {
+      getToolRegistry: vi.fn().mockReturnValue({
+        getTool: vi.fn(),
+      }),
+      getDebugLogger: vi.fn().mockReturnValue({ debug: vi.fn() }),
+      getToolOutputBatchBudget: vi
+        .fn()
+        .mockReturnValue(Number.POSITIVE_INFINITY),
+      getToolResultBytesWritten: vi.fn().mockReturnValue(0),
+      getSessionId: vi.fn().mockReturnValue('approval-session'),
+    } as unknown as Config;
+    const core = new AgentCore(
+      'approval-agent',
+      config,
+      { systemPrompt: '' },
+      { model: 'test-model' },
+      { max_turns: 1 },
+    );
+    const approvalEvents: AgentApprovalRequestEvent[] = [];
+    core.getEventEmitter().on(AgentEventType.TOOL_WAITING_APPROVAL, (event) => {
+      approvalEvents.push(event);
+    });
+
+    const firstOnConfirm = vi.fn(async () => {});
+    const secondOnConfirm = vi.fn(async () => {});
+    const request = {
+      callId: 'call-1',
+      name: 'Shell',
+      args: { command: 'git status' },
+      isClientInitiated: true,
+      prompt_id: 'prompt-1',
+    };
+    const secondWaiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'info',
+        title: 'Hook confirmation',
+        prompt: 'Approve bounced execution?',
+        onConfirm: secondOnConfirm,
+      },
+    } as unknown as WaitingToolCall;
+    const firstWaiting = {
+      status: 'awaiting_approval',
+      request,
+      confirmationDetails: {
+        type: 'exec',
+        title: 'Run command?',
+        command: 'git status',
+        rootCommand: 'git status',
+        onConfirm: vi.fn(async () => {
+          await firstOnConfirm();
+          const scheduler = scheduleSpy.mock.instances[0] as unknown as {
+            onToolCallsUpdate?: (calls: ToolCall[]) => void;
+          };
+          scheduler.onToolCallsUpdate?.([secondWaiting]);
+        }),
+      },
+    } as unknown as WaitingToolCall;
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(async function (this: CoreToolScheduler) {
+        const scheduler = this as unknown as {
+          onToolCallsUpdate?: (calls: ToolCall[]) => void;
+        };
+        scheduler.onToolCallsUpdate?.([firstWaiting]);
+      });
+    const abortController = new AbortController();
+
+    const processing = core.processFunctionCalls(
+      [{ id: request.callId, name: request.name, args: request.args }],
+      abortController,
+      request.prompt_id,
+      1,
+      [{ name: request.name } as FunctionDeclaration],
+    );
+    await vi.waitFor(() => expect(approvalEvents).toHaveLength(1));
+    await Promise.all([
+      approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
+      approvalEvents[0].respond(ToolConfirmationOutcome.ProceedOnce),
+    ]);
+    await vi.waitFor(() => expect(approvalEvents).toHaveLength(2));
+    await Promise.all([
+      approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce),
+      approvalEvents[1].respond(ToolConfirmationOutcome.ProceedOnce),
+    ]);
+    abortController.abort();
+    await processing;
+
+    expect(firstOnConfirm).toHaveBeenCalledOnce();
+    expect(secondOnConfirm).toHaveBeenCalledOnce();
+    scheduleSpy.mockRestore();
   });
 });
 

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -101,6 +101,7 @@ import type {
   AgentUsageEvent,
   AgentHooks,
   AgentExternalMessageEvent,
+  AgentApprovalRequestEvent,
 } from './agent-events.js';
 import { AgentEventEmitter, AgentEventType } from './agent-events.js';
 import { AgentStatistics, type AgentStatsSummary } from './agent-statistics.js';
@@ -127,6 +128,18 @@ import {
 
 const EXECUTION_ALLOWLIST_ERROR_MAX_ITEMS = 8;
 const EXECUTION_ALLOWLIST_ERROR_MAX_CHARS = 240;
+const APPROVAL_DELIVERY_MAX_ATTEMPTS = 3;
+
+interface ApprovalDeliveryState {
+  readonly callId: string;
+  readonly confirmationDetails: ToolCallConfirmationDetails;
+  event: AgentApprovalRequestEvent;
+  attempts: number;
+  delivered: boolean;
+  responded: boolean;
+  active: boolean;
+  retryTimer?: ReturnType<typeof setTimeout>;
+}
 
 function summarizeExecutionAllowlist(
   executionAllowedTools: readonly string[],
@@ -1728,10 +1741,64 @@ export class AgentCore {
     // onToolCallsUpdate only fires the transition event once per callId even
     // though the callback runs repeatedly while the tool executes.
     const executionStartedEmitted = new Set<string>();
-    const emittedApprovalDetails = new Map<
-      string,
-      ToolCallConfirmationDetails
+    const approvalDeliveryByDetails = new WeakMap<
+      ToolCallConfirmationDetails,
+      ApprovalDeliveryState
     >();
+    const currentApprovalDeliveries = new Map<string, ApprovalDeliveryState>();
+    const retireApprovalDelivery = (state: ApprovalDeliveryState) => {
+      state.active = false;
+      if (state.retryTimer !== undefined) {
+        clearTimeout(state.retryTimer);
+        state.retryTimer = undefined;
+      }
+    };
+    const clearApprovalDeliveries = () => {
+      for (const state of currentApprovalDeliveries.values()) {
+        retireApprovalDelivery(state);
+      }
+      currentApprovalDeliveries.clear();
+    };
+    const deliverApproval = (state: ApprovalDeliveryState) => {
+      if (
+        !state.active ||
+        state.delivered ||
+        state.responded ||
+        state.attempts >= APPROVAL_DELIVERY_MAX_ATTEMPTS ||
+        currentApprovalDeliveries.get(state.callId) !== state
+      ) {
+        return;
+      }
+      state.attempts++;
+      try {
+        this.eventEmitter.emit(
+          AgentEventType.TOOL_WAITING_APPROVAL,
+          state.event,
+        );
+        state.delivered = true;
+      } catch (error) {
+        const canRetry =
+          state.active &&
+          !state.responded &&
+          state.attempts < APPROVAL_DELIVERY_MAX_ATTEMPTS;
+        this.runtimeContext
+          .getDebugLogger()
+          ?.error(
+            `Approval event delivery failed for ${state.callId}; ${
+              canRetry
+                ? 'retrying automatically'
+                : 'automatic retries exhausted'
+            }`,
+            error,
+          );
+        if (canRetry) {
+          state.retryTimer = setTimeout(() => {
+            state.retryTimer = undefined;
+            deliverApproval(state);
+          }, 0);
+        }
+      }
+    };
     const scheduler = new CoreToolScheduler({
       config: this.runtimeContext,
       shouldObserveProducer: (callId) => !emittedCallIds.has(callId),
@@ -1751,6 +1818,7 @@ export class AgentCore {
         } as AgentToolOutputUpdateEvent);
       },
       onAllToolCallsComplete: async (completedCalls) => {
+        clearApprovalDeliveries();
         for (const call of completedCalls) {
           if (emittedCallIds.has(call.request.callId)) continue;
           emittedCallIds.add(call.request.callId);
@@ -1812,6 +1880,21 @@ export class AgentCore {
         resolveBatch?.();
       },
       onToolCallsUpdate: (calls: ToolCall[]) => {
+        const awaitingByCallId = new Map(
+          calls
+            .filter(
+              (call): call is WaitingToolCall =>
+                call.status === 'awaiting_approval',
+            )
+            .map((call) => [call.request.callId, call.confirmationDetails]),
+        );
+        for (const [callId, state] of currentApprovalDeliveries) {
+          if (awaitingByCallId.get(callId) !== state.confirmationDetails) {
+            retireApprovalDelivery(state);
+            currentApprovalDeliveries.delete(callId);
+          }
+        }
+
         for (const call of calls) {
           // Track PTY PIDs so TOOL_OUTPUT_UPDATE events can carry them.
           if (call.status === 'executing') {
@@ -1853,11 +1936,10 @@ export class AgentCore {
 
           // Emit approval request event for UI visibility
           const callId = waiting.request.callId;
-          try {
-            const { confirmationDetails } = waiting;
-            if (emittedApprovalDetails.get(callId) === confirmationDetails) {
-              continue;
-            }
+          const { confirmationDetails } = waiting;
+          let deliveryState =
+            approvalDeliveryByDetails.get(confirmationDetails);
+          if (!deliveryState || !deliveryState.active) {
             const { onConfirm: _onConfirm, ...rest } = confirmationDetails;
             // Snapshot the ambient runtime view here, while the loop frame
             // is still live. For inheriting agents (no own runtimeView)
@@ -1875,50 +1957,68 @@ export class AgentCore {
             // can restore it. See `runInAgentFrames` for why this matters
             // (mis-attributed `from="leader"` + leader-guard bypass).
             const inheritedTeammateIdentity = getTeammateContext();
-            let responded = false;
-            this.eventEmitter?.emit(AgentEventType.TOOL_WAITING_APPROVAL, {
-              subagentId: this.subagentId,
-              round: currentRound,
-              callId: waiting.request.callId,
-              name: waiting.request.name,
-              description: this.getToolDescription(
-                waiting.request.name,
-                waiting.request.args,
-              ),
-              args: waiting.request.args,
-              confirmationDetails: rest,
-              respond: async (
-                outcome: ToolConfirmationOutcome,
-                payload?: Parameters<
-                  ToolCallConfirmationDetails['onConfirm']
-                >[1],
-              ) => {
-                if (responded) return;
-                responded = true;
-                // UI invokes this from its own async chain (outside the
-                // reasoning-loop ALS frames), so re-enter both the agent's
-                // runtime view AND its name context before the resumed
-                // tool body runs. See `runInAgentFrames` for rationale.
-                // Also restore the logical owner agent id when present so
-                // approved tools such as Monitor keep owner routing.
-                await this.runInAgentFrames(
-                  () => waiting.confirmationDetails.onConfirm(outcome, payload),
-                  inheritedView,
-                  inheritedAgentId ?? undefined,
-                  inheritedTeammateIdentity,
-                  inheritedAgentDepth,
-                );
+            const newDeliveryState: ApprovalDeliveryState = {
+              callId,
+              confirmationDetails,
+              attempts: 0,
+              delivered: false,
+              responded: false,
+              active: true,
+              event: {
+                subagentId: this.subagentId,
+                round: currentRound,
+                callId: waiting.request.callId,
+                name: waiting.request.name,
+                description: this.getToolDescription(
+                  waiting.request.name,
+                  waiting.request.args,
+                ),
+                args: waiting.request.args,
+                confirmationDetails: rest,
+                respond: async (
+                  outcome: ToolConfirmationOutcome,
+                  payload?: Parameters<
+                    ToolCallConfirmationDetails['onConfirm']
+                  >[1],
+                ) => {
+                  if (
+                    newDeliveryState.responded ||
+                    !newDeliveryState.active ||
+                    currentApprovalDeliveries.get(callId) !==
+                      newDeliveryState ||
+                    awaitingByCallId.get(callId) !== confirmationDetails
+                  ) {
+                    return;
+                  }
+                  newDeliveryState.responded = true;
+                  if (newDeliveryState.retryTimer !== undefined) {
+                    clearTimeout(newDeliveryState.retryTimer);
+                    newDeliveryState.retryTimer = undefined;
+                  }
+                  // UI invokes this from its own async chain (outside the
+                  // reasoning-loop ALS frames), so re-enter both the agent's
+                  // runtime view AND its name context before the resumed
+                  // tool body runs. See `runInAgentFrames` for rationale.
+                  // Also restore the logical owner agent id when present so
+                  // approved tools such as Monitor keep owner routing.
+                  await this.runInAgentFrames(
+                    () =>
+                      waiting.confirmationDetails.onConfirm(outcome, payload),
+                    inheritedView,
+                    inheritedAgentId ?? undefined,
+                    inheritedTeammateIdentity,
+                    inheritedAgentDepth,
+                  );
+                },
+                timestamp: Date.now(),
               },
-              timestamp: Date.now(),
-            });
-            emittedApprovalDetails.set(callId, confirmationDetails);
-          } catch (error) {
-            this.runtimeContext
-              .getDebugLogger()
-              ?.error(
-                `Approval event delivery failed for ${callId}; will retry on next tool update`,
-                error,
-              );
+            };
+            deliveryState = newDeliveryState;
+            approvalDeliveryByDetails.set(confirmationDetails, deliveryState);
+          }
+          currentApprovalDeliveries.set(callId, deliveryState);
+          if (deliveryState.retryTimer === undefined) {
+            deliverApproval(deliveryState);
           }
         }
       },
@@ -1980,6 +2080,7 @@ export class AgentCore {
       // Auto-resolve on abort so processFunctionCalls doesn't block forever
       // when tools are awaiting approval or executing without abort support.
       const onAbort = () => {
+        clearApprovalDeliveries();
         resolveBatch?.();
         for (const req of requests) {
           if (emittedCallIds.has(req.callId)) continue;

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -1858,7 +1858,6 @@ export class AgentCore {
             if (emittedApprovalDetails.get(callId) === confirmationDetails) {
               continue;
             }
-            emittedApprovalDetails.set(callId, confirmationDetails);
             const { onConfirm: _onConfirm, ...rest } = confirmationDetails;
             // Snapshot the ambient runtime view here, while the loop frame
             // is still live. For inheriting agents (no own runtimeView)
@@ -1912,6 +1911,7 @@ export class AgentCore {
               },
               timestamp: Date.now(),
             });
+            emittedApprovalDetails.set(callId, confirmationDetails);
           } catch {
             // ignore UI event emission failures
           }

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -102,6 +102,7 @@ import type {
   AgentHooks,
   AgentExternalMessageEvent,
   AgentApprovalRequestEvent,
+  AgentEventListener,
 } from './agent-events.js';
 import { AgentEventEmitter, AgentEventType } from './agent-events.js';
 import { AgentStatistics, type AgentStatsSummary } from './agent-statistics.js';
@@ -138,6 +139,9 @@ interface ApprovalDeliveryState {
   delivered: boolean;
   responded: boolean;
   active: boolean;
+  failedListeners?: Array<
+    AgentEventListener<AgentEventType.TOOL_WAITING_APPROVAL>
+  >;
   retryTimer?: ReturnType<typeof setTimeout>;
 }
 
@@ -1770,33 +1774,44 @@ export class AgentCore {
         return;
       }
       state.attempts++;
-      try {
-        this.eventEmitter.emit(
-          AgentEventType.TOOL_WAITING_APPROVAL,
-          state.event,
-        );
-        state.delivered = true;
-      } catch (error) {
-        const canRetry =
-          state.active &&
-          !state.responded &&
-          state.attempts < APPROVAL_DELIVERY_MAX_ATTEMPTS;
-        this.runtimeContext
-          .getDebugLogger()
-          ?.error(
-            `Approval event delivery failed for ${state.callId}; ${
-              canRetry
-                ? 'retrying automatically'
-                : 'automatic retries exhausted'
-            }`,
-            error,
-          );
-        if (canRetry) {
-          state.retryTimer = setTimeout(() => {
-            state.retryTimer = undefined;
-            deliverApproval(state);
-          }, 0);
+      const listeners =
+        state.failedListeners ??
+        this.eventEmitter.rawListeners(AgentEventType.TOOL_WAITING_APPROVAL);
+      const failedListeners: typeof listeners = [];
+      for (const listener of listeners) {
+        try {
+          listener(state.event);
+        } catch (error) {
+          failedListeners.push(listener);
+          this.runtimeContext
+            .getDebugLogger()
+            ?.error(
+              `Approval event delivery failed for ${state.callId}; ${
+                state.attempts < APPROVAL_DELIVERY_MAX_ATTEMPTS
+                  ? 'retrying automatically'
+                  : 'automatic retries exhausted'
+              }`,
+              error,
+            );
         }
+      }
+      state.failedListeners = failedListeners;
+      if (failedListeners.length === 0) {
+        state.delivered = true;
+        return;
+      }
+      if (state.attempts < APPROVAL_DELIVERY_MAX_ATTEMPTS) {
+        state.retryTimer = setTimeout(() => {
+          state.retryTimer = undefined;
+          deliverApproval(state);
+        }, 0);
+      } else {
+        // eslint-disable-next-line no-console -- retry exhaustion must be visible outside debug sessions
+        console.error(
+          `Approval event delivery for ${state.callId} exhausted ` +
+            `${APPROVAL_DELIVERY_MAX_ATTEMPTS} attempts for ` +
+            `${failedListeners.length} listener${failedListeners.length === 1 ? '' : 's'}`,
+        );
       }
     };
     const scheduler = new CoreToolScheduler({
@@ -1984,9 +1999,7 @@ export class AgentCore {
                   if (
                     newDeliveryState.responded ||
                     !newDeliveryState.active ||
-                    currentApprovalDeliveries.get(callId) !==
-                      newDeliveryState ||
-                    awaitingByCallId.get(callId) !== confirmationDetails
+                    currentApprovalDeliveries.get(callId) !== newDeliveryState
                   ) {
                     return;
                   }

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -1728,6 +1728,10 @@ export class AgentCore {
     // onToolCallsUpdate only fires the transition event once per callId even
     // though the callback runs repeatedly while the tool executes.
     const executionStartedEmitted = new Set<string>();
+    const emittedApprovalDetails = new Map<
+      string,
+      ToolCallConfirmationDetails
+    >();
     const scheduler = new CoreToolScheduler({
       config: this.runtimeContext,
       shouldObserveProducer: (callId) => !emittedCallIds.has(callId),
@@ -1850,6 +1854,11 @@ export class AgentCore {
           // Emit approval request event for UI visibility
           try {
             const { confirmationDetails } = waiting;
+            const callId = waiting.request.callId;
+            if (emittedApprovalDetails.get(callId) === confirmationDetails) {
+              continue;
+            }
+            emittedApprovalDetails.set(callId, confirmationDetails);
             const { onConfirm: _onConfirm, ...rest } = confirmationDetails;
             // Snapshot the ambient runtime view here, while the loop frame
             // is still live. For inheriting agents (no own runtimeView)

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -1852,9 +1852,9 @@ export class AgentCore {
           const waiting = call as WaitingToolCall;
 
           // Emit approval request event for UI visibility
+          const callId = waiting.request.callId;
           try {
             const { confirmationDetails } = waiting;
-            const callId = waiting.request.callId;
             if (emittedApprovalDetails.get(callId) === confirmationDetails) {
               continue;
             }
@@ -1912,8 +1912,13 @@ export class AgentCore {
               timestamp: Date.now(),
             });
             emittedApprovalDetails.set(callId, confirmationDetails);
-          } catch {
-            // ignore UI event emission failures
+          } catch (error) {
+            this.runtimeContext
+              .getDebugLogger()
+              ?.error(
+                `Approval event delivery failed for ${callId}; will retry on next tool update`,
+                error,
+              );
           }
         }
       },

--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -1718,7 +1718,6 @@ export class AgentCore {
     }
 
     // Build scheduler
-    const responded = new Set<string>();
     let resolveBatch: (() => void) | null = null;
     const emittedCallIds = new Set<string>();
     // pidMap: callId → PTY PID, populated by onToolCallsUpdate when a shell
@@ -1868,6 +1867,7 @@ export class AgentCore {
             // can restore it. See `runInAgentFrames` for why this matters
             // (mis-attributed `from="leader"` + leader-guard bypass).
             const inheritedTeammateIdentity = getTeammateContext();
+            let responded = false;
             this.eventEmitter?.emit(AgentEventType.TOOL_WAITING_APPROVAL, {
               subagentId: this.subagentId,
               round: currentRound,
@@ -1885,8 +1885,8 @@ export class AgentCore {
                   ToolCallConfirmationDetails['onConfirm']
                 >[1],
               ) => {
-                if (responded.has(waiting.request.callId)) return;
-                responded.add(waiting.request.callId);
+                if (responded) return;
+                responded = true;
                 // UI invokes this from its own async chain (outside the
                 // reasoning-loop ALS frames), so re-enter both the agent's
                 // runtime view AND its name context before the resumed

--- a/packages/core/src/agents/runtime/agent-events.ts
+++ b/packages/core/src/agents/runtime/agent-events.ts
@@ -253,6 +253,10 @@ export interface AgentEventMap {
   [AgentEventType.STATUS_CHANGE]: AgentStatusChangeEvent;
 }
 
+export type AgentEventListener<E extends keyof AgentEventMap> = (
+  payload: AgentEventMap[E],
+) => void;
+
 // ─── Event Emitter ──────────────────────────────────────────
 
 export class AgentEventEmitter {
@@ -260,16 +264,22 @@ export class AgentEventEmitter {
 
   on<E extends keyof AgentEventMap>(
     event: E,
-    listener: (payload: AgentEventMap[E]) => void,
+    listener: AgentEventListener<E>,
   ): void {
     this.ee.on(event, listener as (...args: unknown[]) => void);
   }
 
   off<E extends keyof AgentEventMap>(
     event: E,
-    listener: (payload: AgentEventMap[E]) => void,
+    listener: AgentEventListener<E>,
   ): void {
     this.ee.off(event, listener as (...args: unknown[]) => void);
+  }
+
+  rawListeners<E extends keyof AgentEventMap>(
+    event: E,
+  ): Array<AgentEventListener<E>> {
+    return this.ee.rawListeners(event) as Array<AgentEventListener<E>>;
   }
 
   emit<E extends keyof AgentEventMap>(

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -427,6 +427,129 @@ describe('WorkflowRunRegistry', () => {
     expect(event.respond).not.toHaveBeenCalled();
   });
 
+  it('allows the same source to retry after an approval is rejected', async () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_rejected_retry'));
+    const emitter = new AgentEventEmitter();
+    const rejectedRespond = vi.fn(async () => {});
+    r.bridgeApprovalEvents('wf_rejected_retry', emitter);
+
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({ respond: rejectedRespond }),
+    );
+    await vi.waitFor(() => {
+      expect(rejectedRespond).toHaveBeenCalledWith(
+        ToolConfirmationOutcome.Cancel,
+      );
+    });
+
+    r.setApprovalChangeCallback(() => {});
+    const retryRespond = vi.fn(async () => {});
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({
+        respond: retryRespond,
+        timestamp: 1_700_000_000_200,
+      }),
+    );
+
+    expect(r.get('wf_rejected_retry')?.pendingApprovals).toMatchObject([
+      {
+        subagentId: 'workflow-agent-a',
+        callId: 'call-1',
+        at: 1_700_000_000_200,
+      },
+    ]);
+    expect(retryRespond).not.toHaveBeenCalled();
+  });
+
+  it('allows the same source to retry after TOOL_RESULT clears it', () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_tool_result_retry'));
+    r.setApprovalChangeCallback(() => {});
+    const emitter = new AgentEventEmitter();
+    const firstRespond = vi.fn(async () => {});
+    r.bridgeApprovalEvents('wf_tool_result_retry', emitter);
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({ respond: firstRespond }),
+    );
+    emitter.emit(AgentEventType.TOOL_RESULT, {
+      subagentId: 'workflow-agent-a',
+      round: 1,
+      callId: 'call-1',
+      name: 'Shell',
+      success: true,
+      timestamp: 1_700_000_000_200,
+    });
+
+    const retryRespond = vi.fn(async () => {});
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({
+        respond: retryRespond,
+        timestamp: 1_700_000_000_300,
+      }),
+    );
+
+    expect(r.get('wf_tool_result_retry')?.pendingApprovals).toMatchObject([
+      {
+        subagentId: 'workflow-agent-a',
+        callId: 'call-1',
+        at: 1_700_000_000_300,
+      },
+    ]);
+    expect(firstRespond).not.toHaveBeenCalled();
+    expect(retryRespond).not.toHaveBeenCalled();
+  });
+
+  it('does not let an active duplicate block a later retry', async () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_duplicate_retry'));
+    r.setApprovalChangeCallback(() => {});
+    const firstEmitter = new AgentEventEmitter();
+    const duplicateEmitter = new AgentEventEmitter();
+    const firstRespond = vi.fn(async () => {});
+    const duplicateRespond = vi.fn(async () => {});
+    r.bridgeApprovalEvents('wf_duplicate_retry', firstEmitter);
+    r.bridgeApprovalEvents('wf_duplicate_retry', duplicateEmitter);
+
+    firstEmitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({ respond: firstRespond }),
+    );
+    duplicateEmitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({ respond: duplicateRespond }),
+    );
+    r.cancel('wf_duplicate_retry', 2_000);
+    await vi.waitFor(() => {
+      expect(firstRespond).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel);
+    });
+    r.register(reg('wf_duplicate_retry'));
+
+    const retryRespond = vi.fn(async () => {});
+    duplicateEmitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({
+        respond: retryRespond,
+        timestamp: 1_700_000_000_200,
+      }),
+    );
+
+    expect(r.get('wf_duplicate_retry')?.pendingApprovals).toMatchObject([
+      {
+        subagentId: 'workflow-agent-a',
+        callId: 'call-1',
+        at: 1_700_000_000_200,
+      },
+    ]);
+    expect(firstRespond).toHaveBeenCalledOnce();
+    expect(duplicateRespond).not.toHaveBeenCalled();
+    expect(retryRespond).not.toHaveBeenCalled();
+  });
+
   it('re-parks a hook-bounced approval after the prior emission resolves', async () => {
     const r = new WorkflowRunRegistry();
     r.register(reg('wf_hook_bounce'));

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -25,6 +25,17 @@ import {
   type WorkflowStatus,
 } from './workflow-run-registry.js';
 
+const debugWarn = vi.hoisted(() => vi.fn());
+vi.mock('../utils/debugLogger.js', () => ({
+  createDebugLogger: () => ({
+    isEnabled: () => true,
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: debugWarn,
+    error: vi.fn(),
+  }),
+}));
+
 function reg(
   runId: string,
   overrides: Partial<WorkflowTaskRegistration> = {},
@@ -548,6 +559,64 @@ describe('WorkflowRunRegistry', () => {
     expect(firstRespond).toHaveBeenCalledOnce();
     expect(duplicateRespond).not.toHaveBeenCalled();
     expect(retryRespond).not.toHaveBeenCalled();
+  });
+
+  it('releases the source latch when cancellation rejects an approval', async () => {
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_cancelled_retry'));
+    r.setApprovalChangeCallback(() => {});
+    const emitter = new AgentEventEmitter();
+    const firstRespond = vi.fn(async () => {});
+    r.bridgeApprovalEvents('wf_cancelled_retry', emitter);
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({ respond: firstRespond }),
+    );
+
+    r.cancel('wf_cancelled_retry', 2_000);
+    await vi.waitFor(() => {
+      expect(firstRespond).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel);
+    });
+    r.register(reg('wf_cancelled_retry'));
+
+    const retryRespond = vi.fn(async () => {});
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({
+        respond: retryRespond,
+        timestamp: 1_700_000_000_200,
+      }),
+    );
+
+    expect(r.get('wf_cancelled_retry')?.pendingApprovals).toMatchObject([
+      {
+        subagentId: 'workflow-agent-a',
+        callId: 'call-1',
+        at: 1_700_000_000_200,
+      },
+    ]);
+    expect(firstRespond).toHaveBeenCalledOnce();
+    expect(retryRespond).not.toHaveBeenCalled();
+  });
+
+  it('warns when an active source duplicate is dropped', () => {
+    debugWarn.mockClear();
+    const r = new WorkflowRunRegistry();
+    r.register(reg('wf_duplicate_warning'));
+    r.setApprovalChangeCallback(() => {});
+    const emitter = new AgentEventEmitter();
+    r.bridgeApprovalEvents('wf_duplicate_warning', emitter);
+    emitter.emit(AgentEventType.TOOL_WAITING_APPROVAL, approvalEvent());
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({ timestamp: 1_700_000_000_200 }),
+    );
+
+    expect(debugWarn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Workflow approval re-emission dropped (source still latched)',
+      ),
+    );
   });
 
   it('re-parks a hook-bounced approval after the prior emission resolves', async () => {

--- a/packages/core/src/agents/workflow-run-registry.test.ts
+++ b/packages/core/src/agents/workflow-run-registry.test.ts
@@ -427,26 +427,47 @@ describe('WorkflowRunRegistry', () => {
     expect(event.respond).not.toHaveBeenCalled();
   });
 
-  it('does not re-park a duplicate event after it was resolved', async () => {
+  it('re-parks a hook-bounced approval after the prior emission resolves', async () => {
     const r = new WorkflowRunRegistry();
-    r.register(reg('wf_late_duplicate'));
+    r.register(reg('wf_hook_bounce'));
     r.setApprovalChangeCallback(() => {});
     const emitter = new AgentEventEmitter();
-    const event = approvalEvent();
-    r.bridgeApprovalEvents('wf_late_duplicate', emitter);
-    emitter.emit(AgentEventType.TOOL_WAITING_APPROVAL, event);
-    const approvalId =
-      r.get('wf_late_duplicate')!.pendingApprovals[0].approvalId;
+    const secondRespond = vi.fn(async () => {});
+    const firstRespond = vi.fn(async () => {
+      emitter.emit(
+        AgentEventType.TOOL_WAITING_APPROVAL,
+        approvalEvent({
+          respond: secondRespond,
+          timestamp: 1_700_000_000_200,
+        }),
+      );
+    });
+    r.bridgeApprovalEvents('wf_hook_bounce', emitter);
+    emitter.emit(
+      AgentEventType.TOOL_WAITING_APPROVAL,
+      approvalEvent({ respond: firstRespond }),
+    );
+    const firstApprovalId =
+      r.get('wf_hook_bounce')!.pendingApprovals[0].approvalId;
     await r.resolvePendingApproval(
-      'wf_late_duplicate',
-      approvalId,
+      'wf_hook_bounce',
+      firstApprovalId,
       ToolConfirmationOutcome.ProceedOnce,
     );
 
-    emitter.emit(AgentEventType.TOOL_WAITING_APPROVAL, event);
-
-    expect(r.get('wf_late_duplicate')?.pendingApprovals).toEqual([]);
-    expect(event.respond).toHaveBeenCalledOnce();
+    const secondApproval = r.get('wf_hook_bounce')!.pendingApprovals[0];
+    expect(secondApproval).toMatchObject({
+      subagentId: 'workflow-agent-a',
+      callId: 'call-1',
+      at: 1_700_000_000_200,
+    });
+    await r.resolvePendingApproval(
+      'wf_hook_bounce',
+      secondApproval.approvalId,
+      ToolConfirmationOutcome.ProceedOnce,
+    );
+    expect(firstRespond).toHaveBeenCalledOnce();
+    expect(secondRespond).toHaveBeenCalledOnce();
   });
 
   it('normalizes persistent approval outcomes to cancel', async () => {

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -618,7 +618,12 @@ export class WorkflowRunRegistry {
         if (dispatch) dispatch.subagentId = event.subagentId;
       }
       const sourceKey = JSON.stringify([event.subagentId, event.callId]);
-      if (seenSources.has(sourceKey)) return;
+      if (seenSources.has(sourceKey)) {
+        debugLogger.warn(
+          `Workflow approval re-emission dropped (source still latched): ${runId}/${sourceKey}`,
+        );
+        return;
+      }
       seenSources.add(sourceKey);
       const parked = this.parkPendingApproval(runId, event, dispatchId, () =>
         seenSources.delete(sourceKey),

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -617,11 +617,19 @@ export class WorkflowRunRegistry {
         if (dispatch) dispatch.subagentId = event.subagentId;
       }
       const sourceKey = JSON.stringify([event.subagentId, event.callId]);
-      // Re-emission of an already-settled call: respond is idempotent via
-      // the runtime's responded set, so silently dropping it is safe.
       if (seenSources.has(sourceKey)) return;
       seenSources.add(sourceKey);
-      const parked = this.parkPendingApproval(runId, event, dispatchId);
+      const parked = this.parkPendingApproval(
+        runId,
+        {
+          ...event,
+          respond: async (...args) => {
+            seenSources.delete(sourceKey);
+            await event.respond(...args);
+          },
+        },
+        dispatchId,
+      );
       if (parked === 'duplicate') return;
       if (parked === 'rejected') {
         this.rejectResponder(event.respond);

--- a/packages/core/src/agents/workflow-run-registry.ts
+++ b/packages/core/src/agents/workflow-run-registry.ts
@@ -366,6 +366,7 @@ export type WorkflowApprovalRequestCallback = (
 interface WorkflowApprovalRuntime {
   respond: AgentApprovalRequestEvent['respond'];
   requestController?: AbortController;
+  releaseSource: () => void;
 }
 
 export class WorkflowRunRegistry {
@@ -619,19 +620,15 @@ export class WorkflowRunRegistry {
       const sourceKey = JSON.stringify([event.subagentId, event.callId]);
       if (seenSources.has(sourceKey)) return;
       seenSources.add(sourceKey);
-      const parked = this.parkPendingApproval(
-        runId,
-        {
-          ...event,
-          respond: async (...args) => {
-            seenSources.delete(sourceKey);
-            await event.respond(...args);
-          },
-        },
-        dispatchId,
+      const parked = this.parkPendingApproval(runId, event, dispatchId, () =>
+        seenSources.delete(sourceKey),
       );
-      if (parked === 'duplicate') return;
+      if (parked === 'duplicate') {
+        seenSources.delete(sourceKey);
+        return;
+      }
       if (parked === 'rejected') {
+        seenSources.delete(sourceKey);
         this.rejectResponder(event.respond);
         return;
       }
@@ -670,13 +667,11 @@ export class WorkflowRunRegistry {
       (candidate) => candidate.approvalId === approvalId,
     );
     if (!approval) return false;
-    const runtime = this.approvalRuntimes.get(approvalId);
     this.appendApprovalEvent(entry, approval, 'approval-settled', Date.now());
     entry.pendingApprovals = entry.pendingApprovals.filter(
       (candidate) => candidate !== approval,
     );
-    this.approvalRuntimes.delete(approvalId);
-    runtime?.requestController?.abort();
+    const runtime = this.releaseApprovalRuntime(approvalId);
     this.emitApprovalChange(entry);
     if (!runtime) return false;
     const normalized = normalizeWorkflowApprovalOutcome(outcome);
@@ -724,9 +719,7 @@ export class WorkflowRunRegistry {
     entry.pendingApprovals = entry.pendingApprovals.filter(
       (candidate) => candidate !== approval,
     );
-    const runtime = this.approvalRuntimes.get(approval.approvalId);
-    this.approvalRuntimes.delete(approval.approvalId);
-    runtime?.requestController?.abort();
+    this.releaseApprovalRuntime(approval.approvalId);
     this.emitApprovalChange(entry);
     return true;
   }
@@ -734,7 +727,8 @@ export class WorkflowRunRegistry {
   private parkPendingApproval(
     runId: string,
     event: AgentApprovalRequestEvent,
-    dispatchId?: string,
+    dispatchId: string | undefined,
+    releaseSource: () => void,
   ): string | 'duplicate' | 'rejected' {
     const entry = this.entries.get(runId);
     if (
@@ -794,6 +788,7 @@ export class WorkflowRunRegistry {
     this.approvalRuntimes.set(approvalId, {
       respond: event.respond,
       requestController,
+      releaseSource,
     });
     entry.pendingApprovals = [...entry.pendingApprovals, approval];
     this.appendEvent(entry, {
@@ -834,8 +829,7 @@ export class WorkflowRunRegistry {
         entry.pendingApprovals = entry.pendingApprovals.filter(
           (candidate) => candidate.approvalId !== approvalId,
         );
-        this.approvalRuntimes.delete(approvalId);
-        requestController.abort();
+        this.releaseApprovalRuntime(approvalId);
         this.emitApprovalChange(entry);
         return 'rejected';
       }
@@ -1237,11 +1231,10 @@ export class WorkflowRunRegistry {
     for (const entry of this.entries.values()) {
       this.rejectPendingApprovals(entry.runId);
     }
-    for (const runtime of this.approvalRuntimes.values()) {
-      runtime.requestController?.abort();
-      this.rejectResponder(runtime.respond);
+    for (const approvalId of Array.from(this.approvalRuntimes.keys())) {
+      const runtime = this.releaseApprovalRuntime(approvalId);
+      if (runtime) this.rejectResponder(runtime.respond);
     }
-    this.approvalRuntimes.clear();
     this.entries.clear();
     this.handles.clear();
     if (sample) this.emitStatusChange(sample);
@@ -1389,14 +1382,23 @@ export class WorkflowRunRegistry {
     );
     const runtimes: WorkflowApprovalRuntime[] = [];
     for (const approvalId of rejectedIds) {
-      const runtime = this.approvalRuntimes.get(approvalId);
-      this.approvalRuntimes.delete(approvalId);
+      const runtime = this.releaseApprovalRuntime(approvalId);
       if (!runtime) continue;
-      runtime.requestController?.abort();
       runtimes.push(runtime);
     }
     this.emitApprovalChange(entry);
     for (const runtime of runtimes) this.rejectResponder(runtime.respond);
+  }
+
+  private releaseApprovalRuntime(
+    approvalId: string,
+  ): WorkflowApprovalRuntime | undefined {
+    const runtime = this.approvalRuntimes.get(approvalId);
+    if (!runtime) return undefined;
+    this.approvalRuntimes.delete(approvalId);
+    runtime.releaseSource();
+    runtime.requestController?.abort();
+    return runtime;
   }
 
   private rejectResponder(respond: AgentApprovalRequestEvent['respond']): void {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -10753,6 +10753,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     inputFormat?: InputFormat;
     shouldAvoidPermissionPrompts?: boolean;
     experimentalZedIntegration?: boolean;
+    approvalMode?: ApprovalMode;
     includeSensitiveSpanAttributes?: boolean;
     sensitiveSpanAttributeMaxLength?: number;
     onToolCallsUpdate?: ReturnType<typeof vi.fn>;
@@ -10798,7 +10799,7 @@ describe('CoreToolScheduler telemetry spans', () => {
       getSessionId: () => 'test-session-id',
       getUsageStatisticsEnabled: () => true,
       getDebugMode: () => false,
-      getApprovalMode: () => ApprovalMode.YOLO,
+      getApprovalMode: () => options.approvalMode ?? ApprovalMode.YOLO,
       getPermissionsAllow: () => [],
       getContentGeneratorConfig: () => ({
         model: 'test-model',
@@ -10824,6 +10825,7 @@ describe('CoreToolScheduler telemetry spans', () => {
       getInputFormat: () => options.inputFormat ?? InputFormat.TEXT,
       getExperimentalZedIntegration: () =>
         options.experimentalZedIntegration ?? false,
+      getIdeMode: () => false,
       getShouldAvoidPermissionPrompts: () =>
         options.shouldAvoidPermissionPrompts ?? false,
       getTelemetryIncludeSensitiveSpanAttributes: () =>
@@ -12519,6 +12521,56 @@ describe('CoreToolScheduler telemetry spans', () => {
     const blocked = getBlockedSpans();
     expect(blocked).toHaveLength(1);
     expect(blocked[0].ended).toBe(true);
+  });
+
+  it('creates new confirmation details when a tool bounces after approval', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'ok',
+      returnDisplay: 'ok',
+    });
+    const messageBus = askMessageBus();
+    const approvalDetails: ToolCallConfirmationDetails[] = [];
+    const onToolCallsUpdate = vi.fn((calls: ToolCall[]) => {
+      for (const call of calls) {
+        if (
+          call.request.callId === 'approval-then-bounce' &&
+          call.status === 'awaiting_approval'
+        ) {
+          approvalDetails.push(call.confirmationDetails);
+        }
+      }
+    });
+    const { scheduler } = buildScheduler({
+      tools: [new MockEditTool(execute)],
+      messageBus,
+      disableHooks: false,
+      onToolCallsUpdate,
+      approvalMode: ApprovalMode.DEFAULT,
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'approval-then-bounce',
+          name: 'mockEditTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-approval-then-bounce',
+        },
+      ],
+      new AbortController().signal,
+    );
+    const initialWaiting = (await waitForStatus(
+      onToolCallsUpdate,
+      'awaiting_approval',
+    )) as WaitingToolCall;
+    const initialDetails = initialWaiting.confirmationDetails;
+
+    await initialDetails.onConfirm(ToolConfirmationOutcome.ProceedOnce);
+    await vi.waitFor(() => {
+      expect(approvalDetails).toHaveLength(2);
+      expect(approvalDetails[1]).not.toBe(initialDetails);
+    });
   });
 
   it('cancels the tool without executing when the user declines an ask', async () => {


### PR DESCRIPTION
## What this PR does

This change makes workflow approval handling incarnation-aware across scheduler bounces and delivery failures.

- each `confirmationDetails` identity owns one shared responder/delivery state;
- stale events cannot approve a newer incarnation with the same `callId`;
- partial EventEmitter delivery retries reuse the same response latch;
- transient listener failures retry automatically, bounded to three attempts;
- timers and delivery state are retired on response, status transition, completion, and abort;
- workflow source latches are released on response, cancellation, result, failure, and run cleanup.

## Why it's needed

A hook can bounce a tool back into approval with the same call ID but a new approval object. Call-ID-only deduplication dropped the new approval or let stale responders consume it. Event-listener exceptions also either lost delivery permanently or created independent duplicate responders.

## Reviewer Test Plan

Run:

```bash
npm test --workspace @qwen-code/qwen-code-core -- --run src/agents/runtime/agent-core.test.ts src/core/coreToolScheduler.test.ts src/agents/workflow-run-registry.test.ts
```

Verified: 509 tests, core build, lint, typecheck, Prettier, and `git diff --check`.

Coverage includes hook bounce identity, stale responses, partial listener delivery, transient and persistent listener failures, retry caps across sibling updates, waiting/non-waiting re-entry, cancellation, and registry cleanup.

## Risk & Scope

- Automatic redelivery is deliberately bounded to three attempts.
- No public API or migration change.

## Linked Issues

Fixes #9505

<details>
<summary>中文说明</summary>

本改动按 `confirmationDetails` 对象身份管理审批 incarnation。旧事件不能审批同一 `callId` 的新 gate；部分投递和自动重试共享同一个响应门闩；自动重试最多三次，并在响应、状态迁移、完成和 abort 时清理。

验证通过 509 项测试，以及 build、lint、typecheck、Prettier 和 `git diff --check`。

</details>