### PR TITLE
refactor(core): hold Goal sends to the caller's recursion budget, and say why the other carve-outs stay

### DIFF
--- a/packages/core/src/core/client-goal.test.ts
+++ b/packages/core/src/core/client-goal.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '../config/config.js';
 import type { GeminiChat } from './geminiChat.js';
 import {
@@ -19,6 +19,10 @@ import type {
   GoalStateRecordPayloadV2,
   GoalTurnPermit,
 } from '../goals/goal-protocol.js';
+import {
+  __resetActiveGoalStoreForTests,
+  setActiveGoal,
+} from '../goals/activeGoalStore.js';
 import type { ChatRecord } from '../services/chatRecordingService.js';
 import { ApprovalMode } from '../config/config.js';
 
@@ -1073,5 +1077,86 @@ describe('GeminiClient Goal admission', () => {
     expect(events).not.toContainEqual(
       expect.objectContaining({ type: GeminiEventType.MaxSessionTurns }),
     );
+  });
+
+  afterEach(() => __resetActiveGoalStoreForTests());
+
+  it('admits a runtime Goal turn to steer input at a hit session cap', async () => {
+    // Second half of the session-cap exclusion: runtime Goal turns skip the
+    // count increment (pinned by the 75-turn test above) and must also be
+    // admitted to steer input once the user's own turns hit the cap.
+    const { client } = setupGoalClient();
+    client['sessionTurnCount'] = 1;
+    const getSteerInput = vi.fn().mockResolvedValue(undefined);
+
+    await drain(
+      client.sendMessageStream(
+        [{ text: 'continue' }],
+        new AbortController().signal,
+        'goal-steer-cap',
+        {
+          type: SendMessageType.Goal,
+          goalPermit: permit,
+          goalTurnKey: `goal-runtime:${permit.turnId}`,
+          getSteerInput,
+        },
+      ),
+    );
+
+    expect(getSteerInput).toHaveBeenCalled();
+  });
+
+  it('does not decrement the caller recursion budget inside a legacy hook Goal chain', async () => {
+    // A legacy /goal chain recurses inside one sendMessageStream call. With
+    // the caller budget of 2 preserved at every hop, two blocked stops still
+    // run three model turns; a decremented budget would refuse the third.
+    // Unsupported Goal runtime: the legacy hook chain owns the send, so the
+    // branch under test is the one that keys the budget on the active goal.
+    const { client, config } = setupGoalClient();
+    vi.mocked(config.getGoalRuntimeReady).mockRejectedValue(
+      new GoalPersistenceUnavailableError('legacy-only session'),
+    );
+    vi.mocked(config.getSkipNextSpeakerCheck).mockReturnValue(true);
+    vi.mocked(config.getDisableAllHooks).mockReturnValue(false);
+    vi.mocked(config.getMaxSessionTurns).mockReturnValue(0);
+    vi.mocked(config.hasHooksForEvent).mockImplementation(
+      (event) => event === 'Stop',
+    );
+    let stopRequestCount = 0;
+    const messageBus = {
+      request: vi.fn(async () => {
+        stopRequestCount += 1;
+        if (stopRequestCount <= 2) {
+          return {
+            output: { decision: 'block', reason: 'keep going' },
+            stopHookCount: 1,
+          };
+        }
+        return { output: undefined, stopHookCount: 1 };
+      }),
+    };
+    vi.mocked(config.getMessageBus).mockReturnValue(
+      messageBus as unknown as ReturnType<Config['getMessageBus']>,
+    );
+    setActiveGoal('goal-test-session', {
+      condition: 'ship',
+      iterations: 0,
+      setAt: 1,
+      tokensAtStart: 0,
+      hookId: 'goal-hook:test',
+    });
+
+    await drain(
+      client.sendMessageStream(
+        [{ text: 'start the chain' }],
+        new AbortController().signal,
+        'legacy-goal-chain',
+        undefined,
+        2,
+      ),
+    );
+
+    expect(messageBus.request).toHaveBeenCalledTimes(3);
+    expect(turnMocks.run).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/core/src/core/client-goal.test.ts
+++ b/packages/core/src/core/client-goal.test.ts
@@ -1032,7 +1032,6 @@ describe('GeminiClient Goal admission', () => {
             goalPermit: current,
             goalTurnKey: `goal-runtime:${current.turnId}`,
           },
-          0,
         ),
       );
     }
@@ -1040,5 +1039,39 @@ describe('GeminiClient Goal admission', () => {
     expect(started).toHaveLength(turns + 1);
     expect(turnMocks.run).toHaveBeenCalledTimes(turns);
     expect(client['sessionTurnCount']).toBe(0);
+  });
+
+  it('holds a runtime Goal turn to the caller recursion budget like any other send', async () => {
+    // Each Goal continuation is a fresh top-level send that starts from
+    // MAX_TURNS on its own, so a Goal has no reason to outlive one turn's
+    // recursion allowance. A caller that hands over an exhausted budget gets
+    // the same refusal every other message type gets -- and, because the
+    // turn was admitted, the interrupted-exit path pauses the Goal instead
+    // of leaving it running with a permit nobody will finish.
+    const { client, runtime } = setupGoalClient();
+    turnMocks.run.mockImplementation(async function* () {});
+
+    const events = await collect(
+      client.sendMessageStream(
+        [{ text: 'continue' }],
+        new AbortController().signal,
+        'goal-exhausted',
+        {
+          type: SendMessageType.Goal,
+          goalPermit: permit,
+          goalTurnKey: `goal-runtime:${permit.turnId}`,
+        },
+        0,
+      ),
+    );
+
+    expect(turnMocks.run).not.toHaveBeenCalled();
+    expect(runtime.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'pause' }),
+    );
+    expect(runtime.finishTurn).toHaveBeenCalledOnce();
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ type: GeminiEventType.MaxSessionTurns }),
+    );
   });
 });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -3240,6 +3240,15 @@ export class GeminiClient {
         }
       }
 
+      // A runtime-scheduled Goal turn is not a session turn. `maxSessionTurns`
+      // counts every model call the user's own prompts drive, tool
+      // continuations included; a Goal that reads a few files per
+      // continuation would spend a user-set cap of N in N/4 continuations
+      // and die mid-run with no resume path in headless. Autonomous Goal
+      // spend is bounded by the Goal's own token budget instead (armed at
+      // creation, re-armed only by an explicit resume or edit), and the
+      // headless host excludes runtime Goal turns from the same cap for the
+      // same reason, so counting them here would split the two ceilings.
       if (messageType !== SendMessageType.Retry && !isGoalRuntimeTurn) {
         // Attribution snapshots are recorded on every non-retry turn. File
         // history snapshots are created only at UserQuery boundaries; later
@@ -3288,11 +3297,12 @@ export class GeminiClient {
         }
       }
 
-      // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
-      const boundedTurns =
-        messageType === SendMessageType.Goal
-          ? MAX_TURNS
-          : Math.min(turns, MAX_TURNS);
+      // Ensure turns never exceeds MAX_TURNS to prevent infinite loops. A
+      // runtime Goal turn honours the caller's budget like every other
+      // message type: each continuation is a fresh top-level send that
+      // starts from MAX_TURNS on its own, so nothing about a Goal needs to
+      // outlive one turn's recursion allowance.
+      const boundedTurns = Math.min(turns, MAX_TURNS);
       if (!boundedTurns) {
         this.cancelPendingMemoryPrefetch('no_safe_delivery_point');
         endCurrentInteraction('error', 'max turns exhausted', 'max_turns');
@@ -3310,6 +3320,9 @@ export class GeminiClient {
         ) {
           return undefined;
         }
+        // Same ceiling as the session-turn check above, same exclusion: a
+        // runtime Goal turn does not count toward `maxSessionTurns`, so it
+        // must not be refused steer input on that count either.
         const maxSessionTurns = this.config.getMaxSessionTurns();
         if (
           !isGoalRuntimeTurn &&
@@ -4140,7 +4153,13 @@ export class GeminiClient {
           // these semantics (fresh DaemonToolLoopState per continuation).
           // Runaway protection is preserved: the cap still bounds each
           // iteration, and the chain itself is bounded by
-          // stopHookBlockingCap / MAX_GOAL_ITERATIONS.
+          // stopHookBlockingCap / MAX_GOAL_ITERATIONS. Those are the only
+          // bounds on this path: the legacy hook Goal recurses inside one
+          // sendMessageStream call, so the runtime's token budget (which
+          // meters continuations the Goal runtime schedules) never sees it,
+          // and the recursion budget is not decremented below because a
+          // 50-iteration chain with steer and next-speaker continues would
+          // otherwise exhaust MAX_TURNS before its own iteration cap.
           this.loopDetector.reset(prompt_id);
 
           const activeGoal = getActiveGoal(this.config.getSessionId());


### PR DESCRIPTION
## What this PR does

Audits the places where `client.ts` carves runtime-scheduled Goal turns out of the session ceilings, now that a Goal has its own autonomous spend bound (#9891), and acts on each by its own merits. One exemption goes: a Goal-type send no longer ignores the caller's recursion budget (`turns`) — `boundedTurns` is `Math.min(turns, MAX_TURNS)` for every message type. Three stay, with their comments rewritten to say the real reason they stay rather than the reason that stopped being true when the token budget landed.

| Site | Ceiling it bypasses | Why it was added (#7895) | Verdict | Why |
|---|---|---|---|---|
| `boundedTurns = Goal ? MAX_TURNS : min(turns, MAX_TURNS)` | The per-send recursion budget (`MAX_TURNS` = 100 nested steer / next-speaker / hook continuations) | Goal turns should run "beyond the former fixed limit" regardless of what the caller passed | **Removed** | Every runtime continuation is a fresh top-level send that starts from `MAX_TURNS` on its own; no production caller passes `turns` for a Goal send (TUI and headless both use the default; ACP does not go through `client.sendMessageStream` at all). The carve-out only ever mattered for a caller handing over an exhausted budget, and for that caller a Goal should be refused like everything else — which it now is, and the interrupted-exit path pauses the Goal instead of leaving it running with a permit nobody will finish. |
| `if (messageType !== Retry && !isGoalRuntimeTurn)` — `sessionTurnCount++` and the `max_session_turns` check | `maxSessionTurns` (user-set, default unlimited) | "runtime-scheduled Goal turns … without session budgets" | **Retained**, comment rewritten | `sessionTurnCount` increments on every model call the user's prompts drive, tool continuations included. Counting Goal turns would let a user cap of N kill a healthy Goal after roughly N/4 continuations, with no resume path in headless (exit 53). The Goal's spend is bounded by its own token budget, re-armed only by an explicit resume or edit; and the headless host already excludes runtime Goal turns from the same cap (`enforceSessionTurnLimit(isRuntimeGoalTurn)`), so counting them here would split the two ceilings. |
| `takeSteerInput`: `!isGoalRuntimeTurn && sessionTurnCount >= maxSessionTurns` | Same ceiling, applied to steer admission | Consistency with the row above | **Retained**, comment added | A turn that does not count toward the cap must not be refused steer input on that count. Stands or falls with the row above. |
| Legacy hook Goal: `hookTurnBudget = activeGoal ? boundedTurns : boundedTurns - 1` | The recursion budget again, for the pre-runtime stop-hook Goal chain | "bounded by stopHookBlockingCap / MAX_GOAL_ITERATIONS" | **Retained**, comment extended | This chain recurses inside one `sendMessageStream` call, so the runtime's token budget — which meters continuations the Goal *runtime* schedules — never sees it. Its bounds are `MAX_GOAL_ITERATIONS` (50) and `stopHookBlockingCap` (8, pauses the Goal); a 50-iteration chain with steer and next-speaker continues would exhaust `MAX_TURNS` before its own cap, so decrementing here would trade one runaway guard for a new way to kill a legitimate run. |

Two further goal-runtime carve-outs in this file are not ceilings and are untouched: the hook-re-entry microcompaction checkpoint and the managed auto-memory background tasks are skipped for runtime turns. Neither has anything to do with budget; they are noted here so the next reader does not mistake them for the four above.

## Why it's needed

The series plan recorded these as "the `client.ts` goal-turn ceiling exemptions to remove once a budget exists" (#9891 is that budget). Read one by one they are not one thing: one is a recursion budget the Goal had no reason to ignore, two are a user-set session cap whose semantics (every model call counts) would make Goals unusable under it, and one guards a legacy path the token budget cannot reach. Removing all four on the strength of "there is a budget now" would have regressed the two user-visible ones. The value of this PR is as much the recorded reasoning as the one-line removal: every remaining exemption now carries the reason it actually stays.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/core/client.test.ts src/core/client-goal.test.ts src/goals/` — 18 files, 824 tests. New case: `holds a runtime Goal turn to the caller recursion budget like any other send` (a Goal send with `turns = 0` does not run the model, pauses the Goal through the interrupted-exit path, and finishes the permit). The existing 75-turn runtime test no longer passes `0` as the budget — it was only ever passing because of the carve-out this PR removes; with the default budget it still runs all 75 turns and still leaves `sessionTurnCount` at 0, which pins the retained session-turn exclusion.
- Mutation probe: re-adding `messageType === SendMessageType.Goal ? MAX_TURNS : …` fails exactly the new test (22 others green); restored, 23/23.
- `npx tsc --noEmit` in `packages/core`: 32 errors with and without the diff (pre-existing dependency skew outside this change, verified by exporting the diff, checking out the pristine files, and re-applying — no `git stash`). prettier + eslint clean on both files.

### Evidence (Before & After)

N/A (no user-visible change for any production caller; the only behavioral change is for a caller passing an exhausted `turns` budget to a Goal send, which none does).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

N/A (unit tests only).

## Risk & Scope

- Main risk or tradeoff: retaining the `maxSessionTurns` exclusion means a user who sets a session-turn cap still sees Goals run past it. That is deliberate and now documented at the site: the Goal is bounded by its own token budget, and the headless host applies the same exclusion, so the alternative is two ceilings that disagree. If the project later wants Goals under the session cap, the right shape is a per-spend-window count reset on resume, not this exclusion's removal.
- Not validated / out of scope: the headless host's own `enforceSessionTurnLimit` exclusion (mirrors the retained one; untouched). The attribution-snapshot and auto-memory carve-outs for runtime turns (not ceilings; noted above). ACP, which drives `GeminiChat` directly and never passes through these checks.
- Breaking changes / migration notes: none.

## Linked Issues

- Depends on #9891 (the token budget that makes the audit possible).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

审计 `client.ts` 中把运行时调度的 Goal 轮次排除在会话上限之外的各处豁免——现在 Goal 已经有了自己的自主消费边界(#9891)——并逐一按各自的理由处理。撤掉一处:Goal 类型的发送不再忽略调用方给的递归预算(`turns`),`boundedTurns` 对所有消息类型统一为 `Math.min(turns, MAX_TURNS)`。保留三处,并重写注释,写明它们真正保留的理由,而不是那个在 token 预算落地后已不再成立的理由。

| 位置 | 绕过的上限 | 当初为何加入(#7895) | 结论 | 理由 |
|---|---|---|---|---|
| `boundedTurns = Goal ? MAX_TURNS : min(turns, MAX_TURNS)` | 单次发送的递归预算(`MAX_TURNS` = 100 层嵌套的 steer / next-speaker / hook 续跑) | Goal 轮次应「超越旧的固定上限」运行,不管调用方传了什么 | **撤掉** | 每次运行时续跑都是一次全新的顶层发送,自己从 `MAX_TURNS` 起步;生产中没有任何调用方给 Goal 发送传 `turns`(TUI 和 headless 都用默认值;ACP 根本不经过 `client.sendMessageStream`)。这个豁免只对「调用方递交一个已耗尽预算」的情形有意义,而这种情形下 Goal 应该和其他类型一样被拒绝——现在正是如此,并且中断退出路径会暂停 Goal,而不是让它带着一个无人完成的 permit 继续「运行」。 |
| `if (messageType !== Retry && !isGoalRuntimeTurn)`——`sessionTurnCount++` 与 `max_session_turns` 检查 | `maxSessionTurns`(用户设定,默认不限) | 「运行时调度的 Goal 轮次……不受会话预算约束」 | **保留**,重写注释 | `sessionTurnCount` 对用户提示驱动的每一次模型调用递增,含工具续跑。若把 Goal 轮次计入,用户设的上限 N 会让一个健康的 Goal 在大约 N/4 次续跑后中途死亡,而 headless 中没有恢复路径(退出码 53)。Goal 的消费由它自己的 token 预算约束,且只能由显式的 resume 或 edit 重新武装;headless host 已经把运行时 Goal 轮次排除在同一上限之外(`enforceSessionTurnLimit(isRuntimeGoalTurn)`),在这里计入会让两处上限分裂。 |
| `takeSteerInput`:`!isGoalRuntimeTurn && sessionTurnCount >= maxSessionTurns` | 同一上限,作用于 steer 准入 | 与上一行保持一致 | **保留**,补注释 | 不计入上限的轮次也不能因该计数被拒绝 steer 输入。与上一行同进退。 |
| 旧版 hook Goal:`hookTurnBudget = activeGoal ? boundedTurns : boundedTurns - 1` | 同样是递归预算,针对 runtime 之前的 stop-hook Goal 链 | 「受 stopHookBlockingCap / MAX_GOAL_ITERATIONS 约束」 | **保留**,扩展注释 | 这条链在单次 `sendMessageStream` 调用内递归,而 runtime 的 token 预算只计量 Goal *runtime* 调度的续跑,永远看不到它。它的边界是 `MAX_GOAL_ITERATIONS`(50)和 `stopHookBlockingCap`(8,会暂停 Goal);一条 50 次迭代、带 steer 与 next-speaker 续跑的链会在触及自己的上限之前先耗尽 `MAX_TURNS`,所以在这里递减等于用一种新的杀死合法运行的方式换掉一个失控防护。 |

本文件中还有两处针对 goal-runtime 的豁免不是上限,未改动:hook 重入时的 microcompaction 检查点,以及托管自动记忆的后台任务,对运行时轮次都会跳过。二者与预算无关;在此注明,以免下一位读者把它们误认为上述四处之一。

## 为什么需要

系列计划把这些记录为「预算落地后要撤掉的 `client.ts` goal 轮次上限豁免」(#9891 就是那个预算)。逐一读过之后它们并不是同一件事:一处是 Goal 没有理由忽略的递归预算,两处是一个用户设定的会话上限、其语义(每次模型调用都计数)会让 Goal 在其下无法使用,还有一处守护着 token 预算触及不到的旧路径。仅凭「现在有预算了」就全部撤掉,会让其中两处用户可见的行为倒退。本 PR 的价值既在于那一行删除,更在于记录下来的推理:每一处保留的豁免现在都写明了它真正保留的原因。

## 评审验证计划

### 如何验证

- `cd packages/core && npx vitest run src/core/client.test.ts src/core/client-goal.test.ts src/goals/`——18 个文件,824 个测试。新增用例:`holds a runtime Goal turn to the caller recursion budget like any other send`(`turns = 0` 的 Goal 发送不会调用模型,通过中断退出路径暂停 Goal,并完成 permit)。原有的 75 轮运行时测试不再传 `0` 作为预算——它此前之所以能过,只是因为本 PR 撤掉的这个豁免;改用默认预算后它仍跑完全部 75 轮,`sessionTurnCount` 仍为 0,这固定住了保留下来的会话轮次排除。
- 变异检验:重新加回 `messageType === SendMessageType.Goal ? MAX_TURNS : …`,恰好挂新测试(其余 22 绿);恢复后 23/23。
- `packages/core` 的 `npx tsc --noEmit`:有无 diff 均为 32 个错误(本变更之外的已有依赖偏差,通过导出 diff、检出原始文件、再重新应用来验证——未使用 `git stash`)。两个文件 prettier + eslint 干净。

### 证据(前后对比)

N/A(对任何生产调用方都没有用户可见的变化;唯一的行为变化针对给 Goal 发送传入已耗尽 `turns` 预算的调用方,而现实中没有这样的调用方)。

### 已测试平台

Linux ✅;macOS / Windows ⚠️(CI 覆盖)。

### 环境(可选)

N/A(仅单元测试)。

## 风险与范围

- 主要风险或权衡:保留 `maxSessionTurns` 排除意味着设置了会话轮次上限的用户仍会看到 Goal 超出该上限运行。这是刻意的并已在现场注明:Goal 由自己的 token 预算约束,headless host 也采用同样的排除,否则就是两个互相矛盾的上限。如果项目日后希望 Goal 受会话上限约束,正确的形态是按消费窗口计数并在 resume 时重置,而不是撤掉这个排除。
- 未验证/范围外:headless host 自己的 `enforceSessionTurnLimit` 排除(与保留的那处一致;未改动)。运行时轮次的 attribution snapshot 与自动记忆豁免(不是上限;上文已注明)。ACP 直接驱动 `GeminiChat`,从不经过这些检查。
- 破坏性变更/迁移说明:无。

## 关联 Issue

- 依赖 #9891(使本次审计成为可能的 token 预算)。

</details>
