### PR TITLE
fix(web-shell): Stop repeated session title catalog refreshes

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -8567,12 +8567,13 @@ describe('App session callbacks', () => {
     ).toContain('Investigate task failures');
   });
 
-  it('refreshes the generated title after the first turn completes', async () => {
+  it('stops refreshing the generated title after the catalog resolves it', async () => {
     mockConnection.displayName = undefined;
     const { container, rerender } = renderApp();
     await vi.waitFor(() => {
       expect(mockWorkspace.client.listWorkspaceSessions).toHaveBeenCalled();
     });
+    mockWorkspace.client.listWorkspaceSessions.mockClear();
     mockWorkspace.client.listWorkspaceSessions
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
@@ -8607,6 +8608,22 @@ describe('App session callbacks', () => {
       container.querySelector('[data-testid="chat-context-header"]')
         ?.textContent,
     ).toContain('Generated session title');
+    expect(mockWorkspace.client.listWorkspaceSessions).toHaveBeenCalledTimes(2);
+
+    mockWorkspace.client.listWorkspaceSessions.mockClear();
+    act(() => {
+      testState.streamingState = 'responding';
+      rerender();
+    });
+    act(() => {
+      testState.streamingState = 'idle';
+      rerender();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(mockWorkspace.client.listWorkspaceSessions).not.toHaveBeenCalled();
   });
 
   it('defers title refresh while the page is hidden', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -7395,7 +7395,7 @@ export function App({
           : undefined;
       if (workspaceCwd) {
         sessionCatalogController.turnCompleted(workspaceCwd, sessionId);
-        if (!connectionRef.current.displayName) {
+        if (!sessionDisplayName) {
           scheduleDelayedActiveSessionDisplayNameRefresh(
             sessionId,
             workspaceCwd,
@@ -7421,6 +7421,7 @@ export function App({
     connection.workspaceCwd,
     scheduleDelayedActiveSessionDisplayNameRefresh,
     sessionCatalogController,
+    sessionDisplayName,
     streamingState,
   ]);
 


### PR DESCRIPTION
## What this PR does

This PR stops Web Shell from starting a new session-title catalog refresh cycle after the header has resolved an effective display name from either connection metadata or the persisted catalog. It preserves the existing immediate lookup and two-second trailing recovery lookup while no title is available, and it leaves turn-completion activity reconciliation unchanged.

## Why it's needed

When connection metadata has no display name, the persisted catalog can provide a prompt-derived fallback that Web Shell already renders in the header. The previous turn-completion guard ignored that resolved fallback, so every later turn still issued two `sessions?size=200` requests. Avoiding those redundant fresh catalog requests reduces persistent session scanning without changing the daemon protocol or title precedence.

## Reviewer Test Plan

### How to verify

Open a session whose connection metadata has no display name and whose first title lookup is unresolved. Complete a turn and confirm the immediate request and two-second trailing request still run. After the catalog title appears in the header, clear the network log, complete another turn, wait more than two seconds, and confirm no new `sessions?size=200` request is issued. As a control, repeat with a connection-provided display name and confirm no fallback requests are issued. Also verify that turn completion still updates live session activity and that a live metadata title replaces the catalog fallback.

### Evidence (Before & After)

Before: the missing-connection-title case issued two requests after the first turn and two more after the second turn (`0 → 2 → 4`), even though the header already displayed the fallback title before the second turn. After: the first unresolved turn still issues two requests, while the second turn issues zero additional requests (`0 → 2 → 2`). The connection-provided-title control remains at zero requests before and after the turn.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

macOS, Node.js 24.12.0, Vitest with jsdom, and Chromium against a local Web Shell development server with mocked daemon routes.

## Risk & Scope

- Main risk or tradeoff: after any effective fallback title is available, recovery of a later out-of-band generated title relies on the existing live metadata event or a reconnect instead of repeated per-turn catalog polling.
- Not validated / out of scope: real-daemon disk scan latency, Windows/Linux browser execution, daemon live-state protocol changes, and unrelated catalog refresh paths.
- Breaking changes / migration notes: none; this is a client-only refresh guard change with no API or data migration.

## Linked Issues

Fixes #9561

Duplicate report: #9562

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 在 Header 已从连接元数据或持久化 catalog 解析出有效会话标题后，阻止 Web Shell 为后续 turn 启动新的标题 catalog 刷新周期。在标题尚不可用时，保留现有的立即查询和两秒 trailing 补偿查询，同时保持 turn 完成后的会话 activity 协调逻辑不变。

## 为什么需要

当连接元数据没有 display name 时，持久化 catalog 可以提供基于首轮 prompt 的 fallback 标题，Web Shell 也已经会在 Header 中展示该标题。此前 turn 完成时的门控忽略了已经解析出的 fallback，因此后续每个 turn 仍会发出两次 `sessions?size=200` 请求。本修改避免这些冗余的 fresh catalog 请求，在不修改 daemon 协议和标题优先级的前提下降低持久化会话扫描。

## Reviewer 测试计划

### 如何验证

打开一个连接元数据没有 display name、且首次标题查询尚未解析的会话。完成一次 turn，确认立即请求和两秒 trailing 请求仍会执行。catalog 标题出现在 Header 后，清空网络日志，再完成一次 turn 并等待超过两秒，确认没有新的 `sessions?size=200` 请求。作为对照，对连接元数据已经提供 display name 的会话重复测试，确认不会发出 fallback 请求。同时确认 turn 完成仍会更新 live session activity，且 live metadata 标题仍会覆盖 catalog fallback。

### 前后证据

修改前：连接标题缺失时，第一次 turn 后发出两次请求，第二次 turn 后又发出两次请求（`0 → 2 → 4`），即使第二次 turn 前 Header 已显示 fallback 标题。修改后：首次 unresolved turn 仍发出两次请求，第二次 turn 不再增加请求（`0 → 2 → 2`）。连接已经提供标题的对照组在修改前后均保持零请求。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ⚠️ 未测试   |

### 环境（可选）

macOS、Node.js 24.12.0、使用 jsdom 的 Vitest，以及连接本地 Web Shell 开发服务器和模拟 daemon 路由的 Chromium。

## 风险与范围

- 主要风险或权衡：一旦存在有效 fallback 标题，后续带外生成标题的恢复将依赖现有 live metadata 事件或重新连接，而不再依赖每个 turn 的重复 catalog 轮询。
- 未验证或不在范围内：真实 daemon 磁盘扫描延迟、Windows/Linux 浏览器执行、daemon live-state 协议修改，以及其他无关 catalog 刷新路径。
- Breaking change 或迁移说明：无；这是纯客户端刷新门控修改，不涉及 API 或数据迁移。

## 关联 Issue

Fixes #9561

重复报告：#9562

</details>
