### PR TITLE
fix(cli): drop duplicate getCurrentCustomTitle key that breaks the build

### DIFF
--- a/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
+++ b/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
@@ -208,7 +208,6 @@ function makeFakeEnv() {
       return currentSessionId;
     },
     getChatRecordingService: () => ({
-      getCurrentCustomTitle: () => undefined,
       finalize: vi.fn(),
       flush: vi.fn().mockResolvedValue(undefined),
       rebuildTurnBoundaries: vi.fn(),

--- a/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
+++ b/packages/cli/src/ui/hooks/session-swap-telemetry.test.ts
@@ -183,7 +183,6 @@ function makeFakeEnv() {
         return { filePath: `/tmp/${to}.jsonl`, copiedCount: 2 };
       }),
     loadSession: async (id: string) => sessionServiceMocks.sessions.get(id),
-    getSessionDisplayName: vi.fn().mockResolvedValue(undefined),
     // Realistic like SessionService.removeSession (deletes the fork JSONL):
     // the branch hook calls it in exactly the failure path these tests
     // drive (forkCreated && !uiSwapped), so the fork must not survive in


### PR DESCRIPTION
## Problem

`main` fails to build: `tsc --build` in packages/cli reports TS1117 (`An object literal cannot have multiple properties with the same name`) in `src/ui/hooks/session-swap-telemetry.test.ts`, which fails `npm run build` inside `npm ci`'s prepare step — so **every PR's Install dependencies step now fails on fresh runners** (first seen on #9659's Test job).

## Cause

A semantic conflict between two individually-green PRs, materialised by a clean merge:

- #9998 added `getCurrentCustomTitle: vi.fn().mockReturnValue(undefined)` to the `getChatRecordingService` fake (the `/branch` title flow asserts on it);
- #9994's Live Host restore re-added the plain `getCurrentCustomTitle: () => undefined` in the same literal.

Same class as the #9551 episode: each PR builds green alone, the merge stacks both keys.

## Fix

Remove the plain arrow variant, keep the `vi.fn` one. A JS object literal keeps the **last** key, so the `vi.fn` variant is what every run since the merge actually used — runtime behaviour is unchanged. Suite passes 10/10.

---

## 问题(中文)

`main` 当前无法构建:packages/cli 的 `tsc --build` 在 `src/ui/hooks/session-swap-telemetry.test.ts` 报 TS1117(对象字面量重复属性),导致 `npm ci` 的 prepare 步骤里 `npm run build` 失败——**所有 PR 在全新 runner 上的 Install dependencies 步骤都会失败**(最先在 #9659 的 Test job 上暴露)。

## 原因

两个各自绿的 PR 之间的语义冲突,由干净合并引爆:#9998 给 `getChatRecordingService` fake 加了 `vi.fn` 版的 `getCurrentCustomTitle`(`/branch` 标题流程对其断言);#9994 恢复 Live Host 时在同一字面量里又加回了普通箭头函数版。与 #9551 同类:单独构建都绿,合并后两个键叠加。

## 修复

删普通箭头版,保留 `vi.fn` 版。JS 对象字面量取**最后**一个键,合并以来实际生效的本就是 `vi.fn` 版——运行时行为不变。套件 10/10 通过。