### PR TITLE
docs(headless): fix JSON jq examples

### DIFF
--- a/docs/users/features/headless.md
+++ b/docs/users/features/headless.md
@@ -249,7 +249,7 @@ qwen -p "Explain Docker" --output-format json > docker-explanation.json
 qwen -p "Add more details" >> docker-explanation.txt
 
 # Pipe to other tools
-qwen -p "What is Kubernetes?" --output-format json | jq '.response'
+qwen -p "What is Kubernetes?" --output-format json | jq -r '.[-1].result'
 qwen -p "Explain microservices" | wc -w
 qwen -p "List programming languages" | grep -i "python"
 
@@ -325,14 +325,14 @@ cat src/auth.py | qwen -p "Review this authentication code for security issues" 
 
 ```bash
 result=$(git diff --cached | qwen -p "Write a concise commit message for these changes" --output-format json)
-echo "$result" | jq -r '.response'
+echo "$result" | jq -r '.[-1].result'
 ```
 
 ### API documentation
 
 ```bash
 result=$(cat api/routes.js | qwen -p "Generate OpenAPI spec for these routes" --output-format json)
-echo "$result" | jq -r '.response' > openapi.json
+echo "$result" | jq -r '.[-1].result' > openapi.json
 ```
 
 ### Batch code analysis
@@ -341,7 +341,7 @@ echo "$result" | jq -r '.response' > openapi.json
 for file in src/*.py; do
     echo "Analyzing $file..."
     result=$(cat "$file" | qwen -p "Find potential bugs and suggest improvements" --output-format json)
-    echo "$result" | jq -r '.response' > "reports/$(basename "$file").analysis"
+    echo "$result" | jq -r '.[-1].result' > "reports/$(basename "$file").analysis"
     echo "Completed analysis for $(basename "$file")" >> reports/progress.log
 done
 ```
@@ -350,7 +350,7 @@ done
 
 ```bash
 result=$(git diff origin/main...HEAD | qwen -p "Review these changes for bugs, security issues, and code quality" --output-format json)
-echo "$result" | jq -r '.response' > pr-review.json
+echo "$result" | jq -r '.[-1].result' > pr-review.json
 ```
 
 ### Log analysis
@@ -363,7 +363,7 @@ grep "ERROR" /var/log/app.log | tail -20 | qwen -p "Analyze these errors and sug
 
 ```bash
 result=$(git log --oneline v1.0.0..HEAD | qwen -p "Generate release notes from these commits" --output-format json)
-response=$(echo "$result" | jq -r '.response')
+response=$(echo "$result" | jq -r '.[-1].result')
 echo "$response"
 echo "$response" >> CHANGELOG.md
 ```
@@ -372,12 +372,12 @@ echo "$response" >> CHANGELOG.md
 
 ```bash
 result=$(qwen -p "Explain this database schema" --include-directories db --output-format json)
-total_tokens=$(echo "$result" | jq -r '.stats.models // {} | to_entries | map(.value.tokens.total) | add // 0')
-models_used=$(echo "$result" | jq -r '.stats.models // {} | keys | join(", ") | if . == "" then "none" else . end')
-tool_calls=$(echo "$result" | jq -r '.stats.tools.totalCalls // 0')
-tools_used=$(echo "$result" | jq -r '.stats.tools.byName // {} | keys | join(", ") | if . == "" then "none" else . end')
+total_tokens=$(echo "$result" | jq -r '.[-1].stats.models // {} | to_entries | map(.value.tokens.total) | add // 0')
+models_used=$(echo "$result" | jq -r '.[-1].stats.models // {} | keys | join(", ") | if . == "" then "none" else . end')
+tool_calls=$(echo "$result" | jq -r '.[-1].stats.tools.totalCalls // 0')
+tools_used=$(echo "$result" | jq -r '.[-1].stats.tools.byName // {} | keys | join(", ") | if . == "" then "none" else . end')
 echo "$(date): $total_tokens tokens, $tool_calls tool calls ($tools_used) used with models: $models_used" >> usage.log
-echo "$result" | jq -r '.response' > schema-docs.md
+echo "$result" | jq -r '.[-1].result' > schema-docs.md
 echo "Recent usage trends:"
 tail -5 usage.log
 ```


### PR DESCRIPTION
## What this PR does

Updates headless JSON output examples to read from the final result message in the JSON array, using `.[-1].result` for text output and `.[-1].stats` for usage data.

## Why it's needed

The same document already states that `--output-format json` emits an array of message objects, with final text in the last result message's `result` field. Several later examples still used the legacy object shape (`.response` and top-level `.stats`), so copy-pasted commands would produce empty output or fail to read usage stats.

## Reviewer Test Plan

### How to verify

Inspect `docs/users/features/headless.md` and confirm all JSON examples that extract final text use `jq -r '.[-1].result'`, while usage examples read from `.[-1].stats`.

### Evidence (Before & After)

Before: examples used `.response` and top-level `.stats`, which do not match the documented array output shape. After: examples index the final result message and read fields from that object.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Docs-only change; local markdown formatting checked with Prettier.

## Risk & Scope

- Main risk or tradeoff: Low; this changes documentation examples only.
- Not validated / out of scope: Running the examples against a live provider.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #8835 (`headless-json-jq-response`).

<details>
<summary>中文说明</summary>

## What this PR does

更新 headless JSON 输出示例：最终文本从 JSON 数组最后一个 result message 的 `.[-1].result` 读取，usage 数据从 `.[-1].stats` 读取。

## Why it's needed

同一文档前面已经说明 `--output-format json` 会输出 message object 数组，最终文本位于最后一个 result message 的 `result` 字段。但后面的多个示例仍在使用旧对象结构（`.response` 和顶层 `.stats`），用户复制后会得到空输出或读不到 usage stats。

## Reviewer Test Plan

### How to verify

检查 `docs/users/features/headless.md`，确认所有抽取最终文本的 JSON 示例都使用 `jq -r '.[-1].result'`，usage 示例从 `.[-1].stats` 读取。

### Evidence (Before & After)

Before：示例使用 `.response` 和顶层 `.stats`，与文档描述的数组输出结构不一致。After：示例索引最后一个 result message，并从该对象读取字段。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

仅文档改动；本地用 Prettier 检查 Markdown 格式。

## Risk & Scope

- Main risk or tradeoff: 低；只改文档示例。
- Not validated / out of scope: 未连接真实 provider 跑完整示例。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #8835 (`headless-json-jq-response`).

</details>