### PR TITLE
feat(cli): restore each daemon session onto its last selected model

### DIFF
--- a/docs/design/daemon-session-model.md
+++ b/docs/design/daemon-session-model.md
@@ -76,9 +76,13 @@ so the session leaves the snapshot endpoint instead of no-op'ing.
 Live attach/resume skips restore. Cold `loadSession` / `resumeSession`:
 
 1. `newSessionConfig` still constructs Config from current settings.
-2. Before `ensureAuthenticated`, apply the last `session_model` payload, else
-   the last assistant `model` (same auth from `modelsConfig.getCurrentAuthType()`
-   when content-generator auth is not yet populated), else keep settings.
+2. Before `ensureAuthenticated`, apply the last valid `session_model` payload,
+   else the last assistant `model` (same auth from
+   `modelsConfig.getCurrentAuthType()` when content-generator auth is not yet
+   populated), else keep settings. A recorded `baseUrl` is a registry route
+   selector, not an arbitrary endpoint: it is honored only when it matches a
+   configured registry route for that auth type and model, otherwise the
+   implicit registry route is used. `authType` must be a known `AuthType`.
 3. `switchModel` failure is non-fatal. If the restored auth then fails
    `ensureAuthenticated`, load/resume reverts to the settings model and
    retries authentication once.

--- a/docs/design/daemon-session-model.md
+++ b/docs/design/daemon-session-model.md
@@ -62,7 +62,9 @@ false`).
 file; listing, DELETE, and child death all depend on that. A new session
 already inherits `settings.model.name`. Load/resume of a session that never
 switched models uses the last assistant `model`, else the current settings
-default.
+default. A session that has user records but no assistant record and was never
+switched therefore has no binding; that residual window is accepted so empty
+sessions stay file-less.
 
 `loadSession` / `resumeSession` must not write. `workspaceReload` must not
 write.
@@ -83,9 +85,13 @@ Live attach/resume skips restore. Cold `loadSession` / `resumeSession`:
    selector, not an arbitrary endpoint: it is honored only when it matches a
    configured registry route for that auth type and model, otherwise the
    implicit registry route is used. `authType` must be a known `AuthType`.
-3. `switchModel` failure is non-fatal. If the restored auth then fails
-   `ensureAuthenticated`, load/resume reverts to the settings model and
-   retries authentication once.
+3. `switchModel` failure is non-fatal. A recorded runtime-snapshot binding
+   whose live snapshot is gone still switches the bare id when a registry
+   route exists; that can be a different endpoint than the recorded
+   binding. Restore continues on the settings default only when no route
+   resolves. If the restored auth then fails `ensureAuthenticated`,
+   load/resume reverts to the settings model and retries authentication
+   once.
 
 ## Surfaces
 

--- a/docs/design/daemon-session-model.md
+++ b/docs/design/daemon-session-model.md
@@ -72,8 +72,11 @@ Live attach/resume skips restore. Cold `loadSession` / `resumeSession`:
 
 1. `newSessionConfig` still constructs Config from current settings.
 2. Before `ensureAuthenticated`, apply the last `session_model` payload, else
-   the last assistant `model` (same auth), else keep settings.
-3. `switchModel` failure is non-fatal; resume continues on the settings model.
+   the last assistant `model` (same auth from `modelsConfig.getCurrentAuthType()`
+   when content-generator auth is not yet populated), else keep settings.
+3. `switchModel` failure is non-fatal. If the restored auth then fails
+   `ensureAuthenticated`, load/resume reverts to the settings model and
+   retries authentication once.
 
 ## Surfaces
 

--- a/docs/design/daemon-session-model.md
+++ b/docs/design/daemon-session-model.md
@@ -53,11 +53,16 @@ identical payload is a no-op), except rewind: `rewindRecording` re-appends the
 in-memory binding after the rewind record so last-wins on the active branch
 still matches Config.
 
-1. `acpAgent.newSession` after `createAndStoreSession`.
-2. `Session.setModel` after a successful switch (including `persistDefault:
+1. `Session.setModel` after a successful switch (including `persistDefault:
 false`).
-3. ACP `/model <id>` via `switchMainModel` when `executionMode === 'acp'`.
-4. `rewindRecording`, which re-anchors the live binding (not a user switch).
+2. ACP `/model <id>` via `switchMainModel` when `executionMode === 'acp'`.
+3. `rewindRecording`, which re-anchors the live binding (not a user switch).
+
+`acpAgent.newSession` must not write. Empty daemon sessions have no transcript
+file; listing, DELETE, and child death all depend on that. A new session
+already inherits `settings.model.name`. Load/resume of a session that never
+switched models uses the last assistant `model`, else the current settings
+default.
 
 `loadSession` / `resumeSession` must not write. `workspaceReload` must not
 write.

--- a/docs/design/daemon-session-model.md
+++ b/docs/design/daemon-session-model.md
@@ -1,0 +1,81 @@
+# Daemon session model persistence
+
+## Status
+
+Implementation companion to keeping a daemon session on the model it was
+created or last switched to, across detach / idle reap / daemon restart.
+
+## Problem
+
+Each ACP session has its own in-memory `Config`, but `Session.setModel` (and
+ACP `/model`) also write `settings.model.name`. Switching away from an idle
+session typically detaches and closes it. The next load/resume builds a new
+`Config` from current settings, so session A picks up model B.
+
+Assistant JSONL records store `model` per turn, but restore does not apply it.
+
+## Goals
+
+- Daemon load/resume of an existing session restores that session's model.
+- New sessions still inherit the last persisted `model.name` default.
+- TUI and CLI `--resume` do not switch models from this record.
+- Resume stays read-only (no JSONL append).
+
+## Non-goals
+
+- Restoring model in TUI / CLI `--resume`.
+- Changing approval-mode persistence.
+- Stopping `model.name` updates for new-session defaults.
+- Rebinding idle live sessions after `workspaceReload`.
+
+## Record format
+
+Append-only `system` / `session_model` JSONL records, last-wins, same pattern
+as `session_source`.
+
+```ts
+interface SessionModelRecordPayload {
+  modelId: string;
+  authType: string;
+  baseUrl?: string;
+  isRuntime?: boolean;
+}
+```
+
+`modelId` is the canonical id after `switchModel` (no ACP route id, no
+`$runtime|` prefix). Runtime selections store the underlying id with
+`isRuntime: true`.
+
+## Write sites (daemon user intent only)
+
+All writes go through `ChatRecordingService.recordSessionModel` (best-effort,
+identical payload is a no-op), except rewind: `rewindRecording` re-appends the
+in-memory binding after the rewind record so last-wins on the active branch
+still matches Config.
+
+1. `acpAgent.newSession` after `createAndStoreSession`.
+2. `Session.setModel` after a successful switch (including `persistDefault:
+false`).
+3. ACP `/model <id>` via `switchMainModel` when `executionMode === 'acp'`.
+4. `rewindRecording`, which re-anchors the live binding (not a user switch).
+
+`loadSession` / `resumeSession` must not write. `workspaceReload` must not
+write.
+
+Implicit registry records omit `baseUrl` and `isRuntime`. Restore must still
+`switchModel` when the cold Config currently holds a same-id runtime snapshot,
+so the session leaves the snapshot endpoint instead of no-op'ing.
+
+## Restore (ACP cold start only)
+
+Live attach/resume skips restore. Cold `loadSession` / `resumeSession`:
+
+1. `newSessionConfig` still constructs Config from current settings.
+2. Before `ensureAuthenticated`, apply the last `session_model` payload, else
+   the last assistant `model` (same auth), else keep settings.
+3. `switchModel` failure is non-fatal; resume continues on the settings model.
+
+## Surfaces
+
+JSONL is shared, so core must accept the subtype. Replay already skips ordinary
+system records. Only ACP applies `switchModel` on restore.

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2677,7 +2677,7 @@ Response:
 { "modelId": "qwen-staging" }
 ```
 
-On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler. A successful switch also records the session model in the session JSONL on a best-effort basis; when the record is written, daemon load/resume restores this session's model. `settings.model.name` is still updated as the default for **new** sessions.
+On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler. A successful switch also records the session model in the session JSONL on a best-effort basis; when the record is written, daemon load/resume attempts to restore this session's model before authentication; if the recorded model can no longer be applied (model removed, credentials unavailable), the restore is skipped and the session continues on the `settings.model.name` default. `settings.model.name` is still updated as the default for **new** sessions.
 
 ### `POST /session/:id/recap`
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2677,7 +2677,7 @@ Response:
 { "modelId": "qwen-staging" }
 ```
 
-On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler. A successful switch also records the session model in the session JSONL on a best-effort basis; when the record is written, daemon load/resume attempts to restore this session's model before authentication; if the recorded model can no longer be applied (model removed, credentials unavailable), the restore is skipped and the session continues on the `settings.model.name` default. `settings.model.name` is still updated as the default for **new** sessions.
+On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler. A successful switch also records the session model in the session JSONL on a best-effort basis; when the record is written, daemon load/resume attempts to restore this session's model before authentication. If the recorded model can no longer be applied (model removed, credentials unavailable), restore uses a same-id registry route when one exists — for a runtime-snapshot record that can be a different endpoint than the recorded binding — and continues on the `settings.model.name` default only when no route resolves. `settings.model.name` is still updated as the default for **new** sessions.
 
 ### `POST /session/:id/recap`
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2677,7 +2677,7 @@ Response:
 { "modelId": "qwen-staging" }
 ```
 
-On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler. A successful switch also appends a `session_model` record to the session JSONL so daemon load/resume restores this session's model; `settings.model.name` is still updated as the default for **new** sessions.
+On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler. A successful switch also records the session model in the session JSONL on a best-effort basis; when the record is written, daemon load/resume restores this session's model. `settings.model.name` is still updated as the default for **new** sessions.
 
 ### `POST /session/:id/recap`
 

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -2677,7 +2677,7 @@ Response:
 { "modelId": "qwen-staging" }
 ```
 
-On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler.
+On success, publishes `model_switched` to the SSE stream. On failure, publishes `model_switch_failed` (so passive subscribers see the failure, not just the caller). Races against the agent channel exit so a wedged child can't block the HTTP handler. A successful switch also appends a `session_model` record to the session JSONL so daemon load/resume restores this session's model; `settings.model.name` is still updated as the default for **new** sessions.
 
 ### `POST /session/:id/recap`
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3518,6 +3518,50 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('records the current model after creating a new daemon session', async () => {
+    const innerConfig = makeInnerConfig();
+    vi.mocked(loadCliConfig).mockResolvedValue(
+      innerConfig as unknown as Config,
+    );
+    vi.mocked(Session).mockImplementation(
+      (sessionId: string) =>
+        ({
+          getId: vi.fn().mockReturnValue(sessionId),
+          sendAvailableCommandsUpdate: vi.fn().mockResolvedValue(undefined),
+          replayHistory: vi.fn().mockResolvedValue(undefined),
+          installRewriter: vi.fn(),
+          startCronScheduler: vi.fn(),
+          dispose: vi.fn(),
+        }) as unknown as InstanceType<typeof Session>,
+    );
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    await agent.newSession({
+      cwd: '/tmp',
+      mcpServers: [],
+    });
+
+    expect(
+      innerConfig.getChatRecordingService().recordSessionModel,
+    ).toHaveBeenCalledWith({
+      modelId: 'm',
+      authType: 'api-key',
+    });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('forwards a caller-supplied sessionId from _meta to loadCliConfig', async () => {
     await setupSessionMocks('meta-session');
     const { agent, agentPromise } = await bootAcpAgent();
@@ -3890,6 +3934,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       }),
       getFileSystemService: vi.fn().mockReturnValue(undefined),
       getChatRecordingService: vi.fn().mockReturnValue({
+        recordSessionModel: vi.fn().mockResolvedValue(true),
         flush: vi.fn().mockResolvedValue(undefined),
         finalize: vi.fn(),
         close: vi.fn().mockResolvedValue(undefined),
@@ -16476,6 +16521,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       finalize: vi.fn(),
       close: vi.fn().mockResolvedValue(undefined),
       hasWriteOwnership: vi.fn().mockReturnValue(false),
+      recordSessionModel: vi.fn().mockResolvedValue(true),
       runWithWriteBarrier: vi.fn(
         async <T>(operation: () => Promise<T>): Promise<T> => operation(),
       ),
@@ -16492,6 +16538,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         getCurrentAuthType: vi.fn().mockReturnValue('api-key'),
       }),
       refreshAuth: vi.fn().mockResolvedValue(undefined),
+      switchModel: vi.fn().mockResolvedValue(undefined),
       getModel: vi.fn().mockReturnValue('m'),
       storage: {
         getProjectRoot: vi.fn().mockReturnValue('/tmp'),
@@ -16651,6 +16698,9 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         const messages = data.conversation.messages as Array<
           Record<string, unknown>
         >;
+        const lastSessionModel = [...messages]
+          .reverse()
+          .find((message) => message['subtype'] === 'session_model');
         return {
           sessionId,
           filePath: '/tmp/session.jsonl',
@@ -16663,6 +16713,9 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
               lastCompletedUuid:
                 (messages.at(-1)?.['uuid'] as string | undefined) ?? '',
               turnParentUuids: [],
+              ...(lastSessionModel?.['systemPayload']
+                ? { sessionModel: lastSessionModel['systemPayload'] }
+                : {}),
             },
             artifactSnapshot: data.artifactSnapshot,
             goalRecords: messages,
@@ -16863,6 +16916,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         'settings_load',
         'existence_check',
         'config_setup',
+        'restore_session_model',
         'auth',
         'file_system_setup',
         'session_register',
@@ -16895,6 +16949,92 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       await agentPromise;
     },
   );
+
+  it.each(['load', 'resume'] as const)(
+    'cold %s restores the recorded session model before auth',
+    async (action) => {
+      const innerConfig = bindRestoreMocks({
+        sessionExists: true,
+        resumedConversation: {
+          messages: [
+            {
+              uuid: 'model-1',
+              type: 'system',
+              subtype: 'session_model',
+              systemPayload: {
+                modelId: 'qwen3-coder-plus',
+                authType: 'openai',
+              },
+            },
+            { role: 'user', parts: [{ text: 'hello' }] },
+          ],
+        },
+      });
+      const { agent, agentPromise } = await spawnAgent();
+      const request = {
+        cwd: '/tmp',
+        sessionId: 'persisted-1',
+        mcpServers: [],
+      };
+
+      if (action === 'load') {
+        await agent.loadSession(request);
+      } else {
+        await agent.unstable_resumeSession(request);
+      }
+
+      expect(innerConfig.switchModel).toHaveBeenCalledWith(
+        'openai',
+        'qwen3-coder-plus',
+        undefined,
+      );
+      expect(innerConfig.switchModel.mock.invocationCallOrder[0]).toBeLessThan(
+        innerConfig.refreshAuth.mock.invocationCallOrder[0],
+      );
+      expect(
+        innerConfig.getChatRecordingService().recordSessionModel,
+      ).not.toHaveBeenCalled();
+
+      mockConnectionState.resolve();
+      await agentPromise;
+    },
+  );
+
+  it('cold resume still succeeds when restoring the session model fails', async () => {
+    const innerConfig = bindRestoreMocks({
+      sessionExists: true,
+      resumedConversation: {
+        messages: [
+          {
+            uuid: 'model-1',
+            type: 'system',
+            subtype: 'session_model',
+            systemPayload: {
+              modelId: 'missing-model',
+              authType: 'openai',
+            },
+          },
+        ],
+      },
+    });
+    innerConfig.switchModel.mockRejectedValue(new Error('unknown model'));
+    const { agent, agentPromise } = await spawnAgent();
+
+    await expect(
+      agent.unstable_resumeSession({
+        cwd: '/tmp',
+        sessionId: 'persisted-1',
+        mcpServers: [],
+      }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        models: expect.any(Object),
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
 
   it.each(['load', 'resume'] as const)(
     'profiles the live %s restore path without an existence check',
@@ -16949,6 +17089,11 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         ).toEqual(expect.any(Number));
         expect(
           attributes['qwen-code.daemon.session_restore.existence_check_ms'],
+        ).toBeUndefined();
+        expect(
+          attributes[
+            'qwen-code.daemon.session_restore.restore_session_model_ms'
+          ],
         ).toBeUndefined();
       } finally {
         mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3524,7 +3524,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
-  it('records the current model after creating a new daemon session', async () => {
+  it('does not record a session model on an empty new daemon session', async () => {
     const innerConfig = makeInnerConfig();
     vi.mocked(loadCliConfig).mockResolvedValue(
       innerConfig as unknown as Config,
@@ -3559,10 +3559,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     expect(
       innerConfig.getChatRecordingService().recordSessionModel,
-    ).toHaveBeenCalledWith({
-      modelId: 'm',
-      authType: 'api-key',
-    });
+    ).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -210,6 +210,12 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
   isTurnResultRecordPayload: (
     await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
   ).isTurnResultRecordPayload,
+  RUNTIME_SNAPSHOT_PREFIX: (
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
+  ).RUNTIME_SNAPSHOT_PREFIX,
+  stripRuntimeSnapshotPrefix: (
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
+  ).stripRuntimeSnapshotPrefix,
   SESSION_ARTIFACT_PERSISTENCE_VERSION: 2,
   GOAL_STATE_VERSION: 2,
   // The real helper: the goal get/clear fallbacks return its exact shape and

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -247,10 +247,7 @@ import {
   isInactiveExtensionSkill,
 } from './extension-skills.js';
 import { Session, buildAvailableCommandsSnapshot } from './session/Session.js';
-import {
-  recordDaemonSessionModelFromConfig,
-  restoreSessionModelThenAuthenticate,
-} from './session-model-persistence.js';
+import { restoreSessionModelThenAuthenticate } from './session-model-persistence.js';
 import { HistoryReplayer } from './session/history-replayer.js';
 import { renderPreparedGoalUpdate } from './session/recovered-goal-update.js';
 import { ActiveWorkReporter } from './active-work-reporter.js';
@@ -5250,7 +5247,6 @@ class QwenAgent implements Agent {
             session = await profiler.time('session_register', () =>
               this.createAndStoreSession(config, settings),
             );
-            await recordDaemonSessionModelFromConfig(config);
           } catch (error) {
             return this.cleanupAfterRequestFailure(error, async () => {
               if (

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -247,6 +247,10 @@ import {
   isInactiveExtensionSkill,
 } from './extension-skills.js';
 import { Session, buildAvailableCommandsSnapshot } from './session/Session.js';
+import {
+  applyRestoredSessionModel,
+  recordDaemonSessionModelFromConfig,
+} from './session-model-persistence.js';
 import { HistoryReplayer } from './session/history-replayer.js';
 import { renderPreparedGoalUpdate } from './session/recovered-goal-update.js';
 import { ActiveWorkReporter } from './active-work-reporter.js';
@@ -537,6 +541,7 @@ type AcpSessionProfileStage =
   | 'live_restore'
   | 'existence_check'
   | 'config_setup'
+  | 'restore_session_model'
   | 'auth'
   | 'file_system_setup'
   | 'session_register'
@@ -5245,6 +5250,7 @@ class QwenAgent implements Agent {
             session = await profiler.time('session_register', () =>
               this.createAndStoreSession(config, settings),
             );
+            await recordDaemonSessionModelFromConfig(config);
           } catch (error) {
             return this.cleanupAfterRequestFailure(error, async () => {
               if (
@@ -5485,6 +5491,9 @@ class QwenAgent implements Agent {
             : {}),
         })) as LoadSessionResponse;
       try {
+        await profiler.time('restore_session_model', () =>
+          applyRestoredSessionModel(config, projection),
+        );
         await profiler.time('auth', () => this.ensureAuthenticated(config));
         profiler.timeSync('file_system_setup', () =>
           this.setupFileSystem(config),
@@ -5781,6 +5790,9 @@ class QwenAgent implements Agent {
       const projection = config.consumeSessionRestoreProjection?.();
       let response: ResumeSessionResponse | undefined;
       try {
+        await profiler.time('restore_session_model', () =>
+          applyRestoredSessionModel(config, projection),
+        );
         await profiler.time('auth', () => this.ensureAuthenticated(config));
         profiler.timeSync('file_system_setup', () =>
           this.setupFileSystem(config),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -248,8 +248,8 @@ import {
 } from './extension-skills.js';
 import { Session, buildAvailableCommandsSnapshot } from './session/Session.js';
 import {
-  applyRestoredSessionModel,
   recordDaemonSessionModelFromConfig,
+  restoreSessionModelThenAuthenticate,
 } from './session-model-persistence.js';
 import { HistoryReplayer } from './session/history-replayer.js';
 import { renderPreparedGoalUpdate } from './session/recovered-goal-update.js';
@@ -5492,9 +5492,10 @@ class QwenAgent implements Agent {
         })) as LoadSessionResponse;
       try {
         await profiler.time('restore_session_model', () =>
-          applyRestoredSessionModel(config, projection),
+          restoreSessionModelThenAuthenticate(config, projection, () =>
+            profiler.time('auth', () => this.ensureAuthenticated(config)),
+          ),
         );
-        await profiler.time('auth', () => this.ensureAuthenticated(config));
         profiler.timeSync('file_system_setup', () =>
           this.setupFileSystem(config),
         );
@@ -5791,9 +5792,10 @@ class QwenAgent implements Agent {
       let response: ResumeSessionResponse | undefined;
       try {
         await profiler.time('restore_session_model', () =>
-          applyRestoredSessionModel(config, projection),
+          restoreSessionModelThenAuthenticate(config, projection, () =>
+            profiler.time('auth', () => this.ensureAuthenticated(config)),
+          ),
         );
-        await profiler.time('auth', () => this.ensureAuthenticated(config));
         profiler.timeSync('file_system_setup', () =>
           this.setupFileSystem(config),
         );

--- a/packages/cli/src/acp-integration/session-model-persistence.test.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.test.ts
@@ -1,0 +1,352 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { AuthType } from '@qwen-code/qwen-code-core';
+import type {
+  Config,
+  SessionRestoreProjection,
+} from '@qwen-code/qwen-code-core';
+import {
+  applyRestoredSessionModel,
+  recordDaemonSessionModel,
+  recordDaemonSessionModelFromConfig,
+} from './session-model-persistence.js';
+
+function recordingProjection(
+  recording: SessionRestoreProjection['runtime']['recording'],
+): SessionRestoreProjection {
+  return {
+    sessionId: 'session-1',
+    filePath: '/tmp/session.jsonl',
+    startTime: '2026-01-01T00:00:00.000Z',
+    lastUpdated: '2026-01-01T00:00:00.000Z',
+    runtime: {
+      apiHistory: [],
+      uiTelemetryEvents: [],
+      recording,
+      goalRecords: [],
+      initialTurn: 0,
+      backgroundNotificationTaskIds: [],
+    },
+  };
+}
+
+describe('session-model-persistence', () => {
+  it('records through ChatRecordingService', async () => {
+    const recordSessionModel = vi.fn().mockResolvedValue(true);
+    const config = {
+      getChatRecordingService: vi.fn().mockReturnValue({ recordSessionModel }),
+    } as unknown as Config;
+
+    await recordDaemonSessionModel(config, {
+      modelId: 'qwen3-coder-plus',
+      authType: AuthType.USE_OPENAI,
+    });
+
+    expect(recordSessionModel).toHaveBeenCalledWith({
+      modelId: 'qwen3-coder-plus',
+      authType: AuthType.USE_OPENAI,
+    });
+  });
+
+  it('does not throw when recording fails', async () => {
+    const config = {
+      getChatRecordingService: vi.fn().mockReturnValue({
+        recordSessionModel: vi.fn().mockRejectedValue(new Error('disk full')),
+      }),
+    } as unknown as Config;
+
+    await expect(
+      recordDaemonSessionModel(config, {
+        modelId: 'qwen3-coder-plus',
+        authType: AuthType.USE_OPENAI,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('captures the current config model for a new daemon session', async () => {
+    const recordSessionModel = vi.fn().mockResolvedValue(true);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getCurrentModelRegistryBaseUrl: vi
+        .fn()
+        .mockReturnValue('https://example.test/v1'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        baseUrl: 'https://example.test/v1',
+      }),
+      getChatRecordingService: vi.fn().mockReturnValue({ recordSessionModel }),
+    } as unknown as Config;
+
+    await recordDaemonSessionModelFromConfig(config);
+
+    expect(recordSessionModel).toHaveBeenCalledWith({
+      modelId: 'qwen3-coder-plus',
+      authType: AuthType.USE_OPENAI,
+      baseUrl: 'https://example.test/v1',
+    });
+  });
+
+  it('omits baseUrl for an implicit registry route', async () => {
+    const recordSessionModel = vi.fn().mockResolvedValue(true);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(null),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        baseUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+      }),
+      getChatRecordingService: vi.fn().mockReturnValue({ recordSessionModel }),
+    } as unknown as Config;
+
+    await recordDaemonSessionModelFromConfig(config);
+
+    expect(recordSessionModel).toHaveBeenCalledWith({
+      modelId: 'qwen3-coder-plus',
+      authType: AuthType.USE_OPENAI,
+    });
+  });
+
+  it('restores a recorded session model before matching no-ops', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://example.test/v1',
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      { baseUrl: 'https://example.test/v1' },
+    );
+  });
+
+  it('falls back to the last assistant model when no session_model exists', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        lastAssistantModel: 'old-turn-model',
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'old-turn-model',
+      undefined,
+    );
+  });
+
+  it('does not switch when the live config already matches', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi
+        .fn()
+        .mockReturnValue('https://example.test/v1'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        baseUrl: 'https://example.test/v1',
+      }),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://example.test/v1',
+        },
+      }),
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+
+  it('leaves a same-id runtime snapshot when restoring an implicit registry route', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue({
+        authType: AuthType.USE_OPENAI,
+        modelId: 'qwen3-coder-plus',
+      }),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      undefined,
+    );
+  });
+
+  it('does not switch last-assistant fallback when the live model already matches', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue({
+        authType: AuthType.USE_OPENAI,
+        modelId: 'qwen3-coder-plus',
+      }),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        lastAssistantModel: 'qwen3-coder-plus',
+      }),
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+
+  it('does not fail restore when switchModel rejects', async () => {
+    const switchModel = vi.fn().mockRejectedValue(new Error('unknown model'));
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await expect(
+      applyRestoredSessionModel(
+        config,
+        recordingProjection({
+          lastCompletedUuid: 'leaf',
+          turnParentUuids: [null],
+          sessionModel: {
+            modelId: 'gone-runtime',
+            authType: AuthType.USE_OPENAI,
+            isRuntime: true,
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'gone-runtime',
+      undefined,
+    );
+  });
+
+  it('uses a live runtime snapshot id when that snapshot is still present', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue({
+        authType: AuthType.USE_OPENAI,
+        modelId: 'custom-runtime',
+      }),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'custom-runtime',
+          authType: AuthType.USE_OPENAI,
+          isRuntime: true,
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      `$runtime|${AuthType.USE_OPENAI}|custom-runtime`,
+      undefined,
+    );
+  });
+
+  it('requires cached credentials when restoring Qwen OAuth from another auth', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'coder-model',
+          authType: AuthType.QWEN_OAUTH,
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.QWEN_OAUTH,
+      'coder-model',
+      { requireCachedCredentials: true },
+    );
+  });
+});

--- a/packages/cli/src/acp-integration/session-model-persistence.test.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.test.ts
@@ -691,6 +691,69 @@ describe('session-model-persistence', () => {
     );
   });
 
+  it('retries authentication when restore leaves a same-id runtime snapshot', async () => {
+    let currentAuth: string | undefined = AuthType.USE_OPENAI;
+    let currentModel = 'qwen3-coder-plus';
+    let snapshot:
+      | { id?: string; authType: string; modelId: string }
+      | undefined = {
+      authType: AuthType.USE_OPENAI,
+      modelId: 'qwen3-coder-plus',
+    };
+    const switchModel = vi.fn(
+      async (authType: string, modelId: string): Promise<void> => {
+        currentAuth = authType;
+        currentModel = modelId;
+        snapshot = modelId.startsWith('$runtime|')
+          ? {
+              id: modelId,
+              authType,
+              modelId: modelId.split('|').slice(2).join('|'),
+            }
+          : undefined;
+      },
+    );
+    const authenticate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('oauth expired'))
+      .mockResolvedValueOnce(undefined);
+    const config = {
+      getModel: vi.fn(() => currentModel),
+      getAuthType: vi.fn(() => currentAuth),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getActiveRuntimeModelSnapshot: vi.fn(() => snapshot),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await restoreSessionModelThenAuthenticate(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+        },
+      }),
+      authenticate,
+    );
+
+    expect(authenticate).toHaveBeenCalledTimes(2);
+    expect(switchModel).toHaveBeenNthCalledWith(
+      1,
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      undefined,
+    );
+    expect(switchModel).toHaveBeenNthCalledWith(
+      2,
+      AuthType.USE_OPENAI,
+      `$runtime|${AuthType.USE_OPENAI}|qwen3-coder-plus`,
+      undefined,
+    );
+  });
+
   it('surfaces the settings-model auth error when rollback authentication also fails', async () => {
     let currentAuth: string | undefined = AuthType.USE_OPENAI;
     let currentModel = 'settings-default';

--- a/packages/cli/src/acp-integration/session-model-persistence.test.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.test.ts
@@ -349,4 +349,212 @@ describe('session-model-persistence', () => {
       { requireCachedCredentials: true },
     );
   });
+
+  it('marks the payload isRuntime when a runtime snapshot is active', async () => {
+    const recordSessionModel = vi.fn().mockResolvedValue(true);
+    const config = {
+      getModel: vi.fn().mockReturnValue('custom-runtime'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue({
+        authType: AuthType.USE_OPENAI,
+        modelId: 'custom-runtime',
+      }),
+      getCurrentModelRegistryBaseUrl: vi
+        .fn()
+        .mockReturnValue('https://example.test/v1'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getChatRecordingService: vi.fn().mockReturnValue({ recordSessionModel }),
+    } as unknown as Config;
+
+    await recordDaemonSessionModelFromConfig(config);
+
+    expect(recordSessionModel).toHaveBeenCalledWith({
+      modelId: 'custom-runtime',
+      authType: AuthType.USE_OPENAI,
+      isRuntime: true,
+    });
+  });
+
+  it('keeps the settings model when the projection has neither record nor fallback', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+      }),
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+
+  it('does not switch when the live model carries a runtime prefix over the recorded bare id', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi
+        .fn()
+        .mockReturnValue(`$runtime|${AuthType.USE_OPENAI}|qwen3-coder-plus`),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue({
+        authType: AuthType.USE_OPENAI,
+        modelId: 'qwen3-coder-plus',
+      }),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          isRuntime: true,
+        },
+      }),
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+
+  it('does not switch when the live model carries a stacked runtime prefix', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi
+        .fn()
+        .mockReturnValue(
+          `$runtime|${AuthType.USE_OPENAI}|$runtime|${AuthType.USE_OPENAI}|qwen3-coder-plus`,
+        ),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue({
+        authType: AuthType.USE_OPENAI,
+        modelId: 'qwen3-coder-plus',
+      }),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          isRuntime: true,
+        },
+      }),
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+
+  it('corrects the route when the recorded explicit baseUrl differs from the live one', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi
+        .fn()
+        .mockReturnValue('https://b.example/v1'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        baseUrl: 'https://b.example/v1',
+      }),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://a.example/v1',
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      { baseUrl: 'https://a.example/v1' },
+    );
+  });
+
+  it('corrects the route when the recorded explicit baseUrl meets a live implicit route', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(null),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://a.example/v1',
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      { baseUrl: 'https://a.example/v1' },
+    );
+  });
+
+  it('corrects the route when the recorded implicit route meets a live explicit baseUrl', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi
+        .fn()
+        .mockReturnValue('https://b.example/v1'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        baseUrl: 'https://b.example/v1',
+      }),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      undefined,
+    );
+  });
 });

--- a/packages/cli/src/acp-integration/session-model-persistence.test.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.test.ts
@@ -36,6 +36,12 @@ function recordingProjection(
   };
 }
 
+function resolvedWhen(baseUrl: string) {
+  return vi.fn((_auth: string, _model: string, url?: string) =>
+    url === baseUrl ? { id: _model } : undefined,
+  );
+}
+
 describe('session-model-persistence', () => {
   it('records through ChatRecordingService', async () => {
     const recordSessionModel = vi.fn().mockResolvedValue(true);
@@ -120,6 +126,7 @@ describe('session-model-persistence', () => {
       getModel: vi.fn().mockReturnValue('settings-default'),
       getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getResolvedModelConfig: resolvedWhen('https://example.test/v1'),
       switchModel,
     } as unknown as Config;
 
@@ -236,6 +243,7 @@ describe('session-model-persistence', () => {
       getContentGeneratorConfig: vi.fn().mockReturnValue({
         baseUrl: 'https://example.test/v1',
       }),
+      getResolvedModelConfig: resolvedWhen('https://example.test/v1'),
       switchModel,
     } as unknown as Config;
 
@@ -594,6 +602,7 @@ describe('session-model-persistence', () => {
       getCurrentModelRegistryBaseUrl: vi.fn(() => currentBaseUrl),
       getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getResolvedModelConfig: resolvedWhen('https://session.example/v1'),
       switchModel,
     } as unknown as Config;
 
@@ -896,6 +905,7 @@ describe('session-model-persistence', () => {
       getContentGeneratorConfig: vi.fn().mockReturnValue({
         baseUrl: 'https://b.example/v1',
       }),
+      getResolvedModelConfig: resolvedWhen('https://a.example/v1'),
       switchModel,
     } as unknown as Config;
 
@@ -926,6 +936,7 @@ describe('session-model-persistence', () => {
       getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
       getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(null),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getResolvedModelConfig: resolvedWhen('https://a.example/v1'),
       switchModel,
     } as unknown as Config;
 
@@ -971,6 +982,65 @@ describe('session-model-persistence', () => {
         sessionModel: {
           modelId: 'qwen3-coder-plus',
           authType: AuthType.USE_OPENAI,
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      undefined,
+    );
+  });
+
+  it('drops a recorded baseUrl that is not a configured registry route', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getResolvedModelConfig: vi.fn().mockReturnValue(undefined),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://attacker.example/v1',
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      undefined,
+    );
+  });
+
+  it('ignores a recorded authType that is not a known AuthType', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: 'not-an-auth',
         },
       }),
     );

--- a/packages/cli/src/acp-integration/session-model-persistence.test.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.test.ts
@@ -14,6 +14,7 @@ import {
   applyRestoredSessionModel,
   recordDaemonSessionModel,
   recordDaemonSessionModelFromConfig,
+  restoreSessionModelThenAuthenticate,
 } from './session-model-persistence.js';
 
 function recordingProjection(
@@ -167,6 +168,63 @@ describe('session-model-persistence', () => {
     );
   });
 
+  it('uses modelsConfig auth for last-assistant fallback before content-generator auth exists', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(undefined),
+      getModelsConfig: vi.fn().mockReturnValue({
+        getCurrentAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      }),
+      getContentGeneratorConfig: vi.fn().mockReturnValue(undefined),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        lastAssistantModel: 'legacy-turn-model',
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'legacy-turn-model',
+      undefined,
+    );
+  });
+
+  it('prefers the session_model record over lastAssistantModel', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+        },
+        lastAssistantModel: 'older-model',
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      undefined,
+    );
+  });
+
   it('does not switch when the live config already matches', async () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     const config = {
@@ -190,6 +248,32 @@ describe('session-model-persistence', () => {
           modelId: 'qwen3-coder-plus',
           authType: AuthType.USE_OPENAI,
           baseUrl: 'https://example.test/v1',
+        },
+      }),
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+
+  it('does not switch an implicit registry record when the live registry baseUrl is unset', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
         },
       }),
     );
@@ -348,6 +432,141 @@ describe('session-model-persistence', () => {
       'coder-model',
       { requireCachedCredentials: true },
     );
+  });
+
+  it('switches when recorded authType differs even if the model id matches', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('coder-model'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'coder-model',
+          authType: AuthType.QWEN_OAUTH,
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.QWEN_OAUTH,
+      'coder-model',
+      { requireCachedCredentials: true },
+    );
+  });
+
+  it('trims padded recorded authType before switching', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      getModel: vi.fn().mockReturnValue('settings-default'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await applyRestoredSessionModel(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: ' qwen3-coder-plus ',
+          authType: `${AuthType.USE_OPENAI}\n`,
+        },
+      }),
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      undefined,
+    );
+  });
+
+  it('retries authentication on the settings model when restored auth fails', async () => {
+    let currentAuth: string | undefined = AuthType.USE_OPENAI;
+    let currentModel = 'settings-default';
+    const switchModel = vi.fn(
+      async (authType: string, modelId: string): Promise<void> => {
+        currentAuth = authType;
+        currentModel = modelId;
+      },
+    );
+    const authenticate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('oauth expired'))
+      .mockResolvedValueOnce(undefined);
+    const config = {
+      getModel: vi.fn(() => currentModel),
+      getAuthType: vi.fn(() => currentAuth),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await restoreSessionModelThenAuthenticate(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'coder-model',
+          authType: AuthType.QWEN_OAUTH,
+        },
+      }),
+      authenticate,
+    );
+
+    expect(authenticate).toHaveBeenCalledTimes(2);
+    expect(switchModel).toHaveBeenNthCalledWith(
+      1,
+      AuthType.QWEN_OAUTH,
+      'coder-model',
+      { requireCachedCredentials: true },
+    );
+    expect(switchModel).toHaveBeenNthCalledWith(
+      2,
+      AuthType.USE_OPENAI,
+      'settings-default',
+      undefined,
+    );
+  });
+
+  it('does not retry authentication when restore did not change the live model', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const authenticate = vi.fn().mockRejectedValue(new Error('auth required'));
+    const config = {
+      getModel: vi.fn().mockReturnValue('qwen3-coder-plus'),
+      getAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await expect(
+      restoreSessionModelThenAuthenticate(
+        config,
+        recordingProjection({
+          lastCompletedUuid: 'leaf',
+          turnParentUuids: [null],
+          lastAssistantModel: 'qwen3-coder-plus',
+        }),
+        authenticate,
+      ),
+    ).rejects.toThrow('auth required');
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(switchModel).not.toHaveBeenCalled();
   });
 
   it('marks the payload isRuntime when a runtime snapshot is active', async () => {

--- a/packages/cli/src/acp-integration/session-model-persistence.test.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.test.ts
@@ -569,6 +569,211 @@ describe('session-model-persistence', () => {
     expect(switchModel).not.toHaveBeenCalled();
   });
 
+  it('retries authentication when restore only changed the registry baseUrl', async () => {
+    let currentAuth: string | undefined = AuthType.USE_OPENAI;
+    let currentModel = 'qwen3-coder-plus';
+    let currentBaseUrl: string | undefined = 'https://settings.example/v1';
+    const switchModel = vi.fn(
+      async (
+        authType: string,
+        modelId: string,
+        options?: { baseUrl?: string },
+      ): Promise<void> => {
+        currentAuth = authType;
+        currentModel = modelId;
+        currentBaseUrl = options?.baseUrl;
+      },
+    );
+    const authenticate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('oauth expired'))
+      .mockResolvedValueOnce(undefined);
+    const config = {
+      getModel: vi.fn(() => currentModel),
+      getAuthType: vi.fn(() => currentAuth),
+      getCurrentModelRegistryBaseUrl: vi.fn(() => currentBaseUrl),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await restoreSessionModelThenAuthenticate(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://session.example/v1',
+        },
+      }),
+      authenticate,
+    );
+
+    expect(authenticate).toHaveBeenCalledTimes(2);
+    expect(switchModel).toHaveBeenNthCalledWith(
+      1,
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      { baseUrl: 'https://session.example/v1' },
+    );
+    expect(switchModel).toHaveBeenNthCalledWith(
+      2,
+      AuthType.USE_OPENAI,
+      'qwen3-coder-plus',
+      { baseUrl: 'https://settings.example/v1' },
+    );
+  });
+
+  it('rolls back to the settings runtime snapshot id after restored auth fails', async () => {
+    let currentAuth: string | undefined = AuthType.USE_OPENAI;
+    let currentModel = 'custom-runtime';
+    const switchModel = vi.fn(
+      async (authType: string, modelId: string): Promise<void> => {
+        if (modelId === 'custom-runtime') {
+          throw new Error('Model not found');
+        }
+        currentAuth = authType;
+        currentModel = modelId;
+      },
+    );
+    const authenticate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('oauth expired'))
+      .mockResolvedValueOnce(undefined);
+    const config = {
+      getModel: vi.fn(() => currentModel),
+      getAuthType: vi.fn(() => currentAuth),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue({
+        authType: AuthType.USE_OPENAI,
+        modelId: 'custom-runtime',
+      }),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await restoreSessionModelThenAuthenticate(
+      config,
+      recordingProjection({
+        lastCompletedUuid: 'leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'coder-model',
+          authType: AuthType.QWEN_OAUTH,
+        },
+      }),
+      authenticate,
+    );
+
+    expect(authenticate).toHaveBeenCalledTimes(2);
+    expect(switchModel).toHaveBeenNthCalledWith(
+      1,
+      AuthType.QWEN_OAUTH,
+      'coder-model',
+      { requireCachedCredentials: true },
+    );
+    expect(switchModel).toHaveBeenNthCalledWith(
+      2,
+      AuthType.USE_OPENAI,
+      `$runtime|${AuthType.USE_OPENAI}|custom-runtime`,
+      undefined,
+    );
+  });
+
+  it('surfaces the settings-model auth error when rollback authentication also fails', async () => {
+    let currentAuth: string | undefined = AuthType.USE_OPENAI;
+    let currentModel = 'settings-default';
+    const switchModel = vi.fn(
+      async (authType: string, modelId: string): Promise<void> => {
+        currentAuth = authType;
+        currentModel = modelId;
+      },
+    );
+    const authenticate = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('oauth expired'))
+      .mockRejectedValueOnce(new Error('settings auth failed'));
+    const config = {
+      getModel: vi.fn(() => currentModel),
+      getAuthType: vi.fn(() => currentAuth),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await expect(
+      restoreSessionModelThenAuthenticate(
+        config,
+        recordingProjection({
+          lastCompletedUuid: 'leaf',
+          turnParentUuids: [null],
+          sessionModel: {
+            modelId: 'coder-model',
+            authType: AuthType.QWEN_OAUTH,
+          },
+        }),
+        authenticate,
+      ),
+    ).rejects.toThrow('settings auth failed');
+
+    expect(authenticate).toHaveBeenCalledTimes(2);
+    expect(switchModel).toHaveBeenNthCalledWith(
+      2,
+      AuthType.USE_OPENAI,
+      'settings-default',
+      undefined,
+    );
+  });
+
+  it('surfaces the restored auth error when rollback switchModel fails', async () => {
+    let currentAuth: string | undefined = AuthType.USE_OPENAI;
+    let currentModel = 'settings-default';
+    const switchModel = vi.fn(
+      async (authType: string, modelId: string): Promise<void> => {
+        if (modelId === 'settings-default') {
+          throw new Error('Model not found');
+        }
+        currentAuth = authType;
+        currentModel = modelId;
+      },
+    );
+    const authenticate = vi.fn().mockRejectedValue(new Error('oauth expired'));
+    const config = {
+      getModel: vi.fn(() => currentModel),
+      getAuthType: vi.fn(() => currentAuth),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+      getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      switchModel,
+    } as unknown as Config;
+
+    await expect(
+      restoreSessionModelThenAuthenticate(
+        config,
+        recordingProjection({
+          lastCompletedUuid: 'leaf',
+          turnParentUuids: [null],
+          sessionModel: {
+            modelId: 'coder-model',
+            authType: AuthType.QWEN_OAUTH,
+          },
+        }),
+        authenticate,
+      ),
+    ).rejects.toThrow('oauth expired');
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(switchModel).toHaveBeenNthCalledWith(
+      2,
+      AuthType.USE_OPENAI,
+      'settings-default',
+      undefined,
+    );
+  });
+
   it('marks the payload isRuntime when a runtime snapshot is active', async () => {
     const recordSessionModel = vi.fn().mockResolvedValue(true);
     const config = {

--- a/packages/cli/src/acp-integration/session-model-persistence.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.ts
@@ -6,8 +6,8 @@
 
 import {
   AuthType,
+  buildRuntimeSnapshotId,
   createDebugLogger,
-  RUNTIME_SNAPSHOT_PREFIX,
   stripRuntimeSnapshotPrefix,
   type Config,
   type SessionModelRecordPayload,
@@ -123,7 +123,7 @@ export async function applyRestoredSessionModel(
     Boolean(recorded?.isRuntime) &&
     hasMatchingRuntimeSnapshot(config, authType, targetModel);
   const switchModelId = useRuntimeSnapshot
-    ? `${RUNTIME_SNAPSHOT_PREFIX}${authType}|${targetModel}`
+    ? buildRuntimeSnapshotId(authType, targetModel)
     : targetModel;
   const requireCachedCredentials =
     authType === AuthType.QWEN_OAUTH && currentAuth !== authType;
@@ -159,13 +159,16 @@ export async function restoreSessionModelThenAuthenticate(
   const originalAuth = liveAuthType(config);
   const originalModel = config.getModel();
   const originalBaseUrl = config.getCurrentModelRegistryBaseUrl?.();
+  const originalRuntimeSnapshot = config.getActiveRuntimeModelSnapshot?.();
   await applyRestoredSessionModel(config, projection);
   try {
     await authenticate();
   } catch (error) {
     if (
       liveAuthType(config) === originalAuth &&
-      config.getModel() === originalModel
+      config.getModel() === originalModel &&
+      (config.getCurrentModelRegistryBaseUrl?.() ?? undefined) ===
+        (originalBaseUrl ?? undefined)
     ) {
       throw error;
     }
@@ -175,17 +178,26 @@ export async function restoreSessionModelThenAuthenticate(
     if (!originalAuth || !originalModel) {
       throw error;
     }
+    const rollbackModelId =
+      originalRuntimeSnapshot?.authType === originalAuth &&
+      originalRuntimeSnapshot.modelId ===
+        stripRuntimeSnapshotPrefix(originalModel)
+        ? buildRuntimeSnapshotId(
+            originalAuth,
+            stripRuntimeSnapshotPrefix(originalModel),
+          )
+        : originalModel;
     try {
       await config.switchModel(
         originalAuth as AuthType,
-        originalModel,
+        rollbackModelId,
         typeof originalBaseUrl === 'string'
           ? { baseUrl: originalBaseUrl }
           : undefined,
       );
-      await authenticate();
     } catch {
       throw error;
     }
+    await authenticate();
   }
 }

--- a/packages/cli/src/acp-integration/session-model-persistence.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.ts
@@ -85,6 +85,19 @@ function liveAuthType(config: Config): string | undefined {
   );
 }
 
+function runtimeSnapshotIdentity(
+  snapshot: { id?: string; authType?: string; modelId?: string } | undefined,
+): string | undefined {
+  if (!snapshot) return undefined;
+  if (typeof snapshot.id === 'string' && snapshot.id) {
+    return snapshot.id;
+  }
+  if (snapshot.authType && snapshot.modelId) {
+    return buildRuntimeSnapshotId(snapshot.authType, snapshot.modelId);
+  }
+  return undefined;
+}
+
 function recordedRouteMatches(
   recorded: SessionModelRecordPayload | undefined,
   currentRegistryBaseUrl: string | null | undefined,
@@ -201,7 +214,9 @@ export async function restoreSessionModelThenAuthenticate(
       liveAuthType(config) === originalAuth &&
       config.getModel() === originalModel &&
       (config.getCurrentModelRegistryBaseUrl?.() ?? undefined) ===
-        (originalBaseUrl ?? undefined)
+        (originalBaseUrl ?? undefined) &&
+      runtimeSnapshotIdentity(config.getActiveRuntimeModelSnapshot?.()) ===
+        runtimeSnapshotIdentity(originalRuntimeSnapshot)
     ) {
       throw error;
     }

--- a/packages/cli/src/acp-integration/session-model-persistence.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.ts
@@ -7,23 +7,14 @@
 import {
   AuthType,
   createDebugLogger,
+  RUNTIME_SNAPSHOT_PREFIX,
+  stripRuntimeSnapshotPrefix,
   type Config,
   type SessionModelRecordPayload,
   type SessionRestoreProjection,
 } from '@qwen-code/qwen-code-core';
 
 const debugLogger = createDebugLogger('SESSION_MODEL');
-const RUNTIME_SNAPSHOT_PREFIX = '$runtime|';
-
-function canonicalModelId(modelId: string): string {
-  let id = modelId;
-  while (id.startsWith(RUNTIME_SNAPSHOT_PREFIX)) {
-    const stripped = id.split('|').slice(2).join('|');
-    if (!stripped) break;
-    id = stripped;
-  }
-  return id;
-}
 
 export async function recordDaemonSessionModel(
   config: Config,
@@ -100,9 +91,9 @@ export async function applyRestoredSessionModel(
   const modelId = recorded?.modelId || fallbackModel;
   if (!modelId?.trim() || !authType) return;
 
-  const currentModel = canonicalModelId(config.getModel() ?? '');
+  const currentModel = stripRuntimeSnapshotPrefix(config.getModel() ?? '');
   const currentAuth = config.getAuthType();
-  const targetModel = canonicalModelId(modelId.trim());
+  const targetModel = stripRuntimeSnapshotPrefix(modelId.trim());
   const targetBaseUrl = recorded?.baseUrl;
   const currentRegistryBaseUrl = config.getCurrentModelRegistryBaseUrl?.();
   const baseUrlMatches = recordedRouteMatches(recorded, currentRegistryBaseUrl);

--- a/packages/cli/src/acp-integration/session-model-persistence.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  AuthType,
+  createDebugLogger,
+  type Config,
+  type SessionModelRecordPayload,
+  type SessionRestoreProjection,
+} from '@qwen-code/qwen-code-core';
+
+const debugLogger = createDebugLogger('SESSION_MODEL');
+const RUNTIME_SNAPSHOT_PREFIX = '$runtime|';
+
+function canonicalModelId(modelId: string): string {
+  let id = modelId;
+  while (id.startsWith(RUNTIME_SNAPSHOT_PREFIX)) {
+    const stripped = id.split('|').slice(2).join('|');
+    if (!stripped) break;
+    id = stripped;
+  }
+  return id;
+}
+
+export async function recordDaemonSessionModel(
+  config: Config,
+  payload: SessionModelRecordPayload,
+): Promise<void> {
+  const recording = config.getChatRecordingService?.();
+  if (!recording?.recordSessionModel) return;
+  try {
+    await recording.recordSessionModel(payload);
+  } catch (error) {
+    debugLogger.debug('recordSessionModel failed', error);
+  }
+}
+
+export async function recordDaemonSessionModelFromConfig(
+  config: Config,
+): Promise<void> {
+  const modelId = config.getModel()?.trim();
+  const authType = config.getAuthType();
+  if (!modelId || !authType) return;
+  const snapshot = config.getActiveRuntimeModelSnapshot?.();
+  // `null` is the implicit-registry sentinel; do not coerce it to the resolved
+  // default endpoint or restore can pick an explicit same-id route.
+  const registryBaseUrl = snapshot
+    ? undefined
+    : config.getCurrentModelRegistryBaseUrl?.();
+  await recordDaemonSessionModel(config, {
+    modelId,
+    authType,
+    ...(typeof registryBaseUrl === 'string'
+      ? { baseUrl: registryBaseUrl }
+      : {}),
+    ...(snapshot ? { isRuntime: true } : {}),
+  });
+}
+
+function hasMatchingRuntimeSnapshot(
+  config: Config,
+  authType: string,
+  modelId: string,
+): boolean {
+  const snapshot = config.getActiveRuntimeModelSnapshot?.();
+  return snapshot?.authType === authType && snapshot.modelId === modelId;
+}
+
+function recordedRouteMatches(
+  recorded: SessionModelRecordPayload | undefined,
+  currentRegistryBaseUrl: string | null | undefined,
+): boolean {
+  if (!recorded || recorded.isRuntime) return true;
+  const targetBaseUrl = recorded.baseUrl;
+  if (targetBaseUrl === undefined) {
+    return (
+      currentRegistryBaseUrl === null || currentRegistryBaseUrl === undefined
+    );
+  }
+  if (targetBaseUrl === '') {
+    return (
+      currentRegistryBaseUrl === null ||
+      currentRegistryBaseUrl === undefined ||
+      currentRegistryBaseUrl === ''
+    );
+  }
+  return currentRegistryBaseUrl === targetBaseUrl;
+}
+
+export async function applyRestoredSessionModel(
+  config: Config,
+  projection: SessionRestoreProjection | undefined,
+): Promise<void> {
+  const recorded = projection?.runtime.recording.sessionModel;
+  const fallbackModel = projection?.runtime.recording.lastAssistantModel;
+  const authType = recorded?.authType || config.getAuthType();
+  const modelId = recorded?.modelId || fallbackModel;
+  if (!modelId?.trim() || !authType) return;
+
+  const currentModel = canonicalModelId(config.getModel() ?? '');
+  const currentAuth = config.getAuthType();
+  const targetModel = canonicalModelId(modelId.trim());
+  const targetBaseUrl = recorded?.baseUrl;
+  const currentRegistryBaseUrl = config.getCurrentModelRegistryBaseUrl?.();
+  const baseUrlMatches = recordedRouteMatches(recorded, currentRegistryBaseUrl);
+  const currentRuntimeMatches = hasMatchingRuntimeSnapshot(
+    config,
+    authType,
+    targetModel,
+  );
+  // Same id/auth/route is not a no-op when the record is implicit registry
+  // but Config currently holds a same-id runtime snapshot.
+  if (
+    currentModel === targetModel &&
+    currentAuth === authType &&
+    baseUrlMatches &&
+    !(recorded && !recorded.isRuntime && currentRuntimeMatches)
+  ) {
+    return;
+  }
+
+  const useRuntimeSnapshot =
+    Boolean(recorded?.isRuntime) &&
+    hasMatchingRuntimeSnapshot(config, authType, targetModel);
+  const switchModelId = useRuntimeSnapshot
+    ? `${RUNTIME_SNAPSHOT_PREFIX}${authType}|${targetModel}`
+    : targetModel;
+  const requireCachedCredentials =
+    authType === AuthType.QWEN_OAUTH && currentAuth !== authType;
+  const switchOptions =
+    targetBaseUrl || requireCachedCredentials
+      ? {
+          ...(targetBaseUrl ? { baseUrl: targetBaseUrl } : {}),
+          ...(requireCachedCredentials
+            ? { requireCachedCredentials: true }
+            : {}),
+        }
+      : undefined;
+  try {
+    await config.switchModel(
+      authType as AuthType,
+      switchModelId,
+      switchOptions,
+    );
+  } catch (error) {
+    debugLogger.warn(
+      `restore session model failed (${targetModel}/${authType}): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/packages/cli/src/acp-integration/session-model-persistence.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.ts
@@ -15,6 +15,25 @@ import {
 } from '@qwen-code/qwen-code-core';
 
 const debugLogger = createDebugLogger('SESSION_MODEL');
+const AUTH_TYPES = new Set<string>(Object.values(AuthType));
+
+function isAuthType(value: string): value is AuthType {
+  return AUTH_TYPES.has(value);
+}
+
+function registryHonoredBaseUrl(
+  config: Config,
+  authType: AuthType,
+  modelId: string,
+  baseUrl: string | undefined,
+): string | undefined {
+  if (typeof baseUrl !== 'string' || !baseUrl) {
+    return undefined;
+  }
+  return config.getResolvedModelConfig?.(authType, modelId, baseUrl)
+    ? baseUrl
+    : undefined;
+}
 
 export async function recordDaemonSessionModel(
   config: Config,
@@ -93,16 +112,34 @@ export async function applyRestoredSessionModel(
 ): Promise<void> {
   const recorded = projection?.runtime.recording.sessionModel;
   const fallbackModel = projection?.runtime.recording.lastAssistantModel;
-  const authType = (recorded?.authType || liveAuthType(config))?.trim();
+  const recordedAuth = recorded?.authType?.trim();
+  const authType = (
+    recordedAuth && isAuthType(recordedAuth)
+      ? recordedAuth
+      : liveAuthType(config)
+  )?.trim();
   const modelId = recorded?.modelId || fallbackModel;
-  if (!modelId?.trim() || !authType) return;
+  if (!modelId?.trim() || !authType || !isAuthType(authType)) return;
 
   const currentModel = stripRuntimeSnapshotPrefix(config.getModel() ?? '');
   const currentAuth = liveAuthType(config);
   const targetModel = stripRuntimeSnapshotPrefix(modelId.trim());
-  const targetBaseUrl = recorded?.baseUrl;
+  const targetBaseUrl = recorded?.isRuntime
+    ? undefined
+    : registryHonoredBaseUrl(config, authType, targetModel, recorded?.baseUrl);
+  const recordedRoute = recorded
+    ? {
+        ...recorded,
+        ...(targetBaseUrl
+          ? { baseUrl: targetBaseUrl }
+          : { baseUrl: undefined }),
+      }
+    : undefined;
   const currentRegistryBaseUrl = config.getCurrentModelRegistryBaseUrl?.();
-  const baseUrlMatches = recordedRouteMatches(recorded, currentRegistryBaseUrl);
+  const baseUrlMatches = recordedRouteMatches(
+    recordedRoute,
+    currentRegistryBaseUrl,
+  );
   const currentRuntimeMatches = hasMatchingRuntimeSnapshot(
     config,
     authType,
@@ -137,11 +174,7 @@ export async function applyRestoredSessionModel(
         }
       : undefined;
   try {
-    await config.switchModel(
-      authType as AuthType,
-      switchModelId,
-      switchOptions,
-    );
+    await config.switchModel(authType, switchModelId, switchOptions);
   } catch (error) {
     debugLogger.warn(
       `restore session model failed (${targetModel}/${authType}): ${

--- a/packages/cli/src/acp-integration/session-model-persistence.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.ts
@@ -60,6 +60,12 @@ function hasMatchingRuntimeSnapshot(
   return snapshot?.authType === authType && snapshot.modelId === modelId;
 }
 
+function liveAuthType(config: Config): string | undefined {
+  return (
+    config.getAuthType() ?? config.getModelsConfig?.()?.getCurrentAuthType?.()
+  );
+}
+
 function recordedRouteMatches(
   recorded: SessionModelRecordPayload | undefined,
   currentRegistryBaseUrl: string | null | undefined,
@@ -87,12 +93,12 @@ export async function applyRestoredSessionModel(
 ): Promise<void> {
   const recorded = projection?.runtime.recording.sessionModel;
   const fallbackModel = projection?.runtime.recording.lastAssistantModel;
-  const authType = recorded?.authType || config.getAuthType();
+  const authType = (recorded?.authType || liveAuthType(config))?.trim();
   const modelId = recorded?.modelId || fallbackModel;
   if (!modelId?.trim() || !authType) return;
 
   const currentModel = stripRuntimeSnapshotPrefix(config.getModel() ?? '');
-  const currentAuth = config.getAuthType();
+  const currentAuth = liveAuthType(config);
   const targetModel = stripRuntimeSnapshotPrefix(modelId.trim());
   const targetBaseUrl = recorded?.baseUrl;
   const currentRegistryBaseUrl = config.getCurrentModelRegistryBaseUrl?.();
@@ -142,5 +148,44 @@ export async function applyRestoredSessionModel(
         error instanceof Error ? error.message : String(error)
       }`,
     );
+  }
+}
+
+export async function restoreSessionModelThenAuthenticate(
+  config: Config,
+  projection: SessionRestoreProjection | undefined,
+  authenticate: () => Promise<void>,
+): Promise<void> {
+  const originalAuth = liveAuthType(config);
+  const originalModel = config.getModel();
+  const originalBaseUrl = config.getCurrentModelRegistryBaseUrl?.();
+  await applyRestoredSessionModel(config, projection);
+  try {
+    await authenticate();
+  } catch (error) {
+    if (
+      liveAuthType(config) === originalAuth &&
+      config.getModel() === originalModel
+    ) {
+      throw error;
+    }
+    debugLogger.warn(
+      'restored session model made authentication fail; retrying with settings model',
+    );
+    if (!originalAuth || !originalModel) {
+      throw error;
+    }
+    try {
+      await config.switchModel(
+        originalAuth as AuthType,
+        originalModel,
+        typeof originalBaseUrl === 'string'
+          ? { baseUrl: originalBaseUrl }
+          : undefined,
+      );
+      await authenticate();
+    } catch {
+      throw error;
+    }
   }
 }

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -3394,6 +3394,20 @@ describe('Session', () => {
       });
     });
 
+    it('persists a runtime-snapshot switch with the isRuntime payload flag', async () => {
+      const snapshotId = `$runtime|${AuthType.USE_OPENAI}|custom-runtime`;
+      await session.setModel({
+        sessionId: 'test-session-id',
+        modelId: `${snapshotId}(${AuthType.USE_OPENAI})`,
+      });
+
+      expect(mockChatRecordingService.recordSessionModel).toHaveBeenCalledWith({
+        modelId: snapshotId,
+        authType: AuthType.USE_OPENAI,
+        isRuntime: true,
+      });
+    });
+
     it('emits a current_model_update extNotification after switching (A1)', async () => {
       await session.setModel({
         sessionId: 'test-session-id',
@@ -3481,6 +3495,11 @@ describe('Session', () => {
             baseUrl: 'https://two.example/v1',
           },
         },
+      });
+      expect(mockChatRecordingService.recordSessionModel).toHaveBeenCalledWith({
+        modelId: 'shared-model',
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://two.example/v1',
       });
     });
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -437,6 +437,7 @@ describe('Session', () => {
     getBranchCheckpointCursor: ReturnType<typeof vi.fn>;
     recordBranchCheckpointTransaction: ReturnType<typeof vi.fn>;
     flush: ReturnType<typeof vi.fn>;
+    recordSessionModel: ReturnType<typeof vi.fn>;
   };
   let mockFileHistoryService: {
     makeSnapshot: ReturnType<typeof vi.fn>;
@@ -714,6 +715,7 @@ describe('Session', () => {
       }),
       recordBranchCheckpointTransaction: vi.fn().mockResolvedValue(undefined),
       flush: vi.fn().mockResolvedValue(undefined),
+      recordSessionModel: vi.fn().mockResolvedValue(true),
     };
     mockGoalRuntime = {
       getSnapshot: vi.fn().mockReturnValue({
@@ -3386,6 +3388,10 @@ describe('Session', () => {
         'security.auth.selectedType',
         AuthType.USE_OPENAI,
       );
+      expect(mockChatRecordingService.recordSessionModel).toHaveBeenCalledWith({
+        modelId: 'qwen3-coder-plus',
+        authType: AuthType.USE_OPENAI,
+      });
     });
 
     it('emits a current_model_update extNotification after switching (A1)', async () => {
@@ -3583,6 +3589,10 @@ describe('Session', () => {
         undefined,
       );
       expect(mockSettings.setValue).not.toHaveBeenCalled();
+      expect(mockChatRecordingService.recordSessionModel).toHaveBeenCalledWith({
+        modelId: 'qwen3-coder-flash',
+        authType: AuthType.USE_OPENAI,
+      });
     });
 
     it('propagates errors from config.switchModel', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -58,6 +58,7 @@ import {
   AuthType,
   ApprovalMode,
   CompressionStatus,
+  RUNTIME_SNAPSHOT_PREFIX,
   detectLoopSentinel,
   detectAutonomousSentinel,
   LoopTickResolver,
@@ -8752,7 +8753,8 @@ export class Session implements SessionContext {
     const effectiveAuthType = after?.authType ?? selectedAuthType;
     const effectiveModelId = after?.model ?? parsed.modelId;
     const isRuntime =
-      resolvedRoute?.isRuntime ?? rawModelId.startsWith('$runtime|');
+      resolvedRoute?.isRuntime ??
+      rawModelId.startsWith(RUNTIME_SNAPSHOT_PREFIX);
     void recordDaemonSessionModel(this.config, {
       modelId: isRuntime
         ? (resolvedRoute?.modelId ?? parsed.modelId)
@@ -8825,7 +8827,8 @@ export class Session implements SessionContext {
           baseUrl: after?.baseUrl ?? '(default)',
           apiKey: maskApiKeyForDisplay(after?.apiKey),
           isRuntime:
-            resolvedRoute?.isRuntime ?? rawModelId.startsWith('$runtime|'),
+            resolvedRoute?.isRuntime ??
+            rawModelId.startsWith(RUNTIME_SNAPSHOT_PREFIX),
         },
       },
     };

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -294,6 +294,7 @@ import {
 } from '../../utils/acpModelUtils.js';
 import { classifyApiError } from '../../utils/classify-api-error.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
+import { recordDaemonSessionModel } from '../session-model-persistence.js';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import {
   buildExtensionMentionContext,
@@ -8750,6 +8751,18 @@ export class Session implements SessionContext {
     const after = this.config.getContentGeneratorConfig?.();
     const effectiveAuthType = after?.authType ?? selectedAuthType;
     const effectiveModelId = after?.model ?? parsed.modelId;
+    const isRuntime =
+      resolvedRoute?.isRuntime ?? rawModelId.startsWith('$runtime|');
+    void recordDaemonSessionModel(this.config, {
+      modelId: isRuntime
+        ? (resolvedRoute?.modelId ?? parsed.modelId)
+        : effectiveModelId,
+      authType: effectiveAuthType,
+      ...(resolvedRoute && !isRuntime && resolvedRoute.baseUrl !== undefined
+        ? { baseUrl: resolvedRoute.baseUrl ?? '' }
+        : {}),
+      ...(isRuntime ? { isRuntime: true } : {}),
+    });
     const activeRuntimeSnapshot = this.config.getActiveRuntimeModelSnapshot?.();
     const currentAcpModelId = getCurrentAcpModelId(
       buildAcpModelOptions(this.config.getAllConfiguredModels()),

--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -1110,6 +1110,24 @@ describe('HistoryReplayer', () => {
       expect(sendUpdateSpy).not.toHaveBeenCalled();
     });
 
+    it('skips session_model system records', async () => {
+      const systemRecord: ChatRecord = {
+        uuid: 'system-uuid',
+        parentUuid: null,
+        sessionId: 'test-session',
+        timestamp: new Date().toISOString(),
+        type: 'system',
+        subtype: 'session_model',
+        cwd: '/test',
+        version: '1.0.0',
+        systemPayload: { modelId: 'qwen3-coder-plus', authType: 'openai' },
+      };
+
+      await replayer.replay([systemRecord]);
+
+      expect(sendUpdateSpy).not.toHaveBeenCalled();
+    });
+
     it('preserves slash-command provenance when replaying results', async () => {
       const systemRecord: ChatRecord = {
         uuid: 'system-uuid',

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -266,7 +266,10 @@ describe('modelCommand', () => {
 
   it('records the session model in ACP mode after switching', async () => {
     const setValue = vi.fn();
-    const switchModel = vi.fn().mockResolvedValue(undefined);
+    let currentModel = 'old-model';
+    const switchModel = vi.fn().mockImplementation(async () => {
+      currentModel = 'qwen-max';
+    });
     const recordSessionModel = vi.fn().mockResolvedValue(true);
     mockContext = createMockCommandContext({
       executionMode: 'acp',
@@ -281,7 +284,7 @@ describe('modelCommand', () => {
             .fn()
             .mockReturnValue([{ id: 'qwen-max', label: 'Qwen Max' }]),
           switchModel,
-          getModel: vi.fn().mockReturnValue('qwen-max'),
+          getModel: vi.fn(() => currentModel),
           getAuthType: vi.fn().mockReturnValue(AuthType.QWEN_OAUTH),
           getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
           getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
@@ -295,7 +298,9 @@ describe('modelCommand', () => {
 
     await modelCommand.action!(mockContext, 'qwen-max');
 
-    expect(switchModel).toHaveBeenCalled();
+    expect(switchModel.mock.invocationCallOrder[0]).toBeLessThan(
+      recordSessionModel.mock.invocationCallOrder[0],
+    );
     expect(recordSessionModel).toHaveBeenCalledWith({
       modelId: 'qwen-max',
       authType: AuthType.QWEN_OAUTH,

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -215,6 +215,7 @@ describe('modelCommand', () => {
   it('should switch the main model directly in interactive mode when args are provided', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn().mockResolvedValue(undefined);
+    const recordSessionModel = vi.fn().mockResolvedValue(true);
     mockContext = createMockCommandContext({
       invocation: { raw: '/model qwen-max', name: 'model', args: 'qwen-max' },
       services: {
@@ -227,6 +228,9 @@ describe('modelCommand', () => {
             .fn()
             .mockReturnValue([{ id: 'qwen-max', label: 'Qwen Max' }]),
           switchModel,
+          getChatRecordingService: vi.fn().mockReturnValue({
+            recordSessionModel,
+          }),
         },
         settings: createMockSettings(setValue),
       },
@@ -256,6 +260,45 @@ describe('modelCommand', () => {
       type: 'message',
       messageType: 'info',
       content: 'Model: qwen-max',
+    });
+    expect(recordSessionModel).not.toHaveBeenCalled();
+  });
+
+  it('records the session model in ACP mode after switching', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const recordSessionModel = vi.fn().mockResolvedValue(true);
+    mockContext = createMockCommandContext({
+      executionMode: 'acp',
+      invocation: { raw: '/model qwen-max', name: 'model', args: 'qwen-max' },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-max',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'qwen-max', label: 'Qwen Max' }]),
+          switchModel,
+          getModel: vi.fn().mockReturnValue('qwen-max'),
+          getAuthType: vi.fn().mockReturnValue(AuthType.QWEN_OAUTH),
+          getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
+          getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
+          getChatRecordingService: vi.fn().mockReturnValue({
+            recordSessionModel,
+          }),
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    await modelCommand.action!(mockContext, 'qwen-max');
+
+    expect(switchModel).toHaveBeenCalled();
+    expect(recordSessionModel).toHaveBeenCalledWith({
+      modelId: 'qwen-max',
+      authType: AuthType.QWEN_OAUTH,
     });
   });
 

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -27,6 +27,7 @@ import {
   isInlineModelOverrideAllowed,
   parseAcpModelOption,
 } from '../../utils/acpModelUtils.js';
+import { recordDaemonSessionModelFromConfig } from '../../acp-integration/session-model-persistence.js';
 import {
   formatUnsupportedVoiceModelMessage,
   isSelectableVoiceModel,
@@ -1133,6 +1134,9 @@ export const modelCommand: SlashCommand = {
         modelName,
         scopeOverride,
       );
+      if (context.executionMode === 'acp') {
+        await recordDaemonSessionModelFromConfig(config);
+      }
       return {
         type: 'message',
         messageType: 'info',

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -12,7 +12,10 @@ import type { ContentGeneratorConfigSources } from '../core/contentGenerator.js'
 import { DEFAULT_QWEN_MODEL } from '../config/models.js';
 import { tokenLimit } from '../core/tokenLimits.js';
 import { defaultModalities } from '../core/modalityDefaults.js';
-import { RUNTIME_SNAPSHOT_PREFIX } from '../utils/runtimeModelPrefix.js';
+import {
+  RUNTIME_SNAPSHOT_PREFIX,
+  buildRuntimeSnapshotId,
+} from '../utils/runtimeModelPrefix.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 import { ModelRegistry } from './modelRegistry.js';
@@ -578,7 +581,7 @@ export class ModelsConfig {
     authType: AuthType,
     modelId: string,
   ): string {
-    return `${RUNTIME_SNAPSHOT_PREFIX}${authType}|${modelId}`;
+    return buildRuntimeSnapshotId(authType, modelId);
   }
 
   /**

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -2668,6 +2668,111 @@ describe('ChatRecordingService', () => {
       ).resolves.toBe(true);
       expect(jsonl.writeLine).not.toHaveBeenCalled();
     });
+
+    it('writes a second record when only the isRuntime flag differs', async () => {
+      await chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+      });
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+          isRuntime: true,
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).toHaveBeenCalledOnce();
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record.systemPayload).toEqual({
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+        isRuntime: true,
+      });
+    });
+
+    it('writes a new record when only the baseUrl differs', async () => {
+      await chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+        baseUrl: 'https://a.example/v1',
+      });
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+          baseUrl: 'https://b.example/v1',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).toHaveBeenCalledOnce();
+    });
+
+    it('skips a payload identical on the isRuntime and baseUrl dimensions', async () => {
+      await chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+        baseUrl: 'https://a.example/v1',
+        isRuntime: true,
+      });
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+          baseUrl: 'https://a.example/v1',
+          isRuntime: true,
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+    });
+
+    it('re-anchors the pending new binding when a rewind lands mid-write', async () => {
+      chatRecordingService.recordUserMessage([{ text: 'first' }]);
+      await chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+      });
+      chatRecordingService.recordUserMessage([{ text: 'second' }]);
+
+      // Hold the next session_model write at the IO layer so the rewind
+      // lands inside the pending-write window.
+      vi.mocked(jsonl.writeLine).mockClear();
+      let releaseWrite: (() => void) | undefined;
+      vi.mocked(jsonl.writeLine).mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseWrite = resolve;
+          }),
+      );
+      const pendingSwitch = chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-flash',
+        authType: 'openai',
+      });
+      await vi.waitFor(() => {
+        expect(vi.mocked(jsonl.writeLine).mock.calls.length).toBe(1);
+      });
+
+      chatRecordingService.rewindRecording(1, { truncatedCount: 1 });
+      releaseWrite?.();
+      await pendingSwitch;
+      await chatRecordingService.flush();
+
+      const written = vi
+        .mocked(jsonl.writeLine)
+        .mock.calls.map((call) => call[1] as ChatRecord);
+      const rewindIndex = written.findIndex(
+        (record) => record.subtype === 'rewind',
+      );
+      expect(rewindIndex).toBeGreaterThanOrEqual(0);
+      const reAppended = written[rewindIndex + 1];
+      expect(reAppended?.subtype).toBe('session_model');
+      expect(reAppended?.parentUuid).toBe(written[rewindIndex]?.uuid);
+      expect(reAppended?.systemPayload).toEqual({
+        modelId: 'qwen3-coder-flash',
+        authType: 'openai',
+      });
+    });
   });
 
   describe('legacy recorder', () => {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -1131,6 +1131,75 @@ describe('ChatRecordingService', () => {
       ).resolves.toBe(true);
       expect(jsonl.writeLine).not.toHaveBeenCalled();
     });
+
+    it('restores session model bindings from a full-record replay', async () => {
+      vi.mocked(mockConfig.getResumedSessionData).mockReturnValue({
+        conversation: {
+          messages: [
+            {
+              uuid: 'model-1',
+              parentUuid: null,
+              sessionId: 'test-session-id',
+              timestamp: '2026-06-27T00:00:00.000Z',
+              type: 'system',
+              subtype: 'session_model',
+              cwd: '/test/project/root',
+              version: '1.0.0',
+              systemPayload: {
+                modelId: 'qwen3-coder-plus',
+                authType: 'openai',
+              },
+            },
+          ],
+        },
+        lastCompletedUuid: 'model-1',
+      } as unknown as ReturnType<Config['getResumedSessionData']>);
+      const service = new ChatRecordingService(mockConfig, undefined, false);
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        service.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+    });
+
+    it('skips a non-string session_model payload during full-record replay', async () => {
+      vi.mocked(mockConfig.getResumedSessionData).mockReturnValue({
+        conversation: {
+          messages: [
+            {
+              uuid: 'model-1',
+              parentUuid: null,
+              sessionId: 'test-session-id',
+              timestamp: '2026-06-27T00:00:00.000Z',
+              type: 'system',
+              subtype: 'session_model',
+              cwd: '/test/project/root',
+              version: '1.0.0',
+              systemPayload: {
+                modelId: 42,
+                authType: 'openai',
+              },
+            },
+          ],
+        },
+        lastCompletedUuid: 'model-1',
+      } as unknown as ReturnType<Config['getResumedSessionData']>);
+      expect(
+        () => new ChatRecordingService(mockConfig, undefined, false),
+      ).not.toThrow();
+      const service = new ChatRecordingService(mockConfig, undefined, false);
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        service.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).toHaveBeenCalledOnce();
+    });
   });
 
   describe('rewindRecording', () => {
@@ -2630,6 +2699,33 @@ describe('ChatRecordingService', () => {
       expect(jsonl.writeLine).toHaveBeenCalledOnce();
     });
 
+    it('canonicalizes a runtime-prefixed modelId before writing', async () => {
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: '$runtime|openai|custom-runtime',
+          authType: 'openai',
+          isRuntime: true,
+        }),
+      ).resolves.toBe(true);
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record.systemPayload).toEqual({
+        modelId: 'custom-runtime',
+        authType: 'openai',
+        isRuntime: true,
+      });
+
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: '$runtime|openai|custom-runtime',
+          authType: 'openai',
+          isRuntime: true,
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+    });
+
     it('re-anchors the live session model onto the rewind branch', async () => {
       chatRecordingService.recordUserMessage([{ text: 'first' }]);
       await chatRecordingService.recordSessionModel({
@@ -2850,6 +2946,30 @@ describe('ChatRecordingService', () => {
       service.recordUserMessage([{ text: 'legacy' }]);
       await service.flush();
 
+      expect(jsonl.writeLine).toHaveBeenCalledOnce();
+    });
+
+    it('retries an identical session_model payload after a synchronous failure', async () => {
+      const writeFileSpy = vi.spyOn(fs, 'writeFileSync');
+      writeFileSpy.mockImplementationOnce(() => {
+        throw Object.assign(new Error('ENOSPC'), { code: 'ENOSPC' });
+      });
+      const service = new ChatRecordingService(mockConfig, undefined, false);
+
+      await expect(
+        service.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(false);
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+
+      await expect(
+        service.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
       expect(jsonl.writeLine).toHaveBeenCalledOnce();
     });
 

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -1112,6 +1112,25 @@ describe('ChatRecordingService', () => {
       ).rejects.toMatchObject({ name: 'SessionWriterUnavailableError' });
       expect(jsonl.writeLine).not.toHaveBeenCalled();
     });
+
+    it('restores session model bindings for duplicate suppression', async () => {
+      const service = new ChatRecordingService(mockConfig, undefined, false, {
+        lastCompletedUuid: 'projected-leaf',
+        turnParentUuids: [null],
+        sessionModel: {
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        },
+      });
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        service.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+    });
   });
 
   describe('rewindRecording', () => {
@@ -2563,6 +2582,91 @@ describe('ChatRecordingService', () => {
       } finally {
         process.off('unhandledRejection', handler);
       }
+    });
+  });
+
+  describe('recordSessionModel', () => {
+    it('appends a session_model record and skips identical payloads', async () => {
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).toHaveBeenCalledOnce();
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record).toMatchObject({
+        type: 'system',
+        subtype: 'session_model',
+        systemPayload: {
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        },
+      });
+
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: 'qwen3-coder-plus',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
+    });
+
+    it('writes a new record when the model changes', async () => {
+      await chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+      });
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: 'qwen3-coder-flash',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).toHaveBeenCalledOnce();
+    });
+
+    it('re-anchors the live session model onto the rewind branch', async () => {
+      chatRecordingService.recordUserMessage([{ text: 'first' }]);
+      await chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+      });
+      chatRecordingService.recordUserMessage([{ text: 'second' }]);
+      await chatRecordingService.recordSessionModel({
+        modelId: 'qwen3-coder-flash',
+        authType: 'openai',
+      });
+      vi.mocked(jsonl.writeLine).mockClear();
+
+      chatRecordingService.rewindRecording(1, { truncatedCount: 1 });
+      await chatRecordingService.flush();
+
+      const written = vi
+        .mocked(jsonl.writeLine)
+        .mock.calls.map((call) => call[1] as ChatRecord);
+      expect(written.map((record) => record.subtype)).toEqual([
+        'rewind',
+        'session_model',
+      ]);
+      expect(written[1]?.parentUuid).toBe(written[0]?.uuid);
+      expect(written[1]?.systemPayload).toEqual({
+        modelId: 'qwen3-coder-flash',
+        authType: 'openai',
+      });
+
+      vi.mocked(jsonl.writeLine).mockClear();
+      await expect(
+        chatRecordingService.recordSessionModel({
+          modelId: 'qwen3-coder-flash',
+          authType: 'openai',
+        }),
+      ).resolves.toBe(true);
+      expect(jsonl.writeLine).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -25,6 +25,7 @@ import {
   toolResultPartDiagnosticValues,
 } from '../utils/tool-result-boundary-diagnostics.js';
 import { compactToolResultDisplayForRecording } from '../utils/toolResultDisplayCompaction.js';
+import { stripRuntimeSnapshotPrefix } from '../utils/runtimeModelPrefix.js';
 import type { AttributionSnapshot } from './commitAttribution.js';
 import { tryGenerateSessionTitle } from './sessionTitle.js';
 import type {
@@ -305,6 +306,7 @@ export interface ChatRecord {
     | 'custom_title'
     | 'parent_session'
     | 'session_source'
+    | 'session_model'
     | 'rewind'
     | 'agent_bootstrap'
     | 'agent_launch_prompt'
@@ -367,6 +369,7 @@ export interface ChatRecord {
     | CustomTitleRecordPayload
     | ParentSessionRecordPayload
     | SessionSourceRecordPayload
+    | SessionModelRecordPayload
     | NotificationRecordPayload
     | UserPromptRecordPayload
     | RewindRecordPayload
@@ -571,6 +574,42 @@ export interface ParentSessionRecordPayload {
 export interface SessionSourceRecordPayload {
   sourceType: string;
   sourceId?: string;
+}
+
+/** Last-wins binding of the model a daemon session should restore. */
+export interface SessionModelRecordPayload {
+  modelId: string;
+  authType: string;
+  baseUrl?: string;
+  isRuntime?: boolean;
+}
+
+export function normalizeSessionModelPayload(
+  payload: SessionModelRecordPayload,
+): SessionModelRecordPayload {
+  const normalized: SessionModelRecordPayload = {
+    modelId: stripRuntimeSnapshotPrefix(payload.modelId.trim()),
+    authType: payload.authType.trim(),
+  };
+  if (payload.baseUrl !== undefined) {
+    normalized.baseUrl = payload.baseUrl;
+  }
+  if (payload.isRuntime) {
+    normalized.isRuntime = true;
+  }
+  return normalized;
+}
+
+export function sessionModelPayloadsEqual(
+  a: SessionModelRecordPayload,
+  b: SessionModelRecordPayload,
+): boolean {
+  return (
+    a.modelId === b.modelId &&
+    a.authType === b.authType &&
+    (a.baseUrl ?? '') === (b.baseUrl ?? '') &&
+    Boolean(a.isRuntime) === Boolean(b.isRuntime)
+  );
 }
 
 /**
@@ -821,6 +860,7 @@ export interface ChatRecordingRestoreState {
   parentSessionId?: string;
   sourceType?: string;
   sourceId?: string;
+  sessionModel?: SessionModelRecordPayload;
 }
 
 /**
@@ -913,6 +953,8 @@ export class ChatRecordingService {
   /** Immutable creator attribution once recorded. */
   private currentSourceType: string | undefined;
   private currentSourceId: string | undefined;
+  /** Last-wins daemon session model binding, used to skip duplicate writes. */
+  private currentSessionModel: SessionModelRecordPayload | undefined;
   private readonly userDisplayTextsForTitle: Array<string | undefined> = [];
   /**
    * How many auto-title attempts have been made this process.
@@ -1090,6 +1132,7 @@ export class ChatRecordingService {
     this.currentParentSessionId = undefined;
     this.currentSourceType = undefined;
     this.currentSourceId = undefined;
+    this.currentSessionModel = undefined;
     this.activeBranchRecords = [];
     this.activeBranchBaseUuid = null;
     this.pendingBranchToolCalls = [];
@@ -1120,6 +1163,13 @@ export class ChatRecordingService {
           | undefined;
         this.currentSourceType = payload?.sourceType;
         this.currentSourceId = payload?.sourceId;
+      } else if (record.subtype === 'session_model') {
+        const payload = record.systemPayload as
+          | SessionModelRecordPayload
+          | undefined;
+        if (payload?.modelId && payload.authType) {
+          this.currentSessionModel = normalizeSessionModelPayload(payload);
+        }
       }
     }
     if (persistedTitleInfo !== undefined) {
@@ -1148,6 +1198,9 @@ export class ChatRecordingService {
     this.currentParentSessionId = state.parentSessionId;
     this.currentSourceType = state.sourceType;
     this.currentSourceId = state.sourceId;
+    this.currentSessionModel = state.sessionModel
+      ? normalizeSessionModelPayload(state.sessionModel)
+      : undefined;
     if (this.currentCustomTitle) {
       this.bytesSinceTitleAnchor = TITLE_REANCHOR_BYTES;
     }
@@ -2293,6 +2346,17 @@ export class ChatRecordingService {
 
       this.appendRecord(record);
 
+      // Last-wins session_model may now sit on the abandoned branch. Re-append
+      // the live binding so cold restore still sees the model Config is on.
+      if (this.currentSessionModel) {
+        this.appendRecord({
+          ...this.createBaseRecord('system'),
+          type: 'system',
+          subtype: 'session_model',
+          systemPayload: this.currentSessionModel,
+        });
+      }
+
       // Re-record surviving file history snapshots on the active branch so
       // they are visible to reconstructHistory on resume.
       if (survivingFileHistorySnapshots?.length) {
@@ -2510,6 +2574,38 @@ export class ChatRecordingService {
     } catch (error) {
       if (error !== this.writeFailure) {
         debugLogger.error('Error saving session source:', error);
+      }
+      return false;
+    }
+  }
+
+  /** Persist the daemon session's current model so load/resume can restore it. */
+  async recordSessionModel(
+    payload: SessionModelRecordPayload,
+  ): Promise<boolean> {
+    if (!payload.modelId.trim() || !payload.authType.trim()) {
+      return false;
+    }
+    const normalized = normalizeSessionModelPayload(payload);
+    if (
+      this.currentSessionModel &&
+      sessionModelPayloadsEqual(this.currentSessionModel, normalized)
+    ) {
+      return true;
+    }
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('system'),
+        type: 'system',
+        subtype: 'session_model',
+        systemPayload: normalized,
+      };
+      await this.appendRecordStrict(record);
+      this.currentSessionModel = normalized;
+      return true;
+    } catch (error) {
+      if (error !== this.writeFailure) {
+        debugLogger.error('Error saving session model record:', error);
       }
       return false;
     }

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -1167,7 +1167,12 @@ export class ChatRecordingService {
         const payload = record.systemPayload as
           | SessionModelRecordPayload
           | undefined;
-        if (payload?.modelId && payload.authType) {
+        if (
+          typeof payload?.modelId === 'string' &&
+          payload.modelId.trim() &&
+          typeof payload.authType === 'string' &&
+          payload.authType.trim()
+        ) {
           this.currentSessionModel = normalizeSessionModelPayload(payload);
         }
       }
@@ -2607,11 +2612,17 @@ export class ChatRecordingService {
       };
       // Assign before the awaited write so a rewind landing in the
       // pending-write window re-appends the new binding rather than the
-      // stale one. A failed strict write latches `writeFailure`
-      // permanently, so the optimistic state cannot cause a skipped write
-      // on a healthy recorder.
+      // stale one. Roll back on failure: ensureConversationFile can throw
+      // before writeFailure latches, and a later identical call would
+      // otherwise skip the write.
+      const previous = this.currentSessionModel;
       this.currentSessionModel = normalized;
-      await this.appendRecordStrict(record);
+      try {
+        await this.appendRecordStrict(record);
+      } catch (error) {
+        this.currentSessionModel = previous;
+        throw error;
+      }
       return true;
     } catch (error) {
       if (error !== this.writeFailure) {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -2583,7 +2583,12 @@ export class ChatRecordingService {
   async recordSessionModel(
     payload: SessionModelRecordPayload,
   ): Promise<boolean> {
-    if (!payload.modelId.trim() || !payload.authType.trim()) {
+    if (
+      typeof payload.modelId !== 'string' ||
+      !payload.modelId.trim() ||
+      typeof payload.authType !== 'string' ||
+      !payload.authType.trim()
+    ) {
       return false;
     }
     const normalized = normalizeSessionModelPayload(payload);
@@ -2600,8 +2605,13 @@ export class ChatRecordingService {
         subtype: 'session_model',
         systemPayload: normalized,
       };
-      await this.appendRecordStrict(record);
+      // Assign before the awaited write so a rewind landing in the
+      // pending-write window re-appends the new binding rather than the
+      // stale one. A failed strict write latches `writeFailure`
+      // permanently, so the optimistic state cannot cause a skipped write
+      // on a healthy recorder.
       this.currentSessionModel = normalized;
+      await this.appendRecordStrict(record);
       return true;
     } catch (error) {
       if (error !== this.writeFailure) {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -584,6 +584,18 @@ export interface SessionModelRecordPayload {
   isRuntime?: boolean;
 }
 
+export function isValidSessionModelPayload(
+  payload: unknown,
+): payload is SessionModelRecordPayload {
+  const candidate = payload as SessionModelRecordPayload | null | undefined;
+  return (
+    typeof candidate?.modelId === 'string' &&
+    Boolean(candidate.modelId.trim()) &&
+    typeof candidate.authType === 'string' &&
+    Boolean(candidate.authType.trim())
+  );
+}
+
 export function normalizeSessionModelPayload(
   payload: SessionModelRecordPayload,
 ): SessionModelRecordPayload {
@@ -1164,16 +1176,10 @@ export class ChatRecordingService {
         this.currentSourceType = payload?.sourceType;
         this.currentSourceId = payload?.sourceId;
       } else if (record.subtype === 'session_model') {
-        const payload = record.systemPayload as
-          | SessionModelRecordPayload
-          | undefined;
-        if (
-          typeof payload?.modelId === 'string' &&
-          payload.modelId.trim() &&
-          typeof payload.authType === 'string' &&
-          payload.authType.trim()
-        ) {
-          this.currentSessionModel = normalizeSessionModelPayload(payload);
+        if (isValidSessionModelPayload(record.systemPayload)) {
+          this.currentSessionModel = normalizeSessionModelPayload(
+            record.systemPayload,
+          );
         }
       }
     }
@@ -2588,12 +2594,7 @@ export class ChatRecordingService {
   async recordSessionModel(
     payload: SessionModelRecordPayload,
   ): Promise<boolean> {
-    if (
-      typeof payload.modelId !== 'string' ||
-      !payload.modelId.trim() ||
-      typeof payload.authType !== 'string' ||
-      !payload.authType.trim()
-    ) {
+    if (!isValidSessionModelPayload(payload)) {
       return false;
     }
     const normalized = normalizeSessionModelPayload(payload);

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -1693,6 +1693,30 @@ describe('SessionTranscriptReader', () => {
     );
   });
 
+  it('drops a trailing session_model payload that is not a usable string pair', async () => {
+    const validModel: ChatRecord = {
+      ...record('model-1', null, ''),
+      type: 'system',
+      subtype: 'session_model',
+      message: undefined,
+      systemPayload: { modelId: 'qwen3-coder-plus', authType: 'openai' },
+    };
+    const invalidModel = {
+      ...record('model-2', 'model-1', ''),
+      type: 'system' as const,
+      subtype: 'session_model',
+      message: undefined,
+      systemPayload: { modelId: 42, authType: 'openai' },
+    };
+    await writeRecords([validModel, invalidModel as unknown as ChatRecord]);
+
+    const projection = await new SessionTranscriptReader(
+      workspaceDir,
+    ).readRestoreProjection(sessionId, { replay: { kind: 'none' } });
+
+    expect(projection?.runtime.recording.sessionModel).toBeUndefined();
+  });
+
   it('preserves malformed compression failure behavior', async () => {
     await writeRecords([
       record('u1', null, 'prompt'),

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -1693,7 +1693,7 @@ describe('SessionTranscriptReader', () => {
     );
   });
 
-  it('drops a trailing session_model payload that is not a usable string pair', async () => {
+  it('keeps the last valid session_model when a trailing payload is unusable', async () => {
     const validModel: ChatRecord = {
       ...record('model-1', null, ''),
       type: 'system',
@@ -1709,6 +1709,26 @@ describe('SessionTranscriptReader', () => {
       systemPayload: { modelId: 42, authType: 'openai' },
     };
     await writeRecords([validModel, invalidModel as unknown as ChatRecord]);
+
+    const projection = await new SessionTranscriptReader(
+      workspaceDir,
+    ).readRestoreProjection(sessionId, { replay: { kind: 'none' } });
+
+    expect(projection?.runtime.recording.sessionModel).toEqual({
+      modelId: 'qwen3-coder-plus',
+      authType: 'openai',
+    });
+  });
+
+  it('drops a session_model payload that is not a usable string pair', async () => {
+    const invalidModel = {
+      ...record('model-1', null, ''),
+      type: 'system' as const,
+      subtype: 'session_model',
+      message: undefined,
+      systemPayload: { modelId: 42, authType: 'openai' },
+    };
+    await writeRecords([invalidModel as unknown as ChatRecord]);
 
     const projection = await new SessionTranscriptReader(
       workspaceDir,

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -1661,6 +1661,38 @@ describe('SessionTranscriptReader', () => {
     );
   });
 
+  it('captures lastAssistantModel on resume when a trailing compression excludes the last assistant record', async () => {
+    await writeRecords([
+      record('u1', null, 'prompt'),
+      {
+        ...record('a1', 'u1', 'answer'),
+        model: 'session-a-model',
+      },
+      {
+        ...record('compression', 'a1', ''),
+        type: 'system',
+        subtype: 'chat_compression',
+        message: undefined,
+        systemPayload: {
+          compressedHistory: [
+            { role: 'user', parts: [{ text: 'compressed prompt' }] },
+            { role: 'model', parts: [{ text: 'compressed answer' }] },
+          ],
+          info: { newTokenCount: 20, newTokenCountIsEstimated: false },
+        } as ChatRecord['systemPayload'],
+      },
+    ]);
+
+    const projection = await new SessionTranscriptReader(
+      workspaceDir,
+    ).readRestoreProjection(sessionId, { replay: { kind: 'none' } });
+
+    expect(projection?.runtime.recording.sessionModel).toBeUndefined();
+    expect(projection?.runtime.recording.lastAssistantModel).toBe(
+      'session-a-model',
+    );
+  });
+
   it('preserves malformed compression failure behavior', async () => {
     await writeRecords([
       record('u1', null, 'prompt'),

--- a/packages/core/src/services/session-transcript-reader.test.ts
+++ b/packages/core/src/services/session-transcript-reader.test.ts
@@ -1599,6 +1599,68 @@ describe('SessionTranscriptReader', () => {
     });
   });
 
+  it('restores the last session_model payload', async () => {
+    const firstModel: ChatRecord = {
+      ...record('model-1', null, ''),
+      type: 'system',
+      subtype: 'session_model',
+      message: undefined,
+      systemPayload: { modelId: 'old-model', authType: 'openai' },
+    };
+    const laterModel: ChatRecord = {
+      ...record('model-2', 'model-1', ''),
+      type: 'system',
+      subtype: 'session_model',
+      message: undefined,
+      systemPayload: {
+        modelId: 'qwen3-coder-plus',
+        authType: 'openai',
+        baseUrl: 'https://example.test/v1',
+      },
+    };
+    await writeRecords([
+      firstModel,
+      laterModel,
+      record('u1', 'model-2', 'prompt'),
+      {
+        ...record('a1', 'u1', 'answer'),
+        model: 'other-turn-model',
+      },
+    ]);
+
+    const projection = await new SessionTranscriptReader(
+      workspaceDir,
+    ).readRestoreProjection(sessionId, { replay: { kind: 'none' } });
+
+    expect(projection?.runtime.recording.sessionModel).toEqual({
+      modelId: 'qwen3-coder-plus',
+      authType: 'openai',
+      baseUrl: 'https://example.test/v1',
+    });
+    expect(projection?.runtime.recording.lastAssistantModel).toBe(
+      'other-turn-model',
+    );
+  });
+
+  it('captures lastAssistantModel when no session_model record exists', async () => {
+    await writeRecords([
+      record('u1', null, 'prompt'),
+      {
+        ...record('a1', 'u1', 'answer'),
+        model: 'session-a-model',
+      },
+    ]);
+
+    const projection = await new SessionTranscriptReader(
+      workspaceDir,
+    ).readRestoreProjection(sessionId, { replay: { kind: 'none' } });
+
+    expect(projection?.runtime.recording.sessionModel).toBeUndefined();
+    expect(projection?.runtime.recording.lastAssistantModel).toBe(
+      'session-a-model',
+    );
+  });
+
   it('preserves malformed compression failure behavior', async () => {
     await writeRecords([
       record('u1', null, 'prompt'),

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -22,6 +22,7 @@ import type {
   AttributionSnapshotPayload,
   ChatRecord,
   ParentSessionRecordPayload,
+  SessionModelRecordPayload,
   SessionSourceRecordPayload,
   TitleSource,
   UiTelemetryRecordPayload,
@@ -209,6 +210,8 @@ export interface SessionRuntimeResumeState {
     parentSessionId?: string;
     sourceType?: string;
     sourceId?: string;
+    sessionModel?: SessionModelRecordPayload;
+    lastAssistantModel?: string;
   };
   fileHistorySnapshots?: FileHistorySnapshot[];
   artifactSnapshot?: RebuiltSessionArtifactSnapshot;
@@ -2147,6 +2150,10 @@ export class SessionTranscriptReader {
       index,
       (entry) => entry.type === 'system' && entry.subtype === 'session_source',
     );
+    const sessionModelUuid = lastUuidMatching(
+      index,
+      (entry) => entry.type === 'system' && entry.subtype === 'session_model',
+    );
     const uiTelemetrySet = new Set(
       index.runtimeUuids.filter((uuid) => {
         const entry = index.byUuid.get(uuid);
@@ -2176,7 +2183,7 @@ export class SessionTranscriptReader {
     const artifactUuids = selectArtifactUuids(index);
     const artifactSet = new Set(artifactUuids);
     const metadataSet = new Set(
-      [parentSessionUuid, sessionSourceUuid].filter(
+      [parentSessionUuid, sessionSourceUuid, sessionModelUuid].filter(
         (uuid): uuid is string => uuid !== undefined,
       ),
     );
@@ -2200,6 +2207,8 @@ export class SessionTranscriptReader {
     let parentSessionId: string | undefined;
     let sourceType: string | undefined;
     let sourceId: string | undefined;
+    let sessionModel: SessionModelRecordPayload | undefined;
+    let lastAssistantModel: string | undefined;
     let firstRecord: ChatRecord | undefined;
     let firstRecordSeen = false;
     let goalCheckpointAccumulator:
@@ -2234,6 +2243,20 @@ export class SessionTranscriptReader {
           | undefined;
         sourceType = payload?.sourceType;
         sourceId = payload?.sourceId;
+      } else if (record.uuid === sessionModelUuid) {
+        const payload = record.systemPayload as
+          | SessionModelRecordPayload
+          | undefined;
+        if (payload?.modelId && payload.authType) {
+          sessionModel = payload;
+        }
+      }
+      if (
+        record.type === 'assistant' &&
+        typeof record.model === 'string' &&
+        record.model.trim()
+      ) {
+        lastAssistantModel = record.model;
       }
       if (fileHistorySet.has(record.uuid)) {
         try {
@@ -2482,6 +2505,8 @@ export class SessionTranscriptReader {
         ...(parentSessionId !== undefined ? { parentSessionId } : {}),
         ...(sourceType !== undefined ? { sourceType } : {}),
         ...(sourceId !== undefined ? { sourceId } : {}),
+        ...(sessionModel !== undefined ? { sessionModel } : {}),
+        ...(lastAssistantModel !== undefined ? { lastAssistantModel } : {}),
       },
       ...(restoredFileHistory
         ? { fileHistorySnapshots: restoredFileHistory }

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -2151,10 +2151,11 @@ export class SessionTranscriptReader {
       index,
       (entry) => entry.type === 'system' && entry.subtype === 'session_source',
     );
-    const sessionModelUuid = lastUuidMatching(
-      index,
-      (entry) => entry.type === 'system' && entry.subtype === 'session_model',
-    );
+    const sessionModelUuids = index.runtimeUuids.filter((uuid) => {
+      const entry = index.byUuid.get(uuid);
+      return entry?.type === 'system' && entry.subtype === 'session_model';
+    });
+    const sessionModelSet = new Set(sessionModelUuids);
     // The legacy-model fallback reads the last assistant record's `model`.
     // Without an explicit selection it is only dispatched when it happens to
     // land in the replay/model read sets, so on a resume whose tail is a
@@ -2196,7 +2197,7 @@ export class SessionTranscriptReader {
       [
         parentSessionUuid,
         sessionSourceUuid,
-        sessionModelUuid,
+        ...sessionModelUuids,
         lastAssistantUuid,
       ].filter((uuid): uuid is string => uuid !== undefined),
     );
@@ -2256,7 +2257,7 @@ export class SessionTranscriptReader {
           | undefined;
         sourceType = payload?.sourceType;
         sourceId = payload?.sourceId;
-      } else if (record.uuid === sessionModelUuid) {
+      } else if (sessionModelSet.has(record.uuid)) {
         if (isValidSessionModelPayload(record.systemPayload)) {
           sessionModel = record.systemPayload;
         }

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -18,14 +18,15 @@ import { readSessionTitleInfoFromFileSync } from '../utils/sessionStorageUtils.j
 import type { HistoryGap } from '../utils/conversation-chain.js';
 import { parseGoalStateRecordPayloadV2 } from '../goals/goal-reducer.js';
 import type { GoalStateRecordPayloadV2 } from '../goals/goal-protocol.js';
-import type {
-  AttributionSnapshotPayload,
-  ChatRecord,
-  ParentSessionRecordPayload,
-  SessionModelRecordPayload,
-  SessionSourceRecordPayload,
-  TitleSource,
-  UiTelemetryRecordPayload,
+import {
+  isValidSessionModelPayload,
+  type AttributionSnapshotPayload,
+  type ChatRecord,
+  type ParentSessionRecordPayload,
+  type SessionModelRecordPayload,
+  type SessionSourceRecordPayload,
+  type TitleSource,
+  type UiTelemetryRecordPayload,
 } from './chatRecordingService.js';
 import {
   isApiHistoryCompressionCandidate,
@@ -2256,16 +2257,8 @@ export class SessionTranscriptReader {
         sourceType = payload?.sourceType;
         sourceId = payload?.sourceId;
       } else if (record.uuid === sessionModelUuid) {
-        const payload = record.systemPayload as
-          | SessionModelRecordPayload
-          | undefined;
-        if (
-          typeof payload?.modelId === 'string' &&
-          payload.modelId.trim() &&
-          typeof payload.authType === 'string' &&
-          payload.authType.trim()
-        ) {
-          sessionModel = payload;
+        if (isValidSessionModelPayload(record.systemPayload)) {
+          sessionModel = record.systemPayload;
         }
       }
       if (

--- a/packages/core/src/services/session-transcript-reader.ts
+++ b/packages/core/src/services/session-transcript-reader.ts
@@ -2154,6 +2154,15 @@ export class SessionTranscriptReader {
       index,
       (entry) => entry.type === 'system' && entry.subtype === 'session_model',
     );
+    // The legacy-model fallback reads the last assistant record's `model`.
+    // Without an explicit selection it is only dispatched when it happens to
+    // land in the replay/model read sets, so on a resume whose tail is a
+    // chat_compression candidate the record is excluded and the fallback
+    // silently never fires.
+    const lastAssistantUuid = lastUuidMatching(
+      index,
+      (entry) => entry.type === 'assistant',
+    );
     const uiTelemetrySet = new Set(
       index.runtimeUuids.filter((uuid) => {
         const entry = index.byUuid.get(uuid);
@@ -2183,9 +2192,12 @@ export class SessionTranscriptReader {
     const artifactUuids = selectArtifactUuids(index);
     const artifactSet = new Set(artifactUuids);
     const metadataSet = new Set(
-      [parentSessionUuid, sessionSourceUuid, sessionModelUuid].filter(
-        (uuid): uuid is string => uuid !== undefined,
-      ),
+      [
+        parentSessionUuid,
+        sessionSourceUuid,
+        sessionModelUuid,
+        lastAssistantUuid,
+      ].filter((uuid): uuid is string => uuid !== undefined),
     );
     const apiHistory = new SessionApiHistoryAccumulator();
     const resumeTokenCounts = new ResumeTokenCountsAccumulator();
@@ -2247,7 +2259,12 @@ export class SessionTranscriptReader {
         const payload = record.systemPayload as
           | SessionModelRecordPayload
           | undefined;
-        if (payload?.modelId && payload.authType) {
+        if (
+          typeof payload?.modelId === 'string' &&
+          payload.modelId.trim() &&
+          typeof payload.authType === 'string' &&
+          payload.authType.trim()
+        ) {
           sessionModel = payload;
         }
       }

--- a/packages/core/src/utils/modelId.test.ts
+++ b/packages/core/src/utils/modelId.test.ts
@@ -6,7 +6,19 @@
 
 import { describe, expect, it } from 'vitest';
 import { AuthType } from '../core/contentGenerator.js';
-import { resolveModelId, stripRuntimeSnapshotPrefix } from './modelId.js';
+import {
+  buildRuntimeSnapshotId,
+  resolveModelId,
+  stripRuntimeSnapshotPrefix,
+} from './modelId.js';
+
+describe('buildRuntimeSnapshotId', () => {
+  it('builds the canonical $runtime|{auth}|{model} id', () => {
+    expect(buildRuntimeSnapshotId('openai', 'qwen3.6-27b-autoround')).toBe(
+      '$runtime|openai|qwen3.6-27b-autoround',
+    );
+  });
+});
 
 describe('stripRuntimeSnapshotPrefix', () => {
   it('returns bare model IDs unchanged', () => {

--- a/packages/core/src/utils/modelId.ts
+++ b/packages/core/src/utils/modelId.ts
@@ -43,6 +43,7 @@ const AUTH_TYPES = new Set<AuthType>(Object.values(AuthType));
 
 export {
   RUNTIME_SNAPSHOT_PREFIX,
+  buildRuntimeSnapshotId,
   stripRuntimeSnapshotPrefix,
 } from './runtimeModelPrefix.js';
 

--- a/packages/core/src/utils/runtimeModelPrefix.ts
+++ b/packages/core/src/utils/runtimeModelPrefix.ts
@@ -16,6 +16,14 @@
 /** Runtime model snapshot ID prefix; format `$runtime|${authType}|${modelId}`. */
 export const RUNTIME_SNAPSHOT_PREFIX = '$runtime|';
 
+/** Canonical RuntimeModelSnapshot id: `$runtime|{authType}|{modelId}`. */
+export function buildRuntimeSnapshotId(
+  authType: string,
+  modelId: string,
+): string {
+  return `${RUNTIME_SNAPSHOT_PREFIX}${authType}|${modelId}`;
+}
+
 /**
  * Recover the bare model ID from a (possibly runtime-prefixed) model string.
  * Strips every layer so nested prefixes self-heal; bare IDs pass through.

--- a/packages/core/src/utils/transcript-records.test.ts
+++ b/packages/core/src/utils/transcript-records.test.ts
@@ -157,6 +157,26 @@ describe('prepareTranscriptRecords', () => {
     );
   });
 
+  it('accepts session model metadata as a known record subtype', () => {
+    const prepared = prepareTranscriptRecords([
+      record('model', null, {
+        type: 'system',
+        subtype: 'session_model',
+        message: undefined,
+        systemPayload: { modelId: 'qwen3-coder-plus', authType: 'openai' },
+      }),
+      record('root', 'model'),
+    ]);
+
+    expect(prepared.diagnostics).not.toContainEqual(
+      expect.objectContaining({
+        code: 'unknown_record_or_part',
+        recordId: 'model',
+        path: 'subtype',
+      }),
+    );
+  });
+
   it('accepts the workflow agent retry marker as a known record subtype', () => {
     const prepared = prepareTranscriptRecords([
       record('root', null),

--- a/packages/core/src/utils/transcript-records.ts
+++ b/packages/core/src/utils/transcript-records.ts
@@ -126,6 +126,7 @@ const KNOWN_RECORD_SUBTYPES = new Set([
   'agent_retry',
   'file_history_snapshot',
   'session_source',
+  'session_model',
   'branch_checkpoint',
   'goal_state',
   'goal_runtime',


### PR DESCRIPTION
## What this PR does

Keeps each daemon session on the model it was created or last switched to across detach, idle reap, and daemon restart. Switching a session's model appends a last-wins `session_model` JSONL record. Empty sessions do not create a transcript; a session that never switched and has no assistant turn has no binding, so cold load uses the current settings default. Cold load/resume applies a recorded binding with `switchModel` before authentication. `settings.model.name` is still updated and remains the default for new sessions only. TUI and CLI `--resume` do not switch models from this record, and load/resume stay read-only.

Also covers two restore edge cases: an implicit registry binding still switches off a same-id runtime snapshot instead of no-op'ing, and rewind re-anchors the live binding onto the new active branch so last-wins still matches Config.

## Why it's needed

A model switch writes the process-wide new-session default. Switching away from an idle session typically detaches and closes it, so the next load/resume rebuilt Config from that default and session A came back on whatever model session B last used.

## Reviewer Test Plan

### How to verify

Unit tests (from the package directory, not the repo root):

```bash
cd packages/cli && npx vitest run src/acp-integration/session-model-persistence.test.ts src/acp-integration/acpAgent.test.ts src/acp-integration/session/Session.test.ts src/acp-integration/session/history-replayer.test.ts src/ui/commands/modelCommand.test.ts
cd packages/core && npx vitest run src/services/chatRecordingService.test.ts src/services/session-transcript-reader.test.ts src/utils/transcript-records.test.ts
```

Daemon behavior a reviewer should confirm:

1. Start the daemon. Open session A and note its model. Open session B and switch B to a different model.
2. Leave A idle long enough to detach, or restart the daemon, then load/resume A. A should still be on its original model; a new session should use B's model as the default.
3. `POST /session/:id/model` should persist for that session on the next cold load. Load/resume must not append JSONL.
4. Rewind after a model switch should still restore the live model (the binding is re-appended on the new branch).
5. TUI / CLI `--resume` should not switch models from this record.

### Evidence (Before & After)

N/A (daemon restore behavior covered by unit tests; no TUI surface change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A (unit tests only)

## Risk & Scope

- Main risk or tradeoff: cold restore calls `switchModel` before `ensureAuthenticated`; a failed switch is non-fatal and leaves the settings model. Runtime snapshots are restored only when a matching live snapshot still exists — credentials are not written to JSONL.
- Not validated / out of scope: TUI and CLI `--resume` model restore; approval-mode persistence; rebinding idle live sessions after `workspaceReload`; E2E daemon idle-reap timing.
- Breaking changes / migration notes: older transcripts without `session_model` fall back to the last assistant `model` (same auth), else settings. New `system` / `session_model` records are ignored by ordinary replay.

## Linked Issues

Fixes #9686

<details>
<summary>中文说明</summary>

## 这个 PR 做什么

让每个 daemon 会话在 detach、空闲回收和 daemon 重启之后，仍然使用它创建时或最后一次切换的模型。切换模型会向该会话 JSONL 追加一条 last-wins 的 `session_model` 记录。空会话不创建转录文件；从未切过模型且没有 assistant 记录的会话没有绑定，冷 load 使用当前 settings 默认。冷 load/resume 在鉴权之前用 `switchModel` 应用已记录的绑定。`settings.model.name` 仍会更新，但只作为**新建会话**的默认模型。TUI 和 CLI `--resume` 不会根据这条记录切模型，load/resume 保持只读、不追加 JSONL。

同时覆盖两个恢复边界：隐式 registry 绑定在当前 Config 持有同 id 的 runtime snapshot 时仍会 `switchModel`，而不是 no-op；rewind 会把内存里仍在用的绑定重新写到新活跃分支上，使 last-wins 与 Config 一致。

## 为什么需要

切模型会写入进程级的新建会话默认值。离开空闲会话通常会 detach 并关闭它，下一次 load/resume 会按该默认值重建 Config，于是会话 A 会变成会话 B 最后用的模型。

## 评审测试计划

### 如何验证

在对应 package 目录跑上面的单元测试（不要从仓库根目录跑 vitest）。评审还应确认：会话 A 用模型 A，切到 B 并改成模型 B，再冷打开 A 仍是 A；新建会话默认是 B；`POST /session/:id/model` 会按会话持久化；load/resume 不写 JSONL；rewind 后仍恢复当前绑定；TUI / CLI `--resume` 不切模型。

### 证据（改前 / 改后）

N/A（daemon 恢复行为由单测覆盖；无 TUI 表面变化）

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### 环境（可选）

N/A（仅单元测试）

## 风险与范围

- 主要风险或取舍：冷恢复在鉴权前调用 `switchModel`；失败只告警并留在 settings 模型上。runtime snapshot 仅在当前仍有匹配 snapshot 时恢复，凭证不会写入 JSONL。
- 未验证 / 不在范围内：TUI 与 CLI `--resume` 的模型恢复；approval-mode 持久化；`workspaceReload` 后给仍存活的空闲会话重新绑模型；daemon 空闲回收的 E2E 时序。
- 破坏性变更 / 迁移说明：没有 `session_model` 的旧转录回退到最后一条 assistant `model`（同一 auth），再否则用 settings。新增的 `system` / `session_model` 记录会被普通 replay 忽略。

## 关联 Issue

Fixes #9686

</details>

Made with [Cursor](https://cursor.com)
