### PR TITLE
fix(goal): cite this turn's delivered output instead of refusing over it

### DIFF
--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -709,11 +709,14 @@ describe('UpdateGoalTool', () => {
       }),
     );
 
-    await invocation.execute(new AbortController().signal);
+    const result = await invocation.execute(new AbortController().signal);
 
     expect(recordTerminalProposal).toHaveBeenCalledWith(
       permit,
       expect.objectContaining({ evidenceRefs: ['tool-result-1'] }),
+    );
+    expect(JSON.parse(String(result.llmContent))).not.toHaveProperty(
+      'autoCitedCurrentDeliveredOutput',
     );
   });
 

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -613,6 +613,20 @@ describe('UpdateGoalTool', () => {
                 preview: 'X',
                 proofKind: 'delivered_output',
               },
+              {
+                uuid: 'current-external-fact',
+                provenance: 'tool_result',
+                turnId: permit.turnId,
+                preview: 'permission denied',
+                proofKind: 'external_fact',
+              },
+              {
+                uuid: 'prior-delivered-output',
+                provenance: 'assistant_output',
+                turnId: 'prior-turn',
+                preview: 'Earlier output',
+                proofKind: 'delivered_output',
+              },
             ],
             lineageTurnIds: [permit.turnId],
           },
@@ -629,19 +643,16 @@ describe('UpdateGoalTool', () => {
       }),
     );
 
-    await invocation.execute(new AbortController().signal);
+    const result = await invocation.execute(new AbortController().signal);
 
     expect(recordTerminalProposal).toHaveBeenCalledWith(
       permit,
       expect.objectContaining({ evidenceRefs: ['letter-x'] }),
     );
-    expect(
-      JSON.parse(
-        String(
-          (await invocation.execute(new AbortController().signal)).llmContent,
-        ),
-      ),
-    ).not.toHaveProperty('autoCitedCurrentDeliveredOutput');
+    expect(recordTerminalProposal).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(result.llmContent))).not.toHaveProperty(
+      'autoCitedCurrentDeliveredOutput',
+    );
   });
 
   it('leaves a blocked proposal to cite whatever it chose', async () => {

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -614,6 +614,13 @@ describe('UpdateGoalTool', () => {
                 proofKind: 'delivered_output',
               },
               {
+                uuid: 'letter-y',
+                provenance: 'assistant_output',
+                turnId: permit.turnId,
+                preview: 'Y',
+                proofKind: 'delivered_output',
+              },
+              {
                 uuid: 'current-external-fact',
                 provenance: 'tool_result',
                 turnId: permit.turnId,
@@ -628,7 +635,7 @@ describe('UpdateGoalTool', () => {
                 proofKind: 'delivered_output',
               },
             ],
-            lineageTurnIds: [permit.turnId],
+            lineageTurnIds: ['prior-turn', permit.turnId],
           },
         }),
         getSnapshotForPermit: vi.fn(() => activeSnapshot()),
@@ -647,12 +654,12 @@ describe('UpdateGoalTool', () => {
 
     expect(recordTerminalProposal).toHaveBeenCalledWith(
       permit,
-      expect.objectContaining({ evidenceRefs: ['letter-x'] }),
+      expect.objectContaining({ evidenceRefs: ['letter-x', 'letter-y'] }),
     );
     expect(recordTerminalProposal).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(String(result.llmContent))).not.toHaveProperty(
-      'autoCitedCurrentDeliveredOutput',
-    );
+    expect(JSON.parse(String(result.llmContent))).toMatchObject({
+      autoCitedCurrentDeliveredOutput: ['letter-y'],
+    });
   });
 
   it('leaves a blocked proposal to cite whatever it chose', async () => {

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -371,6 +371,23 @@ describe('GetGoalTool', () => {
 });
 
 describe('UpdateGoalTool', () => {
+  const activeSnapshot = () => ({
+    v: 2 as const,
+    activity: 'running' as const,
+    goal: {
+      goalId: permit.goalId,
+      revision: permit.revision,
+      objective: 'Deliver the result',
+      status: 'active' as const,
+      evidenceCursor: { recordId: 'goal-created' },
+      turnCount: 3,
+      activeTimeMs: 100,
+      tokensUsed: 0,
+      createdAt: 1,
+      updatedAt: 2,
+    },
+  });
+
   it('exposes the exact evidence and non-terminal response contract', () => {
     const tool = new UpdateGoalTool(makeConfig({}));
     const schema = tool.schema.parametersJsonSchema as {
@@ -493,8 +510,11 @@ describe('UpdateGoalTool', () => {
     expect(recordTerminalProposal).not.toHaveBeenCalled();
   });
 
-  it('rejects completion that omits current delivered output', async () => {
-    const recordTerminalProposal = vi.fn();
+  it("cites this turn's delivered output for a completion that omitted it", async () => {
+    const recordTerminalProposal = vi.fn(() => ({
+      recorded: true,
+      readyForVerification: true,
+    }));
     const getGoalForWorker = vi.fn().mockResolvedValue({
       goalId: permit.goalId,
       revision: permit.revision,
@@ -553,15 +573,130 @@ describe('UpdateGoalTool', () => {
 
     const result = await invocation.execute(new AbortController().signal);
 
-    expect(JSON.parse(String(result.llmContent))).toEqual({
-      proposalRecorded: false,
-      readyForVerification: false,
-      goalLifecycleChanged: false,
-      uncitedCurrentDeliveredOutput: ['letter-x'],
-      error:
-        'The completion proposal omitted delivered output from the current Goal turn. Call get_goal after delivering the final output, then retry update_goal with the returned evidenceCatalog UUIDs.',
+    // Refusing here could not converge: complying emits assistant text, which
+    // is delivered_output stamped with this same turn, so the required set
+    // grew by one per retry until a human stopped the Goal.
+    expect(recordTerminalProposal).toHaveBeenCalledWith(
+      permit,
+      expect.objectContaining({
+        status: 'complete',
+        evidenceRefs: ['tool-result-1', 'letter-x'],
+      }),
+    );
+    expect(JSON.parse(String(result.llmContent))).toMatchObject({
+      proposalRecorded: true,
+      readyForVerification: true,
+      autoCitedCurrentDeliveredOutput: ['letter-x'],
     });
-    expect(recordTerminalProposal).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate output the completion already cited', async () => {
+    // validateGoalEvidenceReferences rejects a duplicated ref outright, so the
+    // fold has to be a union rather than an append.
+    const recordTerminalProposal = vi.fn(() => ({
+      recorded: true,
+      readyForVerification: true,
+    }));
+    const tool = new UpdateGoalTool(
+      makeConfig({
+        getGoalForWorker: vi.fn().mockResolvedValue({
+          goalId: permit.goalId,
+          revision: permit.revision,
+          objective: 'Deliver the result',
+          evidenceCursor: { recordId: 'goal-created' },
+          evidenceCatalog: {
+            entries: [
+              {
+                uuid: 'letter-x',
+                provenance: 'assistant_output',
+                turnId: permit.turnId,
+                preview: 'X',
+                proofKind: 'delivered_output',
+              },
+            ],
+            lineageTurnIds: [permit.turnId],
+          },
+        }),
+        getSnapshotForPermit: vi.fn(() => activeSnapshot()),
+        recordTerminalProposal,
+      }),
+    );
+    const invocation = goalTurnContext.run(permit, () =>
+      tool.build({
+        status: 'complete',
+        reason: 'Delivered',
+        evidenceRefs: ['letter-x'],
+      }),
+    );
+
+    await invocation.execute(new AbortController().signal);
+
+    expect(recordTerminalProposal).toHaveBeenCalledWith(
+      permit,
+      expect.objectContaining({ evidenceRefs: ['letter-x'] }),
+    );
+    expect(
+      JSON.parse(
+        String(
+          (await invocation.execute(new AbortController().signal)).llmContent,
+        ),
+      ),
+    ).not.toHaveProperty('autoCitedCurrentDeliveredOutput');
+  });
+
+  it('leaves a blocked proposal to cite whatever it chose', async () => {
+    // The gate only ever guarded completion: a blocker is judged on the
+    // blocker, not on what the turn happened to deliver.
+    const recordTerminalProposal = vi.fn(() => ({
+      recorded: true,
+      readyForVerification: false,
+    }));
+    const tool = new UpdateGoalTool(
+      makeConfig({
+        getGoalForWorker: vi.fn().mockResolvedValue({
+          goalId: permit.goalId,
+          revision: permit.revision,
+          objective: 'Deliver the result',
+          evidenceCursor: { recordId: 'goal-created' },
+          evidenceCatalog: {
+            entries: [
+              {
+                uuid: 'tool-result-1',
+                provenance: 'tool_result',
+                turnId: permit.turnId,
+                preview: 'permission denied',
+                proofKind: 'external_fact',
+              },
+              {
+                uuid: 'letter-x',
+                provenance: 'assistant_output',
+                turnId: permit.turnId,
+                preview: 'X',
+                proofKind: 'delivered_output',
+              },
+            ],
+            lineageTurnIds: [permit.turnId],
+          },
+        }),
+        getSnapshotForPermit: vi.fn(() => activeSnapshot()),
+        recordTerminalProposal,
+      }),
+    );
+    const invocation = goalTurnContext.run(permit, () =>
+      tool.build({
+        status: 'blocked',
+        reason: 'The credential store is unreadable',
+        evidenceRefs: ['tool-result-1'],
+        blockerKind: 'external',
+      }),
+    );
+
+    await invocation.execute(new AbortController().signal);
+
+    expect(recordTerminalProposal).toHaveBeenCalledWith(
+      permit,
+      expect.objectContaining({ evidenceRefs: ['tool-result-1'] }),
+    );
   });
 
   it('queues truncated completion for boundary classification', async () => {

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -215,6 +215,7 @@ class UpdateGoalInvocation extends BaseToolInvocation<
     ) {
       throw staleGoalTurnError();
     }
+    let autoCitedCurrentDeliveredOutput: string[] = [];
     const evidenceEntries = view.evidenceCatalog?.entries;
     if (evidenceEntries) {
       const normalizedEvidenceRefs = this.params.evidenceRefs.map((reference) =>
@@ -242,38 +243,38 @@ class UpdateGoalInvocation extends BaseToolInvocation<
         };
       }
       const citedEvidenceRefs = new Set(normalizedEvidenceRefs);
-      const uncitedCurrentDeliveredOutput = evidenceEntries
-        .filter(
-          (entry) =>
-            entry.proofKind === 'delivered_output' &&
-            entry.turnId === permit.turnId &&
-            !citedEvidenceRefs.has(entry.uuid),
-        )
-        .map((entry) => entry.uuid);
-      if (
-        this.params.status === 'complete' &&
-        uncitedCurrentDeliveredOutput.length > 0
-      ) {
-        return {
-          llmContent: JSON.stringify({
-            proposalRecorded: false,
-            readyForVerification: false,
-            goalLifecycleChanged: false,
-            uncitedCurrentDeliveredOutput,
-            error:
-              'The completion proposal omitted delivered output from the current Goal turn. Call get_goal after delivering the final output, then retry update_goal with the returned evidenceCatalog UUIDs.',
-          }),
-          returnDisplay:
-            'Goal proposal was not recorded because the current delivered output was not cited. Read the current Goal and retry.',
-        };
-      }
+      // The verifier judges a completion against this turn's delivered output,
+      // so it has to be cited. Asking the model to cite it cannot converge:
+      // assistant output is `delivered_output` stamped with this same turn, so
+      // every attempt to comply — reading the catalog, then calling back —
+      // emits text that becomes another uncited entry, and the required set
+      // grows by one per retry. Refusing produced runs that proposed
+      // completion until a human paused them.
+      //
+      // Nothing about the list needs the model's judgment: it is exactly the
+      // entries computed here. Fold them in instead of demanding they be
+      // repeated back. Both sets are drawn from the same catalog and are
+      // disjoint by construction, so the union cannot exceed
+      // GOAL_EVIDENCE_REFERENCE_LIMIT, which is that catalog's own entry cap.
+      autoCitedCurrentDeliveredOutput =
+        this.params.status === 'complete'
+          ? evidenceEntries
+              .filter(
+                (entry) =>
+                  entry.proofKind === 'delivered_output' &&
+                  entry.turnId === permit.turnId &&
+                  !citedEvidenceRefs.has(entry.uuid),
+              )
+              .map((entry) => entry.uuid)
+          : [];
     }
     const proposal: GoalTerminalProposal = {
       status: this.params.status,
       reason: this.params.reason.trim(),
-      evidenceRefs: this.params.evidenceRefs.map((reference) =>
-        reference.trim(),
-      ),
+      evidenceRefs: [
+        ...this.params.evidenceRefs.map((reference) => reference.trim()),
+        ...autoCitedCurrentDeliveredOutput,
+      ],
       ...(this.params.blockerKind
         ? { blockerKind: this.params.blockerKind }
         : {}),
@@ -289,6 +290,12 @@ class UpdateGoalInvocation extends BaseToolInvocation<
       proposalRecorded: receipt.recorded,
       readyForVerification: receipt.readyForVerification,
       goalLifecycleChanged: false,
+      // Reported so the proposal the verifier sees is not a surprise, and so a
+      // model that wants to cite this turn's output explicitly can see it was
+      // already covered rather than calling back to add it.
+      ...(autoCitedCurrentDeliveredOutput.length > 0
+        ? { autoCitedCurrentDeliveredOutput }
+        : {}),
       nextAction: receipt.readyForVerification
         ? 'End this turn without user-facing text. Do not claim the Goal is complete or blocked. The Goal status card will report the independent verification result.'
         : 'Continue this turn without claiming the Goal is complete or blocked. A repeated-blocker audit requires the same blocker mode and exact same reason text across three consecutive Goal turns, with current evidence cited on each turn.',


### PR DESCRIPTION
## What this PR does

`update_goal(status: 'complete')` no longer refuses a proposal that leaves the current turn's delivered output uncited. It folds that output into the proposal's `evidenceRefs` and reports what it added as `autoCitedCurrentDeliveredOutput`. The verifier still receives the current turn's delivered output, which is what the refusal was protecting. Only `complete` is affected; a blocker still cites whatever it chose.

## Why it's needed

The refusal could not be satisfied. Assistant output is `delivered_output` (`proofKindOf`, `goal-evidence.ts`) stamped with the turn that produced it, so any text emitted between reading the catalog and calling `update_goal` becomes a new uncited entry of that same turn — and the refusal's own guidance, `Call get_goal after delivering the final output, then retry update_goal`, asks for exactly the round trip that produces it. The required set grows by one per attempt. The act of proposing completion manufactures the evidence that invalidates the proposal.

Nothing bounds the retrying either. A tool-level refusal never reaches the verifier: the turn simply ends with the Goal still `active`, so the runtime queues the next continuation, and the only terminal condition is a human. In a reported session (`qwen-code-export-2026-08-24T07-46-35-716Z.jsonl`, qwen3.8-max, daemon channel) a short verification Goal set at 07:12 ran until the user typed `/goal pause` at 07:46 — 34 minutes, 67 model calls, 8,638,576 tokens, of which 32 were `get_goal` and 23 were `update_goal`. The refusals carry the signature of the defect directly:

```
07:20  uncitedCurrentDeliveredOutput: [05131cb7]
07:27  uncitedCurrentDeliveredOutput: [05131cb7, a36c35d5]
07:33  uncitedCurrentDeliveredOutput: [a36c35d5, 14928ca1]
07:36  uncitedCurrentDeliveredOutput: [a36c35d5, 14928ca1, ffb150bd]
```

The gate was guarding something real — a Goal should not be marked complete while the output that *is* the deliverable sits uncited, because the verifier would then judge completion without seeing what was delivered. But that list requires no judgment from the model: it is precisely the set the tool already computes in order to build the refusal. Handing it to the proposal preserves the guarantee and removes the race.

## Reviewer Test Plan

### How to verify

Set a Goal that finishes in one turn and let the model deliver its result and propose completion in the same turn. Before this change the proposal is refused and each retry is refused again with one more UUID in the list, indefinitely. After it, the proposal is recorded on the first attempt, the reply reports `autoCitedCurrentDeliveredOutput`, and the Goal reaches verification. Then confirm the scope did not widen: a `blocked` proposal in a turn that also delivered output records with only the refs it supplied.

Three tests cover it. The test that pinned the refusal now pins the fold, asserting `recordTerminalProposal` receives the union `['tool-result-1', 'letter-x']` where the model supplied only the first. A second asserts a proposal that already cited this turn's output is not given a duplicate — a duplicated reference is rejected downstream by `validateGoalEvidenceReferences`, so the fold has to be a union rather than an append. A third asserts a `blocked` proposal is left alone.

Both invariants were mutation-checked rather than merely observed to pass. Removing the fold from the proposal fails the first test and leaves the other 36 green. Making the de-duplication predicate constantly true fails the second and leaves the other 36 green. Both were reverted and the suite re-run clean.

The union cannot overflow: `GOAL_EVIDENCE_REFERENCE_LIMIT` is `CATALOG_ENTRY_LIMIT`, and both sets are drawn from that same catalog and are disjoint by construction, so their union is at most the catalog's own size. That is why no cap handling appears in the diff.

`npx vitest run` passes 477 tests across 18 files covering `packages/core/src/goals`, the CLI goal command and the daemon goals route. `npx tsc --noEmit` in `packages/core` is clean, and `prettier` and `eslint` are clean on both changed files.

### Evidence (Before & After)

Before: `{"proposalRecorded":false,"readyForVerification":false,"uncitedCurrentDeliveredOutput":[...],"error":"The completion proposal omitted delivered output from the current Goal turn..."}` — repeated with a longer list each turn until the run was paused by hand.

After: `{"proposalRecorded":true,"readyForVerification":true,"autoCitedCurrentDeliveredOutput":["letter-x"],"nextAction":"End this turn without user-facing text..."}` on the first attempt.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, Node.js 22, unit tests only.

## Risk & Scope

- Main risk or tradeoff: the proposal the verifier judges now contains references the model did not write. That is deliberate and it does not weaken the verdict — `delivered_output` proves only that content was delivered, so adding it cannot manufacture support for a claim about what the user said or what an external system did, and the verifier still has to find support for every claim in the proposal's reason. What was added is reported back in the tool result so it is visible rather than silent.
- Not validated / out of scope: this does not add a retry bound. A Goal that keeps proposing completion for some other reason will still retry without limit, because the runtime has no turn, token or wall-clock ceiling; that belongs with the Goal budget work and putting it here would mix an unrelated contract change into this diff. Windows and macOS were not exercised locally and remain covered by CI.
- Breaking changes / migration notes: none. `uncitedCurrentDeliveredOutput` no longer appears in tool results because that refusal no longer happens; the new `autoCitedCurrentDeliveredOutput` field is additive and only present when something was folded in. Scope for the core triage gate: 35 added and 28 deleted production lines in one file, with no cross-package change.

## Linked Issues

Part of #9877 — this PR removes the self-invalidating citation gate (the first half of that issue's scope). The retry-bound half lands in #9891 as a token budget on all autonomous continuation; #9877 is closed by hand once both are merged, so neither merge closes it early.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`update_goal(status: 'complete')` 不再因为「本轮 delivered output 未被引用」而拒绝提案。它会把这些产出并入提案的 `evidenceRefs`，并以 `autoCitedCurrentDeliveredOutput` 回报所并入的内容。verifier 仍然会收到本轮的 delivered output——这正是那条拒绝所要保护的东西。只有 `complete` 受影响；blocked 提案仍然只引用它自己选择的证据。

## 为什么需要

那条拒绝无法被满足。助手输出的 proofKind 是 `delivered_output`（`goal-evidence.ts` 的 `proofKindOf`），并被打上产生它的那一轮的标记；因此在「读取目录」与「调用 `update_goal`」之间发出的任何文字，都会成为同一轮里一条新的未引用条目——而拒绝自身给出的指引 `Call get_goal after delivering the final output, then retry update_goal`，要求的恰恰是那次会产生它的往返。所需集合每尝试一次就增长一条。**提出完成这个动作，制造了让该提案失效的证据。**

重试也没有任何边界。工具层的拒绝根本走不到 verifier：轮次就此正常结束，而 Goal 仍是 `active`，于是运行时排下一个续跑轮，唯一的终止条件是人。在一份已报告的 session（`qwen-code-export-2026-08-24T07-46-35-716Z.jsonl`，qwen3.8-max，daemon 通道）中，07:12 设下的一个简短验证 Goal 一直跑到用户在 07:46 手动输入 `/goal pause`——34 分钟、67 次模型调用、8,638,576 token，其中 32 次 `get_goal`、23 次 `update_goal`。拒绝信息直接携带着这个缺陷的特征：

```
07:20  uncitedCurrentDeliveredOutput: [05131cb7]
07:27  uncitedCurrentDeliveredOutput: [05131cb7, a36c35d5]
07:33  uncitedCurrentDeliveredOutput: [a36c35d5, 14928ca1]
07:36  uncitedCurrentDeliveredOutput: [a36c35d5, 14928ca1, ffb150bd]
```

这道闸门守护的东西是真实的——不应在「作为交付物的产出」尚未被引用时就把 Goal 标记为完成，否则 verifier 会在没看到交付了什么的情况下判定完成。但那份列表并不需要模型的判断：它恰恰就是工具为了构造这条拒绝而已经算出来的集合。把它交给提案，既保住了这项保证，又消除了这场比赛。

## 评审者测试计划

### 如何验证

设一个一轮内即可完成的 Goal，让模型在同一轮里交付结果并提出完成。改动之前，提案被拒，且每次重试都会以多一个 UUID 的列表再次被拒，无限循环。改动之后，提案在第一次尝试就被记录，返回值报告 `autoCitedCurrentDeliveredOutput`，Goal 进入验证。然后确认范围没有扩大：在一个同样产生了输出的轮次里提出 `blocked`，记录下来的仍然只有它自己提供的引用。

三个测试覆盖它。此前钉住拒绝的那个测试，现在钉住这次并入，断言 `recordTerminalProposal` 收到的是并集 `['tool-result-1', 'letter-x']`，而模型只提供了前者。第二个断言「已经引用过本轮输出的提案不会拿到重复项」——重复引用会被下游的 `validateGoalEvidenceReferences` 拒绝，因此这次并入必须是并集而不是追加。第三个断言 `blocked` 提案不受影响。

两条不变式都做了变异检验而不只是「跑通了」。把并入从提案中移除，第一个测试失败，其余 36 个保持通过。把去重谓词改成恒真，第二个测试失败，其余 36 个保持通过。两次变异都已还原并重跑干净。

并集不可能溢出：`GOAL_EVIDENCE_REFERENCE_LIMIT` 就是 `CATALOG_ENTRY_LIMIT`，而两个集合都取自同一份目录且按构造互斥，因此并集至多等于该目录自身的规模。这就是 diff 中没有出现任何上限处理的原因。

`npx vitest run` 通过 18 个文件共 477 个测试，覆盖 `packages/core/src/goals`、CLI 的 goal 命令与 daemon 的 goals 路由。`packages/core` 的 `npx tsc --noEmit` 干净，两个改动文件的 `prettier` 与 `eslint` 均干净。

### 证据（修复前后）

修复前：`{"proposalRecorded":false,"readyForVerification":false,"uncitedCurrentDeliveredOutput":[...],"error":"The completion proposal omitted delivered output from the current Goal turn..."}`——每一轮重复出现，列表更长，直到运行被人手动暂停。

修复后：第一次尝试即返回 `{"proposalRecorded":true,"readyForVerification":true,"autoCitedCurrentDeliveredOutput":["letter-x"],"nextAction":"End this turn without user-facing text..."}`。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Linux、Node.js 22，仅单元测试。

## 风险与范围

- 主要风险或取舍：verifier 判定的提案中，现在含有并非模型写下的引用。这是有意为之，且不会削弱裁决——`delivered_output` 只能证明「内容被交付过」，因此加入它无法为「用户说过什么」或「外部系统发生了什么」这类主张制造支持，verifier 仍必须为提案理由中的每一条主张找到支持。被加入的内容会在工具返回值中回报，因此是可见的而非静默的。
- 未验证/不在范围：本 PR 不加入重试边界。因其他原因反复提出完成的 Goal 仍会无限重试，因为运行时没有任何轮次、token 或时钟上限；那属于 Goal 预算那部分工作，把它放进来会把一项无关的契约变更混入本 diff。Windows 与 macOS 未在本地验证，仍由 CI 覆盖。
- 破坏性变更/迁移说明：无。`uncitedCurrentDeliveredOutput` 不再出现在工具返回值中，因为那条拒绝不再发生；新增的 `autoCitedCurrentDeliveredOutput` 字段是纯新增，且仅在确实并入了内容时出现。供 core triage gate 参考的规模：单个文件、新增 35 行、删除 28 行生产代码，无跨包改动。

## 关联 Issue

关联 #9877——本 PR 取消自我否定的引用闸门(该 issue 范围的前一半)。重试上界的后一半由 #9891 以覆盖全部自主续跑的 token 预算落地;两者都合入后再手动关闭 #9877,避免任一合并提前关闭它。

</details>

