### PR TITLE
fix(cli): keep Windows IME composition readable

### DIFF
--- a/packages/cli/src/ui/utils/software-cursor.test.ts
+++ b/packages/cli/src/ui/utils/software-cursor.test.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import chalk from 'chalk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getSoftwareCursorBackground,
   renderSoftwareCursor,
@@ -12,6 +13,17 @@ import {
 import { themeManager } from '../themes/theme-manager.js';
 
 describe('renderSoftwareCursor', () => {
+  const originalChalkLevel = chalk.level;
+
+  beforeEach(() => {
+    chalk.level = 3;
+  });
+
+  afterEach(() => {
+    chalk.level = originalChalkLevel;
+    vi.restoreAllMocks();
+  });
+
   it('uses a dark cursor background on light themes', () => {
     expect(getSoftwareCursorBackground('#FAFAFA')).toBe('#3A3A3A');
   });
@@ -30,9 +42,20 @@ describe('renderSoftwareCursor', () => {
   });
 
   it('uses an explicit background instead of reverse-video styling', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
     const rendered = renderSoftwareCursor('x');
 
     expect(rendered).toContain('x');
+    expect(rendered).toContain('\u001b[48;2;');
+    expect(rendered).not.toContain('\u001b[7m');
+  });
+
+  it('keeps the Windows IME composition cell free of a fixed background', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    const rendered = renderSoftwareCursor('x');
+
+    expect(rendered).toBe('\u001b[4mx\u001b[24m');
+    expect(rendered).not.toContain('\u001b[48;');
     expect(rendered).not.toContain('\u001b[7m');
   });
 
@@ -43,7 +66,8 @@ describe('renderSoftwareCursor', () => {
   });
 
   it('renders an empty cursor cell as a space', () => {
-    expect(renderSoftwareCursor('')).toContain(' ');
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    expect(renderSoftwareCursor('')).toBe('\u001b[4m \u001b[24m');
   });
 });
 

--- a/packages/cli/src/ui/utils/software-cursor.ts
+++ b/packages/cli/src/ui/utils/software-cursor.ts
@@ -67,5 +67,8 @@ export function getSoftwareCursorBackground(
 }
 
 export function renderSoftwareCursor(text: string): string {
-  return chalk.bgHex(getSoftwareCursorBackground())(text || ' ');
+  const cursorText = text || ' ';
+  return process.platform === 'win32'
+    ? chalk.underline(cursorText)
+    : chalk.bgHex(getSoftwareCursorBackground())(cursorText);
 }


### PR DESCRIPTION
## What this PR does

On Windows, render the software cursor as an underline without painting a fixed background over the active input cell. Other platforms keep the existing explicit high-contrast cursor background.

Add regression coverage for the Windows ANSI sequence, an empty cursor cell, and the unchanged non-Windows behavior.

## Why it's needed

Microsoft Pinyin shows active composition text at the same terminal cell as the CLI software cursor. The fixed gray cursor background can make that composition text nearly invisible in Windows Terminal, so users cannot reliably see the pinyin they are entering.

## Reviewer Test Plan

### How to verify

In Windows Terminal with Microsoft Pinyin enabled, start the development CLI and enter Chinese text at the prompt. Confirm that the active composition cell remains readable and is marked by an underline without a solid cursor background. On macOS or Linux, confirm that the software cursor still uses its explicit contrasting background.

Run the focused software-cursor and text-input component tests, then run the repository build and typecheck. All should pass.

### Evidence (Before & After)

Before: the Windows cursor emitted a fixed RGB background sequence such as `ESC[48;2;212;212;212m`, which could paint over the low-contrast Microsoft Pinyin composition text.

After: the Windows cursor emits `ESC[4m…ESC[24m` and no background, reverse-video, or foreground-reset sequence. The targeted test suite passes with 239 tests passed and 1 skipped, and the full build and typecheck pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Windows host, Node.js 22 workspace, automated ANSI rendering and CLI component tests.

## Risk & Scope

- Main risk or tradeoff: The Windows software cursor is less block-like, but it remains visible as an underline and no longer obscures IME composition text.
- Not validated / out of scope: Live Microsoft Pinyin composition was not manually exercised; the emitted Windows ANSI sequence and affected input components were verified automatically. Terminal behavior outside Windows is unchanged by implementation and covered through the non-Windows branch test.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #8625

Related to #9666

<details>
<summary>中文说明</summary>

## 本 PR 的改动

在 Windows 上，软件光标改为下划线显示，不再为当前输入单元格绘制固定背景。其他平台继续保留现有的显式高对比度光标背景。

新增回归测试，覆盖 Windows ANSI 序列、空白光标单元格，以及保持不变的非 Windows 行为。

## 为什么需要此改动

微软拼音会在 CLI 软件光标所在的同一个终端单元格中显示正在组合的文本。固定的灰色光标背景可能使 Windows Terminal 中的拼音组合文本几乎不可见，导致用户无法可靠地看清正在输入的拼音。

## 审阅者测试计划

### 验证方法

在启用微软拼音的 Windows Terminal 中启动开发版 CLI，并在提示符处输入中文。确认当前组合单元格的文字保持清晰可读，以下划线标记且没有实心光标背景。在 macOS 或 Linux 上，确认软件光标仍使用显式的对比背景。

运行聚焦的软件光标和文本输入组件测试，然后运行仓库 build 和 typecheck；所有检查都应通过。

### 证据（修复前与修复后）

修复前：Windows 光标会发出类似 `ESC[48;2;212;212;212m` 的固定 RGB 背景序列，可能覆盖低对比度的微软拼音组合文本。

修复后：Windows 光标发出 `ESC[4m…ESC[24m`，且不包含背景、反显或前景色重置序列。针对性测试共 239 项通过、1 项跳过，全仓 build 和 typecheck 均通过。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ⚠️  |
|   🪟 Windows     |  ✅  |
|     🐧 Linux     |  ⚠️  |

### 环境（可选）

Windows 宿主机、Node.js 22 工作区，执行了自动化 ANSI 渲染测试和 CLI 组件测试。

## 风险与范围

- 主要风险或取舍：Windows 软件光标不再像块状光标那样醒目，但仍可以通过下划线识别，并且不会再遮挡 IME 组合文本。
- 未验证或超出范围：未手动操作真实的微软拼音组合输入；已自动验证 Windows 输出的 ANSI 序列和受影响的输入组件。Windows 之外的终端行为在实现中保持不变，并由非 Windows 分支测试覆盖。
- 破坏性变更或迁移说明：无。

## 关联 Issue

修复 #8625

关联 #9666

</details>
