### PR TITLE
docs(acp): update permission mediator status

### DIFF
--- a/packages/acp-bridge/README.md
+++ b/packages/acp-bridge/README.md
@@ -10,7 +10,7 @@ Lift history (#4175 Mode B daemon roadmap):
 | **PR 22a** (#4295)   | Skeleton + `EventBus` + `inMemoryChannel` + `AcpChannel` types + `PermissionMediator` type-only stub                                                                                       | ✅ merged      |
 | **PR 22b/1** (#4298) | Lift `status` + `workspacePaths` + `bridgeErrors` + `bridgeTypes`                                                                                                                          | ✅ merged      |
 | **PR 22b/2** (#4304) | Lift `BridgeOptions` + new `DaemonStatusProvider` injection seam                                                                                                                           | ✅ merged      |
-| **F1**               | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)                                            | ✅ implemented |
+| **F1** (#4490)       | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)                                            | ✅ merged      |
 | **F3 PR 24**         | Implement the four `PermissionMediator` policies (`first-responder`, `designated`, `consensus`, `local-only`) plus audit/emit fan-out; pair-token binding and revocation stay future scope | ✅ implemented |
 
 ## What's here today
@@ -79,14 +79,15 @@ Lift history (#4175 Mode B daemon roadmap):
   child-side `extNotification` routing, early-event buffer + tombstone
   bookkeeping, inline fs proxy for `writeTextFile` / `readTextFile`.
   Exports the supporting `BridgeClientSessionEntry` type consumed by
-  the factory's `resolveEntry` callback.
+  the session-entry lookup passed in by the factory.
 - `bridge` (F1) — `createHttpAcpBridge` factory closure (~3000 LOC)
   - `ChannelInfo` / `SessionEntry` interfaces + factory-only
     helpers (`withTimeout`, `canonicalizeExistingAncestor`,
     `verifyParentWithinWorkspace`, debug log helpers,
     `hasControlCharacter`) + factory constants. Owns session
-    bookkeeping, constructs the `PermissionMediator`, and wires an
-    inline `resolveEntry` callback into `BridgeClient`.
+    bookkeeping, constructs the `MultiClientPermissionMediator` that
+    owns permission state, and passes the session-entry lookup into
+    `BridgeClient`.
 - `bridgeFileSystem` (F1) — `BridgeFileSystem` interface for the
   ACP fs proxy. When wired through `BridgeOptions.fileSystem`,
   `BridgeClient.readTextFile` / `BridgeClient.writeTextFile`

--- a/packages/acp-bridge/README.md
+++ b/packages/acp-bridge/README.md
@@ -5,13 +5,13 @@ and remote-control adapters. Lives in the monorepo, not published to npm.
 
 Lift history (#4175 Mode B daemon roadmap):
 
-| Slice                | Scope                                                                                                                                               | Status         |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| **PR 22a** (#4295)   | Skeleton + `EventBus` + `inMemoryChannel` + `AcpChannel` types + `PermissionMediator` type-only stub                                                | ✅ merged      |
-| **PR 22b/1** (#4298) | Lift `status` + `workspacePaths` + `bridgeErrors` + `bridgeTypes`                                                                                   | ✅ merged      |
-| **PR 22b/2** (#4304) | Lift `BridgeOptions` + new `DaemonStatusProvider` injection seam                                                                                    | ✅ merged      |
-| **F1** (this PR)     | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)     | ✅ in this PR  |
-| **F3 PR 24**         | Implement the four `PermissionMediator` strategies (`first-responder`, `designated`, `consensus`, `local-only`) + pair-token revocation + audit log | ✅ implemented |
+| Slice                | Scope                                                                                                                                                                                      | Status                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| **PR 22a** (#4295)   | Skeleton + `EventBus` + `inMemoryChannel` + `AcpChannel` types + `PermissionMediator` type-only stub                                                                                       | ✅ merged                      |
+| **PR 22b/1** (#4298) | Lift `status` + `workspacePaths` + `bridgeErrors` + `bridgeTypes`                                                                                                                          | ✅ merged                      |
+| **PR 22b/2** (#4304) | Lift `BridgeOptions` + new `DaemonStatusProvider` injection seam                                                                                                                           | ✅ merged                      |
+| **F1** (this PR)     | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)                                            | ✅ in this PR                  |
+| **F3 PR 24**         | Implement the four `PermissionMediator` policies (`first-responder`, `designated`, `consensus`, `local-only`) plus audit/emit fan-out; pair-token binding and revocation stay future scope | ✅ policy dispatch implemented |
 
 ## What's here today
 

--- a/packages/acp-bridge/README.md
+++ b/packages/acp-bridge/README.md
@@ -78,17 +78,15 @@ Lift history (#4175 Mode B daemon roadmap):
   `PermissionMediator`, session-update fan-out into `EventBus`,
   child-side `extNotification` routing, early-event buffer + tombstone
   bookkeeping, inline fs proxy for `writeTextFile` / `readTextFile`.
-  Exports the supporting
-  `PendingPermission` / `PermissionResolutionRecord` /
-  `BridgeClientSessionEntry` types + `MAX_RESOLVED_PERMISSION_RECORDS`
-  cap that the factory's bookkeeping maps consume.
+  Exports the supporting `BridgeClientSessionEntry` type consumed by
+  the factory's `resolveEntry` callback.
 - `bridge` (F1) — `createHttpAcpBridge` factory closure (~3000 LOC)
   - `ChannelInfo` / `SessionEntry` interfaces + factory-only
     helpers (`withTimeout`, `canonicalizeExistingAncestor`,
     `verifyParentWithinWorkspace`, debug log helpers,
-    `hasControlCharacter`) + factory constants. Builds the
-    bookkeeping closures (`resolveEntry`, `registerPending`, etc.)
-    and wires them into `BridgeClient`.
+    `hasControlCharacter`) + factory constants. Owns session
+    bookkeeping, constructs the `PermissionMediator`, and wires an
+    inline `resolveEntry` callback into `BridgeClient`.
 - `bridgeFileSystem` (F1) — `BridgeFileSystem` interface for the
   ACP fs proxy. When wired through `BridgeOptions.fileSystem`,
   `BridgeClient.readTextFile` / `BridgeClient.writeTextFile`

--- a/packages/acp-bridge/README.md
+++ b/packages/acp-bridge/README.md
@@ -74,10 +74,11 @@ Lift history (#4175 Mode B daemon roadmap):
   companion consume this directly instead of each reimplementing the
   child lifecycle.
 - `bridgeClient` (F1) — `BridgeClient` class implementing the ACP
-  `Client` surface: first-responder permission flow, session-update
-  fan-out into `EventBus`, child-side `extNotification` routing,
-  early-event buffer + tombstone bookkeeping, inline fs proxy for
-  `writeTextFile` / `readTextFile`. Exports the supporting
+  `Client` surface: permission requests delegated to
+  `PermissionMediator`, session-update fan-out into `EventBus`,
+  child-side `extNotification` routing, early-event buffer + tombstone
+  bookkeeping, inline fs proxy for `writeTextFile` / `readTextFile`.
+  Exports the supporting
   `PendingPermission` / `PermissionResolutionRecord` /
   `BridgeClientSessionEntry` types + `MAX_RESOLVED_PERMISSION_RECORDS`
   cap that the factory's bookkeeping maps consume.

--- a/packages/acp-bridge/README.md
+++ b/packages/acp-bridge/README.md
@@ -5,13 +5,13 @@ and remote-control adapters. Lives in the monorepo, not published to npm.
 
 Lift history (#4175 Mode B daemon roadmap):
 
-| Slice                | Scope                                                                                                                                               | Status                          |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| **PR 22a** (#4295)   | Skeleton + `EventBus` + `inMemoryChannel` + `AcpChannel` types + `PermissionMediator` type-only stub                                                | ✅ merged                       |
-| **PR 22b/1** (#4298) | Lift `status` + `workspacePaths` + `bridgeErrors` + `bridgeTypes`                                                                                   | ✅ merged                       |
-| **PR 22b/2** (#4304) | Lift `BridgeOptions` + new `DaemonStatusProvider` injection seam                                                                                    | ✅ merged                       |
-| **F1** (this PR)     | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)     | ✅ in this PR                   |
-| **F3 PR 24**         | Implement the four `PermissionMediator` strategies (`first-responder`, `designated`, `consensus`, `local-only`) + pair-token revocation + audit log | F3 in the feature-cohesive plan |
+| Slice                | Scope                                                                                                                                               | Status         |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| **PR 22a** (#4295)   | Skeleton + `EventBus` + `inMemoryChannel` + `AcpChannel` types + `PermissionMediator` type-only stub                                                | ✅ merged      |
+| **PR 22b/1** (#4298) | Lift `status` + `workspacePaths` + `bridgeErrors` + `bridgeTypes`                                                                                   | ✅ merged      |
+| **PR 22b/2** (#4304) | Lift `BridgeOptions` + new `DaemonStatusProvider` injection seam                                                                                    | ✅ merged      |
+| **F1** (this PR)     | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)     | ✅ in this PR  |
+| **F3 PR 24**         | Implement the four `PermissionMediator` strategies (`first-responder`, `designated`, `consensus`, `local-only`) + pair-token revocation + audit log | ✅ implemented |
 
 ## What's here today
 
@@ -25,13 +25,12 @@ Lift history (#4175 Mode B daemon roadmap):
   type contract that `createHttpAcpBridge` (now in this package) plus
   the channels / VSCode IDE companion's own-spawn paths consume via
   `BridgeOptions.channelFactory`.
-- `permission` — type-only `PermissionMediator` interface,
+- `permission` — `PermissionMediator` interface,
   `PermissionPolicy` literal union (4 strategies), and
-  `PermissionResolution` discriminated union. **No implementation
-  yet** — first-responder voting still lives in
-  `BridgeClient.requestPermission` (in `bridgeClient.ts` after F1).
-  F3 PR 24 will move that and add the other three policies behind
-  this interface.
+  `PermissionResolution` discriminated union. `MultiClientPermissionMediator`
+  implements the four policies, owns pending/resolved permission state, and
+  handles strategy dispatch plus audit/emit fan-out; `BridgeClient` only
+  plumbs `requestPermission` into `mediator.request`.
 - `status` (PR 22b/1) — wire-contract status types for
   `/workspace/{mcp,skills,providers,env,preflight}` and
   `/session/:id/{context,supported-commands,tasks}` routes, the
@@ -135,6 +134,6 @@ exported symbols (`createHttpAcpBridge`, `defaultSpawnChannelFactory`,
 - #4175 Mode B daemon roadmap (feature-cohesive F1-F5 plan targeting
   `daemon_mode_b_main`)
 - #3803 `Stage 1.5-prereq AcpChannel lift` (chiga0's original framing)
-- F3 PR 24 will replace the inline first-responder logic in
-  `BridgeClient.requestPermission` with the four `PermissionMediator`
-  strategies declared in `permission.ts`.
+- `permissionMediator.ts` implements the four `PermissionMediator`
+  strategies declared in `permission.ts`; `BridgeClient.requestPermission`
+  delegates to that mediator.

--- a/packages/acp-bridge/README.md
+++ b/packages/acp-bridge/README.md
@@ -5,13 +5,13 @@ and remote-control adapters. Lives in the monorepo, not published to npm.
 
 Lift history (#4175 Mode B daemon roadmap):
 
-| Slice                | Scope                                                                                                                                                                                      | Status                         |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
-| **PR 22a** (#4295)   | Skeleton + `EventBus` + `inMemoryChannel` + `AcpChannel` types + `PermissionMediator` type-only stub                                                                                       | ✅ merged                      |
-| **PR 22b/1** (#4298) | Lift `status` + `workspacePaths` + `bridgeErrors` + `bridgeTypes`                                                                                                                          | ✅ merged                      |
-| **PR 22b/2** (#4304) | Lift `BridgeOptions` + new `DaemonStatusProvider` injection seam                                                                                                                           | ✅ merged                      |
-| **F1** (this PR)     | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)                                            | ✅ in this PR                  |
-| **F3 PR 24**         | Implement the four `PermissionMediator` policies (`first-responder`, `designated`, `consensus`, `local-only`) plus audit/emit fan-out; pair-token binding and revocation stay future scope | ✅ policy dispatch implemented |
+| Slice                | Scope                                                                                                                                                                                      | Status         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| **PR 22a** (#4295)   | Skeleton + `EventBus` + `inMemoryChannel` + `AcpChannel` types + `PermissionMediator` type-only stub                                                                                       | ✅ merged      |
+| **PR 22b/1** (#4298) | Lift `status` + `workspacePaths` + `bridgeErrors` + `bridgeTypes`                                                                                                                          | ✅ merged      |
+| **PR 22b/2** (#4304) | Lift `BridgeOptions` + new `DaemonStatusProvider` injection seam                                                                                                                           | ✅ merged      |
+| **F1**               | Lift `defaultSpawnChannelFactory` + `BridgeClient` + `createHttpAcpBridge` factory closure + new `BridgeFileSystem` injection seam (22b' scope)                                            | ✅ implemented |
+| **F3 PR 24**         | Implement the four `PermissionMediator` policies (`first-responder`, `designated`, `consensus`, `local-only`) plus audit/emit fan-out; pair-token binding and revocation stay future scope | ✅ implemented |
 
 ## What's here today
 

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -6,10 +6,10 @@
 
 /**
  * `PermissionMediator` — interface contract for daemon permission flow.
- * `MultiClientPermissionMediator` in `permissionMediator.ts` implements
- * the supported policies, owns pending/resolved permission state, and
- * is wired through `BridgeClient.requestPermission` plus the
- * `respondToPermission` route in `createHttpAcpBridge`.
+ * `MultiClientPermissionMediator` in `permissionMediator.ts` owns the
+ * policy dispatch and pending/resolved permission state used by
+ * `BridgeClient.requestPermission` plus the `respondToPermission` route
+ * in `createHttpAcpBridge`.
  *
  * The four policies are ordered from cheapest to strongest:
  *
@@ -29,7 +29,7 @@
  *   Use case: workstations where remote control should never grant
  *   privilege escalation.
  *
- * See `permissionMediator.ts` for the production implementation.
+ * See `permissionMediator.ts` for the implementation details.
  */
 export type PermissionPolicy =
   | 'first-responder'
@@ -143,7 +143,7 @@ export type PermissionResolution =
 
 /**
  * The contract `qwen serve`'s permission route layer talks to.
- * `MultiClientPermissionMediator` provides the production implementation.
+ * `MultiClientPermissionMediator` provides the implementation.
  */
 export interface PermissionMediator {
   /** Active policy. May be reconfigured per session in future

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -18,8 +18,9 @@
  *   default; preserves the live-collaboration UX.
  * - `designated` — only the `originatorClientId` that started the
  *   prompt may answer; other clients see `permission_forbidden`.
- *   Use case: per-tenant SaaS where a UI surface must own its own
- *   approvals.
+ *   If the request has no originator, resolution falls back to
+ *   first-responder. Use case: per-tenant SaaS where a UI surface
+ *   must own its own approvals.
  * - `consensus` — N-of-M quorum across the session client IDs
  *   captured when the permission request is issued; intermediate
  *   `permission_partial_vote` events let UIs render progress. Use case:
@@ -38,10 +39,7 @@ export type PermissionPolicy =
   | 'local-only';
 
 /**
- * One pending permission tracked by a `PermissionMediator`. The
- * shape mirrors the current `PendingPermission` record in
- * `@qwen-code/acp-bridge/bridgeClient`
- * so the mediation implementation's lift is a structural rename rather than a redesign.
+ * One pending permission tracked by a `PermissionMediator`.
  */
 export interface PermissionRequestRecord {
   /** ACP `RequestPermission` request id, unique per session. */

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -32,7 +32,10 @@
  * See `permissionMediator.ts` for the production implementation.
  */
 export type PermissionPolicy =
-  'first-responder' | 'designated' | 'consensus' | 'local-only';
+  | 'first-responder'
+  | 'designated'
+  | 'consensus'
+  | 'local-only';
 
 /**
  * One pending permission tracked by a `PermissionMediator`. The

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -20,10 +20,10 @@
  *   prompt may answer; other clients see `permission_forbidden`.
  *   Use case: per-tenant SaaS where a UI surface must own its own
  *   approvals.
- * - `consensus` — N-of-M quorum across pair-token-authenticated
- *   clients before resolving; intermediate `permission_partial_vote`
- *   events let UIs render progress. Use case: enterprise change
- *   review where two operators must agree.
+ * - `consensus` — N-of-M quorum across the session client IDs
+ *   captured when the permission request is issued; intermediate
+ *   `permission_partial_vote` events let UIs render progress. Use case:
+ *   enterprise change review where two operators must agree.
  * - `local-only` — refuses any HTTP voter; the prompt blocks until
  *   a loopback client (the local TUI super-client) resolves it.
  *   Use case: workstations where remote control should never grant
@@ -32,10 +32,7 @@
  * See `permissionMediator.ts` for the production implementation.
  */
 export type PermissionPolicy =
-  | 'first-responder'
-  | 'designated'
-  | 'consensus'
-  | 'local-only';
+  'first-responder' | 'designated' | 'consensus' | 'local-only';
 
 /**
  * One pending permission tracked by a `PermissionMediator`. The

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -11,7 +11,7 @@
  * `BridgeClient.requestPermission` plus the `respondToPermission` route
  * in `createHttpAcpBridge`.
  *
- * The four policies are ordered from cheapest to strongest:
+ * The four policy contracts are ordered from cheapest to strongest:
  *
  * - `first-responder` — first valid `POST /permission/:requestId`
  *   wins; later voters get `permission_already_resolved`. Today's

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -18,11 +18,11 @@
  *   default; preserves the live-collaboration UX.
  * - `designated` — only the `originatorClientId` that started the
  *   prompt may answer; other clients see `permission_forbidden`.
- *   If the request has no originator, resolution falls back to
- *   first-responder. Use case: per-tenant SaaS where a UI surface
- *   must own its own approvals.
+ *   Prompts with no originator fall back to first-responder. Use case:
+ *   per-tenant SaaS where a UI surface must own its own approvals.
  * - `consensus` — N-of-M quorum across the session client IDs
- *   captured when the permission request is issued; intermediate
+ *   captured when the permission request is issued. Client identity is
+ *   self-declared until pair-token authentication lands; intermediate
  *   `permission_partial_vote` events let UIs render progress. Use case:
  *   enterprise change review where two operators must agree.
  * - `local-only` — refuses any HTTP voter; the prompt blocks until

--- a/packages/acp-bridge/src/permission.ts
+++ b/packages/acp-bridge/src/permission.ts
@@ -5,14 +5,11 @@
  */
 
 /**
- * `PermissionMediator` — type-only interface contract for daemon
- * permission flow. **No implementation lives here.** Permission voting
- * still runs inside `BridgeClient.requestPermission`
- * (`@qwen-code/acp-bridge/bridgeClient`) and
- * `respondToPermission` (inside `createHttpAcpBridge` factory closure
- * at `@qwen-code/acp-bridge/bridge` after F1 step 3), hard-coded to
- * `first-responder`. A future change will move that code behind this
- * interface and add the other three policies.
+ * `PermissionMediator` — interface contract for daemon permission flow.
+ * `MultiClientPermissionMediator` in `permissionMediator.ts` implements
+ * the supported policies, owns pending/resolved permission state, and
+ * is wired through `BridgeClient.requestPermission` plus the
+ * `respondToPermission` route in `createHttpAcpBridge`.
  *
  * The four policies are ordered from cheapest to strongest:
  *
@@ -32,9 +29,7 @@
  *   Use case: workstations where remote control should never grant
  *   privilege escalation.
  *
- * See `bridgeClient.ts BridgeClient.requestPermission` for the
- * current first-responder implementation; the `FIXME(stage-1.5)`
- * block above that method scoped this contract.
+ * See `permissionMediator.ts` for the production implementation.
  */
 export type PermissionPolicy =
   | 'first-responder'
@@ -148,9 +143,7 @@ export type PermissionResolution =
 
 /**
  * The contract `qwen serve`'s permission route layer talks to.
- * Today there is one implementation (first-responder) wired
- * inline in `BridgeClient`; The implementation will provide all four behind
- * this surface plus pair-token authentication and an audit log.
+ * `MultiClientPermissionMediator` provides the production implementation.
  */
 export interface PermissionMediator {
   /** Active policy. May be reconfigured per session in future


### PR DESCRIPTION
## What this PR does

Updates the ACP bridge permission documentation so it matches the current implementation: `MultiClientPermissionMediator` implements the permission policies and owns pending/resolved permission state, while `BridgeClient.requestPermission` delegates into the mediator.

## Why it's needed

The README and `permission.ts` comments still described the mediator as a type-only future interface and said first-responder voting lived inline in `BridgeClient.requestPermission`. That is stale against the current source and can mislead readers into looking in the wrong place or reimplementing mediator behavior that already exists.

## Reviewer Test Plan

### How to verify

- `../qwen-code-fail-zero-inode-read/node_modules/.bin/prettier --check packages/acp-bridge/README.md packages/acp-bridge/src/permission.ts`
- `rg -n "No implementation yet|will move|will replace|wired inline|type-only interface contract|MultiClientPermissionMediator|BridgeClient.requestPermission" packages/acp-bridge/README.md packages/acp-bridge/src/permission.ts packages/acp-bridge/src/permissionMediator.ts packages/acp-bridge/src/bridgeClient.ts`

### Evidence (Before & After)

N/A. This is a documentation/comment correction.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A.

## Risk & Scope

- Main risk or tradeoff: Low; this updates documentation and source comments only.
- Not validated / out of scope: No runtime tests were run because implementation code is unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Related to stale ACP bridge permission-mediator documentation noted in repo-hygiene follow-up discussion.

<details>
<summary>中文说明</summary>

## What this PR does

更新 ACP bridge permission 文档，使其与当前实现一致：`MultiClientPermissionMediator` 已实现 permission policies 并持有 pending/resolved permission 状态，`BridgeClient.requestPermission` 只负责委托到 mediator。

## Why it's needed

README 和 `permission.ts` 注释仍把 mediator 描述成未来要实现的 type-only interface，并称 first-responder voting 仍在 `BridgeClient.requestPermission` 内联实现。这个说法已经和当前源码不一致，容易让读者查错位置，甚至重复实现已经存在的 mediator 行为。

## Reviewer Test Plan

### How to verify

- `../qwen-code-fail-zero-inode-read/node_modules/.bin/prettier --check packages/acp-bridge/README.md packages/acp-bridge/src/permission.ts`
- `rg -n "No implementation yet|will move|will replace|wired inline|type-only interface contract|MultiClientPermissionMediator|BridgeClient.requestPermission" packages/acp-bridge/README.md packages/acp-bridge/src/permission.ts packages/acp-bridge/src/permissionMediator.ts packages/acp-bridge/src/bridgeClient.ts`

### Evidence (Before & After)

N/A。此 PR 只修正文档和源码注释。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A。

## Risk & Scope

- Main risk or tradeoff: 风险低；只更新文档和源码注释。
- Not validated / out of scope: 未运行 runtime tests，因为实现代码没有变化。
- Breaking changes / migration notes: 无。

## Linked Issues

关联 repo-hygiene 后续讨论中提到的 ACP bridge permission mediator 过期文档问题。

</details>