### PR TITLE
docs(autofix): correct the round-seed guide on leading whitespace

### DIFF
--- a/.github/workflows/qwen-autofix-round-seed.md
+++ b/.github/workflows/qwen-autofix-round-seed.md
@@ -118,7 +118,7 @@ The literal prefix must match `@qwen-code /takeover` byte-for-byte and the tail
 must be a bare 1–2 digit integer. The command has to be the very first thing in
 the comment: **no leading whitespace of any kind** — space, tab, or blank line.
 The router prefilters on the _raw_ comment body with `startsWith`, so a body
-that does not begin with the command never starts a job at all, and the trim
+with leading whitespace never starts a job at all, and the trim
 that runs inside that job never gets the chance
 ([af-004](./qwen-autofix.md#af-004)). Trailing whitespace is harmless. Anything
 else fails closed — no label, no seed, no partial effect, and, when the router

--- a/.github/workflows/qwen-autofix-round-seed.md
+++ b/.github/workflows/qwen-autofix-round-seed.md
@@ -115,11 +115,14 @@ cap is 100, so a seed of 4 leaves 96.
 ## Accepted and rejected forms
 
 The literal prefix must match `@qwen-code /takeover` byte-for-byte and the tail
-must be a bare 1–2 digit integer. Leading spaces and tabs on the first line, and
-all trailing whitespace, are trimmed — but a blank line before the command is
-not, so it must start the comment's first line. Nothing else is tolerated, and
-anything unrecognized fails closed to "not an exact command" — no label, no
-seed, no partial effect.
+must be a bare 1–2 digit integer. The command has to be the very first thing in
+the comment: **no leading whitespace of any kind** — space, tab, or blank line.
+The router prefilters on the _raw_ comment body with `startsWith`, so a body
+that does not begin with the command never starts a job at all, and the trim
+that runs inside that job never gets the chance
+([af-004](./qwen-autofix.md#af-004)). Trailing whitespace is harmless. Anything
+else fails closed — no label, no seed, no partial effect, and, when the router
+never started, not even a log line.
 
 | Body                                 | Result                                      |
 | ------------------------------------ | ------------------------------------------- |
@@ -132,7 +135,8 @@ seed, no partial effect.
 | `@qwen-code /takeover from 100`      | **nothing** — 3 digits rejected             |
 | `@qwen-code /takeover  from 4`       | **nothing** — double space                  |
 | `please @qwen-code /takeover from 4` | **nothing** — must start the comment        |
-| blank line, then the command         | **nothing** — must start the first line     |
+| `  @qwen-code /takeover from 4`      | **nothing** — leading spaces                |
+| blank line, then the command         | **nothing** — leading newline               |
 | `@qwen-code /takeover from 4 please` | **nothing** — must end the comment          |
 
 ## Reading the result


### PR DESCRIPTION
## What this PR does

Corrects one factual error in `qwen-autofix-round-seed.md`, added in #9622.

The guide told maintainers that leading spaces and tabs on a command comment are trimmed, and that only a blank line before the command breaks it. Neither half is right: **no leading whitespace of any kind survives.** A leading space, a leading tab, and a leading newline all fail identically.

The router prefilters on the *raw* comment body — `startsWith(github.event.comment.body, '@qwen-code /takeover')` — so a body that does not begin with the command never starts a job at all, and the `sed` trim inside `Decide phases` never gets to run. The design record already recorded this at [af-004](https://github.com/QwenLM/qwen-code/blob/main/.github/workflows/qwen-autofix.md#af-004) — "a body with LEADING whitespace dies here even though the decide branch would trim it" — and the guide contradicted it.

The paragraph is rewritten to say leading whitespace of any kind fails and to link af-004; the table's single leading-whitespace row is split into a leading-space row and a leading-newline row; and the failure description now notes that when the router never starts there is not even a log line to find, which matters when someone is trying to work out why nothing happened.

## Why it's needed

This is live guidance on `main` for a command that fails silently. A maintainer who indents the command — pasting it under a bullet, or after a quoted line — gets no label, no seed, no ack, and no error comment, and the guide currently tells them that spelling is fine. The whole reason the guide documents the accepted forms is that the failure mode is invisible.

The error's history is worth recording, since it is the second time this exact claim was got wrong. My original text in #9622 said "leading and trailing whitespace is trimmed", which was wrong. The autofix loop reviewed that PR, correctly spotted that the sentence was false, correctly added the blank-line case — and then fixed it in the wrong direction, keeping "spaces and tabs are trimmed" and restricting the failure to blank lines only (0e2b9a59c). The result was more specific and more confidently stated than what it replaced, and still wrong.

Both mistakes have the same root cause, described in the commit message: replaying the `Decide phases` branch *does* show `  @qwen-code /takeover from 4` parsing cleanly, because the trim there really does strip it. That replay starts inside a job the prefilter would never have started. A command's behaviour is not established by the step that handles it until the expression that admits it has been evaluated too.

## Reviewer Test Plan

### How to verify

The corrected claim was established by evaluating the route job's real `if:` — extracted verbatim from `main`'s `qwen-autofix.yml`, not retyped — through GitHub's own expression engine (`@actions/expressions`, installed outside the repo for the check):

```
route job `if:` starts the job?

true   exact                "@qwen-code /takeover from 4"
false  two leading spaces   "  @qwen-code /takeover from 4"
false  leading tab          "\t@qwen-code /takeover from 4"
false  leading blank line   "\n@qwen-code /takeover from 4"
true   trailing spaces      "@qwen-code /takeover from 4  "
true   trailing newline     "@qwen-code /takeover from 4\n"
false  prefixed text        "please @qwen-code /takeover from 4"
```

Three independent confirmations of the same fact, for a claim that has now been got wrong twice:

1. The expression evaluation above.
2. `af-004` in the design record states it in prose.
3. Reading the prefilter itself: `startsWith` takes `github.event.comment.body` with no `trim()` around it, and GitHub expressions have no implicit whitespace normalisation.

The rest of the table is unchanged and was already replayed against the merged parser in #9622.

Gates:

```
npx prettier --check .github/workflows/qwen-autofix-round-seed.md
bash .github/scripts/check-workflow-size.sh .github/workflows/qwen-autofix.yml
npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow workflow-size   # 272 passed (272)
```

### Evidence (Before & After)

N/A — documentation only, no workflow behaviour changes.

**Before** (on `main`):

> Leading spaces and tabs on the first line, and all trailing whitespace, are trimmed — but a blank line before the command is not, so it must start the comment's first line.

**After:**

> The command has to be the very first thing in the comment: **no leading whitespace of any kind** — space, tab, or blank line. The router prefilters on the _raw_ comment body with `startsWith`, so a body that does not begin with the command never starts a job at all, and the trim that runs inside that job never gets the chance (af-004). Trailing whitespace is harmless.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — no runtime involved; linters and workflow-contract tests only.

## Risk & Scope

- **Main risk or tradeoff:** the corrected claim still is not enforced by anything. `scripts/tests/qwen-autofix-workflow.test.js` pins the prefilter as a string (`expect(workflow).toContain("startsWith(github.event.comment.body, '@qwen-code /takeover')")`) but never evaluates it, so no test would catch this class of drift. Pinning it behaviourally needs an expression evaluator, and `@actions/expressions` is not a repo dependency — adding one is not something a documentation fix should decide, so it is left out and named here instead. That is worth its own change if this keeps happening.
- **Not validated / out of scope:** only the leading-whitespace claim is touched. The two corrections the loop got right in 0e2b9a59c — adding in-budget maintainer feedback to what Critical-only preserves, and the second fork refusal — are correct and left alone.
- **Breaking changes / migration notes:** none.

## Linked Issues

Corrects the guide added in #9622. Documents behaviour introduced in #9321.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修正 `qwen-autofix-round-seed.md` 中的一处事实错误，该文件由 #9622 引入。

指南此前告诉维护者：命令评论开头的空格与 tab 会被裁剪，只有命令前的空行才会导致失效。这两半都不对：**任何形式的前导空白都不会被容忍。** 前导空格、前导 tab、前导换行的失败方式完全相同。

路由器的预过滤器作用于**原始**评论正文 —— `startsWith(github.event.comment.body, '@qwen-code /takeover')` —— 因此一条不以命令开头的正文根本不会启动任何 job，`Decide phases` 内部那次 `sed` 裁剪也就永远没机会执行。设计记录早已在 [af-004](https://github.com/QwenLM/qwen-code/blob/main/.github/workflows/qwen-autofix.md#af-004) 中写明这一点 —— "a body with LEADING whitespace dies here even though the decide branch would trim it" —— 而指南与之矛盾。

该段落已改写为"任何形式的前导空白都会失败"并链接 af-004；表格中原先合并的那一行前导空白拆分为前导空格与前导换行两行；失败描述中新增说明：当路由器根本未启动时，连一行日志都找不到 —— 这一点在有人试图排查"为什么什么都没发生"时很关键。

## 为什么需要

这是 `main` 上关于一个静默失败命令的实时指引。维护者一旦缩进了命令 —— 比如粘贴在某个列表项下方，或跟在一行引用之后 —— 得到的是：没有标签、没有种子、没有回执、也没有报错评论；而指南目前却告诉他们这种写法没问题。指南记录接受形态的全部意义，正是因为这种失败模式不可见。

这处错误的来龙去脉值得记录，因为同一个断言已经被写错两次。我在 #9622 的原始表述是"前导与尾部空白都会被裁剪"，是错的。autofix 循环评审该 PR 时，正确地发现这句为假，也正确地补上了空行的情形 —— 然后朝错误的方向修正，保留了"空格和 tab 会被裁剪"，并把失效场景限缩为仅空行（0e2b9a59c）。结果比它替换掉的表述更具体、语气更肯定，而且依然是错的。

两次错误的根因相同，已写入 commit message：回放 `Decide phases` 分支**确实**会显示 `  @qwen-code /takeover from 4` 解析正常，因为那里的裁剪真的会把它剥掉。但那次回放的起点，位于一个预过滤器根本不会启动的 job 内部。在准入表达式本身被求值之前，仅凭处理命令的那个 step 并不能确立命令的行为。

## 评审者测试计划

### 如何验证

修正后的断言，是通过对 route job 真实的 `if:` 求值确立的 —— 该表达式从 `main` 的 `qwen-autofix.yml` 中逐字抽取，而非手工重敲 —— 使用 GitHub 自己的表达式引擎（`@actions/expressions`，在仓库之外安装用于本次核验）：

```
route job `if:` starts the job?

true   exact                "@qwen-code /takeover from 4"
false  two leading spaces   "  @qwen-code /takeover from 4"
false  leading tab          "\t@qwen-code /takeover from 4"
false  leading blank line   "\n@qwen-code /takeover from 4"
true   trailing spaces      "@qwen-code /takeover from 4  "
true   trailing newline     "@qwen-code /takeover from 4\n"
false  prefixed text        "please @qwen-code /takeover from 4"
```

对于一个已经被写错两次的断言，这里给出三条彼此独立的印证：

1. 上面的表达式求值。
2. 设计记录中的 `af-004` 以散文形式陈述了同一事实。
3. 直接阅读预过滤器本身：`startsWith` 接收的是 `github.event.comment.body`，外面没有任何 `trim()`，而 GitHub 表达式不做隐式空白归一化。

表格其余部分未改动，且已在 #9622 中针对合入版解析器完成回放。

门禁：

```
npx prettier --check .github/workflows/qwen-autofix-round-seed.md
bash .github/scripts/check-workflow-size.sh .github/workflows/qwen-autofix.yml
npx vitest run --config ./scripts/tests/vitest.config.ts qwen-autofix-workflow workflow-size   # 272 passed (272)
```

### 证据（改动前后）

N/A —— 纯文档，无 workflow 行为变更。

**改动前**（`main` 上）：

> Leading spaces and tabs on the first line, and all trailing whitespace, are trimmed — but a blank line before the command is not, so it must start the comment's first line.

**改动后：**

> The command has to be the very first thing in the comment: **no leading whitespace of any kind** — space, tab, or blank line. The router prefilters on the _raw_ comment body with `startsWith`, so a body that does not begin with the command never starts a job at all, and the trim that runs inside that job never gets the chance (af-004). Trailing whitespace is harmless.

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

N/A —— 不涉及运行时；仅 linter 与 workflow 契约测试。

## 风险与范围

- **主要风险或权衡：** 修正后的断言依然没有任何机制强制。`scripts/tests/qwen-autofix-workflow.test.js` 以字符串形式 pin 住了预过滤器（`expect(workflow).toContain("startsWith(github.event.comment.body, '@qwen-code /takeover')")`），但从不对其求值，因此没有任何测试能捕获这一类漂移。要在行为层面 pin 住它需要一个表达式求值器，而 `@actions/expressions` 并非仓库依赖 —— 引入依赖不该由一个文档修复来决定，故此处不引入，仅在此点明。如果这类问题反复出现，值得单独立项处理。
- **未验证 / 不在范围内：** 仅改动前导空白这一处断言。循环在 0e2b9a59c 中改对的另外两处 —— 把"预算内的维护者反馈"补进 Critical-only 放行清单，以及补上第二种 fork 拒绝 —— 是正确的，保持原样。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

修正 #9622 引入的指南。所记录的行为由 #9321 引入。

</details>
