### PR TITLE
chore(ci): Drop NPM_TOKEN in favor of npm Trusted Publishing

### DIFF
--- a/.github/workflows/cd-mobile-mcp.yml
+++ b/.github/workflows/cd-mobile-mcp.yml
@@ -34,6 +34,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@qwen-code'
 
+      - name: 'Install npm 11'
+        run: 'npm install --global npm@11.19.0'
+
       - name: 'Determine version'
         id: 'version'
         run: |

--- a/.github/workflows/cd-mobile-mcp.yml
+++ b/.github/workflows/cd-mobile-mcp.yml
@@ -69,5 +69,3 @@ jobs:
         if: '${{ !inputs.dry_run }}'
         working-directory: 'packages/mobile-mcp'
         run: 'npm publish --provenance --access public'
-        env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -102,6 +102,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@qwen-code'
 
+      - name: 'Install npm 11'
+        run: 'npm install --global npm@11.19.0'
+
       - name: 'Install Dependencies'
         run: |-
           npm ci

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -295,8 +295,6 @@ jobs:
         working-directory: 'packages/sdk-typescript'
         run: |-
           npm publish --provenance --access public --tag=${{ steps.version.outputs.NPM_TAG }} ${{ steps.vars.outputs.is_dry_run == 'true' && '--dry-run' || '' }}
-        env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
 
       - name: 'Create and switch to a release branch'
         if: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,7 +531,6 @@ jobs:
           fi
           npm publish --provenance "${PUBLISH_ARGS[@]}"
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
           NPM_TAG: '${{ needs.prepare.outputs.npm_tag }}'
           IS_DRY_RUN: '${{ needs.prepare.outputs.is_dry_run }}'
@@ -549,7 +548,6 @@ jobs:
           fi
           npm publish --provenance "${PUBLISH_ARGS[@]}"
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
           NPM_TAG: '${{ needs.prepare.outputs.npm_tag }}'
           IS_DRY_RUN: '${{ needs.prepare.outputs.is_dry_run }}'
@@ -567,7 +565,6 @@ jobs:
           fi
           npm publish --provenance "${PUBLISH_ARGS[@]}"
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
           NPM_TAG: '${{ needs.prepare.outputs.npm_tag }}'
           IS_DRY_RUN: '${{ needs.prepare.outputs.is_dry_run }}'
@@ -598,7 +595,6 @@ jobs:
             echo "::warning::Every channel package was already published; nothing shipped"
           fi
         env:
-          NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
           NPM_TAG: '${{ needs.prepare.outputs.npm_tag }}'
           IS_DRY_RUN: '${{ needs.prepare.outputs.is_dry_run }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@qwen-code'
 
+      - name: 'Install npm 11'
+        run: 'npm install --global npm@11.19.0'
+
       - name: 'Install Dependencies'
         env:
           NPM_CONFIG_PREFER_OFFLINE: 'true'

--- a/packages/audio-capture/package.json
+++ b/packages/audio-capture/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/audio-capture",
   "version": "0.21.11",
   "description": "Native microphone capture backend for Qwen Code voice input",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/audio-capture"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-base",
   "version": "0.21.11",
   "description": "Base channel infrastructure for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/base"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-dingtalk",
   "version": "0.21.11",
   "description": "DingTalk channel adapter for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/dingtalk"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/feishu/package.json
+++ b/packages/channels/feishu/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-feishu",
   "version": "0.21.11",
   "description": "Feishu (Lark) channel adapter for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/feishu"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/github/package.json
+++ b/packages/channels/github/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-github",
   "version": "0.21.11",
   "description": "GitHub polling channel adapter for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/github"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/qqbot/package.json
+++ b/packages/channels/qqbot/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-qqbot",
   "version": "0.21.11",
   "description": "QQ Bot (QQ机器人) channel adapter for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/qqbot"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-telegram",
   "version": "0.21.11",
   "description": "Telegram channel adapter for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/telegram"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/wecom/package.json
+++ b/packages/channels/wecom/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-wecom",
   "version": "0.21.11",
   "description": "WeCom channel adapter for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/wecom"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -2,6 +2,11 @@
   "name": "@qwen-code/channel-weixin",
   "version": "0.21.11",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "packages/channels/weixin"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/tests/package-scripts.test.js
+++ b/scripts/tests/package-scripts.test.js
@@ -478,6 +478,51 @@ describe('package scripts', () => {
     );
   });
 
+  it('meets npm trusted publishing requirements', () => {
+    for (const [workflowPath, jobName, publishStepName] of [
+      [
+        '.github/workflows/release.yml',
+        'publish',
+        'Publish @qwen-code/audio-capture',
+      ],
+      [
+        '.github/workflows/release-sdk.yml',
+        'release-sdk',
+        'Publish @qwen-code/sdk',
+      ],
+      ['.github/workflows/cd-mobile-mcp.yml', 'build-and-publish', 'Publish'],
+    ]) {
+      const publishJob = getWorkflowJob(readWorkflow(workflowPath), jobName);
+      const installStep = getWorkflowStep(publishJob, 'Install npm 11');
+      expect(installStep).toContain('npm install --global npm@11.19.0');
+      expect(publishJob.indexOf(installStep)).toBeLessThan(
+        publishJob.indexOf(getWorkflowStep(publishJob, publishStepName)),
+      );
+    }
+
+    for (const packageDirectory of [
+      'packages/audio-capture',
+      'packages/cli',
+      'packages/channels/base',
+      'packages/channels/dingtalk',
+      'packages/channels/feishu',
+      'packages/channels/github',
+      'packages/channels/qqbot',
+      'packages/channels/telegram',
+      'packages/channels/wecom',
+      'packages/channels/weixin',
+      'packages/mobile-mcp',
+      'packages/sdk-typescript',
+    ]) {
+      const packageJson = JSON.parse(
+        readFileSync(path.join(root, packageDirectory, 'package.json'), 'utf8'),
+      );
+      expect(packageJson.repository?.url?.replace(/^git\+/, '')).toBe(
+        'https://github.com/QwenLM/qwen-code.git',
+      );
+    }
+  });
+
   it('fast-tracks trusted autofix issue triggers before LLM assessment', () => {
     const workflow = readWorkflow('.github/workflows/qwen-autofix.yml');
     const issueJob = getWorkflowJob(workflow, 'issue-autofix');


### PR DESCRIPTION
## What this PR does

This PR removes every `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` entry from the npm publish steps in `release.yml` (4 publish steps), `release-sdk.yml`, and `cd-mobile-mcp.yml`, pins npm 11.19.0 in those publish jobs, and adds the `repository` field to the published workspace packages that were missing it. Combined with #9532 (`--provenance` + `id-token: write`), all npm publishing now authenticates through GitHub OIDC via npm Trusted Publishing instead of the long-lived `NPM_TOKEN` secret.

✅ **Verified end-to-end:** the Release workflow dispatched from this branch ([run 32343109856](https://github.com/QwenLM/qwen-code/actions/runs/32343109856)) published every package (`@qwen-code/audio-capture`, `@qwen-code/qwen-code`, `@qwen-code/channel-base`, all channel packages) with tag `nightly` using no token — see `+ @qwen-code/audio-capture@0.21.11-nightly.20260820.b414f135fa` etc. in the Publish Release logs, and the `nightly` dist-tag on the registry.

## Why it's needed

The 2026-08-20 nightly release failed on the first publish step with `npm error 404 Not Found - PUT https://registry.npmjs.org/@qwen-code%2faudio-capture` (#9523, [run 32317194899](https://github.com/QwenLM/qwen-code/actions/runs/32317194899)). A 404 on PUT for a scoped package is npm's response when the presented credentials have no publish permission for that package. The same setup had published nightlies successfully every day through 2026-08-19, and npm status reported no registry incident in that window, so the token auth itself stopped working between the two runs. Dropping token auth in favor of OIDC Trusted Publishing removes this failure mode and eliminates the long-lived secret from the release path entirely.

## What the investigation found

1. The original failing run's publish step used the masked `production-release` environment secret `NPM_TOKEN` (no repo-level `NPM_TOKEN` secret exists), and npm rejected it — the token's publish permission on `@qwen-code/*` died between 2026-08-19 02:41 UTC and 2026-08-20 01:14 UTC.
2. A first token-less verification run ([run 32338170484](https://github.com/QwenLM/qwen-code/actions/runs/32338170484)) failed with the same E404 for two reasons, both fixed by follow-up commits here: the publish runner used npm 10.9.8 (OIDC publish requires npm ≥ 11.5.1, npm/cli#8336 — fixed by the `Install npm 11` step pinning 11.19.0), and npm Trusted Publishing requires each package's `repository` field to match the trusted publisher's repo (added to audio-capture and all channel packages, covered by the new package-scripts test).
3. Note: the placeholder `NODE_AUTH_TOKEN=XXXXX-...` in the publish log is emitted by `actions/setup-node` when no token is supplied; the successful run proves npm 11's OIDC path publishes fine regardless. Cleaning up that org variable is optional follow-up, not a blocker.

## Reviewer Test Plan

### How to verify

1. Confirm the workflow diff only removes the `NODE_AUTH_TOKEN` env lines and adds the npm 11 pin — no other publish logic changes.
2. Verification evidence: [run 32343109856](https://github.com/QwenLM/qwen-code/actions/runs/32343109856) is green end-to-end; `npm view @qwen-code/audio-capture dist-tags.nightly` returns `0.21.11-nightly.20260820.b414f135fa` (published from this branch without any token).
3. After merge, the next scheduled nightly publishes through the same OIDC path.

### Evidence (Before & After)

- Before: nightly publish failed at `@qwen-code/audio-capture` with E404 — [failed run 32317194899](https://github.com/QwenLM/qwen-code/actions/runs/32317194899).
- After: token-less run published all packages successfully — [run 32343109856](https://github.com/QwenLM/qwen-code/actions/runs/32343109856); nightly `0.21.11-nightly.20260820.b414f135fa` is live on the registry with provenance.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

GitHub Actions Release workflow plus focused local workflow tests.

## Risk & Scope

- Main risk or tradeoff: publishing now hard-depends on the npm-side trusted publisher configuration for every `@qwen-code/*` package; if a future package is added without it (or without the `repository` field), its publish step will fail — the new package-scripts test pins the repository-field requirement.
- Not validated / out of scope: `release-sdk.yml` and `cd-mobile-mcp.yml` publish paths got the same treatment but were not exercised by the verification run. Follow-ups: revoke/remove the now-unused `NPM_TOKEN` secrets.
- Breaking changes / migration notes: none for users — this only changes how CI authenticates to npm.

## Linked Issues

Fixes #9523
Follow-up to #9532

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 删除了 `release.yml`（4 个 publish 步骤）、`release-sdk.yml` 和 `cd-mobile-mcp.yml` 中所有 publish 步骤里的 `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`，在这些 publish job 中固定 npm 11.19.0，并为缺少 `repository` 字段的已发布 workspace 包补上该字段。结合 #9532（`--provenance` + `id-token: write`），所有 npm 发布改为通过 npm Trusted Publishing 走 GitHub OIDC 认证，不再依赖长期 `NPM_TOKEN` secret。

✅ **已端到端验证：** 从本分支 dispatch 的 Release workflow（[run 32343109856](https://github.com/QwenLM/qwen-code/actions/runs/32343109856)）在没有任何 token 的情况下发布了全部包（`@qwen-code/audio-capture`、`@qwen-code/qwen-code`、`@qwen-code/channel-base`、所有 channel 包），tag 为 `nightly`——见 Publish Release 日志中的 `+ @qwen-code/audio-capture@0.21.11-nightly.20260820.b414f135fa` 等输出，registry 上 `nightly` dist-tag 已指向该版本。

## 为什么需要

2026-08-20 的 nightly 发布在第一个 publish 步骤失败：`npm error 404 Not Found - PUT https://registry.npmjs.org/@qwen-code%2faudio-capture`（#9523，[run 32317194899](https://github.com/QwenLM/qwen-code/actions/runs/32317194899)）。scoped 包 PUT 返回 404 是 npm 在"凭据没有该包发布权限"时的响应。同样的配置在 2026-08-19 之前每天的 nightly 都成功，npm 状态页该时段也没有事故，因此是 token 认证本身在两次发布之间失效了。改用 OIDC Trusted Publishing 既消除了这个故障模式，也让发布链路不再持有长期 secret。

## 排查发现了什么

1. 原始失败 run 的 publish 步骤使用的是被 mask 的 `production-release` environment secret `NPM_TOKEN`（仓库级并不存在同名 secret），npm 拒绝了它——该 token 对 `@qwen-code/*` 的发布权限在 2026-08-19 02:41 UTC 到 2026-08-20 01:14 UTC 之间失效。
2. 第一次无 token 验证 run（[run 32338170484](https://github.com/QwenLM/qwen-code/actions/runs/32338170484)）以同样的 E404 失败，原因有两个，均由本分支后续提交修复：publish runner 用的是 npm 10.9.8（OIDC publish 需要 npm ≥ 11.5.1，npm/cli#8336——由 `Install npm 11` 步骤固定 11.19.0 解决），以及 npm Trusted Publishing 要求每个包的 `repository` 字段与 trusted publisher 的仓库一致（已为 audio-capture 和所有 channel 包补齐，新增的 package-scripts 测试覆盖了这一要求）。
3. 注意：发布日志里的 `NODE_AUTH_TOKEN=XXXXX-...` 是 `actions/setup-node` 在未提供 token 时生成的占位值；成功的 run 证明 npm 11 的 OIDC 路径在这种情况下也能正常发布。清理该 org 变量属于可选的后续动作，不是合入阻塞项。

## 评审验证计划

### 如何验证

1. 确认 workflow diff 只删除了 `NODE_AUTH_TOKEN` 环境变量行并新增 npm 11 固定步骤，没有其他发布逻辑变化。
2. 验证证据：[run 32343109856](https://github.com/QwenLM/qwen-code/actions/runs/32343109856) 全程绿色；`npm view @qwen-code/audio-capture dist-tags.nightly` 返回 `0.21.11-nightly.20260820.b414f135fa`（从本分支无 token 发布）。
3. 合入后，下一次定时 nightly 将走同样的 OIDC 路径发布。

### 前后对比证据

- 修改前：nightly 在 `@qwen-code/audio-capture` 处以 E404 失败 —— [失败的 run 32317194899](https://github.com/QwenLM/qwen-code/actions/runs/32317194899)。
- 修改后：无 token run 成功发布全部包 —— [run 32343109856](https://github.com/QwenLM/qwen-code/actions/runs/32343109856)；nightly `0.21.11-nightly.20260820.b414f135fa` 已带 provenance 上线 registry。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 环境说明（可选）

GitHub Actions Release workflow，加聚焦的本地 workflow 测试。

## 风险与范围

- 主要风险或取舍：发布从此硬依赖 npm 侧为每个 `@qwen-code/*` 包配置的 trusted publisher；未来新增包如果没配置（或缺 `repository` 字段），其 publish 步骤会失败——新增的 package-scripts 测试固定了 repository 字段要求。
- 未验证 / 超出范围：`release-sdk.yml` 和 `cd-mobile-mcp.yml` 的发布路径做了同样处理，但未被验证 run 覆盖。后续动作：吊销/删除不再使用的 `NPM_TOKEN` secret。
- 破坏性变更 / 迁移说明：对用户无影响——只改变 CI 对 npm 的认证方式。

## 关联 Issue

Fixes #9523
#9532 的后续

</details>

