### PR TITLE
fix(skills): separate extension identity from display name

### DIFF
--- a/docs/design/extension-skill-owner-identity.md
+++ b/docs/design/extension-skill-owner-identity.md
@@ -1,0 +1,38 @@
+# Extension Skill Owner Identity
+
+## Problem
+
+`GET /workspace/skills` exposes the owner of an extension-level Skill through
+`extensionName`. Extension discovery currently stores the localized Extension
+display name in that field. Display names can change with locale and are not
+unique, so clients cannot use the response to join a Skill to its Extension.
+
+## Contract
+
+- `extensionName` is the canonical `name` from the loaded Extension manifest.
+- `extensionDisplayName` is the optional, locale-resolved display name.
+- Identity matching, inactive-state checks, and snapshot deduplication use only
+  `extensionName`.
+- Presentation uses `extensionDisplayName ?? extensionName`.
+
+Both fields remain optional because non-Extension Skills do not have an owner
+and older daemons do not expose `extensionDisplayName`. The status schema stays
+at version 1 because the new field is additive.
+
+## Data flow
+
+The Skill manager records both values when it enumerates active Extensions.
+The ACP workspace snapshot applies the same rule when it synthesizes Skills
+from inactive Extensions. The shared workspace-skills mapper then projects the
+two values into the ACP Bridge and TypeScript SDK status types.
+
+CLI and Web Shell presentation read the display field with a canonical-name
+fallback. MCP and Agent ownership metadata are separate contracts and are not
+changed here.
+
+## Compatibility
+
+Existing third-party clients continue to receive `extensionName`, but its value
+is corrected from display text to the manifest identity. Clients that need a
+friendly label can adopt `extensionDisplayName`; new clients remain compatible
+with older daemons by falling back to `extensionName`.

--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -1386,6 +1386,17 @@ Recommended poll cadence: aligned with whatever already polls `/workspace/mcp`; 
       "userInvocable": false,
       "installedPath": "/home/alice/project/.qwen/skills/review/SKILL.md",
       "argumentHint": "[path]"
+    },
+    {
+      "kind": "skill",
+      "status": "ok",
+      "name": "database-review",
+      "description": "Review database changes",
+      "level": "extension",
+      "modelInvocable": true,
+      "installedPath": "/home/alice/.qwen/extensions/alibabacloud-database-suite/skills/database-review/SKILL.md",
+      "extensionName": "alibabacloud-database-suite",
+      "extensionDisplayName": "Alibaba Cloud Database Suite"
     }
   ]
 }
@@ -1402,6 +1413,11 @@ canonicalizing it. Current daemons emit it for every skill, while clients must
 tolerate its absence from older v1 daemons. Skill bodies, hooks, `skillRoot`,
 and other skill configuration remain excluded. `errors` is omitted when
 discovery succeeds.
+
+For extension-owned skills, `extensionName` is the canonical manifest name and
+is safe to use as the owner identity. `extensionDisplayName` is an optional,
+localized presentation value and may be non-unique. New clients should display
+`extensionDisplayName ?? extensionName`; older daemons omit the display field.
 
 Repeated reads are served from the last committed workspace snapshot,
 periodically revalidated against the child's in-memory cache. A read never

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -480,7 +480,10 @@ export interface ServeWorkspaceSkillStatus extends ServeStatusCell {
   installedPath?: string;
   argumentHint?: string;
   model?: string;
+  /** Canonical name of the extension that provides this skill. */
   extensionName?: string;
+  /** Localized presentation name; never use as an extension identity. */
+  extensionDisplayName?: string;
 }
 
 export interface ServeWorkspaceSkillsRefreshResult {

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -6298,6 +6298,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         description: 'Cross-phase audit',
         level: 'extension',
         extensionName: 'gsd-core',
+        extensionDisplayName: 'GSD Core',
         disableModelInvocation: false,
         body: 'extension secret body',
         filePath: '/ext/gsd-core/skills/gsd-audit-uat/SKILL.md',
@@ -6306,7 +6307,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         name: 'gsd-display-stale',
         description: 'Display-name stale extension skill',
         level: 'extension',
-        extensionName: 'GSD Core',
+        extensionName: 'gsd-core',
+        extensionDisplayName: 'GSD Core',
         disableModelInvocation: false,
         body: 'display stale body',
         filePath: '/ext/gsd-core/skills/gsd-display-stale/SKILL.md',
@@ -6393,6 +6395,26 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
               disableModelInvocation: false,
               body: 'config only body',
               filePath: '/ext/gsd-core/skills/gsd-config-only/SKILL.md',
+            },
+          ],
+        },
+        {
+          id: 'gsd-tools',
+          name: 'gsd-tools',
+          displayName: 'GSD Core',
+          version: '1.0.0',
+          isActive: false,
+          path: '/ext/gsd-tools',
+          config: { name: 'gsd-tools', version: '1.0.0' },
+          contextFiles: [],
+          skills: [
+            {
+              name: 'gsd-config-only',
+              description: 'Colliding config-only extension skill',
+              level: 'extension',
+              disableModelInvocation: false,
+              body: 'colliding config only body',
+              filePath: '/ext/gsd-tools/skills/gsd-config-only/SKILL.md',
             },
           ],
         },
@@ -6602,6 +6624,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           description: 'Cross-phase audit',
           level: 'extension',
           extensionName: 'gsd-core',
+          extensionDisplayName: 'GSD Core',
           modelInvocable: true,
         }),
         expect.objectContaining({
@@ -6610,7 +6633,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           name: 'gsd-display-stale',
           description: 'Display-name stale extension skill',
           level: 'extension',
-          extensionName: 'GSD Core',
+          extensionName: 'gsd-core',
+          extensionDisplayName: 'GSD Core',
           modelInvocable: true,
           installedPath: '/ext/gsd-core/skills/gsd-display-stale/SKILL.md',
         }),
@@ -6620,9 +6644,21 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           name: 'gsd-config-only',
           description: 'Config-only extension skill',
           level: 'extension',
-          extensionName: 'GSD Core',
+          extensionName: 'gsd-core',
+          extensionDisplayName: 'GSD Core',
           modelInvocable: true,
           installedPath: '/ext/gsd-core/skills/gsd-config-only/SKILL.md',
+        }),
+        expect.objectContaining({
+          kind: 'skill',
+          status: 'disabled',
+          name: 'gsd-config-only',
+          description: 'Colliding config-only extension skill',
+          level: 'extension',
+          extensionName: 'gsd-tools',
+          extensionDisplayName: 'GSD Core',
+          modelInvocable: true,
+          installedPath: '/ext/gsd-tools/skills/gsd-config-only/SKILL.md',
         }),
       ]),
     });
@@ -6634,7 +6670,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     ).toHaveLength(1);
     expect(
       skills.skills.filter((skill) => skill.name === 'gsd-config-only'),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
     expect(skillsAgain).toEqual(skills);
     expect(getCachedSkills).toHaveBeenCalledTimes(2);
     // Each read validates that the extension sources have not moved, but an
@@ -6648,6 +6684,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(JSON.stringify(skills)).not.toContain('extension secret body');
     expect(JSON.stringify(skills)).not.toContain('display stale body');
     expect(JSON.stringify(skills)).not.toContain('config only body');
+    expect(JSON.stringify(skills)).not.toContain('colliding config only body');
     expect(JSON.stringify(skills)).not.toContain('"skillRoot"');
     expect(JSON.stringify(skills)).not.toContain('secret-hook');
 

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6833,14 +6833,9 @@ class QwenAgent implements Agent {
       for (const extension of config.getExtensions()) {
         if (extension.isActive) continue;
         for (const skill of extension.skills ?? []) {
-          const extensionName = extension.displayName ?? extension.name;
+          const extensionName = extension.name;
           const key = `extension:${extensionName}:${skill.name}`;
-          if (
-            skillsByKey.has(`extension:${extension.name}:${skill.name}`) ||
-            skillsByKey.has(key)
-          ) {
-            continue;
-          }
+          if (skillsByKey.has(key)) continue;
           skillsByKey.set(
             key,
             mapSkillConfigToStatus(
@@ -6848,6 +6843,7 @@ class QwenAgent implements Agent {
                 ...skill,
                 level: 'extension',
                 extensionName,
+                extensionDisplayName: extension.displayName,
               },
               disablements,
               { disabled: true },

--- a/packages/cli/src/acp-integration/extension-skills.test.ts
+++ b/packages/cli/src/acp-integration/extension-skills.test.ts
@@ -56,13 +56,19 @@ function extensionSkill(name: string): SkillConfig {
 }
 
 describe('extension skill activity helpers', () => {
-  it('matches skills from inactive extensions by name and displayName', () => {
+  it('matches skills from inactive extensions only by canonical name', () => {
     const refs = inactiveExtensionSkillRefs(
       configWithExtensions([
         extension({
           name: 'canonical-ext',
-          displayName: 'Display Ext',
+          displayName: 'Shared Display',
           isActive: false,
+          skills: [extensionSkill('audit')],
+        }),
+        extension({
+          name: 'active-ext',
+          displayName: 'Shared Display',
+          isActive: true,
           skills: [extensionSkill('audit')],
         }),
       ]),
@@ -71,8 +77,11 @@ describe('extension skill activity helpers', () => {
     expect(
       isInactiveExtensionSkill(skill('audit', 'canonical-ext'), refs),
     ).toBe(true);
-    expect(isInactiveExtensionSkill(skill('audit', 'Display Ext'), refs)).toBe(
-      true,
+    expect(
+      isInactiveExtensionSkill(skill('audit', 'Shared Display'), refs),
+    ).toBe(false);
+    expect(isInactiveExtensionSkill(skill('audit', 'active-ext'), refs)).toBe(
+      false,
     );
   });
 

--- a/packages/cli/src/acp-integration/extension-skills.ts
+++ b/packages/cli/src/acp-integration/extension-skills.ts
@@ -16,10 +16,6 @@ export function inactiveExtensionSkillRefs(config: Config): Set<string> {
     if (extension.isActive) continue;
     for (const skill of extension.skills ?? []) {
       refs.add(extensionSkillRef(extension.name, skill.name));
-      // SkillManager exposes extensionName as displayName ?? name.
-      if (extension.displayName) {
-        refs.add(extensionSkillRef(extension.displayName, skill.name));
-      }
     }
   }
   return refs;

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -5416,7 +5416,8 @@ describe('Session', () => {
             body: 'Visible collision instructions',
             filePath: '/skills/collision/SKILL.md',
             level: 'extension',
-            extensionName: 'Disabled Extension',
+            extensionName: 'active-ext',
+            extensionDisplayName: 'Disabled Extension',
           },
           {
             name: 'disabled-extension-skill',
@@ -5424,7 +5425,8 @@ describe('Session', () => {
             body: 'Hidden instructions',
             filePath: '/skills/disabled/SKILL.md',
             level: 'extension',
-            extensionName: 'Disabled Extension',
+            extensionName: 'disabled-ext',
+            extensionDisplayName: 'Disabled Extension',
           },
         ]),
       });

--- a/packages/cli/src/runtime/workspace-skills-mapping.test.ts
+++ b/packages/cli/src/runtime/workspace-skills-mapping.test.ts
@@ -82,16 +82,27 @@ describe('mapSkillConfigToStatus', () => {
     expect(status).not.toHaveProperty('lockedScope');
   });
 
-  it('surfaces optional model and extensionName only when present', () => {
-    expect(mapSkillConfigToStatus(makeSkill())).not.toHaveProperty('model');
-    expect(mapSkillConfigToStatus(makeSkill())).not.toHaveProperty(
-      'extensionName',
+  it('surfaces optional model and extension identity only when present', () => {
+    const nonExtension = mapSkillConfigToStatus(
+      makeSkill({
+        extensionName: 'ignored',
+        extensionDisplayName: 'Ignored',
+      }),
     );
+    expect(nonExtension).not.toHaveProperty('model');
+    expect(nonExtension).not.toHaveProperty('extensionName');
+    expect(nonExtension).not.toHaveProperty('extensionDisplayName');
 
     const status = mapSkillConfigToStatus(
-      makeSkill({ model: 'gpt-4o', extensionName: 'acme' }),
+      makeSkill({
+        level: 'extension',
+        model: 'gpt-4o',
+        extensionName: 'acme',
+        extensionDisplayName: 'Acme Tools',
+      }),
     );
     expect(status.model).toBe('gpt-4o');
     expect(status.extensionName).toBe('acme');
+    expect(status.extensionDisplayName).toBe('Acme Tools');
   });
 });

--- a/packages/cli/src/runtime/workspace-skills-mapping.ts
+++ b/packages/cli/src/runtime/workspace-skills-mapping.ts
@@ -40,6 +40,11 @@ export function mapSkillConfigToStatus(
     installedPath: skill.filePath,
     ...(skill.argumentHint ? { argumentHint: skill.argumentHint } : {}),
     ...(skill.model ? { model: skill.model } : {}),
-    ...(skill.extensionName ? { extensionName: skill.extensionName } : {}),
+    ...(skill.level === 'extension' && skill.extensionName
+      ? { extensionName: skill.extensionName }
+      : {}),
+    ...(skill.level === 'extension' && skill.extensionDisplayName
+      ? { extensionDisplayName: skill.extensionDisplayName }
+      : {}),
   };
 }

--- a/packages/cli/src/services/SkillCommandLoader.test.ts
+++ b/packages/cli/src/services/SkillCommandLoader.test.ts
@@ -330,6 +330,7 @@ describe('SkillCommandLoader', () => {
       const skill = makeSkill({
         level: 'extension',
         extensionName: 'superpowers-lab',
+        extensionDisplayName: 'Superpowers Lab',
         description: 'Use tmux for interactive commands',
       });
       mockSkillManager.listSkills.mockImplementation(
@@ -342,8 +343,11 @@ describe('SkillCommandLoader', () => {
 
       expect(commands[0].modelInvocable).toBe(true);
       expect(commands[0].source).toBe('plugin-command');
-      expect(commands[0].sourceLabel).toBe('Extension: superpowers-lab');
+      expect(commands[0].sourceLabel).toBe('Extension: Superpowers Lab');
       expect(commands[0].sourceDetail).toBe('extension');
+      expect(commands[0].skillDetail).toMatchObject({
+        extensionName: 'superpowers-lab',
+      });
     });
 
     it('should be modelInvocable when whenToUse is present', async () => {
@@ -362,6 +366,7 @@ describe('SkillCommandLoader', () => {
       const commands = await loader.loadCommands(signal);
 
       expect(commands[0].modelInvocable).toBe(true);
+      expect(commands[0].sourceLabel).toBe('Extension: superpowers-lab');
     });
 
     it('should NOT be modelInvocable when description and whenToUse are absent', async () => {

--- a/packages/cli/src/services/SkillCommandLoader.ts
+++ b/packages/cli/src/services/SkillCommandLoader.ts
@@ -117,7 +117,7 @@ export class SkillCommandLoader implements ICommandLoader {
             : true;
 
         const sourceLabel = isExtension
-          ? `${t('Extension:')} ${skill.extensionName ?? 'unknown'}`
+          ? `${t('Extension:')} ${skill.extensionDisplayName ?? skill.extensionName ?? 'unknown'}`
           : skill.level === 'project'
             ? t('Project')
             : t('User');

--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -880,6 +880,43 @@ Body`);
       expect(badSkill?.priority).toBe(0);
     });
 
+    it('uses the canonical extension name for extension-owned skills', async () => {
+      vi.spyOn(mockConfig, 'getActiveExtensions').mockReturnValue([
+        {
+          id: 'database-suite',
+          name: 'alibabacloud-database-suite',
+          displayName: 'Alibaba Cloud Database Suite',
+          version: '1.0.0',
+          isActive: true,
+          path: '/extension',
+          config: {
+            name: 'alibabacloud-database-suite',
+            version: '1.0.0',
+          },
+          contextFiles: [],
+          skills: [
+            {
+              name: 'database-review',
+              description: 'Review database changes',
+              body: 'Body',
+              filePath: '/extension/skills/database-review/SKILL.md',
+              level: 'extension',
+            },
+          ],
+        },
+      ]);
+
+      const skills = await manager.listSkills({
+        level: 'extension',
+        force: true,
+      });
+
+      expect(skills[0]?.extensionName).toBe('alibabacloud-database-suite');
+      expect(skills[0]?.extensionDisplayName).toBe(
+        'Alibaba Cloud Database Suite',
+      );
+    });
+
     it('should deduplicate same-name skills across provider dirs within a level', async () => {
       // Override readdir to return the same skill name from both .qwen and .agents dirs
       vi.mocked(fs.readdir).mockReset();

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -1003,7 +1003,8 @@ export class SkillManager {
           }
           skills.push({
             ...skill,
-            extensionName: extension.displayName ?? extension.name,
+            extensionName: extension.name,
+            extensionDisplayName: extension.displayName,
             // Normalize so downstream consumers reading `skill.priority`
             // (e.g. the `/skills` display sort) observe the same value
             // reflected by the warning above.

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -89,9 +89,15 @@ export interface SkillConfig {
   body: string;
 
   /**
-   * For extension-level skills: the name of the providing extension
+   * For extension-level skills: the canonical name of the providing extension
    */
   extensionName?: string;
+
+  /**
+   * For extension-level skills: the localized display name of the providing
+   * extension. Presentation only; never use this field as an identity.
+   */
+  extensionDisplayName?: string;
 
   /**
    * Argument hint shown after the slash command name in completion menus.

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -1883,7 +1883,10 @@ export interface DaemonWorkspaceSkillStatus extends DaemonStatusCell {
   installedPath?: string;
   argumentHint?: string;
   model?: string;
+  /** Canonical name of the extension that provides this skill. */
   extensionName?: string;
+  /** Localized presentation name; never use as an extension identity. */
+  extensionDisplayName?: string;
 }
 
 export interface DaemonWorkspaceSkillsStatus {

--- a/packages/web-shell/client/components/skills/SkillsManagerPage.tsx
+++ b/packages/web-shell/client/components/skills/SkillsManagerPage.tsx
@@ -18,6 +18,7 @@ import { useI18n } from '../../i18n';
 import {
   filterSkills,
   preserveSkillSelection,
+  skillExtensionLabel,
   type SkillLevelFilter,
   type SkillStatusFilter,
 } from './skills-manager-logic';
@@ -517,7 +518,7 @@ export function SkillsManagerPage({
               />
               <DetailField
                 label={t('skills.extension')}
-                value={selectedSkill.extensionName || '-'}
+                value={skillExtensionLabel(selectedSkill)}
               />
               {selectedSkill.hint ? (
                 <div className="sm:col-span-2">

--- a/packages/web-shell/client/components/skills/skills-manager-logic.test.ts
+++ b/packages/web-shell/client/components/skills/skills-manager-logic.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { DaemonWorkspaceSkillStatus } from '@qwen-code/webui/daemon-react-sdk';
-import { filterSkills, preserveSkillSelection } from './skills-manager-logic';
+import {
+  filterSkills,
+  preserveSkillSelection,
+  skillExtensionLabel,
+} from './skills-manager-logic';
 
 const skills: DaemonWorkspaceSkillStatus[] = [
   {
@@ -11,6 +15,7 @@ const skills: DaemonWorkspaceSkillStatus[] = [
     level: 'extension',
     modelInvocable: true,
     extensionName: 'design-pack',
+    extensionDisplayName: 'Design Pack',
   },
   {
     kind: 'skill',
@@ -54,5 +59,16 @@ describe('skills manager logic', () => {
   it('preserves only a selection that still exists', () => {
     expect(preserveSkillSelection('review', skills)).toBe('review');
     expect(preserveSkillSelection('removed', skills)).toBeNull();
+  });
+
+  it('uses the extension display name only for presentation', () => {
+    expect(skillExtensionLabel(skills[0])).toBe('Design Pack');
+    expect(
+      skillExtensionLabel({
+        ...skills[0],
+        extensionDisplayName: undefined,
+      }),
+    ).toBe('design-pack');
+    expect(skillExtensionLabel(skills[1])).toBe('-');
   });
 });

--- a/packages/web-shell/client/components/skills/skills-manager-logic.ts
+++ b/packages/web-shell/client/components/skills/skills-manager-logic.ts
@@ -3,6 +3,10 @@ import type { DaemonWorkspaceSkillStatus } from '@qwen-code/webui/daemon-react-s
 export type SkillLevelFilter = 'all' | DaemonWorkspaceSkillStatus['level'];
 export type SkillStatusFilter = 'all' | 'enabled' | 'disabled';
 
+export function skillExtensionLabel(skill: DaemonWorkspaceSkillStatus): string {
+  return skill.extensionDisplayName ?? skill.extensionName ?? '-';
+}
+
 export function filterSkills(
   skills: readonly DaemonWorkspaceSkillStatus[],
   query: string,


### PR DESCRIPTION
## What this PR does

This PR separates Extension Skill ownership identity from presentation metadata in the workspace skills status contract. Extension-owned Skills now expose the canonical manifest name through `extensionName` and the optional localized label through `extensionDisplayName`, consistently for active and inactive Extensions.

All inactive-state matching and snapshot deduplication use only the canonical owner name. The CLI and Web Shell continue to show a friendly label by preferring `extensionDisplayName` and falling back to `extensionName`, including when connected to an older daemon that does not provide the new field.

The public ACP Bridge and TypeScript SDK status types and the daemon protocol documentation declare the same additive v1 contract.

## Why it's needed

`extensionName` previously contained a localized display name. Display names can change with locale and are not unique, so consumers could not reliably join a Skill to its owning Extension, and two Extensions sharing a label could affect each other's inactive-state or deduplication behavior.

## Reviewer Test Plan

### How to verify

1. Install an Extension whose manifest name differs from its display name and that provides a Skill. Request `GET /workspace/skills` while the Extension is active; the Skill should return the manifest name in `extensionName`, the friendly label in `extensionDisplayName`, and `status: "ok"`.
2. Disable the Extension at workspace scope and request the endpoint again. The same identity and display fields should remain, while the Skill should return `status: "disabled"` and `disabledReason: "inactive_extension"`.
3. Configure two Extensions with the same display name and the same Skill name. The snapshot should retain one row per canonical Extension owner, and inactive matching should affect only the canonical owner that is disabled.
4. Confirm the CLI Skill source label and Web Shell Skill detail prefer the display name. When the display field is absent, both should show the canonical name.

### Evidence (Before & After)

Before:

```json
{
  "extensionName": "Alibaba Cloud Database Suite"
}
```

After:

```json
{
  "extensionName": "alibabacloud-database-suite",
  "extensionDisplayName": "Alibaba Cloud Database Suite"
}
```

Local verification passed with the freshly built daemon in both active and inactive states. Focused Core, CLI, ACP workspace snapshot, Session, and Web Shell tests passed, as did `npm run build`, `npm run typecheck`, and lint validation.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

The real daemon was started on loopback with an isolated home and workspace. A local Extension fixture was installed through the daemon API, queried while active, disabled at workspace scope, and queried again.

## Risk & Scope

- Main risk or tradeoff: Third-party clients that display `extensionName` directly will now show the technical manifest name. Official clients preserve the friendly label through the new optional display field and canonical fallback.
- Not validated / out of scope: Windows and Linux were not tested locally. MCP and Agent fields with the same name are separate contracts and are intentionally unchanged.
- Breaking changes / migration notes: No migration or schema-version bump is required. `extensionDisplayName` is additive and optional; `extensionName` keeps its existing field shape but now carries its documented canonical identity.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 在 workspace skills 状态契约中拆分 Extension Skill 的归属标识与展示元数据。Extension 所属 Skill 现在统一通过 `extensionName` 返回 manifest canonical name，并通过可选的 `extensionDisplayName` 返回本地化展示名称，active 与 inactive Extension 保持一致。

所有 inactive 状态匹配和快照去重只使用 canonical owner name。CLI 与 Web Shell 继续优先展示 `extensionDisplayName`，并回退到 `extensionName`；连接不返回新字段的旧 daemon 时也能正常展示。

ACP Bridge、TypeScript SDK 的公共状态类型以及 daemon 协议文档同步声明了这一 additive v1 契约。

## 为什么需要

`extensionName` 之前承载的是本地化展示名称。展示名称会随语言环境变化，也不保证唯一，因此消费者无法可靠地将 Skill 关联到归属 Extension；两个共享展示名称的 Extension 还可能在 inactive 判断或去重时互相影响。

## Reviewer 验证计划

### 如何验证

1. 安装一个 manifest name 与 display name 不同、且提供 Skill 的 Extension。Extension 启用时请求 `GET /workspace/skills`；Skill 应在 `extensionName` 返回 manifest name，在 `extensionDisplayName` 返回友好名称，并返回 `status: "ok"`。
2. 在 workspace scope 禁用该 Extension 后再次请求接口。两个归属字段应保持不变，同时 Skill 应返回 `status: "disabled"` 和 `disabledReason: "inactive_extension"`。
3. 配置两个 display name 相同且 Skill name 相同的 Extension。快照应按 canonical Extension owner 分别保留一行，inactive 匹配只影响真正被禁用的 canonical owner。
4. 确认 CLI Skill 来源标签和 Web Shell Skill 详情优先展示 display name；缺少 display 字段时，两处都应展示 canonical name。

### Before / After 证据

Before：

```json
{
  "extensionName": "Alibaba Cloud Database Suite"
}
```

After：

```json
{
  "extensionName": "alibabacloud-database-suite",
  "extensionDisplayName": "Alibaba Cloud Database Suite"
}
```

本地使用最新构建的 daemon 验证了 active 与 inactive 两种状态。Core、CLI、ACP workspace snapshot、Session 和 Web Shell 定向测试均通过，`npm run build`、`npm run typecheck` 与 lint 验证也通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

真实 daemon 在隔离的 home 与 workspace 中通过 loopback 启动。通过 daemon API 安装本地 Extension fixture，分别在启用状态查询、以 workspace scope 禁用后再次查询。

## 风险与范围

- 主要风险或权衡：直接展示 `extensionName` 的第三方客户端现在会显示技术性的 manifest name。官方客户端通过新增的可选展示字段与 canonical fallback 保持友好展示。
- 未验证 / 不在范围：未在 Windows 和 Linux 本地验证。MCP、Agent 中的同名字段属于独立契约，本 PR 有意不修改。
- Breaking changes / 迁移说明：无需迁移或提升 schema 版本。`extensionDisplayName` 是 additive optional 字段；`extensionName` 的字段形态不变，但其值修正为文档定义的 canonical identity。

## 关联 Issue

N/A

</details>
