### PR TITLE
fix(core): avoid ghost shutdown pending state

### DIFF
--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -237,7 +237,16 @@ export class TeamManager {
     | ((message: string, display: string) => void)
     | null = null;
 
-  /** Outstanding shutdown tokens and their response reservations. */
+  /**
+   * Shutdown state is isolated per teammate, so one teammate's writes or
+   * responses cannot gate assignments or consume requests for another.
+   * Each successful request write adds exactly one delivered token, while
+   * repeated test markers share at most one marker token. A response reserves
+   * a specific token before its mailbox write; the reservation keeps the gate
+   * closed until settlement, a successful settlement consumes that token at
+   * most once, and a failed settlement leaves it available. A ledger is
+   * removed only after all writes, tokens, and response reservations settle.
+   */
   private readonly shutdownLedgers = new Map<string, ShutdownLedger>();
 
   /** Per-agent last activity timestamp (updated on events). */
@@ -1775,7 +1784,9 @@ export class TeamManager {
         'shutdown_request',
       );
       if (shutdowns.length > 0) {
-        this.enqueueWithIdentity(agentId, agent, shutdowns[0]!.text);
+        for (const shutdown of shutdowns) {
+          this.enqueueWithIdentity(agentId, agent, shutdown.text);
+        }
         return;
       }
     }

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -233,7 +233,7 @@ export class TeamManager {
    *  cannot clear another request's pending state. */
   private readonly shutdownRequestStates = new Map<
     string,
-    { inFlight: number; delivered: boolean }
+    { inFlight: number; delivered: boolean; resolved: boolean }
   >();
 
   /** Per-agent last activity timestamp (updated on events). */
@@ -698,10 +698,11 @@ export class TeamManager {
     }
 
     let requestState = this.shutdownRequestStates.get(member.name);
-    if (!requestState) {
+    if (!requestState || requestState.resolved) {
       requestState = {
         inFlight: 0,
         delivered: this._shutdownPending.has(member.name),
+        resolved: false,
       };
       this.shutdownRequestStates.set(member.name, requestState);
     }
@@ -721,7 +722,11 @@ export class TeamManager {
       requestState.delivered = true;
     } finally {
       requestState.inFlight -= 1;
-      if (requestState.inFlight === 0 && !requestState.delivered) {
+      if (
+        requestState.inFlight === 0 &&
+        (!requestState.delivered || requestState.resolved) &&
+        this.shutdownRequestStates.get(member.name) === requestState
+      ) {
         this.shutdownRequestStates.delete(member.name);
         this._shutdownPending.delete(member.name);
       }
@@ -1356,7 +1361,7 @@ export class TeamManager {
       return;
     }
 
-    requestState.delivered = false;
+    requestState.resolved = true;
     if (requestState.inFlight === 0) {
       this.shutdownRequestStates.delete(name);
       this._shutdownPending.delete(name);

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -229,6 +229,13 @@ export class TeamManager {
    *  radius across the rest of the session. */
   private readonly _shutdownPending = new Set<string>();
 
+  /** Tracks writes separately from delivered requests so one failed retry
+   *  cannot clear another request's pending state. */
+  private readonly shutdownRequestStates = new Map<
+    string,
+    { inFlight: number; delivered: boolean }
+  >();
+
   /** Per-agent last activity timestamp (updated on events). */
   private readonly lastActivityAt = new Map<string, number>();
 
@@ -597,7 +604,7 @@ export class TeamManager {
         shutdownResponse &&
         this._shutdownPending.has(sender.name)
       ) {
-        this._shutdownPending.delete(sender.name);
+        this.clearDeliveredShutdownRequest(sender.name);
         if (shutdownResponse === 'shutdown_approved') {
           this.getAgentFromBackend(sender.agentId)?.abort();
         }
@@ -690,6 +697,15 @@ export class TeamManager {
       throw new Error(`Teammate "${name}" not found.`);
     }
 
+    let requestState = this.shutdownRequestStates.get(member.name);
+    if (!requestState) {
+      requestState = {
+        inFlight: 0,
+        delivered: this._shutdownPending.has(member.name),
+      };
+      this.shutdownRequestStates.set(member.name, requestState);
+    }
+    requestState.inFlight += 1;
     this._shutdownPending.add(member.name);
     try {
       await sendStructuredMessage(this.teamFile.name, member.name, {
@@ -702,9 +718,13 @@ export class TeamManager {
           '"shutdown_approved" or "shutdown_rejected: <reason>".',
         summary: 'Shutdown requested by leader',
       });
-    } catch (error) {
-      this._shutdownPending.delete(member.name);
-      throw error;
+      requestState.delivered = true;
+    } finally {
+      requestState.inFlight -= 1;
+      if (requestState.inFlight === 0 && !requestState.delivered) {
+        this.shutdownRequestStates.delete(member.name);
+        this._shutdownPending.delete(member.name);
+      }
     }
 
     // If agent is idle, flush immediately (shutdown has
@@ -1329,6 +1349,20 @@ export class TeamManager {
     this._shutdownPending.add(name);
   }
 
+  private clearDeliveredShutdownRequest(name: string): void {
+    const requestState = this.shutdownRequestStates.get(name);
+    if (!requestState) {
+      this._shutdownPending.delete(name);
+      return;
+    }
+
+    requestState.delivered = false;
+    if (requestState.inFlight === 0) {
+      this.shutdownRequestStates.delete(name);
+      this._shutdownPending.delete(name);
+    }
+  }
+
   /**
    * Get an agent object from the backend by agent ID.
    * Returns undefined for backends that don't expose in-process
@@ -1533,6 +1567,7 @@ export class TeamManager {
         this.lastActivityAt.delete(agentId);
         this.agentIdentities.delete(agentId);
         this._shutdownPending.delete(agentName);
+        this.shutdownRequestStates.delete(agentName);
         this.rejectPendingPlanApprovalsForTeammate(
           agentName,
           new Error(

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -690,18 +690,22 @@ export class TeamManager {
       throw new Error(`Teammate "${name}" not found.`);
     }
 
-    await sendStructuredMessage(this.teamFile.name, member.name, {
-      from: LEADER_NAME,
-      type: 'shutdown_request',
-      text:
-        'The team leader has requested that you shut down. ' +
-        'Please finish your current work and use ' +
-        'send_message to reply to "leader" with either ' +
-        '"shutdown_approved" or "shutdown_rejected: <reason>".',
-      summary: 'Shutdown requested by leader',
-    });
-
     this._shutdownPending.add(member.name);
+    try {
+      await sendStructuredMessage(this.teamFile.name, member.name, {
+        from: LEADER_NAME,
+        type: 'shutdown_request',
+        text:
+          'The team leader has requested that you shut down. ' +
+          'Please finish your current work and use ' +
+          'send_message to reply to "leader" with either ' +
+          '"shutdown_approved" or "shutdown_rejected: <reason>".',
+        summary: 'Shutdown requested by leader',
+      });
+    } catch (error) {
+      this._shutdownPending.delete(member.name);
+      throw error;
+    }
 
     // If agent is idle, flush immediately (shutdown has
     // highest priority and will be picked up from mailbox).

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -690,8 +690,6 @@ export class TeamManager {
       throw new Error(`Teammate "${name}" not found.`);
     }
 
-    this._shutdownPending.add(member.name);
-
     await sendStructuredMessage(this.teamFile.name, member.name, {
       from: LEADER_NAME,
       type: 'shutdown_request',
@@ -702,6 +700,8 @@ export class TeamManager {
         '"shutdown_approved" or "shutdown_rejected: <reason>".',
       summary: 'Shutdown requested by leader',
     });
+
+    this._shutdownPending.add(member.name);
 
     // If agent is idle, flush immediately (shutdown has
     // highest priority and will be picked up from mailbox).

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -233,8 +233,11 @@ export class TeamManager {
    *  cannot clear another request's pending state. */
   private readonly shutdownRequestStates = new Map<
     string,
-    { inFlight: number; delivered: boolean; resolved: boolean }
+    { inFlight: number; delivered: boolean }
   >();
+
+  /** Test-only shutdown markers installed without requestShutdown(). */
+  private readonly markedShutdownRequests = new Set<string>();
 
   /** Per-agent last activity timestamp (updated on events). */
   private readonly lastActivityAt = new Map<string, number>();
@@ -698,11 +701,10 @@ export class TeamManager {
     }
 
     let requestState = this.shutdownRequestStates.get(member.name);
-    if (!requestState || requestState.resolved) {
+    if (!requestState) {
       requestState = {
         inFlight: 0,
-        delivered: this._shutdownPending.has(member.name),
-        resolved: false,
+        delivered: false,
       };
       this.shutdownRequestStates.set(member.name, requestState);
     }
@@ -724,11 +726,13 @@ export class TeamManager {
       requestState.inFlight -= 1;
       if (
         requestState.inFlight === 0 &&
-        (!requestState.delivered || requestState.resolved) &&
+        !requestState.delivered &&
         this.shutdownRequestStates.get(member.name) === requestState
       ) {
         this.shutdownRequestStates.delete(member.name);
-        this._shutdownPending.delete(member.name);
+        if (!this.markedShutdownRequests.has(member.name)) {
+          this._shutdownPending.delete(member.name);
+        }
       }
     }
 
@@ -1351,17 +1355,19 @@ export class TeamManager {
    *  that inject the structured shutdown message directly without
    *  going through `requestShutdown`. */
   markShutdownRequested(name: string): void {
+    this.markedShutdownRequests.add(name);
     this._shutdownPending.add(name);
   }
 
   private clearDeliveredShutdownRequest(name: string): void {
+    this.markedShutdownRequests.delete(name);
     const requestState = this.shutdownRequestStates.get(name);
     if (!requestState) {
       this._shutdownPending.delete(name);
       return;
     }
 
-    requestState.resolved = true;
+    requestState.delivered = false;
     if (requestState.inFlight === 0) {
       this.shutdownRequestStates.delete(name);
       this._shutdownPending.delete(name);
@@ -1573,6 +1579,7 @@ export class TeamManager {
         this.agentIdentities.delete(agentId);
         this._shutdownPending.delete(agentName);
         this.shutdownRequestStates.delete(agentName);
+        this.markedShutdownRequests.delete(agentName);
         this.rejectPendingPlanApprovalsForTeammate(
           agentName,
           new Error(

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -726,6 +726,11 @@ export class TeamManager {
           reservations: 0,
           consumed: false,
         });
+        debug.debug(
+          `shutdown[${member.name}]: minted delivered token ` +
+            `(tokens=${ledger.outstandingTokens.length}, ` +
+            `inFlightWrites=${ledger.inFlightWrites})`,
+        );
       }
     } finally {
       if (this.shutdownLedgers.get(member.name) === ledger) {
@@ -1419,6 +1424,11 @@ export class TeamManager {
     if (consumed) {
       reservation.token.consumed = true;
     }
+    debug.debug(
+      `shutdown[${name}]: settled response (succeeded=${succeeded}, ` +
+        `consumedToken=${consumed}, ` +
+        `responsesInFlight=${reservation.ledger.responsesInFlight})`,
+    );
     this.cleanupShutdownLedger(name, reservation.ledger);
     return consumed;
   }
@@ -1434,6 +1444,7 @@ export class TeamManager {
       ledger.responsesInFlight === 0
     ) {
       this.shutdownLedgers.delete(name);
+      debug.debug(`shutdown[${name}]: ledger drained and removed`);
     }
   }
 

--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -147,6 +147,23 @@ interface PendingPlanApproval {
   onAbort?: () => void;
 }
 
+interface ShutdownOutstandingToken {
+  kind: 'delivered' | 'marker';
+  reservations: number;
+  consumed: boolean;
+}
+
+interface ShutdownLedger {
+  inFlightWrites: number;
+  outstandingTokens: ShutdownOutstandingToken[];
+  responsesInFlight: number;
+}
+
+interface ShutdownResponseReservation {
+  ledger: ShutdownLedger;
+  token: ShutdownOutstandingToken;
+}
+
 /**
  * The stable tag wrapping teammate→leader messages in the leader's
  * conversation. No secret/nonce: forgery is prevented structurally by
@@ -220,24 +237,8 @@ export class TeamManager {
     | ((message: string, display: string) => void)
     | null = null;
 
-  /** Names of teammates with a pending leader-requested shutdown.
-   *  Gates both the per-idle mailbox read in flushNextMessage and
-   *  the shutdown_approved abort path in sendMessage. Tracked
-   *  per-agent (rather than as a sticky boolean) so a free-text
-   *  match in an unrelated teammate's reply cannot abort them, and
-   *  so an impersonation-forged shutdown can't widen the blast
-   *  radius across the rest of the session. */
-  private readonly _shutdownPending = new Set<string>();
-
-  /** Tracks writes separately from delivered requests so one failed retry
-   *  cannot clear another request's pending state. */
-  private readonly shutdownRequestStates = new Map<
-    string,
-    { inFlight: number; delivered: boolean }
-  >();
-
-  /** Test-only shutdown markers installed without requestShutdown(). */
-  private readonly markedShutdownRequests = new Set<string>();
+  /** Outstanding shutdown tokens and their response reservations. */
+  private readonly shutdownLedgers = new Map<string, ShutdownLedger>();
 
   /** Per-agent last activity timestamp (updated on events). */
   private readonly lastActivityAt = new Map<string, number>();
@@ -554,61 +555,58 @@ export class TeamManager {
       toName.toLowerCase() === LEADER_NAME ||
       toName === this.teamFile.leadAgentId
     ) {
-      // Classify a shutdown response up front, but only for a teammate
-      // the leader actually asked to shut down (the gate) and only when
-      // the reply *leads* with the structured token — not merely
-      // mentions it in prose. The resulting type is carried on the
-      // message and drives the abort decision below, instead of
-      // re-scanning the free-text body. This is what keeps a
-      // pending-shutdown teammate that mentions "shutdown_approved"
-      // mid-report (e.g. while reviewing shutdown code) from being
-      // aborted, and a non-requested teammate from ever triggering one.
       const sender = from
         ? findMemberByName(this.teamFile.members, from)
         : undefined;
-      const shutdownResponse =
-        sender && !automatic && this._shutdownPending.has(sender.name)
-          ? classifyShutdownResponse(message)
+      const responseCandidate =
+        sender && !automatic ? classifyShutdownResponse(message) : undefined;
+      const shutdownReservation =
+        sender && responseCandidate
+          ? this.reserveShutdownResponse(sender.name)
           : undefined;
+      const shutdownResponse = shutdownReservation
+        ? responseCandidate
+        : undefined;
+      let consumedShutdownToken = false;
 
-      await writeMessage(this.teamFile.name, LEADER_NAME, {
-        from: from ?? 'unknown',
-        text: message,
-        summary,
-        timestamp: new Date().toISOString(),
-        read: false,
-        type: shutdownResponse,
-      });
+      try {
+        await writeMessage(this.teamFile.name, LEADER_NAME, {
+          from: from ?? 'unknown',
+          text: message,
+          summary,
+          timestamp: new Date().toISOString(),
+          read: false,
+          type: shutdownResponse,
+        });
+      } catch (error) {
+        if (sender && shutdownReservation) {
+          this.settleShutdownResponse(sender.name, shutdownReservation, false);
+        }
+        throw error;
+      }
+      if (sender && shutdownResponse && shutdownReservation) {
+        consumedShutdownToken = this.settleShutdownResponse(
+          sender.name,
+          shutdownReservation,
+          true,
+        );
+      }
       if (sender && !automatic) {
         this.explicitLeaderReports.add(sender.agentId);
       }
-      this.teamEventEmitter.emit(TeamEventType.MESSAGE_SENT, {
-        from: from ?? 'unknown',
-        to: LEADER_NAME,
-        message,
-        timestamp: Date.now(),
-      });
-
-      // Act on the typed shutdown response. Approval aborts the
-      // teammate so it actually retires; rejection just clears the
-      // pending flag — leaving it set would keep the teammate excluded
-      // from auto-claim (scanIdleAgentsForTasks skips pending-shutdown
-      // members) and kill-armed. Either way the reply text still
-      // reaches the leader through the inbox write above.
-      //
-      // Re-check the pending flag here, after the await: the response
-      // was classified before `writeMessage`, so a concurrent reply from
-      // the same teammate could have cleared the flag in between. Acting
-      // on the stale capture would abort a teammate whose latest reply
-      // was a rejection — so gate the act on the flag still being set,
-      // keeping check-and-act atomic as the pre-refactor path was.
-      if (
-        sender &&
-        shutdownResponse &&
-        this._shutdownPending.has(sender.name)
-      ) {
-        this.clearDeliveredShutdownRequest(sender.name);
-        if (shutdownResponse === 'shutdown_approved') {
+      try {
+        this.teamEventEmitter.emit(TeamEventType.MESSAGE_SENT, {
+          from: from ?? 'unknown',
+          to: LEADER_NAME,
+          message,
+          timestamp: Date.now(),
+        });
+      } finally {
+        if (
+          sender &&
+          shutdownResponse === 'shutdown_approved' &&
+          consumedShutdownToken
+        ) {
           this.getAgentFromBackend(sender.agentId)?.abort();
         }
       }
@@ -700,16 +698,8 @@ export class TeamManager {
       throw new Error(`Teammate "${name}" not found.`);
     }
 
-    let requestState = this.shutdownRequestStates.get(member.name);
-    if (!requestState) {
-      requestState = {
-        inFlight: 0,
-        delivered: false,
-      };
-      this.shutdownRequestStates.set(member.name, requestState);
-    }
-    requestState.inFlight += 1;
-    this._shutdownPending.add(member.name);
+    const ledger = this.getOrCreateShutdownLedger(member.name);
+    ledger.inFlightWrites += 1;
     try {
       await sendStructuredMessage(this.teamFile.name, member.name, {
         from: LEADER_NAME,
@@ -721,18 +711,17 @@ export class TeamManager {
           '"shutdown_approved" or "shutdown_rejected: <reason>".',
         summary: 'Shutdown requested by leader',
       });
-      requestState.delivered = true;
+      if (this.shutdownLedgers.get(member.name) === ledger) {
+        ledger.outstandingTokens.push({
+          kind: 'delivered',
+          reservations: 0,
+          consumed: false,
+        });
+      }
     } finally {
-      requestState.inFlight -= 1;
-      if (
-        requestState.inFlight === 0 &&
-        !requestState.delivered &&
-        this.shutdownRequestStates.get(member.name) === requestState
-      ) {
-        this.shutdownRequestStates.delete(member.name);
-        if (!this.markedShutdownRequests.has(member.name)) {
-          this._shutdownPending.delete(member.name);
-        }
+      if (this.shutdownLedgers.get(member.name) === ledger) {
+        ledger.inFlightWrites -= 1;
+        this.cleanupShutdownLedger(member.name, ledger);
       }
     }
 
@@ -1355,22 +1344,87 @@ export class TeamManager {
    *  that inject the structured shutdown message directly without
    *  going through `requestShutdown`. */
   markShutdownRequested(name: string): void {
-    this.markedShutdownRequests.add(name);
-    this._shutdownPending.add(name);
+    const ledger = this.getOrCreateShutdownLedger(name);
+    const hasMarker = ledger.outstandingTokens.some(
+      (token) => token.kind === 'marker' && !token.consumed,
+    );
+    if (!hasMarker) {
+      ledger.outstandingTokens.push({
+        kind: 'marker',
+        reservations: 0,
+        consumed: false,
+      });
+    }
   }
 
-  private clearDeliveredShutdownRequest(name: string): void {
-    this.markedShutdownRequests.delete(name);
-    const requestState = this.shutdownRequestStates.get(name);
-    if (!requestState) {
-      this._shutdownPending.delete(name);
-      return;
+  private getOrCreateShutdownLedger(name: string): ShutdownLedger {
+    let ledger = this.shutdownLedgers.get(name);
+    if (!ledger) {
+      ledger = {
+        inFlightWrites: 0,
+        outstandingTokens: [],
+        responsesInFlight: 0,
+      };
+      this.shutdownLedgers.set(name, ledger);
     }
+    return ledger;
+  }
 
-    requestState.delivered = false;
-    if (requestState.inFlight === 0) {
-      this.shutdownRequestStates.delete(name);
-      this._shutdownPending.delete(name);
+  private hasShutdownWork(name: string): boolean {
+    const ledger = this.shutdownLedgers.get(name);
+    return Boolean(
+      ledger &&
+        (ledger.inFlightWrites > 0 ||
+          ledger.outstandingTokens.some((token) => !token.consumed) ||
+          ledger.responsesInFlight > 0),
+    );
+  }
+
+  private reserveShutdownResponse(
+    name: string,
+  ): ShutdownResponseReservation | undefined {
+    const ledger = this.shutdownLedgers.get(name);
+    if (!ledger) return undefined;
+
+    const token =
+      ledger.outstandingTokens.find(
+        (candidate) => !candidate.consumed && candidate.reservations === 0,
+      ) ?? ledger.outstandingTokens.find((candidate) => !candidate.consumed);
+    if (!token) return undefined;
+
+    token.reservations += 1;
+    ledger.responsesInFlight += 1;
+    return { ledger, token };
+  }
+
+  private settleShutdownResponse(
+    name: string,
+    reservation: ShutdownResponseReservation,
+    succeeded: boolean,
+  ): boolean {
+    if (this.shutdownLedgers.get(name) !== reservation.ledger) return false;
+
+    reservation.ledger.responsesInFlight -= 1;
+    reservation.token.reservations -= 1;
+    const consumed = succeeded && !reservation.token.consumed;
+    if (consumed) {
+      reservation.token.consumed = true;
+    }
+    this.cleanupShutdownLedger(name, reservation.ledger);
+    return consumed;
+  }
+
+  private cleanupShutdownLedger(name: string, ledger: ShutdownLedger): void {
+    ledger.outstandingTokens = ledger.outstandingTokens.filter(
+      (token) => !token.consumed || token.reservations > 0,
+    );
+    if (
+      this.shutdownLedgers.get(name) === ledger &&
+      ledger.inFlightWrites === 0 &&
+      ledger.outstandingTokens.length === 0 &&
+      ledger.responsesInFlight === 0
+    ) {
+      this.shutdownLedgers.delete(name);
     }
   }
 
@@ -1577,9 +1631,7 @@ export class TeamManager {
         this.explicitLeaderReports.delete(agentId);
         this.lastActivityAt.delete(agentId);
         this.agentIdentities.delete(agentId);
-        this._shutdownPending.delete(agentName);
-        this.shutdownRequestStates.delete(agentName);
-        this.markedShutdownRequests.delete(agentName);
+        this.shutdownLedgers.delete(agentName);
         this.rejectPendingPlanApprovalsForTeammate(
           agentName,
           new Error(
@@ -1716,7 +1768,7 @@ export class TeamManager {
     //    Only read the mailbox if this specific teammate has had
     //    a shutdown queued — avoids a per-idle inbox round-trip
     //    for everyone whenever any shutdown is in flight.
-    if (this._shutdownPending.has(agentName)) {
+    if (this.hasShutdownWork(agentName)) {
       const shutdowns = await consumeUnread(
         this.teamFile.name,
         agentName,
@@ -1798,7 +1850,7 @@ export class TeamManager {
     if (!agent) return;
     if (agent.getStatus() !== AgentStatus.IDLE) return;
     if (findMemberByName(this.teamFile.members, agentName)?.readOnly) return;
-    if (this._shutdownPending.has(agentName)) return;
+    if (this.hasShutdownWork(agentName)) return;
 
     const pendingTasks =
       pending ??
@@ -1811,7 +1863,7 @@ export class TeamManager {
     for (const task of pendingTasks) {
       if (task.owner) continue;
       if (task.blockedBy.length > 0) continue;
-      if (this._shutdownPending.has(agentName)) return;
+      if (this.hasShutdownWork(agentName)) return;
 
       const claimed = await claimTask(this.teamFile.name, task.id, agentId, {
         checkAgentBusy: true,
@@ -1886,7 +1938,7 @@ export class TeamManager {
         `Spawn the teammate first or choose an existing one.`
       );
     }
-    if (this._shutdownPending.has(member.name)) {
+    if (this.hasShutdownWork(member.name)) {
       return (
         `Cannot assign to "${ownerName}": shutdown is already pending ` +
         `for that teammate.`
@@ -1916,7 +1968,7 @@ export class TeamManager {
     if (task.status !== 'in_progress' || !task.owner) return false;
     const member = findMemberByName(this.teamFile.members, task.owner);
     if (!member) return false;
-    if (this._shutdownPending.has(member.name)) return false;
+    if (this.hasShutdownWork(member.name)) return false;
     const agent = this.getAgentFromBackend(member.agentId);
     if (!agent) return false;
     if (isTerminalStatus(agent.getStatus())) return false;
@@ -1938,7 +1990,7 @@ export class TeamManager {
       // Don't auto-claim a task for a teammate the leader is shutting
       // down — it would start work it's about to abandon. tryAutoClaimTask
       // repeats this check after async task reads for both claim paths.
-      if (this._shutdownPending.has(member.name)) return false;
+      if (this.hasShutdownWork(member.name)) return false;
       const queue = this.pendingMessages.get(member.agentId) ?? [];
       return queue.length === 0;
     });

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -1009,6 +1009,79 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
+    it('clears shutdown state when a response arrives during a concurrent write', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      await h.teamManager.requestShutdown('target');
+
+      let markWriteStarted!: () => void;
+      const writeStarted = new Promise<void>((resolve) => {
+        markWriteStarted = resolve;
+      });
+      let releaseWrite!: () => void;
+      const writeGate = new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markWriteStarted();
+        await writeGate;
+      });
+
+      const concurrentShutdown = h.teamManager.requestShutdown('target');
+      await writeStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: still working',
+        'target',
+      );
+
+      releaseWrite();
+      await concurrentShutdown;
+
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('preserves a new shutdown request after an earlier request is resolved', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      await h.teamManager.requestShutdown('target');
+
+      let markOldWriteStarted!: () => void;
+      const oldWriteStarted = new Promise<void>((resolve) => {
+        markOldWriteStarted = resolve;
+      });
+      let releaseOldWrite!: () => void;
+      const oldWriteGate = new Promise<void>((resolve) => {
+        releaseOldWrite = resolve;
+      });
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markOldWriteStarted();
+        await oldWriteGate;
+      });
+
+      const oldShutdown = h.teamManager.requestShutdown('target');
+      await oldWriteStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: still working',
+        'target',
+      );
+
+      await h.teamManager.requestShutdown('target');
+      releaseOldWrite();
+      await oldShutdown;
+
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+    });
+
     it('gates task assignment while the shutdown mailbox write is pending', async () => {
       const h = await createHarness();
       const target = await h.spawnTeammate('target', {

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -953,6 +953,23 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
+    it('does not clear a test-only shutdown marker when a mailbox write fails', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      h.teamManager.markShutdownRequested('target');
+      const mailboxError = new Error('EIO: mailbox write failed');
+      mockSendStructuredMessage.mockRejectedValueOnce(mailboxError);
+
+      await expect(h.teamManager.requestShutdown('target')).rejects.toBe(
+        mailboxError,
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+    });
+
     it('keeps a successful shutdown pending when a retry write fails', async () => {
       const h = await createHarness();
       await h.spawnTeammate('target', {
@@ -1009,7 +1026,7 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
-    it('clears shutdown state when a response arrives during a concurrent write', async () => {
+    it('keeps shutdown state for a write delivered after a response', async () => {
       const h = await createHarness();
       await h.spawnTeammate('target', {
         onMessage: () => {},
@@ -1041,7 +1058,9 @@ describe('TeamCoordinationHarness', () => {
       releaseWrite();
       await concurrentShutdown;
 
-      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
     });
 
     it('preserves a new shutdown request after an earlier request is resolved', async () => {
@@ -1080,6 +1099,86 @@ describe('TeamCoordinationHarness', () => {
       expect(h.teamManager.validateTaskOwner('target')).toEqual(
         expect.stringContaining('shutdown is already pending'),
       );
+    });
+
+    it('clears a failed new shutdown generation after the resolved generation settles', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      await h.teamManager.requestShutdown('target');
+
+      let markOldWriteStarted!: () => void;
+      const oldWriteStarted = new Promise<void>((resolve) => {
+        markOldWriteStarted = resolve;
+      });
+      let releaseOldWrite!: () => void;
+      const oldWriteGate = new Promise<void>((resolve) => {
+        releaseOldWrite = resolve;
+      });
+      const oldWriteError = new Error('EIO: old mailbox write failed');
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markOldWriteStarted();
+        await oldWriteGate;
+        throw oldWriteError;
+      });
+
+      const oldShutdown = h.teamManager.requestShutdown('target');
+      const oldShutdownRejection = oldShutdown.catch((error: unknown) => error);
+      await oldWriteStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: still working',
+        'target',
+      );
+
+      const newWriteError = new Error('EIO: new mailbox write failed');
+      mockSendStructuredMessage.mockRejectedValueOnce(newWriteError);
+      await expect(h.teamManager.requestShutdown('target')).rejects.toBe(
+        newWriteError,
+      );
+
+      releaseOldWrite();
+      expect(await oldShutdownRejection).toBe(oldWriteError);
+
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('accepts approval for a retry delivered after an earlier rejection', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      await h.teamManager.requestShutdown('target');
+
+      let markRetryStarted!: () => void;
+      const retryStarted = new Promise<void>((resolve) => {
+        markRetryStarted = resolve;
+      });
+      let releaseRetry!: () => void;
+      const retryGate = new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markRetryStarted();
+        await retryGate;
+      });
+
+      const retry = h.teamManager.requestShutdown('target');
+      await retryStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: still working',
+        'target',
+      );
+
+      releaseRetry();
+      await retry;
+      await h.teamManager.sendMessage('leader', 'shutdown_approved', 'target');
+
+      expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
     });
 
     it('gates task assignment while the shutdown mailbox write is pending', async () => {

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -15,12 +15,14 @@ import { createTask, listTasks, updateTask, getTask } from '../tasks.js';
 import { sendStructuredMessage, readInbox, getInboxPath } from '../mailbox.js';
 import { formatAgentId } from '../teamHelpers.js';
 import { runWithTeammateIdentity } from '../identity.js';
+import { TeamEventType } from '../team-events.js';
 import { TaskUpdateTool } from '../../../tools/task-update.js';
 import type { TaskUpdateParams } from '../../../tools/task-update.js';
 import type { Config } from '../../../config/config.js';
 
-const { mockSendStructuredMessage } = vi.hoisted(() => ({
+const { mockSendStructuredMessage, mockWriteMessage } = vi.hoisted(() => ({
   mockSendStructuredMessage: vi.fn(),
+  mockWriteMessage: vi.fn(),
 }));
 
 // Mock Storage so all file I/O uses the harness's temp dir.
@@ -43,9 +45,11 @@ vi.mock('../../../config/storage.js', async (importOriginal) => {
 vi.mock('../mailbox.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../mailbox.js')>();
   mockSendStructuredMessage.mockImplementation(original.sendStructuredMessage);
+  mockWriteMessage.mockImplementation(original.writeMessage);
   return {
     ...original,
     sendStructuredMessage: mockSendStructuredMessage,
+    writeMessage: mockWriteMessage,
   };
 });
 
@@ -970,6 +974,443 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
+    it('does not restore a marker after a failed shutdown request is rejected', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      h.teamManager.markShutdownRequested('target');
+
+      let markWriteStarted!: () => void;
+      const writeStarted = new Promise<void>((resolve) => {
+        markWriteStarted = resolve;
+      });
+      let releaseWrite!: () => void;
+      const writeGate = new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+      const mailboxError = new Error('EIO: mailbox write failed');
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markWriteStarted();
+        await writeGate;
+        throw mailboxError;
+      });
+
+      const shutdown = h.teamManager.requestShutdown('target');
+      const shutdownRejection = shutdown.catch((error: unknown) => error);
+      await writeStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: still working',
+        'target',
+      );
+
+      releaseWrite();
+      expect(await shutdownRejection).toBe(mailboxError);
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('closure audit keeps a later delivered request after an older rejection', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+
+      let markRetryStarted!: () => void;
+      const retryStarted = new Promise<void>((resolve) => {
+        markRetryStarted = resolve;
+      });
+      let releaseRetry!: () => void;
+      const retryGate = new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+      let markNextRequestStarted!: () => void;
+      const nextRequestStarted = new Promise<void>((resolve) => {
+        markNextRequestStarted = resolve;
+      });
+      let releaseNextRequest!: () => void;
+      const nextRequestGate = new Promise<void>((resolve) => {
+        releaseNextRequest = resolve;
+      });
+      const nextRequestError = new Error('EIO: next mailbox write failed');
+      const writeShutdown = mockSendStructuredMessage.getMockImplementation();
+      mockSendStructuredMessage
+        .mockImplementationOnce(
+          async (...args: Parameters<typeof sendStructuredMessage>) => {
+            markRetryStarted();
+            await retryGate;
+            await writeShutdown!(...args);
+          },
+        )
+        .mockImplementationOnce(async () => {
+          markNextRequestStarted();
+          await nextRequestGate;
+          throw nextRequestError;
+        });
+
+      const retry = h.teamManager.requestShutdown('target');
+      await retryStarted;
+
+      let markRejectionStarted!: () => void;
+      const rejectionStarted = new Promise<void>((resolve) => {
+        markRejectionStarted = resolve;
+      });
+      let releaseRejection!: () => void;
+      const rejectionGate = new Promise<void>((resolve) => {
+        releaseRejection = resolve;
+      });
+      mockWriteMessage.mockImplementationOnce(async () => {
+        markRejectionStarted();
+        await rejectionGate;
+      });
+      const rejection = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: retry later',
+        'target',
+      );
+      await rejectionStarted;
+
+      const nextRequest = h.teamManager.requestShutdown('target');
+      const nextRequestRejection = nextRequest.catch((error: unknown) => error);
+      await nextRequestStarted;
+
+      releaseRetry();
+      await retry;
+      releaseNextRequest();
+      expect(await nextRequestRejection).toBe(nextRequestError);
+      releaseRejection();
+      await rejection;
+
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: delivered retry resolved',
+        'target',
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('closure audit does not restore a resolved marker after a real request fails', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      h.teamManager.markShutdownRequested('target');
+
+      let markResponseStarted!: () => void;
+      const responseStarted = new Promise<void>((resolve) => {
+        markResponseStarted = resolve;
+      });
+      let releaseResponse!: () => void;
+      const responseGate = new Promise<void>((resolve) => {
+        releaseResponse = resolve;
+      });
+      mockWriteMessage.mockImplementationOnce(async () => {
+        markResponseStarted();
+        await responseGate;
+      });
+      const markerResponse = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: keep working',
+        'target',
+      );
+      await responseStarted;
+
+      let markRequestStarted!: () => void;
+      const requestStarted = new Promise<void>((resolve) => {
+        markRequestStarted = resolve;
+      });
+      let releaseRequest!: () => void;
+      const requestGate = new Promise<void>((resolve) => {
+        releaseRequest = resolve;
+      });
+      const requestError = new Error('EIO: real mailbox write failed');
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markRequestStarted();
+        await requestGate;
+        throw requestError;
+      });
+      const request = h.teamManager.requestShutdown('target');
+      const requestRejection = request.catch((error: unknown) => error);
+      await requestStarted;
+
+      releaseResponse();
+      await markerResponse;
+      releaseRequest();
+      expect(await requestRejection).toBe(requestError);
+
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('restores a reserved request when the leader mailbox write fails', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+      const responseError = new Error('EIO: leader mailbox write failed');
+      mockWriteMessage.mockRejectedValueOnce(responseError);
+
+      await expect(
+        h.teamManager.sendMessage(
+          'leader',
+          'shutdown_rejected: retry response',
+          'target',
+        ),
+      ).rejects.toBe(responseError);
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: response delivered',
+        'target',
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('lets a backup approval consume the token when the first reservation fails', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+
+      let markFirstResponseStarted!: () => void;
+      const firstResponseStarted = new Promise<void>((resolve) => {
+        markFirstResponseStarted = resolve;
+      });
+      let releaseFirstResponse!: () => void;
+      const firstResponseGate = new Promise<void>((resolve) => {
+        releaseFirstResponse = resolve;
+      });
+      let markBackupResponseStarted!: () => void;
+      const backupResponseStarted = new Promise<void>((resolve) => {
+        markBackupResponseStarted = resolve;
+      });
+      let releaseBackupResponse!: () => void;
+      const backupResponseGate = new Promise<void>((resolve) => {
+        releaseBackupResponse = resolve;
+      });
+      const firstResponseError = new Error('EIO: first response write failed');
+      const writeLeaderMessage = mockWriteMessage.getMockImplementation();
+      mockWriteMessage
+        .mockImplementationOnce(async () => {
+          markFirstResponseStarted();
+          await firstResponseGate;
+          throw firstResponseError;
+        })
+        .mockImplementationOnce(
+          async (
+            ...args: Parameters<NonNullable<typeof writeLeaderMessage>>
+          ) => {
+            markBackupResponseStarted();
+            await backupResponseGate;
+            await writeLeaderMessage!(...args);
+          },
+        );
+
+      const firstResponse = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: first response',
+        'target',
+      );
+      const firstResponseRejection = firstResponse.catch(
+        (error: unknown) => error,
+      );
+      await firstResponseStarted;
+
+      const backupResponse = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_approved',
+        'target',
+      );
+      await backupResponseStarted;
+
+      releaseFirstResponse();
+      expect(await firstResponseRejection).toBe(firstResponseError);
+      expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
+
+      releaseBackupResponse();
+      await backupResponse;
+      expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
+    });
+
+    it('does not let a duplicate successful response consume a later token', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+
+      let markFirstResponseStarted!: () => void;
+      const firstResponseStarted = new Promise<void>((resolve) => {
+        markFirstResponseStarted = resolve;
+      });
+      let releaseFirstResponse!: () => void;
+      const firstResponseGate = new Promise<void>((resolve) => {
+        releaseFirstResponse = resolve;
+      });
+      const writeLeaderMessage = mockWriteMessage.getMockImplementation();
+      mockWriteMessage.mockImplementationOnce(
+        async (...args: Parameters<NonNullable<typeof writeLeaderMessage>>) => {
+          markFirstResponseStarted();
+          await firstResponseGate;
+          await writeLeaderMessage!(...args);
+        },
+      );
+
+      const firstResponse = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: first response',
+        'target',
+      );
+      await firstResponseStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: backup response',
+        'target',
+      );
+      await h.teamManager.requestShutdown('target');
+
+      releaseFirstResponse();
+      await firstResponse;
+
+      const responses = (await readInbox(h.teamName, 'leader')).filter(
+        (message) =>
+          message.text === 'shutdown_rejected: first response' ||
+          message.text === 'shutdown_rejected: backup response',
+      );
+      expect(responses).toHaveLength(2);
+      expect(
+        responses.every((message) => message.type === 'shutdown_rejected'),
+      ).toBe(true);
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: later request',
+        'target',
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('reserves separate tokens for two concurrent responses when available', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+      await h.teamManager.requestShutdown('target');
+
+      let markFirstResponseStarted!: () => void;
+      const firstResponseStarted = new Promise<void>((resolve) => {
+        markFirstResponseStarted = resolve;
+      });
+      let releaseFirstResponse!: () => void;
+      const firstResponseGate = new Promise<void>((resolve) => {
+        releaseFirstResponse = resolve;
+      });
+      let markSecondResponseStarted!: () => void;
+      const secondResponseStarted = new Promise<void>((resolve) => {
+        markSecondResponseStarted = resolve;
+      });
+      let releaseSecondResponse!: () => void;
+      const secondResponseGate = new Promise<void>((resolve) => {
+        releaseSecondResponse = resolve;
+      });
+      mockWriteMessage
+        .mockImplementationOnce(async () => {
+          markFirstResponseStarted();
+          await firstResponseGate;
+        })
+        .mockImplementationOnce(async () => {
+          markSecondResponseStarted();
+          await secondResponseGate;
+        });
+
+      const firstResponse = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: first token',
+        'target',
+      );
+      await firstResponseStarted;
+      const secondResponse = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: second token',
+        'target',
+      );
+      await secondResponseStarted;
+
+      releaseSecondResponse();
+      await secondResponse;
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+
+      releaseFirstResponse();
+      await firstResponse;
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('consumes a reserved request immediately after the mailbox write succeeds', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+      const eventError = new Error('message listener failed');
+      h.teamManager.getEventEmitter().on(TeamEventType.MESSAGE_SENT, () => {
+        throw eventError;
+      });
+
+      await expect(
+        h.teamManager.sendMessage(
+          'leader',
+          'shutdown_rejected: mailbox already persisted this response',
+          'target',
+        ),
+      ).rejects.toBe(eventError);
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
+    it('does not classify a response while only a request write is in flight', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      let markRequestStarted!: () => void;
+      const requestStarted = new Promise<void>((resolve) => {
+        markRequestStarted = resolve;
+      });
+      let releaseRequest!: () => void;
+      const requestGate = new Promise<void>((resolve) => {
+        releaseRequest = resolve;
+      });
+      const requestError = new Error('EIO: request was not delivered');
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markRequestStarted();
+        await requestGate;
+        throw requestError;
+      });
+
+      const request = h.teamManager.requestShutdown('target');
+      const requestRejection = request.catch((error: unknown) => error);
+      await requestStarted;
+      await h.teamManager.sendMessage('leader', 'shutdown_approved', 'target');
+      expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
+
+      releaseRequest();
+      expect(await requestRejection).toBe(requestError);
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
     it('keeps a successful shutdown pending when a retry write fails', async () => {
       const h = await createHarness();
       await h.spawnTeammate('target', {
@@ -1101,7 +1542,7 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
-    it('clears a failed new shutdown generation after the resolved generation settles', async () => {
+    it('clears failed writes after the reserved request is resolved', async () => {
       const h = await createHarness();
       await h.spawnTeammate('target', {
         onMessage: () => {},
@@ -1145,6 +1586,127 @@ describe('TeamCoordinationHarness', () => {
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
     });
 
+    it('keeps a retry delivered after another request fails', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => 'stay_running',
+      });
+      await h.teamManager.sendMessage('target', 'stay busy', 'leader');
+      await h.waitForMessages('target', 1);
+
+      await h.teamManager.requestShutdown('target');
+
+      let markRetryStarted!: () => void;
+      const retryStarted = new Promise<void>((resolve) => {
+        markRetryStarted = resolve;
+      });
+      let releaseRetry!: () => void;
+      const retryGate = new Promise<void>((resolve) => {
+        releaseRetry = resolve;
+      });
+      const writeShutdown = mockSendStructuredMessage.getMockImplementation();
+      mockSendStructuredMessage.mockImplementationOnce(
+        async (...args: Parameters<typeof sendStructuredMessage>) => {
+          markRetryStarted();
+          await retryGate;
+          await writeShutdown!(...args);
+        },
+      );
+
+      const retry = h.teamManager.requestShutdown('target');
+      await retryStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: still working',
+        'target',
+      );
+
+      const newWriteError = new Error('EIO: new mailbox write failed');
+      mockSendStructuredMessage.mockRejectedValueOnce(newWriteError);
+      await expect(h.teamManager.requestShutdown('target')).rejects.toBe(
+        newWriteError,
+      );
+
+      releaseRetry();
+      await retry;
+
+      expect(
+        (await readInbox(h.teamName, 'target')).some(
+          (message) => message.type === 'shutdown_request' && !message.read,
+        ),
+      ).toBe(true);
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+      await h.teamManager.sendMessage('leader', 'shutdown_approved', 'target');
+      expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
+    });
+
+    it.each(['real', 'marker'] as const)(
+      'reserves current %s ownership while a blocked retry is delivered',
+      async (currentKind) => {
+        const h = await createHarness();
+        const target = await h.spawnTeammate('target', {
+          onMessage: () => {},
+        });
+
+        await h.teamManager.requestShutdown('target');
+
+        let markRetryStarted!: () => void;
+        const retryStarted = new Promise<void>((resolve) => {
+          markRetryStarted = resolve;
+        });
+        let releaseRetry!: () => void;
+        const retryGate = new Promise<void>((resolve) => {
+          releaseRetry = resolve;
+        });
+        mockSendStructuredMessage.mockImplementationOnce(async () => {
+          markRetryStarted();
+          await retryGate;
+        });
+
+        const retry = h.teamManager.requestShutdown('target');
+        await retryStarted;
+        await h.teamManager.sendMessage(
+          'leader',
+          'shutdown_rejected: still working',
+          'target',
+        );
+
+        if (currentKind === 'real') {
+          await h.teamManager.requestShutdown('target');
+        } else {
+          h.teamManager.markShutdownRequested('target');
+        }
+
+        let markResponseStarted!: () => void;
+        const responseStarted = new Promise<void>((resolve) => {
+          markResponseStarted = resolve;
+        });
+        let releaseResponse!: () => void;
+        const responseGate = new Promise<void>((resolve) => {
+          releaseResponse = resolve;
+        });
+        mockWriteMessage.mockImplementationOnce(async () => {
+          markResponseStarted();
+          await responseGate;
+        });
+
+        const approval = h.teamManager.sendMessage(
+          'leader',
+          'shutdown_approved',
+          'target',
+        );
+        await responseStarted;
+        releaseRetry();
+        await retry;
+        releaseResponse();
+        await approval;
+
+        expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
+      },
+    );
+
     it('accepts approval for a retry delivered after an earlier rejection', async () => {
       const h = await createHarness();
       const target = await h.spawnTeammate('target', {
@@ -1180,6 +1742,224 @@ describe('TeamCoordinationHarness', () => {
 
       expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
     });
+
+    it('a duplicate reserved approval does not abort after a later request is delivered', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      await h.teamManager.requestShutdown('target');
+
+      let markOldResponseStarted!: () => void;
+      const oldResponseStarted = new Promise<void>((resolve) => {
+        markOldResponseStarted = resolve;
+      });
+      let releaseOldResponse!: () => void;
+      const oldResponseGate = new Promise<void>((resolve) => {
+        releaseOldResponse = resolve;
+      });
+      mockWriteMessage.mockImplementationOnce(async () => {
+        markOldResponseStarted();
+        await oldResponseGate;
+      });
+
+      const oldApproval = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_approved',
+        'target',
+      );
+      await oldResponseStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: continue working',
+        'target',
+      );
+      await h.teamManager.requestShutdown('target');
+
+      releaseOldResponse();
+      await oldApproval;
+
+      expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+    });
+
+    it('a reserved rejection leaves a later delivered request outstanding', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      await h.teamManager.requestShutdown('target');
+
+      let markOldResponseStarted!: () => void;
+      const oldResponseStarted = new Promise<void>((resolve) => {
+        markOldResponseStarted = resolve;
+      });
+      let releaseOldResponse!: () => void;
+      const oldResponseGate = new Promise<void>((resolve) => {
+        releaseOldResponse = resolve;
+      });
+      mockWriteMessage.mockImplementationOnce(async () => {
+        markOldResponseStarted();
+        await oldResponseGate;
+      });
+
+      const oldRejection = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: old request',
+        'target',
+      );
+      await oldResponseStarted;
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: resolve old request',
+        'target',
+      );
+      await h.teamManager.requestShutdown('target');
+
+      releaseOldResponse();
+      await oldRejection;
+
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+    });
+
+    it.each(['shutdown_approved', 'shutdown_rejected: old request'])(
+      'settles a reserved real response while a marker is added: %s',
+      async (oldResponse) => {
+        const h = await createHarness();
+        const target = await h.spawnTeammate('target', {
+          onMessage: () => {},
+        });
+        await h.teamManager.requestShutdown('target');
+
+        let markOldResponseStarted!: () => void;
+        const oldResponseStarted = new Promise<void>((resolve) => {
+          markOldResponseStarted = resolve;
+        });
+        let releaseOldResponse!: () => void;
+        const oldResponseGate = new Promise<void>((resolve) => {
+          releaseOldResponse = resolve;
+        });
+        mockWriteMessage.mockImplementationOnce(async () => {
+          markOldResponseStarted();
+          await oldResponseGate;
+        });
+
+        const staleResponse = h.teamManager.sendMessage(
+          'leader',
+          oldResponse,
+          'target',
+        );
+        await oldResponseStarted;
+        h.teamManager.markShutdownRequested('target');
+
+        releaseOldResponse();
+        await staleResponse;
+
+        if (oldResponse === 'shutdown_approved') {
+          expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
+        } else {
+          expect(h.teamManager.validateTaskOwner('target')).toEqual(
+            expect.stringContaining('shutdown is already pending'),
+          );
+          expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
+        }
+      },
+    );
+
+    it.each(['shutdown_approved', 'shutdown_rejected: old marker'])(
+      'settles a reserved marker response while a real request is delivered: %s',
+      async (oldResponse) => {
+        const h = await createHarness();
+        const target = await h.spawnTeammate('target', {
+          onMessage: () => {},
+        });
+        h.teamManager.markShutdownRequested('target');
+
+        let markOldResponseStarted!: () => void;
+        const oldResponseStarted = new Promise<void>((resolve) => {
+          markOldResponseStarted = resolve;
+        });
+        let releaseOldResponse!: () => void;
+        const oldResponseGate = new Promise<void>((resolve) => {
+          releaseOldResponse = resolve;
+        });
+        mockWriteMessage.mockImplementationOnce(async () => {
+          markOldResponseStarted();
+          await oldResponseGate;
+        });
+
+        const staleResponse = h.teamManager.sendMessage(
+          'leader',
+          oldResponse,
+          'target',
+        );
+        await oldResponseStarted;
+        await h.teamManager.requestShutdown('target');
+
+        releaseOldResponse();
+        await staleResponse;
+
+        if (oldResponse === 'shutdown_approved') {
+          expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
+        } else {
+          expect(h.teamManager.validateTaskOwner('target')).toEqual(
+            expect.stringContaining('shutdown is already pending'),
+          );
+          expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
+        }
+      },
+    );
+
+    it.each(['shutdown_approved', 'shutdown_rejected: old marker'])(
+      'settles a reserved marker response while the marker is refreshed: %s',
+      async (oldResponse) => {
+        const h = await createHarness();
+        const target = await h.spawnTeammate('target', {
+          onMessage: () => {},
+        });
+        h.teamManager.markShutdownRequested('target');
+
+        let markOldResponseStarted!: () => void;
+        const oldResponseStarted = new Promise<void>((resolve) => {
+          markOldResponseStarted = resolve;
+        });
+        let releaseOldResponse!: () => void;
+        const oldResponseGate = new Promise<void>((resolve) => {
+          releaseOldResponse = resolve;
+        });
+        mockWriteMessage.mockImplementationOnce(async () => {
+          markOldResponseStarted();
+          await oldResponseGate;
+        });
+
+        const staleResponse = h.teamManager.sendMessage(
+          'leader',
+          oldResponse,
+          'target',
+        );
+        await oldResponseStarted;
+        await h.teamManager.sendMessage(
+          'leader',
+          'shutdown_rejected: clear old marker',
+          'target',
+        );
+        h.teamManager.markShutdownRequested('target');
+
+        releaseOldResponse();
+        await staleResponse;
+
+        expect(h.teamManager.validateTaskOwner('target')).toEqual(
+          expect.stringContaining('shutdown is already pending'),
+        );
+        expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
+      },
+    );
 
     it('gates task assignment while the shutdown mailbox write is pending', async () => {
       const h = await createHarness();

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -953,6 +953,62 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
+    it('keeps a successful shutdown pending when a retry write fails', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      await h.teamManager.requestShutdown('target');
+      const mailboxError = new Error('EIO: retry mailbox write failed');
+      mockSendStructuredMessage.mockRejectedValueOnce(mailboxError);
+
+      await expect(h.teamManager.requestShutdown('target')).rejects.toBe(
+        mailboxError,
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+    });
+
+    it('keeps a concurrent shutdown pending when another write fails', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      let releaseFirstWrite!: () => void;
+      const firstWriteGate = new Promise<void>((resolve) => {
+        releaseFirstWrite = resolve;
+      });
+      let markFirstWriteStarted!: () => void;
+      const firstWriteStarted = new Promise<void>((resolve) => {
+        markFirstWriteStarted = resolve;
+      });
+      mockSendStructuredMessage
+        .mockImplementationOnce(async () => {
+          markFirstWriteStarted();
+          await firstWriteGate;
+        })
+        .mockRejectedValueOnce(
+          new Error('EIO: concurrent mailbox write failed'),
+        );
+
+      const firstShutdown = h.teamManager.requestShutdown('target');
+      await firstWriteStarted;
+      await expect(h.teamManager.requestShutdown('target')).rejects.toThrow(
+        'EIO: concurrent mailbox write failed',
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+
+      releaseFirstWrite();
+      await firstShutdown;
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+    });
+
     it('gates task assignment while the shutdown mailbox write is pending', async () => {
       const h = await createHarness();
       const target = await h.spawnTeammate('target', {

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -19,6 +19,10 @@ import { TaskUpdateTool } from '../../../tools/task-update.js';
 import type { TaskUpdateParams } from '../../../tools/task-update.js';
 import type { Config } from '../../../config/config.js';
 
+const { mockSendStructuredMessage } = vi.hoisted(() => ({
+  mockSendStructuredMessage: vi.fn(),
+}));
+
 // Mock Storage so all file I/O uses the harness's temp dir.
 vi.mock('../../../config/storage.js', async (importOriginal) => {
   const original =
@@ -33,6 +37,15 @@ vi.mock('../../../config/storage.js', async (importOriginal) => {
         mockGlobalDir = dir;
       },
     },
+  };
+});
+
+vi.mock('../mailbox.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../mailbox.js')>();
+  mockSendStructuredMessage.mockImplementation(original.sendStructuredMessage);
+  return {
+    ...original,
+    sendStructuredMessage: mockSendStructuredMessage,
   };
 });
 
@@ -915,6 +928,29 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('worker');
       await h.waitForStatus('worker', AgentStatus.COMPLETED);
+    });
+
+    it('does not gate a teammate when the shutdown mailbox write fails', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      const mailboxError = new Error('EIO: mailbox write failed');
+      mockSendStructuredMessage.mockRejectedValueOnce(mailboxError);
+
+      await expect(h.teamManager.requestShutdown('target')).rejects.toBe(
+        mailboxError,
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+
+      await createTask(h.teamName, {
+        subject: 'After failed shutdown',
+        description: 'Should still be claimable',
+      });
+      await h.waitForMessages('target', 1);
+      expect(target.getReceivedMessages()[0]).toContain(
+        'After failed shutdown',
+      );
     });
 
     it('shutdown_approved from the requested teammate aborts them', async () => {

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -953,6 +953,45 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
+    it('gates task assignment while the shutdown mailbox write is pending', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      let markWriteStarted!: () => void;
+      const writeStarted = new Promise<void>((resolve) => {
+        markWriteStarted = resolve;
+      });
+      let releaseWrite!: () => void;
+      const writeGate = new Promise<void>((resolve) => {
+        releaseWrite = resolve;
+      });
+      mockSendStructuredMessage.mockImplementationOnce(async () => {
+        markWriteStarted();
+        await writeGate;
+      });
+
+      const shutdown = h.teamManager.requestShutdown('target');
+      await writeStarted;
+      const task = await createTask(h.teamName, {
+        subject: 'During pending shutdown',
+        description: 'Must remain unassigned',
+      });
+      await (
+        h.teamManager as unknown as {
+          scanIdleAgentsForTasks(): Promise<void>;
+        }
+      ).scanIdleAgentsForTasks();
+
+      const pending = await getTask(h.teamName, task.id);
+      expect(pending?.status).toBe('pending');
+      expect(pending?.owner).toBeUndefined();
+      expect(target.getReceivedMessages()).toHaveLength(0);
+
+      releaseWrite();
+      await shutdown;
+    });
+
     it('shutdown_approved from the requested teammate aborts them', async () => {
       const h = await createHarness();
       const target = await h.spawnTeammate('target', {

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AgentEventType } from '../../runtime/agent-events.js';
 import { AgentStatus } from '../../runtime/agent-types.js';
 import { TeamCoordinationHarness } from './coordination-harness.js';
@@ -20,10 +20,20 @@ import { TaskUpdateTool } from '../../../tools/task-update.js';
 import type { TaskUpdateParams } from '../../../tools/task-update.js';
 import type { Config } from '../../../config/config.js';
 
-const { mockSendStructuredMessage, mockWriteMessage } = vi.hoisted(() => ({
-  mockSendStructuredMessage: vi.fn(),
-  mockWriteMessage: vi.fn(),
-}));
+const { mockSendStructuredMessage, mockWriteMessage, realMailbox } = vi.hoisted(
+  () => ({
+    mockSendStructuredMessage: vi.fn(),
+    mockWriteMessage: vi.fn(),
+    realMailbox: {
+      sendStructuredMessage: undefined as
+        | typeof import('../mailbox.js').sendStructuredMessage
+        | undefined,
+      writeMessage: undefined as
+        | typeof import('../mailbox.js').writeMessage
+        | undefined,
+    },
+  }),
+);
 
 // Mock Storage so all file I/O uses the harness's temp dir.
 vi.mock('../../../config/storage.js', async (importOriginal) => {
@@ -44,6 +54,8 @@ vi.mock('../../../config/storage.js', async (importOriginal) => {
 
 vi.mock('../mailbox.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../mailbox.js')>();
+  realMailbox.sendStructuredMessage = original.sendStructuredMessage;
+  realMailbox.writeMessage = original.writeMessage;
   mockSendStructuredMessage.mockImplementation(original.sendStructuredMessage);
   mockWriteMessage.mockImplementation(original.writeMessage);
   return {
@@ -61,6 +73,39 @@ function setMockDir(dir: string): void {
       __setMockGlobalDir: (d: string) => void;
     }
   ).__setMockGlobalDir(dir);
+}
+
+function gateNextMailboxWrite<TArgs extends unknown[]>(
+  mailboxWrite: {
+    mockImplementationOnce(
+      implementation: (...args: TArgs) => Promise<void>,
+    ): unknown;
+  },
+  options: {
+    delegate?: (...args: TArgs) => Promise<void>;
+    rejectWith?: Error;
+  } = {},
+): {
+  started: Promise<void>;
+  release: () => void;
+} {
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  mailboxWrite.mockImplementationOnce(async (...args: TArgs) => {
+    markStarted();
+    await gate;
+    if (options.rejectWith) {
+      throw options.rejectWith;
+    }
+    await options.delegate?.(...args);
+  });
+  return { started, release };
 }
 
 // ─── Helpers ──────────────────────────────────────────────────
@@ -88,6 +133,15 @@ function expectTeamMessage(
 
 describe('TeamCoordinationHarness', () => {
   let harness: TeamCoordinationHarness | undefined;
+
+  beforeEach(() => {
+    mockSendStructuredMessage.mockReset();
+    mockWriteMessage.mockReset();
+    mockSendStructuredMessage.mockImplementation(
+      realMailbox.sendStructuredMessage!,
+    );
+    mockWriteMessage.mockImplementation(realMailbox.writeMessage!);
+  });
 
   afterEach(async () => {
     if (harness) {
@@ -934,6 +988,54 @@ describe('TeamCoordinationHarness', () => {
       await h.waitForStatus('worker', AgentStatus.COMPLETED);
     });
 
+    it('delivers every shutdown consumed by one idle flush exactly once', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => 'stay_running',
+      });
+      await h.teamManager.sendMessage('target', 'stay busy', 'leader');
+      await h.waitForMessages('target', 1);
+
+      await h.teamManager.requestShutdown('target');
+      await h.teamManager.requestShutdown('target');
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+
+      target.goIdle();
+      await h.waitForMessages('target', 2);
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: first request',
+        'target',
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+
+      target.goIdle();
+      await vi.waitFor(
+        () => {
+          expect(target.getReceivedMessages()).toHaveLength(3);
+        },
+        { timeout: 250 },
+      );
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: second request',
+        'target',
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+
+      target.goIdle();
+      await (
+        h.teamManager as unknown as {
+          flushNextMessage(agentId: string, agentName: string): Promise<void>;
+        }
+      ).flushNextMessage(target.agentId, target.agentName);
+      expect(target.getReceivedMessages()).toHaveLength(3);
+    });
+
     it('does not gate a teammate when the shutdown mailbox write fails', async () => {
       const h = await createHarness();
       const target = await h.spawnTeammate('target', {
@@ -974,6 +1076,23 @@ describe('TeamCoordinationHarness', () => {
       );
     });
 
+    it('keeps markShutdownRequested idempotent until one response settles', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+
+      h.teamManager.markShutdownRequested('target');
+      h.teamManager.markShutdownRequested('target');
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: marker resolved',
+        'target',
+      );
+
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
     it('does not restore a marker after a failed shutdown request is rejected', async () => {
       const h = await createHarness();
       await h.spawnTeammate('target', {
@@ -981,31 +1100,21 @@ describe('TeamCoordinationHarness', () => {
       });
       h.teamManager.markShutdownRequested('target');
 
-      let markWriteStarted!: () => void;
-      const writeStarted = new Promise<void>((resolve) => {
-        markWriteStarted = resolve;
-      });
-      let releaseWrite!: () => void;
-      const writeGate = new Promise<void>((resolve) => {
-        releaseWrite = resolve;
-      });
       const mailboxError = new Error('EIO: mailbox write failed');
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markWriteStarted();
-        await writeGate;
-        throw mailboxError;
+      const write = gateNextMailboxWrite(mockSendStructuredMessage, {
+        rejectWith: mailboxError,
       });
 
       const shutdown = h.teamManager.requestShutdown('target');
       const shutdownRejection = shutdown.catch((error: unknown) => error);
-      await writeStarted;
+      await write.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: still working',
         'target',
       );
 
-      releaseWrite();
+      write.release();
       expect(await shutdownRejection).toBe(mailboxError);
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
     });
@@ -1017,69 +1126,34 @@ describe('TeamCoordinationHarness', () => {
       });
       await h.teamManager.requestShutdown('target');
 
-      let markRetryStarted!: () => void;
-      const retryStarted = new Promise<void>((resolve) => {
-        markRetryStarted = resolve;
-      });
-      let releaseRetry!: () => void;
-      const retryGate = new Promise<void>((resolve) => {
-        releaseRetry = resolve;
-      });
-      let markNextRequestStarted!: () => void;
-      const nextRequestStarted = new Promise<void>((resolve) => {
-        markNextRequestStarted = resolve;
-      });
-      let releaseNextRequest!: () => void;
-      const nextRequestGate = new Promise<void>((resolve) => {
-        releaseNextRequest = resolve;
-      });
       const nextRequestError = new Error('EIO: next mailbox write failed');
-      const writeShutdown = mockSendStructuredMessage.getMockImplementation();
-      mockSendStructuredMessage
-        .mockImplementationOnce(
-          async (...args: Parameters<typeof sendStructuredMessage>) => {
-            markRetryStarted();
-            await retryGate;
-            await writeShutdown!(...args);
-          },
-        )
-        .mockImplementationOnce(async () => {
-          markNextRequestStarted();
-          await nextRequestGate;
-          throw nextRequestError;
-        });
+      const retryWrite = gateNextMailboxWrite(mockSendStructuredMessage, {
+        delegate: realMailbox.sendStructuredMessage!,
+      });
+      const nextRequestWrite = gateNextMailboxWrite(mockSendStructuredMessage, {
+        rejectWith: nextRequestError,
+      });
 
       const retry = h.teamManager.requestShutdown('target');
-      await retryStarted;
+      await retryWrite.started;
 
-      let markRejectionStarted!: () => void;
-      const rejectionStarted = new Promise<void>((resolve) => {
-        markRejectionStarted = resolve;
-      });
-      let releaseRejection!: () => void;
-      const rejectionGate = new Promise<void>((resolve) => {
-        releaseRejection = resolve;
-      });
-      mockWriteMessage.mockImplementationOnce(async () => {
-        markRejectionStarted();
-        await rejectionGate;
-      });
+      const rejectionWrite = gateNextMailboxWrite(mockWriteMessage);
       const rejection = h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: retry later',
         'target',
       );
-      await rejectionStarted;
+      await rejectionWrite.started;
 
       const nextRequest = h.teamManager.requestShutdown('target');
       const nextRequestRejection = nextRequest.catch((error: unknown) => error);
-      await nextRequestStarted;
+      await nextRequestWrite.started;
 
-      releaseRetry();
+      retryWrite.release();
       await retry;
-      releaseNextRequest();
+      nextRequestWrite.release();
       expect(await nextRequestRejection).toBe(nextRequestError);
-      releaseRejection();
+      rejectionWrite.release();
       await rejection;
 
       expect(h.teamManager.validateTaskOwner('target')).toEqual(
@@ -1100,46 +1174,25 @@ describe('TeamCoordinationHarness', () => {
       });
       h.teamManager.markShutdownRequested('target');
 
-      let markResponseStarted!: () => void;
-      const responseStarted = new Promise<void>((resolve) => {
-        markResponseStarted = resolve;
-      });
-      let releaseResponse!: () => void;
-      const responseGate = new Promise<void>((resolve) => {
-        releaseResponse = resolve;
-      });
-      mockWriteMessage.mockImplementationOnce(async () => {
-        markResponseStarted();
-        await responseGate;
-      });
+      const responseWrite = gateNextMailboxWrite(mockWriteMessage);
       const markerResponse = h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: keep working',
         'target',
       );
-      await responseStarted;
+      await responseWrite.started;
 
-      let markRequestStarted!: () => void;
-      const requestStarted = new Promise<void>((resolve) => {
-        markRequestStarted = resolve;
-      });
-      let releaseRequest!: () => void;
-      const requestGate = new Promise<void>((resolve) => {
-        releaseRequest = resolve;
-      });
       const requestError = new Error('EIO: real mailbox write failed');
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markRequestStarted();
-        await requestGate;
-        throw requestError;
+      const requestWrite = gateNextMailboxWrite(mockSendStructuredMessage, {
+        rejectWith: requestError,
       });
       const request = h.teamManager.requestShutdown('target');
       const requestRejection = request.catch((error: unknown) => error);
-      await requestStarted;
+      await requestWrite.started;
 
-      releaseResponse();
+      responseWrite.release();
       await markerResponse;
-      releaseRequest();
+      requestWrite.release();
       expect(await requestRejection).toBe(requestError);
 
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
@@ -1180,39 +1233,13 @@ describe('TeamCoordinationHarness', () => {
       });
       await h.teamManager.requestShutdown('target');
 
-      let markFirstResponseStarted!: () => void;
-      const firstResponseStarted = new Promise<void>((resolve) => {
-        markFirstResponseStarted = resolve;
-      });
-      let releaseFirstResponse!: () => void;
-      const firstResponseGate = new Promise<void>((resolve) => {
-        releaseFirstResponse = resolve;
-      });
-      let markBackupResponseStarted!: () => void;
-      const backupResponseStarted = new Promise<void>((resolve) => {
-        markBackupResponseStarted = resolve;
-      });
-      let releaseBackupResponse!: () => void;
-      const backupResponseGate = new Promise<void>((resolve) => {
-        releaseBackupResponse = resolve;
-      });
       const firstResponseError = new Error('EIO: first response write failed');
-      const writeLeaderMessage = mockWriteMessage.getMockImplementation();
-      mockWriteMessage
-        .mockImplementationOnce(async () => {
-          markFirstResponseStarted();
-          await firstResponseGate;
-          throw firstResponseError;
-        })
-        .mockImplementationOnce(
-          async (
-            ...args: Parameters<NonNullable<typeof writeLeaderMessage>>
-          ) => {
-            markBackupResponseStarted();
-            await backupResponseGate;
-            await writeLeaderMessage!(...args);
-          },
-        );
+      const firstWrite = gateNextMailboxWrite(mockWriteMessage, {
+        rejectWith: firstResponseError,
+      });
+      const backupWrite = gateNextMailboxWrite(mockWriteMessage, {
+        delegate: realMailbox.writeMessage!,
+      });
 
       const firstResponse = h.teamManager.sendMessage(
         'leader',
@@ -1222,20 +1249,20 @@ describe('TeamCoordinationHarness', () => {
       const firstResponseRejection = firstResponse.catch(
         (error: unknown) => error,
       );
-      await firstResponseStarted;
+      await firstWrite.started;
 
       const backupResponse = h.teamManager.sendMessage(
         'leader',
         'shutdown_approved',
         'target',
       );
-      await backupResponseStarted;
+      await backupWrite.started;
 
-      releaseFirstResponse();
+      firstWrite.release();
       expect(await firstResponseRejection).toBe(firstResponseError);
       expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
 
-      releaseBackupResponse();
+      backupWrite.release();
       await backupResponse;
       expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
     });
@@ -1247,29 +1274,16 @@ describe('TeamCoordinationHarness', () => {
       });
       await h.teamManager.requestShutdown('target');
 
-      let markFirstResponseStarted!: () => void;
-      const firstResponseStarted = new Promise<void>((resolve) => {
-        markFirstResponseStarted = resolve;
+      const firstWrite = gateNextMailboxWrite(mockWriteMessage, {
+        delegate: realMailbox.writeMessage!,
       });
-      let releaseFirstResponse!: () => void;
-      const firstResponseGate = new Promise<void>((resolve) => {
-        releaseFirstResponse = resolve;
-      });
-      const writeLeaderMessage = mockWriteMessage.getMockImplementation();
-      mockWriteMessage.mockImplementationOnce(
-        async (...args: Parameters<NonNullable<typeof writeLeaderMessage>>) => {
-          markFirstResponseStarted();
-          await firstResponseGate;
-          await writeLeaderMessage!(...args);
-        },
-      );
 
       const firstResponse = h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: first response',
         'target',
       );
-      await firstResponseStarted;
+      await firstWrite.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: backup response',
@@ -1277,7 +1291,7 @@ describe('TeamCoordinationHarness', () => {
       );
       await h.teamManager.requestShutdown('target');
 
-      releaseFirstResponse();
+      firstWrite.release();
       await firstResponse;
 
       const responses = (await readInbox(h.teamName, 'leader')).filter(
@@ -1301,6 +1315,37 @@ describe('TeamCoordinationHarness', () => {
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
     });
 
+    it('stays gated between duplicate response settlements', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+
+      const firstWrite = gateNextMailboxWrite(mockWriteMessage, {
+        delegate: realMailbox.writeMessage!,
+      });
+      const firstResponse = h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: first response',
+        'target',
+      );
+      await firstWrite.started;
+
+      await h.teamManager.sendMessage(
+        'leader',
+        'shutdown_rejected: duplicate response',
+        'target',
+      );
+      expect(h.teamManager.validateTaskOwner('target')).toEqual(
+        expect.stringContaining('shutdown is already pending'),
+      );
+
+      firstWrite.release();
+      await firstResponse;
+      expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
+    });
+
     it('reserves separate tokens for two concurrent responses when available', async () => {
       const h = await createHarness();
       await h.spawnTeammate('target', {
@@ -1309,52 +1354,29 @@ describe('TeamCoordinationHarness', () => {
       await h.teamManager.requestShutdown('target');
       await h.teamManager.requestShutdown('target');
 
-      let markFirstResponseStarted!: () => void;
-      const firstResponseStarted = new Promise<void>((resolve) => {
-        markFirstResponseStarted = resolve;
-      });
-      let releaseFirstResponse!: () => void;
-      const firstResponseGate = new Promise<void>((resolve) => {
-        releaseFirstResponse = resolve;
-      });
-      let markSecondResponseStarted!: () => void;
-      const secondResponseStarted = new Promise<void>((resolve) => {
-        markSecondResponseStarted = resolve;
-      });
-      let releaseSecondResponse!: () => void;
-      const secondResponseGate = new Promise<void>((resolve) => {
-        releaseSecondResponse = resolve;
-      });
-      mockWriteMessage
-        .mockImplementationOnce(async () => {
-          markFirstResponseStarted();
-          await firstResponseGate;
-        })
-        .mockImplementationOnce(async () => {
-          markSecondResponseStarted();
-          await secondResponseGate;
-        });
+      const firstWrite = gateNextMailboxWrite(mockWriteMessage);
+      const secondWrite = gateNextMailboxWrite(mockWriteMessage);
 
       const firstResponse = h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: first token',
         'target',
       );
-      await firstResponseStarted;
+      await firstWrite.started;
       const secondResponse = h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: second token',
         'target',
       );
-      await secondResponseStarted;
+      await secondWrite.started;
 
-      releaseSecondResponse();
+      secondWrite.release();
       await secondResponse;
       expect(h.teamManager.validateTaskOwner('target')).toEqual(
         expect.stringContaining('shutdown is already pending'),
       );
 
-      releaseFirstResponse();
+      firstWrite.release();
       await firstResponse;
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
     });
@@ -1380,33 +1402,40 @@ describe('TeamCoordinationHarness', () => {
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
     });
 
+    it('aborts an approved teammate when the message listener throws', async () => {
+      const h = await createHarness();
+      const target = await h.spawnTeammate('target', {
+        onMessage: () => {},
+      });
+      await h.teamManager.requestShutdown('target');
+      const eventError = new Error('message listener failed');
+      h.teamManager.getEventEmitter().on(TeamEventType.MESSAGE_SENT, () => {
+        throw eventError;
+      });
+
+      await expect(
+        h.teamManager.sendMessage('leader', 'shutdown_approved', 'target'),
+      ).rejects.toBe(eventError);
+      expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
+    });
+
     it('does not classify a response while only a request write is in flight', async () => {
       const h = await createHarness();
       const target = await h.spawnTeammate('target', {
         onMessage: () => {},
       });
-      let markRequestStarted!: () => void;
-      const requestStarted = new Promise<void>((resolve) => {
-        markRequestStarted = resolve;
-      });
-      let releaseRequest!: () => void;
-      const requestGate = new Promise<void>((resolve) => {
-        releaseRequest = resolve;
-      });
       const requestError = new Error('EIO: request was not delivered');
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markRequestStarted();
-        await requestGate;
-        throw requestError;
+      const requestWrite = gateNextMailboxWrite(mockSendStructuredMessage, {
+        rejectWith: requestError,
       });
 
       const request = h.teamManager.requestShutdown('target');
       const requestRejection = request.catch((error: unknown) => error);
-      await requestStarted;
+      await requestWrite.started;
       await h.teamManager.sendMessage('leader', 'shutdown_approved', 'target');
       expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
 
-      releaseRequest();
+      requestWrite.release();
       expect(await requestRejection).toBe(requestError);
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
     });
@@ -1434,25 +1463,13 @@ describe('TeamCoordinationHarness', () => {
       await h.spawnTeammate('target', {
         onMessage: () => {},
       });
-      let releaseFirstWrite!: () => void;
-      const firstWriteGate = new Promise<void>((resolve) => {
-        releaseFirstWrite = resolve;
-      });
-      let markFirstWriteStarted!: () => void;
-      const firstWriteStarted = new Promise<void>((resolve) => {
-        markFirstWriteStarted = resolve;
-      });
-      mockSendStructuredMessage
-        .mockImplementationOnce(async () => {
-          markFirstWriteStarted();
-          await firstWriteGate;
-        })
-        .mockRejectedValueOnce(
-          new Error('EIO: concurrent mailbox write failed'),
-        );
+      const firstWrite = gateNextMailboxWrite(mockSendStructuredMessage);
+      mockSendStructuredMessage.mockRejectedValueOnce(
+        new Error('EIO: concurrent mailbox write failed'),
+      );
 
       const firstShutdown = h.teamManager.requestShutdown('target');
-      await firstWriteStarted;
+      await firstWrite.started;
       await expect(h.teamManager.requestShutdown('target')).rejects.toThrow(
         'EIO: concurrent mailbox write failed',
       );
@@ -1460,7 +1477,7 @@ describe('TeamCoordinationHarness', () => {
         expect.stringContaining('shutdown is already pending'),
       );
 
-      releaseFirstWrite();
+      firstWrite.release();
       await firstShutdown;
       expect(h.teamManager.validateTaskOwner('target')).toEqual(
         expect.stringContaining('shutdown is already pending'),
@@ -1475,28 +1492,17 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('target');
 
-      let markWriteStarted!: () => void;
-      const writeStarted = new Promise<void>((resolve) => {
-        markWriteStarted = resolve;
-      });
-      let releaseWrite!: () => void;
-      const writeGate = new Promise<void>((resolve) => {
-        releaseWrite = resolve;
-      });
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markWriteStarted();
-        await writeGate;
-      });
+      const write = gateNextMailboxWrite(mockSendStructuredMessage);
 
       const concurrentShutdown = h.teamManager.requestShutdown('target');
-      await writeStarted;
+      await write.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: still working',
         'target',
       );
 
-      releaseWrite();
+      write.release();
       await concurrentShutdown;
 
       expect(h.teamManager.validateTaskOwner('target')).toEqual(
@@ -1512,21 +1518,10 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('target');
 
-      let markOldWriteStarted!: () => void;
-      const oldWriteStarted = new Promise<void>((resolve) => {
-        markOldWriteStarted = resolve;
-      });
-      let releaseOldWrite!: () => void;
-      const oldWriteGate = new Promise<void>((resolve) => {
-        releaseOldWrite = resolve;
-      });
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markOldWriteStarted();
-        await oldWriteGate;
-      });
+      const oldWrite = gateNextMailboxWrite(mockSendStructuredMessage);
 
       const oldShutdown = h.teamManager.requestShutdown('target');
-      await oldWriteStarted;
+      await oldWrite.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: still working',
@@ -1534,7 +1529,7 @@ describe('TeamCoordinationHarness', () => {
       );
 
       await h.teamManager.requestShutdown('target');
-      releaseOldWrite();
+      oldWrite.release();
       await oldShutdown;
 
       expect(h.teamManager.validateTaskOwner('target')).toEqual(
@@ -1550,24 +1545,14 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('target');
 
-      let markOldWriteStarted!: () => void;
-      const oldWriteStarted = new Promise<void>((resolve) => {
-        markOldWriteStarted = resolve;
-      });
-      let releaseOldWrite!: () => void;
-      const oldWriteGate = new Promise<void>((resolve) => {
-        releaseOldWrite = resolve;
-      });
       const oldWriteError = new Error('EIO: old mailbox write failed');
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markOldWriteStarted();
-        await oldWriteGate;
-        throw oldWriteError;
+      const oldWrite = gateNextMailboxWrite(mockSendStructuredMessage, {
+        rejectWith: oldWriteError,
       });
 
       const oldShutdown = h.teamManager.requestShutdown('target');
       const oldShutdownRejection = oldShutdown.catch((error: unknown) => error);
-      await oldWriteStarted;
+      await oldWrite.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: still working',
@@ -1580,7 +1565,7 @@ describe('TeamCoordinationHarness', () => {
         newWriteError,
       );
 
-      releaseOldWrite();
+      oldWrite.release();
       expect(await oldShutdownRejection).toBe(oldWriteError);
 
       expect(h.teamManager.validateTaskOwner('target')).toBeUndefined();
@@ -1596,25 +1581,12 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('target');
 
-      let markRetryStarted!: () => void;
-      const retryStarted = new Promise<void>((resolve) => {
-        markRetryStarted = resolve;
+      const retryWrite = gateNextMailboxWrite(mockSendStructuredMessage, {
+        delegate: realMailbox.sendStructuredMessage!,
       });
-      let releaseRetry!: () => void;
-      const retryGate = new Promise<void>((resolve) => {
-        releaseRetry = resolve;
-      });
-      const writeShutdown = mockSendStructuredMessage.getMockImplementation();
-      mockSendStructuredMessage.mockImplementationOnce(
-        async (...args: Parameters<typeof sendStructuredMessage>) => {
-          markRetryStarted();
-          await retryGate;
-          await writeShutdown!(...args);
-        },
-      );
 
       const retry = h.teamManager.requestShutdown('target');
-      await retryStarted;
+      await retryWrite.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: still working',
@@ -1627,7 +1599,7 @@ describe('TeamCoordinationHarness', () => {
         newWriteError,
       );
 
-      releaseRetry();
+      retryWrite.release();
       await retry;
 
       expect(
@@ -1652,21 +1624,10 @@ describe('TeamCoordinationHarness', () => {
 
         await h.teamManager.requestShutdown('target');
 
-        let markRetryStarted!: () => void;
-        const retryStarted = new Promise<void>((resolve) => {
-          markRetryStarted = resolve;
-        });
-        let releaseRetry!: () => void;
-        const retryGate = new Promise<void>((resolve) => {
-          releaseRetry = resolve;
-        });
-        mockSendStructuredMessage.mockImplementationOnce(async () => {
-          markRetryStarted();
-          await retryGate;
-        });
+        const retryWrite = gateNextMailboxWrite(mockSendStructuredMessage);
 
         const retry = h.teamManager.requestShutdown('target');
-        await retryStarted;
+        await retryWrite.started;
         await h.teamManager.sendMessage(
           'leader',
           'shutdown_rejected: still working',
@@ -1679,28 +1640,17 @@ describe('TeamCoordinationHarness', () => {
           h.teamManager.markShutdownRequested('target');
         }
 
-        let markResponseStarted!: () => void;
-        const responseStarted = new Promise<void>((resolve) => {
-          markResponseStarted = resolve;
-        });
-        let releaseResponse!: () => void;
-        const responseGate = new Promise<void>((resolve) => {
-          releaseResponse = resolve;
-        });
-        mockWriteMessage.mockImplementationOnce(async () => {
-          markResponseStarted();
-          await responseGate;
-        });
+        const responseWrite = gateNextMailboxWrite(mockWriteMessage);
 
         const approval = h.teamManager.sendMessage(
           'leader',
           'shutdown_approved',
           'target',
         );
-        await responseStarted;
-        releaseRetry();
+        await responseWrite.started;
+        retryWrite.release();
         await retry;
-        releaseResponse();
+        responseWrite.release();
         await approval;
 
         expect(target.getStatus()).toBe(AgentStatus.CANCELLED);
@@ -1715,28 +1665,17 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('target');
 
-      let markRetryStarted!: () => void;
-      const retryStarted = new Promise<void>((resolve) => {
-        markRetryStarted = resolve;
-      });
-      let releaseRetry!: () => void;
-      const retryGate = new Promise<void>((resolve) => {
-        releaseRetry = resolve;
-      });
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markRetryStarted();
-        await retryGate;
-      });
+      const retryWrite = gateNextMailboxWrite(mockSendStructuredMessage);
 
       const retry = h.teamManager.requestShutdown('target');
-      await retryStarted;
+      await retryWrite.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: still working',
         'target',
       );
 
-      releaseRetry();
+      retryWrite.release();
       await retry;
       await h.teamManager.sendMessage('leader', 'shutdown_approved', 'target');
 
@@ -1751,25 +1690,14 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('target');
 
-      let markOldResponseStarted!: () => void;
-      const oldResponseStarted = new Promise<void>((resolve) => {
-        markOldResponseStarted = resolve;
-      });
-      let releaseOldResponse!: () => void;
-      const oldResponseGate = new Promise<void>((resolve) => {
-        releaseOldResponse = resolve;
-      });
-      mockWriteMessage.mockImplementationOnce(async () => {
-        markOldResponseStarted();
-        await oldResponseGate;
-      });
+      const oldResponseWrite = gateNextMailboxWrite(mockWriteMessage);
 
       const oldApproval = h.teamManager.sendMessage(
         'leader',
         'shutdown_approved',
         'target',
       );
-      await oldResponseStarted;
+      await oldResponseWrite.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: continue working',
@@ -1777,7 +1705,7 @@ describe('TeamCoordinationHarness', () => {
       );
       await h.teamManager.requestShutdown('target');
 
-      releaseOldResponse();
+      oldResponseWrite.release();
       await oldApproval;
 
       expect(target.getStatus()).not.toBe(AgentStatus.CANCELLED);
@@ -1794,25 +1722,14 @@ describe('TeamCoordinationHarness', () => {
 
       await h.teamManager.requestShutdown('target');
 
-      let markOldResponseStarted!: () => void;
-      const oldResponseStarted = new Promise<void>((resolve) => {
-        markOldResponseStarted = resolve;
-      });
-      let releaseOldResponse!: () => void;
-      const oldResponseGate = new Promise<void>((resolve) => {
-        releaseOldResponse = resolve;
-      });
-      mockWriteMessage.mockImplementationOnce(async () => {
-        markOldResponseStarted();
-        await oldResponseGate;
-      });
+      const oldResponseWrite = gateNextMailboxWrite(mockWriteMessage);
 
       const oldRejection = h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: old request',
         'target',
       );
-      await oldResponseStarted;
+      await oldResponseWrite.started;
       await h.teamManager.sendMessage(
         'leader',
         'shutdown_rejected: resolve old request',
@@ -1820,7 +1737,7 @@ describe('TeamCoordinationHarness', () => {
       );
       await h.teamManager.requestShutdown('target');
 
-      releaseOldResponse();
+      oldResponseWrite.release();
       await oldRejection;
 
       expect(h.teamManager.validateTaskOwner('target')).toEqual(
@@ -1837,28 +1754,17 @@ describe('TeamCoordinationHarness', () => {
         });
         await h.teamManager.requestShutdown('target');
 
-        let markOldResponseStarted!: () => void;
-        const oldResponseStarted = new Promise<void>((resolve) => {
-          markOldResponseStarted = resolve;
-        });
-        let releaseOldResponse!: () => void;
-        const oldResponseGate = new Promise<void>((resolve) => {
-          releaseOldResponse = resolve;
-        });
-        mockWriteMessage.mockImplementationOnce(async () => {
-          markOldResponseStarted();
-          await oldResponseGate;
-        });
+        const oldResponseWrite = gateNextMailboxWrite(mockWriteMessage);
 
         const staleResponse = h.teamManager.sendMessage(
           'leader',
           oldResponse,
           'target',
         );
-        await oldResponseStarted;
+        await oldResponseWrite.started;
         h.teamManager.markShutdownRequested('target');
 
-        releaseOldResponse();
+        oldResponseWrite.release();
         await staleResponse;
 
         if (oldResponse === 'shutdown_approved') {
@@ -1881,28 +1787,17 @@ describe('TeamCoordinationHarness', () => {
         });
         h.teamManager.markShutdownRequested('target');
 
-        let markOldResponseStarted!: () => void;
-        const oldResponseStarted = new Promise<void>((resolve) => {
-          markOldResponseStarted = resolve;
-        });
-        let releaseOldResponse!: () => void;
-        const oldResponseGate = new Promise<void>((resolve) => {
-          releaseOldResponse = resolve;
-        });
-        mockWriteMessage.mockImplementationOnce(async () => {
-          markOldResponseStarted();
-          await oldResponseGate;
-        });
+        const oldResponseWrite = gateNextMailboxWrite(mockWriteMessage);
 
         const staleResponse = h.teamManager.sendMessage(
           'leader',
           oldResponse,
           'target',
         );
-        await oldResponseStarted;
+        await oldResponseWrite.started;
         await h.teamManager.requestShutdown('target');
 
-        releaseOldResponse();
+        oldResponseWrite.release();
         await staleResponse;
 
         if (oldResponse === 'shutdown_approved') {
@@ -1925,25 +1820,14 @@ describe('TeamCoordinationHarness', () => {
         });
         h.teamManager.markShutdownRequested('target');
 
-        let markOldResponseStarted!: () => void;
-        const oldResponseStarted = new Promise<void>((resolve) => {
-          markOldResponseStarted = resolve;
-        });
-        let releaseOldResponse!: () => void;
-        const oldResponseGate = new Promise<void>((resolve) => {
-          releaseOldResponse = resolve;
-        });
-        mockWriteMessage.mockImplementationOnce(async () => {
-          markOldResponseStarted();
-          await oldResponseGate;
-        });
+        const oldResponseWrite = gateNextMailboxWrite(mockWriteMessage);
 
         const staleResponse = h.teamManager.sendMessage(
           'leader',
           oldResponse,
           'target',
         );
-        await oldResponseStarted;
+        await oldResponseWrite.started;
         await h.teamManager.sendMessage(
           'leader',
           'shutdown_rejected: clear old marker',
@@ -1951,7 +1835,7 @@ describe('TeamCoordinationHarness', () => {
         );
         h.teamManager.markShutdownRequested('target');
 
-        releaseOldResponse();
+        oldResponseWrite.release();
         await staleResponse;
 
         expect(h.teamManager.validateTaskOwner('target')).toEqual(
@@ -1966,21 +1850,10 @@ describe('TeamCoordinationHarness', () => {
       const target = await h.spawnTeammate('target', {
         onMessage: () => {},
       });
-      let markWriteStarted!: () => void;
-      const writeStarted = new Promise<void>((resolve) => {
-        markWriteStarted = resolve;
-      });
-      let releaseWrite!: () => void;
-      const writeGate = new Promise<void>((resolve) => {
-        releaseWrite = resolve;
-      });
-      mockSendStructuredMessage.mockImplementationOnce(async () => {
-        markWriteStarted();
-        await writeGate;
-      });
+      const write = gateNextMailboxWrite(mockSendStructuredMessage);
 
       const shutdown = h.teamManager.requestShutdown('target');
-      await writeStarted;
+      await write.started;
       const task = await createTask(h.teamName, {
         subject: 'During pending shutdown',
         description: 'Must remain unassigned',
@@ -1996,7 +1869,7 @@ describe('TeamCoordinationHarness', () => {
       expect(pending?.owner).toBeUndefined();
       expect(target.getReceivedMessages()).toHaveLength(0);
 
-      releaseWrite();
+      write.release();
       await shutdown;
     });
 


### PR DESCRIPTION
## What this PR does

This change gates task assignment while teammate shutdown requests are being written, delivered, or answered. It models each successfully delivered request as an outstanding token rather than a shared boolean or generation guess.

- in-flight mailbox writes gate assignment immediately;
- each successful shutdown request creates a distinct outstanding token;
- responses reserve a token, and concurrent fallback responses can share that token;
- only the first successfully persisted response consumes the token and may trigger approval abort;
- failed response writes release reservations without clearing the request;
- duplicate successful responses cannot consume a newer request;
- test-injected shutdown markers use the same token ownership model.

## Why it's needed

The previous `_shutdownPending` boolean had no ownership model. Failed writes, retries, and responses could clear another request's state or leave a stale gate. Generation-based fixes also fail because the wire protocol carries no request ID. A token ledger matches the observable protocol: delivered requests remain outstanding until one successfully persisted response consumes each token.

## Reviewer Test Plan

Run:

```bash
npm test --workspace @qwen-code/qwen-code-core -- --run src/agents/team/test-utils/coordination-harness.test.ts
```

Verified: 82 harness tests, full core suite (20,763 passed, 28 skipped), build, lint, typecheck, Prettier, and `git diff --check`.

The matrix covers initial/retry write failure, concurrent success/failure, assignment gating during writes, blocked responses, response-write rollback, duplicate responses, multiple outstanding requests, marker ownership, and old-response/new-request interleavings.

## Risk & Scope

- Assignment remains blocked while any request write, outstanding token, or response reservation exists.
- The protocol still has no request ID; token reservations provide FIFO ownership without changing the wire format.
- The leader-only `request_shutdown` tool remains in #9401 and is not duplicated here.

## Linked Issues

References #9510. Follow-up delta for #9401.

<details>
<summary>中文说明</summary>

本改动用 token ledger 管理 shutdown 所有权：每次成功投递产生独立 token，响应先预留 token，只有首个成功写入 leader mailbox 的响应才消费 token；失败或重复响应不会误清其他请求。任务分配在写入、待响应或响应处理中都会被阻止。

验证通过 82 项 harness 测试、core 全量 20,763 项测试，以及 build、lint、typecheck、Prettier 和 `git diff --check`。

</details>