### PR TITLE
fix(core): disambiguate send_message destinations

### DIFF
--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -359,6 +359,7 @@ describe('SendMessageTool — background-task mode', () => {
     );
 
     expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
+    expect(result.error?.message).toBe('Task not found: nope');
     expect(result.llmContent).toContain('No background task found');
     expect(result.llmContent).not.toContain('use `to:');
     expect(result.returnDisplay).toContain('Task not found.');
@@ -388,6 +389,9 @@ describe('SendMessageTool — background-task mode', () => {
     );
 
     expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
+    expect(result.error?.message).toContain(
+      'use `to: "qa-reviewer"` instead of `task_id`',
+    );
     expect(result.llmContent).toContain('use `to: "qa-reviewer"`');
     expect(result.returnDisplay).toContain(
       'use "to" for teammate "qa-reviewer"',

--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -361,6 +361,8 @@ describe('SendMessageTool — background-task mode', () => {
     expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
     expect(result.llmContent).toContain('No background task found');
     expect(result.llmContent).not.toContain('use `to:');
+    expect(result.returnDisplay).toContain('Task not found.');
+    expect(result.returnDisplay).not.toContain('use "to"');
   });
 
   it('returns error for non-existent task without an active team', async () => {
@@ -375,6 +377,8 @@ describe('SendMessageTool — background-task mode', () => {
     expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
     expect(result.llmContent).toContain('No background task found');
     expect(result.llmContent).not.toContain('use `to:');
+    expect(result.returnDisplay).toContain('Task not found.');
+    expect(result.returnDisplay).not.toContain('use "to"');
   });
 
   it('suggests the teammate destination for a matching task ID', async () => {

--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -28,6 +28,7 @@ const DEFAULT_MODE = 'default' as ApprovalMode;
 const PLAN_MODE = 'plan' as ApprovalMode;
 
 function makeTeamConfig(opts?: {
+  registry?: BackgroundTaskRegistry;
   teamManager?: {
     sendMessage: (...args: unknown[]) => Promise<void>;
     broadcast: (...args: unknown[]) => Promise<BroadcastResult>;
@@ -43,7 +44,8 @@ function makeTeamConfig(opts?: {
     : null;
   return {
     getTeamManager: () => teamManager,
-    getBackgroundTaskRegistry: () => new BackgroundTaskRegistry(),
+    getBackgroundTaskRegistry: () =>
+      opts?.registry ?? new BackgroundTaskRegistry(),
     getApprovalMode: () => opts?.approvalMode ?? DEFAULT_MODE,
   } as unknown as Config;
 }
@@ -211,6 +213,40 @@ describe('SendMessageTool — team mode', () => {
     expect(() => tool.build({} as never)).toThrow();
     expect(() => tool.build({ to: 'alice' } as never)).toThrow();
   });
+
+  it('rejects ambiguous teammate and background-task destinations', async () => {
+    const registry = new BackgroundTaskRegistry();
+    registry.register({
+      agentId: 'agent-1',
+      description: 'test agent',
+      status: 'running',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      isBackgrounded: true,
+      outputFile: '/tmp/test.jsonl',
+    });
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const tool = new SendMessageTool(
+      makeTeamConfig({
+        registry,
+        teamManager: { sendMessage, broadcast: vi.fn() },
+      }),
+    );
+
+    const result = await tool.validateBuildAndExecute(
+      {
+        to: 'alice',
+        task_id: 'agent-1',
+        message: 'ambiguous destination',
+      },
+      new AbortController().signal,
+    );
+
+    expect(result.error?.type).toBe(ToolErrorType.INVALID_TOOL_PARAMS);
+    expect(result.llmContent).toContain('Only one of "to" or "task_id"');
+    expect(registry.get('agent-1')!.pendingMessages).toEqual([]);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
 });
 
 describe('SendMessageTool — background-task mode', () => {
@@ -226,7 +262,10 @@ describe('SendMessageTool — background-task mode', () => {
     reviveCompletedBackgroundAgent = vi.fn();
     config = {
       getBackgroundTaskRegistry: () => registry,
-      getTeamManager: () => null,
+      getTeamManager: () =>
+        ({
+          getTeamFile: () => ({ members: [{ name: 'qa-reviewer' }] }),
+        }) as ReturnType<Config['getTeamManager']>,
       resumeBackgroundAgent,
       reviveCompletedBackgroundAgent,
     } as unknown as Config;
@@ -321,6 +360,17 @@ describe('SendMessageTool — background-task mode', () => {
 
     expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
     expect(result.llmContent).toContain('No background task found');
+    expect(result.llmContent).not.toContain('use `to:');
+  });
+
+  it('suggests the teammate destination for a matching task ID', async () => {
+    const result = await tool.validateBuildAndExecute(
+      { task_id: 'QA Reviewer', message: 'hello' },
+      new AbortController().signal,
+    );
+
+    expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
+    expect(result.llmContent).toContain('use `to: "qa-reviewer"`');
   });
 
   it('returns error for a failed (non-running, non-revivable) task', async () => {

--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -385,6 +385,9 @@ describe('SendMessageTool — background-task mode', () => {
 
     expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
     expect(result.llmContent).toContain('use `to: "qa-reviewer"`');
+    expect(result.returnDisplay).toContain(
+      'use "to" for teammate "qa-reviewer"',
+    );
   });
 
   it('returns error for a failed (non-running, non-revivable) task', async () => {

--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -363,6 +363,20 @@ describe('SendMessageTool — background-task mode', () => {
     expect(result.llmContent).not.toContain('use `to:');
   });
 
+  it('returns error for non-existent task without an active team', async () => {
+    const noTeamTool = new SendMessageTool(
+      makeTeamConfig({ registry, teamManager: null }),
+    );
+    const result = await noTeamTool.validateBuildAndExecute(
+      { task_id: 'nope', message: 'hello' },
+      new AbortController().signal,
+    );
+
+    expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_FOUND);
+    expect(result.llmContent).toContain('No background task found');
+    expect(result.llmContent).not.toContain('use `to:');
+  });
+
   it('suggests the teammate destination for a matching task ID', async () => {
     const result = await tool.validateBuildAndExecute(
       { task_id: 'QA Reviewer', message: 'hello' },

--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -241,7 +241,7 @@ class SendMessageInvocation extends BaseToolInvocation<
             ? `Task not found; use "to" for teammate "${teammate.name}".`
             : 'Task not found.',
           error: {
-            message: `Task not found: ${this.params.task_id}`,
+            message: `Task not found: ${this.params.task_id}${teammate ? `.${teammateHint}` : ''}`,
             type: ToolErrorType.SEND_MESSAGE_NOT_FOUND,
           },
         };

--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -32,6 +32,7 @@ import type { PermissionDecision } from '../permissions/types.js';
 import { ToolErrorType } from './tool-error.js';
 import { ToolNames, ToolDisplayNames } from './tool-names.js';
 import { getAgentName } from '../agents/team/identity.js';
+import { findMemberByName } from '../agents/team/teamHelpers.js';
 import { LEADER_NAME } from '../agents/team/types.js';
 import type { ApprovalMode } from '../config/approval-mode.js';
 import {
@@ -224,9 +225,21 @@ class SendMessageInvocation extends BaseToolInvocation<
       const entry = registry.get(this.params.task_id);
 
       if (!entry) {
+        const teamManager = this.config.getTeamManager();
+        const teammate = teamManager
+          ? findMemberByName(
+              teamManager.getTeamFile().members,
+              this.params.task_id,
+            )
+          : undefined;
+        const teammateHint = teammate
+          ? ` Did you mean to message teammate "${teammate.name}"? If so, use \`to: "${teammate.name}"\` instead of \`task_id\`.`
+          : '';
         return {
-          llmContent: `Error: No background task found with ID "${this.params.task_id}".`,
-          returnDisplay: 'Task not found.',
+          llmContent: `Error: No background task found with ID "${this.params.task_id}".${teammateHint}`,
+          returnDisplay: teammate
+            ? `Task not found; use "to" for teammate "${teammate.name}".`
+            : 'Task not found.',
           error: {
             message: `Task not found: ${this.params.task_id}`,
             type: ToolErrorType.SEND_MESSAGE_NOT_FOUND,
@@ -534,6 +547,15 @@ export class SendMessageTool extends BaseDeclarativeTool<
     params: SendMessageParams,
   ): ToolInvocation<SendMessageParams, ToolResult> {
     return new SendMessageInvocation(this.config, params);
+  }
+
+  protected override validateToolParamValues(
+    params: SendMessageParams,
+  ): string | null {
+    if (params.to && params.task_id) {
+      return 'Only one of "to" or "task_id" may be provided.';
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
## What this PR does

This PR makes `send_message` destination selection unambiguous. Calls that supply both a teammate destination and a background-task destination now fail validation before either message path is invoked. When a background-task lookup misses but the supplied identifier matches a teammate in the active team roster, the error also suggests retrying with the teammate destination field.

The change preserves the existing missing-task error type and machine-readable message, and adds focused regression coverage for non-dispatch on ambiguous input, teammate-name normalization, and the unchanged generic error for unrelated task IDs.

## Why it's needed

Both destination fields are optional in the tool schema, while execution previously prioritized the background-task field. If both were supplied, the teammate destination was silently ignored; if the task lookup then missed, the caller received only a background-task error even when the intended recipient was a teammate. Runtime validation closes that ambiguity without introducing the provider-incompatible top-level `oneOf` schema shape discussed in #7984.

## Reviewer Test Plan

### How to verify

1. Invoke `send_message` with both `to` and `task_id` targeting valid destinations. Confirm that it returns an invalid-parameters error and that neither the teammate delivery path nor the background-task queue receives the message.
2. Invoke it with only a nonexistent `task_id` whose normalized value matches a teammate name, such as `QA Reviewer` for `qa-reviewer`. Confirm that the result remains `SEND_MESSAGE_NOT_FOUND` and suggests `to: "qa-reviewer"`.
3. Invoke it with an unrelated nonexistent `task_id`. Confirm that it retains the generic missing-background-task error and does not add a teammate hint.

### Evidence (Before & After)

Before: a call carrying both destinations queued the message to the background task and never called teammate delivery. A missing task identifier matching a teammate returned only `Error: No background task found with ID "qa-reviewer".`

After: the ambiguous call returns `Only one of "to" or "task_id" may be provided.` before dispatch. The matching missing-task case retains `SEND_MESSAGE_NOT_FOUND` and adds `Did you mean to message teammate "qa-reviewer"? If so, use to: "qa-reviewer" instead of task_id.`

Focused verification: 23/23 tests passed. Targeted ESLint and Prettier checks passed. The repository build and typecheck passed. The full preflight completed clean/install/format/lint/build/typecheck successfully, but its all-workspace test phase was not green on this Windows host: unrelated suites reported WSL `/bin/bash` absence, Windows symlink/path behavior differences, filesystem lock/permission errors, performance/time-limit failures, and one DWS timing/state expectation. No full-suite failure referenced the changed behavior; the focused test file also passed 23/23 inside the core full-suite run.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ focused tests, lint, formatting, build, and typecheck |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows PowerShell, Node.js v24.11.0, npm 11.6.1, isolated Git worktree, no sandbox runtime.

## Risk & Scope

- Main risk or tradeoff: the teammate hint is based on normalized team-roster membership; actual delivery remains subject to the existing teammate lifecycle checks.
- Not validated / out of scope: changing teammate lifecycle behavior, background-task lifecycle behavior, provider schemas, or unrelated full-suite Windows failures.
- Breaking changes / migration notes: calls that previously supplied both destination fields and silently selected `task_id` now receive an explicit validation error. No data migration or schema change is required.

## Linked Issues

Fixes #10073

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 消除了 `send_message` 目的地选择的歧义。同时提供 teammate 目的地和后台任务目的地的调用，现在会在进入任一消息通道前校验失败。当后台任务查找未命中，但提供的标识符与当前团队 roster 中的 teammate 名称匹配时，错误还会提示改用 teammate 目的地字段重试。

本次修改保留了原有的任务未找到错误类型和机器可读错误消息，并增加了聚焦回归覆盖：歧义输入不得投递、teammate 名称规范化匹配，以及无关任务 ID 仍保持通用错误。

## 为什么需要它

工具 schema 中两个目的地字段均为可选，而原执行逻辑优先处理后台任务字段。如果两者同时提供，teammate 目的地会被静默忽略；随后如果任务查找未命中，即使调用者本意是联系 teammate，也只会收到后台任务错误。运行时校验关闭了这一歧义，同时没有引入 #7984 中提到的、与部分 provider 不兼容的顶层 `oneOf` schema 结构。

## Reviewer 测试计划

### 如何验证

1. 使用同时包含 `to` 和 `task_id`、且两者都指向有效目的地的参数调用 `send_message`。确认它返回参数无效错误，并且 teammate 投递路径和后台任务队列均未收到消息。
2. 只提供一个不存在的 `task_id`，但其规范化值与 teammate 名称匹配，例如用 `QA Reviewer` 匹配 `qa-reviewer`。确认结果仍为 `SEND_MESSAGE_NOT_FOUND`，并提示使用 `to: "qa-reviewer"`。
3. 使用一个与 teammate 无关且不存在的 `task_id`。确认它保留通用的后台任务未找到错误，并且不增加 teammate 提示。

### 前后证据

修复前：同时携带两个目的地的调用会把消息排入后台任务队列，且永远不会调用 teammate 投递。与 teammate 同名的缺失任务标识符只会返回 `Error: No background task found with ID "qa-reviewer".`。

修复后：歧义调用会在投递前返回 `Only one of "to" or "task_id" may be provided.`。同名的任务未命中场景仍保留 `SEND_MESSAGE_NOT_FOUND`，并增加 `Did you mean to message teammate "qa-reviewer"? If so, use to: "qa-reviewer" instead of task_id.` 提示。

聚焦验证：23/23 项测试通过。目标 ESLint 和 Prettier 检查通过。仓库 build 和 typecheck 通过。完整 preflight 的 clean/install/format/lint/build/typecheck 阶段均成功，但其全工作区测试阶段在这台 Windows 主机上未全绿：无关套件报告了 WSL `/bin/bash` 缺失、Windows 符号链接/路径行为差异、文件锁/权限错误、性能/超时失败，以及一个 DWS 时序/状态断言失败。所有全量失败均未引用本次修改行为；目标测试文件在 core 全量测试中也为 23/23 通过。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ✅ 聚焦测试、lint、格式、build 和 typecheck 已验证 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

Windows PowerShell、Node.js v24.11.0、npm 11.6.1、隔离 Git worktree、未使用 sandbox runtime。

## 风险与范围

- 主要风险或权衡：teammate 提示基于规范化后的团队 roster 成员匹配；实际投递仍受现有 teammate 生命周期检查约束。
- 未验证 / 范围外：更改 teammate 生命周期、后台任务生命周期、provider schema，或修复无关的 Windows 全量测试失败。
- 破坏性变更 / 迁移说明：之前同时提供两个目的地字段并静默选择 `task_id` 的调用，现在会收到明确的校验错误。不需要数据迁移或 schema 变更。

## 关联 Issue

Fixes #10073

</details>
