### PR TITLE
fix(core): preserve image_url content parts for DeepSeek vision model

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
@@ -224,6 +224,48 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
       });
     });
 
+    it('preserves image_url content parts when the model declares image support', () => {
+      const visionProvider = new DeepSeekOpenAICompatibleProvider(
+        {
+          ...mockContentGeneratorConfig,
+          baseUrl: 'https://api.deepseek.com/v1',
+          model: 'deepseek-v4-flash-vision-exp',
+          modalities: { image: true },
+        } as ContentGeneratorConfig,
+        mockCliConfig,
+      );
+
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'deepseek-v4-flash-vision-exp',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Describe this image: ' },
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.com/image.png' },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = visionProvider.buildRequest(originalRequest, userPromptId);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages?.[0]).toEqual({
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe this image: ' },
+          {
+            type: 'image_url',
+            image_url: { url: 'https://example.com/image.png' },
+          },
+        ],
+      });
+    });
+
     // https://github.com/QwenLM/qwen-code/issues/3695 — DeepSeek's thinking
     // mode rejects subsequent requests when any prior assistant turn omits
     // reasoning_content, even if the model itself returned no reasoning text.

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -100,16 +100,19 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
   }
 
   /**
-   * DeepSeek's API requires message content to be a plain string, not an
-   * array of content parts. Flatten any text-part arrays into joined
-   * strings; non-text parts (image_url, audio, …) are replaced with a
-   * `[Unsupported content type: <type>]` placeholder so the request still
-   * goes through with a textual breadcrumb rather than silently dropping
-   * the part or raising mid-conversation. Also translate the standard
-   * `reasoning.effort` config into DeepSeek's flat `reasoning_effort`
-   * body parameter — but only on actual DeepSeek hostnames, since the
-   * model-name fallback above can match self-hosted/strict OpenAI-compat
-   * backends that don't accept the DeepSeek extension.
+   * DeepSeek's text models require message content to be a plain string,
+   * not an array of content parts. Flatten any text-part arrays into
+   * joined strings; non-text parts (image_url, audio, …) are replaced
+   * with a `[Unsupported content type: <type>]` placeholder so the request
+   * still goes through with a textual breadcrumb rather than silently
+   * dropping the part or raising mid-conversation. The vision model
+   * (`deepseek-v4-flash-vision-exp`) accepts OpenAI `image_url` content
+   * parts, so when the config declares image support the parts are kept
+   * as-is. Also translate the standard `reasoning.effort` config into
+   * DeepSeek's flat `reasoning_effort` body parameter — but only on actual
+   * DeepSeek hostnames, since the model-name fallback above can match
+   * self-hosted/strict OpenAI-compat backends that don't accept the
+   * DeepSeek extension.
    */
   override buildRequest(
     request: OpenAI.Chat.ChatCompletionCreateParams,
@@ -124,8 +127,14 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
       return reshaped;
     }
 
+    // deepseek-v4-flash-vision-exp accepts OpenAI "content parts" with
+    // image_url, so flattening to a plain string would silently drop the
+    // image. Only flatten when the model has not declared image support.
+    const supportsImages =
+      this.contentGeneratorConfig.modalities?.image === true;
+
     const messages = reshaped.messages.map((message) => {
-      const flattened = flattenContentParts(message);
+      const flattened = supportsImages ? message : flattenContentParts(message);
       return ensureReasoningContentOnAssistantMessage(flattened);
     });
 


### PR DESCRIPTION
## What this PR does

The DeepSeek provider was flattening every message into a plain string for all models, which turned image content into a `[Unsupported content type: image_url]` placeholder. When a user configures the vision model `deepseek-v4-flash-vision-exp` (with `modalities.image`), an image it reads via `read_file` never reaches the model — the request silently degrades to text. This PR stops flattening content when the config declares image support, so `image_url` parts are forwarded to the vision model as-is, while text-only models keep the existing placeholder behavior.

## Why it's needed

DeepSeek's text models require `message.content` to be a plain string, which is why the provider flattens arrays and substitutes non-text parts. But the dedicated vision model accepts OpenAI content parts with `image_url`. Because flattening was unconditional, images read via `read_file` were replaced with `[Unsupported content type: image_url]` and the vision model never saw them, making vision-capable configs silently text-only. Users who set `deepseek-v4-flash-vision-exp` as their active model (a documented vision model) get a broken experience with no error.

## Reviewer Test Plan

### How to verify

Configure `deepseek-v4-flash-vision-exp` as the active model with `modalities.image: true`, then ask the agent to look at an image (or `read_file` a `.png`). Before this PR the request body contains `[Unsupported content type: image_url]` in place of the image; after this PR the `image_url` content part is preserved and sent to the vision model. The regression test asserts that `image_url` parts survive when `modalities.image` is set.

### Evidence (Before & After)

N/A — non-UI change (internal request shaping, no user-facing difference). See the regression test for the before (placeholder) vs after (preserved `image_url`) of the request body.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests via `npm run test --workspaces` (core package, `vitest run`); 28 tests including the new regression case.

## Risk & Scope

- Main risk or tradeoff: vision-capable models switch from flattened-string to content-part messages. Only triggers when `modalities.image === true`, so text-only configs are unaffected.
- Not validated / out of scope: a live round-trip against the DeepSeek vision API; the DeepSeek text behavior is covered by existing tests.
- Breaking changes / migration notes: none — no config or CLI surface changed.

## Linked Issues

Fixes #10027

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

DeepSeek 提供商此前将所有消息扁平化为纯字符串，这会把图片内容转换成 `[Unsupported content type: image_url]` 占位符。当用户配置视觉模型 `deepseek-v4-flash-vision-exp`（并设置 `modalities.image`）时，它通过 `read_file` 读取的图片永远不会到达模型——请求会静默退化为纯文本。此 PR 在配置声明支持图片时停止扁平化内容，从而将 `image_url` 部分原样转发给视觉模型，而纯文本模型则保留原有的占位符行为。

## 为什么需要

DeepSeek 的文本模型要求 `message.content` 是纯字符串，这也是提供商扁平化数组并用占位符替代非文本部分的原因。但专用的视觉模型接受带有 `image_url` 的 OpenAI 内容部分。由于扁平化是无条件的，通过 `read_file` 读取的图片会被替换为 `[Unsupported content type: image_url]`，视觉模型从未真正看到它们，使得配置了视觉能力的模型静默地变成纯文本。用户将 `deepseek-v4-flash-vision-exp` 设为主模型（一个文档化的视觉模型）时会得到一个没有报错的破损体验。

## Reviewer 测试计划

### 如何验证

将 `deepseek-v4-flash-vision-exp` 配置为主模型并设置 `modalities.image: true`，然后让智能体查看一张图片（或 `read_file` 一个 `.png`）。在此 PR 之前，请求体中图片位置是 `[Unsupported content type: image_url]`；在此 PR 之后，`image_url` 内容部分被保留并发送给视觉模型。回归测试断言当 `modalities.image` 被设置时 `image_url` 部分能够存活。

### 前后证据（Before & After）

不适用——非 UI 变更（内部请求整形，无用户可见差异）。请参阅回归测试中的请求体前后对比（占位符 vs 保留的 `image_url`）。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 环境（可选）

通过 `npm run test --workspaces`（core 包，`vitest run`）运行单元测试；28 个测试，包括新增的回归用例。

## 风险与范围

- 主要风险或权衡：视觉模型从扁平化字符串切换为内容部分组成。仅在 `modalities.image === true` 时触发，因此纯文本配置不受影响。
- 未验证 / 超出范围：针对 DeepSeek 视觉 API 的在线往返；DeepSeek 文本行为由现有测试覆盖。
- 破坏性变更 / 迁移说明：无——未改变任何配置或 CLI 表面。

## 关联 Issue

Fixes #10027

</details>
