### PR TITLE
fix(core): unbreak main build by replacing removed countTokens call in test

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -758,7 +758,7 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
       () =>
         ({
           models: {
-            countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+            embedContent: vi.fn().mockResolvedValue({ embeddings: [] }),
           },
         }) as unknown as GoogleGenAI,
     );
@@ -773,7 +773,10 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
         getSessionId: () => 'test-session',
       } as unknown as Config,
     );
-    await generator.countTokens({ model: 'gemini-2.5-pro', contents: 'hello' });
+    await generator.embedContent({
+      model: 'gemini-2.5-pro',
+      contents: 'hello',
+    });
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({ vertexai: true, apiKey: undefined }),


### PR DESCRIPTION
## What this PR does

Fixes the broken build on main: a Vertex AI auth test triggered lazy client construction by calling a token-counting method that no longer exists on the content generator interface. The test now triggers construction through content embedding, which remains on the interface and passes straight through the logging wrapper.

## Why it's needed

Two recently merged PRs conflicted semantically — each was green on its own, but together they break `tsc --build` on main (CI run https://github.com/QwenLM/qwen-code/actions/runs/32706679708 fails every E2E job at the "Build project" step with `error TS2339: Property 'countTokens' does not exist on type 'ContentGenerator'`):

- #9017 added a test asserting Vertex mode initializes with Application Default Credentials, using the token-counting call merely as a trigger to force lazy client construction.
- #9676 then removed that method from the content generator interface.

The test's real assertion (the GenAI client is constructed in Vertex mode with no API key) is unchanged.

## Reviewer Test Plan

### How to verify

On main, `npm run build` fails with `contentGenerator.test.ts(776,21): error TS2339`. On this branch it succeeds, and the previously failing test still passes:

```
cd packages/core && npx vitest run src/core/contentGenerator.test.ts
# Test Files  1 passed (1)
# Tests  27 passed (27)
```

### Evidence (Before & After)

N/A (build/test-only change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — unit tests and build only.

## Risk & Scope

- Main risk or tradeoff: none — single test-only edit; no production code touched.
- Not validated / out of scope: preventing this class of semantic merge conflict generally.
- Breaking changes / migration notes: none.

## Linked Issues

Unblocks main CI after #9676; related to #9017.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 main 上挂掉的构建：一个 Vertex AI 鉴权测试通过调用一个已从 content generator 接口删除的 token 计数方法来触发 lazy 客户端构建。现在改为通过内容嵌入（embed）调用触发构建，该方法仍在接口上，且在 logging 包装层直接透传。

## 为什么需要

两个最近合入的 PR 发生了语义冲突——各自 CI 都是绿的，但组合起来导致 main 上 `tsc --build` 失败（CI run https://github.com/QwenLM/qwen-code/actions/runs/32706679708 中所有 E2E job 都在 "Build project" 步骤报错 `error TS2339: Property 'countTokens' does not exist on type 'ContentGenerator'`）：

- #9017 新增了一个断言 Vertex 模式可用 Application Default Credentials 的测试，其中仅用 token 计数调用作为触发 lazy 客户端构建的手段。
- #9676 随后把该方法从 content generator 接口中删除。

测试真正的断言（GenAI 客户端以 Vertex 模式、无 API key 构造）保持不变。

## Reviewer Test Plan

### 如何验证

在 main 上 `npm run build` 失败，报 `contentGenerator.test.ts(776,21): error TS2339`；在本分支上构建成功，且之前失败的测试仍然通过：

```
cd packages/core && npx vitest run src/core/contentGenerator.test.ts
# Test Files  1 passed (1)
# Tests  27 passed (27)
```

### 证据（Before & After）

N/A（仅构建/测试改动）

### 测试平台

macOS ✅；Windows / Linux 未本地测试。

### 环境（可选）

N/A —— 仅单元测试与构建。

## 风险与范围

- 主要风险或取舍：无 —— 单个测试文件改动，不涉及生产代码。
- 未验证 / 范围之外：从机制上防止这类语义化合并冲突。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

解除 #9676 合入后 main CI 的阻塞；与 #9017 相关。

</details>
