### PR TITLE
refactor(core): break config client runtime cycle

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -17,7 +17,8 @@ import { createUserContent } from './genai-compat.js';
 import process from 'node:process';
 
 // Config
-import { ApprovalMode, type Config } from '../config/config.js';
+import type { Config } from '../config/config.js';
+import { ApprovalMode } from '../config/approval-mode.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { cleanupOldToolResults } from '../utils/toolResultCleanup.js';
 import { Storage } from '../config/storage.js';


### PR DESCRIPTION
## What this PR does

The Core client now imports the approval-mode runtime enum from its dependency-neutral definition while keeping the public configuration type import type-only. The public configuration export remains unchanged.

## Why it's needed

The configuration facade initializes the client, while the client imported that same facade at runtime only to access one enum. Importing the enum from its leaf definition removes the direct runtime cycle without changing API shape or adding an abstraction.

## Reviewer Test Plan

### How to verify

Initialize the Core client through the public configuration path and confirm approval modes, including automatic edit approval, map to the same runtime behavior. Confirm the client can be imported without depending on configuration-facade initialization order.

The targeted client suite passes: 1 relevant test, with 365 unrelated cases skipped by the test filter.

### Evidence (Before & After)

N/A — dependency import correction with no user-facing behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS arm64, Node.js v25.6.1; targeted Vitest test, Core build, and ESLint completed successfully.

## Risk & Scope

- Main risk or tradeoff: Very low; only the runtime import source changes, and both sources expose the same enum object through the existing public re-export.
- Not validated / out of scope: Broader dependency-cycle cleanup and Windows/Linux local runs are out of scope.
- Breaking changes / migration notes: None.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

Core client 现在从无依赖的定义模块导入运行时 approval-mode 枚举，同时保持公共配置类型为纯类型导入。公共配置导出保持不变。

## 为什么需要

配置 facade 会初始化 client，而 client 此前仅为访问一个枚举就在运行时反向导入同一个 facade。直接从叶子定义导入枚举，在不改变 API 形态、也不增加抽象的情况下移除了直接运行时循环。

## Reviewer 测试计划

### 如何验证

通过公共配置路径初始化 Core client，确认包括自动编辑批准在内的 approval mode 仍映射到相同运行时行为。确认导入 client 时不再依赖配置 facade 的初始化顺序。

定向 client 测试通过：1 个相关测试；测试过滤器跳过 365 个无关用例。

### 证据（修改前与修改后）

不适用——这是依赖导入修正，没有用户可见行为变化。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|   🪟 Windows     |  ⚠️  |
|    🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS arm64、Node.js v25.6.1；定向 Vitest 测试、Core 构建和 ESLint 均成功完成。

## 风险与范围

- 主要风险或取舍：非常低；仅修改运行时导入来源，两个来源通过现有公共 re-export 暴露同一个枚举对象。
- 未验证 / 不在范围内：更广泛的依赖循环清理以及 Windows/Linux 本地运行不在范围内。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无。

</details>
