### PR TITLE
fix(core): tolerate HTTP 404 on the optional Streamable HTTP GET SSE probe

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -2949,6 +2949,115 @@ lOTTGqPpwFUbw2EMOOpFYuIyzGMIpUNMBjE2gvJiqFQ=
         expect(await response.text()).toBe('');
       });
 
+      it('treats 404 from optional GET SSE stream as unsupported', async () => {
+        const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+          // Streamable HTTP servers with no GET route at all reject the optional
+          // standalone GET/SSE notification stream with 404 — e.g. the official
+          // MCP SDK's documented stateless StreamableHTTPServerTransport pattern
+          // behind Express, where 404 is Express's own default fallthrough for
+          // the unhandled GET (#8784). (Note: context7 returns a raw 405, which
+          // the SDK tolerates natively — the earlier claim that it returned 404
+          // was retracted in the issue as a reporter-side misconfiguration.)
+          new Response('not found', { status: 404 }),
+        );
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'no-get-route',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream' },
+        });
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(response.status).toBe(405);
+        expect(response.statusText).toBe('Method Not Allowed');
+        expect(await response.text()).toBe('');
+      });
+
+      it('does not rewrite non-SSE GET 404 responses', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('not found', { status: 404 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'plain-get-404',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        });
+
+        expect(response.status).toBe(404);
+        expect(await response.text()).toBe('not found');
+      });
+
+      it('does not rewrite POST 404 responses', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('not found', { status: 404 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'post-404',
+          fetchFn,
+        );
+
+        // The SDK's real POST requests set this exact Accept header
+        // (streamableHttp.ts's transport always sends
+        // 'application/json, text/event-stream'), so the method check is
+        // the only thing standing between a genuine tool-call 404 and being
+        // silently rewritten into a synthetic 405 — the Accept header alone
+        // does not disambiguate POST from the optional GET/SSE probe.
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+          },
+        });
+
+        expect(response.status).toBe(404);
+        expect(await response.text()).toBe('not found');
+      });
+
+      it('bounds the fallback body excerpt read when the 404 body stalls', async () => {
+        // A server that answers the optional GET/SSE probe with 404 headers and
+        // then never sends a body chunk must not park the diagnostics read
+        // forever: the MCP dispatcher runs with `headersTimeout: 0,
+        // bodyTimeout: 0` and nothing above this wrapper bounds the body.
+        vi.useFakeTimers();
+        try {
+          const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+            new Response(
+              new ReadableStream({
+                // Headers are already delivered; the body never yields.
+                pull: () => new Promise<void>(() => {}),
+              }),
+              { status: 404 },
+            ),
+          );
+          const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+            'stalled-404-body',
+            fetchFn,
+          );
+
+          const pending = fetchWithFallback('http://test-server/mcp', {
+            method: 'GET',
+            headers: { Accept: 'text/event-stream' },
+          });
+          await vi.advanceTimersByTimeAsync(2_000);
+          const response = await pending;
+
+          expect(response.status).toBe(405);
+          expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+            expect.not.stringContaining('Response body:'),
+          );
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it('omits response body diagnostics when the fallback body is empty', async () => {
         const fetchFn = vi
           .fn<typeof fetch>()

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -128,8 +128,15 @@ function bindInvocationContextPolicy(
   }
 }
 
-const STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES = new Set([400]);
+const STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES = new Set([400, 404]);
 const STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT = 512;
+// The MCP undici dispatcher runs with headersTimeout: 0, bodyTimeout: 0
+// (see getOrCreateMcpDispatcher in runtimeFetchOptions.ts), and every caller
+// of the optional GET/SSE probe is fire-and-forget, so nothing above this
+// wrapper will ever time out a body that sends headers but never completes.
+// This excerpt is best-effort diagnostics only — bound it so a stalled body
+// can't leak a reader/connection for the life of the process.
+const STREAMABLE_HTTP_GET_SSE_EXCERPT_TIMEOUT_MS = 2_000;
 
 export function getMcpOAuthDialogInstruction(
   action: 'authenticate' | 're-authenticate',
@@ -177,11 +184,11 @@ async function readResponseBodyExcerpt(
     return undefined;
   }
 
-  const decoder = new TextDecoder();
-  let body = '';
-  let bytesRead = 0;
-  let truncated = false;
-  try {
+  const readLoop = async (): Promise<string | undefined> => {
+    const decoder = new TextDecoder();
+    let body = '';
+    let bytesRead = 0;
+    let truncated = false;
     while (bytesRead < STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT) {
       const { done, value } = await reader.read();
       if (done) {
@@ -225,7 +232,23 @@ async function readResponseBodyExcerpt(
       excerpt.length > STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT
       ? `${excerpt.slice(0, STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT)}...`
       : excerpt;
+  };
+
+  try {
+    return await runWithTimeout(
+      readLoop(),
+      STREAMABLE_HTTP_GET_SSE_EXCERPT_TIMEOUT_MS,
+      'Streamable HTTP GET SSE fallback body excerpt',
+    );
   } catch {
+    // Timed out (or the read failed): drop the diagnostics and cancel this
+    // clone's tee branch so the abandoned read settles instead of dangling.
+    // Cancelling one branch alone does not run the underlying source's
+    // cancel algorithm — it's the caller's response.body?.cancel() below
+    // that cancels the sibling branch and actually releases the connection.
+    reader.cancel().catch(() => {
+      // Best-effort cleanup; the caller still returns the 405 sentinel.
+    });
     return undefined;
   }
 }
@@ -250,8 +273,14 @@ function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
 
 /**
  * Wraps fetch to preserve OAuth challenges before the SDK discards response
- * metadata and to normalize Spring AI-style 400 responses to the SDK's
- * unsupported sentinel for the optional Streamable HTTP GET SSE request.
+ * metadata and to normalize conventional "GET not supported" rejections of
+ * the optional Streamable HTTP GET SSE request to the SDK's unsupported
+ * sentinel: Spring AI rejects it with 400 (#4521), and servers with no GET
+ * route at all — e.g. the official SDK's stateless
+ * `StreamableHTTPServerTransport` behind Express, whose default fallthrough
+ * answers 404 — reject it with 404 (#8784). A raw 405 needs no rewriting
+ * (the SDK tolerates it natively) and 401 must stay untouched (the OAuth
+ * challenge detection above depends on observing it).
  *
  * SDK coupling: `StreamableHTTPClientTransport._startOrAuthSse()` treats a
  * 405 response as "GET SSE unsupported" and continues in POST-only mode.


### PR DESCRIPTION
## What this PR does

After the mandatory POST-based MCP handshake succeeds, the SDK also probes an optional standalone `GET <mcp-url>` (`Accept: text/event-stream`) for a server-push notification stream. If a server rejects that optional probe with HTTP 404 instead of 400, the whole MCP connection is torn down — even though the mandatory POST path works fine and the server is fully spec-compliant. `STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES` in `packages/core/src/tools/mcp-client.ts` already tolerates 400 for this exact reason (#4521, Spring AI); this extends it to 404, and bounds a body-read that would otherwise be able to hang or leak on a stalling server.

## Why it's needed

Fixes #8784. 404 here isn't exotic — it's what Express's default fallthrough gives an unhandled `GET` route, including the official MCP SDK's own documented stateless `StreamableHTTPServerTransport` pattern. Maintainer @doudouOUC already confirmed the root cause and endorsed extending the fallback set to 404 in the issue thread.

### Relationship to #8785

@kenshin1986 opened #8785 implementing exactly that Set change, but the repo's review bot found a real Critical in it and it's sat with unaddressed `CHANGES_REQUESTED` for 17 days: routing a 404 response through the existing body-excerpt reader (`readResponseBodyExcerpt`) means a server that sends 404 headers and then never completes the body parks that read forever — the MCP fetch dispatcher runs with `headersTimeout: 0, bodyTimeout: 0`, and nothing above this wrapper ever times out the connection attempt. This PR keeps #8785's Set change and initial test, and adds the missing piece: the body read is now bounded using this same file's own existing `runWithTimeout` idiom (already used by `disconnect()`'s `terminateSession` call, for the identical dispatcher-timeout reason), with the reader cancelled on timeout so the abandoned read settles instead of leaking. This also hardens the pre-existing, previously-untimed 400 path from #4521, not just the new 404 one.

Separately, #8785's test comment attributed the 404 behavior to two specific public servers as reproduction evidence; the issue thread's own follow-up retracted that (the actual repro was a local misconfiguration) — the comment here is corrected to match the issue's own corrected account.

## Reviewer Test Plan

### How to verify

```
cd packages/core
npx vitest run src/tools/mcp-client.test.ts
```

Four new tests, alongside the existing 400/405/Last-Event-ID guard tests (all still passing unchanged):
- `treats 404 from optional GET SSE stream as unsupported`
- `does not rewrite non-SSE GET 404 responses`
- `does not rewrite POST 404 responses` (with the SDK's real Accept header, so it actually exercises the method-check guard rather than only the Accept-header check)
- `bounds the fallback body excerpt read when the 404 body stalls` — the regression test for the hang: a body that sends 404 headers and never yields a chunk; asserts the call still resolves (with fake timers advancing 2s) instead of hanging.

### Evidence (Before & After)

**Before** (unmodified `main`): the whole test file passes (127 tests) since none of it exists yet; the 400-only fallback is the live bug — a 404 GET/SSE probe response reaches the SDK unmodified and the SDK tears down the connection.

**After** (this PR): `131 passed (131)`, exit 0.

**Mutation proof for the hang fix** — reverting only the `runWithTimeout` wrapping (keeping the Set change and all four new tests) makes the stalled-body test hang and fail on a 5s test timeout:
```
FAIL src/tools/mcp-client.test.ts > … > bounds the fallback body excerpt read when the 404 body stalls
Error: Test timed out in 5000ms.
```
Restoring the timeout wrapping makes it pass again in 6ms (fake timers advance instantly). Reverting the Set back to `[400]` fails 2 tests; reverting the method-check in `isStreamableHttpGetSseRequest` (the guard the POST test above exists to pin) fails exactly the `does not rewrite POST 404 responses` test.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

`npx vitest run` locally, Node 22.22.3. N/A beyond the unit test — no external MCP server or sandbox involved.

## Risk & Scope

- Main risk or tradeoff: the 2-second excerpt timeout is best-effort diagnostics only — on timeout the connection is still salvaged (synthetic 405 returned) with no `Response body:` detail logged, exactly matching today's behavior for an empty/failed body read.
- Not validated / out of scope: real-world reproduction against a live server that stalls a 404 body mid-response (the fake-timer test proves the mechanism; no such server was available to test against directly).
- Breaking changes / migration notes: none. `readResponseBodyExcerpt` and `STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES` are module-private; `createStreamableHttpCompatibilityFetch`'s signature is unchanged. Repo-wide grep confirms no other file references the two changed internals.

## Linked Issues

Refs #8784, #8785

<details>
<summary>中文说明</summary>

## 本 PR 的作用

在必须的基于 POST 的 MCP 握手成功后，SDK 还会探测一个可选的独立 `GET <mcp-url>`（`Accept: text/event-stream`）以获取服务器推送通知流。如果服务器对该可选探测返回 404 而不是 400，整个 MCP 连接会被拆除——即便必须的 POST 路径工作正常、服务器完全符合规范。`packages/core/src/tools/mcp-client.ts` 中的 `STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES` 已经因同样原因容忍 400（#4521，Spring AI）；本 PR 将其扩展到 404，并为一个原本可能在服务器卡顿时挂起或泄漏的响应体读取加上了超时保护。

## 为什么需要它

修复 #8784。404 在这里并不罕见——这正是 Express 对未处理 GET 路由的默认兜底行为，官方 MCP SDK 自己文档化的无状态 `StreamableHTTPServerTransport` 模式产生的就是这个结果。维护者 @doudouOUC 已在 issue 讨论中确认根因，并认可将回退集合扩展到 404 的方向。

### 与 #8785 的关系

@kenshin1986 打开的 #8785 正是实现了这一集合改动，但仓库的评审机器人在其中发现了一个真实的 Critical 问题，且已带着未处理的 `CHANGES_REQUESTED` 停滞 17 天：把 404 响应也导向既有的响应体摘要读取器（`readResponseBodyExcerpt`）意味着，一个发送了 404 响应头却始终不完成响应体的服务器，会让这次读取永远卡住——MCP fetch 的 dispatcher 运行在 `headersTimeout: 0, bodyTimeout: 0` 下，而这层封装之上也没有任何东西会为连接尝试设置超时。本 PR 保留了 #8785 的集合改动与初始测试，并补上了缺失的部分：响应体读取现在用本文件已有的 `runWithTimeout` 惯用法加了超时（`disconnect()` 的 `terminateSession` 调用已因同样的 dispatcher 超时原因使用了它），超时后取消 reader，让被放弃的读取正常结束而不是泄漏。这同时也加固了 #4521 中原本没有超时保护的 400 路径，而不仅仅是新增的 404 路径。

另外，#8785 的测试注释曾将 404 行为归因于两个具体的公共服务器作为复现证据；issue 讨论的后续跟进已经撤回了这一说法（实际复现是本地配置问题）——本 PR 中的注释已按 issue 自身的更正说法修正。

## 审阅者测试计划

### 如何验证

```
cd packages/core
npx vitest run src/tools/mcp-client.test.ts
```

新增四个测试，与既有的 400/405/Last-Event-ID 守卫测试并存（全部保持不变、通过）：
- `treats 404 from optional GET SSE stream as unsupported`
- `does not rewrite non-SSE GET 404 responses`
- `does not rewrite POST 404 responses`（使用 SDK 真实的 Accept 请求头，因此真正覆盖了方法检查这一守卫，而不仅仅是 Accept 请求头检查）
- `bounds the fallback body excerpt read when the 404 body stalls` —— 针对挂起问题的回归测试：响应体发送 404 响应头后从不产生数据块；断言该调用仍会正常结束（配合假计时器推进 2 秒），而不是挂起。

### 证据（修复前后）

**修复前**（未修改的 `main`）：整个测试文件通过（127 个测试），因为这些新测试尚不存在；400-only 的回退集合正是当前的活跃 bug——404 的 GET/SSE 探测响应会原样传给 SDK，SDK 随即拆除连接。

**修复后**（本 PR）：`131 passed (131)`，退出码 0。

**挂起修复的突变验证** —— 仅还原 `runWithTimeout` 包装（保留集合改动与全部四个新测试），会让卡顿响应体测试挂起并因 5 秒测试超时而失败：
```
FAIL src/tools/mcp-client.test.ts > … > bounds the fallback body excerpt read when the 404 body stalls
Error: Test timed out in 5000ms.
```
恢复超时包装后，测试在 6 毫秒内再次通过（假计时器瞬间推进）。将集合还原为 `[400]` 会导致 2 个测试失败；还原 `isStreamableHttpGetSseRequest` 中的方法检查（上方 POST 测试正是为了钉住这一守卫）会恰好导致 `does not rewrite POST 404 responses` 这一个测试失败。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 `npx vitest run`，Node 22.22.3。除单元测试外不涉及其他环境——未涉及真实 MCP 服务器或沙箱。

## 风险与范围

- 主要风险或权衡：2 秒的摘要超时仅用于尽力而为的诊断——超时后连接仍会被挽救（返回合成的 405），只是不再记录 `Response body:` 细节，这与今天对空响应体/读取失败的现有行为完全一致。
- 未验证 / 范围之外：未针对一个真实会在 404 响应体中途卡顿的真实服务器做验证（假计时器测试证明了机制本身；未找到可直接测试的此类服务器）。
- 破坏性变更 / 迁移说明：无。`readResponseBodyExcerpt` 与 `STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES` 均为模块私有；`createStreamableHttpCompatibilityFetch` 的签名未变。全仓库 grep 确认没有其他文件引用这两个被修改的内部实现。

## 关联 Issue

Refs #8784, #8785

</details>
