### PR TITLE
fix(core): recognize new DeepSeek/GLM vision models in modality auto-detection

### DIFF
--- a/packages/core/src/core/modalityDefaults.test.ts
+++ b/packages/core/src/core/modalityDefaults.test.ts
@@ -202,11 +202,41 @@ describe('defaultModalities', () => {
     it('returns text-only for deepseek-reasoner', () => {
       expect(defaultModalities('deepseek-reasoner')).toEqual({});
     });
+
+    // (QwenLM/qwen-code#10270)
+    it('returns text-only for non-vision deepseek-v4-flash', () => {
+      expect(defaultModalities('deepseek-v4-flash')).toEqual({});
+    });
+
+    it('returns image for deepseek-v4-flash-vision-exp', () => {
+      const m = defaultModalities('deepseek-v4-flash-vision-exp');
+      expect(m.image).toBe(true);
+      expect(m.pdf).toBeUndefined();
+    });
   });
 
   describe('Zhipu GLM', () => {
     it('returns image for glm-4.5v', () => {
       const m = defaultModalities('glm-4.5v');
+      expect(m.image).toBe(true);
+      expect(m.pdf).toBeUndefined();
+    });
+
+    // (QwenLM/qwen-code#10270)
+    it('returns image for glm-4.6v', () => {
+      const m = defaultModalities('glm-4.6v');
+      expect(m.image).toBe(true);
+      expect(m.pdf).toBeUndefined();
+    });
+
+    it('returns image for glm-5v-turbo', () => {
+      const m = defaultModalities('glm-5v-turbo');
+      expect(m.image).toBe(true);
+      expect(m.pdf).toBeUndefined();
+    });
+
+    it('returns image for glm-5.3-flash', () => {
+      const m = defaultModalities('glm-5.3-flash');
       expect(m.image).toBe(true);
       expect(m.pdf).toBeUndefined();
     });
@@ -217,6 +247,10 @@ describe('defaultModalities', () => {
 
     it('returns text-only for glm-4.7', () => {
       expect(defaultModalities('glm-4.7')).toEqual({});
+    });
+
+    it('returns text-only for glm-4.6 (no v suffix)', () => {
+      expect(defaultModalities('glm-4.6')).toEqual({});
     });
   });
 

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -61,14 +61,19 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   [/^qwen/, {}],
 
   // -------------------
-  // DeepSeek — text-only
+  // DeepSeek — text-only, except explicit vision variants
+  // (QwenLM/qwen-code#10270)
   // -------------------
+  [/^deepseek-.*vision/, { image: true }],
   [/^deepseek/, {}],
 
   // -------------------
-  // Zhipu GLM
+  // Zhipu GLM — v-suffix ids are vision models; others are text-only
+  // (QwenLM/qwen-code#10270)
   // -------------------
-  [/^glm-4\.5v/, { image: true }],
+  [/^glm-[0-9.]+v/, { image: true }],
+  // glm-5.3-flash natively integrates vision input (no v suffix)
+  [/^glm-5\.3-flash/, { image: true }],
   [/^glm-5(?:-|$)/, {}],
   [/^glm-/, {}],
 


### PR DESCRIPTION
## What this PR does

Extends the name-based modality auto-detection table (`MODALITY_PATTERNS` in `packages/core/src/core/modalityDefaults.ts`) so four newly reported vision models are detected as image-capable: `deepseek-v4-flash-vision-exp` (matched by a targeted entry for DeepSeek `-vision` variants placed ahead of the family-wide text-only entry), `glm-4.6v` and `glm-5v-turbo` (the existing `glm-4.5v`-specific entry is generalized to a `v`-suffix family pattern, keeping `glm-4.5v` covered), and `glm-5.3-flash` (its own precise entry, since it integrates vision natively despite having no `v` suffix). Everything else in the table is unchanged.

## Why it's needed

On v0.22.2 and current main, these vision models fall through to the text-only default, so when a user attaches an image via a custom OpenAI-compatible provider without manually overriding `model.generationConfig.modalities`, `createMediaContentPart()` silently replaces the image with a text placeholder before the request is sent and the model never sees the image. The same table feeds `isImageCapable()` in the vision bridge, so these models are also excluded from vision-bridge candidates. There is no user-visible warning, only a debug log line.

## Reviewer Test Plan

### How to verify

Red/green unit-test repro against `defaultModalities()`:
1. On unpatched main, assert `defaultModalities('<model>').image === true` for `deepseek-v4-flash-vision-exp`, `glm-4.6v`, `glm-5v-turbo`, `glm-5.3-flash`: **4 failed | 54 passed** (exactly the four reported ids fail).
2. With this patch: `cd packages/core && npx vitest run src/core/modalityDefaults.test.ts` → **58 passed (58)**. The four models now detect `image: true`, and the regression assertions hold: `deepseek-chat` / `deepseek-reasoner` / non-vision `deepseek-v4-flash` stay text-only, `glm-5` / `glm-4.7` / `glm-4.6` (no `v` suffix) stay text-only, and existing `glm-4.5v` / Qwen / Gemini entries are unchanged.
3. Typecheck: `npm run typecheck -w @qwen-code/qwen-code-core` — clean. `vision-bridge-service.test.ts` also run (65 passed) because `isImageCapable()` consumes this table.

### Evidence (Before & After)

N/A (non-UI detection-table change; test output above is the evidence).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ✅    |

### Environment (optional)

Unit tests only (`vitest`); no vendor API keys needed.

## Risk & Scope

- Main risk or tradeoff: the GLM `v`-suffix pattern is generalized from `^glm-4\.5v` to `^glm-[0-9.]+v` — a strict superset that still matches `glm-4.5v` (covered by the existing test) and tracks Zhipu's `v`-suffix vision naming convention; the DeepSeek `-vision` match follows the repo precedent for explicit vision markers (see the Doubao section). Text-only DeepSeek/GLM models are protected by regression tests.
- Not validated / out of scope: live end-to-end runs against DeepSeek/Zhipu endpoints (the reporter already validated the explicit-override control path; this fix needs no API keys); surfacing the placeholder replacement as a user-visible warning instead of a debug log (optional follow-up noted during triage, separate concern).
- Breaking changes / migration notes: none; explicit `modalities` overrides keep priority and are untouched.

## Linked Issues

Fixes #10270

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

扩展基于模型名的模态自动检测表（`packages/core/src/core/modalityDefaults.ts` 的 `MODALITY_PATTERNS`），使四个新报告的视觉模型被识别为支持图片输入：`deepseek-v4-flash-vision-exp`（新增针对 DeepSeek `-vision` 变体的精确条目，置于整个家族纯文本条目之前）；`glm-4.6v` 与 `glm-5v-turbo`（把原先仅针对 `glm-4.5v` 的条目泛化为 `v` 后缀家族模式，`glm-4.5v` 仍被覆盖）；`glm-5.3-flash`（原生集成视觉但没有 `v` 后缀，单独给精确条目）。表中其余内容不变。

## 为什么需要

在 v0.22.2 和当前 main 上，这些视觉模型落入纯文本默认值：用户通过自定义 OpenAI-compatible provider 附加图片且未手动覆盖 `model.generationConfig.modalities` 时，`createMediaContentPart()` 会在请求发出前把图片静默替换为文本占位符，模型永远看不到图片。同一张表也被 vision bridge 的 `isImageCapable()` 消费，这些模型因此被排除在 vision-bridge 候选之外。全程只有 debug 日志，没有用户可见警告。

## 评审验证计划

### 如何验证

对 `defaultModalities()` 做红/绿单元测试复现：
1. 在未打补丁的 main 上，断言 `deepseek-v4-flash-vision-exp`、`glm-4.6v`、`glm-5v-turbo`、`glm-5.3-flash` 的 `defaultModalities('<model>').image === true`：**4 failed | 54 passed**（恰好是报告的四个模型名失败）。
2. 打上本补丁后：`cd packages/core && npx vitest run src/core/modalityDefaults.test.ts` → **58 passed (58)**。四个模型现在检出 `image: true`，且回归断言成立：`deepseek-chat` / `deepseek-reasoner` / 非 vision 的 `deepseek-v4-flash` 仍为纯文本；`glm-5` / `glm-4.7` / `glm-4.6`（无 `v` 后缀）仍为纯文本；既有 `glm-4.5v` / Qwen / Gemini 条目行为不变。
3. 类型检查：`npm run typecheck -w @qwen-code/qwen-code-core` —— 通过。另跑了 `vision-bridge-service.test.ts`（65 通过），因为 `isImageCapable()` 消费这张表。

### 证据（修复前后）

N/A（非 UI 的检测表改动；以上述测试输出为证据）。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ✅    |

### 环境（可选）

仅单元测试（`vitest`），不需要厂商 API key。

## 风险与范围

- 主要风险/权衡：GLM 的 `v` 后缀模式从 `^glm-4\.5v` 泛化为 `^glm-[0-9.]+v` —— 严格超集，仍匹配 `glm-4.5v`（既有测试覆盖），并遵循智谱的 `v` 后缀视觉命名惯例；DeepSeek `-vision` 匹配沿用仓库中对显式视觉标记的先例（见 Doubao 段）。纯文本的 DeepSeek/GLM 模型有回归测试保护。
- 未验证/超出范围：DeepSeek/智谱端点的真实端到端运行（报告者已验证显式覆盖的对照路径；本修复不需要 API key）；把占位符替换改为用户可见警告而非 debug 日志（分诊阶段记录的可选后续项，属另一关注点）。
- 破坏性变更/迁移说明：无；显式 `modalities` 覆盖优先级不变，未被改动。

## 关联 Issue

Fixes #10270

</details>
