### PR TITLE
fix(core): map OpenAI-compatible finish_reason case-insensitively

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3732,6 +3732,72 @@ describe('OpenAIContentConverter', () => {
       expect(response.modelVersion).toBe('test-model');
     });
 
+    it('maps uppercase finish_reason values case-insensitively', () => {
+      const stop = converter.convertOpenAIResponseToGemini(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-stop',
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'done' },
+              finish_reason: 'STOP',
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+      const truncated = converter.convertOpenAIResponseToGemini(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-max-tokens',
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'cut off' },
+              finish_reason: 'MAX_TOKENS',
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+
+      expect(stop.candidates?.[0]?.finishReason).toBe(FinishReason.STOP);
+      expect(truncated.candidates?.[0]?.finishReason).toBe(
+        FinishReason.MAX_TOKENS,
+      );
+    });
+
+    it('does not throw on a non-string finish_reason from a malformed gateway', () => {
+      const response = converter.convertOpenAIResponseToGemini(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-malformed',
+          created: 123,
+          model: 'test-model',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'done' },
+              finish_reason: 42,
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+
+      expect(response.candidates?.[0]?.finishReason).toBe(
+        FinishReason.FINISH_REASON_UNSPECIFIED,
+      );
+    });
+
     it('omits the input/output breakdown when only total tokens are reported', () => {
       const response = converter.convertOpenAIResponseToGemini(
         {

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1837,15 +1837,21 @@ export function convertOpenAIChunkToGemini(
 function mapOpenAIFinishReasonToGemini(
   openaiReason: string | null,
 ): FinishReason {
-  if (!openaiReason) return FinishReason.FINISH_REASON_UNSPECIFIED;
+  if (typeof openaiReason !== 'string') {
+    return FinishReason.FINISH_REASON_UNSPECIFIED;
+  }
   const mapping: Record<string, FinishReason> = {
     stop: FinishReason.STOP,
     length: FinishReason.MAX_TOKENS,
+    max_tokens: FinishReason.MAX_TOKENS,
     content_filter: FinishReason.SAFETY,
     function_call: FinishReason.STOP,
     tool_calls: FinishReason.STOP,
   };
-  return mapping[openaiReason] || FinishReason.FINISH_REASON_UNSPECIFIED;
+  return (
+    mapping[openaiReason.toLowerCase()] ||
+    FinishReason.FINISH_REASON_UNSPECIFIED
+  );
 }
 
 function mapGeminiFinishReasonToOpenAI(


### PR DESCRIPTION
## What this PR does

Makes `finish_reason` handling case-insensitive when converting OpenAI-compatible chat completions to the internal Gemini representation. Uppercase `finish_reason` values (`STOP`, `MAX_TOKENS`) are now folded to lowercase before lookup, and a `max_tokens` alias is added so the Gemini-native spelling maps to the same truncation state as OpenAI's `length`. The lookup also guards against a non-string runtime `finish_reason` (a malformed gateway can send one), which would otherwise make the lowercase call throw.

## Why it's needed

Google Gemini models exposed through an OpenAI-compatible gateway — for example `gemini-3.7-flash` — return the Gemini-native `finish_reason` spelling in uppercase (`STOP`, `MAX_TOKENS`) rather than the OpenAI lowercase values (`stop`, `length`). The previous case-sensitive lookup mapped `STOP` and `MAX_TOKENS` to `FINISH_REASON_UNSPECIFIED`, which silently broke truncation recovery: the `finishReason === FinishReason.MAX_TOKENS` checks that escalate the output limit never fired, so a turn ended with silently truncated output instead of retrying with a higher limit.

## Reviewer Test Plan

### How to verify

Run the focused unit test:

```console
cd packages/core && npx vitest run src/core/openaiContentGenerator/converter.test.ts
```

The new `maps uppercase finish_reason values case-insensitively` case asserts `STOP` -> `FinishReason.STOP` and `MAX_TOKENS` -> `FinishReason.MAX_TOKENS`. Without the fix, both assert against `FINISH_REASON_UNSPECIFIED` and fail. The `does not throw on a non-string finish_reason from a malformed gateway` case asserts a non-string value degrades to `FINISH_REASON_UNSPECIFIED` instead of throwing.

### Evidence (Before & After)

Before: uppercase values fell through to `FINISH_REASON_UNSPECIFIED` (silent, no error). After: `STOP` -> `FinishReason.STOP`, `MAX_TOKENS` -> `FinishReason.MAX_TOKENS`.

```console
✓ src/core/openaiContentGenerator/converter.test.ts (222 tests) 32ms
Test Files  1 passed (1)
Tests  222 passed (222)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A — unit test only.

## Risk & Scope

- Main risk or tradeoff: low. The change only widens the accepted `finish_reason` spellings; lowercase values map exactly as before, and non-string values now degrade to `FINISH_REASON_UNSPECIFIED` instead of throwing.
- Not validated / out of scope: streaming chunk conversion is not changed directly, but it shares the same finish-reason mapping helper, so the fix applies there too.
- Breaking changes / migration notes: none.

## Linked Issues

Resolves #9882

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 OpenAI 兼容 chat completion 转换为内部 Gemini 表示时的 `finish_reason` 处理改为大小写不敏感。大写 `finish_reason` 值（`STOP`、`MAX_TOKENS`）现在会先转为小写再查表，并新增 `max_tokens` 别名，使 Gemini 原生拼写与 OpenAI 的 `length` 映射到相同的截断状态。查表同时守卫了非字符串的运行时 `finish_reason` 值（畸形网关可能返回此类值），否则小写转换会抛异常。

## 为什么需要

通过 OpenAI 兼容网关暴露的 Google Gemini 模型（例如 `gemini-3.7-flash`）会返回大写形式的 Gemini 原生 `finish_reason` 拼写（`STOP`、`MAX_TOKENS`），而非 OpenAI 的小写值（`stop`、`length`）。此前大小写敏感查表会把 `STOP` 和 `MAX_TOKENS` 映射为 `FINISH_REASON_UNSPECIFIED`，静默地破坏了截断恢复逻辑：那些检查 `finishReason === FinishReason.MAX_TOKENS` 从而提升输出上限的逻辑永远不会触发，导致回合以被静默截断的输出结束，而不是以提高上限重试。

## 评审者验证计划

### 如何验证

运行聚焦单元测试：

```console
cd packages/core && npx vitest run src/core/openaiContentGenerator/converter.test.ts
```

新增用例 `maps uppercase finish_reason values case-insensitively` 断言 `STOP` -> `FinishReason.STOP`、`MAX_TOKENS` -> `FinishReason.MAX_TOKENS`。没有该修复时，两个断言都会落到 `FINISH_REASON_UNSPECIFIED` 而失败。`does not throw on a non-string finish_reason from a malformed gateway` 用例断言非字符串值降级为 `FINISH_REASON_UNSPECIFIED` 而不是抛异常。

### 证据（修复前 & 修复后）

修复前：大写值落到 `FINISH_REASON_UNSPECIFIED`（静默，无报错）。修复后：`STOP` -> `FinishReason.STOP`、`MAX_TOKENS` -> `FinishReason.MAX_TOKENS`。

```console
✓ src/core/openaiContentGenerator/converter.test.ts (222 tests) 32ms
Test Files  1 passed (1)
Tests  222 passed (222)
```

### 在什么环境上测试

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### 环境（可选）

N/A — 仅单元测试。

## 风险与范围

- 主要风险或权衡：低。改动仅放宽了接受的 `finish_reason` 拼写；小写值的映射与之前完全一致，非字符串值现在降级为 `FINISH_REASON_UNSPECIFIED` 而不是抛异常。
- 未验证 / 超出范围：流式 chunk 转换未直接改动，但它复用同一个 finish-reason 映射辅助函数，因此该修复同样对其生效。
- 破坏性变更 / 迁移说明：无。

## 关联 Issues

Resolves #9882

</details>
