### PR TITLE
fix(acp-bridge): Reap ACP child process trees

### DIFF
--- a/docs/design/acp-child-process-tree-reaping.md
+++ b/docs/design/acp-child-process-tree-reaping.md
@@ -1,0 +1,333 @@
+# ACP child process tree reaping
+
+Status: implemented for PR2
+
+Proposed PR title: `fix(acp-bridge): Reap ACP child process trees`
+
+## Problem
+
+`createSpawnChannelFactory()` starts each `qwen --acp` process without an
+isolated process group. `ProcessRegistry` then sends `SIGTERM` and `SIGKILL`
+only to that direct child. When the ACP process has started hooks, shell
+commands, MCP servers, or other grandchildren, terminating the channel can
+leave those descendants running after the ACP root exits.
+
+The failure is not limited to the graceful path. `killSync()` also signals only
+the root, and `ProcessRegistry` removes an entry as soon as the root emits
+`exit`. A later shutdown or second signal therefore cannot reach descendants
+that outlived the root.
+
+A real-process baseline on macOS reproduced all of these cases:
+
+| Path             | Descendant                    | Baseline result                                                                    |
+| ---------------- | ----------------------------- | ---------------------------------------------------------------------------------- |
+| `terminate()`    | ordinary grandchild           | Root was killed after the 5 second grace period; grandchild survived under PPID 1. |
+| `terminate()`    | grandchild in its own session | Root was killed; grandchild survived under PPID 1.                                 |
+| `killSync()`     | ordinary grandchild           | Root was killed immediately; grandchild survived under PPID 1.                     |
+| `killSync()`     | grandchild in its own session | Root was killed immediately; grandchild survived under PPID 1.                     |
+| root exits first | either form                   | The registry had already released the entry, so later termination was a no-op.     |
+
+An isolated root process group fixes the ordinary-grandchild cases, including
+an ordinary grandchild that remains in the group after the root exits. It does
+not fix a descendant that called `setsid()` or otherwise created a separate
+group. Such a descendant is discoverable from a process-table snapshot while
+the root lineage is still intact, but not after it has been reparented.
+
+## Scope
+
+This PR owns the ACP child lifecycle inside `packages/acp-bridge`:
+
+- establish the ownership boundary when the standard spawn factory creates an
+  ACP child;
+- terminate the owned tree on every existing channel teardown path;
+- retain enough cleanup state for the asynchronous graceful path and the
+  synchronous second-signal path;
+- preserve the existing `AcpChannel.exited` meaning and all bridge decisions
+  about when a channel should be killed.
+
+It does not change HookRunner cancellation, endpoint deadlines, request
+abort propagation, session ownership, idle-channel policy, or bridge routing.
+Those are separate PR boundaries. PR2 does not depend on a private helper from
+the HookRunner change, so both PRs can be developed independently.
+
+## Lifecycle contract
+
+The implementation must preserve these invariants:
+
+1. `AcpChannel.exited` reports the raw ACP root exit exactly as it does today.
+   Descendant cleanup must not delay session-death observation.
+2. `AcpChannel.kill()` resolves only after the owned tree is gone. It rejects
+   when the root exits uncleanly or cleanup cannot be confirmed within the
+   existing 10 second deadline.
+3. `AcpChannel.killSync()` dispatches the strongest available tree kill before
+   returning. It cannot wait because the daemon calls it immediately before a
+   forced process exit.
+4. Concurrent `kill()`, registry shutdown, transport-failure teardown, and
+   `killSync()` calls are idempotent.
+5. The registry adds a process group only from the isolated root or a validated
+   snapshot of that root's current lineage; it never expands ownership from a
+   historical PID after the root exits.
+6. Existing external users of `ProcessRegistry` retain direct-child behavior
+   unless they explicitly mark an attached child as a tree owner.
+
+## Design
+
+### Declare ownership at attachment
+
+Add optional ownership metadata to `ProcessReservation.attach()`. The default
+remains direct-child tracking. The standard spawn factory marks only the child
+it created as an owned process-tree root.
+
+On POSIX, marking a child as tree-owned requires the caller to have spawned it
+as an isolated process-group leader. On Windows, the same metadata authorizes a
+`taskkill /T` operation rooted at that PID. Keeping this opt-in avoids treating
+an arbitrary publicly attached child as a group leader and accidentally
+signalling the host's process group.
+
+No `AcpChannel`, bridge, or daemon API changes are needed.
+
+### Establish a POSIX process group
+
+`createSpawnChannelFactory()` sets `detached: true` on non-Windows platforms.
+The ACP root PID then becomes its process-group ID and session ID. Its stdio
+remains piped and the child is not `unref()`ed, so the channel's transport and
+lifecycle ownership do not change.
+
+Isolation does change terminal-signal inheritance: a POSIX signal sent to the
+host's foreground process group no longer reaches the ACP child automatically.
+`qwen serve` therefore routes `SIGHUP`, as well as `SIGINT` and `SIGTERM`,
+through the existing graceful and second-signal shutdown state machine.
+Embedders remain responsible for calling `AcpChannel.kill()` or `killSync()`
+from their own host lifecycle. An untrappable host crash such as `SIGKILL`
+cannot run either cleanup path and remains outside this portable fix.
+
+Windows keeps `detached` disabled and uses the native process-tree operation
+described below.
+
+### Snapshot before the first signal
+
+For a tree-owned POSIX child, `terminate()` first takes one bounded process
+table snapshot containing PID, PPID, and PGID. It walks descendants in memory,
+and records each unique process group. The root group is always included from
+the spawn-time isolation contract, even if the snapshot helper is unavailable.
+Snapshot groups are accepted only when the root row still exists and confirms
+that the root is its own process-group leader. If a present root row contradicts
+that contract, even the provisional root group is discarded and teardown falls
+back to signalling the direct child.
+
+The snapshot must happen before any signal is sent. Killing the root first can
+reparent descendants to PID 1 and destroy the only portable ownership evidence
+for a descendant that left the root group.
+
+The helper stays private to `acp-bridge`, with bounded runtime, output, depth,
+and process count. It invokes `/bin/ps` directly rather than resolving `ps`
+through the inherited `PATH`, because the returned PGIDs authorize later
+signals. If that trusted path is unavailable, snapshot failure follows the safe
+root fallback instead of executing an untrusted replacement. Re-exporting the
+existing Core PID helper would widen PR2 into a cross-package public API change
+and still would not provide PGIDs or the synchronous snapshot required by
+`killSync()`.
+
+### POSIX termination state machine
+
+`terminate()` uses the existing 5 second grace and 10 second total deadline:
+
+1. Mark termination active and memoize the returned promise.
+2. Snapshot the still-owned lineage and merge its PGIDs into the tracked
+   ownership set.
+3. Send `SIGTERM` to each owned process group, with the root group last. Use a
+   direct-child signal only as a fallback for the ACP root itself.
+4. Wait for both the raw root exit and disappearance of every known group.
+   Root exit alone is not completion while a group remains.
+5. At the grace deadline, if the original root is still alive in its isolated
+   group, take one more bounded snapshot rooted only at that root, merge any
+   newly visible descendants, and send `SIGKILL` to every surviving owned
+   group, followed by the direct-root fallback. Once the root exits, never
+   expand ownership from historical PIDs because the operating system can
+   reuse them for unrelated processes.
+6. Resolve after the root and owned members are gone. At the total deadline,
+   reject with the root PID, surviving groups, and any snapshot failure.
+
+After the root exits and KILL has been dispatched, process-group liveness is
+supplemented with a bounded process-state snapshot. This handles Linux PID 1
+environments that do not reap adopted grandchildren: a zombie can keep its
+PGID addressable even though it can no longer execute. A known group is removed
+only when the snapshot observes members for that group and every observed
+member is terminal. An absent group, an unknown state, or a failed query stays
+live. On Linux, a zombie leader with more than one thread also stays live,
+because other threads can still execute after the leader exits.
+
+`ESRCH` means a PID or group is already gone. `EPERM` means it still exists and
+cleanup is not confirmed. Timers and liveness polling remain referenced while
+`kill()` is pending; an unresolved promise does not by itself keep Node alive
+after the ACP root exits.
+
+Termination state is monotonic. A synchronous force-kill sets a
+`forceKillRequested` state before taking its snapshot. The asynchronous path
+checks that state after every awaited snapshot or timer and can only advance
+from TERM to KILL; it must never send a later TERM after `killSync()` has
+already escalated the tree. Registry release is also guarded so concurrent root
+exit, `terminate()`, and `killSync()` paths invoke it exactly once.
+
+The raw root exit and registry release become separate events. During explicit
+termination, root exit settles `AcpChannel.exited` but the tree-owned registry
+entry remains until cleanup settles, so `killAllSync()` can still strengthen an
+in-progress shutdown. A root that exits unexpectedly triggers an immediate
+best-effort synchronous kill of its known root group before the entry is
+released. If termination begins while that cleanup is still in progress, it
+waits for the known groups rather than treating the raw root exit as tree
+completion.
+
+If the initial snapshot is unavailable or truncated, the implementation still
+kills the isolated root group but must not silently claim complete coverage of
+separate descendant groups. After dispatching the safe fallback,
+`terminate()` rejects because full cleanup could not be proven. `killSync()`
+has no error channel, so it records no stronger guarantee than best-effort
+dispatch.
+
+If the root disappears before a valid initial snapshot can establish the
+lineage, the asynchronous path applies the same unverified-cleanup result. The
+second snapshot narrows ordinary spawn races during the grace period, but this
+mechanism is lifecycle cleanup rather than a security sandbox: it cannot stop
+an adversarial process from double-forking out of the observed lineage.
+
+### POSIX synchronous force-kill
+
+`killSync()` takes a bounded synchronous PID/PPID/PGID snapshot before it
+signals the root. It merges that snapshot with groups already recorded by an
+in-progress `terminate()`, sends `SIGKILL` to every known owned group with the
+root group last, and then attempts the direct-root fallback. After root exit it
+does not enumerate again, but still signals groups proved by an earlier
+snapshot.
+
+The synchronous helper shares parsing and ownership validation with the
+asynchronous helper but uses `spawnSync()` with a short timeout. If enumeration
+fails, it still kills the isolated root group. The method guarantees dispatch,
+not observation of process exit, and then returns immediately for the daemon's
+second-signal handler.
+
+### Windows tree termination
+
+Windows does not have POSIX `SIGTERM` semantics. The asynchronous `terminate()`
+path starts the trusted absolute executable
+`%SystemRoot%\\System32\\taskkill.exe` with `/F /T /PID <rootPid>` and waits for
+that operation before using direct-child force-kill as a failure fallback. It
+then waits for the root exit within the existing total deadline. The taskkill
+invocation itself is bounded and cannot outlive that deadline. This path does
+not pretend to provide a TERM grace period.
+
+`killSync()` uses `spawnSync()` with the same absolute path and flags so
+`taskkill` enumerates the tree before the daemon exits. It then attempts the
+direct-child `SIGKILL` fallback if taskkill could not be launched or returned a
+failure. A bare `taskkill` command is not allowed because Windows resolves it
+through the current directory and `PATH`.
+
+### Direct-child compatibility
+
+An attachment without tree ownership keeps the current behavior:
+
+- root `exit` releases the registry entry;
+- `terminate()` signals only the direct child;
+- `killSync()` signals only the direct child;
+- reservation and committed-process accounting remain source compatible.
+
+For a tree-owned child, committed-process accounting extends through explicit
+tree teardown rather than ending at raw root exit. This continues the existing
+admission invariant: a winding-down child remains counted while its owned
+processes may still hold memory.
+
+## Failure semantics
+
+- Repeated and concurrent teardown calls share one asynchronous state and may
+  safely receive an additional synchronous force-kill.
+- A clean root exit is not sufficient while a known descendant group remains.
+- A non-zero or signalled root exit during shutdown remains an unclean-shutdown
+  error after descendant cleanup, preserving current behavior.
+- Snapshot, `ps`, or `taskkill` failure always falls back to the strongest safe
+  root operation. The reported error includes the failed mechanism when full
+  cleanup cannot be confirmed; registry shutdown continues to aggregate child
+  failures.
+- Process-table parsing accepts only positive safe-integer PID/PGID rows,
+  deduplicates cycles, and never signals the host's own process group.
+- A process-state query failure is conservative. Zombie-only groups can be
+  released after KILL, but a group with any live member is retained.
+
+## Platform limit
+
+Portable PID/PPID/PGID enumeration cannot recover a descendant that established
+a separate session and then lost its ancestry because the ACP root exited
+before cleanup began. Windows PID-tree enumeration has the same root-first
+race. Absolute containment for that case needs a Linux cgroup, Windows Job
+Object, or another OS supervisor.
+
+This PR therefore guarantees cleanup of the isolated root group and of separate
+groups that are still discoverable when cleanup starts. It must not claim to
+reap an already-daemonized process whose ownership evidence disappeared before
+teardown. As with any PID/PGID-based lifecycle cleanup, OS identifier reuse
+leaves an irreducible check-to-signal race; stronger identity and containment
+require an OS supervisor. Adding that containment is intentionally out of
+scope for this minimal fix.
+
+## Implementation surface
+
+Production changes should remain limited to:
+
+- `packages/acp-bridge/src/process-registry.ts` for ownership state, bounded
+  snapshots, platform termination, and registry release;
+- `packages/acp-bridge/src/spawnChannel.ts` for POSIX `detached` spawning and
+  the ownership marker;
+- `packages/cli/src/serve/run-qwen-serve.ts` for routing `SIGHUP` through the
+  existing daemon shutdown state machine;
+- at most a contract clarification in `packages/acp-bridge/src/channel.ts`.
+
+No new dependency, shared process-manager abstraction, Core export, or bridge
+production change is required.
+
+## Verification
+
+### Unit and contract tests
+
+- Legacy `attach(child)` retains direct-child semantics.
+- The standard factory uses `detached: true` on POSIX and not on Windows.
+- PID/PPID/PGID parsing is bounded, cycle-safe, and deduplicated.
+- POSIX TERM, grace, resnapshot, and KILL target all owned groups.
+- Root exit does not resolve `kill()` while an owned group is alive.
+- Linux zombie-only groups settle after KILL, while `Z` leaders with live
+  threads and groups with any non-zombie member stay committed.
+- `ESRCH`, `EPERM`, missing PID, spawn errors, snapshot failures, and deadlines
+  follow the declared semantics.
+- Concurrent `terminate()` calls, registry shutdown, and `killSync()` remain
+  idempotent.
+- A root-exited tree remains reachable by `killAllSync()` during explicit
+  teardown.
+- Windows uses the absolute System32 path, exact `/F /T /PID` flags, and a
+  direct-child fallback on launch or exit failure.
+- Multiple children are all attempted and failures remain aggregated.
+- `qwen serve` routes `SIGHUP` through graceful cleanup, keeps the listener for
+  second-signal escalation during drain, and removes it after shutdown.
+
+### Real-process tests
+
+On POSIX, an ACP-like root starts both an ordinary grandchild and a grandchild
+that creates a separate session. Both ignore `SIGTERM`. Exercise `terminate()`,
+`killSync()`, and root-first timing independently, assert the documented
+guarantees and platform limit, and clean every recorded PID in `finally`.
+
+### Bridge and daemon regression
+
+Existing teardown decisions must continue to converge on the tree-aware
+channel operation for channel-construction failure, initialization failure,
+empty session creation, transport failure, normal daemon shutdown, and the
+second signal. A single session failure on a shared channel must not kill that
+channel while another session still owns it.
+
+Focused implementation verification:
+
+```bash
+(cd packages/acp-bridge && npx vitest run src/process-registry.test.ts src/process-registry.process.test.ts src/spawnChannel.test.ts)
+(cd packages/cli && npx vitest run src/serve/run-qwen-serve.test.ts)
+npm run build
+npm run typecheck
+npm run lint
+git diff --check
+```

--- a/packages/acp-bridge/src/channel.ts
+++ b/packages/acp-bridge/src/channel.ts
@@ -36,12 +36,12 @@ export interface AcpChannel {
   transportFailed?: Promise<unknown>;
   /** Present only on daemon-owned bounded transports. */
   transportGuard?: AcpChannelTransportGuard;
-  /** Best-effort terminate; resolves when teardown is complete. */
+  /** Best-effort terminate; resolves when owned teardown is complete. */
   kill(): Promise<void>;
   /**
    * Synchronous force-kill for the second-signal force-exit path.
-   * Fires SIGKILL on the underlying child (or equivalent in-process
-   * tear-down) and returns immediately — no Promise. The daemon's
+   * Force-kills the owned process tree (or equivalent in-process tear-down)
+   * and returns immediately — no Promise. The daemon's
    * signal handler can call this before `process.exit(1)` so that
    * double-Ctrl+C doesn't leave the agent child running after the
    * daemon vanishes.

--- a/packages/acp-bridge/src/process-registry.process.test.ts
+++ b/packages/acp-bridge/src/process-registry.process.test.ts
@@ -32,8 +32,12 @@ process.on('SIGTERM', () => {});
 setInterval(() => {}, 1000);
 `;
 
-function spawnTree(): ChildProcess {
-  return spawn(process.execPath, ['-e', ROOT_SCRIPT], {
+const ROOT_EXITS_FIRST_SCRIPT = `${ROOT_SCRIPT}
+setTimeout(() => process.exit(0), 100);
+`;
+
+function spawnTree(script = ROOT_SCRIPT): ChildProcess {
+  return spawn(process.execPath, ['-e', script], {
     detached: true,
     stdio: ['ignore', 'pipe', 'inherit'],
   });
@@ -146,5 +150,29 @@ describe.skipIf(process.platform === 'win32')(
         await cleanupTree(rootPid, tree);
       }
     });
+
+    it('limits unexpected root-exit cleanup to the known root group', async () => {
+      const child = spawnTree(ROOT_EXITS_FIRST_SCRIPT);
+      const rootPid = child.pid;
+      if (!rootPid) throw new Error('test root has no pid');
+      const registry = new ProcessRegistry();
+      const tracked = registry
+        .reserve()
+        .attach(child, { ownsProcessTree: true });
+      let tree: TreePids | undefined;
+      try {
+        tree = await readTreePids(child);
+
+        await tracked.exited;
+
+        await waitForGone(tree.ordinary);
+        expect(isAlive(tree.detached)).toBe(true);
+        await expect
+          .poll(() => registry.activeProcessCount, { timeout: 3_000 })
+          .toBe(0);
+      } finally {
+        await cleanupTree(rootPid, tree);
+      }
+    }, 15_000);
   },
 );

--- a/packages/acp-bridge/src/process-registry.process.test.ts
+++ b/packages/acp-bridge/src/process-registry.process.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { ProcessRegistry } from './process-registry.js';
+
+interface TreePids {
+  ordinary: number;
+  detached: number;
+}
+
+const LEAF_SCRIPT = `
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1000);
+`;
+
+const ROOT_SCRIPT = `
+const { spawn } = require('node:child_process');
+const leafScript = ${JSON.stringify(LEAF_SCRIPT)};
+const ordinary = spawn(process.execPath, ['-e', leafScript], { stdio: 'ignore' });
+const detached = spawn(process.execPath, ['-e', leafScript], {
+  detached: true,
+  stdio: 'ignore',
+});
+detached.unref();
+process.stdout.write(JSON.stringify({ ordinary: ordinary.pid, detached: detached.pid }) + '\\n');
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1000);
+`;
+
+function spawnTree(): ChildProcess {
+  return spawn(process.execPath, ['-e', ROOT_SCRIPT], {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+}
+
+async function readTreePids(child: ChildProcess): Promise<TreePids> {
+  const stdout = child.stdout;
+  if (!stdout) throw new Error('test child stdout is unavailable');
+  stdout.setEncoding('utf8');
+  return await new Promise((resolve, reject) => {
+    let buffered = '';
+    const onData = (chunk: string) => {
+      buffered += chunk;
+      const newline = buffered.indexOf('\n');
+      if (newline < 0) return;
+      cleanup();
+      resolve(JSON.parse(buffered.slice(0, newline)) as TreePids);
+    };
+    const onExit = () => {
+      cleanup();
+      reject(new Error('test root exited before reporting descendants'));
+    };
+    const cleanup = () => {
+      stdout.off('data', onData);
+      child.off('exit', onExit);
+    };
+    stdout.on('data', onData);
+    child.once('exit', onExit);
+  });
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+async function waitForGone(pid: number): Promise<void> {
+  await expect.poll(() => isAlive(pid), { timeout: 3_000 }).toBe(false);
+}
+
+function forceKill(target: number): void {
+  try {
+    process.kill(target, 'SIGKILL');
+  } catch {
+    // The test or implementation already reaped it.
+  }
+}
+
+async function cleanupTree(rootPid: number, tree?: TreePids): Promise<void> {
+  forceKill(-rootPid);
+  if (tree) {
+    forceKill(-tree.detached);
+    forceKill(tree.ordinary);
+    forceKill(tree.detached);
+  }
+  forceKill(rootPid);
+  await Promise.all(
+    [rootPid, tree?.ordinary, tree?.detached]
+      .filter((pid): pid is number => pid !== undefined)
+      .map((pid) => waitForGone(pid).catch(() => {})),
+  );
+}
+
+describe.skipIf(process.platform === 'win32')(
+  'ProcessRegistry real process trees',
+  () => {
+    it('reaps ordinary and detached descendants after graceful escalation', async () => {
+      const child = spawnTree();
+      const rootPid = child.pid;
+      if (!rootPid) throw new Error('test root has no pid');
+      const tracked = new ProcessRegistry()
+        .reserve()
+        .attach(child, { ownsProcessTree: true });
+      let tree: TreePids | undefined;
+      try {
+        tree = await readTreePids(child);
+
+        await expect(tracked.terminate()).rejects.toThrow(
+          'exited uncleanly during shutdown',
+        );
+
+        await waitForGone(tree.ordinary);
+        await waitForGone(tree.detached);
+      } finally {
+        await cleanupTree(rootPid, tree);
+      }
+    }, 15_000);
+
+    it('reaps ordinary and detached descendants synchronously', async () => {
+      const child = spawnTree();
+      const rootPid = child.pid;
+      if (!rootPid) throw new Error('test root has no pid');
+      const tracked = new ProcessRegistry()
+        .reserve()
+        .attach(child, { ownsProcessTree: true });
+      let tree: TreePids | undefined;
+      try {
+        tree = await readTreePids(child);
+
+        tracked.killSync();
+
+        await waitForGone(rootPid);
+        await waitForGone(tree.ordinary);
+        await waitForGone(tree.detached);
+      } finally {
+        await cleanupTree(rootPid, tree);
+      }
+    });
+  },
+);

--- a/packages/acp-bridge/src/process-registry.test.ts
+++ b/packages/acp-bridge/src/process-registry.test.ts
@@ -288,6 +288,27 @@ describe('ProcessRegistry', () => {
     expect(registry.activeProcessCount).toBe(0);
   });
 
+  it('fails at the total deadline when an owned group survives', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    setAsyncProcessTable('1234 1 1234 S 1');
+    const registry = new ProcessRegistry();
+    const tracked = registry
+      .reserve()
+      .attach(fakeChild(1234), { ownsProcessTree: true });
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    const terminating = tracked.terminate().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(terminating).resolves.toMatchObject({
+      message: expect.stringContaining(
+        'did not exit with its owned process groups within 10000ms',
+      ),
+    });
+    expect(registry.activeProcessCount).toBe(1);
+  });
+
   it('does not expand ownership from a reused root pid after root exit', async () => {
     vi.useFakeTimers();
     setPlatform('linux');
@@ -556,6 +577,41 @@ describe('ProcessRegistry', () => {
     expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGKILL');
     expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGKILL');
     expect(killSpy).toHaveBeenCalledWith(-2234, 'SIGKILL');
+  });
+
+  it('keeps an exited root reachable by registry synchronous teardown', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    setAsyncProcessTable(['1234 1 1234', '1236 1234 1236'].join('\n'));
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
+    const aliveGroups = new Set([1234, 1236]);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      const group = -pid;
+      if (signal === 0) {
+        if (!aliveGroups.has(group)) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGKILL') aliveGroups.delete(group);
+      return true;
+    }) as typeof process.kill);
+
+    const terminating = tracked.terminate();
+    await vi.advanceTimersByTimeAsync(0);
+    child.emit('exit', 0, null);
+
+    registry.killAllSync();
+    await vi.advanceTimersByTimeAsync(50);
+    await terminating;
+
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGKILL');
+    expect(registry.activeProcessCount).toBe(0);
   });
 
   it('rejects a non-leader root in the shared synchronous snapshot', () => {

--- a/packages/acp-bridge/src/process-registry.test.ts
+++ b/packages/acp-bridge/src/process-registry.test.ts
@@ -77,6 +77,24 @@ function errno(code: string): NodeJS.ErrnoException {
   return Object.assign(new Error(code), { code });
 }
 
+function mockGroupKills(
+  aliveGroups: Set<number>,
+  onSignal: (group: number, signal?: NodeJS.Signals | number) => void,
+) {
+  return vi.spyOn(process, 'kill').mockImplementation(((
+    pid: number,
+    signal?: NodeJS.Signals | number,
+  ) => {
+    const group = -pid;
+    if (signal === 0) {
+      if (!aliveGroups.has(group)) throw errno('ESRCH');
+      return true;
+    }
+    onSignal(group, signal);
+    return true;
+  }) as typeof process.kill);
+}
+
 describe('ProcessRegistry', () => {
   it('counts unattached reservations, which is what admission must key on', () => {
     const registry = new ProcessRegistry();
@@ -214,21 +232,12 @@ describe('ProcessRegistry', () => {
     const child = fakeChild(1234);
     const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
     const aliveGroups = new Set([1234, 1236]);
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
-      pid: number,
-      signal?: NodeJS.Signals | number,
-    ) => {
-      const group = -pid;
-      if (signal === 0) {
-        if (!aliveGroups.has(group)) throw errno('ESRCH');
-        return true;
-      }
+    const killSpy = mockGroupKills(aliveGroups, (group, signal) => {
       if (signal === 'SIGKILL') {
         aliveGroups.delete(group);
         if (group === 1234) child.emit('exit', null, 'SIGKILL');
       }
-      return true;
-    }) as typeof process.kill);
+    });
 
     const terminating = tracked.terminate().catch((error: unknown) => error);
     await vi.advanceTimersByTimeAsync(0);
@@ -258,22 +267,13 @@ describe('ProcessRegistry', () => {
     const child = fakeChild(1234);
     const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
     const aliveGroups = new Set([1234, 1236]);
-    vi.spyOn(process, 'kill').mockImplementation(((
-      pid: number,
-      signal?: NodeJS.Signals | number,
-    ) => {
-      const group = -pid;
-      if (signal === 0) {
-        if (!aliveGroups.has(group)) throw errno('ESRCH');
-        return true;
-      }
+    mockGroupKills(aliveGroups, (group, signal) => {
       if (signal === 'SIGTERM' && group === 1234) {
         aliveGroups.delete(1234);
         child.emit('exit', 0, null);
       }
       if (signal === 'SIGKILL') aliveGroups.delete(group);
-      return true;
-    }) as typeof process.kill);
+    });
     let settled = false;
     const terminating = tracked.terminate().then(() => {
       settled = true;
@@ -325,22 +325,13 @@ describe('ProcessRegistry', () => {
     const child = fakeChild(1234);
     const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
     const aliveGroups = new Set([1234, 1236]);
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
-      pid: number,
-      signal?: NodeJS.Signals | number,
-    ) => {
-      const group = -pid;
-      if (signal === 0) {
-        if (!aliveGroups.has(group)) throw errno('ESRCH');
-        return true;
-      }
+    const killSpy = mockGroupKills(aliveGroups, (group, signal) => {
       if (signal === 'SIGTERM' && group === 1234) {
         aliveGroups.delete(group);
         child.emit('exit', 0, null);
       }
       if (signal === 'SIGKILL') aliveGroups.delete(group);
-      return true;
-    }) as typeof process.kill);
+    });
 
     const terminating = tracked.terminate();
     await vi.advanceTimersByTimeAsync(5_000);
@@ -427,21 +418,12 @@ describe('ProcessRegistry', () => {
     const child = fakeChild(1234);
     const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
     const aliveGroups = new Set([1234, 1236]);
-    vi.spyOn(process, 'kill').mockImplementation(((
-      pid: number,
-      signal?: NodeJS.Signals | number,
-    ) => {
-      const group = -pid;
-      if (signal === 0) {
-        if (!aliveGroups.has(group)) throw errno('ESRCH');
-        return true;
-      }
+    mockGroupKills(aliveGroups, (group, signal) => {
       if (signal === 'SIGKILL' && group === 1234) {
         aliveGroups.delete(group);
         child.emit('exit', null, 'SIGKILL');
       }
-      return true;
-    }) as typeof process.kill);
+    });
 
     const terminating = tracked.terminate().catch((error: unknown) => error);
     await vi.advanceTimersByTimeAsync(5_000);
@@ -587,18 +569,9 @@ describe('ProcessRegistry', () => {
     const child = fakeChild(1234);
     const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
     const aliveGroups = new Set([1234, 1236]);
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
-      pid: number,
-      signal?: NodeJS.Signals | number,
-    ) => {
-      const group = -pid;
-      if (signal === 0) {
-        if (!aliveGroups.has(group)) throw errno('ESRCH');
-        return true;
-      }
+    const killSpy = mockGroupKills(aliveGroups, (group, signal) => {
       if (signal === 'SIGKILL') aliveGroups.delete(group);
-      return true;
-    }) as typeof process.kill);
+    });
 
     const terminating = tracked.terminate();
     await vi.advanceTimersByTimeAsync(0);
@@ -717,21 +690,12 @@ describe('ProcessRegistry', () => {
     setSyncProcessTable(['1234 1 1234', '1236 1234 1236'].join('\n'));
     const child = fakeChild(1234);
     const aliveGroups = new Set([1234, 1236]);
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
-      pid: number,
-      signal?: NodeJS.Signals | number,
-    ) => {
-      const group = -pid;
-      if (signal === 0) {
-        if (!aliveGroups.has(group)) throw errno('ESRCH');
-        return true;
-      }
+    const killSpy = mockGroupKills(aliveGroups, (group, signal) => {
       if (signal === 'SIGKILL') {
         aliveGroups.delete(group);
         if (group === 1234) child.emit('exit', null, 'SIGKILL');
       }
-      return true;
-    }) as typeof process.kill);
+    });
     const tracked = new ProcessRegistry()
       .reserve()
       .attach(child, { ownsProcessTree: true });

--- a/packages/acp-bridge/src/process-registry.test.ts
+++ b/packages/acp-bridge/src/process-registry.test.ts
@@ -7,7 +7,29 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockExecFile = vi.hoisted(() => vi.fn());
+const mockSpawnSync = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFile: mockExecFile,
+    spawnSync: mockSpawnSync,
+  };
+});
+
 import { ProcessRegistry } from './process-registry.js';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+const PS = '/bin/ps';
+const TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+
+type StringExecCallback = (
+  error: Error | null,
+  stdout: string,
+  stderr: string,
+) => void;
 
 function fakeChild(pid: number | undefined): ChildProcess {
   return Object.assign(new EventEmitter(), {
@@ -20,7 +42,40 @@ function fakeChild(pid: number | undefined): ChildProcess {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
+  mockExecFile.mockReset();
+  mockSpawnSync.mockReset();
+  Object.defineProperty(process, 'platform', originalPlatform);
 });
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    enumerable: true,
+    value: platform,
+  });
+}
+
+function setAsyncProcessTable(stdout: string): void {
+  mockExecFile.mockImplementation((...args: unknown[]) => {
+    const callback = args[3] as StringExecCallback;
+    callback(null, stdout, '');
+    return new EventEmitter();
+  });
+}
+
+function setSyncProcessTable(stdout: string): void {
+  mockSpawnSync.mockReturnValue({
+    error: undefined,
+    status: 0,
+    stderr: '',
+    stdout,
+  });
+}
+
+function errno(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(code), { code });
+}
 
 describe('ProcessRegistry', () => {
   it('counts unattached reservations, which is what admission must key on', () => {
@@ -147,5 +202,563 @@ describe('ProcessRegistry', () => {
     });
     expect(registry.activeProcessCount).toBe(0);
     expect(registry.shutdown()).toBe(shutdown);
+  });
+
+  it('terminates every process group discovered in the owned tree', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    setAsyncProcessTable(
+      ['1234 1 1234', '1235 1234 1234', '1236 1234 1236'].join('\n'),
+    );
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
+    const aliveGroups = new Set([1234, 1236]);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      const group = -pid;
+      if (signal === 0) {
+        if (!aliveGroups.has(group)) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGKILL') {
+        aliveGroups.delete(group);
+        if (group === 1234) child.emit('exit', null, 'SIGKILL');
+      }
+      return true;
+    }) as typeof process.kill);
+
+    const terminating = tracked.terminate().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      PS,
+      ['-A', '-o', 'pid=,ppid=,pgid=,state=,nlwp='],
+      expect.objectContaining({ encoding: 'utf8', timeout: 2_000 }),
+      expect.any(Function),
+    );
+    expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGTERM');
+    expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGTERM');
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(terminating).resolves.toMatchObject({
+      message: expect.stringContaining('exited uncleanly during shutdown'),
+    });
+    expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGKILL');
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('does not treat root exit as tree teardown completion', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    setAsyncProcessTable(['1234 1 1234', '1236 1234 1236'].join('\n'));
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
+    const aliveGroups = new Set([1234, 1236]);
+    vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      const group = -pid;
+      if (signal === 0) {
+        if (!aliveGroups.has(group)) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGTERM' && group === 1234) {
+        aliveGroups.delete(1234);
+        child.emit('exit', 0, null);
+      }
+      if (signal === 'SIGKILL') aliveGroups.delete(group);
+      return true;
+    }) as typeof process.kill);
+    let settled = false;
+    const terminating = tracked.terminate().then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(settled).toBe(false);
+    expect(registry.activeProcessCount).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    await terminating;
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('does not expand ownership from a reused root pid after root exit', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    const processTables = [
+      ['1234 1 1234', '1236 1234 1236'].join('\n'),
+      ['1234 1 7777', '1236 1 1236'].join('\n'),
+    ];
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as StringExecCallback;
+      callback(null, processTables[mockExecFile.mock.calls.length - 1], '');
+      return new EventEmitter();
+    });
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
+    const aliveGroups = new Set([1234, 1236]);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      const group = -pid;
+      if (signal === 0) {
+        if (!aliveGroups.has(group)) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGTERM' && group === 1234) {
+        aliveGroups.delete(group);
+        child.emit('exit', 0, null);
+      }
+      if (signal === 'SIGKILL') aliveGroups.delete(group);
+      return true;
+    }) as typeof process.kill);
+
+    const terminating = tracked.terminate();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await terminating;
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    expect(killSpy).not.toHaveBeenCalledWith(-7777, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGKILL');
+  });
+
+  it('force-kills the owned root group after an unexpected root exit', async () => {
+    setPlatform('linux');
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    registry.reserve().attach(child, { ownsProcessTree: true });
+    let groupAlive = true;
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
+      _pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      if (signal === 0) {
+        if (!groupAlive) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGKILL') groupAlive = false;
+      return true;
+    }) as typeof process.kill);
+
+    child.emit('exit', 0, null);
+    await Promise.resolve();
+
+    expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGKILL');
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('waits for known groups when termination starts after root exit', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    setAsyncProcessTable('1234 1 1234 S 1');
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
+    let groupAlive = true;
+    vi.spyOn(process, 'kill').mockImplementation(((_pid: number, signal) => {
+      if (signal === 0 && !groupAlive) throw errno('ESRCH');
+      return true;
+    }) as typeof process.kill);
+
+    child.emit('exit', 0, null);
+    let settled = false;
+    const terminating = tracked.terminate().then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(settled).toBe(false);
+    expect(registry.activeProcessCount).toBe(1);
+    expect(mockExecFile).toHaveBeenCalled();
+
+    groupAlive = false;
+    await vi.advanceTimersByTimeAsync(50);
+    await terminating;
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('releases a Linux process group containing only zombies after escalation', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    const processTables = [
+      ['1234 1 1234 S 1', '1236 1234 1236 S 1'].join('\n'),
+      ['1234 1 1234 S 1', '1236 1234 1236 S 1'].join('\n'),
+      '1236 1 1236 Z 1',
+    ];
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as StringExecCallback;
+      const index = Math.min(
+        mockExecFile.mock.calls.length - 1,
+        processTables.length - 1,
+      );
+      callback(null, processTables[index], '');
+      return new EventEmitter();
+    });
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
+    const aliveGroups = new Set([1234, 1236]);
+    vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      const group = -pid;
+      if (signal === 0) {
+        if (!aliveGroups.has(group)) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGKILL' && group === 1234) {
+        aliveGroups.delete(group);
+        child.emit('exit', null, 'SIGKILL');
+      }
+      return true;
+    }) as typeof process.kill);
+
+    const terminating = tracked.terminate().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(terminating).resolves.toMatchObject({
+      message: expect.stringContaining('exited uncleanly during shutdown'),
+    });
+    expect(mockExecFile).toHaveBeenCalledTimes(3);
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('releases an unexpectedly exited Linux root whose group is zombie-only', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    setAsyncProcessTable('1235 1 1234 Z 1');
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    registry.reserve().attach(child, { ownsProcessTree: true });
+    vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    child.emit('exit', 0, null);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it.each([
+    ['zombie leader with live threads', '1235 1 1234 Z 2'],
+    [
+      'zombie group with a live member',
+      ['1235 1 1234 Z 1', '1236 1 1234 S 1'].join('\n'),
+    ],
+  ])('keeps a Linux %s committed', async (_case, processTable) => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    setAsyncProcessTable(processTable);
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    registry.reserve().attach(child, { ownsProcessTree: true });
+    let groupAlive = true;
+    vi.spyOn(process, 'kill').mockImplementation(((_pid: number, signal) => {
+      if (signal === 0 && !groupAlive) throw errno('ESRCH');
+      return true;
+    }) as typeof process.kill);
+
+    child.emit('exit', 0, null);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(registry.activeProcessCount).toBe(1);
+
+    groupAlive = false;
+    await vi.advanceTimersByTimeAsync(250);
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('keeps a group committed when its process state cannot be queried', async () => {
+    vi.useFakeTimers();
+    setPlatform('linux');
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as StringExecCallback;
+      callback(errno('EIO'), '', '');
+      return new EventEmitter();
+    });
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    registry.reserve().attach(child, { ownsProcessTree: true });
+    let groupAlive = true;
+    vi.spyOn(process, 'kill').mockImplementation(((_pid: number, signal) => {
+      if (signal === 0 && !groupAlive) throw errno('ESRCH');
+      return true;
+    }) as typeof process.kill);
+
+    child.emit('exit', 0, null);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(registry.activeProcessCount).toBe(1);
+
+    groupAlive = false;
+    await vi.advanceTimersByTimeAsync(250);
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('uses direct-child teardown when a tree-owned child has no pid', async () => {
+    const registry = new ProcessRegistry();
+    const child = fakeChild(undefined);
+    const tracked = registry.reserve().attach(child, { ownsProcessTree: true });
+
+    const terminating = tracked.terminate();
+    child.emit('error', errno('ENOENT'));
+
+    await expect(terminating).resolves.toBeUndefined();
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(registry.activeProcessCount).toBe(0);
+  });
+
+  it('synchronously snapshots and force-kills owned process groups', () => {
+    setPlatform('linux');
+    setSyncProcessTable(
+      ['1234 1 1234', '1235 1234 1234', '1236 1234 1236'].join('\n'),
+    );
+    const child = fakeChild(1234);
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    tracked.killSync();
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      PS,
+      ['-A', '-o', 'pid=,ppid=,pgid=,state=,nlwp='],
+      expect.objectContaining({ encoding: 'utf8', timeout: 2_000 }),
+    );
+    expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGKILL');
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('shares one synchronous snapshot across registry force-kills', () => {
+    setPlatform('linux');
+    setSyncProcessTable(
+      ['1234 1 1234', '1236 1234 1236', '2234 1 2234'].join('\n'),
+    );
+    const registry = new ProcessRegistry();
+    const first = registry
+      .reserve()
+      .attach(fakeChild(1234), { ownsProcessTree: true });
+    registry.reserve().attach(fakeChild(2234), { ownsProcessTree: true });
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    registry.killAllSync();
+    first.killSync();
+
+    expect(mockSpawnSync).toHaveBeenCalledTimes(1);
+    expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-2234, 'SIGKILL');
+  });
+
+  it('rejects a non-leader root in the shared synchronous snapshot', () => {
+    setPlatform('linux');
+    setSyncProcessTable(['1234 1 999', '1236 1234 1236'].join('\n'));
+    const registry = new ProcessRegistry();
+    const child = fakeChild(1234);
+    registry.reserve().attach(child, { ownsProcessTree: true });
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+
+    registry.killAllSync();
+
+    expect(killSpy).not.toHaveBeenCalledWith(-1234, expect.anything());
+    expect(killSpy).not.toHaveBeenCalledWith(-999, expect.anything());
+    expect(killSpy).not.toHaveBeenCalledWith(-1236, expect.anything());
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('falls back to the direct root when its POSIX group signal fails', async () => {
+    setPlatform('linux');
+    setAsyncProcessTable('1234 1 1234');
+    const child = fakeChild(1234);
+    vi.mocked(child.kill).mockImplementation(() => {
+      child.emit('exit', 0, null);
+      return true;
+    });
+    vi.spyOn(process, 'kill').mockImplementation(((
+      _pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      if (signal === 0) throw errno('ESRCH');
+      throw errno('EPERM');
+    }) as typeof process.kill);
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+
+    await expect(tracked.terminate()).rejects.toThrow('could not send SIGTERM');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('reports an unverified snapshot after applying the root-group fallback', async () => {
+    setPlatform('linux');
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as StringExecCallback;
+      callback(errno('ENOENT'), '', '');
+      return new EventEmitter();
+    });
+    const child = fakeChild(1234);
+    let rootAlive = true;
+    vi.spyOn(process, 'kill').mockImplementation(((
+      _pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      if (signal === 0) {
+        if (!rootAlive) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGTERM') {
+        rootAlive = false;
+        child.emit('exit', 0, null);
+      }
+      return true;
+    }) as typeof process.kill);
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+
+    await expect(tracked.terminate()).rejects.toThrow(
+      'process-tree snapshot failed',
+    );
+  });
+
+  it('does not trust a tree snapshot when the root is not its group leader', async () => {
+    setPlatform('linux');
+    setAsyncProcessTable(['1234 1 999', '1236 1234 1236'].join('\n'));
+    const child = fakeChild(1234);
+    vi.mocked(child.kill).mockImplementation(() => {
+      child.emit('exit', 0, null);
+      return true;
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+
+    await expect(tracked.terminate()).rejects.toThrow(
+      'was not an isolated process-group leader',
+    );
+    expect(killSpy).not.toHaveBeenCalledWith(-1234, expect.anything());
+    expect(killSpy).not.toHaveBeenCalledWith(-999, expect.anything());
+    expect(killSpy).not.toHaveBeenCalledWith(-1236, expect.anything());
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+  });
+
+  it('does not trust an in-flight snapshot after synchronous escalation', async () => {
+    setPlatform('linux');
+    let finishSnapshot: StringExecCallback | undefined;
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      finishSnapshot = args[3] as StringExecCallback;
+      return new EventEmitter();
+    });
+    setSyncProcessTable(['1234 1 1234', '1236 1234 1236'].join('\n'));
+    const child = fakeChild(1234);
+    const aliveGroups = new Set([1234, 1236]);
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((
+      pid: number,
+      signal?: NodeJS.Signals | number,
+    ) => {
+      const group = -pid;
+      if (signal === 0) {
+        if (!aliveGroups.has(group)) throw errno('ESRCH');
+        return true;
+      }
+      if (signal === 'SIGKILL') {
+        aliveGroups.delete(group);
+        if (group === 1234) child.emit('exit', null, 'SIGKILL');
+      }
+      return true;
+    }) as typeof process.kill);
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+    const terminating = tracked.terminate().catch((error: unknown) => error);
+
+    tracked.killSync();
+    finishSnapshot?.(null, ['1234 1 1234', '7776 1234 7777'].join('\n'), '');
+    await terminating;
+
+    expect(killSpy).not.toHaveBeenCalledWith(expect.any(Number), 'SIGTERM');
+    expect(killSpy).not.toHaveBeenCalledWith(-7777, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-1236, 'SIGKILL');
+    expect(killSpy).toHaveBeenCalledWith(-1234, 'SIGKILL');
+  });
+
+  it('uses the absolute Windows taskkill path for asynchronous teardown', async () => {
+    setPlatform('win32');
+    const child = fakeChild(1234);
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as StringExecCallback;
+      callback(null, '', '');
+      child.emit('exit', 0, null);
+      return new EventEmitter();
+    });
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+
+    await tracked.terminate();
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      TASKKILL,
+      ['/f', '/t', '/pid', '1234'],
+      expect.objectContaining({ windowsHide: true, timeout: 2_000 }),
+      expect.any(Function),
+    );
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the direct child when Windows taskkill fails', async () => {
+    setPlatform('win32');
+    const child = fakeChild(1234);
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as StringExecCallback;
+      callback(errno('EACCES'), '', '');
+      return new EventEmitter();
+    });
+    vi.mocked(child.kill).mockImplementation(() => {
+      child.emit('exit', null, 'SIGKILL');
+      return true;
+    });
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+
+    await expect(tracked.terminate()).rejects.toThrow(
+      'process-tree cleanup failed',
+    );
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('uses synchronous Windows taskkill before the direct fallback', () => {
+    setPlatform('win32');
+    mockSpawnSync.mockReturnValue({
+      error: undefined,
+      status: 1,
+      stderr: '',
+      stdout: '',
+    });
+    const child = fakeChild(1234);
+    const tracked = new ProcessRegistry()
+      .reserve()
+      .attach(child, { ownsProcessTree: true });
+
+    tracked.killSync();
+    tracked.killSync();
+
+    expect(mockSpawnSync).toHaveBeenCalledOnce();
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      TASKKILL,
+      ['/f', '/t', '/pid', '1234'],
+      expect.objectContaining({ windowsHide: true, timeout: 2_000 }),
+    );
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
   });
 });

--- a/packages/acp-bridge/src/process-registry.ts
+++ b/packages/acp-bridge/src/process-registry.ts
@@ -4,11 +4,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ChildProcess } from 'node:child_process';
+import {
+  execFile,
+  spawnSync,
+  type ChildProcess,
+  type ExecFileOptionsWithStringEncoding,
+} from 'node:child_process';
 import type { AcpChannelExitInfo } from './channel.js';
 
 const TERM_GRACE_MS = 5_000;
 const EXIT_DEADLINE_MS = 10_000;
+const PROCESS_QUERY_TIMEOUT_MS = 2_000;
+const PROCESS_QUERY_MAX_BUFFER = 8 * 1024 * 1024;
+const PROCESS_POLL_MS = 50;
+const PROCESS_STATE_POLL_MS = 250;
+const MAX_OWNED_PROCESSES = 256;
+const MAX_OWNERSHIP_DEPTH = 8;
+const POSIX_PS = '/bin/ps';
+const WINDOWS_TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+const STRING_EXEC_OPTIONS: ExecFileOptionsWithStringEncoding = {
+  encoding: 'utf8',
+  maxBuffer: PROCESS_QUERY_MAX_BUFFER,
+  timeout: PROCESS_QUERY_TIMEOUT_MS,
+  windowsHide: true,
+};
+
+export interface ProcessAttachmentOptions {
+  /**
+   * The caller owns the complete process tree rooted at this child. POSIX
+   * callers must spawn the child as an isolated process-group leader.
+   */
+  ownsProcessTree?: boolean;
+}
 
 export interface TrackedChildProcess {
   readonly exited: Promise<AcpChannelExitInfo | undefined>;
@@ -17,8 +44,28 @@ export interface TrackedChildProcess {
 }
 
 export interface ProcessReservation {
-  attach(child: ChildProcess): TrackedChildProcess;
+  attach(
+    child: ChildProcess,
+    options?: ProcessAttachmentOptions,
+  ): TrackedChildProcess;
   cancel(): void;
+}
+
+interface ProcessRow {
+  pgid: number;
+  terminal: boolean;
+}
+
+interface ProcessTable {
+  childrenByParent: Map<number, number[]>;
+  rowsByPid: Map<number, ProcessRow>;
+}
+
+interface OwnershipSnapshot {
+  groups: Set<number>;
+  rootIsGroupLeader: boolean;
+  rootSeen: boolean;
+  truncated: boolean;
 }
 
 export class ProcessRegistry {
@@ -35,14 +82,18 @@ export class ProcessRegistry {
     this.reservations.add(token);
     let settled = false;
     return {
-      attach: (child) => {
+      attach: (child, options) => {
         if (settled || !this.reservations.delete(token)) {
           throw new Error('ACP process reservation is no longer active');
         }
         settled = true;
-        const tracked = new TrackedChild(child, () => {
-          this.children.delete(tracked);
-        });
+        const tracked = new TrackedChild(
+          child,
+          options?.ownsProcessTree === true,
+          () => {
+            this.children.delete(tracked);
+          },
+        );
         this.children.add(tracked);
         if (this.draining) void tracked.terminate().catch(() => {});
         return tracked;
@@ -73,7 +124,18 @@ export class ProcessRegistry {
 
   killAllSync(): void {
     this.draining = true;
-    for (const child of this.children) child.killSync();
+    let processTable: ProcessTable | null | undefined;
+    if (
+      process.platform !== 'win32' &&
+      [...this.children].some((child) => child.needsProcessTreeSnapshot)
+    ) {
+      try {
+        processTable = parseProcessTable(queryProcessTableSync());
+      } catch {
+        processTable = null;
+      }
+    }
+    for (const child of this.children) child.killSync(processTable);
   }
 
   get activeProcessCount(): number {
@@ -88,9 +150,9 @@ export class ProcessRegistry {
    * here, while neither is visible in `activeProcessCount` until its child is
    * attached.
    *
-   * A child leaves this count when it *exits*, not when `terminate()` starts,
-   * so a channel swap is counted twice while the old process is still winding
-   * down. That is deliberate: its memory is still resident.
+   * A direct child leaves this count when its root exits. A tree-owned child
+   * under explicit teardown remains committed until its known tree is gone,
+   * so a channel swap includes memory still held by descendants.
    */
   get committedProcessCount(): number {
     return this.children.size + this.reservations.size;
@@ -99,26 +161,39 @@ export class ProcessRegistry {
 
 class TrackedChild implements TrackedChildProcess {
   readonly exited: Promise<AcpChannelExitInfo | undefined>;
+  private readonly knownGroups = new Set<number>();
+  private cleanupProofError: Error | undefined;
+  private exitInfo: AcpChannelExitInfo | undefined;
   private exitedSettled = false;
+  private forceKillRequested = false;
+  private released = false;
+  private releasePollTimer: NodeJS.Timeout | undefined;
+  private releaseStateCheckInFlight = false;
   private spawnConfirmed = false;
   private terminatePromise: Promise<void> | undefined;
+  private terminating = false;
+  private terminationSettled = false;
 
   constructor(
     private readonly child: ChildProcess,
-    private readonly onExit: () => void,
+    private readonly ownsProcessTree: boolean,
+    private readonly onRelease: () => void,
   ) {
+    this.rememberRoot();
     this.exited = new Promise((resolve) => {
       const finish = (info?: AcpChannelExitInfo) => {
         if (this.exitedSettled) return;
         this.exitedSettled = true;
-        this.onExit();
+        this.exitInfo = info;
         resolve(info);
+        this.handleRootExit();
       };
       child.once('exit', (exitCode, signalCode) => {
         finish({ exitCode, signalCode });
       });
       child.once('spawn', () => {
         this.spawnConfirmed = true;
+        this.rememberRoot();
       });
       child.once('error', () => {
         if (!this.spawnConfirmed) finish(undefined);
@@ -127,11 +202,109 @@ class TrackedChild implements TrackedChildProcess {
   }
 
   terminate(): Promise<void> {
-    this.terminatePromise ??= this.terminateOnce();
+    if (this.terminatePromise) return this.terminatePromise;
+    this.terminating = true;
+    if (this.releasePollTimer) {
+      clearTimeout(this.releasePollTimer);
+      this.releasePollTimer = undefined;
+    }
+    const termination = this.ownsProcessTree
+      ? this.terminateTree()
+      : this.terminateDirectChild();
+    this.terminatePromise = termination.finally(() => {
+      this.terminationSettled = true;
+      if (this.ownsProcessTree && this.exitedSettled && !this.released) {
+        this.releaseWhenGroupsExit();
+      }
+    });
     return this.terminatePromise;
   }
 
-  killSync(): void {
+  get needsProcessTreeSnapshot(): boolean {
+    return (
+      this.ownsProcessTree &&
+      !this.forceKillRequested &&
+      !this.rootHasExited &&
+      !this.released
+    );
+  }
+
+  killSync(processTable?: ProcessTable | null): void {
+    if (!this.ownsProcessTree) {
+      this.killDirectChildSync();
+      return;
+    }
+    if (this.released) return;
+    const firstForceKill = !this.forceKillRequested;
+    this.forceKillRequested = true;
+    const rootPid = this.rootPid;
+    if (!rootPid) {
+      this.killDirectChildSync();
+      return;
+    }
+    if (process.platform === 'win32') {
+      if (!firstForceKill) return;
+      if (!taskkillSync(rootPid)) this.killDirectChildSync();
+      return;
+    }
+    if (firstForceKill && !this.rootHasExited) {
+      if (processTable === undefined) this.mergeSynchronousSnapshot();
+      else if (processTable !== null) {
+        this.mergeSnapshot(collectOwnership(processTable, rootPid));
+      }
+    }
+    const rootSignalled = this.signalKnownGroups('SIGKILL');
+    this.signalDirectRootIfNeeded('SIGKILL', rootSignalled);
+    if (this.exitedSettled && this.survivingGroups().length === 0) {
+      this.release();
+    }
+  }
+
+  private get rootPid(): number | undefined {
+    const pid = this.child.pid;
+    return typeof pid === 'number' && Number.isSafeInteger(pid) && pid > 0
+      ? pid
+      : undefined;
+  }
+
+  private get rootHasExited(): boolean {
+    return (
+      this.exitedSettled ||
+      this.child.exitCode !== null ||
+      this.child.signalCode !== null
+    );
+  }
+
+  private rememberRoot(): void {
+    if (!this.ownsProcessTree) return;
+    const rootPid = this.rootPid;
+    if (!rootPid) return;
+    if (process.platform !== 'win32') this.knownGroups.add(rootPid);
+  }
+
+  private handleRootExit(): void {
+    if (!this.ownsProcessTree) {
+      this.release();
+      return;
+    }
+    if (this.terminating && !this.terminationSettled) return;
+    if (process.platform !== 'win32') {
+      this.forceKillRequested = true;
+      this.signalKnownGroups('SIGKILL');
+      this.releaseWhenGroupsExit();
+      return;
+    }
+    this.release();
+  }
+
+  private release(): void {
+    if (this.released) return;
+    this.released = true;
+    if (this.releasePollTimer) clearTimeout(this.releasePollTimer);
+    this.onRelease();
+  }
+
+  private killDirectChildSync(): void {
     if (this.exitedSettled) return;
     try {
       this.child.kill('SIGKILL');
@@ -140,7 +313,20 @@ class TrackedChild implements TrackedChildProcess {
     }
   }
 
-  private async terminateOnce(): Promise<void> {
+  private signalDirectRootIfNeeded(
+    signal: NodeJS.Signals,
+    rootGroupSignalled: boolean,
+  ): void {
+    const rootPid = this.rootPid;
+    if (!rootPid || this.exitedSettled || rootGroupSignalled) return;
+    try {
+      this.child.kill(signal);
+    } catch {
+      // The root may have exited after the group liveness check.
+    }
+  }
+
+  private async terminateDirectChild(): Promise<void> {
     if (this.exitedSettled) return;
     try {
       this.child.kill('SIGTERM');
@@ -151,7 +337,10 @@ class TrackedChild implements TrackedChildProcess {
     let hardKillTimer: NodeJS.Timeout | undefined;
     let deadlineTimer: NodeJS.Timeout | undefined;
     const deadline = new Promise<never>((_, reject) => {
-      hardKillTimer = setTimeout(() => this.killSync(), TERM_GRACE_MS);
+      hardKillTimer = setTimeout(
+        () => this.killDirectChildSync(),
+        TERM_GRACE_MS,
+      );
       hardKillTimer.unref();
       deadlineTimer = setTimeout(() => {
         reject(
@@ -164,18 +353,462 @@ class TrackedChild implements TrackedChildProcess {
     });
     try {
       const exitInfo = await Promise.race([this.exited, deadline]);
-      if (
-        exitInfo &&
-        (exitInfo.exitCode !== 0 || exitInfo.signalCode !== null)
-      ) {
-        throw new Error(
-          `ACP child pid=${this.child.pid ?? 'unknown'} exited uncleanly during shutdown ` +
-            `(code=${exitInfo.exitCode ?? 'none'}, signal=${exitInfo.signalCode ?? 'none'})`,
-        );
-      }
+      this.throwForUncleanExit(exitInfo);
     } finally {
       if (hardKillTimer) clearTimeout(hardKillTimer);
       if (deadlineTimer) clearTimeout(deadlineTimer);
     }
   }
+
+  private async terminateTree(): Promise<void> {
+    if (this.exitedSettled && (process.platform === 'win32' || this.released)) {
+      return;
+    }
+    const rootPid = this.rootPid;
+    if (!rootPid) {
+      await this.terminateDirectChild();
+      return;
+    }
+    if (process.platform === 'win32') {
+      await this.terminateWindowsTree(rootPid);
+      return;
+    }
+    await this.terminatePosixTree(rootPid);
+  }
+
+  private async terminatePosixTree(rootPid: number): Promise<void> {
+    const startedAt = Date.now();
+    if (!this.rootHasExited) {
+      await this.mergeAsynchronousSnapshot(rootPid, true);
+    }
+    let escalated = this.forceKillRequested;
+    let rootSignalled = this.signalKnownGroups(
+      escalated ? 'SIGKILL' : 'SIGTERM',
+    );
+    this.signalDirectRootIfNeeded(
+      escalated ? 'SIGKILL' : 'SIGTERM',
+      rootSignalled,
+    );
+    const graceDeadline = Math.min(
+      startedAt + EXIT_DEADLINE_MS,
+      Date.now() + TERM_GRACE_MS,
+    );
+    const exitDeadline = startedAt + EXIT_DEADLINE_MS;
+    let nextStateCheckAt = 0;
+
+    while (true) {
+      let survivingGroups = this.survivingGroups();
+      let now = Date.now();
+      if (
+        this.exitedSettled &&
+        escalated &&
+        survivingGroups.length > 0 &&
+        now < exitDeadline &&
+        now >= nextStateCheckAt
+      ) {
+        await this.pruneTerminalGroups(survivingGroups, exitDeadline - now);
+        nextStateCheckAt = Date.now() + PROCESS_STATE_POLL_MS;
+        survivingGroups = this.survivingGroups();
+        now = Date.now();
+      }
+      if (this.exitedSettled && survivingGroups.length === 0) {
+        this.release();
+        if (this.cleanupProofError) throw this.cleanupProofError;
+        this.throwForUncleanExit(this.exitInfo);
+        return;
+      }
+
+      if (!escalated && (this.forceKillRequested || now >= graceDeadline)) {
+        if (!this.rootHasExited && this.knownGroups.has(rootPid)) {
+          await this.mergeAsynchronousSnapshot(rootPid, false);
+        }
+        escalated = true;
+        rootSignalled = this.signalKnownGroups('SIGKILL');
+        this.signalDirectRootIfNeeded('SIGKILL', rootSignalled);
+        continue;
+      }
+      if (now >= exitDeadline) {
+        const groups = survivingGroups.join(',') || 'none';
+        const proof = this.cleanupProofError
+          ? `; ${this.cleanupProofError.message}`
+          : '';
+        throw new Error(
+          `ACP child pid=${rootPid} did not exit with its owned process groups ` +
+            `within ${EXIT_DEADLINE_MS}ms (surviving pgids=${groups})${proof}`,
+        );
+      }
+      await delay(
+        Math.min(
+          PROCESS_POLL_MS,
+          (escalated ? exitDeadline : graceDeadline) - now,
+        ),
+      );
+      if (this.forceKillRequested) escalated = true;
+    }
+  }
+
+  private async terminateWindowsTree(rootPid: number): Promise<void> {
+    const startedAt = Date.now();
+    let treeKillError: Error | undefined;
+    try {
+      await taskkill(rootPid);
+    } catch (error) {
+      treeKillError = toError(error);
+      this.killDirectChildSync();
+    }
+
+    const remainingMs = Math.max(
+      1,
+      EXIT_DEADLINE_MS - (Date.now() - startedAt),
+    );
+    const exitInfo = await waitForPromise(this.exited, remainingMs).catch(
+      () => {
+        throw new Error(
+          `ACP child pid=${rootPid} did not exit within ${EXIT_DEADLINE_MS}ms` +
+            (treeKillError ? `; ${treeKillError.message}` : ''),
+        );
+      },
+    );
+    this.release();
+    if (treeKillError) {
+      throw new Error(
+        `ACP child pid=${rootPid} process-tree cleanup failed: ${treeKillError.message}`,
+      );
+    }
+    this.throwForUncleanExit(exitInfo);
+  }
+
+  private async mergeAsynchronousSnapshot(
+    rootPid: number,
+    initial: boolean,
+  ): Promise<void> {
+    try {
+      const table = parseProcessTable(await queryProcessTable());
+      if (this.rootHasExited) {
+        if (initial && !this.forceKillRequested) {
+          this.recordCleanupProofError(
+            `ACP child pid=${rootPid} exited before its initial process-tree snapshot completed`,
+          );
+        }
+        return;
+      }
+      const snapshot = collectOwnership(table, rootPid);
+      this.mergeSnapshot(snapshot);
+      if (snapshot.truncated) {
+        this.recordCleanupProofError(
+          `ACP child pid=${rootPid} process-tree snapshot exceeded ` +
+            `${MAX_OWNED_PROCESSES} processes or depth ${MAX_OWNERSHIP_DEPTH}`,
+        );
+      }
+      if (initial && !snapshot.rootSeen) {
+        this.recordCleanupProofError(
+          `ACP child pid=${rootPid} was absent from the initial process-tree snapshot`,
+        );
+      } else if (initial && !snapshot.rootIsGroupLeader) {
+        this.recordCleanupProofError(
+          `ACP child pid=${rootPid} was not an isolated process-group leader`,
+        );
+      }
+    } catch (error) {
+      this.recordCleanupProofError(
+        `ACP child pid=${rootPid} process-tree snapshot failed: ${toError(error).message}`,
+      );
+    }
+  }
+
+  private mergeSynchronousSnapshot(): void {
+    const rootPid = this.rootPid;
+    if (!rootPid || process.platform === 'win32' || this.rootHasExited) return;
+    try {
+      const table = parseProcessTable(queryProcessTableSync());
+      this.mergeSnapshot(collectOwnership(table, rootPid));
+    } catch {
+      // The isolated root group remains a safe synchronous fallback.
+    }
+  }
+
+  private mergeSnapshot(snapshot: OwnershipSnapshot): void {
+    if (!snapshot.rootIsGroupLeader) {
+      const rootPid = this.rootPid;
+      if (snapshot.rootSeen && rootPid) this.knownGroups.delete(rootPid);
+      return;
+    }
+    for (const group of snapshot.groups) this.knownGroups.add(group);
+  }
+
+  private signalKnownGroups(signal: NodeJS.Signals): boolean {
+    const rootPid = this.rootPid;
+    let rootSignalled = false;
+    const groups = [...this.knownGroups].sort((left, right) => {
+      if (left === rootPid) return 1;
+      if (right === rootPid) return -1;
+      return right - left;
+    });
+    for (const group of groups) {
+      try {
+        process.kill(-group, signal);
+        if (group === rootPid) rootSignalled = true;
+      } catch (error) {
+        if (isErrno(error, 'ESRCH')) {
+          this.knownGroups.delete(group);
+          continue;
+        }
+        this.recordCleanupProofError(
+          `ACP child pid=${rootPid ?? 'unknown'} could not send ${signal} ` +
+            `to pgid=${group}: ${toError(error).message}`,
+        );
+      }
+    }
+    return rootSignalled;
+  }
+
+  private survivingGroups(): number[] {
+    const surviving: number[] = [];
+    for (const group of this.knownGroups) {
+      try {
+        process.kill(-group, 0);
+        surviving.push(group);
+      } catch (error) {
+        if (isErrno(error, 'ESRCH')) {
+          this.knownGroups.delete(group);
+          continue;
+        }
+        surviving.push(group);
+        if (!isErrno(error, 'EPERM')) {
+          this.recordCleanupProofError(
+            `ACP child pid=${this.rootPid ?? 'unknown'} could not inspect ` +
+              `pgid=${group}: ${toError(error).message}`,
+          );
+        }
+      }
+    }
+    return surviving;
+  }
+
+  private recordCleanupProofError(message: string): void {
+    this.cleanupProofError ??= new Error(message);
+  }
+
+  private async pruneTerminalGroups(
+    groups: readonly number[],
+    timeoutMs = PROCESS_QUERY_TIMEOUT_MS,
+  ): Promise<void> {
+    try {
+      const table = parseProcessTable(await queryProcessTable(timeoutMs));
+      const targets = new Set(groups);
+      const terminalGroups = new Set<number>();
+      const liveGroups = new Set<number>();
+      for (const row of table.rowsByPid.values()) {
+        if (!targets.has(row.pgid)) continue;
+        if (row.terminal) terminalGroups.add(row.pgid);
+        else liveGroups.add(row.pgid);
+      }
+      for (const group of terminalGroups) {
+        if (!liveGroups.has(group)) this.knownGroups.delete(group);
+      }
+    } catch {
+      // Keep treating the group as live when process state cannot be verified.
+    }
+  }
+
+  private releaseWhenGroupsExit(): void {
+    if (
+      this.released ||
+      this.releasePollTimer ||
+      this.releaseStateCheckInFlight ||
+      (this.terminating && !this.terminationSettled)
+    ) {
+      return;
+    }
+    const survivingGroups = this.survivingGroups();
+    if (survivingGroups.length === 0) {
+      this.release();
+      return;
+    }
+    this.releaseStateCheckInFlight = true;
+    void this.pruneTerminalGroups(survivingGroups).finally(() => {
+      this.releaseStateCheckInFlight = false;
+      if (this.released) return;
+      if (this.terminating && !this.terminationSettled) return;
+      if (this.survivingGroups().length === 0) {
+        this.release();
+        return;
+      }
+      this.releasePollTimer = setTimeout(() => {
+        this.releasePollTimer = undefined;
+        this.releaseWhenGroupsExit();
+      }, PROCESS_STATE_POLL_MS);
+      this.releasePollTimer.unref();
+    });
+  }
+
+  private throwForUncleanExit(exitInfo: AcpChannelExitInfo | undefined): void {
+    if (exitInfo && (exitInfo.exitCode !== 0 || exitInfo.signalCode !== null)) {
+      throw new Error(
+        `ACP child pid=${this.child.pid ?? 'unknown'} exited uncleanly during shutdown ` +
+          `(code=${exitInfo.exitCode ?? 'none'}, signal=${exitInfo.signalCode ?? 'none'})`,
+      );
+    }
+  }
+}
+
+function parseProcessTable(stdout: string): ProcessTable {
+  const rowsByPid = new Map<number, ProcessRow>();
+  const childrenByParent = new Map<number, number[]>();
+  for (const line of stdout.split('\n')) {
+    const match = line
+      .trim()
+      .match(/^(\d+)\s+(\d+)\s+(\d+)(?:\s+(\S+)(?:\s+(\d+))?)?$/u);
+    if (!match) continue;
+    const pid = Number.parseInt(match[1], 10);
+    const ppid = Number.parseInt(match[2], 10);
+    const pgid = Number.parseInt(match[3], 10);
+    const state = match[4];
+    const threadCount = match[5] ? Number.parseInt(match[5], 10) : undefined;
+    if (
+      !Number.isSafeInteger(pid) ||
+      !Number.isSafeInteger(ppid) ||
+      !Number.isSafeInteger(pgid) ||
+      pid <= 0 ||
+      ppid < 0 ||
+      pgid <= 0
+    ) {
+      continue;
+    }
+    const terminal =
+      state?.startsWith('X') === true ||
+      (state?.startsWith('Z') === true &&
+        (process.platform !== 'linux' || threadCount === 1));
+    rowsByPid.set(pid, { pgid, terminal });
+    const children = childrenByParent.get(ppid);
+    if (children) children.push(pid);
+    else childrenByParent.set(ppid, [pid]);
+  }
+  if (rowsByPid.size === 0) {
+    throw new Error('process-table query returned no parseable rows');
+  }
+  return { childrenByParent, rowsByPid };
+}
+
+function collectOwnership(
+  table: ProcessTable,
+  rootPid: number,
+): OwnershipSnapshot {
+  const groups = new Set<number>();
+  const visited = new Set<number>();
+  const queue = [{ depth: 0, pid: rootPid }];
+  let truncated = false;
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current.pid)) continue;
+    if (visited.size >= MAX_OWNED_PROCESSES) {
+      truncated = true;
+      break;
+    }
+    visited.add(current.pid);
+    const row = table.rowsByPid.get(current.pid);
+    if (row) groups.add(row.pgid);
+    const children = table.childrenByParent.get(current.pid) ?? [];
+    if (current.depth >= MAX_OWNERSHIP_DEPTH) {
+      if (children.length > 0) truncated = true;
+      continue;
+    }
+    for (const pid of children) {
+      queue.push({ depth: current.depth + 1, pid });
+    }
+  }
+  const root = table.rowsByPid.get(rootPid);
+  return {
+    groups,
+    rootIsGroupLeader: root?.pgid === rootPid,
+    rootSeen: root !== undefined,
+    truncated,
+  };
+}
+
+function queryProcessTable(
+  timeoutMs = PROCESS_QUERY_TIMEOUT_MS,
+): Promise<string> {
+  return runExecFile(POSIX_PS, posixPsArgs(), {
+    ...STRING_EXEC_OPTIONS,
+    timeout: Math.max(1, Math.min(PROCESS_QUERY_TIMEOUT_MS, timeoutMs)),
+  });
+}
+
+function queryProcessTableSync(): string {
+  const result = spawnSync(POSIX_PS, posixPsArgs(), STRING_EXEC_OPTIONS);
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`ps exited with status ${result.status ?? 'unknown'}`);
+  }
+  return result.stdout;
+}
+
+function posixPsArgs(): string[] {
+  const columns =
+    process.platform === 'linux'
+      ? 'pid=,ppid=,pgid=,state=,nlwp='
+      : 'pid=,ppid=,pgid=,state=';
+  return ['-A', '-o', columns];
+}
+
+function taskkill(rootPid: number): Promise<string> {
+  return runExecFile(
+    WINDOWS_TASKKILL,
+    ['/f', '/t', '/pid', String(rootPid)],
+    STRING_EXEC_OPTIONS,
+  );
+}
+
+function taskkillSync(rootPid: number): boolean {
+  try {
+    const result = spawnSync(
+      WINDOWS_TASKKILL,
+      ['/f', '/t', '/pid', String(rootPid)],
+      STRING_EXEC_OPTIONS,
+    );
+    return !result.error && result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function runExecFile(
+  file: string,
+  args: string[],
+  options: ExecFileOptionsWithStringEncoding,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+}
+
+function waitForPromise<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('deadline exceeded')), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(1, ms)));
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error.code === code
+  );
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/acp-bridge/src/spawnChannel.test.ts
+++ b/packages/acp-bridge/src/spawnChannel.test.ts
@@ -41,12 +41,18 @@ import { createChildHeapPolicy } from './child-heap-policy.js';
 import { resolveDaemonMemoryBudget } from './daemon-memory-budget.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockSpawn = vi.hoisted(() => vi.fn());
+const { mockExecFile, mockSpawn, mockSpawnSync } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+  mockSpawn: vi.fn(),
+  mockSpawnSync: vi.fn(),
+}));
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
   return {
     ...actual,
+    execFile: mockExecFile,
     spawn: mockSpawn,
+    spawnSync: mockSpawnSync,
   };
 });
 
@@ -59,18 +65,47 @@ import {
 } from './spawnChannel.js';
 
 function createFakeChildProcess(): ChildProcess {
-  return Object.assign(new EventEmitter(), {
+  const child = Object.assign(new EventEmitter(), {
     stdin: new PassThrough(),
     stdout: new PassThrough(),
     stderr: new PassThrough(),
     pid: 12345,
     exitCode: null,
     signalCode: null,
-    kill: vi.fn(() => true),
-  }) as unknown as ChildProcess;
+    kill: vi.fn(),
+  });
+  child.kill.mockImplementation((signal?: NodeJS.Signals | number) => {
+    const signalCode = typeof signal === 'string' ? signal : 'SIGTERM';
+    child.emit('exit', null, signalCode);
+    return true;
+  });
+  return child as unknown as ChildProcess;
 }
 
 beforeEach(() => {
+  mockExecFile.mockImplementation((...args: unknown[]) => {
+    const callback = args[3] as (
+      error: Error | null,
+      stdout: string,
+      stderr: string,
+    ) => void;
+    callback(
+      Object.assign(new Error('mock process lookup failure'), {
+        code: 'ENOENT',
+      }),
+      '',
+      '',
+    );
+    return new EventEmitter();
+  });
+  mockSpawnSync.mockReturnValue({
+    error: Object.assign(new Error('mock process lookup failure'), {
+      code: 'ENOENT',
+    }),
+    status: null,
+    stderr: '',
+    stdout: '',
+  });
   vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
     if (pid < 0) {
       throw Object.assign(new Error('missing fake process group'), {
@@ -83,7 +118,13 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  mockExecFile.mockReset();
+  mockSpawnSync.mockReset();
 });
+
+function expectedTreeFallbackSignal(): NodeJS.Signals {
+  return process.platform === 'win32' ? 'SIGKILL' : 'SIGTERM';
+}
 
 describe('createSpawnChannelFactory env policy', () => {
   const originalArgv1 = process.argv[1];
@@ -172,6 +213,33 @@ describe('createSpawnChannelFactory env policy', () => {
       | { env?: NodeJS.ProcessEnv }
       | undefined;
     expect(spawnOptions?.env?.['QWEN_CODE_SERVE']).toBe('1');
+  });
+
+  it('attaches the spawned ACP child as an owned process tree', async () => {
+    const child = createFakeChildProcess();
+    mockSpawn.mockReturnValue(child);
+    const registry = new ProcessRegistry();
+    const reserve = registry.reserve.bind(registry);
+    let attachmentOptions:
+      | Parameters<ReturnType<ProcessRegistry['reserve']>['attach']>[1]
+      | undefined;
+    vi.spyOn(registry, 'reserve').mockImplementation(() => {
+      const reservation = reserve();
+      const attach = reservation.attach.bind(reservation);
+      vi.spyOn(reservation, 'attach').mockImplementation(
+        (attachedChild, options) => {
+          attachmentOptions = options;
+          return attach(attachedChild, options);
+        },
+      );
+      return reservation;
+    });
+
+    await createSpawnChannelFactory({ processRegistry: registry })(
+      '/tmp/project',
+    );
+
+    expect(attachmentOptions).toEqual({ ownsProcessTree: true });
   });
 
   it('passes optional child args after --acp', async () => {
@@ -269,7 +337,9 @@ describe('createSpawnChannelFactory env policy', () => {
     await expect(channel.transportFailed).resolves.toMatchObject({
       code: 'ndjson_frame_too_large',
     });
-    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith('SIGTERM'));
+    await vi.waitFor(() =>
+      expect(child.kill).toHaveBeenCalledWith(expectedTreeFallbackSignal()),
+    );
     reader.releaseLock();
   });
 
@@ -331,7 +401,9 @@ describe('createSpawnChannelFactory env policy', () => {
       code: 'ndjson_unexpected_eof',
     });
     await expect(connection.closed).resolves.toBeUndefined();
-    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith('SIGTERM'));
+    await vi.waitFor(() =>
+      expect(child.kill).toHaveBeenCalledWith(expectedTreeFallbackSignal()),
+    );
   });
 
   it('terminates the tracked child when outbound serialization fails', async () => {
@@ -355,7 +427,9 @@ describe('createSpawnChannelFactory env policy', () => {
     await expect(writer.write(cyclic as never)).rejects.toBeInstanceOf(
       TypeError,
     );
-    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith('SIGTERM'));
+    await vi.waitFor(() =>
+      expect(child.kill).toHaveBeenCalledWith(expectedTreeFallbackSignal()),
+    );
     writer.releaseLock();
   });
 
@@ -394,7 +468,9 @@ describe('createSpawnChannelFactory env policy', () => {
     await expect(channel.transportFailed).resolves.toMatchObject({
       code: 'ndjson_queue_limit_exceeded',
     });
-    await vi.waitFor(() => expect(child.kill).toHaveBeenCalledWith('SIGTERM'));
+    await vi.waitFor(() =>
+      expect(child.kill).toHaveBeenCalledWith(expectedTreeFallbackSignal()),
+    );
     writer.releaseLock();
   });
 

--- a/packages/acp-bridge/src/spawnChannel.test.ts
+++ b/packages/acp-bridge/src/spawnChannel.test.ts
@@ -70,6 +70,21 @@ function createFakeChildProcess(): ChildProcess {
   }) as unknown as ChildProcess;
 }
 
+beforeEach(() => {
+  vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+    if (pid < 0) {
+      throw Object.assign(new Error('missing fake process group'), {
+        code: 'ESRCH',
+      });
+    }
+    return true;
+  }) as typeof process.kill);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('createSpawnChannelFactory env policy', () => {
   const originalArgv1 = process.argv[1];
   let originalSimple: string | undefined;
@@ -131,9 +146,14 @@ describe('createSpawnChannelFactory env policy', () => {
     });
 
     const spawnOptions = mockSpawn.mock.calls[0]?.[2] as
-      | { env?: NodeJS.ProcessEnv; windowsHide?: boolean }
+      | {
+          detached?: boolean;
+          env?: NodeJS.ProcessEnv;
+          windowsHide?: boolean;
+        }
       | undefined;
     expect(spawnOptions?.windowsHide).toBe(true);
+    expect(spawnOptions?.detached).toBe(process.platform !== 'win32');
     expect(spawnOptions?.env).not.toHaveProperty('QWEN_CODE_SIMPLE');
     expect(spawnOptions?.env).not.toHaveProperty('QWEN_SERVER_TOKEN');
     expect(spawnOptions?.env).not.toHaveProperty(

--- a/packages/acp-bridge/src/spawnChannel.ts
+++ b/packages/acp-bridge/src/spawnChannel.ts
@@ -481,6 +481,7 @@ export function createSpawnChannelFactory(
         {
           cwd: workspaceCwd,
           stdio: ['pipe', 'pipe', 'pipe'],
+          detached: process.platform !== 'win32',
           windowsHide: true,
           env: childEnv,
         },
@@ -489,7 +490,7 @@ export function createSpawnChannelFactory(
       reservation.cancel();
       throw error;
     }
-    const trackedChild = reservation.attach(child);
+    const trackedChild = reservation.attach(child, { ownsProcessTree: true });
 
     // Forward child stderr to the daemon's stderr line-by-line, with a
     // `[serve pid=… cwd=…]` prefix on each line so operators can

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -46,8 +46,8 @@ import { HEADLESS_YOLO_NO_SANDBOX_WARNING } from '../utils/headlessSafetyWarning
  * Pause the current async function indefinitely. Used after the daemon
  * listener is up so yargs `parse()` never resolves — if it did, the
  * top-level CLI would fall through to the interactive (TUI) entry point
- * in `gemini.tsx`. SIGINT / SIGTERM in `runQwenServe` is the sole exit
- * route.
+ * in `gemini.tsx`. SIGINT / SIGTERM / SIGHUP in `runQwenServe` is the sole
+ * exit route.
  */
 function blockForever(): Promise<never> {
   return new Promise<never>(() => {});

--- a/packages/cli/src/serve/process-env-guard.test.ts
+++ b/packages/cli/src/serve/process-env-guard.test.ts
@@ -45,6 +45,14 @@ const allowedProcessEnvAccesses = normalizeAllowances([
     },
   ],
   [
+    'packages/acp-bridge/src/process-registry.ts',
+    {
+      reason:
+        'Windows process-tree cleanup resolves the trusted System32 taskkill path from the process-scoped OS root.',
+      accesses: { 'key:SystemRoot': 1 },
+    },
+  ],
+  [
     'packages/acp-bridge/src/spawnChannel.ts',
     {
       reason:

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -12992,6 +12992,7 @@ describe('runQwenServe channel worker supervisor', () => {
       .spyOn(process, 'exit')
       .mockImplementation((() => undefined) as never);
     const existingSigtermListeners = new Set(process.rawListeners('SIGTERM'));
+    const existingSighupListeners = new Set(process.rawListeners('SIGHUP'));
 
     const handle = await runQwenServe(
       {
@@ -13017,11 +13018,19 @@ describe('runQwenServe channel worker supervisor', () => {
             !existingSigtermListeners.has(listener) &&
             listener.name === 'onSignal',
         ) as ((signal: NodeJS.Signals) => Promise<void>) | undefined;
+      const sighupListener = process
+        .rawListeners('SIGHUP')
+        .find(
+          (listener) =>
+            !existingSighupListeners.has(listener) &&
+            listener.name === 'onSignal',
+        ) as ((signal: NodeJS.Signals) => Promise<void>) | undefined;
       expect(signalListener).toBeDefined();
+      expect(sighupListener).toBe(signalListener);
 
       const firstSignal = signalListener!('SIGTERM');
       await Promise.resolve();
-      const secondSignal = signalListener!('SIGTERM');
+      const secondSignal = sighupListener!('SIGHUP');
       await secondSignal;
 
       expect(worker.killAllSync).toHaveBeenCalled();
@@ -13033,6 +13042,56 @@ describe('runQwenServe channel worker supervisor', () => {
       await firstSignal;
     } finally {
       finishBridgeShutdown?.();
+      await handle.close();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('routes SIGHUP through graceful shutdown and removes its listener', async () => {
+    tmpDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'qws-sighup-shutdown-')),
+    );
+    const bridge = makeFakeBridge();
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    const existingSighupListeners = new Set(process.rawListeners('SIGHUP'));
+    const handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace: tmpDir,
+        serveWebShell: false,
+      },
+      { bridge },
+    );
+    const processRegistry = mockCreateSpawnChannelFactoryOptions.at(-1)?.[
+      'processRegistry'
+    ] as { shutdown: () => Promise<void> };
+    const shutdownSpy = vi.spyOn(processRegistry, 'shutdown');
+
+    try {
+      const signalListener = process
+        .rawListeners('SIGHUP')
+        .find(
+          (listener) =>
+            !existingSighupListeners.has(listener) &&
+            listener.name === 'onSignal',
+        ) as ((signal: NodeJS.Signals) => Promise<void>) | undefined;
+      expect(signalListener).toBeDefined();
+
+      await signalListener!('SIGHUP');
+
+      expect(shutdownSpy).toHaveBeenCalledOnce();
+      expect(bridge.shutdown).toHaveBeenCalledOnce();
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(
+        process
+          .rawListeners('SIGHUP')
+          .some((listener) => !existingSighupListeners.has(listener)),
+      ).toBe(false);
+    } finally {
       await handle.close();
       exitSpy.mockRestore();
     }
@@ -13061,6 +13120,7 @@ describe('runQwenServe channel worker supervisor', () => {
       .mockImplementation((() => undefined) as never);
     const existingSigintListeners = new Set(process.rawListeners('SIGINT'));
     const existingSigtermListeners = new Set(process.rawListeners('SIGTERM'));
+    const existingSighupListeners = new Set(process.rawListeners('SIGHUP'));
 
     await runQwenServe(
       {
@@ -13114,6 +13174,11 @@ describe('runQwenServe channel worker supervisor', () => {
           process.removeListener('SIGTERM', listener as never);
         }
       }
+      for (const listener of process.rawListeners('SIGHUP')) {
+        if (!existingSighupListeners.has(listener)) {
+          process.removeListener('SIGHUP', listener as never);
+        }
+      }
       exitSpy.mockRestore();
     }
   });
@@ -13134,6 +13199,7 @@ describe('runQwenServe channel worker supervisor', () => {
       .mockImplementation((() => undefined) as never);
     const existingSigintListeners = new Set(process.rawListeners('SIGINT'));
     const existingSigtermListeners = new Set(process.rawListeners('SIGTERM'));
+    const existingSighupListeners = new Set(process.rawListeners('SIGHUP'));
 
     await runQwenServe(
       {
@@ -13182,6 +13248,11 @@ describe('runQwenServe channel worker supervisor', () => {
           process.removeListener('SIGTERM', listener as never);
         }
       }
+      for (const listener of process.rawListeners('SIGHUP')) {
+        if (!existingSighupListeners.has(listener)) {
+          process.removeListener('SIGHUP', listener as never);
+        }
+      }
       exitSpy.mockRestore();
     }
   });
@@ -13208,6 +13279,7 @@ describe('runQwenServe channel worker supervisor', () => {
       .mockImplementation((() => undefined) as never);
     const existingSigintListeners = new Set(process.rawListeners('SIGINT'));
     const existingSigtermListeners = new Set(process.rawListeners('SIGTERM'));
+    const existingSighupListeners = new Set(process.rawListeners('SIGHUP'));
 
     await runQwenServe(
       {
@@ -13258,6 +13330,11 @@ describe('runQwenServe channel worker supervisor', () => {
           process.removeListener('SIGTERM', listener as never);
         }
       }
+      for (const listener of process.rawListeners('SIGHUP')) {
+        if (!existingSighupListeners.has(listener)) {
+          process.removeListener('SIGHUP', listener as never);
+        }
+      }
       exitSpy.mockRestore();
     }
   });
@@ -13283,6 +13360,7 @@ describe('runQwenServe channel worker supervisor', () => {
       .mockImplementation((() => undefined) as never);
     const existingSigintListeners = new Set(process.rawListeners('SIGINT'));
     const existingSigtermListeners = new Set(process.rawListeners('SIGTERM'));
+    const existingSighupListeners = new Set(process.rawListeners('SIGHUP'));
 
     const handle = await runQwenServe(
       {
@@ -13330,6 +13408,11 @@ describe('runQwenServe channel worker supervisor', () => {
       for (const listener of process.rawListeners('SIGTERM')) {
         if (!existingSigtermListeners.has(listener)) {
           process.removeListener('SIGTERM', listener as never);
+        }
+      }
+      for (const listener of process.rawListeners('SIGHUP')) {
+        if (!existingSighupListeners.has(listener)) {
+          process.removeListener('SIGHUP', listener as never);
         }
       }
       exitSpy.mockRestore();
@@ -14040,6 +14123,7 @@ describe('runQwenServe channel worker supervisor', () => {
       .mockImplementation((() => undefined) as never);
     const existingSigintListeners = new Set(process.rawListeners('SIGINT'));
     const existingSigtermListeners = new Set(process.rawListeners('SIGTERM'));
+    const existingSighupListeners = new Set(process.rawListeners('SIGHUP'));
     let settled = false;
 
     const running = runQwenServe(
@@ -14098,6 +14182,11 @@ describe('runQwenServe channel worker supervisor', () => {
       for (const listener of process.rawListeners('SIGTERM')) {
         if (!existingSigtermListeners.has(listener)) {
           process.removeListener('SIGTERM', listener as never);
+        }
+      }
+      for (const listener of process.rawListeners('SIGHUP')) {
+        if (!existingSighupListeners.has(listener)) {
+          process.removeListener('SIGHUP', listener as never);
         }
       }
       exitSpy.mockRestore();

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -8592,7 +8592,7 @@ async function runQwenServeImpl(
             clearRuntimeStartAfterHealthTimer();
             clearRuntimeStartFallbackTimer();
             cancelDeferredRuntimeStartup();
-            // NOTE: the SIGINT/SIGTERM handlers stay attached during the
+            // NOTE: the shutdown signal handlers stay attached during the
             // drain so a second signal can take the explicit force-exit path
             // above. Detaching them up front would leave Node's default signal
             // behavior in charge and could orphan agent children. We detach
@@ -8625,6 +8625,7 @@ async function runQwenServeImpl(
               if (!preserveSignalHandlers) {
                 process.removeListener('SIGINT', onSignal);
                 process.removeListener('SIGTERM', onSignal);
+                process.removeListener('SIGHUP', onSignal);
               }
               process.removeListener(
                 'uncaughtExceptionMonitor',
@@ -8930,6 +8931,7 @@ async function runQwenServeImpl(
 
       process.on('SIGINT', onSignal);
       process.on('SIGTERM', onSignal);
+      process.on('SIGHUP', onSignal);
       process.on('uncaughtExceptionMonitor', onUncaughtExceptionMonitor);
 
       // The per-attempt boot-error listener was removed by handleListening.


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR gives ACP children created by the standard spawn factory an explicit process-tree ownership boundary. On POSIX it isolates the ACP root in its own process group, records descendant process groups before signalling, and reaps known groups across graceful shutdown, unexpected root exit, and synchronous force-exit. On Windows it uses the native tree-kill operation. The daemon also routes SIGHUP through the same graceful and second-signal lifecycle as SIGINT and SIGTERM, while Linux zombie-only process groups are released only after conservative state verification.

## Why it's needed

ACP teardown previously signalled only the direct child and released its registry entry as soon as that root exited. Hooks, shell commands, MCP servers, or other descendants could therefore survive channel replacement or daemon shutdown under PID 1, and an isolated ACP process group would otherwise stop receiving the host's SIGHUP lifecycle signal. The change makes the existing teardown contract cover the process tree that the daemon owns without changing bridge routing, session ownership, or legacy direct-child callers.

## Reviewer Test Plan

### How to verify

- Start an ACP-like root that creates both an ordinary descendant and a descendant in a separate session, then trigger graceful teardown; expect both descendants to be gone after TERM-to-KILL escalation and the registry count to return to zero.
- Repeat with synchronous force teardown; expect the known process groups to receive KILL before the call returns.
- Start `qwen serve`, send SIGHUP once, and expect normal draining plus ACP cleanup; send a second shutdown signal during draining and expect the synchronous force-exit path to run.
- Run the focused ACP bridge tests and the daemon serve test file; expect 72 ACP tests and 328 daemon tests to pass, including POSIX ownership, Windows taskkill fallback, Linux zombie-state, concurrency, and signal-listener cases.

### Evidence (Before & After)

Before: On macOS, real-process reproduction showed both ordinary and separately sessioned grandchildren surviving graceful and synchronous root teardown under PPID 1; SIGHUP used Node's default exit path instead of daemon cleanup.

After: The same real-process ACP harness reaped both descendants in graceful and synchronous teardown. A serve-like signal harness reaped the root and leaf on the first SIGHUP, restored listeners, and also reaped both on a second signal during drain before exiting through the force path.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested     |
| 🪟 Windows |   ⚠️ not tested     |
|  🐧 Linux  |   ⚠️ not tested     |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

macOS 26.4.1 (Darwin 25.4.0 arm64), Node.js 22.22.3; source-level real-process and serve-like signal harnesses.

## Risk & Scope

- Main risk or tradeoff: POSIX tree ownership depends on bounded `/bin/ps` snapshots and retains the unavoidable PID/PGID reuse race; cleanup fails closed when ownership cannot be proven.
- Not validated / out of scope: Linux PID 1 zombie behavior is covered by controlled process-table tests but was not exercised in a real Linux PID namespace. Descendants that daemonize before ownership can be observed require cgroups, Windows Job Objects, or another OS supervisor and remain out of scope.
- Breaking changes / migration notes: No intended public breaking change. Existing direct `ProcessRegistry.attach(child)` callers retain direct-child behavior; only the standard ACP spawn path opts into tree ownership.

## Linked Issues

Closes #10140

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为标准 spawn 工厂创建的 ACP 子进程建立显式的进程树所有权边界。在 POSIX 平台上，ACP 根进程会被隔离到独立进程组中，系统在发送信号前记录后代进程组，并在优雅关闭、根进程意外退出和同步强制退出时清理已知进程组。在 Windows 上则使用原生的进程树终止操作。daemon 还会让 SIGHUP 与 SIGINT、SIGTERM 共用同一套优雅关闭和第二次信号生命周期；对于 Linux 上仅包含僵尸进程的进程组，只有在保守验证进程状态后才会释放。

## 为什么需要它

此前 ACP 关闭只向直接子进程发送信号，并在根进程退出后立即释放对应的 registry 条目。因此，hook、shell 命令、MCP server 或其他后代进程可能在 channel 替换或 daemon 关闭后继续以 PID 1 的子进程运行；同时，被隔离到独立进程组的 ACP 进程将无法再自动收到宿主的 SIGHUP 生命周期信号。本改动让现有关闭契约覆盖 daemon 所拥有的进程树，同时不改变 bridge 路由、session 所有权或旧有直接子进程调用方的行为。

## Reviewer 测试计划

### 如何验证

- 启动一个类似 ACP 的根进程，让它同时创建普通后代和位于独立 session 中的后代，然后触发优雅关闭；预期 TERM 到 KILL 的升级完成后两个后代都已消失，registry 计数回到零。
- 使用同步强制关闭重复上述场景；预期调用返回前已向所有已知进程组发送 KILL。
- 启动 `qwen serve`，第一次发送 SIGHUP，预期执行正常 drain 和 ACP 清理；在 drain 期间再发送一次关闭信号，预期进入同步强制退出路径。
- 运行 ACP bridge 的聚焦测试和 daemon serve 测试文件；预期 72 个 ACP 测试和 328 个 daemon 测试全部通过，覆盖 POSIX 所有权、Windows taskkill 回退、Linux 僵尸状态、并发和信号监听器场景。

### 证据（变更前后）

变更前：在 macOS 的真实进程复现中，无论优雅关闭还是同步关闭，普通孙进程和位于独立 session 中的孙进程都会在根进程退出后继续以 PPID 1 存活；SIGHUP 会走 Node 的默认退出路径，而不是 daemon 清理流程。

变更后：同一套真实 ACP 进程测试在优雅关闭和同步关闭时都清理了两个后代进程。类似 serve 的信号测试在第一次 SIGHUP 时清理根进程与后代并恢复监听器；在 drain 期间收到第二次信号时，也会先通过强制路径清理两者再退出。

### 测试平台

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅ 已测试     |
| 🪟 Windows |   ⚠️ 未测试     |
|  🐧 Linux  |   ⚠️ 未测试     |

### 环境（可选）

macOS 26.4.1（Darwin 25.4.0 arm64），Node.js 22.22.3；使用源码级真实进程测试和类似 serve 的信号测试。

## 风险与范围

- 主要风险或权衡：POSIX 进程树所有权依赖有界的 `/bin/ps` 快照，并保留无法消除的 PID/PGID 复用竞争；无法证明所有权时，清理会以失败关闭方式处理。
- 未验证或范围外：Linux PID 1 僵尸进程行为已由受控进程表测试覆盖，但未在真实 Linux PID namespace 中运行。若后代进程在所有权可被观察前就完成 daemonize，则需要 cgroup、Windows Job Object 或其他操作系统级 supervisor，本 PR 不覆盖该场景。
- 破坏性变更或迁移说明：不计划引入公开破坏性变更。现有直接调用 `ProcessRegistry.attach(child)` 的调用方继续保持直接子进程行为；只有标准 ACP spawn 路径会启用进程树所有权。

## 关联 Issue

Closes #10140

</details>
