### PR TITLE
fix(test): mount channel plugin fixture in Docker

### DIFF
--- a/integration-tests/cli/qwen-serve-channel-workers.test.ts
+++ b/integration-tests/cli/qwen-serve-channel-workers.test.ts
@@ -271,6 +271,7 @@ describe('qwen serve multi-workspace channel workers', () => {
       QWEN_HOME: qwenHome,
       QWEN_RUNTIME_DIR: runtimeDir,
       QWEN_CODE_TRUSTED_FOLDERS_PATH: trustedFoldersPath,
+      SANDBOX_MOUNTS: REPO_ROOT,
       OPENAI_API_KEY: 'fake-key',
       OPENAI_BASE_URL: 'http://127.0.0.1:9/v1',
       OPENAI_MODEL: 'fake-model',


### PR DESCRIPTION
## What this PR does

Keeps the repository-backed mock channel extension available when the integration fixture creates an ACP session inside the Docker sandbox. The fixture now adds the repository root to the sandbox mount list; the existing mount parser makes this read-only by default.

## Why it's needed

The fixture installs the mock extension into its temporary Qwen home as an absolute symlink to the repository. The host-side channel worker can load that symlink, but the nested Docker sandbox previously mounted only the temporary workspace, Qwen home, runtime directory, and `/tmp`. Inside the container the repository target was absent, extension discovery failed with `ENOENT`, and `/session new review` returned only `Could not create task "review".` This caused the Docker integration job in release run 33085036437 to fail on all retries.

## Reviewer Test Plan

### How to verify

1. With Docker available, run `QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli/qwen-serve-channel-workers.test.ts -t 'controls a real mock-plugin worker after a channel-less boot' --retry=0`. Confirm both the channel worker and the nested ACP session load the extension, and the first `/session new review` creates and selects the task.
2. Run the same file with `QWEN_SANDBOX=false`. Confirm all four channel-worker scenarios still pass.
3. Run the sandbox unit suite and confirm repository mounts remain read-only when no explicit mode is supplied.

### Evidence (Before & After)

N/A — integration-test fixture only; no user-visible UI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ build, bundle, typecheck, no-sandbox integration, sandbox unit tests |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested locally; failing release runner was Linux/Docker |

### Environment (optional)

Node 22.22.0 and npm 10.9.4. The local Docker client was installed, but its daemon was not running, so the Docker E2E itself remains for CI/reviewer verification.

## Risk & Scope

- Main risk or tradeoff: the test sandbox gains read-only visibility into the repository so Node can resolve the linked extension and its workspace dependencies; production sandbox behavior is unchanged.
- Not validated / out of scope: local execution of the Docker E2E; the separate interactive startup failure from the same release run is handled by #10290.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #10312.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

确保集成测试 fixture 在 Docker 沙箱中创建 ACP 会话时，仍能访问仓库内的 mock channel 扩展。fixture 现在将仓库根目录加入沙箱挂载列表；现有挂载解析逻辑默认以只读方式挂载。

## 为什么需要

该 fixture 使用绝对软链接，将临时 Qwen home 中的 mock 扩展指向仓库目录。宿主侧 channel worker 能加载这个软链接，但嵌套 Docker 沙箱此前只挂载临时 workspace、Qwen home、runtime 目录和 `/tmp`。容器内缺少仓库目标路径，扩展发现因此以 `ENOENT` 失败，`/session new review` 最终只返回 `Could not create task "review".`。这导致发版运行 33085036437 的 Docker 集成 job 在所有重试中均失败。

## Reviewer Test Plan

### 如何验证

1. 在 Docker 可用时运行 `QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli/qwen-serve-channel-workers.test.ts -t 'controls a real mock-plugin worker after a channel-less boot' --retry=0`。确认 channel worker 和嵌套 ACP 会话都能加载扩展，并且第一次 `/session new review` 能创建并选中任务。
2. 使用 `QWEN_SANDBOX=false` 运行同一测试文件，确认四个 channel worker 场景仍全部通过。
3. 运行 sandbox 单元测试，确认未显式指定模式的仓库挂载仍为只读。

### 前后对比证据

N/A —— 仅修改集成测试 fixture，没有用户可见 UI 变化。

### 测试平台

|   操作系统   | 状态 |
| :----------: | :--: |
| 🍏 macOS | ✅ build、bundle、typecheck、无沙箱集成测试、sandbox 单元测试 |
| 🪟 Windows | ⚠️ 未测试 |
| 🐧 Linux | ⚠️ 本地未测试；失败的发版 runner 为 Linux/Docker |

### 环境（可选）

Node 22.22.0、npm 10.9.4。本地已安装 Docker 客户端，但 daemon 未运行，因此 Docker E2E 留给 CI/Reviewer 验证。

## 风险与范围

- 主要风险或权衡：测试沙箱获得仓库的只读可见性，以便 Node 解析软链接扩展及其 workspace 依赖；生产沙箱行为不变。
- 未验证 / 超出范围：本地执行 Docker E2E；同一次发版运行中的独立交互启动故障由 #10290 处理。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

关联 #10312。

</details>
