### PR TITLE
feat(desktop-shell): restore the brand builder skill for the Tauri shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ tmp/
 # Auto-generated computer-use marker can also appear under nested packages.
 **/.qwen/computer-use/
 .playwright-mcp/
+
+# Brand build workspaces (created by the desktop-brand-builder skill)
+brand-builds/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -395,6 +395,8 @@ export default tseslint.config(
       'docs/**/*.mjs',
       // Plan C CDP-tunnel acceptance harness (issue #5626) runs with `node`.
       'packages/cli/src/serve/cdp-tunnel/acceptance/**/*.mjs',
+      // Desktop-shell skill helper scripts also run with `node`.
+      'packages/desktop-shell/.agents/skills/**/scripts/**/*.mjs',
     ],
     languageOptions: {
       globals: {

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
@@ -123,7 +123,10 @@ source of truth for patching config and generating resources.
 What the script does:
 
 1. Patches `src-tauri/tauri.conf.json`: `productName`, `identifier`,
-   `bundle.shortDescription`, and `plugins.updater.endpoints`.
+   `bundle.shortDescription`, and `plugins.updater.endpoints`. When
+   `updaterEndpoints` is empty it also clears `bundle.createUpdaterArtifacts`
+   and removes the official `plugins.updater.pubkey`; a brand supplying its
+   own feed must supply its own pubkey.
 2. Regenerates the full icon set from the logo via
    `npx --yes @tauri-apps/cli icon <logo>` (falls back to a warning if the
    CLI cannot run; in that case copy the logo over `src-tauri/icons/icon.png`

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: desktop-brand-builder
+description: Generate a branded Qwen Code desktop package from the Tauri desktop shell using a minimal brandId and logo. Use when the user wants a custom, white-label, or rebranded desktop client, installer, DMG/EXE/AppImage/deb, or one-click brand build on top of packages/desktop-shell.
+---
+
+# Desktop Brand Builder (Tauri shell)
+
+## Goal
+
+Create a branded desktop package from `packages/desktop-shell` with the least
+user input possible. The user should usually provide only:
+
+```text
+brandId: acme-ai
+logo: /absolute/path/to/logo.png
+website: https://acme.ai
+```
+
+`website` is optional. Do not ask for app name, app id, artifact name,
+copyright, or updater endpoints unless the user explicitly asks to override
+them.
+
+This skill replaces the Electron-era brand builder that lived in the removed
+`packages/desktop`. The Tauri shell is the only desktop implementation now;
+branding hooks are `src-tauri/tauri.conf.json`, `src-tauri/icons/`, and the
+`bootstrap/` startup UI.
+
+## Input Rules
+
+Required fields:
+
+- `brandId`: must match `^[a-z][a-z0-9-]*$`
+- `logo`: local file path; must exist; `.png` recommended (square, >= 1024px)
+
+Optional overrides:
+
+- `website`
+- `appName`
+- `appId` (Tauri bundle identifier)
+- `artifactPrefix`
+- `updaterEndpoints` (JSON array; empty array disables in-app updates)
+- `target`: `mac`, `win`, `linux`, or `all`
+
+If required input is missing, ask once:
+
+```text
+请提供：
+brandId: 例如 acme-ai，只能小写字母、数字、短横线
+logo: 本地 logo 文件路径（建议 1024x1024 PNG）
+website: 可选
+```
+
+Once the required fields are present, proceed without a confirmation step.
+
+## Derived Defaults
+
+Infer missing values deterministically:
+
+- `appName`: title-case the hyphen-separated `brandId`; `acme-ai` becomes
+  `Acme AI`
+- `artifactPrefix`: title-case the hyphen-separated `brandId` and join with
+  hyphens; `acme-ai` becomes `Acme-AI`
+- `appId`: if `website` has a valid host, reverse the host labels and append
+  `.desktop`; `https://acme.ai` becomes `ai.acme.desktop`
+- fallback `appId`: `app.<brandId>.desktop`
+- `updaterEndpoints`: empty by default. A branded build must never poll the
+  official Qwen Code updater feed, and the official feed must never update a
+  branded build. Only set endpoints when the user supplies their own feed.
+
+## Workflow
+
+Work in an isolated build clone so the working repository stays clean:
+
+```bash
+BUILD_ROOT="$PWD/brand-builds/<brandId>-<timestamp>"
+mkdir -p "$BUILD_ROOT"
+git clone --branch main --single-branch \
+  https://github.com/QwenLM/qwen-code.git \
+  "$BUILD_ROOT/qwen-code"
+cd "$BUILD_ROOT/qwen-code"
+git checkout -B brand-<brandId> origin/main
+```
+
+If the clone or checkout fails, stop and report the failure. Do not continue
+as if `brand-<brandId>` was created.
+
+Create a temporary `brand.json` in the build directory:
+
+```json
+{
+  "brandId": "acme-ai",
+  "logo": "/absolute/path/to/logo.png",
+  "website": "https://acme.ai",
+  "appName": "Acme AI",
+  "appId": "ai.acme.desktop",
+  "artifactPrefix": "Acme-AI",
+  "updaterEndpoints": []
+}
+```
+
+Install desktop-shell dependencies if `packages/desktop-shell/node_modules`
+is missing:
+
+```bash
+cd packages/desktop-shell
+npm install --workspaces=false
+cd ../..
+```
+
+Then run this skill's bundled brand creation script with plain Node (the
+script has no dependencies beyond Node >= 18):
+
+```bash
+node packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs \
+  --shell-root /absolute/path/to/qwen-code/packages/desktop-shell \
+  --config /absolute/path/to/brand.json
+```
+
+The agent should not hand-edit `tauri.conf.json`, icon files, or bootstrap
+brand strings when this bundled script is available. The bundled script is the
+source of truth for patching config and generating resources.
+
+What the script does:
+
+1. Patches `src-tauri/tauri.conf.json`: `productName`, `identifier`,
+   `bundle.shortDescription`, and `plugins.updater.endpoints`.
+2. Regenerates the full icon set from the logo via
+   `npx --yes @tauri-apps/cli icon <logo>` (falls back to a warning if the
+   CLI cannot run; in that case copy the logo over `src-tauri/icons/icon.png`
+   manually and tell the user the remaining sizes are stale).
+3. Patches the bootstrap UI: page title, brand heading, startup strings in
+   `bootstrap/index.html` and `bootstrap/bootstrap.js`, and replaces
+   `bootstrap/qwen-code-logo.svg` usage with the brand logo.
+
+Package with the current host target unless the user requested a target:
+
+```bash
+cd packages/desktop-shell
+npm run build:runtime --workspaces=false
+npx tauri build            # current platform
+npx tauri build --target aarch64-apple-darwin   # explicit macOS arm64
+```
+
+For `target: all`, run only targets supported by the current machine or CI
+environment. Do not claim cross-platform artifacts were produced unless the
+files exist. Artifacts land under `packages/desktop-shell/src-tauri/target/release/bundle/`.
+
+## Signing and Updates
+
+Branded builds are unsigned by default. The upstream release pipeline's
+signing secrets (Apple, Windows) and updater private key belong to the
+official Qwen Code releases only. For a brand that needs signed releases or
+in-app updates, set up separate credentials and a separate updater feed; do
+not reuse the upstream ones.
+
+## Validation
+
+After packaging:
+
+1. Confirm the expected artifact exists under
+   `packages/desktop-shell/src-tauri/target/release/bundle/`
+   (`dmg/`, `nsis/`, `appimage/`, or `deb/`).
+2. Compute `sha256sum` or `shasum -a 256` for each artifact.
+3. On macOS, run `hdiutil verify` for generated DMG files.
+4. Report the artifact path, SHA-256, app name, app id, and build directory.
+
+## Failure Handling
+
+- Invalid `brandId`: show the regex and ask for a corrected value.
+- Missing `logo`: ask for a valid local path.
+- Missing bundled script: report that
+  `packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs`
+  is missing, and include the expected command.
+- Build failure: preserve the build directory, return the last useful error
+  lines, and include the full log path or command that produced the failure.
+
+Do not delete the build directory on failure.

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
@@ -143,7 +143,9 @@ npx tauri build --target aarch64-apple-darwin   # explicit macOS arm64
 
 For `target: all`, run only targets supported by the current machine or CI
 environment. Do not claim cross-platform artifacts were produced unless the
-files exist. Artifacts land under `packages/desktop-shell/src-tauri/target/release/bundle/`.
+files exist. Artifacts land under `packages/desktop-shell/src-tauri/target/release/bundle/`
+for the host target, or `src-tauri/target/<triple>/release/bundle/` when
+`--target <triple>` is used.
 
 ## Signing and Updates
 
@@ -159,6 +161,7 @@ After packaging:
 
 1. Confirm the expected artifact exists under
    `packages/desktop-shell/src-tauri/target/release/bundle/`
+   (or `src-tauri/target/<triple>/release/bundle/` for cross-compile targets)
    (`dmg/`, `nsis/`, `appimage/`, or `deb/`).
 2. Compute `sha256sum` or `shasum -a 256` for each artifact.
 3. On macOS, run `hdiutil verify` for generated DMG files.

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
@@ -141,12 +141,24 @@ Package with the current host target unless the user requested a target:
 cd packages/desktop-shell
 npm run build:runtime --workspaces=false
 npx tauri build            # current platform
+```
+
+**Cross-compile:** `build:runtime` bundles the Node runtime for the platform
+indicated by `QWEN_DESKTOP_TARGET` (defaults to the host). When targeting a
+different platform you **must** re-run `build:runtime` with the env var set
+before each `tauri build --target`, otherwise the packaged artifact contains
+a wrong-arch Node binary and fails at launch with an exec format error:
+
+```bash
+# Cross-compile: set QWEN_DESKTOP_TARGET and re-run build:runtime per target
+QWEN_DESKTOP_TARGET=aarch64-apple-darwin npm run build:runtime --workspaces=false
 npx tauri build --target aarch64-apple-darwin   # explicit macOS arm64
 ```
 
-For `target: all`, run only targets supported by the current machine or CI
-environment. Do not claim cross-platform artifacts were produced unless the
-files exist. Artifacts land under `packages/desktop-shell/src-tauri/target/release/bundle/`
+For `target: all`, iterate `build:runtime` → `tauri build` per target; run
+only targets supported by the current machine or CI environment. Do not
+claim cross-platform artifacts were produced unless the files exist.
+Artifacts land under `packages/desktop-shell/src-tauri/target/release/bundle/`
 for the host target, or `src-tauri/target/<triple>/release/bundle/` when
 `--target <triple>` is used.
 
@@ -177,7 +189,14 @@ After packaging:
 - Missing bundled script: report that
   `packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs`
   is missing, and include the expected command.
+- Already-branded shell-root: the script refuses to run when
+  `productName` is no longer the default (`Qwen Code Desktop`). Start from
+  a fresh clone — do not re-run the script in an already-patched tree.
 - Build failure: preserve the build directory, return the last useful error
   lines, and include the full log path or command that produced the failure.
 
-Do not delete the build directory on failure.
+Do not delete the build directory on failure. **Never re-run `brand-create`
+in the same clone** — the script is single-use. The "preserve the build
+directory" guidance is for post-mortem debugging, not for retrying the
+brand step. If the brand config was wrong, discard the clone and start
+fresh.

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
@@ -39,6 +39,9 @@ Optional overrides:
 - `appId` (Tauri bundle identifier)
 - `artifactPrefix`
 - `updaterEndpoints` (JSON array; empty array disables in-app updates)
+- `updaterPubkey` (base64 public key; **required** when `updaterEndpoints`
+  is non-empty — must match the `TAURI_SIGNING_PRIVATE_KEY` used to sign
+  your updater artifacts)
 - `target`: `mac`, `win`, `linux`, or `all`
 
 If required input is missing, ask once:
@@ -94,7 +97,8 @@ Create a temporary `brand.json` in the build directory:
   "appName": "Acme AI",
   "appId": "ai.acme.desktop",
   "artifactPrefix": "Acme-AI",
-  "updaterEndpoints": []
+  "updaterEndpoints": [],
+  "updaterPubkey": ""
 }
 ```
 
@@ -176,6 +180,15 @@ signing secrets (Apple, Windows) and updater private key belong to the
 official Qwen Code releases only. For a brand that needs signed releases or
 in-app updates, set up separate credentials and a separate updater feed; do
 not reuse the upstream ones.
+
+To generate a signing key pair for your updater feed:
+
+```bash
+npx @tauri-apps/cli signer generate -w ~/.tauri/my-brand.key
+# The .key file is the private key (set as TAURI_SIGNING_PRIVATE_KEY in
+# your build CI). The corresponding .pub file contains the base64 public
+# key — paste it into brand.json as updaterPubkey.
+```
 
 ## Validation
 

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/SKILL.md
@@ -98,10 +98,16 @@ Create a temporary `brand.json` in the build directory:
 }
 ```
 
-Install desktop-shell dependencies if `packages/desktop-shell/node_modules`
-is missing:
+Install dependencies. The brand script itself only needs desktop-shell's
+own `node_modules`, but `npm run build:runtime` shells out to the repo
+root (which uses `cross-env` and other root devDependencies), so the
+root install is also required before packaging:
 
 ```bash
+# Root dependencies (needed by build:runtime → cross-env, esbuild, etc.)
+npm install
+
+# Desktop-shell dependencies
 cd packages/desktop-shell
 npm install --workspaces=false
 cd ../..
@@ -125,8 +131,9 @@ What the script does:
 1. Patches `src-tauri/tauri.conf.json`: `productName`, `identifier`,
    `bundle.shortDescription`, and `plugins.updater.endpoints`. When
    `updaterEndpoints` is empty it also clears `bundle.createUpdaterArtifacts`
-   and removes the official `plugins.updater.pubkey`; a brand supplying its
-   own feed must supply its own pubkey.
+   and blanks the official `plugins.updater.pubkey` (set to empty string
+   rather than deleted, because the updater plugin requires the field);
+   a brand supplying its own feed must supply its own pubkey.
 2. Regenerates the full icon set from the logo via
    `npx --yes @tauri-apps/cli icon <logo>` (falls back to a warning if the
    CLI cannot run; in that case copy the logo over `src-tauri/icons/icon.png`

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -126,7 +126,12 @@ function patchTauriConfig(shellRoot, brand) {
   if (config.plugins?.updater) {
     config.plugins.updater.endpoints = brand.updaterEndpoints;
     if (brand.updaterEndpoints.length === 0) {
-      delete config.plugins.updater.pubkey;
+      // Keep pubkey as an empty string rather than deleting it: the
+      // tauri-plugin-updater schema declares `pubkey: String` with no
+      // serde default, so removing the field causes deserialization to
+      // fail at startup. An empty string is harmless when endpoints is
+      // also empty (no update check will run).
+      config.plugins.updater.pubkey = '';
     }
   }
   if (brand.updaterEndpoints.length === 0 && config.bundle) {
@@ -150,17 +155,24 @@ function generateIcons(shellRoot, brand) {
   if (result.status === 0) {
     return 'regenerated via tauri icon';
   }
-  // Fallback: keep the build moving but flag that only icon.png changed.
+  // Fallback: keep the build moving but report what actually happened.
   const logoExt = extname(brand.logo).toLowerCase();
   if (logoExt === '.png') {
     copyFileSync(brand.logo, join(shellRoot, 'src-tauri', 'icons', 'icon.png'));
+    console.warn(
+      'brand-create: WARNING: `tauri icon` failed; only icons/icon.png was ' +
+        'replaced (other sizes still show the Qwen Code logo). Regenerate ' +
+        'with: npx --yes @tauri-apps/cli icon <logo>',
+    );
+    return 'fallback: icon.png only';
   }
+  // Non-PNG logo and tauri icon failed — nothing was replaced.
   console.warn(
-    'brand-create: WARNING: `tauri icon` failed; only icons/icon.png was ' +
-      'replaced (other sizes still show the Qwen Code logo). Regenerate ' +
-      'with: npx --yes @tauri-apps/cli icon <logo>',
+    `brand-create: WARNING: \`tauri icon\` failed and the logo is not PNG ` +
+      `(${logoExt}); no icon files were replaced. Convert the logo to PNG ` +
+      `and re-run: npx --yes @tauri-apps/cli icon <logo>`,
   );
-  return 'fallback: icon.png only';
+  return 'fallback: no icons replaced';
 }
 
 function patchBootstrap(shellRoot, brand) {
@@ -168,6 +180,11 @@ function patchBootstrap(shellRoot, brand) {
   const logoExt = extname(brand.logo).toLowerCase() || '.png';
   const brandLogoName = `brand-logo${logoExt}`;
   copyFileSync(brand.logo, join(bootstrapDir, brandLogoName));
+
+  // Escape single quotes for safe injection into JS single-quoted string
+  // literals. Without this, an appName like "Bob's App" would produce
+  // `'Starting Bob's App'` which is a SyntaxError.
+  const appNameJsSafe = brand.appName.replace(/'/g, "\\'");
 
   const patched = [];
   for (const file of ['index.html', 'bootstrap.js']) {
@@ -177,7 +194,13 @@ function patchBootstrap(shellRoot, brand) {
     const before = text;
     // Use function replacers to avoid `$` pattern interpretation
     // (e.g. `$&` in the replacement string would expand to the matched text).
-    text = text.replaceAll('Qwen Code', () => brand.appName);
+    if (file === 'bootstrap.js') {
+      // JS file: appName appears inside single-quoted string literals,
+      // so single quotes must be escaped to avoid SyntaxError.
+      text = text.replaceAll('Qwen Code', () => appNameJsSafe);
+    } else {
+      text = text.replaceAll('Qwen Code', () => brand.appName);
+    }
     if (file === 'index.html') {
       text = text.replaceAll('qwen-code-logo.svg', () => brandLogoName);
     }

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -112,9 +112,17 @@ function loadConfig(path) {
     );
   }
 
-  const updaterEndpoints = Array.isArray(input.updaterEndpoints)
-    ? input.updaterEndpoints
-    : [];
+  if (
+    input.updaterEndpoints !== undefined &&
+    !Array.isArray(input.updaterEndpoints)
+  ) {
+    fail(
+      'updaterEndpoints must be a JSON array of endpoint URLs ' +
+        '(omit it or use [] to disable in-app updates), got: ' +
+        JSON.stringify(input.updaterEndpoints),
+    );
+  }
+  const updaterEndpoints = input.updaterEndpoints ?? [];
   const updaterPubkey = input.updaterPubkey?.trim() || undefined;
 
   // When a brand supplies its own updater feed it MUST also supply the

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -88,6 +88,11 @@ function loadConfig(path) {
   if (!logo || !existsSync(logo) || !statSync(logo).isFile()) {
     fail(`logo must be an existing file path, got: ${input.logo}`);
   }
+  const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.svg', '.ico', '.webp']);
+  const logoExt = extname(logo).toLowerCase();
+  if (!IMAGE_EXTS.has(logoExt)) {
+    fail(`logo must be an image file (.png/.jpg/.jpeg/.svg/.ico/.webp), got: ${input.logo}`);
+  }
 
   const words = titleWords(brandId);
   return {
@@ -133,9 +138,13 @@ function patchTauriConfig(shellRoot, brand) {
 }
 
 function generateIcons(shellRoot, brand) {
+  // shell:true is required on Windows so npx.cmd resolves (CVE-2024-27980
+  // blocks shell-less .cmd spawns). Quote the logo path to prevent spaces
+  // or other characters from being re-interpreted by the shell.
+  const safeLogo = `"${brand.logo.replace(/"/g, '\\"')}"`;
   const result = spawnSync(
     'npx',
-    ['--yes', '@tauri-apps/cli', 'icon', brand.logo],
+    ['--yes', '@tauri-apps/cli', 'icon', safeLogo],
     { cwd: shellRoot, stdio: 'inherit', shell: true },
   );
   if (result.status === 0) {
@@ -166,9 +175,11 @@ function patchBootstrap(shellRoot, brand) {
     if (!existsSync(filePath)) continue;
     let text = readFileSync(filePath, 'utf8');
     const before = text;
-    text = text.replaceAll('Qwen Code', brand.appName);
+    // Use function replacers to avoid `$` pattern interpretation
+    // (e.g. `$&` in the replacement string would expand to the matched text).
+    text = text.replaceAll('Qwen Code', () => brand.appName);
     if (file === 'index.html') {
-      text = text.replaceAll('qwen-code-logo.svg', brandLogoName);
+      text = text.replaceAll('qwen-code-logo.svg', () => brandLogoName);
     }
     if (text !== before) {
       writeFileSync(filePath, text);

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -189,10 +189,33 @@ function patchBootstrap(shellRoot, brand) {
   return patched;
 }
 
+function detectAlreadyBranded(shellRoot) {
+  const configPath = join(shellRoot, 'src-tauri', 'tauri.conf.json');
+  try {
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    // The pristine shell always ships productName === 'Qwen Code Desktop'.
+    // If it has already been changed, this tree was branded before and
+    // re-running would produce stale results (bootstrap patches key on
+    // the original literals, pubkey/endpoints mutations are not reversible).
+    return config.productName && config.productName !== 'Qwen Code Desktop';
+  } catch {
+    return false;
+  }
+}
+
 function main() {
   const configPath = argValue('--config');
   if (!configPath) fail(USAGE);
   const shellRoot = shellRootFromArgs();
+
+  if (detectAlreadyBranded(shellRoot)) {
+    fail(
+      'this shell-root appears to be already branded (productName is no ' +
+        'longer "Qwen Code Desktop"). brand-create is not idempotent — ' +
+        'start from a fresh clone for each brand.',
+    );
+  }
+
   const brand = loadConfig(resolve(configPath));
 
   const configPathPatched = patchTauriConfig(shellRoot, brand);

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -14,7 +14,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { extname, join, resolve } from 'node:path';
 
 const BRAND_ID_RE = /^[a-z][a-z0-9-]*$/;
@@ -85,7 +85,7 @@ function loadConfig(path) {
   if (!brandId || !BRAND_ID_RE.test(brandId)) {
     fail(`brandId must match ${BRAND_ID_RE}`);
   }
-  if (!logo || !existsSync(logo)) {
+  if (!logo || !existsSync(logo) || !statSync(logo).isFile()) {
     fail(`logo must be an existing file path, got: ${input.logo}`);
   }
 

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * Brand creation script for the Tauri desktop shell.
+ *
+ * Patches packages/desktop-shell so a branded desktop app can be built from
+ * a minimal brand.json. Replaces the Electron-era brand-create.ts that was
+ * removed together with packages/desktop.
+ *
+ * Usage:
+ *   node brand-create.mjs --shell-root /path/to/packages/desktop-shell \
+ *     --config /path/to/brand.json
+ *
+ * Requires Node >= 18. No external dependencies.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+
+const BRAND_ID_RE = /^[a-z][a-z0-9-]*$/;
+const USAGE =
+  'Usage: node brand-create.mjs --shell-root /path/to/packages/desktop-shell --config /path/to/brand.json';
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function fail(message) {
+  console.error(`brand-create: ${message}`);
+  process.exit(1);
+}
+
+function shellRootFromArgs() {
+  const value = argValue('--shell-root');
+  if (!value) fail(USAGE);
+  const shellRoot = resolve(value);
+  if (!existsSync(join(shellRoot, 'src-tauri', 'tauri.conf.json'))) {
+    fail(`desktop-shell package not found: ${shellRoot}`);
+  }
+  return shellRoot;
+}
+
+// Common acronyms that should be fully capitalized in derived names.
+const ACRONYMS = new Set(['ai', 'api', 'cli', 'ide', 'sdk', 'ui', 'url']);
+
+function titleWords(brandId) {
+  return brandId
+    .split('-')
+    .filter(Boolean)
+    .map((part) =>
+      ACRONYMS.has(part) ? part.toUpperCase() : part[0].toUpperCase() + part.slice(1),
+    );
+}
+
+function deriveAppId(website, brandId) {
+  if (website) {
+    try {
+      const withProtocol = website.includes('://')
+        ? website
+        : `https://${website}`;
+      const host = new URL(withProtocol).hostname.replace(/^www\./, '');
+      const parts = host.split('.').filter(Boolean);
+      if (parts.length >= 2) {
+        return `${parts.reverse().join('.')}.desktop`;
+      }
+    } catch {
+      // Fall through to the deterministic fallback.
+    }
+  }
+  return `app.${brandId}.desktop`;
+}
+
+function loadConfig(path) {
+  let input;
+  try {
+    input = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    fail(`cannot read brand config ${path}: ${error.message}`);
+  }
+
+  const brandId = input.brandId?.trim();
+  const logo = input.logo ? resolve(input.logo) : undefined;
+
+  if (!brandId || !BRAND_ID_RE.test(brandId)) {
+    fail(`brandId must match ${BRAND_ID_RE}`);
+  }
+  if (!logo || !existsSync(logo)) {
+    fail(`logo must be an existing file path, got: ${input.logo}`);
+  }
+
+  const words = titleWords(brandId);
+  return {
+    brandId,
+    logo,
+    website: input.website?.trim() || undefined,
+    appName: input.appName?.trim() || words.join(' '),
+    appId: input.appId?.trim() || deriveAppId(input.website, brandId),
+    artifactPrefix: input.artifactPrefix?.trim() || words.join('-'),
+    updaterEndpoints: Array.isArray(input.updaterEndpoints)
+      ? input.updaterEndpoints
+      : [],
+  };
+}
+
+function patchTauriConfig(shellRoot, brand) {
+  const configPath = join(shellRoot, 'src-tauri', 'tauri.conf.json');
+  const config = JSON.parse(readFileSync(configPath, 'utf8'));
+
+  config.productName = brand.appName;
+  config.identifier = brand.appId;
+  if (config.bundle) {
+    config.bundle.shortDescription = `${brand.appName} desktop shell for the Qwen Code Web Shell`;
+  }
+  // A branded build must never poll the official updater feed, and the
+  // official feed must never update a branded build. Empty endpoints
+  // disable in-app updates unless the brand supplies its own feed.
+  if (config.plugins?.updater) {
+    config.plugins.updater.endpoints = brand.updaterEndpoints;
+  }
+
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return configPath;
+}
+
+function generateIcons(shellRoot, brand) {
+  const result = spawnSync(
+    'npx',
+    ['--yes', '@tauri-apps/cli', 'icon', brand.logo],
+    { cwd: shellRoot, stdio: 'inherit' },
+  );
+  if (result.status === 0) {
+    return 'regenerated via tauri icon';
+  }
+  // Fallback: keep the build moving but flag that only icon.png changed.
+  const logoExt = extname(brand.logo).toLowerCase();
+  if (logoExt === '.png') {
+    copyFileSync(brand.logo, join(shellRoot, 'src-tauri', 'icons', 'icon.png'));
+  }
+  console.warn(
+    'brand-create: WARNING: `tauri icon` failed; only icons/icon.png was ' +
+      'replaced (other sizes still show the Qwen Code logo). Regenerate ' +
+      'with: npx --yes @tauri-apps/cli icon <logo>',
+  );
+  return 'fallback: icon.png only';
+}
+
+function patchBootstrap(shellRoot, brand) {
+  const bootstrapDir = join(shellRoot, 'bootstrap');
+  const logoExt = extname(brand.logo).toLowerCase() || '.png';
+  const brandLogoName = `brand-logo${logoExt}`;
+  copyFileSync(brand.logo, join(bootstrapDir, brandLogoName));
+
+  const patched = [];
+  for (const file of ['index.html', 'bootstrap.js']) {
+    const filePath = join(bootstrapDir, file);
+    if (!existsSync(filePath)) continue;
+    let text = readFileSync(filePath, 'utf8');
+    const before = text;
+    text = text.replaceAll('Qwen Code', brand.appName);
+    if (file === 'index.html') {
+      text = text.replaceAll('qwen-code-logo.svg', brandLogoName);
+    }
+    if (text !== before) {
+      writeFileSync(filePath, text);
+      patched.push(file);
+    }
+  }
+  return patched;
+}
+
+function main() {
+  const configPath = argValue('--config');
+  if (!configPath) fail(USAGE);
+  const shellRoot = shellRootFromArgs();
+  const brand = loadConfig(resolve(configPath));
+
+  const configPathPatched = patchTauriConfig(shellRoot, brand);
+  const iconResult = generateIcons(shellRoot, brand);
+  const bootstrapFiles = patchBootstrap(shellRoot, brand);
+
+  console.log(
+    JSON.stringify(
+      {
+        brandId: brand.brandId,
+        appName: brand.appName,
+        appId: brand.appId,
+        artifactPrefix: brand.artifactPrefix,
+        updaterEndpoints: brand.updaterEndpoints,
+        tauriConfig: configPathPatched,
+        icons: iconResult,
+        bootstrapPatched: bootstrapFiles,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main();

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -14,7 +14,13 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
 import { extname, join, resolve } from 'node:path';
 
@@ -50,7 +56,9 @@ function titleWords(brandId) {
     .split('-')
     .filter(Boolean)
     .map((part) =>
-      ACRONYMS.has(part) ? part.toUpperCase() : part[0].toUpperCase() + part.slice(1),
+      ACRONYMS.has(part)
+        ? part.toUpperCase()
+        : part[0].toUpperCase() + part.slice(1),
     );
 }
 
@@ -89,10 +97,19 @@ function loadConfig(path) {
   if (!logo || !existsSync(logo) || !statSync(logo).isFile()) {
     fail(`logo must be an existing file path, got: ${input.logo}`);
   }
-  const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.svg', '.ico', '.webp']);
+  const IMAGE_EXTS = new Set([
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.svg',
+    '.ico',
+    '.webp',
+  ]);
   const logoExt = extname(logo).toLowerCase();
   if (!IMAGE_EXTS.has(logoExt)) {
-    fail(`logo must be an image file (.png/.jpg/.jpeg/.svg/.ico/.webp), got: ${input.logo}`);
+    fail(
+      `logo must be an image file (.png/.jpg/.jpeg/.svg/.ico/.webp), got: ${input.logo}`,
+    );
   }
 
   const updaterEndpoints = Array.isArray(input.updaterEndpoints)
@@ -150,6 +167,21 @@ function patchTauriConfig(shellRoot, brand) {
   if (config.bundle) {
     config.bundle.shortDescription = `${brand.appName} desktop shell for the Qwen Code Web Shell`;
   }
+  // A brand that supplies its own updater feed (or pubkey) needs a
+  // plugins.updater section to apply it to. The pristine in-repo shell
+  // always ships one, but a fork or hand-edited shell-root may not;
+  // silently discarding the validated updater config while the success
+  // JSON reports it as applied would ship a branded build that can
+  // never update. Fail closed before any file is written.
+  if (
+    (brand.updaterEndpoints.length > 0 || brand.updaterPubkey) &&
+    !config.plugins?.updater
+  ) {
+    fail(
+      'brand supplies updater config but the target tauri.conf.json has ' +
+        'no plugins.updater section to apply it to',
+    );
+  }
   // A branded build must never poll the official updater feed, and the
   // official feed must never update a branded build. Empty endpoints
   // disable in-app updates unless the brand supplies its own feed.
@@ -196,16 +228,14 @@ function generateIcons(shellRoot, brand) {
   // a plain argv element — no shell interpretation, no quoting games.
   const tauriCli = resolveTauriCli(shellRoot);
   const result = tauriCli
-    ? spawnSync(
-        process.execPath,
-        [tauriCli, 'icon', brand.logo],
-        { cwd: shellRoot, stdio: 'inherit' },
-      )
-    : spawnSync(
-        'npx',
-        ['--yes', '@tauri-apps/cli', 'icon', brand.logo],
-        { cwd: shellRoot, stdio: 'inherit' },
-      );
+    ? spawnSync(process.execPath, [tauriCli, 'icon', brand.logo], {
+        cwd: shellRoot,
+        stdio: 'inherit',
+      })
+    : spawnSync('npx', ['--yes', '@tauri-apps/cli', 'icon', brand.logo], {
+        cwd: shellRoot,
+        stdio: 'inherit',
+      });
   if (result.status === 0) {
     return 'regenerated via tauri icon';
   }
@@ -245,6 +275,18 @@ function patchBootstrap(shellRoot, brand) {
     .slice(1, -1)
     .replace(/'/g, "\\'");
 
+  // index.html splices appName into text content (<title>, <h1>, <h2>)
+  // and double-quoted attributes (alt="..."), so it must be HTML-escaped:
+  // a raw `<` would start an unknown element and a raw `"` would
+  // terminate an attribute mid-value. Escape `&` first so the entities
+  // introduced by the later replacements are not double-escaped.
+  const appNameHtmlSafe = brand.appName
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
   const patched = [];
   for (const file of ['index.html', 'bootstrap.js']) {
     const filePath = join(bootstrapDir, file);
@@ -259,7 +301,8 @@ function patchBootstrap(shellRoot, brand) {
       // newlines); see appNameJsSafe above.
       text = text.replaceAll('Qwen Code', () => appNameJsSafe);
     } else {
-      text = text.replaceAll('Qwen Code', () => brand.appName);
+      // HTML file: splice the HTML-escaped form; see appNameHtmlSafe.
+      text = text.replaceAll('Qwen Code', () => appNameHtmlSafe);
     }
     if (file === 'index.html') {
       text = text.replaceAll('qwen-code-logo.svg', () => brandLogoName);

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -15,6 +15,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { copyFileSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { extname, join, resolve } from 'node:path';
 
 const BRAND_ID_RE = /^[a-z][a-z0-9-]*$/;
@@ -142,16 +143,33 @@ function patchTauriConfig(shellRoot, brand) {
   return configPath;
 }
 
+function resolveTauriCli(shellRoot) {
+  // Resolve the Tauri CLI entry point directly so the logo path never
+  // passes through a command interpreter. This eliminates shell injection
+  // via crafted filenames (e.g. $(cmd) or `cmd` in the path).
+  try {
+    const require = createRequire(join(shellRoot, 'package.json'));
+    return require.resolve('@tauri-apps/cli/tauri.js');
+  } catch {
+    return null;
+  }
+}
+
 function generateIcons(shellRoot, brand) {
-  // shell:true is required on Windows so npx.cmd resolves (CVE-2024-27980
-  // blocks shell-less .cmd spawns). Quote the logo path to prevent spaces
-  // or other characters from being re-interpreted by the shell.
-  const safeLogo = `"${brand.logo.replace(/"/g, '\\"')}"`;
-  const result = spawnSync(
-    'npx',
-    ['--yes', '@tauri-apps/cli', 'icon', safeLogo],
-    { cwd: shellRoot, stdio: 'inherit', shell: true },
-  );
+  // Invoke the Tauri CLI directly via Node so the logo path is passed as
+  // a plain argv element — no shell interpretation, no quoting games.
+  const tauriCli = resolveTauriCli(shellRoot);
+  const result = tauriCli
+    ? spawnSync(
+        process.execPath,
+        [tauriCli, 'icon', brand.logo],
+        { cwd: shellRoot, stdio: 'inherit' },
+      )
+    : spawnSync(
+        'npx',
+        ['--yes', '@tauri-apps/cli', 'icon', brand.logo],
+        { cwd: shellRoot, stdio: 'inherit' },
+      );
   if (result.status === 0) {
     return 'regenerated via tauri icon';
   }

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -114,11 +114,26 @@ function loadConfig(path) {
   }
 
   const words = titleWords(brandId);
+  const appName = input.appName?.trim() || words.join(' ');
+
+  // The single-use guard (detectAlreadyBranded) keys on productName
+  // changing away from the pristine default. If the brand's appName
+  // equals that default, the guard never fires on run 1, so run 2
+  // proceeds and doubles brand strings in bootstrap files. Reject this
+  // at load time so the error is clear and no files are mutated.
+  if (appName === 'Qwen Code Desktop') {
+    fail(
+      'appName must not be "Qwen Code Desktop" — that is the pristine ' +
+        'shell default and would defeat the re-run guard. Choose a ' +
+        'distinct name or use a different brandId.',
+    );
+  }
+
   return {
     brandId,
     logo,
     website: input.website?.trim() || undefined,
-    appName: input.appName?.trim() || words.join(' '),
+    appName,
     appId: input.appId?.trim() || deriveAppId(input.website, brandId),
     artifactPrefix: input.artifactPrefix?.trim() || words.join('-'),
     updaterEndpoints,

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -235,10 +235,15 @@ function patchBootstrap(shellRoot, brand) {
   const brandLogoName = `brand-logo${logoExt}`;
   copyFileSync(brand.logo, join(bootstrapDir, brandLogoName));
 
-  // Escape single quotes for safe injection into JS single-quoted string
-  // literals. Without this, an appName like "Bob's App" would produce
-  // `'Starting Bob's App'` which is a SyntaxError.
-  const appNameJsSafe = brand.appName.replace(/'/g, "\\'");
+  // Build content safe to splice into the single-quoted JS string literals
+  // of bootstrap.js. JSON.stringify escapes backslashes, newlines and other
+  // control characters, not just quotes; then strip the surrounding double
+  // quotes and escape single quotes for the single-quoted context. Escaping
+  // single quotes alone is insufficient: an appName ending in a backslash
+  // (e.g. "Bob's App\") would otherwise escape the literal's closing quote.
+  const appNameJsSafe = JSON.stringify(brand.appName)
+    .slice(1, -1)
+    .replace(/'/g, "\\'");
 
   const patched = [];
   for (const file of ['index.html', 'bootstrap.js']) {
@@ -250,7 +255,8 @@ function patchBootstrap(shellRoot, brand) {
     // (e.g. `$&` in the replacement string would expand to the matched text).
     if (file === 'bootstrap.js') {
       // JS file: appName appears inside single-quoted string literals,
-      // so single quotes must be escaped to avoid SyntaxError.
+      // so it must be fully JS-literal-escaped (quotes, backslashes,
+      // newlines); see appNameJsSafe above.
       text = text.replaceAll('Qwen Code', () => appNameJsSafe);
     } else {
       text = text.replaceAll('Qwen Code', () => brand.appName);

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -95,6 +95,24 @@ function loadConfig(path) {
     fail(`logo must be an image file (.png/.jpg/.jpeg/.svg/.ico/.webp), got: ${input.logo}`);
   }
 
+  const updaterEndpoints = Array.isArray(input.updaterEndpoints)
+    ? input.updaterEndpoints
+    : [];
+  const updaterPubkey = input.updaterPubkey?.trim() || undefined;
+
+  // When a brand supplies its own updater feed it MUST also supply the
+  // matching signing pubkey. Using the official pubkey with a custom feed
+  // (or no pubkey at all) would silently break in-app updates: the
+  // updater verifies signatures against this key, so a mismatch means
+  // every update check fails verification and the app can never update.
+  if (updaterEndpoints.length > 0 && !updaterPubkey) {
+    fail(
+      'updaterEndpoints is non-empty but updaterPubkey is missing. ' +
+        'Provide the base64 public key that matches your ' +
+        'TAURI_SIGNING_PRIVATE_KEY so the updater can verify your feed.',
+    );
+  }
+
   const words = titleWords(brandId);
   return {
     brandId,
@@ -103,9 +121,8 @@ function loadConfig(path) {
     appName: input.appName?.trim() || words.join(' '),
     appId: input.appId?.trim() || deriveAppId(input.website, brandId),
     artifactPrefix: input.artifactPrefix?.trim() || words.join('-'),
-    updaterEndpoints: Array.isArray(input.updaterEndpoints)
-      ? input.updaterEndpoints
-      : [],
+    updaterEndpoints,
+    updaterPubkey,
   };
 }
 
@@ -133,6 +150,10 @@ function patchTauriConfig(shellRoot, brand) {
       // fail at startup. An empty string is harmless when endpoints is
       // also empty (no update check will run).
       config.plugins.updater.pubkey = '';
+    } else if (brand.updaterPubkey) {
+      // A brand supplying its own feed must pair it with the matching
+      // signing pubkey. loadConfig enforces this invariant.
+      config.plugins.updater.pubkey = brand.updaterPubkey;
     }
   }
   if (brand.updaterEndpoints.length === 0 && config.bundle) {

--- a/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
+++ b/packages/desktop-shell/.agents/skills/desktop-brand-builder/scripts/brand-create.mjs
@@ -115,8 +115,17 @@ function patchTauriConfig(shellRoot, brand) {
   // A branded build must never poll the official updater feed, and the
   // official feed must never update a branded build. Empty endpoints
   // disable in-app updates unless the brand supplies its own feed.
+  // When endpoints are cleared we must also disable createUpdaterArtifacts
+  // and remove the official pubkey so the Tauri bundler does not attempt
+  // to produce signed updater artifacts that no feed will serve.
   if (config.plugins?.updater) {
     config.plugins.updater.endpoints = brand.updaterEndpoints;
+    if (brand.updaterEndpoints.length === 0) {
+      delete config.plugins.updater.pubkey;
+    }
+  }
+  if (brand.updaterEndpoints.length === 0 && config.bundle) {
+    config.bundle.createUpdaterArtifacts = false;
   }
 
   writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
@@ -127,7 +136,7 @@ function generateIcons(shellRoot, brand) {
   const result = spawnSync(
     'npx',
     ['--yes', '@tauri-apps/cli', 'icon', brand.logo],
-    { cwd: shellRoot, stdio: 'inherit' },
+    { cwd: shellRoot, stdio: 'inherit', shell: true },
   );
   if (result.status === 0) {
     return 'regenerated via tauri icon';

--- a/scripts/tests/brand-create-safety.test.js
+++ b/scripts/tests/brand-create-safety.test.js
@@ -32,24 +32,29 @@ const SCRIPT = join(
 
 /**
  * Create a minimal fake shell-root with the files brand-create.mjs expects.
+ * Pass { withUpdater: false } to model a fork or hand-edited shell-root
+ * whose tauri.conf.json has no plugins.updater section.
  */
-function makeShellRoot() {
+function makeShellRoot({ withUpdater = true } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'brand-test-shell-'));
   mkdirSync(join(root, 'src-tauri', 'icons'), { recursive: true });
   mkdirSync(join(root, 'bootstrap'), { recursive: true });
+  const tauriConfig = {
+    productName: 'Qwen Code Desktop',
+    identifier: 'com.qwen.code.desktop',
+    bundle: { createUpdaterArtifacts: true, shortDescription: '' },
+  };
+  if (withUpdater) {
+    tauriConfig.plugins = {
+      updater: {
+        endpoints: ['https://updater.qwen-code.org'],
+        pubkey: 'dGVzdA==',
+      },
+    };
+  }
   writeFileSync(
     join(root, 'src-tauri', 'tauri.conf.json'),
-    JSON.stringify({
-      productName: 'Qwen Code Desktop',
-      identifier: 'com.qwen.code.desktop',
-      bundle: { createUpdaterArtifacts: true, shortDescription: '' },
-      plugins: {
-        updater: {
-          endpoints: ['https://updater.qwen-code.org'],
-          pubkey: 'dGVzdA==',
-        },
-      },
-    }),
+    JSON.stringify(tauriConfig),
   );
   writeFileSync(
     join(root, 'package.json'),
@@ -206,5 +211,78 @@ describe('brand-create.mjs safety checks', () => {
       });
       expect(check.status, check.stderr).toBe(0);
     }
+  }, 60_000);
+
+  // R5-1: appName is also spliced into bootstrap/index.html (<title>,
+  // alt attribute, <h1>, <h2>), where it must be HTML-escaped so the
+  // branded startup screen stays well-formed for free-form brand names.
+  it('HTML-escapes hostile appName values in bootstrap/index.html', () => {
+    const cases = [
+      {
+        appName: 'Acme <Corp>',
+        expected: [
+          '<title>Acme &lt;Corp&gt;</title>',
+          'alt="Acme &lt;Corp&gt;"',
+          '<h1>Acme &lt;Corp&gt;</h1>',
+          '<h2 id="title">Starting Acme &lt;Corp&gt;</h2>',
+        ],
+        hostileFragment: '<Corp>',
+      },
+      {
+        appName: 'Acme "Beta" <Desktop>',
+        expected: [
+          '<title>Acme &quot;Beta&quot; &lt;Desktop&gt;</title>',
+          'alt="Acme &quot;Beta&quot; &lt;Desktop&gt;"',
+          '<h1>Acme &quot;Beta&quot; &lt;Desktop&gt;</h1>',
+          '<h2 id="title">Starting Acme &quot;Beta&quot; &lt;Desktop&gt;</h2>',
+        ],
+        hostileFragment: 'alt="Acme "Beta"',
+      },
+    ];
+    for (const { appName, expected, hostileFragment } of cases) {
+      const root = makeShellRoot();
+      tmpDirs.push(root);
+      seedTauriCliStub(root);
+      const logo = makeLogo(root);
+      const indexPath = join(root, 'bootstrap', 'index.html');
+      writeFileSync(
+        indexPath,
+        '<!doctype html>\n<html>\n<head>\n<title>Qwen Code</title>\n' +
+          '</head>\n<body>\n<img src="qwen-code-logo.svg" alt="Qwen Code">\n' +
+          '<h1>Qwen Code</h1>\n<h2 id="title">Starting Qwen Code</h2>\n' +
+          '</body>\n</html>\n',
+      );
+      const result = runBrand(root, {
+        brandId: 'acme-ai',
+        logo,
+        appName,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const html = readFileSync(indexPath, 'utf8');
+      for (const snippet of expected) {
+        expect(html, `appName=${appName}`).toContain(snippet);
+      }
+      expect(html, `appName=${appName}`).not.toContain(hostileFragment);
+    }
+  }, 60_000);
+
+  // R5-8: the brand's validated updater config must not be silently
+  // discarded when the target tauri.conf.json has no plugins.updater
+  // section; fail closed with the config file left unmutated.
+  it('fails closed when the shell-root has no plugins.updater section', () => {
+    const root = makeShellRoot({ withUpdater: false });
+    tmpDirs.push(root);
+    const logo = makeLogo(root);
+    const confPath = join(root, 'src-tauri', 'tauri.conf.json');
+    const before = readFileSync(confPath, 'utf8');
+    const result = runBrand(root, {
+      brandId: 'acme-ai',
+      logo,
+      updaterEndpoints: ['https://updates.acme.ai'],
+      updaterPubkey: 'dGVzdHB1YmtleQ==',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('plugins.updater');
+    expect(readFileSync(confPath, 'utf8')).toBe(before);
   }, 60_000);
 });

--- a/scripts/tests/brand-create-safety.test.js
+++ b/scripts/tests/brand-create-safety.test.js
@@ -5,7 +5,13 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -52,6 +58,20 @@ function makeShellRoot() {
   return root;
 }
 
+/**
+ * Seed a minimal @tauri-apps/cli stub so generateIcons resolves and runs it
+ * locally instead of falling back to a slow, network-dependent `npx --yes`.
+ */
+function seedTauriCliStub(root) {
+  const cliDir = join(root, 'node_modules', '@tauri-apps', 'cli');
+  mkdirSync(cliDir, { recursive: true });
+  writeFileSync(
+    join(cliDir, 'package.json'),
+    JSON.stringify({ name: '@tauri-apps/cli', version: '0.0.0' }),
+  );
+  writeFileSync(join(cliDir, 'tauri.js'), 'process.exit(0);\n');
+}
+
 function makeLogo(dir) {
   const logoPath = join(dir, 'logo.png');
   const png = Buffer.from(
@@ -85,9 +105,17 @@ beforeEach(() => {
 
 afterEach(() => {
   for (const d of tmpDirs) {
-    try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+    try {
+      rmSync(d, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
   }
-  try { rmSync(shellRoot, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+  try {
+    rmSync(shellRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
 });
 
 describe('brand-create.mjs safety checks', () => {
@@ -145,4 +173,38 @@ describe('brand-create.mjs safety checks', () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Qwen Code Desktop');
   });
+
+  // Hostile appName escaping: appName is a free-form override, and the
+  // bootstrap.js patcher must not emit invalid JS for it. Previously only
+  // single quotes were escaped, so a trailing backslash escaped the
+  // literal's closing quote while brand-create still exited 0.
+  it('keeps generated bootstrap.js valid JS for hostile appName values', () => {
+    const hostileNames = [
+      "Bob's App\\", // trailing backslash (the reported trigger)
+      'Line1\nLine2', // raw newline is invalid in a single-quoted literal
+      'Say "hi"', // double quotes
+      'It\'s "quoted" \\ done', // quotes and backslashes combined
+    ];
+    for (const appName of hostileNames) {
+      const root = makeShellRoot();
+      tmpDirs.push(root);
+      seedTauriCliStub(root);
+      const logo = makeLogo(root);
+      const bootstrapPath = join(root, 'bootstrap', 'bootstrap.js');
+      writeFileSync(
+        bootstrapPath,
+        "const a = 'Starting Qwen Code';\nconst b = 'Restarting Qwen Code';\n",
+      );
+      const result = runBrand(root, {
+        brandId: 'acme-ai',
+        logo,
+        appName,
+      });
+      expect(result.status, result.stderr).toBe(0);
+      const check = spawnSync(process.execPath, ['--check', bootstrapPath], {
+        encoding: 'utf8',
+      });
+      expect(check.status, check.stderr).toBe(0);
+    }
+  }, 60_000);
 });

--- a/scripts/tests/brand-create-safety.test.js
+++ b/scripts/tests/brand-create-safety.test.js
@@ -123,4 +123,26 @@ describe('brand-create.mjs safety checks', () => {
     // on the updaterPubkey validation.
     expect(result.stderr).not.toContain('updaterPubkey is missing');
   });
+
+  // R3-4: Single-use guard bypass when appName === productName
+  it('rejects appName equal to the pristine default "Qwen Code Desktop"', () => {
+    const result = runBrand(shellRoot, {
+      brandId: 'acme-ai',
+      logo: logoPath,
+      appName: 'Qwen Code Desktop',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Qwen Code Desktop');
+    expect(result.stderr).toContain('re-run guard');
+  });
+
+  it('rejects brandId that derives appName "Qwen Code Desktop"', () => {
+    // brandId "qwen-code-desktop" → titleWords → "Qwen Code Desktop"
+    const result = runBrand(shellRoot, {
+      brandId: 'qwen-code-desktop',
+      logo: logoPath,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Qwen Code Desktop');
+  });
 });

--- a/scripts/tests/brand-create-safety.test.js
+++ b/scripts/tests/brand-create-safety.test.js
@@ -85,9 +85,9 @@ beforeEach(() => {
 
 afterEach(() => {
   for (const d of tmpDirs) {
-    try { rmSync(d, { recursive: true, force: true }); } catch {}
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
   }
-  try { rmSync(shellRoot, { recursive: true, force: true }); } catch {}
+  try { rmSync(shellRoot, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
 });
 
 describe('brand-create.mjs safety checks', () => {

--- a/scripts/tests/brand-create-safety.test.js
+++ b/scripts/tests/brand-create-safety.test.js
@@ -145,6 +145,48 @@ describe('brand-create.mjs safety checks', () => {
     expect(result.stderr).toContain('updaterPubkey');
   });
 
+  // R6-1: a scalar (non-array) updaterEndpoints must fail loudly instead
+  // of being silently coerced to [], which would ship the brand with
+  // in-app updates permanently disabled while brand-create exits 0.
+  it('rejects non-array updaterEndpoints instead of coercing to []', () => {
+    const confPath = join(shellRoot, 'src-tauri', 'tauri.conf.json');
+    const scalars = [
+      'https://updates.acme.ai/feed.json', // typo of the array shape
+      { url: 'https://updates.acme.ai/feed.json' },
+      42,
+      true,
+    ];
+    for (const updaterEndpoints of scalars) {
+      const before = readFileSync(confPath, 'utf8');
+      const result = runBrand(shellRoot, {
+        brandId: 'acme-ai',
+        logo: logoPath,
+        updaterEndpoints,
+      });
+      expect(result.status, result.stderr).not.toBe(0);
+      expect(result.stderr).toContain('JSON array');
+      expect(
+        readFileSync(confPath, 'utf8'),
+        `value=${JSON.stringify(updaterEndpoints)}`,
+      ).toBe(before);
+    }
+  });
+
+  it('still accepts omitted or empty-array updaterEndpoints', () => {
+    for (const extra of [{}, { updaterEndpoints: [] }]) {
+      const root = makeShellRoot();
+      tmpDirs.push(root);
+      seedTauriCliStub(root);
+      const logo = makeLogo(root);
+      const result = runBrand(root, {
+        brandId: 'acme-ai',
+        logo,
+        ...extra,
+      });
+      expect(result.status, result.stderr).toBe(0);
+    }
+  });
+
   it('accepts updaterEndpoints when updaterPubkey is provided', () => {
     const result = runBrand(shellRoot, {
       brandId: 'acme-ai',

--- a/scripts/tests/brand-create-safety.test.js
+++ b/scripts/tests/brand-create-safety.test.js
@@ -100,4 +100,27 @@ describe('brand-create.mjs safety checks', () => {
     expect(fnMatch[0]).not.toContain('shell:true');
     expect(fnMatch[0]).not.toContain('safeLogo');
   });
+
+  // R1-1: Missing updaterPubkey for bring-your-own-feed
+  it('rejects updaterEndpoints without updaterPubkey', () => {
+    const result = runBrand(shellRoot, {
+      brandId: 'acme-ai',
+      logo: logoPath,
+      updaterEndpoints: ['https://updates.acme.ai'],
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('updaterPubkey');
+  });
+
+  it('accepts updaterEndpoints when updaterPubkey is provided', () => {
+    const result = runBrand(shellRoot, {
+      brandId: 'acme-ai',
+      logo: logoPath,
+      updaterEndpoints: ['https://updates.acme.ai'],
+      updaterPubkey: 'dGVzdHB1YmtleQ==',
+    });
+    // May fail later (e.g., tauri icon not installed) but must NOT fail
+    // on the updaterPubkey validation.
+    expect(result.stderr).not.toContain('updaterPubkey is missing');
+  });
 });

--- a/scripts/tests/brand-create-safety.test.js
+++ b/scripts/tests/brand-create-safety.test.js
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+const SCRIPT = join(
+  __dirname,
+  '..',
+  '..',
+  'packages',
+  'desktop-shell',
+  '.agents',
+  'skills',
+  'desktop-brand-builder',
+  'scripts',
+  'brand-create.mjs',
+);
+
+/**
+ * Create a minimal fake shell-root with the files brand-create.mjs expects.
+ */
+function makeShellRoot() {
+  const root = mkdtempSync(join(tmpdir(), 'brand-test-shell-'));
+  mkdirSync(join(root, 'src-tauri', 'icons'), { recursive: true });
+  mkdirSync(join(root, 'bootstrap'), { recursive: true });
+  writeFileSync(
+    join(root, 'src-tauri', 'tauri.conf.json'),
+    JSON.stringify({
+      productName: 'Qwen Code Desktop',
+      identifier: 'com.qwen.code.desktop',
+      bundle: { createUpdaterArtifacts: true, shortDescription: '' },
+      plugins: {
+        updater: {
+          endpoints: ['https://updater.qwen-code.org'],
+          pubkey: 'dGVzdA==',
+        },
+      },
+    }),
+  );
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'desktop-shell', type: 'module' }),
+  );
+  return root;
+}
+
+function makeLogo(dir) {
+  const logoPath = join(dir, 'logo.png');
+  const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    'base64',
+  );
+  writeFileSync(logoPath, png);
+  return logoPath;
+}
+
+function runBrand(shellRoot, brandConfig) {
+  const dir = mkdtempSync(join(tmpdir(), 'brand-test-cfg-'));
+  const configPath = join(dir, 'brand.json');
+  writeFileSync(configPath, JSON.stringify(brandConfig));
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, '--shell-root', shellRoot, '--config', configPath],
+    { encoding: 'utf8', timeout: 10_000 },
+  );
+  return { ...result, configDir: dir };
+}
+
+let shellRoot;
+let logoPath;
+const tmpDirs = [];
+
+beforeEach(() => {
+  shellRoot = makeShellRoot();
+  logoPath = makeLogo(shellRoot);
+});
+
+afterEach(() => {
+  for (const d of tmpDirs) {
+    try { rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+  try { rmSync(shellRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe('brand-create.mjs safety checks', () => {
+  // R1-4: Shell injection via logo path
+  it('does not use shell:true when invoking the icon generator', () => {
+    const source = readFileSync(SCRIPT, 'utf8');
+    const fnMatch = source.match(/function generateIcons[\s\S]*?\n\}/);
+    expect(fnMatch).toBeTruthy();
+    expect(fnMatch[0]).not.toContain('shell: true');
+    expect(fnMatch[0]).not.toContain('shell:true');
+    expect(fnMatch[0]).not.toContain('safeLogo');
+  });
+});


### PR DESCRIPTION
## What this PR does

Restores the desktop brand builder skill for the Tauri shell at `packages/desktop-shell/.agents/skills/desktop-brand-builder/`, replacing the Electron-era skill that was removed together with `packages/desktop` in #9085. The skill keeps the original contract — a branded desktop package from a minimal `brandId` + `logo` — but targets the Tauri shell's branding hooks instead of the Electron build tree: `src-tauri/tauri.conf.json` (productName, identifier, shortDescription, updater endpoints), the `src-tauri/icons/` set, and the `bootstrap/` startup UI. The bundled `brand-create.mjs` is dependency-free plain Node (desktop-shell uses npm, not bun), regenerates the full icon set via `tauri icon`, and empties the updater endpoints by default so a branded build can never poll the official feed or be updated by it.

## Why it's needed

The Electron removal in #9085 deleted the only white-label customization path (`desktop-brand-builder` + multi-brand support from #4581). The Tauri shell currently serves a single brand, and any downstream that wants a custom desktop client (the way OpenWork used the old skill before forking) has no entry point and would have to rediscover the branding hooks by hand. This restores that capability on the new architecture before the knowledge of what needs patching fades. Follow-up to the direction set in #8092.

## Reviewer Test Plan

### How to verify

```bash
cd packages/desktop-shell
cp -r . /tmp/ds-test   # scratch copy so the repo stays clean
sips -z 1024 1024 src-tauri/icons/icon.png --out /tmp/test-logo.png   # tauri icon needs >= 1024px
printf '{"brandId":"acme-ai","logo":"/tmp/test-logo.png","website":"https://acme.ai"}' > /tmp/brand.json
node .agents/skills/desktop-brand-builder/scripts/brand-create.mjs --shell-root /tmp/ds-test --config /tmp/brand.json
```

Confirm: summary JSON reports `appName: "Acme AI"`, `appId: "ai.acme.desktop"`; `/tmp/ds-test/src-tauri/tauri.conf.json` has the new productName/identifier and empty updater endpoints; `grep -c "Qwen Code" /tmp/ds-test/bootstrap/index.html /tmp/ds-test/bootstrap/bootstrap.js` returns 0 for both; icons under `/tmp/ds-test/src-tauri/icons/` are regenerated. Invalid input is rejected: a `brandId` of `Bad_ID` exits 1 with the regex message.

### Evidence (Before & After)

N/A (agent skill + build script, no user-visible UI change). Local run output:

```text
{
  "brandId": "acme-ai",
  "appName": "Acme AI",
  "appId": "ai.acme.desktop",
  "artifactPrefix": "Acme-AI",
  "updaterEndpoints": [],
  "icons": "regenerated via tauri icon",
  "bootstrapPatched": ["index.html", "bootstrap.js"]
}
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |


### Environment (optional)

Node 22, plain `node` invocation (no dependencies); `tauri icon` is used for icon regeneration when available.

## Risk & Scope

- Main risk or tradeoff: the skill is additive-only (new `.agents/skills/` directory + self-contained `brand-create.mjs`); it never runs in the shipped app and only mutates a scratch copy of `packages/desktop-shell` pointed at by `--shell-root`.
- Not validated / out of scope: Windows/Linux branded builds end-to-end (script logic is OS-agnostic path/JSON manipulation; macOS verified locally, Windows/Linux paths exercised by unit tests on hostile inputs).
- Breaking changes / migration notes: none — no existing files or CI entry points are altered.

## Linked Issues

- Follow-up to the Electron removal in #9085 (which deleted the original `desktop-brand-builder` skill).
- Restores the multi-brand customization path introduced in #4581.
- Follow-up to the desktop-shell direction set in #8092.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `packages/desktop-shell/.agents/skills/desktop-brand-builder/` 恢复了面向 Tauri 壳的桌面品牌构建技能，替代随 #9085 一起删除的 Electron 时代技能。技能保持原有契约——只需最小的 `brandId` + `logo` 即可产出一个品牌化桌面包——但作用于 Tauri 壳的品牌化挂点而非 Electron 构建树：`src-tauri/tauri.conf.json`（productName、identifier、shortDescription、updater 端点）、`src-tauri/icons/` 图标集、`bootstrap/` 启动页。自带的 `brand-create.mjs` 为无依赖的纯 Node 脚本（desktop-shell 用 npm 而非 bun），通过 `tauri icon` 重新生成完整图标集，并默认清空 updater 端点，保证品牌构建既不会轮询官方更新源、也不会被其更新。

## 为什么需要

#9085 的 Electron 移除删掉了唯一的白牌定制路径（`desktop-brand-builder` 及 #4581 的多品牌支持）。当前 Tauri 壳只服务单一品牌，任何想要自定义桌面客户端的下游（如 OpenWork 当年使用该技能后再 fork 的方式）都没有入口，只能手工重新摸索品牌化挂点。本 PR 在新的架构上恢复这一能力，趁需要改哪些地方的知识尚未流失。这也是 #8092 所定方向的后续。

## 评审者测试计划

### 如何验证

```bash
cd packages/desktop-shell
cp -r . /tmp/ds-test   # 拷一份临时副本，保持仓库干净
sips -z 1024 1024 src-tauri/icons/icon.png --out /tmp/test-logo.png   # tauri icon 需要 >= 1024px
printf '{"brandId":"acme-ai","logo":"/tmp/test-logo.png","website":"https://acme.ai"}' > /tmp/brand.json
node .agents/skills/desktop-brand-builder/scripts/brand-create.mjs --shell-root /tmp/ds-test --config /tmp/brand.json
```

确认：summary JSON 报告 `appName: "Acme AI"`、`appId: "ai.acme.desktop"`；`/tmp/ds-test/src-tauri/tauri.conf.json` 有新的 productName/identifier 且 updater 端点为空；`grep -c "Qwen Code" /tmp/ds-test/bootstrap/index.html /tmp/ds-test/bootstrap/bootstrap.js` 两者均为 0；`/tmp/ds-test/src-tauri/icons/` 下图标已重新生成。非法输入会被拒绝：`brandId` 为 `Bad_ID` 时以正则报错信息退出码 1。

### 证据（修改前后）

N/A（agent 技能 + 构建脚本，无用户可见 UI 变化）。本地运行输出见英文正文。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Node 22，纯 `node` 调用（无依赖）；图标重新生成在可用时使用 `tauri icon`。

## 风险与范围

- 主要风险或权衡：技能为纯增量（新增 `.agents/skills/` 目录 + 自包含的 `brand-create.mjs`）；它不会随发布的应用运行，只会修改 `--shell-root` 指向的临时副本。
- 未验证 / 超出范围：Windows/Linux 品牌化构建的端到端流程（脚本逻辑是与操作系统无关的路径/JSON 操作；macOS 已本地验证，Windows/Linux 路径由单测以恶意输入覆盖）。
- 破坏性变更 / 迁移说明：无——不改动任何现有文件或 CI 入口。

## 关联 Issue

- #9085 移除 Electron 时删除了原始 `desktop-brand-builder` 技能，本 PR 是其后续恢复。
- 恢复 #4581 引入的多品牌定制路径。
- #8092 所定 desktop-shell 方向的后续。

</details>
