### PR TITLE
feat(daemon): Add ACP channel transport liveness

### DIFF
--- a/docs/design/2026-08-24-daemon-channel-transport-liveness.md
+++ b/docs/design/2026-08-24-daemon-channel-transport-liveness.md
@@ -1,0 +1,89 @@
+# Daemon ACP channel transport liveness
+
+## Problem
+
+The daemon knows when an ACP child exits or its bounded NDJSON transport rejects a frame, but it cannot detect a child that remains alive while its event loop or transport stops answering. Session active-work snapshots cannot fill this gap: silence from one Session is not proof that the shared channel is dead, and using that signal to recycle the child would destroy every multiplexed Session.
+
+Layer 2 of #8586 adds a separate channel-level liveness contract. It does not change `activeWork`, Session cleanup, or logical Agent progress detection.
+
+## Scope and ownership
+
+One `AcpSessionBridge` owns one workspace runtime and at most one attach-available ACP child channel. The liveness monitor therefore belongs to `ChannelInfo`, not to a Session. A failure condemns the whole child because every Session on that transport is already unreachable.
+
+The monitor covers only daemon-owned ACP children that acknowledge the v1 capability during `initialize`. Older or alternate children that do not acknowledge it keep the current behavior. Direct ACP consumers and channel adapters are unchanged.
+
+## Wire contract
+
+The daemon advertises this initialize metadata:
+
+```json
+{
+  "qwen.daemon.channelLiveness": { "v": 1 }
+}
+```
+
+A supporting child echoes the same metadata in its initialize response. Once negotiated, the daemon periodically calls the read-only extension method:
+
+```text
+qwen/status/channel/ping { v: 1, nonce: N }
+  -> { v: 1, nonce: N }
+```
+
+`nonce` is a non-negative safe integer allocated monotonically for the life of the channel and wraps to zero after `Number.MAX_SAFE_INTEGER`. The daemon accepts only an exact version and nonce echo. A malformed response or a request rejection after a v1 acknowledgement is a definite protocol failure; it does not spend the timeout retry budget.
+
+No Session id, work state, timeout, or process detail crosses this method.
+
+## Timing and escalation
+
+The fixed internal policy is:
+
+- wait 15 seconds between healthy probes;
+- allow 10 seconds for one response;
+- after the first on-time timeout, retry immediately;
+- after a second consecutive on-time timeout, fail the transport and recycle the channel.
+
+This bounds detection to 35 seconds when a child wedges just after a healthy probe, while requiring two independent unanswered requests before taking down multiplexed Sessions. A successful response resets the consecutive-timeout count. These values are implementation policy, not public configuration, matching #8586's non-goal.
+
+At most two requests can remain unresolved: the first timed-out request and its retry. ACP request ids keep a late first response separate from the retry. Once the channel is condemned, the existing transport teardown closes both.
+
+## Host suspend and parent stalls
+
+Every scheduled callback records its expected firing time using `performance.now()`. If either the interval callback or a probe-timeout callback runs more than one second after its expected monotonic deadline, the daemon treats the observation as a local scheduling gap and clears the miss count. A delayed interval starts a fresh interval; a delayed probe timeout keeps the same bounded request outstanding and gives it a fresh response window. It does not infer anything about the child from a timer the parent could not run on time.
+
+This covers platforms whose monotonic clock advances across host suspend. On platforms where that clock pauses during suspend, the timer deadline pauses with it and no overdue callback is produced. Wall-clock changes never participate.
+
+The rule also prevents a long daemon event-loop pause from charging a child timeout. It does not excuse an on-time timeout merely because the daemon was busy earlier; the immediate retry supplies the second observation.
+
+## Lifecycle and failure path
+
+The monitor starts only after initialize succeeds and the channel is published. Its timers are unreferenced so an otherwise idle daemon can exit. It stops on transport failure, channel exit, synchronous kill-all, and graceful shutdown; every callback also rechecks that the same channel remains live and is not dying.
+
+A terminal liveness failure enters the existing transport-failure path before starting teardown:
+
+1. mark the `ChannelInfo` dying synchronously so no new Session work is admitted;
+2. retain a bounded failure code for telemetry;
+3. clear in-flight extension refresh bookkeeping;
+4. ask the daemon transport guard to fail and terminate the child, or call the channel's ordinary kill fallback for injected channels without a guard;
+5. let the existing `channel.exited` handler remove every multiplexed Session, publish `session_died`, and release channel state.
+
+This preserves the existing overlap invariant: a replacement can be spawned while the dying channel remains reachable to `killAllSync` until OS reap.
+
+## Observability
+
+The daemon emits one `channel.liveness_failed` telemetry event and one bounded stderr line when escalation begins. The existing `channel.exited` event then reports `transport_failed=true`, `transport_failure_initiated_teardown=true`, and either `acp_channel_liveness_timeout` or `acp_channel_liveness_protocol_error`.
+
+No health or status response field is added. Public health remains an observation surface, not a synchronous probe.
+
+## Compatibility and non-goals
+
+- An unacknowledged capability disables the monitor for that channel.
+- Existing Session active-work reporting and conditional close behavior do not change.
+- A responsive process with a logically stalled Agent still answers ping; Layer 3 owns progress watchdogs.
+- Runtime generation draining and recovery remain Layers 4 and 5.
+- There is no public timeout setting, persistence change, transport retry, Session-specific kill, or inference from active-work snapshots.
+
+## Verification
+
+Unit coverage pins negotiation, exact ping echo validation, healthy cadence, timeout reset, two-timeout escalation, local timer-delay suppression, cleanup, legacy compatibility, and teardown of every Session on the failed channel. A child-side test pins the initialize acknowledgement and stateless ping response.
+
+The E2E plan freezes only the ACP child with `SIGSTOP` to reproduce the current gap and verify channel recycle. Host-suspend safety is deterministic unit coverage because a real machine suspend cannot be made reliable or portable in CI.

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -87,6 +87,8 @@ import {
   ACTIVE_WORK_MAX_SNAPSHOT_SESSIONS,
   ACTIVE_WORK_NOTIFICATION_METHOD,
   ACTIVE_WORK_STALE_INTERVALS,
+  CHANNEL_LIVENESS_META_KEY,
+  CHANNEL_LIVENESS_VERSION,
   gradeActiveWorkCoverage,
   CHANNEL_STARTUP_PROFILE_META_KEY,
   CHANNEL_STARTUP_PROFILE_VERSION,
@@ -94,6 +96,11 @@ import {
   WORKTREE_MCP_DEFER_META_KEY,
   LOAD_REPLAY_HIDE_INHERITED_META_KEY,
 } from './bridgeTypes.js';
+import {
+  CHANNEL_LIVENESS_INTERVAL_MS,
+  CHANNEL_LIVENESS_PROBE_TIMEOUT_MS,
+  CHANNEL_LIVENESS_TIMEOUT_CODE,
+} from './channel-liveness.js';
 import {
   ApprovalMode,
   SESSION_ARTIFACT_PERSISTENCE_VERSION,
@@ -272,6 +279,18 @@ function activeWorkInitializeResponse(
         categories: [...ACTIVE_WORK_HOLD_CATEGORIES],
         ...overrides,
       },
+    },
+  };
+}
+
+function channelLivenessInitializeResponse(): InitializeResponse {
+  return {
+    protocolVersion: PROTOCOL_VERSION,
+    agentInfo: { name: 'channel-liveness-agent', version: '0' },
+    authMethods: [],
+    agentCapabilities: {},
+    _meta: {
+      [CHANNEL_LIVENESS_META_KEY]: { v: CHANNEL_LIVENESS_VERSION },
     },
   };
 }
@@ -11855,6 +11874,155 @@ describe('createAcpSessionBridge', () => {
     // pattern as the BkUyD test above. The test runner GCs the
     // dangling promises when this `it` returns.
     void killPromise;
+  });
+
+  describe('channel liveness', () => {
+    it('advertises v1 but stays disabled when the child does not acknowledge it', async () => {
+      vi.useFakeTimers();
+      try {
+        const handle = makeChannel();
+        const bridge = makeBridge({
+          channelFactory: async () => handle.channel,
+        });
+        await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+        expect(handle.agent.initializeCalls[0]?._meta).toMatchObject({
+          [CHANNEL_LIVENESS_META_KEY]: { v: CHANNEL_LIVENESS_VERSION },
+        });
+        await vi.advanceTimersByTimeAsync(
+          CHANNEL_LIVENESS_INTERVAL_MS + CHANNEL_LIVENESS_PROBE_TIMEOUT_MS * 2,
+        );
+        expect(handle.agent.extMethodCalls).not.toContainEqual(
+          expect.objectContaining({
+            method: SERVE_STATUS_EXT_METHODS.channelPing,
+          }),
+        );
+        expect(handle.killed).toBe(false);
+        await bridge.shutdown();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('fails the transport after two unanswered channel probes', async () => {
+      vi.useFakeTimers();
+      try {
+        const event = vi.fn();
+        const channelLifecycle = vi.fn();
+        const handle = makeChannel({
+          initializeImpl: () => channelLivenessInitializeResponse(),
+          extMethodImpl: (method) =>
+            method === SERVE_STATUS_EXT_METHODS.channelPing
+              ? new Promise(() => {})
+              : {},
+        });
+        const baseKill = handle.channel.kill;
+        const transportFail = vi.fn((error: unknown) => {
+          void baseKill();
+          return error;
+        });
+        handle.channel = {
+          ...handle.channel,
+          transportGuard: {
+            maxActiveHandlers: 10,
+            maxActiveHandlerBytes: 1024 * 1024,
+            reserveOutboundOperation: () => () => {},
+            reservePreparedResponse: () => {},
+            fail: transportFail,
+          },
+        };
+        const bridge = makeBridge({
+          channelFactory: async () => handle.channel,
+          sessionScope: 'thread',
+          telemetry: {
+            captureContext: () => undefined,
+            runWithContext: async (_captured, fn) => await fn(),
+            withSpan: async (_operation, _attributes, fn) => await fn(),
+            event,
+            injectPromptContext: (request) => request,
+            metrics: {
+              sessionLifecycle: vi.fn(),
+              channelLifecycle,
+              promptQueueWait: vi.fn(),
+              promptDuration: vi.fn(),
+              cancelled: vi.fn(),
+            },
+          },
+        });
+        const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        const second = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        expect(bridge.sessionCount).toBe(2);
+        const firstEvents: BridgeEvent[] = [];
+        const secondEvents: BridgeEvent[] = [];
+        const firstDrain = (async () => {
+          for await (const event of bridge.subscribeEvents(first.sessionId)) {
+            firstEvents.push(event);
+          }
+        })();
+        const secondDrain = (async () => {
+          for await (const event of bridge.subscribeEvents(second.sessionId)) {
+            secondEvents.push(event);
+          }
+        })();
+
+        await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+        const firstProbeCalls = handle.agent.extMethodCalls.filter(
+          ({ method }) => method === SERVE_STATUS_EXT_METHODS.channelPing,
+        );
+        expect(firstProbeCalls).toEqual([
+          {
+            method: SERVE_STATUS_EXT_METHODS.channelPing,
+            params: { v: CHANNEL_LIVENESS_VERSION, nonce: 0 },
+          },
+        ]);
+        await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+        expect(transportFail).not.toHaveBeenCalled();
+        expect(
+          handle.agent.extMethodCalls.filter(
+            ({ method }) => method === SERVE_STATUS_EXT_METHODS.channelPing,
+          ),
+        ).toHaveLength(2);
+
+        await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+        await handle.channel.exited;
+        await Promise.all([firstDrain, secondDrain]);
+
+        expect(transportFail).toHaveBeenCalledOnce();
+        expect(transportFail.mock.calls[0]?.[0]).toMatchObject({
+          code: CHANNEL_LIVENESS_TIMEOUT_CODE,
+        });
+        expect(bridge.sessionCount).toBe(0);
+        expect(firstEvents.at(-1)).toMatchObject({
+          type: 'session_died',
+          data: { sessionId: first.sessionId, reason: 'channel_closed' },
+        });
+        expect(secondEvents.at(-1)).toMatchObject({
+          type: 'session_died',
+          data: { sessionId: second.sessionId, reason: 'channel_closed' },
+        });
+        expect(channelLifecycle).toHaveBeenCalledWith('exit', false);
+        expect(event).toHaveBeenCalledWith(
+          'channel.liveness_failed',
+          expect.objectContaining({
+            'qwen-code.daemon.channel.session_count': 2,
+            'qwen-code.daemon.channel.transport_error_code':
+              CHANNEL_LIVENESS_TIMEOUT_CODE,
+          }),
+        );
+        expect(event).toHaveBeenCalledWith(
+          'channel.exited',
+          expect.objectContaining({
+            'qwen-code.daemon.channel.transport_failed': true,
+            'qwen-code.daemon.channel.transport_failure_initiated_teardown': true,
+            'qwen-code.daemon.channel.transport_error_code':
+              CHANNEL_LIVENESS_TIMEOUT_CODE,
+          }),
+        );
+        await bridge.shutdown();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   it('transport failure marks the channel dying before process exit', async () => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -135,6 +135,8 @@ import {
   ACTIVE_WORK_HOLD_CATEGORIES,
   ACTIVE_WORK_MAX_SESSION_HOLDS,
   ACTIVE_WORK_STALE_INTERVALS,
+  CHANNEL_LIVENESS_META_KEY,
+  CHANNEL_LIVENESS_VERSION,
   clampActiveWorkIntervalMs,
   type ActiveWorkHeartbeatCapabilityV1,
   type ActiveWorkHoldCategory,
@@ -163,6 +165,11 @@ import {
   isValidTrustedModelPrompt,
   sessionCloseDrainBudgetMs,
 } from './bridgeTypes.js';
+import {
+  startChannelLivenessMonitor,
+  type ChannelLivenessMonitor,
+  type ChannelLivenessFailure,
+} from './channel-liveness.js';
 import { getChannelStartupProfileAttributes } from './channel-startup-profile.js';
 import type {
   BridgeSession,
@@ -966,6 +973,7 @@ interface ChannelInfo {
     /** Highest snapshot sequence applied; guards against reordering only. */
     seq: number;
   };
+  channelLiveness?: ChannelLivenessMonitor;
   handshakeComplete: boolean;
 }
 
@@ -3281,6 +3289,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     context?: string,
   ): Promise<void> {
     ci.isDying = true;
+    ci.channelLiveness?.stop();
     await ci.channel.kill().catch((err) => {
       writeStderrLine(
         `qwen serve: channel kill failed${context ? ` (${context})` : ''}: ${String(err)}`,
@@ -3432,6 +3441,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     if (!channelShouldReapWhenIdle(ci) || !hasNoChannelWork(ci)) return;
     ci.emptyReapPending = false;
     ci.isDying = true;
+    ci.channelLiveness?.stop();
     await ci.channel.kill().catch(() => {
       /* best-effort — channel.exited handler still runs */
     });
@@ -4131,6 +4141,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         info.transportFailed = true;
         info.transportFailureCode = safeTransportFailureCode(error);
         info.isDying = true;
+        info.channelLiveness?.stop();
         clearInFlightExtensionRefreshes(info.connection);
       };
       void channel.transportFailed?.then(
@@ -4176,6 +4187,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // the SIGTERM grace window — even if a concurrent `spawnOrAttach`
       // has already reassigned `channelInfo` to a fresh channel.
       void channel.exited.then((exitInfo) => {
+        info.channelLiveness?.stop();
         clearInFlightExtensionRefreshes(info.connection);
         if (channelInfo === info) cancelIdleTimer();
         if (info.workspaceMcpDiscoveryTimer) {
@@ -4295,6 +4307,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // registered, so failure paths (init throw, timeout, late
       // shutdown) only need to mark dying + kill — the handler does
       // the alive-set cleanup when the OS reaps the child.
+      let channelLivenessNegotiated = false;
       try {
         await telemetry.withSpan(
           'channel.initialize',
@@ -4315,6 +4328,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                     },
                     [CHANNEL_STARTUP_PROFILE_META_KEY]: {
                       v: CHANNEL_STARTUP_PROFILE_VERSION,
+                    },
+                    [CHANNEL_LIVENESS_META_KEY]: {
+                      v: CHANNEL_LIVENESS_VERSION,
                     },
                     [PRIVATE_PARENT_CAPABILITY_META_KEY]:
                       privateParentCapability,
@@ -4364,6 +4380,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 seq: 0,
               };
             }
+            const channelLivenessCapability = isRecord(response._meta)
+              ? response._meta[CHANNEL_LIVENESS_META_KEY]
+              : undefined;
+            channelLivenessNegotiated =
+              isRecord(channelLivenessCapability) &&
+              channelLivenessCapability['v'] === CHANNEL_LIVENESS_VERSION;
             try {
               const attributes = getChannelStartupProfileAttributes(
                 response,
@@ -4418,6 +4440,38 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       // caller.
       channelInfo = info;
       info.handshakeComplete = true;
+      if (channelLivenessNegotiated) {
+        const failChannelLiveness = (error: ChannelLivenessFailure) => {
+          if (info.isDying || !aliveChannels.has(info)) return;
+          markTransportFailed(error);
+          telemetry.event('channel.liveness_failed', {
+            'qwen-code.daemon.acp_channel.id': info.id,
+            'qwen-code.daemon.channel.session_count': info.sessionIds.size,
+            'qwen-code.daemon.channel.transport_error_code': error.code,
+          });
+          writeStderrLine(
+            `qwen serve: channel liveness failed (${error.code}); killing channel`,
+          );
+          if (info.channel.transportGuard) {
+            info.channel.transportGuard.fail(error);
+          } else {
+            void killChannelWithLog(info, 'channel liveness failure');
+          }
+        };
+        info.channelLiveness = startChannelLivenessMonitor({
+          probe: (nonce) =>
+            info.connection.extMethod(SERVE_STATUS_EXT_METHODS.channelPing, {
+              v: CHANNEL_LIVENESS_VERSION,
+              nonce,
+            }),
+          onFailure: failChannelLiveness,
+          isActive: () =>
+            channelInfo === info &&
+            aliveChannels.has(info) &&
+            !info.isDying &&
+            !shuttingDown,
+        });
+      }
       telemetry.metrics?.channelLifecycle('spawn');
       return info;
     })();
@@ -4559,6 +4613,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           // stays set until OS reap so `killAllSync` mid-SIGTERM still
           // finds a target (BkUyD invariant).
           ci.isDying = true;
+          ci.channelLiveness?.stop();
           await ci.channel.kill().catch(() => {
             /* best-effort — channel.exited handler still runs */
           });
@@ -12565,6 +12620,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         });
       }
       for (const info of channels) {
+        info.channelLiveness?.stop();
         try {
           info.channel.killSync();
         } catch {
@@ -12605,7 +12661,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         // `ensureChannel` past the gate would still see the dying
         // state and not attach).
         const channels = Array.from(aliveChannels);
-        for (const ci of channels) ci.isDying = true;
+        for (const ci of channels) {
+          ci.isDying = true;
+          ci.channelLiveness?.stop();
+        }
         // Drain mediator pending state before clearing byId so awaiting
         // `requestPermission` callers unwind. Each `forgetSession`
         // settles all matching pending as session_closed; the bridge's

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -252,6 +252,8 @@ export const REQUESTED_SESSION_ID_META_KEY = 'qwen-code/sessionId';
 export const CHANNEL_STARTUP_PROFILE_META_KEY =
   'qwen.daemon.channelStartupProfile';
 export const CHANNEL_STARTUP_PROFILE_VERSION = 1 as const;
+export const CHANNEL_LIVENESS_META_KEY = 'qwen.daemon.channelLiveness';
+export const CHANNEL_LIVENESS_VERSION = 1 as const;
 export const ACTIVE_WORK_HEARTBEAT_META_KEY = 'qwen.daemon.activeWorkHeartbeat';
 export const ACTIVE_WORK_HEARTBEAT_VERSION = 1 as const;
 /** Reporting cadence the daemon asks for; the child may choose another value

--- a/packages/acp-bridge/src/channel-liveness.test.ts
+++ b/packages/acp-bridge/src/channel-liveness.test.ts
@@ -1,0 +1,267 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CHANNEL_LIVENESS_VERSION } from './bridgeTypes.js';
+import {
+  CHANNEL_LIVENESS_INTERVAL_MS,
+  CHANNEL_LIVENESS_PROBE_TIMEOUT_MS,
+  CHANNEL_LIVENESS_PROTOCOL_ERROR_CODE,
+  CHANNEL_LIVENESS_TIMER_LATE_TOLERANCE_MS,
+  CHANNEL_LIVENESS_TIMEOUT_CODE,
+  startChannelLivenessMonitor,
+} from './channel-liveness.js';
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('startChannelLivenessMonitor', () => {
+  it('keeps a healthy channel on the negotiated cadence', async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn(async (nonce: number) => ({
+      v: CHANNEL_LIVENESS_VERSION,
+      nonce,
+    }));
+    const onFailure = vi.fn();
+    const monitor = startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+
+    expect(probe.mock.calls).toEqual([[0], [1]]);
+    expect(onFailure).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it('fails only after two consecutive on-time timeouts', async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn(() => new Promise<never>(() => {}));
+    const onFailure = vi.fn();
+    startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+    expect(onFailure).toHaveBeenCalledOnce();
+    expect(onFailure.mock.calls[0]?.[0]).toMatchObject({
+      code: CHANNEL_LIVENESS_TIMEOUT_CODE,
+    });
+  });
+
+  it('resets the timeout count when the immediate retry succeeds', async () => {
+    vi.useFakeTimers();
+    const probe = vi
+      .fn<(nonce: number) => Promise<unknown>>()
+      .mockImplementationOnce(() => new Promise<never>(() => {}))
+      .mockImplementation(async (nonce) => ({
+        v: CHANNEL_LIVENESS_VERSION,
+        nonce,
+      }));
+    const onFailure = vi.fn();
+    const monitor = startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      CHANNEL_LIVENESS_INTERVAL_MS + CHANNEL_LIVENESS_PROBE_TIMEOUT_MS,
+    );
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(onFailure).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it('does not charge a callback delayed by the parent event loop', async () => {
+    vi.useFakeTimers();
+    let monotonicNow = 0;
+    const probe = vi.fn(async (nonce: number) => ({
+      v: CHANNEL_LIVENESS_VERSION,
+      nonce,
+    }));
+    const onFailure = vi.fn();
+    const monitor = startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => monotonicNow,
+    });
+
+    monotonicNow =
+      CHANNEL_LIVENESS_INTERVAL_MS +
+      CHANNEL_LIVENESS_TIMER_LATE_TOLERANCE_MS +
+      1;
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+    expect(probe).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+    expect(probe).toHaveBeenCalledOnce();
+    expect(onFailure).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it('clears an existing timeout streak after a delayed callback', async () => {
+    vi.useFakeTimers();
+    let monotonicNow = 0;
+    const probe = vi.fn(() => new Promise<never>(() => {}));
+    const onFailure = vi.fn();
+    startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => monotonicNow,
+    });
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    monotonicNow =
+      CHANNEL_LIVENESS_PROBE_TIMEOUT_MS +
+      CHANNEL_LIVENESS_TIMER_LATE_TOLERANCE_MS +
+      1;
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+    expect(onFailure).toHaveBeenCalledOnce();
+    expect(onFailure.mock.calls[0]?.[0]).toMatchObject({
+      code: CHANNEL_LIVENESS_TIMEOUT_CODE,
+    });
+  });
+
+  it('does not let a late response reset the current probe streak', async () => {
+    vi.useFakeTimers();
+    const first = deferred<unknown>();
+    const probe = vi
+      .fn<(nonce: number) => Promise<unknown>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementation(() => new Promise<never>(() => {}));
+    const onFailure = vi.fn();
+    startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(
+      CHANNEL_LIVENESS_INTERVAL_MS + CHANNEL_LIVENESS_PROBE_TIMEOUT_MS,
+    );
+    expect(probe).toHaveBeenCalledTimes(2);
+
+    first.resolve({ v: CHANNEL_LIVENESS_VERSION, nonce: 0 });
+    await Promise.resolve();
+    expect(onFailure).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+    expect(onFailure).toHaveBeenCalledOnce();
+    expect(onFailure.mock.calls[0]?.[0]).toMatchObject({
+      code: CHANNEL_LIVENESS_TIMEOUT_CODE,
+    });
+  });
+
+  it('fails a malformed response without spending the retry budget', async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn(async () => ({
+      v: CHANNEL_LIVENESS_VERSION,
+      nonce: 99,
+    }));
+    const onFailure = vi.fn();
+    startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+
+    expect(probe).toHaveBeenCalledOnce();
+    expect(onFailure).toHaveBeenCalledOnce();
+    expect(onFailure.mock.calls[0]?.[0]).toMatchObject({
+      code: CHANNEL_LIVENESS_PROTOCOL_ERROR_CODE,
+    });
+  });
+
+  it('fails a rejected probe without spending the retry budget', async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn(() => {
+      throw new Error('ping rejected');
+    });
+    const onFailure = vi.fn();
+    startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+
+    expect(probe).toHaveBeenCalledOnce();
+    expect(onFailure).toHaveBeenCalledOnce();
+    expect(onFailure.mock.calls[0]?.[0]).toMatchObject({
+      code: CHANNEL_LIVENESS_PROTOCOL_ERROR_CODE,
+    });
+  });
+
+  it('cancels an active timeout when stopped', async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn(() => new Promise<never>(() => {}));
+    const onFailure = vi.fn();
+    const monitor = startChannelLivenessMonitor({
+      probe,
+      onFailure,
+      isActive: () => true,
+      now: () => 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_INTERVAL_MS);
+    monitor.stop();
+    await vi.advanceTimersByTimeAsync(CHANNEL_LIVENESS_PROBE_TIMEOUT_MS * 3);
+
+    expect(probe).toHaveBeenCalledOnce();
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+});

--- a/packages/acp-bridge/src/channel-liveness.ts
+++ b/packages/acp-bridge/src/channel-liveness.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { performance } from 'node:perf_hooks';
+import { CHANNEL_LIVENESS_VERSION } from './bridgeTypes.js';
+
+export const CHANNEL_LIVENESS_INTERVAL_MS = 15_000;
+export const CHANNEL_LIVENESS_PROBE_TIMEOUT_MS = 10_000;
+export const CHANNEL_LIVENESS_FAILURE_THRESHOLD = 2;
+export const CHANNEL_LIVENESS_TIMER_LATE_TOLERANCE_MS = 1_000;
+
+export const CHANNEL_LIVENESS_TIMEOUT_CODE = 'acp_channel_liveness_timeout';
+export const CHANNEL_LIVENESS_PROTOCOL_ERROR_CODE =
+  'acp_channel_liveness_protocol_error';
+
+export class ChannelLivenessFailure extends Error {
+  constructor(
+    readonly code:
+      | typeof CHANNEL_LIVENESS_TIMEOUT_CODE
+      | typeof CHANNEL_LIVENESS_PROTOCOL_ERROR_CODE,
+  ) {
+    super(
+      code === CHANNEL_LIVENESS_TIMEOUT_CODE
+        ? 'ACP channel failed consecutive liveness probes'
+        : 'ACP channel returned an invalid liveness response',
+    );
+    this.name = 'ChannelLivenessFailure';
+  }
+}
+
+interface ChannelLivenessMonitorOptions {
+  probe(nonce: number): Promise<unknown>;
+  onFailure(error: ChannelLivenessFailure): void;
+  isActive(): boolean;
+  now?: () => number;
+}
+
+export interface ChannelLivenessMonitor {
+  stop(): void;
+}
+
+type ProbeOutcome =
+  | { kind: 'response'; response: unknown }
+  | { kind: 'rejected' }
+  | { kind: 'timeout' }
+  | { kind: 'local_delay' }
+  | { kind: 'stopped' };
+
+function isValidResponse(response: unknown, nonce: number): boolean {
+  return (
+    typeof response === 'object' &&
+    response !== null &&
+    !Array.isArray(response) &&
+    (response as Record<string, unknown>)['v'] === CHANNEL_LIVENESS_VERSION &&
+    (response as Record<string, unknown>)['nonce'] === nonce
+  );
+}
+
+export function startChannelLivenessMonitor(
+  options: ChannelLivenessMonitorOptions,
+): ChannelLivenessMonitor {
+  const now = options.now ?? (() => performance.now());
+  let stopped = false;
+  let timer: NodeJS.Timeout | undefined;
+  let consecutiveTimeouts = 0;
+  let nextNonce = 0;
+  let resolveStopped!: (outcome: ProbeOutcome) => void;
+  const stoppedOutcome = new Promise<ProbeOutcome>((resolve) => {
+    resolveStopped = resolve;
+  });
+
+  const isActive = () => !stopped && options.isActive();
+  const stop = () => {
+    stopped = true;
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    resolveStopped({ kind: 'stopped' });
+  };
+  const fail = (error: ChannelLivenessFailure) => {
+    if (!isActive()) return;
+    stop();
+    options.onFailure(error);
+  };
+  const timerWasLate = (expectedAt: number) =>
+    now() > expectedAt + CHANNEL_LIVENESS_TIMER_LATE_TOLERANCE_MS;
+
+  const runProbe = async () => {
+    if (!isActive()) return;
+    const nonce = nextNonce;
+    nextNonce = nonce === Number.MAX_SAFE_INTEGER ? 0 : Math.max(0, nonce + 1);
+    const response = Promise.resolve()
+      .then(() => options.probe(nonce))
+      .then<ProbeOutcome, ProbeOutcome>(
+        (value) => ({ kind: 'response', response: value }),
+        () => ({ kind: 'rejected' }),
+      );
+
+    let outcome: ProbeOutcome;
+    while (true) {
+      const expectedAt = now() + CHANNEL_LIVENESS_PROBE_TIMEOUT_MS;
+      const timeout = new Promise<ProbeOutcome>((resolve) => {
+        timer = setTimeout(() => {
+          timer = undefined;
+          resolve(
+            timerWasLate(expectedAt)
+              ? { kind: 'local_delay' }
+              : { kind: 'timeout' },
+          );
+        }, CHANNEL_LIVENESS_PROBE_TIMEOUT_MS);
+        timer.unref();
+      });
+      outcome = await Promise.race([response, timeout, stoppedOutcome]);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      if (outcome.kind === 'stopped' || !isActive()) return;
+      if (outcome.kind !== 'local_delay') break;
+      consecutiveTimeouts = 0;
+    }
+
+    if (outcome.kind === 'response') {
+      if (!isValidResponse(outcome.response, nonce)) {
+        fail(new ChannelLivenessFailure(CHANNEL_LIVENESS_PROTOCOL_ERROR_CODE));
+        return;
+      }
+      consecutiveTimeouts = 0;
+      schedule(CHANNEL_LIVENESS_INTERVAL_MS);
+      return;
+    }
+    if (outcome.kind === 'rejected') {
+      await Promise.resolve();
+      fail(new ChannelLivenessFailure(CHANNEL_LIVENESS_PROTOCOL_ERROR_CODE));
+      return;
+    }
+
+    consecutiveTimeouts++;
+    if (consecutiveTimeouts >= CHANNEL_LIVENESS_FAILURE_THRESHOLD) {
+      fail(new ChannelLivenessFailure(CHANNEL_LIVENESS_TIMEOUT_CODE));
+      return;
+    }
+    void runProbe();
+  };
+
+  function schedule(delayMs: number): void {
+    if (!isActive()) return;
+    const expectedAt = now() + delayMs;
+    timer = setTimeout(() => {
+      timer = undefined;
+      if (!isActive()) return;
+      if (timerWasLate(expectedAt)) {
+        consecutiveTimeouts = 0;
+        schedule(CHANNEL_LIVENESS_INTERVAL_MS);
+        return;
+      }
+      void runProbe();
+    }, delayMs);
+    timer.unref();
+  }
+
+  schedule(CHANNEL_LIVENESS_INTERVAL_MS);
+  return { stop };
+}

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -108,6 +108,7 @@ export class MissingCliEntryError extends Error {
 }
 
 export const SERVE_STATUS_EXT_METHODS = {
+  channelPing: 'qwen/status/channel/ping',
   workspaceMcp: 'qwen/status/workspace/mcp',
   workspaceMcpTools: 'qwen/status/workspace/mcp/tools',
   workspaceMcpResources: 'qwen/status/workspace/mcp/resources',

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1036,6 +1036,8 @@ import {
   ACTIVE_WORK_HOLD_CATEGORIES,
   ACTIVE_WORK_LEGACY_HOLD_CATEGORIES,
   ACTIVE_WORK_NOTIFICATION_METHOD,
+  CHANNEL_LIVENESS_META_KEY,
+  CHANNEL_LIVENESS_VERSION,
   CHANNEL_STARTUP_PROFILE_META_KEY,
   CHANNEL_STARTUP_PROFILE_VERSION,
   PROMPT_CANCEL_METHOD,
@@ -2840,6 +2842,69 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         },
       ],
     });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('negotiates and answers channel liveness without a Session', async () => {
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const response = (await agent.initialize({
+      clientCapabilities: {},
+      _meta: {
+        [CHANNEL_LIVENESS_META_KEY]: { v: CHANNEL_LIVENESS_VERSION },
+      },
+    })) as { _meta?: Record<string, unknown> };
+
+    expect(response._meta).toMatchObject({
+      [CHANNEL_LIVENESS_META_KEY]: { v: CHANNEL_LIVENESS_VERSION },
+    });
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.channelPing, {
+        v: CHANNEL_LIVENESS_VERSION,
+        nonce: 42,
+      }),
+    ).resolves.toEqual({ v: CHANNEL_LIVENESS_VERSION, nonce: 42 });
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.channelPing, {
+        v: CHANNEL_LIVENESS_VERSION,
+        nonce: -1,
+      }),
+    ).rejects.toThrow('Invalid channel liveness ping');
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('does not acknowledge an unrequested channel liveness capability', async () => {
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+
+    const response = (await agent.initialize({
+      clientCapabilities: {},
+    })) as { _meta?: Record<string, unknown> };
+
+    expect(response._meta?.[CHANNEL_LIVENESS_META_KEY]).toBeUndefined();
 
     mockConnectionState.resolve();
     await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -373,6 +373,8 @@ import {
   ACTIVE_WORK_HEARTBEAT_VERSION,
   ACTIVE_WORK_HOLD_CATEGORIES,
   ACTIVE_WORK_LEGACY_HOLD_CATEGORIES,
+  CHANNEL_LIVENESS_META_KEY,
+  CHANNEL_LIVENESS_VERSION,
   clampActiveWorkIntervalMs,
   type ActiveWorkHoldV1,
   CHANNEL_STARTUP_PROFILE_META_KEY,
@@ -4401,6 +4403,13 @@ class QwenAgent implements Agent {
           )
         : ACTIVE_WORK_LEGACY_HOLD_CATEGORIES
       : undefined;
+    const requestedChannelLiveness = args._meta?.[CHANNEL_LIVENESS_META_KEY];
+    const channelLivenessRequested =
+      requestedChannelLiveness !== null &&
+      typeof requestedChannelLiveness === 'object' &&
+      !Array.isArray(requestedChannelLiveness) &&
+      (requestedChannelLiveness as Record<string, unknown>)['v'] ===
+        CHANNEL_LIVENESS_VERSION;
     if (activeWorkIntervalMs !== undefined) {
       this.activeWorkReporter?.dispose();
       this.activeWorkReporter = new ActiveWorkReporter(
@@ -4427,6 +4436,13 @@ class QwenAgent implements Agent {
               v: ACTIVE_WORK_HEARTBEAT_VERSION,
               intervalMs: activeWorkIntervalMs,
               categories: [...(activeWorkCategories ?? [])],
+            },
+          }
+        : {}),
+      ...(channelLivenessRequested
+        ? {
+            [CHANNEL_LIVENESS_META_KEY]: {
+              v: CHANNEL_LIVENESS_VERSION,
             },
           }
         : {}),
@@ -7649,6 +7665,21 @@ class QwenAgent implements Agent {
     const SESSION_ID_RE = /^[0-9a-fA-F-]{32,36}$/;
 
     switch (method) {
+      case SERVE_STATUS_EXT_METHODS.channelPing: {
+        const nonce = params['nonce'];
+        if (
+          params['v'] !== CHANNEL_LIVENESS_VERSION ||
+          typeof nonce !== 'number' ||
+          !Number.isSafeInteger(nonce) ||
+          nonce < 0
+        ) {
+          throw RequestError.invalidParams(
+            undefined,
+            'Invalid channel liveness ping',
+          );
+        }
+        return { v: CHANNEL_LIVENESS_VERSION, nonce };
+      }
       case PROMPT_CANCEL_METHOD: {
         const sessionId = params['sessionId'];
         if (typeof sessionId !== 'string' || sessionId.length === 0) {


### PR DESCRIPTION
## What this PR does

This PR adds an opt-in ACP channel transport-liveness contract for daemon-owned child processes. A supporting child acknowledges the capability during initialization and answers one stateless ping per shared channel. The daemon waits 15 seconds between healthy probes, retries immediately after the first on-time 10-second timeout, and condemns the channel only after a second consecutive on-time timeout. Invalid responses and rejected requests are treated as protocol failures after negotiation.

The monitor uses a monotonic clock and clears its timeout streak when the parent timer itself fires late, so host suspend or a blocked daemon event loop is not charged to the child. A terminal failure enters the existing transport-failure path, which blocks new admission, records a bounded failure code, terminates the child, and tears down every Session multiplexed on that transport. Children that do not acknowledge the capability keep the previous behavior.

The change also documents the wire contract, fixed timing policy, lifecycle ownership, failure semantics, compatibility boundary, and the remaining separation from logical Agent watchdogs and runtime recovery.

## Why it's needed

The daemon currently detects process exit and explicit transport failure, but a child can remain alive with its pipe open while its event loop or ACP transport stops answering. In that state, every multiplexed Session can remain resident indefinitely because no transport-liveness signal reaches the existing teardown path.

Session active-work reporting cannot safely solve this problem: silence from one Session is not proof that the shared channel is dead, and using it as such could destroy unrelated Sessions on the same child. A negotiated channel-level ping keeps transport health independent from work state and provides a bounded, backward-compatible failure path for Layer 2 of #8586.

## Reviewer Test Plan

### How to verify

1. Start two thread-scoped Sessions on one daemon workspace and confirm they share one ACP child. A healthy interval should emit one channel ping, with no Session id or workspace path in the request, and a valid echoed response should leave both Sessions alive.
2. Freeze only the ACP child after both Sessions are established. The first timely probe timeout should retain the child and both Sessions; the second consecutive timely timeout should mark the transport failed, terminate that child, and deliver `session_died` to both Session event streams.
3. Create a new Session after the failed child is reaped. The daemon should spawn a fresh child and a prompt should complete normally, confirming that replacement admission is not attached to the dying channel.
4. Exercise a child that does not acknowledge the capability. No ping should be sent and existing compatibility behavior should remain unchanged.
5. Exercise delayed parent timers and late responses deterministically. A late interval or timeout callback should clear the timeout streak, while a response from an expired request must not reset the current probe's streak.

Local verification passed the full ACP bridge test files (790 tests), the ACP child integration test file (465 tests), build, bundle, typecheck, lint, and diff checks. A real local SIGSTOP run reproduced two live Sessions on one child, observed both Sessions torn down after the negotiated timeout sequence, then completed an `OK` prompt through a newly spawned child.

### Evidence (Before & After)

N/A — this is daemon transport behavior with no TUI change; the separate E2E report comment contains the runtime evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.4.1, Node.js 24.12.0, npm 10.9.8, locally built bundle, `qwen serve --no-web`, and a real ACP child frozen with SIGSTOP.

## Risk & Scope

- Main risk or tradeoff: A terminal liveness decision intentionally tears down every Session sharing the child. The risk is bounded by explicit capability negotiation, two consecutive timely timeouts, monotonic parent-delay classification, exact nonce validation, and reuse of the established transport-failure lifecycle.
- Not validated / out of scope: Windows and Linux were not exercised locally. Logical Agent progress watchdogs, runtime generation draining, unresponsive-Agent recovery, active-work semantics, public timeout configuration, and transport retries remain out of scope.
- Breaking changes / migration notes: None. Unacknowledged children retain the existing behavior, and no persistence or public status schema changes are introduced.

## Linked Issues

Part of #8586

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为 daemon 管理的 ACP 子进程增加了一个选择性启用的 Channel 传输活性协议。支持该协议的 child 会在初始化阶段确认能力，并对每条共享 Channel 回答一个无状态 ping。daemon 在健康探测之间等待 15 秒；第一次按时触发的 10 秒超时后立即重试；只有第二次连续且按时触发的超时才会判定 Channel 失效。能力协商完成后，无效响应和请求拒绝会被视为协议失败。

monitor 使用单调时钟；如果 parent 自身的 timer 延迟触发，它会清空超时连续计数，因此宿主机休眠或 daemon 事件循环阻塞不会被错误归因于 child。终止性失败会进入已有的传输失败路径：阻止新任务进入、记录有界失败码、终止 child，并清理该传输上复用的全部 Session。未确认该能力的 child 保持原有行为。

本变更同时记录了 wire contract、固定时间策略、生命周期归属、失败语义、兼容边界，以及它与逻辑 Agent watchdog 和运行时恢复之间仍然保持的职责分离。

## 为什么需要

daemon 目前可以检测进程退出和显式传输失败，但 child 可能仍保持存活、pipe 仍然打开，同时其事件循环或 ACP 传输已经停止响应。在这种状态下，由于没有传输活性信号进入已有 teardown 路径，所有复用的 Session 都可能无限期驻留。

Session 的 active-work 上报无法安全解决这个问题：一个 Session 沉默并不能证明共享 Channel 已失效，如果据此处理，可能会误毁同一 child 上无关的 Session。协商后的 Channel 级 ping 将传输健康与工作状态分离，并为 #8586 的第 2 层提供一个有界、向后兼容的失败路径。

## Reviewer 测试计划

### 如何验证

1. 在同一个 daemon workspace 上启动两个 thread scope Session，并确认它们共享一个 ACP child。一个健康周期应只发出一次 Channel ping，请求中不包含 Session id 或 workspace path；有效的原样响应应让两个 Session 都保持存活。
2. 在两个 Session 都建立后，只冻结 ACP child。第一次按时的探测超时应保留 child 和两个 Session；第二次连续按时的超时应将传输标记为失败、终止该 child，并向两个 Session 的事件流都发送 `session_died`。
3. 在失败 child 被回收后创建新 Session。daemon 应启动全新的 child，prompt 应能正常完成，以确认替换任务不会接入正在退出的 Channel。
4. 使用不确认该能力的 child。daemon 不应发送 ping，现有兼容行为应保持不变。
5. 以确定性方式验证延迟的 parent timer 和迟到响应。延迟的 interval 或 timeout callback 应清空超时连续计数，而已过期请求的响应不得重置当前探测的连续计数。

本地验证已通过完整 ACP bridge 测试文件（790 个测试）、ACP child 集成测试文件（465 个测试）、build、bundle、typecheck、lint 和 diff 检查。一次真实本地 SIGSTOP 运行先在同一个 child 上复现两个存活 Session，随后观察到两个 Session 在协商的超时序列后一起被清理，最后通过新启动的 child 完成了一个返回 `OK` 的 prompt。

### 证据（Before & After）

N/A — 这是 daemon 传输行为变更，没有 TUI 变化；独立的 E2E 报告评论包含运行时证据。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试   |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS 26.4.1、Node.js 24.12.0、npm 10.9.8、本地构建 bundle、`qwen serve --no-web`，并用 SIGSTOP 冻结真实 ACP child。

## 风险与范围

- 主要风险或权衡：终止性的活性判定会有意清理共享该 child 的所有 Session。通过显式能力协商、两次连续且按时的超时、单调时钟下的 parent 延迟分类、精确 nonce 校验，以及复用既有传输失败生命周期来控制风险。
- 未验证 / 范围外：Windows 和 Linux 未在本地验证。逻辑 Agent 进度 watchdog、运行时 generation draining、无响应 Agent 恢复、active-work 语义、公开 timeout 配置和传输重试仍不在本 PR 范围内。
- Breaking change / 迁移说明：无。未确认能力的 child 保留现有行为，不引入持久化或公开状态 schema 变更。

## 关联 Issue

属于 #8586 的一部分

</details>
