### PR TITLE
fix(core): report broadcast delivery failures in send_message

### DIFF
--- a/packages/core/src/agents/team/TeamManager.ts
+++ b/packages/core/src/agents/team/TeamManager.ts
@@ -88,6 +88,14 @@ const debug = createDebugLogger('AGENTS_TEAM_MANAGER');
 // imported it from this module keep compiling.
 export type { TeamAgentHandle };
 
+/** Delivery outcome of a {@link TeamManager.broadcast} call. */
+export interface BroadcastResult {
+  /** Number of recipients the broadcast attempted (sender excluded). */
+  total: number;
+  /** Names of recipients whose delivery was rejected. */
+  failedRecipients: string[];
+}
+
 /** Configuration for spawning a teammate. */
 export interface TeammateSpawnConfig {
   /** Human-readable name (will be sanitized). */
@@ -670,31 +678,38 @@ export class TeamManager {
   /**
    * Broadcast a message to all teammates and the leader
    * (except the sender).
+   *
+   * Returns the delivery outcome so the caller can distinguish complete
+   * success from partial/total failure instead of assuming every
+   * delivery landed.
    */
-  async broadcast(message: string, fromName: string): Promise<void> {
-    const promises = this.teamFile.members
+  async broadcast(message: string, fromName: string): Promise<BroadcastResult> {
+    const recipients = this.teamFile.members
       .filter((m) => m.name.toLowerCase() !== fromName.toLowerCase())
-      .map((m) => this.sendMessage(m.name, message, fromName));
+      .map((m) => m.name);
 
     // Also deliver to leader inbox if sender is not the leader.
     if (fromName.toLowerCase() !== LEADER_NAME) {
-      promises.push(this.sendMessage(LEADER_NAME, message, fromName));
+      recipients.push(LEADER_NAME);
     }
 
     // allSettled, not all: a single recipient that terminated between
     // the member snapshot and the send throws (its queue is gone), and
     // Promise.all would reject the whole broadcast — making the leader
     // think every recipient failed when the rest were delivered fine.
-    const results = await Promise.allSettled(promises);
-    const failures = results.filter(
-      (r): r is PromiseRejectedResult => r.status === 'rejected',
+    const results = await Promise.allSettled(
+      recipients.map((name) => this.sendMessage(name, message, fromName)),
     );
-    if (failures.length > 0) {
+    const failedRecipients = recipients.filter(
+      (_, i) => results[i]?.status === 'rejected',
+    );
+    if (failedRecipients.length > 0) {
       debug.warn(
-        `Broadcast: ${failures.length}/${results.length} send(s) failed ` +
+        `Broadcast: ${failedRecipients.length}/${results.length} send(s) failed ` +
           `(recipient likely terminated).`,
       );
     }
+    return { total: recipients.length, failedRecipients };
   }
 
   /**

--- a/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
+++ b/packages/core/src/agents/team/test-utils/coordination-harness.test.ts
@@ -2049,6 +2049,33 @@ describe('TeamCoordinationHarness', () => {
       expect(w3.getReceivedMessages()).toHaveLength(1);
       expectTeamMessage(w3.getReceivedMessages()[0], 'w2', 'hello all');
     });
+
+    it('reports zero failures when every delivery lands (#10072)', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('w1');
+      await h.spawnTeammate('w2');
+
+      // Recipients: w2 (member) + leader inbox.
+      const result = await h.teamManager.broadcast('hello all', 'w1');
+
+      expect(result).toEqual({ total: 2, failedRecipients: [] });
+      await h.waitForMessages('w2', 1);
+    });
+
+    it('reports the recipients whose delivery was rejected (#10072)', async () => {
+      const h = await createHarness();
+      await h.spawnTeammate('w1');
+      const w2 = await h.spawnTeammate('w2');
+
+      // w2 terminates between the member snapshot and the send: its
+      // queue is dropped, so its delivery rejects while the leader
+      // inbox write still lands.
+      await w2.shutdown();
+
+      const result = await h.teamManager.broadcast('status update', 'w1');
+
+      expect(result).toEqual({ total: 2, failedRecipients: ['w2'] });
+    });
   });
 
   // ─── 6. Concurrent task claiming ──────────────────────────

--- a/packages/core/src/tools/send-message.broadcast.test.ts
+++ b/packages/core/src/tools/send-message.broadcast.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Broadcast delivery-outcome contract for send_message(to: "*") — #10072.
+ *
+ * Uses the real TeamManager (via TeamCoordinationHarness) so a delivery
+ * rejects the same way it does in production: a recipient terminates
+ * between the member snapshot and the send, its per-agent queue is
+ * dropped, and sendMessage refuses the delivery.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SendMessageTool } from './send-message.js';
+import { BackgroundTaskRegistry } from '../agents/background-tasks.js';
+import type { ApprovalMode, Config } from '../config/config.js';
+import type { TeamManager } from '../agents/team/TeamManager.js';
+import { TeamCoordinationHarness } from '../agents/team/test-utils/coordination-harness.js';
+
+// Mock Storage so all file I/O uses the harness's temp dir.
+vi.mock('../config/storage.js', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../config/storage.js')>();
+  let mockGlobalDir = '';
+  return {
+    ...original,
+    Storage: {
+      ...original.Storage,
+      getGlobalQwenDir: () => mockGlobalDir,
+      __setMockGlobalDir: (dir: string) => {
+        mockGlobalDir = dir;
+      },
+    },
+  };
+});
+
+import { Storage } from '../config/storage.js';
+
+function setMockDir(dir: string): void {
+  (
+    Storage as unknown as {
+      __setMockGlobalDir: (d: string) => void;
+    }
+  ).__setMockGlobalDir(dir);
+}
+
+function makeConfig(teamManager: TeamManager): Config {
+  return {
+    getTeamManager: () => teamManager,
+    getBackgroundTaskRegistry: () => new BackgroundTaskRegistry(),
+    getApprovalMode: () => 'default' as ApprovalMode,
+  } as unknown as Config;
+}
+
+describe('SendMessageTool — broadcast delivery outcomes (#10072)', () => {
+  let harness: TeamCoordinationHarness | undefined;
+
+  afterEach(async () => {
+    await harness?.cleanup();
+    harness = undefined;
+  });
+
+  async function createHarness(): Promise<TeamCoordinationHarness> {
+    const h = await TeamCoordinationHarness.create();
+    setMockDir(h.tmpDir);
+    harness = h;
+    return h;
+  }
+
+  function broadcastInvocation(h: TeamCoordinationHarness) {
+    const tool = new SendMessageTool(makeConfig(h.teamManager));
+    return tool.build({ to: '*', message: 'sync for everyone' });
+  }
+
+  it('does not claim complete success when a delivery is rejected', async () => {
+    const h = await createHarness();
+    await h.spawnTeammate('alice');
+    const bob = await h.spawnTeammate('bob');
+
+    // bob terminates between the member snapshot and the send: its
+    // queue is dropped, so its delivery rejects while alice's lands.
+    await bob.shutdown();
+
+    const result = await broadcastInvocation(h).execute(
+      new AbortController().signal,
+    );
+
+    expect(result.error).toBeUndefined();
+    // Must not claim that every teammate received the message…
+    expect(result.llmContent).not.toBe('Message broadcast to all teammates.');
+    // …and must name the recipient that was not reached.
+    expect(String(result.llmContent)).toContain('bob');
+  });
+
+  it('still reports complete success when every delivery lands', async () => {
+    const h = await createHarness();
+    const alice = await h.spawnTeammate('alice');
+    await h.spawnTeammate('bob');
+
+    const result = await broadcastInvocation(h).execute(
+      new AbortController().signal,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.llmContent).toBe('Message broadcast to all teammates.');
+    await h.waitForMessages('alice', 1);
+    await h.waitForMessages('bob', 1);
+    expect(alice.getReceivedMessages()).toHaveLength(1);
+  });
+
+  it('reports failure when no delivery lands', async () => {
+    const h = await createHarness();
+    const alice = await h.spawnTeammate('alice');
+    const bob = await h.spawnTeammate('bob');
+    await alice.shutdown();
+    await bob.shutdown();
+
+    const result = await broadcastInvocation(h).execute(
+      new AbortController().signal,
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.llmContent).not.toBe('Message broadcast to all teammates.');
+    expect(String(result.llmContent)).toContain('alice');
+    expect(String(result.llmContent)).toContain('bob');
+  });
+});

--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -10,6 +10,7 @@ import { BackgroundTaskRegistry } from '../agents/background-tasks.js';
 import { ToolErrorType } from './tool-error.js';
 import type { ApprovalMode, Config } from '../config/config.js';
 import { runWithTeammateIdentity } from '../agents/team/identity.js';
+import type { BroadcastResult } from '../agents/team/TeamManager.js';
 
 const DEFAULT_MODE = 'default' as ApprovalMode;
 const PLAN_MODE = 'plan' as ApprovalMode;
@@ -17,7 +18,7 @@ const PLAN_MODE = 'plan' as ApprovalMode;
 function makeTeamConfig(opts?: {
   teamManager?: {
     sendMessage: (...args: unknown[]) => Promise<void>;
-    broadcast: (...args: unknown[]) => Promise<void>;
+    broadcast: (...args: unknown[]) => Promise<BroadcastResult>;
   } | null;
   approvalMode?: ApprovalMode;
 }) {
@@ -69,7 +70,9 @@ describe('SendMessageTool — team mode', () => {
   });
 
   it('broadcasts with "*"', async () => {
-    const broadcast = vi.fn().mockResolvedValue(undefined);
+    const broadcast = vi
+      .fn()
+      .mockResolvedValue({ total: 2, failedRecipients: [] });
     const tool = new SendMessageTool(
       makeTeamConfig({
         teamManager: {

--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -242,8 +242,29 @@ class SendMessageInvocation extends BaseToolInvocation<
     try {
       if (to === '*') {
         const sender = getAgentName() ?? LEADER_NAME;
-        await teamManager.broadcast(this.params.message, sender);
-        const msg = 'Message broadcast to all teammates.';
+        const { total, failedRecipients } = await teamManager.broadcast(
+          this.params.message,
+          sender,
+        );
+        if (failedRecipients.length === 0) {
+          const msg = 'Message broadcast to all teammates.';
+          return { llmContent: msg, returnDisplay: msg };
+        }
+        const reached = total - failedRecipients.length;
+        if (reached === 0) {
+          const msg =
+            `Broadcast failed: delivery was rejected for all ${total} ` +
+            `recipient(s): ${failedRecipients.join(', ')}.`;
+          return {
+            llmContent: msg,
+            returnDisplay: msg,
+            error: { message: msg },
+          };
+        }
+        const msg =
+          `Message broadcast delivered to ${reached} of ${total} ` +
+          `recipient(s); delivery failed for: ${failedRecipients.join(', ')}. ` +
+          `The listed recipients did not receive the message.`;
         return { llmContent: msg, returnDisplay: msg };
       }
 


### PR DESCRIPTION
## What this PR does

The `send_message(to: "*")` broadcast path no longer claims complete success when one or more deliveries were rejected. `TeamManager.broadcast()` now returns the delivery outcome it already computed — the number of recipients attempted and the names of the recipients whose delivery was rejected — instead of `Promise<void>`. The broadcast branch of `send_message` uses it to distinguish three outcomes:

- **Complete success**: unchanged `Message broadcast to all teammates.`
- **Partial failure**: reports how many recipients were reached and lists the recipients whose delivery failed, stating explicitly that they did not receive the message.
- **Total failure**: returned as a tool error listing every unreachable recipient.

## Why it's needed

Fixes the misleading tool result reported in #10072: `TeamManager.broadcast()` waits with `Promise.allSettled()` and logs the rejected deliveries, but always resolves normally, and the tool then unconditionally returned `Message broadcast to all teammates.` The leader model could therefore believe every teammate received a message that never reached a terminated/rejected recipient (e.g. a recipient whose queue was dropped between the member snapshot and the send), with no way to retry or escalate.

## Reviewer Test Plan

### How to verify

Reproduced before the fix with an invocation-level fault-injection test using the real `TeamManager` (via `TeamCoordinationHarness`): create a two-teammate team, terminate one teammate so its message queue is dropped, run `send_message(to: "*")`, and observe `Message broadcast to all teammates.`

```
cd packages/core
npx vitest run src/tools/send-message.broadcast.test.ts src/tools/send-message.test.ts src/agents/team/test-utils/coordination-harness.test.ts
```

Before the fix the two fault-injection tests are red (the tool claims complete success; `error` is undefined for total failure). After the fix all 112 tests across the three files are green, including regression tests that complete success still returns the original message byte-for-byte, that existing delivery semantics (sender skip, leader inbox delivery) are unchanged, and that the `debug.warn` log line is preserved.

### Evidence (Before & After)

N/A for UI — this is an agent-visible tool result, not TUI output. Test evidence:

Before (red repro):

```
× does not claim complete success when a delivery is rejected
  → expected 'Message broadcast to all teammates.' not to be 'Message broadcast to all teammates.'
× reports failure when no delivery lands
  → expected undefined to be defined
```

After:

```
✓ src/tools/send-message.test.ts (21 tests)
✓ src/tools/send-message.broadcast.test.ts (3 tests)
✓ src/agents/team/test-utils/coordination-harness.test.ts (88 tests)
Test Files  3 passed (3)
     Tests  112 passed (112)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Unit/integration tests only (vitest) — no runtime environment needed.

## Risk & Scope

- Main risk or tradeoff: partial/total-failure results introduce new result wording that the leader model sees; the complete-success wording is kept byte-for-byte identical so happy-path behavior is unchanged. `TeamManager.broadcast()`'s return type changes from `Promise<void>` to `Promise<BroadcastResult>`; its only production caller is `send_message` (verified by grep).
- Not validated / out of scope: a live end-to-end multi-agent session; the change is covered by harness-based integration tests with the real `TeamManager`.
- Breaking changes / migration notes: none for users; internal API `TeamManager.broadcast()` return type changed.

## Linked Issues

Fixes #10072

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`send_message(to: "*")` 广播路径在部分投递被 reject 时不再声称全部成功。`TeamManager.broadcast()` 不再返回 `Promise<void>`，而是返回它本来就计算好的投递结果：尝试投递的收件人数量和投递被 reject 的收件人名单。`send_message` 的广播分支据此区分三种结果：

- **完整成功**：保持原文案 `Message broadcast to all teammates.` 不变。
- **部分失败**：报告成功送达的收件人数量，并列出投递失败的收件人，明确说明这些收件人没有收到消息。
- **全部失败**：作为工具错误（tool error）返回，并列出所有未送达的收件人。

## 为什么需要

修复 #10072 报告的误导性工具结果：`TeamManager.broadcast()` 用 `Promise.allSettled()` 等待并记录被 reject 的投递，但总是正常 resolve，工具随后无条件返回 `Message broadcast to all teammates.`。这会导致 leader 模型以为所有 teammate 都收到了消息，而实际上消息并未送达已终止/被 reject 的收件人（例如成员快照与发送之间队列被清理的收件人），且无法重试或升级处理。

## 审阅者测试计划

### 如何验证

修复前已用真实 `TeamManager`（通过 `TeamCoordinationHarness`）的调用级故障注入测试复现：创建两个 teammate，终止其中一个使其消息队列被清理，运行 `send_message(to: "*")`，观察到结果仍为 `Message broadcast to all teammates.`。

运行上面「How to verify」中的命令：修复前两个故障注入测试为红（工具声称全部成功；全部失败时 `error` 为 undefined）；修复后三个文件共 112 个测试全绿，包括「完整成功仍返回原文案」的回归测试、既有投递语义（跳过发送者、leader 收件箱投递）不变的验证，以及 `debug.warn` 日志保持原样的确认。

### 前后证据

UI 层面 N/A —— 这是 agent 可见的工具结果，不是 TUI 输出。测试证据见上方英文版。

### 测试环境

macOS 未测试，Windows 未测试，Linux 已测试。

### 环境（可选）

仅单元/集成测试（vitest），无需运行时环境。

## 风险与范围

- 主要风险或权衡：部分/全部失败引入了新的结果文案；完整成功文案保持逐字节不变，快乐路径行为不受影响。`TeamManager.broadcast()` 返回类型从 `Promise<void>` 变为 `Promise<BroadcastResult>`，唯一的生产调用方是 `send_message`（已用 grep 确认）。
- 未验证 / 超出范围：真实端到端多 agent 会话；改动由基于真实 `TeamManager` 的 harness 集成测试覆盖。
- 破坏性变更 / 迁移说明：对用户无；内部 API `TeamManager.broadcast()` 返回类型变化。

## 关联 Issue

Fixes #10072

</details>
