### PR TITLE
fix(ci): route E2E temp files off /tmp

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -220,6 +220,15 @@ jobs:
           # self-hosted runners from pressure-flake unhandled errors.
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: |-
+          export TMPDIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+          if [ "${RUNNER_OS:-}" = "Linux" ]; then
+            QWEN_CI_TMPDIR="$(mktemp -d /var/tmp/qwen-ci-XXXXXX 2>/dev/null || true)"
+            if [ -n "$QWEN_CI_TMPDIR" ]; then
+              TMPDIR="$QWEN_CI_TMPDIR"
+              export TMPDIR
+              trap 'rm -rf "$TMPDIR" 2>/dev/null || true' EXIT
+            fi
+          fi
           # The docker leg runs vitest directly instead of through
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -86,4 +86,12 @@ describe('e2e workflow', () => {
       expect(retryStep.env.VERBOSE).toBe('true');
     });
   });
+
+  it('routes Linux E2E scratch files away from /tmp', () => {
+    const runStep = yml.jobs['e2e-test-linux'].steps.find(
+      (step) => step.name === 'Run E2E tests',
+    );
+    expect(runStep.run).toContain('mktemp -d /var/tmp/qwen-ci-XXXXXX');
+    expect(runStep.run).toContain('trap \'rm -rf "$TMPDIR"');
+  });
 });


### PR DESCRIPTION
## What this PR does

Gives every Linux E2E shard its own disk-backed temporary directory under `/var/tmp`, cleans it when the test step exits, and falls back to the runner-provided temporary directory if allocation is unavailable. This reuses the temporary-directory routing already used by the main CI test jobs.

## Why it's needed

Main E2E run 33150824980 exhausted the reused runner's `/tmp` while creating a test workspace. The same allocation failed on the initial attempt and both Vitest retries, while the other 119 tests in the shard passed. A prior scheduled run failed with the same `/tmp` ENOSPC signature, so rerunning alone does not prevent recurrence.

## Regression origin

This failure was not introduced by #10274; that merge only triggered the main run where the runner exhausted `/tmp`. The regression boundary is #10085, which moved the Linux E2E shards from ephemeral hosted runners to the persistent ECS pool without carrying over the per-run `/var/tmp` routing already used by the main CI jobs. That made accumulated or capacity-limited shared `/tmp` state visible to later E2E runs.

## Reviewer Test Plan

### How to verify

Confirm each Linux E2E shard creates a private temporary directory on `/var/tmp`, exports it before Vitest starts, and removes only that private directory when the step exits. The E2E workflow structure test should continue to pass.

### Evidence (Before & After)

Before: Docker sandbox shard 1/3 failed three times with `ENOSPC: no space left on device, mkdtemp '/tmp/qwen-test-live-journal-recovery-XXXXXX'`. After: the workflow regression test passed 9/9 locally and confirms the `/var/tmp` route plus cleanup trap.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22; focused workflow test.

## Risk & Scope

- Main risk or tradeoff: Linux E2E scratch I/O moves from `/tmp` to the disk-backed `/var/tmp` filesystem.
- Not validated / out of scope: runner-wide cleanup of unrelated processes or files.
- Breaking changes / migration notes: none; CI-only change.

## Linked Issues

Closes #10375

<details>
<summary>中文说明</summary>

## 本 PR 的修改

为每个 Linux E2E shard 在 `/var/tmp` 下创建独立的磁盘临时目录，在测试步骤退出时清理；如果目录分配失败，则回退到 runner 提供的临时目录。该方案复用了主 CI 测试任务已有的临时目录路由方式。

## 修改原因

main E2E run 33150824980 在复用 runner 上创建测试 workspace 时耗尽了 `/tmp`。首次执行以及两次 Vitest 重试都在同一处分配失败，而该 shard 的其余 119 个测试均通过。此前一次定时运行也出现了相同的 `/tmp` ENOSPC，因此仅重跑不能避免复发。

## 回归来源

该失败不是由 #10274 引入；该合并只触发了 runner 耗尽 `/tmp` 的 main run。回归边界是 #10085：它将 Linux E2E shard 从临时 hosted runner 迁移到复用 ECS runner，但没有带上主 CI 已使用的每次运行独立 `/var/tmp` 路由，因此共享 `/tmp` 中累积或受容量限制的状态会影响后续 E2E run。

## Reviewer 测试计划

### 验证方式

确认每个 Linux E2E shard 都会在 `/var/tmp` 创建私有临时目录，在 Vitest 启动前导出该目录，并在步骤退出时只删除自己的私有目录。E2E workflow 结构测试应继续通过。

### 修改前后证据

修改前：Docker sandbox shard 1/3 连续三次失败，错误为 `ENOSPC: no space left on device, mkdtemp '/tmp/qwen-test-live-journal-recovery-XXXXXX'`。修改后：本地 workflow 回归测试 9/9 通过，并验证了 `/var/tmp` 路由和清理 trap。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22；聚焦 workflow 测试。

## 风险与范围

- 主要风险或取舍：Linux E2E 临时 I/O 从 `/tmp` 移到磁盘型 `/var/tmp` 文件系统。
- 未验证 / 范围外：runner 全局范围内清理无关进程或文件。
- 破坏性修改 / 迁移说明：无；仅修改 CI。

## 关联 Issue

Closes #10375

</details>
