### PR TITLE
fix(ci): treat API-error triage responses as failed runs in qwen-triage.yml

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -942,6 +942,30 @@ jobs:
             fi
             exit 1
           fi
+          # A non-empty response is not necessarily a triage: on an API error
+          # the stream-json adapter appends the formatted error LAST
+          # (BaseJsonOutputAdapter appendText), optionally followed by
+          # rate-limit guidance. Run 33070765162 (triage for #10285) answered
+          # with a bare 268-char "[API Error: Connection error. ...]" that
+          # this step passed as success, so nothing retried or alerted. Strip
+          # the known suffixes, right-trim, then fail on the trailing shape --
+          # a real summary that merely quotes an API error mid-prose keeps
+          # writing afterwards and stays green. Same pattern as
+          # qwen-code-pr-review.yml.
+          BODY="${RESPONSE}"
+          for S in \
+            'Possible quota limitations in place or slow response times detected. Please wait and try again later.' \
+            'Please wait and try again later. To increase your limits, request a quota increase through AI Studio, or switch to another /auth method' \
+            'Please wait and try again later. To increase your limits, request a quota increase through Vertex, or switch to another /auth method'; do
+            BODY="${BODY%"$S"}"
+          done
+          BODY="${BODY%"${BODY##*[![:space:]]}"}"
+          case "${BODY}" in
+            *"[API Error: "*"]")
+              echo "::error title=Triage aborted by an API error::The model API returned an error instead of a triage, so no triage was posted. This is infrastructure, not this issue -- re-run the failed job."
+              exit 1
+              ;;
+          esac
           echo "Triage response received (${#RESPONSE} chars)."
 
       - name: 'Notify silent triage re-run'

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -372,6 +372,63 @@ describe('qwen-triage tmux workflow', () => {
     expect(run({ RESPONSE: 'null' }).status).not.toBe(0);
   });
 
+  it('fails an API-error response instead of passing it as a triage (#10314)', () => {
+    const checkStep = step('Check triage response');
+    const body = checkStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
+    expect(body).toBeTruthy();
+    const script = body.replace(/^ {10}/gm, '');
+    const run = (env) => {
+      const proc = spawnSync('bash', ['-c', script], {
+        env: {
+          ...process.env,
+          RESPONSE: '',
+          TRIAGE_OUTCOME: 'success',
+          ...env,
+        },
+        encoding: 'utf8',
+      });
+      return { status: proc.status, out: `${proc.stdout}${proc.stderr}` };
+    };
+
+    // The verbatim 268-char response of run 33070765162 (triage for #10285):
+    // a bare model-layer connection error that the old check classified as a
+    // successful triage, so nothing retried or alerted.
+    const apiError =
+      '[API Error: Connection error. (cause: connect ETIMEDOUT 47.94.20.201:443; connect ENETUNREACH 2408:400a:3e:effd:6ac1:ae6e:cde9:4efe:443 - Local (:::0); connect ETIMEDOUT 101.201.58.201:443; connect ENETUNREACH 2408:400a:3e:effb:c146:fb04:1e3d:5cc1:443 - Local (:::0))]';
+    const bare = run({ RESPONSE: apiError });
+    expect(bare.status).not.toBe(0);
+    expect(bare.out).toContain('API error');
+
+    // The stream-json adapter appends the formatted error LAST
+    // (BaseJsonOutputAdapter appendText), optionally followed by rate-limit
+    // guidance: an error after partial output and a quota error ending in
+    // the guidance suffix must fail too. Same shapes as
+    // qwen-code-pr-review.yml's classifier.
+    expect(
+      run({ RESPONSE: `Partial triage notes\n${apiError}` }).status,
+    ).not.toBe(0);
+    expect(
+      run({
+        RESPONSE:
+          '[API Error: Quota exceeded.] Please wait and try again later. To increase your limits, request a quota increase through AI Studio, or switch to another /auth method',
+      }).status,
+    ).not.toBe(0);
+
+    // A real summary still passes: one that merely QUOTES an API error
+    // mid-prose keeps writing afterwards (parity with the pr-review
+    // workflow's success_mentions_api_error case), and the normal
+    // empty/'null' behavior is untouched.
+    expect(
+      run({
+        RESPONSE:
+          'This issue reports "[API Error: Connection error.]" which points at the model endpoint; needs the endpoint config.',
+      }).status,
+    ).toBe(0);
+    expect(run({ RESPONSE: 'triaged' }).status).toBe(0);
+    expect(run({ RESPONSE: '' }).status).not.toBe(0);
+    expect(run({ RESPONSE: 'null' }).status).not.toBe(0);
+  });
+
   it('notifies the author when a manual triage re-run posts no review', () => {
     const notifyStep = step('Notify silent triage re-run');
 


### PR DESCRIPTION
## What this PR does

Makes the `Check triage response` step of `qwen-triage.yml` fail when the triage action's response is a model-layer API error instead of a triage: it strips the known rate-limit guidance suffixes, right-trims, then fails the step when what remains ends with the `[API Error: ...]` shape. One step, one added condition; no other step is touched.

## Why it's needed

The step currently classifies any non-empty response as a successful triage. An API error response such as `[API Error: Connection error. (cause: connect ETIMEDOUT ...)]` is a non-empty string, so it passed the check: run [33070765162](https://github.com/QwenLM/qwen-code/actions/runs/33070765162) (triage for #10285) returned a 268-char connection error, the run reported success, nothing was posted, and no retry or alert fired. This PR routes that response shape into the existing failure surface: a red run, the "ended early" lifecycle comment, and the re-run path. It reuses the pattern `qwen-code-pr-review.yml` already ships for the same CLI output behavior (the stream-json adapter appends the formatted error last, optionally followed by rate-limit guidance), so an error appended after partial output is caught too while a legitimate summary that merely quotes an API error mid-prose stays green.

## Reviewer Test Plan

### How to verify

1. Reproduce the old behavior on `main`: extract the `Check triage response` step body and run it under GitHub's exact shell flags (`bash --noprofile --norc -eo pipefail`) with `RESPONSE` set to the verbatim 268-char error string from run 33070765162. Observed: `Triage response received (268 chars).`, exit 0 — matching the production log line.
2. With this PR, the same command prints `::error title=Triage aborted by an API error::...` and exits 1; a normal response still prints `Triage response received (... chars).` and exits 0.
3. Run the executed-step tests: `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-triage-workflow.test.js`. The new test covers: the verbatim 268-char response, an error appended after partial output, and a quota error ending in the rate-limit guidance suffix (all must fail the step); a summary that merely quotes an API error mid-prose, a normal response, empty, and `null` (all keep their existing behavior).

### Evidence (Before & After)

Before (step body from `main`, run with the real 268-char response): `Triage response received (268 chars).`, exit 0 — identical to the production log of run 33070765162. After (this branch, same input): `::error title=Triage aborted by an API error::The model API returned an error instead of a triage, so no triage was posted. This is infrastructure, not this issue -- re-run the failed job.`, exit 1.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ not tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ✅ tested   |

### Environment (optional)

Vitest executed-step tests; the step script runs under GitHub's exact shell flags (`bash --noprofile --norc -eo pipefail`).

## Risk & Scope

- Main risk or tradeoff: a legitimate triage summary that ENDS with a quoted `[API Error: ...]` (nothing written after it) would be failed and need a re-run; this is the same tradeoff `qwen-code-pr-review.yml` already ships with this pattern (its `success_mentions_api_error` case covers the mid-prose quote).
- Not validated / out of scope: the CLI-side variant (#8920, headless emits success/exit 0 on API errors); the retry/notification steps themselves are unchanged — this PR only makes the job fail so their existing conditions engage.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10314

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `qwen-triage.yml` 的 `Check triage response` 步骤在 triage action 的响应是模型层 API 错误而非 triage 结果时判定失败：先剥离已知的限流提示后缀、右去空白，当剩余内容以 `[API Error: ...]` 形状结尾时使该步骤失败。只改一个步骤、只加一个判定条件，不动其他步骤。

## 为什么需要

该步骤目前把任何非空响应都判为成功的 triage。像 `[API Error: Connection error. (cause: connect ETIMEDOUT ...)]` 这样的 API 错误响应也是非空字符串，因此能通过检查：运行 [33070765162](https://github.com/QwenLM/qwen-code/actions/runs/33070765162)（#10285 的 triage）返回了 268 字符的连接错误，运行却报告成功、什么都没发，也没有触发任何重试或告警。本 PR 把这种响应形状导入既有的失败面：运行标红、生命周期评论变为 "ended early"、可走重跑路径。它复用了 `qwen-code-pr-review.yml` 针对同一 CLI 输出行为已经在用的模式（stream-json adapter 会把格式化后的错误追加在最后，可能再跟一段限流提示），因此部分输出后追加错误的情况也能被捕获，而正文中仅仅引用 API 错误的正常 summary 仍判为成功。

## 审阅者测试方案

### 如何验证

1. 在 `main` 上复现旧行为：提取 `Check triage response` 步骤体，用 GitHub 的原始 shell 参数（`bash --noprofile --norc -eo pipefail`）运行，并把 `RESPONSE` 设为运行 33070765162 中逐字的 268 字符错误字符串。观察到：`Triage response received (268 chars).`，退出码 0 —— 与生产日志行一致。
2. 在本 PR 上，同样的命令输出 `::error title=Triage aborted by an API error::...` 且退出码为 1；正常响应仍输出 `Triage response received (... chars).` 且退出码为 0。
3. 运行执行式步骤测试：`npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-triage-workflow.test.js`。新测试覆盖：逐字的 268 字符响应、部分输出后追加错误、以及以限流提示后缀结尾的配额错误（三者都必须使步骤失败）；仅引用 API 错误的 summary、正常响应、空响应与 `null`（均保持既有行为）。

### 证据（修改前后）

修改前（`main` 的步骤体，输入真实的 268 字符响应）：`Triage response received (268 chars).`，退出码 0 —— 与运行 33070765162 的生产日志完全一致。修改后（本分支，同样输入）：`::error title=Triage aborted by an API error::The model API returned an error instead of a triage, so no triage was posted. This is infrastructure, not this issue -- re-run the failed job.`，退出码 1。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️ 未测试   |
| 🪟 Windows |   ⚠️ 未测试   |
|  🐧 Linux  |   ✅ 已测试   |

### 环境（可选）

Vitest 执行式步骤测试；步骤脚本以 GitHub 的原始 shell 参数（`bash --noprofile --norc -eo pipefail`）运行。

## 风险与范围

- 主要风险或取舍：一个恰好以引用的 `[API Error: ...]` 结尾（其后没有其他内容）的正常 triage summary 会被判失败、需要重跑；这与 `qwen-code-pr-review.yml` 用同一模式已经承担的取舍一致（其 `success_mentions_api_error` 用例覆盖正文中间引用的情况）。
- 未验证 / 超出范围：CLI 侧变体（#8920，headless 在 API 错误时仍输出 success/exit 0）；重试/通知步骤本身未改动 —— 本 PR 只让 job 失败，使其既有条件被触发。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10314

</details>
