### PR TITLE
feat(web-shell): show git state hints beside branch picker actions

### DIFF
--- a/.qwen/e2e-tests/2026-08-28-webshell-branch-picker-action-hints.md
+++ b/.qwen/e2e-tests/2026-08-28-webshell-branch-picker-action-hints.md
@@ -1,0 +1,47 @@
+# Branch picker action hints
+
+## Scenario
+
+Open a trusted git workspace in the Web Shell (`qwen serve` + the sidebar).
+Click the branch chip on the workspace folder header (or the composer chip /
+Environment panel row) to open the branch picker. Exercise the repo through
+these states between opens:
+
+1. Tracking `origin/main`, in sync, clean tree.
+2. `git reset --hard HEAD~3` (behind 3, clean).
+3. Same as 2 plus an edited tracked file and one new untracked file.
+4. `git checkout -b feat/no-upstream` with one local commit (no upstream).
+5. Start a conflicting `git rebase` and leave it in progress.
+6. `git checkout --detach`.
+
+## Checks
+
+- State 1: Update Project shows "Up to date", Push shows "Nothing to push",
+  Commit shows "No changes"; all three rows are dimmed but still enabled.
+- State 2: Update Project shows "↓3 · origin/main" in the neutral tone.
+- State 3: Update Project shows "↓3 · uncommitted changes" in the warning tone
+  and stays enabled; Commit shows "2 files (1 untracked)".
+- State 4: Update Project shows "No upstream" and is disabled; Push shows
+  "Creates remote branch" and is enabled.
+- State 5: Update Project and Push both show "Rebasing" in the warning tone and
+  are disabled; Commit stays enabled.
+- State 6: Update Project and Push both show "Detached HEAD" and are disabled.
+- After committing through the Commit dialog and reopening the picker, the
+  Commit hint reflects the new tree without waiting for the 60s poll.
+- Switching the UI language to 中文 renders the localized copy
+  ("已是最新", "无上游分支", "↓3 · 有未提交更改", "2 个文件（1 未跟踪）").
+
+## Evidence
+
+Unit coverage lives in
+`packages/web-shell/client/components/BranchPickerPopover.test.tsx`
+(`deriveActionHints` decision table + rendered disabled/tone assertions) and the
+open-time status refresh in
+`packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx`.
+
+```sh
+cd packages/web-shell && npx vitest run \
+  client/components/BranchPickerPopover.test.tsx \
+  client/components/sidebar/WorkspaceSection.test.tsx \
+  client/components/panels/EnvironmentPanel.test.tsx
+```

--- a/.qwen/e2e-tests/2026-08-28-webshell-branch-picker-action-hints.md
+++ b/.qwen/e2e-tests/2026-08-28-webshell-branch-picker-action-hints.md
@@ -13,6 +13,8 @@ these states between opens:
 4. `git checkout -b feat/no-upstream` with one local commit (no upstream).
 5. Start a conflicting `git rebase` and leave it in progress.
 6. `git checkout --detach`.
+7. Start a conflicting `git merge` on a branch with one commit ahead.
+8. Push a branch with `-u`, delete it on the remote, `git fetch --prune`.
 
 ## Checks
 
@@ -20,16 +22,25 @@ these states between opens:
   Commit shows "No changes"; all three rows are dimmed but still enabled.
 - State 2: Update Project shows "↓3 · origin/main" in the neutral tone.
 - State 3: Update Project shows "↓3 · uncommitted changes" in the warning tone
-  and stays enabled; Commit shows "2 files (1 untracked)".
+  and stays enabled; Commit shows "2 changes (1 untracked)" (entries, not
+  files: a partially staged file counts twice).
 - State 4: Update Project shows "No upstream" and is disabled; Push shows
-  "Creates remote branch" and is enabled.
+  "Sets upstream on push" and is enabled.
 - State 5: Update Project and Push both show "Rebasing" in the warning tone and
-  are disabled; Commit stays enabled.
+  are disabled (a rebase detaches HEAD); Commit stays enabled.
 - State 6: Update Project and Push both show "Detached HEAD" and are disabled.
-- After committing through the Commit dialog and reopening the picker, the
-  Commit hint reflects the new tree without waiting for the 60s poll.
+- State 7: Update Project shows "Merging" and is disabled; Push shows "Merging"
+  in the warning tone but stays enabled (a push does not consult the index).
+- State 8: Update Project shows "Upstream gone" and is disabled; Push shows
+  "Sets upstream on push".
+- After committing through the Commit dialog and reopening the picker from
+  any of the three entry points (sidebar chip, composer chip, Environment
+  panel), the Commit hint reflects the new tree without waiting for the poll.
+- With the picker open, run `git branch --unset-upstream` in a terminal and
+  refocus the window: once the chip's status updates, Update Project flips to
+  disabled "No upstream" without reopening.
 - Switching the UI language to 中文 renders the localized copy
-  ("已是最新", "无上游分支", "↓3 · 有未提交更改", "2 个文件（1 未跟踪）").
+  ("已是最新", "无上游分支", "↓3 · 有未提交更改", "2 处更改（1 未跟踪）").
 
 ## Evidence
 

--- a/packages/core/src/utils/git-branches.test.ts
+++ b/packages/core/src/utils/git-branches.test.ts
@@ -141,6 +141,40 @@ describe('gitEnv (R12 env isolation)', () => {
   });
 });
 
+describe('fetchGitBranches upstream tracking', () => {
+  it('marks a branch whose upstream ref was deleted and pruned as gone', async () => {
+    const dir = makeRepo();
+    const remote = makeBareRemote();
+    git(dir, 'remote', 'add', 'origin', remote);
+    git(dir, 'push', '-q', '-u', 'origin', 'master');
+    git(dir, 'checkout', '-q', '-b', 'feat');
+    git(dir, 'push', '-q', '-u', 'origin', 'feat');
+
+    const tracked = (await fetchGitBranches(dir)).local.find(
+      (b) => b.name === 'feat',
+    );
+    expect(tracked?.upstream).toBe('origin/feat');
+    expect(tracked?.upstreamGone).toBeUndefined();
+
+    git(dir, 'push', '-q', 'origin', '--delete', 'feat');
+    git(dir, 'fetch', '-q', '--prune', 'origin');
+
+    const gone = (await fetchGitBranches(dir)).local.find(
+      (b) => b.name === 'feat',
+    );
+    // The configured upstream is still reported so the UI can name it, but
+    // the flag says its ref no longer exists.
+    expect(gone?.upstream).toBe('origin/feat');
+    expect(gone?.upstreamGone).toBe(true);
+    expect(gone?.ahead).toBe(0);
+    expect(gone?.behind).toBe(0);
+    const master = (await fetchGitBranches(dir)).local.find(
+      (b) => b.name === 'master',
+    );
+    expect(master?.upstreamGone).toBeUndefined();
+  });
+});
+
 describe('fetchGitBranches recent branches', () => {
   it('lists recently checked-out branches from the reflog', async () => {
     const dir = makeRepo();

--- a/packages/core/src/utils/git-branches.ts
+++ b/packages/core/src/utils/git-branches.ts
@@ -18,6 +18,12 @@ export interface GitBranchInfo {
   name: string;
   isHead: boolean;
   upstream?: string;
+  /**
+   * `true` when the configured upstream ref no longer exists (git's
+   * `[gone]` tracking state, e.g. after the remote branch was deleted and
+   * pruned). `upstream` still names the configured ref in that case.
+   */
+  upstreamGone?: boolean;
   ahead: number;
   behind: number;
   /** Unix epoch seconds of the branch tip commit. */
@@ -198,11 +204,15 @@ function parseBranchLines(raw: string): GitBranchInfo[] {
         const behindMatch = /behind (\d+)/.exec(track);
         if (aheadMatch) ahead = parseInt(aheadMatch[1], 10);
         if (behindMatch) behind = parseInt(behindMatch[1], 10);
+        // `%(upstream:track,nobracket)` prints `gone` when the upstream is
+        // configured but its ref is missing; ahead/behind are meaningless then.
+        const upstreamGone = upstream !== undefined && /\bgone\b/.test(track);
 
         return {
           name,
           isHead,
           upstream,
+          ...(upstreamGone ? { upstreamGone } : {}),
           ahead,
           behind,
           commitDate,

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -303,6 +303,8 @@ export interface DaemonGitBranchInfo {
   name: string;
   isHead: boolean;
   upstream?: string;
+  /** The configured upstream ref no longer exists (git's `[gone]` state). */
+  upstreamGone?: boolean;
   ahead: number;
   behind: number;
   /** Unix epoch seconds of the branch tip commit. */

--- a/packages/web-shell/client/components/BranchPickerPopover.module.css
+++ b/packages/web-shell/client/components/BranchPickerPopover.module.css
@@ -265,3 +265,27 @@
   font-size: 12px;
   color: var(--muted-foreground, #888);
 }
+
+.actionItemMuted .actionLabel {
+  color: var(--muted-foreground, #888);
+}
+
+.actionHint {
+  flex-shrink: 0;
+  max-width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-foreground, #888);
+}
+
+.actionHint[data-tone='info'] {
+  color: var(--foreground, #e0e0e0);
+  opacity: 0.8;
+}
+
+.actionHint[data-tone='warning'] {
+  color: var(--warning-color, #f59e0b);
+}

--- a/packages/web-shell/client/components/BranchPickerPopover.test.tsx
+++ b/packages/web-shell/client/components/BranchPickerPopover.test.tsx
@@ -8,6 +8,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import type {
+  DaemonGitBranchesResult,
+  DaemonWorkspaceGitStatus,
+} from '@qwen-code/sdk/daemon';
 
 // The real popover shell is Radix, whose focus/scroll-lock effects never
 // settle under `act` in jsdom. Render the trigger and content inline instead
@@ -59,7 +63,9 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
 });
 
 const { I18nProvider } = await import('../i18n');
-const { BranchPickerPopover } = await import('./BranchPickerPopover');
+const { BranchPickerPopover, deriveActionHints } = await import(
+  './BranchPickerPopover'
+);
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -77,6 +83,8 @@ function mount(
     onOpenDiff: () => void;
     onOpenCommit: () => void;
     onOpenChange: (open: boolean) => void;
+    onRefreshStatus: () => void;
+    status: DaemonWorkspaceGitStatus;
   }> = {},
 ): void {
   act(() => {
@@ -86,6 +94,8 @@ function mount(
           open
           onOpenChange={overrides.onOpenChange ?? vi.fn()}
           workspaceCwd="/repo"
+          status={overrides.status}
+          onRefreshStatus={overrides.onRefreshStatus}
           onOpenDiff={overrides.onOpenDiff}
           onOpenCommit={overrides.onOpenCommit}
         >
@@ -213,5 +223,312 @@ describe('BranchPickerPopover actions', () => {
 
     expect(document.body.textContent).toContain('Invalid branch name');
     expect(workspaceGitCreateBranch).not.toHaveBeenCalled();
+  });
+});
+
+// Identity translator: hints assert on keys / interpolated vars, not copy.
+const tKey = (key: string, vars?: Record<string, string | number>) =>
+  vars ? `${key}:${JSON.stringify(vars)}` : key;
+
+function branches(
+  head: Partial<DaemonGitBranchesResult['local'][number]> = {},
+  detached = false,
+): DaemonGitBranchesResult {
+  return {
+    v: 1,
+    workspaceCwd: '/repo',
+    available: true,
+    local: [
+      {
+        name: 'main',
+        isHead: true,
+        ahead: 0,
+        behind: 0,
+        commitDate: 0,
+        commitSubject: '',
+        ...head,
+      },
+    ],
+    remote: [],
+    tags: [],
+    recent: [],
+    head: 'main',
+    detached,
+  };
+}
+
+function status(
+  over: Partial<DaemonWorkspaceGitStatus> = {},
+): DaemonWorkspaceGitStatus {
+  return {
+    v: 2,
+    workspaceCwd: '/repo',
+    branch: 'main',
+    computedAt: 1,
+    staged: 0,
+    unstaged: 0,
+    untracked: 0,
+    conflicted: 0,
+    ...over,
+  };
+}
+
+describe('deriveActionHints', () => {
+  it('dims pull/push/commit when tracking upstream, in sync, and clean', () => {
+    const h = deriveActionHints(
+      tKey,
+      branches({ upstream: 'origin/main' }),
+      status(),
+    );
+    expect(h.pull).toEqual({
+      text: 'branchPicker.hint.upToDate',
+      tone: 'muted',
+    });
+    expect(h.pullDisabled).toBe(false);
+    expect(h.push).toEqual({
+      text: 'branchPicker.hint.nothingToPush',
+      tone: 'muted',
+    });
+    expect(h.pushDisabled).toBe(false);
+    expect(h.commit).toEqual({
+      text: 'branchPicker.hint.noChanges',
+      tone: 'muted',
+    });
+  });
+
+  it('shows behind count with upstream for a clean tree', () => {
+    const h = deriveActionHints(
+      tKey,
+      branches({ upstream: 'origin/main', behind: 3 }),
+      status(),
+    );
+    expect(h.pull).toEqual({ text: '↓3 · origin/main', tone: 'info' });
+    expect(h.pullDisabled).toBe(false);
+  });
+
+  it('warns on pull when behind with uncommitted changes', () => {
+    const h = deriveActionHints(
+      tKey,
+      branches({ upstream: 'origin/main', behind: 2 }),
+      status({ unstaged: 1 }),
+    );
+    expect(h.pull).toEqual({
+      text: 'branchPicker.hint.behindDirty:{"count":2}',
+      tone: 'warning',
+    });
+    expect(h.pullDisabled).toBe(false);
+  });
+
+  it('disables pull and announces upstream creation on push without upstream', () => {
+    const h = deriveActionHints(tKey, branches({ ahead: 1 }), status());
+    expect(h.pull).toEqual({
+      text: 'branchPicker.hint.noUpstream',
+      tone: 'muted',
+    });
+    expect(h.pullDisabled).toBe(true);
+    expect(h.push).toEqual({
+      text: 'branchPicker.hint.willCreateUpstream',
+      tone: 'info',
+    });
+    expect(h.pushDisabled).toBe(false);
+  });
+
+  it('shows ahead count on push and warns when also behind', () => {
+    expect(
+      deriveActionHints(
+        tKey,
+        branches({ upstream: 'origin/main', ahead: 2 }),
+        status(),
+      ).push,
+    ).toEqual({ text: '↑2', tone: 'info' });
+    expect(
+      deriveActionHints(
+        tKey,
+        branches({ upstream: 'origin/main', ahead: 2, behind: 1 }),
+        status(),
+      ).push,
+    ).toEqual({
+      text: 'branchPicker.hint.aheadBehind:{"ahead":2,"behind":1}',
+      tone: 'warning',
+    });
+  });
+
+  it('counts all changed files for commit and calls out untracked ones', () => {
+    expect(
+      deriveActionHints(
+        tKey,
+        branches({ upstream: 'origin/main' }),
+        status({ staged: 1, unstaged: 2 }),
+      ).commit,
+    ).toEqual({
+      text: 'branchPicker.hint.changedFiles:{"count":3}',
+      tone: 'info',
+    });
+    expect(
+      deriveActionHints(
+        tKey,
+        branches({ upstream: 'origin/main' }),
+        status({ staged: 1, unstaged: 2, untracked: 2 }),
+      ).commit,
+    ).toEqual({
+      text: 'branchPicker.hint.changedFilesUntracked:{"count":5,"untracked":2}',
+      tone: 'info',
+    });
+  });
+
+  it('blocks pull and push during an in-progress operation, conflicts, or detached HEAD', () => {
+    const op = deriveActionHints(
+      tKey,
+      branches({ upstream: 'origin/main', behind: 1 }),
+      status({ operation: 'rebase' }),
+    );
+    expect(op.pull).toEqual({ text: 'git.operation.rebase', tone: 'warning' });
+    expect(op.pullDisabled).toBe(true);
+    expect(op.pushDisabled).toBe(true);
+
+    const conflict = deriveActionHints(
+      tKey,
+      branches({ upstream: 'origin/main' }),
+      status({ conflicted: 2 }),
+    );
+    expect(conflict.pull).toEqual({
+      text: 'git.conflicted:{"count":2}',
+      tone: 'warning',
+    });
+    expect(conflict.pullDisabled).toBe(true);
+    expect(conflict.pushDisabled).toBe(true);
+    // Conflicted entries still count as uncommitted work for the commit hint.
+    expect(conflict.commit?.text).toBe(
+      'branchPicker.hint.changedFiles:{"count":2}',
+    );
+
+    const detached = deriveActionHints(tKey, branches({}, true), status());
+    expect(detached.pull).toEqual({ text: 'git.detached', tone: 'warning' });
+    expect(detached.pullDisabled).toBe(true);
+    expect(detached.pushDisabled).toBe(true);
+  });
+
+  it('prefers the freshly fetched branch listing over the polled status for ahead/behind', () => {
+    const h = deriveActionHints(
+      tKey,
+      branches({ upstream: 'origin/main', behind: 0 }),
+      status({ hasUpstream: true, behind: 4 }),
+    );
+    expect(h.pull?.text).toBe('branchPicker.hint.upToDate');
+  });
+
+  it('falls back to status for ahead/behind when the listing has no head entry', () => {
+    const noHead: DaemonGitBranchesResult = { ...branches(), local: [] };
+    const h = deriveActionHints(
+      tKey,
+      noHead,
+      status({ hasUpstream: true, behind: 4 }),
+    );
+    expect(h.pull?.text).toBe('↓4');
+  });
+
+  it('shows no hints at all when neither source is known', () => {
+    const noHead: DaemonGitBranchesResult = { ...branches(), local: [] };
+    const h = deriveActionHints(tKey, noHead, undefined);
+    expect(h).toEqual({ pullDisabled: false, pushDisabled: false });
+  });
+
+  it('omits the commit hint on a v1 status without a computed tree summary', () => {
+    const h = deriveActionHints(tKey, branches({ upstream: 'origin/main' }), {
+      v: 1,
+      workspaceCwd: '/repo',
+      branch: 'main',
+    });
+    expect(h.commit).toBeUndefined();
+    expect(h.pull?.text).toBe('branchPicker.hint.upToDate');
+  });
+});
+
+describe('BranchPickerPopover action hints', () => {
+  function setup(): void {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  }
+
+  it('renders hints beside the actions and disables pull without upstream', async () => {
+    workspaceGitBranches.mockResolvedValue(branches({ ahead: 1 }));
+    setup();
+    mount({ onOpenCommit: vi.fn(), status: status({ unstaged: 2 }) });
+    await flush();
+
+    const pull = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-pull"]',
+    );
+    expect(pull?.disabled).toBe(true);
+    expect(pull?.textContent).toContain('No upstream');
+
+    const commit = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-commit"]',
+    );
+    expect(commit?.disabled).toBe(false);
+    expect(commit?.textContent).toContain('2 files');
+
+    const push = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-push"]',
+    );
+    expect(push?.disabled).toBe(false);
+    expect(push?.textContent).toContain('Creates remote branch');
+  });
+
+  it('warns on pull when behind with uncommitted changes and keeps it enabled', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main', behind: 3 }),
+    );
+    setup();
+    mount({ status: status({ untracked: 1 }) });
+    await flush();
+
+    const pull = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-pull"]',
+    );
+    expect(pull?.disabled).toBe(false);
+    const hint = pull?.querySelector(
+      '[data-testid="branch-picker-action-hint"]',
+    );
+    expect(hint?.getAttribute('data-tone')).toBe('warning');
+    expect(hint?.textContent).toBe('↓3 · uncommitted changes');
+  });
+
+  it('disables pull and push while a rebase is in progress', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main', behind: 1 }),
+    );
+    setup();
+    mount({ status: status({ operation: 'rebase', conflicted: 1 }) });
+    await flush();
+
+    for (const id of ['branch-picker-pull', 'branch-picker-push']) {
+      const btn = document.body.querySelector<HTMLButtonElement>(
+        `[data-testid="${id}"]`,
+      );
+      expect(btn?.disabled).toBe(true);
+      expect(btn?.textContent).toContain('Rebasing');
+    }
+  });
+
+  it('asks the caller to refresh status once when opened, even with an inline callback', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main' }),
+    );
+    setup();
+    const onRefreshStatus = vi.fn();
+    mount({ onRefreshStatus, status: status() });
+    await flush();
+    // Re-render with a new callback identity and new status, as a parent
+    // whose refresh handler calls setState would.
+    mount({
+      onRefreshStatus: () => onRefreshStatus(),
+      status: status({ unstaged: 1 }),
+    });
+    await flush();
+
+    expect(onRefreshStatus).toHaveBeenCalledTimes(1);
+    expect(workspaceGitBranches).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web-shell/client/components/BranchPickerPopover.test.tsx
+++ b/packages/web-shell/client/components/BranchPickerPopover.test.tsx
@@ -28,27 +28,38 @@ vi.mock('./ui/popover', async () => {
   };
 });
 
-const { workspaceGitBranches, workspaceGitCreateBranch, workspaceClient } =
-  vi.hoisted(() => {
-    const workspaceGitBranches = vi.fn();
-    const workspaceGitCreateBranch = vi.fn();
-    // A stable client so the popover's memoized workspace handle (and thus its
-    // fetch effect) stays referentially stable across renders.
-    const workspaceClient = {
-      workspaceByCwd: () => ({
-        workspaceGitBranches,
-        workspaceGitCheckout: vi.fn().mockResolvedValue(undefined),
-        workspaceGitCreateBranch,
-        workspaceGitPush: vi
-          .fn()
-          .mockResolvedValue({ success: true, output: '' }),
-        workspaceGitPull: vi
-          .fn()
-          .mockResolvedValue({ success: true, output: '' }),
-      }),
-    };
-    return { workspaceGitBranches, workspaceGitCreateBranch, workspaceClient };
-  });
+const {
+  workspaceGitBranches,
+  workspaceGitCreateBranch,
+  workspaceGit,
+  workspaceClient,
+} = vi.hoisted(() => {
+  const workspaceGitBranches = vi.fn();
+  const workspaceGitCreateBranch = vi.fn();
+  const workspaceGit = vi.fn();
+  // A stable client so the popover's memoized workspace handle (and thus its
+  // fetch effect) stays referentially stable across renders.
+  const workspaceClient = {
+    workspaceByCwd: () => ({
+      workspaceGitBranches,
+      workspaceGit,
+      workspaceGitCheckout: vi.fn().mockResolvedValue(undefined),
+      workspaceGitCreateBranch,
+      workspaceGitPush: vi
+        .fn()
+        .mockResolvedValue({ success: true, output: '' }),
+      workspaceGitPull: vi
+        .fn()
+        .mockResolvedValue({ success: true, output: '' }),
+    }),
+  };
+  return {
+    workspaceGitBranches,
+    workspaceGitCreateBranch,
+    workspaceGit,
+    workspaceClient,
+  };
+});
 
 vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
   const actual =
@@ -63,9 +74,8 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
 });
 
 const { I18nProvider } = await import('../i18n');
-const { BranchPickerPopover, deriveActionHints } = await import(
-  './BranchPickerPopover'
-);
+const { BranchPickerPopover, deriveActionHints, listingContradictsStatus } =
+  await import('./BranchPickerPopover');
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -83,7 +93,7 @@ function mount(
     onOpenDiff: () => void;
     onOpenCommit: () => void;
     onOpenChange: (open: boolean) => void;
-    onRefreshStatus: () => void;
+    onStatusRefreshed: (status: DaemonWorkspaceGitStatus) => void;
     status: DaemonWorkspaceGitStatus;
   }> = {},
 ): void {
@@ -95,7 +105,7 @@ function mount(
           onOpenChange={overrides.onOpenChange ?? vi.fn()}
           workspaceCwd="/repo"
           status={overrides.status}
-          onRefreshStatus={overrides.onRefreshStatus}
+          onStatusRefreshed={overrides.onStatusRefreshed}
           onOpenDiff={overrides.onOpenDiff}
           onOpenCommit={overrides.onOpenCommit}
         >
@@ -120,7 +130,11 @@ afterEach(() => {
   act(() => root.unmount());
   container.remove();
   vi.clearAllMocks();
+  // Default: the popover's own status fetch yields nothing, so hints derive
+  // from the caller's `status` prop alone unless a test resolves it.
+  workspaceGit.mockRejectedValue(new Error('no status'));
 });
+workspaceGit.mockRejectedValue(new Error('no status'));
 
 describe('BranchPickerPopover actions', () => {
   it('wires "View Changes" to onOpenDiff and closes', async () => {
@@ -319,7 +333,7 @@ describe('deriveActionHints', () => {
     expect(h.pullDisabled).toBe(false);
   });
 
-  it('disables pull and announces upstream creation on push without upstream', () => {
+  it('disables pull without upstream and says push will set one', () => {
     const h = deriveActionHints(tKey, branches({ ahead: 1 }), status());
     expect(h.pull).toEqual({
       text: 'branchPicker.hint.noUpstream',
@@ -327,7 +341,25 @@ describe('deriveActionHints', () => {
     });
     expect(h.pullDisabled).toBe(true);
     expect(h.push).toEqual({
-      text: 'branchPicker.hint.willCreateUpstream',
+      text: 'branchPicker.hint.setsUpstream',
+      tone: 'info',
+    });
+    expect(h.pushDisabled).toBe(false);
+  });
+
+  it('treats a gone upstream like no upstream, with its own copy on pull', () => {
+    const h = deriveActionHints(
+      tKey,
+      branches({ upstream: 'origin/feat', upstreamGone: true, ahead: 0 }),
+      status({ hasUpstream: true }),
+    );
+    expect(h.pull).toEqual({
+      text: 'branchPicker.hint.upstreamGone',
+      tone: 'muted',
+    });
+    expect(h.pullDisabled).toBe(true);
+    expect(h.push).toEqual({
+      text: 'branchPicker.hint.setsUpstream',
       tone: 'info',
     });
     expect(h.pushDisabled).toBe(false);
@@ -353,7 +385,7 @@ describe('deriveActionHints', () => {
     });
   });
 
-  it('counts all changed files for commit and calls out untracked ones', () => {
+  it('counts changes (entries, not files) for commit and calls out untracked ones', () => {
     expect(
       deriveActionHints(
         tKey,
@@ -361,7 +393,7 @@ describe('deriveActionHints', () => {
         status({ staged: 1, unstaged: 2 }),
       ).commit,
     ).toEqual({
-      text: 'branchPicker.hint.changedFiles:{"count":3}',
+      text: 'branchPicker.hint.changes:{"count":3}',
       tone: 'info',
     });
     expect(
@@ -371,20 +403,32 @@ describe('deriveActionHints', () => {
         status({ staged: 1, unstaged: 2, untracked: 2 }),
       ).commit,
     ).toEqual({
-      text: 'branchPicker.hint.changedFilesUntracked:{"count":5,"untracked":2}',
+      text: 'branchPicker.hint.changesUntracked:{"count":5,"untracked":2}',
       tone: 'info',
     });
+    // A partially staged file (porcelain `MM`) is one file but two entries;
+    // the copy must not call it "2 files".
+    expect(
+      deriveActionHints(
+        tKey,
+        branches({ upstream: 'origin/main' }),
+        status({ staged: 1, unstaged: 1 }),
+      ).commit?.text,
+    ).toBe('branchPicker.hint.changes:{"count":2}');
   });
 
-  it('blocks pull and push during an in-progress operation, conflicts, or detached HEAD', () => {
+  it('blocks pull during an in-progress operation or conflicts but only warns on push', () => {
+    // `git pull` refuses both states; `git push` does not consult the index,
+    // so the push row stays clickable with the same warning.
     const op = deriveActionHints(
       tKey,
       branches({ upstream: 'origin/main', behind: 1 }),
-      status({ operation: 'rebase' }),
+      status({ operation: 'merge' }),
     );
-    expect(op.pull).toEqual({ text: 'git.operation.rebase', tone: 'warning' });
+    expect(op.pull).toEqual({ text: 'git.operation.merge', tone: 'warning' });
     expect(op.pullDisabled).toBe(true);
-    expect(op.pushDisabled).toBe(true);
+    expect(op.push).toEqual({ text: 'git.operation.merge', tone: 'warning' });
+    expect(op.pushDisabled).toBe(false);
 
     const conflict = deriveActionHints(
       tKey,
@@ -396,16 +440,31 @@ describe('deriveActionHints', () => {
       tone: 'warning',
     });
     expect(conflict.pullDisabled).toBe(true);
-    expect(conflict.pushDisabled).toBe(true);
+    expect(conflict.pushDisabled).toBe(false);
     // Conflicted entries still count as uncommitted work for the commit hint.
-    expect(conflict.commit?.text).toBe(
-      'branchPicker.hint.changedFiles:{"count":2}',
-    );
+    expect(conflict.commit?.text).toBe('branchPicker.hint.changes:{"count":2}');
+  });
 
+  it('blocks both pull and push on a detached HEAD, naming the operation when there is one', () => {
     const detached = deriveActionHints(tKey, branches({}, true), status());
     expect(detached.pull).toEqual({ text: 'git.detached', tone: 'warning' });
     expect(detached.pullDisabled).toBe(true);
+    expect(detached.push).toEqual({ text: 'git.detached', tone: 'warning' });
     expect(detached.pushDisabled).toBe(true);
+
+    // A rebase detaches HEAD: push is blocked for that reason, but the row
+    // says "Rebasing" since that is what the user is in the middle of.
+    const rebase = deriveActionHints(
+      tKey,
+      branches({}, true),
+      status({ operation: 'rebase', detached: true }),
+    );
+    expect(rebase.push).toEqual({
+      text: 'git.operation.rebase',
+      tone: 'warning',
+    });
+    expect(rebase.pushDisabled).toBe(true);
+    expect(rebase.pullDisabled).toBe(true);
   });
 
   it('prefers the freshly fetched branch listing over the polled status for ahead/behind', () => {
@@ -463,17 +522,67 @@ describe('BranchPickerPopover action hints', () => {
     expect(pull?.disabled).toBe(true);
     expect(pull?.textContent).toContain('No upstream');
 
+    // The pull row is dimmed, not just disabled: both the class hook the
+    // stylesheet keys on and the tone attribute must be present.
+    expect(pull?.className).toMatch(/actionItemMuted/);
+    expect(
+      pull
+        ?.querySelector('[data-testid="branch-picker-action-hint"]')
+        ?.getAttribute('data-tone'),
+    ).toBe('muted');
+
     const commit = document.body.querySelector<HTMLButtonElement>(
       '[data-testid="branch-picker-commit"]',
     );
     expect(commit?.disabled).toBe(false);
-    expect(commit?.textContent).toContain('2 files');
+    expect(commit?.textContent).toContain('2 changes');
+    expect(commit?.className).not.toMatch(/actionItemMuted/);
 
     const push = document.body.querySelector<HTMLButtonElement>(
       '[data-testid="branch-picker-push"]',
     );
     expect(push?.disabled).toBe(false);
-    expect(push?.textContent).toContain('Creates remote branch');
+    expect(push?.textContent).toContain('Sets upstream on push');
+    expect(push?.className).not.toMatch(/actionItemMuted/);
+  });
+
+  it('dims every row on an in-sync clean tree', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main' }),
+    );
+    setup();
+    mount({ onOpenCommit: vi.fn(), status: status() });
+    await flush();
+
+    for (const id of [
+      'branch-picker-pull',
+      'branch-picker-commit',
+      'branch-picker-push',
+    ]) {
+      const btn = document.body.querySelector<HTMLButtonElement>(
+        `[data-testid="${id}"]`,
+      );
+      expect(btn?.disabled).toBe(false);
+      expect(btn?.className).toMatch(/actionItemMuted/);
+    }
+  });
+
+  it('words a partially staged file as changes, not files', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main' }),
+    );
+    setup();
+    mount({
+      onOpenCommit: vi.fn(),
+      status: status({ staged: 1, unstaged: 1 }),
+    });
+    await flush();
+
+    const commit = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-commit"]',
+    );
+    expect(commit?.textContent).toContain('2 changes');
+    expect(commit?.textContent).not.toContain('files');
   });
 
   it('warns on pull when behind with uncommitted changes and keeps it enabled', async () => {
@@ -495,12 +604,14 @@ describe('BranchPickerPopover action hints', () => {
     expect(hint?.textContent).toBe('↓3 · uncommitted changes');
   });
 
-  it('disables pull and push while a rebase is in progress', async () => {
+  it('disables pull and push while a rebase (detached HEAD) is in progress', async () => {
     workspaceGitBranches.mockResolvedValue(
-      branches({ upstream: 'origin/main', behind: 1 }),
+      branches({ upstream: 'origin/main', behind: 1 }, true),
     );
     setup();
-    mount({ status: status({ operation: 'rebase', conflicted: 1 }) });
+    mount({
+      status: status({ operation: 'rebase', detached: true, conflicted: 1 }),
+    });
     await flush();
 
     for (const id of ['branch-picker-pull', 'branch-picker-push']) {
@@ -512,23 +623,173 @@ describe('BranchPickerPopover action hints', () => {
     }
   });
 
-  it('asks the caller to refresh status once when opened, even with an inline callback', async () => {
+  it('keeps push clickable during a conflicted merge on a branch', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main', ahead: 1 }),
+    );
+    setup();
+    mount({ status: status({ operation: 'merge', conflicted: 1 }) });
+    await flush();
+
+    const pull = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-pull"]',
+    );
+    const push = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-push"]',
+    );
+    expect(pull?.disabled).toBe(true);
+    expect(push?.disabled).toBe(false);
+    expect(
+      push
+        ?.querySelector('[data-testid="branch-picker-action-hint"]')
+        ?.getAttribute('data-tone'),
+    ).toBe('warning');
+    expect(push?.textContent).toContain('Merging');
+  });
+
+  it('fetches its own status once on open, reports it, and prefers it over an older prop', async () => {
     workspaceGitBranches.mockResolvedValue(
       branches({ upstream: 'origin/main' }),
     );
+    // The caller's snapshot says clean; the daemon now says otherwise.
+    workspaceGit.mockResolvedValue(status({ unstaged: 3, computedAt: 200 }));
     setup();
-    const onRefreshStatus = vi.fn();
-    mount({ onRefreshStatus, status: status() });
-    await flush();
-    // Re-render with a new callback identity and new status, as a parent
-    // whose refresh handler calls setState would.
+    const onStatusRefreshed = vi.fn();
+    const onOpenCommit = vi.fn();
     mount({
-      onRefreshStatus: () => onRefreshStatus(),
-      status: status({ unstaged: 1 }),
+      onOpenCommit,
+      onStatusRefreshed,
+      status: status({ computedAt: 100 }),
+    });
+    await flush();
+    // Re-render with a new callback identity, as a parent whose handler
+    // calls setState would; the open effect must not re-arm.
+    mount({
+      onOpenCommit,
+      onStatusRefreshed: (s) => onStatusRefreshed(s),
+      status: status({ computedAt: 100 }),
     });
     await flush();
 
-    expect(onRefreshStatus).toHaveBeenCalledTimes(1);
+    expect(workspaceGit).toHaveBeenCalledTimes(1);
+    expect(workspaceGit).toHaveBeenCalledWith({ wait: true });
+    expect(onStatusRefreshed).toHaveBeenCalledTimes(1);
+    expect(onStatusRefreshed.mock.calls[0]?.[0]).toMatchObject({
+      unstaged: 3,
+    });
     expect(workspaceGitBranches).toHaveBeenCalledTimes(1);
+    const commit = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-commit"]',
+    );
+    expect(commit?.textContent).toContain('3 changes');
+  });
+
+  it('reads status through the worktree cwd when one is given', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main' }),
+    );
+    workspaceGit.mockResolvedValue(status());
+    setup();
+    act(() => {
+      root.render(
+        <I18nProvider language="en">
+          <BranchPickerPopover
+            open
+            onOpenChange={vi.fn()}
+            workspaceCwd="/repo"
+            gitCwd="/repo/.qwen/worktrees/wt"
+          >
+            <button type="button">trigger</button>
+          </BranchPickerPopover>
+        </I18nProvider>,
+      );
+    });
+    await flush();
+    expect(workspaceGit).toHaveBeenCalledWith({
+      cwd: '/repo/.qwen/worktrees/wt',
+    });
+  });
+
+  it('re-fetches the listing when a newer status contradicts it, once per status', async () => {
+    // Listing on open: tracking origin/main. Then the terminal runs
+    // `git branch --unset-upstream` and a newer status arrives while the
+    // popover is still open; the second listing fetch reflects that.
+    workspaceGitBranches
+      .mockResolvedValueOnce(branches({ upstream: 'origin/main' }))
+      .mockResolvedValue(branches({}));
+    setup();
+    mount({ status: status({ hasUpstream: true, computedAt: 1 }) });
+    await flush();
+    expect(workspaceGitBranches).toHaveBeenCalledTimes(1);
+    expect(
+      document.body.querySelector<HTMLButtonElement>(
+        '[data-testid="branch-picker-pull"]',
+      )?.disabled,
+    ).toBe(false);
+
+    mount({
+      status: status({ hasUpstream: false, computedAt: Date.now() + 60_000 }),
+    });
+    await flush();
+    expect(workspaceGitBranches).toHaveBeenCalledTimes(2);
+    const pull = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="branch-picker-pull"]',
+    );
+    expect(pull?.disabled).toBe(true);
+    expect(pull?.textContent).toContain('No upstream');
+
+    // The same status arriving again must not fetch again.
+    mount({
+      status: status({ hasUpstream: false, computedAt: Date.now() + 60_000 }),
+    });
+    await flush();
+    expect(workspaceGitBranches).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves the listing alone when the newer status agrees with it', async () => {
+    workspaceGitBranches.mockResolvedValue(
+      branches({ upstream: 'origin/main', ahead: 2 }),
+    );
+    setup();
+    mount({ status: status({ computedAt: 1 }) });
+    await flush();
+    mount({
+      status: status({
+        hasUpstream: true,
+        ahead: 2,
+        behind: 0,
+        computedAt: Date.now() + 60_000,
+      }),
+    });
+    await flush();
+    expect(workspaceGitBranches).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('listingContradictsStatus', () => {
+  it('flags upstream, detached, and ahead/behind disagreements only', () => {
+    const listing = branches({ upstream: 'origin/main', ahead: 1 });
+    expect(listingContradictsStatus(listing, status())).toBe(false);
+    expect(
+      listingContradictsStatus(listing, status({ hasUpstream: false })),
+    ).toBe(true);
+    expect(listingContradictsStatus(listing, status({ detached: true }))).toBe(
+      true,
+    );
+    expect(listingContradictsStatus(listing, status({ ahead: 2 }))).toBe(true);
+    expect(listingContradictsStatus(listing, status({ behind: 1 }))).toBe(true);
+    // Tree counters are not the listing's business.
+    expect(
+      listingContradictsStatus(listing, status({ unstaged: 5, staged: 2 })),
+    ).toBe(false);
+    // The status cannot express a gone upstream (it still reports tracking),
+    // so a gone listing entry never disagrees on the upstream axis.
+    const gone = branches({ upstream: 'origin/feat', upstreamGone: true });
+    expect(listingContradictsStatus(gone, status({ hasUpstream: true }))).toBe(
+      false,
+    );
+    expect(listingContradictsStatus(gone, status({ hasUpstream: false }))).toBe(
+      false,
+    );
   });
 });

--- a/packages/web-shell/client/components/BranchPickerPopover.tsx
+++ b/packages/web-shell/client/components/BranchPickerPopover.tsx
@@ -9,6 +9,7 @@ import { useWorkspace } from '@qwen-code/webui/daemon-react-sdk';
 import type {
   DaemonGitBranchesResult,
   DaemonGitBranchInfo,
+  DaemonWorkspaceGitStatus,
 } from '@qwen-code/sdk/daemon';
 import {
   ArrowDownToLineIcon,
@@ -36,12 +37,140 @@ interface BranchPickerPopoverProps {
   gitCwd?: string;
   side?: 'top' | 'right' | 'bottom' | 'left';
   onBranchChanged?: () => void;
+  /**
+   * Live working-tree summary from the trigger chip. Drives the hints beside
+   * the Update / Commit / Push actions (dirty counts, in-progress operation);
+   * ahead/behind/upstream prefer the branch listing fetched on open, which is
+   * fresher than the chip's polled snapshot.
+   */
+  status?: DaemonWorkspaceGitStatus;
+  /** Invoked when the popover opens so the caller can refresh `status`. */
+  onRefreshStatus?: () => void;
   onOpenDiff?: () => void;
   onOpenCommit?: () => void;
   children: React.ReactNode;
 }
 
 type SectionKey = 'recent' | 'local' | 'remote' | 'tags';
+
+type HintTone = 'muted' | 'info' | 'warning';
+
+interface ActionHint {
+  text: string;
+  tone: HintTone;
+}
+
+interface ActionHints {
+  pull?: ActionHint;
+  pullDisabled: boolean;
+  commit?: ActionHint;
+  push?: ActionHint;
+  pushDisabled: boolean;
+}
+
+type TranslateFn = ReturnType<typeof useI18n>['t'];
+
+/**
+ * Derive the per-action hints shown beside Update / Commit / Push so the user
+ * can judge before clicking. Hard blockers (in-progress merge/rebase,
+ * conflicts, detached HEAD, pull without upstream) disable the action because
+ * the daemon would reject it anyway; soft states (up to date, nothing to push,
+ * clean tree) only dim the row since the action is still harmless.
+ *
+ * Exported for tests.
+ */
+export function deriveActionHints(
+  t: TranslateFn,
+  data: DaemonGitBranchesResult | null,
+  status: DaemonWorkspaceGitStatus | undefined,
+): ActionHints {
+  const head = data?.local.find((b) => b.isHead);
+  const detached = data?.detached ?? status?.detached ?? false;
+  const operation = status?.operation;
+  const conflicted = status?.conflicted ?? 0;
+  // The branch listing is fetched on open, so it wins over the polled status.
+  const ahead = head?.ahead ?? status?.ahead ?? 0;
+  const behind = head?.behind ?? status?.behind ?? 0;
+  const upstream = head?.upstream;
+  const hasUpstream: boolean | undefined = head
+    ? Boolean(head.upstream)
+    : status?.hasUpstream;
+  // Dirty counts only exist on v2 status; `computedAt` marks that the enriched
+  // fields were actually computed rather than defaulted.
+  const hasTreeSummary = status?.computedAt !== undefined;
+  const staged = status?.staged ?? 0;
+  const unstaged = status?.unstaged ?? 0;
+  const untracked = status?.untracked ?? 0;
+  const changed = staged + unstaged + untracked + conflicted;
+
+  const blocker: ActionHint | undefined = operation
+    ? { text: t(`git.operation.${operation}`), tone: 'warning' }
+    : conflicted > 0
+      ? { text: t('git.conflicted', { count: conflicted }), tone: 'warning' }
+      : detached
+        ? { text: t('git.detached'), tone: 'warning' }
+        : undefined;
+
+  let pull: ActionHint | undefined;
+  let pullDisabled = false;
+  if (blocker) {
+    pull = blocker;
+    pullDisabled = true;
+  } else if (hasUpstream === false) {
+    pull = { text: t('branchPicker.hint.noUpstream'), tone: 'muted' };
+    pullDisabled = true;
+  } else if (behind > 0) {
+    pull =
+      changed > 0
+        ? {
+            text: t('branchPicker.hint.behindDirty', { count: behind }),
+            tone: 'warning',
+          }
+        : {
+            text: upstream ? `↓${behind} · ${upstream}` : `↓${behind}`,
+            tone: 'info',
+          };
+  } else if (hasUpstream) {
+    pull = { text: t('branchPicker.hint.upToDate'), tone: 'muted' };
+  }
+
+  let push: ActionHint | undefined;
+  let pushDisabled = false;
+  if (blocker) {
+    push = blocker;
+    pushDisabled = true;
+  } else if (hasUpstream === false) {
+    push = { text: t('branchPicker.hint.willCreateUpstream'), tone: 'info' };
+  } else if (ahead > 0 && behind > 0) {
+    push = {
+      text: t('branchPicker.hint.aheadBehind', { ahead, behind }),
+      tone: 'warning',
+    };
+  } else if (ahead > 0) {
+    push = { text: `↑${ahead}`, tone: 'info' };
+  } else if (hasUpstream) {
+    push = { text: t('branchPicker.hint.nothingToPush'), tone: 'muted' };
+  }
+
+  let commit: ActionHint | undefined;
+  if (hasTreeSummary) {
+    commit =
+      changed > 0
+        ? {
+            text:
+              untracked > 0
+                ? t('branchPicker.hint.changedFilesUntracked', {
+                    count: changed,
+                    untracked,
+                  })
+                : t('branchPicker.hint.changedFiles', { count: changed }),
+            tone: 'info',
+          }
+        : { text: t('branchPicker.hint.noChanges'), tone: 'muted' };
+  }
+
+  return { pull, pullDisabled, commit, push, pushDisabled };
+}
 
 export function BranchPickerPopover({
   open,
@@ -50,6 +179,8 @@ export function BranchPickerPopover({
   gitCwd,
   side = 'bottom',
   onBranchChanged,
+  status,
+  onRefreshStatus,
   onOpenDiff,
   onOpenCommit,
   children,
@@ -82,6 +213,10 @@ export function BranchPickerPopover({
   const searchRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const requestIdRef = useRef(0);
+  // Held in a ref so an inline callback from the parent doesn't re-arm the
+  // open effect on every render (refresh → setState → render → refresh…).
+  const onRefreshStatusRef = useRef(onRefreshStatus);
+  onRefreshStatusRef.current = onRefreshStatus;
 
   const fetchBranches = useCallback(async () => {
     const requestId = ++requestIdRef.current;
@@ -104,6 +239,7 @@ export function BranchPickerPopover({
   useEffect(() => {
     if (open) {
       void fetchBranches();
+      onRefreshStatusRef.current?.();
       setSearch('');
       setNewBranchMode(false);
       setCheckoutRefMode(false);
@@ -254,6 +390,11 @@ export function BranchPickerPopover({
     return groups;
   }, [filteredRemote]);
 
+  const hints = useMemo(
+    () => deriveActionHints(t, data, status),
+    [t, data, status],
+  );
+
   const actionsVisible =
     !q ||
     t('branchPicker.action.pull').toLowerCase().includes(q) ||
@@ -321,9 +462,10 @@ export function BranchPickerPopover({
                 <>
                   <button
                     type="button"
-                    className={styles.actionItem}
-                    disabled={!!busyAction}
+                    className={`${styles.actionItem} ${hints.pull?.tone === 'muted' ? styles.actionItemMuted : ''}`}
+                    disabled={!!busyAction || hints.pullDisabled}
                     onClick={() => void handlePull()}
+                    data-testid="branch-picker-pull"
                   >
                     {busyAction === 'pull' ? (
                       <Loader2Icon
@@ -339,28 +481,32 @@ export function BranchPickerPopover({
                     <span className={styles.actionLabel}>
                       {t('branchPicker.action.pull')}
                     </span>
+                    <ActionHintLabel hint={hints.pull} />
                   </button>
                   {onOpenCommit && (
                     <button
                       type="button"
-                      className={styles.actionItem}
+                      className={`${styles.actionItem} ${hints.commit?.tone === 'muted' ? styles.actionItemMuted : ''}`}
                       disabled={!!busyAction}
                       onClick={() => {
                         onOpenCommit();
                         onOpenChange(false);
                       }}
+                      data-testid="branch-picker-commit"
                     >
                       <GitCommitIcon size={14} className={styles.actionIcon} />
                       <span className={styles.actionLabel}>
                         {t('branchPicker.action.commit')}
                       </span>
+                      <ActionHintLabel hint={hints.commit} />
                     </button>
                   )}
                   <button
                     type="button"
-                    className={styles.actionItem}
-                    disabled={!!busyAction}
+                    className={`${styles.actionItem} ${hints.push?.tone === 'muted' ? styles.actionItemMuted : ''}`}
+                    disabled={!!busyAction || hints.pushDisabled}
                     onClick={() => void handlePush()}
+                    data-testid="branch-picker-push"
                   >
                     {busyAction === 'push' ? (
                       <Loader2Icon
@@ -376,6 +522,7 @@ export function BranchPickerPopover({
                     <span className={styles.actionLabel}>
                       {t('branchPicker.action.push')}
                     </span>
+                    <ActionHintLabel hint={hints.push} />
                   </button>
                   {onOpenDiff && (
                     <button
@@ -581,6 +728,19 @@ export function BranchPickerPopover({
         )}
       </PopoverContent>
     </Popover>
+  );
+}
+
+function ActionHintLabel({ hint }: { hint?: ActionHint }) {
+  if (!hint) return null;
+  return (
+    <span
+      className={styles.actionHint}
+      data-tone={hint.tone}
+      data-testid="branch-picker-action-hint"
+    >
+      {hint.text}
+    </span>
   );
 }
 

--- a/packages/web-shell/client/components/BranchPickerPopover.tsx
+++ b/packages/web-shell/client/components/BranchPickerPopover.tsx
@@ -28,6 +28,7 @@ import {
 import { useI18n } from '../i18n';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { validateBranchName } from './GitModePopover';
+import { deriveStatus, hasComputedTreeSummary } from './GitBranchIndicator';
 import styles from './BranchPickerPopover.module.css';
 
 interface BranchPickerPopoverProps {
@@ -38,14 +39,17 @@ interface BranchPickerPopoverProps {
   side?: 'top' | 'right' | 'bottom' | 'left';
   onBranchChanged?: () => void;
   /**
-   * Live working-tree summary from the trigger chip. Drives the hints beside
-   * the Update / Commit / Push actions (dirty counts, in-progress operation);
-   * ahead/behind/upstream prefer the branch listing fetched on open, which is
-   * fresher than the chip's polled snapshot.
+   * Working-tree summary from the trigger chip. Seeds the hints beside the
+   * Update / Commit / Push actions (dirty counts, in-progress operation) until
+   * the popover's own on-open fetch lands; whichever of the two carries the
+   * newer `computedAt` wins.
    */
   status?: DaemonWorkspaceGitStatus;
-  /** Invoked when the popover opens so the caller can refresh `status`. */
-  onRefreshStatus?: () => void;
+  /**
+   * Receives the status the popover fetches for itself on open, so a caller
+   * that renders a chip from the same object can update it in step.
+   */
+  onStatusRefreshed?: (status: DaemonWorkspaceGitStatus) => void;
   onOpenDiff?: () => void;
   onOpenCommit?: () => void;
   children: React.ReactNode;
@@ -72,12 +76,19 @@ type TranslateFn = ReturnType<typeof useI18n>['t'];
 
 /**
  * Derive the per-action hints shown beside Update / Commit / Push so the user
- * can judge before clicking. Hard blockers (in-progress merge/rebase,
- * conflicts, detached HEAD, pull without upstream) disable the action because
- * the daemon would reject it anyway; soft states (up to date, nothing to push,
- * clean tree) only dim the row since the action is still harmless.
+ * can judge before clicking.
  *
- * Exported for tests.
+ * Disabling is reserved for what git itself refuses: `git pull` during a
+ * merge/rebase/cherry-pick, with unmerged entries, on a detached HEAD, or
+ * without a usable upstream; `git push --set-upstream` only on a detached
+ * HEAD (a push does not consult the index, so conflicts and in-progress
+ * operations are shown as warnings on an enabled row). Soft states (up to
+ * date, nothing to push, clean tree) only dim the row since the action is
+ * still harmless.
+ *
+ * The branch listing (fetched on open) provides ahead/behind/upstream; the
+ * status provides the tree counters and the in-progress operation. When the
+ * listing has no head entry the status fills in. Exported for tests.
  */
 export function deriveActionHints(
   t: TranslateFn,
@@ -85,28 +96,23 @@ export function deriveActionHints(
   status: DaemonWorkspaceGitStatus | undefined,
 ): ActionHints {
   const head = data?.local.find((b) => b.isHead);
-  const detached = data?.detached ?? status?.detached ?? false;
-  const operation = status?.operation;
-  const conflicted = status?.conflicted ?? 0;
-  // The branch listing is fetched on open, so it wins over the polled status.
-  const ahead = head?.ahead ?? status?.ahead ?? 0;
-  const behind = head?.behind ?? status?.behind ?? 0;
+  const s = deriveStatus(status);
+  const detached = data?.detached ?? s.detached;
+  const ahead = head?.ahead ?? s.ahead;
+  const behind = head?.behind ?? s.behind;
   const upstream = head?.upstream;
+  const upstreamGone = head?.upstreamGone === true;
   const hasUpstream: boolean | undefined = head
-    ? Boolean(head.upstream)
+    ? Boolean(head.upstream) && !upstreamGone
     : status?.hasUpstream;
-  // Dirty counts only exist on v2 status; `computedAt` marks that the enriched
-  // fields were actually computed rather than defaulted.
-  const hasTreeSummary = status?.computedAt !== undefined;
-  const staged = status?.staged ?? 0;
-  const unstaged = status?.unstaged ?? 0;
-  const untracked = status?.untracked ?? 0;
-  const changed = staged + unstaged + untracked + conflicted;
+  // Entry-granularity counters (a partially staged file counts twice, an
+  // untracked directory once), so the copy says "changes", not "files".
+  const changed = s.staged + s.unstaged + s.untracked + s.conflicted;
 
-  const blocker: ActionHint | undefined = operation
-    ? { text: t(`git.operation.${operation}`), tone: 'warning' }
-    : conflicted > 0
-      ? { text: t('git.conflicted', { count: conflicted }), tone: 'warning' }
+  const blocker: ActionHint | undefined = s.operation
+    ? { text: t(`git.operation.${s.operation}`), tone: 'warning' }
+    : s.conflicted > 0
+      ? { text: t('git.conflicted', { count: s.conflicted }), tone: 'warning' }
       : detached
         ? { text: t('git.detached'), tone: 'warning' }
         : undefined;
@@ -117,7 +123,14 @@ export function deriveActionHints(
     pull = blocker;
     pullDisabled = true;
   } else if (hasUpstream === false) {
-    pull = { text: t('branchPicker.hint.noUpstream'), tone: 'muted' };
+    pull = {
+      text: t(
+        upstreamGone
+          ? 'branchPicker.hint.upstreamGone'
+          : 'branchPicker.hint.noUpstream',
+      ),
+      tone: 'muted',
+    };
     pullDisabled = true;
   } else if (behind > 0) {
     pull =
@@ -135,12 +148,13 @@ export function deriveActionHints(
   }
 
   let push: ActionHint | undefined;
-  let pushDisabled = false;
+  // Only a detached HEAD makes the daemon's `git push --set-upstream` fail;
+  // an in-progress operation or conflicts are surfaced but left clickable.
+  const pushDisabled = detached;
   if (blocker) {
     push = blocker;
-    pushDisabled = true;
   } else if (hasUpstream === false) {
-    push = { text: t('branchPicker.hint.willCreateUpstream'), tone: 'info' };
+    push = { text: t('branchPicker.hint.setsUpstream'), tone: 'info' };
   } else if (ahead > 0 && behind > 0) {
     push = {
       text: t('branchPicker.hint.aheadBehind', { ahead, behind }),
@@ -153,23 +167,60 @@ export function deriveActionHints(
   }
 
   let commit: ActionHint | undefined;
-  if (hasTreeSummary) {
+  if (hasComputedTreeSummary(status)) {
     commit =
       changed > 0
         ? {
             text:
-              untracked > 0
-                ? t('branchPicker.hint.changedFilesUntracked', {
+              s.untracked > 0
+                ? t('branchPicker.hint.changesUntracked', {
                     count: changed,
-                    untracked,
+                    untracked: s.untracked,
                   })
-                : t('branchPicker.hint.changedFiles', { count: changed }),
+                : t('branchPicker.hint.changes', { count: changed }),
             tone: 'info',
           }
         : { text: t('branchPicker.hint.noChanges'), tone: 'muted' };
   }
 
   return { pull, pullDisabled, commit, push, pushDisabled };
+}
+
+/** Of two statuses, the one the daemon computed later (a missing stamp loses). */
+function newerStatus(
+  a: DaemonWorkspaceGitStatus | undefined,
+  b: DaemonWorkspaceGitStatus | undefined,
+): DaemonWorkspaceGitStatus | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return (b.computedAt ?? -1) >= (a.computedAt ?? -1) ? b : a;
+}
+
+/**
+ * True when a status disagrees with the branch listing on a field the hints
+ * take from the listing — the signal that the listing is stale and should be
+ * re-fetched. Exported for tests.
+ */
+export function listingContradictsStatus(
+  data: DaemonGitBranchesResult,
+  status: DaemonWorkspaceGitStatus,
+): boolean {
+  if (status.detached !== undefined && status.detached !== data.detached) {
+    return true;
+  }
+  const head = data.local.find((b) => b.isHead);
+  if (!head) return false;
+  // The status cannot express a gone upstream (it reports the configured
+  // tracking as present), so the listing's `upstreamGone` is not a
+  // disagreement — only a genuinely set/unset upstream is.
+  const upstreamComparable = !head.upstreamGone;
+  return (
+    (upstreamComparable &&
+      status.hasUpstream !== undefined &&
+      status.hasUpstream !== Boolean(head.upstream)) ||
+    (status.ahead !== undefined && status.ahead !== head.ahead) ||
+    (status.behind !== undefined && status.behind !== head.behind)
+  );
 }
 
 export function BranchPickerPopover({
@@ -180,7 +231,7 @@ export function BranchPickerPopover({
   side = 'bottom',
   onBranchChanged,
   status,
-  onRefreshStatus,
+  onStatusRefreshed,
   onOpenDiff,
   onOpenCommit,
   children,
@@ -213,10 +264,19 @@ export function BranchPickerPopover({
   const searchRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const requestIdRef = useRef(0);
+  // Wall-clock time the current listing was received; lets a status the
+  // daemon computed later trigger a listing re-fetch (see the effect below).
+  const [listingFetchedAt, setListingFetchedAt] = useState<number>();
+  // The popover's own on-open status fetch, so every entry point (sidebar
+  // chip, composer chip, environment panel) sees fresh counters instead of
+  // whatever its caller last polled.
+  const [liveStatus, setLiveStatus] = useState<DaemonWorkspaceGitStatus>();
+  const statusRequestIdRef = useRef(0);
+  const reconciledAtRef = useRef<number | undefined>(undefined);
   // Held in a ref so an inline callback from the parent doesn't re-arm the
-  // open effect on every render (refresh → setState → render → refresh…).
-  const onRefreshStatusRef = useRef(onRefreshStatus);
-  onRefreshStatusRef.current = onRefreshStatus;
+  // open effect on every render (callback → setState → render → refetch…).
+  const onStatusRefreshedRef = useRef(onStatusRefreshed);
+  onStatusRefreshedRef.current = onStatusRefreshed;
 
   const fetchBranches = useCallback(async () => {
     const requestId = ++requestIdRef.current;
@@ -226,6 +286,7 @@ export function BranchPickerPopover({
       const result = await ws.workspaceGitBranches(gitCwd);
       if (requestId !== requestIdRef.current) return;
       setData(result);
+      setListingFetchedAt(Date.now());
     } catch (err) {
       if (requestId !== requestIdRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
@@ -236,10 +297,37 @@ export function BranchPickerPopover({
     }
   }, [ws, gitCwd]);
 
+  const fetchStatus = useCallback(async () => {
+    const requestId = ++statusRequestIdRef.current;
+    try {
+      // Mirrors the app-level poll: a worktree `?cwd=` read always computes
+      // directly, so `wait` only matters for the workspace root.
+      const fresh = await ws.workspaceGit(
+        gitCwd ? { cwd: gitCwd } : { wait: true },
+      );
+      if (requestId !== statusRequestIdRef.current) return;
+      setLiveStatus(fresh);
+      onStatusRefreshedRef.current?.(fresh);
+    } catch {
+      // Keep whatever the caller passed; the hints degrade to the listing.
+    }
+  }, [ws, gitCwd]);
+
+  // A status fetched for a previous workspace must not seed the next one.
+  useEffect(() => {
+    setLiveStatus(undefined);
+    statusRequestIdRef.current++;
+  }, [ws, gitCwd]);
+
+  const effectiveStatus = useMemo(
+    () => newerStatus(status, liveStatus),
+    [status, liveStatus],
+  );
+
   useEffect(() => {
     if (open) {
       void fetchBranches();
-      onRefreshStatusRef.current?.();
+      void fetchStatus();
       setSearch('');
       setNewBranchMode(false);
       setCheckoutRefMode(false);
@@ -248,7 +336,23 @@ export function BranchPickerPopover({
       setStatusMsg(null);
       setTimeout(() => searchRef.current?.focus(), 50);
     }
-  }, [open, fetchBranches]);
+  }, [open, fetchBranches, fetchStatus]);
+
+  // The listing is fetched once on open. If a status the daemon computed
+  // after that disagrees with it (upstream unset, HEAD detached, new commits
+  // from a terminal), re-fetch the listing so the rows follow the repo rather
+  // than the snapshot — once per status, so a persistent disagreement can't
+  // loop.
+  useEffect(() => {
+    if (!open || !data || !effectiveStatus || listingFetchedAt === undefined)
+      return;
+    const at = effectiveStatus.computedAt;
+    if (at === undefined || at <= listingFetchedAt) return;
+    if (reconciledAtRef.current === at) return;
+    if (!listingContradictsStatus(data, effectiveStatus)) return;
+    reconciledAtRef.current = at;
+    void fetchBranches();
+  }, [open, data, effectiveStatus, listingFetchedAt, fetchBranches]);
 
   const showStatus = useCallback(
     (msg: string, type: 'info' | 'error' | 'success' = 'info') => {
@@ -391,8 +495,8 @@ export function BranchPickerPopover({
   }, [filteredRemote]);
 
   const hints = useMemo(
-    () => deriveActionHints(t, data, status),
-    [t, data, status],
+    () => deriveActionHints(t, data, effectiveStatus),
+    [t, data, effectiveStatus],
   );
 
   const actionsVisible =

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -2,6 +2,7 @@
 
 import { act, createRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import type { DaemonWorkspaceGitStatus } from '@qwen-code/sdk/daemon';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   WebShellCustomizationProvider,
@@ -34,6 +35,30 @@ const mockComposerCoreState = vi.hoisted(() => ({
   }>,
   removeTopTag: vi.fn(),
 }));
+
+// Stand in for the branch picker so the tests can assert what the composer
+// hands it (the git status behind its action hints) without driving Radix.
+vi.mock('./BranchPickerPopover', async () => {
+  const { createElement } = await import('react');
+  return {
+    BranchPickerPopover: ({
+      children,
+      status,
+    }: {
+      children?: unknown;
+      status?: { operation?: string; unstaged?: number };
+    }) =>
+      createElement(
+        'div',
+        {
+          'data-testid': 'branch-picker',
+          'data-status-operation': status?.operation ?? undefined,
+          'data-status-unstaged': status?.unstaged ?? undefined,
+        },
+        children,
+      ),
+  };
+});
 
 // Mock useWorkspace so BranchPickerPopover can render without a real provider.
 vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
@@ -341,6 +366,7 @@ interface ChatEditorRenderProps {
     size?: number;
   }>;
   gitBranch?: string;
+  gitStatus?: DaemonWorkspaceGitStatus;
   workspaceName?: string;
   workspaceTitle?: string;
   visibleToolbarActions?: readonly ComposerToolbarAction[];
@@ -1099,6 +1125,25 @@ describe('ChatEditor git branch toolbar integration', () => {
         '[aria-label="Current Git branch: feature/web-shell"]',
       ),
     ).not.toBeNull();
+  });
+
+  it('hands the workspace git status to the branch picker for its action hints', () => {
+    const container = renderChatEditor({
+      gitBranch: 'feature/web-shell',
+      gitStatus: {
+        v: 2,
+        workspaceCwd: '/repo',
+        branch: 'feature/web-shell',
+        operation: 'rebase',
+        unstaged: 4,
+        computedAt: 1,
+      },
+      visibleToolbarActions: ['gitBranch'],
+    });
+
+    const picker = container.querySelector('[data-testid="branch-picker"]');
+    expect(picker?.getAttribute('data-status-operation')).toBe('rebase');
+    expect(picker?.getAttribute('data-status-unstaged')).toBe('4');
   });
 
   it('hides the git branch indicator without a branch or visible action', () => {

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -3131,6 +3131,7 @@ export const ChatEditor = memo(
                         onOpenChange={setBranchPickerOpen}
                         workspaceCwd={selectedWorkspace?.cwd ?? ''}
                         gitCwd={gitCwd}
+                        status={gitStatus}
                         onOpenDiff={onOpenGitDiff}
                         onOpenCommit={onOpenCommit}
                       >

--- a/packages/web-shell/client/components/GitBranchIndicator.tsx
+++ b/packages/web-shell/client/components/GitBranchIndicator.tsx
@@ -39,7 +39,7 @@ function GitBranchIcon() {
 /** Tone of the compact badge dot, by descending severity. */
 type BadgeTone = 'error' | 'warning' | 'accent';
 
-interface DerivedStatus {
+export interface DerivedStatus {
   detached: boolean;
   staged: number;
   unstaged: number;
@@ -52,7 +52,12 @@ interface DerivedStatus {
   dirty: boolean;
 }
 
-function deriveStatus(status?: DaemonWorkspaceGitStatus): DerivedStatus {
+/**
+ * Normalise a (possibly v1, possibly absent) status into zero-defaulted
+ * counters. Shared with the branch picker so both surfaces read the same
+ * numbers from the same object.
+ */
+export function deriveStatus(status?: DaemonWorkspaceGitStatus): DerivedStatus {
   const staged = status?.staged ?? 0;
   const unstaged = status?.unstaged ?? 0;
   const untracked = status?.untracked ?? 0;
@@ -71,6 +76,17 @@ function deriveStatus(status?: DaemonWorkspaceGitStatus): DerivedStatus {
     // changed file is conflicted (staged=unstaged=untracked=0) is still dirty.
     dirty: staged + unstaged + untracked + conflicted > 0,
   };
+}
+
+/**
+ * True once the daemon has actually computed the enriched (v2) fields;
+ * `computedAt` is stamped only on that path, so its absence means the counters
+ * above are defaults rather than a clean tree.
+ */
+export function hasComputedTreeSummary(
+  status?: DaemonWorkspaceGitStatus,
+): boolean {
+  return status?.computedAt !== undefined;
 }
 
 /** Compact badge tone for the icon-only (compact) chip; null when clean. */
@@ -113,7 +129,7 @@ export function gitBranchAriaLabel(
   if (phrases.length > 0) {
     return `${t('git.currentBranch', { branch })} — ${phrases.join(', ')}`;
   }
-  return status?.computedAt !== undefined
+  return hasComputedTreeSummary(status)
     ? `${t('git.currentBranch', { branch })} — ${t('git.clean')}`
     : t('git.currentBranch', { branch });
 }
@@ -269,7 +285,7 @@ export function GitBranchIndicator({
                   {phrase}
                 </div>
               ))
-            ) : status?.computedAt !== undefined ? (
+            ) : hasComputedTreeSummary(status) ? (
               <div className={styles.gitBranchTooltipRow}>{t('git.clean')}</div>
             ) : null}
           </div>

--- a/packages/web-shell/client/components/panels/EnvironmentPanel.test.tsx
+++ b/packages/web-shell/client/components/panels/EnvironmentPanel.test.tsx
@@ -15,11 +15,13 @@ vi.mock('../BranchPickerPopover', async () => {
       open,
       onOpenChange,
       side,
+      status,
     }: {
       children: ReactNode;
       open: boolean;
       onOpenChange: (open: boolean) => void;
       side?: string;
+      status?: { branch: string | null; operation?: string };
     }) =>
       createElement(
         'div',
@@ -27,6 +29,8 @@ vi.mock('../BranchPickerPopover', async () => {
           'data-testid': 'branch-picker',
           'data-open': open,
           'data-side': side,
+          'data-status-branch': status?.branch ?? undefined,
+          'data-status-operation': status?.operation ?? undefined,
           onClick: () => onOpenChange(true),
         },
         children,
@@ -124,6 +128,26 @@ describe('EnvironmentPanel', () => {
     expect(view.textContent).toContain('Environment');
     expect(view.textContent).toContain('Unavailable');
     expect(view.textContent).not.toContain('Clean');
+  });
+
+  it('hands its git status to the branch picker for the action hints', () => {
+    const view = mount({
+      gitWorkspaceCwd: '/work/qwen-code',
+      gitCwd: '/work/qwen-code',
+      gitStatus: {
+        v: 2,
+        workspaceCwd: '/work/qwen-code',
+        branch: 'feat/context-panels',
+        operation: 'rebase',
+        computedAt: 1,
+      },
+    });
+
+    const picker = view.querySelector('[data-testid="branch-picker"]');
+    expect(picker?.getAttribute('data-status-branch')).toBe(
+      'feat/context-panels',
+    );
+    expect(picker?.getAttribute('data-status-operation')).toBe('rebase');
   });
 
   it('opens the branch actions without dismissing a floating panel', () => {

--- a/packages/web-shell/client/components/panels/EnvironmentPanel.tsx
+++ b/packages/web-shell/client/components/panels/EnvironmentPanel.tsx
@@ -248,6 +248,7 @@ export function EnvironmentPanel({
                   workspaceCwd={gitWorkspaceCwd}
                   gitCwd={gitCwd}
                   side="left"
+                  status={gitStatus}
                   onOpenDiff={onOpenGitDiff}
                   onOpenCommit={onOpenGitCommit}
                 >

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -1023,6 +1023,8 @@ describe('WorkspaceSection git chip', () => {
       chipButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await flush();
+    // Opening the picker refreshes the status behind its action hints.
+    expect(workspaceGit).toHaveBeenCalledTimes(2);
 
     // The picker content is portaled outside the section container.
     const mainItem = Array.from(document.body.querySelectorAll('button')).find(
@@ -1035,7 +1037,7 @@ describe('WorkspaceSection git chip', () => {
     await flush();
 
     expect(workspaceGitCheckout).toHaveBeenCalledWith('main', undefined);
-    expect(workspaceGit).toHaveBeenCalledTimes(2);
+    expect(workspaceGit).toHaveBeenCalledTimes(3);
   });
 
   it('hides the chip for an untrusted workspace and never queries git', async () => {

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -1023,7 +1023,8 @@ describe('WorkspaceSection git chip', () => {
       chipButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await flush();
-    // Opening the picker refreshes the status behind its action hints.
+    // Opening the picker fetches a fresh status for its action hints and
+    // hands it back to the chip.
     expect(workspaceGit).toHaveBeenCalledTimes(2);
 
     // The picker content is portaled outside the section container.

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -541,6 +541,8 @@ export function WorkspaceSection({
             onOpenChange={setBranchPickerOpen}
             workspaceCwd={workspace.cwd}
             onBranchChanged={() => void loadGitStatus()}
+            status={gitStatus}
+            onRefreshStatus={() => void loadGitStatus()}
             onOpenDiff={() => onOpenGitDiff(workspace.cwd)}
             onOpenCommit={
               onOpenCommit ? () => onOpenCommit(workspace.cwd) : undefined

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -542,7 +542,7 @@ export function WorkspaceSection({
             workspaceCwd={workspace.cwd}
             onBranchChanged={() => void loadGitStatus()}
             status={gitStatus}
-            onRefreshStatus={() => void loadGitStatus()}
+            onStatusRefreshed={setGitStatus}
             onOpenDiff={() => onOpenGitDiff(workspace.cwd)}
             onOpenCommit={
               onOpenCommit ? () => onOpenCommit(workspace.cwd) : undefined

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -56,17 +56,18 @@ const EN: Messages = {
   'branchPicker.pullSuccess': 'Updated successfully',
   'branchPicker.hint.upToDate': 'Up to date',
   'branchPicker.hint.noUpstream': 'No upstream',
+  'branchPicker.hint.upstreamGone': 'Upstream gone',
   'branchPicker.hint.behindDirty': (v) =>
     `↓${v?.count ?? 0} · uncommitted changes`,
-  'branchPicker.hint.willCreateUpstream': 'Creates remote branch',
+  'branchPicker.hint.setsUpstream': 'Sets upstream on push',
   'branchPicker.hint.aheadBehind': (v) =>
     `↑${v?.ahead ?? 0} ↓${v?.behind ?? 0} · update first`,
   'branchPicker.hint.nothingToPush': 'Nothing to push',
   'branchPicker.hint.noChanges': 'No changes',
-  'branchPicker.hint.changedFiles': (v) =>
-    `${v?.count ?? 0} ${v?.count === 1 ? 'file' : 'files'}`,
-  'branchPicker.hint.changedFilesUntracked': (v) =>
-    `${v?.count ?? 0} ${v?.count === 1 ? 'file' : 'files'} (${v?.untracked ?? 0} untracked)`,
+  'branchPicker.hint.changes': (v) =>
+    `${v?.count ?? 0} ${v?.count === 1 ? 'change' : 'changes'}`,
+  'branchPicker.hint.changesUntracked': (v) =>
+    `${v?.count ?? 0} ${v?.count === 1 ? 'change' : 'changes'} (${v?.untracked ?? 0} untracked)`,
   'gitCommit.title': 'Commit',
   'gitCommit.messagePlaceholder': 'Commit message (⌘/Ctrl+Enter to commit)',
   'gitCommit.generating': 'Generating commit message…',
@@ -3170,15 +3171,16 @@ const ZH: Messages = {
   'branchPicker.pullSuccess': '更新成功',
   'branchPicker.hint.upToDate': '已是最新',
   'branchPicker.hint.noUpstream': '无上游分支',
+  'branchPicker.hint.upstreamGone': '上游分支已不存在',
   'branchPicker.hint.behindDirty': (v) => `↓${v?.count ?? 0} · 有未提交更改`,
-  'branchPicker.hint.willCreateUpstream': '将创建远程分支',
+  'branchPicker.hint.setsUpstream': '推送时设置上游',
   'branchPicker.hint.aheadBehind': (v) =>
     `↑${v?.ahead ?? 0} ↓${v?.behind ?? 0} · 请先更新`,
   'branchPicker.hint.nothingToPush': '无待推送',
   'branchPicker.hint.noChanges': '无更改',
-  'branchPicker.hint.changedFiles': (v) => `${v?.count ?? 0} 个文件`,
-  'branchPicker.hint.changedFilesUntracked': (v) =>
-    `${v?.count ?? 0} 个文件（${v?.untracked ?? 0} 未跟踪）`,
+  'branchPicker.hint.changes': (v) => `${v?.count ?? 0} 处更改`,
+  'branchPicker.hint.changesUntracked': (v) =>
+    `${v?.count ?? 0} 处更改（${v?.untracked ?? 0} 未跟踪）`,
   'gitCommit.title': '提交',
   'gitCommit.messagePlaceholder': '提交信息（⌘/Ctrl+Enter 提交）',
   'gitCommit.generating': '正在生成提交信息…',

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -54,6 +54,19 @@ const EN: Messages = {
   'branchPicker.createdBranch': (v) => `Created branch ${v?.branch ?? ''}`,
   'branchPicker.pushSuccess': 'Pushed successfully',
   'branchPicker.pullSuccess': 'Updated successfully',
+  'branchPicker.hint.upToDate': 'Up to date',
+  'branchPicker.hint.noUpstream': 'No upstream',
+  'branchPicker.hint.behindDirty': (v) =>
+    `↓${v?.count ?? 0} · uncommitted changes`,
+  'branchPicker.hint.willCreateUpstream': 'Creates remote branch',
+  'branchPicker.hint.aheadBehind': (v) =>
+    `↑${v?.ahead ?? 0} ↓${v?.behind ?? 0} · update first`,
+  'branchPicker.hint.nothingToPush': 'Nothing to push',
+  'branchPicker.hint.noChanges': 'No changes',
+  'branchPicker.hint.changedFiles': (v) =>
+    `${v?.count ?? 0} ${v?.count === 1 ? 'file' : 'files'}`,
+  'branchPicker.hint.changedFilesUntracked': (v) =>
+    `${v?.count ?? 0} ${v?.count === 1 ? 'file' : 'files'} (${v?.untracked ?? 0} untracked)`,
   'gitCommit.title': 'Commit',
   'gitCommit.messagePlaceholder': 'Commit message (⌘/Ctrl+Enter to commit)',
   'gitCommit.generating': 'Generating commit message…',
@@ -3155,6 +3168,17 @@ const ZH: Messages = {
   'branchPicker.createdBranch': (v) => `已创建分支 ${v?.branch ?? ''}`,
   'branchPicker.pushSuccess': '推送成功',
   'branchPicker.pullSuccess': '更新成功',
+  'branchPicker.hint.upToDate': '已是最新',
+  'branchPicker.hint.noUpstream': '无上游分支',
+  'branchPicker.hint.behindDirty': (v) => `↓${v?.count ?? 0} · 有未提交更改`,
+  'branchPicker.hint.willCreateUpstream': '将创建远程分支',
+  'branchPicker.hint.aheadBehind': (v) =>
+    `↑${v?.ahead ?? 0} ↓${v?.behind ?? 0} · 请先更新`,
+  'branchPicker.hint.nothingToPush': '无待推送',
+  'branchPicker.hint.noChanges': '无更改',
+  'branchPicker.hint.changedFiles': (v) => `${v?.count ?? 0} 个文件`,
+  'branchPicker.hint.changedFilesUntracked': (v) =>
+    `${v?.count ?? 0} 个文件（${v?.untracked ?? 0} 未跟踪）`,
   'gitCommit.title': '提交',
   'gitCommit.messagePlaceholder': '提交信息（⌘/Ctrl+Enter 提交）',
   'gitCommit.generating': '正在生成提交信息…',


### PR DESCRIPTION
## What this PR does

The branch picker popover (opened from the workspace folder's git chip in the sidebar, the composer chip, or the Environment panel) now shows a short state hint at the right edge of its **Update Project**, **Commit**, and **Push** rows, so the user can judge before clicking:

- **Update Project** shows `↓3 · origin/main` when behind, "Up to date" (dimmed) when in sync, and a warning-toned `↓3 · uncommitted changes` when behind with a dirty tree. It is disabled with "No upstream" when the branch has no tracking branch, and with "Upstream gone" when the tracked remote branch was deleted and pruned.
- **Commit** shows how many changes the commit would sweep up, calling out untracked entries (`5 changes (2 untracked)`), or "No changes" (dimmed) on a clean tree. "Changes" rather than "files" because the daemon's counters are entry-granular (a partially staged file counts twice, an untracked directory once).
- **Push** shows `↑2` when ahead, "Nothing to push" (dimmed) when in sync, "Sets upstream on push" when there is no usable upstream, and a warning-toned `↑2 ↓1 · update first` when the branch is both ahead and behind.
- Disabling follows what git itself refuses: Update Project is disabled during a merge/rebase/cherry-pick, with conflicted entries, on a detached HEAD, or without a usable upstream; Push is disabled only on a detached HEAD (a push does not consult the index), and shows the in-progress operation or conflict as a warning on an enabled row otherwise.

Rows that are merely uninteresting (up to date, nothing to push, no changes) are only dimmed, never disabled, since the action is still harmless.

The popover gets a new optional `status` prop (the same `DaemonWorkspaceGitStatus` the trigger chips already hold) and fetches its own working-tree status when it opens, so all three entry points (sidebar chip, composer chip, Environment panel) see fresh counters rather than their caller's last poll; the newer of the two by `computedAt` wins, and the sidebar receives the fetched status back through `onStatusRefreshed` to keep its chip in step. Ahead/behind/upstream come from the branch listing the popover already fetches on open; if a status the daemon computed later disagrees with that listing (upstream unset, HEAD detached, new commits from a terminal), the listing is re-fetched once so the rows follow the repo rather than the snapshot. The counter normalisation is shared with `GitBranchIndicator` rather than re-implemented.

One small core change: `parseBranchLines` now reads git's `gone` tracking state into an optional `upstreamGone` on the branch listing (`GitBranchInfo` / `DaemonGitBranchInfo`), since neither the listing nor the status could previously distinguish a deleted upstream from a healthy in-sync one.

## Why it's needed

The three actions have consequences that are invisible until after the click: `git pull` without an upstream fails, a pull onto a dirty tree may be refused with a 409, `Commit` runs `git add -A` and therefore sweeps in untracked files, and `Push` with no upstream creates a remote branch. The daemon already computes everything needed to say so up front — the chip that opens the popover even renders `↑n ↓n` and a dirty dot — but none of it reached the popover, so users clicked blind and read the outcome from the status line afterwards.

Related: #10390 changes what happens *after* clicking Update Project on a dirty tree (stash / discard resolution panel). This PR is about what the user sees *before* clicking and is independent of it; the two touch adjacent code in `BranchPickerPopover.tsx` and `i18n.tsx`, so whichever merges second will need a small conflict resolution. The dirty-tree warning stays accurate under #10390 — it just leads to the resolution panel instead of an error.

## Reviewer Test Plan

### How to verify

Unit coverage is the primary check. `deriveActionHints` is exported and covered as a decision table (13 cases: in-sync/clean, behind, behind+dirty, no upstream, ahead, ahead+behind, changed/untracked counts, in-progress operation, conflicts, detached HEAD, listing-vs-status precedence, v1 status without tree summary), plus rendered assertions that the rows carry the expected `disabled` state and `data-tone`, and that opening the popover asks the caller to refresh status exactly once even when the parent passes a new inline callback on re-render.

```sh
cd packages/web-shell && npx vitest run \
  client/components/BranchPickerPopover.test.tsx \
  client/components/sidebar/WorkspaceSection.test.tsx \
  client/components/panels/EnvironmentPanel.test.tsx
# Test Files  4 passed (4) · Tests  170 passed (170)   (round 2, plus client/components/ChatEditor.test.tsx)
cd packages/core && npx vitest run src/utils/git-branches.test.ts   # 58 passed (gone-upstream listing)
```

For a manual check in `qwen serve` + Web Shell, open a trusted git workspace and click the branch chip on the sidebar folder header after putting the repo in each state: in sync and clean → all three rows dimmed with "Up to date" / "No changes" / "Nothing to push"; `git reset --hard HEAD~3` → `↓3 · origin/main`; also edit a tracked file and add an untracked one → warning-toned `↓3 · uncommitted changes` and `2 changes (1 untracked)`; `git checkout -b x` with one local commit → Update Project disabled "No upstream", Push "Sets upstream on push"; an in-progress conflicting rebase → Update Project and Push disabled with "Rebasing"; `git checkout --detach` → both disabled with "Detached HEAD"; a conflicting merge on the branch → Update Project disabled "Merging", Push enabled with a warning "Merging"; push a branch with `-u`, delete it on the remote, `git fetch --prune` → Update Project disabled "Upstream gone", Push "Sets upstream on push". Switch the UI language to 中文 to see the localized copy. The full manual plan is in `.qwen/e2e-tests/2026-08-28-webshell-branch-picker-action-hints.md`.

### Evidence (Before & After)

Round 2 (`1f960ddb36`, after review) re-captured the After column with the revised copy and rules and added two states; the Before column is from round 1 and is unchanged by the review. Captured from the real stack: `npm run bundle` → `node dist/cli.js serve --workspace <fixture>` (isolated `QWEN_HOME`, fake OpenAI env, no model calls) → Playwright clicks the sidebar git chip and screenshots the popover. Both columns were taken against the **same daemon workspace in the same git state**, seconds apart: "Before" is the same bundle with the web-shell UI rebuilt from `origin/main`'s client files, "After" is this branch. Per-row `disabled` / hint text / `data-tone` were also read back from the DOM into a ledger (`dom-ledger.jsonl` next to the images); every Before row has no hint and stays enabled, including the states where the click would fail.

| Repo state | Before | After |
| :-- | :-- | :-- |
| In sync, clean tree | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-sync.png" width="360" alt="before-sync"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-sync.png" width="360" alt="after-sync"> |
| Behind 3, clean | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-behind.png" width="360" alt="before-behind"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-behind.png" width="360" alt="after-behind"> |
| Behind 3 + modified tracked file + untracked file | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-behind-dirty.png" width="360" alt="before-behind-dirty"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-behind-dirty.png" width="360" alt="after-behind-dirty"> |
| New branch, 1 commit, no upstream | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-no-upstream.png" width="360" alt="before-no-upstream"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-no-upstream.png" width="360" alt="after-no-upstream"> |
| Ahead 1 / behind 1 | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-ahead-behind.png" width="360" alt="before-ahead-behind"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-ahead-behind.png" width="360" alt="after-ahead-behind"> |
| Rebase in progress with a conflict (HEAD detached) | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-rebase-conflict.png" width="360" alt="before-rebase-conflict"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-rebase-conflict.png" width="360" alt="after-rebase-conflict"> |
| Detached HEAD | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-detached.png" width="360" alt="before-detached"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-detached.png" width="360" alt="after-detached"> |
| Merge in progress with a conflict, on the branch (round 2) | (as every other Before row: no hint, all rows enabled) | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-merge-conflict.png" width="360" alt="after-merge-conflict"> |
| Upstream deleted on the remote and pruned (round 2) | (as every other Before row: no hint, all rows enabled) | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-upstream-gone.png" width="360" alt="after-upstream-gone"> |


zh-CN, behind 3 with uncommitted changes:

<img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-behind-dirty-zh.png" width="360" alt="after-behind-dirty-zh">

Assets: round 1 [`wenshao/qwen-code@2d7c61f`](https://github.com/wenshao/qwen-code/tree/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify), round 2 [`wenshao/qwen-code@447a954`](https://github.com/wenshao/qwen-code/tree/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2) (branch `pr-assets/10397-verify`).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS; unit tests (vitest + jsdom) plus the bundled `qwen serve` + headless Chromium (Playwright) run above.

## Risk & Scope

- Main risk or tradeoff: Update Project (and Push on a detached HEAD) are now disabled in states git refuses. The popover fetches status on open and re-fetches the listing when a newer status contradicts it, so a rebase finished in a terminal clears the disabled row once the chip's status updates (focus / poll / SSE) without reopening; between those refreshes the row reflects the last known state. The listing-vs-status recency check compares the daemon's `computedAt` with the browser clock, so on a remote daemon with a skewed clock the re-fetch may not fire (the hints then degrade to open-time behaviour, never to a wrong enable).
- Not validated / out of scope: the composer-chip and Environment-panel entry points were not screenshotted (same component, same props; only the sidebar chip was driven). Windows/Linux not run locally (pure client code, no platform-specific paths).
- Breaking changes / migration notes: none. The new props are optional; callers that do not pass `status` still get the popover's own on-open fetch. `upstreamGone` is an additive optional field on the branch listing.

## Linked Issues

Related to #10390 (dirty-working-tree pull resolution; independent, adjacent code).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

分支选择弹窗（从侧栏工作区文件夹的 git 芯片、composer 芯片或环境面板打开）现在会在 **更新项目**、**提交**、**推送** 三行右侧显示一个简短的状态提示，让用户在点击前就能判断：

- **更新项目**：落后时显示 `↓3 · origin/main`；同步时显示"已是最新"（变灰）；落后且工作区有未提交更改时显示警告色的 `↓3 · 有未提交更改`；分支没有上游时禁用并显示"无上游分支"，所跟踪的远程分支已被删除并 prune 时禁用并显示"上游分支已不存在"。
- **提交**：显示这次提交会带入多少处更改，并单独标出未跟踪项（`5 处更改（2 未跟踪）`）；工作区干净时显示"无更改"（变灰）。用"更改"而非"文件"，是因为 daemon 的计数按条目计（部分暂存的文件算两条，未跟踪目录算一条）。
- **推送**：领先时显示 `↑2`；同步时显示"无待推送"（变灰）；没有可用上游时显示"推送时设置上游"；既领先又落后时显示警告色的 `↑2 ↓1 · 请先更新`。
- 禁用规则跟随 git 自身的拒绝：merge/rebase/cherry-pick 进行中、存在冲突条目、HEAD 游离、或没有可用上游时禁用"更新项目"；"推送"只在 HEAD 游离时禁用（push 不看索引），其它情况下把进行中的操作或冲突作为警告显示在可点击的行上。

只是"没什么可做"的行（已是最新、无待推送、无更改）只变灰、不禁用，因为操作本身无害。

弹窗新增可选的 `status` prop（就是触发芯片已经持有的 `DaemonWorkspaceGitStatus`），并在打开时自行拉取一次工作区状态，因此三个入口（侧栏芯片、composer 芯片、环境面板）看到的都是新鲜计数而不是各自调用方上次轮询的结果；两者按 `computedAt` 取较新者，侧栏通过 `onStatusRefreshed` 拿回这份状态让芯片同步。ahead/behind/upstream 取自弹窗打开时本来就会拉取的分支列表；若之后到达的、daemon 计算时间更晚的状态与该列表不一致（上游被取消、HEAD 游离、终端里新提交），会重新拉取一次列表，让各行跟随仓库而不是打开时的快照。计数归一化与 `GitBranchIndicator` 共用，不再各写一份。

core 有一处小改动：`parseBranchLines` 现在把 git 的 `gone` 跟踪状态读入分支列表的可选字段 `upstreamGone`（`GitBranchInfo` / `DaemonGitBranchInfo`），此前无论列表还是状态都无法区分"上游已删除"和"健康且同步"。

## 为什么需要

这三个操作的后果在点击之前是看不见的：没有上游时 `git pull` 会失败；脏工作区上 pull 可能被 409 拒绝；"提交"会执行 `git add -A`，因此会把未跟踪文件一并带入；没有上游时"推送"会创建远程分支。daemon 已经算出了提前说明所需的全部信息——打开弹窗的那个芯片甚至已经渲染了 `↑n ↓n` 和脏点——但这些都没有传到弹窗里，用户只能盲点，然后事后从状态行读结果。

相关：#10390 改的是在脏工作区上点击"更新项目"*之后*发生的事（stash / 放弃 的解决面板）。本 PR 关注的是点击*之前*用户看到什么，与之相互独立；两者在 `BranchPickerPopover.tsx` 和 `i18n.tsx` 中改到相邻代码，后合入的一方需要做一次小的冲突解决。脏工作区警告在 #10390 合入后依然准确——只是点下去会进入解决面板而不是报错。

## 审阅测试计划

### 如何验证

主要依靠单元测试。`deriveActionHints` 已导出并以决策表方式覆盖（13 个用例：同步且干净、落后、落后且脏、无上游、领先、既领先又落后、变更/未跟踪计数、进行中操作、冲突、游离 HEAD、分支列表优先于状态、无树摘要的 v1 状态），另有渲染层断言确认各行携带预期的 `disabled` 状态与 `data-tone`，以及打开弹窗时恰好请求一次状态刷新——即使父组件在重渲染时传入新的内联回调。

```sh
cd packages/web-shell && npx vitest run \
  client/components/BranchPickerPopover.test.tsx \
  client/components/sidebar/WorkspaceSection.test.tsx \
  client/components/panels/EnvironmentPanel.test.tsx
# Test Files  4 passed (4) · Tests  170 passed (170)   （第二轮，另含 client/components/ChatEditor.test.tsx）
cd packages/core && npx vitest run src/utils/git-branches.test.ts   # 58 passed（上游 gone 的分支列表）
```

在 `qwen serve` + Web Shell 中手动检查：打开一个受信任的 git 工作区，把仓库置于以下各状态后点击侧栏文件夹头部的分支芯片：同步且干净 → 三行都变灰，显示"已是最新"/"无更改"/"无待推送"；`git reset --hard HEAD~3` → `↓3 · origin/main`；再改一个已跟踪文件并新增一个未跟踪文件 → 警告色的 `↓3 · 有未提交更改` 与 `2 处更改（1 未跟踪）`；`git checkout -b x` 并本地提交一次 → 更新项目禁用并显示"无上游分支"，推送显示"推送时设置上游"；进行中的冲突 rebase → 更新项目与推送禁用并显示"变基中"；`git checkout --detach` → 两者禁用并显示"游离 HEAD"；分支上进行中的冲突 merge → 更新项目禁用显示"合并中"，推送可点并带警告"合并中"；用 `-u` 推送分支后在远端删除并 `git fetch --prune` → 更新项目禁用显示"上游分支已不存在"，推送显示"推送时设置上游"。切换界面语言到中文查看本地化文案。完整手测计划见 `.qwen/e2e-tests/2026-08-28-webshell-branch-picker-action-hints.md`。

### 证据（前后对比）

第二轮（`1f960ddb36`，评审后）用修订后的文案与规则重截了 After 列并新增两个状态；Before 列来自第一轮，评审未改变它。取自真实栈：`npm run bundle` → `node dist/cli.js serve --workspace <夹具仓库>`（隔离 `QWEN_HOME`、伪造 OpenAI 环境变量，不调用模型）→ Playwright 点击侧栏 git 芯片并截取弹窗。两列都是对着**同一个 daemon 工作区、同一 git 状态**、相隔几秒截取的："Before" 是同一份 bundle 但 web-shell 前端用 `origin/main` 的客户端文件重建，"After" 是本分支。每行的 `disabled` / 提示文本 / `data-tone` 也从 DOM 读回记入台账（与图片同目录的 `dom-ledger.jsonl`）；Before 的每一行都没有提示且始终可点，包括点击必然失败的那些状态。

| 仓库状态 | Before | After |
| :-- | :-- | :-- |
| 同步且干净 | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-sync.png" width="360" alt="before-sync"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-sync.png" width="360" alt="after-sync"> |
| 落后 3，干净 | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-behind.png" width="360" alt="before-behind"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-behind.png" width="360" alt="after-behind"> |
| 落后 3 + 已修改文件 + 未跟踪文件 | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-behind-dirty.png" width="360" alt="before-behind-dirty"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-behind-dirty.png" width="360" alt="after-behind-dirty"> |
| 新分支，1 个提交，无上游 | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-no-upstream.png" width="360" alt="before-no-upstream"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-no-upstream.png" width="360" alt="after-no-upstream"> |
| 领先 1 / 落后 1 | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-ahead-behind.png" width="360" alt="before-ahead-behind"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-ahead-behind.png" width="360" alt="after-ahead-behind"> |
| rebase 进行中且有冲突（HEAD 游离） | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-rebase-conflict.png" width="360" alt="before-rebase-conflict"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-rebase-conflict.png" width="360" alt="after-rebase-conflict"> |
| 游离 HEAD | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify/before-detached.png" width="360" alt="before-detached"> | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-detached.png" width="360" alt="after-detached"> |
| merge 进行中且有冲突，仍在分支上（第二轮新增） | （同其它 Before：无提示，全部可点） | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-merge-conflict.png" width="360" alt="after-merge-conflict"> |
| 上游在远端被删且已 prune（第二轮新增） | （同其它 Before：无提示，全部可点） | <img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-upstream-gone.png" width="360" alt="after-upstream-gone"> |


中文界面，落后 3 且有未提交更改：

<img src="https://raw.githubusercontent.com/wenshao/qwen-code/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2/after-behind-dirty-zh.png" width="360" alt="after-behind-dirty-zh">

资源：第一轮 [`wenshao/qwen-code@2d7c61f`](https://github.com/wenshao/qwen-code/tree/2d7c61f4dd3c398f5bdd04bf4dbea6a6b3792150/verify)，第二轮 [`wenshao/qwen-code@447a954`](https://github.com/wenshao/qwen-code/tree/447a954f7d1df0425e920e15406fa920ab1202e0/verify-r2)（分支 `pr-assets/10397-verify`）。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS；单元测试（vitest + jsdom）加上面的 bundle 版 `qwen serve` + 无头 Chromium（Playwright）实跑。

## 风险与范围

- 主要风险或取舍：在 git 会拒绝的状态下，"更新项目"（以及游离 HEAD 时的"推送"）现在会被禁用。弹窗打开时自取状态、且在更新的状态与列表矛盾时重拉列表，所以终端里完成的 rebase 会在芯片状态更新（聚焦 / 轮询 / SSE）后自动解除禁用，无需重开；两次刷新之间显示的是最后已知状态。列表与状态的新旧比较用的是 daemon 的 `computedAt` 与浏览器时钟，远程 daemon 时钟偏差时重拉可能不触发（此时退化为打开时的行为，绝不会错误地放开）。
- 未验证 / 不在范围内：composer 芯片和环境面板两个入口没有截图（同一组件、同样的 props，只驱动了侧栏芯片）。Windows/Linux 未在本地运行（纯客户端代码，无平台相关路径）。
- 破坏性变更 / 迁移说明：无。新 prop 均为可选；不传 `status` 的调用方也有弹窗自身的打开时拉取。`upstreamGone` 是分支列表上新增的可选字段。

## 关联 Issue

与 #10390 相关（脏工作区 pull 解决面板；相互独立、代码相邻）。

</details>
