### PR TITLE
fix(web-shell): preview document-classified artifacts

### DIFF
--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.test.tsx
@@ -2538,7 +2538,67 @@ describe('ArtifactPanel image preview tabs', () => {
   });
 });
 
-describe('ArtifactPanel download-only workspace artifacts', () => {
+describe('ArtifactPanel workspace artifact previews', () => {
+  it.each([
+    {
+      label: 'Markdown',
+      mimeType: 'text/markdown; charset=utf-8',
+      content: '# Charset Markdown',
+    },
+    {
+      label: 'HTML',
+      mimeType: 'text/html; charset=utf-8',
+      content: '<h1>Charset HTML</h1>',
+    },
+  ])('previews document-classified $label MIME types', async (testCase) => {
+    mockWorkspaceActions.stat.mockResolvedValue({
+      type: 'file',
+      sizeBytes: testCase.content.length,
+      modifiedMs: 1,
+    });
+    mockWorkspaceActions.readWorkspaceFile.mockResolvedValue({
+      content: testCase.content,
+      truncated: false,
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+
+    act(() =>
+      root.render(
+        artifactPanel({
+          id: 'review-artifact',
+          kind: 'document',
+          storage: 'workspace',
+          source: 'tool',
+          status: 'available',
+          title: `${testCase.label} preview`,
+          workspacePath: 'reports/preview',
+          mimeType: testCase.mimeType,
+          retention: 'ephemeral',
+          clientRetained: false,
+          createdAt: '2026-08-23T00:00:00.000Z',
+          updatedAt: '2026-08-23T00:00:00.000Z',
+        }),
+      ),
+    );
+    await flush();
+
+    expect(mockWorkspaceActions.readWorkspaceFile).toHaveBeenCalledWith(
+      'reports/preview',
+    );
+    if (testCase.label === 'Markdown') {
+      expect(container.querySelector('h1')?.textContent).toBe(
+        'Charset Markdown',
+      );
+    } else {
+      expect(
+        container.querySelector('iframe')?.getAttribute('srcdoc'),
+      ).toContain(testCase.content);
+    }
+  });
+
   it('renders a document artifact as download-only and does not preview it', async () => {
     mockWorkspaceActions.stat.mockResolvedValue({
       type: 'file',

--- a/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
+++ b/packages/web-shell/client/components/artifacts/ArtifactPanel.tsx
@@ -68,6 +68,7 @@ import {
   getImageMimeTypeFromPath,
   getReviewDownloadMimeType,
   isDownloadOnlyWorkspaceArtifact,
+  normalizeArtifactMimeType,
   normalizePath,
   readWorkspaceFileAsBlob,
   withArtifactPreviewCsp,
@@ -2556,7 +2557,7 @@ function CodeReviewWorkspaceRequired() {
 
 function isHtmlArtifact(artifact: DaemonSessionArtifact) {
   const path = artifact.workspacePath?.toLowerCase() ?? '';
-  const mimeType = artifact.mimeType?.toLowerCase() ?? '';
+  const mimeType = normalizeArtifactMimeType(artifact.mimeType);
   return (
     artifact.kind === 'html' ||
     path.endsWith('.html') ||
@@ -2567,10 +2568,11 @@ function isHtmlArtifact(artifact: DaemonSessionArtifact) {
 
 function isMarkdownArtifact(artifact: DaemonSessionArtifact) {
   const path = artifact.workspacePath?.toLowerCase() ?? '';
+  const mimeType = normalizeArtifactMimeType(artifact.mimeType);
   return (
     path.endsWith('.md') ||
     path.endsWith('.markdown') ||
-    artifact.mimeType?.toLowerCase() === 'text/markdown'
+    mimeType === 'text/markdown'
   );
 }
 

--- a/packages/web-shell/client/components/artifacts/artifactUtils.test.ts
+++ b/packages/web-shell/client/components/artifacts/artifactUtils.test.ts
@@ -52,6 +52,57 @@ describe('artifactUtils', () => {
     ).toBe(false);
   });
 
+  it.each([
+    { workspacePath: 'notes.md' },
+    { workspacePath: 'notes.markdown' },
+    { workspacePath: 'notes', mimeType: 'text/markdown' },
+    { workspacePath: 'notes', mimeType: 'text/markdown; charset=utf-8' },
+    { workspacePath: 'report.html' },
+    { workspacePath: 'report.htm' },
+    { workspacePath: 'report', mimeType: 'text/html' },
+    { workspacePath: 'report', mimeType: 'text/html; charset=utf-8' },
+  ])('previews document-classified text artifacts', (artifact) => {
+    expect(
+      isDownloadOnlyWorkspaceArtifact({ kind: 'document', ...artifact }),
+    ).toBe(false);
+  });
+
+  it.each([
+    { workspacePath: 'photo.png' },
+    { workspacePath: 'photo', mimeType: 'image/png' },
+  ])('previews document-classified raster image artifacts', (artifact) => {
+    expect(
+      isDownloadOnlyWorkspaceArtifact({ kind: 'document', ...artifact }),
+    ).toBe(false);
+  });
+
+  it.each([
+    ['document', 'graphic.svg', 'image/svg+xml'],
+    ['image', 'graphic.svg', 'image/svg+xml'],
+    ['file', 'graphic.svg', 'image/svg+xml'],
+    ['image', 'graphic.svg', 'image/png'],
+    ['image', 'graphic.svg', 'text/html'],
+    ['file', 'graphic', 'image/svg+xml'],
+  ])('keeps SVG artifacts download-only', (kind, workspacePath, mimeType) => {
+    expect(
+      isDownloadOnlyWorkspaceArtifact({ kind, workspacePath, mimeType }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['report.docx', 'text/html'],
+    ['report.xlsx', 'image/png'],
+    ['report.pdf', 'text/markdown'],
+    ['clip.mp4', 'image/png'],
+  ])(
+    'does not let previewable MIME types override download-only paths',
+    (workspacePath, mimeType) => {
+      expect(isDownloadOnlyWorkspaceArtifact({ workspacePath, mimeType })).toBe(
+        true,
+      );
+    },
+  );
+
   it('rejects directory stats before reading bytes', async () => {
     const readFileBytes = vi.fn();
     const statFile = vi.fn().mockResolvedValue({

--- a/packages/web-shell/client/components/artifacts/artifactUtils.ts
+++ b/packages/web-shell/client/components/artifacts/artifactUtils.ts
@@ -84,20 +84,38 @@ export function isOfficeDocumentPath(workspacePath?: string): boolean {
 export function isDownloadOnlyWorkspaceArtifact(artifact: {
   kind?: string;
   workspacePath?: string;
+  mimeType?: string;
 }): boolean {
-  if (artifact.kind === 'image') {
-    return false;
-  }
+  const extension = pathExtension(artifact.workspacePath);
+  const mimeType = normalizeArtifactMimeType(artifact.mimeType);
   if (
-    artifact.kind === 'document' ||
-    artifact.kind === 'pdf' ||
-    artifact.kind === 'video' ||
-    artifact.kind === 'audio' ||
-    isOfficeDocumentPath(artifact.workspacePath)
+    extension === '.svg' ||
+    mimeType === 'image/svg+xml' ||
+    DOWNLOAD_ONLY_EXTENSIONS.has(extension)
   ) {
     return true;
   }
-  return DOWNLOAD_ONLY_EXTENSIONS.has(pathExtension(artifact.workspacePath));
+  if (
+    getArtifactImageMimeType(artifact) ||
+    extension === '.md' ||
+    extension === '.markdown' ||
+    extension === '.html' ||
+    extension === '.htm' ||
+    mimeType === 'text/markdown' ||
+    mimeType === 'text/html'
+  ) {
+    return false;
+  }
+  if (
+    artifact.kind === 'image' ||
+    artifact.kind === 'document' ||
+    artifact.kind === 'pdf' ||
+    artifact.kind === 'video' ||
+    artifact.kind === 'audio'
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function pathExtension(workspacePath?: string): string {
@@ -134,11 +152,15 @@ const IMAGE_MIME_TYPES: Readonly<Record<string, string>> = {
 const MAX_WORKSPACE_FILE_BLOB_BYTES = 100 * 1024 * 1024;
 const WORKSPACE_FILE_BLOB_CHUNK_BYTES = 100 * 1024;
 
+export function normalizeArtifactMimeType(mimeType?: string): string {
+  return mimeType?.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+}
+
 export function getArtifactImageMimeType(
-  artifact: DaemonSessionArtifact,
+  artifact: Pick<DaemonSessionArtifact, 'mimeType' | 'workspacePath'>,
 ): string | undefined {
-  const mimeType = artifact.mimeType?.split(';', 1)[0]?.trim().toLowerCase();
-  if (mimeType?.startsWith('image/')) {
+  const mimeType = normalizeArtifactMimeType(artifact.mimeType);
+  if (mimeType.startsWith('image/')) {
     if (mimeType === 'image/jpg') return 'image/jpeg';
     return Object.values(IMAGE_MIME_TYPES).includes(mimeType)
       ? mimeType


### PR DESCRIPTION
## What this PR does

Web Shell now recognizes Markdown, HTML, and safe raster images from their workspace path or normalized MIME type before applying a generic `document` classification. MIME parameters such as `charset=utf-8` are normalized consistently through both download routing and the final renderer selection. SVG remains download-only, and known Office, PDF, video, and audio extensions take precedence over conflicting previewable MIME metadata.

## Why it's needed

Generated artifacts can be recorded with the broad `document` kind even when their actual file is Markdown, HTML, or a raster image. The previous kind-first routing replaced those supported previews with a download-only card. This restores the existing format-specific previews while keeping active SVG content and binary document or media formats on the safer download path.

## Reviewer Test Plan

### How to verify

Open workspace artifacts reported as `document` for `.md`, `.markdown`, `.html`, `.htm`, and PNG files and confirm they render as Markdown, sandboxed HTML, and an image respectively. Repeat with extensionless Markdown, HTML, and PNG artifacts whose MIME types include parameters such as `charset=utf-8`, and confirm they use the same previews. Open SVG, DOCX, XLSX, PDF, and MP4 artifacts, including cases where their MIME metadata claims a previewable text or image type, and confirm they remain download-only without reading the workspace file into a text or image renderer.

### Evidence (Before & After)

Before: supported Markdown, HTML, and raster files reported as `document` displayed only the download detail. SVG reported as `image` could fall through to a source preview, and a previewable conflicting MIME type could override a download-only extension.

After: supported text and raster formats use their existing previews; SVG and known binary document/media extensions fail closed to the download detail. The new behavior tests fail against the previous `main` implementation and pass with this change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22; Web Shell Vitest tests, production build, and TypeScript typecheck.

## Risk & Scope

- Main risk or tradeoff: Format-routing precedence changes for workspace artifacts whose broad kind conflicts with their path or MIME metadata; this is covered with positive preview cases and fail-closed conflict cases.
- Not validated / out of scope: Native previews for PDF, Word, Excel, PowerPoint, audio, video, and SVG rendering remain out of scope. Windows and Linux were not tested locally.
- Breaking changes / migration notes: No API, schema, configuration, persistence, or dependency migration is required. After upgrading, existing Markdown, HTML, and safe raster workspace artifacts previously shown as download-only may open directly in their existing preview UI. SVG, Office documents, PDF, audio, and video continue to require download. Integrations that intentionally relied on a broad `document` kind to force download-only behavior should instead use a download-only file extension; supported text and raster formats now follow their actual path or normalized MIME type.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Web Shell 现在会先根据 workspace 路径或规范化后的 MIME 类型识别 Markdown、HTML 和安全栅格图片，再处理宽泛的 `document` 分类。下载路由与最终渲染器选择都会统一规范化 `charset=utf-8` 等 MIME 参数。SVG 仍然仅下载，已知的 Office、PDF、视频和音频扩展名优先于冲突的可预览 MIME 元数据。

## 为什么需要

生成的 artifact 即使实际是 Markdown、HTML 或栅格图片，也可能被记录为宽泛的 `document` kind。此前按 kind 优先的路由会用仅下载卡片替换这些已支持的预览。本次修改恢复已有的格式专用预览，同时让包含主动内容的 SVG 以及二进制文档和媒体格式继续走更安全的下载路径。

## Reviewer Test Plan

### 如何验证

打开被报告为 `document` 的 `.md`、`.markdown`、`.html`、`.htm` 和 PNG workspace artifact，确认它们分别渲染为 Markdown、沙箱 HTML 和图片。再使用无扩展名且 MIME 带有 `charset=utf-8` 等参数的 Markdown、HTML 和 PNG artifact，确认使用相同预览。打开 SVG、DOCX、XLSX、PDF 和 MP4 artifact，包括 MIME 元数据伪装成可预览文本或图片的情况，确认它们保持仅下载，并且不会把 workspace 文件读入文本或图片渲染器。

### 证据（修改前后）

修改前：被报告为 `document` 的 Markdown、HTML 和栅格文件只显示下载详情。被报告为 `image` 的 SVG 可能落入源码预览，可预览的冲突 MIME 还可能覆盖仅下载扩展名。

修改后：支持的文本和栅格格式使用已有预览；SVG 与已知二进制文档和媒体扩展名会安全地进入下载详情。新增行为测试在旧 `main` 实现上失败，在本次修改后通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22；Web Shell Vitest 测试、生产构建和 TypeScript 类型检查。

## 风险与范围

- 主要风险或权衡：当 workspace artifact 的宽泛 kind 与路径或 MIME 元数据冲突时，格式路由优先级会发生变化；正向预览用例和安全失败的冲突用例均已覆盖。
- 未验证或不在范围内：PDF、Word、Excel、PowerPoint、音频、视频的原生预览以及 SVG 渲染仍不在本 PR 范围内。Windows 和 Linux 未进行本地测试。
- 破坏性变化或迁移说明：无需迁移 API、schema、配置、持久化数据或依赖。升级后，原先只显示下载的 Markdown、HTML 和安全栅格 workspace artifact 可能会直接进入已有预览 UI。SVG、Office 文档、PDF、音频和视频仍需下载。若集成方此前刻意利用宽泛的 `document` kind 强制仅下载，应改用下载专用扩展名；受支持的文本和栅格格式现在会按照实际路径或规范化 MIME 类型处理。

## 关联 Issue

无

</details>
