### PR TITLE
feat(goal): let a Goal stop early when its objective is infeasible

### DIFF
--- a/packages/core/src/goals/goal-evidence.test.ts
+++ b/packages/core/src/goals/goal-evidence.test.ts
@@ -108,7 +108,7 @@ function complete(evidenceRefs: string[]): GoalTerminalProposal {
 }
 
 function blocked(
-  blockerKind: 'authority' | 'external' | 'repeated',
+  blockerKind: NonNullable<GoalTerminalProposal['blockerKind']>,
   evidenceRefs: string[],
 ): GoalTerminalProposal {
   return {
@@ -1041,6 +1041,59 @@ describe('Goal evidence lineage and blockers', () => {
       );
     },
   );
+
+  it('holds an infeasible blocker to external facts, not user input or prose', () => {
+    // Infeasibility is a claim about the world. A user can authorise a stop
+    // (that is `authority`), but cannot make an objective impossible, and
+    // the assistant saying it is impossible is exactly the exit this kind
+    // must not become -- so only a tool result can carry it.
+    const records = [
+      record('cursor', 'system'),
+      record('user', 'user', {
+        provenance: 'real_user',
+        turnId: 'turn-2',
+        text: 'Please target the v9 branch',
+      }),
+      record('probe', 'tool_result', {
+        provenance: 'tool_result',
+        turnId: 'turn-3',
+        toolResponse: { output: "fatal: branch 'v9' not found" },
+      }),
+      record('assistant', 'assistant', {
+        provenance: 'assistant_output',
+        turnId: 'turn-3',
+        text: 'The v9 branch does not exist, so this objective cannot be met.',
+      }),
+    ];
+
+    expect(() =>
+      validate(records, blocked('infeasible', ['assistant'])),
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'infeasible_blocker_external_fact_required',
+      }),
+    );
+    expect(() =>
+      validate(records, blocked('infeasible', ['user', 'assistant'])),
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'infeasible_blocker_external_fact_required',
+      }),
+    );
+    expect(
+      validate(records, blocked('infeasible', ['probe', 'assistant']))
+        .citedRecords[0],
+    ).toMatchObject({ uuid: 'probe', proofKind: 'external_fact' });
+    // Like the other immediate blockers, it cannot leave newer evidence
+    // uncited: a later record could contradict the impossibility.
+    expect(() =>
+      validate(records, blocked('infeasible', ['probe'])),
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'immediate_blocker_newer_evidence_required',
+      }),
+    );
+  });
 
   it.each(['authority', 'external'] as const)(
     'gates an immediate %s blocker on checkpoint claims like raw evidence',

--- a/packages/core/src/goals/goal-evidence.ts
+++ b/packages/core/src/goals/goal-evidence.ts
@@ -140,6 +140,7 @@ export type InvalidGoalEvidenceReferenceCode =
   | 'wrong_turn_lineage'
   | 'catalog_truncated'
   | 'immediate_blocker_external_evidence_required'
+  | 'infeasible_blocker_external_fact_required'
   | 'immediate_blocker_newer_evidence_required'
   | 'repeated_blocker_turn_coverage';
 
@@ -890,9 +891,24 @@ function validateBlockerCoverage(
 ): void {
   if (proposal.status !== 'blocked') return;
 
+  // Infeasibility is a claim about the world, so it is held to external
+  // facts only: user input can authorise stopping, but it cannot make an
+  // objective impossible, and assistant prose saying so is exactly the
+  // "I think this can't be done" exit this kind must not become.
+  if (
+    proposal.blockerKind === 'infeasible' &&
+    !citedRecords.some(({ proofKind }) => proofKind === 'external_fact')
+  ) {
+    throw new InvalidGoalEvidenceReferenceError(
+      'infeasible_blocker_external_fact_required',
+      'An infeasible blocker requires cited external tool evidence of the fact that makes the objective unsatisfiable.',
+    );
+  }
+
   if (
     proposal.blockerKind === 'authority' ||
-    proposal.blockerKind === 'external'
+    proposal.blockerKind === 'external' ||
+    proposal.blockerKind === 'infeasible'
   ) {
     if (
       !citedRecords.some(

--- a/packages/core/src/goals/goal-protocol.ts
+++ b/packages/core/src/goals/goal-protocol.ts
@@ -263,11 +263,27 @@ export interface GoalStateResponse {
   snapshot: GoalSnapshotV2;
 }
 
+/**
+ * Why a Goal is blocked.
+ *
+ * `authority` and `external` stop immediately on cited user or external
+ * evidence. `repeated` (the default) needs the same evidenced blocker on
+ * three consecutive turns. `infeasible` also stops immediately: the cited
+ * external fact shows the objective cannot be satisfied as written, so no
+ * amount of retrying would help -- waiting three turns to say so is the
+ * runaway this kind exists to end.
+ */
+export type GoalBlockerKind =
+  | 'authority'
+  | 'external'
+  | 'repeated'
+  | 'infeasible';
+
 export interface GoalTerminalProposal {
   status: 'complete' | 'blocked';
   reason: string;
   evidenceRefs: string[];
-  blockerKind?: 'authority' | 'external' | 'repeated';
+  blockerKind?: GoalBlockerKind;
 }
 
 export function isRepeatedBlockerProposal(
@@ -276,9 +292,19 @@ export function isRepeatedBlockerProposal(
   return (
     proposal.status === 'blocked' &&
     proposal.blockerKind !== 'authority' &&
-    proposal.blockerKind !== 'external'
+    proposal.blockerKind !== 'external' &&
+    proposal.blockerKind !== 'infeasible'
   );
 }
+
+/**
+ * Appended to `lastReason` when an `infeasible` blocker is accepted, so the
+ * stopped Goal tells the user what to do rather than only what went wrong.
+ * The verifier's reason says why the objective cannot hold; this says that
+ * resuming as-is will not change that.
+ */
+export const GOAL_INFEASIBLE_NEXT_STEP =
+  'The objective cannot be satisfied as written; edit or replace the Goal with an objective the evidence allows before resuming it.';
 
 export function validateGoalProposalReason(reason: string): string | null {
   if (!reason.trim()) return 'Goal proposal reason must not be empty';

--- a/packages/core/src/goals/goal-runtime.test.ts
+++ b/packages/core/src/goals/goal-runtime.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { GoalEvidenceRecord } from './goal-evidence.js';
 import type { GoalRecoveryRecord } from './goal-persistence.js';
 import {
+  GOAL_INFEASIBLE_NEXT_STEP,
   GOAL_CHECKPOINT_CLAIM_LIMIT,
   GOAL_CHECKPOINT_REQUEST_TOO_LARGE_REASON,
   GOAL_CHECKPOINT_STALL_LIMIT,
@@ -625,6 +626,82 @@ describe('goal runtime', () => {
       }),
       expect.any(AbortSignal),
     );
+  });
+
+  it('accepts an evidenced infeasible blocker on its first turn, with the next step spelled out', async () => {
+    const journal = fakeGoalJournal();
+    let records: readonly RuntimeRecord[] = [];
+    const evidenceSource = fakeEvidenceSource(() => records);
+    const verifier: GoalVerifier = vi.fn(async () => ({
+      decision: 'accept' as const,
+      reason: 'The named branch does not exist',
+    }));
+    const host = fakeGoalTurnHost();
+    const runtime = createGoalRuntime({ journal, evidenceSource, verifier });
+    runtime.bindHost(host);
+    await runtime.dispatch({
+      action: 'create',
+      objective: 'Rebase onto the v9 branch',
+    });
+    const permit = host.started[0]!;
+    const cursorId = runtime.getSnapshot().goal!.evidenceCursor.recordId!;
+    const base = verifierEvidenceRecords(permit, cursorId, 'probe');
+    records = [
+      base[0]!,
+      {
+        ...base[1]!,
+        type: 'tool_result',
+        provenance: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'shell',
+                response: { output: "fatal: branch 'v9' not found" },
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    // No three-turn streak: the whole point is to stop before the budget
+    // does, and the evidence bar (an external fact) is what earns that.
+    const receipt = runtime.recordTerminalProposal(permit, {
+      status: 'blocked',
+      blockerKind: 'infeasible',
+      reason:
+        'Checked the remote: no v9 branch exists, so nothing in scope can rebase onto it.',
+      evidenceRefs: ['probe'],
+    });
+    expect(receipt).toEqual({ recorded: true, readyForVerification: true });
+
+    await runtime.finishTurn(permit);
+
+    expect(verifier).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proposal: expect.objectContaining({ blockerKind: 'infeasible' }),
+        blockedPolicy: expect.stringContaining(
+          'An infeasible blocker may also be accepted immediately',
+        ),
+      }),
+      expect.any(AbortSignal),
+    );
+    expect(journal.appended.map((payload) => payload.cause)).toEqual([
+      'create',
+      'turn_finished',
+      'verifier_accept',
+      'blocked',
+    ]);
+    expect(runtime.getSnapshot()).toMatchObject({
+      activity: 'idle',
+      goal: {
+        status: 'blocked',
+        lastReason: `The named branch does not exist ${GOAL_INFEASIBLE_NEXT_STEP}`,
+      },
+    });
+    expect(host.started).toHaveLength(1);
   });
 
   it('rejects an invalid evidence reference without calling the verifier', async () => {

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -28,6 +28,7 @@ import {
   GOAL_CHECKPOINT_STALLED_REASON,
   GOAL_DEFAULT_TOKEN_BUDGET,
   GOAL_EVIDENCE_CATALOG_EXHAUSTED_REASON,
+  GOAL_INFEASIBLE_NEXT_STEP,
   GOAL_STATE_VERSION,
   goalTokenBudgetReason,
   isGoalTokenBudgetSpent,
@@ -614,7 +615,7 @@ export function createGoalRuntime(
       ...base,
       proposal: { ...attempt.proposal, status: 'blocked' },
       blockedPolicy:
-        'A blocked Goal is resumable. It may be accepted immediately only when the evidence shows that new user authority or a material user choice is required, or that an external state change is required, and no meaningful in-scope work remains. An ordinary technical blocker requires evidence of the same cause from the current and two immediately preceding Goal turns. Difficulty, uncertainty, incomplete work, or a preference for clarification do not by themselves justify blocked.',
+        'A blocked Goal is resumable. It may be accepted immediately only when the evidence shows that new user authority or a material user choice is required, or that an external state change is required, and no meaningful in-scope work remains. An infeasible blocker may also be accepted immediately, only when cited external_fact evidence shows the objective cannot be satisfied as written: it contradicts itself, it names a target that verifiably does not exist, or it requires an action outside what the tools can perform; reject it when the obstacle is difficulty, uncertainty, information the model could still obtain, or a preference to ask. An ordinary technical blocker requires evidence of the same cause from the current and two immediately preceding Goal turns. Difficulty, uncertainty, incomplete work, or a preference for clarification do not by themselves justify blocked.',
     };
   };
 
@@ -665,7 +666,10 @@ export function createGoalRuntime(
           ...snapshot.goal,
           activeTimeMs: elapsedActiveTime(snapshot.goal, now),
           updatedAt: now,
-          lastReason: outcome.result.reason,
+          lastReason:
+            attempt.proposal.blockerKind === 'infeasible'
+              ? `${outcome.result.reason} ${GOAL_INFEASIBLE_NEXT_STEP}`
+              : outcome.result.reason,
         };
         const acceptedSnapshot: GoalSnapshotV2 = {
           v: GOAL_STATE_VERSION,

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -618,6 +618,16 @@ describe('UpdateGoalTool', () => {
     expect(schema.properties.blockerKind.description).toContain(
       'exact same reason text',
     );
+    expect(
+      (schema.properties.blockerKind as { enum?: string[] }).enum,
+    ).toContain('infeasible');
+    expect(schema.properties.blockerKind.description).toContain(
+      'cannot be satisfied as written',
+    );
+    expect(tool.description).toContain('a tool result, not your own text');
+    expect(tool.description).toContain(
+      'not for difficulty, uncertainty, information you could still obtain',
+    );
   });
 
   it('rejects lineage turn ids before recording a proposal', async () => {

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -23,6 +23,7 @@ import {
 } from './goal-runtime.js';
 import { goalTurnContext } from './goal-turn-context.js';
 import {
+  type GoalBlockerKind,
   GOAL_PROPOSAL_REASON_MAX_CHARACTERS,
   type GoalRecord,
   type GoalSnapshotV2,
@@ -58,7 +59,7 @@ export interface UpdateGoalToolParams {
   status: 'complete' | 'blocked';
   reason: string;
   evidenceRefs: string[];
-  blockerKind?: 'authority' | 'external' | 'repeated';
+  blockerKind?: GoalBlockerKind;
 }
 
 export type GoalToolResult = ToolResult;
@@ -370,7 +371,7 @@ export class UpdateGoalTool extends BaseDeclarativeTool<
     super(
       UpdateGoalTool.Name,
       ToolDisplayNames.UPDATE_GOAL,
-      'Propose that the current Goal is complete or blocked. Before calling, call get_goal in the current turn and cite only values from evidenceCatalog.entries[].uuid, never goalId, turnId, or lineageTurnIds. If completion depends on user-facing content delivered in the current turn, emit only the content required by the objective, then call get_goal, wait for its result, and call update_goal in a later model step with the returned delivered_output UUID. Do not add progress or completion commentary when the objective requires an exact output format. For blocked proposals, use authority when a user or maintainer decision or permission is required, external when an unavailable external resource or capability is evidenced, and repeated for the same evidenced blocker with the exact same reason text across three consecutive Goal turns; omitting blockerKind follows the repeated-blocker audit. Core records at most one proposal for the exact permitted turn and queues eligible proposals for independent verification. This tool never changes the Goal lifecycle or claims a terminal result. Do not tell the user the Goal is complete or blocked. If this tool reports readyForVerification, end the turn without additional user-facing text; otherwise continue the turn without claiming a terminal result. The Goal status card reports the independent verification result.',
+      'Propose that the current Goal is complete or blocked. Before calling, call get_goal in the current turn and cite only values from evidenceCatalog.entries[].uuid, never goalId, turnId, or lineageTurnIds. If completion depends on user-facing content delivered in the current turn, emit only the content required by the objective, then call get_goal, wait for its result, and call update_goal in a later model step with the returned delivered_output UUID. Do not add progress or completion commentary when the objective requires an exact output format. For blocked proposals, use authority when a user or maintainer decision or permission is required, external when an unavailable external resource or capability is evidenced, repeated for the same evidenced blocker with the exact same reason text across three consecutive Goal turns, and infeasible when a cited external_fact (a tool result, not your own text) shows the objective cannot be satisfied as written -- it contradicts itself, names a target that verifiably does not exist, or needs an action no tool can perform; infeasible is not for difficulty, uncertainty, information you could still obtain, or wanting to ask, and its reason must state what was checked and why no in-scope work could satisfy the objective. Omitting blockerKind follows the repeated-blocker audit. Core records at most one proposal for the exact permitted turn and queues eligible proposals for independent verification. This tool never changes the Goal lifecycle or claims a terminal result. Do not tell the user the Goal is complete or blocked. If this tool reports readyForVerification, end the turn without additional user-facing text; otherwise continue the turn without claiming a terminal result. The Goal status card reports the independent verification result.',
       Kind.Think,
       {
         type: 'object',
@@ -397,9 +398,9 @@ export class UpdateGoalTool extends BaseDeclarativeTool<
           },
           blockerKind: {
             type: 'string',
-            enum: ['authority', 'external', 'repeated'],
+            enum: ['authority', 'external', 'repeated', 'infeasible'],
             description:
-              'authority: a user or maintainer decision or permission is required; external: an evidenced external resource or capability is unavailable; repeated: the same evidenced blocker with the exact same reason text across three consecutive Goal turns. Omission uses the repeated-blocker audit.',
+              'authority: a user or maintainer decision or permission is required; external: an evidenced external resource or capability is unavailable; repeated: the same evidenced blocker with the exact same reason text across three consecutive Goal turns; infeasible: a cited external_fact shows the objective cannot be satisfied as written (self-contradictory, names a target that verifiably does not exist, or needs an action no tool can perform) -- not difficulty, uncertainty, or obtainable information. Omission uses the repeated-blocker audit.',
           },
         },
         required: ['status', 'reason', 'evidenceRefs'],


### PR DESCRIPTION
## What this PR does

Adds `blockerKind: 'infeasible'` to Goal terminal proposals, so a Goal whose objective cannot be satisfied as written can stop on the turn that proves it instead of burning until the token budget does. It is not a new status: the Goal settles as `blocked`, which every surface already renders and which resumes into `/goal edit` — the only fix for an objective that cannot hold.

Three rules keep it from becoming an "I think this can't be done" exit. It bypasses the three-turn repetition rule that ordinary technical blockers need — waiting three turns to report an impossibility is the runaway this kind exists to end, and the evidence bar is what earns the early exit. The cited evidence must include an `external_fact` (a tool result): user input can authorise a stop, which is what `authority` is for, but cannot make an objective impossible, and assistant prose saying so is exactly what must not count; like the other immediate blockers it must also cite every newer record so a contradicting fact cannot be omitted. And the verifier policy accepts it only for self-contradiction, a target that verifiably does not exist, or an action outside the tools, and rejects difficulty, uncertainty, obtainable information, or a preference to ask.

An accepted infeasible stop appends a fixed next step to `lastReason` ("edit or replace the Goal with an objective the evidence allows before resuming it"), so the stopped Goal tells the user what to do, not only what went wrong. The `update_goal` tool description and schema mirror the policy so the model learns when the kind applies and what it must cite.

## Why it's needed

Blocked proposals stop immediately only for user authority or an external change; everything else is treated as a repeated technical blocker and must recur with identical reason text on three consecutive turns before the verifier sees it. There was no sanctioned way for the model to say "this cannot be done as stated" that the verifier would honour early, so an impossible objective ran until #9891's budget or a human stopped it. The session that motivated this series spent 34 minutes and 8.6M tokens on an objective ("验证下版本") too under-specified to ever complete. CC's stop evaluator can answer `{ok: false, impossible: true}` and end the loop; this is the counterpart, held to a stricter evidence bar because our verifier judges from cited transcript records, not from the model's own assessment.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/goals/` — 437 tests, 16 files. New: an evidence-validation case (assistant-only or user-only citations are refused with `infeasible_blocker_external_fact_required`; a tool result is accepted with `proofKind: 'external_fact'`; leaving newer evidence uncited is refused like any immediate blocker), a runtime case (an infeasible proposal is `readyForVerification` on its first turn, the verifier receives the infeasible policy sentence, and the accepted Goal is `blocked` with the next step appended to `lastReason`), and tool-schema/description assertions.
- Mutation probes, each run on the three affected suites (194 tests) and each killing exactly one test: route infeasible through the repetition audit; remove the policy sentence; remove the `external_fact` requirement; drop the `lastReason` suffix; remove `'infeasible'` from the schema enum.
- `npx tsc --noEmit` in `packages/core`: 0 errors in `src/goals/`, total identical to the merge base. prettier + eslint clean on the seven changed files. No SDK, webui, web-shell or CLI code enumerates `blockerKind`, so nothing crosses the wire.

### Evidence (Before & After)

N/A (runtime policy; the stop renders through the existing blocked-Goal surfaces). `lastReason` of an accepted infeasible stop, for reference: `<verifier reason> The objective cannot be satisfied as written; edit or replace the Goal with an objective the evidence allows before resuming it.`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

N/A (unit tests only).

## Risk & Scope

- Main risk or tradeoff: a model could over-use `infeasible` to escape hard work. The three rules above are the mitigation — external-fact evidence, full newer-evidence citation, and a verifier policy that names the disqualifiers — and the outcome is `blocked`, which the user can resume or edit, never a silent completion.
- Not validated / out of scope: no change to the blocked-audit fingerprint machinery (infeasible never enters it); no new status, no wire changes; no attempt to detect infeasibility at `/goal set` time — that stays the model's call, judged by the verifier.
- Breaking changes / migration notes: none. `blockerKind` is optional and the new member is additive.

## Linked Issues

- Builds on #9891 (the token budget is the backstop this exit lets a Goal avoid reaching) and #9880 (completion gate).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 Goal 终局提案新增 `blockerKind: 'infeasible'`,让一个「按现有表述无法达成」的 Goal 能在证明这一点的那一轮就停下,而不是烧到 token 预算耗尽。它不是新状态:Goal 落为 `blocked`,所有界面已能渲染,且 resume 的出口就是 `/goal edit`——对一个不可能成立的 objective,这是唯一的修法。

三条规则防止它变成「我觉得做不到」的逃生口。它绕过普通技术性阻塞所需的三轮重复规则——等三轮再报告不可能,正是这个类型要终结的失控,而证据门槛才是换取提前退出的代价。引用的证据必须包含一条 `external_fact`(工具结果):用户输入可以授权停止(那是 `authority` 的用途),但不能让 objective 变得不可能,助手自己说不可能更是绝不能算数;和其他立即阻塞一样,它还必须引用所有更新的记录,以防遗漏相反事实。verifier 策略只在 objective 自相矛盾、指向可验证不存在的目标、或需要工具无法执行的动作时接受,并明确拒绝困难、不确定、可获取的信息、或想要询问这几种情形。

被接受的 infeasible 停止会在 `lastReason` 末尾附加固定的下一步(「编辑或替换 Goal,给出证据允许的 objective,再恢复」),让停止后的 Goal 告诉用户该做什么,而不只是哪里出了问题。`update_goal` 的工具描述与 schema 同步了策略,使模型知道该类型何时适用、必须引用什么。

## 为什么需要

阻塞提案目前只在用户授权或外部变化时立即停止;其余一律视为重复性技术阻塞,必须在连续三轮以完全相同的 reason 文本重现,verifier 才会看到。模型没有任何被认可的方式说出「按现在的表述做不到」并让 verifier 尽早采纳,于是一个不可能的 objective 会一直跑到 #9891 的预算或人工介入。触发本系列的那个 session 在「验证下版本」这种含混到无法完成的 objective 上耗了 34 分钟、860 万 token。CC 的停止评估器可以返回 `{ok: false, impossible: true}` 结束循环;这是对应物,只是证据门槛更严,因为我们的 verifier 依据引用的转录记录判断,而不是模型的自我评估。

## 评审验证计划

### 如何验证

- `cd packages/core && npx vitest run src/goals/`——437 个测试,16 个文件。新增:证据校验用例(仅引用助手或用户记录以 `infeasible_blocker_external_fact_required` 拒绝;工具结果以 `proofKind: 'external_fact'` 接受;遗漏更新证据与其他立即阻塞一样被拒绝)、runtime 用例(infeasible 提案首轮即 `readyForVerification`,verifier 收到 infeasible 策略句,接受后的 Goal 为 `blocked` 且 `lastReason` 附带下一步)、工具 schema/描述断言。
- 变异检验,在三个相关套件(194 个测试)上运行,每个恰好挂一个测试:让 infeasible 走重复审计;删掉策略句;删掉 `external_fact` 要求;去掉 `lastReason` 后缀;从 schema 枚举移除 `'infeasible'`。
- `packages/core` 的 `npx tsc --noEmit`:`src/goals/` 内 0 错,总数与合并基线相同。七个改动文件 prettier + eslint 干净。SDK、webui、web-shell、CLI 均不枚举 `blockerKind`,无线上变更。

### 证据(前后对比)

N/A(运行时策略;停止状态通过现有的 blocked Goal 界面渲染)。被接受的 infeasible 停止的 `lastReason` 形如:`<verifier 理由> The objective cannot be satisfied as written; edit or replace the Goal with an objective the evidence allows before resuming it.`

### 已测试平台

Linux ✅;macOS / Windows ⚠️(CI 覆盖)。

### 环境(可选)

N/A(仅单元测试)。

## 风险与范围

- 主要风险或权衡:模型可能滥用 `infeasible` 逃避困难工作。上述三条规则即是缓解——外部事实证据、完整引用更新证据、点名排除项的 verifier 策略——且结果是 `blocked`,用户可以 resume 或 edit,绝不会静默完成。
- 未验证/范围外:不改动 blocked-audit 指纹机制(infeasible 从不进入它);无新状态、无线上变更;不在 `/goal set` 时尝试检测不可行性——那仍由模型提出、verifier 判断。
- 破坏性变更/迁移说明:无。`blockerKind` 为可选字段,新成员是增量。

## 关联 Issue

- 基于 #9891(token 预算是本退出让 Goal 免于触及的兜底)与 #9880(完成闸门)。

</details>
