### PR TITLE
fix(review): warn on self-targeted asset publishing

### DIFF
--- a/packages/cli/src/commands/review/publish-assets.test.ts
+++ b/packages/cli/src/commands/review/publish-assets.test.ts
@@ -306,6 +306,32 @@ describe('publish-assets', () => {
     expect(ghWithInputPlainMock).not.toHaveBeenCalled();
   });
 
+  it('warns when the assets repo is the reviewed repo, case-insensitively', () => {
+    process.env['QWEN_REVIEW_ASSETS_REPO'] = 'qwenlm/qwen-code';
+    ghMock.mockImplementation((...args: string[]) => {
+      if (args[0] === 'repo' && args[1] === 'view') {
+        return JSON.stringify({
+          owner: { login: 'AaronZ345' },
+          name: 'qwen-code',
+          url: 'https://github.com/AaronZ345/qwen-code',
+          parent: { owner: { login: 'QwenLM' }, name: 'qwen-code' },
+        });
+      }
+      return args.includes('.object.sha') ? 'headsha1234567890' : '{}';
+    });
+    ghWithInputMock.mockImplementation(() => '{}');
+
+    run({ files: [pngFile('evidence.png')] });
+
+    expect(process.exitCode).toBeUndefined();
+    const stderr = (stderrSpy.mock.calls.map((c) => c[0]) as string[]).join(
+      '\n',
+    );
+    expect(stderr).toContain(
+      'QWEN_REVIEW_ASSETS_REPO points at the reviewed repository',
+    );
+  });
+
   it('creates the branch when missing, from the default branch head', () => {
     // First ref lookup throws (missing branch); the creation path then asks
     // for the default branch and its head; the post-upload head read follows.

--- a/packages/cli/src/commands/review/publish-assets.ts
+++ b/packages/cli/src/commands/review/publish-assets.ts
@@ -67,6 +67,48 @@ interface PublishAssetsArgs {
   defaultComment?: boolean;
 }
 
+interface GhRepoView {
+  owner?: { login?: string };
+  name?: string;
+  parent?: {
+    owner?: { login?: string };
+    name?: string;
+  };
+}
+
+function resolveReviewedRepoForSelfTargetWarning(
+  args: PublishAssetsArgs,
+): string | undefined {
+  if (args.reviewedRepo !== undefined) {
+    return args.reviewedRepo;
+  }
+  try {
+    const view = JSON.parse(
+      gh('repo', 'view', '--json', 'owner,name,url,parent'),
+    ) as GhRepoView;
+    const target = view.parent ?? view;
+    const owner = target.owner?.login;
+    const name = target.name;
+    return owner && name ? `${owner}/${name}` : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function warnIfAssetsRepoTargetsReviewedRepo(
+  assetsRepo: string,
+  args: PublishAssetsArgs,
+): void {
+  const reviewedRepo = resolveReviewedRepoForSelfTargetWarning(args);
+  if (reviewedRepo?.toLowerCase() !== assetsRepo.toLowerCase()) return;
+  writeStderrLine(
+    'publish-assets: warning — QWEN_REVIEW_ASSETS_REPO points at the reviewed ' +
+      'repository. Evidence images will still be published because the ' +
+      'destination was explicitly designated, but this recreates pr-assets/* refs ' +
+      'in the repository under review.',
+  );
+}
+
 /** The Contents-API dance for one file: create, or update when it exists. */
 function putContent(
   repo: string,
@@ -469,6 +511,7 @@ export function runPublishAssets(args: PublishAssetsArgs): void {
   const outPath = resolve(args.out);
   mkdirSync(dirname(outPath), { recursive: true });
   writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  warnIfAssetsRepoTargetsReviewedRepo(repo, args);
 
   // ── Pipeline mode: write the URLs back into the findings artifact ─────────
   if (findings && !args.findingsOut) {


### PR DESCRIPTION
## What this PR does

Adds a best-effort warning when `qwen review publish-assets` is configured to publish evidence back into the repository being reviewed. The reviewed repository comes from `--reviewed-repo` when provided, otherwise from `gh repo view`, preserving fork-parent resolution. Publication still proceeds because the destination was explicitly configured.

## Why it's needed

Automated review lanes no longer publish evidence into the repository under review, but a stale local `QWEN_REVIEW_ASSETS_REPO=<repo-under-review>` can still make the user-invoked command create `pr-assets/*` refs there without any signal. This change surfaces that hazardous configuration while preserving the existing explicit-destination contract.

## Reviewer Test Plan

### How to verify

1. Run `npm run test --workspace packages/cli -- src/commands/review/publish-assets.test.ts --pool threads --maxWorkers 1`.
2. Configure `QWEN_REVIEW_ASSETS_REPO` to the reviewed repository, including a case-only spelling difference, and confirm stderr contains the self-target warning while publication continues.
3. Configure a separate assets repository and confirm the self-target warning is absent.

### Evidence (Before & After)

Before, a self-targeting configuration completed without a diagnostic:

```text
(no self-target diagnostic)
```

After, the regression path captures:

```text
publish-assets: warning — QWEN_REVIEW_ASSETS_REPO points at the reviewed repository. Evidence images will still be published because the destination was explicitly designated, but this recreates pr-assets/* refs in the repository under review.
```

With a normal separate assets repository, the same warning remains absent:

```text
(no self-target diagnostic)
```

At the current head, GitHub's `Test (ubuntu-latest, Node 22.x)`, `Dependency CVE audit`, secret scan, and Web Shell smoke checks pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

macOS local targeted unit test; Linux GitHub Actions full test job.

## Risk & Scope

- Main risk or tradeoff: this is deliberately warn-and-proceed, not a refusal. A maintainer with a stale exported variable that resolves to the reviewed repository sees the warning, but explicitly configured publication is not blocked.
- Not validated / out of scope: repository detection is best-effort. If `--reviewed-repo` is absent and `gh repo view` fails or returns incomplete metadata, no warning is emitted. A stale variable pointing somewhere other than the resolved reviewed repository also remains silent.
- Breaking changes / migration notes: none. Existing publication destinations and output manifests are unchanged.

## Linked Issues

Fixes #10239

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当 `qwen review publish-assets` 被配置为把证据发布回正在审查的仓库时，新增一条尽力而为的警告。被审查仓库优先取自 `--reviewed-repo`，未提供时通过 `gh repo view` 解析，并保留 fork 父仓库语义。由于目标仓库是显式配置的，警告后仍继续发布。

## 为什么需要

自动审查流水线已经停止向被审查仓库发布证据，但本地残留的 `QWEN_REVIEW_ASSETS_REPO=<被审查仓库>` 仍可能让用户主动执行的命令在该仓库创建 `pr-assets/*` 引用，且此前没有任何提示。本修改会暴露这种危险配置，同时保持显式目标仓库的既有契约。

## 审查测试计划

### 如何验证

1. 运行 `npm run test --workspace packages/cli -- src/commands/review/publish-assets.test.ts --pool threads --maxWorkers 1`。
2. 将 `QWEN_REVIEW_ASSETS_REPO` 配置为被审查仓库，包括仅大小写不同的写法，确认 stderr 出现自指警告且发布继续。
3. 配置独立的证据仓库，确认不会出现该警告。

### 修改前后证据

修改前，自指配置完成时没有诊断；修改后会输出上方所示警告；使用正常的独立证据仓库时仍保持静默。当前 head 的 GitHub Ubuntu 测试、依赖漏洞审计、密钥扫描和 Web Shell 冒烟检查均通过。

### 测试环境

macOS 本地定向单测；Linux GitHub Actions 完整测试任务。Windows 未单独验证。

## 风险与范围

- 主要权衡：本修改刻意采用“警告后继续”，而非拒绝执行。若维护者保留的旧环境变量能够解析到被审查仓库，会看到警告，但显式配置的发布不会被阻止。
- 未验证或范围外：仓库解析是尽力而为的。若未提供 `--reviewed-repo`，且 `gh repo view` 失败或返回不完整元数据，则不会发出警告。若旧变量指向的仓库并非解析出的被审查仓库，也会保持静默。
- 破坏性变更或迁移说明：无。现有发布目标和输出清单保持不变。

## 关联问题

Fixes #10239

</details>