### PR TITLE
fix(cli): abort subagent generation on unmount

### DIFF
--- a/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
+++ b/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
@@ -111,4 +111,51 @@ describe('DescriptionInput', () => {
 
     expect(capturedSignal?.aborted).toBe(true);
   });
+
+  it('does not advance when generation resolves after unmount', async () => {
+    let resolveGeneration!: (
+      value: Awaited<ReturnType<typeof subagentGenerator>>,
+    ) => void;
+    vi.mocked(subagentGenerator).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGeneration = resolve;
+        }),
+    );
+    const dispatch = vi.fn<(action: WizardAction) => void>();
+    const onNext = vi.fn();
+
+    let app!: ReturnType<typeof renderWithProviders>;
+    act(() => {
+      app = renderWithProviders(
+        <DescriptionInput
+          state={baseState}
+          dispatch={dispatch}
+          onNext={onNext}
+          onPrevious={vi.fn()}
+          onCancel={vi.fn()}
+          config={{} as Config}
+        />,
+      );
+    });
+
+    act(() => {
+      void textInputMock.props?.onSubmit?.('Review code changes');
+    });
+    act(() => {
+      app.unmount();
+    });
+    await act(async () => {
+      resolveGeneration({
+        name: 'reviewer',
+        description: 'Reviews code changes',
+        systemPrompt: 'Review the code.',
+      });
+    });
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SET_GENERATED_CONTENT' }),
+    );
+    expect(onNext).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
+++ b/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Config } from '@qwen-code/qwen-code-core';
+import { subagentGenerator } from '@qwen-code/qwen-code-core';
+import { renderWithProviders } from '../../../../test-utils/render.js';
+import { DescriptionInput } from './DescriptionInput.js';
+import type { CreationWizardState, WizardAction } from '../types.js';
+import type { TextInputProps } from '../../shared/TextInput.js';
+
+const textInputMock = vi.hoisted(() => ({
+  props: null as TextInputProps | null,
+}));
+
+vi.mock('../../shared/TextInput.js', () => ({
+  TextInput: (props: TextInputProps) => {
+    textInputMock.props = props;
+    return null;
+  },
+}));
+
+vi.mock('@qwen-code/qwen-code-core', async (importActual) => {
+  const actual =
+    await importActual<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    subagentGenerator: vi.fn(),
+  };
+});
+
+const baseState: CreationWizardState = {
+  currentStep: 3,
+  location: 'project',
+  generationMethod: 'qwen',
+  userDescription: 'Review code changes',
+  generatedSystemPrompt: '',
+  generatedDescription: '',
+  generatedName: '',
+  selectedTools: [],
+  color: 'blue',
+  isGenerating: false,
+  validationErrors: [],
+  canProceed: true,
+};
+
+describe('DescriptionInput', () => {
+  it('aborts in-flight generation when unmounted', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.mocked(subagentGenerator).mockImplementation(
+      async (_description, _config, signal) => {
+        capturedSignal = signal;
+        return new Promise(() => undefined);
+      },
+    );
+
+    let app!: ReturnType<typeof renderWithProviders>;
+    act(() => {
+      app = renderWithProviders(
+        <DescriptionInput
+          state={baseState}
+          dispatch={vi.fn<(action: WizardAction) => void>()}
+          onNext={vi.fn()}
+          onPrevious={vi.fn()}
+          onCancel={vi.fn()}
+          config={{} as Config}
+        />,
+      );
+    });
+
+    expect(textInputMock.props?.onSubmit).toBeDefined();
+
+    await act(async () => {
+      textInputMock.props?.onSubmit?.('Review code changes');
+    });
+
+    expect(capturedSignal?.aborted).toBe(false);
+
+    act(() => {
+      app.unmount();
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+});

--- a/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
+++ b/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
@@ -158,4 +158,50 @@ describe('DescriptionInput', () => {
     );
     expect(onNext).not.toHaveBeenCalled();
   });
+
+  it('stores generated content and advances when generation resolves while mounted', async () => {
+    let resolveGeneration!: (
+      value: Awaited<ReturnType<typeof subagentGenerator>>,
+    ) => void;
+    vi.mocked(subagentGenerator).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGeneration = resolve;
+        }),
+    );
+    const dispatch = vi.fn<(action: WizardAction) => void>();
+    const onNext = vi.fn();
+
+    act(() => {
+      renderWithProviders(
+        <DescriptionInput
+          state={baseState}
+          dispatch={dispatch}
+          onNext={onNext}
+          onPrevious={vi.fn()}
+          onCancel={vi.fn()}
+          config={{} as Config}
+        />,
+      );
+    });
+
+    act(() => {
+      void textInputMock.props?.onSubmit?.('Review code changes');
+    });
+    await act(async () => {
+      resolveGeneration({
+        name: 'reviewer',
+        description: 'Reviews code changes',
+        systemPrompt: 'Review the code.',
+      });
+    });
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'SET_GENERATED_CONTENT',
+      name: 'reviewer',
+      description: 'Reviews code changes',
+      systemPrompt: 'Review the code.',
+    });
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
+++ b/packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx
@@ -49,6 +49,31 @@ const baseState: CreationWizardState = {
 };
 
 describe('DescriptionInput', () => {
+  it('unmounts cleanly when no generation is in flight', () => {
+    vi.clearAllMocks();
+    const dispatch = vi.fn<(action: WizardAction) => void>();
+    const onNext = vi.fn();
+    let app!: ReturnType<typeof renderWithProviders>;
+
+    act(() => {
+      app = renderWithProviders(
+        <DescriptionInput
+          state={baseState}
+          dispatch={dispatch}
+          onNext={onNext}
+          onPrevious={vi.fn()}
+          onCancel={vi.fn()}
+          config={{} as Config}
+        />,
+      );
+    });
+
+    expect(() => act(() => app.unmount())).not.toThrow();
+    expect(subagentGenerator).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
   it('aborts in-flight generation when unmounted', async () => {
     let capturedSignal: AbortSignal | undefined;
     vi.mocked(subagentGenerator).mockImplementation(

--- a/packages/cli/src/ui/components/subagents/create/DescriptionInput.tsx
+++ b/packages/cli/src/ui/components/subagents/create/DescriptionInput.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import Spinner from 'ink-spinner';
 import type { WizardStepProps, WizardAction } from '../types.js';
@@ -26,6 +26,13 @@ export function DescriptionInput({
   config,
 }: WizardStepProps) {
   const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(
+    () => () => {
+      abortControllerRef.current?.abort();
+    },
+    [],
+  );
 
   const handleTextChange = useCallback(
     (text: string) => {


### PR DESCRIPTION
## What this PR does

- Aborts an in-flight subagent description generation request when `DescriptionInput` unmounts.
- Adds a regression test that starts generation, unmounts the component, and verifies the captured abort signal is cancelled.

## Why it's needed

The subagent creation wizard only aborts generation from the ESC key handler. If the wizard is unmounted while generation is pending, for example because another dialog takes priority or the wizard is closed, the LLM request can continue without a visible owner. The cleanup keeps the request lifecycle tied to the component that started it.

Related to #8835 (`subagent-generation-not-aborted-on-unmount`).

## Reviewer Test Plan

- `npx vitest run packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx`
- `npx vitest run packages/cli/src/ui/components/subagents/create`
- `npx prettier --check packages/cli/src/ui/components/subagents/create/DescriptionInput.tsx packages/cli/src/ui/components/subagents/create/DescriptionInput.test.tsx`

## Notes

<details>
<summary>中文说明</summary>

本 PR 给 subagent 创建向导的 LLM 生成步骤补上 unmount cleanup。生成中按 ESC 取消的既有行为不变；新增逻辑只是在组件卸载时 abort 当前 `AbortController`，避免后台请求继续消耗资源。

</details>