### PR TITLE
ci: run the no-AK integration gate as its own check

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -18,7 +18,7 @@
 9256 build-and-publish-image.yml
 49610 cd-cua-driver.yml
 2076 cd-mobile-mcp.yml
-80980 ci.yml
+91370 ci.yml
 1482 codeql.yml
 9389 comment-attachment-guard.yml
 31677 desktop-release.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,44 +601,6 @@ jobs:
           npm -w packages/chrome-extension run package
           npm -w packages/chrome-extension run scan:artifacts
 
-      - name: 'Run required no-AK integration gate'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
-        timeout-minutes: 20
-        env:
-          HOME: '${{ runner.temp }}/qwen-no-ak-home'
-          USERPROFILE: '${{ runner.temp }}/qwen-no-ak-home'
-          QWEN_HOME: '${{ runner.temp }}/qwen-no-ak-home/.qwen'
-          API_KEY: ''
-          ANTHROPIC_API_KEY: ''
-          ANTHROPIC_BASE_URL: ''
-          ANTHROPIC_MODEL: ''
-          BAILIAN_CODING_PLAN_API_KEY: ''
-          BAILIAN_TOKEN_PLAN_API_KEY: ''
-          DEEPSEEK_API_KEY: ''
-          OPENAI_API_KEY: ''
-          OPENAI_BASE_URL: ''
-          OPENAI_MODEL: ''
-          DASHSCOPE_API_KEY: ''
-          GOOGLE_API_KEY: ''
-          GOOGLE_MODEL: ''
-          QWEN_API_KEY: ''
-          QWEN_MODEL: ''
-          GEMINI_API_KEY: ''
-          GEMINI_MODEL: ''
-          IDEALAB_API_KEY: ''
-          MINIMAX_API_KEY: ''
-          MODELSCOPE_API_KEY: ''
-          MOONSHOT_API_KEY: ''
-          OPENROUTER_API_KEY: ''
-          REQUESTY_API_KEY: ''
-          XAI_API_KEY: ''
-          ZAI_API_KEY: ''
-          QWEN_DEFAULT_AUTH_TYPE: ''
-        run: |-
-          mkdir -p "${HOME}" "${QWEN_HOME}"
-          npm run typecheck:integration
-          npm run test:integration:no-ak:sandbox:none
-
       - name: 'Publish Test Report (for non-forks)'
         if: |-
           ${{ always() && needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && steps.unit_tests.outcome != 'skipped' && (github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -1209,6 +1171,227 @@ jobs:
   # Until merge queue is enabled on `main` this job simply never triggers,
   # so adding it is a no-op for existing PR/push runs. Reuses the exact
   # `test:integration:cli:sandbox:none` script from `release.yml`.
+  integration_no_ak:
+    name: 'Integration Tests (no-AK, No Sandbox)'
+    needs: 'classify_pr'
+    # The deterministic no-credential integration set (#8313) used to run as a
+    # step inside the Ubuntu `test` job. That made it invisible to anything
+    # that reads check names: the `Integration Tests (CLI, No Sandbox)` check
+    # is merge_group-only and shows as skipped on every PR, and the PR review
+    # bot ruled from that skip that a changed integration test "never ran"
+    # (#9895 round 15) while this very gate had executed it and passed inside
+    # `test`. A check of its own carries the fact in its name. Same runner
+    # routing as the Ubuntu gate; same PR + merge-queue events; same profile
+    # gate, classified here because depending on `test` for its output would
+    # serialize this job behind the hour-long unit run.
+    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
+    runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
+    timeout-minutes: 30
+    permissions:
+      contents: 'read'
+    steps:
+      - name: 'Restore workspace ownership'
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; checkout may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; checkout may fail on leftover read-only files"
+
+      # Same pre-checkout recovery as the test job: this job lands on the
+      # same reused pool, so leftover review worktrees and branches from an
+      # interrupted review would break this checkout too.
+      - name: 'Clean stale .qwen before checkout'
+        run: |-
+          set -uo pipefail
+          if [ -d "$GITHUB_WORKSPACE/.qwen" ] && [ ! -L "$GITHUB_WORKSPACE/.qwen" ]; then
+            chmod -R u+w "$GITHUB_WORKSPACE/.qwen" 2>/dev/null || true
+            # Last resort when nothing can DELETE the tree: move it out of the
+            # workspace. Unlinking an entry needs write permission on the
+            # directory holding it — which is exactly what a foreign-owned
+            # leftover denies — while renaming needs it only on the two
+            # parents, and the workspace root is always this runner's own. So
+            # a tree that defeats rm, chmod, and a sudo-less chown still
+            # renames aside, and the checkout below finds nothing to trip on.
+            # Leaving it in place instead poisons EVERY later job scheduled
+            # here, not just this one (measured, run 32621267802: `EACCES
+            # rmdir .qwen/tmp/review-pr-9748-scratch-verify-…/probe-ws/…`
+            # killed checkout for two unrelated PRs on the same runner).
+            rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              sudo -n rm -rf "$GITHUB_WORKSPACE/.qwen" 2>/dev/null ||
+              {
+                quarantine="$(dirname -- "$GITHUB_WORKSPACE")/_qwen-quarantine"
+                mkdir -p "$quarantine" 2>/dev/null || true
+                if mv -- "$GITHUB_WORKSPACE/.qwen" "$quarantine/qwen-$(date -u +%Y%m%dT%H%M%SZ)-$$" 2>/dev/null; then
+                  echo "::warning::could not delete leaked .qwen; moved it to $quarantine so this checkout can proceed — that directory needs manual cleanup"
+                else
+                  echo "::warning::leaked .qwen; runner needs manual cleanup"
+                fi
+              }
+          fi
+          # Interrupted reviews leave worktree registrations under .qwen/tmp/
+          # and qwen-review/* branches behind. prune drops registrations whose
+          # directories the rm above removed; worktree remove --force then
+          # clears any still-registered leftover directory (--force tolerates
+          # dirty contents), since a branch checked out in a live worktree
+          # cannot be deleted. If removal still fails, the registration
+          # survives and the branch delete below warns. The sweep deletes all
+          # review artifacts, not just the current PR's: safe because a runner
+          # executes one job at a time. Kept inline rather than a shared
+          # script: this runs pre-checkout on shared runners, where leftover
+          # workspace files are untrusted.
+          if [ -e "$GITHUB_WORKSPACE/.git" ]; then
+            GIT_SAFE=(git -c core.hooksPath=/dev/null -c core.fsmonitor= -C "$GITHUB_WORKSPACE")
+            "${GIT_SAFE[@]}" worktree prune -v || true
+            "${GIT_SAFE[@]}" worktree list --porcelain \
+              | awk '$1 == "worktree" && index($0, "/.qwen/tmp/review-pr-") > 0 { sub(/^worktree /, ""); print }' \
+              | while read -r worktree; do
+                  [ -n "$worktree" ] || continue
+                  # Registered paths come from leftover git metadata and are
+                  # untrusted: the awk filter above matched by substring, so reject
+                  # `..` traversal and re-anchor to the review prefix before the
+                  # destructive remove.
+                  case "$worktree" in
+                    */../*|../*|*/..)
+                      echo "::warning::skipping suspicious review worktree path: $worktree"
+                      continue
+                      ;;
+                    "$GITHUB_WORKSPACE/.qwen/tmp/review-pr-"*) : ;;
+                    *)
+                      echo "::warning::skipping unexpected review worktree path: $worktree"
+                      continue
+                      ;;
+                  esac
+                  "${GIT_SAFE[@]}" worktree remove --force "$worktree" ||
+                    echo "::warning::could not remove review worktree: $worktree"
+                done || true
+            "${GIT_SAFE[@]}" worktree prune -v || true
+            "${GIT_SAFE[@]}" for-each-ref --format='%(refname:short)' 'refs/heads/qwen-review/*' \
+              | while read -r stale_ref; do
+                  if [ -n "$stale_ref" ]; then
+                    "${GIT_SAFE[@]}" branch -D "$stale_ref" ||
+                      echo "::warning::could not remove review branch: $stale_ref"
+                  fi
+                done || true
+          fi
+
+      - name: 'Checkout'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        with:
+          ref: "${{ (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || github.ref }}"
+          fetch-depth: 1
+
+      - name: 'Verify checkout includes expected head commit'
+        uses: './.github/actions/verify-checkout-head'
+        with:
+          expected_sha: "${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}"
+
+      # KEEP IN SYNC with the `test` job's classifier step: same wrapper, same
+      # fallbacks, so a docs-only or github-ci-only PR skips this gate exactly
+      # when it skips the unit run.
+      - name: 'Classify CI profile'
+        id: 'ci_profile'
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          PR_NUMBER: "${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}"
+          IS_SAME_REPO_PR: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}"
+        run: |-
+          profile=full
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && -n "${PR_NUMBER}" ]]; then
+            if [[ "${IS_SAME_REPO_PR}" == "true" ]]; then
+              set +e
+              profile="$(.github/scripts/ci/classify-pr-profile.sh "${GITHUB_REPOSITORY}" "${PR_NUMBER}")"
+              classify_rc=$?
+              set -e
+              if [ "$classify_rc" -eq 2 ]; then
+                echo "::warning::Unable to list PR changed files; running full CI."
+                profile=full
+              elif [ "$classify_rc" -ne 0 ]; then
+                echo "::error::CI profile classifier exited non-zero; running full CI."
+                profile=full
+              fi
+            else
+              echo "Fork PR detected; running full CI."
+            fi
+          fi
+          echo "ci_profile=${profile}" >> "${GITHUB_OUTPUT}"
+          echo "Selected CI profile: ${profile}"
+
+      - name: 'Setup Node.js (hosted)'
+        if: "${{ steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'github-hosted' }}"
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+
+      - name: 'Use pre-installed Node.js (self-hosted)'
+        if: "${{ steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}"
+        uses: './.github/actions/self-hosted-node'
+
+      - name: 'Configure persistent npm cache (self-hosted)'
+        if: "${{ steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${HOME}/.cache/qwen-code/npm"
+          mkdir -p "${cache_dir}"
+          echo "NPM_CONFIG_CACHE=${cache_dir}" >> "${GITHUB_ENV}"
+          echo "Using persistent npm cache at ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
+
+      - name: 'Install Dependencies'
+        if: "${{ steps.ci_profile.outputs.ci_profile == 'full' }}"
+        env:
+          NPM_CONFIG_PREFER_OFFLINE: 'true'
+        run: |-
+          npm ci --no-audit --progress=false
+
+      - name: 'Report npm cache usage (self-hosted)'
+        if: "${{ always() && steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${NPM_CONFIG_CACHE:-$(npm config get cache)}"
+          echo "npm cache: ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
+
+      - name: 'Run required no-AK integration gate'
+        if: "${{ steps.ci_profile.outputs.ci_profile == 'full' }}"
+        timeout-minutes: 20
+        env:
+          HOME: '${{ runner.temp }}/qwen-no-ak-home'
+          USERPROFILE: '${{ runner.temp }}/qwen-no-ak-home'
+          QWEN_HOME: '${{ runner.temp }}/qwen-no-ak-home/.qwen'
+          API_KEY: ''
+          ANTHROPIC_API_KEY: ''
+          ANTHROPIC_BASE_URL: ''
+          ANTHROPIC_MODEL: ''
+          BAILIAN_CODING_PLAN_API_KEY: ''
+          BAILIAN_TOKEN_PLAN_API_KEY: ''
+          DEEPSEEK_API_KEY: ''
+          OPENAI_API_KEY: ''
+          OPENAI_BASE_URL: ''
+          OPENAI_MODEL: ''
+          DASHSCOPE_API_KEY: ''
+          GOOGLE_API_KEY: ''
+          GOOGLE_MODEL: ''
+          QWEN_API_KEY: ''
+          QWEN_MODEL: ''
+          GEMINI_API_KEY: ''
+          GEMINI_MODEL: ''
+          IDEALAB_API_KEY: ''
+          MINIMAX_API_KEY: ''
+          MODELSCOPE_API_KEY: ''
+          MOONSHOT_API_KEY: ''
+          OPENROUTER_API_KEY: ''
+          REQUESTY_API_KEY: ''
+          XAI_API_KEY: ''
+          ZAI_API_KEY: ''
+          QWEN_DEFAULT_AUTH_TYPE: ''
+        run: |-
+          mkdir -p "${HOME}" "${QWEN_HOME}"
+          npm run typecheck:integration
+          npm run test:integration:no-ak:sandbox:none
+
   integration_cli:
     name: 'Integration Tests (CLI, No Sandbox)'
     needs: 'classify_pr'

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -159,7 +159,15 @@ describe('no-AK integration CI wiring', () => {
     );
   });
 
-  it('runs the no-AK integration script in the required Linux gate only', () => {
+  it('runs the no-AK integration script as its own check on PRs and the merge queue', () => {
+    // The gate ran as a step inside the Ubuntu `test` job from #8313 until
+    // it moved out: a step is invisible to anything that reads check names,
+    // and the PR review bot ruled from the (merge_group-only, hence skipped
+    // on every PR) `Integration Tests (CLI, No Sandbox)` check that a changed
+    // integration test "never ran" while this gate had executed it and
+    // passed inside `test` (#9895 round 15). A check of its own carries the
+    // fact in its name. The env isolation and the two-event condition are
+    // the gate's contract and must survive the move unchanged.
     const workflow = readFileSync(
       path.join(ROOT, '.github/workflows/ci.yml'),
       'utf8',
@@ -167,27 +175,66 @@ describe('no-AK integration CI wiring', () => {
     const ubuntuJob = getWorkflowJob(workflow, 'test');
     const macosJob = getWorkflowJob(workflow, 'test_macos');
     const windowsJob = getWorkflowJob(workflow, 'test_windows');
+    const gateJob = getWorkflowJob(workflow, 'integration_no_ak');
     const permissionsIndex = workflow.indexOf('\npermissions:');
     expect(permissionsIndex).toBeGreaterThan(0);
     const workflowTriggers = workflow.slice(0, permissionsIndex);
-    const gateStepMarker =
-      "      - name: 'Run required no-AK integration gate'";
-    const gateStepStart = ubuntuJob.indexOf(gateStepMarker);
-    expect(gateStepStart).toBeGreaterThanOrEqual(0);
-    const nextStepIndex = ubuntuJob.indexOf(
-      '\n      - name:',
-      gateStepStart + gateStepMarker.length,
-    );
-    expect(nextStepIndex).toBeGreaterThan(0);
-    const gateStep = ubuntuJob.slice(gateStepStart, nextStepIndex);
-
-    expect(workflow).not.toContain('  integration_no_ak:');
-    expect(workflow.split(`npm run ${NO_AK_SCRIPT}`).length - 1).toBe(1);
     expect(workflowTriggers).toContain('\n  pull_request:\n');
     expect(workflowTriggers).toContain('\n  merge_group:\n');
 
-    expect(gateStep).toContain(
+    expect(workflow.split(`npm run ${NO_AK_SCRIPT}`).length - 1).toBe(1);
+    for (const [name, job] of Object.entries({
+      test: ubuntuJob,
+      test_macos: macosJob,
+      test_windows: windowsJob,
+    })) {
+      expect(job, `${name} must not run the no-AK script`).not.toContain(
+        NO_AK_SCRIPT,
+      );
+    }
+
+    expect(gateJob).toContain(
+      "    name: 'Integration Tests (no-AK, No Sandbox)'",
+    );
+    expect(gateJob).toContain("    needs: 'classify_pr'");
+    // Same runner routing as the Ubuntu gate, never a hard-coded pool.
+    expect(gateJob).toContain('needs.classify_pr.outputs.ubuntu_runner');
+    const jobIf = gateJob
+      .split('\n')
+      .find((line) => line.startsWith('    if:'));
+    expect(jobIf).toContain("needs.classify_pr.outputs.skip_ci != 'true'");
+    expect(jobIf).toContain(
       "(github.event_name == 'pull_request' || github.event_name == 'merge_group')",
+    );
+    // PR head ref on pull_request, queue head on merge_group — the same
+    // shape the Ubuntu gate uses, so this check tests the pushed tree, not
+    // the lagging merge ref.
+    expect(getWorkflowStep(gateJob, 'Checkout')).toContain(
+      "format('refs/pull/{0}/head', github.event.pull_request.number)",
+    );
+    // The profile gate is classified in this job: depending on `test` for
+    // its ci_profile output would queue the check behind the hour-long unit
+    // run. Pin the wrapper so the two classifiers cannot drift.
+    const classify = getWorkflowStep(gateJob, 'Classify CI profile');
+    expect(classify).toContain(
+      '.github/scripts/ci/classify-pr-profile.sh "${GITHUB_REPOSITORY}" "${PR_NUMBER}"',
+    );
+    expect(classify).toContain("id: 'ci_profile'");
+    for (const stepName of [
+      'Setup Node.js (hosted)',
+      'Use pre-installed Node.js (self-hosted)',
+      'Install Dependencies',
+      'Run required no-AK integration gate',
+    ]) {
+      expect(
+        getWorkflowStep(gateJob, stepName),
+        `${stepName} must honour the CI profile`,
+      ).toContain("steps.ci_profile.outputs.ci_profile == 'full'");
+    }
+
+    const gateStep = getWorkflowStep(
+      gateJob,
+      'Run required no-AK integration gate',
     );
     const integrationTypecheckCommand = `npm run ${INTEGRATION_TYPECHECK_SCRIPT}`;
     expect(gateStep).toContain(integrationTypecheckCommand);
@@ -235,12 +282,11 @@ describe('no-AK integration CI wiring', () => {
     ]) {
       expect(gateStep).toContain(`\n          ${key}: ''`);
     }
-    expect(ubuntuJob).not.toContain('secrets.OPENAI_API_KEY');
-    expect(ubuntuJob).not.toContain('secrets.OPENAI_BASE_URL');
-    expect(ubuntuJob).not.toContain('secrets.OPENAI_MODEL');
-
-    expect(macosJob).not.toContain(NO_AK_SCRIPT);
-    expect(windowsJob).not.toContain(NO_AK_SCRIPT);
+    for (const job of [ubuntuJob, gateJob]) {
+      expect(job).not.toContain('secrets.OPENAI_API_KEY');
+      expect(job).not.toContain('secrets.OPENAI_BASE_URL');
+      expect(job).not.toContain('secrets.OPENAI_MODEL');
+    }
   });
 
   it('checks out the immutable PR head ref instead of the lagging merge ref', () => {
@@ -253,11 +299,12 @@ describe('no-AK integration CI wiring', () => {
     const macosJob = getWorkflowJob(workflow, 'test_macos');
     const windowsJob = getWorkflowJob(workflow, 'test_windows');
     const integrationJob = getWorkflowJob(workflow, 'integration_cli');
+    const noAkJob = getWorkflowJob(workflow, 'integration_no_ak');
 
     // On PRs every gate checks out refs/pull/N/head, which is published the
     // instant the branch is pushed, instead of the merge ref that GitHub
     // rebuilds asynchronously and can serve stale for minutes.
-    for (const job of [ubuntuJob, macosJob, windowsJob]) {
+    for (const job of [ubuntuJob, macosJob, windowsJob, noAkJob]) {
       expect(job).toContain(
         "format('refs/pull/{0}/head', github.event.pull_request.number)",
       );
@@ -306,6 +353,7 @@ describe('no-AK integration CI wiring', () => {
       web_shell_e2e_smoke: getWorkflowStep(webShellJob, GUARD_STEP),
       test_windows: getWorkflowStep(windowsJob, GUARD_STEP),
       integration_cli: getWorkflowStep(integrationJob, GUARD_STEP),
+      integration_no_ak: getWorkflowStep(noAkJob, GUARD_STEP),
     };
     for (const [jobName, call] of Object.entries(guardCalls)) {
       expect(call, `${jobName} guard must use the shared action`).toContain(
@@ -324,6 +372,9 @@ describe('no-AK integration CI wiring', () => {
     expect(guardCalls.integration_cli).toContain(
       "expected_sha: '${{ github.event.merge_group.head_sha }}'",
     );
+    expect(guardCalls.integration_no_ak).toContain(
+      'expected_sha: "${{ github.event_name == \'merge_group\' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}"',
+    );
 
     // The run conditions are part of the guard's contract: scoping a guard to
     // the wrong runner class or dropping an event would silently disable it.
@@ -339,6 +390,8 @@ describe('no-AK integration CI wiring', () => {
       "if: \"${{ needs.classify_pr.outputs.skip_ci != 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}\"",
     );
     expect(guardCalls.integration_cli).not.toContain('if:');
+    // integration_no_ak likewise gates skip_ci and both events at job level.
+    expect(guardCalls.integration_no_ak).not.toContain('if:');
   });
 
   it('pins the Windows gate kill-switch routing, tuning, and Node split', () => {
@@ -618,6 +671,10 @@ describe('no-AK integration CI wiring', () => {
         getWorkflowJob(workflow, 'integration_cli'),
         'Use pre-installed Node.js (self-hosted)',
       ),
+      integration_no_ak: getWorkflowStep(
+        getWorkflowJob(workflow, 'integration_no_ak'),
+        'Use pre-installed Node.js (self-hosted)',
+      ),
     };
     for (const [jobName, call] of Object.entries(nodeCalls)) {
       expect(call, `${jobName} must use the shared Node preflight`).toContain(
@@ -632,6 +689,9 @@ describe('no-AK integration CI wiring', () => {
         'if: "${{ runner.environment == \'self-hosted\' }}"',
       );
     }
+    expect(nodeCalls.integration_no_ak).toContain(
+      "if: \"${{ steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}\"",
+    );
   });
 
   it('keeps the lightweight coverage comment job on the hosted runner', () => {


### PR DESCRIPTION
## What this PR does

The deterministic no-credential integration gate (the 13-file `test:integration:no-ak:sandbox:none` set from #8313) now runs as its own CI job, `Integration Tests (no-AK, No Sandbox)`, instead of as a step buried inside `Test (ubuntu-latest, Node 22.x)`. Everything about the gate itself is unchanged: same runner routing as the Ubuntu gate, same `pull_request` + `merge_group` events, same isolated `HOME`/`QWEN_HOME`, same 26 cleared provider credentials, same `typecheck:integration` before the run, same 20-minute step timeout. The job classifies the CI profile itself with the same wrapper `test` uses, so a docs-only or github-ci-only PR skips it exactly as before without the check queueing behind the hour-long unit run. The pinning tests move with it, and `.size-baseline` records the new file size.

## Why it's needed

A step is invisible to anything that reads check names. On every PR the check list shows `Integration Tests (CLI, No Sandbox)` as skipped (it is merge_group-only), and nothing shows that the no-AK gate ran. The PR review bot reads exactly that list: `presubmit` classifies checks by name and hands the skipped ones to the reviewer, whose rule is to ask whether a skipped check would have exercised the changed files. On #9895 round 15 it ruled that `integration-tests/cli/qwen-serve-routes.test.ts` "was skipped in CI and its suite did not run locally" and capped the verdict at Comment — while the no-AK gate had executed that very file and passed inside `Test (ubuntu-latest)` (run 33147571754). With its own check the fact is in the name, and the same reasoning that produced the false gap now sees a passed integration check to weigh against the skipped one.

#8313 folded the gate into `test` to reuse "the already-required Test check" without touching branch protection. That premise no longer holds as a constraint: `rules/branches/main` today carries `deletion`, `non_fast_forward` and `pull_request` rules and no `required_status_checks`, so the gate is not required by name today either way; what a separate job costs is one extra `npm ci` (the `prepare` hook builds) on the same pool the Ubuntu gate already uses, in parallel with it rather than after it.

## Reviewer Test Plan

### How to verify

- On this PR's own checks: `Integration Tests (no-AK, No Sandbox)` appears as a separate check and passes; `Test (ubuntu-latest, Node 22.x)` no longer has a `Run required no-AK integration gate` step.
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/no-ak-integration-ci.test.js scripts/tests/review-worktree-cleanup-workflow.test.js` — the rewritten placement test pins the job name, `needs: classify_pr`, the `ubuntu_runner` routing, the two-event job condition, the PR-head checkout ref, the shared classifier wrapper and the profile gate on every heavy step, the typecheck-before-run order, the isolated home, all 26 cleared credentials, and that no `secrets.OPENAI_*` reach either job; the guard and Node-preflight tests cover the new job; the cleanup test's byte-identical requirement across `test` / `web_shell_e2e_smoke` / `integration_cli` / `integration_no_ak` holds. (`review-worktree-cleanup-workflow.test.js` imports built `packages/core`; build it first in a fresh worktree.)
- `WORKFLOW_SIZE_BASE_SHA=<base> .github/scripts/check-workflow-size.sh` passes with the bumped baseline (ci.yml 80980 → 91370 bytes; the growth is the inline pre-checkout sweep the cleanup test requires per job).
- `node scripts/lint.js --actionlint`, `--yamllint`, `--shellcheck`, `npx prettier --check .github/workflows/ci.yml`: clean.

### Evidence (Before & After)

Before (#9895 head `12030874e6`): PR check list shows `Integration Tests (CLI, No Sandbox) — skipping` and `Test (ubuntu-latest, Node 22.x) — pass`; the no-AK gate is a green step inside the latter; round-15 review body: "Not reviewed: build-and-test — Integration Tests (CLI, No Sandbox) was skipped in CI and its suite did not run locally (it collects integration-tests/cli/qwen-serve-routes.test.ts, changed by this PR)". After: this PR's check list carries `Integration Tests (no-AK, No Sandbox)` as its own line.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Node 22; `npm run build -w packages/core` for the cleanup test's import; actionlint installed via `node scripts/lint.js --setup`.

## Risk & Scope

- Main risk or tradeoff: one more job per PR and per merge-group candidate on the Ubuntu pool (hosted `ubuntu-latest` for fork PRs): an `npm ci` (which builds through `prepare`) plus the ~1–2 minute gate, running in parallel with `test` instead of inside it. The Ubuntu gate itself gets that time back.
- Not validated / out of scope: the classifier step is duplicated rather than shared as a composite action (a `./` action needs the checkout first; the classifier runs after checkout so it could be one — left for a follow-up so this PR stays a move). The review bot's ruling is still its own; this PR gives it a check whose name states the fact instead of a step it cannot see.
- Breaking changes / migration notes: none for contributors. If a branch rule or merge-queue configuration ever lists required checks by name, `Integration Tests (no-AK, No Sandbox)` is the name to add.

## Linked Issues

Observed on #9895 (round-15 review); relates to #8313, which introduced the gate as a step.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

确定性的无凭证集成门（#8313 引入的 13 文件 `test:integration:no-ak:sandbox:none` 集合）现在作为独立 CI job `Integration Tests (no-AK, No Sandbox)` 运行，而不再是埋在 `Test (ubuntu-latest, Node 22.x)` 里的一个 step。门本身完全不变：与 Ubuntu 门相同的 runner 路由、相同的 `pull_request` + `merge_group` 事件、相同的隔离 `HOME`/`QWEN_HOME`、相同的 26 个被清空的凭证、先 `typecheck:integration` 再运行、step 超时仍为 20 分钟。该 job 用与 `test` 相同的封装脚本自行分类 CI profile，因此 docs-only / github-ci-only 的 PR 照旧跳过它，且不必排在一小时的单元测试之后。钉扎测试随之迁移，`.size-baseline` 记录新的文件大小。

## 为什么需要

step 对任何按 check 名字读取的东西都是不可见的。每个 PR 的 check 列表里 `Integration Tests (CLI, No Sandbox)` 都显示为 skipped（它只在 merge_group 跑），而 no-AK 门跑过这件事没有任何显示。PR 评审 bot 读的正是这个列表：`presubmit` 按名字分类 check，把 skipped 的交给 reviewer，reviewer 的规则是判断被 skip 的 check 是否本会执行改动的文件。在 #9895 第 15 轮，它据此裁定 `integration-tests/cli/qwen-serve-routes.test.ts`"在 CI 中被跳过、本地也未运行"并把结论封顶为 Comment——而 no-AK 门恰恰在 `Test (ubuntu-latest)` 内执行了该文件并通过（run 33147571754）。有了独立 check，事实就写在名字里，同样的推理现在能看到一个通过的集成 check 与被 skip 的那个相权衡。

#8313 把门折进 `test` 是为了复用"已 required 的 Test check"而不改分支保护。这个前提如今已不构成约束：`rules/branches/main` 目前只有 `deletion`、`non_fast_forward`、`pull_request` 规则，没有 `required_status_checks`，所以无论如何该门今天都不是按名字 required 的；拆成独立 job 的代价是在 Ubuntu 门已用的同一 runner 池上多一次 `npm ci`（`prepare` 钩子负责构建），且与 Ubuntu 门并行而非串行。

## Reviewer Test Plan

### 如何验证

- 看本 PR 自身的 checks：`Integration Tests (no-AK, No Sandbox)` 作为独立 check 出现并通过；`Test (ubuntu-latest, Node 22.x)` 不再有 `Run required no-AK integration gate` step。
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/no-ak-integration-ci.test.js scripts/tests/review-worktree-cleanup-workflow.test.js`——改写后的放置测试钉住 job 名、`needs: classify_pr`、`ubuntu_runner` 路由、双事件 job 条件、PR head 检出 ref、共享的分类脚本与每个重步骤上的 profile 门、先 typecheck 后运行的顺序、隔离 home、全部 26 个清空的凭证，以及两个 job 都不接触 `secrets.OPENAI_*`；guard 与 Node 预检测试覆盖新 job；cleanup 测试要求 `test` / `web_shell_e2e_smoke` / `integration_cli` / `integration_no_ak` 四份预检出清理步骤逐字节一致，成立。（`review-worktree-cleanup-workflow.test.js` 会 import 构建后的 `packages/core`，新 worktree 先构建。）
- `WORKFLOW_SIZE_BASE_SHA=<base> .github/scripts/check-workflow-size.sh` 在提升后的基线下通过（ci.yml 80980 → 91370 字节；增长来自 cleanup 测试要求每个 job 内联的预检出清理步骤）。
- `node scripts/lint.js --actionlint`、`--yamllint`、`--shellcheck`、`npx prettier --check .github/workflows/ci.yml`：干净。

### 证据（Before & After）

Before（#9895 head `12030874e6`）：PR check 列表显示 `Integration Tests (CLI, No Sandbox) — skipping` 与 `Test (ubuntu-latest, Node 22.x) — pass`；no-AK 门是后者内部的一个绿色 step；第 15 轮评审正文："Not reviewed: build-and-test — Integration Tests (CLI, No Sandbox) was skipped in CI and its suite did not run locally (it collects integration-tests/cli/qwen-serve-routes.test.ts, changed by this PR)"。After：本 PR 的 check 列表中 `Integration Tests (no-AK, No Sandbox)` 作为独立一行出现。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境（可选）

Node 22；为 cleanup 测试的 import 执行了 `npm run build -w packages/core`；actionlint 经 `node scripts/lint.js --setup` 安装。

## 风险与范围

- 主要风险或权衡：每个 PR 和每个合并队列候选在 Ubuntu 池（fork PR 用托管 `ubuntu-latest`）上多一个 job：一次 `npm ci`（经 `prepare` 构建）加约 1–2 分钟的门，与 `test` 并行而非包含其中。Ubuntu 门本身省回这段时间。
- 未验证 / 超出范围：分类 step 是复制而非抽成 composite action（`./` action 需先检出；分类在检出之后运行，因此可以抽——留给后续 PR，使本 PR 保持为纯移动）。评审 bot 的裁定仍是它自己的事；本 PR 给它的是一个名字即事实的 check，而不是它看不见的 step。
- 破坏性变更 / 迁移说明：对贡献者无。若日后分支规则或合并队列按名字列出 required checks，应添加的名字是 `Integration Tests (no-AK, No Sandbox)`。

## 关联 Issue

在 #9895（第 15 轮评审）上观察到；关联 #8313（将该门引入为 step）。

</details>
