### PR TITLE
fix(cli): restore goal-less startup broken by the goal-runtime wait refactor

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -200,10 +200,14 @@ jobs:
           # The docker leg runs vitest directly instead of through
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
+          # external-context-mem0-write is quarantined from push E2E while
+          # #10272 (startup hang on macOS/ecs-qwen, bisected to #10128) is
+          # open; the nightly isolated leg below still runs it, same as
+          # cron-interactive (#6986).
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
+            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --shard='${{ matrix.shard }}'
           else
-            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
+            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --shard='${{ matrix.shard }}'
           fi
 
       # The sandbox build retags the same image name every run, so on a
@@ -272,7 +276,9 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --shard="${{ matrix.shard }}"'
+        # Quarantine note: see e2e-test-linux — external-context-mem0-write
+        # hangs at startup on macOS per #10272 and is excluded until fixed.
+        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --exclude "**/interactive/external-context-mem0-write.test.ts" --shard="${{ matrix.shard }}"'
 
   isolated-nightly:
     name: '${{ matrix.label }} (nightly)'
@@ -288,6 +294,10 @@ jobs:
             test_file: 'interactive/cron-interactive.test.ts'
           - label: 'channel-plugin E2E'
             test_file: 'channel-plugin.test.ts'
+          # Quarantined from push E2E per #10272; keep nightly coverage so
+          # the fix is visible when it lands.
+          - label: 'external-context mem0 E2E'
+            test_file: 'interactive/external-context-mem0-write.test.ts'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -200,17 +200,10 @@ jobs:
           # The docker leg runs vitest directly instead of through
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
-          # external-context-mem0-write is quarantined from push E2E while
-          # #10272 (startup hang on macOS/ecs-qwen, bisected to #10128) is
-          # open; the nightly isolated leg below still runs it, same as
-          # cron-interactive (#6986). The same platform-sensitive startup
-          # stall also fails external-context-auto-recall,
-          # context-compress-interactive and qwen-serve-channel-workers on
-          # macOS/pool (ubuntu-hosted green), so they are quarantined too.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --exclude '**/interactive/external-context-auto-recall.test.ts' --exclude '**/interactive/context-compress-interactive.test.ts' --exclude '**/cli/qwen-serve-channel-workers.test.ts' --shard='${{ matrix.shard }}'
+            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
           else
-            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --exclude '**/interactive/external-context-auto-recall.test.ts' --exclude '**/interactive/context-compress-interactive.test.ts' --exclude '**/cli/qwen-serve-channel-workers.test.ts' --shard='${{ matrix.shard }}'
+            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
           fi
 
       # The sandbox build retags the same image name every run, so on a
@@ -279,9 +272,7 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-        # Quarantine note: see e2e-test-linux — external-context-mem0-write
-        # hangs at startup on macOS per #10272 and is excluded until fixed.
-        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --exclude "**/interactive/external-context-mem0-write.test.ts" --exclude "**/interactive/external-context-auto-recall.test.ts" --exclude "**/interactive/context-compress-interactive.test.ts" --exclude "**/cli/qwen-serve-channel-workers.test.ts" --shard="${{ matrix.shard }}"'
+        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --shard="${{ matrix.shard }}"'
 
   isolated-nightly:
     name: '${{ matrix.label }} (nightly)'
@@ -297,16 +288,6 @@ jobs:
             test_file: 'interactive/cron-interactive.test.ts'
           - label: 'channel-plugin E2E'
             test_file: 'channel-plugin.test.ts'
-          # Quarantined from push E2E per #10272; keep nightly coverage so
-          # the fix is visible when it lands.
-          - label: 'external-context mem0 E2E'
-            test_file: 'interactive/external-context-mem0-write.test.ts'
-          - label: 'external-context auto-recall E2E'
-            test_file: 'interactive/external-context-auto-recall.test.ts'
-          - label: 'context-compress E2E'
-            test_file: 'interactive/context-compress-interactive.test.ts'
-          - label: 'qwen-serve channel workers E2E'
-            test_file: 'cli/qwen-serve-channel-workers.test.ts'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -203,11 +203,14 @@ jobs:
           # external-context-mem0-write is quarantined from push E2E while
           # #10272 (startup hang on macOS/ecs-qwen, bisected to #10128) is
           # open; the nightly isolated leg below still runs it, same as
-          # cron-interactive (#6986).
+          # cron-interactive (#6986). The same platform-sensitive startup
+          # stall also fails external-context-auto-recall,
+          # context-compress-interactive and qwen-serve-channel-workers on
+          # macOS/pool (ubuntu-hosted green), so they are quarantined too.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --shard='${{ matrix.shard }}'
+            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --exclude '**/interactive/external-context-auto-recall.test.ts' --exclude '**/interactive/context-compress-interactive.test.ts' --exclude '**/cli/qwen-serve-channel-workers.test.ts' --shard='${{ matrix.shard }}'
           else
-            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --shard='${{ matrix.shard }}'
+            npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --exclude '**/interactive/external-context-mem0-write.test.ts' --exclude '**/interactive/external-context-auto-recall.test.ts' --exclude '**/interactive/context-compress-interactive.test.ts' --exclude '**/cli/qwen-serve-channel-workers.test.ts' --shard='${{ matrix.shard }}'
           fi
 
       # The sandbox build retags the same image name every run, so on a
@@ -278,7 +281,7 @@ jobs:
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
         # Quarantine note: see e2e-test-linux — external-context-mem0-write
         # hangs at startup on macOS per #10272 and is excluded until fixed.
-        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --exclude "**/interactive/external-context-mem0-write.test.ts" --shard="${{ matrix.shard }}"'
+        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --exclude "**/interactive/external-context-mem0-write.test.ts" --exclude "**/interactive/external-context-auto-recall.test.ts" --exclude "**/interactive/context-compress-interactive.test.ts" --exclude "**/cli/qwen-serve-channel-workers.test.ts" --shard="${{ matrix.shard }}"'
 
   isolated-nightly:
     name: '${{ matrix.label }} (nightly)'
@@ -298,6 +301,12 @@ jobs:
           # the fix is visible when it lands.
           - label: 'external-context mem0 E2E'
             test_file: 'interactive/external-context-mem0-write.test.ts'
+          - label: 'external-context auto-recall E2E'
+            test_file: 'interactive/external-context-auto-recall.test.ts'
+          - label: 'context-compress E2E'
+            test_file: 'interactive/context-compress-interactive.test.ts'
+          - label: 'qwen-serve channel workers E2E'
+            test_file: 'cli/qwen-serve-channel-workers.test.ts'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3

--- a/packages/cli/src/ui/utils/goal-runtime.test.ts
+++ b/packages/cli/src/ui/utils/goal-runtime.test.ts
@@ -37,6 +37,27 @@ describe('waitForGoalRuntime', () => {
     );
   });
 
+  it('allows Goal-less sessions when readiness throws synchronously', async () => {
+    const getGoalRuntimeReady = vi.fn((): Promise<GoalRuntime> => {
+      throw new GoalPersistenceUnavailableError();
+    });
+
+    await expect(
+      waitForGoalRuntime({ getGoalRuntimeReady }, { timeoutMs: 100 }),
+    ).resolves.toBe(true);
+  });
+
+  it('does not hide synchronous readiness errors', async () => {
+    const failure = new Error('unsupported Goal lifecycle record');
+    const getGoalRuntimeReady = vi.fn((): Promise<GoalRuntime> => {
+      throw failure;
+    });
+
+    await expect(waitForGoalRuntime({ getGoalRuntimeReady })).rejects.toBe(
+      failure,
+    );
+  });
+
   it('resolves true once the runtime settles within the timeout', async () => {
     const getGoalRuntimeReady = vi.fn().mockResolvedValue({});
     await expect(

--- a/packages/cli/src/ui/utils/goal-runtime.ts
+++ b/packages/cli/src/ui/utils/goal-runtime.ts
@@ -54,10 +54,9 @@ export async function waitForGoalRuntime(
   config: Pick<Config, 'getGoalRuntimeReady'>,
   options: { timeoutMs?: number } = {},
 ): Promise<boolean> {
-  const ready = config.getGoalRuntimeReady();
   const awaitReady = async (): Promise<void> => {
     try {
-      await ready;
+      await config.getGoalRuntimeReady();
     } catch (error) {
       if (!(error instanceof GoalPersistenceUnavailableError)) throw error;
     }


### PR DESCRIPTION
## What this PR does

Restores goal-less interactive startup by keeping the goal-runtime readiness lookup inside the existing persistence-unavailable guard. The temporary E2E quarantine is removed, so all affected tests continue running on every push lane.

## Why it's needed

When chat recording is disabled, the readiness lookup throws `GoalPersistenceUnavailableError` synchronously instead of returning a rejected promise. The timeout refactor in #10128 moved that lookup outside the guard, so the startup effect rejects before the initialized flag is set and the TUI remains on `Connecting to MCP servers...` indefinitely. The integration harness launches interactive sessions with `--no-chat-recording`, which explains the broad post-merge E2E failures tracked in #10272.

This failure is deterministic, not platform-specific. `--no-chat-recording` makes `Config.getGoalRuntime()` throw on its first branch (`!chatRecordingEnabled`), so `getGoalRuntimeReady()` always throws synchronously on every platform. The "ubuntu-hosted passes" observation in #10272 reflects shard composition, not a platform difference: non-interactive (`-p`) tests never render `AppContainer` and are unaffected, so a shard without interactive files stays green anywhere. Signal counts from the latest red main run (33080103209, 7 failing jobs): `Connecting to MCP servers` x5651, `Poll timed out` x50, network errors x0 -- the entire red is this one class.

## Reviewer Test Plan

### How to verify

1. Launch an interactive session with chat recording disabled and confirm it reaches a usable prompt instead of remaining on the initialization banner.
2. Confirm synchronous persistence-unavailable errors are treated as a valid goal-less session, while other synchronous readiness errors still propagate.
3. Run the previously affected interactive and serve E2E files and confirm they remain enabled in the normal push lanes.

### Evidence (Before & After)

Before: the CLI logged `CRITICAL: Unhandled Promise Rejection! Reason: GoalPersistenceUnavailableError` after configuration completed, then remained on `Connecting to MCP servers...` until the E2E poll timed out.

After: the focused goal-runtime suite passes 8/8, including both synchronous-error branches. Repository prepare/build and full typecheck pass. The local PTY E2E runner could not start Ink tests (`posix_openpt failed: Device not configured`); the non-PTY serve E2E passed 4/4, and the same production fix was independently verified against the mem0 and full interactive suites in #10303.

Verification gap: E2E does not run on PR lanes (`Integration Tests (CLI, No Sandbox)` is SKIPPED here; e2e.yml has no `pull_request` trigger). Please dispatch an e2e run against this PR head before merging -- that is the only outstanding check.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ build, typecheck, unit; PTY unavailable |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ independently verified in #10303 |

### Environment (optional)

Node 22 project toolchain; macOS local worktree.

## Risk & Scope

- Main risk or tradeoff: negligible; only the already-declared persistence-unavailable error is treated as settled, and the regression test confirms other synchronous errors still propagate.
- Not validated / out of scope: the separate lease-contention timeout behavior remains unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10272

Also fixes the auto-filed duplicates of the same regression:
Fixes #10293
Fixes #10298
Fixes #10299
Fixes #10306
Fixes #10308

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

恢复无 Goal 的交互式启动：goal runtime 就绪查询重新置于现有的“持久化不可用”保护逻辑内。临时 E2E quarantine 已撤销，所有受影响测试继续在每条 push lane 中运行。

## 为什么需要

关闭聊天记录时，就绪查询会同步抛出 `GoalPersistenceUnavailableError`，而不是返回 rejected promise。#10128 的超时重构把该查询移到了保护逻辑之外，导致启动 effect 在 initialized 标志写入前 reject，TUI 永久停在 `Connecting to MCP servers...`。集成测试框架通过 `--no-chat-recording` 启动交互会话，这解释了 #10272 跟踪的大范围合并后 E2E 失败。

该失败是确定性的，与平台无关。`--no-chat-recording` 使 `Config.getGoalRuntime()` 在第一个分支（`!chatRecordingEnabled`）就抛出，因此 `getGoalRuntimeReady()` 在任何平台上 都必定同步抛出。#10272 中"ubuntu-hosted 通过"反映的是分片构成而非平台差异：非交互（`-p`） 测试不渲染 `AppContainer`，不受影响，因此不含 interactive 文件的分片在任何平台都是绿的。 最近一次 main 红色运行（33080103209，7 个 job 失败）的信号统计： `Connecting to MCP servers` 5651 次、`Poll timed out` 50 次、网络错误 0 次 —— 红的全部是这一个类。

## 评审测试计划

### 如何验证

1. 关闭聊天记录启动交互会话，确认它进入可用提示符，而不是停在初始化横幅。
2. 确认同步的持久化不可用异常被视为合法的无 Goal 会话，其他同步就绪异常仍继续抛出。
3. 运行此前受影响的 interactive 与 serve E2E 文件，确认它们仍在普通 push lane 中启用。

### 前后证据

修复前：配置初始化完成后，CLI 记录 `CRITICAL: Unhandled Promise Rejection! Reason: GoalPersistenceUnavailableError`，随后一直停在 `Connecting to MCP servers...`，直到 E2E 轮询超时。

修复后：聚焦 goal-runtime 测试 8/8 通过，覆盖两类同步异常分支；仓库 prepare/build 和完整 typecheck 通过。本地 PTY E2E runner 无法启动 Ink 测试（`posix_openpt failed: Device not configured`）；非 PTY serve E2E 4/4 通过，相同生产修复也已在 #10303 中针对 mem0 与完整 interactive 套件独立验证。

验证缺口：E2E 不在 PR lane 运行（此处 `Integration Tests (CLI, No Sandbox)` 为 SKIPPED； e2e.yml 无 `pull_request` 触发器）。合并前请针对本 PR head 手动 dispatch 一次 e2e 运行 —— 这是唯一尚未闭环的检查。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ build、typecheck、单测；PTY 不可用 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 已在 #10303 独立验证 |

### 环境（可选）

Node 22 项目工具链；macOS 本地 worktree。

## 风险与范围

- 主要风险或权衡：极低；只有已经声明的持久化不可用异常会被视为 settled，回归测试确认其他同步异常仍继续抛出。
- 未验证 / 超出范围：独立的租约竞争超时行为保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10272

同一回归的自动重复报告（一并关闭）：#10293、#10298、#10299、#10306、#10308。

</details>

