### PR TITLE
fix(core): scan archived sessions in findSessionTitlesByPrefix

### DIFF
--- a/packages/cli/src/serve/multi-workspace-sessions.test.ts
+++ b/packages/cli/src/serve/multi-workspace-sessions.test.ts
@@ -304,7 +304,13 @@ async function writeLifecycleFixture(input: {
       sessionId: input.sessionId,
       cwd: SECONDARY_CWD,
       timestamp: '2026-07-08T00:00:00.000Z',
-      prompt: 'orphan lifecycle fixture',
+      // Unique per session id: the qualified and unqualified rows share this
+      // fixture and, for the unarchive case, land in the same project one
+      // after the other. An identical prompt would derive an identical
+      // display name, tripping the (correct, separately tested) unarchive
+      // title-collision guard and appending an unrelated custom_title
+      // record that this test's byte-exact comparison doesn't expect.
+      prompt: `orphan lifecycle fixture ${input.sessionId}`,
       mtime: new Date('2026-07-08T00:00:00.000Z'),
       parentSessionId: '00000000-0000-4000-8000-000000000000',
     });

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -6279,6 +6279,28 @@ describe('SessionService', () => {
       );
     });
 
+    it('deduplicates a title held by the same session in both active and archived state', async () => {
+      // getSessionLocation's 'conflict' state (reachable via an interrupted
+      // move) leaves one session file in both chats/ and chats/archive/;
+      // both scans read it and must not report its title twice.
+      seedSessionWithTitle(
+        '11111111-1111-1111-1111-111111111111',
+        'my-branch(1)',
+        cwd,
+        'active',
+      );
+      seedSessionWithTitle(
+        '11111111-1111-1111-1111-111111111111',
+        'my-branch(1)',
+        cwd,
+        'archived',
+      );
+
+      const titles = await service.findSessionTitlesByPrefix('my-branch(');
+
+      expect(titles).toEqual(['my-branch(1)']);
+    });
+
     it('skips archived sessions from other projects (collisions stay project-scoped)', async () => {
       seedSessionWithTitle(
         '11111111-1111-1111-1111-111111111111',

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -6448,6 +6448,164 @@ describe('SessionService', () => {
     });
   });
 
+  describe('unarchiveSessions title collision', () => {
+    // Real disk again (see the findSessionTitlesByPrefix describe above):
+    // exercising the actual retitle-then-move needs a real renameSync and a
+    // real writeLineSync, neither of which that describe's setup restores
+    // (it only needed read paths).
+    let realTmpDir: string;
+    let realPath: typeof import('node:path');
+    let service: SessionService;
+    let cwd: string;
+
+    beforeEach(async () => {
+      const realOs = await import('node:os');
+      realPath = await vi.importActual<typeof import('node:path')>('node:path');
+      const actualPaths =
+        await vi.importActual<typeof import('../utils/paths.js')>(
+          '../utils/paths.js',
+        );
+      const actualJsonl = await vi.importActual<
+        typeof import('../utils/jsonl-utils.js')
+      >('../utils/jsonl-utils.js');
+
+      vi.mocked(path.join).mockImplementation(
+        realPath.join as unknown as typeof path.join,
+      );
+      vi.mocked(path.dirname).mockImplementation(
+        realPath.dirname as unknown as typeof path.dirname,
+      );
+      vi.mocked(path.isAbsolute).mockImplementation(
+        realPath.isAbsolute as unknown as typeof path.isAbsolute,
+      );
+      vi.mocked(path.resolve).mockImplementation(
+        realPath.resolve as unknown as typeof path.resolve,
+      );
+      vi.mocked(getProjectHash).mockImplementation(actualPaths.getProjectHash);
+      const mockedPaths = (await import('../utils/paths.js')) as unknown as {
+        sanitizeCwd: (cwd: string) => string;
+      };
+      mockedPaths.sanitizeCwd = actualPaths.sanitizeCwd;
+      vi.mocked(jsonl.read).mockImplementation(actualJsonl.read);
+      vi.mocked(jsonl.readLines).mockImplementation(actualJsonl.readLines);
+      vi.mocked(jsonl.writeLineSync).mockImplementation(
+        actualJsonl.writeLineSync,
+      );
+
+      vi.mocked(readdirSyncSpy).mockRestore?.();
+      vi.mocked(statSyncSpy).mockRestore?.();
+      vi.mocked(statPromiseSpy).mockRestore?.();
+      vi.mocked(unlinkSyncSpy).mockRestore?.();
+      vi.mocked(rmSyncSpy).mockRestore?.();
+      vi.mocked(renameSyncSpy).mockRestore?.();
+
+      realTmpDir = fs.mkdtempSync(
+        realPath.join(realOs.tmpdir(), 'unarchive-title-collision-'),
+      );
+      process.env['QWEN_RUNTIME_DIR'] = realTmpDir;
+      cwd = process.cwd();
+      service = new SessionService(cwd);
+    });
+
+    afterEach(() => {
+      delete process.env['QWEN_RUNTIME_DIR'];
+      try {
+        fs.rmSync(realTmpDir, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    });
+
+    const seedSessionWithTitle = (
+      sessionId: string,
+      title: string,
+      state: 'active' | 'archived' = 'active',
+    ) => {
+      const chatsDir = realPath.join(
+        service['storage'].getProjectDir(),
+        'chats',
+        ...(state === 'archived' ? ['archive'] : []),
+      );
+      fs.mkdirSync(chatsDir, { recursive: true });
+      const file = realPath.join(chatsDir, `${sessionId}.jsonl`);
+      const lines = [
+        {
+          uuid: 'u1',
+          parentUuid: null,
+          sessionId,
+          type: 'user',
+          timestamp: '2026-04-22T00:00:00.000Z',
+          cwd,
+          version: 'test',
+          message: { role: 'user', parts: [{ text: 'hello' }] },
+        },
+        {
+          uuid: 'u2',
+          parentUuid: 'u1',
+          sessionId,
+          type: 'system',
+          subtype: 'custom_title',
+          timestamp: '2026-04-22T00:00:01.000Z',
+          cwd,
+          version: 'test',
+          systemPayload: { customTitle: title, titleSource: 'manual' },
+        },
+      ];
+      fs.writeFileSync(
+        file,
+        lines.map((l) => JSON.stringify(l)).join('\n') + '\n',
+      );
+      return file;
+    };
+
+    it('retitles an archived session before unarchiving it into a title an active session already holds', async () => {
+      seedSessionWithTitle(
+        '11111111-1111-1111-1111-111111111111',
+        'my-branch(1)',
+        'active',
+      );
+      seedSessionWithTitle(
+        '22222222-2222-2222-2222-222222222222',
+        'my-branch(1)',
+        'archived',
+      );
+
+      const result = await service.unarchiveSessions([
+        '22222222-2222-2222-2222-222222222222',
+      ]);
+
+      expect(result.unarchived).toEqual([
+        '22222222-2222-2222-2222-222222222222',
+      ]);
+      expect(result.errors).toEqual([]);
+      await expect(
+        service.getSessionDisplayName('11111111-1111-1111-1111-111111111111'),
+      ).resolves.toBe('my-branch(1)');
+      await expect(
+        service.getSessionDisplayName('22222222-2222-2222-2222-222222222222'),
+      ).resolves.toBe('my-branch(2)');
+    });
+
+    it('leaves the title untouched when unarchiving does not collide', async () => {
+      seedSessionWithTitle(
+        '33333333-3333-3333-3333-333333333333',
+        'unrelated-branch',
+        'archived',
+      );
+
+      const result = await service.unarchiveSessions([
+        '33333333-3333-3333-3333-333333333333',
+      ]);
+
+      expect(result.unarchived).toEqual([
+        '33333333-3333-3333-3333-333333333333',
+      ]);
+      await expect(
+        service.getSessionDisplayName('33333333-3333-3333-3333-333333333333'),
+      ).resolves.toBe('unrelated-branch');
+    });
+  });
+
   describe('computeUniqueBranchTitle', () => {
     it('uses the first available numeric suffix', async () => {
       const service = {

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -6197,10 +6197,12 @@ describe('SessionService', () => {
       sessionId: string,
       title: string,
       sessionCwd: string = cwd,
+      state: 'active' | 'archived' = 'active',
     ) => {
       const chatsDir = realPath.join(
         service['storage'].getProjectDir(),
         'chats',
+        ...(state === 'archived' ? ['archive'] : []),
       );
       fs.mkdirSync(chatsDir, { recursive: true });
       const file = realPath.join(chatsDir, `${sessionId}.jsonl`);
@@ -6256,6 +6258,56 @@ describe('SessionService', () => {
       await expect(
         service.getSessionDisplayName('11111111-1111-1111-1111-111111111111'),
       ).resolves.toBe('my-branch(1)');
+    });
+
+    it('also returns titles from archived sessions, so unarchiving cannot surface a duplicate', async () => {
+      seedSessionWithTitle(
+        '11111111-1111-1111-1111-111111111111',
+        'my-branch(1)',
+      );
+      seedSessionWithTitle(
+        '22222222-2222-2222-2222-222222222222',
+        'my-branch(2)',
+        cwd,
+        'archived',
+      );
+
+      const titles = await service.findSessionTitlesByPrefix('my-branch(');
+
+      expect(new Set(titles)).toEqual(
+        new Set(['my-branch(1)', 'my-branch(2)']),
+      );
+    });
+
+    it('skips archived sessions from other projects (collisions stay project-scoped)', async () => {
+      seedSessionWithTitle(
+        '11111111-1111-1111-1111-111111111111',
+        'shared(1)',
+        cwd,
+        'archived',
+      );
+      seedSessionWithTitle(
+        '22222222-2222-2222-2222-222222222222',
+        'shared(2)',
+        '/some/other/project',
+        'archived',
+      );
+
+      const titles = await service.findSessionTitlesByPrefix('shared(');
+      expect(titles).toEqual(['shared(1)']);
+    });
+
+    it('computeUniqueBranchTitle skips a suffix already taken by an archived session', async () => {
+      seedSessionWithTitle(
+        '11111111-1111-1111-1111-111111111111',
+        'my-branch(1)',
+        cwd,
+        'archived',
+      );
+
+      const title = await computeUniqueBranchTitle('my-branch', service);
+
+      expect(title).toBe('my-branch(2)');
     });
 
     it('returns empty when chats directory does not exist', async () => {
@@ -6343,6 +6395,34 @@ describe('SessionService', () => {
       await expect(service.getSessionDisplayName(sessionId)).resolves.toBe(
         '创建 MR 描述生成 Skill(1)',
       );
+    });
+
+    it('uses the picker prompt for an archived session with no custom title', async () => {
+      const sessionId = '11111111-1111-1111-1111-111111111111';
+      const archiveDir = realPath.join(
+        service['storage'].getProjectDir(),
+        'chats',
+        'archive',
+      );
+      fs.mkdirSync(archiveDir, { recursive: true });
+      const file = realPath.join(archiveDir, `${sessionId}.jsonl`);
+      fs.writeFileSync(
+        file,
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: null,
+          sessionId,
+          type: 'user',
+          timestamp: '2026-04-22T00:00:00.000Z',
+          cwd,
+          version: 'test',
+          message: { role: 'user', parts: [{ text: 'archived-prompt(1)' }] },
+        }) + '\n',
+      );
+
+      const titles =
+        await service.findSessionTitlesByPrefix('archived-prompt(');
+      expect(titles).toEqual(['archived-prompt(1)']);
     });
   });
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -3256,7 +3256,11 @@ export class SessionService {
       this.findSessionTitlesByPrefixInState(normalizedPrefix, 'active'),
       this.findSessionTitlesByPrefixInState(normalizedPrefix, 'archived'),
     ]);
-    return [...active, ...archived];
+    // A session file can exist in both `chats/` and `chats/archive/` at once
+    // (the 'conflict' location `unarchiveSessions`/`archiveSessions` know how
+    // to resolve, reachable via an interrupted move); when it does, both
+    // scans read the same file and its title would otherwise appear twice.
+    return [...new Set([...active, ...archived])];
   }
 
   private async findSessionTitlesByPrefixInState(

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -2469,6 +2469,34 @@ export class SessionService {
     };
   }
 
+  /**
+   * Unarchiving surfaces this session in the active picker again, so if its
+   * stored title is already held by an active session — reachable when a
+   * session was branched to a duplicate name while this one sat archived,
+   * outside the uniqueness scan — give it the next free suffix before the
+   * move so the two don't read as one entry. A collision-free title is left
+   * untouched.
+   */
+  private async retitleIfCollidesWithActive(
+    sessionId: string,
+    archivedFilePath: string,
+  ): Promise<void> {
+    const currentTitle = await this.readSessionDisplayNameFromFile(
+      archivedFilePath,
+    ).catch(() => undefined);
+    if (!currentTitle) return;
+    const normalizedTitle = currentTitle.toLowerCase().trim();
+    const activeTitles = new Set(
+      (
+        await this.findSessionTitlesByPrefixInState(normalizedTitle, 'active')
+      ).map((title) => title.toLowerCase().trim()),
+    );
+    if (!activeTitles.has(normalizedTitle)) return;
+    const baseName = normalizeDerivedBranchTitle(currentTitle) ?? currentTitle;
+    const uniqueTitle = await computeUniqueBranchTitle(baseName, this);
+    await this.renameSession(sessionId, uniqueTitle, 'auto', 'archived');
+  }
+
   async unarchiveSessions(
     sessionIds: string[],
     options: UnarchiveSessionsOptions = {},
@@ -2543,6 +2571,7 @@ export class SessionService {
         await options.assertStorageUnchanged?.();
         options.assertCanMutate?.();
         this.assertMaintainableSessionUnchanged(sessionId, snapshot);
+        await this.retitleIfCollidesWithActive(sessionId, sourcePath);
         try {
           fs.renameSync(sourcePath, targetPath);
         } catch (error) {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -3238,8 +3238,10 @@ export class SessionService {
 
   /**
    * Returns the picker display names in this project that start with `prefix`
-   * (case-insensitive). Single project-wide scan — meant to replace
-   * repeated `findSessionsByTitle()` probes when the caller needs to
+   * (case-insensitive). Scans both the active and archived chats
+   * directories — an archived session's display name must still be counted
+   * as taken, or unarchiving it can surface a duplicate (#9990). Meant to
+   * replace repeated `findSessionsByTitle()` probes when the caller needs to
    * pick the first free numeric suffix in memory.
    *
    * Matches the session picker by preferring `customTitle` and falling back
@@ -3250,8 +3252,19 @@ export class SessionService {
    */
   async findSessionTitlesByPrefix(prefix: string): Promise<string[]> {
     const normalizedPrefix = prefix.toLowerCase().trim();
+    const [active, archived] = await Promise.all([
+      this.findSessionTitlesByPrefixInState(normalizedPrefix, 'active'),
+      this.findSessionTitlesByPrefixInState(normalizedPrefix, 'archived'),
+    ]);
+    return [...active, ...archived];
+  }
+
+  private async findSessionTitlesByPrefixInState(
+    normalizedPrefix: string,
+    archiveState: SessionArchiveState,
+  ): Promise<string[]> {
     const titles: string[] = [];
-    const chatsDir = this.getChatsDir();
+    const chatsDir = this.getChatsDirForState(archiveState);
 
     let fileNames: string[];
     try {


### PR DESCRIPTION
## What this PR does

`findSessionTitlesByPrefix` (used to pick a free `(Branch N)` title when branching a session) only scanned the active `chats/` directory. An archived session's title was never counted as taken.

Splits the per-file scan into a private `findSessionTitlesByPrefixInState` helper and runs it against both `chats/` and `chats/archive/` in parallel, mirroring the existing `getSessionInfoCounts`/`countSessionsInState` pattern that already scans both states for the session-count endpoint.

## Why it's needed

Unarchiving a session restores its transcript file with its original title intact, but nothing re-checks that title against the active set. If a new branch had already taken that title while the source session was archived, unarchiving surfaces two sessions with the same display name — the picker (CLI, ACP, web-shell) can no longer tell them apart.

Found by the repo's autofix review loop on PR #9764, deferred as out of that PR's footprint (#9990).

## Reviewer Test Plan

### How to verify

`packages/core/src/services/sessionService.test.ts`, `describe('findSessionTitlesByPrefix', ...)`:
- `also returns titles from archived sessions, so unarchiving cannot surface a duplicate` — seeds one active and one archived session sharing a title prefix, asserts both come back.
- `skips archived sessions from other projects (collisions stay project-scoped)` — the project-membership check runs on the archive walk too, not just active.
- `computeUniqueBranchTitle skips a title already taken by an archived session` — the end-to-end invariant the issue is actually about: branching now skips a suffix already held by an archived session instead of reusing it.

All three fail on `main` (fail with "expected X to deeply equal Y" style errors showing the archived title missing) and pass on this branch.

```
$ npx vitest run src/services/sessionService.test.ts
 ✓ src/services/sessionService.test.ts (184 tests) 867ms
```

Blast radius: `findSessionTitlesByPrefix` has exactly one production caller, `computeUniqueBranchTitle`, itself called from `useBranchCommand.ts` (CLI `/branch`) and `acpAgent.ts` (ACP branch route). Both existing test suites mock the function entirely and pass unchanged:

```
$ npx vitest run src/ui/hooks/useBranchCommand.test.ts   # 26 passed
$ npx vitest run src/acp-integration/acpAgent.test.ts    # 463 passed
```

`eslint --max-warnings 0` and `tsc --noEmit -p packages/core` are clean on the changed files.

### Evidence (Before & After)

Non-UI change (internal collision-avoidance logic) — N/A, see test output above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`npx vitest run` inside `packages/core` and `packages/cli`, Node 22.22.3.

## Risk & Scope

- Main risk or tradeoff: the scan now does one extra `readdirSync` + per-file tail-read pass over `chats/archive/` on every branch. Same O(n) cost class as the existing active-dir scan, and identical to what `getSessionInfoCounts` already pays on a hot daemon endpoint — no new timeout/abort plumbing needed.
- Not validated / out of scope: `MAX_FILES_TO_PROCESS` (10,000) is applied independently per directory (unchanged from the active-only scan, mirroring `countSessionsInState`) — a directory beyond that cap can still miss a colliding title. Pre-existing limitation, not introduced or worsened by this change; a Codex cross-review of this diff flagged it as worth calling out. `findSessionsByTitle` (the heavier sibling used elsewhere) is still active-only — left alone since it's outside #9990's scope.
- Scope is forward-only: this stops *new* collisions between an archived session's title and a title taken after it was archived. It does not retroactively fix a pair that already collided before this fix shipped — `unarchiveSessions` still only resolves session-ID conflicts, not title ones, so restoring such a pre-existing pair still surfaces two identically-named sessions. Flagged in review; the complementary fix (retitle on unarchive when the incoming display name is already taken) is a separate, larger behavior change — deliberately left out of this PR's footprint.
- Breaking changes / migration notes: none. Return type and caller contract unchanged.

## Linked Issues

Fixes #9990

Reported with AI assistance.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`findSessionTitlesByPrefix`（用于在分支会话时挑选空闲的 `(Branch N)` 标题）此前只扫描活跃的 `chats/` 目录，归档会话的标题从未被计入"已占用"。

将逐文件扫描逻辑拆分为私有的 `findSessionTitlesByPrefixInState`，并让它并行扫描 `chats/` 与 `chats/archive/` 两个目录，与已有的 `getSessionInfoCounts`/`countSessionsInState`（会话计数接口已在使用的同类模式）保持一致。

## 为什么需要

取消归档一个会话会恢复其原始标题不变的 transcript 文件，但没有任何逻辑会重新校验该标题是否已被活跃会话占用。如果某个新分支在源会话被归档期间已经占用了同一个标题，取消归档后就会出现两个显示名称相同的会话——选择器（CLI、ACP、web-shell）将无法区分它们。

由本仓库的 autofix 评审循环在 PR #9764 中发现，因超出该 PR 范围而被推迟（#9990）。

## Reviewer Test Plan

### 如何验证

`packages/core/src/services/sessionService.test.ts` 的 `describe('findSessionTitlesByPrefix', ...)`：
- `also returns titles from archived sessions, so unarchiving cannot surface a duplicate` —— 分别在活跃目录和归档目录中各建一个共享标题前缀的会话，断言两者都被返回。
- `skips archived sessions from other projects (collisions stay project-scoped)` —— 项目归属校验在归档目录的扫描中同样生效，而不仅限于活跃目录。
- `computeUniqueBranchTitle skips a title already taken by an archived session` —— 该 issue 真正关心的端到端不变量：分支时会跳过已被归档会话占用的后缀，而不是复用它。

这三个测试在 `main` 上均失败（报错显示缺少归档标题），在本分支上通过。

阻断范围：`findSessionTitlesByPrefix` 只有一个生产环境调用方 `computeUniqueBranchTitle`，其又分别被 `useBranchCommand.ts`（CLI `/branch`）与 `acpAgent.ts`（ACP 分支路由）调用。两处现有测试套件均完全 mock 了该函数，未受影响，全部通过。

`eslint --max-warnings 0` 与 `tsc --noEmit -p packages/core` 在改动文件上均干净。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

## 风险与范围

- 主要风险/权衡：每次分支时会对 `chats/archive/` 多做一次 `readdirSync` 加逐文件尾部读取，开销级别与现有活跃目录扫描相同，也与 `getSessionInfoCounts` 在守护进程热路径上已经承担的开销一致。
- 未验证/超出范围：`MAX_FILES_TO_PROCESS`（10000）仍按目录独立生效（与 `countSessionsInState` 一致，非本次改动引入）——超过该上限的目录仍可能漏检冲突标题；这是预先存在的限制，未被本次改动引入或加剧，Codex 交叉评审也指出了这一点值得说明。`findSessionsByTitle`（其他场景使用的更重量级同类函数）仍只扫描活跃目录，超出 #9990 范围，未改动。
- 破坏性变更/迁移说明：无，返回类型与调用约定未变。

## 关联 Issue

Fixes #9990

本报告在 AI 协助下完成。

</details>

