### PR TITLE
fix(web-shell): don't steal approval focus while the user is typing

### DIFF
--- a/packages/web-shell/client/components/messages/ToolApproval.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolApproval.test.tsx
@@ -266,6 +266,61 @@ describe('ToolApproval accessibility', () => {
     );
   });
 
+  describe('yielding to active typing (#9571)', () => {
+    let composer: HTMLTextAreaElement;
+
+    beforeEach(() => {
+      // The user is typing in the composer when the approval arrives. In the
+      // app the overlay commit hides the composer in the same render, so the
+      // editable target still holds focus when the focus effect runs (jsdom
+      // mirrors that: display:none never blurs).
+      composer = document.createElement('textarea');
+      document.body.appendChild(composer);
+      composer.focus();
+    });
+
+    afterEach(() => {
+      composer.remove();
+    });
+
+    it('does not grab focus to the default option while an editable target is focused', () => {
+      expect(document.activeElement).toBe(composer);
+      render(undefined);
+      // Stealing focus here redirects the in-progress keystroke (Enter to
+      // send, Space, digits) onto the safe-default option and can confirm it.
+      expect(document.activeElement).toBe(composer);
+      expect(optionButtons().some((o) => o === document.activeElement)).toBe(
+        false,
+      );
+    });
+
+    it('does not re-grab focus when a new request arrives mid-typing', () => {
+      render(undefined);
+      expect(document.activeElement).toBe(composer);
+      rerender(true, { ...request, id: 'req-2' });
+      expect(document.activeElement).toBe(composer);
+    });
+
+    it('does not grab focus on re-activation while typing', () => {
+      render(false);
+      expect(document.activeElement).toBe(composer);
+      rerender(true);
+      expect(document.activeElement).toBe(composer);
+    });
+
+    it('still operates by keyboard once the user tabs in', () => {
+      render(undefined);
+      expect(document.activeElement).toBe(composer);
+      // Explicit tab-in: focusing an option engages the usual roving behavior.
+      const opts = optionButtons();
+      act(() => {
+        opts[0]!.focus();
+      });
+      pressKey(opts[0]!, 'ArrowDown');
+      expect(document.activeElement).toBe(opts[1]);
+    });
+  });
+
   it('confirms the clicked option', () => {
     render(undefined);
     act(() => {

--- a/packages/web-shell/client/components/messages/ToolApproval.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolApproval.test.tsx
@@ -319,6 +319,57 @@ describe('ToolApproval accessibility', () => {
       pressKey(opts[0]!, 'ArrowDown');
       expect(document.activeElement).toBe(opts[1]);
     });
+
+    it('yields to a contenteditable composer (CodeMirror shape)', () => {
+      // The production composer is a CodeMirror EditorView — a contenteditable
+      // div inside `.cm-editor` (the textarea backend is touch devices only).
+      // The textarea cases above never exercise isEditableTarget's
+      // contenteditable branches; pin them so simplifying the helper to bare
+      // form controls cannot silently re-open #9571.
+      const editor = document.createElement('div');
+      editor.className = 'cm-editor';
+      const editable = document.createElement('div');
+      editable.setAttribute('contenteditable', 'true');
+      editor.appendChild(editable);
+      document.body.appendChild(editor);
+      act(() => {
+        editable.focus();
+      });
+      expect(document.activeElement).toBe(editable);
+      render(undefined);
+      expect(document.activeElement).toBe(editable);
+      expect(optionButtons().some((o) => o === document.activeElement)).toBe(
+        false,
+      );
+      editor.remove();
+    });
+
+    it('yields in shadow-DOM (portal) mode, where document.activeElement retargets', () => {
+      // Portal mode mounts the shell inside a shadow root, where
+      // document.activeElement retargets to the non-editable host; the guard
+      // must resolve the active element from the panel's own root instead.
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      const shadowComposer = document.createElement('textarea');
+      shadowRoot.appendChild(shadowComposer);
+      const shadowContainer = document.createElement('div');
+      shadowRoot.appendChild(shadowContainer);
+      act(() => {
+        shadowComposer.focus();
+      });
+      expect(shadowRoot.activeElement).toBe(shadowComposer);
+
+      container = shadowContainer;
+      root = createRoot(container);
+      rerender(undefined);
+
+      expect(shadowRoot.activeElement).toBe(shadowComposer);
+      expect(optionButtons().some((o) => o === shadowRoot.activeElement)).toBe(
+        false,
+      );
+      host.remove();
+    });
   });
 
   it('confirms the clicked option', () => {

--- a/packages/web-shell/client/components/messages/ToolApproval.tsx
+++ b/packages/web-shell/client/components/messages/ToolApproval.tsx
@@ -12,6 +12,7 @@ import type { PermissionRequest, TodoItem } from '../../adapters/types';
 import { useI18n } from '../../i18n';
 import { PlanExecutionView } from './PlanExecutionView';
 import { isExitPlanApprovalRequest } from '../../utils/todos';
+import { getShadowAwareActiveElement, isEditableTarget } from '../../utils/dom';
 import { localizeToolDisplayName } from './toolFormatting';
 import styles from './ToolApproval.module.css';
 
@@ -259,6 +260,7 @@ export function ToolApproval({
   const safeDefaultIndexRef = useRef(safeDefaultIndex);
   safeDefaultIndexRef.current = safeDefaultIndex;
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const headingId = useId();
   const questionId = useId();
   const descId = useId();
@@ -316,6 +318,18 @@ export function ToolApproval({
     if (!keyboardActive) return;
     const requestChanged = request.id !== prevRequestId;
     if (wasActive && !requestChanged) return;
+    // The approval can appear while the user is mid-typing in the composer:
+    // the same commit hides the composer and mounts this overlay, so focus is
+    // still on the editable target when this effect runs. Grabbing it would
+    // redirect the in-progress keystrokes — Enter-to-send, Space, digits — to
+    // the safe-default option and can confirm the request unintentionally.
+    // Yield to the editable target; the dialog stays reachable by Tab/click.
+    // (The composer is hidden via CSS in the same commit, so style recalc —
+    // and its focus drop — has not happened yet when effects run; the active
+    // element still reflects where the user was typing.)
+    if (isEditableTarget(getShadowAwareActiveElement(panelRef.current))) {
+      return;
+    }
     // Fresh request → safe default; same request re-activated (e.g. a covering
     // panel closed) → restore the option the user had selected rather than
     // snapping focus back to the default and silently changing their choice.
@@ -399,6 +413,7 @@ export function ToolApproval({
 
   return (
     <div
+      ref={panelRef}
       className={
         variant === 'floating'
           ? `${styles.approval} ${styles.floating}${

--- a/packages/web-shell/client/components/messages/ToolApproval.tsx
+++ b/packages/web-shell/client/components/messages/ToolApproval.tsx
@@ -1,6 +1,7 @@
 import {
   useState,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useRef,
   useMemo,
@@ -310,7 +311,14 @@ export function ToolApproval({
   // already topmost on mount still focuses its default.
   const prevKeyboardActiveRef = useRef(false);
   const prevRequestIdRef = useRef(request.id);
-  useEffect(() => {
+  // Must be a layout effect, not a passive one: the commit that mounts this
+  // overlay also hides the composer, and sibling layout effects can force a
+  // synchronous style recalculation (by reading layout) before any passive
+  // effect runs — Chromium drops focus from the just-hidden composer during
+  // that recalculation, so a passive guard would read `body` and miss.
+  // Layout effects run right after DOM mutation, before any recalculation,
+  // while the hidden composer still holds focus.
+  useLayoutEffect(() => {
     const wasActive = prevKeyboardActiveRef.current;
     const prevRequestId = prevRequestIdRef.current;
     prevKeyboardActiveRef.current = keyboardActive;
@@ -319,14 +327,11 @@ export function ToolApproval({
     const requestChanged = request.id !== prevRequestId;
     if (wasActive && !requestChanged) return;
     // The approval can appear while the user is mid-typing in the composer:
-    // the same commit hides the composer and mounts this overlay, so focus is
-    // still on the editable target when this effect runs. Grabbing it would
-    // redirect the in-progress keystrokes — Enter-to-send, Space, digits — to
-    // the safe-default option and can confirm the request unintentionally.
-    // Yield to the editable target; the dialog stays reachable by Tab/click.
-    // (The composer is hidden via CSS in the same commit, so style recalc —
-    // and its focus drop — has not happened yet when effects run; the active
-    // element still reflects where the user was typing.)
+    // the same commit hides the composer and mounts this overlay. Grabbing
+    // focus would redirect the in-progress keystrokes — Enter-to-send, Space,
+    // digits — to the safe-default option and can confirm the request
+    // unintentionally. Yield to the editable target; the dialog stays
+    // reachable by Tab/click.
     if (isEditableTarget(getShadowAwareActiveElement(panelRef.current))) {
       return;
     }


### PR DESCRIPTION
## What this PR does

The Web Shell tool-approval dialog no longer pulls keyboard focus to its safe-default option when it appears while the user is typing in an editable element (the composer). The focus-grab effect in `ToolApproval` now yields when the active element is an editable target, reusing the existing `isEditableTarget` / `getShadowAwareActiveElement` helpers from `client/utils/dom.ts`. In every other situation — nothing focused, focus on a non-editable element, split-view panes, re-activation after a covering panel closes — the existing focus handoff is unchanged.

## Why it's needed

Fixes the behavior reported in #9571: while a task is running and the user is typing in the input box, the confirmation box pops up "selected by default". The mechanism: when a tool approval arrives, the same React commit hides the composer (`App.tsx`, `composerHidden`) and mounts the `ToolApproval` overlay, whose focus effect then unconditionally focuses the safe-default option button. Because keyboard handling is focus-scoped to the panel, the user's in-progress keystrokes land on the dialog: `Enter`/`Space` natively activate the focused default option, and digits `1`–`9` confirm by position — so the message-send Enter or plain typing can unintentionally approve or reject the tool call.

## Reviewer Test Plan

### How to verify

The fix rests on one browser-timing fact: when effects run (post-commit, pre-paint), the composer textarea still holds focus even though it was just given `display:none`; the browser drops that focus only during the later style recalc. Verified three ways:

1. **Red/green component tests** — `packages/web-shell/client/components/messages/ToolApproval.test.tsx`, new `yielding to active typing (#9571)` block (4 tests). On unfixed `main` all 4 fail (focus moves from the focused textarea to the safe-default option); with the fix all 36 tests in the file pass:

   ```text
   # before (unfixed main): Tests  4 failed | 32 passed (36)
   # after  (this branch):  Tests  36 passed (36)
   ```

2. **Real-browser timing probe** (Playwright headless Chromium): focus a textarea, then synchronously set its wrapper `display:none` and mount a button (the commit order), reading `document.activeElement` immediately and after paint:

   ```json
   { "focusedOnComposer": true, "syncActiveIsComposer": true, "syncActiveTag": "TEXTAREA", "postPaintActiveTag": "BODY" }
   ```

   i.e. at effect time the active element still reflects the typing target (guard works), and without any grab focus falls to `body` after paint — so stray keystrokes hit nothing instead of confirming the dialog.

3. **Regression scope** — full `packages/web-shell` suite: `Test Files 192 passed (192)`, `Tests 4001 passed (4001)` (includes the App-level approval-overlay and `composerHidden` tests, and the existing focus-grab/roving-tabindex/digit-shortcut tests which pin the unchanged behavior). `typecheck`, `eslint`, and `prettier --check` are clean.

A full manual pass (`qwen serve` + a live turn that triggers an approval while typing) was not run here — no model session is available in this environment; the component tests exercise the exact focus contract through real DOM focus (unmocked).

### Evidence (Before & After)

Focus behavior is not screenshot-capturable; the red/green test block and the browser probe output above are the evidence. Before: `document.activeElement` jumps from the focused composer textarea to the `Reject`/safe-default option the instant the approval mounts. After: it stays on the textarea, and the dialog is reached by Tab/click as designed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests: `npx vitest run --config vitest.config.ts` in `packages/web-shell` (Node v24.19.0). Timing probe: Playwright headless Chromium.

## Risk & Scope

- Main risk or tradeoff: when an approval appears exactly while the user is typing, keyboard users are not auto-placed on the default option and need one Tab into the dialog; appearance without active typing is unchanged. If a browser ever dropped focus from the hidden composer before effects run, the guard simply misses and behavior degrades to today's grab — never worse than status quo.
- Not validated / out of scope: `AskUserQuestion` has the symmetric unguarded focus grab (its key *shortcuts* already check `isEditableTarget`, the grab does not) — left for a follow-up to keep this PR scoped to the reported confirmation box. No live e2e with a real daemon/model session.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9571

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当工具审批弹窗出现时，如果用户正在可编辑元素（输入框）中打字，Web Shell 的审批弹窗不再把键盘焦点抢到"安全默认"选项上。`ToolApproval` 的焦点抢占 effect 现在会在当前焦点位于可编辑元素时让位，复用 `client/utils/dom.ts` 里现成的 `isEditableTarget` / `getShadowAwareActiveElement` 工具函数。其余所有情况——无焦点、焦点在非编辑元素、分栏面板、遮挡面板关闭后的重新激活——原有的焦点交接行为完全不变。

## 为什么需要

修复 #9571 报告的行为：任务执行中用户在输入框打字时，确认弹窗弹出即"已默认选中"。机制是：工具审批到达时，同一个 React commit 里既隐藏了输入框（`App.tsx` 的 `composerHidden`）又挂载了 `ToolApproval` 弹窗，其焦点 effect 随后无条件地把焦点移到安全默认选项按钮上。由于键盘处理是按面板焦点作用域绑定的，用户正在敲的按键就落在弹窗上：`Enter`/`Space` 原生激活被聚焦的默认选项，数字键 `1`–`9` 按位置直接确认——于是习惯性的"回车发送"或正在输入的字符可能无意间批准或拒绝工具调用。

## 评审验证计划

### 如何验证

修复依赖一个浏览器时序事实：effect 运行时（commit 之后、绘制之前），即使输入框刚被设为 `display:none`，焦点仍在输入框 textarea 上；浏览器要到之后的样式重算才会丢掉这个焦点。用三种方式验证：

1. **红转绿组件测试**——`packages/web-shell/client/components/messages/ToolApproval.test.tsx` 新增 `yielding to active typing (#9571)` 块（4 条）。未修复的 `main` 上 4 条全部失败（焦点从已聚焦的 textarea 跳到安全默认选项）；修复后该文件 36 条全部通过。

2. **真实浏览器时序探针**（Playwright headless Chromium）：聚焦一个 textarea，然后同步地把它的外层设为 `display:none` 并挂载一个按钮（即 commit 顺序），分别在当时和绘制后读取 `document.activeElement`：effect 时刻焦点仍是 textarea（守卫有效），绘制后焦点落到 `body`——即不抢占时多余按键什么都不会命中，而不是确认弹窗。

3. **回归范围**——`packages/web-shell` 全量套件：192 个文件 / 4001 条测试全部通过（含 App 层审批弹窗与 `composerHidden` 测试，以及固化原有行为的焦点抢占/roving tabindex/数字快捷键测试）。`typecheck`、`eslint`、`prettier --check` 均干净。

没有跑完整的手动链路（`qwen serve` + 真实触发审批的回合 + 打字）——本环境没有可用模型会话；组件测试通过真实 DOM 焦点（未 mock）覆盖的正是这条焦点契约。

### 前后证据

焦点行为无法截图取证；上面的红转绿测试块与浏览器探针输出即证据。修复前：审批弹窗挂载瞬间 `document.activeElement` 从已聚焦的输入框跳到安全默认选项。修复后：焦点保持在输入框，弹窗按设计通过 Tab/点击到达。

### 测试环境

Linux ✅（单测 + 探针）；macOS / Windows 未测。

## 风险与范围

- 主要风险/取舍：审批恰好在用户打字时出现时，键盘用户不会被自动放到默认选项上，需要多按一次 Tab 进入弹窗；无输入行为时的弹窗出现不受影响。若某浏览器在 effect 运行前就丢掉了被隐藏输入框的焦点，守卫只会失效并退回今天的抢占行为——不会比现状更差。
- 未验证/超出范围：`AskUserQuestion` 存在同样未加守卫的焦点抢占（它的按键快捷键已有 `isEditableTarget` 检查，抢占本身没有）——为把本 PR 收敛在报告所述的确认框，留作后续处理。未做真实 daemon/模型会话的 live e2e。
- 破坏性变更/迁移说明：无。

</details>
