### PR TITLE
fix(web-shell): replace the boot white screen with a recoverable error state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33083,6 +33083,7 @@
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.2.0",
+        "jsdom": "^26.1.0",
         "postcss": "^8.5.17",
         "postcss-selector-parser": "^7.1.4",
         "react": "^19.2.0",

--- a/packages/web-shell/client/boot-watchdog.test.ts
+++ b/packages/web-shell/client/boot-watchdog.test.ts
@@ -1,0 +1,336 @@
+// @vitest-environment jsdom
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractInlineScript } from './test/indexHtmlTestUtils';
+
+/**
+ * Run the shipped watchdog exactly as the browser does: the inline script
+ * executes while `#root` is still unparsed. Tests that need the element call
+ * {@link parseRoot} afterwards — never before, or they would exercise a
+ * document order this page does not have.
+ */
+function installBootWatchdog(): void {
+  expect(document.getElementById('root')).toBeNull();
+  new Function(extractInlineScript('data-boot-fallback'))();
+}
+
+/** Finish parsing the document: `#root` appears, then DOMContentLoaded. */
+function parseRoot(): HTMLElement {
+  document.body.insertAdjacentHTML('beforeend', '<div id="root"></div>');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+  return document.getElementById('root') as HTMLElement;
+}
+
+function mountApp(): HTMLElement {
+  const app = document.createElement('div');
+  app.setAttribute('data-app', '');
+  document.getElementById('root')?.appendChild(app);
+  return app;
+}
+
+function fallback(): Element | null {
+  return document.querySelector('[data-boot-fallback]');
+}
+
+function resourceErrorEvent(url: string, message?: string): void {
+  const script = document.createElement('script');
+  script.src = url;
+  document.body.appendChild(script);
+  // Real resource-load failures fire a bare, non-bubbling Event; the
+  // watchdog listens in the capture phase precisely so it still sees them.
+  script.dispatchEvent(
+    message ? new ErrorEvent('error', { message }) : new Event('error'),
+  );
+}
+
+function stylesheetErrorEvent(url: string): void {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = url;
+  document.body.appendChild(link);
+  link.dispatchEvent(new Event('error'));
+}
+
+function inlineScriptErrorEvent(message: string): void {
+  const script = document.createElement('script');
+  script.textContent = 'void 0;';
+  document.body.appendChild(script);
+  script.dispatchEvent(new ErrorEvent('error', { message }));
+}
+
+function rejectionEvent(reason: unknown): void {
+  const event = new Event('unhandledrejection');
+  Object.defineProperty(event, 'reason', { value: reason });
+  window.dispatchEvent(event);
+}
+
+/** Let jsdom deliver MutationObserver records (queued as microtasks). */
+async function flushObservers(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('boot watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    document.documentElement.className = 'theme-dark';
+  });
+
+  afterEach(() => {
+    // Drive any watchdog left mid-flight to its terminal state, so a stale
+    // capture-phase listener cannot render fallbacks in a later test.
+    document.body.innerHTML = '<div id="root"><div data-app></div></div>';
+    vi.advanceTimersByTime(60_000);
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  describe('immediate resource failures', () => {
+    it('shows the fallback when a module script fails to load', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      resourceErrorEvent(
+        'http://localhost:5173/main.tsx',
+        'Failed to load resource: 504 (Outdated Optimize Dep)',
+      );
+
+      const box = fallback();
+      expect(box).not.toBeNull();
+      expect(box?.textContent).toContain('Web Shell 加载失败');
+      expect(box?.textContent).toContain('504 (Outdated Optimize Dep)');
+      expect(box?.textContent).toContain('http://localhost:5173/main.tsx');
+      expect(box?.querySelector('button')?.textContent).toContain('Reload');
+    });
+
+    it('shows the fallback for a message-less resource error', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      resourceErrorEvent('http://localhost:5173/main.tsx');
+
+      expect(fallback()?.textContent).toContain(
+        'http://localhost:5173/main.tsx',
+      );
+    });
+
+    it('shows the fallback when a stylesheet fails to load', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      stylesheetErrorEvent('http://localhost:5173/assets/index.css');
+
+      expect(fallback()?.textContent).toContain(
+        'http://localhost:5173/assets/index.css',
+      );
+    });
+
+    it('defers an inline-script runtime error to the grace timer', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      // An inline <script> that throws also targets a SCRIPT element. It is
+      // a runtime error, not a failed fetch, so it must not short-circuit to
+      // the fallback — boot may still succeed.
+      inlineScriptErrorEvent('inline boom');
+      expect(fallback()).toBeNull();
+
+      vi.advanceTimersByTime(15_001);
+
+      expect(fallback()?.textContent).toContain('did not start');
+      expect(fallback()?.querySelector('pre')?.textContent).toContain(
+        'inline boom',
+      );
+    });
+  });
+
+  describe('captured error panel', () => {
+    it('captures pre-fallback errors and rejections', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      window.dispatchEvent(new ErrorEvent('error', { message: 'boot threw' }));
+      rejectionEvent(new Error('rejection reason'));
+      resourceErrorEvent('http://localhost:5173/main.tsx');
+
+      const pre = fallback()?.querySelector('pre');
+      expect(pre?.textContent).toContain('boot threw');
+      expect(pre?.textContent).toContain('rejection reason');
+    });
+
+    it('captures rejection reasons that are not Errors', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      rejectionEvent('network timeout');
+      rejectionEvent(undefined);
+      resourceErrorEvent('http://localhost:5173/main.tsx');
+
+      const pre = fallback()?.querySelector('pre');
+      expect(pre?.textContent).toContain('network timeout');
+      expect(pre?.textContent).toContain('unhandled rejection');
+    });
+
+    it('keeps at most five captured errors', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      for (let i = 1; i <= 6; i += 1) {
+        window.dispatchEvent(new ErrorEvent('error', { message: `boom-${i}` }));
+      }
+      resourceErrorEvent('http://localhost:5173/main.tsx');
+
+      // A dev-server restart can invalidate several chunks at once; the panel
+      // keeps the first few and drops the rest rather than growing without
+      // bound.
+      const pre = fallback()?.querySelector('pre');
+      expect(pre?.textContent).toContain('boom-1');
+      expect(pre?.textContent).toContain('boom-5');
+      expect(pre?.textContent).not.toContain('boom-6');
+    });
+  });
+
+  describe('grace timer', () => {
+    it('shows the fallback when the app never mounts in time', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      vi.advanceTimersByTime(14_999);
+      expect(fallback()).toBeNull();
+
+      vi.advanceTimersByTime(2);
+
+      expect(fallback()?.textContent).toContain('did not start within 15s');
+    });
+
+    it('keeps the specific early reason when the timer later fires', () => {
+      installBootWatchdog();
+      parseRoot();
+
+      resourceErrorEvent(
+        'http://localhost:5173/main.tsx',
+        'Failed to load resource: 504 (Outdated Optimize Dep)',
+      );
+      vi.advanceTimersByTime(15_001);
+
+      // The generic timeout copy must not overwrite the actionable one.
+      expect(fallback()?.textContent).toContain('504 (Outdated Optimize Dep)');
+      expect(fallback()?.textContent).not.toContain('did not start');
+    });
+
+    it('stays silent once the app has mounted', async () => {
+      installBootWatchdog();
+      parseRoot();
+      mountApp();
+      await flushObservers();
+
+      vi.advanceTimersByTime(60_000);
+
+      expect(fallback()).toBeNull();
+    });
+
+    it('does not clobber the app when a resource fails after mount', async () => {
+      installBootWatchdog();
+      const root = parseRoot();
+      const app = mountApp();
+      await flushObservers();
+
+      resourceErrorEvent('http://localhost:5173/lazy-chunk.js');
+
+      expect(fallback()).toBeNull();
+      expect(root.firstElementChild).toBe(app);
+    });
+  });
+
+  describe('uninstall', () => {
+    // The watchdog script runs before #root is parsed, so a MutationObserver
+    // created at install time would be constructed against null and silently
+    // dropped — the failure this suite exists to pin. Every test here runs in
+    // that shipped order.
+    it('observes #root even though it is parsed after the script', () => {
+      const observed: Node[] = [];
+      const Real = globalThis.MutationObserver;
+      class Recording extends Real {
+        override observe(target: Node, options?: MutationObserverInit): void {
+          observed.push(target);
+          super.observe(target, options);
+        }
+      }
+      globalThis.MutationObserver = Recording;
+
+      try {
+        installBootWatchdog();
+        expect(observed).toEqual([]);
+
+        const root = parseRoot();
+
+        expect(observed).toEqual([root]);
+      } finally {
+        globalThis.MutationObserver = Real;
+      }
+    });
+
+    it('releases listeners, timer and observer once the app mounts', async () => {
+      const disconnect = vi.spyOn(MutationObserver.prototype, 'disconnect');
+      const clear = vi.spyOn(globalThis, 'clearTimeout');
+
+      installBootWatchdog();
+      const root = parseRoot();
+      mountApp();
+      await flushObservers();
+
+      expect(disconnect).toHaveBeenCalled();
+      expect(clear).toHaveBeenCalled();
+
+      // Behavioural oracle: with the capture-phase listeners gone, nothing
+      // can render a fallback any more. Any silently-failed removal (a
+      // dropped `true` capture flag, a deleted call site) resurrects one.
+      root.textContent = '';
+      resourceErrorEvent('http://localhost:5173/late-chunk.js');
+      vi.advanceTimersByTime(60_000);
+
+      expect(fallback()).toBeNull();
+      disconnect.mockRestore();
+      clear.mockRestore();
+    });
+
+    it('releases listeners once the fallback is rendered', () => {
+      installBootWatchdog();
+      const root = parseRoot();
+
+      resourceErrorEvent('http://localhost:5173/main.tsx');
+      expect(fallback()).not.toBeNull();
+
+      // The box is terminal, so the watchdog is done: later failures must
+      // find nothing listening.
+      root.textContent = '';
+      resourceErrorEvent('http://localhost:5173/other-chunk.js');
+      vi.advanceTimersByTime(60_000);
+
+      expect(fallback()).toBeNull();
+    });
+
+    it('uninstalls when the app mounted before the observer installed', async () => {
+      installBootWatchdog();
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        '<div id="root"><div data-app></div></div>',
+      );
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+
+      const root = document.getElementById('root') as HTMLElement;
+      root.textContent = '';
+      resourceErrorEvent('http://localhost:5173/late-chunk.js');
+      vi.advanceTimersByTime(60_000);
+
+      expect(fallback()).toBeNull();
+    });
+  });
+});

--- a/packages/web-shell/client/index-html-boot.test.ts
+++ b/packages/web-shell/client/index-html-boot.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+import { readIndexHtml } from './test/indexHtmlTestUtils';
+
+/**
+ * Parse the real index.html the way a browser does — inline scripts execute
+ * during parsing, in document order — instead of hand-placing #root around a
+ * hand-installed watchdog. The bug this file guards against was invisible to
+ * a simulated order: a MutationObserver built at install time is constructed
+ * against a #root that has not been parsed yet.
+ */
+function bootDocument(): JSDOM {
+  // Drop only the module script's src: jsdom would try to fetch /main.tsx,
+  // and the app never mounting is precisely the state under test.
+  const html = readIndexHtml().replace(' src="/main.tsx"', '');
+
+  return new JSDOM(html, {
+    runScripts: 'dangerously',
+    url: 'http://localhost:5173/',
+  });
+}
+
+function failResource(dom: JSDOM, url: string, message?: string): void {
+  const { document, ErrorEvent, Event } = dom.window;
+  const script = document.createElement('script');
+  script.src = url;
+  document.body.appendChild(script);
+  script.dispatchEvent(
+    message ? new ErrorEvent('error', { message }) : new Event('error'),
+  );
+}
+
+function root(dom: JSDOM): HTMLElement {
+  return dom.window.document.getElementById('root') as HTMLElement;
+}
+
+function fallback(dom: JSDOM): Element | null {
+  return dom.window.document.querySelector('[data-boot-fallback]');
+}
+
+describe('boot watchdog in a really parsed document', () => {
+  it('renders the fallback when a module fails to load', () => {
+    const dom = bootDocument();
+
+    failResource(
+      dom,
+      'http://localhost:5173/main.tsx',
+      'Failed to load resource: 504 (Outdated Optimize Dep)',
+    );
+
+    expect(fallback(dom)?.textContent).toContain('504 (Outdated Optimize Dep)');
+    dom.window.close();
+  });
+
+  it('uninstalls on mount even though #root is parsed after the script', async () => {
+    const dom = bootDocument();
+
+    const app = dom.window.document.createElement('div');
+    app.setAttribute('data-app', '');
+    root(dom).appendChild(app);
+    // The mount observer only exists if installation was deferred past
+    // parsing; without it nothing ever releases the capture-phase listeners.
+    await new Promise((resolve) => dom.window.queueMicrotask(resolve));
+
+    root(dom).textContent = '';
+    failResource(dom, 'http://localhost:5173/late-chunk.js');
+
+    expect(fallback(dom)).toBeNull();
+    dom.window.close();
+  });
+});

--- a/packages/web-shell/client/index-html.test.ts
+++ b/packages/web-shell/client/index-html.test.ts
@@ -1,17 +1,8 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
+import { extractInlineScript, readIndexHtml } from './test/indexHtmlTestUtils';
 
 function extractMeasureScript(): string {
-  const html = readFileSync(resolve(__dirname, 'index.html'), 'utf8');
-  const script = Array.from(
-    html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
-  )
-    .map((match) => match[1] ?? '')
-    .find((source) => source.includes('performance.measure ='));
-
-  if (!script) throw new Error('Performance measure guard not found');
-  return script;
+  return extractInlineScript('performance.measure =');
 }
 
 function installMeasureGuard(
@@ -237,5 +228,33 @@ describe('React performance measure guard', () => {
 
     expect(() => install(undefined)).not.toThrow();
     expect(() => install({})).not.toThrow();
+  });
+});
+
+describe('boot watchdog document contract', () => {
+  // The watchdog detects a mount as "#root has a first element child that is
+  // not the fallback box". A static child shipped in the HTML — a boot
+  // spinner, say — reads as already-mounted, which disables the watchdog
+  // outright: no immediate fallback on a module failure, no timeout
+  // fallback, exactly the white screen this feature exists to replace. No
+  // boot-watchdog unit test can catch that, because they all build their own
+  // #root; pin it against the real document instead.
+  it('ships an empty #root', () => {
+    const root = /<div id="root"[^>]*>([\s\S]*?)<\/div>/.exec(readIndexHtml());
+
+    expect(root).not.toBeNull();
+    expect(root?.[1]).toMatch(/^\s*$/);
+  });
+
+  // The watchdog is deliberately installed before #root is parsed so it is
+  // already listening while the module graph loads. If a future edit moves
+  // it after #root the DOMContentLoaded deferral becomes dead code, so the
+  // boot-watchdog suite must keep exercising the install-before-#root order.
+  it('installs the watchdog before #root is parsed', () => {
+    const html = readIndexHtml();
+
+    expect(html.indexOf('data-boot-fallback')).toBeLessThan(
+      html.indexOf('<div id="root">'),
+    );
   });
 });

--- a/packages/web-shell/client/index.html
+++ b/packages/web-shell/client/index.html
@@ -88,6 +88,200 @@
         };
       })();
     </script>
+    <!--
+      Boot watchdog: when the app never mounts (a dev-server restart
+      invalidating module URLs mid-load, the daemon unreachable, a rotated
+      auth token, ...) the page would otherwise stay blank with no error and
+      no way to recover. After a grace period — or immediately when a
+      script/module resource fails to load — render a visible, theme-aware
+      fallback showing the captured errors and a reload action. Errors thrown
+      by a booting module are captured too, but surfaced by the grace timer
+      rather than immediately, so a burst accumulates in one panel. Kept
+      dependency-free ES5 so it runs even if every module import fails.
+
+      This script deliberately runs before #root is parsed, so it is already
+      listening while the module graph loads. Everything therefore resolves
+      #root lazily, and the mount observer installs on DOMContentLoaded when
+      the element does not exist yet — a MutationObserver created here
+      against a null root would be silently dropped.
+
+      Invariant: #root must stay empty until React mounts. Mount detection
+      keys off "first child that is not the fallback box", so a static child
+      (e.g. a boot spinner) would read as mounted and disable the watchdog;
+      keep #root empty in index.html. Both terminal states — a real mount,
+      or the fallback being rendered — uninstall the watchdog (listeners,
+      timer, observer) and release its captured errors, so nothing survives
+      a settled boot. The fallback box, once shown, is sticky, so a late
+      timer never overwrites a more specific earlier reason.
+    -->
+    <script>
+      !(function () {
+        var GRACE_MS = 15000;
+        var MAX_ERRORS = 5;
+        var errors = [];
+        var timer = null;
+        var observer = null;
+        var pendingInstall = false;
+        function rootEl() {
+          return document.getElementById('root');
+        }
+        function fallbackPresent() {
+          var r = rootEl();
+          return !!(r && r.querySelector('[data-boot-fallback]'));
+        }
+        function appMounted() {
+          var r = rootEl();
+          return !!(
+            r &&
+            r.firstElementChild &&
+            !r.firstElementChild.hasAttribute('data-boot-fallback')
+          );
+        }
+        function pushError(msg) {
+          if (errors.length < MAX_ERRORS) errors.push(msg);
+        }
+        function uninstall() {
+          if (timer !== null) {
+            clearTimeout(timer);
+            timer = null;
+          }
+          if (observer) {
+            observer.disconnect();
+            observer = null;
+          }
+          if (pendingInstall) {
+            document.removeEventListener('DOMContentLoaded', installObserver);
+            pendingInstall = false;
+          }
+          window.removeEventListener('error', onError, true);
+          window.removeEventListener('unhandledrejection', onRejection);
+          errors.length = 0;
+        }
+        function show(reason) {
+          var r = rootEl();
+          if (!r || appMounted() || fallbackPresent()) return;
+          var dark = document.documentElement.classList.contains('theme-dark');
+          var box = document.createElement('div');
+          box.setAttribute('data-boot-fallback', '');
+          box.style.cssText =
+            'min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;padding:24px;box-sizing:border-box;font-family:system-ui,sans-serif;text-align:center;background:' +
+            (dark ? '#0d0d0d' : '#ffffff') +
+            ';color:' +
+            (dark ? '#e5e5e5' : '#1a1a1a');
+          var h = document.createElement('h1');
+          h.style.cssText = 'font-size:18px;margin:0';
+          h.textContent = 'Web Shell 加载失败 / failed to load';
+          var p = document.createElement('p');
+          p.style.cssText =
+            'margin:0;font-size:13px;opacity:.75;max-width:560px';
+          p.textContent = reason;
+          box.appendChild(h);
+          box.appendChild(p);
+          if (errors.length) {
+            var pre = document.createElement('pre');
+            pre.style.cssText =
+              'margin:0;font-size:11px;opacity:.6;max-width:720px;max-height:160px;overflow:auto;text-align:left;white-space:pre-wrap';
+            pre.textContent = errors.join('\n');
+            box.appendChild(pre);
+          }
+          var btn = document.createElement('button');
+          btn.textContent = '重新加载 / Reload';
+          btn.style.cssText =
+            'padding:8px 20px;border-radius:8px;border:1px solid ' +
+            (dark ? '#444' : '#ccc') +
+            ';background:' +
+            (dark ? '#222' : '#f5f5f5') +
+            ';color:inherit;font-size:14px;cursor:pointer';
+          btn.addEventListener('click', function () {
+            location.reload();
+          });
+          box.appendChild(btn);
+          r.textContent = '';
+          r.appendChild(box);
+          // The box is terminal — it is sticky, and further errors would
+          // never reach the panel — so release everything here rather than
+          // waiting on a mount that may never come.
+          uninstall();
+        }
+        function onError(e) {
+          var t = e && e.target;
+          // An inline <script> that throws also targets a SCRIPT element, so
+          // require a src/href: only a failed *fetch* proves boot is
+          // impossible right now.
+          var isResource = !!(
+            t &&
+            ((t.tagName === 'SCRIPT' && t.src) ||
+              (t.tagName === 'LINK' && t.href))
+          );
+          var msg = (e && e.message) || 'unknown error';
+          if (isResource) msg += ' (' + (t.src || t.href) + ')';
+          pushError(msg);
+          if (appMounted()) return;
+          // Runtime errors and rejections are captured and surfaced by the
+          // grace timer (or by a later resource failure) so a burst of boot
+          // errors accumulates in the panel instead of being truncated to
+          // the first one.
+          if (isResource) {
+            show(
+              'A required resource failed to load: ' +
+                msg +
+                '. This usually happens right after a dev-server or daemon restart — reload the page.',
+            );
+          }
+        }
+        function onRejection(e) {
+          var reason = e && e.reason;
+          pushError(
+            String(
+              (reason && reason.message) || reason || 'unhandled rejection',
+            ),
+          );
+        }
+        function installObserver() {
+          if (pendingInstall) {
+            document.removeEventListener('DOMContentLoaded', installObserver);
+            pendingInstall = false;
+          }
+          if (observer) return;
+          var root = rootEl();
+          if (!root) {
+            // #root is parsed after this script; retry once the document is
+            // complete. Nothing is lost meanwhile: React cannot have mounted
+            // into an element that does not exist yet.
+            if (!pendingInstall) {
+              pendingInstall = true;
+              document.addEventListener('DOMContentLoaded', installObserver);
+            }
+            return;
+          }
+          // A mount that beat this install would never produce a record.
+          if (appMounted()) {
+            uninstall();
+            return;
+          }
+          if (typeof MutationObserver === 'undefined') return;
+          observer = new MutationObserver(function () {
+            if (appMounted()) uninstall();
+          });
+          observer.observe(root, { childList: true });
+        }
+        window.addEventListener('error', onError, true);
+        window.addEventListener('unhandledrejection', onRejection);
+        installObserver();
+        timer = setTimeout(function () {
+          if (!appMounted()) {
+            show(
+              'The app did not start within ' +
+                GRACE_MS / 1000 +
+                's. The daemon may be restarting or its access token may have rotated — reload the page.',
+            );
+          }
+          // The grace period is over either way: mounted, fallback shown, or
+          // show() declined. Nothing this watchdog can still do is useful.
+          uninstall();
+        }, GRACE_MS);
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/main.tsx"></script>
   </body>

--- a/packages/web-shell/client/main-boot.test.tsx
+++ b/packages/web-shell/client/main-boot.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testState = vi.hoisted(() => ({
+  containers: [] as Array<Element | null>,
+  resolveToken: undefined as ((token: string) => void) | undefined,
+}));
+
+vi.mock('react-dom/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-dom/client')>()),
+  default: {
+    createRoot: (container: Element | null) => {
+      testState.containers.push(container);
+      return { render: vi.fn() };
+    },
+  },
+}));
+vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+  DaemonWorkspaceProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('./components/WorkspaceSessionProvider', () => ({
+  WorkspaceSessionProvider: () => null,
+}));
+vi.mock('./config/daemon', () => ({
+  getDaemonBaseUrl: () => '',
+  // No token in the URL, so boot blocks on the postMessage handshake — the
+  // window in which the watchdog's grace period can expire.
+  getDaemonToken: () => null,
+  removeDaemonTokenFromUrl: vi.fn(),
+  waitForDaemonTokenMessage: () =>
+    new Promise<string>((resolve) => {
+      testState.resolveToken = resolve;
+    }),
+}));
+
+describe('web shell boot', () => {
+  beforeEach(() => {
+    testState.containers = [];
+    testState.resolveToken = undefined;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('clears the boot fallback when the app mounts after the grace period', async () => {
+    document.body.innerHTML =
+      '<div id="root"><div data-boot-fallback>failed to load</div></div>';
+    const root = document.getElementById('root') as HTMLElement;
+
+    await import('./main');
+    // The watchdog gave up while the handshake was outstanding; the panel is
+    // on screen when the token finally arrives.
+    expect(root.querySelector('[data-boot-fallback]')).not.toBeNull();
+
+    testState.resolveToken?.('token');
+    await vi.waitFor(() => expect(testState.containers).toHaveLength(1));
+
+    // React appends, so a surviving panel would sit above the recovered app.
+    expect(testState.containers[0]).toBe(root);
+    expect(root.querySelector('[data-boot-fallback]')).toBeNull();
+  });
+
+  it('mounts into #root on a normal boot', async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    const root = document.getElementById('root') as HTMLElement;
+
+    await import('./main');
+    testState.resolveToken?.('token');
+    await vi.waitFor(() => expect(testState.containers).toHaveLength(1));
+
+    expect(testState.containers[0]).toBe(root);
+  });
+});

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -193,7 +193,15 @@ async function main() {
   const daemonToken = getDaemonToken() ?? (await waitForDaemonTokenMessage());
   removeDaemonTokenFromUrl();
 
-  ReactDOM.createRoot(document.getElementById('root')!).render(
+  const container = document.getElementById('root');
+  // Boot can outlast the watchdog's grace period (a slow daemon, a token
+  // handshake that only completes after a restart settles), in which case
+  // index.html's fallback panel is already in #root. React appends to the
+  // container rather than replacing it, so drop the panel here — otherwise
+  // the recovered app renders below a full-viewport "failed to load" screen.
+  container?.querySelector('[data-boot-fallback]')?.remove();
+
+  ReactDOM.createRoot(container!).render(
     <React.StrictMode>
       <StandaloneApp daemonToken={daemonToken} />
     </React.StrictMode>,

--- a/packages/web-shell/client/test/indexHtmlTestUtils.ts
+++ b/packages/web-shell/client/test/indexHtmlTestUtils.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/** The literal text of `client/index.html`. */
+export function readIndexHtml(): string {
+  return readFileSync(resolve(__dirname, '../index.html'), 'utf8');
+}
+
+/**
+ * Extract an inline `<script>` body from `client/index.html` by a marker
+ * substring. Shared by the inline-script unit tests so the HTML-parsing
+ * logic lives in one place.
+ *
+ * Lives under `client/test/` rather than beside the source it tests: it
+ * reaches for `node:fs`, and `client/test/**` is excluded from the library
+ * declaration build, so it never lands in the published type surface of a
+ * browser-targeted package.
+ */
+export function extractInlineScript(marker: string): string {
+  const html = readIndexHtml();
+  const script = Array.from(
+    html.matchAll(/<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/g),
+  )
+    .map((match) => match[1] ?? '')
+    .find((source) => source.includes(marker));
+
+  if (!script) throw new Error(`Inline script not found: ${marker}`);
+  return script;
+}

--- a/packages/web-shell/package.json
+++ b/packages/web-shell/package.json
@@ -77,6 +77,7 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.2.0",
+    "jsdom": "^26.1.0",
     "postcss": "^8.5.17",
     "postcss-selector-parser": "^7.1.4",
     "react": "^19.2.0",


### PR DESCRIPTION
## What this PR does

A Web Shell tab that fails to boot stays blank forever, with no error message and no way to recover other than knowing to hit reload. `packages/web-shell/client/index.html` has no boot fallback at all, and the `ErrorBoundary` wired up in `main.tsx` cannot help: it only catches errors thrown after React mounts, while `main()` reaches `createRoot().render()` only after the daemon-token handshake settles. Anything that goes wrong before that — a module fetch failing, the daemon being unreachable, a rotated token — lands on an empty `#root` with nothing watching.

This adds a dependency-free ES5 watchdog to `index.html`. It renders a theme-aware fallback carrying the captured errors and a reload button, either immediately when a script or stylesheet fails to fetch, or after a 15-second grace period if `#root` is still empty. Runtime errors and unhandled rejections are captured but deliberately left to the grace timer rather than shown immediately, so a burst of boot errors accumulates into one panel instead of the page committing to whichever error happened to arrive first. Both terminal states — a real mount, or the fallback being rendered — uninstall the watchdog entirely, so nothing survives a settled boot.

The watchdog script deliberately runs before `<div id="root">` is parsed, so it is already listening while the module graph loads. Everything therefore resolves `#root` lazily, and the mount observer is installed on `DOMContentLoaded` rather than at script-execution time: a `MutationObserver` constructed against a `#root` that has not been parsed yet is silently dropped, and it takes the uninstall-on-mount path down with it.

One case the watchdog would otherwise create on its own: boot can outlast the grace period, so the panel can still be on screen when React finally mounts. React appends to its container rather than replacing it, which would leave the recovered app rendering underneath a full-viewport "failed to load" screen. `main.tsx` now drops the panel before mounting.

## Why it's needed

Fixes #9253. The report carries a Playwright reproduction (restarting Vite under an open tab leaves `#root` empty), accessibility-tree inspection of a stuck tab, and daemon access logs showing 401s from stale tokens after a restart. The repo's own triage confirmed the root cause in source and labelled it P2. The failure window recurs on every dev-server or daemon restart, and large sessions widen it further because the transcript cold-render keeps `#root` empty for seconds even on a healthy boot.

### Relationship to #9254

@wenshao opened #9254 against this issue with a watchdog of essentially this design, then closed it a day later rather than push a follow-up, leaving `CHANGES_REQUESTED` standing. The review bot had found a real Critical: the round-1 fix for "the watchdog never uninstalls" added a `MutationObserver` built at script-execution time, which in the shipped document order is constructed against a `null` root — dead code in every real page load. The uninstall-on-mount path therefore never fired in production, and on a slow boot the capture-phase `error`/`unhandledrejection` listeners persisted for the page lifetime. The tests masked it precisely: their `beforeEach` created `#root` *before* installing the watchdog, the opposite of the shipped order, so the observer existed in jsdom and the suite passed 7/7.

This PR keeps the design and closes that hole differently from the bot's first suggestion. Moving `<div id="root">` above the script would make the deferral dead instead, and would quietly make correctness depend on document order. Keeping the script early — which is the whole point, it must be listening while the module graph loads — and deferring observer installation to `DOMContentLoaded` makes the watchdog correct in the order it actually ships. It also picks up the remaining review items: `show()` now uninstalls too (the panel is sticky, so later errors could never reach it anyway), the header comment no longer contradicts the deferred-runtime-error design, `isResource` requires a `src`/`href` so a throwing inline script is not misread as a failed fetch, and the Node-only test helper moved to `client/test/` — which is excluded from `tsconfig.lib.json`, so it no longer ships in `dist/types` of a browser-targeted package.

## Reviewer Test Plan

### How to verify

```
cd packages/web-shell
npx vitest run --config vitest.config.ts index-html boot-watchdog main-boot
```

29 tests across five files. The load-bearing one is `client/index-html-boot.test.ts`: it feeds the real `index.html` to jsdom with `runScripts: 'dangerously'`, so the inline scripts execute during parsing in genuine document order. That is what makes it immune to the setup-order masking that let #9254's defect through — a test that assembles `#root` by hand can be made to pass either way.

To see it in a browser, build the shell and break the module URL the way a dev-server restart does:

```
cd packages/web-shell && npm run build
```

then serve `dist/` with the `<script type="module">` src pointed at a path that 404s (immediate fallback), or at a module that never resolves (15s timeout fallback).

### Evidence (Before & After)

Verified in a real browser against the built `dist/index.html`, served over HTTP.

**Before** (`main`, module URL 404s): a completely blank page. No text, no error, no control — exactly the reported failure. The only recovery is knowing to press reload.

**After**, three cases:

- *Module fetch fails* — panel reads "Web Shell 加载失败 / failed to load", "A required resource failed to load: … (http://localhost:8899/assets/stale-chunk-504.js). This usually happens right after a dev-server or daemon restart — reload the page.", with the captured error listed below it and a 重新加载 / Reload button.
- *Module loads but boot never completes* (`await new Promise(() => {})` standing in for a daemon token that never arrives) — page is blank for 15s, then the panel appears reading "The app did not start within 15s. The daemon may be restarting or its access token may have rotated — reload the page."
- *Light theme* (`?theme=light`) — same panel on a white background with dark text, following the theme class the existing theme-init script sets before first paint.

The repo's own `Capture web-shell visuals` job renders base-vs-head screenshots on every push, so the rendered panel will also be attached to this PR automatically.

**Mutation proof.** Every new test was checked against a deliberately broken source; each one flips:

| Mutation | Tests that fail |
| --- | --- |
| Restore #9254's install-time `MutationObserver` | 3 unit tests **and** the really-parsed-document test |
| Drop the `true` capture flag from `removeEventListener('error', …)` | 5 |
| Delete the `uninstall()` call in `show()` | 1 |
| `MAX_ERRORS` 5 → 4 | 1 |
| `errors.length <` → `<=` (effective cap 6) | 1 |
| Drop `&& t.src` from the `isResource` check | 1 |
| Add a static child to `#root` in `index.html` (the documented invariant) | 1 |
| Drop the fallback removal in `main.tsx` | 1 |

Full `packages/web-shell` suite is green: 4317 tests, exit 0. `npx tsc -p tsconfig.json --noEmit` and `npx tsc -p tsconfig.lib.json` both clean, and `dist/types` confirmed free of the test helper.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node 22, `npx vitest run` plus `npm run build` and a local static server for the browser check. Chrome on macOS for the screenshots. No daemon or real backend involved — the failure is reproduced by breaking the module URL, which is what a dev-server restart does.

## Risk & Scope

- Main risk or tradeoff: the 15-second grace period is a judgement call. Too short and a slow cold-render on a very large transcript could flash the panel over a boot that was going to succeed; the mount observer uninstalls the watchdog the moment React commits, and `main.tsx` clears the panel if a mount does land late, so the worst case is a transient panel rather than a stuck one. The watchdog also adds one capture-phase `error` listener for at most 15 seconds of page life.
- Not validated / out of scope: the transcript cold-render cost that widens the blank window on large sessions (#7271, #7272, #7274, #7275) is unchanged — this PR replaces the *silent* failure, it does not make boot faster. The stale-token 401 polling behaviour in `client/config/daemon.ts` is likewise untouched; the panel now tells the user to reload, which resolves it, but the token rotation itself is a separate problem.
- Breaking changes / migration notes: none. The watchdog is inert once the app mounts. It does add one documented constraint — `#root` must ship empty, since a static child would read as "already mounted" — and `index-html.test.ts` now pins that against the real file so it cannot regress silently. `jsdom` is added to `packages/web-shell` devDependencies (already a root dev dependency; one-line lockfile delta) because the really-parsed-document test imports it directly, matching what `packages/cli` already does.

## Linked Issues

Fixes #9253
Refs #9254

<details>
<summary>中文说明</summary>

## 本 PR 的作用

启动失败的 Web Shell 标签页会永远停留在白屏，没有任何错误提示，除了知道要手动刷新之外没有任何恢复途径。`packages/web-shell/client/index.html` 完全没有启动兜底，而 `main.tsx` 中接好的 `ErrorBoundary` 帮不上忙：它只能捕获 React 挂载之后抛出的错误，而 `main()` 要等 daemon token 握手结束后才会走到 `createRoot().render()`。在那之前出的任何问题——模块拉取失败、daemon 不可达、token 轮换——都会落在一个空的 `#root` 上，无人看守。

本 PR 在 `index.html` 中加入一个零依赖的 ES5 watchdog。它会渲染一个跟随主题的兜底页，带上捕获到的错误和重载按钮：脚本或样式表拉取失败时立即渲染，或在 15 秒宽限期后 `#root` 仍为空时渲染。运行时错误和未处理的 rejection 会被捕获，但刻意交给宽限定时器而不是立即展示，这样一批启动错误可以汇总进同一个面板，而不是让页面锁定在恰好最先到达的那一个上。两种终态——真正挂载，或兜底页已渲染——都会彻底卸载 watchdog，因此启动尘埃落定后不会有任何残留。

watchdog 脚本刻意运行在 `<div id="root">` 被解析之前，这样模块图加载期间它已经在监听。因此所有地方都惰性解析 `#root`，挂载 observer 也改为在 `DOMContentLoaded` 时安装，而不是脚本执行时：针对尚未解析的 `#root` 构造出的 `MutationObserver` 会被静默丢弃，并连带让挂载即卸载这条路径失效。

还有一种情况是 watchdog 自身会引入的：启动可能超出宽限期，于是 React 最终挂载时兜底面板仍在屏幕上。React 是往容器里追加而不是替换，这会让恢复后的应用渲染在一个占满视口的"加载失败"页下方。`main.tsx` 现在会在渲染前移除该面板。

## 为什么需要它

修复 #9253。报告附有 Playwright 复现（open tab 下重启 Vite 会让 `#root` 保持为空）、卡死 tab 的无障碍树检查，以及 daemon 访问日志中重启后旧 token 产生的 401。仓库自身的 triage 已在源码中确认根因并标记为 P2。每次 dev server 或 daemon 重启都会再次进入该失败窗口，大会话还会进一步拉长它，因为即便启动正常，transcript 冷渲染也会让 `#root` 空上数秒。

### 与 #9254 的关系

@wenshao 针对本 issue 提交了 #9254，其中的 watchdog 设计与此基本一致，但作者在一天后关闭了它而没有继续推送，`CHANGES_REQUESTED` 仍然挂着。评审机器人发现了一个真实的 Critical：针对第 1 轮"watchdog 永不卸载"意见的修复，添加了一个在脚本执行时构造的 `MutationObserver`，而在实际发布的文档顺序下它是针对 `null` root 构造的——在任何真实页面加载中都是死代码。因此挂载即卸载的路径在生产环境从未触发，慢启动时捕获阶段的 `error`/`unhandledrejection` 监听器会存活整个页面生命周期。测试恰好掩盖了这一点：其 `beforeEach` 在安装 watchdog **之前**创建 `#root`，与发布顺序相反，因此在 jsdom 中 observer 确实存在，测试 7/7 通过。

本 PR 保留了该设计，但采用了与机器人首选建议不同的修法。把 `<div id="root">` 移到脚本之上只会让延迟安装变成死代码，并让正确性悄悄依赖文档顺序。保持脚本在前——这正是关键，它必须在模块图加载期间就开始监听——并把 observer 安装延迟到 `DOMContentLoaded`，可以让 watchdog 在它实际发布的顺序下就是正确的。本 PR 同时处理了其余评审项：`show()` 现在也会卸载（面板是粘性的，之后的错误本来也到不了面板）、头部注释不再与"运行时错误延迟处理"的设计自相矛盾、`isResource` 要求存在 `src`/`href`，从而不会把抛错的内联脚本误判为拉取失败，以及把仅 Node 可用的测试辅助移入 `client/test/`——该目录被 `tsconfig.lib.json` 排除，因此它不再出现在面向浏览器的包的 `dist/types` 中。

## 审阅者测试计划

### 如何验证

```
cd packages/web-shell
npx vitest run --config vitest.config.ts index-html boot-watchdog main-boot
```

五个文件共 29 个测试。最关键的是 `client/index-html-boot.test.ts`：它以 `runScripts: 'dangerously'` 把真实的 `index.html` 交给 jsdom，内联脚本会按真正的文档顺序在解析期间执行。这正是它不会被 #9254 那种 setup 顺序掩盖的原因——手工拼装 `#root` 的测试无论哪种实现都可以通过。

要在浏览器中查看，先构建 shell，再按 dev server 重启的方式弄坏模块 URL：

```
cd packages/web-shell && npm run build
```

然后用静态服务器提供 `dist/`，把 `<script type="module">` 的 src 指向一个会 404 的路径（立即兜底），或指向一个永不 resolve 的模块（15 秒超时兜底）。

### 证据（改动前后）

在真实浏览器中针对构建产物 `dist/index.html` 通过 HTTP 验证。

**改动前**（`main`，模块 URL 404）：完全空白的页面。没有文字、没有错误、没有任何控件——正是报告中的失败现象。唯一的恢复方式是知道要按刷新。

**改动后**，三种情况：

- *模块拉取失败* —— 面板显示 "Web Shell 加载失败 / failed to load"、"A required resource failed to load: …（http://localhost:8899/assets/stale-chunk-504.js）。This usually happens right after a dev-server or daemon restart — reload the page."，下方列出捕获到的错误，并有"重新加载 / Reload"按钮。
- *模块加载成功但启动永不完成*（用 `await new Promise(() => {})` 代表永远不到的 daemon token）—— 页面空白 15 秒后出现面板，显示 "The app did not start within 15s. The daemon may be restarting or its access token may have rotated — reload the page."
- *浅色主题*（`?theme=light`）—— 同一面板呈白底深色文字，跟随既有 theme-init 脚本在首次绘制前设置的主题 class。

仓库自带的 `Capture web-shell visuals` 任务会在每次推送时渲染 base 与 head 的对比截图，因此渲染后的面板也会自动附到本 PR 上。

**变异验证。** 每个新增测试都对照被刻意改坏的源码验证过，全部会翻转：

| 变异 | 失败的测试 |
| --- | --- |
| 恢复 #9254 在安装时构造的 `MutationObserver` | 3 个单测**以及**真实解析文档的测试 |
| 去掉 `removeEventListener('error', …)` 的 `true` 捕获标志 | 5 |
| 删除 `show()` 中的 `uninstall()` 调用 | 1 |
| `MAX_ERRORS` 5 → 4 | 1 |
| `errors.length <` → `<=`（实际上限变 6） | 1 |
| 去掉 `isResource` 检查中的 `&& t.src` | 1 |
| 在 `index.html` 的 `#root` 中加入静态子元素（已写明的不变式） | 1 |
| 删除 `main.tsx` 中移除兜底面板的那行 | 1 |

`packages/web-shell` 全量测试通过：4317 个测试，退出码 0。`npx tsc -p tsconfig.json --noEmit` 与 `npx tsc -p tsconfig.lib.json` 均无错误，并已确认 `dist/types` 中不含该测试辅助文件。

### 测试环境

|    系统    | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 运行环境（可选）

Node 22，`npx vitest run`，外加 `npm run build` 与本地静态服务器用于浏览器验证；截图使用 macOS 上的 Chrome。不涉及 daemon 或真实后端——失败通过弄坏模块 URL 复现，这正是 dev server 重启所造成的效果。

## 风险与范围

- 主要风险或权衡：15 秒宽限期是一个判断取舍。太短的话，超大 transcript 的慢速冷渲染可能会在本可成功的启动过程中闪出面板；挂载 observer 会在 React 提交的那一刻卸载 watchdog，而 `main.tsx` 会在挂载确实迟到时清除面板，因此最坏情况是面板短暂出现而不是卡住。watchdog 还会在页面生命周期中最多 15 秒内增加一个捕获阶段的 `error` 监听器。
- 未验证 / 超出范围：拉长大会话空白窗口的 transcript 冷渲染开销（#7271、#7272、#7274、#7275）未作改动——本 PR 替换的是*无声*失败，并没有让启动变快。`client/config/daemon.ts` 中旧 token 轮询产生 401 的行为同样未动；面板现在会提示用户刷新，从而解决该现象，但 token 轮换本身是另一个问题。
- 破坏性变更 / 迁移说明：无。应用挂载后 watchdog 即失效。它确实新增了一条已写明的约束——`#root` 必须以空的形式发布，因为静态子元素会被读成"已挂载"——`index-html.test.ts` 现在会针对真实文件钉住这一点，使其无法悄悄回退。`jsdom` 被加入 `packages/web-shell` 的 devDependencies（本就是根级 dev 依赖，锁文件仅增加一行），因为真实解析文档的测试直接引用了它，这与 `packages/cli` 的既有做法一致。

## 关联 Issue

Fixes #9253
Refs #9254

</details>
