### PR TITLE
fix(channels/qqbot): key the cron textChunk guard on active prompts, not streamState

### DIFF
--- a/packages/channels/qqbot/src/QQChannel.ts
+++ b/packages/channels/qqbot/src/QQChannel.ts
@@ -214,6 +214,21 @@ export class QQChannel extends ChannelBase {
   private _reconnectId: number = 0;
   private blockStreaming: boolean = false;
   private flushedSessions: Set<string> = new Set();
+  /**
+   * Sessions with a prompt turn currently in flight, tracked via
+   * onPromptStart/onPromptEnd.
+   *
+   * This is the discriminator the cron textChunk handler uses to tell
+   * "prompt-response chunk" from "cron/non-prompt chunk". streamState
+   * cannot serve that role (#6094): it is never populated when
+   * blockStreaming is 'on' (onResponseChunk early-returns), so prompt
+   * chunks leak into cronBuffer; and a residual entry from a finished
+   * turn's unsettled flush silently blocks cron delivery. This set is
+   * reliable because ChannelBase always brackets a prompt turn with
+   * onPromptStart and onPromptEnd (onPromptEnd runs in the prompt path's
+   * finally, even on error/cancel), independent of streaming config.
+   */
+  private activePromptSessions: Set<string> = new Set();
   private readonly qqStatePath: string;
   /**
    * Path to the global sessions.json managed by start.ts.
@@ -302,7 +317,13 @@ export class QQChannel extends ChannelBase {
         return;
       }
       if (!wasInCronFlow) return;
-      if (this.streamState.has(sessionId)) return;
+      // Sessions with an active prompt turn belong to the prompt path
+      // (which delivers the response itself) — never capture their chunks
+      // into the cron buffer. Keyed on activePromptSessions rather than
+      // streamState (#6094): streamState is empty under blockStreaming:'on'
+      // (prompt chunks would be duplicated) and can linger after a turn
+      // ends (cron chunks would be silently dropped).
+      if (this.activePromptSessions.has(sessionId)) return;
       let entry = this.cronBuffer.get(sessionId);
       if (!entry) {
         entry = { buffer: '', timer: null };
@@ -968,24 +989,31 @@ export class QQChannel extends ChannelBase {
     this.flushingSessions.clear();
     this.pendingStreamDelete.clear();
     this.flushedSessions.clear();
+    this.activePromptSessions.clear();
   }
 
   /**
-   * QQ Bot API V2 does not provide a typing indicator endpoint.
-   * ChannelBase calls these hooks to signal prompt start/end;
-   * they are intentionally no-ops for this channel.
+   * QQ Bot API V2 does not provide a typing indicator endpoint, but these
+   * hooks still maintain activePromptSessions — the cron textChunk
+   * discriminator (see activePromptSessions). ChannelBase always pairs the
+   * two calls per prompt turn (onPromptEnd runs in the prompt path's
+   * finally, even on error/cancel).
    */
   protected override onPromptStart(
     _chatId: string,
-    _sessionId: string,
+    sessionId: string,
     _messageId?: string,
-  ): void {}
+  ): void {
+    this.activePromptSessions.add(sessionId);
+  }
 
   protected override onPromptEnd(
     _chatId: string,
-    _sessionId: string,
+    sessionId: string,
     _messageId?: string,
-  ): void {}
+  ): void {
+    this.activePromptSessions.delete(sessionId);
+  }
 
   // ── Streaming (idle-flush with per-session buffers) ────────────
 
@@ -1290,6 +1318,7 @@ export class QQChannel extends ChannelBase {
     this.flushingSessions.delete(sessionId);
     this.pendingStreamDelete.delete(sessionId);
     this.flushedSessions.delete(sessionId);
+    this.activePromptSessions.delete(sessionId);
     super.onSessionDied(sessionId);
   }
   // ── State Persistence (cross-server context continuation) ──────

--- a/packages/channels/qqbot/src/cron.test.ts
+++ b/packages/channels/qqbot/src/cron.test.ts
@@ -54,6 +54,7 @@ vi.mock('@qwen-code/channel-base', () => ({
     protected handleInbound(_env: unknown): Promise<void> {
       return Promise.resolve();
     }
+    protected onSessionDied(_sessionId: string): void {}
   },
   SessionRouter: class {
     restoreSessions(): Promise<void> {
@@ -77,7 +78,9 @@ function mockResponse(
   return { ok, status, text: async () => '' };
 }
 
-function makeChannel(): QQChannelClass {
+function makeChannel(
+  configOverrides?: Record<string, unknown>,
+): QQChannelClass {
   textChunkHandlers.length = 0;
 
   const router = {
@@ -109,6 +112,7 @@ function makeChannel(): QQChannelClass {
       appID: 'test-app-id',
       appSecret: 'test-secret',
       'cron-msg-experimental': true,
+      ...configOverrides,
     },
     bridge as unknown as import('@qwen-code/channel-base').AcpBridge,
     { router } as unknown as Record<string, unknown>,
@@ -312,21 +316,22 @@ describe('cronTextHandler', () => {
     stderrSpy.mockRestore();
   });
 
-  // A6: streamState isolation — cron handler skips sessions owned by prompt path
-  it('streamState isolation: cron handler skips sessions with existing streamState entry', async () => {
+  // A6: prompt-path isolation — cron handler skips sessions with an active
+  // prompt turn. (Discriminator is activePromptSessions, keyed by
+  // onPromptStart/onPromptEnd — see #6094. A bare streamState entry no
+  // longer blocks cron; covered by the #6094 item 2 test below.)
+  it('prompt-path isolation: cron handler skips sessions with an active prompt turn', async () => {
     const ch = makeChannel();
     const pvt = ch as unknown as Record<string, unknown>;
     pvt['_ready'] = true;
     pvt['_inCronFlow'] = 1;
 
-    // Pre-populate streamState for this session — prompt path owns it
-    const ss = pvt['streamState'] as Map<string, unknown>;
-    ss.set('sess-stream', {
-      chatId: 'test-chat',
-      buffer: 'existing prompt text',
-      timer: null,
-      retryCount: 0,
-    });
+    // ChannelBase brackets the prompt turn with onPromptStart/onPromptEnd.
+    (
+      ch as unknown as {
+        onPromptStart: (chatId: string, sessionId: string) => void;
+      }
+    ).onPromptStart('test-chat', 'sess-stream');
 
     triggerTextChunk('sess-stream', 'should be ignored by cron');
     await flushSetImmediate();
@@ -566,5 +571,174 @@ describe('disconnect cron cleanup', () => {
     (ch as unknown as { disconnect: () => void }).disconnect();
 
     expect(pvt['_inCronFlow']).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prompt/cron discriminator (issue #6094)
+// ---------------------------------------------------------------------------
+describe('prompt/cron textChunk discriminator (#6094)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    textChunkHandlers.length = 0;
+    mockSendQQMessage.mockResolvedValue(mockResponse(true));
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function flushSetImmediate(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  function promptHooks(ch: QQChannelClass): {
+    onPromptStart: (chatId: string, sessionId: string) => void;
+    onPromptEnd: (chatId: string, sessionId: string) => void;
+  } {
+    return ch as unknown as {
+      onPromptStart: (chatId: string, sessionId: string) => void;
+      onPromptEnd: (chatId: string, sessionId: string) => void;
+    };
+  }
+
+  // #6094 item 1: with blockStreaming:'on', onResponseChunk early-returns
+  // without populating streamState, so the streamState.has(sessionId) guard
+  // cannot tell prompt chunks from cron chunks. While a cron flow is active,
+  // every prompt-response chunk leaks into cronBuffer and is re-sent by the
+  // 2s idle flush on top of the BlockStreamer delivery.
+  it('item 1: blockStreaming=on prompt chunks during a cron flow are not duplicated into cronBuffer', async () => {
+    const ch = makeChannel({ blockStreaming: 'on' });
+    const pvt = ch as unknown as Record<string, unknown>;
+    pvt['_ready'] = true;
+
+    // ChannelBase brackets every prompt turn with onPromptStart/onPromptEnd.
+    promptHooks(ch).onPromptStart('test-chat', 'sess-prompt');
+
+    // A cron flow is active concurrently (scheduled-message flow in flight).
+    pvt['_inCronFlow'] = 1;
+
+    // Prompt response chunk arrives. With blockStreaming:'on' the streaming
+    // path early-returns, so no streamState entry exists for this session.
+    triggerTextChunk('sess-prompt', 'prompt response text');
+    await flushSetImmediate();
+
+    const cronBuffer = pvt['cronBuffer'] as Map<string, { buffer: string }>;
+    // The prompt text belongs to an active prompt — it must not be captured
+    // by the cron buffer (BlockStreamer already delivers it).
+    expect(cronBuffer.has('sess-prompt')).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockSendQQMessage).not.toHaveBeenCalled();
+
+    promptHooks(ch).onPromptEnd('test-chat', 'sess-prompt');
+  });
+
+  // Regression guard for item 1 fix: genuine cron chunks (no active prompt
+  // for the session) must still be buffered and delivered with
+  // blockStreaming:'on'.
+  it('item 1 regression: cron chunks without an active prompt are still delivered (blockStreaming=on)', async () => {
+    const ch = makeChannel({ blockStreaming: 'on' });
+    const pvt = ch as unknown as Record<string, unknown>;
+    pvt['_ready'] = true;
+    pvt['_inCronFlow'] = 1;
+
+    triggerTextChunk('sess-cron', 'cron text');
+    await flushSetImmediate();
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(mockSendQQMessage).toHaveBeenCalledTimes(1);
+    expect(mockSendQQMessage).toHaveBeenCalledWith(
+      'https://api.sgroup.qq.com',
+      '/v2/users/test-chat/messages',
+      'test-token',
+      { msg_type: 2, markdown: { content: 'cron text' } },
+    );
+  });
+
+  // #6094 item 2: a lingering streamState entry from an earlier prompt (e.g.
+  // cancelled/errored turn whose cleanup has not settled) silently drops all
+  // subsequent cron textChunks for the same sessionId because the guard keys
+  // on streamState. The guard must key on whether a prompt turn is actually
+  // active, not on residual streaming state.
+  it('item 2: lingering streamState entry after prompt end does not block cron delivery', async () => {
+    const ch = makeChannel();
+    const pvt = ch as unknown as Record<string, unknown>;
+    pvt['_ready'] = true;
+
+    // A prompt turn streams a partial answer, then ends (ChannelBase always
+    // runs onPromptEnd in its finally, even on error/cancel).
+    promptHooks(ch).onPromptStart('test-chat', 'sess-leak');
+    (
+      ch as unknown as {
+        onResponseChunk: (
+          chatId: string,
+          chunk: string,
+          sessionId: string,
+        ) => void;
+      }
+    ).onResponseChunk('test-chat', 'partial answer', 'sess-leak');
+    promptHooks(ch).onPromptEnd('test-chat', 'sess-leak');
+
+    // The streamState entry lingers until its idle flush settles.
+    const ss = pvt['streamState'] as Map<string, unknown>;
+    expect(ss.has('sess-leak')).toBe(true);
+
+    // A cron flow now emits output for the same session.
+    pvt['_inCronFlow'] = 1;
+    triggerTextChunk('sess-leak', 'cron text');
+    await flushSetImmediate();
+
+    const cronBuffer = pvt['cronBuffer'] as Map<string, { buffer: string }>;
+    expect(cronBuffer.get('sess-leak')?.buffer).toBe('cron text');
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    // The cron text must be delivered despite the lingering streamState.
+    const sentBodies = mockSendQQMessage.mock.calls.map(
+      (call) => call[3] as { markdown?: { content?: string } },
+    );
+    expect(
+      sentBodies.some((body) => body.markdown?.content === 'cron text'),
+    ).toBe(true);
+  });
+
+  // After the prompt turn ends, cron chunks for the session flow again.
+  it('resumes cron capture after the prompt turn ends', async () => {
+    const ch = makeChannel();
+    const pvt = ch as unknown as Record<string, unknown>;
+    pvt['_ready'] = true;
+    pvt['_inCronFlow'] = 1;
+
+    promptHooks(ch).onPromptStart('test-chat', 'sess-resume');
+    promptHooks(ch).onPromptEnd('test-chat', 'sess-resume');
+
+    triggerTextChunk('sess-resume', 'cron after prompt');
+    await flushSetImmediate();
+
+    const cronBuffer = pvt['cronBuffer'] as Map<string, { buffer: string }>;
+    expect(cronBuffer.get('sess-resume')?.buffer).toBe('cron after prompt');
+  });
+
+  // Session-death cleanup: a dead session must not stay marked as an active
+  // prompt (mirrors streamState cleanup in onSessionDied).
+  it('onSessionDied clears the active-prompt marker', async () => {
+    const ch = makeChannel();
+    const pvt = ch as unknown as Record<string, unknown>;
+    pvt['_ready'] = true;
+    pvt['_inCronFlow'] = 1;
+
+    promptHooks(ch).onPromptStart('test-chat', 'sess-died');
+    (
+      ch as unknown as { onSessionDied: (sessionId: string) => void }
+    ).onSessionDied('sess-died');
+
+    triggerTextChunk('sess-died', 'cron after death');
+    await flushSetImmediate();
+
+    const cronBuffer = pvt['cronBuffer'] as Map<string, { buffer: string }>;
+    expect(cronBuffer.get('sess-died')?.buffer).toBe('cron after death');
   });
 });


### PR DESCRIPTION
## What this PR does

Replaces the cron textChunk discriminator in the QQ Bot channel. `handleCronTextChunk` used `streamState.has(sessionId)` to decide whether an incoming `textChunk` belongs to an in-progress prompt (and must be left to the prompt path) or to a cron/non-prompt flow (and must be captured into the cron buffer). This PR tracks sessions with an active prompt turn in a dedicated `activePromptSessions` set, maintained by the `onPromptStart`/`onPromptEnd` hooks, and keys the cron guard on that set instead. The marker is cleared alongside the existing streaming-state cleanup in `disconnect()` and `onSessionDied`.

## Why it's needed

`streamState.has(sessionId)` is not a reliable prompt/cron discriminator, and it fails in both directions (issue #6094, items 1 and 2):

1. **Duplicate messages with `blockStreaming: 'on'`** — `onResponseChunk` early-returns under block streaming and never populates `streamState`. During an active cron flow, prompt-response chunks therefore pass the `streamState.has()` guard, land in `cronBuffer`, and get re-sent by the 2s idle flush on top of the BlockStreamer delivery.
2. **Silent cron drops** — a residual `streamState` entry from a finished turn whose flush has not settled (e.g. a cancelled/errored prompt mid-flush) keeps the guard true, silently discarding all subsequent cron textChunks for that session.

`activePromptSessions` is reliable because ChannelBase always brackets a prompt turn with `onPromptStart` and `onPromptEnd` — `onPromptEnd` runs in the prompt path's `finally`, even on error/cancel — and the marker is independent of streaming configuration.

## Reviewer Test Plan

### How to verify

Unit-level reproduction of both failure modes, driven through QQChannel's real hooks (`onPromptStart`/`onResponseChunk`/`onPromptEnd`, `runCronFlow`/`_inCronFlow`, bridge `textChunk` listener):

1. Item 1: `blockStreaming: 'on'`, active prompt turn (`onPromptStart`), concurrent cron flow → emit a `textChunk` for the prompt's session. Before: chunk is captured into `cronBuffer` and re-sent (duplicate). After: chunk is skipped; no cron send.
2. Item 2: prompt turn streams a partial answer then ends (`onPromptEnd` while the streamState flush has not settled) → cron flow emits a `textChunk` for the same session. Before: silently dropped. After: buffered and delivered.

All three repro tests fail on `main` and pass with this PR (verified by running the suite with and without the QQChannel.ts change):

```
packages/channels/qqbot && vitest run
 Test Files  7 passed (7)
      Tests  296 passed (296)
```

Also run: `tsc --build` for the package (clean), `eslint` + `prettier --check` on the changed files (clean).

Note: the cron path is gated behind the opt-in `cron-msg-experimental` config flag, so the default (stable) path is untouched.

### Evidence (Before & After)

N/A — channel-adapter logic, no user-visible UI. Test evidence above; failing tests before the fix:

```
× cronTextHandler > prompt-path isolation: cron handler skips sessions with an active prompt turn
× prompt/cron textChunk discriminator (#6094) > item 1: blockStreaming=on prompt chunks during a cron flow are not duplicated into cronBuffer
× prompt/cron textChunk discriminator (#6094) > item 2: lingering streamState entry after prompt end does not block cron delivery
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest run` in `packages/channels/qqbot`) + package `tsc --build`.

## Risk & Scope

- Main risk or tradeoff: the cron skip window now spans the whole prompt turn (`onPromptStart` → `onPromptEnd`) instead of only the streamState lifetime — a slightly wider window in which cron chunks for the same session are dropped during a prompt. This matches the existing intent (never mix cron output into an active prompt) and is the same semantics the non-blockStreaming path always had. The pre-existing streamState-isolation unit test was rewritten to drive the new discriminator.
- Not validated / out of scope: issue items 3 and 4 are already addressed on main (plain-text fallback for no-msgId sends exists and is covered by `send.test.ts`; `setBridge` re-attaches `_cronTextHandler`). Items 5 (botOpenId instruction timing) and 6 (token-refresh `connect()` retry) remain open as separate low-priority work. The author's broader cron-session refactor proposals (separate cron sessionIds / textChunkType discriminator) are design discussions, not part of this fix.
- Breaking changes / migration notes: none; behavior changes only under the opt-in `cron-msg-experimental` flag.

## Linked Issues

Partially fixes #6094 (items 1 and 2). Items 3 and 4 were verified as already addressed on main; items 5 and 6 stay open.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

替换 QQ Bot 频道中 cron textChunk 的判别器。`handleCronTextChunk` 原先用 `streamState.has(sessionId)` 来判断收到的 `textChunk` 是属于进行中的 prompt（应交给 prompt 路径处理），还是属于 cron/非 prompt 流（应捕获进 cron 缓冲区）。本 PR 改为用一个专门的 `activePromptSessions` 集合来跟踪有活跃 prompt 回合的 session，由 `onPromptStart`/`onPromptEnd` 钩子维护，并把 cron 守卫改为基于该集合判断。该标记在 `disconnect()` 和 `onSessionDied` 中与现有流式状态清理一起清除。

## 为什么需要

`streamState.has(sessionId)` 不是可靠的 prompt/cron 判别器，且两个方向都会出错（issue #6094 的第 1、2 条）：

1. **`blockStreaming: 'on'` 时消息重复** —— 块流式下 `onResponseChunk` 提前返回，从不填充 `streamState`。在 cron 流活跃期间，prompt 响应块因此能通过 `streamState.has()` 守卫，落入 `cronBuffer`，被 2 秒空闲 flush 再次发送，造成在 BlockStreamer 投递之外的重复消息。
2. **cron 消息被静默丢弃** —— 已结束回合残留的 `streamState` 条目（例如被取消/出错的 prompt 的 flush 尚未落定）会让守卫一直为真，导致该 session 后续所有 cron textChunk 被静默丢弃。

`activePromptSessions` 是可靠的，因为 ChannelBase 总是成对调用 `onPromptStart` 和 `onPromptEnd` —— `onPromptEnd` 在 prompt 路径的 `finally` 中执行，即使出错/取消也会执行 —— 且该标记与流式配置无关。

## 审阅者测试方案

### 如何验证

通过 QQChannel 的真实钩子（`onPromptStart`/`onResponseChunk`/`onPromptEnd`、`runCronFlow`/`_inCronFlow`、bridge 的 `textChunk` 监听器）对两种失败模式做单测级复现：

1. 第 1 条：`blockStreaming: 'on'`、活跃 prompt 回合（`onPromptStart`）、并发 cron 流 → 对该 prompt 的 session 发出 `textChunk`。修复前：块被捕获进 `cronBuffer` 并被重发（重复）。修复后：块被跳过，无 cron 发送。
2. 第 2 条：prompt 回合流出部分回答后结束（`onPromptEnd` 时 streamState 的 flush 尚未落定）→ cron 流对同一 session 发出 `textChunk`。修复前：被静默丢弃。修复后：被缓冲并投递。

三个复现测试在 `main` 上失败、在本 PR 上通过（已通过"应用/还原 QQChannel.ts 改动"两种方式分别验证）：

```
packages/channels/qqbot && vitest run
 Test Files  7 passed (7)
      Tests  296 passed (296)
```

另外：该包 `tsc --build`（通过）、对改动文件跑 `eslint` + `prettier --check`（通过）。

注意：cron 路径在可选配置 `cron-msg-experimental` 开关之后，默认（稳定）路径不受影响。

### 证据（修复前后）

N/A —— 频道适配器逻辑，无用户可见 UI。测试证据见上；修复前失败的测试：

```
× cronTextHandler > prompt-path isolation: cron handler skips sessions with an active prompt turn
× prompt/cron textChunk discriminator (#6094) > item 1: blockStreaming=on prompt chunks during a cron flow are not duplicated into cronBuffer
× prompt/cron textChunk discriminator (#6094) > item 2: lingering streamState entry after prompt end does not block cron delivery
```

### 测试环境

|   系统    | 状态 |
| :-------: | :--: |
|  🍏 macOS |  ⚠️  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux |  ✅  |

### 环境（可选）

仅单元测试（`packages/channels/qqbot` 下 `vitest run`）+ 该包 `tsc --build`。

## 风险与范围

- 主要风险/权衡：cron 的跳过窗口从"仅 streamState 存活期"变为"整个 prompt 回合（`onPromptStart` → `onPromptEnd`）"，即在 prompt 进行中丢弃同 session cron 块的窗口略变宽。这与既有意图一致（不把 cron 输出混入活跃 prompt），也与非块流式路径一直以来的语义相同。原有的 streamState 隔离单测已改写为驱动新判别器。
- 未验证/超出范围：issue 第 3、4 条在 main 上已处理（无 msgId 发送已有纯文本降级回退，`send.test.ts` 有覆盖；`setBridge` 会重新挂载 `_cronTextHandler`）。第 5 条（botOpenId 指令注入时机）和第 6 条（token 刷新后 `connect()` 无重试）仍作为独立的低优先级事项开放。作者提出的更宏观的 cron session 重构方向（独立 cron sessionId / textChunkType 判别器）属于设计讨论，不在本修复范围。
- 破坏性变更/迁移说明：无；行为变化仅发生在可选开关 `cron-msg-experimental` 之下。

## 关联 Issue

Partially fixes #6094（第 1、2 条）。第 3、4 条已确认在 main 上解决；第 5、6 条保持开放。

</details>
