### PR TITLE
fix(vscode-ide-companion): resolve workspace-relative paths in closeDiff

### DIFF
--- a/packages/vscode-ide-companion/src/commands/index.ts
+++ b/packages/vscode-ide-companion/src/commands/index.ts
@@ -88,7 +88,22 @@ export function registerNewCommands(
   disposables.push(
     vscode.commands.registerCommand(
       closeDiffCommand,
-      async (filePath: string) => diffManager.closeDiff(filePath, true),
+      async (filePath: string) => {
+        // Mirror showDiffCommand: diffs opened with a workspace-relative
+        // path are stored under the resolved absolute path, so closing
+        // them requires the same resolution (issue #10372).
+        let absolutePath = filePath;
+        if (shouldResolveAgainstWorkspace(filePath)) {
+          const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+          if (workspaceFolder) {
+            absolutePath = vscode.Uri.joinPath(
+              workspaceFolder.uri,
+              filePath,
+            ).fsPath;
+          }
+        }
+        await diffManager.closeDiff(absolutePath, true);
+      },
     ),
   );
 

--- a/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
@@ -8,6 +8,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { QwenAgentManager } from '../../services/qwenAgentManager.js';
 import type { ConversationStore } from '../../services/conversationStore.js';
 import { FileMessageHandler } from './FileMessageHandler.js';
+import { DiffContentProvider, DiffManager } from '../../diff-manager.js';
+import { registerNewCommands } from '../../commands/index.js';
 import * as vscode from 'vscode';
 
 const shouldIgnoreFileMock = vi.hoisted(() => vi.fn());
@@ -17,16 +19,48 @@ const fileSearchMock = vi.hoisted(() => ({
 }));
 
 const vscodeMock = vi.hoisted(() => {
+  const commandHandlers = new Map<string, (...args: unknown[]) => unknown>();
+
   class Uri {
     fsPath: string;
-    constructor(fsPath: string) {
+    scheme: string;
+    query: string;
+    constructor(fsPath: string, scheme = 'file', query = '') {
       this.fsPath = fsPath;
+      this.scheme = scheme;
+      this.query = query;
+    }
+    with(change: { scheme?: string; query?: string }) {
+      return new Uri(
+        this.fsPath,
+        change.scheme ?? this.scheme,
+        change.query ?? this.query,
+      );
+    }
+    toString() {
+      return `${this.scheme}://${this.fsPath}${this.query ? `?${this.query}` : ''}`;
     }
     static file(fsPath: string) {
       return new Uri(fsPath);
     }
     static joinPath(base: Uri, ...pathSegments: string[]) {
       return new Uri(`${base.fsPath}/${pathSegments.join('/')}`);
+    }
+  }
+
+  class EventEmitter {
+    private readonly listeners = new Set<(e: unknown) => void>();
+    event = (listener: (e: unknown) => void) => {
+      this.listeners.add(listener);
+      return { dispose: () => this.listeners.delete(listener) };
+    };
+    fire(e: unknown) {
+      for (const listener of this.listeners) {
+        listener(e);
+      }
+    }
+    dispose() {
+      this.listeners.clear();
     }
   }
 
@@ -62,11 +96,25 @@ const vscodeMock = vi.hoisted(() => {
 
   return {
     Uri,
+    EventEmitter,
+    commandHandlers,
     Position,
     Selection,
     Range,
     TextEditorRevealType: { InCenter: 2 },
     ViewColumn: { One: 1, Two: 2, Three: 3, Beside: -2 },
+    commands: {
+      registerCommand: vi.fn(
+        (id: string, handler: (...args: unknown[]) => unknown) => {
+          commandHandlers.set(id, handler);
+          return { dispose: vi.fn(() => commandHandlers.delete(id)) };
+        },
+      ),
+      executeCommand: vi.fn(async (id: string, ...args: unknown[]) => {
+        const handler = commandHandlers.get(id);
+        return handler ? handler(...args) : undefined;
+      }),
+    },
     workspace: {
       findFiles: vi.fn(),
       getWorkspaceFolder: vi.fn(),
@@ -85,17 +133,20 @@ const vscodeMock = vi.hoisted(() => {
       activeTextEditor: undefined,
       showTextDocument: vi.fn(),
       showErrorMessage: vi.fn(),
+      onDidChangeActiveTextEditor: vi.fn(() => ({ dispose: vi.fn() })),
       tabGroups: {
         all: [] as Array<{
           tabs: Array<{ input: unknown }>;
           viewColumn: number;
         }>,
+        close: vi.fn(),
       },
     },
   };
 });
 
 vi.mock('vscode', () => vscodeMock);
+vi.mock('../../extension.js', () => ({ DIFF_SCHEME: 'qwen-diff' }));
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
@@ -422,6 +473,97 @@ describe('FileMessageHandler', () => {
         viewColumn: number;
       };
       expect(options.viewColumn).toBe(vscodeMock.ViewColumn.Beside);
+    });
+  });
+
+  describe('closeDiff path resolution (issue #10372)', () => {
+    function diffDocuments(
+      diffManager: DiffManager,
+    ): Map<string, { originalFilePath: string }> {
+      return (
+        diffManager as unknown as {
+          diffDocuments: Map<string, { originalFilePath: string }>;
+        }
+      ).diffDocuments;
+    }
+
+    function setupWithRegisteredCommands() {
+      vscodeMock.commandHandlers.clear();
+      vscodeMock.workspace.workspaceFolders = [
+        { uri: vscode.Uri.file('/workspace'), name: 'workspace', index: 0 },
+      ];
+      vscodeMock.window.tabGroups.all = [];
+      vscodeMock.workspace.openTextDocument.mockResolvedValue({
+        getText: () => 'new-content',
+      });
+
+      const contentProvider = new DiffContentProvider();
+      const diffManager = new DiffManager(() => {}, contentProvider);
+      registerNewCommands(
+        { subscriptions: [] } as never,
+        () => {},
+        diffManager,
+        () => [],
+        vi.fn() as never,
+      );
+
+      const handler = new FileMessageHandler(
+        {} as QwenAgentManager,
+        {} as ConversationStore,
+        null,
+        vi.fn(),
+      );
+      return { diffManager, handler };
+    }
+
+    it('closes a diff opened with a workspace-relative path when closeDiff receives the same relative path', async () => {
+      const { diffManager, handler } = setupWithRegisteredCommands();
+
+      // webview openDiff -> showDiffCommand resolves 'docs/plan.md'
+      // against the workspace before handing it to DiffManager.
+      await handler.handle({
+        type: 'openDiff',
+        data: { path: 'docs/plan.md', oldText: 'old', newText: 'new' },
+      });
+
+      const docs = diffDocuments(diffManager);
+      expect(docs.size).toBe(1);
+      expect([...docs.values()][0]?.originalFilePath).toBe(
+        '/workspace/docs/plan.md',
+      );
+
+      // webview closeDiff sends the same raw workspace-relative path the
+      // transcript produced (EmbeddedApp.closeOpenPermissionDiffs /
+      // reconcile loop).
+      await handler.handle({
+        type: 'closeDiff',
+        data: { path: 'docs/plan.md' },
+      });
+
+      expect(docs.size).toBe(0);
+    });
+
+    it('still closes a diff opened with an absolute path', async () => {
+      const { diffManager, handler } = setupWithRegisteredCommands();
+
+      await handler.handle({
+        type: 'openDiff',
+        data: {
+          path: '/workspace/docs/plan.md',
+          oldText: 'old',
+          newText: 'new',
+        },
+      });
+
+      const docs = diffDocuments(diffManager);
+      expect(docs.size).toBe(1);
+
+      await handler.handle({
+        type: 'closeDiff',
+        data: { path: '/workspace/docs/plan.md' },
+      });
+
+      expect(docs.size).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## What this PR does

`closeDiffCommand` now mirrors the workspace-relative path resolution that `showDiffCommand` already performs: when the incoming path is relative, it is resolved against the first workspace folder via `shouldResolveAgainstWorkspace` + `Uri.joinPath` before being passed to `diffManager.closeDiff`. Absolute paths are passed through unchanged.

## Why it's needed

Fixes a follow-up defect split out of the #9811 review (#10372). `showDiffCommand` resolves workspace-relative paths to absolute ones before calling `diffManager.showDiff`, and `DiffManager` stores diffs keyed by `path.normalize(filePath)` — i.e. the absolute path. `closeDiffCommand` passed the raw path through, so `path.normalize('docs/plan.md')` stayed relative and never matched the stored absolute key. Every diff opened through a workspace-relative path (e.g. the permission diff preview, whose close messages come from `EmbeddedApp.closeOpenPermissionDiffs` and the transcript reconcile loop with the same raw path) could never be closed: the diff editor stayed open and the `diffDocuments` entry leaked, including on unmount cleanup. The fix is one change point in `closeDiffCommand`, which is the single funnel for all three call sites.

## Reviewer Test Plan

### How to verify

Run the new regression tests that drive the real chain (`FileMessageHandler` → real command registry via `registerNewCommands` → real `DiffManager`, nothing under test mocked):

```bash
npm run test -w packages/vscode-ide-companion -- src/webview/handlers/FileMessageHandler.test.ts src/commands/index.test.ts
```

- `closes a diff opened with a workspace-relative path when closeDiff receives the same relative path` — openDiff with `docs/plan.md` stores the diff under `/workspace/docs/plan.md` (asserted), then closeDiff with the same relative path must empty `diffDocuments`. This test fails without the fix (`expected 1 to be +0` — the entry survives, reproducing the leak) and passes with it.
- `still closes a diff opened with an absolute path` — guards that the resolution does not break the existing absolute-path behavior.
- Full package suite: `vitest run` in `packages/vscode-ide-companion` → 41 files passed, 457 passed | 1 skipped; `tsc --noEmit` clean; `eslint` clean on both changed files.

### Evidence (Before & After)

Non-UI change (command wiring inside the extension host); N/A for screenshots. Test output before the fix (relative path case):

```
× closes a diff opened with a workspace-relative path when closeDiff receives the same relative path
AssertionError: expected 1 to be +0
  expect(docs.size).toBe(0);
```

After the fix the same file reports `Test Files 1 passed`, `Tests 10 passed`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit/component tests only (vitest) against branch head `86c1c689c0`; no extension host launch.

## Risk & Scope

- Main risk or tradeoff: relative paths that were never meant to resolve against the workspace would now be resolved; this matches `showDiffCommand` exactly, so open/close stay symmetric by construction.
- Not validated / out of scope: this fix only takes effect on the `codex/vscode-web-shell-cutover` branch where the webview closeDiff path exists; on `main` there is no behavior change (the MCP `closeDiff`/`openDiff` tools both pass paths raw, so no asymmetry exists there) — intentionally untouched. No changes to `showDiff` or `DiffManager`.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10372

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`closeDiffCommand` 现在与 `showDiffCommand` 已有的工作区相对路径解析逻辑保持一致：当传入路径为相对路径时，先通过 `shouldResolveAgainstWorkspace` + `Uri.joinPath` 解析到第一个工作区目录，再交给 `diffManager.closeDiff`。绝对路径原样透传，不做任何处理。

## 为什么需要

修复从 #9811 评审中剥离出来的后续缺陷（#10372）。`showDiffCommand` 在调用 `diffManager.showDiff` 之前会把工作区相对路径解析成绝对路径，而 `DiffManager` 以 `path.normalize(filePath)`（即绝对路径）作为 key 存储 diff；`closeDiffCommand` 却把原始路径原样透传，导致 `path.normalize('docs/plan.md')` 仍是相对路径，永远匹配不到已存储的绝对 key。所有通过工作区相对路径打开的 diff（例如权限 diff 预览，其 close 消息由 `EmbeddedApp.closeOpenPermissionDiffs` 与 transcript reconcile 循环用同一份原始路径发出）都永远无法关闭：diff 编辑器一直开着，`diffDocuments` 条目持续泄漏，卸载清理时同样如此。修复只改 `closeDiffCommand` 这一个点，它是三条调用路径的唯一收口。

## 评审者测试计划

### 如何验证

运行新增的回归测试，这些测试走真实链路（`FileMessageHandler` → 经 `registerNewCommands` 注册的真实命令 → 真实 `DiffManager`，被测逻辑无任何 mock）：

```bash
npm run test -w packages/vscode-ide-companion -- src/webview/handlers/FileMessageHandler.test.ts src/commands/index.test.ts
```

- `closes a diff opened with a workspace-relative path when closeDiff receives the same relative path`——用 `docs/plan.md` 打开 diff 后，断言其以 `/workspace/docs/plan.md` 存储；再用同一相对路径发送 closeDiff，`diffDocuments` 必须被清空。不带修复时该测试失败（`expected 1 to be +0`，条目残留，复现泄漏），带修复时通过。
- `still closes a diff opened with an absolute path`——回归保护：确认解析逻辑没有破坏原有的绝对路径行为。
- 包级全量：在 `packages/vscode-ide-companion` 下 `vitest run` → 41 个文件全部通过，457 passed | 1 skipped；`tsc --noEmit` 通过；两个改动文件 `eslint` 通过。

### 前后对比证据

非 UI 改动（扩展宿主内部的命令接线），截图 N/A。修复前的测试输出（相对路径用例）：

```
× closes a diff opened with a workspace-relative path when closeDiff receives the same relative path
AssertionError: expected 1 to be +0
  expect(docs.size).toBe(0);
```

修复后同一文件输出 `Test Files 1 passed`、`Tests 10 passed`。

### 测试环境

|     操作系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元/组件测试（vitest），基于分支 head `86c1c689c0`，未启动扩展宿主。

## 风险与范围

- 主要风险或取舍：原本不打算按工作区解析的相对路径现在也会被解析；但这与 `showDiffCommand` 的行为完全一致，open/close 从构造上保持对称。
- 未验证/超出范围：本修复只在 `codex/vscode-web-shell-cutover` 分支生效（webview closeDiff 路径仅存在于该分支）；`main` 上无行为变化（MCP 的 `closeDiff`/`openDiff` 工具都原样传路径，不存在不对称），故有意不动。未改动 `showDiff` 与 `DiffManager`。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #10372

</details>
