### PR TITLE
fix(core): refuse substitutions hidden in pattern words and heredoc bodies

### DIFF
--- a/packages/core/src/utils/shellAstParser.test.ts
+++ b/packages/core/src/utils/shellAstParser.test.ts
@@ -1336,3 +1336,215 @@ describe('consistency: isShellCommandReadOnly (regex) vs isShellCommandReadOnlyA
     });
   });
 });
+
+describe('substitution hidden in an expansion pattern word', () => {
+  // tree-sitter-bash parses the pattern word as a leaf, so the substitution
+  // never becomes a command_substitution node — but bash still runs it.
+  it.each(['%%', '%', '##', '#', '^^', '^', ',,', ','])(
+    'refuses a command substitution hidden by the operator %s',
+    async (operator) => {
+      expect(
+        await classifyShellCommandSafety(
+          `echo \${HOME${operator}$(rm -rf build)}`,
+        ),
+      ).toBe('unknown');
+      expect(
+        await classifyShellCommandSafety(
+          `echo "\${HOME${operator}$(rm -rf build)}"`,
+        ),
+      ).toBe('unknown');
+      expect(
+        await classifyShellCommandSafety(
+          `echo \${HOME${operator}\`rm -rf build\`}`,
+        ),
+      ).toBe('unknown');
+    },
+  );
+
+  // bash runs `<(…)` and `>(…)` in a pattern word exactly as it runs `$(…)`,
+  // and tree-sitter emits no node for those either.
+  it.each(['%%', '%', '##', '#', '^^', '^', ',,', ','])(
+    'refuses a process substitution hidden by the operator %s',
+    async (operator) => {
+      for (const opener of ['<(', '>(']) {
+        expect(
+          await classifyShellCommandSafety(
+            `echo \${HOME${operator}${opener}rm -rf build)}`,
+          ),
+        ).toBe('unknown');
+        expect(
+          await classifyShellCommandSafety(
+            `echo "\${HOME${operator}${opener}rm -rf build)}"`,
+          ),
+        ).toBe('unknown');
+      }
+    },
+  );
+
+  // `${v@P}` runs any $(…) held in the variable's value, and in a pattern word
+  // it is a leaf, so the @/P child-adjacency check never sees it either.
+  it.each(['%%', '%', '##', '#', '^^', '^', ',,', ','])(
+    'refuses a prompt expansion hidden by the operator %s',
+    async (operator) => {
+      expect(
+        await classifyShellCommandSafety(`echo \${x${operator}\${v@P}}`),
+      ).toBe('unknown');
+    },
+  );
+
+  // `${var/pat/rep}` has two halves and bash expands both, so each needs its
+  // own pin — the pattern half is where the other operators put their word,
+  // and the replacement half is the one an operator-shaped test never reaches.
+  // A `$(…)` here does become a real command_substitution node, so it is
+  // classified from the command inside it — `write`, which is stronger than
+  // the `unknown` the leaf-parsed spellings get. Both are refusals; they are
+  // pinned apart so that a spelling silently changing category is a failure.
+  it.each([
+    ['pattern', 'echo ${x/$(rm -rf build)/rep}', 'write'],
+    ['pattern', 'echo ${x/`rm -rf build`/rep}', 'unknown'],
+    ['pattern', 'echo ${x/<(rm -rf build)/rep}', 'unknown'],
+    ['pattern', 'echo ${x/${v@P}/rep}', 'unknown'],
+    ['replacement', 'echo ${x/pat/$(rm -rf build)}', 'write'],
+    ['replacement', 'echo ${x/pat/`rm -rf build`}', 'unknown'],
+    ['replacement', 'echo ${x/pat/<(rm -rf build)}', 'unknown'],
+    ['replacement', 'echo ${x//pat/$(rm -rf build)}', 'write'],
+  ])(
+    'refuses a substitution in the %s half of ${var/…/…}',
+    async (_half, command, expected) => {
+      expect(await classifyShellCommandSafety(command)).toBe(expected);
+      expect(await classifyShellCommandSafety(`"${command}"`)).toBe(expected);
+    },
+  );
+
+  it('treats ${var/pat/${v@P}} as unknown', async () => {
+    expect(await classifyShellCommandSafety('echo ${x/pat/${v@P}}')).toBe(
+      'unknown',
+    );
+  });
+
+  // The default/assign/error/alternate operators take a *word* just as the
+  // trim and case operators do, and bash expands it the same way.
+  it.each([':-', '-', ':=', '=', ':?', '?', ':+', '+'])(
+    'refuses a substitution behind the value operator %s',
+    async (operator) => {
+      // `$(…)` becomes a real node and is classified from the command inside
+      // it; the leaf-parsed spellings reach the regex instead.
+      expect(
+        await classifyShellCommandSafety(`echo \${x${operator}$(rm -rf b)}`),
+      ).toBe('write');
+      for (const payload of ['`rm -rf b`', '<(rm -rf b)', '${v@P}']) {
+        expect(
+          await classifyShellCommandSafety(`echo \${x${operator}${payload}}`),
+        ).toBe('unknown');
+      }
+    },
+  );
+
+  it('refuses a substitution in a substring or subscript position', async () => {
+    expect(await classifyShellCommandSafety('echo ${x:1:$(rm -rf b)}')).toBe(
+      'write',
+    );
+    expect(await classifyShellCommandSafety('echo ${x[$(rm -rf b)]}')).toBe(
+      'write',
+    );
+    expect(await classifyShellCommandSafety('echo ${!x@P}')).toBe('unknown');
+  });
+
+  it('does not flag expansions without a substitution', async () => {
+    expect(await classifyShellCommandSafety('echo ${HOME%%/*}')).toBe(
+      'read-only',
+    );
+    expect(await classifyShellCommandSafety('echo ${HOME}')).toBe('read-only');
+  });
+});
+
+describe('substitution hidden in a heredoc body', () => {
+  // The body is one leaf too, and bash expands it before feeding it to stdin.
+  // Expansion there follows double-quote rules, so `$(…)`, backticks and the
+  // `@P` operator run while `<(…)` does not.
+  it('treats an unquoted-delimiter body containing a substitution as unsafe', async () => {
+    expect(
+      await classifyShellCommandSafety('cat <<EOF\n`rm -rf build`\nEOF'),
+    ).toBe('unknown');
+    expect(
+      await classifyShellCommandSafety('cat <<-EOF\n`rm -rf build`\nEOF'),
+    ).toBe('unknown');
+  });
+
+  it('treats $(…) in a body as unsafe, tab-stripped form included', async () => {
+    // A `<<-` body is always one raw leaf, so the `$(` branch of the body
+    // regex is the only thing that catches this — the AST walk sees no
+    // command_substitution node to classify.
+    // Only the tab-indented `<<-` spelling is the always-leaf case the body
+    // regex has to catch; the others parse into a real command_substitution
+    // node and are classified from the command inside it. Pinned apart so a
+    // spelling silently changing category is a failure, not a pass.
+    expect(
+      await classifyShellCommandSafety('cat <<-EOF\n\t$(rm -rf build)\n\tEOF'),
+    ).toBe('unknown');
+    expect(
+      await classifyShellCommandSafety('cat <<-EOF\n$(rm -rf build)\nEOF'),
+    ).toBe('write');
+    expect(
+      await classifyShellCommandSafety('cat <<EOF\n$(rm -rf build)\nEOF'),
+    ).toBe('write');
+    // Nested one level deep, where the closing paren is not the last
+    // character of the line.
+    expect(
+      await classifyShellCommandSafety(
+        'cat <<-EOF\n\tprefix $(rm -rf build) suffix\n\tEOF',
+      ),
+    ).toBe('write');
+  });
+
+  it('treats ${v@P} in a body as unsafe, tab-stripped form included', async () => {
+    // A `<<-` body is always one raw leaf, so the expansion never becomes a
+    // child node the walk above could see.
+    expect(
+      await classifyShellCommandSafety('cat <<-EOF\n\t${v@P}\n\tEOF'),
+    ).toBe('unknown');
+    expect(await classifyShellCommandSafety('cat <<EOF\n${v@P}\nEOF')).toBe(
+      'unknown',
+    );
+  });
+
+  it('does not flag a process substitution in a body, which bash never runs', async () => {
+    expect(
+      await classifyShellCommandSafety('cat <<EOF\n<(rm -rf build)\nEOF'),
+    ).toBe('read-only');
+  });
+
+  it('leaves a quoted delimiter alone, which makes the body inert', async () => {
+    expect(
+      await classifyShellCommandSafety("cat <<'EOF'\n`rm -rf build`\nEOF"),
+    ).toBe('read-only');
+    expect(
+      await classifyShellCommandSafety('cat <<"EOF"\n`rm -rf build`\nEOF'),
+    ).toBe('read-only');
+    // `<<\EOF` quotes the delimiter just as surely.
+    expect(
+      await classifyShellCommandSafety('cat <<\\EOF\n$(rm -rf build)\nEOF'),
+    ).toBe('read-only');
+  });
+
+  it('refuses a substitution in the heredoc DELIMITER, which bash expands', async () => {
+    // The body and the opener-line segments are pinned above and below, but
+    // the delimiter itself was not — and bash expands it. Today the refusal
+    // rides on two mechanisms this block never asserts (the `root.hasError`
+    // bailout and the ERROR node landing in the unknown-floored default arm),
+    // so a tree-sitter upgrade that parses the `$(…)` into real nodes, or a
+    // refactor of either mechanism, would flip this to read-only unnoticed.
+    expect(
+      await classifyShellCommandSafety('cat <<$(rm -rf build)\nhello\nEOF'),
+    ).toBe('unknown');
+    expect(
+      await classifyShellCommandSafety('cat <<`rm -rf build`\nhello\nEOF'),
+    ).toBe('unknown');
+  });
+
+  it('does not flag a body without a substitution', async () => {
+    expect(await classifyShellCommandSafety('cat <<EOF\nplain\nEOF')).toBe(
+      'read-only',
+    );
+  });
+});

--- a/packages/core/src/utils/shellAstParser.ts
+++ b/packages/core/src/utils/shellAstParser.ts
@@ -959,6 +959,34 @@ function processSafety(root: string, args: string[]): Safety {
   return 'write';
 }
 
+/**
+ * The subset that runs inside a heredoc body, where expansion follows
+ * double-quote rules. `<(…)` is not expanded there, so including it would only
+ * refuse a body that quotes the text.
+ */
+const HEREDOC_SUBSTITUTION = /\$\(|`/;
+
+/**
+ * `${v@P}` prompt expansion, which runs any `$(…)` held in the variable's
+ * value. In a pattern word it is a leaf, so the `@`/`P` child-adjacency check
+ * never sees it.
+ *
+ * Deliberately not anchored to a brace-free span: `${a[${b}]@P}` nests a brace
+ * inside the expansion, and a `[^{}]*` bridge stops at it — so the computed
+ * subscript form escaped while bash still ran the expansion. This is a leaf
+ * fallback for sites the node walk cannot reach, so treating any `@P` that
+ * co-occurs with a `${` as unsafe costs at most a prompt.
+ */
+const PROMPT_EXPANSION = /\$\{[\s\S]*@P/;
+
+/**
+ * A command or process substitution that survived the substitution-node walk.
+ * Both openers count: bash runs `<(…)` and `>(…)` wherever it runs `$(…)` —
+ * in a pattern word, that is. See `HEREDOC_SUBSTITUTION` for the one place it
+ * does not.
+ */
+const HIDDEN_SUBSTITUTION = /\$\(|`|<\(|>\(/;
+
 function evaluateSubstitutions(node: SyntaxNode): ShellCommandSafety {
   const substitutions = collectDescendants(
     node,
@@ -975,6 +1003,36 @@ function evaluateSubstitutions(node: SyntaxNode): ShellCommandSafety {
           return 'unknown';
         }
       }
+      // tree-sitter-bash parses the pattern word of `${v%%…}`, `${v%…}`,
+      // `${v##…}` and `${v#…}` as a single leaf, so a substitution inside it
+      // yields no node of its own even though bash runs it while expanding.
+      // Nothing was collected above, so an opener still present in an
+      // expansion is exactly that hidden channel.
+      if (
+        HIDDEN_SUBSTITUTION.test(expansion.text) ||
+        PROMPT_EXPANSION.test(expansion.text)
+      ) {
+        return 'unknown';
+      }
+    }
+    // A heredoc body is one leaf too (`<<-` bodies always, `<<` bodies when
+    // nothing inside them parsed), and bash expands it before feeding it to
+    // stdin — unless the delimiter is quoted, which makes the body inert.
+    // Expansion there follows double-quote rules: `$(…)`, backticks and `@P`
+    // run, `<(…)` does not.
+    for (const body of collectDescendants(node, new Set(['heredoc_body']))) {
+      if (
+        !HEREDOC_SUBSTITUTION.test(body.text) &&
+        !PROMPT_EXPANSION.test(body.text)
+      ) {
+        continue;
+      }
+      const delimiter = body.parent?.namedChildren.find(
+        (child) => child.type === 'heredoc_start',
+      );
+      // `<<\EOF` quotes the delimiter as surely as `<<'EOF'` does.
+      if (delimiter && /['"\\]/.test(delimiter.text)) continue;
+      return 'unknown';
     }
     return 'read-only';
   }


### PR DESCRIPTION
## What this PR does

Closes two places where tree-sitter-bash hands back a single leaf node, so the classifier's substitution walk finds nothing to collect while bash still runs what is inside.

**Expansion pattern words.** The pattern of `${v%%…}`, `${v%…}`, `${v##…}`, `${v#…}`, `${v^^…}`, `${v^…}`, `${v,,…}`, `${v,…}` is one leaf. So is each half of `${v/pat/rep}`, and the operand of `${v:-…}`, `${v:=…}`, `${v:?…}`, `${v:+…}`. A substitution written there yields no node of its own, so `echo ${x%%$(rm -rf build)}` classified `read-only` — and would run unattended in Plan Mode. Since the collection pass already found nothing, an opener still present in the expansion's text is exactly that hidden channel, and the leaf is refused on the text.

**Heredoc bodies.** A body is one leaf too — always for `<<-`, and for `<<` whenever nothing inside it parsed — and bash expands it before feeding it to stdin. Expansion there follows double-quote rules, so `$(…)`, backticks and `${v@P}` run while `<(…)` does not; the body is refused for the first three only. A quoted delimiter (`<<'EOF'`, `<<"EOF"`, `<<\EOF`) makes the body inert and is exempted.

`${v@P}` is handled in both, because a prompt expansion runs any `$(…)` held in the variable's value, and in a pattern word or a body it is a leaf the `@`/`P` child-adjacency check never sees. Its regex is deliberately not anchored to a brace-free span: `${a[${b}]@P}` nests a brace, and a `[^{}]*` bridge stops at it.

## Why it's needed

These are the inputs where the AST gives less information than bash acts on. The classifier's whole contract is that a `read-only` verdict means nothing executes — and in Plan Mode a `read-only` verdict means the command runs with no confirmation at all. `echo ${x%%$(rm -rf build)}` is a deletion that never appears as a command node.

## Reviewer Test Plan

### How to verify

```
cd packages/core && npx vitest run src/utils/shellAstParser.test.ts

 Test Files  1 passed (1)
      Tests  598 passed (598)
```

Before this change, on `main`:

```js
await isShellCommandReadOnlyAST('echo ${x%%$(rm -rf build)}')       // true
await isShellCommandReadOnlyAST('echo ${x/a/$(rm -rf build)}')      // true
await isShellCommandReadOnlyAST('cat <<-EOF\n\t$(rm -rf build)\n\tEOF')  // true
```

After, all three are `false`. The exemptions still hold:

```js
await isShellCommandReadOnlyAST("cat <<'EOF'\n$(rm -rf build)\nEOF")  // true — quoted delimiter
await isShellCommandReadOnlyAST('cat <<EOF\n<(rm -rf build)\nEOF')    // true — bash never runs <() here
await isShellCommandReadOnlyAST('echo ${x%%.txt}')                    // true — no substitution
```

Mutation-verified: neutralising the three leaf regexes fails 28, 10 and 2 tests respectively, and dropping the quoted-delimiter exemption fails 1.

Note: `src/permissions/permission-manager.test.ts` has 2 failures on `main` at this commit (`resolveToolName exhaustiveness (#9827)`, about `ReportFindings`). They are unrelated to this PR and reproduce on a clean `origin/main` checkout.

### Evidence (Before & After)

N/A — no TUI change. The user-visible difference is that these forms now prompt instead of running unattended.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- **Main risk:** these are text checks on leaf nodes, not structural analysis, so they over-refuse by construction — an expansion whose pattern merely *contains* the characters `$(` is refused whether or not bash would expand it. They are fallbacks for sites the node walk cannot reach at all, so the cost is a prompt and the alternative is silence; but a user with an unusual pattern word will see a confirmation they did not before.
- **Not validated / out of scope:** the pre-existing `permission-manager` failures noted above. The deprecated regex fallback in `shellReadOnlyChecker.ts` is untouched.
- **Breaking changes:** none.

## Linked Issues

No issue to close. This is a self-contained correctness fix carved out of #9950 — the hidden-substitution leaves surfaced while that PR was under review, and it is filed separately so it can land on its own merits. Referenced without a closing keyword: #9950.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复两处 tree-sitter-bash 只返回单个叶子节点、导致分类器的替换遍历什么都收集不到、而 bash 仍会执行其中内容的情形。

**展开的模式词。** `${v%%…}`、`${v%…}`、`${v##…}`、`${v#…}`、`${v^^…}`、`${v^…}`、`${v,,…}`、`${v,…}` 的模式部分是一个叶子；`${v/pat/rep}` 的两半、以及 `${v:-…}`、`${v:=…}`、`${v:?…}`、`${v:+…}` 的操作数同样如此。写在那里的替换不会产生自己的节点，于是 `echo ${x%%$(rm -rf build)}` 被判为 `read-only`，在 Plan Mode 下会无人值守执行。既然收集阶段已经一无所获，展开文本中仍然存在的开启符恰恰就是那条隐藏通道，因此按文本拒绝该叶子。

**heredoc body。** body 同样是一个叶子（`<<-` 恒为如此，`<<` 在其内部无内容被解析时亦然），而 bash 会先展开它再送入 stdin。此处的展开遵循双引号规则：`$(…)`、反引号、`${v@P}` 会执行，`<(…)` 不会——因此只对前三者拒绝。带引号的分隔符（`<<'EOF'`、`<<"EOF"`、`<<\EOF`）使 body 惰性化，予以豁免。

`${v@P}` 两处都处理，因为提示符展开会运行变量值中携带的任何 `$(…)`，而在模式词或 body 中它是一个叶子，`@`/`P` 子节点相邻检查永远看不到它。其正则刻意不限定为无花括号跨度：`${a[${b}]@P}` 内嵌了花括号，`[^{}]*` 桥接会在那里断掉。

## 为什么需要它

这些正是 AST 提供的信息少于 bash 实际行为的输入。分类器的全部契约是「`read-only` 意味着什么都不会执行」——而在 Plan Mode 下，`read-only` 意味着命令完全不弹窗直接执行。`echo ${x%%$(rm -rf build)}` 是一次从不以命令节点形式出现的删除。

## 验证方式

见上文英文部分。变异测试：把三个叶子正则置空分别导致 28、10、2 个测试失败；去掉带引号分隔符的豁免导致 1 个失败。

注：本提交所基于的 `main` 上，`permission-manager.test.ts` 本身有 2 个与本 PR 无关的失败。

## 风险与范围

- **主要风险：** 这些是对叶子节点的文本检查而非结构分析，因此按构造就会过度拒绝——模式词只要**包含** `$(` 字符就会被拒绝，无论 bash 是否真的会展开。它们是节点遍历根本到不了的位置的兜底，代价是弹窗，而另一个选择是静默；但使用不寻常模式词的用户会看到此前没有的确认框。
- **明确不在范围内：** 上述 `main` 自带的失败；已废弃的正则回退路径不动。
- **破坏性变更：** 无。

## 关联 Issue

没有需要关闭的 issue。这是从 #9950 中拆分出来的一处独立正确性修复——隐藏替换叶子节点是在那个 PR 评审过程中发现的，单独提出以便独立评审合入。仅作引用、不带关闭关键字：#9950。

</details>

