### PR TITLE
fix(webui): preserve hydrated Goal state during event startup

### DIFF
--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -8645,6 +8645,70 @@ describe('DaemonSessionProvider', () => {
     });
   });
 
+  it('preserves hydrated Goal state when the event stream starts', async () => {
+    sdkMocks.sessions.push(createMockSession({ sessionId: 'session-a' }));
+    const goal = createDeferred<GoalStateResponse>();
+    const eventApplied = createDeferred<void>();
+    sdkMocks.sessions.push(
+      createMockSession({
+        sessionId: 'session-b',
+        goal: vi.fn(() => goal.promise),
+        events: async function* events(opts = {}) {
+          yield {
+            v: 1,
+            type: 'git_branch_changed',
+            data: { branch: 'feature' },
+          };
+          eventApplied.resolve();
+          await new Promise<void>((resolve) => {
+            if (opts.signal?.aborted) {
+              resolve();
+              return;
+            }
+            opts.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            });
+          });
+        },
+      }),
+    );
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    act(() => {
+      void requireActions(actions).loadSession('session-b');
+    });
+    await act(async () => {
+      await flushPromises();
+    });
+    expect(connection?.goalState).toBeUndefined();
+
+    await act(async () => {
+      goal.resolve({
+        snapshot: { v: 2, goal: null, activity: 'idle' },
+      });
+      await eventApplied.promise;
+      await flushPromises();
+    });
+
+    expect(connection).toMatchObject({
+      sessionId: 'session-b',
+      gitBranch: 'feature',
+      goalState: { v: 2, goal: null, activity: 'idle' },
+    });
+  });
+
   it('retries a session switch while the target session is closing', async () => {
     const firstSession = createMockSession({ sessionId: 'session-a' });
     const secondSession = createMockSession({ sessionId: 'session-b' });

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -1028,7 +1028,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       const next =
         typeof update === 'function' ? update(connectionRef.current) : update;
       connectionRef.current = next;
-      setConnection(next);
+      setConnection(update);
     },
     [],
   );
@@ -2621,12 +2621,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                 activeSession.clientId,
                 eventOptionsRef.current,
                 (update) => {
-                  setConnectionSynchronous((current) => {
-                    if (sessionRef.current !== activeSession) return current;
-                    return typeof update === 'function'
-                      ? update(current)
-                      : update;
-                  });
+                  if (sessionRef.current !== activeSession) return;
+                  setConnectionSynchronous(update);
                 },
               );
               const uiEvents = filterDaemonUiEventsForTranscript(


### PR DESCRIPTION
## What this PR does

Preserves independently hydrated Goal state when the live session event stream starts during the same React update batch. Live event updates now retain their functional state-update semantics while still updating the synchronous connection reference immediately, and stale attachment events are rejected before they are queued.

Adds a deterministic regression test that switches to a loaded session, resolves its idle Goal snapshot, and delivers an immediate branch-change event before React commits the hydration update.

## Why it's needed

Switching to an existing session could intermittently leave Goal ownership unknown even though the Goal endpoint returned an idle snapshot. An immediate live event could build a complete connection object from the stale synchronous reference and enqueue it as replacement state, overwriting the queued Goal hydration update. Slash commands such as `/compress` then remained blocked with the message that Goal was occupying the session or still loading.

## Reviewer Test Plan

### How to verify

Switch between existing sessions and run `/compress` after each switch. The command should no longer remain blocked after an idle Goal snapshot has loaded, including when a live session event arrives immediately as the event stream starts. The regression test models this exact ordering and verifies that both the event update and idle Goal state survive.

### Evidence (Before & After)

Before: the deterministic regression test ended with `goalState: undefined` after the branch-change event, reproducing the persistent Slash-command gate.

After: the same test retains `{ v: 2, goal: null, activity: 'idle' }` together with the event-updated branch.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Local Node.js workspace. Verified with the complete session-provider test file (245 tests), WebUI lint, repository build, and repository typecheck.

## Risk & Scope

- Main risk or tradeoff: functional event updaters are evaluated once for the synchronous reference and again by React against the latest queued state; these state updaters are pure and the full existing provider test suite passes.
- Not validated / out of scope: manual Windows and Linux browser verification.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当实时会话事件流在同一个 React 更新批次中启动时，保留独立加载完成的 Goal 状态。实时事件更新现在会保留函数式状态更新语义，同时仍立即更新同步连接引用；过期 attachment 的事件会在入队前被拒绝。

新增一个确定性的回归测试：切换到已加载会话，解析其空闲 Goal 快照，并在 React 提交 hydration 更新前立即发送分支变化事件。

## 为什么需要

切换到已有会话时，即使 Goal 接口已经返回空闲快照，Goal 所有权仍可能间歇性保持未知。事件流启动后立即到达的实时事件可能根据过期的同步引用构造完整连接对象，并以 replacement state 入队，从而覆盖已经排队的 Goal hydration 更新。之后 `/compress` 等 Slash 命令会持续提示 Goal 正在占用会话或状态仍在加载。

## Reviewer 测试计划

### 如何验证

在已有会话之间切换，并在每次切换后运行 `/compress`。空闲 Goal 快照加载后，该命令不应继续被阻止，包括事件流启动时立即收到实时会话事件的情况。回归测试模拟了这个精确时序，并验证事件更新和空闲 Goal 状态都会保留。

### 前后证据

修复前：确定性回归测试在分支变化事件后得到 `goalState: undefined`，复现 Slash 命令持续被阻止的问题。

修复后：同一测试会同时保留 `{ v: 2, goal: null, activity: 'idle' }` 和事件更新后的分支。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 Node.js workspace。已通过完整 session-provider 测试文件（245 个测试）、WebUI lint、仓库构建和仓库 typecheck。

## 风险与范围

- 主要风险或取舍：函数式事件 updater 会为同步引用执行一次，并由 React 基于最新排队状态再次执行；这些状态 updater 是纯函数，且现有 Provider 全量测试全部通过。
- 未验证或范围外：Windows 和 Linux 的手动浏览器验证。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>
