### PR TITLE
docs(zed): use real debug log env var

### DIFF
--- a/packages/zed-extension/README.md
+++ b/packages/zed-extension/README.md
@@ -60,7 +60,7 @@ For additional environment variables, configure them in your Zed settings:
   "agent_servers": {
     "qwen-code": {
       "env": {
-        "QWEN_LOG_LEVEL": "info",
+        "QWEN_DEBUG_LOG_FILE": "/tmp/qwen-code-debug.log",
         "YOUR_CUSTOM_VAR": "value"
       }
     }

--- a/packages/zed-extension/README.md
+++ b/packages/zed-extension/README.md
@@ -60,7 +60,7 @@ For additional environment variables, configure them in your Zed settings:
   "agent_servers": {
     "qwen-code": {
       "env": {
-        "QWEN_DEBUG_LOG_FILE": "/tmp/qwen-code-debug.log",
+        "QWEN_DEBUG_LOG_FILE": "1",
         "YOUR_CUSTOM_VAR": "value"
       }
     }


### PR DESCRIPTION
## What this PR does

Updates the Zed extension environment-variable example to use a real Qwen Code debug logging variable.

## Why it's needed

The README example used `QWEN_LOG_LEVEL`, but that variable is not read by Qwen Code. The replacement points users to `QWEN_DEBUG_LOG_FILE`, which is the environment variable used by the debug logger.

## Reviewer Test Plan

### How to verify

Search the codebase for `QWEN_LOG_LEVEL` and `QWEN_DEBUG_LOG_FILE`; confirm the README no longer documents the nonexistent variable and the replacement matches the logger's environment lookup.

### Evidence (Before & After)

Before: the Zed README showed `QWEN_LOG_LEVEL`, which has no code read sites.

After: the example uses `QWEN_DEBUG_LOG_FILE`, matching the debug logger.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Docs-only change. Verified formatting with `npx prettier --check packages/zed-extension/README.md`.

## Risk & Scope

- Main risk or tradeoff: low; this only fixes a README example.
- Not validated / out of scope: Zed runtime behavior.
- Breaking changes / migration notes: none.

## Linked Issues

References #8835

<details>
<summary>中文说明</summary>

## What this PR does

更新 Zed 扩展 README 的环境变量示例，改用 Qwen Code 实际支持的 debug 日志变量。

## Why it's needed

README 原本使用 `QWEN_LOG_LEVEL`，但 Qwen Code 并不会读取这个变量。替换为 `QWEN_DEBUG_LOG_FILE` 后，示例和 debug logger 的真实环境变量一致。

## Reviewer Test Plan

### How to verify

在代码库中搜索 `QWEN_LOG_LEVEL` 和 `QWEN_DEBUG_LOG_FILE`，确认 README 不再记录不存在的变量，且替换后的变量与 logger 的环境读取一致。

### Evidence (Before & After)

Before：Zed README 展示了没有代码读取点的 `QWEN_LOG_LEVEL`。

After：示例改为 `QWEN_DEBUG_LOG_FILE`，和 debug logger 一致。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

纯文档变更。已用 `npx prettier --check packages/zed-extension/README.md` 验证格式。

## Risk & Scope

- Main risk or tradeoff：低风险；只修正 README 示例。
- Not validated / out of scope：Zed 运行时行为。
- Breaking changes / migration notes：无。

## Linked Issues

References #8835

</details>