### PR TITLE
test(ci): make release classifier stub module-safe

### DIFF
--- a/.github/scripts/classify-release-notes.test.mjs
+++ b/.github/scripts/classify-release-notes.test.mjs
@@ -241,7 +241,7 @@ describe('release note classification', () => {
           "if (args[0] === 'api' && args[1] === '-X' && (args[2] === 'POST' || args[2] === 'DELETE') && /\\/issues\\/\\d+\\/labels/.test(args[3])) {",
           "  const action = args[2] === 'DELETE' ? 'remove' : 'add';",
           "  const number = args[3].match(/\\/issues\\/(\\d+)\\/labels/)[1];",
-          `  require('node:fs').appendFileSync(${JSON.stringify(updates)}, number + ' ' + action + '\\n');`,
+          `  process.getBuiltinModule('node:fs').appendFileSync(${JSON.stringify(updates)}, number + ' ' + action + '\\n');`,
           '  process.exit(0);',
           '}',
           'process.exit(1);',


### PR DESCRIPTION
## What this PR does

Makes the release-note classifier test stub work whether Node interprets the extensionless executable as CommonJS or ESM.

## Why it's needed

The Ubuntu CI job intermittently failed on some self-hosted runners because the generated `gh` stub used CommonJS-only `require`. When the runner interpreted that extensionless script as ESM, label updates failed and the test produced no summary output.

## Reviewer Test Plan

### How to verify

Run the release-note classifier test normally and again with Node forced to treat extensionless scripts as ESM. Both runs should pass all three test cases, including continuing label updates after one lookup failure.

### Evidence (Before & After)

N/A — test-only compatibility fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.14.0; verified in normal mode and with `NODE_OPTIONS=--experimental-default-type=module`.

## Risk & Scope

- Main risk or tradeoff: Minimal; the change only affects a generated test stub and uses a Node.js API available in the supported Node 22 runtime.
- Not validated / out of scope: Windows and Linux were not tested locally.
- Breaking changes / migration notes: None.

## Linked Issues

Observed in the CI failures on #9984 and #10115.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

让发布说明分类测试中的模拟命令在 Node 将无扩展名可执行文件解释为 CommonJS 或 ESM 时都能正常运行。

## 为什么需要

部分自托管 runner 上的 Ubuntu CI 会间歇失败，因为生成的 `gh` 模拟命令使用了仅 CommonJS 可用的 `require`。当 runner 将该无扩展名脚本解释为 ESM 时，标签更新失败，测试无法输出汇总结果。

## Reviewer Test Plan

### 如何验证

正常运行发布说明分类测试，然后强制 Node 将无扩展名脚本解释为 ESM 再运行一次。两次都应通过全部三个用例，包括单次查询失败后继续更新其他标签的场景。

### 证据（修改前后）

不适用——仅测试兼容性修复。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22.14.0；已在普通模式和 `NODE_OPTIONS=--experimental-default-type=module` 模式下验证。

## 风险与范围

- 主要风险或权衡：极低；改动仅影响测试生成的模拟命令，并使用受支持 Node 22 运行时已提供的 API。
- 未验证或范围外：未在本地验证 Windows 和 Linux。
- 破坏性变更或迁移说明：无。

## 关联问题

该问题出现在 #9984 和 #10115 的 CI 失败中。

</details>
