### PR TITLE
fix(web-shell): pass session workspace cwd when opening from overview panel

### DIFF
--- a/packages/web-shell/client/components/SessionOverviewPanel.test.tsx
+++ b/packages/web-shell/client/components/SessionOverviewPanel.test.tsx
@@ -320,7 +320,29 @@ describe('SessionOverviewPanel', () => {
     render();
     const label = container!.querySelector('ul li button') as HTMLButtonElement;
     act(() => label.dispatchEvent(new MouseEvent('click', { bubbles: true })));
-    expect(onOpenSession).toHaveBeenCalledWith('s-run');
+    expect(onOpenSession).toHaveBeenCalledWith('s-run', '/w');
+  });
+
+  it("passes the owning workspace cwd when clicking another workspace's session", async () => {
+    connectionState.capabilities = {
+      features: [],
+      workspaceCwd: '/w',
+      workspaces: [
+        { id: 'w0', cwd: '/w', primary: true, trusted: true },
+        { id: 'w1', cwd: '/wsB', primary: false, trusted: true },
+      ],
+    };
+    sessionsState.sessions = [session('s-run', { displayName: 'Alpha' })];
+    otherWorkspaceSessions['/wsB'] = [
+      session('b1', { workspaceCwd: '/wsB', displayName: 'Beta' }),
+    ];
+    render();
+    await flushAsync();
+    const beta = Array.from(container!.querySelectorAll('ul li button')).find(
+      (b) => b.textContent?.trim() === 'Beta',
+    ) as HTMLButtonElement;
+    act(() => beta.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(onOpenSession).toHaveBeenCalledWith('b1', '/wsB');
   });
 
   it('always shows selection + the "Open in new tab" batch action', () => {

--- a/packages/web-shell/client/components/SessionOverviewPanel.tsx
+++ b/packages/web-shell/client/components/SessionOverviewPanel.tsx
@@ -167,7 +167,7 @@ function SessionOverviewPanelInner({
   includeOtherWorkspaces,
   workspaceCwd,
 }: {
-  onOpenSession: (sessionId: string) => void;
+  onOpenSession: (sessionId: string, workspaceCwd?: string) => void;
   onOpenSplit?: (sessionIds: string[]) => void;
   includeOtherWorkspaces: boolean;
   workspaceCwd?: string;
@@ -417,7 +417,7 @@ function SessionOverviewPanelInner({
               <button
                 type="button"
                 className={styles.cardLabel}
-                onClick={() => onOpenSession(card.sessionId)}
+                onClick={() => onOpenSession(card.sessionId, card.workspaceCwd)}
                 title={card.label}
               >
                 {card.label}
@@ -485,7 +485,7 @@ export function SessionOverviewPanel({
   includeOtherWorkspaces = true,
   workspaceCwd,
 }: {
-  onOpenSession: (sessionId: string) => void;
+  onOpenSession: (sessionId: string, workspaceCwd?: string) => void;
   onOpenSplit?: (sessionIds: string[]) => void;
   includeOtherWorkspaces?: boolean;
   workspaceCwd?: string;


### PR DESCRIPTION
## What this PR does

Clicking a session card in the Session Overview panel now hands the session's owning workspace directory to the session-switch path, so the load request targets the workspace where the session actually lives. The callback contract between the panel and the app is widened to carry that directory; nothing else changes.

## Why it's needed

On a daemon registered with multiple workspaces, the overview panel lists sessions from every workspace. Clicking a session that belongs to a non-primary workspace used to drop the session's workspace association, so the switch fell back to the primary workspace. The daemon then looked for the session under the wrong workspace runtime and rejected the load — `404 session_not_found` for a cold session, or `409 session_workspace_conflict` when the session was already live under its own runtime. The URL still navigated to `/session/<id>` (without the workspace selector), but the main view was left on the empty "New session" state and the user could not enter the session from the overview panel at all. The same session opened fine from the sidebar list, which already passed the workspace directory.

## Reviewer Test Plan

### How to verify

1. Start a daemon with two workspaces: `node dist/cli.js serve --port 4173 --workspace <dir-a> --workspace <dir-b>`.
2. Create a session in the second workspace and send it a message (e.g. via `POST /session` + `POST /session/:id/prompt` with `cwd` set to `<dir-b>`).
3. Open the Web Shell, open the Session Overview panel, and click that session's card.
4. Expected: the `POST /session/:id/load` request body carries `cwd: <dir-b>` (resolved, e.g. `/private/tmp/...` on macOS), the daemon returns 200, the URL gains a `?workspace=…` selector, and the transcript loads. Before this fix the request carried the primary workspace's `cwd` and failed with 404/409, leaving the view on "New session".
5. Regression: clicking a primary-workspace card in the panel still works, and the sidebar list behavior is unchanged.
6. `cd packages/web-shell && npx vitest run client/components/SessionOverviewPanel.test.tsx` — 28/28 pass, including a new cross-workspace regression test.

### Evidence (Before & After)

**Before** (Playwright traffic capture, panel click on a workspace-B session): request body `{"cwd":"/private/tmp/qwen-webshell-repro",...}` (primary workspace, wrong) → `404 session_not_found`, URL at `/session/<id>` without `?workspace=`, main view stuck on "New session", console logged `DaemonHttpError: POST /session/:id/load`.

**After** (same scenario, rebuilt daemon): request body `{"cwd":"/private/tmp/qwen-webshell-verify-b",...}` (session's own workspace) → `200`, URL `/session/<id>?workspace=aac870abadba792e`, transcript loaded, no console errors or error toasts.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Built bundle (`npm run build`), real daemon with two workspaces, headless Playwright chromium.

## Risk & Scope

- Main risk or tradeoff: minimal — only adds an argument that the session-switch path already accepted and fell back to the primary workspace when missing; for primary-workspace cards the passed value equals the previous fallback.
- Not validated / out of scope: the sidebar's Archived section does not react to clicks at all (a separate pre-existing issue, reported here, not touched by this PR); opening goal/scheduled-task dialogs still pass only the session id (their data does not carry a workspace directory today).
- Breaking changes / migration notes: none.

## Linked Issues

N/A (no open issue; reproduction notes recorded locally).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

从 Session Overview（会话管理）面板点击会话卡片时，现在会把该会话所属的 workspace 目录传给会话切换链路，使加载请求指向会话真实所在的 workspace。面板与 App 之间的回调签名相应扩展以携带该目录；其他逻辑不变。

## 为什么需要它

在多 workspace 注册的 daemon 上，会话管理面板会列出所有 workspace 的会话。此前点击属于非 primary workspace 的会话时，会话的 workspace 归属被丢弃，切换链路退回 primary workspace，daemon 便在错误的 workspace runtime 下找会话并拒绝加载：冷会话返回 `404 session_not_found`，会话已在其自身 runtime 下运行时返回 `409 session_workspace_conflict`。此时 URL 虽然跳到了 `/session/<id>`（但不带 workspace 选择参数），主区域却停留在 "New session" 空态，用户从会话管理面板完全进不去该会话。而同一个会话从侧栏会话列表点击是正常的，因为侧栏一直带着 workspace 目录。

## 评审者验证计划

### 如何验证

1. 启动一个注册了两个 workspace 的 daemon：`node dist/cli.js serve --port 4173 --workspace <dir-a> --workspace <dir-b>`。
2. 在第二个 workspace 中创建一个会话并发一条消息（例如用 `cwd` 指向 `<dir-b>` 的 `POST /session` + `POST /session/:id/prompt`）。
3. 打开 Web Shell，打开 Session Overview 面板，点击该会话卡片。
4. 预期：`POST /session/:id/load` 请求体携带 `cwd: <dir-b>`（解析后的路径，macOS 上形如 `/private/tmp/...`），daemon 返回 200，URL 带上 `?workspace=…` 选择参数，transcript 正常加载。修复前请求体携带的是 primary workspace 的 `cwd`，返回 404/409，页面停留在 "New session"。
5. 回归：点击面板中 primary workspace 的卡片依然正常，侧栏行为不变。
6. `cd packages/web-shell && npx vitest run client/components/SessionOverviewPanel.test.tsx` — 28/28 通过，其中包含新增的跨 workspace 回归测试。

### 证据（修复前/修复后）

**修复前**（Playwright 抓包，面板点击 workspace-B 的会话）：请求体 `{"cwd":"/private/tmp/qwen-webshell-repro",...}`（primary workspace，错误）→ `404 session_not_found`，URL 为不带 `?workspace=` 的 `/session/<id>`，主区域卡在 "New session"，console 记录 `DaemonHttpError: POST /session/:id/load`。

**修复后**（同一场景，重新构建的 daemon）：请求体 `{"cwd":"/private/tmp/qwen-webshell-verify-b",...}`（会话自己的 workspace）→ `200`，URL 为 `/session/<id>?workspace=aac870abadba792e`，transcript 正常加载，无 console 报错、无错误 toast。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 运行环境（可选）

构建产物（`npm run build`），注册了两个 workspace 的真实 daemon，headless Playwright chromium。

## 风险与范围

- 主要风险或权衡：很小——只是多传了一个会话切换链路本就支持的参数，原先缺省时正是回退到 primary workspace；对 primary workspace 的卡片而言，传入值与原回退值相同。
- 未验证/不在范围内：侧栏 Archived 区归档会话点击完全无反应（另一个既有问题，已在复现报告中记录，本 PR 未处理）；Goals/定时任务弹窗打开会话时仍只传会话 id（它们的数据目前不携带 workspace 目录）。
- 破坏性变更/迁移说明：无。

## 关联 Issue

N/A（暂无 issue；复现记录保存在本地）。

</details>
