### PR TITLE
perf(cli): raise VP scroll rendering to 60 FPS

### DIFF
--- a/docs/design/2026-08-21-vp-scroll-frame-pacing.md
+++ b/docs/design/2026-08-21-vp-scroll-frame-pacing.md
@@ -1,0 +1,55 @@
+# VP scroll frame pacing
+
+## Problem
+
+Mouse scrolling in the terminal-buffer UI is governed twice. `ScrollableList`
+waits up to one 16 ms frame before committing accumulated wheel input, while
+Ink independently limits terminal paints to its default 30 FPS. In a real
+120x40 detached tmux run, the unchanged production bundle sustains roughly 26
+FPS with a 43 ms median frame interval. Profiling shows terminal frame
+composition and serialization dominate the active scroll window; Yoga layout
+is a much smaller share.
+
+## Change
+
+Raise the terminal paint ceiling for VP scrolling without changing input
+semantics:
+
+- Pass `maxFps: 60` to Ink only when terminal-buffer mode is active. Preserve
+  the existing 30 FPS default for legacy rendering.
+- Keep the existing trailing 16 ms input coalescer. A leading-and-trailing
+  variant was rejected because high-frequency direct-PTY testing showed
+  path-dependent scroll distance through the dynamically measured list.
+
+No rendering-library fork or virtual-list rewrite is part of the first pass.
+Broader work is justified only if the measured result remains below the
+acceptance threshold.
+
+## Measurement
+
+Run the unchanged baseline and candidate in alternating order with the same
+large and small recorded sessions and 100 SGR wheel events. Keep the 120x40
+detached tmux test for comparison, and add a 120x40 direct-PTY run that injects
+one event every 5 ms; spawning `tmux send-keys` once per event takes roughly 45
+ms on the test host and therefore caps the observable input-driven frame rate.
+For each, record steady frame count, FPS, p50/p90 frame interval, bytes per
+frame, event-injection duration, and final viewport position. Use at least three
+runs per session and compare medians. Verify ordinary 50 ms wheel input ends at
+the same viewport. For the 5 ms stress burst, verify every write succeeds and
+use a controlled-height list test to assert the exact accumulated scroll delta:
+the real history estimator starts unseen items at three rows, so rendering more
+intermediate layouts can discover actual heights and legitimately change its
+final content anchor.
+
+The first pass is successful when both session sizes reach at least 45 FPS with
+a p50 frame interval below 25 ms in the direct-PTY run, without dropping input,
+changing ordinary-rate scroll behavior, or changing the recorded sessions. CPU
+time and terminal bytes per second are guardrails: the higher frame rate must
+not come from an unbounded render loop.
+
+## Risks
+
+60 FPS can increase total terminal output and CPU use during active scrolling.
+The limit applies only to VP mode, and scroll events retain their existing
+coalescing behavior. Keyboard behavior and non-VP output retain their current
+scheduling.

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -2750,6 +2750,7 @@ describe('startInteractiveUI', () => {
       exitOnCtrlC: false,
       isScreenReaderEnabled: false,
       alternateScreen: true,
+      maxFps: 60,
     });
 
     // Verify React element structure is valid (but don't deep dive into JSX internals)
@@ -2787,6 +2788,7 @@ describe('startInteractiveUI', () => {
 
     const [, options] = renderSpy.mock.calls[0];
     expect(options).toMatchObject({ alternateScreen: false });
+    expect(options).not.toHaveProperty('maxFps');
   });
 
   it('should not use alternate screen when stdout is not interactive', async () => {

--- a/packages/cli/src/ui/components/shared/ScrollableList.test.tsx
+++ b/packages/cli/src/ui/components/shared/ScrollableList.test.tsx
@@ -5,11 +5,12 @@
  */
 
 import type React from 'react';
+import { createRef } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { act } from '@testing-library/react';
 import { Text } from 'ink';
-import { ScrollableList } from './ScrollableList.js';
+import { ScrollableList, type ScrollableListRef } from './ScrollableList.js';
 import { SCROLL_TO_ITEM_END } from './VirtualizedList.js';
 import { KeypressProvider } from '../../contexts/KeypressContext.js';
 
@@ -102,6 +103,38 @@ describe('<ScrollableList /> mouse scrolling', () => {
     });
     await flushScrollFrame();
     expect(lastFrame()).toContain('item-0');
+  });
+
+  it('preserves the full delta of a coalesced wheel burst', async () => {
+    const listRef = createRef<ScrollableListRef<Item>>();
+    const renderItem = ({ item }: { item: Item }) => <Text>{item.label}</Text>;
+    const Wrapper = () => (
+      <ScrollableList<Item>
+        ref={listRef}
+        hasFocus
+        data={makeItems(200)}
+        renderItem={renderItem}
+        estimatedItemHeight={estimatedItemHeight}
+        keyExtractor={keyExtractor}
+        initialScrollIndex={SCROLL_TO_ITEM_END}
+        initialScrollOffsetInIndex={SCROLL_TO_ITEM_END}
+        containerHeight={5}
+        width={40}
+        showScrollbar={false}
+      />
+    );
+
+    const { stdin, rerender } = render(withKeypress(<Wrapper />));
+    rerender(withKeypress(<Wrapper />));
+    await act(async () => {});
+    expect(listRef.current?.getScrollState().scrollTop).toBe(195);
+
+    await act(async () => {
+      for (let i = 0; i < 30; i++) stdin.write(wheelUp(5, 5));
+    });
+    await flushScrollFrame();
+
+    expect(listRef.current?.getScrollState().scrollTop).toBe(105);
   });
 
   it('does not crash when hasFocus is false (mouse pipeline inactive)', () => {

--- a/packages/cli/src/ui/startInteractiveUI.tsx
+++ b/packages/cli/src/ui/startInteractiveUI.tsx
@@ -252,6 +252,7 @@ export async function startInteractiveUI(
       exitOnCtrlC: false,
       isScreenReaderEnabled: config.getScreenReader(),
       alternateScreen: useVP,
+      ...(useVP ? { maxFps: 60 } : {}),
     },
   );
   if (useVP) {


### PR DESCRIPTION
## What this PR does

Raises the terminal paint ceiling to 60 FPS when terminal-buffer virtual scrolling is active, while preserving Ink's existing default for legacy rendering. It also adds regression coverage for the mode-specific render limit and for preserving the full accumulated delta of a coalesced wheel burst.

## Why it's needed

Virtual scrolling already batches mouse input on a 16 ms cadence, but terminal paints were independently capped by Ink's 30 FPS default. In a real 120×40 PTY this produced only 20–23 FPS with 44–46 ms median frame intervals, making history scrolling feel visibly choppy. The new ceiling allows the existing virtualized UI to sustain about 50 FPS without changing ordinary-rate scroll behavior.

## Reviewer Test Plan

### How to verify

Enable terminal-buffer mode, resume a conversation with enough history to scroll, and continuously wheel through it in a 120×40 terminal. The viewport should respond at roughly 50 FPS, wheel bursts should retain their accumulated distance, and ordinary 50 ms/event scrolling should finish at the same viewport as before. Then disable terminal-buffer mode and confirm legacy rendering retains its existing frame limit rather than receiving the VP override.

### Evidence (Before & After)

| 120×40 direct PTY, three-run median | Before | After |
| --- | ---: | ---: |
| 5.9 MB / 2,805-record session FPS | 20.94 | 50.43 |
| Large-session p50 / p90 | 45.50 / 57.76 ms | 22.53 / 33.67 ms |
| 231 KB / 104-record session FPS | 22.51 | 49.95 |
| Small-session p50 / p90 | 43.61 / 48.00 ms | 20.82 / 31.53 ms |

Each stress run delivered all 100 SGR wheel events. A separate 50 ms/event run started and ended at byte-identical viewports before and after the change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS arm64, Node.js 24.18, 120×40 direct PTY and detached tmux, production bundle, sandbox disabled, safe mode enabled.

## Risk & Scope

- Main risk or tradeoff: Active-scroll terminal throughput rises with the additional frames, from roughly 119–137 KB/s to 292–311 KB/s in the measured sessions; the higher ceiling is limited to terminal-buffer mode.
- Not validated / out of scope: Windows and Linux terminals were not manually profiled. Remaining p90 latency is dominated by React commit and terminal frame composition and is intentionally left for a deeper renderer optimization.
- Breaking changes / migration notes: None.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在终端缓冲区虚拟滚动开启时，将终端绘制上限提高到 60 FPS，同时保留旧渲染模式现有的 Ink 默认值。还补充了两类回归覆盖：不同模式使用正确的帧率上限，以及合并后的滚轮 burst 能完整保留累计滚动距离。

## 为什么需要

虚拟滚动已经以 16 ms 的节奏合并鼠标输入，但终端绘制还被 Ink 默认的 30 FPS 独立限制。在真实 120×40 PTY 中，实际只能达到 20–23 FPS，帧间隔中位数为 44–46 ms，历史记录滚动会明显卡顿。新的上限让现有虚拟化 UI 可以稳定在约 50 FPS，同时不改变正常输入节奏下的滚动行为。

## Reviewer 测试计划

### 如何验证

开启终端缓冲区模式，恢复一段足够长、可以滚动的会话，并在 120×40 终端中连续滚动。viewport 应能以约 50 FPS 响应，滚轮 burst 应完整保留累计距离，50 ms/事件的普通滚动应和修改前停在相同 viewport。随后关闭终端缓冲区模式，确认旧渲染模式仍使用原有帧率限制，不会收到 VP 专用覆盖。

### 证据（修改前后）

| 120×40 direct PTY，三轮中位数 | 修改前 | 修改后 |
| --- | ---: | ---: |
| 5.9 MB / 2,805 records 会话 FPS | 20.94 | 50.43 |
| 大会话 p50 / p90 | 45.50 / 57.76 ms | 22.53 / 33.67 ms |
| 231 KB / 104 records 会话 FPS | 22.51 | 49.95 |
| 小会话 p50 / p90 | 43.61 / 48.00 ms | 20.82 / 31.53 ms |

每轮压力测试的 100 个 SGR 滚轮事件均完整写入。另一次 50 ms/事件的测试中，修改前后的起点和终点 viewport 均逐字节相同。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS arm64、Node.js 24.18、120×40 direct PTY 与 detached tmux、production bundle、关闭 sandbox、开启 safe mode。

## 风险与范围

- 主要风险或取舍：活动滚动期终端吞吐量会随帧数上升；实测从约 119–137 KB/s 增至 292–311 KB/s。更高上限仅应用于终端缓冲区模式。
- 未验证 / 范围外：没有在 Windows 和 Linux 终端上做人工性能分析。剩余 p90 延迟主要来自 React commit 和终端帧合成，留待更深入的 renderer 优化。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
