### PR TITLE
fix(cli): keep in-flight tool calls pending during live session replay

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -11736,6 +11736,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.anything(),
       expect.anything(),
       gaps,
+      expect.anything(),
     );
 
     mockConnectionState.resolve();
@@ -12045,6 +12046,128 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(mockHistoryReplayPage).toHaveBeenLastCalledWith(
       expect.anything(),
       [],
+      expect.objectContaining({ finalizeDangling: true }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('live session load keeps dangling transcript calls in flight while a prompt is active', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    innerConfig.getSessionRuntimeBaseDir = vi
+      .fn()
+      .mockReturnValue('/tmp/qwen-runtime-test');
+    vi.mocked(SessionService).mockImplementation(
+      () =>
+        ({
+          readLiveRestoreProjection: vi.fn().mockResolvedValue({
+            replay: {
+              records: [{ role: 'user' }],
+              gaps: [],
+            },
+          }),
+        }) as unknown as InstanceType<typeof SessionService>,
+    );
+    mockHistoryReplay.mockResolvedValue(undefined);
+    const { agent, agentPromise } = await bootAcpAgent();
+    const loadSession = (params: Record<string, unknown>) =>
+      (
+        agent as unknown as {
+          loadSession: (p: Record<string, unknown>) => Promise<unknown>;
+        }
+      ).loadSession(params);
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    let finishPrompt: ((value: unknown) => void) | undefined;
+    lastSessionMock!.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishPrompt = resolve;
+        }),
+    );
+
+    const prompt = agent.prompt({ sessionId: VALID_SESSION_ID, prompt: [] });
+    await vi.waitFor(() => expect(lastSessionMock!.prompt).toHaveBeenCalled());
+
+    await loadSession({
+      cwd: '/tmp',
+      sessionId: VALID_SESSION_ID,
+      mcpServers: [],
+    });
+    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ finalizeDangling: false }),
+    );
+
+    finishPrompt?.({ stopReason: 'end_turn' });
+    await prompt;
+
+    await loadSession({
+      cwd: '/tmp',
+      sessionId: VALID_SESSION_ID,
+      mcpServers: [],
+    });
+    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ finalizeDangling: true }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/session/loadUpdates keeps dangling transcript calls in flight while a prompt is active', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    innerConfig.getSessionRuntimeBaseDir = vi
+      .fn()
+      .mockReturnValue('/tmp/qwen-runtime-test');
+    mockSessionServiceLoad({
+      conversation: {
+        messages: [{ role: 'user' }],
+        startTime: 'start',
+        lastUpdated: 'end',
+      },
+    });
+    mockHistoryReplay.mockResolvedValue(undefined);
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    let finishPrompt: ((value: unknown) => void) | undefined;
+    lastSessionMock!.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishPrompt = resolve;
+        }),
+    );
+
+    const prompt = agent.prompt({ sessionId: VALID_SESSION_ID, prompt: [] });
+    await vi.waitFor(() => expect(lastSessionMock!.prompt).toHaveBeenCalled());
+
+    await agent.extMethod('qwen/session/loadUpdates', {
+      sessionId: VALID_SESSION_ID,
+      cwd: '/tmp',
+    });
+    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      expect.objectContaining({ finalizeDangling: false }),
+    );
+
+    finishPrompt?.({ stopReason: 'end_turn' });
+    await prompt;
+
+    await agent.extMethod('qwen/session/loadUpdates', {
+      sessionId: VALID_SESSION_ID,
+      cwd: '/tmp',
+    });
+    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
       expect.objectContaining({ finalizeDangling: true }),
     );
 
@@ -19355,6 +19478,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     });
 
     expect(replayOptions).toEqual({
+      finalizeDangling: true,
       goalBootstrap: {
         goalStatus: {
           kind: 'set',
@@ -19440,7 +19564,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       },
     });
 
-    expect(replayOptions).toBeUndefined();
+    expect(replayOptions).toEqual({ finalizeDangling: true });
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -19512,7 +19636,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       },
     });
 
-    expect(replayOptions).toBeUndefined();
+    expect(replayOptions).toEqual({ finalizeDangling: true });
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -12078,6 +12078,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         }
       ).loadSession(params);
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    lastSessionMock!.isTurnIdle.mockReturnValue(false);
     let finishPrompt: ((value: unknown) => void) | undefined;
     lastSessionMock!.prompt.mockImplementation(
       () =>
@@ -12103,6 +12104,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     finishPrompt?.({ stopReason: 'end_turn' });
     await prompt;
+    lastSessionMock!.isTurnIdle.mockReturnValue(true);
 
     await loadSession({
       cwd: '/tmp',
@@ -12114,6 +12116,52 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({ finalizeDangling: true }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('live session load keeps a dangling call pending when a turn settles during the restore read', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    innerConfig.getSessionRuntimeBaseDir = vi
+      .fn()
+      .mockReturnValue('/tmp/qwen-runtime-test');
+    vi.mocked(SessionService).mockImplementation(
+      () =>
+        ({
+          readLiveRestoreProjection: vi.fn().mockResolvedValue({
+            replay: {
+              records: [{ role: 'user' }],
+              gaps: [],
+            },
+          }),
+        }) as unknown as InstanceType<typeof SessionService>,
+    );
+    mockHistoryReplay.mockResolvedValue(undefined);
+    const { agent, agentPromise } = await bootAcpAgent();
+    const loadSession = (params: Record<string, unknown>) =>
+      (
+        agent as unknown as {
+          loadSession: (p: Record<string, unknown>) => Promise<unknown>;
+        }
+      ).loadSession(params);
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    // A turn that is active before the transcript read but settles inside
+    // the restore window: only the before-read sample keeps the trailing
+    // call pending.
+    lastSessionMock!.isTurnIdle.mockReturnValueOnce(false);
+
+    await loadSession({
+      cwd: '/tmp',
+      sessionId: VALID_SESSION_ID,
+      mcpServers: [],
+    });
+    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ finalizeDangling: false }),
     );
 
     mockConnectionState.resolve();
@@ -12135,6 +12183,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     mockHistoryReplay.mockResolvedValue(undefined);
     const { agent, agentPromise } = await bootAcpAgent();
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    lastSessionMock!.isTurnIdle.mockReturnValue(false);
     let finishPrompt: ((value: unknown) => void) | undefined;
     lastSessionMock!.prompt.mockImplementation(
       () =>
@@ -12159,6 +12208,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
     finishPrompt?.({ stopReason: 'end_turn' });
     await prompt;
+    lastSessionMock!.isTurnIdle.mockReturnValue(true);
 
     await agent.extMethod('qwen/session/loadUpdates', {
       sessionId: VALID_SESSION_ID,
@@ -12169,6 +12219,40 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.anything(),
       undefined,
       expect.objectContaining({ finalizeDangling: true }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/session/loadUpdates keeps a dangling call pending when a turn settles during the read', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    innerConfig.getSessionRuntimeBaseDir = vi
+      .fn()
+      .mockReturnValue('/tmp/qwen-runtime-test');
+    mockSessionServiceLoad({
+      conversation: {
+        messages: [{ role: 'user' }],
+        startTime: 'start',
+        lastUpdated: 'end',
+      },
+    });
+    mockHistoryReplay.mockResolvedValue(undefined);
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    // Active before the read, idle by replay time: the before-read sample
+    // alone must keep the trailing call pending.
+    lastSessionMock!.isTurnIdle.mockReturnValueOnce(false);
+
+    await agent.extMethod('qwen/session/loadUpdates', {
+      sessionId: VALID_SESSION_ID,
+      cwd: '/tmp',
+    });
+    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      expect.objectContaining({ finalizeDangling: false }),
     );
 
     mockConnectionState.resolve();
@@ -17031,6 +17115,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         waitForActiveTurnsToSettle: vi.fn().mockResolvedValue(undefined),
         cancelPendingPrompt: vi.fn().mockResolvedValue(undefined),
         assertCanStartTurn: vi.fn().mockResolvedValue(undefined),
+        isTurnIdle: vi.fn().mockReturnValue(true),
         sendUpdate: opts.recoveredGoalSendError
           ? vi.fn().mockRejectedValue(opts.recoveredGoalSendError)
           : vi.fn().mockResolvedValue(undefined),
@@ -18151,6 +18236,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       assertCanStartTurn: vi.fn().mockResolvedValue(undefined),
       beginClose: vi.fn().mockReturnValue(vi.fn()),
       waitForActiveTurnsToSettle: vi.fn().mockResolvedValue(undefined),
+      isTurnIdle: vi.fn().mockReturnValue(true),
       sendUpdate: vi.fn().mockResolvedValue(undefined),
       clearActiveTodoPlanRevision: vi.fn(),
     };
@@ -19163,6 +19249,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       waitForCloseGateToRelease: vi.fn().mockResolvedValue(undefined),
       cancelPendingPrompt: vi.fn().mockResolvedValue(undefined),
       waitForActiveTurnsToSettle: vi.fn().mockResolvedValue(undefined),
+      isTurnIdle: vi.fn().mockReturnValue(true),
       dispose: replacementDispose,
     } as unknown as InstanceType<typeof Session>;
     const sessions = (

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -12139,6 +12139,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       undefined,
       expect.objectContaining({ finalizeDangling: false }),
     );
+    // The diagnostic must be a single interpolated string: debugLogger does
+    // no printf substitution, so %s placeholders would ship unexpanded.
+    expect(mockDebugLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[ACP] restore replay finalizeDangling=false (idleBeforeRead=false, idleAtReplay=false)',
+      ),
+    );
 
     finishPrompt?.({ stopReason: 'end_turn' });
     await prompt;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -11736,7 +11736,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.anything(),
       expect.anything(),
       gaps,
-      expect.anything(),
+      // Non-live loadUpdates replays have no live stream to deliver a
+      // trailing result, so dangling calls must still finalize.
+      expect.objectContaining({ finalizeDangling: true }),
     );
 
     mockConnectionState.resolve();
@@ -12053,7 +12055,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
-  it('live session load keeps dangling transcript calls in flight while a prompt is active', async () => {
+  it('live session load finalizes dangling calls because the restore gate drains active turns', async () => {
     const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
     innerConfig.getSessionRuntimeBaseDir = vi
       .fn()
@@ -12078,33 +12080,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         }
       ).loadSession(params);
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    // The restore gate drains active turns and blocks new ones before the
+    // replay runs, so the live path must finalize regardless of turn state;
+    // sampling isTurnIdle() under the gate is structurally false and would
+    // keep genuinely abandoned calls pending forever.
     lastSessionMock!.isTurnIdle.mockReturnValue(false);
-    let finishPrompt: ((value: unknown) => void) | undefined;
-    lastSessionMock!.prompt.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          finishPrompt = resolve;
-        }),
-    );
-
-    const prompt = agent.prompt({ sessionId: VALID_SESSION_ID, prompt: [] });
-    await vi.waitFor(() => expect(lastSessionMock!.prompt).toHaveBeenCalled());
-
-    await loadSession({
-      cwd: '/tmp',
-      sessionId: VALID_SESSION_ID,
-      mcpServers: [],
-    });
-    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ finalizeDangling: false }),
-    );
-
-    finishPrompt?.({ stopReason: 'end_turn' });
-    await prompt;
-    lastSessionMock!.isTurnIdle.mockReturnValue(true);
 
     await loadSession({
       cwd: '/tmp',
@@ -12116,52 +12096,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({ finalizeDangling: true }),
-    );
-
-    mockConnectionState.resolve();
-    await agentPromise;
-  });
-
-  it('live session load keeps a dangling call pending when a turn settles during the restore read', async () => {
-    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
-    innerConfig.getSessionRuntimeBaseDir = vi
-      .fn()
-      .mockReturnValue('/tmp/qwen-runtime-test');
-    vi.mocked(SessionService).mockImplementation(
-      () =>
-        ({
-          readLiveRestoreProjection: vi.fn().mockResolvedValue({
-            replay: {
-              records: [{ role: 'user' }],
-              gaps: [],
-            },
-          }),
-        }) as unknown as InstanceType<typeof SessionService>,
-    );
-    mockHistoryReplay.mockResolvedValue(undefined);
-    const { agent, agentPromise } = await bootAcpAgent();
-    const loadSession = (params: Record<string, unknown>) =>
-      (
-        agent as unknown as {
-          loadSession: (p: Record<string, unknown>) => Promise<unknown>;
-        }
-      ).loadSession(params);
-    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    // A turn that is active before the transcript read but settles inside
-    // the restore window: only the before-read sample keeps the trailing
-    // call pending.
-    lastSessionMock!.isTurnIdle.mockReturnValueOnce(false);
-
-    await loadSession({
-      cwd: '/tmp',
-      sessionId: VALID_SESSION_ID,
-      mcpServers: [],
-    });
-    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-      expect.objectContaining({ finalizeDangling: false }),
     );
 
     mockConnectionState.resolve();
@@ -12243,6 +12177,42 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     // Active before the read, idle by replay time: the before-read sample
     // alone must keep the trailing call pending.
     lastSessionMock!.isTurnIdle.mockReturnValueOnce(false);
+
+    await agent.extMethod('qwen/session/loadUpdates', {
+      sessionId: VALID_SESSION_ID,
+      cwd: '/tmp',
+    });
+    expect(mockHistoryReplay).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      expect.objectContaining({ finalizeDangling: false }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/session/loadUpdates keeps a dangling call pending when a turn starts during the read', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    innerConfig.getSessionRuntimeBaseDir = vi
+      .fn()
+      .mockReturnValue('/tmp/qwen-runtime-test');
+    mockSessionServiceLoad({
+      conversation: {
+        messages: [{ role: 'user' }],
+        startTime: 'start',
+        lastUpdated: 'end',
+      },
+    });
+    mockHistoryReplay.mockResolvedValue(undefined);
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    // Idle before the read, active by replay time: the replay-time sample
+    // alone must keep the trailing call pending.
+    lastSessionMock!.isTurnIdle
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
 
     await agent.extMethod('qwen/session/loadUpdates', {
       sessionId: VALID_SESSION_ID,

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -11645,11 +11645,14 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
   const VALID_SESSION_ID = '12345678-1234-1234-1234-1234567890ab';
 
-  function mockSessionServiceLoad(result: unknown) {
+  function mockSessionServiceLoad(result: unknown, onRead?: () => void) {
     vi.mocked(SessionService).mockImplementation(
       () =>
         ({
-          loadSession: vi.fn().mockResolvedValue(result),
+          loadSession: vi.fn().mockImplementation(async () => {
+            onRead?.();
+            return result;
+          }),
         }) as unknown as InstanceType<typeof SessionService>,
     );
   }
@@ -12171,19 +12174,28 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     innerConfig.getSessionRuntimeBaseDir = vi
       .fn()
       .mockReturnValue('/tmp/qwen-runtime-test');
-    mockSessionServiceLoad({
-      conversation: {
-        messages: [{ role: 'user' }],
-        startTime: 'start',
-        lastUpdated: 'end',
+    // Anchor the settle flip to the read boundary: the session is active
+    // before the read and the mocked sessionService.loadSession flips it to
+    // idle inside the read window (mirrors the sessionTranscript test that
+    // toggles state inside readPage.mockImplementationOnce). Keying the
+    // isTurnIdle mock by call order instead would let a mutation that moves
+    // the before-read sample across the read survive.
+    mockSessionServiceLoad(
+      {
+        conversation: {
+          messages: [{ role: 'user' }],
+          startTime: 'start',
+          lastUpdated: 'end',
+        },
       },
-    });
+      () => lastSessionMock!.isTurnIdle.mockReturnValue(true),
+    );
     mockHistoryReplay.mockResolvedValue(undefined);
     const { agent, agentPromise } = await bootAcpAgent();
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
     // Active before the read, idle by replay time: the before-read sample
     // alone must keep the trailing call pending.
-    lastSessionMock!.isTurnIdle.mockReturnValueOnce(false);
+    lastSessionMock!.isTurnIdle.mockReturnValue(false);
 
     await agent.extMethod('qwen/session/loadUpdates', {
       sessionId: VALID_SESSION_ID,
@@ -12205,21 +12217,27 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     innerConfig.getSessionRuntimeBaseDir = vi
       .fn()
       .mockReturnValue('/tmp/qwen-runtime-test');
-    mockSessionServiceLoad({
-      conversation: {
-        messages: [{ role: 'user' }],
-        startTime: 'start',
-        lastUpdated: 'end',
+    // Anchor the start flip to the read boundary: the session is idle
+    // before the read and the mocked sessionService.loadSession flips it to
+    // active inside the read window. Keying the isTurnIdle mock by call
+    // order instead would let a mutation that moves the replay-time sample
+    // across the read survive.
+    mockSessionServiceLoad(
+      {
+        conversation: {
+          messages: [{ role: 'user' }],
+          startTime: 'start',
+          lastUpdated: 'end',
+        },
       },
-    });
+      () => lastSessionMock!.isTurnIdle.mockReturnValue(false),
+    );
     mockHistoryReplay.mockResolvedValue(undefined);
     const { agent, agentPromise } = await bootAcpAgent();
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
     // Idle before the read, active by replay time: the replay-time sample
     // alone must keep the trailing call pending.
-    lastSessionMock!.isTurnIdle
-      .mockReturnValueOnce(true)
-      .mockReturnValue(false);
+    lastSessionMock!.isTurnIdle.mockReturnValue(true);
 
     await agent.extMethod('qwen/session/loadUpdates', {
       sessionId: VALID_SESSION_ID,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4998,12 +4998,10 @@ class QwenAgent implements Agent {
   ): boolean {
     const idleAtReplay = session?.isTurnIdle() ?? true;
     const finalize = turnIdleBeforeRead && idleAtReplay;
+    // Template literal, not printf-style placeholders: createDebugLogger's
+    // formatArgs does no util.format substitution, it space-joins the args.
     debugLogger.debug(
-      '[ACP] restore replay finalizeDangling=%s (idleBeforeRead=%s, idleAtReplay=%s) session=%s',
-      finalize,
-      turnIdleBeforeRead,
-      idleAtReplay,
-      session?.getId() ?? '(non-live)',
+      `[ACP] restore replay finalizeDangling=${finalize} (idleBeforeRead=${turnIdleBeforeRead}, idleAtReplay=${idleAtReplay}) session=${session?.getId() ?? '(non-live)'}`,
     );
     return finalize;
   }

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4980,18 +4980,32 @@ class QwenAgent implements Agent {
   }
 
   /**
-   * Whether a restore replay may finalize dangling tool calls. A session
-   * with an active turn — a client prompt or an autonomous goal/cron/
-   * notification turn — may still owe the trailing call's result, so the
-   * replay keeps it pending and lets the live stream deliver it (#9704).
-   * Samples the turn state before the transcript read and again at replay
-   * time so a turn that starts or settles inside the read window is seen.
+   * Whether an ungated restore replay (qwen/session/loadUpdates) may
+   * finalize dangling tool calls. A session with an active turn — a client
+   * prompt or an autonomous goal/cron/notification turn — may still owe the
+   * trailing call's result, so the replay keeps it pending and lets the
+   * live stream deliver it (#9704). Samples the turn state before the
+   * transcript read and again at replay time so a turn that starts or
+   * settles inside the read window is seen. Not for the live loadSession
+   * path: that restore runs under the close gate, which drains active
+   * turns, blocks new ones, and reports closing=true — so isTurnIdle()
+   * there is structurally false and would keep genuinely abandoned calls
+   * pending forever.
    */
   private finalizeDanglingForRestore(
     session: Session | undefined,
     turnIdleBeforeRead: boolean,
   ): boolean {
-    return turnIdleBeforeRead && (session?.isTurnIdle() ?? true);
+    const idleAtReplay = session?.isTurnIdle() ?? true;
+    const finalize = turnIdleBeforeRead && idleAtReplay;
+    debugLogger.debug(
+      '[ACP] restore replay finalizeDangling=%s (idleBeforeRead=%s, idleAtReplay=%s) session=%s',
+      finalize,
+      turnIdleBeforeRead,
+      idleAtReplay,
+      session?.getId() ?? '(non-live)',
+    );
+    return finalize;
   }
 
   private async assertLiveSessionScope(
@@ -5385,7 +5399,6 @@ class QwenAgent implements Agent {
         loadSettingsCached(params.cwd),
       );
       const liveConfig = liveSession.getConfig();
-      const turnIdleBeforeRead = liveSession.isTurnIdle();
       return profiler.time('live_restore', async () => {
         await this.assertLiveSessionScope(liveConfig, settings, params.cwd);
         return this.withLiveSessionRestore(
@@ -5421,15 +5434,13 @@ class QwenAgent implements Agent {
                 replayState: replayPage.replay,
                 goalBootstrap: replayGoalBootstrap(projection),
                 suppressRestoreAskUserQuestion,
-                // A trailing unmatched call is in-flight, not abandoned,
-                // while the session still has an active turn (#9704); keep
-                // it pending instead of finalizing it as a permanent
-                // failure. The paged transcript read applies the same
-                // guard on its own predicate.
-                finalizeDangling: this.finalizeDanglingForRestore(
-                  liveSession,
-                  turnIdleBeforeRead,
-                ),
+                // The restore gate already drained active turns and blocks
+                // new ones (and a drain timeout rejects before replay), so
+                // a trailing unmatched call here is genuinely abandoned —
+                // finalize it. The turn-activity guard cannot be sampled
+                // under the gate: isTurnIdle() is structurally false while
+                // the close gate is held (#9704).
+                finalizeDangling: true,
                 ...(restoreOptions.replay.kind === 'recent'
                   ? {
                       limits: {
@@ -11943,7 +11954,9 @@ class QwenAgent implements Agent {
           // Read-only history dump never re-hangs the question. Skip
           // finalize only on load/resume that will actually restore.
           suppressRestoreAskUserQuestion: true,
-          // Same in-flight guard as the session-load replay (#9704).
+          // Ungated read: unlike the live loadSession restore (whose gate
+          // drains turns), a turn may still be running here, so guard on
+          // turn activity instead of finalizing unconditionally (#9704).
           finalizeDangling: this.finalizeDanglingForRestore(
             liveSession,
             turnIdleBeforeRead,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5370,6 +5370,7 @@ class QwenAgent implements Agent {
         loadSettingsCached(params.cwd),
       );
       const liveConfig = liveSession.getConfig();
+      const activePromptBeforeRead = this.activePromptCalls.has(sessionId);
       return profiler.time('live_restore', async () => {
         await this.assertLiveSessionScope(liveConfig, settings, params.cwd);
         return this.withLiveSessionRestore(
@@ -5405,6 +5406,13 @@ class QwenAgent implements Agent {
                 replayState: replayPage.replay,
                 goalBootstrap: replayGoalBootstrap(projection),
                 suppressRestoreAskUserQuestion,
+                // A trailing unmatched call is in-flight, not abandoned,
+                // while a prompt is still running in this process (#9704);
+                // keep it pending instead of finalizing it as a permanent
+                // failure. Mirrors the transcript paging guard below.
+                finalizeDangling:
+                  !activePromptBeforeRead &&
+                  !this.activePromptCalls.has(sessionId),
                 ...(restoreOptions.replay.kind === 'recent'
                   ? {
                       limits: {
@@ -11876,6 +11884,7 @@ class QwenAgent implements Agent {
         }
 
         const liveSession = this.sessions.get(sessionId);
+        const activePromptBeforeRead = this.activePromptCalls.has(sessionId);
         let replayConfig = this.config;
         let sessionData: ResumedSessionData | undefined;
         if (liveSession) {
@@ -11917,6 +11926,9 @@ class QwenAgent implements Agent {
           // Read-only history dump never re-hangs the question. Skip
           // finalize only on load/resume that will actually restore.
           suppressRestoreAskUserQuestion: true,
+          // Same in-flight guard as the session-load replay (#9704).
+          finalizeDangling:
+            !activePromptBeforeRead && !this.activePromptCalls.has(sessionId),
         });
 
         return {

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4979,6 +4979,21 @@ class QwenAgent implements Agent {
     return runWithAcpRuntimeOutputDir(settings, cwd, operation);
   }
 
+  /**
+   * Whether a restore replay may finalize dangling tool calls. A session
+   * with an active turn — a client prompt or an autonomous goal/cron/
+   * notification turn — may still owe the trailing call's result, so the
+   * replay keeps it pending and lets the live stream deliver it (#9704).
+   * Samples the turn state before the transcript read and again at replay
+   * time so a turn that starts or settles inside the read window is seen.
+   */
+  private finalizeDanglingForRestore(
+    session: Session | undefined,
+    turnIdleBeforeRead: boolean,
+  ): boolean {
+    return turnIdleBeforeRead && (session?.isTurnIdle() ?? true);
+  }
+
   private async assertLiveSessionScope(
     config: Config,
     settings: LoadedSettings,
@@ -5370,7 +5385,7 @@ class QwenAgent implements Agent {
         loadSettingsCached(params.cwd),
       );
       const liveConfig = liveSession.getConfig();
-      const activePromptBeforeRead = this.activePromptCalls.has(sessionId);
+      const turnIdleBeforeRead = liveSession.isTurnIdle();
       return profiler.time('live_restore', async () => {
         await this.assertLiveSessionScope(liveConfig, settings, params.cwd);
         return this.withLiveSessionRestore(
@@ -5407,12 +5422,14 @@ class QwenAgent implements Agent {
                 goalBootstrap: replayGoalBootstrap(projection),
                 suppressRestoreAskUserQuestion,
                 // A trailing unmatched call is in-flight, not abandoned,
-                // while a prompt is still running in this process (#9704);
-                // keep it pending instead of finalizing it as a permanent
-                // failure. Mirrors the transcript paging guard below.
-                finalizeDangling:
-                  !activePromptBeforeRead &&
-                  !this.activePromptCalls.has(sessionId),
+                // while the session still has an active turn (#9704); keep
+                // it pending instead of finalizing it as a permanent
+                // failure. The paged transcript read applies the same
+                // guard on its own predicate.
+                finalizeDangling: this.finalizeDanglingForRestore(
+                  liveSession,
+                  turnIdleBeforeRead,
+                ),
                 ...(restoreOptions.replay.kind === 'recent'
                   ? {
                       limits: {
@@ -11884,7 +11901,7 @@ class QwenAgent implements Agent {
         }
 
         const liveSession = this.sessions.get(sessionId);
-        const activePromptBeforeRead = this.activePromptCalls.has(sessionId);
+        const turnIdleBeforeRead = liveSession?.isTurnIdle() ?? true;
         let replayConfig = this.config;
         let sessionData: ResumedSessionData | undefined;
         if (liveSession) {
@@ -11927,8 +11944,10 @@ class QwenAgent implements Agent {
           // finalize only on load/resume that will actually restore.
           suppressRestoreAskUserQuestion: true,
           // Same in-flight guard as the session-load replay (#9704).
-          finalizeDangling:
-            !activePromptBeforeRead && !this.activePromptCalls.has(sessionId),
+          finalizeDangling: this.finalizeDanglingForRestore(
+            liveSession,
+            turnIdleBeforeRead,
+          ),
         });
 
         return {

--- a/packages/cli/src/acp-integration/session/history-replay-page.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.test.ts
@@ -286,6 +286,38 @@ describe('history replay page', () => {
     ).toBe(false);
   });
 
+  it('finalizes a dangling tool call as failed by default', async () => {
+    const result = await collectHistoryReplayUpdates({
+      sessionId: SESSION_ID,
+      records: [userRecord(), toolCallRecord()],
+      cumulativeUsage: createReplayCumulativeUsage(),
+    });
+
+    expect(result.replayError).toBeUndefined();
+    expect(result.updates).toContainEqual(
+      expect.objectContaining({
+        sessionUpdate: 'tool_call_update',
+        status: 'failed',
+      }),
+    );
+  });
+
+  it('keeps a dangling tool call in flight when finalizeDangling is false', async () => {
+    const result = await collectHistoryReplayUpdates({
+      sessionId: SESSION_ID,
+      records: [userRecord(), toolCallRecord()],
+      cumulativeUsage: createReplayCumulativeUsage(),
+      finalizeDangling: false,
+    });
+
+    expect(result.replayError).toBeUndefined();
+    expect(
+      result.updates.some(
+        (update) => update.sessionUpdate === 'tool_call_update',
+      ),
+    ).toBe(false);
+  });
+
   it('bounds textual tool results collected for bulk replay', async () => {
     const source = 'x'.repeat(499_999);
     const result = await collectHistoryReplayUpdates({

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -254,6 +254,7 @@ export async function collectHistoryReplayUpdates({
   goalBootstrap,
   limits,
   suppressRestoreAskUserQuestion,
+  finalizeDangling,
 }: {
   sessionId: string;
   config?: Config;
@@ -270,6 +271,12 @@ export async function collectHistoryReplayUpdates({
    * so the replayed card doesn't spin forever with no restore prompt coming.
    */
   suppressRestoreAskUserQuestion?: boolean;
+  /**
+   * Live-session loads while a prompt is still active must not finalize
+   * dangling calls: a trailing unmatched call is in-flight, not abandoned,
+   * and its result arrives through the live stream (#9704).
+   */
+  finalizeDangling?: boolean;
 }): Promise<{ updates: SessionUpdate[]; replayError?: string }> {
   const updates: SessionUpdate[] = [];
   try {
@@ -299,6 +306,7 @@ export async function collectHistoryReplayUpdates({
       ...(initial.goalCause ? { initialGoalCause: initial.goalCause } : {}),
       ...(goalBootstrap ? { goalBootstrap } : {}),
       ...(skipFinalizeCallIds ? { skipFinalizeCallIds } : {}),
+      ...(finalizeDangling === undefined ? {} : { finalizeDangling }),
     });
   } catch (error) {
     if (error instanceof HistoryReplayLimitError) throw error;

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -272,9 +272,11 @@ export async function collectHistoryReplayUpdates({
    */
   suppressRestoreAskUserQuestion?: boolean;
   /**
-   * Live-session loads while a prompt is still active must not finalize
-   * dangling calls: a trailing unmatched call is in-flight, not abandoned,
-   * and its result arrives through the live stream (#9704).
+   * Ungated live-session loads (qwen/session/loadUpdates) while the
+   * session still has an active turn must not finalize dangling calls: a
+   * trailing unmatched call is in-flight, not abandoned, and its result
+   * arrives through the live stream (#9704). The gated live loadSession
+   * path and non-live loads pass true.
    */
   finalizeDangling?: boolean;
 }): Promise<{ updates: SessionUpdate[]; replayError?: string }> {

--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -433,6 +433,34 @@ describe('HistoryReplayer', () => {
       ]);
     });
 
+    it('keeps a dangling call in flight when finalizeDangling is false', async () => {
+      const record: ChatRecord = {
+        ...createAssistantRecord(''),
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-inflight',
+                name: 'run_shell_command',
+                args: { command: 'sleep 10' },
+              },
+            },
+          ],
+        },
+      };
+
+      await replayer.replay([record], undefined, { finalizeDangling: false });
+
+      const updates = sentUpdates();
+      expect(updates.map((update) => update['sessionUpdate'])).toEqual([
+        'tool_call',
+      ]);
+      expect(replayer.getPendingToolCalls()).toEqual([
+        expect.objectContaining({ callId: 'call-inflight' }),
+      ]);
+    });
+
     it('should carry dangling function calls across replay pages', async () => {
       const record: ChatRecord = {
         ...createAssistantRecord(''),

--- a/packages/cli/src/acp-integration/session/history-replayer.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.ts
@@ -91,6 +91,7 @@ export class HistoryReplayer {
       initialGoalCause?: GoalStateCause;
       goalBootstrap?: HistoryReplayGoalBootstrap;
       skipFinalizeCallIds?: ReadonlySet<string>;
+      finalizeDangling?: boolean;
     } = {},
   ): Promise<void> {
     try {
@@ -108,7 +109,7 @@ export class HistoryReplayer {
         await this.sendUpdate(update);
       }
       await this.replayPage(records, {
-        finalizeDangling: true,
+        finalizeDangling: options.finalizeDangling ?? true,
         gaps,
         ...(options.skipFinalizeCallIds
           ? { skipFinalizeCallIds: options.skipFinalizeCallIds }


### PR DESCRIPTION
## What this PR does

Narrows #9704: session-restore replays no longer finalize a trailing tool call as the permanent "Tool result missing from saved history" failure while the session still has an active turn in this process, covering client prompts and the daemon's autonomous goal, cron, and notification turns. The call stays pending and its result arrives through the live stream. This PR does not close the issue entirely; the remaining windows are disclosed below and the issue stays open.

This replaces the earlier recorder-flush attempt, which was withdrawn: the scheduler only records results after a tool batch reaches a terminal state, so during the reported window there was nothing to flush. The failure was on the reader side, not the writer side.

## Why it's needed

The bulk session-restore replay finalized dangling tool calls unconditionally. During a live in-flight turn, that made the reader convert a still-running tool call into a permanent missing-result placeholder before the real result could be streamed.

## Reviewer Test Plan

### How to verify

1. In a daemon session with an active turn, either a client prompt or a goal, cron, or notification turn, call qwen/session/loadUpdates for that session while a tool call's result has not been persisted yet.
2. Expect the replayed trailing call to stay pending, with no "Tool result missing from saved history" placeholder, and expect the result to appear through the live stream once the tool completes.
3. Load the same session once it is fully idle and confirm genuinely abandoned calls are still finalized as before.

### Evidence (Before & After)

Before: a live restore could show a permanent "Tool result missing from saved history" placeholder for a tool call that was still running. After: the replay keeps that call pending while the session has an active turn, then the live stream supplies the result.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local Node workspace tests and repository build/typecheck/lint/format checks.

## Risk & Scope

- Main risk or tradeoff: the guard is intentionally limited to sessions with active turns; idle sessions keep the previous finalization behavior.
- Not validated / out of scope: live session load still has the existing 30s active-turn drain timeout; cold restores of sessions not live in this process still finalize because distinguishing a dead writer from a slow writer requires ownership evidence. Those remaining shapes are tracked in #9773 and #9483.
- Breaking changes / migration notes: none.

## Linked Issues

Relates to #9704 and #9483. Follow-up for the live in-memory load shape: #9773.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

收窄 #9704：当当前进程里 session 仍有活跃 turn 时，session restore replay 不再把尾部未匹配的 tool call 固化为永久的 "Tool result missing from saved history" 失败，覆盖客户端 prompt 以及 daemon 的 goal、cron、notification 自主 turn。该 tool call 会保持 pending，并通过 live stream 收到后续结果。本 PR 不完全关闭该 issue；剩余窗口在下方说明，issue 保持打开。

这替代了早先撤回的 recorder flush 尝试：scheduler 只有在 tool batch 进入终态后才记录结果，所以报告窗口里没有可 flush 的内容。失败点在读取侧，不在写入侧。

## 为什么需要

批量 session restore replay 过去会无条件 finalize dangling tool call。在 live in-flight turn 中，这会让读取侧在真实结果流回来前，把仍在运行的 tool call 转成永久 missing-result placeholder。

## 评审测试计划

### 如何验证

1. 在有活跃 turn 的 daemon session 中，无论是客户端 prompt 还是 goal、cron、notification turn，在某个 tool call 结果尚未持久化时调用 qwen/session/loadUpdates。
2. 预期 replay 出来的尾部 call 保持 pending，不出现 "Tool result missing from saved history" placeholder，并且 tool 完成后结果通过 live stream 出现。
3. 同一个 session 完全 idle 后再次 load，确认真正 abandoned 的 call 仍按原行为 finalize。

### 证据（Before & After）

Before：live restore 可能把仍在运行的 tool call 显示成永久 "Tool result missing from saved history" placeholder。After：session 有活跃 turn 时 replay 会让该 call 保持 pending，随后由 live stream 补上结果。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 Node workspace 测试以及仓库 build/typecheck/lint/format 检查。

## 风险与范围

- 主要风险或取舍：guard 有意限定在仍有活跃 turn 的 session；idle session 保持原先 finalize 行为。
- 未验证/超出范围：live session load 仍有现有的 30s active-turn drain timeout；非当前进程 live 的 cold restore 仍会 finalize，因为区分 dead writer 和 slow writer 需要可靠 ownership evidence。这些剩余形态由 #9773 和 #9483 跟踪。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Relates to #9704 and #9483。live in-memory load 形态的 follow-up：#9773。

</details>
