### PR TITLE
ci: serialize helper test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
           node scripts/lint.js --setup
           node scripts/lint.js --actionlint
           node scripts/lint.js --yamllint
-          node --test ${{ env.HELPER_TESTS }}
+          node --test --test-concurrency=1 ${{ env.HELPER_TESTS }}
 
       # Avoid setup-node downloads on ECS, where nodejs.org may be unreachable
       # through the egress proxy; reuse the machine's Node instead.
@@ -496,7 +496,7 @@ jobs:
       # regression tests. Linux-only (they're platform-independent).
       - name: 'Run .github/scripts helper tests'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node --test ${{ env.HELPER_TESTS }}'
+        run: 'node --test --test-concurrency=1 ${{ env.HELPER_TESTS }}'
 
       # The install-script packaging suite needs zip/unzip, and throws on a
       # CI host that ships neither, so a silent skip there is impossible.

--- a/scripts/tests/ci-platform-lanes.test.js
+++ b/scripts/tests/ci-platform-lanes.test.js
@@ -197,6 +197,18 @@ describe('platform lanes — the retired sensitivity classifier', () => {
   });
 });
 
+describe('GitHub helper tests', () => {
+  it('runs every invocation serially', () => {
+    const helperSteps = Object.values(ci.jobs)
+      .flatMap((job) => job.steps ?? [])
+      .filter((step) => String(step.run ?? '').includes('env.HELPER_TESTS'));
+    expect(helperSteps).not.toHaveLength(0);
+    for (const step of helperSteps) {
+      expect(String(step.run), step.name).toContain('--test-concurrency=1');
+    }
+  });
+});
+
 describe('platform lanes — a failing nightly is visible', () => {
   it('files an issue when the scheduled CI run fails on main', () => {
     // A nightly nobody is told about is the same silence the merge-queue gate


### PR DESCRIPTION
## What this PR does

Runs the repository's GitHub helper test files serially in both CI entry points. Test cases inside each file still use Node's normal test runner behavior.

## Why it's needed

The helper suite shares process-level and repository-level resources across files. Running all files concurrently caused the release-note classifier test to fail intermittently in required CI, while the same test passed alone and the suite passed when file concurrency was limited to one.

## Reviewer Test Plan

### How to verify

Confirm both helper-test invocations pass `--test-concurrency=1`, and that the helper test step completes without the prior cross-file interference.

### Evidence (Before & After)

N/A — CI-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22.22.0.

## Risk & Scope

- Main risk or tradeoff: helper files take slightly longer because file-level execution is serial.
- Not validated / out of scope: no production or product test behavior changes.
- Breaking changes / migration notes: none.

## Linked Issues

N/A.

<details>
<summary>中文说明</summary>

## 本 PR 的修改

在 CI 的两个入口中串行运行仓库的 GitHub helper 测试文件。每个文件内部的测试用例仍保留 Node 测试运行器的正常行为。

## 修改原因

helper 测试套件的不同文件会共享进程级和仓库级资源。并发运行所有文件时，release-note classifier 测试曾在必要 CI 中间歇失败；同一测试单独运行可以通过，将文件并发数限制为一后整套 CI 也通过。

## Reviewer 测试计划

### 验证方式

确认两个 helper-test 调用都传入 `--test-concurrency=1`，并确认 helper 测试步骤不再出现此前的跨文件干扰。

### 证据（修改前后）

N/A——仅 CI 修改。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22.22.0。

## 风险与范围

- 主要风险或取舍：helper 文件按串行执行，耗时会略有增加。
- 未验证 / 范围外：不修改生产逻辑或产品测试行为。
- 破坏性修改 / 迁移说明：无。

## 关联 Issue

N/A。

</details>
