### PR TITLE
fix(autofix): include pending runs in the busy-PR enumeration

### DIFF
--- a/.github/workflows/qwen-autofix.md
+++ b/.github/workflows/qwen-autofix.md
@@ -896,7 +896,14 @@ the per-PR group it should have skipped. Pending runs cost one
 extra jobs-view each and match nothing until their matrix
 materialises. Filtered this way the limit applies to LIVE runs
 only (at most a handful), and one jobs-view per live run stays
-cheap.
+cheap. The enumeration calls the runs API directly, not `gh run
+list --status`: gh validates --status against a client-side
+allow-list that only accepts 'pending' from 2.65.0 onward, while
+the self-hosted ecs-qwen pool (already used by the issue-autofix,
+build-cli, and review-address sibling jobs) lags the hosted
+images — an older gh exits 1 on the flag and FAIL-CLOSED below
+then silently empties every scan. The API's status filter is
+server-side on every gh version.
 
 FAIL-CLOSED: any enumeration failure (the run list, or one run's
 jobs view) empties THIS scan's candidate set. Measured 2026-08-16

--- a/.github/workflows/qwen-autofix.md
+++ b/.github/workflows/qwen-autofix.md
@@ -883,9 +883,20 @@ same PRs and the per-PR address groups accumulate duplicates that
 later replay stale watermarks. The status filter is SERVER-side: a
 client-side filter over the N newest runs loses a long-lived
 fanned-out run once cron traffic pushes it past the window, and
-its queued PRs silently stop looking busy. Filtered this way the
-limit applies to LIVE runs only (at most a handful), and one
-jobs-view per live run stays cheap.
+its queued PRs silently stop looking busy. The union covers THREE
+statuses — in_progress, queued, AND pending: GitHub reports a run
+'pending' while its remaining jobs wait on concurrency groups
+(neither 'queued' nor 'in_progress'), and the run-level status
+trails the job-level flip by minutes, so the two-status union
+loses legs that are already running. Measured 2026-08-21 (#9596):
+a run whose four legs had been running for several minutes still
+listed 'pending', the scan re-dispatched all four, and every
+duplicate burned one build-cli (~5 min) before queueing behind
+the per-PR group it should have skipped. Pending runs cost one
+extra jobs-view each and match nothing until their matrix
+materialises. Filtered this way the limit applies to LIVE runs
+only (at most a handful), and one jobs-view per live run stays
+cheap.
 
 FAIL-CLOSED: any enumeration failure (the run list, or one run's
 jobs view) empties THIS scan's candidate set. Measured 2026-08-16

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2544,7 +2544,7 @@ jobs:
           BUSY_ENUM_OK=1
           LIVE_RUNS=''
           BUSY_ENUM_ERR="$(mktemp)"
-          for LIVE_STATUS in in_progress queued; do
+          for LIVE_STATUS in in_progress queued pending; do
             if ! PART="$(gh run list --repo "${REPO}" --workflow qwen-autofix.yml \
               --status "${LIVE_STATUS}" --limit 50 --json databaseId \
               --jq '.[].databaseId' 2>> "${BUSY_ENUM_ERR}")"; then

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2548,8 +2548,9 @@ jobs:
             # Runs API, not `gh run list --status`: gh validates --status
             # against a client-side allow-list that rejects 'pending' before
             # 2.65.0; the API filter is server-side on every gh version.
+            # The REST envelope's field is `id`, NOT the gh-CLI `databaseId`.
             if ! PART="$(gh api "repos/${REPO}/actions/workflows/qwen-autofix.yml/runs?status=${LIVE_STATUS}&per_page=50" \
-              --jq '.workflow_runs[].databaseId' 2>> "${BUSY_ENUM_ERR}")"; then
+              --jq '.workflow_runs[].id' 2>> "${BUSY_ENUM_ERR}")"; then
               BUSY_ENUM_OK=0
               break
             fi

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -2545,9 +2545,11 @@ jobs:
           LIVE_RUNS=''
           BUSY_ENUM_ERR="$(mktemp)"
           for LIVE_STATUS in in_progress queued pending; do
-            if ! PART="$(gh run list --repo "${REPO}" --workflow qwen-autofix.yml \
-              --status "${LIVE_STATUS}" --limit 50 --json databaseId \
-              --jq '.[].databaseId' 2>> "${BUSY_ENUM_ERR}")"; then
+            # Runs API, not `gh run list --status`: gh validates --status
+            # against a client-side allow-list that rejects 'pending' before
+            # 2.65.0; the API filter is server-side on every gh version.
+            if ! PART="$(gh api "repos/${REPO}/actions/workflows/qwen-autofix.yml/runs?status=${LIVE_STATUS}&per_page=50" \
+              --jq '.workflow_runs[].databaseId' 2>> "${BUSY_ENUM_ERR}")"; then
               BUSY_ENUM_OK=0
               break
             fi

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -498,11 +498,14 @@ describe('qwen-autofix workflow', () => {
     // validates that flag against a client-side allow-list that rejects
     // 'pending' before 2.65.0, so a runner whose gh lags the hosted images
     // would exit 1 and silently fail-close EVERY scan; the API filter is
-    // server-side on every gh version.
+    // server-side on every gh version. The jq filter must read the REST
+    // envelope's `id` — the gh-CLI `databaseId` field does not exist in the
+    // API payload, and an empty read would silently un-busy every scan.
     expect(reviewScanJob).toContain(
       'gh api "repos/${REPO}/actions/workflows/qwen-autofix.yml/runs?status=${LIVE_STATUS}&per_page=50"',
     );
-    expect(reviewScanJob).toContain("--jq '.workflow_runs[].databaseId'");
+    expect(reviewScanJob).toContain("--jq '.workflow_runs[].id'");
+    expect(reviewScanJob).not.toContain('.workflow_runs[].databaseId');
     expect(reviewScanJob).not.toContain(
       'gh run list --repo "${REPO}" --workflow qwen-autofix.yml',
     );
@@ -4034,7 +4037,7 @@ describe('qwen-autofix workflow', () => {
     expect(listFailed.fleet).toContain('HTTP 502: bad gateway');
     // A jobs-view failure mid-enumeration fails closed the same way.
     const viewFailed = runEnum({
-      listAnswer: JSON.stringify({ workflow_runs: [{ databaseId: 101 }] }),
+      listAnswer: JSON.stringify({ workflow_runs: [{ id: 101 }] }),
       viewError: 'HTTP 500',
     });
     expect(viewFailed.candidates).toBe('');
@@ -4042,7 +4045,7 @@ describe('qwen-autofix workflow', () => {
     expect(viewFailed.fleet).toContain('HTTP 500');
     // A healthy enumeration accumulates the busy set and keeps candidates.
     const ok = runEnum({
-      listAnswer: JSON.stringify({ workflow_runs: [{ databaseId: 101 }] }),
+      listAnswer: JSON.stringify({ workflow_runs: [{ id: 101 }] }),
       viewAnswer: JSON.stringify({
         jobs: [
           { name: 'review-address (101, round 2)', status: 'in_progress' },

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -486,10 +486,14 @@ describe('qwen-autofix workflow', () => {
       'review-address already in flight or queued — skipping',
     );
     // The live-run listing filters status SERVER-side (in_progress + queued
-    // union): a client-side filter over the N newest runs loses a long-lived
-    // fanned-out run once cron traffic pushes it past the window, and its
-    // queued PRs silently stop looking busy.
-    expect(reviewScanJob).toContain('for LIVE_STATUS in in_progress queued');
+    // + pending union): a client-side filter over the N newest runs loses a
+    // long-lived fanned-out run once cron traffic pushes it past the window,
+    // and its queued PRs silently stop looking busy. 'pending' is part of the
+    // union because GitHub reports a run neither queued nor in_progress while
+    // its jobs wait on concurrency groups (#9596).
+    expect(reviewScanJob).toContain(
+      'for LIVE_STATUS in in_progress queued pending',
+    );
     expect(reviewScanJob).toContain('--status "${LIVE_STATUS}" --limit 50');
     expect(reviewScanJob).not.toContain('--limit 15');
     // The busy-set cannot see a sibling scan that has not yet emitted its

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -494,7 +494,18 @@ describe('qwen-autofix workflow', () => {
     expect(reviewScanJob).toContain(
       'for LIVE_STATUS in in_progress queued pending',
     );
-    expect(reviewScanJob).toContain('--status "${LIVE_STATUS}" --limit 50');
+    // The union calls the runs API directly, not `gh run list --status`: gh
+    // validates that flag against a client-side allow-list that rejects
+    // 'pending' before 2.65.0, so a runner whose gh lags the hosted images
+    // would exit 1 and silently fail-close EVERY scan; the API filter is
+    // server-side on every gh version.
+    expect(reviewScanJob).toContain(
+      'gh api "repos/${REPO}/actions/workflows/qwen-autofix.yml/runs?status=${LIVE_STATUS}&per_page=50"',
+    );
+    expect(reviewScanJob).toContain("--jq '.workflow_runs[].databaseId'");
+    expect(reviewScanJob).not.toContain(
+      'gh run list --repo "${REPO}" --workflow qwen-autofix.yml',
+    );
     expect(reviewScanJob).not.toContain('--limit 15');
     // The busy-set cannot see a sibling scan that has not yet emitted its
     // matrix, so review-address REVALIDATES the watermark against LIVE
@@ -3958,7 +3969,7 @@ describe('qwen-autofix workflow', () => {
             '  esac',
             'done',
             'set -- "${positional[@]}"',
-            'if [[ "$1" == "run" && "$2" == "list" ]]; then',
+            'if [[ "$1" == "api" ]]; then',
             '  if [[ -n "${ENUM_LIST_ERROR}" ]]; then printf \'%s\' "${ENUM_LIST_ERROR}" >&2; exit 1; fi',
             '  payload="${ENUM_LIST_ANSWER}"',
             'elif [[ "$1" == "run" && "$2" == "view" ]]; then',
@@ -4023,7 +4034,7 @@ describe('qwen-autofix workflow', () => {
     expect(listFailed.fleet).toContain('HTTP 502: bad gateway');
     // A jobs-view failure mid-enumeration fails closed the same way.
     const viewFailed = runEnum({
-      listAnswer: JSON.stringify([{ databaseId: 101 }]),
+      listAnswer: JSON.stringify({ workflow_runs: [{ databaseId: 101 }] }),
       viewError: 'HTTP 500',
     });
     expect(viewFailed.candidates).toBe('');
@@ -4031,7 +4042,7 @@ describe('qwen-autofix workflow', () => {
     expect(viewFailed.fleet).toContain('HTTP 500');
     // A healthy enumeration accumulates the busy set and keeps candidates.
     const ok = runEnum({
-      listAnswer: JSON.stringify([{ databaseId: 101 }]),
+      listAnswer: JSON.stringify({ workflow_runs: [{ databaseId: 101 }] }),
       viewAnswer: JSON.stringify({
         jobs: [
           { name: 'review-address (101, round 2)', status: 'in_progress' },


### PR DESCRIPTION
## What this PR does

The review scan skips PRs whose autofix address work is already running or queued by listing live workflow runs server-side, filtered by status. This PR adds `pending` to that status union, and moves the reasoning into the workflow's design record and the test that pins the union.

## Why it's needed

GitHub reports a run as `pending` while its remaining jobs wait on concurrency groups — neither `queued` nor `in_progress` — and the run-level status trails the job-level flip by minutes. The two-status union therefore lost address legs that were already running, so the scan re-dispatched them: each duplicate burned one build-cli (~5 min) and queued behind the per-PR head-write group it was supposed to skip, holding the PR's dispatch-pending commit status open in the meantime.

Measured live on 2026-08-21 while investigating #9596's stall: one scan re-dispatched four PRs whose address legs had been running for several minutes while their run still listed `pending` (verified against the runs API — the run-level status flipped to `in_progress` only minutes after its jobs did), and a duplicate leg queued behind #9596's still-running leg kept its dispatch-pending check pending for close to an hour.

## Reviewer Test Plan

### How to verify

- The change is one loop literal; the pinned test asserts it and the fail-closed path is untouched. Locally: `npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow workflow-size` — 268 pass. The 4 failures in `qwen-autofix-workflow` (bite check / verification-gate baseline A/B) reproduce identically on unmodified main on macOS bash 3.2 (`mapfile: command not found`, exit 127) and are unrelated to this change.
- Live behavior: `gh run list --repo QwenLM/qwen-code --workflow qwen-autofix.yml --status pending` returns runs whose address legs are waiting on concurrency groups today — those were invisible to the old union. After this lands, the next scan's enumeration includes them and logs `🚧 address in flight/queued for PR(s): ...` instead of re-dispatching.

### Evidence (Before & After)

Before (2026-08-21, observed): the 10:03 scan's busy enumeration reported only `🚧 address in flight/queued for PR(s): 9596 9370`, missed four legs that were already running under a run still listed `pending`, and re-dispatched all four (their duplicate legs then sat pending behind the per-PR groups).
After (expected): pending runs are part of the union, so legs waiting on concurrency — and legs whose run-level status has not caught up yet — are skipped as busy.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Script tests via vitest; live verification via the gh CLI against the repository's runs API. No CLI runtime involved.

## Risk & Scope

- Main risk or tradeoff: one extra run-list query per scan plus one jobs-view per pending run. Pending runs match nothing until their address matrix materialises, so busy detection only gains entries; the fail-closed rule and the dispatch-pending marker check are unchanged.
- Not validated / out of scope: an enumeration that succeeds but returns an empty page still fails open (fail-closed triggers on command errors only). Distinguishing a transient empty API page from "nothing live" is a separate hardening, as are the long-stuck queued dispatch runs visible in the run list.
- Breaking changes / migration notes: none.

## Linked Issues

Observed while investigating the stall on #9596 (reference only, no closing keyword).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

review scan 通过按状态在服务端列出存活的 workflow run,来跳过那些 autofix address 工作已在运行或排队的 PR。本 PR 把 `pending` 加入该状态并集,并把理由同步写入 workflow 的设计记录与 pin 该并集的测试。

## 为什么需要

当一个 run 的剩余 job 在等待 concurrency group 时,GitHub 把该 run 报告为 `pending` —— 既不是 `queued` 也不是 `in_progress` —— 而且 run 级状态会滞后 job 级翻转数分钟。因此两状态并集会漏掉已经在运行的 address leg,导致 scan 重复派发:每个重复派发白白消耗一次 build-cli(约 5 分钟),然后排在本应跳过的 per-PR head-write group 后面,期间该 PR 的 dispatch-pending commit status 一直挂着 pending。

2026-08-21 排查 #9596 堵车时实测:一次 scan 重复派发了 4 个 PR,它们的 address leg 已经跑了好几分钟,而其 run 仍显示 `pending`(已对照 runs API 验证 —— run 级状态比 job 级晚了好几分钟才翻转为 `in_progress`);另一个重复 leg 排在 #9596 仍在运行的 leg 后面,使其 dispatch-pending check 挂了将近一小时。

## 评审测试计划

### 如何验证

- 改动只有一行循环字面量;pin 测试已断言它,fail-closed 路径未动。本地:`npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow workflow-size` —— 268 通过。`qwen-autofix-workflow` 里 4 个失败(bite check / verification-gate baseline A/B)在未改动的 main 上于 macOS bash 3.2 同样复现(`mapfile: command not found`,exit 127),与本改动无关。
- 实际行为:`gh run list --repo QwenLM/qwen-code --workflow qwen-autofix.yml --status pending` 今天就能返回 address leg 正在等 concurrency group 的 run —— 旧并集看不到它们。合入后,下一次 scan 的枚举会包含它们,输出 `🚧 address in flight/queued for PR(s): ...` 而不是重复派发。

### 证据(前后对比)

改动前(2026-08-21 实测):10:03 的 scan 的 busy 枚举只报告 `🚧 address in flight/queued for PR(s): 9596 9370`,漏掉了 4 条已在一个仍显示 `pending` 的 run 下运行的 leg,并把这 4 个全部重复派发(其重复 leg 随后排在 per-PR group 后面 pending)。
改动后(预期):pending run 进入并集,正在等 concurrency group 的 leg —— 以及 run 级状态尚未追上的 leg —— 会被当作 busy 跳过。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境(可选)

vitest 跑脚本测试;通过 gh CLI 对仓库 runs API 做了实际验证。不涉及 CLI 运行时。

## 风险与范围

- 主要风险或权衡:每次 scan 多一次 run-list 查询,每个 pending run 多一次 jobs-view。pending run 在其 address matrix 落地前匹配不到任何内容,所以 busy 检测只会多不会少;fail-closed 规则与 dispatch-pending marker 检查均未变。
- 未验证 / 不在范围内:枚举成功但返回空页时仍然 fail-open(fail-closed 只对命令报错生效)。区分"API 瞬时返回空页"与"确实没有存活 run"是另一个加固项;run 列表里长期卡 queued 的 dispatch run 同理。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

排查 #9596 堵车时观测到本问题(仅引用,不带关闭关键字)。

</details>
