### PR TITLE
fix(daemon): avoid custom attachment upload header

### DIFF
--- a/packages/cli/src/serve/routes/session.ts
+++ b/packages/cli/src/serve/routes/session.ts
@@ -4416,27 +4416,20 @@ export function registerSessionRoutes(
     withOwnerMutableSession(
       'POST /session/:id/attachments',
       async (req, res, sessionId, runtime) => {
-        const encodedName = req.headers['x-qwen-attachment-name'];
+        const name = req.query['name'];
         const contentType = req.headers['content-type']
           ?.split(';', 1)[0]
           ?.trim()
           .toLowerCase();
         if (
-          typeof encodedName !== 'string' ||
+          typeof name !== 'string' ||
           !contentType ||
           !Buffer.isBuffer(req.body)
         ) {
           res.status(400).json({
             error:
-              'request body, Content-Type, and X-Qwen-Attachment-Name are required',
+              'request body, Content-Type, and name query parameter are required',
           });
-          return;
-        }
-        let name: string;
-        try {
-          name = decodeURIComponent(encodedName);
-        } catch {
-          res.status(400).json({ error: 'attachment name is invalid' });
           return;
         }
         const clientId = parseClientIdHeader(req, res);

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -9576,10 +9576,10 @@ describe('createServeApp', () => {
       );
       const uploaded = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'notes 你好.txt' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'text/plain')
-        .set('X-Qwen-Attachment-Name', encodeURIComponent('notes 你好.txt'))
         .send(Buffer.from('hello'));
 
       expect(uploaded.status).toBe(201);
@@ -9599,10 +9599,10 @@ describe('createServeApp', () => {
       );
       const uploaded = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'empty.txt' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'text/plain')
-        .set('X-Qwen-Attachment-Name', 'empty.txt')
         .set('Content-Length', '0')
         .send(Buffer.alloc(0));
 
@@ -9623,10 +9623,10 @@ describe('createServeApp', () => {
       );
       const uploaded = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'empty.png' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'image/png')
-        .set('X-Qwen-Attachment-Name', 'empty.png')
         .set('Content-Length', '0')
         .send(Buffer.alloc(0));
 
@@ -9644,10 +9644,10 @@ describe('createServeApp', () => {
       );
       const uploaded = await request(app)
         .post('/SESSION/s-1/ATTACHMENTS')
+        .query({ name: 'notes.txt' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'text/plain')
-        .set('X-Qwen-Attachment-Name', 'notes.txt')
         .send(Buffer.from('hello'));
 
       expect(uploaded.status).toBe(201);
@@ -9665,10 +9665,10 @@ describe('createServeApp', () => {
       );
       const uploaded = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'data.json' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'application/json')
-        .set('X-Qwen-Attachment-Name', 'data.json')
         .send('{"enabled":true}');
 
       expect(uploaded.status).toBe(201);
@@ -9689,10 +9689,10 @@ describe('createServeApp', () => {
       const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
       const uploaded = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'image.png' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'image/png')
-        .set('X-Qwen-Attachment-Name', 'image.png')
         .send(bytes);
 
       expect(uploaded.status).toBe(201);
@@ -9742,7 +9742,7 @@ describe('createServeApp', () => {
       expect(response.status).toBe(400);
     });
 
-    it('rejects malformed encoded attachment names', async () => {
+    it('rejects repeated attachment name query parameters', async () => {
       const app = createServeApp(
         { ...baseOpts, token: 'secret', workspace: WS_BOUND },
         undefined,
@@ -9750,14 +9750,17 @@ describe('createServeApp', () => {
       );
       const response = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: ['one.txt', 'two.txt'] })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'text/plain')
-        .set('X-Qwen-Attachment-Name', '%E0%A4%A')
         .send('hello');
 
       expect(response.status).toBe(400);
-      expect(response.body).toEqual({ error: 'attachment name is invalid' });
+      expect(response.body).toEqual({
+        error:
+          'request body, Content-Type, and name query parameter are required',
+      });
     });
 
     it('maps attachment name and Content-Type mismatches to 400', async () => {
@@ -9772,10 +9775,10 @@ describe('createServeApp', () => {
       );
       const response = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'screenshot.png' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'text/plain')
-        .set('X-Qwen-Attachment-Name', 'screenshot.png')
         .send('hello');
 
       expect(response.status).toBe(400);
@@ -9792,10 +9795,10 @@ describe('createServeApp', () => {
       );
       const response = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'image.svg' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'image/svg+xml')
-        .set('X-Qwen-Attachment-Name', 'image.svg')
         .send(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>'));
 
       expect(response.status).toBe(201);
@@ -9818,10 +9821,10 @@ describe('createServeApp', () => {
       const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
       const uploaded = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'image.png' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'image/png')
-        .set('X-Qwen-Attachment-Name', 'image.png')
         .send(bytes);
       expect(uploaded.status).toBe(201);
 
@@ -9843,10 +9846,10 @@ describe('createServeApp', () => {
       );
       const response = await request(app)
         .post('/session/s-1/attachments')
+        .query({ name: 'image.png' })
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
         .set('Content-Type', 'image/png')
-        .set('X-Qwen-Attachment-Name', 'image.png')
         .send(Buffer.alloc(8 * 1024 * 1024 + 1));
 
       expect(response.status).toBe(413);

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -3301,16 +3301,10 @@ export class DaemonClient {
     opts?: { signal?: AbortSignal; clientId?: string },
   ): Promise<DaemonSessionAttachmentReference> {
     return await this.fetchWithTimeout(
-      `${this.baseUrl}/session/${urlEncode(sessionId)}/attachments`,
+      `${this.baseUrl}/session/${urlEncode(sessionId)}/attachments?name=${urlEncode(name)}`,
       {
         method: 'POST',
-        headers: this.headers(
-          {
-            'Content-Type': mimeType,
-            'X-Qwen-Attachment-Name': encodeURIComponent(name),
-          },
-          opts?.clientId,
-        ),
+        headers: this.headers({ 'Content-Type': mimeType }, opts?.clientId),
         body: data,
         signal: opts?.signal,
       },

--- a/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
@@ -737,7 +737,7 @@ describe('DaemonSessionClient', () => {
     await expect(
       session.uploadAttachment(
         new Blob([Uint8Array.of(1, 2, 3)]),
-        'image.png',
+        'image 你好.png',
         'image/png',
       ),
     ).resolves.toEqual(reference);
@@ -748,7 +748,10 @@ describe('DaemonSessionClient', () => {
         'x-qwen-client-id': 'client-1',
       }),
     });
-    expect(calls[0]?.url).toContain('/session/s-1/attachments');
+    expect(calls[0]?.headers).not.toHaveProperty('x-qwen-attachment-name');
+    expect(calls[0]?.url).toBe(
+      'http://daemon/session/s-1/attachments?name=image%20%E4%BD%A0%E5%A5%BD.png',
+    );
   });
 
   it('removes session attachment through the authenticated session route', async () => {


### PR DESCRIPTION
## What this PR does

This is a follow-up fix for #9477. It sends the attachment filename as an encoded upload query parameter instead of a custom request header, while keeping the raw file body, MIME type, size limits, duplicate-name handling, and attachment references unchanged.

## Why it's needed

Putting the filename in a custom header may cause cross-origin issues. Using the upload URL for this metadata avoids requiring that custom header while preserving the existing attachment behavior.

## Reviewer Test Plan

### How to verify

Upload a file with spaces or non-ASCII characters in its name from Web Shell. Confirm that the upload succeeds, the request URL contains the encoded filename, the removed custom header is absent, and the resulting attachment can still be referenced and previewed. Also confirm that a missing or repeated filename parameter is rejected.

### Evidence (Before & After)

Before: attachment uploads used a custom filename header that could cause a cross-origin preflight failure.

After: the SDK request-contract test passes with an encoded filename query parameter and no custom filename header; all 12 daemon attachment-route tests pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22; focused SDK and daemon route tests, package typechecks, lint, formatting, and the full repository build.

## Risk & Scope

- Main risk or tradeoff: attachment filenames are now carried in the upload URL.
- Not validated / out of scope: no changes to attachment storage, rendering, preview, cleanup, or size limits.
- Breaking changes / migration notes: #9477 has not been released. The SDK and daemon are published together, so there is no deployed compatibility boundary and no legacy protocol compatibility is needed.

## Linked Issues

Follow-up to #9477.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这是 #9477 的后续修复。附件文件名不再通过自定义请求 header 发送，而是作为经过编码的上传 query 参数传递；文件原始二进制内容、MIME 类型、大小限制、同名处理和附件引用行为均保持不变。

## 为什么需要

将文件名放在自定义 header 中可能会存在跨域问题。改为通过上传 URL 传递该元数据，可以移除这个自定义 header，同时保留现有附件行为。

## Reviewer 测试计划

### 如何验证

在 Web Shell 中上传一个文件名包含空格或非 ASCII 字符的文件。确认上传成功、请求 URL 包含编码后的文件名、不再携带已移除的自定义文件名 header，并且生成的附件仍可引用和预览。同时确认缺少文件名参数或重复传递文件名参数时请求会被拒绝。

### Before & After 证据

Before：附件上传使用自定义文件名 header，可能导致跨域预检失败。

After：SDK 请求协议测试通过，确认使用编码后的文件名 query 参数且不再发送自定义文件名 header；daemon 的 12 个附件路由测试全部通过。

### 已测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境

Node.js 22；已运行 SDK 与 daemon 定向测试、包级 typecheck、lint、格式检查和完整仓库构建。

## 风险与范围

- 主要风险或权衡：附件文件名现在位于上传 URL 中。
- 未验证或范围外：不修改附件存储、渲染、预览、清理和大小限制。
- 破坏性变更与迁移说明：#9477 尚未发包。SDK 与 daemon 会一起发布，不存在已部署的兼容边界，因此无需保留旧协议兼容逻辑。

## 关联

#9477 的后续修复。

</details>
