### PR TITLE
fix(web-shell): Polish new-session welcome header visuals

### DIFF
--- a/packages/web-shell/client/App.module.css
+++ b/packages/web-shell/client/App.module.css
@@ -454,9 +454,9 @@
   --streaming-label-color: #b794f4;
   --agent-logo-gradient: linear-gradient(
     90deg,
-    #4796e4 0%,
-    #847ace 52%,
-    #c3677f 100%
+    #5b8def 0%,
+    #6d44e8 55%,
+    #a78bfa 100%
   );
   --subtle-bg: rgba(255, 255, 255, 0.04);
   --subtle-bg-strong: rgba(255, 255, 255, 0.06);
@@ -528,9 +528,9 @@
   --streaming-label-color: #7b4ab8;
   --agent-logo-gradient: linear-gradient(
     90deg,
-    #0b66c3 0%,
-    #7357b8 52%,
-    #bd4f67 100%
+    #2563eb 0%,
+    #6d44e8 55%,
+    #7c3aed 100%
   );
   --subtle-bg: rgba(32, 31, 25, 0.05);
   --subtle-bg-strong: rgba(32, 31, 25, 0.08);

--- a/packages/web-shell/client/components/WelcomeHeader.module.css
+++ b/packages/web-shell/client/components/WelcomeHeader.module.css
@@ -2,10 +2,29 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 12px 0 16px;
+  gap: 10px;
+  padding: 24px 0 20px;
   font-family: var(--font-sans, system-ui, sans-serif);
   text-align: center;
+  animation: welcomeFadeIn 400ms ease-out;
+}
+
+@keyframes welcomeFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header {
+    animation: none;
+  }
 }
 
 .titleRow {
@@ -15,9 +34,10 @@
   justify-content: center;
   gap: 0.35em;
   color: var(--foreground);
-  font-size: 28px;
+  font-size: 32px;
   font-weight: 600;
-  line-height: 36px;
+  line-height: 40px;
+  letter-spacing: -0.02em;
 }
 
 .title {
@@ -29,15 +49,19 @@
 }
 
 .subtitle {
-  color: var(--muted-foreground);
-  font-size: 16px;
+  color: color-mix(in srgb, var(--muted-foreground) 85%, transparent);
+  font-size: 15px;
   font-weight: 400;
-  line-height: 24px;
+  line-height: 22px;
 }
 
 @media (max-width: 760px) {
+  .header {
+    padding: 16px 0 14px;
+  }
+
   .titleRow {
-    font-size: 24px;
-    line-height: 32px;
+    font-size: 26px;
+    line-height: 34px;
   }
 }


### PR DESCRIPTION
## What this PR does

Polishes the Web Shell new-session welcome screen (the chat empty state shown before the first message): the title is larger with tighter letter spacing, the subtitle is slightly smaller and softer, the header gets more breathing room, and the whole header gently fades in on first render (disabled when the user prefers reduced motion). The brand gradient on the product name is also replaced: the old blue-to-rose sweep is now a tighter blue-to-brand-purple arc centered on the Qwen logo purple, so the wordmark matches the sidebar logo.

## Why it's needed

The new-session screen is the first thing a user sees, and the previous header felt cramped and visually flat. This is a pure visual refinement: no content, layout structure, or behavior changes, and host-provided welcome header/footer overrides are unaffected.

## Reviewer Test Plan

### How to verify

Open the Web Shell with no active session (or start a new session) in both light and dark themes, at desktop and mobile widths. Expected: the welcome title renders larger with tighter letter spacing, the subtitle reads a touch softer, there is more space around the header, the header fades in subtly on first render, and the product-name gradient runs blue to Qwen brand purple with no rose/red tail. With reduced motion enabled at the OS level, no animation plays.

### Evidence (Before & After)

Zoomed to the welcome header region (same crop, before on top / after on bottom):

**Dark theme**

![dark before after](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/web-shell-new-session-welcome-polish/pr-assets/web-shell-new-session-welcome-polish/compare-dark.png)

**Light theme**

![light before after](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/web-shell-new-session-welcome-polish/pr-assets/web-shell-new-session-welcome-polish/compare-light.png)

<details>
<summary>Full-page screenshots</summary>

| | Before | After |
| :-- | :----: | :---: |
| Dark | ![before dark](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/web-shell-new-session-welcome-polish/pr-assets/web-shell-new-session-welcome-polish/before-dark.png) | ![after dark](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/web-shell-new-session-welcome-polish/pr-assets/web-shell-new-session-welcome-polish/after-dark.png) |
| Light | ![before light](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/web-shell-new-session-welcome-polish/pr-assets/web-shell-new-session-welcome-polish/before-light.png) | ![after light](https://raw.githubusercontent.com/wenshao/qwen-code/pr-assets/web-shell-new-session-welcome-polish/pr-assets/web-shell-new-session-welcome-polish/after-light.png) |

</details>

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

`npm run dev` (Vite dev server) plus the Playwright visual harness (`client/e2e/visuals`) for the before/after captures; 546 web-shell unit tests pass.

## Risk & Scope

- Main risk or tradeoff: cosmetic only — a single scoped CSS module; reduced-motion users see no animation.
- Not validated / out of scope: Windows/Linux visual check (the CSS is platform-independent); mobile widths verified via stylesheet breakpoint, not screenshot.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

打磨 Web Shell 新建会话欢迎页（发送第一条消息前的聊天空状态）：标题更大、字距更紧，副标题略小且更柔和，标题区域间距更宽裕，整个标题在首次渲染时柔和淡入（开启"减弱动态效果"时自动关闭）。产品名的品牌渐变也一并替换：原来的蓝到玫瑰红大跨度渐变改为围绕 Qwen logo 紫的蓝紫短弧渐变，与侧栏 logo 品牌色一致。

## 为什么需要

新建会话页是用户看到的第一个界面，之前的标题显得局促、视觉平淡。本次是纯视觉优化：不涉及内容、布局结构或行为变化，宿主侧提供的欢迎页头/尾自定义渲染也不受影响。

## 评审验证计划

### 如何验证

在无会话状态下打开 Web Shell（或新建一个会话），分别在明暗主题、桌面和移动端宽度下查看。预期：欢迎标题更大、字距更紧，副标题更柔和，标题周围空间更宽裕，首次渲染时标题轻微淡入，产品名渐变为蓝到品牌紫、不再有红色末端。在系统层面开启减弱动态效果时不播放动画。

### 前后对比证据

见上方英文部分的暗色/亮色主题 Before & After 截图。

### 测试平台

macOS ✅；Windows / Linux 未测（CSS 与平台无关）。

### 环境（可选）

`npm run dev`（Vite 开发服务器）+ Playwright 视觉截图 harness（`client/e2e/visuals`）生成前后对比图；web-shell 546 个单元测试全部通过。

## 风险与范围

- 主要风险或取舍：仅外观层面——单个 scoped CSS module；开启减弱动态效果的用户无动画。
- 未验证 / 不在范围内：Windows/Linux 视觉检查（CSS 与平台无关）；移动端宽度通过样式断点验证，未截图。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无

</details>
