### PR TITLE
docs(core): fix read file paging default comment

### DIFF
--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -529,7 +529,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
   static readonly Name: string = ToolNames.READ_FILE;
 
   // Self-managed: ReadFile controls its own size via line-based paging
-  // (offset/limit, default 2000 lines), so it is exempt from the scheduler's
+  // (offset/limit, default truncateToolOutputLines setting), so it is exempt from the scheduler's
   // char-based truncation. Oversized reads are bounded by the per-message
   // batch budget instead.
   override get maxOutputChars(): number {


### PR DESCRIPTION
## What this PR does

Updates the ReadFile tool comment so it describes the default paging limit as the `truncateToolOutputLines` setting instead of a hard-coded `2000` line value.

## Why it's needed

The actual default comes from `DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES`, currently `1000`, via `config.getTruncateToolOutputLines()`. Keeping the comment tied to the setting avoids stale documentation if the default changes again and removes the current 2000-vs-1000 mismatch.

## Reviewer Test Plan

### How to verify

- `../qwen-code-fail-zero-inode-read/node_modules/.bin/prettier --check packages/core/src/tools/read-file.ts`
- `rg -n "default 2000 lines|default truncateToolOutputLines setting|DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES = 1000" packages/core/src/tools/read-file.ts packages/core/src/config/config.ts`

### Evidence (Before & After)

N/A. This is a comment-only documentation correction.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A.

## Risk & Scope

- Main risk or tradeoff: Very low; this changes only an explanatory comment.
- Not validated / out of scope: Full test suite, because runtime behavior is unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

References #8835 (`readfile-paging-default-2000-vs-1000`).

<details>
<summary>中文说明</summary>

## What this PR does

更新 ReadFile 工具注释，将默认分页限制描述为 `truncateToolOutputLines` 设置，而不是硬编码的 `2000` 行数值。

## Why it's needed

实际默认值来自 `DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES`，当前为 `1000`，并通过 `config.getTruncateToolOutputLines()` 使用。让注释指向设置项可以避免默认值再次变化时文档过期，也消除当前 2000 与 1000 不一致的问题。

## Reviewer Test Plan

### How to verify

- `../qwen-code-fail-zero-inode-read/node_modules/.bin/prettier --check packages/core/src/tools/read-file.ts`
- `rg -n "default 2000 lines|default truncateToolOutputLines setting|DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES = 1000" packages/core/src/tools/read-file.ts packages/core/src/config/config.ts`

### Evidence (Before & After)

N/A。此 PR 只修正文档注释。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A。

## Risk & Scope

- Main risk or tradeoff: 风险很低；只修改解释性注释。
- Not validated / out of scope: 未跑完整测试套件，因为运行时行为没有变化。
- Breaking changes / migration notes: 无。

## Linked Issues

关联 #8835（`readfile-paging-default-2000-vs-1000`）。

</details>