### PR TITLE
fix(serve): allow dotdot-prefixed cwd subdirectories

### DIFF
--- a/packages/cli/src/serve/workspace-route-runtime.test.ts
+++ b/packages/cli/src/serve/workspace-route-runtime.test.ts
@@ -60,6 +60,14 @@ describe('resolveContainedCwd', () => {
     );
   });
 
+  it('returns the resolved path for a contained directory starting with dotdot', () => {
+    const sub = path.join(workspace, '..build');
+    fs.mkdirSync(sub);
+    expect(resolveContainedCwd(fakeReq(sub), workspace)).toBe(
+      fs.realpathSync(sub),
+    );
+  });
+
   it('accepts the workspace root itself', () => {
     expect(resolveContainedCwd(fakeReq(workspace), workspace)).toBe(
       fs.realpathSync(workspace),
@@ -116,6 +124,14 @@ describe('resolveContainedCwdOrFail', () => {
 
   it('returns the resolved path for a valid contained cwd', () => {
     const sub = path.join(workspace, 'sub');
+    fs.mkdirSync(sub);
+    expect(resolveContainedCwdOrFail(fakeReq(sub), workspace)).toBe(
+      fs.realpathSync(sub),
+    );
+  });
+
+  it('returns the resolved path for a contained cwd starting with dotdot', () => {
+    const sub = path.join(workspace, '..build');
     fs.mkdirSync(sub);
     expect(resolveContainedCwdOrFail(fakeReq(sub), workspace)).toBe(
       fs.realpathSync(sub),

--- a/packages/cli/src/serve/workspace-route-runtime.ts
+++ b/packages/cli/src/serve/workspace-route-runtime.ts
@@ -7,6 +7,7 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
 import type { Request, Response } from 'express';
+import { isWithinRoot } from '../config/path-comparison.js';
 import { canonicalizeWorkspace } from './acp-session-bridge.js';
 import type {
   WorkspaceEntry,
@@ -342,8 +343,7 @@ export function resolveContainedCwd(
   try {
     const resolved = fs.realpathSync(path.resolve(rawCwd));
     const root = fs.realpathSync(workspaceCwd);
-    const rel = path.relative(root, resolved);
-    if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+    if (isWithinRoot(resolved, root)) {
       return resolved;
     }
   } catch {
@@ -376,8 +376,7 @@ export function resolveContainedCwdOrFail(
   try {
     const resolved = fs.realpathSync(path.resolve(rawCwd));
     const root = fs.realpathSync(workspaceCwd);
-    const rel = path.relative(root, resolved);
-    if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+    if (isWithinRoot(resolved, root)) {
       return resolved;
     }
   } catch {


### PR DESCRIPTION
## What this PR does

Updates serve workspace cwd containment checks so an in-workspace directory whose basename starts with `..` (for example `<workspace>/..build`) is treated as contained, while real parent traversal such as `<workspace>/../outside` remains rejected.

## Why it's needed

The serve git routes accept a `cwd` under the workspace. The previous inline check used `rel.startsWith('..')`, so `path.relative(workspace, path.join(workspace, '..build'))` produced `..build` and was incorrectly classified as escaping the workspace. Read routes could silently fall back to the workspace root and mutation routes could reject the cwd with `invalid_cwd`, even though the path is inside the workspace. This aligns the check with the repository's segment-aware containment rule: reject only `..`, `../...`, and absolute relatives.

## Reviewer Test Plan

### How to verify

Run the targeted serve runtime tests and confirm that dotdot-prefixed in-workspace directories are accepted while real parent traversal is still rejected.

### Evidence (Before & After)

Before: the added regression test for `..build` fails because the old `startsWith('..')` check treats it as parent traversal. After: the targeted test suite passes, and existing parent traversal rejection remains covered.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local Node/npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: Low; this only narrows the rejection condition to segment-aware parent traversal and keeps absolute-path rejection intact.
- Not validated / out of scope: Manual end-to-end serve route testing in a browser client.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #8835 (`contained-cwd-dotdot-prefix`).

<details>
<summary>中文说明</summary>

## What this PR does

更新 serve workspace 的 cwd 包含性判断：如果工作区内目录名以 `..` 开头（例如 `<workspace>/..build`），仍然视为工作区内路径；真正的父目录逃逸（例如 `<workspace>/../outside`）仍会被拒绝。

## Why it's needed

serve 的 git 路由允许传入工作区内的 `cwd`。旧逻辑使用 `rel.startsWith('..')`，所以 `path.relative(workspace, path.join(workspace, '..build'))` 得到 `..build` 后会被误判为逃逸工作区。读取类路由可能静默回退到工作区根目录，变更类路由可能返回 `invalid_cwd`，但该路径实际仍在工作区内。本 PR 将判断改为仓库已有的分段感知规则：只拒绝 `..`、`../...` 和绝对相对路径。

## Reviewer Test Plan

### How to verify

运行目标 serve runtime 测试，确认工作区内 `..build` 这类目录可被接受，同时真正的父目录逃逸仍被拒绝。

### Evidence (Before & After)

Before：新增的 `..build` 回归测试会失败，因为旧的 `startsWith('..')` 检查会把它当作父目录穿越。After：目标测试套件通过，已有父目录逃逸拒绝逻辑仍被覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

macOS 本地 Node/npm 工作区。

## Risk & Scope

- Main risk or tradeoff: 低；只把拒绝条件收窄为分段感知的父目录穿越判断，并保留绝对路径拒绝。
- Not validated / out of scope: 未手工跑浏览器客户端里的 serve route 端到端流程。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #8835 (`contained-cwd-dotdot-prefix`).

</details>