### PR TITLE
fix(release): drop channel-dws from the publish allowlist until npm org allows new packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -606,8 +606,15 @@ jobs:
         working-directory: 'packages/channels'
         run: |-
           # Explicit allowlist: new channel workspaces require release approval.
+          # `dws` is deliberately absent: the package does not exist on npm yet
+          # and the release automation token cannot CREATE a new package under
+          # the @qwen-code org (the PUT 404'd and failed every release since
+          # v0.22.1). The channel loads via a tolerated dynamic import
+          # (channel-registry Promise.allSettled), so an unpublished dws breaks
+          # nothing. Re-add `dws` once the npm org grants package creation (or
+          # the package is pre-created and the CI user added as maintainer).
           PUBLISH_MARKER="$(mktemp)"
-          for channel in dingtalk dws feishu github qqbot telegram wecom weixin; do
+          for channel in dingtalk feishu github qqbot telegram wecom weixin; do
             echo "::group::Publishing @qwen-code/channel-${channel}"
             (
               cd "${channel}"


### PR DESCRIPTION
## What this PR does

Removes `dws` from the `Publish remaining channel packages` allowlist in `release.yml`, with a comment recording why it is absent and the exact condition for re-adding it.

## Why it's needed

Every release since v0.22.1 dies in the publish job on `@qwen-code/channel-dws`: the package (added in #9394) does not exist on npm yet, and the release automation token cannot CREATE a new package under the @qwen-code org — the PUT returns 404 (`npm error 404 Not Found - PUT https://registry.npmjs.org/@qwen-code%2fchannel-dws`), aborting the whole publish. Evidence: the v0.22.1 attempt (run 32872158347, main package published, then failed at dws) and the v0.22.2-preview.0 nightly (#10062, run 32916084739, same E404). Until the npm org grants package creation, the allowlist entry makes every release fail; removing it unblocks releases without losing anything:

- The published `@qwen-code/qwen-code` package carries no dependency on `@qwen-code/channel-dws` (verified: `npm view @qwen-code/qwen-code@0.22.1 dependencies` lists no channel packages).
- `channel-registry.ts` loads channels via `Promise.allSettled` dynamic imports, so an unresolvable dws import is tolerated (the channel simply does not register), matching how absent optional channels already behave.
- The workspace package still builds, tests, and versions in lockstep; only the registry publish is deferred.

## Reviewer Test Plan

### How to verify

1. `scripts/tests/package-scripts.test.js` passes (18/18 locally) — no tripwire pins the channel loop's member list; the step-shape assertions (subshell loop, already-published skip, nothing-shipped warning) are untouched.
2. YAML validity verified locally (file parses; only the loop line and comments changed).
3. Next release run: the publish job should proceed past the channel loop; dws is skipped because it is no longer listed. Re-add `dws` to the loop once the npm org grants the automation account package-creation rights (or the package is pre-created with the CI user as maintainer).

### Evidence (Before & After)

N/A (workflow change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | N/A |
| 🪟 Windows | N/A |
|  🐧 Linux  | ✅ tested |

Closes #10062