### PR TITLE
feat(goal): make get_goal's default view a summary instead of the whole catalog

### DIFF
--- a/packages/core/src/goals/goal-evidence.ts
+++ b/packages/core/src/goals/goal-evidence.ts
@@ -272,7 +272,7 @@ export class GoalEvidenceRecordIndexAccumulator {
         this.lastPartPreviewValues,
       ).trim();
     }
-    preview = capPreviewBytes(preview);
+    preview = capPreviewBytes(preview, CATALOG_PREVIEW_BYTE_LIMIT);
     const catalogEntry =
       this.provenance && this.parsedGoalContext && preview
         ? {
@@ -959,7 +959,10 @@ function checkpointCatalogEntries(
     uuid: claim.id,
     provenance: 'goal_checkpoint',
     turnId: `checkpoint:${checkpoint.checkpointId}`,
-    preview: capPreviewBytes(claim.claim.slice(0, CATALOG_PREVIEW_LIMIT)),
+    preview: capPreviewBytes(
+      claim.claim.slice(0, CATALOG_PREVIEW_LIMIT),
+      CATALOG_PREVIEW_BYTE_LIMIT,
+    ),
     proofKind: claim.proofKind,
   }));
 }
@@ -1067,18 +1070,17 @@ function legacySafeProvenance(
 }
 
 /**
- * Cut `value` to at most {@link CATALOG_PREVIEW_BYTE_LIMIT} UTF-8 bytes
- * without splitting a code point.
+ * Cut `value` to at most `limit` UTF-8 bytes without splitting a code point.
  */
-function capPreviewBytes(value: string): string {
-  if (Buffer.byteLength(value, 'utf8') <= CATALOG_PREVIEW_BYTE_LIMIT) {
+export function capPreviewBytes(value: string, limit: number): string {
+  if (Buffer.byteLength(value, 'utf8') <= limit) {
     return value;
   }
   let byteLength = 0;
   let cutoff = 0;
   for (const codePoint of value) {
     const codePointBytes = Buffer.byteLength(codePoint, 'utf8');
-    if (byteLength + codePointBytes > CATALOG_PREVIEW_BYTE_LIMIT) break;
+    if (byteLength + codePointBytes > limit) break;
     byteLength += codePointBytes;
     cutoff += codePoint.length;
   }
@@ -1139,6 +1141,7 @@ function evidencePreview(
   if (projection?.displayText !== undefined) {
     return capPreviewBytes(
       projection.displayText.slice(0, CATALOG_PREVIEW_LIMIT).trim(),
+      CATALOG_PREVIEW_BYTE_LIMIT,
     );
   }
   let preview = '';
@@ -1159,7 +1162,7 @@ function evidencePreview(
     }
     if (preview.length >= CATALOG_PREVIEW_LIMIT) break;
   }
-  return capPreviewBytes(preview.trim());
+  return capPreviewBytes(preview.trim(), CATALOG_PREVIEW_BYTE_LIMIT);
 }
 
 function renderToolResponse(functionResponse: {

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -15,6 +15,7 @@ import {
   type GoalTurnHost,
 } from './goal-runtime.js';
 import {
+  type GetGoalToolParams,
   GetGoalTool,
   UpdateGoalTool,
   type GoalToolConfig,
@@ -350,6 +351,7 @@ describe('GetGoalTool', () => {
     expect(getSnapshotForPermit).toHaveBeenCalledWith(permit);
     expect(JSON.parse(String(result.llmContent))).toEqual({
       active: true,
+      view: 'summary',
       snapshot,
       evidenceCatalog: {
         entries: [
@@ -367,6 +369,169 @@ describe('GetGoalTool', () => {
     });
     expect(String(result.llmContent)).not.toContain('must not leak');
     expect(result.returnDisplay).toBe('Active goal · revision 3');
+  });
+
+  it('exposes the view parameter and nothing else', () => {
+    const tool = new GetGoalTool(makeConfig({ getGoalForWorker: vi.fn() }));
+    expect(tool.schema.parametersJsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        view: {
+          type: 'string',
+          enum: ['summary', 'full'],
+          description: expect.stringContaining('summary (default)'),
+        },
+      },
+      additionalProperties: false,
+    });
+  });
+
+  // A long-running Goal after a few checkpoints: 32 claims of the maximum
+  // length, a catalog at its entry cap, and a lineage at its cap.
+  const LONG_CLAIM = 'C'.repeat(2_000);
+  const LONG_PREVIEW_ASCII = 'p'.repeat(240);
+  const LONG_PREVIEW_CJK = '证'.repeat(80); // 240 bytes
+  const checkpointedGoal = () => ({
+    goalId: 'goal-1',
+    revision: 3,
+    objective: 'Ship Goal v3',
+    status: 'active' as const,
+    evidenceCursor: { recordId: 'checkpoint-9' },
+    turnCount: 40,
+    activeTimeMs: 120,
+    tokensUsed: 0,
+    createdAt: 10,
+    updatedAt: 20,
+    evidenceCheckpoint: {
+      checkpointId: 'checkpoint-9',
+      createdAt: 15,
+      claims: Array.from({ length: 32 }, (_, index) => ({
+        id: `checkpoint-9:${index + 1}`,
+        proofKind: 'external_fact' as const,
+        claim: `SECRET_CLAIM_TEXT ${LONG_CLAIM}`,
+        sourceRefs: Array.from(
+          { length: 4 },
+          (_, ref) => `src-${index}-${ref}`,
+        ),
+      })),
+    },
+  });
+  const checkpointedCatalog = () => ({
+    entries: [
+      ...Array.from({ length: 32 }, (_, index) => ({
+        uuid: `checkpoint-9:${index + 1}`,
+        provenance: 'goal_checkpoint' as const,
+        turnId: 'checkpoint:checkpoint-9',
+        preview: `claim ${index + 1} ${LONG_PREVIEW_ASCII}`.slice(0, 240),
+        proofKind: 'external_fact' as const,
+      })),
+      ...Array.from({ length: 60 }, (_, index) => ({
+        uuid: `earlier-${index}`,
+        provenance: 'tool_result' as const,
+        turnId: `earlier-turn-${index % 12}`,
+        preview: index % 2 === 0 ? LONG_PREVIEW_ASCII : LONG_PREVIEW_CJK,
+        proofKind: 'external_fact' as const,
+      })),
+      ...Array.from({ length: 8 }, (_, index) => ({
+        uuid: `current-${index}`,
+        provenance: 'assistant_output' as const,
+        turnId: permit.turnId,
+        preview: LONG_PREVIEW_ASCII,
+        proofKind: 'delivered_output' as const,
+      })),
+    ],
+    lineageTurnIds: [
+      ...Array.from({ length: 15 }, (_, index) => `earlier-turn-${index}`),
+      permit.turnId,
+    ],
+    truncated: false,
+  });
+  const checkpointedTool = () =>
+    new GetGoalTool(
+      makeConfig({
+        getGoalForWorker: vi.fn().mockResolvedValue({
+          goalId: 'goal-1',
+          revision: 3,
+          objective: 'Ship Goal v3',
+          evidenceCursor: { recordId: 'checkpoint-9' },
+          evidenceCatalog: checkpointedCatalog(),
+        }),
+        getSnapshotForPermit: vi.fn(() => ({
+          v: 2 as const,
+          activity: 'running' as const,
+          goal: checkpointedGoal(),
+        })),
+      }),
+    );
+  const read = async (params: GetGoalToolParams) => {
+    const invocation = goalTurnContext.run(permit, () =>
+      checkpointedTool().build(params),
+    );
+    const result = await invocation.execute(new AbortController().signal);
+    return String(result.llmContent);
+  };
+
+  it('collapses checkpoint claims and shortens earlier previews in the summary view', async () => {
+    const content = await read({});
+    const payload = JSON.parse(content);
+
+    // The claims' text is the duplicate: each claim is already a catalog entry.
+    expect(content).not.toContain('SECRET_CLAIM_TEXT');
+    expect(payload.snapshot.goal.evidenceCheckpoint).toEqual({
+      checkpointId: 'checkpoint-9',
+      createdAt: 15,
+      claimCount: 32,
+    });
+    expect(payload.view).toBe('summary');
+
+    const entries: Array<{
+      uuid: string;
+      turnId: string;
+      provenance: string;
+      preview: string;
+    }> = payload.evidenceCatalog.entries;
+    // Every uuid survives: the summary changes what is shown, not what is
+    // citable.
+    expect(entries.map((entry) => entry.uuid)).toEqual(
+      checkpointedCatalog().entries.map((entry) => entry.uuid),
+    );
+    for (const entry of entries) {
+      const bytes = Buffer.byteLength(entry.preview, 'utf8');
+      if (
+        entry.provenance === 'goal_checkpoint' ||
+        entry.turnId === permit.turnId
+      ) {
+        expect(bytes).toBe(240);
+      } else {
+        expect(bytes).toBeLessThanOrEqual(80);
+      }
+    }
+    // Multi-byte previews are cut on a code point, not mid-character.
+    expect(entries.find((entry) => entry.uuid === 'earlier-1')?.preview).toBe(
+      '证'.repeat(26),
+    );
+    expect(payload.evidenceCatalog.shortenedPreviews).toBe(60);
+    expect(payload.evidenceCatalog.lineageTurnIds).toHaveLength(16);
+  });
+
+  it('returns the whole checkpoint and catalog in the full view', async () => {
+    const payload = JSON.parse(await read({ view: 'full' }));
+
+    expect(payload.view).toBe('full');
+    expect(payload.snapshot.goal).toEqual(checkpointedGoal());
+    expect(payload.evidenceCatalog).toEqual(checkpointedCatalog());
+    expect(payload.evidenceCatalog).not.toHaveProperty('shortenedPreviews');
+  });
+
+  it('keeps a steady-state summary read under a fixed byte ceiling', async () => {
+    const summaryBytes = Buffer.byteLength(await read({}), 'utf8');
+    const fullBytes = Buffer.byteLength(await read({ view: 'full' }), 'utf8');
+
+    // The full read of this fixture is what a long Goal paid on every
+    // get_goal before: the 2,000-character claims alone are ~64 KB.
+    expect(fullBytes).toBeGreaterThan(100_000);
+    expect(summaryBytes).toBeLessThanOrEqual(36_000);
+    expect(fullBytes / summaryBytes).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -432,6 +432,13 @@ describe('GetGoalTool', () => {
         preview: index % 2 === 0 ? LONG_PREVIEW_ASCII : LONG_PREVIEW_CJK,
         proofKind: 'external_fact' as const,
       })),
+      {
+        uuid: 'earlier-short',
+        provenance: 'tool_result' as const,
+        turnId: 'earlier-turn-0',
+        preview: '12 tests passed',
+        proofKind: 'external_fact' as const,
+      },
       ...Array.from({ length: 8 }, (_, index) => ({
         uuid: `current-${index}`,
         provenance: 'assistant_output' as const,
@@ -510,6 +517,11 @@ describe('GetGoalTool', () => {
     expect(entries.find((entry) => entry.uuid === 'earlier-1')?.preview).toBe(
       '证'.repeat(26),
     );
+    // An earlier-turn preview already within the cap passes through
+    // byte-identical and is not counted as shortened.
+    expect(
+      entries.find((entry) => entry.uuid === 'earlier-short')?.preview,
+    ).toBe('12 tests passed');
     expect(payload.evidenceCatalog.shortenedPreviews).toBe(60);
     expect(payload.evidenceCatalog.lineageTurnIds).toHaveLength(16);
   });

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -32,7 +32,24 @@ export interface GoalToolConfig {
   getGoalRuntime(): GoalRuntime;
 }
 
-export type GetGoalToolParams = Record<string, never>;
+export interface GetGoalToolParams {
+  /**
+   * `summary` (default) keeps the payload small on every read: checkpoint
+   * claims collapse to a count (their previews are already catalog entries),
+   * and entries from earlier turns carry previews capped at
+   * SUMMARY_PREVIEW_BYTE_LIMIT. `full` returns the whole catalog and the
+   * checkpoint verbatim. Entry uuids are identical in both views.
+   */
+  view?: 'summary' | 'full';
+}
+
+/**
+ * Preview bytes an earlier-turn entry keeps in the summary view. Enough to
+ * recognise what a record is ("12 tests passed", "wrote src/x.ts") without
+ * re-sending the 240-byte preview on every read of a Goal that has been
+ * running for a while -- one call used to cost the whole bounded catalog.
+ */
+const SUMMARY_PREVIEW_BYTE_LIMIT = 80;
 
 export interface UpdateGoalToolParams {
   status: 'complete' | 'blocked';
@@ -96,7 +113,12 @@ class GetGoalInvocation extends BaseToolInvocation<
     ) {
       throw staleGoalTurnError();
     }
-    const payload = projectWorkerView(view, snapshot);
+    const payload = projectWorkerView(
+      view,
+      snapshot,
+      this.permit,
+      this.params.view ?? 'summary',
+    );
     return {
       llmContent: JSON.stringify(payload),
       returnDisplay: `Active goal · revision ${view.revision}`,
@@ -114,11 +136,18 @@ export class GetGoalTool extends BaseDeclarativeTool<
     super(
       GetGoalTool.Name,
       ToolDisplayNames.GET_GOAL,
-      'Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. Outside a permitted Goal turn it reports "active": false together with "lastGoal", a scalar summary (goalId, revision, status, turnCount, activeTimeMs, tokensUsed, and lastReason when one was recorded) of the session\'s most recent Goal, so a Goal that has already stopped can still be inspected. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.',
+      'Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. The default "summary" view keeps every read small: checkpoint claims are reported as a count (each claim is already an evidenceCatalog entry with its own preview), entries from this turn and checkpoint entries keep full previews, and entries from earlier turns carry previews shortened to 80 bytes. Every entry uuid is present in both views and is valid for update_goal; request view "full" only when a shortened preview is not enough to decide what to cite. Outside a permitted Goal turn it reports "active": false together with "lastGoal", a scalar summary (goalId, revision, status, turnCount, activeTimeMs, tokensUsed, and lastReason when one was recorded) of the session\'s most recent Goal, so a Goal that has already stopped can still be inspected. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.',
       Kind.Read,
       {
         type: 'object',
-        properties: {},
+        properties: {
+          view: {
+            type: 'string',
+            enum: ['summary', 'full'],
+            description:
+              'summary (default): checkpoint claims as a count, full previews only for this turn and checkpoint entries, 80-byte previews for earlier turns. full: the whole catalog and checkpoint verbatim. Uuids are identical in both.',
+          },
+        },
         additionalProperties: false,
       },
     );
@@ -461,15 +490,85 @@ function staleGoalTurnError(): Error {
   return new Error(STALE_GOAL_TURN_MESSAGE);
 }
 
-function projectWorkerView(view: GoalWorkerView, snapshot: GoalSnapshotV2) {
+function projectWorkerView(
+  view: GoalWorkerView,
+  snapshot: GoalSnapshotV2,
+  permit: GoalTurnPermit,
+  detail: NonNullable<GetGoalToolParams['view']>,
+) {
+  const full = detail === 'full';
   return {
     active: true,
-    snapshot: structuredClone(snapshot),
+    view: detail,
+    snapshot: full ? structuredClone(snapshot) : summarizeSnapshot(snapshot),
     ...(view.evidenceCatalog
-      ? { evidenceCatalog: structuredClone(view.evidenceCatalog) }
+      ? {
+          evidenceCatalog: full
+            ? structuredClone(view.evidenceCatalog)
+            : summarizeCatalog(view.evidenceCatalog, permit),
+        }
       : {}),
     ...(view.verifierFeedback
       ? { verifierFeedback: view.verifierFeedback }
       : {}),
   };
+}
+
+/**
+ * The checkpoint's claims are the largest thing a Goal record carries -- up to
+ * 32 claims of up to 2,000 characters -- and every one of them is already in
+ * the catalog as a `goal_checkpoint` entry with a preview and the same uuid.
+ * The summary keeps the checkpoint's identity and drops the duplicate text.
+ */
+function summarizeSnapshot(snapshot: GoalSnapshotV2) {
+  const clone = structuredClone(snapshot);
+  if (!clone.goal?.evidenceCheckpoint) return clone;
+  const { claims, ...checkpoint } = clone.goal.evidenceCheckpoint;
+  return {
+    ...clone,
+    goal: {
+      ...clone.goal,
+      evidenceCheckpoint: { ...checkpoint, claimCount: claims.length },
+    },
+  };
+}
+
+function summarizeCatalog(
+  catalog: NonNullable<GoalWorkerView['evidenceCatalog']>,
+  permit: GoalTurnPermit,
+) {
+  let shortenedPreviews = 0;
+  const entries = catalog.entries.map((entry) => {
+    // Checkpoint claims are the compacted proof of everything before the
+    // window, and this turn's entries are the ones a proposal cites next; both
+    // keep their full preview. Earlier turns only need to be recognisable.
+    if (
+      entry.provenance === 'goal_checkpoint' ||
+      entry.turnId === permit.turnId
+    ) {
+      return { ...entry };
+    }
+    const preview = capPreviewBytes(entry.preview, SUMMARY_PREVIEW_BYTE_LIMIT);
+    if (preview !== entry.preview) shortenedPreviews += 1;
+    return { ...entry, preview };
+  });
+  return {
+    ...structuredClone(catalog),
+    entries,
+    ...(shortenedPreviews > 0 ? { shortenedPreviews } : {}),
+  };
+}
+
+/** Cut `value` to at most `limit` UTF-8 bytes without splitting a code point. */
+function capPreviewBytes(value: string, limit: number): string {
+  if (Buffer.byteLength(value, 'utf8') <= limit) return value;
+  let byteLength = 0;
+  let cutoff = 0;
+  for (const codePoint of value) {
+    const codePointBytes = Buffer.byteLength(codePoint, 'utf8');
+    if (byteLength + codePointBytes > limit) break;
+    byteLength += codePointBytes;
+    cutoff += codePoint.length;
+  }
+  return value.slice(0, cutoff);
 }

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -6,7 +6,10 @@
 
 import { ToolDisplayNames, ToolNames } from '../tools/tool-names.js';
 import type { ToolInvocation, ToolResult } from '../tools/tools.js';
-import { GOAL_EVIDENCE_REFERENCE_LIMIT } from './goal-evidence.js';
+import {
+  capPreviewBytes,
+  GOAL_EVIDENCE_REFERENCE_LIMIT,
+} from './goal-evidence.js';
 import {
   BaseDeclarativeTool,
   BaseToolInvocation,
@@ -136,7 +139,7 @@ export class GetGoalTool extends BaseDeclarativeTool<
     super(
       GetGoalTool.Name,
       ToolDisplayNames.GET_GOAL,
-      'Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. The default "summary" view keeps every read small: checkpoint claims are reported as a count (each claim is already an evidenceCatalog entry with its own preview), entries from this turn and checkpoint entries keep full previews, and entries from earlier turns carry previews shortened to 80 bytes. Every entry uuid is present in both views and is valid for update_goal; request view "full" only when a shortened preview is not enough to decide what to cite. Outside a permitted Goal turn it reports "active": false together with "lastGoal", a scalar summary (goalId, revision, status, turnCount, activeTimeMs, tokensUsed, and lastReason when one was recorded) of the session\'s most recent Goal, so a Goal that has already stopped can still be inspected. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.',
+      `Read the current Goal identity, objective, evidence cursor, and bounded evidence-reference catalog for this permitted Goal turn. The default "summary" view keeps every read small: checkpoint claims are reported as a count (each claim is already an evidenceCatalog entry with its own preview), entries from this turn and checkpoint entries keep full previews, and entries from earlier turns carry previews shortened to ${SUMMARY_PREVIEW_BYTE_LIMIT} bytes. Every entry uuid is present in both views and is valid for update_goal; request view "full" only when a shortened preview is not enough to decide what to cite. Outside a permitted Goal turn it reports "active": false together with "lastGoal", a scalar summary (goalId, revision, status, turnCount, activeTimeMs, tokensUsed, and lastReason when one was recorded) of the session's most recent Goal, so a Goal that has already stopped can still be inspected. It never returns uncited transcript history or changes Goal state. Use the result silently; do not narrate or acknowledge the retrieval to the user.`,
       Kind.Read,
       {
         type: 'object',
@@ -144,8 +147,7 @@ export class GetGoalTool extends BaseDeclarativeTool<
           view: {
             type: 'string',
             enum: ['summary', 'full'],
-            description:
-              'summary (default): checkpoint claims as a count, full previews only for this turn and checkpoint entries, 80-byte previews for earlier turns. full: the whole catalog and checkpoint verbatim. Uuids are identical in both.',
+            description: `summary (default): checkpoint claims as a count, full previews only for this turn and checkpoint entries, ${SUMMARY_PREVIEW_BYTE_LIMIT}-byte previews for earlier turns. full: the whole catalog and checkpoint verbatim. Uuids are identical in both.`,
           },
         },
         additionalProperties: false,
@@ -521,16 +523,19 @@ function projectWorkerView(
  * The summary keeps the checkpoint's identity and drops the duplicate text.
  */
 function summarizeSnapshot(snapshot: GoalSnapshotV2) {
-  const clone = structuredClone(snapshot);
-  if (!clone.goal?.evidenceCheckpoint) return clone;
-  const { claims, ...checkpoint } = clone.goal.evidenceCheckpoint;
-  return {
-    ...clone,
+  const goal = snapshot.goal;
+  const checkpoint = goal?.evidenceCheckpoint;
+  if (!goal || !checkpoint) return structuredClone(snapshot);
+  // Collapse the claims to their count before cloning, not after: the claims
+  // are the bulk of a checkpoint and none of them survives the summary.
+  const { claims, ...checkpointRest } = checkpoint;
+  return structuredClone({
+    ...snapshot,
     goal: {
-      ...clone.goal,
-      evidenceCheckpoint: { ...checkpoint, claimCount: claims.length },
+      ...goal,
+      evidenceCheckpoint: { ...checkpointRest, claimCount: claims.length },
     },
-  };
+  });
 }
 
 function summarizeCatalog(
@@ -552,23 +557,12 @@ function summarizeCatalog(
     if (preview !== entry.preview) shortenedPreviews += 1;
     return { ...entry, preview };
   });
+  // Clone only what survives the summary; the entries above are rebuilt from
+  // the originals, so cloning them first would allocate and drop the copy.
+  const { entries: _entries, ...catalogRest } = catalog;
   return {
-    ...structuredClone(catalog),
+    ...structuredClone(catalogRest),
     entries,
     ...(shortenedPreviews > 0 ? { shortenedPreviews } : {}),
   };
-}
-
-/** Cut `value` to at most `limit` UTF-8 bytes without splitting a code point. */
-function capPreviewBytes(value: string, limit: number): string {
-  if (Buffer.byteLength(value, 'utf8') <= limit) return value;
-  let byteLength = 0;
-  let cutoff = 0;
-  for (const codePoint of value) {
-    const codePointBytes = Buffer.byteLength(codePoint, 'utf8');
-    if (byteLength + codePointBytes > limit) break;
-    byteLength += codePointBytes;
-    cutoff += codePoint.length;
-  }
-  return value.slice(0, cutoff);
 }


### PR DESCRIPTION
## What this PR does

Gives `get_goal` a `view` parameter — `'summary'` (default) or `'full'` — and makes the default read a summary instead of the whole evidence catalog. The summary collapses the Goal snapshot's checkpoint claims to a count (every claim is already a `goal_checkpoint` catalog entry with the same uuid and its own preview), keeps full 240-byte previews for checkpoint entries and for this turn's entries — the compacted proof of everything earlier and the records a proposal cites next — and shortens previews from earlier turns to 80 bytes, cut on a code point so multi-byte text is never split. The payload names its view and reports how many previews were shortened. `view: 'full'` returns the payload exactly as before. The tool description tells the model when to ask for the full view.

Every entry uuid is present in both views and remains valid for `update_goal`: that tool validates `evidenceRefs` against a fresh runtime catalog, never against what the model was shown, which is what makes a slim read safe. Nothing about what the catalog stores changes — only what a read returns.

## Why it's needed

Every `get_goal` read returned up to 100 catalog entries with 240-byte previews plus the Goal snapshot, which carries the evidence checkpoint verbatim — up to 32 claims of up to 2,000 characters each, all duplicated as catalog previews. A Goal that had been running for a while paid all of that on every read. In the 27-round session analyzed for this series the prompt grew from 44k to 277k tokens, dominated by these reads; in the second session the model called `get_goal` 32 times in 34 minutes (8.6M tokens in total). On a steady-state fixture — 32 maximal claims, a catalog at its 100-entry cap, a 16-turn lineage — one read drops from **105,317 bytes to 27,225 bytes** (3.87×). The catalog is the right design; re-sending all of it on every read was the cost problem.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/goals/` — 400 tests, 16 files. New in `goal-tools.test.ts`: the `view` schema pin; `collapses checkpoint claims and shortens earlier previews in the summary view` (claim text absent, checkpoint collapsed to `{checkpointId, createdAt, claimCount}`, uuid list identical to the full catalog, 240-byte previews kept only for checkpoint and current-turn entries, a 240-byte CJK preview cut to exactly 26 characters / 78 bytes, `shortenedPreviews: 60`); `returns the whole checkpoint and catalog in the full view` (byte-for-byte today's payload); `keeps a steady-state summary read under a fixed byte ceiling` (full > 100,000 bytes, summary ≤ 36,000, ratio ≥ 3).
- Mutation probes run during development, each restored afterwards: defaulting to `full` fails 3 tests; removing the current-turn exemption fails the summary test; removing the checkpoint exemption fails the summary test; breaking the `full` switch fails 2 tests; leaving the claims uncollapsed fails 2 tests. Restored suite 39/39 in the file.
- `npx tsc --noEmit` in `packages/core`: 0 errors. prettier and eslint clean on both changed files.
- The existing worker-view test (`returns only the bounded worker view for the captured permit`) changes only by the new `view: 'summary'` key — its single entry is current-turn, so its preview is untouched.

### Evidence (Before & After)

N/A (tool payload only; no UI). Payload size on the steady-state fixture: before 105,317 bytes, after 27,225 bytes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

N/A (unit tests only).

## Risk & Scope

- Main risk or tradeoff: a model deciding what to cite from an 80-byte preview of an earlier-turn record may need a second read with `view: 'full'`; that is one extra call in the rare case, versus the full catalog on every call today. The 80-byte cap and the two exemptions are the whole policy and live in one function.
- Not validated / out of scope: no change to continuation prompts (they already say "use get_goal for the authoritative objective and evidence state" and stay correct); no change to the catalog budgets themselves; `packages/cli` tests that quote the continuation prompt were not re-run (they do not read this payload). Overlaps textually with #9880 (auto-cite) and #9891 (`tokenBudget` in the unpermitted summary) in `goal-tools.ts`; both edits are in different functions, so the merge is mechanical.
- Breaking changes / migration notes: none for callers — `get_goal` with no arguments still succeeds; the payload gains a `view` key and, in summary, `evidenceCatalog.shortenedPreviews` and a collapsed `snapshot.goal.evidenceCheckpoint`.

## Linked Issues

Series context: #9834 (B2, merged prompt convergence), #9835 (C2, catalog byte budget), #9880 (G1, current-turn auto-cite).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 `get_goal` 增加 `view` 参数——`'summary'`(默认)或 `'full'`——并让默认读取返回摘要而不是整本证据目录。摘要把 Goal 快照里的 checkpoint claims 折叠为数量(每条 claim 本来就是一条 `goal_checkpoint` 目录条目,uuid 相同、自带 preview),对 checkpoint 条目和本轮条目保留完整的 240 字节 preview——它们分别是此前一切的压缩证明和提案接下来要引用的记录——对更早轮次的条目把 preview 缩短到 80 字节,并按码点切割,绝不拆开多字节字符。载荷标明自己的视图并报告缩短了多少条 preview。`view: 'full'` 原样返回此前的载荷。工具描述告诉模型何时该请求完整视图。

两种视图中每个条目的 uuid 都存在,且对 `update_goal` 仍然有效:该工具是对 runtime 新取的目录校验 `evidenceRefs`,而不是对模型看到的内容校验——这正是精简读取安全的原因。目录存储的内容完全不变——只改变一次读取返回什么。

## 为什么需要

每次 `get_goal` 读取都会返回多达 100 条带 240 字节 preview 的目录条目,外加 Goal 快照——它原样携带证据 checkpoint:最多 32 条、每条最长 2,000 字符的 claim,而这些全部已在目录里以 preview 形式重复。运行了一段时间的 Goal 每次读取都要付这全部代价。本系列分析的 27 轮 session 里 prompt 从 44k 涨到 277k token,主要就是这些读取;第二个 session 里模型 34 分钟内调用了 32 次 `get_goal`(总计 860 万 token)。在一个稳态 fixture 上——32 条最长 claim、100 条满载目录、16 轮 lineage——一次读取从 **105,317 字节降到 27,225 字节**(3.87 倍)。目录本身的设计是对的;每次读取都重发全部内容才是成本问题。

## 评审验证计划

### 如何验证

- `cd packages/core && npx vitest run src/goals/`——400 个测试,16 个文件。`goal-tools.test.ts` 新增:`view` schema 固定;`collapses checkpoint claims and shortens earlier previews in the summary view`(claim 文本不出现、checkpoint 折叠为 `{checkpointId, createdAt, claimCount}`、uuid 列表与完整目录一致、只有 checkpoint 与本轮条目保留 240 字节 preview、一条 240 字节的中文 preview 被精确切到 26 个字符 / 78 字节、`shortenedPreviews: 60`);`returns the whole checkpoint and catalog in the full view`(与此前载荷逐字节一致);`keeps a steady-state summary read under a fixed byte ceiling`(完整 > 100,000 字节,摘要 ≤ 36,000,比值 ≥ 3)。
- 开发期间的变异检验,每次都已还原:默认改为 `full` 挂 3 个测试;去掉本轮豁免挂摘要测试;去掉 checkpoint 豁免挂摘要测试;破坏 `full` 开关挂 2 个;不折叠 claims 挂 2 个。还原后该文件 39/39。
- `packages/core` 的 `npx tsc --noEmit`:0 错误。两个改动文件 prettier 与 eslint 干净。
- 既有的 worker-view 测试(`returns only the bounded worker view for the captured permit`)只多了新的 `view: 'summary'` 键——它唯一的条目属于本轮,preview 不变。

### 证据(前后对比)

N/A(仅工具载荷,无 UI)。稳态 fixture 上的载荷大小:改前 105,317 字节,改后 27,225 字节。

### 已测试平台

Linux ✅;macOS / Windows ⚠️(由 CI 覆盖)。

## 风险与范围

- 主要风险或权衡:模型凭更早轮次记录的 80 字节 preview 决定引用什么时,可能需要用 `view: 'full'` 再读一次;那是罕见情况下多一次调用,而今天是每次调用都发整本目录。80 字节上限和两项豁免就是全部策略,集中在一个函数里。
- 未验证/范围外:不改续跑提示词(它们已写明「用 get_goal 获取权威的 objective 与证据状态」,仍然正确);不改目录预算本身;`packages/cli` 中引用续跑提示词的测试未重跑(它们不读取该载荷)。与 #9880(自动引用)和 #9891(未许可摘要里的 `tokenBudget`)在 `goal-tools.ts` 上有文本重叠;改动位于不同函数,合并是机械性的。
- 破坏性变更/迁移说明:对调用方无——不带参数的 `get_goal` 仍然成功;载荷新增 `view` 键,摘要视图下新增 `evidenceCatalog.shortenedPreviews` 与折叠后的 `snapshot.goal.evidenceCheckpoint`。

## 关联 Issue

系列上下文:#9834(B2,已合入的提示词收敛)、#9835(C2,目录字节预算)、#9880(G1,本轮自动引用)。

</details>
