### PR TITLE
fix(cli): keep hardware cursor aligned after layout changes

### DIFF
--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -176,16 +176,20 @@ export function getPhysicalCursorPosition(
 ): { x: number; y: number } | undefined {
   if (!showCursor || !hasMeasured) return undefined;
 
-  const position = getAbsolutePosition(node);
-  if (!position) return undefined;
+  if (!node) return undefined;
 
   const relativeRow = cursorVisualRow - scrollVisualRow;
   const lineText = linesToRender[relativeRow] || '';
   const textBeforeCursor = cpSlice(lineText, 0, cursorVisualCol);
   const physicalCol = stringWidth(textBeforeCursor);
   return {
-    x: position.left + prefixWidth + physicalCol,
-    y: position.top + relativeRow + 1,
+    // Ink recalculates Yoga layout after this render, before reading these values.
+    get x() {
+      return getAbsolutePosition(node)!.left + prefixWidth + physicalCol;
+    },
+    get y() {
+      return getAbsolutePosition(node)!.top + relativeRow + 1;
+    },
   };
 }
 

--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -145,6 +145,7 @@ export type PhysicalCursorState = {
 export function getAbsolutePosition(
   node: DOMElement | null,
 ): { top: number; left: number } | undefined {
+  // Lazy cursor getters rely on this being the only undefined path.
   if (!node) return undefined;
 
   let top = 0;

--- a/packages/cli/src/ui/ink-cursor-rendering.test.tsx
+++ b/packages/cli/src/ui/ink-cursor-rendering.test.tsx
@@ -112,6 +112,28 @@ async function unmount(app: Instance): Promise<void> {
   mountedApps.delete(app);
 }
 
+function LazyCursorOwner() {
+  const ref = useRef<DOMElement | null>(null);
+  const { hasMeasured } = useBoxMetrics(ref);
+  useCursor().setCursorPosition(
+    getPhysicalCursorPosition(ref.current, {
+      hasMeasured,
+      showCursor: true,
+      cursorVisualRow: 0,
+      cursorVisualCol: 0,
+      scrollVisualRow: 0,
+      linesToRender: [''],
+      prefixWidth: 2,
+    }),
+  );
+  return (
+    <Box ref={ref} flexDirection="column">
+      <Text>border</Text>
+      <Text>input</Text>
+    </Box>
+  );
+}
+
 describe.each([false, true])(
   'Ink cursor rendering (incrementalRendering: %s)',
   (incrementalRendering) => {
@@ -298,32 +320,10 @@ describe.each([false, true])(
         return <Text>{multiline ? 'history-a\nhistory-b' : 'history'}</Text>;
       }
 
-      function CursorOwner() {
-        const ref = useRef<DOMElement | null>(null);
-        const { hasMeasured } = useBoxMetrics(ref);
-        useCursor().setCursorPosition(
-          getPhysicalCursorPosition(ref.current, {
-            hasMeasured,
-            showCursor: true,
-            cursorVisualRow: 0,
-            cursorVisualCol: 0,
-            scrollVisualRow: 0,
-            linesToRender: [''],
-            prefixWidth: 2,
-          }),
-        );
-        return (
-          <Box ref={ref} flexDirection="column">
-            <Text>border</Text>
-            <Text>input</Text>
-          </Box>
-        );
-      }
-
       const app = await mount(
         <Box flexDirection="column">
           <History />
-          <CursorOwner />
+          <LazyCursorOwner />
           <Text>{'footer-a\nfooter-b'}</Text>
         </Box>,
         capture.stdout,
@@ -500,32 +500,10 @@ describe.each([false, true])(
           return <Text>{multiline ? 'history-a\nhistory-b' : 'history'}</Text>;
         }
 
-        function CursorOwner() {
-          const ref = useRef<DOMElement | null>(null);
-          const { hasMeasured } = useBoxMetrics(ref);
-          useCursor().setCursorPosition(
-            getPhysicalCursorPosition(ref.current, {
-              hasMeasured,
-              showCursor: true,
-              cursorVisualRow: 0,
-              cursorVisualCol: 0,
-              scrollVisualRow: 0,
-              linesToRender: [''],
-              prefixWidth: 2,
-            }),
-          );
-          return (
-            <Box ref={ref} flexDirection="column">
-              <Text>border</Text>
-              <Text>input</Text>
-            </Box>
-          );
-        }
-
         const app = await mount(
           <Box flexDirection="column">
             <History />
-            <CursorOwner />
+            <LazyCursorOwner />
             <Text>footer</Text>
           </Box>,
           capture.stdout,

--- a/packages/cli/src/ui/ink-cursor-rendering.test.tsx
+++ b/packages/cli/src/ui/ink-cursor-rendering.test.tsx
@@ -4,10 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { act, useState, type ReactNode } from 'react';
+import { act, useRef, useState, type ReactNode } from 'react';
 import ansiEscapes from 'ansi-escapes';
-import { Box, render, Static, Text, type Instance, useCursor } from 'ink';
+import {
+  Box,
+  render,
+  Static,
+  Text,
+  type DOMElement,
+  type Instance,
+  useBoxMetrics,
+  useCursor,
+} from 'ink';
 import { afterEach, describe, expect, it } from 'vitest';
+import { getPhysicalCursorPosition } from './components/BaseTextInput.js';
 
 const SHOW_CURSOR = '\u001B[?25h';
 const mountedApps = new Set<Instance>();
@@ -221,6 +231,64 @@ describe.each([false, true])(
       await unmount(app);
     });
 
+    it('positions a lazy cursor after content above it shrinks out of fullscreen', async () => {
+      const capture = createTestStdout(6);
+      let shrinkHistory!: () => void;
+
+      function History() {
+        const [multiline, setMultiline] = useState(true);
+        shrinkHistory = () => setMultiline(false);
+        return <Text>{multiline ? 'history-a\nhistory-b' : 'history'}</Text>;
+      }
+
+      function CursorOwner() {
+        const ref = useRef<DOMElement | null>(null);
+        const { hasMeasured } = useBoxMetrics(ref);
+        useCursor().setCursorPosition(
+          getPhysicalCursorPosition(ref.current, {
+            hasMeasured,
+            showCursor: true,
+            cursorVisualRow: 0,
+            cursorVisualCol: 0,
+            scrollVisualRow: 0,
+            linesToRender: [''],
+            prefixWidth: 2,
+          }),
+        );
+        return (
+          <Box ref={ref} flexDirection="column">
+            <Text>border</Text>
+            <Text>input</Text>
+          </Box>
+        );
+      }
+
+      const app = await mount(
+        <Box flexDirection="column">
+          <History />
+          <CursorOwner />
+          <Text>{'footer-a\nfooter-b'}</Text>
+        </Box>,
+        capture.stdout,
+        incrementalRendering,
+      );
+      capture.reset();
+
+      await updateAndFlush(app, shrinkHistory);
+
+      const output = capture.read();
+      expect(output).toContain(ansiEscapes.clearTerminal);
+      expect(output).not.toContain(
+        'history\nborder\ninput\nfooter-a\nfooter-b\n' +
+          expectedCursorSuffix(2),
+      );
+      expect(output).toContain(
+        'history\nborder\ninput\nfooter-a\nfooter-b\n' +
+          expectedCursorSuffix(3),
+      );
+      await unmount(app);
+    });
+
     it('positions the hardware cursor at the correct row in fullscreen (y > 0)', async () => {
       // Regression test for QwenLM/qwen-code#7980: in fullscreen mode the
       // output has no trailing newline, so the terminal cursor sits ON the
@@ -359,6 +427,63 @@ describe.each([false, true])(
       expect(capture.read()).toContain(expectedCursorSuffix(3, 4));
       await unmount(app);
     });
+
+    it.each([
+      { direction: 'grows', initiallyMultiline: false, staleCursorUp: 3 },
+      { direction: 'shrinks', initiallyMultiline: true, staleCursorUp: 1 },
+    ])(
+      'does not show a stale cursor when content above the input $direction',
+      async ({ initiallyMultiline, staleCursorUp }) => {
+        const capture = createTestStdout();
+        let updateHistory!: () => void;
+
+        function History() {
+          const [multiline, setMultiline] = useState(initiallyMultiline);
+          updateHistory = () => setMultiline(!initiallyMultiline);
+          return <Text>{multiline ? 'history-a\nhistory-b' : 'history'}</Text>;
+        }
+
+        function CursorOwner() {
+          const ref = useRef<DOMElement | null>(null);
+          const { hasMeasured } = useBoxMetrics(ref);
+          useCursor().setCursorPosition(
+            getPhysicalCursorPosition(ref.current, {
+              hasMeasured,
+              showCursor: true,
+              cursorVisualRow: 0,
+              cursorVisualCol: 0,
+              scrollVisualRow: 0,
+              linesToRender: [''],
+              prefixWidth: 2,
+            }),
+          );
+          return (
+            <Box ref={ref} flexDirection="column">
+              <Text>border</Text>
+              <Text>input</Text>
+            </Box>
+          );
+        }
+
+        const app = await mount(
+          <Box flexDirection="column">
+            <History />
+            <CursorOwner />
+            <Text>footer</Text>
+          </Box>,
+          capture.stdout,
+          incrementalRendering,
+        );
+        capture.reset();
+
+        await updateAndFlush(app, updateHistory);
+
+        const output = capture.read();
+        expect(output).not.toContain(expectedCursorSuffix(staleCursorUp));
+        expect(output).toContain(expectedCursorSuffix(2));
+        await unmount(app);
+      },
+    );
 
     it('does not write when a sibling rerenders identical output', async () => {
       const capture = createTestStdout();

--- a/packages/cli/src/ui/ink-cursor-rendering.test.tsx
+++ b/packages/cli/src/ui/ink-cursor-rendering.test.tsx
@@ -150,6 +150,63 @@ describe.each([false, true])(
       await unmount(app);
     });
 
+    it('resolves lazy cursor coordinates once per output flush', async () => {
+      const capture = createTestStdout();
+      let updateFooter!: () => void;
+      let xReads = 0;
+      let yReads = 0;
+      let cursorRenderCount = 0;
+
+      function CursorOwner() {
+        cursorRenderCount++;
+        const position = useRef({
+          get x() {
+            xReads++;
+            return 2;
+          },
+          get y() {
+            yReads++;
+            return 0;
+          },
+        }).current;
+        useCursor().setCursorPosition(position);
+        return <Text>input</Text>;
+      }
+
+      function Footer() {
+        const [version, setVersion] = useState(0);
+        updateFooter = () => setVersion((value) => value + 1);
+        return <Text>footer-{version}</Text>;
+      }
+
+      const app = await mount(
+        <Box flexDirection="column">
+          <CursorOwner />
+          <Footer />
+        </Box>,
+        capture.stdout,
+        incrementalRendering,
+      );
+      expect(cursorRenderCount).toBe(1);
+      xReads = 0;
+      yReads = 0;
+
+      await updateAndFlush(app, updateFooter);
+
+      expect(xReads).toBe(1);
+      expect(yReads).toBe(1);
+      expect(cursorRenderCount).toBe(1);
+      xReads = 0;
+      yReads = 0;
+
+      await updateAndFlush(app, updateFooter);
+
+      expect(xReads).toBe(1);
+      expect(yReads).toBe(1);
+      expect(cursorRenderCount).toBe(1);
+      await unmount(app);
+    });
+
     it('reasserts the cursor after Static output is appended', async () => {
       const capture = createTestStdout();
       let appendStatic!: () => void;

--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -303,10 +303,13 @@ diff --git a/node_modules/ink/build/log-update.js b/node_modules/ink/build/log-u
 index cdb5fc4..3247e02 100644
 --- a/node_modules/ink/build/log-update.js
 +++ b/node_modules/ink/build/log-update.js
-@@ -4,6 +4,7 @@
+@@ -4,6 +4,10 @@
  // Count visible lines in a string, ignoring the trailing empty element
  // that `split('\n')` produces when the string ends with '\n'.
  const visibleLineCount = (lines, str) => str.endsWith('\n') ? lines.length - 1 : lines.length;
++// Lazy cursor getters resolve against live Yoga layout. Each renderer prepares
++// one numeric snapshot per flush and invalidates unconsumed snapshots on state
++// resets so they cannot cross flush boundaries.
 +const snapshotCursorPosition = (position) => position ? { x: position.x, y: position.y } : undefined;
  const createStandard = (stream, { showCursor = false } = {}) => {
      let previousLineCount = 0;

--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -300,18 +300,55 @@ index ef659f3..767d861 100644
              this.lastOutputToRender = outputToRender;
              this.lastOutputHeight = outputHeight;
 diff --git a/node_modules/ink/build/log-update.js b/node_modules/ink/build/log-update.js
-index cdb5fc4..89925ea 100644
+index cdb5fc4..3247e02 100644
 --- a/node_modules/ink/build/log-update.js
 +++ b/node_modules/ink/build/log-update.js
-@@ -12,6 +12,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+@@ -4,6 +4,7 @@
+ // Count visible lines in a string, ignoring the trailing empty element
+ // that `split('\n')` produces when the string ends with '\n'.
+ const visibleLineCount = (lines, str) => str.endsWith('\n') ? lines.length - 1 : lines.length;
++const snapshotCursorPosition = (position) => position ? { x: position.x, y: position.y } : undefined;
+ const createStandard = (stream, { showCursor = false } = {}) => {
+     let previousLineCount = 0;
+     let previousOutput = '';
+@@ -12,7 +13,26 @@
      let cursorDirty = false;
      let previousCursorPosition;
      let cursorWasShown = false;
+-    const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
 +    let previousHasTrailingNewline = true;
-     const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
++    let preparedActiveCursor;
++    let activeCursorPrepared = false;
++    const prepareActiveCursor = () => {
++        if (!activeCursorPrepared) {
++            preparedActiveCursor = snapshotCursorPosition(cursorDirty ? cursorPosition : undefined);
++            activeCursorPrepared = true;
++        }
++        return preparedActiveCursor;
++    };
++    const consumeActiveCursor = () => {
++        const activeCursor = prepareActiveCursor();
++        preparedActiveCursor = undefined;
++        activeCursorPrepared = false;
++        return activeCursor;
++    };
++    const invalidateActiveCursor = () => {
++        preparedActiveCursor = undefined;
++        activeCursorPrepared = false;
++    };
      const hasChanges = (str, activeCursor) => {
          const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
-@@ -32,7 +33,8 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+         return str !== previousOutput || cursorChanged;
+@@ -24,7 +44,7 @@
+         }
+         // Only use cursor if setCursorPosition was called since last render.
+         // This ensures stale positions don't persist after component unmount.
+-        const activeCursor = getActiveCursor();
++        const activeCursor = consumeActiveCursor();
+         cursorDirty = false;
+         const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
+         if (!hasChanges(str, activeCursor)) {
+@@ -32,7 +52,8 @@
          }
          const lines = str.split('\n');
          const visibleCount = visibleLineCount(lines, str);
@@ -321,7 +358,7 @@ index cdb5fc4..89925ea 100644
          if (str === previousOutput && cursorChanged) {
              stream.write(buildCursorOnlySequence({
                  cursorWasShown,
-@@ -40,6 +42,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+@@ -40,6 +61,7 @@
                  previousCursorPosition,
                  visibleLineCount: visibleCount,
                  cursorPosition: activeCursor,
@@ -329,7 +366,7 @@ index cdb5fc4..89925ea 100644
              }));
          }
          else {
-@@ -50,6 +53,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+@@ -50,6 +72,7 @@
                  str +
                  cursorSuffix);
              previousLineCount = lines.length;
@@ -337,11 +374,12 @@ index cdb5fc4..89925ea 100644
          }
          previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
          cursorWasShown = activeCursor !== undefined;
-@@ -62,12 +66,14 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+@@ -62,12 +85,16 @@
          previousLineCount = 0;
          previousCursorPosition = undefined;
          cursorWasShown = false;
 +        previousHasTrailingNewline = true;
++        invalidateActiveCursor();
      };
      render.done = () => {
          previousOutput = '';
@@ -349,18 +387,21 @@ index cdb5fc4..89925ea 100644
          previousCursorPosition = undefined;
          cursorWasShown = false;
 +        previousHasTrailingNewline = true;
++        invalidateActiveCursor();
          if (!showCursor) {
              cliCursor.show(stream);
              hasHiddenCursor = false;
-@@ -78,6 +84,7 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+@@ -78,18 +105,21 @@
          previousLineCount = 0;
          previousCursorPosition = undefined;
          cursorWasShown = false;
 +        previousHasTrailingNewline = true;
++        invalidateActiveCursor();
      };
      render.sync = (str) => {
-         const activeCursor = cursorDirty ? cursorPosition : undefined;
-@@ -85,11 +92,12 @@ const createStandard = (stream, { showCursor = false } = {}) => {
+-        const activeCursor = cursorDirty ? cursorPosition : undefined;
++        const activeCursor = consumeActiveCursor();
+         cursorDirty = false;
          const lines = str.split('\n');
          previousOutput = str;
          previousLineCount = lines.length;
@@ -374,15 +415,56 @@ index cdb5fc4..89925ea 100644
          }
          previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
          cursorWasShown = activeCursor !== undefined;
-@@ -110,6 +118,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -97,9 +127,10 @@
+     render.setCursorPosition = (position) => {
+         cursorPosition = position;
+         cursorDirty = true;
++        invalidateActiveCursor();
+     };
+     render.isCursorDirty = () => cursorDirty;
+-    render.willRender = (str) => hasChanges(str, getActiveCursor());
++    render.willRender = (str) => hasChanges(str, prepareActiveCursor());
+     return render;
+ };
+ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -110,7 +141,26 @@
      let cursorDirty = false;
      let previousCursorPosition;
      let cursorWasShown = false;
+-    const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
 +    let previousHasTrailingNewline = true;
-     const getActiveCursor = () => (cursorDirty ? cursorPosition : undefined);
++    let preparedActiveCursor;
++    let activeCursorPrepared = false;
++    const prepareActiveCursor = () => {
++        if (!activeCursorPrepared) {
++            preparedActiveCursor = snapshotCursorPosition(cursorDirty ? cursorPosition : undefined);
++            activeCursorPrepared = true;
++        }
++        return preparedActiveCursor;
++    };
++    const consumeActiveCursor = () => {
++        const activeCursor = prepareActiveCursor();
++        preparedActiveCursor = undefined;
++        activeCursorPrepared = false;
++        return activeCursor;
++    };
++    const invalidateActiveCursor = () => {
++        preparedActiveCursor = undefined;
++        activeCursorPrepared = false;
++    };
      const hasChanges = (str, activeCursor) => {
          const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
-@@ -138,6 +147,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+         return str !== previousOutput || cursorChanged;
+@@ -122,7 +172,7 @@
+         }
+         // Only use cursor if setCursorPosition was called since last render.
+         // This ensures stale positions don't persist after component unmount.
+-        const activeCursor = getActiveCursor();
++        const activeCursor = consumeActiveCursor();
+         cursorDirty = false;
+         const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
+         if (!hasChanges(str, activeCursor)) {
+@@ -138,6 +188,7 @@
                  previousCursorPosition,
                  visibleLineCount: visibleCount,
                  cursorPosition: activeCursor,
@@ -390,7 +472,7 @@ index cdb5fc4..89925ea 100644
              }));
              previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
              cursorWasShown = activeCursor !== undefined;
-@@ -145,7 +155,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -145,7 +196,7 @@
          }
          const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
          if (str === '\n' || previousOutput.length === 0) {
@@ -399,7 +481,7 @@ index cdb5fc4..89925ea 100644
              stream.write(returnPrefix +
                  ansiEscapes.eraseLines(previousLines.length) +
                  str +
-@@ -154,6 +164,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -154,6 +205,7 @@
              previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
              previousOutput = str;
              previousLines = nextLines;
@@ -407,7 +489,7 @@ index cdb5fc4..89925ea 100644
              return true;
          }
          const hasTrailingNewline = str.endsWith('\n');
-@@ -187,13 +198,14 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -187,13 +239,14 @@
                  // has no trailing newline (fullscreen mode).
                  (isLastLine && !hasTrailingNewline ? '' : '\n'));
          }
@@ -423,11 +505,12 @@ index cdb5fc4..89925ea 100644
          return true;
      };
      render.clear = () => {
-@@ -203,12 +215,14 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -203,12 +256,16 @@
          previousLines = [];
          previousCursorPosition = undefined;
          cursorWasShown = false;
 +        previousHasTrailingNewline = true;
++        invalidateActiveCursor();
      };
      render.done = () => {
          previousOutput = '';
@@ -435,18 +518,21 @@ index cdb5fc4..89925ea 100644
          previousCursorPosition = undefined;
          cursorWasShown = false;
 +        previousHasTrailingNewline = true;
++        invalidateActiveCursor();
          if (!showCursor) {
              cliCursor.show(stream);
              hasHiddenCursor = false;
-@@ -219,6 +233,7 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+@@ -219,18 +276,21 @@
          previousLines = [];
          previousCursorPosition = undefined;
          cursorWasShown = false;
 +        previousHasTrailingNewline = true;
++        invalidateActiveCursor();
      };
      render.sync = (str) => {
-         const activeCursor = cursorDirty ? cursorPosition : undefined;
-@@ -226,11 +241,12 @@ const createIncremental = (stream, { showCursor = false } = {}) => {
+-        const activeCursor = cursorDirty ? cursorPosition : undefined;
++        const activeCursor = consumeActiveCursor();
+         cursorDirty = false;
          const lines = str.split('\n');
          previousOutput = str;
          previousLines = lines;
@@ -460,6 +546,18 @@ index cdb5fc4..89925ea 100644
          }
          previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
          cursorWasShown = activeCursor !== undefined;
+@@ -238,9 +298,10 @@
+     render.setCursorPosition = (position) => {
+         cursorPosition = position;
+         cursorDirty = true;
++        invalidateActiveCursor();
+     };
+     render.isCursorDirty = () => cursorDirty;
+-    render.willRender = (str) => hasChanges(str, getActiveCursor());
++    render.willRender = (str) => hasChanges(str, prepareActiveCursor());
+     return render;
+ };
+ const create = (stream, { showCursor = false, incremental = false } = {}) => {
 diff --git a/node_modules/ink/build/output.d.ts b/node_modules/ink/build/output.d.ts
 index 0f4523f..a3ef634 100644
 --- a/node_modules/ink/build/output.d.ts

--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -314,7 +314,7 @@ index cdb5fc4..3247e02 100644
  const createStandard = (stream, { showCursor = false } = {}) => {
      let previousLineCount = 0;
      let previousOutput = '';
-@@ -12,7 +13,26 @@
+@@ -12,7 +16,26 @@
      let cursorDirty = false;
      let previousCursorPosition;
      let cursorWasShown = false;
@@ -342,7 +342,7 @@ index cdb5fc4..3247e02 100644
      const hasChanges = (str, activeCursor) => {
          const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
          return str !== previousOutput || cursorChanged;
-@@ -24,7 +44,7 @@
+@@ -24,7 +47,7 @@
          }
          // Only use cursor if setCursorPosition was called since last render.
          // This ensures stale positions don't persist after component unmount.
@@ -351,7 +351,7 @@ index cdb5fc4..3247e02 100644
          cursorDirty = false;
          const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
          if (!hasChanges(str, activeCursor)) {
-@@ -32,7 +52,8 @@
+@@ -32,7 +55,8 @@
          }
          const lines = str.split('\n');
          const visibleCount = visibleLineCount(lines, str);
@@ -361,7 +361,7 @@ index cdb5fc4..3247e02 100644
          if (str === previousOutput && cursorChanged) {
              stream.write(buildCursorOnlySequence({
                  cursorWasShown,
-@@ -40,6 +61,7 @@
+@@ -40,6 +64,7 @@
                  previousCursorPosition,
                  visibleLineCount: visibleCount,
                  cursorPosition: activeCursor,
@@ -369,7 +369,7 @@ index cdb5fc4..3247e02 100644
              }));
          }
          else {
-@@ -50,6 +72,7 @@
+@@ -50,6 +75,7 @@
                  str +
                  cursorSuffix);
              previousLineCount = lines.length;
@@ -377,7 +377,7 @@ index cdb5fc4..3247e02 100644
          }
          previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
          cursorWasShown = activeCursor !== undefined;
-@@ -62,12 +85,16 @@
+@@ -62,12 +88,16 @@
          previousLineCount = 0;
          previousCursorPosition = undefined;
          cursorWasShown = false;
@@ -394,7 +394,7 @@ index cdb5fc4..3247e02 100644
          if (!showCursor) {
              cliCursor.show(stream);
              hasHiddenCursor = false;
-@@ -78,18 +105,21 @@
+@@ -78,18 +108,21 @@
          previousLineCount = 0;
          previousCursorPosition = undefined;
          cursorWasShown = false;
@@ -418,7 +418,7 @@ index cdb5fc4..3247e02 100644
          }
          previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
          cursorWasShown = activeCursor !== undefined;
-@@ -97,9 +127,10 @@
+@@ -97,9 +130,10 @@
      render.setCursorPosition = (position) => {
          cursorPosition = position;
          cursorDirty = true;
@@ -430,7 +430,7 @@ index cdb5fc4..3247e02 100644
      return render;
  };
  const createIncremental = (stream, { showCursor = false } = {}) => {
-@@ -110,7 +141,26 @@
+@@ -110,7 +144,26 @@
      let cursorDirty = false;
      let previousCursorPosition;
      let cursorWasShown = false;
@@ -458,7 +458,7 @@ index cdb5fc4..3247e02 100644
      const hasChanges = (str, activeCursor) => {
          const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
          return str !== previousOutput || cursorChanged;
-@@ -122,7 +172,7 @@
+@@ -122,7 +175,7 @@
          }
          // Only use cursor if setCursorPosition was called since last render.
          // This ensures stale positions don't persist after component unmount.
@@ -467,7 +467,7 @@ index cdb5fc4..3247e02 100644
          cursorDirty = false;
          const cursorChanged = cursorPositionChanged(activeCursor, previousCursorPosition);
          if (!hasChanges(str, activeCursor)) {
-@@ -138,6 +188,7 @@
+@@ -138,6 +191,7 @@
                  previousCursorPosition,
                  visibleLineCount: visibleCount,
                  cursorPosition: activeCursor,
@@ -475,7 +475,7 @@ index cdb5fc4..3247e02 100644
              }));
              previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
              cursorWasShown = activeCursor !== undefined;
-@@ -145,7 +196,7 @@
+@@ -145,7 +199,7 @@
          }
          const returnPrefix = buildReturnToBottomPrefix(cursorWasShown, previousLines.length, previousCursorPosition);
          if (str === '\n' || previousOutput.length === 0) {
@@ -484,7 +484,7 @@ index cdb5fc4..3247e02 100644
              stream.write(returnPrefix +
                  ansiEscapes.eraseLines(previousLines.length) +
                  str +
-@@ -154,6 +205,7 @@
+@@ -154,6 +208,7 @@
              previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
              previousOutput = str;
              previousLines = nextLines;
@@ -492,7 +492,7 @@ index cdb5fc4..3247e02 100644
              return true;
          }
          const hasTrailingNewline = str.endsWith('\n');
-@@ -187,13 +239,14 @@
+@@ -187,13 +242,14 @@
                  // has no trailing newline (fullscreen mode).
                  (isLastLine && !hasTrailingNewline ? '' : '\n'));
          }
@@ -508,7 +508,7 @@ index cdb5fc4..3247e02 100644
          return true;
      };
      render.clear = () => {
-@@ -203,12 +256,16 @@
+@@ -203,12 +259,16 @@
          previousLines = [];
          previousCursorPosition = undefined;
          cursorWasShown = false;
@@ -525,7 +525,7 @@ index cdb5fc4..3247e02 100644
          if (!showCursor) {
              cliCursor.show(stream);
              hasHiddenCursor = false;
-@@ -219,18 +276,21 @@
+@@ -219,18 +279,21 @@
          previousLines = [];
          previousCursorPosition = undefined;
          cursorWasShown = false;
@@ -549,7 +549,7 @@ index cdb5fc4..3247e02 100644
          }
          previousCursorPosition = activeCursor ? { ...activeCursor } : undefined;
          cursorWasShown = activeCursor !== undefined;
-@@ -238,9 +298,10 @@
+@@ -238,9 +301,10 @@
      render.setCursorPosition = (position) => {
          cursorPosition = position;
          cursorDirty = true;

--- a/patches/ink+7.0.3.patch
+++ b/patches/ink+7.0.3.patch
@@ -290,6 +290,15 @@ index ef659f3..767d861 100644
          const hasStaticOutput = staticOutput !== '';
          const isTty = this.options.stdout.isTTY;
          // Detect fullscreen: output fills or exceeds terminal height.
+@@ -710,7 +729,7 @@ export default class Ink {
+             if (sync) {
+                 this.options.stdout.write(bsu);
+             }
+-            this.options.stdout.write(ansiEscapes.clearTerminal + this.fullStaticOutput + output);
++            this.options.stdout.write(ansiEscapes.clearTerminal + this.fullStaticOutput + outputToRender);
+             this.lastOutput = output;
+             this.lastOutputToRender = outputToRender;
+             this.lastOutputHeight = outputHeight;
 diff --git a/node_modules/ink/build/log-update.js b/node_modules/ink/build/log-update.js
 index cdb5fc4..89925ea 100644
 --- a/node_modules/ink/build/log-update.js


### PR DESCRIPTION
## What this PR does

Keeps the terminal hardware cursor aligned with the visible input cursor when content above the composer grows or shrinks. Cursor coordinates are resolved against the committed terminal layout, and full-reset rendering now writes the same trailing-newline geometry that cursor restoration models.

## Why it's needed

In Virtualized History, normal output growth and scrolling can move the composer without any terminal resize event. The previous render could retain the input's old absolute row, placing the hardware cursor above or below the visible input. A separate clear-and-sync path could also move the cursor one extra row upward when an overflowing frame returned to a shorter non-fullscreen frame.

## Reviewer Test Plan

### How to verify

1. Start an interactive session in a constrained terminal with Virtualized History enabled.
2. Run a command that gradually emits enough lines for the live frame to overflow the viewport and then return to the normal prompt, without resizing the terminal.
3. Confirm that the hardware cursor remains on the visible input row while content grows and shrinks and after the full-reset transition completes.
4. Repeat with standard and incremental rendering; both paths should produce the same cursor row.

### Evidence (Before & After)

An automated real-PTY run fixed the terminal at 80×24, emitted ten shell-output rows over time, and compared the terminal cursor row with the visible input row after every completed synchronized-output transaction.

- Before (published 0.22.2): 9 mismatches in 22 completed transactions.
- After: 0 mismatches in 16 completed transactions; final cursor row and input row were both 20.
- No resize event was sent in either run.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS, tmux-backed 80×24 PTY, Virtualized History enabled, standard and incremental Ink rendering. Automated focused coverage also exercises layout growth, layout shrinkage, fullscreen rendering, and the full-reset transition back to non-fullscreen output.

## Risk & Scope

- Main risk or tradeoff: Cursor coordinates are read lazily during frame rendering, and non-fullscreen full-reset output now includes the same trailing newline as ordinary non-fullscreen output.
- Not validated / out of scope: Manual verification on Windows and Linux, screen-reader mode, and the separate text-selection behavior discussed in the linked issue.
- Breaking changes / migration notes: None.

## Linked Issues

Addresses the cursor-positioning portion of #8113.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当输入框上方内容增长或收缩时，保持终端硬件光标与可见输入光标对齐。光标坐标会根据已提交的终端布局读取；完整清屏重绘现在也会写出与光标恢复逻辑所依据的相同尾部换行结构。

## 为什么需要

在 Virtualized History 模式下，正常的输出增长和滚动即使没有触发终端 resize，也可能移动输入框。此前的渲染可能保留输入框原来的绝对行号，使硬件光标出现在可见输入行的上方或下方。另一个清屏同步分支在溢出帧恢复为较短的非全屏帧时，还可能让光标额外向上移动一行。

## Reviewer 测试计划

### 如何验证

1. 在空间受限的终端中启动交互会话，并启用 Virtualized History。
2. 运行一个逐步输出足够多行的命令，使实时帧溢出视口后再返回普通输入提示符，期间不要调整终端大小。
3. 确认内容增长、收缩以及完整清屏恢复结束后，硬件光标始终位于可见输入行。
4. 分别使用普通和增量渲染重复验证；两条路径应得到相同的光标行。

### 前后证据

自动化真实 PTY 测试将终端固定为 80×24，随时间输出十行 shell 内容，并在每个完整同步输出事务结束后比较终端光标行与可见输入行。

- 修复前（已发布的 0.22.2）：22 个完整事务中出现 9 次错位。
- 修复后：16 个完整事务中没有错位；最终光标行和输入行均为第 20 行。
- 两次运行都没有发送 resize 事件。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      |  ✅  |
|    🪟 Windows    |  ⚠️  |
|     🐧 Linux     |  ⚠️  |

### 环境（可选）

macOS、tmux 驱动的 80×24 PTY、启用 Virtualized History，并覆盖普通和增量 Ink 渲染。自动化定向测试还覆盖布局增长、布局收缩、全屏渲染以及完整清屏后返回非全屏输出的转换。

## 风险与范围

- 主要风险或权衡：光标坐标在帧渲染期间延迟读取；非全屏完整清屏输出现在会像普通非全屏输出一样包含尾部换行。
- 未验证 / 不在范围内：Windows 和 Linux 上的手工验证、screen-reader 模式，以及关联 issue 中讨论的独立文字选择行为。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

处理 #8113 中与光标定位有关的部分。

</details>
