### PR TITLE
fix(review): the sandbox default named an image that does not exist

### DIFF
--- a/packages/cli/src/commands/review/lib/sandboxed-exec.test.ts
+++ b/packages/cli/src/commands/review/lib/sandboxed-exec.test.ts
@@ -11,9 +11,10 @@
 // happens when there is no runtime at all.
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { join, sep } from 'node:path';
+import { dirname, join, sep } from 'node:path';
 import {
   existsSync,
+  readFileSync,
   mkdirSync,
   writeFileSync,
   mkdtempSync,
@@ -22,6 +23,7 @@ import {
   symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import type { spawnSync } from 'node:child_process';
 import { isolateOperatorReviewSettings } from './test-utils.js';
 import * as environment from '../../../config/environment.js';
@@ -917,6 +919,37 @@ describe('reviewSandboxImage', () => {
     expect(reviewSandboxImage({ QWEN_REVIEW_SANDBOX_IMAGE: 'mine:1' })).toBe(
       'mine:1',
     );
-    expect(reviewSandboxImage({})).toContain('sandbox');
+    // The operator's own sandbox image, if they configured one for
+    // `qwen --sandbox`, rather than ignoring it and pulling a second one.
+    expect(reviewSandboxImage({ QWEN_SANDBOX_IMAGE: 'theirs:2' })).toBe(
+      'theirs:2',
+    );
+  });
+
+  it('defaults to the image this CLI actually ships with', () => {
+    // Pinned against the MANIFEST, not against a spelling. The assertion this
+    // replaces was `toContain('sandbox')`, which is how a default of
+    // `ghcr.io/qwenlm/qwen-code/sandbox:latest` shipped: it contains the word,
+    // it is not the CLI's image, and it does not resolve at all — an anonymous
+    // manifest request answers 403 where the real one answers 200, so every
+    // command of an opted-in review failed at image pull. Nineteen rounds of
+    // argv-level review could not see it because no container was ever
+    // started. The real image happens NOT to contain "sandbox", so the old
+    // assertion would fail on the correct value and pass on the broken one.
+    const manifest = JSON.parse(
+      readFileSync(
+        join(
+          dirname(fileURLToPath(import.meta.url)),
+          '..',
+          '..',
+          '..',
+          '..',
+          'package.json',
+        ),
+        'utf8',
+      ),
+    ) as { config?: { sandboxImageUri?: string } };
+    expect(manifest.config?.sandboxImageUri).toBeTruthy();
+    expect(reviewSandboxImage({})).toBe(manifest.config?.sandboxImageUri);
   });
 });

--- a/packages/cli/src/commands/review/lib/sandboxed-exec.test.ts
+++ b/packages/cli/src/commands/review/lib/sandboxed-exec.test.ts
@@ -23,6 +23,7 @@ import {
   symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { CLI_VERSION } from '../../../generated/git-commit.js';
 import { fileURLToPath } from 'node:url';
 import type { spawnSync } from 'node:child_process';
 import { isolateOperatorReviewSettings } from './test-utils.js';
@@ -924,6 +925,48 @@ describe('reviewSandboxImage', () => {
     expect(reviewSandboxImage({ QWEN_SANDBOX_IMAGE: 'theirs:2' })).toBe(
       'theirs:2',
     );
+    // ORDER, with both set at once — the only way a reordering of the chain
+    // can be seen. Reviewed-repository-specific beats the operator's general
+    // one, because the review override exists for a toolchain the repository
+    // declared it needs; the other way round runs the build in an image
+    // missing it.
+    expect(
+      reviewSandboxImage({
+        QWEN_REVIEW_SANDBOX_IMAGE: 'mine:1',
+        QWEN_SANDBOX_IMAGE: 'theirs:2',
+      }),
+    ).toBe('mine:1');
+    expect(
+      reviewSandboxImage({
+        QWEN_CODE_CUSTOM_SANDBOX_IMAGE: 'custom:3',
+        QWEN_SANDBOX_IMAGE: 'theirs:2',
+      }),
+    ).toBe('custom:3');
+    expect(
+      reviewSandboxImage({
+        QWEN_REVIEW_SANDBOX_IMAGE: 'mine:1',
+        QWEN_CODE_CUSTOM_SANDBOX_IMAGE: 'custom:3',
+      }),
+    ).toBe('mine:1');
+  });
+
+  it('consults the manifest, and falls back to a name that exists', () => {
+    // These two cannot be told apart by their VALUE: `DEFAULT_IMAGE`'s tag is
+    // `CLI_VERSION`, generated from the same manifest version, so today the
+    // fallback string-equals the manifest field. Deleting the manifest lookup
+    // entirely therefore leaves the pin below green. Injecting the reader is
+    // what makes the mechanism visible at all.
+    expect(reviewSandboxImage({}, () => 'manifest-image:test')).toBe(
+      'manifest-image:test',
+    );
+    // ...and when the manifest cannot be found — the unusual install layout
+    // the literal exists for — the argv still names something that resolves.
+    // This is the branch the defect this PR fixes lived in: with no coverage,
+    // reverting it to an unpullable name ships green.
+    const fallback = reviewSandboxImage({}, () => undefined);
+    expect(fallback).toBe(`ghcr.io/qwenlm/qwen-code:${CLI_VERSION}`);
+    expect(fallback).not.toContain('/sandbox');
+    expect(fallback).not.toContain(':latest');
   });
 
   it('defaults to the image this CLI actually ships with', () => {

--- a/packages/cli/src/commands/review/lib/sandboxed-exec.ts
+++ b/packages/cli/src/commands/review/lib/sandboxed-exec.ts
@@ -48,11 +48,14 @@
 import { spawnSync } from 'node:child_process';
 import { realpathSync } from 'node:fs';
 import { basename, dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { operatorReviewSettings } from './review-settings.js';
 import { REVIEW_TMP_DIR } from './paths.js';
 import { redirectedAncestor } from './worktree.js';
 import { CUSTOM_SANDBOX_IMAGE_ENV_VAR } from '../../../utils/processUtils.js';
 import { isFileSourcedEnvKey } from '../../../config/environment.js';
+import { readPackageUpSync } from 'read-package-up';
+import { CLI_VERSION } from '../../../generated/git-commit.js';
 
 /**
  * The fallback when neither override names an image: the published sandbox
@@ -60,7 +63,13 @@ import { isFileSourcedEnvKey } from '../../../config/environment.js';
  * digest would go stale in a file nobody updates, and the override exists for
  * anyone who needs reproducibility.
  */
-const DEFAULT_IMAGE = 'ghcr.io/qwenlm/qwen-code/sandbox:latest';
+/**
+ * Last resort only, and versioned rather than floating: the real default is
+ * the CLI's own `config.sandboxImageUri` — see `cliSandboxImage`. This literal
+ * exists for the case where the package manifest cannot be found at all (an
+ * unusual install layout), so the argv still names something that exists.
+ */
+const DEFAULT_IMAGE = `ghcr.io/qwenlm/qwen-code:${CLI_VERSION}`;
 
 /** Container runtimes this module knows how to drive, in preference order. */
 const RUNTIMES = ['docker', 'podman'] as const;
@@ -698,6 +707,43 @@ export function containerCommand(
  * a specific Node major), which is the case this default cannot cover and
  * should not pretend to.
  */
+/**
+ * The image `qwen --sandbox` itself runs, read from the package manifest that
+ * ships with this CLI (`config.sandboxImageUri`) — the same field
+ * `sandboxConfig.ts` reads, so the two cannot drift.
+ *
+ * This is a correction, not a refinement. The first cut hardcoded
+ * `ghcr.io/qwenlm/qwen-code/sandbox:latest` and its comment claimed that was
+ * "the same image `qwen --sandbox` uses". It is not: the CLI's image is
+ * `ghcr.io/qwenlm/qwen-code:<version>`, a different repository path and a
+ * pinned tag, and the hardcoded name does not resolve at all — an anonymous
+ * manifest request answers 403 where the real one answers 200. Every command
+ * of an opted-in review therefore failed at image pull, which nineteen rounds
+ * of argv-level review could not see because no container was ever started
+ * from that argv.
+ *
+ * Read once and cached: this is on the per-command path.
+ */
+function cliSandboxImage(): string | undefined {
+  if (manifestImage !== undefined) return manifestImage ?? undefined;
+  try {
+    const found = readPackageUpSync({
+      cwd: dirname(fileURLToPath(import.meta.url)),
+    });
+    const uri = (
+      found?.packageJson as
+        | { config?: { sandboxImageUri?: string } }
+        | undefined
+    )?.config?.sandboxImageUri;
+    manifestImage = typeof uri === 'string' && uri.trim() ? uri.trim() : null;
+  } catch {
+    manifestImage = null;
+  }
+  return manifestImage ?? undefined;
+}
+
+let manifestImage: string | null | undefined;
+
 export function reviewSandboxImage(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
@@ -711,6 +757,11 @@ export function reviewSandboxImage(
   return (
     pick('QWEN_REVIEW_SANDBOX_IMAGE') ||
     pick(CUSTOM_SANDBOX_IMAGE_ENV_VAR) ||
+    // The operator's own sandbox image, if they configured one for
+    // `qwen --sandbox`. Through `pick`, so a repository shipping it in its
+    // `.qwen/.env` cannot choose the image its own code runs in.
+    pick('QWEN_SANDBOX_IMAGE') ||
+    cliSandboxImage() ||
     DEFAULT_IMAGE
   );
 }

--- a/packages/cli/src/commands/review/lib/sandboxed-exec.ts
+++ b/packages/cli/src/commands/review/lib/sandboxed-exec.ts
@@ -742,12 +742,29 @@ let manifestImage: string | null | undefined;
  * hardcoded name made it false; it is now a description of the code rather
  * than an intention about it.
  *
+ * The parity is over the DEFAULT, not over every channel `--sandbox` reads.
+ * An operator who set `QWEN_SANDBOX_IMAGE` in a user-level `~/.qwen/.env` or
+ * in `settings.env` loses it here and falls back to that default: the loader
+ * records every key it applies from a file without distinguishing the user's
+ * own from the reviewed repository's, and this side cannot afford to guess
+ * wrong about which one it is holding. Exporting it in the shell keeps
+ * parity. Widening that would mean teaching the loader to carry the
+ * home-scoped classification it already computes — a change to the loader,
+ * not to this pick.
+ *
  * `QWEN_REVIEW_SANDBOX_IMAGE` overrides it for a repository whose toolchain
  * needs more (a JDK, a Python, a specific Node major), which is the case this
  * default cannot cover and should not pretend to.
  */
 export function reviewSandboxImage(
   env: NodeJS.ProcessEnv = process.env,
+  // Injected so a test can tell the manifest apart from the fallback. It
+  // cannot otherwise: `DEFAULT_IMAGE`'s tag comes from `CLI_VERSION`, which is
+  // generated from the same manifest version, so the two currently produce the
+  // SAME string — deleting the manifest lookup falls through to a literal that
+  // string-equals it and the suite stays green. That is the mechanism this
+  // change exists to add, pinned by nothing until the two can be told apart.
+  manifest: () => string | undefined = cliSandboxImage,
 ): string {
   // File-sourced overrides are ignored for the same reason the policy ignores
   // them, and this one is sharper: the image IS the code the reviewed
@@ -763,7 +780,7 @@ export function reviewSandboxImage(
     // `qwen --sandbox`. Through `pick`, so a repository shipping it in its
     // `.qwen/.env` cannot choose the image its own code runs in.
     pick('QWEN_SANDBOX_IMAGE') ||
-    cliSandboxImage() ||
+    manifest() ||
     DEFAULT_IMAGE
   );
 }

--- a/packages/cli/src/commands/review/lib/sandboxed-exec.ts
+++ b/packages/cli/src/commands/review/lib/sandboxed-exec.ts
@@ -58,16 +58,14 @@ import { readPackageUpSync } from 'read-package-up';
 import { CLI_VERSION } from '../../../generated/git-commit.js';
 
 /**
- * The fallback when neither override names an image: the published sandbox
- * image for this CLI line. Pinned by tag rather than digest on purpose — a
- * digest would go stale in a file nobody updates, and the override exists for
- * anyone who needs reproducibility.
- */
-/**
- * Last resort only, and versioned rather than floating: the real default is
- * the CLI's own `config.sandboxImageUri` — see `cliSandboxImage`. This literal
- * exists for the case where the package manifest cannot be found at all (an
- * unusual install layout), so the argv still names something that exists.
+ * Last resort only: the real default is the CLI's own `config.sandboxImageUri`
+ * — see `cliSandboxImage`. This literal covers the case where the package
+ * manifest cannot be found at all (an unusual install layout), so the argv
+ * still names something that exists.
+ *
+ * Versioned rather than floating on `:latest`, and by tag rather than digest —
+ * a digest would go stale in a file nobody updates, and the overrides exist
+ * for anyone who needs reproducibility.
  */
 const DEFAULT_IMAGE = `ghcr.io/qwenlm/qwen-code:${CLI_VERSION}`;
 
@@ -698,16 +696,6 @@ export function containerCommand(
 }
 
 /**
- * The image the reviewed repository's commands run in.
- *
- * Defaults to the CLI's own sandbox image, which already carries a Node
- * toolchain — the same image `qwen --sandbox` uses, so a repository that
- * builds under one builds under the other. `QWEN_REVIEW_SANDBOX_IMAGE`
- * overrides it for a repository whose toolchain needs more (a JDK, a Python,
- * a specific Node major), which is the case this default cannot cover and
- * should not pretend to.
- */
-/**
  * The image `qwen --sandbox` itself runs, read from the package manifest that
  * ships with this CLI (`config.sandboxImageUri`) — the same field
  * `sandboxConfig.ts` reads, so the two cannot drift.
@@ -744,6 +732,20 @@ function cliSandboxImage(): string | undefined {
 
 let manifestImage: string | null | undefined;
 
+/**
+ * The image the reviewed repository's commands run in.
+ *
+ * Defaults to the CLI's own sandbox image, which already carries a Node
+ * toolchain — literally the same image `qwen --sandbox` resolves, read from
+ * the same manifest field, so a repository that builds under one builds under
+ * the other. That sentence was here before `cliSandboxImage` existed, when a
+ * hardcoded name made it false; it is now a description of the code rather
+ * than an intention about it.
+ *
+ * `QWEN_REVIEW_SANDBOX_IMAGE` overrides it for a repository whose toolchain
+ * needs more (a JDK, a Python, a specific Node major), which is the case this
+ * default cannot cover and should not pretend to.
+ */
 export function reviewSandboxImage(
   env: NodeJS.ProcessEnv = process.env,
 ): string {


### PR DESCRIPTION
## What this PR does

Makes `review.sandbox` resolve its container image from the CLI's own manifest instead of a hardcoded name, and honours an operator's `QWEN_SANDBOX_IMAGE` when they have configured one. The last-resort literal is now versioned rather than floating on `:latest`.

## Why it's needed

#9723 shipped `ghcr.io/qwenlm/qwen-code/sandbox:latest` as the default, with a comment claiming it was "the same image `qwen --sandbox` uses". Neither half held. The CLI's image comes from its own manifest field `config.sandboxImageUri` — `ghcr.io/qwenlm/qwen-code:<version>` — a different repository path and a pinned tag. And the hardcoded name does not resolve at all: an anonymous manifest request answers 403 where the real one answers 200. Every command of a review that opted into `auto` or `required` therefore failed at image pull, before anything ran. The default is `off`, so nothing broke for anyone who had not opted in; for anyone who had, the feature could not work at all.

The test that let this through asserted `toContain('sandbox')` — a substring of the name rather than the property it meant to pin. The broken value contains that word and the correct one does not, so the assertion passed on the defect and would have failed on the fix.

## Reviewer Test Plan

### How to verify

Confirm the two images differ in the way that matters, with no local state involved:

```
for img in ghcr.io/qwenlm/qwen-code:0.22.0 ghcr.io/qwenlm/qwen-code/sandbox:latest; do
  repo=${img#ghcr.io/}; repo=${repo%%:*}; tag=${img##*:}
  t=$(curl -s "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" | jq -r .token)
  printf '%-45s %s\n' "$img" "$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $t" \
    -H 'Accept: application/vnd.oci.image.index.v1+json' "https://ghcr.io/v2/${repo}/manifests/${tag}")"
done
```

Expected: `0.22.0` → 200, `sandbox:latest` → 403.

Then, on a machine with a container runtime, that the contained path actually runs. Lay a fixture out the way the pipeline does — `<repo>/.qwen/tmp/review-pr-1/` with a `package.json` — **under a path your runtime shares** (`$HOME` is safe; see the risk note below), set `QWEN_REVIEW_SANDBOX=required`, and drive `containerCommand` through the real runtime. Unit tests, from the repository root: `npm run test --workspace=packages/cli -- src/commands/review/lib/sandboxed-exec.test.ts`.

### Evidence (Before & After)

Five live arms, same fixture and same runtime, differing only in the image the code resolves:

| Arm | Merged default | This PR |
| --- | --- | --- |
| Image resolves | ✗ pull denied | ✓ |
| Phase gate admits, workload runs in the image | ✗ | ✓ prints `IN-CONTAINER` |
| Env is the allowlist, not the host's | ✗ | ✓ host canary absent, `CI=1` present |
| `--network none` for test, network for install | ✗ | ✓ `DNS-FAIL` / `DNS-OK` |
| Writes land in the mount, host-owned | ✗ | ✓ file uid = invoking uid |
| No container survives the run | ✗ | ✓ |

With the merged default every arm fails before anything runs, because no container starts.

Mutation evidence: reverting to the hardcoded default reddens two unit tests; dropping `QWEN_SANDBOX_IMAGE` support reddens one.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Docker Desktop, macOS arm64, image `ghcr.io/qwenlm/qwen-code:0.22.0` (226 MB, linux/arm64). Unit tests under vitest, no runtime required.

## Risk & Scope

- **Main risk or tradeoff:** the resolved image now tracks the release version, so a review runs whatever `config.sandboxImageUri` names at that version rather than a fixed name an operator may have pre-pulled. That is the intended coupling — it is the image the CLI already ships with — but it does mean the first opted-in review on a cold machine pays a pull.
- **Not validated / out of scope:** Windows and Linux runtimes were not exercised locally; the manifest lookup is plain file reading and platform-independent, but the live container arms were run on macOS only. Separately, on macOS Docker Desktop a bind mount whose host path is **not in the runtime's shared-paths list** silently gives the container an empty in-VM directory instead of the host tree — the reviewed commands then run against an empty tree and fail confusingly, with no signal that the mount did not take. A repository under `$HOME` (the normal case) is unaffected, and Linux is unaffected. Not fixed here; recorded because it cost real time to diagnose.
- **Breaking changes / migration notes:** none. `review.sandbox` defaults to `off`; an operator who had set `QWEN_REVIEW_SANDBOX_IMAGE` keeps that value at the same precedence.

## Linked Issues

Fixes a defect introduced by #9723. Related: #9556.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `review.sandbox` 从 CLI 自己的 manifest 解析容器镜像，而不是用一个硬编码的名字；并在操作者配置过 `QWEN_SANDBOX_IMAGE` 时尊重它。兜底字面量也从浮动的 `:latest` 改成带版本号的形式。

## 为什么需要

#9723 交付的默认值是 `ghcr.io/qwenlm/qwen-code/sandbox:latest`，旁边的注释写着它是「`qwen --sandbox` 用的同一个镜像」。两半都不成立。CLI 的镜像来自它自己的 manifest 字段 `config.sandboxImageUri` —— `ghcr.io/qwenlm/qwen-code:<version>` —— 不同的仓库路径、版本固定的 tag。而那个硬编码的名字**根本无法解析**：匿名 manifest 请求返回 403，真实镜像返回 200。因此任何开启了 `auto` 或 `required` 的审查，每条命令都会在拉镜像时失败，在任何东西运行之前。默认值是 `off`，所以没有开启的人不受影响；但对开启的人来说，这个功能完全无法工作。

放过这个缺陷的那条测试断言的是 `toContain('sandbox')` —— 检查名字的**子串**，而不是它本想钉住的**性质**。坏的值含有这个词，正确的值反而不含，所以这条断言在缺陷上通过、会在修复上失败。

## 评审者验证方案

### 如何验证

先确认两个镜像的关键差异，不涉及任何本地状态：

```
for img in ghcr.io/qwenlm/qwen-code:0.22.0 ghcr.io/qwenlm/qwen-code/sandbox:latest; do
  repo=${img#ghcr.io/}; repo=${repo%%:*}; tag=${img##*:}
  t=$(curl -s "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" | jq -r .token)
  printf '%-45s %s\n' "$img" "$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $t" \
    -H 'Accept: application/vnd.oci.image.index.v1+json' "https://ghcr.io/v2/${repo}/manifests/${tag}")"
done
```

预期：`0.22.0` → 200，`sandbox:latest` → 403。

然后在有容器运行时的机器上验证容器化路径确实能跑。按流水线的布局造夹具 —— `<repo>/.qwen/tmp/review-pr-1/` 内含 `package.json` —— **放在运行时共享的路径下**（`$HOME` 是安全的，原因见下方风险说明），设置 `QWEN_REVIEW_SANDBOX=required`，用真实运行时驱动 `containerCommand`。单元测试，在仓库根目录执行：`npm run test --workspace=packages/cli -- src/commands/review/lib/sandboxed-exec.test.ts`。

### 证据（前后对比）

五条活体验证，同一夹具、同一运行时，唯一差别是代码解析出的镜像：

| 验证项 | 已合入的默认值 | 本 PR |
| --- | --- | --- |
| 镜像可解析 | ✗ 拉取被拒 | ✓ |
| 阶段门放行、工作负载在镜像内运行 | ✗ | ✓ 打印 `IN-CONTAINER` |
| env 是白名单而非宿主环境 | ✗ | ✓ 宿主哨兵不出现、`CI=1` 在 |
| test 用 `--network none`、install 保留网络 | ✗ | ✓ `DNS-FAIL` / `DNS-OK` |
| 写入落在挂载内且属主为宿主用户 | ✗ | ✓ 文件 uid = 调用者 uid |
| 运行结束无残留容器 | ✗ | ✓ |

用已合入的默认值，五臂在任何东西开始运行之前就全部失败，因为容器根本起不来。

变异证据：退回硬编码默认值会让两条单元测试变红；去掉对 `QWEN_SANDBOX_IMAGE` 的支持会让一条变红。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

Docker Desktop、macOS arm64、镜像 `ghcr.io/qwenlm/qwen-code:0.22.0`（226 MB，linux/arm64）。单元测试在 vitest 下运行，不需要容器运行时。

## 风险与范围

- **主要风险或权衡：** 解析出的镜像现在跟随发布版本，因此一次审查运行的是该版本下 `config.sandboxImageUri` 所指的镜像，而不是操作者可能已预先拉取的某个固定名字。这正是有意建立的耦合 —— 它就是 CLI 本身附带的镜像 —— 但代价是冷机器上第一次开启审查要付一次拉取。
- **未验证 / 不在范围内：** Windows 与 Linux 运行时未在本地实测；manifest 查找只是普通文件读取、与平台无关，但活体容器验证仅在 macOS 上跑过。另外，在 macOS Docker Desktop 上，如果绑定挂载的宿主路径**不在该运行时的共享路径清单里**，挂载会静默地给容器一个 VM 内的空目录而不是宿主的树 —— 被审命令于是对着一棵空树运行并以令人困惑的方式失败，没有任何信号表明挂载没有生效。仓库位于 `$HOME` 下（常规情形）不受影响，Linux 不受影响。本 PR 不修，记录在此是因为它确实耗费了排查时间。
- **破坏性变更 / 迁移说明：** 无。`review.sandbox` 默认 `off`；已设置 `QWEN_REVIEW_SANDBOX_IMAGE` 的操作者，该值的优先级不变。

## 关联 Issue

修复 #9723 引入的一个缺陷。相关：#9556。

</details>
