### PR TITLE
fix(vscode): sync companion token limits

### DIFF
--- a/packages/vscode-ide-companion/src/utils/tokenLimits.test.ts
+++ b/packages/vscode-ide-companion/src/utils/tokenLimits.test.ts
@@ -92,4 +92,41 @@ describe('vscode-ide-companion tokenLimit (browser-safe mirror)', () => {
       expect(tokenLimit('some-unknown-model', 'output')).toBe(32_000);
     });
   });
+
+  describe('DeepSeek limits', () => {
+    it('returns 1M input and 384K output for DeepSeek V4 models', () => {
+      expect(tokenLimit('deepseek-v4-flash')).toBe(1_000_000);
+      expect(tokenLimit('deepseek-v4-pro')).toBe(1_000_000);
+      expect(tokenLimit('deepseek-v4-flash', 'output')).toBe(384_000);
+      expect(tokenLimit('deepseek-v4-pro', 'output')).toBe(384_000);
+    });
+  });
+
+  describe('Zhipu GLM limits', () => {
+    it('returns 1M input for GLM-5.2+ while preserving 200K for GLM-5.1 and earlier', () => {
+      expect(tokenLimit('glm-5.2')).toBe(1_000_000);
+      expect(tokenLimit('GLM-5.2')).toBe(1_000_000);
+      expect(tokenLimit('zai/GLM-5.2')).toBe(1_000_000);
+      expect(tokenLimit('glm-6')).toBe(1_000_000);
+      expect(tokenLimit('glm-10')).toBe(1_000_000);
+      expect(tokenLimit('glm-5.1')).toBe(202_752);
+      expect(tokenLimit('glm-4.7')).toBe(202_752);
+    });
+
+    it('returns 128K output for GLM-5.x and 16K for GLM-4.7', () => {
+      expect(tokenLimit('glm-5.2', 'output')).toBe(131_072);
+      expect(tokenLimit('GLM-5.2', 'output')).toBe(131_072);
+      expect(tokenLimit('glm-5.1', 'output')).toBe(131_072);
+      expect(tokenLimit('glm-5', 'output')).toBe(131_072);
+      expect(tokenLimit('glm-4.7', 'output')).toBe(16_384);
+    });
+  });
+
+  describe('MiniMax limits', () => {
+    it('returns 1M input for MiniMax-M3 while preserving existing MiniMax limits', () => {
+      expect(tokenLimit('MiniMax-M3')).toBe(1_000_000);
+      expect(tokenLimit('MiniMax-M2.5')).toBe(196_608);
+      expect(tokenLimit('MiniMax-M2.1')).toBe(200_000);
+    });
+  });
 });

--- a/packages/vscode-ide-companion/src/utils/tokenLimits.ts
+++ b/packages/vscode-ide-companion/src/utils/tokenLimits.ts
@@ -48,6 +48,7 @@ const LIMITS = {
   '200k': 200_000,
   '256k': 262_144,
   '272k': 272_000,
+  '384k': 384_000,
   '400k': 400_000,
   '512k': 524_288,
   '1m': 1_000_000,
@@ -137,13 +138,16 @@ const INPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^qwen/, LIMITS['256k']],
 
   // DeepSeek
+  [/^deepseek-v4/, LIMITS['1m']],
   [/^deepseek/, LIMITS['128k']],
 
   // Zhipu GLM
-  [/^glm-5/, 202_752 as TokenCount],
+  [/^glm-5(\.[01])?(-|$)/, 202_752 as TokenCount],
+  [/^glm-(?:[5-9]|\d{2,})/, LIMITS['1m']],
   [/^glm-/, 202_752 as TokenCount],
 
   // MiniMax
+  [/^minimax-m3/i, LIMITS['1m']],
   [/^minimax-m2\.5/i, LIMITS['192k']],
   [/^minimax-/i, LIMITS['200k']],
 
@@ -177,11 +181,12 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^coder-model$/, LIMITS['64k']],
   [/^qwen/, LIMITS['32k']],
 
+  [/^deepseek-v4/, LIMITS['384k']],
   [/^deepseek-reasoner/, LIMITS['64k']],
   [/^deepseek-r1/, LIMITS['64k']],
   [/^deepseek-chat/, LIMITS['8k']],
 
-  [/^glm-5/, LIMITS['16k']],
+  [/^glm-5(?:\.\d+)?(?:-|$)/, LIMITS['128k']],
   [/^glm-4\.7/, LIMITS['16k']],
 
   [/^minimax-m2\.5/i, LIMITS['64k']],


### PR DESCRIPTION
## What this PR does

Updates the browser-safe VS Code companion token-limit mirror so it matches the core model limits for newer DeepSeek, GLM, and MiniMax model families.

## Why it's needed

The companion mirror can otherwise report stale fallback context or output windows for these model identifiers when the browser-safe fallback path is used, while core already knows the newer limits.

## Reviewer Test Plan

### How to verify

Run the VS Code companion token limit tests and confirm DeepSeek V4, GLM-5.2+, and MiniMax-M3 resolve to the same limits as core.

### Evidence (Before & After)

Before: the added regression cases failed for DeepSeek V4 input, GLM-5.2+ input/output, and MiniMax-M3 input because the mirror returned older fallback limits.

After: `npm test -- src/utils/tokenLimits.test.ts` passes with 15 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local package checks from `packages/vscode-ide-companion`: `npm test -- src/utils/tokenLimits.test.ts`, `npm run check-types`, `npm run lint`, and `npm run build`.

## Risk & Scope

- Main risk or tradeoff: low; this only updates the companion fallback mirror to match existing core limits.
- Not validated / out of scope: Windows and Linux local runs; GitHub Actions should cover them.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

更新 VS Code companion 的浏览器安全 token limit mirror，使它和 core 里较新的 DeepSeek、GLM、MiniMax 模型限制保持一致。

## Why it's needed

如果浏览器安全 fallback 路径被使用，旧 mirror 会对这些模型返回过时的上下文或输出窗口，而 core 已经维护了更新后的限制。

## Reviewer Test Plan

### How to verify

运行 VS Code companion 的 token limit 测试，确认 DeepSeek V4、GLM-5.2+、MiniMax-M3 和 core 返回一致的限制。

### Evidence (Before & After)

Before：新增回归用例会失败，失败点分别是 DeepSeek V4 input、GLM-5.2+ input/output、MiniMax-M3 input 返回了旧 fallback 限制。

After：`npm test -- src/utils/tokenLimits.test.ts` 通过，15 个测试全部成功。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

在 `packages/vscode-ide-companion` 下完成本地 package 检查：`npm test -- src/utils/tokenLimits.test.ts`、`npm run check-types`、`npm run lint`、`npm run build`。

## Risk & Scope

- Main risk or tradeoff：低风险；只把 companion fallback mirror 同步到 core 已有模型限制。
- Not validated / out of scope：未在 Windows 和 Linux 本地运行，交给 GitHub Actions 覆盖。
- Breaking changes / migration notes：无。

## Linked Issues

N/A

</details>