### PR TITLE
test(core): align lazy generator vertex test

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -758,7 +758,7 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
       () =>
         ({
           models: {
-            countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+            embedContent: vi.fn().mockResolvedValue({ embeddings: [] }),
           },
         }) as unknown as GoogleGenAI,
     );
@@ -773,7 +773,10 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
         getSessionId: () => 'test-session',
       } as unknown as Config,
     );
-    await generator.countTokens({ model: 'gemini-2.5-pro', contents: 'hello' });
+    await generator.embedContent({
+      model: 'gemini-2.5-pro',
+      contents: 'hello',
+    });
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({ vertexai: true, apiKey: undefined }),


### PR DESCRIPTION
## What this PR does

Updates the Vertex-mode lazy content generator test to call `embedContent` instead of `countTokens`, matching the narrowed `ContentGenerator` interface introduced on `main`.

## Why it's needed

`main` currently fails the core package TypeScript build because the test still calls `generator.countTokens(...)` on a value typed as `ContentGenerator`, but that method is no longer part of the interface. The test only needs to force lazy provider construction, and `embedContent` exercises the same path while remaining part of the interface.

## Reviewer Test Plan

- `npm run build --workspace=packages/core`
- `npx vitest run packages/core/src/core/contentGenerator.test.ts`
- `npx prettier --check packages/core/src/core/contentGenerator.test.ts`

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 Vertex 模式 lazy content generator 测试中的触发调用从 `countTokens` 改为 `embedContent`，以匹配 `main` 上已经收窄后的 `ContentGenerator` 接口。

## 为什么需要

当前 `main` 的 core package TypeScript build 会失败，因为测试仍然在 `ContentGenerator` 类型值上调用已移出接口的 `countTokens`。该测试只是需要触发 lazy provider 构造，`embedContent` 可以覆盖同一路径且仍属于接口。

## 测试计划

- `npm run build --workspace=packages/core`
- `npx vitest run packages/core/src/core/contentGenerator.test.ts`
- `npx prettier --check packages/core/src/core/contentGenerator.test.ts`

</details>