### PR TITLE
fix(daemon): keep restored ask_user_question valid after load

### DIFF
--- a/docs/design/daemon-ask-user-question-restore.md
+++ b/docs/design/daemon-ask-user-question-restore.md
@@ -62,16 +62,23 @@ session. No settings.json key and no capability tag in v1.
 
 ## Runtime
 
-1. `startChat` skips orphan repair **only** for the eligible AUQ call ids;
-   the per-send inline repair pass does the same, so a prompt that beats
-   the restore prompt does not close the preserved call with a synthetic
-   failure.
+1. `startChat` skips orphan repair **only** for the eligible AUQ call ids,
+   and only when this load/resume will actually re-hang the question. A
+   suppressed restore (no attached client, fork) repairs Gemini history in
+   lockstep with replay finalization. The per-send inline repair pass always
+   closes a dangling call: an ordinary prompt that beats the restore prompt
+   must not send `model[functionCall] → user[text]` (Anthropic-compatible
+   providers reject that shape). Restore itself sends the real
+   functionResponse, so that pass is a no-op on the restore path.
 2. Transcript replay `finalize()` skips those call ids so the UI stays
-   in-progress. Skip and re-hang stay in lockstep: when the daemon already
-   knows it will decline (no attached client, fork restore), the
+   in-progress. Skip ids come from live chat when it is initialized, otherwise
+   from the transcript tail (cold bulk `historyReplay: 'response'` runs
+   before `startChat`). Skip and re-hang stay in lockstep: when the daemon
+   already knows it will decline (no attached client, fork restore), the
    child-bound request carries
    `qwen.daemon.suppressRestoreAskUserQuestion` and the child neither hints
-   nor skips — the replay finalizes the question as failed.
+   nor skips — the replay finalizes the question as failed. Read-only
+   `qwen/session/loadUpdates` always finalizes; it never re-hangs.
 3. Child load/resume `_meta` includes `qwen.daemon.restoreAskUserQuestion`
    when the argv switch is on and the session is eligible. The default-off
    path never calls the restore-only Session helper.
@@ -82,10 +89,14 @@ session. No settings.json key and no capability tag in v1.
    and `goalTurnActive` are all clear); admission failures are logged and
    swallowed — restore is a best-effort side effect of a successful load.
 5. `Session.prompt()` rebuilds the tool, `requestPermission`, then Submit
-   writes the real function response and continues the model. Cancel
-   persists a decline (live decline handling). A **timeout** on a restored
-   question persists nothing: the call stays dangling in the transcript so
-   a later load can re-hang it again.
+   writes the real function response and continues the model. Restore
+   continuations skip file-history snapshots (they are not user turns).
+   Pending worktree / recovered-agent notices are attached to the
+   post-answer message and cleared only after that message lands. Cancel
+   persists a decline (live decline handling). **Unattended** termination of
+   a restored batch (`timeout`, `session_closed`, abort) persists nothing
+   for the whole batch: the calls stay dangling in the transcript so a
+   later load can re-hang them again.
 
 `requestId` is not persisted across restarts.
 

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -847,7 +847,7 @@ export const DAEMON_RESTORE_ASK_USER_QUESTION_META_KEY =
  * / `session_closed`). The ACP wire frame itself only carries
  * `{outcome:'cancelled'}`; the child uses this to avoid persisting a
  * fabricated "canceled by the user" tool result when an unattended restore
- * prompt's permission wait simply timed out.
+ * prompt's permission wait timed out or the session closed.
  */
 export const DAEMON_PERMISSION_CANCEL_REASON_META_KEY =
   'qwen.daemon.permissionCancelReason';

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -244,6 +244,14 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
   SessionIdCaseConflictError: (
     await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
   ).SessionIdCaseConflictError,
+  // The real helpers: `history-replay-page` is not mocked and calls them to
+  // compute the restore skip set when a replay is not suppress-driven.
+  lastHistoryContentFromRecords: (
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
+  ).lastHistoryContentFromRecords,
+  restorableAskUserQuestionCallIds: (
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
+  ).restorableAskUserQuestionCallIds,
   normalizeEventPayload: vi.fn((payload: unknown) =>
     typeof payload === 'object' &&
     payload !== null &&
@@ -968,7 +976,10 @@ import {
   GoalInvalidTransitionError,
 } from '@qwen-code/qwen-code-core';
 import { ndJsonStream } from '@qwen-code/acp-bridge/ndJsonStream';
-import { SESSION_SOURCE_META_KEY } from '@qwen-code/acp-bridge';
+import {
+  DAEMON_SUPPRESS_RESTORE_ASK_USER_QUESTION_META_KEY,
+  SESSION_SOURCE_META_KEY,
+} from '@qwen-code/acp-bridge';
 import type {
   Agent,
   LoadSessionResponse,
@@ -11753,6 +11764,67 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('qwen/session/loadUpdates finalizes a dangling ask_user_question even with the restore flag on', async () => {
+    const settings = makeCoreSettings();
+    mockConfig = {
+      ...mockConfig,
+      getRestoreAskUserQuestion: vi.fn().mockReturnValue(true),
+    } as unknown as Config;
+    mockSessionServiceLoad({
+      conversation: {
+        messages: [
+          {
+            type: 'assistant',
+            message: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    id: 'call-auq',
+                    name: 'ask_user_question',
+                    args: {
+                      questions: [
+                        {
+                          question: 'Which approach?',
+                          header: 'Approach',
+                          options: [
+                            { label: 'Polling', description: 'Poll the API' },
+                            { label: 'Webhook', description: 'Use a webhook' },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        startTime: 'start',
+        lastUpdated: 'end',
+      },
+    });
+    mockHistoryReplay.mockReset();
+    mockHistoryReplay.mockResolvedValue(undefined);
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await agent.extMethod('qwen/session/loadUpdates', {
+      sessionId: VALID_SESSION_ID,
+    });
+
+    // The read-only dump never re-hangs the question, so the replayer must
+    // receive no skipFinalizeCallIds even though the restore flag is on and
+    // the transcript tail is a restorable ask_user_question.
+    expect(mockHistoryReplay).toHaveBeenCalled();
+    const replayOptions = mockHistoryReplay.mock.calls[0]?.[3] as
+      | Record<string, unknown>
+      | undefined;
+    expect(replayOptions?.['skipFinalizeCallIds']).toBeUndefined();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('qwen/status/session/transcript returns id-less replay events from transcript reader pages', async () => {
     const settings = makeCoreSettings();
     mockRunExitCleanup.mockResolvedValue(undefined);
@@ -16591,6 +16663,7 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
       assertCanStartTurn: vi.fn().mockResolvedValue(undefined),
       getSessionService: vi.fn(),
       consumeSessionRestoreProjection: vi.fn(),
+      suppressRestorableAskUserQuestionPreservation: vi.fn(),
       // load path reads back the persisted conversation here and feeds
       // it to `session.replayHistory`. resume path doesn't read this.
       getResumedSessionData: vi
@@ -16960,6 +17033,65 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
         ).toBe(true);
       } finally {
         mockArgv.restoreAskUserQuestion = undefined;
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    },
+  );
+
+  it.each(['load', 'resume'] as const)(
+    '%s suppresses AUQ preservation when the daemon declines the re-hang',
+    async (action) => {
+      const innerConfig = bindRestoreMocks({ sessionExists: true });
+      const { agent, agentPromise } = await spawnAgent();
+
+      try {
+        const params = {
+          cwd: '/tmp',
+          sessionId: 'persisted-1',
+          mcpServers: [],
+          _meta: {
+            [DAEMON_SUPPRESS_RESTORE_ASK_USER_QUESTION_META_KEY]: true,
+          },
+        };
+        if (action === 'load') {
+          await agent.loadSession(params);
+        } else {
+          await agent.unstable_resumeSession(params);
+        }
+
+        expect(
+          innerConfig.suppressRestorableAskUserQuestionPreservation,
+        ).toHaveBeenCalledOnce();
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    },
+  );
+
+  it.each(['load', 'resume'] as const)(
+    '%s keeps AUQ preservation without the suppress meta key',
+    async (action) => {
+      const innerConfig = bindRestoreMocks({ sessionExists: true });
+      const { agent, agentPromise } = await spawnAgent();
+
+      try {
+        const params = {
+          cwd: '/tmp',
+          sessionId: 'persisted-1',
+          mcpServers: [],
+        };
+        if (action === 'load') {
+          await agent.loadSession(params);
+        } else {
+          await agent.unstable_resumeSession(params);
+        }
+
+        expect(
+          innerConfig.suppressRestorableAskUserQuestionPreservation,
+        ).not.toHaveBeenCalled();
+      } finally {
         mockConnectionState.resolve();
         await agentPromise;
       }

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5510,6 +5510,9 @@ class QwenAgent implements Agent {
           restoreOptions,
         ),
       );
+      if (suppressRestoreAskUserQuestion) {
+        config.suppressRestorableAskUserQuestionPreservation();
+      }
       const projection = config.consumeSessionRestoreProjection?.();
       const suppressRecoveredGoalPresentation =
         projection?.runtime.goalRecoverySourceUuid !== undefined &&
@@ -5853,6 +5856,9 @@ class QwenAgent implements Agent {
           RESUME_RESTORE_OPTIONS,
         ),
       );
+      if (suppressRestoreAskUserQuestion) {
+        config.suppressRestorableAskUserQuestionPreservation();
+      }
       const projection = config.consumeSessionRestoreProjection?.();
       let response: ResumeSessionResponse | undefined;
       try {
@@ -11908,6 +11914,9 @@ class QwenAgent implements Agent {
           gaps: sessionData.historyGaps,
           cumulativeUsage: createReplayCumulativeUsage(),
           logger: debugLogger,
+          // Read-only history dump never re-hangs the question. Skip
+          // finalize only on load/resume that will actually restore.
+          suppressRestoreAskUserQuestion: true,
         });
 
         return {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -3218,6 +3218,100 @@ describe('Session', () => {
       expect(mockChatRecordingService.recordToolResult).not.toHaveBeenCalled();
     });
 
+    it('does not persist the answered sibling when the rest of the restored batch times out', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue([
+        { role: 'user', parts: [{ text: 'pick two' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-auq-a',
+                name: 'ask_user_question',
+                args: auqArgs,
+              },
+            },
+            {
+              functionCall: {
+                id: 'call-auq-b',
+                name: 'ask_user_question',
+                args: auqArgs,
+              },
+            },
+          ],
+        },
+      ]);
+      mockToolRegistry.getTool.mockReturnValue(
+        mockConfirmingTool(
+          'ask_user_question',
+          vi.fn().mockResolvedValue({
+            llmContent: 'User answers:\nQuestion: Polling',
+            returnDisplay: 'answered',
+          }),
+        ),
+      );
+      vi.mocked(mockClient.requestPermission)
+        .mockResolvedValueOnce({
+          outcome: { outcome: 'selected', optionId: 'proceed_once' },
+          answers: { '0': 'Polling' },
+        })
+        .mockResolvedValueOnce({
+          outcome: { outcome: 'cancelled' },
+          _meta: { 'qwen.daemon.permissionCancelReason': 'timeout' },
+        });
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [],
+        _meta: { 'qwen.daemon.restoreAskUserQuestion': true },
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      // Persisting the answered sibling would leave a user turn after the
+      // dangling model turn, making the batch unrestorable on the next load.
+      expect(mockChatRecordingService.recordToolResult).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        label: 'resolves after the abort',
+        permissionResult: {
+          outcome: { outcome: 'selected', optionId: 'proceed_once' },
+          answers: { '0': 'Polling' },
+        } as const,
+        reject: false,
+      },
+      {
+        label: 'rejects after the abort',
+        permissionResult: new Error('permission transport closed'),
+        reject: true,
+      },
+    ])(
+      'does not persist a restored ask_user_question whose permission wait is aborted ($label)',
+      async ({ permissionResult, reject }) => {
+        mockChat.getHistory = vi.fn().mockReturnValue(danglingAuqHistory());
+        mockToolRegistry.getTool.mockReturnValue(
+          mockConfirmingTool('ask_user_question', vi.fn()),
+        );
+        vi.mocked(mockClient.requestPermission).mockImplementation(async () => {
+          // The abort carries no permissionCancelReason meta, so only the
+          // wasAborted mark can keep the fabricated result off disk.
+          await session.cancelPendingPrompt();
+          if (reject) throw permissionResult;
+          return permissionResult;
+        });
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [],
+          _meta: { 'qwen.daemon.restoreAskUserQuestion': true },
+        } as unknown as Parameters<typeof session.prompt>[0]);
+
+        expect(
+          mockChatRecordingService.recordToolResult,
+        ).not.toHaveBeenCalled();
+      },
+    );
+
     it('carries a pending recovered-agents notice on the post-answer message', async () => {
       mockChat.getHistory = vi.fn().mockReturnValue(danglingAuqHistory());
       mockToolRegistry.getTool.mockReturnValue(

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -3137,6 +3137,202 @@ describe('Session', () => {
       expect(session.pendingWorktreeNotice).toBe(notice);
       expect(finishedSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('does not persist the decline when a restored question is session_closed', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue(danglingAuqHistory());
+      const execute = vi.fn();
+      mockToolRegistry.getTool.mockReturnValue(
+        mockConfirmingTool(
+          'ask_user_question',
+          execute,
+          'ask_user_question',
+          vi.fn().mockResolvedValue(undefined),
+        ),
+      );
+      vi.mocked(mockClient.requestPermission).mockResolvedValue({
+        outcome: { outcome: 'cancelled' },
+        _meta: { 'qwen.daemon.permissionCancelReason': 'session_closed' },
+      });
+
+      const result = await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [],
+        _meta: { 'qwen.daemon.restoreAskUserQuestion': true },
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      expect(result.stopReason).toBe('end_turn');
+      expect(
+        mockChatRecordingService.recordToolResult,
+      ).not.toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            functionResponse: expect.objectContaining({ id: 'call-auq' }),
+          }),
+        ]),
+        expect.anything(),
+      );
+    });
+
+    it('does not persist skipped siblings when a restored batch times out', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue([
+        { role: 'user', parts: [{ text: 'pick two' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-auq-a',
+                name: 'ask_user_question',
+                args: auqArgs,
+              },
+            },
+            {
+              functionCall: {
+                id: 'call-auq-b',
+                name: 'ask_user_question',
+                args: auqArgs,
+              },
+            },
+          ],
+        },
+      ]);
+      mockToolRegistry.getTool.mockReturnValue(
+        mockConfirmingTool(
+          'ask_user_question',
+          vi.fn(),
+          'ask_user_question',
+          vi.fn().mockResolvedValue(undefined),
+        ),
+      );
+      vi.mocked(mockClient.requestPermission).mockResolvedValue({
+        outcome: { outcome: 'cancelled' },
+        _meta: { 'qwen.daemon.permissionCancelReason': 'timeout' },
+      });
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [],
+        _meta: { 'qwen.daemon.restoreAskUserQuestion': true },
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      expect(mockChatRecordingService.recordToolResult).not.toHaveBeenCalled();
+    });
+
+    it('carries a pending recovered-agents notice on the post-answer message', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue(danglingAuqHistory());
+      mockToolRegistry.getTool.mockReturnValue(
+        mockConfirmingTool(
+          'ask_user_question',
+          vi.fn().mockResolvedValue({
+            llmContent: 'User answers:\nQuestion: Polling',
+            returnDisplay: 'answered',
+          }),
+        ),
+      );
+      vi.mocked(mockClient.requestPermission).mockResolvedValue({
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+        answers: { '0': 'Polling' },
+      });
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              candidates: [{ content: { parts: [{ text: 'got it' }] } }],
+            },
+          },
+        ]),
+      );
+      const notice = 'Recovered background agents: researcher';
+      session.pendingRecoveredAgentsNotice = notice;
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [],
+        _meta: { 'qwen.daemon.restoreAskUserQuestion': true },
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      const sent = firstSentMessage();
+      expect(
+        sent.some(
+          (part) =>
+            typeof part.text === 'string' &&
+            part.text.includes('<system-reminder>') &&
+            part.text.includes(notice),
+        ),
+      ).toBe(true);
+      expect(session.pendingRecoveredAgentsNotice).toBeNull();
+    });
+
+    it('keeps the worktree notice when the post-answer send fails', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue(danglingAuqHistory());
+      mockToolRegistry.getTool.mockReturnValue(
+        mockConfirmingTool(
+          'ask_user_question',
+          vi.fn().mockResolvedValue({
+            llmContent: 'User answers:\nQuestion: Polling',
+            returnDisplay: 'answered',
+          }),
+        ),
+      );
+      vi.mocked(mockClient.requestPermission).mockResolvedValue({
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+        answers: { '0': 'Polling' },
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockRejectedValue(new Error('compression failed'));
+      const notice = 'worktree restore notice';
+      session.pendingWorktreeNotice = notice;
+
+      await expect(
+        session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [],
+          _meta: { 'qwen.daemon.restoreAskUserQuestion': true },
+        } as unknown as Parameters<typeof session.prompt>[0]),
+      ).rejects.toThrow('compression failed');
+
+      expect(session.pendingWorktreeNotice).toBe(notice);
+    });
+
+    it('does not snapshot file history on a restore continuation', async () => {
+      mockChat.getHistory = vi.fn().mockReturnValue(danglingAuqHistory());
+      mockToolRegistry.getTool.mockReturnValue(
+        mockConfirmingTool(
+          'ask_user_question',
+          vi.fn().mockResolvedValue({
+            llmContent: 'User answers:\nQuestion: Polling',
+            returnDisplay: 'answered',
+          }),
+        ),
+      );
+      vi.mocked(mockClient.requestPermission).mockResolvedValue({
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+        answers: { '0': 'Polling' },
+      });
+      mockChat.sendMessageStream = vi.fn().mockResolvedValue(
+        createStreamWithChunks([
+          {
+            type: core.StreamEventType.CHUNK,
+            value: {
+              candidates: [{ content: { parts: [{ text: 'got it' }] } }],
+            },
+          },
+        ]),
+      );
+
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [],
+        _meta: { 'qwen.daemon.restoreAskUserQuestion': true },
+      } as unknown as Parameters<typeof session.prompt>[0]);
+
+      expect(mockFileHistoryService.makeSnapshot).not.toHaveBeenCalled();
+      expect(
+        mockChatRecordingService.recordFileHistorySnapshot,
+      ).not.toHaveBeenCalled();
+    });
   });
 
   // Runs a full exit_plan_mode approval turn and returns the permission

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -9220,8 +9220,14 @@ export class Session implements SessionContext {
       orderedRecords.forEach((record, index) => {
         // A restored ask_user_question whose permission wait timed out stays
         // dangling on disk so a later load can re-hang it; only the
-        // in-memory result is produced.
-        if (record.skipPersistence === true) {
+        // in-memory result is produced. The flag check is retroactive on
+        // purpose: an answered sibling queued before the batch ended
+        // unattended must stay dangling too, or the persisted user turn
+        // would make the trailing model turn unrestorable.
+        if (
+          record.skipPersistence === true ||
+          this.#shouldSkipRestoredAskUserQuestionPersistence(record.callId)
+        ) {
           return;
         }
         this.config

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -485,6 +485,10 @@ function getAbortAwareEndTurnStopReason(
   return signal.aborted ? 'cancelled' : 'end_turn';
 }
 
+function isUnattendedRestorePermissionCancel(reason: unknown): boolean {
+  return reason === 'timeout' || reason === 'session_closed';
+}
+
 type RunToolResult = {
   parts: Part[];
   stopAfterPermissionCancel: boolean;
@@ -1915,10 +1919,13 @@ export class Session implements SessionContext {
   /**
    * Call ids of the ask_user_question being re-hung by the current restore
    * turn, if any. While set, a permission cancel that the bridge resolved as
-   * an unattended timeout does NOT persist the fabricated decline — the
-   * transcript keeps the dangling call so a later load can re-hang it again.
+   * an unattended timeout / session close, or an abort of the restore wait,
+   * does NOT persist the fabricated decline — the transcript keeps the
+   * dangling call so a later load can re-hang it again.
    */
   private restoringAskUserQuestionCallIds: Set<string> | undefined;
+  /** Once any restored call is unattended-terminated, remaining batch skips follow. */
+  private restoredAskUserQuestionSkipPersistence = false;
 
   // Implement SessionContext interface
   readonly sessionId: string;
@@ -4809,21 +4816,27 @@ export class Session implements SessionContext {
             // block in GeminiClient.sendMessageStream). Placed after
             // slash-command and hook early-returns so locally handled commands
             // don't create phantom snapshots that desync the snapshot index.
-            try {
-              const fileHistoryService = this.config.getFileHistoryService();
-              await fileHistoryService.makeSnapshot(promptId);
+            // Restore continuations record no user message; rewindToTurn()
+            // indexes snapshots by user-turn position, so skip them.
+            if (!isRestoreAskUserQuestion) {
               try {
-                const latestSnapshot = fileHistoryService.getSnapshots().at(-1);
-                if (latestSnapshot) {
-                  this.config
-                    .getChatRecordingService()
-                    ?.recordFileHistorySnapshot(latestSnapshot);
+                const fileHistoryService = this.config.getFileHistoryService();
+                await fileHistoryService.makeSnapshot(promptId);
+                try {
+                  const latestSnapshot = fileHistoryService
+                    .getSnapshots()
+                    .at(-1);
+                  if (latestSnapshot) {
+                    this.config
+                      .getChatRecordingService()
+                      ?.recordFileHistorySnapshot(latestSnapshot);
+                  }
+                } catch (e) {
+                  debugLogger.error(`FileHistory: recordSnapshot failed: ${e}`);
                 }
               } catch (e) {
-                debugLogger.error(`FileHistory: recordSnapshot failed: ${e}`);
+                debugLogger.error(`FileHistory: makeSnapshot failed: ${e}`);
               }
-            } catch (e) {
-              debugLogger.error(`FileHistory: makeSnapshot failed: ${e}`);
             }
 
             // Prepend session-level system reminders (plan mode / subagent /
@@ -4906,6 +4919,7 @@ export class Session implements SessionContext {
 
             let nextMessage: Content | null = { role: 'user', parts };
             let turnCount = 0;
+            let restorePostAnswerNoticesAttached = false;
             const toolLoopState = createDaemonToolLoopState(
               channelTurn ? 'off' : this.repeatedToolFailureGuardMode,
             );
@@ -4932,6 +4946,7 @@ export class Session implements SessionContext {
                     .map((call) => call.id)
                     .filter((id): id is string => typeof id === 'string'),
                 );
+                this.restoredAskUserQuestionSkipPersistence = false;
                 // The permission-timeout persistence skip only needs to
                 // cover the run itself — the durable record is written on
                 // runToolCalls' return path.
@@ -4950,6 +4965,7 @@ export class Session implements SessionContext {
                   );
                 } finally {
                   this.restoringAskUserQuestionCallIds = undefined;
+                  this.restoredAskUserQuestionSkipPersistence = false;
                 }
                 if (
                   toolRun.stopAfterPermissionCancel ||
@@ -5023,7 +5039,19 @@ export class Session implements SessionContext {
                       noticePart,
                     ]),
                   };
-                  this.pendingWorktreeNotice = null;
+                  restorePostAnswerNoticesAttached = true;
+                }
+                if (nextMessage?.parts && this.pendingRecoveredAgentsNotice) {
+                  const noticePart = {
+                    text: `<system-reminder>\n${this.pendingRecoveredAgentsNotice}\n</system-reminder>\n\n`,
+                  };
+                  nextMessage = {
+                    ...nextMessage,
+                    parts: insertAfterFunctionResponses(nextMessage.parts, [
+                      noticePart,
+                    ]),
+                  };
+                  restorePostAnswerNoticesAttached = true;
                 }
               }
 
@@ -5032,6 +5060,9 @@ export class Session implements SessionContext {
                 if (pendingSend.signal.aborted) {
                   this.todoStopGuard.suspend();
                   this.#getCurrentChat().addHistory(nextMessage);
+                  if (restorePostAnswerNoticesAttached) {
+                    this.#clearPendingRestoreNotices();
+                  }
                   return { stopReason: 'cancelled' };
                 }
 
@@ -5077,11 +5108,22 @@ export class Session implements SessionContext {
                     // history before the send, so dropping it here on a
                     // non-cancelled failure would lose the orphaned turn the
                     // user never got an answer to.
+                    const preserveFullMessage =
+                      isContinue || sendResult.stopReason === 'cancelled';
                     this.#preserveUnsentMessageHistory(
                       nextMessage,
-                      isContinue || sendResult.stopReason === 'cancelled',
+                      preserveFullMessage,
                     );
+                    if (
+                      preserveFullMessage &&
+                      restorePostAnswerNoticesAttached
+                    ) {
+                      this.#clearPendingRestoreNotices();
+                    }
                     return { stopReason: sendResult.stopReason };
+                  }
+                  if (restorePostAnswerNoticesAttached) {
+                    this.#clearPendingRestoreNotices();
                   }
                   const responseStream = sendResult.responseStream;
                   nextMessage = null;
@@ -6769,6 +6811,25 @@ export class Session implements SessionContext {
       ? await chat.sendMessageStream(model, request, promptId, goalPermit)
       : await chat.sendMessageStream(model, request, promptId);
     return { responseStream };
+  }
+
+  #clearPendingRestoreNotices(): void {
+    this.pendingWorktreeNotice = null;
+    this.pendingRecoveredAgentsNotice = null;
+  }
+
+  #markUnattendedRestoredAskUserQuestion(): void {
+    this.restoredAskUserQuestionSkipPersistence = true;
+  }
+
+  #shouldSkipRestoredAskUserQuestionPersistence(
+    callId: string | undefined,
+  ): boolean {
+    return (
+      typeof callId === 'string' &&
+      this.restoringAskUserQuestionCallIds?.has(callId) === true &&
+      this.restoredAskUserQuestionSkipPersistence
+    );
   }
 
   #preserveUnsentMessageHistory(
@@ -9199,6 +9260,9 @@ export class Session implements SessionContext {
           callId,
           toolName,
           responseParts: [part],
+          ...(this.#shouldSkipRestoredAskUserQuestionPersistence(callId)
+            ? { skipPersistence: true }
+            : {}),
           metadata: {
             callId,
             status: 'error',
@@ -9995,18 +10059,24 @@ export class Session implements SessionContext {
 
     const cancelBeforeExecutionIfAborted = (
       toolName = fc.name ?? 'unknown_tool',
-    ) =>
-      activeToolAbortSignal.aborted
-        ? earlyErrorResponse(
-            new Error('Tool call was cancelled before execution.'),
-            toolName,
-            {
-              status: 'cancelled',
-              errorType: undefined,
-              executionStatus: 'not_started',
-            },
-          )
-        : undefined;
+    ) => {
+      if (!activeToolAbortSignal.aborted) return undefined;
+      if (this.restoringAskUserQuestionCallIds?.has(callId) === true) {
+        this.#markUnattendedRestoredAskUserQuestion();
+      }
+      return earlyErrorResponse(
+        new Error('Tool call was cancelled before execution.'),
+        toolName,
+        {
+          status: 'cancelled',
+          errorType: undefined,
+          executionStatus: 'not_started',
+          ...(this.#shouldSkipRestoredAskUserQuestionPersistence(callId)
+            ? { skipPersistence: true }
+            : {}),
+        },
+      );
+    };
 
     const initialCancellation = cancelBeforeExecutionIfAborted();
     if (initialCancellation) return initialCancellation;
@@ -10837,6 +10907,12 @@ export class Session implements SessionContext {
                 if (!wasAborted) {
                   onStopAfterPermissionCancel?.();
                 }
+                if (
+                  wasAborted &&
+                  this.restoringAskUserQuestionCallIds?.has(callId) === true
+                ) {
+                  this.#markUnattendedRestoredAskUserQuestion();
+                }
                 const permissionFailureMessage = isExitPlanModeTool
                   ? 'The host could not present plan-exit approval. Plan mode remains active; use the host mode selector or /plan exit to leave plan mode.'
                   : planShellDecision.classification === 'unknown'
@@ -10860,6 +10936,11 @@ export class Session implements SessionContext {
                       : ToolErrorType.UNHANDLED_EXCEPTION,
                     executionStatus: 'not_started',
                     stopAfterPermissionCancel: !wasAborted,
+                    ...(this.#shouldSkipRestoredAskUserQuestionPersistence(
+                      callId,
+                    )
+                      ? { skipPersistence: true }
+                      : {}),
                   },
                 );
               }
@@ -10967,17 +11048,23 @@ export class Session implements SessionContext {
                     'Switch-to-Default outcome must be normalized before execution.',
                   );
                 case ToolConfirmationOutcome.Cancel: {
-                  // A restored ask_user_question whose permission wait timed
-                  // out (nobody was there to answer) must not persist the
+                  // A restored ask_user_question whose permission wait ended
+                  // unattended (timeout, session closed) must not persist the
                   // fabricated decline — leave the transcript dangling so a
                   // later load can re-hang the question. A deliberate user
                   // cancel persists, matching live decline handling.
                   const cancelReason = (
                     output as { _meta?: Record<string, unknown> | null }
                   )._meta?.[DAEMON_PERMISSION_CANCEL_REASON_META_KEY];
-                  const skipPersistence =
-                    cancelReason === 'timeout' &&
+                  const unattendedRestore =
+                    isUnattendedRestorePermissionCancel(cancelReason) &&
                     this.restoringAskUserQuestionCallIds?.has(callId) === true;
+                  if (unattendedRestore) {
+                    this.#markUnattendedRestoredAskUserQuestion();
+                  }
+                  const skipPersistence =
+                    unattendedRestore ||
+                    this.#shouldSkipRestoredAskUserQuestionPersistence(callId);
                   // Route through the terminal helper so the declined call is
                   // emitted and recorded consistently without marking its span
                   // as an error.

--- a/packages/cli/src/acp-integration/session/history-replay-page.ts
+++ b/packages/cli/src/acp-integration/session/history-replay-page.ts
@@ -7,6 +7,7 @@
 import {
   parseGoalSnapshotV2,
   parseGoalStateCause,
+  lastHistoryContentFromRecords,
   restorableAskUserQuestionCallIds,
   type ChatRecord,
   type Config,
@@ -273,21 +274,24 @@ export async function collectHistoryReplayUpdates({
   const updates: SessionUpdate[] = [];
   try {
     const initial = parseTranscriptReplayState(replayState, logger);
-    // `getChat()` THROWS 'Chat not initialized' when startChat never ran —
-    // optional chaining cannot catch that, and the bootstrap config used for
-    // non-live sessions is deliberately never chat-initialized. An
-    // uninitialized chat has no re-hung question in this process anyway, so
-    // guarding on isInitialized() is semantically right, not just
-    // throw-avoidance.
-    const replayClient = config?.getGeminiClient?.();
-    const skipFinalizeCallIds =
+    // Prefer live chat when it is initialized (authoritative after startChat
+    // preserve). Cold bulk replay runs before startChat — `getChat()` throws
+    // — so fall back to the transcript tail instead of finalizing the
+    // dangling question that load is about to re-hang.
+    let skipFinalizeCallIds: Set<string> | undefined;
+    if (
       suppressRestoreAskUserQuestion !== true &&
-      config?.getRestoreAskUserQuestion?.() === true &&
-      replayClient?.isInitialized?.() === true
-        ? restorableAskUserQuestionCallIds(
-            replayClient.getChat().peekLastHistoryEntry(),
-          )
-        : undefined;
+      config?.getRestoreAskUserQuestion?.() === true
+    ) {
+      const replayClient = config.getGeminiClient?.();
+      const lastHistoryContent =
+        replayClient?.isInitialized?.() === true
+          ? (replayClient.getChat?.()?.peekLastHistoryEntry?.() ??
+            lastHistoryContentFromRecords(records))
+          : lastHistoryContentFromRecords(records);
+      skipFinalizeCallIds =
+        restorableAskUserQuestionCallIds(lastHistoryContent);
+    }
     await new HistoryReplayer(
       replayContext(sessionId, updates, cumulativeUsage, config, limits),
     ).replay(records, gaps, {

--- a/packages/cli/src/acp-integration/session/history-replayer.test.ts
+++ b/packages/cli/src/acp-integration/session/history-replayer.test.ts
@@ -18,6 +18,10 @@ import {
   HistoryReplayer,
   MISSING_TOOL_RESULT_MESSAGE,
 } from './history-replayer.js';
+import {
+  collectHistoryReplayUpdates,
+  createReplayCumulativeUsage,
+} from './history-replay-page.js';
 import type { SessionContext } from './types.js';
 import { ChatRecordingService } from '@qwen-code/qwen-code-core';
 import type {
@@ -1532,5 +1536,80 @@ describe('HistoryReplayer', () => {
         assistantRecord.timestamp,
       );
     });
+  });
+});
+
+describe('collectHistoryReplayUpdates restore skip', () => {
+  const AUQ_ARGS = {
+    questions: [
+      {
+        question: 'Which approach?',
+        header: 'Approach',
+        options: [
+          { label: 'Polling', description: 'Poll the API' },
+          { label: 'Webhook', description: 'Use a webhook' },
+        ],
+      },
+    ],
+  };
+
+  const danglingRecord = (): ChatRecord => ({
+    uuid: 'assistant-auq',
+    parentUuid: 'user-uuid',
+    sessionId: 'test-session',
+    timestamp: new Date().toISOString(),
+    type: 'assistant',
+    cwd: '/test',
+    version: '1.0.0',
+    message: {
+      role: 'model',
+      parts: [
+        {
+          functionCall: {
+            id: 'call-auq',
+            name: 'ask_user_question',
+            args: AUQ_ARGS,
+          },
+        },
+      ],
+    },
+  });
+
+  it('skips finalize from the transcript tail when chat is not initialized', async () => {
+    const config = {
+      getRestoreAskUserQuestion: () => true,
+      getGeminiClient: () => ({ isInitialized: () => false }),
+    } as unknown as Config;
+
+    const replay = await collectHistoryReplayUpdates({
+      sessionId: 'test-session',
+      config,
+      records: [danglingRecord()],
+      cumulativeUsage: createReplayCumulativeUsage(),
+    });
+
+    expect(replay.updates.map((update) => update.sessionUpdate)).toEqual([
+      'tool_call',
+    ]);
+  });
+
+  it('finalizes when restore skip is suppressed', async () => {
+    const config = {
+      getRestoreAskUserQuestion: () => true,
+      getGeminiClient: () => ({ isInitialized: () => false }),
+    } as unknown as Config;
+
+    const replay = await collectHistoryReplayUpdates({
+      sessionId: 'test-session',
+      config,
+      records: [danglingRecord()],
+      cumulativeUsage: createReplayCumulativeUsage(),
+      suppressRestoreAskUserQuestion: true,
+    });
+
+    expect(replay.updates.map((update) => update.sessionUpdate)).toEqual([
+      'tool_call',
+      'tool_call_update',
+    ]);
   });
 });

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -676,6 +676,33 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  describe('restorable ask_user_question preservation', () => {
+    it('defaults to off when the restore switch is unset', () => {
+      const config = new Config(baseParams);
+      expect(config.getRestoreAskUserQuestion()).toBe(false);
+      expect(config.getPreserveRestorableAskUserQuestion()).toBe(false);
+    });
+
+    it('preserves by default when the restore switch is on', () => {
+      const config = new Config({
+        ...baseParams,
+        restoreAskUserQuestion: true,
+      });
+      expect(config.getRestoreAskUserQuestion()).toBe(true);
+      expect(config.getPreserveRestorableAskUserQuestion()).toBe(true);
+    });
+
+    it('stops preserving after suppression, without touching the restore switch', () => {
+      const config = new Config({
+        ...baseParams,
+        restoreAskUserQuestion: true,
+      });
+      config.suppressRestorableAskUserQuestionPreservation();
+      expect(config.getPreserveRestorableAskUserQuestion()).toBe(false);
+      expect(config.getRestoreAskUserQuestion()).toBe(true);
+    });
+  });
+
   describe('getVisionBridgeTimeoutMs', () => {
     it('returns undefined when unset', () => {
       expect(new Config(baseParams).getVisionBridgeTimeoutMs()).toBeUndefined();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2048,6 +2048,12 @@ export class Config {
   private sessionRegistered = false;
   private readonly experimentalZedIntegration: boolean = false;
   private readonly restoreAskUserQuestion: boolean = false;
+  /**
+   * startChat orphan-repair preserve. Defaults to `restoreAskUserQuestion`.
+   * A load/resume that will not re-hang (no client, fork) turns this off so
+   * Gemini history is repaired in lockstep with replay finalization.
+   */
+  private preserveRestorableAskUserQuestion = false;
   private readonly sessionWriterLeaseEnabled: boolean = false;
   private readonly cronEnabled: boolean = true;
   /** Recurring cron max age in days, resolved once at construction
@@ -2333,6 +2339,7 @@ export class Config {
     this.experimentalZedIntegration =
       params.experimentalZedIntegration ?? false;
     this.restoreAskUserQuestion = params.restoreAskUserQuestion === true;
+    this.preserveRestorableAskUserQuestion = this.restoreAskUserQuestion;
     this.sessionWriterLeaseEnabled =
       this.experimentalZedIntegration === true &&
       params.sessionWriterLeaseEnabled === true;
@@ -7253,6 +7260,15 @@ export class Config {
 
   getRestoreAskUserQuestion(): boolean {
     return this.restoreAskUserQuestion;
+  }
+
+  getPreserveRestorableAskUserQuestion(): boolean {
+    return this.preserveRestorableAskUserQuestion;
+  }
+
+  /** Load/resume declined the re-hang: repair Gemini history like flag-off. */
+  suppressRestorableAskUserQuestionPreservation(): void {
+    this.preserveRestorableAskUserQuestion = false;
   }
 
   isSessionWriterLeaseEnabled(): boolean {

--- a/packages/core/src/core/ask-user-question-restore.test.ts
+++ b/packages/core/src/core/ask-user-question-restore.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import type { Content } from '@google/genai';
 import {
   findRestorableAskUserQuestion,
+  lastHistoryContentFromRecords,
   parseAskUserQuestionParams,
   restorableAskUserQuestionCallIds,
 } from './ask-user-question-restore.js';
@@ -142,5 +143,39 @@ describe('findRestorableAskUserQuestion', () => {
     };
     expect(findRestorableAskUserQuestion(last)).toBeUndefined();
     expect(restorableAskUserQuestionCallIds(last)).toBeUndefined();
+  });
+});
+
+describe('lastHistoryContentFromRecords', () => {
+  it('returns the last non-system message', () => {
+    const last = lastHistoryContentFromRecords([
+      { type: 'user', message: { role: 'user', parts: [{ text: 'pick' }] } },
+      {
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-auq',
+                name: 'ask_user_question',
+                args: AUQ_ARGS,
+              },
+            },
+          ],
+        },
+      },
+      { type: 'system', message: { role: 'user', parts: [{ text: 'noise' }] } },
+    ]);
+    expect(last?.role).toBe('model');
+    expect(restorableAskUserQuestionCallIds(last)).toEqual(
+      new Set(['call-auq']),
+    );
+  });
+
+  it('returns undefined when there is no API-facing message', () => {
+    expect(
+      lastHistoryContentFromRecords([{ type: 'system' }, { type: 'user' }]),
+    ).toBeUndefined();
   });
 });

--- a/packages/core/src/core/ask-user-question-restore.ts
+++ b/packages/core/src/core/ask-user-question-restore.ts
@@ -106,3 +106,18 @@ export function restorableAskUserQuestionCallIds(
       .filter((id): id is string => typeof id === 'string' && id.length > 0),
   );
 }
+
+/**
+ * Last API-facing content in a transcript replay, skipping system/bookkeeping
+ * records. Used when chat is not initialized yet (cold bulk load replay).
+ */
+export function lastHistoryContentFromRecords(
+  records: ReadonlyArray<{ type?: string; message?: Content }>,
+): Content | undefined {
+  for (let i = records.length - 1; i >= 0; i--) {
+    const record = records[i];
+    if (record?.type === 'system' || !record?.message) continue;
+    return record.message;
+  }
+  return undefined;
+}

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -2013,6 +2013,46 @@ describe('Gemini Client (client.ts)', () => {
       expect(hasFunctionResponse).toBe(false);
     });
 
+    it('repairs a restorable ask_user_question when restore preservation is suppressed', async () => {
+      vi.mocked(mockConfig.getRestoreAskUserQuestion).mockReturnValue(true);
+      Object.assign(mockConfig, {
+        getPreserveRestorableAskUserQuestion: vi.fn().mockReturnValue(false),
+      });
+
+      await client.startChat([
+        { role: 'user', parts: [{ text: 'pick one' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call_auq_resume',
+                name: 'ask_user_question',
+                args: {
+                  questions: [
+                    {
+                      question: 'Which approach?',
+                      header: 'Approach',
+                      options: [
+                        { label: 'Polling', description: 'Poll the API' },
+                        { label: 'Webhook', description: 'Use a webhook' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            } as never,
+          ],
+        },
+      ]);
+
+      const history = client.getHistory();
+      const hasFunctionResponse = history.some((h) =>
+        h.parts?.some((p) => p.functionResponse?.id === 'call_auq_resume'),
+      );
+      expect(hasFunctionResponse).toBe(true);
+    });
+
     it('is a no-op when the resumed transcript has no dangling tool_use', async () => {
       // Happy resume path: don't inject a synthetic functionResponse
       // into a transcript whose tool_use pairing is already valid (or,

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1815,9 +1815,11 @@ export class GeminiClient {
       // any pre-send code reading `chat.history` from seeing a malformed
       // shape.)
       profiler.timeSync('orphan_tool_use_repair', () => {
-        const preserveCallIds = this.config.getRestoreAskUserQuestion?.()
-          ? restorableAskUserQuestionCallIds(chat.peekLastHistoryEntry())
-          : undefined;
+        const preserveCallIds =
+          (this.config.getPreserveRestorableAskUserQuestion?.() ??
+          this.config.getRestoreAskUserQuestion?.())
+            ? restorableAskUserQuestionCallIds(chat.peekLastHistoryEntry())
+            : undefined;
         this.repairOrphanedToolUseTurnsInHistory(
           undefined,
           preserveCallIds ? { preserveCallIds } : undefined,

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -208,6 +208,7 @@ describe('GeminiChat', async () => {
       takePendingManualPlanExitNotice: vi.fn().mockReturnValue(undefined),
       restorePendingManualPlanExitNotice: vi.fn(),
       getFileReadCache: vi.fn().mockReturnValue({ clear: vi.fn() }),
+      getRestoreAskUserQuestion: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     // Disable 429 simulation for tests
@@ -1233,6 +1234,69 @@ describe('GeminiChat', async () => {
       expect(userTurn.parts![0]!.functionResponse?.id).toBe(
         'call_dangling_for_send',
       );
+    });
+
+    it('still synthesizes when restore is on and the user sends ordinary text', async () => {
+      vi.mocked(mockConfig.getRestoreAskUserQuestion).mockReturnValue(true);
+      chat.setHistory([
+        { role: 'user', parts: [{ text: 'pick one' }] },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call_auq_ordinary_send',
+                name: 'ask_user_question',
+                args: {
+                  questions: [
+                    {
+                      question: 'Which approach?',
+                      header: 'Approach',
+                      options: [
+                        { label: 'Polling', description: 'Poll the API' },
+                        { label: 'Webhook', description: 'Use a webhook' },
+                      ],
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ]);
+
+      const ackStream = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: { role: 'model', parts: [{ text: 'ok' }] },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        ackStream,
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'never mind, just continue' },
+        'prompt-ordinary-over-auq',
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      const history = chat.getHistory();
+      const userTurn = history[2]!;
+      expect(userTurn.role).toBe('user');
+      expect(userTurn.parts![0]!.functionResponse?.id).toBe(
+        'call_auq_ordinary_send',
+      );
+      expect(
+        userTurn.parts!.some((p) => p.text === 'never mind, just continue'),
+      ).toBe(true);
     });
 
     it('does NOT synthesize when the user supplies a matching tool_result', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -18,7 +18,6 @@ import type {
   GenerateContentResponseUsageMetadata,
 } from '@google/genai';
 import { createUserContent, FinishReason } from './genai-compat.js';
-import { restorableAskUserQuestionCallIds } from './ask-user-question-restore.js';
 import { enforceFunctionResponseBudget } from '../utils/tool-response-finalizer.js';
 import {
   retryWithBackoff,
@@ -2610,15 +2609,6 @@ export class GeminiChat {
         }
       }
 
-      // Capture the trailing entry BEFORE the user push: when
-      // --restore-ask-user-question preserved a dangling ask_user_question
-      // at load, a send that beats the restore prompt must not close it
-      // with a synthetic failure — the restore hint is one-shot.
-      const preserveCallIds =
-        this.config.getRestoreAskUserQuestion?.() === true
-          ? restorableAskUserQuestionCallIds(this.history.at(-1))
-          : undefined;
-
       // Add user content to history ONCE before any attempts.
       this.history.push(userContent);
       currentUserContent = userContent;
@@ -2629,14 +2619,13 @@ export class GeminiChat {
       // Per-send orphan repair (belt-and-suspenders alongside the
       // startChat load-time pass). Runs AFTER user content lands so a
       // user-supplied tool_result closes the pair before we synthesize
-      // anything. Logs are tagged so investigators can distinguish this
-      // pass from the session-load pass and from the React scheduler's
-      // dedup-drop. See the canonical note above
-      // `ORPHAN_TOOL_USE_REPAIR_REASON`.
+      // anything. An ordinary prompt that races a restore re-hang must
+      // still close the pair — `model[functionCall] → user[text]` is
+      // rejected by Anthropic-compatible providers. Restore itself sends
+      // the real functionResponse, so this pass is a no-op on that path.
       const inlineRepair = repairOrphanedToolUseTurns(
         this.history,
         ORPHAN_TOOL_USE_REPAIR_REASON,
-        preserveCallIds ? { preserveCallIds } : undefined,
       );
       if (inlineRepair.injected.length > 0) {
         debugLogger.warn(


### PR DESCRIPTION
## What this PR does

Follow-up to #9665. Keeps a restored trailing `ask_user_question` valid after load/resume: ordinary user text no longer sends `model[functionCall] → user[text]` to the provider; restore continuations do not insert a phantom file-history snapshot; recovered-agent and worktree notices ride on the post-answer message and are cleared only after that message lands; unattended restore (`timeout` / `session_closed` / abort while waiting) skips transcript persistence for the whole restored batch so a later load can re-hang it; cold bulk replay and read-only `qwen/session/loadUpdates` stop leaving a pending card that nobody will re-hang.

When load/resume will not re-hang (no attached client, fork), Gemini history is repaired in lockstep with replay finalization. User cancel still persists.

## Why it's needed

Post-merge review on #9665 found real defects on the opt-in restore path: Anthropic-compatible providers reject a dangling function call followed by plain user text; rewind indexes snapshots by user-turn position, so a restore snapshot shifts later rewinds; resume notices could be dropped or never delivered; a timeout on one question in a batch persisted synthetic skips for the rest; cold `historyReplay: 'response'` finalized the question before `startChat`, then load advertised it again; `loadUpdates` skipped finalize without ever re-hanging.

## Reviewer Test Plan

### How to verify

With `--restore-ask-user-question`, load a session that ends on an unanswered `ask_user_question`.

- Answer it: the model continues the same turn; if the session also recovered background agents or a live worktree, those notices appear on the post-answer request, not on a later unrelated prompt. If send/compression fails before the message lands, the next real prompt still has the notices.
- Type ordinary text (or cancel then type) before/instead of answering: the provider history is `model[functionCall] → user[functionResponse, text]`, not a bare text turn after the call.
- Timeout or close the session while the restored questions are waiting: disk transcript does not record a fabricated decline; a later load can re-hang them. User cancel still persists.
- Cold load of a large session (`historyReplay: 'response'`) and `qwen/session/loadUpdates`: load/resume still skip finalize for the trailing question; the read-only dump finalizes it and does not leave a spinning card.
- Fork / no-client load still finalizes (no restore prompt) and Gemini history matches that finalize.

Without the flag, load/resume still synthesize a failed tool result as today.

### Evidence (Before & After)

N/A (daemon restore hardening; covered by unit tests for ordinary-send history, suppress-path Gemini repair, restore snapshot skip, post-answer notices and failed-send retention, unattended skip-persist, transcript-tail skip ids, and loadUpdates finalize).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Package-local vitest: `packages/core` (`ask-user-question-restore`, `client`, `geminiChat`) and `packages/cli` (`Session.test`, `Session.worktree.test`, `history-replayer`, live-load restore path in `acpAgent.test`). N/A for a full daemon restart.

## Risk & Scope

- Main risk or tradeoff: unattended restore now leaves the transcript dangling on purpose so a later attended load can re-hang; this process still writes an in-memory functionResponse for protocol validity. Ordinary send always closes a dangling call (synthetic FR) so restore racing a user message cannot keep illegal provider history.
- Not validated / out of scope: rejecting restore on persisted `parentSessionId`; skip-set matching only the last occurrence of a duplicated raw call id; signed provenance for daemon cancel meta; restore coalescing vs late attach; replay snapshot `rawCallId` on deduplicated pending calls; mixed text+functionCall compression outside the restore preserve path; the full extra regression matrix from the #9665 post-merge review.
- Breaking changes / migration notes: none. Still opt-in, default off.

## Linked Issues

Follow-up to #9665. Related to #9664.

<details>
<summary>中文说明</summary>

## 这个 PR 做什么

#9665 的 follow-up。保证恢复出来的尾部 `ask_user_question` 在 load/resume 之后仍然合法：普通用户文本不再向 provider 发送 `model[functionCall] → user[text]`；restore 续跑不再插入幽灵 file-history 快照；恢复的 agent notice 和 worktree notice 跟在答完后的消息上，且只在该消息落地后才清空；无人值守结束（`timeout` / `session_closed` / 等待中 abort）对整批恢复提问跳过 transcript 持久化，以便下次 load 还能再挂；冷启动 bulk replay 和只读 `qwen/session/loadUpdates` 不再留下无人会再挂的 pending 卡片。

load/resume 不会再挂时（无附着客户端、fork），Gemini history 与 replay finalize 同步修好。用户主动 cancel 仍会持久化。

## 为什么需要

#9665 合入后的 review 在 opt-in 恢复路径上找到了真实缺陷：Anthropic 兼容 provider 会拒绝「悬空 functionCall 后面直接跟用户文本」；rewind 按用户 turn 下标切快照，restore 插入的快照会错位；resume notice 可能被丢掉或永远发不出去；一批里一个提问超时会把其余提问写成合成 skip；冷启动 `historyReplay: 'response'` 会在 `startChat` 前就把提问终结，随后 load 又提示再挂；`loadUpdates` 跳过 finalize 却从不重新挂起。

## 评审测试计划

### 如何验证

打开 `--restore-ask-user-question`，load 一个尾部停在未回答 `ask_user_question` 的会话。

- 作答：模型继续同一轮；若该会话还恢复了后台 agent 或活的 worktree，这些 notice 应出现在答完后的请求上，而不是下一次无关 prompt。若发送/压缩在消息落地前失败，下一次真正的 prompt 仍应带上这些 notice。
- 在作答前（或取消后再）输入普通文本：provider history 是 `model[functionCall] → user[functionResponse, text]`，不是 call 后面直接跟裸文本。
- 恢复提问等待时超时或关闭会话：磁盘 transcript 不记录伪造的 decline；之后再 load 仍可重新挂起。用户主动 cancel 仍会持久化。
- 大会话冷 load（`historyReplay: 'response'`）以及 `qwen/session/loadUpdates`：load/resume 仍对尾部提问跳过 finalize；只读 dump 会 finalize，不留下空转卡片。
- Fork / 无客户端 load 仍会 finalize（不发 restore prompt），且 Gemini history 与这次 finalize 对齐。

开关关闭时，load/resume 仍按今天的行为合成失败 tool result。

### 证据（Before & After）

N/A（daemon restore 加固；由单元测试覆盖普通发送的 history、suppress 路径的 Gemini 修复、restore 跳过快照、答后 notice 以及发送失败时保留、无人值守 skip-persist、从 transcript 尾取 skip ids、loadUpdates finalize）。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

包内 vitest：`packages/core`（`ask-user-question-restore`、`client`、`geminiChat`）和 `packages/cli`（`Session.test`、`Session.worktree.test`、`history-replayer`、`acpAgent.test` 的 live-load restore）。无完整 daemon 重启验证。

## 风险与范围

- 主要风险或取舍：无人值守 restore 故意让 transcript 保持悬空，以便下次带客户端的 load 还能再挂；本进程内存里仍会写 functionResponse 以满足协议。普通 send 总会补上合成 FR 关掉悬空 call，避免 restore 与用户消息竞态时出现非法 provider history。
- 未验证 / 不在范围内：按持久化的 `parentSessionId` 一律拒绝 restore；skip set 只匹配重复 raw call id 的最后一次；给 daemon cancel meta 做带出处校验；restore coalescing 与晚附着；回放快照里去重 pending 的 `rawCallId`；restore preserve 路径之外的混合 text+functionCall 压缩；#9665 合入后 review 里那份完整回归矩阵。
- 破坏性变更 / 迁移说明：无。仍是默认关闭的 opt-in。

## 关联 Issue

#9665 的 follow-up。关联 #9664。

</details>

Made with [Cursor](https://cursor.com)