### PR TITLE
fix(web-shell): constrain responsive sidebar drawer

### DIFF
--- a/docs/developers/daemon-ui/sidebar-customization.md
+++ b/docs/developers/daemon-ui/sidebar-customization.md
@@ -133,11 +133,11 @@ interface WebShellSidebarFooterOptions {
 }
 ```
 
-| Value                                          | Effect                  |
-| ---------------------------------------------- | ----------------------- |
-| `undefined` (default)                          | All items shown         |
-| `false`                                        | Footer hidden entirely  |
-| `{ items: ['settings', 'theme', 'collapse'] }` | Only listed items shown |
+| Value                                          | Effect                                                                    |
+| ---------------------------------------------- | ------------------------------------------------------------------------- |
+| `undefined` (default)                          | All items shown                                                           |
+| `false`                                        | Footer hidden; the mobile drawer keeps only its close control             |
+| `{ items: ['settings', 'theme', 'collapse'] }` | Only listed items shown; the mobile drawer always keeps its close control |
 
 The footer auto-adapts to narrow widths: labels are hidden and version is
 dropped below certain thresholds.

--- a/docs/developers/daemon-ui/sidebar-customization.md
+++ b/docs/developers/daemon-ui/sidebar-customization.md
@@ -288,14 +288,18 @@ These `WebShellProps` affect sidebar behavior indirectly:
 
 ## Collapsed and mobile states
 
-| State     | Behavior                                           |
-| --------- | -------------------------------------------------- |
-| Expanded  | Full sidebar with text labels                      |
-| Collapsed | Icon-rail mode (logo, pen icon, action icons only) |
-| Mobile    | Drawer slides from left with backdrop overlay      |
+| State     | Behavior                                                                                       |
+| --------- | ---------------------------------------------------------------------------------------------- |
+| Expanded  | Full sidebar with text labels                                                                  |
+| Collapsed | Icon-rail mode (logo, pen icon, action icons only)                                             |
+| Mobile    | Drawer uses 70% of its container, within width limits, with backdrop and footer close controls |
 
 Collapse state is persisted in `localStorage` under the key
 `qwen-code-web-shell-sidebar-collapsed`.
+
+The resized desktop width is restored only in expanded layouts. Opening or
+closing the mobile drawer does not overwrite that width or the persisted
+desktop collapse preference.
 
 ## Source locations
 

--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -347,6 +347,7 @@
     position: fixed;
     top: 0;
     left: 0;
+    right: 0;
     bottom: 0;
     z-index: 50;
     pointer-events: none;

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -1031,6 +1031,7 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
       onOpenDaemonStatus?: () => void;
       onOpenSessions?: () => void;
       onOpenSplitView?: () => void;
+      onMobileClose?: () => void;
       onNewSession?: () => Promise<boolean> | boolean;
       onLoadSession?: (sessionId: string) => Promise<void> | void;
       onOpenAddWorkspace?: () => void;
@@ -1114,6 +1115,15 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
             onClick: props.onOpenSplitView,
           },
           'split view',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'close-mobile-sidebar',
+            type: 'button',
+            onClick: props.onMobileClose,
+          },
+          'close mobile sidebar',
         ),
       );
     },
@@ -18047,6 +18057,36 @@ describe('App session callbacks', () => {
     );
     expect(drawer).not.toBeNull();
     expect(drawer?.className).toContain('mobileDrawerForced');
+  });
+
+  it('closes the forced compact drawer from the sidebar control', async () => {
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ sidebar: true, shellRef });
+    await flush();
+
+    await act(async () => {
+      shellRef.current?.openSessionDrawer();
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).not.toBeNull();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="close-mobile-sidebar"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-sidebar-shell][role="dialog"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-sidebar-shell]')?.className,
+    ).not.toContain('mobileDrawerForced');
   });
 
   it('does not open or lock scrolling when the sidebar is disabled', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -12220,6 +12220,7 @@ export function App({
                   onSessionRenameConfirmed={reconcileCatalogRename}
                   onError={reportError}
                   mobileOpen={mobileDrawerOpen}
+                  onMobileClose={closeMobileDrawer}
                   selectedWorkspaceCwd={selectedWorkspaceCwd}
                   onSelectWorkspace={setSelectedWorkspaceCwd}
                   onOpenGitDiff={(workspaceCwd) =>

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
@@ -369,6 +369,9 @@ describe('WebShellSidebar collapsed session group persistence', () => {
       'button[aria-label="Collapse"]',
     );
     expect(close).not.toBeNull();
+    expect(
+      container.querySelectorAll(`.${sidebarStyles.footer} button`),
+    ).toHaveLength(1);
     click(close!);
 
     expect(onMobileClose).toHaveBeenCalledOnce();

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
@@ -222,6 +222,10 @@ function renderSidebar(
   collapsed = false,
   props: {
     onSelectCurrentSession?: () => void;
+    onCollapsedChange?: (collapsed: boolean) => void;
+    mobileOpen?: boolean;
+    onMobileClose?: () => void;
+    footer?: false;
     sessionActions?: WebShellSidebarSessionActionsOptions;
     strict?: boolean;
   } = {},
@@ -229,7 +233,7 @@ function renderSidebar(
   const sidebar = (
     <WebShellSidebar
       collapsed={collapsed}
-      onCollapsedChange={() => {}}
+      onCollapsedChange={props.onCollapsedChange ?? (() => {})}
       onOpenSettings={() => {}}
       onOpenDaemonStatus={() => {}}
       onOpenScheduledTasks={() => {}}
@@ -239,6 +243,9 @@ function renderSidebar(
       onNewSession={() => false}
       onLoadSession={loadSession}
       onSelectCurrentSession={props.onSelectCurrentSession}
+      mobileOpen={props.mobileOpen}
+      onMobileClose={props.onMobileClose}
+      footer={props.footer}
       onError={() => {}}
       sessionActions={props.sessionActions}
     />
@@ -318,6 +325,39 @@ afterEach(() => {
 });
 
 describe('WebShellSidebar collapsed session group persistence', () => {
+  it('uses drawer constraints and closes mobile without persisting desktop collapse', async () => {
+    const onCollapsedChange = vi.fn();
+    const onMobileClose = vi.fn();
+    renderSidebar(false, {
+      mobileOpen: true,
+      onMobileClose,
+      onCollapsedChange,
+      footer: false,
+    });
+    await flushSidebar();
+
+    const sidebar = container.querySelector<HTMLElement>('aside');
+    expect(sidebar?.className).toContain(sidebarStyles.mobileOpen);
+    expect(
+      sidebar?.style.getPropertyValue('--web-shell-sidebar-min-width'),
+    ).toBe('220px');
+    expect(
+      sidebar?.style.getPropertyValue('--web-shell-sidebar-max-width'),
+    ).toBe('512px');
+
+    const close = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse"]',
+    );
+    expect(close).not.toBeNull();
+    click(close!);
+
+    expect(onMobileClose).toHaveBeenCalledOnce();
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+    expect(
+      window.localStorage.getItem('qwen-code-web-shell-sidebar-collapsed'),
+    ).toBeNull();
+  });
+
   it('includes secondary workspace attention without querying the primary workspace', async () => {
     const multiWorkspaceCapabilities = {
       ...organizationCapabilities,

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.collapse-persist.test.tsx
@@ -345,6 +345,26 @@ describe('WebShellSidebar collapsed session group persistence', () => {
       sidebar?.style.getPropertyValue('--web-shell-sidebar-max-width'),
     ).toBe('512px');
 
+    const resizeHandle =
+      container.querySelector<HTMLElement>('[role="separator"]');
+    expect(resizeHandle).not.toBeNull();
+    act(() => {
+      resizeHandle!.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 300,
+          pointerId: 1,
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent('pointerup', { clientX: 100, pointerId: 1 }),
+      );
+    });
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+    expect(
+      window.localStorage.getItem('qwen-code-web-shell-sidebar-width'),
+    ).toBeNull();
+
     const close = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Collapse"]',
     );

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -27,6 +27,19 @@
   align-items: center;
 }
 
+.sidebar.mobileOpen {
+  width: clamp(
+    var(--web-shell-sidebar-min-width, 220px),
+    70%,
+    var(--web-shell-sidebar-max-width, 420px)
+  );
+  min-width: clamp(
+    var(--web-shell-sidebar-min-width, 220px),
+    70%,
+    var(--web-shell-sidebar-max-width, 420px)
+  );
+}
+
 .newChatButton,
 .pluginButton,
 .footerButton,
@@ -1799,9 +1812,6 @@
   .sidebar.mobileOpen {
     display: flex;
     z-index: 50;
-    /* The width var is shared with the desktop resize handle and can be wider
-       than a phone viewport; cap it so the drawer never overflows the screen. */
-    max-width: 100vw;
   }
 
   .resizeHandle {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -40,6 +40,10 @@
   );
 }
 
+.sidebar.mobileOpen .resizeHandle {
+  display: none;
+}
+
 .newChatButton,
 .pluginButton,
 .footerButton,

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -371,6 +371,7 @@ interface WebShellSidebarProps {
   theme: WebShellTheme;
   onThemeChange: (theme: WebShellTheme) => void;
   mobileOpen?: boolean;
+  onMobileClose?: () => void;
   /**
    * Phase 4: workspace cwd picked for the next new session (undefined =
    * primary). Only meaningful on multi-workspace daemons.
@@ -833,6 +834,7 @@ export function WebShellSidebar({
   theme,
   onThemeChange,
   mobileOpen,
+  onMobileClose,
   selectedWorkspaceCwd,
   onSelectWorkspace,
   onOpenGitDiff,
@@ -1832,6 +1834,8 @@ export function WebShellSidebar({
   const footerTight = !collapsed && sidebarWidth < SIDEBAR_FOOTER_TIGHT_WIDTH;
   const sidebarStyle = {
     '--web-shell-sidebar-width': `${sidebarWidth}px`,
+    '--web-shell-sidebar-min-width': `${SIDEBAR_MIN_WIDTH}px`,
+    '--web-shell-sidebar-max-width': `${getSidebarMaxWidth()}px`,
   } as CSSProperties;
   const newSessionDisabled = creatingSession;
 
@@ -5471,7 +5475,7 @@ export function WebShellSidebar({
           </SidebarSessionSurface>
         </div>
 
-        {footer !== false && (
+        {(footer !== false || mobileOpen) && (
           <div
             className={cx(
               styles.footer,
@@ -5575,19 +5579,27 @@ export function WebShellSidebar({
                   <ActivityIcon size={16} strokeWidth={1.2} />
                 </button>
               )}
-              {!mobileOpen && footerItems.has('collapse') && (
+              {(mobileOpen || footerItems.has('collapse')) && (
                 <button
                   className={styles.collapseButton}
                   type="button"
                   title={
-                    collapsed ? t('sidebar.expand') : t('sidebar.collapse')
+                    mobileOpen || !collapsed
+                      ? t('sidebar.collapse')
+                      : t('sidebar.expand')
                   }
                   aria-label={
-                    collapsed ? t('sidebar.expand') : t('sidebar.collapse')
+                    mobileOpen || !collapsed
+                      ? t('sidebar.collapse')
+                      : t('sidebar.expand')
                   }
-                  onClick={() => onCollapsedChange(!collapsed)}
+                  onClick={() =>
+                    mobileOpen
+                      ? onMobileClose?.()
+                      : onCollapsedChange(!collapsed)
+                  }
                 >
-                  {collapsed ? (
+                  {collapsed && !mobileOpen ? (
                     <PanelLeftOpenIcon size={16} strokeWidth={1.2} />
                   ) : (
                     <PanelLeftCloseIcon size={16} strokeWidth={1.2} />

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -3680,7 +3680,7 @@ export function WebShellSidebar({
 
   const handleResizePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (collapsed) return;
+      if (collapsed || mobileOpen) return;
       event.preventDefault();
       resizeTeardownRef.current?.(true);
       setIsResizing(true);
@@ -3752,7 +3752,7 @@ export function WebShellSidebar({
         once: true,
       });
     },
-    [collapsed, onCollapsedChange, sidebarWidth],
+    [collapsed, mobileOpen, onCollapsedChange, sidebarWidth],
   );
 
   const deleteCandidateLabel = deleteCandidate

--- a/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
@@ -145,6 +145,25 @@ test('keeps a persisted wide sidebar inside the mobile drawer and exposes close'
       ),
     )
     .toBe('512');
+
+  await page.setViewportSize({ width: 700, height: 915 });
+  await page.getByRole('button', { name: 'Toggle menu' }).click();
+  await expect(drawer).toBeVisible();
+  await expect
+    .poll(() =>
+      sidebar.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeCloseTo(420, 0);
+  await page.getByRole('button', { name: 'Collapse' }).click();
+  await expect(drawer).toBeHidden();
+
+  await page.setViewportSize({ width: 1000, height: 915 });
+  await expect(sidebar).toBeVisible();
+  await expect
+    .poll(() =>
+      sidebar.evaluate((element) => element.getBoundingClientRect().width),
+    )
+    .toBeCloseTo(420, 0);
 });
 
 test('tap, type, and Send submit through the shared prompt pipeline', async ({

--- a/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
@@ -27,6 +27,7 @@ import {
 } from './utils/emptyMobileComposer';
 
 const COMPOSER_TEXTAREA = 'textarea[data-web-shell-composer-editor]';
+const SIDEBAR_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-sidebar-width';
 
 test('renders the textarea backend instead of CodeMirror on touch devices', async ({
   page,
@@ -100,6 +101,50 @@ test('keeps voice controls reachable on an extra-narrow touch viewport', async (
   await expect(more).toBeHidden();
   await expect(send).toBeVisible();
   await expect(activeToolbar.locator('button:visible')).toHaveCount(2);
+});
+
+test('keeps a persisted wide sidebar inside the mobile drawer and exposes close', async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(
+    ([key, width]) => {
+      window.localStorage.setItem(key, width);
+    },
+    [SIDEBAR_WIDTH_STORAGE_KEY, '512'] as const,
+  );
+  const scenario = createWebShellDaemonScenario();
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoSession(page, scenario, daemon);
+  await page.getByRole('button', { name: 'Toggle menu' }).tap();
+
+  const drawer = page.getByRole('dialog', { name: 'Workspace sidebar' });
+  const sidebar = page.getByRole('complementary', {
+    name: 'Workspace sidebar',
+  });
+  await expect(drawer).toBeVisible();
+  await expect(sidebar).toBeVisible();
+  const { drawerWidth, sidebarWidth } = await sidebar.evaluate((element) => ({
+    drawerWidth: element.parentElement?.getBoundingClientRect().width ?? 0,
+    sidebarWidth: element.getBoundingClientRect().width,
+  }));
+  expect(sidebarWidth).toBeCloseTo(drawerWidth * 0.7, 0);
+  expect(sidebarWidth).toBeLessThanOrEqual(drawerWidth);
+
+  await page.screenshot({
+    path: 'client/e2e/test-results/responsive-sidebar-drawer.png',
+    fullPage: true,
+  });
+  await page.getByRole('button', { name: 'Collapse' }).tap();
+  await expect(drawer).toBeHidden();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => window.localStorage.getItem(key),
+        SIDEBAR_WIDTH_STORAGE_KEY,
+      ),
+    )
+    .toBe('512');
 });
 
 test('tap, type, and Send submit through the shared prompt pipeline', async ({

--- a/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.composer.mobile.spec.ts
@@ -159,6 +159,8 @@ test('keeps a persisted wide sidebar inside the mobile drawer and exposes close'
 
   await page.setViewportSize({ width: 1000, height: 915 });
   await expect(sidebar).toBeVisible();
+  // Width stays at the mobile-mount clamp: resize re-clamping only shrinks
+  // within a session, and the drawer never expands toward the persisted 512.
   await expect
     .poll(() =>
       sidebar.evaluate((element) => element.getBoundingClientRect().width),


### PR DESCRIPTION
## What this PR does

This PR makes an open responsive sidebar drawer use 70% of its WebShell container while preserving the sidebar's existing minimum and maximum width constraints. It also keeps a visible footer close control in drawer mode, including when the host disables the normal footer, without changing the persisted desktop collapse or resize preferences.

## Why it's needed

A desktop-resized sidebar width is persisted in localStorage and was reused as both width and min-width in narrow layouts. The previous mobile max-width rule could not override that larger min-width, so the drawer could overflow the WebShell container, hide content, and make the sidebar impossible to close from inside the panel.

## Reviewer Test Plan

### How to verify

1. On a wide WebShell, resize the sidebar to 512px and reload to confirm the desktop width is restored.
2. Switch to a narrow viewport and open the sidebar drawer.
3. Confirm the drawer sidebar is 70% of the WebShell container, remains within its configured min/max limits, and does not overflow.
4. Confirm the bottom-right Collapse control is visible and closes the drawer.
5. Return to a wide viewport and confirm the saved 512px desktop width and collapse preference were not overwritten.

Automated verification: the focused Vitest run passed 574 tests across the App and sidebar persistence suites; the new Pixel 7 Playwright regression passed 1/1; WebShell typecheck and production build passed. The full preflight was attempted but lint could not start on this machine because Node 22.11 resolved ESM `ansi-regex@6` into CommonJS `pretty-format@27`; install output also reports affected dependencies require Node >=22.12.

### Evidence (Before & After)

Before: with a persisted 512px width, the narrow drawer inherited a 512px min-width and could extend beyond its container, hiding content and the internal close affordance.

After: the Pixel 7 Playwright regression measures the sidebar at 70% of the drawer container, verifies it remains inside the container, activates the visible Collapse control, and confirms the persisted width remains 512 after closing. A screenshot is included in the linked internal test report: https://alidocs.dingtalk.com/i/nodes/6LeBq413JA9BOdm2izKaqenbJDOnGvpb

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, Node 22.11, standalone WebShell Vite server, Playwright mobile-chromium with Pixel 7 emulation and the repository mock daemon.

## Risk & Scope

- Main risk or tradeoff: At containers narrower than the existing 220px minimum, the minimum remains authoritative as required by the public sidebar customization contract.
- Not validated / out of scope: A wide browser viewport with a narrow embedded container was not separately exercised in a real browser; it shares the same `mobileOpen` sizing rule and the forced drawer path is covered by App tests. Windows and Linux were not tested locally. IDE integration was blocked because the IDE lockfile consumes WebShell 0.21.9-preview.0 while this contribution targets 0.22.0.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #10014

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 让响应式侧边栏抽屉在打开时使用 WebShell 容器宽度的 70%，同时继续遵守侧边栏已有的最小和最大宽度约束。抽屉状态下始终保留 footer 右下角的关闭控件，即使宿主关闭普通 footer 也可用，并且不会改变桌面端持久化的收起状态或 resize 宽度。

## 为什么需要

桌面端手动调整的 sidebar 宽度会保存在 localStorage 中，窄屏时旧实现仍把它同时作为 width 和 min-width。原有移动端 max-width 无法覆盖更大的 min-width，因此抽屉可能超出 WebShell 容器，导致内容被遮挡，并且用户无法从面板内部找到可用的收起入口。

## Reviewer 测试计划

### 验证方式

1. 在宽屏 WebShell 中把 sidebar 调整为 512px，刷新后确认桌面宽度恢复。
2. 切换到窄屏并打开 sidebar 抽屉。
3. 确认抽屉 sidebar 为 WebShell 容器的 70%，仍受已有 min/max 限制且不越界。
4. 确认右下角 Collapse 控件可见，并能关闭抽屉。
5. 回到宽屏，确认桌面端保存的 512px 宽度和收起偏好没有被覆盖。

自动化验证：App 与 sidebar persistence 的定向 Vitest 共 574 项全部通过；新增 Pixel 7 Playwright 回归 1/1 通过；WebShell typecheck 和生产构建通过。已尝试完整 preflight，但本机 Node 22.11 把 ESM `ansi-regex@6` 解析给 CommonJS `pretty-format@27`，导致 lint 无法启动；安装日志同时提示相关依赖要求 Node >=22.12。

### 前后证据

修复前：保存 512px 宽度后，窄屏抽屉继承 512px min-width，可能超出容器并隐藏内容和内部关闭入口。

修复后：Pixel 7 Playwright 回归实测 sidebar 为 drawer 容器的 70%，确认没有越界，点击可见的 Collapse 控件后抽屉关闭，并确认持久化宽度仍为 512。截图已内嵌在内部测试报告：https://alidocs.dingtalk.com/i/nodes/6LeBq413JA9BOdm2izKaqenbJDOnGvpb

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境

macOS、Node 22.11、standalone WebShell Vite server、Playwright mobile-chromium Pixel 7 仿真和仓库 mock daemon。

## 风险与范围

- 主要风险或取舍：当容器比已有 220px 最小宽度更窄时，按公共 sidebar customization 契约继续以最小宽度为准。
- 未验证 / 范围外：未在真实浏览器中单独覆盖“宽浏览器视口中的窄嵌入容器”，该路径与窄屏共享 `mobileOpen` 尺寸规则，强制抽屉路径已有 App 测试覆盖；Windows、Linux 未本地测试。IDE 联调因 IDE lockfile 使用 WebShell 0.21.9-preview.0、而本次贡献目标为 0.22.0 被依赖版本阻断。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10014

</details>
