### PR TITLE
chore(release): v0.22.1

### DIFF
--- a/integrations/external-context/package.json
+++ b/integrations/external-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/external-context",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "description": "Provider-bound external context for Qwen Code",
   "type": "module",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*",
@@ -94,7 +94,7 @@
     },
     "integrations/external-context": {
       "name": "@qwen-code/external-context",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "undici": "^7.28.0",
@@ -19033,7 +19033,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19055,7 +19054,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19077,7 +19075,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19099,7 +19096,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19121,7 +19117,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19143,7 +19138,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19165,7 +19159,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19187,7 +19180,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19209,7 +19201,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19231,7 +19222,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -19253,7 +19243,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -29437,7 +29426,7 @@
     },
     "packages/acp-bridge": {
       "name": "@qwen-code/acp-bridge",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@qwen-code/qwen-code-core": "file:../core"
@@ -29452,7 +29441,7 @@
     },
     "packages/audio-capture": {
       "name": "@qwen-code/audio-capture",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.8.4"
@@ -29469,7 +29458,7 @@
     },
     "packages/channels/base": {
       "name": "@qwen-code/channel-base",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1"
       },
@@ -29479,9 +29468,9 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
-        "@qwen-code/channel-base": "0.22.0",
+        "@qwen-code/channel-base": "0.22.1",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
       },
       "devDependencies": {
@@ -29490,9 +29479,9 @@
     },
     "packages/channels/dws": {
       "name": "@qwen-code/channel-dws",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
-        "@qwen-code/channel-base": "0.22.0"
+        "@qwen-code/channel-base": "0.22.1"
       },
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -29500,10 +29489,10 @@
     },
     "packages/channels/feishu": {
       "name": "@qwen-code/channel-feishu",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.73.0",
-        "@qwen-code/channel-base": "0.22.0"
+        "@qwen-code/channel-base": "0.22.1"
       },
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -29526,10 +29515,10 @@
     },
     "packages/channels/github": {
       "name": "@qwen-code/channel-github",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
-        "@qwen-code/channel-base": "0.22.0",
+        "@qwen-code/channel-base": "0.22.1",
         "https-proxy-agent": "^7.0.6"
       },
       "devDependencies": {
@@ -29538,10 +29527,10 @@
     },
     "packages/channels/gitlab": {
       "name": "@qwen-code/channel-gitlab",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@gitbeaker/rest": "^42.5.0",
-        "@qwen-code/channel-base": "0.22.0",
+        "@qwen-code/channel-base": "0.22.1",
         "zod": "^3.25.0"
       },
       "devDependencies": {
@@ -29550,7 +29539,7 @@
     },
     "packages/channels/plugin-example": {
       "name": "@qwen-code/channel-plugin-example",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "ws": "^8.18.0"
@@ -29564,9 +29553,9 @@
     },
     "packages/channels/qqbot": {
       "name": "@qwen-code/channel-qqbot",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
-        "@qwen-code/channel-base": "0.22.0",
+        "@qwen-code/channel-base": "0.22.1",
         "@tencent-connect/qqbot-connector": "^1.1.0",
         "ws": "^8.18.0"
       },
@@ -29576,9 +29565,9 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
-        "@qwen-code/channel-base": "0.22.0",
+        "@qwen-code/channel-base": "0.22.1",
         "grammy": "^1.41.1",
         "https-proxy-agent": "^7.0.6",
         "telegram-markdown-formatter": "^0.1.2"
@@ -29589,9 +29578,9 @@
     },
     "packages/channels/wecom": {
       "name": "@qwen-code/channel-wecom",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
-        "@qwen-code/channel-base": "0.22.0",
+        "@qwen-code/channel-base": "0.22.1",
         "@wecom/aibot-node-sdk": "^1.0.7"
       },
       "devDependencies": {
@@ -29600,9 +29589,9 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
-        "@qwen-code/channel-base": "0.22.0"
+        "@qwen-code/channel-base": "0.22.1"
       },
       "devDependencies": {
         "typescript": "^5.0.0"
@@ -29610,7 +29599,7 @@
     },
     "packages/chrome-extension": {
       "name": "@qwen-code/chrome-bridge",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/chrome": "^0.1.32",
@@ -29638,7 +29627,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@google/genai": "2.6.0",
@@ -29964,7 +29953,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.1",
@@ -32983,13 +32972,14 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "LICENSE",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@qwen-code/acp-bridge": "*",
         "@qwen-code/sdk": "*",
+        "@qwen-code/web-shell": "*",
         "@qwen-code/webui": "*",
         "cors": "^2.8.5",
         "dotenv": "^17.1.0",
@@ -33053,7 +33043,7 @@
     },
     "packages/web-shell": {
       "name": "@qwen-code/web-shell",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.0",
         "@codemirror/commands": "^6.7.0",
@@ -33804,7 +33794,7 @@
     },
     "packages/web-templates": {
       "name": "@qwen-code/web-templates",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -34311,7 +34301,7 @@
     },
     "packages/webui": {
       "name": "@qwen-code/webui",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "@qwen-code/sdk": "file:../sdk-typescript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "engines": {
     "node": ">=22.0.0"
   },
@@ -27,7 +27,7 @@
     "url": "git+https://github.com/QwenLM/qwen-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.22.0"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.22.1"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/packages/acp-bridge/package.json
+++ b/packages/acp-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/acp-bridge",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Shared ACP bridge core (createHttpAcpBridge factory, BridgeClient, defaultSpawnChannelFactory, BridgeFileSystem injection seam) + primitives (EventBus, AcpChannel, in-memory channel, PermissionMediator interface) used by qwen serve, channels, IDE, TUI, and remote-control adapters.",
   "repository": {
     "type": "git",

--- a/packages/audio-capture/package.json
+++ b/packages/audio-capture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/audio-capture",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Native microphone capture backend for Qwen Code voice input",
   "repository": {
     "type": "git",

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-base",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Base channel infrastructure for Qwen Code",
   "repository": {
     "type": "git",

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "DingTalk channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "0.22.0",
+    "@qwen-code/channel-base": "0.22.1",
     "dingtalk-stream-sdk-nodejs": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/channels/dws/package.json
+++ b/packages/channels/dws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dws",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "DingTalk Workspace channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "0.22.0"
+    "@qwen-code/channel-base": "0.22.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/channels/feishu/package.json
+++ b/packages/channels/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-feishu",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Feishu (Lark) channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.73.0",
-    "@qwen-code/channel-base": "0.22.0"
+    "@qwen-code/channel-base": "0.22.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/channels/github/package.json
+++ b/packages/channels/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-github",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "GitHub polling channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "0.22.0",
+    "@qwen-code/channel-base": "0.22.1",
     "@octokit/rest": "^21.1.1",
     "https-proxy-agent": "^7.0.6"
   },

--- a/packages/channels/gitlab/package.json
+++ b/packages/channels/gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-gitlab",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "GitLab polling channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@gitbeaker/rest": "^42.5.0",
-    "@qwen-code/channel-base": "0.22.0",
+    "@qwen-code/channel-base": "0.22.1",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/channels/plugin-example/package.json
+++ b/packages/channels/plugin-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-plugin-example",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/qqbot/package.json
+++ b/packages/channels/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-qqbot",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "QQ Bot (QQ机器人) channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "0.22.0",
+    "@qwen-code/channel-base": "0.22.1",
     "@tencent-connect/qqbot-connector": "^1.1.0",
     "ws": "^8.18.0"
   },

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Telegram channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "0.22.0",
+    "@qwen-code/channel-base": "0.22.1",
     "grammy": "^1.41.1",
     "https-proxy-agent": "^7.0.6",
     "telegram-markdown-formatter": "^0.1.2"

--- a/packages/channels/wecom/package.json
+++ b/packages/channels/wecom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-wecom",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "WeCom channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "0.22.0",
+    "@qwen-code/channel-base": "0.22.1",
     "@wecom/aibot-node-sdk": "^1.0.7"
   },
   "devDependencies": {

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "test:ci": "vitest run"
   },
   "dependencies": {
-    "@qwen-code/channel-base": "0.22.0"
+    "@qwen-code/channel-base": "0.22.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/chrome-bridge",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Chrome extension bridge for Qwen CLI - enables AI-powered browser interactions",
   "private": true,
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.22.0"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.22.1"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
   "description": "Enable Qwen Code with direct access to your VS Code workspace.",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
   "repository": {

--- a/packages/web-shell/package.json
+++ b/packages/web-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/web-shell",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/web-templates/package.json
+++ b/packages/web-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/web-templates",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Web templates bundled as embeddable JS/CSS strings",
   "repository": {
     "type": "git",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/webui",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Shared UI components for Qwen Code packages",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Release PR for v0.22.1. Syncs package.json versions and package-lock.json on main.

- Root and 21 lockstep workspace packages bumped `0.22.0` -> `0.22.1` (sdk-typescript, mobile-mcp kept on independent versions).
- `@qwen-code/channel-base` pinned to the exact `0.22.1` in every channel adapter and refreshed in the lockfile via `npm install --ignore-scripts`.
- `sandboxImageUri` updated to `0.22.1` in root and cli package.json.
- CHANGELOG.md is regenerated from GitHub Releases after the tag ships; intentionally not hand-edited here.