### PR TITLE
feat: register toggle-only reasoning for Qwen hybrid models

### DIFF
--- a/docs/design/model-reasoning-capabilities.md
+++ b/docs/design/model-reasoning-capabilities.md
@@ -1,0 +1,66 @@
+# Model reasoning capabilities
+
+## Goal
+
+Expose accurate reasoning controls for common Alibaba Cloud Coding Plan and
+Token Plan models without inventing effort levels that their Chat Completions
+APIs do not support.
+
+## Research
+
+Alibaba Cloud documents `qwen3.8-max` with native `low`, `medium`, and `xhigh`
+reasoning effort levels. It documents `qwen3.6-plus`, `qwen3.6-flash`,
+`qwen3.7-plus`, `qwen3.7-max`, and `qwen3.5-plus` as hybrid-thinking models that
+can enable or disable thinking, but use an integer thinking budget instead of
+discrete Chat Completions effort levels.
+
+The registered capabilities therefore are:
+
+| Exact model id  | Thinking | Effort control           |
+| --------------- | -------- | ------------------------ |
+| `qwen3.8-max`   | Optional | `low`, `medium`, `xhigh` |
+| `qwen3.7-max`   | Optional | None                     |
+| `qwen3.7-plus`  | Optional | None                     |
+| `qwen3.6-plus`  | Optional | None                     |
+| `qwen3.6-flash` | Optional | None                     |
+| `qwen3.5-plus`  | Optional | None                     |
+
+Sources:
+
+- [Qwen Code and Coding Plan model ids](https://help.aliyun.com/zh/model-studio/qwen-code)
+- [Thinking modes and defaults](https://help.aliyun.com/zh/model-studio/deep-thinking)
+- [Chat Completions thinking parameters](https://help.aliyun.com/zh/model-studio/qwen-api-via-openai-chat-completions)
+
+## Design
+
+The model manifest distinguishes tiered reasoning from toggle-only reasoning
+and continues to match exact model ids. Toggle-only models produce the same ACP
+configuration option as tiered models, with two values: `none` and `default`.
+Selecting `none` disables thinking for the live session. Selecting `default`
+clears the session override so the existing model or provider default applies.
+
+The daemon marks toggle-only options in ACP metadata. WebShell maps them to an
+empty effort list, renders only the Thinking switch, and shows `Thinking` or
+`Thinking Off` on the model chip. Existing tiered controls retain their effort
+rows and labels.
+
+Opening the controls does not mutate generation settings. No provider,
+authentication, persistence, or runtime-snapshot behavior changes.
+
+## Deferred models
+
+DeepSeek, GLM, Kimi, and Grok models are not registered here. Their reasoning
+parameters or defaults vary between direct and Alibaba Cloud endpoints, while
+the current manifest is keyed only by model id. Registering them before the
+provider path carries the relevant capability context could display a control
+whose selected value is not sent correctly.
+
+Qwen aliases, dated variants, coder models, and models with a preset default
+that differs from the model default are also deferred. They require separate
+capability or resolved-configuration semantics rather than broadened matching.
+
+## Compatibility
+
+Older ACP clients can continue to treat the option as a normal select. Older
+daemons do not advertise the toggle-only metadata, so current WebShell keeps
+the controls hidden unless the capability is explicit.

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -7172,6 +7172,79 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
+  it('projects toggle-only Qwen reasoning without effort tiers', async () => {
+    const sessionId = 'qwen37-toggle-reasoning-session';
+    const innerConfig = await setupSessionMocks(sessionId);
+    const generation: {
+      reasoning?: false | { effort?: string };
+    } = {};
+    innerConfig.getModel = vi.fn().mockReturnValue('qwen3.7-plus');
+    innerConfig.getContentGeneratorConfig = vi.fn(() => generation);
+    innerConfig.getReasoningEffort = vi.fn(() =>
+      generation.reasoning ? generation.reasoning.effort : undefined,
+    );
+
+    const { agent, agentPromise } = await bootAcpAgent();
+    try {
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+      })) as {
+        configOptions: Array<{
+          id: string;
+          currentValue: string;
+          options: Array<{ value: string }>;
+          _meta?: Record<string, unknown>;
+        }>;
+      };
+      const option = session.configOptions.find(
+        (item) => item.id === 'reasoning_effort',
+      );
+      expect(option).toMatchObject({
+        currentValue: 'default',
+        options: [{ value: 'none' }, { value: 'default' }],
+        _meta: {
+          'qwenCode/reasoning': { toggleOnly: true },
+        },
+      });
+
+      const disabled = (await agent.setSessionConfigOption({
+        sessionId,
+        configId: 'reasoning_effort',
+        value: 'none',
+      })) as SetSessionConfigOptionResponse;
+      expect(generation.reasoning).toBe(false);
+      expect(
+        disabled.configOptions.find((item) => item.id === 'reasoning_effort')
+          ?.currentValue,
+      ).toBe('none');
+
+      const enabled = (await agent.setSessionConfigOption({
+        sessionId,
+        configId: 'reasoning_effort',
+        value: 'default',
+      })) as SetSessionConfigOptionResponse;
+      expect(generation.reasoning).toBeUndefined();
+      expect(
+        enabled.configOptions.find((item) => item.id === 'reasoning_effort')
+          ?.currentValue,
+      ).toBe('default');
+
+      await expect(
+        agent.setSessionConfigOption({
+          sessionId,
+          configId: 'reasoning_effort',
+          value: 'low',
+        }),
+      ).rejects.toThrow(
+        'Unknown reasoning effort: low. Choose one of: none, default',
+      );
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
   it('hides qwen3.8-max reasoning controls when thinking is mandatory', async () => {
     const sessionId = 'qwen38-mandatory-thinking-session';
     const innerConfig = await setupSessionMocks(sessionId);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5913,19 +5913,32 @@ class QwenAgent implements Agent {
           session.getConfig(),
         );
         if (modelReasoning) {
+          const effortValues = modelReasoning.toggleOnly
+            ? undefined
+            : modelReasoning.efforts;
           const selected =
             value === ACP_REASONING_EFFORT_NONE
               ? ACP_REASONING_EFFORT_NONE
-              : modelReasoning.efforts.find((effort) => effort === value);
+              : modelReasoning.toggleOnly
+                ? value === ACP_REASONING_EFFORT_DEFAULT
+                  ? ACP_REASONING_EFFORT_DEFAULT
+                  : undefined
+                : effortValues?.find((effort) => effort === value);
           if (!selected) {
+            const choices = [
+              ACP_REASONING_EFFORT_NONE,
+              ...(effortValues ?? [ACP_REASONING_EFFORT_DEFAULT]),
+            ];
             throw RequestError.invalidParams(
               undefined,
-              `Unknown reasoning effort: ${value}. Choose one of: ${ACP_REASONING_EFFORT_NONE}, ${modelReasoning.efforts.join(', ')}`,
+              `Unknown reasoning effort: ${value}. Choose one of: ${choices.join(', ')}`,
             );
           }
           const generation = session.getConfig().getContentGeneratorConfig();
           if (selected === ACP_REASONING_EFFORT_NONE) {
             generation.reasoning = false;
+          } else if (selected === ACP_REASONING_EFFORT_DEFAULT) {
+            generation.reasoning = undefined;
           } else {
             const current = generation.reasoning;
             generation.reasoning = {
@@ -13118,24 +13131,36 @@ class QwenAgent implements Agent {
           currentValue:
             config.getContentGeneratorConfig().reasoning === false
               ? ACP_REASONING_EFFORT_NONE
-              : (modelReasoning.efforts.find(
-                  (effort) => effort === currentModelEffort,
-                ) ?? modelReasoning.defaultEffort),
+              : modelReasoning.toggleOnly
+                ? ACP_REASONING_EFFORT_DEFAULT
+                : (modelReasoning.efforts.find(
+                    (effort) => effort === currentModelEffort,
+                  ) ?? modelReasoning.defaultEffort),
           options: [
             {
               value: ACP_REASONING_EFFORT_NONE,
               name: 'Thinking off',
               description: 'Disable thinking for this session',
             },
-            ...modelReasoning.efforts.map((effort) => ({
-              value: effort,
-              name: ACP_REASONING_EFFORT_NAMES[effort],
-              description: 'Apply this effort to the next request',
-            })),
+            ...(modelReasoning.toggleOnly
+              ? [
+                  {
+                    value: ACP_REASONING_EFFORT_DEFAULT,
+                    name: 'Thinking on',
+                    description: 'Use the model or provider thinking default',
+                  },
+                ]
+              : modelReasoning.efforts.map((effort) => ({
+                  value: effort,
+                  name: ACP_REASONING_EFFORT_NAMES[effort],
+                  description: 'Apply this effort to the next request',
+                }))),
           ],
           _meta: {
             'qwenCode/reasoning': {
-              defaultEffort: modelReasoning.defaultEffort,
+              ...(modelReasoning.toggleOnly
+                ? { toggleOnly: true }
+                : { defaultEffort: modelReasoning.defaultEffort }),
             },
           },
         }
@@ -13177,7 +13202,9 @@ class QwenAgent implements Agent {
     const reasoning = getModelConfiguration(config.getModel())?.reasoning;
     const currentEffort = config.getReasoningEffort?.();
     return reasoning?.thinking &&
-      (!currentEffort || reasoning.efforts.includes(currentEffort))
+      (reasoning.toggleOnly ||
+        !currentEffort ||
+        reasoning.efforts.includes(currentEffort))
       ? reasoning
       : undefined;
   }

--- a/packages/cli/src/acp-integration/model-configuration.test.ts
+++ b/packages/cli/src/acp-integration/model-configuration.test.ts
@@ -19,11 +19,32 @@ describe('model configuration manifest', () => {
   });
 
   it.each([
+    'qwen3.5-plus',
+    'qwen3.6-plus',
+    'qwen3.6-flash',
+    'qwen3.7-plus',
+    'qwen3.7-max',
+  ])('registers toggle-only reasoning for %s', (modelId) => {
+    expect(getModelConfiguration(modelId)).toEqual({
+      reasoning: {
+        thinking: true,
+        toggleOnly: true,
+      },
+    });
+  });
+
+  it.each([
     undefined,
     'qwen3.8-max-preview',
     'qwen3.8-max-latest',
     'qwen3.8-max-2026-08-12',
     'vendor/qwen3.8-max',
+    'qwen3.7-plus-latest',
+    'vendor/qwen3.7-plus',
+    'QWEN3.7-PLUS',
+    'qwen3-max-2026-01-23',
+    'qwen3-coder-plus',
+    'qwen3-coder-next',
   ])('does not broaden the manifest to %s', (modelId) => {
     expect(getModelConfiguration(modelId)).toBeUndefined();
   });

--- a/packages/cli/src/acp-integration/model-configuration.ts
+++ b/packages/cli/src/acp-integration/model-configuration.ts
@@ -6,13 +6,36 @@
 
 import type { ReasoningEffort } from '@qwen-code/qwen-code-core';
 
-export interface ModelReasoningConfiguration {
-  readonly thinking: true;
-  readonly efforts: readonly ReasoningEffort[];
-  readonly defaultEffort: ReasoningEffort;
-}
+export type ModelReasoningConfiguration =
+  | {
+      readonly thinking: true;
+      readonly toggleOnly: true;
+    }
+  | {
+      readonly thinking: true;
+      readonly toggleOnly?: false;
+      readonly efforts: readonly ReasoningEffort[];
+      readonly defaultEffort: ReasoningEffort;
+    };
 
-const MODEL_CONFIGURATIONS = {
+const MODEL_CONFIGURATIONS: Readonly<
+  Record<string, { readonly reasoning?: ModelReasoningConfiguration }>
+> = {
+  'qwen3.5-plus': {
+    reasoning: { thinking: true, toggleOnly: true },
+  },
+  'qwen3.6-plus': {
+    reasoning: { thinking: true, toggleOnly: true },
+  },
+  'qwen3.6-flash': {
+    reasoning: { thinking: true, toggleOnly: true },
+  },
+  'qwen3.7-plus': {
+    reasoning: { thinking: true, toggleOnly: true },
+  },
+  'qwen3.7-max': {
+    reasoning: { thinking: true, toggleOnly: true },
+  },
   'qwen3.8-max': {
     reasoning: {
       thinking: true,
@@ -20,15 +43,12 @@ const MODEL_CONFIGURATIONS = {
       defaultEffort: 'xhigh',
     },
   },
-} as const satisfies Record<
-  string,
-  { reasoning?: ModelReasoningConfiguration }
->;
+};
 
 export function getModelConfiguration(modelId: string | undefined):
   | {
       readonly reasoning?: ModelReasoningConfiguration;
     }
   | undefined {
-  return modelId === 'qwen3.8-max' ? MODEL_CONFIGURATIONS[modelId] : undefined;
+  return modelId ? MODEL_CONFIGURATIONS[modelId] : undefined;
 }

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -1061,6 +1061,7 @@ function ModelReasoningControls({
 }) {
   const { t } = useI18n();
   const [busy, setBusy] = useState(false);
+  const hasEffortOptions = reasoning.efforts.length > 0;
   const select = async (value: string) => {
     if (busy) return;
     setBusy(true);
@@ -1090,26 +1091,30 @@ function ModelReasoningControls({
           }
         />
       </div>
-      <div className={styles.reasoningDivider} />
-      <div className={styles.reasoningSectionTitle}>
-        {t('reasoning.effort')}
-      </div>
-      {reasoning.efforts.map((effort) => (
-        <button
-          key={effort}
-          type="button"
-          className={styles.reasoningEffortRow}
-          aria-pressed={reasoning.effort === effort}
-          data-web-shell-effort={effort}
-          disabled={!reasoning.enabled || busy}
-          onClick={() => void select(effort)}
-        >
-          <span>{t(`reasoning.effort.${effort}`)}</span>
-          <span className={styles.dropdownItemCheck}>
-            {reasoning.effort === effort ? <CheckIcon /> : null}
-          </span>
-        </button>
-      ))}
+      {hasEffortOptions ? (
+        <>
+          <div className={styles.reasoningDivider} />
+          <div className={styles.reasoningSectionTitle}>
+            {t('reasoning.effort')}
+          </div>
+          {reasoning.efforts.map((effort) => (
+            <button
+              key={effort}
+              type="button"
+              className={styles.reasoningEffortRow}
+              aria-pressed={reasoning.effort === effort}
+              data-web-shell-effort={effort}
+              disabled={!reasoning.enabled || busy}
+              onClick={() => void select(effort)}
+            >
+              <span>{t(`reasoning.effort.${effort}`)}</span>
+              <span className={styles.dropdownItemCheck}>
+                {reasoning.effort === effort ? <CheckIcon /> : null}
+              </span>
+            </button>
+          ))}
+        </>
+      ) : null}
     </div>
   );
 }
@@ -2310,7 +2315,9 @@ export const ChatEditor = memo(
     });
     const showReasoningOptions = Boolean(reasoning && onSelectReasoningEffort);
     const reasoningEffortLabel = reasoning
-      ? t(`reasoning.effort.${reasoning.effort}`)
+      ? reasoning.efforts.length > 0
+        ? t(`reasoning.effort.${reasoning.effort}`)
+        : t('reasoning.thinking')
       : '';
     const modelChipLabel = showReasoningOptions
       ? `${modelLabel} · ${

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -275,6 +275,59 @@ test('configures qwen3.8-max reasoning from the model popover @smoke', async ({
   ).toBeVisible();
 });
 
+test('toggles reasoning without effort tiers for qwen3.7-plus @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    currentModel: 'qwen3.7-plus',
+    state: {
+      configOptions: [
+        {
+          id: 'reasoning_effort',
+          name: 'Reasoning effort',
+          type: 'select',
+          currentValue: 'default',
+          options: [
+            { value: 'none', name: 'Thinking off' },
+            { value: 'default', name: 'Thinking on' },
+          ],
+          _meta: {
+            'qwenCode/reasoning': { toggleOnly: true },
+          },
+        },
+      ],
+    },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+  await gotoSession(page, scenario, daemon);
+
+  const modelButton = page.locator('[data-web-shell-model-button]');
+  await modelButton.click();
+  const controls = page.locator('[data-web-shell-model-reasoning]');
+  const thinking = controls.locator('[data-web-shell-thinking-toggle]');
+  await expect(controls).toBeVisible();
+  await expect(thinking).toBeChecked();
+  await expect(controls.locator('[data-web-shell-effort]')).toHaveCount(0);
+  await expect(modelButton).toContainText('Thinking');
+
+  await thinking.click();
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(1);
+  expect(
+    requestBodyRecord(firstRequest(daemon.configOptionRequests())),
+  ).toEqual({ configId: 'reasoning_effort', value: 'none' });
+  await expect(thinking).not.toBeChecked();
+  await expect(modelButton).toContainText('Thinking Off');
+
+  await thinking.click();
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(2);
+  expect(requestBodyRecord(daemon.configOptionRequests()[1]!)).toEqual({
+    configId: 'reasoning_effort',
+    value: 'default',
+  });
+  await expect(thinking).toBeChecked();
+  await expect(modelButton).toContainText('Thinking');
+});
+
 test('uploads an Extension archive from the manager @smoke', async ({
   page,
 }, testInfo) => {

--- a/packages/webui/src/daemon/session/mappers.test.ts
+++ b/packages/webui/src/daemon/session/mappers.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
   getReplayTokenCount,
   getReplayTokenUsage,
+  mapReasoningControls,
   mapWorkspaceSkills,
   updateConnectionFromDaemonEvent,
 } from './mappers.js';
@@ -71,6 +72,27 @@ const turnComplete: DaemonEvent = {
   type: 'turn_complete',
   data: { stopReason: 'end_turn' },
 };
+
+describe('mapReasoningControls', () => {
+  it('maps toggle-only reasoning without exposing an effort list', () => {
+    expect(
+      mapReasoningControls([
+        {
+          id: 'reasoning_effort',
+          currentValue: 'default',
+          options: [{ value: 'none' }, { value: 'default' }],
+          _meta: {
+            'qwenCode/reasoning': { toggleOnly: true },
+          },
+        },
+      ]),
+    ).toEqual({
+      enabled: true,
+      effort: 'default',
+      efforts: [],
+    });
+  });
+});
 
 describe('getReplayTokenCount', () => {
   it('returns undefined for an empty array', () => {

--- a/packages/webui/src/daemon/session/mappers.ts
+++ b/packages/webui/src/daemon/session/mappers.ts
@@ -147,11 +147,19 @@ export function mapReasoningControls(
     return value ? [value] : [];
   });
   if (!values.includes('none')) return undefined;
-  const efforts = values.filter((value) => value !== 'none');
-  if (efforts.length === 0) return undefined;
   const currentValue = getString(option, 'currentValue');
   const meta = getRecord(option['_meta']);
   const reasoningMeta = getRecord(meta?.['qwenCode/reasoning']);
+  const selectableValues = values.filter((value) => value !== 'none');
+  if (selectableValues.length === 0) return undefined;
+  if (reasoningMeta?.['toggleOnly'] === true) {
+    return {
+      enabled: currentValue !== 'none',
+      effort: selectableValues[0]!,
+      efforts: [],
+    };
+  }
+  const efforts = selectableValues;
   const defaultEffort = getString(reasoningMeta, 'defaultEffort');
   const effort =
     [currentValue, fallbackEffort, defaultEffort].find(


### PR DESCRIPTION
## What this PR does

Registers accurate reasoning controls for the exact stable `qwen3.5-plus`, `qwen3.6-plus`, `qwen3.6-flash`, `qwen3.7-plus`, and `qwen3.7-max` model ids. These hybrid-thinking models now expose a Thinking switch without invented effort tiers, while `qwen3.8-max` keeps its existing native `low`, `medium`, and `xhigh` controls.

Selecting Thinking off disables reasoning for the live session. Re-enabling it clears the session override and restores the existing model or provider default. The WebShell model popover hides the effort section for toggle-only models and shows `Thinking` or `Thinking Off` on the model chip.

The capability decisions and official Alibaba Cloud references are recorded in the design note. Exact-id matching remains deliberate; aliases and unverified variants are not inferred.

## Why it's needed

The existing model manifest could only represent optional thinking together with discrete effort levels. Copying the Qwen 3.8 tiers to older hybrid-thinking Qwen models would advertise controls that their Chat Completions APIs do not support, while omitting them leaves valid Thinking on/off behavior unavailable in WebShell.

Parallel official-document research also covered DeepSeek, GLM, Kimi, and Grok. They remain out of scope because their reasoning wire parameters or defaults vary by provider, while the current capability lookup only has a model id. Registering them here could display a control whose selected value is not sent correctly.

## Reviewer Test Plan

### How to verify

1. Start a WebShell session with any of the five registered toggle-only models and open the model popover.
2. Confirm that a Thinking switch is present, no reasoning-effort rows are shown, and the model chip shows `Thinking`.
3. Turn Thinking off and confirm the live config-option request sends `none`, the switch turns off, and the chip shows `Thinking Off`.
4. Turn Thinking on and confirm the request sends `default`, the switch turns on, and no effort rows appear.
5. Repeat with exact `qwen3.8-max` and confirm its existing `low`, `medium`, and `xhigh` rows still work.
6. Try a vendor-prefixed, dated, `latest`, or uppercase variant and confirm it does not receive model-specific controls.

### Evidence (Before & After)

Before: the five hybrid-thinking models had no model-popover Thinking control because they could not be represented without fake effort tiers.

After: the browser smoke verifies a switch-only popover and the real `none` then `default` config-option payload sequence; the existing Qwen 3.8 browser scenario passes unchanged.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.17.0, local worktree, no sandbox. Verified with `npm run build`, `npm run typecheck`, focused ESLint and Prettier checks, 459 CLI manifest/ACP tests, 17 WebUI mapper tests, 153 DashScope provider tests, and two Chromium reasoning smoke tests.

## Risk & Scope

- Main risk or tradeoff: the UI capability remains exact-model-id based, so only officially verified stable ids are registered.
- Not validated / out of scope: DeepSeek, GLM, Kimi, Grok, aliases, dated variants, provider changes, persistence, authentication, and runtime snapshots.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为精确稳定模型 ID `qwen3.5-plus`、`qwen3.6-plus`、`qwen3.6-flash`、`qwen3.7-plus` 和 `qwen3.7-max` 注册准确的推理控制。这些混合思考模型现在只展示 Thinking 开关，不虚构强度档位；`qwen3.8-max` 继续保留已有的原生 `low`、`medium` 和 `xhigh` 控制。

关闭 Thinking 会在当前实时会话中禁用推理。重新开启会清除会话覆盖并恢复现有模型或 provider 默认值。WebShell 的模型弹层会为仅开关模型隐藏强度区域，并在模型标签上显示 `Thinking` 或 `Thinking Off`。

能力决策和阿里云官方资料已记录在设计说明中。模型仍按精确 ID 匹配，不推断别名或未验证变体。

## 为什么需要

现有模型清单只能表达“可选思考 + 离散强度档位”。如果直接复制 Qwen 3.8 的档位，会向旧版混合思考 Qwen 模型展示其 Chat Completions API 不支持的控制；如果不注册，又会让 WebShell 无法使用真实有效的 Thinking 开关能力。

并行官方资料调研还覆盖了 DeepSeek、GLM、Kimi 和 Grok。它们暂不纳入，因为不同 provider 的推理 wire 参数或默认值存在差异，而当前能力查找只有模型 ID；在这里直接注册可能导致界面显示的控制没有被正确发送。

## Reviewer 测试计划

### 如何验证

1. 使用任意一个已注册的五个仅开关模型启动 WebShell 会话并打开模型弹层。
2. 确认显示 Thinking 开关、不显示推理强度行，且模型标签显示 `Thinking`。
3. 关闭 Thinking，确认实时配置请求发送 `none`、开关关闭，且标签显示 `Thinking Off`。
4. 重新开启 Thinking，确认请求发送 `default`、开关开启，且仍无强度行。
5. 使用精确 `qwen3.8-max` 重复验证，确认已有 `low`、`medium`、`xhigh` 强度行保持正常。
6. 尝试带 provider 前缀、日期、`latest` 或大写变体，确认不会获得模型专属控制。

### 证据（Before & After）

Before：五个混合思考模型无法在不虚构强度档位的前提下表达，因此模型弹层没有 Thinking 控制。

After：浏览器 smoke 验证了仅开关弹层以及真实的 `none`、`default` 配置请求顺序；现有 Qwen 3.8 浏览器场景保持通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22.17.0，本地 worktree，无 sandbox。已验证 `npm run build`、`npm run typecheck`、聚焦 ESLint 和 Prettier 检查、459 个 CLI 清单/ACP 测试、17 个 WebUI mapper 测试、153 个 DashScope provider 测试，以及两条 Chromium reasoning smoke 测试。

## 风险与范围

- 主要风险或取舍：UI 能力仍按精确模型 ID 判断，因此只注册有官方证据的稳定 ID。
- 未验证 / 范围外：DeepSeek、GLM、Kimi、Grok、别名、日期变体、provider 修改、持久化、认证和 runtime snapshot。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
