### PR TITLE
refactor(core): centralize agent config derivation

### DIFF
--- a/docs/design/derived-config-ownership.md
+++ b/docs/design/derived-config-ownership.md
@@ -28,3 +28,5 @@ Migration order:
 The generic factory intentionally accepts public getter overrides only. Named profiles keep private field rebinding and lifecycle management inside `config.ts` without exposing arbitrary Config mutation.
 
 The approval profile owns child-local approval state and its parent permission-manager strip/restore contract. Callers remain responsible for invoking its cleanup callback when the agent lifecycle ends.
+
+Production core modules that import `Config` are linted against non-null `Object.create(...)` calls, keeping new prototype overlays behind the generic or named factories.

--- a/docs/design/derived-config-ownership.md
+++ b/docs/design/derived-config-ownership.md
@@ -2,21 +2,21 @@
 
 `Config` derivation is a state-ownership operation, not a clone. `deriveConfig` keeps the existing prototype overlay model behind one boundary while production callers are migrated incrementally.
 
-| State                      | Ownership                        | Contract                                                                                                                         |
-| -------------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| workspace path and context | shared until explicitly overlaid | Worktree profiles must override the paired public getters and private reads together.                                            |
-| file service and discovery | shared until explicitly overlaid | Worktree profiles rebind both to the target workspace.                                                                           |
-| tool registry              | shared or explicitly replaced    | Agent profiles that rebuild it own cleanup of the replacement registry.                                                          |
-| permission manager         | shared or explicitly replaced    | Agent profiles preserve the existing strip/restore lifecycle.                                                                    |
-| approval mode              | shared                           | Derived profiles may read the inherited mode but cannot mutate it until they own an independent permission-manager lifecycle.    |
-| file-read cache            | child-local                      | The first getter call installs a fresh cache on the derived Config.                                                              |
-| memory-pressure monitor    | child-local                      | The first getter call installs a new monitor using the inherited configuration snapshot.                                         |
-| active todo state          | child-local                      | The first mutation installs independent maps.                                                                                    |
-| chat recording service     | shared unless hidden             | Scoped profiles may hide it through a getter override.                                                                           |
-| goal runtime               | prohibited                       | A derived Config cannot resolve the parent conversation's runtime.                                                               |
-| session writer state       | prohibited                       | Writer ownership stays with the canonical session Config.                                                                        |
-| canonical lifecycle        | prohibited                       | A derived Config cannot initialize, start a session, relocate the workspace, or clean up inherited Team/Arena runtime resources. |
-| approval mode mutation     | prohibited                       | A derived Config cannot restore or strip rules on the canonical PermissionManager.                                               |
+| State                      | Ownership                        | Contract                                                                                                                                |
+| -------------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| workspace path and context | shared until explicitly overlaid | Worktree profiles must override the paired public getters and private reads together.                                                   |
+| file service and discovery | shared until explicitly overlaid | Worktree profiles rebind both to the target workspace.                                                                                  |
+| tool registry              | shared or explicitly replaced    | Agent profiles that rebuild it own cleanup of the replacement registry.                                                                 |
+| permission manager         | shared or explicitly replaced    | Agent profiles preserve the existing strip/restore lifecycle.                                                                           |
+| approval mode              | shared or explicitly copied      | Bare derived profiles cannot mutate it; agent execution profiles own child-local state and preserve the canonical permission lifecycle. |
+| file-read cache            | child-local                      | The first getter call installs a fresh cache on the derived Config.                                                                     |
+| memory-pressure monitor    | child-local                      | The first getter call installs a new monitor using the inherited configuration snapshot.                                                |
+| active todo state          | child-local                      | The first mutation installs independent maps.                                                                                           |
+| chat recording service     | shared unless hidden             | Scoped profiles may hide it through a getter override.                                                                                  |
+| goal runtime               | prohibited                       | A derived Config cannot resolve the parent conversation's runtime.                                                                      |
+| session writer state       | prohibited                       | Writer ownership stays with the canonical session Config.                                                                               |
+| canonical lifecycle        | prohibited                       | A derived Config cannot initialize, start a session, relocate the workspace, or clean up inherited Team/Arena runtime resources.        |
+| approval mode mutation     | prohibited or explicitly copied  | Only the approval-profile factory may install a child-local transition method and cleanup contract.                                     |
 
 Migration order:
 
@@ -25,6 +25,6 @@ Migration order:
 3. Scoped memory/remember/skill-review profiles.
 4. Enforce that production prototype derivation occurs only inside `deriveConfig`.
 
-The factory intentionally accepts public getter overrides only. Private field rebinding needed by worktree contexts remains a separate migration concern and must be encoded without exposing arbitrary Config mutation.
+The generic factory intentionally accepts public getter overrides only. Named profiles keep private field rebinding and lifecycle management inside `config.ts` without exposing arbitrary Config mutation.
 
-Approval-mode override wrappers that call Config prototype mutators remain outside `deriveConfig` until their strip/restore lifecycle is owned independently from the parent permission manager.
+The approval profile owns child-local approval state and its parent permission-manager strip/restore contract. Callers remain responsible for invoking its cleanup callback when the agent lifecycle ends.

--- a/eslint-rules/no-config-object-create.js
+++ b/eslint-rules/no-config-object-create.js
@@ -1,0 +1,59 @@
+function importsConfig(node) {
+  return (
+    typeof node.source.value === 'string' &&
+    node.source.value.endsWith('/config/config.js') &&
+    node.specifiers.some(
+      (specifier) =>
+        specifier.type === 'ImportSpecifier' &&
+        specifier.imported.type === 'Identifier' &&
+        specifier.imported.name === 'Config',
+    )
+  );
+}
+
+function isObjectCreate(node) {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'Object' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'create' &&
+    !(node.arguments[0]?.type === 'Literal' && node.arguments[0].value === null)
+  );
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require Config prototype derivation to go through deriveConfig.',
+    },
+    schema: [],
+    messages: {
+      useDeriveConfig:
+        'Do not derive Config with Object.create(). Use deriveConfig() or a specialized Config factory.',
+    },
+  },
+
+  create(context) {
+    let hasConfigImport = false;
+    const objectCreateCalls = [];
+
+    return {
+      ImportDeclaration(node) {
+        if (importsConfig(node)) hasConfigImport = true;
+      },
+      CallExpression(node) {
+        if (isObjectCreate(node)) objectCreateCalls.push(node);
+      },
+      'Program:exit'() {
+        if (!hasConfigImport) return;
+        for (const node of objectCreateCalls) {
+          context.report({ node, messageId: 'useDeriveConfig' });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ import noCoreRootBarrelImport from './eslint-rules/no-core-root-barrel-import.js
 import noUtilsUpwardImport from './eslint-rules/no-utils-upward-import.js';
 import noCoreUtilsUpwardImport from './eslint-rules/no-core-utils-upward-import.js';
 import { legacyFilenames } from './eslint.legacy-filenames.mjs';
+import noConfigObjectCreate from './eslint-rules/no-config-object-create.js';
 
 // General syntax restrictions applied to every TS/TSX source file. Hoisted so
 // surface-specific overrides (flat config keeps only the last
@@ -333,6 +334,27 @@ export default tseslint.config(
     },
     rules: {
       'no-console': 'off',
+    },
+  },
+  {
+    files: ['packages/core/src/**/*.ts'],
+    ignores: [
+      'packages/core/src/config/config.ts',
+      '**/*.test.ts',
+      '**/*.spec.ts',
+      '**/__tests__/**',
+      '**/generated/**',
+      '**/*.generated.ts',
+    ],
+    plugins: {
+      'qwen-code': {
+        rules: {
+          'no-config-object-create': noConfigObjectCreate,
+        },
+      },
+    },
+    rules: {
+      'qwen-code/no-config-object-create': 'error',
     },
   },
   {

--- a/packages/core/src/agents/backends/InProcessBackend.ts
+++ b/packages/core/src/agents/backends/InProcessBackend.ts
@@ -13,20 +13,23 @@
 
 import path from 'node:path';
 import { createDebugLogger } from '../../utils/debugLogger.js';
-import { ApprovalMode, Config } from '../../config/config.js';
+import {
+  ApprovalMode,
+  type Config,
+  type DerivedApprovalModeConfigHooks,
+  deriveApprovalModeConfig,
+  deriveAgentConfig,
+} from '../../config/config.js';
 import { Storage } from '../../config/storage.js';
 import { type ContentGenerator } from '../../core/contentGenerator.js';
 import type { RuntimeContentGeneratorView } from '../runtime/agent-context.js';
 import type { ToolRegistry } from '../../tools/tool-registry.js';
-import { WorkspaceContext } from '../../utils/workspaceContext.js';
-import { FileDiscoveryService } from '../../services/fileDiscoveryService.js';
 import { createRuntimeContentGeneratorView } from '../../models/content-generator-config.js';
 import { AgentStatus, isTerminalStatus } from '../runtime/agent-types.js';
 import { AgentCore } from '../runtime/agent-core.js';
 import { AgentEventEmitter } from '../runtime/agent-events.js';
 import { ContextState } from '../runtime/agent-headless.js';
 import { AgentInteractive } from '../runtime/agent-interactive.js';
-import { createDenialState } from '../../permissions/denialTracking.js';
 import { runWithTeammateIdentity } from '../team/identity.js';
 import type {
   Backend,
@@ -492,49 +495,34 @@ async function createPerAgentConfig(
   modelId?: string,
   authOverrides?: InProcessSpawnConfig['authOverrides'],
   approvalMode?: ApprovalMode,
-  approvalModeHooks?: ApprovalModeOverrideHooks,
+  approvalModeHooks?: DerivedApprovalModeConfigHooks,
 ): Promise<{
   config: Config;
   contentGenerator?: ContentGenerator;
   runtimeView?: RuntimeContentGeneratorView;
   cleanup: () => void;
 }> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let override = Object.create(base) as any;
-  let dedicatedContentGenerator: ContentGenerator | undefined;
-  let runtimeView: RuntimeContentGeneratorView | undefined;
-  let cleanup = () => {};
-
-  if (approvalMode !== undefined) {
-    const handle = createApprovalModeConfigOverride(
-      base,
-      approvalMode,
-      approvalModeHooks,
-    );
-    override = handle.config as unknown as Record<string, unknown>;
-    cleanup = handle.cleanup;
-  }
-
-  let agentRegistry: ToolRegistry | undefined;
-  try {
-    override.getWorkingDir = () => cwd;
-    override.getTargetDir = () => cwd;
-    override.getProjectRoot = () => cwd;
-    override.getPlanFilePath = () => {
+  const approvalHandle =
+    approvalMode === undefined
+      ? { config: base, cleanup: () => {} }
+      : deriveApprovalModeConfig(base, approvalMode, {
+          hooks: approvalModeHooks,
+        });
+  const handle = deriveAgentConfig(approvalHandle.config, cwd, {
+    customIgnoreFiles: base.getFileFilteringOptions().customIgnoreFiles,
+    getPlanFilePath: () => {
       const sessionId = Storage.sanitizePlanSessionId(base.getSessionId());
       const scopedAgentId = Storage.sanitizePlanSessionId(agentId);
       return path.join(base.getPlansDir(), `${sessionId}-${scopedAgentId}.md`);
-    };
+    },
+  });
+  const override = handle.config;
+  const cleanup = approvalHandle.cleanup;
+  let dedicatedContentGenerator: ContentGenerator | undefined;
+  let runtimeView: RuntimeContentGeneratorView | undefined;
+  let agentRegistry: ToolRegistry | undefined;
 
-    const agentWorkspace = new WorkspaceContext(cwd);
-    override.getWorkspaceContext = () => agentWorkspace;
-
-    const agentFileService = new FileDiscoveryService(
-      cwd,
-      base.getFileFilteringOptions().customIgnoreFiles,
-    );
-    override.getFileService = () => agentFileService;
-
+  try {
     // Delegated rather than re-enacted. The three steps below used to be
     // inlined here, identical to the shared helper — and a second copy is a
     // second place for an invariant to be broken: a change sharing the
@@ -596,125 +584,6 @@ async function createPerAgentConfig(
     }
     throw error;
   }
-}
-
-interface ApprovalModeOverrideHooks {
-  acquireAutoApprovalOverride(): boolean;
-  releaseAutoApprovalOverride(): void;
-}
-
-function createApprovalModeConfigOverride(
-  base: Config,
-  mode: ApprovalMode,
-  hooks?: ApprovalModeOverrideHooks,
-): { config: Config; cleanup: () => void } {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const override = Object.create(base) as any;
-  const baseApprovalMode = base.getApprovalMode();
-  const initialMode = getTrustedInitialApprovalMode(base, mode);
-  let autoOverrideAcquired = false;
-  const acquireAutoOverride = () => {
-    if (autoOverrideAcquired || base.getApprovalMode() === ApprovalMode.AUTO) {
-      return;
-    }
-    if (hooks) {
-      autoOverrideAcquired = hooks.acquireAutoApprovalOverride();
-      return;
-    }
-    base.getPermissionManager?.()?.stripDangerousRulesForAutoMode();
-    autoOverrideAcquired = true;
-  };
-  const releaseAutoOverride = () => {
-    if (!autoOverrideAcquired) {
-      return;
-    }
-    if (hooks) {
-      hooks.releaseAutoApprovalOverride();
-    } else if (base.getApprovalMode() !== ApprovalMode.AUTO) {
-      base.getPermissionManager?.()?.restoreDangerousRules();
-    }
-    autoOverrideAcquired = false;
-  };
-
-  override.approvalMode = initialMode;
-  override.manualPlanExitNoticeEventState = {
-    ...(override.manualPlanExitNoticeEventState ?? {
-      version: 0,
-      kind: 'clear',
-    }),
-  };
-  override.getApprovalMode = Config.prototype.getApprovalMode;
-  override.prePlanMode =
-    initialMode === ApprovalMode.PLAN
-      ? baseApprovalMode === ApprovalMode.PLAN
-        ? base.getPrePlanMode()
-        : baseApprovalMode
-      : undefined;
-  override.approvalModeRevision = 0;
-
-  override.setApprovalMode = (
-    nextMode: ApprovalMode,
-    options?: Parameters<Config['setApprovalMode']>[1],
-  ) => {
-    const beforeMode = (override as Config).getApprovalMode();
-    const hadOwnPermissionManager = Object.prototype.hasOwnProperty.call(
-      override,
-      'permissionManager',
-    );
-    const ownPermissionManager = override.permissionManager;
-    override.permissionManager = null;
-    try {
-      Config.prototype.setApprovalMode.call(
-        override as Config,
-        nextMode,
-        options,
-      );
-    } finally {
-      if (hadOwnPermissionManager) {
-        override.permissionManager = ownPermissionManager;
-      } else {
-        delete override.permissionManager;
-      }
-    }
-
-    const afterMode = (override as Config).getApprovalMode();
-    if (beforeMode !== ApprovalMode.AUTO && afterMode === ApprovalMode.AUTO) {
-      acquireAutoOverride();
-    } else if (
-      beforeMode === ApprovalMode.AUTO &&
-      afterMode !== ApprovalMode.AUTO
-    ) {
-      releaseAutoOverride();
-    }
-  };
-  override.autoModeDenialState = createDenialState();
-
-  const cleanup = () => {
-    releaseAutoOverride();
-  };
-
-  if (
-    initialMode === ApprovalMode.AUTO &&
-    base.getApprovalMode() !== ApprovalMode.AUTO
-  ) {
-    acquireAutoOverride();
-  }
-
-  return { config: override as Config, cleanup };
-}
-
-function getTrustedInitialApprovalMode(
-  base: Config,
-  mode: ApprovalMode,
-): ApprovalMode {
-  if (
-    !base.isTrustedFolder() &&
-    mode !== ApprovalMode.DEFAULT &&
-    mode !== ApprovalMode.PLAN
-  ) {
-    return ApprovalMode.DEFAULT;
-  }
-  return mode;
 }
 
 function createRunInContext(

--- a/packages/core/src/agents/runtime/workflow-orchestrator.ts
+++ b/packages/core/src/agents/runtime/workflow-orchestrator.ts
@@ -7,7 +7,11 @@
 import { randomBytes } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import * as os from 'node:os';
-import { deriveWorktreeConfig, type Config } from '../../config/config.js';
+import {
+  deriveConfig,
+  deriveWorktreeConfig,
+  type Config,
+} from '../../config/config.js';
 import {
   createWorkflowSandbox,
   debugLogger,
@@ -794,12 +798,10 @@ function reportTokens(
  * would bypass that normalization and require us to duplicate it here.
  *
  * Why the worktree-rebound Config is passed as `runtimeContext` (not
- * `toolConfigOverride`): `SubagentManager.buildSubagentContextOverride`
- * (subagent-manager.ts:857) builds the subagent context via
- * `Object.create(runtimeContext)`. The own-property rebinds we set on the
- * worktree override propagate through the prototype chain, so all
- * `getTargetDir() / getCwd() / getFileService() / getWorkspaceContext()`
- * call sites inside the subagent see the worktree path. Subsequent
+ * `toolConfigOverride`): `SubagentManager` derives its subagent context from
+ * this worktree profile.
+ * The worktree profile's own getter and field rebinds propagate through that
+ * derivation, so workspace-bound call sites keep the selected path.
  * `rebuildToolRegistryOnOverride` re-resolves `this.config` through the
  * chain and anchors EditTool / WriteFileTool / ReadFileTool to the
  * worktree's FileReadCache, so the subagent cannot leak writes back into
@@ -1551,12 +1553,11 @@ async function createSchemaConfigOverride(
   base: Config,
   schema: Record<string, unknown>,
 ): Promise<Config> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const override: any = Object.create(base);
-  await rebuildToolRegistryOnOverride(override as Config, base);
+  const override = deriveConfig(base);
+  await rebuildToolRegistryOnOverride(override, base);
   const registry = override.getToolRegistry();
   registry.registerTool(new SyntheticOutputTool(schema));
-  return override as Config;
+  return override;
 }
 
 export class WorkflowOrchestrator {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1815,8 +1815,194 @@ export type DerivedConfigOverrides = Partial<
   >
 >;
 
+export interface DerivedApprovalModeConfigHooks {
+  acquireAutoApprovalOverride(): boolean;
+  releaseAutoApprovalOverride(): void;
+}
+
+export interface DerivedApprovalModeConfigOptions {
+  hooks?: DerivedApprovalModeConfigHooks;
+}
+
+export interface DerivedApprovalModeConfigHandle {
+  config: Config;
+  cleanup: () => void;
+}
+
+export interface DerivedAgentConfigOptions {
+  customIgnoreFiles?: string[];
+  getPlanFilePath?: Config['getPlanFilePath'];
+}
+
+export interface DerivedAgentConfigHandle {
+  config: Config;
+  fileService: FileDiscoveryService;
+  workspaceContext: WorkspaceContext;
+}
+
 export interface DerivedWorktreeConfigOptions {
   customIgnoreFiles?: string[];
+}
+
+/**
+ * Derives a Config with child-local approval state while preserving the
+ * canonical PermissionManager's AUTO strip/restore lifecycle.
+ */
+export function deriveApprovalModeConfig(
+  base: Config,
+  mode: ApprovalMode,
+  options: DerivedApprovalModeConfigOptions = {},
+): DerivedApprovalModeConfigHandle {
+  const baseApprovalMode = base.getApprovalMode();
+  const initialMode = getTrustedDerivedApprovalMode(base, mode);
+  let autoOverrideAcquired = false;
+  const acquireAutoOverride = () => {
+    if (autoOverrideAcquired || base.getApprovalMode() === ApprovalMode.AUTO) {
+      return;
+    }
+    if (options.hooks) {
+      autoOverrideAcquired = options.hooks.acquireAutoApprovalOverride();
+      return;
+    }
+    base.getPermissionManager?.()?.stripDangerousRulesForAutoMode();
+    autoOverrideAcquired = true;
+  };
+  const releaseAutoOverride = () => {
+    if (!autoOverrideAcquired) return;
+    if (options.hooks) {
+      options.hooks.releaseAutoApprovalOverride();
+    } else if (base.getApprovalMode() !== ApprovalMode.AUTO) {
+      base.getPermissionManager?.()?.restoreDangerousRules();
+    }
+    autoOverrideAcquired = false;
+  };
+
+  const derived = deriveConfig(base, {
+    getApprovalMode: Config.prototype.getApprovalMode,
+  });
+  const state = derived as unknown as {
+    approvalMode: ApprovalMode;
+    prePlanMode?: ApprovalMode;
+    approvalModeRevision: number;
+    manualPlanExitNoticeEventState: ManualPlanExitNoticeEventState;
+    autoModeDenialState: AutoModeDenialState;
+    permissionManager: PermissionManager | null;
+  };
+  state.approvalMode = initialMode;
+  state.prePlanMode =
+    initialMode === ApprovalMode.PLAN
+      ? baseApprovalMode === ApprovalMode.PLAN
+        ? base.getPrePlanMode()
+        : baseApprovalMode
+      : undefined;
+  state.approvalModeRevision = 0;
+  state.manualPlanExitNoticeEventState = {
+    ...((
+      base as unknown as {
+        manualPlanExitNoticeEventState?: ManualPlanExitNoticeEventState;
+      }
+    ).manualPlanExitNoticeEventState ?? { version: 0, kind: 'clear' }),
+  };
+  state.autoModeDenialState = createDenialState();
+
+  Object.defineProperty(derived, 'setApprovalMode', {
+    value: (
+      nextMode: ApprovalMode,
+      setOptions?: Parameters<Config['setApprovalMode']>[1],
+    ): void => {
+      const beforeMode = derived.getApprovalMode();
+      const hadOwnPermissionManager = Object.hasOwn(
+        derived,
+        'permissionManager',
+      );
+      const ownPermissionManager = state.permissionManager;
+      state.permissionManager = null;
+      try {
+        Config.prototype.setApprovalMode.call(derived, nextMode, setOptions);
+      } finally {
+        if (hadOwnPermissionManager) {
+          state.permissionManager = ownPermissionManager;
+        } else {
+          delete (state as Partial<typeof state>).permissionManager;
+        }
+      }
+
+      const afterMode = derived.getApprovalMode();
+      if (beforeMode !== ApprovalMode.AUTO && afterMode === ApprovalMode.AUTO) {
+        acquireAutoOverride();
+      } else if (
+        beforeMode === ApprovalMode.AUTO &&
+        afterMode !== ApprovalMode.AUTO
+      ) {
+        releaseAutoOverride();
+      }
+    },
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+
+  if (
+    initialMode === ApprovalMode.AUTO &&
+    base.getApprovalMode() !== ApprovalMode.AUTO
+  ) {
+    acquireAutoOverride();
+  }
+
+  return { config: derived, cleanup: releaseAutoOverride };
+}
+
+/**
+ * Derives the workspace and optional approval-mode state for one agent.
+ */
+export function deriveAgentConfig(
+  base: Config,
+  workingDirectory: string,
+  options: DerivedAgentConfigOptions = {},
+): DerivedAgentConfigHandle {
+  const fileService = new FileDiscoveryService(
+    workingDirectory,
+    options.customIgnoreFiles,
+  );
+  const workspaceContext = new WorkspaceContext(workingDirectory);
+  const derived = deriveConfig(base, {
+    getTargetDir: () => workingDirectory,
+    getCwd: () => workingDirectory,
+    getWorkingDir: () => workingDirectory,
+    getProjectRoot: () => workingDirectory,
+    getPlanFilePath: options.getPlanFilePath,
+    getFileService: () => fileService,
+    getWorkspaceContext: () => workspaceContext,
+  });
+  const workspaceState = derived as unknown as {
+    targetDir: string;
+    cwd: string;
+    fileDiscoveryService: FileDiscoveryService;
+    workspaceContext: WorkspaceContext;
+  };
+  workspaceState.targetDir = workingDirectory;
+  workspaceState.cwd = workingDirectory;
+  workspaceState.fileDiscoveryService = fileService;
+  workspaceState.workspaceContext = workspaceContext;
+  return {
+    config: derived,
+    fileService,
+    workspaceContext,
+  };
+}
+
+function getTrustedDerivedApprovalMode(
+  base: Config,
+  requestedMode: ApprovalMode,
+): ApprovalMode {
+  if (
+    !base.isTrustedFolder() &&
+    requestedMode !== ApprovalMode.DEFAULT &&
+    requestedMode !== ApprovalMode.PLAN
+  ) {
+    return ApprovalMode.DEFAULT;
+  }
+  return requestedMode;
 }
 
 /**
@@ -1859,8 +2045,8 @@ export function deriveWorktreeConfig(
  * Creates a Config overlay while keeping prototype delegation inside one
  * reviewable boundary. Callers supply only public getter overrides; Config's
  * child-local and prohibited runtime state remains enforced by its accessors.
- * Approval-mode override wrappers that call Config prototype mutators must keep
- * owning their strip/restore lifecycle before migrating to this factory.
+ * Named profiles layer any private-state rebinding and cleanup contract above
+ * this generic factory.
  */
 export function deriveConfig(
   base: Config,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2132,10 +2132,8 @@ export class Config {
   private backgroundAgentResumeService?: BackgroundAgentResumeService;
   private readonly backgroundShellRegistry = new BackgroundShellRegistry();
   private readonly workflowRunRegistry = new WorkflowRunRegistry();
-  // Field initializer runs once on the parent Config; child Configs
-  // built via Object.create(parent) intentionally do NOT pick this up
-  // — see getFileReadCache() for the per-instance lazy initialization
-  // that keeps subagent caches isolated from the parent's.
+  // Derived Configs do not run field initializers. getFileReadCache()
+  // lazily installs an own cache to keep child state isolated.
   private fileReadCache: FileReadCache = new FileReadCache();
   private extensionManager!: ExtensionManager;
   private skillManager: SkillManager | null = null;
@@ -2324,8 +2322,8 @@ export class Config {
   private readonly chatRecordingFailureListeners =
     new Set<ChatRecordingFailureListener>();
   private fileCheckpointingEnabled: boolean;
-  // Object (not primitive) so sub-agents via Object.create(parentConfig)
-  // share the same budget instance through prototype lookup.
+  // Object state is intentionally shared by derived Configs through prototype
+  // lookup so every agent contributes to the same session budget.
   private readonly toolResultBudget = { bytesWritten: 0 };
   private fileHistoryService: FileHistoryService | undefined;
   private readonly proxy: string | undefined;
@@ -4370,9 +4368,8 @@ export class Config {
     // /clear or session resume would let a follow-up Read return the
     // placeholder despite the new session never having received the
     // file contents. Use the getter so the lazy own-property
-    // initialization in getFileReadCache() applies even for Configs
-    // constructed via Object.create — those should clear their own
-    // cache, not the parent's.
+    // initialization in getFileReadCache() applies even for derived Configs;
+    // each derived Config should clear its own cache, not the parent's.
     this.getFileReadCache().clear();
     this.toolResultBudget.bytesWritten = 0;
     this.getMemoryPressureMonitor()?.resetForNewSession();
@@ -7289,11 +7286,9 @@ export class Config {
   }
 
   /**
-   * Session-scoped memory pressure monitor. Child Configs created with
-   * `Object.create(parent)` inherit the parent's monitor through the prototype
-   * chain until this getter installs an own monitor backed by the inherited
-   * pressure config snapshot. This mirrors getFileReadCache()'s isolation
-   * contract while keeping type-safe direct field assignment inside the class.
+   * Session-scoped memory pressure monitor. Derived Configs inherit the
+   * parent's monitor until this getter installs an own monitor backed by the
+   * inherited pressure config snapshot. This mirrors getFileReadCache().
    */
   getMemoryPressureMonitor(): MemoryPressureMonitor | undefined {
     if (!Object.prototype.hasOwnProperty.call(this, 'memoryPressureMonitor')) {
@@ -8679,22 +8674,13 @@ export class Config {
    * subagent (which gets its own Config) does not inherit the parent's
    * recorded reads via the prototype chain.
    *
-   * The wrinkle: every subagent / scoped-agent / fork path in this
-   * codebase constructs its Config via `Object.create(parent)`. That
-   * does **not** run instance field initializers, so the parent's
-   * `fileReadCache` field is reachable on the child only by prototype
-   * lookup — i.e. child and parent end up sharing the same cache. The
-   * own-property check below detects "this instance was made by
-   * Object.create" and lazily attaches a fresh cache, ensuring
-   * isolation without requiring every Object.create site to remember
-   * to override the field.
+   * Derived Configs do not run instance field initializers, so the parent's
+   * `fileReadCache` is initially reachable through the prototype chain. The
+   * own-property check below lazily installs a fresh cache for each child.
    */
   getFileReadCache(): FileReadCache {
     if (!Object.prototype.hasOwnProperty.call(this, 'fileReadCache')) {
-      // The own-property write needs to bypass `private`'s structural
-      // check — the field is conceptually still private to the class,
-      // we just need TS to let us install an own copy on a child
-      // instance produced by `Object.create(parent)`.
+      // Install child-local state while keeping the field private to Config.
       (this as unknown as { fileReadCache: FileReadCache }).fileReadCache =
         new FileReadCache();
     }
@@ -8898,10 +8884,8 @@ export class Config {
     // in sync between them.
     //
     // Skipped when building a subagent-context registry. `this.jsonSchema`
-    // propagates to subagent overrides via prototype delegation
-    // (`Object.create(base)` in `createApprovalModeOverride` /
-    // `buildSubagentContextOverride`), but only `runNonInteractive`'s main
-    // and drain loops detect a successful structured_output call as
+    // propagates through Config derivation, but only `runNonInteractive`'s
+    // main and drain loops detect a successful structured_output call as
     // terminal. A subagent that called the tool would receive the
     // "Session will end now" llmContent, then keep running because its
     // own loop has no termination handler — wasted tokens with no
@@ -9191,9 +9175,9 @@ export class Config {
     // The ACP session's own registry is built before its constructor wires the
     // spawner, so that one is registered by the Session itself. Every registry
     // built afterwards reaches the spawner from here: sub-agent and override
-    // configs are `Object.create(base)`, and `copyDiscoveredToolsFrom` carries
-    // discovered tools only, so without this a daemon sub-agent would silently
-    // lose the tool.
+    // configs derive from the base Config, and `copyDiscoveredToolsFrom`
+    // carries discovered tools only, so without this a daemon sub-agent would
+    // silently lose the tool.
     if (this.getSubSessionSpawner()) {
       await registerLazy(ToolNames.CREATE_SUB_SESSION, async () => {
         const { CreateSubSessionTool } = await import(

--- a/packages/core/src/memory/memory-scoped-agent-config.ts
+++ b/packages/core/src/memory/memory-scoped-agent-config.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { PermissionManager } from '../permissions/permission-manager.js';
@@ -403,8 +403,7 @@ export function createMemoryScopedAgentConfig(
     },
   };
 
-  const scopedConfig = Object.create(config) as Config;
-  scopedConfig.getPermissionManager = () =>
-    scopedPm as unknown as PermissionManager;
-  return scopedConfig;
+  return deriveConfig(config, {
+    getPermissionManager: () => scopedPm as unknown as PermissionManager,
+  });
 }

--- a/packages/core/src/memory/remember.ts
+++ b/packages/core/src/memory/remember.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import { ToolNames } from '../tools/tool-names.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { runForkedAgent } from '../agents/forkedAgent.js';
@@ -106,15 +106,17 @@ function createHiddenRememberConfig(
   config: Config,
   options: { disableHooks?: boolean } = {},
 ): Config {
-  const hiddenConfig = Object.create(config) as Config;
-  hiddenConfig.getChatRecordingService = () => undefined;
-  hiddenConfig.getTranscriptPath = () => '';
-  if (options.disableHooks) {
-    hiddenConfig.getDisableAllHooks = () => true;
-    hiddenConfig.getHookSystem = () => undefined;
-    hiddenConfig.getMessageBus = () => undefined;
-  }
-  return hiddenConfig;
+  return deriveConfig(config, {
+    getChatRecordingService: () => undefined,
+    getTranscriptPath: () => '',
+    ...(options.disableHooks
+      ? {
+          getDisableAllHooks: () => true,
+          getHookSystem: () => undefined,
+          getMessageBus: () => undefined,
+        }
+      : {}),
+  });
 }
 
 function uniqueSortedScopes(scopes: Iterable<WorkspaceRememberScope>) {
@@ -165,14 +167,10 @@ export async function runManagedRememberByAgent(params: {
   // section — and in clean mode re-injecting parent-session memory into the
   // intended blank-slate agent. Zero it out for every mode so the section is
   // present exactly once, via the remember system prompt above.
-  const baseConfig = (() => {
-    const derived = Object.create(params.config) as Config;
-    derived.getAutoMemoryPrompt = () => '';
-    if (params.contextMode === 'clean') {
-      derived.getUserMemory = () => '';
-    }
-    return derived;
-  })();
+  const baseConfig = deriveConfig(params.config, {
+    getAutoMemoryPrompt: () => '',
+    ...(params.contextMode === 'clean' ? { getUserMemory: () => '' } : {}),
+  });
   const hiddenConfig = createHiddenRememberConfig(baseConfig, {
     disableHooks: params.contextMode === 'clean',
   });

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -7,7 +7,7 @@
 import type { Content } from '@google/genai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import type { PermissionManager } from '../permissions/permission-manager.js';
 import type {
   PermissionCheckContext,
@@ -256,10 +256,9 @@ export function createSkillScopedAgentConfig(
     },
   };
 
-  const scopedConfig = Object.create(config) as Config;
-  scopedConfig.getPermissionManager = () =>
-    scopedPm as unknown as PermissionManager;
-  return scopedConfig;
+  return deriveConfig(config, {
+    getPermissionManager: () => scopedPm as unknown as PermissionManager,
+  });
 }
 
 // Exported for tests so the `auto-skill-` prefix instruction stays asserted

--- a/packages/core/src/subagents/subagent-manager-override.test.ts
+++ b/packages/core/src/subagents/subagent-manager-override.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { Config, ApprovalMode } from '../config/config.js';
+import { Config, ApprovalMode, deriveConfig } from '../config/config.js';
 import { SubagentManager } from './subagent-manager.js';
 import type { SubagentConfig } from './types.js';
 import { ToolNames } from '../tools/tool-names.js';
@@ -14,16 +14,9 @@ import { ReadFileTool } from '../tools/read-file.js';
 import { createApprovalModeOverride } from '../tools/agent/agent.js';
 
 /**
- * Companion to `tools/agent/agent-override.test.ts`. Same regression:
- * Object.create(parent) by itself is not enough to isolate a subagent's
- * core tools from the parent's bound `EditTool` / `WriteFileTool` /
- * `ReadFileTool`. The subagent path (which flows through
- * `SubagentManager.createAgentHeadless` →
- * `buildSubagentContextOverride`) must rebuild the tool registry on
- * the override Config so bound tools resolve `this.config` to the
- * subagent rather than the parent — otherwise mutations executed via
- * the bound tool reach the parent's FileReadCache and silently weaken
- * prior-read enforcement.
+ * Companion to `tools/agent/agent-override.test.ts`. A derived child must
+ * rebuild core tools so Edit/Write/Read resolve its child-local cache rather
+ * than the parent's recorded reads.
  */
 describe('SubagentManager.buildSubagentContextOverride bound-tool isolation', () => {
   // Bare mode keeps the registry small (ReadFile / Edit / Shell only) and
@@ -131,23 +124,7 @@ describe('SubagentManager.buildSubagentContextOverride bound-tool isolation', ()
     expect(child.getFileReadCache().size()).toBe(0);
   });
 
-  it('skips rebuild and inherits registry via prototype when an upstream wrapper has already rebuilt the registry (real-world chained-override case)', async () => {
-    // This mirrors the real-world flow: agent.ts wraps the parent in
-    // `createApprovalModeOverride` (which builds R1 on the wrapper),
-    // then passes that wrapper — sometimes wrapped one more level in
-    // `bgConfig = Object.create(agentConfig)` for the background path —
-    // through `createAgentHeadless` → `buildSubagentContextOverride`.
-    // We do NOT want the second layer to build a redundant R2 — that
-    // would (a) waste work, (b) leak listeners on every later
-    // AgentTool/SkillTool factory invocation, and (c) split the cache
-    // so client-level clears target an empty R2 cache while the bound
-    // tools (still in R1) keep using R1's.
-    //
-    // Detection is via the `TOOL_REGISTRY_REBUILT` symbol marker that
-    // `createApprovalModeOverride` sets on its return value; Symbol
-    // property lookup walks the prototype chain so even an Object.create
-    // wrapper above the rebuilt Config is correctly recognised as
-    // having an upstream rebuild.
+  it('skips rebuild and inherits registry when an upstream derived wrapper already rebuilt it', async () => {
     const parent = new Config(baseParams);
     const parentRegistry = await parent.createToolRegistry(undefined, {
       skipDiscovery: true,
@@ -162,30 +139,19 @@ describe('SubagentManager.buildSubagentContextOverride bound-tool isolation', ()
     );
     const upstreamRegistry = upstreamWrapper.getToolRegistry();
 
-    // Layer 2: simulate `bgConfig = Object.create(agentConfig)` from
-    // the background path — own properties added on this layer should
-    // not hide the marker on the prototype.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const bgWrapper = Object.create(upstreamWrapper) as any;
-    bgWrapper.getShouldAvoidPermissionPrompts = () => true;
+    // Layer 2: add the background prompt policy through the factory.
+    const bgWrapper = deriveConfig(upstreamWrapper, {
+      getShouldAvoidPermissionPrompts: () => true,
+    });
 
     const manager = new SubagentManager(parent);
 
     const child = await callBuildOverride(manager, bgWrapper as Config);
 
-    // child is still a distinct instance (Object.create) so the
-    // FileReadCache lazy-init still works, but its registry must
-    // resolve via the prototype back to upstreamRegistry — we did not
-    // build a new one.
+    // The child is distinct, but the rebuilt registry remains inherited from
+    // the approval profile so no duplicate registry lifecycle is created.
     expect(child).not.toBe(bgWrapper);
     expect(child.getToolRegistry()).toBe(upstreamRegistry);
-
-    // Critically: tools the model later instantiates from the registry
-    // are bound to upstreamWrapper, NOT the second-layer child. That
-    // is what the optimization is for — the bound tool still resolves
-    // `this.config.getFileReadCache()` to upstreamWrapper's cache,
-    // which is the cache the rest of the subagent execution actually
-    // uses.
     const childEdit = await child.getToolRegistry().ensureTool(ToolNames.EDIT);
     expect(childEdit).toBeInstanceOf(EditTool);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/subagents/subagent-manager.test.ts
+++ b/packages/core/src/subagents/subagent-manager.test.ts
@@ -2407,8 +2407,8 @@ bad`);
         const { runtimeContext, runtimeView } = destructureAgentHeadlessCall(
           mockAgentHeadlessCreate.mock.calls[0],
         );
-        // Subagents always get an `Object.create(parent)` wrapper for
-        // FileReadCache isolation — distinct instance, prototype === parent.
+        // Subagents always get a derived wrapper for child-local state.
+        // It remains a distinct instance whose prototype is the parent.
         expect(runtimeContext).not.toBe(mockConfig);
         expect(Object.getPrototypeOf(runtimeContext)).toBe(mockConfig);
         expect(runtimeView).toBeDefined();

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -37,7 +37,7 @@ import type {
   AgentHooks,
 } from '../agents/runtime/agent-events.js';
 import type { Config, MCPServerConfig } from '../config/config.js';
-import { APPROVAL_MODES } from '../config/config.js';
+import { APPROVAL_MODES, deriveConfig } from '../config/config.js';
 import type { HookDefinition, HookEventName } from '../hooks/types.js';
 import type { RuntimeContentGeneratorView } from '../agents/runtime/agent-context.js';
 import {
@@ -976,8 +976,8 @@ export class SubagentManager {
 
   /**
    * Build the per-subagent Config override used as the AgentHeadless
-   * runtime context. The override is a thin prototype-delegation wrapper
-   * (`Object.create(runtimeContext)`): no method changes, but a distinct
+   * runtime context. The override is a thin factory-derived wrapper: no
+   * method changes, but a distinct
    * instance triggers the lazy own-property init in
    * `Config.getFileReadCache()` so the subagent gets its own cache
    * rather than inheriting the parent's recorded reads — which would
@@ -991,8 +991,8 @@ export class SubagentManager {
    * `agent.ts:createApprovalModeOverride`, which marks itself via a
    * Symbol-keyed flag — Symbol lookup walks the prototype chain, so
    * this also catches wrapper-on-wrapper layering like the background
-   * launch passing its stamped `createApprovalModeOverride` override
-   * directly as `runtimeContext`). Rebuilding twice would waste work,
+   * launch passing its stamped `createApprovalModeOverride` override directly
+   * as `runtimeContext`). Rebuilding twice would waste work,
    * leak listeners on shared managers, and split caches across registry
    * layers.
    */
@@ -1014,8 +1014,7 @@ export class SubagentManager {
      */
     cleanup?: () => Promise<void>;
   }> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const subagentContext = Object.create(runtimeContext) as any as Config;
+    const subagentContext = deriveConfig(runtimeContext);
 
     // Per-agent MCP server overrides. Frontmatter `mcpServers` entries shadow
     // session-level servers on key collision (more-specific-wins, matching

--- a/packages/core/src/tools/agent/agent-override.test.ts
+++ b/packages/core/src/tools/agent/agent-override.test.ts
@@ -332,6 +332,22 @@ describe('createApprovalModeOverride bound-tool isolation', () => {
     expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
   });
 
+  it('restores AUTO rules when registry setup fails', async () => {
+    const parent = await createParentWithRegistry();
+    const { stripDangerousRulesForAutoMode, restoreDangerousRules } =
+      attachFakePermissionManager(parent);
+    vi.spyOn(parent, 'createToolRegistry').mockRejectedValue(
+      new Error('registry boom'),
+    );
+
+    await expect(
+      createApprovalModeOverride(parent, ApprovalMode.AUTO),
+    ).rejects.toThrow('registry boom');
+
+    expect(stripDangerousRulesForAutoMode).toHaveBeenCalledTimes(1);
+    expect(restoreDangerousRules).toHaveBeenCalledTimes(1);
+  });
+
   it('does not need cleanup restore after a child leaves AUTO mode itself', async () => {
     const parent = await createParentWithRegistry();
     const { stripDangerousRulesForAutoMode, restoreDangerousRules } =

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -107,12 +107,12 @@ import {
 import { toModelVisibleSubagentResult } from '../../agents/subagent-result.js';
 import {
   ApprovalMode,
-  Config,
+  deriveApprovalModeConfig,
   deriveWorktreeConfig,
   normalizeMaxSubagentDepth,
   validateMaxSessionTurns,
+  type Config,
 } from '../../config/config.js';
-import { createDenialState } from '../../permissions/denialTracking.js';
 import { isTeammate } from '../../agents/team/identity.js';
 import { isSubagentLikeExecutionContext } from '../../agents/runtime/subagent-plan-tool-policy.js';
 import {
@@ -606,118 +606,23 @@ function capturePersistedCliFlags(
 }
 
 /**
- * Creates a Config override with a different approval mode.
- *
- * Uses prototype delegation (Object.create) to avoid mutating the parent
- * config, then delegates to {@link rebuildToolRegistryOnOverride} so the
- * override's tool registry has core tools bound to the override rather
- * than to the parent. Without that rebuild, the parent's cached tool
- * instances continue to resolve `this.config` to the parent, defeating
- * per-Config isolation of FileReadCache / approval mode for any code
- * path that goes through the bound tool.
- *
- * Returns `{ config, cleanup }`. Callers MUST invoke `cleanup` in a
- * `finally` block after the override is no longer in use, otherwise
- * the parent's PermissionManager may leak a strip across the sub-agent
- * boundary (see strip lifecycle below).
- *
- * Strip lifecycle for AUTO overrides:
- *   - parent not in AUTO, override starts in AUTO: this function strips
- *     the PARENT's PM (shared via prototype chain — the override cannot
- *     have its own PM without a much bigger refactor).
- *   - parent already in AUTO, override starts in AUTO: parent's
- *     `setApprovalMode` already stripped on its own entry, so this
- *     function does not strip again.
- *   - override enters/leaves AUTO later: `setApprovalMode` reuses Config's
- *     normal state transition, but suppresses AUTO strip/restore while the
- *     parent is already in AUTO because the parent owns that strip lifecycle.
- *     `cleanup` only restores if the child finishes still in AUTO while the
- *     parent is not in AUTO.
+ * Creates an agent approval profile, then rebuilds its tool registry so bound
+ * tools resolve the derived Config and its child-local state.
  */
 export async function createApprovalModeOverride(
   base: Config,
   mode: ApprovalMode,
   options: ApprovalModeOverrideOptions = {},
 ): Promise<ApprovalModeOverrideHandle> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const override = Object.create(base) as any;
-  const baseApprovalMode = base.getApprovalMode();
-  // These own properties intentionally mirror Config's TS-private field names.
-  // Config prototype methods read/write them at runtime on this override object.
-  override.approvalMode = mode;
-  override.manualPlanExitNoticeEventState = {
-    ...(override.manualPlanExitNoticeEventState ?? {
-      version: 0,
-      kind: 'clear',
-    }),
-  };
-  override.getApprovalMode = Config.prototype.getApprovalMode;
-  override.prePlanMode =
-    mode === ApprovalMode.PLAN
-      ? baseApprovalMode === ApprovalMode.PLAN
-        ? base.getPrePlanMode()
-        : baseApprovalMode
-      : undefined;
-  override.approvalModeRevision = 0;
-  override.autoModeDenialState = createDenialState();
-  override.setApprovalMode = (
-    nextMode: ApprovalMode,
-    setOptions?: Parameters<Config['setApprovalMode']>[1],
-  ): void => {
-    if (base.getApprovalMode() !== ApprovalMode.AUTO) {
-      Config.prototype.setApprovalMode.call(
-        override as Config,
-        nextMode,
-        setOptions,
-      );
-      return;
-    }
-
-    const hadOwnPermissionManager = Object.prototype.hasOwnProperty.call(
-      override,
-      'permissionManager',
-    );
-    const ownPermissionManager = override.permissionManager;
-    override.permissionManager = null;
-    try {
-      Config.prototype.setApprovalMode.call(
-        override as Config,
-        nextMode,
-        setOptions,
-      );
-    } finally {
-      if (hadOwnPermissionManager) {
-        override.permissionManager = ownPermissionManager;
-      } else {
-        delete override.permissionManager;
-      }
-    }
-  };
-  applyPersistedCliFlagOverrides(override as Config, options.persistedCliFlags);
-  await rebuildToolRegistryOnOverride(override as Config, base);
-
-  const cleanup = () => {
-    if (
-      (override as Config).getApprovalMode() === ApprovalMode.AUTO &&
-      base.getApprovalMode() !== ApprovalMode.AUTO
-    ) {
-      base.getPermissionManager?.()?.restoreDangerousRules();
-    }
-  };
-
-  if (mode === ApprovalMode.AUTO) {
-    const baseWasAuto = base.getApprovalMode() === ApprovalMode.AUTO;
-    if (!baseWasAuto) {
-      // This override is bringing AUTO into a non-AUTO parent. Strip
-      // dangerous allow rules so the sub-agent's classifier actually
-      // gates them. Cleanup handles restore if the child finishes in AUTO.
-      base.getPermissionManager?.()?.stripDangerousRulesForAutoMode();
-    }
-    // baseWasAuto: parent's setApprovalMode already stripped; cleanup
-    // will not restore while the parent remains in AUTO.
+  const { config: override, cleanup } = deriveApprovalModeConfig(base, mode);
+  try {
+    applyPersistedCliFlagOverrides(override, options.persistedCliFlags);
+    await rebuildToolRegistryOnOverride(override, base);
+    return { config: override, cleanup };
+  } catch (error) {
+    cleanup();
+    throw error;
   }
-
-  return { config: override as Config, cleanup };
 }
 
 /**

--- a/scripts/tests/no-config-object-create.test.js
+++ b/scripts/tests/no-config-object-create.test.js
@@ -1,0 +1,43 @@
+import { Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+import rule from '../../eslint-rules/no-config-object-create.js';
+
+function verify(code) {
+  const linter = new Linter({ configType: 'eslintrc' });
+  linter.defineRule('qwen-code/no-config-object-create', rule);
+  return linter.verify(code, {
+    parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: { 'qwen-code/no-config-object-create': 'error' },
+  });
+}
+
+describe('no-config-object-create', () => {
+  it('rejects prototype derivation in a module that imports Config', () => {
+    const messages = verify(`
+      import { Config } from '../config/config.js';
+      const child = Object.create(parent);
+    `);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.messageId).toBe('useDeriveConfig');
+  });
+
+  it('allows deriveConfig and null-prototype dictionaries', () => {
+    expect(
+      verify(`
+        import { Config, deriveConfig } from '../config/config.js';
+        const child = deriveConfig(parent);
+        const dictionary = Object.create(null);
+      `),
+    ).toEqual([]);
+  });
+
+  it('ignores unrelated Config imports', () => {
+    expect(
+      verify(`
+        import { Config } from '../telemetry/config.js';
+        const error = Object.create(Object.getPrototypeOf(source));
+      `),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this PR does

This PR moves approval profiles, in-process agent workspace profiles, subagent runtime contexts, and workflow schema contexts behind the shared derived-Config boundary. Approval profiles now own child-local approval state plus the canonical permission manager's AUTO strip/restore cleanup contract, while each agent workspace profile rebinds its directory, workspace context, file discovery service, and plan path as one operation.

The existing registry lifecycle remains intact: approval and subagent launch paths still rebuild tools against the correct derived Config, in-process agents retain their long-lived registry semantics, per-agent MCP registries remain independently disposable, and background prompt policy stays on the registry-bound Config so nested launches inherit it.

This is stacked on #9915 and contains only the agent-execution slice relative to that PR.

## Why it's needed

These paths previously hand-built several variations of the same prototype overlay, including duplicate approval-state and permission cleanup logic. That made ownership rules difficult to review and allowed new execution paths to bypass the boundary introduced in #8100. Centralizing the profiles removes the duplicate logic without changing agent behavior.

## Reviewer Test Plan

### How to verify

1. Confirm child approval mode transitions do not mutate the parent and AUTO rule stripping is restored on normal cleanup and registry setup failure.
2. Confirm in-process agents resolve workspace getters, file discovery, and plan paths to their own working directory while preserving parent state and concurrent AUTO-child accounting.
3. Confirm subagents keep child-local file-read caches, correctly bind rebuilt tools, preserve per-agent MCP registry ownership, and avoid redundant registry rebuilds.
4. Confirm background and resumed agents retain prompt-avoidance/bubbling policy through nested launches.
5. Confirm workflow schema agents receive an independently derived and rebuilt registry containing their schema-bound output tool.

### Evidence (Before & After)

N/A — internal refactor with no user-visible behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22; clean dependency install and full repository build, full repository typecheck, focused ESLint and Prettier checks, and 989 focused Config/Agent/Subagent/Workflow tests. The workflow-focused suite was rerun after migrating the final schema-context caller.

## Risk & Scope

- Main risk or tradeoff: approval profiles share the canonical permission manager while owning child-local approval state, so every caller must execute the returned cleanup callback; existing lifecycle tests and a registry-failure regression test cover this contract.
- Not validated / out of scope: memory, remember, and skill-review scoped profiles remain the next #8083 slice; no user-facing E2E behavior changes are introduced here.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #8083
Depends on #9915

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 将 approval profile、进程内 agent 工作区 profile、subagent 运行上下文和 workflow schema 上下文迁移到共享的派生 Config 边界。Approval profile 现在拥有子级独立的 approval 状态，以及规范 PermissionManager 的 AUTO 规则剥离/恢复清理契约；每个 agent 工作区 profile 则通过一次操作统一重绑定目录、工作区上下文、文件发现服务和 plan 路径。

现有 registry 生命周期保持不变：approval 与 subagent 启动路径仍基于正确的派生 Config 重建工具；进程内 agent 保留长期 registry 语义；每个 agent 的 MCP registry 仍可独立释放；后台 prompt policy 继续落在工具 registry 实际绑定的 Config 上，使嵌套启动可以继承该策略。

这个 PR 堆叠在 #9915 之上，相对 #9915 只包含 agent-execution 切片。

## 为什么需要

此前这些路径各自手工构造多种 prototype overlay，其中还包含重复的 approval 状态和权限清理逻辑。这让所有权规则难以审查，也使新增执行路径可能绕过 #8100 引入的边界。集中这些 profile 可以在不改变 agent 行为的前提下删除重复逻辑。

## Reviewer Test Plan

### 如何验证

1. 确认子级 approval mode 切换不会修改父 Config，并且 AUTO 规则在正常清理和 registry 初始化失败时都会恢复。
2. 确认进程内 agent 的工作区 getter、文件发现和 plan 路径都指向自身工作目录，同时保留父状态和并发 AUTO 子级计数语义。
3. 确认 subagent 保持子级独立的文件读取缓存、正确绑定重建后的工具、保留每个 agent 的 MCP registry 所有权，并避免重复 registry 重建。
4. 确认后台和恢复后的 agent 在嵌套启动中保留 prompt avoidance / permission bubbling 策略。
5. 确认 workflow schema agent 获得独立派生并重建的 registry，其中包含对应 schema 的输出工具。

### Evidence (Before & After)

N/A —— 内部重构，没有用户可见行为变化。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22；独立依赖安装与全仓构建、全仓 typecheck、聚焦 ESLint/Prettier 检查，以及 989 个 Config/Agent/Subagent/Workflow 聚焦测试。在迁移最后一个 schema 上下文调用方后，又单独重跑了 workflow 聚焦测试。

## Risk & Scope

- 主要风险或取舍：approval profile 与父级共享规范 PermissionManager，同时拥有子级独立的 approval 状态，因此每个调用方都必须执行返回的 cleanup 回调；现有生命周期测试和新增的 registry 初始化失败回归测试覆盖了这个契约。
- 未验证 / 范围外：memory、remember 和 skill-review scoped profile 是 #8083 的下一切片；这里不引入用户可见的 E2E 行为变化。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Refs #8083
依赖 #9915

</details>
