### PR TITLE
fix(cli): give the case-variant delete test the attachments mock

### DIFF
--- a/packages/cli/src/serve/server/session-archive.test.ts
+++ b/packages/cli/src/serve/server/session-archive.test.ts
@@ -1066,7 +1066,10 @@ describe('deleteDaemonSessions', () => {
     const result = await deleteDaemonSessions({
       sessionIds: [sessionId.toUpperCase(), sessionId],
       service: new SessionService(workspaceDir),
-      bridge: { closeSession },
+      bridge: {
+        closeSession,
+        deleteSessionAttachments: vi.fn().mockResolvedValue(undefined),
+      },
       coordinator: new SessionArchiveCoordinator(),
     });
 


### PR DESCRIPTION
## What

`main` does not build. `npm ci` runs `prepare` → `build`, and `tsc --build` fails:

```
src/serve/server/session-archive.test.ts(1069,7): error TS2741: Property
'deleteSessionAttachments' is missing in type '{ closeSession: Mock<Procedure>; }'
but required in type 'Pick<AcpSessionBridge, "closeSession" | "deleteSessionAttachments">'
```

Every branch cut from current `main` inherits it — the Test, web-shell E2E Smoke and Coverage jobs all fail in *Install dependencies*, before a single test runs.

## Why it happened

Two PRs that were each green on their own merge ref:

- **#9477** (`a41d5ec058`) widened `deleteDaemonSessions`' parameter to `Pick<AcpSessionBridge, 'closeSession' | 'deleteSessionAttachments'>` and updated every mock that existed at the time.
- **#9341** (`a659539bc7`) landed in parallel and added one more test — *"collapses case-variant spellings in one batch to a single delete"* — passing `bridge: { closeSession }`.

Neither could see the other. There is no post-merge CI run on `main`, so nothing caught the combination.

## The fix

One mock site, given the same `vi.fn().mockResolvedValue(undefined)` its neighbours at lines 1048/1096/1126 already pass.

## Verification

- **A/B typecheck** in a worktree at `origin/main` with per-worktree `@qwen-code/*` symlinks (so `packages/cli` resolves siblings to the worktree, not a stale checkout): base reproduces CI's `TS2741` verbatim; with the patch, `session-archive` errors go to 0.
- `vitest run src/serve/server/session-archive.test.ts` → **48/48 pass**. The test asserts on the delete result, not on the spy, so its meaning is unchanged.

---

## 中文说明

`main` 目前构建失败：`npm ci` 的 `prepare` 会跑 `build`，`tsc --build` 在 `session-archive.test.ts:1069` 报 `TS2741`。所有从当前 `main` 切出的分支都会继承这个失败，CI 在「Install dependencies」阶段就挂掉，一个测试都跑不到。

成因是两个 PR 的语义冲突：#9477 把 `deleteDaemonSessions` 的 `bridge` 参数收紧为 `Pick<AcpSessionBridge, 'closeSession' | 'deleteSessionAttachments'>`，并更新了当时存在的所有 mock；#9341 并行合入，新增了一个只传 `{ closeSession }` 的用例。两者各自的 merge ref 都是绿的，而 `main` 合并后没有 CI 复跑，于是无人发现。

修复只动一处 mock，补上与相邻用例（1048/1096/1126 行）完全一致的 `vi.fn().mockResolvedValue(undefined)`。验证：A/B 类型检查确认 base 能复现 CI 的原始报错、打上补丁后归零；该测试文件 48/48 通过，断言的是删除结果而非该 spy，语义不变。