### PR TITLE
fix(sdk): support relative daemon file URLs

### DIFF
--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1798,22 +1798,21 @@ export class DaemonClient {
     } = {},
     clientId?: string,
   ): Promise<DaemonWorkspaceFile> {
-    const url = new URL(`${this.baseUrl}/file`);
-    url.searchParams.set('path', filePath);
+    const query = new URLSearchParams({ path: filePath });
     if (opts.maxBytes !== undefined) {
-      url.searchParams.set('maxBytes', String(opts.maxBytes));
+      query.set('maxBytes', String(opts.maxBytes));
     }
     if (opts.line !== undefined) {
-      url.searchParams.set('line', String(opts.line));
+      query.set('line', String(opts.line));
     }
     if (opts.limit !== undefined) {
-      url.searchParams.set('limit', String(opts.limit));
+      query.set('limit', String(opts.limit));
     }
     if (opts.cursor !== undefined) {
-      url.searchParams.set('cursor', opts.cursor);
+      query.set('cursor', opts.cursor);
     }
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/file?${query.toString()}`,
       { headers: this.headers({}, clientId) },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /file');
@@ -1845,10 +1844,9 @@ export class DaemonClient {
   }
 
   async fileStat(filePath: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/stat`);
-    url.searchParams.set('path', filePath);
+    const query = new URLSearchParams({ path: filePath });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/stat?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /stat');
@@ -1858,10 +1856,9 @@ export class DaemonClient {
   }
 
   async dirList(dirPath: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/list`);
-    url.searchParams.set('path', dirPath);
+    const query = new URLSearchParams({ path: dirPath });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/list?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /list');
@@ -1875,10 +1872,9 @@ export class DaemonClient {
    * pick a path outside any registered workspace (e.g. "Add workspace").
    */
   async workspacePathSuggestions(prefix: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/workspace-path-suggestions`);
-    url.searchParams.set('prefix', prefix);
+    const query = new URLSearchParams({ prefix });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/workspace-path-suggestions?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) {
@@ -1903,10 +1899,9 @@ export class DaemonClient {
   }
 
   async glob(pattern: string): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/glob`);
-    url.searchParams.set('pattern', pattern);
+    const query = new URLSearchParams({ pattern });
     return await this.fetchWithTimeout(
-      url.toString(),
+      `${this.baseUrl}/glob?${query.toString()}`,
       { headers: this.headers() },
       async (res) => {
         if (!res.ok) throw await this.failOnError(res, 'GET /glob');
@@ -1970,9 +1965,8 @@ export class DaemonClient {
     req: DaemonWorkspaceFileUploadRequest,
     clientId?: string,
   ): Promise<DaemonWorkspaceFileUploadResult> {
-    const target = new URL(`${this.baseUrl}${uploadPath}`);
-    target.searchParams.set('path', req.path);
-    const url = target.toString();
+    const query = new URLSearchParams({ path: req.path });
+    const url = `${this.baseUrl}${uploadPath}?${query.toString()}`;
     const headers = this.headers(
       { 'Content-Type': 'application/octet-stream' },
       clientId,

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -607,6 +607,49 @@ describe('DaemonClient', () => {
       );
     });
 
+    it('builds workspace file helper URLs with a relative base URL', async () => {
+      const filePayload = {
+        kind: 'file',
+        path: 'src/a.ts',
+        content: 'export {}\n',
+        encoding: 'utf-8',
+        bom: false,
+        lineEnding: 'lf',
+        sizeBytes: 10,
+        returnedBytes: 10,
+        truncated: false,
+        hash: 'sha256:' + 'a'.repeat(64),
+        matchedIgnore: null,
+        originalLineCount: null,
+      };
+      const { fetch, calls } = recordingFetch((req) => {
+        if (req.url.startsWith('/daemon/file?')) {
+          return jsonResponse(200, filePayload);
+        }
+        return jsonResponse(200, { ok: true });
+      });
+      const client = new DaemonClient({ baseUrl: '/daemon/', fetch });
+
+      await expect(
+        client.readWorkspaceFile('src/a.ts', { line: 2, limit: 3 }, 'client-1'),
+      ).resolves.toEqual(filePayload);
+      await expect(client.fileStat('src/a.ts')).resolves.toEqual({ ok: true });
+      await expect(client.dirList('src')).resolves.toEqual({ ok: true });
+      await expect(client.workspacePathSuggestions('/repo/s')).resolves.toEqual(
+        { ok: true },
+      );
+      await expect(client.glob('src/**/*.ts')).resolves.toEqual({ ok: true });
+
+      expect(calls.map((call) => call.url)).toEqual([
+        '/daemon/file?path=src%2Fa.ts&line=2&limit=3',
+        '/daemon/stat?path=src%2Fa.ts',
+        '/daemon/list?path=src',
+        '/daemon/workspace-path-suggestions?prefix=%2Frepo%2Fs',
+        '/daemon/glob?pattern=src%2F**%2F*.ts',
+      ]);
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+    });
+
     it('writes and edits files with JSON bodies and client identity', async () => {
       const writeResult = {
         kind: 'file_write',

--- a/packages/sdk-typescript/test/unit/DaemonClient.upload.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.upload.test.ts
@@ -124,6 +124,22 @@ describe('uploadWorkspaceFile', () => {
     expect(url.searchParams.get('path')).toBe('a&b+c=d #1 数据 %b.txt');
   });
 
+  it('uploads with a relative base URL', async () => {
+    const { fetch, calls } = recordingFetch(() =>
+      jsonResponse(201, uploadResult),
+    );
+    const client = new DaemonClient({ baseUrl: '/daemon', fetch });
+
+    await expect(
+      client.uploadWorkspaceFile({
+        path: 'blob.bin',
+        data: new Uint8Array([1, 2, 3, 4]),
+      }),
+    ).resolves.toEqual(uploadResult);
+
+    expect(calls[0]?.url).toBe('/daemon/file/upload?path=blob.bin');
+  });
+
   it('sends the raw bytes as the request body', async () => {
     const { fetch, calls } = recordingFetch(() =>
       jsonResponse(201, uploadResult),


### PR DESCRIPTION
## What this PR does

Updates the remaining TypeScript SDK workspace file helpers to build request URLs with `URLSearchParams` plus string interpolation instead of the absolute-only `new URL(...)` constructor.

Covered methods:
- `readWorkspaceFile`
- `fileStat`
- `dirList`
- `workspacePathSuggestions`
- `glob`
- `uploadFileToPath`

## Why it's needed

Web Shell integrations can configure a same-origin relative daemon base URL such as `/daemon`. `readWorkspaceFileBytes` already supports that shape, but these sibling helpers still throw `TypeError: Invalid URL` before sending the request because `new URL('/daemon/file')` requires an absolute base.

This makes the helpers consistent with the relative-URL-safe pattern added for byte reads.

## Reviewer Test Plan

### How to verify

- `cd packages/sdk-typescript && npm test -- --run test/unit/DaemonClient.test.ts test/unit/DaemonClient.upload.test.ts`

### Evidence (Before & After)

Before: the new regression tests failed with `TypeError: Invalid URL` for relative `/daemon` base URLs.

After: the targeted SDK daemon client tests pass.

### Tested on

- macOS
- Node/Vitest via package test script

## Risk & Scope

Low risk. This only changes URL construction for existing REST helpers and preserves the same query parameter encoding through `URLSearchParams`.

## Linked Issues

Fixes #9816

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 TypeScript SDK 中剩余的 workspace file helper 从只能处理绝对 URL 的 `new URL(...)` 构造方式，改为 `URLSearchParams` 加字符串拼接。

覆盖的方法包括：
- `readWorkspaceFile`
- `fileStat`
- `dirList`
- `workspacePathSuggestions`
- `glob`
- `uploadFileToPath`

## 为什么需要

Web Shell 集成会使用 `/daemon` 这样的同源相对 daemon base URL。`readWorkspaceFileBytes` 已经支持这种写法，但几个相邻 helper 仍会在发送请求前因为 `new URL('/daemon/file')` 抛出 `TypeError: Invalid URL`。

本 PR 让这些 helper 与 byte read 已采用的相对 URL 安全写法保持一致。

## Reviewer Test Plan

### How to verify

- `cd packages/sdk-typescript && npm test -- --run test/unit/DaemonClient.test.ts test/unit/DaemonClient.upload.test.ts`

### Evidence (Before & After)

Before：新增回归测试在相对 `/daemon` base URL 下失败，错误为 `TypeError: Invalid URL`。

After：相关 SDK daemon client 测试通过。

### Tested on

- macOS
- Node/Vitest package test script

## Risk & Scope

风险较低。改动只影响既有 REST helper 的 URL 构造方式，查询参数仍由 `URLSearchParams` 编码。

## Linked Issues

Fixes #9816
</details>