### PR TITLE
refactor(core): centralize scoped config profiles

### DIFF
--- a/docs/design/derived-config-ownership.md
+++ b/docs/design/derived-config-ownership.md
@@ -28,3 +28,5 @@ Migration order:
 The generic factory intentionally accepts public getter overrides only. Named profiles keep private field rebinding and lifecycle management inside `config.ts` without exposing arbitrary Config mutation.
 
 The approval profile owns child-local approval state and its parent permission-manager strip/restore contract. Callers remain responsible for invoking its cleanup callback when the agent lifecycle ends.
+
+Production core modules that import `Config` are linted against non-null `Object.create(...)` calls, keeping new prototype overlays behind the generic or named factories.

--- a/eslint-rules/no-config-object-create.js
+++ b/eslint-rules/no-config-object-create.js
@@ -1,0 +1,59 @@
+function importsConfig(node) {
+  return (
+    typeof node.source.value === 'string' &&
+    node.source.value.endsWith('/config/config.js') &&
+    node.specifiers.some(
+      (specifier) =>
+        specifier.type === 'ImportSpecifier' &&
+        specifier.imported.type === 'Identifier' &&
+        specifier.imported.name === 'Config',
+    )
+  );
+}
+
+function isObjectCreate(node) {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'Object' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'create' &&
+    !(node.arguments[0]?.type === 'Literal' && node.arguments[0].value === null)
+  );
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require Config prototype derivation to go through deriveConfig.',
+    },
+    schema: [],
+    messages: {
+      useDeriveConfig:
+        'Do not derive Config with Object.create(). Use deriveConfig() or a specialized Config factory.',
+    },
+  },
+
+  create(context) {
+    let hasConfigImport = false;
+    const objectCreateCalls = [];
+
+    return {
+      ImportDeclaration(node) {
+        if (importsConfig(node)) hasConfigImport = true;
+      },
+      CallExpression(node) {
+        if (isObjectCreate(node)) objectCreateCalls.push(node);
+      },
+      'Program:exit'() {
+        if (!hasConfigImport) return;
+        for (const node of objectCreateCalls) {
+          context.report({ node, messageId: 'useDeriveConfig' });
+        }
+      },
+    };
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ import noCoreRootBarrelImport from './eslint-rules/no-core-root-barrel-import.js
 import noUtilsUpwardImport from './eslint-rules/no-utils-upward-import.js';
 import noCoreUtilsUpwardImport from './eslint-rules/no-core-utils-upward-import.js';
 import { legacyFilenames } from './eslint.legacy-filenames.mjs';
+import noConfigObjectCreate from './eslint-rules/no-config-object-create.js';
 
 // General syntax restrictions applied to every TS/TSX source file. Hoisted so
 // surface-specific overrides (flat config keeps only the last
@@ -333,6 +334,27 @@ export default tseslint.config(
     },
     rules: {
       'no-console': 'off',
+    },
+  },
+  {
+    files: ['packages/core/src/**/*.ts'],
+    ignores: [
+      'packages/core/src/config/config.ts',
+      '**/*.test.ts',
+      '**/*.spec.ts',
+      '**/__tests__/**',
+      '**/generated/**',
+      '**/*.generated.ts',
+    ],
+    plugins: {
+      'qwen-code': {
+        rules: {
+          'no-config-object-create': noConfigObjectCreate,
+        },
+      },
+    },
+    rules: {
+      'qwen-code/no-config-object-create': 'error',
     },
   },
   {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2132,10 +2132,8 @@ export class Config {
   private backgroundAgentResumeService?: BackgroundAgentResumeService;
   private readonly backgroundShellRegistry = new BackgroundShellRegistry();
   private readonly workflowRunRegistry = new WorkflowRunRegistry();
-  // Field initializer runs once on the parent Config; child Configs
-  // built via Object.create(parent) intentionally do NOT pick this up
-  // — see getFileReadCache() for the per-instance lazy initialization
-  // that keeps subagent caches isolated from the parent's.
+  // Derived Configs do not run field initializers. getFileReadCache()
+  // lazily installs an own cache to keep child state isolated.
   private fileReadCache: FileReadCache = new FileReadCache();
   private extensionManager!: ExtensionManager;
   private skillManager: SkillManager | null = null;
@@ -2324,8 +2322,8 @@ export class Config {
   private readonly chatRecordingFailureListeners =
     new Set<ChatRecordingFailureListener>();
   private fileCheckpointingEnabled: boolean;
-  // Object (not primitive) so sub-agents via Object.create(parentConfig)
-  // share the same budget instance through prototype lookup.
+  // Object state is intentionally shared by derived Configs through prototype
+  // lookup so every agent contributes to the same session budget.
   private readonly toolResultBudget = { bytesWritten: 0 };
   private fileHistoryService: FileHistoryService | undefined;
   private readonly proxy: string | undefined;
@@ -4370,9 +4368,8 @@ export class Config {
     // /clear or session resume would let a follow-up Read return the
     // placeholder despite the new session never having received the
     // file contents. Use the getter so the lazy own-property
-    // initialization in getFileReadCache() applies even for Configs
-    // constructed via Object.create — those should clear their own
-    // cache, not the parent's.
+    // initialization in getFileReadCache() applies even for derived Configs;
+    // each derived Config should clear its own cache, not the parent's.
     this.getFileReadCache().clear();
     this.toolResultBudget.bytesWritten = 0;
     this.getMemoryPressureMonitor()?.resetForNewSession();
@@ -7289,11 +7286,9 @@ export class Config {
   }
 
   /**
-   * Session-scoped memory pressure monitor. Child Configs created with
-   * `Object.create(parent)` inherit the parent's monitor through the prototype
-   * chain until this getter installs an own monitor backed by the inherited
-   * pressure config snapshot. This mirrors getFileReadCache()'s isolation
-   * contract while keeping type-safe direct field assignment inside the class.
+   * Session-scoped memory pressure monitor. Derived Configs inherit the
+   * parent's monitor until this getter installs an own monitor backed by the
+   * inherited pressure config snapshot. This mirrors getFileReadCache().
    */
   getMemoryPressureMonitor(): MemoryPressureMonitor | undefined {
     if (!Object.prototype.hasOwnProperty.call(this, 'memoryPressureMonitor')) {
@@ -8679,22 +8674,13 @@ export class Config {
    * subagent (which gets its own Config) does not inherit the parent's
    * recorded reads via the prototype chain.
    *
-   * The wrinkle: every subagent / scoped-agent / fork path in this
-   * codebase constructs its Config via `Object.create(parent)`. That
-   * does **not** run instance field initializers, so the parent's
-   * `fileReadCache` field is reachable on the child only by prototype
-   * lookup — i.e. child and parent end up sharing the same cache. The
-   * own-property check below detects "this instance was made by
-   * Object.create" and lazily attaches a fresh cache, ensuring
-   * isolation without requiring every Object.create site to remember
-   * to override the field.
+   * Derived Configs do not run instance field initializers, so the parent's
+   * `fileReadCache` is initially reachable through the prototype chain. The
+   * own-property check below lazily installs a fresh cache for each child.
    */
   getFileReadCache(): FileReadCache {
     if (!Object.prototype.hasOwnProperty.call(this, 'fileReadCache')) {
-      // The own-property write needs to bypass `private`'s structural
-      // check — the field is conceptually still private to the class,
-      // we just need TS to let us install an own copy on a child
-      // instance produced by `Object.create(parent)`.
+      // Install child-local state while keeping the field private to Config.
       (this as unknown as { fileReadCache: FileReadCache }).fileReadCache =
         new FileReadCache();
     }
@@ -8898,10 +8884,8 @@ export class Config {
     // in sync between them.
     //
     // Skipped when building a subagent-context registry. `this.jsonSchema`
-    // propagates to subagent overrides via prototype delegation
-    // (`Object.create(base)` in `createApprovalModeOverride` /
-    // `buildSubagentContextOverride`), but only `runNonInteractive`'s main
-    // and drain loops detect a successful structured_output call as
+    // propagates through Config derivation, but only `runNonInteractive`'s
+    // main and drain loops detect a successful structured_output call as
     // terminal. A subagent that called the tool would receive the
     // "Session will end now" llmContent, then keep running because its
     // own loop has no termination handler — wasted tokens with no
@@ -9191,9 +9175,9 @@ export class Config {
     // The ACP session's own registry is built before its constructor wires the
     // spawner, so that one is registered by the Session itself. Every registry
     // built afterwards reaches the spawner from here: sub-agent and override
-    // configs are `Object.create(base)`, and `copyDiscoveredToolsFrom` carries
-    // discovered tools only, so without this a daemon sub-agent would silently
-    // lose the tool.
+    // configs derive from the base Config, and `copyDiscoveredToolsFrom`
+    // carries discovered tools only, so without this a daemon sub-agent would
+    // silently lose the tool.
     if (this.getSubSessionSpawner()) {
       await registerLazy(ToolNames.CREATE_SUB_SESSION, async () => {
         const { CreateSubSessionTool } = await import(

--- a/packages/core/src/memory/memory-scoped-agent-config.ts
+++ b/packages/core/src/memory/memory-scoped-agent-config.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { PermissionManager } from '../permissions/permission-manager.js';
@@ -403,8 +403,7 @@ export function createMemoryScopedAgentConfig(
     },
   };
 
-  const scopedConfig = Object.create(config) as Config;
-  scopedConfig.getPermissionManager = () =>
-    scopedPm as unknown as PermissionManager;
-  return scopedConfig;
+  return deriveConfig(config, {
+    getPermissionManager: () => scopedPm as unknown as PermissionManager,
+  });
 }

--- a/packages/core/src/memory/remember.ts
+++ b/packages/core/src/memory/remember.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import { ToolNames } from '../tools/tool-names.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { runForkedAgent } from '../agents/forkedAgent.js';
@@ -106,15 +106,17 @@ function createHiddenRememberConfig(
   config: Config,
   options: { disableHooks?: boolean } = {},
 ): Config {
-  const hiddenConfig = Object.create(config) as Config;
-  hiddenConfig.getChatRecordingService = () => undefined;
-  hiddenConfig.getTranscriptPath = () => '';
-  if (options.disableHooks) {
-    hiddenConfig.getDisableAllHooks = () => true;
-    hiddenConfig.getHookSystem = () => undefined;
-    hiddenConfig.getMessageBus = () => undefined;
-  }
-  return hiddenConfig;
+  return deriveConfig(config, {
+    getChatRecordingService: () => undefined,
+    getTranscriptPath: () => '',
+    ...(options.disableHooks
+      ? {
+          getDisableAllHooks: () => true,
+          getHookSystem: () => undefined,
+          getMessageBus: () => undefined,
+        }
+      : {}),
+  });
 }
 
 function uniqueSortedScopes(scopes: Iterable<WorkspaceRememberScope>) {
@@ -165,14 +167,10 @@ export async function runManagedRememberByAgent(params: {
   // section — and in clean mode re-injecting parent-session memory into the
   // intended blank-slate agent. Zero it out for every mode so the section is
   // present exactly once, via the remember system prompt above.
-  const baseConfig = (() => {
-    const derived = Object.create(params.config) as Config;
-    derived.getAutoMemoryPrompt = () => '';
-    if (params.contextMode === 'clean') {
-      derived.getUserMemory = () => '';
-    }
-    return derived;
-  })();
+  const baseConfig = deriveConfig(params.config, {
+    getAutoMemoryPrompt: () => '',
+    ...(params.contextMode === 'clean' ? { getUserMemory: () => '' } : {}),
+  });
   const hiddenConfig = createHiddenRememberConfig(baseConfig, {
     disableHooks: params.contextMode === 'clean',
   });

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -7,7 +7,7 @@
 import type { Content } from '@google/genai';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import type { Config } from '../config/config.js';
+import { deriveConfig, type Config } from '../config/config.js';
 import type { PermissionManager } from '../permissions/permission-manager.js';
 import type {
   PermissionCheckContext,
@@ -256,10 +256,9 @@ export function createSkillScopedAgentConfig(
     },
   };
 
-  const scopedConfig = Object.create(config) as Config;
-  scopedConfig.getPermissionManager = () =>
-    scopedPm as unknown as PermissionManager;
-  return scopedConfig;
+  return deriveConfig(config, {
+    getPermissionManager: () => scopedPm as unknown as PermissionManager,
+  });
 }
 
 // Exported for tests so the `auto-skill-` prefix instruction stays asserted

--- a/scripts/tests/no-config-object-create.test.js
+++ b/scripts/tests/no-config-object-create.test.js
@@ -1,0 +1,43 @@
+import { Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+import rule from '../../eslint-rules/no-config-object-create.js';
+
+function verify(code) {
+  const linter = new Linter({ configType: 'eslintrc' });
+  linter.defineRule('qwen-code/no-config-object-create', rule);
+  return linter.verify(code, {
+    parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: { 'qwen-code/no-config-object-create': 'error' },
+  });
+}
+
+describe('no-config-object-create', () => {
+  it('rejects prototype derivation in a module that imports Config', () => {
+    const messages = verify(`
+      import { Config } from '../config/config.js';
+      const child = Object.create(parent);
+    `);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.messageId).toBe('useDeriveConfig');
+  });
+
+  it('allows deriveConfig and null-prototype dictionaries', () => {
+    expect(
+      verify(`
+        import { Config, deriveConfig } from '../config/config.js';
+        const child = deriveConfig(parent);
+        const dictionary = Object.create(null);
+      `),
+    ).toEqual([]);
+  });
+
+  it('ignores unrelated Config imports', () => {
+    expect(
+      verify(`
+        import { Config } from '../telemetry/config.js';
+        const error = Object.create(Object.getPrototypeOf(source));
+      `),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What this PR does

This PR migrates the remaining memory, remember, and skill-review Config overlays to the shared derivation boundary. Scoped permission managers, hidden transcript/hook views, and clean-memory views now express their existing getter overrides through the factory instead of constructing prototype children directly.

It also adds a production lint boundary for core modules that import the canonical Config: non-null `Object.create(...)` calls are rejected outside the factory implementation, while unrelated Config imports and null-prototype dictionaries remain allowed. The rule has focused positive and negative tests, and the ownership design records the enforcement.

This is stacked on #9918 and contains only the scoped-profile migration and enforcement relative to that PR.

## Why it's needed

After the worktree and agent-execution migrations, these four memory-related call sites were the last production Config prototype derivations outside the factory. Moving them closes the migration loop and makes the ownership boundary mechanically enforceable, so future scoped agents cannot silently recreate ad hoc overlays.

## Reviewer Test Plan

### How to verify

1. Confirm memory and skill-review scoped agents still expose their scoped permission manager while inheriting the parent Config otherwise.
2. Confirm managed remember still hides chat recording/transcript state, disables hooks only in clean mode, suppresses duplicate auto-memory content, and removes user memory only in clean mode.
3. Confirm the lint rule rejects non-null `Object.create(...)` in a core module importing the canonical Config, permits `deriveConfig`, permits `Object.create(null)`, and ignores unrelated Config imports.
4. Confirm a production-source search finds Config prototype construction only inside the factory implementation.

### Evidence (Before & After)

N/A — internal refactor and architecture enforcement with no user-visible behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22; clean dependency install and full repository build, full repository typecheck and lint, 69 focused memory/remember/skill-review tests, 3 focused lint-rule tests, and Prettier checks.

## Risk & Scope

- Main risk or tradeoff: the lint rule deliberately treats every non-null `Object.create(...)` in a canonical-Config-consuming production module as a possible boundary bypass; null-prototype dictionaries and unrelated Config imports are explicitly exempted.
- Not validated / out of scope: this PR does not alter memory permission decisions, prompts, persistence, or user-visible output; cross-platform behavior is delegated to CI.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #8083
Depends on #9918

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 将剩余的 memory、remember 和 skill-review Config overlay 迁移到共享派生边界。Scoped PermissionManager、隐藏 transcript/hook 的视图以及 clean-memory 视图现在都通过工厂表达原有 getter 覆盖，不再直接构造 prototype 子对象。

它还为导入规范 Config 的 core 生产模块增加 lint 边界：除工厂实现外，非 null 的 `Object.create(...)` 会被拒绝；其他同名 Config 导入和 null-prototype 字典仍被允许。规则包含聚焦的正反例测试，所有权设计文档也记录了这一约束。

这个 PR 堆叠在 #9918 之上，相对 #9918 只包含 scoped-profile 迁移和防回退约束。

## 为什么需要

完成 worktree 和 agent-execution 迁移后，这 4 个 memory 相关调用点是工厂外最后的生产 Config prototype 派生。迁移它们后可以闭合整个迁移环，并用机械规则守住所有权边界，避免未来的 scoped agent 再次静默创建临时 overlay。

## Reviewer Test Plan

### 如何验证

1. 确认 memory 和 skill-review scoped agent 仍暴露各自的 scoped PermissionManager，其余 Config 行为继续继承父级。
2. 确认 managed remember 仍隐藏 chat recording/transcript 状态，只在 clean mode 禁用 hooks，避免重复 auto-memory 内容，并且只在 clean mode 移除 user memory。
3. 确认 lint 规则会拒绝导入规范 Config 的 core 模块中的非 null `Object.create(...)`，允许 `deriveConfig`、允许 `Object.create(null)`，并忽略其他同名 Config 导入。
4. 确认生产源码搜索只在工厂实现内部找到 Config prototype 构造。

### Evidence (Before & After)

N/A —— 内部重构和架构约束，没有用户可见行为变化。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22；独立依赖安装与全仓构建、全仓 typecheck 和 lint、69 个聚焦 memory/remember/skill-review 测试、3 个聚焦 lint 规则测试，以及 Prettier 检查。

## Risk & Scope

- 主要风险或取舍：lint 规则会刻意把导入规范 Config 的生产模块中所有非 null `Object.create(...)` 都视为可能绕过边界；null-prototype 字典和其他同名 Config 导入已明确豁免。
- 未验证 / 范围外：这个 PR 不修改 memory 权限决策、prompt、持久化或用户可见输出；跨平台行为交给 CI 验证。
- 破坏性变更 / 迁移说明：无。

## Linked Issues

Refs #8083
依赖 #9918

</details>
