### PR TITLE
fix(ci): repost the review ack under the command and react to it

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -144,6 +144,9 @@ jobs:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           PR_NUMBER: '${{ github.event.issue.number || github.event.pull_request.number }}'
           RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          # Empty for a pull_request_review trigger: review bodies have no
+          # reactions endpoint, so only the two comment shapes get the 👀.
+          COMMENT_ID: '${{ github.event.comment.id }}'
         run: |-
           set -euo pipefail
           PR_STATE="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq '.state')"
@@ -151,32 +154,55 @@ jobs:
             echo "PR #${PR_NUMBER} is ${PR_STATE}; skipping acknowledgement." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          # The 👀 on the command itself is the one signal GitHub renders in
+          # place, next to what the requester typed. Best effort: a failed
+          # reaction must not cost the ack comment below.
+          case "$GITHUB_EVENT_NAME" in
+            issue_comment)
+              REACTION_PATH="repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" ;;
+            pull_request_review_comment)
+              REACTION_PATH="repos/${GITHUB_REPOSITORY}/pulls/comments/${COMMENT_ID}/reactions" ;;
+            *)
+              REACTION_PATH="" ;;
+          esac
+          if [ -n "$REACTION_PATH" ] && [ -n "$COMMENT_ID" ]; then
+            gh api --method POST "$REACTION_PATH" -f content=eyes > /dev/null \
+              || echo "Could not react to comment ${COMMENT_ID}." >> "$GITHUB_STEP_SUMMARY"
+          fi
           # Blank line after the marker, or none of the prose below renders. A
           # line opening with `<!--` starts an HTML block that runs to the line
           # containing the closing delimiter, and the REST of that line stays
           # inside it — so gluing the text on shipped it as raw source with a
           # dead link. Verified against GitHub's own renderer.
-          ACK_BODY="$(printf '<!-- qwen-review-ack -->\n\n_Qwen Code review request accepted. Review is queued in [workflow run](%s)._' "$RUN_URL")"
-          EXISTING_ACK_ID="$(
-            # -F would otherwise make gh api default to POST.
-            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-              --method GET \
-              --paginate \
-              -F per_page=100 \
-              | jq -sr '[.[][] | select(.body | contains("<!-- qwen-review-ack -->")) | select(.user.login == "github-actions[bot]")] | last | .id // empty'
-          )" || EXISTING_ACK_ID=""
-          if [ -n "$EXISTING_ACK_ID" ]; then
-            gh api \
-              --method PATCH \
-              "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING_ACK_ID}" \
-              -f body="$ACK_BODY" > /dev/null
-            echo "Queued acknowledgement updated on PR #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
-          else
-            gh pr comment "$PR_NUMBER" \
-              --repo "$GITHUB_REPOSITORY" \
-              --body "$ACK_BODY"
-            echo "Queued acknowledgement posted on PR #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          #
+          # A command-triggered run executes against the base branch, so its
+          # `review-pr` check attaches to main's commit and never shows under
+          # this PR's checks — the link here is the only way to watch it.
+          ACK_BODY="$(printf '<!-- qwen-review-ack -->\n\n_Qwen Code review request accepted. Review is running in [workflow run](%s). A command-triggered review is not listed under the checks of this PR; the result is posted here as a review when it finishes._' "$RUN_URL")"
+          # One ack per PR, and it must sit right under the command that asked
+          # for it. Editing the previous ack in place kept the count at one but
+          # left the notice wherever the FIRST request landed — on a 15-comment
+          # thread that was comment #2, above the previous day's triage, and
+          # the requester reading from the bottom concluded nothing had
+          # started. Delete-then-post keeps the count and moves the notice to
+          # the bottom. Nothing keys on the comment id: every consumer
+          # (qwen-autofix's bot-comment filters, the review's bypass audit)
+          # matches the marker.
+          # -F would otherwise make gh api default to POST.
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --method GET \
+            --paginate \
+            -F per_page=100 \
+            | jq -r '.[] | select(.body | contains("<!-- qwen-review-ack -->")) | select(.user.login == "github-actions[bot]") | .id' \
+            | while read -r STALE_ACK_ID; do
+                [ -n "$STALE_ACK_ID" ] || continue
+                gh api --method DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${STALE_ACK_ID}" \
+                  || echo "Could not delete stale acknowledgement ${STALE_ACK_ID}." >> "$GITHUB_STEP_SUMMARY"
+              done
+          gh pr comment "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "$ACK_BODY"
+          echo "Queued acknowledgement posted on PR #${PR_NUMBER}." >> "$GITHUB_STEP_SUMMARY"
 
   review-config:
     # Bot-requested review_requested only: a CODEOWNERS-covered PR open

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -2539,6 +2539,55 @@ describe('bot comment markers', () => {
     expect(ackLine).toContain('[workflow run](%s)');
     expect(ackLine).toContain('"$RUN_URL"');
   });
+
+  describe('queued ack placement', () => {
+    // One ack per PR, but it has to land under the command that asked for
+    // it. The in-place PATCH kept the count at one and left the notice at
+    // the position of the FIRST request — comment #2 of 15 on #10259 — so
+    // a requester reading from the bottom saw nothing start. Delete the
+    // stale ack(s), then post: same count, right position. Nothing keys on
+    // the comment id (autofix filters and the bypass audit match the
+    // marker), so recreating is safe.
+    const ackRun = parse(workflow).jobs['ack-review-request'].steps[0].run;
+
+    it('deletes stale acks and posts a fresh one instead of editing in place', () => {
+      expect(ackRun).not.toContain('--method PATCH');
+      expect(ackRun).toContain(
+        '--method DELETE "repos/${GITHUB_REPOSITORY}/issues/comments/${STALE_ACK_ID}"',
+      );
+      // Every stale ack, not just the last: a PATCH-era thread can carry
+      // several after a failed delete, and `last` would leave the rest.
+      expect(ackRun).not.toMatch(/\|\s*last\s*\|/);
+      // The post is unconditional — no `else` branch that skips it when a
+      // stale ack existed.
+      const postIndex = ackRun.indexOf('gh pr comment "$PR_NUMBER"');
+      expect(postIndex).toBeGreaterThan(ackRun.indexOf('--method DELETE'));
+      expect(ackRun.slice(0, postIndex)).not.toMatch(/^\s*else\s*$/m);
+    });
+
+    it('reacts 👀 to the triggering comment, best effort', () => {
+      expect(ackRun).toContain('-f content=eyes');
+      expect(ackRun).toContain(
+        'repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions',
+      );
+      expect(ackRun).toContain(
+        'repos/${GITHUB_REPOSITORY}/pulls/comments/${COMMENT_ID}/reactions',
+      );
+      // A failed reaction must not abort the ack under `set -e`.
+      expect(ackRun).toMatch(/content=eyes[^\n]*\n\s*\|\| echo/);
+      expect(
+        parse(workflow).jobs['ack-review-request'].steps[0].env.COMMENT_ID,
+      ).toBe('${{ github.event.comment.id }}');
+    });
+
+    it('tells the requester the run is not a PR check', () => {
+      // A command-triggered run executes against the base branch, so its
+      // review-pr check never shows under the PR — the ack link is the only
+      // handle, and the copy has to say so or the requester keeps looking
+      // for a yellow dot.
+      expect(ackRun).toContain('not listed under the checks of this PR');
+    });
+  });
 });
 
 describe('qwen pr review concurrency routing', () => {


### PR DESCRIPTION
## What this PR does

When someone comments `@qwen-code /review`, the `ack-review-request` job now deletes any earlier acknowledgement and posts a fresh one, so the "review request accepted — [workflow run]" notice always lands directly under the command that asked for it. It also reacts 👀 to the triggering comment (issue comments and review comments; review bodies have no reactions endpoint), and the ack text now says that a command-triggered review runs against the base branch and is therefore not listed under the PR's checks — the link is the only way to watch it.

## Why it's needed

The ack existed, but it was edited in place whenever a previous ack was on the thread. On #10259 the second `/review` updated the ack left by the first one — comment 2 of 15, above the previous day's triage output — so a requester reading from the bottom saw nothing happen, found no pending check on the PR (a command-triggered run's `review-pr` check attaches to main's commit, not the PR head), and concluded the review had not started while it was in fact running. One ack per PR is still the right count; it just has to be at the right position and say why there is no yellow dot.

Recreating the comment is safe: nothing keys on the ack's comment id. Every consumer — the eight bot-comment filters in `qwen-autofix.yml` and the review's bypass audit in `packages/cli/src/commands/review/cleanup.ts` — matches the `<!-- qwen-review-ack -->` marker.

## Reviewer Test Plan

### How to verify

- Read the `ack-review-request` step: it reacts `eyes` on `issues/comments/{id}` or `pulls/comments/{id}` depending on the event (best effort, `|| echo` so a failed reaction cannot abort the ack under `set -e`), deletes every existing `github-actions[bot]` comment carrying the marker, then posts the new ack unconditionally — there is no `PATCH` and no `else` branch.
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js` — the new `queued ack placement` block pins the delete-then-post shape, the two reaction endpoints with `content=eyes`, the `COMMENT_ID` env wiring, and the "not listed under the checks of this PR" copy. The existing `pins the workflow-run URL into the ack printf` test still passes (the printf line keeps `[workflow run](%s)` and `"$RUN_URL"`).
- Live check after merge: comment `@qwen-code /review` on a PR that already has an ack from an earlier request; expect the old ack to disappear, a new one to appear as the last comment linking to the new run, and 👀 on the command.

### Evidence (Before & After)

Before (#10259, 2026-08-28): `/review` posted at 08:09:37Z → ack comment `5435672165` (created 2026-08-27, position 2 of 15) silently PATCHed at 08:09:54Z; no reaction on the command; PR checks show nothing for the run. After: N/A until it runs in CI — the shape is pinned by the tests above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

`bash -n` and shellcheck on the extracted `run:` script; scripts test suite (the two `unwritable directory` tests fail locally as root regardless of this change).

## Risk & Scope

- Main risk or tradeoff: the ack now has a new comment id on every request; anything that stored the old id would dangle — nothing in the repo does. If a stale-ack delete fails the job logs it and still posts, so the worst case is two acks, which is the pre-existing shape before the in-place PATCH was added.
- Not validated / out of scope: the `pull_request_review` trigger gets no reaction (GitHub has no reactions API for review bodies); the ack is still never removed when the review completes.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up observed on #10259 (no tracking issue).

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当有人评论 `@qwen-code /review` 时，`ack-review-request` job 现在会先删除线程里已有的确认评论，再新发一条，这样"review request accepted — [workflow run]"这条通知总是紧贴在发出命令的评论下方。同时对触发命令的评论加 👀 反应（issue 评论和 review 评论；review 正文没有 reactions 接口），并在 ack 文案中说明：命令触发的 review 运行在 base 分支上，因此不会出现在 PR 的 checks 列表里——链接是唯一的观察入口。

## 为什么需要

ack 本来就存在，但只要线程里已有一条 ack，它就会被原地编辑。在 #10259 上，第二次 `/review` 更新的是第一次留下的那条 ack——15 条评论中的第 2 条，位于前一天的 triage 输出上方——所以从底部往上看的请求者什么都没看到，PR 上也没有 pending 的 check（命令触发的 run 的 `review-pr` check 挂在 main 的 commit 上，不在 PR head 上），于是断定 review 没有启动，而实际上它正在运行。每个 PR 只保留一条 ack 仍然是对的，只是它必须在正确的位置，并说明为什么没有黄点。

重建评论是安全的：没有任何东西依赖 ack 的评论 id。所有消费方——`qwen-autofix.yml` 中的 8 处 bot 评论过滤和 `packages/cli/src/commands/review/cleanup.ts` 中的绕过审计——都按 `<!-- qwen-review-ack -->` 标记匹配。

## Reviewer Test Plan

### 如何验证

- 阅读 `ack-review-request` 步骤：根据事件类型对 `issues/comments/{id}` 或 `pulls/comments/{id}` 加 `eyes` 反应（尽力而为，`|| echo` 保证在 `set -e` 下反应失败不会中止 ack），删除所有带标记的 `github-actions[bot]` 评论，然后无条件发布新 ack——没有 `PATCH`，也没有 `else` 分支。
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/qwen-pr-review-workflow.test.js`——新增的 `queued ack placement` 测试块钉住了"先删后发"的形态、两个带 `content=eyes` 的反应端点、`COMMENT_ID` 环境变量接线，以及"not listed under the checks of this PR"文案。原有的 `pins the workflow-run URL into the ack printf` 测试仍然通过（printf 行保留了 `[workflow run](%s)` 和 `"$RUN_URL"`）。
- 合并后实测：在一个已有旧 ack 的 PR 上评论 `@qwen-code /review`；预期旧 ack 消失、新 ack 作为最后一条评论出现并链接到新 run、命令评论上出现 👀。

### 证据（Before & After）

Before（#10259，2026-08-28）：08:09:37Z 发出 `/review` → ack 评论 `5435672165`（创建于 2026-08-27，位置 15 之 2）在 08:09:54Z 被静默 PATCH；命令上无反应；PR checks 里没有该 run。After：需在 CI 中运行后才有——形态已由上述测试钉住。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

对抽取出的 `run:` 脚本做了 `bash -n` 和 shellcheck；scripts 测试套件（其中两个 `unwritable directory` 测试在本地以 root 运行时无论如何都会失败，与本改动无关）。

## 风险与范围

- 主要风险或权衡：每次请求后 ack 的评论 id 都会变化；若有地方存了旧 id 会失效——仓库里没有这样的地方。若删除旧 ack 失败，job 会记录并照常发布，最坏情况是出现两条 ack，这正是加入原地 PATCH 之前的旧形态。
- 未验证 / 超出范围：`pull_request_review` 触发方式不加反应（GitHub 没有 review 正文的 reactions API）；review 完成后 ack 仍不会被移除。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

在 #10259 上观察到的后续问题（无跟踪 issue）。

</details>
