### PR TITLE
fix(daemon): Persist empty sessions before scheduled-task binding

### DIFF
--- a/docs/design/2026-08-26-scheduled-task-empty-session-persistence.md
+++ b/docs/design/2026-08-26-scheduled-task-empty-session-persistence.md
@@ -1,0 +1,29 @@
+# Persist empty sessions before scheduled-task binding
+
+## Problem
+
+The scheduled-task REST route can bind an existing live, idle default session. A session created through `POST /session` without `sourceType` and without a prompt has no transcript yet. The binding succeeds and the durable task stores that session id, but after the client detaches and the daemon restarts, keepalive cannot resume the missing transcript. The task remains bound to an unavailable session.
+
+Asking the user to send a message first leaks a persistence implementation detail into the product flow. Sending a synthetic prompt would be worse: it would call the model, run hooks, consume tokens, and add visible conversation content.
+
+## Design
+
+Before the REST path commits a task that explicitly names an existing session, the selected workspace bridge asks that session's child process to durably record its default source metadata. This reuses the existing `session_source` transcript record and `ChatRecordingService` writer lease. It creates a restorable transcript without a user message, model call, hook, or new transcript schema.
+
+The bridge operation is intentionally narrow: it persists `sourceType: "default"` for a live session and succeeds only after the child acknowledges `persisted: true`. The route already permits only default-source sessions with no parent or source id, so other session kinds never reach it. The operation runs before the task-file lock; the existing eligibility check inside that lock remains the final authority. A generation check after persistence prevents a draining workspace generation from committing the task.
+
+The route is selected-runtime scoped. It uses only the bridge captured for the task's resolved workspace and never falls back to the primary runtime. A missing bridge capability fails closed with `session_binding_unavailable`; a vanished session returns `session_not_found`; a failed durable write returns `session_persistence_failed`. If persistence succeeds but the later task write fails, the harmless default-source record remains because the session is caller-owned and deleting its transcript would be unsafe.
+
+The trusted `cron_create` current-session path is unchanged. It runs inside an active prompt, whose transcript already exists, and a daemon-to-child persistence round trip from that private callback would introduce unnecessary re-entrancy risk. Omitted-session REST creation is also unchanged: it still creates a detached task-owned session with `sourceType: "scheduled_task"`.
+
+## Compatibility and scope
+
+- No task schema, REST request schema, capability flag, UI flow, or transcript record format changes.
+- Existing populated sessions remain idempotent because recording an identical source returns success without another record.
+- Ordinary sessions that are never explicitly bound are not persisted early.
+- Already-orphaned tasks are not repaired automatically; after restart there is no safe way to distinguish a never-persisted session from an intentionally deleted or corrupt transcript.
+- The persisted empty session can appear in session history. That is expected once the caller explicitly makes it the durable owner of a scheduled task.
+
+## Verification
+
+Unit tests cover bridge acknowledgement, failed persistence, REST ordering and failure mapping, and the unchanged cron-tool path. A real-process regression creates an empty source-less session, binds it, detaches, restarts the daemon, and verifies the same session is restored while no user/model message was generated. Existing default detached task creation and ordinary unbound session behavior remain unchanged.

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -21768,6 +21768,57 @@ describe('createAcpSessionBridge', () => {
   });
 
   describe('session source metadata', () => {
+    it('durably anchors a source-less default session on demand', async () => {
+      const handle = makeChannel({
+        extMethodImpl: async (method) =>
+          method === SERVE_CONTROL_EXT_METHODS.sessionSource
+            ? { persisted: true }
+            : {},
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+      });
+      const session = await bridge.spawnOrAttach({
+        workspaceCwd: WS_A,
+        sessionScope: 'thread',
+      });
+
+      await expect(
+        bridge.ensureDefaultSessionPersisted!(session.sessionId),
+      ).resolves.toBeUndefined();
+      expect(handle.agent.extMethodCalls).toContainEqual({
+        method: SERVE_CONTROL_EXT_METHODS.sessionSource,
+        params: {
+          sessionId: session.sessionId,
+          sourceType: 'default',
+        },
+      });
+
+      await bridge.shutdown();
+    });
+
+    it('rejects when the child cannot persist the default session anchor', async () => {
+      const handle = makeChannel({
+        extMethodImpl: async (method) =>
+          method === SERVE_CONTROL_EXT_METHODS.sessionSource
+            ? { persisted: false }
+            : {},
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      await expect(
+        bridge.ensureDefaultSessionPersisted!(session.sessionId),
+      ).rejects.toThrow('could not be persisted');
+      await expect(
+        bridge.ensureDefaultSessionPersisted!('missing'),
+      ).rejects.toThrow(SessionNotFoundError);
+
+      await bridge.shutdown();
+    });
+
     it('rejects the reserved standalone source before spawning a child', async () => {
       const factory = vi.fn<ChannelFactory>();
       const bridge = makeBridge({ channelFactory: factory });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -10234,6 +10234,25 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       return closeSessionImpl(sessionId, context, closeOpts);
     },
 
+    async ensureDefaultSessionPersisted(sessionId) {
+      const entry = byId.get(sessionId);
+      if (!entry) throw new SessionNotFoundError(sessionId);
+      const result = (await withTimeout(
+        Promise.race([
+          entry.connection.extMethod(SERVE_CONTROL_EXT_METHODS.sessionSource, {
+            sessionId,
+            sourceType: 'default',
+          }),
+          getTransportClosedReject(entry),
+        ]),
+        initTimeoutMs,
+        'ensureDefaultSessionPersisted',
+      )) as { persisted?: unknown };
+      if (result?.persisted !== true) {
+        throw new Error(`Session '${sessionId}' could not be persisted`);
+      }
+    },
+
     updateSessionMetadata(sessionId, metadata, context) {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -1541,6 +1541,9 @@ export interface AcpSessionBridge extends WorkspaceEventBridge {
     opts?: CloseSessionOpts,
   ): Promise<void>;
 
+  /** Durably anchor an eligible live default session before task binding. */
+  ensureDefaultSessionPersisted?(sessionId: string): Promise<void>;
+
   /**
    * Update mutable session metadata. Supports `displayName` and `pr`.
    * Throws `SessionNotFoundError` for unknown ids.

--- a/packages/cli/src/serve/routes/scheduled-tasks.test.ts
+++ b/packages/cli/src/serve/routes/scheduled-tasks.test.ts
@@ -54,6 +54,7 @@ interface StubBridge {
     sourceId?: string;
   }): Promise<{ sessionId: string }>;
   closeSession(sessionId: string): Promise<unknown>;
+  ensureDefaultSessionPersisted(sessionId: string): Promise<void>;
   updateSessionMetadata(
     sessionId: string,
     metadata: { displayName?: string },
@@ -84,8 +85,10 @@ interface StubBridge {
   spawnScopes: Array<'single' | 'thread' | undefined>;
   spawnSources: Array<{ sourceType?: string; sourceId?: string }>;
   closed: string[];
+  persisted: string[];
   named: Array<{ sessionId: string; displayName?: string }>;
   failNext: boolean;
+  persistenceError?: Error;
 }
 
 function makeStubBridge(): StubBridge {
@@ -95,6 +98,7 @@ function makeStubBridge(): StubBridge {
     spawnScopes: [],
     spawnSources: [],
     closed: [],
+    persisted: [],
     named: [],
     markSessionCatalogChanged: vi.fn(),
     failNext: false,
@@ -123,6 +127,13 @@ function makeStubBridge(): StubBridge {
       bridge.closed.push(sessionId);
       bridge.liveSessions.delete(sessionId);
       return undefined;
+    },
+    async ensureDefaultSessionPersisted(sessionId: string) {
+      if (bridge.persistenceError) throw bridge.persistenceError;
+      if (!bridge.liveSessions.has(sessionId)) {
+        throw new SessionNotFoundError(sessionId);
+      }
+      bridge.persisted.push(sessionId);
     },
     updateSessionMetadata(sessionId, metadata) {
       bridge.named.push({ sessionId, ...metadata });
@@ -737,6 +748,7 @@ describe('scheduled-tasks routes', () => {
     expect(res.status).toBe(201);
     expect(res.body.sessionId).toBe(CALLER_SESSION_ID);
     expect(h.bridge.spawned).toEqual([]);
+    expect(h.bridge.persisted).toEqual([CALLER_SESSION_ID]);
     expect(h.bridge.named).toEqual([]);
     expect(await readCronTasks(h.workspace)).toEqual([
       expect.objectContaining({
@@ -750,6 +762,89 @@ describe('scheduled-tasks routes', () => {
       .send({ name: 'Renamed task' })
       .expect(200);
     expect(h.bridge.named).toEqual([]);
+  });
+
+  it('fails closed when existing-session persistence is unavailable', async () => {
+    addLiveSession(h.bridge, CALLER_SESSION_ID, h.workspace);
+    delete (h.bridge as Partial<StubBridge>).ensureDefaultSessionPersisted;
+
+    const res = await create({
+      cron: '0 9 * * *',
+      prompt: 'p',
+      sessionId: CALLER_SESSION_ID,
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('session_binding_unavailable');
+    expect(await readCronTasks(h.workspace)).toEqual([]);
+  });
+
+  it('does not bind a task when the session transcript cannot be persisted', async () => {
+    addLiveSession(h.bridge, CALLER_SESSION_ID, h.workspace);
+    h.bridge.persistenceError = new Error('disk full');
+
+    const res = await create({
+      cron: '0 9 * * *',
+      prompt: 'p',
+      sessionId: CALLER_SESSION_ID,
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('session_persistence_failed');
+    expect(await readCronTasks(h.workspace)).toEqual([]);
+  });
+
+  it('returns 404 when the session disappears during persistence', async () => {
+    addLiveSession(h.bridge, CALLER_SESSION_ID, h.workspace);
+    h.bridge.ensureDefaultSessionPersisted = async (sessionId) => {
+      h.bridge.liveSessions.delete(sessionId);
+      throw new SessionNotFoundError(sessionId);
+    };
+
+    const res = await create({
+      cron: '0 9 * * *',
+      prompt: 'p',
+      sessionId: CALLER_SESSION_ID,
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('session_not_found');
+    expect(await readCronTasks(h.workspace)).toEqual([]);
+  });
+
+  it('returns 503 when the runtime generation closes during persistence', async () => {
+    await teardown(h);
+    let generationOpen = true;
+    h = await makeHarness(true, {
+      get closed() {
+        return !generationOpen;
+      },
+      assertOpen() {
+        if (!generationOpen) {
+          throw Object.assign(new Error('generation closed'), {
+            code: 'workspace_generation_closed',
+          });
+        }
+      },
+      close() {
+        generationOpen = false;
+      },
+    });
+    addLiveSession(h.bridge, CALLER_SESSION_ID, h.workspace);
+    h.bridge.ensureDefaultSessionPersisted = async () => {
+      generationOpen = false;
+      throw new Error('channel closed');
+    };
+
+    const res = await request(h.app).post('/scheduled-tasks').send({
+      cron: '0 9 * * *',
+      prompt: 'p',
+      sessionId: CALLER_SESSION_ID,
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.body.code).toBe('workspace_runtime_unavailable');
+    expect(await readCronTasks(h.workspace)).toEqual([]);
   });
 
   it('rejects invalid, missing, and busy caller sessions', async () => {
@@ -840,6 +935,7 @@ describe('scheduled-tasks routes', () => {
     );
     expect(task.lastFiredAt).not.toBeNull();
     expect(task.lastFiredAt! % 60_000).toBe(0);
+    expect(h.bridge.persisted).toEqual([]);
   });
 
   it('rechecks the exact caller prompt inside the task-file lock', async () => {

--- a/packages/cli/src/serve/routes/scheduled-tasks.ts
+++ b/packages/cli/src/serve/routes/scheduled-tasks.ts
@@ -91,6 +91,8 @@ export interface ScheduledTasksSessionBridge {
     sourceId?: string;
   }): Promise<{ sessionId: string }>;
   closeSession(sessionId: string): Promise<unknown>;
+  /** Persist a restorable transcript anchor for an eligible default session. */
+  ensureDefaultSessionPersisted?(sessionId: string): Promise<void>;
   /** Advance the in-memory session-catalog revision after a successful
    * persisted removal driven by task cleanup. Optional so existing
    * structural test fakes stay source-compatible; the production bridge
@@ -331,6 +333,38 @@ export async function createScheduledTaskWithExistingSession(
     assertCallerPromptActive,
   );
   target.assertGenerationOpen?.();
+
+  if (options.source === 'rest') {
+    const ensurePersisted = target.bridge?.ensureDefaultSessionPersisted;
+    if (!ensurePersisted) {
+      throw new ExistingSessionScheduledTaskCreateError(
+        409,
+        'session_binding_unavailable',
+        'Session persistence is not available for this workspace',
+      );
+    }
+    try {
+      await ensurePersisted.call(target.bridge, input.sessionId);
+    } catch (error) {
+      target.assertGenerationOpen?.();
+      if (error instanceof SessionNotFoundError) {
+        throw new ExistingSessionScheduledTaskCreateError(
+          404,
+          'session_not_found',
+          `Session '${input.sessionId}' was not found`,
+        );
+      }
+      writeStderrLine(
+        `qwen serve: failed to persist scheduled-task session '${input.sessionId}': ${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw new ExistingSessionScheduledTaskCreateError(
+        500,
+        'session_persistence_failed',
+        'Failed to persist the requested session',
+      );
+    }
+    target.assertGenerationOpen?.();
+  }
 
   const now = Date.now();
   const task: DurableCronTask = {


### PR DESCRIPTION
## What this PR does

This PR makes an explicitly bound, empty default session restorable before the scheduled task is committed. The selected workspace bridge asks the live session child to durably record the existing hidden `session_source` metadata and requires a positive persistence acknowledgement before writing the task. The REST path fails closed when persistence is unavailable, the session disappears, the workspace generation drains, or the durable write fails.

The trusted current-session `cron_create` path remains unchanged because it runs inside an already-persisted prompt. Task creation without `sessionId` also retains its existing detached task-owned session behavior. No task schema, REST request schema, capability flag, UI flow, or transcript record format changes.

## Why it's needed

The REST API currently accepts a live, idle session that has never received a prompt. That session has no transcript, so the task is stored successfully but detach or daemon restart cannot restore the bound session. The task then remains pointed at an unavailable session. Requiring the user to send a message exposes an implementation detail, while sending a synthetic prompt would call the model, run hooks, consume tokens, and create visible conversation content.

## Reviewer Test Plan

### How to verify

Start the bundled daemon with an isolated state directory and a model endpoint that records requests. Create a thread-scoped session without `sourceType`, do not send a prompt, and bind a scheduled task to that session through the REST API. Confirm task creation returns 201 only after the session transcript contains one hidden `system/session_source` record with `sourceType: "default"`, with no user or assistant records and no model request. Detach the client and restart the daemon with the same state directory; the same task and session id should be restored without a rehydration error.

As compatibility checks, create and detach a separate unbound empty session and confirm it remains ephemeral, then create a scheduled task without `sessionId` and confirm it still receives an isolated task-owned session with `sourceType: "scheduled_task"`.

Automated verification completed: 109 scheduled-task route tests, 798 ACP bridge tests, 36 bundled-daemon integration tests, repository build, bundle, typecheck, lint, formatting, and an independent real-process restart E2E.

### Evidence (Before & After)

Before: binding the empty session returned 201 without creating a transcript; after restart, the daemon logged `Resource not found: session:<id>` and `failed to rehydrate scheduled-task session`, while the durable task still referenced that id.

After: binding created exactly one hidden `session_source: default` record before the task timestamp. A local fake OpenAI server observed zero requests. Detach and full daemon restart restored the same task and session id with no rehydration error.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS Darwin 25.4.0 arm64, Node.js v22.22.3, npm 10.9.8, bundled `qwen serve`, isolated `QWEN_HOME`, and a local fake OpenAI endpoint.

## Risk & Scope

- Main risk or tradeoff: If session persistence succeeds but a later task-file commit fails, the caller-owned session keeps a harmless default-source transcript anchor; rolling it back could delete user-owned state.
- Not validated / out of scope: Windows and Linux runtime E2E, automatic repair of tasks already orphaned before this change, manual browser interaction, and waiting for an actual wall-clock task fire.
- Breaking changes / migration notes: None. Existing task and transcript schemas are unchanged.

## Linked Issues

#10143

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 会在提交定时任务之前，让显式绑定的空默认 session 具备可恢复的持久化记录。选定 workspace 的 bridge 会请求该 live session 的子进程持久化现有隐藏 `session_source` 元数据，并且只有在收到明确的持久化成功确认后才写入任务。当持久化能力不可用、session 消失、workspace generation 正在关闭或持久化写入失败时，REST 路径会失败关闭，不会留下不可恢复的任务绑定。

受信任的当前 session `cron_create` 路径保持不变，因为它运行在已经持久化的 prompt 内。未指定 `sessionId` 的任务创建也继续使用原有的独立 task-owned session 行为。本变更不修改任务 schema、REST 请求 schema、能力标识、UI 流程或 transcript 记录格式。

## 为什么需要

REST API 当前会接受一个从未接收 prompt 的 live idle session。该 session 没有 transcript，因此任务虽然能成功保存，但客户端 detach 或 daemon 重启后无法恢复绑定的 session，任务会继续指向一个不可用的 session。要求用户先发送消息会暴露持久化实现细节，而发送合成 prompt 会调用模型、执行 hooks、消耗 token，并产生可见的对话内容。

## 审阅者测试计划

### 如何验证

使用隔离的状态目录和能够记录请求的模型端点启动打包后的 daemon。创建一个不带 `sourceType` 的 thread-scoped session，不发送 prompt，然后通过 REST API 将定时任务绑定到该 session。确认任务只有在 session transcript 包含一条隐藏的 `system/session_source` 且 `sourceType: "default"` 的记录后才返回 201，同时不存在 user 或 assistant 记录，也没有模型请求。detach 客户端并使用相同状态目录重启 daemon；相同的任务和 session id 应被恢复，且不出现 rehydration 错误。

作为兼容性检查，另外创建并 detach 一个未绑定的空 session，确认它仍然是临时的；然后创建一个不带 `sessionId` 的定时任务，确认它仍然获得一个隔离的 task-owned session，且 `sourceType: "scheduled_task"`。

已完成自动化验证：109 项 scheduled-task 路由测试、798 项 ACP bridge 测试、36 项打包 daemon 集成测试、仓库 build、bundle、typecheck、lint、format，以及独立的真实进程重启 E2E。

### 前后证据

修复前：绑定空 session 返回 201，但不会创建 transcript；daemon 重启后记录 `Resource not found: session:<id>` 和 `failed to rehydrate scheduled-task session`，同时持久化任务仍引用该 id。

修复后：绑定操作会在任务时间戳之前创建且仅创建一条隐藏的 `session_source: default` 记录。本地假 OpenAI 服务观测到 0 个请求。detach 和完整 daemon 重启后都恢复了相同的任务和 session id，且没有 rehydration 错误。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS     |  ✅  |
|    🪟 Windows   |  ⚠️  |
|     🐧 Linux    |  ⚠️  |

### 环境（可选）

macOS Darwin 25.4.0 arm64、Node.js v22.22.3、npm 10.9.8、打包后的 `qwen serve`、隔离的 `QWEN_HOME` 和本地假 OpenAI 端点。

## 风险与范围

- 主要风险或权衡：如果 session 持久化成功，但之后任务文件提交失败，调用方拥有的 session 会保留一个无害的默认 source transcript 锚点；回滚该记录可能会删除用户拥有的状态。
- 未验证 / 范围外：Windows 和 Linux 运行时 E2E、自动修复本变更前已经孤立的任务、手动浏览器交互，以及等待真实墙钟时间触发任务。
- 破坏性变更 / 迁移说明：无。现有任务和 transcript schema 均未改变。

## 关联 Issue

#10143

</details>
