### PR TITLE
fix(review): stop shedding the convergence observation first

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -2693,8 +2693,9 @@ describe('composeReviewCommand handler (the CLI glue)', () => {
 
   it('prints the convergence paragraph the trim notice points at', async () => {
     // `noteTrimmedRanks` tells the author the shed sections "still hold —
-    // read them in the terminal report", and rank 0 is the first thing the
-    // ladder sheds. Without this line that promise names nothing.
+    // read them in the terminal report". The convergence paragraph is the
+    // LAST rank the ladder sheds, so this line is the only other copy the
+    // promise can point at. Without it that promise names nothing.
     const dir = mkdtempSync(join(tmpdir(), 'compose-convergence-'));
     const inputPath = join(dir, 'compose.json');
     const commentsPath = join(dir, 'comments.json');
@@ -9369,19 +9370,21 @@ describe('convergence diagnosis reaches the POSTED body', () => {
     expect(r.body).toContain('Convergence:');
   });
 
-  it('yields the whole paragraph before any disclosure that qualifies the verdict', () => {
-    // The rounds this fires on are the high-volume rounds most likely to
-    // overflow, and the paragraph decides nothing — so it is the FIRST thing
-    // the ladder sheds. Untagged it ranked with the blockers and outlived
-    // the not-reviewed disclosures, which do qualify what was read.
+  it('outlives every disclosure the ladder can shed', () => {
+    // It was rank 0 — shed second, right after the mechanism-health note —
+    // on the reasoning that an advisory paragraph decides nothing. The
+    // arithmetic refutes that ordering: rendered bilingually the paragraph
+    // is 603 characters on a volume-only signal and 2,372 at its largest,
+    // against a 56,830-character budget. Shed early it could pay for at
+    // most 4% of an overflow, so any overflow bigger than itself spent it
+    // AND went on to spend the disclosures — and the rounds this fires on
+    // are the high-volume ones where that is the normal case. It is rank 3
+    // now: the last rank to go, because it is the cheapest to keep and the
+    // only one whose reader is the PR author alone.
     //
-    // The blocker is sized so the ladder sheds rank 0 — the convergence
-    // paragraph, which yields before every other rank — and stops. Shed
-    // everything and the body is identical whichever order the ladder used,
-    // so the order would have no guard at all, which is why this constant is
-    // tuned rather than round. To retune after a body-copy change: raise it
-    // until `Convergence:` disappears, and stop before `Not reviewed:` does.
-    // The window is as wide as the paragraph itself.
+    // The blocker is sized to land in the window where the ladder sheds
+    // rank 2 and stops. To retune after a body-copy change: raise it until
+    // `Not reviewed:` disappears, and stop before `Convergence:` does.
     sideFile({
       round: 4,
       posted: 9,
@@ -9392,7 +9395,43 @@ describe('convergence diagnosis reaches the POSTED body', () => {
       modelId: 'm',
       criticalsInline: 0,
       suggestionsInline: 1,
-      bodyCriticals: ['B'.repeat(55_850)],
+      bodyCriticals: ['B'.repeat(55_600)],
+      unreviewedDimensions: ['security'],
+      draftedComments: [
+        { path: 'src/a.ts', line: 1, body: '**[Suggestion]** again' },
+      ],
+    });
+    expect(r.body.length).toBeLessThanOrEqual(65536);
+    expect(r.body).toContain('Convergence:');
+    expect(r.body).not.toContain('Not reviewed:');
+    // And the notice names what ACTUALLY went. Every notice surface keys on
+    // the rank, so a rank that sheds the wrong section announces the wrong
+    // one too.
+    expect(r.body).toContain('the not-reviewed and non-blocking disclosures');
+    expect(r.body).not.toContain('the convergence observation');
+    expect(r.bodyTrim.deferralList).toBe(false);
+  });
+
+  it('still yields — last, and named — when shedding the rest was not enough', () => {
+    // Ranked last is not unrankable. A body that cannot hold its blockers
+    // must still drop an advisory, and being ranked is what makes the trim
+    // notice say so instead of the paragraph vanishing silently.
+    //
+    // Sized one rung past the test above: the ladder sheds rank 2, still
+    // does not fit, sheds rank 3, and stops before the hard cut. To retune:
+    // raise it until `Convergence:` disappears, and stop before `TRUNCATED`
+    // appears.
+    sideFile({
+      round: 4,
+      posted: 9,
+      findings: [{ id: 'R2-1', sev: 'S', file: 'src/a.ts', title: 'x' }],
+    });
+    const r = composeReview({
+      planPath: plan(),
+      modelId: 'm',
+      criticalsInline: 0,
+      suggestionsInline: 1,
+      bodyCriticals: ['B'.repeat(56_100)],
       unreviewedDimensions: ['security'],
       draftedComments: [
         { path: 'src/a.ts', line: 1, body: '**[Suggestion]** again' },
@@ -9400,17 +9439,11 @@ describe('convergence diagnosis reaches the POSTED body', () => {
     });
     expect(r.body.length).toBeLessThanOrEqual(65536);
     expect(r.body).not.toContain('Convergence:');
-    // A lower-ranked disclosure outlives it: the ladder reached this far and
-    // the paragraph went first.
-    expect(r.body).toContain('Not reviewed:');
-    // And the notice names what ACTUALLY went. Every notice surface keys on
-    // the rank, so sharing a rank with the deferral list made a round that
-    // shed only this paragraph announce a deferred-findings list that never
-    // existed and point the author at artifact entries that do not exist.
     expect(r.body).toContain('the convergence observation');
-    expect(r.body).not.toContain('the deferred-findings list');
-    expect(r.body).not.toContain('findings artifact');
-    expect(r.bodyTrim.deferralList).toBe(false);
+    expect(r.body).toContain('the not-reviewed and non-blocking disclosures');
+    // The rank path, not the cut: a truncated body would prove nothing
+    // about the ORDER the ranks went in.
+    expect(r.body).not.toContain('TRUNCATED');
   });
 
   it('stamps the posting floor this round ran under beside its volume', () => {
@@ -10096,8 +10129,9 @@ describe('convergence diagnosis reaches the POSTED body', () => {
   });
 
   it('names the health note in the trim notice, not the convergence one', () => {
-    // With no diagnosis firing, rank -1 holds ONLY this note. Sharing rank 0
-    // made the notice name "the convergence observation" for a section that
+    // With no diagnosis firing, rank -1 holds ONLY this note. Sharing the
+    // convergence paragraph's rank made the notice name
+    // "the convergence observation" for a section that
     // never existed in the body.
     sideFile({ round: 4, posted: 9, fresh: 9, findings: [] });
     const r = composeReview({

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -9545,9 +9545,10 @@ describe('convergence diagnosis reaches the POSTED body', () => {
     expect(r.body).not.toContain('9999');
   });
 
-  it('leaves a terminal copy of the paragraph the ladder sheds first', () => {
-    // Rank 0 goes first, and the trim notice tells the author the trimmed
-    // sections "still hold — read them in the terminal report". Unlike the
+  it('leaves a terminal copy of the paragraph the ladder can shed', () => {
+    // The paragraph is the LAST rank the ladder sheds, and the trim notice
+    // tells the author the trimmed sections "still hold — read them in the
+    // terminal report" whichever rank went. Unlike the
     // deferral list (findings artifact) and the not-reviewed disclosures
     // (the model's own inputs), a diagnosis derived from the side file has
     // no other copy anywhere unless the composed result carries one.
@@ -9641,6 +9642,13 @@ describe('convergence diagnosis reaches the POSTED body', () => {
     // The promise the trim notice makes is about a body that DROPPED the
     // paragraph. A test that asserts the body still contains it never
     // reaches the case the copy exists for.
+    //
+    // Sized like the two order tests above, and for the same reason: the
+    // paragraph is the last rank the ladder sheds, so reaching a body that
+    // dropped it means sizing past every other rank. The window here runs
+    // 55,825–56,350 — this constant sat at 55,850, twenty-five characters
+    // above its own floor. To retune after a body-copy change: raise it
+    // until `Convergence:` disappears, and stop before `TRUNCATED` appears.
     sideFile({
       round: 4,
       posted: 9,
@@ -9652,13 +9660,14 @@ describe('convergence diagnosis reaches the POSTED body', () => {
       modelId: 'm',
       criticalsInline: 0,
       suggestionsInline: 1,
-      bodyCriticals: ['B'.repeat(55_850)],
+      bodyCriticals: ['B'.repeat(56_100)],
       unreviewedDimensions: ['security'],
       draftedComments: [
         { path: 'src/a.ts', line: 1, body: '**[Suggestion]** again' },
       ],
     });
     expect(r.body).not.toContain('Convergence:');
+    expect(r.body).not.toContain('TRUNCATED');
     expect(r.convergence?.en).toContain('Convergence:');
   });
 

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -6911,8 +6911,9 @@ describe('composeReview — convergence-posture deferrals (typed channel; disclo
 describe("composeReview — the composed body fits GitHub's limit", () => {
   // A POST over 65,536 characters is rejected WHOLE — the review's blockers
   // included — so the body carries its own budget. What it may drop, and in
-  // what order, is the policy under test: the deferral display yields first,
-  // the not-reviewed disclosures second, the blockers and the caps never.
+  // what order, is the policy under test: the mechanism-health note yields
+  // first, then the deferral display, then the not-reviewed disclosures,
+  // then the convergence observation, and the blockers and the caps never.
   const LIMIT = 65536;
   /** An unpaired half in EITHER direction — the oracle was one-sided. */
   const LONE_SURROGATE =

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -828,12 +828,15 @@ export interface ComposeReviewResult {
    * The convergence paragraph, when a signal fired — the SAME text the body
    * carries, returned so a terminal copy exists.
    *
-   * The overflow ladder sheds this paragraph first, and its notice tells the
+   * The overflow ladder can shed this paragraph — last of its ranks, and
+   * see the convergence block below for why last — and its notice tells the
    * author the trimmed sections "still hold — read them in the terminal
    * report". That was a false record while this text lived only inside the
    * body composer: unlike the deferral list (findings artifact) and the
    * not-reviewed disclosures (the model's own inputs), a diagnosis derived
-   * from the side file has no other copy anywhere.
+   * from the side file has no other copy anywhere. Ranking it last does not
+   * retire this copy — it makes it the one that matters, because the rounds
+   * that reach rank 3 are the rounds that shed everything.
    */
   convergence?: { en: string; zh: string };
   /**
@@ -3743,8 +3746,10 @@ function composeReviewBody(
         ...floorEnforcedNote,
         {
           // Rank 1: the display of findings the review deliberately did NOT
-          // request is the first thing to yield when the body overflows —
-          // the artifact and the terminal report keep every entry whole.
+          // request is the first CONTENT rank to yield when the body
+          // overflows — only the operator-facing mechanism-health note
+          // (rank -1) goes before it — and the artifact and the terminal
+          // report keep every entry whole.
           trim: 1,
           en: `Deferred under the convergence posture (round ${deferredRound}, not a blocker) — recorded, not requested in this round:\n\n${deferredShown
             .map((entry) => `- ${mdField(entry)}`)
@@ -3757,10 +3762,10 @@ function composeReviewBody(
     : [];
 
   // The not-reviewed disclosures yield after the deferral display and before
-  // nothing else: they say what the review could not certify, which the
-  // verdict's own cap already carries, so trimming them costs detail rather
-  // than the claim. (`notReviewedParts` itself stays untagged — the length
-  // checks below ask about presence, not about rank.)
+  // the convergence observation: they say what the review could not certify,
+  // which the verdict's own cap already carries, so trimming them costs
+  // detail rather than the claim. (`notReviewedParts` itself stays untagged
+  // — the length checks below ask about presence, not about rank.)
   const notReviewedForBody: Bi[] = notReviewedParts.map((p) => ({
     ...p,
     trim: 2,
@@ -4946,11 +4951,12 @@ export const composeReviewCommand: CommandModule = {
           : ` (previous round: ${result.prevPostedInline})`),
     );
     // The terminal copy the body's own trim notice promises. The convergence
-    // paragraph is the first thing the overflow ladder sheds, and unlike the
-    // deferral list (findings artifact) or the not-reviewed disclosures (the
-    // model's own inputs) it has no other copy anywhere — so the notice's
-    // "read them in the terminal report" was a false record until this line
-    // existed.
+    // paragraph is the ladder's LAST rank, and unlike the deferral list
+    // (findings artifact) or the not-reviewed disclosures (the model's own
+    // inputs) it has no other copy anywhere — so the notice's "read them in
+    // the terminal report" was a false record until this line existed. Last
+    // does not mean safe: a body that reaches rank 3 has already shed every
+    // other rank, which is exactly when this line is the only copy left.
     if (result.convergence) {
       writeStderrLine(`CONVERGENCE: ${result.convergence.en}`);
     }

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -2973,12 +2973,14 @@ function composeReviewBody(
   /** What a rank drops, in the author's words — the note names it. */
   const RANK_NAMES: Record<number, { en: string; zh: string }> = {
     [-1]: { en: 'the mechanism-health note', zh: '机制健康说明' },
-    0: { en: 'the convergence observation', zh: '收敛情况观察' },
     1: { en: 'the deferred-findings list', zh: '延后发现清单' },
     2: {
       en: 'the not-reviewed and non-blocking disclosures',
       zh: '未审查范围与非阻断披露',
     },
+    // Last, and see the block that carries it for why: it is the smallest
+    // rank and the only one whose reader is the PR author alone.
+    3: { en: 'the convergence observation', zh: '收敛情况观察' },
   };
 
   /**
@@ -3054,7 +3056,7 @@ function composeReviewBody(
    * last-resort path drops ranks AND cuts, and a stderr record naming only
    * the cut leaves the kinds it dropped disclosed nowhere but the body.
    * Rank 1 has a second durable copy (each deferral is a `D<round>-<n>`
-   * entry in the findings artifact) and rank 0 has one too (the composed
+   * entry in the findings artifact) and rank 3 has one too (the composed
    * result carries the paragraph, and the command prints it as
    * `CONVERGENCE:`); a trimmed disclosure section survives nowhere but the
    * terminal summary, so ask for it there rather than pointing at an
@@ -3771,13 +3773,28 @@ function composeReviewBody(
   // paragraph here that comments on the SHAPE of the review history rather
   // than on the diff.
   //
-  // `trim: 0` — its own rank, shed before every other EXCEPT the
-  // mechanism-health note below it (rank -1, and see there for why it goes
-  // first). An untagged block
-  // ranks with the blockers and the verdict-qualifying sentences, and the
-  // rounds this fires on are precisely the high-volume rounds most likely to
-  // overflow: unranked, an advisory paragraph that decides nothing survived
-  // while the deferral list and the not-reviewed disclosures were spent.
+  // `trim: 3` — the LAST rank the ladder sheds, and the reason is
+  // arithmetic. Rendered bilingually this paragraph runs 603 characters when
+  // only the volume signal fired, 1,510 with three clusters, and 2,372 with
+  // the clusters, the evidence caveats and the land reading together —
+  // against a body budget of 56,830. Shed second (it was rank 0), it could
+  // pay for at most 4% of an overflow, so any overflow larger than itself
+  // spent it and then went on to spend the deferral list and the
+  // not-reviewed disclosures anyway. On the rounds this fires on — the
+  // high-volume ones — that is the normal case, not the edge: the author
+  // lost the only sentence about the SHAPE of the loop and lost the
+  // disclosures too.
+  //
+  // It is still ranked rather than untagged: if the body genuinely cannot
+  // hold the blockers, an advisory must yield, and being ranked is what
+  // makes the trim notice name it when it does. It is ranked LAST because
+  // it is the cheapest block to keep and the only one whose reader is the
+  // author of the pull request alone — the deferral list has a second
+  // durable copy in the findings artifact, the disclosures are restated in
+  // the terminal report, and the mechanism-health note above it is written
+  // for the operator, who has the `HEALTH:` line. This paragraph is the
+  // whole of what this pipeline tells a PR author about a loop that is not
+  // settling; shedding it early bought almost nothing and cost exactly that.
   //
   // A rank of its own, not a share of the deferral list's: every notice
   // surface keys on the RANK, not on what actually went — the rank's name,
@@ -3831,15 +3848,16 @@ function composeReviewBody(
           anchorFailsClosed(cappedBy, scopeUnproven, dimensionGapsAreDepthOnly),
       })
     : null;
-  // Its OWN rank, shed before the convergence paragraph. Sharing rank 0 made
-  // the notice name "the convergence observation" for a body whose rank-0
-  // content was only this note — a section that never existed. It goes first
+  // Its OWN rank, shed before every other. Sharing the convergence
+  // paragraph's rank made the notice name "the convergence observation" for
+  // a body whose content at that rank was only this note — a section that
+  // never existed. It goes first
   // because its primary reader is the operator, who has the `HEALTH:`
   // terminal line, while the convergence paragraph's recommendations are
   // addressed to the author reading the PR.
   const healthBlock: Bi[] = healthNote ? [{ ...healthNote, trim: -1 }] : [];
   const convergenceBlock: Bi[] = convergenceNote
-    ? [{ ...convergenceNote, trim: 0 }]
+    ? [{ ...convergenceNote, trim: 3 }]
     : [];
 
   // The resumed-run continuity note: the run reused certified work from an

--- a/packages/cli/src/commands/review/save-artifact.test.ts
+++ b/packages/cli/src/commands/review/save-artifact.test.ts
@@ -452,8 +452,9 @@ describe('saveReviewArtifact', () => {
   it('carries the fresh count and the convergence paragraph into the artifact', () => {
     // Both are new surfaces on the composed result, and the allow-list is
     // where a new field silently stops existing. The paragraph matters most:
-    // it is the FIRST clause the overflow ladder sheds, so on the rounds it
-    // fires the artifact may be the only durable copy.
+    // the overflow ladder sheds it LAST, so a round that lost it from the
+    // body lost every other rank too, and the artifact may be the only
+    // durable copy.
     const paths = fixture();
     writeJson(paths.composed, {
       ...verdict,

--- a/packages/cli/src/commands/review/save-artifact.ts
+++ b/packages/cli/src/commands/review/save-artifact.ts
@@ -314,10 +314,11 @@ function validateVerdict(value: unknown): PersistedVerdict {
       'Composed verdict.postedInline must be a non-negative integer.',
     );
   }
-  // The convergence paragraph is the ONE clause the overflow ladder sheds
-  // first, and the artifact is where a trimmed round's record lives. Dropped
-  // by this allow-list, the durable record of a round whose body shed it
-  // held neither copy.
+  // The convergence paragraph is a clause the overflow ladder can shed —
+  // its last rank, so a body that shed it shed every other rank too — and
+  // the artifact is where a trimmed round's record lives. Dropped by this
+  // allow-list, the durable record of a round whose body shed it held
+  // neither copy.
   const rawConvergence = verdict['convergence'];
   let convergence: { en: string; zh: string } | undefined;
   if (rawConvergence !== undefined && rawConvergence !== null) {


### PR DESCRIPTION
## What this PR does

The posted review body carries one paragraph about the shape of the review loop rather than about the diff: the convergence observation — what recurred, whether the rate of first-time findings is falling, and the handling recommendations derived from those measurements. It was the second block the body-budget ladder shed, right behind the mechanism-health note. This moves it to the last rank the ladder sheds, so it survives every disclosure the budget can afford to drop instead, and goes only when dropping all of them was still not enough.

It stays ranked rather than becoming untrimmable. A body that genuinely cannot hold its blockers must drop an advisory, and being ranked is what makes the trim notice name it when that happens.

## Why it's needed

The old ordering rested on "an advisory paragraph decides nothing, so it should yield first". The arithmetic does not support it. Rendered bilingually the paragraph is 603 characters when only the volume signal fired, 1,510 with three recurrence clusters, and 2,372 with the clusters, the evidence caveats and the land reading together — against a body budget of 56,830 characters. Shed second it can pay for at most 4% of an overflow, so any overflow larger than the paragraph itself spent it and then went on to spend the disclosures anyway.

That is not an edge case. The rounds this paragraph fires on are precisely the high-volume rounds most likely to overflow — that is what it is for. So on its own target population the old order lost the reminder AND the disclosures.

Which one to keep, when the budget affords exactly one, is the substance of the change. The convergence observation is the cheapest block to keep, and the only one whose reader is the pull request's author alone: the deferred-findings list has a second durable copy in the run's findings artifact, the not-reviewed disclosures are restated in the terminal report, and the mechanism-health note ranked above it is written for the operator, who has the `HEALTH:` terminal line. The convergence paragraph is the whole of what this pipeline tells a PR author about a loop that is not settling.

## Reviewer Test Plan

### How to verify

`npx vitest run packages/cli/src/commands/review` — 98 files, 4,403 passing. That count is this directory only, which is the whole of what this change can reach; a full-repo run reports ~23,000 and is the same signal at a wider scope. Two tests carry the policy directly, both in `convergence diagnosis reaches the POSTED body`:

- `outlives every disclosure the ladder can shed` — sized to the window where the ladder sheds the not-reviewed disclosures and stops; asserts the paragraph survives and the trim notice names the disclosures rather than the paragraph.
- `still yields — last, and named — when shedding the rest was not enough` — sized one rung further; asserts the paragraph goes and the notice names it, before the hard cut.

Both constants are tuned rather than round, and each test says how to retune it after a body-copy change.

Mutation-verified, one named test each:

| Mutation | Red |
| --- | --- |
| restore `trim: 0` (the old ordering) | both new tests |
| make the block untagged (never shed by rank) | `still yields — last, and named …`, plus the existing `keeps the terminal copy on the round that actually sheds the paragraph` |
| remove the rank's entry from `RANK_NAMES` | only the naming assertion in `still yields — last, and named …` |

### Evidence (Before & After)

Same fixture through both trees, sweeping the blocker size across the overflow region. `conv` is the convergence observation, `notrev` the not-reviewed disclosures.

```
BEFORE 55400 conv=SHED notrev=kept   ||   AFTER  55400 conv=kept notrev=SHED
BEFORE 55500 conv=SHED notrev=kept   ||   AFTER  55500 conv=kept notrev=SHED
BEFORE 55600 conv=SHED notrev=kept   ||   AFTER  55600 conv=kept notrev=SHED
BEFORE 55700 conv=SHED notrev=kept   ||   AFTER  55700 conv=kept notrev=SHED
BEFORE 55800 conv=SHED notrev=kept   ||   AFTER  55800 conv=kept notrev=SHED
BEFORE 55900 conv=SHED notrev=SHED   ||   AFTER  55900 conv=SHED notrev=SHED
BEFORE 56000 conv=SHED notrev=SHED   ||   AFTER  56000 conv=SHED notrev=SHED
   … identical from here up, and truncating in both from 56400
```

Read honestly: below the region both bodies are whole; inside it the two orders swap which block the author keeps; above it both orders shed both blocks — which is the "spent and bought nothing" case the size measurement predicts, and it is visible from 55,900 up, where the old order shed the paragraph and still had to shed the disclosures.

The width of the swap window is the size of the ranks below the paragraph. This fixture's only lower rank is a not-reviewed block of comparable size, so the window is narrow here; a body also carrying a deferred-findings list — often several KB — widens it by that much.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`vitest`), plus `tsc --noEmit` on `packages/cli`.

## Risk & Scope

- Main risk or tradeoff: in the window where the budget affords exactly one, the author now keeps the convergence observation and loses the not-reviewed and non-blocking disclosures. Both losses are disclosed by the trim notice, which names what went; the disclosures are restated in the terminal report, and the paragraph would have had only the same terminal copy. The judgement is that the loop signal reaches nobody else, while the disclosures do.
- Not validated / out of scope: the tuned constants are sized against the current body copy — a change to the disclosure wording moves them, which is why both tests carry retuning instructions. No change to what the paragraph says, to when it fires, or to any verdict.
- Breaking changes / migration notes: none. `RANK_NAMES` gains a rank-3 entry and loses its rank-0 one; `bodyTrim.deferralList` and the artifact pointer key on rank 1 and are untouched.

## Linked Issues

Refs #9278

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

发布的评审正文里有且只有一段是在讲**评审回路的形态**而非 diff 本身：收敛情况观察——什么在反复出现、首次提出的产出速度是否下降，以及由这些测量推导出的处置建议。它原本是正文预算阶梯**第二个**被丢弃的块，紧跟在机制健康说明之后。本 PR 把它移到阶梯**最后**一档：预算能丢的其它披露都丢完之后，它才会走。

它仍然是"有档位"的，而不是不可裁剪。如果正文连阻塞项都放不下，建议性内容本就该让位；而保留档位正是让裁剪通告在它真被丢弃时能点名说出来的原因。

## 为什么需要

旧定级依据是"一段不决定任何事的建议应当先让位"。算术不支持这个排序。双语渲染下，这段在只有 volume 信号时是 603 字符，带三个复发簇时 1,510，簇 + 证据说明 + land 读数齐全时 2,372——而正文预算是 56,830 字符。放在第二位丢，它最多只能抵消 4% 的溢出；因此任何比它自身更大的溢出，都会先花掉它、然后照样继续花掉那些披露。

这不是边缘情况。这段文字触发的正是最容易溢出的高产出轮次——它本来就是为这种轮次存在的。所以在它自己的目标人群上，旧顺序把提醒和披露一起丢了。

当预算只够留一个时该留哪个，是本 PR 的实质。收敛观察是最便宜的块，也是唯一读者只有 PR 作者的块：延后发现清单在本次运行的 findings 工件里另有一份持久副本，未审查披露会在终端报告中重述，而排在它上面的机制健康说明是写给操作者看的，操作者有 `HEALTH:` 终端行。这段文字是本流水线告知 PR 作者"回路没有收敛"的全部。

## 复核方式

`npx vitest run packages/cli/src/commands/review`——98 个文件、4,403 条通过。该计数仅限本目录（也就是本改动能触及的全部范围）；全仓运行约 2.3 万条，是同一个信号的更大口径。直接承载该策略的是两条测试（见英文正文），两个常量都是调出来的而非取整，每条测试都写明了正文文案变动后如何重新调参。变异验证见上表，每条变异只让点名的测试变红。

### 证据（前后对比）

同一夹具在两棵树上跑，扫描阻塞项体积穿过溢出区（表格见上）。如实解读：区间以下两版正文都完整；区间之内，两种顺序交换了作者能留住的那一块；区间以上两种顺序都会把两块一起丢——这正是体积测算所预言的"花了却没买到任何东西"，从 55,900 起可见：旧顺序丢了这段文字，仍然不得不再丢披露。

交换窗口的宽度等于排在它下面的那些档的体积。本夹具唯一的下位档是体积相近的未审查披露，所以这里窗口很窄；如果正文同时带着延后发现清单（常有数 KB），窗口会相应变宽。

## 风险与范围

- 主要风险/取舍：在预算只够留一个的窗口里，作者现在留下收敛观察、失去未审查与非阻断披露。两种丢弃都会被裁剪通告点名；披露在终端报告中有重述，而这段文字原本也只有同样的终端副本。判断依据是：回路信号无法通过任何其它途径抵达作者，披露可以。
- 未验证 / 范围外：调出来的常量是针对当前正文文案的，披露措辞变化会移动它们——这正是两条测试都带重新调参说明的原因。不改变这段文字的内容、触发时机，也不改变任何结论。
- 破坏性变更：无。`RANK_NAMES` 新增 rank 3 条目、移除 rank 0 条目；`bodyTrim.deferralList` 与工件指针以 rank 1 为键，未受影响。

## 关联 issue

Refs #9278

</details>

