### PR TITLE
fix(cli): make review cleanup prefix-free across dash-extended targets

### DIFF
--- a/packages/cli/src/commands/review/cleanup.test.ts
+++ b/packages/cli/src/commands/review/cleanup.test.ts
@@ -145,8 +145,9 @@ vi.mock('./lib/paths.js', async (importOriginal) => {
     LEASE_PREFIX: 'qwen-review-lease-',
     REVIEW_TMP_DIR: '/repo/.qwen/tmp',
     tmpFile: (target: string, suffix: string) =>
-      `/repo/.qwen/tmp/qwen-review-${target}-${suffix}`,
-    tmpPrefix: (target: string) => `qwen-review-${target}-`,
+      `/repo/.qwen/tmp/qwen-review-${target}~${suffix}`,
+    // Real tmpPrefix: the dash-twin sweep below is the prefix-free property,
+    // and a restated mock would stay green while the helper drifted.
   };
 });
 
@@ -238,7 +239,7 @@ describe('runCleanup', () => {
     // every later cleanup, and nothing sweeps it automatically.
     mocks.execFileSync.mockReturnValue(Buffer.from(''));
     mocks.existsSync.mockReturnValue(true);
-    mocks.readdirSync.mockReturnValue(['qwen-review-pr-123-diff.txt']);
+    mocks.readdirSync.mockReturnValue(['qwen-review-pr-123~diff.txt']);
     mocks.rmSync.mockImplementation(() => {
       throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
     });
@@ -275,7 +276,7 @@ describe('runCleanup', () => {
     // gate would reach for the holder's side files and trip the
     // rmSync-not-called assertion below.
     mocks.existsSync.mockReturnValue(true);
-    mocks.readdirSync.mockReturnValue(['qwen-review-pr-123-diff.txt']);
+    mocks.readdirSync.mockReturnValue(['qwen-review-pr-123~diff.txt']);
 
     runCleanup('pr-123');
 
@@ -418,7 +419,7 @@ describe('runCleanup', () => {
       // Neither of these belongs to this review: one is another PR's scratch
       // tree, the other an ordinary side file.
       'review-pr-999-scratch-verify--round-1--ccc',
-      'qwen-review-pr-123-diff.txt',
+      'qwen-review-pr-123~diff.txt',
     ] as unknown as []);
 
     runCleanup('pr-123');
@@ -603,13 +604,13 @@ describe('runCleanup', () => {
     mocks.execFileSync.mockReturnValue(Buffer.from(''));
     mocks.existsSync.mockReturnValue(true);
     mocks.readdirSync.mockReturnValue([
-      'qwen-review-lease-diff.txt',
+      'qwen-review-lease~diff.txt',
       'qwen-review-lease-pr-999.json',
     ]);
 
     runCleanup('lease');
 
-    const sideFile = join('/repo/.qwen/tmp', 'qwen-review-lease-diff.txt');
+    const sideFile = join('/repo/.qwen/tmp', 'qwen-review-lease~diff.txt');
     expect(mocks.rmSync).toHaveBeenCalledWith(sideFile, {
       recursive: true,
       force: true,
@@ -626,11 +627,11 @@ describe('runCleanup', () => {
     // prefix, not on the sweep itself.
     mocks.execFileSync.mockReturnValue(Buffer.from(''));
     mocks.existsSync.mockReturnValue(true);
-    mocks.readdirSync.mockReturnValue(['qwen-review-local-diff.txt']);
+    mocks.readdirSync.mockReturnValue(['qwen-review-local~diff.txt']);
 
     runCleanup('local');
 
-    const sideFile = join('/repo/.qwen/tmp', 'qwen-review-local-diff.txt');
+    const sideFile = join('/repo/.qwen/tmp', 'qwen-review-local~diff.txt');
     expect(mocks.rmSync).toHaveBeenCalledWith(sideFile, {
       recursive: true,
       force: true,
@@ -638,6 +639,33 @@ describe('runCleanup', () => {
     expect(mocks.writeStdoutLine).toHaveBeenCalledWith(
       `Removed temp file: ${sideFile}`,
     );
+  });
+
+  it("does not delete a dash-extended twin target's artifacts (#10057)", () => {
+    // safeTarget keeps dashes, and tmpPrefix used to join with another dash,
+    // so `src/foo` (token `src_foo`) was a strict prefix of `src/foo-bar`
+    // (token `src_foo-bar`). Cleanup's startsWith sweep then deleted the
+    // twin's live family — file/local reviews take no lease, so nothing
+    // blocked the interleaving.
+    mocks.execFileSync.mockReturnValue(Buffer.from(''));
+    mocks.existsSync.mockReturnValue(true);
+    const own = 'qwen-review-src_foo~diff.txt';
+    const twinArtifacts = [
+      'qwen-review-src_foo-bar-diff.txt',
+      'qwen-review-src_foo-bar-findings.json',
+      'qwen-review-src_foo-bar-composed.json',
+      'qwen-review-src_foo-bar-stop.json',
+      'qwen-review-src_foo-bar~diff.txt',
+    ];
+    mocks.readdirSync.mockReturnValue([own, ...twinArtifacts]);
+
+    runCleanup('src/foo');
+
+    const removed = mocks.rmSync.mock.calls.map((c) => String(c[0]));
+    expect(removed).toContain(join('/repo/.qwen/tmp', own));
+    for (const file of twinArtifacts) {
+      expect(removed).not.toContain(join('/repo/.qwen/tmp', file));
+    }
   });
 
   it('keeps the record directory of a NON-CONVERGED reverse audit (#9206)', () => {
@@ -648,9 +676,9 @@ describe('runCleanup', () => {
     mocks.execFileSync.mockReturnValue(Buffer.from(''));
     mocks.existsSync.mockReturnValue(true);
     mocks.readdirSync.mockReturnValue([
-      'qwen-review-pr-123-fetch.json',
-      'qwen-review-pr-123-fetch-prompts',
-      'qwen-review-pr-123-diff.txt',
+      'qwen-review-pr-123~fetch.json',
+      'qwen-review-pr-123~fetch-prompts',
+      'qwen-review-pr-123~diff.txt',
     ]);
     mocks.readFileSync.mockImplementation((path: string): string => {
       if (path.endsWith('budget-stop.json')) {
@@ -672,14 +700,14 @@ describe('runCleanup', () => {
     runCleanup('pr-123');
 
     const removed = mocks.rmSync.mock.calls.map((c) => c[0]);
-    expect(removed).toContain('/repo/.qwen/tmp/qwen-review-pr-123-fetch.json');
-    expect(removed).toContain('/repo/.qwen/tmp/qwen-review-pr-123-diff.txt');
+    expect(removed).toContain('/repo/.qwen/tmp/qwen-review-pr-123~fetch.json');
+    expect(removed).toContain('/repo/.qwen/tmp/qwen-review-pr-123~diff.txt');
     expect(removed).not.toContain(
-      '/repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+      '/repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
     );
     expect(mocks.writeStdoutLine).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Kept /repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+        'Kept /repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       ),
     );
   });
@@ -693,7 +721,7 @@ describe('runCleanup', () => {
     mocks.existsSync.mockReturnValue(true);
     mocks.readdirSync.mockImplementation((p: string): string[] =>
       p === '/repo/.qwen/tmp'
-        ? ['qwen-review-pr-123-fetch.json', 'qwen-review-pr-123-fetch-prompts']
+        ? ['qwen-review-pr-123~fetch.json', 'qwen-review-pr-123~fetch-prompts']
         : ['reverse-audit--chunk-13--round-1--abc.txt'],
     );
     // No marker — the readFileSync default throws for budget-stop.json.
@@ -705,12 +733,12 @@ describe('runCleanup', () => {
     runCleanup('pr-123');
 
     expect(mocks.rmSync).not.toHaveBeenCalledWith(
-      '/repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+      '/repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       expect.anything(),
     );
     expect(mocks.writeStdoutLine).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Kept /repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+        'Kept /repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       ),
     );
   });
@@ -722,17 +750,17 @@ describe('runCleanup', () => {
     // and "Nothing to clean" must NOT print while something was kept.
     mocks.execFileSync.mockReturnValue(Buffer.from(''));
     mocks.existsSync.mockImplementation((p: string) => p === '/repo/.qwen/tmp');
-    mocks.readdirSync.mockReturnValue(['qwen-review-pr-123-fetch-prompts']);
+    mocks.readdirSync.mockReturnValue(['qwen-review-pr-123~fetch-prompts']);
 
     runCleanup('pr-123');
 
     expect(mocks.rmSync).not.toHaveBeenCalledWith(
-      '/repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+      '/repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       expect.anything(),
     );
     expect(mocks.writeStdoutLine).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Kept /repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+        'Kept /repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       ),
     );
     expect(mocks.writeStdoutLine).not.toHaveBeenCalledWith(
@@ -749,7 +777,7 @@ describe('runCleanup', () => {
     mocks.existsSync.mockReturnValue(true);
     mocks.readdirSync.mockImplementation((p: string): string[] =>
       p === '/repo/.qwen/tmp'
-        ? ['qwen-review-pr-123-fetch.json', 'qwen-review-pr-123-fetch-prompts']
+        ? ['qwen-review-pr-123~fetch.json', 'qwen-review-pr-123~fetch-prompts']
         : [],
     );
     const planNow = Date.now();
@@ -778,12 +806,12 @@ describe('runCleanup', () => {
     runCleanup('pr-123');
 
     expect(mocks.rmSync).not.toHaveBeenCalledWith(
-      '/repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+      '/repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       expect.anything(),
     );
     expect(mocks.writeStdoutLine).toHaveBeenCalledWith(
       expect.stringContaining(
-        'Kept /repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+        'Kept /repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       ),
     );
   });
@@ -795,15 +823,15 @@ describe('runCleanup', () => {
     mocks.execFileSync.mockReturnValue(Buffer.from(''));
     mocks.existsSync.mockReturnValue(true);
     mocks.readdirSync.mockReturnValue([
-      'qwen-review-pr-123-fetch.json',
-      'qwen-review-pr-123-fetch-prompts',
+      'qwen-review-pr-123~fetch.json',
+      'qwen-review-pr-123~fetch-prompts',
     ]);
     mocks.readFileSync.mockReturnValue(JSON.stringify({}));
 
     runCleanup('pr-123');
 
     expect(mocks.rmSync).toHaveBeenCalledWith(
-      '/repo/.qwen/tmp/qwen-review-pr-123-fetch-prompts',
+      '/repo/.qwen/tmp/qwen-review-pr-123~fetch-prompts',
       { recursive: true, force: true },
     );
   });
@@ -985,7 +1013,7 @@ describe('runCleanup — bypass-write audit', () => {
     runCleanup('pr-123');
 
     expect(mocks.readFileSync).toHaveBeenCalledWith(
-      '/repo/.qwen/tmp/qwen-review-pr-123-fetch.json',
+      '/repo/.qwen/tmp/qwen-review-pr-123~fetch.json',
       'utf8',
     );
     expect(mocks.setGhHost).toHaveBeenCalledWith('ghe.example.com');

--- a/packages/cli/src/commands/review/fetch-pr.test.ts
+++ b/packages/cli/src/commands/review/fetch-pr.test.ts
@@ -3727,7 +3727,7 @@ describe('fetch-pr --resume', () => {
     // other read (resume marker, session ledger) is ENOENT.
     producerMocks.readFileSync.mockImplementation((path?: unknown) => {
       if (path === OUT) return prevReport();
-      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+      if (String(path).endsWith('qwen-review-pr-42~diff.txt')) {
         return Buffer.from(DIFF_BYTES) as unknown as string;
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -3892,7 +3892,7 @@ describe('fetch-pr --resume', () => {
   it('falls through when the diff bytes changed — the content key', async () => {
     producerMocks.readFileSync.mockImplementation((path?: unknown) => {
       if (path === OUT) return prevReport();
-      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+      if (String(path).endsWith('qwen-review-pr-42~diff.txt')) {
         return Buffer.from('tampered') as unknown as string;
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -4035,7 +4035,7 @@ describe('fetch-pr --resume', () => {
   it('refuses on an explicit effort different from the recorded run', async () => {
     producerMocks.readFileSync.mockImplementation((path?: unknown) => {
       if (path === OUT) return prevReport({ effort: 'medium' });
-      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+      if (String(path).endsWith('qwen-review-pr-42~diff.txt')) {
         return Buffer.from(DIFF_BYTES) as unknown as string;
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -4051,7 +4051,7 @@ describe('fetch-pr --resume', () => {
   it('resumes at the recorded effort when none is passed, and says so', async () => {
     producerMocks.readFileSync.mockImplementation((path?: unknown) => {
       if (path === OUT) return prevReport({ effort: 'medium' });
-      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+      if (String(path).endsWith('qwen-review-pr-42~diff.txt')) {
         return Buffer.from(DIFF_BYTES) as unknown as string;
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -4221,7 +4221,7 @@ describe('fetch-pr --resume bookkeeping is counted, not merely called', () => {
     vi.clearAllMocks();
     producerMocks.readFileSync.mockImplementation((path?: unknown) => {
       if (path === OUT) return prevReport();
-      if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+      if (String(path).endsWith('qwen-review-pr-42~diff.txt')) {
         return Buffer.from(DIFF_BYTES) as unknown as string;
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
@@ -4440,7 +4440,7 @@ describe('fetch-pr --resume bookkeeping is counted, not merely called', () => {
           return realFs.readFileSync(String(path), 'utf8');
         }
         if (path === OUT) return prevReport();
-        if (String(path).endsWith('qwen-review-pr-42-diff.txt')) {
+        if (String(path).endsWith('qwen-review-pr-42~diff.txt')) {
           return Buffer.from(DIFF_BYTES) as unknown as string;
         }
         throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });

--- a/packages/cli/src/commands/review/issue-9206-repro.test.ts
+++ b/packages/cli/src/commands/review/issue-9206-repro.test.ts
@@ -78,6 +78,7 @@ import {
   writeRoundCapStop,
 } from './lib/deadline.js';
 import { runCleanup } from './cleanup.js';
+import { tmpFile } from './lib/paths.js';
 
 const PLAN = {
   diffPathAbsolute: '/abs/.qwen/tmp/qwen-review-pr-9206-diff.txt',
@@ -498,12 +499,7 @@ describe('issue #9206 — Step 9 cleanup must not destroy a non-converged run’
     // deletes run A's history with no Kept line: the evidence loss this
     // issue reports, recurring for the killed-run shape.
     mkdirSync(join(dir, '.qwen', 'tmp'), { recursive: true });
-    const planPath = join(
-      dir,
-      '.qwen',
-      'tmp',
-      'qwen-review-pr-9206-fetch.json',
-    );
+    const planPath = join(dir, tmpFile('pr-9206', 'fetch.json'));
     writeFileSync(planPath, JSON.stringify({ prNumber: '9206' }));
     const recordDir = promptRecordDir(planPath);
     mkdirSync(recordDir, { recursive: true });
@@ -529,12 +525,7 @@ describe('issue #9206 — Step 9 cleanup must not destroy a non-converged run’
     // history of the killed run; the sweep must keep them on that signal
     // alone.
     mkdirSync(join(dir, '.qwen', 'tmp'), { recursive: true });
-    const planPath = join(
-      dir,
-      '.qwen',
-      'tmp',
-      'qwen-review-pr-9206-fetch.json',
-    );
+    const planPath = join(dir, tmpFile('pr-9206', 'fetch.json'));
     writeFileSync(planPath, JSON.stringify({ prNumber: '9206' }));
     const recordDir = promptRecordDir(planPath);
     mkdirSync(recordDir, { recursive: true });
@@ -560,12 +551,7 @@ describe('issue #9206 — Step 9 cleanup must not destroy a non-converged run’
     // the first cleanup explicitly kept. A record directory whose plan is
     // gone is itself the retained shape: keep it.
     mkdirSync(join(dir, '.qwen', 'tmp'), { recursive: true });
-    const planPath = join(
-      dir,
-      '.qwen',
-      'tmp',
-      'qwen-review-pr-9206-fetch.json',
-    );
+    const planPath = join(dir, tmpFile('pr-9206', 'fetch.json'));
     const recordDir = promptRecordDir(planPath);
     mkdirSync(recordDir, { recursive: true });
     writeFileSync(
@@ -597,12 +583,7 @@ describe('issue #9206 — Step 9 cleanup must not destroy a non-converged run’
     // swept the older evidence beside it. `a-broken-symlink` sorts before
     // the record, so the old code hit the throw first.
     mkdirSync(join(dir, '.qwen', 'tmp'), { recursive: true });
-    const planPath = join(
-      dir,
-      '.qwen',
-      'tmp',
-      'qwen-review-pr-9206-fetch.json',
-    );
+    const planPath = join(dir, tmpFile('pr-9206', 'fetch.json'));
     const recordDir = promptRecordDir(planPath);
     mkdirSync(recordDir, { recursive: true });
     writeFileSync(
@@ -630,12 +611,7 @@ describe('issue #9206 — Step 9 cleanup must not destroy a non-converged run’
     // `<` \u2192 `!==` mutant (retain a converged run's own records forever,
     // under a false Kept claim) from shipping green.
     mkdirSync(join(dir, '.qwen', 'tmp'), { recursive: true });
-    const planPath = join(
-      dir,
-      '.qwen',
-      'tmp',
-      'qwen-review-pr-9206-fetch.json',
-    );
+    const planPath = join(dir, tmpFile('pr-9206', 'fetch.json'));
     writeFileSync(planPath, JSON.stringify({ prNumber: '9206' }));
     const recordDir = promptRecordDir(planPath);
     mkdirSync(recordDir, { recursive: true });
@@ -653,12 +629,7 @@ describe('issue #9206 — Step 9 cleanup must not destroy a non-converged run’
     // The real run's shape: the loop never converged and hit the 5-round cap,
     // so the builder wrote its round-cap stop marker INSIDE the record dir.
     mkdirSync(join(dir, '.qwen', 'tmp'), { recursive: true });
-    const planPath = join(
-      dir,
-      '.qwen',
-      'tmp',
-      'qwen-review-pr-9206-fetch.json',
-    );
+    const planPath = join(dir, tmpFile('pr-9206', 'fetch.json'));
     writeFileSync(planPath, JSON.stringify({ prNumber: '9206' }));
     const recordDir = promptRecordDir(planPath);
     mkdirSync(recordDir, { recursive: true });

--- a/packages/cli/src/commands/review/lib/paths.test.ts
+++ b/packages/cli/src/commands/review/lib/paths.test.ts
@@ -9,6 +9,7 @@ import { basename, dirname, join, resolve } from 'node:path';
 import {
   inertPath,
   tmpFile,
+  tmpPrefix,
   probeWorktreePath,
   scratchLabel,
   scratchWorktreePath,
@@ -31,10 +32,10 @@ describe('PARSE_ARGS_REPORT', () => {
 describe('tmpFile — target is a single safe component', () => {
   it('keeps ordinary labels intact', () => {
     expect(tmpFile('pr-6771', 'diff.txt')).toContain(
-      'qwen-review-pr-6771-diff.txt',
+      'qwen-review-pr-6771~diff.txt',
     );
     expect(tmpFile('local', 'plan.json')).toContain(
-      'qwen-review-local-plan.json',
+      'qwen-review-local~plan.json',
     );
   });
 
@@ -46,7 +47,7 @@ describe('tmpFile — target is a single safe component', () => {
     expect(dirname(p)).toBe(join('.qwen', 'tmp'));
     // The separator is flattened to an underscore, so the target survives as a
     // single component directly under the temp dir.
-    expect(basename(p)).toBe('qwen-review-src_foo.ts-diff.txt');
+    expect(basename(p)).toBe('qwen-review-src_foo.ts~diff.txt');
   });
 
   it('refuses to escape the temp dir with a crafted target', () => {
@@ -54,7 +55,22 @@ describe('tmpFile — target is a single safe component', () => {
     expect(dirname(p)).toBe(join('.qwen', 'tmp'));
     expect(p).not.toContain('..');
     // The dot-segment traversal is stripped to a plain component, not nested.
-    expect(basename(p)).toBe('qwen-review-evil-diff.txt');
+    expect(basename(p)).toBe('qwen-review-evil~diff.txt');
+  });
+});
+
+describe('tmpPrefix — prefix-free across dash-extended twins', () => {
+  it('does not match a concurrent src/foo-bar family when sweeping src/foo', () => {
+    // safeTarget keeps dashes, so `src/foo` → `src_foo` is a strict prefix of
+    // `src/foo-bar` → `src_foo-bar`. A family separator inside that alphabet
+    // makes cleanup's startsWith sweep delete the twin's live artifacts.
+    const prefix = tmpPrefix('src/foo');
+    expect(basename(tmpFile('src/foo', 'diff.txt')).startsWith(prefix)).toBe(
+      true,
+    );
+    expect(
+      basename(tmpFile('src/foo-bar', 'diff.txt')).startsWith(prefix),
+    ).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/review/lib/paths.ts
+++ b/packages/cli/src/commands/review/lib/paths.ts
@@ -195,6 +195,13 @@ export function reviewBranch(prNumber: string | number): string {
 }
 
 /**
+ * Joiner between the target token and the per-family suffix. Outside
+ * {@link safeTarget}'s alphabet so cleanup's `startsWith(tmpPrefix(target))`
+ * sweep cannot match a dash-extended twin.
+ */
+const TMP_FAMILY_SEP = '~';
+
+/**
  * Per-target side-file path (review JSON, PR context, presubmit report).
  *
  * Files live under `.qwen/tmp/` rather than the OS temp dir so the path is
@@ -203,12 +210,21 @@ export function reviewBranch(prNumber: string | number): string {
  * and so they're scoped to the project rather than the user's whole machine.
  */
 export function tmpFile(target: string, suffix: string): string {
-  return join(REVIEW_TMP_DIR, `qwen-review-${safeTarget(target)}-${suffix}`);
+  return join(
+    REVIEW_TMP_DIR,
+    `qwen-review-${safeTarget(target)}${TMP_FAMILY_SEP}${suffix}`,
+  );
 }
 
-/** Filename prefix used by `tmpFile`; useful for cleanup globbing. */
+/**
+ * Filename prefix used by `tmpFile`; useful for cleanup globbing.
+ *
+ * The joiner is outside safeTarget's alphabet (`A-Za-z0-9._-`) so a token
+ * that is a dash-prefix of another (`src/foo` → `src_foo`, `src/foo-bar` →
+ * `src_foo-bar`) cannot make this prefix match the twin's family.
+ */
 export function tmpPrefix(target: string): string {
-  return `qwen-review-${safeTarget(target)}-`;
+  return `qwen-review-${safeTarget(target)}${TMP_FAMILY_SEP}`;
 }
 
 /**

--- a/packages/cli/src/commands/review/submit.test.ts
+++ b/packages/cli/src/commands/review/submit.test.ts
@@ -24,7 +24,8 @@ import {
   recordedSeverityFloor,
   reviewWriteAuthorization,
 } from './lib/authorization.js';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { tmpFile } from './lib/paths.js';
 import { promptRecordDir, briefPath } from './lib/prompt-record.js';
 import { parseLedger } from './lib/ledger.js';
 
@@ -164,9 +165,8 @@ const CAPTURED_DIFF_FIXTURE = [
 ].join('\n');
 
 function writeCapturedDiff(pr: number): string {
-  const dirPath = join('.qwen', 'tmp');
-  mkdirSync(dirPath, { recursive: true });
-  const p = join(dirPath, `qwen-review-pr-${pr}-diff.txt`);
+  const p = tmpFile(`pr-${pr}`, 'diff.txt');
+  mkdirSync(dirname(p), { recursive: true });
   writeFileSync(p, CAPTURED_DIFF_FIXTURE, 'utf8');
   return p;
 }
@@ -3623,7 +3623,7 @@ describe('what the reviewer caught in this change', () => {
 // receipt lands there.
 describe('submit receipt (producer half of the audit contract)', () => {
   const receiptPath = () =>
-    join(dir, '.qwen', 'tmp', 'qwen-review-pr-6771-submit-receipt.json');
+    join(dir, tmpFile('pr-6771', 'submit-receipt.json'));
 
   const authorizedPost = (over: Record<string, unknown> = {}) =>
     args({ userAuthorized: true, ...over });


### PR DESCRIPTION
## What this PR does

`qwen review cleanup` used to sweep per-target side files with `file.startsWith(tmpPrefix(target))`, where the family separator was `-` and `safeTarget` keeps dashes. That made the token space not prefix-free: cleaning `src/foo` (token `src_foo`) also matched every `qwen-review-src_foo-bar-*` artifact of a concurrent `src/foo-bar` review and deleted them mid-round.

This changes the family joiner in `tmpFile` / `tmpPrefix` to `~`, which is outside `safeTarget`'s alphabet, so one family's prefix can no longer match another family's files.

## Why it's needed

File and local reviews take no lease, so nothing blocked that interleaving. A finishing cleanup of one target could wipe another live review's diff, findings, composed verdict, and stop sidecar.

## Reviewer Test Plan

### How to verify

1. `tmpPrefix('src/foo')` is `qwen-review-src_foo~` and does not match `tmpFile('src/foo-bar', 'diff.txt')`.
2. `runCleanup('src/foo')` removes `qwen-review-src_foo~diff.txt` and leaves every `qwen-review-src_foo-bar-*` / `qwen-review-src_foo-bar~*` twin artifact in place.
3. Existing cleanup retention, lease, fetch-pr resume, and submit receipt tests still pass against the new names.

```
cd packages/cli
npx vitest run src/commands/review/lib/paths.test.ts src/commands/review/cleanup.test.ts src/commands/review/issue-9206-repro.test.ts src/commands/review/fetch-pr.test.ts src/commands/review/submit.test.ts
```

372 tests passed locally.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest run` in `packages/cli`).

## Risk & Scope

- Main risk or tradeoff: one-round leftover of old dash-named side files; they are simply not found by the new prefix. Skill literals that still spell `qwen-review-{target}-<suffix>` with a dash are unchanged in this PR — cleanup of those names is no longer prefix-overlapping, and CLI-produced names go through `tmpFile`/`tmpPrefix`.
- Not validated / out of scope: bundled review-skill string spellings and the separate `prev-ledger` sibling-of-plan convention.
- Breaking changes / migration notes: new CLI side files use `qwen-review-<token>~<suffix>`. Old `qwen-review-<token>-<suffix>` names are not cleaned or reused for one round.

## Linked Issues

Fixes #10057

<details>
<summary>中文说明</summary>

## 本 PR 做什么

`qwen review cleanup` 过去用 `file.startsWith(tmpPrefix(target))` 清扫 per-target 侧文件，family 分隔符是 `-`，而 `safeTarget` 保留连字符。token 空间因此不是前缀无关的：清理 `src/foo`（token `src_foo`）会匹配并发 `src/foo-bar` 评审的全部 `qwen-review-src_foo-bar-*` 产物，并在轮次中删除它们。

本 PR 把 `tmpFile` / `tmpPrefix` 的 family 连接符改成 `safeTarget` 字母表外的 `~`，一个 family 的前缀不再能匹配另一个 family 的文件。

## 为什么需要

file / local 评审没有租约，无法阻止这种交错。一次收尾清理可以清掉另一场仍在进行的评审的 diff、findings、composed verdict 和 stop sidecar。

## 评审者测试计划

### 如何验证

1. `tmpPrefix('src/foo')` 为 `qwen-review-src_foo~`，且不匹配 `tmpFile('src/foo-bar', 'diff.txt')`。
2. `runCleanup('src/foo')` 删除 `qwen-review-src_foo~diff.txt`，并保留全部 `qwen-review-src_foo-bar-*` / `qwen-review-src_foo-bar~*` 孪生产物。
3. 现有 cleanup 保留、lease、fetch-pr resume、submit receipt 测试在新名字下仍然通过。

本地 372 个测试通过。

### 证据（Before & After）

N/A

### 测试平台

Linux 已测；macOS / Windows 未测。

## 风险与范围

- 主要取舍：旧的连字符侧文件会遗留一轮，新前缀找不到它们。bundled skill 里仍用连字符拼写的字面量本 PR 未改。
- 未验证 / 范围外：bundled review-skill 字面拼写，以及独立的 `prev-ledger` 约定。
- 破坏性 / 迁移：新的 CLI 侧文件使用 `qwen-review-<token>~<suffix>`。

## 关联议题

Fixes #10057

</details>