### PR TITLE
fix(webui): hydrate Goal independently of session metadata

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -1902,11 +1902,9 @@ describe('DaemonSessionProvider', () => {
     expect(sessionId).toBeDefined();
     await act(async () => {
       actions?.applyGoalSnapshot(sessionId!, created);
-    });
-    expect(connection?.goalState).toBe(created);
-
-    pendingGoal.resolve({ snapshot: { v: 2, goal: null, activity: 'idle' } });
-    await act(async () => {
+      pendingGoal.resolve({
+        snapshot: { v: 2, goal: null, activity: 'idle' },
+      });
       await flushPromises();
     });
 
@@ -8572,6 +8570,81 @@ describe('DaemonSessionProvider', () => {
     expect(loadCalls[1]?.[3]).toBe('client-a');
   });
 
+  it('hydrates Goal state without waiting for session metadata after a switch', async () => {
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-a' }));
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const providers = createDeferred<unknown>();
+    const commands =
+      createDeferred<Awaited<ReturnType<MockSession['supportedCommands']>>>();
+    const context =
+      createDeferred<Awaited<ReturnType<MockSession['context']>>>();
+    sdkMocks.workspaceProviders.mockReturnValueOnce(providers.promise);
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-b',
+        supportedCommands: vi.fn(() => commands.promise),
+        context: vi.fn(() => context.promise),
+      }),
+    );
+
+    let loadSession: Promise<void> | undefined;
+    act(() => {
+      loadSession = requireActions(actions).loadSession('session-b');
+    });
+    await act(async () => {
+      await wait(5);
+      await loadSession;
+      await flushPromises();
+    });
+    const goalStateBeforeMetadata = connection?.goalState;
+
+    providers.resolve({
+      v: 1,
+      workspaceCwd: '/mock-workspace',
+      initialized: true,
+      providers: [],
+    });
+    commands.resolve({
+      v: 1,
+      sessionId: 'session-b',
+      availableCommands: [],
+      availableSkills: [],
+    });
+    context.resolve({
+      v: 1,
+      sessionId: 'session-b',
+      workspaceCwd: '/mock-workspace',
+      state: {},
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(goalStateBeforeMetadata).toEqual({
+      v: 2,
+      goal: null,
+      activity: 'idle',
+    });
+    expect(connection?.goalState).toEqual({
+      v: 2,
+      goal: null,
+      activity: 'idle',
+    });
+  });
+
   it('retries a session switch while the target session is closing', async () => {
     const firstSession = createMockSession({ sessionId: 'session-a' });
     const secondSession = createMockSession({ sessionId: 'session-b' });
@@ -9113,6 +9186,7 @@ describe('DaemonSessionProvider', () => {
     expect(connection).toMatchObject({
       sessionId: 'session-1',
       displayName: 'Updated session',
+      goalState: { v: 2, goal: null, activity: 'idle' },
     });
   });
 

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -39,7 +39,6 @@ import {
   type DaemonTurnCompleteData,
   type DaemonUiEvent,
   type DaemonUnrecognizedDiagnostic,
-  type GoalSnapshotV2,
 } from '@qwen-code/sdk/daemon';
 import {
   createDaemonSessionActions,
@@ -2280,13 +2279,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             : activeSession.workspaceCwd
               ? client.workspaceByCwd(activeSession.workspaceCwd).workspaceGit()
               : client.workspaceGit();
-          const [
-            providerResult,
-            commandResult,
-            contextResult,
-            gitResult,
-            goalResult,
-          ] = await Promise.allSettled([
+          const metadataPromise = Promise.allSettled([
             canReuseSessionMetadata
               ? Promise.resolve(undefined)
               : client.workspaceProviders(),
@@ -2297,8 +2290,55 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               ? Promise.resolve(undefined)
               : activeSession.context(),
             gitPromise,
-            activeSession.goal(),
           ]);
+          // Hydrate Goal ownership independently so unrelated metadata cannot
+          // leave Slash commands blocked. Reconcile against any Goal frame
+          // that landed while the read was in flight.
+          const goalPromise = activeSession
+            .goal()
+            .then(
+              (response) => response.snapshot,
+              () => undefined,
+            )
+            .then((goalState) => {
+              if (
+                disposed ||
+                abort.signal.aborted ||
+                sessionRef.current !== activeSession
+              ) {
+                return goalState;
+              }
+              setConnection((current) => {
+                if (
+                  sessionRef.current !== activeSession ||
+                  current.sessionId !== activeSession.sessionId
+                ) {
+                  return current;
+                }
+                if (!goalState && goalStateAtLoadStart !== undefined) {
+                  return current;
+                }
+                return {
+                  ...current,
+                  goalState: goalState
+                    ? selectGoalStateFromRead(
+                        current.goalState,
+                        goalState,
+                        goalStateAtLoadStart?.goal?.goalId,
+                      )
+                    : (current.goalState ?? {
+                        v: 2,
+                        goal: null,
+                        activity: 'idle',
+                      }),
+                };
+              });
+              return goalState;
+            });
+          const [
+            [providerResult, commandResult, contextResult, gitResult],
+            goalState,
+          ] = await Promise.all([metadataPromise, goalPromise]);
           if (
             disposed ||
             abort.signal.aborted ||
@@ -2322,22 +2362,10 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             gitResult?.status === 'fulfilled'
               ? (gitResult.value.branch ?? undefined)
               : undefined;
-          const goalState =
-            goalResult.status === 'fulfilled'
-              ? goalResult.value.snapshot
-              : undefined;
-          // A failed goal fetch on a session with no known state still needs a
-          // snapshot so consumers stop treating the state as hydrating; it must
-          // never reconcile against a state a frame installed meanwhile.
           const goalStateFallback =
-            goalResult.status === 'fulfilled' ||
-            goalStateAtLoadStart !== undefined
-              ? undefined
-              : ({
-                  v: 2,
-                  goal: null,
-                  activity: 'idle',
-                } satisfies GoalSnapshotV2);
+            goalState === undefined && goalStateAtLoadStart === undefined
+              ? ({ v: 2, goal: null, activity: 'idle' } as const)
+              : undefined;
           const loadWarningTexts = [
             providerResult?.status === 'rejected'
               ? loadWarningsRef.current?.models
@@ -2375,7 +2403,9 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
 
           setConnection((current) => {
             if (
-              sessionRef.current !== activeSession ||
+              abort.signal.aborted ||
+              (sessionRef.current !== undefined &&
+                sessionRef.current !== activeSession) ||
               current.sessionId !== activeSession.sessionId
             ) {
               return current;


### PR DESCRIPTION
## What this PR does

This change hydrates Goal ownership independently from the rest of session metadata and publishes the Goal snapshot as soon as its session-scoped request settles. Provider, supported-command, context, and Git metadata continue loading in parallel without keeping Slash commands behind their slowest request.

Goal snapshots still reconcile through the existing revision and cleared-goal ordering rules. Functional state updates preserve a Goal created or updated while the load-time read is in flight, and exact session attachment checks prevent a replaced attachment from publishing stale state.

Regression coverage now exercises a session switch where unrelated metadata remains pending, a Goal update and a stale bare-null read resolving in the same React batch, immediate metadata events, Goal request failures, streamed revisions, clear tombstones, and replaced same-ID attachments.

## Why it's needed

The Slash-command gate deliberately fails closed whenever a real session has no hydrated Goal state, because `undefined` means the client does not yet know whether a Goal owns the session. During a session switch, however, the Goal request was grouped with unrelated metadata in one aggregate wait. A slow provider, command, context, or `workspace/git` request therefore left Goal state unknown even after the daemon had already returned `{ goal: null, activity: "idle" }`.

That produced the misleading persistent error “Goal is occupying the session or state is still loading” for commands such as `/compress`. Waiting or sending an ordinary chat message did not repair it because neither action changed the unresolved Goal hydration state. Goal is the only state that determines this gate, so its availability should not depend on unrelated workspace metadata.

The independent update also has to remain ordered with live Goal changes. A load-time bare-null response can resolve in the same React batch as a newly created active Goal; publishing a value computed from an older connection reference would overwrite that Goal and incorrectly reopen the Slash gate. This change keeps both the early Goal publication and final metadata merge functional, so reconciliation always sees the newest queued state.

## Reviewer Test Plan

### How to verify

1. Open a session without a Goal, switch to another session without a Goal, and delay any non-Goal metadata response. Once the target session's Goal response reports idle/null, verify `/compress` is accepted before the delayed metadata completes.
2. While the load-time Goal read is pending, publish a newly created active Goal and resolve the read with a stale bare-null snapshot in the same update batch. Verify the active Goal remains visible and Slash commands remain gated.
3. Switch to a session with an active Goal and verify forwarded Slash commands remain blocked. Pause or complete the Goal and verify the existing transition behavior is unchanged.
4. Verify immediate auth, terminal stream, and session-closed paths still restore workspace model metadata, and replacing an attachment with the same session ID does not accept metadata from the old attachment.

### Evidence (Before & After)

Before: the deterministic session-switch regression observed `goalState === undefined` while the Goal request had already completed, and the same-batch concurrency regression observed a newly created active Goal being replaced by the stale idle/null read.

After: the session-switch regression observes idle/null before unrelated metadata resolves, while the same-batch regression retains the active Goal. The complete Provider suite passes 244/244, Goal action/mapper tests pass 135/135, and Goal gate tests pass 10/10.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local Node.js workspace with Vitest, TypeScript, Vite production build, Prettier, and ESLint pre-commit checks.

## Risk & Scope

- Main risk or tradeoff: Goal state can now render before other session metadata. Revision/tombstone reconciliation and attachment identity guards remain authoritative, with regression coverage for concurrent writes and immediate terminal events.
- Not validated / out of scope: Browser-level visual automation and live daemon E2E were not run; Windows and Linux were not tested locally.
- Breaking changes / migration notes: None. No daemon route, schema, or persisted state changes.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本次修改将 Goal 所有权状态从其他会话 metadata 中独立加载，并在会话级 Goal 请求完成后立即发布快照。Provider、支持的命令、上下文和 Git metadata 仍会并行加载，但 Slash 命令不再等待其中最慢的请求。

Goal 快照仍通过现有 revision 与 cleared-goal 顺序规则合并。functional state update 会保留 load-time 读取期间创建或更新的 Goal，精确的会话 attachment 检查则会阻止已被替换的 attachment 发布过期状态。

回归测试覆盖：无关 metadata 持续 pending 时切换会话、Goal 更新与过期 bare-null 读取在同一个 React 批次完成、立即到达的 metadata 事件、Goal 请求失败、流式 revision、清空 tombstone，以及 same-ID attachment 替换。

## 为什么需要修改

Slash 命令门禁在真实会话尚未完成 Goal hydration 时会故意 fail closed，因为 `undefined` 表示客户端还不知道该会话是否正被 Goal 占用。但在切换会话时，Goal 请求此前与无关 metadata 被放在同一个聚合等待中。只要 provider、命令、上下文或 `workspace/git` 中任一请求较慢，即使 daemon 已返回 `{ goal: null, activity: "idle" }`，Goal 状态仍会保持未知。

这会让 `/compress` 等命令持续显示误导性的“Goal 正在占用会话或状态仍在加载”。继续等待或发送普通聊天消息都无法修复，因为这两个动作都不会改变尚未发布的 Goal hydration 状态。Goal 是该门禁唯一依赖的状态，因此它的可用性不应取决于无关的 workspace metadata。

独立更新还必须与实时 Goal 变化保持正确顺序。load-time 的 bare-null 响应可能与新创建的 active Goal 在同一个 React 批次内完成；如果根据旧 connection ref 发布确定值，就会覆盖 active Goal 并错误地重新开放 Slash 门禁。本次修改让提前发布 Goal 和最终合并 metadata 都使用 functional update，从而保证 reconciliation 总能看到队列中的最新状态。

## Reviewer 测试计划

### 如何验证

1. 打开一个没有 Goal 的会话，切换到另一个没有 Goal 的会话，并延迟任一非 Goal metadata 响应。当目标会话的 Goal 响应为 idle/null 后，确认延迟的 metadata 尚未完成时 `/compress` 已可执行。
2. 在 load-time Goal 读取 pending 时发布一个新创建的 active Goal，并让读取在同一更新批次返回过期 bare-null 快照。确认 active Goal 仍然可见，Slash 命令仍被门禁阻止。
3. 切换到存在 active Goal 的会话，确认转发型 Slash 命令仍被阻止；暂停或完成 Goal 后，确认现有状态转换行为不变。
4. 确认立即发生的 auth、terminal stream 和 session-closed 路径仍能恢复 workspace model metadata，并且 same-ID attachment 替换后不会接收旧 attachment 的 metadata。

### Before / After 证据

修改前：确定性会话切换回归测试在 Goal 请求已经完成时仍观察到 `goalState === undefined`；同批次并发回归测试则观察到新创建的 active Goal 被过期 idle/null 读取覆盖。

修改后：会话切换测试在无关 metadata 完成前即可观察到 idle/null，同批次测试则保留 active Goal。Provider 完整测试 244/244 通过，Goal action/mapper 测试 135/135 通过，Goal gate 测试 10/10 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 Node.js workspace，使用 Vitest、TypeScript、Vite production build、Prettier 和 ESLint pre-commit 检查。

## 风险与范围

- 主要风险或权衡：Goal 状态现在可能早于其他会话 metadata 渲染。revision/tombstone reconciliation 与 attachment identity guard 仍然权威，并已有并发写入及立即 terminal 事件的回归测试。
- 未验证或不在范围内：未运行浏览器级视觉自动化和真实 daemon E2E；未在 Windows 和 Linux 本地测试。
- Breaking changes / 迁移说明：无。没有 daemon 路由、schema 或持久化状态变更。

## 关联 Issue

N/A

</details>
