### PR TITLE
docs(core): fix goal judge timeout unit

### DIFF
--- a/packages/core/src/goals/goalHook.ts
+++ b/packages/core/src/goals/goalHook.ts
@@ -36,7 +36,7 @@ const debugLogger = createDebugLogger('GOAL_HOOK');
  */
 export const MAX_GOAL_ITERATIONS = 50;
 
-/** Default budget (seconds) for a single goal-judge LLM call. */
+/** Default budget (milliseconds) for a single goal-judge LLM call. */
 export const GOAL_JUDGE_TIMEOUT_MS = 25_000;
 export const GOAL_HOOK_TIMEOUT_SECONDS = 30;
 export const GOAL_HOOK_TIMEOUT_MS = GOAL_HOOK_TIMEOUT_SECONDS * 1000;


### PR DESCRIPTION
## What this PR does

Corrects the `GOAL_JUDGE_TIMEOUT_MS` JSDoc unit from seconds to milliseconds.

## Why it's needed

The constant name, `setTimeout()` call, and debug log all treat `GOAL_JUDGE_TIMEOUT_MS` as milliseconds. The previous comment said seconds, which makes the 25,000 value look like roughly seven hours instead of 25 seconds.

## Reviewer Test Plan

### How to verify

Inspect `packages/core/src/goals/goalHook.ts` and confirm the comment unit matches the `_MS` constant name, `setTimeout()` usage, and debug message suffix.

### Evidence (Before & After)

Before: the comment said `Default budget (seconds)` for a value passed directly to `setTimeout`. After: the comment says `Default budget (milliseconds)`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

Comment-only change; local formatting checked with Prettier.

## Risk & Scope

- Main risk or tradeoff: Low; this changes one comment only.
- Not validated / out of scope: Runtime goal-hook behavior, because no execution logic changed.
- Breaking changes / migration notes: None.

## Linked Issues

Refs #8835 (`goalhook-timeout-unit-mislabeled`).

<details>
<summary>中文说明</summary>

## What this PR does

把 `GOAL_JUDGE_TIMEOUT_MS` 的 JSDoc 单位从 seconds 修正为 milliseconds。

## Why it's needed

常量名、`setTimeout()` 调用和 debug 日志都把 `GOAL_JUDGE_TIMEOUT_MS` 当作毫秒。旧注释写成 seconds，会让 25,000 这个值看起来像约 7 小时，而不是 25 秒。

## Reviewer Test Plan

### How to verify

检查 `packages/core/src/goals/goalHook.ts`，确认注释单位与 `_MS` 常量名、`setTimeout()` 用法和 debug 日志里的 `ms` 后缀一致。

### Evidence (Before & After)

Before：注释写的是 `Default budget (seconds)`，但值直接传给 `setTimeout`。After：注释写的是 `Default budget (milliseconds)`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

仅注释改动；本地用 Prettier 检查格式。

## Risk & Scope

- Main risk or tradeoff: 低；只改一行注释。
- Not validated / out of scope: 未验证 goal-hook 运行时行为，因为没有执行逻辑改动。
- Breaking changes / migration notes: 无。

## Linked Issues

Refs #8835 (`goalhook-timeout-unit-mislabeled`).

</details>