### PR TITLE
fix(core): strip uniqueItems from function schemas

### DIFF
--- a/packages/core/src/utils/schemaConverter.test.ts
+++ b/packages/core/src/utils/schemaConverter.test.ts
@@ -342,6 +342,29 @@ describe('relaxSchemaForFunctionCalling', () => {
     );
   });
 
+  it('strips uniqueItems keywords from function-calling schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        blockedBy: {
+          type: 'array',
+          items: { type: 'string' },
+          uniqueItems: true,
+        },
+        uniqueItems: { type: 'boolean' },
+      },
+      required: ['blockedBy'],
+      additionalProperties: false,
+    };
+
+    const relaxed = relaxSchemaForFunctionCalling(schema) as {
+      properties: Record<string, { uniqueItems?: unknown }>;
+    };
+
+    expect(relaxed.properties['blockedBy']!.uniqueItems).toBeUndefined();
+    expect(Object.keys(relaxed.properties)).toContain('uniqueItems');
+  });
+
   it('relaxes nested object levels independently', () => {
     const nested = {
       type: 'object',

--- a/packages/core/src/utils/schemaConverter.ts
+++ b/packages/core/src/utils/schemaConverter.ts
@@ -195,8 +195,8 @@ function toOpenAPI30(schema: Record<string, unknown>): Record<string, unknown> {
  *   declare optional properties (some `properties` key missing from
  *   `required`). Levels where every property is required keep the
  *   constraint — there is nothing for a gateway to promote.
- * - `$schema` / `$id` metadata is dropped at every level (some gateways
- *   reject unknown keywords).
+ * - `$schema` / `$id` metadata and `uniqueItems` are dropped at every level
+ *   (some gateways reject unknown or unsupported keywords).
  * - Everything else passes through untouched; client-side
  *   `validateToolParams` still enforces the full source schema, so the
  *   constraint is relaxed on the wire only.
@@ -229,7 +229,7 @@ export function relaxSchemaForFunctionCalling(
       Object.keys(properties).some((key) => !required.includes(key));
 
     for (const [key, value] of Object.entries(source)) {
-      if (key === '$schema' || key === '$id') {
+      if (key === '$schema' || key === '$id' || key === 'uniqueItems') {
         continue;
       }
       if (


### PR DESCRIPTION
## What this PR does

- Removes `uniqueItems` from the OpenAI-compatible function-calling wire schema produced by `relaxSchemaForFunctionCalling`.
- Keeps property names such as `properties.uniqueItems` intact while stripping only the JSON Schema keyword.
- Adds a regression test covering array schema relaxation for built-in tool declarations such as todo dependencies.

## Why it's needed

Some OpenAI-compatible gateways reject tool schemas that include `uniqueItems`, causing requests to fail before the model can answer even for ordinary prompts. This keeps source schemas strict for local validation while relaxing only the outbound function schema.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/utils/schemaConverter.test.ts -t "strips uniqueItems"`
- `cd packages/core && npx vitest run src/utils/schemaConverter.test.ts`

### Evidence (Before & After)

- Before: the new regression test fails because `blockedBy.uniqueItems` remains `true` after function schema relaxation.
- After: the regression test passes and the full schema converter test file reports 31 passing tests.

### Tested on

- macOS, Node.js v26.3.0

## Risk & Scope

- Scope is limited to OpenAI-compatible function-calling schema relaxation.
- Local tool parameter validation still uses the source schema and continues to enforce uniqueness.
- Response JSON schemas are not changed by this helper.

## Linked Issues

Fixes #9865

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

- 从 `relaxSchemaForFunctionCalling` 生成的 OpenAI-compatible function-calling wire schema 中移除 `uniqueItems`。
- 保留 `properties.uniqueItems` 这类字段名，只移除 JSON Schema 关键字。
- 增加回归测试，覆盖类似 todo dependency 数组 schema 的松绑逻辑。

## 为什么需要

部分 OpenAI-compatible 网关会拒绝包含 `uniqueItems` 的 tool schema，导致普通 prompt 还没到模型就失败。这个改动只放宽出站 function schema，本地工具参数校验仍使用原始 schema 并继续保证唯一性。

## Reviewer Test Plan

### 验证方式

- `cd packages/core && npx vitest run src/utils/schemaConverter.test.ts -t "strips uniqueItems"`
- `cd packages/core && npx vitest run src/utils/schemaConverter.test.ts`

### 前后证据

- 修复前：新增回归测试失败，因为 function schema relaxation 后 `blockedBy.uniqueItems` 仍为 `true`。
- 修复后：回归测试通过，完整 schemaConverter 测试文件 31 个测试全部通过。

### 测试环境

- macOS, Node.js v26.3.0

## 风险与范围

- 范围仅限 OpenAI-compatible function-calling schema relaxation。
- 本地工具参数校验仍使用原始 schema，继续约束唯一性。
- 不影响 response JSON schema。

## 关联 Issue

Fixes #9865

</details>