### PR TITLE
fix(core): scope debug logs to daemon session context

### DIFF
--- a/packages/core/src/utils/debugLogger.test.ts
+++ b/packages/core/src/utils/debugLogger.test.ts
@@ -17,6 +17,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { Storage } from '../config/storage.js';
 import { getTraceContext } from '../telemetry/trace-context.js';
+import { sessionIdContext } from './sessionIdContext.js';
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -96,6 +97,27 @@ describe('debugLogger', () => {
       logger.info('visible outside context');
       await vi.runAllTimersAsync();
       expect(fs.appendFile).toHaveBeenCalledOnce();
+    });
+
+    it('prefers the daemon session id context over the global debug session', async () => {
+      setDebugLogSession({ getSessionId: () => 'session-b' });
+      const logger = createDebugLogger('ACP');
+
+      await sessionIdContext.run('session-a', async () => {
+        logger.info('session scoped line');
+        await vi.runAllTimersAsync();
+      });
+
+      expect(fs.appendFile).toHaveBeenCalledWith(
+        Storage.getDebugLogPath('session-a'),
+        '2026-01-24T10:30:00.000Z [INFO] [ACP] session scoped line\n',
+        'utf8',
+      );
+      expect(fs.appendFile).not.toHaveBeenCalledWith(
+        Storage.getDebugLogPath('session-b'),
+        expect.any(String),
+        'utf8',
+      );
     });
 
     it('writes debug log without trace context when telemetry context is unset', async () => {

--- a/packages/core/src/utils/debugLogger.ts
+++ b/packages/core/src/utils/debugLogger.ts
@@ -10,6 +10,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import util from 'node:util';
 import { Storage } from '../config/storage.js';
 import { updateSymlink } from './symlink.js';
+import { sessionIdContext } from './sessionIdContext.js';
 import {
   getTraceContext,
   type TraceContext,
@@ -45,7 +46,14 @@ export function isDebugLogFileEnabled(): boolean {
 function getActiveSession(): DebugLogSession | null {
   const contextSession = sessionContext.getStore();
   if (contextSession === false) return null;
-  return contextSession ?? globalSession;
+  if (contextSession) return contextSession;
+
+  const daemonSessionId = sessionIdContext.getStore();
+  if (daemonSessionId) {
+    return { getSessionId: () => daemonSessionId };
+  }
+
+  return globalSession;
 }
 
 function ensureDebugDirExists(): Promise<void> {
@@ -204,7 +212,8 @@ export function runWithoutDebugLogSession<T>(fn: () => T): T {
  *
  * Session resolution order:
  * 1) async-local suppression or session
- * 2) process-wide session (setDebugLogSession)
+ * 2) daemon async-local session ID
+ * 3) process-wide session (setDebugLogSession)
  */
 export function createDebugLogger(tag?: string): DebugLogger {
   return {


### PR DESCRIPTION
## Summary
- Route debug log writes through `sessionIdContext` before falling back to the process-wide debug session.
- Add a regression test proving an ACP daemon session writes to its own debug log even when another session is the global fallback.

## Linked Issues
Fixes #9535

## Test Plan
- npm test --workspace @qwen-code/qwen-code-core -- --run src/utils/debugLogger.test.ts
- npm run typecheck --workspace @qwen-code/qwen-code-core
- npm run lint --workspace @qwen-code/qwen-code-core -- src/utils/debugLogger.ts src/utils/debugLogger.test.ts