### PR TITLE
fix(core): remove duplicate telemetry test registry stub

### DIFF
--- a/packages/core/src/core/client.telemetrySwap.test.ts
+++ b/packages/core/src/core/client.telemetrySwap.test.ts
@@ -89,9 +89,6 @@ function makeEnv() {
   const config: any = {
     getSessionId: () => sessionId,
     getResumedSessionData: () => resumedData,
-    // initialize() on a resumed session asks the skill tool to restore its
-    // loaded skills via config.getToolRegistry().getTool(...).
-    getToolRegistry: () => ({ getTool: () => undefined }),
     swap(id: string, data?: ResumedSessionData) {
       sessionId = id;
       resumedData = data;


### PR DESCRIPTION
## Summary
- Remove the duplicate `getToolRegistry` property from `client.telemetrySwap.test.ts`'s minimal Config double.
- Keep the fuller documented stub so resumed-session initialization can still call `restoreLoadedSkillsFromHistory` without touching a real skill registry.

## Validation
- RED: `npm run typecheck --workspace packages/core` failed with `TS1117: An object literal cannot have multiple properties with the same name` before the fix.
- GREEN: `npm run typecheck --workspace packages/core`
- GREEN: `npm run build --workspace packages/core && npm run test --workspace packages/core -- src/core/client.telemetrySwap.test.ts --pool threads --maxWorkers 1`

Closes #10205