### PR TITLE
fix(ci): move undeletable workspace residue aside instead of leaving it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,28 @@ jobs:
           set -uo pipefail
           if [ -d "$GITHUB_WORKSPACE/.qwen" ] && [ ! -L "$GITHUB_WORKSPACE/.qwen" ]; then
             chmod -R u+w "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || true
-            rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || sudo -n rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || echo "::warning::leaked .qwen; runner needs manual cleanup"
+            # Last resort when nothing can DELETE the tree: move it out of the
+            # workspace. Unlinking an entry needs write permission on the
+            # directory holding it — which is exactly what a foreign-owned
+            # leftover denies — while renaming needs it only on the two
+            # parents, and the workspace root is always this runner's own. So
+            # a tree that defeats rm, chmod, and a sudo-less chown still
+            # renames aside, and the checkout below finds nothing to trip on.
+            # Leaving it in place instead poisons EVERY later job scheduled
+            # here, not just this one (measured, run 32621267802: `EACCES
+            # rmdir .qwen/tmp/review-pr-9748-scratch-verify-…/probe-ws/…`
+            # killed checkout for two unrelated PRs on the same runner).
+            rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              sudo -n rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              {
+                quarantine="$(dirname -- "$GITHUB_WORKSPACE")/_qwen-quarantine"
+                mkdir -p "$quarantine" 2>/dev/null || true
+                if mv -- "$GITHUB_WORKSPACE/.qwen" "$quarantine/qwen-$(date -u +%Y%m%dT%H%M%SZ)-$$" 2>/dev/null; then
+                  echo "::warning::could not delete leaked .qwen; moved it to $quarantine so this checkout can proceed — that directory needs manual cleanup"
+                else
+                  echo "::warning::leaked .qwen; runner needs manual cleanup"
+                fi
+              }
           fi
           # Interrupted reviews leave worktree registrations under .qwen/tmp/
           # and qwen-review/* branches behind. prune drops registrations whose
@@ -658,7 +679,28 @@ jobs:
           set -uo pipefail
           if [ -d "$GITHUB_WORKSPACE/.qwen" ] && [ ! -L "$GITHUB_WORKSPACE/.qwen" ]; then
             chmod -R u+w "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || true
-            rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || sudo -n rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || echo "::warning::leaked .qwen; runner needs manual cleanup"
+            # Last resort when nothing can DELETE the tree: move it out of the
+            # workspace. Unlinking an entry needs write permission on the
+            # directory holding it — which is exactly what a foreign-owned
+            # leftover denies — while renaming needs it only on the two
+            # parents, and the workspace root is always this runner's own. So
+            # a tree that defeats rm, chmod, and a sudo-less chown still
+            # renames aside, and the checkout below finds nothing to trip on.
+            # Leaving it in place instead poisons EVERY later job scheduled
+            # here, not just this one (measured, run 32621267802: `EACCES
+            # rmdir .qwen/tmp/review-pr-9748-scratch-verify-…/probe-ws/…`
+            # killed checkout for two unrelated PRs on the same runner).
+            rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              sudo -n rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              {
+                quarantine="$(dirname -- "$GITHUB_WORKSPACE")/_qwen-quarantine"
+                mkdir -p "$quarantine" 2>/dev/null || true
+                if mv -- "$GITHUB_WORKSPACE/.qwen" "$quarantine/qwen-$(date -u +%Y%m%dT%H%M%SZ)-$$" 2>/dev/null; then
+                  echo "::warning::could not delete leaked .qwen; moved it to $quarantine so this checkout can proceed — that directory needs manual cleanup"
+                else
+                  echo "::warning::leaked .qwen; runner needs manual cleanup"
+                fi
+              }
           fi
           # Interrupted reviews leave worktree registrations under .qwen/tmp/
           # and qwen-review/* branches behind. prune drops registrations whose
@@ -1092,7 +1134,28 @@ jobs:
           set -uo pipefail
           if [ -d "$GITHUB_WORKSPACE/.qwen" ] && [ ! -L "$GITHUB_WORKSPACE/.qwen" ]; then
             chmod -R u+w "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || true
-            rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || sudo -n rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || echo "::warning::leaked .qwen; runner needs manual cleanup"
+            # Last resort when nothing can DELETE the tree: move it out of the
+            # workspace. Unlinking an entry needs write permission on the
+            # directory holding it — which is exactly what a foreign-owned
+            # leftover denies — while renaming needs it only on the two
+            # parents, and the workspace root is always this runner's own. So
+            # a tree that defeats rm, chmod, and a sudo-less chown still
+            # renames aside, and the checkout below finds nothing to trip on.
+            # Leaving it in place instead poisons EVERY later job scheduled
+            # here, not just this one (measured, run 32621267802: `EACCES
+            # rmdir .qwen/tmp/review-pr-9748-scratch-verify-…/probe-ws/…`
+            # killed checkout for two unrelated PRs on the same runner).
+            rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              sudo -n rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              {
+                quarantine="$(dirname -- "$GITHUB_WORKSPACE")/_qwen-quarantine"
+                mkdir -p "$quarantine" 2>/dev/null || true
+                if mv -- "$GITHUB_WORKSPACE/.qwen" "$quarantine/qwen-$(date -u +%Y%m%dT%H%M%SZ)-$$" 2>/dev/null; then
+                  echo "::warning::could not delete leaked .qwen; moved it to $quarantine so this checkout can proceed — that directory needs manual cleanup"
+                else
+                  echo "::warning::leaked .qwen; runner needs manual cleanup"
+                fi
+              }
           fi
           # Interrupted reviews leave worktree registrations under .qwen/tmp/
           # and qwen-review/* branches behind. prune drops registrations whose

--- a/scripts/tests/review-worktree-cleanup-workflow.test.js
+++ b/scripts/tests/review-worktree-cleanup-workflow.test.js
@@ -11,6 +11,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   symlinkSync,
@@ -128,6 +129,33 @@ function expectCleanupRecipe(run) {
   expect(code.indexOf('worktree prune', remove)).toBeGreaterThan(remove);
   expect(code.indexOf(`refs/heads/${branchFamily}*`)).toBeGreaterThan(remove);
   expectPipedLoopsIsolated(code, 2);
+}
+
+// Deleting the tree is not always possible: a containerised job on this
+// shared pool can leave residue owned by another uid, and on a pool member
+// without passwordless sudo nothing unprivileged can unlink it. Leaving it
+// in place poisons the checkout of every LATER job scheduled here, so the
+// sweep must move it out of the workspace instead of warning and continuing
+// — renaming needs write permission only on the two parents, and the
+// workspace root is always the runner's own.
+function expectQuarantineFallback(run) {
+  const code = stripComments(run);
+  expect(code).toContain('_qwen-quarantine');
+  // The move must be the fallback of the removal chain, not an
+  // unconditional relocation: a workspace that deletes cleanly keeps its
+  // caches.
+  expect(code).toMatch(
+    /rm -rf "\$GITHUB_WORKSPACE\/\.qwen"[\s\S]*?sudo -n rm -rf[\s\S]*?mv -- "\$GITHUB_WORKSPACE\/\.qwen"/,
+  );
+  // Same filesystem by construction — a cross-device `mv` degrades to
+  // copy-then-unlink, which fails on exactly the residue this exists for.
+  expect(code).toContain(
+    '"$(dirname -- "$GITHUB_WORKSPACE")/_qwen-quarantine"',
+  );
+  // The quarantined tree still needs a human: the warning must name where
+  // it went, and the terminal warning must survive for the case where even
+  // the rename fails.
+  expect(code).toContain('leaked .qwen; runner needs manual cleanup');
 }
 
 function expectHardenedGit(run) {
@@ -256,6 +284,7 @@ describe('review worktree cleanup steps', () => {
       expect(cleanIdx, id).toBeLessThan(checkoutIdx);
       expectCleanupRecipe(run);
       expectHardenedGit(run);
+      expectQuarantineFallback(run);
     }
     // The copies are deliberate: a pre-checkout step cannot trust leftover
     // workspace scripts, so the recipe stays inline per job. Pin them
@@ -454,6 +483,93 @@ describe('review worktree cleanup steps', () => {
       });
       expect(out.status).toBe(0);
       expect(out.stdout.trim()).toBe(review);
+    },
+  );
+
+  it.skipIf(!permissionFixturesAvailable)(
+    'the pre-checkout sweep moves residue it cannot delete out of the workspace',
+    () => {
+      // The incident this exists for: residue whose containing directory
+      // denies the unlink, so `rm -rf` fails and actions/checkout dies
+      // wiping the workspace (measured, run 32621267802 — two unrelated PRs
+      // failed at Checkout on the same runner). Reproduced here with a
+      // write-denied parent rather than a foreign uid, which needs root:
+      // the failing syscall and the recovery are the same, and the sweep's
+      // own chmod is stepped over so it cannot repair the fixture away.
+      const root = mkdtempSync(join(tmpdir(), 'ci-quarantine-'));
+      const workspace = join(root, 'repo', 'repo');
+      const poison = join(
+        workspace,
+        `${toPosix(REVIEW_TMP_DIR)}/review-pr-9748-scratch-verify--round-1--x`,
+      );
+      const locked = join(poison, 'probe-ws/.qwen/tmp');
+      try {
+        mkdirSync(join(locked, 'review-pr-666'), { recursive: true });
+        chmodSync(locked, 0o500);
+        const out = spawnSync(
+          'bash',
+          [
+            '-c',
+            // Neutralise the sweep's own chmod and any sudo: this models the
+            // pool member that cannot repair the residue at all.
+            `set -euo pipefail\nchmod() { return 1; }\nsudo() { return 1; }\n${ciCleanSteps[0].run}`,
+            'clean-stale-qwen',
+          ],
+          {
+            cwd: workspace,
+            env: { ...process.env, GITHUB_WORKSPACE: workspace },
+            encoding: 'utf8',
+          },
+        );
+        expect(out.status).toBe(0);
+        // The workspace is clear, so the checkout that follows has nothing
+        // to trip on …
+        expect(existsSync(join(workspace, '.qwen'))).toBe(false);
+        // … and the residue was moved, not deleted: it still needs a human,
+        // and the warning says where it went.
+        const quarantine = join(root, 'repo', '_qwen-quarantine');
+        expect(existsSync(quarantine)).toBe(true);
+        expect(readdirSync(quarantine)).toHaveLength(1);
+        const warnings = out.stdout
+          .split('\n')
+          .filter((line) => line.startsWith('::warning::'));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain('_qwen-quarantine');
+      } finally {
+        // The locked directory has usually MOVED by now (that is the point),
+        // so repair the whole fixture by path rather than the original one.
+        spawnSync('bash', [
+          '-c',
+          `chmod -R u+rwX "${root}" 2>/dev/null || true`,
+        ]);
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(!permissionFixturesAvailable)(
+    'the pre-checkout sweep still deletes residue it can remove',
+    () => {
+      // The fallback must stay a fallback: a workspace that deletes cleanly
+      // keeps its caches instead of accumulating quarantined copies.
+      const root = mkdtempSync(join(tmpdir(), 'ci-quarantine-'));
+      const workspace = join(root, 'repo', 'repo');
+      try {
+        mkdirSync(join(workspace, `${toPosix(REVIEW_TMP_DIR)}/review-pr-77`), {
+          recursive: true,
+        });
+        const out = spawnSync('bash', ['-c', ciCleanSteps[0].run], {
+          cwd: workspace,
+          env: { ...process.env, GITHUB_WORKSPACE: workspace },
+          encoding: 'utf8',
+        });
+        expect(out.status).toBe(0);
+        expect(existsSync(join(workspace, '.qwen'))).toBe(false);
+        expect(existsSync(join(root, 'repo', '_qwen-quarantine'))).toBe(false);
+        expect(out.stdout).not.toContain('::warning::');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
     },
   );
 


### PR DESCRIPTION
## What this PR does

Gives the pre-checkout sweep in `ci.yml` a last resort for residue it cannot delete: move the tree out of the workspace instead of warning and handing it to `actions/checkout` unchanged.

The recovery is a rename, and that is the whole idea. Unlinking an entry needs write permission on the directory holding it — exactly what foreign-owned residue denies on a pool member without passwordless sudo — while renaming needs it only on the two parents, and the workspace root is always the runner's own. So a tree that defeats `rm`, `chmod`, and `chown` still moves aside. The destination sits beside the workspace so the rename cannot cross a filesystem and silently degrade into copy-then-unlink, and the warning names it, because the quarantined tree still needs a human. Removal stays the normal path: a workspace that deletes cleanly keeps its caches and prints nothing.

## Why it's needed

A leftover the sweep cannot delete does not just fail the job that finds it — **it poisons the checkout of every later job scheduled onto that runner.**

Measured on run 32621267802: residue from a review probe survived on one shared-pool member —

```
EACCES: permission denied, rmdir
'…/_work/qwen-code/qwen-code/.qwen/tmp/review-pr-9748-scratch-verify--round-1--721f6d1cc279/probe-ws/.qwen/tmp/review-pr-666'
```

— and two unrelated PRs (#9776 and `feat/review-coverage-ledger`) then died at Checkout on the identical runner and the identical path. Both pre-checkout steps had reported **success** on the way there: their ladder ends at `echo "::warning::leaked .qwen; runner needs manual cleanup"`, so a workspace they cannot repair is passed to checkout exactly as found. The runner stays poisoned until someone logs into the host.

The existing ladder already handles what it can — `chmod`, then `sudo -n chown`/`chmod` where the member has it. This adds the rung for the case those cannot reach, which is the case that was actually observed.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/review-worktree-cleanup-workflow.test.js` — 15 pass, including three new ones. Two execute the real step body extracted from `ci.yml` against a fixture: one where the residue cannot be unlinked (the incident), one where it can (the fallback must stay a fallback).
2. Confirm the tests discriminate: reverting the step to the old warn-and-leave line turns all three red (the pinning test plus both behavioural ones).
3. Reproduce the incident and the fix end to end with real foreign ownership — this needs Linux, because a macOS bind mount maps ownership back to the host user:

```bash
# in a Linux container: residue owned by root, workspace by the runner user,
# sudo unavailable — then run the step body and try a checkout-style wipe.
docker run --rm -v "$PWD:/probe:ro" debian:stable-slim bash -c '…'
```

   Before (`origin/main`'s step):

```
::warning::leaked .qwen; runner needs manual cleanup
--- .qwen still in workspace: yes
wipe error: rm: cannot remove './.qwen/tmp/review-pr-9748-…/probe-ws/.qwen/tmp': Permission denied
RESULT: CHECKOUT WOULD FAIL
```

   After (this branch):

```
::warning::could not delete leaked .qwen; moved it to /work/qwen-code/_qwen-quarantine so this checkout can proceed — that directory needs manual cleanup
--- .qwen still in workspace: no
--- quarantine holds: qwen-20260824T060633Z-24
wipe error: none
RESULT: CHECKOUT WOULD SUCCEED
```

4. Confirm the three shared-pool copies stayed byte-identical (the suite pins this), and that `actionlint` and the workflow-size gate pass.

### Evidence (Before & After)

Before: an unrepairable workspace is handed to `actions/checkout`, which fails; the runner keeps failing every job scheduled onto it.

After: the same workspace is cleared by rename, the checkout proceeds, and a warning names the quarantine directory for manual cleanup. Both states are shown above from the container reproduction, and both are pinned by tests that fail against the previous step body.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

Unit suite on macOS; the foreign-ownership reproduction in a Debian container. The steps run only on the Linux self-hosted pool.

### Environment (optional)

Node.js 22 development checkout on macOS, Docker for the Linux fixture. `actionlint` and `.github/scripts/check-workflow-size.sh` both pass.

## Risk & Scope

- Main risk or tradeoff: quarantined trees accumulate under `_qwen-quarantine` next to the workspace, since by definition this job cannot delete them. That is the point — they are out of the checkout path — but the directory does need occasional manual cleanup, and the warning says so. It is only ever written on a runner that would otherwise have broken.
- Not validated / out of scope: the review workflow's own `remove_review_tree` ladder ends in the same warn-and-leave rung and could take the same fallback; that is a follow-up. This PR fixes the universal path — the pre-checkout sweep every shared-pool job runs — so residue from any workflow stops breaking checkouts. It does not stop residue being created.
- Breaking changes / migration notes: none.

## Linked Issues

None. Observed on run 32621267802 (#9776 and `feat/review-coverage-ledger` both failing at Checkout on runner `…-18`).

<details>
<summary>中文说明</summary>

## 本 PR 做什么

给 `ci.yml` 的 checkout 前清理步骤加一条最后手段：删不掉的残留改为**移出工作区**，而不是打个警告就把工作区原样交给 `actions/checkout`。

这条恢复手段是 rename，而这正是要点所在。删除一个条目需要其所在目录的写权限——在没有免密 sudo 的机器上，异属主残留恰恰不给这个权限——而重命名只需要两个父目录的写权限，且工作区根始终归 runner 自己所有。因此一棵能挫败 `rm`、`chmod`、`chown` 的树，仍然可以被挪开。目标位置紧邻工作区，使重命名不会跨文件系统而悄悄退化为「复制后删除」；警告会点名该位置，因为被隔离的树仍然需要人工处理。删除仍是正常路径：能干净删除的工作区保留其缓存，且不输出任何内容。

## 为什么需要

清理步骤删不掉的残留，不只是让发现它的那个 job 失败——**它会污染之后被调度到那台 runner 的每一个 job 的 checkout。**

实测于 run 32621267802：一次评审探针的残留留在了共享池的某台机器上——

```
EACCES: permission denied, rmdir
'…/_work/qwen-code/qwen-code/.qwen/tmp/review-pr-9748-scratch-verify--round-1--721f6d1cc279/probe-ws/.qwen/tmp/review-pr-666'
```

——随后两个互不相关的 PR（#9776 与 `feat/review-coverage-ledger`）在**同一台 runner、同一路径**上死在 Checkout。而两个 checkout 前步骤一路都报告**成功**：它们的阶梯止于 `echo "::warning::leaked .qwen; runner needs manual cleanup"`，因此修不好的工作区被原封不动交给了 checkout。这台 runner 会一直被污染，直到有人登录主机处理。

现有阶梯已经处理了它能处理的部分——`chmod`，以及在有权限的机器上 `sudo -n chown`/`chmod`。本 PR 补的是那些手段够不到的情形，也正是实际观察到的情形。

## 评审测试计划

### 如何验证

1. `npx vitest run scripts/tests/review-worktree-cleanup-workflow.test.js`——15 项通过，其中 3 项是新增。两项会执行从 `ci.yml` 中抽出的真实步骤体：一项针对无法删除的残留（即事故形态），一项针对可以删除的残留（兜底必须始终只是兜底）。
2. 确认这些测试具备判别力：把步骤改回旧的「警告后放行」写法，三项全部变红（钉住测试加两项行为测试）。
3. 用真实异属主端到端复现事故与修复——这需要 Linux，因为 macOS 的 bind mount 会把属主映射回宿主用户。前后输出见上方英文部分：修复前警告 `leaked .qwen`、树仍在、checkout 式清理以 `Permission denied` 失败；修复后树被隔离、清理成功、警告点明去向。
4. 确认三份共享池副本仍逐字节一致（测试套件对此有钉住），且 `actionlint` 与 workflow 体积门通过。

### 证据（前后对比）

前：修不好的工作区被交给 `actions/checkout`，checkout 失败；该 runner 之后每个 job 都会继续失败。

后：同一个工作区通过 rename 被清空，checkout 得以继续，并以警告点名隔离目录供人工清理。两种状态均来自上述容器复现，且都由「对旧步骤体会失败」的测试钉住。

### 测试平台

|    系统    |  状态  |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

单元套件在 macOS 上运行；异属主复现在 Debian 容器中完成。这些步骤只在 Linux 自建池上运行。

### 环境（可选）

macOS 上的 Node.js 22 开发检出，Linux 夹具使用 Docker。`actionlint` 与 `.github/scripts/check-workflow-size.sh` 均通过。

## 风险与范围

- 主要权衡：被隔离的树会在工作区旁的 `_qwen-quarantine` 下累积，因为按定义这个 job 就是删不掉它们。这正是目的——它们离开了 checkout 路径——但该目录确实需要偶尔人工清理，警告中已说明。它只会在本来就会崩掉的 runner 上被写入。
- 未验证/范围外：评审工作流自身的 `remove_review_tree` 阶梯同样止于「警告后放行」，可以采用相同兜底，这属于后续工作。本 PR 修的是通用路径——每个共享池 job 都会执行的 checkout 前清理——因此任何工作流留下的残留都不再破坏 checkout。它并不阻止残留被产生。
- 无破坏性变更。

## 关联 Issue

无。观察自 run 32621267802（#9776 与 `feat/review-coverage-ledger` 均在 runner `…-18` 上失败于 Checkout）。

</details>
