### PR TITLE
fix(cua-driver): support sandboxed Windows SDK clients

### DIFF
--- a/packages/cua-driver/rust/crates/cua-driver/src/serve.rs
+++ b/packages/cua-driver/rust/crates/cua-driver/src/serve.rs
@@ -1235,8 +1235,43 @@ unsafe fn named_pipe_client_sid(pipe: *mut std::ffi::c_void) -> Option<String> {
 }
 
 #[cfg(target_os = "windows")]
-fn named_pipe_sid_is_authorized(expected: Option<&str>, actual: Option<&str>) -> bool {
-    matches!((expected, actual), (Some(expected), Some(actual)) if expected.eq_ignore_ascii_case(actual))
+const TRUSTED_CLIENT_SID_ENV: &str = "CUA_DRIVER_EMBEDDED_TRUSTED_CLIENT_SID";
+
+#[cfg(target_os = "windows")]
+fn valid_windows_sid(value: &str) -> bool {
+    value.len() <= 184
+        && value.starts_with("S-1-")
+        && value[4..].split('-').all(|component| {
+            !component.is_empty() && component.bytes().all(|byte| byte.is_ascii_digit())
+        })
+}
+
+#[cfg(target_os = "windows")]
+fn configured_trusted_client_sid(embedded: bool) -> anyhow::Result<Option<String>> {
+    let Some(value) = std::env::var_os(TRUSTED_CLIENT_SID_ENV) else {
+        return Ok(None);
+    };
+    if !embedded {
+        anyhow::bail!("{TRUSTED_CLIENT_SID_ENV} requires --embedded");
+    }
+    let value = value.to_string_lossy().into_owned();
+    if !valid_windows_sid(&value) {
+        anyhow::bail!("{TRUSTED_CLIENT_SID_ENV} is not a valid Windows SID");
+    }
+    Ok(Some(value))
+}
+
+#[cfg(target_os = "windows")]
+fn named_pipe_sid_is_authorized(
+    owner: Option<&str>,
+    delegated: Option<&str>,
+    actual: Option<&str>,
+) -> bool {
+    let Some(actual) = actual else {
+        return false;
+    };
+    owner.is_some_and(|expected| expected.eq_ignore_ascii_case(actual))
+        || delegated.is_some_and(|expected| expected.eq_ignore_ascii_case(actual))
 }
 
 #[cfg(target_os = "windows")]
@@ -1252,10 +1287,15 @@ fn named_pipe_host_pid_is_authorized(expected: Option<u32>, actual: Option<u32>)
 /// connected client's process token before request parsing.
 #[cfg(target_os = "windows")]
 unsafe fn build_pipe_security_attrs(
-    _embedded: bool,
+    owner_sid: &str,
+    trusted_client_sid: Option<&str>,
 ) -> Option<(SecurityAttributesRaw, *mut std::ffi::c_void)> {
-    let sid = current_user_sid_string()?;
-    security_attrs_from_sddl(&format!("D:P(A;;GA;;;{sid})S:(ML;;NW;;;LW)"))
+    let delegated_ace = trusted_client_sid
+        .map(|sid| format!("(A;;GA;;;{sid})"))
+        .unwrap_or_default();
+    security_attrs_from_sddl(&format!(
+        "D:P(A;;GA;;;{owner_sid}){delegated_ace}S:(ML;;NW;;;LW)"
+    ))
 }
 
 #[cfg(target_os = "windows")]
@@ -1280,12 +1320,15 @@ pub async fn run_serve(
 
     eprintln!("Qwen Cua Driver daemon listening on {socket_path}");
 
-    // Build the current-user descriptor once and reuse it for every pipe
-    // instance. Both service and embedded mode fail closed if the ACL cannot
-    // be created; an Everyone ACL would expose the desktop-action endpoint to
-    // unrelated local principals.
+    // Build the descriptor once and reuse it for every pipe instance. An
+    // embedded host may explicitly delegate its trusted session to one exact
+    // sandbox account SID; ordinary daemons remain current-user-only.
     let embedded = cua_driver_core::embedded_mode();
-    let security_attrs = unsafe { build_pipe_security_attrs(embedded) };
+    let owner_sid = unsafe { current_user_sid_string() }
+        .ok_or_else(|| anyhow::anyhow!("resolve current-user SID for named pipe"))?;
+    let trusted_client_sid = configured_trusted_client_sid(embedded)?;
+    let security_attrs =
+        unsafe { build_pipe_security_attrs(&owner_sid, trusted_client_sid.as_deref()) };
     if security_attrs.is_none() {
         anyhow::bail!("failed to build current-user security descriptor for named pipe");
     }
@@ -1345,14 +1388,14 @@ pub async fn run_serve(
         tokio::select! {
             result = server.connect() => {
                 result.map_err(|e| anyhow::anyhow!("named pipe connect: {e}"))?;
-                let expected_sid = unsafe { current_user_sid_string() };
                 let client_process_id =
                     unsafe { named_pipe_client_process_id(server.as_raw_handle().cast()) };
                 let client_sid = unsafe {
                     named_pipe_client_sid(server.as_raw_handle().cast())
                 };
                 if !named_pipe_sid_is_authorized(
-                    expected_sid.as_deref(),
+                    Some(&owner_sid),
+                    trusted_client_sid.as_deref(),
                     client_sid.as_deref(),
                 ) {
                     tracing::warn!(
@@ -1364,11 +1407,19 @@ pub async fn run_serve(
                 let expected_host_process_id = std::env::var("CUA_DRIVER_EMBEDDED_HOST_PID")
                     .ok()
                     .and_then(|value| value.parse::<u32>().ok());
+                let delegated_trusted_connection = trusted_client_sid
+                    .as_deref()
+                    .is_some_and(|expected| {
+                        client_sid
+                            .as_deref()
+                            .is_some_and(|actual| expected.eq_ignore_ascii_case(actual))
+                    });
                 let trusted_host_connection = embedded
-                    && named_pipe_host_pid_is_authorized(
-                        expected_host_process_id,
-                        client_process_id,
-                    );
+                    && (delegated_trusted_connection
+                        || named_pipe_host_pid_is_authorized(
+                            expected_host_process_id,
+                            client_process_id,
+                        ));
 
                 let reg = sdk.clone();
                 let shutdown_tx2 = shutdown_tx.clone();
@@ -1697,20 +1748,45 @@ pub async fn run_serve(
 
 #[cfg(all(test, target_os = "windows"))]
 mod named_pipe_authentication_tests {
-    use super::{named_pipe_host_pid_is_authorized, named_pipe_sid_is_authorized};
+    use super::{
+        named_pipe_host_pid_is_authorized, named_pipe_sid_is_authorized, valid_windows_sid,
+    };
 
     #[test]
     fn missing_or_foreign_sid_is_rejected_before_request_parsing() {
-        assert!(!named_pipe_sid_is_authorized(None, Some("S-1-5-21-1")));
-        assert!(!named_pipe_sid_is_authorized(Some("S-1-5-21-1"), None));
+        assert!(!named_pipe_sid_is_authorized(
+            None,
+            None,
+            Some("S-1-5-21-1")
+        ));
         assert!(!named_pipe_sid_is_authorized(
             Some("S-1-5-21-1"),
+            None,
+            None
+        ));
+        assert!(!named_pipe_sid_is_authorized(
+            Some("S-1-5-21-1"),
+            None,
             Some("S-1-5-21-2")
         ));
         assert!(named_pipe_sid_is_authorized(
             Some("S-1-5-21-1"),
+            None,
             Some("s-1-5-21-1")
         ));
+        assert!(named_pipe_sid_is_authorized(
+            Some("S-1-5-21-1"),
+            Some("S-1-5-21-2"),
+            Some("s-1-5-21-2")
+        ));
+    }
+
+    #[test]
+    fn delegated_sid_is_strictly_parsed_before_entering_sddl() {
+        assert!(valid_windows_sid("S-1-5-21-123-456-789-1001"));
+        assert!(!valid_windows_sid("s-1-5-21-1"));
+        assert!(!valid_windows_sid("S-1-5-21-1)(A;;GA;;;WD"));
+        assert!(!valid_windows_sid("S-1-5-"));
     }
 
     #[test]

--- a/packages/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
+++ b/packages/cua-driver/rust/crates/platform-windows/src/tools/impl_.rs
@@ -5759,11 +5759,24 @@ static PERFORM_SECONDARY_ACTION_DEF: std::sync::OnceLock<ToolDef> = std::sync::O
 #[async_trait]
 impl Tool for PerformSecondaryActionTool {
     fn def(&self) -> &ToolDef {
-        PERFORM_SECONDARY_ACTION_DEF.get_or_init(|| {
-            ToolDef::from_contract(
-                &cua_driver_contract::tool_contract("perform_secondary_action")
-                    .expect("perform_secondary_action contract"),
-            )
+        PERFORM_SECONDARY_ACTION_DEF.get_or_init(|| ToolDef {
+            name: "perform_secondary_action".into(),
+            description: "Perform one exact action name advertised by a cached UIA element. Unavailable actions fail closed and never fall back to a primary action or pixels.".into(),
+            input_schema: json!({
+                "type": "object",
+                "required": ["pid", "element_token", "action"],
+                "properties": {
+                    "pid": { "type": "integer", "minimum": 1 },
+                    "window_id": { "type": "integer", "minimum": 1 },
+                    "element_token": cua_driver_core::tool_schema::element_token_schema(),
+                    "action": { "type": "string" }
+                },
+                "additionalProperties": false
+            }),
+            read_only: false,
+            destructive: true,
+            idempotent: false,
+            open_world: true,
         })
     }
 
@@ -5958,6 +5971,28 @@ impl Tool for PerformSecondaryActionTool {
                 .with_structured(json!({ "code": "secondary_action_unavailable" })),
             Err(error) => ToolResult::error(format!("secondary action task failed: {error}")),
         }
+    }
+}
+
+#[cfg(test)]
+mod perform_secondary_action_schema_tests {
+    use super::{PerformSecondaryActionTool, ToolState};
+    use cua_driver_core::tool::Tool;
+
+    #[test]
+    fn runtime_schema_stays_platform_owned() {
+        let tool = PerformSecondaryActionTool {
+            state: ToolState::new(),
+        };
+        let def = tool.def();
+        assert_eq!(def.name, "perform_secondary_action");
+        assert!(def.description.contains("cached UIA element"));
+        assert_eq!(def.input_schema["required"].as_array().unwrap().len(), 3);
+        assert_eq!(
+            def.input_schema["properties"]["action"],
+            serde_json::json!({ "type": "string" })
+        );
+        assert_eq!(def.input_schema["additionalProperties"], false);
     }
 }
 


### PR DESCRIPTION
## What this PR does

This PR lets an embedded Windows CUA driver explicitly delegate its named-pipe connection to one sandbox account SID while preserving the existing owner-only behavior for ordinary daemons. It also keeps the Windows secondary-action tool definition platform-owned and compatible with the portable SDK input contract.

## Why it's needed

Windows sandbox agents run under a restricted account while the desktop-owning embedded driver runs in the interactive host session. The previous named-pipe ACL and trusted-host check accepted only the driver owner or original host process, so a restricted Node REPL client could not use `ComputerUse.connect()` even when the host had intentionally created that session for it. The new embedded-only setting validates one canonical SID, grants only that SID access to the pipe, and binds trusted authority to the authenticated pipe client. This is required before the fixed Windows native payload can be released through `@qwen-code/cua-sdk`.

## Reviewer Test Plan

### How to verify

- Start the embedded Windows daemon with `CUA_DRIVER_EMBEDDED_TRUSTED_CLIENT_SID` set to a restricted local account SID, then connect from that account through the configured named pipe. The typed SDK should initialize and execute through the host-owned desktop runtime.
- Confirm a missing client SID, a foreign SID, a malformed delegated SID, or use of the setting outside embedded mode is rejected before request dispatch.
- Confirm the Windows `perform_secondary_action` schema requires `pid`, `element_token`, and `action`, keeps `window_id` optional, and remains accepted by the portable SDK contract.

### Evidence (Before & After)

N/A — this is a non-UI runtime and schema change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ `cargo fmt --all -- --check`; 164/164 `qwen-cua-driver` unit tests |
| 🪟 Windows | ✅ 3/3 named-pipe authentication tests; 1/1 secondary-action schema test; real restricted-user Node REPL → `ComputerUse.connect()` smoke and UI action chain |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows Server 2025 interactive desktop session with an Administrator-owned embedded daemon and a restricted local agent account.

## Risk & Scope

- Main risk or tradeoff: an embedded host that opts into delegation grants one exact local SID the same trusted session authority as the host connection; malformed SIDs and non-embedded use fail closed.
- Not validated / out of scope: benchmark orchestration, SDK versioning, native artifact publication, and Linux runtime behavior.
- Breaking changes / migration notes: none; delegation is disabled unless the embedded-only environment setting is present.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 允许 Windows embedded CUA driver 将 named pipe 连接显式委托给一个 sandbox 账户 SID，同时保持普通 daemon 现有的仅 owner 可访问行为。它还让 Windows 次级动作工具继续使用平台自有定义，并与 portable SDK 输入契约兼容。

## 为什么需要

Windows sandbox agent 以受限账户运行，而拥有桌面的 embedded driver 运行在交互式 host session 中。此前 named pipe ACL 和 trusted-host 检查只接受 driver owner 或原始 host process，因此即使 host 有意为受限 Node REPL client 创建该 session，客户端也无法使用 `ComputerUse.connect()`。新的 embedded-only 设置会校验一个规范 SID，仅向该 SID 授予 pipe 访问权限，并把 trusted authority 绑定到已认证的 pipe client。这是通过 `@qwen-code/cua-sdk` 发布修复后 Windows native payload 的前置条件。

## Reviewer 测试计划

### 如何验证

- 在 Windows 上使用 `CUA_DRIVER_EMBEDDED_TRUSTED_CLIENT_SID` 指定受限本地账户 SID 启动 embedded daemon，然后从该账户通过配置的 named pipe 连接。typed SDK 应能初始化并通过 host-owned desktop runtime 执行。
- 确认缺失 client SID、外部 SID、格式错误的委托 SID，或在非 embedded 模式使用该设置时，都会在请求分发前被拒绝。
- 确认 Windows `perform_secondary_action` schema 要求 `pid`、`element_token` 和 `action`，`window_id` 保持可选，并继续被 portable SDK contract 接受。

### Before / After 证据

N/A——这是非 UI 的 runtime 和 schema 改动。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ `cargo fmt --all -- --check`；164/164 `qwen-cua-driver` 单测 |
| 🪟 Windows | ✅ 3/3 named-pipe authentication 测试；1/1 secondary-action schema 测试；受限用户 Node REPL → `ComputerUse.connect()` 真实 smoke 与 UI action 链 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

Windows Server 2025 交互式桌面 session，Administrator 拥有 embedded daemon，agent 使用受限本地账户。

## 风险与范围

- 主要风险或取舍：选择启用委托的 embedded host 会让一个精确的本地 SID 获得与 host connection 相同的 trusted session authority；错误 SID 和非 embedded 使用会 fail closed。
- 未验证 / 范围外：benchmark 编排、SDK 版本、native artifact 发布和 Linux runtime 行为。
- Breaking change / 迁移说明：无；只有设置 embedded-only 环境变量时才启用委托。

## 关联 Issue

N/A

</details>
