### PR TITLE
chore(github): add @qqqys as core package codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /.github/workflows/security-checks.yml  @pomelo-nwu @wenshao
 
 # --- Core package ---
-/packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan @doudouOUC
+/packages/core/        @wenshao @tanzhenxin @yiliang114 @LaZzyMan @doudouOUC @qqqys
 
 # --- CUA Driver & Mobile MCP ---
 /packages/cua-driver/  @LaZzyMan


### PR DESCRIPTION
## What this PR does

Adds @qqqys to the codeowner list of the core package, so core reviews are also routed to them.

## Why it's needed

@qqqys has been a heavy and sustained contributor to the core package — 86 commits touching `packages/core/` over the past 6 months, ranking among the top contributors there (more than some current codeowners). Adding them spreads review load and reflects actual ownership.

## Reviewer Test Plan

### How to verify

Confirm the one-line diff only appends `@qqqys` to the core package entry, and that GitHub recognizes the owner (no "unknown owner" warning on the PR files tab after merge).

### Evidence (Before & After)

N/A (repository metadata change, not user-visible).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: one more required-reviewer candidate for core PRs; owners are OR-ed, so any single owner's approval still suffices.
- Not validated / out of scope: no other ownership entries are changed.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

本 PR 将 @qqqys 加入 core 包的 codeowner 列表，使 core 的 review 也会分派给他。

@qqqys 近 6 个月在 `packages/core/` 有 86 个 commit，是 core 的头部贡献者之一（超过部分现有 codeowner）。加入后可以分摊 review 压力，也更符合实际 ownership。

验证方式：确认 diff 只有一行，仅在 core 包条目末尾追加 `@qqqys`，合并后 GitHub 不报 unknown owner。

风险与范围：owner 之间是 OR 关系，任一 owner approve 即可，不会提高合并门槛；未改动其他条目；无 breaking change。

</details>
