### PR TITLE
fix(ci): record cd-cua-driver.yml's shipped size in the workflow size baseline

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -16,7 +16,7 @@
 3480 audio-capture-prebuilds.yml
 9023 auto-minimize-spam.yml
 4638 build-and-publish-image.yml
-29715 cd-cua-driver.yml
+42519 cd-cua-driver.yml
 2076 cd-mobile-mcp.yml
 69782 ci.yml
 1482 codeql.yml


### PR DESCRIPTION
## What this PR does

Corrects one number in `.github/workflows/.size-baseline`: the entry for `cd-cua-driver.yml` becomes 42519, the size of the file that is actually on disk, replacing the 29715 it was left at.

## Why it's needed

This is the second instance of the shape #9747 fixed, in a different file. #9587 grew `cd-cua-driver.yml` from 29715 to 42519 bytes — a versioned Computer Use SDK and its release pipeline — and did not move the manifest entry with it. That is 12804 bytes over an allowance of 4096, so the growth ratchet fails on `main` itself.

The step it fails is `Check workflow file size`, number 7 of the `Test` job and ahead of `Install dependencies`, and a failure there skips every step after it. A PR whose merge ref contains that commit therefore shows a red `Test` lane that ran no tests at all, over a workflow file the PR never touched. Two PRs from different authors were measured failing at step 7 and at no other, while a PR still based on an earlier merge ref stays green — which is what places the cause.

The growth is real, so the number moves rather than the file, and the ratchet resumes measuring drift from what is actually there.

## Reviewer Test Plan

### How to verify

On `main`, both the shell gate and its vitest mirror fail; with this one-line change, both pass.

```
# on main
$ bash .github/scripts/check-workflow-size.sh
::error file=.github/workflows/cd-cua-driver.yml::… grew to 42519 bytes, 12804 over its recorded 29715 (allowance 4096). …

$ npx vitest run --root . scripts/tests/workflow-size.test.js
 × workflow size growth ratchet > .github/workflows/cd-cua-driver.yml is within its baseline allowance
 Tests  1 failed | 180 passed (181)

# with this change
$ bash .github/scripts/check-workflow-size.sh
✅ every workflow file is under the 470000-byte gate and within 4096 bytes of its recorded baseline

$ npx vitest run --root . scripts/tests/workflow-size.test.js
 Tests  181 passed (181)
```

Restoring the old number turns the mirror red again, so the single line is what the result hangs on.

The rest of the manifest is accurate and stays untouched: all 52 workflow files have an entry, 48 match their file byte-for-byte, and the three remaining drifts (`qwen-autofix-fork-signal.yml` +1147, `qwen-autofix.yml` +827, `qwen-code-pr-review.yml` +146) are inside the allowance, which is what the allowance is for.

### Evidence (Before & After)

N/A — no user-visible surface; the before/after is the command output above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

macOS; the gate is a byte count over files in the repo, so it has no platform-dependent behaviour. CI covers the Linux lane.

## Risk & Scope

- Main risk or tradeoff: recording the shipped size banks 12804 bytes of growth that no reviewer approved as growth. The alternative is trimming a workflow this PR has no stake in, which would hold every other PR's CI hostage meanwhile. The number now sits where the next drift is measured from, so the ratchet's next objection comes that much later for this one file.
- Not validated / out of scope: whether `cd-cua-driver.yml` should be smaller than 42519, and whether the ratchet wants a rule that fails the PR doing the growing rather than the next PR to merge — this is the second time the manifest has been left behind, which is a signal about the mechanism, not about either file.
- Breaking changes / migration notes: none.

## Linked Issues

Follows up #9747. Caused by #9587.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修正 `.github/workflows/.size-baseline` 里的一个数字：`cd-cua-driver.yml` 的条目改为 42519，即磁盘上文件的真实大小，替换掉停留在那里的 29715。

## 为什么需要

这是 #9747 修过的同一类问题第二次发生，换了个文件。#9587 把 `cd-cua-driver.yml` 从 29715 涨到 42519 字节（版本化的 Computer Use SDK 及其发布流水线），却没有同步移动清单条目。超出 4096 允差 12804 字节，于是增长棘轮在 `main` 自己身上就失败。

它失败的那一步是 `Check workflow file size`，`Test` job 的第 7 步，排在 `Install dependencies` 之前，而该步失败会跳过其后的每一步。于是任何 merge ref 含该 commit 的 PR，都会看到一条红着的 `Test` 通道，而它一个测试都没跑，起因还是一个该 PR 从未碰过的 workflow 文件。实测两个来自不同作者的 PR 都恰好挂在第 7 步、且不挂在其它任何一步；而 merge ref 更早的 PR 仍然是绿的——这就定住了因果。

增长是真实的，所以要动的是数字而不是文件；棘轮从真实存在的那个大小重新开始度量漂移。

## 评审验证计划

见上方英文正文的命令与输出。把旧数字改回去，镜像测试会重新变红——说明结果就悬在这一行上。清单其余部分准确、不做改动：52 个 workflow 文件都有条目，48 个逐字节相符，剩余三处漂移都在允差之内。

### 证据（前后对比）

N/A —— 没有用户可见界面；前后对比就是上面的命令输出。

## 风险与范围

- 主要风险或取舍：记录落库大小，等于把 12804 字节的增长收进基线，而没有评审者把它当作"增长"批准过。另一条路是去裁一个与本 PR 毫无关系的 workflow，而在此期间所有其他 PR 的 CI 都被扣住。这个数字现在成了下一次漂移的度量起点，所以棘轮对这个文件的下一次反对会相应推后。
- 未验证 / 范围之外：`cd-cua-driver.yml` 是否应当小于 42519；以及棘轮是否需要一条"让制造增长的那个 PR 失败、而不是让下一个合并的 PR 失败"的规则——清单被落下已经是第二次了，这是关于机制的信号，而不是关于这两个文件中的任何一个。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

跟进 #9747。由 #9587 引入。

</details>
