### PR TITLE
fix(web-shell): restore composer after closing MCP plugin panel

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -5214,8 +5214,12 @@ function makePendingPermissionBlock(
 beforeEach(() => {
   // Split persistence uses sessionStorage; clear it so one test's split doesn't
   // auto-restore into the next test's App mount.
-  sessionStorage.clear();
-  localStorage.removeItem('qwen-code-web-shell-chat-width');
+  try {
+    sessionStorage.clear();
+    window.localStorage?.removeItem('qwen-code-web-shell-chat-width');
+  } catch {
+    // Web storage may be unavailable under storage-disabled jsdom contexts.
+  }
   mockReleaseWebTerminal.mockReset();
   Object.defineProperty(document, 'hidden', {
     configurable: true,

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -18283,6 +18283,61 @@ describe('App session callbacks', () => {
     ).toBe('true');
   });
 
+  it('restores composer interaction after closing Plugins on the MCP tab', async () => {
+    mockWorkspaceActions.loadMcpStatus.mockResolvedValue({
+      initialized: true,
+      discoveryState: 'completed',
+      servers: [],
+    });
+    const { container } = renderApp();
+    await flush();
+    expect(testState.latestChatEditorProps?.dialogOpen).toBe(false);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-plugins"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await flush();
+    const panel = container.querySelector('[data-testid="inline-panel"]');
+    const tabs =
+      panel?.querySelectorAll<HTMLButtonElement>('button[role="tab"]');
+    expect(Array.from(tabs ?? []).map((tab) => tab.textContent)).toEqual([
+      'Extensions',
+      'MCP',
+      'Skills',
+      'Agents',
+    ]);
+    const mcpTab = Array.from(tabs ?? []).find(
+      (tab) => tab.textContent === 'MCP',
+    );
+    await act(async () => {
+      mcpTab?.focus();
+      mcpTab?.click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(mockWorkspaceActions.loadMcpStatus).toHaveBeenCalled();
+    expect(testState.latestChatEditorProps?.dialogOpen).toBe(true);
+
+    const mcpPanel = container.querySelector('[data-testid="inline-panel"]');
+    await act(async () => {
+      mcpPanel?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key: 'Escape',
+        }),
+      );
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
+    expect(testState.latestChatEditorProps?.dialogOpen).toBe(false);
+  });
+
   it('opens Channel management from the sidebar', async () => {
     const { container } = renderApp();
     await flush();

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -6830,6 +6830,8 @@ export function App({
     modelDialogMode !== null ||
     showApprovalModeDialog ||
     tasksDialogMessage !== null ||
+    // mcpDialogMessage survives closing the Plugins panel; MCP surfaces are
+    // already blocked by activePanel below, so including it would lock chat.
     showMemoryDialog ||
     showAuthDialog ||
     showAddWorkspaceDialog ||

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -6830,7 +6830,6 @@ export function App({
     modelDialogMode !== null ||
     showApprovalModeDialog ||
     tasksDialogMessage !== null ||
-    mcpDialogMessage !== null ||
     showMemoryDialog ||
     showAuthDialog ||
     showAddWorkspaceDialog ||


### PR DESCRIPTION
## What this PR does

Restores the web-shell composer after the user closes the Plugins panel while the MCP tab is active. The persisted MCP status still marks an MCP dialog as open, but that status should not keep the composer dormant once the replacement panel has been dismissed.

It also adds a regression test for the exact flow: open Plugins, switch to MCP, close with Escape, and confirm composer interaction is restored.

## Why it's needed

Fixes a user-visible dead state reported in #10228 where closing the Plugins panel could leave the input stuck disabled with `dialogOpen`, forcing users to reopen or restart the web shell before they could type again.

## Reviewer Test Plan

### How to verify

1. Start the web shell and connect to a daemon state with MCP status data present.
2. Open Plugins from the sidebar and switch to the MCP tab.
3. Press Escape to close the panel.
4. Confirm the composer is enabled again and no longer reports `dialogOpen`.

Automated checks run locally:

- `npm -w packages/web-shell run test -- client/App.test.tsx -t "restores composer interaction after closing Plugins on the MCP tab" --reporter dot`
- `npm -w packages/web-shell run test -- client/App.test.tsx -t "opens plugin management tabs from the sidebar|closes the panel on Escape from outside the sidebar|marks the composer dormant \\(dialogOpen\\) while a panel replaces the chat" --reporter verbose`
- `npm -w packages/web-shell run typecheck`
- `npx prettier --check packages/web-shell/client/App.tsx packages/web-shell/client/App.test.tsx`
- `npx eslint packages/web-shell/client/App.tsx packages/web-shell/client/App.test.tsx`

### Evidence (Before & After)

Before: the regression test fails because the composer stays blocked after the MCP tab panel is closed.

After: the focused regression test passes and confirms the composer is not disabled after Escape closes the panel.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local Node/Vitest workspace tests in `packages/web-shell`; no live daemon required for the regression test.

## Risk & Scope

- Main risk or tradeoff: low; the change only narrows when MCP status can mark the composer dormant, so the replacement panel still disables composer input while it is open.
- Not validated / out of scope: manual cross-platform browser testing and live daemon screenshot capture.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10228

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 Web Shell 中关闭 Plugins 面板后输入框仍不可用的问题。当 MCP tab 处于激活状态时，持久化的 MCP 状态仍然会表示 MCP dialog 打开过，但在替代面板已经关闭后，它不应该继续让 composer 保持 dormant。

同时补充了覆盖该流程的回归测试：打开 Plugins，切到 MCP tab，用 Escape 关闭面板，并确认输入框恢复可交互。

## 为什么需要

修复 #10228 中报告的用户可见死状态：关闭 Plugins 面板后，输入框可能仍因 `dialogOpen` 被禁用，用户必须重新打开或重启 Web Shell 才能继续输入。

## Reviewer 测试计划

### 如何验证

1. 启动 Web Shell，并连接到存在 MCP 状态数据的 daemon 状态。
2. 从侧边栏打开 Plugins，并切换到 MCP tab。
3. 按 Escape 关闭面板。
4. 确认 composer 重新可用，且不再显示 `dialogOpen`。

本地已运行的自动化检查：

- `npm -w packages/web-shell run test -- client/App.test.tsx -t "restores composer interaction after closing Plugins on the MCP tab" --reporter dot`
- `npm -w packages/web-shell run test -- client/App.test.tsx -t "opens plugin management tabs from the sidebar|closes the panel on Escape from outside the sidebar|marks the composer dormant \\(dialogOpen\\) while a panel replaces the chat" --reporter verbose`
- `npm -w packages/web-shell run typecheck`
- `npx prettier --check packages/web-shell/client/App.tsx packages/web-shell/client/App.test.tsx`
- `npx eslint packages/web-shell/client/App.tsx packages/web-shell/client/App.test.tsx`

### 证据（修复前后）

修复前：回归测试失败，因为 MCP tab 面板关闭后 composer 仍保持 blocked。

修复后：聚焦回归测试通过，确认 Escape 关闭面板后 composer 不再 disabled。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### 环境（可选）

在 `packages/web-shell` 中运行本地 Node/Vitest workspace 测试；该回归测试不需要真实 daemon。

## 风险与范围

- 主要风险或取舍：低；改动只收窄 MCP 状态让 composer 进入 dormant 的条件，替代面板打开时仍会禁用 composer 输入。
- 未验证 / 范围外：手动跨平台浏览器测试和 live daemon 截图采集。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10228

</details>

🤖 Generated with Claude Code