### PR TITLE
fix(acp-bridge): refresh artifact updatedAt on material changes

### DIFF
--- a/packages/acp-bridge/src/sessionArtifacts.test.ts
+++ b/packages/acp-bridge/src/sessionArtifacts.test.ts
@@ -5345,3 +5345,177 @@ describe('SessionArtifactStore', () => {
     });
   });
 });
+
+describe('SessionArtifactStore updatedAt freshness (issue 9927)', () => {
+  let workspace: string;
+
+  beforeEach(async () => {
+    workspace = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'qwen-artifacts-9927-'),
+    );
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await fs.rm(workspace, { recursive: true, force: true });
+  });
+
+  it('stamps updatedAt when workspace content drifts without a re-register', async () => {
+    const store = new SessionArtifactStore({
+      sessionId: 's9927-drift',
+      workspaceCwd: workspace,
+    });
+    await fs.writeFile(
+      path.join(workspace, 'report.html'),
+      '<html>hello</html>',
+    );
+    const created = await store.upsertMany(
+      [{ title: 'Report', workspacePath: 'report.html' }],
+      { strict: true },
+    );
+    const artifactId = created.changes[0]!.artifactId;
+    const initial = created.changes[0]!.artifact!;
+    expect(initial.updatedAt).toBe(initial.createdAt);
+
+    // Same-length rewrite: sizeBytes alone cannot signal the change.
+    await fs.writeFile(
+      path.join(workspace, 'report.html'),
+      '<html>HELLO</html>',
+    );
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(path.join(workspace, 'report.html'), future, future);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() + 6_000));
+    const observed = await store.get(artifactId);
+    expect(observed).toMatchObject({ id: artifactId, status: 'changed' });
+    expect(observed?.sizeBytes).toBe(Buffer.byteLength('<html>HELLO</html>'));
+    expect(observed?.createdAt).toBe(initial.createdAt);
+    expect(observed?.updatedAt).not.toBe(initial.createdAt);
+  });
+
+  it('stamps updatedAt when the workspace file disappears', async () => {
+    const store = new SessionArtifactStore({
+      sessionId: 's9927-missing',
+      workspaceCwd: workspace,
+    });
+    await fs.writeFile(path.join(workspace, 'note.txt'), 'note');
+    const created = await store.upsertMany(
+      [{ title: 'Note', workspacePath: 'note.txt' }],
+      { strict: true },
+    );
+    const artifactId = created.changes[0]!.artifactId;
+    const initial = created.changes[0]!.artifact!;
+
+    await fs.rm(path.join(workspace, 'note.txt'));
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() + 6_000));
+    const observed = await store.get(artifactId);
+    expect(observed).toMatchObject({ id: artifactId, status: 'missing' });
+    expect(observed?.createdAt).toBe(initial.createdAt);
+    expect(observed?.updatedAt).not.toBe(initial.createdAt);
+  });
+
+  it('keeps updatedAt stable while unchanged content is re-stated', async () => {
+    const store = new SessionArtifactStore({
+      sessionId: 's9927-stable',
+      workspaceCwd: workspace,
+    });
+    await fs.writeFile(path.join(workspace, 'stable.txt'), 'stable');
+    const created = await store.upsertMany(
+      [{ title: 'Stable', workspacePath: 'stable.txt' }],
+      { strict: true },
+    );
+    const artifactId = created.changes[0]!.artifactId;
+    const initial = created.changes[0]!.artifact!;
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() + 6_000));
+    const observed = await store.get(artifactId);
+    expect(observed).toMatchObject({
+      id: artifactId,
+      status: 'available',
+      createdAt: initial.createdAt,
+      updatedAt: initial.updatedAt,
+    });
+  });
+
+  it('stamps updatedAt on the removed snapshot', async () => {
+    const store = new SessionArtifactStore({
+      sessionId: 's9927-remove',
+      workspaceCwd: workspace,
+    });
+    const created = await store.upsertMany(
+      [{ title: 'Link', url: 'https://example.com/a' }],
+      { strict: true },
+    );
+    const snapshot = created.changes[0]!.artifact!;
+    expect(snapshot.updatedAt).toBe(snapshot.createdAt);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() + 60_000));
+    const removed = await store.remove(snapshot.id);
+    expect(removed.changes).toHaveLength(1);
+    expect(removed.changes[0]).toMatchObject({ action: 'removed' });
+    expect(removed.changes[0]!.artifact!.createdAt).toBe(snapshot.createdAt);
+    expect(removed.changes[0]!.artifact!.updatedAt).not.toBe(
+      snapshot.createdAt,
+    );
+  });
+
+  it('stamps updatedAt when republished content changes at the same byte length', async () => {
+    const store = new SessionArtifactStore({
+      sessionId: 's9927-published',
+      workspaceCwd: workspace,
+    });
+    const bodyA = '<html>body-a</html>';
+    const bodyB = '<html>body-b</html>';
+    expect(Buffer.byteLength(bodyA)).toBe(Buffer.byteLength(bodyB));
+    const input = (body: string) => ({
+      title: 'Page',
+      storage: 'published' as const,
+      managedId: 'managed-page',
+      url: 'https://example.com/page',
+      mimeType: 'text/html',
+      sizeBytes: Buffer.byteLength(body),
+      metadata: {
+        'qwen.published.sha256': createHash('sha256')
+          .update(body)
+          .digest('hex'),
+      },
+    });
+
+    const created = await store.upsertMany([input(bodyA)], {
+      strict: true,
+      trustedPublisher: true,
+    });
+    const initial = created.changes[0]!.artifact!;
+    expect(initial.updatedAt).toBe(initial.createdAt);
+
+    // Same byte length, different content fingerprint.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.now() + 60_000));
+    const republished = await store.upsertMany([input(bodyB)], {
+      strict: true,
+      trustedPublisher: true,
+    });
+    expect(republished.changes).toHaveLength(1);
+    expect(republished.changes[0]).toMatchObject({ action: 'updated' });
+    expect(republished.changes[0]!.artifact!.createdAt).toBe(initial.createdAt);
+    expect(republished.changes[0]!.artifact!.updatedAt).not.toBe(
+      initial.createdAt,
+    );
+
+    // Identical republish stays a no-op and must not refresh updatedAt.
+    vi.setSystemTime(new Date(Date.now() + 120_000));
+    const noop = await store.upsertMany([input(bodyB)], {
+      strict: true,
+      trustedPublisher: true,
+    });
+    expect(noop.changes).toEqual([]);
+    const listed = await store.list();
+    expect(listed.artifacts[0]?.updatedAt).toBe(
+      republished.changes[0]!.artifact!.updatedAt,
+    );
+  });
+});

--- a/packages/acp-bridge/src/sessionArtifacts.ts
+++ b/packages/acp-bridge/src/sessionArtifacts.ts
@@ -17,6 +17,7 @@ import {
   MAX_DIRECTORY_ARTIFACT_DEPTH,
   MAX_DIRECTORY_ARTIFACT_FILES,
   metadataBudgetBytes,
+  PUBLISHED_CONTENT_SHA256_METADATA_KEY,
   SESSION_ARTIFACT_PERSISTENCE_VERSION,
   pathHasSkippedDirectoryComponent,
   stableSessionArtifactId,
@@ -419,6 +420,7 @@ export class SessionArtifactStore {
           const updated = mergeArtifact(existing, artifact);
           if (updated.changed) {
             if (updated.artifact.id !== existing.id) {
+              stampRemovedAt(existing);
               const removeChange: InternalSessionArtifactChange = {
                 action: 'removed',
                 artifactId: existing.id,
@@ -432,6 +434,7 @@ export class SessionArtifactStore {
               changes.push(removeChange);
               this.artifacts.delete(existing.id);
             } else if (shouldRecordEphemeralUnpin(existing, artifact)) {
+              stampRemovedAt(existing);
               changes.push({
                 action: 'removed',
                 artifactId: existing.id,
@@ -612,10 +615,14 @@ export class SessionArtifactStore {
       // Tool/hook artifacts are session-scoped outputs and may be removed by
       // any caller that already passed session mutation auth.
       this.denyCrossClientMutation('remove', artifactId, existing, options);
+      // Stamp a copy, not the live object: if durable tombstone persistence
+      // fails below, the rollback snapshot must keep the pre-removal state.
+      const removedSnapshot: StoredArtifact = { ...existing };
+      stampRemovedAt(removedSnapshot);
       const removeChange: InternalSessionArtifactChange = {
         action: 'removed',
         artifactId,
-        artifact: toPublicArtifact(existing),
+        artifact: toPublicArtifact(removedSnapshot),
         reason: 'explicit',
         durableTombstoneRequired:
           existing.durableTombstoneRequired ||
@@ -1701,6 +1708,8 @@ export class SessionArtifactStore {
     if (!artifact.workspacePath) {
       return;
     }
+    const previousStatus = artifact.status;
+    const previousSizeBytes = artifact.sizeBytes;
     try {
       const status = await getWorkspaceStatus(
         artifact.workspacePath,
@@ -1713,9 +1722,9 @@ export class SessionArtifactStore {
       );
       const changed = isWorkspaceContentChanged(artifact, status);
       artifact.status = changed ? 'changed' : status.status;
-      if (!changed) {
-        artifact.sizeBytes = status.sizeBytes;
-      }
+      // Report the currently observed size even when the content drifted, so
+      // the public field does not lag behind the file on disk.
+      artifact.sizeBytes = status.sizeBytes;
       if (status.escaped) {
         artifact.status = 'missing';
         artifact.sizeBytes = undefined;
@@ -1733,7 +1742,15 @@ export class SessionArtifactStore {
         artifact.sizeBytes = undefined;
         artifact.lastStatAt = options.now ?? Date.now();
       }
-      return;
+    }
+    // Material changes (content drift or a reachability transition) must move
+    // updatedAt; clients such as the Web Shell preview cache on it. Unchanged
+    // re-stats and same-identity no-op upserts must keep it stable.
+    if (
+      artifact.status !== previousStatus ||
+      artifact.sizeBytes !== previousSizeBytes
+    ) {
+      artifact.updatedAt = new Date().toISOString();
     }
   }
 
@@ -1795,6 +1812,7 @@ export class SessionArtifactStore {
       candidates.splice(candidates.indexOf(artifact), 1);
       sourceCounts[artifact.retentionSource]--;
       removePriorChange(changes, artifact.id);
+      stampRemovedAt(artifact);
       removed.push({
         action: 'removed',
         artifactId: artifact.id,
@@ -2169,7 +2187,8 @@ function mergeMetadata(
   for (const [key, value] of Object.entries(incoming.metadata)) {
     if (
       (key === WORKSPACE_CONTENT_SHA256_METADATA_KEY ||
-        key === WORKSPACE_CONTENT_MTIME_MS_METADATA_KEY) &&
+        key === WORKSPACE_CONTENT_MTIME_MS_METADATA_KEY ||
+        key === PUBLISHED_CONTENT_SHA256_METADATA_KEY) &&
       merged[key] !== value
     ) {
       merged[key] = value;
@@ -2272,6 +2291,15 @@ function removePriorChange(
   if (index >= 0) {
     changes.splice(index, 1);
   }
+}
+
+/**
+ * Removal is a material change: stamp the removed snapshot's updatedAt so
+ * consumers see when the artifact went away, while createdAt keeps the first
+ * registration time.
+ */
+function stampRemovedAt(artifact: StoredArtifact): void {
+  artifact.updatedAt = new Date().toISOString();
 }
 
 function toPublicArtifact(

--- a/packages/core/src/services/session-artifact-persistence.ts
+++ b/packages/core/src/services/session-artifact-persistence.ts
@@ -11,6 +11,7 @@ export const SESSION_ARTIFACT_PERSISTENCE_VERSION = 2 as const;
 const CONTENT_ID_PATTERN = /^[0-9a-f]{64}-[0-9a-f]{16}$/;
 export const WORKSPACE_CONTENT_SHA256_METADATA_KEY = 'qwen.workspace.sha256';
 export const WORKSPACE_CONTENT_MTIME_MS_METADATA_KEY = 'qwen.workspace.mtimeMs';
+export const PUBLISHED_CONTENT_SHA256_METADATA_KEY = 'qwen.published.sha256';
 const MAX_PERSISTED_ARTIFACTS = 500;
 const MAX_PERSISTED_EVENT_CHANGES = 800;
 const MAX_PERSISTED_IDS = 500;

--- a/packages/core/src/tools/artifact/artifact-tool.test.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.test.ts
@@ -5,15 +5,17 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { Config } from '../../config/config.js';
 import { StandardFileSystemService } from '../../services/fileSystemService.js';
+import { PUBLISHED_CONTENT_SHA256_METADATA_KEY } from '../../services/session-artifact-persistence.js';
 import { ToolErrorType } from '../tool-error.js';
 import { ArtifactTool, type UrlOpener } from './artifact-tool.js';
 import { LocalPublisher } from './local-publisher.js';
-import { MAX_ARTIFACT_BYTES } from './html.js';
+import { MAX_ARTIFACT_BYTES, wrapArtifactHtml } from './html.js';
 
 const signal = new AbortController().signal;
 
@@ -87,6 +89,21 @@ describe('ArtifactTool', () => {
     expect(html).toMatch(/^<!doctype html>/i);
     expect(html).toContain('<title>My Report</title>');
     expect(html).toContain('<h1>Report</h1>');
+  });
+
+  it('records the published content fingerprint for same-length republish detection', async () => {
+    const file = await writeFragment('fingerprint.html', '<h1>Report</h1>');
+    const res = await tool
+      .build({ file_path: file, title: 'My Report' })
+      .execute(signal);
+
+    expect(res.error).toBeUndefined();
+    const expectedSha = createHash('sha256')
+      .update(wrapArtifactHtml('<h1>Report</h1>', 'My Report'))
+      .digest('hex');
+    expect(res.artifacts?.[0]?.metadata).toMatchObject({
+      [PUBLISHED_CONTENT_SHA256_METADATA_KEY]: expectedSha,
+    });
   });
 
   it('redeploys the same source path to the same url', async () => {

--- a/packages/core/src/tools/artifact/artifact-tool.ts
+++ b/packages/core/src/tools/artifact/artifact-tool.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import type { Config } from '../../config/config.js';
+import { PUBLISHED_CONTENT_SHA256_METADATA_KEY } from '../../services/session-artifact-persistence.js';
 import type {
   ToolCallConfirmationDetails,
   ToolInfoConfirmationDetails,
@@ -255,6 +257,13 @@ class ArtifactToolInvocation extends BaseToolInvocation<
           managedId,
           mimeType: 'text/html',
           sizeBytes: bytes,
+          metadata: {
+            // Content fingerprint so a republish with a changed body bumps
+            // the stored artifact's updatedAt even at identical byte length.
+            [PUBLISHED_CONTENT_SHA256_METADATA_KEY]: createHash('sha256')
+              .update(html)
+              .digest('hex'),
+          },
         },
       ],
     };


### PR DESCRIPTION
## What this PR does

Session artifacts kept `updatedAt` equal to `createdAt` whenever only the artifact **content** changed. This PR makes the artifact store stamp `updatedAt` whenever it observes a material change: workspace content drifting from the recorded fingerprint, a reachability transition (`available` ↔ `changed` ↔ `missing`), or a removal (the removed snapshot now carries the removal time). It also reports the currently observed `sizeBytes` on the drift path instead of keeping the stale size, and records a published-content fingerprint (`qwen.published.sha256`) on Artifact-tool publishes so a same-byte-length republish is detected as an update.

## Why it's needed

`updatedAt` is the cache key for the Web Shell HTML/image preview, and it only moved on registration-field diffs. Rewriting a workspace file (especially with the same byte length) left `status: changed` with `updatedAt == createdAt`, so the preview panel could keep showing the stale body until the panel remounted. Republishing an Artifact-tool page with a different body of the same byte length produced no change at all. Fixing the timestamp at the store level makes every consumer (preview cache key included) truthful without client changes.

## Reviewer Test Plan

### How to verify

Five new store tests in `packages/acp-bridge/src/sessionArtifacts.test.ts` (describe `SessionArtifactStore updatedAt freshness (issue 9927)`) each fail on the parent commit and pass with this PR:

```bash
cd packages/acp-bridge && npx vitest run src/sessionArtifacts.test.ts
```

- Register a workspace artifact, rewrite the file with different content of the same byte length, then `get`/`list`: before — `status: changed` but `updatedAt == createdAt`; after — `updatedAt` moves and `sizeBytes` is the observed size.
- Delete the file: `status: missing` now moves `updatedAt`.
- `remove()`: the removed snapshot now carries the removal time while `createdAt` keeps the first registration time.
- Republish a published artifact with a changed `qwen.published.sha256` but identical size/url/title: before — zero changes; after — one `updated` change. An identical republish stays a no-op and does not refresh `updatedAt`.
- One new Artifact-tool test asserts the publish records `qwen.published.sha256` of the wrapped HTML (`packages/core/src/tools/artifact/artifact-tool.test.ts`).

Invariants preserved (covered by the same files): unchanged re-stats and same-identity no-op upserts keep `updatedAt` stable; `status` stays reachability-only; GET/list still emit no `artifact_changed`; eviction order stays `createdAt`-based.

### Evidence (Before & After)

N/A — data-layer logic change; no UI rendering code is touched (the Web Shell preview already keys its refetch on `artifact.updatedAt`, which becomes truthful with this fix).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only: `vitest run` for the two touched test files plus `tsc --noEmit` for `packages/acp-bridge` and `packages/core`, and eslint/prettier on the changed files.

## Risk & Scope

- Main risk or tradeoff: `updatedAt` now moves on status-refresh observations, so anything comparing old vs new `updatedAt` across a refresh may see more updates — that is the intended fix; no-op paths are guarded by regression tests.
- Not validated / out of scope: no reachability re-check is added for published/managed/URL artifacts (they stay `available` by design); Web Shell client code is unchanged; no full-monorepo test run.
- Breaking changes / migration notes: none — public API shape unchanged, no persisted-schema change (the fingerprint rides in existing user metadata).

## Linked Issues

Fixes #9927

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

会话工件的 `updatedAt` 在只有**内容**变化时一直等于 `createdAt`。本 PR 让工件存储在观察到实质变化时更新 `updatedAt`：工作区内容偏离已记录指纹、可达性状态转换（`available` ↔ `changed` ↔ `missing`）、以及删除（删除快照现在带删除时间）。漂移路径上 `sizeBytes` 也改为报告当前观察值，而不是保留旧值；同时 Artifact 工具发布时记录发布内容指纹（`qwen.published.sha256`），使同字节长度的重新发布也能被识别为更新。

## 为什么需要

`updatedAt` 是 Web Shell HTML/图片预览的缓存键，而它过去只在注册字段变化时才动。重写工作区文件（尤其是字节数不变的重写）会让 `status: changed` 但 `updatedAt == createdAt`，预览面板可能一直显示旧内容直到重新挂载。用不同内容、相同字节长度重新发布 Artifact 工具页面则完全不会产生任何变更。在存储层修正时间戳后，所有消费方（包括预览缓存键）无需客户端改动即可拿到真实值。

## 评审验证计划

### 如何验证

`packages/acp-bridge/src/sessionArtifacts.test.ts` 中新增 5 个存储测试（describe `SessionArtifactStore updatedAt freshness (issue 9927)`），每一个都在父提交上失败、在本 PR 上通过：

```bash
cd packages/acp-bridge && npx vitest run src/sessionArtifacts.test.ts
```

- 登记工作区工件后，用相同字节长度的不同内容重写文件，再 `get`/`list`：修复前 `status: changed` 但 `updatedAt == createdAt`；修复后 `updatedAt` 变化，且 `sizeBytes` 为观察值。
- 删除文件：`status: missing` 现在会推动 `updatedAt`。
- `remove()`：删除快照现在带删除时间，`createdAt` 保持首次登记时间。
- 以相同 size/url/title 但不同 `qwen.published.sha256` 重新发布已发布工件：修复前零变更；修复后产生一条 `updated` 变更。完全相同的重新发布仍是无操作，不刷新 `updatedAt`。
- Artifact 工具新增一个测试，断言发布时记录了包裹后 HTML 的 `qwen.published.sha256`（`packages/core/src/tools/artifact/artifact-tool.test.ts`）。

保持不变的约束（同一批文件覆盖）：内容未变的重新 stat、同身份无操作 upsert 都保持 `updatedAt` 稳定；`status` 仅表示可达性；GET/list 仍不发 `artifact_changed`；驱逐顺序仍基于 `createdAt`。

### 前后对比证据

N/A —— 数据层逻辑改动；未触碰任何 UI 渲染代码（Web Shell 预览本就以 `artifact.updatedAt` 作为重新拉取的键，本修复使该值变为真实值）。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元测试：对两个受影响的测试文件执行 `vitest run`，并对 `packages/acp-bridge` 和 `packages/core` 执行 `tsc --noEmit`，另对改动文件跑了 eslint/prettier。

## 风险与范围

- 主要风险或取舍：`updatedAt` 现在会因状态刷新观察而移动，因此对比刷新前后 `updatedAt` 的逻辑可能看到更多更新——这正是修复目标；无操作路径已有回归测试保护。
- 未验证 / 超出范围：不为 published/managed/URL 工件新增可达性复查（它们按设计保持 `available`）；未改动 Web Shell 客户端代码；未跑全 monorepo 测试。
- 破坏性变更 / 迁移说明：无——公开 API 结构不变，无持久化 schema 变更（指纹复用现有用户 metadata）。

## 关联 Issue

Fixes #9927

</details>
