### PR TITLE
fix(cli): keep Agent View queued messages across teammate tab switches

### DIFF
--- a/packages/cli/src/ui/components/QueuedMessageDisplay.tsx
+++ b/packages/cli/src/ui/components/QueuedMessageDisplay.tsx
@@ -13,10 +13,12 @@ const NUM_TIMES_QUEUE_HINT_SHOWN = 3;
 
 export interface QueuedMessageDisplayProps {
   messageQueue: readonly string[];
+  showHint?: boolean;
 }
 
 export const QueuedMessageDisplay = ({
   messageQueue,
+  showHint: hintEnabled = true,
 }: QueuedMessageDisplayProps) => {
   // Track how many times the edit hint has been shown (per session).
   // Once the user has seen it enough times, hide it.
@@ -35,7 +37,7 @@ export const QueuedMessageDisplay = ({
     wasEmptyRef.current = false;
   }
 
-  const showHint = hintSeenCountRef.current <= NUM_TIMES_QUEUE_HINT_SHOWN;
+  const shouldShowHint = hintSeenCountRef.current <= NUM_TIMES_QUEUE_HINT_SHOWN;
 
   return (
     <Box flexDirection="column" marginTop={1}>
@@ -60,7 +62,7 @@ export const QueuedMessageDisplay = ({
           </Text>
         </Box>
       )}
-      {showHint && (
+      {hintEnabled && shouldShowHint && (
         <Box paddingLeft={2}>
           <Text dimColor italic>
             {t('Ctrl+Q to queue · ↑ to edit queued messages')}

--- a/packages/cli/src/ui/components/QueuedMessageDisplay.tsx
+++ b/packages/cli/src/ui/components/QueuedMessageDisplay.tsx
@@ -12,7 +12,7 @@ const MAX_DISPLAYED_QUEUED_MESSAGES = 3;
 const NUM_TIMES_QUEUE_HINT_SHOWN = 3;
 
 export interface QueuedMessageDisplayProps {
-  messageQueue: string[];
+  messageQueue: readonly string[];
 }
 
 export const QueuedMessageDisplay = ({

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.queuedMessages.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.queuedMessages.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for #10069 — a follow-up accepted and shown as queued
+ * while a teammate is busy must survive teammate tab switches. The layout
+ * renders AgentComposer with `key={activeView}`, so switching tabs unmounts
+ * the composer; any queue held only in local component state is discarded
+ * and the message is never delivered.
+ */
+
+import { render } from 'ink-testing-library';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AgentStatus,
+  ApprovalMode,
+  type AgentInteractive,
+} from '@qwen-code/qwen-code-core';
+import {
+  AgentViewProvider,
+  useAgentViewActions,
+  useAgentViewState,
+} from '../../contexts/AgentViewContext.js';
+import { useConfig } from '../../contexts/ConfigContext.js';
+import { useAgentStreamingState } from '../../hooks/useAgentStreamingState.js';
+import { usePreferredEditor } from '../../hooks/usePreferredEditor.js';
+import { useTerminalSize } from '../../hooks/useTerminalSize.js';
+import { StreamingState } from '../../types.js';
+import { useTextBuffer } from '../shared/text-buffer.js';
+import { AgentComposer } from './AgentComposer.js';
+
+// Captures the onSubmit handler of the most recently rendered composer
+// input so tests can submit messages without driving real keypresses.
+const submitCapture = vi.hoisted(() => ({
+  current: undefined as ((text: string) => void) | undefined,
+}));
+
+vi.mock('../../contexts/ConfigContext.js');
+vi.mock('../../hooks/useAgentStreamingState.js');
+vi.mock('../../hooks/useKeypress.js');
+vi.mock('../../hooks/usePreferredEditor.js');
+vi.mock('../../hooks/useTerminalSize.js');
+vi.mock('../shared/text-buffer.js');
+vi.mock('../BaseTextInput.js', () => ({
+  BaseTextInput: (props: { onSubmit: (text: string) => void }) => {
+    submitCapture.current = props.onSubmit;
+    return null;
+  },
+}));
+vi.mock('../LoadingIndicator.js', () => ({ LoadingIndicator: () => null }));
+vi.mock('./AgentFooter.js', () => ({ AgentFooter: () => null }));
+
+const BUSY = {
+  status: AgentStatus.RUNNING,
+  streamingState: StreamingState.Responding,
+  isInputActive: true,
+  elapsedTime: 0,
+  lastPromptTokenCount: 0,
+};
+
+const IDLE = {
+  status: AgentStatus.IDLE,
+  streamingState: StreamingState.Idle,
+  isInputActive: true,
+  elapsedTime: 0,
+  lastPromptTokenCount: 0,
+};
+
+/** Let ink flush scheduled effects/state updates. */
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function makeFakeAgent(): AgentInteractive {
+  return {
+    enqueueMessage: vi.fn(),
+    cancelCurrentRound: vi.fn(),
+    getError: vi.fn(),
+    getLastRoundError: vi.fn(),
+    getCore: () => ({
+      runtimeContext: {
+        getApprovalMode: () => ApprovalMode.DEFAULT,
+        setApprovalMode: vi.fn(),
+      },
+    }),
+  } as unknown as AgentInteractive;
+}
+
+describe('AgentComposer queued follow-ups (#10069)', () => {
+  let agentA: AgentInteractive;
+  let agentB: AgentInteractive;
+  const streamingByAgent = new Map<AgentInteractive, typeof IDLE>();
+
+  // Mirrors DefaultAppLayout: AgentComposer is keyed by the active view,
+  // so switching tabs unmounts and remounts the composer from scratch.
+  function Harness({ view }: { view: string }) {
+    const { agents } = useAgentViewState();
+    const { registerAgent } = useAgentViewActions();
+
+    useEffect(() => {
+      if (!agents.has('agent-a')) {
+        registerAgent('agent-a', agentA, 'qwen', 'cyan');
+      }
+      if (!agents.has('agent-b')) {
+        registerAgent('agent-b', agentB, 'qwen', 'blue');
+      }
+    }, [agents, registerAgent]);
+
+    return agents.has(view) ? (
+      <AgentComposer key={view} agentId={view} />
+    ) : null;
+  }
+
+  const view = (name: string) => (
+    <AgentViewProvider>
+      <Harness view={name} />
+    </AgentViewProvider>
+  );
+
+  const renderWithView = async (name: string) => {
+    const app = render(view(name));
+    await tick();
+    await tick();
+    return app;
+  };
+
+  const switchTo = async (
+    app: ReturnType<typeof render>,
+    name: string,
+  ): Promise<void> => {
+    app.rerender(view(name));
+    await tick();
+    await tick();
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    streamingByAgent.clear();
+    submitCapture.current = undefined;
+    agentA = makeFakeAgent();
+    agentB = makeFakeAgent();
+
+    vi.mocked(useConfig).mockReturnValue({
+      getContentGeneratorConfig: () => undefined,
+    } as never);
+    vi.mocked(usePreferredEditor).mockReturnValue(undefined);
+    vi.mocked(useTerminalSize).mockReturnValue({ columns: 80, rows: 24 });
+    vi.mocked(useTextBuffer).mockReturnValue({
+      text: '',
+      allVisualLines: [''],
+      visualCursor: [0, 0],
+    } as never);
+    vi.mocked(useAgentStreamingState).mockImplementation(
+      (agent: AgentInteractive | undefined) =>
+        (agent && streamingByAgent.get(agent)) || IDLE,
+    );
+  });
+
+  it('keeps a queued follow-up across tab switches and delivers it exactly once', async () => {
+    streamingByAgent.set(agentA, BUSY);
+    const app = await renderWithView('agent-a');
+
+    // Submit while agent-a is busy — accepted and shown as queued.
+    expect(submitCapture.current).toBeDefined();
+    submitCapture.current!('follow-up for later');
+    await switchTo(app, 'agent-a');
+    expect(app.lastFrame()).toContain('follow-up for later');
+    expect(agentA.enqueueMessage).not.toHaveBeenCalled();
+
+    // Switch to teammate B, then back to A (layout key remounts composer).
+    await switchTo(app, 'agent-b');
+    await switchTo(app, 'agent-a');
+
+    // The accepted message must still be queued for agent-a.
+    expect(app.lastFrame()).toContain('follow-up for later');
+    expect(agentA.enqueueMessage).not.toHaveBeenCalled();
+
+    // Agent-a settles to idle — the queued message is delivered once.
+    streamingByAgent.set(agentA, IDLE);
+    await switchTo(app, 'agent-a');
+    expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(agentA.enqueueMessage).toHaveBeenCalledWith('follow-up for later');
+    expect(app.lastFrame()).not.toContain('follow-up for later');
+
+    // A later re-render must not re-deliver the message.
+    await switchTo(app, 'agent-a');
+    expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins multiple queued follow-ups into one prompt after a tab switch', async () => {
+    streamingByAgent.set(agentA, BUSY);
+    const app = await renderWithView('agent-a');
+
+    submitCapture.current!('first follow-up');
+    await switchTo(app, 'agent-a');
+    submitCapture.current!('second follow-up');
+    await switchTo(app, 'agent-a');
+    expect(app.lastFrame()).toContain('first follow-up');
+    expect(app.lastFrame()).toContain('second follow-up');
+
+    await switchTo(app, 'agent-b');
+    await switchTo(app, 'agent-a');
+
+    streamingByAgent.set(agentA, IDLE);
+    await switchTo(app, 'agent-a');
+    expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(agentA.enqueueMessage).toHaveBeenCalledWith(
+      'first follow-up\nsecond follow-up',
+    );
+  });
+
+  it('still enqueues immediately when the teammate is idle', async () => {
+    streamingByAgent.set(agentA, IDLE);
+    const app = await renderWithView('agent-a');
+
+    submitCapture.current!('hello');
+    await switchTo(app, 'agent-a');
+    expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(agentA.enqueueMessage).toHaveBeenCalledWith('hello');
+    expect(app.lastFrame()).not.toContain('hello');
+  });
+});

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.queuedMessages.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.queuedMessages.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { render } from 'ink-testing-library';
-import { useEffect } from 'react';
+import { StrictMode, useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AgentStatus,
@@ -114,9 +114,11 @@ describe('AgentComposer queued follow-ups (#10069)', () => {
   }
 
   const view = (name: string) => (
-    <AgentViewProvider>
-      <Harness view={name} />
-    </AgentViewProvider>
+    <StrictMode>
+      <AgentViewProvider>
+        <Harness view={name} />
+      </AgentViewProvider>
+    </StrictMode>
   );
 
   const renderWithView = async (name: string) => {
@@ -189,6 +191,19 @@ describe('AgentComposer queued follow-ups (#10069)', () => {
     expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
   });
 
+  it('flushes when returning to a tab after the agent becomes idle', async () => {
+    streamingByAgent.set(agentA, BUSY);
+    const app = await renderWithView('agent-a');
+
+    submitCapture.current!('follow-up while away');
+    await switchTo(app, 'agent-b');
+    streamingByAgent.set(agentA, IDLE);
+    await switchTo(app, 'agent-a');
+
+    expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(agentA.enqueueMessage).toHaveBeenCalledWith('follow-up while away');
+  });
+
   it('joins multiple queued follow-ups into one prompt after a tab switch', async () => {
     streamingByAgent.set(agentA, BUSY);
     const app = await renderWithView('agent-a');
@@ -208,6 +223,27 @@ describe('AgentComposer queued follow-ups (#10069)', () => {
     expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
     expect(agentA.enqueueMessage).toHaveBeenCalledWith(
       'first follow-up\nsecond follow-up',
+    );
+  });
+
+  it('keeps both submits when two land in one batch while busy', async () => {
+    streamingByAgent.set(agentA, BUSY);
+    const app = await renderWithView('agent-a');
+
+    // Two submits dispatched before the composer re-renders (e.g. two Enter
+    // presses in one stdin chunk): the second must not replace the first.
+    submitCapture.current!('same-batch one');
+    submitCapture.current!('same-batch two');
+    await switchTo(app, 'agent-a');
+
+    expect(app.lastFrame()).toContain('same-batch one');
+    expect(app.lastFrame()).toContain('same-batch two');
+
+    streamingByAgent.set(agentA, IDLE);
+    await switchTo(app, 'agent-a');
+    expect(agentA.enqueueMessage).toHaveBeenCalledTimes(1);
+    expect(agentA.enqueueMessage).toHaveBeenCalledWith(
+      'same-batch one\nsame-batch two',
     );
   });
 

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.test.tsx
@@ -67,11 +67,13 @@ describe('AgentComposer', () => {
       agentInputBufferText: '',
       agentTabBarFocused: false,
       agentApprovalModes: new Map(),
+      agentMessageQueues: new Map(),
     } as never);
     vi.mocked(useAgentViewActions).mockReturnValue({
       setAgentInputBufferText,
       setAgentTabBarFocused,
       setAgentApprovalMode,
+      setAgentMessageQueue: vi.fn(),
     } as never);
     vi.mocked(useConfig).mockReturnValue({
       getContentGeneratorConfig: () => undefined,

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Box, Text, useStdin } from 'ink';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   AgentStatus,
   isTerminalStatus,
@@ -72,6 +72,7 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
     setAgentTabBarFocused,
     setAgentApprovalMode,
     setAgentMessageQueue,
+    appendToAgentMessageQueue,
   } = useAgentViewActions();
   const agent = agents.get(agentId);
   const interactiveAgent = agent?.interactiveAgent;
@@ -207,6 +208,7 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
   const messageQueue = agentMessageQueues.get(agentId) ?? EMPTY_MESSAGE_QUEUE;
 
   // When agent becomes idle (and not terminal), flush queued messages.
+  const flushedQueueRef = useRef<readonly string[] | null>(null);
   useEffect(() => {
     if (
       streamingState === StreamingState.Idle &&
@@ -214,6 +216,8 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
       status !== undefined &&
       !isTerminalStatus(status)
     ) {
+      if (flushedQueueRef.current === messageQueue) return;
+      flushedQueueRef.current = messageQueue;
       const combined = messageQueue.join('\n');
       setAgentMessageQueue(agentId, []);
       interactiveAgent?.enqueueMessage(combined);
@@ -234,16 +238,10 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
       if (streamingState === StreamingState.Idle) {
         interactiveAgent.enqueueMessage(trimmed);
       } else {
-        setAgentMessageQueue(agentId, [...messageQueue, trimmed]);
+        appendToAgentMessageQueue(agentId, trimmed);
       }
     },
-    [
-      interactiveAgent,
-      streamingState,
-      agentId,
-      messageQueue,
-      setAgentMessageQueue,
-    ],
+    [interactiveAgent, streamingState, agentId, appendToAgentMessageQueue],
   );
 
   // ── Render ──
@@ -307,7 +305,7 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
           </Box>
         )}
 
-        <QueuedMessageDisplay messageQueue={messageQueue} />
+        <QueuedMessageDisplay messageQueue={messageQueue} showHint={false} />
 
         {/* Input prompt — always visible, like the main Composer */}
         <BaseTextInput

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Box, Text, useStdin } from 'ink';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import {
   AgentStatus,
   isTerminalStatus,
@@ -55,13 +55,23 @@ interface AgentComposerProps {
 
 // ─── Component ──────────────────────────────────────────────
 
+// Shared empty queue identity so unregistered agents don't allocate on
+// every render.
+const EMPTY_MESSAGE_QUEUE: readonly string[] = [];
+
 export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
-  const { agents, agentTabBarFocused, agentShellFocused, agentApprovalModes } =
-    useAgentViewState();
+  const {
+    agents,
+    agentTabBarFocused,
+    agentShellFocused,
+    agentApprovalModes,
+    agentMessageQueues,
+  } = useAgentViewState();
   const {
     setAgentInputBufferText,
     setAgentTabBarFocused,
     setAgentApprovalMode,
+    setAgentMessageQueue,
   } = useAgentViewActions();
   const agent = agents.get(agentId);
   const interactiveAgent = agent?.interactiveAgent;
@@ -188,8 +198,13 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
   );
 
   // ── Message queue (accumulate while streaming, flush as one prompt on idle) ──
+  //
+  // The queue lives in AgentViewContext (keyed by agentId), not in local
+  // state: the layout keys this component by the active view, so switching
+  // teammate tabs unmounts it and a local queue would be silently dropped
+  // before the flush below ever runs (#10069).
 
-  const [messageQueue, setMessageQueue] = useState<string[]>([]);
+  const messageQueue = agentMessageQueues.get(agentId) ?? EMPTY_MESSAGE_QUEUE;
 
   // When agent becomes idle (and not terminal), flush queued messages.
   useEffect(() => {
@@ -200,10 +215,17 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
       !isTerminalStatus(status)
     ) {
       const combined = messageQueue.join('\n');
-      setMessageQueue([]);
+      setAgentMessageQueue(agentId, []);
       interactiveAgent?.enqueueMessage(combined);
     }
-  }, [streamingState, messageQueue, interactiveAgent, status]);
+  }, [
+    streamingState,
+    messageQueue,
+    interactiveAgent,
+    status,
+    agentId,
+    setAgentMessageQueue,
+  ]);
 
   const handleSubmit = useCallback(
     (text: string) => {
@@ -212,10 +234,16 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
       if (streamingState === StreamingState.Idle) {
         interactiveAgent.enqueueMessage(trimmed);
       } else {
-        setMessageQueue((prev) => [...prev, trimmed]);
+        setAgentMessageQueue(agentId, [...messageQueue, trimmed]);
       }
     },
-    [interactiveAgent, streamingState],
+    [
+      interactiveAgent,
+      streamingState,
+      agentId,
+      messageQueue,
+      setAgentMessageQueue,
+    ],
   );
 
   // ── Render ──

--- a/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
@@ -170,3 +170,68 @@ describe('AgentViewProvider in-process bridges', () => {
     expect(lastFrame()).toContain('main:false');
   });
 });
+
+describe('AgentViewProvider per-agent message queues', () => {
+  it('stores queues per agent and clears them when emptied or unregistered', async () => {
+    const config = makeConfig();
+    const interactiveAgent = {
+      getCore: () => ({
+        runtimeContext: { getApprovalMode: () => ApprovalMode.DEFAULT },
+      }),
+    } as AgentInteractive;
+
+    const probeActions: {
+      registerAgent?: (
+        agentId: string,
+        agent: AgentInteractive,
+        modelId: string,
+        color: string,
+      ) => void;
+      unregisterAgent?: (agentId: string) => void;
+      setAgentMessageQueue?: (agentId: string, queue: string[]) => void;
+    } = {};
+
+    function Probe() {
+      const state = useAgentViewState();
+      const actions = useAgentViewActions();
+      probeActions.registerAgent = actions.registerAgent;
+      probeActions.unregisterAgent = actions.unregisterAgent;
+      probeActions.setAgentMessageQueue = actions.setAgentMessageQueue;
+      const queueA = state.agentMessageQueues.get('agent-a') ?? [];
+      const queueB = state.agentMessageQueues.get('agent-b') ?? [];
+      return (
+        <Text>
+          a:[{queueA.join(',')}] b:[{queueB.join(',')}]
+        </Text>
+      );
+    }
+
+    const { lastFrame } = render(
+      <AgentViewProvider config={config}>
+        <Probe />
+      </AgentViewProvider>,
+    );
+
+    await act(async () => {
+      probeActions.setAgentMessageQueue?.('agent-a', ['m1', 'm2']);
+      probeActions.setAgentMessageQueue?.('agent-b', ['x']);
+    });
+    expect(lastFrame()).toContain('a:[m1,m2]');
+    expect(lastFrame()).toContain('b:[x]');
+
+    // Emptying a queue removes it; other agents keep theirs.
+    await act(async () => {
+      probeActions.setAgentMessageQueue?.('agent-a', []);
+    });
+    expect(lastFrame()).toContain('a:[]');
+    expect(lastFrame()).toContain('b:[x]');
+
+    // Unregistering an agent drops its pending queue, so a future agent
+    // registered under the same id never inherits stale messages.
+    await act(async () => {
+      probeActions.registerAgent?.('agent-b', interactiveAgent, 'm', 'c');
+      probeActions.unregisterAgent?.('agent-b');
+    });
+    expect(lastFrame()).toContain('b:[]');
+  });
+});

--- a/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.test.tsx
@@ -234,4 +234,153 @@ describe('AgentViewProvider per-agent message queues', () => {
     });
     expect(lastFrame()).toContain('b:[]');
   });
+
+  it('appends queued messages without losing same-batch updates', async () => {
+    const config = makeConfig();
+    const interactiveAgent = {
+      getCore: () => ({
+        runtimeContext: { getApprovalMode: () => ApprovalMode.DEFAULT },
+      }),
+    } as AgentInteractive;
+
+    const probeActions: {
+      registerAgent?: (
+        agentId: string,
+        agent: AgentInteractive,
+        modelId: string,
+        color: string,
+      ) => void;
+      appendToAgentMessageQueue?: (agentId: string, message: string) => void;
+    } = {};
+
+    function Probe() {
+      const state = useAgentViewState();
+      const actions = useAgentViewActions();
+      probeActions.registerAgent = actions.registerAgent;
+      probeActions.appendToAgentMessageQueue =
+        actions.appendToAgentMessageQueue;
+      const queue = state.agentMessageQueues.get('agent-a') ?? [];
+      return <Text>a:[{queue.join(',')}]</Text>;
+    }
+
+    const { lastFrame } = render(
+      <AgentViewProvider config={config}>
+        <Probe />
+      </AgentViewProvider>,
+    );
+
+    await act(async () => {
+      probeActions.registerAgent?.('agent-a', interactiveAgent, 'm', 'c');
+    });
+    // Two appends dispatched before the provider re-renders must both land:
+    // a render-time snapshot + replace write would keep only the second.
+    await act(async () => {
+      probeActions.appendToAgentMessageQueue?.('agent-a', 'first');
+      probeActions.appendToAgentMessageQueue?.('agent-a', 'second');
+    });
+
+    expect(lastFrame()).toContain('a:[first,second]');
+  });
+
+  it('drops a same-batch append for an agent that is unregistering', async () => {
+    // If an Enter-submit and unregisterAgent land in one React batch (team
+    // manager detaching while the user submits), the append must not
+    // resurrect the queue entry the delete just removed.
+    const config = makeConfig();
+    const interactiveAgent = {
+      getCore: () => ({
+        runtimeContext: { getApprovalMode: () => ApprovalMode.DEFAULT },
+      }),
+    } as AgentInteractive;
+
+    const probeActions: {
+      registerAgent?: (
+        agentId: string,
+        agent: AgentInteractive,
+        modelId: string,
+        color: string,
+      ) => void;
+      unregisterAgent?: (agentId: string) => void;
+      appendToAgentMessageQueue?: (agentId: string, message: string) => void;
+    } = {};
+
+    function Probe() {
+      const state = useAgentViewState();
+      const actions = useAgentViewActions();
+      probeActions.registerAgent = actions.registerAgent;
+      probeActions.unregisterAgent = actions.unregisterAgent;
+      probeActions.appendToAgentMessageQueue =
+        actions.appendToAgentMessageQueue;
+      const queue = state.agentMessageQueues.get('agent-a') ?? [];
+      return <Text>a:[{queue.join(',')}]</Text>;
+    }
+
+    const { lastFrame } = render(
+      <AgentViewProvider config={config}>
+        <Probe />
+      </AgentViewProvider>,
+    );
+
+    await act(async () => {
+      probeActions.registerAgent?.('agent-a', interactiveAgent, 'm', 'c');
+    });
+    await act(async () => {
+      probeActions.unregisterAgent?.('agent-a');
+      probeActions.appendToAgentMessageQueue?.('agent-a', 'orphan');
+    });
+
+    expect(lastFrame()).toContain('a:[]');
+  });
+
+  it('clears all queued messages when all agents unregister', async () => {
+    const config = makeConfig();
+    const interactiveAgent = {
+      getCore: () => ({
+        runtimeContext: { getApprovalMode: () => ApprovalMode.DEFAULT },
+      }),
+    } as AgentInteractive;
+
+    const probeActions: {
+      registerAgent?: (
+        agentId: string,
+        agent: AgentInteractive,
+        modelId: string,
+        color: string,
+      ) => void;
+      appendToAgentMessageQueue?: (agentId: string, message: string) => void;
+      unregisterAll?: () => void;
+    } = {};
+
+    function Probe() {
+      const state = useAgentViewState();
+      const actions = useAgentViewActions();
+      probeActions.registerAgent = actions.registerAgent;
+      probeActions.appendToAgentMessageQueue =
+        actions.appendToAgentMessageQueue;
+      probeActions.unregisterAll = actions.unregisterAll;
+      const queue = state.agentMessageQueues.get('agent-a') ?? [];
+      return <Text>a:[{queue.join(',')}]</Text>;
+    }
+
+    const { lastFrame } = render(
+      <AgentViewProvider config={config}>
+        <Probe />
+      </AgentViewProvider>,
+    );
+
+    await act(async () => {
+      probeActions.registerAgent?.('agent-a', interactiveAgent, 'm', 'c');
+    });
+    await act(async () => {
+      probeActions.appendToAgentMessageQueue?.('agent-a', 'first');
+      probeActions.appendToAgentMessageQueue?.('agent-a', 'second');
+    });
+    expect(lastFrame()).toContain('a:[first,second]');
+
+    await act(async () => {
+      probeActions.unregisterAll?.();
+    });
+
+    expect(lastFrame()).toContain('a:[]');
+  });
 });

--- a/packages/cli/src/ui/contexts/AgentViewContext.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.tsx
@@ -56,6 +56,13 @@ export interface AgentViewState {
   agentTabBarFocused: boolean;
   /** Per-agent approval modes (keyed by agentId). */
   agentApprovalModes: ReadonlyMap<string, ApprovalMode>;
+  /**
+   * Queued follow-up messages per agent (keyed by agentId). Held here —
+   * not in the composer — because the layout keys AgentComposer by the
+   * active view, so switching teammate tabs unmounts the composer and any
+   * component-local queue would be silently discarded (#10069).
+   */
+  agentMessageQueues: ReadonlyMap<string, readonly string[]>;
 }
 
 export interface AgentViewActions {
@@ -75,6 +82,8 @@ export interface AgentViewActions {
   setAgentInputBufferText(text: string): void;
   setAgentTabBarFocused(focused: boolean): void;
   setAgentApprovalMode(agentId: string, mode: ApprovalMode): void;
+  /** Replace the queued follow-up messages for an agent (see state docs). */
+  setAgentMessageQueue(agentId: string, queue: readonly string[]): void;
 }
 
 // ─── Context ────────────────────────────────────────────────
@@ -91,6 +100,7 @@ const DEFAULT_STATE: AgentViewState = {
   agentInputBufferText: '',
   agentTabBarFocused: false,
   agentApprovalModes: new Map(),
+  agentMessageQueues: new Map(),
 };
 
 const noop = () => {};
@@ -106,6 +116,7 @@ const DEFAULT_ACTIONS: AgentViewActions = {
   setAgentInputBufferText: noop,
   setAgentTabBarFocused: noop,
   setAgentApprovalMode: noop,
+  setAgentMessageQueue: noop,
 };
 
 // ─── Hook: useAgentViewState ────────────────────────────────
@@ -140,6 +151,9 @@ export function AgentViewProvider({
   const [agentTabBarFocused, setAgentTabBarFocused] = useState(false);
   const [agentApprovalModes, setAgentApprovalModes] = useState<
     Map<string, ApprovalMode>
+  >(() => new Map());
+  const [agentMessageQueues, setAgentMessageQueues] = useState<
+    Map<string, readonly string[]>
   >(() => new Map());
 
   // ── Navigation ──
@@ -230,12 +244,19 @@ export function AgentViewProvider({
       next.delete(agentId);
       return next;
     });
+    setAgentMessageQueues((prev) => {
+      if (!prev.has(agentId)) return prev;
+      const next = new Map(prev);
+      next.delete(agentId);
+      return next;
+    });
     setActiveView((current) => (current === agentId ? 'main' : current));
   }, []);
 
   const unregisterAll = useCallback(() => {
     setAgents(new Map());
     setAgentApprovalModes(new Map());
+    setAgentMessageQueues(new Map());
     setActiveView('main');
     setAgentTabBarFocused(false);
   }, []);
@@ -257,6 +278,21 @@ export function AgentViewProvider({
     [agents],
   );
 
+  const setAgentMessageQueue = useCallback(
+    (agentId: string, queue: readonly string[]) => {
+      setAgentMessageQueues((prev) => {
+        const next = new Map(prev);
+        if (queue.length === 0) {
+          next.delete(agentId);
+        } else {
+          next.set(agentId, queue);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
   // ── Memoized values ──
 
   const state: AgentViewState = useMemo(
@@ -267,6 +303,7 @@ export function AgentViewProvider({
       agentInputBufferText,
       agentTabBarFocused,
       agentApprovalModes,
+      agentMessageQueues,
     }),
     [
       activeView,
@@ -275,6 +312,7 @@ export function AgentViewProvider({
       agentInputBufferText,
       agentTabBarFocused,
       agentApprovalModes,
+      agentMessageQueues,
     ],
   );
 
@@ -290,6 +328,7 @@ export function AgentViewProvider({
       setAgentInputBufferText,
       setAgentTabBarFocused,
       setAgentApprovalMode,
+      setAgentMessageQueue,
     }),
     [
       switchToAgent,
@@ -302,6 +341,7 @@ export function AgentViewProvider({
       setAgentInputBufferText,
       setAgentTabBarFocused,
       setAgentApprovalMode,
+      setAgentMessageQueue,
     ],
   );
 

--- a/packages/cli/src/ui/contexts/AgentViewContext.tsx
+++ b/packages/cli/src/ui/contexts/AgentViewContext.tsx
@@ -84,6 +84,8 @@ export interface AgentViewActions {
   setAgentApprovalMode(agentId: string, mode: ApprovalMode): void;
   /** Replace the queued follow-up messages for an agent (see state docs). */
   setAgentMessageQueue(agentId: string, queue: readonly string[]): void;
+  /** Append one follow-up message without relying on a render-time snapshot. */
+  appendToAgentMessageQueue(agentId: string, message: string): void;
 }
 
 // ─── Context ────────────────────────────────────────────────
@@ -117,6 +119,7 @@ const DEFAULT_ACTIONS: AgentViewActions = {
   setAgentTabBarFocused: noop,
   setAgentApprovalMode: noop,
   setAgentMessageQueue: noop,
+  appendToAgentMessageQueue: noop,
 };
 
 // ─── Hook: useAgentViewState ────────────────────────────────
@@ -155,6 +158,12 @@ export function AgentViewProvider({
   const [agentMessageQueues, setAgentMessageQueues] = useState<
     Map<string, readonly string[]>
   >(() => new Map());
+  // Synchronous mirror of the registered agent ids. The `agents` state only
+  // reflects register/unregister after commit, so a same-batch append cannot
+  // consult it to learn that an agent is being unregistered right now; this
+  // ref is updated at action-call time so appendToAgentMessageQueue drops
+  // follow-ups for a departing agent instead of resurrecting its queue.
+  const registeredIdsRef = useRef<Set<string>>(new Set());
 
   // ── Navigation ──
 
@@ -210,6 +219,7 @@ export function AgentViewProvider({
       color: string,
       modelName?: string,
     ) => {
+      registeredIdsRef.current.add(agentId);
       setAgents((prev) => {
         const next = new Map(prev);
         next.set(agentId, {
@@ -232,6 +242,7 @@ export function AgentViewProvider({
   );
 
   const unregisterAgent = useCallback((agentId: string) => {
+    registeredIdsRef.current.delete(agentId);
     setAgents((prev) => {
       if (!prev.has(agentId)) return prev;
       const next = new Map(prev);
@@ -254,6 +265,7 @@ export function AgentViewProvider({
   }, []);
 
   const unregisterAll = useCallback(() => {
+    registeredIdsRef.current.clear();
     setAgents(new Map());
     setAgentApprovalModes(new Map());
     setAgentMessageQueues(new Map());
@@ -287,6 +299,22 @@ export function AgentViewProvider({
         } else {
           next.set(agentId, queue);
         }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const appendToAgentMessageQueue = useCallback(
+    (agentId: string, message: string) => {
+      // Membership is checked against the registered-agents mirror, not the
+      // queues map: empty queues hold no map entry (a `prev.has` guard would
+      // drop the first message), and the mirror already reflects an
+      // unregisterAgent that ran earlier in the same React batch.
+      if (!registeredIdsRef.current.has(agentId)) return;
+      setAgentMessageQueues((prev) => {
+        const next = new Map(prev);
+        next.set(agentId, [...(next.get(agentId) ?? []), message]);
         return next;
       });
     },
@@ -329,6 +357,7 @@ export function AgentViewProvider({
       setAgentTabBarFocused,
       setAgentApprovalMode,
       setAgentMessageQueue,
+      appendToAgentMessageQueue,
     }),
     [
       switchToAgent,
@@ -342,6 +371,7 @@ export function AgentViewProvider({
       setAgentTabBarFocused,
       setAgentApprovalMode,
       setAgentMessageQueue,
+      appendToAgentMessageQueue,
     ],
   );
 


### PR DESCRIPTION
## What this PR does

While a teammate is busy, Agent View accepted submitted follow-up messages into a queue local to the `AgentComposer` component and only handed them to the runtime queue once the teammate settled back to idle. This PR lifts that per-agent queue into `AgentViewContext`, keyed by agent id, so it lives above the composer instead of inside it. Submissions while busy now update the context queue, the idle flush joins and enqueues them exactly as before, and unregistering an agent drops its pending queue so a re-registered id never inherits stale messages. The `key={activeView}` layout behavior (which resets composer input state on tab switch) and the idle submit path are untouched.

## Why it's needed

`DefaultAppLayout` renders `AgentComposer` with `key={activeView}`, so switching to another teammate tab unmounts the composer and silently discards its local queue — a message the UI already accepted and displayed as queued is lost and is never delivered after the teammate becomes idle (#10069). The reproduction was confirmed with a component test before the fix: after a tab switch the queued message disappears from the display and `enqueueMessage` is never called.

## Reviewer Test Plan

### How to verify

Run the new regression tests (red before the fix, green with it):

```bash
cd packages/cli
npx vitest run src/ui/components/agent-view/AgentComposer.queuedMessages.test.tsx
```

They render the real `AgentViewProvider` and remount `AgentComposer` by changing the view key, mirroring `DefaultAppLayout`:

- `keeps a queued follow-up across tab switches and delivers it exactly once` — submit while busy, switch to teammate B and back, assert the message is still shown as queued; settle to idle and assert `enqueueMessage` was called exactly once with the message and never again on later re-renders.
- `joins multiple queued follow-ups into one prompt after a tab switch` — two busy submissions survive the switch and flush as one joined prompt (previous semantics preserved).
- `still enqueues immediately when the teammate is idle` — the idle path is unchanged.

Plus the provider lifecycle test in `src/ui/contexts/AgentViewContext.test.tsx` (per-agent storage, empty-queue removal, queue dropped on unregister). Broader regression surface: `npx vitest run src/ui/components/agent-view/ src/ui/contexts/AgentViewContext.test.tsx src/ui/components/QueuedMessageDisplay.test.tsx src/ui/components/Composer.test.tsx src/ui/layouts/DefaultAppLayout.test.tsx src/ui/components/InputPrompt.test.tsx` — 310 tests pass locally, and `tsc --noEmit` / `eslint` are clean for `packages/cli`.

Manual check for reviewers with a live Agent Team: start a long turn on teammate A, submit a follow-up (queued display appears), switch to teammate B and back, let A finish — the queued message should remain visible and be delivered once.

### Evidence (Before & After)

Component-test level (before/after in the TUI not captured): reproducing this in a terminal-capture scenario would require a live Agent Team with two teammates and a controllable long-running busy turn, which the scenario harness cannot construct stably. Instead the regression tests assert the exact observable sequence from the issue. Before the fix, `keeps a queued follow-up across tab switches...` fails with `expected '' to contain 'follow-up for later'` and `expected "spy" to be called 1 times, but got 0 times`; after the fix all three tests pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit/component tests only: `vitest` + `ink-testing-library` with the real `AgentViewProvider`; runtime agents faked.

## Risk & Scope

- Main risk or tradeoff: the queue state moved from component-local `useState` to context, so every queue mutation re-renders `AgentViewProvider` consumers — same frequency as before (one re-render per submit/flush) and only while messages are queued.
- Not validated / out of scope: unsent editor draft text is still lost on tab switch (reporter's open question, separate concern); the alternative "enqueue into runtime immediately while busy" semantics change was intentionally not taken (it would turn N queued messages into N rounds instead of one joined prompt).
- Breaking changes / migration notes: none; `QueuedMessageDisplay` prop widened to `readonly string[]` (callers unaffected).

## Linked Issues

Fixes #10069

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当 teammate 忙碌时，Agent View 会把提交的 follow-up 消息先放进 `AgentComposer` 组件内部的本地队列，等 teammate 回到 idle 后再交给 runtime 队列。本 PR 把这个按 agent id 区分队列提升到 `AgentViewContext`，让它存活在 composer 之外：busy 期间的提交写入 context 队列，idle 时的 flush 仍按原逻辑合并后投递一次；注销某个 agent 时会清掉它的待投递队列，避免同一 id 重新注册时继承到旧消息。`key={activeView}` 的布局行为（切 tab 重置输入态）和 idle 时的直接提交路径均未改动。

## 为什么需要

`DefaultAppLayout` 用 `key={activeView}` 渲染 `AgentComposer`，切换到其他 teammate tab 会卸载 composer，本地队列被静默丢弃——UI 已经接受并显示为 queued 的消息就此丢失，teammate 空闲后也不会投递（#10069）。修复前已用组件测试确认复现：切 tab 回来后队列消息从展示中消失，`enqueueMessage` 始终 0 次调用。

## 评审测试计划

### 如何验证

运行新增回归测试（修复前红、修复后绿）：

```bash
cd packages/cli
npx vitest run src/ui/components/agent-view/AgentComposer.queuedMessages.test.tsx
```

测试使用真实 `AgentViewProvider`，通过切换 view key 重挂载 `AgentComposer`，与 `DefaultAppLayout` 的行为一致：

- `keeps a queued follow-up across tab switches and delivers it exactly once`——busy 时提交，切到 teammate B 再切回，断言消息仍在队列展示中；转 idle 后断言 `enqueueMessage` 恰好被调用一次且后续重渲染不重复投递。
- `joins multiple queued follow-ups into one prompt after a tab switch`——busy 时提交两条，跨切换后合并为一条 prompt 投递（保持原有语义）。
- `still enqueues immediately when the teammate is idle`——idle 路径不受影响。

另有 `src/ui/contexts/AgentViewContext.test.tsx` 中的 provider 生命周期测试（按 agent 存取、空队列移除、注销时清理）。更大回归面：`npx vitest run src/ui/components/agent-view/ src/ui/contexts/AgentViewContext.test.tsx src/ui/components/QueuedMessageDisplay.test.tsx src/ui/components/Composer.test.tsx src/ui/layouts/DefaultAppLayout.test.tsx src/ui/components/InputPrompt.test.tsx`——本地 310 个测试全部通过，`packages/cli` 的 `tsc --noEmit` / `eslint` 干净。

有真实 Agent Team 环境的评审者可手动验证：让 teammate A 跑一个长 turn，提交一条 follow-up（出现 queued 展示），切到 teammate B 再切回，等 A 结束——queued 消息应保持可见且只投递一次。

### 证据（修复前后）

组件测试级证据（未提供 TUI 前后截图）：要在 terminal-capture 场景中复现，需要一个有两个 teammate、且 busy turn 可控的真实 Agent Team 会话，scenario 无法稳定构造。回归测试断言了 issue 描述的完整可观察序列。修复前 `keeps a queued follow-up across tab switches...` 失败：`expected '' to contain 'follow-up for later'`、`expected "spy" to be called 1 times, but got 0 times`；修复后三个测试全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

仅单元/组件测试：`vitest` + `ink-testing-library`，使用真实 `AgentViewProvider`，runtime agent 为假对象。

## 风险与范围

- 主要风险/权衡：队列状态从组件本地 `useState` 移到 context，队列变化会触发 `AgentViewProvider` 消费者重渲染——频率与之前相同（每次提交/flush 一次），且仅在队列非空时发生。
- 未验证/不在范围内：未提交的输入框草稿仍会因切 tab 丢失（报告者提出的疑问，属独立问题）；刻意未采用"busy 时立即进 runtime 队列"的备选方案（那会把 N 条排队消息变成 N 轮，而不是合并为一轮）。
- 破坏性变更/迁移说明：无；`QueuedMessageDisplay` 的 prop 放宽为 `readonly string[]`（调用方不受影响）。

## 关联 Issue

Fixes #10069

</details>
