### PR TITLE
fix(cli): persist skipped duplicate tool results

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -28500,7 +28500,7 @@ describe('Session', () => {
       });
     });
 
-    it('drops repeated duplicate provider functionCall ids after the first synthetic response', async () => {
+    it('records repeated duplicate provider calls without returning results', async () => {
       const execute = vi.fn().mockResolvedValue({
         llmContent: 'should not run',
         returnDisplay: 'should not run',
@@ -28529,6 +28529,7 @@ describe('Session', () => {
           ],
         ]),
       );
+      const usedIds = new Set(['shell_1']);
       const [duplicatePart] = core.normalizeModelToolCallIds(
         [
           {
@@ -28539,7 +28540,7 @@ describe('Session', () => {
             },
           },
         ],
-        new Set(['shell_1']),
+        usedIds,
         new Set<string>(),
       );
       const duplicateCall = duplicatePart.functionCall!;
@@ -28549,6 +28550,19 @@ describe('Session', () => {
       ).runToolCalls(new AbortController().signal, 'prompt-history-dup', [
         duplicateCall,
       ]);
+      const [repeatedPart] = core.normalizeModelToolCallIds(
+        [
+          {
+            functionCall: {
+              id: 'shell_1',
+              name: 'read_file',
+              args: { file_path: 'b.ts' },
+            },
+          },
+        ],
+        usedIds,
+        new Set<string>(),
+      );
       const toolLoopState: DaemonToolLoopState = {
         totalToolCalls: 0,
         invalidToolParamErrors: new Map<string, number>(),
@@ -28558,13 +28572,14 @@ describe('Session', () => {
         repeatedToolFailureMode: 'off',
         repeatedToolFailureState: createRepeatedToolFailureGuardState(),
       };
+      expect(repeatedPart.functionCall?.id).toBe('shell_1__qwen_dup_3');
       const secondResult = await (
         session as unknown as ToolCallInternals
       ).runToolCalls(
         new AbortController().signal,
         'prompt-history-dup',
         [
-          duplicateCall,
+          repeatedPart.functionCall!,
           { id: 'fresh_shell', name: 'read_file', args: { file_path: 'c.ts' } },
         ],
         toolLoopState,
@@ -28589,9 +28604,39 @@ describe('Session', () => {
         core.LoopType.GLOBAL_TOOL_CALL_DUPLICATE,
       );
       expect(mockChatRecordingService.recordToolResult).toHaveBeenCalledTimes(
-        1,
+        3,
       );
-      expect(mockClient.sessionUpdate).toHaveBeenCalledTimes(1);
+      expect(
+        mockChatRecordingService.recordToolResult.mock.calls
+          .slice(1)
+          .map(([parts, metadata]) => ({
+            callId: metadata.callId,
+            responseId: parts[0]?.functionResponse?.id,
+            error: parts[0]?.functionResponse?.response?.['error'],
+            status: metadata.status,
+            executionStatus: metadata.executionStatus,
+          })),
+      ).toEqual([
+        {
+          callId: 'shell_1__qwen_dup_3',
+          responseId: 'shell_1__qwen_dup_3',
+          error: expect.stringContaining(
+            'loop detection stopped the current turn',
+          ),
+          status: 'error',
+          executionStatus: 'not_started',
+        },
+        {
+          callId: 'fresh_shell',
+          responseId: 'fresh_shell',
+          error: expect.stringContaining(
+            'loop detection stopped the current turn',
+          ),
+          status: 'error',
+          executionStatus: 'not_started',
+        },
+      ]);
+      expect(mockClient.sessionUpdate).toHaveBeenCalledTimes(3);
     });
 
     it('suppresses duplicate TodoWrite calls without emitting plan updates', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -9055,11 +9055,22 @@ export class Session implements SessionContext {
       } else {
         debugLogger.warn(message);
       }
-      return await finalizeRunToolResult({
+      await Promise.all(
+        dedupedFunctionCalls.map((fc) =>
+          recordSkippedToolCall(
+            fc,
+            LOOP_DETECTED_SKIP_MESSAGE,
+            false,
+            ToolErrorType.UNKNOWN,
+          ),
+        ),
+      );
+      const result = await finalizeRunToolResult({
         parts: [],
         stopAfterPermissionCancel: false,
         loopDetected: true,
       });
+      return { ...result, parts: [] };
     }
 
     const pushDuplicateBatch = (


### PR DESCRIPTION
## What this PR does

This PR persists a terminal error result for every function call dropped when the ACP repeated duplicate-provider breaker stops a turn. The breaker still reports loop detection and returns no tool response parts to the model, so it cannot continue the loop.

## Why it's needed

The assistant function calls are recorded before tool execution begins. Previously, the repeated-duplicate breaker returned early without recording results for the triggering call or its siblings, leaving dangling calls that transcript replay rendered as missing tool results after a session resume.

## Reviewer Test Plan

### How to verify

Run an ACP turn with an exact provider tool-call replay followed by another call in the same batch. Confirm that neither tool executes, the turn stops with loop detection, no response parts are returned to the model, and both normalized call IDs receive terminal `error` / `not_started` records with matching response IDs.

### Evidence (Before & After)

N/A — daemon session logic only; no UI rendering changed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v22.22.0. The focused regression test, all 667 session tests, the repository build and typecheck, changed-file ESLint, and the local high-effort review gate passed.

## Risk & Scope

- Main risk or tradeoff: Calls skipped by the breaker now produce terminal failed updates for clients, while the model-facing response remains empty.
- Not validated / out of scope: Provider ID collision classification is unchanged; argument-aware collision handling remains covered by #9436. Windows and Linux were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

Resolves #9586

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 ACP 的重复 provider tool-call 熔断器停止当前 turn 时，本 PR 会为所有被丢弃的 function call 持久化 terminal error result。熔断器仍会报告 loop detection，且不会把 tool response parts 返回给模型，因此模型不会继续循环。

## 为什么需要这个改动

assistant function call 会在工具开始执行前写入记录。此前，重复调用熔断器会直接返回，不为触发调用及其同批次调用记录结果，导致 transcript replay 在恢复 session 后把这些悬空调用显示为缺失 tool result。

## Reviewer 测试计划

### 如何验证

构造一次 ACP turn：先出现一个 provider tool-call 的精确 replay，再在同一批次追加另一个调用。确认两个工具都未执行，turn 因 loop detection 停止，没有 response parts 返回给模型，并且两个归一化 call ID 都写入 terminal `error` / `not_started` 记录，且 response ID 与 call ID 一致。

### 证据（改动前后）

N/A —— 仅修改 daemon session 逻辑，没有 UI 渲染变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js v22.22.0。聚焦回归测试、全部 667 个 session 测试、仓库 build 与 typecheck、变更文件 ESLint，以及本地 high-effort review gate 均已通过。

## 风险与范围

- 主要风险或权衡：被熔断器跳过的调用现在会向客户端产生 terminal failed update，但返回模型的响应仍为空。
- 未验证 / 不在范围内：provider ID collision 的分类逻辑不变；基于参数判断 collision 的行为仍由 #9436 覆盖。Windows 和 Linux 未在本地测试。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Resolves #9586

</details>
