### PR TITLE
fix(core): ignore blank task list filters

### DIFF
--- a/packages/core/src/tools/task-list.test.ts
+++ b/packages/core/src/tools/task-list.test.ts
@@ -130,6 +130,36 @@ describe('TaskListTool', () => {
     expect(result.llmContent).toContain('Legacy');
   });
 
+  it('treats a blank owner filter as omitted', async () => {
+    const t = await createTask(TEAM, {
+      subject: 'Owned',
+      description: 'desc',
+    });
+    await updateTask(TEAM, t.id, { owner: 'alice' });
+
+    const invocation = tool.build({ owner: '   ' });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.llmContent).toContain('Owned');
+    expect(result.llmContent).not.toContain('No tasks found');
+  });
+
+  it('treats a blank blockedBy filter as omitted', async () => {
+    const dependency = await createTask(TEAM, {
+      subject: 'Dependency',
+      description: 'desc',
+    });
+    const blocked = await createTask(TEAM, {
+      subject: 'Blocked',
+      description: 'desc',
+    });
+    await updateTask(TEAM, blocked.id, { addBlockedBy: [dependency.id] });
+
+    const invocation = tool.build({ blockedBy: '' });
+    const result = await invocation.execute(new AbortController().signal);
+    expect(result.llmContent).toContain('Blocked');
+    expect(result.llmContent).not.toContain('No tasks found');
+  });
+
   it('rejects owner filters that sanitize to empty', async () => {
     const invocation = tool.build({ owner: '!!!' });
     const result = await invocation.execute(new AbortController().signal);

--- a/packages/core/src/tools/task-list.ts
+++ b/packages/core/src/tools/task-list.ts
@@ -66,9 +66,12 @@ class TaskListInvocation extends BaseToolInvocation<
       };
     }
 
+    const ownerParam = this.params.owner?.trim() || undefined;
+    const blockedByParam = this.params.blockedBy?.trim() || undefined;
+
     let ownerFilter: string | undefined;
-    if (this.params.owner !== undefined) {
-      ownerFilter = sanitizeName(this.params.owner);
+    if (ownerParam !== undefined) {
+      ownerFilter = sanitizeName(ownerParam);
       if (!ownerFilter) {
         const msg =
           'Cannot filter by owner: owner must include at least one ' +
@@ -84,7 +87,7 @@ class TaskListInvocation extends BaseToolInvocation<
     const tasks = await listTasks(teamName, {
       status: this.params.status,
       owner: ownerFilter,
-      blockedBy: this.params.blockedBy,
+      blockedBy: blockedByParam,
     });
 
     if (tasks.length === 0) {


### PR DESCRIPTION
## What this PR does

- Treats blank `task_list` `owner` and `blockedBy` filter strings as omitted optional filters.
- Adds regression coverage for blank owner and blocked-by filters.

## Why it's needed

Blank optional filters currently activate literal filtering, which can make a populated task list appear empty or reject an otherwise omitted owner filter. Normalizing blanks at the tool boundary matches the public optional-filter contract without changing nonblank validation behavior.

Fixes #9281.

## Reviewer Test Plan

- `npx vitest run packages/core/src/tools/task-list.test.ts -t "treats a blank"`
- `npx vitest run packages/core/src/tools/task-list.test.ts`
- `npx prettier --check packages/core/src/tools/task-list.ts packages/core/src/tools/task-list.test.ts`

## Notes

<details>
<summary>中文说明</summary>

本 PR 修复 `task_list` 对空白 `owner` / `blockedBy` 可选过滤参数的处理：空白字符串现在会被视为未传入，而不是触发空结果或 owner 校验错误。非空但非法的 owner（例如 `!!!`）仍然保持原有拒绝行为。

</details>