### PR TITLE
feat(skills): add repository knowledge lifecycle

### DIFF
--- a/.qwen/skills/bugfix/SKILL.md
+++ b/.qwen/skills/bugfix/SKILL.md
@@ -103,6 +103,13 @@ with a verdict:
 After fixing valid issues, re-run unit tests and a quick verification sanity
 check.
 
+## Step 7: Knowledge Closeout
+
+Run `/knowledge-lifecycle` before declaring the fix complete. Route only facts
+introduced or changed by this work, update repository files that are in scope,
+and leave GitHub mutations as proposals unless they are explicitly authorized.
+Do not create a closeout artifact when no knowledge should persist.
+
 ## Iteration Rules
 
 - If Step 4 fails, go back to Step 3, then re-run Step 4.

--- a/.qwen/skills/feat-dev/SKILL.md
+++ b/.qwen/skills/feat-dev/SKILL.md
@@ -131,7 +131,16 @@ After fixes, re-run unit tests and a quick E2E sanity check.
 
 Output: clean implementation with valid review findings addressed.
 
-## Phase 8: Wrap Up
+## Phase 8: Knowledge Closeout
+
+Run `/knowledge-lifecycle` before declaring the feature complete. Route only
+facts introduced or changed by this work, update repository files that are in
+scope, and leave GitHub mutations as proposals unless they are explicitly
+authorized. Do not create a closeout artifact when no knowledge should persist.
+
+Output: canonical sources updated, or an explicit no-persistence result.
+
+## Phase 9: Wrap Up
 
 Skip unless the user asks. Create the branch, commit with Conventional Commits,
 push, and create a draft PR using the project PR template. Post E2E results as a

--- a/.qwen/skills/knowledge-lifecycle/SKILL.md
+++ b/.qwen/skills/knowledge-lifecycle/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: knowledge-lifecycle
+description: Route Qwen Code repository knowledge to its canonical artifact
+  before, during, and after development work. Use for source-of-truth discovery,
+  knowledge closeout, durable knowledge promotion, or compact handoffs; do not
+  use it as a general note-taking or memory-dump workflow.
+---
+
+# Repository Knowledge Lifecycle
+
+Keep one canonical source for each fact. Other artifacts may summarize it only
+when they also point to that source.
+
+## Modes
+
+- **Analyze-only** is the default for audits, reviews, and unclear write scope.
+  Report recommended updates without changing repository or GitHub state.
+- **Explicit-write** applies when the user asked for an implementation or
+  documentation change and the proposed file updates are within that scope.
+  GitHub issues, pull requests, projects, and comments still require explicit
+  authorization before each workflow that mutates them.
+
+## Before Work
+
+1. Identify the task and affected paths.
+2. Read the applicable `AGENTS.md` files and path-scoped rules.
+3. Find current documentation, durable design records, and active GitHub or
+   implementation-plan context relevant to those paths.
+4. Verify drift-prone claims against current code, tests, schemas, and
+   configuration before treating them as current facts.
+5. Keep stable pointers to the sources you use. Do not copy their full content
+   into a new note.
+
+If sources conflict, report the conflict. Do not silently choose the newest file
+or assume that current implementation overrides an accepted contract.
+
+## Route Knowledge
+
+| Knowledge | Canonical artifact | Update or retire when |
+| --- | --- | --- |
+| Recurring repository or path-specific working agreement | The nearest applicable `AGENTS.md` or path-scoped rule | The agreement changes or no longer recurs |
+| Current user or developer behavior | Current documentation | Shipped behavior changes; replace stale guidance |
+| Durable rationale or a hard-to-reverse decision | Design document, RFC, or ADR | A later decision supersedes it; retain a pointer to the replacement |
+| Active scope, ownership, progress, discussion, or blockers | GitHub issue, project, pull request, or active implementation plan | Work advances, closes, or is abandoned |
+| Behavior that must remain true | Test, schema, lint rule, hook, or CI check | The invariant changes or is intentionally removed |
+| Operational, migration, deprecation, or release knowledge | The relevant runbook or lifecycle document | The process or supported lifecycle changes |
+| Short-lived investigation or handoff | A temporary `.qwen/` work artifact | Its stated expiry condition is met |
+
+Do not create a new artifact when an existing canonical source should be
+updated. Do not add a manually maintained index merely to repeat the repository
+tree.
+
+## During Work
+
+- Update only the artifacts that own changed facts.
+- Use short summaries and stable pointers when another artifact needs context.
+- Put dynamic status in GitHub, not in durable documentation.
+- Put enforceable behavior in executable artifacts when practical; prose alone
+  is not the canonical source for an invariant.
+- Keep investigations and transcripts temporary unless closeout identifies a
+  durable fact worth promoting.
+
+## Knowledge Closeout
+
+Before declaring work complete, inspect the actual diff and verified results,
+then decide:
+
+1. Did current behavior change? Update current documentation and the executable
+   constraint that should preserve it.
+2. Was a durable decision made? Update or add its design record and point from
+   any superseded record.
+3. Did a working agreement prove recurring? Update the narrowest applicable
+   instruction file; do not promote task-specific advice.
+4. Did active scope or status change? Propose the GitHub update and perform it
+   only with explicit authorization.
+5. Was operational knowledge discovered? Update the owning runbook or lifecycle
+   document.
+6. Is the information useful only for the current task? Leave it temporary or
+   discard it when its expiry condition is met.
+
+Report the result as a compact list of `source -> action -> pointer`. If no
+knowledge should persist, say so instead of creating an empty closeout artifact.
+
+## Handoff
+
+When another agent or person must continue the work, provide only:
+
+- **Base commit:** the exact commit the verified state is based on.
+- **Verified state:** what was checked and the observed result.
+- **Blockers:** unresolved conditions, or `None`.
+- **First next action:** one concrete action that can resume progress.
+- **Expires when:** the condition that makes this handoff stale.
+- **Canonical pointers:** links or paths to the owning issue, plan, design,
+  documentation, tests, or runbook.
+
+Do not copy specifications, issue discussions, or conversation history into the
+handoff.
+
+## Routing Examples
+
+- **Small bug fix:** the regression test owns the invariant. Update user docs
+  only if documented behavior changed; keep progress in the issue or pull
+  request.
+- **Behavior-changing feature:** current docs describe the shipped behavior,
+  tests enforce it, and a design record holds only durable rationale.
+- **Durable design decision:** record the decision and alternatives in the
+  design document or ADR; mark an older decision as superseded with a pointer.
+- **Long-running implementation:** keep ownership, progress, and blockers in the
+  active issue, project, or plan; handoffs point there instead of copying it.
+- **Operational discovery:** update the runbook, migration, deprecation, or
+  release document that owns the process; do not bury it in a task transcript.

--- a/.qwen/skills/knowledge-lifecycle/SKILL.md
+++ b/.qwen/skills/knowledge-lifecycle/SKILL.md
@@ -36,15 +36,15 @@ or assume that current implementation overrides an accepted contract.
 
 ## Route Knowledge
 
-| Knowledge | Canonical artifact | Update or retire when |
-| --- | --- | --- |
-| Recurring repository or path-specific working agreement | The nearest applicable `AGENTS.md` or path-scoped rule | The agreement changes or no longer recurs |
-| Current user or developer behavior | Current documentation | Shipped behavior changes; replace stale guidance |
-| Durable rationale or a hard-to-reverse decision | Design document, RFC, or ADR | A later decision supersedes it; retain a pointer to the replacement |
-| Active scope, ownership, progress, discussion, or blockers | GitHub issue, project, pull request, or active implementation plan | Work advances, closes, or is abandoned |
-| Behavior that must remain true | Test, schema, lint rule, hook, or CI check | The invariant changes or is intentionally removed |
-| Operational, migration, deprecation, or release knowledge | The relevant runbook or lifecycle document | The process or supported lifecycle changes |
-| Short-lived investigation or handoff | A temporary `.qwen/` work artifact | Its stated expiry condition is met |
+| Knowledge                                                  | Canonical artifact                                                 | Update or retire when                                               |
+| ---------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| Recurring repository or path-specific working agreement    | The nearest applicable `AGENTS.md` or path-scoped rule             | The agreement changes or no longer recurs                           |
+| Current user or developer behavior                         | Current documentation                                              | Shipped behavior changes; replace stale guidance                    |
+| Durable rationale or a hard-to-reverse decision            | Design document, RFC, or ADR                                       | A later decision supersedes it; retain a pointer to the replacement |
+| Active scope, ownership, progress, discussion, or blockers | GitHub issue, project, pull request, or active implementation plan | Work advances, closes, or is abandoned                              |
+| Behavior that must remain true                             | Test, schema, lint rule, hook, or CI check                         | The invariant changes or is intentionally removed                   |
+| Operational, migration, deprecation, or release knowledge  | The relevant runbook or lifecycle document                         | The process or supported lifecycle changes                          |
+| Short-lived investigation or handoff                       | A temporary `.qwen/` work artifact                                 | Its stated expiry condition is met                                  |
 
 Do not create a new artifact when an existing canonical source should be
 updated. Do not add a manually maintained index merely to repeat the repository

--- a/docs/design/repository-knowledge-lifecycle-skill.md
+++ b/docs/design/repository-knowledge-lifecycle-skill.md
@@ -1,0 +1,45 @@
+# Repository Knowledge Lifecycle Skill
+
+Status: accepted for exploration in
+[issue #9781](https://github.com/QwenLM/qwen-code/issues/9781).
+
+## Problem
+
+Qwen Code has instructions, current documentation, design records, active
+GitHub state, executable constraints, and temporary work artifacts. Existing
+workflows can update several of these, but they do not share a small decision
+process for choosing the canonical destination of newly learned information or
+retiring stale knowledge.
+
+The result can be duplicated facts, durable documents containing temporary
+status, and handoffs that depend on conversation history.
+
+## Decision
+
+Add a project-level `knowledge-lifecycle` skill that:
+
+- discovers applicable sources before work and verifies drift-prone claims;
+- routes each fact according to its lifecycle instead of creating a new store;
+- defaults to analyze-only behavior and distinguishes authorized file edits
+  from separately authorized GitHub mutations;
+- performs a lightweight closeout before feature and bug-fix workflows finish;
+- defines a compact handoff containing state and canonical pointers rather than
+  copied specifications.
+
+The feature and bug-fix skills invoke the closeout at the end of their existing
+verification and review phases. They keep ownership of implementation and
+testing; the new skill owns only the routing decision.
+
+## Scope
+
+The first version changes project workflow instructions only. It does not add
+production code, a generated index, a storage system, automatic journaling, or
+automatic GitHub writes. It does not migrate existing design documents or
+plans.
+
+## Validation
+
+Validate the new skill's frontmatter and structure with the skill validator,
+then inspect each representative routing example against the decision table.
+Review the workflow changes to confirm they add one bounded closeout step and
+do not replace existing feature or bug-fix verification.


### PR DESCRIPTION
## What this PR does

This PR adds a project-level knowledge lifecycle skill that routes repository knowledge to the artifact matching its lifecycle, keeps one canonical source per fact, and distinguishes analyze-only behavior from authorized writes. It also adds a bounded knowledge-closeout step to the existing feature and bug-fix workflows, plus a short design record for the accepted v1 decisions and scope.

## Why it's needed

Qwen Code already has instructions, current documentation, design records, GitHub state, executable constraints, and temporary work artifacts, but its development workflows do not share a decision process for choosing which source should own newly learned information. The new skill reduces duplicated facts, stale handoffs, and temporary status leaking into durable documentation without introducing a new store or index.

## Reviewer Test Plan

### How to verify

1. Run `npm run preflight` in the full source tree.
2. Start Qwen Code `0.22.0` with local Ollama `qwen3:8b`, then test both plan mode and explicit `/knowledge-lifecycle` invocation against the four-file fixture.
3. Compare fixture hashes before and after each run.

### Results

- **Preflight: not fully green.** `format`, `lint`, `build`, and `typecheck` passed. CLI tests finished with 24 files passed and 1 failed: `AuthDialog.test.tsx` has a stable MiniMax navigation assertion failure unrelated to this documentation-only diff. Core tests initially had 10 failures because the source tree lacked `.git`; after restoring Git metadata, the targeted `gitUtils.test.ts` rerun passed 12/12.
- **Plan mode / read-only boundary: passed.** `skill` and `read_file` were registered; write tools were not registered; fixture hashes did not change.
- **Automatic Skill routing: not passed.** The model read 3/4 fixture files, did not invoke `knowledge-lifecycle`, and the session ended before the fourth file. This is not claimed as a successful end-to-end routing verification.
- **Explicit invocation / write boundary: passed.** With `/knowledge-lifecycle` plus auto-edit, the first edit was rejected because the file had not yet been read. After reading, Qwen Code changed only `current-behavior.md` (`--dry-run` → `--preview`), reread it successfully, and all other fixture hashes remained unchanged.
- Fixture files were restored after the test; the local `qwen3:8b` model was removed.

### Evidence (Before & After)

N/A — project workflow documentation only; no user-facing UI or runtime behavior changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Qwen Code `0.22.0`, and a temporary local Ollama `qwen3:8b` model. The model was deleted after verification.

## Risk & Scope

- Main risk or tradeoff: Agents could over-persist task-specific information; the skill mitigates this with analyze-only default behavior, one canonical source per fact, explicit retirement rules, and an allowed no-persistence result.
- Not fully validated / out of scope: Automatic Skill routing remains unverified in the tested local-model session; migration of existing design documents and plans, generated indexes, storage systems, automatic journaling, and automatic GitHub writes remain out of scope.
- Breaking changes / migration notes: None. This changes project development guidance only.

## Linked Issues

Fixes #9781

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 新增一个项目级知识生命周期 Skill，根据信息生命周期将仓库知识路由到正确工件，确保一条事实只有一个权威来源，并区分只读分析与已授权写入。同时，它在现有 Feature 与 Bug 修复流程中加入一个有边界的知识收尾步骤，并用一份简短设计记录保存第一版已接受的决策和范围。

## 为什么需要它

Qwen Code 已有工作指令、当前文档、设计记录、GitHub 状态、可执行约束和临时工作工件，但开发流程之间缺少一套共同的判断机制，用于决定新获得的信息应该由哪个来源负责。新 Skill 在不引入新存储或新索引的前提下，减少重复事实、过期交接以及临时状态进入长期文档的问题。

## Reviewer Test Plan

### 如何验证

1. 在完整源码树中运行 `npm run preflight`。
2. 使用 Qwen Code `0.22.0` 与本地 Ollama `qwen3:8b`，针对四文件 fixture 分别测试 plan 模式和显式 `/knowledge-lifecycle` 调用。
3. 对比每次运行前后的 fixture 哈希。

### 结果

- **Preflight：未全绿。** `format`、`lint`、`build`、`typecheck` 通过。CLI 测试为 24 个文件通过、1 个失败：`AuthDialog.test.tsx` 存在稳定的 MiniMax 导航断言失败，与本次纯文档 diff 无关。Core 测试最初因源码树缺少 `.git` 出现 10 个失败；恢复 Git 元数据后，定向复跑 `gitUtils.test.ts` 为 12/12 通过。
- **Plan 模式／只读边界：通过。** 已注册 `skill` 与 `read_file`，未注册写工具；fixture 哈希未变化。
- **自动 Skill 路由：未通过。** 模型读取了 3/4 个 fixture 文件，没有调用 `knowledge-lifecycle`，并在读取第 4 个文件前结束。本 PR 不把它表述为端到端路由验证成功。
- **显式调用／写入边界：通过。** 使用 `/knowledge-lifecycle` 加 auto-edit 时，首次编辑因尚未读取文件被拒绝；读取后，Qwen Code 只修改了 `current-behavior.md`（`--dry-run` → `--preview`），复读成功，其他 fixture 哈希均未变化。
- 测试后已恢复 fixture 文件，并删除本地 `qwen3:8b` 模型。

### 前后证据

N/A——仅修改项目工作流文档，没有用户可见 UI 或运行时行为变化。

### 已测试系统

| 系统 | 状态 |
| :--: | :--: |
| macOS | ✅ |
| Windows | ⚠️ |
| Linux | ⚠️ |

### 环境

macOS、Qwen Code `0.22.0`，以及临时使用的本地 Ollama `qwen3:8b` 模型。验证完成后已删除该模型。

## 风险与范围

- 主要风险或权衡：Agent 可能过度持久化任务特定信息；Skill 通过默认只读分析、一条事实一个权威来源、明确退休规则和允许“不持久化”结果来降低风险。
- 未完全验证或不在范围内：在本地模型会话中，自动 Skill 路由仍未验证通过；迁移已有设计文档与计划、生成索引、存储系统、自动日志及自动 GitHub 写入仍不在本 PR 范围内。
- 破坏性变更或迁移说明：无。该 PR 只修改项目开发指导。

## 关联 Issue

Fixes #9781

</details>