### PR TITLE
fix(ci): record cd-cua-driver.yml's shipped size in the workflow size baseline

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -16,7 +16,7 @@
 3480 audio-capture-prebuilds.yml
 9023 auto-minimize-spam.yml
 4638 build-and-publish-image.yml
-29715 cd-cua-driver.yml
+42519 cd-cua-driver.yml
 2076 cd-mobile-mcp.yml
 69782 ci.yml
 1482 codeql.yml


### PR DESCRIPTION
## What this PR does

Updates the workflow size-baseline entry for `cd-cua-driver.yml` from 29715 to its shipped 42519 bytes, so the `Check workflow file size` ratchet stops failing every PR that carries current `main`.

## Why it's needed

#9587 (the versioned Computer Use SDK release pipeline) grew `cd-cua-driver.yml` by 12804 bytes without updating `.github/workflows/.size-baseline`, and its own CI never exercised the size gate — so `main` itself is over its recorded baseline. The gate is the first step of the Test job, which means every branch that merges or rebases onto current `main` now fails Test in ~24 seconds before a single test runs (first observed on #9794 after its takeover merge of `main`). The growth is real feature surface at 8% of GitHub's 512000-byte start-runs limit; recording it is exactly what the gate's own error message prescribes and what #9747 did for `qwen-autofix.yml`.

## Reviewer Test Plan

### How to verify

On this branch, `bash .github/scripts/check-workflow-size.sh` prints the all-green line (`✅ every workflow file is under the 470000-byte gate and within 4096 bytes of its recorded baseline`); on `main` it errors with `cd-cua-driver.yml grew to 42519 bytes, 12804 over its recorded 29715`. The vitest mirror stays green: `npx vitest run scripts/tests/workflow-size.test.js` — 181 passed.

### Evidence (Before & After)

Before (main): `##[error].github/workflows/cd-cua-driver.yml grew to 42519 bytes, 12804 over its recorded 29715 (allowance 4096)` — e.g. the Test job on #9794's head after merging main, failing at 24s.

After (this branch): `✅ every workflow file is under the 470000-byte gate and within 4096 bytes of its recorded baseline`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local shell + vitest; no build needed.

## Risk & Scope

- Main risk or tradeoff: none beyond accepting the 12804-byte growth into the ratchet — the file sits at 8% of the hard limit, and the ratchet keeps guarding further drift from the new number.
- Not validated / out of scope: shrinking `cd-cua-driver.yml` itself (moving prose out) — worth doing if it keeps growing, but not required at this size.
- Breaking changes / migration notes: none — a one-line data change.

## Linked Issues

Unblocks CI on #9794 and any other branch carrying `main` at or after #9587.

<details><summary>中文说明</summary>

## 这个 PR 做了什么

把 workflow 体积基线中 `cd-cua-driver.yml` 的条目从 29715 更新为实际的 42519 字节,使 `Check workflow file size` 棘轮门禁不再让所有携带当前 `main` 的 PR 失败。

## 为什么需要

#9587(Computer Use SDK 版本化发布流水线)把 `cd-cua-driver.yml` 撑大了 12804 字节却没有更新 `.github/workflows/.size-baseline`,而它自己的 CI 没有跑到这个门禁——因此 `main` 本身就超出了记录的基线。该门禁是 Test job 的第一步,导致所有 merge/rebase 到当前 `main` 的分支在任何测试运行前约 24 秒即失败(最先在 #9794 的 takeover merge main 之后观察到)。该增长是真实的功能面,仅占 GitHub 512000 字节启动上限的 8%;按门禁自身报错信息的指引记录它,与 #9747 对 `qwen-autofix.yml` 的处理一致。

## 评审验证方案

### 如何验证

本分支上 `bash .github/scripts/check-workflow-size.sh` 输出全绿行;`main` 上则报 `cd-cua-driver.yml grew to 42519 bytes, 12804 over its recorded 29715`。vitest 镜像保持绿:`npx vitest run scripts/tests/workflow-size.test.js` —— 181 通过。

### 证据(前后对比)

之前(main):`##[error].github/workflows/cd-cua-driver.yml grew to 42519 bytes, 12804 over its recorded 29715 (allowance 4096)`——例如 #9794 head 在 merge main 后的 Test job,24 秒失败。

之后(本分支):`✅ every workflow file is under the 470000-byte gate and within 4096 bytes of its recorded baseline`。

### 测试平台

Linux 已验证(✅);macOS/Windows 未本地验证(⚠️,纯数据行改动,CI 覆盖)。

### 环境(可选)

本地 shell + vitest;无需构建。

## 风险与范围

- 主要风险/权衡:除接受 12804 字节增长进入棘轮外无其他——该文件仅占硬上限 8%,棘轮从新数字继续守护后续漂移。
- 未验证/范围外:给 `cd-cua-driver.yml` 本身瘦身(外移 prose)——若持续增长值得做,当前体量不必。
- 破坏性变更/迁移说明:无——单行数据改动。

## 关联 Issue

解除 #9794 及所有携带 #9587 之后 `main` 的分支的 CI 阻塞。

</details>
