### PR TITLE
feat(web-shell): keep a turn expanded while its background shell runs

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -394,6 +394,7 @@ const {
         }) => void;
         isResponding?: boolean;
         activeTurnStartedAt?: number;
+        terminalBackgroundShellTaskIds?: ReadonlySet<string>;
       } | null,
       latestBtwMessageProps: null as {
         question: string;
@@ -800,6 +801,7 @@ vi.mock('./components/MessageList', async () => {
         }) => void;
         isResponding?: boolean;
         activeTurnStartedAt?: number;
+        terminalBackgroundShellTaskIds?: ReadonlySet<string>;
         welcomeHeader?: React.ReactNode;
       },
       ref: React.ForwardedRef<{ scrollToBottom: () => void }>,
@@ -1780,6 +1782,13 @@ describe('task activity key', () => {
             args: { is_background: true },
           },
           {
+            callId: 'promoted-shell',
+            toolName: 'run_shell_command',
+            status: 'completed',
+            args: { is_background: false },
+            rawOutput: 'Promoted to background: bg_1234abcd',
+          },
+          {
             callId: 'monitor-call',
             toolName: 'monitor',
             status: 'completed',
@@ -1790,7 +1799,7 @@ describe('task activity key', () => {
     ] satisfies Message[];
 
     expect(getTaskActivityKey(messages)).toBe(
-      'shell-call:in_progress|agent-call:pending|nested-shell:completed|completed-shell:completed|monitor-call:completed',
+      'shell-call:in_progress|agent-call:pending|nested-shell:completed|completed-shell:completed|promoted-shell:completed|monitor-call:completed',
     );
   });
 
@@ -7814,6 +7823,36 @@ describe('App session callbacks', () => {
     });
 
     expect(testState.latestStatusBarTasks).toEqual([monitor]);
+  });
+
+  it('passes terminal background shell task ids to the message list', async () => {
+    const running: DaemonSessionShellTaskStatus = {
+      kind: 'shell',
+      id: 'shell-running',
+      label: 'Running shell',
+      description: 'Running shell',
+      status: 'running',
+      startTime: 1_000,
+      runtimeMs: 5_000,
+      command: 'npm run dev',
+      cwd: '/tmp/project',
+    };
+    testState.backgroundTasks = [
+      running,
+      {
+        ...running,
+        id: 'shell-completed',
+        status: 'completed',
+      },
+    ];
+
+    renderApp();
+    await flush();
+
+    expect([
+      ...(testState.latestMessageListProps?.terminalBackgroundShellTaskIds ??
+        []),
+    ]).toEqual(['shell-completed']);
   });
 
   it('controls the built-in chat header actions through header items', () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -272,7 +272,10 @@ import {
 import { isDefinitelyRejectedPromptAdmission } from './utils/promptAdmission';
 import { base64ToBlob } from './utils/base64';
 import type { ACPToolCall, Message, PermissionRequest } from './adapters/types';
-import { isBackgroundSubAgentToolCall } from './adapters/toolClassification';
+import {
+  backgroundShellTaskId,
+  isBackgroundSubAgentToolCall,
+} from './adapters/toolClassification';
 import {
   computeTodoDetails,
   computeTodoTimeline,
@@ -1313,6 +1316,7 @@ function parseRenameArgument(
 function isBackgroundTaskToolCall(tool: ACPToolCall): boolean {
   const name = tool.toolName.toLowerCase();
   if (name === 'monitor') return true;
+  if (backgroundShellTaskId(tool) !== undefined) return true;
   if (tool.args?.is_background !== true) return false;
   return (
     name === 'shell' ||
@@ -4013,6 +4017,24 @@ export function App({
     taskActivityKey,
     connection.status === 'connected',
     backgroundTasksRefreshTrigger,
+  );
+  const terminalBackgroundShellTaskIdsKey = useMemo(
+    () =>
+      sessionTasks
+        .filter((task) => task.kind === 'shell' && task.status !== 'running')
+        .map((task) => task.id)
+        .join(','),
+    [sessionTasks],
+  );
+  // Preserve Set identity when polling returns an equivalent task snapshot.
+  const terminalBackgroundShellTaskIds = useMemo(
+    () =>
+      new Set(
+        terminalBackgroundShellTaskIdsKey
+          ? terminalBackgroundShellTaskIdsKey.split(',')
+          : [],
+      ),
+    [terminalBackgroundShellTaskIdsKey],
   );
   const environmentAgentTasks = useMemo(
     () => getEnvironmentAgentTasks(messages, sessionTasks),
@@ -12378,6 +12400,9 @@ export function App({
                               <MessageList
                                 ref={messageListRef}
                                 messages={displayMessages}
+                                terminalBackgroundShellTaskIds={
+                                  terminalBackgroundShellTaskIds
+                                }
                                 pendingApproval={pendingToolApproval}
                                 onShowContextDetail={handleShowContextDetail}
                                 loadingTranscript={connection.loadingTranscript}

--- a/packages/web-shell/client/adapters/toolClassification.test.ts
+++ b/packages/web-shell/client/adapters/toolClassification.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ACPToolCall } from './types';
 import {
+  backgroundShellTaskId,
   isActiveToolStatus,
   isBackgroundSubAgentToolCall,
 } from './toolClassification';
@@ -93,5 +94,55 @@ describe('isBackgroundSubAgentToolCall', () => {
         rawOutput: { type: 'task_execution', status: 'background' },
       }),
     ).toBe(true);
+  });
+});
+
+describe('backgroundShellTaskId', () => {
+  it.each([
+    ['Background shell bg_1234abcd started.', 'bg_1234abcd'],
+    ['background shell bg_1234abcd started.', 'bg_1234abcd'],
+    ['Promoted to background: bg_abcd-1234', 'bg_abcd-1234'],
+  ])('extracts the task id from %s', (rawOutput, taskId) => {
+    expect(
+      backgroundShellTaskId({
+        callId: 'shell-1',
+        toolName: 'shell',
+        status: 'completed',
+        rawOutput,
+      }),
+    ).toBe(taskId);
+  });
+
+  it('ignores failed shell calls', () => {
+    expect(
+      backgroundShellTaskId({
+        callId: 'shell-1',
+        toolName: 'shell',
+        status: 'failed',
+        rawOutput: 'Background shell bg_1234abcd started.',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('ignores non-shell tool names', () => {
+    expect(
+      backgroundShellTaskId({
+        callId: 'read-1',
+        toolName: 'Read',
+        status: 'completed',
+        rawOutput: 'Background shell bg_1234abcd started.',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('ignores non-string rawOutput', () => {
+    expect(
+      backgroundShellTaskId({
+        callId: 'shell-1',
+        toolName: 'shell',
+        status: 'completed',
+        rawOutput: { taskId: 'bg_1234abcd' },
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/web-shell/client/adapters/toolClassification.ts
+++ b/packages/web-shell/client/adapters/toolClassification.ts
@@ -68,3 +68,24 @@ export function isBackgroundSubAgentToolCall(tool: ACPToolCall): boolean {
     defaultsToBackground
   );
 }
+
+const BACKGROUND_SHELL_NAMES = new Set([
+  'shell',
+  'bash',
+  'run_shell_command',
+  'exec',
+]);
+const BACKGROUND_SHELL_ID_PATTERN =
+  /^(?:Background shell|Promoted to background:)\s+(bg_[\w-]+)/i;
+
+export function backgroundShellTaskId(tool: ACPToolCall): string | undefined {
+  if (
+    tool.status === 'failed' ||
+    !BACKGROUND_SHELL_NAMES.has(tool.toolName.toLowerCase())
+  ) {
+    return undefined;
+  }
+  return typeof tool.rawOutput === 'string'
+    ? BACKGROUND_SHELL_ID_PATTERN.exec(tool.rawOutput)?.[1]
+    : undefined;
+}

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -87,6 +87,36 @@ function makeBackgroundNotification(id: string, toolUseId?: string): Message {
   };
 }
 
+function makeBackgroundShellToolGroup(
+  id: string,
+  taskId: string,
+): Extract<Message, { role: 'tool_group' }> {
+  return {
+    id,
+    role: 'tool_group',
+    tools: [
+      {
+        callId: `call-${id}`,
+        toolName: 'shell',
+        status: 'completed',
+        args: { command: 'npm test', is_background: true },
+        rawOutput: `Background shell ${taskId} started.`,
+      },
+    ],
+  };
+}
+
+function makeBackgroundShellNotification(id: string, taskId: string): Message {
+  return {
+    id,
+    role: 'system',
+    content: 'Background shell completed.',
+    variant: 'info',
+    source: 'background_notification',
+    data: { kind: 'shell', taskId, status: 'completed' },
+  };
+}
+
 function makePlanMessage(id: string): Message {
   return { id, role: 'plan', todos: [] };
 }
@@ -1101,6 +1131,7 @@ function collapseItems(
     pendingApprovalCallId: string | null;
     backgroundSummaryGraceActive: boolean;
     waitForUnmatchedAgentCompletions: boolean;
+    terminalBackgroundShellTaskIds: ReadonlySet<string>;
     automaticallyExpandedAgentKeys: ReadonlySet<string>;
     enabled: boolean;
   }> = {},
@@ -1112,6 +1143,7 @@ function collapseItems(
     backgroundSummaryGraceActive: opts.backgroundSummaryGraceActive ?? true,
     waitForUnmatchedAgentCompletions:
       opts.waitForUnmatchedAgentCompletions ?? true,
+    terminalBackgroundShellTaskIds: opts.terminalBackgroundShellTaskIds,
     automaticallyExpandedAgentKeys: opts.automaticallyExpandedAgentKeys,
     enabled: opts.enabled ?? true,
   });
@@ -1897,6 +1929,107 @@ describe('applyTurnCollapse', () => {
       'ans2',
     ]);
     expect(collapseOf(out, 'u2')?.collapsed).toBe(true);
+  });
+
+  it('keeps a completed turn open while its background shell is running', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeBackgroundShellToolGroup('shell', 'bg_1234abcd'),
+      makeAssistantMessage('launched'),
+    ]);
+
+    const turn = collapseOf(collapseItems(items), 'u1');
+    expect(turn?.collapsed).toBe(false);
+    expect(turn?.liveStartedAt).toBeUndefined();
+  });
+
+  it('uses a terminal task snapshot when the shell notification is missing', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeBackgroundShellToolGroup('shell', 'bg_1234abcd'),
+      makeAssistantMessage('launched'),
+    ]);
+
+    const out = collapseItems(items, {
+      terminalBackgroundShellTaskIds: new Set(['bg_1234abcd']),
+    });
+
+    expect(collapseOf(out, 'u1')?.collapsed).toBe(true);
+  });
+
+  it('releases the launch turn when its background shell notification arrives', () => {
+    const running = [
+      makeUserMessage('u1'),
+      makeBackgroundShellToolGroup('shell', 'bg_1234abcd'),
+      makeAssistantMessage('launched'),
+    ];
+    const notified = [
+      ...running,
+      makeBackgroundShellNotification('shell-done', 'bg_1234abcd'),
+    ];
+    const summarized = [...notified, makeAssistantMessage('summary')];
+
+    expect(
+      collapseOf(collapseItems(groupParallelAgents(running)), 'u1')?.collapsed,
+    ).toBe(false);
+    expect(
+      collapseOf(collapseItems(groupParallelAgents(notified)), 'u1')?.collapsed,
+    ).toBe(false);
+    expect(
+      collapseOf(collapseItems(groupParallelAgents(summarized)), 'u1')
+        ?.collapsed,
+    ).toBe(true);
+  });
+
+  it('matches a shell completion back to its original turn', () => {
+    const running = [
+      makeUserMessage('u1'),
+      makeBackgroundShellToolGroup('shell', 'bg_1234abcd'),
+      makeAssistantMessage('launched'),
+      makeUserMessage('u2'),
+      makeMultiToolGroup('other'),
+      makeAssistantMessage('other-answer'),
+    ];
+    const completed = [
+      ...running,
+      makeBackgroundShellNotification('shell-done', 'bg_1234abcd'),
+      makeAssistantMessage('summary'),
+    ];
+
+    const before = collapseItems(groupParallelAgents(running));
+    expect(collapseOf(before, 'u1')?.collapsed).toBe(false);
+    expect(collapseOf(before, 'u2')?.collapsed).toBe(true);
+
+    const after = collapseItems(groupParallelAgents(completed));
+    expect(collapseOf(after, 'u1')?.collapsed).toBe(true);
+    expect(collapseOf(after, 'u2')?.collapsed).toBe(true);
+  });
+
+  it('ignores malformed background shell notifications', () => {
+    const running = [
+      makeUserMessage('u1'),
+      makeBackgroundShellToolGroup('shell', 'bg_1234abcd'),
+      makeAssistantMessage('launched'),
+    ];
+    const malformed = [
+      {
+        ...makeBackgroundShellNotification('bad-data', 'bg_1234abcd'),
+        data: 'oops',
+      },
+      {
+        ...makeBackgroundShellNotification('bad-kind', 'bg_1234abcd'),
+        data: { kind: 'agent', taskId: 'bg_1234abcd' },
+      },
+      {
+        ...makeBackgroundShellNotification('bad-task-id', 'bg_1234abcd'),
+        data: { kind: 'shell', taskId: 42 },
+      },
+    ];
+
+    for (const notification of malformed) {
+      const items = groupParallelAgents([...running, notification]);
+      expect(collapseOf(collapseItems(items), 'u1')?.collapsed).toBe(false);
+    }
   });
 
   it('still allows manually collapsing a turn with no final answer', () => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -27,6 +27,7 @@ import type {
 } from '../adapters/types';
 import type { PermissionRequest } from '../adapters/types';
 import {
+  backgroundShellTaskId,
   isBackgroundSubAgentToolCall,
   isSubAgentToolCall,
 } from '../adapters/toolClassification';
@@ -73,6 +74,7 @@ const UNMATCHED_AGENT_COMPLETION_GRACE_MS = 5_000;
 
 interface MessageListProps {
   messages: Message[];
+  terminalBackgroundShellTaskIds?: ReadonlySet<string>;
   pendingApproval: PermissionRequest | null;
   /** Run /context detail, exactly like typing it (context-usage panels). */
   onShowContextDetail?: () => void;
@@ -621,6 +623,7 @@ export interface ApplyTurnCollapseOptions {
    * so a lost notification cannot pin the turn expanded forever.
    */
   waitForUnmatchedAgentCompletions?: boolean;
+  terminalBackgroundShellTaskIds?: ReadonlySet<string>;
   automaticallyExpandedAgentKeys?: ReadonlySet<string>;
   /**
    * Tool-call id of a pending approval, if any. The turn containing it is
@@ -1482,6 +1485,36 @@ function turnHasActiveAgent(
   );
 }
 
+function completedBackgroundShellTaskIds(
+  items: readonly DisplayItem[],
+  terminalTaskIds?: ReadonlySet<string>,
+) {
+  const taskIds = new Set(terminalTaskIds);
+  for (const item of items) {
+    if (item.type !== 'message' || item.message.role !== 'system') continue;
+    if (item.message.source !== 'background_notification') continue;
+    const data = item.message.data;
+    if (!data || typeof data !== 'object' || Array.isArray(data)) continue;
+    if (!('kind' in data) || data.kind !== 'shell') continue;
+    // Shell background notifications are terminal-only.
+    const taskId = 'taskId' in data ? data.taskId : undefined;
+    if (typeof taskId === 'string') taskIds.add(taskId);
+  }
+  return taskIds;
+}
+
+function turnHasPendingBackgroundShell(
+  items: readonly DisplayItem[],
+  start: number,
+  end: number,
+  completedTaskIds: ReadonlySet<string>,
+): boolean {
+  return someTurnToolCall(items, start, end, (tool) => {
+    const taskId = backgroundShellTaskId(tool);
+    return taskId !== undefined && !completedTaskIds.has(taskId);
+  });
+}
+
 function turnHasActiveBackgroundAgent(
   items: readonly DisplayItem[],
   start: number,
@@ -1709,6 +1742,7 @@ export function applyTurnCollapse(
     activeTurnStartedAt,
     backgroundSummaryGraceActive = true,
     waitForUnmatchedAgentCompletions = true,
+    terminalBackgroundShellTaskIds,
     automaticallyExpandedAgentKeys,
     pendingApprovalCallId,
     includeSubagentToolUsageInMetrics = true,
@@ -1726,6 +1760,11 @@ export function applyTurnCollapse(
   }
   if (userIdxs.length === 0) return items;
 
+  const completedShellTaskIds = completedBackgroundShellTaskIds(
+    items,
+    terminalBackgroundShellTaskIds,
+  );
+
   const result: DisplayItem[] = [];
   // Anything before the first prompt (e.g. a session-restore banner) is not
   // part of any turn and passes through verbatim.
@@ -1740,6 +1779,12 @@ export function applyTurnCollapse(
     const isLastTurn = k === userIdxs.length - 1;
     const isActiveTurn = isLastTurn && isResponding;
     const hasActiveAgent = turnHasActiveAgent(items, start, end);
+    const hasPendingBackgroundShell = turnHasPendingBackgroundShell(
+      items,
+      start,
+      end,
+      completedShellTaskIds,
+    );
     const hasAutomaticallyExpandedAgent = turnHasAutomaticallyExpandedAgent(
       items,
       start,
@@ -1850,14 +1895,15 @@ export function applyTurnCollapse(
     }
 
     // A turn with foldable steps gets a chevron and defaults to expanded while
-    // streaming, while a subagent is still active, or when the latest turn is
-    // incomplete; otherwise it collapses once a newer turn starts. A
+    // streaming, while background work is still active, or when the latest
+    // turn is incomplete; otherwise it collapses once a newer turn starts. A
     // step-less turn (e.g. a plain "hi" reply) has nothing to fold, so it stays
     // expanded and shows a chevron-less metrics line. An explicit user toggle
     // always wins.
     const shouldStayOpen =
       isActiveTurn ||
       hasActiveAgent ||
+      hasPendingBackgroundShell ||
       hasAutomaticallyExpandedAgent ||
       awaitsBackgroundSummary ||
       ((hasTurnError || answerIdx < 0) && isLastTurn);
@@ -2626,6 +2672,7 @@ export const MessageList = memo(
   forwardRef<MessageListHandle, MessageListProps>(function MessageList(
     {
       messages,
+      terminalBackgroundShellTaskIds,
       pendingApproval,
       onShowContextDetail,
       onImagePreview,
@@ -3244,6 +3291,7 @@ export const MessageList = memo(
         collapseOverrides,
         isResponding,
         activeTurnStartedAt,
+        terminalBackgroundShellTaskIds,
         backgroundSummaryGraceActive,
         latestTurnHasActiveBackgroundAgent,
         unmatchedCompletionGraceExpired,
@@ -3299,6 +3347,7 @@ export const MessageList = memo(
         overrides: collapseOverrides,
         isResponding,
         activeTurnStartedAt,
+        terminalBackgroundShellTaskIds,
         backgroundSummaryGraceActive,
         waitForUnmatchedAgentCompletions:
           latestTurnHasActiveBackgroundAgent ||
@@ -3369,6 +3418,7 @@ export const MessageList = memo(
       collapseOverrides,
       isResponding,
       activeTurnStartedAt,
+      terminalBackgroundShellTaskIds,
       backgroundSummaryGraceActive,
       latestTurnHasActiveBackgroundAgent,
       unmatchedCompletionGraceExpired,


### PR DESCRIPTION
## What this PR does

Web Shell keeps a conversation turn expanded while the background shell it launched is still running, and collapses it once that shell completes. This covers both shells started directly in the background (`is_background: true`) and foreground commands promoted to the background, and matches the existing background-subagent handling: only the active turn shows a live timer, and older turns with pending background work stay open without one.

## Why it's needed

A turn that launches a long-running background shell used to collapse as soon as a newer turn started, hiding the shell's progress and the launch context. With this change the launch turn stays visible until the shell finishes, so the user can follow the background task without losing its place in the conversation. Completion is detected from the shell completion notification or, when that notification is lost, from a terminal snapshot of shell tasks, so a turn can never be pinned open forever.

## Reviewer Test Plan

### How to verify

1. Run a turn that launches a background shell (e.g. `npm test` with `is_background: true`), then start a second turn. The first turn must stay expanded with the background shell still running.
2. When the background shell completes, the launch turn collapses (immediately for non-final turns; after the completion narration for the final turn, consistent with background subagents).
3. Unit coverage: `toolClassification.test.ts` pins task-id extraction (both launch texts, case-insensitive), failed-call and non-shell rejection; `MessageList.test.ts` pins stay-open, snapshot fallback, release-on-notification and malformed-notification guards; `App.test.tsx` pins the sessionTasks → MessageList wiring.

### Evidence (Before & After)

N/A — behavior verified by 651 unit tests in `packages/web-shell` (MessageList, App, toolClassification); no screenshots captured.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run dev` / unit tests only (`npx vitest run components/MessageList.test.ts App.test.tsx adapters/toolClassification.test.ts`). No E2E run performed.

## Risk & Scope

- Main risk or tradeoff: a lost completion notification would previously have been the only way to release a turn; the terminal snapshot fallback closes that gap. The `liveStartedAt` behavior for non-active turns is unchanged from before this PR.
- Not validated / out of scope: Windows/Linux E2E; visual regression of the collapse animation.
- Breaking changes / migration notes: none. New `terminalBackgroundShellTaskIds` prop on `MessageList` is optional and defaults to `undefined`, so existing consumers are unaffected.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Web Shell 会在某个 turn 启动的后台 shell 仍在运行时保持该 turn 展开，直到该 shell 完成后再折叠。覆盖直接以 `is_background: true` 启动的 shell 和前台命令提升为后台（promoted）两种情况，并与既有后台 subagent 行为保持一致：只有活动 turn 显示实时计时器，旧的、有待处理后台工作的 turn 保持展开但不显示计时器。

## 为什么需要

启动长耗时后台 shell 的 turn 过去会在新 turn 开始后立即折叠，隐藏了 shell 的进度和启动上下文。本改动让启动 turn 在 shell 结束前保持可见，用户能跟随后台任务进度而不丢失对话中的位置。完成状态来自 shell 完成通知，通知丢失时则回退到 shell 任务的终态快照，因此 turn 不会被永久钉在展开状态。

## Reviewer 测试计划

### 如何验证

1. 运行一个启动后台 shell（如 `is_background: true` 的 `npm test`）的 turn，再开始第二个 turn——第一个 turn 在后台 shell 运行期间必须保持展开。
2. 后台 shell 完成时启动 turn 折叠（非最后 turn 立即折叠；最后 turn 在完成叙述后折叠，与后台 subagent 一致）。
3. 单测覆盖：`toolClassification.test.ts` 钉住任务 id 提取（两种启动文案、大小写不敏感）、失败与非 shell 调用拒绝；`MessageList.test.ts` 钉住保持展开、快照兜底、通知释放与畸形通知守卫；`App.test.tsx` 钉住 sessionTasks → MessageList 的接线。

### 前后对比证据

N/A——行为由 `packages/web-shell` 的 651 个单元测试验证（MessageList、App、toolClassification）；未截图。

### 测试环境

macOS ✅（仅单元测试）；Windows/Linux 未本地测试（CI 覆盖）。

## 风险与范围

- 主要风险/权衡：此前丢失完成通知会让 turn 无法释放；终态快照兜底补上了这个缺口。非活动 turn 的 `liveStartedAt` 行为与 PR 之前完全一致。
- 未验证/超范围：Windows/Linux E2E；折叠动画的视觉回归。
- 破坏性变更：无。`MessageList` 新增的 `terminalBackgroundShellTaskIds` prop 可选、默认 `undefined`，现有接入方不受影响。

## 关联 Issue

N/A

</details>
