### PR TITLE
feat(web-shell): expose agent task changes

### DIFF
--- a/docs/design/web-shell/web-shell-agent-tasks-change.md
+++ b/docs/design/web-shell/web-shell-agent-tasks-change.md
@@ -1,0 +1,18 @@
+# Web Shell agent-task callback
+
+## Goal
+
+Let an embedding host react when the active session gains or loses subagents
+without polling daemon task APIs or reproducing Web Shell's transcript merge.
+
+## Design
+
+Add an optional `onAgentTasksChange(tasks)` prop to `WebShell`. The callback
+receives the same merged agent-task snapshot used by Session Overview: agent
+tool calls retained in the transcript are combined with current `/tasks`
+records, preserving the existing correlation and deduplication behavior.
+
+The callback is independent of the built-in header and overview-panel
+configuration. It reports an empty list when no agent tasks are available, so
+hosts can derive visibility with `tasks.length > 0` and clear stale state when
+the session changes. It adds no task requests and does not block rendering.

--- a/docs/design/web-shell/web-shell-agent-tasks-change.md
+++ b/docs/design/web-shell/web-shell-agent-tasks-change.md
@@ -17,5 +17,7 @@ configuration. It reports an empty list when no agent tasks are available, so
 hosts can derive visibility with `tasks.length > 0` and clear stale state when
 the session changes. The initial snapshot is delivered after mount; subsequent
 snapshots with identical task content are suppressed even when streaming or
-polling replaces the source arrays. It adds no task requests and does not block
-rendering.
+polling replaces the source arrays. Poll-only changes to runtime, stats, and
+recent activity telemetry are also suppressed; changes to the task roster,
+status, or stable metadata still produce a new snapshot. It adds no task
+requests and does not block rendering.

--- a/docs/design/web-shell/web-shell-agent-tasks-change.md
+++ b/docs/design/web-shell/web-shell-agent-tasks-change.md
@@ -15,4 +15,7 @@ records, preserving the existing correlation and deduplication behavior.
 The callback is independent of the built-in header and overview-panel
 configuration. It reports an empty list when no agent tasks are available, so
 hosts can derive visibility with `tasks.length > 0` and clear stale state when
-the session changes. It adds no task requests and does not block rendering.
+the session changes. The initial snapshot is delivered after mount; subsequent
+snapshots with identical task content are suppressed even when streaming or
+polling replaces the source arrays. It adds no task requests and does not block
+rendering.

--- a/docs/design/web-shell/web-shell-agent-tasks-change.md
+++ b/docs/design/web-shell/web-shell-agent-tasks-change.md
@@ -17,7 +17,7 @@ configuration. It reports an empty list when no agent tasks are available, so
 hosts can derive visibility with `tasks.length > 0` and clear stale state when
 the session changes. The initial snapshot is delivered after mount; subsequent
 snapshots with identical task content are suppressed even when streaming or
-polling replaces the source arrays. Poll-only changes to runtime, stats, and
-recent activity telemetry are also suppressed; changes to the task roster,
-status, or stable metadata still produce a new snapshot. It adds no task
-requests and does not block rendering.
+polling replaces the source arrays. Immutable prompt text and poll-only changes
+to runtime, stats, and recent activity telemetry are omitted from the change
+fingerprint; changes to the task roster, status, or stable metadata still
+produce a new snapshot. It adds no task requests and does not block rendering.

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -10,6 +10,7 @@ import {
   type DaemonSessionMonitorTaskStatus,
   type DaemonSessionShellTaskStatus,
   type DaemonSessionStatsStatus,
+  type DaemonSessionTaskStatus,
   type DaemonSettingDescriptor,
   type DaemonWorkspaceGitStatus,
   type GoalSnapshotV2,
@@ -415,7 +416,7 @@ const {
         | ((error: unknown, fallback: string) => void)
         | null,
       latestBackgroundTasksRefreshTrigger: null as number | null,
-      backgroundTasks: [] as DaemonSessionMonitorTaskStatus[],
+      backgroundTasks: [] as DaemonSessionTaskStatus[],
       latestMonitorDetailsOnOpen: null as
         | ((tool: {
             callId: string;
@@ -4161,6 +4162,114 @@ describe('artifact panel fullscreen', () => {
 });
 
 describe('environment agent tasks', () => {
+  it('reports transcript agent tasks without enabling the overview panel', async () => {
+    testState.messages = [
+      {
+        id: 'tools',
+        role: 'tool_group',
+        tools: [
+          {
+            callId: 'agent-call',
+            toolName: 'agent',
+            title: 'Agent: Explore code',
+            status: 'completed',
+            args: {
+              description: 'Explore code',
+              run_in_background: false,
+            },
+            rawOutput: {
+              type: 'task_execution',
+              status: 'completed',
+            },
+          },
+        ],
+      },
+    ];
+    const onAgentTasksChange = vi.fn();
+
+    renderApp({
+      header: { items: [] },
+      environmentPanel: { items: [] },
+      onAgentTasksChange,
+    });
+    await flush();
+
+    expect(onAgentTasksChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        id: 'agent-call',
+        label: 'Explore code',
+        status: 'completed',
+        isBackgrounded: false,
+      }),
+    ]);
+  });
+
+  it('reports merged live tasks without duplication and clears for a new session', async () => {
+    const onAgentTasksChange = vi.fn();
+    const props = {
+      header: { items: [] as const },
+      environmentPanel: { items: [] as const },
+      onAgentTasksChange,
+    };
+    const { rerender } = renderApp(props);
+    await flush();
+    expect(onAgentTasksChange).toHaveBeenLastCalledWith([]);
+
+    testState.messages = [
+      {
+        id: 'tools',
+        role: 'tool_group',
+        tools: [
+          {
+            callId: 'agent-call',
+            toolName: 'agent',
+            title: 'Agent: Review code',
+            status: 'in_progress',
+            args: {
+              description: 'Review code',
+              subagent_type: 'reviewer',
+              run_in_background: true,
+            },
+          },
+        ],
+      },
+    ];
+    testState.backgroundTasks = [
+      {
+        kind: 'agent',
+        id: 'agent-task',
+        label: 'reviewer: Review code',
+        description: 'Review code',
+        subagentType: 'reviewer',
+        status: 'running',
+        startTime: 1,
+        runtimeMs: 1,
+        isBackgrounded: true,
+        toolUseId: 'agent-call',
+      },
+    ];
+    rerender(props);
+    await flush();
+
+    const mergedTasks = onAgentTasksChange.mock.lastCall?.[0];
+    expect(mergedTasks).toHaveLength(1);
+    expect(mergedTasks?.[0]).toMatchObject({
+      id: 'agent-task',
+      label: 'Review code',
+      status: 'running',
+      toolUseId: 'agent-call',
+    });
+
+    mockConnection.sessionId = 'session-2';
+    testState.ownerVersion += 1;
+    testState.messages = [];
+    testState.backgroundTasks = [];
+    rerender(props);
+    await flush();
+
+    expect(onAgentTasksChange).toHaveBeenLastCalledWith([]);
+  });
+
   it('keeps a completed foreground agent from the session transcript', () => {
     const messages = [
       {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -4260,6 +4260,13 @@ describe('environment agent tasks', () => {
       toolUseId: 'agent-call',
     });
 
+    const mergeCallCount = onAgentTasksChange.mock.calls.length;
+    testState.messages = [...testState.messages];
+    testState.backgroundTasks = [...testState.backgroundTasks];
+    rerender(props);
+    await flush();
+    expect(onAgentTasksChange).toHaveBeenCalledTimes(mergeCallCount);
+
     mockConnection.sessionId = 'session-2';
     testState.ownerVersion += 1;
     testState.messages = [];

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -4262,7 +4262,18 @@ describe('environment agent tasks', () => {
 
     const mergeCallCount = onAgentTasksChange.mock.calls.length;
     testState.messages = [...testState.messages];
-    testState.backgroundTasks = [...testState.backgroundTasks];
+    testState.backgroundTasks = testState.backgroundTasks.map((task) => ({
+      ...task,
+      runtimeMs: 3_001,
+      ...(task.kind === 'agent'
+        ? {
+            stats: { totalTokens: 42, toolUses: 3, durationMs: 3_001 },
+            recentActivities: [
+              { name: 'read', description: 'Read App.tsx', at: 3_000 },
+            ],
+          }
+        : {}),
+    }));
     rerender(props);
     await flush();
     expect(onAgentTasksChange).toHaveBeenCalledTimes(mergeCallCount);
@@ -4275,6 +4286,36 @@ describe('environment agent tasks', () => {
     await flush();
 
     expect(onAgentTasksChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('reports the current snapshot after the callback is reattached', async () => {
+    testState.backgroundTasks = [
+      {
+        kind: 'agent',
+        id: 'agent-task',
+        label: 'Review code',
+        description: 'Review code',
+        status: 'running',
+        startTime: 1,
+        runtimeMs: 1,
+        isBackgrounded: true,
+      },
+    ];
+    const onAgentTasksChange = vi.fn();
+    const props = { onAgentTasksChange };
+    const { rerender } = renderApp(props);
+    await flush();
+    expect(onAgentTasksChange).toHaveBeenCalledTimes(1);
+
+    rerender({});
+    await flush();
+    rerender(props);
+    await flush();
+
+    expect(onAgentTasksChange).toHaveBeenCalledTimes(2);
+    expect(onAgentTasksChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ id: 'agent-task', status: 'running' }),
+    ]);
   });
 
   it('keeps a completed foreground agent from the session transcript', () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -883,6 +883,8 @@ export interface WebShellProps {
   onConnectionChange?: (status: string) => void;
   /** Called when prompt status changes (idle/waiting/responding). */
   onStreamingStateChange?: (state: DaemonStreamingState) => void;
+  /** Called whenever the active session's merged agent task list changes. */
+  onAgentTasksChange?: (tasks: readonly DaemonSessionAgentTaskStatus[]) => void;
   /**
    * Called whenever transcript blocks change. Receives the full blocks array
    * at most once per animation frame during active generation.
@@ -1827,6 +1829,7 @@ export function App({
   virtualScrollThreshold,
   markdown,
   loadingPhrases,
+  onAgentTasksChange,
   onTranscriptChange,
   onToast,
   composerRef,
@@ -4018,6 +4021,9 @@ export function App({
     () => getEnvironmentAgentTasks(messages, sessionTasks),
     [messages, sessionTasks],
   );
+  useEffect(() => {
+    onAgentTasksChange?.(environmentAgentTasks);
+  }, [environmentAgentTasks, onAgentTasksChange]);
   const backgroundTasks = useMemo(
     () => sessionTasks.filter((task) => task.kind !== 'agent'),
     [sessionTasks],

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -4031,13 +4031,16 @@ export function App({
       lastReportedAgentTasksRef.current = undefined;
       return;
     }
-    const snapshot = JSON.stringify(environmentAgentTasks, (key, value) =>
-      key === 'runtimeMs' ||
-      key === 'stats' ||
-      key === 'recentActivities' ||
-      key === 'prompt'
-        ? undefined
-        : value,
+    const snapshot = JSON.stringify(
+      environmentAgentTasks.map(
+        ({
+          runtimeMs: _runtimeMs,
+          stats: _stats,
+          recentActivities: _recentActivities,
+          prompt: _prompt,
+          ...stable
+        }) => stable,
+      ),
     );
     if (snapshot === lastReportedAgentTasksRef.current) return;
     lastReportedAgentTasksRef.current = snapshot;

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -4032,7 +4032,10 @@ export function App({
       return;
     }
     const snapshot = JSON.stringify(environmentAgentTasks, (key, value) =>
-      key === 'runtimeMs' || key === 'stats' || key === 'recentActivities'
+      key === 'runtimeMs' ||
+      key === 'stats' ||
+      key === 'recentActivities' ||
+      key === 'prompt'
         ? undefined
         : value,
     );

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -883,7 +883,10 @@ export interface WebShellProps {
   onConnectionChange?: (status: string) => void;
   /** Called when prompt status changes (idle/waiting/responding). */
   onStreamingStateChange?: (state: DaemonStreamingState) => void;
-  /** Called whenever the active session's merged agent task list changes. */
+  /**
+   * Called with the initial merged agent task snapshot and whenever its
+   * contents change.
+   */
   onAgentTasksChange?: (tasks: readonly DaemonSessionAgentTaskStatus[]) => void;
   /**
    * Called whenever transcript blocks change. Receives the full blocks array
@@ -4021,8 +4024,16 @@ export function App({
     () => getEnvironmentAgentTasks(messages, sessionTasks),
     [messages, sessionTasks],
   );
+  const lastReportedAgentTasksRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    onAgentTasksChange?.(environmentAgentTasks);
+    if (!onAgentTasksChange) {
+      lastReportedAgentTasksRef.current = undefined;
+      return;
+    }
+    const snapshot = JSON.stringify(environmentAgentTasks);
+    if (snapshot === lastReportedAgentTasksRef.current) return;
+    lastReportedAgentTasksRef.current = snapshot;
+    onAgentTasksChange(environmentAgentTasks);
   }, [environmentAgentTasks, onAgentTasksChange]);
   const backgroundTasks = useMemo(
     () => sessionTasks.filter((task) => task.kind !== 'agent'),

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -884,8 +884,9 @@ export interface WebShellProps {
   /** Called when prompt status changes (idle/waiting/responding). */
   onStreamingStateChange?: (state: DaemonStreamingState) => void;
   /**
-   * Called with the initial merged agent task snapshot and whenever its
-   * contents change.
+   * Called with the initial merged agent task snapshot and when its roster,
+   * status, or stable metadata changes. Poll-only runtime, stats, and activity
+   * updates are suppressed.
    */
   onAgentTasksChange?: (tasks: readonly DaemonSessionAgentTaskStatus[]) => void;
   /**
@@ -4030,7 +4031,11 @@ export function App({
       lastReportedAgentTasksRef.current = undefined;
       return;
     }
-    const snapshot = JSON.stringify(environmentAgentTasks);
+    const snapshot = JSON.stringify(environmentAgentTasks, (key, value) =>
+      key === 'runtimeMs' || key === 'stats' || key === 'recentActivities'
+        ? undefined
+        : value,
+    );
     if (snapshot === lastReportedAgentTasksRef.current) return;
     lastReportedAgentTasksRef.current = snapshot;
     onAgentTasksChange(environmentAgentTasks);


### PR DESCRIPTION
## What this PR does

Adds an optional WebShell callback that reports the active session's complete subagent task snapshot. The snapshot reuses the same transcript-plus-daemon merge shown by Session Overview, works even when the built-in header and overview panel are disabled, and reports an empty list when the active session has no subagents.

## Why it's needed

Embedding hosts need a supported way to decide whether to show their own Session Overview entry point. Without this callback, a host must poll the daemon task API and still cannot reproduce WebShell's historical transcript merge, which can make the host entry disagree with the built-in panel.

## Reviewer Test Plan

### How to verify

- Mount WebShell with the callback while disabling the built-in header and overview panel; a completed foreground subagent retained only in the transcript should still be reported.
- Provide a matching live daemon task for a transcript subagent; the callback should report one merged task with the live status rather than duplicate entries.
- Switch to a session without subagents; the callback should report an empty list so host state can be cleared.
- Confirm existing Session Overview rendering and task polling behavior remain unchanged.

### Evidence (Before & After)

N/A — this adds a host integration callback and does not change WebShell UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22 workspace. The complete WebShell App test file passed with 492 tests; the repository build, workspace typecheck, WebShell lint, formatting check, and diff check also passed.

## Risk & Scope

- Main risk or tradeoff: Hosts receive a full idempotent snapshot after render whenever the existing merged agent-task value changes.
- Not validated / out of scope: No consumer-side DAC UI change or visual E2E is included.
- Breaking changes / migration notes: None. The callback is optional and does not change daemon APIs, SDK schemas, polling, or existing UI defaults.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

新增一个可选的 WebShell 回调，用于上报当前会话完整的子 Agent 任务快照。该快照复用 Session Overview 已有的 transcript 与 daemon 合并结果，即使关闭内置 header 和概览面板也可工作；当前会话没有子 Agent 时会返回空数组。

## 为什么需要

嵌入 WebShell 的宿主需要一个受支持的方式判断是否展示自己的 Session Overview 入口。没有该回调时，宿主只能自行轮询 daemon 任务接口，而且仍无法复现 WebShell 对历史 transcript 的合并，因此宿主入口可能与内置面板不一致。

## Reviewer Test Plan

### 如何验证

- 在关闭内置 header 和概览面板时挂载带回调的 WebShell；仅保留在 transcript 中的已完成前台子 Agent 仍应被上报。
- 为 transcript 子 Agent 提供匹配的 daemon 实时任务；回调应只上报一条带实时状态的合并任务，不应产生重复项。
- 切换到没有子 Agent 的会话；回调应返回空数组，以便宿主清理状态。
- 确认现有 Session Overview 渲染和任务轮询行为保持不变。

### Before & After 证据

N/A——本次新增的是宿主集成回调，不改变 WebShell UI。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22 工作区。完整 WebShell App 测试文件的 492 个测试全部通过；全仓构建、workspace typecheck、WebShell lint、格式检查和 diff 检查也均通过。

## 风险与范围

- 主要风险或权衡：既有合并任务值变化时，宿主会在渲染后收到完整且可幂等处理的快照。
- 未验证或范围外：不包含 DAC 消费侧 UI 改动或视觉 E2E。
- 破坏性变更或迁移说明：无。该回调为可选属性，不改变 daemon API、SDK schema、轮询或现有 UI 默认行为。

## 关联 Issue

N/A

</details>
