### PR TITLE
feat(web-shell): show GitHub-style state icons for session PR bindings

### DIFF
--- a/packages/web-shell/client/components/SessionPrBadge.module.css
+++ b/packages/web-shell/client/components/SessionPrBadge.module.css
@@ -5,16 +5,17 @@
   height: 20px;
   display: inline-flex;
   align-items: center;
+  gap: 3px;
   padding: 0 7px;
   border-radius: 999px;
   background: color-mix(
     in srgb,
-    var(--color-accent-fg, #8b5cf6) 10%,
+    var(--muted-foreground, #6b7280) 10%,
     transparent
   );
   color: color-mix(
     in srgb,
-    var(--color-accent-fg, #8b5cf6) 95%,
+    var(--muted-foreground, #6b7280) 75%,
     var(--foreground)
   );
   font-size: 11px;
@@ -27,29 +28,14 @@
 .sessionPrBadge:hover {
   background: color-mix(
     in srgb,
-    var(--color-accent-fg, #8b5cf6) 18%,
-    transparent
-  );
-}
-
-/* Merged PRs are settled history — dim the badge so open work stands out. */
-.sessionPrBadgeMerged {
-  background: color-mix(
-    in srgb,
-    var(--muted-foreground, #6b7280) 10%,
-    transparent
-  );
-  color: color-mix(
-    in srgb,
-    var(--muted-foreground, #6b7280) 75%,
-    var(--foreground)
-  );
-}
-
-.sessionPrBadgeMerged:hover {
-  background: color-mix(
-    in srgb,
     var(--muted-foreground, #6b7280) 16%,
     transparent
   );
+}
+
+/* State is carried by the GitHub-style icon, not the pill background. */
+.sessionPrBadge svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
 }

--- a/packages/web-shell/client/components/SessionPrBadge.test.tsx
+++ b/packages/web-shell/client/components/SessionPrBadge.test.tsx
@@ -12,7 +12,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { DaemonSessionPrInfo } from '@qwen-code/sdk/daemon';
 import { I18nProvider } from '../i18n';
 import { SessionPrBadge } from './SessionPrBadge';
-import styles from './SessionPrBadge.module.css';
+import styles from './SessionPrStateIcon.module.css';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -44,19 +44,38 @@ afterEach(() => {
 });
 
 describe('SessionPrBadge', () => {
-  it('dims the badge when the latest bound PR is merged', () => {
-    const container = renderBadge([pr(9517, 'merged')]);
-    const badge = container.querySelector('a');
-    expect(badge?.classList.contains(styles.sessionPrBadgeMerged)).toBe(true);
+  it('shows the GitHub-style state icon of the latest bound PR', () => {
+    const iconOf = (state?: DaemonSessionPrInfo['state']) =>
+      renderBadge([pr(9517, state)]).querySelector('a svg');
+    expect(iconOf('merged')?.classList.contains('lucide-git-merge')).toBe(true);
+    expect(
+      iconOf('merged')?.classList.contains(styles.sessionPrStateMerged),
+    ).toBe(true);
+    expect(
+      iconOf('closed')?.classList.contains('lucide-git-pull-request-closed'),
+    ).toBe(true);
+    expect(
+      iconOf('closed')?.classList.contains(styles.sessionPrStateClosed),
+    ).toBe(true);
+    expect(iconOf('open')?.classList.contains('lucide-git-pull-request')).toBe(
+      true,
+    );
+    expect(iconOf('open')?.classList.contains(styles.sessionPrStateOpen)).toBe(
+      true,
+    );
+    // A state-less binding keeps the neutral icon without a state color.
+    expect(iconOf()?.classList.contains('lucide-git-pull-request')).toBe(true);
+    expect(iconOf()?.className).not.toContain('sessionPrState');
   });
 
-  it('keeps the accent style for open or stateless bindings', () => {
-    for (const state of ['open', undefined] as const) {
-      const container = renderBadge([pr(9517, state)]);
-      const badge = container.querySelector('a');
-      expect(badge?.classList.contains(styles.sessionPrBadgeMerged)).toBe(
-        false,
-      );
-    }
+  it('appends the state name to the aria-label for merged and closed PRs', () => {
+    const labelOf = (state?: DaemonSessionPrInfo['state']) =>
+      renderBadge([pr(9517, state)])
+        .querySelector('a')
+        ?.getAttribute('aria-label');
+    expect(labelOf('merged')).toContain('Merged');
+    expect(labelOf('closed')).toContain('Closed');
+    expect(labelOf('open')).not.toContain('Open');
+    expect(labelOf()).not.toContain('Open');
   });
 });

--- a/packages/web-shell/client/components/SessionPrBadge.tsx
+++ b/packages/web-shell/client/components/SessionPrBadge.tsx
@@ -8,7 +8,7 @@ import type { DaemonSessionPrInfo } from '@qwen-code/sdk/daemon';
 import { useI18n } from '../i18n';
 import { useExternalLinkOpener } from '../hooks/useExternalLinkOpener';
 import { isExternalOpenUrl } from '../utils/externalOpen';
-import { SessionPrStateIcon } from './SessionPrStateIcon';
+import { SessionPrStateIcon, sessionPrStateLabel } from './SessionPrStateIcon';
 import styles from './SessionPrBadge.module.css';
 
 interface SessionPrBadgeProps {
@@ -41,12 +41,7 @@ export function SessionPrBadge({ prs, tabIndex }: SessionPrBadgeProps) {
         count: openable.length,
       })
     : t('sidebar.sessionPr', { number: latest.number });
-  const stateSuffix =
-    latest.state === 'merged'
-      ? t('sidebar.sessionPrStateMerged')
-      : latest.state === 'closed'
-        ? t('sidebar.sessionPrStateClosed')
-        : undefined;
+  const stateSuffix = sessionPrStateLabel(t, latest.state);
   return (
     <a
       className={styles.sessionPrBadge}

--- a/packages/web-shell/client/components/SessionPrBadge.tsx
+++ b/packages/web-shell/client/components/SessionPrBadge.tsx
@@ -8,6 +8,7 @@ import type { DaemonSessionPrInfo } from '@qwen-code/sdk/daemon';
 import { useI18n } from '../i18n';
 import { useExternalLinkOpener } from '../hooks/useExternalLinkOpener';
 import { isExternalOpenUrl } from '../utils/externalOpen';
+import { SessionPrStateIcon } from './SessionPrStateIcon';
 import styles from './SessionPrBadge.module.css';
 
 interface SessionPrBadgeProps {
@@ -40,17 +41,19 @@ export function SessionPrBadge({ prs, tabIndex }: SessionPrBadgeProps) {
         count: openable.length,
       })
     : t('sidebar.sessionPr', { number: latest.number });
+  const stateSuffix =
+    latest.state === 'merged'
+      ? t('sidebar.sessionPrStateMerged')
+      : latest.state === 'closed'
+        ? t('sidebar.sessionPrStateClosed')
+        : undefined;
   return (
     <a
-      className={
-        latest.state === 'merged'
-          ? `${styles.sessionPrBadge} ${styles.sessionPrBadgeMerged}`
-          : styles.sessionPrBadge
-      }
+      className={styles.sessionPrBadge}
       href={latest.url}
       target="_blank"
       rel="noreferrer"
-      aria-label={label}
+      aria-label={stateSuffix ? `${label} · ${stateSuffix}` : label}
       title={multiple ? label : latest.url}
       {...(tabIndex !== undefined ? { tabIndex } : {})}
       onClick={(event) => {
@@ -66,7 +69,7 @@ export function SessionPrBadge({ prs, tabIndex }: SessionPrBadgeProps) {
         if (event.key === 'Enter') event.stopPropagation();
       }}
     >
-      #{latest.number}
+      <SessionPrStateIcon state={latest.state} />#{latest.number}
       {multiple ? ` +${openable.length - 1}` : ''}
     </a>
   );

--- a/packages/web-shell/client/components/SessionPrStateIcon.module.css
+++ b/packages/web-shell/client/components/SessionPrStateIcon.module.css
@@ -1,0 +1,14 @@
+/* GitHub-style PR state: open green, merged purple, closed red. The class is
+   doubled because consumers like `.sessionDetailsRow svg` set a default muted
+   icon color at specificity (0,1,1); these rules must outrank it. */
+.sessionPrStateOpen.sessionPrStateOpen {
+  color: var(--success-color, #22c55e);
+}
+
+.sessionPrStateMerged.sessionPrStateMerged {
+  color: var(--color-accent-fg, #8b5cf6);
+}
+
+.sessionPrStateClosed.sessionPrStateClosed {
+  color: var(--destructive, #ef4444);
+}

--- a/packages/web-shell/client/components/SessionPrStateIcon.tsx
+++ b/packages/web-shell/client/components/SessionPrStateIcon.tsx
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DaemonSessionPrInfo } from '@qwen-code/sdk/daemon';
+import {
+  GitMergeIcon,
+  GitPullRequestClosedIcon,
+  GitPullRequestIcon,
+} from 'lucide-react';
+import styles from './SessionPrStateIcon.module.css';
+
+const STATE_ICONS = {
+  open: { Icon: GitPullRequestIcon, className: styles.sessionPrStateOpen },
+  merged: { Icon: GitMergeIcon, className: styles.sessionPrStateMerged },
+  closed: {
+    Icon: GitPullRequestClosedIcon,
+    className: styles.sessionPrStateClosed,
+  },
+} as const;
+
+/**
+ * GitHub-style PR state icon shared by the session-row badge and the session
+ * details tooltip: open=green pull-request, merged=purple merge, closed=red
+ * closed-pull-request. A state-less binding renders the neutral pull-request
+ * glyph with no state color.
+ */
+export function SessionPrStateIcon({
+  state,
+}: {
+  state?: DaemonSessionPrInfo['state'];
+}) {
+  const entry = state ? STATE_ICONS[state] : undefined;
+  const Icon = entry?.Icon ?? GitPullRequestIcon;
+  return (
+    <Icon
+      aria-hidden="true"
+      {...(entry ? { className: entry.className } : {})}
+    />
+  );
+}

--- a/packages/web-shell/client/components/SessionPrStateIcon.tsx
+++ b/packages/web-shell/client/components/SessionPrStateIcon.tsx
@@ -14,12 +14,20 @@ import styles from './SessionPrStateIcon.module.css';
 
 const STATE_ICONS = {
   open: { Icon: GitPullRequestIcon, className: styles.sessionPrStateOpen },
-  merged: { Icon: GitMergeIcon, className: styles.sessionPrStateMerged },
+  merged: {
+    Icon: GitMergeIcon,
+    className: styles.sessionPrStateMerged,
+    labelKey: 'sidebar.sessionPrStateMerged',
+  },
   closed: {
     Icon: GitPullRequestClosedIcon,
     className: styles.sessionPrStateClosed,
+    labelKey: 'sidebar.sessionPrStateClosed',
   },
-} as const;
+} as const satisfies Record<
+  NonNullable<DaemonSessionPrInfo['state']>,
+  { Icon: typeof GitPullRequestIcon; className: string; labelKey?: string }
+>;
 
 /**
  * GitHub-style PR state icon shared by the session-row badge and the session
@@ -40,4 +48,18 @@ export function SessionPrStateIcon({
       {...(entry ? { className: entry.className } : {})}
     />
   );
+}
+
+/**
+ * Localized state name for assistive tech (badge aria-label, tooltip sr-only
+ * text). Only merged/closed carry a label; open and state-less bindings read
+ * as the bare PR reference. Keyed beside STATE_ICONS so a new state forces
+ * both the icon and the label mapping to be updated together.
+ */
+export function sessionPrStateLabel(
+  t: (key: string) => string,
+  state?: DaemonSessionPrInfo['state'],
+): string | undefined {
+  if (state !== 'merged' && state !== 'closed') return undefined;
+  return t(STATE_ICONS[state].labelKey);
 }

--- a/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.test.tsx
+++ b/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.test.tsx
@@ -209,9 +209,9 @@ describe('SessionDetailsTooltip', () => {
     expect(rowIcon(9503)?.className).not.toContain('sessionPrState');
 
     // State lives in the icon; visible text stays the bare PR label, with an
-    // sr-only state name so screen readers keep the information.
-    expect(byNumber(9500)?.textContent).toBe('Pull Request #9500Merged');
-    expect(byNumber(9501)?.textContent).toBe('Pull Request #9501Closed');
+    // sr-only " · State" suffix so screen readers keep the information.
+    expect(byNumber(9500)?.textContent).toBe('Pull Request #9500 · Merged');
+    expect(byNumber(9501)?.textContent).toBe('Pull Request #9501 · Closed');
     expect(byNumber(9502)?.textContent).toBe('Pull Request #9502');
 
     act(() => root.unmount());

--- a/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.test.tsx
+++ b/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.test.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../../i18n';
 import { SessionDetailsTooltip } from './SessionDetailsTooltip';
+import styles from './WebShellSidebar.module.css';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -134,7 +135,7 @@ describe('SessionDetailsTooltip', () => {
     act(() => root.unmount());
   });
 
-  it('marks merged and closed pull requests with a state suffix', async () => {
+  it('marks pull request state with GitHub-style icons', async () => {
     vi.useFakeTimers();
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -159,7 +160,12 @@ describe('SessionDetailsTooltip', () => {
                   url: 'https://github.com/o/r/pull/9501',
                   state: 'closed',
                 },
-                { number: 9502, url: 'https://github.com/o/r/pull/9502' },
+                {
+                  number: 9502,
+                  url: 'https://github.com/o/r/pull/9502',
+                  state: 'open',
+                },
+                { number: 9503, url: 'https://github.com/o/r/pull/9503' },
               ],
             }}
             label="Fix CI"
@@ -177,11 +183,36 @@ describe('SessionDetailsTooltip', () => {
     const details = document.querySelector('[role="dialog"]');
     const byNumber = (number: number) =>
       details?.querySelector(`a[href="https://github.com/o/r/pull/${number}"]`);
-    // An open (or state-less) binding renders without a suffix; swapped or
-    // deleted label branches are the exact regression this pins.
+    const rowIcon = (number: number) =>
+      byNumber(number)?.parentElement?.querySelector('svg');
+    expect(rowIcon(9500)?.classList.contains('lucide-git-merge')).toBe(true);
+    expect(rowIcon(9500)?.classList.contains(styles.sessionPrStateMerged)).toBe(
+      true,
+    );
+    expect(
+      rowIcon(9501)?.classList.contains('lucide-git-pull-request-closed'),
+    ).toBe(true);
+    expect(rowIcon(9501)?.classList.contains(styles.sessionPrStateClosed)).toBe(
+      true,
+    );
+    expect(rowIcon(9502)?.classList.contains('lucide-git-pull-request')).toBe(
+      true,
+    );
+    expect(rowIcon(9502)?.classList.contains(styles.sessionPrStateOpen)).toBe(
+      true,
+    );
+    // A state-less binding keeps the neutral icon without a state color;
+    // swapped or dropped state branches are the exact regression this pins.
+    expect(rowIcon(9503)?.classList.contains('lucide-git-pull-request')).toBe(
+      true,
+    );
+    expect(rowIcon(9503)?.className).not.toContain('sessionPrState');
+
+    // State lives in the icon; visible text stays the bare PR label, with an
+    // sr-only state name so screen readers keep the information.
+    expect(byNumber(9500)?.textContent).toBe('Pull Request #9500Merged');
+    expect(byNumber(9501)?.textContent).toBe('Pull Request #9501Closed');
     expect(byNumber(9502)?.textContent).toBe('Pull Request #9502');
-    expect(byNumber(9501)?.textContent).toBe('Pull Request #9501 · Closed');
-    expect(byNumber(9500)?.textContent).toBe('Pull Request #9500 · Merged');
 
     act(() => root.unmount());
   });

--- a/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.test.tsx
+++ b/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.test.tsx
@@ -6,7 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../../i18n';
 import { SessionDetailsTooltip } from './SessionDetailsTooltip';
-import styles from './WebShellSidebar.module.css';
+import styles from '../SessionPrStateIcon.module.css';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.tsx
+++ b/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.tsx
@@ -13,7 +13,7 @@ import { writeClipboardText } from '../../utils/clipboard';
 import { isExternalOpenUrl } from '../../utils/externalOpen';
 import { workspaceBasename } from '../../utils/workspace';
 import { Popover, PopoverAnchor, PopoverContent } from '../ui/popover';
-import { SessionPrStateIcon } from '../SessionPrStateIcon';
+import { SessionPrStateIcon, sessionPrStateLabel } from '../SessionPrStateIcon';
 import styles from './WebShellSidebar.module.css';
 import { resolveSessionDetailsCollisionBoundary } from './sessionDetailsCollisionBoundary';
 
@@ -147,37 +147,36 @@ export function SessionDetailsTooltip({
         {[...(session.prs ?? [])]
           .reverse()
           .filter((pr) => isExternalOpenUrl(pr.url))
-          .map((pr, index) => (
-            // Index composite: a hand-edited sidecar can carry duplicate
-            // numbers (the reader validates shape, not uniqueness), and a
-            // duplicate key would reconcile rows against each other. The
-            // list is a stable per-snapshot order, so index keys are safe.
-            <div
-              className={styles.sessionDetailsRow}
-              key={`${index}-${pr.number}`}
-            >
-              <SessionPrStateIcon state={pr.state} />
-              <a
-                href={pr.url}
-                target="_blank"
-                rel="noreferrer"
-                title={pr.url}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  openExternalLink(event, pr.url);
-                }}
+          .map((pr, index) => {
+            const stateLabel = sessionPrStateLabel(t, pr.state);
+            return (
+              // Index composite: a hand-edited sidecar can carry duplicate
+              // numbers (the reader validates shape, not uniqueness), and a
+              // duplicate key would reconcile rows against each other. The
+              // list is a stable per-snapshot order, so index keys are safe.
+              <div
+                className={styles.sessionDetailsRow}
+                key={`${index}-${pr.number}`}
               >
-                {t('sidebar.sessionPr', { number: pr.number })}
-                {pr.state === 'merged' || pr.state === 'closed' ? (
-                  <span className="sr-only">
-                    {pr.state === 'merged'
-                      ? t('sidebar.sessionPrStateMerged')
-                      : t('sidebar.sessionPrStateClosed')}
-                  </span>
-                ) : null}
-              </a>
-            </div>
-          ))}
+                <SessionPrStateIcon state={pr.state} />
+                <a
+                  href={pr.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={pr.url}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    openExternalLink(event, pr.url);
+                  }}
+                >
+                  {t('sidebar.sessionPr', { number: pr.number })}
+                  {stateLabel ? (
+                    <span className="sr-only">{` · ${stateLabel}`}</span>
+                  ) : null}
+                </a>
+              </div>
+            );
+          })}
         <div className={styles.sessionDetailsRow}>
           <RadioTowerIcon aria-hidden="true" />
           <span>{status}</span>

--- a/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.tsx
+++ b/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.tsx
@@ -1,16 +1,10 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react';
-import type {
-  DaemonSessionPrInfo,
-  DaemonSessionSummary,
-} from '@qwen-code/sdk/daemon';
+import type { DaemonSessionSummary } from '@qwen-code/sdk/daemon';
 import {
   CheckIcon,
   CopyIcon,
   FolderClosedIcon,
   GitBranchIcon,
-  GitMergeIcon,
-  GitPullRequestClosedIcon,
-  GitPullRequestIcon,
   RadioTowerIcon,
 } from 'lucide-react';
 import { useI18n } from '../../i18n';
@@ -19,6 +13,7 @@ import { writeClipboardText } from '../../utils/clipboard';
 import { isExternalOpenUrl } from '../../utils/externalOpen';
 import { workspaceBasename } from '../../utils/workspace';
 import { Popover, PopoverAnchor, PopoverContent } from '../ui/popover';
+import { SessionPrStateIcon } from '../SessionPrStateIcon';
 import styles from './WebShellSidebar.module.css';
 import { resolveSessionDetailsCollisionBoundary } from './sessionDetailsCollisionBoundary';
 
@@ -28,29 +23,6 @@ interface SessionDetailsTooltipProps {
   time: string;
   completedUnread: boolean;
   children: ReactElement;
-}
-
-/** GitHub-style state icon and color; a state-less binding stays neutral. */
-function sessionPrStateIcon(pr: DaemonSessionPrInfo): {
-  Icon: typeof GitPullRequestIcon;
-  className: string | undefined;
-} {
-  switch (pr.state) {
-    case 'merged':
-      return { Icon: GitMergeIcon, className: styles.sessionPrStateMerged };
-    case 'closed':
-      return {
-        Icon: GitPullRequestClosedIcon,
-        className: styles.sessionPrStateClosed,
-      };
-    case 'open':
-      return {
-        Icon: GitPullRequestIcon,
-        className: styles.sessionPrStateOpen,
-      };
-    default:
-      return { Icon: GitPullRequestIcon, className: undefined };
-  }
 }
 
 export function SessionDetailsTooltip({
@@ -175,44 +147,37 @@ export function SessionDetailsTooltip({
         {[...(session.prs ?? [])]
           .reverse()
           .filter((pr) => isExternalOpenUrl(pr.url))
-          .map((pr, index) => {
-            const { Icon: StateIcon, className: stateClass } =
-              sessionPrStateIcon(pr);
-            return (
-              // Index composite: a hand-edited sidecar can carry duplicate
-              // numbers (the reader validates shape, not uniqueness), and a
-              // duplicate key would reconcile rows against each other. The
-              // list is a stable per-snapshot order, so index keys are safe.
-              <div
-                className={styles.sessionDetailsRow}
-                key={`${index}-${pr.number}`}
+          .map((pr, index) => (
+            // Index composite: a hand-edited sidecar can carry duplicate
+            // numbers (the reader validates shape, not uniqueness), and a
+            // duplicate key would reconcile rows against each other. The
+            // list is a stable per-snapshot order, so index keys are safe.
+            <div
+              className={styles.sessionDetailsRow}
+              key={`${index}-${pr.number}`}
+            >
+              <SessionPrStateIcon state={pr.state} />
+              <a
+                href={pr.url}
+                target="_blank"
+                rel="noreferrer"
+                title={pr.url}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  openExternalLink(event, pr.url);
+                }}
               >
-                <StateIcon
-                  aria-hidden="true"
-                  {...(stateClass ? { className: stateClass } : {})}
-                />
-                <a
-                  href={pr.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  title={pr.url}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    openExternalLink(event, pr.url);
-                  }}
-                >
-                  {t('sidebar.sessionPr', { number: pr.number })}
-                  {pr.state === 'merged' || pr.state === 'closed' ? (
-                    <span className="sr-only">
-                      {pr.state === 'merged'
-                        ? t('sidebar.sessionPrStateMerged')
-                        : t('sidebar.sessionPrStateClosed')}
-                    </span>
-                  ) : null}
-                </a>
-              </div>
-            );
-          })}
+                {t('sidebar.sessionPr', { number: pr.number })}
+                {pr.state === 'merged' || pr.state === 'closed' ? (
+                  <span className="sr-only">
+                    {pr.state === 'merged'
+                      ? t('sidebar.sessionPrStateMerged')
+                      : t('sidebar.sessionPrStateClosed')}
+                  </span>
+                ) : null}
+              </a>
+            </div>
+          ))}
         <div className={styles.sessionDetailsRow}>
           <RadioTowerIcon aria-hidden="true" />
           <span>{status}</span>

--- a/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.tsx
+++ b/packages/web-shell/client/components/sidebar/SessionDetailsTooltip.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react';
-import type { DaemonSessionSummary } from '@qwen-code/sdk/daemon';
+import type {
+  DaemonSessionPrInfo,
+  DaemonSessionSummary,
+} from '@qwen-code/sdk/daemon';
 import {
   CheckIcon,
   CopyIcon,
   FolderClosedIcon,
   GitBranchIcon,
+  GitMergeIcon,
+  GitPullRequestClosedIcon,
   GitPullRequestIcon,
   RadioTowerIcon,
 } from 'lucide-react';
@@ -23,6 +28,29 @@ interface SessionDetailsTooltipProps {
   time: string;
   completedUnread: boolean;
   children: ReactElement;
+}
+
+/** GitHub-style state icon and color; a state-less binding stays neutral. */
+function sessionPrStateIcon(pr: DaemonSessionPrInfo): {
+  Icon: typeof GitPullRequestIcon;
+  className: string | undefined;
+} {
+  switch (pr.state) {
+    case 'merged':
+      return { Icon: GitMergeIcon, className: styles.sessionPrStateMerged };
+    case 'closed':
+      return {
+        Icon: GitPullRequestClosedIcon,
+        className: styles.sessionPrStateClosed,
+      };
+    case 'open':
+      return {
+        Icon: GitPullRequestIcon,
+        className: styles.sessionPrStateOpen,
+      };
+    default:
+      return { Icon: GitPullRequestIcon, className: undefined };
+  }
 }
 
 export function SessionDetailsTooltip({
@@ -147,37 +175,44 @@ export function SessionDetailsTooltip({
         {[...(session.prs ?? [])]
           .reverse()
           .filter((pr) => isExternalOpenUrl(pr.url))
-          .map((pr, index) => (
-            // Index composite: a hand-edited sidecar can carry duplicate
-            // numbers (the reader validates shape, not uniqueness), and a
-            // duplicate key would reconcile rows against each other. The
-            // list is a stable per-snapshot order, so index keys are safe.
-            <div
-              className={styles.sessionDetailsRow}
-              key={`${index}-${pr.number}`}
-            >
-              <GitPullRequestIcon aria-hidden="true" />
-              <a
-                href={pr.url}
-                target="_blank"
-                rel="noreferrer"
-                title={pr.url}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  openExternalLink(event, pr.url);
-                }}
+          .map((pr, index) => {
+            const { Icon: StateIcon, className: stateClass } =
+              sessionPrStateIcon(pr);
+            return (
+              // Index composite: a hand-edited sidecar can carry duplicate
+              // numbers (the reader validates shape, not uniqueness), and a
+              // duplicate key would reconcile rows against each other. The
+              // list is a stable per-snapshot order, so index keys are safe.
+              <div
+                className={styles.sessionDetailsRow}
+                key={`${index}-${pr.number}`}
               >
-                {t('sidebar.sessionPr', { number: pr.number })}
-                {pr.state === 'merged' || pr.state === 'closed'
-                  ? ` · ${
-                      pr.state === 'merged'
+                <StateIcon
+                  aria-hidden="true"
+                  {...(stateClass ? { className: stateClass } : {})}
+                />
+                <a
+                  href={pr.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={pr.url}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    openExternalLink(event, pr.url);
+                  }}
+                >
+                  {t('sidebar.sessionPr', { number: pr.number })}
+                  {pr.state === 'merged' || pr.state === 'closed' ? (
+                    <span className="sr-only">
+                      {pr.state === 'merged'
                         ? t('sidebar.sessionPrStateMerged')
-                        : t('sidebar.sessionPrStateClosed')
-                    }`
-                  : ''}
-              </a>
-            </div>
-          ))}
+                        : t('sidebar.sessionPrStateClosed')}
+                    </span>
+                  ) : null}
+                </a>
+              </div>
+            );
+          })}
         <div className={styles.sessionDetailsRow}>
           <RadioTowerIcon aria-hidden="true" />
           <span>{status}</span>

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -795,6 +795,20 @@
   white-space: nowrap;
 }
 
+/* Match the session-row badge text: neutral muted tone, not the global link
+   blue — a blue/purple link would clash with the merged state icon's purple. */
+.sessionDetailsRow a {
+  color: color-mix(
+    in srgb,
+    var(--muted-foreground, #6b7280) 75%,
+    var(--foreground)
+  );
+}
+
+.sessionDetailsRow a:hover {
+  color: var(--foreground);
+}
+
 .sessionDetailsIdRow {
   min-width: 0;
   display: flex;

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -788,6 +788,19 @@
   stroke-width: 1.6;
 }
 
+/* GitHub-style PR state: open green, merged purple, closed red. */
+.sessionDetailsRow svg.sessionPrStateOpen {
+  color: var(--success-color, #22c55e);
+}
+
+.sessionDetailsRow svg.sessionPrStateMerged {
+  color: var(--color-accent-fg, #8b5cf6);
+}
+
+.sessionDetailsRow svg.sessionPrStateClosed {
+  color: var(--destructive, #ef4444);
+}
+
 .sessionDetailsRow span {
   min-width: 0;
   overflow: hidden;

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.module.css
@@ -788,19 +788,6 @@
   stroke-width: 1.6;
 }
 
-/* GitHub-style PR state: open green, merged purple, closed red. */
-.sessionDetailsRow svg.sessionPrStateOpen {
-  color: var(--success-color, #22c55e);
-}
-
-.sessionDetailsRow svg.sessionPrStateMerged {
-  color: var(--color-accent-fg, #8b5cf6);
-}
-
-.sessionDetailsRow svg.sessionPrStateClosed {
-  color: var(--destructive, #ef4444);
-}
-
 .sessionDetailsRow span {
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
## What this PR does

Sessions bound to GitHub pull requests (#9729) now show the PR state in GitHub's visual vocabulary in both places the binding appears in the Web Shell sidebar. In the session details tooltip, each bound PR row previously used the same neutral pull-request icon with a text suffix ("· Merged" / "· Closed"); it now shows an open binding as a green pull-request icon, a merged binding as a purple merge icon, and a closed binding as a red closed-pull-request icon, with the visible text staying the bare PR label in the same muted tone as the badge text (the global link blue read as a competing color next to the merged icon's purple). On the session row itself, the PR number badge previously rendered the same accent-colored pill for every state and only dimmed merged PRs; it now renders the same three state icons on a neutral pill, so state is visible in the session list without hovering. Bindings whose state has not been fetched yet keep the neutral pull-request glyph with no color on both surfaces, and screen readers get the state name via sr-only text (tooltip) and the badge's aria-label. The icon/color mapping lives in one shared component used by both surfaces.

## Why it's needed

Green open / purple merged / red closed is the state vocabulary GitHub users already know, and this feature exists precisely for people who bind GitHub PRs to sessions — GitHub itself uses three different glyphs for the three states. Encoding state in both the icon glyph and its color makes the bindings scannable at a glance and keeps the information accessible to color-blind users, where a uniform icon plus a trailing text suffix required reading every row, and a single accent pill conveyed no state at all. The badge matters most here: it is always visible in a list of 20+ sessions, so it answers "which sessions still have an open PR" without hovering. The same convention already exists elsewhere in the Web Shell (the GitHub PRs dialog colors open PRs green), so this also aligns the sidebar with existing in-app behavior.

## Reviewer Test Plan

### How to verify

With sessions bound to PRs in different states (open, merged, closed, and if possible a binding whose state has not been refreshed yet): (1) look at the session rows in the sidebar — the PR number badge should show a green pull-request icon for open, a purple merge icon for merged, a red closed-pull-request icon for closed, and a neutral uncolored icon when no state snapshot exists, all on the same neutral pill; (2) hover a session — the tooltip rows should show the same three icons, with no "· Merged" / "· Closed" text suffix. The collocated unit tests pin exactly this icon/class mapping on both surfaces and pass (10/10): `cd packages/web-shell && npx vitest run client/components/SessionPrBadge.test.tsx client/components/sidebar/SessionDetailsTooltip.test.tsx`. Note: the state color rules intentionally use a doubled-class selector so they outrank the tooltip row's default muted icon color — worth a glance in the rendered UI that the icons are actually colored, not gray.

### Evidence (Before & After)

Session list badge — Before: the same accent-purple pill for every state (merged only dimmed). After: GitHub state icon on a neutral pill (open=green, merged=purple, closed=red, state-less=neutral).

| Before | After |
| :----: | :---: |
| ![badge before](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/5868f75af0fea41f9f187e07d44350c4f9352dca/before-sidebar.png) | ![badge after](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/75deced1611d3488cbb10ad9dd87d9f90baf3b89/after-sidebar.png) |

Session details tooltip — Before: one neutral pull-request icon with a "· Merged" text suffix. After: purple merge icon and the bare PR label (sr-only keeps the state for screen readers).

| Before | After |
| :----: | :---: |
| ![tooltip before](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/5868f75af0fea41f9f187e07d44350c4f9352dca/before-tooltip.png) | ![tooltip after](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/75deced1611d3488cbb10ad9dd87d9f90baf3b89/after-tooltip.png) |

Captured in Chromium against the Playwright mock-daemon harness with four bound PRs (open / merged / closed / state-less). Computed icon colors verified in the same run: badge open `rgb(72, 187, 120)`, badge merged `rgb(139, 92, 246)`, badge closed = the `--destructive` red, state-less neutral gray, and tooltip merged `rgb(139, 92, 246)` — confirming the state colors outrank the tooltip row's default muted icon color. Unit tests: `✓ components/SessionPrBadge.test.tsx (2 tests)`, `✓ components/sidebar/SessionDetailsTooltip.test.tsx (8 tests)`.

### Tested on

|     OS     |      Status      |
| :--------: | :--------------: |
|  🍏 macOS  | ✅ tested (unit) |
| 🪟 Windows | ⚠️ not tested    |
|  🐧 Linux  | ⚠️ not tested    |

### Environment (optional)

Unit tests via vitest in packages/web-shell; no live daemon required.

## Risk & Scope

- Main risk or tradeoff: the session-row badge loses its accent-colored pill in favor of a neutral pill with a colored state icon — deliberate, to follow GitHub's list convention and avoid two competing color vocabularies (accent purple previously meant "has a PR" while purple now means "merged"). State colors come from existing theme tokens (success / accent / destructive) rather than GitHub's exact hex values, so the palette stays coherent across light and dark themes but is not pixel-identical to github.com.
- Not validated / out of scope: PR state freshness itself (the 5-minute daemon refresh from #9729) is unchanged; this PR only changes how the stored state is rendered.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up polish to #9729.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

绑定到 GitHub PR 的会话（#9729）现在在 Web Shell 侧栏展示绑定的两个位置都以 GitHub 的视觉词汇显示 PR 状态。会话详情悬浮提示（tooltip）中，此前每个绑定 PR 行使用同一个中性 pull-request 图标并以文字后缀（"· Merged" / "· Closed"）呈现状态；现在 open 绑定显示绿色 pull-request 图标，merged 显示紫色 merge 图标，closed 显示红色 closed-pull-request 图标，可见文本保持为纯粹的 PR 标签，并采用与 badge 文字一致的 muted 色调（全局链接蓝紫在 merged 图标的紫色旁边像另一种状态色）。会话行上的 PR 号 badge 此前对所有状态渲染同一个强调色药丸、仅对 merged 调灰；现在在相同的中性药丸上渲染同样的三个状态图标，无需悬停即可在会话列表中看到状态。尚未获取到状态快照的绑定在两个界面上都保持中性 pull-request 字形、不带颜色；屏幕阅读器通过 sr-only 文本（tooltip）和 badge 的 aria-label 获取状态名称。图标/颜色映射抽取为一个共享组件，两个界面共用。

## 为什么需要

绿 open / 紫 merged / 红 closed 是 GitHub 用户早已熟知的状态词汇，而这个功能恰恰服务于把 GitHub PR 绑定到会话的用户——GitHub 自己对三个状态使用的就是三个不同字形。把状态同时编码在图标形状和颜色上，让绑定一眼可扫读，也让色盲用户依然能区分状态——此前统一的图标加尾随文字后缀需要逐行阅读，单一强调色药丸则完全不含状态信息。badge 在这里最重要：它在 20+ 会话的列表中常驻可见，不用悬停就能回答"哪些会话还有 open 的 PR"。同样的约定在 Web Shell 其他位置已经存在（GitHub PRs 对话框把 open PR 标为绿色），因此这也让侧栏与应用内既有行为对齐。

## 评审者测试计划

### 如何验证

准备绑定了不同状态 PR（open、merged、closed，以及如有可能，一个状态尚未刷新的绑定）的会话：(1) 看侧栏会话行——PR 号 badge 应对 open 显示绿色 pull-request 图标、merged 显示紫色 merge 图标、closed 显示红色 closed-pull-request 图标、无状态快照时显示中性无色图标，药丸底色统一为中性；(2) 悬停会话——tooltip 行应显示同样的三个图标，且不再带 "· Merged" / "· Closed" 文字后缀。collocated 单元测试在两个界面上精确定住了这套图标/样式映射并通过（10/10）：`cd packages/web-shell && npx vitest run client/components/SessionPrBadge.test.tsx client/components/sidebar/SessionDetailsTooltip.test.tsx`。注意：状态颜色规则有意使用了双写类选择器，以压过 tooltip 行的默认灰色图标颜色——建议在渲染后的 UI 里确认图标确实是彩色的而非灰色。

### 证据（Before & After）

会话列表 badge——Before：所有状态都是同一个强调紫药丸（仅 merged 调灰）。After：中性药丸上的 GitHub 状态图标（open=绿、merged=紫、closed=红、无状态=中性）。

| Before | After |
| :----: | :---: |
| ![badge before](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/5868f75af0fea41f9f187e07d44350c4f9352dca/before-sidebar.png) | ![badge after](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/75deced1611d3488cbb10ad9dd87d9f90baf3b89/after-sidebar.png) |

会话详情悬浮提示——Before：一个中性 pull-request 图标加 "· Merged" 文字后缀。After：紫色 merge 图标加纯 PR 标签（sr-only 为屏幕阅读器保留状态）。

| Before | After |
| :----: | :---: |
| ![tooltip before](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/5868f75af0fea41f9f187e07d44350c4f9352dca/before-tooltip.png) | ![tooltip after](https://gist.githubusercontent.com/wenshao/ddb3facde79e8076120e0ebe84ff8aaa/raw/75deced1611d3488cbb10ad9dd87d9f90baf3b89/after-tooltip.png) |

在 Chromium 中基于 Playwright mock-daemon 设施截取，包含四个绑定 PR（open / merged / closed / 无状态）。同一次运行验证了图标计算颜色：badge open `rgb(72, 187, 120)`、badge merged `rgb(139, 92, 246)`、badge closed 为 `--destructive` 红、无状态为中性灰、tooltip merged `rgb(139, 92, 246)`——确认状态颜色压过了 tooltip 行的默认灰色图标颜色。单测：`✓ components/SessionPrBadge.test.tsx (2 tests)`、`✓ components/sidebar/SessionDetailsTooltip.test.tsx (8 tests)`。

### 测试平台

macOS ✅ 已测（单测）；Windows ⚠️ 未测；Linux ⚠️ 未测（CI 覆盖三平台）。

### 环境（可选）

packages/web-shell 内的 vitest 单元测试；无需 live daemon。

## 风险与范围

- 主要风险/取舍：会话行 badge 放弃强调色药丸，改为中性药丸加彩色状态图标——这是有意为之，以遵循 GitHub 的列表惯例，并避免两套互相冲突的颜色词汇（此前强调紫表示"有 PR"，而现在紫色表示"merged"）。状态颜色取自现有主题 token（success / accent / destructive）而非 GitHub 精确色值，因此调色板在深浅主题下保持协调，但不与 github.com 像素级一致。
- 未验证/超出范围：PR 状态的新鲜度本身（#9729 的 5 分钟 daemon 刷新）不变；本 PR 只改已存储状态的渲染方式。
- 破坏性变更/迁移说明：无。

## 关联 Issue

#9729 的后续打磨。

</details>
