### PR TITLE
fix(goal): stamp the wind-down hand-off only when its turn was delivered

### DIFF
--- a/packages/core/src/goals/goal-reducer.ts
+++ b/packages/core/src/goals/goal-reducer.ts
@@ -46,7 +46,10 @@ export interface GoalTurnFinishedTransition {
   lastReason?: string;
   /** Tokens billed to the turn that just finished. */
   tokensUsed?: number;
-  /** Set when the finishing turn was the spend window's wind-down hand-off. */
+  /**
+   * Set when the finishing turn was the spend window's wind-down hand-off
+   * and was delivered to the model.
+   */
   windDownTurnId?: string;
 }
 

--- a/packages/core/src/goals/goal-runtime.test.ts
+++ b/packages/core/src/goals/goal-runtime.test.ts
@@ -373,6 +373,9 @@ describe('goal runtime', () => {
     expect(host.inputs[0]).not.toHaveProperty('windDown');
     expect(runtime.getSnapshot().goal?.status).toBe('active');
 
+    // The hand-off reached the model: only a delivered wind-down turn
+    // stamps the record.
+    runtime.markTurnDelivered(`goal-runtime:${host.started[1]!.turnId}`);
     await runtime.finishTurn(host.started[1]!);
 
     // The hand-off turn stamps the record, and the stop settles on the
@@ -446,6 +449,9 @@ describe('goal runtime', () => {
     await runtime.finishTurn(host.started[0]!);
     expect(host.started).toHaveLength(2);
     expect(host.inputs[1]).toMatchObject({ windDown: true });
+    // The hand-off reached the model: only a delivered wind-down turn
+    // stamps the record.
+    runtime.markTurnDelivered(`goal-runtime:${host.started[1]!.turnId}`);
     await runtime.finishTurn(host.started[1]!);
 
     await vi.waitFor(() => {
@@ -488,6 +494,9 @@ describe('goal runtime', () => {
 
     spend.set(host.started[0]!.turnId, 1_500);
     await runtime.finishTurn(host.started[0]!);
+    // The hand-off reached the model: only a delivered wind-down turn
+    // stamps the record.
+    runtime.markTurnDelivered(`goal-runtime:${host.started[1]!.turnId}`);
     await runtime.finishTurn(host.started[1]!);
 
     await vi.waitFor(() => {
@@ -548,6 +557,71 @@ describe('goal runtime', () => {
     await new Promise((resolve) => setImmediate(resolve));
     expect(inputs.at(-1)).toMatchObject({ windDown: true });
     expect(started).toHaveLength(2);
+  });
+
+  it('grants the hand-off again when its turn finished without being delivered', async () => {
+    // A system message or a direct user query can claim the wind-down
+    // continuation's permit and send its own text under it. The turn then
+    // finishes, but the user never got the hand-off -- so the record must
+    // not say they did, and the next continuation owes it again.
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const spend = new Map<string, number>();
+    const runtime = createGoalRuntime({
+      journal,
+      tokenLedger: {
+        takeGoalTurnTokens: (turnId: string) => spend.get(turnId) ?? 0,
+      },
+      tokenBudgetGrant: 1_000,
+    });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    spend.set(host.started[0]!.turnId, 1_500);
+    await runtime.finishTurn(host.started[0]!);
+    expect(host.inputs[1]).toMatchObject({ windDown: true });
+
+    // Finished under the wind-down permit, never marked delivered.
+    await runtime.finishTurn(host.started[1]!);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(runtime.getSnapshot().goal?.status).toBe('active');
+    expect(runtime.getSnapshot().goal).not.toHaveProperty('windDownTurnId');
+    expect(journal.appended.at(-1)!.snapshot.goal).not.toHaveProperty(
+      'windDownTurnId',
+    );
+    expect(host.started).toHaveLength(3);
+    expect(host.inputs[2]).toMatchObject({ windDown: true });
+  });
+
+  it('stops after the hand-off once a delivered wind-down turn finishes', async () => {
+    const journal = fakeGoalJournal();
+    const host = fakeGoalTurnHost();
+    const spend = new Map<string, number>();
+    const runtime = createGoalRuntime({
+      journal,
+      tokenLedger: {
+        takeGoalTurnTokens: (turnId: string) => spend.get(turnId) ?? 0,
+      },
+      tokenBudgetGrant: 1_000,
+    });
+    runtime.bindHost(host);
+    await runtime.dispatch({ action: 'create', objective: 'ship' });
+    spend.set(host.started[0]!.turnId, 1_500);
+    await runtime.finishTurn(host.started[0]!);
+    const windDown = host.started[1]!;
+    expect(host.inputs[1]).toMatchObject({ windDown: true });
+
+    runtime.markTurnDelivered(`goal-runtime:${windDown.turnId}`);
+    await runtime.finishTurn(windDown);
+
+    await vi.waitFor(() => {
+      expect(runtime.getSnapshot().goal?.status).toBe('usage_limited');
+    });
+    expect(runtime.getSnapshot().goal).toMatchObject({
+      limitKind: 'token_budget',
+      windDownTurnId: windDown.turnId,
+    });
+    expect(host.started).toHaveLength(2);
   });
 
   it('completes a Goal whose hand-off turn proves the objective done', async () => {

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -1521,15 +1521,22 @@ export function createGoalRuntime(
           // query can claim a queued continuation's permit and send its own
           // text instead. Only the host's delivery mark says the model saw
           // the objective; without it the notice stays owed.
-          settleCurrentTurnAnnouncement(currentTurnDelivered);
+          const delivered = currentTurnDelivered;
+          settleCurrentTurnAnnouncement(delivered);
           const recordUuid = randomUUID();
-          const finishedWindDown = windDownTurnId === permit.turnId;
+          // The same rule decides the hand-off. The record's marker means
+          // "the user got the hand-off", and the budget gate stops the Goal
+          // on it -- so a wind-down permit that finished under someone
+          // else's text leaves no marker, and the next continuation grants
+          // the hand-off again instead of stopping cold.
+          const heldWindDown = windDownTurnId === permit.turnId;
+          const finishedWindDown = heldWindDown && delivered;
           const nextGoal = reduceGoalTurnFinished(snapshot.goal, {
             now: Date.now(),
             tokensUsed: takeTurnTokens(permit.turnId),
             ...(finishedWindDown ? { windDownTurnId: permit.turnId } : {}),
           });
-          if (finishedWindDown) windDownTurnId = undefined;
+          if (heldWindDown) windDownTurnId = undefined;
           const persistedSnapshot: GoalSnapshotV2 = {
             v: GOAL_STATE_VERSION,
             goal: nextGoal,

--- a/packages/core/src/goals/goal-runtime.ts
+++ b/packages/core/src/goals/goal-runtime.ts
@@ -300,7 +300,8 @@ export function createGoalRuntime(
   /**
    * The permit turn of the wind-down continuation now in flight, if any.
    * In memory only: a wind-down the host dropped undelivered must be minted
-   * again, and only the turn that actually finishes stamps the record.
+   * again, and only a wind-down turn that finishes delivered stamps the
+   * record; one finished under someone else's text leaves the hand-off owed.
    */
   let windDownTurnId: string | undefined;
   let restorePreparation: Promise<CheckpointAttempt | undefined> | undefined;
@@ -606,8 +607,9 @@ export function createGoalRuntime(
     }
     if (isGoalTokenBudgetSpent(snapshot.goal)) {
       // A spent window buys one hand-off before it stops. The record marks
-      // the hand-off that finished; until then -- never granted, or granted
-      // and dropped by the host before the model saw it -- grant it.
+      // the hand-off that was delivered and finished; until then -- never
+      // granted, dropped before the model saw it, or finished under someone
+      // else's text -- grant it.
       if (snapshot.goal.windDownTurnId !== undefined) {
         stopForSpentBudget();
         return;


### PR DESCRIPTION
## What this PR does

Stamps `GoalRecord.windDownTurnId` — the marker that says "the user received the budget hand-off" — only when the wind-down turn was actually delivered to the model, using the delivery mark hosts already set (`markTurnDelivered`) and the rule #10013 established for the objective-updated notice. `finishTurn` reads `currentTurnDelivered` before the announcement settle resets it; a wind-down permit that finished undelivered leaves the record clean, so the next `queueContinuation` grants the hand-off again instead of settling `usage_limited`. The in-memory permit marker is released either way, since it belongs to the permit rather than to the outcome.

## Why it's needed

#10132 inferred "the hand-off was delivered" from "the turn holding the wind-down permit finished". #10013 showed why that inference fails: a system message (Cron/Notification/Teammate via `claimSystemGoalTurn`) or a direct user query (`/btw` via `claimDirectUserAdmission`) can claim a queued continuation's permit and send its own text under it, skipping both the continuation render and the delivery mark. If the claimed permit is the wind-down permit, the record was stamped, the next continuation stopped the Goal on a hand-off the user never got, and a resume did not repair it — the marker is cleared only by a re-arm. Filed as #10150.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/goals/` — 478 pass (17 files). `goal-runtime.test.ts` gains two cases: `grants the hand-off again when its turn finished without being delivered` (finish the wind-down turn with no delivery mark → no `windDownTurnId` on the record or in the journal, Goal still `active`, the next continuation is `windDown: true` again) and `stops after the hand-off once a delivered wind-down turn finishes` (mark delivered, finish → marker stamped, `usage_limited`, no third turn). The three existing wind-down tests that finish the hand-off turn now mark it delivered first, so they keep meaning "the model saw the hand-off".
- Mutation probe run during development: making the stamp unconditional again (`finishedWindDown = heldWindDown`) fails exactly the undelivered case, 145 others green.
- `cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx src/acp-integration` — 2151 pass; the host suites that exercise wind-down are unchanged, since hosts already mark delivery at their send sites.
- `tsc --noEmit`: no goal-code errors in `packages/core`; prettier + eslint clean on the two changed files.

### Evidence (Before & After)

N/A (runtime bookkeeping; the visible surfaces are unchanged — what changes is whether the hand-off is re-offered when the first attempt never reached the model).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

N/A (unit tests only).

## Risk & Scope

- Main risk or tradeoff: a wind-down turn whose host never calls `markTurnDelivered` would now re-grant the hand-off each window instead of stopping after one; all three hosts mark delivery at their real send site as of #10013, and the runtime tests were updated to say so explicitly rather than rely on the old unconditional stamp.
- Not validated / out of scope: no change to the budget gate, the re-arm rules, or the wind-down prompt; no host code touched.
- Breaking changes / migration notes: none. Persisted records are read the same way; only when the marker is written changes.

## Linked Issues

- Fixes #10150.
- Applies #10013's delivery rule to #10132's hand-off marker.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`GoalRecord.windDownTurnId`——表示「用户已收到预算收尾交接」的标记——现在只在收尾轮真正送达模型时才盖章,复用 host 已在真实发送点设置的送达标记(`markTurnDelivered`)以及 #10013 为「objective 已变更」通知确立的规则。`finishTurn` 在宣告结算重置之前读取 `currentTurnDelivered`;未送达就结束的收尾 permit 不在记录上留标记,于是下一次 `queueContinuation` 会再次授予交接,而不是落为 `usage_limited`。内存中的 permit 标记无论如何都会释放,它属于 permit 而非结果。

## 为什么需要

#10132 以「持有收尾 permit 的轮次结束了」推断「交接已送达」。#10013 说明了这个推断为何不成立:系统消息(经 `claimSystemGoalTurn` 的 Cron/Notification/Teammate)或直接用户查询(经 `claimDirectUserAdmission` 的 `/btw`)可以认领排队中续跑的 permit 并在其下发送自己的文本,跳过续跑渲染与送达标记。若被认领的正是收尾 permit,记录会被盖章,下一次续跑会在一份用户从未收到的交接上停止 Goal,resume 也无法修复——标记只在重新武装时清除。已记录为 #10150。

## 评审验证计划

### 如何验证

- `cd packages/core && npx vitest run src/goals/`——478 通过(17 个文件)。`goal-runtime.test.ts` 新增两个用例:`grants the hand-off again when its turn finished without being delivered`(未标记送达就结束收尾轮 → 记录与日志均无 `windDownTurnId`,Goal 仍为 `active`,下一次续跑再次为 `windDown: true`)和 `stops after the hand-off once a delivered wind-down turn finishes`(标记送达后结束 → 盖章、`usage_limited`、无第三轮)。原有三个结束收尾轮的测试现在先标记送达,使其含义保持为「模型看到了交接」。
- 开发期间的变异检验:把盖章改回无条件(`finishedWindDown = heldWindDown`),恰好挂未送达用例,其余 145 绿。
- `cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx src/acp-integration`——2151 通过;涉及收尾的 host 套件不变,因为 host 已在发送点标记送达。
- `tsc --noEmit`:`packages/core` 中 goal 代码无错误;两个改动文件 prettier + eslint 干净。

### 证据(前后对比)

N/A(运行时账本;可见界面不变,改变的是首次交接未到达模型时是否重新提供)。

### 已测试平台

Linux ✅;macOS / Windows ⚠️(CI 覆盖)。

### 环境(可选)

N/A(仅单元测试)。

## 风险与范围

- 主要风险或权衡:若某个 host 从不调用 `markTurnDelivered`,收尾轮会在每个窗口重复授予而不是一次即停;自 #10013 起三个 host 都在真实发送点标记送达,运行时测试也已改为显式表达这一点,而不再依赖旧的无条件盖章。
- 未验证/范围外:不改变预算闸门、重新武装规则或收尾提示词;不触碰 host 代码。
- 破坏性变更/迁移说明:无。持久化记录的读取方式不变,变的只是何时写入标记。

## 关联 Issue

- Fixes #10150。
- 将 #10013 的送达规则应用于 #10132 的交接标记。

</details>
