### PR TITLE
fix(ci): treat a PR closed during a triage re-run as a terminal action

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -958,6 +958,27 @@ jobs:
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
         run: |-
           set -euo pipefail
+          # A close at/after the trigger is a terminal action of THIS run:
+          # Stage 1-pre closes a duplicate PR without leaving a review, and
+          # the review-list check below cannot tell that apart from a re-run
+          # that did nothing — it would announce on the just-closed PR that
+          # the re-run "did not" review it, and the ::warning would dispatch
+          # a human to a correctly-handled run. Read the PR's own state and
+          # exit quietly; a close BEFORE the trigger keeps the old behaviour,
+          # because this run still owes its summary. A failed `gh pr view`
+          # is not fatal: the review-list check below then decides, as before.
+          if PR_STATE="$(
+               gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json state,closedAt
+             )" &&
+             CLOSED_SINCE_TRIGGER="$(
+               printf '%s' "$PR_STATE" |
+                 jq -r --arg since "$TRIGGERED_AT" \
+                   '.closedAt != null and .closedAt >= $since'
+             )" &&
+             [ "$CLOSED_SINCE_TRIGGER" = true ]; then
+            echo "PR closed at/after the trigger comment; no re-run summary needed."
+            exit 0
+          fi
           HAS_REVIEW=false
           HEAD_SHA=''
           # unknown until both the review list and the head SHA are readable

--- a/scripts/tests/qwen-triage-workflow.test.js
+++ b/scripts/tests/qwen-triage-workflow.test.js
@@ -1196,7 +1196,8 @@ describe('qwen-triage tmux workflow', () => {
           const bin = join(dir, 'bin');
           mkdirSync(bin, { recursive: true });
           writeFileSync(join(dir, 'reviews.json'), JSON.stringify(reviews));
-          // Stand-in for `gh`: serves the review list and head SHA, and
+          // Stand-in for `gh`: serves the PR state, the review list and
+          // the head SHA, and
           // captures the comment body the step would have posted.
           writeFileSync(
             join(bin, 'gh'),
@@ -1204,6 +1205,7 @@ describe('qwen-triage tmux workflow', () => {
               '#!/usr/bin/env bash',
               'case "$*" in',
               `  "api user --jq .login") echo bot ;;`,
+              `  "pr view 1 --repo QwenLM/qwen-code --json state,closedAt") echo '{"state":"OPEN","closedAt":null}' ;;`,
               `  *"/pulls/1/reviews"*) cat "${join(dir, 'reviews.json')}" ;;`,
               `  *"/pulls/1 --jq .head.sha") [ -n "$FAKE_HEAD" ] && echo "$FAKE_HEAD" || exit 1 ;;`,
               `  *"/issues/1/comments"*)`,
@@ -1281,6 +1283,104 @@ describe('qwen-triage tmux workflow', () => {
       expect(noHead.status).toBe(0);
       expect(noHead.log).not.toContain('Triage re-run left no bot review');
       expect(noHead.comment).toContain('could not be read');
+    },
+  );
+
+  // A Stage 1-pre duplicate-close exit leaves no review at all, and the
+  // review-list check above cannot tell it apart from a re-run that did
+  // nothing: it announced "completed without a new review ... it did not"
+  // on the PR the same run just closed, and the ::warning dispatched a
+  // human to a correctly-handled run. The close IS the terminal action:
+  // the step must read the PR's own state and exit quietly. A close BEFORE
+  // the trigger keeps the old behaviour — that run still owes its summary.
+  it.skipIf(spawnSync('jq', ['--version']).status !== 0)(
+    'exits quietly when the PR was closed at/after the trigger comment',
+    () => {
+      const notifyStep = step('Notify silent triage re-run');
+      // The exemption reads the PR itself, not only the review list.
+      expect(notifyStep).toContain(
+        'gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json state,closedAt',
+      );
+      const body = notifyStep.match(/run: \|-\n([\s\S]*)$/)?.[1];
+      expect(body).toBeTruthy();
+      const script = body.replace(/^ {10}/gm, '');
+
+      const run = (prState, reviews = []) => {
+        const dir = mkdtempSync(join(tmpdir(), 'triage-close-exit-'));
+        try {
+          const bin = join(dir, 'bin');
+          mkdirSync(bin, { recursive: true });
+          writeFileSync(join(dir, 'pr-state.json'), JSON.stringify(prState));
+          writeFileSync(join(dir, 'reviews.json'), JSON.stringify(reviews));
+          // Stand-in for `gh`: serves the PR state, an (empty) review list
+          // and the head SHA, and captures the comment body the step would
+          // have posted.
+          writeFileSync(
+            join(bin, 'gh'),
+            [
+              '#!/usr/bin/env bash',
+              'case "$*" in',
+              `  "api user --jq .login") echo bot ;;`,
+              `  "pr view 1 --repo QwenLM/qwen-code --json state,closedAt") cat "${join(dir, 'pr-state.json')}" ;;`,
+              `  *"/pulls/1/reviews"*) cat "${join(dir, 'reviews.json')}" ;;`,
+              `  *"/pulls/1 --jq .head.sha") echo head ;;`,
+              `  *"/issues/1/comments"*)`,
+              `    for a in "$@"; do case "$a" in body=*) printf '%s' "\${a#body=}" > "${join(dir, 'comment.txt')}" ;; esac; done`,
+              `    echo '{}' ;;`,
+              '  *) echo "unexpected gh call: $*" >&2; exit 1 ;;',
+              'esac',
+            ].join('\n'),
+            { mode: 0o755 },
+          );
+          const proc = spawnSync('bash', ['-c', script], {
+            env: {
+              ...process.env,
+              PATH: `${bin}:${process.env.PATH}`,
+              GITHUB_REPOSITORY: 'QwenLM/qwen-code',
+              NUMBER: '1',
+              TRIGGERED_AT: '2026-01-02T00:00:00Z',
+              RUN_URL: 'https://example.invalid/run',
+            },
+            encoding: 'utf8',
+          });
+          let comment = '';
+          try {
+            comment = readFileSync(join(dir, 'comment.txt'), 'utf8');
+          } catch {
+            comment = '';
+          }
+          return {
+            status: proc.status,
+            log: `${proc.stdout}${proc.stderr}`,
+            comment,
+          };
+        } finally {
+          rmSync(dir, { recursive: true, force: true });
+        }
+      };
+
+      // The close-exit shape: closed after the trigger, no review left.
+      // Neither the summary comment nor the warning may fire.
+      const closeExit = run({
+        state: 'CLOSED',
+        closedAt: '2026-01-03T00:00:00Z',
+      });
+      expect(closeExit.status).toBe(0);
+      expect(closeExit.comment).toBe('');
+      expect(closeExit.log).not.toContain('Triage re-run left no bot review');
+      expect(closeExit.log).toContain('no re-run summary needed');
+
+      // The boundary: a close BEFORE the trigger comment is not this run's
+      // terminal action, so the old notify behaviour stays intact.
+      const closedBefore = run({
+        state: 'CLOSED',
+        closedAt: '2026-01-01T00:00:00Z',
+      });
+      expect(closedBefore.status).toBe(0);
+      expect(closedBefore.log).toContain('Triage re-run left no bot review');
+      expect(closedBefore.comment).toContain(
+        '<!-- qwen-triage stage=rerun-summary -->',
+      );
     },
   );
 


### PR DESCRIPTION
## What this PR does

Makes the `Notify silent triage re-run` step in `.github/workflows/qwen-triage.yml` aware of the PR's own close state. Before deciding whether to warn about a missing bot review, the step now fetches `gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json state,closedAt`. If the PR was closed at or after the `/triage` trigger comment, the close is treated as the run's terminal action and the step exits quietly — no `stage=rerun-summary` comment, no `::warning title=Triage re-run left no bot review`. A close before the trigger keeps today's notify behavior, and a failed `gh pr view` falls through to the existing review-list check. Only this one step changes; no other step is touched.

## Why it's needed

Stage 1-pre's duplicate-close exit is the first terminal triage action that leaves no PR review, and this step decides solely from the review list (`HAS_REVIEW` / `STANDING`). As reported in #10324 — and reproduced by driving the extracted step body with a stubbed `gh` in the close-exit state — a `/triage` re-run that closes the PR as a duplicate then POSTs the contradictory `stage=rerun-summary` comment ("Triage re-run completed without a new review … If this re-run was meant to review or approve, it did not") on the same PR it just closed, and emits `::warning title=Triage re-run left no bot review`, dispatching a human to a correctly-handled run. The check is shape-agnostic (it also covers a maintainer closing the PR mid-run), so it can land ahead of #10292.

## Reviewer Test Plan

### How to verify

`scripts/tests/qwen-triage-workflow.test.js` gains an executed test that extracts the real step body and drives it with a stubbed `gh` (same pattern as the existing pin): (1) the close-exit shape — PR closed after the trigger, empty review list — must exit 0 with no comment POSTed and no warning; (2) the boundary — closed before the trigger — must keep the existing warning plus the `stage=rerun-summary` comment. The existing executed pin for open PRs is extended to serve the new `pr view` call, so the pinned no-review notification behavior is regression-guarded. Run `vitest run --config scripts/tests/vitest.config.ts scripts/tests/qwen-triage-workflow.test.js`; the new test goes red without the workflow change (verified).

### Evidence (Before & After)

Before (extracted step driven in the close-exit state): POSTs the 908-char `stage=rerun-summary` comment ending in "If this re-run was meant to review or approve, it did not" and emits `::warning title=Triage re-run left no bot review`. After: logs `PR closed at/after the trigger comment; no re-run summary needed.`, POSTs nothing, warns nothing; an open PR in the same no-review state still receives the full bilingual summary and warning.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Workflow-script tests only: vitest with a stubbed `gh` on PATH, real step body, GitHub's exact shell flags. No live workflow run was triggered.

## Risk & Scope

- Main risk or tradeoff: a transient `gh pr view` failure falls through to the existing review-list check, so the worst case is today's behavior (notify), never a silent miss of a real problem.
- Not validated / out of scope: no live workflow run; other review-less terminal shapes (deferred approve-on-green, Stage 1b re-run escalation) do not close the PR and are unaffected; no other step of the workflow is modified.
- Breaking changes / migration notes: none — the pinned notify behavior for open PRs is unchanged and now additionally guarded by the extended stub in the existing executed test.

## Linked Issues

Fixes #10324

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 `.github/workflows/qwen-triage.yml` 中的 `Notify silent triage re-run` 步骤感知 PR 自身的关闭状态。在判断是否就缺失的机器人评审发出告警之前，该步骤现在会调用 `gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json state,closedAt`。如果 PR 在 `/triage` 触发评论之时或之后被关闭，则把这次关闭视为本轮运行的终止动作，步骤安静退出 —— 不发 `stage=rerun-summary` 评论，也不发 `::warning title=Triage re-run left no bot review`。触发之前的关闭保持现有通知行为；`gh pr view` 调用失败则回落到既有的评审列表检查。只改了这一个步骤，其他步骤一律未动。

## 为什么需要

Stage 1-pre 的重复关闭退出是第一个不留下任何 PR 评审的 triage 终止动作，而该步骤只依据评审列表（`HAS_REVIEW` / `STANDING`）判断。正如 #10324 所报告 —— 并已复现：把逐字提取的步骤体用 stub 的 `gh` 在关闭退出态下驱动 —— 一次把 PR 作为重复关闭的 `/triage` 重跑，会在它刚刚关闭的同一个 PR 上发出自相矛盾的 `stage=rerun-summary` 评论（"Triage re-run completed without a new review … If this re-run was meant to review or approve, it did not"），并输出 `::warning title=Triage re-run left no bot review`，把人力派往一次本就正确处理了的运行。该检查与具体形态无关（也覆盖维护者在运行中途手动关闭 PR 的情况），因此可以先于 #10292 合入。

## 评审者测试计划

### 如何验证

`scripts/tests/qwen-triage-workflow.test.js` 新增一个执行型测试：逐字提取真实步骤体，用 stub 的 `gh` 驱动（与既有钉住测试同一模式）：(1) 关闭退出形态 —— 触发后关闭、评审列表为空 —— 必须以 0 退出，不 POST 任何评论、不发告警；(2) 边界 —— 触发之前关闭 —— 必须保留现有告警和 `stage=rerun-summary` 评论。既有针对 open PR 的执行型钉住测试被扩展为同时应答新增的 `pr view` 调用，从而守住"无评审重跑仍要通知"这一被钉住行为的回归。运行 `vitest run --config scripts/tests/vitest.config.ts scripts/tests/qwen-triage-workflow.test.js`；不带工作流改动时新测试为红（已验证）。

### 证据（修复前 / 修复后）

修复前（关闭退出态下驱动提取的步骤体）：POST 一条 908 字符的 `stage=rerun-summary` 评论，结尾是 "If this re-run was meant to review or approve, it did not"，并输出 `::warning title=Triage re-run left no bot review`。修复后：日志输出 `PR closed at/after the trigger comment; no re-run summary needed.`，不 POST、不告警；open PR 在同样的无评审状态下仍然收到完整的双语摘要和告警。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

### 环境（可选）

仅工作流脚本测试：PATH 上放 stub `gh` 的 vitest，执行真实步骤体、使用与 GitHub 完全一致的 shell 参数。未触发任何真实工作流运行。

## 风险与范围

- 主要风险或取舍：`gh pr view` 瞬时失败会回落到既有的评审列表检查，因此最坏情况就是现状（发通知），绝不会静默漏掉真实问题。
- 未验证 / 超出范围：无真实工作流运行；其他无评审的终止形态（延迟 approve-on-green、Stage 1b 重跑升级）不会关闭 PR，不受影响；工作流的其他步骤均未改动。
- 破坏性变更 / 迁移说明：无 —— open PR 的被钉住通知行为不变，且现在由既有执行型测试中扩展后的 stub 额外守护。

## 关联 Issue

Fixes #10324

</details>
