### PR TITLE
fix(test): route ACP cron fixtures by prompt

### DIFF
--- a/integration-tests/cli/acp-cron.test.ts
+++ b/integration-tests/cli/acp-cron.test.ts
@@ -74,6 +74,16 @@ type PermissionRequest = {
   }>;
 };
 
+const CRON_CREATE_INSTRUCTION = 'Call cron_create with cron expression';
+
+function isCronCreateRequest(body: Record<string, unknown>): boolean {
+  const messages = body['messages'];
+  return (
+    Array.isArray(messages) &&
+    JSON.stringify(messages.at(-1))?.includes(CRON_CREATE_INSTRUCTION) === true
+  );
+}
+
 /**
  * Sets up an ACP test environment with cron support enabled, backed by
  * a fake-openai-server for deterministic model responses.
@@ -400,14 +410,8 @@ async function initSession(
       const rig = new TestRig();
       await rig.setup('acp-cron-e2e');
 
-      // Only requestIndex 0 is load-bearing: it returns the cron_create
-      // tool call. The CLI makes internal model calls (tool-call
-      // classification, suggestion mode) between user-facing turns, so
-      // later indices do not map 1:1 to the prompts sent below. No
-      // assertion reads scripted response content, so the default reply
-      // suffices for every other turn.
-      const fakeServer = await startFakeOpenAIServer(({ requestIndex }) => {
-        if (requestIndex === 0) {
+      const fakeServer = await startFakeOpenAIServer(({ body }) => {
+        if (isCronCreateRequest(body)) {
           return {
             toolCalls: [
               fakeToolCall('cron_create', {
@@ -440,14 +444,12 @@ async function initSession(
           })) as { stopReason: string };
           expect(createResult.stopReason).toBe('end_turn');
 
-          // Fail fast if the cron_create tool call was not served to the first
-          // user prompt. An internal model call before the first prompt (title
-          // generation, a classifier pass) would shift dispatch and otherwise
-          // surface only as an opaque 75s timeout in Part 3a.
+          // Fail fast instead of surfacing a missing tool call as an opaque
+          // 75s timeout in Part 3a.
           expect(
-            JSON.stringify(fakeServer.requests[0]?.body['messages']),
-            'requestIndex 0 was not the cron_create prompt — dispatch shifted',
-          ).toContain('CRONFIRE7742');
+            fakeServer.requests.some(({ body }) => isCronCreateRequest(body)),
+            'fake server did not receive the cron_create prompt',
+          ).toBe(true);
 
           // --- Part 2: Session stays responsive while cron is pending ---
           const interactiveResult = (await sendRequest('session/prompt', {

--- a/integration-tests/cli/acp-cron.test.ts
+++ b/integration-tests/cli/acp-cron.test.ts
@@ -78,9 +78,13 @@ const CRON_CREATE_INSTRUCTION = 'Call cron_create with cron expression';
 
 function isCronCreateRequest(body: Record<string, unknown>): boolean {
   const messages = body['messages'];
+  const latestMessage = Array.isArray(messages) ? messages.at(-1) : undefined;
   return (
-    Array.isArray(messages) &&
-    JSON.stringify(messages.at(-1))?.includes(CRON_CREATE_INSTRUCTION) === true
+    typeof latestMessage === 'object' &&
+    latestMessage !== null &&
+    'role' in latestMessage &&
+    latestMessage.role === 'user' &&
+    JSON.stringify(latestMessage)?.includes(CRON_CREATE_INSTRUCTION) === true
   );
 }
 


### PR DESCRIPTION
## What this PR does

Routes the ACP cron fixture's scripted tool response by the latest prompt content instead of the fake server's global request number. Unrelated requests now receive the ordinary fallback response, while the cron creation prompt receives the required tool call regardless of arrival order.

## Why it's needed

Main E2E run 33150408634 showed a request from a parallel SDK lifecycle test arriving at this fake server before the ACP cron prompt. That foreign request consumed index zero, received the cron tool response, and shifted every later response; the cron test then failed before creating its scheduled job. Prompt-based routing removes the cross-test ordering assumption without changing production behavior.

## Regression origin

This failure was not introduced by #10077; that merge only triggered the main run where the flake surfaced. The brittle `requestIndex === 0` dispatch and matching assertion were introduced by #8082 when the ACP cron test moved to the fake OpenAI server. The foreign SDK request seen in the log exposed that pre-existing ordering assumption.

## Reviewer Test Plan

### How to verify

Confirm the ACP cron integration test creates the recurring job, remains responsive for the interactive prompt, and receives both the cron-sourced user notification and the later agent notification even when model request order is not assumed.

### Evidence (Before & After)

Before: Linux sandbox:none shard 1/3 failed because request index zero contained the SDK lifecycle prompt `Hello world` instead of the cron creation prompt. After: the focused ACP cron E2E passed 1/1 locally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22, sandbox disabled, focused Vitest integration run.

## Risk & Scope

- Main risk or tradeoff: the fixture recognizes the specific cron creation instruction in the latest message rather than relying on request order.
- Not validated / out of scope: the underlying SDK child-process teardown race inferred from the foreign request is not changed here.
- Breaking changes / migration notes: none; test-only change.

## Linked Issues

Closes #10370

<details>
<summary>中文说明</summary>

## 本 PR 的修改

ACP cron 测试夹具不再按 fake server 的全局请求序号返回脚本化工具响应，而是根据最新一条 prompt 的内容进行分发。无关请求会收到普通兜底响应，cron 创建 prompt 无论以什么顺序到达，都会收到所需的工具调用。

## 修改原因

main E2E run 33150408634 显示，并行 SDK 生命周期测试的请求先于 ACP cron prompt 到达了这个 fake server。该外来请求占用了第零号索引并错误收到 cron 工具响应，导致后续响应全部错位；cron 测试因此在创建定时任务前失败。按 prompt 分发可以消除跨测试的顺序假设，同时不修改生产行为。

## 回归来源

该失败不是由 #10077 引入；该合并只触发了暴露此 flake 的 main run。ACP cron 测试迁移到 fake OpenAI server 时，#8082 引入了脆弱的 `requestIndex === 0` 分发逻辑及对应断言。日志中的外来 SDK 请求暴露了这个既有的顺序假设。

## Reviewer 测试计划

### 验证方式

确认 ACP cron 集成测试能够创建循环任务、在交互 prompt 中保持响应，并依次收到 cron 来源的用户通知和后续 agent 通知，且不依赖模型请求的固定顺序。

### 修改前后证据

修改前：Linux sandbox:none shard 1/3 失败，因为第零号请求包含 SDK 生命周期测试的 `Hello world`，而不是 cron 创建 prompt。修改后：本地聚焦运行 ACP cron E2E，1/1 通过。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22，关闭 sandbox，聚焦 Vitest 集成测试。

## 风险与范围

- 主要风险或取舍：测试夹具通过最新消息中的特定 cron 创建指令识别请求，而不再依赖请求顺序。
- 未验证 / 范围外：从外来请求推断出的 SDK 子进程清理竞态，本 PR 不做修改。
- 破坏性修改 / 迁移说明：无；仅修改测试。

## 关联 Issue

Closes #10370

</details>
