### PR TITLE
test(core): give the telemetry-swap client mock a getToolRegistry

### DIFF
--- a/packages/core/src/core/client.telemetrySwap.test.ts
+++ b/packages/core/src/core/client.telemetrySwap.test.ts
@@ -93,6 +93,11 @@ function makeEnv() {
       sessionId = id;
       resumedData = data;
     },
+    // `initialize()` calls restoreLoadedSkillsFromHistory, which resolves the
+    // SKILL tool through the registry; this mock only exercises the telemetry
+    // swap, so return an empty registry (no SKILL tool → the restore is a
+    // no-op) rather than let the call throw `getToolRegistry is not a function`.
+    getToolRegistry: () => ({ getTool: () => undefined }),
   };
   const client = new GeminiClient(config as Config);
   const fakeChat = {


### PR DESCRIPTION
## What this PR does

Adds `getToolRegistry` to the minimal `Config` mock the telemetry-swap transaction tests build, returning an empty registry (no SKILL tool), so `client.initialize()` can run without throwing.

## Why it's needed

`GeminiClient.initialize()` now calls `restoreLoadedSkillsFromHistory`, which resolves the SKILL tool through `this.config.getToolRegistry()`. The telemetry-swap tests (`client.telemetrySwap.test.ts`, from #9833) construct a small hand-rolled config mock that predates that call and does not expose `getToolRegistry`. Every test in the file awaits `client.initialize()`, so each now throws `TypeError: this.config.getToolRegistry is not a function` and the whole file fails — reddening the `Test (ubuntu-latest, Node 22.x)` unit lane on current `main`. This restores the mock to the surface `initialize()` now touches, leaving the transaction behaviour under test unchanged (the empty registry means the skill restore is a no-op, which is exactly what these telemetry-only tests want).

## Reviewer Test Plan

### How to verify

Before this change, on current `main`: `npm run test --workspace=packages/core -- src/core/client.telemetrySwap.test.ts` fails all 10 cases with `TypeError: this.config.getToolRegistry is not a function` at `GeminiClient.restoreLoadedSkillsFromHistory` (`client.ts`), reached from `initialize()`. After this change the same command passes 10/10. No production code changes — only the test's config mock gains one method.

### Evidence (Before & After)

N/A — non-user-visible test-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest`, packages/core).

## Risk & Scope

- Main risk or tradeoff: none — the change is confined to a test fixture's mock object; it adds a method the code under test already expects and does not alter any assertion.
- Not validated / out of scope: the reason `restoreLoadedSkillsFromHistory` runs during `initialize()` in these telemetry tests (that coupling is pre-existing); this only stops the mock from throwing.
- Breaking changes / migration notes: none.

## Linked Issues

N/A — repairs a standing failure on `main` introduced by the interaction of `restoreLoadedSkillsFromHistory` (skill-state restore) with this test's older config mock.

<details>
<summary>中文说明</summary>

`GeminiClient.initialize()` 现在会调用 `restoreLoadedSkillsFromHistory`,后者通过 `this.config.getToolRegistry()` 解析 SKILL 工具。而 telemetry-swap 事务测试(`client.telemetrySwap.test.ts`,来自 #9833)用的是一个早于该调用的最小 config mock,没有 `getToolRegistry`。文件里每个用例都 `await client.initialize()`,于是全部抛 `TypeError: this.config.getToolRegistry is not a function`,把 `Test (ubuntu-latest, Node 22.x)` 单测道在当前 `main` 上打红。此改动给 mock 补上 `getToolRegistry`(返回空注册表,无 SKILL 工具→技能恢复为 no-op),被测的事务行为不变。纯测试改动,无生产代码变更。

</details>
