### PR TITLE
fix(core): keep the ask_user_question dialog behind allow rules and auto-approval

### DIFF
--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.test.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.test.ts
@@ -541,6 +541,9 @@ describe('PermissionController', () => {
         name: 'ask_user_question',
         args: { questions: [] } as Record<string, unknown>,
       },
+      invocation: {
+        requiresUserInteraction: () => true,
+      },
       confirmationDetails: {
         type: 'ask_user_question',
         title: 'Please answer',

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
@@ -574,7 +574,10 @@ export class PermissionController extends BaseController {
       const behavior = String(payload['behavior'] || '').toLowerCase();
 
       if (behavior === 'allow') {
-        if (requiresUserInteraction) {
+        if (
+          requiresUserInteraction &&
+          toolCall.request.name === ToolNames.EXIT_PLAN_MODE
+        ) {
           await toolCall.confirmationDetails.onConfirm(
             ToolConfirmationOutcome.ProceedOnce,
           );

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
@@ -574,6 +574,11 @@ export class PermissionController extends BaseController {
       const behavior = String(payload['behavior'] || '').toLowerCase();
 
       if (behavior === 'allow') {
+        // exit_plan_mode approves through the dialog alone: its onConfirm
+        // takes no payload, and the approved plan must not be replaced by
+        // the host's updatedInput. Any other requiresUserInteraction tool
+        // (e.g. ask_user_question) must take the updatedInput path below —
+        // that channel carries the user's answers.
         if (
           requiresUserInteraction &&
           toolCall.request.name === ToolNames.EXIT_PLAN_MODE

--- a/packages/core/src/core/permissionFlow.test.ts
+++ b/packages/core/src/core/permissionFlow.test.ts
@@ -18,6 +18,9 @@ import {
   isPlanModeBlocked,
   isAutoEditApproved,
 } from './permissionFlow.js';
+import { AskUserQuestionTool } from '../tools/askUserQuestion.js';
+import { PermissionManager } from '../permissions/permission-manager.js';
+import { applySkillAllowedTools } from '../tools/skill-utils.js';
 
 // Mock types for testing
 const mockConfig = (overrides: Partial<Config> = {}): Config =>
@@ -214,6 +217,108 @@ describe('evaluatePermissionFlow', () => {
 
     expect(result.finalPermission).toBe('deny');
     expect(result.denyMessage).toContain('denied by permission rules');
+  });
+});
+
+describe('evaluatePermissionFlow with ask_user_question', () => {
+  const questions = [
+    {
+      question: 'Which check defines success?',
+      header: 'Check',
+      options: [
+        { label: 'npm test', description: 'exit code 0' },
+        { label: 'npm run lint', description: 'no warnings' },
+      ],
+      multiSelect: false,
+    },
+  ];
+
+  const askConfig = (interactive: boolean) =>
+    ({
+      isInteractive: vi.fn().mockReturnValue(interactive),
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
+      getTargetDir: vi.fn().mockReturnValue('/test'),
+      getExperimentalZedIntegration: vi.fn().mockReturnValue(false),
+      getInputFormat: vi.fn().mockReturnValue(undefined),
+    }) as unknown as Config;
+
+  const pmWithSkillGrant = () => {
+    const pm = new PermissionManager({
+      getPermissionsAllow: () => [],
+      getPermissionsAsk: () => [],
+      getPermissionsDeny: () => [],
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+    });
+    pm.initialize();
+    // Exactly what loading a skill whose SKILL.md lists
+    // `allowedTools: [ask_user_question]` does to the session.
+    applySkillAllowedTools(pm, [ToolNames.ASK_USER_QUESTION]);
+    return pm;
+  };
+
+  it("keeps the dialog when a skill's allowedTools grant would otherwise allow the tool", async () => {
+    const config = askConfig(true);
+    const pm = pmWithSkillGrant();
+    const invocation = new AskUserQuestionTool(config).build({ questions });
+
+    const result = await evaluatePermissionFlow(
+      { ...config, getPermissionManager: () => pm } as unknown as Config,
+      invocation,
+      ToolNames.ASK_USER_QUESTION,
+      { questions },
+    );
+
+    // The grant did override the 'ask' default at L4 …
+    expect(result.defaultPermission).toBe('ask');
+    expect(await pm.evaluate(result.pmCtx)).toBe('allow');
+    // … but the invocation still reaches the user, in every approval mode.
+    expect(result.requiresUserInteraction).toBe(true);
+    expect(result.finalPermission).toBe('ask');
+    expect(
+      needsConfirmation(
+        result.finalPermission,
+        ApprovalMode.YOLO,
+        ToolNames.ASK_USER_QUESTION,
+        result.requiresUserInteraction,
+      ),
+    ).toBe(true);
+  });
+
+  it('still lets headless runs skip the tool, where nothing can prompt', async () => {
+    const config = askConfig(false);
+    const pm = pmWithSkillGrant();
+    const invocation = new AskUserQuestionTool(config).build({ questions });
+
+    const result = await evaluatePermissionFlow(
+      { ...config, getPermissionManager: () => pm } as unknown as Config,
+      invocation,
+      ToolNames.ASK_USER_QUESTION,
+      { questions },
+    );
+
+    expect(result.requiresUserInteraction).toBe(false);
+    expect(result.finalPermission).toBe('allow');
+  });
+
+  it('preserves an explicit deny rule for ask_user_question', async () => {
+    const config = askConfig(true);
+    const pm = new PermissionManager({
+      getPermissionsAllow: () => [],
+      getPermissionsAsk: () => [],
+      getPermissionsDeny: () => [ToolNames.ASK_USER_QUESTION],
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+    });
+    pm.initialize();
+    const invocation = new AskUserQuestionTool(config).build({ questions });
+
+    const result = await evaluatePermissionFlow(
+      { ...config, getPermissionManager: () => pm } as unknown as Config,
+      invocation,
+      ToolNames.ASK_USER_QUESTION,
+      { questions },
+    );
+
+    expect(result.finalPermission).toBe('deny');
   });
 });
 

--- a/packages/core/src/tools/askUserQuestion.test.ts
+++ b/packages/core/src/tools/askUserQuestion.test.ts
@@ -203,6 +203,47 @@ describe('AskUserQuestionTool', () => {
     });
   });
 
+  describe('requiresUserInteraction', () => {
+    const params = {
+      questions: [
+        {
+          question: 'Pick a framework?',
+          header: 'Framework',
+          options: [
+            { label: 'React', description: 'A JavaScript library' },
+            { label: 'Vue', description: 'Progressive framework' },
+          ],
+          multiSelect: false,
+        },
+      ],
+    };
+
+    it('requires the dialog in interactive mode so allow rules cannot skip it', () => {
+      // A bare `ask_user_question` allow rule (a skill's `allowedTools`
+      // grant, permissions.allow, "always allow") overrides the 'ask'
+      // default at L4. Without this flag the scheduler would then run the
+      // tool with no dialog and execute() would report "declined".
+      const invocation = tool.build(params);
+      expect(invocation.requiresUserInteraction?.()).toBe(true);
+    });
+
+    it('requires the dialog for ACP hosts that run non-interactively', () => {
+      (mockConfig.isInteractive as Mock).mockReturnValue(false);
+      (mockConfig.getInputFormat as Mock).mockReturnValue('stream-json');
+      expect(tool.build(params).requiresUserInteraction?.()).toBe(true);
+
+      (mockConfig.getInputFormat as Mock).mockReturnValue(undefined);
+      (mockConfig.getExperimentalZedIntegration as Mock).mockReturnValue(true);
+      expect(tool.build(params).requiresUserInteraction?.()).toBe(true);
+    });
+
+    it('does not require a dialog in headless mode, where nothing can prompt', () => {
+      (mockConfig.isInteractive as Mock).mockReturnValue(false);
+      const invocation = tool.build(params);
+      expect(invocation.requiresUserInteraction?.()).toBe(false);
+    });
+  });
+
   describe('execute', () => {
     it('should return error in non-interactive mode', async () => {
       (mockConfig.isInteractive as Mock).mockReturnValue(false);

--- a/packages/core/src/tools/askUserQuestion.ts
+++ b/packages/core/src/tools/askUserQuestion.ts
@@ -20,7 +20,7 @@ import type { FunctionDeclaration } from '@google/genai';
 import type { Config } from '../config/config.js';
 import { ToolDisplayNames, ToolNames } from './tool-names.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
-import { InputFormat } from '../output/types.js';
+import { resolveInteractionMode } from '../core/prompts.js';
 
 const debugLogger = createDebugLogger('ASK_USER_QUESTION');
 
@@ -178,10 +178,7 @@ class AskUserQuestionToolInvocation extends BaseToolInvocation<
    * confirmation channel.
    */
   private canCollectAnswers(): boolean {
-    const isAcpMode =
-      this._config.getExperimentalZedIntegration() ||
-      this._config.getInputFormat() === InputFormat.STREAM_JSON;
-    return this._config.isInteractive() || isAcpMode;
+    return resolveInteractionMode(this._config) !== 'headless';
   }
 
   /**

--- a/packages/core/src/tools/askUserQuestion.ts
+++ b/packages/core/src/tools/askUserQuestion.ts
@@ -172,20 +172,44 @@ class AskUserQuestionToolInvocation extends BaseToolInvocation<
   }
 
   /**
+   * Whether a host is present that can put the questions in front of the
+   * user. ACP hosts (VSCode extension, Zed, stream-json clients) run in
+   * non-interactive mode but still collect answers through the
+   * confirmation channel.
+   */
+  private canCollectAnswers(): boolean {
+    const isAcpMode =
+      this._config.getExperimentalZedIntegration() ||
+      this._config.getInputFormat() === InputFormat.STREAM_JSON;
+    return this._config.isInteractive() || isAcpMode;
+  }
+
+  /**
    * ask_user_question always requires user confirmation so the user can
    * provide answers. In non-interactive mode without ACP support, we skip
    * confirmation (and subsequently skip execution).
    */
   override async getDefaultPermission(): Promise<PermissionDecision> {
-    const isAcpMode =
-      this._config.getExperimentalZedIntegration() ||
-      this._config.getInputFormat() === InputFormat.STREAM_JSON;
-
-    if (!this._config.isInteractive() && !isAcpMode) {
+    if (!this.canCollectAnswers()) {
       // Non-interactive + no ACP: skip entirely
       return 'allow';
     }
     return 'ask';
+  }
+
+  /**
+   * The confirmation dialog IS this tool: the answers are collected through
+   * `onConfirm`, so an approval that skips the dialog does not "allow" the
+   * tool, it silently answers "declined" on the user's behalf. Permission
+   * rules and automatic approval modes must therefore never satisfy it —
+   * a bare `ask_user_question` allow rule (a skill's `allowedTools` grant,
+   * `permissions.allow`, an "always allow" answer) would otherwise override
+   * the 'ask' default at L4 and the scheduler would run the tool with no
+   * dialog ever shown. Headless runs stay as they were: nothing can prompt
+   * there, and `execute()` reports that instead.
+   */
+  override requiresUserInteraction(): boolean {
+    return this.canCollectAnswers();
   }
 
   override async getConfirmationDetails(
@@ -222,14 +246,8 @@ class AskUserQuestionToolInvocation extends BaseToolInvocation<
 
   async execute(_signal: AbortSignal): Promise<ToolResult> {
     try {
-      // Check if we're in a mode that supports user interaction
-      // ACP mode (VSCode extension, etc.) uses non-interactive mode but can still collect user input
-      const isAcpMode =
-        this._config.getExperimentalZedIntegration() ||
-        this._config.getInputFormat() === InputFormat.STREAM_JSON;
-
       // In non-interactive mode without ACP support, we cannot collect user input
-      if (!this._config.isInteractive() && !isAcpMode) {
+      if (!this.canCollectAnswers()) {
         const errorMessage =
           'Cannot ask user questions in non-interactive mode without ACP support. Please run in interactive mode or enable ACP mode to use this tool.';
         return {


### PR DESCRIPTION
## What this PR does

`ask_user_question` now declares `requiresUserInteraction()` whenever a host can actually show its dialog (interactive TUI, or an ACP / stream-json host), so the question dialog can no longer be skipped by a permission rule or an automatic approval mode. The permission flow already forces `'ask'` for interaction-required invocations regardless of L4 allow rules, and the scheduler already refuses to auto-approve them alongside a sibling — this change simply opts the tool into that path. Headless runs are unchanged: nothing can prompt there, the flag stays `false`, and `execute()` keeps returning its existing "cannot ask user questions in non-interactive mode" message. The three mode checks in the tool are folded into one `canCollectAnswers()` helper so the permission default, the interaction flag, and `execute()` cannot drift apart again.

Two layers of regression tests are added: tool-level (`requiresUserInteraction()` is `true` interactively and for ACP hosts, `false` headless) and flow-level with the real `AskUserQuestionTool`, the real `PermissionManager`, and the exact `applySkillAllowedTools` grant a skill's `allowedTools` applies — asserting that the grant does override the default to `allow` at L4 yet `evaluatePermissionFlow` still yields `'ask'` and `needsConfirmation` is `true` even in YOLO, that headless still yields `'allow'`, and that an explicit deny rule is preserved.

## Why it's needed

The confirmation dialog *is* this tool: its answers are collected through `onConfirm`. Approving it without the dialog does not "allow" the tool, it silently answers "declined" on the user's behalf, and the tool then reports `User declined to answer the questions.` as a successful result. Any bare `ask_user_question` allow rule triggers exactly that — a skill's `allowedTools` grant (applied as a session-wide allow rule via `applySkillAllowedTools` → `addSessionAllowRule`), a `permissions.allow` entry, or an "always allow" answer. The review of #10002 caught this live: with the grant loaded the scheduler went `validating → scheduled → executing → success` with no `awaiting_approval`, and the skill drafted on a fabricated refusal; the fix there was to drop the grant from that one skill, and the reviewer flagged the root cause as a maintainer call. Two bundled skills on `main` still carry the same grant (`batch`, `extension-creator`), and once any skill with it has loaded, every later `ask_user_question` in that session loses its dialog too — including the ACP and Web Shell paths. The fabricated "declined" also lands in the transcript as evidence, which the Goal verifier is designed to trust.

## Reviewer Test Plan

### How to verify

1. `cd packages/core && npx vitest run src/tools/askUserQuestion.test.ts src/core/permissionFlow.test.ts src/tools/exitPlanMode.test.ts src/core/coreToolScheduler.test.ts` — all pass; the three new `permissionFlow` cases and three new `askUserQuestion` cases are the regression.
2. Interactive, in **Ask** approval mode: run `/batch` or `/extension-creator` (both ship `allowedTools: [ask_user_question]`) and drive them to a clarifying question. Before: the question never appears and the model continues with "User declined to answer the questions." After: the question dialog renders; answering feeds the answers back.
3. Interactive, **YOLO** (`-y`): same — the question dialog still appears (YOLO already special-cased this tool by name; the flag now covers rule-based allows the same way).
4. Headless: `qwen -p "Use the ask_user_question tool to ask me which framework I prefer"` behaves exactly as before — in a plain `-p` run the tool is not even registered (the model reports `No tools found matching 'keyword:ask_user_question'`), and the `false` branch of the flag for non-interactive, non-ACP configs is pinned by the new unit tests; no new "requires user approval but cannot execute in non-interactive mode" warning.

### Evidence (Before & After)

Before (from the #10002 review probe, real `PermissionManager` + `CoreToolScheduler`, grant loaded from a SKILL.md): `WITH grant: L3 'ask' -> L4 'allow'; scheduler [validating, scheduled, executing, success] (no awaiting_approval, dialog never shown) -> tool result: "User declined to answer the questions." (executionStatus: success)`.

After — the same grant, through `evaluatePermissionFlow` (new test `keeps the dialog when a skill's allowedTools grant would otherwise allow the tool`): `defaultPermission: 'ask'`, `pm.evaluate(ctx): 'allow'`, `requiresUserInteraction: true`, `finalPermission: 'ask'`, `needsConfirmation(…, YOLO, …): true`. Headless counterpart: `requiresUserInteraction: false`, `finalPermission: 'allow'`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Linux, Node 22, `npm ci` + `npm run build` + `npm run bundle`; core `tsc --noEmit` clean; 460 core tests (askUserQuestion, permissionFlow, exitPlanMode, coreToolScheduler) and 832 cli tests (permissionController, permissionUtils, Session, gemini) pass; headless `-p` run for step 4 against DashScope `qwen3.8-max`.

## Risk & Scope

- Main risk or tradeoff: for interaction-required invocations the scheduler sets `hideAlwaysAllow` and skips them in `autoApproveCompatiblePendingTools`; for this tool both are the desired behavior (there is no meaningful "always allow" for a question, and approving a sibling must not answer a question). In AUTO mode the classifier fast path is skipped for this tool — it already fell back to the dialog for it.
- Not validated / out of scope: the `ask_user_question` entries in `batch` and `extension-creator` `SKILL.md` are left in place — with this change they are inert rather than harmful, and removing them is a separate cleanup. No change to ACP hosts' handling of the confirmation request; they already received `'ask'` for this tool.
- Breaking changes / migration notes: a `permissions.allow` rule for `ask_user_question` no longer suppresses the dialog. That rule never produced answers, only silent refusals, so nothing that worked before stops working.

## Linked Issues

Follow-up to #10002 (review finding on the `ask_user_question` grant).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`ask_user_question` 现在在宿主能真正弹出对话框的场景（交互式 TUI，或 ACP / stream-json 宿主）下声明 `requiresUserInteraction()`，因此它的提问对话框不再会被权限规则或自动审批模式跳过。权限流程本来就会对"需要用户交互"的调用强制返回 `'ask'`（无视 L4 的 allow 规则），调度器也本来就不会把它随同级工具一起自动批准——本改动只是让这个工具走上这条路径。headless 运行不变：那里没有任何东西能弹窗，标志保持 `false`，`execute()` 仍返回原有的"非交互模式下无法向用户提问"消息。工具里三处模式判断合并成一个 `canCollectAnswers()` 辅助函数，避免权限默认值、交互标志和 `execute()` 再次各自漂移。

新增两层回归测试：工具级（交互和 ACP 宿主下 `requiresUserInteraction()` 为 `true`，headless 下为 `false`），以及 permissionFlow 级——用真实的 `AskUserQuestionTool`、真实的 `PermissionManager` 和 skill 的 `allowedTools` 实际施加的 `applySkillAllowedTools` 授权，断言该授权确实在 L4 把默认值覆盖成了 `allow`，但 `evaluatePermissionFlow` 仍然给出 `'ask'`、即使在 YOLO 下 `needsConfirmation` 也为 `true`；headless 仍为 `'allow'`；显式 deny 规则保留。

## 为什么需要

确认对话框就是这个工具本身：答案是通过 `onConfirm` 收集的。不弹对话框就"批准"它，并不是允许了这个工具，而是替用户默默回答了"拒绝"，工具随后把 `User declined to answer the questions.` 当作成功结果返回。任何裸的 `ask_user_question` allow 规则都会触发这一点——skill 的 `allowedTools` 授权（通过 `applySkillAllowedTools` → `addSessionAllowRule` 以会话级 allow 规则施加）、`permissions.allow` 条目、或一次"总是允许"。#10002 的评审现场抓到了这个问题：加载授权后调度器直接 `validating → scheduled → executing → success`，没有 `awaiting_approval`，skill 基于伪造的拒绝继续起草；当时的修法是从那一个 skill 里去掉授权，评审把根因标为维护者决策。`main` 上还有两个内置 skill 带着同样的授权（`batch`、`extension-creator`），而且一旦任何带此授权的 skill 加载过，该会话里之后所有 `ask_user_question` 的对话框都会失效——包括 ACP 和 Web Shell 路径。伪造的"拒绝"还会作为证据留在 transcript 里，而 Goal verifier 正是被设计成信任 transcript 的。

## Reviewer 测试计划

### 如何验证

1. `cd packages/core && npx vitest run src/tools/askUserQuestion.test.ts src/core/permissionFlow.test.ts src/tools/exitPlanMode.test.ts src/core/coreToolScheduler.test.ts`——全部通过；`permissionFlow` 新增的三个用例和 `askUserQuestion` 新增的三个用例就是回归测试。
2. 交互模式、**Ask** 审批模式：运行 `/batch` 或 `/extension-creator`（两者都带 `allowedTools: [ask_user_question]`），推进到一个澄清提问。Before：提问永远不出现，模型以"User declined to answer the questions."继续。After：提问对话框渲染出来；回答后答案回传。
3. 交互模式、**YOLO**（`-y`）：同上——提问对话框仍然出现（YOLO 本来就按工具名特判了它；现在标志以同样方式覆盖了基于规则的 allow）。
4. Headless：`qwen -p "Use the ask_user_question tool to ask me which framework I prefer"` 行为与之前完全一致——普通 `-p` 运行里该工具根本没有注册（模型报告 `No tools found matching 'keyword:ask_user_question'`），非交互、非 ACP 配置下标志为 `false` 的分支由新增单元测试锁定；没有新增"requires user approval but cannot execute in non-interactive mode"警告。

### 证据（Before & After）

Before（来自 #10002 评审探针，真实 `PermissionManager` + `CoreToolScheduler`，授权从 SKILL.md 加载）：`WITH grant: L3 'ask' -> L4 'allow'; scheduler [validating, scheduled, executing, success]（无 awaiting_approval，对话框从未显示）-> 工具结果："User declined to answer the questions."（executionStatus: success）`。

After——同样的授权经过 `evaluatePermissionFlow`（新测试 `keeps the dialog when a skill's allowedTools grant would otherwise allow the tool`）：`defaultPermission: 'ask'`、`pm.evaluate(ctx): 'allow'`、`requiresUserInteraction: true`、`finalPermission: 'ask'`、`needsConfirmation(…, YOLO, …): true`。headless 对照：`requiresUserInteraction: false`、`finalPermission: 'allow'`。

### 测试平台

Linux ✅；macOS、Windows ⚠️ 未测试。

### 环境（可选）

Linux，Node 22，`npm ci` + `npm run build` + `npm run bundle`；core `tsc --noEmit` 干净；core 460 个测试（askUserQuestion、permissionFlow、exitPlanMode、coreToolScheduler）与 cli 832 个测试（permissionController、permissionUtils、Session、gemini）通过；第 4 步为一次针对 DashScope `qwen3.8-max` 的 headless `-p` 运行。

## 风险与范围

- 主要风险/取舍：对需要交互的调用，调度器会设置 `hideAlwaysAllow` 并在 `autoApproveCompatiblePendingTools` 中跳过它们；对这个工具而言两者都是期望行为（对提问不存在有意义的"总是允许"，批准同级工具也不应替用户回答问题）。AUTO 模式下会跳过分类器快速路径——它对该工具本来就回落到对话框。
- 未验证/范围外：`batch` 和 `extension-creator` 的 `SKILL.md` 里的 `ask_user_question` 条目保留不动——有了本改动它们从有害变成无效，移除属于另一次清理。不改变 ACP 宿主对确认请求的处理；它们对该工具本来就收到 `'ask'`。
- 破坏性变更/迁移说明：`permissions.allow` 里针对 `ask_user_question` 的规则不再能抑制对话框。这条规则从来没产生过答案、只产生过静默拒绝，所以之前能工作的东西没有一样会停止工作。

## 关联 Issue

#10002 的后续（评审对 `ask_user_question` 授权的发现）。

</details>

https://claude.ai/code/session_01FV7i3w7egJ2kMw4AhQC38Z
