### PR TITLE
fix(core): make stale team reclaim generation-safe

### DIFF
--- a/packages/core/src/agents/team/teamHelpers.test.ts
+++ b/packages/core/src/agents/team/teamHelpers.test.ts
@@ -48,6 +48,34 @@ vi.mock('../../config/storage.js', async (importOriginal) => {
   };
 });
 
+// Optional readFile hook for simulating mid-reclaim I/O failures.
+// While a hook is installed and returns a value, that value is used;
+// otherwise the real readFile runs.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  type ReadFileHook = (
+    ...args: Parameters<typeof actual.readFile>
+  ) => unknown;
+  let readFileHook: ReadFileHook | undefined;
+  return {
+    ...actual,
+    __setReadFileHook: (fn: ReadFileHook | undefined) => {
+      readFileHook = fn;
+    },
+    readFile: (...args: Parameters<typeof actual.readFile>) => {
+      const hooked = readFileHook?.(...args);
+      if (hooked !== undefined) {
+        return hooked;
+      }
+      return actual.readFile(...args);
+    },
+  };
+});
+
+const { __setReadFileHook } = (await import('node:fs/promises')) as unknown as {
+  __setReadFileHook: (fn?: unknown) => void;
+};
+
 // ─── Fixtures ─────────────────────────────────────────────────
 
 function makeMember(
@@ -443,6 +471,75 @@ describe('file I/O', () => {
 
       await expect(tryReclaimStaleTeam('other-user')).resolves.toBe(false);
       expect(await readTeamFile('other-user')).toBeDefined();
+    });
+
+    it('aborts when the config content is the JSON literal null', async () => {
+      // A config whose entire content is the valid-JSON literal `null`
+      // parses without entering the JSON.parse catch, so the shape
+      // guard must reject it instead of throwing on
+      // `existing.leadPid`. Like any unreadable/corrupt file, it
+      // can't prove its owner is gone — leave it for manual recovery.
+      await writeTeamFile('nullcfg', makeTeamFile({ leadPid: deadPid() }));
+      const tasksDir = getTasksDir('nullcfg');
+      await fs.mkdir(tasksDir, { recursive: true });
+      await fs.writeFile(path.join(tasksDir, 'marker.json'), '{}');
+      await fs.writeFile(getTeamFilePath('nullcfg'), 'null');
+
+      await expect(tryReclaimStaleTeam('nullcfg')).resolves.toBe(false);
+      expect(await fs.readFile(getTeamFilePath('nullcfg'), 'utf-8')).toBe(
+        'null',
+      );
+      await expect(fs.access(tasksDir)).resolves.toBeUndefined();
+    });
+
+    it('aborts when the config is unparseable at inspection', async () => {
+      // Corrupt/torn config: ownership liveness cannot be proven, so
+      // the dirs must be left for manual recovery instead of deleted.
+      await writeTeamFile('corrupt', makeTeamFile({ leadPid: deadPid() }));
+      const tasksDir = getTasksDir('corrupt');
+      await fs.mkdir(tasksDir, { recursive: true });
+      await fs.writeFile(path.join(tasksDir, 'marker.json'), '{}');
+      await fs.writeFile(getTeamFilePath('corrupt'), '{ "name": ');
+
+      await expect(tryReclaimStaleTeam('corrupt')).resolves.toBe(false);
+      expect(await fs.readFile(getTeamFilePath('corrupt'), 'utf-8')).toBe(
+        '{ "name": ',
+      );
+      await expect(fs.access(tasksDir)).resolves.toBeUndefined();
+    });
+
+    it('aborts when the config vanishes before the delete', async () => {
+      // If the config disappears between the staleness inspection and
+      // the byte-equality re-read, a by-name delete could hit a
+      // generation this reclaim never inspected — abort and leave the
+      // dirs intact.
+      await writeTeamFile('flaky', makeTeamFile({ leadPid: deadPid() }));
+      const tasksDir = getTasksDir('flaky');
+      await fs.mkdir(tasksDir, { recursive: true });
+      await fs.writeFile(path.join(tasksDir, 'marker.json'), '{}');
+
+      let readCount = 0;
+      __setReadFileHook(() => {
+        readCount += 1;
+        if (readCount === 2) {
+          // The re-read before the delete fails with ENOENT.
+          return Promise.reject(
+            Object.assign(new Error('ENOENT: no such file or directory'), {
+              code: 'ENOENT',
+            }),
+          );
+        }
+        return undefined;
+      });
+      try {
+        await expect(tryReclaimStaleTeam('flaky')).resolves.toBe(false);
+      } finally {
+        __setReadFileHook(undefined);
+      }
+      await expect(fs.access(tasksDir)).resolves.toBeUndefined();
+      await expect(
+        fs.access(getTeamFilePath('flaky')),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/core/src/agents/team/teamHelpers.ts
+++ b/packages/core/src/agents/team/teamHelpers.ts
@@ -308,26 +308,56 @@ export async function createTeamFile(
  *
  * Conservative on ambiguity: an unreadable/corrupt team file or a
  * pre-`leadPid` file can't prove its owner is gone, so it is left
- * for manual recovery.
+ * for manual recovery. Likewise when the config changes between the
+ * staleness check and the delete — that change means another creator
+ * already reclaimed the name and created a new live generation, which
+ * a by-name delete would destroy (#10209).
  */
 export async function tryReclaimStaleTeam(teamName: string): Promise<boolean> {
-  let existing: TeamFile | undefined;
+  const configPath = getTeamFilePath(teamName);
+  let inspectedRaw: string;
   try {
-    existing = await readTeamFile(teamName);
-  } catch {
+    inspectedRaw = await fs.readFile(configPath, 'utf-8');
+  } catch (err) {
+    if (isNodeError(err) && err.code === 'ENOENT') {
+      // config.json vanished between the caller's EEXIST and this read —
+      // a concurrent team_delete finished the job. The dirs may still
+      // hold leftovers; clear them so the retried create starts clean.
+      await deleteTeamDirs(teamName);
+      return true;
+    }
     return false;
   }
-  if (!existing) {
-    // config.json vanished between the caller's EEXIST and this read —
-    // a concurrent team_delete finished the job. The dirs may still
-    // hold leftovers; clear them so the retried create starts clean.
-    await deleteTeamDirs(teamName);
-    return true;
+  let existing: TeamFile;
+  try {
+    existing = JSON.parse(inspectedRaw) as TeamFile;
+  } catch {
+    return false;
   }
   if (typeof existing.leadPid !== 'number' || existing.leadPid <= 0) {
     return false;
   }
   if (existing.leadPid !== process.pid && isPidAlive(existing.leadPid)) {
+    return false;
+  }
+  // Generation safety (#10209): the delete below targets the team NAME,
+  // not the generation inspected above. Two concurrent creators can
+  // read the same stale config and both pass the liveness check; if
+  // one of them reclaims the name and creates a new team before this
+  // delete runs, a by-name delete would destroy that newer live
+  // generation. Only proceed when the on-disk config is still
+  // byte-identical to the stale generation this reclaim inspected —
+  // otherwise the name now belongs to a newer generation, and the
+  // caller's retried create will fail with EEXIST against it.
+  try {
+    const currentRaw = await fs.readFile(configPath, 'utf-8');
+    if (currentRaw !== inspectedRaw) {
+      return false;
+    }
+  } catch {
+    // The config vanished or became unreadable after the inspection —
+    // ambiguous, and a by-name delete could hit a generation this
+    // reclaim never inspected.
     return false;
   }
   await deleteTeamDirs(teamName);

--- a/packages/core/src/agents/team/teamHelpers.ts
+++ b/packages/core/src/agents/team/teamHelpers.ts
@@ -330,7 +330,15 @@ export async function tryReclaimStaleTeam(teamName: string): Promise<boolean> {
   }
   let existing: TeamFile;
   try {
-    existing = JSON.parse(inspectedRaw) as TeamFile;
+    const parsed: unknown = JSON.parse(inspectedRaw);
+    // A config containing the literal `null` (or any other non-object
+    // JSON value) parses successfully but proves nothing about the
+    // owner — treat it like a corrupt file and leave the dirs for
+    // manual recovery.
+    if (parsed === null || typeof parsed !== 'object') {
+      return false;
+    }
+    existing = parsed as TeamFile;
   } catch {
     return false;
   }

--- a/packages/core/src/tools/team-create-reclaim-race.test.ts
+++ b/packages/core/src/tools/team-create-reclaim-race.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview Regression test for #10209 — concurrent creators
+ * reclaiming the same stale team name: a delayed reclaim decision must
+ * not delete a newer live team generation.
+ *
+ * The reported interleaving (cross-session in the wild):
+ *   1. A stale team with a dead leader PID exists on disk.
+ *   2. Creators A and B both read that stale config and both pass the
+ *      liveness check.
+ *   3. A deletes the stale dirs and creates a new live team under the
+ *      same name.
+ *   4. B resumes its previously authorized reclaim, whose
+ *      deleteTeamDirs() targets the team name — wiping A's fresh
+ *      config.json and task dir while A holds a live TeamManager.
+ *
+ * The read barrier below makes the interleaving deterministic: B's
+ * inspection read of the stale config is captured at call time and its
+ * delivery held until A has completed its full reclaim+create cycle,
+ * so B resumes its reclaim against a generation that is no longer on
+ * disk.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TeamCreateTool } from './team-create.js';
+
+vi.mock('../config/storage.js', () => {
+  let mockDir = '/tmp/test';
+  return {
+    QWEN_DIR: '.qwen',
+    Storage: {
+      getGlobalQwenDir: () => mockDir,
+    },
+    __setMockGlobalDir: (d: string) => {
+      mockDir = d;
+    },
+  };
+});
+
+/**
+ * One-shot read barrier for team config files. While armed, the NEXT
+ * read of `teams/<name>/config.json` captures the file content at call
+ * time, resolves `arrival`, and holds delivery until `release` resolves
+ * — pinning the reader to the generation it inspected even while the
+ * file on disk is replaced by another creator.
+ */
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  const barrier = {
+    armed: false,
+    captured: undefined as string | undefined,
+    arrival: null as { promise: Promise<void>; resolve: () => void } | null,
+    release: null as { promise: Promise<void>; resolve: () => void } | null,
+  };
+  return {
+    ...actual,
+    __readBarrier: barrier,
+    async readFile(...args: Parameters<typeof actual.readFile>) {
+      const filePath = String(args[0]);
+      const isTeamConfig =
+        (filePath.includes('/teams/') || filePath.includes('\\teams\\')) &&
+        filePath.endsWith('config.json');
+      if (readBarrier.armed && readBarrier.release && isTeamConfig) {
+        readBarrier.armed = false;
+        readBarrier.captured = await actual.readFile(args[0], 'utf-8');
+        readBarrier.arrival?.resolve();
+        await readBarrier.release.promise;
+        return readBarrier.captured;
+      }
+      return actual.readFile(...args);
+    },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { __setMockGlobalDir } = (await import('../config/storage.js')) as any;
+
+interface ReadBarrier {
+  armed: boolean;
+  captured: string | undefined;
+  arrival: { promise: Promise<void>; resolve: () => void } | null;
+  release: { promise: Promise<void>; resolve: () => void } | null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { __readBarrier: barrier } = (await import('node:fs/promises')) as any;
+const readBarrier = barrier as ReadBarrier;
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function makeConfig(sessionId: string) {
+  return {
+    getArenaManager: () => null,
+    getTeamManager: () => null,
+    getSubagentManager: () => null,
+    getAgentsSettings: () => ({}),
+    getSessionId: () => sessionId,
+    setTeamManager: vi.fn(),
+    setTeamContext: vi.fn(),
+  } as unknown as import('../config/config.js').Config;
+}
+
+describe('team_create stale-reclaim race (#10209)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'reclaim-race-test-'));
+    __setMockGlobalDir(tmpDir);
+    readBarrier.armed = false;
+    readBarrier.arrival = null;
+    readBarrier.release = null;
+    readBarrier.captured = undefined;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /** PID of a process that has already exited. */
+  function deadPid(): number {
+    const child = spawnSync(process.execPath, ['-e', '']);
+    return child.pid!;
+  }
+
+  /** Seed a stranded stale team: dead leader PID, leftovers on disk. */
+  async function seedStaleTeam(teamName: string): Promise<void> {
+    const teamDir = path.join(tmpDir, 'teams', teamName);
+    await fs.mkdir(teamDir, { recursive: true });
+    await fs.writeFile(
+      path.join(teamDir, 'config.json'),
+      JSON.stringify(
+        {
+          name: teamName,
+          createdAt: 1,
+          leadAgentId: `leader@${teamName}`,
+          leadSessionId: 'session-stale',
+          leadPid: deadPid(),
+          members: [],
+        },
+        null,
+        2,
+      ) + '\n',
+      'utf-8',
+    );
+    const tasksDir = path.join(tmpDir, 'tasks', teamName);
+    await fs.mkdir(tasksDir, { recursive: true });
+    await fs.writeFile(path.join(tasksDir, 'task-1.json'), '{}', 'utf-8');
+  }
+
+  it('a delayed reclaim must not delete a newer live generation', async () => {
+    await seedStaleTeam('race');
+    const configPath = path.join(tmpDir, 'teams', 'race', 'config.json');
+    const signal = new AbortController().signal;
+
+    const creatorA = new TeamCreateTool(makeConfig('session-a'));
+    const creatorB = new TeamCreateTool(makeConfig('session-b'));
+
+    // B reaches reclaim first. Its inspection read of the stale config
+    // is captured and held at the barrier — B's reclaim decision is now
+    // based on a generation snapshot.
+    readBarrier.arrival = deferred();
+    readBarrier.release = deferred();
+    readBarrier.armed = true;
+    const bDone = creatorB.build({ team_name: 'race' }).execute(signal);
+    await readBarrier.arrival.promise;
+    expect(readBarrier.captured).toContain('session-stale');
+
+    // While B is held, A completes the entire reclaim+create cycle and
+    // owns the name with a new live generation.
+    const aResult = await creatorA.build({ team_name: 'race' }).execute(signal);
+    expect(aResult.error).toBeUndefined();
+    const aGeneration = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+    expect(aGeneration.leadSessionId).toBe('session-a');
+
+    // B resumes its previously authorized reclaim. Whatever it does
+    // next must not destroy A's generation.
+    readBarrier.release!.resolve();
+    const bResult = await bDone;
+
+    expect(bResult.error).toBeDefined();
+    expect(bResult.llmContent).toContain('live');
+    const survivor = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+    expect(survivor.leadSessionId).toBe('session-a');
+  });
+
+  it('still reclaims a stale team when no other creator interferes', async () => {
+    await seedStaleTeam('quiet');
+    const configPath = path.join(tmpDir, 'teams', 'quiet', 'config.json');
+
+    const creator = new TeamCreateTool(makeConfig('session-q'));
+    const result = await creator
+      .build({ team_name: 'quiet' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    const config = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+    expect(config.leadSessionId).toBe('session-q');
+  });
+});


### PR DESCRIPTION
## What this PR does

Makes the Agent Team stale-reclaim path generation-safe. `tryReclaimStaleTeam()` previously separated its staleness decision (`readTeamFile()` + `leadPid` liveness check) from the actual cleanup (`deleteTeamDirs()`, which removes `~/.qwen/teams/{name}` and `~/.qwen/tasks/{name}` purely by name), so nothing tied the delete to the generation that was inspected. This change captures the inspected config's raw bytes, re-reads the config immediately before deleting, and aborts the reclaim when the on-disk config is no longer byte-identical to the stale generation the reclaim inspected — i.e., when another creator has since reclaimed the name and created a newer live team generation. A losing creator now gets the normal "owned by a live session" error instead of destroying the winner's state.

## Why it's needed

Fixes the race reported in #10209 (follow-up split from the #10074 lifecycle audit). Two concurrent `team_create` calls for the same stale team name can both read the stale config and both pass the liveness check. If creator A then completes delete → `wx`-exclusive create → task/inbox reset and continues with a live in-memory `TeamManager`, creator B's previously authorized reclaim resumes and its by-name `deleteTeamDirs()` wipes A's fresh `config.json` and task directory; B's retried create then succeeds on the emptied name. The result is a silent divergence — A live in memory, B on disk — and loss of A's coordination state. Expected behavior per the issue: a reclaim decision based on one stale generation must never delete a later live generation, and exactly one creator should acquire the team name.

## Reviewer Test Plan

### How to verify

Run the new deterministic two-creator test and the surrounding team suites:

```
cd packages/core
npx vitest run src/tools/team-create-reclaim-race.test.ts
npx vitest run src/agents/team/ src/tools/team-create.test.ts src/tools/team-delete.test.ts src/tools/team-lifecycle.test.ts
npm run typecheck
```

Reproduction method: a stale team is seeded with a dead leader PID and leftover task files; creator B's `team_create` reaches reclaim first and its inspection read of the stale config is captured and held at a one-shot read barrier; while B is held, creator A completes the full reclaim + `wx`-exclusive create cycle and owns the name with a new live generation; B's held read is then delivered so B resumes its previously authorized reclaim against a generation that is no longer on disk.

- Before (unfixed): B's delayed reclaim deletes A's generation, B's retried create succeeds, and the on-disk config ends up as B's (`leadSessionId: session-b`). The race test fails with `expected undefined to be defined` at `expect(bResult.error).toBeDefined()` — B wrongly reports success.
- After (this PR): B's pre-delete re-read sees A's config, detects the generation change, aborts, and B reports "owned by a live qwen-code session". The on-disk config stays A's (`leadSessionId: session-a`). Both tests pass.
- Regression protection: the second new test asserts an uncontended stale reclaim still succeeds end-to-end, and all pre-existing reclaim tests in `teamHelpers.test.ts` / `team-create.test.ts` continue to pass (314 team-related tests green).

### Evidence (Before & After)

Before (race test red on unfixed code):

```
× team_create stale-reclaim race (#10209) > a delayed reclaim must not delete a newer live generation
  → expected undefined to be defined   (B reported success after wiping A's config)
Tests  1 failed | 1 passed (2)
```

After (with fix):

```
✓ src/tools/team-create-reclaim-race.test.ts (2 tests)
Test Files  1 passed (1)
Tests  2 passed (2)
```

Full affected surface: `src/agents/team/` + `src/tools/team-*.test.ts` → 13 files, 314 tests passed. `npm run typecheck` clean; eslint/prettier clean on changed files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest run` in `packages/core`), Node from the repo toolchain on Linux.

## Risk & Scope

- Main risk or tradeoff: the generation check compares config bytes immediately before the by-name delete, which closes the reported interleaving deterministically but leaves a microsecond theoretical window between the final re-read and `fs.rm`; a cross-process `proper-lockfile` barrier around reclaim+create would be stronger but is a larger behavioral change — triage in #10209 explicitly endorsed compare-and-delete as a suitable fix direction. Aborting on ambiguity (config vanished/changed after inspection) is conservative: the name is left to the winning creator or to a retry, never deleted blindly.
- Not validated / out of scope: a two-real-process E2E run (reproduction is test-level with a deterministic barrier, the same accepted approach as the sibling #10208/#10210 fixes); `team_delete` behavior is unchanged; no changes to the liveness semantics (`leadPid === process.pid` self-reclaim is untouched).
- Breaking changes / migration notes: none — legitimate uncontended reclaims behave exactly as before.

PR size: source +40/−10 in `packages/core/src/agents/team/teamHelpers.ts`; tests +214 (new file `packages/core/src/tools/team-create-reclaim-race.test.ts`); total +254/−10, within budget.

Generation-safety guarantee: the reclaim now carries the inspected generation's identity (raw config bytes) to the moment of deletion; any rewrite in between — necessarily changing `createdAt`/`leadSessionId`/`leadPid` bytes for a new generation — makes the comparison fail and the reclaim aborts before any `rm` runs, so a delayed reclaim can only ever delete the exact stale generation it inspected, and the retried `wx`-exclusive create remains the final arbiter of who owns the name.

## Linked Issues

Fixes #10209

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 Agent Team 的 stale-reclaim 路径具备 generation 安全性。此前 `tryReclaimStaleTeam()` 的过期判定（`readTeamFile()` + `leadPid` 存活检查）与实际清理（`deleteTeamDirs()`，纯按名称删除 `~/.qwen/teams/{name}` 和 `~/.qwen/tasks/{name}`）是分离的，删除操作与被检查的 generation 之间没有任何绑定。本改动在检查时捕获 config 的原始字节，在删除前立即重读 config，若磁盘上的 config 与本次 reclaim 检查过的 stale generation 不再逐字节一致（即另一个创建者已经 reclaim 了该名称并创建了更新的活跃 team generation），则中止本次 reclaim。失败的创建者会得到正常的 "owned by a live session" 错误，而不是毁掉胜出者的状态。

## 为什么需要

修复 #10209 报告的竞态（#10074 生命周期审计按 triage 要求拆分的后续）。两个并发的 `team_create` 调用争用同一个 stale team 名称时，都可能读到同一份 stale config 并都通过存活检查。若创建者 A 先完成 删除 → `wx` 独占创建 → 重置 tasks/inboxes，并继续持有内存中活跃的 `TeamManager`，创建者 B 此前已被授权的 reclaim 恢复执行，其按名称执行的 `deleteTeamDirs()` 会删掉 A 刚写好的 `config.json` 和 task 目录；B 重试创建又在被清空的名称上成功。结果是静默分歧 —— A 在内存、B 在磁盘 —— 并丢失 A 的协调状态。issue 期望的行为：基于某个 stale generation 的 reclaim 决定绝不能删除更晚的活跃 generation，且恰好一个创建者获得该 team 名称。

## 审阅者测试计划

### 如何验证

运行新的确定性双创建者测试及周边 team 测试套件（命令见英文部分）。复现方式：先落盘一个 leader PID 已死的 stale team 及残留 task 文件；创建者 B 的 `team_create` 先进入 reclaim，其对 stale config 的检查读取被一次性读屏障捕获并挂起；在 B 挂起期间，创建者 A 完成完整的 reclaim + `wx` 独占创建并持有名称；随后放行 B 的读取，使 B 恢复其已被授权的 reclaim，而磁盘上的 generation 已不再是它检查过的那一份。修复前：B 的延迟 reclaim 删掉 A 的 generation，B 重试创建成功，race 测试在 `expect(bResult.error).toBeDefined()` 处失败（B 错误地报告成功）。修复后：B 在删除前重读发现 generation 变化，中止并报告 "owned by a live qwen-code session"，磁盘 config 保持为 A 的。回归保护：第二个新测试验证无竞争的 stale reclaim 仍端到端成功，`teamHelpers.test.ts` / `team-create.test.ts` 中既有的全部 reclaim 测试继续通过（314 个 team 相关测试全绿）。

### 证据（修复前后）

修复前（race 测试在未修复代码上红）：1 failed | 1 passed，失败点为 `expected undefined to be defined`（B 删掉 A 的 config 后错误地报告成功）。修复后：该文件 2 个测试全部通过；受影响的全部范围（`src/agents/team/` + `src/tools/team-*.test.ts`）13 个文件 314 个测试通过；`npm run typecheck` 干净；改动文件 eslint/prettier 干净。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ 未测   |
| 🪟 Windows |   ⚠️ 未测   |
|  🐧 Linux  |   ✅ 已测   |

环境说明：仅单元测试（`packages/core` 内 `vitest run`），Linux 上仓库工具链的 Node。

## 风险与范围

- 主要风险/权衡：generation 检查在按名称删除之前立即比对 config 字节，确定性地封堵了所报告的交错，但最终重读与 `fs.rm` 之间理论上仍留有微秒级窗口；跨进程 `proper-lockfile` 屏障更强，但属于更大的行为变更 —— #10209 的 triage 已明确认可 compare-and-delete 方向。对歧义情形（检查后 config 消失/变化）一律保守中止：名称留给胜出者或下次重试，绝不盲删。
- 未验证/超出范围：两个真实进程的 E2E 验证（本次为屏障式测试级复现，与同批 #10208/#10210 修复被接受的方式一致）；`team_delete` 行为不变；存活判定语义（`leadPid === process.pid` 的自身 reclaim）不变。
- 破坏性变更/迁移说明：无 —— 合法的无竞争 reclaim 行为与之前完全一致。

PR 规模：源码 +40/−10（`teamHelpers.ts`），测试 +214（新文件），合计 +254/−10，在预算内。

Generation 安全保证：reclaim 现在把被检查 generation 的身份（config 原始字节）携带到删除时刻；期间的任何重写（新 generation 必然改变 `createdAt`/`leadSessionId`/`leadPid` 字节）都会使比对失败并在任何 `rm` 执行前中止，因此延迟的 reclaim 只能删除它检查过的那一份 stale generation，重试的 `wx` 独占创建仍是名称归属的最终裁决。

## 关联 Issue

Fixes #10209

</details>
