### PR TITLE
fix(cli): drop duplicate fake properties breaking the main build

### DIFF
--- a/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
+++ b/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
@@ -194,7 +194,6 @@ function makeFakeEnv() {
     }),
     renameSession: vi.fn().mockResolvedValue(true),
     findSessionTitlesByPrefix: vi.fn().mockResolvedValue([]),
-    getSessionDisplayName: vi.fn().mockResolvedValue(undefined),
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -208,7 +207,6 @@ function makeFakeEnv() {
       return currentSessionId;
     },
     getChatRecordingService: () => ({
-      getCurrentCustomTitle: () => undefined,
       finalize: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
       rebuildTurnBoundaries: vi.fn(),


### PR DESCRIPTION
## Motivation

Main is currently red: every workflow that installs dependencies fails during the prepare build, e.g. the SDK Java daemon E2E run and the npm cache producer run from the latest push to main.

The root cause is a test-fake regression from #9998: the session-swap telemetry fakes already declared a session display name lookup and a custom title lookup, and that PR added both properties a second time in the same object literals. TypeScript rejects duplicate object properties (TS1117), so the CLI package no longer compiles.

## Changes

Removes the two duplicate declarations, keeping the versions added by #9998 (the later property wins at runtime today, so behavior is unchanged). Two lines deleted, nothing else touched.

## Reviewer Test Plan

**How to verify**: check out this branch, run `npm install` (its prepare step performs the full build that fails on main), and confirm it completes. Running the session-swap telemetry test file should show all 10 tests passing. Verified locally: full build succeeds and the suite passes.