### PR TITLE
fix(core): suppress unchanged todo writes

### DIFF
--- a/packages/core/src/tools/todoWrite.test.ts
+++ b/packages/core/src/tools/todoWrite.test.ts
@@ -334,9 +334,47 @@ describe('TodoWriteTool', () => {
       );
 
       expect(result.llmContent).toContain('Todo list is unchanged');
-      expect(result.returnDisplay).toBe('Todo list unchanged.');
+      expect(result.llmContent).toContain('<system-reminder>');
+      expect(result.returnDisplay).toMatchObject({
+        type: 'todo_list',
+        planId: 'plan-1',
+        todos: unchangedTodos,
+        changes: {
+          created: [],
+          completed: [],
+        },
+      });
       expect(mockAtomicWrite).not.toHaveBeenCalled();
-      expect(mockConfig.setActiveTodoReminder).not.toHaveBeenCalled();
+      expect(mockConfig.setActiveTodoReminder).toHaveBeenCalledWith(
+        'todo-prompt',
+        expect.stringContaining('Task'),
+      );
+    });
+
+    it('should preserve structured no-op display for an unchanged empty list', async () => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({ todos: [] }));
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockAtomicWrite.mockResolvedValue(undefined);
+
+      const result = await promptIdContext.run('todo-prompt', () =>
+        tool.build({ todos: [] }).execute(mockAbortSignal),
+      );
+
+      expect(result.llmContent).toContain('Todo list is unchanged');
+      expect(result.llmContent).toContain('<system-reminder>');
+      expect(result.returnDisplay).toMatchObject({
+        type: 'todo_list',
+        todos: [],
+        changes: {
+          created: [],
+          completed: [],
+        },
+      });
+      expect(mockAtomicWrite).not.toHaveBeenCalled();
+      expect(mockConfig.setActiveTodoReminder).toHaveBeenCalledWith(
+        'todo-prompt',
+        undefined,
+      );
     });
 
     it('should not rewrite a repeated terminal snapshot', async () => {
@@ -355,7 +393,11 @@ describe('TodoWriteTool', () => {
         })
         .execute(mockAbortSignal);
 
-      expect(result.returnDisplay).toBe('Todo list unchanged.');
+      expect(result.returnDisplay).toMatchObject({
+        type: 'todo_list',
+        planId: 'finished-plan',
+        todos: [{ id: '1', content: 'Done', status: 'completed' }],
+      });
       expect(mockAtomicWrite).not.toHaveBeenCalled();
     });
 

--- a/packages/core/src/tools/todoWrite.test.ts
+++ b/packages/core/src/tools/todoWrite.test.ts
@@ -315,7 +315,31 @@ describe('TodoWriteTool', () => {
       ).toMatchObject({ planId: 'plan-1' });
     });
 
-    it('should retain the plan ID for a repeated terminal snapshot', async () => {
+    it('should not rewrite or render a todo panel when the snapshot is unchanged', async () => {
+      const unchangedTodos: TodoItem[] = [
+        { id: '1', content: 'Task', status: 'in_progress' },
+        { id: '2', content: 'Next', status: 'pending' },
+      ];
+      mockFs.readFile.mockResolvedValue(
+        JSON.stringify({
+          planId: 'plan-1',
+          todos: unchangedTodos,
+        }),
+      );
+      mockFs.mkdir.mockResolvedValue(undefined);
+      mockAtomicWrite.mockResolvedValue(undefined);
+
+      const result = await promptIdContext.run('todo-prompt', () =>
+        tool.build({ todos: unchangedTodos }).execute(mockAbortSignal),
+      );
+
+      expect(result.llmContent).toContain('Todo list is unchanged');
+      expect(result.returnDisplay).toBe('Todo list unchanged.');
+      expect(mockAtomicWrite).not.toHaveBeenCalled();
+      expect(mockConfig.setActiveTodoReminder).not.toHaveBeenCalled();
+    });
+
+    it('should not rewrite a repeated terminal snapshot', async () => {
       mockFs.readFile.mockResolvedValue(
         JSON.stringify({
           planId: 'finished-plan',
@@ -331,10 +355,8 @@ describe('TodoWriteTool', () => {
         })
         .execute(mockAbortSignal);
 
-      expect(result.returnDisplay).toMatchObject({ planId: 'finished-plan' });
-      expect(
-        JSON.parse(mockAtomicWrite.mock.calls[0][1] as string),
-      ).toMatchObject({ planId: 'finished-plan' });
+      expect(result.returnDisplay).toBe('Todo list unchanged.');
+      expect(mockAtomicWrite).not.toHaveBeenCalled();
     });
 
     it('should start a new plan after the previous plan completed', async () => {

--- a/packages/core/src/tools/todoWrite.ts
+++ b/packages/core/src/tools/todoWrite.ts
@@ -255,6 +255,28 @@ ${systemMessage}
   };
 }
 
+function updateActiveTodoReminder(
+  config: Config,
+  promptId: string | undefined,
+  todos: TodoItem[],
+): void {
+  if (!promptId) return;
+
+  const unfinishedTodos = todos.filter((todo) => todo.status !== 'completed');
+  const serializedTodos = escapeSystemReminderTags(
+    unfinishedTodos
+      .map((todo) => `- [${todo.status}] ${todo.content}`)
+      .join('\n'),
+  );
+  const todoContext = serializedTodos.slice(0, MAX_ACTIVE_TODO_CONTEXT_CHARS);
+  config.setActiveTodoReminder(
+    promptId,
+    unfinishedTodos.length > 0
+      ? `<system-reminder>\nThe current task still has unfinished todo items:\n${todoContext}${serializedTodos.length > todoContext.length ? '\n[truncated]' : ''}\nKeep the todo list current and continue the task. Do not treat a successful intermediate tool call as task completion.\n</system-reminder>`
+      : undefined,
+  );
+}
+
 class TodoWriteToolInvocation extends BaseToolInvocation<
   TodoWriteParams,
   ToolResult
@@ -303,13 +325,25 @@ class TodoWriteToolInvocation extends BaseToolInvocation<
       const oldTodosMap = new Map(oldTodos.map((t) => [t.id, t]));
 
       if (isDeepStrictEqual(finalTodos, oldTodos)) {
+        const resultPlanId = previousPlan.planId;
+        updateActiveTodoReminder(
+          this.config,
+          promptIdContext.getStore(),
+          finalTodos,
+        );
+
         return {
           llmContent: `Todo list is unchanged.
 
 <system-reminder>
 The todo list already matches the requested state. DO NOT mention this explicitly to the user. Continue on with the tasks at hand if applicable.
 </system-reminder>`,
-          returnDisplay: 'Todo list unchanged.',
+          returnDisplay: {
+            type: 'todo_list' as const,
+            ...(resultPlanId ? { planId: resultPlanId } : {}),
+            todos: finalTodos,
+            changes,
+          },
         };
       }
 
@@ -381,8 +415,7 @@ The todo list already matches the requested state. DO NOT mention this explicitl
       const startsNewPlan =
         finalTodos.length > 0 &&
         (oldTodos.length === 0 ||
-          (oldTodos.every((todo) => todo.status === 'completed') &&
-            !isDeepStrictEqual(finalTodos, oldTodos)));
+          oldTodos.every((todo) => todo.status === 'completed'));
       const activePlanId =
         finalTodos.length === 0
           ? undefined
@@ -393,27 +426,11 @@ The todo list already matches the requested state. DO NOT mention this explicitl
 
       // 4. Write new todos AFTER all validation passes
       await writeTodosToFile(finalTodos, activePlanId, sessionId);
-      const unfinishedTodos = finalTodos.filter(
-        (todo) => todo.status !== 'completed',
+      updateActiveTodoReminder(
+        this.config,
+        promptIdContext.getStore(),
+        finalTodos,
       );
-      const promptId = promptIdContext.getStore();
-      if (promptId) {
-        const serializedTodos = escapeSystemReminderTags(
-          unfinishedTodos
-            .map((todo) => `- [${todo.status}] ${todo.content}`)
-            .join('\n'),
-        );
-        const todoContext = serializedTodos.slice(
-          0,
-          MAX_ACTIVE_TODO_CONTEXT_CHARS,
-        );
-        this.config.setActiveTodoReminder(
-          promptId,
-          unfinishedTodos.length > 0
-            ? `<system-reminder>\nThe current task still has unfinished todo items:\n${todoContext}${serializedTodos.length > todoContext.length ? '\n[truncated]' : ''}\nKeep the todo list current and continue the task. Do not treat a successful intermediate tool call as task completion.\n</system-reminder>`
-            : undefined,
-        );
-      }
 
       // 5. POST-WRITE PHASE: Execute hooks for side effects (logging, HTTP sync, etc.)
       // These hooks can now safely perform side effects knowing data is persisted

--- a/packages/core/src/tools/todoWrite.ts
+++ b/packages/core/src/tools/todoWrite.ts
@@ -302,6 +302,17 @@ class TodoWriteToolInvocation extends BaseToolInvocation<
       const changes = detectTodoChanges(oldTodos, finalTodos);
       const oldTodosMap = new Map(oldTodos.map((t) => [t.id, t]));
 
+      if (isDeepStrictEqual(finalTodos, oldTodos)) {
+        return {
+          llmContent: `Todo list is unchanged.
+
+<system-reminder>
+The todo list already matches the requested state. DO NOT mention this explicitly to the user. Continue on with the tasks at hand if applicable.
+</system-reminder>`,
+          returnDisplay: 'Todo list unchanged.',
+        };
+      }
+
       // 3. VALIDATION PHASE: Execute all hooks with Validation phase
       // Hooks should only check and return block/approve decisions, no side effects
       const hookSystem = this.config.getHookSystem();


### PR DESCRIPTION
## What this PR does

Short-circuits `todo_write` when the requested todo snapshot exactly matches the persisted snapshot. In that no-op path the tool now skips the file rewrite, skips todo hooks/reminder side effects, and returns a compact unchanged display instead of another full `todo_list` panel.

## Why it's needed

Issue #9548 reports duplicate TodoList panels with byte-identical content in a single assistant turn. The core tool previously emitted a full todo display even when the model re-sent the same list, so the TUI rendered both snapshots faithfully.

## Reviewer Test Plan

### How to verify

- `npx vitest run packages/core/src/tools/todoWrite.test.ts -t "should not rewrite or render a todo panel when the snapshot is unchanged"` first failed before the implementation with the old "Todos have been modified successfully" response.
- `npx vitest run packages/core/src/tools/todoWrite.test.ts`
- `npx prettier --check packages/core/src/tools/todoWrite.ts packages/core/src/tools/todoWrite.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`

### Evidence (Before & After)

Before: an unchanged todo snapshot still wrote the todo file and returned a `todo_list` display object.

After: unchanged snapshots return `Todo list unchanged.`, do not write the file, and do not emit a full todo panel.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A.

## Risk & Scope

- Main risk or tradeoff: Low; this changes only exact no-op `todo_write` calls where persisted and requested todos are deeply equal.
- Not validated / out of scope: Live TUI rendering was not manually replayed because the regression is pinned at the tool result boundary.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #9548

<details>
<summary>中文说明</summary>

## What this PR does

当 `todo_write` 请求的 todo 快照与已持久化快照完全一致时，直接短路返回。该 no-op 路径会跳过文件重写、跳过 todo hooks/reminder 副作用，并返回简短 unchanged display，而不是再次返回完整 `todo_list` 面板。

## Why it's needed

#9548 报告同一个 assistant turn 内出现内容完全一致的重复 TodoList 面板。此前 core 工具即使收到模型重复发送的相同列表，也会返回完整 todo display，TUI 因而忠实渲染两份快照。

## Reviewer Test Plan

### How to verify

- `npx vitest run packages/core/src/tools/todoWrite.test.ts -t "should not rewrite or render a todo panel when the snapshot is unchanged"` 在实现前先失败，失败信息为旧的 "Todos have been modified successfully" 响应。
- `npx vitest run packages/core/src/tools/todoWrite.test.ts`
- `npx prettier --check packages/core/src/tools/todoWrite.ts packages/core/src/tools/todoWrite.test.ts`
- `npm run typecheck --workspace=packages/core`
- `npm run build --workspace=packages/core`

### Evidence (Before & After)

Before：未变化的 todo 快照仍会写文件并返回 `todo_list` display 对象。

After：未变化快照返回 `Todo list unchanged.`，不写文件，也不发出完整 todo 面板。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | N/A |

### Environment (optional)

N/A。

## Risk & Scope

- Main risk or tradeoff: 低；只影响持久化 todo 和请求 todo 深度相等的 no-op `todo_write` 调用。
- Not validated / out of scope: 未手动复现 live TUI 渲染；回归点已在 tool result 边界固定。
- Breaking changes / migration notes: 无。

## Linked Issues

Fixes #9548

</details>