### PR TITLE
fix(core): emit OpenRouter's reasoning disable when thinking is off

### DIFF
--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -598,6 +598,8 @@ Setting `reasoning: false` (the literal boolean) explicitly disables thinking on
 
 On a `api.deepseek.com` baseURL, the OpenAI pipeline emits the explicit `thinking: { type: 'disabled' }` field that DeepSeek V4+ requires — the server-side default is `'enabled'`, so simply omitting `reasoning_effort` would still pay thinking latency/cost. Self-hosted DeepSeek backends (sglang/vllm) and other OpenAI-compatible servers do **not** receive this field; if you need to disable thinking on those, inject `thinking: { type: 'disabled' }` (or whatever knob your inference framework exposes) via `samplingParams`/`extra_body`.
 
+On an `openrouter.ai` baseURL, the OpenAI pipeline emits OpenRouter's provider-level `reasoning: { enabled: false }` field when reasoning is disabled. Other OpenAI-compatible servers do not receive this OpenRouter-specific field; use `samplingParams`/`extra_body` for their native disable knob.
+
 ### Interaction with `samplingParams` (OpenAI-compatible only)
 
 > [!warning]

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1728,6 +1728,284 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.thinking).toBeUndefined();
     });
 
+    it('emits reasoning.enabled=false on OpenRouter hostname when includeThoughts is false', async () => {
+      // Regression for #9757: OpenRouter's native thinking switch is the
+      // provider-level `reasoning` parameter. The disable path emits only
+      // shapes OpenRouter ignores (chat_template_kwargs for qwen-family
+      // models) and strips any `reasoning` object, so thinking-capable
+      // models routed through OpenRouter keep thinking enabled. The
+      // AUTO-mode classifier's stage-1 side query (256-token budget,
+      // forced respond_in_schema tool call, includeThoughts: false) then
+      // spends its whole budget on reasoning, never emits the tool call,
+      // and fail-closes with "Classifier stage 1 unavailable". Verify the
+      // OpenRouter-native disable shape is emitted.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://openrouter.ai/api/v1',
+        model: 'qwen/qwen3.8-27b',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen/qwen3.8-27b',
+        contents: [{ parts: [{ text: 'Classify action' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Classify action' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'side-query:permission-classifier');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toEqual({ enabled: false });
+    });
+
+    it('emits reasoning.enabled=false on OpenRouter hostname when reasoning is configured to false', async () => {
+      // Config-level opt-out (`reasoning: false`) must also land OpenRouter's
+      // native disable shape, matching the DeepSeek hostname branch.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://openrouter.ai/api/v1',
+        model: 'qwen/qwen3.8-27b',
+        reasoning: false,
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen/qwen3.8-27b',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Hello' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'main');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toEqual({ enabled: false });
+    });
+
+    it('emits reasoning.enabled=false on OpenRouter for non-qwen models too', async () => {
+      // `reasoning` is an OpenRouter provider-level parameter the gateway
+      // routes to any model that supports it — not a qwen-family wire field
+      // like `enable_thinking`. Gating on the model family would leave every
+      // other thinking model on OpenRouter broken the same way.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://openrouter.ai/api/v1',
+        model: 'deepseek/deepseek-r1',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'deepseek/deepseek-r1',
+        contents: [{ parts: [{ text: 'Classify action' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Classify action' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'side-query:permission-classifier');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toEqual({ enabled: false });
+    });
+
+    it('does NOT emit reasoning.enabled=false for thinking-mandatory models on OpenRouter', async () => {
+      // thinkingMandatory marks models that reject a thinking-disable shape
+      // with a 400; the exemption must hold on OpenRouter too.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://openrouter.ai/api/v1',
+        model: 'qwen/qwen3.8-27b',
+        thinkingMandatory: true,
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen/qwen3.8-27b',
+        contents: [{ parts: [{ text: 'Classify action' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Classify action' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toBeUndefined();
+    });
+
+    it('does NOT emit reasoning on a non-OpenRouter OpenAI-compatible endpoint', async () => {
+      // The disable shape is OpenRouter-specific wire shape; other
+      // OpenAI-compatible gateways (vLLM/SGLang/strict-compat) must not
+      // receive the extra `reasoning` field.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://my-vllm.example.com:8000/v1',
+        model: 'qwen/qwen3-32b',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen/qwen3-32b',
+        contents: [{ parts: [{ text: 'Classify action' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Classify action' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toBeUndefined();
+    });
+
+    it('does NOT treat lookalike hostnames as OpenRouter', async () => {
+      // Hostname match must be exact (openrouter.ai or *.openrouter.ai); a
+      // substring check would false-positive on hostile hosts.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://openrouter.ai.evil.com/v1',
+        model: 'qwen/qwen3.8-27b',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen/qwen3.8-27b',
+        contents: [{ parts: [{ text: 'Classify action' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Classify action' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toBeUndefined();
+    });
+
+    it('does NOT emit reasoning on the official OpenAI endpoint when includeThoughts is false', async () => {
+      // The new OpenRouter branch must not leak onto api.openai.com, which
+      // has its own reasoning shapes and rejects unknown fields.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'gpt-5',
+        contents: [{ parts: [{ text: 'Classify action' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Classify action' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toBeUndefined();
+    });
+
     it('emits enable_thinking:false on DashScope hostname when includeThoughts is false', async () => {
       // Regression for #4501: qwen3 hybrid models (e.g. qwen3.5-flash)
       // default to thinking-on. Provider buildRequest never auto-injects

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1774,6 +1774,41 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.reasoning).toEqual({ enabled: false });
     });
 
+    it('does NOT emit reasoning.enabled=false on OpenRouter when thinking is enabled', async () => {
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://openrouter.ai/api/v1',
+        model: 'qwen/qwen3.8-27b',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen/qwen3.8-27b',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Hello' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'main');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.reasoning).toBeUndefined();
+    });
+
     it('emits reasoning.enabled=false on OpenRouter hostname when reasoning is configured to false', async () => {
       // Config-level opt-out (`reasoning: false`) must also land OpenRouter's
       // native disable shape, matching the DeepSeek hostname branch.

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -20,6 +20,7 @@ import {
   isOfficialOpenAIEndpoint,
 } from './prefix-caching.js';
 import { isDeepSeekHostname } from './provider/deepseek.js';
+import { isOpenRouterHostname } from './provider/openrouter.js';
 import { openaiRequestCaptureContext } from './requestCaptureContext.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
 import { TaggedThinkingParser } from './taggedThinkingParser.js';
@@ -1214,6 +1215,30 @@ export class ContentGenerationPipeline {
       // we don't push it there. See https://api-docs.deepseek.com/.
       if (isDeepSeekHostname(this.contentGeneratorConfig)) {
         typed['thinking'] = { type: 'disabled' };
+      }
+      // OpenRouter's thinking switch is the provider-level `reasoning`
+      // parameter (`reasoning: { enabled: false }`, see
+      // https://openrouter.ai/docs/features/reasoning-tokens). The shapes
+      // emitted above are ignored by the gateway, and the strip just above
+      // removes any `reasoning` object a provider hook injected — so
+      // thinking-capable models routed through OpenRouter keep thinking on.
+      // That breaks the AUTO-mode classifier's stage-1 side query (#9757):
+      // the 256-token budget is spent on reasoning, the forced
+      // respond_in_schema tool call never ships, and the classifier
+      // fail-closes. Must be emitted after the strip, which runs later
+      // than the provider buildRequest hook.
+      //
+      // Provider-level, not model-family-gated: unlike `enable_thinking`
+      // (a qwen-family wire field that leaks upstream on non-qwen
+      // routings), `reasoning` is an OpenRouter API parameter the gateway
+      // applies to whatever model supports it. `thinkingMandatory` models
+      // stay exempt: a disable shape they reject would be a guaranteed
+      // request failure.
+      if (
+        !thinkingMandatory &&
+        isOpenRouterHostname(this.contentGeneratorConfig)
+      ) {
+        typed['reasoning'] = { enabled: false };
       }
     }
 

--- a/packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/openrouter.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { isOpenRouterHostname } from './openrouter.js';
+
+describe('isOpenRouterHostname', () => {
+  it.each([
+    ['https://openrouter.ai/api/v1', true],
+    ['https://eu.openrouter.ai/api/v1', true],
+    ['https://openrouter.ai.evil.com/v1', false],
+    ['https://evilopenrouter.ai/v1', false],
+    ['not a url', false],
+    ['', false],
+  ])('classifies %s as %s', (baseUrl, expected) => {
+    expect(isOpenRouterHostname({ baseUrl } as ContentGeneratorConfig)).toBe(
+      expected,
+    );
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/openrouter.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/openrouter.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+
+/**
+ * Hostname-only check used to decide whether a thinking-disable request
+ * should carry OpenRouter's provider-level `reasoning` parameter. Mirrors
+ * `isDeepSeekHostname`: hostname matching only — no model-name fallback.
+ * OpenRouter's `reasoning` parameter is a gateway-level extension of the
+ * chat-completions API; pushing it at strict OpenAI-compatible backends
+ * (self-hosted vLLM/SGLang, official OpenAI) could trip an unknown-key
+ * rejection, and those gateways have their own thinking switches anyway.
+ *
+ * Parses the baseUrl with `new URL(...)` and matches the hostname against
+ * `openrouter.ai` (and its subdomains) exactly — a naive substring check
+ * would false-positive on hostile hosts like
+ * `https://openrouter.ai.evil.com/v1`. Invalid URLs are treated as
+ * non-OpenRouter. The hostname shape mirrors `openRouterProvider.ownsModel`
+ * in `providers/presets/openrouter.ts`.
+ *
+ * Exposed as a free function so consumers (the pipeline post-processing
+ * hook, in particular) can run the check without a provider class —
+ * OpenRouter requests flow through `DefaultOpenAICompatibleProvider`.
+ */
+export function isOpenRouterHostname(
+  contentGeneratorConfig: ContentGeneratorConfig,
+): boolean {
+  const baseUrl = contentGeneratorConfig.baseUrl ?? '';
+  if (!baseUrl) return false;
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return hostname === 'openrouter.ai' || hostname.endsWith('.openrouter.ai');
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What this PR does

When reasoning is disabled (`includeThoughts: false` on a request, e.g. the AUTO-mode classifier's stage-1 side query, or config-level `reasoning: false`) and the endpoint is OpenRouter (`openrouter.ai` or a subdomain), the OpenAI-compatible pipeline now emits OpenRouter's native thinking-disable parameter `reasoning: { enabled: false }` on the wire request. The detection is a hostname-only helper (`isOpenRouterHostname`) mirroring the existing `isDeepSeekHostname` precedent, and the emission sits in the `reasoningDisabled` branch after the unconditional `reasoning` / `reasoning_effort` strip, because the provider `buildRequest` hook runs before that strip and anything emitted there would be removed again.

## Why it's needed

Fixes the failure chain in #9757: the classifier's stage 1 is a structured side query that forces a `respond_in_schema` tool call (`tool_choice: 'required'`, forced-tool mapping from #6929) with a 256-token budget and `thinkingConfig: { includeThoughts: false }`. On OpenRouter the thinking-disable only rendered into shapes the gateway ignores — `chat_template_kwargs.enable_thinking` (the vLLM/SGLang shape) for qwen-family models — and the pipeline then stripped the `reasoning` object, which is exactly OpenRouter's native thinking knob. Thinking stayed enabled, the model spent the whole 256-token budget on reasoning and never emitted the forced tool call, `generateJson` returned `{}`, schema validation failed, and the classifier fail-closed with `Classifier stage 1 unavailable`, forcing manual approval for every AUTO-mode action. This is a residual gap next to #6929 (which added the forced tool call + budget), not a duplicate: #6929 works wherever the thinking-disable actually lands, but OpenRouter was missing from the disable-rendering logic. It is also disjoint from #9590 (still open), which covers DeepSeek/GLM/Kimi thinking controls on the WebShell UI and does not touch the OpenRouter classifier path.

## Reviewer Test Plan

### How to verify

Detector-level reproduction and regression coverage live in `packages/core/src/core/openaiContentGenerator/pipeline.test.ts` (search `OpenRouter`): with `baseUrl: https://openrouter.ai/api/v1` and `thinkingConfig: { includeThoughts: false }`, the captured `chat.completions.create` body is asserted to carry `reasoning: { enabled: false }`. On unpatched main these tests fail with `reasoning: undefined`; with this PR they pass. Negative guards: no `reasoning` field leaks to the official OpenAI endpoint, to non-OpenRouter OpenAI-compatible gateways (vLLM/SGLang), or to lookalike hostnames (`openrouter.ai.evil.com`), and `thinkingMandatory` models on OpenRouter stay exempt. Existing behavior preserved: DashScope tiered (`reasoning_effort: 'none'`) and boolean (`enable_thinking: false`) branches, vLLM/SGLang `chat_template_kwargs`, and DeepSeek hostname `thinking: { type: 'disabled' }` are untouched and covered by their existing tests. Run: `cd packages/core && npx vitest run src/core/openaiContentGenerator/pipeline.test.ts` — 167 passed locally, plus `npm run typecheck` (clean).

### Evidence (Before & After)

N/A — non-user-visible wire-shape fix; evidence is the unit-test red/green pair described above (3 emission tests failed before the fix, all 167 pass after).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest` + `tsc --noEmit` in `packages/core`); no live OpenRouter account was used.

## Risk & Scope

- Main risk or tradeoff: `reasoning: { enabled: false }` is now sent on every reasoning-disabled request to OpenRouter hostnames regardless of model family. That is intentional — `reasoning` is an OpenRouter provider-level parameter the gateway routes to whatever model supports it (unlike `enable_thinking`, a qwen-specific wire field that the existing code deliberately family-gates to avoid leaking upstream) — but it means OpenRouter-side handling of the parameter is the only validation so far.
- Not validated / out of scope: live end-to-end capture against OpenRouter (no API key in the test environment); qwen-family models on OpenRouter still also receive the harmless `chat_template_kwargs.enable_thinking=false` field the gateway ignores — left in place to keep the diff minimal; no changes to classifier budgets or stage-2 behavior.
- Breaking changes / migration notes: none — additive wire field gated on hostname, only when reasoning is already being disabled.

## Linked Issues

Fixes #9757

Related: #6929 (forced `respond_in_schema` tool call + 256-token budget for side queries — this PR fixes the OpenRouter gap its failure comment describes), #6791 (same failure family), #9590 (open; DeepSeek/GLM/Kimi WebShell thinking controls, disjoint scope)

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当推理被禁用时（请求级 `includeThoughts: false`，例如 AUTO 模式分类器的 stage-1 side query；或配置级 `reasoning: false`），如果端点是 OpenRouter（`openrouter.ai`或其子域名），OpenAI 兼容管道现在会在出站请求上带上 OpenRouter 原生的思考关闭参数 `reasoning: { enabled: false }`。检测是一个仅看 hostname 的辅助函数（`isOpenRouterHostname`），对齐现有 `isDeepSeekHostname` 先例；补发逻辑放在 `reasoningDisabled` 分支里对 `reasoning` / `reasoning_effort` 的无条件剥离之后，因为 provider 的 `buildRequest` hook 先于剥离运行，在那里发出的字段会被再次删掉。

## 为什么需要

修复 #9757 的失败链：分类器 stage 1 是一个结构化 side query，强制 `respond_in_schema` 工具调用（`tool_choice: 'required'`，来自 #6929 的强制工具映射），预算 256 token，并带 `thinkingConfig: { includeThoughts: false }`。在 OpenRouter 上，思考关闭只渲染成网关忽略的格式——qwen family 模型拿到 `chat_template_kwargs.enable_thinking`（vLLM/SGLang 形状）——随后管道又把 `reasoning` 对象剥掉，而这恰恰是 OpenRouter 原生的思考开关。于是思考仍然开启，模型把 256 token 预算全花在推理上，永远发不出强制工具调用，`generateJson` 返回 `{}`，schema 校验失败，分类器 fail-closed 报 `Classifier stage 1 unavailable`，AUTO 模式每个操作都转手动审批。这是 #6929 之后的残留缺口而非重复：#6929 在思考关闭能真正生效的端点上是有效的，只是关闭逻辑的渲染里漏了 OpenRouter。与仍 open 的 #9590 也不重叠——那个 PR 覆盖 WebShell UI 上 DeepSeek/GLM/Kimi 的思考控件，不涉及 OpenRouter 分类器路径。

## 审阅者测试计划

### 如何验证

检测器级复现与回归保护在 `packages/core/src/core/openaiContentGenerator/pipeline.test.ts`（搜 `OpenRouter`）：`baseUrl: https://openrouter.ai/api/v1` + `thinkingConfig: { includeThoughts: false }` 时，断言捕获到的 `chat.completions.create` 请求体带 `reasoning: { enabled: false }`。在未修复的 main 上这些测试以 `reasoning: undefined` 失败；本 PR 下通过。负向保护：官方 OpenAI 端点、非 OpenRouter 的 OpenAI 兼容网关（vLLM/SGLang）、仿冒域名（`openrouter.ai.evil.com`）都不会多收 `reasoning` 字段；OpenRouter 上的 `thinkingMandatory` 模型保持豁免。既有行为保留：DashScope 分层（`reasoning_effort: 'none'`）与布尔（`enable_thinking: false`）分支、vLLM/SGLang 的 `chat_template_kwargs`、DeepSeek hostname 的 `thinking: { type: 'disabled' }` 均未改动且由既有测试覆盖。运行：`cd packages/core && npx vitest run src/core/openaiContentGenerator/pipeline.test.ts`——本地 167 个全部通过，另有 `npm run typecheck` 无错误。

### 前后证据

N/A——非用户可见的线上请求形状修复；证据是上述单元测试的修复前红/修复后绿（3 个补发断言修复前失败，修复后 167 个全过）。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### 环境（可选）

仅单元测试（`packages/core` 里的 `vitest` + `tsc --noEmit`）；未使用真实 OpenRouter 账号。

## 风险与范围

- 主要风险或取舍：现在所有发往 OpenRouter 域名的禁用推理请求都会带 `reasoning: { enabled: false }`，不限模型族。这是有意为之——`reasoning` 是 OpenRouter 的 provider 级参数，网关会把它路由给支持的模型（不同于 `enable_thinking`，那是 qwen 专属线上字段，现有代码刻意按模型族门控以防泄漏到上游）——但这也意味着目前对 `reasoning` 参数的验证只到 OpenRouter 文档层面。
- 未验证 / 超出范围：对 OpenRouter 的真实端到端抓包（测试环境无 API key）；OpenRouter 上的 qwen family 模型仍会同时带上网关忽略的 `chat_template_kwargs.enable_thinking=false` 字段，为保持最小 diff 保留；分类器预算与 stage-2 行为均未改动。
- 破坏性变更 / 迁移说明：无——仅在 hostname 命中且推理本就要关闭时附加一个线上字段。

## 关联 Issue

Fixes #9757

相关：#6929（side query 的强制 `respond_in_schema` 工具调用 + 256 token 预算——本 PR 修复的正是其失败评论描述的 OpenRouter 缺口）、#6791（同族问题）、#9590（open；DeepSeek/GLM/Kimi WebShell 思考控件，范围不重叠）

</details>
