### PR TITLE
fix(ci): verify previous release tag exists in git before anchoring release notes

### DIFF
--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -346,10 +346,41 @@ function getAndVerifyTags(npmDistTag, _gitTagPattern) {
   };
 }
 
+function listExistingStableTags() {
+  const output = execSync(`git tag -l 'v*'`).toString();
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+    .sort(semver.rcompare);
+}
+
 function getLatestStableReleaseTag() {
   try {
     const result = getAndVerifyTags('latest', 'v[0-9].[0-9].[0-9]');
-    return result ? result.latestTag : '';
+    if (!result) return '';
+    const npmDerivedTag = result.latestTag;
+    let existingTags;
+    try {
+      existingTags = listExistingStableTags();
+    } catch (gitError) {
+      // Without a tag listing we cannot verify; keep the npm-derived tag as
+      // before rather than dropping the release-notes anchor entirely.
+      console.error(
+        `Could not list git tags to verify ${npmDerivedTag} (${gitError.message}); using the npm-derived tag as-is.`,
+      );
+      return npmDerivedTag;
+    }
+    if (existingTags.includes(npmDerivedTag)) return npmDerivedTag;
+    // A half-shipped release can leave the npm baseline ahead of any git tag
+    // (npm publish succeeded, tag creation failed). Anchoring the release
+    // notes at a tag that does not exist makes GitHub fall back to the entire
+    // branch history, so anchor at the latest stable tag that does exist.
+    const fallbackTag = existingTags[0] ?? '';
+    console.error(
+      `npm-derived previous tag ${npmDerivedTag} does not exist in git; falling back to ${fallbackTag || '<none>'}.`,
+    );
+    return fallbackTag;
   } catch (error) {
     console.error(
       `Failed to determine latest stable release tag: ${error.message}`,

--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -351,7 +351,7 @@ function listExistingStableTags() {
   return output
     .split('\n')
     .map((line) => line.trim())
-    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+    .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag) && semver.valid(tag))
     .sort(semver.rcompare);
 }
 

--- a/scripts/tests/get-release-version.test.js
+++ b/scripts/tests/get-release-version.test.js
@@ -51,6 +51,7 @@ describe('getVersion', () => {
     if (command.includes('deprecated')) return '';
 
     // Git Tag Mocks
+    if (command.includes("git tag -l 'v*'")) return 'v0.6.0\nv0.6.1';
     if (command.includes("git tag -l 'v[0-9].[0-9].[0-9]'")) return 'v0.6.1';
     if (command.includes("git tag -l 'v*-preview*'")) return 'v0.7.0-preview.1';
     if (command.includes("git tag -l 'v*-nightly*'"))
@@ -225,6 +226,8 @@ describe('getVersion', () => {
       vi.mocked(execSync).mockImplementation((command) => {
         if (command.includes('npm view') && command.includes('--tag=latest'))
           return '0.8.0';
+        if (command.includes("git tag -l 'v*'"))
+          return 'v0.6.0\nv0.6.1\nv0.8.0';
         return mockExecSync(command);
       });
 
@@ -238,6 +241,8 @@ describe('getVersion', () => {
       vi.mocked(execSync).mockImplementation((command) => {
         if (command.includes('npm view') && command.includes('--tag=latest'))
           return '0.9.0';
+        if (command.includes("git tag -l 'v*'"))
+          return 'v0.6.0\nv0.6.1\nv0.9.0';
         return mockExecSync(command);
       });
 
@@ -251,6 +256,8 @@ describe('getVersion', () => {
       vi.mocked(execSync).mockImplementation((command) => {
         if (command.includes('npm view') && command.includes('--tag=latest'))
           return '0.7.9';
+        if (command.includes("git tag -l 'v*'"))
+          return 'v0.6.0\nv0.6.1\nv0.7.9';
         return mockExecSync(command);
       });
 
@@ -258,6 +265,31 @@ describe('getVersion', () => {
       expect(result.releaseVersion).toBe('0.8.0-preview.0');
       expect(result.npmTag).toBe('preview');
       expect(result.previousReleaseTag).toBe('v0.7.9');
+    });
+
+    it('should fall back to the latest existing git tag when the npm baseline has no tag (half-shipped release)', () => {
+      vi.mocked(execSync).mockImplementation((command) => {
+        if (command.includes('npm view') && command.includes('--tag=latest'))
+          // Published to npm, but its release run failed before the git
+          // tag was created, so the base mock's tag list lacks v0.6.2.
+          return '0.6.2';
+        return mockExecSync(command);
+      });
+
+      const result = getVersion({ type: 'stable' });
+      expect(result.previousReleaseTag).toBe('v0.6.1');
+    });
+
+    it('should keep the npm-derived previous tag when git tag listing fails', () => {
+      vi.mocked(execSync).mockImplementation((command) => {
+        if (command.includes("git tag -l 'v*'")) {
+          throw new Error('git not available');
+        }
+        return mockExecSync(command);
+      });
+
+      const result = getVersion({ type: 'stable' });
+      expect(result.previousReleaseTag).toBe('v0.6.1');
     });
 
     it('should fall back to package.json when no nightly dist-tag exists (preview)', () => {

--- a/scripts/tests/get-release-version.test.js
+++ b/scripts/tests/get-release-version.test.js
@@ -280,6 +280,30 @@ describe('getVersion', () => {
       expect(result.previousReleaseTag).toBe('v0.6.1');
     });
 
+    it('should skip unparseable tags (e.g. leading zeros) when resolving the previous release tag', () => {
+      vi.mocked(execSync).mockImplementation((command) => {
+        if (command.includes('npm view') && command.includes('--tag=latest'))
+          return '0.6.2';
+        if (command.includes("git tag -l 'v*'"))
+          return 'v01.2.3\nv0.6.0\nv0.6.1';
+        return mockExecSync(command);
+      });
+
+      const result = getVersion({ type: 'stable' });
+      expect(result.previousReleaseTag).toBe('v0.6.1');
+    });
+
+    it('should sort tags by semver order, not lexicographic order', () => {
+      vi.mocked(execSync).mockImplementation((command) => {
+        if (command.includes("git tag -l 'v*'")) return 'v0.9.0\nv0.10.0';
+        return mockExecSync(command);
+      });
+
+      const result = getVersion({ type: 'stable' });
+      // semver descending: v0.10.0 > v0.9.0 (lexicographic would pick v0.9.0)
+      expect(result.previousReleaseTag).toBe('v0.10.0');
+    });
+
     it('should keep the npm-derived previous tag when git tag listing fails', () => {
       vi.mocked(execSync).mockImplementation((command) => {
         if (command.includes("git tag -l 'v*'")) {

--- a/scripts/tests/get-release-version.test.js
+++ b/scripts/tests/get-release-version.test.js
@@ -292,6 +292,19 @@ describe('getVersion', () => {
       expect(result.previousReleaseTag).toBe('v0.6.1');
     });
 
+    it('should return an empty previous tag when no stable git tags exist', () => {
+      vi.mocked(execSync).mockImplementation((command) => {
+        if (command.includes("git tag -l 'v*'")) {
+          // Only prerelease tags exist; the stable filter drops them all.
+          return 'v0.7.0-preview.1\nv0.8.0-nightly.20250916.abcdef';
+        }
+        return mockExecSync(command);
+      });
+
+      const result = getVersion({ type: 'stable' });
+      expect(result.previousReleaseTag).toBe('');
+    });
+
     it('should fall back to package.json when no nightly dist-tag exists (preview)', () => {
       const mockWithNoNightly = (command) => {
         // No nightly dist-tag exists


### PR DESCRIPTION
## What this PR does

When the release workflow computes the previous release tag used to anchor generated release notes, it now verifies that the tag actually exists in git. If the npm-derived tag is missing from the repository (for example, an earlier release that published to npm but failed before its git tag was created), the workflow falls back to the latest stable tag that does exist, and logs a warning. If git tags cannot be listed at all, the previous npm-only behavior is kept rather than dropping the anchor.

## Why it's needed

The previous release tag is derived solely from the npm `latest` dist-tag and is never checked against git. A half-shipped release — npm publish succeeded, tag creation failed — therefore poisons the next release's notes anchor, and the failure mode is severe: the notes degrade to the entire branch history, get truncated past the API limit, and ship a broken compare link. This happened in production with v0.22.2; details and evidence below. The finalize-release workflow already resolves the previous tag by walking real git tags and was unaffected — this aligns the release workflow's prepare stage with that behavior.

## Incident evidence (v0.22.2 release notes)

**1. v0.22.1 half-shipped.** The v0.22.1 release run failed in the Publish job after npm publish: [run 32872158347](https://github.com/QwenLM/qwen-code/actions/runs/32872158347). Result: [`@qwen-code/qwen-code@0.22.1`](https://www.npmjs.com/package/@qwen-code/qwen-code/v/0.22.1) exists on npm (published 2026-08-25T17:45 UTC), but git tag `v0.22.1` was never created — the [tag list](https://github.com/QwenLM/qwen-code/tags) jumps from `v0.22.0` to `v0.22.2`.

**2. v0.22.2 anchored at the nonexistent tag.** In the v0.22.2 publish job ([run 32966498893, job 98182388545](https://github.com/QwenLM/qwen-code/actions/runs/32966498893/job/98182388545)), the prepare stage derived the anchor from npm `latest` (still 0.22.1 at that point). Log excerpts from that job:

```text
PREVIOUS_RELEASE_TAG: v0.22.1
##[warning]Could not generate notes anchored at v0.22.1; retrying without an anchor
##[warning]Release notes exceeded 120000 characters; truncated
```

**3. Shipped notes were unusable.** The unanchored fallback generated the entire branch history (PRs as old as [#3477](https://github.com/QwenLM/qwen-code/pull/3477) appeared in a 0.22.x changelog), the body was truncated at the 120000-character cap, and the footer compare link pointed at the missing tag (`v0.22.1...v0.22.2`). The [v0.22.2 release](https://github.com/QwenLM/qwen-code/releases/tag/v0.22.2) was repaired manually afterward (regenerated with `previous_tag_name=v0.22.0`), and the [Finalize Stable Release run 32971394283](https://github.com/QwenLM/qwen-code/actions/runs/32971394283) independently resolved `PREVIOUS_RELEASE_TAG: v0.22.0` by walking real git tags — confirming the anchor this PR makes the prepare stage produce.

**With this fix**, step 2 instead logs `npm-derived previous tag v0.22.1 does not exist in git; falling back to v0.22.0.` and the notes generate against the correct range.

## Reviewer Test Plan

### How to verify

- Run `npx vitest run scripts/tests/get-release-version.test.js` — 50 tests pass, including two new cases: a half-shipped release (npm baseline has no git tag) falls back to the latest existing stable tag, and a failed git tag listing keeps the npm-derived tag.
- Read-only smoke check: `node scripts/get-release-version.js --type=stable` prints `previousReleaseTag` resolved against real tags. In a clone that lacks the newest tag it logs the fallback warning and returns the latest tag that exists; in a full clone it returns the npm-derived tag unchanged.

### Evidence (Before & After)

N/A (CI script change, not user-visible). See the Incident evidence section above for the production Before; the After is the fallback behavior described there, covered by the two new unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Unit tests plus a read-only local run of the release version script against the real npm registry and repository tags.

## Risk & Scope

- Main risk or tradeoff: the fallback picks the highest existing stable tag, which could be behind the true previous release if a tag was deleted deliberately; the warning log makes that visible.
- Not validated / out of scope: the version-bump baseline still comes from npm only, unchanged by design; the finalize workflow needed no change.
- Breaking changes / migration notes: none; output shape is unchanged.

## Linked Issues

Reference: v0.22.2 release notes incident — [run 32966498893](https://github.com/QwenLM/qwen-code/actions/runs/32966498893) (publish job), [v0.22.1 failed run 32872158347](https://github.com/QwenLM/qwen-code/actions/runs/32872158347).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Release workflow 在计算用于锚定 release notes 的上一个 release tag 时，现在会校验该 tag 在 git 中真实存在。如果从 npm 推导出的 tag 在仓库里不存在（例如上一次 release 已发布 npm 但在创建 git tag 前失败），则回退到实际存在的最新 stable tag，并打印告警日志。如果完全无法列出 git tag，则保持原有的 npm 推导行为，而不是丢掉锚点。

## 为什么需要

上一个 release tag 此前只从 npm `latest` dist-tag 推导，从不与 git 校验。一次"半发布"（npm 发布成功、建 tag 失败）就会污染下一次 release 的 notes 锚点，且失败模式很严重：notes 退化为整条分支历史、超过 API 上限被截断、并带上一个坏掉的 compare 链接。v0.22.2 已在生产环境实际发生，证据见下。finalize-release workflow 本来就是遍历真实 git tag 找上一个 stable，不受影响——本 PR 让 release workflow 的 prepare 阶段对齐这一行为。

## 事故证据（v0.22.2 release notes）

**1. v0.22.1 半发布。** v0.22.1 的 release run 在 npm 发布之后、Publish job 内失败：[run 32872158347](https://github.com/QwenLM/qwen-code/actions/runs/32872158347)。结果：npm 上存在 [`@qwen-code/qwen-code@0.22.1`](https://www.npmjs.com/package/@qwen-code/qwen-code/v/0.22.1)（2026-08-25T17:45 UTC 发布），但 git tag `v0.22.1` 从未创建——[tag 列表](https://github.com/QwenLM/qwen-code/tags)从 `v0.22.0` 直接跳到 `v0.22.2`。

**2. v0.22.2 锚定到不存在的 tag。** 在 v0.22.2 的 publish job（[run 32966498893, job 98182388545](https://github.com/QwenLM/qwen-code/actions/runs/32966498893/job/98182388545)）中，prepare 阶段从 npm `latest`（当时仍为 0.22.1）推导锚点。该 job 的日志原文：

```text
PREVIOUS_RELEASE_TAG: v0.22.1
##[warning]Could not generate notes anchored at v0.22.1; retrying without an anchor
##[warning]Release notes exceeded 120000 characters; truncated
```

**3. 发布的 notes 不可用。** 无锚点降级生成了整条分支历史（0.22.x 的 changelog 里出现了 [#3477](https://github.com/QwenLM/qwen-code/pull/3477) 这种远古 PR），body 在 120000 字符上限处被截断，尾部 compare 链接指向缺失的 tag（`v0.22.1...v0.22.2`）。[v0.22.2 release](https://github.com/QwenLM/qwen-code/releases/tag/v0.22.2) 事后已手动修复（用 `previous_tag_name=v0.22.0` 重新生成），且 [Finalize Stable Release run 32971394283](https://github.com/QwenLM/qwen-code/actions/runs/32971394283) 独立地通过遍历真实 git tag 得出 `PREVIOUS_RELEASE_TAG: v0.22.0`——这正是本 PR 让 prepare 阶段产出的锚点。

**修复后**，第 2 步会打印 `npm-derived previous tag v0.22.1 does not exist in git; falling back to v0.22.0.`，notes 按正确区间生成。

## 评审验证计划

- 运行 `npx vitest run scripts/tests/get-release-version.test.js`，50 个测试全部通过，其中新增两个用例：半发布场景（npm 基线没有对应 git tag）回退到实际存在的最新 stable tag；git tag 列举失败时保持 npm 推导值。
- 只读冒烟：`node scripts/get-release-version.js --type=stable` 会基于真实 tag 输出 `previousReleaseTag`。在缺少最新 tag 的 clone 里会打印回退告警并返回实际存在的最新 tag；在完整 clone 里原样返回 npm 推导值。

## 证据（修复前/后）

N/A（CI 脚本改动，非用户可见）。修复前见上方事故证据；修复后为其中描述的回退行为，由两个新增单测覆盖。

## 风险与范围

- 主要风险/权衡：回退取实际存在的最高 stable tag，如果某个 tag 被人为删除，结果可能落后于真实的上一个 release；告警日志可暴露这种情况。
- 未验证/不在范围内：版本号计算的基线仍然只看 npm，这是有意保持不变；finalize workflow 无需改动。
- 破坏性变更/迁移说明：无，输出结构不变。

## 关联 Issue

参考：v0.22.2 release notes 事故——[run 32966498893](https://github.com/QwenLM/qwen-code/actions/runs/32966498893)（publish job）、[v0.22.1 失败 run 32872158347](https://github.com/QwenLM/qwen-code/actions/runs/32872158347)。

</details>
