### PR TITLE
fix(core): Normalize both sides of the session title echo comparison

### DIFF
--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -12,7 +12,11 @@ import {
   SYSTEM_REMINDER_CLOSE,
   SYSTEM_REMINDER_OPEN,
 } from '../utils/environmentContext.js';
-import { sanitizeTitle, tryGenerateSessionTitle } from './sessionTitle.js';
+import {
+  normalizeForEchoCompare,
+  sanitizeTitle,
+  tryGenerateSessionTitle,
+} from './sessionTitle.js';
 
 interface MockOptions {
   fastModel?: string | undefined;
@@ -698,5 +702,31 @@ describe('sanitizeTitle', () => {
     // High surrogate must not linger on its own.
     expect(sanitized).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
     expect(sanitized.length).toBeLessThanOrEqual(200);
+  });
+});
+
+describe('normalizeForEchoCompare', () => {
+  it('normalizes both sides of the echo comparison identically (#9772)', () => {
+    // An example with edge punctuation must compare equal to the echo that
+    // sanitizeTitle strips that punctuation off — otherwise the guard
+    // silently misses it.
+    expect(normalizeForEchoCompare('Fix CI!')).toBe(
+      normalizeForEchoCompare('Fix CI'),
+    );
+    expect(normalizeForEchoCompare('"Fix CI!"')).toBe(
+      normalizeForEchoCompare('fix ci'),
+    );
+    expect(normalizeForEchoCompare('重构鉴权！')).toBe(
+      normalizeForEchoCompare('重构鉴权'),
+    );
+  });
+
+  it('keeps interior punctuation so distinct titles stay distinct', () => {
+    expect(normalizeForEchoCompare('(WIP) Fix build')).not.toBe(
+      normalizeForEchoCompare('WIP Fix build'.toLowerCase()),
+    );
+    expect(normalizeForEchoCompare('Fix login button styling')).not.toBe(
+      normalizeForEchoCompare('Fix login button on mobile'),
+    );
   });
 });

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -239,23 +239,31 @@ export function sanitizeTitle(s: string): string {
  * that merely resembles an example still passes. Also catches the prompt's
  * "Bad (wrong case)" variant of the first example.
  *
- * Wrapper characters are stripped for the comparison only: `sanitizeTitle`
- * keeps ASCII/full-width brackets because real titles use them (e.g.
- * "(WIP) Fix build"), but `(Fix login button on mobile)` is the same canned
- * echo as the bare example and must not slip past the guard. The strip is
- * Unicode-aware (any leading/trailing non-letter/non-digit run) so the next
- * wrapper family — `["..."]`, `<...>`, `«...»` — cannot bypass it by
- * falling outside an enumerated character class.
+ * Both sides of the comparison go through `normalizeForEchoCompare`, so an
+ * example carrying edge punctuation (e.g. "Fix CI!") cannot slip past the
+ * guard just because `sanitizeTitle` strips that punctuation off the
+ * candidate (#9772).
  */
 function isPromptExampleEcho(title: string): boolean {
-  const normalized = title
+  const normalized = normalizeForEchoCompare(title);
+  return TITLE_PROMPT_EXAMPLE_TITLES.some(
+    (example) => normalizeForEchoCompare(example) === normalized,
+  );
+}
+
+/**
+ * Normal form for echo comparison: trimmed, lowercased, with leading/trailing
+ * runs of non-letter/non-digit characters stripped. The strip is Unicode-aware
+ * so no wrapper family — `(...)`, `["..."]`, `<...>`, `«...»` — can bypass it
+ * by falling outside an enumerated character class. Comparison-only: the title
+ * shown to the user is never rewritten by it. Exported for unit tests.
+ */
+export function normalizeForEchoCompare(s: string): string {
+  return s
     .trim()
     .toLowerCase()
     .replace(/^[^\p{L}\p{N}]+/u, '')
     .replace(/[^\p{L}\p{N}]+$/u, '');
-  return TITLE_PROMPT_EXAMPLE_TITLES.some(
-    (example) => example.toLowerCase() === normalized,
-  );
 }
 
 /**


### PR DESCRIPTION
## What this PR does

The session-title echo guard compares a model-generated candidate against the prompt's own example titles, but the two sides went through different normalization: the candidate was trimmed, lowercased, and stripped of leading/trailing non-letter/non-digit runs, while each example only got lowercased. This PR extracts that normalization into a single helper and runs both sides of the comparison through it, so the guard is symmetric by construction. A unit test locks in the symmetry, including an example with edge punctuation comparing equal to its stripped echo.

## Why it's needed

The asymmetry is unreachable today because all four current example titles start and end with letters, but it becomes a silent bypass the moment an example with leading/trailing punctuation is added: the candidate's trailing punctuation is stripped during sanitization while the example side keeps it, the exact comparison misses, and the canned echo is accepted as a genuine title — the very regression the guard exists to prevent. Normalizing both sides with the same function removes the whole class instead of relying on future examples happening to be clean.

## Reviewer Test Plan

### How to verify

Run `cd packages/core && npx vitest run src/services/sessionTitle.test.ts` — 32/32 pass, including the new `normalizeForEchoCompare` suite: an example like `Fix CI!` now normalizes identically to the sanitized echo `Fix CI`, while interior punctuation is preserved so distinct titles stay distinct. All pre-existing echo-guard tests (verbatim, case-variant, and wrapper-decorated echoes rejected; genuine titles like `(WIP) Fix build` accepted) still pass unchanged, confirming behavior on the current example set is identical.

### Evidence (Before & After)

N/A — internal normalization change with no user-visible behavior difference on the current example set.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (`npx vitest run` from `packages/core`); plus `eslint`, `prettier --check`, and `tsc --noEmit` clean on the changed files.

## Risk & Scope

- Main risk or tradeoff: none expected — current examples are clean, so comparison results are byte-identical today; the helper is exported for tests following the existing `sanitizeTitle` precedent.
- Not validated / out of scope: no E2E run, since behavior on the shipped example set is provably unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9772

Follow-up to the non-blocking observation by @wenshao on #9709 (echo guard introduced there for #9706).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

会话标题回显守卫会把模型生成的候选标题与提示词自带的示例标题做比较，但两侧走的归一化并不一致：候选标题会经过 trim、小写化、剥离首尾连续的非字母/非数字字符，而每个示例只做小写化。本 PR 把这套归一化抽成一个单独的辅助函数，让比较的两侧都走同一套逻辑，使守卫在结构上保持对称。并补充单元测试锁定这一对称性，包括带边缘标点的示例与其被剥离后的回显归一化结果相等。

## 为什么需要

当前四个示例标题首尾都是字母，所以这个不对称今天不可达；但一旦加入带首尾标点的示例就会变成静默绕过：候选标题的尾部标点在 sanitize 阶段被剥掉，示例侧却保留着，精确比较失配，罐头回显就会被当成真实标题接受——这正是守卫要防的回归。两侧走同一套归一化可以一次消除整类问题，而不是依赖将来的示例恰好都是干净的。

## 评审者测试计划

### 如何验证

运行 `cd packages/core && npx vitest run src/services/sessionTitle.test.ts`——32/32 通过，包含新增的 `normalizeForEchoCompare` 套件：`Fix CI!` 这样的示例现在与被 sanitize 后的回显 `Fix CI` 归一化结果一致，同时内部标点被保留、不同标题仍可区分。所有既有回显守卫测试（原样/大小写变体/包裹符装饰的回显被拒，`(WIP) Fix build` 等真实标题被接受）均不变通过，证明对当前示例集合的行为完全一致。

### 前后对比证据

N/A——内部归一化变更，对当前示例集合无用户可见行为差异。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境说明（可选）

仅单元测试（`packages/core` 下 `npx vitest run`）；另对改动文件跑了 `eslint`、`prettier --check`、`tsc --noEmit`，均干净。

## 风险与范围

- 主要风险或权衡：预期没有——当前示例都是干净的，今天的比较结果逐字节一致；辅助函数按既有 `sanitizeTitle` 先例导出供测试使用。
- 未验证 / 超出范围：未跑 E2E，因为对现有示例集合的行为可证明不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #9772

对应 @wenshao 在 #9709 上提出的不阻塞观察（回显守卫即在该 PR 中为 #9706 引入）。

</details>