### PR TITLE
refactor(acp-bridge): narrow workspace event capabilities

### DIFF
--- a/docs/design/2026-08-25-acp-workspace-event-capability.md
+++ b/docs/design/2026-08-25-acp-workspace-event-capability.md
@@ -1,0 +1,15 @@
+# ACP workspace event capability
+
+## Problem
+
+Several serve-layer services accept the full ACP session bridge even though they only publish workspace events, or publish events plus validate an originating client id. This couples small services and their tests to a bridge interface with more than one hundred members.
+
+## Design
+
+Define a workspace event publisher capability and a two-method workspace event bridge capability. The full session bridge continues to implement both through interface extension, so runtime behavior and construction stay unchanged. Narrow the git-status watcher, device-flow fan-out, memory mutation routes, and GitHub setup route to the smallest applicable capability.
+
+## Non-goals
+
+- Split the bridge implementation or factory.
+- Change event delivery, client validation, or bridge construction.
+- Migrate session lifecycle, artifacts, permissions, or command invocation in this change.

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -1265,7 +1265,24 @@ export type RuntimeMcpServerRemoveResult =
     }
   | { name: string; skipped: true; reason: 'not_present' };
 
-export interface AcpSessionBridge {
+export interface WorkspaceEventPublisher {
+  /**
+   * Workspace-level event fan-out for mutations that change daemon-wide state.
+   * Best-effort per session; closed buses silently skipped.
+   */
+  publishWorkspaceEvent(event: Omit<BridgeEvent, 'id' | 'v'>): void;
+}
+
+export interface WorkspaceEventBridge extends WorkspaceEventPublisher {
+  /**
+   * Union of every live session's `clientIds`. Used by workspace-level
+   * mutation routes to validate the optional `X-Qwen-Client-Id` header.
+   * Returns a snapshot — callers must not mutate.
+   */
+  knownClientIds(): ReadonlySet<string>;
+}
+
+export interface AcpSessionBridge extends WorkspaceEventBridge {
   /** Read-only daemon diagnostics for status endpoints. */
   getDaemonStatusSnapshot(): BridgeDaemonStatusSnapshot;
 
@@ -1569,19 +1586,6 @@ export interface AcpSessionBridge {
    * Returns `undefined` for unknown sessions.
    */
   getHeartbeatState(sessionId: string): BridgeHeartbeatState | undefined;
-
-  /**
-   * Workspace-level event fan-out for mutations that change daemon-wide state.
-   * Best-effort per session; closed buses silently skipped.
-   */
-  publishWorkspaceEvent(event: Omit<BridgeEvent, 'id' | 'v'>): void;
-
-  /**
-   * Union of every live session's `clientIds`. Used by workspace-level
-   * mutation routes to validate the optional `X-Qwen-Client-Id` header.
-   * Returns a snapshot — callers must not mutate.
-   */
-  knownClientIds(): ReadonlySet<string>;
 
   /**
    * Generic workspace-status query delegated through the live ACP channel.

--- a/packages/cli/src/serve/acp-session-bridge.ts
+++ b/packages/cli/src/serve/acp-session-bridge.ts
@@ -105,6 +105,8 @@ export type {
   BridgeDaemonSessionDiagnostic,
   BridgeDaemonStatusSnapshot,
   BridgeShutdownOptions,
+  WorkspaceEventPublisher,
+  WorkspaceEventBridge,
   AcpSessionBridge,
   HttpAcpBridge,
 } from '@qwen-code/acp-bridge/bridgeTypes';

--- a/packages/cli/src/serve/routes/workspace-setup-github.ts
+++ b/packages/cli/src/serve/routes/workspace-setup-github.ts
@@ -7,7 +7,7 @@
 import { promises as fsp } from 'node:fs';
 import * as path from 'node:path';
 import type { Application, Request, RequestHandler, Response } from 'express';
-import type { AcpSessionBridge } from '../acp-session-bridge.js';
+import type { WorkspaceEventBridge } from '../acp-session-bridge.js';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import { isFsError, type WorkspaceFileSystemFactory } from '../fs/index.js';
 import {
@@ -29,7 +29,7 @@ const ROUTE = 'POST /workspace/setup-github';
 
 interface RegisterDeps {
   boundWorkspace: string;
-  bridge: AcpSessionBridge;
+  bridge: WorkspaceEventBridge;
   env: Readonly<NodeJS.ProcessEnv>;
   mutate: (opts?: { strict?: boolean }) => RequestHandler;
   parseClientId: (req: Request, res: Response) => string | undefined | null;

--- a/packages/cli/src/serve/server/device-flow-registry.test.ts
+++ b/packages/cli/src/serve/server/device-flow-registry.test.ts
@@ -11,7 +11,7 @@ import {
   type DeviceFlowProvider,
   type DeviceFlowProviderId,
 } from '../auth/device-flow.js';
-import type { AcpSessionBridge } from '../acp-session-bridge.js';
+import type { WorkspaceEventPublisher } from '../acp-session-bridge.js';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 
 vi.mock('../../utils/stdioHelpers.js', () => ({ writeStderrLine: vi.fn() }));
@@ -38,13 +38,11 @@ function fakeProvider(): DeviceFlowProvider {
   };
 }
 
-function fakeBridge(): AcpSessionBridge & {
+function fakeBridge(): WorkspaceEventPublisher & {
   publishWorkspaceEvent: ReturnType<typeof vi.fn>;
 } {
   return {
     publishWorkspaceEvent: vi.fn(),
-  } as unknown as AcpSessionBridge & {
-    publishWorkspaceEvent: ReturnType<typeof vi.fn>;
   };
 }
 

--- a/packages/cli/src/serve/server/device-flow-registry.ts
+++ b/packages/cli/src/serve/server/device-flow-registry.ts
@@ -6,7 +6,7 @@
 
 import type { Application } from 'express';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
-import type { AcpSessionBridge } from '../acp-session-bridge.js';
+import type { WorkspaceEventPublisher } from '../acp-session-bridge.js';
 import {
   DeviceFlowRegistry,
   setDeviceFlowRegistry,
@@ -18,10 +18,10 @@ import { QwenOAuthDeviceFlowProvider } from '../auth/qwen-device-flow-provider.j
 
 interface SetupDeviceFlowRegistryDeps {
   app: Application;
-  bridge: AcpSessionBridge;
+  bridge: WorkspaceEventPublisher;
   registry?: DeviceFlowRegistry;
   providers?: DeviceFlowProvider[];
-  resolveEventBridges?: () => AcpSessionBridge[];
+  resolveEventBridges?: () => WorkspaceEventPublisher[];
 }
 
 export interface ServeDeviceFlowRuntime {
@@ -30,7 +30,7 @@ export interface ServeDeviceFlowRuntime {
 }
 
 export function createDeviceFlowRegistry(deps: {
-  bridge: AcpSessionBridge;
+  bridge: WorkspaceEventPublisher;
   registry?: DeviceFlowRegistry;
   providers?: DeviceFlowProvider[];
   /**
@@ -38,7 +38,7 @@ export function createDeviceFlowRegistry(deps: {
    * (primary + trusted secondary runtimes), resolved lazily on every publish.
    * Defaults to the single `bridge` when omitted, preserving prior behavior.
    */
-  resolveEventBridges?: () => AcpSessionBridge[];
+  resolveEventBridges?: () => WorkspaceEventPublisher[];
 }): ServeDeviceFlowRuntime {
   const deviceFlowProviderMap = new Map<
     DeviceFlowProviderId,

--- a/packages/cli/src/serve/workspace-git-state.test.ts
+++ b/packages/cli/src/serve/workspace-git-state.test.ts
@@ -11,7 +11,7 @@ import {
   watchRepoBranch,
   type GitWorkingTreeStatus,
 } from '@qwen-code/qwen-code-core';
-import type { AcpSessionBridge } from './acp-session-bridge.js';
+import type { WorkspaceEventPublisher } from './acp-session-bridge.js';
 import { writeStderrLineSafe } from '../utils/stdioHelpers.js';
 import { WorkspaceGitState } from './workspace-git-state.js';
 
@@ -51,7 +51,7 @@ function summary(
 
 function bridgeWith(publishWorkspaceEvent = vi.fn()) {
   return {
-    bridge: { publishWorkspaceEvent } as unknown as AcpSessionBridge,
+    bridge: { publishWorkspaceEvent } satisfies WorkspaceEventPublisher,
     publishWorkspaceEvent,
   };
 }
@@ -81,7 +81,7 @@ describe('WorkspaceGitState', () => {
     await expect(
       state.getStatus('/workspace', {
         publishWorkspaceEvent,
-      } as unknown as AcpSessionBridge),
+      } satisfies WorkspaceEventPublisher),
     ).resolves.toEqual({
       v: 2,
       workspaceCwd: '/workspace',
@@ -123,7 +123,7 @@ describe('WorkspaceGitState', () => {
         '/workspace',
         {
           publishWorkspaceEvent: vi.fn(),
-        } as unknown as AcpSessionBridge,
+        } satisfies WorkspaceEventPublisher,
         { wait: true },
       ),
     ).resolves.toEqual({
@@ -139,7 +139,7 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
     const bridge = {
       publishWorkspaceEvent: vi.fn(),
-    } as unknown as AcpSessionBridge;
+    } satisfies WorkspaceEventPublisher;
 
     const [first, second] = await Promise.all([
       state.getStatus('/plain', bridge),
@@ -160,7 +160,7 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
     const bridge = {
       publishWorkspaceEvent: vi.fn(),
-    } as unknown as AcpSessionBridge;
+    } satisfies WorkspaceEventPublisher;
 
     await expect(state.getStatus('/retry', bridge)).rejects.toThrow(
       'git unavailable',
@@ -193,7 +193,7 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
     const bridge = {
       publishWorkspaceEvent: vi.fn(),
-    } as unknown as AcpSessionBridge;
+    } satisfies WorkspaceEventPublisher;
 
     const status = await state.getStatus('/workspace', bridge, { wait: true });
     expect(status).toMatchObject({
@@ -232,7 +232,7 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
     const bridge = {
       publishWorkspaceEvent: vi.fn(),
-    } as unknown as AcpSessionBridge;
+    } satisfies WorkspaceEventPublisher;
 
     const status = await state.getStatus('/workspace', bridge, { wait: true });
     expect(status).not.toHaveProperty('operation');
@@ -258,7 +258,7 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
     const bridge = {
       publishWorkspaceEvent: vi.fn(),
-    } as unknown as AcpSessionBridge;
+    } satisfies WorkspaceEventPublisher;
 
     await expect(
       state.getStatus('/workspace', bridge, { wait: true }),
@@ -278,7 +278,7 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
     const bridge = {
       publishWorkspaceEvent: vi.fn(),
-    } as unknown as AcpSessionBridge;
+    } satisfies WorkspaceEventPublisher;
     await state.getStatus('/first', bridge);
     await state.getStatus('/second', bridge);
 
@@ -302,7 +302,7 @@ describe('WorkspaceGitState', () => {
     const state = new WorkspaceGitState();
     const bridge = {
       publishWorkspaceEvent: vi.fn(),
-    } as unknown as AcpSessionBridge;
+    } satisfies WorkspaceEventPublisher;
 
     const first = state.getStatus('/same', bridge);
     state.disposeWorkspace('/same');

--- a/packages/cli/src/serve/workspace-git-state.ts
+++ b/packages/cli/src/serve/workspace-git-state.ts
@@ -11,7 +11,7 @@ import {
   type GitOperation,
   type GitWorkingTreeStatus,
 } from '@qwen-code/qwen-code-core';
-import type { AcpSessionBridge } from './acp-session-bridge.js';
+import type { WorkspaceEventPublisher } from './acp-session-bridge.js';
 import { writeStderrLineSafe } from '../utils/stdioHelpers.js';
 
 export interface WorkspaceGitStatus {
@@ -107,7 +107,7 @@ export class WorkspaceGitState {
    */
   async getStatus(
     workspaceCwd: string,
-    bridge: AcpSessionBridge,
+    bridge: WorkspaceEventPublisher,
     opts?: { wait?: boolean },
   ): Promise<WorkspaceGitStatus> {
     const entry = await this.getOrCreateEntry(workspaceCwd, bridge);
@@ -183,7 +183,7 @@ export class WorkspaceGitState {
   private startRefresh(
     workspaceCwd: string,
     entry: WorkspaceGitEntry,
-    bridge: AcpSessionBridge,
+    bridge: WorkspaceEventPublisher,
     force: boolean,
   ): Promise<void> | undefined {
     if (entry.statusPromise) return entry.statusPromise;
@@ -232,7 +232,7 @@ export class WorkspaceGitState {
 
   private getOrCreateEntry(
     workspaceCwd: string,
-    bridge: AcpSessionBridge,
+    bridge: WorkspaceEventPublisher,
   ): Promise<WorkspaceGitEntry> {
     const existing = this.entries.get(workspaceCwd);
     if (existing) return existing;
@@ -249,7 +249,7 @@ export class WorkspaceGitState {
 
   private async createEntry(
     workspaceCwd: string,
-    bridge: AcpSessionBridge,
+    bridge: WorkspaceEventPublisher,
   ): Promise<WorkspaceGitEntry> {
     const entry: WorkspaceGitEntry = {
       branch: await resolveBranchName(workspaceCwd),

--- a/packages/cli/src/serve/workspace-memory.test.ts
+++ b/packages/cli/src/serve/workspace-memory.test.ts
@@ -27,7 +27,7 @@ import {
 import { createMutationGate } from './auth.js';
 import {
   InvalidClientIdError,
-  type AcpSessionBridge,
+  type WorkspaceEventBridge,
 } from './acp-session-bridge.js';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import { mountWorkspaceMemoryRoutes } from './workspace-memory.js';
@@ -38,7 +38,7 @@ function buildBridgeStub(
   opts: {
     knownIds?: Iterable<string>;
   } = {},
-): AcpSessionBridge & { events: RecordedEvent[] } {
+): WorkspaceEventBridge & { events: RecordedEvent[] } {
   const events: RecordedEvent[] = [];
   const known = new Set<string>(opts.knownIds ?? []);
   return {
@@ -49,75 +49,11 @@ function buildBridgeStub(
     knownClientIds() {
       return new Set(known);
     },
-    // Methods below are not used by the memory routes; throw to keep
-    // unrelated tests from accidentally relying on them.
-    spawnOrAttach: () => {
-      throw new Error('not implemented');
-    },
-    loadSession: () => {
-      throw new Error('not implemented');
-    },
-    resumeSession: () => {
-      throw new Error('not implemented');
-    },
-    sendPrompt: () => {
-      throw new Error('not implemented');
-    },
-    cancelSession: () => {
-      throw new Error('not implemented');
-    },
-    subscribeEvents: () => {
-      throw new Error('not implemented');
-    },
-    closeSession: () => {
-      throw new Error('not implemented');
-    },
-    updateSessionMetadata: () => {
-      throw new Error('not implemented');
-    },
-    respondToPermission: () => {
-      throw new Error('not implemented');
-    },
-    respondToSessionPermission: () => {
-      throw new Error('not implemented');
-    },
-    listWorkspaceSessions: () => {
-      throw new Error('not implemented');
-    },
-    recordHeartbeat: () => {
-      throw new Error('not implemented');
-    },
-    getHeartbeatState: () => undefined,
-    getWorkspaceMcpStatus: async () => {
-      throw new Error('not implemented');
-    },
-    getWorkspaceSkillsStatus: async () => {
-      throw new Error('not implemented');
-    },
-    getWorkspaceProvidersStatus: async () => {
-      throw new Error('not implemented');
-    },
-    getSessionContextStatus: async () => {
-      throw new Error('not implemented');
-    },
-    getSessionSupportedCommandsStatus: async () => {
-      throw new Error('not implemented');
-    },
-    setSessionModel: async () => {
-      throw new Error('not implemented');
-    },
-    killSession: async () => true,
-    detachClient: async () => {},
-    sessionCount: 0,
-    pendingPermissionCount: 0,
-    killAllSync: () => {},
-    shutdown: async () => {},
-    preheat: async () => {},
-  } as unknown as AcpSessionBridge & { events: RecordedEvent[] };
+  };
 }
 
 function buildApp(opts: {
-  bridge: AcpSessionBridge;
+  bridge: WorkspaceEventBridge;
   boundWorkspace: string;
   strictNoToken?: boolean;
   collectStatus?: Parameters<

--- a/packages/cli/src/serve/workspace-memory.ts
+++ b/packages/cli/src/serve/workspace-memory.ts
@@ -16,7 +16,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { writeStderrLine } from '../utils/stdioHelpers.js';
 import { isServeDebugMode } from './debug-mode.js';
-import type { AcpSessionBridge } from './acp-session-bridge.js';
+import type { WorkspaceEventBridge } from './acp-session-bridge.js';
 import {
   createIdleWorkspaceMemoryStatus,
   STATUS_SCHEMA_VERSION,
@@ -63,7 +63,7 @@ import type { WorkspaceRegistry } from './workspace-registry.js';
  */
 
 export interface WorkspaceMemoryRouteDeps {
-  bridge: AcpSessionBridge;
+  bridge: WorkspaceEventBridge;
   boundWorkspace: string;
   collectStatus?: typeof collectWorkspaceMemoryStatus;
   /**


### PR DESCRIPTION
## What this PR does

Workspace event consumers now depend on capability-focused bridge contracts: publishers receive only event publication, while consumers that validate connected clients also receive the known-client query. The full session bridge continues to satisfy both contracts.

## Why it's needed

Several services accepted the entire ACP session bridge even though they used only one or two event methods. That widened their architectural dependency, made tests construct large unrelated fakes, and obscured which services are allowed to inspect client membership.

## Reviewer Test Plan

### How to verify

Trigger workspace Git state, device-flow, workspace-memory, and GitHub setup events. Confirm each event is still published, and confirm only the memory/setup paths query known client IDs when validating a target. Review the service boundaries and verify publication-only consumers cannot access session lifecycle operations through their declared dependency.

Four focused CLI suites pass: 54 tests.

### Evidence (Before & After)

N/A — type-level capability narrowing with unchanged event behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS arm64, Node.js v25.6.1; 54 focused Vitest tests, ACP bridge build, CLI build, and ESLint completed successfully.

## Risk & Scope

- Main risk or tradeoff: An omitted capability could surface as a compile or test failure; both affected packages build and every narrowed consumer's focused suite passes.
- Not validated / out of scope: The full session bridge API and runtime event routing are unchanged; Windows and Linux were not tested locally.
- Breaking changes / migration notes: None. The narrower contracts are additive and the existing full bridge remains compatible.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

工作区事件消费者现在依赖按能力划分的 bridge 契约：只发布事件的消费者仅接收发布能力，需要校验已连接客户端的消费者还会接收已知客户端查询能力。完整 session bridge 仍然满足这两种契约。

## 为什么需要

多个服务此前接收完整 ACP session bridge，但实际只使用一两个事件方法。这扩大了架构依赖，迫使测试构造包含大量无关内容的假对象，也模糊了哪些服务有权检查客户端成员关系。

## Reviewer 测试计划

### 如何验证

触发工作区 Git 状态、device flow、工作区 memory 和 GitHub setup 事件。确认每个事件仍会发布，并确认只有 memory/setup 路径在校验目标时查询已知客户端 ID。检查服务边界，确认仅发布消费者无法通过其声明的依赖访问 session 生命周期操作。

4 个 CLI 聚焦测试套件全部通过：54 个测试。

### 证据（修改前与修改后）

不适用——这是类型层面的能力收窄，事件行为保持不变。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|   🪟 Windows     |  ⚠️  |
|    🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS arm64、Node.js v25.6.1；54 个聚焦 Vitest 测试、ACP bridge 构建、CLI 构建和 ESLint 均成功完成。

## 风险与范围

- 主要风险或取舍：遗漏能力会表现为编译或测试失败；受影响的两个 package 均构建成功，每个收窄消费者的聚焦测试也已通过。
- 未验证 / 不在范围内：完整 session bridge API 和运行时事件路由未改变；未在本地测试 Windows 和 Linux。
- 破坏性变更 / 迁移说明：无。更窄的契约是新增的，现有完整 bridge 仍然兼容。

## 关联 Issue

无。

</details>
