### PR TITLE
fix(web-shell): fall back after stale mid-turn rejection

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -373,6 +373,7 @@ const {
       messages: [] as unknown[],
       queuedPromptHoldHistory: [] as boolean[],
       queuedPromptStreamingState: 'idle',
+      queuedPromptSessionHasActivePrompt: false,
       chatEditorRenderCount: 0,
       latestChatEditorProps: null as ChatEditorTestProps | null,
       onChatEditorLayout: null as ((props: ChatEditorTestProps) => void) | null,
@@ -605,11 +606,14 @@ vi.mock('./hooks/useQueuedPrompts', () => ({
   useQueuedPrompts: (args: {
     holdQueuedPromptsLocally?: boolean;
     streamingState: string;
+    sessionHasActivePrompt?: boolean;
   }) => {
     testState.queuedPromptHoldHistory.push(
       args.holdQueuedPromptsLocally === true,
     );
     testState.queuedPromptStreamingState = args.streamingState;
+    testState.queuedPromptSessionHasActivePrompt =
+      args.sessionHasActivePrompt === true;
     return {
       queuedPrompts: [],
       queuedTexts,
@@ -4795,6 +4799,7 @@ beforeEach(() => {
   testState.messages = [];
   testState.queuedPromptHoldHistory = [];
   testState.queuedPromptStreamingState = 'idle';
+  testState.queuedPromptSessionHasActivePrompt = false;
   testState.chatEditorRenderCount = 0;
   testState.latestChatEditorProps = null;
   testState.onChatEditorLayout = null;
@@ -10475,7 +10480,7 @@ describe('App session callbacks', () => {
       mockConnection.missingSession = true;
 
       const onSessionIdChange = vi.fn();
-      const { container } = renderApp({
+      const { container, rerender } = renderApp({
         onSessionIdChange,
       });
       await flush();
@@ -10497,6 +10502,23 @@ describe('App session callbacks', () => {
       expect(mockSessionActions.attachSession).not.toHaveBeenCalled();
       expect(onSessionIdChange).toHaveBeenCalledWith(undefined);
       expect(onSessionIdChange).toHaveBeenCalledTimes(1);
+
+      mockConnection.status = 'connected';
+      mockConnection.sessionId = undefined;
+      mockConnection.error = undefined;
+      mockConnection.errorStatus = undefined;
+      mockConnection.missingSession = false;
+      testState.sessionHasActivePrompt = false;
+      rerender();
+      await flush();
+
+      await act(async () => {
+        testState.latestChatEditorProps?.onSubmit('first message');
+        await flush();
+      });
+
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
+      expect(rawEnqueuePrompt).not.toHaveBeenCalled();
     },
   );
 
@@ -11130,7 +11152,8 @@ describe('App session callbacks', () => {
     expect(rawEnqueuePrompt.mock.calls[0]?.[0]).toBe(
       'hello before first token',
     );
-    expect(testState.queuedPromptStreamingState).toBe('responding');
+    expect(testState.queuedPromptStreamingState).toBe('idle');
+    expect(testState.queuedPromptSessionHasActivePrompt).toBe(true);
 
     mockSessionActions.sendPrompt.mockClear();
     rawEnqueuePrompt.mockClear();
@@ -11144,6 +11167,7 @@ describe('App session callbacks', () => {
     });
 
     expect(testState.queuedPromptStreamingState).toBe('idle');
+    expect(testState.queuedPromptSessionHasActivePrompt).toBe(false);
     expect(mockSessionActions.sendPrompt).toHaveBeenCalledTimes(1);
     expect(rawEnqueuePrompt).not.toHaveBeenCalled();
   });

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -4227,10 +4227,6 @@ export function App({
   const [isStartingNewSessionSuggestion, setIsStartingNewSessionSuggestion] =
     useState(false);
   const streamingState = useStreamingState();
-  const queuedPromptStreamingState =
-    streamingState === 'idle' && sessionHasActivePrompt
-      ? 'responding'
-      : streamingState;
   const failedPromptRetryIsCurrent = Boolean(
     failedPromptRetry &&
       retryOwnerMatchesCurrent(
@@ -6315,7 +6311,8 @@ export function App({
     canQueryMidTurn,
     canInjectMidTurnMedia,
     workspaceFileActions: artifactWorkspaceActions,
-    streamingState: queuedPromptStreamingState,
+    streamingState,
+    sessionHasActivePrompt,
     sessionActions,
     store,
     editorRef,
@@ -12768,7 +12765,8 @@ export function App({
                               t={t}
                               canMutateMidTurn={canMutateMidTurn}
                               canInsertMidTurn={
-                                queuedPromptStreamingState !== 'idle'
+                                streamingState !== 'idle' ||
+                                sessionHasActivePrompt
                               }
                               onDelete={removeQueuedPrompt}
                               onInsert={insertQueuedPrompt}

--- a/packages/web-shell/client/components/ChatPane.test.tsx
+++ b/packages/web-shell/client/components/ChatPane.test.tsx
@@ -33,6 +33,7 @@ let streamingStateValue: string;
 let pendingPermission: any;
 let sessionHasActivePromptValue: boolean;
 let queuedPromptStreamingState: string | undefined;
+let queuedPromptSessionHasActivePrompt: boolean | undefined;
 let latestOnSubmit:
   | ((
       text: string,
@@ -142,8 +143,12 @@ vi.mock('../session-catalog/session-catalog-hooks', () => ({
 }));
 
 vi.mock('../hooks/useQueuedPrompts', () => ({
-  useQueuedPrompts: (args: { streamingState: string }) => {
+  useQueuedPrompts: (args: {
+    streamingState: string;
+    sessionHasActivePrompt?: boolean;
+  }) => {
     queuedPromptStreamingState = args.streamingState;
+    queuedPromptSessionHasActivePrompt = args.sessionHasActivePrompt;
     return {
       queuedPrompts: queuedPromptsMock,
       queuedTexts: queuedTextsMock,
@@ -409,6 +414,7 @@ beforeEach(() => {
   renderRealChatEditor = false;
   sessionHasActivePromptValue = false;
   queuedPromptStreamingState = undefined;
+  queuedPromptSessionHasActivePrompt = undefined;
   latestComposerCoreOptions.current = null;
   latestFollowupAccept = undefined;
   latestMonitorDetailsOnOpen = undefined;
@@ -1657,6 +1663,7 @@ describe('ChatPane', () => {
     expect(sendPrompt).not.toHaveBeenCalled();
     expect(enqueuePrompt).toHaveBeenCalled();
     expect(queuedPromptStreamingState).toBe('responding');
+    expect(queuedPromptSessionHasActivePrompt).toBe(false);
   });
 
   it('inserts a prompt before the first stream event reaches the pane', () => {
@@ -1671,7 +1678,8 @@ describe('ChatPane', () => {
 
     expect(sendPrompt).not.toHaveBeenCalled();
     expect(enqueuePrompt).toHaveBeenCalled();
-    expect(queuedPromptStreamingState).toBe('responding');
+    expect(queuedPromptStreamingState).toBe('idle');
+    expect(queuedPromptSessionHasActivePrompt).toBe(true);
 
     sendPrompt.mockClear();
     enqueuePrompt.mockClear();
@@ -1686,6 +1694,7 @@ describe('ChatPane', () => {
     );
 
     expect(queuedPromptStreamingState).toBe('idle');
+    expect(queuedPromptSessionHasActivePrompt).toBe(false);
     expect(sendPrompt).toHaveBeenCalledTimes(1);
     expect(enqueuePrompt).not.toHaveBeenCalled();
   });

--- a/packages/web-shell/client/components/ChatPane.tsx
+++ b/packages/web-shell/client/components/ChatPane.tsx
@@ -273,10 +273,6 @@ export function ChatPane({
   const transcriptHistory = useTranscriptHistory();
   const store = useTranscriptStore();
   const streamingState = useStreamingState();
-  const queuedPromptStreamingState =
-    streamingState === 'idle' && sessionHasActivePrompt
-      ? 'responding'
-      : streamingState;
   const [goalControlBusy, setGoalControlBusy] = useState(false);
   const goalControlOpSeqRef = useRef(0);
   const goalControlOwnerRef = useRef<
@@ -608,7 +604,8 @@ export function ChatPane({
     canQueryMidTurn,
     canInjectMidTurnMedia,
     workspaceFileActions: attachmentWorkspaceTarget?.actions,
-    streamingState: queuedPromptStreamingState,
+    streamingState,
+    sessionHasActivePrompt,
     sessionActions: actions,
     store,
     editorRef,
@@ -1351,7 +1348,9 @@ export function ChatPane({
                 prompts={queuedPrompts}
                 t={t}
                 canMutateMidTurn={canMutateMidTurn}
-                canInsertMidTurn={queuedPromptStreamingState !== 'idle'}
+                canInsertMidTurn={
+                  streamingState !== 'idle' || sessionHasActivePrompt
+                }
                 onDelete={removeQueuedPrompt}
                 onInsert={insertQueuedPrompt}
                 onEdit={editQueuedPrompt}

--- a/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
@@ -100,6 +100,7 @@ interface HarnessOptions {
   canQueryMidTurn?: boolean;
   canInjectMidTurnMedia?: boolean;
   streamingState?: DaemonStreamingState;
+  sessionHasActivePrompt?: boolean;
   holdQueuedPromptsLocally?: boolean;
 }
 
@@ -155,6 +156,7 @@ function createHarness() {
       canInjectMidTurnMedia: opts.canInjectMidTurnMedia ?? true,
       workspaceFileActions: stableWorkspaceFileActions as never,
       streamingState: opts.streamingState ?? 'responding',
+      sessionHasActivePrompt: opts.sessionHasActivePrompt ?? false,
       holdQueuedPromptsLocally: opts.holdQueuedPromptsLocally ?? false,
       sessionActions: sdkMock.actions as never,
       store: stableStore as never,
@@ -569,6 +571,93 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
       expect(sdkMock.actions.submitPrompt).toHaveBeenCalledWith(
         'query late response',
         expect.objectContaining({ sessionId: 'session-a' }),
+      );
+      expect(harness.reportError).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('falls back when live state is active but raw streaming is idle', async () => {
+    let resolveAdmission:
+      | ((value: { accepted: boolean; messageId?: string }) => void)
+      | undefined;
+    sdkMock.actions.enqueueMidTurnMessage.mockImplementation(
+      (_message: string, opts?: { onAdmissionStarted?: () => void }) =>
+        new Promise((resolve) => {
+          opts?.onAdmissionStarted?.();
+          resolveAdmission = resolve;
+        }),
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({
+        streamingState: 'idle',
+        sessionHasActivePrompt: true,
+      });
+      await act(async () => {
+        harness.result().enqueuePrompt('live state race');
+      });
+      await act(async () => {
+        resolveAdmission?.({ accepted: false });
+      });
+
+      expect(sdkMock.actions.enqueueMidTurnMessage).toHaveBeenCalledOnce();
+      expect(sdkMock.actions.submitPrompt).toHaveBeenCalledOnce();
+      expect(sdkMock.actions.submitPrompt).toHaveBeenCalledWith(
+        'live state race',
+        expect.objectContaining({ sessionId: 'session-a' }),
+      );
+      expect(harness.reportError).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('preserves file annotations when a live-state insert falls back', async () => {
+    const fileText = '@docs/notes.txt';
+    const text = `${fileText} explain this`;
+    const annotation = {
+      type: 'reference' as const,
+      start: 0,
+      end: fileText.length,
+      text: fileText,
+      reference: {
+        id: 'file:docs/notes.txt',
+        kind: 'file' as const,
+        value: 'docs/notes.txt',
+      },
+    };
+    sdkMock.actions.enqueueMidTurnMessage.mockImplementationOnce(
+      (_message: string, opts?: { onAdmissionStarted?: () => void }) => {
+        opts?.onAdmissionStarted?.();
+        return Promise.resolve({ accepted: false });
+      },
+    );
+    const harness = createHarness();
+    try {
+      await harness.render({
+        streamingState: 'idle',
+        sessionHasActivePrompt: true,
+      });
+      await act(async () => {
+        harness
+          .result()
+          .enqueuePrompt(text, undefined, undefined, undefined, [annotation]);
+        await Promise.resolve();
+      });
+
+      expect(sdkMock.actions.removeAttachment).toHaveBeenCalledWith(
+        'notes.txt',
+        { sessionId: 'session-a' },
+      );
+      expect(sdkMock.actions.submitPrompt).toHaveBeenCalledWith(
+        text,
+        expect.objectContaining({
+          files: undefined,
+          inputAnnotations: [annotation],
+          sessionId: 'session-a',
+        }),
       );
       expect(harness.reportError).not.toHaveBeenCalled();
     } finally {

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -78,6 +78,7 @@ interface UseQueuedPromptsArgs {
   canInjectMidTurnMedia: boolean;
   workspaceFileActions?: Pick<DaemonWorkspaceActions, 'readFileBytes' | 'stat'>;
   streamingState: DaemonStreamingState;
+  sessionHasActivePrompt?: boolean;
   /** Keep ordinary submissions local until the Goal is paused, cleared, or the
    * user explicitly inserts one into the current turn. */
   holdQueuedPromptsLocally?: boolean;
@@ -403,6 +404,7 @@ export function useQueuedPrompts({
   canInjectMidTurnMedia,
   workspaceFileActions,
   streamingState,
+  sessionHasActivePrompt = false,
   holdQueuedPromptsLocally = false,
   sessionActions,
   store,
@@ -472,7 +474,10 @@ export function useQueuedPrompts({
   >(new Map());
   const appendedBeforeResponsePromptIdsRef = useRef<Set<string>>(new Set());
   const removedBeforeResponsePromptIdsRef = useRef<Set<string>>(new Set());
-  const latestStreamingStateRef = useRef(streamingState);
+  const latestRawStreamingStateRef = useRef(streamingState);
+  const latestSessionActiveRef = useRef(
+    streamingState !== 'idle' || sessionHasActivePrompt,
+  );
   const holdQueuedPromptsLocallyRef = useRef(holdQueuedPromptsLocally);
   const refreshRequestSeqRef = useRef(0);
   /** Stale-response fence for `getMidTurnMessages` reconciliation calls. */
@@ -496,11 +501,12 @@ export function useQueuedPrompts({
   latestSessionIdRef.current = sessionId;
   latestWorkspaceCwdRef.current = workspaceCwd;
   holdQueuedPromptsLocallyRef.current = holdQueuedPromptsLocally;
-  const streamingIdle = streamingState === 'idle';
+  const sessionActive = streamingState !== 'idle' || sessionHasActivePrompt;
   useLayoutEffect(() => {
     midTurnReconcileSeqRef.current += 1;
-  }, [streamingIdle]);
-  latestStreamingStateRef.current = streamingState;
+  }, [sessionActive]);
+  latestRawStreamingStateRef.current = streamingState;
+  latestSessionActiveRef.current = sessionActive;
 
   const visibleQueuedPrompts =
     queuedPromptsOwnerRef.current === ownerToken ? queuedPrompts : [];
@@ -1149,7 +1155,7 @@ export function useQueuedPrompts({
     prevPendingVersionRef.current = pendingPromptVersion;
     if (!versionChanged) {
       if (!canQueryMidTurn && queuedPromptsRef.current.length > 0) return;
-      if (streamingState === 'idle' && !canQueryMidTurn) return;
+      if (!sessionActive && !canQueryMidTurn) return;
       if (initialRefreshSessionIdRef.current === sessionId) return;
       initialRefreshSessionIdRef.current = sessionId;
     }
@@ -1163,7 +1169,7 @@ export function useQueuedPrompts({
     pendingPromptVersion,
     connected,
     sessionId,
-    streamingState,
+    sessionActive,
     canQueryMidTurn,
     ownerToken,
     refreshPendingPrompts,
@@ -1387,7 +1393,7 @@ export function useQueuedPrompts({
             displayedServerPromptIdsRef.current.delete(result.promptId);
             return;
           }
-          if (latestStreamingStateRef.current === 'idle') {
+          if (!latestSessionActiveRef.current) {
             if (!localMessageAppended) {
               appendLocalQueuedPrompt(prompt, result.promptId);
             }
@@ -1591,7 +1597,7 @@ export function useQueuedPrompts({
         workspaceFileActions !== undefined;
       const shouldInsertMidTurn =
         !holdQueuedPromptsLocallyRef.current &&
-        latestStreamingStateRef.current !== 'idle' &&
+        latestSessionActiveRef.current &&
         (imageList.length === 0 || canSendMidTurnMedia) &&
         (fileList.length === 0 || canSendMidTurnFiles) &&
         annotated !== undefined &&
@@ -1796,13 +1802,13 @@ export function useQueuedPrompts({
               // runs) instead of dropping it.
               if (
                 targetIsCurrent() &&
-                latestStreamingStateRef.current === 'idle'
+                latestRawStreamingStateRef.current === 'idle'
               ) {
                 const shouldHold =
                   holdQueuedPromptsLocallyRef.current ||
                   writeBlockedRef.current;
                 const prompt: QueuedPrompt = {
-                  ...pendingAdmission,
+                  ...restoreAdmission,
                   midTurnState: undefined,
                   midTurnMessageId: undefined,
                   ...(shouldHold ? {} : { serverState: 'submitting' as const }),
@@ -1973,7 +1979,7 @@ export function useQueuedPrompts({
             fallbackToPendingPrompt(prompt.id);
             return;
           }
-          if (latestStreamingStateRef.current === 'idle') {
+          if (!latestSessionActiveRef.current) {
             const next = current.filter((item) => item.id !== prompt.id);
             queuedPromptsRef.current = next;
             setQueuedPrompts(next);
@@ -2065,7 +2071,7 @@ export function useQueuedPrompts({
   ]);
 
   useEffect(() => {
-    if (streamingState !== 'idle' || writeBlocked) return;
+    if (sessionActive || writeBlocked) return;
     if (!canQueryMidTurn) {
       const acceptedIds = new Set(
         queuedPromptsRef.current
@@ -2167,7 +2173,7 @@ export function useQueuedPrompts({
       reconcileCtrl.abort();
     };
   }, [
-    streamingState,
+    sessionActive,
     writeBlocked,
     holdQueuedPromptsLocally,
     canQueryMidTurn,
@@ -2364,7 +2370,7 @@ export function useQueuedPrompts({
             );
             return false;
           }
-          const settledAtIdle = latestStreamingStateRef.current === 'idle';
+          const settledAtIdle = !latestSessionActiveRef.current;
           if (settledAtIdle) {
             const next = current.filter((prompt) => prompt.id !== target.id);
             queuedPromptsRef.current = next;
@@ -2405,7 +2411,7 @@ export function useQueuedPrompts({
             reportError(error, fallback);
             return false;
           }
-          const settledAtIdle = latestStreamingStateRef.current === 'idle';
+          const settledAtIdle = !latestSessionActiveRef.current;
           if (settledAtIdle) {
             const next = queuedPromptsRef.current.filter(
               (prompt) => prompt.id !== target.id,
@@ -2475,7 +2481,7 @@ export function useQueuedPrompts({
       const prompt = queuedPromptsRef.current.find((item) => item.id === id);
       if (
         !canMutateMidTurn ||
-        latestStreamingStateRef.current === 'idle' ||
+        !latestSessionActiveRef.current ||
         !prompt ||
         prompt.serverState !== undefined ||
         prompt.serverPromptId !== undefined ||
@@ -2579,8 +2585,7 @@ export function useQueuedPrompts({
         const submitAtIdle =
           isCurrentOwnerTokenRef.current(insertionOwnerToken) &&
           insertOwnerMatches() &&
-          (latestStreamingStateRef.current as DaemonStreamingState) ===
-            'idle' &&
+          !latestSessionActiveRef.current &&
           !writeBlockedRef.current &&
           !holdQueuedPromptsLocallyRef.current;
         const nextFlags = {
@@ -2686,7 +2691,7 @@ export function useQueuedPrompts({
       const index = current.findIndex((item) => item.id === prompt.id);
       const acceptedAtLegacyIdle =
         insertOwnerMatches() &&
-        (latestStreamingStateRef.current as DaemonStreamingState) === 'idle' &&
+        !latestSessionActiveRef.current &&
         !canQueryMidTurn;
       if (index === -1) {
         const stashKey = currentStashKey();


### PR DESCRIPTION
## What this PR does

This change keeps the raw SSE streaming state separate from the daemon-authoritative active-prompt signal. An active-prompt signal still causes an ordinary message to try mid-turn insertion first. If the daemon definitively rejects that insertion while the raw SSE state is already idle, Web Shell submits the message once through the ordinary prompt path instead of showing a rejection toast. The fallback preserves text, images, files, file annotations, and completion callbacks in both the main chat and split panes.

## Why it's needed

The live session snapshot can briefly continue reporting an active prompt after the turn has already become idle. Previously Web Shell converted that combination into a synthetic responding state, which discarded the raw idle information. A message submitted during that window tried mid-turn insertion, and a definitive idle rejection from the daemon surfaced as `Daemon rejected mid-turn message` instead of sending the user's message normally.

## Reviewer Test Plan

### How to verify

With a session whose raw SSE state is idle while live state still reports an active prompt, submit an ordinary text message and have the daemon reject the mid-turn admission. Confirm Web Shell first attempts mid-turn insertion, then submits exactly one ordinary prompt without an error toast. Repeat with an `@file` reference and confirm the original text and annotation reach the ordinary prompt path. With a genuinely responding session, reject the mid-turn admission and confirm Web Shell retains the existing rejection behavior rather than falling back. From a 404 or 410 missing-session screen, create a new conversation and submit its first message; confirm it uses the ordinary prompt path and does not attempt mid-turn insertion.

### Evidence (Before & After)

Before: `streamingState=idle` plus `hasActivePrompt=true` was flattened to a synthetic responding state. A definitive mid-turn rejection produced an error toast and did not retry through the ordinary prompt path.

After: the same state still attempts mid-turn insertion first, but a definitive rejection falls back once when the raw SSE state is idle. Genuine streaming rejections continue to surface normally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local Web Shell unit tests, TypeScript typecheck, ESLint, production build, and browser-level missing-session flow against the mock daemon.

## Risk & Scope

- Main risk or tradeoff: `accepted:false` does not identify whether the daemon rejected because the session became idle, was closing, or reached another admission limit. The fallback is therefore deliberately limited to cases where the raw SSE state is idle; an ordinary submission can still return its normal error if the session cannot accept it.
- Not validated / out of scope: changing the daemon response contract, unifying ordinary and mid-turn submission behind a new backend API, and fixing old direct links that omit a secondary workspace identity.
- Breaking changes / migration notes: None.

## Linked Issues

Related: #9667

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本改动将真实 SSE 流状态与 daemon 权威的 active-prompt 信号分开保存。active-prompt 信号仍会让普通消息优先尝试 mid-turn 插入。如果 daemon 明确拒绝该插入，且真实 SSE 状态已经是 idle，Web Shell 会改用普通 prompt 路径提交一次，而不是展示拒绝错误。该降级路径在主会话和分屏会话中都会保留文本、图片、附件、文件 annotation 和完成回调。

## 为什么需要

在 turn 已经进入 idle 后，live session snapshot 可能短暂继续报告 active prompt。之前 Web Shell 会将这个组合转换为人工的 responding 状态，从而丢失真实的 idle 信息。用户在该窗口期间发送消息时，前端会尝试 mid-turn 插入；当 daemon 明确以 idle 拒绝时，界面会显示 `Daemon rejected mid-turn message`，而不是正常发送用户消息。

## Reviewer 测试计划

### 验证方法

在真实 SSE 状态为 idle、但 live state 仍报告 active prompt 的会话中提交普通文本，并让 daemon 拒绝 mid-turn admission。确认 Web Shell 先尝试 mid-turn 插入，然后只提交一次普通 prompt，且不显示错误 toast。使用 `@file` 引用重复测试，确认原始文本和 annotation 进入普通 prompt 路径。在真正 responding 的会话中拒绝 mid-turn admission，确认 Web Shell 保留现有的拒绝处理，而不是降级发送。从 404 或 410 的会话不存在页面新建会话并提交第一条消息，确认该消息走普通 prompt，而不是 mid-turn 插入。

### 前后对比证据

修复前：`streamingState=idle` 加 `hasActivePrompt=true` 会被合并为人工的 responding 状态。mid-turn 被明确拒绝后会显示错误 toast，也不会通过普通 prompt 路径重试。

修复后：同样的状态仍会先尝试 mid-turn 插入，但在被明确拒绝后，若真实 SSE 状态为 idle，则降级发送一次。真正 streaming 时的拒绝仍然正常显示。

### 测试环境

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS       |  ✅  |
| 🪟 Windows     | N/A  |
|  🐧 Linux       | N/A  |

### 环境（可选）

本地 Web Shell 单元测试、TypeScript typecheck、ESLint、生产构建，以及基于 mock daemon 的会话不存在浏览器流程。

## 风险与范围

- 主要风险或权衡：`accepted:false` 不会指明 daemon 是因为 session 变为 idle、正在关闭，还是达到了其他 admission 限制而拒绝。因此降级严格限定在真实 SSE 状态为 idle 的情况；如果 session 无法接收消息，普通提交仍可能返回其正常错误。
- 未验证或范围外：修改 daemon 响应合同、通过新后端 API 统一普通与 mid-turn 提交，以及修复未携带 secondary workspace 标识的旧直达链接。
- 破坏性变更或迁移说明：无。

## 关联问题

相关：#9667

</details>
