### PR TITLE
docs(sdk): fix query timeout example signature

### DIFF
--- a/docs/developers/sdk-typescript.md
+++ b/docs/developers/sdk-typescript.md
@@ -94,12 +94,17 @@ The SDK enforces the following default timeouts:
 You can customize these timeouts via the `timeout` option:
 
 ```typescript
-const query = qwen.query('Your prompt', {
-  timeout: {
-    canUseTool: 60000, // 60 seconds for permission callback
-    mcpRequest: 600000, // 10 minutes for MCP tool calls
-    controlRequest: 60000, // 60 seconds for control requests
-    streamClose: 15000, // 15 seconds for stream close wait
+import { query } from '@qwen-code/sdk';
+
+const q = query({
+  prompt: 'Your prompt',
+  options: {
+    timeout: {
+      canUseTool: 60000, // 60 seconds for permission callback
+      mcpRequest: 600000, // 10 minutes for MCP tool calls
+      controlRequest: 60000, // 60 seconds for control requests
+      streamClose: 15000, // 15 seconds for stream close wait
+    },
   },
 });
 ```

--- a/packages/sdk-typescript/README.md
+++ b/packages/sdk-typescript/README.md
@@ -91,12 +91,17 @@ The SDK enforces the following default timeouts:
 You can customize these timeouts via the `timeout` option:
 
 ```typescript
-const query = qwen.query('Your prompt', {
-  timeout: {
-    canUseTool: 60000, // 60 seconds for permission callback
-    mcpRequest: 600000, // 10 minutes for MCP tool calls
-    controlRequest: 60000, // 60 seconds for control requests
-    streamClose: 15000, // 15 seconds for stream close wait
+import { query } from '@qwen-code/sdk';
+
+const q = query({
+  prompt: 'Your prompt',
+  options: {
+    timeout: {
+      canUseTool: 60000, // 60 seconds for permission callback
+      mcpRequest: 600000, // 10 minutes for MCP tool calls
+      controlRequest: 60000, // 60 seconds for control requests
+      streamClose: 15000, // 15 seconds for stream close wait
+    },
   },
 });
 ```


### PR DESCRIPTION
## What this PR does

Updates the TypeScript SDK timeout examples to use the exported `query({ prompt, options })` factory signature instead of the stale `qwen.query(prompt, options)` call shape.

## Why it's needed

The current timeout examples reference an undefined `qwen` binding and pass two positional arguments, but the SDK API accepts a single object with `prompt` and `options`. Copying the old example would not compile or run, while the updated snippet matches the public API used elsewhere in the docs.

## Reviewer Test Plan

### How to verify

- `../qwen-code-fail-zero-inode-read/node_modules/.bin/prettier --check packages/sdk-typescript/README.md docs/developers/sdk-typescript.md`
- `rg -n "qwen\.query\('Your prompt'|const q = query\(\{|prompt: 'Your prompt'|import \{ query \} from '@qwen-code/sdk';" packages/sdk-typescript/README.md docs/developers/sdk-typescript.md`

### Evidence (Before & After)

N/A. This is a documentation example correction.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A.

## Risk & Scope

- Main risk or tradeoff: Low; this changes documentation examples only.
- Not validated / out of scope: Full SDK test suite, because implementation code is unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

References #8835 (`sdk-ts-readme-query-signature`).

<details>
<summary>中文说明</summary>

## What this PR does

更新 TypeScript SDK timeout 示例，使用导出的 `query({ prompt, options })` factory 签名，而不是过期的 `qwen.query(prompt, options)` 调用形式。

## Why it's needed

当前 timeout 示例引用了未定义的 `qwen` 变量，并传入两个位置参数；但 SDK API 接收的是包含 `prompt` 和 `options` 的单个对象。复制旧示例无法编译或运行，而更新后的片段与文档其他位置使用的公开 API 一致。

## Reviewer Test Plan

### How to verify

- `../qwen-code-fail-zero-inode-read/node_modules/.bin/prettier --check packages/sdk-typescript/README.md docs/developers/sdk-typescript.md`
- `rg -n "qwen\.query\('Your prompt'|const q = query\(\{|prompt: 'Your prompt'|import \{ query \} from '@qwen-code/sdk';" packages/sdk-typescript/README.md docs/developers/sdk-typescript.md`

### Evidence (Before & After)

N/A。此 PR 只修正文档示例。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A。

## Risk & Scope

- Main risk or tradeoff: 风险低；只修改文档示例。
- Not validated / out of scope: 未运行完整 SDK 测试套件，因为实现代码没有变化。
- Breaking changes / migration notes: 无。

## Linked Issues

关联 #8835（`sdk-ts-readme-query-signature`）。

</details>