### PR TITLE
fix(web-shell): keep pinned sessions visible in their sidebar group sections

### DIFF
--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -1017,9 +1017,7 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
     );
     expect(searchButton).not.toBeNull();
     act(() => {
-      searchButton!.dispatchEvent(
-        new MouseEvent('click', { bubbles: true }),
-      );
+      searchButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await flushSidebar();
     const searchInput = container.querySelector<HTMLInputElement>(
@@ -1118,14 +1116,91 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
     const titles = Array.from(
       group!.querySelectorAll('[data-web-shell-session-title]'),
     ).map((node) => node.textContent ?? '');
-    expect(
-      titles.filter((title) => title === 'Pinned member'),
-    ).toHaveLength(1);
-    expect(
-      titles.filter((title) => title === 'Active member'),
-    ).toHaveLength(1);
+    expect(titles.filter((title) => title === 'Pinned member')).toHaveLength(1);
+    expect(titles.filter((title) => title === 'Active member')).toHaveLength(1);
     // The pinned member still renders in the Pinned section too.
     expect(pinnedListTitles()).toContain('Pinned member');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
+
+  it('keeps a pinned color-tagged session in its color section', async () => {
+    mockDesignGroupCatalog();
+    const colorMember = makeSession('pinned-color', {
+      displayName: 'Pinned color',
+      color: 'red',
+      groupId: null,
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    active.sessions = [
+      colorMember,
+      makeSession('plain', { displayName: 'Plain session' }),
+    ];
+    active.data = active.sessions;
+    pinned.sessions = [colorMember];
+    pinned.data = pinned.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    // Color sections render only when non-empty: a pinned row that lost the
+    // color classification would make an all-pinned color section disappear
+    // entirely — the #10391 membership-loss symptom one path over.
+    const colorSection = container.querySelector<HTMLElement>(
+      'section[aria-label="Red"]',
+    );
+    expect(colorSection).not.toBeNull();
+    expect(colorSection?.textContent).toContain('\u00b7 1');
+    expect(colorSection?.textContent).toContain('Pinned color');
+    // The row stays in the Pinned section and never spills into Ungrouped.
+    expect(pinnedListTitles()).toContain('Pinned color');
+    const ungrouped = container.querySelector<HTMLElement>(
+      'section[aria-label="Ungrouped"]',
+    );
+    expect(ungrouped?.textContent ?? '').not.toContain('Pinned color');
+    expect(ungrouped?.textContent).toContain('Plain session');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
+
+  it('keeps a pinned member visible in its group preview ahead of unpinned members', async () => {
+    mockDesignGroupCatalog();
+    const pinnedMember = makeSession('pinned-member', {
+      displayName: 'Pinned member',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    // One pinned member plus five unpinned: the bucket exceeds the preview
+    // limit (5), so the pinned row must keep its catalog position (pinned
+    // sorts first) instead of being appended after every unpinned member,
+    // which would hide it behind "Show all".
+    const unpinnedMembers = [1, 2, 3, 4, 5].map((index) =>
+      makeSession(`unpinned-${index}`, {
+        displayName: `Unpinned ${index}`,
+        groupId: 'design-group',
+      }),
+    );
+    active.sessions = [pinnedMember, ...unpinnedMembers];
+    active.data = active.sessions;
+    pinned.sessions = [pinnedMember];
+    pinned.data = pinned.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    expect(group?.textContent).toContain('\u00b7 6');
+    const rows = Array.from(
+      group!.querySelectorAll('[data-web-shell-session-title]'),
+    ).map((node) => node.textContent ?? '');
+    expect(rows).toHaveLength(5);
+    expect(rows[0]).toBe('Pinned member');
+    expect(group?.textContent).toContain('Show all');
 
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -1204,6 +1204,7 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
 
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });
+
   it('drops a pinned member from its group when search only matches unpinned members', async () => {
     mockDesignGroupCatalog();
     const pinnedMember = makeSession('pinned-member', {
@@ -1258,6 +1259,62 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
     expect(group?.textContent).toContain('\u00b7 1');
     expect(group?.textContent).toContain('Active member');
     expect(group?.textContent ?? '').not.toContain('Pinned member');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
+
+  it('mounts a single rename form from the group row when the Pinned section is collapsed', async () => {
+    mockDesignGroupCatalog();
+    const member = makeSession('pinned-member', {
+      displayName: 'Pinned member',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    active.sessions = [member];
+    active.data = active.sessions;
+    pinned.sessions = [member];
+    pinned.data = pinned.sessions;
+    connection.sessionId = 'pinned-member';
+
+    renderSidebar();
+    await flushSidebar();
+
+    // Collapse the Pinned section: its rows unmount, so the duplicate group
+    // row becomes the rename host.
+    const pinnedToggle = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]'),
+    ).find((button) => button.textContent?.includes('Pinned'));
+    expect(pinnedToggle).not.toBeUndefined();
+    act(() => {
+      pinnedToggle!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushSidebar();
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]'),
+      )
+        .find((button) => button.textContent?.includes('Pinned'))
+        ?.getAttribute('aria-expanded'),
+    ).toBe('false');
+
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    const groupRow = Array.from(
+      group!.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((element) => element.textContent?.includes('Pinned member'));
+    expect(groupRow).not.toBeUndefined();
+    act(() => {
+      groupRow!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    });
+    await flushSidebar();
+
+    expect(
+      container.querySelectorAll('input[aria-label="Rename: Pinned member"]')
+        .length,
+    ).toBe(1);
 
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -976,4 +976,118 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
 
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });
+
+  function mockDesignGroupCatalog(): void {
+    workspaceActions.listSessionGroups.mockResolvedValue({
+      groups: [
+        {
+          id: 'design-group',
+          name: 'Design',
+          color: 'blue',
+          order: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+    });
+  }
+
+  it('keeps the group section visible when search only matches pinned members', async () => {
+    mockDesignGroupCatalog();
+    const member = makeSession('pinned-member', {
+      displayName: 'Pinned member',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    active.sessions = [
+      member,
+      makeSession('plain', { displayName: 'Plain session' }),
+    ];
+    active.data = active.sessions;
+    pinned.sessions = [member];
+    pinned.data = pinned.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    const searchButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Search sessions"]',
+    );
+    expect(searchButton).not.toBeNull();
+    act(() => {
+      searchButton!.dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    await flushSidebar();
+    const searchInput = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Search sessions"]',
+    );
+    expect(searchInput).not.toBeNull();
+    act(() => {
+      const setValue = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )!.set!;
+      setValue.call(searchInput, 'Pinned member');
+      searchInput!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flushSidebar();
+
+    // The only match is pinned, so the pinned-filtered flat list is empty;
+    // the body must still render the group section holding that member
+    // instead of the empty-state notice.
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    expect(group?.textContent).toContain('Pinned member');
+    expect(group?.textContent).toContain('\u00b7 1');
+    expect(container.textContent ?? '').not.toContain('No sessions');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
+
+  it('mounts a single rename form for a pinned member rendered in two rows', async () => {
+    mockDesignGroupCatalog();
+    const member = makeSession('pinned-member', {
+      displayName: 'Pinned member',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    active.sessions = [member];
+    active.data = active.sessions;
+    pinned.sessions = [member];
+    pinned.data = pinned.sessions;
+    connection.sessionId = 'pinned-member';
+
+    renderSidebar();
+    await flushSidebar();
+
+    // The member renders twice: in the Pinned section and in its group
+    // section. Starting a rename from the group row must mount one form.
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    const groupRow = Array.from(
+      group!.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((element) => element.textContent?.includes('Pinned member'));
+    expect(groupRow).not.toBeUndefined();
+    act(() => {
+      groupRow!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    });
+    await flushSidebar();
+
+    expect(
+      container.querySelectorAll('input[aria-label="Rename: Pinned member"]')
+        .length,
+    ).toBe(1);
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
+
 });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -1318,4 +1318,131 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
 
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });
+
+  it('mounts a single rename form for a secondary-workspace pinned member rendered in two rows', async () => {
+    // The sidebar-level Pinned section lifts pinned rows out of every
+    // workspace; a secondary workspace's own group section keeps the member
+    // too (#10391), so the member renders twice and only one row may host
+    // the rename form.
+    connection.capabilities = {
+      ...organizationCapabilities,
+      // Qualified-rest rename for non-current secondary sessions.
+      features: [
+        ...organizationCapabilities.features,
+        'workspace_session_metadata',
+        'workspace_qualified_rest_core',
+      ],
+    };
+    workspace.capabilities = {
+      ...organizationCapabilities,
+      workspaces: [
+        { id: 'primary', cwd: '/tmp/project', primary: true, trusted: true },
+        {
+          id: 'secondary',
+          cwd: '/tmp/other',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    const designGroupCatalog = {
+      groups: [
+        {
+          id: 'design-group',
+          name: 'Design',
+          color: 'blue',
+          order: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+    };
+    workspaceActions.listSessionGroups.mockResolvedValue({
+      groups: [],
+      colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+    });
+    const member = makeSession('secondary-member', {
+      displayName: 'Secondary member',
+      workspaceCwd: '/tmp/other',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    // The sidebar's secondary pinned page carries the grouped member.
+    useSessionCatalogQueries.mockImplementation(
+      (
+        _client: unknown,
+        queries: Array<{
+          workspaceCwd: string;
+          options?: Record<string, unknown>;
+        }>,
+      ) =>
+        queries.map((query) => {
+          if (
+            query.workspaceCwd === '/tmp/other' &&
+            query.options?.group === 'pinned'
+          ) {
+            return {
+              page: { sessions: [member] },
+              loading: false,
+              stale: false,
+            };
+          }
+          return {};
+        }),
+    );
+    // The secondary workspace section loads its own session and group pages.
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => {
+      if (cwd === '/tmp/other') {
+        return {
+          listWorkspaceSessions: vi.fn().mockResolvedValue([
+            member,
+            makeSession('secondary-plain', {
+              displayName: 'Secondary plain',
+              workspaceCwd: '/tmp/other',
+            }),
+          ]),
+          listSessionGroups: vi.fn().mockResolvedValue(designGroupCatalog),
+        };
+      }
+      return {
+        listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+        listSessionGroups: vi.fn().mockResolvedValue({
+          groups: [],
+          colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+        }),
+      };
+    });
+    pinned.sessions = [];
+    pinned.data = pinned.sessions;
+    active.sessions = [];
+    active.data = active.sessions;
+    connection.sessionId = 'secondary-member';
+
+    renderSidebar();
+    await flushSidebar();
+    await flushSidebar();
+
+    // The member renders twice: in the Pinned section and in the secondary
+    // workspace's group section.
+    expect(sessionTitleCount('Secondary member')).toBe(2);
+    const group = Array.from(
+      container.querySelectorAll<HTMLElement>('section[aria-label="Design"]'),
+    ).find((section) => section.textContent?.includes('Secondary member'));
+    expect(group).not.toBeUndefined();
+    const groupRow = Array.from(
+      group!.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((element) => element.textContent?.includes('Secondary member'));
+    expect(groupRow).not.toBeUndefined();
+    act(() => {
+      groupRow!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    });
+    await flushSidebar();
+
+    expect(
+      container.querySelectorAll('input[aria-label="Rename: Secondary member"]')
+        .length,
+    ).toBe(1);
+  });
 });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -1090,4 +1090,43 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });
 
+  it('renders each member once when a group mixes pinned and unpinned sessions', async () => {
+    mockDesignGroupCatalog();
+    const pinnedMember = makeSession('pinned-member', {
+      displayName: 'Pinned member',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    const activeMember = makeSession('active-member', {
+      displayName: 'Active member',
+      groupId: 'design-group',
+    });
+    active.sessions = [pinnedMember, activeMember];
+    active.data = active.sessions;
+    pinned.sessions = [pinnedMember];
+    pinned.data = pinned.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    expect(group?.textContent).toContain('\u00b7 2');
+    const titles = Array.from(
+      group!.querySelectorAll('[data-web-shell-session-title]'),
+    ).map((node) => node.textContent ?? '');
+    expect(
+      titles.filter((title) => title === 'Pinned member'),
+    ).toHaveLength(1);
+    expect(
+      titles.filter((title) => title === 'Active member'),
+    ).toHaveLength(1);
+    // The pinned member still renders in the Pinned section too.
+    expect(pinnedListTitles()).toContain('Pinned member');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
 });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -1319,6 +1319,40 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });
 
+  it('keeps a group-less pinned session out of the Ungrouped section', async () => {
+    mockDesignGroupCatalog();
+    const pinnedFree = makeSession('pinned-free', {
+      displayName: 'Pinned free',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+      // groupId and color stay null: the row has no color/group bucket.
+    });
+    active.sessions = [
+      pinnedFree,
+      makeSession('plain', { displayName: 'Plain session' }),
+    ];
+    active.data = active.sessions;
+    pinned.sessions = [pinnedFree];
+    pinned.data = pinned.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    // The pinned row stays in the dedicated Pinned section...
+    expect(pinnedListTitles()).toContain('Pinned free');
+
+    // ...and never spills into Ungrouped, which keeps only the plain row.
+    const ungrouped = container.querySelector<HTMLElement>(
+      'section[aria-label="Ungrouped"]',
+    );
+    expect(ungrouped).not.toBeNull();
+    expect(ungrouped?.textContent).toContain('Plain session');
+    expect(ungrouped?.textContent).toContain('\u00b7 1');
+    expect(ungrouped?.textContent ?? '').not.toContain('Pinned free');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
+
   it('mounts a single rename form for a secondary-workspace pinned member rendered in two rows', async () => {
     // The sidebar-level Pinned section lifts pinned rows out of every
     // workspace; a secondary workspace's own group section keeps the member

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -918,3 +918,62 @@ describe('WebShellSidebar session pinning (issue #9465)', () => {
     expect(pinnedListTitles()).toEqual(['Only pinned']);
   });
 });
+
+describe('WebShellSidebar pinned group members (issue #10391)', () => {
+  const defaultGroupsCatalog = {
+    groups: [],
+    colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+  };
+
+  it('keeps pinned sessions inside their group section instead of rendering the group empty', async () => {
+    workspaceActions.listSessionGroups.mockResolvedValue({
+      groups: [
+        {
+          id: 'design-group',
+          name: 'Design',
+          color: 'blue',
+          order: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+    });
+    const member = makeSession('pinned-member', {
+      displayName: 'Pinned member',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    active.sessions = [
+      member,
+      makeSession('plain', { displayName: 'Plain session' }),
+    ];
+    active.data = active.sessions;
+    pinned.sessions = [member];
+    pinned.data = pinned.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    // Reported symptom: every member pinned -> group rendered `· 0`.
+    expect(group?.textContent).toContain('· 1');
+    expect(group?.textContent).toContain('Pinned member');
+
+    // The pinned row also stays in the dedicated Pinned section.
+    expect(pinnedListTitles()).toContain('Pinned member');
+
+    // ...and it does not fall into Ungrouped.
+    const ungrouped = container.querySelector<HTMLElement>(
+      'section[aria-label="Ungrouped"]',
+    );
+    expect(ungrouped?.textContent ?? '').not.toContain('Pinned member');
+    expect(ungrouped?.textContent).toContain('Plain session');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
+});

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -1479,4 +1479,111 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
         .length,
     ).toBe(1);
   });
+
+  it('mounts the rename form on the workspace row while the pinned page is absent', async () => {
+    // Cold-load race: the secondary workspace's own session page settles
+    // before the sidebar's secondary pinned catalog page (or the pinned
+    // query errors and retries only after 30s). `pinnedSessions` then lacks
+    // the member, so the Pinned section renders no host row for it — the
+    // workspace group row must host the rename form itself instead of being
+    // suppressed, otherwise double-click rename is a silent no-op.
+    connection.capabilities = {
+      ...organizationCapabilities,
+      features: [
+        ...organizationCapabilities.features,
+        'workspace_session_metadata',
+        'workspace_qualified_rest_core',
+      ],
+    };
+    workspace.capabilities = {
+      ...organizationCapabilities,
+      workspaces: [
+        { id: 'primary', cwd: '/tmp/project', primary: true, trusted: true },
+        {
+          id: 'secondary',
+          cwd: '/tmp/other',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    };
+    const designGroupCatalog = {
+      groups: [
+        {
+          id: 'design-group',
+          name: 'Design',
+          color: 'blue',
+          order: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+    };
+    workspaceActions.listSessionGroups.mockResolvedValue({
+      groups: [],
+      colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+    });
+    const member = makeSession('secondary-member', {
+      displayName: 'Secondary member',
+      workspaceCwd: '/tmp/other',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    // The secondary pinned catalog page never settles (absent query result),
+    // so `pinnedSessions` stays empty and the Pinned section never renders.
+    useSessionCatalogQueries.mockImplementation(
+      (_client: unknown, queries: Array<{ workspaceCwd: string }>) =>
+        queries.map(() => ({})),
+    );
+    // The secondary workspace section loads its own session page carrying
+    // the pinned member.
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => {
+      if (cwd === '/tmp/other') {
+        return {
+          listWorkspaceSessions: vi.fn().mockResolvedValue([member]),
+          listSessionGroups: vi.fn().mockResolvedValue(designGroupCatalog),
+        };
+      }
+      return {
+        listWorkspaceSessions: vi.fn().mockResolvedValue([]),
+        listSessionGroups: vi.fn().mockResolvedValue({
+          groups: [],
+          colorOptions: ['red', 'orange', 'yellow', 'green', 'blue', 'purple'],
+        }),
+      };
+    });
+    pinned.sessions = [];
+    pinned.data = pinned.sessions;
+    active.sessions = [];
+    active.data = active.sessions;
+    connection.sessionId = 'secondary-member';
+
+    renderSidebar();
+    await flushSidebar();
+    await flushSidebar();
+
+    // No host row exists in the Pinned section...
+    expect(pinnedListTitles()).not.toContain('Secondary member');
+    // ...so the only rendered copy is the workspace group row.
+    expect(sessionTitleCount('Secondary member')).toBe(1);
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    const groupRow = Array.from(
+      group!.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((element) => element.textContent?.includes('Secondary member'));
+    expect(groupRow).not.toBeUndefined();
+    act(() => {
+      groupRow!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    });
+    await flushSidebar();
+
+    expect(
+      container.querySelectorAll('input[aria-label="Rename: Secondary member"]')
+        .length,
+    ).toBe(1);
+  });
 });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
@@ -1204,4 +1204,61 @@ describe('WebShellSidebar pinned group members (issue #10391)', () => {
 
     workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
   });
+  it('drops a pinned member from its group when search only matches unpinned members', async () => {
+    mockDesignGroupCatalog();
+    const pinnedMember = makeSession('pinned-member', {
+      displayName: 'Pinned member',
+      groupId: 'design-group',
+      isPinned: true,
+      pinnedAt: '2026-01-02T00:00:00.000Z',
+    });
+    active.sessions = [
+      pinnedMember,
+      makeSession('active-member', {
+        displayName: 'Active member',
+        groupId: 'design-group',
+      }),
+    ];
+    active.data = active.sessions;
+    pinned.sessions = [pinnedMember];
+    pinned.data = pinned.sessions;
+
+    renderSidebar();
+    await flushSidebar();
+
+    const searchButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Search sessions"]',
+    );
+    expect(searchButton).not.toBeNull();
+    act(() => {
+      searchButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushSidebar();
+    const searchInput = container.querySelector<HTMLInputElement>(
+      'input[aria-label="Search sessions"]',
+    );
+    expect(searchInput).not.toBeNull();
+    act(() => {
+      const setValue = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )!.set!;
+      setValue.call(searchInput, 'Active member');
+      searchInput!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flushSidebar();
+
+    // The query matches only the unpinned member: the grouped bucket must
+    // read the search-filtered list, so the pinned member leaves the group
+    // instead of lingering as a stale row with a stale count.
+    const group = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(group).not.toBeNull();
+    expect(group?.textContent).toContain('\u00b7 1');
+    expect(group?.textContent).toContain('Active member');
+    expect(group?.textContent ?? '').not.toContain('Pinned member');
+
+    workspaceActions.listSessionGroups.mockResolvedValue(defaultGroupsCatalog);
+  });
 });

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -5400,10 +5400,26 @@ export function WebShellSidebar({
                           }
                           renderSessions={!ws.primary}
                           renderSession={(session) =>
-                            renderSessionRow({
-                              ...session,
-                              workspaceCwd: ws.cwd,
-                            })
+                            renderSessionRow(
+                              {
+                                ...session,
+                                workspaceCwd: ws.cwd,
+                              },
+                              {
+                                // Pinned members also render in the
+                                // sidebar-level Pinned section; while that
+                                // section is expanded its row hosts the
+                                // rename form, so this duplicate row must
+                                // not mount a second autofocused input.
+                                // Channel mode has no Pinned section, so
+                                // the workspace row is the only copy and
+                                // must stay editable.
+                                renameFormDisabled:
+                                  selectedSessionSource !== 'channel' &&
+                                  Boolean(session.isPinned) &&
+                                  pinnedExpanded,
+                              },
+                            )
                           }
                           showSessionDetails={sessionActionItems.has('details')}
                           headerActions={(visible) => {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -3491,19 +3491,15 @@ export function WebShellSidebar({
     ],
   );
 
-  const filteredSessions = useMemo(() => {
+  const searchedSessions = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     const sourceScopedSessions = sessions
       .map(applyOptimisticPin)
       .filter((session) =>
         matchesSessionSource(session, selectedSessionSource),
       );
-    const unpinnedSessions =
-      selectedSessionSource === 'channel'
-        ? sourceScopedSessions
-        : sourceScopedSessions.filter((session) => !session.isPinned);
-    const nextSessions = query
-      ? unpinnedSessions.filter((session) => {
+    return query
+      ? sourceScopedSessions.filter((session) => {
           const label = getSessionLabel(session).toLowerCase();
           return (
             label.includes(query) ||
@@ -3511,7 +3507,14 @@ export function WebShellSidebar({
             sessionMatchesGitQuery(session, query)
           );
         })
-      : unpinnedSessions.slice();
+      : sourceScopedSessions;
+  }, [applyOptimisticPin, searchQuery, selectedSessionSource, sessions]);
+  const filteredSessions = useMemo(() => {
+    const unpinnedSessions =
+      selectedSessionSource === 'channel'
+        ? searchedSessions
+        : searchedSessions.filter((session) => !session.isPinned);
+    const nextSessions = unpinnedSessions.slice();
     if (organizationEnabled) {
       return nextSessions;
     }
@@ -3526,13 +3529,7 @@ export function WebShellSidebar({
         (createdTimeById.get(b.sessionId) ?? 0) -
         (createdTimeById.get(a.sessionId) ?? 0),
     );
-  }, [
-    applyOptimisticPin,
-    organizationEnabled,
-    searchQuery,
-    selectedSessionSource,
-    sessions,
-  ]);
+  }, [organizationEnabled, searchedSessions, selectedSessionSource]);
 
   const channelCatalogLoaded = channelCatalogData !== undefined;
   const channelSessionSections = useMemo(
@@ -3587,6 +3584,22 @@ export function WebShellSidebar({
         recentSessions.push(session);
       }
     }
+    // Pinned members are lifted into the Pinned section, but their group must
+    // keep them: without this merge a group whose members are all pinned
+    // rendered `· 0`, indistinguishable from lost memberships (#10391).
+    // The channel source keeps pinned rows in `filteredSessions` already; for
+    // other sources pinned sessions without a group stay Pinned-section-only
+    // and never spill into Ungrouped.
+    if (selectedSessionSource !== 'channel') {
+      for (const session of searchedSessions) {
+        if (!session.isPinned) continue;
+        const groupSessions =
+          session.groupId && validGroupIds.has(session.groupId)
+            ? sessionsByGroupId.get(session.groupId)
+            : undefined;
+        if (groupSessions) groupSessions.push(session);
+      }
+    }
     const sections: SessionSection[] = [];
     // Color buckets first, in palette order; only render non-empty ones so the
     // sidebar never shows six empty color headers.
@@ -3626,7 +3639,15 @@ export function WebShellSidebar({
       });
     }
     return sections;
-  }, [filteredSessions, groups, organizationEnabled, searchQuery, t]);
+  }, [
+    filteredSessions,
+    groups,
+    organizationEnabled,
+    searchedSessions,
+    searchQuery,
+    selectedSessionSource,
+    t,
+  ]);
 
   useEffect(() => {
     const activeSections = channelSessionSections ?? sessionSections;

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -3835,9 +3835,10 @@ export function WebShellSidebar({
       session: DaemonSessionSummary,
       options: {
         isArchived?: boolean;
+        renameFormDisabled?: boolean;
       } = {},
     ) => {
-      const { isArchived = false } = options;
+      const { isArchived = false, renameFormDisabled = false } = options;
       const sessionIdentity = getIdentityForSession(session);
       const label = getSessionLabel(session);
       const stamp = session.updatedAt || session.createdAt;
@@ -3846,7 +3847,12 @@ export function WebShellSidebar({
       const exporting = exportingSessionIds.has(sessionIdentity);
       const completedUnread =
         !isCurrentSession(session) && completedUnreadIds.has(sessionIdentity);
-      const isEditing = editingSessionIdentity === sessionIdentity;
+      // Pinned group members also render in the Pinned section; callers
+      // suppress the rename form on the duplicate row so only one input can
+      // mount — a rival input's autofocus would blur this one and its blur
+      // handler would cancel the rename.
+      const isEditing =
+        !renameFormDisabled && editingSessionIdentity === sessionIdentity;
       const gitIcon = session.worktree ? (
         <GitForkIcon aria-label={t('sidebar.newWorktreeTask')} />
       ) : session.branch ? (
@@ -4445,7 +4451,6 @@ export function WebShellSidebar({
       filteredSessions.length === 0 &&
       (selectedSessionSource === 'channel' ||
         channelSessionSections !== null ||
-        searchQuery.trim() ||
         !organizationEnabled ||
         sessionSections.length === 0)
     ) {
@@ -4503,7 +4508,14 @@ export function WebShellSidebar({
           deleteLabel={t('sidebar.groupDelete')}
           actionsDisabled={groupBusy}
         >
-          {section.sessions.map((session) => renderSessionRow(session))}
+          {section.sessions.map((session) =>
+            renderSessionRow(session, {
+              // Pinned members also render in the Pinned section; while that
+              // section is expanded its row hosts the rename form, so this
+              // duplicate row must not mount a second autofocused input.
+              renameFormDisabled: Boolean(session.isPinned) && pinnedExpanded,
+            }),
+          )}
         </SessionGroupSection>
       );
     });
@@ -4519,6 +4531,7 @@ export function WebShellSidebar({
     handleRenameGroup,
     loading,
     organizationEnabled,
+    pinnedExpanded,
     reload,
     renderSessionRow,
     searchQuery,

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -5413,11 +5413,24 @@ export function WebShellSidebar({
                                 // not mount a second autofocused input.
                                 // Channel mode has no Pinned section, so
                                 // the workspace row is the only copy and
-                                // must stay editable.
+                                // must stay editable. The suppression also
+                                // requires the Pinned section to actually
+                                // carry the member: `pinnedSessions` merges
+                                // only the pinned catalog pages and the
+                                // primary sessions page, never this
+                                // workspace's own page, so before the
+                                // pinned page settles (or while it errors)
+                                // this row is the only copy and must host
+                                // the form itself.
                                 renameFormDisabled:
                                   selectedSessionSource !== 'channel' &&
                                   Boolean(session.isPinned) &&
-                                  pinnedExpanded,
+                                  pinnedExpanded &&
+                                  pinnedSessions.some(
+                                    (candidate) =>
+                                      getIdentityForSession(candidate) ===
+                                      getIdentityForSession(session),
+                                  ),
                               },
                             )
                           }

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -3565,7 +3565,15 @@ export function WebShellSidebar({
       sessionsByGroupId.set(group.id, []);
     }
     const recentSessions: DaemonSessionSummary[] = [];
-    for (const session of filteredSessions) {
+    // Bucket the search-filtered catalog in one pass, pinned rows included:
+    // they are lifted into the Pinned section, but their group/color section
+    // must keep them, otherwise a section whose members are all pinned
+    // rendered `· 0`, indistinguishable from lost memberships (#10391).
+    // One pass (instead of bucketing the unpinned rows first and appending
+    // the pinned ones) preserves the daemon catalog order — pinned rows sort
+    // first there — so a pinned member is never pushed behind its section's
+    // preview limit by rows it sorts ahead of.
+    for (const session of searchedSessions) {
       // Color takes precedence: the picker keeps color and group mutually
       // exclusive, but stay defensive if a store somehow carries both.
       if (session.color && SESSION_GROUP_COLORS.includes(session.color)) {
@@ -3580,25 +3588,14 @@ export function WebShellSidebar({
           : undefined;
       if (groupSessions) {
         groupSessions.push(session);
-      } else {
-        recentSessions.push(session);
+        continue;
       }
-    }
-    // Pinned members are lifted into the Pinned section, but their group must
-    // keep them: without this merge a group whose members are all pinned
-    // rendered `· 0`, indistinguishable from lost memberships (#10391).
-    // The channel source keeps pinned rows in `filteredSessions` already; for
-    // other sources pinned sessions without a group stay Pinned-section-only
-    // and never spill into Ungrouped.
-    if (selectedSessionSource !== 'channel') {
-      for (const session of searchedSessions) {
-        if (!session.isPinned) continue;
-        const groupSessions =
-          session.groupId && validGroupIds.has(session.groupId)
-            ? sessionsByGroupId.get(session.groupId)
-            : undefined;
-        if (groupSessions) groupSessions.push(session);
-      }
+      // On sources with a Pinned section, a pinned session without a
+      // (renderable) group stays Pinned-section-only; it never spills into
+      // Ungrouped. The channel source has no Pinned section, so its pinned
+      // rows keep the normal Ungrouped bucket.
+      if (session.isPinned && selectedSessionSource !== 'channel') continue;
+      recentSessions.push(session);
     }
     const sections: SessionSection[] = [];
     // Color buckets first, in palette order; only render non-empty ones so the
@@ -3640,7 +3637,6 @@ export function WebShellSidebar({
     }
     return sections;
   }, [
-    filteredSessions,
     groups,
     organizationEnabled,
     searchedSessions,

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -1316,4 +1316,37 @@ describe('WorkspaceSection pinned group members (issue #10391)', () => {
     expect(groupSection?.textContent).toContain('Pinned member');
     expect(groupSection?.textContent ?? '').not.toContain('Active member');
   });
+
+  it('keeps a group-less pinned session out of the Ungrouped section', async () => {
+    renderSection({
+      client: makeOrganizationClient([
+        {
+          sessionId: 'pinned-free',
+          displayName: 'Pinned free',
+          groupId: null,
+          isPinned: true,
+          pinnedAt: '2026-01-02T00:00:00.000Z',
+        },
+        {
+          sessionId: 'plain-session',
+          displayName: 'Plain session',
+          groupId: null,
+        },
+      ] as Array<Partial<DaemonSessionSummary>>),
+      expanded: true,
+      organizationEnabled: true,
+      excludePinned: true,
+    });
+    await flush();
+
+    // `ungrouped` derives from the pinned-filtered list, so the group-less
+    // pinned session never duplicates the Pinned section inside Ungrouped.
+    const ungrouped = container.querySelector<HTMLElement>(
+      'section[aria-label="Ungrouped"]',
+    );
+    expect(ungrouped).not.toBeNull();
+    expect(ungrouped?.textContent).toContain('\u00b7 1');
+    expect(ungrouped?.textContent).toContain('Plain session');
+    expect(ungrouped?.textContent ?? '').not.toContain('Pinned free');
+  });
 });

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -134,6 +134,7 @@ function renderSection(
     sessionGroupCatalog: DaemonSessionGroupCatalog;
     sessionLiveStateEnabled: boolean;
     excludePinned: boolean;
+    searchQuery: string;
   }> = {},
 ): void {
   act(() => {
@@ -156,6 +157,7 @@ function renderSection(
           sessionGroupCatalog={overrides.sessionGroupCatalog}
           sessionLiveStateEnabled={overrides.sessionLiveStateEnabled}
           excludePinned={overrides.excludePinned}
+          searchQuery={overrides.searchQuery}
           sourceType={overrides.sourceType}
           channelGroupingEnabled={overrides.channelGroupingEnabled}
           ungroupedLabel="Ungrouped"
@@ -1278,5 +1280,40 @@ describe('WorkspaceSection pinned group members (issue #10391)', () => {
     expect(groupSection?.textContent).toContain('\u00b7 1');
     expect(groupSection?.textContent).toContain('Pinned member');
     expect(container.textContent ?? '').not.toContain('No sessions');
+  });
+
+  it('keeps a pinned member in its group while searching matches only it', async () => {
+    renderSection({
+      client: makeOrganizationClient([
+        {
+          sessionId: 'pinned-member',
+          displayName: 'Pinned member',
+          groupId: 'design-group',
+          isPinned: true,
+          pinnedAt: '2026-01-02T00:00:00.000Z',
+        },
+        {
+          sessionId: 'active-member',
+          displayName: 'Active member',
+          groupId: 'design-group',
+        },
+      ] as Array<Partial<DaemonSessionSummary>>),
+      expanded: true,
+      organizationEnabled: true,
+      excludePinned: true,
+      searchQuery: 'pinned',
+    });
+    await flush();
+
+    // The query matches only the pinned member, so group items must derive
+    // from the search-filtered list: it stays in its group while the
+    // non-matching member disappears.
+    const groupSection = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(groupSection).not.toBeNull();
+    expect(groupSection?.textContent).toContain('\u00b7 1');
+    expect(groupSection?.textContent).toContain('Pinned member');
+    expect(groupSection?.textContent ?? '').not.toContain('Active member');
   });
 });

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -133,6 +133,7 @@ function renderSection(
     sessionCatalogRequestsEnabled: boolean;
     sessionGroupCatalog: DaemonSessionGroupCatalog;
     sessionLiveStateEnabled: boolean;
+    excludePinned: boolean;
   }> = {},
 ): void {
   act(() => {
@@ -154,6 +155,7 @@ function renderSection(
           }
           sessionGroupCatalog={overrides.sessionGroupCatalog}
           sessionLiveStateEnabled={overrides.sessionLiveStateEnabled}
+          excludePinned={overrides.excludePinned}
           sourceType={overrides.sourceType}
           channelGroupingEnabled={overrides.channelGroupingEnabled}
           ungroupedLabel="Ungrouped"
@@ -1149,5 +1151,103 @@ describe('isAbsolutePath', () => {
     expect(isAbsolutePath('\\\\server\\share')).toBe(true);
     expect(isAbsolutePath('relative/path')).toBe(false);
     expect(isAbsolutePath('name')).toBe(false);
+  });
+});
+
+describe('WorkspaceSection pinned group members (issue #10391)', () => {
+  function makeOrganizationClient(
+    sessions: Array<Partial<DaemonSessionSummary>>,
+  ): DaemonClient {
+    return {
+      workspaceByCwd: vi.fn(() => ({
+        workspaceGit,
+        listWorkspaceSessionsPage: vi.fn().mockResolvedValue({ sessions }),
+        listSessionGroups: vi.fn().mockResolvedValue({
+          groups: [
+            {
+              id: 'design-group',
+              name: 'Design',
+              color: 'blue',
+              order: 0,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      })),
+    } as unknown as DaemonClient;
+  }
+
+  it('keeps pinned members in their group section and count', async () => {
+    renderSection({
+      client: makeOrganizationClient([
+        {
+          sessionId: 'pinned-member',
+          displayName: 'Pinned member',
+          groupId: 'design-group',
+          isPinned: true,
+          pinnedAt: '2026-01-02T00:00:00.000Z',
+        },
+        {
+          sessionId: 'plain-session',
+          displayName: 'Plain session',
+          groupId: null,
+        },
+      ] as Array<Partial<DaemonSessionSummary>>),
+      expanded: true,
+      organizationEnabled: true,
+      excludePinned: true,
+    });
+    await flush();
+
+    const groupSection = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(groupSection).not.toBeNull();
+    // The reported symptom: a group whose members are all pinned rendered
+    // `· 0`, visually identical to lost memberships.
+    expect(groupSection?.textContent).toContain('· 1');
+    expect(groupSection?.textContent).toContain('Pinned member');
+
+    // Pinned members keep their group and must not fall into Ungrouped.
+    const ungrouped = container.querySelector<HTMLElement>(
+      'section[aria-label="Ungrouped"]',
+    );
+    expect(ungrouped?.textContent).toContain('Plain session');
+    expect(ungrouped?.textContent ?? '').not.toContain('Pinned member');
+  });
+
+  it('still renders unpinned members when pinned rows are lifted into the group', async () => {
+    renderSection({
+      client: makeOrganizationClient([
+        {
+          sessionId: 'pinned-member',
+          displayName: 'Pinned member',
+          groupId: 'design-group',
+          isPinned: true,
+          pinnedAt: '2026-01-02T00:00:00.000Z',
+        },
+        {
+          sessionId: 'active-member',
+          displayName: 'Active member',
+          groupId: 'design-group',
+        },
+      ] as Array<Partial<DaemonSessionSummary>>),
+      expanded: true,
+      organizationEnabled: true,
+      excludePinned: true,
+    });
+    await flush();
+
+    const groupSection = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(groupSection?.textContent).toContain('· 2');
+    expect(groupSection?.textContent).toContain('Active member');
+    expect(groupSection?.textContent).toContain('Pinned member');
+    // Every session belongs to the group, so no Ungrouped bucket renders.
+    expect(
+      container.querySelector('section[aria-label="Ungrouped"]'),
+    ).toBeNull();
   });
 });

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.test.tsx
@@ -1250,4 +1250,33 @@ describe('WorkspaceSection pinned group members (issue #10391)', () => {
       container.querySelector('section[aria-label="Ungrouped"]'),
     ).toBeNull();
   });
+
+  it('renders group sections instead of the empty label when every session is pinned', async () => {
+    renderSection({
+      client: makeOrganizationClient([
+        {
+          sessionId: 'pinned-member',
+          displayName: 'Pinned member',
+          groupId: 'design-group',
+          isPinned: true,
+          pinnedAt: '2026-01-02T00:00:00.000Z',
+        },
+      ] as Array<Partial<DaemonSessionSummary>>),
+      expanded: true,
+      organizationEnabled: true,
+      excludePinned: true,
+    });
+    await flush();
+
+    // Every session is a pinned group member, so the pinned-filtered list is
+    // empty; the grouped view must still render the member instead of the
+    // empty label.
+    const groupSection = container.querySelector<HTMLElement>(
+      'section[aria-label="Design"]',
+    );
+    expect(groupSection).not.toBeNull();
+    expect(groupSection?.textContent).toContain('\u00b7 1');
+    expect(groupSection?.textContent).toContain('Pinned member');
+    expect(container.textContent ?? '').not.toContain('No sessions');
+  });
 });

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -588,7 +588,16 @@ export function WorkspaceSection({
               <div className={styles.error} role="status">
                 {loadErrorLabel}
               </div>
-            ) : visibleSessions.length === 0 ? (
+            ) : visibleSessions.length === 0 &&
+              // Group sections keep pinned members even when the
+              // pinned-filtered list is empty, so only show the empty label
+              // when the grouped view has nothing to render either.
+              !(
+                groupedSessions &&
+                groupedSessions.sections.some(
+                  (section) => section.sessions.length > 0,
+                )
+              ) ? (
               // A source switch swaps the query key; until the new source's
               // page settles there is no data yet, so the "no sessions" notice
               // would flash for a whole fetch round-trip.

--- a/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
+++ b/packages/web-shell/client/components/sidebar/WorkspaceSection.tsx
@@ -429,12 +429,11 @@ export function WorkspaceSection({
     workspace.trusted,
   ]);
 
-  const visibleSessions = useMemo(() => {
+  const searchedSessions = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     return sessions
       .map((session) => mapSession?.(session) ?? session)
       .filter((session) => {
-        if (excludePinned && session.isPinned) return false;
         if (!query) return true;
         const label = (session.displayName || '').toLowerCase();
         return (
@@ -443,7 +442,14 @@ export function WorkspaceSection({
           sessionMatchesGitQuery(session, query)
         );
       });
-  }, [excludePinned, mapSession, searchQuery, sessions]);
+  }, [mapSession, searchQuery, sessions]);
+  const visibleSessions = useMemo(
+    () =>
+      excludePinned
+        ? searchedSessions.filter((session) => !session.isPinned)
+        : searchedSessions,
+    [excludePinned, searchedSessions],
+  );
   const directSessions =
     searchActive || showAllSessions || !limitSessions
       ? visibleSessions
@@ -454,7 +460,12 @@ export function WorkspaceSection({
       return null;
     const assigned = new Set<string>();
     const sections = groups.map((group) => {
-      const items = visibleSessions.filter(
+      // Group sections derive from the search-filtered list, not the
+      // pinned-filtered one: pinned members are lifted into the Pinned
+      // section, but dropping them here rendered a group whose members are
+      // all pinned as `· 0`, indistinguishable from lost memberships
+      // (#10391).
+      const items = searchedSessions.filter(
         (session) => session.groupId === group.id,
       );
       items.forEach((session) => assigned.add(session.sessionId));
@@ -462,11 +473,19 @@ export function WorkspaceSection({
     });
     return {
       sections,
+      // Pinned sessions without a group stay Pinned-section-only; they never
+      // spill into Ungrouped.
       ungrouped: visibleSessions.filter(
         (session) => !assigned.has(session.sessionId),
       ),
     };
-  }, [channelGroupingEnabled, groups, organizationEnabled, visibleSessions]);
+  }, [
+    channelGroupingEnabled,
+    groups,
+    organizationEnabled,
+    searchedSessions,
+    visibleSessions,
+  ]);
 
   const channelSessionGroups = useMemo(
     () =>

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -628,7 +628,8 @@ function readRequestBody(raw: string | null): unknown {
 
 // Mirror production query modes: `group=pinned` is the pinned bucket;
 // `group=all` (and missing group) returns the full active list. The UI
-// excludes pinned rows from organized sections via `excludePinned`.
+// renders pinned rows in the Pinned section and keeps them inside their
+// named groups; unassigned pinned rows stay out of Ungrouped.
 function filterScenarioSessions(
   scenario: WebShellDaemonScenario,
   searchParams: URLSearchParams,


### PR DESCRIPTION
## What this PR does

The web-shell sidebar lifts pinned sessions into the dedicated Pinned section, but it also silently dropped them from their group sections: both group rendering paths derived sections from the already pinned-filtered session list, so group membership and counts only ever saw unpinned members. This change keeps pinned members inside their named group in both paths — `groupedSessions` in `WorkspaceSection` (secondary workspaces) and `sessionSections` in `WebShellSidebar` (primary workspace) — by deriving the group buckets from the search-filtered list, which still contains pinned rows. The Pinned section keeps its rows, and Ungrouped keeps excluding pinned sessions, so unassigned pinned sessions stay Pinned-section-only.

## Why it's needed

Reported in #10391: a group whose members are all pinned rendered `· 0` with no rows — visually identical to losing the memberships, even though the server-side organization store and the organized-view API still return the correct `groupId`. Assigning an already-pinned session to a group also gave no visible feedback. Group memberships are data the user created deliberately; pinning a member must not make the membership disappear from the sidebar.

## Reviewer Test Plan

### How to verify

Unit/integration (deterministic), in `packages/web-shell`:

```
npx vitest run --config vitest.config.ts client/components/sidebar/WorkspaceSection.test.tsx client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
```

Three new cases (red before the fix, green after):

- `WorkspaceSection` with `excludePinned` + one group whose only member is pinned: the group renders `· 1` and contains the pinned member row; the pinned member does not fall into Ungrouped. Before the fix it rendered `Design· 0` with no rows.
- Same setup with one pinned + one unpinned member: group renders `· 2` with both rows; no Ungrouped bucket appears. Before: `· 1` (unpinned member only).
- `WebShellSidebar` (primary-workspace path) with the same data shape: group shows `· 1` with the pinned row, the row also stays in the Pinned section, and Ungrouped only holds the two ungrouped sessions.

Regression guards: the pre-existing channel-mode test (`excludePinned` off) still passes — pinned channel rows stay inside their platform section; the full package suite passes (206 files / 4421 tests).

Manual UI verification (real runtime, headless Chromium): a throwaway `qwen serve` instance on a non-default port with a seeded workspace — one session pinned **and** assigned to a named group (sole member), two ungrouped sessions — served through the package's vite dev server. Before/after captured by reverting/applying only this diff on the same daemon data.

Typecheck (`tsc -p tsconfig.json --noEmit` in `packages/web-shell`): no new errors introduced by this diff. One pre-existing error in `client/App.tsx` (`MODES_CYCLE.indexOf(currentMode)` with a `string` mode) reproduces identically with this diff reverted on the same locally built workspace deps, so it is unrelated to this change.

### Evidence (Before & After)

Before — all-pinned group renders `· 0`, member only in Pinned (`designTitles: []`):

![before: group shows · 0](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/qc-10391-before-group-0.png)

After — group shows `· 1` with the pinned member row; still listed in Pinned; Ungrouped unchanged:

![after: group keeps its pinned member](https://raw.githubusercontent.com/yiliang114/img-host/main/assets/qc-10391-after-group-member.png)

DOM assertions captured with the screenshots:

```json
{
  "phase": "before",
  "designSectionText": "Design· 0",
  "designTitles": [],
  "ungroupedTitles": ["Ungrouped task B", "Ungrouped task A"],
  "pinnedTitles": ["Pinned group member"]
}
{
  "phase": "after",
  "designSectionText": "Design· 1Pinned group member",
  "designTitles": ["Pinned group member"],
  "ungroupedTitles": ["Ungrouped task B", "Ungrouped task A"],
  "pinnedTitles": ["Pinned group member"]
}
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node v24.19.0; package-local Vitest; UI capture via Playwright-driven headless Chromium against a local `qwen serve` (0.22.2, isolated workspace + non-default port + own bearer token) proxied through the web-shell vite dev server. The production daemon on this machine was not touched.

## Risk & Scope

- Main risk or tradeoff: pinned group members now render twice — once in the Pinned section and once inside their named group. This mirrors today's channel-source behavior, where pinned rows already stay inside their platform section; rows carry the existing pinned-row affordances (Unpin action), so the duplicate is identifiable.
- Not validated / out of scope: server-side organization store and organized-view API were verified intact by the report and re-checked here — unchanged. The e2e mock daemon comment describing the old behavior is updated; e2e specs are otherwise untouched (channel-mode fixtures are unaffected). Color-bucket behavior for pinned sessions is unchanged (out of the reported scope).
- Breaking changes / migration notes: none — client-only rendering change; no API, storage, or i18n surface changes.

## Linked Issues

Fixes #10391

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Web Shell 侧边栏会把置顶会话提升到专门的「Pinned」区，但此前也把它们从所属分组区里悄悄移除了：两条分组渲染路径都从「已过滤掉置顶行」的会话列表推导分组，因此分组成员与计数永远只能看到未置顶成员。本改动在两条路径中都让置顶成员保留在其命名分组内 —— `WorkspaceSection` 的 `groupedSessions`（次级工作区）与 `WebShellSidebar` 的 `sessionSections`（主工作区）—— 分组桶改为从搜索过滤后的列表（仍包含置顶行）推导。Pinned 区保留原有行；Ungrouped 继续排除置顶会话，因此未分组的置顶会话仍然只出现在 Pinned 区。

## 为什么需要

来自 #10391：成员全部被置顶的分组会渲染成 `· 0` 且没有任何行 —— 视觉上与「归属关系丢失」完全相同，尽管服务端组织存储和 organized-view API 仍返回正确的 `groupId`。把已置顶的会话分配到分组时也没有任何可见反馈。分组归属是用户主动创建的数据；置顶成员不应导致归属从侧边栏消失。

## 评审验证计划

### 如何验证

单元/集成（确定性），在 `packages/web-shell` 下：

```
npx vitest run --config vitest.config.ts client/components/sidebar/WorkspaceSection.test.tsx client/components/sidebar/WebShellSidebar.session-pinning.test.tsx
```

三个新用例（修复前红、修复后绿）：

- `WorkspaceSection` 在 `excludePinned` + 唯一成员被置顶的分组下：分组渲染 `· 1` 且包含置顶成员行；该成员不会落入 Ungrouped。修复前渲染为 `Design· 0` 且无行。
- 同上但为一个置顶 + 一个未置顶成员：分组渲染 `· 2` 且两行都在；不出现 Ungrouped 桶。修复前为 `· 1`（仅未置顶成员）。
- `WebShellSidebar`（主工作区路径）相同数据形状：分组显示 `· 1` 且含置顶行，该行同时保留在 Pinned 区，Ungrouped 只含两个未分组会话。

回归保护：既有的 channel 模式测试（`excludePinned` 关闭）仍通过 —— 置顶的 channel 行仍留在其平台分区内；整包测试通过（206 文件 / 4421 用例）。

手工 UI 验证（真实运行时、headless Chromium）：在非默认端口起一次性 `qwen serve` 实例，种子数据为一个工作区 —— 一个会话同时被置顶并分配到命名分组（唯一成员），另有两个未分组会话 —— 通过包内 vite dev server 提供客户端。before/after 通过在同一份守护进程数据上仅还原/应用本 diff 捕获。

类型检查（`packages/web-shell` 内 `tsc -p tsconfig.json --noEmit`）：本 diff 未引入新错误。`client/App.tsx` 中一个既有错误（`MODES_CYCLE.indexOf(currentMode)`，mode 为 `string`）在本 diff 还原后、使用同样的本地构建工作区依赖时可同样复现，与本改动无关。

### 证据（修改前与修改后）

修改前 —— 全置顶分组渲染 `· 0`，成员只在 Pinned 区（`designTitles: []`）；修改后 —— 分组显示 `· 1` 且含置顶成员行，同时仍在 Pinned 区，Ungrouped 不变（截图见英文部分）。随截图捕获的 DOM 断言：

```json
{
  "phase": "before",
  "designSectionText": "Design· 0",
  "designTitles": [],
  "ungroupedTitles": ["Ungrouped task B", "Ungrouped task A"],
  "pinnedTitles": ["Pinned group member"]
}
{
  "phase": "after",
  "designSectionText": "Design· 1Pinned group member",
  "designTitles": ["Pinned group member"],
  "ungroupedTitles": ["Ungrouped task B", "Ungrouped task A"],
  "pinnedTitles": ["Pinned group member"]
}
```

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

### 环境（可选）

Node v24.19.0；包内 Vitest；UI 截图由 Playwright 驱动的 headless Chromium 完成，目标为本地 `qwen serve`（0.22.2，隔离工作区 + 非默认端口 + 独立 bearer token），经 web-shell vite dev server 代理。本机生产守护进程未被触碰。

## 风险与范围

- 主要风险/取舍：置顶的分组成员现在会出现两次 —— Pinned 区一次、其命名分组内一次。这与今天 channel 来源的行为一致（置顶行本就保留在其平台分区内）；行上带有既有的置顶行操作（Unpin），重复是可辨识的。
- 未验证/不在范围：服务端组织存储与 organized-view API 已由报告确认完好并在本次复核 —— 未改动。e2e mock daemon 中描述旧行为的注释已更新；其余 e2e 用例未动（channel 模式 fixture 不受影响）。置顶会话的颜色桶行为不变（超出本 issue 范围）。
- 破坏性变更/迁移说明：无 —— 纯客户端渲染改动；不涉及 API、存储或 i18n 面。

## 关联 Issue

Fixes #10391

</details>
