### PR TITLE
refactor(web-shell): reuse canonical todo parser

### DIFF
--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -523,11 +523,15 @@ describe('transcriptBlocksToDaemonMessages', () => {
           content: '检查项目结构',
           priority: 'medium',
           status: 'pending',
+          _meta: { qwenTodo: { id: 'inspect' } },
         },
         {
           content: '运行类型检查',
           priority: 'high',
           status: 'in_progress',
+          _meta: {
+            qwenTodo: { id: 'typecheck', blockedBy: ['inspect'] },
+          },
         },
       ],
     };
@@ -543,16 +547,17 @@ describe('transcriptBlocksToDaemonMessages', () => {
         timestamp: 1,
         todos: [
           {
-            id: 'plan-0',
+            id: 'inspect',
             content: '检查项目结构',
             priority: 'medium',
             status: 'pending',
           },
           {
-            id: 'plan-1',
+            id: 'typecheck',
             content: '运行类型检查',
             priority: 'high',
             status: 'in_progress',
+            blockedBy: ['inspect'],
           },
         ],
       },

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -22,6 +22,8 @@ import type {
   DaemonMessageTodoItem,
   DaemonUserMessage,
 } from './messageTypes.js';
+import { isTaskExecutionRaw } from './toolClassification.js';
+import { parseTodoItemsFromEntries } from '../utils/todos.js';
 
 interface PermissionToolInfo {
   title?: string;
@@ -355,29 +357,6 @@ function getBackgroundNotificationData(
 
 function isTextBlockEmpty(block: DaemonTextTranscriptBlock): boolean {
   return block.text.length === 0;
-}
-
-function parseDaemonTodoItemsFromEntries(
-  entries: readonly unknown[],
-): DaemonMessageTodoItem[] | undefined {
-  const todos = entries.flatMap((entry, index): DaemonMessageTodoItem[] => {
-    const item = getRecord(entry);
-    const content = getString(item, 'content');
-    if (!content) return [];
-    const id = getString(item, 'id') ?? `plan-${index}`;
-    return [
-      {
-        id,
-        content,
-        status: getTodoStatus(getString(item, 'status')),
-        ...(() => {
-          const priority = getTodoPriority(getString(item, 'priority'));
-          return priority ? { priority } : {};
-        })(),
-      },
-    ];
-  });
-  return todos.length > 0 ? todos : undefined;
 }
 
 /**
@@ -1074,14 +1053,6 @@ function isSubAgentToolCall(tool: DaemonMessageToolCall): boolean {
   return Boolean(tool.args?.subagent_type);
 }
 
-function isTaskExecutionRaw(raw: unknown): boolean {
-  return (
-    !!raw &&
-    typeof raw === 'object' &&
-    (raw as Record<string, unknown>).type === 'task_execution'
-  );
-}
-
 function parsePlanTodos(text: string): DaemonMessageTodoItem[] | undefined {
   const rawJson = text.startsWith('plan: ')
     ? text.slice('plan: '.length)
@@ -1099,7 +1070,8 @@ function parsePlanTodos(text: string): DaemonMessageTodoItem[] | undefined {
     ) {
       return undefined;
     }
-    return parseDaemonTodoItemsFromEntries(record['entries']);
+    const todos = parseTodoItemsFromEntries(record['entries']);
+    return todos.length > 0 ? todos : undefined;
   } catch {
     return undefined;
   }
@@ -1118,22 +1090,6 @@ function getString(
 ): string | undefined {
   const value = record?.[key];
   return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function getTodoStatus(
-  value: string | undefined,
-): DaemonMessageTodoItem['status'] {
-  return value === 'completed' || value === 'in_progress' || value === 'pending'
-    ? value
-    : 'pending';
-}
-
-function getTodoPriority(
-  value: string | undefined,
-): DaemonMessageTodoItem['priority'] | undefined {
-  return value === 'high' || value === 'medium' || value === 'low'
-    ? value
-    : undefined;
 }
 
 function daemonToolBlockToToolCall(

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -22,7 +22,7 @@ import type {
   DaemonMessageTodoItem,
   DaemonUserMessage,
 } from './messageTypes.js';
-import { isTaskExecutionRaw } from './toolClassification.js';
+import { isSubAgentToolCall } from './toolClassification.js';
 import { parseTodoItemsFromEntries } from '../utils/todos.js';
 
 interface PermissionToolInfo {
@@ -1043,14 +1043,6 @@ function mergeToolCall(
 
 function isTerminalToolStatus(status: DaemonMessageToolCallStatus): boolean {
   return status === 'completed' || status === 'failed';
-}
-
-function isSubAgentToolCall(tool: DaemonMessageToolCall): boolean {
-  const name = tool.toolName.toLowerCase();
-  if (name === 'agent' || name === 'task') return true;
-  if (tool.subTools || tool.subContent) return true;
-  if (isTaskExecutionRaw(tool.rawOutput)) return true;
-  return Boolean(tool.args?.subagent_type);
 }
 
 function parsePlanTodos(text: string): DaemonMessageTodoItem[] | undefined {


### PR DESCRIPTION
## What this PR does

Web Shell transcript replay now uses the same task-entry decoder and task-execution classifier as the live todo timeline. Replayed daemon plan updates preserve canonical task IDs, dependency relationships, status, priority, and display metadata instead of rebuilding a reduced copy.

## Why it's needed

The transcript adapter had a second implementation of the todo wire format. It had already drifted from the canonical decoder by dropping task identity and dependency metadata, and future protocol changes would have required two coordinated updates.

## Reviewer Test Plan

### How to verify

Replay a daemon plan update containing canonical task IDs and a blocked-by relationship. Confirm the resulting timeline keeps both values, still recognizes task-execution entries, and continues to ignore malformed entries without changing legacy behavior.

The focused Web Shell adapter suite passes: 135 tests.

### Evidence (Before & After)

N/A — internal transcript normalization refactor with regression coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS arm64, Node.js v25.6.1; focused Vitest suite, Web Shell typecheck/build, and ESLint completed successfully.

## Risk & Scope

- Main risk or tradeoff: A shared decoder can expose metadata that the reduced local decoder previously discarded; regression coverage verifies the existing display shape while preserving canonical identity fields.
- Not validated / out of scope: Windows and Linux were not tested locally; CI provides cross-platform coverage.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Web Shell 的记录回放现在与实时 todo 时间线复用同一套任务条目解码和任务执行分类逻辑。回放 daemon 计划更新时会保留规范的任务 ID、依赖关系、状态、优先级和展示元数据，不再重新构造一个字段更少的副本。

## 为什么需要

记录适配层此前维护了第二套 todo 传输格式实现。它已经与规范解码逻辑产生偏差，会丢失任务身份和依赖元数据；后续协议变化也需要同步修改两处。

## Reviewer 测试计划

### 如何验证

回放一条包含规范任务 ID 和 blocked-by 依赖关系的 daemon 计划更新。确认生成的时间线保留这两个值，仍能识别任务执行条目，并继续忽略格式错误的条目且不改变旧行为。

Web Shell 聚焦适配器测试全部通过：135 个测试。

### 证据（修改前与修改后）

不适用——这是带回归测试覆盖的内部记录规范化重构。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|   🪟 Windows     |  ⚠️  |
|    🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS arm64、Node.js v25.6.1；聚焦 Vitest 测试、Web Shell 类型检查/构建和 ESLint 均成功完成。

## 风险与范围

- 主要风险或取舍：共享解码器会暴露原有精简解码器曾丢弃的元数据；回归测试验证现有展示形态，同时保留规范身份字段。
- 未验证 / 不在范围内：未在本地测试 Windows 和 Linux；跨平台覆盖由 CI 提供。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
