### PR TITLE
fix(web-shell): keep pagination-completed turns expanded

### DIFF
--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -12902,6 +12902,7 @@ export function App({
                             const messageListContent = (
                               <LiveMessageList
                                 ref={messageListRef}
+                                sessionKey={connection.sessionId}
                                 baselineBlocks={blocks}
                                 baselineSummary={blockChangeSummary}
                                 baselineMessages={messages}

--- a/packages/web-shell/client/components/MessageItem.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageItem.dom.test.tsx
@@ -9,6 +9,7 @@ import {
   type WebShellCustomization,
 } from '../customization';
 import type { Message } from '../adapters/types';
+import { summaryRunId } from './summaryRunId';
 
 vi.mock('../WebShellContexts', async () => {
   const { createContext } = await import('react');
@@ -243,7 +244,7 @@ describe('MessageItem tool group spacing', () => {
     const synthetic = render(
       <I18nProvider language="en">
         <CompactModeContext.Provider value={true}>
-          {item(toolMsg('summary-agent-1'))}
+          {item(toolMsg(summaryRunId('agent-1')))}
         </CompactModeContext.Provider>
       </I18nProvider>,
     );

--- a/packages/web-shell/client/components/MessageItem.tsx
+++ b/packages/web-shell/client/components/MessageItem.tsx
@@ -18,6 +18,7 @@ import {
 } from './messages/AssistantMessage';
 import { SystemMessage } from './messages/SystemMessage';
 import { ToolGroup } from './messages/ToolGroup';
+import { isSummaryRunId } from './summaryRunId';
 import { PlanMessage } from './messages/PlanMessage';
 import { BtwMessage } from './messages/BtwMessage';
 import { UserShellMessage } from './messages/UserShellMessage';
@@ -123,7 +124,7 @@ export const MessageItem = memo(function MessageItem({
           <ToolGroup
             tools={message.tools}
             thoughts={message.thoughts}
-            compactSummary={compactMode && message.id.startsWith('summary-')}
+            compactSummary={compactMode && isSummaryRunId(message.id)}
             pendingApproval={pendingApproval}
             workspaceCwd={workspaceCwd}
             isLocateFlashing={isLocateFlashing}

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -406,6 +406,8 @@ function rerenderMessages(
     loadingTranscript?: boolean;
     catchingUp?: boolean;
     isResponding?: boolean;
+    hasOlderHistory?: boolean;
+    onLoadOlderHistory?: (options?: { force?: boolean }) => Promise<void>;
   } = {},
 ): void {
   const entry = mounted.find((item) => item.container === container);
@@ -422,6 +424,8 @@ function rerenderMessages(
                 loadingTranscript={opts.loadingTranscript}
                 catchingUp={opts.catchingUp}
                 isResponding={opts.isResponding}
+                hasOlderHistory={opts.hasOlderHistory}
+                onLoadOlderHistory={opts.onLoadOlderHistory}
               />
             </TranscriptRenderModeProvider>
           </CompactModeContext.Provider>
@@ -1014,6 +1018,547 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(has(c, 'u1')).toBe(true);
     expect(has(c, 'a1')).toBe(true);
     expect(isCollapsed(c, 'g1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps a turn expanded when pagination completes its head after its tail was shown', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    // The daemon split turn B: only its tail (t1/a1) is loaded; turn C is
+    // complete in the window, so the tail renders as pre-prompt passthrough.
+    const c = mount(
+      [
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    expect(has(c, 't1')).toBe(true);
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // The next page brings turn B's head. The turn must stay expanded instead
+    // of collapsing the steps the user is already reading.
+    rerenderMessages(
+      c,
+      [
+        userMsg('u1'),
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(has(c, 'u1')).toBe(true);
+    expect(has(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+    // The unrelated complete turn still collapses as usual.
+    expect(isCollapsed(c, 't2')).toBe(true);
+  });
+
+  it('still collapses a turn whose head arrives in one complete page', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const c = mount(
+      [userMsg('u2'), thinkingMsg('t2'), asstMsg('a2')],
+      undefined,
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    rerenderMessages(
+      c,
+      [
+        userMsg('u1'),
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    // A head that arrives together with its whole turn was never shown
+    // before, so the default collapse behavior applies unchanged.
+    expect(has(c, 'u1')).toBe(true);
+    expect(isCollapsed(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('lets an explicit toggle re-collapse a pagination-expanded turn for good', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const c = mount(
+      [
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    const completed = [
+      userMsg('u1'),
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    rerenderMessages(c, completed, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(has(c, 't1')).toBe(true);
+
+    // The user collapses the turn: the toggle must stick across later
+    // re-renders instead of the pagination keep-open re-asserting itself.
+    click(toggle(c, 'u1'));
+    expect(isCollapsed(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+
+    rerenderMessages(c, completed, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(isCollapsed(c, 't1')).toBe(true);
+  });
+
+  it('re-expands the anchored turn when its collapse hides the anchor row', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const rect = (
+      width: number,
+      height: number,
+      top: number,
+      left = 0,
+    ): DOMRect => ({
+      width,
+      height,
+      top,
+      right: left + width,
+      bottom: top + height,
+      left,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const rowKey = this.getAttribute('data-message-row-key');
+        if (rowKey === 'msg:u1') return rect(800, 50, 50);
+        if (rowKey === 'msg:t1') return rect(800, 50, 100);
+        if (rowKey === 'msg:a1') return rect(800, 50, 150);
+        if (this.hasAttribute('data-web-shell-message-list')) {
+          return rect(800, 600, 100);
+        }
+        return rect(800, 50, 0);
+      });
+    let resolveLoad!: () => void;
+    const onLoadOlderHistory = vi.fn(
+      () => new Promise<void>((resolve) => (resolveLoad = resolve)),
+    );
+    const messages = [userMsg('u1'), thinkingMsg('t1'), asstMsg('a1')];
+    // The turn is live (expanded) while a history page is requested; the
+    // anchor captures the topmost visible message row (t1).
+    const c = mount(messages, undefined, {
+      isResponding: true,
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    expect(has(c, 't1')).toBe(true);
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    try {
+      // The session ends while the page is still in flight: the turn
+      // collapses and the anchored row disappears.
+      rerenderMessages(c, messages, { isResponding: false });
+      expect(has(c, 't1')).toBe(true);
+
+      // The anchor restore re-expands the turn instead of dropping the
+      // anchor, so the reader keeps their position and the content.
+      await act(async () => {
+        resolveLoad();
+        await Promise.resolve();
+      });
+      await nextFrame();
+      expect(has(c, 't1')).toBe(true);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('drops the anchor instead of re-expanding when the user collapsed the anchored turn', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const rect = (
+      width: number,
+      height: number,
+      top: number,
+      left = 0,
+    ): DOMRect => ({
+      width,
+      height,
+      top,
+      right: left + width,
+      bottom: top + height,
+      left,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const rowKey = this.getAttribute('data-message-row-key');
+        if (rowKey === 'msg:u1') return rect(800, 50, 50);
+        if (rowKey === 'msg:t1') return rect(800, 50, 100);
+        if (rowKey === 'msg:a1') return rect(800, 50, 150);
+        if (this.hasAttribute('data-web-shell-message-list')) {
+          return rect(800, 600, 100);
+        }
+        return rect(800, 50, 0);
+      });
+    let resolveLoad!: () => void;
+    const onLoadOlderHistory = vi.fn(
+      () => new Promise<void>((resolve) => (resolveLoad = resolve)),
+    );
+    const tail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const completed = [userMsg('u1'), ...tail];
+    const c = mount(tail, undefined, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    try {
+      // Page 1 completes the split turn's head: the keep-open expands it.
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      rerenderMessages(c, completed, {
+        hasOlderHistory: true,
+        onLoadOlderHistory,
+      });
+      await act(async () => {
+        resolveLoad();
+        await Promise.resolve();
+      });
+      await nextFrame();
+      expect(has(c, 't1')).toBe(true);
+
+      // Page 2 anchors on the now-visible t1 row while the fetch is in flight.
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+
+      // The user collapses the turn before the page commits.
+      click(toggle(c, 'u1'));
+      expect(isCollapsed(c, 't1')).toBe(true);
+
+      // The commit lands: the explicit collapse wins over the keep-open, so
+      // the fallback must drop the anchor instead of re-expanding...
+      await act(async () => {
+        resolveLoad();
+        await Promise.resolve();
+      });
+      await nextFrame();
+      expect(isCollapsed(c, 't1')).toBe(true);
+
+      // ...and pagination is not stuck: a third load still fires.
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      expect(onLoadOlderHistory).toHaveBeenCalledTimes(3);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('does not let a live message landing mid-fetch consume the split-turn detection', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    let resolveLoad!: () => void;
+    const onLoadOlderHistory = vi.fn(
+      () => new Promise<void>((resolve) => (resolveLoad = resolve)),
+    );
+    const tail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const c = mount(tail, undefined, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // A live message appends while the page is in flight; it must not
+    // consume the detection snapshot (the head has not changed yet).
+    rerenderMessages(c, [...tail, asstMsg('live')], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+
+    await act(async () => {
+      resolveLoad();
+      await Promise.resolve();
+    });
+
+    // The page then commits the split turn's head; detection still fires and
+    // keeps the turn expanded.
+    rerenderMessages(c, [userMsg('u1'), ...tail, asstMsg('live')], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(has(c, 'u1')).toBe(true);
+    expect(has(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('keeps the snapshot across a non-pagination head change mid-fetch', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    let resolveLoad!: () => void;
+    const onLoadOlderHistory = vi.fn(
+      () => new Promise<void>((resolve) => (resolveLoad = resolve)),
+    );
+    const tail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const c = mount(tail, undefined, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // A non-pagination head change (transcript reload / session switch with
+    // fresh ids) lands while the fetch is in flight; it must NOT consume the
+    // snapshot, or the page commit below would silently skip detection.
+    rerenderMessages(c, [userMsg('x1'), thinkingMsg('x2'), asstMsg('x3')], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    await act(async () => {
+      resolveLoad();
+      await Promise.resolve();
+    });
+
+    // The real page then commits the split turn's head; detection still
+    // fires because the snapshot survived.
+    rerenderMessages(c, [userMsg('u1'), ...tail], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(has(c, 'u1')).toBe(true);
+    expect(has(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('clears the in-flight pagination snapshot on /clear so the next session is not mislabeled', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    // Session A tail; the block ids below are reused verbatim by session B,
+    // mirroring the daemon's per-session ordinal id scheme.
+    const sessionATail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const c = mount(sessionATail, undefined, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+
+    // /clear while the load is still in flight: the snapshot must not leak
+    // into the next session.
+    rerenderMessages(c, [], { hasOlderHistory: true, onLoadOlderHistory });
+
+    // Session B arrives with a complete, never-split turn that reuses the
+    // same ids; it must collapse by default, not stay expanded off a stale
+    // pre-clear snapshot.
+    rerenderMessages(c, [userMsg('u1'), thinkingMsg('t1'), asstMsg('a1')], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(has(c, 'u1')).toBe(true);
+    expect(isCollapsed(c, 't1')).toBe(true);
     expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
   });
 

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -319,6 +319,7 @@ function mount(
     historyCapacityReached?: boolean;
     historyPaginationError?: boolean;
     onLoadOlderHistory?: (options?: { force?: boolean }) => Promise<void>;
+    sessionKey?: string;
     transcriptBlockCount?: number;
     transcriptActivity?: {
       getSnapshot(): {
@@ -370,6 +371,7 @@ function mount(
                 historyCapacityReached={opts.historyCapacityReached}
                 historyPaginationError={opts.historyPaginationError}
                 onLoadOlderHistory={opts.onLoadOlderHistory}
+                sessionKey={opts.sessionKey}
                 transcriptBlockCount={opts.transcriptBlockCount}
                 transcriptActivity={opts.transcriptActivity}
                 onReloadTranscript={opts.onReloadTranscript}
@@ -408,6 +410,7 @@ function rerenderMessages(
     isResponding?: boolean;
     hasOlderHistory?: boolean;
     onLoadOlderHistory?: (options?: { force?: boolean }) => Promise<void>;
+    sessionKey?: string;
   } = {},
 ): void {
   const entry = mounted.find((item) => item.container === container);
@@ -426,6 +429,7 @@ function rerenderMessages(
                 isResponding={opts.isResponding}
                 hasOlderHistory={opts.hasOlderHistory}
                 onLoadOlderHistory={opts.onLoadOlderHistory}
+                sessionKey={opts.sessionKey}
               />
             </TranscriptRenderModeProvider>
           </CompactModeContext.Provider>
@@ -1380,9 +1384,500 @@ describe('MessageList — turn collapse (DOM)', () => {
         await Promise.resolve();
       });
       expect(onLoadOlderHistory).toHaveBeenCalledTimes(3);
+
+      // The superseded load's snapshot must not wedge later detection: page 3
+      // lands mid-turn...
+      rerenderMessages(c, [thinkingMsg('tC1'), asstMsg('aC1'), ...completed], {
+        hasOlderHistory: true,
+        onLoadOlderHistory,
+      });
+      await act(async () => {
+        resolveLoad();
+        await Promise.resolve();
+      });
+      // ...page 4 then completes that turn's head while its tail is already
+      // on screen, so it stays expanded.
+      // Re-top the container: re-renders snap it to the bottom while
+      // following; the scroll event must start near the top to trigger.
+      list.scrollTop = 0;
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      expect(onLoadOlderHistory).toHaveBeenCalledTimes(4);
+      rerenderMessages(
+        c,
+        [userMsg('uC'), thinkingMsg('tC1'), asstMsg('aC1'), ...completed],
+        { hasOlderHistory: true, onLoadOlderHistory },
+      );
+      expect(has(c, 'tC1')).toBe(true);
+      expect(toggleRow(c, 'uC').getAttribute('aria-expanded')).toBe('true');
     } finally {
       rectSpy.mockRestore();
     }
+  });
+
+  it('keeps split-turn detection alive when a superseded load fails', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const rect = (
+      width: number,
+      height: number,
+      top: number,
+      left = 0,
+    ): DOMRect => ({
+      width,
+      height,
+      top,
+      right: left + width,
+      bottom: top + height,
+      left,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const rowKey = this.getAttribute('data-message-row-key');
+        if (rowKey === 'msg:u1') return rect(800, 50, 50);
+        if (rowKey === 'msg:t1') return rect(800, 50, 100);
+        if (rowKey === 'msg:a1') return rect(800, 50, 150);
+        if (this.hasAttribute('data-web-shell-message-list')) {
+          return rect(800, 600, 100);
+        }
+        return rect(800, 50, 0);
+      });
+    let rejectLoad!: (error: Error) => void;
+    const onLoadOlderHistory = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            rejectLoad = reject;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const tail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const completed = [userMsg('u1'), ...tail];
+    const c = mount(tail, undefined, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    try {
+      // Page 1 completes the split turn's head; the keep-open expands it.
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      rerenderMessages(c, completed, {
+        hasOlderHistory: true,
+        onLoadOlderHistory,
+      });
+      expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+
+      // Page 2 anchors on the visible t1 row; the user collapses the turn
+      // before the fetch settles, superseding the load.
+      list.scrollTop = 0;
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+      click(toggle(c, 'u1'));
+      expect(isCollapsed(c, 't1')).toBe(true);
+
+      // The superseded load fails: its snapshot must still be dropped.
+      await act(async () => {
+        rejectLoad(new Error('load failed'));
+        await Promise.resolve();
+      });
+
+      // Page 3 lands mid-turn...
+      rerenderMessages(c, [thinkingMsg('tC1'), asstMsg('aC1'), ...completed], {
+        hasOlderHistory: true,
+        onLoadOlderHistory,
+      });
+      // ...and page 4 completes turn uC, whose tail page 3 showed: it stays
+      // expanded instead of collapsing mid-read behind the orphan snapshot.
+      list.scrollTop = 0;
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      expect(onLoadOlderHistory).toHaveBeenCalledTimes(3);
+      rerenderMessages(
+        c,
+        [userMsg('uC'), thinkingMsg('tC1'), asstMsg('aC1'), ...completed],
+        { hasOlderHistory: true, onLoadOlderHistory },
+      );
+      expect(has(c, 'tC1')).toBe(true);
+      expect(toggleRow(c, 'uC').getAttribute('aria-expanded')).toBe('true');
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('resets pagination state on a direct session switch without empty messages', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const rect = (
+      width: number,
+      height: number,
+      top: number,
+      left = 0,
+    ): DOMRect => ({
+      width,
+      height,
+      top,
+      right: left + width,
+      bottom: top + height,
+      left,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const rowKey = this.getAttribute('data-message-row-key');
+        if (rowKey === 'msg:u1') return rect(800, 50, 50);
+        if (rowKey === 'msg:t1') return rect(800, 50, 100);
+        if (rowKey === 'msg:a1') return rect(800, 50, 150);
+        if (this.hasAttribute('data-web-shell-message-list')) {
+          return rect(800, 600, 100);
+        }
+        return rect(800, 50, 0);
+      });
+    let resolveLoad!: () => void;
+    const onLoadOlderHistory = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const tail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const c = mount(tail, undefined, {
+      sessionKey: 'session-a',
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    try {
+      // Page 1 completes the split turn's head: a keep-open entry for u1.
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      rerenderMessages(c, [userMsg('u1'), ...tail], {
+        sessionKey: 'session-a',
+        hasOlderHistory: true,
+        onLoadOlderHistory,
+      });
+      await act(async () => {
+        resolveLoad();
+        await Promise.resolve();
+      });
+      expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+
+      // The user expands turn u2 explicitly: an override entry.
+      click(toggle(c, 'u2'));
+      expect(has(c, 't2')).toBe(true);
+
+      // Load 2 flies with an anchor on the visible t1 row.
+      list.scrollTop = 0;
+      await act(async () => {
+        list.dispatchEvent(new Event('scroll'));
+        await Promise.resolve();
+      });
+      expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+
+      // Direct switch to session B, which reuses the same ids, with no empty
+      // render in between and load 2 still pending: B's complete turns
+      // collapse by default — neither A's keep-open entry, nor A's override,
+      // nor A's orphaned anchor may force them open.
+      rerenderMessages(
+        c,
+        [
+          userMsg('u1'),
+          thinkingMsg('t1'),
+          asstMsg('a1'),
+          userMsg('u2'),
+          thinkingMsg('t2'),
+          asstMsg('a2'),
+        ],
+        { sessionKey: 'session-b', hasOlderHistory: true, onLoadOlderHistory },
+      );
+      expect(isCollapsed(c, 't1')).toBe(true);
+      expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+      expect(isCollapsed(c, 't2')).toBe(true);
+      expect(toggleRow(c, 'u2').getAttribute('aria-expanded')).toBe('false');
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('lets the next session paginate after switching away from an in-flight load', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const resolvers: Array<() => void> = [];
+    const onLoadOlderHistory = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const sessionATail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const c = mount(sessionATail, undefined, {
+      sessionKey: 'session-a',
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    // Session A's load never settles: its snapshot is pending at switch time.
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // Direct switch to session B with distinct ids and no empty intermediate.
+    rerenderMessages(c, [userMsg('u5'), thinkingMsg('t5'), asstMsg('a5')], {
+      sessionKey: 'session-b',
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(isCollapsed(c, 't5')).toBe(true);
+
+    // B paginates: page 1 lands mid-turn u4...
+    list.scrollTop = 0;
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      resolvers[1]?.();
+      await Promise.resolve();
+    });
+    rerenderMessages(
+      c,
+      [
+        thinkingMsg('t4'),
+        asstMsg('a4'),
+        userMsg('u5'),
+        thinkingMsg('t5'),
+        asstMsg('a5'),
+      ],
+      { sessionKey: 'session-b', hasOlderHistory: true, onLoadOlderHistory },
+    );
+
+    // ...page 2 completes u4's head while its tail is on screen: the turn
+    // must stay expanded, detected through B's own snapshot.
+    list.scrollTop = 0;
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      resolvers[2]?.();
+      await Promise.resolve();
+    });
+    rerenderMessages(
+      c,
+      [
+        userMsg('u4'),
+        thinkingMsg('t4'),
+        asstMsg('a4'),
+        userMsg('u5'),
+        thinkingMsg('t5'),
+        asstMsg('a5'),
+      ],
+      { sessionKey: 'session-b', hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(has(c, 't4')).toBe(true);
+    expect(toggleRow(c, 'u4').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('does not block the next session when the previous load fails after a switch', async () => {
+    let scrollHeight = 1200;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const rejects: Array<(error: Error) => void> = [];
+    const onLoadOlderHistory = vi.fn(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejects.push(reject);
+        }),
+    );
+    const c = mount(
+      [
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { sessionKey: 'session-a', hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // Switch while A's load is still in flight.
+    rerenderMessages(c, [userMsg('u5'), thinkingMsg('t5'), asstMsg('a5')], {
+      sessionKey: 'session-b',
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    // A's load fails only after the switch: its stale failure must not
+    // retry-block the new session's pagination.
+    await act(async () => {
+      rejects[0]?.(new Error('session A load failed'));
+      await Promise.resolve();
+    });
+
+    // B's transcript is short: pagination is underfill-driven. A live update
+    // re-renders, and the auto-load must fire.
+    scrollHeight = 600;
+    rerenderMessages(
+      c,
+      [userMsg('u5'), thinkingMsg('t5'), asstMsg('a5'), asstMsg('a5b')],
+      { sessionKey: 'session-b', hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the retry block of a failed previous-session load on switch', async () => {
+    let scrollHeight = 1200;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('load failed'))
+      .mockResolvedValue(undefined);
+    const c = mount(
+      [
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { sessionKey: 'session-a', hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // Switch to session B, whose transcript is short (underfill-driven
+    // pagination): A's failed load must not block B's auto-load.
+    scrollHeight = 600;
+    rerenderMessages(c, [userMsg('u5'), thinkingMsg('t5'), asstMsg('a5')], {
+      sessionKey: 'session-b',
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
   });
 
   it('does not let a live message landing mid-fetch consume the split-turn detection', async () => {

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -1786,6 +1786,124 @@ describe('MessageList — turn collapse (DOM)', () => {
     }
   });
 
+  it('restores the scroll position when the page extends the anchored compact run', async () => {
+    let scrollHeight = 1200;
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const rect = (
+      width: number,
+      height: number,
+      top: number,
+      left = 0,
+    ): DOMRect => ({
+      width,
+      height,
+      top,
+      right: left + width,
+      bottom: top + height,
+      left,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+    // After the page lands, the prepended history pushes the anchored turn's
+    // rows down while the scroll position has not followed yet.
+    let shifted = false;
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const rowKey = this.getAttribute('data-message-row-key');
+        const shift = shifted ? 600 : 0;
+        if (rowKey === 'msg:summary-t1') return rect(800, 50, 100);
+        if (rowKey === 'msg:u1') return rect(800, 50, 100 + shift);
+        if (rowKey === 'msg:summary-t0') return rect(800, 50, 150 + shift);
+        if (this.hasAttribute('data-web-shell-message-list')) {
+          return rect(800, 600, 100);
+        }
+        return rect(800, 50, 0);
+      });
+    let resolveLoad!: () => void;
+    const onLoadOlderHistory = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoad = () => {
+            scrollHeight = 1800;
+            resolve();
+          };
+        }),
+    );
+    // The daemon split turn u1 across pages: only its tail (t1/g1) is loaded,
+    // aggregated into one summary row in compact mode, before a newer turn.
+    const c = mount(
+      [
+        thinkingMsg('t1'),
+        toolMsg('g1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { compactMode: true, hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    expect(has(c, 'summary-t1')).toBe(true);
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    try {
+      // The page completes the split turn and extends its aggregated run: the
+      // summary row re-keys from summary-t1 to summary-t0 while the anchor
+      // still holds the captured key.
+      shifted = true;
+      rerenderMessages(
+        c,
+        [
+          userMsg('u1'),
+          thinkingMsg('t0'),
+          toolMsg('g0'),
+          thinkingMsg('t1'),
+          toolMsg('g1'),
+          userMsg('u2'),
+          thinkingMsg('t2'),
+          asstMsg('a2'),
+        ],
+        { hasOlderHistory: true, onLoadOlderHistory },
+      );
+      expect(has(c, 'summary-t0')).toBe(true);
+
+      await act(async () => {
+        resolveLoad();
+        await Promise.resolve();
+      });
+      await nextFrame();
+      // The keep-open re-expanded the turn, and the anchor restore followed
+      // the re-keyed run to a visible row instead of dropping: the scroll
+      // position moved with the prepended history.
+      expect(has(c, 'summary-t0')).toBe(true);
+      expect(list.scrollTop).toBe(600);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
   it('resets the pagination snapshot when a history load fails', async () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
       configurable: true,
@@ -1893,6 +2011,115 @@ describe('MessageList — turn collapse (DOM)', () => {
     });
     expect(isCollapsed(c, 't2')).toBe(true);
     expect(toggleRow(c, 'u3').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps a later page split turn expanded when its load raced the earlier page commit', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const resolvers: Array<() => void> = [];
+    const onLoadOlderHistory = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    // Turns uC and u1 are both split across pages: only turn u1's tail
+    // (t1/a1) is loaded, plus a complete newer turn.
+    const c = mount(
+      [
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    expect(has(c, 't1')).toBe(true);
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // Load 1 resolves SDK-side before its page commits to the transcript, and
+    // the anchor effect clears the in-flight flag while the render commit is
+    // still throttled: a fast scroll-up starts load 2 against the same
+    // pre-page-1 snapshot.
+    await act(async () => {
+      resolvers[0]?.();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
+
+    // Page 1 completes turn u1 and lands mid-turn uC, consuming the pending
+    // detection.
+    rerenderMessages(
+      c,
+      [
+        thinkingMsg('tC1'),
+        asstMsg('aC1'),
+        thinkingMsg('tC2'),
+        asstMsg('aC2'),
+        userMsg('u1'),
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(has(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+    expect(has(c, 'tC2')).toBe(true);
+
+    // Page 2 completes turn uC. Its tail was already on screen, so it must
+    // stay expanded even though its load's snapshot raced page 1's commit.
+    await act(async () => {
+      resolvers[1]?.();
+      await Promise.resolve();
+    });
+    rerenderMessages(
+      c,
+      [
+        userMsg('uC'),
+        thinkingMsg('tC1'),
+        asstMsg('aC1'),
+        thinkingMsg('tC2'),
+        asstMsg('aC2'),
+        userMsg('u1'),
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(has(c, 'tC2')).toBe(true);
+    expect(toggleRow(c, 'uC').getAttribute('aria-expanded')).toBe('true');
   });
 
   it('keeps latest assistant content when active agents are pinned after it', () => {

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -262,6 +262,13 @@ const systemMsg = (id: string): SystemMessage => ({
   variant: 'warning',
   source: 'prompt_cancelled',
 });
+const recapMsg = (id: string): SystemMessage => ({
+  id,
+  role: 'system',
+  content: 'Recap: earlier work',
+  variant: 'info',
+  source: 'recap',
+});
 const backgroundNotificationMsg = (
   id: string,
   toolUseId?: string,
@@ -1999,6 +2006,69 @@ describe('MessageList — turn collapse (DOM)', () => {
       hasOlderHistory: true,
       onLoadOlderHistory,
     });
+    expect(has(c, 'u1')).toBe(true);
+    expect(has(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('keeps split-turn detection alive when a recap message is pinned at the head', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const recap = recapMsg('local-recap-1');
+    // A /recap issued after Ctrl+L pins a local recap message at index 0;
+    // pagination prepends cannot move it. The daemon split turn u1: only its
+    // tail (t1/a1) is loaded, plus a complete turn u2 after it.
+    const c = mount(
+      [
+        recap,
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    expect(has(c, 't1')).toBe(true);
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // The page completes the split turn's head, landing right after the
+    // pinned recap; the recap stays at index 0.
+    rerenderMessages(
+      c,
+      [
+        recap,
+        userMsg('u1'),
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
     expect(has(c, 'u1')).toBe(true);
     expect(has(c, 't1')).toBe(true);
     expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -1509,7 +1509,7 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('clears the in-flight pagination snapshot on /clear so the next session is not mislabeled', async () => {
+  it('clears the pagination snapshot and keep-open set on /clear so the next session is not mislabeled', async () => {
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
       configurable: true,
       value: 1200,
@@ -1546,8 +1546,16 @@ describe('MessageList — turn collapse (DOM)', () => {
       await Promise.resolve();
     });
 
-    // /clear while the load is still in flight: the snapshot must not leak
-    // into the next session.
+    // The page completes the split turn's head first, so the keep-open set
+    // holds an entry by the time the screen clears.
+    rerenderMessages(c, [userMsg('u1'), ...sessionATail], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+
+    // /clear must drop the snapshot and the keep-open entry alike, or the
+    // entry leaks into the next session.
     rerenderMessages(c, [], { hasOlderHistory: true, onLoadOlderHistory });
 
     // Session B arrives with a complete, never-split turn that reuses the
@@ -1560,6 +1568,331 @@ describe('MessageList — turn collapse (DOM)', () => {
     expect(has(c, 'u1')).toBe(true);
     expect(isCollapsed(c, 't1')).toBe(true);
     expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps the pagination-completed turn expanded while the tail streams', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const streamingTail = (content: string): AssistantMessage => ({
+      ...asstMsg('a2'),
+      content,
+      isStreaming: true,
+    });
+    const tail: Message[] = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      streamingTail('partial'),
+    ];
+    const c = mount(tail, undefined, {
+      isResponding: true,
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // The page commits while the tail is still streaming. The head object is
+    // reused verbatim by the later snapshots, mirroring how the daemon reuses
+    // message identities and only replaces the streaming tail.
+    const head = userMsg('u1');
+    rerenderMessages(c, [head, ...tail], {
+      isResponding: true,
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+
+    // Streaming keeps updating the tail over the same messages; the keep-open
+    // added by the detection must not be masked by the streaming-tail
+    // fast-path cache serving the page-commit render's collapsed value.
+    rerenderMessages(
+      c,
+      [head, ...tail.slice(0, -1), streamingTail('partial answer')],
+      { isResponding: true, hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(has(c, 'u1')).toBe(true);
+    expect(has(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('keeps a split turn expanded in compact mode when the page extends its aggregated run', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    // Interrupted (assistant-less) turn: only its thinking/tool tail fragment
+    // is loaded, aggregated into one summary row in compact mode, plus a
+    // newer complete turn.
+    const c = mount(
+      [
+        thinkingMsg('t1'),
+        toolMsg('g1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      undefined,
+      { compactMode: true, hasOlderHistory: true, onLoadOlderHistory },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    // Sanity: aggregation is live — the fragment renders as one summary row.
+    expect(has(c, 'summary-t1')).toBe(true);
+    expect(has(c, 't1')).toBe(false);
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // The page prepends the turn's head and extends the aggregated run
+    // (summary-t1 re-keys to summary-t0); the turn the user is reading must
+    // stay expanded.
+    rerenderMessages(
+      c,
+      [
+        userMsg('u1'),
+        thinkingMsg('t0'),
+        toolMsg('g0'),
+        thinkingMsg('t1'),
+        toolMsg('g1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(has(c, 'u1')).toBe(true);
+    expect(has(c, 'summary-t0')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('re-expands the anchored turn through a compact aggregate row key', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const rect = (
+      width: number,
+      height: number,
+      top: number,
+      left = 0,
+    ): DOMRect => ({
+      width,
+      height,
+      top,
+      right: left + width,
+      bottom: top + height,
+      left,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        const rowKey = this.getAttribute('data-message-row-key');
+        if (rowKey === 'msg:u1') return rect(800, 50, 50);
+        if (rowKey === 'msg:summary-t1') return rect(800, 50, 100);
+        if (this.hasAttribute('data-web-shell-message-list')) {
+          return rect(800, 600, 100);
+        }
+        return rect(800, 50, 0);
+      });
+    let resolveLoad!: () => void;
+    const onLoadOlderHistory = vi.fn(
+      () => new Promise<void>((resolve) => (resolveLoad = resolve)),
+    );
+    const messages = [userMsg('u1'), thinkingMsg('t1'), toolMsg('g1')];
+    // Compact mode aggregates the run into one row; the anchor captures it.
+    const c = mount(messages, undefined, {
+      compactMode: true,
+      isResponding: true,
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    expect(has(c, 'summary-t1')).toBe(true);
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    try {
+      // The response completes while the page is still in flight: the turn
+      // collapses and the anchored aggregate row disappears.
+      rerenderMessages(c, [...messages, asstMsg('a1')], {
+        isResponding: false,
+      });
+
+      // The anchor restore resolves the aggregate row key and re-expands the
+      // turn instead of dropping the anchor.
+      expect(has(c, 'summary-t1')).toBe(true);
+      await act(async () => {
+        resolveLoad();
+        await Promise.resolve();
+      });
+      await nextFrame();
+      expect(has(c, 'summary-t1')).toBe(true);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('resets the pagination snapshot when a history load fails', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('load failed'));
+    const sessionATail = [
+      thinkingMsg('t1'),
+      asstMsg('a1'),
+      userMsg('u2'),
+      thinkingMsg('t2'),
+      asstMsg('a2'),
+    ];
+    const c = mount(sessionATail, undefined, {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // Session B reuses the tail ids in a complete, never-split turn: it must
+    // collapse by default, not stay expanded off the failed load's snapshot.
+    rerenderMessages(c, [userMsg('u1'), thinkingMsg('t1'), asstMsg('a1')], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(has(c, 'u1')).toBe(true);
+    expect(isCollapsed(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('consumes the pagination snapshot when the page completes no split turn', async () => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      value: 1200,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      value: 600,
+    });
+    const onLoadOlderHistory = vi.fn().mockResolvedValue(undefined);
+    const c = mount(
+      [userMsg('u2'), thinkingMsg('t2'), asstMsg('a2')],
+      undefined,
+      {
+        hasOlderHistory: true,
+        onLoadOlderHistory,
+      },
+    );
+    const list = c.querySelector(
+      '[data-web-shell-message-list]',
+    ) as HTMLElement;
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      writable: true,
+      value: 0,
+    });
+
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'));
+      await Promise.resolve();
+    });
+    expect(onLoadOlderHistory).toHaveBeenCalledTimes(1);
+
+    // The page lands a whole turn at once: no split turn, so nothing is
+    // marked keep-open and the snapshot is consumed.
+    rerenderMessages(
+      c,
+      [
+        userMsg('u1'),
+        thinkingMsg('t1'),
+        asstMsg('a1'),
+        userMsg('u2'),
+        thinkingMsg('t2'),
+        asstMsg('a2'),
+      ],
+      { hasOlderHistory: true, onLoadOlderHistory },
+    );
+    expect(isCollapsed(c, 't1')).toBe(true);
+    expect(toggleRow(c, 'u1').getAttribute('aria-expanded')).toBe('false');
+
+    // A later head change must not be compared against the stale snapshot:
+    // reused tail ids alone cannot force a turn open.
+    rerenderMessages(c, [userMsg('u3'), thinkingMsg('t2'), asstMsg('a2')], {
+      hasOlderHistory: true,
+      onLoadOlderHistory,
+    });
+    expect(isCollapsed(c, 't2')).toBe(true);
+    expect(toggleRow(c, 'u3').getAttribute('aria-expanded')).toBe('false');
   });
 
   it('keeps latest assistant content when active agents are pinned after it', () => {

--- a/packages/web-shell/client/components/MessageList.test.ts
+++ b/packages/web-shell/client/components/MessageList.test.ts
@@ -1133,6 +1133,7 @@ function collapseItems(
     waitForUnmatchedAgentCompletions: boolean;
     terminalBackgroundShellTaskIds: ReadonlySet<string>;
     automaticallyExpandedAgentKeys: ReadonlySet<string>;
+    paginatedExpanded: ReadonlySet<string>;
     enabled: boolean;
   }> = {},
 ): DisplayItem[] {
@@ -1145,6 +1146,7 @@ function collapseItems(
       opts.waitForUnmatchedAgentCompletions ?? true,
     terminalBackgroundShellTaskIds: opts.terminalBackgroundShellTaskIds,
     automaticallyExpandedAgentKeys: opts.automaticallyExpandedAgentKeys,
+    paginatedExpanded: opts.paginatedExpanded,
     enabled: opts.enabled ?? true,
   });
 }
@@ -1218,6 +1220,50 @@ describe('applyTurnCollapse', () => {
       collapsed: false,
       hiddenCount: 1,
     });
+  });
+
+  it('keeps a turn expanded when its tail was shown before pagination completed its head', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeMultiToolGroup('g1'),
+      makeAssistantMessage('a1'),
+      makeUserMessage('u2'),
+      makeMultiToolGroup('g2'),
+      makeAssistantMessage('a2'),
+    ]);
+    const out = collapseItems(items, {
+      paginatedExpanded: new Set(['u1']),
+    });
+    // The pagination-completed turn stays open (its steps are visible); the
+    // following complete turn still collapses as usual.
+    expect(rowIds(out)).toEqual([
+      'u1',
+      'tc-u1',
+      'g1',
+      'a1',
+      'u2',
+      'tc-u2',
+      'a2',
+    ]);
+    expect(collapseOf(out, 0)).toMatchObject({
+      collapsed: false,
+      hiddenCount: 1,
+    });
+    expect(collapseOf(out, 4)).toMatchObject({ collapsed: true });
+  });
+
+  it('lets an explicit user toggle override the pagination keep-open', () => {
+    const items = groupParallelAgents([
+      makeUserMessage('u1'),
+      makeMultiToolGroup('g1'),
+      makeAssistantMessage('a1'),
+    ]);
+    const out = collapseItems(items, {
+      paginatedExpanded: new Set(['u1']),
+      overrides: new Map([['u1', false]]),
+    });
+    expect(rowIds(out)).toEqual(['u1', 'tc-u1', 'a1']);
+    expect(collapseOf(out, 0)).toMatchObject({ collapsed: true });
   });
 
   it('keeps every row but still tags the head when the turn is expanded', () => {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -997,7 +997,14 @@ function turnIdOfMessageRow(
   rowKey: string,
 ): string | undefined {
   if (!rowKey.startsWith('msg:')) return undefined;
-  const messageId = rowKey.slice('msg:'.length);
+  let messageId = rowKey.slice('msg:'.length);
+  if (messageId.startsWith('summary-')) {
+    // Compact-aggregate row keys embed the run's first member id. Resolve
+    // through it so the key still maps to its turn when looked up in the raw
+    // message list, including after a page extending the run re-keyed the
+    // aggregate.
+    messageId = messageId.slice('summary-'.length);
+  }
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (message?.id !== messageId) continue;
@@ -3319,6 +3326,7 @@ export const MessageList = memo(
       null,
     );
     const pendingPaginationTurnCompare = useRef(false);
+    const paginationLoadResolved = useRef(false);
     const [turnLayoutPending, startTurnLayoutTransition] = useTransition();
     const turnLayoutTransitionStarted = useRef(false);
     const turnLayoutRowTops = useRef(new Map<string, number>());
@@ -3394,10 +3402,10 @@ export const MessageList = memo(
     useLayoutEffect(() => {
       mergedMessageCountRef.current = mergedMessages.length;
     }, [mergedMessages.length]);
-    const mergedMessagesRef = useRef(mergedMessages);
+    const rawMessagesRef = useRef(messages);
     useLayoutEffect(() => {
-      mergedMessagesRef.current = mergedMessages;
-    }, [mergedMessages]);
+      rawMessagesRef.current = messages;
+    }, [messages]);
     const [
       suppressOlderHistoryLoadingStatus,
       setSuppressOlderHistoryLoadingStatus,
@@ -3469,6 +3477,7 @@ export const MessageList = memo(
         turnFileChanges,
         turnArtifacts,
         turnScheduledTasks,
+        paginatedExpandedTurns,
       ] as const;
       const cached = visibleItemsCache.current;
       const currentTail = displayItems[displayItems.length - 1];
@@ -4145,7 +4154,7 @@ export const MessageList = memo(
         // was loading (a turn completed by pagination). Re-expand that turn so
         // the anchor can be restored instead of dropping the reader's position.
         const anchorTurnId = turnIdOfMessageRow(
-          mergedMessagesRef.current,
+          rawMessagesRef.current,
           olderHistoryAnchor.rowKey,
         );
         if (
@@ -4622,11 +4631,13 @@ export const MessageList = memo(
           // a turn the daemon split across pages (tail shown first, head
           // completing later) can be detected and kept expanded.
           previousPaginationMessageIds.current = new Set(
-            mergedMessagesRef.current.map((message) => message.id),
+            rawMessagesRef.current.map((message) => message.id),
           );
           pendingPaginationTurnCompare.current = true;
+          paginationLoadResolved.current = false;
           await onLoadOlderHistory(force ? { force: true } : undefined);
           if (generation === olderHistoryLoadGeneration.current) {
+            paginationLoadResolved.current = true;
             setOlderHistoryAnchor((anchor) =>
               anchor?.generation === generation
                 ? { ...anchor, settled: true }
@@ -4675,11 +4686,14 @@ export const MessageList = memo(
       // while the fetch is in flight append at the tail. Wait for the head to
       // change so a mid-flight live update cannot consume the snapshot before
       // the page commits (which would silently skip the split-turn detection).
-      const first = mergedMessages[0];
+      // Compare raw message ids, not the compact-mode aggregate ids: a page
+      // that extends an aggregated run re-keys the synthetic summary id, but
+      // the run members keep their daemon ids.
+      const first = messages[0];
       if (!first || before.has(first.id)) return;
       const newTurnIds: string[] = [];
-      for (let i = 0; i < mergedMessages.length; i++) {
-        const message = mergedMessages[i];
+      for (let i = 0; i < messages.length; i++) {
+        const message = messages[i];
         if (
           !message ||
           !isTurnStartMessage(message) ||
@@ -4688,8 +4702,8 @@ export const MessageList = memo(
           continue;
         }
         let tailShown = false;
-        for (let j = i + 1; j < mergedMessages.length; j++) {
-          const next = mergedMessages[j];
+        for (let j = i + 1; j < messages.length; j++) {
+          const next = messages[j];
           if (isTurnStartMessage(next)) break;
           if (before.has(next.id)) {
             tailShown = true;
@@ -4698,12 +4712,21 @@ export const MessageList = memo(
         }
         if (tailShown) newTurnIds.push(message.id);
       }
-      // Consume the snapshot only once detection actually ran against a
-      // page-like commit. A head change that is not the page landing (a
-      // transcript reload, a session/branch switch) otherwise discards the
-      // snapshot and the page commit that follows silently skips detection —
-      // the split turn collapses again, the bug this code exists to fix.
-      if (newTurnIds.length === 0) return;
+      if (newTurnIds.length === 0) {
+        // A changed head while the load is resolved is the page landing, so
+        // consume the snapshot even when it completed no split turn —
+        // otherwise every later transcript update rescans it for the rest of
+        // the session. While the load is still in flight a head change is
+        // not the page (a transcript reload or session/branch switch);
+        // discarding the snapshot there would let the page commit that
+        // follows silently skip detection — the split turn collapses again,
+        // the bug this code exists to fix.
+        if (paginationLoadResolved.current) {
+          pendingPaginationTurnCompare.current = false;
+          previousPaginationMessageIds.current = null;
+        }
+        return;
+      }
       pendingPaginationTurnCompare.current = false;
       previousPaginationMessageIds.current = null;
       setPaginatedExpandedTurns((prev) => {
@@ -4716,7 +4739,7 @@ export const MessageList = memo(
         }
         return next ?? prev;
       });
-    }, [mergedMessages]);
+    }, [messages]);
 
     useEffect(() => {
       const pendingGeneration = pendingOlderHistoryTopLoad.current;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -665,6 +665,14 @@ export interface ApplyTurnCollapseOptions {
    */
   pendingApprovalCallId?: string | null;
   includeSubagentToolUsageInMetrics?: boolean;
+  /**
+   * Turns kept expanded despite being complete. Two sources: pagination
+   * split-turn detection (the tail was on screen before pagination completed
+   * the user prompt), and the anchor fallback (a turn collapsed while a
+   * history anchor sat on it). Entries persist until the user toggles the
+   * turn or the screen is cleared; an explicit user toggle always wins.
+   */
+  paginatedExpanded?: ReadonlySet<string>;
   /** Master switch; when false the items pass through untouched. */
   enabled: boolean;
 }
@@ -980,6 +988,39 @@ function isScheduledTaskMessage(message: {
 // auto-follow still uses getLastUserMessageId so shell prompts do not jump.
 function isTurnStartMessage(message: Message): boolean {
   return message.role === 'user' || message.role === 'user_shell';
+}
+
+// Find the turn head (user message id) owning the message referenced by a
+// `msg:` row key, when the message is still present.
+function turnIdOfMessageRow(
+  messages: Message[],
+  rowKey: string,
+): string | undefined {
+  if (!rowKey.startsWith('msg:')) return undefined;
+  const messageId = rowKey.slice('msg:'.length);
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.id !== messageId) continue;
+    for (let j = i; j >= 0; j--) {
+      const candidate = messages[j];
+      if (candidate && isTurnStartMessage(candidate)) return candidate.id;
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+// True when the given turn currently renders as a collapsed turn_collapse row.
+function isTurnCollapsedInVisibleItems(
+  items: DisplayItem[],
+  turnId: string,
+): boolean {
+  for (const item of items) {
+    if (item.type === 'turn_collapse' && item.turnCollapse.turnId === turnId) {
+      return item.turnCollapse.collapsed;
+    }
+  }
+  return false;
 }
 
 function timelineDetailSnippetForMessage(
@@ -1798,6 +1839,7 @@ export function applyTurnCollapse(
     automaticallyExpandedAgentKeys,
     pendingApprovalCallId,
     includeSubagentToolUsageInMetrics = true,
+    paginatedExpanded,
     enabled,
   }: ApplyTurnCollapseOptions,
 ): DisplayItem[] {
@@ -1953,7 +1995,8 @@ export function applyTurnCollapse(
     // turn is incomplete; otherwise it collapses once a newer turn starts. A
     // step-less turn (e.g. a plain "hi" reply) has nothing to fold, so it stays
     // expanded and shows a chevron-less metrics line. An explicit user toggle
-    // always wins.
+    // always wins; a turn whose tail was shown before pagination finished its
+    // head stays open so that content never vanishes mid-read.
     const shouldStayOpen =
       isActiveTurn ||
       hasActiveAgent ||
@@ -1967,7 +2010,9 @@ export function applyTurnCollapse(
         ? true
         : overrides.has(turnId)
           ? (overrides.get(turnId) as boolean)
-          : shouldStayOpen;
+          : paginatedExpanded?.has(turnId)
+            ? true
+            : shouldStayOpen;
     const collapsed = !expanded;
     // Push the user message
     result.push({
@@ -3262,6 +3307,18 @@ export const MessageList = memo(
     const [collapseOverrides, setCollapseOverrides] = useState<
       ReadonlyMap<string, boolean>
     >(() => new Map());
+    // Turns kept expanded despite being complete. Two sources: pagination
+    // split-turn detection (tail was on screen before the user prompt
+    // arrived), and the anchor fallback (a turn collapsed while a history
+    // anchor sat on it). Entries persist until the user toggles the turn or
+    // the screen is cleared.
+    const [paginatedExpandedTurns, setPaginatedExpandedTurns] = useState<
+      ReadonlySet<string>
+    >(() => new Set());
+    const previousPaginationMessageIds = useRef<ReadonlySet<string> | null>(
+      null,
+    );
+    const pendingPaginationTurnCompare = useRef(false);
     const [turnLayoutPending, startTurnLayoutTransition] = useTransition();
     const turnLayoutTransitionStarted = useRef(false);
     const turnLayoutRowTops = useRef(new Map<string, number>());
@@ -3337,6 +3394,10 @@ export const MessageList = memo(
     useLayoutEffect(() => {
       mergedMessageCountRef.current = mergedMessages.length;
     }, [mergedMessages.length]);
+    const mergedMessagesRef = useRef(mergedMessages);
+    useLayoutEffect(() => {
+      mergedMessagesRef.current = mergedMessages;
+    }, [mergedMessages]);
     const [
       suppressOlderHistoryLoadingStatus,
       setSuppressOlderHistoryLoadingStatus,
@@ -3459,6 +3520,7 @@ export const MessageList = memo(
         automaticallyExpandedAgentKeys,
         pendingApprovalCallId: pendingApproval?.toolCallId ?? null,
         includeSubagentToolUsageInMetrics,
+        paginatedExpanded: paginatedExpandedTurns,
         enabled: collapseEnabled,
       });
       let metricsApplied = false;
@@ -3539,6 +3601,7 @@ export const MessageList = memo(
       turnFileChanges,
       turnArtifacts,
       turnScheduledTasks,
+      paginatedExpandedTurns,
     ]);
     const virtualizerItems =
       visibleItemsCache.current?.sourceMessages === messages
@@ -3848,6 +3911,15 @@ export const MessageList = memo(
           });
         turnLayoutTransitionStarted.current = true;
         startTurnLayoutTransition(() => {
+          // An explicit toggle is the user's own decision: it wins over the
+          // pagination keep-open and returns the turn to normal collapse
+          // semantics.
+          setPaginatedExpandedTurns((prev) => {
+            if (!prev.has(turnId)) return prev;
+            const next = new Set(prev);
+            next.delete(turnId);
+            return next;
+          });
           setCollapseOverrides((prev) => {
             const next = new Map(prev);
             next.set(turnId, nextExpanded);
@@ -4069,6 +4141,33 @@ export const MessageList = memo(
         olderHistoryAnchor.rowKey &&
         !hasVisibleRowKey(olderHistoryAnchor.rowKey)
       ) {
+        // The anchor row can vanish because its turn collapsed while the page
+        // was loading (a turn completed by pagination). Re-expand that turn so
+        // the anchor can be restored instead of dropping the reader's position.
+        const anchorTurnId = turnIdOfMessageRow(
+          mergedMessagesRef.current,
+          olderHistoryAnchor.rowKey,
+        );
+        if (
+          anchorTurnId !== undefined &&
+          isTurnCollapsedInVisibleItems(visibleItems, anchorTurnId)
+        ) {
+          // Re-expanding only helps when it can actually take effect: an
+          // explicit user collapse override wins over the keep-open, and a
+          // turn already marked keep-open yet still hidden cannot be helped.
+          // Fall through and drop the anchor in those cases, or pagination
+          // state stays pinned in-flight forever (every later load bails at
+          // the in-flight guard).
+          if (
+            collapseOverrides.get(anchorTurnId) !== false &&
+            !paginatedExpandedTurns.has(anchorTurnId)
+          ) {
+            setPaginatedExpandedTurns((prev) =>
+              prev.has(anchorTurnId) ? prev : new Set(prev).add(anchorTurnId),
+            );
+            return;
+          }
+        }
         if (
           olderHistoryAnchor.generation === olderHistoryLoadGeneration.current
         ) {
@@ -4163,6 +4262,8 @@ export const MessageList = memo(
       mergedMessages.length,
       olderHistoryAnchor,
       visibleItems,
+      collapseOverrides,
+      paginatedExpandedTurns,
     ]);
     const virtualItems = virtualizer.getVirtualItems();
     const totalVirtualSize = virtualizer.getTotalSize();
@@ -4517,6 +4618,13 @@ export const MessageList = memo(
               : {})),
         });
         try {
+          // Remember which messages were on screen before the page arrives so
+          // a turn the daemon split across pages (tail shown first, head
+          // completing later) can be detected and kept expanded.
+          previousPaginationMessageIds.current = new Set(
+            mergedMessagesRef.current.map((message) => message.id),
+          );
+          pendingPaginationTurnCompare.current = true;
           await onLoadOlderHistory(force ? { force: true } : undefined);
           if (generation === olderHistoryLoadGeneration.current) {
             setOlderHistoryAnchor((anchor) =>
@@ -4529,6 +4637,8 @@ export const MessageList = memo(
           if (generation === olderHistoryLoadGeneration.current) {
             olderHistoryRetryBlocked.current = true;
             olderHistoryLoadInFlight.current = false;
+            pendingPaginationTurnCompare.current = false;
+            previousPaginationMessageIds.current = null;
             setOlderHistoryAnchor(null);
           }
         } finally {
@@ -4552,6 +4662,61 @@ export const MessageList = memo(
     const retryOlderHistory = useCallback(() => {
       void loadOlderHistory(true, true);
     }, [loadOlderHistory]);
+
+    // After a pagination page commits, mark turns whose user prompt just
+    // arrived while their tail was already on screen (the daemon split the
+    // turn across pages). `applyTurnCollapse` keeps those expanded so the
+    // content the user is reading never silently collapses.
+    useLayoutEffect(() => {
+      if (!pendingPaginationTurnCompare.current) return;
+      const before = previousPaginationMessageIds.current;
+      if (before === null) return;
+      // A page prepends older messages at the head; live messages that land
+      // while the fetch is in flight append at the tail. Wait for the head to
+      // change so a mid-flight live update cannot consume the snapshot before
+      // the page commits (which would silently skip the split-turn detection).
+      const first = mergedMessages[0];
+      if (!first || before.has(first.id)) return;
+      const newTurnIds: string[] = [];
+      for (let i = 0; i < mergedMessages.length; i++) {
+        const message = mergedMessages[i];
+        if (
+          !message ||
+          !isTurnStartMessage(message) ||
+          before.has(message.id)
+        ) {
+          continue;
+        }
+        let tailShown = false;
+        for (let j = i + 1; j < mergedMessages.length; j++) {
+          const next = mergedMessages[j];
+          if (isTurnStartMessage(next)) break;
+          if (before.has(next.id)) {
+            tailShown = true;
+            break;
+          }
+        }
+        if (tailShown) newTurnIds.push(message.id);
+      }
+      // Consume the snapshot only once detection actually ran against a
+      // page-like commit. A head change that is not the page landing (a
+      // transcript reload, a session/branch switch) otherwise discards the
+      // snapshot and the page commit that follows silently skips detection —
+      // the split turn collapses again, the bug this code exists to fix.
+      if (newTurnIds.length === 0) return;
+      pendingPaginationTurnCompare.current = false;
+      previousPaginationMessageIds.current = null;
+      setPaginatedExpandedTurns((prev) => {
+        let next: Set<string> | null = null;
+        for (const id of newTurnIds) {
+          if (!prev.has(id)) {
+            next ??= new Set(prev);
+            next.add(id);
+          }
+        }
+        return next ?? prev;
+      });
+    }, [mergedMessages]);
 
     useEffect(() => {
       const pendingGeneration = pendingOlderHistoryTopLoad.current;
@@ -4821,7 +4986,13 @@ export const MessageList = memo(
         pendingBottomFollowAfterCooldown.current = false;
         setShouldFollow(true);
         pendingScrollRef.current = null;
+        // Drop the in-flight pagination snapshot too: without this a stale
+        // pre-clear snapshot survives into the next session and can mislabel
+        // a complete turn as keep-open (block ids are per-session ordinals).
+        pendingPaginationTurnCompare.current = false;
+        previousPaginationMessageIds.current = null;
         setCollapseOverrides((prev) => (prev.size ? new Map() : prev));
+        setPaginatedExpandedTurns((prev) => (prev.size ? new Set() : prev));
       }
     }, [messages.length, setShouldFollow]);
 

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -42,6 +42,7 @@ import { formatContextTokens } from '../utils/formatTokenCount';
 import { useWebShellPortalRoot } from '../portalRoot';
 import { useTranscriptRenderMode } from '../transcriptRenderMode';
 import { MessageItem } from './MessageItem';
+import { summaryRunFirstMemberId, summaryRunId } from './summaryRunId';
 import type { SessionContentGenerator } from './messages/AssistantMessage';
 import { MessageTimestamp } from './MessageTimestamp';
 import {
@@ -88,6 +89,13 @@ interface MessageListProps {
   historyCapacityReached?: boolean;
   historyPaginationError?: boolean;
   onLoadOlderHistory?: (options?: { force?: boolean }) => Promise<void>;
+  /**
+   * Identity of the session whose transcript `messages` show. Block ids are
+   * per-session ordinals, so changing it resets every session-scoped UI state
+   * (collapse overrides, pagination keep-open, pending page snapshots, the
+   * scroll anchor) — a direct session switch never renders empty messages.
+   */
+  sessionKey?: string;
   transcriptBlockCount?: number;
   transcriptActivity?: {
     getSnapshot(): {
@@ -286,14 +294,6 @@ export interface SessionTimelineRange {
   endIndex: number;
   currentIndex: number;
 }
-
-const SUMMARY_RUN_ID_PREFIX = 'summary-';
-const summaryRunId = (firstMemberId: string): string =>
-  `${SUMMARY_RUN_ID_PREFIX}${firstMemberId}`;
-const summaryRunFirstMemberId = (id: string): string | undefined =>
-  id.startsWith(SUMMARY_RUN_ID_PREFIX)
-    ? id.slice(SUMMARY_RUN_ID_PREFIX.length)
-    : undefined;
 
 // Synthetic compact summaries carry a folded thought next to their single
 // tool; the parallel-agent path must never swallow that row, so agent-only
@@ -2787,6 +2787,7 @@ export const MessageList = memo(
   forwardRef<MessageListHandle, MessageListProps>(function MessageList(
     {
       messages,
+      sessionKey,
       terminalBackgroundShellTaskIds,
       pendingApproval,
       onShowContextDetail,
@@ -3419,6 +3420,25 @@ export const MessageList = memo(
       suppressOlderHistoryLoadingStatus,
       setSuppressOlderHistoryLoadingStatus,
     ] = useState(false);
+
+    // A direct session switch never renders empty messages (the provider
+    // batches the store reset and the replay into one notification), so the
+    // /clear reset never runs for it. Block ids are per-session ordinals, so
+    // every session-scoped state must drop when the displayed session
+    // changes: stale keep-open and snapshot entries would collide with the
+    // new session's reused ids, and an old anchor would restore the previous
+    // session's scroll metrics into the new transcript.
+    const [trackedSessionKey, setTrackedSessionKey] = useState(sessionKey);
+    if (trackedSessionKey !== sessionKey) {
+      setTrackedSessionKey(sessionKey);
+      pendingPaginationTurnCompares.current.clear();
+      olderHistoryLoadGeneration.current += 1;
+      olderHistoryLoadInFlight.current = false;
+      olderHistoryRetryBlocked.current = false;
+      setOlderHistoryAnchor(null);
+      setCollapseOverrides((prev) => (prev.size ? new Map() : prev));
+      setPaginatedExpandedTurns((prev) => (prev.size ? new Set() : prev));
+    }
 
     useEffect(() => {
       if (!hasOlderHistory) {
@@ -4651,10 +4671,13 @@ export const MessageList = memo(
             resolved: false,
           });
           await onLoadOlderHistory(force ? { force: true } : undefined);
+          // The snapshot belongs to this load regardless of anchor state: a
+          // superseding anchor drop bumps the generation mid-flight and would
+          // otherwise orphan the entry unresolved at the FIFO head, wedging
+          // every later split-turn detection.
+          const compare = pendingPaginationTurnCompares.current.get(generation);
+          if (compare) compare.resolved = true;
           if (generation === olderHistoryLoadGeneration.current) {
-            const compare =
-              pendingPaginationTurnCompares.current.get(generation);
-            if (compare) compare.resolved = true;
             setOlderHistoryAnchor((anchor) =>
               anchor?.generation === generation
                 ? { ...anchor, settled: true }
@@ -4662,10 +4685,12 @@ export const MessageList = memo(
             );
           }
         } catch {
+          // A failed load commits no page, so its snapshot is always safe to
+          // drop, including when the load was superseded mid-flight.
+          pendingPaginationTurnCompares.current.delete(generation);
           if (generation === olderHistoryLoadGeneration.current) {
             olderHistoryRetryBlocked.current = true;
             olderHistoryLoadInFlight.current = false;
-            pendingPaginationTurnCompares.current.delete(generation);
             setOlderHistoryAnchor(null);
           }
         } finally {

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -4722,7 +4722,13 @@ export const MessageList = memo(
     useLayoutEffect(() => {
       const pending = pendingPaginationTurnCompares.current;
       if (pending.size === 0) return;
-      const first = messages[0];
+      // Skip locally-injected messages (recap ids `local-*`): /recap re-pins
+      // them at index 0 on every render and pagination cannot move them, so
+      // they never reflect a page landing and would pin the head-change check
+      // forever, wedging split-turn detection for the rest of the session.
+      const first = messages.find(
+        (message) => !message?.id.startsWith('local-'),
+      );
       if (!first) return;
       const oldest = pending.entries().next().value;
       if (!oldest) return;

--- a/packages/web-shell/client/components/MessageList.tsx
+++ b/packages/web-shell/client/components/MessageList.tsx
@@ -287,13 +287,21 @@ export interface SessionTimelineRange {
   currentIndex: number;
 }
 
+const SUMMARY_RUN_ID_PREFIX = 'summary-';
+const summaryRunId = (firstMemberId: string): string =>
+  `${SUMMARY_RUN_ID_PREFIX}${firstMemberId}`;
+const summaryRunFirstMemberId = (id: string): string | undefined =>
+  id.startsWith(SUMMARY_RUN_ID_PREFIX)
+    ? id.slice(SUMMARY_RUN_ID_PREFIX.length)
+    : undefined;
+
 // Synthetic compact summaries carry a folded thought next to their single
 // tool; the parallel-agent path must never swallow that row, so agent-only
 // detection excludes them.
 function isAgentOnlyToolGroup(msg: Message): boolean {
   return (
     msg.role === 'tool_group' &&
-    !msg.id.startsWith('summary-') &&
+    summaryRunFirstMemberId(msg.id) === undefined &&
     msg.tools.length === 1 &&
     isSubAgentToolCall(msg.tools[0])
   );
@@ -302,7 +310,7 @@ function isAgentOnlyToolGroup(msg: Message): boolean {
 function isBackgroundAgentOnlyToolGroup(msg: Message): boolean {
   return (
     msg.role === 'tool_group' &&
-    !msg.id.startsWith('summary-') &&
+    summaryRunFirstMemberId(msg.id) === undefined &&
     msg.tools.length === 1 &&
     isBackgroundSubAgentToolCall(msg.tools[0])
   );
@@ -411,7 +419,7 @@ function mergeCompactToolGroups(
       // Synthetic id so the aggregated group never collides with an original
       // message key: React then remounts instead of carrying the expanded
       // summary state into non-compact mode.
-      id: `summary-${run[0]!.id}`,
+      id: summaryRunId(run[0]!.id),
       role: 'tool_group',
       tools,
       ...(thoughts.length > 0 ? { thoughts } : {}),
@@ -430,7 +438,7 @@ function updateCompactStreamingThinkingTail(
   const group = messages[messages.length - 1];
   if (
     group?.role !== 'tool_group' ||
-    !group.id.startsWith('summary-') ||
+    summaryRunFirstMemberId(group.id) === undefined ||
     !group.thoughts?.length
   ) {
     return undefined;
@@ -448,7 +456,9 @@ function updateCompactStreamingThinkingTail(
   result[result.length - 1] = {
     ...group,
     thoughts,
-    ...(group.id === `summary-${tail.id}` ? { timestamp: tail.timestamp } : {}),
+    ...(group.id === summaryRunId(tail.id)
+      ? { timestamp: tail.timestamp }
+      : {}),
   };
   return result;
 }
@@ -998,13 +1008,11 @@ function turnIdOfMessageRow(
 ): string | undefined {
   if (!rowKey.startsWith('msg:')) return undefined;
   let messageId = rowKey.slice('msg:'.length);
-  if (messageId.startsWith('summary-')) {
-    // Compact-aggregate row keys embed the run's first member id. Resolve
-    // through it so the key still maps to its turn when looked up in the raw
-    // message list, including after a page extending the run re-keyed the
-    // aggregate.
-    messageId = messageId.slice('summary-'.length);
-  }
+  // Compact-aggregate row keys embed the run's first member id. Resolve
+  // through it so the key still maps to its turn when looked up in the raw
+  // message list, including after a page extending the run re-keyed the
+  // aggregate.
+  messageId = summaryRunFirstMemberId(messageId) ?? messageId;
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (message?.id !== messageId) continue;
@@ -3322,11 +3330,12 @@ export const MessageList = memo(
     const [paginatedExpandedTurns, setPaginatedExpandedTurns] = useState<
       ReadonlySet<string>
     >(() => new Set());
-    const previousPaginationMessageIds = useRef<ReadonlySet<string> | null>(
-      null,
+    // Pending split-turn detection snapshots keyed by load generation: a load
+    // can resolve SDK-side before its page commits to the transcript, letting
+    // a next load enqueue its own snapshot before the earlier page lands.
+    const pendingPaginationTurnCompares = useRef(
+      new Map<number, { ids: Set<string>; resolved: boolean }>(),
     );
-    const pendingPaginationTurnCompare = useRef(false);
-    const paginationLoadResolved = useRef(false);
     const [turnLayoutPending, startTurnLayoutTransition] = useTransition();
     const turnLayoutTransitionStarted = useRef(false);
     const turnLayoutRowTops = useRef(new Map<string, number>());
@@ -4174,6 +4183,13 @@ export const MessageList = memo(
             setPaginatedExpandedTurns((prev) =>
               prev.has(anchorTurnId) ? prev : new Set(prev).add(anchorTurnId),
             );
+            // A page extending the turn's aggregated run re-keys the captured
+            // row, so anchor on the turn's user row instead: the re-expanded
+            // turn always renders it, and the restore path then adjusts the
+            // scroll position rather than dropping the anchor.
+            setOlderHistoryAnchor((anchor) =>
+              anchor ? { ...anchor, rowKey: `msg:${anchorTurnId}` } : anchor,
+            );
             return;
           }
         }
@@ -4630,14 +4646,15 @@ export const MessageList = memo(
           // Remember which messages were on screen before the page arrives so
           // a turn the daemon split across pages (tail shown first, head
           // completing later) can be detected and kept expanded.
-          previousPaginationMessageIds.current = new Set(
-            rawMessagesRef.current.map((message) => message.id),
-          );
-          pendingPaginationTurnCompare.current = true;
-          paginationLoadResolved.current = false;
+          pendingPaginationTurnCompares.current.set(generation, {
+            ids: new Set(rawMessagesRef.current.map((message) => message.id)),
+            resolved: false,
+          });
           await onLoadOlderHistory(force ? { force: true } : undefined);
           if (generation === olderHistoryLoadGeneration.current) {
-            paginationLoadResolved.current = true;
+            const compare =
+              pendingPaginationTurnCompares.current.get(generation);
+            if (compare) compare.resolved = true;
             setOlderHistoryAnchor((anchor) =>
               anchor?.generation === generation
                 ? { ...anchor, settled: true }
@@ -4648,8 +4665,7 @@ export const MessageList = memo(
           if (generation === olderHistoryLoadGeneration.current) {
             olderHistoryRetryBlocked.current = true;
             olderHistoryLoadInFlight.current = false;
-            pendingPaginationTurnCompare.current = false;
-            previousPaginationMessageIds.current = null;
+            pendingPaginationTurnCompares.current.delete(generation);
             setOlderHistoryAnchor(null);
           }
         } finally {
@@ -4679,9 +4695,13 @@ export const MessageList = memo(
     // turn across pages). `applyTurnCollapse` keeps those expanded so the
     // content the user is reading never silently collapses.
     useLayoutEffect(() => {
-      if (!pendingPaginationTurnCompare.current) return;
-      const before = previousPaginationMessageIds.current;
-      if (before === null) return;
+      const pending = pendingPaginationTurnCompares.current;
+      if (pending.size === 0) return;
+      const first = messages[0];
+      if (!first) return;
+      const oldest = pending.entries().next().value;
+      if (!oldest) return;
+      const [generation, compare] = oldest;
       // A page prepends older messages at the head; live messages that land
       // while the fetch is in flight append at the tail. Wait for the head to
       // change so a mid-flight live update cannot consume the snapshot before
@@ -4689,15 +4709,14 @@ export const MessageList = memo(
       // Compare raw message ids, not the compact-mode aggregate ids: a page
       // that extends an aggregated run re-keys the synthetic summary id, but
       // the run members keep their daemon ids.
-      const first = messages[0];
-      if (!first || before.has(first.id)) return;
+      if (compare.ids.has(first.id)) return;
       const newTurnIds: string[] = [];
       for (let i = 0; i < messages.length; i++) {
         const message = messages[i];
         if (
           !message ||
           !isTurnStartMessage(message) ||
-          before.has(message.id)
+          compare.ids.has(message.id)
         ) {
           continue;
         }
@@ -4705,7 +4724,7 @@ export const MessageList = memo(
         for (let j = i + 1; j < messages.length; j++) {
           const next = messages[j];
           if (isTurnStartMessage(next)) break;
-          if (before.has(next.id)) {
+          if (compare.ids.has(next.id)) {
             tailShown = true;
             break;
           }
@@ -4721,24 +4740,28 @@ export const MessageList = memo(
         // discarding the snapshot there would let the page commit that
         // follows silently skip detection — the split turn collapses again,
         // the bug this code exists to fix.
-        if (paginationLoadResolved.current) {
-          pendingPaginationTurnCompare.current = false;
-          previousPaginationMessageIds.current = null;
-        }
-        return;
-      }
-      pendingPaginationTurnCompare.current = false;
-      previousPaginationMessageIds.current = null;
-      setPaginatedExpandedTurns((prev) => {
-        let next: Set<string> | null = null;
-        for (const id of newTurnIds) {
-          if (!prev.has(id)) {
-            next ??= new Set(prev);
-            next.add(id);
+        if (!compare.resolved) return;
+      } else {
+        setPaginatedExpandedTurns((prev) => {
+          let next: Set<string> | null = null;
+          for (const id of newTurnIds) {
+            if (!prev.has(id)) {
+              next ??= new Set(prev);
+              next.add(id);
+            }
           }
+          return next ?? prev;
+        });
+      }
+      pending.delete(generation);
+      // The page that just committed is visible now: fold its ids into any
+      // newer pending snapshot so that load's detection still recognizes the
+      // tail a mid-turn page boundary showed.
+      for (const remaining of pending.values()) {
+        for (const message of messages) {
+          if (message) remaining.ids.add(message.id);
         }
-        return next ?? prev;
-      });
+      }
     }, [messages]);
 
     useEffect(() => {
@@ -5009,11 +5032,10 @@ export const MessageList = memo(
         pendingBottomFollowAfterCooldown.current = false;
         setShouldFollow(true);
         pendingScrollRef.current = null;
-        // Drop the in-flight pagination snapshot too: without this a stale
+        // Drop the in-flight pagination snapshots too: without this a stale
         // pre-clear snapshot survives into the next session and can mislabel
         // a complete turn as keep-open (block ids are per-session ordinals).
-        pendingPaginationTurnCompare.current = false;
-        previousPaginationMessageIds.current = null;
+        pendingPaginationTurnCompares.current.clear();
         setCollapseOverrides((prev) => (prev.size ? new Map() : prev));
         setPaginatedExpandedTurns((prev) => (prev.size ? new Set() : prev));
       }

--- a/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
+++ b/packages/web-shell/client/components/messages/tools/ToolChrome.module.css
@@ -427,9 +427,11 @@
 
 .lineName {
   flex-shrink: 0;
+  font-size: 13px;
 }
 
 .lineArg {
+  font-size: 13px;
   min-width: 0;
   flex: 1;
   overflow: hidden;

--- a/packages/web-shell/client/components/summaryRunId.ts
+++ b/packages/web-shell/client/components/summaryRunId.ts
@@ -1,0 +1,15 @@
+/**
+ * Synthetic ids for compact-mode aggregated tool runs.
+ * `mergeCompactToolGroups` builds them via `summaryRunId`; render paths detect
+ * them through the shared predicate so the prefix scheme lives in one place.
+ */
+export const SUMMARY_RUN_ID_PREFIX = 'summary-';
+
+export const summaryRunId = (firstMemberId: string): string =>
+  `${SUMMARY_RUN_ID_PREFIX}${firstMemberId}`;
+
+export const isSummaryRunId = (id: string): boolean =>
+  id.startsWith(SUMMARY_RUN_ID_PREFIX);
+
+export const summaryRunFirstMemberId = (id: string): string | undefined =>
+  isSummaryRunId(id) ? id.slice(SUMMARY_RUN_ID_PREFIX.length) : undefined;


### PR DESCRIPTION
## What this PR does

When the session transcript is paginated, a very large turn that the daemon had to split across pages first shows its tail as expanded content, then collapses the whole turn the moment pagination completes its user prompt — the content the reader was just looking at silently vanishes. This PR keeps such pagination-completed turns expanded until the user explicitly collapses them, and adds a defensive anchor fallback that re-expands a turn if its collapse would otherwise hide the reader's anchored position.

Also includes a small styling adjustment to the tool chrome rows: both the line name and the line argument now render at 13px, matching each other so a long argument no longer looks visually mismatched against its label.

## Why it's needed

The daemon already tries hard to return whole turns (turn-alignment with a byte budget) and only splits a turn when it exceeds the alignment budget. The client previously had no way to know a turn was split, so when the head arrived the completed turn was treated like any other and auto-collapsed. The reader perceives this as data loss ("the content I was reading just disappeared"), with no toggle having ever been visible on the passthrough content.

## Reviewer Test Plan

### How to verify

1. Open a session whose transcript contains a very large turn (one that exceeds the daemon's per-page alignment budget, e.g. a single turn with hundreds of tool steps).
2. Scroll up to page in the older history: the split turn's tail renders expanded with no collapse toggle (passthrough).
3. Continue scrolling: once the turn's head (user prompt) loads, the turn must STAY expanded — the steps you were reading remain visible, and the collapse toggle now appears at the top of the turn.
4. Click the toggle to collapse it: the turn collapses and stays collapsed across further scrolling/re-renders (the explicit user choice wins).
5. A normal complete turn loaded by pagination (head and tail in one page) still auto-collapses as before — unchanged behavior.

Unit tests cover the keep-open/override precedence; DOM tests cover the pagination-completion flow, the explicit-toggle override, the anchor fallback (session ending mid-fetch re-expands the anchored turn), and the two race fixes (a live message or a session switch mid-fetch must not consume the detection snapshot; /clear must drop the in-flight snapshot so the next session is not mislabeled).

### Evidence (Before & After)

N/A (non-UI behavior verified through unit and DOM tests; the styling change is a 13px font-size on two tool-chrome rows).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment

Local web-shell session; verification via `vitest` (288 tests: MessageList unit + DOM suites), `tsc --noEmit`, ESLint, Prettier.

## Risk & Scope

- Main risk or tradeoff: the keep-open set is bounded (cleared on /clear and on explicit user toggle); the anchor fallback only re-expands a turn when the re-expansion can actually take effect, so pagination state can never stay pinned in-flight.
- Not validated / out of scope: Windows and Linux test runs; the daemon-side turn-alignment itself (unchanged — the client now reacts to split turns instead).
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

会话记录分页加载时,被 daemon 拆页的超大 turn 会先展开显示其尾部内容,一旦分页补全了该 turn 的用户提示词,整个 turn 会被立刻自动收起——用户正在阅读的内容瞬间消失,且此前透传阶段根本没有折叠开关,观感等同数据丢失。本 PR 让这类"分页补全"的 turn 保持展开,直到用户显式收起;并增加锚点兜底:若收起会导致读者的锚定位置被隐藏,则自动重新展开该 turn。

同时包含一处小的样式调整:工具行(line name 与 line argument)的字号统一为 13px,避免长参数与其标签视觉不匹配。

## 为什么需要

daemon 侧已尽力返回完整 turn(turn 对齐 + 字节预算),仅在 turn 超过对齐预算时才拆页;但客户端此前无从得知"turn 被拆开",于是头部补全后按普通 turn 处理并自动收起。透传内容阶段没有折叠开关,用户从未做过任何显式操作,内容"加载完就消失"造成数据丢失的错觉。

## 评审验证计划

复现:打开一个包含超大 turn(超过 daemon 单页对齐预算,如单个 turn 含数百条工具步骤)的会话,向上翻页加载历史:被拆开的 turn 尾部以无折叠开关的透传形式展开显示;继续翻页,当 turn 头部(用户提示词)加载后,该 turn 必须保持展开,正在阅读的步骤仍然可见,顶部出现折叠开关;点击折叠开关收起后,后续滚动/重渲染保持收起(用户显式操作优先);普通完整 turn 分页加载仍按原默认自动收起,行为不变。

单测覆盖 keep-open 与 override 的优先级;DOM 测试覆盖分页补全流程、显式 toggle 覆盖、锚点兜底(分页 in-flight 期间会话结束自动展开锚定 turn),以及两个竞态修复(分页 in-flight 期间的实时消息或会话切换不得消费检测快照;/clear 必须丢弃在途快照以免下一会话被误标)。

| OS | 状态 |
| :--------: | :----: |
| 🍏 macOS | ✅ |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 未测试 |

验证方式:vitest 288 个测试(MessageList 单测 + DOM 套件)、tsc --noEmit、ESLint、Prettier。

## 风险与范围

主要风险:keep-open 集合有界(/clear 与用户显式 toggle 时清除);锚点兜底仅在重新展开确实生效时才展开,分页状态不会被永久钉住。未验证:Windows/Linux 测试运行;daemon 侧 turn 对齐本身未改动。无破坏性变更。
</details>
