### PR TITLE
test(core): align Vertex auth test with content interface

### DIFF
--- a/packages/core/src/core/contentGenerator.test.ts
+++ b/packages/core/src/core/contentGenerator.test.ts
@@ -758,7 +758,7 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
       () =>
         ({
           models: {
-            countTokens: vi.fn().mockResolvedValue({ totalTokens: 1 }),
+            embedContent: vi.fn().mockResolvedValue({ embeddings: [] }),
           },
         }) as unknown as GoogleGenAI,
     );
@@ -773,7 +773,10 @@ describe('validateModelConfig - Vertex AI Application Default Credentials', () =
         getSessionId: () => 'test-session',
       } as unknown as Config,
     );
-    await generator.countTokens({ model: 'gemini-2.5-pro', contents: 'hello' });
+    await generator.embedContent({
+      model: 'gemini-2.5-pro',
+      contents: 'hello',
+    });
 
     expect(GoogleGenAI).toHaveBeenCalledWith(
       expect.objectContaining({ vertexai: true, apiKey: undefined }),


### PR DESCRIPTION
## What this PR does

Updates the remaining Vertex auth lazy-construction test to exercise `embedContent`, the same surviving `ContentGenerator` operation used by the rest of the #9676 test migration.

## Why it's needed

#9676 removed `countTokens` from `ContentGenerator`, but a Vertex ADC test added independently on `main` retained one `generator.countTokens(...)` call. As a result, current `main` fails during `npm ci`, build, and typecheck with `TS2339` at `contentGenerator.test.ts:776`. The PR's own sandboxed verification had already captured the integration failure [here](https://github.com/QwenLM/qwen-code/pull/9676#issuecomment-5392019167).

## Reviewer Test Plan

### How to verify

1. On current `main`, run `npm run build --workspace packages/core` and observe `Property 'countTokens' does not exist on type 'ContentGenerator'`.
2. On this branch, run `cd packages/core && npx vitest run src/core/contentGenerator.test.ts --maxWorkers=1` and confirm all 27 tests pass.
3. Run `npm run typecheck` and confirm every workspace plus `typecheck:integration` passes.

### Evidence (Before & After)

N/A for UI. Before: core compilation stops at `contentGenerator.test.ts:776` with `TS2339`. After: the full repository build completes during `npm ci`, the focused file passes `27/27`, and workspace plus integration typecheck completes successfully.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22.22.2 on macOS. Verified with a clean `npm ci`, which completed the full prepare/build pipeline.

## Risk & Scope

- Main risk or tradeoff: None beyond changing which retained API initializes the mocked Gemini client in this test.
- Not validated / out of scope: Production behavior and unrelated #9676 follow-up suggestions.
- Breaking changes / migration notes: None; this is test-only and restores the build after the interface shrink.

## Linked Issues

Follow-up to #9676.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

将遗漏的 Vertex 认证懒构造测试改为调用 `embedContent`；这是 #9676 其余测试迁移统一采用、且仍保留在 `ContentGenerator` 中的操作。

## 为什么需要

#9676 从 `ContentGenerator` 删除了 `countTokens`，但 `main` 上独立加入的一条 Vertex ADC 测试仍保留 `generator.countTokens(...)`。因此当前 `main` 在 `npm ci`、build 和 typecheck 阶段都会于 `contentGenerator.test.ts:776` 报出 `TS2339`。该集成失败此前也已被该 PR 自身的沙箱验证[记录](https://github.com/QwenLM/qwen-code/pull/9676#issuecomment-5392019167)。

## 审查测试计划

### 验证方法

1. 在当前 `main` 上运行 `npm run build --workspace packages/core`，可看到 `Property 'countTokens' does not exist on type 'ContentGenerator'`。
2. 在本分支运行 `cd packages/core && npx vitest run src/core/contentGenerator.test.ts --maxWorkers=1`，确认 27 条测试全部通过。
3. 运行 `npm run typecheck`，确认所有 workspace 与 `typecheck:integration` 均通过。

### 前后证据

UI 不适用。修改前：core 编译在 `contentGenerator.test.ts:776` 因 `TS2339` 中止。修改后：干净 `npm ci` 中的全仓库 build 完成，目标文件 `27/27` 通过，全工作区与 integration typecheck 成功完成。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

macOS，Node.js 22.22.2。已通过干净 `npm ci` 验证，它完整执行并通过了 prepare/build 流程。

## 风险与范围

- 主要风险或取舍：除测试中改用另一个仍保留的 API 来初始化 Gemini mock 客户端外，无其他风险。
- 未验证 / 范围外：生产行为及 #9676 的其他后续建议。
- 破坏性变更 / 迁移说明：无；这是纯测试修复，用于恢复接口收缩后的构建。

## 关联问题

#9676 的后续修复。

</details>
