### PR TITLE
fix(goal): stamp tool results in every host, so Goals can prove anything

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -19606,10 +19606,18 @@ describe('Session', () => {
           getDefaultPermission: vi.fn().mockResolvedValue('allow'),
           getDescription: vi.fn().mockReturnValue(name),
           toolLocations: vi.fn().mockReturnValue([]),
-          execute: vi.fn().mockResolvedValue({
-            llmContent: 'ok',
-            returnDisplay: 'ok',
-          }),
+          execute: vi.fn().mockResolvedValue(
+            name === 'run_shell_command'
+              ? {
+                  llmContent: 'command failed',
+                  returnDisplay: 'command failed',
+                  error: {
+                    message: 'command failed',
+                    type: core.ToolErrorType.EXECUTION_FAILED,
+                  },
+                }
+              : { llmContent: 'ok', returnDisplay: 'ok' },
+          ),
         }));
         mockChat.sendMessageStream = vi
           .fn()
@@ -19621,6 +19629,7 @@ describe('Session', () => {
                   functionCalls: [
                     { id: 'call-read', name: 'read_file', args: {} },
                     { id: 'call-goal', name: 'get_goal', args: {} },
+                    { id: 'call-failed', name: 'run_shell_command', args: {} },
                   ],
                 },
               },
@@ -19648,6 +19657,88 @@ describe('Session', () => {
           goalContext: permit,
           provenance: 'goal_runtime',
         });
+        // A failed command is evidence too -- it is exactly what an
+        // `infeasible` completion cites -- so the stamp must not depend on
+        // the tool succeeding.
+        expect(
+          mockChatRecordingService.recordToolResult.mock.calls.find(
+            (call: unknown[]) =>
+              (call[1] as { callId?: string } | undefined)?.callId ===
+              'call-failed',
+          )?.[1],
+        ).toMatchObject({ status: 'error' });
+        expect(optionsFor('call-failed')).toEqual({ goalContext: permit });
+      });
+
+      it('does not stamp a background-notification turn with a permit inherited by lineage', async () => {
+        // A notification fires from async resources created inside the turn
+        // that spawned the task, so the Goal store is inherited into it long
+        // after that turn ended. The notification turn is not a Goal turn:
+        // its tool results must record unstamped, or they would become
+        // external_fact evidence for a turn that never made those calls.
+        const permit: core.GoalTurnPermit = {
+          goalId: 'goal-1',
+          revision: 1,
+          turnId: 'turn-stale',
+        };
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+        mockToolRegistry.getTool.mockImplementation((name: string) => ({
+          name,
+          displayName: name,
+          kind: core.Kind.Read,
+          schema: { name, description: name, parameters: {} },
+          validateToolParams: vi.fn().mockReturnValue(null),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getDescription: vi.fn().mockReturnValue(name),
+          toolLocations: vi.fn().mockReturnValue([]),
+          execute: vi
+            .fn()
+            .mockResolvedValue({ llmContent: 'ok', returnDisplay: 'ok' }),
+        }));
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    { id: 'call-notified', name: 'read_file', args: {} },
+                  ],
+                },
+              },
+            ]),
+          )
+          .mockResolvedValue(createEmptyStream());
+
+        // Enqueue from inside a Goal turn's store, as a task completion
+        // handler created during that turn would.
+        const notification = core.goalTurnContext.run(permit, () =>
+          session.enqueueBackgroundNotification({
+            displayText: 'Background agent completed.',
+            modelText: '<task-notification />',
+            taskId: 'agent-stale',
+            status: 'completed',
+            kind: 'agent',
+          }),
+        );
+        await expect(notification).resolves.toEqual({ accepted: true });
+        await vi.waitFor(() => {
+          expect(
+            mockChatRecordingService.recordToolResult.mock.calls.some(
+              (call: unknown[]) =>
+                (call[1] as { callId?: string } | undefined)?.callId ===
+                'call-notified',
+            ),
+          ).toBe(true);
+        });
+
+        const call = mockChatRecordingService.recordToolResult.mock.calls.find(
+          (call: unknown[]) =>
+            (call[1] as { callId?: string } | undefined)?.callId ===
+            'call-notified',
+        )!;
+        expect(call).toHaveLength(2);
       });
 
       it('runs a host-scheduled Goal turn with the canonical permit', async () => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -19567,6 +19567,89 @@ describe('Session', () => {
         expect(publishedActivities).toEqual(['idle', 'running']);
       });
 
+      it('stamps a Goal turn’s tool results with the permit, and its own reads as bookkeeping', async () => {
+        // The evidence catalog derives provenance from this stamp: an
+        // unstamped tool result yields no catalog entry at all, so an ACP
+        // Goal could never cite an external_fact and could never prove a
+        // completion with anything but the model's own words.
+        const permit: core.GoalTurnPermit = {
+          goalId: 'goal-1',
+          revision: 1,
+          turnId: 'turn-stamp',
+        };
+        mockGoalRuntime.getSnapshot.mockReturnValue({
+          v: 2,
+          activity: 'running',
+          goal: {
+            goalId: 'goal-1',
+            revision: 1,
+            objective: 'check weather',
+            status: 'active',
+            evidenceCursor: { recordId: 'cursor-1' },
+            turnCount: 0,
+            activeTimeMs: 0,
+            tokensUsed: 0,
+            createdAt: 1234,
+            updatedAt: 1234,
+          },
+        });
+        mockGoalRuntime.permitForTurn.mockImplementation((turnKey: string) =>
+          turnKey === 'goal-runtime:turn-stamp' ? permit : undefined,
+        );
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+        mockToolRegistry.getTool.mockImplementation((name: string) => ({
+          name,
+          displayName: name,
+          kind: core.Kind.Read,
+          schema: { name, description: name, parameters: {} },
+          validateToolParams: vi.fn().mockReturnValue(null),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getDescription: vi.fn().mockReturnValue(name),
+          toolLocations: vi.fn().mockReturnValue([]),
+          execute: vi.fn().mockResolvedValue({
+            llmContent: 'ok',
+            returnDisplay: 'ok',
+          }),
+        }));
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    { id: 'call-read', name: 'read_file', args: {} },
+                    { id: 'call-goal', name: 'get_goal', args: {} },
+                  ],
+                },
+              },
+            ]),
+          )
+          .mockResolvedValue(createEmptyStream());
+
+        expect(boundGoalHost).toBeDefined();
+        await boundGoalHost!.startGoalTurn({
+          permit,
+          continuationContext: 'check weather',
+        });
+
+        await vi.waitFor(() => {
+          expect(mockGoalRuntime.finishTurn).toHaveBeenCalledWith(permit);
+        });
+
+        const optionsFor = (callId: string) =>
+          mockChatRecordingService.recordToolResult.mock.calls.find(
+            (call: unknown[]) =>
+              (call[1] as { callId?: string } | undefined)?.callId === callId,
+          )?.[2];
+        expect(optionsFor('call-read')).toEqual({ goalContext: permit });
+        expect(optionsFor('call-goal')).toEqual({
+          goalContext: permit,
+          provenance: 'goal_runtime',
+        });
+      });
+
       it('runs a host-scheduled Goal turn with the canonical permit', async () => {
         const permit: core.GoalTurnPermit = {
           goalId: 'goal-1',

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -19738,7 +19738,88 @@ describe('Session', () => {
             (call[1] as { callId?: string } | undefined)?.callId ===
             'call-notified',
         )!;
-        expect(call).toHaveLength(2);
+        expect(call[2]).toBeUndefined();
+      });
+
+      it('does not stamp a cron turn with a permit inherited by lineage', async () => {
+        // `#drainCronQueue()` is fired from inside Goal-turn code paths (the
+        // turn settle's `finally`, among others), so a cron item can drain
+        // while a Goal permit is live in the store. A cron turn is never a
+        // Goal turn: its tool results must record unstamped, exactly like
+        // the notification turn above.
+        const permit: core.GoalTurnPermit = {
+          goalId: 'goal-1',
+          revision: 1,
+          turnId: 'turn-stale-cron',
+        };
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.YOLO);
+        mockToolRegistry.getTool.mockImplementation((name: string) => ({
+          name,
+          displayName: name,
+          kind: core.Kind.Read,
+          schema: { name, description: name, parameters: {} },
+          validateToolParams: vi.fn().mockReturnValue(null),
+          getDefaultPermission: vi.fn().mockResolvedValue('allow'),
+          getDescription: vi.fn().mockReturnValue(name),
+          toolLocations: vi.fn().mockReturnValue([]),
+          execute: vi
+            .fn()
+            .mockResolvedValue({ llmContent: 'ok', returnDisplay: 'ok' }),
+        }));
+        let fireCron!: (job: { prompt: string; cronExpr: string }) => void;
+        const scheduler = {
+          hasPendingWork: true,
+          enableDurable: vi.fn().mockResolvedValue(undefined),
+          start: vi.fn(
+            (callback: (job: { prompt: string; cronExpr: string }) => void) => {
+              fireCron = callback;
+            },
+          ),
+          stop: vi.fn(),
+          list: vi.fn().mockReturnValue([]),
+          getExitSummary: vi.fn().mockReturnValue(undefined),
+        };
+        mockConfig.isCronEnabled = vi.fn().mockReturnValue(true);
+        mockConfig.getCronScheduler = vi.fn().mockReturnValue(scheduler);
+        session.startCronScheduler();
+        await vi.waitFor(() => expect(scheduler.start).toHaveBeenCalled());
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValueOnce(
+            createStreamWithChunks([
+              {
+                type: core.StreamEventType.CHUNK,
+                value: {
+                  functionCalls: [
+                    { id: 'call-cron', name: 'read_file', args: {} },
+                  ],
+                },
+              },
+            ]),
+          )
+          .mockResolvedValue(createEmptyStream());
+
+        // Fire from inside a Goal turn's store, as a drain triggered from a
+        // Goal-turn code path would be.
+        core.goalTurnContext.run(permit, () =>
+          fireCron({ prompt: 'cron work', cronExpr: '* * * * *' }),
+        );
+        await vi.waitFor(() => {
+          expect(
+            mockChatRecordingService.recordToolResult.mock.calls.some(
+              (call: unknown[]) =>
+                (call[1] as { callId?: string } | undefined)?.callId ===
+                'call-cron',
+            ),
+          ).toBe(true);
+        });
+
+        const call = mockChatRecordingService.recordToolResult.mock.calls.find(
+          (call: unknown[]) =>
+            (call[1] as { callId?: string } | undefined)?.callId ===
+            'call-cron',
+        )!;
+        expect(call[2]).toBeUndefined();
       });
 
       it('runs a host-scheduled Goal turn with the canonical permit', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -8093,10 +8093,14 @@ export class Session implements SessionContext {
    * `_meta.source='cron'`, streams the model response, and handles tool calls.
    */
   async #executeCronPrompt(item: CronQueueItem): Promise<void> {
-    // Same session-ID binding rationale as #executePrompt.
-    return runWithInvocationContext(undefined, () =>
-      sessionIdContext.run(this.config.getSessionId(), () =>
-        this.#executeCronPromptInner(item),
+    // Same session-ID binding rationale as #executePrompt, and the same
+    // reason to leave the Goal store as the notification drain: a cron turn
+    // is never a Goal turn, whatever lineage it was scheduled from.
+    return goalTurnContext.exit(() =>
+      runWithInvocationContext(undefined, () =>
+        sessionIdContext.run(this.config.getSessionId(), () =>
+          this.#executeCronPromptInner(item),
+        ),
       ),
     );
   }
@@ -8873,9 +8877,17 @@ export class Session implements SessionContext {
         this.currentShellNotificationActive = item.kind === 'shell';
         this.#activeWorkChanged();
         try {
-          await runWithInvocationContext(undefined, () =>
-            sessionIdContext.run(this.config.getSessionId(), () =>
-              this.#executeBackgroundNotificationPromptInner(item),
+          // A notification fires from async resources created inside the
+          // turn that spawned the task, so a Goal permit can reach here by
+          // lineage after that turn is long over. This is not a Goal turn:
+          // leave the store, as #executePrompt does for every non-Goal turn,
+          // or the notification's tool results would be stamped as evidence
+          // for a turn that never made those calls.
+          await goalTurnContext.exit(() =>
+            runWithInvocationContext(undefined, () =>
+              sessionIdContext.run(this.config.getSessionId(), () =>
+                this.#executeBackgroundNotificationPromptInner(item),
+              ),
             ),
           );
         } finally {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -169,6 +169,7 @@ import {
   refreshMemoryAfterManagedWrite,
   refreshMemoryInstruction,
   GoalPersistenceUnavailableError,
+  ambientGoalToolResultProvenance,
   goalTurnContext,
   sessionIdContext,
   promptIdContext,
@@ -9731,13 +9732,19 @@ export class Session implements SessionContext {
         ) {
           return;
         }
-        this.config
-          .getChatRecordingService()
-          ?.recordToolResult(finalized[index].responseParts, {
+        const goalProvenance = ambientGoalToolResultProvenance(record.toolName);
+        this.config.getChatRecordingService()?.recordToolResult(
+          finalized[index].responseParts,
+          {
             ...record.metadata,
             persistedOutputFiles: finalized[index].persistedOutputFiles,
             artifacts: finalized[index].artifacts,
-          });
+          },
+          // Passed only inside a Goal turn: outside one this call keeps its
+          // former two-argument shape, so nothing about ordinary recording
+          // changes.
+          ...(goalProvenance ? ([goalProvenance] as const) : ([] as const)),
+        );
       });
       return {
         ...result,

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2881,6 +2881,33 @@ describe('runNonInteractive', () => {
         }),
       );
       const permit = { goalId: 'g-1', revision: 2, turnId: 't-1' };
+      mockCoreExecuteToolCall.mockImplementation(
+        async (
+          _config: unknown,
+          request: { callId: string; name: string },
+        ) => ({
+          responseParts: [
+            {
+              functionResponse: {
+                id: request.callId,
+                name: request.name,
+                response:
+                  request.callId === 'shell-failed'
+                    ? { error: 'command failed' }
+                    : { output: 'ok' },
+              },
+            },
+          ],
+          resultDisplay:
+            request.callId === 'shell-failed' ? 'command failed' : 'ok',
+          ...(request.callId === 'shell-failed'
+            ? {
+                error: new Error('command failed'),
+                errorType: ToolErrorType.EXECUTION_FAILED,
+              }
+            : {}),
+        }),
+      );
       const goalToolCall = (callId: string, name: string) => ({
         type: GeminiEventType.ToolCallRequest,
         value: {
@@ -2897,6 +2924,7 @@ describe('runNonInteractive', () => {
           createStreamFromEvents([
             goalToolCall('shell-1', ToolNames.READ_FILE),
             goalToolCall('goal-read', ToolNames.GET_GOAL),
+            goalToolCall('shell-failed', ToolNames.SHELL),
           ] as unknown as ServerGeminiStreamEvent[]),
         )
         .mockReturnValueOnce(createStreamFromEvents(finishTurn));
@@ -2912,6 +2940,17 @@ describe('runNonInteractive', () => {
       expect(optionsByCallId.get('goal-read')).toEqual({
         goalContext: permit,
         provenance: 'goal_runtime',
+      });
+      // A failed command is evidence too -- it is exactly what an
+      // `infeasible` completion cites -- so the stamp must not depend on the
+      // tool succeeding.
+      expect(
+        recordToolResult.mock.calls.find(
+          (call) => call[1]?.callId === 'shell-failed',
+        )?.[1],
+      ).toMatchObject({ status: 'error' });
+      expect(optionsByCallId.get('shell-failed')).toEqual({
+        goalContext: permit,
       });
     });
 

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2841,6 +2841,132 @@ describe('runNonInteractive', () => {
       ).toEqual(['not_started', 'not_started', 'not_started']);
     });
 
+    it('stamps a Goal turn’s tool results with the permit that asked for them', async () => {
+      // The evidence catalog derives provenance from this stamp; without it a
+      // headless Goal produces no `external_fact` at all, so a completion can
+      // only ever cite the model's own words and the verifier refuses it.
+      setupMetricsMock();
+      const recordToolResult = vi.fn();
+      (
+        mockConfig as Config & {
+          getChatRecordingService: () => {
+            recordToolResult: typeof recordToolResult;
+            finalize: ReturnType<typeof vi.fn>;
+            flush: ReturnType<typeof vi.fn>;
+          };
+        }
+      ).getChatRecordingService = () => ({
+        recordToolResult,
+        finalize: vi.fn(),
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(mockToolRegistry.getTool).mockReturnValue({
+        kind: Kind.Read,
+      } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
+      mockCoreExecuteToolCall.mockImplementation(
+        async (
+          _config: unknown,
+          request: { callId: string; name: string },
+        ) => ({
+          responseParts: [
+            {
+              functionResponse: {
+                id: request.callId,
+                name: request.name,
+                response: { output: 'ok' },
+              },
+            },
+          ],
+          resultDisplay: 'ok',
+        }),
+      );
+      const permit = { goalId: 'g-1', revision: 2, turnId: 't-1' };
+      const goalToolCall = (callId: string, name: string) => ({
+        type: GeminiEventType.ToolCallRequest,
+        value: {
+          callId,
+          name,
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'p-goal',
+          goalContext: permit,
+        },
+      });
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents([
+            goalToolCall('shell-1', ToolNames.READ_FILE),
+            goalToolCall('goal-read', ToolNames.GET_GOAL),
+          ] as unknown as ServerGeminiStreamEvent[]),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      await runNonInteractive(mockConfig, 'work the goal', 'p-goal');
+
+      const optionsByCallId = new Map(
+        recordToolResult.mock.calls.map((call) => [call[1]?.callId, call[2]]),
+      );
+      // An ordinary tool becomes citable external evidence...
+      expect(optionsByCallId.get('shell-1')).toEqual({ goalContext: permit });
+      // ...while the Goal's own reads stay out of the catalog.
+      expect(optionsByCallId.get('goal-read')).toEqual({
+        goalContext: permit,
+        provenance: 'goal_runtime',
+      });
+    });
+
+    it('leaves tool results outside a Goal turn unstamped', async () => {
+      setupMetricsMock();
+      const recordToolResult = vi.fn();
+      (
+        mockConfig as Config & {
+          getChatRecordingService: () => {
+            recordToolResult: typeof recordToolResult;
+            finalize: ReturnType<typeof vi.fn>;
+            flush: ReturnType<typeof vi.fn>;
+          };
+        }
+      ).getChatRecordingService = () => ({
+        recordToolResult,
+        finalize: vi.fn(),
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.mocked(mockToolRegistry.getTool).mockReturnValue({
+        kind: Kind.Read,
+      } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
+      mockCoreExecuteToolCall.mockImplementation(
+        async (
+          _config: unknown,
+          request: { callId: string; name: string },
+        ) => ({
+          responseParts: [
+            {
+              functionResponse: {
+                id: request.callId,
+                name: request.name,
+                response: { output: 'ok' },
+              },
+            },
+          ],
+          resultDisplay: 'ok',
+        }),
+      );
+      mockGeminiClient.sendMessageStream
+        .mockReturnValueOnce(
+          createStreamFromEvents(
+            toolCallEvents(['plain-1'], ToolNames.READ_FILE, 'p-plain'),
+          ),
+        )
+        .mockReturnValueOnce(createStreamFromEvents(finishTurn));
+
+      await runNonInteractive(mockConfig, 'plain work', 'p-plain');
+
+      expect(recordToolResult).toHaveBeenCalled();
+      for (const call of recordToolResult.mock.calls) {
+        expect(call[2]).toBeUndefined();
+      }
+    });
+
     it('runs a batch of concurrency-safe tool calls concurrently', async () => {
       setupMetricsMock();
       // Kind.Read is concurrency-safe, so the whole batch is one parallel

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -2863,23 +2863,6 @@ describe('runNonInteractive', () => {
       vi.mocked(mockToolRegistry.getTool).mockReturnValue({
         kind: Kind.Read,
       } as unknown as ReturnType<typeof mockToolRegistry.getTool>);
-      mockCoreExecuteToolCall.mockImplementation(
-        async (
-          _config: unknown,
-          request: { callId: string; name: string },
-        ) => ({
-          responseParts: [
-            {
-              functionResponse: {
-                id: request.callId,
-                name: request.name,
-                response: { output: 'ok' },
-              },
-            },
-          ],
-          resultDisplay: 'ok',
-        }),
-      );
       const permit = { goalId: 'g-1', revision: 2, turnId: 't-1' };
       mockCoreExecuteToolCall.mockImplementation(
         async (

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -33,6 +33,7 @@ import {
   InputFormat,
   LoopType,
   ToolNames,
+  goalToolResultProvenance,
   uiTelemetryService,
   parseAndFormatApiError,
   createDebugLogger,
@@ -2245,18 +2246,23 @@ export async function runNonInteractive(
           const { request, response } = orderedResponses[index];
           const finalizedParts = finalized[index].responseParts;
           toolResponseParts.push(...finalizedParts);
-          chatRecordingService?.recordToolResult?.(finalizedParts, {
-            callId: request.callId,
-            status:
-              statusByResponse.get(response) ??
-              (response.error ? 'error' : 'success'),
-            resultDisplay: response.resultDisplay,
-            persistedOutputFiles: finalized[index].persistedOutputFiles,
-            artifacts: finalized[index].artifacts,
-            error: response.error,
-            errorType: response.errorType,
-            executionStatus: response.executionStatus,
-          });
+          const goalProvenance = goalToolResultProvenance(request);
+          chatRecordingService?.recordToolResult?.(
+            finalizedParts,
+            {
+              callId: request.callId,
+              status:
+                statusByResponse.get(response) ??
+                (response.error ? 'error' : 'success'),
+              resultDisplay: response.resultDisplay,
+              persistedOutputFiles: finalized[index].persistedOutputFiles,
+              artifacts: finalized[index].artifacts,
+              error: response.error,
+              errorType: response.errorType,
+              executionStatus: response.executionStatus,
+            },
+            ...(goalProvenance ? ([goalProvenance] as const) : ([] as const)),
+          );
         }
 
         return {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -33,6 +33,7 @@ import {
   SendMessageType,
   createDebugLogger,
   ToolNames,
+  goalToolResultProvenance,
   getErrorMessage,
   isNodeError,
   MessageSenderType,
@@ -3919,7 +3920,6 @@ export const useGeminiStream = (
             );
             immediateDuplicateToolResponses.responses.forEach(
               ({ request, response }, index) => {
-                const goalContext = request.goalContext;
                 config.getChatRecordingService?.()?.recordToolResult?.(
                   finalized[index].responseParts,
                   {
@@ -3932,15 +3932,7 @@ export const useGeminiStream = (
                     errorType: response.errorType,
                     executionStatus: response.executionStatus,
                   },
-                  goalContext
-                    ? request.name === ToolNames.GET_GOAL ||
-                      request.name === ToolNames.UPDATE_GOAL
-                      ? {
-                          goalContext: { ...goalContext },
-                          provenance: 'goal_runtime' as const,
-                        }
-                      : { goalContext: { ...goalContext } }
-                    : undefined,
+                  goalToolResultProvenance(request),
                 );
               },
             );
@@ -4860,7 +4852,6 @@ export const useGeminiStream = (
         (entry) => entry.responseParts,
       );
       orderedResponses.forEach(({ request, response, status }, index) => {
-        const goalContext = request.goalContext;
         config.getChatRecordingService?.()?.recordToolResult?.(
           finalizedResponses[index].responseParts,
           {
@@ -4874,15 +4865,7 @@ export const useGeminiStream = (
             errorType: response.errorType,
             executionStatus: response.executionStatus,
           },
-          goalContext
-            ? request.name === ToolNames.GET_GOAL ||
-              request.name === ToolNames.UPDATE_GOAL
-              ? {
-                  goalContext: { ...goalContext },
-                  provenance: 'goal_runtime' as const,
-                }
-              : { goalContext: { ...goalContext } }
-            : undefined,
+          goalToolResultProvenance(request),
         );
       });
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -6285,10 +6285,13 @@ export class CoreToolScheduler {
         error: call.response.error,
         errorType: call.response.errorType,
       };
+      const goalProvenance = goalToolResultProvenance(call.request);
       this.chatRecordingService.recordToolResult(
         call.response.responseParts,
         result,
-        goalToolResultProvenance(call.request),
+        // Passed only inside a Goal turn, so recording outside one keeps its
+        // two-argument shape.
+        ...(goalProvenance ? ([goalProvenance] as const) : ([] as const)),
       );
     }
   }

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -205,6 +205,7 @@ import {
 } from '../utils/invocation-context.js';
 import { evaluateToolInvocationGuard } from './tool-invocation-guard.js';
 import { goalTurnContext } from '../goals/goal-turn-context.js';
+import { goalToolResultProvenance } from '../goals/goal-tool-result-provenance.js';
 
 const debugLogger = createDebugLogger('TOOL_SCHEDULER');
 
@@ -6284,28 +6285,11 @@ export class CoreToolScheduler {
         error: call.response.error,
         errorType: call.response.errorType,
       };
-      const goalContext = call.request.goalContext;
-      if (!goalContext) {
-        this.chatRecordingService.recordToolResult(
-          call.response.responseParts,
-          result,
-        );
-      } else if (
-        call.request.name === ToolNames.GET_GOAL ||
-        call.request.name === ToolNames.UPDATE_GOAL
-      ) {
-        this.chatRecordingService.recordToolResult(
-          call.response.responseParts,
-          result,
-          { goalContext: { ...goalContext }, provenance: 'goal_runtime' },
-        );
-      } else {
-        this.chatRecordingService.recordToolResult(
-          call.response.responseParts,
-          result,
-          { goalContext: { ...goalContext } },
-        );
-      }
+      this.chatRecordingService.recordToolResult(
+        call.response.responseParts,
+        result,
+        goalToolResultProvenance(call.request),
+      );
     }
   }
 

--- a/packages/core/src/goals/goal-tool-result-provenance.test.ts
+++ b/packages/core/src/goals/goal-tool-result-provenance.test.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ToolNames } from '../tools/tool-names.js';
+import { goalTurnContext } from './goal-turn-context.js';
+import {
+  ambientGoalToolResultProvenance,
+  goalToolResultProvenance,
+} from './goal-tool-result-provenance.js';
+
+const permit = { goalId: 'g-1', revision: 2, turnId: 't-1' };
+
+describe('goalToolResultProvenance', () => {
+  it('stamps an ordinary tool result with the permit that asked for it', () => {
+    // Without the stamp the catalog derives no provenance at all, so the
+    // result cannot become the `external_fact` a completion is proved with.
+    expect(
+      goalToolResultProvenance({
+        name: 'run_shell_command',
+        goalContext: permit,
+      }),
+    ).toEqual({ goalContext: permit });
+  });
+
+  it('copies the permit rather than aliasing the request', () => {
+    const request = { name: 'read_file', goalContext: { ...permit } };
+    const options = goalToolResultProvenance(request);
+    expect(options?.goalContext).not.toBe(request.goalContext);
+    expect(options?.goalContext).toEqual(permit);
+  });
+
+  it.each([ToolNames.GET_GOAL, ToolNames.UPDATE_GOAL])(
+    'marks %s as the Goal’s own bookkeeping',
+    (name) => {
+      // Excluded from the catalog on purpose: a Goal that cited its own reads
+      // as proof would be arguing in a circle.
+      expect(goalToolResultProvenance({ name, goalContext: permit })).toEqual({
+        goalContext: permit,
+        provenance: 'goal_runtime',
+      });
+    },
+  );
+
+  it('leaves a tool call made outside a Goal turn unstamped', () => {
+    expect(goalToolResultProvenance({ name: 'read_file' })).toBeUndefined();
+  });
+});
+
+describe('ambientGoalToolResultProvenance', () => {
+  it('reads the permit from the surrounding Goal turn', () => {
+    const options = goalTurnContext.run(permit, () =>
+      ambientGoalToolResultProvenance('run_shell_command'),
+    );
+    expect(options).toEqual({ goalContext: permit });
+  });
+
+  it('applies the same bookkeeping rule inside a turn', () => {
+    const options = goalTurnContext.run(permit, () =>
+      ambientGoalToolResultProvenance(ToolNames.GET_GOAL),
+    );
+    expect(options).toEqual({
+      goalContext: permit,
+      provenance: 'goal_runtime',
+    });
+  });
+
+  it('stamps nothing outside a Goal turn', () => {
+    expect(ambientGoalToolResultProvenance('read_file')).toBeUndefined();
+  });
+});

--- a/packages/core/src/goals/goal-tool-result-provenance.ts
+++ b/packages/core/src/goals/goal-tool-result-provenance.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { RecordToolResultOptions } from '../services/chatRecordingService.js';
+import { ToolNames } from '../tools/tool-names.js';
+import type { GoalTurnPermit } from './goal-protocol.js';
+import { goalTurnContext } from './goal-turn-context.js';
+
+/** The slice of a tool-call request this reads. */
+export interface GoalToolResultRequest {
+  name: string;
+  goalContext?: GoalTurnPermit;
+}
+
+/**
+ * How a finished tool call should be recorded, so its result can become Goal
+ * evidence.
+ *
+ * The evidence catalog derives a record's provenance from the Goal permit
+ * stamped on it (`goal-evidence.ts`: no parsed goal context, no provenance,
+ * no catalog entry). A tool result recorded without the stamp is therefore
+ * invisible to the catalog -- and since `tool_result` is the only provenance
+ * that maps to `external_fact`, an unstamped host produces a Goal that can
+ * never prove anything about the world: completions citing only the model's
+ * own words are refused by the verifier, and the `infeasible` and `external`
+ * blockers, which require external evidence, are unreachable.
+ *
+ * `get_goal` and `update_goal` are stamped as `goal_runtime` instead: they are
+ * the Goal's own bookkeeping, and a catalog that cited its own reads as proof
+ * would be circular.
+ *
+ * Every host that records tool results during a Goal turn must route through
+ * here, so the three of them cannot drift on the rule.
+ */
+export function goalToolResultProvenance(
+  request: GoalToolResultRequest,
+): RecordToolResultOptions | undefined {
+  const { goalContext } = request;
+  if (!goalContext) return undefined;
+  if (
+    request.name === ToolNames.GET_GOAL ||
+    request.name === ToolNames.UPDATE_GOAL
+  ) {
+    return { goalContext: { ...goalContext }, provenance: 'goal_runtime' };
+  }
+  return { goalContext: { ...goalContext } };
+}
+
+/**
+ * The same rule for a host that executes tools straight from the model's
+ * function calls and so has no `ToolCallRequestInfo` to read a permit from.
+ *
+ * The permit comes from the ambient Goal turn context, which the host enters
+ * around the whole turn -- including the tool calls it issues -- so a result
+ * recorded here belongs to the turn that asked for it.
+ */
+export function ambientGoalToolResultProvenance(
+  toolName: string,
+): RecordToolResultOptions | undefined {
+  const goalContext = goalTurnContext.getStore();
+  return goalToolResultProvenance({
+    name: toolName,
+    ...(goalContext ? { goalContext } : {}),
+  });
+}

--- a/packages/core/src/goals/goal-tool-result-provenance.ts
+++ b/packages/core/src/goals/goal-tool-result-provenance.ts
@@ -32,8 +32,9 @@ export interface GoalToolResultRequest {
  * the Goal's own bookkeeping, and a catalog that cited its own reads as proof
  * would be circular.
  *
- * Every host that records tool results during a Goal turn must route through
- * here, so the three of them cannot drift on the rule.
+ * Every site that records tool results during a Goal turn routes through
+ * here -- the interactive scheduler, both TUI recording paths, headless, and
+ * ACP -- so the rule cannot drift between them.
  */
 export function goalToolResultProvenance(
   request: GoalToolResultRequest,

--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -64,6 +64,7 @@ export type {
   LegacyGoalTerminal,
 } from './goal-legacy-projection.js';
 export * from './goal-evidence.js';
+export * from './goal-tool-result-provenance.js';
 export * from './goal-checkpoint.js';
 export * from './goal-checkpoint-verifier.js';
 export * from './goal-verifier.js';


### PR DESCRIPTION
## What this PR does

Records tool results with the Goal turn permit in the headless and ACP hosts, so their results can become evidence. The rule is extracted into one exported helper, `goalToolResultProvenance`, and the interactive scheduler — which already got this right inline — is switched over to it rather than left as a fourth copy: no permit means no stamp; `get_goal` and `update_goal` are stamped `goal_runtime` so the Goal's own bookkeeping stays out of the catalog it would otherwise cite as proof of itself; every other tool result becomes citable external evidence.

The two hosts read the permit differently because they execute tools differently. Headless already had it — `ToolCallRequestInfo.goalContext`, filled in by `Turn` — and simply ignored it at the recording call. ACP runs tools straight from the model's function calls and has no request object, so it reads the ambient `goalTurnContext` that the session enters around the whole turn (and explicitly exits for non-Goal prompts, which is why a plain prompt still records nothing).

Outside a Goal turn both call sites keep their former two-argument shape, so ordinary recording is byte-for-byte unchanged.

## Why it's needed

The evidence catalog derives a record's provenance from the permit stamped on it — `goal-evidence.ts`: `this.provenance = this.parsedGoalContext ? coherentEvidenceProvenance(record) : undefined`, and a record with no provenance produces no catalog entry. The string `goalContext` did not appear anywhere in `nonInteractiveCli.ts` or `Session.ts`.

So in those two hosts — precisely the ones an unattended long-running Goal actually uses — the catalog could only ever hold `delivered_output` (assistant turns, which *are* stamped) and `user_input`. `tool_result` is the only provenance that maps to `external_fact`, so no Goal running there could prove anything about the world:

- an independent verifier correctly refuses a completion proved only by the model's own words;
- `blockerKind: 'infeasible'` (#10125) requires a cited `external_fact`;
- an immediate `external` blocker requires cited user input or external tool evidence.

All three were unreachable. The only terminal state such a Goal could reach on its own was the token-budget stop (#9891). Reported as #10172.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/goals/ src/core/coreToolScheduler.test.ts` — 839 pass, including 8 new cases pinning the shared rule (ordinary tool stamped, permit copied not aliased, `get_goal`/`update_goal` marked `goal_runtime`, nothing stamped outside a turn, and the same four through the ambient reader).
- `cd packages/cli && npx vitest run src/acp-integration src/nonInteractiveCli.test.ts` — 1913 pass. Each host gains a test that drives a real Goal turn through one ordinary tool and one `get_goal`, asserting the recorded options per call id, plus a test that a non-Goal turn records with no options at all.
- Mutation probes run during development: headless stamp removed → exactly the headless test fails (131 others green); ACP stamp removed → exactly the ACP test fails; the shared rule collapsed to always-`goal_runtime` → exactly the bookkeeping assertion fails.
- `tsc --noEmit` clean for the changed code in both packages; prettier + eslint clean.

A host-level assertion is required and the core-side tests cannot substitute: they build evidence windows from hand-written records that already carry the stamp, which is exactly why the whole suite stayed green while two of three hosts produced no evidence at all.

### Evidence (Before & After)

The same headless run on the same working directory — a Chinese objective over eight documents, with `GOAL_DEFAULT_TOKEN_BUDGET` temporarily shrunk to 400,000 to bound the cost (the constant is unchanged in this diff):

| | before | after |
|---|---|---|
| `tool_result` records carrying the stamp | **0 / 31** | **20 / 20** |
| Goal turns | 5 | **1** |
| verifier rejections | **8** | 0 |
| terminal state | `usage_limited` (budget spent) | **`complete`** |
| tokens | 542,051 | **228,302** |

Before, the objective was actually finished — `结论.md` was written with all eight sections and the model confirmed it with `run_shell_command` — and the Goal still could not prove it. The rejections say so directly: "the cited evidence has proofKind 'delivered_output', which proves only that the assistant said so", and finally "An immediate blocker requires cited user input or external tool evidence", closing the escape hatch too.

After, the verifier accepts on the first turn and its reason cites the evidence uuids the earlier run could never produce: "Evidence confirms all eight module documents were read (ce8a0e37–371a7949), the working directory was verified…".

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests plus two live headless runs against DashScope, before and after, described above.

## Risk & Scope

- Main risk or tradeoff: tool results inside a Goal turn now enter the bounded evidence catalog, so Goals that previously catalogued almost nothing will consume catalog budget at the intended rate. That is the design (#9165, #9835, #9840, #9975 bound and compact exactly this), and the measured run compacted once and finished; but a Goal that was quietly "cheap" because its evidence was being dropped will now do real checkpoint work.
- Not validated / out of scope: no change to what the catalog stores or how it is bounded; no change to the interactive host's behaviour (its rule moved, its outcome did not); the wind-down delivery gap in #10150 and the missing operator control over `tokenBudgetGrant` are separate.
- Breaking changes / migration notes: none. Recording outside a Goal turn is unchanged, including argument arity.

## Linked Issues

- Fixes #10172.
- Makes #10125's `infeasible` early exit reachable in the hosts it matters for, and gives #9891's budget something to stop *short of*.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 headless 与 ACP 两个 host 中,记录工具结果时带上 Goal 轮次 permit,使其结果能够成为证据。该规则被抽取为唯一的导出函数 `goalToolResultProvenance`,并且把本来就写对了的交互式调度器也切换过去,而不是留下第四份拷贝:没有 permit 就不盖戳;`get_goal` 与 `update_goal` 盖 `goal_runtime`,使 Goal 自身的账本不进入它本可能引以为证的目录(否则就是循环论证);其余工具结果成为可引用的外部证据。

两个 host 取 permit 的方式不同,因为它们执行工具的方式不同。headless 本来就持有它——`ToolCallRequestInfo.goalContext`,由 `Turn` 填充——只是在记录调用处忽略了。ACP 直接从模型的 function call 执行工具,没有请求对象,因此读取 session 在整个轮次外围进入的 `goalTurnContext`(非 Goal 的 prompt 会被显式 exit,所以普通 prompt 依然不记录任何戳)。

在 Goal 轮次之外,两个调用点保持原本的两参数形态,普通记录逐字节不变。

## 为什么需要

证据目录以记录上的 permit 戳派生 provenance(`goal-evidence.ts`),没有 provenance 就不产生目录条目。而 `goalContext` 这个字符串在 `nonInteractiveCli.ts` 与 `Session.ts` 中根本不存在。

于是在这两个 host——恰恰是无人值守长跑 Goal 真正使用的两个——目录只可能包含 `delivered_output` 与 `user_input`。`tool_result` 是唯一映射到 `external_fact` 的 provenance,因此那里的 Goal 无法证明关于世界的任何事:独立验证器会正确拒绝仅以模型自述为证的完成;#10125 的 `infeasible` 要求引用 `external_fact`;立即型 `external` 阻塞要求外部证据。三条路径全部不可达,唯一能自主到达的终局只剩 #9891 的预算停止。已记录为 #10172。

## 评审验证计划

### 如何验证

- `cd packages/core && npx vitest run src/goals/ src/core/coreToolScheduler.test.ts`——839 通过,含 8 个新用例固定共享规则(普通工具盖戳、permit 是复制而非别名、`get_goal`/`update_goal` 标记为 `goal_runtime`、轮次外不盖戳,以及经由 ambient 读取器的同样四条)。
- `cd packages/cli && npx vitest run src/acp-integration src/nonInteractiveCli.test.ts`——1913 通过。每个 host 新增一个测试:驱动真实 Goal 轮次执行一次普通工具与一次 `get_goal`,按 call id 断言记录选项;另有一个测试断言非 Goal 轮次不带任何选项。
- 开发期间的变异检验:去掉 headless 盖戳 → 恰好挂 headless 测试(其余 131 绿);去掉 ACP 盖戳 → 恰好挂 ACP 测试;把共享规则塌缩为恒 `goal_runtime` → 恰好挂账本断言。
- 两个包中改动代码的 `tsc --noEmit` 干净;prettier + eslint 干净。

必须在 host 层断言,core 侧测试无法替代:它们使用的是本身就带戳的手写记录——这正是三个 host 里有两个完全不产生证据、而全量测试却始终全绿的原因。

### 证据(前后对比)

同一次 headless 运行、同一工作目录——中文 objective、八份文档,为控制成本将 `GOAL_DEFAULT_TOKEN_BUDGET` 临时改为 400,000(该常量在本 diff 中未改动):

| | 修复前 | 修复后 |
|---|---|---|
| 带戳的 `tool_result` 记录 | **0 / 31** | **20 / 20** |
| Goal 轮数 | 5 | **1** |
| 验证拒绝次数 | **8** | 0 |
| 终局状态 | `usage_limited`(预算耗尽) | **`complete`** |
| token | 542,051 | **228,302** |

修复前,目标其实已经完成——`结论.md` 八节齐全,模型用 `run_shell_command` 复核过——但 Goal 无法证明这一点。拒绝理由直说了:「所引用证据的 proofKind 是 'delivered_output',只能证明助手这样说过」,最后是「立即型阻塞需要引用用户输入或外部工具证据」,连逃生通道也一并关闭。

修复后,验证器在第一轮即接受,理由引用的正是此前根本无法产生的证据 uuid:「Evidence confirms all eight module documents were read (ce8a0e37–371a7949), the working directory was verified…」。

### 已测试平台

Linux ✅;macOS / Windows ⚠️(CI 覆盖)。单元测试之外,另有针对 DashScope 的两次真实 headless 运行(前后对比,见上)。

## 风险与范围

- 主要风险或权衡:Goal 轮次内的工具结果现在会进入有界证据目录,因此此前几乎不记录任何内容的 Goal 将按设计速率消耗目录预算。这正是设计意图(#9165、#9835、#9840、#9975 正是为约束与压缩它而存在),实测运行压缩了一次并顺利完成;但此前因证据被丢弃而显得「便宜」的 Goal,现在会真正做 checkpoint 工作。
- 未验证/范围外:不改变目录存储内容或其约束方式;不改变交互式 host 的行为(规则位置变了,结果没变);#10150 的收尾轮送达问题与 `tokenBudgetGrant` 缺少 operator 控制,均为独立问题。
- 破坏性变更/迁移说明:无。Goal 轮次之外的记录行为不变,包括参数个数。

## 关联 Issue

- Fixes #10172。
- 使 #10125 的 `infeasible` 早退在真正需要它的 host 中变得可达,也让 #9891 的预算有了「不必走到」的余地。

</details>
