### PR TITLE
fix(ci): record qwen-autofix.yml's shipped size in the workflow size baseline

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -34,7 +34,7 @@
 6495 pr-self-report-label.yml
 9646 qwen-autofix-fork-bridge.yml
 5942 qwen-autofix-fork-signal.yml
-392111 qwen-autofix.yml
+397656 qwen-autofix.yml
 7061 qwen-ci-flaky-rerun.yml
 151937 qwen-code-pr-review.yml
 79041 qwen-fleet-shepherd.yml


### PR DESCRIPTION
## What this PR does

Corrects one number in `.github/workflows/.size-baseline`: the entry for `qwen-autofix.yml` becomes 397656, the size of the file that is actually on disk, replacing the 392111 recorded alongside it.

## Why it's needed

The growth ratchet added in #9677 does not pass on the tree that added it. That PR moved prose out of `qwen-autofix.yml` (431526 → 397656 bytes) and wrote the manifest in the same commit, but the number it wrote is the size from an earlier revision of its own branch — 5545 bytes below what shipped, and 1449 past the 4096-byte allowance the gate permits.

Nothing downstream can get past it. `Check workflow file size` is step 7 of the `Test` job, ahead of `Install dependencies`, and a failure there skips every step after it — so a PR whose merge ref contains #9677 shows a red `Test` lane that ran no tests at all, over a workflow file the PR never touched. Two PRs from different authors were measured failing at that step and at no other; PRs still based on a merge ref from before #9677 stay green, which is what places the cause.

The file is the post-migration one #9677 intended to ship, so the number is what moves rather than the file. The ratchet resumes measuring drift from the size that is really there.

## Reviewer Test Plan

### How to verify

On `main`, both the shell gate and its vitest mirror fail; with this one-line change, both pass.

```
# on main
$ bash .github/scripts/check-workflow-size.sh ; echo "exit=$?"
::error file=.github/workflows/qwen-autofix.yml::.github/workflows/qwen-autofix.yml grew to 397656 bytes, 5545 over its recorded 392111 (allowance 4096). ...
exit=1

$ npx vitest run --root . scripts/tests/workflow-size.test.js
 × workflow size growth ratchet > .github/workflows/qwen-autofix.yml is within its baseline allowance
   → expected 397656 to be less than or equal to 396207
 Tests  1 failed | 180 passed (181)

# with this change
$ bash .github/scripts/check-workflow-size.sh ; echo "exit=$?"
✅ every workflow file is under the 470000-byte gate and within 4096 bytes of its recorded baseline
exit=0

$ npx vitest run --root . scripts/tests/workflow-size.test.js
 Tests  181 passed (181)
```

Restoring the old number turns the mirror red again, so the single line is what the result hangs on.

The manifest is otherwise accurate and stays untouched: all 52 workflow files have an entry, 50 match their file byte-for-byte, and the one remaining drift (`qwen-code-pr-review.yml`, +1339) is inside the allowance, which is what the allowance is for.

### Evidence (Before & After)

N/A — no user-visible surface; the before/after is the command output above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

macOS; the gate is a byte count over files in the repo, so it has no platform-dependent behaviour. CI covers the Linux lane.

## Risk & Scope

- Main risk or tradeoff: recording the shipped size banks 5545 bytes of growth that no reviewer approved as growth. It was not growth — #9677 shrank the file by 33870 bytes overall — but the number now sits where the next drift is measured from, so the ratchet's next objection comes 5545 bytes later than if the file had been trimmed instead.
- Not validated / out of scope: whether `qwen-autofix.yml` should be smaller than 397656. This restores the gate to working order at the size #9677 chose; trimming it further is a separate change.
- Breaking changes / migration notes: none.

## Linked Issues

Follows up #9677.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修正 `.github/workflows/.size-baseline` 里的一个数字：`qwen-autofix.yml` 的条目改为 397656，即磁盘上文件的真实大小，替换掉与之一同落库的 392111。

## 为什么需要

#9677 引入的增长棘轮，在引入它的那棵树上就过不去。那个 PR 把散文从 `qwen-autofix.yml` 移了出去（431526 → 397656 字节），并在同一个 commit 里写下清单，但它写下的数字是该分支更早某个修订版的大小——比实际落库的小 5545 字节，超出闸门允许的 4096 字节允差 1449 字节。

下游没有任何东西能越过它。`Check workflow file size` 是 `Test` job 的第 7 步，排在 `Install dependencies` 之前，而该步失败会跳过其后的每一步——于是任何 merge ref 含 #9677 的 PR，都会看到一条红着的 `Test` 通道，而它一个测试都没跑，起因还是一个该 PR 从未碰过的 workflow 文件。实测两个来自不同作者的 PR 都恰好挂在这一步、且不挂在其它任何一步；而 merge ref 早于 #9677 的 PR 仍然是绿的——这就定住了因果。

该文件正是 #9677 想要落库的迁移后版本，所以要动的是数字而不是文件。棘轮从真实存在的那个大小重新开始度量漂移。

## 评审验证计划

### 如何验证

在 `main` 上，shell 闸门与它的 vitest 镜像都会失败；加上这一行改动后两者都通过。命令与输出见上方英文正文的代码块。

把旧数字改回去，镜像测试会重新变红——说明结果就悬在这一行上。

清单其余部分是准确的，不做改动：52 个 workflow 文件都有条目，其中 50 个与文件逐字节相符，剩下唯一的漂移（`qwen-code-pr-review.yml`，+1339）落在允差之内，而这正是允差的用途。

### 证据（前后对比）

N/A —— 没有用户可见的界面；前后对比就是上面的命令输出。

### 测试环境

见上方表格。闸门只是对仓库内文件做字节计数，没有平台相关行为；Linux 通道由 CI 覆盖。

## 风险与范围

- 主要风险或取舍：记录落库大小，等于把 5545 字节的增长收进了基线，而没有评审者把它当作"增长"批准过。它本来也不是增长——#9677 整体缩小了该文件 33870 字节——但这个数字现在成了下一次漂移的度量起点，所以棘轮的下一次反对会比"把文件裁小"的做法晚 5545 字节到来。
- 未验证 / 范围之外：`qwen-autofix.yml` 是否应当小于 397656。本 PR 只是把闸门恢复到可用状态，停在 #9677 自己选定的大小上；进一步裁剪是另一件事。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

跟进 #9677。

</details>
