### PR TITLE
fix(web-shell): keep reasoning effort controls available

### DIFF
--- a/docs/design/webshell-qwen38-reasoning-config.md
+++ b/docs/design/webshell-qwen38-reasoning-config.md
@@ -63,11 +63,30 @@ Reading the manifest alone does not inject a default into generation
 configuration, so sessions that never change the controls retain main's
 existing wire behavior.
 
-If the live session already carries a generic effort outside the manifest
-(`high` or `max`), ACP preserves that value through its existing generic
-option and WebShell hides the model-specific controls. This avoids displaying
-an inaccurate tier or changing live configuration merely by opening the
-popover.
+If the live session inherits a generic effort outside the manifest (`high` or
+`max`), ACP projects its documented effective alias, `xhigh`, through the
+registered model-specific choices. The controls stay available instead of
+disappearing after session creation. DashScope likewise maps `minimal` to
+`low`; a static `thinking_budget` maps to `low` at 0–4096 tokens, `medium` at
+4097–16384, and `xhigh` at 16385–262144, following the
+[OpenAI-compatible Qwen API](https://help.aliyun.com/zh/model-studio/qwen-api-via-openai-chat-completions).
+
+If a static DashScope thinking field currently overrides the unified setting,
+ACP projects its effective off state or effort alias through the same controls.
+Selecting a model-specific value removes only the competing thinking fields
+from copied request-parameter maps, preserves both the original shared maps
+and unrelated request parameters, and applies the selected value. This keeps
+the control truthful instead of acknowledging a choice that a higher-priority
+field would silently shadow.
+
+When the active model requires thinking, ACP omits `none` from the option and
+marks that constraint in metadata. WebShell keeps the Thinking switch checked
+and disabled while leaving every supported effort selectable. An unmarked
+generic option without `none` remains incompatible and hidden. Workspace
+previews resolve this constraint from the selected provider-model entry, so the
+same behavior is available before lazy session creation. A stale welcome
+Thinking-off intent is discarded if refreshed model metadata makes thinking
+mandatory before the first prompt.
 
 The daemon exposes one owner-routed config-option mutation. Its public route is
 restricted to `reasoning_effort`; the response carries fresh `configOptions`,
@@ -84,6 +103,7 @@ Included:
   prompt;
 - authoritative replacement by same-session context;
 - the current WebShell conversation;
+- effort changes after completed messages and while a prompt is running;
 - Thinking on/off and `low`, `medium`, `xhigh` effort;
 - browser coverage for welcome, live override, model switching, old daemons,
   and the existing live mutation behavior.

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4043,9 +4043,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getModes: vi.fn().mockReturnValue([]),
       getApprovalMode: vi.fn().mockReturnValue('default'),
       getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      getReasoningEffortOverride: vi.fn().mockReturnValue(undefined),
       setReasoningEffort: vi.fn(),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),
       getAuthType: vi.fn().mockReturnValue('api-key'),
+      getCurrentModelRegistryBaseUrl: vi.fn().mockReturnValue(undefined),
       getAllConfiguredModels: vi.fn().mockReturnValue([]),
       getGeminiClient: vi.fn().mockReturnValue({
         isInitialized: vi.fn().mockReturnValue(true),
@@ -7646,6 +7648,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getAuthType: vi.fn().mockReturnValue('qwen'),
       getActiveRuntimeModelSnapshot: vi.fn().mockReturnValue(undefined),
       getModel: vi.fn().mockReturnValue('qwen3.8-max'),
+      getResolvedModelConfig: vi.fn((authType: string, modelId: string) =>
+        authType === 'qwen' && modelId === 'qwen3.8-max'
+          ? { generationConfig: { thinkingMandatory: true } }
+          : undefined,
+      ),
       getAllConfiguredModels: vi.fn().mockReturnValue([
         {
           id: 'qwen3.8-max',
@@ -7714,12 +7721,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       {
         id: 'reasoning_effort',
         currentValue: 'xhigh',
-        options: [
-          { value: 'none' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'xhigh' },
-        ],
+        options: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
+        _meta: {
+          'qwenCode/reasoning': {
+            defaultEffort: 'xhigh',
+            thinkingMandatory: true,
+          },
+        },
       },
     ]);
     expect(
@@ -7943,19 +7951,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         session.configOptions.filter((item) => item.id === 'effort'),
       ).toEqual([]);
       expect(option).toMatchObject({
-        currentValue: 'high',
-      });
-      expect(option?.options.map(({ value }) => value)).not.toContain('none');
-
-      const reset = (await agent.setSessionConfigOption({
-        sessionId,
-        configId: 'reasoning_effort',
-        value: 'default',
-      })) as SetSessionConfigOptionResponse;
-      expect(innerConfig.setReasoningEffort).toHaveBeenCalledWith(undefined);
-      expect(
-        reset.configOptions.find((item) => item.id === 'reasoning_effort'),
-      ).toMatchObject({
         currentValue: 'xhigh',
         options: [
           { value: 'none' },
@@ -8008,6 +8003,291 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         'Unknown reasoning effort: high. Choose one of: none, low, medium, xhigh',
       );
       expect(generation.reasoning).toEqual({ effort: 'medium' });
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it('makes qwen3.8-max effort mutable over a static request override', async () => {
+    const sessionId = 'qwen38-static-reasoning-override';
+    const innerConfig = await setupSessionMocks(sessionId);
+    const generation: {
+      reasoning?: false | { effort?: string };
+      samplingParams?: Record<string, unknown>;
+    } = {
+      reasoning: false,
+      samplingParams: { reasoning_effort: 'high' },
+    };
+    innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+    innerConfig.getContentGeneratorConfig = vi.fn(() => generation);
+    innerConfig.getReasoningEffort = vi.fn(() =>
+      generation.reasoning ? generation.reasoning.effort : undefined,
+    );
+    innerConfig.getReasoningEffortOverride = vi.fn(() =>
+      generation.samplingParams?.['reasoning_effort'] === undefined
+        ? undefined
+        : {
+            source: 'samplingParams' as const,
+            field: 'reasoning_effort' as const,
+          },
+    );
+
+    const { agent, agentPromise } = await bootAcpAgent();
+    try {
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+      })) as SetSessionConfigOptionResponse;
+      expect(
+        session.configOptions.find((item) => item.id === 'reasoning_effort'),
+      ).toMatchObject({
+        currentValue: 'none',
+        options: [
+          { value: 'none' },
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'xhigh' },
+        ],
+      });
+
+      const selected = (await agent.setSessionConfigOption({
+        sessionId,
+        configId: 'reasoning_effort',
+        value: 'medium',
+      })) as SetSessionConfigOptionResponse;
+      expect(generation.samplingParams).toEqual({});
+      expect(generation.reasoning).toEqual({ effort: 'medium' });
+      expect(
+        selected.configOptions.find((item) => item.id === 'reasoning_effort')
+          ?.currentValue,
+      ).toBe('medium');
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it.each([
+    [false, 'none'],
+    [true, 'medium'],
+  ] as const)(
+    'projects a static budget over unified thinking disable with mandatory=%s as %s',
+    async (thinkingMandatory, expectedValue) => {
+      const sessionId = `qwen38-disabled-budget-${thinkingMandatory}`;
+      const innerConfig = await setupSessionMocks(sessionId);
+      const generation: {
+        thinkingMandatory?: true;
+        reasoning: false;
+        samplingParams: Record<string, unknown>;
+      } = {
+        ...(thinkingMandatory ? { thinkingMandatory: true as const } : {}),
+        reasoning: false,
+        samplingParams: { thinking_budget: 4097 },
+      };
+      innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+      innerConfig.getContentGeneratorConfig = vi.fn(() => generation);
+      innerConfig.getReasoningEffort = vi.fn().mockReturnValue(undefined);
+      innerConfig.getReasoningEffortOverride = vi.fn(() => ({
+        source: 'samplingParams' as const,
+        field: 'thinking_budget' as const,
+      }));
+
+      const { agent, agentPromise } = await bootAcpAgent();
+      try {
+        const session = (await agent.newSession({
+          cwd: '/tmp',
+          mcpServers: [],
+        })) as SetSessionConfigOptionResponse;
+        expect(
+          session.configOptions.find((item) => item.id === 'reasoning_effort')
+            ?.currentValue,
+        ).toBe(expectedValue);
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    },
+  );
+
+  it('re-enables qwen3.8-max after a static thinking disable', async () => {
+    const sessionId = 'qwen38-static-thinking-disable';
+    const innerConfig = await setupSessionMocks(sessionId);
+    const extraBody = { enable_thinking: false, seed: 7 };
+    const samplingParams = { thinking_budget: 2048, temperature: 0.2 };
+    const generation: {
+      reasoning?: false | { effort?: string };
+      extra_body?: Record<string, unknown>;
+      samplingParams?: Record<string, unknown>;
+    } = {
+      reasoning: { effort: 'low' },
+      extra_body: extraBody,
+      samplingParams,
+    };
+    innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+    innerConfig.getContentGeneratorConfig = vi.fn(() => generation);
+    innerConfig.getReasoningEffort = vi.fn(() =>
+      generation.reasoning ? generation.reasoning.effort : undefined,
+    );
+    innerConfig.getReasoningEffortOverride = vi.fn(() =>
+      generation.extra_body?.['enable_thinking'] === false
+        ? {
+            source: 'extra_body' as const,
+            field: 'enable_thinking' as const,
+          }
+        : generation.samplingParams?.['thinking_budget'] !== undefined
+          ? {
+              source: 'samplingParams' as const,
+              field: 'thinking_budget' as const,
+            }
+          : undefined,
+    );
+
+    const { agent, agentPromise } = await bootAcpAgent();
+    try {
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+      })) as SetSessionConfigOptionResponse;
+      expect(
+        session.configOptions.find((item) => item.id === 'reasoning_effort'),
+      ).toMatchObject({
+        currentValue: 'none',
+        options: [
+          { value: 'none' },
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'xhigh' },
+        ],
+      });
+
+      const selected = (await agent.setSessionConfigOption({
+        sessionId,
+        configId: 'reasoning_effort',
+        value: 'xhigh',
+      })) as SetSessionConfigOptionResponse;
+      expect(generation.extra_body).toEqual({ seed: 7 });
+      expect(generation.samplingParams).toEqual({ temperature: 0.2 });
+      expect(generation.extra_body).not.toBe(extraBody);
+      expect(generation.samplingParams).not.toBe(samplingParams);
+      expect(extraBody).toEqual({ enable_thinking: false, seed: 7 });
+      expect(samplingParams).toEqual({
+        thinking_budget: 2048,
+        temperature: 0.2,
+      });
+      expect(generation.reasoning).toEqual({ effort: 'xhigh' });
+      expect(
+        selected.configOptions.find((item) => item.id === 'reasoning_effort')
+          ?.currentValue,
+      ).toBe('xhigh');
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it.each([
+    [4096, 'low'],
+    [4097, 'medium'],
+    [16384, 'medium'],
+    [16385, 'xhigh'],
+  ] as const)(
+    'projects a static qwen3.8-max thinking budget of %i as %s',
+    async (thinkingBudget, expectedEffort) => {
+      const sessionId = `qwen38-static-thinking-budget-${thinkingBudget}`;
+      const innerConfig = await setupSessionMocks(sessionId);
+      const generation: {
+        reasoning?: false | { effort?: string };
+        samplingParams?: Record<string, unknown>;
+      } = {
+        samplingParams: { thinking_budget: thinkingBudget },
+      };
+      innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+      innerConfig.getContentGeneratorConfig = vi.fn(() => generation);
+      innerConfig.getReasoningEffort = vi.fn(() =>
+        generation.reasoning ? generation.reasoning.effort : undefined,
+      );
+      innerConfig.getReasoningEffortOverride = vi.fn(() => ({
+        source: 'samplingParams' as const,
+        field: 'thinking_budget' as const,
+      }));
+
+      const { agent, agentPromise } = await bootAcpAgent();
+      try {
+        const session = (await agent.newSession({
+          cwd: '/tmp',
+          mcpServers: [],
+        })) as SetSessionConfigOptionResponse;
+        expect(
+          session.configOptions.find((item) => item.id === 'reasoning_effort')
+            ?.currentValue,
+        ).toBe(expectedEffort);
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    },
+  );
+
+  it('does not project qwen3.8 controls onto an opaque model route', async () => {
+    const sessionId = 'qwen38-opaque-route-reasoning';
+    const innerConfig = await setupSessionMocks(sessionId);
+    let currentEffort: string | undefined;
+    innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+    innerConfig.getAuthType = vi.fn().mockReturnValue('openai');
+    innerConfig.getCurrentModelRegistryBaseUrl = vi
+      .fn()
+      .mockReturnValue('https://one.example/v1');
+    innerConfig.getAllConfiguredModels = vi.fn().mockReturnValue([
+      {
+        id: 'qwen3.8-max',
+        label: 'Qwen 3.8 Max One',
+        authType: 'openai',
+        baseUrl: 'https://one.example/v1',
+        registryBaseUrl: 'https://one.example/v1',
+      },
+      {
+        id: 'qwen3.8-max',
+        label: 'Qwen 3.8 Max Two',
+        authType: 'openai',
+        baseUrl: 'https://two.example/v1',
+        registryBaseUrl: 'https://two.example/v1',
+      },
+    ]);
+    innerConfig.getReasoningEffort = vi.fn(() => currentEffort);
+    innerConfig.setReasoningEffort = vi.fn((effort: string | undefined) => {
+      currentEffort = effort;
+    });
+
+    const { agent, agentPromise } = await bootAcpAgent();
+    try {
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+      })) as SetSessionConfigOptionResponse;
+      expect(
+        session.configOptions.find((item) => item.id === 'model')?.currentValue,
+      ).toMatch(/^qwen-route:v1:/);
+      expect(
+        session.configOptions.find((item) => item.id === 'reasoning_effort'),
+      ).toMatchObject({
+        currentValue: 'default',
+        options: [
+          { value: 'default' },
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+          { value: 'max' },
+        ],
+      });
+
+      await agent.setSessionConfigOption({
+        sessionId,
+        configId: 'reasoning_effort',
+        value: 'medium',
+      });
+      expect(innerConfig.setReasoningEffort).toHaveBeenCalledWith('medium');
     } finally {
       mockConnectionState.resolve();
       await agentPromise;
@@ -8087,7 +8367,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
-  it('hides qwen3.8-max reasoning controls when thinking is mandatory', async () => {
+  it('keeps qwen3.8-max effort controls when thinking is mandatory', async () => {
     const sessionId = 'qwen38-mandatory-thinking-session';
     const innerConfig = await setupSessionMocks(sessionId);
     const generation = {
@@ -8113,8 +8393,27 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       const option = session.configOptions.find(
         (item) => item.id === 'reasoning_effort',
       );
-      expect(option?.currentValue).toBe('medium');
-      expect(option?.options.map(({ value }) => value)).not.toContain('none');
+      expect(option).toMatchObject({
+        currentValue: 'medium',
+        options: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
+        _meta: {
+          'qwenCode/reasoning': {
+            defaultEffort: 'xhigh',
+            thinkingMandatory: true,
+          },
+        },
+      });
+
+      const selected = (await agent.setSessionConfigOption({
+        sessionId,
+        configId: 'reasoning_effort',
+        value: 'xhigh',
+      })) as SetSessionConfigOptionResponse;
+      expect(generation.reasoning).toEqual({ effort: 'xhigh' });
+      expect(
+        selected.configOptions.find((item) => item.id === 'reasoning_effort')
+          ?.currentValue,
+      ).toBe('xhigh');
 
       await expect(
         agent.setSessionConfigOption({
@@ -8123,9 +8422,81 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           value: 'none',
         }),
       ).rejects.toThrow(
-        'Unknown reasoning effort: none. Choose one of: default, low, medium, high, xhigh, max',
+        'Unknown reasoning effort: none. Choose one of: low, medium, xhigh',
       );
-      expect(generation.reasoning).toEqual({ effort: 'medium' });
+      expect(generation.reasoning).toEqual({ effort: 'xhigh' });
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it('reports the model default when mandatory thinking strips a static disable', async () => {
+    const sessionId = 'qwen38-mandatory-static-disable-session';
+    const innerConfig = await setupSessionMocks(sessionId);
+    const generation: {
+      thinkingMandatory: true;
+      reasoning: { effort: string };
+      extra_body: Record<string, unknown>;
+    } = {
+      thinkingMandatory: true,
+      reasoning: { effort: 'low' },
+      extra_body: { enable_thinking: false },
+    };
+    innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+    innerConfig.getContentGeneratorConfig = vi.fn(() => generation);
+    innerConfig.getReasoningEffort = vi.fn(() => generation.reasoning.effort);
+    innerConfig.getReasoningEffortOverride = vi.fn(() => ({
+      source: 'extra_body' as const,
+      field: 'enable_thinking' as const,
+    }));
+
+    const { agent, agentPromise } = await bootAcpAgent();
+    try {
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+      })) as SetSessionConfigOptionResponse;
+      expect(
+        session.configOptions.find((item) => item.id === 'reasoning_effort')
+          ?.currentValue,
+      ).toBe('xhigh');
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
+  it('reports the model default when mandatory thinking strips a static effort while disabled', async () => {
+    const sessionId = 'qwen38-mandatory-disabled-static-effort-session';
+    const innerConfig = await setupSessionMocks(sessionId);
+    const generation: {
+      thinkingMandatory: true;
+      reasoning: false;
+      samplingParams: Record<string, unknown>;
+    } = {
+      thinkingMandatory: true,
+      reasoning: false,
+      samplingParams: { reasoning_effort: 'low' },
+    };
+    innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+    innerConfig.getContentGeneratorConfig = vi.fn(() => generation);
+    innerConfig.getReasoningEffort = vi.fn().mockReturnValue(undefined);
+    innerConfig.getReasoningEffortOverride = vi.fn(() => ({
+      source: 'samplingParams' as const,
+      field: 'reasoning_effort' as const,
+    }));
+
+    const { agent, agentPromise } = await bootAcpAgent();
+    try {
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+      })) as SetSessionConfigOptionResponse;
+      expect(
+        session.configOptions.find((item) => item.id === 'reasoning_effort')
+          ?.currentValue,
+      ).toBe('xhigh');
     } finally {
       mockConnectionState.resolve();
       await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -5612,6 +5612,8 @@ class QwenAgent implements Agent {
           break;
         }
         case 'reasoning_effort': {
+          const generation = session.getConfig().getContentGeneratorConfig();
+          const thinkingMandatory = generation.thinkingMandatory === true;
           const modelReasoning = this.getModelReasoningConfiguration(
             session.getConfig(),
           );
@@ -5620,7 +5622,7 @@ class QwenAgent implements Agent {
               ? undefined
               : modelReasoning.efforts;
             const selected =
-              value === REASONING_EFFORT_NONE
+              value === REASONING_EFFORT_NONE && !thinkingMandatory
                 ? REASONING_EFFORT_NONE
                 : modelReasoning.toggleOnly
                   ? value === REASONING_EFFORT_DEFAULT
@@ -5629,7 +5631,7 @@ class QwenAgent implements Agent {
                   : effortValues?.find((effort) => effort === value);
             if (!selected) {
               const choices = [
-                REASONING_EFFORT_NONE,
+                ...(thinkingMandatory ? [] : [REASONING_EFFORT_NONE]),
                 ...(effortValues ?? [REASONING_EFFORT_DEFAULT]),
               ];
               throw RequestError.invalidParams(
@@ -5637,7 +5639,17 @@ class QwenAgent implements Agent {
                 `Unknown reasoning effort: ${value}. Choose one of: ${choices.join(', ')}`,
               );
             }
-            const generation = session.getConfig().getContentGeneratorConfig();
+            if (!modelReasoning.toggleOnly) {
+              for (const source of ['extra_body', 'samplingParams'] as const) {
+                const layer = generation[source];
+                if (!layer) continue;
+                const next = { ...layer };
+                delete next['enable_thinking'];
+                delete next['reasoning_effort'];
+                delete next['thinking_budget'];
+                generation[source] = next;
+              }
+            }
             if (selected === REASONING_EFFORT_NONE) {
               generation.reasoning = false;
             } else if (selected === REASONING_EFFORT_DEFAULT) {
@@ -6909,7 +6921,14 @@ class QwenAgent implements Agent {
         const configOptions =
           model.isRuntimeModel || modelId.startsWith(ACP_ROUTE_ID_PREFIX)
             ? undefined
-            : buildModelReasoningConfigPreview(model.id);
+            : buildModelReasoningConfigPreview(model.id, {
+                thinkingMandatory:
+                  config.getResolvedModelConfig?.(
+                    model.authType,
+                    model.id,
+                    model.registryBaseUrl ?? model.baseUrl,
+                  )?.generationConfig.thinkingMandatory === true,
+              });
         const providerModel: ServeWorkspaceProviderModel = {
           modelId,
           baseModelId: parseAcpBaseModelId(effectiveModelId),
@@ -12971,12 +12990,67 @@ class QwenAgent implements Agent {
       options: configModelOptions,
     };
 
-    const modelReasoning = this.getModelReasoningConfiguration(config);
+    const generation = config.getContentGeneratorConfig();
+    const modelReasoning = this.getModelReasoningConfiguration(
+      config,
+      currentModelId,
+    );
     const currentModelEffort = config.getReasoningEffort?.();
+    const reasoningOverride = config.getReasoningEffortOverride?.();
+    const reasoningOverrideValue = reasoningOverride
+      ? generation[reasoningOverride.source]?.[reasoningOverride.field]
+      : undefined;
+    const normalizedEffortOverride =
+      reasoningOverride?.field === 'reasoning_effort' &&
+      typeof reasoningOverrideValue === 'string'
+        ? reasoningOverrideValue === 'minimal'
+          ? 'low'
+          : REASONING_EFFORT_TIERS.find(
+              (effort) => effort === reasoningOverrideValue,
+            )
+        : undefined;
+    const normalizedBudgetOverride =
+      reasoningOverride?.field === 'thinking_budget' &&
+      typeof reasoningOverrideValue === 'number' &&
+      Number.isFinite(reasoningOverrideValue) &&
+      reasoningOverrideValue >= 0 &&
+      reasoningOverrideValue <= 262_144
+        ? reasoningOverrideValue <= 4_096
+          ? 'low'
+          : reasoningOverrideValue <= 16_384
+            ? 'medium'
+            : 'xhigh'
+        : undefined;
+    const normalizedOverrideEffort =
+      normalizedEffortOverride ?? normalizedBudgetOverride;
+    const overrideDisablesReasoning =
+      (reasoningOverride?.field === 'enable_thinking' &&
+        reasoningOverrideValue === false) ||
+      (reasoningOverride?.field === 'reasoning_effort' &&
+        reasoningOverrideValue === REASONING_EFFORT_NONE);
+    const mandatoryUsesDefaultEffort =
+      generation.thinkingMandatory === true &&
+      (overrideDisablesReasoning ||
+        (generation.reasoning === false &&
+          reasoningOverride?.field === 'reasoning_effort'));
+    const effectiveModelEffort =
+      modelReasoning && !modelReasoning.toggleOnly
+        ? mandatoryUsesDefaultEffort
+          ? modelReasoning.defaultEffort
+          : normalizedOverrideEffort
+            ? (modelReasoning.efforts.find(
+                (effort) => effort === normalizedOverrideEffort,
+              ) ?? modelReasoning.defaultEffort)
+            : currentModelEffort
+        : currentModelEffort;
+    const reasoningEnabled =
+      generation.reasoning !== false &&
+      (!reasoningOverride || !overrideDisablesReasoning);
     const reasoningEffortConfigOption: SessionConfigOption = (modelReasoning
       ? buildModelReasoningConfigOption(rawCurrentModelId, {
-          enabled: config.getContentGeneratorConfig().reasoning !== false,
-          effort: currentModelEffort,
+          enabled: reasoningEnabled,
+          effort: effectiveModelEffort,
+          thinkingMandatory: generation.thinkingMandatory === true,
         })
       : undefined) ?? {
       id: 'reasoning_effort',
@@ -13005,22 +13079,24 @@ class QwenAgent implements Agent {
 
   private getModelReasoningConfiguration(
     config: Config,
+    currentAcpModelId?: string,
   ): ModelReasoningConfiguration | undefined {
-    if (
-      config.getActiveRuntimeModelSnapshot?.() ||
-      config.getReasoningEffortOverride?.() ||
-      config.getContentGeneratorConfig().thinkingMandatory === true
-    ) {
+    if (config.getActiveRuntimeModelSnapshot?.()) {
+      return undefined;
+    }
+    const completeModelId =
+      currentAcpModelId ??
+      getCurrentAcpModelId(
+        this.buildSelectableModelOptions(config),
+        (config.getModel() || '').trim(),
+        config.getAuthType?.(),
+        config.getCurrentModelRegistryBaseUrl?.(),
+      );
+    if (completeModelId.startsWith(ACP_ROUTE_ID_PREFIX)) {
       return undefined;
     }
     const reasoning = getModelConfiguration(config.getModel())?.reasoning;
-    const currentEffort = config.getReasoningEffort?.();
-    return reasoning?.thinking &&
-      (reasoning.toggleOnly ||
-        !currentEffort ||
-        reasoning.efforts.includes(currentEffort))
-      ? reasoning
-      : undefined;
+    return reasoning?.thinking ? reasoning : undefined;
   }
 
   private buildSelectableModelOptions(config: Config) {

--- a/packages/cli/src/acp-integration/model-configuration.test.ts
+++ b/packages/cli/src/acp-integration/model-configuration.test.ts
@@ -38,6 +38,32 @@ describe('model configuration manifest', () => {
     });
   });
 
+  it('omits Thinking off when qwen3.8-max requires thinking', () => {
+    expect(
+      buildModelReasoningConfigOption('qwen3.8-max', {
+        thinkingMandatory: true,
+      }),
+    ).toMatchObject({
+      currentValue: 'xhigh',
+      options: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
+      _meta: {
+        'qwenCode/reasoning': {
+          defaultEffort: 'xhigh',
+          thinkingMandatory: true,
+        },
+      },
+    });
+  });
+
+  it.each(['high', 'max'] as const)(
+    'presents inherited %s as the qwen3.8-max xhigh alias',
+    (effort) => {
+      expect(
+        buildModelReasoningConfigOption('qwen3.8-max', { effort }),
+      ).toMatchObject({ currentValue: 'xhigh' });
+    },
+  );
+
   it.each([
     undefined,
     'qwen3.7-plus',
@@ -53,6 +79,18 @@ describe('model configuration manifest', () => {
   it('wraps the stable default option for workspace preview', () => {
     expect(buildModelReasoningConfigPreview('qwen3.8-max')).toEqual([
       buildModelReasoningConfigOption('qwen3.8-max'),
+    ]);
+  });
+
+  it('preserves mandatory thinking in the workspace preview', () => {
+    expect(
+      buildModelReasoningConfigPreview('qwen3.8-max', {
+        thinkingMandatory: true,
+      }),
+    ).toEqual([
+      buildModelReasoningConfigOption('qwen3.8-max', {
+        thinkingMandatory: true,
+      }),
     ]);
   });
 

--- a/packages/cli/src/acp-integration/model-configuration.ts
+++ b/packages/cli/src/acp-integration/model-configuration.ts
@@ -57,6 +57,12 @@ export const REASONING_EFFORT_NAMES: Record<ReasoningEffort, string> = {
   max: 'Max',
 };
 
+type ModelReasoningConfigState = {
+  enabled?: boolean;
+  effort?: ReasoningEffort;
+  thinkingMandatory?: boolean;
+};
+
 export function getModelConfiguration(modelId: string | undefined):
   | {
       readonly reasoning?: ModelReasoningConfiguration;
@@ -67,13 +73,14 @@ export function getModelConfiguration(modelId: string | undefined):
 
 export function buildModelReasoningConfigOption(
   modelId: string | undefined,
-  state: { enabled?: boolean; effort?: ReasoningEffort } = {},
+  state: ModelReasoningConfigState = {},
 ): SessionConfigOption | undefined {
   const reasoning = getModelConfiguration(modelId)?.reasoning;
   if (!reasoning?.thinking) return undefined;
+  const thinkingMandatory = state.thinkingMandatory === true;
 
   const currentValue =
-    state.enabled === false
+    state.enabled === false && !thinkingMandatory
       ? REASONING_EFFORT_NONE
       : reasoning.toggleOnly
         ? REASONING_EFFORT_DEFAULT
@@ -88,11 +95,15 @@ export function buildModelReasoningConfigOption(
     type: 'select',
     currentValue,
     options: [
-      {
-        value: REASONING_EFFORT_NONE,
-        name: 'Thinking off',
-        description: 'Disable thinking for this session',
-      },
+      ...(thinkingMandatory
+        ? []
+        : [
+            {
+              value: REASONING_EFFORT_NONE,
+              name: 'Thinking off',
+              description: 'Disable thinking for this session',
+            },
+          ]),
       ...(reasoning.toggleOnly
         ? [
             {
@@ -109,17 +120,24 @@ export function buildModelReasoningConfigOption(
     ],
     _meta: {
       'qwenCode/reasoning': reasoning.toggleOnly
-        ? { toggleOnly: true }
-        : { defaultEffort: reasoning.defaultEffort },
+        ? {
+            toggleOnly: true,
+            ...(thinkingMandatory ? { thinkingMandatory: true } : {}),
+          }
+        : {
+            defaultEffort: reasoning.defaultEffort,
+            ...(thinkingMandatory ? { thinkingMandatory: true } : {}),
+          },
     },
   };
 }
 
 export function buildModelReasoningConfigPreview(
   modelId: string | undefined,
+  state: ModelReasoningConfigState = {},
 ): SessionConfigOption[] | undefined {
   const reasoning = getModelConfiguration(modelId)?.reasoning;
   if (!reasoning?.thinking || reasoning.toggleOnly) return undefined;
-  const option = buildModelReasoningConfigOption(modelId);
+  const option = buildModelReasoningConfigOption(modelId, state);
   return option ? [option] : undefined;
 }

--- a/packages/cli/src/serve/workspace-providers-status.test.ts
+++ b/packages/cli/src/serve/workspace-providers-status.test.ts
@@ -280,7 +280,11 @@ describe('createWorkspaceProvidersStatusProvider', () => {
       model: { name: 'qwen3.8-max' },
       modelProviders: {
         openai: [
-          { id: 'qwen3.8-max', name: 'Qwen 3.8 Max' },
+          {
+            id: 'qwen3.8-max',
+            name: 'Qwen 3.8 Max',
+            generationConfig: { thinkingMandatory: true },
+          },
           { id: 'qwen3.8-max-preview', name: 'Qwen 3.8 Max Preview' },
           { id: 'qwen3.8-max-latest', name: 'Qwen 3.8 Max Alias' },
           { id: 'qwen-plus', name: 'Qwen Plus' },
@@ -296,12 +300,13 @@ describe('createWorkspaceProvidersStatusProvider', () => {
       {
         id: 'reasoning_effort',
         currentValue: 'xhigh',
-        options: [
-          { value: 'none' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'xhigh' },
-        ],
+        options: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
+        _meta: {
+          'qwenCode/reasoning': {
+            defaultEffort: 'xhigh',
+            thinkingMandatory: true,
+          },
+        },
       },
     ]);
     expect(

--- a/packages/cli/src/serve/workspace-providers-status.ts
+++ b/packages/cli/src/serve/workspace-providers-status.ts
@@ -165,7 +165,14 @@ function buildWorkspaceProvidersStatus(
         currentAuth === model.authType && currentAcpModelId === modelId;
       const configOptions = modelId.startsWith(ACP_ROUTE_ID_PREFIX)
         ? undefined
-        : buildModelReasoningConfigPreview(model.id);
+        : buildModelReasoningConfigPreview(model.id, {
+            thinkingMandatory:
+              modelsConfig.getResolvedModel(
+                model.authType,
+                model.id,
+                model.registryBaseUrl ?? model.baseUrl,
+              )?.generationConfig.thinkingMandatory === true,
+          });
       const providerModel: ServeWorkspaceProviderModel = {
         modelId,
         baseModelId: parseAcpBaseModelId(effectiveModelId),

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -41,7 +41,17 @@ type MockConnection = {
   workspaceCwd: string;
   currentModel: string;
   currentMode: string;
-  models: Array<{ id: string; label?: string }>;
+  models: Array<{
+    id: string;
+    label?: string;
+    reasoningPreview?: {
+      enabled: boolean;
+      effort: string;
+      efforts: string[];
+      defaultEffort: string;
+      canDisable?: boolean;
+    };
+  }>;
   commands: unknown[];
   skills: string[] | undefined;
   capabilities: { qwenCodeVersion: string; features: string[] };
@@ -98,6 +108,14 @@ type ChatEditorTestProps = {
   disabled?: boolean;
   dialogOpen?: boolean;
   onToggleShortcuts?: () => void;
+  reasoning?: {
+    enabled: boolean;
+    effort: string;
+    efforts: string[];
+    defaultEffort: string;
+    canDisable?: boolean;
+  };
+  onSelectReasoningEffort?: (value: string) => Promise<void> | void;
   voiceTarget?: VoiceWorkspaceTarget;
   voiceStatusRevision?: VoiceStatusRevision;
   placeholderText?: string;
@@ -262,6 +280,7 @@ const {
       }),
       refreshCommands: vi.fn().mockResolvedValue(undefined),
       setModel: vi.fn().mockResolvedValue(undefined),
+      setReasoningEffort: vi.fn().mockResolvedValue(undefined),
       setApprovalMode: vi.fn().mockResolvedValue(undefined),
       getRewindSnapshots: vi.fn().mockResolvedValue([]),
       rewindSession: vi.fn().mockResolvedValue(undefined),
@@ -5023,6 +5042,7 @@ beforeEach(() => {
   mockConnection.displayName = 'Session One';
   mockConnection.currentMode = 'default';
   mockConnection.currentModel = 'qwen';
+  mockConnection.models = [{ id: 'qwen', label: 'Qwen' }];
   mockConnection.error = undefined;
   mockConnection.errorStatus = undefined;
   mockConnection.missingSession = false;
@@ -5182,6 +5202,7 @@ beforeEach(() => {
   mockSessionActions.reloadSession.mockResolvedValue(undefined);
   mockSessionActions.refreshCommands.mockResolvedValue(undefined);
   mockSessionActions.setModel.mockResolvedValue(undefined);
+  mockSessionActions.setReasoningEffort.mockResolvedValue(undefined);
   mockSessionActions.setApprovalMode.mockResolvedValue(undefined);
   mockSessionActions.getRewindSnapshots.mockResolvedValue([]);
   mockSessionActions.rewindSession.mockResolvedValue(undefined);
@@ -14111,6 +14132,76 @@ describe('App session callbacks', () => {
     expect(
       container.querySelector('[data-testid="streaming-status"]'),
     ).not.toBeNull();
+  });
+
+  it('does not restore a stale welcome disable after mandatory reasoning clears it', async () => {
+    const reasoningPreview = (canDisable: boolean) => ({
+      enabled: true,
+      effort: 'xhigh',
+      efforts: ['low', 'medium', 'xhigh'],
+      defaultEffort: 'xhigh',
+      canDisable,
+    });
+    mockConnection.sessionId = undefined;
+    mockConnection.workspaceCwd = '/workspace';
+    mockConnection.currentModel = 'qwen3.8-max';
+    mockConnection.models = [
+      {
+        id: 'qwen3.8-max',
+        label: 'qwen3.8-max',
+        reasoningPreview: reasoningPreview(true),
+      },
+    ];
+    mockSessionActions.createSession.mockImplementation(async () => {
+      mockConnection.sessionId = 'session-created';
+      return { sessionId: 'session-created' };
+    });
+
+    const { rerender } = renderApp();
+    await flush();
+    act(() => {
+      testState.latestChatEditorProps?.onSelectReasoningEffort?.('none');
+    });
+    await flush();
+    expect(testState.latestChatEditorProps?.reasoning?.enabled).toBe(false);
+
+    mockConnection.models = [
+      {
+        id: 'qwen3.8-max',
+        label: 'qwen3.8-max',
+        reasoningPreview: reasoningPreview(false),
+      },
+    ];
+    rerender();
+    await flush();
+    expect(testState.latestChatEditorProps?.reasoning).toMatchObject({
+      enabled: true,
+      canDisable: false,
+      effort: 'xhigh',
+    });
+
+    mockConnection.models = [
+      {
+        id: 'qwen3.8-max',
+        label: 'qwen3.8-max',
+        reasoningPreview: reasoningPreview(true),
+      },
+    ];
+    rerender();
+    await flush();
+    expect(testState.latestChatEditorProps?.reasoning).toMatchObject({
+      enabled: true,
+      canDisable: true,
+      effort: 'xhigh',
+    });
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('first prompt');
+      await vi.waitFor(() => {
+        expect(mockSessionActions.sendPrompt).toHaveBeenCalledOnce();
+      });
+    });
+    expect(mockSessionActions.setReasoningEffort).not.toHaveBeenCalled();
   });
 
   it('commits the first prompt after creating its session', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -6012,8 +6012,9 @@ export function App({
         reasoningIntent &&
         reasoningIntent.modelId === modelId &&
         reasoningPreview &&
-        (reasoningIntent.value === 'none' ||
-          reasoningPreview.efforts.includes(reasoningIntent.value))
+        (reasoningIntent.value === 'none'
+          ? reasoningPreview.canDisable !== false
+          : reasoningPreview.efforts.includes(reasoningIntent.value))
           ? reasoningIntent.value
           : undefined;
       const modeId =
@@ -6529,11 +6530,26 @@ export function App({
       ? connection.models?.find((model) => model.id === currentModel)
           ?.reasoningPreview
       : undefined;
+  useEffect(() => {
+    if (
+      pendingReasoningIntent?.modelId === currentModel &&
+      pendingReasoningIntent.value === 'none' &&
+      welcomeReasoningPreview?.canDisable === false
+    ) {
+      setPendingReasoningIntent(undefined);
+    }
+  }, [
+    currentModel,
+    pendingReasoningIntent,
+    setPendingReasoningIntent,
+    welcomeReasoningPreview,
+  ]);
   const validPendingReasoningIntent =
     pendingReasoningIntent?.modelId === currentModel &&
     welcomeReasoningPreview &&
-    (pendingReasoningIntent.value === 'none' ||
-      welcomeReasoningPreview.efforts.includes(pendingReasoningIntent.value))
+    (pendingReasoningIntent.value === 'none'
+      ? welcomeReasoningPreview.canDisable !== false
+      : welcomeReasoningPreview.efforts.includes(pendingReasoningIntent.value))
       ? pendingReasoningIntent
       : undefined;
   const displayedReasoning = hasAuthoritativeReasoningContext
@@ -11249,6 +11265,7 @@ export function App({
       if (!preview) return;
       const previous = pendingReasoningIntentRef.current;
       if (value === 'none') {
+        if (preview.canDisable === false) return;
         const previousEffort =
           previous?.modelId === modelId &&
           preview.efforts.includes(previous.effort)

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -1083,7 +1083,7 @@ function ModelReasoningControls({
         <span>{t('reasoning.thinking')}</span>
         <Switch
           checked={reasoning.enabled}
-          disabled={busy || !onSelect}
+          disabled={busy || !onSelect || reasoning.canDisable === false}
           aria-label={t('reasoning.thinking')}
           data-web-shell-thinking-toggle
           onCheckedChange={(enabled) =>

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -45,6 +45,26 @@ const qwen38ReasoningConfigOptions = (currentValue = 'xhigh') => [
   },
 ];
 
+const qwen38MandatoryReasoningConfigOptions = (currentValue = 'xhigh') => [
+  {
+    id: 'reasoning_effort',
+    name: 'Reasoning effort',
+    type: 'select',
+    currentValue,
+    options: [
+      { value: 'low', name: 'Low' },
+      { value: 'medium', name: 'Medium' },
+      { value: 'xhigh', name: 'Extra high' },
+    ],
+    _meta: {
+      'qwenCode/reasoning': {
+        defaultEffort: 'xhigh',
+        thinkingMandatory: true,
+      },
+    },
+  },
+];
+
 test('loads replayed transcript and connects to fake daemon @smoke', async ({
   page,
 }, testInfo) => {
@@ -277,6 +297,57 @@ test('configures qwen3.8-max reasoning from the model popover @smoke', async ({
   ).toBeVisible();
 });
 
+test('keeps mandatory qwen3.8-max effort switchable after messages and while running @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    currentModel: 'qwen3.8-max',
+    events: [
+      userTextEvent('Completed question', { id: 1 }),
+      assistantTextEvent('Completed answer', { id: 2 }),
+      turnCompleteEvent('completed-prompt', { id: 3 }),
+    ],
+    state: {
+      configOptions: qwen38MandatoryReasoningConfigOptions(),
+    },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+  await gotoSession(page, scenario, daemon);
+
+  await expect(page.locator('[data-web-shell-message-list]')).toContainText(
+    'Completed answer',
+  );
+  const modelButton = page.locator('[data-web-shell-model-button]');
+  await modelButton.click();
+  const controls = page.locator('[data-web-shell-model-reasoning]');
+  const thinking = controls.locator('[data-web-shell-thinking-toggle]');
+  const medium = controls.locator('[data-web-shell-effort="medium"]');
+  await expect(controls).toBeVisible();
+  await expect(thinking).toBeChecked();
+  await expect(thinking).toBeDisabled();
+  await expect(medium).toBeEnabled();
+  await medium.click();
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(1);
+  expect(
+    requestBodyRecord(firstRequest(daemon.configOptionRequests())),
+  ).toEqual({ configId: 'reasoning_effort', value: 'medium' });
+
+  await page.keyboard.press('Escape');
+  await fillComposer(page, 'Keep switching while this prompt runs');
+  await page.locator('[data-web-shell-composer-submit]').click();
+  await expect.poll(() => daemon.promptRequests().length).toBe(1);
+  await modelButton.click();
+  const low = controls.locator('[data-web-shell-effort="low"]');
+  await expect(low).toBeEnabled();
+  await low.click();
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(2);
+  expect(requestBodyRecord(daemon.configOptionRequests()[1]!)).toEqual({
+    configId: 'reasoning_effort',
+    value: 'low',
+  });
+  await expect(modelButton).toContainText('Low');
+});
+
 test('previews qwen3.8-max reasoning before lazy session creation @smoke', async ({
   page,
 }, testInfo) => {
@@ -462,6 +533,72 @@ test('previews qwen3.8-max reasoning before lazy session creation @smoke', async
   await expect(
     page.locator('[data-web-shell-effort="medium"]'),
   ).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('keeps mandatory qwen3.8-max effort switchable before lazy session creation @smoke', async ({
+  page,
+}, testInfo) => {
+  const stableModel = {
+    modelId: 'qwen3.8-max',
+    baseModelId: 'qwen3.8-max',
+    name: 'qwen3.8-max',
+    contextLimit: 131_072,
+    isCurrent: true,
+    isRuntime: false,
+    configOptions: qwen38MandatoryReasoningConfigOptions(),
+  };
+  const scenario = createWebShellDaemonScenario({
+    currentModel: 'qwen3.8-max',
+    state: {
+      configOptions: qwen38MandatoryReasoningConfigOptions(),
+      models: {
+        currentModelId: 'qwen3.8-max',
+        availableModels: [
+          {
+            modelId: 'qwen3.8-max',
+            baseModelId: 'qwen3.8-max',
+            name: 'qwen3.8-max',
+            contextLimit: 131_072,
+          },
+        ],
+      },
+    },
+    providers: {
+      providers: [
+        {
+          kind: 'model_provider',
+          status: 'ok',
+          authType: 'qwen-oauth',
+          current: true,
+          models: [stableModel],
+        },
+      ],
+    },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+  await gotoEmptyMobileWelcomeHarness(page);
+
+  const modelButton = page.locator('[data-web-shell-model-button]');
+  await modelButton.click();
+  const thinking = page.locator('[data-web-shell-thinking-toggle]');
+  await expect(thinking).toBeChecked();
+  await expect(thinking).toBeDisabled();
+  await expect(modelButton).toContainText('Extra High');
+  const medium = page.locator('[data-web-shell-effort="medium"]');
+  await expect(medium).toBeEnabled();
+  await medium.click();
+  await expect(medium).toHaveAttribute('aria-pressed', 'true');
+  await expect(modelButton).toContainText('Medium');
+  expect(daemon.configOptionRequests()).toHaveLength(0);
+
+  await page.keyboard.press('Escape');
+  await fillComposer(page, 'Create the mandatory-thinking session');
+  await page.locator('[data-web-shell-composer-submit]').click();
+  await expect.poll(() => daemon.configOptionRequests().length).toBe(1);
+  expect(
+    requestBodyRecord(firstRequest(daemon.configOptionRequests())),
+  ).toEqual({ configId: 'reasoning_effort', value: 'medium' });
+  await expect.poll(() => daemon.promptRequests().length).toBe(1);
 });
 
 test('does not apply a model-bound welcome effort after switching models @smoke', async ({

--- a/packages/webui/src/daemon/session/mappers.test.ts
+++ b/packages/webui/src/daemon/session/mappers.test.ts
@@ -96,6 +96,29 @@ describe('mapReasoningControls', () => {
       efforts: [],
     });
   });
+
+  it('maps mandatory reasoning without inventing Thinking off', () => {
+    expect(
+      mapReasoningControls([
+        {
+          id: 'reasoning_effort',
+          currentValue: 'xhigh',
+          options: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
+          _meta: {
+            'qwenCode/reasoning': {
+              defaultEffort: 'xhigh',
+              thinkingMandatory: true,
+            },
+          },
+        },
+      ]),
+    ).toEqual({
+      enabled: true,
+      effort: 'xhigh',
+      efforts: ['low', 'medium', 'xhigh'],
+      canDisable: false,
+    });
+  });
 });
 
 describe('mapProviderStatus reasoning preview', () => {

--- a/packages/webui/src/daemon/session/mappers.ts
+++ b/packages/webui/src/daemon/session/mappers.ts
@@ -149,11 +149,13 @@ export function mapReasoningControls(
     const value = getString(getRecord(item), 'value');
     return value ? [value] : [];
   });
-  if (!values.includes('none')) return undefined;
-  const currentValue = getString(option, 'currentValue');
-  if (!currentValue || !values.includes(currentValue)) return undefined;
   const meta = getRecord(option['_meta']);
   const reasoningMeta = getRecord(meta?.['qwenCode/reasoning']);
+  const thinkingMandatory = reasoningMeta?.['thinkingMandatory'] === true;
+  if (!thinkingMandatory && !values.includes('none')) return undefined;
+  const currentValue = getString(option, 'currentValue');
+  if (!currentValue || !values.includes(currentValue)) return undefined;
+  if (thinkingMandatory && currentValue === 'none') return undefined;
   const selectableValues = values.filter((value) => value !== 'none');
   if (selectableValues.length === 0) return undefined;
   if (reasoningMeta?.['toggleOnly'] === true) {
@@ -161,6 +163,7 @@ export function mapReasoningControls(
       enabled: currentValue !== 'none',
       effort: selectableValues[0]!,
       efforts: [],
+      ...(thinkingMandatory ? { canDisable: false } : {}),
     };
   }
   const efforts = selectableValues;
@@ -170,7 +173,12 @@ export function mapReasoningControls(
       (value): value is string =>
         typeof value === 'string' && efforts.includes(value),
     ) ?? efforts[0]!;
-  return { enabled: currentValue !== 'none', effort, efforts };
+  return {
+    enabled: currentValue !== 'none',
+    effort,
+    efforts,
+    ...(thinkingMandatory ? { canDisable: false } : {}),
+  };
 }
 
 export function mapSessionContextReasoning(

--- a/packages/webui/src/daemon/session/types.ts
+++ b/packages/webui/src/daemon/session/types.ts
@@ -118,6 +118,8 @@ export interface DaemonReasoningControls {
   enabled: boolean;
   effort: string;
   efforts: string[];
+  /** Defaults to true. False means effort is mutable but thinking is required. */
+  canDisable?: boolean;
 }
 
 export interface DaemonTokenUsage {


### PR DESCRIPTION
## What this PR does

This keeps the model-specific reasoning controls available for qwen3.8-max before session creation, after messages have been sent, and while a prompt is running. Models that require thinking keep the Thinking switch checked and disabled while all supported effort tiers remain selectable.

The live session now reports the effective model-specific tier for documented effort aliases, thinking budgets, and request-level overrides. Choosing a tier clears only competing thinking fields through copy-on-write, so unrelated request parameters and shared source objects remain intact.

Welcome-state reasoning uses the same mandatory-thinking metadata as the live session. If refreshed metadata makes thinking mandatory, a pending Thinking-off choice is discarded and cannot reappear or be sent with the first prompt.

## Why it's needed

After the first message, the authoritative live session could downgrade qwen3.8-max to a generic reasoning option or hide it entirely when thinking was mandatory or a static request field was present. WebShell then showed only the model list, even though the model still supported changing reasoning effort. This made the control depend on session lifecycle instead of model capability.

## Reviewer Test Plan

### How to verify

1. Open a new WebShell task with qwen3.8-max and confirm Low, Medium, and Extra High are available before the lazy session is created.
2. Send a prompt, reopen the model popover after the response, and confirm the effort controls remain visible and mutable.
3. Change effort while a later prompt is running and confirm the next configuration mutation is accepted.
4. For a mandatory-thinking qwen3.8-max configuration, confirm Thinking is checked and disabled while Low, Medium, and Extra High stay enabled in both welcome and live states.
5. Confirm older daemons, unsupported models, and opaque model routes still do not invent model-specific reasoning controls.

### Evidence (Before & After)

Before: the reported post-message popover contained only the model list; the live mandatory/no-off option was rejected by the WebShell mapper, so effort controls disappeared.

After: the qwen-code WebShell fake-daemon Chromium smoke suite passes 33/33, including welcome-state selection, replayed messages, mandatory thinking, and a configuration change during an active prompt. ACP/model projection passes 560/560 tests, WebUI session mapping passes 146/146, and WebShell App/ChatEditor passes 635/635. Two independent source/wire reviews completed with Critical 0 and Suggestion 0.

Repository build, typecheck, and lint passed before the final rebase. On the current origin/main base, the repository build is blocked by an upstream TS1117 duplicate property in an unchanged core test mock; this branch has no diff in that file. All focused suites and the full WebShell smoke suite above pass on the rebased commit, and CI will be followed through resolution.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local qwen-code WebShell with its fake daemon and Playwright Chromium. No DataWorks page or environment was used.

## Risk & Scope

- Main risk or tradeoff: Model-specific projection must stay aligned with DashScope wire precedence; regression coverage includes aliases, boundary budgets, static disable/effort fields, mandatory thinking, and copy-on-write cleanup.
- Not validated / out of scope: A real external DashScope request was not sent; preview/latest aliases, unsupported models, older daemons, runtime models, and opaque routes remain intentionally fail-closed.
- Breaking changes / migration notes: None. The added constraint metadata is optional and older consumers continue to ignore it.

## Linked Issues

N/A — fixes the reported WebShell reasoning-selector regression.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 让 qwen3.8-max 的模型专属思考控制在首屏尚未创建会话、已经发送消息以及提示词运行中都保持可用。对于强制思考模型，Thinking 开关保持选中且禁用，但所有受支持的思考强度仍可选择。

实时会话现在会根据官方定义的强度别名、thinking budget 和请求级覆盖项展示真实生效的模型专属档位。用户选择档位时只通过 copy-on-write 清理冲突的思考字段，不会破坏无关请求参数或共享的源对象。

首屏思考能力与实时会话使用同一份强制思考元数据。如果刷新后的模型元数据变为强制思考，待应用的“关闭思考”选择会被丢弃，不会在之后恢复，也不会随首条提示词发送。

## 为什么需要

发送首条消息后，权威实时会话在强制思考或存在静态请求字段时，可能把 qwen3.8-max 降级成通用思考选项，或者完全隐藏它。WebShell 随后只显示模型列表，尽管该模型仍支持切换思考强度。这让控件是否出现取决于会话生命周期，而不是模型能力。

## Reviewer 测试计划

### 如何验证

1. 使用 qwen3.8-max 打开新的 WebShell 任务，在延迟创建会话之前确认 Low、Medium、Extra High 可用。
2. 发送提示词并等待回复后重新打开模型弹层，确认思考强度仍然可见且可切换。
3. 在下一条提示词运行中切换思考强度，确认后续配置变更被接受。
4. 对强制思考的 qwen3.8-max 配置，确认首屏和实时会话中 Thinking 都保持选中且禁用，同时 Low、Medium、Extra High 保持可用。
5. 确认旧 daemon、不支持的模型以及不透明模型路由不会凭空获得模型专属思考控制。

### 前后证据

修复前：用户反馈的发送消息后弹层只包含模型列表；实时的强制思考/无关闭选项会被 WebShell 映射层拒绝，因此思考强度消失。

修复后：qwen-code WebShell fake daemon 的 Chromium smoke 33/33 通过，覆盖首屏选择、历史消息、强制思考以及提示词运行中的配置切换。ACP/模型投影 560/560、WebUI 会话映射 146/146、WebShell App/ChatEditor 635/635 均通过。两次独立 source/wire 复审结果均为 Critical 0、Suggestion 0。

仓库级 build、typecheck、lint 在最终 rebase 前均已通过。当前 origin/main 基线上，仓库 build 被上游 core 测试 mock 中重复属性导致的 TS1117 阻塞；本分支对该文件没有任何 diff。上述聚焦测试和完整 WebShell smoke 已在 rebase 后提交上通过，并会继续跟进 CI 直至阻塞解除。

### 测试系统

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境

本地 qwen-code WebShell、其自带 fake daemon 以及 Playwright Chromium。未使用任何 DataWorks 页面或环境。

## 风险与范围

- 主要风险或取舍：模型专属投影必须与 DashScope wire 优先级保持一致；回归覆盖了别名、budget 边界、静态关闭/强度字段、强制思考以及 copy-on-write 清理。
- 未验证或超出范围：没有发起真实的外部 DashScope 请求；preview/latest 别名、不支持的模型、旧 daemon、runtime model 和不透明路由仍然按预期 fail-closed。
- 破坏性变更或迁移说明：无。新增的约束元数据为可选字段，旧消费者会继续忽略它。

## 关联 Issue

无——修复本次反馈的 WebShell 思考选择器回归。

</details>
