### PR TITLE
fix(java): avoid Java 11 HTTP fixture reuse

### DIFF
--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
@@ -261,11 +261,14 @@ class DaemonSessionClientTest {
         CountDownLatch cancelReceived = new CountDownLatch(1);
         server.createContext("/session/session-1/cancel", exchange -> {
             cancelReceived.countDown();
+            exchange.getResponseHeaders().set("Connection", "close");
             exchange.sendResponseHeaders(204, -1);
             exchange.close();
         });
-        server.createContext("/session/session-1/detach", noContent());
-        server.createContext("/session/session-2/detach", noContent());
+        server.createContext("/session/session-1/detach",
+                noContentAndCloseConnection());
+        server.createContext("/session/session-2/detach",
+                noContentAndCloseConnection());
 
         try (DaemonClient daemon = newClient();
                 DaemonSessionClient first = daemon.createSession()) {
@@ -2944,6 +2947,14 @@ class DaemonSessionClientTest {
 
     private static HttpHandler noContent() {
         return exchange -> {
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+        };
+    }
+
+    private static HttpHandler noContentAndCloseConnection() {
+        return exchange -> {
+            exchange.getResponseHeaders().set("Connection", "close");
             exchange.sendResponseHeaders(204, -1);
             exchange.close();
         };


### PR DESCRIPTION
## What this PR does

This PR makes the slow-session-creation concurrency test close its HTTP connection after cancel and detach responses. The change is limited to that test fixture and does not alter production request or retry behavior.

## Why it's needed

Main failed intermittently on Ubuntu Java 11 with `HTTP/1.1 header parser received no bytes` while the Java 17, Java 21, macOS, Windows, and real-daemon jobs passed. The same test and EOF signature have appeared on unrelated changes, indicating connection reuse between Java 11 `HttpClient` and the in-process `HttpServer` fixture rather than a product regression. Example: https://github.com/QwenLM/qwen-code/actions/runs/33140800515/job/98750998297

## Reviewer Test Plan

### How to verify

Run the slow-session-creation test repeatedly with Java 11 and confirm cancel plus both session detach operations complete without an EOF from the HTTP header parser. Run the same focused test with Java 17 or newer as a control. The GitHub Java matrix should remain green across all configured JDK versions.

### Evidence (Before & After)

N/A — test-fixture-only change. Before this change, the Java 11 matrix intermittently failed during session cleanup; after this change, the fixture does not reuse those HTTP connections.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ GitHub CI, Java 21 |
| 🪟 Windows | ✅ GitHub CI, Java 21 |
|  🐧 Linux  | ✅ GitHub CI, Java 11/17/21 and real-daemon Java 11 E2E |

### Environment (optional)

Local Java and Maven runtimes were unavailable. `git diff --check` passed, and the complete GitHub SDK Java matrix passed: https://github.com/QwenLM/qwen-code/actions/runs/33148076915

## Risk & Scope

- Main risk or tradeoff: The affected test no longer exercises keep-alive reuse for cancel and detach responses; other tests continue to cover the normal shared fixture behavior.
- Not validated / out of scope: No production retry was added because these mutations have outcome-unknown semantics.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 让慢速会话创建并发测试在 cancel 和 detach 响应后关闭 HTTP 连接。改动仅限该测试夹具，不修改生产请求或重试行为。

## 为什么需要

Main 在 Ubuntu Java 11 上偶发失败并报告 `HTTP/1.1 header parser received no bytes`，同时 Java 17、Java 21、macOS、Windows 和真实 daemon 任务均通过。相同测试和 EOF 特征曾出现在无关改动上，说明问题来自 Java 11 `HttpClient` 与进程内 `HttpServer` 测试夹具之间的连接复用，而不是产品回归。示例：https://github.com/QwenLM/qwen-code/actions/runs/33140800515/job/98750998297

## Reviewer 测试计划

### 如何验证

使用 Java 11 重复运行慢速会话创建测试，确认 cancel 和两个会话的 detach 操作都能完成，且 HTTP header parser 不再出现 EOF。使用 Java 17 或更高版本运行相同的聚焦测试作为对照。GitHub Java 矩阵应在所有配置的 JDK 版本上保持绿色。

### 前后证据

不适用——这是仅测试夹具的改动。改动前，Java 11 矩阵会在会话清理期间偶发失败；改动后，该夹具不会复用这些 HTTP 连接。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ GitHub CI，Java 21 |
| 🪟 Windows | ✅ GitHub CI，Java 21 |
|  🐧 Linux  | ✅ GitHub CI，Java 11/17/21 和真实 daemon Java 11 E2E |

### 环境（可选）

本地没有可用的 Java 和 Maven 运行时。`git diff --check` 已通过，完整 GitHub SDK Java 矩阵也已通过：https://github.com/QwenLM/qwen-code/actions/runs/33148076915

## 风险与范围

- 主要风险或取舍：受影响的测试不再覆盖 cancel 和 detach 响应的 keep-alive 复用；其他测试仍覆盖常规共享夹具行为。
- 未验证/范围外：未添加生产重试，因为这些变更操作具有结果未知语义。
- 破坏性变更/迁移说明：无。

## 关联 Issue

不适用

</details>
