### PR TITLE
fix(core): reject session titles that echo the prompt's own examples

### DIFF
--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -124,10 +124,12 @@ describe('tryGenerateSessionTitle', () => {
   });
 
   it('returns {ok:true, title, modelUsed} on success', async () => {
+    // Not one of the TITLE_SYSTEM_PROMPT "Good examples" — those are
+    // rejected as prompt echoes (see the #9706 tests below).
     const { config, generateJson } = makeConfig({
       fastModel: 'qwen-turbo',
       history: DIALOG_HISTORY,
-      generateJsonResult: { title: 'Fix login button on mobile' },
+      generateJsonResult: { title: 'Debug mobile login breakage' },
     });
     const outcome = await tryGenerateSessionTitle(
       config,
@@ -135,7 +137,7 @@ describe('tryGenerateSessionTitle', () => {
     );
     expect(outcome).toEqual({
       ok: true,
-      title: 'Fix login button on mobile',
+      title: 'Debug mobile login breakage',
       modelUsed: 'qwen-turbo',
     });
     // Schema call must use the fast model (not the main model) and the
@@ -155,6 +157,72 @@ describe('tryGenerateSessionTitle', () => {
     expect(callOpts.schema.required).toEqual(['title']);
     expect(callOpts.schema.properties.title.type).toBe('string');
     expect(callOpts.maxAttempts).toBe(1);
+  });
+
+  // #9706: when the recent conversation carries little topical signal
+  // (boilerplate-heavy channel sessions), the title model takes the cheapest
+  // schema-valid answer and parrots a TITLE_SYSTEM_PROMPT "Good example"
+  // back verbatim. Such canned titles say nothing about the session, so
+  // they must be treated like an empty result and let the caller fall back.
+  it('rejects a verbatim echo of a TITLE_SYSTEM_PROMPT example (#9706)', async () => {
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history: DIALOG_HISTORY,
+      generateJsonResult: { title: 'Fix login button on mobile' },
+    });
+    const outcome = await tryGenerateSessionTitle(
+      config,
+      new AbortController().signal,
+    );
+    expect(outcome).toEqual({ ok: false, reason: 'empty_result' });
+  });
+
+  it('rejects case/punctuation variants of every prompt example (#9706)', async () => {
+    const echoes = [
+      // Case variants (incl. the prompt's own "Bad (wrong case)" example).
+      'Fix Login Button On Mobile',
+      'fix LOGIN button on mobile',
+      // Whitespace / residual punctuation that sanitizeTitle strips down to
+      // the bare example.
+      '  Add OAuth authentication flow  ',
+      'Debug failing CI pipeline tests.',
+      // The CJK example.
+      '重构用户鉴权中间件',
+    ];
+    for (const title of echoes) {
+      const { config } = makeConfig({
+        fastModel: 'qwen-turbo',
+        history: DIALOG_HISTORY,
+        generateJsonResult: { title },
+      });
+      const outcome = await tryGenerateSessionTitle(
+        config,
+        new AbortController().signal,
+      );
+      expect(outcome, `echo not rejected: ${JSON.stringify(title)}`).toEqual({
+        ok: false,
+        reason: 'empty_result',
+      });
+    }
+  });
+
+  it('still accepts a topical title that merely resembles an example (#9706)', async () => {
+    // The guard must be an exact (normalized) match, not fuzzy: a session
+    // genuinely about a login button still gets a real, non-canned title.
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history: DIALOG_HISTORY,
+      generateJsonResult: { title: 'Fix login button styling' },
+    });
+    const outcome = await tryGenerateSessionTitle(
+      config,
+      new AbortController().signal,
+    );
+    expect(outcome).toEqual({
+      ok: true,
+      title: 'Fix login button styling',
+      modelUsed: 'qwen-turbo',
+    });
   });
 
   it('uses the user-facing projection instead of hidden prompt context', async () => {

--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -215,6 +215,11 @@ describe('tryGenerateSessionTitle', () => {
       '[Add OAuth authentication flow]',
       '{Debug failing CI pipeline tests}',
       '（重构用户鉴权中间件）',
+      // Wrappers that survive sanitizeTitle with inner punctuation intact —
+      // the guard must not depend on an enumerated bracket family.
+      '["Fix login button on mobile"]',
+      '<Add OAuth authentication flow>',
+      '«Debug failing CI pipeline tests»',
     ];
     for (const title of wrapped) {
       const { config } = makeConfig({

--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -206,6 +206,53 @@ describe('tryGenerateSessionTitle', () => {
     }
   });
 
+  it('rejects bracket-wrapped echoes of prompt examples (#9706)', async () => {
+    // sanitizeTitle keeps ASCII/full-width brackets (legitimate in titles
+    // like "(WIP) Fix build"), so the guard itself must see through a
+    // bracket wrapper around a canned example.
+    const wrapped = [
+      '(Fix login button on mobile)',
+      '[Add OAuth authentication flow]',
+      '{Debug failing CI pipeline tests}',
+      '（重构用户鉴权中间件）',
+    ];
+    for (const title of wrapped) {
+      const { config } = makeConfig({
+        fastModel: 'qwen-turbo',
+        history: DIALOG_HISTORY,
+        generateJsonResult: { title },
+      });
+      const outcome = await tryGenerateSessionTitle(
+        config,
+        new AbortController().signal,
+      );
+      expect(
+        outcome,
+        `wrapped echo not rejected: ${JSON.stringify(title)}`,
+      ).toEqual({ ok: false, reason: 'empty_result' });
+    }
+  });
+
+  it('still accepts a genuine title wrapped in brackets (#9706)', async () => {
+    // The wrapper strip is comparison-only: a real title that happens to
+    // carry brackets must pass through unchanged, not be corrupted or
+    // rejected.
+    const { config } = makeConfig({
+      fastModel: 'qwen-turbo',
+      history: DIALOG_HISTORY,
+      generateJsonResult: { title: '(WIP) Fix build' },
+    });
+    const outcome = await tryGenerateSessionTitle(
+      config,
+      new AbortController().signal,
+    );
+    expect(outcome).toEqual({
+      ok: true,
+      title: '(WIP) Fix build',
+      modelUsed: 'qwen-turbo',
+    });
+  });
+
   it('still accepts a topical title that merely resembles an example (#9706)', async () => {
     // The guard must be an exact (normalized) match, not fuzzy: a session
     // genuinely about a login button still gets a real, non-canned title.

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -239,17 +239,20 @@ export function sanitizeTitle(s: string): string {
  * that merely resembles an example still passes. Also catches the prompt's
  * "Bad (wrong case)" variant of the first example.
  *
- * Bracket wrappers are stripped for the comparison only: `sanitizeTitle`
+ * Wrapper characters are stripped for the comparison only: `sanitizeTitle`
  * keeps ASCII/full-width brackets because real titles use them (e.g.
  * "(WIP) Fix build"), but `(Fix login button on mobile)` is the same canned
- * echo as the bare example and must not slip past the guard.
+ * echo as the bare example and must not slip past the guard. The strip is
+ * Unicode-aware (any leading/trailing non-letter/non-digit run) so the next
+ * wrapper family — `["..."]`, `<...>`, `«...»` — cannot bypass it by
+ * falling outside an enumerated character class.
  */
 function isPromptExampleEcho(title: string): boolean {
   const normalized = title
     .trim()
     .toLowerCase()
-    .replace(/^[()[\]{}（）\s]+/, '')
-    .replace(/[()[\]{}（）\s]+$/, '');
+    .replace(/^[^\p{L}\p{N}]+/u, '')
+    .replace(/[^\p{L}\p{N}]+$/u, '');
   return TITLE_PROMPT_EXAMPLE_TITLES.some(
     (example) => example.toLowerCase() === normalized,
   );

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -21,6 +21,20 @@ const debugLogger = createDebugLogger('SESSION_TITLE');
 const MAX_CONVERSATION_CHARS = 1000;
 const RECENT_MESSAGE_WINDOW = 20;
 
+// The "Good examples" shown to the model in TITLE_SYSTEM_PROMPT, and the
+// echo-guard set: when the recent conversation carries little topical signal
+// (boilerplate-heavy channel/hook context), the model takes the cheapest
+// schema-valid answer and parrots one of these back verbatim (#9706). A
+// canned example says nothing about the session, so matches are rejected
+// like empty results. The prompt's "Good examples" block is rendered from
+// this array, so the two cannot drift apart.
+const TITLE_PROMPT_EXAMPLE_TITLES = [
+  'Fix login button on mobile',
+  'Add OAuth authentication flow',
+  'Debug failing CI pipeline tests',
+  '重构用户鉴权中间件',
+];
+
 const TITLE_SYSTEM_PROMPT = `Generate a concise, sentence-case title (3-7 words) that captures what this programming-assistant session is about. Think of it as a git commit subject for the session.
 
 Rules:
@@ -31,10 +45,9 @@ Rules:
 - Be specific about the user's actual goal — name the feature, bug, or subject area. Avoid vague "Code changes", "Help request", "Conversation".
 
 Good examples:
-{"title": "Fix login button on mobile"}
-{"title": "Add OAuth authentication flow"}
-{"title": "Debug failing CI pipeline tests"}
-{"title": "重构用户鉴权中间件"}
+${TITLE_PROMPT_EXAMPLE_TITLES.map(
+  (title) => `{"title": ${JSON.stringify(title)}}`,
+).join('\n')}
 
 Bad (too vague): {"title": "Code changes"}
 Bad (too long): {"title": "Investigate and fix the session title generation issue in the chat recording service"}
@@ -45,19 +58,6 @@ Return ONLY a JSON object with a single "title" key. No preamble, no reasoning, 
 
 const TITLE_USER_PROMPT =
   'Generate the session title now. Populate the schema with a single short title string.';
-
-// The "Good examples" shown to the model in TITLE_SYSTEM_PROMPT. When the
-// recent conversation carries little topical signal (boilerplate-heavy
-// channel/hook context), the model takes the cheapest schema-valid answer
-// and parrots one of these back verbatim (#9706). A canned example says
-// nothing about the session, so matches are rejected like empty results.
-// Keep in sync with the "Good examples" block in TITLE_SYSTEM_PROMPT.
-const TITLE_PROMPT_EXAMPLE_TITLES = [
-  'Fix login button on mobile',
-  'Add OAuth authentication flow',
-  'Debug failing CI pipeline tests',
-  '重构用户鉴权中间件',
-];
 
 const TITLE_SCHEMA = {
   type: 'object',
@@ -183,6 +183,11 @@ export async function tryGenerateSessionTitle(
       typeof result?.['title'] === 'string' ? (result['title'] as string) : '';
     const title = sanitizeTitle(rawTitle);
     if (!title || isPromptExampleEcho(title)) {
+      // Pre-#9706 an echo produced a visible bad title; post-guard the
+      // failure mode is a silent absence, so leave a trace for oncall.
+      debugLogger.warn(
+        `Session title rejected (${title ? 'prompt-example echo' : 'empty'}): ${JSON.stringify(rawTitle)}`,
+      );
       return { ok: false, reason: 'empty_result' };
     }
 
@@ -233,9 +238,18 @@ export function sanitizeTitle(s: string): string {
  * after sanitization — deliberately not fuzzy, so a genuinely topical title
  * that merely resembles an example still passes. Also catches the prompt's
  * "Bad (wrong case)" variant of the first example.
+ *
+ * Bracket wrappers are stripped for the comparison only: `sanitizeTitle`
+ * keeps ASCII/full-width brackets because real titles use them (e.g.
+ * "(WIP) Fix build"), but `(Fix login button on mobile)` is the same canned
+ * echo as the bare example and must not slip past the guard.
  */
 function isPromptExampleEcho(title: string): boolean {
-  const normalized = title.trim().toLowerCase();
+  const normalized = title
+    .trim()
+    .toLowerCase()
+    .replace(/^[()[\]{}（）\s]+/, '')
+    .replace(/[()[\]{}（）\s]+$/, '');
   return TITLE_PROMPT_EXAMPLE_TITLES.some(
     (example) => example.toLowerCase() === normalized,
   );

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -46,6 +46,19 @@ Return ONLY a JSON object with a single "title" key. No preamble, no reasoning, 
 const TITLE_USER_PROMPT =
   'Generate the session title now. Populate the schema with a single short title string.';
 
+// The "Good examples" shown to the model in TITLE_SYSTEM_PROMPT. When the
+// recent conversation carries little topical signal (boilerplate-heavy
+// channel/hook context), the model takes the cheapest schema-valid answer
+// and parrots one of these back verbatim (#9706). A canned example says
+// nothing about the session, so matches are rejected like empty results.
+// Keep in sync with the "Good examples" block in TITLE_SYSTEM_PROMPT.
+const TITLE_PROMPT_EXAMPLE_TITLES = [
+  'Fix login button on mobile',
+  'Add OAuth authentication flow',
+  'Debug failing CI pipeline tests',
+  '重构用户鉴权中间件',
+];
+
 const TITLE_SCHEMA = {
   type: 'object',
   properties: {
@@ -80,9 +93,10 @@ const TRAILING_PAIRED_BRACKETS_RE =
  *   usually means the session hasn't authenticated yet.
  * - `empty_history`: the conversation has fewer than 2 turns of usable text.
  *   User should send at least one message before asking for a title.
- * - `empty_result`: the model returned nothing parseable into a title. Often
- *   means the model is too small or the conversation text is meaningless
- *   (e.g., only tool calls).
+ * - `empty_result`: the model returned nothing parseable into a title, or
+ *   only parroted back one of the prompt's own example titles (#9706).
+ *   Often means the model is too small or the conversation text is
+ *   meaningless (e.g., only tool calls).
  * - `aborted`: AbortSignal fired (user pressed Ctrl-C / new session / switch).
  * - `model_error`: the LLM call threw — rate limit, auth, network, etc.
  */
@@ -168,7 +182,9 @@ export async function tryGenerateSessionTitle(
     const rawTitle =
       typeof result?.['title'] === 'string' ? (result['title'] as string) : '';
     const title = sanitizeTitle(rawTitle);
-    if (!title) return { ok: false, reason: 'empty_result' };
+    if (!title || isPromptExampleEcho(title)) {
+      return { ok: false, reason: 'empty_result' };
+    }
 
     return { ok: true, title, modelUsed: model };
   } catch (err) {
@@ -209,6 +225,20 @@ export function sanitizeTitle(s: string): string {
     t = t.replace(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '');
   }
   return t;
+}
+
+/**
+ * Detect a sanitized title that is just the model echoing one of the
+ * prompt's own "Good examples" back (#9706). Exact, case-insensitive match
+ * after sanitization — deliberately not fuzzy, so a genuinely topical title
+ * that merely resembles an example still passes. Also catches the prompt's
+ * "Bad (wrong case)" variant of the first example.
+ */
+function isPromptExampleEcho(title: string): boolean {
+  const normalized = title.trim().toLowerCase();
+  return TITLE_PROMPT_EXAMPLE_TITLES.some(
+    (example) => example.toLowerCase() === normalized,
+  );
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Adds a guard to the session-title generation path: if the model's output matches one of the "Good examples" in the title system prompt verbatim (exact, case-insensitive comparison after the existing sanitization), it is now treated as an `empty_result`. Callers then take the pre-existing fallback unchanged — auto-title skips the write (retries bounded by the existing `AUTO_TITLE_ATTEMPT_CAP`), and `/rename --auto` surfaces its actionable message. No new failure reason, no config, no change to temperature/maxAttempts or the prompt itself.

This also updates the pre-existing "returns {ok:true, title, modelUsed} on success" unit test, which mocked the model returning `"Fix login button on mobile"` — literally one of the prompt examples — and asserted it was accepted; that test encoded the bug. It now uses a non-example title, and new regression tests cover the guard.

## Why it's needed

#9706: auto-generated session titles can echo a `TITLE_SYSTEM_PROMPT` example verbatim — most visibly `"Fix login button on mobile"` appearing as the title of sessions that have nothing to do with a login button. The title side query feeds the model only the last 1000 characters of recent dialog, so in boilerplate-heavy sessions (channel memory, hook context, included payloads) there is little topical signal and copying an example becomes the cheapest schema-valid answer; `temperature: 0.2` + `maxAttempts: 1` then makes it deterministic. `sanitizeTitle` strips formatting/punctuation/control sequences but had no echo guard, so the canned title was accepted and displayed as the session's identity.

## Reviewer Test Plan

### How to verify

Deterministic unit-level reproduction, no live model needed (mock the title side-query response):

1. On the parent commit (`git checkout HEAD~1 -- packages/core/src/services/sessionTitle.ts` and run `npx vitest run src/services/sessionTitle.test.ts` inside `packages/core`), the two new `#9706` tests fail red — the mocked model response `"Fix login button on mobile"` comes back as `{ ok: true, title: 'Fix login button on mobile', modelUsed: 'qwen-turbo' }` instead of `{ ok: false, reason: 'empty_result' }`. That failure is the bug.
2. With the fix applied, `cd packages/core && npx vitest run src/services/sessionTitle.test.ts` → 28 passed (28). The verbatim echo, case variants (including the prompt's own "Bad (wrong case)" example), padded/trailing-punctuation variants, and the CJK example are all rejected via `empty_result`; a near-miss topical title (`"Fix login button styling"`) is still accepted — the guard is deliberately exact-after-normalization, not fuzzy.
3. Consumer paths unaffected: `npx vitest run src/services/chatRecordingService.autoTitle.test.ts src/services/chatRecordingService.customTitle.test.ts` → 47 passed (47); `packages/core` typecheck (`tsc --noEmit`) clean; eslint + prettier clean on the changed files.

### Evidence (Before & After)

N/A — core-internal title generation; no user-visible TUI change. The red/green test output above is the evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest`), Node v24.19.0.

## Risk & Scope

- Main risk or tradeoff: a session genuinely about the example's topic (e.g. actually fixing a mobile login button) could produce exactly the example title and get rejected. Acceptable per the issue discussion: the fallback is merely an untitled session (auto-title retries up to the existing cap), never wrong data. Comparison is exact after trim/case normalization — no fuzzy matching, so near-miss real titles pass.
- Not validated / out of scope: temperature/maxAttempts and the example order are untouched; the "Bad" examples in the prompt (e.g. `"Code changes"`) are not part of the guard set — the reported echo concerns the Good examples, and guarding more strings can be added later if observed. No live-model run (the repro is deterministic at the unit level).
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9706

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为会话标题生成路径增加一道守卫：如果模型输出与标题系统提示词中的某个 "Good examples" 完全一致（在既有 sanitize 之后做精确、大小写不敏感的比较），则按 `empty_result` 处理。调用方随后走既有回退路径，不做任何改动——自动标题跳过写入（重试受既有 `AUTO_TITLE_ATTEMPT_CAP` 上限约束），`/rename --auto` 给出可操作的提示。没有新增失败原因、没有配置项、不改 temperature/maxAttempts，也不改提示词本身。

同时更新了既有的 "returns {ok:true, title, modelUsed} on success" 单元测试：它原本把模型 mock 成返回 `"Fix login button on mobile"`——恰好是提示词里的示例之一——并断言该标题被接受；这个测试把 bug 固化成了预期行为。现在它改用非示例标题，并新增回归测试覆盖守卫逻辑。

## 为什么需要

#9706：自动生成的会话标题可能原样复读 `TITLE_SYSTEM_PROMPT` 里的示例——最典型的是与登录按钮毫无关系的会话却显示标题 `"Fix login button on mobile"`。标题 side query 只喂给模型最近对话的最后 1000 个字符，因此在样板内容占多数的会话（channel memory、hook 上下文、include 的载荷）里几乎没有主题信号，照抄示例成了最省力的合法输出；`temperature: 0.2` + `maxAttempts: 1` 又使其趋于确定性。`sanitizeTitle` 只清理格式/标点/控制序列，没有回显守卫，于是罐头标题被接受并显示为会话标识。

## 审阅者测试计划

### 如何验证

确定性的单元级复现，无需真实模型（mock 标题 side-query 的返回）：

1. 在父提交上（`git checkout HEAD~1 -- packages/core/src/services/sessionTitle.ts`，然后在 `packages/core` 下运行 `npx vitest run src/services/sessionTitle.test.ts`），两个新增的 `#9706` 测试会红——mock 的模型返回 `"Fix login button on mobile"` 时，结果是 `{ ok: true, title: 'Fix login button on mobile', modelUsed: 'qwen-turbo' }` 而非 `{ ok: false, reason: 'empty_result' }`。这个失败就是 bug 本身。
2. 应用修复后，`cd packages/core && npx vitest run src/services/sessionTitle.test.ts` → 28 passed (28)。原样回显、大小写变体（含提示词自带的 "Bad (wrong case)" 示例）、带空白/尾标点变体、CJK 示例全部被按 `empty_result` 拒绝；近似但不同的真实标题（`"Fix login button styling"`）仍被接受——守卫刻意只做归一化后的精确匹配，不做模糊匹配。
3. 消费方路径不受影响：`npx vitest run src/services/chatRecordingService.autoTitle.test.ts src/services/chatRecordingService.customTitle.test.ts` → 47 passed (47)；`packages/core` typecheck（`tsc --noEmit`）通过；改动文件 eslint + prettier 均干净。

### 前后对比证据

N/A——core 内部标题生成，无用户可见 TUI 变化。上面的红/绿测试输出即证据。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元测试（`vitest`），Node v24.19.0。

## 风险与范围

- 主要风险/权衡：真正围绕示例主题的会话（比如确实在修移动端登录按钮）可能恰好生成与示例完全相同的标题而被拒绝。按 issue 讨论这是可接受的：回退只是暂时没有标题（自动标题有既有重试上限），绝不会是错误数据。比较在 trim/大小写归一化后做精确匹配——不做模糊匹配，因此近似的真实标题不受影响。
- 未验证/超出范围：temperature/maxAttempts 与示例顺序不动；提示词里的 "Bad" 示例（如 `"Code changes"`）不纳入守卫集合——报告的回显问题针对 Good examples，后续若观察到再补充。未做真实模型运行（复现在单元级是确定性的）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #9706

</details>
