### PR TITLE
chore(ci): refresh the core issue-owner pool

### DIFF
--- a/.github/issue-owners.json
+++ b/.github/issue-owners.json
@@ -15,7 +15,6 @@
       "labels": ["category/core", "scope/core"],
       "owners": [
         "wenshao",
-        "tanzhenxin",
         "yiliang114",
         "LaZzyMan",
         "doudouOUC",
@@ -25,7 +24,11 @@
         "chiga0",
         "qqqys",
         "ytahdn",
-        "BenGuanRan"
+        "BenGuanRan",
+        "DragonnZhang",
+        "callmeYe",
+        "zjunothing",
+        "ZijianZhang989"
       ]
     }
   ]


### PR DESCRIPTION
## What this PR does

Refreshes the owner pool of the `core` area in the label-driven issue assignment map: removes `@tanzhenxin` and adds four collaborators with push access who are actively contributing to `packages/core` — `@DragonnZhang`, `@callmeYe`, `@zjunothing`, and `@ZijianZhang989`. Nothing else changes: the trigger policy (`need-discussion` + a core label), the skip labels, and the assignment algorithm (lowest open-issue load, rotation on ties) all stay as they are.

## Why it's needed

The assignment workflow introduced in #8668 is running healthy — every label event triggers it, and issues carrying `need-discussion` plus a core label are being assigned automatically. But the pool it draws from no longer matches who actually works on core. Over the last 90 days (merged PRs / file touches under `packages/core`):

| Candidate | Merged PRs | Core touches | Status |
|---|---:|---:|---|
| @DragonnZhang | 99 (repo-wide #1) | 50 | added |
| @callmeYe | 47 | 61 | added |
| @zjunothing | 51 | 37 | added |
| @ZijianZhang989 | 29 | memory/compression/agent-view; already hand-assigned #7040, #6383 | added |
| @tanzhenxin | — | — | removed per maintainer request |

The pool currently holds 12 owners, but load is counted across all open assigned issues repo-wide, so several owners carry 30–47 open issues while highly active core contributors sit outside the pool. Widening the pool spreads the rotation and keeps new core issues from piling onto the single lowest-loaded owner. All four additions already have push access (verified against the collaborator API), and the assignment script re-checks permissions before every write, so a stale entry can never grant an assignment.

Follow-ups deliberately out of scope: backfilling the ~11 pre-existing unassigned core issues (handled post-merge via the existing `workflow_dispatch` entry point with `dry_run=false`), and any CODEOWNERS change (the merge gate stays untouched).

## Reviewer Test Plan

### How to verify

The change is a pure data edit to the owner map. Confirm the four added logins have push access (`gh api repos/QwenLM/qwen-code/collaborators/{login}/permission`), and run the assignment script's guard suite, which validates the map's shape and the pick/skip policy: `node --test .github/scripts/assign-issue-owner.test.mjs` — 31 tests, all passing. After merge, a `workflow_dispatch` run against any open core issue with `dry_run=true` should report an assignee drawn from the new 15-entry pool.

### Evidence (Before & After)

N/A (CI configuration change, no user-visible behaviour).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests only (`node --test`).

## Risk & Scope

- Main risk or tradeoff: the four new owners become eligible for automatic issue assignment immediately; their current open-issue load is low, so early assignments will skew toward them until loads balance out — this is the intended rotation behaviour.
- Not validated / out of scope: backfill of existing unassigned core issues (post-merge dispatch); CODEOWNERS and the `require_code_owner_review` ruleset are untouched.
- Breaking changes / migration notes: none — the map schema is unchanged.

## Linked Issues

Follow-up to #8668.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

刷新 label 驱动 issue 自动分配地图中 `core` 领域的 owner 池：移除 `@tanzhenxin`，新增四位拥有 push 权限且持续在 `packages/core` 贡献的协作者 —— `@DragonnZhang`、`@callmeYe`、`@zjunothing`、`@ZijianZhang989`。其余全部不变：触发策略（`need-discussion` + core 标签）、跳过标签、分配算法（负载最低优先、同负载按编号轮转）都保持原样。

## 为什么需要

#8668 引入的自动分配工作流运转健康 —— 每次标签事件都会触发，带 `need-discussion` 和 core 标签的 issue 会被自动分配。但候选池已经和实际在 core 上工作的人不匹配了。近 90 天数据（merged PR 数 / `packages/core` 下的文件触碰数）：

| 候选 | Merged PR | Core 触碰 | 处理 |
|---|---:|---:|---|
| @DragonnZhang | 99（全仓第一） | 50 | 新增 |
| @callmeYe | 47 | 61 | 新增 |
| @zjunothing | 51 | 37 | 新增 |
| @ZijianZhang989 | 29 | memory/compression/agent-view；已被手工分配 #7040、#6383 | 新增 |
| @tanzhenxin | — | — | 按 maintainer 要求移除 |

池子目前有 12 位 owner，但负载按全仓 open assigned issue 统计，几位 owner 已背了 30–47 个 open issue，而高度活跃的 core 贡献者却在池外。扩大池子能让轮转更均匀，避免新的 core issue 全部堆到唯一负载最低的 owner 身上。四位新增者均已有 push 权限（已对照协作者 API 核实），且分配脚本在每次写入前都会重新校验权限，过期条目不可能获得分配。

刻意不在本 PR 范围内的后续事项：回填约 11 个存量未分配的 core issue（合并后通过现有 `workflow_dispatch` 入口以 `dry_run=false` 处理）；以及任何 CODEOWNERS 变更（合并门禁保持不动）。

## Reviewer 测试计划

### 如何验证

本改动是对 owner 地图的纯数据编辑。确认四个新增 login 拥有 push 权限（`gh api repos/QwenLM/qwen-code/collaborators/{login}/permission`），并运行分配脚本的守卫测试套件（校验地图结构与选取/跳过策略）：`node --test .github/scripts/assign-issue-owner.test.mjs` —— 31 个测试全部通过。合并后，对任意一个带 core 标签的 open issue 以 `dry_run=true` 触发 `workflow_dispatch`，应报告从新的 15 人池中选出的 assignee。

### 前后对比证据

N/A（CI 配置变更，无用户可见行为）。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

仅单元测试（`node --test`）。

## 风险与范围

- 主要风险或权衡：四位新 owner 会立即进入自动分配候选；他们当前 open issue 负载较低，早期分配会偏向他们，直到负载拉平 —— 这正是轮转机制的预期行为。
- 未验证 / 不在范围内：存量未分配 core issue 的回填（合并后 dispatch 处理）；CODEOWNERS 与 `require_code_owner_review` ruleset 保持不动。
- 破坏性变更 / 迁移说明：无 —— 地图 schema 未变。

## 关联 Issue

#8668 的后续。

</details>
