### PR TITLE
fix(core): recognize new DeepSeek/GLM vision models in modality defaults

### DIFF
--- a/packages/core/src/core/modalityDefaults.test.ts
+++ b/packages/core/src/core/modalityDefaults.test.ts
@@ -202,6 +202,24 @@ describe('defaultModalities', () => {
     it('returns text-only for deepseek-reasoner', () => {
       expect(defaultModalities('deepseek-reasoner')).toEqual({});
     });
+
+    it('returns image for deepseek-v4-flash-vision-exp', () => {
+      expect(defaultModalities('deepseek-v4-flash-vision-exp')).toEqual({
+        image: true,
+      });
+    });
+
+    it('returns image for deepseek-vl2', () => {
+      expect(defaultModalities('deepseek-vl2')).toEqual({ image: true });
+    });
+
+    it('returns image for deepseek-vl-chat', () => {
+      expect(defaultModalities('deepseek-vl-chat')).toEqual({ image: true });
+    });
+
+    it('returns text-only for deepseek-v3 (v-prefixed text model)', () => {
+      expect(defaultModalities('deepseek-v3')).toEqual({});
+    });
   });
 
   describe('Zhipu GLM', () => {
@@ -217,6 +235,26 @@ describe('defaultModalities', () => {
 
     it('returns text-only for glm-4.7', () => {
       expect(defaultModalities('glm-4.7')).toEqual({});
+    });
+
+    it('returns image for glm-4.6v', () => {
+      expect(defaultModalities('glm-4.6v')).toEqual({ image: true });
+    });
+
+    it('returns image for glm-5v-turbo', () => {
+      expect(defaultModalities('glm-5v-turbo').image).toBe(true);
+    });
+
+    it('returns image + video + pdf for glm-5.3-flash', () => {
+      const m = defaultModalities('glm-5.3-flash');
+      expect(m.image).toBe(true);
+      expect(m.video).toBe(true);
+      expect(m.pdf).toBe(true);
+      expect(m.audio).toBeUndefined();
+    });
+
+    it('returns text-only for glm-5.3 (non-flash)', () => {
+      expect(defaultModalities('glm-5.3')).toEqual({});
     });
   });
 

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -61,14 +61,19 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   [/^qwen/, {}],
 
   // -------------------
-  // DeepSeek — text-only
+  // DeepSeek — vision variants accept image input (deepseek-v4-flash-vision-exp,
+  // 2026-08); everything else remains text-only (QwenLM/qwen-code#10270)
   // -------------------
+  [/^deepseek-.*(vision|vl)/, { image: true }],
   [/^deepseek/, {}],
 
   // -------------------
-  // Zhipu GLM
+  // Zhipu GLM — v-suffix family (glm-4.5v/4.6v/5v-turbo) accepts image input;
+  // glm-5.3-flash natively integrates vision incl. video/pdf (BigModel docs, 2026-08);
+  // other GLM models remain text-only (QwenLM/qwen-code#10270)
   // -------------------
-  [/^glm-4\.5v/, { image: true }],
+  [/^glm-\d+(?:\.\d+)?v/, { image: true }],
+  [/^glm-5\.3-flash/, { image: true, video: true, pdf: true }],
   [/^glm-5(?:-|$)/, {}],
   [/^glm-/, {}],
 


### PR DESCRIPTION
## What this PR does

Extends the modality auto-detection table (`MODALITY_PATTERNS` in `packages/core/src/core/modalityDefaults.ts`) so the new vision-capable models are recognized without a manual `modalities` override: DeepSeek vision variants (`deepseek-v4-flash-vision-exp`, and `vl`-suffixed naming), the GLM v-suffix family (`glm-4.5v`/`glm-4.6v`/`glm-5v-turbo`), and `glm-5.3-flash` (image + video + pdf per BigModel docs, 2026-08). Text-only defaults for the rest of both families are unchanged, and explicit `modalities` overrides keep taking precedence.

## Why it's needed

Fixes #10270. The documented behavior in `docs/users/configuration/settings.md` says Qwen Code "automatically detects supported modalities … based on model name pattern matching"; the detection table predates these models, so users who don't know about the override silently lose image input (the image is swapped for a text placeholder with only a debug-level log, and these models are excluded from vision-bridge candidates). The triage on #10270 confirmed the gap and this fix direction.

## Reviewer Test Plan

### How to verify

1. `npx vitest run src/core/modalityDefaults.test.ts` (from `packages/core`) — new cases cover `deepseek-v4-flash-vision-exp`, `deepseek-vl2`/`deepseek-vl-chat`, `glm-4.6v`, `glm-5v-turbo`, `glm-5.3-flash`, plus negative controls (`deepseek-v3` v-prefixed text model, `glm-5.3` non-flash) that pin the pattern boundaries.
2. Optionally, build from source and run with a custom OpenAI-compatible provider: select `deepseek-v4-flash-vision-exp` **without** any `modalities` override and reference an image — the model should now describe the image instead of receiving the `[Unsupported image file: …]` placeholder.

### Evidence (Before & After)

**Before** (v0.22.2, no override — image silently replaced by the placeholder, model reports it cannot see it; full transcript evidence on #10270):

![before](https://github.com/jarvislee90s-dot/vision-relay/releases/download/qwen-modality-evidence-20260827/qwen-issue-deepseek-before.png)

**After** (this PR, local source build, same model entry still **without** override, non-interactive `qwen -m deepseek-v4-flash-vision-exp -p "@<image> 这张图片里是什么内容？请具体描述"`, DeepSeek official endpoint):

> 识别出 Qwen Code CLI v0.22.2 深色终端界面、QWEN 蓝粉渐变 logo、状态栏，并正确读出截图内嵌的历史对话内容（"宝蓝色西装外套、白色衬衫未系领带、佩戴眼镜、讲台前对着麦克风发言"）

The session transcript confirms the image entered the request as an `inlineData` part (both the user-message path and the `read_file` tool-result path) with no `[Unsupported image file` placeholder. Same result with `glm-5.3-flash` via the GLM coding-plan endpoint (model describes the terminal screenshot contents in detail).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local source build (`npm run build` + non-interactive CLI), Node.js ≥22 on Windows; unit tests (60/60 in `modalityDefaults.test.ts`), ESLint, typecheck, and Prettier pass on the changed files; end-to-end verified against the DeepSeek official API and the Zhipu GLM Coding Plan endpoint.

## Risk & Scope

- Main risk or tradeoff: a text-only endpoint that (incorrectly) names a model matching the new patterns would now receive multipart input and may reject it — the same tradeoff #9854 accepted (declared/detected capability beats per-family guessing).
- Not validated / out of scope: future vision models without `vision`/`vl`/`v` naming still need new entries (structural maintenance cost of the table, noted on #10270); making the placeholder replacement a user-visible warning is tracked as an optional follow-up on #10270.
- Breaking changes / migration notes: none — behavior only changes for model ids that currently get silently-downgraded image input.

## Linked Issues

Fixes #10270

<details>
<summary>中文说明</summary>

## 本 PR 的改动

扩展模态自动检测表（`packages/core/src/core/modalityDefaults.ts` 的 `MODALITY_PATTERNS`），使新发布的视觉模型无需手动 `modalities` 覆盖即可被识别：DeepSeek 视觉变体（`deepseek-v4-flash-vision-exp` 及 `vl` 后缀命名）、GLM v 后缀家族（`glm-4.5v`/`glm-4.6v`/`glm-5v-turbo`）、以及 `glm-5.3-flash`（按 BigModel 文档 2026-08 支持 image + video + pdf）。两个家族其余模型的纯文本默认不变，显式 `modalities` 覆盖依然优先。

## 为什么需要此改动

修复 #10270。`docs/users/configuration/settings.md` 文档承诺 Qwen Code 会"基于模型名模式自动检测支持的模态"；检测表早于这些模型，不知道覆盖项的用户会静默丢失图片输入（图片被替换为文本占位符、仅有一条 debug 级日志，且这些模型被排除在 vision bridge 候选之外）。#10270 的 triage 已确认该缺口与修复方向。

## 审查者测试计划

### 验证方式

1. 在 `packages/core` 下运行 `npx vitest run src/core/modalityDefaults.test.ts` —— 新用例覆盖 `deepseek-v4-flash-vision-exp`、`deepseek-vl2`/`deepseek-vl-chat`、`glm-4.6v`、`glm-5v-turbo`、`glm-5.3-flash`，以及钉住模式边界的负例（`deepseek-v3` v 前缀文本模型、`glm-5.3` 非 flash）。
2. 可选：源码构建，配置自定义 OpenAI 兼容 provider，选择 `deepseek-v4-flash-vision-exp` 且**不写**任何 `modalities` 覆盖，引用一张图片 —— 模型应能直接描述图片，而不是收到 `[Unsupported image file: …]` 占位符。

### 证据（修复前后）

**修复前**（v0.22.2，无覆盖 —— 图片被静默替换为占位符，模型表示看不到；完整 transcript 证据见 #10270）:

![修复前](https://github.com/jarvislee90s-dot/vision-relay/releases/download/qwen-modality-evidence-20260827/qwen-issue-deepseek-before.png)

**修复后**（本 PR，本地源码构建，同样**不写**覆盖，非交互 `qwen -m deepseek-v4-flash-vision-exp -p "@<图片> 这张图片里是什么内容？请具体描述"`，DeepSeek 官方端点）:

> 识别出 Qwen Code CLI v0.22.2 深色终端界面、QWEN 蓝粉渐变 logo、状态栏，并正确读出截图内嵌的历史对话内容（"宝蓝色西装外套、白色衬衫未系领带、佩戴眼镜、讲台前对着麦克风发言"）

会话 transcript 确认图片以 `inlineData` part 进入请求（用户消息路径与 `read_file` 工具结果路径均验证），`[Unsupported image file` 占位符完全消失。GLM coding plan 端点 + `glm-5.3-flash` 同样验证通过（模型详细描述了终端截图内容）。

### 测试平台

|    操作系统    | 状态  |
| :------------: | :---: |
|      macOS     | ⚠️ 未测试 |
|     Windows    | ✅ 已测试 |
|     Linux      | ⚠️ 未测试 |

### 环境（可选）

本地源码构建（`npm run build` + 非交互 CLI），Windows / Node.js ≥22；改动文件的单测（`modalityDefaults.test.ts` 60/60）、ESLint、typecheck、Prettier 全部通过；端到端对 DeepSeek 官方 API 与智谱 GLM Coding Plan 端点实测通过。

## 风险与范围

- 主要风险或取舍：命名命中新模式的纯文本端点现在会收到 multipart 输入并可能拒绝请求 —— 与 #9854 的取舍一致（检测到的能力优先于按家族猜测）。
- 未验证 / 不在范围内：未来不带 `vision`/`vl`/`v` 命名的视觉模型仍需补条目（检测表的结构性维护成本，已在 #10270 说明）；把占位符替换改为用户可见警告是 #10270 记录的可选后续。
- 破坏性变更 / 迁移说明：无 —— 仅影响当前图片输入被静默降级的模型 id。

## 关联 Issue

Fixes #10270

</details>
