### PR TITLE
fix(cli): detect overlapping review comment ranges

### DIFF
--- a/packages/cli/src/commands/review/presubmit.test.ts
+++ b/packages/cli/src/commands/review/presubmit.test.ts
@@ -405,7 +405,12 @@ describe('presubmitCommand', () => {
   // `id?` entry type covers the carried-id (#9208) tests unchanged.
   async function presubmitWithComments(
     comments: Array<Record<string, unknown>>,
-    newFindings: Array<{ path: string; line: number; id?: string }>,
+    newFindings: Array<{
+      path: string;
+      line: number;
+      start_line?: number;
+      id?: string;
+    }>,
   ) {
     ghApiAllMock.mockReturnValue(comments);
     ghApiMock.mockReturnValue(null);
@@ -828,6 +833,62 @@ describe('presubmitCommand', () => {
       expect(result.existingComments.total).toBe(1);
       expect(result.existingComments.byBucket.overlap).toBe(1);
       expect(result.blockOnExistingComments).toBe(true);
+    });
+
+    it('classifies a comment inside a new finding range as overlap', async () => {
+      const result = await presubmitWithComments(
+        [
+          {
+            id: 3,
+            body: '**[Critical]** existing finding',
+            path: 'a.ts',
+            line: 15,
+            commit_id: 'abc123',
+            user: { login: 'qwen-code-ci-bot' },
+          },
+        ],
+        [{ path: 'a.ts', start_line: 12, line: 18 }],
+      );
+      expect(result.existingComments.byBucket.overlap).toBe(1);
+      expect(result.existingComments.byBucket.noConflict).toBe(0);
+    });
+
+    it('classifies intersecting existing and new finding ranges as overlap', async () => {
+      const result = await presubmitWithComments(
+        [
+          {
+            id: 4,
+            body: '**[Critical]** existing finding',
+            path: 'a.ts',
+            start_line: 8,
+            line: 14,
+            commit_id: 'abc123',
+            user: { login: 'qwen-code-ci-bot' },
+          },
+        ],
+        [{ path: 'a.ts', start_line: 12, line: 18 }],
+      );
+      expect(result.existingComments.byBucket.overlap).toBe(1);
+      expect(result.existingComments.byBucket.noConflict).toBe(0);
+    });
+
+    it('keeps disjoint ranges in noConflict', async () => {
+      const result = await presubmitWithComments(
+        [
+          {
+            id: 5,
+            body: '**[Critical]** existing finding',
+            path: 'a.ts',
+            start_line: 4,
+            line: 8,
+            commit_id: 'abc123',
+            user: { login: 'qwen-code-ci-bot' },
+          },
+        ],
+        [{ path: 'a.ts', start_line: 12, line: 18 }],
+      );
+      expect(result.existingComments.byBucket.overlap).toBe(0);
+      expect(result.existingComments.byBucket.noConflict).toBe(1);
     });
 
     it('classifies the shape attribution-off actually posts — markerless body, trailing marker, reviewing account', async () => {
@@ -1727,6 +1788,10 @@ describe('parseFindingsFile (via mocked fs)', () => {
     ['{"path":"a.ts"}', null], // object, not array
     ['[{"line":5}]', null], // entry without a string path → reject WHOLE file
     ['[{"path":"a.ts","line":5}]', [{ path: 'a.ts', line: 5 }]],
+    [
+      '[{"path":"a.ts","start_line":3,"line":5}]',
+      [{ path: 'a.ts', startLine: 3, line: 5 }],
+    ],
     ['[{"path":"a.ts"}]', [{ path: 'a.ts', line: 0 }]], // missing line → 0
     // Carried ledger id for the re-post exemption (#9208); a present-but-
     // non-string id rejects the WHOLE file, same fail-safe as `path`.

--- a/packages/cli/src/commands/review/presubmit.ts
+++ b/packages/cli/src/commands/review/presubmit.ts
@@ -50,6 +50,7 @@ import {
 interface FindingAnchor {
   path: string;
   line: number;
+  startLine?: number;
   /**
    * Ledger id (`R<round>-<n>`) — carried-forward findings ONLY. The
    * orchestrator omits it on fresh findings of the current round: a fresh id
@@ -126,6 +127,7 @@ interface RawComment {
   body?: string;
   path?: string;
   line?: number;
+  start_line?: number;
   commit_id?: string;
   in_reply_to_id?: number;
   user?: { login?: string };
@@ -238,7 +240,12 @@ export function parseFindingsFile(path: string): FindingAnchor[] | null {
     ) {
       return null;
     }
-    const e = entry as { path: string; line?: unknown; id?: unknown };
+    const e = entry as {
+      path: string;
+      line?: unknown;
+      start_line?: unknown;
+      id?: unknown;
+    };
     // Same fail-safe as `path`: an `id` of the wrong type or shape is a
     // malformed file, and silently ignoring it would let a carried re-post
     // read as a fresh duplicate at the very location it belongs (a typo'd
@@ -256,6 +263,7 @@ export function parseFindingsFile(path: string): FindingAnchor[] | null {
     out.push({
       path: e.path,
       line: typeof e.line === 'number' ? e.line : 0,
+      ...(typeof e.start_line === 'number' ? { startLine: e.start_line } : {}),
       ...(typeof e.id === 'string' ? { id: e.id } : {}),
     });
   }
@@ -641,7 +649,6 @@ function classifyExistingComments(
     CommentSummary[]
   > = { stale: [], resolved: [], overlap: [], repost: [], noConflict: [] };
 
-  const newFindingKeys = new Set(newFindings.map((f) => `${f.path}:${f.line}`));
   // Location → carried ids of the findings anchored there. Only findings with
   // an id participate, and the orchestrator writes ids ONLY on carried
   // findings (SKILL.md — the findings file): a fresh `R<this-round>-<n>`
@@ -688,6 +695,20 @@ function classifyExistingComments(
   }
 
   for (const c of qwenComments) {
+    const commentLine = c.line ?? 0;
+    const commentStartLine = c.start_line ?? commentLine;
+    const commentRangeStart = Math.min(commentStartLine, commentLine);
+    const commentRangeEnd = Math.max(commentStartLine, commentLine);
+    const overlapsNewFinding = newFindings.some((finding) => {
+      if (finding.path !== (c.path ?? '')) return false;
+      const findingStartLine = finding.startLine ?? finding.line;
+      const findingRangeStart = Math.min(findingStartLine, finding.line);
+      const findingRangeEnd = Math.max(findingStartLine, finding.line);
+      return (
+        findingRangeStart <= commentRangeEnd &&
+        commentRangeStart <= findingRangeEnd
+      );
+    });
     const summary: CommentSummary = {
       id: c.id,
       path: c.path ?? '',
@@ -701,13 +722,13 @@ function classifyExistingComments(
       buckets.stale.push(summary);
     } else if (repliedToIds.has(c.id)) {
       buckets.resolved.push(summary);
-    } else if (newFindingKeys.has(`${c.path}:${c.line}`)) {
-      // Overlap stays location-based: a same-line finding with a DIFFERENT
-      // claim is still dropped (the drop log now names this comment so the
-      // false positive is visible — #9208). Repost is the additional, id-based
-      // bucket: a Step 6 ledger re-post lands on the original thread's line by
-      // construction and carries the original id in its prefix, so an id match
-      // marks the re-post target and exempts that finding from the drop.
+    } else if (overlapsNewFinding) {
+      // Overlap stays location-based: an intersecting same-file finding with
+      // a DIFFERENT claim is still dropped (the drop log names this comment so
+      // the false positive is visible — #9208). Repost remains exact-line and
+      // id-based: a Step 6 ledger re-post lands on the original thread's line
+      // by construction and carries the original id in its prefix, so an id
+      // match marks the re-post target and exempts that finding from the drop.
       buckets.overlap.push(summary);
       const wantedIds = carriedIdsByLocation.get(`${c.path}:${c.line}`);
       // Ledger ids are per-account — two reviewers of the same PR keep two


### PR DESCRIPTION
## What this PR does

Preserves the start of multi-line review findings and classifies existing inline comments by same-file closed-interval intersection instead of comparing only their ending lines. Exact single-line behavior remains unchanged, and carried-finding re-post detection remains tied to the exact original anchor.

## Why it's needed

`/review presubmit` could report `noConflict` when an existing comment sat inside a newly drafted multi-line finding. That allowed a duplicate finding to pass the deterministic overlap gate and forced reviewers to detect it manually.

## Reviewer Test Plan

### How to verify

1. Run `cd packages/cli && npx vitest run src/commands/review/presubmit.test.ts`.
2. Confirm all 109 tests pass.
3. Confirm the regression cases classify a point inside a new range and two partially intersecting ranges as `overlap`, while disjoint ranges remain `noConflict`.
4. Confirm the existing carried-id and re-post tests remain green, showing that range overlap does not broaden thread reuse.

### Evidence (Before & After)

Before: the focused regression produced two failures because a comment at line 15 did not match a new finding spanning lines 12–18, and partially intersecting ranges were also reported as `noConflict`.

After: the complete presubmit test file passes 109/109, including point-inside-range, partial intersection, disjoint control, parsing, exact-line, and carried-id/re-post coverage. An independent test-engineer run passed the 19 parsing/range-focused tests and `git diff --check`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Windows 11, Node.js 22.19.0, npm 10.x, Vitest 3.2.7. Repository-wide build and typecheck passed; focused Prettier and ESLint checks passed.

## Risk & Scope

- Main risk or tradeoff: same-file range intersection intentionally blocks a new finding when any existing review-comment range intersects it, matching the deterministic location-based dedup policy.
- Not validated / out of scope: semantic body matching, full-body report rendering, and the optional nearby-comment bucket remain tracked by #9219.
- Breaking changes / migration notes: none.

## Linked Issues

Partially addresses #9219.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

保留多行 review finding 的起始行，并将既有行内评论的冲突判定从“仅比较结束行”改为“同一文件内闭区间相交”。单行行为保持不变，carried finding 的 re-post 识别仍严格绑定原始精确锚点。

## 为什么需要它

当既有评论位于新起草的多行 finding 范围内部时，`/review presubmit` 可能错误报告 `noConflict`。这会让重复 finding 穿过确定性 overlap gate，只能依赖 reviewer 手工发现。

## Reviewer Test Plan

### 如何验证

1. 运行 `cd packages/cli && npx vitest run src/commands/review/presubmit.test.ts`。
2. 确认 109 个测试全部通过。
3. 确认回归用例将“点位于新区间内部”和“两个区间部分相交”归类为 `overlap`，同时不相交区间仍归类为 `noConflict`。
4. 确认既有 carried-id 与 re-post 测试保持通过，证明范围冲突不会放宽 thread 复用。

### 修改前后证据

修改前：定向回归产生两个失败；位于第 15 行的评论无法匹配第 12–18 行的新 finding，部分相交的区间也被报告为 `noConflict`。

修改后：完整 presubmit 测试文件 109/109 通过，覆盖范围内点、部分相交、不相交对照、解析、精确单行以及 carried-id/re-post。独立 test-engineer 运行的 19 个解析/范围相关测试与 `git diff --check` 也通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  ⚠️  |

### 环境

Windows 11、Node.js 22.19.0、npm 10.x、Vitest 3.2.7。仓库级 build 与 typecheck 通过；定向 Prettier 与 ESLint 检查通过。

## 风险与范围

- 主要风险或取舍：同一文件内区间相交会有意阻止新的 finding，这与现有基于位置的确定性去重策略一致。
- 未验证 / 范围之外：语义正文匹配、报告全文渲染以及可选的邻近评论 bucket 仍由 #9219 跟踪。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

部分解决 #9219，不自动关闭该跟踪 Issue。

</details>
