### PR TITLE
fix(review): stop the fallback comment from firing on superseded runs

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1903,12 +1903,22 @@ jobs:
   # re-runs, which keep the same run id. A review-pr that dies to its own
   # job-level timeout is auto-CANCELLED by GitHub — result 'cancelled' and
   # failure() false — which opens neither a failure-only gate nor the in-job
-  # step, so the gate admits 'cancelled' too; a run-level cancel cancels this
-  # queued job with it, so a live gate evaluation seeing 'cancelled' is
-  # overwhelmingly the timeout case, and the residual manual single-job
-  # cancel just gets a benign retry-guidance comment. The PR number comes
-  # from the event payload, not the dead job's outputs, which do not survive
-  # a crash.
+  # step, so the gate admits 'cancelled' — but only when the upstream chain
+  # finished. `always()` keeps this job running through a RUN-level cancel
+  # (it does not die with the run), so a concurrency supersede used to post
+  # a false "did not complete" while the surviving run was still reviewing:
+  # on PR #9131 a same-head pull_request_target pair started 1s apart, the
+  # newer run cancelled the older inside authorize, and the older run's gate
+  # saw review-pr 'cancelled' (run 32558544379) — same-head, so the in-step
+  # head-moved guard could not catch it. The two cancels are separable in
+  # `needs`: a job-level timeout cancels review-pr ALONE — authorize and
+  # delay-automatic-review completed long before — while a run-level cancel
+  # sweeps the whole chain, so 'cancelled' opens the gate only when neither
+  # upstream job was itself cancelled. A manual run-cancel during the delay
+  # window goes silent under this rule (the person who cancelled does not
+  # need retry guidance); a manual cancel of review-pr alone mid-review
+  # still posts, benign as before. The PR number comes from the event
+  # payload, not the dead job's outputs, which do not survive a crash.
   fallback-comment:
     needs:
       [
@@ -1921,7 +1931,9 @@ jobs:
     if: |-
       always() &&
       (needs.review-pr.result == 'failure' ||
-       needs.review-pr.result == 'cancelled' ||
+       (needs.review-pr.result == 'cancelled' &&
+        needs.authorize.result != 'cancelled' &&
+        needs.delay-automatic-review.result != 'cancelled') ||
        needs.authorize.result == 'failure' ||
        needs.review-config.result == 'failure' ||
        needs.delay-automatic-review.result == 'failure' ||

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1916,9 +1916,11 @@ jobs:
   # sweeps the whole chain, so 'cancelled' opens the gate only when neither
   # upstream job was itself cancelled. A run-level cancel landing AFTER the
   # chain finished (mid-review) still opens the gate: the push-supersede
-  # flavor is then suppressed by the in-step head-moved guard, and a
-  # same-head twin cannot land that late — its cancel fires at run
-  # creation, seconds in. A manual run-cancel during the delay window goes
+  # flavor is then suppressed by the in-step head-moved guard, the close
+  # flavor (a `closed`-action run joining the PR-scoped group hours in, the
+  # head unchanged) by the in-step PR-state check, and a same-head twin
+  # cannot land that late — its cancel fires at run creation, seconds in.
+  # A manual run-cancel during the delay window goes
   # silent under this rule (the person who cancelled does not need retry
   # guidance); a manual cancel of review-pr alone mid-review still posts,
   # benign as before. The PR number comes from the event payload, not the

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1914,11 +1914,15 @@ jobs:
   # `needs`: a job-level timeout cancels review-pr ALONE — authorize and
   # delay-automatic-review completed long before — while a run-level cancel
   # sweeps the whole chain, so 'cancelled' opens the gate only when neither
-  # upstream job was itself cancelled. A manual run-cancel during the delay
-  # window goes silent under this rule (the person who cancelled does not
-  # need retry guidance); a manual cancel of review-pr alone mid-review
-  # still posts, benign as before. The PR number comes from the event
-  # payload, not the dead job's outputs, which do not survive a crash.
+  # upstream job was itself cancelled. A run-level cancel landing AFTER the
+  # chain finished (mid-review) still opens the gate: the push-supersede
+  # flavor is then suppressed by the in-step head-moved guard, and a
+  # same-head twin cannot land that late — its cancel fires at run
+  # creation, seconds in. A manual run-cancel during the delay window goes
+  # silent under this rule (the person who cancelled does not need retry
+  # guidance); a manual cancel of review-pr alone mid-review still posts,
+  # benign as before. The PR number comes from the event payload, not the
+  # dead job's outputs, which do not survive a crash.
   fallback-comment:
     needs:
       [

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -3069,9 +3069,19 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
     expect(job.if).toContain("needs.review-pr.result == 'failure'");
     // A review-pr that dies to its own job-level timeout is auto-cancelled
     // (result 'cancelled', failure() false), which would open neither this
-    // gate nor the in-job step; a run-level cancel cancels this queued job
-    // too, so a live evaluation seeing 'cancelled' is the timeout case.
-    expect(job.if).toContain("needs.review-pr.result == 'cancelled'");
+    // gate nor the in-job step — but `always()` keeps this job alive through
+    // a RUN-level cancel, so a bare 'cancelled' clause posts a false "did
+    // not complete" from a concurrency-superseded run while its same-head
+    // twin is still reviewing (PR #9131, run 32558544379 — same head, so
+    // the in-step head-moved guard cannot catch it). The two cancels differ
+    // in `needs`: a timeout cancels review-pr ALONE, a run-level cancel
+    // sweeps the upstream chain too. Pin the full compound clause — the
+    // grouping included — so reverting either upstream conjunct fails here.
+    expect(job.if).toContain(
+      "(needs.review-pr.result == 'cancelled' &&\n" +
+        "  needs.authorize.result != 'cancelled' &&\n" +
+        "  needs.delay-automatic-review.result != 'cancelled') ||",
+    );
     expect(job.if).toContain("needs.authorize.result == 'failure'");
     expect(job.if).toContain("needs.review-config.result == 'failure'");
     expect(job.if).toContain(

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -3082,6 +3082,13 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
         "  needs.authorize.result != 'cancelled' &&\n" +
         "  needs.delay-automatic-review.result != 'cancelled') ||",
     );
+    // ...and the bare disjunct must be ABSENT, not just the compound one
+    // present: a merge-conflict resolution keeping both sides re-adds
+    // `== 'cancelled' ||` beside the intact compound clause, the gate opens
+    // on every cancelled review-pr again, and the pin above stays green.
+    // (Inside the compound clause the substring is followed by ` &&`, so
+    // this negation holds on the intended gate.)
+    expect(job.if).not.toContain("needs.review-pr.result == 'cancelled' ||");
     expect(job.if).toContain("needs.authorize.result == 'failure'");
     expect(job.if).toContain("needs.review-config.result == 'failure'");
     expect(job.if).toContain(

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -3082,13 +3082,15 @@ describe('fallback comment resilience (PR #8894 incident class)', () => {
         "  needs.authorize.result != 'cancelled' &&\n" +
         "  needs.delay-automatic-review.result != 'cancelled') ||",
     );
-    // ...and the bare disjunct must be ABSENT, not just the compound one
-    // present: a merge-conflict resolution keeping both sides re-adds
-    // `== 'cancelled' ||` beside the intact compound clause, the gate opens
-    // on every cancelled review-pr again, and the pin above stays green.
-    // (Inside the compound clause the substring is followed by ` &&`, so
-    // this negation holds on the intended gate.)
-    expect(job.if).not.toContain("needs.review-pr.result == 'cancelled' ||");
+    // ...and that clause must be the ONLY place the gate tests review-pr
+    // for 'cancelled': a merge-conflict resolution keeping both sides
+    // re-adds a bare `== 'cancelled'` disjunct beside the intact compound
+    // clause — in any rendering (bare, parenthesized, respaced) — and the
+    // gate opens on every cancelled review-pr again while the pin above
+    // stays green. Counting occurrences catches every rendering.
+    expect(
+      job.if.match(/needs\.review-pr\.result == 'cancelled'/g),
+    ).toHaveLength(1);
     expect(job.if).toContain("needs.authorize.result == 'failure'");
     expect(job.if).toContain("needs.review-config.result == 'failure'");
     expect(job.if).toContain(


### PR DESCRIPTION
## What this PR does

Teaches the review pipeline's fallback path to tell two kinds of cancellation apart. When a review run is cancelled as a whole — typically because a newer run for the same pull request superseded it in the concurrency group — the "review did not complete" fallback comment is no longer posted. When only the review step itself is cancelled, which is how GitHub reports a job-level timeout, the fallback comment still fires as before.

## Why it's needed

The fallback gate assumed a run-level cancel would take the queued fallback job down with it, leaving job-level timeout as the only live source of a cancelled review step. That assumption does not hold: the fallback job is guarded by `always()`, which keeps it running through a run-level cancel. On #9131 two same-head runs started one second apart, the newer one cancelled the older inside the authorization step, and the older run posted a false "**Qwen Code review did not complete successfully**" ([the comment](https://github.com/QwenLM/qwen-code/pull/9131#issuecomment-5378857350), [run 32558544379](https://github.com/QwenLM/qwen-code/actions/runs/32558544379)) while the surviving run was still reviewing. The existing head-comparison guard inside the step could not catch it because both runs pointed at the same head commit.

The two cases are separable from the dependency results alone: a job-level timeout cancels the review step in isolation, its upstream jobs having completed long before, while a run-level cancel sweeps the whole chain. The gate now admits a cancelled review step only when no upstream job was itself cancelled.

## Reviewer Test Plan

### How to verify

Replay the gate expression against the four cancellation shapes:

1. Superseded run (the #9131 incident): authorization cancelled, delay cancelled, review cancelled → gate stays closed, no comment. Previously posted the false fallback.
2. Review step hits its job-level timeout: authorization succeeded, delay succeeded (or skipped on explicit-trigger runs), review cancelled → gate opens, fallback posts, unchanged.
3. Review step fails or dies with the runner: unchanged — the failure clauses are untouched.
4. Manual cancel of the review step alone mid-review: still posts, matching the previously documented benign behavior. A manual cancel of the whole run during the delay window now goes silent — desired, since the person who cancelled does not need retry guidance.

### Evidence (Before & After)

Before: https://github.com/QwenLM/qwen-code/pull/9131#issuecomment-5378857350 — a false "review did not complete" posted by the concurrency-cancelled twin of a run that was still reviewing.

After: N/A (CI workflow change; the matrix above is the verification).

### Tested on

N/A — CI workflow change, validated by YAML parsing and actionlint (its single finding is pre-existing on an untouched line), plus the scenario matrix above.

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: a run-level manual cancel during the delay window no longer leaves a retry-guidance comment; that silence is intentional.
- Not validated / out of scope: why the same head produced two `pull_request_target` runs one second apart in the first place — worth a separate look; this change only stops the misleading comment such twins produce.
- Breaking changes / migration notes: none.

## Linked Issues

Observed on #9131 (false fallback comment from run 32558544379).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让评审流水线的 fallback 路径区分两类取消：整个 run 被取消（通常是同一 PR 的更新 run 在并发组里顶掉旧 run）时，不再发布 "review did not complete" 兜底评论；只有评审步骤本身被取消（GitHub 对 job 级超时的表现形式）时，兜底评论照常发出。

## 为什么需要

原有 gate 假设 run 级取消会连带取消排队中的 fallback job，因此现场看到 cancelled 的评审步骤就只剩超时一种来源。该假设不成立：fallback job 由 `always()` 守卫，整个 run 被取消后它仍会继续执行。#9131 上两个相同 head 的 run 相隔 1 秒启动，新 run 在 authorization 阶段取消了旧 run，旧 run 随即发出一条错误的 "Qwen Code review did not complete successfully"（run 32558544379），而幸存的 run 仍在正常评审。步骤内已有的 head 对比守卫无法拦截，因为两个 run 指向同一个 head。

两类取消仅凭依赖结果即可区分：job 级超时只取消评审步骤本身（上游 job 早已完成），run 级取消则横扫整条链。新 gate 仅在上游 job 均未被取消时，才为 cancelled 的评审步骤放行。

## 风险与范围

- 主要权衡：delay 窗口内手动取消整个 run 不再收到重试提示评论；这是有意为之——主动取消的人不需要被提示重试。
- 未验证/范围外：同一 head 为何会在 1 秒内产生两个 `pull_request_target` run，值得单独排查；本改动只消除这类孪生 run 产出的误导性评论。
- 破坏性变更：无。

</details>
