### PR TITLE
fix(goal): count catalog previews in the unit their budget is written in

### DIFF
--- a/packages/core/src/goals/goal-evidence.test.ts
+++ b/packages/core/src/goals/goal-evidence.test.ts
@@ -548,10 +548,50 @@ describe('Goal evidence catalog', () => {
     expect(small?.content).toBe('output 1');
   });
 
+  it('does not start truncated under a full checkpoint of multi-byte claims', () => {
+    // The failure this guards: catalog previews were cut to 240 *characters*
+    // while the catalog budget counts *bytes*. A legal 32-claim checkpoint of
+    // Chinese claims serialized to ~29kB against the 24kB cap, so the window
+    // was truncated before a single new record was scanned — and `truncated`
+    // switches `shouldCheckpoint` off, so compaction could never run again and
+    // the Goal was stopped as `usage_limited` with nothing to salvage.
+    const checkpointGoal: GoalRecord = {
+      ...goal('checkpoint-1'),
+      evidenceCheckpoint: {
+        checkpointId: 'checkpoint-1',
+        createdAt: 1,
+        claims: Array.from({ length: 32 }, (_, index) => ({
+          id: `checkpoint-1:${index + 1}`,
+          proofKind: 'external_fact' as const,
+          claim: '\u4e2d'.repeat(2_000),
+          sourceRefs: ['cursor'],
+        })),
+      },
+    };
+
+    const window = buildGoalEvidenceCheckpointWindow({
+      records: [
+        record('checkpoint-1', 'system'),
+        record('evidence-0', 'assistant', {
+          provenance: 'assistant_output',
+          turnId: 'turn-3',
+          text: '\u4e2d'.repeat(50),
+        }),
+      ],
+      goal: checkpointGoal,
+      permit: permit(),
+    });
+
+    expect(window.truncated).toBe(false);
+  });
+
   it('caps window content on a code point boundary for multi-byte text', () => {
     const records = [
       record('cursor', 'system'),
-      ...Array.from({ length: 26 }, (_, index) =>
+      // Sized against the byte-capped catalog entry (~364 bytes each), not the
+      // ~910 a 240-character CJK preview used to cost: 53 entries reach the
+      // 19,200-byte checkpoint threshold, 66 would reach the 24,000 cap.
+      ...Array.from({ length: 55 }, (_, index) =>
         record(`evidence-${index}`, 'assistant', {
           provenance: 'assistant_output',
           turnId: 'turn-3',

--- a/packages/core/src/goals/goal-evidence.ts
+++ b/packages/core/src/goals/goal-evidence.ts
@@ -19,7 +19,16 @@ import {
   projectUserTranscriptForDisplay,
 } from '../utils/transcript-records.js';
 
+// Previews are cut to a character count while building — cheap, and it bounds
+// the work — but the catalog budget they feed is denominated in bytes, so the
+// guarantee has to be too. In UTF-8 the two units differ by up to 4x: 240 CJK
+// characters are 720 bytes, so a full 32-claim checkpoint of Chinese evidence
+// serialized to ~29kB against a 24kB catalog and marked the window truncated
+// before a single new record was even scanned — which switched compaction off
+// permanently. `capPreviewBytes` is what actually holds the bound; the
+// character slices below only keep the intermediate strings small.
 const CATALOG_PREVIEW_LIMIT = 240;
+const CATALOG_PREVIEW_BYTE_LIMIT = 240;
 const CATALOG_ENTRY_LIMIT = 100;
 const CATALOG_BYTE_LIMIT = 24_000;
 const CATALOG_LINEAGE_LIMIT = 16;
@@ -263,6 +272,7 @@ export class GoalEvidenceRecordIndexAccumulator {
         this.lastPartPreviewValues,
       ).trim();
     }
+    preview = capPreviewBytes(preview);
     const catalogEntry =
       this.provenance && this.parsedGoalContext && preview
         ? {
@@ -462,11 +472,18 @@ export class GoalEvidenceCheckpointAccumulator {
       catalogBytes += entryBytes;
     }
     this.truncated = truncated;
+    // A truncated window is the case that most needs compressing, not the one
+    // that should skip it: the budget is already full, and the newest evidence
+    // that did fit is exactly what a checkpoint would fold into claims. Gating
+    // compaction on `!truncated` meant the one state compaction exists to
+    // resolve was the one state it refused to run in, and the Goal was stopped
+    // instead. Compress whatever the window did capture; the older evidence
+    // left behind is already covered by the previous checkpoint's claims.
     this.shouldCheckpoint =
-      !truncated &&
       this.candidateUuids.length > 0 &&
-      (this.checkpointEntries.length + this.candidateUuids.length >=
-        CHECKPOINT_ENTRY_THRESHOLD ||
+      (truncated ||
+        this.checkpointEntries.length + this.candidateUuids.length >=
+          CHECKPOINT_ENTRY_THRESHOLD ||
         catalogBytes >= CHECKPOINT_BYTE_THRESHOLD);
   }
 
@@ -942,7 +959,7 @@ function checkpointCatalogEntries(
     uuid: claim.id,
     provenance: 'goal_checkpoint',
     turnId: `checkpoint:${checkpoint.checkpointId}`,
-    preview: claim.claim.slice(0, CATALOG_PREVIEW_LIMIT),
+    preview: capPreviewBytes(claim.claim.slice(0, CATALOG_PREVIEW_LIMIT)),
     proofKind: claim.proofKind,
   }));
 }
@@ -1049,6 +1066,25 @@ function legacySafeProvenance(
   return undefined;
 }
 
+/**
+ * Cut `value` to at most {@link CATALOG_PREVIEW_BYTE_LIMIT} UTF-8 bytes
+ * without splitting a code point.
+ */
+function capPreviewBytes(value: string): string {
+  if (Buffer.byteLength(value, 'utf8') <= CATALOG_PREVIEW_BYTE_LIMIT) {
+    return value;
+  }
+  let byteLength = 0;
+  let cutoff = 0;
+  for (const codePoint of value) {
+    const codePointBytes = Buffer.byteLength(codePoint, 'utf8');
+    if (byteLength + codePointBytes > CATALOG_PREVIEW_BYTE_LIMIT) break;
+    byteLength += codePointBytes;
+    cutoff += codePoint.length;
+  }
+  return value.slice(0, cutoff);
+}
+
 function capCheckpointContent(content: string): string {
   if (Buffer.byteLength(content, 'utf8') <= CHECKPOINT_CONTENT_BYTE_LIMIT) {
     return content;
@@ -1101,7 +1137,9 @@ function evidencePreview(
       ? projectUserTranscriptForDisplay(record)
       : undefined;
   if (projection?.displayText !== undefined) {
-    return projection.displayText.slice(0, CATALOG_PREVIEW_LIMIT).trim();
+    return capPreviewBytes(
+      projection.displayText.slice(0, CATALOG_PREVIEW_LIMIT).trim(),
+    );
   }
   let preview = '';
   const append = (value: string) => {
@@ -1121,7 +1159,7 @@ function evidencePreview(
     }
     if (preview.length >= CATALOG_PREVIEW_LIMIT) break;
   }
-  return preview.trim();
+  return capPreviewBytes(preview.trim());
 }
 
 function renderToolResponse(functionResponse: {

--- a/packages/core/src/goals/goal-runtime.test.ts
+++ b/packages/core/src/goals/goal-runtime.test.ts
@@ -9,7 +9,6 @@ import type { GoalEvidenceRecord } from './goal-evidence.js';
 import type { GoalRecoveryRecord } from './goal-persistence.js';
 import {
   GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
-  GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
   GOAL_PROPOSAL_REASON_MAX_BYTES,
   type GoalSnapshotV2,
   type GoalStateCause,
@@ -1120,7 +1119,7 @@ describe('goal runtime', () => {
     expect(host.started).toHaveLength(2);
   });
 
-  it.each(['flush', 'read', 'truncated'] as const)(
+  it.each(['flush', 'read'] as const)(
     'moves to usage_limited when checkpoint %s fails',
     async (failurePoint) => {
       const journal = fakeGoalJournal();
@@ -1155,7 +1154,7 @@ describe('goal runtime', () => {
       records = verifierEvidenceWindow(
         permit,
         runtime.getSnapshot().goal!.evidenceCursor.recordId!,
-        failurePoint === 'truncated' ? 101 : 80,
+        80,
       );
 
       await runtime.finishTurn(permit);
@@ -1171,21 +1170,57 @@ describe('goal runtime', () => {
       ]);
       expect(host.started).toHaveLength(1);
       expect(checkpointVerifier).toHaveBeenCalledTimes(0);
-      if (failurePoint === 'truncated') {
-        expect(runtime.getSnapshot().goal).toMatchObject({
-          lastReason: GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
-          limitKind: 'evidence_catalog',
-        });
-        await expect(
-          runtime.dispatch({
-            action: 'resume',
-            expectedGoalId: permit.goalId,
-            expectedRevision: permit.revision,
-          }),
-        ).rejects.toThrow('edit or replace');
-      }
     },
   );
+
+  it('compresses a truncated window instead of stopping the Goal', async () => {
+    // A window that overflows its budget is the state compaction exists to
+    // resolve. It used to be the one state compaction refused to run in:
+    // `shouldCheckpoint` required `!truncated`, so an overflow went straight
+    // to `usage_limited` — the only Goal state the reducer refuses to resume.
+    // The evidence left behind is already covered by the previous checkpoint's
+    // claims, so folding in what did fit is strictly better than stopping.
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const checkpointVerifier = vi.fn(async () => ({
+      claims: [
+        {
+          proofKind: 'delivered_output' as const,
+          claim: 'The implementation result was delivered.',
+          sourceRefs: ['assistant-evidence-100'],
+        },
+      ],
+    }));
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({
+      journal,
+      evidenceSource,
+      verifier: vi.fn(),
+      checkpointVerifier,
+    });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'deliver result' });
+    const permit = host.started[0]!;
+    records = verifierEvidenceWindow(
+      permit,
+      runtime.getSnapshot().goal!.evidenceCursor.recordId!,
+      101,
+    );
+
+    await runtime.finishTurn(permit);
+
+    expect(checkpointVerifier).toHaveBeenCalledTimes(1);
+    expect(runtime.getSnapshot()).toMatchObject({
+      goal: { status: 'active' },
+    });
+    expect(runtime.getSnapshot().goal).toHaveProperty('evidenceCheckpoint');
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'checkpoint',
+    ]);
+  });
 
   it('keeps a goal active when the checkpoint verifier provider fails', async () => {
     const journal = fakeGoalJournal();

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -888,7 +888,11 @@ export function createGoalRuntime(
           permit: attempt.permit,
         });
       }
-      if (window.truncated) {
+      // A truncated window still compresses: `shouldCheckpoint` stays true
+      // whenever anything was captured, and folding that into claims is what
+      // frees the budget. Only a window that captured nothing at all has
+      // nothing to salvage, and that is the state this stops the Goal in.
+      if (window.truncated && !window.shouldCheckpoint) {
         await recordCheckpointFailure(
           attempt,
           GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,


### PR DESCRIPTION
## What this PR does

Evidence catalog previews are now capped to 240 UTF-8 bytes on a code point boundary, rather than to 240 characters, at the two points a catalog entry is built. And a truncated evidence window now compresses what it captured instead of stopping the Goal — only a window that captured nothing at all still fails.

## Why it's needed

The catalog budget is 24,000 bytes. The preview limit that feeds it was 240 characters. In UTF-8 those units differ by up to four times, so the guard held only for ASCII.

The consequence is not a tuning problem, it is a Goal that cannot run in some languages. A checkpoint may carry 32 claims; each is projected into the catalog as a preview plus a small envelope. With ASCII that is about 430 bytes per entry, so a full checkpoint occupies 13,760 bytes — 57% of the budget, leaving room for roughly 23 more records. With Chinese the same legal checkpoint serializes to about 29,000 bytes, over the cap on its own, before a single new record has been scanned. The window is then marked truncated, and `shouldCheckpoint` required `!truncated` — so the one state compaction exists to resolve was the one state it refused to run in. The runtime read that as unrecoverable and stopped the Goal as `usage_limited`, which `reduceGoalResume` refuses to resume, and there was nothing left to salvage because no candidate evidence had been collected yet.

An English Goal never reached that state. A Chinese one could not avoid it: the failure arrives on the first checkpoint that fills its claim budget, regardless of how the run is going.

The second half follows from the first. A window that overflows its budget is precisely the state compaction is for — the newest evidence that did fit is exactly what a checkpoint folds into claims, and the older evidence left behind is already covered by the previous checkpoint's claims. Refusing to compress there and stopping the Goal instead is strictly worse than compressing what is available.

## Reviewer Test Plan

### How to verify

Run a Goal whose objective and work are in a non-Latin script — Chinese is the reported case — long enough for it to take a checkpoint whose claims fill the claim budget. Before this change the next window is truncated on arrival and the Goal stops as `usage_limited` with `limitKind: 'evidence_catalog'`, and `/goal resume` is refused. After it, the checkpoint stays comfortably inside the catalog budget and the run continues. Then force an overflow deliberately (more than 100 post-cursor records) and confirm the Goal now takes a checkpoint and stays active rather than stopping.

Two tests carry the change. `does not start truncated under a full checkpoint of multi-byte claims` builds a goal carrying 32 claims of 2,000 Chinese characters — the maximum a checkpoint may hold — and asserts the window is not truncated. `compresses a truncated window instead of stopping the Goal` drives 101 post-cursor records through the runtime and asserts the checkpoint verifier is called, the Goal stays active, and the journal records a `checkpoint` rather than a `usage_limited` cause.

Both were mutation-checked rather than merely observed to pass. Reverting the byte cap on checkpoint claims to the old character slice fails the multi-byte test and leaves the other 29 in that file green. Restoring the `!truncated` gate on `shouldCheckpoint` fails the salvage test and leaves the other 108 in the runtime file green. Both mutations were reverted and the suites re-run clean.

The existing `moves to usage_limited when checkpoint %s fails` case was split: `flush` and `read` still assert `usage_limited`, because a transient I/O failure is unrelated to this change, while `truncated` became the salvage test above. One existing multi-byte fixture was rescaled from 26 records to 55 — its intent is that a window crossing the 19,200-byte threshold arms a checkpoint, and a correctly capped CJK entry now costs about 364 bytes instead of about 910, so the same record count no longer reaches the threshold. The assertion is unchanged; only the fixture size moved.

`npx vitest run packages/core/src/goals/` passes 388 tests across 15 files. `npx tsc --noEmit` in `packages/core` is clean apart from pre-existing `@types/node` skew in `src/utils/tool-result-boundary-diagnostics.ts`, a file this PR does not touch. `prettier` and `eslint` are clean on all four changed files.

### Evidence (Before & After)

Before, from the reported session: a Chinese Goal ran 27 turns and stopped as `usage_limited` with `The current Goal revision exceeded the bounded evidence catalog. Automatic retries cannot recover. Edit or replace the Goal before resuming it.` — 27 of 60 files written, no output, and `/goal resume` refused.

After: a full 32-claim Chinese checkpoint occupies roughly 13,000 bytes rather than 29,000, so the window is not truncated on arrival; and when a window does overflow, the runtime compresses it and the Goal stays active.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, Node.js 22, unit tests only.

## Risk & Scope

- Main risk or tradeoff: non-Latin previews get shorter — a Chinese preview now holds about 80 characters where it previously held 240. That is the cost of the cap actually holding, and it is the same information density ASCII has always had. Previews are a catalog index, not the evidence itself: the terminal verifier reads full content through `evidenceContent`, which is capped separately and unchanged here. ASCII previews are byte-for-byte unchanged, since the two units already agreed there.
- Not validated / out of scope: this does not change `CATALOG_BYTE_LIMIT`, `CHECKPOINT_BYTE_THRESHOLD` or the claim budget — the units are reconciled at the values already in the tree rather than retuned. It does not add compaction-effectiveness detection: a checkpoint that compresses but does not shrink enough will still overflow again, which is a separate change. Windows and macOS were not exercised locally and remain covered by CI.
- Breaking changes / migration notes: none. Goals persisted with longer previews are re-projected through the cap when their window is next built, so an existing transcript is not invalidated. Scope for the core triage gate: 49 added and 7 deleted production lines across two files in `packages/core/src/goals`, with no cross-package change.

## Linked Issues

None — the failure is reported here rather than in an existing issue.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

证据目录的 preview 现在按 240 个 UTF-8 **字节**、在码点边界上截断，而不是按 240 个**字符**；截断施加在构造 catalog entry 的两个汇聚点上。另外，被截断的证据窗口现在会压缩它已经捕获的内容，而不是停掉 Goal —— 只有「什么都没捕获到」的窗口才仍然失败。

## 为什么需要

catalog 预算是 24,000 字节，而喂给它的 preview 上限是 240 个字符。UTF-8 下这两个单位最多相差四倍，因此这道防线只在 ASCII 下成立。

后果不是调参问题，而是 Goal 在某些语言下根本跑不了。一个 checkpoint 最多可以携带 32 条 claim，每条会被投影成 catalog 中的一条 preview 加一个小信封。ASCII 下每条约 430 字节，满载 checkpoint 占 13,760 字节 —— 预算的 57%，之后还能装大约 23 条记录。中文下同样合法的 checkpoint 序列化后约 29,000 字节，**在还没扫描任何一条新记录之前，光它自己就越过了上限**。窗口于是被标记为 truncated，而 `shouldCheckpoint` 要求 `!truncated` —— 压缩本该解决的那个状态，恰恰是它拒绝运行的那个状态。运行时把这读作不可恢复，将 Goal 停为 `usage_limited`（`reduceGoalResume` 拒绝恢复的那个状态），而且此时没有任何可抢救的东西，因为一条候选证据都还没被收集。

英文 Goal 永远到不了这个状态；中文 Goal 则无法避免它：故障在第一个填满 claim 预算的 checkpoint 上就会到来，与运行得好不好无关。

第二半是第一半的推论。一个越过预算的窗口，正是压缩存在的意义 —— 装得下的那些最新证据，恰恰是 checkpoint 要折叠成 claim 的东西，而被留下的更旧证据早已被上一个 checkpoint 的 claim 覆盖。在那里拒绝压缩、转而停掉 Goal，严格劣于压缩手头能压的部分。

## 评审者测试计划

### 如何验证

用非拉丁文字（报告的案例是中文）的 objective 跑一个 Goal，跑到它做出一个 claim 填满预算的 checkpoint。改动之前，下一个窗口在构造时就是 truncated，Goal 以 `usage_limited` 与 `limitKind: 'evidence_catalog'` 停止，`/goal resume` 被拒绝。改动之后，checkpoint 稳稳落在 catalog 预算之内，运行继续。然后刻意制造一次溢出（游标之后超过 100 条记录），确认 Goal 现在会做一次 checkpoint 并保持 active，而不是停止。

两个测试承载这次改动。`does not start truncated under a full checkpoint of multi-byte claims` 构造一个携带 32 条、每条 2,000 个中文字符 claim 的 goal（checkpoint 可容纳的上限），断言窗口未被截断。`compresses a truncated window instead of stopping the Goal` 把 101 条游标后记录送进运行时，断言 checkpoint verifier 被调用、Goal 保持 active、journal 记录的是 `checkpoint` 而不是 `usage_limited`。

两者都做了变异检验而不只是「跑通了」。把 checkpoint claim 的字节封顶改回旧的字符切片，恰好让多字节那个测试失败，同文件其余 29 个仍绿。把 `shouldCheckpoint` 上的 `!truncated` 门恢复，恰好让抢救那个测试失败，runtime 文件其余 108 个仍绿。两次变异都已还原并重跑干净。

既有的 `moves to usage_limited when checkpoint %s fails` 用例被拆开：`flush` 与 `read` 仍断言 `usage_limited`，因为瞬时 I/O 失败与本次改动无关；`truncated` 则变成了上面那个抢救测试。另有一个既有的多字节 fixture 从 26 条记录扩到 55 条 —— 它的意图是「跨过 19,200 字节阈值的窗口会武装 checkpoint」，而正确封顶后的 CJK entry 现在约 364 字节而非约 910，同样的记录数不再够到阈值。断言未变，只是 fixture 规模改了。

`npx vitest run packages/core/src/goals/` 通过 15 个文件共 388 个测试。`packages/core` 的 `npx tsc --noEmit` 干净，仅剩 `src/utils/tool-result-boundary-diagnostics.ts` 中预先存在的 `@types/node` 偏斜，本 PR 未触及该文件。四个改动文件的 `prettier` 与 `eslint` 均干净。

### 证据（修复前后）

修复前，来自已报告的 session：一个中文 Goal 跑了 27 轮后以 `usage_limited` 停止，原因是 `The current Goal revision exceeded the bounded evidence catalog. Automatic retries cannot recover. Edit or replace the Goal before resuming it.` —— 60 个文件写了 27 个、没有产出，且 `/goal resume` 被拒绝。

修复后：满载 32 条 claim 的中文 checkpoint 约占 13,000 字节而非 29,000，窗口在构造时不再是 truncated；而当窗口确实溢出时，运行时会压缩它，Goal 保持 active。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Linux、Node.js 22，仅单元测试。

## 风险与范围

- 主要风险或取舍：非拉丁文字的 preview 会变短 —— 中文 preview 现在约容纳 80 个字符，此前是 240 个。这是「上限真正生效」的代价，而且这正是 ASCII 一直以来的信息密度。preview 是目录索引而不是证据本身：终审 verifier 通过 `evidenceContent` 读取完整内容，那一路有独立的封顶，本 PR 未改动。ASCII 的 preview 逐字节不变，因为那里两个单位本来就一致。
- 未验证/不在范围：本 PR 不改动 `CATALOG_BYTE_LIMIT`、`CHECKPOINT_BYTE_THRESHOLD` 或 claim 预算 —— 是在树上已有的数值下把单位对齐，而不是重新调参。它也不加入「压缩是否有效」的检测：一个压缩了但没缩够的 checkpoint 仍会再次溢出，那是另一次改动。Windows 与 macOS 未在本地验证，仍由 CI 覆盖。
- 破坏性变更/迁移说明：无。以更长 preview 持久化的 Goal，在下次构造窗口时会重新经过封顶投影，因此既有转录不会失效。供 core triage gate 参考的规模：`packages/core/src/goals` 下两个文件，新增 49 行、删除 7 行生产代码，无跨包改动。

## 关联 Issue

无 —— 该故障在此处首次记录，没有对应的既有 issue。

</details>
