### PR TITLE
fix(cli): use target dir for ACP core settings

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2125,6 +2125,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getWorkspaceContext: vi.fn().mockReturnValue({}),
       getDebugMode: vi.fn().mockReturnValue(false),
       getToolRegistry: vi.fn().mockReturnValue(undefined),
+      getTargetDir: vi.fn().mockReturnValue(process.cwd()),
     } as unknown as Config;
     vi.mocked(loadSettings).mockReturnValue(makeSessionSettings());
 

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -986,6 +986,7 @@ import {
   GoalConflictError,
   GoalInvalidTransitionError,
   sessionIdContext,
+  ExtensionManager,
 } from '@qwen-code/qwen-code-core';
 import { ndJsonStream } from '@qwen-code/acp-bridge/ndJsonStream';
 import {
@@ -11104,6 +11105,43 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('qwen/settings/getCore prefers explicit cwd over config target dir', async () => {
+    mockConfig.getTargetDir = vi.fn().mockReturnValue('/worktree/project');
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await agent.extMethod('qwen/settings/getCore', { cwd: '/explicit/dir' });
+
+    expect(loadSettings).toHaveBeenCalledWith('/explicit/dir');
+    expect(vi.mocked(ExtensionManager)).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: '/explicit/dir' }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/settings/getCore uses the session target dir when cwd is omitted', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111111';
+    const targetDir = '/relocated/worktree';
+    const innerConfig = await setupSessionMocks(sessionId);
+    innerConfig.getTargetDir = vi.fn().mockReturnValue(targetDir);
+    const settings = makeCoreSettings();
+    vi.mocked(loadSettings).mockReturnValue(settings);
+    const { agent, agentPromise } = await bootAcpAgent();
+
+    await agent.newSession({ cwd: '/launch/dir', mcpServers: [] });
+    await agent.extMethod('qwen/settings/getCore', { sessionId });
+
+    expect(loadSettings).toHaveBeenLastCalledWith(targetDir);
+    expect(vi.mocked(ExtensionManager)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ workspaceDir: targetDir }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('qwen/settings/setCoreValue falls back to config target dir when cwd is omitted', async () => {
     const targetDir = '/worktree/.qwen';
     mockConfig.getTargetDir = vi.fn().mockReturnValue(targetDir);
@@ -11121,6 +11159,53 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       'Workspace',
       'general.outputLanguage',
       'Japanese',
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/settings/setCoreValue prefers explicit cwd over config target dir', async () => {
+    mockConfig.getTargetDir = vi.fn().mockReturnValue('/worktree/project');
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await agent.extMethod('qwen/settings/setCoreValue', {
+      cwd: '/explicit/dir',
+      scope: 'workspace',
+      key: 'general.outputLanguage',
+      value: 'Japanese',
+    });
+
+    expect(loadSettings).toHaveBeenCalledWith('/explicit/dir');
+    expect(vi.mocked(ExtensionManager)).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: '/explicit/dir' }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/settings/setCoreValue uses the session target dir when cwd is omitted', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111111';
+    const targetDir = '/relocated/worktree';
+    const innerConfig = await setupSessionMocks(sessionId);
+    innerConfig.getTargetDir = vi.fn().mockReturnValue(targetDir);
+    const settings = makeCoreSettings();
+    vi.mocked(loadSettings).mockReturnValue(settings);
+    const { agent, agentPromise } = await bootAcpAgent();
+
+    await agent.newSession({ cwd: '/launch/dir', mcpServers: [] });
+    await agent.extMethod('qwen/settings/setCoreValue', {
+      sessionId,
+      scope: 'workspace',
+      key: 'general.outputLanguage',
+      value: 'Japanese',
+    });
+
+    expect(loadSettings).toHaveBeenLastCalledWith(targetDir);
+    expect(vi.mocked(ExtensionManager)).toHaveBeenLastCalledWith(
+      expect.objectContaining({ workspaceDir: targetDir }),
     );
 
     mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -11014,6 +11014,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
 
   // Shared boot helper for the qwen/settings/* handler tests below.
   async function bootCoreSettingsAgent(settings: LoadedSettings) {
+    if (typeof mockConfig.getTargetDir !== 'function') {
+      mockConfig.getTargetDir = vi.fn().mockReturnValue(process.cwd());
+    }
     vi.mocked(loadSettings).mockReturnValue(settings);
     const agentPromise = runAcpAgent(mockConfig, settings, mockArgv);
     await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
@@ -11081,6 +11084,43 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       workspace: expect.objectContaining({ values: expect.anything() }),
       merged: expect.objectContaining({ values: expect.anything() }),
     });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/settings/getCore falls back to config target dir when cwd is omitted', async () => {
+    const targetDir = '/worktree/.qwen';
+    mockConfig.getTargetDir = vi.fn().mockReturnValue(targetDir);
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await agent.extMethod('qwen/settings/getCore', {});
+
+    expect(loadSettings).toHaveBeenCalledWith(targetDir);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('qwen/settings/setCoreValue falls back to config target dir when cwd is omitted', async () => {
+    const targetDir = '/worktree/.qwen';
+    mockConfig.getTargetDir = vi.fn().mockReturnValue(targetDir);
+    const settings = makeCoreSettings();
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    await agent.extMethod('qwen/settings/setCoreValue', {
+      scope: 'workspace',
+      key: 'general.outputLanguage',
+      value: 'Japanese',
+    });
+
+    expect(loadSettings).toHaveBeenCalledWith(targetDir);
+    expect(settings.setValue).toHaveBeenCalledWith(
+      'Workspace',
+      'general.outputLanguage',
+      'Japanese',
+    );
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -11138,9 +11138,10 @@ class QwenAgent implements Agent {
         return { newSessionId, title, displayName: title };
       }
       case 'qwen/settings/getCore': {
-        const settings = loadSettings(cwd);
+        const coreSettingsCwd = requestedCwd || this.config.getTargetDir();
+        const settings = loadSettings(coreSettingsCwd);
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, coreSettingsCwd);
       }
       case 'qwen/settings/setCoreValue': {
         const key = params['key'];
@@ -11153,7 +11154,8 @@ class QwenAgent implements Agent {
             'Unsupported Qwen setting key',
           );
         }
-        const settings = loadSettings(cwd);
+        const coreSettingsCwd = requestedCwd || this.config.getTargetDir();
+        const settings = loadSettings(coreSettingsCwd);
         const settingKey = key as QwenCoreSettingKey;
         const normalizedValue = normalizeCoreSettingValue(
           settingKey,
@@ -11183,7 +11185,7 @@ class QwenAgent implements Agent {
         // `setValue` already persisted to disk and recomputed the in-memory
         // merged view, so reloading from disk here is redundant I/O.
         this.settings = settings;
-        return this.buildCoreSettings(settings, cwd);
+        return this.buildCoreSettings(settings, coreSettingsCwd);
       }
       case 'qwen/settings/setMcpServer': {
         const name = params['name'];

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5691,6 +5691,27 @@ class QwenAgent implements Agent {
     };
   }
 
+  private resolveCoreSettingsCwd(
+    params: Record<string, unknown>,
+    requestedCwd: string | undefined,
+  ): string {
+    if (requestedCwd) {
+      return requestedCwd;
+    }
+    const sessionId =
+      typeof params['sessionId'] === 'string' ? params['sessionId'] : undefined;
+    if (sessionId) {
+      const sessionTargetDir = this.sessions
+        .get(sessionId)
+        ?.getConfig()
+        .getTargetDir();
+      if (sessionTargetDir) {
+        return sessionTargetDir;
+      }
+    }
+    return this.config.getTargetDir();
+  }
+
   private syncLivePermissionManagers(
     before: PermissionRuleSet,
     after: PermissionRuleSet,
@@ -11138,7 +11159,10 @@ class QwenAgent implements Agent {
         return { newSessionId, title, displayName: title };
       }
       case 'qwen/settings/getCore': {
-        const coreSettingsCwd = requestedCwd || this.config.getTargetDir();
+        const coreSettingsCwd = this.resolveCoreSettingsCwd(
+          params,
+          requestedCwd,
+        );
         const settings = loadSettings(coreSettingsCwd);
         this.settings = settings;
         return this.buildCoreSettings(settings, coreSettingsCwd);
@@ -11154,7 +11178,10 @@ class QwenAgent implements Agent {
             'Unsupported Qwen setting key',
           );
         }
-        const coreSettingsCwd = requestedCwd || this.config.getTargetDir();
+        const coreSettingsCwd = this.resolveCoreSettingsCwd(
+          params,
+          requestedCwd,
+        );
         const settings = loadSettings(coreSettingsCwd);
         const settingKey = key as QwenCoreSettingKey;
         const normalizedValue = normalizeCoreSettingValue(


### PR DESCRIPTION
## What this PR does

- Uses the active Config target directory when ACP core settings methods are called without an explicit `cwd`.
- Adds regression coverage for `qwen/settings/getCore` and `qwen/settings/setCoreValue` so omitted `cwd` resolves through `config.getTargetDir()`.

## Why it's needed

Worktree-backed ACP sessions can run from a daemon process root that differs from the active workspace. Falling back to `process.cwd()` makes core settings reads and writes target the wrong `.qwen/settings.json`; using the target directory keeps workspace settings scoped to the active worktree.

Fixes #8138.

## Reviewer Test Plan

- `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts`
- `cd packages/cli && npm run typecheck`

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

- ACP core settings 方法没有传入 `cwd` 时，改用当前 Config 的 target directory。
- 增加 `qwen/settings/getCore` 和 `qwen/settings/setCoreValue` 的回归测试，覆盖省略 `cwd` 时走 `config.getTargetDir()` 的路径。

## 为什么需要

worktree 场景下，ACP daemon 的进程根目录可能不是当前工作区。继续 fallback 到 `process.cwd()` 会把 core settings 读写到错误的 `.qwen/settings.json`；使用 target directory 后，workspace 设置会落在当前 worktree。

修复 #8138。

## 验证

- `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts`
- `cd packages/cli && npm run typecheck`

</details>