### PR TITLE
feat(core): one-shot modality probe for pattern-guessed models (/model action, phase 1)

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -859,6 +859,7 @@ vi.mock('../config/loadedSettingsAdapter.js', () => ({
 vi.mock('../config/config.js', () => ({
   loadCliConfig: vi.fn(),
   buildDisabledSkillNamesProvider: vi.fn(() => () => new Set<string>()),
+  buildProbeResultStoreProvider: vi.fn(() => () => undefined),
   SessionIdConflictError: class SessionIdConflictError extends Error {
     sessionId: string;
     constructor(sessionId: string, message: string) {
@@ -3691,10 +3692,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     expect(argv).toMatchObject({
       sessionId: '550e8400-e29b-41d4-a716-446655440000',
     });
-    // Index 8 is `throwOnSessionIdConflict`: it must be true so a duplicate
+    // Index 9 is `throwOnSessionIdConflict`: it must be true so a duplicate
     // caller-supplied id throws (mapped to a RequestError) instead of
-    // process.exit(1)-ing the shared ACP child.
-    expect(vi.mocked(loadCliConfig).mock.calls[0]![8]).toBe(true);
+    // process.exit(1)-ing the shared ACP child. (Index 8 is the settings
+    // watcher; index 6 is the probe-result store provider.)
+    expect(vi.mocked(loadCliConfig).mock.calls[0]![9]).toBe(true);
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -10929,6 +10931,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       '/tmp',
       undefined,
       expect.anything(),
+      // disabledSkillNamesProvider, probeResultStoreProvider
+      expect.any(Function),
       expect.any(Function),
       expect.anything(),
       undefined,
@@ -16488,7 +16492,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       ],
     });
 
-    const sessionMcpServers = vi.mocked(loadCliConfig).mock.calls[0]?.[6];
+    // Arg index 7 = sessionMcpServers (index 6 is the probe-result store
+    // provider).
+    const sessionMcpServers = vi.mocked(loadCliConfig).mock.calls[0]?.[7];
     const localConfig = sessionMcpServers?.['local'] as unknown as {
       _args: unknown[];
     };
@@ -18847,7 +18853,9 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
     });
     vi.mocked(loadSettings).mockReturnValue(makeRestoreSettings());
     vi.mocked(loadCliConfig).mockImplementation(async (...args: unknown[]) => {
-      const hostPolicy = args[9] as
+      // Index 10 is `hostPolicy` (index 9 is `throwOnSessionIdConflict`;
+      // index 6 is the probe-result store provider).
+      const hostPolicy = args[10] as
         | {
             sessionRestore?: {
               projectionSource: (sessionId: string) => Promise<unknown>;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -234,6 +234,7 @@ import { z } from 'zod';
 import type { CliArgs } from '../config/config.js';
 import {
   buildDisabledSkillNamesProvider,
+  buildProbeResultStoreProvider,
   loadCliConfig,
   SessionIdConflictError,
 } from '../config/config.js';
@@ -3755,6 +3756,7 @@ class QwenAgent implements Agent {
           projectHooks: settings.getProjectHooks(),
         },
         buildDisabledSkillNamesProvider(settings),
+        buildProbeResultStoreProvider(settings),
       ),
     );
     config.setMcpTransportPool(this.mcpPool);
@@ -12487,6 +12489,7 @@ class QwenAgent implements Agent {
       // session. ACP/Zed sessions otherwise leak persisted disabled skills
       // into the first <available_skills> at cold start.
       buildDisabledSkillNamesProvider(settings),
+      buildProbeResultStoreProvider(settings),
       sessionMcpServers,
       // The daemon owns the settings watcher lifecycle.
       undefined,

--- a/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.worktree.test.ts
@@ -280,6 +280,7 @@ vi.mock('../config/settings-cache.js', async () => {
 vi.mock('../config/config.js', () => ({
   loadCliConfig: vi.fn(),
   buildDisabledSkillNamesProvider: vi.fn(() => () => new Set<string>()),
+  buildProbeResultStoreProvider: vi.fn(() => () => undefined),
 }));
 vi.mock('./session/Session.js', () => ({
   Session: vi.fn(),

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1594,6 +1594,7 @@ describe('loadCliConfig', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       sessionMcpServers,
     );
 
@@ -1623,6 +1624,7 @@ describe('loadCliConfig', () => {
       settings,
       argv,
       process.cwd(),
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -1688,6 +1690,7 @@ describe('loadCliConfig', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       sessionMcpServers,
     );
 
@@ -1746,6 +1749,7 @@ describe('loadCliConfig', () => {
       },
       argv,
       process.cwd(),
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -1818,6 +1822,7 @@ describe('loadCliConfig', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       false,
       { sessionRestore: { projectionSource } },
     );
@@ -1870,6 +1875,7 @@ describe('loadCliConfig', () => {
     await loadCliConfig(
       { experimental: { sessionWriterLease: true } },
       { resume: sourceSessionId } as CliArgs,
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -2006,6 +2012,7 @@ describe('loadCliConfig', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       true,
     );
 
@@ -2029,6 +2036,7 @@ describe('loadCliConfig', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
       true,
     );
 
@@ -2044,6 +2052,7 @@ describe('loadCliConfig', () => {
     const config = await loadCliConfig(
       {},
       { sessionId } as CliArgs,
+      undefined,
       undefined,
       undefined,
       undefined,
@@ -3711,6 +3720,7 @@ describe('loadCliConfig with includeDirectories', () => {
       argv,
       mockCwd,
       [],
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -42,6 +42,7 @@ import {
   SchemaValidator,
   type ConfigParameters,
   type MCPServerConfig,
+  type ProbeResultStore,
   type SkillLevel,
   type WebSearchSettings,
   MAX_SUBAGENT_DEPTH_LIMIT,
@@ -1482,6 +1483,25 @@ export function buildDisabledSkillNamesProvider(
 }
 
 /**
+ * Builds the live-read closure for the persisted modality probe results
+ * (`probeResults` settings key, QwenLM/qwen-code#10309). Forwarded to
+ * `ConfigParameters.probeResultStoreProvider` so the model registry's
+ * modality resolution chain (explicit > probe > pattern) reflects verdicts
+ * written by the /model dialog's "Test image support" action without
+ * rebuilding `Config`.
+ *
+ * Like `buildDisabledSkillNamesProvider`, the closure is over the LIVE
+ * `LoadedSettings` instance (reading `merged` on every call), NOT over a
+ * `Settings` snapshot — `LoadedSettings.setValue` replaces `_merged`, so a
+ * snapshot closure would never observe newly written probe verdicts.
+ */
+export function buildProbeResultStoreProvider(
+  loadedSettings: LoadedSettings,
+): () => ProbeResultStore | undefined {
+  return () => loadedSettings.merged.probeResults;
+}
+
+/**
  * Thrown (instead of `process.exit(1)`) when a caller-supplied session id
  * already exists and `throwOnSessionIdConflict` is set. The interactive CLI
  * exits the process on a duplicate id, but that would kill a shared ACP child
@@ -1525,6 +1545,15 @@ export async function loadCliConfig(
    * correctly.
    */
   disabledSkillNamesProvider?: () => ReadonlySet<string>,
+  /**
+   * Live-read provider for the persisted modality probe results. Forwarded
+   * to `ConfigParameters` so the model registry's modality resolution chain
+   * sees probe verdicts written by the /model dialog within the same
+   * process. Callers MUST close over the live `LoadedSettings` instance —
+   * use `buildProbeResultStoreProvider(loadedSettings)` to construct it
+   * correctly.
+   */
+  probeResultStoreProvider?: () => ProbeResultStore | undefined,
   /**
    * MCP servers injected by the embedding session (e.g. ACP / IDE clients).
    * Treated as a session-level source at the TOP of the precedence stack — above
@@ -2339,6 +2368,7 @@ export async function loadCliConfig(
     includePartialMessages,
     modelProvidersConfig,
     providerProtocolConfig,
+    probeResultStoreProvider,
     generationConfigSources: resolvedCliConfig.sources,
     generationConfig: resolvedCliConfig.generationConfig,
     initialModelRegistryBaseUrl: resolvedCliConfig.registryBaseUrl,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -13,6 +13,7 @@ import type {
   ChatCompressionSettings,
   ModelProvidersConfig,
   ProviderProtocolConfig,
+  ModalityProbeRecord,
 } from '@qwen-code/qwen-code-core';
 import {
   ApprovalMode,
@@ -378,6 +379,19 @@ const SETTINGS_SCHEMA = {
       'Maps a custom modelProviders provider id to the SDK protocol that routes its requests (e.g. {"idealab": "openai"}). Lets a custom provider id reuse a built-in protocol. Built-in provider ids (openai, gemini, anthropic, vertex-ai, qwen-oauth) are routed automatically and need no entry.',
     showInDialog: false,
     mergeStrategy: MergeStrategy.REPLACE,
+  },
+
+  // Persisted modality probe results (QwenLM/qwen-code#10309, phase 1).
+  probeResults: {
+    type: 'object',
+    label: 'Modality Probe Results',
+    category: 'Model',
+    requiresRestart: false,
+    default: {} as Record<string, ModalityProbeRecord>,
+    showInDialog: false,
+    mergeStrategy: MergeStrategy.SHALLOW_MERGE,
+    description:
+      'Persisted one-shot image modality probe verdicts, keyed by "authType|modelId|baseUrl". Written by the "Test image support" action in /model; feeds the modality resolution chain (explicit modalities > probe result > name-pattern table). Records are advisory metadata, never user declarations.',
   },
 
   plansDirectory: {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -138,6 +138,7 @@ vi.mock('./config/config.js', () => ({
   parseArguments: vi.fn().mockResolvedValue({}),
   isDebugMode: vi.fn(() => false),
   buildDisabledSkillNamesProvider: vi.fn(() => () => new Set<string>()),
+  buildProbeResultStoreProvider: vi.fn(() => () => undefined),
   // Mirrors SESSION_ID_REGEX in ./config/config.ts; keep them in sync.
   isValidSessionId: vi.fn((value: string) =>
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}(-agent-[a-zA-Z0-9_.-]+)?$/i.test(
@@ -851,6 +852,8 @@ describe('gemini.tsx main function', () => {
         userHooks: undefined,
         projectHooks: undefined,
       },
+      // disabledSkillNamesProvider, probeResultStoreProvider
+      expect.any(Function),
       expect.any(Function),
       undefined,
       // settingsWatcher: not started in bare mode

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -39,6 +39,7 @@ import { scrubAndReportInheritedLoaderEnv } from './config/shared-env-keys.js';
 import { QWEN_CODE_SERVE_ENV } from './config/acp-channel-fallback.js';
 import {
   buildDisabledSkillNamesProvider,
+  buildProbeResultStoreProvider,
   loadCliConfig,
   parseArguments,
 } from './config/config.js';
@@ -576,6 +577,7 @@ export async function main() {
           projectHooks: settings.getProjectHooks(),
         },
         buildDisabledSkillNamesProvider(settings),
+        buildProbeResultStoreProvider(settings),
       );
 
       if (!settings.merged.security?.auth?.useExternal) {
@@ -872,6 +874,7 @@ export async function main() {
         projectHooks: settings.getProjectHooks(),
       },
       buildDisabledSkillNamesProvider(settings),
+      buildProbeResultStoreProvider(settings),
       undefined,
       settingsWatcher,
     );

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -543,6 +543,18 @@ export default {
   'Using {{count}} tools': 'Using {{count}} tools',
   'Enter to select, ↑↓ to navigate, Esc to close':
     'Enter to select, ↑↓ to navigate, Esc to close',
+  't: test image support': 't: test image support',
+  'Image probe': 'Image probe',
+  'probe-tested': 'probe-tested',
+  'auto-detected': 'auto-detected',
+  manual: 'manual',
+  'testing…': 'testing…',
+  'accepts images': 'accepts images',
+  'text only': 'text only',
+  'inconclusive (auth/rate-limit/timeout) — nothing written':
+    'inconclusive (auth/rate-limit/timeout) — nothing written',
+  'Image probe verdict could not be saved.':
+    'Image probe verdict could not be saved.',
   'Esc to go back': 'Esc to go back',
   'Enter to confirm, Esc to cancel': 'Enter to confirm, Esc to cancel',
   'Enter to select, ↑↓ to navigate, Esc to go back':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -526,6 +526,17 @@ export default {
   'Using {{count}} tools': '正在使用 {{count}} 个工具',
   'Enter to select, ↑↓ to navigate, Esc to close':
     'Enter 选择，↑↓ 导航，Esc 关闭',
+  't: test image support': 't: 测试图像支持',
+  'Image probe': '图像探测',
+  'probe-tested': '已实测',
+  'auto-detected': '自动检测',
+  manual: '手动设置',
+  'testing…': '测试中…',
+  'accepts images': '支持图像输入',
+  'text only': '仅文本',
+  'inconclusive (auth/rate-limit/timeout) — nothing written':
+    '结论不明（鉴权/限流/超时）— 未写入任何结果',
+  'Image probe verdict could not be saved.': '图像探测结论保存失败。',
   'Esc to go back': '按 Esc 返回',
   'Enter to confirm, Esc to cancel': 'Enter 确认，Esc 取消',
   'Enter to select, ↑↓ to navigate, Esc to go back':

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -14,7 +14,11 @@ import { ConfigContext } from '../contexts/ConfigContext.js';
 import { SettingsContext } from '../contexts/SettingsContext.js';
 import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
 import type { Config } from '@qwen-code/qwen-code-core';
-import { AuthType, DEFAULT_QWEN_MODEL } from '@qwen-code/qwen-code-core';
+import {
+  AuthType,
+  DEFAULT_QWEN_MODEL,
+  probeImageSupport,
+} from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../../config/settings.js';
 import { SettingScope } from '../../config/settings.js';
 import { getFilteredQwenModels } from '../models/availableModels.js';
@@ -27,6 +31,15 @@ const mockedUseKeypress = vi.mocked(useKeypress);
 vi.mock('./shared/DescriptiveRadioButtonSelect.js', () => ({
   DescriptiveRadioButtonSelect: vi.fn(() => null),
 }));
+
+// The "Test image support" action must hit a controlled probe, never the
+// network. Everything else from core stays real.
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return { ...actual, probeImageSupport: vi.fn() };
+});
+const mockedProbeImageSupport = vi.mocked(probeImageSupport);
 
 // Helper to create getAvailableModelsForAuthType mock
 const createMockGetAvailableModelsForAuthType = () =>
@@ -1951,6 +1964,435 @@ describe('<ModelDialog />', () => {
       (m) => m.id === DEFAULT_QWEN_MODEL,
     );
     expect(mockedSelect.mock.calls[1][0].initialIndex).toBe(expectedCoderIndex);
+  });
+
+  // --- Modality provenance badge + "Test image support" action (#10309) ---
+
+  const pressT = async () => {
+    // The dialog registers two useKeypress handlers: [0] escape/left,
+    // [1] the gated 't' probe action.
+    await act(async () => {
+      mockedUseKeypress.mock.calls[1][0]({
+        name: 't',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 't',
+      });
+      // The probe handler is fire-and-forget async; flush its microtasks
+      // inside act so the verdict state updates land in this batch.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  };
+
+  const patternSourceModel = {
+    id: 'pattern-model',
+    label: 'Pattern Model',
+    description: '',
+    authType: AuthType.USE_OPENAI,
+    baseUrl: 'https://api.example.com/v1',
+    envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
+    modalitiesSource: 'pattern',
+  };
+
+  it('badges pattern-guessed modalities as auto-detected and offers the t action', () => {
+    const { getByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'pattern-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+      getModelsConfig: vi.fn(() => ({
+        getGenerationConfig: vi.fn(() => ({
+          baseUrl: 'https://api.example.com/v1',
+        })),
+      })),
+    } as unknown as Partial<Config>);
+
+    expect(getByText('text-only · auto-detected')).toBeDefined();
+    expect(getByText('t: test image support')).toBeDefined();
+  });
+
+  it('badges probe-tested modalities without offering the t action again', () => {
+    const { getByText, queryByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'vl-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'vl-model',
+          label: 'VL Model',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+          modalitiesSource: 'probe',
+        },
+      ]),
+    } as unknown as Partial<Config>);
+
+    expect(getByText('text · image · probe-tested')).toBeDefined();
+    expect(queryByText('t: test image support')).toBeNull();
+  });
+
+  it('badges explicitly declared modalities as manual', () => {
+    const { getByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'explicit-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'explicit-model',
+          label: 'Explicit Model',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+          modalitiesSource: 'explicit',
+        },
+      ]),
+    } as unknown as Partial<Config>);
+
+    expect(getByText('text · image · manual')).toBeDefined();
+  });
+
+  it('does not run the probe for non-pattern modality sources', async () => {
+    const { mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'explicit-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'explicit-model',
+          label: 'Explicit Model',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://api.example.com/v1',
+          envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
+          modalities: { image: true },
+          modalitiesSource: 'explicit',
+        },
+      ]),
+      getModelsConfig: vi.fn(() => ({
+        getGenerationConfig: vi.fn(() => ({
+          baseUrl: 'https://api.example.com/v1',
+        })),
+      })),
+    } as unknown as Partial<Config>);
+
+    await pressT();
+
+    expect(mockedProbeImageSupport).not.toHaveBeenCalled();
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+  });
+
+  it('probes a pattern-source entry on t and persists the whole probeResults map', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'image',
+        httpStatus: 200,
+        snippet: 'ok',
+      });
+      const existingRecord = {
+        verdict: 'text_only' as const,
+        probedAt: '2026-01-01T00:00:00.000Z',
+      };
+      // Scope-targeted read: the write must start from the TARGET scope's
+      // own map (preserving its records) — not from the merged view.
+      const userSettingsFile = {
+        settings: {
+          probeResults: {
+            'openai|older-model|https://older.example.com/v1': existingRecord,
+          },
+        },
+      };
+
+      const { getByText, mockSettings } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          forScope: () => userSettingsFile,
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).toHaveBeenCalledTimes(1);
+      expect(mockedProbeImageSupport).toHaveBeenCalledWith({
+        model: 'pattern-model',
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'sk-probe-test',
+      });
+      expect(mockSettings.setValue).toHaveBeenCalledTimes(1);
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'probeResults',
+        {
+          'openai|older-model|https://older.example.com/v1': existingRecord,
+          'openai|pattern-model|https://api.example.com/v1': {
+            verdict: 'image',
+            probedAt: expect.any(String),
+          },
+        },
+      );
+      // Registry entries are not reloaded mid-dialog: BOTH the badge and the
+      // modality value flip to the verdict-consistent presentation from
+      // local dialog state.
+      expect(getByText('text · image · probe-tested')).toBeDefined();
+      expect(getByText('accepts images')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('writes nothing when the probe verdict is unknown', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'unknown',
+        httpStatus: 401,
+        snippet: 'unauthorized',
+      });
+
+      const { getByText, mockSettings } = renderComponent({}, {
+        getModel: vi.fn(() => 'pattern-model'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+        getModelsConfig: vi.fn(() => ({
+          getGenerationConfig: vi.fn(() => ({
+            baseUrl: 'https://api.example.com/v1',
+          })),
+        })),
+      } as unknown as Partial<Config>);
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).toHaveBeenCalledTimes(1);
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+      expect(
+        getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
+      ).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('reports inconclusive without probing when the API key env is unset', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    // No key in the environment: the handler must bail out BEFORE any
+    // network attempt and write nothing.
+    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    try {
+      const { getByText, mockSettings } = renderComponent({}, {
+        getModel: vi.fn(() => 'pattern-model'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+        getModelsConfig: vi.fn(() => ({
+          getGenerationConfig: vi.fn(() => ({
+            baseUrl: 'https://api.example.com/v1',
+          })),
+        })),
+      } as unknown as Partial<Config>);
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).not.toHaveBeenCalled();
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+      expect(
+        getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
+      ).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('hydrates a settings-backed API key before probing', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    // The key exists only in settings.env — NOT in process.env — so the
+    // probe only works if the handler hydrates the env first.
+    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'text_only',
+        httpStatus: 400,
+        snippet: 'does not support images',
+      });
+
+      const { getByText, mockSettings } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          merged: {
+            env: { MODEL_DIALOG_PROBE_TEST_KEY: 'sk-from-settings-env' },
+          },
+          forScope: () => ({ settings: {} }),
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'sk-from-settings-env' }),
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledTimes(1);
+      expect(getByText('text only')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('displaces the verdict display when the highlight moves to another entry', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'image',
+        httpStatus: 200,
+        snippet: 'ok',
+      });
+
+      const { getByText, queryByText } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [
+            patternSourceModel,
+            {
+              id: 'pattern-model-b',
+              label: 'Pattern Model B',
+              description: '',
+              authType: AuthType.USE_OPENAI,
+              modalitiesSource: 'pattern',
+            },
+          ]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          forScope: () => ({ settings: {} }),
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+      // Entry A (highlighted) shows the verdict.
+      expect(getByText('text · image · probe-tested')).toBeDefined();
+      // Move the highlight to entry B: B shows its OWN pattern badge and
+      // none of A's verdict display leaks onto it.
+      const selectProps = mockedSelect.mock.calls[0][0];
+      const entryB = selectProps.items[1].value;
+      act(() => {
+        selectProps.onHighlight?.(entryB);
+      });
+      expect(getByText('text-only · auto-detected')).toBeDefined();
+      expect(queryByText('accepts images')).toBeNull();
+      expect(queryByText('text · image · probe-tested')).toBeNull();
+
+      // Moving back to A re-shows A's (uncorrupted) verdict display.
+      act(() => {
+        selectProps.onHighlight?.(selectProps.items[0].value);
+      });
+      expect(getByText('text · image · probe-tested')).toBeDefined();
+      expect(getByText('accepts images')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('surfaces a settings-write failure instead of unhandled success', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    const setValue = vi.fn(() => {
+      const error = new Error('settings are read-only');
+      Object.assign(error, { code: 'EACCES' });
+      throw error;
+    });
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'image',
+        httpStatus: 200,
+        snippet: 'ok',
+      });
+
+      const { getByText, queryByText } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          setValue,
+          forScope: () => ({ settings: {} }),
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+
+      expect(setValue).toHaveBeenCalledTimes(1);
+      // The failure surfaces through the dialog's error channel...
+      expect(
+        getByText((text) =>
+          text.includes('Image probe verdict could not be saved.'),
+        ),
+      ).toBeDefined();
+      // ...and no success feedback or verdict badge is shown (nothing was
+      // persisted, so the entry's own pattern source stays on display and
+      // the t action remains available for a retry).
+      expect(queryByText('accepts images')).toBeNull();
+      expect(queryByText('text · image · probe-tested')).toBeNull();
+      expect(getByText('text-only · auto-detected')).toBeDefined();
+      expect(getByText('t: test image support')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
   });
 });
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -1969,10 +1969,13 @@ describe('<ModelDialog />', () => {
   // --- Modality provenance badge + "Test image support" action (#10309) ---
 
   const pressT = async () => {
-    // The dialog registers two useKeypress handlers: [0] escape/left,
-    // [1] the gated 't' probe action.
+    // The dialog registers two useKeypress handlers per render: escape/left
+    // first, then the gated 't' probe action. Handlers accumulate across
+    // re-renders and remounts, so always fire the LATEST registered one —
+    // its closure holds the current mount's props and state.
+    const calls = mockedUseKeypress.mock.calls;
     await act(async () => {
-      mockedUseKeypress.mock.calls[1][0]({
+      calls[calls.length - 1][0]({
         name: 't',
         ctrl: false,
         meta: false,
@@ -2029,6 +2032,87 @@ describe('<ModelDialog />', () => {
     } as unknown as Partial<Config>);
 
     expect(getByText('text · image · probe-tested')).toBeDefined();
+    expect(queryByText('t: test image support')).toBeNull();
+  });
+
+  it('prefers a settings-persisted probe verdict over the registry pattern cache', () => {
+    // The registry cached modalitiesSource at registration time and a plain
+    // settings.setValue does not refresh it — but the dialog reads the live
+    // settings store, so the persisted verdict must drive BOTH the badge and
+    // the t-action gating even while the entry still says 'pattern'.
+    const { getByText, queryByText } = renderComponent(
+      {},
+      {
+        getModel: vi.fn(() => 'pattern-model'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+        getModelsConfig: vi.fn(() => ({
+          getGenerationConfig: vi.fn(() => ({
+            baseUrl: 'https://api.example.com/v1',
+          })),
+        })),
+      } as unknown as Partial<Config>,
+      {
+        merged: {
+          probeResults: {
+            'openai|pattern-model|https://api.example.com/v1': {
+              verdict: 'text_only',
+              probedAt: '2026-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      } as unknown as Partial<LoadedSettings>,
+    );
+
+    expect(getByText('text-only · probe-tested')).toBeDefined();
+    expect(queryByText('t: test image support')).toBeNull();
+  });
+
+  it('shows a hand-written explicit declaration over a stale persisted probe record', () => {
+    // A wrong verdict was persisted earlier; the phase-1 remediation is to
+    // hand-write modelProviders modalities and reload the registry, which
+    // stamps the entry 'explicit'. The live probe read must not shadow
+    // that: badge shows manual with the hand-written value.
+    const { getByText, queryByText } = renderComponent(
+      {},
+      {
+        getModel: vi.fn(() => 'explicit-model'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() => [
+          {
+            id: 'explicit-model',
+            label: 'Explicit Model',
+            description: '',
+            authType: AuthType.USE_OPENAI,
+            baseUrl: 'https://api.example.com/v1',
+            envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
+            modalities: { image: true },
+            modalitiesSource: 'explicit',
+          },
+        ]),
+        getModelsConfig: vi.fn(() => ({
+          getGenerationConfig: vi.fn(() => ({
+            baseUrl: 'https://api.example.com/v1',
+          })),
+        })),
+      } as unknown as Partial<Config>,
+      {
+        merged: {
+          probeResults: {
+            // Stale text_only verdict under the SAME key the dialog's live
+            // read would use — it must not flip the hand-written value.
+            'openai|explicit-model|https://api.example.com/v1': {
+              verdict: 'text_only',
+              probedAt: '2026-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      } as unknown as Partial<LoadedSettings>,
+    );
+
+    expect(getByText('text · image · manual')).toBeDefined();
+    expect(queryByText('text-only · probe-tested')).toBeNull();
+    // Explicit entries never offer the t action, record or not.
     expect(queryByText('t: test image support')).toBeNull();
   });
 
@@ -2145,6 +2229,71 @@ describe('<ModelDialog />', () => {
       // local dialog state.
       expect(getByText('text · image · probe-tested')).toBeDefined();
       expect(getByText('accepts images')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('hides the t action once a verdict concludes and keeps it after unknown', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    const renderPatternDialog = () =>
+      renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          forScope: () => ({ settings: {} }),
+        } as unknown as Partial<LoadedSettings>,
+      );
+    try {
+      // Concluded verdict: the t action must disappear. Note the mocked
+      // setValue does NOT refresh settings.merged, so the live-settings
+      // lookup still misses — only the local verdict state gates the action
+      // here, which is exactly the fallback under test.
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'image',
+        httpStatus: 200,
+        snippet: 'ok',
+      });
+      const first = renderPatternDialog();
+
+      await pressT();
+
+      expect(first.getByText('text · image · probe-tested')).toBeDefined();
+      expect(first.queryByText('t: test image support')).toBeNull();
+      first.unmount();
+
+      // Unknown verdict: nothing was written and no conclusion exists, so
+      // retry stays available (phase 1 has no other re-probe entry point).
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'unknown',
+        httpStatus: 429,
+        snippet: 'rate limited',
+      });
+      const second = renderPatternDialog();
+
+      await pressT();
+
+      expect(
+        second.getByText(
+          'inconclusive (auth/rate-limit/timeout) — nothing written',
+        ),
+      ).toBeDefined();
+      expect(second.getByText('t: test image support')).toBeDefined();
+      second.unmount();
     } finally {
       if (previousKey === undefined) {
         delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -14,7 +14,11 @@ import { ConfigContext } from '../contexts/ConfigContext.js';
 import { SettingsContext } from '../contexts/SettingsContext.js';
 import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
 import type { Config } from '@qwen-code/qwen-code-core';
-import { AuthType, DEFAULT_QWEN_MODEL } from '@qwen-code/qwen-code-core';
+import {
+  AuthType,
+  DEFAULT_QWEN_MODEL,
+  probeImageSupport,
+} from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../../config/settings.js';
 import { SettingScope } from '../../config/settings.js';
 import { getFilteredQwenModels } from '../models/availableModels.js';
@@ -27,6 +31,15 @@ const mockedUseKeypress = vi.mocked(useKeypress);
 vi.mock('./shared/DescriptiveRadioButtonSelect.js', () => ({
   DescriptiveRadioButtonSelect: vi.fn(() => null),
 }));
+
+// The "Test image support" action must hit a controlled probe, never the
+// network. Everything else from core stays real.
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return { ...actual, probeImageSupport: vi.fn() };
+});
+const mockedProbeImageSupport = vi.mocked(probeImageSupport);
 
 // Helper to create getAvailableModelsForAuthType mock
 const createMockGetAvailableModelsForAuthType = () =>
@@ -1951,6 +1964,435 @@ describe('<ModelDialog />', () => {
       (m) => m.id === DEFAULT_QWEN_MODEL,
     );
     expect(mockedSelect.mock.calls[1][0].initialIndex).toBe(expectedCoderIndex);
+  });
+
+  // --- Modality provenance badge + "Test image support" action (#10309) ---
+
+  const pressT = async () => {
+    // The dialog registers two useKeypress handlers: [0] escape/left,
+    // [1] the gated 't' probe action.
+    await act(async () => {
+      mockedUseKeypress.mock.calls[1][0]({
+        name: 't',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 't',
+      });
+      // The probe handler is fire-and-forget async; flush its microtasks
+      // inside act so the verdict state updates land in this batch.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  };
+
+  const patternSourceModel = {
+    id: 'pattern-model',
+    label: 'Pattern Model',
+    description: '',
+    authType: AuthType.USE_OPENAI,
+    baseUrl: 'https://api.example.com/v1',
+    envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
+    modalitiesSource: 'pattern',
+  };
+
+  it('badges pattern-guessed modalities as auto-detected and offers the t action', () => {
+    const { getByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'pattern-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+      getModelsConfig: vi.fn(() => ({
+        getGenerationConfig: vi.fn(() => ({
+          baseUrl: 'https://api.example.com/v1',
+        })),
+      })),
+    } as unknown as Partial<Config>);
+
+    expect(getByText('text-only · auto-detected')).toBeDefined();
+    expect(getByText('t: test image support')).toBeDefined();
+  });
+
+  it('badges probe-tested modalities without offering the t action again', () => {
+    const { getByText, queryByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'vl-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'vl-model',
+          label: 'VL Model',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+          modalitiesSource: 'probe',
+        },
+      ]),
+    } as unknown as Partial<Config>);
+
+    expect(getByText('text · image · probe-tested')).toBeDefined();
+    expect(queryByText('t: test image support')).toBeNull();
+  });
+
+  it('badges explicitly declared modalities as manual', () => {
+    const { getByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'explicit-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'explicit-model',
+          label: 'Explicit Model',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          modalities: { image: true },
+          modalitiesSource: 'explicit',
+        },
+      ]),
+    } as unknown as Partial<Config>);
+
+    expect(getByText('text · image · manual')).toBeDefined();
+  });
+
+  it('does not run the probe for non-pattern modality sources', async () => {
+    const { mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'explicit-model'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'explicit-model',
+          label: 'Explicit Model',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://api.example.com/v1',
+          envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
+          modalities: { image: true },
+          modalitiesSource: 'explicit',
+        },
+      ]),
+      getModelsConfig: vi.fn(() => ({
+        getGenerationConfig: vi.fn(() => ({
+          baseUrl: 'https://api.example.com/v1',
+        })),
+      })),
+    } as unknown as Partial<Config>);
+
+    await pressT();
+
+    expect(mockedProbeImageSupport).not.toHaveBeenCalled();
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+  });
+
+  it('probes a pattern-source entry on t and persists the whole probeResults map', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'image',
+        httpStatus: 200,
+        snippet: 'ok',
+      });
+      const existingRecord = {
+        verdict: 'text_only' as const,
+        probedAt: '2026-01-01T00:00:00.000Z',
+      };
+      // Scope-targeted read: the write must start from the TARGET scope's
+      // own map (preserving its records) — not from the merged view.
+      const userSettingsFile = {
+        settings: {
+          probeResults: {
+            'openai|older-model|https://older.example.com/v1': existingRecord,
+          },
+        },
+      };
+
+      const { getByText, mockSettings } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          forScope: () => userSettingsFile,
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).toHaveBeenCalledTimes(1);
+      expect(mockedProbeImageSupport).toHaveBeenCalledWith({
+        model: 'pattern-model',
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'sk-probe-test',
+      });
+      expect(mockSettings.setValue).toHaveBeenCalledTimes(1);
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'probeResults',
+        {
+          'openai|older-model|https://older.example.com/v1': existingRecord,
+          'openai|pattern-model|https://api.example.com/v1': {
+            verdict: 'image',
+            probedAt: expect.any(String),
+          },
+        },
+      );
+      // Registry entries are not reloaded mid-dialog: BOTH the badge and the
+      // modality value flip to the verdict-consistent presentation from
+      // local dialog state.
+      expect(getByText('text · image · probe-tested')).toBeDefined();
+      expect(getByText('accepts images')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('writes nothing when the probe verdict is unknown', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'unknown',
+        httpStatus: 401,
+        snippet: 'unauthorized',
+      });
+
+      const { getByText, mockSettings } = renderComponent({}, {
+        getModel: vi.fn(() => 'pattern-model'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+        getModelsConfig: vi.fn(() => ({
+          getGenerationConfig: vi.fn(() => ({
+            baseUrl: 'https://api.example.com/v1',
+          })),
+        })),
+      } as unknown as Partial<Config>);
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).toHaveBeenCalledTimes(1);
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+      expect(
+        getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
+      ).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('reports inconclusive without probing when the API key env is unset', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    // No key in the environment: the handler must bail out BEFORE any
+    // network attempt and write nothing.
+    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    try {
+      const { getByText, mockSettings } = renderComponent({}, {
+        getModel: vi.fn(() => 'pattern-model'),
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+        getModelsConfig: vi.fn(() => ({
+          getGenerationConfig: vi.fn(() => ({
+            baseUrl: 'https://api.example.com/v1',
+          })),
+        })),
+      } as unknown as Partial<Config>);
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).not.toHaveBeenCalled();
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+      expect(
+        getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
+      ).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('hydrates a settings-backed API key before probing', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    // The key exists only in settings.env — NOT in process.env — so the
+    // probe only works if the handler hydrates the env first.
+    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'text_only',
+        httpStatus: 400,
+        snippet: 'does not support images',
+      });
+
+      const { getByText, mockSettings } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          merged: {
+            env: { MODEL_DIALOG_PROBE_TEST_KEY: 'sk-from-env-42' },
+          },
+          forScope: () => ({ settings: {} }),
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+
+      expect(mockedProbeImageSupport).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'sk-from-env-42' }),
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledTimes(1);
+      expect(getByText('text only')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('displaces the verdict display when the highlight moves to another entry', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'image',
+        httpStatus: 200,
+        snippet: 'ok',
+      });
+
+      const { getByText, queryByText } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [
+            patternSourceModel,
+            {
+              id: 'pattern-model-b',
+              label: 'Pattern Model B',
+              description: '',
+              authType: AuthType.USE_OPENAI,
+              modalitiesSource: 'pattern',
+            },
+          ]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          forScope: () => ({ settings: {} }),
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+      // Entry A (highlighted) shows the verdict.
+      expect(getByText('text · image · probe-tested')).toBeDefined();
+      // Move the highlight to entry B: B shows its OWN pattern badge and
+      // none of A's verdict display leaks onto it.
+      const selectProps = mockedSelect.mock.calls[0][0];
+      const entryB = selectProps.items[1].value;
+      act(() => {
+        selectProps.onHighlight?.(entryB);
+      });
+      expect(getByText('text-only · auto-detected')).toBeDefined();
+      expect(queryByText('accepts images')).toBeNull();
+      expect(queryByText('text · image · probe-tested')).toBeNull();
+
+      // Moving back to A re-shows A's (uncorrupted) verdict display.
+      act(() => {
+        selectProps.onHighlight?.(selectProps.items[0].value);
+      });
+      expect(getByText('text · image · probe-tested')).toBeDefined();
+      expect(getByText('accepts images')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
+  });
+
+  it('surfaces a settings-write failure instead of unhandled success', async () => {
+    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
+    const setValue = vi.fn(() => {
+      const error = new Error('settings are read-only');
+      Object.assign(error, { code: 'EACCES' });
+      throw error;
+    });
+    try {
+      mockedProbeImageSupport.mockResolvedValue({
+        verdict: 'image',
+        httpStatus: 200,
+        snippet: 'ok',
+      });
+
+      const { getByText, queryByText } = renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'pattern-model'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.example.com/v1',
+            })),
+          })),
+        } as unknown as Partial<Config>,
+        {
+          setValue,
+          forScope: () => ({ settings: {} }),
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      await pressT();
+
+      expect(setValue).toHaveBeenCalledTimes(1);
+      // The failure surfaces through the dialog's error channel...
+      expect(
+        getByText((text) =>
+          text.includes('Image probe verdict could not be saved.'),
+        ),
+      ).toBeDefined();
+      // ...and no success feedback or verdict badge is shown (nothing was
+      // persisted, so the entry's own pattern source stays on display and
+      // the t action remains available for a retry).
+      expect(queryByText('accepts images')).toBeNull();
+      expect(queryByText('text · image · probe-tested')).toBeNull();
+      expect(getByText('text-only · auto-detected')).toBeDefined();
+      expect(getByText('t: test image support')).toBeDefined();
+    } finally {
+      if (previousKey === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+      }
+    }
   });
 });
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -1999,37 +1999,87 @@ describe('<ModelDialog />', () => {
     modalitiesSource: 'pattern',
   };
 
-  it('badges pattern-guessed modalities as auto-detected and offers the t action', () => {
-    const { getByText } = renderComponent({}, {
-      getModel: vi.fn(() => 'pattern-model'),
+  // The probe suite's explicit-declaration counterpart: same endpoint shape
+  // as patternSourceModel with hand-written modalities.
+  const explicitSourceModel = {
+    id: 'explicit-model',
+    label: 'Explicit Model',
+    description: '',
+    authType: AuthType.USE_OPENAI,
+    baseUrl: 'https://api.example.com/v1',
+    envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
+    modalities: { image: true },
+    modalitiesSource: 'explicit',
+  };
+
+  /** Minimal dialog Config around a model list: the FIRST model is the
+   * current selection, and getModelsConfig mirrors its baseUrl so the
+   * highlighted row resolves to it. */
+  const probeDialogConfig = (
+    models: Array<Record<string, unknown>>,
+  ): Partial<Config> =>
+    ({
+      getModel: vi.fn(() => models[0]!['id']),
       getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+      getAllConfiguredModels: vi.fn(() => models),
       getModelsConfig: vi.fn(() => ({
         getGenerationConfig: vi.fn(() => ({
-          baseUrl: 'https://api.example.com/v1',
+          baseUrl: models[0]!['baseUrl'],
         })),
       })),
-    } as unknown as Partial<Config>);
+    }) as unknown as Partial<Config>;
+
+  /** Mount the probe suite's standard dialog over `models`. */
+  const renderProbeDialog = (
+    models: Array<Record<string, unknown>> = [patternSourceModel],
+    settingsValue?: Partial<LoadedSettings>,
+  ) => renderComponent({}, probeDialogConfig(models), settingsValue);
+
+  /** `it` wrapper that pins MODEL_DIALOG_PROBE_TEST_KEY to `value` (deleted
+   * when undefined) for the body and restores the prior value afterwards. */
+  const itWithProbeKeyEnv = (
+    name: string,
+    value: string | undefined,
+    fn: () => Promise<void> | void,
+  ) =>
+    // The wrapper forwards a literal title from each call site below.
+    // eslint-disable-next-line vitest/valid-title
+    it(name, async () => {
+      const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      if (value === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = value;
+      }
+      try {
+        await fn();
+      } finally {
+        if (previousKey === undefined) {
+          delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+        } else {
+          process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+        }
+      }
+    });
+
+  it('badges pattern-guessed modalities as auto-detected and offers the t action', () => {
+    const { getByText } = renderProbeDialog();
 
     expect(getByText('text-only · auto-detected')).toBeDefined();
     expect(getByText('t: test image support')).toBeDefined();
   });
 
   it('badges probe-tested modalities without offering the t action again', () => {
-    const { getByText, queryByText } = renderComponent({}, {
-      getModel: vi.fn(() => 'vl-model'),
-      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [
-        {
-          id: 'vl-model',
-          label: 'VL Model',
-          description: '',
-          authType: AuthType.USE_OPENAI,
-          modalities: { image: true },
-          modalitiesSource: 'probe',
-        },
-      ]),
-    } as unknown as Partial<Config>);
+    const { getByText, queryByText } = renderProbeDialog([
+      {
+        id: 'vl-model',
+        label: 'VL Model',
+        description: '',
+        authType: AuthType.USE_OPENAI,
+        modalities: { image: true },
+        modalitiesSource: 'probe',
+      },
+    ]);
 
     expect(getByText('text · image · probe-tested')).toBeDefined();
     expect(queryByText('t: test image support')).toBeNull();
@@ -2040,29 +2090,16 @@ describe('<ModelDialog />', () => {
     // settings.setValue does not refresh it — but the dialog reads the live
     // settings store, so the persisted verdict must drive BOTH the badge and
     // the t-action gating even while the entry still says 'pattern'.
-    const { getByText, queryByText } = renderComponent(
-      {},
-      {
-        getModel: vi.fn(() => 'pattern-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>,
-      {
-        merged: {
-          probeResults: {
-            'openai|pattern-model|https://api.example.com/v1': {
-              verdict: 'text_only',
-              probedAt: '2026-01-01T00:00:00.000Z',
-            },
+    const { getByText, queryByText } = renderProbeDialog(undefined, {
+      merged: {
+        probeResults: {
+          'openai|pattern-model|https://api.example.com/v1': {
+            verdict: 'text_only',
+            probedAt: '2026-01-01T00:00:00.000Z',
           },
         },
-      } as unknown as Partial<LoadedSettings>,
-    );
+      },
+    } as unknown as Partial<LoadedSettings>);
 
     expect(getByText('text-only · probe-tested')).toBeDefined();
     expect(queryByText('t: test image support')).toBeNull();
@@ -2073,29 +2110,8 @@ describe('<ModelDialog />', () => {
     // hand-write modelProviders modalities and reload the registry, which
     // stamps the entry 'explicit'. The live probe read must not shadow
     // that: badge shows manual with the hand-written value.
-    const { getByText, queryByText } = renderComponent(
-      {},
-      {
-        getModel: vi.fn(() => 'explicit-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [
-          {
-            id: 'explicit-model',
-            label: 'Explicit Model',
-            description: '',
-            authType: AuthType.USE_OPENAI,
-            baseUrl: 'https://api.example.com/v1',
-            envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
-            modalities: { image: true },
-            modalitiesSource: 'explicit',
-          },
-        ]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>,
+    const { getByText, queryByText } = renderProbeDialog(
+      [explicitSourceModel],
       {
         merged: {
           probeResults: {
@@ -2117,46 +2133,22 @@ describe('<ModelDialog />', () => {
   });
 
   it('badges explicitly declared modalities as manual', () => {
-    const { getByText } = renderComponent({}, {
-      getModel: vi.fn(() => 'explicit-model'),
-      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [
-        {
-          id: 'explicit-model',
-          label: 'Explicit Model',
-          description: '',
-          authType: AuthType.USE_OPENAI,
-          modalities: { image: true },
-          modalitiesSource: 'explicit',
-        },
-      ]),
-    } as unknown as Partial<Config>);
+    const { getByText } = renderProbeDialog([
+      {
+        id: 'explicit-model',
+        label: 'Explicit Model',
+        description: '',
+        authType: AuthType.USE_OPENAI,
+        modalities: { image: true },
+        modalitiesSource: 'explicit',
+      },
+    ]);
 
     expect(getByText('text · image · manual')).toBeDefined();
   });
 
   it('does not run the probe for non-pattern modality sources', async () => {
-    const { mockSettings } = renderComponent({}, {
-      getModel: vi.fn(() => 'explicit-model'),
-      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [
-        {
-          id: 'explicit-model',
-          label: 'Explicit Model',
-          description: '',
-          authType: AuthType.USE_OPENAI,
-          baseUrl: 'https://api.example.com/v1',
-          envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
-          modalities: { image: true },
-          modalitiesSource: 'explicit',
-        },
-      ]),
-      getModelsConfig: vi.fn(() => ({
-        getGenerationConfig: vi.fn(() => ({
-          baseUrl: 'https://api.example.com/v1',
-        })),
-      })),
-    } as unknown as Partial<Config>);
+    const { mockSettings } = renderProbeDialog([explicitSourceModel]);
 
     await pressT();
 
@@ -2164,10 +2156,10 @@ describe('<ModelDialog />', () => {
     expect(mockSettings.setValue).not.toHaveBeenCalled();
   });
 
-  it('probes a pattern-source entry on t and persists the whole probeResults map', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    try {
+  itWithProbeKeyEnv(
+    'probes a pattern-source entry on t and persists the whole probeResults map',
+    'sk-probe-test',
+    async () => {
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'image',
         httpStatus: 200,
@@ -2187,22 +2179,9 @@ describe('<ModelDialog />', () => {
         },
       };
 
-      const { getByText, mockSettings } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          forScope: () => userSettingsFile,
-        } as unknown as Partial<LoadedSettings>,
-      );
+      const { getByText, mockSettings } = renderProbeDialog(undefined, {
+        forScope: () => userSettingsFile,
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2229,36 +2208,13 @@ describe('<ModelDialog />', () => {
       // local dialog state.
       expect(getByText('text · image · probe-tested')).toBeDefined();
       expect(getByText('accepts images')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('hides the t action once a verdict concludes and keeps it after unknown', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    const renderPatternDialog = () =>
-      renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          forScope: () => ({ settings: {} }),
-        } as unknown as Partial<LoadedSettings>,
-      );
-    try {
+  itWithProbeKeyEnv(
+    'hides the t action once a verdict concludes and keeps it after unknown',
+    'sk-probe-test',
+    async () => {
       // Concluded verdict: the t action must disappear. Note the mocked
       // setValue does NOT refresh settings.merged, so the live-settings
       // lookup still misses — only the local verdict state gates the action
@@ -2268,7 +2224,9 @@ describe('<ModelDialog />', () => {
         httpStatus: 200,
         snippet: 'ok',
       });
-      const first = renderPatternDialog();
+      const first = renderProbeDialog(undefined, {
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2283,7 +2241,9 @@ describe('<ModelDialog />', () => {
         httpStatus: 429,
         snippet: 'rate limited',
       });
-      const second = renderPatternDialog();
+      const second = renderProbeDialog(undefined, {
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2294,35 +2254,20 @@ describe('<ModelDialog />', () => {
       ).toBeDefined();
       expect(second.getByText('t: test image support')).toBeDefined();
       second.unmount();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('writes nothing when the probe verdict is unknown', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    try {
+  itWithProbeKeyEnv(
+    'writes nothing when the probe verdict is unknown',
+    'sk-probe-test',
+    async () => {
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'unknown',
         httpStatus: 401,
         snippet: 'unauthorized',
       });
 
-      const { getByText, mockSettings } = renderComponent({}, {
-        getModel: vi.fn(() => 'pattern-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>);
+      const { getByText, mockSettings } = renderProbeDialog();
 
       await pressT();
 
@@ -2331,31 +2276,16 @@ describe('<ModelDialog />', () => {
       expect(
         getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
       ).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('reports inconclusive without probing when the API key env is unset', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    // No key in the environment: the handler must bail out BEFORE any
-    // network attempt and write nothing.
-    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    try {
-      const { getByText, mockSettings } = renderComponent({}, {
-        getModel: vi.fn(() => 'pattern-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>);
+  itWithProbeKeyEnv(
+    'reports inconclusive without probing when the API key env is unset',
+    undefined,
+    async () => {
+      // No key in the environment: the handler must bail out BEFORE any
+      // network attempt and write nothing.
+      const { getByText, mockSettings } = renderProbeDialog();
 
       await pressT();
 
@@ -2364,46 +2294,27 @@ describe('<ModelDialog />', () => {
       expect(
         getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
       ).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('hydrates a settings-backed API key before probing', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    // The key exists only in settings.env — NOT in process.env — so the
-    // probe only works if the handler hydrates the env first.
-    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    try {
+  itWithProbeKeyEnv(
+    'hydrates a settings-backed API key before probing',
+    undefined,
+    async () => {
+      // The key exists only in settings.env — NOT in process.env — so the
+      // probe only works if the handler hydrates the env first.
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'text_only',
         httpStatus: 400,
         snippet: 'does not support images',
       });
 
-      const { getByText, mockSettings } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          merged: {
-            env: { MODEL_DIALOG_PROBE_TEST_KEY: 'sk-from-settings-env' },
-          },
-          forScope: () => ({ settings: {} }),
-        } as unknown as Partial<LoadedSettings>,
-      );
+      const { getByText, mockSettings } = renderProbeDialog(undefined, {
+        merged: {
+          env: { MODEL_DIALOG_PROBE_TEST_KEY: 'sk-from-settings-env' },
+        },
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2412,46 +2323,30 @@ describe('<ModelDialog />', () => {
       );
       expect(mockSettings.setValue).toHaveBeenCalledTimes(1);
       expect(getByText('text only')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('displaces the verdict display when the highlight moves to another entry', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    try {
+  itWithProbeKeyEnv(
+    'displaces the verdict display when the highlight moves to another entry',
+    'sk-probe-test',
+    async () => {
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'image',
         httpStatus: 200,
         snippet: 'ok',
       });
 
-      const { getByText, queryByText } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [
-            patternSourceModel,
-            {
-              id: 'pattern-model-b',
-              label: 'Pattern Model B',
-              description: '',
-              authType: AuthType.USE_OPENAI,
-              modalitiesSource: 'pattern',
-            },
-          ]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
+      const { getByText, queryByText } = renderProbeDialog(
+        [
+          patternSourceModel,
+          {
+            id: 'pattern-model-b',
+            label: 'Pattern Model B',
+            description: '',
+            authType: AuthType.USE_OPENAI,
+            modalitiesSource: 'pattern',
+          },
+        ],
         {
           forScope: () => ({ settings: {} }),
         } as unknown as Partial<LoadedSettings>,
@@ -2477,47 +2372,28 @@ describe('<ModelDialog />', () => {
       });
       expect(getByText('text · image · probe-tested')).toBeDefined();
       expect(getByText('accepts images')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('surfaces a settings-write failure instead of unhandled success', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    const setValue = vi.fn(() => {
-      const error = new Error('settings are read-only');
-      Object.assign(error, { code: 'EACCES' });
-      throw error;
-    });
-    try {
+  itWithProbeKeyEnv(
+    'surfaces a settings-write failure instead of unhandled success',
+    'sk-probe-test',
+    async () => {
+      const setValue = vi.fn(() => {
+        const error = new Error('settings are read-only');
+        Object.assign(error, { code: 'EACCES' });
+        throw error;
+      });
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'image',
         httpStatus: 200,
         snippet: 'ok',
       });
 
-      const { getByText, queryByText } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          setValue,
-          forScope: () => ({ settings: {} }),
-        } as unknown as Partial<LoadedSettings>,
-      );
+      const { getByText, queryByText } = renderProbeDialog(undefined, {
+        setValue,
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2535,14 +2411,8 @@ describe('<ModelDialog />', () => {
       expect(queryByText('text · image · probe-tested')).toBeNull();
       expect(getByText('text-only · auto-detected')).toBeDefined();
       expect(getByText('t: test image support')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 });
 
 describe('encodeAuxModelSelector', () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -1999,37 +1999,87 @@ describe('<ModelDialog />', () => {
     modalitiesSource: 'pattern',
   };
 
-  it('badges pattern-guessed modalities as auto-detected and offers the t action', () => {
-    const { getByText } = renderComponent({}, {
-      getModel: vi.fn(() => 'pattern-model'),
+  // The probe suite's explicit-declaration counterpart: same endpoint shape
+  // as patternSourceModel with hand-written modalities.
+  const explicitSourceModel = {
+    id: 'explicit-model',
+    label: 'Explicit Model',
+    description: '',
+    authType: AuthType.USE_OPENAI,
+    baseUrl: 'https://api.example.com/v1',
+    envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
+    modalities: { image: true },
+    modalitiesSource: 'explicit',
+  };
+
+  /** Minimal dialog Config around a model list: the FIRST model is the
+   * current selection, and getModelsConfig mirrors its baseUrl so the
+   * highlighted row resolves to it. */
+  const probeDialogConfig = (
+    models: Array<Record<string, unknown>>,
+  ): Partial<Config> =>
+    ({
+      getModel: vi.fn(() => models[0]!['id']),
       getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
+      getAllConfiguredModels: vi.fn(() => models),
       getModelsConfig: vi.fn(() => ({
         getGenerationConfig: vi.fn(() => ({
-          baseUrl: 'https://api.example.com/v1',
+          baseUrl: models[0]!['baseUrl'],
         })),
       })),
-    } as unknown as Partial<Config>);
+    }) as unknown as Partial<Config>;
+
+  /** Mount the probe suite's standard dialog over `models`. */
+  const renderProbeDialog = (
+    models: Array<Record<string, unknown>> = [patternSourceModel],
+    settingsValue?: Partial<LoadedSettings>,
+  ) => renderComponent({}, probeDialogConfig(models), settingsValue);
+
+  /** `it` wrapper that pins MODEL_DIALOG_PROBE_TEST_KEY to `value` (deleted
+   * when undefined) for the body and restores the prior value afterwards. */
+  const itWithProbeKeyEnv = (
+    name: string,
+    value: string | undefined,
+    fn: () => Promise<void> | void,
+  ) =>
+    // The wrapper forwards a literal title from each call site below.
+    // eslint-disable-next-line vitest/valid-title
+    it(name, async () => {
+      const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      if (value === undefined) {
+        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+      } else {
+        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = value;
+      }
+      try {
+        await fn();
+      } finally {
+        if (previousKey === undefined) {
+          delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
+        } else {
+          process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
+        }
+      }
+    });
+
+  it('badges pattern-guessed modalities as auto-detected and offers the t action', () => {
+    const { getByText } = renderProbeDialog();
 
     expect(getByText('text-only · auto-detected')).toBeDefined();
     expect(getByText('t: test image support')).toBeDefined();
   });
 
   it('badges probe-tested modalities without offering the t action again', () => {
-    const { getByText, queryByText } = renderComponent({}, {
-      getModel: vi.fn(() => 'vl-model'),
-      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [
-        {
-          id: 'vl-model',
-          label: 'VL Model',
-          description: '',
-          authType: AuthType.USE_OPENAI,
-          modalities: { image: true },
-          modalitiesSource: 'probe',
-        },
-      ]),
-    } as unknown as Partial<Config>);
+    const { getByText, queryByText } = renderProbeDialog([
+      {
+        id: 'vl-model',
+        label: 'VL Model',
+        description: '',
+        authType: AuthType.USE_OPENAI,
+        modalities: { image: true },
+        modalitiesSource: 'probe',
+      },
+    ]);
 
     expect(getByText('text · image · probe-tested')).toBeDefined();
     expect(queryByText('t: test image support')).toBeNull();
@@ -2040,29 +2090,16 @@ describe('<ModelDialog />', () => {
     // settings.setValue does not refresh it — but the dialog reads the live
     // settings store, so the persisted verdict must drive BOTH the badge and
     // the t-action gating even while the entry still says 'pattern'.
-    const { getByText, queryByText } = renderComponent(
-      {},
-      {
-        getModel: vi.fn(() => 'pattern-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>,
-      {
-        merged: {
-          probeResults: {
-            'openai|pattern-model|https://api.example.com/v1': {
-              verdict: 'text_only',
-              probedAt: '2026-01-01T00:00:00.000Z',
-            },
+    const { getByText, queryByText } = renderProbeDialog(undefined, {
+      merged: {
+        probeResults: {
+          'openai|pattern-model|https://api.example.com/v1': {
+            verdict: 'text_only',
+            probedAt: '2026-01-01T00:00:00.000Z',
           },
         },
-      } as unknown as Partial<LoadedSettings>,
-    );
+      },
+    } as unknown as Partial<LoadedSettings>);
 
     expect(getByText('text-only · probe-tested')).toBeDefined();
     expect(queryByText('t: test image support')).toBeNull();
@@ -2073,29 +2110,8 @@ describe('<ModelDialog />', () => {
     // hand-write modelProviders modalities and reload the registry, which
     // stamps the entry 'explicit'. The live probe read must not shadow
     // that: badge shows manual with the hand-written value.
-    const { getByText, queryByText } = renderComponent(
-      {},
-      {
-        getModel: vi.fn(() => 'explicit-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [
-          {
-            id: 'explicit-model',
-            label: 'Explicit Model',
-            description: '',
-            authType: AuthType.USE_OPENAI,
-            baseUrl: 'https://api.example.com/v1',
-            envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
-            modalities: { image: true },
-            modalitiesSource: 'explicit',
-          },
-        ]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>,
+    const { getByText, queryByText } = renderProbeDialog(
+      [explicitSourceModel],
       {
         merged: {
           probeResults: {
@@ -2117,46 +2133,22 @@ describe('<ModelDialog />', () => {
   });
 
   it('badges explicitly declared modalities as manual', () => {
-    const { getByText } = renderComponent({}, {
-      getModel: vi.fn(() => 'explicit-model'),
-      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [
-        {
-          id: 'explicit-model',
-          label: 'Explicit Model',
-          description: '',
-          authType: AuthType.USE_OPENAI,
-          modalities: { image: true },
-          modalitiesSource: 'explicit',
-        },
-      ]),
-    } as unknown as Partial<Config>);
+    const { getByText } = renderProbeDialog([
+      {
+        id: 'explicit-model',
+        label: 'Explicit Model',
+        description: '',
+        authType: AuthType.USE_OPENAI,
+        modalities: { image: true },
+        modalitiesSource: 'explicit',
+      },
+    ]);
 
     expect(getByText('text · image · manual')).toBeDefined();
   });
 
   it('does not run the probe for non-pattern modality sources', async () => {
-    const { mockSettings } = renderComponent({}, {
-      getModel: vi.fn(() => 'explicit-model'),
-      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-      getAllConfiguredModels: vi.fn(() => [
-        {
-          id: 'explicit-model',
-          label: 'Explicit Model',
-          description: '',
-          authType: AuthType.USE_OPENAI,
-          baseUrl: 'https://api.example.com/v1',
-          envKey: 'MODEL_DIALOG_PROBE_TEST_KEY',
-          modalities: { image: true },
-          modalitiesSource: 'explicit',
-        },
-      ]),
-      getModelsConfig: vi.fn(() => ({
-        getGenerationConfig: vi.fn(() => ({
-          baseUrl: 'https://api.example.com/v1',
-        })),
-      })),
-    } as unknown as Partial<Config>);
+    const { mockSettings } = renderProbeDialog([explicitSourceModel]);
 
     await pressT();
 
@@ -2164,10 +2156,10 @@ describe('<ModelDialog />', () => {
     expect(mockSettings.setValue).not.toHaveBeenCalled();
   });
 
-  it('probes a pattern-source entry on t and persists the whole probeResults map', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    try {
+  itWithProbeKeyEnv(
+    'probes a pattern-source entry on t and persists the whole probeResults map',
+    'sk-probe-test',
+    async () => {
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'image',
         httpStatus: 200,
@@ -2187,22 +2179,9 @@ describe('<ModelDialog />', () => {
         },
       };
 
-      const { getByText, mockSettings } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          forScope: () => userSettingsFile,
-        } as unknown as Partial<LoadedSettings>,
-      );
+      const { getByText, mockSettings } = renderProbeDialog(undefined, {
+        forScope: () => userSettingsFile,
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2229,36 +2208,13 @@ describe('<ModelDialog />', () => {
       // local dialog state.
       expect(getByText('text · image · probe-tested')).toBeDefined();
       expect(getByText('accepts images')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('hides the t action once a verdict concludes and keeps it after unknown', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    const renderPatternDialog = () =>
-      renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          forScope: () => ({ settings: {} }),
-        } as unknown as Partial<LoadedSettings>,
-      );
-    try {
+  itWithProbeKeyEnv(
+    'hides the t action once a verdict concludes and keeps it after unknown',
+    'sk-probe-test',
+    async () => {
       // Concluded verdict: the t action must disappear. Note the mocked
       // setValue does NOT refresh settings.merged, so the live-settings
       // lookup still misses — only the local verdict state gates the action
@@ -2268,7 +2224,9 @@ describe('<ModelDialog />', () => {
         httpStatus: 200,
         snippet: 'ok',
       });
-      const first = renderPatternDialog();
+      const first = renderProbeDialog(undefined, {
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2283,7 +2241,9 @@ describe('<ModelDialog />', () => {
         httpStatus: 429,
         snippet: 'rate limited',
       });
-      const second = renderPatternDialog();
+      const second = renderProbeDialog(undefined, {
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2294,35 +2254,20 @@ describe('<ModelDialog />', () => {
       ).toBeDefined();
       expect(second.getByText('t: test image support')).toBeDefined();
       second.unmount();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('writes nothing when the probe verdict is unknown', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    try {
+  itWithProbeKeyEnv(
+    'writes nothing when the probe verdict is unknown',
+    'sk-probe-test',
+    async () => {
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'unknown',
         httpStatus: 401,
         snippet: 'unauthorized',
       });
 
-      const { getByText, mockSettings } = renderComponent({}, {
-        getModel: vi.fn(() => 'pattern-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>);
+      const { getByText, mockSettings } = renderProbeDialog();
 
       await pressT();
 
@@ -2331,31 +2276,16 @@ describe('<ModelDialog />', () => {
       expect(
         getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
       ).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('reports inconclusive without probing when the API key env is unset', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    // No key in the environment: the handler must bail out BEFORE any
-    // network attempt and write nothing.
-    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    try {
-      const { getByText, mockSettings } = renderComponent({}, {
-        getModel: vi.fn(() => 'pattern-model'),
-        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-        getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-        getModelsConfig: vi.fn(() => ({
-          getGenerationConfig: vi.fn(() => ({
-            baseUrl: 'https://api.example.com/v1',
-          })),
-        })),
-      } as unknown as Partial<Config>);
+  itWithProbeKeyEnv(
+    'reports inconclusive without probing when the API key env is unset',
+    undefined,
+    async () => {
+      // No key in the environment: the handler must bail out BEFORE any
+      // network attempt and write nothing.
+      const { getByText, mockSettings } = renderProbeDialog();
 
       await pressT();
 
@@ -2364,46 +2294,27 @@ describe('<ModelDialog />', () => {
       expect(
         getByText('inconclusive (auth/rate-limit/timeout) — nothing written'),
       ).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('hydrates a settings-backed API key before probing', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    // The key exists only in settings.env — NOT in process.env — so the
-    // probe only works if the handler hydrates the env first.
-    delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    try {
+  itWithProbeKeyEnv(
+    'hydrates a settings-backed API key before probing',
+    undefined,
+    async () => {
+      // The key exists only in settings.env — NOT in process.env — so the
+      // probe only works if the handler hydrates the env first.
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'text_only',
         httpStatus: 400,
         snippet: 'does not support images',
       });
 
-      const { getByText, mockSettings } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          merged: {
-            env: { MODEL_DIALOG_PROBE_TEST_KEY: 'sk-from-env-42' },
-          },
-          forScope: () => ({ settings: {} }),
-        } as unknown as Partial<LoadedSettings>,
-      );
+      const { getByText, mockSettings } = renderProbeDialog(undefined, {
+        merged: {
+          env: { MODEL_DIALOG_PROBE_TEST_KEY: 'sk-from-env-42' },
+        },
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2412,46 +2323,30 @@ describe('<ModelDialog />', () => {
       );
       expect(mockSettings.setValue).toHaveBeenCalledTimes(1);
       expect(getByText('text only')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('displaces the verdict display when the highlight moves to another entry', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    try {
+  itWithProbeKeyEnv(
+    'displaces the verdict display when the highlight moves to another entry',
+    'sk-probe-test',
+    async () => {
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'image',
         httpStatus: 200,
         snippet: 'ok',
       });
 
-      const { getByText, queryByText } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [
-            patternSourceModel,
-            {
-              id: 'pattern-model-b',
-              label: 'Pattern Model B',
-              description: '',
-              authType: AuthType.USE_OPENAI,
-              modalitiesSource: 'pattern',
-            },
-          ]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
+      const { getByText, queryByText } = renderProbeDialog(
+        [
+          patternSourceModel,
+          {
+            id: 'pattern-model-b',
+            label: 'Pattern Model B',
+            description: '',
+            authType: AuthType.USE_OPENAI,
+            modalitiesSource: 'pattern',
+          },
+        ],
         {
           forScope: () => ({ settings: {} }),
         } as unknown as Partial<LoadedSettings>,
@@ -2477,47 +2372,28 @@ describe('<ModelDialog />', () => {
       });
       expect(getByText('text · image · probe-tested')).toBeDefined();
       expect(getByText('accepts images')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 
-  it('surfaces a settings-write failure instead of unhandled success', async () => {
-    const previousKey = process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-    process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = 'sk-probe-test';
-    const setValue = vi.fn(() => {
-      const error = new Error('settings are read-only');
-      Object.assign(error, { code: 'EACCES' });
-      throw error;
-    });
-    try {
+  itWithProbeKeyEnv(
+    'surfaces a settings-write failure instead of unhandled success',
+    'sk-probe-test',
+    async () => {
+      const setValue = vi.fn(() => {
+        const error = new Error('settings are read-only');
+        Object.assign(error, { code: 'EACCES' });
+        throw error;
+      });
       mockedProbeImageSupport.mockResolvedValue({
         verdict: 'image',
         httpStatus: 200,
         snippet: 'ok',
       });
 
-      const { getByText, queryByText } = renderComponent(
-        {},
-        {
-          getModel: vi.fn(() => 'pattern-model'),
-          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
-          getAllConfiguredModels: vi.fn(() => [patternSourceModel]),
-          getModelsConfig: vi.fn(() => ({
-            getGenerationConfig: vi.fn(() => ({
-              baseUrl: 'https://api.example.com/v1',
-            })),
-          })),
-        } as unknown as Partial<Config>,
-        {
-          setValue,
-          forScope: () => ({ settings: {} }),
-        } as unknown as Partial<LoadedSettings>,
-      );
+      const { getByText, queryByText } = renderProbeDialog(undefined, {
+        setValue,
+        forScope: () => ({ settings: {} }),
+      } as unknown as Partial<LoadedSettings>);
 
       await pressT();
 
@@ -2535,14 +2411,8 @@ describe('<ModelDialog />', () => {
       expect(queryByText('text · image · probe-tested')).toBeNull();
       expect(getByText('text-only · auto-detected')).toBeDefined();
       expect(getByText('t: test image support')).toBeDefined();
-    } finally {
-      if (previousKey === undefined) {
-        delete process.env['MODEL_DIALOG_PROBE_TEST_KEY'];
-      } else {
-        process.env['MODEL_DIALOG_PROBE_TEST_KEY'] = previousKey;
-      }
-    }
-  });
+    },
+  );
 });
 
 describe('encodeAuxModelSelector', () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -2035,6 +2035,20 @@ describe('<ModelDialog />', () => {
     settingsValue?: Partial<LoadedSettings>,
   ) => renderComponent({}, probeDialogConfig(models), settingsValue);
 
+  /** Settings value giving every scope an empty settings object — the
+   * standard "no pre-existing probe records" persistence target. */
+  const emptyScopeSettings = {
+    forScope: () => ({ settings: {} }),
+  } as unknown as Partial<LoadedSettings>;
+
+  /** Pin the mocked probe endpoint's next verdict. */
+  const mockProbeVerdict = (
+    verdict: 'image' | 'text_only' | 'unknown',
+    httpStatus: number,
+    snippet: string,
+  ) =>
+    mockedProbeImageSupport.mockResolvedValue({ verdict, httpStatus, snippet });
+
   /** `it` wrapper that pins MODEL_DIALOG_PROBE_TEST_KEY to `value` (deleted
    * when undefined) for the body and restores the prior value afterwards. */
   const itWithProbeKeyEnv = (
@@ -2160,11 +2174,7 @@ describe('<ModelDialog />', () => {
     'probes a pattern-source entry on t and persists the whole probeResults map',
     'sk-probe-test',
     async () => {
-      mockedProbeImageSupport.mockResolvedValue({
-        verdict: 'image',
-        httpStatus: 200,
-        snippet: 'ok',
-      });
+      mockProbeVerdict('image', 200, 'ok');
       const existingRecord = {
         verdict: 'text_only' as const,
         probedAt: '2026-01-01T00:00:00.000Z',
@@ -2219,14 +2229,8 @@ describe('<ModelDialog />', () => {
       // setValue does NOT refresh settings.merged, so the live-settings
       // lookup still misses — only the local verdict state gates the action
       // here, which is exactly the fallback under test.
-      mockedProbeImageSupport.mockResolvedValue({
-        verdict: 'image',
-        httpStatus: 200,
-        snippet: 'ok',
-      });
-      const first = renderProbeDialog(undefined, {
-        forScope: () => ({ settings: {} }),
-      } as unknown as Partial<LoadedSettings>);
+      mockProbeVerdict('image', 200, 'ok');
+      const first = renderProbeDialog(undefined, emptyScopeSettings);
 
       await pressT();
 
@@ -2236,14 +2240,8 @@ describe('<ModelDialog />', () => {
 
       // Unknown verdict: nothing was written and no conclusion exists, so
       // retry stays available (phase 1 has no other re-probe entry point).
-      mockedProbeImageSupport.mockResolvedValue({
-        verdict: 'unknown',
-        httpStatus: 429,
-        snippet: 'rate limited',
-      });
-      const second = renderProbeDialog(undefined, {
-        forScope: () => ({ settings: {} }),
-      } as unknown as Partial<LoadedSettings>);
+      mockProbeVerdict('unknown', 429, 'rate limited');
+      const second = renderProbeDialog(undefined, emptyScopeSettings);
 
       await pressT();
 
@@ -2261,11 +2259,7 @@ describe('<ModelDialog />', () => {
     'writes nothing when the probe verdict is unknown',
     'sk-probe-test',
     async () => {
-      mockedProbeImageSupport.mockResolvedValue({
-        verdict: 'unknown',
-        httpStatus: 401,
-        snippet: 'unauthorized',
-      });
+      mockProbeVerdict('unknown', 401, 'unauthorized');
 
       const { getByText, mockSettings } = renderProbeDialog();
 
@@ -2303,11 +2297,7 @@ describe('<ModelDialog />', () => {
     async () => {
       // The key exists only in settings.env — NOT in process.env — so the
       // probe only works if the handler hydrates the env first.
-      mockedProbeImageSupport.mockResolvedValue({
-        verdict: 'text_only',
-        httpStatus: 400,
-        snippet: 'does not support images',
-      });
+      mockProbeVerdict('text_only', 400, 'does not support images');
 
       const { getByText, mockSettings } = renderProbeDialog(undefined, {
         merged: {
@@ -2330,11 +2320,7 @@ describe('<ModelDialog />', () => {
     'displaces the verdict display when the highlight moves to another entry',
     'sk-probe-test',
     async () => {
-      mockedProbeImageSupport.mockResolvedValue({
-        verdict: 'image',
-        httpStatus: 200,
-        snippet: 'ok',
-      });
+      mockProbeVerdict('image', 200, 'ok');
 
       const { getByText, queryByText } = renderProbeDialog(
         [
@@ -2347,9 +2333,7 @@ describe('<ModelDialog />', () => {
             modalitiesSource: 'pattern',
           },
         ],
-        {
-          forScope: () => ({ settings: {} }),
-        } as unknown as Partial<LoadedSettings>,
+        emptyScopeSettings,
       );
 
       await pressT();
@@ -2384,16 +2368,12 @@ describe('<ModelDialog />', () => {
         Object.assign(error, { code: 'EACCES' });
         throw error;
       });
-      mockedProbeImageSupport.mockResolvedValue({
-        verdict: 'image',
-        httpStatus: 200,
-        snippet: 'ok',
-      });
+      mockProbeVerdict('image', 200, 'ok');
 
       const { getByText, queryByText } = renderProbeDialog(undefined, {
         setValue,
-        forScope: () => ({ settings: {} }),
-      } as unknown as Partial<LoadedSettings>);
+        ...emptyScopeSettings,
+      });
 
       await pressT();
 

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -5,7 +5,6 @@
  */
 
 import type React from 'react';
-import process from 'node:process';
 import { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import {
@@ -16,19 +15,19 @@ import {
   isImageCapable,
   isImageGenerationCapable,
   parseVisionModelSetting,
-  probeImageSupport,
-  readProbeResult,
   resolveModelId,
-  withProbeResult,
   type AvailableModel as CoreAvailableModel,
   type Config,
   type ContentGeneratorConfig,
   type InputModalities,
-  type ModalityProbeVerdict,
   type ModalitySource,
 } from '@qwen-code/qwen-code-core';
 import { SettingScope } from '../../config/settings.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import {
+  hydrateApiKeyEnvFromSettings,
+  useImageSupportProbe,
+} from '../hooks/use-image-support-probe.js';
 import { theme } from '../semantic-colors.js';
 import { DescriptiveRadioButtonSelect } from './shared/DescriptiveRadioButtonSelect.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
@@ -238,24 +237,6 @@ function persistAuthTypeSelection(
 ): void {
   const scope = resolvePersistScope(settings, persistScope);
   settings.setValue(scope, 'security.auth.selectedType', authType);
-}
-
-function hydrateApiKeyEnvFromSettings(
-  settings: ReturnType<typeof useSettings>,
-  envKey: string | undefined,
-): void {
-  if (!envKey || process.env[envKey]) {
-    return;
-  }
-  const settingsEnvValue = (
-    settings?.merged?.env as Record<string, unknown> | undefined
-  )?.[envKey];
-  if (
-    typeof settingsEnvValue === 'string' &&
-    settingsEnvValue.trim().length > 0
-  ) {
-    process.env[envKey] = settingsEnvValue;
-  }
 }
 
 interface HandleModelSwitchSuccessParams {
@@ -784,134 +765,27 @@ export function ModelDialog({
     );
   }, [highlightedValue, preferredKey, availableModelEntries]);
 
-  // One-shot image modality probe (issue #10309, phase 1). `probeTargetKey`
-  // remembers WHICH entry a pending/finished verdict belongs to, so moving
-  // the highlight mid-probe never shows another entry's result.
-  const [probeState, setProbeState] = useState<
-    'idle' | 'probing' | ModalityProbeVerdict
-  >('idle');
-  const [probeTargetKey, setProbeTargetKey] = useState<string | null>(null);
-
   const highlightedEntryKey = highlightedEntry
     ? entrySelectionKey(highlightedEntry)
     : null;
-  const activeProbeState =
-    probeTargetKey !== null && probeTargetKey === highlightedEntryKey
-      ? probeState
-      : 'idle';
 
-  // Live probe-verdict source: the registry caches modalitiesSource at
-  // registration/reload time (a plain settings.setValue does NOT refresh
-  // already-registered entries), so a verdict concluded earlier in this
-  // session — or written by an earlier dialog session — is visible here only
-  // through the settings store itself. Keyed the same way the write path
-  // keys it (declared/resolved entry baseUrl). Read-side hardening mirrors
-  // the registry: only verdicts exactly 'image'/'text_only' are honored;
-  // hand-edited garbage abstains to the entry's own source.
-  //
-  // The live read only applies to STILL-PATTERN-CACHED entries. An
-  // 'explicit'-stamped entry got there because the user hand-wrote
-  // modelProviders modalities — the phase-1 remediation exit for a wrong
-  // verdict — and a stale probe record must not shadow it in the UI. A
-  // 'probe'-stamped entry loses nothing either: phase 1 has no re-probe
-  // path, so the live store can never hold a newer conclusion than the
-  // registration-time stamp.
-  const liveRawVerdict =
-    highlightedEntry &&
-    !highlightedEntry.isRuntime &&
-    highlightedEntry.model.modalitiesSource === 'pattern'
-      ? readProbeResult(
-          settings.merged?.probeResults,
-          highlightedEntry.authType,
-          highlightedEntry.model.id,
-          highlightedEntry.model.baseUrl,
-        )?.verdict
-      : undefined;
-  const liveProbeVerdict: 'image' | 'text_only' | undefined =
-    liveRawVerdict === 'image' || liveRawVerdict === 'text_only'
-      ? liveRawVerdict
-      : undefined;
-
-  // The `t` action only applies to regex-guessed (pattern-source)
-  // modalities: explicit declarations need no probe, and entries carrying a
-  // conclusion — registry-stamped 'probe' source OR a live settings hit for
-  // a still-pattern-cached entry — need none; QWEN_OAUTH's two probe-key
-  // spellings diverge in phase 1 (see probe-store.ts), so it is excluded.
-  // Runtime models have no modalitiesSource and are excluded by the same
-  // check. A probe in flight disables re-trigger globally so two concurrent
-  // probes can never race the whole-map read-modify-write, and a CONCLUDED
-  // local verdict hides the action too ('unknown' keeps it — retry is the
-  // only recourse for an inconclusive probe in phase 1).
-  const canTestImageSupport =
-    !!highlightedEntry &&
-    !highlightedEntry.isRuntime &&
-    highlightedEntry.authType !== AuthType.QWEN_OAUTH &&
-    (liveProbeVerdict === undefined
-      ? highlightedEntry.model.modalitiesSource
-      : 'probe') === 'pattern' &&
-    probeState !== 'probing' &&
-    activeProbeState !== 'image' &&
-    activeProbeState !== 'text_only';
-
-  const handleTestImageSupport = useCallback(async () => {
-    if (!highlightedEntry || probeState === 'probing') return;
-    const { model } = highlightedEntry;
-    setErrorMessage(null);
-    setProbeState('probing');
-    setProbeTargetKey(entrySelectionKey(highlightedEntry));
-    // Settings-backed keys are not in process.env until hydrated — the same
-    // in-file helper handleSelect uses before switching models — so mid-
-    // session settings.env keys work without a restart. The API key is read
-    // from the environment at probe time only — never displayed, never
-    // logged, never persisted.
-    hydrateApiKeyEnvFromSettings(settings, model.envKey);
-    const apiKey = model.envKey ? process.env[model.envKey] : undefined;
-    if (!apiKey || !model.baseUrl) {
-      setProbeState('unknown');
-      return;
-    }
-    const result = await probeImageSupport({
-      model: model.id,
-      baseUrl: model.baseUrl,
-      apiKey,
-    });
-    if (result.verdict !== 'unknown') {
-      // Read the TARGET scope's own map (not the merged view) so records
-      // from other scopes never bleed into this write, and always write the
-      // WHOLE map under the single 'probeResults' key — composite probe
-      // keys embed dots and '|' that settings' dotted-path addressing would
-      // mis-nest.
-      const scope = resolvePersistScope(settings, persistScope);
-      try {
-        settings.setValue(
-          scope,
-          'probeResults',
-          withProbeResult(
-            settings.forScope(scope).settings.probeResults,
-            highlightedEntry.authType,
-            model.id,
-            model.baseUrl,
-            { verdict: result.verdict, probedAt: new Date().toISOString() },
-          ),
-        );
-      } catch (e) {
-        // setValue can throw (saveSettings re-throws fs errors) and this
-        // handler runs fire-and-forget, so an uncaught throw would be an
-        // unhandled rejection while the UI shows success. Surface the
-        // failure through the dialog's error channel (the same ✕ box
-        // handleSelect uses) and reset the probe display: the feedback row
-        // is hidden and the badge falls back to the entry's own (registry)
-        // source, which stays truthful because nothing was persisted.
-        const message = e instanceof Error ? e.message : String(e);
-        setProbeState('idle');
-        setErrorMessage(
-          `${t('Image probe verdict could not be saved.')}\n\n${message}`,
-        );
-        return;
-      }
-    }
-    setProbeState(result.verdict);
-  }, [highlightedEntry, persistScope, probeState, settings]);
+  // One-shot image modality probe (issue #10309, phase 1): the probe state
+  // machine, the live-verdict read, the t-action gating, and the derived
+  // badge/modality/feedback presentation all live in the hook; this
+  // component keeps only rendering and key binding.
+  const {
+    canTestImageSupport,
+    handleTestImageSupport,
+    displayedModalities,
+    displayedModalitiesSource,
+    probeFeedback,
+  } = useImageSupportProbe({
+    highlightedEntry,
+    highlightedEntryKey,
+    settings,
+    scope: resolvePersistScope(settings, persistScope),
+    setErrorMessage,
+  });
 
   // Registered separately from the escape handler above: this one depends
   // on `highlightedEntry` and the probe state, which are computed later in
@@ -930,48 +804,6 @@ export function ModelDialog({
     },
     { isActive: true },
   );
-
-  // Modality badge/value provenance is a two-layer source. Layer 1 is the
-  // registry's registration-time cache (`modalitiesSource`), which a plain
-  // settings.setValue does not refresh without a registry reload — and we
-  // deliberately do NOT reload mid-dialog. Layer 2 is the live settings
-  // store (`probeResults`), read on every render for the highlighted entry
-  // — but ONLY while that entry is still pattern-cached; 'explicit' and
-  // 'probe' stamps show their own value (a hand-written explicit
-  // declaration is the phase-1 way out of a wrong verdict, so it must not
-  // be shadowed by the stale probe record underneath). A local verdict from
-  // THIS dialog's probe overrides both, so the panel never contradicts
-  // itself mid-feedback (e.g. `text-only · probe-tested` above
-  // `accepts images`).
-  const displayedProbeVerdict: 'image' | 'text_only' | undefined =
-    activeProbeState === 'image' || activeProbeState === 'text_only'
-      ? activeProbeState
-      : liveProbeVerdict;
-  const displayedModalitiesSource: ModalitySource | undefined =
-    displayedProbeVerdict !== undefined
-      ? 'probe'
-      : highlightedEntry?.model.modalitiesSource;
-  const displayedModalities: InputModalities | undefined =
-    displayedProbeVerdict === 'image'
-      ? { ...highlightedEntry?.model.modalities, image: true }
-      : displayedProbeVerdict === 'text_only' &&
-          highlightedEntry?.model.modalities
-        ? { ...highlightedEntry.model.modalities, image: false }
-        : highlightedEntry?.model.modalities;
-
-  const probeFeedback: { text: string; color: string } | undefined =
-    activeProbeState === 'probing'
-      ? { text: t('testing…'), color: theme.text.secondary }
-      : activeProbeState === 'unknown'
-        ? {
-            text: t('inconclusive (auth/rate-limit/timeout) — nothing written'),
-            color: theme.status.warning,
-          }
-        : activeProbeState === 'image'
-          ? { text: t('accepts images'), color: theme.status.success }
-          : activeProbeState === 'text_only'
-            ? { text: t('text only'), color: theme.text.secondary }
-            : undefined;
 
   const handleSelect = useCallback(
     async (selected: string) => {

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -17,6 +17,7 @@ import {
   isImageGenerationCapable,
   parseVisionModelSetting,
   probeImageSupport,
+  readProbeResult,
   resolveModelId,
   withProbeResult,
   type AvailableModel as CoreAvailableModel,
@@ -799,19 +800,58 @@ export function ModelDialog({
       ? probeState
       : 'idle';
 
+  // Live probe-verdict source: the registry caches modalitiesSource at
+  // registration/reload time (a plain settings.setValue does NOT refresh
+  // already-registered entries), so a verdict concluded earlier in this
+  // session — or written by an earlier dialog session — is visible here only
+  // through the settings store itself. Keyed the same way the write path
+  // keys it (declared/resolved entry baseUrl). Read-side hardening mirrors
+  // the registry: only verdicts exactly 'image'/'text_only' are honored;
+  // hand-edited garbage abstains to the entry's own source.
+  //
+  // The live read only applies to STILL-PATTERN-CACHED entries. An
+  // 'explicit'-stamped entry got there because the user hand-wrote
+  // modelProviders modalities — the phase-1 remediation exit for a wrong
+  // verdict — and a stale probe record must not shadow it in the UI. A
+  // 'probe'-stamped entry loses nothing either: phase 1 has no re-probe
+  // path, so the live store can never hold a newer conclusion than the
+  // registration-time stamp.
+  const liveRawVerdict =
+    highlightedEntry &&
+    !highlightedEntry.isRuntime &&
+    highlightedEntry.model.modalitiesSource === 'pattern'
+      ? readProbeResult(
+          settings.merged?.probeResults,
+          highlightedEntry.authType,
+          highlightedEntry.model.id,
+          highlightedEntry.model.baseUrl,
+        )?.verdict
+      : undefined;
+  const liveProbeVerdict: 'image' | 'text_only' | undefined =
+    liveRawVerdict === 'image' || liveRawVerdict === 'text_only'
+      ? liveRawVerdict
+      : undefined;
+
   // The `t` action only applies to regex-guessed (pattern-source)
-  // modalities: explicit declarations need no probe, probe-derived entries
-  // already carry a persisted verdict, and QWEN_OAUTH's two probe-key
+  // modalities: explicit declarations need no probe, and entries carrying a
+  // conclusion — registry-stamped 'probe' source OR a live settings hit for
+  // a still-pattern-cached entry — need none; QWEN_OAUTH's two probe-key
   // spellings diverge in phase 1 (see probe-store.ts), so it is excluded.
   // Runtime models have no modalitiesSource and are excluded by the same
   // check. A probe in flight disables re-trigger globally so two concurrent
-  // probes can never race the whole-map read-modify-write.
+  // probes can never race the whole-map read-modify-write, and a CONCLUDED
+  // local verdict hides the action too ('unknown' keeps it — retry is the
+  // only recourse for an inconclusive probe in phase 1).
   const canTestImageSupport =
     !!highlightedEntry &&
     !highlightedEntry.isRuntime &&
     highlightedEntry.authType !== AuthType.QWEN_OAUTH &&
-    highlightedEntry.model.modalitiesSource === 'pattern' &&
-    probeState !== 'probing';
+    (liveProbeVerdict === undefined
+      ? highlightedEntry.model.modalitiesSource
+      : 'probe') === 'pattern' &&
+    probeState !== 'probing' &&
+    activeProbeState !== 'image' &&
+    activeProbeState !== 'text_only';
 
   const handleTestImageSupport = useCallback(async () => {
     if (!highlightedEntry || probeState === 'probing') return;
@@ -891,21 +931,31 @@ export function ModelDialog({
     { isActive: true },
   );
 
-  // Registry entries cache modalities/modalitiesSource — a plain
-  // settings.setValue does not refresh them without a registry reload, which
-  // we deliberately do NOT trigger mid-dialog. While a final verdict for the
-  // highlighted entry is on screen, locally derive BOTH the badge source and
-  // the modality value from it, so the panel never contradicts itself (e.g.
-  // `text-only · probe-tested` above `accepts images`); other entries'
-  // badges refresh the next time the dialog opens.
-  const displayedModalitiesSource: ModalitySource | undefined =
+  // Modality badge/value provenance is a two-layer source. Layer 1 is the
+  // registry's registration-time cache (`modalitiesSource`), which a plain
+  // settings.setValue does not refresh without a registry reload — and we
+  // deliberately do NOT reload mid-dialog. Layer 2 is the live settings
+  // store (`probeResults`), read on every render for the highlighted entry
+  // — but ONLY while that entry is still pattern-cached; 'explicit' and
+  // 'probe' stamps show their own value (a hand-written explicit
+  // declaration is the phase-1 way out of a wrong verdict, so it must not
+  // be shadowed by the stale probe record underneath). A local verdict from
+  // THIS dialog's probe overrides both, so the panel never contradicts
+  // itself mid-feedback (e.g. `text-only · probe-tested` above
+  // `accepts images`).
+  const displayedProbeVerdict: 'image' | 'text_only' | undefined =
     activeProbeState === 'image' || activeProbeState === 'text_only'
+      ? activeProbeState
+      : liveProbeVerdict;
+  const displayedModalitiesSource: ModalitySource | undefined =
+    displayedProbeVerdict !== undefined
       ? 'probe'
       : highlightedEntry?.model.modalitiesSource;
   const displayedModalities: InputModalities | undefined =
-    activeProbeState === 'image'
+    displayedProbeVerdict === 'image'
       ? { ...highlightedEntry?.model.modalities, image: true }
-      : activeProbeState === 'text_only' && highlightedEntry?.model.modalities
+      : displayedProbeVerdict === 'text_only' &&
+          highlightedEntry?.model.modalities
         ? { ...highlightedEntry.model.modalities, image: false }
         : highlightedEntry?.model.modalities;
 

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -16,11 +16,15 @@ import {
   isImageCapable,
   isImageGenerationCapable,
   parseVisionModelSetting,
+  probeImageSupport,
   resolveModelId,
+  withProbeResult,
   type AvailableModel as CoreAvailableModel,
   type Config,
   type ContentGeneratorConfig,
   type InputModalities,
+  type ModalityProbeVerdict,
+  type ModalitySource,
 } from '@qwen-code/qwen-code-core';
 import { SettingScope } from '../../config/settings.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -46,6 +50,22 @@ function formatModalities(modalities?: InputModalities): string {
   if (modalities.video) parts.push(t('video'));
   if (parts.length === 0) return t('text-only');
   return `${t('text')} · ${parts.join(' · ')}`;
+}
+
+/**
+ * Modality provenance suffix for the details panel (issue #10309): the
+ * badge reads the resolver's `modalitiesSource` annotation — never the
+ * settings sources map, which labels probe-derived modalities misleadingly
+ * as 'modelProviders'. Undefined source renders the plain base value.
+ */
+function formatModalitiesWithSource(
+  modalities: InputModalities | undefined,
+  source: ModalitySource | undefined,
+): string {
+  const base = formatModalities(modalities);
+  if (source === 'probe') return `${base} · ${t('probe-tested')}`;
+  if (source === 'pattern') return `${base} · ${t('auto-detected')}`;
+  return source === 'explicit' ? `${base} · ${t('manual')}` : base;
 }
 
 /**
@@ -85,6 +105,29 @@ function parseModelSelectionKey(key: string): {
     };
   }
   return { authType, modelId: rest };
+}
+
+/**
+ * Selection key for a dialog entry: runtime snapshots are keyed by their
+ * snapshot id, registry entries by `authType::modelId[\0baseUrl]`. Every
+ * consumer — the option list, highlight resolution, selection handling, and
+ * the probe flow's `probeTargetKey` displacement guard — must agree
+ * byte-for-byte, so they all go through this one helper.
+ */
+function entrySelectionKey({
+  authType,
+  model,
+  isRuntime,
+  snapshotId,
+}: {
+  authType: AuthType;
+  model: CoreAvailableModel;
+  isRuntime?: boolean;
+  snapshotId?: string;
+}): string {
+  return isRuntime && snapshotId
+    ? snapshotId
+    : buildModelSelectionKey(authType, model.id, model.baseUrl);
 }
 
 /**
@@ -129,13 +172,21 @@ interface ModelDialogProps {
 const MAX_MODEL_ITEMS_TO_SHOW = 10;
 // Non-list dialog chrome to reserve when capping visible model rows: outer
 // round border (2) + outer padding (2) + title (1) + gap before the list (1)
-// + highlighted-entry detail panel (divider + up to 4 detail rows, ~6) +
-// footer gap and hint text (2). The list intentionally omits the ▲/▼ scroll
-// indicators other list dialogs enable: they are two always-rendered chrome
-// rows, and in a height-capped dialog those rows are better spent on two
+// + highlighted-entry detail panel (divider + up to 4 standing detail rows,
+// ~6) + footer gap and hint text (2). The list intentionally omits the ▲/▼
+// scroll indicators other list dialogs enable: they are two always-rendered
+// chrome rows, and in a height-capped dialog those rows are better spent on two
 // more entries — the entry numbering already shows where the visible window
 // sits in the list. Adjust this whenever the surrounding layout changes, and
 // re-verify with an E2E height sweep rather than guessing.
+//
+// Two CONDITIONAL rows are deliberately NOT reserved in this budget (phase-1
+// slack; dynamic counting is a phase-2 nicety): a 5th detail row — the Image
+// probe feedback, rendered while a probe/verdict for the highlighted entry is
+// on screen — and a second footer hint line (`t: test image support`,
+// rendered whenever a pattern-source entry is highlighted; that one is NOT
+// transient). When either renders, a height-capped dialog grows by that row
+// rather than dropping a model entry.
 const MODEL_DIALOG_FIXED_ROWS = 14;
 const MODEL_OPTION_ROW_HEIGHT = 1;
 const MODEL_OPTION_ROW_HEIGHT_WITH_DESCRIPTION = 2;
@@ -398,64 +449,58 @@ export function ModelDialog({
 
   const MODEL_OPTIONS = useMemo(
     () =>
-      availableModelEntries.map(
-        ({ authType: t2, model, isRuntime, snapshotId }) => {
-          const value =
-            isRuntime && snapshotId
-              ? snapshotId
-              : buildModelSelectionKey(t2, model.id, model.baseUrl);
+      availableModelEntries.map((entry) => {
+        const { authType: t2, model, isRuntime } = entry;
+        const value = entrySelectionKey(entry);
 
-          const isQwenOAuth = t2 === AuthType.QWEN_OAUTH;
+        const isQwenOAuth = t2 === AuthType.QWEN_OAUTH;
 
-          const title = (
-            <Text>
-              <Text
-                bold
-                color={
-                  isQwenOAuth
+        const title = (
+          <Text>
+            <Text
+              bold
+              color={
+                isQwenOAuth
+                  ? theme.status.warning
+                  : isRuntime
                     ? theme.status.warning
-                    : isRuntime
-                      ? theme.status.warning
-                      : theme.text.accent
-                }
-              >
-                [{t2}]
-              </Text>
-              <Text>{` ${model.label}`}</Text>
-              {model.id !== model.label && (
-                <Text color={theme.text.secondary} italic>
-                  {' '}
-                  ({model.id})
-                </Text>
-              )}
-              {isRuntime && (
-                <Text color={theme.status.warning}> (Runtime)</Text>
-              )}
-              {isQwenOAuth && !isRuntime && (
-                <Text color={theme.status.warning}> ({t('Discontinued')})</Text>
-              )}
+                    : theme.text.accent
+              }
+            >
+              [{t2}]
             </Text>
-          );
+            <Text>{` ${model.label}`}</Text>
+            {model.id !== model.label && (
+              <Text color={theme.text.secondary} italic>
+                {' '}
+                ({model.id})
+              </Text>
+            )}
+            {isRuntime && <Text color={theme.status.warning}> (Runtime)</Text>}
+            {isQwenOAuth && !isRuntime && (
+              <Text color={theme.status.warning}> ({t('Discontinued')})</Text>
+            )}
+          </Text>
+        );
 
-          // Include runtime / discontinued indicator in description
-          let description = model.description || '';
-          if (isRuntime) {
-            description = description
-              ? `${description} (Runtime)`
-              : 'Runtime model';
-          }
-          if (isQwenOAuth && !isRuntime) {
-            description = t('Discontinued — switch to Coding Plan or API Key');
-          }
+        // Include runtime / discontinued indicator in description
+        let description = model.description || '';
+        if (isRuntime) {
+          description = description
+            ? `${description} (Runtime)`
+            : 'Runtime model';
+        }
+        if (isQwenOAuth && !isRuntime) {
+          description = t('Discontinued — switch to Coding Plan or API Key');
+        }
 
-          return {
-            value,
-            title,
-            description,
-            key: value,
-          };
-        },
-      ),
+        return {
+          value,
+          title,
+          description,
+          key: value,
+        };
+      }),
     [availableModelEntries],
   );
   const modelOptionRowHeight = MODEL_OPTIONS.some(
@@ -734,28 +779,156 @@ export function ModelDialog({
   const highlightedEntry = useMemo(() => {
     const key = highlightedValue ?? preferredKey;
     return availableModelEntries.find(
-      ({ authType: t2, model, isRuntime, snapshotId }) => {
-        const v =
-          isRuntime && snapshotId
-            ? snapshotId
-            : buildModelSelectionKey(t2, model.id, model.baseUrl);
-        return v === key;
-      },
+      (entry) => entrySelectionKey(entry) === key,
     );
   }, [highlightedValue, preferredKey, availableModelEntries]);
+
+  // One-shot image modality probe (issue #10309, phase 1). `probeTargetKey`
+  // remembers WHICH entry a pending/finished verdict belongs to, so moving
+  // the highlight mid-probe never shows another entry's result.
+  const [probeState, setProbeState] = useState<
+    'idle' | 'probing' | ModalityProbeVerdict
+  >('idle');
+  const [probeTargetKey, setProbeTargetKey] = useState<string | null>(null);
+
+  const highlightedEntryKey = highlightedEntry
+    ? entrySelectionKey(highlightedEntry)
+    : null;
+  const activeProbeState =
+    probeTargetKey !== null && probeTargetKey === highlightedEntryKey
+      ? probeState
+      : 'idle';
+
+  // The `t` action only applies to regex-guessed (pattern-source)
+  // modalities: explicit declarations need no probe, probe-derived entries
+  // already carry a persisted verdict, and QWEN_OAUTH's two probe-key
+  // spellings diverge in phase 1 (see probe-store.ts), so it is excluded.
+  // Runtime models have no modalitiesSource and are excluded by the same
+  // check. A probe in flight disables re-trigger globally so two concurrent
+  // probes can never race the whole-map read-modify-write.
+  const canTestImageSupport =
+    !!highlightedEntry &&
+    !highlightedEntry.isRuntime &&
+    highlightedEntry.authType !== AuthType.QWEN_OAUTH &&
+    highlightedEntry.model.modalitiesSource === 'pattern' &&
+    probeState !== 'probing';
+
+  const handleTestImageSupport = useCallback(async () => {
+    if (!highlightedEntry || probeState === 'probing') return;
+    const { model } = highlightedEntry;
+    setErrorMessage(null);
+    setProbeState('probing');
+    setProbeTargetKey(entrySelectionKey(highlightedEntry));
+    // Settings-backed keys are not in process.env until hydrated — the same
+    // in-file helper handleSelect uses before switching models — so mid-
+    // session settings.env keys work without a restart. The API key is read
+    // from the environment at probe time only — never displayed, never
+    // logged, never persisted.
+    hydrateApiKeyEnvFromSettings(settings, model.envKey);
+    const apiKey = model.envKey ? process.env[model.envKey] : undefined;
+    if (!apiKey || !model.baseUrl) {
+      setProbeState('unknown');
+      return;
+    }
+    const result = await probeImageSupport({
+      model: model.id,
+      baseUrl: model.baseUrl,
+      apiKey,
+    });
+    if (result.verdict !== 'unknown') {
+      // Read the TARGET scope's own map (not the merged view) so records
+      // from other scopes never bleed into this write, and always write the
+      // WHOLE map under the single 'probeResults' key — composite probe
+      // keys embed dots and '|' that settings' dotted-path addressing would
+      // mis-nest.
+      const scope = resolvePersistScope(settings, persistScope);
+      try {
+        settings.setValue(
+          scope,
+          'probeResults',
+          withProbeResult(
+            settings.forScope(scope).settings.probeResults,
+            highlightedEntry.authType,
+            model.id,
+            model.baseUrl,
+            { verdict: result.verdict, probedAt: new Date().toISOString() },
+          ),
+        );
+      } catch (e) {
+        // setValue can throw (saveSettings re-throws fs errors) and this
+        // handler runs fire-and-forget, so an uncaught throw would be an
+        // unhandled rejection while the UI shows success. Surface the
+        // failure through the dialog's error channel (the same ✕ box
+        // handleSelect uses) and reset the probe display: the feedback row
+        // is hidden and the badge falls back to the entry's own (registry)
+        // source, which stays truthful because nothing was persisted.
+        const message = e instanceof Error ? e.message : String(e);
+        setProbeState('idle');
+        setErrorMessage(
+          `${t('Image probe verdict could not be saved.')}\n\n${message}`,
+        );
+        return;
+      }
+    }
+    setProbeState(result.verdict);
+  }, [highlightedEntry, persistScope, probeState, settings]);
+
+  // Registered separately from the escape handler above: this one depends
+  // on `highlightedEntry` and the probe state, which are computed later in
+  // the component body.
+  useKeypress(
+    (key) => {
+      if (
+        key.name === 't' &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.shift &&
+        canTestImageSupport
+      ) {
+        void handleTestImageSupport();
+      }
+    },
+    { isActive: true },
+  );
+
+  // Registry entries cache modalities/modalitiesSource — a plain
+  // settings.setValue does not refresh them without a registry reload, which
+  // we deliberately do NOT trigger mid-dialog. While a final verdict for the
+  // highlighted entry is on screen, locally derive BOTH the badge source and
+  // the modality value from it, so the panel never contradicts itself (e.g.
+  // `text-only · probe-tested` above `accepts images`); other entries'
+  // badges refresh the next time the dialog opens.
+  const displayedModalitiesSource: ModalitySource | undefined =
+    activeProbeState === 'image' || activeProbeState === 'text_only'
+      ? 'probe'
+      : highlightedEntry?.model.modalitiesSource;
+  const displayedModalities: InputModalities | undefined =
+    activeProbeState === 'image'
+      ? { ...highlightedEntry?.model.modalities, image: true }
+      : activeProbeState === 'text_only' && highlightedEntry?.model.modalities
+        ? { ...highlightedEntry.model.modalities, image: false }
+        : highlightedEntry?.model.modalities;
+
+  const probeFeedback: { text: string; color: string } | undefined =
+    activeProbeState === 'probing'
+      ? { text: t('testing…'), color: theme.text.secondary }
+      : activeProbeState === 'unknown'
+        ? {
+            text: t('inconclusive (auth/rate-limit/timeout) — nothing written'),
+            color: theme.status.warning,
+          }
+        : activeProbeState === 'image'
+          ? { text: t('accepts images'), color: theme.status.success }
+          : activeProbeState === 'text_only'
+            ? { text: t('text only'), color: theme.text.secondary }
+            : undefined;
 
   const handleSelect = useCallback(
     async (selected: string) => {
       if (selectionInFlightRef.current || selectionCommittedRef.current) return;
       setErrorMessage(null);
       const selectedEntry = availableModelEntries.find(
-        ({ authType: t2, model, isRuntime, snapshotId }) => {
-          const value =
-            isRuntime && snapshotId
-              ? snapshotId
-              : buildModelSelectionKey(t2, model.id, model.baseUrl);
-          return value === selected;
-        },
+        (entry) => entrySelectionKey(entry) === selected,
       );
 
       if (isVoiceModelMode) {
@@ -1152,8 +1325,19 @@ export function ModelDialog({
             )}
           <DetailRow
             label={t('Modality')}
-            value={formatModalities(highlightedEntry.model.modalities)}
+            value={formatModalitiesWithSource(
+              displayedModalities,
+              displayedModalitiesSource,
+            )}
           />
+          {probeFeedback && (
+            <DetailRow
+              label={t('Image probe')}
+              value={
+                <Text color={probeFeedback.color}>{probeFeedback.text}</Text>
+              }
+            />
+          )}
           <DetailRow
             label={t('Context Window')}
             value={formatContextWindow(
@@ -1187,6 +1371,9 @@ export function ModelDialog({
         <Text color={theme.text.secondary}>
           {t('Enter to select, ↑↓ to navigate, Esc to close')}
         </Text>
+        {canTestImageSupport && (
+          <Text color={theme.text.secondary}>{t('t: test image support')}</Text>
+        )}
       </Box>
     </Box>
   );

--- a/packages/cli/src/ui/hooks/use-image-support-probe.ts
+++ b/packages/cli/src/ui/hooks/use-image-support-probe.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useState } from 'react';
+import process from 'node:process';
+import {
+  AuthType,
+  probeImageSupport,
+  readProbeResult,
+  withProbeResult,
+  type AvailableModel as CoreAvailableModel,
+  type InputModalities,
+  type ModalityProbeVerdict,
+  type ModalitySource,
+} from '@qwen-code/qwen-code-core';
+import {
+  type LoadedSettings,
+  type SettingScope,
+} from '../../config/settings.js';
+import { theme } from '../semantic-colors.js';
+import { t } from '../../i18n/index.js';
+
+/** A /model dialog entry the probe operates on — the subset of the dialog's
+ * entry shape the hook reads (dialog entries satisfy it structurally). */
+export interface ProbeTargetEntry {
+  readonly authType: AuthType;
+  readonly model: CoreAvailableModel;
+  readonly isRuntime?: boolean;
+}
+
+export interface UseImageSupportProbeParams {
+  /** The currently highlighted dialog entry, if any. */
+  readonly highlightedEntry: ProbeTargetEntry | undefined;
+  /** Selection key of `highlightedEntry`, owned by the dialog (it keys the
+   * option list, highlight, and selection handling); reused as the probe's
+   * displacement-guard key. */
+  readonly highlightedEntryKey: string | null;
+  readonly settings: LoadedSettings;
+  /** Pre-resolved scope the probe write persists under. */
+  readonly scope: SettingScope;
+  /** The dialog's error channel: cleared when a probe starts, fed when a
+   * verdict write fails. */
+  readonly setErrorMessage: (message: string | null) => void;
+}
+
+export interface UseImageSupportProbeResult {
+  /** Whether the `t` action may trigger a probe for the highlighted entry. */
+  readonly canTestImageSupport: boolean;
+  /** Fire-and-forget probe handler; own guard clauses make it a no-op when
+   * `canTestImageSupport` is false. */
+  readonly handleTestImageSupport: () => Promise<void>;
+  /** Modality value + provenance to render in the details panel. */
+  readonly displayedModalities: InputModalities | undefined;
+  readonly displayedModalitiesSource: ModalitySource | undefined;
+  /** Feedback row for the highlighted entry's probe, if one is on screen. */
+  readonly probeFeedback:
+    | { readonly text: string; readonly color: string }
+    | undefined;
+}
+
+/** Settings-backed keys are not in process.env until hydrated, so mid-session
+ * settings.env keys work without a restart. The API key is read from the
+ * environment at action time only — never displayed, never logged, never
+ * persisted. */
+export function hydrateApiKeyEnvFromSettings(
+  settings: LoadedSettings,
+  envKey: string | undefined,
+): void {
+  if (!envKey || process.env[envKey]) {
+    return;
+  }
+  const settingsEnvValue = (
+    settings?.merged?.env as Record<string, unknown> | undefined
+  )?.[envKey];
+  if (
+    typeof settingsEnvValue === 'string' &&
+    settingsEnvValue.trim().length > 0
+  ) {
+    process.env[envKey] = settingsEnvValue;
+  }
+}
+
+/** One-shot image modality probe (issue #10309, phase 1) for the /model
+ * dialog: owns the probe state machine, the live verdict read, the t-action
+ * gating, and the derived badge/modality/feedback presentation. The dialog
+ * keeps only rendering and key binding. */
+export function useImageSupportProbe({
+  highlightedEntry,
+  highlightedEntryKey,
+  settings,
+  scope,
+  setErrorMessage,
+}: UseImageSupportProbeParams): UseImageSupportProbeResult {
+  // `probeTargetKey` remembers WHICH entry a pending/finished verdict belongs
+  // to, so moving the highlight mid-probe never shows another entry's result.
+  const [probeState, setProbeState] = useState<
+    'idle' | 'probing' | ModalityProbeVerdict
+  >('idle');
+  const [probeTargetKey, setProbeTargetKey] = useState<string | null>(null);
+
+  const activeProbeState =
+    probeTargetKey !== null && probeTargetKey === highlightedEntryKey
+      ? probeState
+      : 'idle';
+
+  // Live probe-verdict source: the registry caches modalitiesSource at
+  // registration/reload time (a plain settings.setValue does NOT refresh
+  // already-registered entries), so a verdict concluded earlier in this
+  // session — or written by an earlier dialog session — is visible here only
+  // through the settings store itself. Keyed the same way the write path
+  // keys it (declared/resolved entry baseUrl). Read-side hardening mirrors
+  // the registry: only verdicts exactly 'image'/'text_only' are honored;
+  // hand-edited garbage abstains to the entry's own source.
+  //
+  // The live read only applies to STILL-PATTERN-CACHED entries. An
+  // 'explicit'-stamped entry got there because the user hand-wrote
+  // modelProviders modalities — the phase-1 remediation exit for a wrong
+  // verdict — and a stale probe record must not shadow it in the UI. A
+  // 'probe'-stamped entry loses nothing either: phase 1 has no re-probe
+  // path, so the live store can never hold a newer conclusion than the
+  // registration-time stamp.
+  const liveRawVerdict =
+    highlightedEntry &&
+    !highlightedEntry.isRuntime &&
+    highlightedEntry.model.modalitiesSource === 'pattern'
+      ? readProbeResult(
+          settings.merged?.probeResults,
+          highlightedEntry.authType,
+          highlightedEntry.model.id,
+          highlightedEntry.model.baseUrl,
+        )?.verdict
+      : undefined;
+  const liveProbeVerdict: 'image' | 'text_only' | undefined =
+    liveRawVerdict === 'image' || liveRawVerdict === 'text_only'
+      ? liveRawVerdict
+      : undefined;
+
+  // The `t` action only applies to regex-guessed (pattern-source)
+  // modalities: explicit declarations need no probe, and entries carrying a
+  // conclusion — registry-stamped 'probe' source OR a live settings hit for
+  // a still-pattern-cached entry — need none; QWEN_OAUTH's two probe-key
+  // spellings diverge in phase 1 (see probe-store.ts), so it is excluded.
+  // Runtime models have no modalitiesSource and are excluded by the same
+  // check. A probe in flight disables re-trigger globally so two concurrent
+  // probes can never race the whole-map read-modify-write, and a CONCLUDED
+  // local verdict hides the action too ('unknown' keeps it — retry is the
+  // only recourse for an inconclusive probe in phase 1).
+  const canTestImageSupport =
+    !!highlightedEntry &&
+    !highlightedEntry.isRuntime &&
+    highlightedEntry.authType !== AuthType.QWEN_OAUTH &&
+    (liveProbeVerdict === undefined
+      ? highlightedEntry.model.modalitiesSource
+      : 'probe') === 'pattern' &&
+    probeState !== 'probing' &&
+    activeProbeState !== 'image' &&
+    activeProbeState !== 'text_only';
+
+  const handleTestImageSupport = useCallback(async () => {
+    if (!highlightedEntry || probeState === 'probing') return;
+    const { model } = highlightedEntry;
+    setErrorMessage(null);
+    setProbeState('probing');
+    setProbeTargetKey(highlightedEntryKey);
+    hydrateApiKeyEnvFromSettings(settings, model.envKey);
+    const apiKey = model.envKey ? process.env[model.envKey] : undefined;
+    if (!apiKey || !model.baseUrl) {
+      setProbeState('unknown');
+      return;
+    }
+    const result = await probeImageSupport({
+      model: model.id,
+      baseUrl: model.baseUrl,
+      apiKey,
+    });
+    if (result.verdict !== 'unknown') {
+      // Read the TARGET scope's own map (not the merged view) so records
+      // from other scopes never bleed into this write, and always write the
+      // WHOLE map under the single 'probeResults' key — composite probe
+      // keys embed dots and '|' that settings' dotted-path addressing would
+      // mis-nest.
+      try {
+        settings.setValue(
+          scope,
+          'probeResults',
+          withProbeResult(
+            settings.forScope(scope).settings.probeResults,
+            highlightedEntry.authType,
+            model.id,
+            model.baseUrl,
+            { verdict: result.verdict, probedAt: new Date().toISOString() },
+          ),
+        );
+      } catch (e) {
+        // setValue can throw (saveSettings re-throws fs errors) and this
+        // handler runs fire-and-forget, so an uncaught throw would be an
+        // unhandled rejection while the UI shows success. Surface the
+        // failure through the dialog's error channel (the same ✕ box
+        // handleSelect uses) and reset the probe display: the feedback row
+        // is hidden and the badge falls back to the entry's own (registry)
+        // source, which stays truthful because nothing was persisted.
+        const message = e instanceof Error ? e.message : String(e);
+        setProbeState('idle');
+        setErrorMessage(
+          `${t('Image probe verdict could not be saved.')}\n\n${message}`,
+        );
+        return;
+      }
+    }
+    setProbeState(result.verdict);
+  }, [
+    highlightedEntry,
+    highlightedEntryKey,
+    probeState,
+    scope,
+    setErrorMessage,
+    settings,
+  ]);
+
+  // Modality badge/value provenance is a two-layer source. Layer 1 is the
+  // registry's registration-time cache (`modalitiesSource`), which a plain
+  // settings.setValue does not refresh without a registry reload — and we
+  // deliberately do NOT reload mid-dialog. Layer 2 is the live settings
+  // store (`probeResults`), read on every render for the highlighted entry
+  // — but ONLY while that entry is still pattern-cached; 'explicit' and
+  // 'probe' stamps show their own value (a hand-written explicit
+  // declaration is the phase-1 way out of a wrong verdict, so it must not
+  // be shadowed by the stale probe record underneath). A local verdict from
+  // THIS dialog's probe overrides both, so the panel never contradicts
+  // itself mid-feedback (e.g. `text-only · probe-tested` above
+  // `accepts images`).
+  const displayedProbeVerdict: 'image' | 'text_only' | undefined =
+    activeProbeState === 'image' || activeProbeState === 'text_only'
+      ? activeProbeState
+      : liveProbeVerdict;
+  const displayedModalitiesSource: ModalitySource | undefined =
+    displayedProbeVerdict !== undefined
+      ? 'probe'
+      : highlightedEntry?.model.modalitiesSource;
+  const displayedModalities: InputModalities | undefined =
+    displayedProbeVerdict === 'image'
+      ? { ...highlightedEntry?.model.modalities, image: true }
+      : displayedProbeVerdict === 'text_only' &&
+          highlightedEntry?.model.modalities
+        ? { ...highlightedEntry.model.modalities, image: false }
+        : highlightedEntry?.model.modalities;
+
+  const probeFeedback: { text: string; color: string } | undefined =
+    activeProbeState === 'probing'
+      ? { text: t('testing…'), color: theme.text.secondary }
+      : activeProbeState === 'unknown'
+        ? {
+            text: t('inconclusive (auth/rate-limit/timeout) — nothing written'),
+            color: theme.status.warning,
+          }
+        : activeProbeState === 'image'
+          ? { text: t('accepts images'), color: theme.status.success }
+          : activeProbeState === 'text_only'
+            ? { text: t('text only'), color: theme.text.secondary }
+            : undefined;
+
+  return {
+    canTestImageSupport,
+    handleTestImageSupport,
+    displayedModalities,
+    displayedModalitiesSource,
+    probeFeedback,
+  };
+}

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -297,6 +297,7 @@ import {
   type AvailableModel,
   type ResolvedModelConfig,
   type RuntimeModelSnapshot,
+  type ProbeResultStore,
 } from '../models/index.js';
 import { resolveModelId } from '../utils/modelId.js';
 import type { WebSearchSettings } from '../tools/web-search.js';
@@ -1328,6 +1329,13 @@ export interface ConfigParameters {
   modelProvidersConfig?: ModelProvidersConfig;
   /** Maps custom provider ids to their SDK protocol (AuthType) */
   providerProtocolConfig?: ProviderProtocolConfig;
+  /**
+   * Lazy provider for the persisted modality probe store (settings
+   * `probeResults`); feeds the modalities resolution chain (explicit >
+   * probe > pattern). A callback so persisted verdicts are read live rather
+   * than snapshotted at boot. `undefined` keeps probe-free behavior.
+   */
+  probeResultStoreProvider?: () => ProbeResultStore | undefined;
   /** Agent and multi-agent collaboration settings */
   agents?: AgentsCollabSettings;
   /** General-purpose worktree settings (Phase D-2). */
@@ -2208,6 +2216,9 @@ export class Config {
   private modelsConfig!: ModelsConfig;
   private readonly modelProvidersConfig?: ModelProvidersConfig;
   private readonly providerProtocolConfig?: ProviderProtocolConfig;
+  private readonly probeResultStoreProvider?: () =>
+    | ProbeResultStore
+    | undefined;
   private readonly sandbox: SandboxConfig | undefined;
   private targetDir: string;
   private workspaceContext: WorkspaceContext;
@@ -2718,6 +2729,7 @@ export class Config {
     this.ideMode = params.ideMode ?? false;
     this.modelProvidersConfig = params.modelProvidersConfig;
     this.providerProtocolConfig = params.providerProtocolConfig;
+    this.probeResultStoreProvider = params.probeResultStoreProvider;
     this.cliVersion = params.cliVersion;
 
     this.chatRecordingEnabled = params.chatRecording ?? true;
@@ -2854,6 +2866,7 @@ export class Config {
       initialAuthType: params.authType ?? params.generationConfig?.authType,
       modelProvidersConfig: this.modelProvidersConfig,
       providerProtocolConfig: this.providerProtocolConfig,
+      probeResultStoreProvider: this.probeResultStoreProvider,
       generationConfig: {
         model: params.model,
         ...(params.generationConfig || {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export {
   type ModelConfigSettingsInput,
   type ModelConfigSourcesInput,
   type ModelConfigValidationResult,
+  type ModalitySource,
   ModelRegistry,
   isImageGenerationCapable,
   modelRegistryKey,
@@ -317,7 +318,17 @@ export * from './services/fileHistoryService.js';
 export * from './services/fileReadCache.js';
 export * from './services/fileSystemService.js';
 export * from './services/tool-write-origin.js';
-export type { ModalityProbeRecord } from './services/modalityProbe/probe-store.js';
+export {
+  type ModalityProbeRecord,
+  type ProbeResultStore,
+  withProbeResult,
+} from './services/modalityProbe/probe-store.js';
+export {
+  type ModalityProbeInput,
+  type ModalityProbeResult,
+  type ModalityProbeVerdict,
+  probeImageSupport,
+} from './services/modalityProbe/probe.js';
 export {
   decodeBufferWithEncodingInfo,
   encodeTextFileContent,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -321,6 +321,7 @@ export * from './services/tool-write-origin.js';
 export {
   type ModalityProbeRecord,
   type ProbeResultStore,
+  readProbeResult,
   withProbeResult,
 } from './services/modalityProbe/probe-store.js';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -317,6 +317,7 @@ export * from './services/fileHistoryService.js';
 export * from './services/fileReadCache.js';
 export * from './services/fileSystemService.js';
 export * from './services/tool-write-origin.js';
+export type { ModalityProbeRecord } from './services/modalityProbe/probe-store.js';
 export {
   decodeBufferWithEncodingInfo,
   encodeTextFileContent,

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -14,7 +14,13 @@ export {
   type AvailableModel,
   type ModelSwitchMetadata,
   type RuntimeModelSnapshot,
+  type ModalitySource,
 } from './types.js';
+
+export type {
+  ProbeResultStore,
+  ModalityProbeRecord,
+} from '../services/modalityProbe/probe-store.js';
 
 export {
   ModelRegistry,

--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -11,6 +11,11 @@ import {
 } from './modelConfigResolver.js';
 import { AuthType } from '../core/contentGenerator.js';
 import { DEFAULT_QWEN_MODEL, MAINLINE_CODER_MODEL } from '../config/models.js';
+import {
+  buildProbeKey,
+  withProbeResult,
+  type ProbeResultStore,
+} from '../services/modalityProbe/probe-store.js';
 
 describe('modelConfigResolver', () => {
   describe('resolveModelConfig', () => {
@@ -1079,6 +1084,175 @@ describe('modelConfigResolver', () => {
 
       expect(result.config.contextWindowSize).toBe(32_000);
       expect(result.sources['contextWindowSize'].kind).toBe('settings');
+    });
+  });
+
+  describe('modalities fallback chain (probe layer)', () => {
+    // Chain under test (QwenLM/qwen-code#10309 phase 1):
+    //   explicit modalities (settings/modelProviders generationConfig)
+    //   > persisted probe verdict (settings `probeResults` store)
+    //   > name-pattern table (defaultModalities).
+    const PROBED_AT = '2026-08-27T00:00:00.000Z';
+    const BASE_URL = 'http://localhost:8000/v1';
+
+    function probeStore(
+      modelId: string,
+      verdict: 'image' | 'text_only',
+      baseUrl?: string,
+    ): ProbeResultStore {
+      return withProbeResult(undefined, AuthType.USE_OPENAI, modelId, baseUrl, {
+        verdict,
+        probedAt: PROBED_AT,
+      });
+    }
+
+    it('explicit settings modalities win over a matching probe verdict', () => {
+      // 'qwen3-coder-plus' pattern-resolves to text-only ({}), so the explicit
+      // { image: true } below is distinguishable from BOTH lower tiers — and
+      // the text_only probe entry matches the exact resolution key.
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {
+          generationConfig: {
+            modalities: { image: true },
+          },
+        },
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: BASE_URL,
+          OPENAI_MODEL: 'qwen3-coder-plus',
+        },
+        probeResultStore: probeStore('qwen3-coder-plus', 'text_only', BASE_URL),
+      });
+
+      expect(result.config.modalities).toEqual({ image: true });
+      expect(result.sources['modalities'].kind).toBe('settings');
+    });
+
+    it('probe verdict image wins over the name-pattern table', () => {
+      // 'qwen3-coder-plus' pattern-resolves to {} (text-only); a persisted
+      // 'image' verdict must flip it to { image: true }.
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: BASE_URL,
+          OPENAI_MODEL: 'qwen3-coder-plus',
+        },
+        probeResultStore: probeStore('qwen3-coder-plus', 'image', BASE_URL),
+      });
+
+      expect(result.config.modalities).toEqual({ image: true });
+      expect(result.sources['modalities'].kind).toBe('computed');
+      expect(result.sources['modalities'].detail).toBe(
+        `probe-tested ${PROBED_AT}`,
+      );
+    });
+
+    it('probe verdict text_only wins over the name-pattern table', () => {
+      // 'glm-4.5v' pattern-resolves to { image: true }; a persisted
+      // 'text_only' verdict must flip it to {}. Keyed WITHOUT a baseUrl —
+      // covers the undefined-baseUrl key spelling (no OPENAI_BASE_URL set).
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_MODEL: 'glm-4.5v',
+        },
+        probeResultStore: probeStore('glm-4.5v', 'text_only'),
+      });
+
+      expect(result.config.modalities).toEqual({});
+      expect(result.sources['modalities'].kind).toBe('computed');
+      expect(result.sources['modalities'].detail).toBe(
+        `probe-tested ${PROBED_AT}`,
+      );
+    });
+
+    it('falls through to the pattern table when no probe entry matches', () => {
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: BASE_URL,
+          OPENAI_MODEL: 'glm-4.5v',
+        },
+      });
+
+      expect(result.config.modalities).toEqual({ image: true });
+      expect(result.sources['modalities'].kind).toBe('computed');
+      expect(result.sources['modalities'].detail).toBe(
+        'auto-detected from model',
+      );
+    });
+
+    it('explicit modelProvider modalities win over a matching probe verdict', () => {
+      // Mirrors the settings-channel test above through the OTHER explicit
+      // channel (modelProviders): explicit { image: false } vs an 'image'
+      // probe verdict vs the { image: true } pattern for 'glm-4.5v'.
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          MY_CUSTOM_KEY: 'provider-key',
+        },
+        modelProvider: {
+          id: 'glm-4.5v',
+          name: 'GLM 4.5V',
+          envKey: 'MY_CUSTOM_KEY',
+          baseUrl: 'https://provider.example.com',
+          generationConfig: {
+            modalities: { image: false },
+          },
+        },
+        probeResultStore: probeStore(
+          'glm-4.5v',
+          'image',
+          'https://provider.example.com',
+        ),
+      });
+
+      expect(result.config.modalities).toEqual({ image: false });
+      expect(result.sources['modalities'].kind).toBe('modelProviders');
+    });
+
+    it('ignores hand-corrupted probe records (invalid verdict falls through to pattern)', () => {
+      // Read-side hardening: a hand-edited settings.json can put garbage in
+      // the store; only verdicts exactly 'image'/'text_only' are honored, so
+      // a corrupt record abstains to the pattern tier — never a wrong answer.
+      const corrupted: ProbeResultStore = {
+        [buildProbeKey(AuthType.USE_OPENAI, 'glm-4.5v', BASE_URL)]: {
+          // Simulate a hand-edited record; the static type says this can't
+          // happen, settings.json is not type-checked.
+          verdict: 'garbage' as 'image',
+          probedAt: PROBED_AT,
+        },
+      };
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: BASE_URL,
+          OPENAI_MODEL: 'glm-4.5v',
+        },
+        probeResultStore: corrupted,
+      });
+
+      expect(result.config.modalities).toEqual({ image: true });
+      expect(result.sources['modalities'].kind).toBe('computed');
+      expect(result.sources['modalities'].detail).toBe(
+        'auto-detected from model',
+      );
     });
   });
 });

--- a/packages/core/src/models/modelConfigResolver.ts
+++ b/packages/core/src/models/modelConfigResolver.ts
@@ -23,6 +23,8 @@ import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import { DEFAULT_QWEN_MODEL } from '../config/models.js';
 import { defaultModalities } from '../core/modalityDefaults.js';
 import { knownTokenLimit } from '../core/tokenLimits.js';
+import { readProbeResult } from '../services/modalityProbe/probe-store.js';
+import type { ProbeResultStore } from '../services/modalityProbe/probe-store.js';
 import {
   resolveField,
   resolveOptionalField,
@@ -93,6 +95,10 @@ export interface ModelConfigSourcesInput {
 
   /** Proxy URL (computed from Config) */
   proxy?: string;
+
+  /** Persisted modality probe verdicts (settings `probeResults`). Consulted
+   * between the explicit modalities layer and the name-pattern table. */
+  probeResultStore?: ProbeResultStore;
 }
 
 /**
@@ -275,6 +281,8 @@ export function resolveModelConfig(
     authType,
     modelProvider?.id ?? modelResult.value,
     sources,
+    input.probeResultStore,
+    baseUrlResult?.value,
   );
 
   // ---- Env override: QWEN_CODE_API_TIMEOUT_MS ----
@@ -356,6 +364,8 @@ function resolveQwenOAuthConfig(
     AuthType.QWEN_OAUTH,
     resolvedModel,
     sources,
+    input.probeResultStore,
+    undefined,
   );
 
   // ---- Env override: QWEN_CODE_API_TIMEOUT_MS ----
@@ -381,6 +391,8 @@ function resolveGenerationConfig(
   authType: AuthType | undefined,
   modelId: string | undefined,
   sources: ConfigSources,
+  probeResultStore?: ProbeResultStore,
+  baseUrl?: string,
 ): Partial<ContentGeneratorConfig> {
   const result: Partial<ContentGeneratorConfig> = {};
 
@@ -426,9 +438,30 @@ function resolveGenerationConfig(
   // on `modalities === undefined` to mean "unresolved" — use the sources map
   // (kind === 'computed' vs 'modelProviders'/'settings') if that distinction
   // matters.
+  // modalities fallback chain: explicit (handled above via settings/modelProviders
+  // field copying) > persisted probe result > name-pattern table.
+  //
+  // NOTE(#8558/#10309): when the API-backed model metadata catalog (#8558)
+  // lands, its provider-native metadata layer slots in HERE — between the
+  // explicit user/provider layer and the probe layer. Final chain per the
+  // #10309 design discussion: explicit > provider-native catalog (#8558) >
+  // probe result > regex table > conservative defaults.
+  //
+  // Read-side hardening: only a record whose `verdict` is exactly 'image' or
+  // 'text_only' is honored — hand-edited settings.json garbage abstains to the
+  // pattern tier, never a wrong verdict.
   if (result.modalities === undefined && modelId) {
-    result.modalities = defaultModalities(modelId);
-    sources['modalities'] = computedSource('auto-detected from model');
+    const probe =
+      authType !== undefined
+        ? readProbeResult(probeResultStore, authType, modelId, baseUrl)
+        : undefined;
+    if (probe?.verdict === 'image' || probe?.verdict === 'text_only') {
+      result.modalities = probe.verdict === 'image' ? { image: true } : {};
+      sources['modalities'] = computedSource(`probe-tested ${probe.probedAt}`);
+    } else {
+      result.modalities = defaultModalities(modelId);
+      sources['modalities'] = computedSource('auto-detected from model');
+    }
   }
 
   return result;

--- a/packages/core/src/models/modelRegistry.test.ts
+++ b/packages/core/src/models/modelRegistry.test.ts
@@ -13,6 +13,7 @@ import {
 } from './modelRegistry.js';
 import { AuthType } from '../core/contentGenerator.js';
 import type { ModelProvidersConfig, ProviderProtocolConfig } from './types.js';
+import { withProbeResult } from '../services/modalityProbe/probe-store.js';
 
 const debugLoggerWarnSpy = vi.hoisted(() => vi.fn());
 
@@ -322,6 +323,76 @@ describe('ModelRegistry', () => {
         image: true,
         video: true,
       });
+    });
+
+    it('stamps modalitiesSource probe when a persisted verdict matches', () => {
+      // The probe store is keyed by (authType, modelId, RESOLVED baseUrl) —
+      // here the provider entry's own baseUrl, which is already resolved.
+      const store = withProbeResult(
+        undefined,
+        AuthType.USE_OPENAI,
+        'qwen3-coder-plus',
+        'https://example.invalid',
+        { verdict: 'image', probedAt: '2026-08-27T00:00:00.000Z' },
+      );
+      const registry = new ModelRegistry(
+        {
+          openai: [
+            {
+              id: 'qwen3-coder-plus',
+              name: 'Qwen3 Coder Plus',
+              baseUrl: 'https://example.invalid',
+              generationConfig: {},
+            },
+          ],
+        },
+        undefined,
+        () => store,
+      );
+
+      const model = registry.getModel(AuthType.USE_OPENAI, 'qwen3-coder-plus');
+      // Pattern table alone would say {} (text-only); the probe verdict wins.
+      expect(model?.generationConfig.modalities).toEqual({ image: true });
+      expect(model?.modalitiesSource).toBe('probe');
+    });
+
+    it('stamps modalitiesSource pattern when no probe verdict matches', () => {
+      const registry = new ModelRegistry({
+        openai: [
+          {
+            id: 'gpt-4-turbo',
+            name: 'GPT-4 Turbo',
+            baseUrl: 'https://api.openai.com/v1',
+            generationConfig: {},
+          },
+        ],
+      });
+
+      const model = registry.getModel(AuthType.USE_OPENAI, 'gpt-4-turbo');
+      expect(model?.generationConfig.modalities).toEqual({ image: true });
+      expect(model?.modalitiesSource).toBe('pattern');
+    });
+
+    it('stamps modalitiesSource explicit when the provider declares modalities', () => {
+      // Not a canonical-forced id (MiniMax-M3 et al.), so the provider's own
+      // declaration survives with an 'explicit' stamp.
+      const registry = new ModelRegistry({
+        openai: [
+          {
+            id: 'gpt-4-turbo',
+            name: 'GPT-4 Turbo',
+            baseUrl: 'https://api.openai.com/v1',
+            generationConfig: { modalities: { image: true, pdf: true } },
+          },
+        ],
+      });
+
+      const model = registry.getModel(AuthType.USE_OPENAI, 'gpt-4-turbo');
+      expect(model?.generationConfig.modalities).toEqual({
+        image: true,
+        pdf: true,
+      });
+      expect(model?.modalitiesSource).toBe('explicit');
     });
   });
 

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -8,12 +8,15 @@ import { AuthType } from '../core/contentGenerator.js';
 import { defaultModalities } from '../core/modalityDefaults.js';
 import { tokenLimit } from '../core/tokenLimits.js';
 import { DEFAULT_OPENAI_BASE_URL } from '../core/openaiContentGenerator/constants.js';
+import { readProbeResult } from '../services/modalityProbe/probe-store.js';
+import type { ProbeResultStore } from '../services/modalityProbe/probe-store.js';
 import {
   type ModelConfig,
   type ModelProvidersConfig,
   type ProviderProtocolConfig,
   type ResolvedModelConfig,
   type AvailableModel,
+  type ModalitySource,
 } from './types.js';
 import { DEFAULT_QWEN_MODEL } from '../config/models.js';
 import { QWEN_OAUTH_MODELS } from './constants.js';
@@ -89,6 +92,19 @@ export class ModelRegistry {
   /** providerId -> SDK protocol mapping; persists across reloads. */
   private providerProtocolConfig: ProviderProtocolConfig;
 
+  /**
+   * Lazy provider for the persisted modality probe store (settings
+   * `probeResults`), so the CLI layer can supply live settings. Consulted at
+   * registration/reload time only: entries cache probe-informed modalities
+   * and `modalitiesSource`, so a later
+   * `settings.setValue('probeResults', …)` does NOT refresh already
+   * registered entries until a registry reload. `undefined` keeps probe-free
+   * behavior (pattern table only).
+   */
+  private readonly probeResultStoreProvider?: () =>
+    | ProbeResultStore
+    | undefined;
+
   private getDefaultBaseUrl(authType: AuthType): string {
     switch (authType) {
       case AuthType.QWEN_OAUTH:
@@ -103,9 +119,11 @@ export class ModelRegistry {
   constructor(
     modelProvidersConfig?: ModelProvidersConfig,
     providerProtocolConfig?: ProviderProtocolConfig,
+    probeResultStoreProvider?: () => ProbeResultStore | undefined,
   ) {
     this.modelsByAuthType = new Map();
     this.providerProtocolConfig = providerProtocolConfig ?? {};
+    this.probeResultStoreProvider = probeResultStoreProvider;
 
     // Always register qwen-oauth models (hard-coded, cannot be overridden)
     this.registerAuthTypeModels(AuthType.QWEN_OAUTH, QWEN_OAUTH_MODELS);
@@ -314,11 +332,35 @@ export class ModelRegistry {
     // them explicitly. Without this, downstream consumers that read straight
     // from the registry (e.g. sub-agents via getResolvedModel) would inherit
     // the parent session's modalities instead of the agent's own.
+    //
+    // modalities fallback chain: explicit (provider-declared) > persisted
+    // probe verdict > name-pattern table; provenance is stamped on
+    // `modalitiesSource` for the /model dialog badge (issue #10309). The
+    // probe lookup is keyed by the RESOLVED baseUrl — the /model dialog
+    // probes with the same resolved baseUrl shown on the entry, so keys
+    // match. Read-side hardening: only verdicts exactly 'image'/'text_only'
+    // are honored (hand-edited settings.json garbage abstains to pattern).
+    let modalitiesSource: ModalitySource;
     if (
-      generationConfig.modalities === undefined ||
-      shouldUseCanonicalModalities(config.id)
+      generationConfig.modalities !== undefined &&
+      !shouldUseCanonicalModalities(config.id)
     ) {
-      generationConfig.modalities = defaultModalities(config.id);
+      modalitiesSource = 'explicit';
+    } else {
+      const probe = readProbeResult(
+        this.probeResultStoreProvider?.(),
+        authType,
+        config.id,
+        config.baseUrl || this.getDefaultBaseUrl(authType),
+      );
+      if (probe?.verdict === 'image' || probe?.verdict === 'text_only') {
+        generationConfig.modalities =
+          probe.verdict === 'image' ? { image: true } : {};
+        modalitiesSource = 'probe';
+      } else {
+        generationConfig.modalities = defaultModalities(config.id);
+        modalitiesSource = 'pattern';
+      }
     }
 
     return {
@@ -329,6 +371,7 @@ export class ModelRegistry {
       ...(config.baseUrl ? { registryBaseUrl: config.baseUrl } : {}),
       generationConfig,
       capabilities: config.capabilities || {},
+      modalitiesSource,
     };
   }
 

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -246,6 +246,9 @@ export class ModelRegistry {
       // `modalities` is auto-filled in `resolveModelConfig`, so it is
       // always defined on `ResolvedModelConfig` — no fallback needed here.
       modalities: model.generationConfig.modalities,
+      ...(model.modalitiesSource !== undefined
+        ? { modalitiesSource: model.modalitiesSource }
+        : {}),
       baseUrl: model.baseUrl,
       ...(model.registryBaseUrl !== undefined
         ? { registryBaseUrl: model.registryBaseUrl }

--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -9,6 +9,8 @@ import { ModelsConfig } from './modelsConfig.js';
 import { AuthType } from '../core/contentGenerator.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import type { ModelProvidersConfig } from './types.js';
+import { withProbeResult } from '../services/modalityProbe/probe-store.js';
+import type { ProbeResultStore } from '../services/modalityProbe/probe-store.js';
 
 describe('ModelsConfig', () => {
   function deepClone<T>(value: T): T {
@@ -1620,6 +1622,89 @@ describe('ModelsConfig', () => {
 
     expect(modelsConfig.getGenerationConfig().modalities).toEqual({
       image: true,
+    });
+    expect(modelsConfig.getGenerationConfigSources()['modalities']).toEqual({
+      kind: 'settings',
+      settingsPath: 'model.generationConfig.modalities',
+    });
+  });
+
+  it('flips raw model modalities when a persisted probe verdict matches', async () => {
+    // applyRawModelDerivedDefaults keys the probe by (currentAuthType,
+    // modelId, this._generationConfig.baseUrl) — the session-resolved
+    // baseUrl the raw model actually uses.
+    const makeConfig = (probeResultStoreProvider?: () => ProbeResultStore) =>
+      new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        generationConfig: {
+          model: 'qwen3.6-plus',
+          baseUrl: 'https://example.invalid/v1',
+        },
+        ...(probeResultStoreProvider ? { probeResultStoreProvider } : {}),
+      });
+
+    // Without a record the pattern tier decides: /^qwen/ → text-only.
+    const patternOnly = makeConfig();
+    await patternOnly.setModel('qwen3.7-max');
+    expect(patternOnly.getGenerationConfig().modalities).toEqual({});
+    expect(patternOnly.getGenerationConfigSources()['modalities']).toEqual({
+      kind: 'computed',
+      detail: 'auto-detected from model',
+    });
+
+    // Same raw switch with a persisted 'image' verdict under that key.
+    const probeStore = withProbeResult(
+      undefined,
+      AuthType.USE_OPENAI,
+      'qwen3.7-max',
+      'https://example.invalid/v1',
+      { verdict: 'image', probedAt: '2026-08-27T00:00:00.000Z' },
+    );
+    const probeBacked = makeConfig(() => probeStore);
+    await probeBacked.setModel('qwen3.7-max');
+    expect(probeBacked.getGenerationConfig().modalities).toEqual({
+      image: true,
+    });
+    expect(
+      probeBacked.getGenerationConfigSources()['modalities'],
+    ).toMatchObject({
+      kind: 'computed',
+      detail: expect.stringMatching(/^probe-tested/),
+    });
+  });
+
+  it('does not let a persisted probe verdict override explicit modalities on a raw switch', async () => {
+    const probeStore = withProbeResult(
+      undefined,
+      AuthType.USE_OPENAI,
+      'qwen3.7-max',
+      'https://example.invalid/v1',
+      { verdict: 'text_only', probedAt: '2026-08-27T00:00:00.000Z' },
+    );
+    const modelsConfig = new ModelsConfig({
+      initialAuthType: AuthType.USE_OPENAI,
+      generationConfig: {
+        model: 'qwen3.6-plus',
+        baseUrl: 'https://example.invalid/v1',
+        modalities: { image: true, video: true },
+      },
+      generationConfigSources: {
+        modalities: {
+          kind: 'settings',
+          settingsPath: 'model.generationConfig.modalities',
+        },
+      },
+      probeResultStoreProvider: () => probeStore,
+    });
+
+    await modelsConfig.setModel('qwen3.7-max');
+
+    // Explicit settings modalities outrank the probe layer: the verdict says
+    // text_only (and the pattern tier alone would say {}), yet neither may
+    // replace a kind: 'settings' field (shouldUpdateModelDerivedDefault gate).
+    expect(modelsConfig.getGenerationConfig().modalities).toEqual({
+      image: true,
+      video: true,
     });
     expect(modelsConfig.getGenerationConfigSources()['modalities']).toEqual({
       kind: 'settings',

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -19,6 +19,8 @@ import {
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 import { ModelRegistry } from './modelRegistry.js';
+import { readProbeResult } from '../services/modalityProbe/probe-store.js';
+import type { ProbeResultStore } from '../services/modalityProbe/probe-store.js';
 import {
   type ModelProvidersConfig,
   type ProviderProtocolConfig,
@@ -68,6 +70,12 @@ export interface ModelsConfigOptions {
   initialRegistryBaseUrl?: string | null;
   /** Callback when model changes require refresh */
   onModelChange?: OnModelChangeCallback;
+  /**
+   * Lazy provider for the persisted modality probe store (settings
+   * `probeResults`); consulted between the explicit modalities layer and the
+   * name-pattern table. `undefined` keeps probe-free behavior.
+   */
+  probeResultStoreProvider?: () => ProbeResultStore | undefined;
 }
 
 /**
@@ -110,6 +118,12 @@ export class ModelsConfig {
 
   // Callback for notifying Config of model changes
   private onModelChange?: OnModelChangeCallback;
+
+  /** Lazy provider for the persisted modality probe store (settings
+   * `probeResults`); `undefined` keeps probe-free behavior. */
+  private readonly probeResultStoreProvider?: () =>
+    | ProbeResultStore
+    | undefined;
 
   // Flag indicating whether authType was explicitly provided (not defaulted)
   private readonly authTypeWasExplicitlyProvided: boolean;
@@ -159,8 +173,10 @@ export class ModelsConfig {
     this.modelRegistry = new ModelRegistry(
       options.modelProvidersConfig,
       options.providerProtocolConfig,
+      options.probeResultStoreProvider,
     );
     this.onModelChange = options.onModelChange;
+    this.probeResultStoreProvider = options.probeResultStoreProvider;
 
     // Initialize generation config
     // Note: generationConfig.model should already be fully resolved by ModelConfigResolver
@@ -438,11 +454,33 @@ export class ModelsConfig {
    */
   private applyRawModelDerivedDefaults(modelId: string): void {
     if (this.shouldUpdateModelDerivedDefault('modalities')) {
-      this._generationConfig.modalities = defaultModalities(modelId);
-      this.generationConfigSources['modalities'] = {
-        kind: 'computed',
-        detail: 'auto-detected from model',
-      };
+      // modalities fallback chain: probe verdict > name-pattern table. The
+      // probe lookup is keyed by the baseUrl this raw model actually uses
+      // (the resolver-spelled resolved baseUrl). Read-side hardening: only
+      // verdicts exactly 'image'/'text_only' are honored.
+      const probe =
+        this.currentAuthType !== undefined
+          ? readProbeResult(
+              this.probeResultStoreProvider?.(),
+              this.currentAuthType,
+              modelId,
+              this._generationConfig.baseUrl,
+            )
+          : undefined;
+      if (probe?.verdict === 'image' || probe?.verdict === 'text_only') {
+        this._generationConfig.modalities =
+          probe.verdict === 'image' ? { image: true } : {};
+        this.generationConfigSources['modalities'] = {
+          kind: 'computed',
+          detail: `probe-tested ${probe.probedAt}`,
+        };
+      } else {
+        this._generationConfig.modalities = defaultModalities(modelId);
+        this.generationConfigSources['modalities'] = {
+          kind: 'computed',
+          detail: 'auto-detected from model',
+        };
+      }
     }
 
     if (this.shouldUpdateModelDerivedDefault('contextWindowSize')) {
@@ -932,7 +970,10 @@ export class ModelsConfig {
       };
     }
 
-    // modalities fallback: auto-detect from model when not set by provider
+    // modalities fallback: auto-detect from model when not set by provider.
+    // Defensive only: the registry always pre-fills modalities (the explicit,
+    // probe, and pattern branches all assign in resolveModelConfig), so this
+    // never fires for registry-fed models.
     if (gc.modalities === undefined) {
       this._generationConfig.modalities = defaultModalities(model.id);
       this.generationConfigSources['modalities'] = {

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -150,6 +150,12 @@ export interface AvailableModel {
   isVision?: boolean;
   contextWindowSize?: number;
   modalities?: InputModalities;
+  /**
+   * Provenance of `modalities` mirrored from `ResolvedModelConfig` so the
+   * /model dialog can badge probe-tested vs pattern-guessed entries
+   * (issue #10309). Absent when modalities were never resolved.
+   */
+  modalitiesSource?: ModalitySource;
   baseUrl?: string;
   /** Exact optional baseUrl used in the model registry key, before defaults. */
   registryBaseUrl?: string;

--- a/packages/core/src/models/types.ts
+++ b/packages/core/src/models/types.ts
@@ -105,6 +105,14 @@ export type ProviderProtocolConfig = {
 };
 
 /**
+ * Provenance of a model's resolved input modalities (issue #10309):
+ * - 'explicit' — declared by the provider entry or settings generationConfig
+ * - 'probe' — one-shot endpoint probe verdict (settings `probeResults`)
+ * - 'pattern' — model-name regex table (`defaultModalities`)
+ */
+export type ModalitySource = 'explicit' | 'probe' | 'pattern';
+
+/**
  * Resolved model config with all defaults applied
  */
 export interface ResolvedModelConfig extends ModelConfig {
@@ -122,6 +130,12 @@ export interface ResolvedModelConfig extends ModelConfig {
   generationConfig: ModelGenerationConfig;
   /** Capabilities (always present, defaults to {}) */
   capabilities: ModelCapabilities;
+  /**
+   * Provenance annotation for `generationConfig.modalities` (non-persisted):
+   * which tier of the resolution chain produced it. Consumed by the /model
+   * dialog badge (issue #10309). Absent when modalities were never resolved.
+   */
+  modalitiesSource?: ModalitySource;
 }
 
 /**

--- a/packages/core/src/services/modalityProbe/probe-store.test.ts
+++ b/packages/core/src/services/modalityProbe/probe-store.test.ts
@@ -10,6 +10,7 @@ import {
   readProbeResult,
   withProbeResult,
   type ModalityProbeRecord,
+  type ProbeResultStore,
 } from './probe-store.js';
 
 describe('probeStore', () => {
@@ -59,5 +60,23 @@ describe('probeStore', () => {
     });
     expect(second['openai|m1|']?.verdict).toEqual('text_only');
     expect(Object.keys(second)).toHaveLength(1);
+  });
+
+  it('treats a hand-corrupted non-object store as empty on write', () => {
+    // Spreading a raw string would materialize index keys ("0", "1", ...)
+    // and persist them; the write must start from an empty map instead.
+    const record: ModalityProbeRecord = {
+      verdict: 'image',
+      probedAt: '2026-08-28T00:00:00Z',
+    };
+    const next = withProbeResult(
+      'corrupted' as unknown as ProbeResultStore,
+      'openai',
+      'm1',
+      '',
+      record,
+    );
+    expect(next).toEqual({ 'openai|m1|': record });
+    expect(Object.keys(next)).toHaveLength(1);
   });
 });

--- a/packages/core/src/services/modalityProbe/probe-store.test.ts
+++ b/packages/core/src/services/modalityProbe/probe-store.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  buildProbeKey,
+  readProbeResult,
+  withProbeResult,
+  type ModalityProbeRecord,
+} from './probe-store.js';
+
+describe('probeStore', () => {
+  it('builds stable composite keys', () => {
+    expect(buildProbeKey('openai', 'm1', 'https://api.example.com/v1')).toEqual(
+      'openai|m1|https://api.example.com/v1',
+    );
+    expect(buildProbeKey('openai', 'm1', undefined)).toEqual('openai|m1|');
+  });
+
+  it('reads a matching record and ignores non-matching keys', () => {
+    const store: Record<string, ModalityProbeRecord> = {
+      'openai|m1|https://a.example': {
+        verdict: 'image',
+        probedAt: '2026-08-27T00:00:00Z',
+      },
+    };
+    expect(
+      readProbeResult(store, 'openai', 'm1', 'https://a.example')?.verdict,
+    ).toEqual('image');
+    expect(
+      readProbeResult(store, 'openai', 'm2', 'https://a.example'),
+    ).toBeUndefined();
+  });
+
+  it('returns a new map on write (immutable read-modify-write)', () => {
+    const store: Record<string, ModalityProbeRecord> = {};
+    const next = withProbeResult(store, 'openai', 'm1', '', {
+      verdict: 'text_only',
+      probedAt: '2026-08-27T00:00:00Z',
+    });
+    expect(next['openai|m1|']).toEqual({
+      verdict: 'text_only',
+      probedAt: '2026-08-27T00:00:00Z',
+    });
+    expect(store).toEqual({});
+  });
+
+  it('lets the last write win for the same key (re-probe overwrites)', () => {
+    const first = withProbeResult(undefined, 'openai', 'm1', '', {
+      verdict: 'image',
+      probedAt: '2026-08-27T00:00:00Z',
+    });
+    const second = withProbeResult(first, 'openai', 'm1', '', {
+      verdict: 'text_only',
+      probedAt: '2026-08-28T00:00:00Z',
+    });
+    expect(second['openai|m1|']?.verdict).toEqual('text_only');
+    expect(Object.keys(second)).toHaveLength(1);
+  });
+});

--- a/packages/core/src/services/modalityProbe/probe-store.ts
+++ b/packages/core/src/services/modalityProbe/probe-store.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ModalityProbeVerdict } from './probe.js';
+
+/** A persisted probe verdict. `verdict` is `image` or `text_only` — `unknown`
+ * results are never persisted (no conclusion, nothing to cache). */
+export interface ModalityProbeRecord {
+  readonly verdict: Exclude<ModalityProbeVerdict, 'unknown'>;
+  readonly probedAt: string;
+}
+
+export type ProbeResultStore = Record<string, ModalityProbeRecord>;
+
+/** `|` is an acceptable separator: realistic authType/modelId/baseUrl values
+ * never contain it, so the worst case is one wrong advisory verdict that a
+ * re-probe overwrites — and `\0` (used by modelRegistryKey) would be hostile
+ * in a human-editable settings.json. */
+export function buildProbeKey(
+  authType: string,
+  modelId: string,
+  baseUrl: string | undefined,
+): string {
+  return `${authType}|${modelId}|${baseUrl ?? ''}`;
+}
+
+export function readProbeResult(
+  store: ProbeResultStore | undefined,
+  authType: string,
+  modelId: string,
+  baseUrl: string | undefined,
+): ModalityProbeRecord | undefined {
+  return store?.[buildProbeKey(authType, modelId, baseUrl)];
+}
+
+/** Read-modify-write of the whole map — the composite keys embed dots
+ * (hostnames in baseUrl), `|`, and `:`, which settings' dotted-path
+ * addressing would mis-nest, so the caller persists the returned object as
+ * the whole `probeResults` settings value. */
+export function withProbeResult(
+  store: ProbeResultStore | undefined,
+  authType: string,
+  modelId: string,
+  baseUrl: string | undefined,
+  record: ModalityProbeRecord,
+): ProbeResultStore {
+  return { ...store, [buildProbeKey(authType, modelId, baseUrl)]: record };
+}

--- a/packages/core/src/services/modalityProbe/probe-store.ts
+++ b/packages/core/src/services/modalityProbe/probe-store.ts
@@ -27,6 +27,13 @@ export type ProbeResultStore = Record<string, ModalityProbeRecord>;
  * resolves to `''` in the resolver path but 'DYNAMIC_QWEN_OAUTH_BASE_URL' in
  * the registry path — hard-coded oauth models are therefore poor probe
  * candidates in phase 1.
+ *
+ * Another known divergence (phase-1 boundary, see the Draft PR description):
+ * under baseUrl environment overrides (e.g. OPENAI_BASE_URL), the resolver
+ * composes keys from the RESOLVED baseUrl while the registry/dialog compose
+ * keys from the DECLARED value — a record written via one path can be missed
+ * by the other. Advisory-only impact (a missed record falls back to the
+ * pattern tier); revisit when a re-probe/reset flow lands.
  */
 export function buildProbeKey(
   authType: string,
@@ -56,5 +63,13 @@ export function withProbeResult(
   baseUrl: string | undefined,
   record: ModalityProbeRecord,
 ): ProbeResultStore {
-  return { ...store, [buildProbeKey(authType, modelId, baseUrl)]: record };
+  // Write-side hardening: settings.json is human-editable, so `probeResults`
+  // may be hand-corrupted into a non-object (e.g. a bare string). Spreading
+  // such a value would materialize index keys ("0", "1", ...) and persist
+  // them, so treat anything that is not a plain object as empty.
+  const base =
+    typeof store === 'object' && store !== null && !Array.isArray(store)
+      ? store
+      : {};
+  return { ...base, [buildProbeKey(authType, modelId, baseUrl)]: record };
 }

--- a/packages/core/src/services/modalityProbe/probe-store.ts
+++ b/packages/core/src/services/modalityProbe/probe-store.ts
@@ -18,7 +18,16 @@ export type ProbeResultStore = Record<string, ModalityProbeRecord>;
 /** `|` is an acceptable separator: realistic authType/modelId/baseUrl values
  * never contain it, so the worst case is one wrong advisory verdict that a
  * re-probe overwrites — and `\0` (used by modelRegistryKey) would be hostile
- * in a human-editable settings.json. */
+ * in a human-editable settings.json.
+ *
+ * Phase-1 key spelling: registry-listed /model entries are keyed by their
+ * RESOLVED baseUrl (default-filled, as displayed on the dialog entry);
+ * raw/session models are keyed by the session-resolved baseUrl (which may be
+ * undefined, yielding a `''` final segment). Known divergence: QWEN_OAUTH
+ * resolves to `''` in the resolver path but 'DYNAMIC_QWEN_OAUTH_BASE_URL' in
+ * the registry path — hard-coded oauth models are therefore poor probe
+ * candidates in phase 1.
+ */
 export function buildProbeKey(
   authType: string,
   modelId: string,

--- a/packages/core/src/services/modalityProbe/probe.test.ts
+++ b/packages/core/src/services/modalityProbe/probe.test.ts
@@ -52,6 +52,41 @@ describe('classifyProbeResponse', () => {
         }),
       ),
     ).toEqual('text_only');
+    expect(
+      classifyProbeResponse(
+        400,
+        JSON.stringify({ error: { message: '当前模型不支持图片输入' } }),
+      ),
+    ).toEqual('text_only');
+    expect(
+      classifyProbeResponse(
+        400,
+        JSON.stringify({ error: { message: '该模型不支持图像理解' } }),
+      ),
+    ).toEqual('text_only');
+  });
+
+  it('abstains on region-unsupported errors despite "not supported" phrasing', () => {
+    // Objectless "not supported" is entitlement/region vocabulary, not a
+    // modality rejection — a wrong text_only here would be persisted with no
+    // re-probe escape hatch in phase 1.
+    expect(
+      classifyProbeResponse(
+        403,
+        JSON.stringify({
+          error: { message: 'Model o1 is not supported in your region' },
+        }),
+      ),
+    ).toEqual('unknown');
+  });
+
+  it('abstains on Chinese region-unsupported errors despite "不支持" phrasing', () => {
+    expect(
+      classifyProbeResponse(
+        400,
+        JSON.stringify({ error: { message: '此模型在您的区域不受支持' } }),
+      ),
+    ).toEqual('unknown');
   });
 
   it('abstains on non-modality errors', () => {

--- a/packages/core/src/services/modalityProbe/probe.test.ts
+++ b/packages/core/src/services/modalityProbe/probe.test.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  classifyProbeResponse,
+  probeImageSupport,
+  RED_PNG_DATA_URL,
+} from './probe.js';
+
+describe('classifyProbeResponse', () => {
+  it('accepts an image-bearing 200 as image', () => {
+    expect(classifyProbeResponse(200, '')).toEqual('image');
+  });
+
+  it('classifies modality-semantic errors as text_only', () => {
+    expect(
+      classifyProbeResponse(
+        400,
+        JSON.stringify({
+          error: { message: 'This model does not support image' },
+        }),
+      ),
+    ).toEqual('text_only');
+    expect(
+      classifyProbeResponse(
+        400,
+        JSON.stringify({
+          error: {
+            code: '1210',
+            message: "messages.content.type 参数非法，取值范围 ['text']",
+          },
+        }),
+      ),
+    ).toEqual('text_only');
+    expect(
+      classifyProbeResponse(
+        404,
+        JSON.stringify({
+          error: { message: 'No endpoints found that support image input' },
+        }),
+      ),
+    ).toEqual('text_only');
+    expect(
+      classifyProbeResponse(
+        400,
+        JSON.stringify({
+          error: 'this model does not support image input (ref: 9eb0a003)',
+        }),
+      ),
+    ).toEqual('text_only');
+  });
+
+  it('abstains on non-modality errors', () => {
+    expect(
+      classifyProbeResponse(401, JSON.stringify({ error: 'Unauthorized' })),
+    ).toEqual('unknown');
+    expect(
+      classifyProbeResponse(
+        429,
+        JSON.stringify({ error: { message: 'Provider returned error' } }),
+      ),
+    ).toEqual('unknown');
+    expect(classifyProbeResponse(-1, 'TimeoutError: timeout')).toEqual(
+      'unknown',
+    );
+    expect(
+      classifyProbeResponse(
+        400,
+        JSON.stringify({ error: { message: 'invalid model id' } }),
+      ),
+    ).toEqual('unknown');
+  });
+
+  it('abstains on 5xx bodies that merely mention multimodal in tracebacks', () => {
+    expect(
+      classifyProbeResponse(
+        500,
+        JSON.stringify({
+          error: {
+            message: 'Traceback ... File "/vllm/multimodal/utils.py", line 42',
+          },
+        }),
+      ),
+    ).toEqual('unknown');
+  });
+});
+
+describe('probeImageSupport', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sends image_url to the chat completions endpoint and returns the verdict', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await probeImageSupport({
+      model: 'm1',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'sk-test',
+    });
+    expect(result.verdict).toEqual('image');
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toEqual('https://api.example.com/v1/chat/completions');
+    expect(init.method).toEqual('POST');
+    expect((init.headers as Record<string, string>)['Content-Type']).toEqual(
+      'application/json',
+    );
+    expect((init.headers as Record<string, string>)['Authorization']).toEqual(
+      'Bearer sk-test',
+    );
+    const body = JSON.parse(String(init.body)) as {
+      messages: Array<{
+        content: Array<{ type: string; image_url?: { url: string } }>;
+      }>;
+      max_tokens: number;
+    };
+    expect(
+      body.messages[0]!.content.some(
+        (p) => p.type === 'image_url' && p.image_url!.url === RED_PNG_DATA_URL,
+      ),
+    ).toBe(true);
+    expect(body.max_tokens).toBeLessThanOrEqual(32);
+  });
+
+  it('normalizes a trailing slash in baseUrl', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const result = await probeImageSupport({
+      model: 'm1',
+      baseUrl: 'https://api.example.com/v1/',
+      apiKey: 'k',
+    });
+    expect(result.verdict).toEqual('image');
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toEqual('https://api.example.com/v1/chat/completions');
+  });
+
+  it('maps endpoint errors to the three-state verdict without throwing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: { message: 'This model does not support image' },
+          }),
+          { status: 400 },
+        ),
+      ),
+    );
+    const result = await probeImageSupport({
+      model: 'm1',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'k',
+    });
+    expect(result.verdict).toEqual('text_only');
+    expect(result.httpStatus).toEqual(400);
+  });
+
+  it('returns unknown on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('boom')));
+    const result = await probeImageSupport({
+      model: 'm1',
+      baseUrl: 'https://api.example.com/v1',
+      apiKey: 'k',
+    });
+    expect(result.verdict).toEqual('unknown');
+  });
+});

--- a/packages/core/src/services/modalityProbe/probe.ts
+++ b/packages/core/src/services/modalityProbe/probe.ts
@@ -24,14 +24,21 @@
 /** Error-text phrases that express a modality rejection. Observed in the wild
  * (2026-08-27, four-endpoint validation — see issue #10309): DeepSeek/Ollama
  * reject via error.message; Zhipu phrases it as content.type enum validation;
- * OpenRouter's router returns 404 "No endpoints found that support image input". */
+ * OpenRouter's router returns 404 "No endpoints found that support image input".
+ *
+ * Phrases carry their object ("...image", "不支持图片/图像"): objectless
+ * variants ("not supported", "不支持") also appear in region/entitlement
+ * errors like "not supported in your region" (403) or "此模型在您的区域不受
+ * 支持" (400), and matching those would persist a wrong text_only verdict —
+ * phase 1 has no re-probe escape hatch once a verdict is written. */
 const MODALITY_ERROR_HINTS = [
-  'not support',
+  'not support image',
   'text-only',
   'text only',
   'multimodal',
   'modalit',
-  '不支持',
+  '不支持图片',
+  '不支持图像',
   '多模态',
   '识图',
   '无法处理图片',

--- a/packages/core/src/services/modalityProbe/probe.ts
+++ b/packages/core/src/services/modalityProbe/probe.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * One-shot image modality probe (QwenLM/qwen-code#10309, phase 1).
+ *
+ * Sends a single chat-completions request carrying a tiny red 8x8 PNG to the
+ * model's own endpoint and classifies the endpoint's response. Deliberately
+ * bypasses the content pipeline: the converter's modality gate would replace
+ * the image with a placeholder for pattern-guessed (text-only) models, which
+ * is exactly the belief under test.
+ *
+ * Verdict is based solely on acceptance — the successful response's CONTENT is
+ * never inspected: reasoning models routinely return an empty `content` with
+ * text in `reasoning_content`/`thinking` even when the image was accepted.
+ * Auth / rate-limit / timeout / ambiguous errors yield `unknown` (no
+ * conclusion) — never a wrong `text_only`, which would be cached and silently
+ * strip images from a vision model.
+ */
+
+/** Error-text phrases that express a modality rejection. Observed in the wild
+ * (2026-08-27, four-endpoint validation — see issue #10309): DeepSeek/Ollama
+ * reject via error.message; Zhipu phrases it as content.type enum validation;
+ * OpenRouter's router returns 404 "No endpoints found that support image input". */
+const MODALITY_ERROR_HINTS = [
+  'not support',
+  'text-only',
+  'text only',
+  'multimodal',
+  'modalit',
+  '不支持',
+  '多模态',
+  '识图',
+  '无法处理图片',
+  'images are not',
+  'does not accept',
+  'support image input',
+  'content.type 参数非法',
+  "取值范围 ['text']",
+] as const;
+
+/** The hints pre-lowercased once at module load, so the classification hot
+ * path does substring checks without re-lowercasing every hint per call. */
+const MODALITY_ERROR_HINTS_LOWER = MODALITY_ERROR_HINTS.map((hint) =>
+  hint.toLowerCase(),
+);
+
+/** Red 8x8 PNG as a data URL. 8x8 rather than 1x1: some endpoints enforce a
+ * minimum image size and would reject a 1x1 as malformed traffic, corrupting
+ * the verdict. */
+export const RED_PNG_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAEklEQVR4nGP4z8CAFWEXHbQSACj/P8Fu7N9hAAAAAElFTkSuQmCC';
+
+export type ModalityProbeVerdict = 'image' | 'text_only' | 'unknown';
+
+export interface ModalityProbeInput {
+  readonly model: string;
+  readonly baseUrl: string;
+  readonly apiKey: string;
+  readonly timeoutMs?: number;
+}
+
+export interface ModalityProbeResult {
+  readonly verdict: ModalityProbeVerdict;
+  readonly httpStatus: number;
+  /** Truncated response/error body — for UI display and debug logging only. */
+  readonly snippet: string;
+}
+
+export function classifyProbeResponse(
+  status: number,
+  errorText: string,
+): ModalityProbeVerdict {
+  if (status === 200) {
+    return 'image';
+  }
+  // Hints are only consulted for 4xx client errors: 5xx bodies may contain
+  // incidental "multimodal" text in server tracebacks (e.g. a vLLM stack
+  // frame path like vllm/multimodal/utils.py), and trusting those would
+  // classify a vision model as text_only — a verdict later tasks persist,
+  // silently stripping images. Anything else non-200 abstains to 'unknown'
+  // (the safe direction).
+  if (status < 400 || status >= 500) {
+    return 'unknown';
+  }
+  const low = (errorText ?? '').toLowerCase();
+  // Match against the raw response text, not a parsed error.message field —
+  // the error payload's shape itself differs per vendor (object-with-message
+  // vs plain string).
+  if (MODALITY_ERROR_HINTS_LOWER.some((hint) => low.includes(hint))) {
+    return 'text_only';
+  }
+  return 'unknown';
+}
+
+export async function probeImageSupport(
+  input: ModalityProbeInput,
+): Promise<ModalityProbeResult> {
+  const body = {
+    model: input.model,
+    max_tokens: 24,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '这张图片是什么颜色？' },
+          { type: 'image_url', image_url: { url: RED_PNG_DATA_URL } },
+        ],
+      },
+    ],
+  };
+  try {
+    const response = await fetch(
+      `${input.baseUrl.replace(/\/$/, '')}/chat/completions`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${input.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(input.timeoutMs ?? 90_000),
+      },
+    );
+    const text = await response.text();
+    return {
+      verdict: classifyProbeResponse(response.status, text),
+      httpStatus: response.status,
+      snippet: text.slice(0, 200),
+    };
+  } catch (error) {
+    return {
+      verdict: 'unknown',
+      httpStatus: -1,
+      snippet:
+        error instanceof Error
+          ? `${error.name}: ${error.message}`
+          : String(error),
+    };
+  }
+}

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -49,6 +49,11 @@
       "type": "object",
       "additionalProperties": true
     },
+    "probeResults": {
+      "description": "Persisted one-shot image modality probe verdicts, keyed by \"authType|modelId|baseUrl\". Written by the \"Test image support\" action in /model; feeds the modality resolution chain (explicit modalities > probe result > name-pattern table). Records are advisory metadata, never user declarations.",
+      "type": "object",
+      "additionalProperties": true
+    },
     "plansDirectory": {
       "description": "Custom directory for approved Plan Mode files. Relative paths are resolved from the project root, and the resolved path must stay within the project root. Defaults to ~/.qwen/plans.",
       "type": "string"


### PR DESCRIPTION
## What this PR does

Implements **phase 1** of #10309: an explicit one-shot image modality probe for models whose input modalities were guessed by the name-pattern table.

- **Probe module** (`packages/core/src/services/modalityProbe/`): sends a single chat-completions request carrying a red 8×8 PNG to the model's own endpoint, deliberately bypassing the content pipeline (the converter's modality gate is exactly the belief under test). Three-state verdict: `200` → `image`; error text carrying modality semantics → `text_only`; auth / rate-limit / timeout / ambiguous errors → `unknown` (no conclusion, nothing persisted). The successful response's content is never inspected — reasoning models routinely return an empty `content` with text in `reasoning_content`/`thinking` even when the image was accepted. The error-dialect dictionary covers the four vendor dialects observed in the #10309 validation matrix (DeepSeek/Ollama `does not support image…`, Zhipu's content-type enum validation, OpenRouter's router-level 404), with hints deliberately phrased with an object (`not support image`, `不支持图片`) so region-availability errors abstain rather than misjudge.
- **Persistence**: verdicts are stored under a new top-level `probeResults` settings key (`authType|modelId|baseUrl` → `{ verdict, probedAt }`). `unknown` is never persisted; the write side guards against hand-corrupted stores; probe results never touch a model entry's `generationConfig.modalities`.
- **Resolution chain**: `explicit modalities (settings/modelProviders) > persisted probe result > name-pattern table`, stamped as `modalitiesSource` (`explicit` / `probe` / `pattern`) on the resolved config. A comment marks the insertion point reserved for the #8558 API-backed catalog layer (final chain: explicit > provider-native catalog > probe > regex > conservative defaults).
- **UI**: the `/model` dialog shows a provenance badge next to the modality value (`manual` / `probe-tested` / `auto-detected`) and offers a `t` — test image support action on pattern-sourced entries only (live settings read; hidden once a verdict concludes, retryable after `unknown`; never offered for user-configured entries).

## Why it's needed

Fixes the recurring pattern-table race documented on #10309 (#4219, then #10270 → #10278 hours later): every newly shipped vision model needs a manual `MODALITY_PATTERNS` entry, and until one lands, users' images are silently replaced by a text placeholder. This PR is the staged first step the #10309 triage recommended ("explicit test-image-support action on pattern-guessed entries in /model"), submitted as a **Draft to anchor the design discussion** — wizard-time auto-probing, invalidation/re-probe policy, and offline behavior are deliberately out of scope pending that discussion.

## Reviewer Test Plan

### How to verify

```bash
cd packages/core && npx vitest run src/services/modalityProbe src/models/modelConfigResolver.test.ts src/models/modelRegistry.test.ts src/models/modelsConfig.test.ts; cd ../..
cd packages/cli && npx vitest run src/ui/components/ModelDialog.test.tsx; cd ../..
```

Coverage highlights: three-state classification (all four vendor dialects, region-error abstention EN/zh, 5xx abstention, network failure), storage round-trip + corrupted-store guards, and the resolution chain in both directions — an explicit declaration written *after* a probe verdict still wins at the resolver **and** in the dialog display.

Optional end-to-end (any OpenAI-compatible provider): configure a pattern-guessed vision model (e.g. `deepseek-v4-flash-vision-exp` without a `modalities` override), open `/model`, press `t` on the entry — the badge flips to `probe-tested` and the verdict lands in `probeResults`. The probe script from #10309 ([gist](https://gist.github.com/jarvislee90s-dot/1f62250a2b0cfa9a3abcb808a12734dc)) re-runs the four-endpoint validation with any subset of keys.

### Evidence (Before & After)

User-visible TUI change; screenshots to be attached once CI renders the draft. Unit-level before/after is expressed by the tests above (N/A — no visual capture in this environment yet).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local source build on Windows, Node ≥22. Scoped suites: probe 19, resolver 62, registry 82, modelsConfig 85, ModelDialog 73 — all green; typecheck / eslint / prettier clean on changed files; `settings.schema.json` regenerated (CI drift gate). Repo-wide preflight on this Windows machine has known environment-only failures (EPERM symlink, git-path classes — same set on base `b90c2f0`); none touch the changed files' suites.

## Risk & Scope

- Size note: ~2,010 insertions across 28 files — above the repo's ~1,200-line split guidance, hence this note. Composition: 51% tests; the probe UI logic is isolated in a dedicated hook (`packages/cli/src/ui/hooks/use-image-support-probe.ts`), so the `ModelDialog` diff is mostly rendering and keybinding. Before this draft is marked ready-for-review, the plan is to split it into two stacked PRs — core resolution chain (probe module + resolver + persistence + unit tests, ≈1,150 lines) and UI (hook + dialog + dialog tests, ≈970 lines) — each under the guideline.
- Main risk or tradeoff: a wrong `text_only` verdict would be persisted with no phase-1 re-probe path — mitigated by the three-state protocol (uncertainty abstains), object-scoped dialect hints, verdict re-validation on read, and the explicit-declaration escape hatch that always overrides in both the runtime chain and the dialog.
- Known boundaries (deliberate, for the design discussion): the probe verdict feeds the *runtime* resolution chain on the next model-providers reload (e.g. restart); the dialog already displays it live. Wiring the write to an in-session registry reload is the open option. `QWEN_OAUTH` routes are not probeable in phase 1; a `baseUrl` env override can key-diverge from the resolver path (documented in `probe-store.ts`).
- Storage choice rationale (open question 1 on #10309): a top-level `probeResults` map because `settings.setValue` cannot address nested array items and composite keys containing URLs are unsafe as dotted paths; alternatives (per-entry field, standalone cache file) noted for the discussion.
- Not validated / out of scope: wizard auto-probe, invalidation/TTL, re-probe action, responses-API wire format, video/pdf probes, `accepted-not-seen` fourth state.
- Breaking changes / migration notes: none — absent `probeResults`, behavior is byte-identical to current main (covered by the untouched existing suites).

## Linked Issues

References #10309 (draft for the design discussion; not requesting merge yet). Complements #8558 — the catalog covers known provider+model pairs, the probe covers the catalog's blind spots (self-hosted, gateways, brand-new releases); the chain insertion point is marked in `modelConfigResolver.ts`.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

实现 #10309 的**一期**：为模态来源是名称模式表猜测的模型提供显式一次性图片模态探测。

- **探测模块**（`packages/core/src/services/modalityProbe/`）：向模型自身端点发送一条携带红色 8×8 PNG 的 chat-completions 请求，刻意绕过内容管线（转换器的模态闸门正是被检验的对象）。三态判定：`200` → `image`；报错文本含模态语义 → `text_only`；鉴权/限流/超时/含糊报错 → `unknown`（不下结论、不落盘）。绝不检查成功响应的内容——推理模型即使在图片被接受时也经常返回空 `content`、正文落在 `reasoning_content`/`thinking`。报错方言字典覆盖 #10309 验证矩阵实测的四种厂商方言，且短语刻意带宾语（`not support image`、`不支持图片`），使区域可用性类报错弃权而非误判。
- **持久化**：判定存入顶层新键 `probeResults`（`authType|modelId|baseUrl` → `{ verdict, probedAt }`）。`unknown` 永不落盘；写侧对手改损坏的 store 设防；探测结论绝不触碰模型条目的 `generationConfig.modalities`。
- **解析链**：显式 `modalities` > 已持久化探测结果 > 名称模式表，来源以 `modalitiesSource`（`explicit`/`probe`/`pattern`）标注在解析结果上。注释标出为 #8558 目录层预留的插入位（终态链：显式 > 目录 > 探测 > 正则 > 保守默认）。
- **UI**：`/model` 对话框模态值旁显示来源徽标（manual / probe-tested / auto-detected），仅对 pattern 来源条目提供 `t` 测试图片支持动作（活读 settings；得出结论后隐藏，unknown 后可重试；用户手写条目永不显示）。

## 为什么需要此改动

修复 #10309 记录的反复出现的模式表竞速（#4219，随后 #10270 → #10278 数小时竞态）：每个新发布的视觉模型都需要人工补 `MODALITY_PATTERNS` 条目，补上之前用户的图片被静默替换为文本占位符。本 PR 是 #10309 triage 建议的分期第一步（"先做 /model 中对 pattern 猜测条目的显式测试动作"），以 **Draft 形式提交作为设计讨论的锚点**——向导自动探测、失效/重测策略、离线行为均刻意留待讨论。

## 审查者测试计划

### 验证方式

```bash
cd packages/core && npx vitest run src/services/modalityProbe src/models/modelConfigResolver.test.ts src/models/modelRegistry.test.ts src/models/modelsConfig.test.ts; cd ../..
cd packages/cli && npx vitest run src/ui/components/ModelDialog.test.tsx; cd ../..
```

覆盖要点：三态分类（四种厂商方言、中英文区域报错弃权、5xx 弃权、网络失败）、存取往返与损坏 store 守卫、以及双向优先级链——探测结论落盘*之后*再手写显式声明，在解析器与对话框显示两层都仍然获胜。

可选端到端（任一 OpenAI 兼容 provider）：配置一个 pattern 猜测的视觉模型（如不带 `modalities` 覆盖的 `deepseek-v4-flash-vision-exp`），打开 `/model`，在条目上按 `t` —— 徽标变为 probe-tested、判定落入 `probeResults`。#10309 的探测脚本（[gist](https://gist.github.com/jarvislee90s-dot/1f62250a2b0cfa9a3abcb808a12734dc)）可用任意子集 key 复跑四端点验证。

### 证据（修复前后）

用户可见的 TUI 变更；截图待 CI 渲染草稿后补。单测层面的前后对照由上述测试表达（本环境暂无视觉捕获，N/A）。

### 测试平台

|    操作系统    | 状态  |
| :------------: | :---: |
|      macOS     | ⚠️ 未测试 |
|     Windows    | ✅ 已测试 |
|     Linux      | ⚠️ 未测试 |

### 环境（可选）

Windows 本地源码构建，Node ≥22。分范围套件：probe 19、resolver 62、registry 82、modelsConfig 85、ModelDialog 73——全绿；改动文件的 typecheck / eslint / prettier 干净；`settings.schema.json` 已重新生成（CI 漂移门禁）。本 Windows 机器的全仓 preflight 存在已知环境性失败（EPERM symlink、git 路径类——base `b90c2f0` 上同一集合）；均不涉及改动文件的套件。

## 风险与范围

- 体量说明：约 2,010 行新增、28 个文件——超过仓库约 1,200 行的拆分指引，特此说明。构成：51% 为测试；探测 UI 逻辑已隔离到独立 hook（`packages/cli/src/ui/hooks/use-image-support-probe.ts`），`ModelDialog` 的 diff 以渲染与键位绑定为主。本草稿标记 ready-for-review 前，计划拆为两个堆叠 PR——核心解析链（探测模块 + resolver + 持久化 + 单测，约 1,150 行）与 UI（hook + 对话框 + 对话框测试，约 970 行）——各自低于指引线。
- 主要风险或取舍：错误的 `text_only` 判定会被持久化且一期无重测出口——由三态协议（不确定即弃权）、带宾语的方言短语、读侧 verdict 复验、以及永远获胜的显式声明补救出口共同缓解。
- 已知边界（刻意保留，供设计讨论）：探测判定在下次模型 provider 重载（如重启）时进入*运行时*解析链；对话框已活读显示。写入时联动会话内 registry 重载是待讨论的开放选项。`QWEN_OAUTH` 路由一期不可探测；`baseUrl` 环境覆盖可能与解析路径键分歧（已记录于 `probe-store.ts`）。
- 存储选型说明（#10309 开放问题 1）：顶层 `probeResults` 映射——因 settings.setValue 无法寻址嵌套数组元素、含 URL 的组合键作 dotted path 不安全；备选（条目内字段、独立缓存文件）已列出供讨论。
- 未验证 / 不在范围内：向导自动探测、失效/TTL、重测动作、responses API 线格式、video/pdf 探针、`accepted-not-seen` 第四态。
- 破坏性变更 / 迁移说明：无——无 `probeResults` 时行为与当前 main 逐字节一致（由未改动的既有套件覆盖）。

## 关联 Issue

References #10309（设计讨论用草稿；暂不请求合并）。与 #8558 互补——目录覆盖已知 provider+model 对，探测覆盖目录盲区（自托管、网关、全新发布）；链插入位已在 `modelConfigResolver.ts` 标注。

</details>
