### PR TITLE
fix(core): prevent duplicate task owner dispatch

### DIFF
--- a/packages/core/src/agents/team/tasks.test.ts
+++ b/packages/core/src/agents/team/tasks.test.ts
@@ -393,6 +393,44 @@ describe('tasks', () => {
       expect(['alice', 'bob']).toContain(final?.owner);
     });
 
+    it('rejects a stale leader assignment when the expected owner changed', async () => {
+      const task = await createTask('team', {
+        subject: 'Shared',
+        description: '',
+      });
+      const options = {
+        expectedOwner: null,
+      };
+
+      const results = await Promise.allSettled([
+        updateTask(
+          'team',
+          task.id,
+          { status: 'in_progress', owner: 'alice' },
+          options,
+        ),
+        updateTask(
+          'team',
+          task.id,
+          { status: 'in_progress', owner: 'bob' },
+          options,
+        ),
+      ]);
+
+      expect(
+        results.filter((result) => result.status === 'fulfilled'),
+      ).toHaveLength(1);
+      const rejected = results.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected',
+      );
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0]!.reason).toBeInstanceOf(Error);
+      expect((rejected[0]!.reason as Error).message).toContain('owner changed');
+      const final = await getTask('team', task.id);
+      expect(['alice', 'bob']).toContain(final?.owner);
+    });
+
     it('lets the leader (no callerName) override an existing owner', async () => {
       const task = await createTask('team', {
         subject: 'Shared',

--- a/packages/core/src/agents/team/tasks.test.ts
+++ b/packages/core/src/agents/team/tasks.test.ts
@@ -23,6 +23,7 @@ import {
   onTasksUpdated,
   notifyTasksUpdated,
   TaskOwnershipError,
+  TaskOwnerChangedError,
   RECIPROCAL_CALLER,
   normalizeTaskId,
 } from './tasks.js';
@@ -425,10 +426,48 @@ describe('tasks', () => {
           result.status === 'rejected',
       );
       expect(rejected).toHaveLength(1);
-      expect(rejected[0]!.reason).toBeInstanceOf(Error);
+      expect(rejected[0]!.reason).toBeInstanceOf(TaskOwnerChangedError);
       expect((rejected[0]!.reason as Error).message).toContain('owner changed');
+      expect((rejected[0]!.reason as Error).message).toContain(
+        'content-only task_update',
+      );
+      expect((rejected[0]!.reason as Error).message).toContain(
+        'without re-delivering',
+      );
       const final = await getTask('team', task.id);
       expect(['alice', 'bob']).toContain(final?.owner);
+    });
+
+    it('rejects a stale leader assignment when status changed', async () => {
+      const task = await createTask('team', {
+        subject: 'Shared',
+        description: '',
+        owner: 'alice',
+      });
+      await updateTask('team', task.id, { status: 'in_progress' });
+      await updateTask(
+        'team',
+        task.id,
+        { status: 'completed' },
+        { callerName: 'alice' },
+      );
+
+      await expect(
+        updateTask(
+          'team',
+          task.id,
+          { status: 'in_progress', owner: 'bob' },
+          { expectedOwner: 'alice', expectedStatus: 'in_progress' },
+        ),
+      ).rejects.toMatchObject({
+        name: 'TaskOwnerChangedError',
+        expectedStatus: 'in_progress',
+        actualStatus: 'completed',
+      });
+      expect(await getTask('team', task.id)).toMatchObject({
+        status: 'completed',
+        owner: 'alice',
+      });
     });
 
     it('lets the leader (no callerName) override an existing owner', async () => {

--- a/packages/core/src/agents/team/tasks.test.ts
+++ b/packages/core/src/agents/team/tasks.test.ts
@@ -23,7 +23,7 @@ import {
   onTasksUpdated,
   notifyTasksUpdated,
   TaskOwnershipError,
-  TaskOwnerChangedError,
+  TaskSnapshotChangedError,
   RECIPROCAL_CALLER,
   normalizeTaskId,
 } from './tasks.js';
@@ -426,16 +426,57 @@ describe('tasks', () => {
           result.status === 'rejected',
       );
       expect(rejected).toHaveLength(1);
-      expect(rejected[0]!.reason).toBeInstanceOf(TaskOwnerChangedError);
+      expect(rejected[0]!.reason).toBeInstanceOf(TaskSnapshotChangedError);
       expect((rejected[0]!.reason as Error).message).toContain('owner changed');
-      expect((rejected[0]!.reason as Error).message).toContain(
-        'content-only task_update',
-      );
-      expect((rejected[0]!.reason as Error).message).toContain(
-        'without re-delivering',
-      );
       const final = await getTask('team', task.id);
       expect(['alice', 'bob']).toContain(final?.owner);
+    });
+
+    it('reports only the expected fields that changed', async () => {
+      const task = await createTask('team', {
+        subject: 'Shared',
+        description: '',
+        owner: 'alice',
+      });
+      await updateTask('team', task.id, { status: 'in_progress' });
+      await updateTask(
+        'team',
+        task.id,
+        { status: 'completed' },
+        { callerName: 'alice' },
+      );
+
+      const update = updateTask(
+        'team',
+        task.id,
+        { status: 'pending' },
+        { expectedStatus: 'in_progress' },
+      );
+
+      await expect(update).rejects.toMatchObject({
+        expectedStatus: 'in_progress',
+        actualStatus: 'completed',
+      });
+      await expect(update).rejects.toThrow('status changed');
+      await expect(update).rejects.not.toThrow('owner changed');
+    });
+
+    it('does not check an undefined expected status', async () => {
+      const task = await createTask('team', {
+        subject: 'Shared',
+        description: '',
+      });
+
+      await expect(
+        updateTask(
+          'team',
+          task.id,
+          { status: 'in_progress' },
+          { expectedStatus: undefined },
+        ),
+      ).resolves.toMatchObject({
+        status: 'in_progress',
+      });
     });
 
     it('rejects a stale leader assignment when status changed', async () => {
@@ -460,7 +501,7 @@ describe('tasks', () => {
           { expectedOwner: 'alice', expectedStatus: 'in_progress' },
         ),
       ).rejects.toMatchObject({
-        name: 'TaskOwnerChangedError',
+        name: 'TaskSnapshotChangedError',
         expectedStatus: 'in_progress',
         actualStatus: 'completed',
       });

--- a/packages/core/src/agents/team/tasks.ts
+++ b/packages/core/src/agents/team/tasks.ts
@@ -363,12 +363,26 @@ export class TaskOwnerChangedError extends Error {
     readonly taskId: string,
     readonly expectedOwner: string | undefined,
     readonly actualOwner: string | undefined,
+    readonly expectedStatus?: SwarmTaskStatus,
+    readonly actualStatus?: SwarmTaskStatus,
   ) {
     const label = (owner: string | undefined) => owner ?? 'unassigned';
+    const changes: string[] = [];
+    if (expectedOwner !== actualOwner) {
+      changes.push(
+        `owner changed from "${label(expectedOwner)}" to "${label(actualOwner)}"`,
+      );
+    }
+    if (expectedStatus !== undefined && expectedStatus !== actualStatus) {
+      changes.push(
+        `status changed from "${expectedStatus}" to "${actualStatus}"`,
+      );
+    }
     super(
-      `Task #${taskId} owner changed from "${label(expectedOwner)}" to ` +
-        `"${label(actualOwner)}" before this assignment committed. ` +
-        'Retry task_update using the current task state.',
+      `Task #${taskId} ${changes.join(' and ')} before this assignment ` +
+        `committed. Current state is owner "${label(actualOwner)}", status ` +
+        `"${actualStatus}". Re-read the task before retrying. A content-only ` +
+        `task_update persists changes without re-delivering the assignment.`,
     );
     this.name = 'TaskOwnerChangedError';
   }
@@ -386,10 +400,10 @@ export class TaskOwnerChangedError extends Error {
  * pre-lock guard on an unowned task and have the second writer
  * silently overwrite the first one's claim.
  *
- * `opts.expectedOwner`, when present, adds an optimistic ownership
- * check for leader-side assignment. `null` means the caller observed
- * an unowned task. A stale assignment is rejected inside the same lock
- * before any fields are changed.
+ * `opts.expectedOwner` and `opts.expectedStatus`, when present, add
+ * optimistic checks for leader-side assignment. `null` means the caller
+ * observed an unowned task. A stale assignment is rejected inside the
+ * same lock before any fields are changed.
  */
 export async function updateTask(
   teamName: string,
@@ -404,7 +418,11 @@ export async function updateTask(
     addBlocks?: string[];
     addBlockedBy?: string[];
   },
-  opts?: { callerName?: string; expectedOwner?: string | null },
+  opts?: {
+    callerName?: string;
+    expectedOwner?: string | null;
+    expectedStatus?: SwarmTaskStatus;
+  },
 ): Promise<SwarmTask | undefined> {
   const taskPath = getTaskPath(teamName, taskId);
 
@@ -424,13 +442,24 @@ export async function updateTask(
       }
       const task = JSON.parse(raw) as SwarmTask;
 
-      if (opts && 'expectedOwner' in opts) {
+      const checksExpectedOwner = opts && 'expectedOwner' in opts;
+      const checksExpectedStatus = opts && 'expectedStatus' in opts;
+      if (checksExpectedOwner || checksExpectedStatus) {
         const expectedOwner = opts.expectedOwner
           ? sanitizeName(opts.expectedOwner)
           : undefined;
         const actualOwner = task.owner ? sanitizeName(task.owner) : undefined;
-        if (expectedOwner !== actualOwner) {
-          throw new TaskOwnerChangedError(taskId, expectedOwner, actualOwner);
+        if (
+          (checksExpectedOwner && expectedOwner !== actualOwner) ||
+          (checksExpectedStatus && opts.expectedStatus !== task.status)
+        ) {
+          throw new TaskOwnerChangedError(
+            taskId,
+            expectedOwner,
+            actualOwner,
+            opts.expectedStatus,
+            task.status,
+          );
         }
       }
 

--- a/packages/core/src/agents/team/tasks.ts
+++ b/packages/core/src/agents/team/tasks.ts
@@ -358,33 +358,34 @@ export class TaskOwnershipError extends Error {
   }
 }
 
-export class TaskOwnerChangedError extends Error {
+export class TaskSnapshotChangedError extends Error {
   constructor(
     readonly taskId: string,
     readonly expectedOwner: string | undefined,
     readonly actualOwner: string | undefined,
-    readonly expectedStatus?: SwarmTaskStatus,
-    readonly actualStatus?: SwarmTaskStatus,
+    readonly expectedStatus: SwarmTaskStatus | undefined,
+    readonly actualStatus: SwarmTaskStatus | undefined,
+    checksExpectedOwner: boolean,
+    checksExpectedStatus: boolean,
   ) {
     const label = (owner: string | undefined) => owner ?? 'unassigned';
     const changes: string[] = [];
-    if (expectedOwner !== actualOwner) {
+    if (checksExpectedOwner && expectedOwner !== actualOwner) {
       changes.push(
         `owner changed from "${label(expectedOwner)}" to "${label(actualOwner)}"`,
       );
     }
-    if (expectedStatus !== undefined && expectedStatus !== actualStatus) {
+    if (checksExpectedStatus && expectedStatus !== actualStatus) {
       changes.push(
         `status changed from "${expectedStatus}" to "${actualStatus}"`,
       );
     }
     super(
-      `Task #${taskId} ${changes.join(' and ')} before this assignment ` +
-        `committed. Current state is owner "${label(actualOwner)}", status ` +
-        `"${actualStatus}". Re-read the task before retrying. A content-only ` +
-        `task_update persists changes without re-delivering the assignment.`,
+      `Task #${taskId} ${changes.join(' and ')} before this update committed. ` +
+        `Current state is owner "${label(actualOwner)}", status ` +
+        `"${actualStatus}". Re-read the task before retrying.`,
     );
-    this.name = 'TaskOwnerChangedError';
+    this.name = 'TaskSnapshotChangedError';
   }
 }
 
@@ -442,8 +443,8 @@ export async function updateTask(
       }
       const task = JSON.parse(raw) as SwarmTask;
 
-      const checksExpectedOwner = opts && 'expectedOwner' in opts;
-      const checksExpectedStatus = opts && 'expectedStatus' in opts;
+      const checksExpectedOwner = opts !== undefined && 'expectedOwner' in opts;
+      const checksExpectedStatus = opts?.expectedStatus !== undefined;
       if (checksExpectedOwner || checksExpectedStatus) {
         const expectedOwner = opts.expectedOwner
           ? sanitizeName(opts.expectedOwner)
@@ -453,12 +454,14 @@ export async function updateTask(
           (checksExpectedOwner && expectedOwner !== actualOwner) ||
           (checksExpectedStatus && opts.expectedStatus !== task.status)
         ) {
-          throw new TaskOwnerChangedError(
+          throw new TaskSnapshotChangedError(
             taskId,
             expectedOwner,
             actualOwner,
             opts.expectedStatus,
             task.status,
+            checksExpectedOwner,
+            checksExpectedStatus,
           );
         }
       }

--- a/packages/core/src/agents/team/tasks.ts
+++ b/packages/core/src/agents/team/tasks.ts
@@ -358,6 +358,22 @@ export class TaskOwnershipError extends Error {
   }
 }
 
+export class TaskOwnerChangedError extends Error {
+  constructor(
+    readonly taskId: string,
+    readonly expectedOwner: string | undefined,
+    readonly actualOwner: string | undefined,
+  ) {
+    const label = (owner: string | undefined) => owner ?? 'unassigned';
+    super(
+      `Task #${taskId} owner changed from "${label(expectedOwner)}" to ` +
+        `"${label(actualOwner)}" before this assignment committed. ` +
+        'Retry task_update using the current task state.',
+    );
+    this.name = 'TaskOwnerChangedError';
+  }
+}
+
 /**
  * Update fields on an existing task.
  * Uses file locking for safe concurrent updates.
@@ -369,6 +385,11 @@ export class TaskOwnershipError extends Error {
  * inside the lock — without that, two teammates can both pass a
  * pre-lock guard on an unowned task and have the second writer
  * silently overwrite the first one's claim.
+ *
+ * `opts.expectedOwner`, when present, adds an optimistic ownership
+ * check for leader-side assignment. `null` means the caller observed
+ * an unowned task. A stale assignment is rejected inside the same lock
+ * before any fields are changed.
  */
 export async function updateTask(
   teamName: string,
@@ -383,7 +404,7 @@ export async function updateTask(
     addBlocks?: string[];
     addBlockedBy?: string[];
   },
-  opts?: { callerName?: string },
+  opts?: { callerName?: string; expectedOwner?: string | null },
 ): Promise<SwarmTask | undefined> {
   const taskPath = getTaskPath(teamName, taskId);
 
@@ -402,6 +423,16 @@ export async function updateTask(
         throw err;
       }
       const task = JSON.parse(raw) as SwarmTask;
+
+      if (opts && 'expectedOwner' in opts) {
+        const expectedOwner = opts.expectedOwner
+          ? sanitizeName(opts.expectedOwner)
+          : undefined;
+        const actualOwner = task.owner ? sanitizeName(task.owner) : undefined;
+        if (expectedOwner !== actualOwner) {
+          throw new TaskOwnerChangedError(taskId, expectedOwner, actualOwner);
+        }
+      }
 
       if (
         opts?.callerName !== undefined &&

--- a/packages/core/src/tools/task-update.test.ts
+++ b/packages/core/src/tools/task-update.test.ts
@@ -34,10 +34,11 @@ const { __setMockGlobalDir } = (await import('../config/storage.js')) as any;
 let tmpDir: string;
 const TEAM = 'test-team';
 
-function makeConfig(approvalMode = DEFAULT_MODE) {
+function makeConfig(approvalMode = DEFAULT_MODE, teamManager: unknown = null) {
   return {
     getTeamContext: () => ({ teamName: TEAM }),
     getApprovalMode: () => approvalMode,
+    getTeamManager: () => teamManager,
   } as unknown as Config;
 }
 
@@ -208,6 +209,36 @@ describe('TaskUpdateTool', () => {
     expect(result.llmContent).toContain('unowned pending task');
     const reloaded = await getTask(TEAM, task.id);
     expect(reloaded?.status).toBe('completed');
+  });
+
+  it('rejects leader reassignment after dispatching an in-progress task', async () => {
+    const dispatchedOwners: string[] = [];
+    const teamManager = {
+      validateTaskOwner: () => undefined,
+      dispatchAssignedTask: vi.fn(async (task: { owner?: string }) => {
+        if (task.owner) dispatchedOwners.push(task.owner);
+        return true;
+      }),
+    };
+    tool = new TaskUpdateTool(makeConfig(DEFAULT_MODE, teamManager));
+    const task = await createTask(TEAM, {
+      subject: 'Race',
+      description: 'desc',
+    });
+
+    const first = await tool
+      .build({ taskId: task.id, status: 'in_progress', owner: 'alice' })
+      .execute(new AbortController().signal);
+    const second = await tool
+      .build({ taskId: task.id, owner: 'bob' })
+      .execute(new AbortController().signal);
+
+    expect(first.error).toBeUndefined();
+    expect(second.error).toBeDefined();
+    expect(String(second.llmContent)).toContain('already assigned');
+    expect(dispatchedOwners).toEqual(['alice']);
+    const reloaded = await getTask(TEAM, task.id);
+    expect(reloaded?.owner).toBe('alice');
   });
 
   it('validates required taskId', () => {

--- a/packages/core/src/tools/task-update.test.ts
+++ b/packages/core/src/tools/task-update.test.ts
@@ -211,7 +211,7 @@ describe('TaskUpdateTool', () => {
     expect(reloaded?.status).toBe('completed');
   });
 
-  it('rejects leader reassignment after dispatching an in-progress task', async () => {
+  it('lets the leader reassign an in-progress task after dispatch', async () => {
     const dispatchedOwners: string[] = [];
     const teamManager = {
       validateTaskOwner: () => undefined,
@@ -234,11 +234,10 @@ describe('TaskUpdateTool', () => {
       .execute(new AbortController().signal);
 
     expect(first.error).toBeUndefined();
-    expect(second.error).toBeDefined();
-    expect(String(second.llmContent)).toContain('already assigned');
-    expect(dispatchedOwners).toEqual(['alice']);
+    expect(second.error).toBeUndefined();
+    expect(dispatchedOwners).toEqual(['alice', 'bob']);
     const reloaded = await getTask(TEAM, task.id);
-    expect(reloaded?.owner).toBe('alice');
+    expect(reloaded?.owner).toBe('bob');
   });
 
   it('validates required taskId', () => {

--- a/packages/core/src/tools/task-update.test.ts
+++ b/packages/core/src/tools/task-update.test.ts
@@ -315,6 +315,10 @@ describe('TaskUpdateTool', () => {
 
     expect(result.error).toBeDefined();
     expect(result.error?.message).toContain('owner changed');
+    expect(result.error?.message).toContain('content-only task_update');
+    expect(result.error?.message).toContain(
+      'without re-delivering the assignment',
+    );
     expect(dispatchAssignedTask).not.toHaveBeenCalled();
     expect(await getTask(TEAM, task.id)).toMatchObject({
       status: 'in_progress',
@@ -353,6 +357,41 @@ describe('TaskUpdateTool', () => {
     expect(dispatchAssignedTask).not.toHaveBeenCalled();
     expect(await getTask(TEAM, task.id)).toMatchObject({
       status: 'completed',
+      owner: 'alice',
+    });
+  });
+
+  it('rejects a status-only update from a stale snapshot', async () => {
+    const dispatchAssignedTask = vi.fn(async () => true);
+    const teamManager = {
+      validateTaskOwner: vi.fn(() => undefined),
+      dispatchAssignedTask,
+    };
+    tool = new TaskUpdateTool(makeConfig(DEFAULT_MODE, teamManager));
+    const task = await createTask(TEAM, {
+      subject: 'Pending',
+      description: 'desc',
+    });
+    taskUpdateMock.beforeUpdate = async (realUpdateTask) => {
+      await realUpdateTask(
+        TEAM,
+        task.id,
+        { status: 'in_progress', owner: 'alice' },
+        { callerName: 'alice' },
+      );
+    };
+
+    const result = await tool
+      .build({ taskId: task.id, status: 'completed' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain('owner changed');
+    expect(result.error?.message).toContain('status changed');
+    expect(result.error?.message).not.toContain('without re-delivering');
+    expect(dispatchAssignedTask).not.toHaveBeenCalled();
+    expect(await getTask(TEAM, task.id)).toMatchObject({
+      status: 'in_progress',
       owner: 'alice',
     });
   });

--- a/packages/core/src/tools/task-update.test.ts
+++ b/packages/core/src/tools/task-update.test.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { TaskUpdateTool } from './task-update.js';
-import { createTask, getTask } from '../agents/team/tasks.js';
+import { createTask, getTask, updateTask } from '../agents/team/tasks.js';
 import type { ApprovalMode, Config } from '../config/config.js';
 import { runWithTeammateIdentity } from '../agents/team/identity.js';
 
@@ -34,10 +34,11 @@ const { __setMockGlobalDir } = (await import('../config/storage.js')) as any;
 let tmpDir: string;
 const TEAM = 'test-team';
 
-function makeConfig(approvalMode = DEFAULT_MODE) {
+function makeConfig(approvalMode = DEFAULT_MODE, teamManager: unknown = null) {
   return {
     getTeamContext: () => ({ teamName: TEAM }),
     getApprovalMode: () => approvalMode,
+    getTeamManager: () => teamManager,
   } as unknown as Config;
 }
 
@@ -208,6 +209,60 @@ describe('TaskUpdateTool', () => {
     expect(result.llmContent).toContain('unowned pending task');
     const reloaded = await getTask(TEAM, task.id);
     expect(reloaded?.status).toBe('completed');
+  });
+
+  it('rejects reassignment while the current owner is active', async () => {
+    const dispatchedOwners: string[] = [];
+    const teamManager = {
+      validateTaskOwner: () => undefined,
+      dispatchAssignedTask: vi.fn(async (task: { owner?: string }) => {
+        if (task.owner) dispatchedOwners.push(task.owner);
+        return true;
+      }),
+    };
+    tool = new TaskUpdateTool(makeConfig(DEFAULT_MODE, teamManager));
+    const task = await createTask(TEAM, {
+      subject: 'Assigned',
+      description: 'desc',
+      owner: 'alice',
+    });
+    await updateTask(TEAM, task.id, { status: 'in_progress' });
+
+    const result = await tool
+      .build({ taskId: task.id, owner: 'bob' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(String(result.llmContent)).toContain('still active');
+    expect(dispatchedOwners).toEqual([]);
+    expect((await getTask(TEAM, task.id))?.owner).toBe('alice');
+  });
+
+  it('allows reassignment after the current owner becomes inactive', async () => {
+    const dispatchedOwners: string[] = [];
+    const teamManager = {
+      validateTaskOwner: (owner: string) =>
+        owner === 'alice' ? 'alice is inactive' : undefined,
+      dispatchAssignedTask: vi.fn(async (task: { owner?: string }) => {
+        if (task.owner) dispatchedOwners.push(task.owner);
+        return true;
+      }),
+    };
+    tool = new TaskUpdateTool(makeConfig(DEFAULT_MODE, teamManager));
+    const task = await createTask(TEAM, {
+      subject: 'Recovery',
+      description: 'desc',
+      owner: 'alice',
+    });
+    await updateTask(TEAM, task.id, { status: 'in_progress' });
+
+    const result = await tool
+      .build({ taskId: task.id, owner: 'bob' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(dispatchedOwners).toEqual(['bob']);
+    expect((await getTask(TEAM, task.id))?.owner).toBe('bob');
   });
 
   it('validates required taskId', () => {

--- a/packages/core/src/tools/task-update.test.ts
+++ b/packages/core/src/tools/task-update.test.ts
@@ -13,6 +13,28 @@ import { createTask, getTask, updateTask } from '../agents/team/tasks.js';
 import type { ApprovalMode, Config } from '../config/config.js';
 import { runWithTeammateIdentity } from '../agents/team/identity.js';
 
+type UpdateTask = (typeof import('../agents/team/tasks.js'))['updateTask'];
+
+const taskUpdateMock = vi.hoisted(() => ({
+  beforeUpdate: undefined as
+    | ((updateTask: UpdateTask) => Promise<void>)
+    | undefined,
+}));
+
+vi.mock('../agents/team/tasks.js', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('../agents/team/tasks.js')>();
+  return {
+    ...original,
+    updateTask: async (...args: Parameters<UpdateTask>) => {
+      const beforeUpdate = taskUpdateMock.beforeUpdate;
+      taskUpdateMock.beforeUpdate = undefined;
+      if (beforeUpdate) await beforeUpdate(original.updateTask);
+      return original.updateTask(...args);
+    },
+  };
+});
+
 const DEFAULT_MODE = 'default' as ApprovalMode;
 const PLAN_MODE = 'plan' as ApprovalMode;
 
@@ -48,6 +70,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  taskUpdateMock.beforeUpdate = undefined;
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -237,11 +260,11 @@ describe('TaskUpdateTool', () => {
     expect((await getTask(TEAM, task.id))?.owner).toBe('bob');
   });
 
-  it('allows reassignment after the current owner becomes inactive', async () => {
+  it('reassigns without consulting the previous owner activity', async () => {
     const dispatchedOwners: string[] = [];
+    const validateTaskOwner = vi.fn(() => undefined);
     const teamManager = {
-      validateTaskOwner: (owner: string) =>
-        owner === 'alice' ? 'alice is inactive' : undefined,
+      validateTaskOwner,
       dispatchAssignedTask: vi.fn(async (task: { owner?: string }) => {
         if (task.owner) dispatchedOwners.push(task.owner);
         return true;
@@ -260,8 +283,111 @@ describe('TaskUpdateTool', () => {
       .execute(new AbortController().signal);
 
     expect(result.error).toBeUndefined();
+    expect(validateTaskOwner).toHaveBeenCalledWith('bob');
+    expect(validateTaskOwner).not.toHaveBeenCalledWith('alice');
     expect(dispatchedOwners).toEqual(['bob']);
     expect((await getTask(TEAM, task.id))?.owner).toBe('bob');
+  });
+
+  it('rejects an owner update from a stale unowned snapshot', async () => {
+    const dispatchAssignedTask = vi.fn(async () => true);
+    const teamManager = {
+      validateTaskOwner: vi.fn(() => undefined),
+      dispatchAssignedTask,
+    };
+    tool = new TaskUpdateTool(makeConfig(DEFAULT_MODE, teamManager));
+    const task = await createTask(TEAM, {
+      subject: 'Pending',
+      description: 'desc',
+    });
+    taskUpdateMock.beforeUpdate = async (realUpdateTask) => {
+      await realUpdateTask(
+        TEAM,
+        task.id,
+        { status: 'in_progress', owner: 'alice' },
+        { callerName: 'alice' },
+      );
+    };
+
+    const result = await tool
+      .build({ taskId: task.id, owner: 'bob' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain('owner changed');
+    expect(dispatchAssignedTask).not.toHaveBeenCalled();
+    expect(await getTask(TEAM, task.id)).toMatchObject({
+      status: 'in_progress',
+      owner: 'alice',
+    });
+  });
+
+  it('rejects an assignment from a stale status snapshot', async () => {
+    const dispatchAssignedTask = vi.fn(async () => true);
+    const teamManager = {
+      validateTaskOwner: vi.fn(() => undefined),
+      dispatchAssignedTask,
+    };
+    tool = new TaskUpdateTool(makeConfig(DEFAULT_MODE, teamManager));
+    const task = await createTask(TEAM, {
+      subject: 'Assigned',
+      description: 'desc',
+      owner: 'alice',
+    });
+    await updateTask(TEAM, task.id, { status: 'in_progress' });
+    taskUpdateMock.beforeUpdate = async (realUpdateTask) => {
+      await realUpdateTask(
+        TEAM,
+        task.id,
+        { status: 'completed' },
+        { callerName: 'alice' },
+      );
+    };
+
+    const result = await tool
+      .build({ taskId: task.id, status: 'in_progress', owner: 'bob' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toContain('status changed');
+    expect(dispatchAssignedTask).not.toHaveBeenCalled();
+    expect(await getTask(TEAM, task.id)).toMatchObject({
+      status: 'completed',
+      owner: 'alice',
+    });
+  });
+
+  it('does not dispatch during a stale content-only update', async () => {
+    const dispatchAssignedTask = vi.fn(async () => true);
+    const teamManager = {
+      validateTaskOwner: vi.fn(() => undefined),
+      dispatchAssignedTask,
+    };
+    tool = new TaskUpdateTool(makeConfig(DEFAULT_MODE, teamManager));
+    const task = await createTask(TEAM, {
+      subject: 'Pending',
+      description: 'desc',
+    });
+    taskUpdateMock.beforeUpdate = async (realUpdateTask) => {
+      await realUpdateTask(
+        TEAM,
+        task.id,
+        { status: 'in_progress', owner: 'alice' },
+        { callerName: 'alice' },
+      );
+    };
+
+    const result = await tool
+      .build({ taskId: task.id, subject: 'New title' })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(dispatchAssignedTask).not.toHaveBeenCalled();
+    expect(await getTask(TEAM, task.id)).toMatchObject({
+      subject: 'New title',
+      status: 'in_progress',
+      owner: 'alice',
+    });
   });
 
   it('validates required taskId', () => {

--- a/packages/core/src/tools/task-update.test.ts
+++ b/packages/core/src/tools/task-update.test.ts
@@ -211,7 +211,7 @@ describe('TaskUpdateTool', () => {
     expect(reloaded?.status).toBe('completed');
   });
 
-  it('rejects reassignment while the current owner is active', async () => {
+  it('allows sequential reassignment while the current owner is active', async () => {
     const dispatchedOwners: string[] = [];
     const teamManager = {
       validateTaskOwner: () => undefined,
@@ -232,10 +232,9 @@ describe('TaskUpdateTool', () => {
       .build({ taskId: task.id, owner: 'bob' })
       .execute(new AbortController().signal);
 
-    expect(result.error).toBeDefined();
-    expect(String(result.llmContent)).toContain('still active');
-    expect(dispatchedOwners).toEqual([]);
-    expect((await getTask(TEAM, task.id))?.owner).toBe('alice');
+    expect(result.error).toBeUndefined();
+    expect(dispatchedOwners).toEqual(['bob']);
+    expect((await getTask(TEAM, task.id))?.owner).toBe('bob');
   });
 
   it('allows reassignment after the current owner becomes inactive', async () => {

--- a/packages/core/src/tools/task-update.ts
+++ b/packages/core/src/tools/task-update.ts
@@ -444,6 +444,23 @@ class TaskUpdateInvocation extends BaseToolInvocation<
       existing?.status !== 'in_progress';
     const ownerChanged =
       explicitOwner !== undefined && explicitOwner !== existingOwner;
+    if (
+      existing.status === 'in_progress' &&
+      existingOwner &&
+      existingOwner !== LEADER_NAME &&
+      explicitOwner &&
+      explicitOwner !== existingOwner
+    ) {
+      const msg =
+        `Cannot assign task #${taskId} to "${explicitOwner}": ` +
+        `it is already assigned to "${existingOwner}". ` +
+        `Complete or unassign the task before assigning it to another teammate.`;
+      return {
+        llmContent: msg,
+        returnDisplay: msg,
+        error: { message: msg },
+      };
+    }
     const nextBlockedBy = new Set(existing?.blockedBy ?? []);
     for (const blockedBy of this.params.addBlockedBy ?? []) {
       nextBlockedBy.add(blockedBy);

--- a/packages/core/src/tools/task-update.ts
+++ b/packages/core/src/tools/task-update.ts
@@ -444,23 +444,6 @@ class TaskUpdateInvocation extends BaseToolInvocation<
       existing?.status !== 'in_progress';
     const ownerChanged =
       explicitOwner !== undefined && explicitOwner !== existingOwner;
-    if (
-      existing.status === 'in_progress' &&
-      existingOwner &&
-      existingOwner !== LEADER_NAME &&
-      explicitOwner &&
-      explicitOwner !== existingOwner
-    ) {
-      const msg =
-        `Cannot assign task #${taskId} to "${explicitOwner}": ` +
-        `it is already assigned to "${existingOwner}". ` +
-        `Complete or unassign the task before assigning it to another teammate.`;
-      return {
-        llmContent: msg,
-        returnDisplay: msg,
-        error: { message: msg },
-      };
-    }
     const nextBlockedBy = new Set(existing?.blockedBy ?? []);
     for (const blockedBy of this.params.addBlockedBy ?? []) {
       nextBlockedBy.add(blockedBy);

--- a/packages/core/src/tools/task-update.ts
+++ b/packages/core/src/tools/task-update.ts
@@ -36,7 +36,7 @@ import {
   getTask,
   listTasks,
   TaskOwnershipError,
-  TaskOwnerChangedError,
+  TaskSnapshotChangedError,
   RECIPROCAL_CALLER,
 } from '../agents/team/tasks.js';
 import { LEADER_NAME, type SwarmTask } from '../agents/team/types.js';
@@ -506,12 +506,18 @@ class TaskUpdateInvocation extends BaseToolInvocation<
     } catch (err) {
       if (
         err instanceof TaskOwnershipError ||
-        err instanceof TaskOwnerChangedError
+        err instanceof TaskSnapshotChangedError
       ) {
+        const dispatchHint =
+          err instanceof TaskSnapshotChangedError && explicitOwner !== undefined
+            ? ' A content-only task_update persists changes without ' +
+              're-delivering the assignment.'
+            : '';
+        const message = err.message + dispatchHint;
         return {
-          llmContent: err.message,
-          returnDisplay: err.message,
-          error: { message: err.message },
+          llmContent: message,
+          returnDisplay: message,
+          error: { message },
         };
       }
       throw err;

--- a/packages/core/src/tools/task-update.ts
+++ b/packages/core/src/tools/task-update.ts
@@ -482,8 +482,11 @@ class TaskUpdateInvocation extends BaseToolInvocation<
       const updateOptions =
         teammateCallerName !== undefined
           ? { callerName: teammateCallerName }
-          : shouldDispatchAssignment
-            ? { expectedOwner: existingOwner ?? null }
+          : explicitOwner !== undefined || this.params.status !== undefined
+            ? {
+                expectedOwner: existingOwner ?? null,
+                expectedStatus: existing.status,
+              }
             : undefined;
       task = await updateTask(
         teamName,
@@ -555,6 +558,7 @@ class TaskUpdateInvocation extends BaseToolInvocation<
       // sees the task on its next task_list (no notification path).
       persistedOwner !== LEADER_NAME &&
       persistedOwner !== teammateCallerName &&
+      (explicitOwner !== undefined || this.params.status !== undefined) &&
       (persistedOwner !== existingOwner || statusBecameInProgress)
     ) {
       const dispatched = await teamManager.dispatchAssignedTask(task);

--- a/packages/core/src/tools/task-update.ts
+++ b/packages/core/src/tools/task-update.ts
@@ -36,6 +36,7 @@ import {
   getTask,
   listTasks,
   TaskOwnershipError,
+  TaskOwnerChangedError,
   RECIPROCAL_CALLER,
 } from '../agents/team/tasks.js';
 import { LEADER_NAME, type SwarmTask } from '../agents/team/types.js';
@@ -474,10 +475,33 @@ class TaskUpdateInvocation extends BaseToolInvocation<
           error: { message: refusal },
         };
       }
+      if (
+        existing.status === 'in_progress' &&
+        existingOwner &&
+        existingOwner !== LEADER_NAME &&
+        ownerChanged &&
+        teamManager.validateTaskOwner(existingOwner) === undefined
+      ) {
+        const msg =
+          `Cannot reassign task #${taskId} from "${existingOwner}" while ` +
+          `that teammate is still active. Shut down or release the current ` +
+          `owner before assigning "${explicitOwner}".`;
+        return {
+          llmContent: msg,
+          returnDisplay: msg,
+          error: { message: msg },
+        };
+      }
     }
 
     let task;
     try {
+      const updateOptions =
+        teammateCallerName !== undefined
+          ? { callerName: teammateCallerName }
+          : shouldDispatchAssignment
+            ? { expectedOwner: existingOwner ?? null }
+            : undefined;
       task = await updateTask(
         teamName,
         taskId,
@@ -491,12 +515,13 @@ class TaskUpdateInvocation extends BaseToolInvocation<
           addBlocks: this.params.addBlocks,
           addBlockedBy: this.params.addBlockedBy,
         },
-        teammateCallerName !== undefined
-          ? { callerName: teammateCallerName }
-          : undefined,
+        updateOptions,
       );
     } catch (err) {
-      if (err instanceof TaskOwnershipError) {
+      if (
+        err instanceof TaskOwnershipError ||
+        err instanceof TaskOwnerChangedError
+      ) {
         return {
           llmContent: err.message,
           returnDisplay: err.message,

--- a/packages/core/src/tools/task-update.ts
+++ b/packages/core/src/tools/task-update.ts
@@ -475,23 +475,6 @@ class TaskUpdateInvocation extends BaseToolInvocation<
           error: { message: refusal },
         };
       }
-      if (
-        existing.status === 'in_progress' &&
-        existingOwner &&
-        existingOwner !== LEADER_NAME &&
-        ownerChanged &&
-        teamManager.validateTaskOwner(existingOwner) === undefined
-      ) {
-        const msg =
-          `Cannot reassign task #${taskId} from "${existingOwner}" while ` +
-          `that teammate is still active. Shut down or release the current ` +
-          `owner before assigning "${explicitOwner}".`;
-        return {
-          llmContent: msg,
-          returnDisplay: msg,
-          error: { message: msg },
-        };
-      }
     }
 
     let task;


### PR DESCRIPTION
## What this PR does

Prevents stale concurrent leader assignments from dispatching one task to multiple teammates. Leader assignments carry the owner observed before the update and verify it while holding the task lock, so only one assignment from the same stale snapshot can commit. Intentional sequential reassignment remains supported and dispatches the task once to the newly committed owner.

## Why it's needed

Fixes #10207. Previously, concurrent leader updates could both read the same owner, persist different owners in sequence, and each dispatch its own snapshot. The fix closes that stale-write race without breaking the existing recovery and manual reassignment workflow.

## Reviewer Test Plan

### How to verify

1. Run the task persistence, `task_update`, and coordination harness suites.
2. Confirm two concurrent assignments that both observed an unowned task produce one successful update and one `TaskOwnerChangedError`.
3. Confirm an intentional sequential reassignment from `alice` to `bob` succeeds, persists `bob`, and dispatches once to `bob`.
4. Confirm reassignment after an inactive owner also remains supported.
5. Run core lint, the full repository build, and the full repository typecheck.

### Evidence (Before & After)

Before: two leader assignments from the same stale owner snapshot could both commit and dispatch. After: exactly one stale concurrent assignment succeeds and the other returns a retryable owner-changed error. The existing sequential reassignment contract remains green. The focused persistence, tool, and coordination suites report 165 passing tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js monorepo dependencies installed with `npm ci`; validation used Vitest, ESLint, the repository build, and TypeScript typecheck.

## Risk & Scope

- Main risk or tradeoff: leader-side task ownership changes now use optimistic owner validation, so a stale update returns a retryable error instead of overwriting a newer owner.
- Not validated / out of scope: Windows and Linux were not tested locally; CI covers the applicable Linux profile. This change does not alter teammate lifecycle or queue internals.
- Breaking changes / migration notes: none. Intentional sequential reassignment remains supported.

## Linked Issues

Fixes #10207

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

防止基于陈旧状态的并发 leader 分配把同一个任务派发给多个 teammate。leader 分配任务时会携带更新前观察到的 owner，并在持有任务锁期间校验，因此基于同一陈旧快照的多个分配中只有一个能够提交。有意进行的顺序改派仍然受支持，并且只会向新提交的 owner 派发一次。

## 为什么需要

修复 #10207。此前，并发的 leader 更新可能读取到同一个 owner，依次写入不同 owner，并分别派发各自的任务快照。本修复关闭陈旧写入竞态，同时保留已有的恢复性改派和手动改派流程。

## Reviewer 测试计划

### 如何验证

1. 运行 task persistence、`task_update` 和 coordination harness 测试。
2. 确认两个都观察到任务未分配的并发分配中，一个更新成功，另一个抛出 `TaskOwnerChangedError`。
3. 确认从 `alice` 到 `bob` 的有意顺序改派成功，持久化 owner 为 `bob`，并且只向 `bob` 派发一次。
4. 确认旧 owner 失活后的恢复性改派仍然可用。
5. 运行 core lint、全仓 build 和全仓 TypeScript typecheck。

### 前后证据

修复前：基于同一个陈旧 owner 快照的两个 leader 分配都可能提交并派发。修复后：陈旧并发分配中恰好一个成功，另一个返回可重试的 owner-changed 错误；已有的顺序改派契约保持通过。task persistence、工具层和 coordination 定向测试共 165 项通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

使用 `npm ci` 安装 Node.js monorepo 依赖；验证使用 Vitest、ESLint、仓库 build 和 TypeScript typecheck。

## 风险与范围

- 主要风险或权衡：leader 修改任务 owner 时现在使用乐观 owner 校验，因此陈旧更新会返回可重试错误，而不是覆盖较新的 owner。
- 未验证或范围外：本地未测试 Windows 和 Linux；适用的 Linux profile 由 CI 覆盖。本改动不修改 teammate 生命周期或队列内部实现。
- 破坏性变更或迁移说明：无。有意进行的顺序改派仍然受支持。

## 关联 Issue

Fixes #10207

</details>