### PR TITLE
i18n(cli): translate Unset in the settings dialog

### DIFF
--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -512,6 +512,7 @@ export default {
   'Tool Output Truncation Lines': "Línies de truncament de la sortida d'eines",
   'Folder Trust': 'Confiança de carpeta',
   'Tool Schema Compliance': 'Compliment de Tool Schema',
+  Unset: 'No definit',
   'Auto (detect from system)': 'Automàtic (detectar del sistema)',
   'Auto (follow user input)': "Automàtic (seguir l'entrada de l'usuari)",
   'Auto (detect terminal theme)': 'Automàtic (detectar el tema del terminal)',

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -444,6 +444,7 @@ export default {
   'Tool Output Truncation Lines': 'Zeilen für Werkzeugausgabe-Kürzung',
   'Folder Trust': 'Ordnervertrauen',
   'Tool Schema Compliance': 'Tool Schema-Konformität',
+  Unset: 'Nicht festgelegt',
   // Settings enum options
   'Auto (detect from system)': 'Automatisch (vom System erkennen)',
   'Auto (follow user input)': 'Automatisch (Benutzereingabe folgen)',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -765,6 +765,7 @@ export default {
   'Tool Output Truncation Lines': 'Tool Output Truncation Lines',
   'Folder Trust': 'Folder Trust',
   'Tool Schema Compliance': 'Tool Schema Compliance',
+  Unset: 'Unset',
   // Settings enum options
   'Auto (detect from system)': 'Auto (detect from system)',
   'Auto (follow user input)': 'Auto (follow user input)',

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -520,6 +520,7 @@ export default {
   'Tool Output Truncation Lines': 'Lignes de troncature de sortie des outils',
   'Folder Trust': 'Confiance des dossiers',
   'Tool Schema Compliance': 'Conformité Tool Schema',
+  Unset: 'Non défini',
   'Auto (detect from system)': 'Auto (détecter depuis le système)',
   'Auto (follow user input)': "Auto (suivre l'entrée utilisateur)",
   'Auto (detect terminal theme)': 'Auto (détecter le thème du terminal)',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -392,6 +392,7 @@ export default {
   'Tool Output Truncation Threshold': 'ツール出力切り詰めのしきい値',
   'Tool Output Truncation Lines': 'ツール出力の切り詰め行数',
   'Tool Schema Compliance': 'Tool Schema 準拠',
+  Unset: '未設定',
   'Auto (detect from system)': '自動(システムから検出)',
   'Auto (follow user input)': '自動(ユーザー入力に従う)',
   'Auto (detect terminal theme)': '自動（端末テーマを検出）',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -467,6 +467,7 @@ export default {
     'Linhas de Truncamento de Saída de Ferramenta',
   'Folder Trust': 'Confiança de Pasta',
   'Tool Schema Compliance': 'Conformidade de Tool Schema',
+  Unset: 'Não definido',
 
   // Settings enum options
   'Auto (detect from system)': 'Automático (detectar do sistema)',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -463,6 +463,7 @@ export default {
   'Tool Output Truncation Lines': 'Лимит строк вывода инструментов',
   'Folder Trust': 'Доверие к папке',
   'Tool Schema Compliance': 'Соответствие Tool Schema',
+  Unset: 'Не задано',
   // Варианты перечислений настроек
   'Auto (detect from system)': 'Авто (определить из системы)',
   'Auto (follow user input)': 'Авто (следовать вводу пользователя)',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -724,6 +724,7 @@ export default {
   'Tool Output Truncation Lines': '工具輸出截斷行數',
   'Folder Trust': '檔案夾信任',
   'Tool Schema Compliance': 'Tool Schema 兼容性',
+  Unset: '未設定',
   'Auto (detect from system)': '自動（從系統檢測）',
   'Auto (follow user input)': '自動（跟隨使用者輸入）',
   'Auto (detect terminal theme)': '自動（檢測終端主題）',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -766,6 +766,7 @@ export default {
   'Tool Output Truncation Lines': '工具输出截断行数',
   'Folder Trust': '文件夹信任',
   'Tool Schema Compliance': 'Tool Schema 兼容性',
+  Unset: '未设置',
   // Settings enum options
   'Auto (detect from system)': '自动（从系统检测）',
   'Auto (follow user input)': '自动（跟随用户输入）',

--- a/packages/cli/src/i18n/mustTranslateKeys.ts
+++ b/packages/cli/src/i18n/mustTranslateKeys.ts
@@ -131,4 +131,5 @@ export const MUST_TRANSLATE_KEYS = [
   'best',
   'Token Trend',
   'In/Out',
+  'Unset',
 ] as const;


### PR DESCRIPTION
## What this PR does

This PR adds an `Unset` entry to all 9 CLI locale dictionaries (`packages/cli/src/i18n/locales/{en,zh,zh-TW,ja,de,fr,ru,pt,ca}.js`, placed with the other settings labels) with the translations agreed in the #5821 review thread — zh `未设置`, zh-TW `未設定`, ja `未設定`, de `Nicht festgelegt`, fr `Non défini`, ru `Не задано`, pt `Não definido`, ca `No definit`, en `Unset` — and registers `'Unset'` in `MUST_TRANSLATE_KEYS` so the normal i18n checks (`npm run check-i18n` plus the must-translate test suite) cover this key from now on.

## Why it's needed

The settings dialog will display `Unset` for settings with an undefined default once #5821 lands (that PR introduces the `t('Unset')` call sites in `getDisplayValue` in `packages/cli/src/utils/settingsUtils.ts`, plain branch and enum fall-through). The key is missing from every locale dictionary, and `t()` silently falls back to the key itself (`translations[key] ?? key`), so all non-English locales would show the English word "Unset" amid otherwise translated rows. Because the key is also absent from `MUST_TRANSLATE_KEYS`, no existing check catches the gap — this issue tracks that omission as a follow-up from the late review rounds on #5821.

## Reviewer Test Plan

### How to verify

The repo's own i18n checks produce the red→green evidence. With `'Unset'` declared in `MUST_TRANSLATE_KEYS` but the locale entries absent (this PR's `mustTranslateKeys.ts` change alone), `npm run check-i18n` in `packages/cli` exits 1 with 8 errors `Required translation still falls back to English in <locale>.js: "Unset"` (one per non-English locale), and `npx vitest run src/i18n/mustTranslateKeys.test.ts` fails 9 tests with `expected [ 'Unset' ] to deeply equal []` — direct runtime proof that `t('Unset')` falls back to English in every non-English locale. With this PR's locale entries applied, both turn green: `npm run check-i18n` exits 0 (`✅ All checks passed!`) and `npx vitest run src/i18n/mustTranslateKeys.test.ts src/i18n/index.test.ts` passes 31/31. A runtime probe (`setLanguageAsync(lang)` then `t('Unset')`) now returns the translated value for all 8 non-English locales. Also run: `npm run typecheck` in `packages/cli` (passes), `npx prettier --check` and `npx eslint --max-warnings 0` on the ten changed files (both pass).

Sequencing note: the only `t('Unset')` call sites live in the still-open #5821, so until that PR merges, `Unset` appears in check-i18n's pre-existing "unused translation keys" warning bucket (warning-only — the check still passes; the repo already carries ~340 such keys). The warning disappears once #5821 merges. This matches the sequencing suggested in the #9713 triage comment.

### Evidence (Before & After)

N/A (i18n data + check-coverage change, no user-visible rendering change on current main — the dialog branch that consumes this key ships with #5821). Red/green command output is summarized under "How to verify".

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node v24.19.0, npm 11.17.0 on Linux; verification via `npm run check-i18n`, vitest i18n suites, a tsx runtime probe, and `npm run typecheck` in `packages/cli` — no dev server or TUI session.

## Risk & Scope

- Main risk or tradeoff: sequencing with #5821 — until #5821 merges, `Unset` has no call site on main and shows up in the check-i18n unused-keys warning; if #5821 were closed unmerged, the entries would need to come back out.
- Not validated / out of scope: runtime rendering of the settings dialog (the consuming branch is in unmerged #5821, which also handles the enum fall-through for undefined defaults itself). No full-monorepo test run — only the i18n suites, check-i18n, and cli typecheck.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9713
Refs #5821

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 在全部 9 个 CLI 语言文件（`packages/cli/src/i18n/locales/{en,zh,zh-TW,ja,de,fr,ru,pt,ca}.js`，与其他设置项标签放在一起）中补上了 `Unset` 条目，译文采用 #5821 评审线程中达成一致的结果 —— zh `未设置`、zh-TW `未設定`、ja `未設定`、de `Nicht festgelegt`、fr `Non défini`、ru `Не задано`、pt `Não definido`、ca `No definit`、en `Unset` —— 并把 `'Unset'` 加入 `MUST_TRANSLATE_KEYS`，让常规 i18n 检查（`npm run check-i18n` 和 must-translate 测试）从此覆盖这个 key。

## 为什么需要

一旦 #5821 合入，设置对话框会对默认值为 undefined 的设置项显示 `Unset`（该 PR 在 `packages/cli/src/utils/settingsUtils.ts` 的 `getDisplayValue` 中引入了 `t('Unset')` 调用点，包括 plain 分支和 enum fall-through）。由于所有语言文件都缺这个 key，而 `t()` 会静默回退为 key 本身（`translations[key] ?? key`），所有非英文语言都会在已翻译的界面中显示英文单词 "Unset"。又因为这个 key 不在 `MUST_TRANSLATE_KEYS` 里，现有检查都无法发现这个缺失 —— 本 issue 就是 #5821 后期评审中针对该遗漏的后续跟踪。

## 评审者测试计划

### 如何验证

仓库自带的 i18n 检查提供了红转绿证据。只在 `MUST_TRANSLATE_KEYS` 中声明 `'Unset'` 而语言文件缺条目时（即只应用本 PR 的 `mustTranslateKeys.ts` 改动），在 `packages/cli` 下运行 `npm run check-i18n` 会以退出码 1 失败，报 8 个错误 `Required translation still falls back to English in <locale>.js: "Unset"`（每个非英文语言一个）；`npx vitest run src/i18n/mustTranslateKeys.test.ts` 有 9 个测试失败，报 `expected [ 'Unset' ] to deeply equal []` —— 这是 `t('Unset')` 在每个非英文语言下都回退为英文的直接运行时证据。应用本 PR 的语言文件条目后两者转绿：`npm run check-i18n` 退出码 0（`✅ All checks passed!`），`npx vitest run src/i18n/mustTranslateKeys.test.ts src/i18n/index.test.ts` 31/31 通过。运行时探针（`setLanguageAsync(lang)` 后调用 `t('Unset')`）在全部 8 个非英文语言下都返回翻译后的值。另外还跑了：`packages/cli` 下 `npm run typecheck`（通过）、对 10 个改动文件的 `npx prettier --check` 和 `npx eslint --max-warnings 0`（均通过）。

顺序说明：`t('Unset')` 的唯一调用点在尚未合并的 #5821 中，所以在该 PR 合入前，`Unset` 会出现在 check-i18n 既有的 “unused translation keys” 警告里（仅警告，检查仍然通过；仓库目前已有约 340 个这类 key）。#5821 合入后该警告自动消失。这与 #9713 triage 评论建议的顺序一致。

### 证据（修改前 / 修改后）

N/A（i18n 数据 + 检查覆盖改动，当前 main 上没有用户可见的渲染变化 —— 消费该 key 的对话框分支随 #5821 一起上线）。红转绿的命令输出见「如何验证」。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### 环境（可选）

Linux 上 Node v24.19.0、npm 11.17.0；验证方式为 `npm run check-i18n`、vitest i18n 测试套件、tsx 运行时探针，以及 `packages/cli` 下的 `npm run typecheck` —— 没有启动 dev server 或 TUI 会话。

## 风险与范围

- 主要风险或权衡：与 #5821 的合并顺序 —— 在 #5821 合入前，`Unset` 在 main 上没有调用点，会出现在 check-i18n 的 unused-keys 警告里；如果 #5821 最终关闭不合入，这些条目需要一并撤掉。
- 未验证 / 不在范围内：设置对话框的运行时渲染（消费分支在未合并的 #5821 中，undefined 默认值的 enum fall-through 场景也由 #5821 自身处理）。没有跑整个 monorepo 的全量测试 —— 只跑了 i18n 测试套件、check-i18n 和 cli typecheck。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #9713
Refs #5821

</details>
