### PR TITLE
fix(core): remove duplicate getToolRegistry in telemetry-swap test mock

### DIFF
--- a/packages/core/src/core/client.telemetrySwap.test.ts
+++ b/packages/core/src/core/client.telemetrySwap.test.ts
@@ -89,9 +89,6 @@ function makeEnv() {
   const config: any = {
     getSessionId: () => sessionId,
     getResumedSessionData: () => resumedData,
-    // initialize() on a resumed session asks the skill tool to restore its
-    // loaded skills via config.getToolRegistry().getTool(...).
-    getToolRegistry: () => ({ getTool: () => undefined }),
     swap(id: string, data?: ResumedSessionData) {
       sessionId = id;
       resumedData = data;


### PR DESCRIPTION
## What this PR does

Removes a duplicated mock property from the telemetry-swap client contract test, where the same stub was defined twice with identical content in one object literal.

## Why it's needed

Two recent PRs independently added the same `getToolRegistry` stub to the test's minimal config mock — the skill-restore call that `initialize()` now makes resolves the SKILL tool through it — and the merge kept both copies because they sit at different positions in the object literal, so no textual conflict was raised. TypeScript rejects duplicate property names in an object literal (TS1117), which breaks `tsc --build` and therefore `npm run build` on `main`, while the unit suite stayed green because vitest only transpiles and does not type-check. This restores a green build.

## Reviewer Test Plan

### How to verify

On the current `main`, `npm run build` fails in the core package with `error TS1117: An object literal cannot have multiple properties with the same name.` With this patch, `npm run build` completes with exit code 0, and the telemetry-swap test file still passes all 10 tests — the two copies were byte-identical, so removing one changes no runtime behaviour.

### Evidence (Before & After)

Before:

```
src/core/client.telemetrySwap.test.ts(103,5): error TS1117: An object literal cannot have multiple properties with the same name.
```

After: `npm run build` exits 0; `npx vitest run src/core/client.telemetrySwap.test.ts` → 10 passed (10).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local full package build plus the affected unit test file.

## Risk & Scope

- Main risk or tradeoff: none — the two definitions were identical, so removal is semantically neutral.
- Not validated / out of scope: nothing beyond the single test mock.
- Breaking changes / migration notes: none.

## Linked Issues

None — follow-up to the merge that left `main` with a broken build.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

移除了遥测交换（telemetry-swap）客户端契约测试中一个重复的 mock 属性——同一个对象字面量里把完全相同的 stub 定义了两次。

## 为什么需要

最近两个 PR 各自往该测试的精简 config mock 里加了同一个 `getToolRegistry` stub（`initialize()` 现在会调用技能恢复逻辑，需要通过它解析 SKILL 工具），而合并时两份拷贝位于对象字面量的不同位置，没有产生文本冲突，于是都被保留了下来。TypeScript 禁止对象字面量中出现重复属性名（TS1117），导致 `tsc --build` 失败，进而 `main` 分支上 `npm run build` 报错；而单测之所以一直是绿的，是因为 vitest 只做转译、不做类型检查。本 PR 恢复绿色构建。

## 评审者测试计划

### 如何验证

在当前 `main` 上，`npm run build` 会在 core 包报 `error TS1117: An object literal cannot have multiple properties with the same name.`。打上本补丁后，`npm run build` 以退出码 0 完成，且遥测交换测试文件的 10 个测试全部通过——两份定义逐字节相同，删除其中一份不改变任何运行时行为。

### 前后对比证据

修复前：

```
src/core/client.telemetrySwap.test.ts(103,5): error TS1117: An object literal cannot have multiple properties with the same name.
```

修复后：`npm run build` 退出码 0；`npx vitest run src/core/client.telemetrySwap.test.ts` → 10 passed (10)。

### 测试环境

|   操作系统   | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地完整包构建 + 受影响的单测文件。

## 风险与范围

- 主要风险或权衡：无——两份定义完全相同，删除其一在语义上是中性的。
- 未验证 / 超出范围：除这一个测试 mock 之外无其他改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无——这是对让 `main` 构建挂掉的那次合并的跟进修复。

</details>
