### PR TITLE
docs(autofix): add an operator guide for `/takeover from N`

### DIFF
--- a/.github/workflows/qwen-autofix-round-seed.md
+++ b/.github/workflows/qwen-autofix-round-seed.md
@@ -1,0 +1,143 @@
+# Round seeding — `@qwen-code /takeover from N`
+
+Operator guide for the one parameterized takeover command. For the
+implementation rationale behind each gate, see the design record:
+[`qwen-autofix.md`](./qwen-autofix.md) — [af-007](./qwen-autofix.md#af-007)
+(the parser) and [af-016](./qwen-autofix.md#af-016) (the marker).
+
+## The problem it solves
+
+The autofix loop stops implementing non-Critical feedback once a PR has
+completed `CRITICAL_ONLY_AFTER_ROUND` (5) change-producing rounds. From there
+only Critical findings, `Request changes` reviews, failed checks, and base
+conflicts drive code changes; everything else is recorded in a
+`Deferred non-Critical feedback` section and left for a human.
+
+That counter is **window-scoped**, and engaging takeover opens a fresh window.
+So a PR that had already absorbed nine rounds of ordinary human review got five
+more suggestion-capable rounds the moment it was managed — the loop grew the
+diff on nice-to-haves at exactly the point it should have been converging.
+
+`from N` lets you state what the loop cannot infer: how much review this PR has
+already been through.
+
+## Usage
+
+```
+@qwen-code /takeover from 4
+```
+
+Engages takeover **and** starts this counting window's round counter at 4. With
+the threshold at 5, the Critical-only brake then engages after **one** more
+change-producing round instead of a fresh five.
+
+The bot confirms in its engage ack, and the seed rides as its own marker:
+
+```
+🤝 Takeover engaged: … This window's round counter starts at 4 (the rounds this
+PR spent in review before takeover), so the Critical-only brake engages after 1
+more change-producing round(s) instead of a full fresh 5. …
+
+<!-- takeover-ack engaged -->
+<!-- autofix-round-start 4 -->
+```
+
+Who may issue it is unchanged from the bare command: the PR author on an in-repo
+PR (holding triage+ _at the time of the comment_), or any write+ collaborator.
+The same refusals apply — a non-`main` base, `autofix/skip`, and a fork without
+maintainer-edit access are all declined out loud.
+
+### Picking N
+
+N is "how many review rounds has this PR already had", counted the way the loop
+counts: **rounds that produced changes**, not individual comments or reviews. A
+practical proxy is the number of times the author pushed a revision in response
+to review.
+
+You do not have to be precise. The seed only decides how much suggestion budget
+remains, and you can always re-seed (below). When unsure, err toward the higher
+number: the tail of a long-running PR is where suggestion churn hurts most, and
+Critical findings, `Request changes` reviews, failed checks, and base-conflict
+resolution keep flowing regardless of the seed.
+
+| You type | Counter starts at | Suggestion-capable rounds left                 |
+| -------- | ----------------- | ---------------------------------------------- |
+| `from 0` | 0                 | 5 — identical to a bare `/takeover`            |
+| `from 3` | 3                 | 2                                              |
+| `from 4` | 4                 | 1                                              |
+| `from 5` | 5                 | 0 — Critical-only from the first managed round |
+
+## Semantics
+
+**The seed is a floor for an empty window, not an offset added to every round.**
+The counter is `max(this window's round markers)`, falling back to the seed when
+the window has none yet. The first managed round therefore records `N+1`, the
+next `N+2`, and the seed stops mattering. It cannot double-count.
+
+**The seed lives and dies with the counting window.** It is read from the engage
+ack whose timestamp _is_ the window key, so a superseded window's seed can never
+leak forward. Consequently:
+
+- `@qwen-code /retry` opens a new window with **no** seed — the counter returns
+  to 0 and the suggestion valve reopens. That is what re-arming means.
+- A bare `@qwen-code /takeover` on an already-managed PR does the same.
+- To re-arm a late-stage PR _without_ reopening the valve, re-issue the command
+  **with its number**: `@qwen-code /takeover from 7`. On an already-managed PR
+  this takes the re-arm path and says so ("the round counter restarts at 7 —
+  rounds already spent on this PR").
+
+**The seed is clamped strictly below the round cap.** The cap is 100 while
+`autofix/takeover` is present and 10 without it. A seed at or past the effective
+cap would park the PR at its cap on the very round it was taken over — stopping
+the loop instead of starting it — so it is clamped to `cap - 1`. When that
+happens, the Critical-only audit record cites the number you **typed**, plus a
+note naming the clamp, so it never quotes a command nobody sent.
+
+## What it does not do
+
+**It does not seed the growth brake.** `CRITICAL_ONLY_AFTER_ROUND` is only one
+of two brakes; the other trips when the diff grows past
+`GROWTH_BUDGET_SRC_LINES` / `GROWTH_BUDGET_TEST_LINES` beyond the window's
+baseline. That baseline is anchored at the window's first measured round, and a
+pre-takeover baseline is not recoverable from anything the loop can read — so
+diff growth is always measured **from engagement**, seeded or not.
+
+**It does not change what Critical-only preserves.** Critical findings,
+`Request changes` reviews, in-budget maintainer feedback, failed checks, and
+base-conflict resolution all keep flowing. Only the suggestion channel stops.
+
+**It does not shorten the round cap in any meaningful way.** Under takeover the
+cap is 100, so a seed of 4 leaves 96.
+
+## Accepted and rejected forms
+
+The literal prefix must match `@qwen-code /takeover` byte-for-byte and the tail
+must be a bare 1–2 digit integer. Leading and trailing whitespace on the comment
+is trimmed; nothing else is tolerated, and anything unrecognized fails closed to
+"not an exact command" — no label, no seed, no partial effect.
+
+| Body                                 | Result                                      |
+| ------------------------------------ | ------------------------------------------- |
+| `@qwen-code /takeover from 4`        | engage, seed 4                              |
+| `@qwen-code /takeover from 04`       | engage, seed 4 (read as decimal, not octal) |
+| `@qwen-code /takeover from 0`        | engage, no seed — the explicit spelling     |
+| `@qwen-code /takeover`               | engage, no seed                             |
+| `@qwen-code /takeover stop`          | release                                     |
+| `@qwen-code /takeover stop from 4`   | **nothing** — neither releases nor engages  |
+| `@qwen-code /takeover from 100`      | **nothing** — 3 digits rejected             |
+| `@qwen-code /takeover  from 4`       | **nothing** — double space                  |
+| `please @qwen-code /takeover from 4` | **nothing** — must start the comment        |
+| `@qwen-code /takeover from 4 please` | **nothing** — must end the comment          |
+
+## Reading the result
+
+Once the brake engages, the round report carries a `Deferred non-Critical
+feedback` section whose preamble names the seed explicitly, for example:
+
+> the round counter reached 5 (this window was seeded at round 4 by
+> `@qwen-code /takeover from 4`, plus 1 change-producing round(s) since)
+
+That wording exists so a maintainer seeing Critical-only fire on a PR the loop
+has only run once can tell it from a misfire. The agent is told the same thing
+in `SKILL.md`, so it treats an early engagement as ordinary rather than
+suspicious.

--- a/.github/workflows/qwen-autofix-round-seed.md
+++ b/.github/workflows/qwen-autofix-round-seed.md
@@ -9,9 +9,10 @@ implementation rationale behind each gate, see the design record:
 
 The autofix loop stops implementing non-Critical feedback once a PR has
 completed `CRITICAL_ONLY_AFTER_ROUND` (5) change-producing rounds. From there
-only Critical findings, `Request changes` reviews, failed checks, and base
-conflicts drive code changes; everything else is recorded in a
-`Deferred non-Critical feedback` section and left for a human.
+only Critical findings, `Request changes` reviews, in-budget maintainer
+feedback, failed checks, and base conflicts drive code changes; everything
+else is recorded in a `Deferred non-Critical feedback` section and left for a
+human.
 
 That counter is **window-scoped**, and engaging takeover opens a fresh window.
 So a PR that had already absorbed nine rounds of ordinary human review got five
@@ -44,8 +45,9 @@ more change-producing round(s) instead of a full fresh 5. …
 
 Who may issue it is unchanged from the bare command: the PR author on an in-repo
 PR (holding triage+ _at the time of the comment_), or any write+ collaborator.
-The same refusals apply — a non-`main` base, `autofix/skip`, and a fork without
-maintainer-edit access are all declined out loud.
+The same refusals apply — a non-`main` base, `autofix/skip`, a fork without
+maintainer-edit access, and a fork whose author lacks write+ on this repository
+are all declined out loud.
 
 ### Picking N
 
@@ -57,8 +59,9 @@ to review.
 You do not have to be precise. The seed only decides how much suggestion budget
 remains, and you can always re-seed (below). When unsure, err toward the higher
 number: the tail of a long-running PR is where suggestion churn hurts most, and
-Critical findings, `Request changes` reviews, failed checks, and base-conflict
-resolution keep flowing regardless of the seed.
+Critical findings, `Request changes` reviews, in-budget maintainer feedback,
+failed checks, and base-conflict resolution keep flowing regardless of the
+seed.
 
 | You type | Counter starts at | Suggestion-capable rounds left                 |
 | -------- | ----------------- | ---------------------------------------------- |
@@ -112,9 +115,11 @@ cap is 100, so a seed of 4 leaves 96.
 ## Accepted and rejected forms
 
 The literal prefix must match `@qwen-code /takeover` byte-for-byte and the tail
-must be a bare 1–2 digit integer. Leading and trailing whitespace on the comment
-is trimmed; nothing else is tolerated, and anything unrecognized fails closed to
-"not an exact command" — no label, no seed, no partial effect.
+must be a bare 1–2 digit integer. Leading spaces and tabs on the first line, and
+all trailing whitespace, are trimmed — but a blank line before the command is
+not, so it must start the comment's first line. Nothing else is tolerated, and
+anything unrecognized fails closed to "not an exact command" — no label, no
+seed, no partial effect.
 
 | Body                                 | Result                                      |
 | ------------------------------------ | ------------------------------------------- |
@@ -127,6 +132,7 @@ is trimmed; nothing else is tolerated, and anything unrecognized fails closed to
 | `@qwen-code /takeover from 100`      | **nothing** — 3 digits rejected             |
 | `@qwen-code /takeover  from 4`       | **nothing** — double space                  |
 | `please @qwen-code /takeover from 4` | **nothing** — must start the comment        |
+| blank line, then the command         | **nothing** — must start the first line     |
 | `@qwen-code /takeover from 4 please` | **nothing** — must end the comment          |
 
 ## Reading the result

--- a/.github/workflows/qwen-autofix.md
+++ b/.github/workflows/qwen-autofix.md
@@ -46,6 +46,12 @@ titled with the job and step it belongs to. Editing rules: keep the pointer and
 the section id in sync, put new long-form reasoning here rather than in the
 YAML, and never delete a section without deleting its pointer.
 
+This file records _why the code is the way it is_, indexed by code site. For
+task-oriented guides — what a maintainer types and what happens next — see:
+
+- [`qwen-autofix-round-seed.md`](./qwen-autofix-round-seed.md) — seeding the
+  round counter with `@qwen-code /takeover from N`.
+
 ## Contents
 
 - [1. (top level) — One workflow for the whole autonomous-fix lifecycle:](#af-001)

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -428,6 +428,7 @@ jobs:
                 # '<cmd> from N' — the ONE parameterized form, and the only
                 # place this workflow reads a value out of a comment body.
                 # Full rationale → qwen-autofix.md#af-007
+                # Operator guide → qwen-autofix-round-seed.md
                 if [[ "${BODY_TRIMMED}" =~ ^(.*)\ from\ ([0-9]{1,2})$ ]]; then
                   # Two statements, not one `[[ ... && ... ]]`: BASH_REMATCH is
                   # only guaranteed populated once the =~ test has completed,


### PR DESCRIPTION
## What this PR does

Adds `.github/workflows/qwen-autofix-round-seed.md`, a task-oriented operator guide for `@qwen-code /takeover from N`, and cross-links it with the existing design record.

`qwen-autofix.md` is a design record: it holds the verbatim prose that moved out of the YAML, indexed by code site, and it already covers this feature — [af-007](https://github.com/QwenLM/qwen-code/blob/main/.github/workflows/qwen-autofix.md#af-007) for the parser and [af-016](https://github.com/QwenLM/qwen-code/blob/main/.github/workflows/qwen-autofix.md#af-016) for the marker the engage ack writes. That answers "why is this code shaped like this". A maintainer looking at a long-running PR and deciding whether to seed the takeover has a different question — what do I type, what number do I pick, and what happens after — and nothing answered it.

The guide covers: the problem the seed solves; how to choose N, with a table of remaining suggestion budget per seed; the three semantics that surprise people — the seed is a floor for an empty window rather than an offset added to every round, it dies with its counting window so `@qwen-code /retry` and a bare `@qwen-code /takeover` both return the counter to zero, and it is clamped strictly below the round cap while the audit record still cites the number that was typed; and the two things it deliberately does not do — seed the growth brake, or change what Critical-only keeps flowing.

Cross-linked both ways. The design record's preamble now says it is indexed by code site and points at task-oriented guides; the parser in the YAML keeps its `af-007` pointer and gains an `Operator guide →` line beside it. The workflow grows by 64 bytes.

## Why it's needed

`from N` shipped in #9321 with its rationale documented but no usage documentation anywhere. The command's audience is maintainers who mostly will not read a workflow file to discover that a parameter exists, and the parts most likely to be got wrong are exactly the parts the rationale comments do not address — that re-arming silently drops the seed, that the growth brake is a separate brake the seed does not touch, and that anything other than the exact accepted spelling fails closed with no partial effect and no error comment.

Placed in `.github/workflows/` next to the workflow and its design record rather than under `docs/`: `docs/_meta.ts` publishes only `users` and `developers`, and `/takeover` is a repo-internal command that collaborators on this repository can issue. It does not belong in the published product documentation.

## Reviewer Test Plan

### How to verify

Read the guide, then spot-check its claims against `main` — every number and quoted string in it was taken from the merged workflow, not from the PR that introduced the feature.

The accepted/rejected command table is the part most likely to rot, so it was not written from the regex. The parser fragment was extracted verbatim from the merged `qwen-autofix.yml` (the `CMD=''` … `RETRY_REQ=''` block in `route` · `Decide phases`), combined with the marker-write condition from `takeover-command`, and every row was replayed:

```
@qwen-code /takeover from 4          -> CMD='add'    seed=4
@qwen-code /takeover from 04         -> CMD='add'    seed=4
@qwen-code /takeover from 08         -> CMD='add'    seed=8
@qwen-code /takeover from 99         -> CMD='add'    seed=99
@qwen-code /takeover from 0          -> CMD='add'    seed=(none)
@qwen-code /takeover                 -> CMD='add'    seed=(none)
@qwen-code /takeover stop            -> CMD='remove' seed=(none)
@qwen-code /takeover stop from 4     -> CMD=''       seed=(none)
@qwen-code /takeover from 100        -> CMD=''       seed=(none)
@qwen-code /takeover  from 4         -> CMD=''       seed=(none)
please @qwen-code /takeover from 4   -> CMD=''       seed=(none)
@qwen-code /takeover from 4 please   -> CMD=''       seed=(none)
```

All ten rows in the doc match. `from 04` / `from 08` seeding 4 and 8 rather than tripping octal is the `10#` canonicalisation from #9321's R2 round, and the guide documents the observed result rather than the intent.

The constants the guide quotes were re-read from `origin/main` after this branch was rebased onto it: `CRITICAL_ONLY_AFTER_ROUND: '5'`, `MAX_ROUNDS: '10'`, `TAKEOVER_MAX_ROUNDS: '100'`, `GROWTH_BUDGET_SRC_LINES`/`GROWTH_BUDGET_TEST_LINES` at 400, both clamp sites, and the re-arm and Critical-only audit wordings.

There is also one piece of production evidence, from #9491. `@qwen-code /takeover from 4` was issued there on 2026-08-20; the engage ack rendered "starts at 4 … after 1 more change-producing round(s)" and carried `<!-- autofix-round-start 4 -->` on its own line below a byte-identical `<!-- takeover-ack engaged -->`. The next scan then wrote `<!-- autofix-eval ts=… acted=false round=4 win=2026-08-20T12:43:35Z -->`, i.e. the read path computed the seeded value with no eval markers in the window and a no-change round materialised it into a durable marker. **Partial**: that PR merged before any change-producing round ran, so the brake itself was not exercised in production — the round-5 transition and the Critical-only engagement are still only covered by the unit tests from #9321.

Gates, run on this branch after rebasing onto the current `main`:

```
bash .github/scripts/check-workflow-size.sh .github/workflows/qwen-autofix.yml   # ✅ under the 470000-byte gate
node scripts/lint.js --actionlint                                                # exit 0
npx prettier --check .github/workflows/qwen-autofix-round-seed.md .github/workflows/qwen-autofix.md
npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow workflow-size   # 249 passed (249)
```

### Evidence (Before & After)

N/A — documentation only, plus a 64-byte comment pointer in the workflow. No runtime behaviour changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — no runtime involved; workflow-contract tests and linters only.

## Risk & Scope

- **Main risk or tradeoff:** documentation drifts from the workflow it describes. Mitigated by sourcing every claim from merged code and by replaying the command table rather than transcribing the regex, but nothing enforces it — a future change to the parser or to `CRITICAL_ONLY_AFTER_ROUND` will not fail a test because this file went stale. The `af-007` pointer sitting directly above the parser is the main defence.
- **Not validated / out of scope:** the guide documents `from N` only, not the wider takeover command surface (`stop`, `/retry`, the labels, the caps), which still has no operator-facing page. The one behavioural line in this PR is a comment; the feature itself is unchanged.
- **Breaking changes / migration notes:** none.

## Linked Issues

Follows #9321, which introduced `@qwen-code /takeover from N`.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增 `.github/workflows/qwen-autofix-round-seed.md`：面向操作的 `@qwen-code /takeover from N` 使用指南，并与既有的设计记录做了双向交叉链接。

`qwen-autofix.md` 是一份设计记录：它保存从 YAML 中迁出的逐字原文，按代码位置索引，并且已经覆盖了本特性 —— [af-007](https://github.com/QwenLM/qwen-code/blob/main/.github/workflows/qwen-autofix.md#af-007) 对应解析器，[af-016](https://github.com/QwenLM/qwen-code/blob/main/.github/workflows/qwen-autofix.md#af-016) 对应接管回执写入的标记。那回答的是"这段代码为什么长这样"。而一位维护者面对一个长期运行的 PR、在决定要不要给接管种子时，问的是另一个问题 —— 我该敲什么、数字选多少、之后会发生什么 —— 此前没有任何文档回答它。

指南涵盖：种子解决的问题；如何选 N，并附每个种子对应剩余 suggestion 预算的对照表；最容易让人意外的三条语义 —— 种子是空窗口的下界而非叠加到每一轮的偏移量、它随所属计数窗口一同消亡（因此 `@qwen-code /retry` 与裸 `@qwen-code /takeover` 都会把计数归零）、以及它被收敛在轮次上限之下而审计记录仍引用你实际输入的数字；还有它刻意不做的两件事 —— 不种子化增长刹车，也不改变 Critical-only 放行的内容。

双向交叉链接：设计记录的前言现在说明自身按代码位置索引，并指向面向任务的指南；YAML 中的解析器保留其 `af-007` 指针，并在旁边新增一行 `Operator guide →`。workflow 因此增加 64 字节。

## 为什么需要

`from N` 随 #9321 发布时带了完整的实现理由，却没有任何使用文档。该命令的受众是维护者，他们多半不会为了发现"存在一个参数"去读 workflow 文件；而最容易搞错的部分，恰恰是那些理由注释没有覆盖的 —— 重新武装会静默丢弃种子、增长刹车是种子管不到的另一道刹车、以及除精确写法外任何输入都会 fail closed，既不产生部分效果也不会有任何报错评论。

放在 `.github/workflows/` 下、紧邻 workflow 与其设计记录，而不是放到 `docs/` 下：`docs/_meta.ts` 只发布 `users` 与 `developers` 两个页面，而 `/takeover` 是本仓库协作者可用的仓库内部命令，不应进入对外发布的产品文档。

## 评审者测试计划

### 如何验证

阅读该指南，然后对照 `main` 抽查其中的断言 —— 文中每一个数字与引用字符串都取自**已合入的** workflow，而非引入该特性的那个 PR。

接受/拒绝命令表是最容易腐化的部分，因此它不是照着正则写出来的。解析器片段是从已合入的 `qwen-autofix.yml` 中逐字抽取的（`route` · `Decide phases` 里从 `CMD=''` 到 `RETRY_REQ=''` 的那一段），再拼上 `takeover-command` 中的标记写入条件，然后逐行回放：

```
@qwen-code /takeover from 4          -> CMD='add'    seed=4
@qwen-code /takeover from 04         -> CMD='add'    seed=4
@qwen-code /takeover from 08         -> CMD='add'    seed=8
@qwen-code /takeover from 99         -> CMD='add'    seed=99
@qwen-code /takeover from 0          -> CMD='add'    seed=(none)
@qwen-code /takeover                 -> CMD='add'    seed=(none)
@qwen-code /takeover stop            -> CMD='remove' seed=(none)
@qwen-code /takeover stop from 4     -> CMD=''       seed=(none)
@qwen-code /takeover from 100        -> CMD=''       seed=(none)
@qwen-code /takeover  from 4         -> CMD=''       seed=(none)
please @qwen-code /takeover from 4   -> CMD=''       seed=(none)
@qwen-code /takeover from 4 please   -> CMD=''       seed=(none)
```

文档中的十行全部吻合。`from 04` / `from 08` 得到 4 与 8 而非触发八进制，来自 #9321 第二轮评审加入的 `10#` 归一化；指南记录的是实测结果而非设计意图。

指南引用的常量，是在本分支变基到 `origin/main` 之后重新读取的：`CRITICAL_ONLY_AFTER_ROUND: '5'`、`MAX_ROUNDS: '10'`、`TAKEOVER_MAX_ROUNDS: '100'`、`GROWTH_BUDGET_SRC_LINES`/`GROWTH_BUDGET_TEST_LINES` 均为 400，两处 clamp 位置，以及重新武装与 Critical-only 审计的措辞。

另有一份来自 #9491 的生产证据。2026-08-20 在该 PR 上执行了 `@qwen-code /takeover from 4`；接管回执渲染为"starts at 4 … after 1 more change-producing round(s)"，并在字节完全一致的 `<!-- takeover-ack engaged -->` 下方单独一行携带 `<!-- autofix-round-start 4 -->`。随后的扫描写入了 `<!-- autofix-eval ts=… acted=false round=4 win=2026-08-20T12:43:35Z -->`，即读取侧在窗口内没有任何 eval 标记的情况下算出了种子值，并由一个无改动轮次把它固化为持久标记。**但这只是部分验证**：该 PR 在任何产生改动的轮次运行之前就已合入，因此刹车本身并未在生产中被触发 —— 第 5 轮的跨越与 Critical-only 的实际生效，目前仍只由 #9321 的单元测试覆盖。

门禁，在本分支变基到当前 `main` 之后运行：

```
bash .github/scripts/check-workflow-size.sh .github/workflows/qwen-autofix.yml   # ✅ 低于 470000 字节门限
node scripts/lint.js --actionlint                                                # 退出码 0
npx prettier --check .github/workflows/qwen-autofix-round-seed.md .github/workflows/qwen-autofix.md
npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow workflow-size   # 249 passed (249)
```

### 证据（改动前后）

N/A —— 纯文档，外加 workflow 中一处 64 字节的注释指针。无运行时行为变更。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

N/A —— 不涉及运行时；仅 workflow 契约测试与各类 linter。

## 风险与范围

- **主要风险或权衡：** 文档会与它所描述的 workflow 发生漂移。缓解手段是所有断言均取自已合入代码、且命令表通过回放得出而非誊抄正则，但没有任何机制强制这一点 —— 未来改动解析器或 `CRITICAL_ONLY_AFTER_ROUND` 并不会因为本文件过时而导致测试失败。紧贴解析器上方的 `af-007` 指针是主要防线。
- **未验证 / 不在范围内：** 本指南仅覆盖 `from N`，不覆盖更广的接管命令面（`stop`、`/retry`、各标签、各上限），后者仍然没有面向操作者的页面。本 PR 中唯一涉及行为文件的改动是一行注释；特性本身未做任何变更。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

承接 #9321，该 PR 引入了 `@qwen-code /takeover from N`。

</details>
