### PR TITLE
fix(core): clarify user-directed tool cancellation

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -12705,7 +12705,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(responseText).not.toContain('had already completed');
   });
 
-  it('tells the model a post-completion cancellation discarded finished work', async () => {
+  it('tells the model a post-completion cancellation was user-directed and should stop', async () => {
     const abortController = new AbortController();
     const { completedCalls } = await runSingleTool({
       abortController,
@@ -12719,8 +12719,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(completedCall.status).toBe('cancelled');
     expect(completedCall.response.executionStatus).toBe('cancelled');
     const responseText = JSON.stringify(completedCall.response.responseParts);
-    expect(responseText).toContain('The tool had already completed');
-    expect(responseText).not.toContain('User cancelled tool execution.');
+    expect(responseText).toContain('User intentionally cancelled');
+    expect(responseText).toContain('Stop and await further instructions');
+    expect(responseText).toContain('discarded');
   });
 
   // A post-execution cancellation drops the model-visible output, but the

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -13405,7 +13405,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     );
   });
 
-  it('tells the model a queued sibling cancellation was user-directed', async () => {
+  it('tells the model a queued sibling was cancelled before execution', async () => {
     const abortController = new AbortController();
     const siblingExecute = vi.fn().mockResolvedValue({
       llmContent: 'unexpected',
@@ -13459,8 +13459,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(siblingExecute).not.toHaveBeenCalled();
     const responseText = JSON.stringify(queuedSibling?.response.responseParts);
     expect(responseText).toContain(
-      'User intentionally cancelled this tool call before it ran.',
+      'This tool call was cancelled before it ran.',
     );
+    expect(responseText).not.toContain('User intentionally cancelled');
     expect(responseText).toContain(
       'Stop and await further instructions; do not retry or work around it.',
     );
@@ -16301,8 +16302,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(toolSpan?.ended).toBe(true);
     const responseText = JSON.stringify(cancelledCall.response.responseParts);
     expect(responseText).toContain(
-      'User intentionally cancelled this tool call before it ran.',
+      'This tool call was cancelled before it ran.',
     );
+    expect(responseText).not.toContain('User intentionally cancelled');
     expect(responseText).toContain(
       'Stop and await further instructions; do not retry or work around it.',
     );
@@ -16448,8 +16450,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     const completedCall = completedCalls[0] as CompletedToolCall;
     const responseText = JSON.stringify(completedCall.response.responseParts);
     expect(responseText).toContain(
-      'User intentionally cancelled this tool call before it ran.',
+      'This tool call was cancelled before it ran.',
     );
+    expect(responseText).not.toContain('User intentionally cancelled');
     expect(responseText).toContain(
       'Stop and await further instructions; do not retry or work around it.',
     );

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -13377,6 +13377,9 @@ describe('CoreToolScheduler telemetry spans', () => {
       'User intentionally cancelled this tool call.',
     );
     expect(responseText).not.toContain('had already completed');
+    expect(responseText).toContain(
+      'Stop and await further instructions; do not retry or work around it.',
+    );
   });
 
   it('tells the model a post-completion cancellation discarded finished work', async () => {
@@ -13400,6 +13403,68 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(responseText).toContain(
       'Stop and await further instructions; do not retry or work around it.',
     );
+  });
+
+  it('tells the model a queued sibling cancellation was user-directed', async () => {
+    const abortController = new AbortController();
+    const siblingExecute = vi.fn().mockResolvedValue({
+      llmContent: 'unexpected',
+      returnDisplay: 'unexpected',
+    });
+    const { scheduler, onAllToolCallsComplete } = buildScheduler({
+      tools: [
+        new MockTool({
+          name: 'mockTool',
+          execute: vi.fn().mockImplementation(() => {
+            abortController.abort();
+            return Promise.reject(
+              Object.assign(new Error('Tool call aborted'), {
+                name: 'AbortError',
+              }),
+            );
+          }),
+        }),
+        new MockTool({ name: 'mockTool2', execute: siblingExecute }),
+      ],
+    });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'running-call',
+          name: 'mockTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-telemetry',
+        },
+        {
+          callId: 'queued-sibling',
+          name: 'mockTool2',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-telemetry',
+        },
+      ],
+      abortController.signal,
+    );
+
+    const completedCalls = onAllToolCallsComplete.mock.calls.at(
+      -1,
+    )?.[0] as CompletedToolCall[];
+    const queuedSibling = completedCalls.find(
+      (call) => call.request.callId === 'queued-sibling',
+    );
+    expect(queuedSibling?.status).toBe('cancelled');
+    expect(queuedSibling?.response.executionStatus).toBe('not_started');
+    expect(siblingExecute).not.toHaveBeenCalled();
+    const responseText = JSON.stringify(queuedSibling?.response.responseParts);
+    expect(responseText).toContain(
+      'User intentionally cancelled this tool call before it ran.',
+    );
+    expect(responseText).toContain(
+      'Stop and await further instructions; do not retry or work around it.',
+    );
+    expect(responseText).not.toContain('had already completed');
   });
 
   // A post-execution cancellation drops the model-visible output, but the

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -13397,6 +13397,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(responseText).not.toContain(
       'User intentionally cancelled this tool call. Stop',
     );
+    expect(responseText).toContain(
+      'Stop and await further instructions; do not retry or work around it.',
+    );
   });
 
   // A post-execution cancellation drops the model-visible output, but the

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -16274,6 +16274,10 @@ describe('CoreToolScheduler telemetry spans', () => {
     // assertions.
     abortController.abort();
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const cancelledCall = (await waitForStatus(
+      onToolCallsUpdate,
+      'cancelled',
+    )) as CompletedToolCall;
 
     expect(
       (scheduler as unknown as { toolSpans: Map<string, unknown> }).toolSpans
@@ -16295,6 +16299,13 @@ describe('CoreToolScheduler telemetry spans', () => {
       (r) => r.name === 'tool.mockEditTool',
     );
     expect(toolSpan?.ended).toBe(true);
+    const responseText = JSON.stringify(cancelledCall.response.responseParts);
+    expect(responseText).toContain(
+      'User intentionally cancelled this tool call before it ran.',
+    );
+    expect(responseText).toContain(
+      'Stop and await further instructions; do not retry or work around it.',
+    );
   });
 
   it('plan-mode block emits failure_kind=plan_mode_blocked (#4321)', async () => {
@@ -16416,7 +16427,7 @@ describe('CoreToolScheduler telemetry spans', () => {
 
   it('validated pre-execution cancellation keeps the parent span UNSET', async () => {
     const abortController = new AbortController();
-    const { spanRecord } = await runSingleTool({
+    const { spanRecord, completedCalls } = await runSingleTool({
       abortController,
       tools: [
         new MockTool({
@@ -16434,6 +16445,14 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(
       toolSpanRecords.find((record) => record.name === 'tool.execution'),
     ).toBeUndefined();
+    const completedCall = completedCalls[0] as CompletedToolCall;
+    const responseText = JSON.stringify(completedCall.response.responseParts);
+    expect(responseText).toContain(
+      'User intentionally cancelled this tool call before it ran.',
+    );
+    expect(responseText).toContain(
+      'Stop and await further instructions; do not retry or work around it.',
+    );
   });
 
   it('signal.abort during awaiting_approval: blocked span ends with aborted/system (#4321)', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -309,7 +309,9 @@ const TOOL_SPAN_STATUS_TOOL_TIMEOUT = 'Tool execution timed out';
 const TOOL_CANCELLED_BEFORE_COMPLETION_MESSAGE =
   'User cancelled tool execution.';
 const TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE =
-  'The tool had already completed; its output was discarded.';
+  'User intentionally cancelled this tool call after it completed. ' +
+  'Its output was discarded. Stop and await further instructions; ' +
+  'do not retry or work around it.';
 
 /**
  * Builds the failure ToolResult surfaced when a tool call exceeds the

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -396,7 +396,7 @@ const TOOL_SPAN_STATUS_TOOL_TIMEOUT = 'Tool execution timed out';
 const TOOL_CANCELLED_BEFORE_COMPLETION_MESSAGE =
   'User intentionally cancelled this tool call. Stop and await further instructions; do not retry or work around it.';
 const TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE =
-  'The tool had already completed; its output was discarded. User intentionally cancelled. Stop and await further instructions; do not retry.';
+  'The tool had already completed; its output was discarded. User intentionally cancelled. Stop and await further instructions; do not retry or work around it.';
 
 /**
  * Builds the failure ToolResult surfaced when a tool call exceeds the

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1925,7 +1925,7 @@ export class CoreToolScheduler {
     this.setStatusInternal(
       callId,
       'cancelled',
-      'Tool call cancelled by user.',
+      TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE,
       'not_started',
     );
     this.finalizeBlockedSpan(callId, 'aborted', 'system');
@@ -2065,7 +2065,7 @@ export class CoreToolScheduler {
           this.setStatusInternal(
             callId,
             'cancelled',
-            'Tool call cancelled by user.',
+            TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE,
             'not_started',
           );
           if (this.blockedSpans.has(callId)) {
@@ -3786,7 +3786,7 @@ export class CoreToolScheduler {
             this.setStatusInternal(
               reqInfo.callId,
               'cancelled',
-              'Tool call cancelled by user.',
+              TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE,
               'not_started',
             );
             // If this tool was waiting on the user, end the blocked span
@@ -3948,7 +3948,7 @@ export class CoreToolScheduler {
         this.setStatusInternal(
           callId,
           'cancelled',
-          'Tool call cancelled by user.',
+          TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE,
           'not_started',
         );
       } else {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -385,6 +385,10 @@ const TOOL_SPAN_STATUS_TOOL_CANCELLED = 'Tool execution cancelled by user';
 
 const TOOL_SPAN_STATUS_TOOL_TIMEOUT = 'Tool execution timed out';
 
+const TOOL_CANCELLATION_STOP_DIRECTIVE =
+  'Stop and await further instructions; do not retry or work around it.';
+const TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE = `User intentionally cancelled this tool call before it ran. ${TOOL_CANCELLATION_STOP_DIRECTIVE}`;
+
 // The cancellation notice handed to the model depends on whether the tool's
 // work actually finished. Claiming a tool "already completed" when it was
 // interrupted mid-flight makes the model skip work that never happened; the
@@ -393,10 +397,8 @@ const TOOL_SPAN_STATUS_TOOL_TIMEOUT = 'Tool execution timed out';
 //
 // Both messages include an explicit stop directive so the model does not
 // misattribute the cancellation as a transient fault and retry (#10170).
-const TOOL_CANCELLED_BEFORE_COMPLETION_MESSAGE =
-  'User intentionally cancelled this tool call. Stop and await further instructions; do not retry or work around it.';
-const TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE =
-  'The tool had already completed; its output was discarded. User intentionally cancelled. Stop and await further instructions; do not retry or work around it.';
+const TOOL_CANCELLED_BEFORE_COMPLETION_MESSAGE = `User intentionally cancelled this tool call. ${TOOL_CANCELLATION_STOP_DIRECTIVE}`;
+const TOOL_CANCELLED_AFTER_COMPLETION_MESSAGE = `The tool had already completed; its output was discarded. User intentionally cancelled. ${TOOL_CANCELLATION_STOP_DIRECTIVE}`;
 
 /**
  * Builds the failure ToolResult surfaced when a tool call exceeds the
@@ -2511,7 +2513,7 @@ export class CoreToolScheduler {
             request: reqInfo,
             response: createCancelledResponse(
               reqInfo,
-              'Tool call cancelled before execution.',
+              TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE,
               'not_started',
             ),
             ...(resolvedTool ? { tool: resolvedTool } : {}),
@@ -4858,7 +4860,7 @@ export class CoreToolScheduler {
       if (signal.aborted) {
         const cancelledResponse = createCancelledResponse(
           scheduledCall.request,
-          'Tool call cancelled before execution.',
+          TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE,
           'not_started',
         );
         observeSyntheticProducer(cancelledResponse);
@@ -4898,7 +4900,7 @@ export class CoreToolScheduler {
       ) {
         const cancelledResponse = createCancelledResponse(
           scheduledCall.request,
-          'Tool call cancelled before execution.',
+          TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE,
           'not_started',
         );
         observeSyntheticProducer(cancelledResponse);

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -387,7 +387,7 @@ const TOOL_SPAN_STATUS_TOOL_TIMEOUT = 'Tool execution timed out';
 
 const TOOL_CANCELLATION_STOP_DIRECTIVE =
   'Stop and await further instructions; do not retry or work around it.';
-const TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE = `User intentionally cancelled this tool call before it ran. ${TOOL_CANCELLATION_STOP_DIRECTIVE}`;
+const TOOL_CANCELLED_BEFORE_EXECUTION_MESSAGE = `This tool call was cancelled before it ran. ${TOOL_CANCELLATION_STOP_DIRECTIVE}`;
 
 // The cancellation notice handed to the model depends on whether the tool's
 // work actually finished. Claiming a tool "already completed" when it was


### PR DESCRIPTION
## What this PR does

- Updates the model-facing message for post-completion tool cancellations to make the user's Esc action explicit.
- Keeps the existing discarded-output signal while telling the model to stop and await further instructions instead of retrying or working around the cancelled tool call.
- Adds a regression assertion for the post-completion cancellation branch.

## Why it's needed

When a user presses Esc while a tool is running, the cancellation can arrive after the tool has already produced output. The previous message only said the tool had already completed and its output was discarded, which can be misread as a transient tool/runtime issue and cause the model to retry. This makes the user intent clear.

## Reviewer Test Plan

- `npm -w @qwen-code/qwen-code-core test -- src/core/coreToolScheduler.test.ts -t "post-completion cancellation"`
- `npm -w @qwen-code/qwen-code-core test -- src/core/coreToolScheduler.test.ts`
- `npm -w @qwen-code/qwen-code-core run lint`

## Risk & Scope

- Low risk: only changes the cancellation text returned to the model for the post-completion cancellation branch.
- No scheduler state-machine or tool execution behavior changes.

## Linked Issues

Fixes #10170