### PR TITLE
fix(web-shell): cap React dev performance.measure accumulation to stop renderer OOM

### DIFF
--- a/packages/web-shell/client/index-html.test.ts
+++ b/packages/web-shell/client/index-html.test.ts
@@ -79,28 +79,47 @@ describe('React performance measure guard', () => {
 
   it('clears the measure timeline on a budget so entries cannot accumulate', () => {
     const measure = vi.fn(() => 'measure');
-    const clearMeasures = vi.fn();
-    const performance = installMeasureGuard(measure, clearMeasures);
+    const clearThis: unknown[] = [];
+    const clearMeasures = vi.fn(function (this: unknown) {
+      clearThis.push(this);
+    });
+    const fakePerformance = installMeasureGuard(measure, clearMeasures);
     const reactOptions = {
       start: 1,
       end: 2,
-      detail: { devtools: { track: 'Components ⚛' } },
+      // A non-Components track: the flood is dominated by lane/scheduler
+      // tracks, so the budget must count every React devtools measure.
+      detail: { devtools: { track: 'Blocking' } },
     };
 
     for (let i = 0; i < 16384; i += 1) {
-      performance.measure('React', reactOptions);
+      fakePerformance.measure('⏱ track', reactOptions);
     }
+    // The timeline is cleared with no name filter (React never names its
+    // measures) and with the performance object as receiver (a detached
+    // brand-checked clearMeasures throws Illegal invocation).
     expect(clearMeasures).toHaveBeenCalledTimes(1);
+    expect(clearMeasures).toHaveBeenCalledWith();
+    expect(clearThis).toEqual([fakePerformance]);
+    // Every React measure is still forwarded, detail stripped — including
+    // the one that triggers the clear.
+    expect(measure).toHaveBeenCalledTimes(16384);
+    expect(
+      (measure.mock.calls[16383]?.[1] as PerformanceMeasureOptions).detail,
+    ).toBeNull();
 
-    performance.measure('React', reactOptions);
-    expect(clearMeasures).toHaveBeenCalledTimes(1);
+    // The clear is not latched: a second full window clears again.
+    for (let i = 0; i < 16384; i += 1) {
+      fakePerformance.measure('⏱ track', reactOptions);
+    }
+    expect(clearMeasures).toHaveBeenCalledTimes(2);
 
     // Non-React measures do not count toward the budget.
     for (let i = 0; i < 16384 - 1; i += 1) {
-      performance.measure('custom-measure', {
+      fakePerformance.measure('custom-measure', {
         detail: { source: 'web-shell' },
       });
     }
-    expect(clearMeasures).toHaveBeenCalledTimes(1);
+    expect(clearMeasures).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web-shell/client/index-html.test.ts
+++ b/packages/web-shell/client/index-html.test.ts
@@ -2,10 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
-function installMeasureGuard(
-  measure: (...args: unknown[]) => unknown,
-  clearMeasures?: () => void,
-): Performance {
+function extractMeasureScript(): string {
   const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
   const script = Array.from(
     html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
@@ -14,7 +11,14 @@ function installMeasureGuard(
     .find((source) => source.includes('performance.measure ='));
 
   if (!script) throw new Error('Performance measure guard not found');
+  return script;
+}
 
+function installMeasureGuard(
+  measure: (...args: unknown[]) => unknown,
+  clearMeasures?: () => void,
+): Performance {
+  const script = extractMeasureScript();
   const performance = { measure, clearMeasures };
   Function('performance', 'DOMException', script)(performance, DOMException);
   return performance as Performance;
@@ -78,48 +82,155 @@ describe('React performance measure guard', () => {
   });
 
   it('clears the measure timeline on a budget so entries cannot accumulate', () => {
-    const measure = vi.fn(() => 'measure');
+    const measureThis: unknown[] = [];
+    const measure = vi.fn(function (this: unknown): string {
+      measureThis.push(this);
+      return 'measure';
+    });
     const clearThis: unknown[] = [];
     const clearMeasures = vi.fn(function (this: unknown) {
       clearThis.push(this);
     });
     const fakePerformance = installMeasureGuard(measure, clearMeasures);
-    const reactOptions = {
-      start: 1,
-      end: 2,
-      // A non-Components track: the flood is dominated by lane/scheduler
-      // tracks, so the budget must count every React devtools measure.
-      detail: { devtools: { track: 'Blocking' } },
+    // The real flood mixes lane/scheduler tracks and measure names, so drive
+    // a mixed flood: the budget must count every React devtools measure
+    // regardless of track or name.
+    const tracks = ['Blocking', 'Transition', 'Suspense', 'Components ⚛'];
+    const names = ['⏱ lane', '⏱ render', '⏱ commit'];
+    const reactName = (index: number): string => names[index % names.length];
+    let reactDriven = 0;
+    const driveReact = (count: number): void => {
+      for (let i = 0; i < count; i += 1) {
+        fakePerformance.measure(reactName(reactDriven), {
+          start: 1,
+          end: 2,
+          detail: { devtools: { track: tracks[reactDriven % tracks.length] } },
+        });
+        reactDriven += 1;
+      }
     };
 
-    for (let i = 0; i < 16384; i += 1) {
-      fakePerformance.measure('⏱ track', reactOptions);
-    }
+    // The clear fires at exactly the budget, not one measure early.
+    driveReact(16383);
+    expect(clearMeasures).not.toHaveBeenCalled();
+    driveReact(1);
+    expect(clearMeasures).toHaveBeenCalledTimes(1);
     // The timeline is cleared with no name filter (React never names its
     // measures) and with the performance object as receiver (a detached
     // brand-checked clearMeasures throws Illegal invocation).
-    expect(clearMeasures).toHaveBeenCalledTimes(1);
     expect(clearMeasures).toHaveBeenCalledWith();
     expect(clearThis).toEqual([fakePerformance]);
-    // Every React measure is still forwarded, detail stripped — including
-    // the one that triggers the clear.
+    // Every React measure is still forwarded with its name preserved and its
+    // detail stripped — including the one that triggers the clear.
     expect(measure).toHaveBeenCalledTimes(16384);
-    expect(
-      (measure.mock.calls[16383]?.[1] as PerformanceMeasureOptions).detail,
-    ).toBeNull();
+    expect(measure.mock.calls[16383]).toEqual([
+      reactName(16383),
+      expect.objectContaining({ detail: null }),
+    ]);
 
-    // The clear is not latched: a second full window clears again.
-    for (let i = 0; i < 16384; i += 1) {
-      fakePerformance.measure('⏱ track', reactOptions);
-    }
+    // The clear is not latched: a second full window clears again, and
+    // forwarding + stripping survive past the first clear.
+    driveReact(16384);
     expect(clearMeasures).toHaveBeenCalledTimes(2);
+    expect(measure).toHaveBeenCalledTimes(32768);
+    expect(measure.mock.calls[32767]).toEqual([
+      reactName(32767),
+      expect.objectContaining({ detail: null }),
+    ]);
 
-    // Non-React measures do not count toward the budget.
+    // A full window of non-React measures neither counts toward the budget
+    // nor is dropped or stripped after a clear.
+    const customOptions = { start: 1, end: 2, detail: { source: 'web-shell' } };
     for (let i = 0; i < 16384 - 1; i += 1) {
-      fakePerformance.measure('custom-measure', {
-        detail: { source: 'web-shell' },
-      });
+      fakePerformance.measure('custom-measure', customOptions);
     }
+    // The wrapper's return value passes through like the native call's.
+    const customResult = fakePerformance.measure(
+      'custom-measure',
+      customOptions,
+    );
     expect(clearMeasures).toHaveBeenCalledTimes(2);
+    expect(customResult).toBe('measure');
+    expect(measure).toHaveBeenCalledTimes(49152);
+    // Identity: the non-React options object is forwarded as-is.
+    expect(measure.mock.calls[49151]?.[0]).toBe('custom-measure');
+    expect(measure.mock.calls[49151]?.[1]).toBe(customOptions);
+
+    // Mixed app + React traffic still reaches the budget: interleaved
+    // non-React measures must not reset the counter.
+    for (let i = 0; i < 16384; i += 1) {
+      driveReact(1);
+      fakePerformance.measure('custom-measure', customOptions);
+    }
+    expect(clearMeasures).toHaveBeenCalledTimes(3);
+
+    // A detached wrapper call still reaches the native measure bound to the
+    // performance object (both captures keep their .bind(performance)).
+    const detachedMeasure = fakePerformance.measure as (
+      ...args: unknown[]
+    ) => unknown;
+    detachedMeasure('detached', {
+      start: 1,
+      end: 2,
+      detail: { devtools: { track: 'Blocking' } },
+    });
+    expect(measure).toHaveBeenCalledTimes(81921);
+    expect(measureThis.every((receiver) => receiver === fakePerformance)).toBe(
+      true,
+    );
+  });
+
+  it('keeps measuring when clearMeasures is unavailable', () => {
+    const measure = vi.fn(() => 'measure');
+    const performance = installMeasureGuard(measure);
+    const options = {
+      start: 1,
+      end: 2,
+      detail: { devtools: { track: 'Blocking' } },
+    };
+
+    expect(() => {
+      for (let i = 0; i < 16384 + 1; i += 1) {
+        performance.measure('⏱ lane', options);
+      }
+    }).not.toThrow();
+    expect(measure).toHaveBeenCalledTimes(16384 + 1);
+  });
+
+  it('forwards standard measure shapes untouched', () => {
+    const measure = vi.fn(() => 'measure');
+    const performance = installMeasureGuard(measure);
+    const bareMeasure = performance.measure as (
+      name: string,
+      options?: unknown,
+    ) => unknown;
+    const options = { start: 1, end: 2 };
+
+    expect(() => {
+      bareMeasure('plain');
+      bareMeasure('null-options', null);
+      bareMeasure('string-mark', 'start-mark');
+      bareMeasure('detail-less', options);
+    }).not.toThrow();
+
+    expect(bareMeasure('return-check', options)).toBe('measure');
+    expect(measure.mock.calls[0]).toEqual(['plain']);
+    expect(measure.mock.calls[1]).toEqual(['null-options', null]);
+    expect(measure.mock.calls[2]).toEqual(['string-mark', 'start-mark']);
+    expect(measure.mock.calls[3]).toEqual(['detail-less', options]);
+  });
+
+  it('does not touch environments without performance.measure', () => {
+    const script = extractMeasureScript();
+    const install = (performance: unknown): void => {
+      Function(
+        'performance',
+        'DOMException',
+        script,
+      )(performance, DOMException);
+    };
+
+    expect(() => install(undefined)).not.toThrow();
+    expect(() => install({})).not.toThrow();
   });
 });

--- a/packages/web-shell/client/index-html.test.ts
+++ b/packages/web-shell/client/index-html.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 function installMeasureGuard(
   measure: (...args: unknown[]) => unknown,
+  clearMeasures?: () => void,
 ): Performance {
   const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
   const script = Array.from(
@@ -14,7 +15,7 @@ function installMeasureGuard(
 
   if (!script) throw new Error('Performance measure guard not found');
 
-  const performance = { measure };
+  const performance = { measure, clearMeasures };
   Function('performance', 'DOMException', script)(performance, DOMException);
   return performance as Performance;
 }
@@ -58,5 +59,48 @@ describe('React performance measure guard', () => {
     performance.measure('custom-measure', options);
 
     expect(measure).toHaveBeenCalledWith('custom-measure', options);
+  });
+
+  it('strips detail from any React devtools track, not just Components', () => {
+    const measure = vi.fn(() => 'measure');
+    const performance = installMeasureGuard(measure);
+    const options = {
+      start: 1,
+      end: 2,
+      detail: { devtools: { track: 'Blocking', properties: [['k', 'v']] } },
+    };
+
+    performance.measure('React', options);
+
+    expect(
+      (measure.mock.calls[0]?.[1] as PerformanceMeasureOptions).detail,
+    ).toBeNull();
+  });
+
+  it('clears the measure timeline on a budget so entries cannot accumulate', () => {
+    const measure = vi.fn(() => 'measure');
+    const clearMeasures = vi.fn();
+    const performance = installMeasureGuard(measure, clearMeasures);
+    const reactOptions = {
+      start: 1,
+      end: 2,
+      detail: { devtools: { track: 'Components ⚛' } },
+    };
+
+    for (let i = 0; i < 16384; i += 1) {
+      performance.measure('React', reactOptions);
+    }
+    expect(clearMeasures).toHaveBeenCalledTimes(1);
+
+    performance.measure('React', reactOptions);
+    expect(clearMeasures).toHaveBeenCalledTimes(1);
+
+    // Non-React measures do not count toward the budget.
+    for (let i = 0; i < 16384 - 1; i += 1) {
+      performance.measure('custom-measure', {
+        detail: { source: 'web-shell' },
+      });
+    }
+    expect(clearMeasures).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web-shell/client/index-html.test.ts
+++ b/packages/web-shell/client/index-html.test.ts
@@ -155,6 +155,11 @@ describe('React performance measure guard', () => {
     // Identity: the non-React options object is forwarded as-is.
     expect(measure.mock.calls[49151]?.[0]).toBe('custom-measure');
     expect(measure.mock.calls[49151]?.[1]).toBe(customOptions);
+    // Value survival, not just reference: an in-place strip of the caller's
+    // options object must fail here.
+    expect(
+      (measure.mock.calls[49151]?.[1] as PerformanceMeasureOptions).detail,
+    ).toEqual({ source: 'web-shell' });
 
     // Mixed app + React traffic still reaches the budget: interleaved
     // non-React measures must not reset the counter.

--- a/packages/web-shell/client/index.html
+++ b/packages/web-shell/client/index.html
@@ -51,12 +51,22 @@
       Prevent React 19 dev-mode OOM crashes. React records component prop
       details through performance.measure(), which structured-clones and retains
       those details. Strip the detail before large transcripts reach the native
-      call while preserving the component timing and non-React measures.
+      call while preserving the component timing and non-React measures. The
+      stripped entries themselves still accumulate in the browser's unbounded
+      user-timing buffer — an idle dev page emits ~16k measures/s — so the
+      timeline is also cleared on a budget, or long-lived dev tabs exhaust the
+      renderer's PartitionAlloc address space and die with SIGABRT.
     -->
     <script>
       !(function () {
         if (typeof performance === 'undefined' || !performance.measure) return;
         var m = performance.measure.bind(performance);
+        var clear =
+          typeof performance.clearMeasures === 'function'
+            ? performance.clearMeasures.bind(performance)
+            : null;
+        var reactMeasures = 0;
+        var CLEAR_EVERY = 16384;
         performance.measure = function () {
           var options = arguments[1];
           var devtools =
@@ -64,7 +74,12 @@
             typeof options === 'object' &&
             options.detail &&
             options.detail.devtools;
-          if (devtools && devtools.track === 'Components ⚛') {
+          if (devtools) {
+            reactMeasures += 1;
+            if (clear && reactMeasures >= CLEAR_EVERY) {
+              reactMeasures = 0;
+              clear();
+            }
             var args = Array.prototype.slice.call(arguments);
             args[1] = Object.assign({}, options, { detail: null });
             return m.apply(this, args);


### PR DESCRIPTION
## What this PR does

Bounds a React 19 dev-mode memory leak in the Web Shell shell page. In dev builds React records component timings via `performance.measure()`; the browser's user-timing buffer retains those entries without limit (Blink-side, invisible to the JS heap), and an idle Web Shell dev page emits ~16k of them per second. The existing inline guard already stripped the structured-cloned `detail` payload but let the stripped entries accumulate forever. This PR extends the guard to strip `detail` on every React devtools track (not just `Components ⚛`) and clears the measure timeline every 16,384 React measures so entries can no longer accumulate without bound. Production builds are unaffected: production React never emits devtools measures, so the guard stays inert.

## Why it's needed

Long-lived vite dev tabs were crashing the Chrome renderer. Over 8/19–8/23 a maintainer machine recorded 12 renderer crashes (`SIGABRT`, "Aw, Snap!"), all on the vite dev server origin (`localhost:5173`), each with the PartitionAlloc crash key `page-allocator-mapped-size ≈ 65GiB` — the renderer's address-space pool exhausted. The production build served by the daemon never reproduced. Reproduction against the real 78MB session transcript showed the renderer RSS ratcheting 603→1501MB with no plateau during a 60s scroll soak on the dev build; with this fix the same soak plateaus (593→971MB, then flat), and measure entries oscillate under the 16,384 cap instead of growing at 16k/s.

## Reviewer Test Plan

### How to verify

1. Run the unit tests: `cd packages/web-shell && npx vitest run client/index-html.test.ts` — 4 tests pass, covering detail-stripping on a non-Components track, the periodic clear, and that non-React measures neither get stripped nor count toward the budget.
2. Optional live check on a vite dev server (`npx vite` in `packages/web-shell`): open any page, then in DevTools console run `performance.getEntriesByType('measure').length` twice ~15s apart. Before this PR the count grows ~16k/s unboundedly; after, it oscillates and never exceeds 16,384.

### Evidence (Before & After)

Before (dev build, 60s scroll soak over a 78MB session): renderer RSS 603→620→…→1453→1501MB, monotonic. After: 593→…→971→972→968MB, plateau. Measure entries before: 132,766 at t=6s → 296,280 at t=16s; after: oscillates in 1,632–15,449 over 70s on the session view.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

Reproduced and verified with real Chrome (headless, Playwright + CDP metrics) against a vite dev server proxying the live daemon, using a real 78MB session transcript.

## Risk & Scope

- Main risk or tradeoff: clearing the whole measure timeline truncates an in-progress DevTools Performance recording of React tracks (dev-only, inherent to the mitigation).
- Not validated / out of scope: Windows/Linux not tested (browser behavior is cross-platform; the guard runs identically). The fix breaks the measured growth ratchet; if dev crashes ever recur, the next suspect would be React dev owner stacks, which are out of scope here.
- Breaking changes / migration notes: none.

## Linked Issues

N/A — investigated from local crash reports; no tracking issue filed.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 Web Shell 页面修复一个 React 19 dev 模式的内存泄漏上界。dev 构建中 React 通过 `performance.measure()` 记录组件耗时,而浏览器的 user-timing 缓冲区会无界保留这些条目(在 Blink 侧,JS 堆不可见),空闲的 Web Shell dev 页面每秒产生约 1.6 万条。现有的内联 guard 只剥离了被结构化克隆的 `detail` 载荷,条目本身却永久累积。本 PR 将 guard 扩展为:对所有 React devtools track(不再限于 `Components ⚛`)剥离 `detail`,并且每累积 16,384 条 React measure 就调用 `performance.clearMeasures()` 清空时间线,使条目不再无界增长。生产构建不受影响:生产版 React 不会发送 devtools measure,guard 保持惰性。

## 为什么需要

长时间存活的 vite dev 标签页会导致 Chrome 渲染进程崩溃。8/19–8/23 期间一台维护者机器记录了 12 次 renderer 崩溃(`SIGABRT`,即 "Aw, Snap!"),全部发生在 vite dev server 源(`localhost:5173`),每次崩溃的 PartitionAlloc crash key `page-allocator-mapped-size ≈ 65GiB`——渲染进程地址空间池耗尽。daemon 提供的生产构建从未复现。用真实 78MB 会话 transcript 复现:dev 构建下滚动 60 秒 renderer RSS 从 603MB 单调涨到 1501MB 无平台期;修复后同样操作 RSS 在 593→971MB 后进入平台期,measure 条目数在 16,384 上限内振荡,而不是以每秒 1.6 万条无限增长。

## 审查者验证方式

1. 运行单元测试:`cd packages/web-shell && npx vitest run client/index-html.test.ts`——4 个测试全部通过,覆盖非 Components track 的 detail 剥离、周期性清理,以及非 React measure 既不被剥离也不计入预算。
2. 可选实测:在 vite dev server 上打开任意页面,DevTools 控制台间隔约 15 秒运行两次 `performance.getEntriesByType('measure').length`。修复前条目以每秒约 1.6 万无界增长;修复后振荡且永不超过 16,384。

</details>
