### PR TITLE
fix(dws): include command output in failures

### DIFF
--- a/packages/channels/dws/src/dws-client-process.test.ts
+++ b/packages/channels/dws/src/dws-client-process.test.ts
@@ -108,6 +108,23 @@ describe('DWS command process', () => {
     );
   });
 
+  it('prefers stderr details over stdout details', async () => {
+    mockFailedDwsCommand({
+      stdout: 'detail on stdout',
+      stderr: 'detail on stderr',
+    });
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toContain(
+      'DWS command failed (1): detail on stderr',
+    );
+    expect((error as Error).message).not.toContain('detail on stdout');
+  });
+
   it('falls back to stdout when stderr sanitizes to empty', async () => {
     mockFailedDwsCommand({
       stdout: 'error: quota exceeded',
@@ -158,7 +175,18 @@ describe('DWS command process', () => {
 
     const prefix = 'DWS command failed (1): ';
     expect(error).toBeInstanceOf(DwsCommandError);
-    expect((error as Error).message).toBe(`${prefix}${'x'.repeat(256)}`);
-    expect((error as Error).message).not.toContain('tail');
+    expect((error as Error).message).toBe(`${prefix}${'x'.repeat(252)}tail`);
+    expect((error as Error).message).not.toContain('x'.repeat(253));
+  });
+
+  it('keeps later diagnostics from long command output', async () => {
+    mockFailedDwsCommand({ stderr: `${'noise'.repeat(200)}fatal: denied` });
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toContain('fatal: denied');
   });
 });

--- a/packages/channels/dws/src/dws-client-process.test.ts
+++ b/packages/channels/dws/src/dws-client-process.test.ts
@@ -11,6 +11,31 @@ import { DwsClient, DwsCommandError } from './dws-client.js';
 vi.mock('node:child_process', () => ({ execFile: vi.fn() }));
 
 describe('DWS command process', () => {
+  function mockFailedDwsCommand({
+    code = 1,
+    stdout = '',
+    stderr = '',
+  }: {
+    code?: unknown;
+    stdout?: string;
+    stderr?: string;
+  }) {
+    vi.mocked(execFile).mockImplementation(((
+      _file,
+      _args,
+      _options,
+      callback,
+    ) => {
+      queueMicrotask(() => {
+        callback(Object.assign(new Error('exit'), { code }), stdout, stderr);
+      });
+      return {
+        exitCode: typeof code === 'number' ? code : null,
+        kill: vi.fn(),
+      };
+    }) as typeof execFile);
+  }
+
   afterEach(() => {
     vi.useRealTimers();
     vi.mocked(execFile).mockReset();
@@ -49,28 +74,15 @@ describe('DWS command process', () => {
     await vi.advanceTimersByTimeAsync(50_000);
 
     expect(child.kill).toHaveBeenCalledWith('SIGKILL');
-    await expect(result).resolves.toBeInstanceOf(DwsCommandError);
+    const error = await result;
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toBe('DWS command failed.');
   });
 
   it('includes sanitized stderr details when a DWS command exits non-zero', async () => {
-    vi.mocked(execFile).mockImplementation(((
-      _file,
-      _args,
-      _options,
-      callback,
-    ) => {
-      queueMicrotask(() => {
-        callback(
-          Object.assign(new Error('exit 1'), { code: 1 }),
-          '',
-          '\u001b[31mHTTP 400\n{"errorCode":"InvalidArgs"}\u001b[0m',
-        );
-      });
-      return {
-        exitCode: 1,
-        kill: vi.fn(),
-      };
-    }) as typeof execFile);
+    mockFailedDwsCommand({
+      stderr: '\u001b[31mHTTP 400\n{"errorCode":"InvalidArgs"}\u001b[0m',
+    });
 
     const error = await new DwsClient({ executable: '/opt/dws' })
       .assertCompatible()
@@ -81,5 +93,72 @@ describe('DWS command process', () => {
       'DWS command failed (1): HTTP 400\\n{"errorCode":"InvalidArgs"}',
     );
     expect((error as Error).message).not.toContain('[31m');
+  });
+
+  it('uses stdout details when stderr is empty', async () => {
+    mockFailedDwsCommand({ stdout: 'detail on stdout' });
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toContain(
+      'DWS command failed (1): detail on stdout',
+    );
+  });
+
+  it('falls back to stdout when stderr sanitizes to empty', async () => {
+    mockFailedDwsCommand({
+      stdout: 'error: quota exceeded',
+      stderr: '\u001b[2K\r',
+    });
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toContain(
+      'DWS command failed (1): error: quota exceeded',
+    );
+  });
+
+  it('uses a bare message when stderr and stdout sanitize to empty', async () => {
+    mockFailedDwsCommand({ stderr: '\u001b[2K\r' });
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toBe('DWS command failed (1).');
+  });
+
+  it('strips OSC terminal control sequences from failure details', async () => {
+    mockFailedDwsCommand({
+      stderr: `${String.fromCharCode(27)}]0;evil${String.fromCharCode(7)}boom`,
+    });
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toContain('boom');
+    expect((error as Error).message).not.toContain(']0;evil');
+  });
+
+  it('caps failure details before exposing them in the error message', async () => {
+    mockFailedDwsCommand({ stderr: `${'x'.repeat(300)}tail` });
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    const prefix = 'DWS command failed (1): ';
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toBe(`${prefix}${'x'.repeat(256)}`);
+    expect((error as Error).message).not.toContain('tail');
   });
 });

--- a/packages/channels/dws/src/dws-client-process.test.ts
+++ b/packages/channels/dws/src/dws-client-process.test.ts
@@ -51,4 +51,35 @@ describe('DWS command process', () => {
     expect(child.kill).toHaveBeenCalledWith('SIGKILL');
     await expect(result).resolves.toBeInstanceOf(DwsCommandError);
   });
+
+  it('includes sanitized stderr details when a DWS command exits non-zero', async () => {
+    vi.mocked(execFile).mockImplementation(((
+      _file,
+      _args,
+      _options,
+      callback,
+    ) => {
+      queueMicrotask(() => {
+        callback(
+          Object.assign(new Error('exit 1'), { code: 1 }),
+          '',
+          '\u001b[31mHTTP 400\n{"errorCode":"InvalidArgs"}\u001b[0m',
+        );
+      });
+      return {
+        exitCode: 1,
+        kill: vi.fn(),
+      };
+    }) as typeof execFile);
+
+    const error = await new DwsClient({ executable: '/opt/dws' })
+      .assertCompatible()
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DwsCommandError);
+    expect((error as Error).message).toContain(
+      'DWS command failed (1): HTTP 400\\n{"errorCode":"InvalidArgs"}',
+    );
+    expect((error as Error).message).not.toContain('[31m');
+  });
 });

--- a/packages/channels/dws/src/dws-client.ts
+++ b/packages/channels/dws/src/dws-client.ts
@@ -6,7 +6,7 @@
 
 import { execFile } from 'node:child_process';
 import { stripVTControlCharacters } from 'node:util';
-import { sanitizeLogText } from '@qwen-code/channel-base';
+import { sanitizeLogText, truncateCodePoints } from '@qwen-code/channel-base';
 import { dwsProcessEnvironment } from './dws-environment.js';
 import {
   startDwsEventProcess,
@@ -203,13 +203,22 @@ function dwsCommandFailureMessage(
 }
 
 function dwsCommandFailureDetails(output: unknown): string {
-  const window = String(output ?? '').slice(0, DWS_ERROR_OUTPUT_WINDOW_CHARS);
+  const window = String(output ?? '').slice(-DWS_ERROR_OUTPUT_WINDOW_CHARS);
   if (!window.trim()) return '';
-  const details = sanitizeLogText(
-    stripVTControlCharacters(window),
+  const details = truncateCodePointsFromEnd(
+    sanitizeLogText(
+      stripVTControlCharacters(window),
+      DWS_ERROR_OUTPUT_WINDOW_CHARS,
+    ),
     DWS_ERROR_OUTPUT_MAX_CHARS,
   ).trim();
   return details;
+}
+
+function truncateCodePointsFromEnd(str: string, max: number): string {
+  const truncated = truncateCodePoints(str, max);
+  if (truncated === str) return str;
+  return Array.from(str).slice(-max).join('');
 }
 
 function runDwsProcess(

--- a/packages/channels/dws/src/dws-client.ts
+++ b/packages/channels/dws/src/dws-client.ts
@@ -5,6 +5,7 @@
  */
 
 import { execFile } from 'node:child_process';
+import { sanitizeLogText } from '@qwen-code/channel-base';
 import { dwsProcessEnvironment } from './dws-environment.js';
 import {
   startDwsEventProcess,
@@ -16,6 +17,8 @@ const DWS_PROCESS_TIMEOUT_MS = 45_000;
 const DWS_PROCESS_FORCE_KILL_DELAY_MS = 5_000;
 const MINIMUM_DWS_VERSION = [1, 0, 57] as const;
 const DWS_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+const DWS_ERROR_OUTPUT_MAX_CHARS = 1000;
+const ANSI_ESCAPE_SEQUENCE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
 const MAX_MESSAGE_PAGES = 100;
 const MAX_TODO_PAGES = 50;
 const TODO_PAGE_SIZE = 20;
@@ -187,6 +190,21 @@ export function classifyDwsCommandFailure(code: unknown): DwsCommandOutcome {
     : 'unknown';
 }
 
+function dwsCommandFailureMessage(
+  code: unknown,
+  stdout: unknown,
+  stderr: unknown,
+): string {
+  const base = `DWS command failed${code === undefined ? '' : ` (${String(code)})`}`;
+  const output = String(stderr ?? '').trim() || String(stdout ?? '').trim();
+  if (!output) return `${base}.`;
+  const details = sanitizeLogText(
+    output.replace(ANSI_ESCAPE_SEQUENCE, ''),
+    DWS_ERROR_OUTPUT_MAX_CHARS,
+  ).trim();
+  return details ? `${base}: ${details}` : `${base}.`;
+}
+
 function runDwsProcess(
   executable: string,
   args: string[],
@@ -212,7 +230,7 @@ function runDwsProcess(
           const outcome = classifyDwsCommandFailure(code);
           reject(
             new DwsCommandError(
-              `DWS command failed${code === undefined ? '' : ` (${String(code)})`}.`,
+              dwsCommandFailureMessage(code, stdout, stderr),
               outcome,
             ),
           );

--- a/packages/channels/dws/src/dws-client.ts
+++ b/packages/channels/dws/src/dws-client.ts
@@ -5,6 +5,7 @@
  */
 
 import { execFile } from 'node:child_process';
+import { stripVTControlCharacters } from 'node:util';
 import { sanitizeLogText } from '@qwen-code/channel-base';
 import { dwsProcessEnvironment } from './dws-environment.js';
 import {
@@ -17,11 +18,8 @@ const DWS_PROCESS_TIMEOUT_MS = 45_000;
 const DWS_PROCESS_FORCE_KILL_DELAY_MS = 5_000;
 const MINIMUM_DWS_VERSION = [1, 0, 57] as const;
 const DWS_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
-const DWS_ERROR_OUTPUT_MAX_CHARS = 1000;
-const ANSI_ESCAPE_SEQUENCE = new RegExp(
-  `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
-  'g',
-);
+const DWS_ERROR_OUTPUT_MAX_CHARS = 256;
+const DWS_ERROR_OUTPUT_WINDOW_CHARS = DWS_ERROR_OUTPUT_MAX_CHARS * 2;
 const MAX_MESSAGE_PAGES = 100;
 const MAX_TODO_PAGES = 50;
 const TODO_PAGE_SIZE = 20;
@@ -198,14 +196,20 @@ function dwsCommandFailureMessage(
   stdout: unknown,
   stderr: unknown,
 ): string {
-  const base = `DWS command failed${code === undefined ? '' : ` (${String(code)})`}`;
-  const output = String(stderr ?? '').trim() || String(stdout ?? '').trim();
-  if (!output) return `${base}.`;
+  const base = `DWS command failed${code === undefined || code === null ? '' : ` (${String(code)})`}`;
+  const details =
+    dwsCommandFailureDetails(stderr) || dwsCommandFailureDetails(stdout);
+  return details ? `${base}: ${details}` : `${base}.`;
+}
+
+function dwsCommandFailureDetails(output: unknown): string {
+  const window = String(output ?? '').slice(0, DWS_ERROR_OUTPUT_WINDOW_CHARS);
+  if (!window.trim()) return '';
   const details = sanitizeLogText(
-    output.replace(ANSI_ESCAPE_SEQUENCE, ''),
+    stripVTControlCharacters(window),
     DWS_ERROR_OUTPUT_MAX_CHARS,
   ).trim();
-  return details ? `${base}: ${details}` : `${base}.`;
+  return details;
 }
 
 function runDwsProcess(

--- a/packages/channels/dws/src/dws-client.ts
+++ b/packages/channels/dws/src/dws-client.ts
@@ -18,7 +18,10 @@ const DWS_PROCESS_FORCE_KILL_DELAY_MS = 5_000;
 const MINIMUM_DWS_VERSION = [1, 0, 57] as const;
 const DWS_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const DWS_ERROR_OUTPUT_MAX_CHARS = 1000;
-const ANSI_ESCAPE_SEQUENCE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+const ANSI_ESCAPE_SEQUENCE = new RegExp(
+  `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
+  'g',
+);
 const MAX_MESSAGE_PAGES = 100;
 const MAX_TODO_PAGES = 50;
 const TODO_PAGE_SIZE = 20;


### PR DESCRIPTION
## What this PR does

Includes sanitized stderr/stdout details in DWS command failure errors instead of reporting only the exit code. ANSI color sequences are stripped before the detail is attached, and the diagnostic text is capped so command failures remain readable.

## Why it's needed

When a DWS command exits non-zero, the current daemon log only says `DWS command failed (1).` That hides the actionable failure detail from operators and makes debugging require reproducing the command outside the daemon. This PR preserves the relevant command output so failures surface as messages like `DWS command failed (1): HTTP 400 ...`.

## Reviewer Test Plan

### How to verify

Trigger or review the regression test for a DWS command that exits non-zero with ANSI-colored stderr. The expected behavior is that the thrown error and daemon log include the sanitized stderr/stdout detail, for example `DWS command failed (1): HTTP 400 ...`, rather than only `DWS command failed (1).`

### Evidence (Before & After)

Before: non-zero DWS exits surfaced only the exit code, so the model/operator saw `DWS command failed (1).` with no stderr/stdout detail.

After: non-zero DWS exits include a sanitized, bounded command-output excerpt in the error message; ANSI control codes are removed before the excerpt is appended.

Local verification:

```bash
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client-process.test.ts -t "includes sanitized stderr" --reporter verbose
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client-process.test.ts
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client.test.ts
NO_COLOR=1 TERM=dumb npx vitest run src/dws-channel.test.ts
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client-process.test.ts src/dws-client.test.ts src/dws-channel.test.ts
NO_COLOR=1 TERM=dumb npm run build
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

Local tests were run in `packages/channels/dws` on macOS with `NO_COLOR=1 TERM=dumb`.

## Risk & Scope

- Main risk or tradeoff: error strings now include a bounded excerpt of command output, so snapshots or callers that match the exact previous error text may need to accept the added diagnostic detail.
- Not validated / out of scope: this does not change retry behavior or resend semantics after a failed DWS command; it only exposes the failure detail.
- Breaking changes / migration notes: none expected.

## Linked Issues

Related to #10276. This PR addresses only the swallowed error-detail portion of that issue; retry replay behavior and final failed-attempt handling remain out of scope.

<details>
<summary>中文说明</summary>

## What this PR does

在 DWS 命令失败错误里保留经过清理的 stderr/stdout 细节，而不是只返回退出码。错误详情会先去掉 ANSI 颜色控制序列，并做长度限制，避免失败信息过长。

## Why it's needed

DWS 命令非零退出时，当前 daemon 日志只显示 `DWS command failed (1).`，会把真正可用于排查的失败原因藏起来，排障时只能到 daemon 外重新复现命令。本 PR 会把相关命令输出带回错误信息，例如 `DWS command failed (1): HTTP 400 ...`。

## Reviewer Test Plan

### How to verify

运行或检查新增回归测试：构造一个带 ANSI 彩色 stderr 的非零退出 DWS 命令。预期错误和 daemon 日志包含清理后的 stderr/stdout 摘要，例如 `DWS command failed (1): HTTP 400 ...`，而不是只有 `DWS command failed (1).`。

### Evidence (Before & After)

Before：DWS 非零退出只暴露退出码，模型/操作者只能看到 `DWS command failed (1).`，看不到 stderr/stdout 里的具体错误。

After：DWS 非零退出会在错误信息里附带经过清理和截断的命令输出摘要；追加前会移除 ANSI 控制码。

本地验证：

```bash
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client-process.test.ts -t "includes sanitized stderr" --reporter verbose
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client-process.test.ts
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client.test.ts
NO_COLOR=1 TERM=dumb npx vitest run src/dws-channel.test.ts
NO_COLOR=1 TERM=dumb npx vitest run src/dws-client-process.test.ts src/dws-client.test.ts src/dws-channel.test.ts
NO_COLOR=1 TERM=dumb npm run build
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally |
|  🐧 Linux  | ⚠️ not tested locally |

### Environment (optional)

本地测试在 macOS 的 `packages/channels/dws` 目录下运行，环境变量为 `NO_COLOR=1 TERM=dumb`。

## Risk & Scope

- 主要风险或权衡：错误字符串现在会包含有长度限制的命令输出摘要；如果有调用方严格匹配旧错误文本，可能需要接受新增的诊断信息。
- 未验证 / 不在范围内：本 PR 不改变失败后重试行为，也不处理最终失败后是否重发已生成内容；这里只解决错误详情被吞掉的问题。
- Breaking changes / migration notes：预计无。

## Linked Issues

关联 #10276。本 PR 只处理该 issue 中“错误详情被吞掉”的部分；重试重跑整轮对话和最终失败处理不在本 PR 范围内。

</details>