### PR TITLE
fix(cli): degrade gracefully when messageRewrite.promptFile cannot be read

### DIFF
--- a/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.test.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { Config } from '@qwen-code/qwen-code-core';
 import type { TurnContent, MessageRewriteConfig } from './types.js';
 
@@ -276,6 +279,67 @@ describe('LlmRewriter', () => {
       const input =
         mockGenerateContent.mock.calls[1][0].contents[0].parts[0].text;
       expect(input).not.toContain('上一轮改写结果');
+    });
+  });
+
+  describe('promptFile', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), 'llm-rewriter-promptfile-'));
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function promptOf(rewriter: unknown): string {
+      return (rewriter as { prompt: string }).prompt;
+    }
+
+    it('loads a custom prompt from a readable file', () => {
+      const filePath = join(tempDir, 'prompt.md');
+      writeFileSync(filePath, '  custom rewrite prompt  ');
+
+      const rewriter = new LlmRewriter(makeConfig(), {
+        enabled: true,
+        target: 'all',
+        promptFile: filePath,
+      } as MessageRewriteConfig);
+
+      expect(promptOf(rewriter)).toBe('custom rewrite prompt');
+    });
+
+    it('falls back to the default prompt when the file is missing', () => {
+      const rewriter = new LlmRewriter(makeConfig(), {
+        enabled: true,
+        target: 'all',
+        promptFile: join(tempDir, 'does-not-exist.md'),
+      } as MessageRewriteConfig);
+
+      expect(promptOf(rewriter)).toContain('rewrites raw coding-agent output');
+    });
+
+    // Regression for #9752: promptFile pointing at a path that exists but
+    // cannot be read as a file (a directory) used to throw EISDIR from the
+    // constructor, crashing ACP session startup.
+    it('falls back to the default prompt when promptFile is a directory', () => {
+      expect(
+        () =>
+          new LlmRewriter(makeConfig(), {
+            enabled: true,
+            target: 'all',
+            promptFile: tempDir,
+          } as MessageRewriteConfig),
+      ).not.toThrow();
+
+      const rewriter = new LlmRewriter(makeConfig(), {
+        enabled: true,
+        target: 'all',
+        promptFile: tempDir,
+      } as MessageRewriteConfig);
+
+      expect(promptOf(rewriter)).toContain('rewrites raw coding-agent output');
     });
   });
 });

--- a/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.ts
@@ -57,16 +57,29 @@ export class LlmRewriter {
     // promptFile takes precedence over inline prompt
     if (rewriteConfig.promptFile) {
       const filePath = resolve(rewriteConfig.promptFile);
-      if (existsSync(filePath)) {
-        this.prompt = readFileSync(filePath, 'utf-8').trim();
-        debugLogger.info(
-          `Loaded rewrite prompt from file: ${filePath} (${this.prompt.length} chars)`,
-        );
-      } else {
+      if (!existsSync(filePath)) {
         debugLogger.warn(
           `Rewrite prompt file not found: ${filePath}, using default`,
         );
         this.prompt = DEFAULT_REWRITE_PROMPT;
+      } else {
+        // existsSync passes for directories and says nothing about
+        // readability, so the read itself can still fail (EISDIR, EACCES,
+        // ...). Degrade like the missing-file case instead of throwing,
+        // which would crash ACP session startup (#9752).
+        try {
+          this.prompt = readFileSync(filePath, 'utf-8').trim();
+          debugLogger.info(
+            `Loaded rewrite prompt from file: ${filePath} (${this.prompt.length} chars)`,
+          );
+        } catch (error) {
+          debugLogger.warn(
+            `Rewrite prompt file could not be read: ${filePath} (${
+              error instanceof Error ? error.message : String(error)
+            }), using default`,
+          );
+          this.prompt = DEFAULT_REWRITE_PROMPT;
+        }
       }
     } else {
       this.prompt = rewriteConfig.prompt || DEFAULT_REWRITE_PROMPT;

--- a/packages/cli/src/acp-integration/session/rewrite/README.md
+++ b/packages/cli/src/acp-integration/session/rewrite/README.md
@@ -33,3 +33,6 @@ Add to `settings.json`:
 ```
 
 `timeoutMs` sets the per-rewrite LLM call timeout in milliseconds. Defaults to 30000.
+If `promptFile` is missing or cannot be read, rewriting falls back to the
+built-in default prompt. Set `QWEN_DEBUG_LOG_FILE` to capture the fallback
+warning.


### PR DESCRIPTION
## What this PR does

Wraps the `messageRewrite.promptFile` read in the `LlmRewriter` constructor in error handling. When the configured path exists but cannot be read as a file — a directory (`EISDIR`) is the deterministic example, unreadable files (`EACCES`/`EPERM`) behave the same — it now logs a warning and falls back to the built-in `DEFAULT_REWRITE_PROMPT`, the same degradation path already used for a missing file. Previously the bare `readFileSync()` threw out of the constructor.

## Why it's needed

Before this change, `existsSync()` passed for a directory, then `readFileSync()` threw synchronously with no error handling anywhere between the constructor and the session-creation caller: `Session.installRewriter()` runs inside the `createAndStoreSession` try block, whose catch disposes the half-built session and rethrows. The result was that a misconfigured `promptFile` crashed ACP session startup entirely, bypassing the rewrite feature's intended safe-degradation behavior. After this change, the session opens normally with the default rewrite prompt and a debug warning.

## Reviewer Test Plan

### How to verify

Unit level: `npx vitest run src/acp-integration/session/rewrite/LlmRewriter.test.ts` in `packages/cli`. The new `promptFile` describe block covers three cases: a real temp directory as `promptFile` (the #9752 regression), a missing file (degradation unchanged), and a readable file (custom prompt still loaded and trimmed). On the pre-fix code the directory test fails with the exact error from the issue:

```
× LlmRewriter > promptFile > falls back to the default prompt when promptFile is a directory
AssertionError: expected [Function] to not throw an error
+ Received: "Error: EISDIR: illegal operation on a directory, read"
```

After the fix all 15 tests in the file pass. End-to-end shape: set `"messageRewrite": { "enabled": true, "target": "all", "promptFile": "." }`, open an ACP session — pre-fix the session fails to open with `EISDIR`, post-fix it opens and rewriting uses the default prompt.

### Evidence (Before & After)

N/A — no TUI/UI change; this is the ACP session startup path. The failing/passing test output above is the observable evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest`), Node v24 on Linux. The failing path is platform-independent (synchronous `fs` read).

## Risk & Scope

- Main risk or tradeoff: none expected — the read failure now degrades instead of throwing, matching the feature's existing missing-file behavior; the missing-file branch itself and its warning message are unchanged.
- Not validated / out of scope: the `EACCES`/`EPERM` variants go through the same catch but are not tested directly, since chmod-based permission tests are unreliable when CI runs as root; the directory case is the deterministic one. No config schema changes, no changes to other rewrite middleware.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9752

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 `LlmRewriter` 构造函数中读取 `messageRewrite.promptFile` 的逻辑加上了错误处理。当配置的路径存在但无法按文件读取时——目录（`EISDIR`）是确定性例子，不可读文件（`EACCES`/`EPERM`）行为相同——现在会打印警告并回退到内置的 `DEFAULT_REWRITE_PROMPT`，与文件缺失分支已有的降级路径完全一致。此前裸的 `readFileSync()` 会直接从构造函数抛错。

## 为什么需要

改动之前，目录能通过 `existsSync()`，随后 `readFileSync()` 同步抛错，而从构造函数到会话创建调用方之间没有任何错误处理：`Session.installRewriter()` 运行在 `createAndStoreSession` 的 try 块内，其 catch 会销毁半初始化的会话并重新抛出。结果就是配置错误的 `promptFile` 会让整个 ACP 会话启动崩溃，绕过了 rewrite 功能本应有的安全降级行为。改动之后，会话可以正常打开，使用默认 rewrite prompt，并打印一条 debug 警告。

## 评审验证方案

### 如何验证

单元测试层：在 `packages/cli` 下执行 `npx vitest run src/acp-integration/session/rewrite/LlmRewriter.test.ts`。新增的 `promptFile` describe 块覆盖三个用例：真实临时目录作为 `promptFile`（#9752 回归）、文件缺失（降级行为不变）、可读文件（自定义 prompt 仍正常加载并 trim）。在修复前的代码上，目录用例会以 issue 中报告的原始错误失败：

```
× LlmRewriter > promptFile > falls back to the default prompt when promptFile is a directory
AssertionError: expected [Function] to not throw an error
+ Received: "Error: EISDIR: illegal operation on a directory, read"
```

修复后该文件全部 15 个测试通过。端到端形态：设置 `"messageRewrite": { "enabled": true, "target": "all", "promptFile": "." }` 后打开 ACP 会话——修复前会话因 `EISDIR` 打不开，修复后正常打开且改写使用默认 prompt。

### 前后对比证据

N/A——无 TUI/UI 变化；这是 ACP 会话启动路径。上面失败/通过的测试输出即为可观测证据。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元测试（`vitest`），Linux 上 Node v24。失败路径与平台无关（同步 `fs` 读取）。

## 风险与范围

- 主要风险或权衡：预期没有——读取失败现在降级而不是抛错，与该功能已有的文件缺失行为一致；文件缺失分支本身及其警告信息保持不变。
- 未验证 / 超出范围：`EACCES`/`EPERM` 变体走同一个 catch，但未直接测试，因为 CI 以 root 运行时基于 chmod 的权限测试不可靠；目录用例是确定性的。不改配置 schema，不改其他 rewrite 中间件。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #9752

</details>
