### PR TITLE
docs(review): name the axis when two of them both call it "rank 3"

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -7557,7 +7557,8 @@ describe("composeReview — the composed body fits GitHub's limit", () => {
     // `contextUnavailableClause` is `keep: 1` so the rung-3 cut spends
     // blockers before the diff-only trust warning; no truncation fixture
     // carried the clause, so deleting the tag shipped green — the untagged
-    // clause sorted to rank 3 and the cut spent the warning first.
+    // clause sorted to `keep` 3 (the cut's axis, not a `trim` rank) and the
+    // cut spent the warning first.
     const r = composeReview(
       base({
         criticalsInline: 1,
@@ -9384,9 +9385,9 @@ describe('convergence diagnosis reaches the POSTED body', () => {
     // against a 56,830-character budget. Shed early it could pay for at
     // most 4% of an overflow, so any overflow bigger than itself spent it
     // AND went on to spend the disclosures — and the rounds this fires on
-    // are the high-volume ones where that is the normal case. It is rank 3
-    // now: the last rank to go, because it is the cheapest to keep and the
-    // only one whose reader is the PR author alone.
+    // are the high-volume ones where that is the normal case. It is trim
+    // rank 3 now: the last rank to go, because it is the cheapest to keep
+    // and the only one whose reader is the PR author alone.
     //
     // The blocker is sized to land in the window where the ladder sheds
     // rank 2 and stops. To retune after a body-copy change: raise it until
@@ -9424,9 +9425,9 @@ describe('convergence diagnosis reaches the POSTED body', () => {
     // notice say so instead of the paragraph vanishing silently.
     //
     // Sized one rung past the test above: the ladder sheds rank 2, still
-    // does not fit, sheds rank 3, and stops before the hard cut. To retune:
-    // raise it until `Convergence:` disappears, and stop before `TRUNCATED`
-    // appears.
+    // does not fit, sheds trim rank 3, and stops before the hard cut. To
+    // retune: raise it until `Convergence:` disappears, and stop before
+    // `TRUNCATED` appears.
     sideFile({
       round: 4,
       posted: 9,

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -858,7 +858,7 @@ export interface ComposeReviewResult {
    * not-reviewed disclosures (the model's own inputs), a diagnosis derived
    * from the side file has no other copy anywhere. Ranking it last does not
    * retire this copy — it makes it the one that matters, because the rounds
-   * that reach rank 3 are the rounds that shed everything.
+   * that reach trim rank 3 are the rounds that shed everything.
    */
   convergence?: { en: string; zh: string };
   /**
@@ -3367,7 +3367,7 @@ function composeReviewBody(
    * last-resort path drops ranks AND cuts, and a stderr record naming only
    * the cut leaves the kinds it dropped disclosed nowhere but the body.
    * Rank 1 has a second durable copy (each deferral is a `D<round>-<n>`
-   * entry in the findings artifact) and rank 3 has one too (the composed
+   * entry in the findings artifact) and trim rank 3 has one too (the composed
    * result carries the paragraph, and the command prints it as
    * `CONVERGENCE:`); a trimmed disclosure section survives nowhere but the
    * terminal summary, so ask for it there rather than pointing at an
@@ -3823,8 +3823,12 @@ function composeReviewBody(
     cannotTell.length === 0
       ? []
       : [
-          // Deliberately untagged (rank 3, spent first by the last-resort
-          // cut). These entries are open blockers the review could not
+          // Deliberately untagged, so `keep` defaults to 3 and the
+          // last-resort cut spends it first. That 3 is the CUT's axis, not a
+          // `trim` rank — the two share the number and mean opposite things:
+          // `trim: 3` is the LAST rank the ladder sheds, while `keep: 3` is
+          // the FIRST thing the cut below the ladder spends.
+          // These entries are open blockers the review could not
           // clear — and every one of them was DELIVERED to the author in
           // the round that raised it, where this round's body Criticals are
           // the only copy that exists. So when the cut has to choose, it
@@ -5263,8 +5267,9 @@ export const composeReviewCommand: CommandModule = {
     // (findings artifact) or the not-reviewed disclosures (the model's own
     // inputs) it has no other copy anywhere — so the notice's "read them in
     // the terminal report" was a false record until this line existed. Last
-    // does not mean safe: a body that reaches rank 3 has already shed every
-    // other rank, which is exactly when this line is the only copy left.
+    // does not mean safe: a body that reaches trim rank 3 has already shed
+    // every other rank, which is exactly when this line is the only copy
+    // left.
     if (result.convergence) {
       writeStderrLine(`CONVERGENCE: ${result.convergence.en}`);
     }


### PR DESCRIPTION
## What this PR does

Names the axis wherever a comment says "rank 3", because two different orderings in `compose-review.ts` now use that number for opposite things.

`trim: 3` is the LAST rank the body-budget ladder sheds — that landed in #9715. `keep: 3` is the default on the last-resort cut's axis, and it is the FIRST thing that cut spends. Both were already written as a bare "rank 3", so the cannot-tell block's `// Deliberately untagged (rank 3, spent first by the last-resort cut)` now reads directly against a comment three hundred lines above it saying rank 3 goes last. Both sentences are true; they contradict each other only because the number is shared.

Every mention of the number on either axis now says which axis it is on. The cannot-tell block states the collision outright rather than only qualifying itself. The one `keep` comment that already disambiguated itself — "No `trim` rank rides here" — is untouched.

## Why it's needed

This ladder is maintained through its comments: the retuning instructions for the sized overflow tests live in them, and #9715's own review found five separate comments still asserting the pre-#9715 order, two of which had been stale since earlier rank additions. A number that means "shed last" in one paragraph and "spent first" in another is the next instance of exactly that, already sitting in the tree.

The item was raised by the review on #9715 and deferred there as non-blocking; #9715 merged before this commit was pushed, so it is carried here rather than lost.

## Reviewer Test Plan

### How to verify

Comments only — the diff contains no executable line. `git show --unified=0 -- packages/cli/src/commands/review/` on this commit shows every changed line beginning with `//` or a JSDoc `*`.

`npx vitest run packages/cli/src/commands/review` — 99 files, 4,650 passing on this base. That count is this directory only, which is the whole of what a comments-only change can reach; a full-repo run reports ~23,300 and is the same signal at a wider scope.

To confirm the collision is gone: `grep -rn "rank 3\|keep: 3\|keep ?? 3" packages/cli/src/commands/review/*.ts` — every hit now names `trim` or `keep`, or is the `keep ?? 3` expression itself.

### Evidence (Before & After)

N/A — comments only, no user-visible or runtime surface.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only. Note for the reviewer: `tsc --noEmit -p packages/cli` reports pre-existing errors in `packages/cli/src/acp-integration/**` on this base — verified identical on pristine `origin/main`, and caused by stale build artifacts resolving `@qwen-code/acp-bridge/bridgeTypes` to an old `.d.ts` (the symbols do exist in `packages/acp-bridge/src/bridgeTypes.ts`). Unrelated to this change, which cannot introduce a type error.

## Risk & Scope

- Main risk or tradeoff: none — no executable line changes.
- Not validated / out of scope: the two axes still share the number. Renaming one of them (or giving `keep` a named constant) would remove the collision at its root rather than annotating it; that is a larger change than the deferred item asked for.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #9715. Refs #9278.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

凡是注释里写「rank 3」的地方都标明它属于哪条轴，因为 `compose-review.ts` 里现在有两套不同的排序都用这个数字，且含义相反。

`trim: 3` 是正文预算阶梯**最后**丢的一档——这是 #9715 落地的。`keep: 3` 是兜底截断那条轴上的默认值，而它是那次截断**最先**花掉的东西。两者原本都写成裸的「rank 3」，于是 cannot-tell 块的 `// Deliberately untagged (rank 3, spent first by the last-resort cut)` 与其上三百行"rank 3 最后才丢"的注释直接对撞。两句都为真，矛盾只源于共用了一个数字。

现在两条轴上出现的这个数字，每一处都标明所属。cannot-tell 块直接把这次撞名写出来，而不只是给自己加限定。已经自行消歧的那处 `keep` 注释（"No `trim` rank rides here"）未动。

## 为什么需要

这个阶梯是靠注释维护的：定容溢出测试的重新调参说明就写在注释里，而 #9715 自身的评审发现了五处仍在断言 #9715 之前顺序的注释，其中两处从更早的档位新增起就已过时。一个数字在一段里意为"最后才丢"、在另一段里意为"最先花掉"，就是同一问题的下一个实例，且已经躺在代码树里。

该条由 #9715 的评审提出并在那里作为非阻断项延后；#9715 在本提交推送前就已合入，所以改由本 PR 承载，而不是让它丢失。

## 复核方式

纯注释——diff 中没有任何可执行行。本提交上执行 `git show --unified=0 -- packages/cli/src/commands/review/` 可见每一处改动行都以 `//` 或 JSDoc 的 `*` 开头。

`npx vitest run packages/cli/src/commands/review`——本基线上 99 个文件、4,650 条通过。该计数仅限本目录（纯注释改动能触及的全部范围）；全仓运行约 2.33 万条，是同一个信号的更大口径。

确认撞名已消除：`grep -rn "rank 3\|keep: 3\|keep ?? 3" packages/cli/src/commands/review/*.ts`——每一处命中要么点明 `trim` 或 `keep`，要么就是 `keep ?? 3` 表达式本身。

### 证据（前后对比）

N/A——纯注释，无用户可见面或运行时表面。

### 环境说明

仅单元测试。提请评审注意：本基线上 `tsc --noEmit -p packages/cli` 会报 `packages/cli/src/acp-integration/**` 的既有错误——已在纯净的 `origin/main` 上验证完全相同，成因是陈旧构建产物让 `@qwen-code/acp-bridge/bridgeTypes` 解析到了旧的 `.d.ts`（这些符号在 `packages/acp-bridge/src/bridgeTypes.ts` 中确实存在）。与本改动无关，纯注释改动也不可能引入类型错误。

## 风险与范围

- 主要风险/取舍：无——没有任何可执行行发生变化。
- 未验证 / 范围外：两条轴仍然共用这个数字。把其中一条改名（或给 `keep` 一个具名常量）才是从根上消除撞名，但那超出了这条延后项的请求范围。
- 破坏性变更：无。

## 关联 issue

#9715 的跟进。Refs #9278。

</details>

