### PR TITLE
fix(core): keep sub-commands after a state planter in the confirmation scope

### DIFF
--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -133,7 +133,12 @@ vi.mock('../utils/shell-utils.js', async (importOriginal) => {
 
 const mockIsShellCommandReadOnlyAST = vi.hoisted(() => vi.fn());
 const mockExtractCommandRules = vi.hoisted(() => vi.fn());
-vi.mock('../utils/shellAstParser.js', () => ({
+vi.mock('../utils/shellAstParser.js', async (importOriginal) => ({
+  // `plantsStateForLaterCommands` is deliberately NOT mocked away: the
+  // confirmation scope depends on the real predicate, and a stub returning
+  // false would hide the very defect it guards. Imported rather than copied,
+  // so it cannot go stale against the production version.
+  ...(await importOriginal<typeof import('../utils/shellAstParser.js')>()),
   isShellCommandReadOnlyASTInDirectory: mockIsShellCommandReadOnlyAST,
   extractCommandRules: mockExtractCommandRules,
 }));
@@ -422,6 +427,51 @@ describe('MonitorTool', () => {
         'Monitor(tail -f *)',
         'Monitor(rm -rf *)',
       ]);
+    });
+
+    it('keeps sub-commands after a state planter in the confirmation scope', async () => {
+      // Ported from shell.test.ts: monitor runs the identical loop, and until
+      // now nothing here exercised it — deleting the gate left this suite
+      // green. A read-only classification is only meaningful for the world the
+      // sub-command actually runs in; after a planter, classifying a later one
+      // alone measures the wrong world, so it must stay in the approved scope.
+      // `npm run build` must stay non-read-only, or every segment is dropped
+      // and the "nothing left, show everything" fallback masks the gate.
+      mockIsShellCommandReadOnlyAST.mockImplementation(
+        async (sub: string) => !sub.startsWith('npm'),
+      );
+      for (const command of [
+        'cd /hostile && tail -f /tmp/app.log && npm run build',
+        'export GIT_DIR=/hostile/.git && tail -f /tmp/app.log && npm run build',
+        'hash -p ./evil/git git && tail -f /tmp/app.log && npm run build',
+      ]) {
+        const invocation = createInvocation({ command });
+        const details = (await invocation.getConfirmationDetails(
+          new AbortController().signal,
+        )) as ToolCallConfirmationDetails & { rootCommand: string };
+
+        expect(details.rootCommand).toContain('tail');
+        expect(details.rootCommand).toContain('npm');
+      }
+      mockIsShellCommandReadOnlyAST.mockReset();
+    });
+
+    it('never drops the state planter itself from the scope', async () => {
+      // The planter is the segment that makes the rest mean something else,
+      // so it is the one the user most needs to see — even though it
+      // classifies read-only on its own.
+      mockIsShellCommandReadOnlyAST.mockImplementation(
+        async (sub: string) => !sub.startsWith('npm'),
+      );
+      const invocation = createInvocation({
+        command: 'cd /hostile && tail -f /tmp/app.log && npm run build',
+      });
+      const details = (await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      )) as ToolCallConfirmationDetails & { rootCommand: string };
+
+      expect(details.rootCommand).toContain('cd');
+      mockIsShellCommandReadOnlyAST.mockReset();
     });
 
     it('falls back to a canonical Monitor rule if command extraction fails', async () => {

--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -143,6 +143,22 @@ vi.mock('../utils/shellAstParser.js', async (importOriginal) => ({
   extractCommandRules: mockExtractCommandRules,
 }));
 
+// `debugLogger.warn` writes nothing without an active debug-log session, so a
+// console spy cannot see it. The logger is replaced instead, which is also the
+// only way to assert on what the message carries.
+const mockDebugWarn = vi.hoisted(() => vi.fn());
+const mockDebugLog = vi.hoisted(() => vi.fn());
+vi.mock('../utils/debugLogger.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/debugLogger.js')>()),
+  createDebugLogger: () => ({
+    isEnabled: () => true,
+    debug: mockDebugLog,
+    info: vi.fn(),
+    warn: mockDebugWarn,
+    error: vi.fn(),
+  }),
+}));
+
 import { MonitorTool, sanitizeMonitorLine } from './monitor.js';
 import type { Config } from '../config/config.js';
 import { MonitorRegistry } from '../services/monitorRegistry.js';
@@ -510,6 +526,75 @@ describe('MonitorTool', () => {
       // Sub-command should still be in confirmation scope (not dropped)
       expect(details.permissionRules).toBeDefined();
       expect(details.permissionRules!.length).toBeGreaterThan(0);
+    });
+
+    it('never reaches the classifier once a sub-command has planted state', async () => {
+      // The reason the failure log carries no `plants`/`statePlanted` values:
+      // `!statePlanted && !plants && (await isShellCommandReadOnly…)`
+      // short-circuits, so the classifier — and therefore its catch — is only
+      // ever reached while both flags are false. Reporting them there would
+      // print two constants. Pinned so that if the short-circuit is ever
+      // reordered, the claim in the comment fails instead of quietly rotting.
+      mockIsShellCommandReadOnlyAST.mockReset();
+      mockIsShellCommandReadOnlyAST.mockResolvedValue(true);
+
+      const planted = createInvocation({
+        command: 'cd /tmp && tail -f app.log && tail -f other.log',
+      });
+      await planted.getConfirmationDetails(new AbortController().signal);
+
+      // `cd` itself short-circuits on `!plants`, and every later segment
+      // short-circuits on `!statePlanted`, so the classifier is not consulted
+      // once — there is no path on which its catch sees a true flag.
+      expect(mockIsShellCommandReadOnlyAST).not.toHaveBeenCalled();
+
+      // Control, so the assertion above cannot pass merely because the
+      // classifier is never called for this command shape at all.
+      const unplanted = createInvocation({
+        command: 'tail -f app.log && tail -f other.log',
+      });
+      await unplanted.getConfirmationDetails(new AbortController().signal);
+
+      expect(
+        mockIsShellCommandReadOnlyAST.mock.calls.map((call) => call[0]),
+      ).toEqual(['tail -f app.log', 'tail -f other.log']);
+      mockIsShellCommandReadOnlyAST.mockReset();
+    });
+
+    it('names the planter that widened the confirmation scope', async () => {
+      mockDebugLog.mockClear();
+      mockIsShellCommandReadOnlyAST.mockReset();
+      mockIsShellCommandReadOnlyAST.mockResolvedValue(true);
+
+      const invocation = createInvocation({
+        command: 'cd /tmp && tail -f app.log',
+      });
+      await invocation.getConfirmationDetails(new AbortController().signal);
+
+      const planterLogs = mockDebugLog.mock.calls.filter((call) =>
+        String(call[0]).includes('plants state'),
+      );
+      expect(planterLogs).toHaveLength(1);
+      expect(planterLogs[0]![1]).toBe('cd /tmp');
+      mockIsShellCommandReadOnlyAST.mockReset();
+    });
+
+    it('logs no planter line when nothing plants state', async () => {
+      mockDebugLog.mockClear();
+      mockIsShellCommandReadOnlyAST.mockReset();
+      mockIsShellCommandReadOnlyAST.mockResolvedValue(false);
+
+      const invocation = createInvocation({
+        command: 'tail -f app.log && tail -f other.log',
+      });
+      await invocation.getConfirmationDetails(new AbortController().signal);
+
+      expect(
+        mockDebugLog.mock.calls.filter((call) =>
+          String(call[0]).includes('plants state'),
+        ),
+      ).toHaveLength(0);
+      mockIsShellCommandReadOnlyAST.mockReset();
     });
   });
 

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -52,6 +52,7 @@ import { MAX_CONCURRENT_MONITORS } from '../services/monitorRegistry.js';
 import {
   extractCommandRules,
   isShellCommandReadOnlyASTInDirectory,
+  plantsStateForLaterCommands,
 } from '../utils/shellAstParser.js';
 import { getCurrentAgentId } from '../agents/runtime/agent-context.js';
 import { getShellContextEnvVars } from '../services/shellContextEnv.js';
@@ -212,6 +213,10 @@ class MonitorToolInvocation extends BaseToolInvocation<
     const subCommands = splitCommands(normalized.safetyCommand);
     const confirmableSubCommands: string[] = [];
 
+    // See `plantsStateForLaterCommands`: after a `cd` or an `export`, a later
+    // sub-command no longer means alone what it means in sequence, so it must
+    // stay inside the scope the user approves.
+    let statePlanted = false;
     for (const sub of subCommands) {
       // Only filter out read-only commands via AST analysis.
       // We intentionally do NOT consult pm.isCommandAllowed() here because
@@ -220,9 +225,16 @@ class MonitorToolInvocation extends BaseToolInvocation<
       // Monitor is a long-running background process with a different risk
       // profile than one-shot shell execution and should maintain its own
       // permission boundary.
+      // Decided before the drop below, and never dropped itself: a planter
+      // that classifies read-only alone (`cd /hostile`) is the one segment
+      // the user most needs to see.
+      const plants = await plantsStateForLaterCommands(sub);
       let isReadOnly = false;
       try {
-        isReadOnly = await isShellCommandReadOnlyASTInDirectory(sub, cwd);
+        isReadOnly =
+          !statePlanted &&
+          !plants &&
+          (await isShellCommandReadOnlyASTInDirectory(sub, cwd));
       } catch (e) {
         // Conservative fallback: if AST analysis fails, keep the sub-command
         // in the confirmation scope instead of accidentally dropping it.
@@ -231,6 +243,8 @@ class MonitorToolInvocation extends BaseToolInvocation<
           e,
         );
       }
+
+      statePlanted ||= plants;
 
       if (isReadOnly) {
         continue;

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -238,12 +238,28 @@ class MonitorToolInvocation extends BaseToolInvocation<
       } catch (e) {
         // Conservative fallback: if AST analysis fails, keep the sub-command
         // in the confirmation scope instead of accidentally dropping it.
+        // Deliberately does NOT carry `plants`/`statePlanted`: the `&&` above
+        // short-circuits, so the classifier is only ever reached when both are
+        // already false. Logging them here would print two constants. The
+        // planter transition is logged below, where the value actually varies.
         debugLogger.warn(
           'AST read-only check failed for monitor sub-command, falling back to ask:',
           e,
         );
       }
 
+      // Logged on the transition only, and only here: this is the one place
+      // where the answer to "why does this dialog list more sub-commands than
+      // I expected" is not already visible. Everything after this segment
+      // stays in scope because of it, so the segment that caused it is worth
+      // naming. `debugLogger` no-ops without an active session, so the cost
+      // outside a debug run is a boolean test.
+      if (plants && !statePlanted) {
+        debugLogger.debug(
+          'monitor sub-command plants state; later sub-commands stay in the confirmation scope:',
+          sub,
+        );
+      }
       statePlanted ||= plants;
 
       if (isReadOnly) {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -7279,8 +7279,11 @@ describe('ShellTool', () => {
       expect(details.type).toBe('exec');
     });
 
-    it('should exclude read-only sub-commands from confirmation details in compound commands', async () => {
-      // "cd" is read-only, "npm run build" is not
+    it('keeps a directory-changing sub-command in the confirmation scope', async () => {
+      // `cd` classifies read-only on its own, and used to be dropped for it.
+      // But it is the segment that makes `npm run build` mean something other
+      // than what it says — the user has to see which directory they are
+      // approving a build in. A planter is never dropped.
       const params = {
         command: 'cd packages/core && npm run build',
         is_background: false,
@@ -7294,17 +7297,65 @@ describe('ShellTool', () => {
         new AbortController().signal,
       )) as { rootCommand: string; permissionRules: string[] };
 
-      // rootCommand should only include 'npm', not 'cd'
-      expect(details.rootCommand).not.toContain('cd');
+      expect(details.rootCommand).toContain('cd');
       expect(details.rootCommand).toContain('npm');
-
-      // permissionRules should not include Bash(cd *)
-      expect(details.permissionRules).not.toContainEqual(
-        expect.stringContaining('cd'),
-      );
       expect(details.permissionRules).toContainEqual(
         expect.stringContaining('npm'),
       );
+    });
+
+    it('still drops a read-only sub-command that plants nothing', async () => {
+      const invocation = shellTool.build({
+        command: 'ls -la && npm run build',
+        is_background: false,
+      });
+
+      const details = (await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      )) as { rootCommand: string; permissionRules: string[] };
+
+      expect(details.rootCommand).not.toContain('ls');
+      expect(details.rootCommand).toContain('npm');
+    });
+
+    it('keeps sub-commands after a state planter in the confirmation scope', async () => {
+      // A read-only classification is only meaningful for the directory and
+      // environment the sub-command actually runs in. After a `cd` or an
+      // `export`, classifying a later sub-command alone measures the wrong
+      // one — so it must stay in the scope the user approves, or approval
+      // silently covers a command the dialog never showed.
+      for (const command of [
+        'cd /hostile && git status && npm run build',
+        'export GIT_DIR=/hostile/.git && git status && npm run build',
+        // `hash -p` rewrites which binary the name `git` resolves to, and
+        // `unset PATH` changes resolution for everything after it. Neither
+        // touches the directory or the environment variables the planted
+        // config gate reads, so the later part still classifies read-only on
+        // its own text — the case the planter list exists to catch.
+        'hash -p ./evil/git git && git status && npm run build',
+        'unset PATH && git status && npm run build',
+      ]) {
+        const invocation = shellTool.build({ command, is_background: false });
+        const details = (await invocation.getConfirmationDetails(
+          new AbortController().signal,
+        )) as { rootCommand: string };
+
+        expect(details.rootCommand).toContain('git');
+        expect(details.rootCommand).toContain('npm');
+      }
+    });
+
+    it('still drops a read-only sub-command that no planter precedes', async () => {
+      const invocation = shellTool.build({
+        command: 'git status && npm run build',
+        is_background: false,
+      });
+      const details = (await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      )) as { rootCommand: string };
+
+      expect(details.rootCommand).not.toContain('git');
+      expect(details.rootCommand).toContain('npm');
     });
 
     it('should not surface file descriptor redirects as standalone commands in confirmation details', async () => {
@@ -7347,6 +7398,59 @@ describe('ShellTool', () => {
 
       expect(details.rootCommand).toBe('git');
       expect(details.permissionRules).toEqual(['Bash(git commit *)']);
+    });
+
+    it('does not let an allow rule drop a sub-command after a planter', async () => {
+      // The `statePlanted` gate has to hold on the allow-rule path too. An
+      // allow rule matches on the sub-command's own text, which after a `cd`
+      // no longer says where it runs — so approving a dialog that shows only
+      // `npm run build` would also run `git status` in the cd'd directory.
+      const pm = new PermissionManager({
+        getPermissionsAllow: () => ['Bash(git *)'],
+        getPermissionsAsk: () => [],
+        getPermissionsDeny: () => [],
+        getProjectRoot: () => '/test/dir',
+        getCwd: () => '/test/dir',
+      });
+      pm.initialize();
+      (mockConfig.getPermissionManager as Mock).mockReturnValue(pm);
+
+      const invocation = shellTool.build({
+        command: 'cd /repo2 && git status && npm run build',
+        is_background: false,
+      });
+
+      const details = (await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      )) as { rootCommand: string; permissionRules: string[] };
+
+      expect(details.rootCommand).toContain('cd');
+      expect(details.rootCommand).toContain('git');
+      expect(details.rootCommand).toContain('npm');
+    });
+
+    it('still lets an allow rule drop a sub-command with no planter before it', async () => {
+      const pm = new PermissionManager({
+        getPermissionsAllow: () => ['Bash(git *)'],
+        getPermissionsAsk: () => [],
+        getPermissionsDeny: () => [],
+        getProjectRoot: () => '/test/dir',
+        getCwd: () => '/test/dir',
+      });
+      pm.initialize();
+      (mockConfig.getPermissionManager as Mock).mockReturnValue(pm);
+
+      const invocation = shellTool.build({
+        command: 'git commit -m "msg" && npm run build',
+        is_background: false,
+      });
+
+      const details = (await invocation.getConfirmationDetails(
+        new AbortController().signal,
+      )) as { rootCommand: string; permissionRules: string[] };
+
+      expect(details.rootCommand).not.toContain('git');
+      expect(details.rootCommand).toContain('npm');
     });
 
     it('should pass the invocation directory to permission-manager command checks', async () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -74,6 +74,7 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { checkPriorRead, StructuredToolError } from './priorReadEnforcement.js';
 import {
   isShellCommandReadOnlyASTInDirectory,
+  plantsStateForLaterCommands,
   extractCommandRules,
 } from '../utils/shellAstParser.js';
 import {
@@ -2122,19 +2123,34 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // Split compound command and filter out already-allowed (read-only) sub-commands
     const subCommands = splitCommands(command);
     const confirmableSubCommands: string[] = [];
+    // A read-only classification is only meaningful for the directory and
+    // environment the sub-command actually runs in. Once an earlier one has
+    // planted state, classifying a later one alone measures the wrong world,
+    // so it stays in the scope the user approves. Mirrors
+    // `PermissionManager.evaluateCompoundCommand`.
+    let statePlanted = false;
     for (const sub of subCommands) {
+      // Decided before the drop below, and never dropped itself: a planter
+      // that happens to classify read-only on its own (`cd /hostile`) is the
+      // one segment the user most needs to see, since it is what makes the
+      // rest of the compound mean something other than what it says.
+      const plants = await plantsStateForLaterCommands(sub);
       let isReadOnly = false;
       try {
-        isReadOnly = await isShellCommandReadOnlyASTInDirectory(sub, cwd);
+        isReadOnly =
+          !statePlanted &&
+          !plants &&
+          (await isShellCommandReadOnlyASTInDirectory(sub, cwd));
       } catch {
         // conservative: treat unknown commands as requiring confirmation
       }
+      statePlanted ||= plants;
 
       if (isReadOnly) {
         continue;
       }
 
-      if (pm) {
+      if (pm && !statePlanted) {
         try {
           if ((await pm.isCommandAllowed(sub, cwd)) === 'allow') {
             continue;

--- a/packages/core/src/utils/shellAstParser.test.ts
+++ b/packages/core/src/utils/shellAstParser.test.ts
@@ -15,6 +15,7 @@ import {
   isShellCommandReadOnlyAST,
   isShellCommandReadOnlyASTInDirectory,
   extractCommandRules,
+  plantsStateForLaterCommands,
   _resetParser,
   _setParserFailedForTesting,
 } from './shellAstParser.js';
@@ -1334,5 +1335,100 @@ describe('consistency: isShellCommandReadOnly (regex) vs isShellCommandReadOnlyA
         false,
       );
     });
+  });
+});
+
+describe('plantsStateForLaterCommands', () => {
+  it('decides state planting on the parse, not on the leading word', async () => {
+    // A confirmation dialog is built by dropping the sub-commands that
+    // classify read-only, which is sound only while each part means the same
+    // thing alone as it does in sequence. Deciding that on raw text cannot be
+    // completed: the planter hides behind a block, a keyword, an assignment
+    // prefix, a resolution-order prefix, a respelling, a negation, or a
+    // function definition, and a bare assignment carries no command word.
+    for (const command of [
+      // named planters, plainly spelled
+      'cd x',
+      'pushd x',
+      'popd',
+      'export FOO=1',
+      'unset PATH',
+      'declare -x FOO=1',
+      'readonly FOO=1',
+      'typeset FOO=1',
+      'local FOO=1',
+      'set -e',
+      'shopt -s expand_aliases',
+      'alias git=evil',
+      'unalias -a',
+      'hash -p ./evil/git git',
+      "trap 'cp /tmp/evil .git/config' DEBUG",
+      'enable -f ./evil.so git',
+      'fc -e vi 1',
+      'let PATH=a',
+      'eval "$X"',
+      'exec > /tmp/out',
+      'source ./x',
+      '. ./x',
+      // variable-assigning builtins
+      'read PATH <<< ./evil',
+      'mapfile -t X < f',
+      'readarray -t X < f',
+      'getopts ab: opt',
+      'unsetenv PATH',
+      'printf -v PATH evil',
+      // bare assignment statement: no command word to anchor on
+      'PATH=evil',
+      'GIT_DIR=/hostile/.git',
+      // hiding shapes
+      '{ cd /hostile; }',
+      'if true; then cd /hostile; fi',
+      'FOO=1 cd /hostile',
+      'command cd /hostile',
+      'builtin cd /hostile',
+      'command -p cd /hostile',
+      'command -- cd /hostile',
+      'time cd /tmp',
+      '\\cd /hostile',
+      '"cd" /hostile',
+      '! cd /hostile',
+      'git() { rm -rf $HOME; }',
+      // a substitution in a redirect target runs before anything after it
+      'echo x < $(./evil.sh)',
+      'echo x > $(./evil.sh)',
+      // fails closed on anything it cannot read
+      '$CMD /hostile',
+      'cat <<EOF',
+    ]) {
+      expect(await plantsStateForLaterCommands(command)).toBe(true);
+    }
+  });
+
+  it('leaves ordinary commands alone', async () => {
+    for (const inert of [
+      'git status',
+      'npm run build',
+      'ls -la',
+      'cdr x',
+      'exports x',
+      'hashcat x',
+      'setup x',
+      'echo cd',
+      'FOO=1 ls',
+      'command git status',
+      'builtin echo hi',
+      'time npm run build',
+      'printf %s hello',
+      'npm run build 2>&1',
+      'echo x > /tmp/out',
+    ]) {
+      expect(await plantsStateForLaterCommands(inert)).toBe(false);
+    }
+  });
+
+  it('fails closed on an unparseable segment', async () => {
+    for (const command of ['', '   ', 'if then fi else']) {
+      expect(await plantsStateForLaterCommands(command)).toBe(true);
+    }
   });
 });

--- a/packages/core/src/utils/shellAstParser.ts
+++ b/packages/core/src/utils/shellAstParser.ts
@@ -1176,6 +1176,173 @@ async function classifyInternal(
     tree.delete();
   }
 }
+/**
+ * Builtins that rebind how a *later* command resolves or what it reads.
+ *
+ * `read`/`mapfile`/`readarray`/`getopts` are here alongside the obvious
+ * `cd`/`export` family because they assign variables from stdin or argv —
+ * `read PATH <<< ./evil` plants exactly what `export PATH=./evil` does — and
+ * `let PATH=a` assigns arithmetically. `trap`, `enable`, `fc`, `alias`,
+ * `unalias`, `hash` and `shopt` rebind what a later *name* resolves to, which
+ * is the same unsoundness reached from the other side: a `DEBUG` trap runs
+ * before every later command without appearing in any of them. `exec` is here
+ * rather than among the resolution prefixes below because `exec > file`
+ * carries no command at all and redirects the current shell.
+ */
+const STATE_PLANTING_BUILTIN =
+  /^(?:cd|pushd|popd|export|unset|declare|readonly|typeset|local|set|shopt|alias|unalias|hash|trap|enable|fc|let|eval|exec|source|\.|read|mapfile|readarray|getopts)$/;
+
+/**
+ * Words that only choose *how* the next word is resolved, so the planter may
+ * be hiding behind one: `command cd /hostile`, `builtin cd /hostile`,
+ * `time cd /hostile` (bash's `time` keyword does not fork, so the `cd` lands
+ * on the current shell).
+ */
+const RESOLUTION_ORDER_PREFIX = /^(?:command|builtin|time)$/;
+
+/** Shapes that are a list of statements rather than a statement themselves. */
+const TRANSPARENT_STATEMENT_WRAPPER: ReadonlySet<string> = new Set([
+  'list',
+  'pipeline',
+  'redirected_statement',
+]);
+
+/** Substitutions bash evaluates while expanding a redirect target. */
+const REDIRECT_TARGET_SUBSTITUTION: Set<string> = new Set([
+  'command_substitution',
+  'process_substitution',
+]);
+
+/**
+ * The literal text a word carries after bash strips its quoting, or `null`
+ * when the word is not a plain literal at all.
+ *
+ * `\\cd` and `"cd"` are the same command as `cd` to bash but different text to
+ * a regex, which is one of the ways an enumerated planter used to hide.
+ */
+function literalWordText(node: SyntaxNode): string | null {
+  if (hasShellExpansion(node)) return null;
+  const stripped = stripOuterQuotes(node.text).replace(/\\(.)/g, '$1');
+  return /^[A-Za-z0-9_.-]+$/.test(stripped) ? stripped : null;
+}
+
+/**
+ * Whether one parsed statement plants state for whatever follows it.
+ *
+ * Fails closed by shape: only a plain `command` node can be cleared, and only
+ * once its resolved name is read and found not to be a planter. Every other
+ * shape — a bare `variable_assignment`, a `declaration_command`, an
+ * `unset_command`, a `function_definition`, a `negated_command`, a block, a
+ * keyword statement, a subshell — is treated as planting, because each is
+ * either a planter itself or a container the enumeration cannot see into.
+ *
+ * Inside a `command` node the same discipline applies to the parts that are
+ * not the name: a resolution-order prefix followed by anything this function
+ * cannot read is assumed to hide a planter rather than assumed not to, and
+ * `printf -v VAR` assigns despite `printf` being an ordinary name.
+ */
+function statementPlantsState(node: SyntaxNode): boolean {
+  if (node.type === 'comment') return false;
+  if (TRANSPARENT_STATEMENT_WRAPPER.has(node.type)) {
+    // Mirrors the classifier's own `redirected_statement` arm: the redirect
+    // operator itself plants nothing, but whatever follows a heredoc opener on
+    // the same line is parsed *inside* the redirect node, so its non-inert
+    // children are still real statements.
+    return node.namedChildren.some((child) =>
+      child.type.endsWith('_redirect')
+        ? redirectPlantsState(child)
+        : statementPlantsState(child),
+    );
+  }
+  if (node.type !== 'command') return true;
+
+  let sawResolutionPrefix = false;
+  let name: string | null = null;
+  for (const child of node.namedChildren) {
+    // A `VAR=VALUE` prefix on a command is scoped to that command, so it is
+    // not itself a planter — but the command it prefixes may be.
+    if (child.type === 'variable_assignment') continue;
+    // Redirects attach to the enclosing `redirected_statement`, not to the
+    // `command` itself, so they are screened in the wrapper arm above; this
+    // only guards against a grammar that starts attaching them here.
+    if (child.type.endsWith('_redirect')) continue;
+    if (name !== null) {
+      // Past the command name: only `printf -v VAR` still assigns.
+      if (name === 'printf' && /^-v/.test(stripOuterQuotes(child.text)))
+        return true;
+      continue;
+    }
+    const text = literalWordText(child);
+    if (text === null) return true;
+    if (STATE_PLANTING_BUILTIN.test(text)) return true;
+    if (RESOLUTION_ORDER_PREFIX.test(text)) {
+      sawResolutionPrefix = true;
+      continue;
+    }
+    // `command -p cd /hostile` and `command -- cd /hostile` put the planter
+    // behind a flag. The flags a resolution prefix takes are its own small
+    // vocabulary, but reading past one to find the real name is the kind of
+    // enumeration this predicate exists to stop doing — so a dash-leading word
+    // after a prefix plants.
+    if (sawResolutionPrefix && text.startsWith('-')) return true;
+    name = text;
+  }
+  return false;
+}
+
+/** Whether a redirect node runs something while its target is expanded. */
+function redirectPlantsState(node: SyntaxNode): boolean {
+  // The safety axis evaluates a substitution separately, on its own nodes, so
+  // it can treat one inside a redirect as inert. The plant axis has no such
+  // second pass: `echo x < $(./evil.sh)` runs the script before anything
+  // after it is classified.
+  return collectDescendants(node, REDIRECT_TARGET_SUBSTITUTION).length > 0;
+}
+
+/**
+ * Whether a sub-command plants state that makes classifying the sub-commands
+ * after it in isolation unsound.
+ *
+ * A confirmation dialog is built by splitting a compound command and dropping
+ * the parts that classify read-only, so the user approves only what needs
+ * approving. That is sound only while each part means the same thing alone as
+ * it does in sequence. `cd /hostile && wrapper status` moves the directory the
+ * planted-config gate probes; `export GIT_DIR=/hostile/.git && wrapper status`
+ * moves it with no `cd` at all; `hash -p ./evil/git git && git status` rewrites
+ * which binary the name `git` resolves to. Either way the later part is probed
+ * against the wrong world, classifies read-only, and vanishes from the scope
+ * the user is shown — while approval still runs the original compound.
+ *
+ * Decided on the parse rather than on the raw text, because the text form
+ * cannot be enumerated: a planter hides behind a block (`{ cd /hostile; }`), a
+ * keyword (`if true; then cd /hostile; fi`), an assignment prefix
+ * (`FOO=1 cd /hostile`), a resolution-order prefix (`command cd /hostile`), a
+ * respelling (`\\cd`, `"cd"`), a negation (`! cd /hostile`), or a function
+ * definition that rebinds a trusted name (`git() { rm -rf $HOME; }`), and a
+ * bare `PATH=evil` assignment statement carries no command word at all.
+ *
+ * Fails closed: an unparseable or unrecognised segment plants, which costs a
+ * larger confirmation dialog rather than a silently narrowed one.
+ */
+export async function plantsStateForLaterCommands(
+  command: string,
+): Promise<boolean> {
+  if (typeof command !== 'string' || !command.trim()) return true;
+  let tree: Parser.Tree;
+  try {
+    tree = await parseShellCommand(command);
+  } catch {
+    return true;
+  }
+  try {
+    const root = tree.rootNode;
+    if (root.hasError || root.namedChildCount === 0) return true;
+    return root.namedChildren.some(statementPlantsState);
+  } finally {
+    tree.delete();
+  }
+}
+
 export async function classifyShellCommandSafety(
   command: string,
 ): Promise<ShellCommandSafety> {


### PR DESCRIPTION
## What this PR does

Stops the shell confirmation dialog from showing less than what it runs.

The dialog is built by splitting a compound command and dropping the parts that classify read-only, so the user approves only what needs approving. That is sound only while each part means the same thing alone as it does in sequence — and after a `cd`, an `export`, or a `hash -p` it does not. `cd /hostile && git status && npm run build` showed the user `npm`, dropped `git status` as independently read-only, and then executed the whole original compound, `git status` included, in the planted directory. Approval covered a command the dialog never displayed.

Both call sites — `ShellTool` and `MonitorTool` — now stop dropping sub-commands once an earlier one has planted state, mirroring what `PermissionManager.evaluateCompoundCommand` already does. The planter is decided *before* its own drop decision and is never dropped itself: `cd /hostile` classifies read-only on its own, and it is precisely the segment the user most needs to see. The gate also covers the allow-rule path, since a `Bash(git *)` rule matches on a sub-command's own text, which after a `cd` no longer says where it runs.

**Whether a segment plants is decided on the parse, not the raw text.** A leading-word regex cannot be completed here: the planter hides behind a block (`{ cd /hostile; }`), a keyword (`if true; then cd /hostile; fi`), an assignment prefix (`FOO=1 cd`), a resolution-order prefix (`command -p cd`), a respelling (`\cd`, `"cd"`), a negation (`! cd`), or a function definition that rebinds a trusted name (`git() { rm -rf $HOME; }`) — and a bare `PATH=evil` assignment carries no command word at all. So only a plain `command` node whose resolved name is not a planter is cleared, and every other shape fails closed. That costs a larger dialog, never a silently narrowed one.

The planter set covers the builtins that rebind what a later command resolves to or reads: the `cd`/`export` family, the assigning builtins (`read`, `mapfile`, `readarray`, `getopts`, `printf -v`), and the resolution-rebinding ones (`hash`, `alias`, `unalias`, `trap`, `enable`, `fc`, `shopt`, `let`, `exec`). A substitution in a redirect target plants too: `echo x < $(./evil.sh)` runs the script before anything after it is classified.

## Why it's needed

This is an approve-what-wasn't-shown bug. `execute()` runs `this.params.command` — the full original string — while the dialog is assembled from a filtered subset. Any gap between the two is a command the user authorised without seeing, and the gap is reachable with a single `cd`.

## Reviewer Test Plan

### How to verify

```
cd packages/core && npx vitest run src/utils/shellAstParser.test.ts src/tools/shell.test.ts src/tools/monitor.test.ts

 Test Files  3 passed (3)
      Tests  936 passed (936)
```

Behavioural check, before this change on `main` — build a `ShellToolInvocation` for `cd /repo2 && git status && npm run build` and read `getConfirmationDetails()`:

- **Before:** `rootCommand` is `npm`. `git status` and `cd` are both gone.
- **After:** `rootCommand` is `cd, git, npm`.

The drop itself is intact for segments that mean the same thing alone as in sequence — `ls -la && npm run build` still drops `ls`.

Mutation-verified on both sides: removing the `statePlanted` gate in `shell.ts` fails 1 test, in `monitor.ts` fails 2; removing the allow-rule guard fails 1; forcing the planter decision to `false` fails 3; and clearing every non-`command` shape in the predicate fails 1.

`monitor.test.ts` previously mocked the whole `shellAstParser` module; the mock now spreads `importOriginal()` so the confirmation scope runs against the real predicate — a stub returning `false` would hide the very defect these tests guard.

Note: `src/permissions/permission-manager.test.ts` has 2 failures on `main` at this commit (`resolveToolName exhaustiveness (#9827)`, about `ReportFindings`). They are unrelated to this PR and reproduce on a clean `origin/main` checkout.

### Evidence (Before & After)

The user-visible change is the content of the confirmation dialog's question line and its extracted permission rules, both asserted in `shell.test.ts` / `monitor.test.ts` as above. No layout or styling change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

## Risk & Scope

- **Main risk:** confirmation dialogs get longer. Any compound whose first segment is a planter now lists every later segment, including ones the user was used to seeing dropped. That is the intended direction — the dialog should not claim a smaller scope than it grants — but it is more clicking for `cd x && <read-only thing>`.
- **Also:** the predicate fails closed on anything it cannot parse or recognise, so an exotic-but-harmless segment will keep later ones in scope rather than drop them. Deliberate: over-showing is recoverable, under-showing is not.
- **Not validated / out of scope:** the pre-existing `permission-manager` failures noted above. `isToolCallConcurrencySafe` is untouched — it is a batching optimisation, not a permission decision.
- **Breaking changes:** none.

## Linked Issues

No issue to close. This is a self-contained correctness fix carved out of #9950 — the confirmation-scope and state-planter gaps surfaced while that PR was under review, and they are filed separately so they can land on their own merits. Referenced without a closing keyword: #9950.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

阻止 shell 确认对话框「显示的比实际执行的少」。

对话框的构建方式是：拆分复合命令，丢弃其中被判为只读的部分，让用户只批准需要批准的内容。这只在「每一部分单独出现时与在序列中含义相同」时才成立——而在 `cd`、`export` 或 `hash -p` 之后就不成立了。`cd /hostile && git status && npm run build` 只向用户展示 `npm`，把 `git status` 作为独立只读丢弃，然后在被植入的目录里执行整条原始复合命令（包含 `git status`）。批准覆盖了一条对话框从未展示过的命令。

两处调用点（`ShellTool` 与 `MonitorTool`）现在在前序子命令植入状态后不再丢弃后续子命令，与 `PermissionManager.evaluateCompoundCommand` 的既有行为一致。植入者在其自身的丢弃判定**之前**被识别，且永不被丢弃：`cd /hostile` 单独看是只读的，而它恰恰是用户最需要看到的那一段。该门禁同样覆盖 allow 规则路径，因为 `Bash(git *)` 这类规则匹配的是子命令自身的文本，而在 `cd` 之后那段文本已不再说明它在哪里运行。

**是否植入由解析结果判定，而非原始文本。** 首词正则在这里无法穷尽：植入者会藏在代码块（`{ cd /hostile; }`）、关键字（`if true; then cd /hostile; fi`）、赋值前缀（`FOO=1 cd`）、解析顺序前缀（`command -p cd`）、改写拼法（`\cd`、`"cd"`）、取反（`! cd`）或重绑定可信名字的函数定义（`git() { rm -rf $HOME; }`）之后，而裸的 `PATH=evil` 赋值根本没有命令词。因此只有「解析出的名字不是植入者的普通 `command` 节点」才被放行，其余所有形态一律 fail closed。代价是更长的对话框，而绝不是被静默收窄的对话框。

## 为什么需要它

这是一个「批准了未展示内容」的缺陷。`execute()` 运行的是 `this.params.command`——完整的原始字符串——而对话框由过滤后的子集拼装。两者之间的任何差距都是用户在未看见的情况下授权的命令，而一个 `cd` 就能造出这个差距。

## 验证方式

见上文英文部分的命令与前后对比。两侧均做了变异测试：移除 `shell.ts` 的 `statePlanted` 门禁导致 1 个失败，`monitor.ts` 导致 2 个；移除 allow 规则守卫导致 1 个；把植入判定强制为 `false` 导致 3 个；把谓词中所有非 `command` 形态放行导致 1 个。

`monitor.test.ts` 此前整体 mock 了 `shellAstParser` 模块；现在改为展开 `importOriginal()`，使确认作用域跑在真实谓词上——返回 `false` 的 stub 会掩盖这些测试本要守护的缺陷。

注：本提交所基于的 `main` 上，`permission-manager.test.ts` 本身有 2 个与本 PR 无关的失败。

## 风险与范围

- **主要风险：** 确认对话框会变长。任何首段是植入者的复合命令现在都会列出后续每一段，包括用户习惯于看到被丢弃的那些。这是预期方向——对话框不应宣称比它实际授予的更小的范围——但 `cd x && <只读操作>` 会多点一次。
- **另外：** 谓词对任何无法解析或识别的内容 fail closed，因此某个罕见但无害的段落会把后续段落保留在范围内而非丢弃。这是刻意的：多显示可以挽回，少显示不能。
- **明确不在范围内：** 上述 `main` 自带的失败；`isToolCallConcurrencySafe` 不动，它是批处理优化而非权限决策。
- **破坏性变更：** 无。

## 关联 Issue

没有需要关闭的 issue。这是从 #9950 中拆分出来的一处独立正确性修复——确认范围与状态植入这两个缺口是在那个 PR 评审过程中发现的，单独提出以便独立评审合入。仅作引用、不带关闭关键字：#9950。

</details>

