### PR TITLE
fix(ci): author the release PR with a third bot PAT

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -201,12 +201,13 @@ jobs:
           ${{ steps.meta.outputs.is_stable == 'true' }}
         id: 'pr'
         env:
-          # Author the PR as github-actions[bot] (installation token) so that
-          # NEITHER bot PAT is the author: GitHub forbids self-approval, and
-          # the two approve steps below need both PAT identities free to
-          # supply the branch protection's two required approvals without a
-          # human.
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          # Author the PR as the review bot (a third identity) so that NEITHER
+          # approve PAT (ci-bot / dev-bot) is the author: GitHub forbids
+          # self-approval, and the two approve steps below need both PAT
+          # identities free to supply the branch protection's two required
+          # approvals without a human. GITHUB_TOKEN cannot be used here
+          # because the org disables GitHub Actions from creating PRs.
+          GITHUB_TOKEN: '${{ secrets.CI_REVIEW_BOT_PAT }}'
           RELEASE_BRANCH: '${{ steps.meta.outputs.release_branch }}'
           RELEASE_TAG: '${{ env.RELEASE_TAG }}'
         run: |-


### PR DESCRIPTION
## What this PR does

The release finalization workflow merges the release branch back into main by opening a pull request. This PR changes which account opens that pull request: instead of the built-in GitHub Actions token, a dedicated bot account now authors it, so the two bot accounts that approve it are no longer the author.

## Why it's needed

Since #9056 the release pull request was opened with the built-in GitHub Actions token. That token can only open pull requests when the repository setting "Allow GitHub Actions to create and approve pull requests" is enabled, and the QwenLM organization disables that capability. As a result, finalization has failed to open the release pull request for the last three stable releases (v0.21.12, v0.21.13, v0.21.14), leaving main's package versions and CHANGELOG behind the released tags. A GitHub Actions token cannot be used here without an org-admin change, so the pull request is now authored with a third bot identity, which keeps the existing two-bot approval flow working.

## Reviewer Test Plan

### How to verify

1. Confirm the PR-creation step now uses the dedicated review-bot PAT instead of the GitHub Actions token.
2. Re-run the finalize workflow for one of the missed tags (e.g. v0.21.14) via manual dispatch and confirm it opens the release PR, both bots approve, and the PR merges into main.
3. Confirm the merged PR updates package.json versions and CHANGELOG.md on main.

### Evidence (Before & After)

Before: finalization for v0.21.12/13/14 failed at the PR-creation step with `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`.

After: not yet re-run — will be confirmed by re-running finalization for the missed tags.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

This is a CI workflow change; it is exercised by re-running the workflow, not by local OS testing.

## Risk & Scope

- Main risk or tradeoff: the new bot PAT must be a third identity distinct from the two approving bots; if it were the same account, one approval would be blocked by self-approval.
- Not validated / out of scope: the end-to-end open/approve/merge flow has not been re-run yet.
- Breaking changes / migration notes: none. This depends on the CI_REVIEW_BOT_PAT secret already existing in the repository.

## Linked Issues

Related: #9056 (introduced the regression), #9054 (original self-approval problem).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

发布收尾流程会打开一个 PR 把 release 分支合回 main。这个 PR 改变了打开该 PR 的账号：不再使用 GitHub Actions 内置 token，而是由一个专用 bot 账号来创建，这样负责审批的两个 bot 账号就不再是作者。

## 为什么需要它

自 #9056 起，release PR 用 GitHub Actions 内置 token 创建。该 token 只有在仓库开启 "Allow GitHub Actions to create and approve pull requests" 设置时才能创建 PR，而 QwenLM 组织禁用了这一能力。结果导致最近三个稳定版本（v0.21.12、v0.21.13、v0.21.14）的收尾流程都无法创建 release PR，main 上的 package 版本号和 CHANGELOG 落后于已发布的 tag。在不改动组织设置的前提下无法使用 GitHub Actions token，因此改用第三个 bot 身份来创建 PR，从而保持原有的双 bot 审批流程继续工作。

## 评审测试计划

### 如何验证

1. 确认创建 PR 的步骤现在使用专用 review-bot PAT，而不是 GitHub Actions token。
2. 通过手动触发，对某个漏掉的 tag（如 v0.21.14）重新运行收尾流程，确认它能创建 release PR、两个 bot 都审批通过、PR 合并进 main。
3. 确认合并后的 PR 更新了 main 上的 package.json 版本号和 CHANGELOG.md。

### 证据（前后对比）

之前：v0.21.12/13/14 的收尾流程在创建 PR 步骤失败，报错 `GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`。

之后：尚未重新运行——将通过对漏掉的 tag 重新运行收尾流程来确认。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

这是 CI workflow 改动，通过重新运行 workflow 来验证，而非本地操作系统测试。

## 风险与范围

- 主要风险或权衡：新的 bot PAT 必须是独立于两个审批 bot 的第三身份；如果是同一个账号，其中一个审批会被 self-approval 规则拦截。
- 未验证 / 超出范围：完整的 创建→审批→合并 流程尚未端到端重跑。
- 破坏性变更 / 迁移说明：无。此改动依赖 CI_REVIEW_BOT_PAT secret 已在仓库中存在。

## 关联 Issue

相关：#9056（引入该回归）、#9054（最初的 self-approval 问题）。

</details>