### PR TITLE
fix(core): register report_findings in the permission alias table

### DIFF
--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -247,6 +247,11 @@ export const TOOL_NAME_ALIASES: Readonly<Record<string, string>> = {
   Artifact: 'artifact',
   record_artifact: 'record_artifact',
   RecordArtifact: 'record_artifact',
+
+  // Report Findings tool
+  report_findings: 'report_findings',
+  ReportFindings: 'report_findings',
+
   request_shutdown: 'request_shutdown',
   RequestShutdown: 'request_shutdown',
 


### PR DESCRIPTION
## What this PR does

Adds the `report_findings` tool to the permission-rule tool name alias table, registering both its canonical name and its display name so permission rules written against this tool actually match.

## Why it's needed

The `report_findings` tool landed without a matching alias entry, so permission rules spelled `report_findings` or `ReportFindings` parse but never match the tool — the exact silent-miss bug class the exhaustiveness test guards against. The Release workflow's Quality Checks job on main was failing on two exhaustiveness tests because of this.

## Which PR dropped it — direct answer

**No PR ever deleted the entry. It was never added.** Pickaxe proof over the whole main history:

```
$ git log --oneline -S "report_findings" origin/main -- packages/core/src/permissions/rule-parser.ts
a6d30ebc6b fix(core): register report_findings in the permission alias table (#10033)
```

This PR is the *only* commit that ever mentions `report_findings` in that file. So the omission belongs to two PRs in sequence, and they fail in different ways:

| PR | Role | What it did | What it missed |
| :-- | :-- | :-- | :-- |
| **#9794** `feat(review): report findings to clients as a typed contract` | **primary omission** — the PR that should have added the entry | Added `ToolNames.REPORT_FINDINGS = 'report_findings'` and `ToolDisplayNames.REPORT_FINDINGS = 'ReportFindings'` to `packages/core/src/tools/tool-names.ts` | Touched **nothing** under `packages/core/src/permissions/`. The hand-maintained `TOOL_NAME_ALIASES` table already existed at its merge commit (`rule-parser.ts:49`), so there was nothing blocking it — it simply did not add the entry. |
| **#9829** `fix(core): make permissions.allow restrict the tool schemas sent to the model` | **secondary omission** — the last chance to backfill, and the PR that introduced the guard that finally caught it | Backfilled ~40 alias entries in one commit (`send_message`, `get_goal`/`Goal`, `update_goal`, `save_memory`, `ask_user_question`, `cron_create`/`cron_list`/`cron_delete`, `loop_wakeup`, `create_sub_session`, `list_agents`, `task_stop`/`task_create`/`task_update`/`task_list`, `team_create`/`team_delete`/`team_plan_approval`, `image_gen`, `tool_search`, `structured_output`, worktree tools, …) and added the `resolveToolName exhaustiveness (#9827)` suite | Missed `report_findings`, which had merged to main **9h48m earlier**. Its branch merge-base is `22bb5e8b9f` (2026-08-24T17:39:04Z) — *before* #9794 merged at 2026-08-25T02:09:46Z — so `REPORT_FINDINGS` did not exist anywhere in #9829's branch and the backfill sweep could not have seen it. |

## The conditions that made this invisible

All four had to hold at once:

1. **The tool is declared.** `ToolNames` / `ToolDisplayNames` carry `report_findings` / `ReportFindings` (#9794).
2. **The alias table has no entry for either spelling.** Never added by any PR (see the pickaxe output above).
3. **Resolution fails open, not closed.** `resolveToolName` is `TOOL_NAME_ALIASES[raw] ?? raw`, so a rule spelled `report_findings` or `ReportFindings` parses without error and silently never matches — no warning, no rejection, nothing for a user to notice.
4. **No CI run executed the guard against the merged main state.** Neither PR's own CI could have caught it:
   - **#9794's CI ran before the guard existed.** The exhaustiveness suite was added by #9829, 9h48m later. Head `6e242c3e44`: 132 checks, 20 success / 112 skipped, `Test (ubuntu-latest, Node 22.x)` ✅ — legitimately green.
   - **#9829's CI ran on a branch that did not contain the tool.** Head `5e63280089`: 204 checks, 19 success / 183 skipped / 2 cancelled, `Test (ubuntu-latest, Node 22.x)` ✅ — also legitimately green, because the suite walked a `ToolNames` set with no `REPORT_FINDINGS` in it (`git show 5e63280089:packages/core/src/tools/tool-names.ts` has no `REPORT_FINDINGS`).
   - PR checks run against the pre-merge head, and nothing re-ran the unit suite on the post-merge main state. The guard fired for the first time only when the Release workflow ran Quality Checks on main.

Net effect: any permission rule targeting `report_findings` silently never activates, and every CI run that executes the exhaustiveness suite on main is red.

> Correction to this PR's original description: it attributed the miss to "143 skipped checks" on #9829, implying the unit suite never ran there. That was imprecise. The suite **did** run on #9829's head and passed — the real reason it passed is the branch-base timing above, not skipped checks.

## Evidence

First red signal — Release workflow run [`32860613912`](https://github.com/QwenLM/qwen-code/actions/runs/32860613912) (`workflow_dispatch`, 2026-08-25T14:37Z, head `2ef511a07f`, i.e. main after #9829 and before this PR), `Quality Checks` job **failure**:

```
❯ src/permissions/permission-manager.test.ts (411 tests | 2 failed)
× resolveToolName exhaustiveness (#9827) > covers 'REPORT_FINDINGS' ('ReportFindings' -> 'report_findings')
  → expected 'ReportFindings' to be 'report_findings' // Object.is equality
× resolveToolName exhaustiveness (#9827) > registers every canonical tool name in the alias map
  → expected undefined to be 'report_findings' // Object.is equality
```

Timeline:

| Time (UTC) | Event |
| :-- | :-- |
| 2026-08-24 17:39 | `22bb5e8b9f` — #9829's branch base |
| 2026-08-25 02:09 | #9794 merges as `03dd85842e` — tool declared, no alias entry |
| 2026-08-25 11:57 | #9829 merges as `f2e593c26b` — guard + backfill, `report_findings` missed |
| 2026-08-25 14:37 | Release run `32860613912` → `Quality Checks` **failure**, 2 exhaustiveness cases red |
| 2026-08-25 15:50 | This PR merges as `a6d30ebc6b` |
| 2026-08-25 16:28 | Release run [`32872158347`](https://github.com/QwenLM/qwen-code/actions/runs/32872158347) → `Quality Checks` **success** |

This PR restores the missing entries without changing any other behavior.

## Reviewer Test Plan

### How to verify

Run `cd packages/core && npx vitest run src/permissions/permission-manager.test.ts` — the `resolveToolName exhaustiveness (#9827)` suite passes, where it previously failed with the two assertions quoted above.

### Evidence (Before & After)

N/A (no user-visible UI change).

Before: 2 failed in `resolveToolName exhaustiveness (#9827)` (Release run `32860613912`).
After: `Test Files 1 passed`, all exhaustiveness cases green (this PR's head `3e7044e719` `Test (ubuntu-latest, Node 22.x)` ✅; Release run `32872158347` `Quality Checks` ✅).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: none expected — additive alias-map entries only.
- Not validated / out of scope: full cross-platform CI run (covered by PR checks); the Windows runner 8.3 short-path failures seen on some fork PRs are a separate pre-existing issue.
- Breaking changes / migration notes: none.

## Linked Issues

No linked issue — repairs the failing Quality Checks job of the Release workflow on main. Follow-up to the alias entry #9794 never added and the guard #9829 introduced.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 `report_findings` 工具加入权限规则的工具名别名表,同时注册其规范名和显示名,使针对该工具编写的权限规则能够真正命中。

## 为什么需要

`report_findings` 工具合入时没有对应的别名表条目,导致写成 `report_findings` 或 `ReportFindings` 的权限规则能解析但永远匹配不到该工具——正是穷举测试要防的静默漏配问题。main 上 Release 工作流的 Quality Checks 任务也因此有 2 个穷举测试失败。

## 到底是哪个 PR 丢的 —— 直接回答

**没有任何 PR 删过这个条目,它从来就没被加进去过。** 对整个 main 历史做 pickaxe:

```
$ git log --oneline -S "report_findings" origin/main -- packages/core/src/permissions/rule-parser.ts
a6d30ebc6b fix(core): register report_findings in the permission alias table (#10033)
```

本 PR 是该文件里**唯一**一个提到 `report_findings` 的提交。所以漏配属于先后两个 PR,且两者的失误性质不同:

| PR | 角色 | 做了什么 | 漏了什么 |
| :-- | :-- | :-- | :-- |
| **#9794** `feat(review): report findings to clients as a typed contract` | **主要漏配** —— 本该加条目的那个 PR | 在 `packages/core/src/tools/tool-names.ts` 里加了 `ToolNames.REPORT_FINDINGS = 'report_findings'` 和 `ToolDisplayNames.REPORT_FINDINGS = 'ReportFindings'` | `packages/core/src/permissions/` 下**一行都没改**。手工维护的 `TOOL_NAME_ALIASES` 表在它合入时就已经存在(`rule-parser.ts:49`),没有任何阻碍——就是没加。 |
| **#9829** `fix(core): make permissions.allow restrict the tool schemas sent to the model` | **次要漏配** —— 最后一次补齐机会,同时也是引入守卫测试的那个 PR | 在同一个提交里补了约 40 个别名条目(`send_message`、`get_goal`/`Goal`、`update_goal`、`save_memory`、`ask_user_question`、`cron_create`/`cron_list`/`cron_delete`、`loop_wakeup`、`create_sub_session`、`list_agents`、`task_*`、`team_*`、`image_gen`、`tool_search`、`structured_output`、worktree 系列等),并加上了 `resolveToolName exhaustiveness (#9827)` 套件 | 漏掉了 **9 小时 48 分钟前**已合入 main 的 `report_findings`。它的分支 merge-base 是 `22bb5e8b9f`(2026-08-24T17:39:04Z),**早于** #9794 的合入时间 2026-08-25T02:09:46Z,所以 `REPORT_FINDINGS` 在 #9829 的分支里根本不存在,补齐扫描不可能看到它。 |

## 让这个问题隐形的那些条件

四个条件必须同时成立:

1. **工具已声明。** `ToolNames` / `ToolDisplayNames` 里有 `report_findings` / `ReportFindings`(#9794)。
2. **别名表里没有这两种拼法的条目。** 没有任何 PR 加过(见上面的 pickaxe 结果)。
3. **解析是"失败即放行",不是"失败即报错"。** `resolveToolName` 的实现是 `TOOL_NAME_ALIASES[raw] ?? raw`,所以写成 `report_findings` 或 `ReportFindings` 的规则能正常解析、然后静默地永远匹配不上——没有告警、没有拒绝,用户无从察觉。
4. **没有任何 CI 在合并后的 main 状态上跑过这个守卫。** 两个 PR 各自的 CI 都不可能发现:
   - **#9794 的 CI 跑在守卫存在之前。** 穷举套件是 9 小时 48 分钟后由 #9829 加的。head `6e242c3e44`:132 个 check,20 成功 / 112 跳过,`Test (ubuntu-latest, Node 22.x)` ✅ —— 绿得合理。
   - **#9829 的 CI 跑在一个不含该工具的分支上。** head `5e63280089`:204 个 check,19 成功 / 183 跳过 / 2 取消,`Test (ubuntu-latest, Node 22.x)` ✅ —— 也是绿得合理,因为套件遍历的 `ToolNames` 里没有 `REPORT_FINDINGS`(`git show 5e63280089:packages/core/src/tools/tool-names.ts` 里没有 `REPORT_FINDINGS`)。
   - PR check 跑的是合并前的 head,合并后的 main 状态上没有任何东西重跑单测套件。守卫第一次真正生效,是在 Release 工作流跑 main 的 Quality Checks 时。

净效果:任何针对 `report_findings` 的权限规则都静默失效;且 main 上所有执行穷举套件的 CI 都是红的。

> 对本 PR 原始描述的更正:原描述把这次漏配归因于 #9829 上"143 个 skipped check",暗示单测套件没在那里跑过。这个说法不准确。套件**确实**在 #9829 的 head 上跑了并通过——它通过的真实原因是上面说的分支基点时间差,不是 check 被跳过。

## 证据

第一个红灯 —— Release 工作流运行 [`32860613912`](https://github.com/QwenLM/qwen-code/actions/runs/32860613912)(`workflow_dispatch`,2026-08-25T14:37Z,head `2ef511a07f`,即 #9829 之后、本 PR 之前的 main),`Quality Checks` 任务 **failure**:

```
❯ src/permissions/permission-manager.test.ts (411 tests | 2 failed)
× resolveToolName exhaustiveness (#9827) > covers 'REPORT_FINDINGS' ('ReportFindings' -> 'report_findings')
  → expected 'ReportFindings' to be 'report_findings' // Object.is equality
× resolveToolName exhaustiveness (#9827) > registers every canonical tool name in the alias map
  → expected undefined to be 'report_findings' // Object.is equality
```

时间线:

| 时间(UTC) | 事件 |
| :-- | :-- |
| 2026-08-24 17:39 | `22bb5e8b9f` —— #9829 的分支基点 |
| 2026-08-25 02:09 | #9794 合入为 `03dd85842e` —— 声明了工具,没有别名条目 |
| 2026-08-25 11:57 | #9829 合入为 `f2e593c26b` —— 守卫 + 补齐,漏掉 `report_findings` |
| 2026-08-25 14:37 | Release 运行 `32860613912` → `Quality Checks` **failure**,2 个穷举用例红 |
| 2026-08-25 15:50 | 本 PR 合入为 `a6d30ebc6b` |
| 2026-08-25 16:28 | Release 运行 [`32872158347`](https://github.com/QwenLM/qwen-code/actions/runs/32872158347) → `Quality Checks` **success** |

本 PR 只补回缺失的条目,不改变任何其他行为。

## 评审验证方式

### 如何验证

运行 `cd packages/core && npx vitest run src/permissions/permission-manager.test.ts`,`resolveToolName exhaustiveness (#9827)` 套件通过;此前该套件报上面引用的两个断言失败。

### 前后对比

N/A(无用户可见的 UI 变化)。

修复前:`resolveToolName exhaustiveness (#9827)` 2 个用例失败(Release 运行 `32860613912`)。修复后:测试文件全部通过(本 PR head `3e7044e719` 的 `Test (ubuntu-latest, Node 22.x)` ✅;Release 运行 `32872158347` 的 `Quality Checks` ✅)。

### 测试环境

仅单元测试,在 macOS 上验证。

## 风险与范围

- 主要风险或权衡:预期没有——只是向别名表新增条目。
- 未验证 / 不在范围内:跨平台完整 CI(由 PR checks 覆盖);个别 fork PR 上看到的 Windows runner 8.3 短路径失败是另一个独立的既有问题。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

无——用于修复 main 上 Release 工作流 Quality Checks 任务的失败。是对 #9794 从未添加的别名条目、以及 #9829 引入的守卫测试的后续修复。

</details>
