### PR TITLE
fix(core): stop forcing DeepSeek temperature

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
@@ -516,10 +516,8 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
   });
 
   describe('getDefaultGenerationConfig', () => {
-    it('returns temperature 0', () => {
-      expect(provider.getDefaultGenerationConfig()).toEqual({
-        temperature: 0,
-      });
+    it('does not force a deterministic temperature by default', () => {
+      expect(provider.getDefaultGenerationConfig()).toEqual({});
     });
   });
 });

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -136,9 +136,7 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
   }
 
   override getDefaultGenerationConfig(): GenerateContentConfig {
-    return {
-      temperature: 0,
-    };
+    return {};
   }
 }
 


### PR DESCRIPTION
## What this PR does

Removes the DeepSeek OpenAI-compatible provider's hard-coded default `temperature: 0` so DeepSeek models can use their model/server default sampling behavior unless the user explicitly configures a temperature.

## Why it's needed

Issue #9765 reports that forcing greedy sampling by default can make DeepSeek reasoning models such as `deepseek-v4-flash` fall into repetitive thinking loops. The provider should not override the model default for all DeepSeek requests; explicit user overrides via generation config remain supported by the normal request-building path.

## Reviewer Test Plan

### How to verify

Run the targeted DeepSeek provider tests, Prettier on the touched files, and the core package typecheck.

### Evidence (Before & After)

Before: `DeepSeekOpenAICompatibleProvider.getDefaultGenerationConfig()` returned `{ temperature: 0 }` and a regression test expecting no forced temperature failed.

After: the provider returns `{}`, leaving default sampling to the model/server unless the user explicitly sets a temperature.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

Local Node/npm workspace on macOS.

## Risk & Scope

- Main risk or tradeoff: Low; this changes only the DeepSeek provider default generation config and preserves explicit user temperature settings.
- Not validated / out of scope: Live DeepSeek API behavior was not exercised locally.
- Breaking changes / migration notes: Users who relied on implicit deterministic DeepSeek temperature can still set `generationConfig.samplingParams.temperature` explicitly.

## Linked Issues

Fixes #9765.

<details>
<summary>中文说明</summary>

## What this PR does

移除 DeepSeek OpenAI-compatible provider 中硬编码的默认 `temperature: 0`，让 DeepSeek 模型在用户没有显式配置 temperature 时使用模型/服务端默认采样行为。

## Why it's needed

#9765 报告了 DeepSeek reasoning 模型（例如 `deepseek-v4-flash`）在默认贪心采样下容易进入重复 thinking loop。provider 不应该对所有 DeepSeek 请求强制覆盖模型默认值；用户显式配置的 temperature 仍会通过现有请求构造路径生效。

## Reviewer Test Plan

### How to verify

运行 DeepSeek provider 目标测试、改动文件 Prettier 检查、core 包 typecheck。

### Evidence (Before & After)

Before：`DeepSeekOpenAICompatibleProvider.getDefaultGenerationConfig()` 返回 `{ temperature: 0 }`，期望不强制 temperature 的回归测试失败。

After：provider 返回 `{}`，默认采样交给模型/服务端，除非用户显式设置 temperature。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally; covered by CI |
|  🐧 Linux  | ⚠️ not tested locally; covered by CI |

### Environment (optional)

macOS 本地 Node/npm 工作区。

## Risk & Scope

- Main risk or tradeoff: 低；只改变 DeepSeek provider 的默认 generation config，并保留用户显式 temperature 设置。
- Not validated / out of scope: 未在本地请求真实 DeepSeek API。
- Breaking changes / migration notes: 依赖隐式 deterministic DeepSeek temperature 的用户仍可显式配置 `generationConfig.samplingParams.temperature`。

## Linked Issues

Fixes #9765.

</details>