### PR TITLE
test(serve): mock attachment cleanup in batch delete test

### DIFF
--- a/packages/cli/src/serve/server/session-archive.test.ts
+++ b/packages/cli/src/serve/server/session-archive.test.ts
@@ -1062,11 +1062,12 @@ describe('deleteDaemonSessions', () => {
     const sessionId = '550e8400-e29b-41d4-a716-446655440170';
     writeSessionFile(workspaceDir, sessionId, 'active');
     const closeSession = vi.fn().mockResolvedValue(undefined);
+    const deleteSessionAttachments = vi.fn().mockResolvedValue(undefined);
 
     const result = await deleteDaemonSessions({
       sessionIds: [sessionId.toUpperCase(), sessionId],
       service: new SessionService(workspaceDir),
-      bridge: { closeSession },
+      bridge: { closeSession, deleteSessionAttachments },
       coordinator: new SessionArchiveCoordinator(),
     });
 
@@ -1076,6 +1077,7 @@ describe('deleteDaemonSessions', () => {
       errors: [],
     });
     expect(closeSession).toHaveBeenCalledTimes(1);
+    expect(deleteSessionAttachments).toHaveBeenCalledTimes(1);
     expect(fs.existsSync(sessionPath(workspaceDir, sessionId, 'active'))).toBe(
       false,
     );


### PR DESCRIPTION
## What this PR does

Updates the case-variant batch-delete regression test to provide the session attachment cleanup dependency and verifies that attachment cleanup runs exactly once for duplicate case spellings.

## Why it's needed

Two closely timed merges left `main` with a semantic integration mismatch: the batch-delete API began requiring attachment cleanup after another PR had added a test mock containing only session close. The resulting TypeScript error blocks CLI builds and downstream CI jobs.

## Reviewer Test Plan

### How to verify

Run the session archive test and CLI typecheck. The archive suite should pass all 48 tests, the case-variant delete test should call both session close and attachment cleanup once, and TypeScript should no longer report TS2741 for the bridge mock.

### Evidence (Before & After)

N/A — test-only change. Before: CLI compilation fails because the bridge mock lacks `deleteSessionAttachments`. After: the targeted suite and CLI typecheck pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 workspace checkout.

## Risk & Scope

- Main risk or tradeoff: Minimal; this changes only a test mock and its assertion.
- Not validated / out of scope: No UI or runtime behavior changes; Windows and Linux were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

Follow-up integration fix for #9477 after #9341 merged a new caller shortly before it.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

更新批量删除中大小写变体的回归测试，为其补充 session 附件清理依赖，并验证同一 session 的重复大小写拼写只会触发一次附件清理。

## 修改原因

两个时间非常接近的合并在 `main` 中形成了语义集成不一致：一个 PR 新增了仅包含 session close 的测试 mock，随后批量删除接口开始要求附件清理依赖，最终导致 TypeScript 编译错误，并阻塞 CLI 构建及下游 CI。

## Reviewer Test Plan

### 验证方法

运行 session archive 测试和 CLI typecheck。archive 测试应当 48 项全部通过；大小写变体删除用例应分别只调用一次 session close 和附件清理；TypeScript 不应再为 bridge mock 报告 TS2741。

### 前后证据

N/A——仅测试改动。修改前：CLI 因 bridge mock 缺少 `deleteSessionAttachments` 而编译失败。修改后：定向测试和 CLI typecheck 均通过。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22 workspace checkout。

## 风险与范围

- 主要风险或权衡：极低，仅修改测试 mock 及其断言。
- 未验证或不在范围内：没有 UI 或运行时行为改动；未在本地测试 Windows 和 Linux。
- 破坏性改动或迁移说明：无。

## 关联事项

这是 #9341 在 #9477 合并前不久新增调用点后产生的集成 follow-up 修复。

</details>
