### PR TITLE
fix(cli): reserve ShowMoreLines' row in VP mode's height budget

### DIFF
--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -16,6 +16,7 @@ import {
 } from '../contexts/UIActionsContext.js';
 import { AppContext } from '../contexts/AppContext.js';
 import { OverflowProvider } from '../contexts/OverflowContext.js';
+import { StreamingContext } from '../contexts/StreamingContext.js';
 import { ThoughtExpandedProvider } from '../contexts/ThoughtExpandedContext.js';
 import { ToolCallStatus, StreamingState } from '../types.js';
 
@@ -73,10 +74,17 @@ vi.mock('./HistoryItemDisplay.js', () => ({
 // test can distinguish between "mounted but disconnected from overflow
 // state" and "mounted with a live overflow context".
 vi.mock('./ShowMoreLines.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('./ShowMoreLines.js')>(
+      './ShowMoreLines.js',
+    );
   const { useOverflowState } = await vi.importActual<
     typeof import('../contexts/OverflowContext.js')
   >('../contexts/OverflowContext.js');
   return {
+    // The real hook — VpScrollRegion uses it to reserve ShowMoreLines' row,
+    // and it has no rendering of its own to fake out.
+    useShowMoreLinesVisible: actual.useShowMoreLinesVisible,
     ShowMoreLines: () => {
       const overflow = useOverflowState();
       // Non-overlapping markers so a `toContain('SHOW_MORE')` substring
@@ -258,9 +266,15 @@ const renderMainContent = (uiState: UIState) =>
     <AppContext.Provider value={{ version: '1.2.3', startupWarnings: [] }}>
       <UIActionsContext.Provider value={createUIActions()}>
         <UIStateContext.Provider value={uiState}>
-          <OverflowProvider>
-            <MainContent />
-          </OverflowProvider>
+          {/* Mirrors App.tsx: VpScrollRegion reads useShowMoreLinesVisible
+              (which reads useStreamingContext) to reserve ShowMoreLines'
+              row, so the real provider must be present even though
+              ShowMoreLines itself is mocked below. */}
+          <StreamingContext.Provider value={uiState.streamingState}>
+            <OverflowProvider>
+              <MainContent />
+            </OverflowProvider>
+          </StreamingContext.Provider>
         </UIStateContext.Provider>
       </UIActionsContext.Provider>
     </AppContext.Provider>,
@@ -300,9 +314,11 @@ describe('<MainContent />', () => {
               historyRemountKey: 7,
             })}
           >
-            <OverflowProvider>
-              <MainContent />
-            </OverflowProvider>
+            <StreamingContext.Provider value={createUIState().streamingState}>
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </StreamingContext.Provider>
           </UIStateContext.Provider>
         </UIActionsContext.Provider>
       </AppContext.Provider>,
@@ -497,9 +513,11 @@ describe('<MainContent />', () => {
               historyRemountKey: 1,
             })}
           >
-            <OverflowProvider>
-              <MainContent />
-            </OverflowProvider>
+            <StreamingContext.Provider value={createUIState().streamingState}>
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </StreamingContext.Provider>
           </UIStateContext.Provider>
         </UIActionsContext.Provider>
       </AppContext.Provider>,
@@ -547,9 +565,11 @@ describe('<MainContent />', () => {
           <UIStateContext.Provider
             value={createUIState({ history, historyRemountKey: 2 })}
           >
-            <OverflowProvider>
-              <MainContent />
-            </OverflowProvider>
+            <StreamingContext.Provider value={createUIState().streamingState}>
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </StreamingContext.Provider>
           </UIStateContext.Provider>
         </UIActionsContext.Provider>
       </AppContext.Provider>,
@@ -651,9 +671,11 @@ describe('<MainContent />', () => {
               currentModel: 'model-b',
             })}
           >
-            <OverflowProvider>
-              <MainContent />
-            </OverflowProvider>
+            <StreamingContext.Provider value={createUIState().streamingState}>
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </StreamingContext.Provider>
           </UIStateContext.Provider>
         </UIActionsContext.Provider>
       </AppContext.Provider>,
@@ -1275,9 +1297,11 @@ describe('<MainContent />', () => {
                 slashCommands: stableSlashCommands,
               })}
             >
-              <OverflowProvider>
-                <MainContent />
-              </OverflowProvider>
+              <StreamingContext.Provider value={createUIState().streamingState}>
+                <OverflowProvider>
+                  <MainContent />
+                </OverflowProvider>
+              </StreamingContext.Provider>
             </UIStateContext.Provider>
           </UIActionsContext.Provider>
         </AppContext.Provider>,
@@ -1327,9 +1351,11 @@ describe('<MainContent />', () => {
                 slashCommands: stableSlashCommands,
               })}
             >
-              <OverflowProvider>
-                <MainContent />
-              </OverflowProvider>
+              <StreamingContext.Provider value={createUIState().streamingState}>
+                <OverflowProvider>
+                  <MainContent />
+                </OverflowProvider>
+              </StreamingContext.Provider>
             </UIStateContext.Provider>
           </UIActionsContext.Provider>
         </AppContext.Provider>,
@@ -1380,9 +1406,11 @@ describe('<MainContent />', () => {
                 slashCommands: stableSlashCommands,
               })}
             >
-              <OverflowProvider>
-                <MainContent />
-              </OverflowProvider>
+              <StreamingContext.Provider value={createUIState().streamingState}>
+                <OverflowProvider>
+                  <MainContent />
+                </OverflowProvider>
+              </StreamingContext.Provider>
             </UIStateContext.Provider>
           </UIActionsContext.Provider>
         </AppContext.Provider>,
@@ -1438,9 +1466,11 @@ describe('<MainContent />', () => {
                 slashCommands: stableSlashCommands,
               })}
             >
-              <OverflowProvider>
-                <MainContent />
-              </OverflowProvider>
+              <StreamingContext.Provider value={createUIState().streamingState}>
+                <OverflowProvider>
+                  <MainContent />
+                </OverflowProvider>
+              </StreamingContext.Provider>
             </UIStateContext.Provider>
           </UIActionsContext.Provider>
         </AppContext.Provider>,

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type React from 'react';
 import { Box, Static, type DOMElement } from 'ink';
 import {
   memo,
@@ -21,7 +22,7 @@ import {
   ToolCallStatus,
 } from '../types.js';
 import { HistoryItemDisplay } from './HistoryItemDisplay.js';
-import { ShowMoreLines } from './ShowMoreLines.js';
+import { ShowMoreLines, useShowMoreLinesVisible } from './ShowMoreLines.js';
 import { Notifications } from './Notifications.js';
 import { OverflowProvider } from '../contexts/OverflowContext.js';
 import { useUIState } from '../contexts/UIStateContext.js';
@@ -123,6 +124,78 @@ const virtualKeyExtractor = (item: VpItem) =>
 const virtualIsStaticItem = (item: VpItem) =>
   item.type === 'vp-banner' || item.id > 0;
 
+interface VpScrollRegionProps {
+  data: VpItem[];
+  renderItem: (info: { item: VpItem; index: number }) => React.ReactElement;
+  hasFocus: boolean;
+  containerHeight: number;
+  measureAtFullHeight: boolean;
+  showScrollbar: boolean;
+  constrainHeight: boolean;
+  footerRef?: RefObject<DOMElement | null>;
+}
+
+/**
+ * The VP-mode scrollable region: the virtualized list plus the sibling
+ * `<ShowMoreLines>` hint. `<ShowMoreLines>` renders below the list, OUTSIDE
+ * its height-clamped box, so a row it adds is a row the list's own
+ * `containerHeight` budget never accounted for — and VP mode's alternate
+ * screen has no scrollback to reveal a row that does not fit. Reading
+ * `useShowMoreLinesVisible` here — the same predicate `<ShowMoreLines>`
+ * itself uses — and reserving that one row up front keeps the list's real
+ * on-screen footprint (list + hint) within the budget the caller computed
+ * (issue #8239: VP-mode content cut off at bottom).
+ */
+export function VpScrollRegion({
+  data,
+  renderItem,
+  hasFocus,
+  containerHeight,
+  measureAtFullHeight,
+  showScrollbar,
+  constrainHeight,
+  footerRef,
+}: VpScrollRegionProps) {
+  const scrollRef = useRef<ScrollableListRef<VpItem>>(null);
+  const reserveForHint = useShowMoreLinesVisible(constrainHeight) ? 1 : 0;
+
+  return (
+    <>
+      <ScrollableList
+        ref={scrollRef}
+        hasFocus={hasFocus}
+        data={data}
+        renderItem={renderItem}
+        estimatedItemHeight={virtualEstimatedItemHeight}
+        keyExtractor={virtualKeyExtractor}
+        initialScrollIndex={data.length <= 1 ? 0 : SCROLL_TO_ITEM_END}
+        isStaticItem={virtualIsStaticItem}
+        containerHeight={Math.max(0, containerHeight - reserveForHint)}
+        measureAtFullHeight={measureAtFullHeight}
+        showScrollbar={showScrollbar}
+      />
+      <TextSelectionController
+        isActive={hasFocus}
+        getViewportRect={() => scrollRef.current?.getViewportRect() ?? null}
+        getAdditionalSelectableRects={() =>
+          footerRef?.current ? [measureElementPosition(footerRef.current)] : []
+        }
+        getScrollState={() =>
+          scrollRef.current?.getScrollState() ?? {
+            scrollTop: 0,
+            scrollHeight: 0,
+            innerHeight: 0,
+          }
+        }
+        hitTestScrollbar={(location) =>
+          scrollRef.current?.hitTestScrollbar(location) ?? false
+        }
+      />
+      <ShowMoreLines constrainHeight={constrainHeight} />
+    </>
+  );
+}
+
 interface MainContentProps {
   footerRef?: RefObject<DOMElement | null>;
 }
@@ -155,7 +228,6 @@ export const MainContent = ({ footerRef }: MainContentProps) => {
   // state still computes because it lives at the top of the component, but
   // useMemo keeps it cheap when nothing changes.
   const useVirtualScroll = uiState.useTerminalBuffer;
-  const scrollRef = useRef<ScrollableListRef<VpItem>>(null);
 
   const { historyItemsWithSourceCopyOffsets, pendingStartSourceCopyOffsets } =
     useMemo(() => {
@@ -496,41 +568,16 @@ export const MainContent = ({ footerRef }: MainContentProps) => {
 
     return (
       <OverflowProvider>
-        <ScrollableList
-          ref={scrollRef}
-          hasFocus={!uiState.dialogsVisible}
+        <VpScrollRegion
           data={allVirtualItems}
           renderItem={renderVirtualItem}
-          estimatedItemHeight={virtualEstimatedItemHeight}
-          keyExtractor={virtualKeyExtractor}
-          initialScrollIndex={
-            allVirtualItems.length <= 1 ? 0 : SCROLL_TO_ITEM_END
-          }
-          isStaticItem={virtualIsStaticItem}
+          hasFocus={!uiState.dialogsVisible}
           containerHeight={scrollContainerHeight}
           measureAtFullHeight={hasPendingPlainTextConfirmation}
           showScrollbar={showScrollbar}
+          constrainHeight={uiState.constrainHeight}
+          footerRef={footerRef}
         />
-        <TextSelectionController
-          isActive={!uiState.dialogsVisible}
-          getViewportRect={() => scrollRef.current?.getViewportRect() ?? null}
-          getAdditionalSelectableRects={() =>
-            footerRef?.current
-              ? [measureElementPosition(footerRef.current)]
-              : []
-          }
-          getScrollState={() =>
-            scrollRef.current?.getScrollState() ?? {
-              scrollTop: 0,
-              scrollHeight: 0,
-              innerHeight: 0,
-            }
-          }
-          hitTestScrollbar={(location) =>
-            scrollRef.current?.hitTestScrollbar(location) ?? false
-          }
-        />
-        <ShowMoreLines constrainHeight={uiState.constrainHeight} />
       </OverflowProvider>
     );
   }

--- a/packages/cli/src/ui/components/MainContent.vpScrollRegion.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.vpScrollRegion.test.tsx
@@ -5,21 +5,24 @@
  */
 
 // `VpScrollRegion` composes the real ScrollableList (-> VirtualizedList) and
-// the real ShowMoreLines exactly as MainContent.tsx's VP branch does, so
-// this exercises the real render tree rather than a mocked ScrollableList
+// the real ShowMoreLines the way MainContent's VP branch does, so this
+// exercises the real render tree rather than a mocked ScrollableList
 // (MainContent.test.tsx mocks ScrollableList to test data-wiring; it cannot
 // exercise the height math these tests cover).
+//
+// The overflow condition is produced by a real MaxSizedBox — the only
+// component in the codebase that registers an overflow id — rather than by
+// calling addOverflowingId directly, so these tests cannot pass on a
+// condition production never creates.
 
-import { useEffect } from 'react';
+import type React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'ink-testing-library';
-import { Text } from 'ink';
+import { Box, Text } from 'ink';
 import { VpScrollRegion } from './MainContent.js';
+import { MaxSizedBox } from './shared/MaxSizedBox.js';
 import type { HistoryItem } from '../types.js';
-import {
-  useOverflowActions,
-  OverflowProvider,
-} from '../contexts/OverflowContext.js';
+import { OverflowProvider } from '../contexts/OverflowContext.js';
 import { StreamingContext } from '../contexts/StreamingContext.js';
 import { KeypressProvider } from '../contexts/KeypressContext.js';
 import { StreamingState } from '../types.js';
@@ -28,130 +31,100 @@ vi.mock('../selection/use-text-selection.js', () => ({
   TextSelectionController: () => null,
 }));
 
-// One-line stub per item. The item flagged `registersOverflow` calls the
-// exact same `addOverflowingId` a real MaxSizedBox calls when ITS OWN
-// content (e.g. a long /about block) is truncated to fit its per-item
-// height budget — this is what makes <ShowMoreLines> render its hint.
-function StubItem({
-  item,
-}: {
-  item: { id: number; registersOverflow?: boolean };
-}) {
-  const overflowActions = useOverflowActions();
-  useEffect(() => {
-    if (item.registersOverflow) {
-      overflowActions?.addOverflowingId(`item-${item.id}`);
-    }
-  }, [item.registersOverflow, overflowActions, item.id]);
-  return <Text>{`HISTORY:${item.id}`}</Text>;
-}
+const BUDGET = 8;
 
-const renderVpScrollRegion = (data: HistoryItem[], containerHeight: number) =>
-  render(
+// Enough one-line items that the list fills its whole height budget — the
+// only regime in which the budget can be exceeded at all, since
+// VirtualizedList collapses its root to the content height when the content
+// is shorter than the budget.
+const items = Array.from({ length: 12 }, (_, i) => ({
+  id: i + 1,
+  type: 'user',
+  text: `item ${i + 1}`,
+})) as unknown as HistoryItem[];
+
+const OVERFLOWING_ITEM_ID = 12;
+
+const renderRegion = (opts: { withOverflowingItem: boolean }) => {
+  const tree = (
     <KeypressProvider kittyProtocolEnabled={false}>
       <StreamingContext.Provider value={StreamingState.Idle}>
         <OverflowProvider>
           <VpScrollRegion
-            data={data}
-            renderItem={({ item }) => (
-              <StubItem
-                item={
-                  item as unknown as {
-                    id: number;
-                    registersOverflow?: boolean;
-                  }
-                }
-              />
-            )}
+            data={items}
+            renderItem={({ item }) => {
+              const id = (item as unknown as { id: number }).id;
+              if (opts.withOverflowingItem && id === OVERFLOWING_ITEM_ID) {
+                // Truncates its content, so it registers a real overflow id
+                // and ShowMoreLines renders — exactly what a long tool
+                // output does in a real session.
+                return (
+                  <MaxSizedBox maxHeight={3} maxWidth={60}>
+                    {Array.from({ length: 20 }, (_, i) => (
+                      <Box key={i}>
+                        <Text>{`out ${i}`}</Text>
+                      </Box>
+                    ))}
+                  </MaxSizedBox>
+                );
+              }
+              return <Text>{`ITEM${id}`}</Text>;
+            }}
             hasFocus={true}
-            containerHeight={containerHeight}
+            containerHeight={BUDGET}
             measureAtFullHeight={false}
             showScrollbar={false}
             constrainHeight={true}
           />
         </OverflowProvider>
       </StreamingContext.Provider>
-    </KeypressProvider>,
+    </KeypressProvider>
   );
+  return { tree, ...render(tree) };
+};
 
-describe('VpScrollRegion height budget (issue #8239)', () => {
-  it('keeps total rendered rows within containerHeight when an item overflows and the ctrl-s hint shows', async () => {
-    const BUDGET = 5;
-    const data = Array.from({ length: 10 }, (_, i) => ({
-      id: i,
-      // The last item — guaranteed to be in the visible window once
-      // scrolled to the end — registers overflow, mirroring a long /about
-      // block sitting at the bottom of history.
-      registersOverflow: i === 9,
-    })) as unknown as HistoryItem[];
+const settle = async (
+  rerender: (t: React.ReactElement) => void,
+  tree: React.ReactElement,
+) => {
+  const tick = () => new Promise<void>((r) => setImmediate(r));
+  await tick();
+  rerender(tree);
+  await tick();
+  await tick();
+};
 
-    const { lastFrame, rerender } = renderVpScrollRegion(data, BUDGET);
-    // Let the mounted item's useEffect (addOverflowingId) flush and the
-    // resulting re-render settle.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    rerender(
-      <KeypressProvider kittyProtocolEnabled={false}>
-        <StreamingContext.Provider value={StreamingState.Idle}>
-          <OverflowProvider>
-            <VpScrollRegion
-              data={data}
-              renderItem={({ item }) => (
-                <StubItem
-                  item={
-                    item as unknown as {
-                      id: number;
-                      registersOverflow?: boolean;
-                    }
-                  }
-                />
-              )}
-              hasFocus={true}
-              containerHeight={BUDGET}
-              measureAtFullHeight={false}
-              showScrollbar={false}
-              constrainHeight={true}
-            />
-          </OverflowProvider>
-        </StreamingContext.Provider>
-      </KeypressProvider>,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 0));
+describe('VpScrollRegion height budget', () => {
+  it('stays within containerHeight when a truncated item makes the ctrl-s hint render', async () => {
+    const { tree, lastFrame, rerender } = renderRegion({
+      withOverflowingItem: true,
+    });
+    await settle(rerender, tree);
 
     const frame = lastFrame() ?? '';
     const lines = frame.split('\n');
 
-    // The contract AppContainer relies on: this region must never render
-    // more than `containerHeight` rows, because AppContainer computed the
-    // footer's position assuming exactly that many rows are consumed above
-    // it, and VP mode's alternate screen has no scrollback to reveal a row
-    // that does not fit.
-    expect({
-      lineCount: lines.length,
-      containsHint: frame.includes('Press ctrl-s to show more lines'),
-    }).toEqual({
-      lineCount: BUDGET,
-      containsHint: true,
-    });
+    // The hint must actually be on screen — otherwise this test would pass
+    // trivially without exercising the reservation at all.
+    expect(frame).toContain('Press ctrl-s to show more lines');
+    // AppContainer positions the composer assuming this region consumes at
+    // most `containerHeight` rows, and VP mode's alternate screen has no
+    // scrollback to reveal a row that does not fit. Without the reservation
+    // this renders BUDGET + 1.
+    expect(lines.length).toBeLessThanOrEqual(BUDGET);
   });
 
-  it('does not waste a row reserving for the hint when nothing overflows', () => {
-    const BUDGET = 5;
-    const data = Array.from({ length: 10 }, (_, i) => ({
-      id: i,
-    })) as unknown as HistoryItem[];
+  it('uses the full budget when nothing overflows', async () => {
+    const { tree, lastFrame, rerender } = renderRegion({
+      withOverflowingItem: false,
+    });
+    await settle(rerender, tree);
 
-    const { lastFrame } = renderVpScrollRegion(data, BUDGET);
     const frame = lastFrame() ?? '';
     const lines = frame.split('\n');
 
-    // No overflow registered, so <ShowMoreLines> never renders — the list
-    // should get the full budget, not budget-minus-one.
-    expect({
-      lineCount: lines.length,
-      containsHint: frame.includes('Press ctrl-s to show more lines'),
-    }).toEqual({
-      lineCount: BUDGET,
-      containsHint: false,
-    });
+    // No overflow registered, so no hint and no row reserved for one.
+    expect(frame).not.toContain('Press ctrl-s to show more lines');
+    expect(lines.length).toBe(BUDGET);
   });
 });

--- a/packages/cli/src/ui/components/MainContent.vpScrollRegion.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.vpScrollRegion.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// `VpScrollRegion` composes the real ScrollableList (-> VirtualizedList) and
+// the real ShowMoreLines exactly as MainContent.tsx's VP branch does, so
+// this exercises the real render tree rather than a mocked ScrollableList
+// (MainContent.test.tsx mocks ScrollableList to test data-wiring; it cannot
+// exercise the height math these tests cover).
+
+import { useEffect } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { VpScrollRegion } from './MainContent.js';
+import type { HistoryItem } from '../types.js';
+import {
+  useOverflowActions,
+  OverflowProvider,
+} from '../contexts/OverflowContext.js';
+import { StreamingContext } from '../contexts/StreamingContext.js';
+import { KeypressProvider } from '../contexts/KeypressContext.js';
+import { StreamingState } from '../types.js';
+
+vi.mock('../selection/use-text-selection.js', () => ({
+  TextSelectionController: () => null,
+}));
+
+// One-line stub per item. The item flagged `registersOverflow` calls the
+// exact same `addOverflowingId` a real MaxSizedBox calls when ITS OWN
+// content (e.g. a long /about block) is truncated to fit its per-item
+// height budget — this is what makes <ShowMoreLines> render its hint.
+function StubItem({
+  item,
+}: {
+  item: { id: number; registersOverflow?: boolean };
+}) {
+  const overflowActions = useOverflowActions();
+  useEffect(() => {
+    if (item.registersOverflow) {
+      overflowActions?.addOverflowingId(`item-${item.id}`);
+    }
+  }, [item.registersOverflow, overflowActions, item.id]);
+  return <Text>{`HISTORY:${item.id}`}</Text>;
+}
+
+const renderVpScrollRegion = (data: HistoryItem[], containerHeight: number) =>
+  render(
+    <KeypressProvider kittyProtocolEnabled={false}>
+      <StreamingContext.Provider value={StreamingState.Idle}>
+        <OverflowProvider>
+          <VpScrollRegion
+            data={data}
+            renderItem={({ item }) => (
+              <StubItem
+                item={
+                  item as unknown as {
+                    id: number;
+                    registersOverflow?: boolean;
+                  }
+                }
+              />
+            )}
+            hasFocus={true}
+            containerHeight={containerHeight}
+            measureAtFullHeight={false}
+            showScrollbar={false}
+            constrainHeight={true}
+          />
+        </OverflowProvider>
+      </StreamingContext.Provider>
+    </KeypressProvider>,
+  );
+
+describe('VpScrollRegion height budget (issue #8239)', () => {
+  it('keeps total rendered rows within containerHeight when an item overflows and the ctrl-s hint shows', async () => {
+    const BUDGET = 5;
+    const data = Array.from({ length: 10 }, (_, i) => ({
+      id: i,
+      // The last item — guaranteed to be in the visible window once
+      // scrolled to the end — registers overflow, mirroring a long /about
+      // block sitting at the bottom of history.
+      registersOverflow: i === 9,
+    })) as unknown as HistoryItem[];
+
+    const { lastFrame, rerender } = renderVpScrollRegion(data, BUDGET);
+    // Let the mounted item's useEffect (addOverflowingId) flush and the
+    // resulting re-render settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    rerender(
+      <KeypressProvider kittyProtocolEnabled={false}>
+        <StreamingContext.Provider value={StreamingState.Idle}>
+          <OverflowProvider>
+            <VpScrollRegion
+              data={data}
+              renderItem={({ item }) => (
+                <StubItem
+                  item={
+                    item as unknown as {
+                      id: number;
+                      registersOverflow?: boolean;
+                    }
+                  }
+                />
+              )}
+              hasFocus={true}
+              containerHeight={BUDGET}
+              measureAtFullHeight={false}
+              showScrollbar={false}
+              constrainHeight={true}
+            />
+          </OverflowProvider>
+        </StreamingContext.Provider>
+      </KeypressProvider>,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const frame = lastFrame() ?? '';
+    const lines = frame.split('\n');
+
+    // The contract AppContainer relies on: this region must never render
+    // more than `containerHeight` rows, because AppContainer computed the
+    // footer's position assuming exactly that many rows are consumed above
+    // it, and VP mode's alternate screen has no scrollback to reveal a row
+    // that does not fit.
+    expect({
+      lineCount: lines.length,
+      containsHint: frame.includes('Press ctrl-s to show more lines'),
+    }).toEqual({
+      lineCount: BUDGET,
+      containsHint: true,
+    });
+  });
+
+  it('does not waste a row reserving for the hint when nothing overflows', () => {
+    const BUDGET = 5;
+    const data = Array.from({ length: 10 }, (_, i) => ({
+      id: i,
+    })) as unknown as HistoryItem[];
+
+    const { lastFrame } = renderVpScrollRegion(data, BUDGET);
+    const frame = lastFrame() ?? '';
+    const lines = frame.split('\n');
+
+    // No overflow registered, so <ShowMoreLines> never renders — the list
+    // should get the full budget, not budget-minus-one.
+    expect({
+      lineCount: lines.length,
+      containsHint: frame.includes('Press ctrl-s to show more lines'),
+    }).toEqual({
+      lineCount: BUDGET,
+      containsHint: false,
+    });
+  });
+});

--- a/packages/cli/src/ui/components/ShowMoreLines.tsx
+++ b/packages/cli/src/ui/components/ShowMoreLines.tsx
@@ -14,19 +14,29 @@ interface ShowMoreLinesProps {
   constrainHeight: boolean;
 }
 
-export const ShowMoreLines = ({ constrainHeight }: ShowMoreLinesProps) => {
+/**
+ * Whether <ShowMoreLines> will render its one-row hint right now. Exported
+ * so a fixed-height container that lays it out as a sibling (VP mode's
+ * viewport, which cannot scroll to reveal a row it did not budget for) can
+ * reserve that row instead of discovering it only after paint.
+ */
+export const useShowMoreLinesVisible = (constrainHeight: boolean): boolean => {
   const overflowState = useOverflowState();
   const streamingState = useStreamingContext();
 
-  if (
-    overflowState === undefined ||
-    overflowState.overflowingIds.size === 0 ||
-    !constrainHeight ||
-    !(
-      streamingState === StreamingState.Idle ||
-      streamingState === StreamingState.WaitingForConfirmation
-    )
-  ) {
+  return (
+    overflowState !== undefined &&
+    overflowState.overflowingIds.size > 0 &&
+    constrainHeight &&
+    (streamingState === StreamingState.Idle ||
+      streamingState === StreamingState.WaitingForConfirmation)
+  );
+};
+
+export const ShowMoreLines = ({ constrainHeight }: ShowMoreLinesProps) => {
+  const visible = useShowMoreLinesVisible(constrainHeight);
+
+  if (!visible) {
     return null;
   }
 


### PR DESCRIPTION
## What this PR does

Reserves one row in VP mode's height budget for the "Press ctrl-s to show more lines" hint, so the scrollable history region never renders taller than the height its caller allocated for it.

## Why it's needed

In VP mode, `<ShowMoreLines>` renders as a sibling right after the virtualized history list, outside the list's height-clamped box. `AppContainer` computes the list's `containerHeight` assuming the list is the only thing consuming rows in that region, and never subtracts a row for the hint. When a `MaxSizedBox` truncates its content it registers an overflow id, the hint renders, and the region becomes `containerHeight + 1` rows tall. VP mode uses the alternate screen and has no scrollback, so that extra row is pushed off the bottom rather than being scrollable into view.

This only bites when the list content actually fills the budget: `VirtualizedList` collapses its root to the content height when content is shorter, so a short conversation is unaffected.

## Scope correction — this does not fix #8239

This PR was originally opened claiming to fix #8239 (`/about` output cut off at the bottom). That claim was wrong and I have removed it. `/about` renders through `AboutBox`, which uses only plain Ink `Box`/`Text`; it contains no `MaxSizedBox`, and `MaxSizedBox` is the only production caller of `addOverflowingId`. So the `/about` path never registers an overflow id, the hint never renders there, and this change is a provable no-op on it — measured directly, the overflow count is 0 at every terminal height I swept. I was also unable to reproduce #8239's reported symptom on that path at all: driving the real `AboutBox` through the real VP scroll region, the last field (`Memory Usage`) was reachable at every viewport height where the list scrolls.

The bug fixed here is real and reproducible, but it is a different bug, found while investigating #8239. #8239 should stay open.

## Reviewer Test Plan

### How to verify

`packages/cli/src/ui/components/MainContent.vpScrollRegion.test.tsx` renders the real VP scroll region (`ScrollableList` -> `VirtualizedList`, plus the real `ShowMoreLines`) with a fixed `containerHeight` of 8 and enough items to fill it. The overflow condition comes from a **real `MaxSizedBox`** truncating its content, not from calling `addOverflowingId` directly, so the test cannot pass on a condition production never creates. It asserts the hint is actually on screen, then asserts the region is at most `containerHeight` rows. A second test asserts no row is wasted when nothing overflows.

The assertion is mutation-sensitive: forcing the reservation to `0` fails with `expected 9 to be less than or equal to 8`.

### Evidence (Before & After)

A/B against the same test, real `MaxSizedBox`, `containerHeight` 8:

```
reservation disabled:  lines=9  budget=8  hint=true   -> overflows by 1
reservation enabled:   lines=8  budget=8  hint=true   -> fits
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node.js 22.22.3, `npx vitest run` inside `packages/cli`. No sandbox.

## Risk & Scope

- Main risk or tradeoff: while the hint is showing, the visible history list is one row shorter than before. That is the intent — the row now goes to the hint instead of overflowing the region.
- Not validated / out of scope: I have not reproduced this against a live terminal; the evidence is the unit test above driving the real components. The `/skills` dialog has a separate height-budget gap noted during triage of #9037 — not touched here.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #8239 — found while investigating that report. **Does not fix it**; see the scope-correction section above.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 VP 模式的高度预算中为"按 ctrl-s 显示更多行"提示预留一行，使可滚动的历史区域不会渲染得比调用方分配给它的高度更高。

## 为什么需要

在 VP 模式下，`<ShowMoreLines>` 作为紧跟虚拟化历史列表之后的兄弟节点渲染，位于列表的高度限制盒子之外。`AppContainer` 计算列表的 `containerHeight` 时，假定该区域只有列表占用行数，从未为提示预留一行。当 `MaxSizedBox` 截断其内容时会注册一个 overflow id，提示随之渲染，该区域就变成 `containerHeight + 1` 行高。VP 模式使用备用屏幕且没有回滚缓冲区，因此这多出的一行会被挤出底部，而不是可以滚动查看。

只有当列表内容确实填满预算时才会触发：内容较短时 `VirtualizedList` 会将其根节点收缩到内容高度，因此短会话不受影响。

## 范围更正 —— 本 PR 并不修复 #8239

本 PR 最初声称修复 #8239（`/about` 输出底部被截断）。该声称是错误的，现已移除。`/about` 通过 `AboutBox` 渲染，后者只使用普通的 Ink `Box`/`Text`，不包含 `MaxSizedBox`，而 `MaxSizedBox` 是 `addOverflowingId` 在生产代码中唯一的调用方。因此 `/about` 路径永远不会注册 overflow id，提示也不会在该路径渲染，本改动对其可证明是无操作 —— 实测在我扫描的每一个终端高度上 overflow 计数均为 0。我也完全无法在该路径复现 #8239 报告的现象：通过真实 VP 滚动区域驱动真实 `AboutBox` 时，在列表可滚动的每个视口高度下最后一个字段（`Memory Usage`）都可以到达。

此处修复的缺陷真实且可复现，但它是在排查 #8239 过程中发现的另一个缺陷。#8239 应保持开启状态。

## 审查者测试计划

### 如何验证

`packages/cli/src/ui/components/MainContent.vpScrollRegion.test.tsx` 以固定的 `containerHeight`（8）和足以填满它的条目，渲染真实的 VP 滚动区域（`ScrollableList` -> `VirtualizedList`，以及真实的 `ShowMoreLines`）。溢出条件来自**真实的 `MaxSizedBox`** 截断其内容，而不是直接调用 `addOverflowingId`，因此该测试不可能建立在生产环境从不产生的条件之上。它先断言提示确实出现在屏幕上，再断言该区域至多占用 `containerHeight` 行。第二个测试断言在没有溢出时不会浪费任何一行。

该断言对变异敏感：将预留强制为 `0` 会以 `expected 9 to be less than or equal to 8` 失败。

### 证据（修复前后对比）

同一测试、真实 `MaxSizedBox`、`containerHeight` 为 8 的 A/B 对比：

```
关闭预留:  lines=9  budget=8  hint=true   -> 超出 1 行
开启预留:  lines=8  budget=8  hint=true   -> 正好放下
```

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 运行环境（可选）

Node.js 22.22.3，在 `packages/cli` 下运行 `npx vitest run`。无沙箱。

## 风险与范围

- 主要风险或权衡：提示显示期间，可见的历史列表比之前少一行。这正是本意 —— 该行现在归提示所有，而不是溢出整个区域。
- 未验证 / 范围之外：尚未在真实终端上复现；证据是上述驱动真实组件的单元测试。`/skills` 对话框存在另一处高度预算缺口（在排查 #9037 时记录）—— 本 PR 未涉及。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #8239 —— 在排查该报告时发现。**并不修复它**；详见上方范围更正一节。

</details>
