### PR TITLE
fix(core): normalize both sides of session title echo guard

### DIFF
--- a/packages/core/src/services/sessionTitle.test.ts
+++ b/packages/core/src/services/sessionTitle.test.ts
@@ -12,7 +12,11 @@ import {
   SYSTEM_REMINDER_CLOSE,
   SYSTEM_REMINDER_OPEN,
 } from '../utils/environmentContext.js';
-import { sanitizeTitle, tryGenerateSessionTitle } from './sessionTitle.js';
+import {
+  sanitizeTitle,
+  TITLE_PROMPT_EXAMPLE_TITLES,
+  tryGenerateSessionTitle,
+} from './sessionTitle.js';
 
 interface MockOptions {
   fastModel?: string | undefined;
@@ -235,6 +239,37 @@ describe('tryGenerateSessionTitle', () => {
         outcome,
         `wrapped echo not rejected: ${JSON.stringify(title)}`,
       ).toEqual({ ok: false, reason: 'empty_result' });
+    }
+  });
+
+  it('rejects echoes of decorated prompt examples (#9772)', async () => {
+    // The guard normalizes the candidate title's edges; the example side
+    // must go through the same normalization, or a "Good example" entry
+    // carrying leading/trailing punctuation would let a bare echo of its
+    // inner text slip past (#9772).
+    const originalLength = TITLE_PROMPT_EXAMPLE_TITLES.length;
+    TITLE_PROMPT_EXAMPLE_TITLES.push(
+      '** Upgrade Node runtime **',
+      '《部署网关灰度》',
+    );
+    try {
+      for (const title of ['Upgrade Node runtime', '部署网关灰度']) {
+        const { config } = makeConfig({
+          fastModel: 'qwen-turbo',
+          history: DIALOG_HISTORY,
+          generateJsonResult: { title },
+        });
+        const outcome = await tryGenerateSessionTitle(
+          config,
+          new AbortController().signal,
+        );
+        expect(
+          outcome,
+          `decorated-example echo not rejected: ${JSON.stringify(title)}`,
+        ).toEqual({ ok: false, reason: 'empty_result' });
+      }
+    } finally {
+      TITLE_PROMPT_EXAMPLE_TITLES.length = originalLength;
     }
   });
 

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -27,8 +27,10 @@ const RECENT_MESSAGE_WINDOW = 20;
 // schema-valid answer and parrots one of these back verbatim (#9706). A
 // canned example says nothing about the session, so matches are rejected
 // like empty results. The prompt's "Good examples" block is rendered from
-// this array, so the two cannot drift apart.
-const TITLE_PROMPT_EXAMPLE_TITLES = [
+// this array, so the two cannot drift apart. Exported for unit tests so the
+// guard can be exercised against decorated examples without changing the
+// prompt the model actually sees.
+export const TITLE_PROMPT_EXAMPLE_TITLES = [
   'Fix login button on mobile',
   'Add OAuth authentication flow',
   'Debug failing CI pipeline tests',
@@ -233,6 +235,20 @@ export function sanitizeTitle(s: string): string {
 }
 
 /**
+ * Normalize one side of the echo comparison: trim, lowercase, and strip
+ * leading/trailing runs of non-letter/non-digit characters. Applied to BOTH
+ * the candidate title and each prompt example (#9772) — normalizing only the
+ * candidate would let a decorated example entry slip past the guard.
+ */
+function normalizeForEchoCompare(s: string): string {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/^[^\p{L}\p{N}]+/u, '')
+    .replace(/[^\p{L}\p{N}]+$/u, '');
+}
+
+/**
  * Detect a sanitized title that is just the model echoing one of the
  * prompt's own "Good examples" back (#9706). Exact, case-insensitive match
  * after sanitization — deliberately not fuzzy, so a genuinely topical title
@@ -248,13 +264,9 @@ export function sanitizeTitle(s: string): string {
  * falling outside an enumerated character class.
  */
 function isPromptExampleEcho(title: string): boolean {
-  const normalized = title
-    .trim()
-    .toLowerCase()
-    .replace(/^[^\p{L}\p{N}]+/u, '')
-    .replace(/[^\p{L}\p{N}]+$/u, '');
+  const normalized = normalizeForEchoCompare(title);
   return TITLE_PROMPT_EXAMPLE_TITLES.some(
-    (example) => example.toLowerCase() === normalized,
+    (example) => normalizeForEchoCompare(example) === normalized,
   );
 }
 


### PR DESCRIPTION
## What this PR does

The session-title echo guard (`isPromptExampleEcho` in `packages/core/src/services/sessionTitle.ts`) rejects titles that merely parrot one of the prompt's own "Good examples" back (#9706). Today it normalizes the candidate title (trim → lowercase → strip leading/trailing runs of non-letter/non-digit characters) but applies only `toLowerCase()` to each entry of `TITLE_PROMPT_EXAMPLE_TITLES`. This PR extracts that normalization into a shared `normalizeForEchoCompare` helper and applies it to both sides of the comparison, exactly as requested in #9772, and adds a regression test covering decorated example entries (leading/trailing punctuation, ASCII and CJK wrappers) whose bare inner-text echo must still be rejected.

## Why it's needed

The asymmetry is unreachable with the four current examples (all start and end with a letter or digit), but the echo-guard set and the prompt's "Good examples" block are rendered from the same array and get edited together. As soon as an example entry carries leading/trailing punctuation, a verbatim echo of its inner text would slip past the guard and resurface the exact bad-title failure mode #9706 fixed. Normalizing both sides keeps the guard robust against any future example wording at zero behavior cost today.

## Reviewer Test Plan

### How to verify

The asymmetry is internal (no user-visible behavior change with today's examples), so coverage is unit-level. The new test pushes decorated entries (`** Upgrade Node runtime **`, `《部署网关灰度》`) into `TITLE_PROMPT_EXAMPLE_TITLES`, feeds the model results `Upgrade Node runtime` / `部署网关灰度` through the full `tryGenerateSessionTitle` path, and asserts each echo is rejected with `{ ok: false, reason: 'empty_result' }`. Before this PR the new test fails — the decorated example side is only lowercased, so the echo is accepted as a real title:

```
× tryGenerateSessionTitle > rejects echoes of decorated prompt examples (#9772)
  → decorated-example echo not rejected: "Upgrade Node runtime":
    expected { ok: true, title: "Upgrade Node runtime", modelUsed: "qwen-turbo" }
    to deeply equal { ok: false, reason: 'empty_result' }
```

After this PR the whole file is green:

```
✓ src/services/sessionTitle.test.ts (31 tests) 49ms

Test Files  1 passed (1)
     Tests  31 passed (31)
```

Run it with: `cd packages/core && npx vitest run src/services/sessionTitle.test.ts`

### Evidence (Before & After)

Non-user-visible hardening — the red/green test output above is the evidence; no TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Unit tests only (`vitest`), Node v22.14.0 on Windows. `eslint`, `prettier --check`, and `tsc --noEmit` (packages/core) all pass.

## Risk & Scope

- Main risk or tradeoff: none functional — with the current clean examples both sides normalize identically, so behavior is unchanged today.
- Not validated / out of scope: no live-model run; the guard is exercised purely through the existing mocked `generateJson` path. `TITLE_PROMPT_EXAMPLE_TITLES` gains an `export` purely as a unit-test seam (same convention as the already-exported `sanitizeTitle`).
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9772

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

会话标题回声防护（`packages/core/src/services/sessionTitle.ts` 中的 `isPromptExampleEcho`）会拒绝那些只是把 prompt 自带 "Good examples" 原样复述回来的标题（#9706）。目前它对候选标题做了归一化（trim → 小写 → 去掉首尾连续的非字母/非数字字符），但对 `TITLE_PROMPT_EXAMPLE_TITLES` 的每一项只做 `toLowerCase()`。本 PR 把该归一化提取为共享的 `normalizeForEchoCompare` 函数并对比对两侧都应用，与 #9772 的要求完全一致，并新增回归测试覆盖带装饰的 example 条目（首尾标点，ASCII 与 CJK 包裹符），其内部文本的回声仍必须被拒绝。

## 为什么需要

以当前 4 个 example（均以字母或数字开头结尾）而言，这种不对称还触发不了，但 echo-guard 集合与 prompt 的 "Good examples" 块由同一数组渲染、会一起被修改。一旦某个 example 条目带上了首尾标点，其内部文本的逐字回声就会绕过防护，重新引发 #9706 修掉的坏标题故障。两侧归一化让防护对未来任何 example 措辞都保持稳健，且当前零行为代价。

## 评审测试计划

### 如何验证

该不对称是内部问题（以当前 example 而言无用户可见行为变化），因此覆盖在单测层面。新用例向 `TITLE_PROMPT_EXAMPLE_TITLES` 推入带装饰的条目（`** Upgrade Node runtime **`、`《部署网关灰度》`），让模型结果 `Upgrade Node runtime` / `部署网关灰度` 走完整 `tryGenerateSessionTitle` 流程，断言每个回声都被拒绝并返回 `{ ok: false, reason: 'empty_result' }`。本 PR 之前新用例失败——装饰过的 example 侧只做了小写化，回声被当作真实标题接受：

```
× tryGenerateSessionTitle > rejects echoes of decorated prompt examples (#9772)
  → decorated-example echo not rejected: "Upgrade Node runtime":
    expected { ok: true, title: "Upgrade Node runtime", modelUsed: "qwen-turbo" }
    to deeply equal { ok: false, reason: 'empty_result' }
```

本 PR 之后整个文件全绿：

```
✓ src/services/sessionTitle.test.ts (31 tests) 49ms

Test Files  1 passed (1)
     Tests  31 passed (31)
```

运行方式：`cd packages/core && npx vitest run src/services/sessionTitle.test.ts`

### 证据（前后对比）

非用户可见的加固改动——上面的红/绿测试输出即证据，无 TUI 变化。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ✅ 已测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

仅单元测试（vitest），Node v22.14.0，Windows。eslint、prettier --check、tsc --noEmit（packages/core）全部通过。

## 风险与范围

- 主要风险或权衡：功能上无——当前干净的 example 两侧归一化结果完全相同，今天行为不变。
- 未验证 / 超出范围：未跑真实模型；防护完全通过现有 mock 的 generateJson 路径验证。`TITLE_PROMPT_EXAMPLE_TITLES` 新增 export 仅作为单测缝隙（与已导出的 `sanitizeTitle` 同一惯例）。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #9772

</details>
