### PR TITLE
refactor(cli): reuse trusted workspace runtime resolver

### DIFF
--- a/packages/cli/src/serve/routes/workspace-git-branches.ts
+++ b/packages/cli/src/serve/routes/workspace-git-branches.ts
@@ -18,30 +18,16 @@ import {
 } from '@qwen-code/qwen-code-core';
 import type { SendBridgeError } from '../server/error-response.js';
 import { safeBody } from '../server/request-helpers.js';
-import type {
-  WorkspaceRegistry,
-  WorkspaceRuntime,
-} from '../workspace-registry.js';
+import type { WorkspaceRegistry } from '../workspace-registry.js';
 import {
-  requireTrustedWorkspaceRuntime,
   resolveContainedCwd,
   resolveContainedCwdOrFail,
-  resolveWorkspaceRuntimeFromParam,
+  resolveTrustedRuntime,
   sendGenerationClosedError,
   sendUntrustedWorkspaceResponse,
 } from '../workspace-route-runtime.js';
 
 const GIT_ERROR_MESSAGE_MAX = 512;
-
-function resolveTrustedRuntime(
-  registry: WorkspaceRegistry,
-  req: Request,
-  res: Response,
-): WorkspaceRuntime | null {
-  const runtime = resolveWorkspaceRuntimeFromParam(registry, req, res);
-  if (!runtime) return null;
-  return requireTrustedWorkspaceRuntime(runtime, res) ? runtime : null;
-}
 
 function sendGitError(
   res: Response,

--- a/packages/cli/src/serve/routes/workspace-git-diff.ts
+++ b/packages/cli/src/serve/routes/workspace-git-diff.ts
@@ -12,14 +12,10 @@ import {
   type GitDiffResult,
 } from '@qwen-code/qwen-code-core';
 import type { SendBridgeError } from '../server/error-response.js';
-import type {
-  WorkspaceRegistry,
-  WorkspaceRuntime,
-} from '../workspace-registry.js';
+import type { WorkspaceRegistry } from '../workspace-registry.js';
 import {
-  requireTrustedWorkspaceRuntime,
   resolveContainedCwd,
-  resolveWorkspaceRuntimeFromParam,
+  resolveTrustedRuntime,
   sendUntrustedWorkspaceResponse,
 } from '../workspace-route-runtime.js';
 import { applyReadHeaders } from './workspace-file-read.js';
@@ -198,16 +194,6 @@ export function registerWorkspaceGitDiffRoutes(
       deps.captureGenerationAssertion?.(),
     );
   });
-}
-
-function resolveTrustedRuntime(
-  registry: WorkspaceRegistry,
-  req: Request,
-  res: Response,
-): WorkspaceRuntime | null {
-  const runtime = resolveWorkspaceRuntimeFromParam(registry, req, res);
-  if (!runtime) return null;
-  return requireTrustedWorkspaceRuntime(runtime, res) ? runtime : null;
 }
 
 export function registerWorkspaceQualifiedGitDiffRoutes(

--- a/packages/cli/src/serve/routes/workspace-git-log.ts
+++ b/packages/cli/src/serve/routes/workspace-git-log.ts
@@ -14,14 +14,10 @@ import {
   type GitCommitDetail,
 } from '@qwen-code/qwen-code-core';
 import type { SendBridgeError } from '../server/error-response.js';
-import type {
-  WorkspaceRegistry,
-  WorkspaceRuntime,
-} from '../workspace-registry.js';
+import type { WorkspaceRegistry } from '../workspace-registry.js';
 import {
-  requireTrustedWorkspaceRuntime,
   resolveContainedCwd,
-  resolveWorkspaceRuntimeFromParam,
+  resolveTrustedRuntime,
 } from '../workspace-route-runtime.js';
 import { applyReadHeaders } from './workspace-file-read.js';
 
@@ -177,16 +173,6 @@ export function registerWorkspaceGitLogRoutes(
       'GET /workspace/git/log/commit',
     );
   });
-}
-
-function resolveTrustedRuntime(
-  registry: WorkspaceRegistry,
-  req: Request,
-  res: Response,
-): WorkspaceRuntime | null {
-  const runtime = resolveWorkspaceRuntimeFromParam(registry, req, res);
-  if (!runtime) return null;
-  return requireTrustedWorkspaceRuntime(runtime, res) ? runtime : null;
 }
 
 export function registerWorkspaceQualifiedGitLogRoutes(

--- a/packages/cli/src/serve/routes/workspace-git.ts
+++ b/packages/cli/src/serve/routes/workspace-git.ts
@@ -4,19 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Application, Request, Response } from 'express';
+import type { Application } from 'express';
 import { getGitWorkingTreeStatus } from '@qwen-code/qwen-code-core';
 import type { AcpSessionBridge } from '../acp-session-bridge.js';
 import type { SendBridgeError } from '../server/error-response.js';
 import type { WorkspaceGitState } from '../workspace-git-state.js';
-import type {
-  WorkspaceRegistry,
-  WorkspaceRuntime,
-} from '../workspace-registry.js';
+import type { WorkspaceRegistry } from '../workspace-registry.js';
 import {
-  requireTrustedWorkspaceRuntime,
   resolveContainedCwd,
-  resolveWorkspaceRuntimeFromParam,
+  resolveTrustedRuntime,
   sendUntrustedWorkspaceResponse,
 } from '../workspace-route-runtime.js';
 
@@ -58,16 +54,6 @@ export function registerWorkspaceGitRoutes(
       deps.sendBridgeError(res, err, { route: 'GET /workspace/git' });
     }
   });
-}
-
-function resolveTrustedRuntime(
-  registry: WorkspaceRegistry,
-  req: Request,
-  res: Response,
-): WorkspaceRuntime | null {
-  const runtime = resolveWorkspaceRuntimeFromParam(registry, req, res);
-  if (!runtime) return null;
-  return requireTrustedWorkspaceRuntime(runtime, res) ? runtime : null;
 }
 
 export function registerWorkspaceQualifiedGitRoutes(

--- a/packages/cli/src/serve/routes/workspace-status.ts
+++ b/packages/cli/src/serve/routes/workspace-status.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Application, Request, RequestHandler, Response } from 'express';
+import type { Application, RequestHandler } from 'express';
 import type { AcpSessionBridge } from '../acp-session-bridge.js';
 import type { SendBridgeError } from '../server/error-response.js';
 import {
@@ -12,10 +12,7 @@ import {
   MAX_SERVER_NAME_LENGTH,
 } from '../server/request-helpers.js';
 import type { DaemonWorkspaceService } from '../workspace-service/index.js';
-import {
-  requireTrustedWorkspaceRuntime,
-  resolveWorkspaceRuntimeFromParam,
-} from '../workspace-route-runtime.js';
+import { resolveTrustedRuntime } from '../workspace-route-runtime.js';
 import type {
   WorkspaceRegistry,
   WorkspaceRuntime,
@@ -227,16 +224,6 @@ export function registerWorkspaceStatusRoutes(
       sendBridgeError(res, err, { route: 'GET /workspace/providers' });
     }
   });
-}
-
-function resolveTrustedRuntime(
-  registry: WorkspaceRegistry,
-  req: Request,
-  res: Response,
-): WorkspaceRuntime | null {
-  const runtime = resolveWorkspaceRuntimeFromParam(registry, req, res);
-  if (!runtime) return null;
-  return requireTrustedWorkspaceRuntime(runtime, res) ? runtime : null;
 }
 
 export function registerWorkspaceQualifiedStatusRoutes(

--- a/packages/cli/src/serve/workspace-route-runtime.test.ts
+++ b/packages/cli/src/serve/workspace-route-runtime.test.ts
@@ -18,6 +18,7 @@ import {
   resolveContainedCwd,
   resolveContainedCwdOrFail,
   resolveRegisteredWorkspaceRuntimeByPathSelector,
+  resolveTrustedRuntime,
   resolveWorkspaceRuntimeFromParam,
   resolveWorkspaceRuntimeWithLiveCompatibilityFromParam,
 } from './workspace-route-runtime.js';
@@ -240,6 +241,44 @@ describe('resolveWorkspaceRuntimeFromParam', () => {
     expect(response.json).toHaveBeenCalledWith({
       error: '`:workspace` must decode to a workspace id or absolute path',
       code: 'workspace_mismatch',
+    });
+  });
+});
+
+describe('resolveTrustedRuntime', () => {
+  it('returns an active trusted runtime', () => {
+    const runtime = makeRuntime();
+    const registry = createSingleWorkspaceRegistry(runtime);
+
+    expect(
+      resolveTrustedRuntime(
+        registry,
+        {
+          params: { workspace: runtime.workspaceId },
+        } as unknown as Request,
+        makeResponse(),
+      ),
+    ).toBe(runtime);
+  });
+
+  it('rejects an active untrusted runtime', () => {
+    const runtime = { ...makeRuntime(), trusted: false };
+    const registry = createSingleWorkspaceRegistry(runtime);
+    const response = makeResponse();
+
+    expect(
+      resolveTrustedRuntime(
+        registry,
+        {
+          params: { workspace: runtime.workspaceId },
+        } as unknown as Request,
+        response,
+      ),
+    ).toBeNull();
+    expect(response.status).toHaveBeenCalledWith(403);
+    expect(response.json).toHaveBeenCalledWith({
+      error: 'Workspace is not trusted.',
+      code: 'untrusted_workspace',
     });
   });
 });

--- a/packages/cli/src/serve/workspace-route-runtime.ts
+++ b/packages/cli/src/serve/workspace-route-runtime.ts
@@ -176,6 +176,22 @@ export function resolveWorkspaceRuntimeFromParam(
   return runtime;
 }
 
+export function resolveTrustedRuntime(
+  registry: WorkspaceRegistry,
+  req: Request,
+  res: Response,
+  paramName = 'workspace',
+): WorkspaceRuntime | null {
+  const runtime = resolveWorkspaceRuntimeFromParam(
+    registry,
+    req,
+    res,
+    paramName,
+  );
+  if (!runtime) return null;
+  return requireTrustedWorkspaceRuntime(runtime, res) ? runtime : null;
+}
+
 export function resolveWorkspaceRuntimeWithLiveCompatibilityFromParam(
   registry: WorkspaceRegistry,
   req: Request,


### PR DESCRIPTION
## What this PR does

Workspace-scoped Git and status routes now reuse one trusted-runtime resolution path. The shared path performs runtime lookup and workspace trust validation together, preserving the existing route results and failure responses.

## Why it's needed

Five routes independently repeated the same security-sensitive lookup and trust guard. Keeping the check in one place makes the workspace boundary explicit and prevents future routes from accidentally implementing only part of the guard.

## Reviewer Test Plan

### How to verify

Exercise the workspace Git branches, diff, log, repository status, and workspace status routes against a trusted runtime and confirm their existing responses are unchanged. Repeat against an untrusted runtime and confirm every route rejects the request with HTTP 403 rather than reaching a fallback runtime.

The focused route suites pass: 26 tests.

### Evidence (Before & After)

N/A — internal route boundary refactor with direct trusted and untrusted runtime coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS arm64, Node.js v25.6.1; 26 focused Vitest tests, CLI build, and ESLint completed successfully.

## Risk & Scope

- Main risk or tradeoff: The shared helper is security-sensitive; direct tests cover both the resolved runtime and the exact untrusted-workspace 403 response.
- Not validated / out of scope: Other daemon route ownership models are unchanged; Windows and Linux were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

工作区范围的 Git 和状态路由现在复用同一条可信运行时解析路径。共享逻辑把运行时查找和工作区信任校验放在一起，同时保持原有路由结果和失败响应不变。

## 为什么需要

此前五个路由分别重复同一套安全敏感的查找和信任保护。将检查集中到一处可以明确工作区边界，也能避免未来路由只实现其中一部分保护逻辑。

## Reviewer 测试计划

### 如何验证

对可信运行时分别调用工作区 Git 分支、diff、日志、仓库状态和工作区状态路由，确认原有响应不变。再对不可信运行时重复调用，确认所有路由都返回 HTTP 403，而不会落到后备运行时。

聚焦路由测试全部通过：26 个测试。

### 证据（修改前与修改后）

不适用——这是带可信和不可信运行时直接覆盖的内部路由边界重构。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|   🪟 Windows     |  ⚠️  |
|    🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS arm64、Node.js v25.6.1；26 个聚焦 Vitest 测试、CLI 构建和 ESLint 均成功完成。

## 风险与范围

- 主要风险或取舍：共享辅助逻辑涉及安全边界；直接测试同时覆盖成功解析的运行时和精确的不可信工作区 403 响应。
- 未验证 / 不在范围内：其他 daemon 路由的归属模型未改变；未在本地测试 Windows 和 Linux。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
