### PR TITLE
fix(node-repl): make package verification idempotent

### DIFF
--- a/packages/node-repl/scripts/verify-package.mjs
+++ b/packages/node-repl/scripts/verify-package.mjs
@@ -104,15 +104,36 @@ if (tarballs.length !== 1 || tarballs[0] !== packed.filename) {
     `expected exactly one Node REPL tarball, found ${tarballs.join(', ')}`,
   );
 }
-run('npm', [
-  'publish',
-  tarball,
-  '--dry-run',
-  '--access',
-  'public',
-  '--json',
-  `--registry=${npmRegistry}`,
-]);
+const remoteIntegrityResult = spawnSync(
+  'npm',
+  [
+    'view',
+    `${packed.name}@${packed.version}`,
+    'dist.integrity',
+    `--registry=${npmRegistry}`,
+  ],
+  { cwd: packageRoot, encoding: 'utf8', stdio: 'pipe' },
+);
+if (remoteIntegrityResult.error) throw remoteIntegrityResult.error;
+const remoteIntegrity =
+  remoteIntegrityResult.status === 0 ? remoteIntegrityResult.stdout.trim() : '';
+if (remoteIntegrity) {
+  if (remoteIntegrity !== packed.integrity) {
+    throw new Error(
+      `${packed.name}@${packed.version} already exists with different integrity`,
+    );
+  }
+} else {
+  run('npm', [
+    'publish',
+    tarball,
+    '--dry-run',
+    '--access',
+    'public',
+    '--json',
+    `--registry=${npmRegistry}`,
+  ]);
+}
 
 const consumer = mkdtempSync(path.join(tmpdir(), 'qwen-node-repl-consumer-'));
 const textOf = (result) =>


### PR DESCRIPTION
## What this PR does

Makes standalone Node REPL package verification idempotent when the same immutable version is already published. The verifier now compares the packed tarball integrity with the registry copy and skips `npm publish --dry-run` only when they match; a mismatch still fails, and an unpublished version still exercises the publish dry-run path.

## Why it's needed

The CUA 0.20.1 release dry-run failed after all 148 Node REPL tests and smoke checks passed because npm 11 rejects `npm publish --dry-run` for the already published Node REPL 0.1.0 version. The production publish step already has the same immutable-integrity behavior, so package verification must be repeatable too.

## Reviewer Test Plan

### How to verify

Run the package verifier with npm 11.19.0 while `@qwen-code/node-repl-mcp@0.1.0` exists on the public registry. It should pack and clean-install the package, confirm the exact published integrity, and exit successfully without attempting to overwrite the version.

### Evidence (Before & After)

Before: release dry-run 32955392148 failed with `You cannot publish over the previously published versions: 0.1.0`. After: the same verifier completed successfully with npm 11.19.0 and produced integrity `sha512-ZAl0jyjQAH854In5ewit4TMA6KfuPp8xgiUiuv051Tj/hfPg4V9npPJaHEeIsP0Fbbn+xVrakB2UOqiW1DmBVg==`, matching the registry.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Node REPL unit tests: 148 passed. TypeScript typecheck passed. Exact package verification passed with npm 11.19.0 against the public npm registry.

## Risk & Scope

- Main risk or tradeoff: package verification now queries registry integrity before deciding whether publish dry-run is applicable.
- Not validated / out of scope: no package version or package contents change; production publication remains in the protected release workflow.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to the CUA 0.20.1 release dry-run.

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

让独立 Node REPL 包在同一个不可变版本已经发布时仍可重复验证。验证器现在会比较本地打包 tarball 与 npm 远端包的 integrity；一致时跳过 `npm publish --dry-run`，不一致时仍然失败，未发布版本仍执行 publish dry-run。

## 为什么需要

CUA 0.20.1 release dry-run 中，Node REPL 的 148 个测试和所有 smoke 检查都已通过，但 npm 11 会拒绝对已发布的 Node REPL 0.1.0 再执行 `npm publish --dry-run`。正式 publish step 已经使用相同的不可变 integrity 逻辑，因此 package verification 也必须可以重复执行。

## Reviewer Test Plan

### 如何验证

在公共 registry 已存在 `@qwen-code/node-repl-mcp@0.1.0` 时，使用 npm 11.19.0 运行 package verifier。它应完成打包和 clean install，确认远端 integrity 完全一致并成功退出，不尝试覆盖已有版本。

### 证据（修改前后）

修改前：release dry-run 32955392148 失败并报告 `You cannot publish over the previously published versions: 0.1.0`。修改后：相同 verifier 使用 npm 11.19.0 成功完成，产出的 integrity 为 `sha512-ZAl0jyjQAH854In5ewit4TMA6KfuPp8xgiUiuv051Tj/hfPg4V9npPJaHEeIsP0Fbbn+xVrakB2UOqiW1DmBVg==`，与 registry 一致。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node REPL 单元测试 148 passed；TypeScript typecheck 通过；使用 npm 11.19.0 对公共 npm registry 的真实 package verification 通过。

## 风险与范围

- 主要风险或权衡：package verification 会先查询 registry integrity，再决定 publish dry-run 是否适用。
- 未验证或超出范围：不修改包版本或包内容；正式发布仍由受保护的 release workflow 执行。
- 破坏性变更或迁移说明：无。

## 关联 Issue

CUA 0.20.1 release dry-run 的后续修复。

</details>
