### PR TITLE
test(cli): step through Grok before MiniMax in the provider-order test

### DIFF
--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -1103,6 +1103,7 @@ describe('AuthDialog', { timeout: 15000 }, () => {
         },
         { timeout: WAIT_FOR_TIMEOUT },
       );
+      await moveDownAndWaitForSelection(stdin, lastFrame, 'Grok (xAI) API Key');
       await moveDownAndWaitForSelection(stdin, lastFrame, 'MiniMax API Key');
       await pressEnterAndWaitFor(
         stdin,


### PR DESCRIPTION
## What this PR does

Fixes a deterministic failure in `AuthDialog.test.tsx`'s `'drives API key provider steps from endpoint options metadata'` test. The test presses down once from "DeepSeek API Key" expecting the selection to land on "MiniMax API Key" directly, then presses Enter and asserts the MiniMax endpoint step. That assumption is stale: Grok (xAI) was added between DeepSeek and MiniMax in the third-party provider list (#6805), so one down-press now lands on "Grok (xAI) API Key" instead, and the test times out waiting for MiniMax to become selected.

The fix adds the missing intermediate step: move down to "Grok (xAI) API Key" first, then down again to "MiniMax API Key", matching the actual list order (`packages/core/src/providers/all-providers.ts`: DeepSeek, Grok, MiniMax, Z.AI, Moonshot, ...).

## Why it's needed

This test currently fails deterministically when run (verified locally, see evidence below). It's `itWhenTuiInputReliable`-gated and skipped in CI (`CI=true`), which is why it hasn't shown up as a red check anywhere — it only fails for a contributor running the suite locally. Test-only change; no production code touched.

## Reviewer Test Plan

### How to verify

```
cd packages/cli
npx vitest run src/ui/auth/AuthDialog.test.tsx
```

### Evidence (Before & After)

**Before** (unmodified `main`, this test in isolation):

```
FAIL  src/ui/auth/AuthDialog.test.tsx > AuthDialog > drives API key provider steps from endpoint options metadata
AssertionError: expected '...' to match /›\s*(?:\d+\.\s*)?MiniMax API Key/
+ Received: "...  › Grok (xAI) API Key ..."
Test Files  1 failed (1)
     Tests  1 failed | 24 skipped (25)
```

**After** (this PR):

```
✓ src/ui/auth/AuthDialog.test.tsx (25 tests) 6891ms
  ✓ AuthDialog > drives API key provider steps from endpoint options metadata  396ms
Test Files  1 passed (1)
     Tests  25 passed (25)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

`npx vitest run` locally, Node 22.22.3. N/A beyond the unit test — no runtime/sandbox involved.

## Risk & Scope

- Main risk or tradeoff: none — this only edits a test's input sequence to match the current (already-shipped) provider list order. No production code changes.
- Not validated / out of scope: `AuthDialog.test.tsx` has separately-known flakiness under a full parallel `preflight` run (unrelated `vi.waitFor` timeouts on unmodified `main` under resource contention, not touched by this change) — this PR only fixes the one deterministic ordering bug reproduced above.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #9946

<details>
<summary>中文说明</summary>

## 本 PR 的作用

修复 `AuthDialog.test.tsx` 中 `'drives API key provider steps from endpoint options metadata'` 测试的一个确定性失败。该测试从 "DeepSeek API Key" 按一次下键，期望直接选中 "MiniMax API Key"，然后回车并断言 MiniMax 的 endpoint 步骤。这一假设已经过时：Grok (xAI) 已在第三方提供商列表中插入到 DeepSeek 和 MiniMax 之间（#6805），因此现在按一次下键会落在 "Grok (xAI) API Key" 上，而不是 MiniMax，导致测试在等待 MiniMax 被选中时超时。

修复方式是补上缺失的中间步骤：先下移到 "Grok (xAI) API Key"，再下移到 "MiniMax API Key"，与实际列表顺序保持一致（`packages/core/src/providers/all-providers.ts`：DeepSeek、Grok、MiniMax、Z.AI、Moonshot……）。

## 为什么需要它

该测试目前在运行时会确定性地失败（本地已验证，见下方证据）。它由 `itWhenTuiInputReliable` 门控，在 CI 中被跳过（`CI=true`），这也是它从未在任何红色检查中出现过的原因——只有贡献者在本地运行测试套件时才会失败。仅修改测试，未触及生产代码。

## 审阅者测试计划

### 如何验证

```
cd packages/cli
npx vitest run src/ui/auth/AuthDialog.test.tsx
```

### 证据（修复前后）

**修复前**（未修改的 `main`，单独运行该测试）：

```
FAIL  src/ui/auth/AuthDialog.test.tsx > AuthDialog > drives API key provider steps from endpoint options metadata
AssertionError: expected '...' to match /›\s*(?:\d+\.\s*)?MiniMax API Key/
+ Received: "...  › Grok (xAI) API Key ..."
Test Files  1 failed (1)
     Tests  1 failed | 24 skipped (25)
```

**修复后**（本 PR）：

```
✓ src/ui/auth/AuthDialog.test.tsx (25 tests) 6891ms
  ✓ AuthDialog > drives API key provider steps from endpoint options metadata  396ms
Test Files  1 passed (1)
     Tests  25 passed (25)
```

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 `npx vitest run`，Node 22.22.3。除单元测试外不涉及其他环境——不涉及运行时/沙箱。

## 风险与范围

- 主要风险或权衡：无——本 PR 仅修改测试的按键序列，以匹配当前（已发布）的提供商列表顺序，未改动任何生产代码。
- 未验证 / 范围之外：`AuthDialog.test.tsx` 在完整并行 `preflight` 运行下存在另一个已知的 flaky 问题（未修改的 `main` 上因资源争用导致的 `vi.waitFor` 超时，与本次改动无关）——本 PR 仅修复上方复现的这一个确定性顺序错误。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #9946

</details>
