### PR TITLE
fix(tests): retry acp-cron cleanup rm on transient ENOTEMPTY

### DIFF
--- a/integration-tests/cli/acp-cron.test.ts
+++ b/integration-tests/cli/acp-cron.test.ts
@@ -292,7 +292,16 @@ function setupAcpCronTest(rig: TestRig, fakeServer: FakeOpenAIServer) {
     pending.forEach(({ timeout }) => clearTimeout(timeout));
     pending.clear();
     await waitForExit();
-    rmSync(qwenHome, { recursive: true, force: true });
+    // The cron job is recurring and, under QWEN_CODE_TEST_CRON_FAST, re-fires
+    // every ~5s. A second fire can race cleanup and drop a fresh file into the
+    // fake HOME after the recursive walk has drained it, making the final rmdir
+    // fail with ENOTEMPTY. Retry a few times so the transient write settles.
+    rmSync(qwenHome, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
   };
 
   return {


### PR DESCRIPTION
## What this PR does

`main`'s E2E "acp cron integration > cron job fires and streams results" flakes on cleanup: `rmSync(qwenHome, { recursive: true, force: true })` throws `ENOTEMPTY: directory not empty, rmdir '.../acp-cron-e2e-home'`.

The cron job is recurring and, under `QWEN_CODE_TEST_CRON_FAST`, re-fires every ~5s. A second fire can race the cleanup's recursive removal and drop a fresh file into the fake HOME after the walk has drained it, making the final `rmdir` fail.

## Why it's needed

The failure makes `main`'s E2E red intermittently (e.g. `Test (Linux) - sandbox:none - shard 1/3` in run 32341810576). The cleanup uses a single-shot `rmSync` that gives up on the first transient `ENOTEMPTY`.

## Reviewer Test Plan

### How to verify

Run the acp-cron integration test a few times against a built CLI bundle (with `QWEN_CODE_TEST_CRON_FAST=1`). Cleanup should no longer fail with `ENOTEMPTY`. Node retries `ENOTEMPTY` (among `EBUSY`/`EMFILE`/`ENFILE`/`EPERM`) when `recursive: true`.

### Evidence (Before & After)

N/A (test-infra only; the failure is a non-deterministic cleanup race).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  ⚠️    |

<!-- ⚠️ not yet verified locally -->

### Environment (optional)

N/A (no local E2E run; the race is hard to reproduce deterministically).

## Risk & Scope

- Main risk or tradeoff: none — only adds `maxRetries`/`retryDelay` to a test cleanup `rmSync`; no production code change.
- Not validated / out of scope: local E2E reproduction (the race is non-deterministic).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`main` 的 E2E 用例 "acp cron integration > cron job fires and streams results" 在清理阶段偶发失败：`rmSync(qwenHome, { recursive: true, force: true })` 抛出 `ENOTEMPTY: directory not empty, rmdir '.../acp-cron-e2e-home'`。

cron 任务是 recurring 的，在 `QWEN_CODE_TEST_CRON_FAST` 下每 ~5s 触发一次。第二次触发可能与 cleanup 的递归删除产生竞态，在遍历清空之后又往 fake HOME 里写入一个新文件，导致最后的 `rmdir` 失败。

## 为什么需要

这个失败会让 `main` 的 E2E 间歇性变红（例如 run 32341810576 中的 `Test (Linux) - sandbox:none - shard 1/3`）。原 cleanup 用的是单次 `rmSync`，遇到第一次瞬时的 `ENOTEMPTY` 就放弃。

## Reviewer 测试计划

### 如何验证

用构建好的 CLI bundle 多跑几次 acp-cron 集成测试（带 `QWEN_CODE_TEST_CRON_FAST=1`）。清理阶段不应再报 `ENOTEMPTY`。Node 在 `recursive: true` 时会重试 `ENOTEMPTY`（以及 `EBUSY`/`EMFILE`/`ENFILE`/`EPERM`）。

### 证据（修改前后）

N/A（仅测试基础设施；失败是非确定性的清理竞态）。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ⚠️  |

<!-- ⚠️ 本地尚未验证 -->

### 环境（可选）

N/A（未做本地 E2E 复现；该竞态难以确定性复现）。

## 风险与范围

- 主要风险或权衡：无 —— 只是给测试 cleanup 的 `rmSync` 加了 `maxRetries`/`retryDelay`，不改生产代码。
- 未验证或不在范围内：本地 E2E 复现（竞态是非确定性的）。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无。

</details>
