### PR TITLE
fix(java): read control response subtype from payload

### DIFF
--- a/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/session/Session.java
+++ b/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/session/Session.java
@@ -230,11 +230,15 @@ public class Session {
                             new TypeReference<CLIControlResponse<? extends ControlResponsePayload>>() {});
                     MyConcurrentUtils.runAndWait(() -> sessionEventConsumers.onControlResponse(this, controlResponse),
                             Optional.ofNullable(sessionEventConsumers.onControlResponseTimeout(this, controlResponse)).orElse(defaultEventTimeout));
-                    if (!"error".equals(jsonObject.getString("subtype"))) {
+                    String responseSubtype = Optional.ofNullable(controlResponse)
+                            .map(CLIControlResponse::getResponse)
+                            .map(CLIControlResponse.Response::getSubtype)
+                            .orElse(jsonObject.getString("subtype"));
+                    if (!"error".equals(responseSubtype)) {
                         return false;
                     } else {
                         log.info("control_response error: {}", jsonObject.toJSONString());
-                        return "error".equals(jsonObject.getString("subtype"));
+                        return true;
                     }
                 } else if ("control_request".equals(messageType)) {
                     CLIControlResponse<? extends ControlResponsePayload> controlResponse;

--- a/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/session/Session.java
+++ b/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/session/Session.java
@@ -230,16 +230,10 @@ public class Session {
                             new TypeReference<CLIControlResponse<? extends ControlResponsePayload>>() {});
                     MyConcurrentUtils.runAndWait(() -> sessionEventConsumers.onControlResponse(this, controlResponse),
                             Optional.ofNullable(sessionEventConsumers.onControlResponseTimeout(this, controlResponse)).orElse(defaultEventTimeout));
-                    String responseSubtype = Optional.ofNullable(controlResponse)
-                            .map(CLIControlResponse::getResponse)
-                            .map(CLIControlResponse.Response::getSubtype)
-                            .orElse(jsonObject.getString("subtype"));
-                    if (!"error".equals(responseSubtype)) {
-                        return false;
-                    } else {
-                        log.info("control_response error: {}", jsonObject.toJSONString());
-                        return true;
+                    if ("error".equals(getControlResponseSubtype(jsonObject, controlResponse))) {
+                        log.warn("control_response error: {}", jsonObject.toJSONString());
                     }
+                    return false;
                 } else if ("control_request".equals(messageType)) {
                     CLIControlResponse<? extends ControlResponsePayload> controlResponse;
                     try {
@@ -296,6 +290,22 @@ public class Session {
      */
     public Capabilities getCapabilities() {
         return Optional.ofNullable(lastCliControlInitializeResponse).map(CLIControlInitializeResponse::getCapabilities).orElse(new Capabilities());
+    }
+
+    private String getControlResponseSubtype(JSONObject jsonObject,
+            CLIControlResponse<? extends ControlResponsePayload> controlResponse) {
+        JSONObject responseObject = jsonObject.getJSONObject("response");
+        if (responseObject != null && responseObject.containsKey("subtype")) {
+            return responseObject.getString("subtype");
+        }
+        String topLevelSubtype = jsonObject.getString("subtype");
+        if (topLevelSubtype != null) {
+            return topLevelSubtype;
+        }
+        return Optional.ofNullable(controlResponse)
+                .map(CLIControlResponse::getResponse)
+                .map(CLIControlResponse.Response::getSubtype)
+                .orElse(null);
     }
 
     private void checkAvailable() throws SessionControlException {

--- a/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/session/Session.java
+++ b/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/session/Session.java
@@ -230,7 +230,7 @@ public class Session {
                             new TypeReference<CLIControlResponse<? extends ControlResponsePayload>>() {});
                     MyConcurrentUtils.runAndWait(() -> sessionEventConsumers.onControlResponse(this, controlResponse),
                             Optional.ofNullable(sessionEventConsumers.onControlResponseTimeout(this, controlResponse)).orElse(defaultEventTimeout));
-                    if ("error".equals(getControlResponseSubtype(jsonObject, controlResponse))) {
+                    if ("error".equals(getControlResponseSubtype(jsonObject))) {
                         log.warn("control_response error: {}", jsonObject.toJSONString());
                     }
                     return false;
@@ -292,20 +292,12 @@ public class Session {
         return Optional.ofNullable(lastCliControlInitializeResponse).map(CLIControlInitializeResponse::getCapabilities).orElse(new Capabilities());
     }
 
-    private String getControlResponseSubtype(JSONObject jsonObject,
-            CLIControlResponse<? extends ControlResponsePayload> controlResponse) {
+    private String getControlResponseSubtype(JSONObject jsonObject) {
         JSONObject responseObject = jsonObject.getJSONObject("response");
         if (responseObject != null && responseObject.containsKey("subtype")) {
             return responseObject.getString("subtype");
         }
-        String topLevelSubtype = jsonObject.getString("subtype");
-        if (topLevelSubtype != null) {
-            return topLevelSubtype;
-        }
-        return Optional.ofNullable(controlResponse)
-                .map(CLIControlResponse::getResponse)
-                .map(CLIControlResponse.Response::getSubtype)
-                .orElse(null);
+        return jsonObject.getString("subtype");
     }
 
     private void checkAvailable() throws SessionControlException {

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
@@ -14,6 +14,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.qwen.code.cli.QwenCodeCli;
 import com.alibaba.qwen.code.cli.protocol.data.AssistantUsage;
@@ -36,7 +39,6 @@ import com.alibaba.qwen.code.cli.session.exception.SessionSendPromptException;
 import com.alibaba.qwen.code.cli.transport.Transport;
 import com.alibaba.qwen.code.cli.transport.TransportOptions;
 import com.alibaba.qwen.code.cli.utils.Timeout;
-
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
@@ -47,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SessionTest {
 
@@ -268,22 +271,28 @@ class SessionTest {
         Session session = new Session(transport);
         AtomicInteger controlResponses = new AtomicInteger();
         AtomicInteger results = new AtomicInteger();
+        ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
 
-        session.sendPrompt("hello", new SessionEventSimpleConsumers() {
-            @Override
-            public void onControlResponse(Session session, CLIControlResponse<?> cliControlResponse) {
-                controlResponses.incrementAndGet();
-            }
+        try {
+            session.sendPrompt("hello", new SessionEventSimpleConsumers() {
+                @Override
+                public void onControlResponse(Session session, CLIControlResponse<?> cliControlResponse) {
+                    controlResponses.incrementAndGet();
+                }
 
-            @Override
-            public void onResultMessage(Session session, SDKResultMessage sdkResultMessage) {
-                results.incrementAndGet();
-            }
-        });
+                @Override
+                public void onResultMessage(Session session, SDKResultMessage sdkResultMessage) {
+                    results.incrementAndGet();
+                }
+            });
+        } finally {
+            detachSessionLogAppender(logAppender);
+        }
 
         assertEquals(3, transport.getProcessedPromptLineCount());
         assertEquals(1, controlResponses.get());
         assertEquals(1, results.get());
+        assertTrue(hasControlResponseErrorWarning(logAppender));
     }
 
     @Test
@@ -294,10 +303,16 @@ class SessionTest {
                 "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
 
         Session session = new Session(transport);
+        ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
 
-        session.sendPrompt("hello", new SessionEventSimpleConsumers());
+        try {
+            session.sendPrompt("hello", new SessionEventSimpleConsumers());
+        } finally {
+            detachSessionLogAppender(logAppender);
+        }
 
         assertEquals(2, transport.getProcessedPromptLineCount());
+        assertTrue(hasControlResponseErrorWarning(logAppender));
     }
 
     @Test
@@ -319,6 +334,28 @@ class SessionTest {
 
         assertEquals(2, transport.getProcessedPromptLineCount());
         assertEquals(1, results.get());
+    }
+
+    private static ListAppender<ILoggingEvent> attachSessionLogAppender() {
+        ch.qos.logback.classic.Logger sessionLogger = (ch.qos.logback.classic.Logger) LoggerFactory
+                .getLogger(Session.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        sessionLogger.addAppender(appender);
+        return appender;
+    }
+
+    private static void detachSessionLogAppender(ListAppender<ILoggingEvent> appender) {
+        ch.qos.logback.classic.Logger sessionLogger = (ch.qos.logback.classic.Logger) LoggerFactory
+                .getLogger(Session.class);
+        sessionLogger.detachAppender(appender);
+        appender.stop();
+    }
+
+    private static boolean hasControlResponseErrorWarning(ListAppender<ILoggingEvent> appender) {
+        return appender.list.stream()
+                .anyMatch(event -> event.getLevel().equals(Level.WARN)
+                        && event.getFormattedMessage().contains("control_response error"));
     }
 
     @Test

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
@@ -49,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SessionTest {
@@ -292,7 +293,7 @@ class SessionTest {
         assertEquals(3, transport.getProcessedPromptLineCount());
         assertEquals(1, controlResponses.get());
         assertEquals(1, results.get());
-        assertTrue(hasControlResponseErrorWarning(logAppender));
+        assertTrue(hasControlResponseErrorWarning(logAppender, "set model failed"));
     }
 
     @Test
@@ -312,7 +313,28 @@ class SessionTest {
         }
 
         assertEquals(2, transport.getProcessedPromptLineCount());
-        assertTrue(hasControlResponseErrorWarning(logAppender));
+        assertTrue(hasControlResponseErrorWarning(logAppender, "set model failed"));
+    }
+
+    @Test
+    void sendPromptUsesTopLevelSubtypeWhenResponseObjectIsMissing()
+            throws SessionControlException, SessionSendPromptException {
+        FakeTransport transport = new FakeTransport(
+                "{\"type\":\"control_response\",\"subtype\":\"error\",\"request_id\":\"set-model\","
+                        + "\"error\":\"set model failed\"}",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+
+        Session session = new Session(transport);
+        ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
+
+        try {
+            session.sendPrompt("hello", new SessionEventSimpleConsumers());
+        } finally {
+            detachSessionLogAppender(logAppender);
+        }
+
+        assertEquals(2, transport.getProcessedPromptLineCount());
+        assertTrue(hasControlResponseErrorWarning(logAppender, "set model failed"));
     }
 
     @Test
@@ -323,17 +345,52 @@ class SessionTest {
                 "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
 
         Session session = new Session(transport);
+        AtomicInteger controlResponses = new AtomicInteger();
         AtomicInteger results = new AtomicInteger();
+        ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
 
-        session.sendPrompt("hello", new SessionEventSimpleConsumers() {
-            @Override
-            public void onResultMessage(Session session, SDKResultMessage sdkResultMessage) {
-                results.incrementAndGet();
-            }
-        });
+        try {
+            session.sendPrompt("hello", new SessionEventSimpleConsumers() {
+                @Override
+                public void onControlResponse(Session session, CLIControlResponse<?> cliControlResponse) {
+                    controlResponses.incrementAndGet();
+                }
+
+                @Override
+                public void onResultMessage(Session session, SDKResultMessage sdkResultMessage) {
+                    results.incrementAndGet();
+                }
+            });
+        } finally {
+            detachSessionLogAppender(logAppender);
+        }
 
         assertEquals(2, transport.getProcessedPromptLineCount());
+        assertEquals(1, controlResponses.get());
         assertEquals(1, results.get());
+        assertFalse(hasControlResponseErrorWarning(logAppender, "ok"));
+    }
+
+    @Test
+    void sendPromptDoesNotWarnWhenControlResponseSubtypeIsNotExactError()
+            throws SessionControlException, SessionSendPromptException {
+        FakeTransport transport = new FakeTransport(
+                "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"error_extra\","
+                        + "\"error\":\"not an exact error subtype\"}}",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+
+        Session session = new Session(transport);
+        ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
+
+        try {
+            session.sendPrompt("hello", new SessionEventSimpleConsumers());
+        } finally {
+            detachSessionLogAppender(logAppender);
+        }
+
+        assertEquals(2, transport.getProcessedPromptLineCount());
+        assertFalse(
+                hasControlResponseErrorWarning(logAppender, "not an exact error subtype"));
     }
 
     private static ListAppender<ILoggingEvent> attachSessionLogAppender() {
@@ -352,10 +409,12 @@ class SessionTest {
         appender.stop();
     }
 
-    private static boolean hasControlResponseErrorWarning(ListAppender<ILoggingEvent> appender) {
+    private static boolean hasControlResponseErrorWarning(
+            ListAppender<ILoggingEvent> appender, String expectedPayload) {
         return appender.list.stream()
                 .anyMatch(event -> event.getLevel().equals(Level.WARN)
-                        && event.getFormattedMessage().contains("control_response error"));
+                        && event.getFormattedMessage().contains("control_response error")
+                        && event.getFormattedMessage().contains(expectedPayload));
     }
 
     @Test

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
@@ -261,7 +261,7 @@ class SessionTest {
     void sendPromptDrainsTurnWhenControlResponseSubtypeIsNestedError() throws SessionControlException, SessionSendPromptException {
         FakeTransport transport = new FakeTransport(
                 "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"error\","
-                        + "\"response\":{\"message\":\"set model failed\"}}}",
+                        + "\"error\":\"set model failed\"}}",
                 "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"still consumed\"}]}}",
                 "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
 
@@ -290,7 +290,7 @@ class SessionTest {
     void sendPromptUsesTopLevelSubtypeWhenNestedSubtypeIsMissing() throws SessionControlException, SessionSendPromptException {
         FakeTransport transport = new FakeTransport(
                 "{\"type\":\"control_response\",\"subtype\":\"error\",\"response\":{\"request_id\":\"set-model\","
-                        + "\"response\":{\"message\":\"set model failed\"}}}",
+                        + "\"error\":\"set model failed\"}}",
                 "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
 
         Session session = new Session(transport);

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
@@ -258,17 +258,67 @@ class SessionTest {
     }
 
     @Test
-    void sendPromptStopsWhenControlResponseSubtypeIsNestedError() throws SessionControlException, SessionSendPromptException {
+    void sendPromptDrainsTurnWhenControlResponseSubtypeIsNestedError() throws SessionControlException, SessionSendPromptException {
         FakeTransport transport = new FakeTransport(
                 "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"error\","
                         + "\"response\":{\"message\":\"set model failed\"}}}",
-                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"should not be read\"}]}}");
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"still consumed\"}]}}",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+
+        Session session = new Session(transport);
+        AtomicInteger controlResponses = new AtomicInteger();
+        AtomicInteger results = new AtomicInteger();
+
+        session.sendPrompt("hello", new SessionEventSimpleConsumers() {
+            @Override
+            public void onControlResponse(Session session, CLIControlResponse<?> cliControlResponse) {
+                controlResponses.incrementAndGet();
+            }
+
+            @Override
+            public void onResultMessage(Session session, SDKResultMessage sdkResultMessage) {
+                results.incrementAndGet();
+            }
+        });
+
+        assertEquals(3, transport.getProcessedPromptLineCount());
+        assertEquals(1, controlResponses.get());
+        assertEquals(1, results.get());
+    }
+
+    @Test
+    void sendPromptUsesTopLevelSubtypeWhenNestedSubtypeIsMissing() throws SessionControlException, SessionSendPromptException {
+        FakeTransport transport = new FakeTransport(
+                "{\"type\":\"control_response\",\"subtype\":\"error\",\"response\":{\"request_id\":\"set-model\","
+                        + "\"response\":{\"message\":\"set model failed\"}}}",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
 
         Session session = new Session(transport);
 
         session.sendPrompt("hello", new SessionEventSimpleConsumers());
 
-        assertEquals(1, transport.getProcessedPromptLineCount());
+        assertEquals(2, transport.getProcessedPromptLineCount());
+    }
+
+    @Test
+    void sendPromptContinuesAfterNestedControlResponseSuccess() throws SessionControlException, SessionSendPromptException {
+        FakeTransport transport = new FakeTransport(
+                "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"success\","
+                        + "\"response\":{\"message\":\"ok\"}}}",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+
+        Session session = new Session(transport);
+        AtomicInteger results = new AtomicInteger();
+
+        session.sendPrompt("hello", new SessionEventSimpleConsumers() {
+            @Override
+            public void onResultMessage(Session session, SDKResultMessage sdkResultMessage) {
+                results.incrementAndGet();
+            }
+        });
+
+        assertEquals(2, transport.getProcessedPromptLineCount());
+        assertEquals(1, results.get());
     }
 
     @Test

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
@@ -267,7 +267,8 @@ class SessionTest {
                 "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"error\","
                         + "\"error\":\"set model failed\"}}",
                 "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"still consumed\"}]}}",
-                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"canary\"}]}}");
 
         Session session = new Session(transport);
         AtomicInteger controlResponses = new AtomicInteger();
@@ -301,7 +302,8 @@ class SessionTest {
         FakeTransport transport = new FakeTransport(
                 "{\"type\":\"control_response\",\"subtype\":\"error\",\"response\":{\"request_id\":\"set-model\","
                         + "\"error\":\"set model failed\"}}",
-                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"canary\"}]}}");
 
         Session session = new Session(transport);
         ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
@@ -322,7 +324,8 @@ class SessionTest {
         FakeTransport transport = new FakeTransport(
                 "{\"type\":\"control_response\",\"subtype\":\"error\",\"request_id\":\"set-model\","
                         + "\"error\":\"set model failed\"}",
-                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"canary\"}]}}");
 
         Session session = new Session(transport);
         ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
@@ -342,7 +345,8 @@ class SessionTest {
         FakeTransport transport = new FakeTransport(
                 "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"success\","
                         + "\"response\":{\"message\":\"ok\"}}}",
-                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"canary\"}]}}");
 
         Session session = new Session(transport);
         AtomicInteger controlResponses = new AtomicInteger();
@@ -377,7 +381,8 @@ class SessionTest {
         FakeTransport transport = new FakeTransport(
                 "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"error_extra\","
                         + "\"error\":\"not an exact error subtype\"}}",
-                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}");
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"canary\"}]}}");
 
         Session session = new Session(transport);
         ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
@@ -391,6 +396,50 @@ class SessionTest {
         assertEquals(2, transport.getProcessedPromptLineCount());
         assertFalse(
                 hasControlResponseErrorWarning(logAppender, "not an exact error subtype"));
+    }
+
+    @Test
+    void sendPromptDoesNotWarnWhenControlResponseSubtypeIsProgress()
+            throws SessionControlException, SessionSendPromptException {
+        FakeTransport transport = new FakeTransport(
+                "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"progress\","
+                        + "\"response\":{\"message\":\"still working\"}}}",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"canary\"}]}}");
+
+        Session session = new Session(transport);
+        ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
+
+        try {
+            session.sendPrompt("hello", new SessionEventSimpleConsumers());
+        } finally {
+            detachSessionLogAppender(logAppender);
+        }
+
+        assertEquals(2, transport.getProcessedPromptLineCount());
+        assertFalse(hasControlResponseErrorWarning(logAppender, "still working"));
+    }
+
+    @Test
+    void sendPromptDoesNotWarnWhenControlResponseSubtypeIsMissing()
+            throws SessionControlException, SessionSendPromptException {
+        FakeTransport transport = new FakeTransport(
+                "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\","
+                        + "\"response\":{\"message\":\"no subtype\"}}}",
+                "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"canary\"}]}}");
+
+        Session session = new Session(transport);
+        ListAppender<ILoggingEvent> logAppender = attachSessionLogAppender();
+
+        try {
+            session.sendPrompt("hello", new SessionEventSimpleConsumers());
+        } finally {
+            detachSessionLogAppender(logAppender);
+        }
+
+        assertEquals(2, transport.getProcessedPromptLineCount());
+        assertFalse(hasControlResponseErrorWarning(logAppender, "no subtype"));
     }
 
     private static ListAppender<ILoggingEvent> attachSessionLogAppender() {

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/session/SessionTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import com.alibaba.fastjson2.JSON;
@@ -45,11 +46,16 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class SessionTest {
 
     private static final Logger log = LoggerFactory.getLogger(SessionTest.class);
     private static final String INIT_RESPONSE = "{\"type\":\"control_response\",\"response\":{\"subtype\":\"success\","
             + "\"response\":{\"subtype\":\"initialize\",\"capabilities\":{}}}}";
+    private static final String INITIALIZE_RESPONSE
+            = "{\"type\":\"control_response\",\"response\":{\"request_id\":\"init\",\"subtype\":\"success\","
+            + "\"response\":{\"subtype\":\"initialize\",\"session_id\":\"session-test\"}}}";
 
     @TempDir
     Path tempDir;
@@ -252,6 +258,20 @@ class SessionTest {
     }
 
     @Test
+    void sendPromptStopsWhenControlResponseSubtypeIsNestedError() throws SessionControlException, SessionSendPromptException {
+        FakeTransport transport = new FakeTransport(
+                "{\"type\":\"control_response\",\"response\":{\"request_id\":\"set-model\",\"subtype\":\"error\","
+                        + "\"response\":{\"message\":\"set model failed\"}}}",
+                "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"should not be read\"}]}}");
+
+        Session session = new Session(transport);
+
+        session.sendPrompt("hello", new SessionEventSimpleConsumers());
+
+        assertEquals(1, transport.getProcessedPromptLineCount());
+    }
+
+    @Test
     void testJSON() {
         String json
                 = "{\"type\":\"assistant\",\"uuid\":\"ed8374fe-a4eb-4fc0-9780-9bd2fd831cda\","
@@ -316,6 +336,61 @@ class SessionTest {
 
         @Override
         public void inputNoWaitResponse(String message) throws IOException {
+        }
+    }
+
+    private static class FakeTransport implements Transport {
+        private final String[] promptLines;
+        private final AtomicInteger processedPromptLineCount = new AtomicInteger();
+
+        FakeTransport(String... promptLines) {
+            this.promptLines = promptLines;
+        }
+
+        @Override
+        public TransportOptions getTransportOptions() {
+            return new TransportOptions();
+        }
+
+        @Override
+        public boolean isReading() {
+            return false;
+        }
+
+        @Override
+        public void start() throws IOException {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return true;
+        }
+
+        @Override
+        public String inputWaitForOneLine(String message) {
+            return INITIALIZE_RESPONSE;
+        }
+
+        @Override
+        public void inputWaitForMultiLine(String message, Function<String, Boolean> callBackFunction) {
+            for (String line : promptLines) {
+                processedPromptLineCount.incrementAndGet();
+                if (callBackFunction.apply(line)) {
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public void inputNoWaitResponse(String message) throws IOException {
+        }
+
+        int getProcessedPromptLineCount() {
+            return processedPromptLineCount.get();
         }
     }
 }


### PR DESCRIPTION
## What this PR does

Updates the Java SDK session response handling to read `control_response` status from the nested `response.subtype` field, matching the CLI wire format. It keeps the legacy top-level `subtype` lookup as a fallback, drains the rest of the current turn, and logs nested or top-level error control responses.

## Why it's needed

The current code checks the top-level `subtype`, but CLI control responses carry the status under `response.subtype`. That makes the error branch unreachable for real responses, so Java sessions miss the warning signal for control errors in normal daemon responses. The regression coverage also pins the drain-to-result behavior, non-error dispatch, and no-warning behavior for neutral or missing subtypes.

## Reviewer Test Plan

### How to verify

Run these tests in `packages/sdk-java/qwencode`:

- `mvn test -Dtest=SessionTest#sendPromptDrainsTurnWhenControlResponseSubtypeIsNestedError`
- `mvn test -Dtest=SessionTest#sendPromptUsesTopLevelSubtypeWhenNestedSubtypeIsMissing`
- `mvn test -Dtest=SessionTest#sendPromptUsesTopLevelSubtypeWhenResponseObjectIsMissing`
- `mvn test -Dtest=SessionTest#sendPromptContinuesAfterNestedControlResponseSuccess`
- `mvn test -Dtest=SessionTest#sendPromptDoesNotWarnWhenControlResponseSubtypeIsNotExactError`
- `mvn test -Dtest=SessionTest#sendPromptDoesNotWarnWhenControlResponseSubtypeIsProgress`
- `mvn test -Dtest=SessionTest#sendPromptDoesNotWarnWhenControlResponseSubtypeIsMissing`

The regression tests feed nested, legacy top-level, and response-less `error` control responses; verify prompt turns stop at the `result` line instead of consuming canary output; assert error responses emit the `control_response error` warning; assert success/progress/missing subtypes do not emit that warning; and assert non-error control responses still reach `onControlResponse`.

### Evidence (Before & After)

N/A for UI. Static local checks: `git diff --check` passed. Local Java test execution was not available because this machine has no Maven (`mvn: command not found`); the GitHub Java SDK matrix should provide runtime verification.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | partially tested: `git diff --check` only |
| Windows | not tested locally; covered by CI |
|  Linux  | not tested locally; covered by CI |

### Environment (optional)

Local machine lacks Maven, so Java runtime verification is delegated to CI.

## Risk & Scope

- Main risk or tradeoff: low; the change only affects Java SDK `control_response` subtype detection for warning logs and preserves the old top-level subtype fallback.
- Not validated / out of scope: full local Maven test execution; broader Java SDK integration behavior beyond this subtype path.
- Breaking changes / migration notes: none.

## Linked Issues

References #8835 (`java-session-control-response-subtype-wrong-level`).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

更新 Java SDK 的 session 响应处理逻辑，从嵌套的 `response.subtype` 字段读取 `control_response` 状态，以匹配 CLI wire format。代码保留旧的顶层 `subtype` 读取作为兜底，继续 drain 当前 turn，并在嵌套或顶层 error control response 出现时记录 warning 日志。

## 为什么需要

当前代码检查顶层 `subtype`，但 CLI control response 的状态实际在 `response.subtype` 下。真实响应会导致 error 分支不可达，因此 Java session 会错过普通 daemon 响应里的 control error warning 信号。回归测试也钉住了 drain 到 result 的行为、非 error 控制响应分发，以及中性或缺失 subtype 不应误报警告的行为。

## Reviewer Test Plan

### 如何验证

在 `packages/sdk-java/qwencode` 下运行：

- `mvn test -Dtest=SessionTest#sendPromptDrainsTurnWhenControlResponseSubtypeIsNestedError`
- `mvn test -Dtest=SessionTest#sendPromptUsesTopLevelSubtypeWhenNestedSubtypeIsMissing`
- `mvn test -Dtest=SessionTest#sendPromptUsesTopLevelSubtypeWhenResponseObjectIsMissing`
- `mvn test -Dtest=SessionTest#sendPromptContinuesAfterNestedControlResponseSuccess`
- `mvn test -Dtest=SessionTest#sendPromptDoesNotWarnWhenControlResponseSubtypeIsNotExactError`
- `mvn test -Dtest=SessionTest#sendPromptDoesNotWarnWhenControlResponseSubtypeIsProgress`
- `mvn test -Dtest=SessionTest#sendPromptDoesNotWarnWhenControlResponseSubtypeIsMissing`

回归测试会喂入嵌套、旧顶层和缺少 response 对象的 `error` control response；验证 prompt turn 在 `result` 行结束而不会消费 canary 输出；断言 error response 会输出 `control_response error` warning；断言 success/progress/缺失 subtype 不会误报该 warning；并断言非 error control response 仍会分发给 `onControlResponse`。

### 证据（Before & After）

非 UI 改动，N/A。本地静态检查：`git diff --check` 通过。本机缺少 Maven（`mvn: command not found`），无法执行本地 Java 测试；运行时验证依赖 GitHub 的 Java SDK matrix。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  macOS  | 部分验证：仅 `git diff --check` |
| Windows | 本地未测试；由 CI 覆盖 |
|  Linux  | 本地未测试；由 CI 覆盖 |

### 环境（可选）

本机缺少 Maven，因此 Java 运行时验证交给 CI。

## 风险和范围

- 主要风险或取舍：低；改动只影响 Java SDK 的 `control_response` subtype 检测和 warning 日志，并保留旧顶层 subtype 兜底。
- 未验证 / 范围外：本地完整 Maven 测试；除此 subtype 路径外的更广 Java SDK 集成行为。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #8835（`java-session-control-response-subtype-wrong-level`）。

</details>