### PR TITLE
chore(cua-driver): bump SDK to 0.20.1

### DIFF
--- a/packages/cua-driver/rust/Cargo.lock
+++ b/packages/cua-driver/rust/Cargo.lock
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-bindgen"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "cbindgen",
  "uniffi",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-contract"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "schemars",
  "serde",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-core"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1064,7 +1064,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-sdk"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "core-foundation",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-testkit"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "core-foundation",
  "libc",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "cua-driver-uia"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "cua-driver-core",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-overlay"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "cua-driver-contract",
@@ -1132,7 +1132,7 @@ dependencies = [
 
 [[package]]
 name = "cursor-theme-cli"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "cursor-overlay",
@@ -2900,7 +2900,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pip-preview"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2960,7 +2960,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platform-linux"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "platform-macos"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "platform-windows"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/packages/cua-driver/rust/Cargo.toml
+++ b/packages/cua-driver/rust/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 authors = ["trycua"]
 license = "MIT"

--- a/packages/cua-driver/rust/Skills/cua-driver/SKILL.md
+++ b/packages/cua-driver/rust/Skills/cua-driver/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cua-driver
 description: Drive a native GUI app (macOS, Windows, Linux) via the Qwen Cua Driver CLI (default) or MCP server; snapshot its accessibility tree, act through snapshot-bound element tokens, native menu paths, exact window geometry, or pixel coordinates, and verify from fresh state. Use when the user asks you to operate, drive, automate, or perform a GUI task in a real application on the host.
-version: 0.20.0 # x-release-please-version
+version: 0.20.1 # x-release-please-version
 metadata:
   openclaw:
     requires:

--- a/packages/cua-driver/typescript/package-lock.json
+++ b/packages/cua-driver/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/cua-sdk",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/cua-sdk",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/cua-driver/typescript/package.json
+++ b/packages/cua-driver/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/cua-sdk",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Typed CUA Driver SDK and Computer Use API for Node.js",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What this PR does

Bumps the CUA Driver Rust workspace and `@qwen-code/cua-sdk` package version from 0.20.0 to 0.20.1 so the merged Windows sandbox runtime fixes can be published as a new immutable release.

## Why it's needed

The 0.20.0 npm package and GitHub release cannot be overwritten. RecreationBench needs a published package that includes the Windows delegated-client named-pipe authorization and secondary-action schema fixes merged in #10120.

## Reviewer Test Plan

### How to verify

Confirm the Rust workspace, lockfile, skill metadata, npm manifest, and npm lockfile all report 0.20.1. The CUA release workflow should accept 0.20.1 without a version mismatch.

### Evidence (Before & After)

N/A (release metadata only).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

`cargo fmt --all -- --check`; `cargo test --locked -p cua-driver --bin qwen-cua-driver` (164 passed); `npm test` in the SDK package (22 passed).

## Risk & Scope

- Main risk or tradeoff: release metadata must remain synchronized across Rust, skill, and npm manifests.
- Not validated / out of scope: production publication is performed by the protected release workflow after merge.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up release for #10120.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

将 CUA Driver Rust workspace 和 `@qwen-code/cua-sdk` 包版本从 0.20.0 提升到 0.20.1，以便把已经合并的 Windows 沙箱运行时修复发布为新的不可变版本。

## 为什么需要

已有的 0.20.0 npm 包和 GitHub Release 不能覆盖。RecreationBench 需要一个包含 #10120 已合并 Windows 委托客户端命名管道授权和次级动作 schema 修复的已发布包。

## Reviewer Test Plan

### 如何验证

确认 Rust workspace、lockfile、skill 元数据、npm manifest 和 npm lockfile 都是 0.20.1。CUA 发布 workflow 应能接受 0.20.1，且不会报告版本不一致。

### 证据（修改前后）

N/A（仅发布元数据）。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

运行了 `cargo fmt --all -- --check`；`cargo test --locked -p cua-driver --bin qwen-cua-driver`（164 passed）；SDK 包内 `npm test`（22 passed）。

## 风险与范围

- 主要风险或权衡：Rust、skill 和 npm manifest 的发布版本必须保持同步。
- 未验证或超出范围：生产发布在合并后由受保护的 release workflow 执行。
- 破坏性变更或迁移说明：无。

## 关联 Issue

#10120 的后续发布。

</details>
