### PR TITLE
fix(cli): bound the goal-runtime startup wait and skip the no-op Bun memory relaunch

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -148,9 +148,9 @@ export function validateDnsResolutionOrder(
 function getNodeMemoryArgs(isDebugMode: boolean): string[] {
   // Bun accepts --max-old-space-size but it is a no-op (Bun's heap limit
   // starts small and adapts dynamically instead of honouring the flag).
-  // Relaunching just to apply a flag that does nothing wastes a process hop
-  // (autoConfigureMemory users would relaunch on every startup), so skip the
-  // memory-flag relaunch entirely under Bun.
+  // The one-process relaunch below happens unconditionally, so under Bun
+  // this only stops forwarding a flag that does nothing into the
+  // relaunch/sandbox child.
   if ('bun' in process.versions) {
     return [];
   }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -146,6 +146,15 @@ export function validateDnsResolutionOrder(
 }
 
 function getNodeMemoryArgs(isDebugMode: boolean): string[] {
+  // Bun accepts --max-old-space-size but it is a no-op (Bun's heap limit
+  // starts small and adapts dynamically instead of honouring the flag).
+  // Relaunching just to apply a flag that does nothing wastes a process hop
+  // (autoConfigureMemory users would relaunch on every startup), so skip the
+  // memory-flag relaunch entirely under Bun.
+  if ('bun' in process.versions) {
+    return [];
+  }
+
   const totalMemoryMB = os.totalmem() / (1024 * 1024);
   const heapStats = v8.getHeapStatistics();
   const currentMaxOldSpaceSizeMb = Math.floor(

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -967,7 +967,15 @@ export const AppContainer = (props: AppContainerProps) => {
         );
       }
       setStartupWarnings((currentWarnings) =>
-        mergeStartupWarnings(currentWarnings, config.getWarnings()),
+        mergeStartupWarnings(
+          currentWarnings,
+          goalRuntimeReady
+            ? config.getWarnings()
+            : [
+                ...config.getWarnings(),
+                `Goal features are degraded: the goal runtime did not settle within ${GOAL_RUNTIME_STARTUP_TIMEOUT_MS}ms at startup.`,
+              ],
+        ),
       );
       profileCheckpoint('config_initialize_end');
       setConfigInitialized(true);

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -266,6 +266,10 @@ import {
 import { MAIN_CONTENT_HEIGHT_RESERVATION } from './utils/layoutUtils.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
+// Startup gate for the goal runtime: under session-writer lease contention
+// getGoalRuntimeReady() can stay pending forever; bound it so the command
+// registry still loads and the TUI stays usable (see waitForGoalRuntime).
+const GOAL_RUNTIME_STARTUP_TIMEOUT_MS = 5_000;
 const debugLogger = createDebugLogger('APP_CONTAINER');
 
 export function isRenderModeToggleKey(key: Key): boolean {
@@ -947,7 +951,21 @@ export const AppContainer = (props: AppContainerProps) => {
       // handled by the global catch.
       profileCheckpoint('config_initialize_start');
       await config.initialize();
-      await waitForGoalRuntime(config);
+      // Bound the goal-runtime gate: under session-writer lease contention
+      // (a crashed/sibling process holding the lease) getGoalRuntimeReady()
+      // never settles, which used to hang startup here and leave the command
+      // registry empty — every slash command, even /quit, came back
+      // "Unknown command". After the timeout we proceed with goal features
+      // degraded rather than an unusable TUI.
+      const goalRuntimeReady = await waitForGoalRuntime(config, {
+        timeoutMs: GOAL_RUNTIME_STARTUP_TIMEOUT_MS,
+      });
+      if (!goalRuntimeReady) {
+        debugLogger.warn(
+          `Goal runtime did not settle within ${GOAL_RUNTIME_STARTUP_TIMEOUT_MS}ms ` +
+            '(session writer lease contention?); continuing with goal features degraded.',
+        );
+      }
       setStartupWarnings((currentWarnings) =>
         mergeStartupWarnings(currentWarnings, config.getWarnings()),
       );

--- a/packages/cli/src/ui/utils/goal-runtime.test.ts
+++ b/packages/cli/src/ui/utils/goal-runtime.test.ts
@@ -4,22 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, vi } from 'vitest';
-import { GoalPersistenceUnavailableError } from '@qwen-code/qwen-code-core';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+  GoalPersistenceUnavailableError,
+  type GoalRuntime,
+} from '@qwen-code/qwen-code-core';
 import {
   shouldDisplayGoalStateCause,
   waitForGoalRuntime,
 } from './goal-runtime.js';
 
 describe('waitForGoalRuntime', () => {
+  afterEach(() => vi.useRealTimers());
+
   it('allows Goal-less sessions when persistence is disabled', async () => {
     const getGoalRuntimeReady = vi
       .fn()
       .mockRejectedValue(new GoalPersistenceUnavailableError());
 
-    await expect(
-      waitForGoalRuntime({ getGoalRuntimeReady }),
-    ).resolves.toBeUndefined();
+    await expect(waitForGoalRuntime({ getGoalRuntimeReady })).resolves.toBe(
+      true,
+    );
     expect(getGoalRuntimeReady).toHaveBeenCalledTimes(1);
   });
 
@@ -30,6 +35,45 @@ describe('waitForGoalRuntime', () => {
     await expect(waitForGoalRuntime({ getGoalRuntimeReady })).rejects.toBe(
       failure,
     );
+  });
+
+  it('resolves true once the runtime settles within the timeout', async () => {
+    const getGoalRuntimeReady = vi.fn().mockResolvedValue({});
+    await expect(
+      waitForGoalRuntime({ getGoalRuntimeReady }, { timeoutMs: 100 }),
+    ).resolves.toBe(true);
+  });
+
+  it('proceeds (false) instead of hanging when the runtime never settles', async () => {
+    vi.useFakeTimers();
+    // A promise that never resolves — the lease-contention hang.
+    const getGoalRuntimeReady = vi.fn(() => new Promise<GoalRuntime>(() => {}));
+    const pending = waitForGoalRuntime(
+      { getGoalRuntimeReady },
+      { timeoutMs: 50 },
+    );
+    await vi.advanceTimersByTimeAsync(60);
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it('a late rejection after timeout does not become unhandled', async () => {
+    vi.useFakeTimers();
+    let reject!: (err: Error) => void;
+    const getGoalRuntimeReady = vi.fn(
+      () =>
+        new Promise<GoalRuntime>((_resolve, rej) => {
+          reject = rej;
+        }),
+    );
+    const pending = waitForGoalRuntime(
+      { getGoalRuntimeReady },
+      { timeoutMs: 10 },
+    );
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(pending).resolves.toBe(false);
+    // Reject after the timeout won; the race must have a handler attached.
+    reject(new Error('late'));
+    await vi.advanceTimersByTimeAsync(10);
   });
 
   it('keeps turn and verifier bookkeeping out of scrollback', () => {

--- a/packages/cli/src/ui/utils/goal-runtime.ts
+++ b/packages/cli/src/ui/utils/goal-runtime.ts
@@ -35,12 +35,52 @@ export function shouldDisplayGoalStateCause(cause: GoalStateCause): boolean {
   }
 }
 
+/**
+ * Awaits the goal runtime becoming ready.
+ *
+ * `getGoalRuntimeReady()` can stay pending indefinitely when the session
+ * writer lease is contended (a crashed/sibling process holding the lease),
+ * which previously hung the ink startup gate forever — the command registry
+ * was never populated and EVERY slash command, including `/quit`, reported
+ * "Unknown command". `timeoutMs` bounds that wait: after the timeout the
+ * gate proceeds so the UI stays usable (goal features degrade rather than
+ * blocking the whole CLI). Pass no timeout for the original unbounded
+ * semantics.
+ *
+ * Resolves `true` when the runtime settled (or persistence is unavailable,
+ * which is treated as settled), `false` when the timeout fired first.
+ */
 export async function waitForGoalRuntime(
   config: Pick<Config, 'getGoalRuntimeReady'>,
-): Promise<void> {
+  options: { timeoutMs?: number } = {},
+): Promise<boolean> {
+  const ready = config.getGoalRuntimeReady();
+  const awaitReady = async (): Promise<void> => {
+    try {
+      await ready;
+    } catch (error) {
+      if (!(error instanceof GoalPersistenceUnavailableError)) throw error;
+    }
+  };
+
+  const { timeoutMs } = options;
+  if (timeoutMs == null || timeoutMs <= 0) {
+    await awaitReady();
+    return true;
+  }
+
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), timeoutMs);
+    // The timeout must not keep the process alive on its own.
+    timer.unref?.();
+  });
   try {
-    await config.getGoalRuntimeReady();
-  } catch (error) {
-    if (!(error instanceof GoalPersistenceUnavailableError)) throw error;
+    // Promise.race keeps a handler on the losing promise too, so a late
+    // rejection of the goal-runtime promise cannot become unhandled.
+    const winner = await Promise.race([awaitReady(), timeout]);
+    return winner !== 'timeout';
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }


### PR DESCRIPTION
## What this PR does

Two small startup-path robustness fixes on the default (ink) renderer path. First, the goal-runtime readiness wait at startup is now bounded by a 5-second timeout; when the runtime cannot settle in time the TUI continues with goal features degraded instead of hanging. Second, the automatic memory-flag relaunch is skipped entirely under Bun, where the flag has no effect.

## Why it's needed

The goal runtime signals readiness through a session-writer lease. When the lease is contended — a crashed or sibling process still holding it — the readiness promise never settles, and startup blocks before the command registry is populated. The result is a TUI where every slash command, including `/quit`, answers "Unknown command" and the only escape is killing the process. Bounding the wait trades degraded goal features for a usable CLI, which is the strictly better outcome for the user. Separately, Bun accepts `--max-old-space-size` but ignores it (its heap limit starts small and adapts dynamically), so the memory-configuration relaunch under Bun only wastes a process hop on every startup.

Both fixes are extracted from the OpenTUI migration work (#8677), where they were reviewed and regression-tested; they land here standalone because they benefit the current ink renderer immediately and carry no dependency on the migration batches tracked in #8662.

## Reviewer Test Plan

### How to verify

1. The timeout path is covered by three new unit tests (timeout fires on a never-settling promise; normal settle still returns true; a late rejection after the timeout cannot become unhandled). Run: `cd packages/cli && npx vitest run src/ui/utils/goal-runtime.test.ts src/ui/AppContainer.test.tsx src/gemini.test.tsx` — 239 tests pass.
2. The other two call sites of the wait helper (branch/resume commands) pass no timeout and keep the original unbounded semantics; the signature change is backwards compatible (`Promise<boolean>` return may be ignored).
3. Reproducing the hang manually requires holding the session-writer lease with a crashed sibling process; the unit test simulates the same never-settling promise instead.

### Evidence (Before & After)

N/A (no user-visible rendering change; behavior change is only on the previously-hung path, where the CLI now starts with goal features degraded and logs a warning)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npm run build`, `npm run typecheck`, unit tests under Node 22.23.1.

## Risk & Scope

- Main risk or tradeoff: under genuine lease contention the startup gate now proceeds after 5s with goal features degraded instead of hanging forever; a debug warning marks the degraded path.
- Not validated / out of scope: the branch/resume command wait paths remain unbounded by design (user-initiated waits, different UX); Bun behavior verified by code inspection of Bun's flag handling, not a Bun E2E run.
- Breaking changes / migration notes: none.

## Linked Issues

Part of the incremental landing tracked in #8662 (originally scheduled with the renderer-activation batch; pulled forward because both fixes benefit the ink renderer directly).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

两个启动路径上的健壮性小修复，都在默认（ink）渲染器路径上。其一，启动时等待 goal runtime 就绪增加 5 秒超时上限：超时后 TUI 以 goal 功能降级的方式继续启动，而不是永久挂起。其二，在 Bun 下完全跳过内存参数重启流程，因为该参数在 Bun 下无效。

## 为什么需要

goal runtime 通过 session-writer 租约通知就绪状态。当租约被争用——例如崩溃的或并行的兄弟进程仍持有租约——就绪 promise 永不落定，启动会卡在命令注册表填充之前。结果就是整个 TUI 里所有斜杠命令（包括 `/quit`）都返回 "Unknown command"，唯一出路是杀进程。给等待设上限，是用 goal 功能降级换取可用的 CLI，对用户是严格更优的结果。另外，Bun 接受 `--max-old-space-size` 但实际忽略它（其堆上限从很小起步并动态自适应），所以 Bun 下的内存配置重启每次启动都白白浪费一次进程跳转。

两个修复都提取自 OpenTUI 迁移工作（#8677），在那里已经过评审和回归测试；这里单独落地，因为它们立即惠及当前的 ink 渲染器，且不依赖 #8662 跟踪的任何迁移批次。

## 评审测试计划

### 如何验证

1. 超时路径由三个新增单测覆盖（永不落定的 promise 触发超时；正常就绪仍返回 true；超时后的迟到 reject 不会变成 unhandled rejection）。运行：`cd packages/cli && npx vitest run src/ui/utils/goal-runtime.test.ts src/ui/AppContainer.test.tsx src/gemini.test.tsx`——239 个测试通过。
2. 等待 helper 的另外两个调用点（branch/resume 命令）不传超时，保持原有无界语义；签名变更向后兼容（`Promise<boolean>` 返回值可忽略）。
3. 手工复现挂起需要用崩溃的兄弟进程持有 session-writer 租约；单测用等价的永不落定 promise 模拟了同样场景。

### 前后对比证据

N/A（无用户可见渲染变化；行为变化只发生在原先挂起的路径上——现在 CLI 会以 goal 功能降级启动并打印一条 warning 日志）

### 测试环境

|   操作系统   | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node 22.23.1 下的 `npm run build`、`npm run typecheck`、单元测试。

## 风险与范围

- 主要风险或权衡：真正的租约争用下，启动门禁现在会在 5 秒后以 goal 功能降级继续，而不是永久挂起；降级路径有 debug warning 标记。
- 未验证 / 范围外：branch/resume 命令的等待路径按设计保持无界（用户主动发起的等待，UX 语义不同）；Bun 行为依据其对标志的处理方式做了代码走查，未做 Bun E2E 运行。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

属于 #8662 跟踪的增量落地的一部分（原计划随 renderer-activation 批次落地；因两个修复都直接惠及 ink 渲染器而提前）。

</details>
