### PR TITLE
fix(core): support per-provider stream idle timeout

### DIFF
--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -317,6 +317,7 @@ Most local inference servers (vLLM, Ollama, LM Studio, etc.) provide an OpenAI-c
         "baseUrl": "http://localhost:11434/v1",
         "generationConfig": {
           "timeout": 300000,
+          "streamIdleTimeoutMs": 600000,
           "maxRetries": 1,
           "contextWindowSize": 32768,
           "samplingParams": {
@@ -357,6 +358,13 @@ Most local inference servers (vLLM, Ollama, LM Studio, etc.) provide an OpenAI-c
   }
 }
 ```
+
+For queued or slow local OpenAI-compatible servers, `streamIdleTimeoutMs`
+controls how long this model may stay silent between streamed chunks. It
+overrides the global `QWEN_STREAM_IDLE_TIMEOUT_MS` value for the selected
+provider entry; set it to `0` to disable the idle guard. The separate 15-minute
+stream lifetime cap still applies unless `QWEN_STREAM_MAX_LIFETIME_MS` is raised
+or disabled.
 
 For local servers that don't require authentication, you can use any placeholder value for the API key:
 

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -202,6 +202,7 @@ These settings are read from operator scopes only (User, System, and SystemDefau
   "model": {
     "generationConfig": {
       "timeout": 60000,
+      "streamIdleTimeoutMs": 300000,
       "contextWindowSize": 128000,
       "modalities": {
         "image": true
@@ -232,10 +233,10 @@ These settings are read from operator scopes only (User, System, and SystemDefau
 
 Two guards bound a streaming response, each accepting `0` to disable. Neither is implemented by the Anthropic/Gemini generators, which leave the drip-fed shape below unbounded.
 
-- `QWEN_STREAM_IDLE_TIMEOUT_MS` (default `240000`) bounds inactivity _between_ streamed chunks: a stream that goes silent for this long is aborted as a retryable `ETIMEDOUT`.
+- `streamIdleTimeoutMs` (default `240000`) bounds inactivity _between_ streamed chunks: a stream that goes silent for this long is aborted as a retryable `ETIMEDOUT`. For provider-backed models, set it under the matching `modelProviders[providerId][].generationConfig`; for runtime models, use `model.generationConfig`. An explicit model value takes precedence over `QWEN_STREAM_IDLE_TIMEOUT_MS`, and `0` disables the idle guard.
 - `QWEN_STREAM_MAX_LIFETIME_MS` (default `900000`) caps the _total_ upstream-wait time of one streaming response regardless of chunk flow — the bound a drip-fed stream that never completes cannot reset.
 
-These are **environment variables (or, for embedders, `ContentGeneratorConfig.streamIdleTimeoutMs` / `streamMaxLifetimeMs`) only — there is no settings.json key**; writing `"streamMaxLifetimeMs"` into settings.json has no effect. Upgrade notes: a deployment that previously set `QWEN_STREAM_IDLE_TIMEOUT_MS=0` — or passed `streamIdleTimeoutMs: 0` in `ContentGeneratorConfig` — to opt out of stream aborts now also needs `QWEN_STREAM_MAX_LIFETIME_MS=0` (or `streamMaxLifetimeMs: 0`) to keep that; and the 15-minute lifetime cap bounds even a stream whose idle timeout you raised above it (e.g. `QWEN_STREAM_IDLE_TIMEOUT_MS=1800000`) — raise the cap likewise, or set it to `0`, if you rely on a longer window.
+`streamMaxLifetimeMs` remains available only through `QWEN_STREAM_MAX_LIFETIME_MS` or, for embedders, `ContentGeneratorConfig.streamMaxLifetimeMs`; writing it into `settings.json` has no effect. The 15-minute lifetime cap still bounds a stream whose idle timeout you raise above it. Raise the lifetime environment variable likewise, or set it to `0`, if you rely on a longer window. Disabling `streamIdleTimeoutMs` alone does not disable this lifetime cap.
 
 **max_tokens (output token limit):**
 

--- a/packages/cli/src/config/settingsSchema.test.ts
+++ b/packages/cli/src/config/settingsSchema.test.ts
@@ -278,6 +278,21 @@ describe('SettingsSchema', () => {
       expect(model.maxToolCallsPerTurn.type).toBe('integer');
     });
 
+    it('should define streamIdleTimeoutMs as a bounded generation setting', () => {
+      const streamIdleTimeout =
+        getSettingsSchema().model.properties.generationConfig.properties
+          ?.streamIdleTimeoutMs;
+
+      expect(streamIdleTimeout).toMatchObject({
+        type: 'integer',
+        default: undefined,
+        minimum: 0,
+        maximum: 2_147_483_647,
+        requiresRestart: false,
+        showInDialog: false,
+      });
+    });
+
     it('should define stopHookBlockingCap schema override as a positive integer', () => {
       expect(
         getSettingsSchema().stopHookBlockingCap.jsonSchemaOverride,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1707,6 +1707,19 @@ const SETTINGS_SCHEMA = {
             parentKey: 'generationConfig',
             showInDialog: false,
           },
+          streamIdleTimeoutMs: {
+            type: 'integer',
+            label: 'Stream Idle Timeout',
+            category: 'Generation Configuration',
+            requiresRestart: false,
+            default: undefined as number | undefined,
+            description:
+              'Maximum inactivity between streamed chunks for OpenAI-compatible models, in milliseconds. Set to 0 to disable the idle guard. For provider-backed models, configure this field in the selected modelProviders entry.',
+            minimum: 0,
+            maximum: 2_147_483_647,
+            parentKey: 'generationConfig',
+            showInDialog: false,
+          },
           maxRetries: {
             type: 'number',
             label: 'Max Retries',

--- a/packages/core/src/models/constants.ts
+++ b/packages/core/src/models/constants.ts
@@ -21,6 +21,7 @@ type ContentGeneratorConfig =
 export const MODEL_GENERATION_CONFIG_FIELDS = [
   'samplingParams',
   'timeout',
+  'streamIdleTimeoutMs',
   'maxRetries',
   'retryInitialDelayMs',
   'retryMaxDelayMs',

--- a/packages/core/src/models/content-generator-config.test.ts
+++ b/packages/core/src/models/content-generator-config.test.ts
@@ -46,6 +46,7 @@ describe('buildAgentContentGeneratorConfig', () => {
     samplingParams: { temperature: 0.7, top_p: 0.9 },
     reasoning: { effort: 'high' as const },
     timeout: 30000,
+    streamIdleTimeoutMs: 300000,
     maxRetries: 3,
     contextWindowSize: 128000,
     extra_body: { custom: 'value' },
@@ -68,6 +69,7 @@ describe('buildAgentContentGeneratorConfig', () => {
       expect(result.samplingParams).toEqual({ temperature: 0.7, top_p: 0.9 });
       expect(result.reasoning).toEqual({ effort: 'high' });
       expect(result.timeout).toBe(30000);
+      expect(result.streamIdleTimeoutMs).toBe(300000);
       expect(result.maxRetries).toBe(3);
       expect(result.contextWindowSize).toBe(128000);
       expect(result.extra_body).toEqual({ custom: 'value' });
@@ -101,6 +103,7 @@ describe('buildAgentContentGeneratorConfig', () => {
       expect(result.samplingParams).toBeUndefined();
       expect(result.reasoning).toBeUndefined();
       expect(result.timeout).toBeUndefined();
+      expect(result.streamIdleTimeoutMs).toBeUndefined();
       expect(result.maxRetries).toBeUndefined();
       expect(result.contextWindowSize).toBeUndefined();
       expect(result.extra_body).toBeUndefined();
@@ -152,6 +155,7 @@ describe('buildAgentContentGeneratorConfig', () => {
       envKey: 'REGISTRY_API_KEY',
       generationConfig: {
         samplingParams: { temperature: 0.5 },
+        streamIdleTimeoutMs: 600000,
         contextWindowSize: 200000,
         reasoning: { effort: 'medium' as const },
       },
@@ -182,6 +186,7 @@ describe('buildAgentContentGeneratorConfig', () => {
       expect(result.apiKeyEnvKey).toBe('REGISTRY_API_KEY');
       // Registry generation config applied
       expect(result.samplingParams).toEqual({ temperature: 0.5 });
+      expect(result.streamIdleTimeoutMs).toBe(600000);
       expect(result.contextWindowSize).toBe(200000);
       expect(result.reasoning).toEqual({ effort: 'medium' });
       // Fields not in registry stay cleared (cross-provider)

--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -328,6 +328,7 @@ describe('modelConfigResolver', () => {
             apiKey: 'key',
             generationConfig: {
               timeout: 60000,
+              streamIdleTimeoutMs: 300000,
               maxRetries: 5,
               samplingParams: {
                 temperature: 0.7,
@@ -338,12 +339,14 @@ describe('modelConfigResolver', () => {
         });
 
         expect(result.config.timeout).toBe(60000);
+        expect(result.config.streamIdleTimeoutMs).toBe(300000);
         expect(result.config.maxRetries).toBe(5);
         expect(result.config.retryInitialDelayMs).toBeUndefined();
         expect(result.config.retryMaxDelayMs).toBeUndefined();
         expect(result.config.samplingParams?.temperature).toBe(0.7);
 
         expect(result.sources['timeout'].kind).toBe('settings');
+        expect(result.sources['streamIdleTimeoutMs'].kind).toBe('settings');
         expect(result.sources['samplingParams'].kind).toBe('settings');
       });
 
@@ -354,6 +357,7 @@ describe('modelConfigResolver', () => {
           settings: {
             generationConfig: {
               timeout: 30000,
+              streamIdleTimeoutMs: 300000,
               retryInitialDelayMs: 60_000,
               retryMaxDelayMs: 300_000,
             },
@@ -368,6 +372,7 @@ describe('modelConfigResolver', () => {
             baseUrl: 'https://api.example.com',
             generationConfig: {
               timeout: 60000,
+              streamIdleTimeoutMs: 0,
               retryInitialDelayMs: 3_000,
               retryMaxDelayMs: 30_000,
             },
@@ -375,9 +380,13 @@ describe('modelConfigResolver', () => {
         });
 
         expect(result.config.timeout).toBe(60000);
+        expect(result.config.streamIdleTimeoutMs).toBe(0);
         expect(result.config.retryInitialDelayMs).toBe(3_000);
         expect(result.config.retryMaxDelayMs).toBe(30_000);
         expect(result.sources['timeout'].kind).toBe('modelProviders');
+        expect(result.sources['streamIdleTimeoutMs'].kind).toBe(
+          'modelProviders',
+        );
         expect(result.sources['retryInitialDelayMs'].kind).toBe(
           'modelProviders',
         );

--- a/packages/core/src/models/modelRegistry.test.ts
+++ b/packages/core/src/models/modelRegistry.test.ts
@@ -150,6 +150,7 @@ describe('ModelRegistry', () => {
             name: 'GPT-4 Turbo',
             baseUrl: 'https://api.openai.com/v1',
             generationConfig: {
+              streamIdleTimeoutMs: 600000,
               samplingParams: {
                 temperature: 0.8,
                 max_tokens: 4096,
@@ -176,6 +177,7 @@ describe('ModelRegistry', () => {
 
       expect(model?.generationConfig.samplingParams?.temperature).toBe(0.8);
       expect(model?.generationConfig.samplingParams?.max_tokens).toBe(4096);
+      expect(model?.generationConfig.streamIdleTimeoutMs).toBe(600000);
       // No defaults are applied - only the configured values are present
       expect(model?.generationConfig.samplingParams?.top_p).toBeUndefined();
       expect(model?.generationConfig.timeout).toBeUndefined();

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -31,6 +31,7 @@ export type ModelGenerationConfig = Pick<
   ContentGeneratorConfig,
   | 'samplingParams'
   | 'timeout'
+  | 'streamIdleTimeoutMs'
   | 'maxRetries'
   | 'retryInitialDelayMs'
   | 'retryMaxDelayMs'

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -763,6 +763,12 @@
               "description": "Request timeout in milliseconds.",
               "type": "number"
             },
+            "streamIdleTimeoutMs": {
+              "description": "Maximum inactivity between streamed chunks for OpenAI-compatible models, in milliseconds. Set to 0 to disable the idle guard. For provider-backed models, configure this field in the selected modelProviders entry.",
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 2147483647
+            },
             "maxRetries": {
               "description": "Maximum number of retries for failed requests.",
               "type": "number"


### PR DESCRIPTION
## What this PR does

This exposes `streamIdleTimeoutMs` as a model-scoped generation setting, including `modelProviders[].generationConfig`, and carries it through model registry resolution and agent configuration. It also adds the generated settings schema entry, regression coverage for provider precedence and provider switching, and documentation for the idle/lifetime guard interaction.

## Why it's needed

The global `QWEN_STREAM_IDLE_TIMEOUT_MS` variable is too broad when one Qwen Code configuration mixes responsive cloud providers with a queued local OpenAI-compatible server. Local queue wait plus prompt prefill can legitimately produce several minutes of SSE silence, while repeated watchdog retries re-enter the queue and add load. A per-provider setting keeps the stricter global default for cloud routes without making a slow local route unusable.

## Reviewer Test Plan

### How to verify

1. Configure an OpenAI-compatible provider with `generationConfig.streamIdleTimeoutMs: 1000` and set the global `QWEN_STREAM_IDLE_TIMEOUT_MS=100`.
2. Point it at an SSE test endpoint that sends one role chunk, waits 350 ms, then sends content and `[DONE]`.
3. Confirm the provider-backed request completes. Remove the provider field and confirm the same request aborts after roughly 100 ms.
4. Run `npx vitest run src/models/modelConfigResolver.test.ts src/models/modelRegistry.test.ts src/models/content-generator-config.test.ts` from `packages/core` (153 passed), `npx vitest run src/core/openaiContentGenerator/pipeline.test.ts -t "stream inactivity timeout"` from `packages/core` (34 passed), and `npx vitest run src/config/settingsSchema.test.ts` from `packages/cli` (43 passed).
5. Run `npm run preflight` with the repository's Node 22 toolchain. Clean/install, formatting, lint, build, and typecheck pass. The parallel full-test stage reaches an existing `AuthDialog` MiniMax keyboard-navigation failure; it reproduces identically on a clean detached worktree at base commit `431a0bd`. The original server failure passes in the three-file rerun, the two transient server assertions from that rerun pass 2/2 when targeted, and `workspace-agents.test.ts` passes 49/49.

### Evidence (Before & After)

N/A — no visual UI change. In the local mock-SSE probe, the control configuration exited 1 with `No stream activity for 100ms after 1 chunks`; the same request with the provider override exited 0 and printed `provider timeout works`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS arm64, Node.js v22.22.2, local source build, and a mock OpenAI-compatible SSE endpoint.

## Risk & Scope

- Main risk or tradeoff: An explicit model value now overrides the global idle-timeout environment variable for that model; validation limits it to an integer from `0` through the platform timer maximum.
- Not validated / out of scope: Anthropic and Gemini generators remain unchanged; treating raw SSE comments as activity and making the total stream lifetime provider-specific are out of scope.
- Breaking changes / migration notes: None. Existing configurations continue to use the environment value or the 240-second default when the new field is absent; `0` disables only the idle guard, not the separate total-lifetime guard.

## Linked Issues

Addresses the per-provider follow-up in #5975.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 将 `streamIdleTimeoutMs` 暴露为模型级生成配置，包括 `modelProviders[].generationConfig`，并让该字段完整经过模型注册表解析和 Agent 配置链路。同时补充生成的 settings schema、provider 优先级与切换行为的回归测试，以及空闲守卫和总生命周期守卫交互关系的文档。

## 为什么需要

当同一份 Qwen Code 配置同时包含响应较快的云端 provider 和需要排队的本地 OpenAI-compatible 服务时，全局 `QWEN_STREAM_IDLE_TIMEOUT_MS` 过于粗粒度。本地服务的排队等待加上长提示词 prefill 可能合理地产生数分钟 SSE 静默，而 watchdog 的重复重试会重新进入队列并增加负载。按 provider 配置后，云端路由仍可保留更严格的全局默认值，同时允许较慢的本地路由正常工作。

## 审阅者测试计划

### 验证方法

1. 配置一个 OpenAI-compatible provider，设置 `generationConfig.streamIdleTimeoutMs: 1000`，同时设置全局 `QWEN_STREAM_IDLE_TIMEOUT_MS=100`。
2. 将其指向一个 SSE 测试端点：先发送一个 role chunk，静默 350 ms，再发送内容和 `[DONE]`。
3. 确认带 provider 配置的请求可以完成；删除该 provider 字段后，确认同一请求在约 100 ms 后中止。
4. 在 `packages/core` 运行 `npx vitest run src/models/modelConfigResolver.test.ts src/models/modelRegistry.test.ts src/models/content-generator-config.test.ts`（153 项通过），在 `packages/core` 运行 `npx vitest run src/core/openaiContentGenerator/pipeline.test.ts -t "stream inactivity timeout"`（34 项通过），并在 `packages/cli` 运行 `npx vitest run src/config/settingsSchema.test.ts`（43 项通过）。
5. 使用仓库指定的 Node 22 工具链运行 `npm run preflight`。清理/安装、格式化、lint、构建和类型检查均通过。并行全量测试阶段命中一条现有的 `AuthDialog` MiniMax 键盘导航失败；该失败可在基准提交 `431a0bd` 的干净 detached worktree 中完全一致地复现。原始 server 失败在三文件复跑中通过，该次复跑新增的两条瞬时 server 失败在定向运行时 2/2 通过，`workspace-agents.test.ts` 也以 49/49 通过。

### 前后证据

N/A — 没有可视化 UI 变化。在本地 mock SSE 探针中，对照配置以退出码 1 结束，并输出 `No stream activity for 100ms after 1 chunks`；加入 provider 覆盖后，同一请求以退出码 0 结束并输出 `provider timeout works`。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS     |  ✅  |
|    🪟 Windows   | N/A  |
|     🐧 Linux    | N/A  |

### 环境（可选）

macOS arm64、Node.js v22.22.2、本地源码构建，以及 mock OpenAI-compatible SSE 端点。

## 风险与范围

- 主要风险或权衡：显式模型配置现在会覆盖该模型的全局空闲超时环境变量；schema 将其限制为从 `0` 到平台定时器上限的整数。
- 未验证 / 范围之外：Anthropic 和 Gemini generator 保持不变；将原始 SSE comment 视为活动、让总流生命周期按 provider 配置不在本 PR 范围内。
- 破坏性变更 / 迁移说明：无。未配置新字段时，现有配置继续使用环境变量值或 240 秒默认值；`0` 只禁用空闲守卫，不会禁用独立的总生命周期守卫。

## 关联 Issue

处理 #5975 中按 provider 配置的后续需求。

</details>
