### PR TITLE
test(core): pin that subagent registries carry no MCP instructions

### DIFF
--- a/packages/core/src/agents/backends/InProcessBackend.test.ts
+++ b/packages/core/src/agents/backends/InProcessBackend.test.ts
@@ -12,6 +12,7 @@ import { AgentCore } from '../runtime/agent-core.js';
 import { getTeammateContext } from '../team/identity.js';
 import { createContentGenerator } from '../../core/contentGenerator.js';
 import { ApprovalMode, Config } from '../../config/config.js';
+import { hasRebuiltToolRegistry } from '../../tools/agent/agent.js';
 import { join } from 'node:path';
 
 const DEFAULT_MODE = 'default' as ApprovalMode;
@@ -642,6 +643,21 @@ describe('InProcessBackend', () => {
     expect(agentContext.getWorkingDir()).toBe(agentCwd);
     expect(agentContext.getTargetDir()).toBe(agentCwd);
     expect(agentContext.getToolRegistry()).toBeDefined();
+
+    // This config is LONG-LIVED — the agent keeps it — so it must NOT carry
+    // the rebuilt marker. `hasRebuiltToolRegistry` reads it through the
+    // prototype chain, so a wrapper built on it later (a dir-scoped workflow
+    // dispatch) would see it and skip `buildSubagentContextOverride`'s
+    // rebuild — the sole re-anchoring that lifts the subagent's tools above
+    // that wrapper. Without it, relative paths resolve against this agent's
+    // cwd instead of the provisioned worktree.
+    //
+    // Pinned HERE, at the call site, because the helper's own tests pass
+    // explicit options and so say nothing about what this caller passes:
+    // dropping `{ markRebuilt: false }` left every other suite green.
+    expect(hasRebuiltToolRegistry(runtimeContext as unknown as Config)).toBe(
+      false,
+    );
   });
 
   it('uses a per-agent approval mode without mutating the parent config', async () => {

--- a/packages/core/src/agents/backends/InProcessBackend.ts
+++ b/packages/core/src/agents/backends/InProcessBackend.ts
@@ -35,6 +35,7 @@ import type {
   InProcessSpawnConfig,
 } from './types.js';
 import { DISPLAY_MODE } from './types.js';
+import { rebuildToolRegistryOnOverride } from '../../tools/agent/agent.js';
 import type { AnsiOutput } from '../../utils/terminalSerializer.js';
 
 const debugLogger = createDebugLogger('IN_PROCESS_BACKEND');
@@ -534,13 +535,16 @@ async function createPerAgentConfig(
     );
     override.getFileService = () => agentFileService;
 
-    const registry = await override.createToolRegistry(undefined, {
-      skipDiscovery: true,
-      forSubAgent: true,
-    });
-    agentRegistry = registry;
-    registry.copyDiscoveredToolsFrom(base.getToolRegistry());
-    override.getToolRegistry = () => registry;
+    // Delegated rather than re-enacted. The three steps below used to be
+    // inlined here, identical to the shared helper — and a second copy is a
+    // second place for an invariant to be broken: a change sharing the
+    // parent's `McpClientManager`, or propagating server instructions during
+    // the copy, would leak them into every in-process-spawned agent's first
+    // message while the tests covering the other spawn path stayed green.
+    // Delegating also sets the rebuilt marker, so a wrapper-of-wrapper spawn
+    // downstream can skip a redundant rebuild.
+    await rebuildToolRegistryOnOverride(override as Config, base);
+    agentRegistry = override.getToolRegistry();
 
     if (authOverrides?.authType) {
       try {

--- a/packages/core/src/agents/backends/InProcessBackend.ts
+++ b/packages/core/src/agents/backends/InProcessBackend.ts
@@ -541,9 +541,18 @@ async function createPerAgentConfig(
     // parent's `McpClientManager`, or propagating server instructions during
     // the copy, would leak them into every in-process-spawned agent's first
     // message while the tests covering the other spawn path stayed green.
-    // Delegating also sets the rebuilt marker, so a wrapper-of-wrapper spawn
-    // downstream can skip a redundant rebuild.
-    await rebuildToolRegistryOnOverride(override as Config, base);
+    //
+    // `markRebuilt: false` keeps the delegation behaviour-identical to the
+    // block it replaced. This config is LONG-LIVED — the agent keeps it — and
+    // the marker is read through the prototype chain, so stamping it would
+    // hand "you may skip your rebuild" to every wrapper built on it later. A
+    // dir-scoped workflow dispatch rebinds only the dir getters; its rebuild
+    // is the sole re-anchoring that lifts the subagent's tools above the
+    // wrapper, and skipping it resolves relative paths against the parent's
+    // working directory instead of the provisioned worktree.
+    await rebuildToolRegistryOnOverride(override as Config, base, {
+      markRebuilt: false,
+    });
     agentRegistry = override.getToolRegistry();
 
     if (authOverrides?.authType) {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -445,6 +445,25 @@ export function hasRebuiltToolRegistry(config: Config): boolean {
 export async function rebuildToolRegistryOnOverride(
   override: Config,
   base: Config,
+  options?: {
+    /**
+     * Whether to stamp {@link TOOL_REGISTRY_REBUILT} on `override`.
+     *
+     * The marker means "a descendant may skip its own rebuild", and
+     * `hasRebuiltToolRegistry` reads it through the prototype chain — so a
+     * LONG-LIVED override that carries it hands that permission to every
+     * wrapper built on it later, not just to the spawn it was made for. That
+     * is right for a short-lived per-launch override and wrong for a config
+     * an agent keeps: a dir-scoped workflow dispatch rebinds only the dir
+     * getters, and its rebuild is the sole re-anchoring that moves the
+     * subagent's tools above the wrapper. Skipping it leaves them bound to
+     * the config below, so relative paths resolve against the parent's
+     * working directory instead of the provisioned worktree.
+     *
+     * Default true, which is what every caller before this option did.
+     */
+    markRebuilt?: boolean;
+  },
 ): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ov = override as any;
@@ -454,7 +473,9 @@ export async function rebuildToolRegistryOnOverride(
   });
   agentRegistry.copyDiscoveredToolsFrom(base.getToolRegistry());
   ov.getToolRegistry = () => agentRegistry;
-  ov[TOOL_REGISTRY_REBUILT] = true;
+  if (options?.markRebuilt !== false) {
+    ov[TOOL_REGISTRY_REBUILT] = true;
+  }
 }
 
 /**

--- a/packages/core/src/utils/environmentContext.mcp-subagent.test.ts
+++ b/packages/core/src/utils/environmentContext.mcp-subagent.test.ts
@@ -8,6 +8,9 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { Config } from '../config/config.js';
 import type { MCPServerConfig } from '../config/config.js';
 import { buildMcpServerInstructionsReminder } from './environmentContext.js';
+import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
+import type { CallableTool } from '@google/genai';
+import { rebuildToolRegistryOnOverride } from '../tools/agent/agent.js';
 
 // Why this exists.
 //
@@ -45,7 +48,7 @@ describe('MCP server instructions and subagent registries', () => {
       debugMode: false,
       model: 'test-model',
       mcpServers,
-    } as ConstructorParameters<typeof Config>[0]);
+    });
     configs.push(config);
     return config;
   }
@@ -70,9 +73,10 @@ describe('MCP server instructions and subagent registries', () => {
   });
 
   it('does not carry instructions across a tool copy from the parent', async () => {
-    // `rebuildToolRegistryOnOverride` copies the parent's discovered tools into
-    // the fresh registry. If a future change copied instructions with them,
-    // the reminder would reappear — this is the assertion that would fail.
+    // Drives `rebuildToolRegistryOnOverride` itself — the function the spawn
+    // path uses — rather than re-enacting its two steps. Re-enacting them
+    // pins `copyDiscoveredToolsFrom`'s contract only, and a change that
+    // propagated instructions inside the rebuild would survive.
     const config = makeConfig({ 'server-a': { command: 'a' } });
     await config.initialize({
       skipGeminiInitialization: true,
@@ -85,19 +89,50 @@ describe('MCP server instructions and subagent registries', () => {
     // discovery is skipped in tests, so an un-stubbed parent reports an empty
     // map and the copy below would be trivially empty either way. (Measured:
     // without this stub a mutation that propagates instructions still passes.)
+    //
+    // Stubbed on the MANAGER, not on the registry getter. Instructions live on
+    // `McpClientManager`; the registry method only delegates. A subagent
+    // registry that SHARED the parent's manager would read the real manager
+    // and never touch a registry-level stub — measured: with the stub one
+    // layer up, `this.mcpClientManager = source.mcpClientManager` in the copy
+    // survives green, while in production that shares live connected clients.
     const parent = config.getToolRegistry();
-    vi.spyOn(parent, 'getMcpServerInstructions').mockReturnValue(
-      new Map([['server-a', 'Prefer concise replies.']]),
-    );
+    vi.spyOn(
+      parent.getMcpClientManager(),
+      'getServerInstructions',
+    ).mockReturnValue(new Map([['server-a', 'Prefer concise replies.']]));
     expect(parent.getMcpServerInstructions().size).toBe(1);
 
-    const subagentRegistry = await config.createToolRegistry(undefined, {
-      skipDiscovery: true,
-      forSubAgent: true,
-    });
-    subagentRegistry.copyDiscoveredToolsFrom(parent);
+    // …and the parent must hold a discovered TOOL, or the copy below iterates
+    // an empty map and its body never runs. A change that propagated a copied
+    // tool's server instructions — a shape closer to this method's tools-only
+    // design than a whole-map copy — would then copy nothing and leave the
+    // assertions green, blessing the regression this file exists to catch.
+    parent.registerTool(
+      new DiscoveredMCPTool(
+        {} as CallableTool,
+        'server-a',
+        'do_thing',
+        'A discovered tool from server-a.',
+        { type: 'object', properties: {} },
+      ),
+    );
+
+    const override = Object.create(config) as typeof config;
+    await rebuildToolRegistryOnOverride(override, config);
+    const subagentRegistry = override.getToolRegistry();
+
+    // The rebuild really produced a different registry that took the copy.
+    expect(subagentRegistry).not.toBe(parent);
+    expect(subagentRegistry.getTool('mcp__server-a__do_thing')).toBeDefined();
 
     expect(subagentRegistry.getMcpServerInstructions().size).toBe(0);
     expect(buildMcpServerInstructionsReminder(subagentRegistry)).toBeNull();
+    // The structural half: sharing the manager is the other way instructions
+    // could arrive, and it would defeat any assertion phrased on contents
+    // alone once the parent's manager holds real clients.
+    expect(subagentRegistry.getMcpClientManager()).not.toBe(
+      parent.getMcpClientManager(),
+    );
   });
 });

--- a/packages/core/src/utils/environmentContext.mcp-subagent.test.ts
+++ b/packages/core/src/utils/environmentContext.mcp-subagent.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Config } from '../config/config.js';
+import type { MCPServerConfig } from '../config/config.js';
+import { buildMcpServerInstructionsReminder } from './environmentContext.js';
+
+// Why this exists.
+//
+// `getInitialChatHistory` gates three of its four reminder parts and leaves
+// `buildMcpServerInstructionsReminder` ungated, which reads as an oversight:
+// the skills and deferred-tools reminders are both suppressed for subagents
+// precisely because announcing something the agent cannot use wastes a turn.
+//
+// The MCP part needs no gate, and this pins the reason so the asymmetry is not
+// "fixed" into a behaviour change. Server instructions live on the
+// `McpClientManager` that each `ToolRegistry` constructs for itself, and they
+// are populated only by discovery. A subagent's registry is built with
+// `skipDiscovery: true`, and `copyDiscoveredToolsFrom` copies TOOLS from the
+// parent — not instructions. So the map is empty and the reminder is already
+// null, without a flag.
+//
+// The failure this guards against is a future change that shares the parent's
+// manager, or copies instructions along with the tools: the reminder would
+// start riding into every subagent's first message silently, since nothing
+// else asserts it does not.
+describe('MCP server instructions and subagent registries', () => {
+  const configs: Config[] = [];
+
+  afterEach(async () => {
+    while (configs.length) {
+      await configs.pop()?.shutdown();
+    }
+  });
+
+  function makeConfig(mcpServers: Record<string, MCPServerConfig>): Config {
+    const config = new Config({
+      sessionId: `mcp-subagent-${configs.length}`,
+      targetDir: process.cwd(),
+      cwd: process.cwd(),
+      debugMode: false,
+      model: 'test-model',
+      mcpServers,
+    } as ConstructorParameters<typeof Config>[0]);
+    configs.push(config);
+    return config;
+  }
+
+  it('leaves a skipDiscovery registry with no server instructions', async () => {
+    const config = makeConfig({ 'server-a': { command: 'a' } });
+    await config.initialize({
+      skipGeminiInitialization: true,
+      skipHooks: true,
+      skipMcpDiscovery: true,
+      skipFileCheckpointing: true,
+    });
+
+    // The shape `AgentTool` builds for every subagent launch.
+    const subagentRegistry = await config.createToolRegistry(undefined, {
+      skipDiscovery: true,
+      forSubAgent: true,
+    });
+
+    expect(subagentRegistry.getMcpServerInstructions().size).toBe(0);
+    expect(buildMcpServerInstructionsReminder(subagentRegistry)).toBeNull();
+  });
+
+  it('does not carry instructions across a tool copy from the parent', async () => {
+    // `rebuildToolRegistryOnOverride` copies the parent's discovered tools into
+    // the fresh registry. If a future change copied instructions with them,
+    // the reminder would reappear — this is the assertion that would fail.
+    const config = makeConfig({ 'server-a': { command: 'a' } });
+    await config.initialize({
+      skipGeminiInitialization: true,
+      skipHooks: true,
+      skipMcpDiscovery: true,
+      skipFileCheckpointing: true,
+    });
+
+    // The parent must actually HOLD instructions, or this asserts nothing:
+    // discovery is skipped in tests, so an un-stubbed parent reports an empty
+    // map and the copy below would be trivially empty either way. (Measured:
+    // without this stub a mutation that propagates instructions still passes.)
+    const parent = config.getToolRegistry();
+    vi.spyOn(parent, 'getMcpServerInstructions').mockReturnValue(
+      new Map([['server-a', 'Prefer concise replies.']]),
+    );
+    expect(parent.getMcpServerInstructions().size).toBe(1);
+
+    const subagentRegistry = await config.createToolRegistry(undefined, {
+      skipDiscovery: true,
+      forSubAgent: true,
+    });
+    subagentRegistry.copyDiscoveredToolsFrom(parent);
+
+    expect(subagentRegistry.getMcpServerInstructions().size).toBe(0);
+    expect(buildMcpServerInstructionsReminder(subagentRegistry)).toBeNull();
+  });
+});

--- a/packages/core/src/utils/environmentContext.mcp-subagent.test.ts
+++ b/packages/core/src/utils/environmentContext.mcp-subagent.test.ts
@@ -10,7 +10,10 @@ import type { MCPServerConfig } from '../config/config.js';
 import { buildMcpServerInstructionsReminder } from './environmentContext.js';
 import { DiscoveredMCPTool } from '../tools/mcp-tool.js';
 import type { CallableTool } from '@google/genai';
-import { rebuildToolRegistryOnOverride } from '../tools/agent/agent.js';
+import {
+  rebuildToolRegistryOnOverride,
+  hasRebuiltToolRegistry,
+} from '../tools/agent/agent.js';
 
 // Why this exists.
 //
@@ -70,6 +73,41 @@ describe('MCP server instructions and subagent registries', () => {
 
     expect(subagentRegistry.getMcpServerInstructions().size).toBe(0);
     expect(buildMcpServerInstructionsReminder(subagentRegistry)).toBeNull();
+  });
+
+  it('leaves a long-lived override unmarked when asked', async () => {
+    // The marker means "a descendant may skip its own rebuild", and
+    // `hasRebuiltToolRegistry` reads it through the PROTOTYPE CHAIN. On a
+    // short-lived per-launch override that is the point; on a config an agent
+    // keeps — `InProcessBackend`'s per-agent config — it hands that permission
+    // to every wrapper built on it later.
+    //
+    // The one that matters is a dir-scoped workflow dispatch: its wrapper
+    // rebinds only the dir getters, so the rebuild it would otherwise run is
+    // the sole re-anchoring that lifts the subagent's tools above the wrapper.
+    // Skipped, relative paths resolve against the parent's working directory
+    // instead of the provisioned worktree.
+    const config = makeConfig({ 'server-a': { command: 'a' } });
+    await config.initialize({
+      skipGeminiInitialization: true,
+      skipHooks: true,
+      skipMcpDiscovery: true,
+      skipFileCheckpointing: true,
+    });
+
+    const longLived = Object.create(config) as typeof config;
+    await rebuildToolRegistryOnOverride(longLived, config, {
+      markRebuilt: false,
+    });
+    expect(hasRebuiltToolRegistry(longLived)).toBe(false);
+    // …and a wrapper on it still owes its own rebuild.
+    const dirScoped = Object.create(longLived) as typeof config;
+    expect(hasRebuiltToolRegistry(dirScoped)).toBe(false);
+
+    // The default is unchanged for the per-launch callers that want it.
+    const perLaunch = Object.create(config) as typeof config;
+    await rebuildToolRegistryOnOverride(perLaunch, config);
+    expect(hasRebuiltToolRegistry(perLaunch)).toBe(true);
   });
 
   it('does not carry instructions across a tool copy from the parent', async () => {


### PR DESCRIPTION
## What this PR does

Adds two tests pinning that a subagent's tool registry carries no MCP server instructions, so the ungated `buildMcpServerInstructionsReminder` stays harmless. No production code changes.

## Why it's needed

`getInitialChatHistory` assembles four reminder parts. Three are gated — the startup context by `getSkipStartupContext()`, the skills snapshot by `includeAvailableSkillsReminder`, the deferred-tools list by `includeDeferredToolsReminder` — and subagents suppress the latter two precisely because announcing something the agent cannot use wastes a turn. `buildMcpServerInstructionsReminder` has no gate at all.

Reviewed as an oversight of the same class, it is not one. Three facts combine to make the reminder already empty for a subagent:

- Each `ToolRegistry` constructs **its own** `McpClientManager` (`tool-registry.ts:224`); it does not share the parent's.
- Instructions are populated only by discovery, and a subagent's registry is built with `skipDiscovery: true`, which skips `discoverAllTools()` (`config.ts:8882`).
- `copyDiscoveredToolsFrom` copies **tools**, not instructions (`tool-registry.ts:413-422`).

So `getMcpServerInstructions()` returns an empty map and the builder returns `null`. The part is already gated — by construction rather than by a flag.

Adding the flag would not have been free. The MCP part is deliberately first in the reminder order so prefix-caching servers keep the KV-cache for the shared prefix, and a gate keyed on "is this a subagent" would also strip instructions from a subagent that genuinely does declare MCP tools.

What was actually missing is the assertion. Nothing pinned the invariant, so a future change that shares the parent's manager, or copies instructions alongside the tools, would start injecting server-authored prose into every subagent's first message — silently, and re-sent on every turn.

## Reviewer Test Plan

### How to verify

```
cd packages/core && npx vitest run src/utils/ src/config/config.test.ts
#   Test Files  130 passed (130)
#        Tests  5025 passed | 3 skipped (5028)
```

`npm run lint` is clean.

The tests build a real `Config` with `mcpServers` configured, then the registry shape `AgentTool` builds for every subagent launch (`skipDiscovery: true, forSubAgent: true`), and assert both `getMcpServerInstructions().size === 0` and that the builder returns `null`.

**The second test stubs the parent so it actually holds instructions, and that stub is load-bearing.** Discovery is skipped in tests, so an un-stubbed parent reports an empty map — the copy would then be trivially empty and the assertion green whatever the implementation did. Measured: without the stub, a mutation that propagates instructions across the copy still passes.

**Mutation** (with the stub in place): give `ToolRegistry` a field the copy fills and the getter merges — a persistent implementation of exactly the change this guards against — and `does not carry instructions across a tool copy from the parent` turns red (`1 failed | 1 passed`). A first attempt that wrote into the map returned by `getMcpServerInstructions()` did *not* fail, because that getter builds a fresh map per call; that is why the mutation had to be persistent to mean anything.

### Evidence (Before & After)

N/A — tests only, no behaviour change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- **Main risk or tradeoff:** none to behaviour — no production file is touched. The tests construct and shut down real `Config` instances, which is heavier than a mocked registry; that is deliberate, because a mocked registry is what would have let the original claim stand unexamined.
- **Not validated / out of scope:** whether an MCP-connected *parent* session should still carry instructions it has (unchanged here), and the case of a subagent that declares MCP tools and might want its server's instructions — today it gets neither, which this PR documents rather than changes.
- **Breaking changes / migration notes:** none.

## Linked Issues

Follow-up from review of #9678; companion to #9718.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增两条测试，钉住「子 agent 的工具注册表不携带任何 MCP server instructions」这一不变量，从而使未设门的 `buildMcpServerInstructionsReminder` 保持无害。不改动任何生产代码。

## 为什么需要

`getInitialChatHistory` 组装四段提醒。其中三段有门控——启动上下文由 `getSkipStartupContext()`、技能快照由 `includeAvailableSkillsReminder`、延迟工具清单由 `includeDeferredToolsReminder`——而子 agent 之所以抑制后两者，正是因为公告一个它无法使用的东西会浪费一轮。唯独 `buildMcpServerInstructionsReminder` 完全没有门控。

它被评审视为同类疏漏，但实际上不是。三个事实叠加，使该提醒对子 agent 本就为空：

- 每个 `ToolRegistry` **各自新建** `McpClientManager`（`tool-registry.ts:224`），并不共享父级的。
- instructions 只在发现阶段被填充，而子 agent 的注册表以 `skipDiscovery: true` 构建，该标志会跳过 `discoverAllTools()`（`config.ts:8882`）。
- `copyDiscoveredToolsFrom` 复制的是**工具**，不是 instructions（`tool-registry.ts:413-422`）。

因此 `getMcpServerInstructions()` 返回空 map，构造函数返回 `null`。这一段本就是被门控的——只是靠构造方式，而非靠标志位。

而加上这个标志并非没有代价。MCP 段被刻意排在提醒序列的首位，以便启用前缀缓存的服务端保留共享前缀的 KV 缓存；并且一个以「是否为子 agent」为键的门控，也会连带剥夺那些确实声明了 MCP 工具的子 agent 的 instructions。

真正缺失的是断言。此前没有任何测试钉住该不变量，因此将来若有改动共享了父级的 manager、或在复制工具时连带复制 instructions，server 提供的文本就会开始被注入每个子 agent 的首条消息——静默发生，且逐轮重发。

## 审查者验证方案

### 如何验证

```
cd packages/core && npx vitest run src/utils/ src/config/config.test.ts
#   Test Files  130 passed (130)
#        Tests  5025 passed | 3 skipped (5028)
```

`npm run lint` 干净通过。

测试会构造一个配置了 `mcpServers` 的真实 `Config`，随后构造 `AgentTool` 在每次子 agent 启动时所建的那种注册表形态（`skipDiscovery: true, forSubAgent: true`），并断言 `getMcpServerInstructions().size === 0` 以及构造函数返回 `null`。

**第二条测试对父级做了桩，使其真正持有 instructions，而这个桩是承重的。** 测试中跳过了发现流程，因此未打桩的父级会报告空 map——那样一来复制结果必然为空，无论实现如何断言都会是绿的。实测：不打桩时，一个会跨复制传播 instructions 的变异仍然通过。

**变异测试**（在有桩的前提下）：给 `ToolRegistry` 增加一个字段，由复制填充、由 getter 合并——即本测试所要防范的那种改动的持久化实现——`does not carry instructions across a tool copy from the parent` 变红（`1 failed | 1 passed`）。最初一次尝试是往 `getMcpServerInstructions()` 返回的 map 里写入，**并未**导致失败，因为该 getter 每次调用都新建 map；这正是变异必须做成持久化才有意义的原因。

### 证据（前后对比）

N/A —— 仅测试，无行为变化。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## 风险与范围

- **主要风险或权衡：** 对行为无风险——未触及任何生产文件。测试会构造并关闭真实的 `Config` 实例，比使用 mock 注册表更重；这是刻意的，因为正是 mock 注册表会让原先那个论断无从被检验。
- **未验证 / 范围之外：** 已连接 MCP 的**父**会话是否仍应携带其持有的 instructions（本次未改动）；以及一个声明了 MCP 工具、可能希望获得其 server instructions 的子 agent——今天它两者都得不到，本 PR 只记录这一现状而不改变它。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

来自 #9678 评审的跟进；与 #9718 配套。

</details>
