### PR TITLE
fix(mcp): recover restarted HTTP MCP servers in-session and in CLI

### DIFF
--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -271,6 +271,9 @@ describe('mcp reconnect command', () => {
         'Failed to reconnect to server "test-server": Connection refused',
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+      // The handler's `process.exit(1)` does not terminate stdio MCP servers
+      // the failed attempt spawned; shutdown must run on the failure path too.
+      expect(mockConfig.shutdown).toHaveBeenCalled();
     });
   });
 
@@ -456,6 +459,9 @@ describe('mcp reconnect command', () => {
       expect(mockWriteStdoutLine).not.toHaveBeenCalledWith(
         'Successfully reconnected to server "test-server".',
       );
+      // Verification failure throws before the success output; shutdown must
+      // still run or the spawned server is orphaned by `process.exit(1)`.
+      expect(mockConfig.shutdown).toHaveBeenCalled();
     });
 
     it('marks --all entries failed when they never reached CONNECTED', async () => {

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -361,6 +361,13 @@ describe('mcp reconnect command', () => {
         'Failed to reconnect 1 of 2 configured server(s).',
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+      // The process-scope note must print on the failure path too — that is
+      // exactly when the user's running session still has broken tools.
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'cannot refresh the MCP tools of an already-running Qwen Code session',
+        ),
+      );
     });
   });
 
@@ -489,6 +496,11 @@ describe('mcp reconnect command', () => {
         '✗ server-two: Failed - connection attempt finished without a live connection (status: disconnected)',
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'cannot refresh the MCP tools of an already-running Qwen Code session',
+        ),
+      );
     });
   });
 

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -67,6 +67,7 @@ describe('mcp reconnect command', () => {
     getToolRegistry: vi.Mock;
     shutdown: vi.Mock;
     initialize: vi.Mock;
+    getMcpServerUnavailableReason: vi.Mock;
     isMcpServerDisabled: vi.Mock;
     isMcpServerPendingApproval: vi.Mock;
     isTrustedFolder: vi.Mock;
@@ -94,6 +95,7 @@ describe('mcp reconnect command', () => {
       initialize: vi.fn().mockResolvedValue(undefined),
       // Default: nothing is skipped, so verification failures report the
       // generic connection message.
+      getMcpServerUnavailableReason: vi.fn().mockReturnValue(undefined),
       isMcpServerDisabled: vi.fn().mockReturnValue(false),
       isMcpServerPendingApproval: vi.fn().mockReturnValue(false),
       isTrustedFolder: vi.fn().mockReturnValue(true),
@@ -709,6 +711,122 @@ describe('mcp reconnect command', () => {
         'Failed to reconnect 1 of 2 configured server(s).',
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('reports an excluded server with the mcp.excluded reason, not the disabled flag', async () => {
+      // A real Config answers `isMcpServerDisabled` = true for an
+      // `mcp.excluded` server, so pre-fix the skip was misattributed to a
+      // per-server disabled flag that does not exist. The admission
+      // classifier (`getMcpServerUnavailableReason`) must win.
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+      mockConfig.getMcpServerUnavailableReason.mockReturnValue('excluded');
+      mockConfig.isMcpServerDisabled.mockReturnValue(true);
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Failed to reconnect to server "test-server": no connection attempt was made: server is excluded in settings (mcp.excluded)',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('reports an allow-list-blocked server as skipped instead of a failed connection', async () => {
+      // A server the `mcp.allowed` list keeps out is a deliberate skip;
+      // pre-fix it fell through every classifier branch and was reported
+      // as a failed connection attempt (status: disconnected).
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+      mockConfig.getMcpServerUnavailableReason.mockReturnValue('not_allowed');
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Failed to reconnect to server "test-server": no connection attempt was made: server is not in the mcp.allowed list',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('--all reports an allow-list-blocked server as skipped without counting it as a failure', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'server-one': { command: '/path/to/server1' },
+            'server-two': { command: '/path/to/server2' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockImplementation((name: string) =>
+        name === 'server-one' ? 'connected' : 'disconnected',
+      );
+      mockConfig.getMcpServerUnavailableReason.mockImplementation(
+        (name: string) => (name === 'server-two' ? 'not_allowed' : undefined),
+      );
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': undefined, all: true });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '✓ server-one: Reconnected successfully',
+      );
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '- server-two: Skipped - server is not in the mcp.allowed list',
+      );
+      // An intentional skip must not count toward the failure total —
+      // otherwise one allow-list-blocked server forces exit 1 forever.
+      expect(mockWriteStderrLine).not.toHaveBeenCalled();
+      expect(mockProcessExit).not.toHaveBeenCalled();
+    });
+
+    it('--all reports an excluded server as skipped without counting it as a failure', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'server-one': { command: '/path/to/server1' },
+            'server-two': { command: '/path/to/server2' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockImplementation((name: string) =>
+        name === 'server-one' ? 'connected' : 'disconnected',
+      );
+      mockConfig.getMcpServerUnavailableReason.mockImplementation(
+        (name: string) => (name === 'server-two' ? 'excluded' : undefined),
+      );
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': undefined, all: true });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '✓ server-one: Reconnected successfully',
+      );
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '- server-two: Skipped - server is excluded in settings (mcp.excluded)',
+      );
+      expect(mockWriteStderrLine).not.toHaveBeenCalled();
+      expect(mockProcessExit).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -65,6 +65,9 @@ describe('mcp reconnect command', () => {
     getToolRegistry: vi.Mock;
     shutdown: vi.Mock;
     initialize: vi.Mock;
+    isMcpServerDisabled: vi.Mock;
+    isMcpServerPendingApproval: vi.Mock;
+    isTrustedFolder: vi.Mock;
   };
   let mockToolRegistry: {
     discoverToolsForServer: vi.Mock;
@@ -87,6 +90,11 @@ describe('mcp reconnect command', () => {
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
       shutdown: vi.fn().mockResolvedValue(undefined),
       initialize: vi.fn().mockResolvedValue(undefined),
+      // Default: nothing is skipped, so verification failures report the
+      // generic connection message.
+      isMcpServerDisabled: vi.fn().mockReturnValue(false),
+      isMcpServerPendingApproval: vi.fn().mockReturnValue(false),
+      isTrustedFolder: vi.fn().mockReturnValue(true),
     };
 
     mockExtensionManager = {
@@ -474,6 +482,68 @@ describe('mcp reconnect command', () => {
       expect(mockWriteStdoutLine).toHaveBeenCalledWith(
         '✗ server-two: Failed - connection attempt finished without a live connection (status: disconnected)',
       );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('skip-vs-failure reporting (issue #9944)', () => {
+    // Discovery skips disabled / pending-approval / untrusted-folder servers
+    // BEFORE any connection attempt, and the status registry defaults
+    // never-seen servers to DISCONNECTED. Reporting those as failed
+    // connection attempts would send debugging in the wrong direction —
+    // the client never tried to connect.
+    it.each([
+      ['disabled', 'isMcpServerDisabled', 'server is disabled in settings'],
+      [
+        'pending approval',
+        'isMcpServerPendingApproval',
+        'server is pending approval (.mcp.json)',
+      ],
+    ] as const)(
+      'reports a %s server as skipped instead of a failed connection',
+      async (_label, predicate, reason) => {
+        mockedLoadSettings.mockReturnValue({
+          merged: {
+            mcpServers: {
+              'test-server': { command: '/path/to/server' },
+            },
+          },
+        });
+        mockGetMCPServerStatus.mockReturnValue('disconnected');
+        mockConfig[predicate].mockReturnValue(true);
+
+        const handler = reconnectCommand.handler as (
+          argv: Record<string, unknown>,
+        ) => Promise<void>;
+        await handler({ 'server-name': 'test-server', all: false });
+
+        expect(mockWriteStderrLine).toHaveBeenCalledWith(
+          `Failed to reconnect to server "test-server": no connection attempt was made: ${reason}`,
+        );
+        expect(mockProcessExit).toHaveBeenCalledWith(1);
+      },
+    );
+
+    it('reports an untrusted workspace as the skip reason', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+      mockConfig.isTrustedFolder.mockReturnValue(false);
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Failed to reconnect to server "test-server": no connection attempt was made: workspace folder is not trusted',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -630,4 +630,59 @@ describe('mcp reconnect command', () => {
       expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('workspace trust in the throwaway config (issue #9944)', () => {
+    // createMinimalConfig must carry the real workspace trust state so the
+    // untrusted-skip branch is reachable and consistent with a normal
+    // session's discovery gate, which skips MCP servers in untrusted folders.
+    it('passes an untrusted workspace to the reconnect config', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+      mockedIsWorkspaceTrusted.mockReturnValue({
+        isTrusted: false,
+        source: 'file',
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(MockedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trustedFolder: false,
+        }),
+      );
+    });
+
+    it('defaults to trusted when workspace trust is undecided', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+      mockedIsWorkspaceTrusted.mockReturnValue({
+        isTrusted: undefined,
+        source: undefined,
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(MockedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trustedFolder: true,
+        }),
+      );
+    });
+  });
 });

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -439,6 +439,33 @@ describe('mcp reconnect command', () => {
         ),
       );
     });
+
+    it('clarifies that single-server failure only covers this process', async () => {
+      // The note must not be success-only: a failed reconnect is exactly
+      // when the user's running session still has broken tools and might
+      // read the exit-1 output as session-level state. `--all` already
+      // prints the note on failure; pin the single-server path to match.
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'cannot refresh the MCP tools of an already-running Qwen Code session',
+        ),
+      );
+    });
   });
 
   describe('connection verification (issue #9944)', () => {

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -297,6 +297,8 @@ describe('mcp reconnect command', () => {
       expect(mockWriteStdoutLine).toHaveBeenCalledWith(
         '✓ server-two: Reconnected successfully',
       );
+      // All servers verified live → no failure exit.
+      expect(mockProcessExit).not.toHaveBeenCalled();
     });
 
     it('should print message when no servers configured', async () => {
@@ -341,6 +343,13 @@ describe('mcp reconnect command', () => {
       expect(mockWriteStdoutLine).toHaveBeenCalledWith(
         '✗ server-two: Failed - Timeout',
       );
+      // A partial failure must still exit non-zero so wrapper scripts
+      // (`qwen mcp reconnect --all || alert`) can see it — matching the
+      // single-server path, which exits 1 for the identical failure.
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Failed to reconnect 1 of 2 configured server(s).',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
   });
 

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -39,11 +39,19 @@ vi.mock('../../config/mcpApprovals.js', () => ({
   getPendingGatedMcpServers: mockGetPendingGatedMcpServers,
 }));
 
+const mockGetMCPServerStatus = vi.hoisted(() => vi.fn());
+
 vi.mock('@qwen-code/qwen-code-core', () => ({
   Config: vi.fn(),
   FileDiscoveryService: vi.fn(),
   ExtensionManager: vi.fn(),
   getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+  getMCPServerStatus: mockGetMCPServerStatus,
+  MCPServerStatus: {
+    DISCONNECTED: 'disconnected',
+    CONNECTING: 'connecting',
+    CONNECTED: 'connected',
+  },
 }));
 
 const mockedLoadSettings = loadSettings as vi.Mock;
@@ -89,6 +97,10 @@ describe('mcp reconnect command', () => {
     MockedConfig.mockImplementation(() => mockConfig);
     MockedExtensionManager.mockImplementation(() => mockExtensionManager);
     mockGetPendingGatedMcpServers.mockReturnValue([]);
+    // Discovery is best-effort and swallows connect errors, so the command
+    // verifies the outcome through the status registry; default to a live
+    // connection so success-path tests stay green.
+    mockGetMCPServerStatus.mockReturnValue('connected');
     mockedAssembleMcpServers.mockImplementation((servers) => servers ?? {});
     mockedIsWorkspaceTrusted.mockReturnValue({
       isTrusted: true,
@@ -328,6 +340,130 @@ describe('mcp reconnect command', () => {
       );
       expect(mockWriteStdoutLine).toHaveBeenCalledWith(
         '✗ server-two: Failed - Timeout',
+      );
+    });
+  });
+
+  describe('process scope (issue #9944)', () => {
+    it('initializes the throwaway config without background MCP discovery', async () => {
+      // The command runs its own targeted `discoverToolsForServer`; the
+      // background incremental pass would race `config.shutdown()` and
+      // re-arm health-check timers that keep the process alive forever.
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockConfig.initialize).toHaveBeenCalledWith({
+        skipMcpDiscovery: true,
+      });
+    });
+
+    it('clarifies that single-server success only covers this process', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'cannot refresh the MCP tools of an already-running Qwen Code session',
+        ),
+      );
+    });
+
+    it('clarifies that --all success only covers this process', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'server-one': { command: '/path/to/server1' },
+          },
+        },
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': undefined, all: true });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'cannot refresh the MCP tools of an already-running Qwen Code session',
+        ),
+      );
+    });
+  });
+
+  describe('connection verification (issue #9944)', () => {
+    // `discoverToolsForServer` swallows connect errors, so a bare "it
+    // returned" is not proof the server is reachable. The command must
+    // verify the live status instead of printing a false success.
+    it('reports failure when a single server never reached CONNECTED', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { httpUrl: 'http://127.0.0.1:3939/mcp' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockToolRegistry.discoverToolsForServer).toHaveBeenCalledWith(
+        'test-server',
+      );
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Failed to reconnect to server "test-server": connection attempt finished without a live connection (status: disconnected)',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockWriteStdoutLine).not.toHaveBeenCalledWith(
+        'Successfully reconnected to server "test-server".',
+      );
+    });
+
+    it('marks --all entries failed when they never reached CONNECTED', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'server-one': { command: '/path/to/server1' },
+            'server-two': { command: '/path/to/server2' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockImplementation((name: string) =>
+        name === 'server-one' ? 'connected' : 'disconnected',
+      );
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': undefined, all: true });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '✓ server-one: Reconnected successfully',
+      );
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '✗ server-two: Failed - connection attempt finished without a live connection (status: disconnected)',
       );
     });
   });

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -563,5 +563,71 @@ describe('mcp reconnect command', () => {
       );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
+
+    it('--all reports a deliberately skipped server without counting it as a failure', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'server-one': { command: '/path/to/server1' },
+            'server-two': { command: '/path/to/server2', scope: 'workspace' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockImplementation((name: string) =>
+        name === 'server-one' ? 'connected' : 'disconnected',
+      );
+      mockConfig.isMcpServerPendingApproval.mockImplementation(
+        (name: string) => name === 'server-two',
+      );
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': undefined, all: true });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '✓ server-one: Reconnected successfully',
+      );
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '- server-two: Skipped - server is pending approval (.mcp.json)',
+      );
+      // Nothing was attempted-and-failed: no failure summary, exit 0. A
+      // wrapper running `qwen mcp reconnect --all || alert` must not alert
+      // on an intentional skip.
+      expect(mockWriteStderrLine).not.toHaveBeenCalled();
+      expect(mockProcessExit).not.toHaveBeenCalled();
+    });
+
+    it('--all counts only attempted-and-failed servers when skips are present', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'server-one': { command: '/path/to/server1' },
+            'server-two': { command: '/path/to/server2', scope: 'workspace' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+      mockConfig.isMcpServerPendingApproval.mockImplementation(
+        (name: string) => name === 'server-two',
+      );
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': undefined, all: true });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '✗ server-one: Failed - connection attempt finished without a live connection (status: disconnected)',
+      );
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '- server-two: Skipped - server is pending approval (.mcp.json)',
+      );
+      // 1 attempted-and-failed of 2 configured — the skip is not counted.
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Failed to reconnect 1 of 2 configured server(s).',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
   });
 });

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -40,6 +40,7 @@ vi.mock('../../config/mcpApprovals.js', () => ({
 }));
 
 const mockGetMCPServerStatus = vi.hoisted(() => vi.fn());
+const mockGetMCPServerLastError = vi.hoisted(() => vi.fn());
 
 vi.mock('@qwen-code/qwen-code-core', () => ({
   Config: vi.fn(),
@@ -47,6 +48,7 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   ExtensionManager: vi.fn(),
   getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
   getMCPServerStatus: mockGetMCPServerStatus,
+  getMCPServerLastError: mockGetMCPServerLastError,
   MCPServerStatus: {
     DISCONNECTED: 'disconnected',
     CONNECTING: 'connecting',
@@ -109,6 +111,8 @@ describe('mcp reconnect command', () => {
     // verifies the outcome through the status registry; default to a live
     // connection so success-path tests stay green.
     mockGetMCPServerStatus.mockReturnValue('connected');
+    // No recorded failure cause by default; failure-path tests opt in.
+    mockGetMCPServerLastError.mockReturnValue(undefined);
     mockedAssembleMcpServers.mockImplementation((servers) => servers ?? {});
     mockedIsWorkspaceTrusted.mockReturnValue({
       isTrusted: true,
@@ -501,6 +505,56 @@ describe('mcp reconnect command', () => {
           'cannot refresh the MCP tools of an already-running Qwen Code session',
         ),
       );
+    });
+
+    it('surfaces the recorded failure cause when verification fails', async () => {
+      // Discovery swallows the connect error (debugLogger only), but the
+      // client records the cause in the status registry before it is
+      // swallowed. The failure output must carry it — a bare
+      // "(status: disconnected)" sends debugging in no direction at all.
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { httpUrl: 'http://127.0.0.1:3939/mcp' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+      mockGetMCPServerLastError.mockReturnValue(
+        'connect ECONNREFUSED 127.0.0.1:3939',
+      );
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        'Failed to reconnect to server "test-server": connection attempt finished without a live connection (status: disconnected): connect ECONNREFUSED 127.0.0.1:3939',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('--all surfaces the recorded failure cause per server', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'server-one': { httpUrl: 'http://127.0.0.1:3939/mcp' },
+          },
+        },
+      });
+      mockGetMCPServerStatus.mockReturnValue('disconnected');
+      mockGetMCPServerLastError.mockReturnValue('HTTP 401 Unauthorized');
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': undefined, all: true });
+
+      expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+        '✗ server-one: Failed - connection attempt finished without a live connection (status: disconnected): HTTP 401 Unauthorized',
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
   });
 

--- a/packages/cli/src/commands/mcp/reconnect.test.ts
+++ b/packages/cli/src/commands/mcp/reconnect.test.ts
@@ -685,4 +685,106 @@ describe('mcp reconnect command', () => {
       );
     });
   });
+
+  describe('allow/exclude gates in the throwaway config (issue #9944)', () => {
+    // The real session wires `mcp.allowed` / `mcp.excluded` from settings
+    // into Config (loadCliConfig); without the same wiring here the command
+    // would still reach a server the user disabled, or one kept off the
+    // allow-list — connections a normal session would never attempt.
+    it('passes the settings excluded list so excluded servers stay skipped', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+          mcp: {
+            excluded: ['test-server'],
+          },
+        },
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(MockedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludedMcpServers: ['test-server'],
+        }),
+      );
+    });
+
+    it('passes the settings allowed list so the allow-list is respected', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+          mcp: {
+            allowed: ['other-server'],
+          },
+        },
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(MockedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedMcpServers: ['other-server'],
+        }),
+      );
+    });
+
+    it('filters empty entries from both gates like the real session wiring', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+          mcp: {
+            allowed: ['kept', ''],
+            excluded: ['dropped', '', 'dropped'],
+          },
+        },
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(MockedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedMcpServers: ['kept'],
+          excludedMcpServers: ['dropped'],
+        }),
+      );
+    });
+
+    it('leaves both gates undefined when settings has no mcp lists', async () => {
+      mockedLoadSettings.mockReturnValue({
+        merged: {
+          mcpServers: {
+            'test-server': { command: '/path/to/server' },
+          },
+        },
+      });
+
+      const handler = reconnectCommand.handler as (
+        argv: Record<string, unknown>,
+      ) => Promise<void>;
+      await handler({ 'server-name': 'test-server', all: false });
+
+      expect(MockedConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedMcpServers: undefined,
+          excludedMcpServers: undefined,
+        }),
+      );
+    });
+  });
 });

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -157,18 +157,31 @@ function createReconnectError(
 
 /**
  * Discovery skips some servers deliberately BEFORE any connection attempt —
+ * servers off the `mcp.allowed` allow-list, servers in `mcp.excluded`,
  * disabled servers, `.mcp.json` servers pending approval, untrusted
  * workspaces — and `getMCPServerStatus` defaults never-seen servers to
  * DISCONNECTED. Without this check every skip would be reported as a failed
  * connection attempt, sending whoever is debugging to chase networking for a
  * server the client never tried to contact. The skip reasons are cheap and
- * knowable, so report them instead. (Budget-refused slots are decided inside
- * the client manager and stay on the generic failure message.)
+ * knowable, so report them instead. The allow/exclude gates reuse the same
+ * classifier as the tool-not-found path (`getMcpServerUnavailableReason`):
+ * an allow-list-blocked server otherwise falls through every branch below
+ * and is misreported as a failed connection on every run, and an
+ * `mcp.excluded` server is misattributed to the per-server disabled flag
+ * (issue #9944). (Budget-refused slots are decided inside the client
+ * manager and stay on the generic failure message.)
  */
 function describeSkippedConnectionReason(
   config: Config,
   serverName: string,
 ): string | undefined {
+  const unavailableReason = config.getMcpServerUnavailableReason(serverName);
+  if (unavailableReason === 'excluded') {
+    return 'server is excluded in settings (mcp.excluded)';
+  }
+  if (unavailableReason === 'not_allowed') {
+    return 'server is not in the mcp.allowed list';
+  }
   if (config.isMcpServerDisabled(serverName)) {
     return 'server is disabled in settings';
   }

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -11,6 +11,8 @@ import {
   Config,
   FileDiscoveryService,
   ExtensionManager,
+  getMCPServerStatus,
+  MCPServerStatus,
 } from '@qwen-code/qwen-code-core';
 import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
@@ -79,7 +81,12 @@ async function createMinimalConfig(): Promise<Config> {
     ...(fileFiltering !== undefined ? { fileFiltering } : {}),
   });
 
-  await config.initialize();
+  // This command runs its own targeted per-server discovery below
+  // (`discoverToolsForServer`); it does not need the background incremental
+  // pass `initialize()` would otherwise start. Skipping it removes the race
+  // where that background pass re-arms health-check timers after
+  // `config.shutdown()` and leaves the process hanging (issue #9944).
+  await config.initialize({ skipMcpDiscovery: true });
 
   return config;
 }
@@ -88,6 +95,15 @@ interface ReconnectError extends Error {
   exitCode: number;
 }
 
+/**
+ * The reconnect command runs in its own short-lived process: it can verify
+ * (and refresh) its own connection, but it has no channel into a running
+ * Qwen Code session. Say so plainly in the success output so it is not read
+ * as "your running session's MCP tools are back" (issue #9944).
+ */
+const SESSION_SCOPE_NOTE =
+  'Note: this command reconnects in a separate process; it cannot refresh the MCP tools of an already-running Qwen Code session. Restart that session if its tools remain unavailable.';
+
 function createReconnectError(
   message: string,
   exitCode: number = 1,
@@ -95,6 +111,28 @@ function createReconnectError(
   const error = new Error(message) as ReconnectError;
   error.exitCode = exitCode;
   return error;
+}
+
+/**
+ * Runs discovery for one server and verifies that it actually produced a
+ * live connection. `discoverToolsForServer` is best-effort and swallows
+ * connect errors, so without the status check this command would print
+ * "Reconnected successfully" for a server it never reached — e.g. a
+ * single-session HTTP server whose only session is held by a running Qwen
+ * Code session, or a server that is simply down (issue #9944).
+ */
+async function discoverAndVerifyConnection(
+  config: Config,
+  serverName: string,
+): Promise<void> {
+  const toolRegistry = config.getToolRegistry();
+  await toolRegistry.discoverToolsForServer(serverName);
+  const status = getMCPServerStatus(serverName);
+  if (status !== MCPServerStatus.CONNECTED) {
+    throw new Error(
+      `connection attempt finished without a live connection (status: ${status})`,
+    );
+  }
 }
 
 async function reconnectMcpServer(serverName: string): Promise<void> {
@@ -110,9 +148,9 @@ async function reconnectMcpServer(serverName: string): Promise<void> {
 
   try {
     const config = await createMinimalConfig();
-    const toolRegistry = config.getToolRegistry();
-    await toolRegistry.discoverToolsForServer(serverName);
+    await discoverAndVerifyConnection(config, serverName);
     writeStdoutLine(`Successfully reconnected to server "${serverName}".`);
+    writeStdoutLine(SESSION_SCOPE_NOTE);
     await config.shutdown();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -144,17 +182,18 @@ async function reconnectAllMcpServers(): Promise<void> {
   let config: Config | undefined;
   try {
     config = await createMinimalConfig();
-    const toolRegistry = config.getToolRegistry();
 
     for (const serverName of serverNames) {
       try {
-        await toolRegistry.discoverToolsForServer(serverName);
+        await discoverAndVerifyConnection(config, serverName);
         writeStdoutLine(`✓ ${serverName}: Reconnected successfully`);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         writeStdoutLine(`✗ ${serverName}: Failed - ${message}`);
       }
     }
+    writeStdoutLine('');
+    writeStdoutLine(SESSION_SCOPE_NOTE);
   } finally {
     if (config) {
       await config.shutdown();

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -114,6 +114,32 @@ function createReconnectError(
 }
 
 /**
+ * Discovery skips some servers deliberately BEFORE any connection attempt —
+ * disabled servers, `.mcp.json` servers pending approval, untrusted
+ * workspaces — and `getMCPServerStatus` defaults never-seen servers to
+ * DISCONNECTED. Without this check every skip would be reported as a failed
+ * connection attempt, sending whoever is debugging to chase networking for a
+ * server the client never tried to contact. The skip reasons are cheap and
+ * knowable, so report them instead. (Budget-refused slots are decided inside
+ * the client manager and stay on the generic failure message.)
+ */
+function describeSkippedConnectionReason(
+  config: Config,
+  serverName: string,
+): string | undefined {
+  if (config.isMcpServerDisabled(serverName)) {
+    return 'server is disabled in settings';
+  }
+  if (config.isMcpServerPendingApproval(serverName)) {
+    return 'server is pending approval (.mcp.json)';
+  }
+  if (config.isTrustedFolder() === false) {
+    return 'workspace folder is not trusted';
+  }
+  return undefined;
+}
+
+/**
  * Runs discovery for one server and verifies that it actually produced a
  * live connection. `discoverToolsForServer` is best-effort and swallows
  * connect errors, so without the status check this command would print
@@ -129,8 +155,11 @@ async function discoverAndVerifyConnection(
   await toolRegistry.discoverToolsForServer(serverName);
   const status = getMCPServerStatus(serverName);
   if (status !== MCPServerStatus.CONNECTED) {
+    const skippedReason = describeSkippedConnectionReason(config, serverName);
     throw new Error(
-      `connection attempt finished without a live connection (status: ${status})`,
+      skippedReason
+        ? `no connection attempt was made: ${skippedReason}`
+        : `connection attempt finished without a live connection (status: ${status})`,
     );
   }
 }

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -68,6 +68,18 @@ async function createMinimalConfig(): Promise<Config> {
   );
   const mcpServers = await getMcpServersFromConfig();
 
+  // Mirror the real session's allow/exclude gates (see loadCliConfig in
+  // config.ts, which reads the same settings.mcp source): without them this
+  // throwaway Config still reaches servers the user excluded in settings
+  // (`mcp.excluded`) or kept off the `mcp.allowed` list — connections a
+  // normal session would never attempt.
+  const allowedMcpServers = settings.merged.mcp?.allowed
+    ? new Set(settings.merged.mcp.allowed.filter(Boolean))
+    : undefined;
+  const excludedMcpServers = settings.merged.mcp?.excluded
+    ? new Set(settings.merged.mcp.excluded.filter(Boolean))
+    : undefined;
+
   const config = new Config({
     sessionId: 'mcp-reconnect',
     targetDir: cwd,
@@ -78,6 +90,12 @@ async function createMinimalConfig(): Promise<Config> {
     pendingMcpServers: getPendingGatedMcpServers(mcpServers, cwd),
     fileDiscoveryService: fileService,
     mcpServerCommand: settings.merged.mcp?.serverCommand,
+    allowedMcpServers: allowedMcpServers
+      ? Array.from(allowedMcpServers)
+      : undefined,
+    excludedMcpServers: excludedMcpServers
+      ? Array.from(excludedMcpServers)
+      : undefined,
     // Mirror a real session's trust gate: discovery skips MCP servers in an
     // untrusted workspace, so the throwaway Config must carry the same trust
     // state. Without it `isTrustedFolder()` defaults to true here, the

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -239,6 +239,11 @@ async function reconnectMcpServer(serverName: string): Promise<void> {
     writeStdoutLine(SESSION_SCOPE_NOTE);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    // The scope note applies to failure exactly as to success — a failed
+    // reconnect is precisely when the user's running session still has
+    // broken tools and the "separate process" caveat matters. `--all`
+    // prints it on failure too; the two paths must stay consistent.
+    writeStdoutLine(SESSION_SCOPE_NOTE);
     throw createReconnectError(
       `Failed to reconnect to server "${serverName}": ${message}`,
     );

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -96,6 +96,23 @@ interface ReconnectError extends Error {
 }
 
 /**
+ * Thrown when discovery deliberately skips a server BEFORE any connection
+ * attempt (disabled, `.mcp.json` pending approval, untrusted workspace).
+ * Typed so result-aggregating callers can tell a skip from a failed
+ * connection attempt: `--all` must not count skips toward its failure total,
+ * or one intentionally-skipped server would force exit code 1 forever.
+ */
+class SkippedConnectionError extends Error {
+  readonly skipReason: string;
+
+  constructor(skipReason: string) {
+    super(`no connection attempt was made: ${skipReason}`);
+    this.name = 'SkippedConnectionError';
+    this.skipReason = skipReason;
+  }
+}
+
+/**
  * The reconnect command runs in its own short-lived process: it can verify
  * (and refresh) its own connection, but it has no channel into a running
  * Qwen Code session. Say so plainly in the success output so it is not read
@@ -156,10 +173,11 @@ async function discoverAndVerifyConnection(
   const status = getMCPServerStatus(serverName);
   if (status !== MCPServerStatus.CONNECTED) {
     const skippedReason = describeSkippedConnectionReason(config, serverName);
+    if (skippedReason) {
+      throw new SkippedConnectionError(skippedReason);
+    }
     throw new Error(
-      skippedReason
-        ? `no connection attempt was made: ${skippedReason}`
-        : `connection attempt finished without a live connection (status: ${status})`,
+      `connection attempt finished without a live connection (status: ${status})`,
     );
   }
 }
@@ -227,6 +245,15 @@ async function reconnectAllMcpServers(): Promise<void> {
         await discoverAndVerifyConnection(config, serverName);
         writeStdoutLine(`✓ ${serverName}: Reconnected successfully`);
       } catch (error) {
+        if (error instanceof SkippedConnectionError) {
+          // An intentional skip is not a failure — the client never tried to
+          // connect. Report it informationally and keep it out of failedCount:
+          // counting it would force exit code 1 on every run (alerting
+          // `qwen mcp reconnect --all || alert` wrappers forever) even though
+          // nothing actually failed.
+          writeStdoutLine(`- ${serverName}: Skipped - ${error.skipReason}`);
+          continue;
+        }
         failedCount++;
         const message = error instanceof Error ? error.message : String(error);
         writeStdoutLine(`✗ ${serverName}: Failed - ${message}`);

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -180,6 +180,7 @@ async function reconnectAllMcpServers(): Promise<void> {
   writeStdoutLine('Reconnecting to all MCP servers...\n');
 
   let config: Config | undefined;
+  let failedCount = 0;
   try {
     config = await createMinimalConfig();
 
@@ -188,6 +189,7 @@ async function reconnectAllMcpServers(): Promise<void> {
         await discoverAndVerifyConnection(config, serverName);
         writeStdoutLine(`✓ ${serverName}: Reconnected successfully`);
       } catch (error) {
+        failedCount++;
         const message = error instanceof Error ? error.message : String(error);
         writeStdoutLine(`✗ ${serverName}: Failed - ${message}`);
       }
@@ -198,6 +200,17 @@ async function reconnectAllMcpServers(): Promise<void> {
     if (config) {
       await config.shutdown();
     }
+  }
+
+  // Per-server errors are caught and reported above; without this throw the
+  // handler's `process.exit(exitCode)` never runs and `--all` exits 0 even
+  // when some (or all) servers failed verification — the single-server path
+  // exits 1 for the identical failure. Wrapper scripts running
+  // `qwen mcp reconnect --all || alert` would never alert.
+  if (failedCount > 0) {
+    throw createReconnectError(
+      `Failed to reconnect ${failedCount} of ${serverNames.length} configured server(s).`,
+    );
   }
 }
 

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -175,17 +175,26 @@ async function reconnectMcpServer(serverName: string): Promise<void> {
 
   writeStdoutLine(`Reconnecting to server "${serverName}"...`);
 
+  // Shutdown must run on the failure path too: `discoverAndVerifyConnection`
+  // throws on a non-CONNECTED status, the handler then `process.exit(1)`s,
+  // and `process.exit` does not terminate stdio MCP servers the failed
+  // attempt spawned — each retry would orphan another process. Mirror the
+  // `--all` try/finally structure (issue #9944).
+  let config: Config | undefined;
   try {
-    const config = await createMinimalConfig();
+    config = await createMinimalConfig();
     await discoverAndVerifyConnection(config, serverName);
     writeStdoutLine(`Successfully reconnected to server "${serverName}".`);
     writeStdoutLine(SESSION_SCOPE_NOTE);
-    await config.shutdown();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw createReconnectError(
       `Failed to reconnect to server "${serverName}": ${message}`,
     );
+  } finally {
+    if (config) {
+      await config.shutdown();
+    }
   }
 }
 

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -11,6 +11,7 @@ import {
   Config,
   FileDiscoveryService,
   ExtensionManager,
+  getMCPServerLastError,
   getMCPServerStatus,
   MCPServerStatus,
 } from '@qwen-code/qwen-code-core';
@@ -187,6 +188,12 @@ function describeSkippedConnectionReason(
  * "Reconnected successfully" for a server it never reached — e.g. a
  * single-session HTTP server whose only session is held by a running Qwen
  * Code session, or a server that is simply down (issue #9944).
+ *
+ * When verification fails, the underlying connect cause (ECONNREFUSED, an
+ * OAuth 401, a spawn error...) is retrievable via `getMCPServerLastError`:
+ * the client records it into the status registry before discovery's
+ * best-effort catch swallows it. Append it so the failure output tells the
+ * user WHY instead of a bare status enum.
  */
 async function discoverAndVerifyConnection(
   config: Config,
@@ -200,8 +207,10 @@ async function discoverAndVerifyConnection(
     if (skippedReason) {
       throw new SkippedConnectionError(skippedReason);
     }
+    const lastError = getMCPServerLastError(serverName);
     throw new Error(
-      `connection attempt finished without a live connection (status: ${status})`,
+      `connection attempt finished without a live connection (status: ${status})` +
+        (lastError ? `: ${lastError}` : ''),
     );
   }
 }

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -78,6 +78,12 @@ async function createMinimalConfig(): Promise<Config> {
     pendingMcpServers: getPendingGatedMcpServers(mcpServers, cwd),
     fileDiscoveryService: fileService,
     mcpServerCommand: settings.merged.mcp?.serverCommand,
+    // Mirror a real session's trust gate: discovery skips MCP servers in an
+    // untrusted workspace, so the throwaway Config must carry the same trust
+    // state. Without it `isTrustedFolder()` defaults to true here, the
+    // untrusted-skip reporting below becomes unreachable, and this command
+    // would attempt connections a normal session would not (issue #9944).
+    trustedFolder: isWorkspaceTrusted(settings.merged).isTrusted ?? true,
     ...(fileFiltering !== undefined ? { fileFiltering } : {}),
   });
 

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -1527,6 +1527,65 @@ describe('McpClientManager', () => {
     }
   });
 
+  it('unrefs health-check timers so they never hold the event loop open (issue #9944)', async () => {
+    // `qwen mcp reconnect` (and other short-lived Config consumers) call
+    // `config.shutdown()` while an incremental discovery pass is still in
+    // flight; that pass's `finally` block re-arms health checks AFTER
+    // `stop()` cleared them. Pre-fix those intervals were ref'd, so the
+    // process hung forever. Health monitoring is background bookkeeping —
+    // the timer must be unref'd so it never keeps the loop alive on its own.
+    // Real timers here: the assertion is about `hasRef()`, which fake timers
+    // do not model faithfully.
+    const client = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      discover: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn(),
+    };
+    vi.mocked(McpClient).mockReturnValue(client as unknown as McpClient);
+
+    const mockConfig = {
+      isTrustedFolder: () => true,
+      getMcpServers: () => ({ 'test-server': {} }),
+      getMcpServerCommand: () => undefined,
+      getTargetDir: () => '/session/worktree',
+      getPromptRegistry: () =>
+        ({ removePromptsByServer: vi.fn() }) as unknown as PromptRegistry,
+      getResourceRegistry: () => ({ removeResourcesByServer: vi.fn() }),
+      getWorkspaceContext: () => ({}) as WorkspaceContext,
+      getDebugMode: () => false,
+    } as unknown as Config;
+    const manager = mkManager({
+      config: mockConfig,
+      options: {
+        healthConfig: {
+          autoReconnect: true,
+          // Long interval: we only inspect the armed timer, we never let it
+          // fire.
+          checkIntervalMs: 60_000,
+          maxConsecutiveFailures: 3,
+          reconnectDelayMs: 10,
+        },
+      },
+    });
+
+    try {
+      await manager.discoverMcpToolsForServer(
+        'test-server',
+        {} as unknown as Config,
+      );
+      const timer = (
+        manager as unknown as {
+          healthCheckTimers: Map<string, NodeJS.Timeout>;
+        }
+      ).healthCheckTimers.get('test-server');
+      expect(timer).toBeDefined();
+      expect(timer?.hasRef()).toBe(false);
+    } finally {
+      await manager.stop();
+    }
+  });
+
   it('should clear in-flight discovery tracking when stopping', async () => {
     let resolveConnect!: () => void;
     const connectPromise = new Promise<void>((resolve) => {

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -2010,6 +2010,15 @@ export class McpClientManager {
     const timer = setInterval(async () => {
       await this.performHealthCheck(serverName);
     }, this.healthConfig.checkIntervalMs);
+    // Health monitoring is background bookkeeping — it must never hold the
+    // event loop open. Short-lived consumers (`qwen mcp reconnect`, other
+    // one-shot Config users) call `config.shutdown()` while an incremental
+    // discovery pass is still in flight; that pass's `finally` block then
+    // re-arms health checks AFTER `stop()` already cleared them, and a
+    // ref'd interval left the process hanging forever (issue #9944). Long-
+    // running sessions keep their own loop refs (TTY / server sockets), so
+    // unref'ing the monitor does not shorten its life where it matters.
+    timer.unref?.();
 
     this.healthCheckTimers.set(serverName, timer);
   }

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -3678,9 +3678,7 @@ lOTTGqPpwFUbw2EMOOpFYuIyzGMIpUNMBjE2gvJiqFQ=
         mockedClient as unknown as ClientLib.Client,
       );
       const mockedTransport = {
-        terminateSession: vi
-          .fn()
-          .mockRejectedValue(new Error('ECONNREFUSED')),
+        terminateSession: vi.fn().mockRejectedValue(new Error('ECONNREFUSED')),
         close: vi.fn().mockResolvedValue(undefined),
       };
       vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue(
@@ -3702,6 +3700,57 @@ lOTTGqPpwFUbw2EMOOpFYuIyzGMIpUNMBjE2gvJiqFQ=
       expect(client.getStatus()).toBe(MCPServerStatus.DISCONNECTED);
 
       removeMCPServerStatus('dead-http-server');
+    });
+
+    it('disconnect() does not hang when terminateSession never responds (issue #9944)', async () => {
+      // A live-but-unresponsive server (TCP open, never answers the DELETE)
+      // must not block teardown: the SDK's `terminateSession()` has no
+      // timeout of its own and the transport's abort controller is only
+      // aborted by `close()` — which runs after the await. `disconnect()`
+      // therefore bounds the call and proceeds to `close()`, which aborts
+      // the still-in-flight request.
+      vi.useFakeTimers();
+      try {
+        const mockedClient = {
+          connect: vi.fn(),
+          registerCapabilities: vi.fn(),
+          setRequestHandler: vi.fn(),
+          close: vi.fn(),
+          getInstructions: vi.fn(),
+        };
+        vi.mocked(ClientLib.Client).mockReturnValue(
+          mockedClient as unknown as ClientLib.Client,
+        );
+        const mockedTransport = {
+          terminateSession: vi.fn(() => new Promise<void>(() => {})), // never settles
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+        vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue(
+          mockedTransport as unknown as SdkClientStdioLib.StdioClientTransport,
+        );
+
+        const client = new McpClient(
+          'unresponsive-http-server',
+          { command: 'test-command' },
+          {} as ToolRegistry,
+          {} as PromptRegistry,
+          { getDirectories: () => [] } as unknown as WorkspaceContext,
+          false,
+        );
+
+        await client.connect();
+        const disconnected = client.disconnect();
+        // The bounded wait fires, and teardown completes even though the
+        // DELETE never got an answer.
+        await vi.advanceTimersByTimeAsync(2_000);
+        await expect(disconnected).resolves.toBeUndefined();
+        expect(mockedTransport.close).toHaveBeenCalledTimes(1);
+        expect(client.getStatus()).toBe(MCPServerStatus.DISCONNECTED);
+
+        removeMCPServerStatus('unresponsive-http-server');
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -3609,6 +3609,13 @@ lOTTGqPpwFUbw2EMOOpFYuIyzGMIpUNMBjE2gvJiqFQ=
 
       // The entry must remain absent — no resurrection.
       expect(getAllMCPServerStatuses().has('racy-server')).toBe(false);
+      // Same invariant for the failure-cause map: the status write is
+      // suppressed by the `isDisconnecting` guard, and the lastError record
+      // in connect()'s catch must be gated the same way — otherwise the
+      // doomed in-flight connect resurrects an orphan cause entry that
+      // `removeMCPServerStatus` already dropped (persisting until process
+      // exit and misattributing to a later re-added incarnation).
+      expect(getMCPServerLastError('racy-server')).toBeUndefined();
     });
 
     it('disconnect() propagates DISCONNECTED to the global registry', async () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2138,6 +2138,52 @@ lOTTGqPpwFUbw2EMOOpFYuIyzGMIpUNMBjE2gvJiqFQ=
       expect(promptRegistry.registerPrompt).not.toHaveBeenCalled();
     });
 
+    it('discoverAndReturn records the discovery failure cause in the status registry (issue #9944)', async () => {
+      // Same carrier as connect()'s catch: a server whose connect()
+      // succeeds but discovery fails (up-but-empty) reaches
+      // discoverAndReturn()'s catch, which the manager swallows for
+      // best-effort discovery. `qwen mcp reconnect` relies on
+      // `getMCPServerLastError` to print the cause — the status enum alone
+      // only says DISCONNECTED.
+      const mockedClient = {
+        connect: vi.fn(),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        getServerCapabilities: vi.fn().mockReturnValue({ prompts: {} }),
+        request: vi.fn().mockResolvedValue({ prompts: [] }),
+        listTools: vi.fn().mockResolvedValue({ tools: [] }),
+        getInstructions: vi.fn(),
+      };
+      vi.mocked(ClientLib.Client).mockReturnValue(
+        mockedClient as unknown as ClientLib.Client,
+      );
+      vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue(
+        {} as SdkClientStdioLib.StdioClientTransport,
+      );
+      vi.mocked(GenAiLib.mcpToTool).mockReturnValue({
+        tool: () => Promise.resolve({ functionDeclarations: [] }),
+      } as unknown as GenAiLib.CallableTool);
+
+      const client = new McpClient(
+        'discovery-cause-server',
+        { command: 'test-command' },
+        { registerTool: vi.fn() } as unknown as ToolRegistry,
+        { registerPrompt: vi.fn() } as unknown as PromptRegistry,
+        {} as WorkspaceContext,
+        false,
+      );
+      await client.connect();
+      await expect(
+        client.discoverAndReturn(cfgWithResources()),
+      ).rejects.toThrow('No prompts, tools, or resources found on the server.');
+
+      expect(getMCPServerLastError('discovery-cause-server')).toBe(
+        'No prompts, tools, or resources found on the server.',
+      );
+
+      removeMCPServerStatus('discovery-cause-server');
+    });
+
     it('keeps a server with only app-visible tools connected', async () => {
       mockAppOnlyMcpServer();
       const client = new McpClient(

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -3614,6 +3614,95 @@ lOTTGqPpwFUbw2EMOOpFYuIyzGMIpUNMBjE2gvJiqFQ=
       // Cleanup the registry entry so this test doesn't leak.
       removeMCPServerStatus('healthy-server');
     });
+
+    it('disconnect() terminates a Streamable HTTP session before closing the transport (issue #9944)', async () => {
+      // The SDK's `transport.close()` only tears down local state; the
+      // server-side session stays alive unless we send the spec's DELETE
+      // (`terminateSession()`). An abandoned session keeps occupying
+      // single-session servers, which then reject every later `initialize`
+      // with "Server already initialized".
+      const mockedClient = {
+        connect: vi.fn(),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        close: vi.fn(),
+        getInstructions: vi.fn(),
+      };
+      vi.mocked(ClientLib.Client).mockReturnValue(
+        mockedClient as unknown as ClientLib.Client,
+      );
+      const callOrder: string[] = [];
+      const mockedTransport = {
+        terminateSession: vi.fn().mockImplementation(async () => {
+          callOrder.push('terminateSession');
+        }),
+        close: vi.fn().mockImplementation(async () => {
+          callOrder.push('close');
+        }),
+      };
+      vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue(
+        mockedTransport as unknown as SdkClientStdioLib.StdioClientTransport,
+      );
+
+      const client = new McpClient(
+        'http-server',
+        { command: 'test-command' },
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        { getDirectories: () => [] } as unknown as WorkspaceContext,
+        false,
+      );
+
+      await client.connect();
+      await client.disconnect();
+
+      expect(mockedTransport.terminateSession).toHaveBeenCalledTimes(1);
+      // Termination must happen while the transport can still send
+      // requests — i.e. before `close()` aborts it.
+      expect(callOrder).toEqual(['terminateSession', 'close']);
+
+      removeMCPServerStatus('http-server');
+    });
+
+    it('disconnect() swallows session-termination failures (issue #9944)', async () => {
+      // A dead server must not block teardown: the DELETE fails, but
+      // disconnect still completes and closes the transport.
+      const mockedClient = {
+        connect: vi.fn(),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        close: vi.fn(),
+        getInstructions: vi.fn(),
+      };
+      vi.mocked(ClientLib.Client).mockReturnValue(
+        mockedClient as unknown as ClientLib.Client,
+      );
+      const mockedTransport = {
+        terminateSession: vi
+          .fn()
+          .mockRejectedValue(new Error('ECONNREFUSED')),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue(
+        mockedTransport as unknown as SdkClientStdioLib.StdioClientTransport,
+      );
+
+      const client = new McpClient(
+        'dead-http-server',
+        { command: 'test-command' },
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        { getDirectories: () => [] } as unknown as WorkspaceContext,
+        false,
+      );
+
+      await client.connect();
+      await expect(client.disconnect()).resolves.toBeUndefined();
+      expect(mockedTransport.close).toHaveBeenCalledTimes(1);
+      expect(client.getStatus()).toBe(MCPServerStatus.DISCONNECTED);
+
+      removeMCPServerStatus('dead-http-server');
+    });
   });
 
   describe('hasNetworkTransport', () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -41,6 +41,7 @@ import {
   discoverPrompts,
   discoverResources,
   getAllMCPServerStatuses,
+  getMCPServerLastError,
   getMcpOAuthDialogInstruction,
   getMCPServerStatus,
   hasNetworkTransport,
@@ -3751,6 +3752,51 @@ lOTTGqPpwFUbw2EMOOpFYuIyzGMIpUNMBjE2gvJiqFQ=
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('records the connect failure cause in the status registry (issue #9944)', async () => {
+      // Discovery is best-effort and swallows connect errors (the manager's
+      // catch logs them via debugLogger only), so the status enum alone
+      // cannot tell a consumer WHY a server is not CONNECTED. connect() must
+      // record the cause so `qwen mcp reconnect` can print it.
+      const mockedClient = {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new Error('connect ECONNREFUSED 127.0.0.1:3939')),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        close: vi.fn(),
+        getInstructions: vi.fn(),
+      };
+      vi.mocked(ClientLib.Client).mockReturnValue(
+        mockedClient as unknown as ClientLib.Client,
+      );
+      vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue({
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as SdkClientStdioLib.StdioClientTransport);
+
+      const client = new McpClient(
+        'cause-recording-server',
+        { command: 'test-command' },
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        { getDirectories: () => [] } as unknown as WorkspaceContext,
+        false,
+      );
+
+      await expect(client.connect()).rejects.toThrow(
+        'connect ECONNREFUSED 127.0.0.1:3939',
+      );
+      expect(getMCPServerLastError('cause-recording-server')).toBe(
+        'connect ECONNREFUSED 127.0.0.1:3939',
+      );
+
+      // A recovered connection clears the stale cause.
+      mockedClient.connect.mockResolvedValue(undefined);
+      await client.connect();
+      expect(getMCPServerLastError('cause-recording-server')).toBeUndefined();
+
+      removeMCPServerStatus('cause-recording-server');
     });
   });
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -605,7 +605,12 @@ export class McpClient {
       // the only other witness. Recording it lets status consumers (e.g.
       // `qwen mcp reconnect`) tell the user WHY the connection failed
       // instead of a bare "status: disconnected" (issue #9944).
-      recordMCPServerLastError(this.serverName, getErrorMessage(error));
+      // Same guard as `updateStatus()`: a late rejection from a doomed
+      // in-flight connect (server disabled/removed mid-connect) must not
+      // resurrect a cause entry that `removeMCPServerStatus` already dropped.
+      if (!this.isDisconnecting) {
+        recordMCPServerLastError(this.serverName, getErrorMessage(error));
+      }
       throw error;
     }
   }
@@ -741,8 +746,11 @@ export class McpClient {
       this.updateStatus(MCPServerStatus.DISCONNECTED);
       // Same carrier as `connect()`'s catch: the manager swallows this error
       // for best-effort discovery; keep the cause retrievable for status
-      // consumers (issue #9944).
-      recordMCPServerLastError(this.serverName, getErrorMessage(error));
+      // consumers (issue #9944). Gated like the status write so a server
+      // removed mid-discovery doesn't get an orphan cause entry resurrected.
+      if (!this.isDisconnecting) {
+        recordMCPServerLastError(this.serverName, getErrorMessage(error));
+      }
       throw error;
     }
   }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -64,7 +64,10 @@ import {
   resetDispatcherCache,
 } from '../utils/runtimeFetchOptions.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import { discoveryTimeoutFor } from './mcp-discovery-timeout.js';
+import {
+  discoveryTimeoutFor,
+  runWithTimeout,
+} from './mcp-discovery-timeout.js';
 import { retryWithBackoff } from './mcp-retry.js';
 import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
 import { sanitizeChildEnv } from '../utils/sanitize-child-env.js';
@@ -771,23 +774,14 @@ export class McpClient {
           // controller is only aborted by `close()` below — after this
           // await. A live-but-unresponsive server would otherwise hang
           // `disconnect()` (and every teardown caller) indefinitely. On
-          // timeout we fall through to `close()`, which aborts the
-          // still-in-flight request.
-          let timeout: ReturnType<typeof setTimeout> | undefined;
-          const timedOut = new Promise<void>((resolve) => {
-            timeout = setTimeout(resolve, TERMINATE_SESSION_TIMEOUT_MS);
-            timeout.unref?.();
-          });
-          try {
-            await Promise.race([
-              streamableTransport.terminateSession(),
-              timedOut,
-            ]);
-          } finally {
-            if (timeout) {
-              clearTimeout(timeout);
-            }
-          }
+          // timeout `runWithTimeout` rejects into the catch below (logged,
+          // then falls through to `close()`, which aborts the still-in-flight
+          // request) — same contract as the pool spawn/restart bounds.
+          await runWithTimeout(
+            streamableTransport.terminateSession(),
+            TERMINATE_SESSION_TIMEOUT_MS,
+            `terminateSession for server '${this.serverName}'`,
+          );
         } catch (error) {
           debugLogger.debug(
             `Could not terminate MCP session for server '${this.serverName}' during disconnect (continuing): ${getErrorMessage(error)}`,

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -743,6 +743,29 @@ export class McpClient {
     updateMCPServerStatus(this.serverName, MCPServerStatus.DISCONNECTED);
     this.isDisconnecting = true;
     if (this.transport) {
+      // Streamable HTTP only: the SDK's `transport.close()` aborts local
+      // state but leaves the server-side session alive. Per spec, a client
+      // that no longer needs a session SHOULD terminate it explicitly
+      // (`terminateSession()` sends the DELETE). Without this, a session we
+      // abandon keeps occupying the server: single-session HTTP servers
+      // then reject every later `initialize` with "Server already
+      // initialized" (issue #9944 — e.g. the internal reconnect path or a
+      // later `qwen mcp reconnect` can never recover them), and
+      // multi-session servers accumulate orphaned sessions. Best-effort —
+      // a dead/unreachable server must not block teardown. Must run BEFORE
+      // `close()` aborts the transport's request machinery.
+      const streamableTransport = this.transport as {
+        terminateSession?: () => Promise<void>;
+      };
+      if (typeof streamableTransport.terminateSession === 'function') {
+        try {
+          await streamableTransport.terminateSession();
+        } catch (error) {
+          debugLogger.debug(
+            `Could not terminate MCP session for server '${this.serverName}' during disconnect (continuing): ${getErrorMessage(error)}`,
+          );
+        }
+      }
       await this.transport.close();
     }
     this.client.close();

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -35,12 +35,18 @@ import { ServiceAccountImpersonationProvider } from '../mcp/sa-impersonation-pro
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import type { McpToolAnnotations } from './mcp-tool.js';
 import { SdkControlClientTransport } from './sdk-control-client-transport.js';
-import { MCPServerStatus, updateMCPServerStatus } from './mcp-status.js';
+import {
+  MCPServerStatus,
+  recordMCPServerLastError,
+  updateMCPServerStatus,
+} from './mcp-status.js';
 export {
   addMCPStatusChangeListener,
   getAllMCPServerStatuses,
+  getMCPServerLastError,
   getMCPServerStatus,
   MCPServerStatus,
+  recordMCPServerLastError,
   removeMCPServerStatus,
   removeMCPStatusChangeListener,
   updateMCPServerStatus,
@@ -594,6 +600,12 @@ export class McpClient {
         }
       }
       this.updateStatus(MCPServerStatus.DISCONNECTED);
+      // Preserve the cause: the manager's discovery catch swallows this
+      // error (best-effort discovery), leaving the status registry's enum as
+      // the only other witness. Recording it lets status consumers (e.g.
+      // `qwen mcp reconnect`) tell the user WHY the connection failed
+      // instead of a bare "status: disconnected" (issue #9944).
+      recordMCPServerLastError(this.serverName, getErrorMessage(error));
       throw error;
     }
   }
@@ -727,6 +739,10 @@ export class McpClient {
       return { tools, prompts, resources };
     } catch (error) {
       this.updateStatus(MCPServerStatus.DISCONNECTED);
+      // Same carrier as `connect()`'s catch: the manager swallows this error
+      // for best-effort discovery; keep the cause retrievable for status
+      // consumers (issue #9944).
+      recordMCPServerLastError(this.serverName, getErrorMessage(error));
       throw error;
     }
   }

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -99,6 +99,12 @@ export const MCP_APP_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
 
 const debugLogger = createDebugLogger('MCP');
 const AUTOMATIC_MCP_OAUTH_TIMEOUT_MS = 60_000;
+/**
+ * Upper bound for the session-termination DELETE in `disconnect()`. The SDK
+ * call has no timeout of its own; a live-but-unresponsive server must not
+ * hang teardown (see `disconnect()`).
+ */
+const TERMINATE_SESSION_TIMEOUT_MS = 2_000;
 
 const invocationContextTransports = new WeakSet<Transport>();
 const invocationContextClients = new WeakSet<Client>();
@@ -759,7 +765,29 @@ export class McpClient {
       };
       if (typeof streamableTransport.terminateSession === 'function') {
         try {
-          await streamableTransport.terminateSession();
+          // Bound the DELETE: the SDK's `terminateSession()` has no timeout
+          // of its own (the MCP undici dispatcher runs with
+          // `headersTimeout: 0, bodyTimeout: 0`), and the transport's abort
+          // controller is only aborted by `close()` below — after this
+          // await. A live-but-unresponsive server would otherwise hang
+          // `disconnect()` (and every teardown caller) indefinitely. On
+          // timeout we fall through to `close()`, which aborts the
+          // still-in-flight request.
+          let timeout: ReturnType<typeof setTimeout> | undefined;
+          const timedOut = new Promise<void>((resolve) => {
+            timeout = setTimeout(resolve, TERMINATE_SESSION_TIMEOUT_MS);
+            timeout.unref?.();
+          });
+          try {
+            await Promise.race([
+              streamableTransport.terminateSession(),
+              timedOut,
+            ]);
+          } finally {
+            if (timeout) {
+              clearTimeout(timeout);
+            }
+          }
         } catch (error) {
           debugLogger.debug(
             `Could not terminate MCP session for server '${this.serverName}' during disconnect (continuing): ${getErrorMessage(error)}`,

--- a/packages/core/src/tools/mcp-discovery-timeout.ts
+++ b/packages/core/src/tools/mcp-discovery-timeout.ts
@@ -70,8 +70,7 @@ export function runWithTimeout<T>(
     const timer = setTimeout(() => {
       reject(
         new Error(
-          `Timed out after ${timeoutMs}ms: ${label}. The MCP server may be ` +
-            `hung; pool will roll back the spawn/restart and free its budget slot.`,
+          `Timed out after ${timeoutMs}ms: ${label}. The MCP server may be hung.`,
         ),
       );
     }, timeoutMs);

--- a/packages/core/src/tools/mcp-pool-entry.ts
+++ b/packages/core/src/tools/mcp-pool-entry.ts
@@ -1015,7 +1015,8 @@ export class PoolEntry {
           });
         })(),
         timeoutMs,
-        `pool restart for ${this.id}`,
+        `pool restart for ${this.id} ` +
+          `(pool will roll back the restart and free its budget slot)`,
       );
     } catch (err) {
       debugLogger.error(

--- a/packages/core/src/tools/mcp-status.test.ts
+++ b/packages/core/src/tools/mcp-status.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getMCPServerLastError,
+  MCPServerStatus,
+  recordMCPServerLastError,
+  removeMCPServerStatus,
+  updateMCPServerStatus,
+} from './mcp-status.js';
+
+describe('mcp-status last-error carrier (issue #9944)', () => {
+  // Discovery is best-effort and swallows connect errors (debugLogger only),
+  // so the status enum alone cannot tell a consumer WHY a server is not
+  // CONNECTED. The registry therefore carries the most recent failure cause
+  // per server for consumers like `qwen mcp reconnect`.
+  const serverName = 'last-error-carrier-server';
+
+  afterEach(() => {
+    removeMCPServerStatus(serverName);
+  });
+
+  it('returns undefined when no failure was recorded', () => {
+    expect(getMCPServerLastError(serverName)).toBeUndefined();
+  });
+
+  it('round-trips a recorded failure cause', () => {
+    recordMCPServerLastError(serverName, 'connect ECONNREFUSED 127.0.0.1:3939');
+    expect(getMCPServerLastError(serverName)).toBe(
+      'connect ECONNREFUSED 127.0.0.1:3939',
+    );
+  });
+
+  it('keeps the most recent cause when failures repeat', () => {
+    recordMCPServerLastError(serverName, 'first cause');
+    recordMCPServerLastError(serverName, 'second cause');
+    expect(getMCPServerLastError(serverName)).toBe('second cause');
+  });
+
+  it('keeps the recorded cause across DISCONNECTED status writes', () => {
+    recordMCPServerLastError(serverName, 'HTTP 401 Unauthorized');
+    updateMCPServerStatus(serverName, MCPServerStatus.DISCONNECTED);
+    expect(getMCPServerLastError(serverName)).toBe('HTTP 401 Unauthorized');
+  });
+
+  it('clears the recorded cause when the server reaches CONNECTED', () => {
+    recordMCPServerLastError(serverName, 'HTTP 401 Unauthorized');
+    updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
+    expect(getMCPServerLastError(serverName)).toBeUndefined();
+  });
+
+  it('clears the recorded cause when the server is removed from the registry', () => {
+    recordMCPServerLastError(serverName, 'spawn ENOENT');
+    removeMCPServerStatus(serverName);
+    expect(getMCPServerLastError(serverName)).toBeUndefined();
+  });
+});

--- a/packages/core/src/tools/mcp-status.ts
+++ b/packages/core/src/tools/mcp-status.ts
@@ -22,6 +22,36 @@ export enum MCPServerStatus {
 const serverStatuses: Map<string, MCPServerStatus> = new Map();
 
 /**
+ * The most recent connect/discovery failure message per server. Discovery is
+ * best-effort and swallows connect errors (logged only via `debugLogger`),
+ * so the status enum alone cannot tell a consumer WHY a server is not
+ * CONNECTED. Producers that fail a connect/discovery record the cause here;
+ * consumers that observe a non-CONNECTED status (e.g. `qwen mcp reconnect`)
+ * can read it back. Entries are dropped automatically when the server
+ * reaches CONNECTED or is removed from the registry.
+ */
+const serverLastErrors: Map<string, string> = new Map();
+
+/**
+ * Record the most recent connect/discovery failure message for a server.
+ */
+export function recordMCPServerLastError(
+  serverName: string,
+  message: string,
+): void {
+  serverLastErrors.set(serverName, message);
+}
+
+/**
+ * The most recently recorded connect/discovery failure message for a server,
+ * or `undefined` when nothing is recorded (never failed, last attempt
+ * succeeded, or the server was removed from the registry).
+ */
+export function getMCPServerLastError(serverName: string): string | undefined {
+  return serverLastErrors.get(serverName);
+}
+
+/**
  * Event listeners for MCP server status changes.
  * `status` is `undefined` when the server has been removed from the registry
  * (e.g. disabled via `/mcp`), so consumers can drop it from their snapshots
@@ -62,6 +92,11 @@ export function updateMCPServerStatus(
   status: MCPServerStatus,
 ): void {
   serverStatuses.set(serverName, status);
+  if (status === MCPServerStatus.CONNECTED) {
+    // A live connection invalidates any previously recorded failure cause;
+    // keeping it would let a stale error shadow a recovered server.
+    serverLastErrors.delete(serverName);
+  }
   // Snapshot the listener list so a listener that detaches itself (or
   // attaches a new one) during dispatch doesn't mutate the array we're
   // iterating.
@@ -76,6 +111,7 @@ export function updateMCPServerStatus(
  * longer shows up in the Footer's MCP health pill as offline.
  */
 export function removeMCPServerStatus(serverName: string): void {
+  serverLastErrors.delete(serverName);
   if (!serverStatuses.has(serverName)) {
     return;
   }

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -2201,6 +2201,52 @@ describe('DiscoveredMCPTool', () => {
       },
     );
 
+    it('routes an HTTP 404 dead-session response to the reconnect path even with unenumerated prose (issue #9944)', async () => {
+      // Per spec, a restarted HTTP server MUST answer a POST carrying a
+      // stale `mcp-session-id` with 404 (the SDK surfaces it as a
+      // StreamableHTTPError whose `code` is the HTTP status); the prose it
+      // wraps the 404 in is server-defined. "Unknown session" matches none
+      // of the enumerated `MCP_DEAD_SESSION_ERROR_PATTERN` phrasings, so
+      // only the structural `code: 404` signal can trigger recovery here —
+      // without it every subsequent call re-POSTs the stale session id and
+      // fails.
+      const unknownSessionError = Object.assign(new Error('Unknown session'), {
+        code: 404,
+      });
+      const initialClient: McpDirectClient = {
+        callTool: vi.fn().mockRejectedValueOnce(unknownSessionError),
+      };
+      const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
+      const ensureTool = vi.fn();
+      const mockConfig = {
+        isTrustedFolder: () => true,
+        getToolRegistry: () => ({ discoverToolsForServer, ensureTool }),
+      };
+      const tool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        true,
+        undefined,
+        mockConfig as any,
+        initialClient,
+        undefined,
+        undefined,
+        undefined, // no annotations → no replay, but repair must still run
+      );
+
+      updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
+      await expect(
+        tool.build({ param: 'test' }).execute(new AbortController().signal),
+      ).rejects.toThrow(unsafeReplayErrorMessage);
+
+      expect(initialClient.callTool).toHaveBeenCalledTimes(1);
+      expect(discoverToolsForServer).toHaveBeenCalledWith(serverName);
+      expect(ensureTool).toHaveBeenCalledTimes(1);
+    });
+
     it('should not retry on non-connection errors', async () => {
       const params = { param: 'test' };
       const mockMcpClient: McpDirectClient = {

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -1980,12 +1980,13 @@ describe('DiscoveredMCPTool', () => {
         tool: vi.fn(),
         callTool: vi.fn().mockRejectedValueOnce(new Error('Connection closed')),
       } as unknown as Mocked<CallableTool>;
-      const discoverToolsForServer = vi.fn();
+      const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
+      const ensureTool = vi.fn();
       const mockConfig = {
         isTrustedFolder: () => true,
         getToolRegistry: () => ({
           discoverToolsForServer,
-          ensureTool: vi.fn(),
+          ensureTool,
         }),
       };
       const unsafeTool = new DiscoveredMCPTool(
@@ -2010,8 +2011,12 @@ describe('DiscoveredMCPTool', () => {
           .execute(new AbortController().signal),
       ).rejects.toThrow(unsafeReplayErrorMessage);
 
+      // The call itself is never replayed (its outcome is ambiguous)...
       expect(initialCallable.callTool).toHaveBeenCalledTimes(1);
-      expect(discoverToolsForServer).not.toHaveBeenCalled();
+      // ...but the dead connection is still repaired so the next call can
+      // succeed (issue #9944).
+      expect(discoverToolsForServer).toHaveBeenCalledTimes(1);
+      expect(ensureTool).toHaveBeenCalledTimes(1);
     });
 
     it.each<{
@@ -2064,7 +2069,7 @@ describe('DiscoveredMCPTool', () => {
             new Error('Connection closed after side effect completed'),
           ),
       };
-      const discoverToolsForServer = vi.fn();
+      const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
       const ensureTool = vi.fn();
       const mockConfig = {
         isTrustedFolder: () => testCase.trustedFolder,
@@ -2092,9 +2097,103 @@ describe('DiscoveredMCPTool', () => {
           .execute(new AbortController().signal),
       ).rejects.toThrow(unsafeReplayErrorMessage);
 
+      // No replay of the ambiguous call...
       expect(initialClient.callTool).toHaveBeenCalledTimes(1);
-      expect(discoverToolsForServer).not.toHaveBeenCalled();
-      expect(ensureTool).not.toHaveBeenCalled();
+      // ...but the connection is still repaired best-effort so the next
+      // call does not inherit the dead session (issue #9944).
+      expect(discoverToolsForServer).toHaveBeenCalledTimes(1);
+      expect(ensureTool).toHaveBeenCalledTimes(1);
+    });
+
+    it('repairs the session of an unannotated tool after the server restarted (issue #9944)', async () => {
+      // An HTTP MCP server that restarted comes back with a fresh
+      // `mcp-session-id` space and answers our stale session with
+      // `-32001 "Session not found"`. The tool carries no
+      // readOnlyHint/idempotentHint annotations, so pre-fix the reconnect
+      // path never ran and the tool stayed unusable until a full session
+      // restart. The ambiguous call must still not be replayed — but the
+      // session repair (fresh initialize + tool reload) has to happen.
+      const sessionNotFoundError = Object.assign(
+        new Error(
+          'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}',
+        ),
+        { code: -32001 },
+      );
+      const initialClient: McpDirectClient = {
+        callTool: vi.fn().mockRejectedValueOnce(sessionNotFoundError),
+      };
+      const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
+      const ensureTool = vi.fn();
+      const mockConfig = {
+        isTrustedFolder: () => true,
+        getToolRegistry: () => ({ discoverToolsForServer, ensureTool }),
+      };
+      const tool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        true,
+        undefined,
+        mockConfig as any,
+        initialClient,
+        undefined,
+        undefined,
+        undefined, // no annotations
+      );
+
+      updateMCPServerStatus(serverName, MCPServerStatus.DISCONNECTED);
+      await expect(
+        tool.build({ param: 'test' }).execute(new AbortController().signal),
+      ).rejects.toThrow(unsafeReplayErrorMessage);
+
+      expect(initialClient.callTool).toHaveBeenCalledTimes(1);
+      expect(discoverToolsForServer).toHaveBeenCalledWith(serverName);
+      expect(ensureTool).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes "Session not found" to the reconnect path even while the status is still CONNECTED (issue #9944)', async () => {
+      // Servers that keep no GET SSE stream never flip the client status to
+      // DISCONNECTED when the session dies; the stale `-32001` code would
+      // then be misread as an execution timeout and the reconnect path would
+      // never run. The session-error carve-out must win.
+      const sessionNotFoundError = Object.assign(
+        new Error(
+          'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}',
+        ),
+        { code: -32001 },
+      );
+      const initialClient: McpDirectClient = {
+        callTool: vi.fn().mockRejectedValueOnce(sessionNotFoundError),
+      };
+      const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
+      const ensureTool = vi.fn();
+      const mockConfig = {
+        isTrustedFolder: () => true,
+        getToolRegistry: () => ({ discoverToolsForServer, ensureTool }),
+      };
+      const tool = new DiscoveredMCPTool(
+        mockCallableToolInstance,
+        serverName,
+        serverToolName,
+        baseDescription,
+        inputSchema,
+        true,
+        undefined,
+        mockConfig as any,
+        initialClient,
+        undefined,
+        undefined,
+        undefined, // no annotations → no replay, but repair must still run
+      );
+
+      updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
+      await expect(
+        tool.build({ param: 'test' }).execute(new AbortController().signal),
+      ).rejects.toThrow(unsafeReplayErrorMessage);
+
+      expect(discoverToolsForServer).toHaveBeenCalledWith(serverName);
     });
 
     it('should not retry on non-connection errors', async () => {

--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -2153,48 +2153,53 @@ describe('DiscoveredMCPTool', () => {
       expect(ensureTool).toHaveBeenCalledTimes(1);
     });
 
-    it('routes "Session not found" to the reconnect path even while the status is still CONNECTED (issue #9944)', async () => {
-      // Servers that keep no GET SSE stream never flip the client status to
-      // DISCONNECTED when the session dies; the stale `-32001` code would
-      // then be misread as an execution timeout and the reconnect path would
-      // never run. The session-error carve-out must win.
-      const sessionNotFoundError = Object.assign(
-        new Error(
-          'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"Session not found"},"id":null}',
-        ),
-        { code: -32001 },
-      );
-      const initialClient: McpDirectClient = {
-        callTool: vi.fn().mockRejectedValueOnce(sessionNotFoundError),
-      };
-      const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
-      const ensureTool = vi.fn();
-      const mockConfig = {
-        isTrustedFolder: () => true,
-        getToolRegistry: () => ({ discoverToolsForServer, ensureTool }),
-      };
-      const tool = new DiscoveredMCPTool(
-        mockCallableToolInstance,
-        serverName,
-        serverToolName,
-        baseDescription,
-        inputSchema,
-        true,
-        undefined,
-        mockConfig as any,
-        initialClient,
-        undefined,
-        undefined,
-        undefined, // no annotations → no replay, but repair must still run
-      );
+    it.each(['Session not found', 'Session terminated', 'Session expired'])(
+      'routes "%s" to the reconnect path even while the status is still CONNECTED (issue #9944)',
+      async (sessionMessage) => {
+        // Servers that keep no GET SSE stream never flip the client status
+        // to DISCONNECTED when the session dies; the stale `-32001` code
+        // would then be misread as an execution timeout and the reconnect
+        // path would never run. The session-error carve-out must win for
+        // every dead-session phrasing a server may use — not just
+        // "Session not found" — so all three variants exercise it.
+        const sessionError = Object.assign(
+          new Error(
+            `Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32001,"message":"${sessionMessage}"},"id":null}`,
+          ),
+          { code: -32001 },
+        );
+        const initialClient: McpDirectClient = {
+          callTool: vi.fn().mockRejectedValueOnce(sessionError),
+        };
+        const discoverToolsForServer = vi.fn().mockResolvedValue(undefined);
+        const ensureTool = vi.fn();
+        const mockConfig = {
+          isTrustedFolder: () => true,
+          getToolRegistry: () => ({ discoverToolsForServer, ensureTool }),
+        };
+        const tool = new DiscoveredMCPTool(
+          mockCallableToolInstance,
+          serverName,
+          serverToolName,
+          baseDescription,
+          inputSchema,
+          true,
+          undefined,
+          mockConfig as any,
+          initialClient,
+          undefined,
+          undefined,
+          undefined, // no annotations → no replay, but repair must still run
+        );
 
-      updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
-      await expect(
-        tool.build({ param: 'test' }).execute(new AbortController().signal),
-      ).rejects.toThrow(unsafeReplayErrorMessage);
+        updateMCPServerStatus(serverName, MCPServerStatus.CONNECTED);
+        await expect(
+          tool.build({ param: 'test' }).execute(new AbortController().signal),
+        ).rejects.toThrow(unsafeReplayErrorMessage);
 
-      expect(discoverToolsForServer).toHaveBeenCalledWith(serverName);
-    });
+        expect(discoverToolsForServer).toHaveBeenCalledWith(serverName);
+      },
+    );
 
     it('should not retry on non-connection errors', async () => {
       const params = { param: 'test' };

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -105,14 +105,20 @@ function isExecutionTimeoutFailure(
   // user cancellation against the timeout SLI, so the abort side wins.
   if (signal.aborted) return false;
   if (!isMcpRequestTimeout(error)) return false;
-  // `-32001` doubles as the server's "Session not found" response code when
-  // it no longer recognizes our `mcp-session-id` (typical right after an
-  // HTTP server restart). That is a dead connection `handleReconnectOnError`
-  // can repair, not an execution timeout — without this carve-out the error
-  // would be reported as a timeout whenever the client-side status has not
-  // flipped to DISCONNECTED yet (e.g. servers that keep no GET SSE stream),
-  // and the reconnect path would never run (issue #9944).
-  if (/session not found/i.test(getErrorMessage(error))) return false;
+  // `-32001` doubles as the server's dead-session response code when it no
+  // longer recognizes our `mcp-session-id` (typical right after an HTTP
+  // server restart) — servers phrase that as "Session not found",
+  // "Session terminated", or "Session expired". That is a dead connection
+  // `handleReconnectOnError` can repair, not an execution timeout — without
+  // this carve-out the error would be reported as a timeout whenever the
+  // client-side status has not flipped to DISCONNECTED yet (e.g. servers
+  // that keep no GET SSE stream), and the reconnect path would never run
+  // (issue #9944). Must match the same variants as
+  // `MCP_CONNECTION_ERROR_PATTERNS` above; a narrower regex here would
+  // misroute the uncovered variants to EXECUTION_TIMEOUT.
+  if (/session (not found|terminated|expired)/i.test(getErrorMessage(error))) {
+    return false;
+  }
   const statuses = getAllMCPServerStatuses();
   return !(
     statuses.has(serverName) &&

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -87,12 +87,31 @@ const MCP_CONNECTION_ERROR_PATTERNS = [
 // classification here.
 const MCP_REQUEST_TIMEOUT_CODE = -32001;
 
+// Structural dead-session signal. Per the MCP spec, an HTTP server that no
+// longer recognizes a request's `mcp-session-id` (the canonical state right
+// after a restart) MUST answer the POST with 404; the SDK surfaces that as
+// a `StreamableHTTPError` whose `code` is the HTTP status. The prose a
+// server wraps the 404 in is NOT spec-pinned — "Unknown session" is just as
+// dead as "Session not found" — so the structural code must trigger
+// recovery on its own, alongside `MCP_DEAD_SESSION_ERROR_PATTERN` (which
+// only covers enumerated phrasings) (issue #9944).
+const MCP_DEAD_SESSION_HTTP_CODE = 404;
+
 function isMcpRequestTimeout(error: unknown): boolean {
   return (
     typeof error === 'object' &&
     error !== null &&
     'code' in error &&
     (error as { code?: unknown }).code === MCP_REQUEST_TIMEOUT_CODE
+  );
+}
+
+function isMcpDeadSessionHttpError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === MCP_DEAD_SESSION_HTTP_CODE
   );
 }
 
@@ -522,6 +541,14 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     }
 
     if (getMCPServerStatus(this.serverName) === MCPServerStatus.DISCONNECTED) {
+      return true;
+    }
+
+    // Spec-pinned structural signal: HTTP 404 on the session POST means the
+    // server no longer knows our `mcp-session-id`, regardless of the prose
+    // it wrapped the 404 in — the patterns below only cover enumerated
+    // phrasings (issue #9944).
+    if (isMcpDeadSessionHttpError(error)) {
       return true;
     }
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -58,6 +58,11 @@ const MCP_CONNECTION_ERROR_PATTERNS = [
   /not connected/i,
   /disconnected/i,
   /transport closed/i,
+  // The server no longer knows our session id — the canonical failure right
+  // after an HTTP server restart (it comes back with a fresh
+  // `mcp-session-id` space and answers our stale id with a `-32001`
+  // "Session not found"). Reconnect (a fresh `initialize`) is the remedy.
+  /session (not found|terminated|expired)/i,
 ];
 // The MCP SDK's generic `RequestTimeout` code. It is emitted for both
 // client-configured timeouts (`timeout` / `resetTimeoutOnProgress`) and
@@ -100,6 +105,14 @@ function isExecutionTimeoutFailure(
   // user cancellation against the timeout SLI, so the abort side wins.
   if (signal.aborted) return false;
   if (!isMcpRequestTimeout(error)) return false;
+  // `-32001` doubles as the server's "Session not found" response code when
+  // it no longer recognizes our `mcp-session-id` (typical right after an
+  // HTTP server restart). That is a dead connection `handleReconnectOnError`
+  // can repair, not an execution timeout — without this carve-out the error
+  // would be reported as a timeout whenever the client-side status has not
+  // flipped to DISCONNECTED yet (e.g. servers that keep no GET SSE stream),
+  // and the reconnect path would never run (issue #9944).
+  if (/session not found/i.test(getErrorMessage(error))) return false;
   const statuses = getAllMCPServerStatuses();
   return !(
     statuses.has(serverName) &&
@@ -393,6 +406,17 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     }
 
     if (!this.canSafelyReplay()) {
+      // This specific call cannot be auto-replayed — its outcome is ambiguous
+      // and re-running it could apply the side effect twice. The dead
+      // connection itself is still repairable though: re-initialize the
+      // server session and reload the tool registry so the NEXT call does not
+      // inherit the stale session (issue #9944). Pre-fix, tools without
+      // `readOnlyHint`/`idempotentHint` annotations never reached
+      // `attemptReconnect`, so an HTTP server that restarted with a new
+      // `mcp-session-id` stayed unusable until a full session restart.
+      // Best-effort: if the reconnect fails we throw the same error as
+      // before.
+      await this.attemptReconnect();
       throw new Error(DiscoveredMCPToolInvocation.UNSAFE_REPLAY_ERROR_MESSAGE);
     }
 

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -49,6 +49,24 @@ import { isImagePart } from '../services/visionBridge/image-part-utils.js';
 
 const debugLogger = createDebugLogger('MCP_TOOL');
 
+/**
+ * The dead-session responses an HTTP server emits right after a restart: it
+ * comes back with a fresh `mcp-session-id` space and answers our stale id
+ * with a `-32001` whose message phrases the session as not found /
+ * terminated / expired. TWO decision sites must agree on exactly these
+ * variants and both consume this single pattern:
+ *
+ *  - `MCP_CONNECTION_ERROR_PATTERNS` below (drives `shouldAttemptReconnect`)
+ *  - the execution-timeout carve-out in `isExecutionTimeoutFailure`
+ *
+ * A divergence between the two would misroute a covered variant — either
+ * into a hard EXECUTION_TIMEOUT the user has to retry by hand (carve-out
+ * narrower than the matcher) or past the reconnect matcher (matcher narrower
+ * than the carve-out). Keep this the single source of truth.
+ */
+const MCP_DEAD_SESSION_ERROR_PATTERN =
+  /session (not found|terminated|expired)/i;
+
 const MCP_CONNECTION_ERROR_PATTERNS = [
   /ECONNREFUSED/i,
   /ENOTFOUND/i,
@@ -58,11 +76,10 @@ const MCP_CONNECTION_ERROR_PATTERNS = [
   /not connected/i,
   /disconnected/i,
   /transport closed/i,
-  // The server no longer knows our session id — the canonical failure right
-  // after an HTTP server restart (it comes back with a fresh
-  // `mcp-session-id` space and answers our stale id with a `-32001`
-  // "Session not found"). Reconnect (a fresh `initialize`) is the remedy.
-  /session (not found|terminated|expired)/i,
+  // The server no longer knows our session id (see
+  // `MCP_DEAD_SESSION_ERROR_PATTERN`) — the canonical failure right after an
+  // HTTP server restart. Reconnect (a fresh `initialize`) is the remedy.
+  MCP_DEAD_SESSION_ERROR_PATTERN,
 ];
 // The MCP SDK's generic `RequestTimeout` code. It is emitted for both
 // client-configured timeouts (`timeout` / `resetTimeoutOnProgress`) and
@@ -107,16 +124,14 @@ function isExecutionTimeoutFailure(
   if (!isMcpRequestTimeout(error)) return false;
   // `-32001` doubles as the server's dead-session response code when it no
   // longer recognizes our `mcp-session-id` (typical right after an HTTP
-  // server restart) — servers phrase that as "Session not found",
-  // "Session terminated", or "Session expired". That is a dead connection
-  // `handleReconnectOnError` can repair, not an execution timeout — without
-  // this carve-out the error would be reported as a timeout whenever the
-  // client-side status has not flipped to DISCONNECTED yet (e.g. servers
-  // that keep no GET SSE stream), and the reconnect path would never run
-  // (issue #9944). Must match the same variants as
-  // `MCP_CONNECTION_ERROR_PATTERNS` above; a narrower regex here would
-  // misroute the uncovered variants to EXECUTION_TIMEOUT.
-  if (/session (not found|terminated|expired)/i.test(getErrorMessage(error))) {
+  // server restart). That is a dead connection `handleReconnectOnError` can
+  // repair, not an execution timeout — without this carve-out the error
+  // would be reported as a timeout whenever the client-side status has not
+  // flipped to DISCONNECTED yet (e.g. servers that keep no GET SSE stream),
+  // and the reconnect path would never run (issue #9944). Consumes the same
+  // `MCP_DEAD_SESSION_ERROR_PATTERN` as `MCP_CONNECTION_ERROR_PATTERNS` so
+  // the reconnect matcher and this carve-out can never drift apart.
+  if (MCP_DEAD_SESSION_ERROR_PATTERN.test(getErrorMessage(error))) {
     return false;
   }
   const statuses = getAllMCPServerStatuses();

--- a/packages/core/src/tools/mcp-transport-pool.ts
+++ b/packages/core/src/tools/mcp-transport-pool.ts
@@ -1044,7 +1044,8 @@ export class McpTransportPool {
           });
         })(),
         timeoutMs,
-        `pool spawn for ${id}`,
+        `pool spawn for ${id} ` +
+          `(pool will roll back the spawn and free its budget slot)`,
       );
       if (this.draining) {
         debugLogger.warn(
@@ -1274,7 +1275,8 @@ export class McpTransportPool {
           });
         })(),
         timeoutMs,
-        `unpooled spawn for ${id}`,
+        `unpooled spawn for ${id} ` +
+          `(pool will roll back the spawn and free its budget slot)`,
       );
       // Re-check terminal state after the await — a concurrent
       // `releaseSession(sessionId)` may have invoked `forceShutdown`


### PR DESCRIPTION
## What this PR does

Makes MCP reconnection actually recover an HTTP (Streamable HTTP) MCP server that restarted with a new `mcp-session-id` space, instead of reporting success while the tools stay unusable. Four stacked defects are fixed. In the running session, a failing tool call now repairs the connection even when the call itself cannot be auto-replayed: pre-fix, tools without `readOnlyHint`/`idempotentHint` annotations never triggered a reconnect, and the restart's canonical `-32001 "Session not found"` failure was neither recognized as a connection error nor routed to the reconnect path (while the client still believed it was CONNECTED it was misclassified as an execution timeout). The repair re-initializes the server session, adopts the server's new session id, and reloads the tool registry; the ambiguous failing call itself is still never replayed. `McpClient.disconnect()` now terminates the server-side session via the spec's DELETE (`terminateSession()`) before closing the transport — previously abandoned sessions kept occupying the server, so single-session servers rejected every later `initialize` with `"Server already initialized"` (permanent breakage) and multi-session servers accumulated orphaned sessions. Finally, `qwen mcp reconnect` no longer lies or hangs: it verifies the connection through the server status (discovery swallows connect errors), states plainly that it runs in a separate process and cannot refresh a running session, and exits on its own (the throwaway config skips background MCP discovery, which used to re-arm a ref'd health-check timer after shutdown; the health-check timer is also unref'd so it can never hold the event loop open).

## Why it's needed

Fixes the symptom in #9944: after an HTTP MCP server restart, `qwen mcp reconnect --all` printed `✓ Reconnected successfully` while every MCP tool call in the running session kept failing with `Tool not found on MCP server` (or the unsafe-replay message), and only a full restart of Qwen Code recovered the tools. In-session recovery depended entirely on the health monitor (~90 s) and silently failed permanently against single-session servers whose session slot had been consumed and abandoned. With this PR the first failing tool call after a restart repairs the session immediately, the health-monitor path stops orphaning sessions, and the CLI command reports truthfully and exits.

## Reviewer Test Plan

### How to verify

Unit tests (red on the pre-fix code, green with the fix): `cd packages/core && npx vitest run src/tools/mcp-tool.test.ts src/tools/mcp-client.test.ts src/tools/mcp-client-manager.test.ts` and `cd packages/cli && npx vitest run src/commands/mcp/reconnect.test.ts` — the new/updated cases cover: reconnect (session repair) firing for unannotated tools, no auto-replay of ambiguous calls, `Session not found` reaching the reconnect path while status is still CONNECTED, `terminateSession()` running before `transport.close()` and its failure being swallowed, the CLI failing loudly when the server never reaches CONNECTED, the process-scope note, and the unref'd health-check timer.

End-to-end (how this was validated against a live build): run a minimal Streamable HTTP MCP server with one unannotated `echo` tool, boot a core session (`Config.initialize()` → background discovery → tool registry) against it, kill the server and restart it on the same port (new `mcp-session-id` space), then invoke the tool twice: the first call fails with the unsafe-replay message (the ambiguous call is not replayed) while repairing the session, and the second call succeeds against the restarted server instance — no Qwen Code restart. Then run `qwen mcp reconnect --all`: it exits on its own within ~2 s, prints the process-scope note, reports `✗ ... Failed - connection attempt finished without a live connection (status: disconnected)` for a single-session server whose session is held by the running session, and a genuine `✓` against a multi-session server, which does not disturb the running session. The same matrix was re-checked against the canonical SDK multi-session server pattern.

### Evidence (Before & After)

Before (from the reproduction on this same baseline, single-session server, no annotations): first call after restart → `MCP tool execution may have completed before the connection failed. Automatic replay was skipped ...` on every subsequent call, health monitor re-discovery rejected with `Invalid Request: Server already initialized`, `Tool ... not found on MCP server ...` for 200+ s; `qwen mcp reconnect --all` printed `✓ reprosrv: Reconnected successfully` and had to be killed after 30 s (hung).

After (post-fix build, same scenario): first call after restart → same unsafe-replay message once, and the server issues a new `mcp-session-id` during the repair; second call → `echo:hello-after-restart-2 instance=B` (recovered, no restart); `qwen mcp reconnect --all` → `✗ reprosrv: Failed - connection attempt finished without a live connection (status: disconnected)` + scope note, exit in ~1.8 s (single-session server held by the live session); against a multi-session server → genuine `✓ reprosrv: Reconnected successfully` + scope note, exit 0, and the CLI's session is terminated on exit (`session closed` logged by the server).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Node v24.19.0, MCP SDK 1.30.0; validated against locally built `packages/core/dist` + `packages/cli/dist` from this branch with minimal single-session and multi-session Streamable HTTP servers, plus the targeted vitest suites on Linux.

## Risk & Scope

- Main risk or tradeoff: every connection-error failure of an unsafe-to-replay tool now triggers a best-effort reconnect (one extra connect attempt per failing call) — bounded by the existing `shouldAttemptReconnect` gate, and it fails through to the same error as before when the server is unreachable. `disconnect()` now sends a DELETE for Streamable HTTP sessions; servers answering 405 (termination unsupported) or errors are treated as best-effort and never block teardown.
- Not validated / out of scope: STDIO transport reconnect (#9675), the transport-pool (daemon) reconnect internals, and adding an in-session `/mcp reconnect` subcommand. Known limitation that is server-side by design: an SDK-based single-session server whose session was terminated (e.g. by a `qwen mcp reconnect` run before the session recovered) has exhausted its one-shot transport lifecycle and needs a server restart.
- Breaking changes / migration notes: none; CLI success/failure output wording changed (`qwen mcp reconnect` now reports per-server truthfully and always prints the process-scope note).

## Linked Issues

Fixes #9944

Related: #9675 (similar symptom on STDIO transport — not addressed here), #8492.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 MCP 重连在 HTTP（Streamable HTTP）MCP 服务器以新的 `mcp-session-id` 空间重启后真正恢复可用，而不是报成功但工具依旧不可用。共修复四个叠加缺陷。在运行中的会话里，即使当前调用本身不能被自动重放，失败的工具调用现在也会修复连接：修复前，没有 `readOnlyHint`/`idempotentHint` 注解的工具从不触发重连，而且重启后典型的 `-32001 "Session not found"` 错误既不被识别为连接错误，也不会走到重连路径（客户端还认为自己是 CONNECTED 时，它会被误判为执行超时）。修复动作会重新初始化服务器会话、采用服务器新的 session id 并重载工具注册表；而那次结果不明的失败调用本身仍然不会被自动重放。`McpClient.disconnect()` 现在会在关闭 transport 之前按规范的 DELETE（`terminateSession()`）终止服务端会话——此前被遗弃的会话一直占用着服务器：单会话服务器会拒绝后续所有 `initialize`（报 `"Server already initialized"`，永久损坏），多会话服务器则会累积孤儿会话。最后，`qwen mcp reconnect` 不再谎报、不再挂起：它通过服务器状态核实连接（discovery 会吞掉连接错误），明确说明自己运行在独立进程、无法刷新运行中的会话，并且能自行退出（一次性 Config 跳过后台 MCP 发现——它过去会在 shutdown 之后重新 arm 一个 ref'd 健康检查定时器；健康检查定时器也改为 unref，永远不会挂住事件循环）。

## 为什么需要

修复 #9944 中的现象：HTTP MCP 服务器重启后，`qwen mcp reconnect --all` 打印 `✓ Reconnected successfully`，但运行中会话里的每个 MCP 工具调用持续失败，报 `Tool not found on MCP server`（或 unsafe-replay 提示），只有整体重启 Qwen Code 才能恢复。会话内的恢复完全依赖健康监视器（约 90 秒），而且对会话槽位已被消耗并遗弃的单会话服务器会静默地永久失败。本 PR 之后，重启后的第一次失败工具调用就会立即修复会话，健康监视器路径不再遗弃会话，CLI 命令如实报告并正常退出。

## 审阅者测试计划

### 如何验证

单元测试（修复前红、修复后绿）：`cd packages/core && npx vitest run src/tools/mcp-tool.test.ts src/tools/mcp-client.test.ts src/tools/mcp-client-manager.test.ts` 以及 `cd packages/cli && npx vitest run src/commands/mcp/reconnect.test.ts`——新增/更新的用例覆盖：无注解工具也触发重连（会话修复）、结果不明的调用不被自动重放、状态仍为 CONNECTED 时 `Session not found` 也能进入重连路径、`terminateSession()` 先于 `transport.close()` 执行且其失败被吞掉、服务器未达到 CONNECTED 时 CLI 明确报错、进程范围提示、以及 unref 后的健康检查定时器。

端到端（在真实构建上的验证方式）：启动一个最小 Streamable HTTP MCP 服务器（一个无注解的 `echo` 工具），用它启动一个 core 会话（`Config.initialize()` → 后台发现 → 工具注册表），杀掉服务器并在同端口重启（新的 `mcp-session-id` 空间），然后连续调用工具两次：第一次调用以 unsafe-replay 消息失败（不重放该调用）但同时修复会话，第二次调用在重启后的服务器实例上成功——无需重启 Qwen Code。再运行 `qwen mcp reconnect --all`：它在约 2 秒内自行退出，打印进程范围提示；对会话正被运行中会话占用的单会话服务器报 `✗ ... Failed - connection attempt finished without a live connection (status: disconnected)`，对多会话服务器报真实的 `✓`，且不打扰运行中的会话。同一套验证也对 SDK 标准的多会话服务器模式复跑过。

### 证据（修复前后对比）

修复前（同一基线上的复现，单会话服务器、无注解）：重启后第一次调用 → 之后每次调用都报 `MCP tool execution may have completed before the connection failed. Automatic replay was skipped ...`，健康监视器重新发现被拒（`Invalid Request: Server already initialized`），200 秒以上持续 `Tool ... not found on MCP server ...`；`qwen mcp reconnect --all` 打印 `✓ reprosrv: Reconnected successfully` 且 30 秒后仍需手动杀掉（挂起）。

修复后（修复版构建、同一场景）：重启后第一次调用 → 仅一次同样的 unsafe-replay 消息，修复过程中服务器颁发了新的 `mcp-session-id`；第二次调用 → `echo:hello-after-restart-2 instance=B`（已恢复，无需重启）；`qwen mcp reconnect --all` → `✗ reprosrv: Failed - connection attempt finished without a live connection (status: disconnected)` + 范围提示，约 1.8 秒退出（单会话服务器的会话被运行中会话占用）；对多会话服务器 → 真实的 `✓ reprosrv: Reconnected successfully` + 范围提示，退出码 0，且 CLI 的会话在退出时被终止（服务器日志出现 `session closed`）。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

Node v24.19.0、MCP SDK 1.30.0；在 Linux 上基于本分支本地构建的 `packages/core/dist` + `packages/cli/dist`，用最小的单会话与多会话 Streamable HTTP 服务器完成验证，并运行了对应的 vitest 目标套件。

## 风险与范围

- 主要风险或取舍：不可安全重放工具的每次连接类错误失败现在都会触发一次尽力而为的重连（每次失败调用多一次连接尝试）——受现有 `shouldAttemptReconnect` 门控约束，服务器不可达时仍按原样抛出同一错误。`disconnect()` 现在会为 Streamable HTTP 会话发送 DELETE；对返回 405（不支持终止）或报错的服务器按尽力而为处理，绝不阻塞拆除流程。
- 未验证 / 不在范围内：STDIO 传输的重连（#9675）、传输池（daemon）内部的重连逻辑、以及新增会话内 `/mcp reconnect` 子命令。一个服务端设计决定的已知限制：SDK 型单会话服务器若其会话已被终止（例如在会话恢复之前运行过 `qwen mcp reconnect`），其一次性传输生命周期已耗尽，需要重启服务器。
- 破坏性变更 / 迁移说明：无；CLI 的成功/失败输出措辞有变化（`qwen mcp reconnect` 现在逐服务器如实报告，并总是打印进程范围提示）。

## 关联 Issue

Fixes #9944

相关：#9675（STDIO 传输的类似现象——本 PR 不处理）、#8492。

</details>
