### PR TITLE
docs(vscode): correct minimum VS Code version

### DIFF
--- a/packages/vscode-ide-companion/README.md
+++ b/packages/vscode-ide-companion/README.md
@@ -25,7 +25,7 @@ Seamlessly integrate [Qwen Code](https://github.com/QwenLM/qwen-code) into Visua
 
 ## Requirements
 
-- Visual Studio Code 1.85.0 or newer (also works with Cursor, Windsurf, and other VS Code-based editors)
+- Visual Studio Code 1.96.0 or newer (also works with Cursor, Windsurf, and other VS Code-based editors)
 
 ## Quick Start
 


### PR DESCRIPTION
## What this PR does

Updates the VS Code companion requirements to state the extension's actual minimum supported VS Code version.

## Why it's needed

The README advertised compatibility with VS Code 1.85.0, but the extension manifest requires 1.96.0. Users on 1.85-1.95 would be told the extension should work even though VS Code will not load it.

## Reviewer Test Plan

### How to verify

Compare the README requirement with the extension manifest's `engines.vscode` field and confirm both now say 1.96.0.

### Evidence (Before & After)

Before: README said VS Code 1.85.0 or newer while the manifest required 1.96.0.

After: README and manifest both use 1.96.0.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Docs-only change. Verified formatting with `npx prettier --check packages/vscode-ide-companion/README.md`.

## Risk & Scope

- Main risk or tradeoff: low; this only corrects documentation to match enforced manifest metadata.
- Not validated / out of scope: extension runtime behavior.
- Breaking changes / migration notes: none.

## Linked Issues

References #8835

<details>
<summary>中文说明</summary>

## What this PR does

更新 VS Code companion 的 Requirements 文档，使其写明扩展真实支持的最低 VS Code 版本。

## Why it's needed

README 原本写的是 VS Code 1.85.0 或更新版本，但扩展 manifest 要求 1.96.0。1.85-1.95 的用户会被文档误导，因为 VS Code 实际不会加载该扩展。

## Reviewer Test Plan

### How to verify

对比 README 的版本要求和扩展 manifest 的 `engines.vscode` 字段，确认两者现在都为 1.96.0。

### Evidence (Before & After)

Before：README 写的是 VS Code 1.85.0 或更新版本，而 manifest 要求 1.96.0。

After：README 和 manifest 都写为 1.96.0。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

纯文档变更。已用 `npx prettier --check packages/vscode-ide-companion/README.md` 验证格式。

## Risk & Scope

- Main risk or tradeoff：低风险；只把文档改到和 manifest 中实际强制的版本一致。
- Not validated / out of scope：扩展运行时行为。
- Breaking changes / migration notes：无。

## Linked Issues

References #8835

</details>