### PR TITLE
fix(web-shell): reduce streaming thought render jank

### DIFF
--- a/docs/design/web-shell-collapsed-thinking-performance.md
+++ b/docs/design/web-shell-collapsed-thinking-performance.md
@@ -1,0 +1,43 @@
+# Web Shell collapsed thinking performance
+
+## Problem
+
+Pure assistant and thought tail appends wake the top-level `App`, even though
+only the transcript row needs the new text. Compact activity summaries also
+keep their complete tool and thought subtree mounted while collapsed, so hidden
+rows continue reconciling streamed thought props.
+
+## Design
+
+The top-level app consumes a structural transcript snapshot. A store change
+summary proves when an update is only an append to the active assistant or
+thought block; those app-level notifications are ignored. Stores without a
+change summary retain the existing behavior.
+
+The message list separately consumes the live throttled snapshot and applies
+the existing streaming-tail projector against the app's latest structural
+messages. This updates only the visible tail without starting a second
+background-agent reconciliation loop. Structural changes still flow through
+the app and replace the baseline immediately. Insight protocol markers use a
+full projection while retaining the unchanged message prefix.
+
+Compact tool summaries mount their detail subtree only while expanded. The
+summary button remains live while collapsed; expanding reconstructs the current
+tool and thought rows from props. Collapse is immediate so the hidden subtree
+stops work without waiting for an exit animation.
+
+## Compatibility
+
+Tool, permission, terminal, reset, history, and session changes remain
+structural. Transcript callbacks continue receiving live snapshots from the
+message-list boundary. Collapsing a compact group no longer preserves local
+expanded state inside its hidden detail rows.
+
+## Verification
+
+- Prove structural snapshots ignore pure tail appends and resume on the next
+  structural change.
+- Prove a collapsed compact group has no detail subtree and restores current
+  details when expanded.
+- Run the deterministic folded-thought performance scenario and targeted unit
+  tests.

--- a/docs/design/web-shell-collapsed-thinking-performance.md
+++ b/docs/design/web-shell-collapsed-thinking-performance.md
@@ -21,10 +21,10 @@ background-agent reconciliation loop. Structural changes still flow through
 the app and replace the baseline immediately. Insight protocol markers use a
 full projection while retaining the unchanged message prefix.
 
-Compact tool summaries mount their detail subtree only while expanded. The
-summary button remains live while collapsed; expanding reconstructs the current
-tool and thought rows from props. Collapse is immediate so the hidden subtree
-stops work without waiting for an exit animation.
+Compact tool summaries mount their detail subtree only while expanded, except
+for MCP Apps whose iframe state must survive a collapse. The summary button
+remains live while collapsed; expanding reconstructs the current tool and
+thought rows from props. Collapse and expansion are immediate and unanimated.
 
 ## Compatibility
 

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -595,8 +595,13 @@ vi.mock('./hooks/useMessages', () => ({
 }));
 
 vi.mock('./hooks/useAnimationFrameTranscriptBlocks', () => ({
-  useAnimationFrameTranscriptSnapshot: () => ({
-    blocks: testState.liveBlocks ?? testState.blocks,
+  useAnimationFrameTranscriptSnapshot: (options?: {
+    structuralOnly?: boolean;
+  }) => ({
+    blocks:
+      options?.structuralOnly === true
+        ? testState.blocks
+        : (testState.liveBlocks ?? testState.blocks),
   }),
 }));
 
@@ -5225,7 +5230,10 @@ describe('App live transcript boundary', () => {
       .mockResolvedValue();
     testState.prompt = '/copy';
     testState.blocks = [{ id: 'assistant', text: 'a' }];
-    testState.liveBlocks = [{ id: 'assistant', text: 'ab' }];
+    testState.liveBlocks = [
+      { id: 'assistant', text: 'ab' },
+      { id: 'tool', kind: 'tool' },
+    ];
     testState.messages = [{ id: 'assistant', role: 'assistant', content: 'a' }];
     testState.streamingTailMessages = [
       { id: 'assistant', role: 'assistant', content: 'ab' },
@@ -5237,7 +5245,7 @@ describe('App live transcript boundary', () => {
     expect(testState.latestMessageListProps?.messages).toMatchObject([
       { id: 'assistant', role: 'assistant', content: 'ab' },
     ]);
-    expect(testState.latestMessageListProps?.transcriptBlockCount).toBe(1);
+    expect(testState.latestMessageListProps?.transcriptBlockCount).toBe(2);
 
     await clickSubmit(document.body);
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith('ab'));

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -586,6 +586,7 @@ vi.mock('@qwen-code/sdk/daemon', () => {
 });
 
 vi.mock('./hooks/useMessages', () => ({
+  projectStreamingTailMessages: () => undefined,
   useMessages: () => testState.messages,
   useMessagesFromBlocks: () => testState.messages,
 }));

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -373,6 +373,9 @@ const {
       sessionHasActivePrompt: false,
       blocks: [] as unknown[],
       liveBlocks: undefined as unknown[] | undefined,
+      snapshotCallOptions: [] as Array<
+        { structuralOnly?: boolean } | undefined
+      >,
       messages: [] as unknown[],
       streamingTailMessages: undefined as unknown[] | undefined,
       queuedPromptHoldHistory: [] as boolean[],
@@ -597,12 +600,15 @@ vi.mock('./hooks/useMessages', () => ({
 vi.mock('./hooks/useAnimationFrameTranscriptBlocks', () => ({
   useAnimationFrameTranscriptSnapshot: (options?: {
     structuralOnly?: boolean;
-  }) => ({
-    blocks:
-      options?.structuralOnly === true
-        ? testState.blocks
-        : (testState.liveBlocks ?? testState.blocks),
-  }),
+  }) => {
+    testState.snapshotCallOptions.push(options);
+    return {
+      blocks:
+        options?.structuralOnly === true
+          ? testState.blocks
+          : (testState.liveBlocks ?? testState.blocks),
+    };
+  },
 }));
 
 vi.mock('./hooks/useBackgroundTasks', () => ({
@@ -5030,6 +5036,7 @@ beforeEach(() => {
   testState.sessionHasActivePrompt = false;
   testState.blocks = [];
   testState.liveBlocks = undefined;
+  testState.snapshotCallOptions = [];
   testState.messages = [];
   testState.streamingTailMessages = undefined;
   testState.queuedPromptHoldHistory = [];
@@ -5246,6 +5253,10 @@ describe('App live transcript boundary', () => {
       { id: 'assistant', role: 'assistant', content: 'ab' },
     ]);
     expect(testState.latestMessageListProps?.transcriptBlockCount).toBe(2);
+    expect(testState.snapshotCallOptions).toContainEqual({
+      structuralOnly: true,
+    });
+    expect(testState.snapshotCallOptions).toContainEqual(undefined);
 
     await clickSubmit(document.body);
     await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith('ab'));

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -372,7 +372,9 @@ const {
       streamingState: 'idle' as StreamingState,
       sessionHasActivePrompt: false,
       blocks: [] as unknown[],
+      liveBlocks: undefined as unknown[] | undefined,
       messages: [] as unknown[],
+      streamingTailMessages: undefined as unknown[] | undefined,
       queuedPromptHoldHistory: [] as boolean[],
       queuedPromptStreamingState: 'idle',
       queuedPromptSessionHasActivePrompt: false,
@@ -401,6 +403,7 @@ const {
         isResponding?: boolean;
         transcriptReloadPaused?: boolean;
         activeTurnStartedAt?: number;
+        transcriptBlockCount?: number;
         terminalBackgroundShellTaskIds?: ReadonlySet<string>;
       } | null,
       latestBtwMessageProps: null as {
@@ -586,13 +589,15 @@ vi.mock('@qwen-code/sdk/daemon', () => {
 });
 
 vi.mock('./hooks/useMessages', () => ({
-  projectStreamingTailMessages: () => undefined,
+  projectStreamingTailMessages: () => testState.streamingTailMessages,
   useMessages: () => testState.messages,
   useMessagesFromBlocks: () => testState.messages,
 }));
 
 vi.mock('./hooks/useAnimationFrameTranscriptBlocks', () => ({
-  useAnimationFrameTranscriptSnapshot: () => ({ blocks: testState.blocks }),
+  useAnimationFrameTranscriptSnapshot: () => ({
+    blocks: testState.liveBlocks ?? testState.blocks,
+  }),
 }));
 
 vi.mock('./hooks/useBackgroundTasks', () => ({
@@ -5019,7 +5024,9 @@ beforeEach(() => {
   testState.streamingState = 'idle';
   testState.sessionHasActivePrompt = false;
   testState.blocks = [];
+  testState.liveBlocks = undefined;
   testState.messages = [];
+  testState.streamingTailMessages = undefined;
   testState.queuedPromptHoldHistory = [];
   testState.queuedPromptStreamingState = 'idle';
   testState.queuedPromptSessionHasActivePrompt = false;
@@ -5209,6 +5216,32 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe('App live transcript boundary', () => {
+  it('renders and copies the projected live tail over the structural baseline', async () => {
+    const writeText = vi
+      .spyOn(navigator.clipboard, 'writeText')
+      .mockResolvedValue();
+    testState.prompt = '/copy';
+    testState.blocks = [{ id: 'assistant', text: 'a' }];
+    testState.liveBlocks = [{ id: 'assistant', text: 'ab' }];
+    testState.messages = [{ id: 'assistant', role: 'assistant', content: 'a' }];
+    testState.streamingTailMessages = [
+      { id: 'assistant', role: 'assistant', content: 'ab' },
+    ];
+
+    renderApp();
+    await flush();
+
+    expect(testState.latestMessageListProps?.messages).toMatchObject([
+      { id: 'assistant', role: 'assistant', content: 'ab' },
+    ]);
+    expect(testState.latestMessageListProps?.transcriptBlockCount).toBe(1);
+
+    await clickSubmit(document.body);
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith('ab'));
+  });
 });
 
 describe('App compact mode', () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2717,9 +2717,6 @@ export function App({
 
   const messages = useMessagesFromBlocks(t, blocks, blockChangeSummary);
   const messagesRef = useRef(messages);
-  useLayoutEffect(() => {
-    messagesRef.current = messages;
-  }, [messages]);
   const [failedPrompt, setFailedPrompt] = useState<FailedPrompt | null>(null);
   const failedPromptRef = useRef<FailedPrompt | null>(failedPrompt);
   const [failedPromptRetry, setFailedPromptRetry] =

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1,6 +1,8 @@
 import './styles/globals.css';
 import {
   createContext,
+  forwardRef,
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -8,6 +10,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type ComponentPropsWithoutRef,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
@@ -42,6 +45,7 @@ import type {
   DaemonInputAnnotation,
   DaemonSessionAgentTaskStatus,
   DaemonSkillToggleMutation,
+  DaemonTranscriptBlockChangeSummary,
   DaemonTranscriptBlock,
   DaemonSessionMonitorTaskStatus,
   DaemonSessionShellTaskStatus,
@@ -212,7 +216,10 @@ import { mergeCommands } from './hooks/daemonSessionMappers';
 import { useAnimationFrameTranscriptSnapshot } from './hooks/useAnimationFrameTranscriptBlocks';
 import { useBackgroundTasks } from './hooks/useBackgroundTasks';
 import { isSessionDisconnectedError } from './utils/sessionErrors';
-import { useMessagesFromBlocks } from './hooks/useMessages';
+import {
+  projectStreamingTailMessages,
+  useMessagesFromBlocks,
+} from './hooks/useMessages';
 import { useSessionArtifacts } from './hooks/useSessionArtifacts';
 import { useShallowMemo, useStableArray } from './hooks/useShallowMemo';
 import {
@@ -836,6 +843,97 @@ interface LocalAnchoredMessage {
   anchorIndex: number;
   message: Message;
 }
+
+function buildDisplayMessages(
+  messages: Message[],
+  recapMessage: LocalAnchoredMessage | null,
+): Message[] {
+  if (!recapMessage) return filterModelSwitchMessages(messages);
+  const result = [...messages];
+  const anchorIndex = recapMessage.anchorAfterId
+    ? result.findIndex((message) => message.id === recapMessage.anchorAfterId)
+    : -1;
+  result.splice(
+    anchorIndex >= 0
+      ? anchorIndex + 1
+      : Math.min(recapMessage.anchorIndex, result.length),
+    0,
+    recapMessage.message,
+  );
+  return filterModelSwitchMessages(result);
+}
+
+type LiveMessageListProps = Omit<
+  ComponentPropsWithoutRef<typeof MessageList>,
+  'messages' | 'transcriptBlockCount'
+> & {
+  baselineBlocks: readonly DaemonTranscriptBlock[];
+  baselineSummary?: DaemonTranscriptBlockChangeSummary;
+  baselineMessages: Message[];
+  recapMessage: LocalAnchoredMessage | null;
+  messagesRef: { current: Message[] };
+  onTranscriptChange?: (blocks: readonly DaemonTranscriptBlock[]) => void;
+  t: ReturnType<typeof getTranslator>;
+};
+
+const LiveMessageList = memo(
+  forwardRef<MessageListHandle, LiveMessageListProps>(function LiveMessageList(
+    {
+      baselineBlocks,
+      baselineSummary,
+      baselineMessages,
+      recapMessage,
+      messagesRef,
+      onTranscriptChange,
+      t,
+      ...props
+    },
+    ref,
+  ) {
+    const live = useAnimationFrameTranscriptSnapshot();
+    const messages = useMemo(
+      () =>
+        projectStreamingTailMessages(
+          {
+            blocks: baselineBlocks,
+            messages: baselineMessages,
+            t,
+            blockChangeSummary: baselineSummary,
+          },
+          live.blocks,
+          t,
+          live.blockChangeSummary,
+        ) ?? baselineMessages,
+      [
+        baselineBlocks,
+        baselineMessages,
+        baselineSummary,
+        live.blockChangeSummary,
+        live.blocks,
+        t,
+      ],
+    );
+    const displayMessages = useMemo(
+      () => buildDisplayMessages(messages, recapMessage),
+      [messages, recapMessage],
+    );
+    useLayoutEffect(() => {
+      messagesRef.current = messages;
+    }, [messages, messagesRef]);
+    useEffect(() => {
+      onTranscriptChange?.(live.blocks);
+    }, [live.blocks, onTranscriptChange]);
+
+    return (
+      <MessageList
+        {...props}
+        ref={ref}
+        messages={displayMessages}
+        transcriptBlockCount={live.blocks.length}
+      />
+    );
+  }),
+);
 
 interface ModelSwitchSummary {
   authType: string;
@@ -2189,7 +2287,9 @@ export function App({
   const CustomComposerHeader = renderComposerHeader;
   const CustomComposerFooter = renderComposerFooter;
   const store = useTranscriptStore();
-  const { blocks, blockChangeSummary } = useAnimationFrameTranscriptSnapshot();
+  const { blocks, blockChangeSummary } = useAnimationFrameTranscriptSnapshot({
+    structuralOnly: true,
+  });
   const connection = useConnection();
   const logicalSessionKey = getLogicalSessionKey(
     connection.sessionId,
@@ -2617,7 +2717,9 @@ export function App({
 
   const messages = useMessagesFromBlocks(t, blocks, blockChangeSummary);
   const messagesRef = useRef(messages);
-  messagesRef.current = messages;
+  useLayoutEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
   const [failedPrompt, setFailedPrompt] = useState<FailedPrompt | null>(null);
   const failedPromptRef = useRef<FailedPrompt | null>(failedPrompt);
   const [failedPromptRetry, setFailedPromptRetry] =
@@ -2689,31 +2791,10 @@ export function App({
   const lastNotifiedSessionIdRef = useRef<string | undefined>(undefined);
   const lastNotifiedWorkspaceIdRef = useRef<string | undefined>(undefined);
   const lastNotifiedWorkspaceCwdRef = useRef<string | undefined>(undefined);
-  const displayMessages = useMemo(() => {
-    const localMessages = [recapMessage].filter(
-      (message): message is LocalAnchoredMessage => message !== null,
-    );
-    if (localMessages.length === 0) {
-      return filterModelSwitchMessages(messages);
-    }
-
-    const result = [...messages];
-    for (const localMessage of localMessages.sort(
-      (a, b) => a.anchorIndex - b.anchorIndex,
-    )) {
-      const anchorIndex = localMessage.anchorAfterId
-        ? result.findIndex(
-            (message) => message.id === localMessage.anchorAfterId,
-          )
-        : -1;
-      const index =
-        anchorIndex >= 0
-          ? anchorIndex + 1
-          : Math.min(localMessage.anchorIndex, result.length);
-      result.splice(index, 0, localMessage.message);
-    }
-    return filterModelSwitchMessages(result);
-  }, [messages, recapMessage]);
+  const displayMessages = useMemo(
+    () => buildDisplayMessages(messages, recapMessage),
+    [messages, recapMessage],
+  );
   useEffect(() => {
     const failed = failedPromptRef.current;
     if (!failed) return;
@@ -6820,8 +6901,9 @@ export function App({
     if (sessionWriteBlocked) return;
     if (!requireActiveSessionForLocalCommand()) return;
     const messageId = `local-recap-${nextRecapMessageIdRef.current++}`;
-    const anchorIndex = messages.length;
-    const anchorAfterId = messages.at(-1)?.id;
+    const currentMessages = messagesRef.current;
+    const anchorIndex = currentMessages.length;
+    const anchorAfterId = currentMessages.at(-1)?.id;
     const sessionId = connection.sessionId;
     const workspaceCwd = connection.workspaceCwd;
     setRecapMessage({
@@ -6871,7 +6953,6 @@ export function App({
   }, [
     connection.sessionId,
     connection.workspaceCwd,
-    messages,
     requireActiveSessionForLocalCommand,
     sessionWriteBlocked,
     sessionActions,
@@ -7829,10 +7910,6 @@ export function App({
   useEffect(() => {
     onConnectionChange?.(connection.status);
   }, [connection.status, onConnectionChange]);
-
-  useEffect(() => {
-    onTranscriptChange?.(blocks);
-  }, [blocks, onTranscriptChange]);
 
   useEffect(() => {
     if (connection.error) {
@@ -12794,9 +12871,15 @@ export function App({
                               .join(' ');
 
                             const messageListContent = (
-                              <MessageList
+                              <LiveMessageList
                                 ref={messageListRef}
-                                messages={displayMessages}
+                                baselineBlocks={blocks}
+                                baselineSummary={blockChangeSummary}
+                                baselineMessages={messages}
+                                recapMessage={recapMessage}
+                                messagesRef={messagesRef}
+                                onTranscriptChange={onTranscriptChange}
+                                t={t}
                                 terminalBackgroundShellTaskIds={
                                   terminalBackgroundShellTaskIds
                                 }
@@ -12812,7 +12895,6 @@ export function App({
                                 historyPaginationError={
                                   transcriptHistory.paginationError}
                                 onLoadOlderHistory={transcriptHistory.loadMore}
-                                transcriptBlockCount={blocks.length}
                                 transcriptActivity={store}
                                 onReloadTranscript={
                                   transcriptReloadSupported

--- a/packages/web-shell/client/components/WebShellTranscript.dom.test.tsx
+++ b/packages/web-shell/client/components/WebShellTranscript.dom.test.tsx
@@ -342,6 +342,12 @@ describe('WebShellTranscript DOM integration', () => {
       <WebShellTranscript blocks={blocks} collapseCompletedTurns={false} />,
     );
 
+    const summary = container.querySelector('button')!;
+    expect(summary.textContent).toContain('Asked 1 question');
+    expect(summary.getAttribute('aria-expanded')).toBe('false');
+
+    act(() => summary.click());
+
     expect(container.textContent).toContain('Ask user 1 question');
     expect(container.textContent).toContain('User answer: Staging');
     expect(container.querySelector('button[type="submit"]')).toBeNull();

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -10,6 +10,7 @@ import { WebShellCustomizationProvider } from '../../customization';
 import { TranscriptRenderModeProvider } from '../../transcriptRenderMode';
 import { SubagentDetailsProvider } from '../../subagentDetailsContext';
 import { MonitorDetailsProvider } from '../../monitorDetailsContext';
+import { McpAppHostContext } from '../../mcpAppHostContext';
 
 vi.mock('../../App', async () => {
   const { createContext } = await import('react');
@@ -92,18 +93,26 @@ function renderToolGroup(
   onOpenMonitor?: (tool: ACPToolCall) => Promise<boolean>,
   language: 'en' | 'zh-CN' = 'en',
   generateContent?: SessionContentGenerator,
+  mcpAppHostUrl?: string,
 ): HTMLElement {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
-    const group = (
+    const toolGroup = (
       <ToolGroup
         tools={tools}
         thoughts={thoughts}
         compactSummary={compactSummary}
         generateContent={generateContent}
       />
+    );
+    const group = mcpAppHostUrl ? (
+      <McpAppHostContext.Provider value={mcpAppHostUrl}>
+        {toolGroup}
+      </McpAppHostContext.Provider>
+    ) : (
+      toolGroup
     );
     root.render(
       <I18nProvider language={language}>
@@ -483,25 +492,49 @@ describe('tool group summary logic', () => {
   });
 
   it('opens a completed MCP App result in the session transcript', () => {
-    const container = renderToolGroup([
-      makeTool({
-        toolName: 'mcp__demo__show_dashboard',
-        rawOutput: {
-          type: 'mcp_app',
-          serverName: 'demo',
-          resourceUri: 'ui://demo/dashboard',
-          html: '<main>Dashboard</main>',
-          toolResult: { content: [] },
-          toolArguments: {},
-          fallbackText: 'Dashboard ready',
-        },
-      }),
-    ]);
+    const container = renderToolGroup(
+      [
+        makeTool({
+          toolName: 'mcp__demo__show_dashboard',
+          rawOutput: {
+            type: 'mcp_app',
+            serverName: 'demo',
+            resourceUri: 'ui://demo/dashboard',
+            html: '<main>Dashboard</main>',
+            toolResult: { content: [] },
+            toolArguments: {},
+            fallbackText: 'Dashboard ready',
+          },
+        }),
+      ],
+      {},
+      undefined,
+      false,
+      undefined,
+      undefined,
+      'en',
+      undefined,
+      'http://localhost:5173',
+    );
 
     expect(
       container.querySelector('button')?.getAttribute('aria-expanded'),
     ).toBe('true');
-    expect(container.textContent).toContain('Dashboard ready');
+
+    const content = container.querySelector(
+      '[class*="chatSummaryContentClip"]',
+    );
+    const iframe = container.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    iframe!.dataset['testState'] = 'preserved';
+    act(() => container.querySelector('button')?.click());
+    expect(content).toBe(
+      container.querySelector('[class*="chatSummaryContentClip"]'),
+    );
+    expect((content as HTMLElement | null)?.style.display).toBe('none');
+    act(() => container.querySelector('button')?.click());
+    expect(container.querySelector('iframe')).toBe(iframe);
+    expect(iframe?.dataset['testState']).toBe('preserved');
   });
 
   it('keeps an MCP App open when multiple tools share a summary', () => {
@@ -829,7 +862,6 @@ describe('tool row rendering', () => {
       const content = container.querySelector(
         '[class*="chatSummaryContentClip"]',
       );
-      expect(content?.className).not.toContain('chatSummaryContentCollapsed');
       expect(content?.textContent).toContain('custom 5s');
 
       act(() => {

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -588,6 +588,7 @@ describe('tool group summary logic', () => {
         args: { file_path: 'README.md' },
       }),
     ]);
+    act(() => container.querySelector('button')?.click());
 
     expect(container.textContent).toContain('Shell');
     expect(container.textContent).toContain('查询用户工作空间列表');
@@ -998,6 +999,7 @@ describe('tool row rendering', () => {
         },
       }),
     ]);
+    act(() => container.querySelector('button')?.click());
 
     const titleRow = container.querySelector('[class*="expandedCardTitleRow"]');
     expect(titleRow).not.toBeNull();
@@ -1012,6 +1014,7 @@ describe('tool row rendering', () => {
         content: [{ type: 'content', content: { text: 'Permission denied' } }],
       }),
     ]);
+    act(() => container.querySelector('button')?.click());
 
     const titleRow = container.querySelector('[class*="expandedCardTitleRow"]');
     expect(titleRow).not.toBeNull();
@@ -1022,6 +1025,7 @@ describe('tool row rendering', () => {
     const container = renderToolGroup([
       makeTool({ toolName: 'glob', status: 'failed' }),
     ]);
+    act(() => container.querySelector('button')?.click());
 
     const titleRow = container.querySelector('[class*="expandedCardTitleRow"]');
     expect(titleRow).not.toBeNull();
@@ -1805,19 +1809,19 @@ describe('thinking rows in the compact summary', () => {
       true,
     );
     const outerSummary = container.querySelector('button')!;
-    const parallelSummary = Array.from(
-      container.querySelectorAll('button'),
-    ).find((button) => button.textContent?.includes('Parallel agents'))!;
 
     expect(outerSummary.textContent).toContain('Ran 2 agents');
     expect(
       container.querySelector('[data-testid="compact-parallel-agents"]'),
-    ).not.toBeNull();
+    ).toBeNull();
     expect(outerSummary.getAttribute('aria-expanded')).toBe('false');
-    expect(parallelSummary.getAttribute('aria-expanded')).toBe('false');
 
     act(() => outerSummary.click());
+    const parallelSummary = Array.from(
+      container.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('Parallel agents'))!;
     expect(outerSummary.getAttribute('aria-expanded')).toBe('true');
+    expect(parallelSummary.getAttribute('aria-expanded')).toBe('false');
     expect(parallelSummary.textContent).toContain('2/2 done');
 
     act(() => parallelSummary.click());
@@ -1841,6 +1845,15 @@ describe('thinking rows in the compact summary', () => {
     expect(container.querySelector('button')?.textContent).toContain(
       'Thinking',
     );
+    expect(
+      container.querySelector('[class*="chatSummaryThoughtHeader"]'),
+    ).toBeNull();
+
+    act(() => container.querySelector('button')?.click());
+
+    expect(
+      container.querySelector('[class*="chatSummaryThoughtHeader"]'),
+    ).not.toBeNull();
   });
 
   it('renders a completed thought line that expands its content on click', () => {
@@ -2032,8 +2045,8 @@ describe('thinking rows in the compact summary', () => {
       ],
     );
 
+    act(() => container.querySelector('button')?.click());
     act(() => {
-      container.querySelector('button')?.click();
       for (const header of container.querySelectorAll(
         '[data-testid="compact-thinking-summary"]',
       )) {

--- a/packages/web-shell/client/components/messages/ToolGroup.test.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.test.tsx
@@ -535,6 +535,7 @@ describe('tool group summary logic', () => {
     act(() => container.querySelector('button')?.click());
     expect(container.querySelector('iframe')).toBe(iframe);
     expect(iframe?.dataset['testState']).toBe('preserved');
+    expect((content as HTMLElement | null)?.style.display).toBe('');
   });
 
   it('keeps an MCP App open when multiple tools share a summary', () => {

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1811,8 +1811,11 @@ export const ToolGroup = memo(function ToolGroup({
             aria-hidden="true"
           />
         </button>
-        {chatExpanded && (
-          <div className={styles.chatSummaryContentClip}>
+        {(chatExpanded || hasMcpApp) && (
+          <div
+            className={styles.chatSummaryContentClip}
+            style={chatExpanded ? undefined : { display: 'none' }}
+          >
             <div className={styles.chatSummaryContentInner}>
               <div className={`${styles.group} ${styles.chatSummaryGroup}`}>
                 {tools.map((tool) => {

--- a/packages/web-shell/client/components/messages/ToolGroup.tsx
+++ b/packages/web-shell/client/components/messages/ToolGroup.tsx
@@ -1811,89 +1811,85 @@ export const ToolGroup = memo(function ToolGroup({
             aria-hidden="true"
           />
         </button>
-        <div
-          className={
-            chatExpanded
-              ? styles.chatSummaryContentClip
-              : `${styles.chatSummaryContentClip} ${styles.chatSummaryContentCollapsed}`
-          }
-        >
-          <div className={styles.chatSummaryContentInner}>
-            <div className={`${styles.group} ${styles.chatSummaryGroup}`}>
-              {tools.map((tool) => {
-                if (groupedAgentCallIds.has(tool.callId)) return null;
-                const parallelAgents = parallelAgentsByFirstCallId.get(
-                  tool.callId,
-                );
-                return (
-                  <Fragment key={tool.callId}>
-                    {thoughts
-                      ?.filter(
-                        (thought) => thought.beforeToolCallId === tool.callId,
-                      )
-                      .map((thought, index) => (
-                        <ThoughtLine
-                          key={`thought-${tool.callId}-${index}`}
-                          content={thought.content}
-                          isStreaming={thought.isStreaming}
-                          generateContent={generateContent}
-                        />
-                      ))}
-                    {parallelAgents ? (
-                      <>
-                        <div
-                          className={styles.chatSummaryParallelAgents}
-                          data-testid="compact-parallel-agents"
-                        >
-                          <ParallelAgentsGroup
-                            agents={parallelAgents}
-                            pendingApproval={pendingApproval}
+        {chatExpanded && (
+          <div className={styles.chatSummaryContentClip}>
+            <div className={styles.chatSummaryContentInner}>
+              <div className={`${styles.group} ${styles.chatSummaryGroup}`}>
+                {tools.map((tool) => {
+                  if (groupedAgentCallIds.has(tool.callId)) return null;
+                  const parallelAgents = parallelAgentsByFirstCallId.get(
+                    tool.callId,
+                  );
+                  return (
+                    <Fragment key={tool.callId}>
+                      {thoughts
+                        ?.filter(
+                          (thought) => thought.beforeToolCallId === tool.callId,
+                        )
+                        .map((thought, index) => (
+                          <ThoughtLine
+                            key={`thought-${tool.callId}-${index}`}
+                            content={thought.content}
+                            isStreaming={thought.isStreaming}
+                            generateContent={generateContent}
                           />
-                        </div>
-                        {parallelAgents
-                          .slice(1)
-                          .flatMap((agent) =>
-                            thoughts
-                              ?.filter(
-                                (thought) =>
-                                  thought.beforeToolCallId === agent.callId,
-                              )
-                              .map((thought, index) => (
-                                <ThoughtLine
-                                  key={`thought-${agent.callId}-${index}`}
-                                  content={thought.content}
-                                  isStreaming={thought.isStreaming}
-                                  generateContent={generateContent}
-                                />
-                              )),
-                          )}
-                      </>
-                    ) : (
-                      <ToolLine
-                        tool={tool}
-                        approval={pendingApproval}
-                        workspaceCwd={workspaceCwd}
-                        summaryOnly={!singleTool || compactToolLines}
-                        forceExpanded={!!singleTool && !compactToolLines}
-                        hideHeader={!!singleTool && !compactToolLines}
-                      />
-                    )}
-                  </Fragment>
-                );
-              })}
-              {thoughts
-                ?.filter((thought) => thought.beforeToolCallId === undefined)
-                .map((thought, index) => (
-                  <ThoughtLine
-                    key={`thought-trailing-${index}`}
-                    content={thought.content}
-                    isStreaming={thought.isStreaming}
-                    generateContent={generateContent}
-                  />
-                ))}
+                        ))}
+                      {parallelAgents ? (
+                        <>
+                          <div
+                            className={styles.chatSummaryParallelAgents}
+                            data-testid="compact-parallel-agents"
+                          >
+                            <ParallelAgentsGroup
+                              agents={parallelAgents}
+                              pendingApproval={pendingApproval}
+                            />
+                          </div>
+                          {parallelAgents
+                            .slice(1)
+                            .flatMap((agent) =>
+                              thoughts
+                                ?.filter(
+                                  (thought) =>
+                                    thought.beforeToolCallId === agent.callId,
+                                )
+                                .map((thought, index) => (
+                                  <ThoughtLine
+                                    key={`thought-${agent.callId}-${index}`}
+                                    content={thought.content}
+                                    isStreaming={thought.isStreaming}
+                                    generateContent={generateContent}
+                                  />
+                                )),
+                            )}
+                        </>
+                      ) : (
+                        <ToolLine
+                          tool={tool}
+                          approval={pendingApproval}
+                          workspaceCwd={workspaceCwd}
+                          summaryOnly={!singleTool || compactToolLines}
+                          forceExpanded={!!singleTool && !compactToolLines}
+                          hideHeader={!!singleTool && !compactToolLines}
+                        />
+                      )}
+                    </Fragment>
+                  );
+                })}
+                {thoughts
+                  ?.filter((thought) => thought.beforeToolCallId === undefined)
+                  .map((thought, index) => (
+                    <ThoughtLine
+                      key={`thought-trailing-${index}`}
+                      content={thought.content}
+                      isStreaming={thought.isStreaming}
+                      generateContent={generateContent}
+                    />
+                  ))}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -398,11 +398,6 @@
   grid-template-rows: 1fr;
   min-height: 0;
   overflow: hidden;
-  transition: grid-template-rows 180ms ease;
-}
-
-.chatSummaryContentCollapsed {
-  grid-template-rows: 0fr;
 }
 
 .chatSummaryContentInner {

--- a/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
+++ b/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
@@ -130,6 +130,11 @@ afterEach(() => {
 
 describe('useAnimationFrameTranscriptSnapshot', () => {
   it('caches structural snapshots when the store has no change summary', () => {
+    let pendingFrame: FrameRequestCallback | null = null;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      pendingFrame = callback;
+      return 1;
+    });
     testStore.disableBlockChangeSummary();
     container = document.createElement('div');
     document.body.append(container);
@@ -139,6 +144,14 @@ describe('useAnimationFrameTranscriptSnapshot', () => {
 
     expect(renderCount).toBe(1);
     expect(latestBlocks).toEqual([]);
+
+    // Without a change summary every notification may be structural, so the
+    // consumer must keep the pre-change update behavior and wake.
+    act(() => testStore.update([{ id: 'a' } as DaemonTranscriptBlock]));
+    act(() => pendingFrame?.(1_000));
+
+    expect(renderCount).toBeGreaterThan(1);
+    expect(latestBlocks).toHaveLength(1);
   });
 
   it('keeps structural consumers asleep for pure tail appends', () => {

--- a/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
+++ b/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
@@ -93,8 +93,8 @@ let renderLog: Array<{
   revision?: number;
 }> = [];
 
-function Harness() {
-  const snapshot = useAnimationFrameTranscriptSnapshot();
+function Harness({ structuralOnly = false }: { structuralOnly?: boolean }) {
+  const snapshot = useAnimationFrameTranscriptSnapshot({ structuralOnly });
   latestBlocks = snapshot.blocks;
   latestSummary = snapshot.blockChangeSummary;
   renderCount += 1;
@@ -123,6 +123,35 @@ afterEach(() => {
 });
 
 describe('useAnimationFrameTranscriptSnapshot', () => {
+  it('keeps structural consumers asleep for pure tail appends', () => {
+    let pendingFrame: FrameRequestCallback | null = null;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      pendingFrame = callback;
+      return 1;
+    });
+    vi.spyOn(performance, 'now').mockReturnValue(1_000);
+    const first = { id: 'thought', text: 'a' } as DaemonTranscriptBlock;
+    testStore.update([first]);
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+    act(() => root!.render(<Harness structuralOnly />));
+    const initialRenderCount = renderCount;
+
+    act(() => testStore.appendTail([{ ...first, text: 'ab' }], 'thought'));
+
+    expect(pendingFrame).toBeNull();
+    expect(renderCount).toBe(initialRenderCount);
+    expect(latestBlocks).toEqual([first]);
+
+    const tool = { id: 'tool', kind: 'tool' } as DaemonTranscriptBlock;
+    act(() => testStore.update([{ ...first, text: 'ab' }, tool]));
+    act(() => pendingFrame?.(1_000));
+
+    expect(renderCount).toBeGreaterThan(initialRenderCount);
+    expect(latestBlocks).toEqual([{ ...first, text: 'ab' }, tool]);
+  });
+
   it('keeps coalesced tail blocks paired with their change summary', () => {
     let pendingFrame: FrameRequestCallback | null = null;
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {

--- a/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
+++ b/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.test.tsx
@@ -20,10 +20,12 @@ const testStore = vi.hoisted(() => {
     revision: 0,
     tailAppendBarrierRevision: 0,
   };
+  let blockChangeSummaryEnabled = true;
   const listeners = new Set<() => void>();
   return {
     getSnapshot: () => ({ blocks, blockIndexById }),
-    getBlockChangeSummary: () => blockChangeSummary,
+    getBlockChangeSummary: () =>
+      blockChangeSummaryEnabled ? blockChangeSummary : undefined,
     subscribe: (listener: () => void) => {
       listeners.add(listener);
       return () => listeners.delete(listener);
@@ -60,6 +62,9 @@ const testStore = vi.hoisted(() => {
       };
       listeners.forEach((listener) => listener());
     },
+    disableBlockChangeSummary() {
+      blockChangeSummaryEnabled = false;
+    },
     reset() {
       blocks = [];
       blockIndexById = {};
@@ -68,6 +73,7 @@ const testStore = vi.hoisted(() => {
         revision: 0,
         tailAppendBarrierRevision: 0,
       };
+      blockChangeSummaryEnabled = true;
       listeners.clear();
     },
   };
@@ -123,6 +129,18 @@ afterEach(() => {
 });
 
 describe('useAnimationFrameTranscriptSnapshot', () => {
+  it('caches structural snapshots when the store has no change summary', () => {
+    testStore.disableBlockChangeSummary();
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => root!.render(<Harness structuralOnly />));
+
+    expect(renderCount).toBe(1);
+    expect(latestBlocks).toEqual([]);
+  });
+
   it('keeps structural consumers asleep for pure tail appends', () => {
     let pendingFrame: FrameRequestCallback | null = null;
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {

--- a/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.ts
+++ b/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.ts
@@ -36,7 +36,26 @@ interface AnimationFrameTranscriptSnapshot {
   blockChangeSummary?: DaemonTranscriptBlockChangeSummary;
 }
 
-export function useAnimationFrameTranscriptSnapshot(): AnimationFrameTranscriptSnapshot {
+interface AnimationFrameTranscriptSnapshotOptions {
+  structuralOnly?: boolean;
+}
+
+function isSameTranscriptStructure(
+  previous: DaemonTranscriptBlockChangeSummary | undefined,
+  next: DaemonTranscriptBlockChangeSummary | undefined,
+): boolean {
+  return (
+    previous !== undefined &&
+    next !== undefined &&
+    previous.source === next.source &&
+    previous.tailAppendBarrierRevision === next.tailAppendBarrierRevision
+  );
+}
+
+export function useAnimationFrameTranscriptSnapshot(
+  options: AnimationFrameTranscriptSnapshotOptions = {},
+): AnimationFrameTranscriptSnapshot {
+  const structuralOnly = options.structuralOnly === true;
   const store = useTranscriptStore();
   const { sessionId } = useConnection();
   const subscribe = useCallback(
@@ -64,7 +83,14 @@ export function useAnimationFrameTranscriptSnapshot(): AnimationFrameTranscriptS
         }
       };
       document.addEventListener('beforeinput', recordInput, true);
+      let previousSummary = store.getBlockChangeSummary?.();
       const unsubscribe = store.subscribe(() => {
+        const nextSummary = store.getBlockChangeSummary?.();
+        const tailOnly =
+          structuralOnly &&
+          isSameTranscriptStructure(previousSummary, nextSummary);
+        previousSummary = nextSummary;
+        if (tailOnly) return;
         if (frame !== null) return;
         pendingSinceTs = performance.now();
         frame = window.requestAnimationFrame(dispatchWhenDue);
@@ -77,7 +103,7 @@ export function useAnimationFrameTranscriptSnapshot(): AnimationFrameTranscriptS
         }
       };
     },
-    [store],
+    [store, structuralOnly],
   );
   const getSnapshot = useMemo(() => {
     let cached:
@@ -90,12 +116,15 @@ export function useAnimationFrameTranscriptSnapshot(): AnimationFrameTranscriptS
     return () => {
       const state = store.getSnapshot();
       const blockChangeSummary = store.getBlockChangeSummary?.();
-      if (
-        !cached ||
-        cached.blocks !== state.blocks ||
-        cached.blockIndexById !== state.blockIndexById ||
-        cached.blockChangeSummary !== blockChangeSummary
-      ) {
+      const changed = structuralOnly
+        ? !isSameTranscriptStructure(
+            cached?.blockChangeSummary,
+            blockChangeSummary,
+          ) || cached?.blockIndexById !== state.blockIndexById
+        : cached?.blocks !== state.blocks ||
+          cached?.blockIndexById !== state.blockIndexById ||
+          cached?.blockChangeSummary !== blockChangeSummary;
+      if (!cached || changed) {
         cached = {
           blocks: state.blocks,
           blockIndexById: state.blockIndexById,
@@ -104,7 +133,7 @@ export function useAnimationFrameTranscriptSnapshot(): AnimationFrameTranscriptS
       }
       return cached;
     };
-  }, [store]);
+  }, [store, structuralOnly]);
   const live = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   // Defer transcript re-renders so urgent updates — composer keystrokes,
   // button presses — are never queued behind a streaming frame. The deferred

--- a/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.ts
+++ b/packages/web-shell/client/hooks/useAnimationFrameTranscriptBlocks.ts
@@ -116,7 +116,11 @@ export function useAnimationFrameTranscriptSnapshot(
     return () => {
       const state = store.getSnapshot();
       const blockChangeSummary = store.getBlockChangeSummary?.();
-      const changed = structuralOnly
+      const canCompareStructure =
+        structuralOnly &&
+        cached?.blockChangeSummary !== undefined &&
+        blockChangeSummary !== undefined;
+      const changed = canCompareStructure
         ? !isSameTranscriptStructure(
             cached?.blockChangeSummary,
             blockChangeSummary,

--- a/packages/web-shell/client/hooks/useMessages.test.ts
+++ b/packages/web-shell/client/hooks/useMessages.test.ts
@@ -742,9 +742,11 @@ describe('background agent task reconciliation', () => {
     const t = (key: string) => key;
     const source = {};
     const agent = backgroundAgentBlock('agent-call');
+    // An empty assistant block projects no message (unlike thought), so the
+    // insight append below hits the "no matching projected message" fallback.
     const tail = baseBlock({
-      id: 'empty-thought',
-      kind: 'thought',
+      id: 'empty-assistant',
+      kind: 'assistant',
       text: '',
       streaming: true,
     });

--- a/packages/web-shell/client/hooks/useMessages.test.ts
+++ b/packages/web-shell/client/hooks/useMessages.test.ts
@@ -810,6 +810,84 @@ describe('background agent task reconciliation', () => {
     await act(async () => root.unmount());
   });
 
+  it('keeps agent reconciliation when an insight tail matches a projected message', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const t = (key: string) => key;
+    const source = {};
+    const agent = backgroundAgentBlock('agent-call');
+    // An empty thought block projects a thinking message (unlike assistant),
+    // so the insight append below matches the tail's projected message.
+    const tail = baseBlock({
+      id: 'empty-thought',
+      kind: 'thought',
+      text: '',
+      streaming: true,
+    });
+    let latest: Message[] = [];
+    hookState.connection.status = 'connected';
+    hookState.resolveSubagentSession.mockReset();
+    hookState.resolveSubagentSession.mockResolvedValue(
+      backgroundAgentResolution('completed'),
+    );
+    function Consumer({
+      blocks,
+      summary,
+    }: {
+      blocks: DaemonTranscriptBlock[];
+      summary: DaemonTranscriptBlockChangeSummary;
+    }) {
+      latest = useMessagesFromBlocks(t, blocks, summary);
+      return null;
+    }
+
+    await act(async () =>
+      root.render(
+        createElement(Consumer, {
+          blocks: [agent, tail],
+          summary: {
+            source,
+            revision: 1,
+            tailAppendBarrierRevision: 1,
+          },
+        }),
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(latest[0]).toMatchObject({
+        role: 'tool_group',
+        tools: [{ status: 'completed' }],
+      }),
+    );
+    const reconciledToolGroup = latest[0];
+
+    adapterSpies.project.mockClear();
+    await act(async () =>
+      root.render(
+        createElement(Consumer, {
+          blocks: [
+            agent,
+            { ...tail, text: 'prefix "insight_progress":{}', updatedAt: 2 },
+          ],
+          summary: {
+            source,
+            revision: 2,
+            tailAppendBarrierRevision: 1,
+            tailBlockId: tail.id,
+          },
+        }),
+      ),
+    );
+
+    expect(adapterSpies.project).toHaveBeenCalled();
+    expect(latest[0]).toBe(reconciledToolGroup);
+    expect(latest).toMatchObject([
+      { role: 'tool_group', tools: [{ status: 'completed' }] },
+      { role: 'thinking', content: 'prefix "insight_progress":{}' },
+    ]);
+    await act(async () => root.unmount());
+  });
+
   it('uses terminal agent notifications as a reconciliation trigger without requiring toolUseId', () => {
     expect(
       getBackgroundAgentNotificationKey([

--- a/packages/web-shell/client/hooks/useMessages.test.ts
+++ b/packages/web-shell/client/hooks/useMessages.test.ts
@@ -513,6 +513,35 @@ describe('transcriptBlocksToLocalizedMessages', () => {
     ]);
   });
 
+  it('falls back when an insight tail has no matching projected message', () => {
+    const t = (key: string) => key;
+    const thought = baseBlock({
+      id: 'merged-thought',
+      kind: 'thought',
+      text: 'prefix "insi',
+      streaming: true,
+    });
+
+    expect(
+      projectStreamingTailMessages(
+        {
+          blocks: [thought],
+          messages: [
+            {
+              id: 'earlier-assistant',
+              role: 'thinking',
+              content: thought.text,
+              isStreaming: true,
+            },
+          ],
+          t,
+        },
+        [{ ...thought, text: 'prefix "insight_progress":{}' }],
+        t,
+      ),
+    ).toBeUndefined();
+  });
+
   it.each([undefined, ''])(
     'falls back safely when a streaming block has empty text (%j)',
     async (text) => {
@@ -704,6 +733,78 @@ describe('background agent task reconciliation', () => {
       { role: 'tool_group', tools: [{ status: 'completed' }] },
       { role: 'thinking', content: 'ab' },
     ]);
+    await act(async () => root.unmount());
+  });
+
+  it('keeps agent reconciliation when an insight tail has no projected message', async () => {
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const t = (key: string) => key;
+    const source = {};
+    const agent = backgroundAgentBlock('agent-call');
+    const tail = baseBlock({
+      id: 'empty-thought',
+      kind: 'thought',
+      text: '',
+      streaming: true,
+    });
+    let latest: Message[] = [];
+    hookState.connection.status = 'connected';
+    hookState.resolveSubagentSession.mockReset();
+    hookState.resolveSubagentSession.mockResolvedValue(
+      backgroundAgentResolution('completed'),
+    );
+    function Consumer({
+      blocks,
+      summary,
+    }: {
+      blocks: DaemonTranscriptBlock[];
+      summary: DaemonTranscriptBlockChangeSummary;
+    }) {
+      latest = useMessagesFromBlocks(t, blocks, summary);
+      return null;
+    }
+
+    await act(async () =>
+      root.render(
+        createElement(Consumer, {
+          blocks: [agent, tail],
+          summary: {
+            source,
+            revision: 1,
+            tailAppendBarrierRevision: 1,
+          },
+        }),
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(latest[0]).toMatchObject({
+        role: 'tool_group',
+        tools: [{ status: 'completed' }],
+      }),
+    );
+
+    await act(async () =>
+      root.render(
+        createElement(Consumer, {
+          blocks: [
+            agent,
+            { ...tail, text: 'prefix "insight_progress":{}', updatedAt: 2 },
+          ],
+          summary: {
+            source,
+            revision: 2,
+            tailAppendBarrierRevision: 1,
+            tailBlockId: tail.id,
+          },
+        }),
+      ),
+    );
+
+    expect(latest[0]).toMatchObject({
+      role: 'tool_group',
+      tools: [{ status: 'completed' }],
+    });
     await act(async () => root.unmount());
   });
 

--- a/packages/web-shell/client/hooks/useMessages.test.ts
+++ b/packages/web-shell/client/hooks/useMessages.test.ts
@@ -350,7 +350,7 @@ describe('transcriptBlocksToLocalizedMessages', () => {
     ).toBeUndefined();
   });
 
-  it('falls back when an insight marker spans the appended-text boundary', async () => {
+  it('projects an insight marker that spans the appended-text boundary', async () => {
     const container = document.createElement('div');
     const root = createRoot(container);
     const t = (key: string) => key;
@@ -361,6 +361,7 @@ describe('transcriptBlocksToLocalizedMessages', () => {
       text: 'prefix "insi',
       streaming: true,
     });
+    let latest: Message[] = [];
     function Consumer({
       blocks,
       summary,
@@ -368,7 +369,7 @@ describe('transcriptBlocksToLocalizedMessages', () => {
       blocks: DaemonTranscriptBlock[];
       summary: DaemonTranscriptBlockChangeSummary;
     }) {
-      useMessagesFromBlocks(t, blocks, summary);
+      latest = useMessagesFromBlocks(t, blocks, summary);
       return null;
     }
 
@@ -400,11 +401,15 @@ describe('transcriptBlocksToLocalizedMessages', () => {
     );
 
     expect(adapterSpies.project).toHaveBeenCalledOnce();
+    expect(latest).toMatchObject([
+      { role: 'thinking', content: 'prefix "insight_progress":{}' },
+    ]);
     await act(async () => root.unmount());
   });
 
-  it('falls back when a later append completes an insight message', () => {
+  it('projects a later append that completes an insight message', () => {
     const t = (key: string) => key;
+    const user = baseBlock({ id: 'user', kind: 'user', text: 'hello' });
     const assistant = baseBlock({
       id: 'assistant',
       kind: 'assistant',
@@ -415,41 +420,97 @@ describe('transcriptBlocksToLocalizedMessages', () => {
       ...assistant,
       text: `${assistant.text}}`,
     };
-    const messages = transcriptBlocksToLocalizedMessages([assistant], t);
+    const messages = transcriptBlocksToLocalizedMessages([user, assistant], t);
     const source = {};
 
+    const projected = projectStreamingTailMessages(
+      {
+        blocks: [user, assistant],
+        messages,
+        t,
+        blockChangeSummary: {
+          source,
+          revision: 1,
+          tailAppendBarrierRevision: 1,
+        },
+      },
+      [user, completedAssistant],
+      t,
+      {
+        source,
+        revision: 2,
+        tailAppendBarrierRevision: 1,
+        tailBlockId: assistant.id,
+      },
+    );
+
+    expect(projected?.[0]).toBe(messages[0]);
+    expect(projected).toMatchObject([
+      { role: 'user' },
+      { role: 'insight_progress' },
+    ]);
     expect(
       projectStreamingTailMessages(
-        {
-          blocks: [assistant],
-          messages,
-          t,
-          blockChangeSummary: {
-            source,
-            revision: 1,
-            tailAppendBarrierRevision: 1,
-          },
-        },
-        [completedAssistant],
+        { blocks: [user, assistant], messages, t },
+        [user, completedAssistant],
         t,
-        {
+      ),
+    ).toMatchObject([{ role: 'user' }, { role: 'insight_progress' }]);
+
+    const partialReady = {
+      ...completedAssistant,
+      text: `${completedAssistant.text}\n{"insight_ready":{"path":"/tmp/report.md"`,
+    };
+    const partialReadyMessages = projectStreamingTailMessages(
+      {
+        blocks: [user, completedAssistant],
+        messages: projected!,
+        t,
+        blockChangeSummary: {
           source,
           revision: 2,
           tailAppendBarrierRevision: 1,
-          tailBlockId: assistant.id,
         },
-      ),
-    ).toBeUndefined();
-    expect(
-      projectStreamingTailMessages(
-        { blocks: [assistant], messages, t },
-        [completedAssistant],
+      },
+      [user, partialReady],
+      t,
+      {
+        source,
+        revision: 3,
+        tailAppendBarrierRevision: 1,
+        tailBlockId: assistant.id,
+      },
+    );
+    const completedReady = {
+      ...partialReady,
+      text: `${partialReady.text}}}`,
+    };
+    const readyMessages = projectStreamingTailMessages(
+      {
+        blocks: [user, partialReady],
+        messages: partialReadyMessages!,
         t,
-      ),
-    ).toBeUndefined();
-    expect(
-      transcriptBlocksToLocalizedMessages([completedAssistant], t),
-    ).toMatchObject([{ role: 'insight_progress' }]);
+        blockChangeSummary: {
+          source,
+          revision: 3,
+          tailAppendBarrierRevision: 1,
+        },
+      },
+      [user, completedReady],
+      t,
+      {
+        source,
+        revision: 4,
+        tailAppendBarrierRevision: 1,
+        tailBlockId: assistant.id,
+      },
+    );
+
+    expect(readyMessages?.[0]).toBe(messages[0]);
+    expect(readyMessages).toMatchObject([
+      { role: 'user' },
+      { role: 'insight_ready', path: '/tmp/report.md' },
+    ]);
   });
 
   it.each([undefined, ''])(

--- a/packages/web-shell/client/hooks/useMessages.ts
+++ b/packages/web-shell/client/hooks/useMessages.ts
@@ -207,15 +207,14 @@ export function projectStreamingTailMessages(
   }
 
   if (after.text.includes(INSIGHT_CONTENT_MARKER)) {
-    const messages = transcriptBlocksToLocalizedMessages(blocks, t);
     const tailPrefix = `${before.id}-`;
     const firstTailMessageIndex = previous.messages.findIndex(
       (message) =>
         message.id === before.id || message.id.startsWith(tailPrefix),
     );
-    const stablePrefixLength =
-      firstTailMessageIndex >= 0 ? firstTailMessageIndex : 0;
-    for (let i = 0; i < stablePrefixLength; i += 1) {
+    if (firstTailMessageIndex < 0) return undefined;
+    const messages = transcriptBlocksToLocalizedMessages(blocks, t);
+    for (let i = 0; i < firstTailMessageIndex; i += 1) {
       if (
         messages[i]?.id !== previous.messages[i]?.id ||
         messages[i]?.role !== previous.messages[i]?.role

--- a/packages/web-shell/client/hooks/useMessages.ts
+++ b/packages/web-shell/client/hooks/useMessages.ts
@@ -36,7 +36,7 @@ const BACKGROUND_AGENT_RECONCILIATION_MAX_ATTEMPTS = 8;
 // registration. Require repeated misses before treating the agent as gone.
 const MISSING_BACKGROUND_AGENT_GRACE_MISSES = 2;
 // Insight JSON can split one growing text block into multiple projected
-// messages, so prefix identity reuse is unsafe once its marker appears.
+// messages, so the tail needs a full projection once its marker appears.
 const INSIGHT_CONTENT_MARKER = '"insight_';
 
 interface MessageProjection {
@@ -201,8 +201,33 @@ export function projectStreamingTailMessages(
     typeof before.text !== 'string' ||
     typeof after.text !== 'string' ||
     after.text.length < before.text.length ||
-    (!summaryProvesTailAppend && !after.text.startsWith(before.text)) ||
-    after.text.includes(INSIGHT_CONTENT_MARKER) ||
+    (!summaryProvesTailAppend && !after.text.startsWith(before.text))
+  ) {
+    return undefined;
+  }
+
+  if (after.text.includes(INSIGHT_CONTENT_MARKER)) {
+    const messages = transcriptBlocksToLocalizedMessages(blocks, t);
+    const tailPrefix = `${before.id}-`;
+    const firstTailMessageIndex = previous.messages.findIndex(
+      (message) =>
+        message.id === before.id || message.id.startsWith(tailPrefix),
+    );
+    const stablePrefixLength =
+      firstTailMessageIndex >= 0 ? firstTailMessageIndex : 0;
+    for (let i = 0; i < stablePrefixLength; i += 1) {
+      if (
+        messages[i]?.id !== previous.messages[i]?.id ||
+        messages[i]?.role !== previous.messages[i]?.role
+      ) {
+        break;
+      }
+      messages[i] = previous.messages[i];
+    }
+    return messages;
+  }
+
+  if (
     (previousTail.role !== 'assistant' && previousTail.role !== 'thinking') ||
     previousTail.isStreaming !== true ||
     (after.kind === 'assistant') !== (previousTail.role === 'assistant')


### PR DESCRIPTION
## What this PR does

This change keeps pure streamed assistant and thinking text updates out of the top-level application render path while preserving live updates in the transcript. It also unmounts compact tool and thinking details while collapsed, and retains correct live projection when Insight protocol messages span multiple stream chunks.

## Why it's needed

Long thinking output caused hidden transcript content and unrelated application surfaces to reconcile on every streamed chunk. Typing, starting actions, and collapsing activity groups could therefore feel sluggish during an active response.

## Reviewer Test Plan

### How to verify

Start a Web Shell session that produces sustained thinking output, keep the compact activity group collapsed, and type in the composer while streaming continues. Confirm that text remains live, typing and toolbar actions stay responsive, expanding restores the current tool and thinking details, and Insight progress or ready messages appear immediately even when their JSON marker spans chunks.

### Evidence (Before & After)

In the deterministic 5,000-character / 400-chunk folded-thinking scenario, frame-time P95 improved from 17 ms to 9 ms. Sustained stream time improved by approximately 21%, and typing overhead improved by approximately 34%. The post-fix run completed in 5,057 ms with 120 ms typing overhead, 9 ms frame-time P95, and 24 ms maximum input latency.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Vite development server with the daemon-backed Web Shell session, plus package unit tests and production builds.

## Risk & Scope

- Main risk or tradeoff: Collapsed detail rows are reconstructed when reopened, so their local nested expansion state is intentionally not preserved.
- Not validated / out of scope: An intermittent development-mode long frame around the terminal turn-completion transition remains a separate optimization opportunity.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本次改动让纯粹的助手文本和思考文本流式增量不再进入顶层应用渲染路径，同时保持 transcript 内容实时更新。紧凑工具与思考详情在收起时会被卸载，并且当 Insight 协议消息跨多个流式 chunk 时仍能正确实时投影。

## 为什么需要

长时间思考输出此前会导致隐藏的 transcript 内容和无关应用区域在每个流式 chunk 上进行协调更新。因此，在响应进行期间，输入、启动操作以及收起活动组都可能出现卡顿。

## Reviewer 测试计划

### 如何验证

启动一个会持续输出思考内容的 Web Shell 会话，保持紧凑活动组收起，并在流式输出期间继续在编辑器中输入。确认文本保持实时更新，输入和工具栏操作保持响应，展开后能够恢复当前工具与思考详情，并且即使 Insight progress 或 ready 的 JSON 标记跨 chunk，也会立即显示。

### 证据（修复前后）

在确定性的 5,000 字符 / 400 chunk 折叠思考场景中，帧耗时 P95 从 17 ms 降至 9 ms。持续流式处理时间约改善 21%，输入额外开销约改善 34%。修复后一次运行耗时 5,057 ms，输入额外开销 120 ms，帧耗时 P95 为 9 ms，最大输入延迟为 24 ms。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

使用本地 Vite 开发服务器和 daemon 驱动的 Web Shell 会话，并运行包级单元测试与生产构建。

## 风险与范围

- 主要风险或取舍：收起的详情行会在重新打开时重建，因此其中局部的嵌套展开状态不会保留。
- 未验证或不在范围内：任务结束切换附近偶发的开发模式长帧仍是独立的后续优化机会。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
