### PR TITLE
docs(external-context): Design a configurable Mem0 provider extension

### DIFF
--- a/docs/design/external-context-mem0-extension.md
+++ b/docs/design/external-context-mem0-extension.md
@@ -1,0 +1,314 @@
+# Configurable Mem0 Provider Extension
+
+**Status:** Proposed
+
+**Date:** 2026-08-26
+
+**Related profile:**
+[External Context Provider Extensions](./external-context-provider-extensions.md)
+
+**Related implementation proposal:**
+[PR #9952](https://github.com/QwenLM/qwen-code/pull/9952)
+
+## Decision
+
+Mem0-compatible services integrate through a self-contained local stdio
+Extension named `external-context-mem0`. The Extension implements External
+Context MCP Profile v1 and translates the fixed `context_search({ query })`
+contract into a bounded, versioned REST dialect selected by administrator
+configuration.
+
+External Context MCP Profile v1 remains the only public Qwen interoperability
+boundary. Qwen Core does not gain a provider registry, a public provider SDK,
+dynamic module loading, or new third-party cases in its private
+`ProviderConfig` union. The existing direct `mem0-platform-v3` integration
+remains available for compatibility, but it does not become a registry for
+Mem0 product variants.
+
+This proposal defines architecture and compatibility policy only. Runtime
+code, configuration schemas, presets, packaging, and provider tests land in
+later pull requests.
+
+## Goals
+
+- Add common Mem0-compatible REST services through versioned preset data rather
+  than Qwen Core changes.
+- Keep the model-facing contract stable as `context_search({ query })` while
+  endpoint, credential, scope, timeout, and dialect remain operator-owned.
+- Give providers whose protocols do not fit the bounded REST grammar a clear
+  path to publish their own local or remote MCP Extension.
+- Preserve the current direct integration while a portable retrieval-only path
+  is introduced incrementally.
+
+## Non-goals
+
+- Implement the Extension, schemas, provider adapters, or packages in this
+  proposal.
+- Define a dynamic provider ABI, arbitrary request templates, JSONPath,
+  scripting, or custom executable hooks.
+- Probe V3, V2, and V1 endpoints automatically or silently fall back between
+  product versions.
+- Add memory creation, update, deletion, or Auto Recall behavior to the
+  portable Extension.
+- Migrate or remove the existing direct External Context provider.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Q["Qwen Core"] --> P["External Context MCP Profile v1"]
+    P --> R["Provider-owned Remote MCP"]
+    P --> E["external-context-mem0 local stdio Extension"]
+    E --> C["Administrator-owned instance configuration"]
+    E --> D["Versioned bounded dialect preset"]
+    C --> X["Bounded request engine"]
+    D --> X
+    X --> S["Mem0-compatible service"]
+```
+
+The local Extension owns the HTTP translation and ships as a self-contained
+artifact. Qwen sees only the MCP profile. A service with a protocol outside the
+bounded grammar owns a separate MCP implementation instead of extending the
+grammar or Qwen Core.
+
+## Version model
+
+Four independent version axes must remain explicit:
+
+1. **MCP Profile version** defines the Qwen-to-Extension tool contract. This
+   proposal implements External Context MCP Profile v1.
+2. **Instance schema version** defines the operator configuration shape, such
+   as `schemaVersion: 1`.
+3. **Dialect version** defines preset interpretation, such as
+   `dialectVersion: 1`.
+4. **Upstream product or API version** belongs to the provider and may differ
+   between operations in one product.
+
+An upstream product must not be labeled simply "V1", "V2", or "V3" at the
+Extension boundary. For example, a Hologres long-memory deployment can expose
+a mixture of versioned operation paths; its preset records the exact verified
+contract for each operation.
+
+## Instance configuration
+
+An instance selects one immutable preset and supplies deployment-specific
+values. The following shape is conceptual; the implementation pull request
+will publish and validate the canonical schema.
+
+```json
+{
+  "schemaVersion": 1,
+  "preset": "aliyun-polardb-mysql-2026-08",
+  "endpoint": {
+    "origin": "http://10.0.0.8:8080",
+    "basePath": "",
+    "allowInsecureHttp": true
+  },
+  "credentialEnv": "MEMORY_API_KEY",
+  "scope": {
+    "userId": "repository-memory",
+    "agentId": "qwen-code"
+  },
+  "timeoutMs": 5000
+}
+```
+
+The endpoint is split into an origin and a base path so the implementation can
+validate the authority separately from path joining. Credentials are
+referenced by environment-variable name and are never stored in this document.
+Scope values are fixed operator input, not tool arguments. A preset declares
+which of `userId`, `agentId`, and `appId` it consumes; startup validation
+rejects a missing required value or a configured value that the preset does
+not use. For example, a Mem0 Platform V3 instance uses
+`"scope": { "appId": "shared-repository" }` instead of the PolarDB-oriented
+scope above.
+
+### Configuration ownership and loading
+
+One environment variable, `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG`, points to the
+absolute path of the instance JSON file. The local Extension reads and
+validates that file once at startup and fails closed before exposing its tool
+when the path is relative, the file is unavailable, the schema is unsupported,
+or the selected preset is unknown. The instance file can name the environment
+variable holding a credential, but cannot contain the credential value.
+
+An Extension setting may populate this non-secret path after its
+installation-to-child-process behavior is covered by E2E. Managed deployments
+instead supply it through an administrator-owned launcher, system settings, or
+pinned MCP configuration. Repository-controlled configuration is trusted only
+when the repository itself is inside the deployment's trust boundary.
+
+Each MCP server instance binds exactly one endpoint, preset, and scope. A
+deployment that needs several memory services registers separately named MCP
+server instances. The model does not choose or switch the provider for a call.
+
+## Dialect presets
+
+A preset describes only the small set of differences required to issue a
+retrieval request and normalize its response. For example:
+
+```json
+{
+  "dialectVersion": 1,
+  "id": "aliyun-polardb-mysql-2026-08",
+  "auth": "authorization-token",
+  "search": {
+    "method": "POST",
+    "path": "/v2/memories/search",
+    "queryLocation": "json",
+    "userIdLocation": "json.filters",
+    "agentIdLocation": "json",
+    "limitField": "limit"
+  },
+  "response": {
+    "collection": "results",
+    "idField": "id",
+    "contentField": "memory",
+    "scoreField": "score"
+  }
+}
+```
+
+The initial grammar is deliberately closed:
+
+- Authentication is one of `authorization-token`, `authorization-bearer`, or
+  `x-api-key`.
+- Search uses `GET` or `POST`.
+- Query, user, agent, and app values use only `json`, `json.filters`, `query`,
+  or `omit` locations supported by the relevant field. Their request names are
+  selected from an explicit allowlist such as `query`, `user_id`, `agent_id`,
+  and `app_id`.
+- Result limits use `top_k`, `limit`, or `omit`.
+- Response collections are `results` or a root array.
+- Identifier fields are selected from known simple names such as `id` and
+  `memory_id`; content fields are selected from `memory`, `content`, and
+  `text`. Other normalized fields follow the same explicit allowlist model.
+- Optional behaviors such as `threshold` and `rerank` are typed preset fields,
+  not free-form request fragments.
+- Request paths are static exact paths. Path joining preserves a required
+  trailing slash.
+
+Presets cannot define arbitrary headers, body interpolation, JSONPath, code,
+environment-variable expansion, redirects, or response transformations. If a
+new service requires one of those capabilities, it does not fit this grammar.
+
+Built-in preset identifiers include a provider and a stable contract version,
+for example:
+
+- `mem0-platform-v3`
+- `mem0-oss-rest-2026-08`
+- `aliyun-polardb-mysql-2026-08`
+- `aliyun-hologres-mem0-2.0.6`
+- `aliyun-rds-postgresql-memory-2026-08`
+
+The names above reserve design intent; each preset lands only after its exact
+request and response contract is verified. A published identifier never
+silently changes to an incompatible mapping. A breaking mapping receives a new
+identifier.
+
+## Adding another service
+
+The integration decision is mechanical:
+
+1. If the service fits the bounded grammar, add a versioned preset and contract
+   fixtures to the Extension package. Qwen Core does not change.
+2. If the service does not fit the grammar but can implement External Context
+   MCP Profile v1, publish a separate local or remote MCP Extension. Qwen Core
+   still does not change.
+3. Change the profile only when multiple independent implementations prove a
+   missing interoperable capability. A single provider exception is not
+   sufficient.
+
+A later implementation may accept an administrator-owned custom preset file
+for retrieval-only deployments. Such a file must use an absolute path, pass
+the same closed schema and semantic validation as built-in presets, and contain
+neither credentials nor executable behavior. Custom presets do not expand the
+grammar and cannot enable write operations.
+
+This keeps new data sources configurable where their differences are data, and
+plugin-owned where their differences require behavior. It avoids making every
+new provider a Qwen release while also avoiding an unbounded HTTP programming
+language in configuration.
+
+## Security and failure behavior
+
+- The model supplies only `query`. It cannot select the endpoint, credential,
+  user, agent, filter, dialect, timeout, or result limit.
+- Credentials are read from the named process environment variable. Presets
+  and instance configuration never contain credential values.
+- HTTPS is required by default. Plain HTTP requires an explicit
+  `allowInsecureHttp` opt-in intended for trusted private networks.
+- Endpoint validation treats `origin` and `basePath` separately and rejects
+  embedded credentials, query strings, fragments, dot traversal, and encoded
+  traversal.
+- The request engine does not follow redirects, retry requests, probe protocol
+  versions, or cache provider responses.
+- The provider timeout is shorter than the enclosing MCP timeout so the
+  Extension can return a bounded error. A provider response is capped at 1 MiB
+  before parsing.
+- Error results redact the query, endpoint, credential, upstream response body,
+  and raw exception. Retrieved content remains untrusted external context.
+- Fixed `userId`, `agentId`, and `appId` values are routing values, not
+  authorization boundaries. Shared multi-user deployments should use a
+  provider-operated Remote MCP service with OAuth subject binding and
+  provider-side authorization.
+- Managed deployments enforce the exact Extension and environment through
+  operator-owned system settings or pinned MCP configuration. An Extension is
+  a distribution unit, not a security binding or sandbox; a local Extension
+  runs with the Qwen process user's privileges.
+
+## Retrieval and write boundary
+
+The portable Mem0 Extension v1 manifest exposes exactly:
+
+```json
+{
+  "includeTools": ["context_search"]
+}
+```
+
+Memory creation, update, and deletion require a separate future profile or
+Extension. A custom preset cannot enable them. Write protocols differ in
+idempotency, duplicate handling, ambiguous timeout outcomes, asynchronous
+status, inference behavior, and identifier formats; treating them as another
+search mapping would hide data-loss and duplication risks.
+
+## Relationship to PR #9952
+
+[PR #9952](https://github.com/QwenLM/qwen-code/pull/9952) provides useful
+PolarDB protocol and test evidence. This proposal is independent of that
+branch and does not add a `polardb-mem0` case to the private `ProviderConfig`
+union.
+
+A later Extension implementation can port verified request fixtures and
+normalization cases without cherry-picking the full provider-specific change.
+If PR #9952 merges first, its behavior remains backward-compatible until a
+separate migration decision. If it does not merge, superseding it with the
+Extension requires an explicit maintainer decision; this design document alone
+does not make that decision.
+
+## Rollout
+
+1. **PR0:** Land this architecture decision and its link from the External
+   Context provider-extension proposal. No runtime behavior changes.
+2. **PR1:** Add the self-contained Extension skeleton, canonical instance and
+   dialect schemas, the bounded request engine, and contract tests against
+   synthetic fixtures. Do not enable a live provider.
+3. **PR2:** Add verified retrieval presets for Mem0 Platform V3 and PolarDB
+   MySQL.
+4. **PR3:** Add Hologres, Mem0 OSS, RDS PostgreSQL, and other presets only after
+   each contract is verified independently.
+5. Design any portable write capability separately.
+
+Each implementation pull request remains independently reviewable and can be
+rolled back by disabling or uninstalling the Extension. No step silently
+migrates existing direct-provider configuration.
+
+## PR0 verification
+
+PR0 changes documentation only. It introduces no user-visible behavior and
+does not require an E2E plan. Verification consists of Markdown formatting,
+link consistency, `git diff --check`, and two consecutive clean design audits
+covering architecture boundaries, failure paths, compatibility,
+maintainability, complexity, security, testing strategy, and simpler
+alternatives.

--- a/docs/design/external-context-provider-extensions.md
+++ b/docs/design/external-context-provider-extensions.md
@@ -9,6 +9,9 @@
 **Existing direct integration:**
 [Direct External Context Provider](./direct-external-context-provider.md)
 
+**Mem0 family extension:**
+[Configurable Mem0 Provider Extension](./external-context-mem0-extension.md)
+
 ## Decision
 
 External context integrations owned by other teams use Qwen Code Extensions


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR documents a configurable Mem0-compatible External Context Extension architecture. It keeps External Context MCP Profile v1 as Qwen's public boundary, defines a self-contained local stdio Extension with administrator-owned instance configuration and versioned bounded dialect presets, separates profile, configuration, dialect, and upstream API versions, and records security, compatibility, write isolation, and staged rollout decisions.

## Why it's needed

Mem0 Platform, Mem0 OSS, PolarDB MySQL, Hologres, RDS PostgreSQL, and future compatible services vary in endpoint paths, authentication, scope placement, and response shapes. Adding every variant to Qwen's private provider union would require repeated core changes, while a fully programmable HTTP template would create an unsafe and difficult-to-maintain configuration language. The proposed boundary lets closed, data-only differences use versioned presets and routes behaviorally different protocols to provider-owned MCP Extensions without expanding Qwen Core.

## Reviewer Test Plan

### How to verify

Review the proposal and confirm that the model-facing surface remains exactly `context_search({ query })`, endpoint, credential, scope, and dialect selection stay operator-owned, preset capabilities are closed and retrieval-only, unsupported protocols use separate MCP Extensions, the current direct Mem0 provider remains compatible, and PR #9952 is treated as protocol evidence rather than an implementation dependency. Confirm that the diff contains documentation only. Run `npx prettier --check docs/design/external-context-mem0-extension.md docs/design/external-context-provider-extensions.md` and `git diff --check origin/main...HEAD`; both should complete without errors.

### Evidence (Before & After)

N/A

### Tested on

|     OS     |   Status   |
| :--------: | :--------: |
|  🍏 macOS  |  ✅ tested  |
| 🪟 Windows |    N/A     |
|  🐧 Linux  |    N/A     |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: The bounded preset grammar may intentionally reject a future service whose protocol requires executable transformations; that service must publish a separate MCP Extension rather than widening configuration into a programming language.
- Not validated / out of scope: Runtime implementation, canonical JSON Schemas, packaging, live provider requests, automatic protocol probing, write operations, and migration of the existing direct provider are not included.
- Breaking changes / migration notes: None. This documentation-only PR does not change runtime behavior or existing configuration.

## Linked Issues

Related: #9952

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 记录一个可配置的 Mem0 兼容 External Context Extension 架构。它继续以 External Context MCP Profile v1 作为 Qwen 的公开边界，定义一个自包含的本地 stdio Extension、管理员持有的实例配置和版本化的有界 dialect preset，区分 profile、配置、dialect 与上游 API 四类版本，并明确安全、兼容性、写入隔离和分阶段交付决策。

## 为什么需要它

Mem0 Platform、Mem0 OSS、PolarDB MySQL、Hologres、RDS PostgreSQL 和未来兼容服务在 endpoint 路径、认证、scope 放置方式及响应结构上存在差异。如果把每个变体都加入 Qwen 的私有 provider union，就需要反复修改 Core；如果提供完全可编程的 HTTP 模板，又会形成不安全且难维护的配置语言。该边界允许有界、纯数据差异通过版本化 preset 接入，并让行为差异较大的协议由 provider 自己的 MCP Extension 承担，而不扩展 Qwen Core。

## Reviewer Test Plan

### 如何验证

审阅方案并确认模型侧接口仍严格为 `context_search({ query })`，endpoint、credential、scope 和 dialect 选择由运维人员控制，preset 能力是封闭且只读检索的，不支持的协议使用独立 MCP Extension，当前直接 Mem0 provider 保持兼容，并且 PR #9952 仅作为协议证据而不是实现依赖。确认 diff 只包含文档。运行 `npx prettier --check docs/design/external-context-mem0-extension.md docs/design/external-context-provider-extensions.md` 和 `git diff --check origin/main...HEAD`，两条命令都应无错误完成。

### 证据（变更前后）

N/A

### 测试平台

|     OS     |   状态   |
| :--------: | :------: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows |   N/A    |
|  🐧 Linux  |   N/A    |

### 环境（可选）

N/A

## 风险与范围

- 主要风险或权衡：有界 preset 语法会有意拒绝需要可执行转换的未来服务；这类服务必须发布独立 MCP Extension，而不能把配置扩展成编程语言。
- 未验证或不在范围内：不包含运行时实现、正式 JSON Schema、打包、真实 provider 请求、自动协议探测、写入操作，以及现有直接 provider 的迁移。
- 破坏性变更或迁移说明：无。此纯文档 PR 不改变运行时行为或现有配置。

## 关联事项

相关：#9952

</details>
