### PR TITLE
fix(sdk): support relative daemon base URLs in remaining workspace file helpers

### DIFF
--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1798,22 +1798,21 @@ export class DaemonClient {
     } = {},
     clientId?: string,
   ): Promise<DaemonWorkspaceFile> {
-    const url = new URL(`${this.baseUrl}/file`);
-    url.searchParams.set('path', filePath);
+    const query = new URLSearchParams({ path: filePath });
     if (opts.maxBytes !== undefined) {
-      url.searchParams.set('maxBytes', String(opts.maxBytes));
+      query.set('maxBytes', String(opts.maxBytes));
     }
     if (opts.line !== undefined) {
-      url.searchParams.set('line', String(opts.line));
+      query.set('line', String(opts.line));
     }
     if (opts.limit !== undefined) {
-      url.searchParams.set('limit', String(opts.limit));
+      query.set('limit', String(opts.limit));
     }
     if (opts.cursor !== undefined) {
-      url.searchParams.set('cursor', opts.cursor);
+      query.set('cursor', opts.cursor);
     }
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/file?${query.toString()}`,
       { headers: this.headers({}, clientId) },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /file');
@@ -1845,10 +1844,9 @@ export class DaemonClient {
   }
 
   async fileStat(filePath: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/stat`);
-    url.searchParams.set('path', filePath);
+    const query = new URLSearchParams({ path: filePath });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/stat?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /stat');
@@ -1858,10 +1856,9 @@ export class DaemonClient {
   }
 
   async dirList(dirPath: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/list`);
-    url.searchParams.set('path', dirPath);
+    const query = new URLSearchParams({ path: dirPath });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/list?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /list');
@@ -1875,10 +1872,9 @@ export class DaemonClient {
    * pick a path outside any registered workspace (e.g. "Add workspace").
    */
   async workspacePathSuggestions(prefix: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/workspace-path-suggestions`);
-    url.searchParams.set('prefix', prefix);
+    const query = new URLSearchParams({ prefix });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/workspace-path-suggestions?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) {
@@ -1903,10 +1899,9 @@ export class DaemonClient {
   }
 
   async glob(pattern: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/glob`);
-    url.searchParams.set('pattern', pattern);
+    const query = new URLSearchParams({ pattern });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/glob?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /glob');
@@ -1970,9 +1965,8 @@ export class DaemonClient {
     req: DaemonWorkspaceFileUploadRequest,
     clientId?: string,
   ): Promise<DaemonWorkspaceFileUploadResult> {
-    const target = new URL(`${this.baseUrl}${uploadPath}`);
-    target.searchParams.set('path', req.path);
-    const url = target.toString();
+    const query = new URLSearchParams({ path: req.path });
+    const url = `${this.baseUrl}${uploadPath}?${query.toString()}`;
     const headers = this.headers(
       { 'Content-Type': 'application/octet-stream' },
       clientId,

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -629,6 +629,19 @@ describe('DaemonClient', () => {
         client.readWorkspaceFile('src/a.ts', { line: 2, limit: 3 }),
       ).resolves.toEqual(payload);
       expect(calls[0]?.url).toBe('/daemon/file?path=src%2Fa.ts&line=2&limit=3');
+
+      // maxBytes is the one GET /file option no test pinned on either base URL:
+      // deleting its branch left the whole suite green.
+      await expect(
+        client.readWorkspaceFile('src/a.ts', {
+          maxBytes: 100,
+          line: 2,
+          limit: 3,
+        }),
+      ).resolves.toEqual(payload);
+      expect(calls[1]?.url).toBe(
+        '/daemon/file?path=src%2Fa.ts&maxBytes=100&line=2&limit=3',
+      );
     });
 
     it('stats files with a relative base URL', async () => {

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -607,6 +607,90 @@ describe('DaemonClient', () => {
       );
     });
 
+    it('reads text files with a relative base URL', async () => {
+      const payload = {
+        kind: 'file',
+        path: 'src/a.ts',
+        content: 'export {}\n',
+        encoding: 'utf-8',
+        bom: false,
+        lineEnding: 'lf',
+        sizeBytes: 10,
+        returnedBytes: 10,
+        truncated: false,
+        hash: 'sha256:' + 'a'.repeat(64),
+        matchedIgnore: null,
+        originalLineCount: null,
+      };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, payload));
+      const client = new DaemonClient({ baseUrl: '/daemon', fetch });
+
+      await expect(
+        client.readWorkspaceFile('src/a.ts', { line: 2, limit: 3 }),
+      ).resolves.toEqual(payload);
+      expect(calls[0]?.url).toBe('/daemon/file?path=src%2Fa.ts&line=2&limit=3');
+    });
+
+    it('stats files with a relative base URL', async () => {
+      const payload = { kind: 'stat', path: 'src/a.ts', sizeBytes: 10 };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, payload));
+      const client = new DaemonClient({ baseUrl: '/daemon', fetch });
+
+      await expect(client.fileStat('src/a.ts')).resolves.toEqual(payload);
+      expect(calls[0]?.url).toBe('/daemon/stat?path=src%2Fa.ts');
+    });
+
+    it('lists directories with a relative base URL', async () => {
+      const payload = { kind: 'list', path: 'src', entries: [] };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, payload));
+      const client = new DaemonClient({ baseUrl: '/daemon', fetch });
+
+      await expect(client.dirList('src')).resolves.toEqual(payload);
+      expect(calls[0]?.url).toBe('/daemon/list?path=src');
+    });
+
+    it('suggests workspace paths with a relative base URL', async () => {
+      const payload = { suggestions: [] };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, payload));
+      const client = new DaemonClient({ baseUrl: '/daemon', fetch });
+
+      await expect(
+        client.workspacePathSuggestions('/home/user'),
+      ).resolves.toEqual(payload);
+      expect(calls[0]?.url).toBe(
+        '/daemon/workspace-path-suggestions?prefix=%2Fhome%2Fuser',
+      );
+    });
+
+    it('globs with a relative base URL', async () => {
+      const payload = { matches: [] };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, payload));
+      const client = new DaemonClient({ baseUrl: '/daemon', fetch });
+
+      await expect(client.glob('**/*.ts')).resolves.toEqual(payload);
+      expect(calls[0]?.url).toBe('/daemon/glob?pattern=**%2F*.ts');
+    });
+
+    it('uploads files with a relative base URL', async () => {
+      const payload = {
+        kind: 'file_upload' as const,
+        path: 'bin.dat',
+        sizeBytes: 2,
+        hash: 'sha256:' + 'a'.repeat(64),
+      };
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, payload));
+      const client = new DaemonClient({ baseUrl: '/daemon', fetch });
+
+      await expect(
+        client.uploadWorkspaceFile({
+          path: 'bin.dat',
+          data: new Uint8Array([1, 2]),
+        }),
+      ).resolves.toEqual(payload);
+      expect(calls[0]?.method).toBe('POST');
+      expect(calls[0]?.url).toBe('/daemon/file/upload?path=bin.dat');
+    });
+
     it('writes and edits files with JSON bodies and client identity', async () => {
       const writeResult = {
         kind: 'file_write',


### PR DESCRIPTION
## What this PR does

Applies the URL construction pattern from #9734 to the six workspace file helpers that still used the absolute-only `URL` constructor: `readWorkspaceFile`, `fileStat`, `dirList`, `workspacePathSuggestions`, `glob`, and `uploadFileToPath`. Adds a relative-base-URL regression test for each.

## Why it's needed

Web Shell integrations configure a same-origin relative daemon base path such as `/daemon`. #9734 fixed `readWorkspaceFileBytes` and listed the remaining helpers as out of scope; each of them still throws `Failed to construct 'URL': Invalid URL` before the request reaches the daemon. This finishes that migration with the identical `URLSearchParams` + string interpolation approach, so absolute base URLs produce byte-for-byte the same requests as before.

## Reviewer Test Plan

### How to verify

Run the SDK unit suite: `npm test -- test/unit/DaemonClient.test.ts` in `packages/sdk-typescript`. With the new tests but pristine source, all six new cases fail with `TypeError: Invalid URL`; with the fix the file passes 354/354. Pre-existing absolute-URL coverage for these helpers passes unchanged, which is the no-regression check for the standard configuration. `npm run lint` and `npm run typecheck` for the SDK package are clean.

### Evidence (Before & After)

N/A (no user-visible change; evidence is the RED/GREEN test output described above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A (unit tests only).

## Risk & Scope

- Main risk or tradeoff: URL assembly changes in six methods. For absolute base URLs the new code produces identical request strings (covered by the pre-existing absolute-URL tests); a base URL with a trailing slash behaves exactly as it does in the already-merged `readWorkspaceFileBytes` from #9734, since the construction is the same pattern.
- Not validated / out of scope: `uploadFileToPath` against a live daemon (unit-mocked only); base paths that already carry a query string (none of the six methods accept one today); the seventh helper `readWorkspaceFileBytes` is untouched, it was fixed in #9734.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9816

<details>
<summary>中文说明</summary>

## 本 PR 的内容

将 #9734 的 URL 构造模式应用到仍在使用仅支持绝对地址的 `URL` 构造函数的六个工作区文件辅助方法：`readWorkspaceFile`、`fileStat`、`dirList`、`workspacePathSuggestions`、`glob` 和 `uploadFileToPath`。并为每个方法添加了相对 base URL 的回归测试。

## 为什么需要

Web Shell 集成会配置同源的相对 daemon 基础路径（例如 `/daemon`）。#9734 修复了 `readWorkspaceFileBytes`，并把其余辅助方法列为超出范围；这些方法在请求到达 daemon 之前仍会抛出 `Failed to construct 'URL': Invalid URL`。本 PR 用完全相同的 `URLSearchParams` + 字符串插值方式完成该迁移，绝对 base URL 生成的请求与之前逐字节一致。

## 审查者测试计划

在 `packages/sdk-typescript` 中运行 `npm test -- test/unit/DaemonClient.test.ts`。仅有新测试而未应用修复时，六个新用例全部因 `TypeError: Invalid URL` 失败；应用修复后该文件 354/354 通过。已有的绝对 URL 用例保持不变通过。`npm run lint` 与 `npm run typecheck` 均无问题。本地在 macOS 上验证；Windows 与 Linux 依赖 CI。

## 风险与范围

- 主要风险或权衡：六个方法的 URL 拼装有改动。对绝对 base URL，新代码生成完全相同的请求字符串（由已有测试覆盖）；带尾斜杠的 base URL 行为与 #9734 已合并的 `readWorkspaceFileBytes` 完全一致，因为构造模式相同。
- 未验证 / 超出范围：`uploadFileToPath` 未对真实 daemon 端到端验证（仅单元 mock）；已携带 query string 的基础路径（这六个方法目前都不接受）；`readWorkspaceFileBytes` 未改动，已在 #9734 修复。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #9816

</details>
