### PR TITLE
fix(desktop): clear window drag state on close

### DIFF
--- a/packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts
+++ b/packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { RPC_CHANNELS } from '@craft-agent/shared/protocol';
+import type { RpcServer } from '@craft-agent/server-core/transport';
+import type { HandlerDeps } from '../handler-deps';
+import { registerWindowDragGuiHandlers } from '../window-drag';
+
+type Handler = (ctx: { webContentsId?: number }, ...args: number[]) => void;
+
+type MockWindow = {
+  getPosition: ReturnType<typeof mock>;
+  setPosition: ReturnType<typeof mock>;
+  isDestroyed: ReturnType<typeof mock>;
+  once: ReturnType<typeof mock>;
+  emitClosed: () => void;
+};
+
+const handlers = new Map<string, Handler>();
+
+function createMockServer(): RpcServer {
+  return {
+    handle(channel: string, handler: unknown) {
+      handlers.set(channel, handler as Handler);
+    },
+    push() {},
+    async invokeClient() {},
+  };
+}
+
+function createMockWindow(position: [number, number]): MockWindow {
+  let closedHandler: (() => void) | undefined;
+
+  return {
+    getPosition: mock(() => position),
+    setPosition: mock(() => {}),
+    isDestroyed: mock(() => false),
+    once: mock((eventName: string, handler: () => void) => {
+      if (eventName === 'closed') {
+        closedHandler = handler;
+      }
+    }),
+    emitClosed: () => {
+      closedHandler?.();
+    },
+  };
+}
+
+function createMockDeps(window: MockWindow): HandlerDeps {
+  return {
+    windowManager: {
+      getWindowByWebContentsId: mock(() => window),
+    },
+  } as unknown as HandlerDeps;
+}
+
+describe('window drag handlers', () => {
+  beforeEach(() => {
+    handlers.clear();
+  });
+
+  it('clears drag state when the source window is closed', () => {
+    const sourceWindow = createMockWindow([10, 20]);
+    const replacementWindow = createMockWindow([100, 200]);
+    const deps = createMockDeps(sourceWindow);
+
+    registerWindowDragGuiHandlers(createMockServer(), deps);
+
+    handlers.get(RPC_CHANNELS.window.BEGIN_DRAG)?.(
+      { webContentsId: 1 },
+      50,
+      60,
+    );
+    sourceWindow.emitClosed();
+    (
+      deps.windowManager?.getWindowByWebContentsId as ReturnType<typeof mock>
+    ).mockImplementation(() => replacementWindow);
+
+    handlers.get(RPC_CHANNELS.window.MOVE_DRAG)?.(
+      { webContentsId: 1 },
+      55,
+      65,
+    );
+
+    expect(replacementWindow.setPosition).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/apps/electron/src/main/handlers/window-drag.ts
+++ b/packages/desktop/apps/electron/src/main/handlers/window-drag.ts
@@ -16,7 +16,7 @@ export const GUI_HANDLED_CHANNELS = [
 ] as const;
 
 const dragStates = new Map<number, WindowDragState>();
-
+const closedCleanupRegistered = new Set<number>();
 function isFinitePoint(screenX: number, screenY: number): boolean {
   return Number.isFinite(screenX) && Number.isFinite(screenY);
 }
@@ -42,6 +42,13 @@ export function registerWindowDragGuiHandlers(
         startWindowX,
         startWindowY,
       });
+      if (!closedCleanupRegistered.has(webContentsId)) {
+        closedCleanupRegistered.add(webContentsId);
+        window.once('closed', () => {
+          dragStates.delete(webContentsId);
+          closedCleanupRegistered.delete(webContentsId);
+        });
+      }
     },
   );
 


### PR DESCRIPTION
## What this PR does
- Clears cached window drag state when the source Electron window emits `closed`.
- Adds a regression test that starts a drag, closes the source window, and verifies a replacement window with the same webContents id is not moved from stale state.

## Why it's needed
`dragStates` was only cleared by `END_DRAG`. If a window closed mid-drag, the stale entry could survive and be reused by later move events, causing incorrect movement and retaining state longer than needed.

## Reviewer Test Plan
- `npx bun test packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts`
- `npx prettier --check packages/desktop/apps/electron/src/main/handlers/window-drag.ts packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts`
- `npx eslint --no-warn-ignored packages/desktop/apps/electron/src/main/handlers/window-drag.ts packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts`

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么
- Electron 源窗口关闭时清理缓存的窗口拖拽状态。
- 新增回归测试：开始拖拽后关闭源窗口，再确认同一 webContents id 对应的新窗口不会被旧状态移动。

## 为什么需要
`dragStates` 之前只在 `END_DRAG` 时清理。窗口如果在拖拽中关闭，旧状态可能残留，被后续移动事件复用，也会让状态保留过久。

## 验证
- `npx bun test packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts`
- `npx prettier --check packages/desktop/apps/electron/src/main/handlers/window-drag.ts packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts`
- `npx eslint --no-warn-ignored packages/desktop/apps/electron/src/main/handlers/window-drag.ts packages/desktop/apps/electron/src/main/handlers/__tests__/window-drag.test.ts`
</details>