### PR TITLE
fix(core): preserve images for multimodal DeepSeek

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type OpenAI from 'openai';
 import { DeepSeekOpenAICompatibleProvider } from './deepseek.js';
+import { determineProvider } from '../index.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import type { Config } from '../../../config/config.js';
 
@@ -223,6 +224,42 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
         content: 'Hello \n\n[Unsupported content type: image_url]',
       });
     });
+
+    it.each(['https://opencode.ai/zen/go/v1', 'https://api.deepseek.com'])(
+      'preserves image parts when image input is enabled on %s',
+      (baseUrl) => {
+        const config = {
+          ...mockContentGeneratorConfig,
+          baseUrl,
+          model: 'deepseek-v4-flash-vision-exp',
+          modalities: { image: true },
+        } as ContentGeneratorConfig;
+        const visionProvider = determineProvider(config, mockCliConfig);
+        const expectedMessage = {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Describe this image' },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://example.com/image.png' },
+            },
+          ],
+        } satisfies OpenAI.Chat.ChatCompletionUserMessageParam;
+        const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+          model: 'deepseek-v4-flash-vision-exp',
+          messages: [structuredClone(expectedMessage)],
+        };
+
+        const result = visionProvider.buildRequest(
+          originalRequest,
+          userPromptId,
+        );
+
+        expect(visionProvider).toBeInstanceOf(DeepSeekOpenAICompatibleProvider);
+        expect(result.messages?.[0]).toEqual(expectedMessage);
+        expect(originalRequest.messages[0]).toEqual(expectedMessage);
+      },
+    );
 
     // https://github.com/QwenLM/qwen-code/issues/3695 — DeepSeek's thinking
     // mode rejects subsequent requests when any prior assistant turn omits

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -16,13 +16,14 @@ import { ensureReasoningContentOnAssistantMessage } from './utils.js';
 /**
  * Hostname-only check used to decide whether `reasoning.effort` should be
  * rewritten into DeepSeek's flat `reasoning_effort` body parameter, and
- * whether to emit `thinking: { type: 'disabled' }` when reasoning is
- * turned off. The broader `isDeepSeekProvider` falls back to model-name
- * matching to cover self-hosted deployments (sglang/vllm/ollama) — that
- * fallback is right for content-part flattening (a model-format
- * constraint) but trusting it for the body-shape rewrite would push a
- * DeepSeek extension at strict OpenAI-compat backends that may not
- * accept it. Keep the two decisions separated.
+ * whether to emit `thinking: { type: 'disabled' }` when reasoning is turned
+ * off. The broader `isDeepSeekProvider` falls back to model-name matching to
+ * cover self-hosted deployments (sglang/vllm/ollama) — that
+ * fallback is right for selecting DeepSeek-specific content handling, but
+ * explicit image support still takes precedence over text-only flattening.
+ * Trusting it for the body-shape rewrite would push a DeepSeek extension at
+ * strict OpenAI-compat backends that may not accept it. Keep the two decisions
+ * separated.
  *
  * Parses the baseUrl with `new URL(...)` and matches the hostname
  * against `api.deepseek.com` (and its subdomains) exactly — a naive
@@ -51,13 +52,13 @@ export function isDeepSeekHostname(
 }
 
 /**
- * Broad detection used to select the DeepSeek provider class for
- * content-part flattening: hostname OR model-name. Self-hosted
- * deployments (sglang/vllm/ollama) running DeepSeek models share the
- * same input-format constraint, so the model-name fallback is
- * intentional. For decisions that depend on the wire shape DeepSeek's
- * own API exposes (e.g. `reasoning_effort`, `thinking`), use
- * `isDeepSeekHostname` instead — see https://github.com/QwenLM/qwen-code/issues/3613.
+ * Broad detection used to select the DeepSeek provider class for content-part
+ * handling: hostname OR model-name. Self-hosted deployments
+ * (sglang/vllm/ollama) running DeepSeek models share the same text-only input
+ * constraint unless image support is explicitly declared. For decisions that
+ * depend on the wire shape DeepSeek's own API exposes (e.g.
+ * `reasoning_effort`, `thinking`), use `isDeepSeekHostname` instead — see
+ * https://github.com/QwenLM/qwen-code/issues/3613.
  */
 export function isDeepSeekProvider(
   contentGeneratorConfig: ContentGeneratorConfig,
@@ -100,16 +101,17 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
   }
 
   /**
-   * DeepSeek's API requires message content to be a plain string, not an
-   * array of content parts. Flatten any text-part arrays into joined
-   * strings; non-text parts (image_url, audio, …) are replaced with a
-   * `[Unsupported content type: <type>]` placeholder so the request still
-   * goes through with a textual breadcrumb rather than silently dropping
-   * the part or raising mid-conversation. Also translate the standard
-   * `reasoning.effort` config into DeepSeek's flat `reasoning_effort`
-   * body parameter — but only on actual DeepSeek hostnames, since the
-   * model-name fallback above can match self-hosted/strict OpenAI-compat
-   * backends that don't accept the DeepSeek extension.
+   * Text-only DeepSeek APIs require message content to be a plain string, not
+   * an array of content parts. Flatten text-only request arrays into joined
+   * strings; non-text parts (image_url, audio, …) are replaced with an
+   * `[Unsupported content type: <type>]` placeholder so the request still goes
+   * through with a textual breadcrumb rather than silently dropping the part
+   * or raising mid-conversation. Models that explicitly declare image input
+   * retain multipart content for compatible gateways. Also translate the
+   * standard `reasoning.effort` config into DeepSeek's flat `reasoning_effort`
+   * body parameter — but only on actual DeepSeek hostnames, since the model-name
+   * fallback above can match self-hosted/strict OpenAI-compat backends that
+   * don't accept the DeepSeek extension.
    */
   override buildRequest(
     request: OpenAI.Chat.ChatCompletionCreateParams,
@@ -124,10 +126,13 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
       return reshaped;
     }
 
-    const messages = reshaped.messages.map((message) => {
-      const flattened = flattenContentParts(message);
-      return ensureReasoningContentOnAssistantMessage(flattened);
-    });
+    const messages = reshaped.messages.map((message) =>
+      ensureReasoningContentOnAssistantMessage(
+        this.contentGeneratorConfig.modalities?.image
+          ? message
+          : flattenContentParts(message),
+      ),
+    );
 
     return {
       ...reshaped,


### PR DESCRIPTION
## What this PR does

This change preserves multipart image input for DeepSeek-compatible routes when the selected model explicitly declares image support. Text-only DeepSeek routes retain their existing request normalization, and regression coverage exercises both the official endpoint and a custom OpenAI-compatible gateway.

## Why it's needed

DeepSeek provider selection also matches model names on custom gateways. That path previously flattened every multipart message after capability resolution, replacing an image with an unsupported-content placeholder even when the user explicitly configured image input. Vision-capable DeepSeek models therefore could not receive images through Qwen Code.

## Reviewer Test Plan

### How to verify

Configure a DeepSeek-named OpenAI-compatible model with image input enabled, send an image, and confirm the backend receives multipart content and describes the image. Then use a text-only DeepSeek configuration and confirm its multipart content still follows the existing string-flattening behavior.

### Evidence (Before & After)

Before: the outgoing image part became `[Unsupported content type: image_url]`.

After: the same local CLI path sent a real PNG to `deepseek-v4-flash-vision-exp`; the model correctly identified a purple-violet interlocking angular mark and a blue circle. The focused provider test passes all 29 cases.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Local source CLI without sandbox; Node.js 24.18.0. Focused provider tests and the core package typecheck passed.

## Risk & Scope

- Main risk or tradeoff: a text-only endpoint incorrectly configured with image support will now receive multipart input and may reject it; the explicit capability declaration is treated as authoritative.
- Not validated / out of scope: other media modalities and live testing on macOS or Windows.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9832

<details>
<summary>中文说明</summary>

## 本 PR 的改动

当选中的模型明确声明支持图片输入时，此改动为 DeepSeek 兼容路由保留多段图片内容。纯文本 DeepSeek 路由继续使用现有请求整形，并通过官方端点和自定义 OpenAI 兼容网关的回归用例覆盖该行为。

## 为什么需要此改动

DeepSeek 提供商选择也会在自定义网关上按模型名匹配。此前该路径会在能力解析后无条件扁平化所有多段消息，即使用户明确配置了图片输入，图片仍会被替换成不支持内容类型的占位符。因此，具备视觉能力的 DeepSeek 模型无法通过 Qwen Code 接收图片。

## 审查者测试计划

### 验证方式

配置一个启用图片输入的 DeepSeek 命名 OpenAI 兼容模型，发送图片，并确认后端收到多段内容且能够描述图片。随后使用纯文本 DeepSeek 配置，确认其多段内容仍采用现有字符串扁平化行为。

### 证据（修复前后）

修复前：发出的图片部分会变成 `[Unsupported content type: image_url]`。

修复后：同一本地 CLI 路径向 `deepseek-v4-flash-vision-exp` 发送了真实 PNG；模型正确识别出紫罗兰色交织棱角图形和蓝色圆形。提供商专项测试的 29 个用例全部通过。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|      macOS       | ⚠️ 未测试 |
|     Windows      | ⚠️ 未测试 |
|      Linux       | ✅ 已测试 |

### 环境（可选）

本地源码 CLI，未启用沙箱；Node.js 24.18.0。提供商专项测试和核心包类型检查均已通过。

## 风险与范围

- 主要风险或取舍：如果纯文本端点被错误配置为支持图片，它现在会收到多段输入并可能拒绝请求；此改动将显式能力声明视为权威配置。
- 未验证或不在范围内：其他媒体模态，以及 macOS 或 Windows 上的真实测试。
- 破坏性变更或迁移说明：无。

## 关联问题

Fixes #9832

</details>