### PR TITLE
fix(web-shell): allow reasoning selection before session creation

### DIFF
--- a/docs/design/webshell-qwen38-reasoning-config.md
+++ b/docs/design/webshell-qwen38-reasoning-config.md
@@ -4,7 +4,8 @@
 
 Expose Thinking and effort controls for the exact `qwen3.8-max` model in the
 WebShell model popover, including the welcome state before a lazy session is
-created. Acknowledged changes apply only to subsequent live-session requests.
+created. A welcome selection applies to that lazy session before its first
+prompt; acknowledged live changes apply only to subsequent requests.
 
 ## Design
 
@@ -29,7 +30,8 @@ capability.
 WebShell applies the following priority:
 
 1. When both `sessionId` and session context are absent, it may render the
-   selected model's workspace preview. The suffix and controls are read-only.
+   selected model's workspace preview. The controls update a local, one-shot
+   intent bound to that exact model.
 2. Once a session id is allocated but its context has not arrived, WebShell
    hides the preview.
 3. Once context for that session arrives, its `currentValue`, options, and
@@ -39,18 +41,27 @@ WebShell applies the following priority:
 The welcome preview deliberately does not create an empty session. Hosts such
 as DataWorks use lazy creation so the first prompt can create or adopt the
 real daemon session; pre-creating one would change that contract and leave
-empty sessions behind. The preview is display-only: it does not persist,
-queue, or apply a selection before session creation.
+empty sessions behind. Selecting a welcome effort only records local intent.
+The first prompt creates and attaches the session, sets the selected model,
+applies the effort through the live config-option mutation, and then submits
+the prompt. A model or effort mutation that cannot be confirmed fails closed:
+WebShell releases the unused session, keeps the composer and intent available
+for retry, and does not send the prompt.
+
+The intent is cleared after successful preparation or after an unrelated
+session is attached. It is not a workspace default and is never persisted or
+broadcast. If the user changes models before submission, the model-bound
+intent is not applied to the other model.
 
 WebShell retains PR #8675's interaction design: the current reasoning state is
 shown as a suffix on the model chip, reasoning options occupy the first model
 popover, and model search is opened from its Model submenu.
 
-Selecting `none` writes `reasoning: false` to the current session's live
-generator configuration. Selecting an effort writes that effort and enables
-reasoning. Reading the manifest does not inject a default into generation
-configuration, so sessions that never use the controls retain main's existing
-wire behavior.
+Selecting `none` applies Thinking off to the next lazy session or the current
+live session. Selecting an effort applies that effort and enables reasoning.
+Reading the manifest alone does not inject a default into generation
+configuration, so sessions that never change the controls retain main's
+existing wire behavior.
 
 If the live session already carries a generic effort outside the manifest
 (`high` or `max`), ACP preserves that value through its existing generic
@@ -68,7 +79,9 @@ added.
 Included:
 
 - exact stable `qwen3.8-max` only;
-- a read-only welcome preview with `xhigh` as the manifest default;
+- an editable, one-shot welcome preview with `xhigh` as the manifest default;
+- application after lazy attach and model selection but before the first
+  prompt;
 - authoritative replacement by same-session context;
 - the current WebShell conversation;
 - Thinking on/off and `low`, `medium`, `xhigh` effort;
@@ -79,7 +92,7 @@ Excluded:
 
 - persistence across sessions or restarts;
 - persisted/default-model semantics;
-- saving or queueing welcome-state effort changes;
+- workspace-level, reusable, or cross-client reasoning defaults;
 - preview, aliases, and future reasoning-control shapes;
 - route and runtime models;
 - TUI, channel, provider, auth-refresh, and runtime-snapshot behavior;

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1234,6 +1234,12 @@ type SessionActionsWithCreate = {
   releaseSession: (sessionId: string) => Promise<void>;
 };
 
+type PendingReasoningIntent = {
+  modelId: string;
+  value: string;
+  effort: string;
+};
+
 const emptyComposerApi: WebShellComposerApi = {
   insertText: () => {},
   setText: () => {},
@@ -5712,6 +5718,17 @@ export function App({
     currentModelRef.current = modelId;
     setCurrentModel(modelId);
   }, []);
+  const [pendingReasoningIntent, setPendingReasoningIntentState] = useState<
+    PendingReasoningIntent | undefined
+  >(undefined);
+  const pendingReasoningIntentRef = useRef(pendingReasoningIntent);
+  const setPendingReasoningIntent = useCallback(
+    (intent: PendingReasoningIntent | undefined) => {
+      pendingReasoningIntentRef.current = intent;
+      setPendingReasoningIntentState(intent);
+    },
+    [],
+  );
   const connectionRef = useRef(connection);
   connectionRef.current = connection;
   /**
@@ -5847,6 +5864,14 @@ export function App({
     null,
   );
   const preparingSessionIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      connection.sessionId &&
+      connection.sessionId !== preparingSessionIdRef.current
+    ) {
+      setPendingReasoningIntent(undefined);
+    }
+  }, [connection.sessionId, setPendingReasoningIntent]);
   const allocatedSessionCatalogOwnerRef = useRef<
     | {
         sessionId: string;
@@ -5908,6 +5933,18 @@ export function App({
       let allocatedSessionId: string | undefined;
       const modelId =
         currentModelRef.current || connectionRef.current.currentModel;
+      const reasoningIntent = pendingReasoningIntentRef.current;
+      const reasoningPreview = connectionRef.current.models?.find(
+        (model) => model.id === modelId,
+      )?.reasoningPreview;
+      const reasoningEffort =
+        reasoningIntent &&
+        reasoningIntent.modelId === modelId &&
+        reasoningPreview &&
+        (reasoningIntent.value === 'none' ||
+          reasoningPreview.efforts.includes(reasoningIntent.value))
+          ? reasoningIntent.value
+          : undefined;
       const modeId =
         currentModeRef.current || connectionRef.current.currentMode;
       const primaryWorkspaceCwd = ordinaryWorkspaces.find(
@@ -5934,6 +5971,7 @@ export function App({
           sessionActions: sessionActions as typeof sessionActions &
             SessionActionsWithCreate,
           modelId,
+          reasoningEffort,
           modeId,
           workspaceCwd: targetWorkspaceCwd,
           worktree:
@@ -5971,6 +6009,9 @@ export function App({
           // composer chip stays in the selected mode so the user knows
           // the intent was not fulfilled and can retry.
           setGitModeIntent({ mode: 'current' });
+          if (pendingReasoningIntentRef.current === reasoningIntent) {
+            setPendingReasoningIntent(undefined);
+          }
         });
       } catch (error) {
         if (allocatedSessionId && catalogWorkspaceCwd) {
@@ -5997,6 +6038,7 @@ export function App({
     lockedWorkspaceCwd,
     sessionActions,
     sessionCatalogController,
+    setPendingReasoningIntent,
     workspace.workspaceCwd,
     ordinaryWorkspaces,
   ]);
@@ -6411,11 +6453,30 @@ export function App({
     connection.sessionId &&
       connection.context?.sessionId === connection.sessionId,
   );
-  const displayedReasoning = hasAuthoritativeReasoningContext
-    ? connection.reasoning
-    : !connection.sessionId && !connection.context
+  const welcomeReasoningPreview =
+    !connection.sessionId && !connection.context
       ? connection.models?.find((model) => model.id === currentModel)
           ?.reasoningPreview
+      : undefined;
+  const validPendingReasoningIntent =
+    pendingReasoningIntent?.modelId === currentModel &&
+    welcomeReasoningPreview &&
+    (pendingReasoningIntent.value === 'none' ||
+      welcomeReasoningPreview.efforts.includes(pendingReasoningIntent.value))
+      ? pendingReasoningIntent
+      : undefined;
+  const displayedReasoning = hasAuthoritativeReasoningContext
+    ? connection.reasoning
+    : welcomeReasoningPreview
+      ? {
+          ...welcomeReasoningPreview,
+          enabled: validPendingReasoningIntent
+            ? validPendingReasoningIntent.value !== 'none'
+            : welcomeReasoningPreview.enabled,
+          effort:
+            validPendingReasoningIntent?.effort ??
+            welcomeReasoningPreview.effort,
+        }
       : undefined;
   // The workspace the Changes dialog reads — the same active workspace the
   // git-status effect targets (computed once above), so the chip and the
@@ -9421,11 +9482,12 @@ export function App({
             (connectionRef.current.sessionId === admissionOwner.sessionId &&
               getComposerWorkspaceCwd() === admissionOwner.workspaceCwd));
         const { trackSendFailure = false, ...sendOptions } = opts ?? {};
+        const startedWithoutSession = !connectionRef.current.sessionId;
         const deferComposerCommit =
           Boolean(prepareSubmitRef.current || onSubmitBeforeRef.current) ||
           createSessionPromiseRef.current !== null;
         const clearComposerOnPromptStart =
-          !connectionRef.current.sessionId || deferComposerCommit;
+          startedWithoutSession || deferComposerCommit;
         let optimisticUserMessage: OptimisticUserMessage | undefined;
         let submittedPromptText = promptText;
         let submittedInputAnnotations = sendOptions.inputAnnotations;
@@ -9511,6 +9573,17 @@ export function App({
               files: promptFiles,
               inputAnnotations: submittedInputAnnotations,
             });
+          }
+          if (startedWithoutSession && !admissionStarted) {
+            const editor = editorRef.current;
+            if (editor && !editor.hasInput()) {
+              editor.setText(submittedPromptText);
+              if (promptImages?.length) editor.restoreImages(promptImages);
+              if (promptFiles?.length) editor.restoreFiles(promptFiles);
+              if (submittedInputAnnotations?.length) {
+                editor.restoreInputAnnotations?.(submittedInputAnnotations);
+              }
+            }
           }
           reportError(error, errorMessage);
         });
@@ -11115,6 +11188,41 @@ export function App({
         );
     },
     [reportError, sessionActions, sessionWriteBlocked, t],
+  );
+
+  const handleWelcomeReasoningEffort = useCallback(
+    (value: string) => {
+      const activeConnection = connectionRef.current;
+      if (
+        sessionWriteBlockedRef.current ||
+        activeConnection.sessionId ||
+        activeConnection.context
+      ) {
+        return;
+      }
+      const modelId = currentModelRef.current;
+      const preview = activeConnection.models?.find(
+        (model) => model.id === modelId,
+      )?.reasoningPreview;
+      if (!preview) return;
+      const previous = pendingReasoningIntentRef.current;
+      if (value === 'none') {
+        const previousEffort =
+          previous?.modelId === modelId &&
+          preview.efforts.includes(previous.effort)
+            ? previous.effort
+            : preview.effort;
+        setPendingReasoningIntent({
+          modelId,
+          value,
+          effort: previousEffort,
+        });
+        return;
+      }
+      if (!preview.efforts.includes(value)) return;
+      setPendingReasoningIntent({ modelId, value, effort: value });
+    },
+    [setPendingReasoningIntent],
   );
 
   const handleDeleteModel = useCallback(
@@ -13365,7 +13473,9 @@ export function App({
                           onSelectReasoningEffort={
                             hasAuthoritativeReasoningContext
                               ? handleReasoningEffort
-                              : undefined
+                              : welcomeReasoningPreview && !sessionWriteBlocked
+                                ? handleWelcomeReasoningEffort
+                                : undefined
                           }
                           workspaces={composerWorkspaces}
                           selectedWorkspaceCwd={

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -1588,13 +1588,30 @@ async function handleDaemonRoute(
         await badRequest(route, 'Invalid config-option request.');
         return;
       }
-      const configOptions = Array.isArray(scenario.state.configOptions)
-        ? scenario.state.configOptions.map((option) =>
-            isRecord(option) && option['id'] === configId
-              ? { ...option, currentValue: value }
-              : option,
-          )
+      const currentConfigOptions = Array.isArray(scenario.state.configOptions)
+        ? scenario.state.configOptions
         : [];
+      const reasoningOption = currentConfigOptions.find(
+        (option) => isRecord(option) && option['id'] === configId,
+      );
+      const allowedValues = isRecord(reasoningOption)
+        ? reasoningOption['options']
+        : undefined;
+      if (
+        !Array.isArray(allowedValues) ||
+        !allowedValues.some(
+          (option) =>
+            isRecord(option) && readStringField(option, 'value') === value,
+        )
+      ) {
+        await badRequest(route, 'Unsupported config-option value.');
+        return;
+      }
+      const configOptions = currentConfigOptions.map((option) =>
+        isRecord(option) && option['id'] === configId
+          ? { ...option, currentValue: value }
+          : option,
+      );
       scenario.state.configOptions = configOptions;
       await json(route, { configOptions });
       return;

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -354,16 +354,32 @@ test('previews qwen3.8-max reasoning before lazy session creation @smoke', async
   ).toBeChecked();
   await expect(
     controls.locator('[data-web-shell-thinking-toggle]'),
-  ).toBeDisabled();
-  await expect(
-    controls.locator('[data-web-shell-effort="low"]'),
-  ).toBeDisabled();
-  await expect(
-    controls.locator('[data-web-shell-effort="medium"]'),
-  ).toBeVisible();
+  ).toBeEnabled();
+  await expect(controls.locator('[data-web-shell-effort="low"]')).toBeEnabled();
+  const medium = controls.locator('[data-web-shell-effort="medium"]');
+  await expect(medium).toBeEnabled();
   await expect(
     controls.locator('[data-web-shell-effort="xhigh"]'),
   ).toBeVisible();
+  await medium.click();
+  await expect(medium).toHaveAttribute('aria-pressed', 'true');
+  await expect(modelButton).toContainText('qwen3.8-max · Medium');
+  const thinking = controls.locator('[data-web-shell-thinking-toggle]');
+  await thinking.click();
+  await expect(thinking).not.toBeChecked();
+  await expect(medium).toBeDisabled();
+  await expect(medium).toHaveAttribute('aria-pressed', 'true');
+  await expect(modelButton).toContainText('qwen3.8-max · Thinking Off');
+  await thinking.click();
+  await expect(thinking).toBeChecked();
+  await expect(medium).toBeEnabled();
+  await expect(modelButton).toContainText('qwen3.8-max · Medium');
+  expect(daemon.configOptionRequests()).toHaveLength(0);
+  expect(
+    daemon.requests.filter(
+      (request) => request.method === 'POST' && request.path === '/session',
+    ),
+  ).toHaveLength(0);
   await page.locator('[data-web-shell-model-submenu-trigger]').click();
   await page
     .locator('[data-web-shell-model-submenu]')
@@ -394,7 +410,7 @@ test('previews qwen3.8-max reasoning before lazy session creation @smoke', async
     .locator('[data-web-shell-toolbar-popover]:visible')
     .getByRole('button', { name: 'qwen3.8-max', exact: true })
     .click();
-  await expect(modelButton).toContainText('qwen3.8-max · Extra High');
+  await expect(modelButton).toContainText('qwen3.8-max · Medium');
   expect(
     daemon.requests.filter(
       (request) => request.method === 'POST' && request.path === '/session',
@@ -412,12 +428,153 @@ test('previews qwen3.8-max reasoning before lazy session creation @smoke', async
         ).length,
     )
     .toBe(1);
-  await expect(modelButton).toContainText('qwen3.8-max · Thinking Off');
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(1);
+  expect(
+    requestBodyRecord(firstRequest(daemon.configOptionRequests())),
+  ).toEqual({
+    configId: 'reasoning_effort',
+    value: 'medium',
+  });
+  await expect.poll(() => daemon.promptRequests().length).toBe(1);
+  const configRequestIndex = daemon.requests.findIndex(
+    (request) =>
+      request.method === 'POST' &&
+      /\/session\/[^/]+\/config-option$/.test(request.path),
+  );
+  const promptRequestIndex = daemon.requests.findIndex(
+    (request) =>
+      request.method === 'POST' &&
+      /\/session\/[^/]+\/prompt\/?$/.test(request.path),
+  );
+  expect(configRequestIndex).toBeGreaterThanOrEqual(0);
+  const modelRequestIndex = daemon.requests.findIndex(
+    (request) =>
+      request.method === 'POST' &&
+      /\/session\/[^/]+\/model$/.test(request.path),
+  );
+  expect(modelRequestIndex).toBeGreaterThanOrEqual(0);
+  expect(modelRequestIndex).toBeLessThan(configRequestIndex);
+  expect(configRequestIndex).toBeLessThan(promptRequestIndex);
+  await expect(modelButton).toContainText('qwen3.8-max · Medium');
   await modelButton.click();
-  await expect(
-    page.locator('[data-web-shell-thinking-toggle]'),
-  ).not.toBeChecked();
+  await expect(page.locator('[data-web-shell-thinking-toggle]')).toBeChecked();
   await expect(page.locator('[data-web-shell-thinking-toggle]')).toBeEnabled();
+  await expect(
+    page.locator('[data-web-shell-effort="medium"]'),
+  ).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('does not apply a model-bound welcome effort after switching models @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    currentModel: 'qwen3.8-max',
+    state: { configOptions: [], models: undefined },
+    providers: {
+      providers: [
+        {
+          kind: 'model_provider',
+          status: 'ok',
+          authType: 'qwen-oauth',
+          current: true,
+          models: [
+            {
+              modelId: 'qwen3.8-max',
+              baseModelId: 'qwen3.8-max',
+              name: 'qwen3.8-max',
+              isCurrent: true,
+              isRuntime: false,
+              configOptions: qwen38ReasoningConfigOptions(),
+            },
+            {
+              modelId: 'qwen-plus',
+              baseModelId: 'qwen-plus',
+              name: 'qwen-plus',
+              isCurrent: false,
+              isRuntime: false,
+            },
+          ],
+        },
+      ],
+    },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoEmptyMobileWelcomeHarness(page);
+
+  const modelButton = page.locator('[data-web-shell-model-button]');
+  await modelButton.click();
+  await page.locator('[data-web-shell-effort="medium"]').click();
+  await page.locator('[data-web-shell-model-submenu-trigger]').click();
+  await page
+    .locator('[data-web-shell-model-submenu]')
+    .getByRole('button', { name: 'qwen-plus', exact: true })
+    .click();
+  await expect(modelButton).toContainText('qwen-plus');
+  await expect(modelButton).not.toContainText('Medium');
+
+  await page.keyboard.press('Escape');
+  await fillComposer(page, 'Use the non-reasoning model');
+  await page.locator('[data-web-shell-composer-submit]').click();
+
+  await expect.poll(() => daemon.promptRequests().length).toBe(1);
+  expect(daemon.configOptionRequests()).toHaveLength(0);
+});
+
+test('cancels the first prompt when live reasoning capability is missing @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    currentModel: 'qwen3.8-max',
+    state: { configOptions: [], models: undefined },
+    providers: {
+      providers: [
+        {
+          kind: 'model_provider',
+          status: 'ok',
+          authType: 'qwen-oauth',
+          current: true,
+          models: [
+            {
+              modelId: 'qwen3.8-max',
+              baseModelId: 'qwen3.8-max',
+              name: 'qwen3.8-max',
+              isCurrent: true,
+              isRuntime: false,
+              configOptions: qwen38ReasoningConfigOptions(),
+            },
+          ],
+        },
+      ],
+    },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoEmptyMobileWelcomeHarness(page);
+
+  const modelButton = page.locator('[data-web-shell-model-button]');
+  await modelButton.click();
+  await page.locator('[data-web-shell-effort="medium"]').click();
+  await page.keyboard.press('Escape');
+  const prompt = 'Keep this prompt for retry';
+  await fillComposer(page, prompt);
+  await page.locator('[data-web-shell-composer-submit]').click();
+
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(1);
+  await expect(
+    page.locator('[data-web-shell-composer-editor] .cm-content'),
+  ).toContainText(prompt);
+  await expect(modelButton).toContainText('qwen3.8-max · Medium');
+  expect(daemon.promptRequests()).toHaveLength(0);
+
+  scenario.state.configOptions = qwen38ReasoningConfigOptions('none');
+  await page.locator('[data-web-shell-composer-submit]').click();
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(2);
+  expect(requestBodyRecord(daemon.configOptionRequests()[1]!)).toEqual({
+    configId: 'reasoning_effort',
+    value: 'medium',
+  });
+  await expect.poll(() => daemon.promptRequests().length).toBe(1);
 });
 
 test('does not invent welcome reasoning for an older daemon @smoke', async ({

--- a/packages/web-shell/client/utils/sessionPreparation.test.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.test.ts
@@ -16,6 +16,7 @@ function createActions(
     clearSession: vi.fn(async () => {}),
     releaseSession: vi.fn(async () => {}),
     setModel: vi.fn(async () => modelResult),
+    setReasoningEffort: vi.fn(async () => {}),
     ...overrides,
   };
 }
@@ -63,6 +64,88 @@ describe('createAndAttachSessionForPrompt', () => {
     // Model is still a post-create call, sequenced after attach.
     expect(order).toEqual(['create', 'attach', 'model']);
     expect(actions.setModel).toHaveBeenCalledWith('qwen3');
+  });
+
+  it('applies an explicit reasoning effort after the model and before resolving', async () => {
+    const order: string[] = [];
+    const actions = createActions({
+      createSession: vi.fn(async () => {
+        order.push('create');
+        return sessionResult;
+      }),
+      attachSession: vi.fn(async () => {
+        order.push('attach');
+      }),
+      setModel: vi.fn(async () => {
+        order.push('model');
+        return modelResult;
+      }),
+      setReasoningEffort: vi.fn(async () => {
+        order.push('reasoning');
+      }),
+    });
+
+    await prepareSession({
+      sessionActions: actions,
+      modelId: 'qwen3.8-max',
+      reasoningEffort: 'medium',
+    });
+
+    expect(order).toEqual(['create', 'attach', 'model', 'reasoning']);
+    expect(actions.setReasoningEffort).toHaveBeenCalledWith('medium');
+  });
+
+  it('releases and clears the session when an explicit reasoning effort cannot be applied', async () => {
+    const error = new Error('reasoning failed');
+    const warn = vi.fn();
+    const actions = createActions({
+      setReasoningEffort: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    await expect(
+      prepareSession({
+        sessionActions: actions,
+        modelId: 'qwen3.8-max',
+        reasoningEffort: 'medium',
+        warn,
+      }),
+    ).rejects.toThrow(error);
+
+    expect(actions.releaseSession).toHaveBeenCalledWith('session-1');
+    expect(actions.clearSession).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      '[WebShell] failed to set reasoning effort:',
+      error,
+    );
+  });
+
+  it('fails closed when the target model cannot be set for an explicit reasoning effort', async () => {
+    const error = new Error('model failed');
+    const warn = vi.fn();
+    const actions = createActions({
+      setModel: vi.fn(async () => {
+        throw error;
+      }),
+    });
+
+    await expect(
+      prepareSession({
+        sessionActions: actions,
+        modelId: 'qwen3.8-max',
+        reasoningEffort: 'medium',
+        warn,
+      }),
+    ).rejects.toThrow(error);
+
+    expect(actions.setReasoningEffort).not.toHaveBeenCalled();
+    expect(actions.releaseSession).toHaveBeenCalledWith('session-1');
+    expect(actions.clearSession).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      '[WebShell] failed to set model for new session:',
+      error,
+    );
   });
 
   it('omits approvalMode when the mode is not a recognized daemon approval mode', async () => {

--- a/packages/web-shell/client/utils/sessionPreparation.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.ts
@@ -22,6 +22,7 @@ type PromptSessionActions = {
   clearSession: () => Promise<void>;
   releaseSession: (sessionId: string) => Promise<void>;
   setModel: (modelId: string) => Promise<unknown>;
+  setReasoningEffort: (value: string) => Promise<void>;
 };
 
 export function isDaemonApprovalMode(mode: string): mode is DaemonApprovalMode {
@@ -31,6 +32,7 @@ export function isDaemonApprovalMode(mode: string): mode is DaemonApprovalMode {
 export async function createAndAttachSessionForPrompt({
   sessionActions,
   modelId,
+  reasoningEffort,
   modeId,
   workspaceCwd,
   worktree,
@@ -42,6 +44,7 @@ export async function createAndAttachSessionForPrompt({
 }: {
   sessionActions: PromptSessionActions;
   modelId?: string;
+  reasoningEffort?: string;
   modeId?: string;
   workspaceCwd?: string;
   worktree?: { slug?: string };
@@ -115,6 +118,23 @@ export async function createAndAttachSessionForPrompt({
         `Session changed while attaching: expected ${sessionId}, found ${sessionIdAfterAttach}`,
       );
     }
+
+    // The model is normally best-effort because the composer may already match
+    // the daemon. An explicit model-bound reasoning choice is different: it
+    // must never be applied after a failed switch to an unknown model.
+    if (modelId) {
+      preparationStep = 'set model for new session';
+      try {
+        await sessionActions.setModel(modelId);
+      } catch (error) {
+        if (reasoningEffort) throw error;
+        warn('[WebShell] failed to set model for new session:', error);
+      }
+    }
+    if (reasoningEffort) {
+      preparationStep = 'set reasoning effort';
+      await sessionActions.setReasoningEffort(reasoningEffort);
+    }
   } catch (error) {
     warn(`[WebShell] failed to ${preparationStep}:`, error);
     await sessionActions
@@ -133,15 +153,6 @@ export async function createAndAttachSessionForPrompt({
       );
     }
     throw error;
-  }
-  // The model still needs a post-create call: `POST /session` only accepts a
-  // `modelServiceId`, whereas the composer selects a plain `modelId`. The
-  // `POST /session/:id/model` route now resolves the owning workspace runtime,
-  // so this succeeds for non-primary workspaces too.
-  if (modelId) {
-    await sessionActions.setModel(modelId).catch((error: unknown) => {
-      warn('[WebShell] failed to set model for new session:', error);
-    });
   }
   return {
     ...(worktreeInfo ? { worktree: worktreeInfo } : {}),

--- a/packages/webui/src/daemon/session/actions.test.ts
+++ b/packages/webui/src/daemon/session/actions.test.ts
@@ -2397,6 +2397,52 @@ describe('createDaemonSessionActions', () => {
     });
   });
 
+  it('applies a reasoning effort only when the daemon confirms it', async () => {
+    const session = createMockSession('session-a');
+    session.setConfigOption.mockResolvedValueOnce({
+      configOptions: reasoningConfigOptions('medium'),
+    });
+    const { actions, getConnection } = createActionsHarness({
+      connection: {
+        status: 'connected',
+        sessionId: 'session-a',
+        currentModel: 'qwen3.8-max',
+      },
+      session,
+    });
+
+    await expect(actions.setReasoningEffort('medium')).resolves.toBeUndefined();
+
+    expect(session.setConfigOption).toHaveBeenCalledWith(
+      'reasoning_effort',
+      'medium',
+    );
+    expect(getConnection().reasoning).toEqual({
+      enabled: true,
+      effort: 'medium',
+      efforts: ['low', 'medium', 'xhigh'],
+    });
+  });
+
+  it('rejects a reasoning effort when live config options do not confirm it', async () => {
+    const session = createMockSession('session-a');
+    session.setConfigOption.mockResolvedValueOnce({ configOptions: [] });
+    const { actions, getConnection } = createActionsHarness({
+      connection: {
+        status: 'connected',
+        sessionId: 'session-a',
+        currentModel: 'qwen3.8-max',
+      },
+      session,
+    });
+
+    await expect(actions.setReasoningEffort('medium')).rejects.toThrow(
+      'Daemon did not confirm reasoning effort "medium"',
+    );
+
+    expect(getConnection().reasoning).toBeUndefined();
+  });
+
   it('does not apply a late approval mode to a replacement attachment', async () => {
     const source = createMockSession('session-a', 'client-a');
     const target = createMockSession('session-a', 'client-b');
@@ -2618,6 +2664,9 @@ function createMockSession(
     context: vi.fn(async () => contextStatus(sessionId)),
     detach: vi.fn(async () => undefined),
     setModel: vi.fn(async () => ({})),
+    setConfigOption: vi.fn(async (_configId: string, value: string) => ({
+      configOptions: reasoningConfigOptions(value),
+    })),
     uploadAttachment: vi.fn(
       async (data: Blob, name: string, mimeType: string) => ({
         type: mimeType.startsWith('image/')
@@ -2640,6 +2689,21 @@ function createMockSession(
     goal: vi.fn(),
     controlGoal: vi.fn(),
   };
+}
+
+function reasoningConfigOptions(currentValue: string) {
+  return [
+    {
+      id: 'reasoning_effort',
+      currentValue,
+      options: [
+        { value: 'none' },
+        { value: 'low' },
+        { value: 'medium' },
+        { value: 'xhigh' },
+      ],
+    },
+  ];
 }
 
 function createDeferred<T>() {

--- a/packages/webui/src/daemon/session/actions.ts
+++ b/packages/webui/src/daemon/session/actions.ts
@@ -1096,6 +1096,19 @@ export function createDaemonSessionActions({
           ),
           'Set reasoning effort timed out',
         );
+        const nextReasoning = mapReasoningControls(
+          result.configOptions,
+          getConnection().reasoning?.effort,
+        );
+        const confirmed =
+          value === 'none'
+            ? nextReasoning?.enabled === false
+            : nextReasoning?.enabled === true && nextReasoning.effort === value;
+        if (!confirmed) {
+          throw new Error(
+            `Daemon did not confirm reasoning effort ${JSON.stringify(value)}`,
+          );
+        }
         const current = getConnection();
         if (
           sessionRef.current === session &&
@@ -1115,10 +1128,7 @@ export function createDaemonSessionActions({
             const configOptions = result.configOptions;
             return {
               ...current,
-              reasoning: mapReasoningControls(
-                configOptions,
-                current.reasoning?.effort,
-              ),
+              reasoning: nextReasoning,
               context: current.context
                 ? {
                     ...current.context,


### PR DESCRIPTION
## What this PR does

This PR makes the manifest-backed reasoning controls editable while WebShell is in the lazy welcome state with no session id and no session context. A choice is stored only as a one-shot local intent bound to the selected model; choosing an effort does not create an empty session or send a daemon mutation.

On the first prompt, WebShell creates and attaches the real session, confirms the selected model, applies the pending reasoning effort through the live config-option route, and only then submits the prompt. Once a same-session context exists, its Thinking state, current effort, and available options remain authoritative. Model or config mutations that cannot be confirmed fail closed: the unused session is released, the prompt is not sent, and the draft plus pending choice remain available for retry.

The existing capability boundary is unchanged. Only a model that already carries a valid per-model preview can accept a welcome choice, so preview, alias, dated, runtime, route, unrelated, and old-daemon models do not gain inferred reasoning support.

## Why it's needed

#9599 fixed the missing `qwen3.8-max · Extra High` suffix and exposed Thinking/effort controls before DataWorks lazily creates a session, but that PR deliberately made the welcome preview read-only. As a result, users could see the default yet could not choose Medium, Low, Extra High, or Thinking off for their first prompt.

Pre-creating a session on selection would still break DataWorks' lazy-create/adopt contract and leave empty sessions behind. A one-shot model-bound intent preserves that contract while ensuring the explicit choice is applied to the authoritative live session before any prompt reaches the model.

## Reviewer Test Plan

### How to verify

1. Open the [DataWorks bare welcome route](https://dataworks.data.aliyun.com/cn-chengdu/agent/528dd4604eb149039d5cd741bd80aede/session) with no existing session selected and the exact stable `qwen3.8-max` current. Open the model popover and choose Medium. Confirm the chip changes to `qwen3.8-max · Medium`, Thinking can be toggled off and back on without losing Medium, and no session or config request is created yet.
2. Submit the first prompt. Confirm exactly one session is created and the request order is model selection, reasoning config mutation, then prompt. Confirm the live UI reports Medium from the mutation response.
3. Choose Medium, switch to preview, alias, or another model, and submit. Confirm the target-model intent does not produce a config mutation for the other model.
4. Simulate a daemon whose workspace preview exists but whose live session does not confirm the reasoning option. Confirm the first prompt is cancelled, the unused session is released, the draft and Medium choice remain, and a retry succeeds once capability is available.
5. Attach an existing session and confirm its live context still controls Thinking/effort. Verify old daemons without the optional preview and live contexts without a compatible option do not display invented capability.

### Evidence (Before & After)

| Before: #9599 welcome preview | After: editable lazy-session intent |
| --- | --- |
| `qwen3.8-max · Extra High` and the Thinking/effort rows are visible, but every control is disabled; forced clicks produce no chip change, no config request, and no session. See the [original welcome-preview evidence](https://github.com/QwenLM/qwen-code/pull/9599). | The full local embedding harness selects Medium and toggles Thinking before creation with `POST /session = 0`; the first prompt records `model < config-option(medium) < prompt`. A second harness proves `Thinking Off` records `config-option(none) < prompt`. |

Focused behavior results on the final commit: WebShell reasoning Playwright 7/7; session preparation 19/19; WebUI actions 100/100. Independent post-fix verification additionally passed actions + mappers 137/137, provider reasoning lifecycle 3/3, and two retry/Thinking-off harness cases 2/2. Repository build, root typecheck, package typechecks, lint, and format checks pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node.js 22 monorepo workspace; Chromium Playwright full WebShell embedding harness with a request-ledger mock daemon.

## Risk & Scope

- Main risk or tradeoff: An explicit welcome choice adds one awaited live config mutation before the first prompt. Unknown, rejected, or incompatible confirmation aborts that first prompt instead of silently using a different effort; the draft is retained for retry.
- Not validated / out of scope: Persisting a reasoning choice across sessions or restarts, workspace/default-model settings, TUI or channel behavior, runtime snapshots, provider/auth refresh, and cross-client broadcasts.
- Breaking changes / migration notes: None. No protocol field or session-creation API changes are introduced; old daemons remain fail-closed because an absent preview cannot create an intent and an unconfirmed live mutation cannot admit a prompt.

## Linked Issues

Fixes #10006

Follow-up to #9599 and #9595.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 让 WebShell 在既没有 session id、也没有 session context 的懒创建欢迎态中，可以编辑来自模型 manifest 的 reasoning 控件。选择只会记录为与当前模型精确绑定的一次性本地意图；选择 effort 时不会预创建空 session，也不会立即发送 daemon mutation。

首次提问时，WebShell 会创建并 attach 正式 session，确认目标模型，随后通过 live config-option 路由应用待处理的 reasoning effort，最后才发送 prompt。一旦同一 session 的 context 到达，它返回的 Thinking 状态、当前 effort 和可选项仍然拥有权威优先级。若模型或 config mutation 无法得到确认，则按失败关闭处理：释放未使用的 session，不发送 prompt，并保留草稿和待处理选择供用户重试。

现有能力边界保持不变。只有已经携带有效 per-model preview 的模型才能在欢迎态接受选择，因此 preview、alias、dated、runtime、route、其他模型以及旧 daemon 都不会被推断出 reasoning 能力。

## 为什么需要

#9599 修复了 DataWorks 懒创建 session 前缺少 `qwen3.8-max · Extra High` 后缀和 Thinking/effort 控件的问题，但该 PR 有意把欢迎态 preview 限定为只读。因此用户虽然能看到默认值，却无法为首次提问选择 Medium、Low、Extra High 或 Thinking off。

在选择时预创建 session 仍会破坏 DataWorks 的懒创建/收养契约，并留下空会话。一次性、按模型绑定的本地意图可以保留该契约，同时确保用户的显式选择在任何 prompt 到达模型前，应用到权威 live session。

## Reviewer 测试计划

### 验证方式

1. 打开 [DataWorks 裸欢迎页](https://dataworks.data.aliyun.com/cn-chengdu/agent/528dd4604eb149039d5cd741bd80aede/session)，不选择已有 session，并保持精确稳定版 `qwen3.8-max` 为当前模型。打开模型弹层并选择 Medium，确认 chip 变成 `qwen3.8-max · Medium`；Thinking 可以关闭再开启且不会丢失 Medium；此时还没有创建 session 或发送 config 请求。
2. 发送首次提问，确认只创建一个 session，请求顺序为模型选择、reasoning config mutation、prompt；确认 live UI 使用 mutation response 返回的 Medium。
3. 先选 Medium，再切到 preview、alias 或其他模型并提交，确认目标模型的意图不会对其他模型产生 config mutation。
4. 模拟 workspace preview 存在、但 live session 不确认 reasoning option 的 daemon，确认首次提问被取消，未使用的 session 被释放，草稿和 Medium 选择保留；能力恢复后可以成功重试。
5. Attach 已有 session，确认其 live context 继续权威控制 Thinking/effort；旧 daemon 不返回可选 preview、或 live context 缺少兼容 option 时，不会显示伪造能力。

### 证据（Before & After）

| Before：#9599 欢迎态 preview | After：可编辑的懒创建 session 意图 |
| --- | --- |
| `qwen3.8-max · Extra High` 与 Thinking/effort 行可见，但所有控件都被禁用；强制点击不会改变 chip，也不会产生 config 请求或创建 session。参见[原 welcome preview 证据](https://github.com/QwenLM/qwen-code/pull/9599)。 | 本地完整嵌入 harness 在 session 创建前选择 Medium 并切换 Thinking，此时 `POST /session = 0`；首次提问记录的顺序为 `model < config-option(medium) < prompt`。另一条 harness 证明 `Thinking Off` 按 `config-option(none) < prompt` 生效。 |

最终 commit 的聚焦行为测试结果：WebShell reasoning Playwright 7/7；session preparation 19/19；WebUI actions 100/100。独立 post-fix 验证还通过了 actions + mappers 137/137、provider reasoning lifecycle 3/3，以及 retry/Thinking-off 两条 harness 2/2。仓库 build、根级 typecheck、包级 typecheck、lint 和 format check 均通过。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### 环境（可选）

Node.js 22 monorepo workspace；Chromium Playwright 完整 WebShell 嵌入 harness，使用带请求账本的 mock daemon。

## 风险与范围

- 主要风险或取舍：欢迎态有显式选择时，首次 prompt 前会多一次等待完成的 live config mutation。未知、拒绝或不兼容的确认会取消首次提问，而不是静默使用其他 effort；草稿会保留供重试。
- 未验证/非目标：跨 session 或重启持久化 reasoning 选择、workspace/default-model 设置、TUI 或 channel 行为、runtime snapshot、provider/auth refresh，以及跨客户端广播。
- 破坏性变更/迁移说明：无。本 PR 不新增协议字段，也不修改 session 创建 API；旧 daemon 保持失败关闭，因为 preview 缺失时无法形成意图，live mutation 未确认时也不会放行 prompt。

## 关联 Issue

Fixes #10006

Follow-up to #9599 and #9595.

</details>
