### PR TITLE
fix(core): align skill allowedTools caveats with the deferred-registry behavior (#10075)

### DIFF
--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -46,8 +46,10 @@ export interface SkillConfig {
    *
    * This is an additive grant only: it never hides or restricts the tools the
    * model can see. Under an active `permissions.allow` registry allowlist it
-   * still cannot register a tool the startup allowlist skipped — that tool
-   * needs the rule in settings `permissions.allow` plus a restart (#9827).
+   * cannot promote a deferred tool into the eager model request — a tool the
+   * startup allowlist left uncovered stays deferred (still registered and
+   * loadable via `tool_search`) until the rule is added to settings
+   * `permissions.allow` plus a restart (#9827, #10075).
    * Malformed entries are ignored. See `applySkillAllowedTools`.
    */
   allowedTools?: string[];

--- a/packages/core/src/tools/skill-utils.ts
+++ b/packages/core/src/tools/skill-utils.ts
@@ -275,13 +275,14 @@ ${escapeXml(entry.description)}
  * auto-approved for the rest of the session instead of prompting. This is an
  * additive grant only — it never hides or restricts the tools the model sees.
  *
- * Caveat under an active `permissions.allow` registry allowlist (#9827): the
- * grant flips the runtime permission predicate, but it can never REGISTER a
- * tool that the startup allowlist skipped at registration — the registry is
- * built once in `Config.initialize`, so such a tool still fails
- * TOOL_NOT_REGISTERED until the rule is added to settings `permissions.allow`
- * and the session restarts. `PermissionManager.addSessionAllowRule` logs this
- * caveat on the first such grant.
+ * Caveat under an active `permissions.allow` registry allowlist (#9827,
+ * #10075): the grant auto-approves matching calls and extends allowlist
+ * membership, but it cannot promote a deferred tool into the eager model
+ * request — a tool the startup allowlist left uncovered stays deferred
+ * (still registered and loadable via `tool_search`, schema not sent eagerly)
+ * until the rule is added to settings `permissions.allow` and the session
+ * restarts. `PermissionManager.addSessionAllowRule` logs this caveat on the
+ * first such grant.
  *
  * No-ops when there is no permission manager or nothing to grant.
  */


### PR DESCRIPTION
## What this PR does

Updates two stale doc-comments so they match the deferred-registry behavior that #10082 landed. Before #10082, an allowlist-uncovered built-in tool was **skipped at registration** (and a later call failed `TOOL_NOT_REGISTERED`); since #10082 it is **deferred** — still registered and loadable via `tool_search`, with its schema just kept out of the eager model request. Two comments still described the old "skipped / TOOL_NOT_REGISTERED" behavior and now contradict the code:

- `packages/core/src/tools/skill-utils.ts` — `applySkillAllowedTools` docstring caveat
- `packages/core/src/skills/types.ts` — `SkillFrontmatter.allowedTools` docstring caveat

Both are rewritten to say the grant cannot **promote a deferred tool into the eager request** (the tool stays registered + `tool_search`-loadable until the rule is added to settings `permissions.allow` and the session restarts), which is consistent with the already-correct caveat logged by `PermissionManager.addSessionAllowRule`.

## Why it's needed

Comment-only, but the stale text is actively misleading: it tells readers a session grant "can never register a tool the startup allowlist skipped" and that such a tool "fails TOOL_NOT_REGISTERED" — neither is true under the merged deferred behavior. Doc-comment drift here is likely to mislead future skill/permission work.

## Reviewer Test Plan

### How to verify

Comment-only change; no runtime behavior touched.
- `npx eslint packages/core/src/tools/skill-utils.ts packages/core/src/skills/types.ts` → clean.
- Wording cross-checks against `PermissionManager.addSessionAllowRule`'s existing caveat (permission-manager.ts), which already uses the "stays deferred (loadable via ToolSearch, schema not sent eagerly)" phrasing.

### Evidence (Before & After)

N/A — documentation comments only, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅ (lint) |

### Environment (optional)

N/A — comment-only.

## Risk & Scope

- Main risk or tradeoff: none — comments only, no code path changes.
- Not validated / out of scope: no runtime behavior to test.
- Breaking changes / migration notes: none.

## Linked Issues

Related: #10075, #9827, and follow-up to #10082 (aligns comments with the deferred behavior it introduced). Supersedes the full-decoupling proposal in #10098.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

更新两处过时的文档注释,使其与 #10082 落地的"延迟注册 (deferred)"行为一致。#10082 之前,白名单未覆盖的内置工具会在**注册阶段被跳过**(后续调用报 `TOOL_NOT_REGISTERED`);#10082 之后改为**延迟**——仍然注册、可通过 `tool_search` 加载,只是其 schema 不进 eager 模型请求。有两处注释仍在描述旧的"跳过 / TOOL_NOT_REGISTERED"行为,已与代码矛盾:

- `packages/core/src/tools/skill-utils.ts` —— `applySkillAllowedTools` 的注释
- `packages/core/src/skills/types.ts` —— `SkillFrontmatter.allowedTools` 的注释

两处都改写为:授权**无法把延迟工具提升到 eager 请求**(该工具保持注册、可经 `tool_search` 加载,直到规则写入 settings `permissions.allow` 并重启会话)。这与 `PermissionManager.addSessionAllowRule` 已经在记录的正确 caveat 措辞保持一致。

## 为什么需要

纯注释改动,但旧文案有误导性:它说会话授权"永远无法注册被启动白名单跳过的工具"、该工具"会报 TOOL_NOT_REGISTERED"——在合并后的 deferred 行为下这两点都不成立。此处注释漂移容易误导后续 skill/permission 相关开发。

## 测试方式

纯注释改动,不涉及运行时行为。`npx eslint` 两个文件干净;措辞与 `permission-manager.ts` 中 `addSessionAllowRule` 已有的 caveat 交叉核对一致。

- 主要风险:无,纯注释。
- 无运行时行为可测。
- 无破坏性变更。

相关:#10075、#9827,是 #10082 的注释对齐后续;取代 #10098 的全量解耦提案。

</details>
