### PR TITLE
fix(core): replace removed countTokens call in lazy generator vertex test

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -758,7 +758,7 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
       () =>
         ({
           models: {
-            countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+            embedContent: vi.fn().mockResolvedValue({ embeddings: [] }),
           },
         }) as unknown as GoogleGenAI,
     );
@@ -773,7 +773,10 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
         getSessionId: () => 'test-session',
       } as unknown as Config,
     );
-    await generator.countTokens({ model: 'gemini-2.5-pro', contents: 'hello' });
+    await generator.embedContent({
+      model: 'gemini-2.5-pro',
+      contents: 'hello',
+    });
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({ vertexai: true, apiKey: undefined }),


### PR DESCRIPTION
## What this PR does

Replaces the removed `countTokens` call in the lazy-generator Vertex test with `embedContent`, the simplest surviving pass-through method on the `ContentGenerator` interface. The test's actual assertion is the `GoogleGenAI` constructor shape (`vertexai: true, apiKey: undefined`); `countTokens` was only the trigger forcing lazy provider creation. The mock is swapped alongside the call (`models.embedContent` resolving `{ embeddings: [] }`).

## Why it's needed

#9676 removed `countTokens` from the `ContentGenerator` interface and the provider implementations, but this test survived still calling it. The result broke `tsc --build` in `packages/core` (TS2339 at contentGenerator.test.ts:776), which fails the build step of every E2E shard — run 32709027390 failed all 8 shards at build, tracked by #9889. This is the same one-line repair as #9888 and #9890 (identical diffs); this PR consolidates the fix so there is one repair to merge.

## Reviewer Test Plan

### How to verify

Run the exact step that failed in CI, now green: `cd packages/core && npx tsc --build` exits 0. Run the touched test file: `npx vitest run src/core/contentGenerator.test.ts` — 27/27 passing locally, including the changed `builds the client in Vertex mode from the auth type alone` test.

### Evidence (Before & After)

N/A — test-only repair of a compile error, no user-visible change. Before: `src/core/contentGenerator.test.ts(776,21): error TS2339: Property 'countTokens' does not exist on type 'ContentGenerator'` from `tsc --build` (run 32709027390). After: `tsc --build` exit 0, 27/27 tests passing.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪖 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Local Linux, Node v22, `npx tsc --build` and `npx vitest run` in `packages/core`; no sandbox.

## Risk & Scope

- Main risk or tradeoff: none functional — the test's assertion (constructor shape) is unchanged; only the lazy-instantiation trigger method changed, and the client is fully mocked.
- Not validated / out of scope: Windows/macOS local runs (the change is platform-independent TypeScript).
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #9889. Supersedes #9888 and #9890 (identical one-line repair; consolidating to a single PR).

<details>
<summary>中文说明</summary>

#9676 从 `ContentGenerator` 接口移除了 `countTokens`，但 contentGenerator.test.ts:776 的 Vertex 懒加载测试仍用它当触发器，导致 `tsc --build` 编译失败（TS2339），run 32709027390 全部 8 个 E2E shard 在构建阶段失败（#9889 跟踪）。本 PR 把触发器换成接口上仍存在的 `embedContent`（mock 同步替换），测试断言本身（GoogleGenAI 构造参数）不变。与 #9888、#9890 是同一处单行修复，本 PR 用于收敛为单一修复。本地验证：`tsc --build` 通过、该测试文件 27/27 通过。

</details>
