### PR TITLE
test(cli): teach session-swap telemetry fakes the /branch title prerequisites

### DIFF
--- a/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
+++ b/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
@@ -183,6 +183,7 @@ function makeFakeEnv() {
         return { filePath: `/tmp/${to}.jsonl`, copiedCount: 2 };
       }),
     loadSession: async (id: string) => sessionServiceMocks.sessions.get(id),
+    getSessionDisplayName: vi.fn().mockResolvedValue(undefined),
     // Realistic like SessionService.removeSession (deletes the fork JSONL):
     // the branch hook calls it in exactly the failure path these tests
     // drive (forkCreated && !uiSwapped), so the fork must not survive in
@@ -209,6 +210,7 @@ function makeFakeEnv() {
       finalize: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
       rebuildTurnBoundaries: vi.fn(),
+      getCurrentCustomTitle: vi.fn().mockReturnValue(undefined),
     }),
     getSessionService: () => sessionService,
     getGoalRuntimeReady: vi.fn().mockResolvedValue({}),


### PR DESCRIPTION
## What this PR does

Completes the fake environment used by the session-swap telemetry regression tests added in #9844: the fake recording service and session service gain the two title-related methods the real services have had since the branch-title work — the outgoing recorder's current custom title and the source session's display name. With those stubs in place, the three /branch scenarios drive the intended fork/swap/rollback paths again instead of dying at the first title lookup.

## Why it's needed

The branch-title change that landed just before the regression suite taught /branch to read the outgoing recorder's custom title (and fall back to the source session's display name) before forking the JSONL. The regression PR branched from a base without that change, so its fake environment only stubs the recorder's finalize/flush and the session service's fork/load/remove/rename/title-prefix methods. Once both landed on main, every /branch scenario threw a "not a function" error before the fork, and main's CI fails three tests: a failed /branch restores the process-wide aggregate, a successful /branch keeps the replayed usage, and a failure after the UI re-key does not roll back or undo. The /resume scenarios never read those methods, which is why they stayed green. This PR completes the fakes only; no production code changes.

## Reviewer Test Plan

### How to verify

Run the session-swap telemetry regression file from packages/cli at main to observe the same three /branch failures as CI, then apply this change and rerun: the whole file passes (10/10). The /branch and /resume command suites stay green as well.

### Evidence (Before & After)

Before: `Tests  3 failed | 7 passed (10)` — identical to main's CI. After: `Tests  10 passed (10)`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment

N/A — unit tests only; CI covers the remaining platforms.

## Risk & Scope

- Main risk or tradeoff: none expected — test-only change; the added stubs return undefined, matching the state the scenarios assume (no pre-existing custom title or display name), so branch-title derivation still falls back to the first user prompt exactly as the assertions expect.
- Not validated / out of scope: production behavior is untouched.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #9844; the missing fake surface comes from #9764.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

补全 #9844 新增的会话切换 telemetry 回归测试所用的假环境：给假 recording service 和假 session service 补上分支标题功能落地后真实服务早已具备的两个标题相关方法——切出方 recorder 的当前自定义标题、源会话的展示名。补上后，三个 /branch 场景重新走预期的 fork/切换/回滚路径，而不是在第一步标题查询处就抛错。

## 为什么需要

紧邻该回归套件之前合入的分支标题改动让 /branch 在 fork JSONL 之前先读取切出方 recorder 的自定义标题（并回退到源会话展示名）。回归 PR 的分支基线不含该改动，假环境只 mock 了 recorder 的 finalize/flush 和 session service 的 fork/load/remove/rename/标题前缀查询。两者在 main 上汇合后，所有 /branch 场景在 fork 之前就抛 “not a function”，main 的 CI 因此挂三个用例：a failed /branch restores the process-wide aggregate、a successful /branch keeps the replayed usage、a failure after the UI re-key does not roll back or undo。/resume 场景不读这两个方法，所以一直绿。本 PR 只补假环境，不改任何生产代码。

### 如何验证

在 packages/cli 下于 main 跑该回归文件，复现与 CI 一致的三个 /branch 失败；应用本改动后重跑，整文件通过（10/10），/branch 与 /resume 命令套件同样保持绿。

### 证据（改动前后）

改动前：`Tests  3 failed | 7 passed (10)`，与 main CI 一致。改动后：`Tests  10 passed (10)`。

### 测试平台

macOS ✅；Windows / Linux 交由 CI（⚠️）。

### 环境

N/A —— 纯单测。

## 风险与范围

- 主要风险：预期无。仅测试改动；新增 stub 返回 undefined，与场景假设的初始状态（没有既有自定义标题或展示名）一致，分支标题推导仍按断言预期回退到首条用户 prompt。
- 未验证 / 超出范围：生产行为未触碰。
- 破坏性变更：无。

## 关联 Issue

#9844 的后续修复；缺失的假接口来自 #9764。

</details>
