### PR TITLE
feat(web-shell): add Local Control QR code entry to pane header

### DIFF
--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -478,6 +478,7 @@ const {
       latestSettingsState: null as {
         settings: DaemonSettingDescriptor[];
       } | null,
+      latestSettingsInitialCategory: undefined as string | undefined,
       latestModelManagement: null as {
         busy?: boolean;
         onSelectModel?: (modelId: string) => void;
@@ -920,6 +921,7 @@ vi.mock('./components/messages/SettingsMessage', async () => {
       settingsState: {
         settings: DaemonSettingDescriptor[];
       };
+      initialCategory?: string;
       onSubDialog?: (key: string, scope: 'user' | 'workspace') => void;
       onLanguageChange?: (
         language: string,
@@ -936,6 +938,7 @@ vi.mock('./components/messages/SettingsMessage', async () => {
       };
     }) => {
       testState.latestSettingsState = props.settingsState;
+      testState.latestSettingsInitialCategory = props.initialCategory;
       testState.latestModelManagement = props.modelManagement ?? null;
       return React.createElement(
         'div',
@@ -991,6 +994,24 @@ vi.mock('./components/messages/SettingsMessage', async () => {
         ),
       );
     },
+  };
+});
+
+// Expose the Local Control popover's settings callback as a plain button so
+// tests can drive the pane-header deep link without opening a Radix popover.
+vi.mock('./components/LocalControlQrButton', async () => {
+  const React = await import('react');
+  return {
+    LocalControlQrButton: (props: { onOpenSettings: () => void }) =>
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          'aria-label': 'Mobile access',
+          onClick: props.onOpenSettings,
+        },
+        'mobile access',
+      ),
   };
 });
 
@@ -5243,6 +5264,7 @@ beforeEach(() => {
   testState.latestMonitorDetailsOnOpen = null;
   testState.settings = [];
   testState.latestSettingsState = null;
+  testState.latestSettingsInitialCategory = undefined;
   testState.latestModelManagement = null;
   testState.latestScheduledTasksProps = null;
   testState.latestGoalsProps = null;
@@ -18463,8 +18485,58 @@ describe('App session callbacks', () => {
     );
     expect(actions).not.toBeNull();
     expect(
+      actions!.querySelector('[aria-label="Mobile access"]'),
+    ).not.toBeNull();
+    expect(
       actions!.querySelector('[aria-label="Session token usage"]'),
     ).toBeNull();
+  });
+
+  it('deep-links Settings to Daemon from the QR entry and clears the link on any panel close', async () => {
+    const { container, rerender } = renderApp({
+      sidebar: false,
+      splitSessionIds: ['s1'],
+    });
+    await flush();
+
+    // Click the pane-header QR entry's settings action: leaves split view,
+    // opens the Settings panel deep-linked to the Daemon category.
+    const qrEntry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="split-header-actions"] [aria-label="Mobile access"]',
+    );
+    expect(qrEntry).not.toBeNull();
+    await act(async () => {
+      qrEntry!.click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(
+      container.querySelector('[data-testid="inline-panel"]'),
+    ).not.toBeNull();
+    expect(testState.latestSettingsInitialCategory).toBe('Daemon');
+
+    // Close the panel through a non-closePanel path: a gated tool call
+    // arriving auto-closes the panel so the approval overlay is visible.
+    await act(async () => {
+      testState.blocks = [makePendingPermissionBlock()];
+      rerender();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-testid="inline-panel"]')).toBeNull();
+    await act(async () => {
+      testState.blocks = [];
+      rerender();
+      await Promise.resolve();
+    });
+
+    // A later ordinary Settings open must not inherit the stale deep link.
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+    expect(
+      container.querySelector('[data-testid="inline-panel"]'),
+    ).not.toBeNull();
+    expect(testState.latestSettingsInitialCategory).toBeUndefined();
   });
 
   it('does not reopen controlled split view when the same ids get a new array reference', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -18456,10 +18456,15 @@ describe('App session callbacks', () => {
     });
     await flush();
 
+    // Built-in header actions still exist (Local Control QR entry), but the
+    // token usage action stays behind its chat-header opt-in.
+    const actions = container.querySelector(
+      '[data-testid="split-header-actions"]',
+    );
+    expect(actions).not.toBeNull();
     expect(
-      container.querySelector('[data-testid="split-has-header-actions"]')
-        ?.textContent,
-    ).toBe('no');
+      actions!.querySelector('[aria-label="Session token usage"]'),
+    ).toBeNull();
   });
 
   it('does not reopen controlled split view when the same ids get a new array reference', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -8399,6 +8399,54 @@ describe('App session callbacks', () => {
     expect(container.textContent).toContain('Token Usage');
   });
 
+  it('exposes the Local Control settings deep link to a custom chat header', async () => {
+    const renderChatHeader = vi.fn(
+      ({ onOpenLocalControlSettings }: ChatHeaderRenderInfo) => (
+        <button type="button" onClick={onOpenLocalControlSettings}>
+          Custom mobile access
+        </button>
+      ),
+    );
+    const { container } = renderApp({ renderChatHeader });
+    await flush();
+
+    expect(renderChatHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onOpenLocalControlSettings: expect.any(Function),
+      }),
+    );
+    await act(async () => {
+      Array.from(container.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Custom mobile access')!
+        .click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(
+      container.querySelector('[data-testid="inline-panel"]'),
+    ).not.toBeNull();
+    expect(testState.latestSettingsInitialCategory).toBe('Daemon');
+  });
+
+  it('opens Settings deep-linked to Daemon from the main chat header QR entry', async () => {
+    const { container } = renderApp();
+    await flush();
+
+    const entry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-context-header"] [aria-label="Mobile access"]',
+    );
+    expect(entry).not.toBeNull();
+    await act(async () => {
+      entry!.click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(
+      container.querySelector('[data-testid="inline-panel"]'),
+    ).not.toBeNull();
+    expect(testState.latestSettingsInitialCategory).toBe('Daemon');
+  });
+
   it('opens the token usage panel from the main chat header action', async () => {
     const statsFixture: DaemonSessionStatsStatus = {
       v: 1,

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -57,6 +57,7 @@ import type {
 
 import { isGoalGateBlocked as isGoalGateBlockedFor } from './utils/goalGate';
 import { type SessionGitIntent } from './components/GitModePopover';
+import { LocalControlQrButton } from './components/LocalControlQrButton';
 import {
   SESSION_LIST_PAGE_SIZE,
   SESSION_MONITOR_TOOL_CORRELATION_FEATURE,
@@ -5351,7 +5352,15 @@ export function App({
     | null
   >(null);
   const activePanelRef = useRef(activePanel);
-  const closePanel = useCallback(() => setActivePanel(null), []);
+  // Deep-link target for the Settings panel (e.g. 'Daemon' from the Local
+  // Control QR popover); cleared when the panel closes.
+  const [settingsInitialCategory, setSettingsInitialCategory] = useState<
+    string | undefined
+  >();
+  const closePanel = useCallback(() => {
+    setActivePanel(null);
+    setSettingsInitialCategory(undefined);
+  }, []);
   const handleUseSkill = useCallback(
     (name: string) => {
       closePanel();
@@ -5506,28 +5515,43 @@ export function App({
     clearSplitSessions();
     openPanel('sessions');
   }, [notifyControlledSplitClose, openPanel]);
-  // Built-in pane action follows the same tokenUsage opt-in as the chat header.
+  const handleOpenLocalControlSettings = useCallback(() => {
+    setSettingsInitialCategory('Daemon');
+    openPanel('settings');
+  }, [openPanel]);
+  // Built-in pane actions: Local Control QR entry is always shown; the token
+  // usage action follows the same tokenUsage opt-in as the chat header.
   // Hosts can override via `renderPaneHeaderActions` to replace or extend it.
   const defaultPaneHeaderActions = useCallback<PaneHeaderActionsRenderer>(
     ({ sessionId, sessionActions }) => (
-      <button
-        type="button"
-        className={styles.tokenUsageHeaderButton}
-        aria-label={t('tokenUsage.open')}
-        title={t('tokenUsage.open')}
-        disabled={!sessionActions}
-        onClick={() =>
-          sessionActions && openTokenUsagePanel(sessionId, sessionActions, true)
-        }
-      >
-        <GaugeIcon size={16} aria-hidden="true" />
-      </button>
+      <>
+        <LocalControlQrButton onOpenSettings={handleOpenLocalControlSettings} />
+        {tokenUsageHeaderItemVisible && (
+          <button
+            type="button"
+            className={styles.tokenUsageHeaderButton}
+            aria-label={t('tokenUsage.open')}
+            title={t('tokenUsage.open')}
+            disabled={!sessionActions}
+            onClick={() =>
+              sessionActions &&
+              openTokenUsagePanel(sessionId, sessionActions, true)
+            }
+          >
+            <GaugeIcon size={16} aria-hidden="true" />
+          </button>
+        )}
+      </>
     ),
-    [openTokenUsagePanel, t],
+    [
+      handleOpenLocalControlSettings,
+      openTokenUsagePanel,
+      t,
+      tokenUsageHeaderItemVisible,
+    ],
   );
   const resolvedPaneHeaderActions =
-    renderPaneHeaderActions ??
-    (tokenUsageHeaderItemVisible ? defaultPaneHeaderActions : undefined);
+    renderPaneHeaderActions ?? defaultPaneHeaderActions;
   // A `?split=a,b` URL (opened in a new tab from the overview) enters the split
   // view with those sessions on load. Consume the param once so a later reload
   // or exit doesn't force the split back on.
@@ -12735,6 +12759,7 @@ export function App({
                       <SettingsMessage
                         settingsState={targetedWorkspaceSettingsState}
                         embedded
+                        initialCategory={settingsInitialCategory}
                         onLanguageChange={handleSettingsLanguageChange}
                         onThemeChange={handleThemeChange}
                         chatWidthMode={chatWidthMode}

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -12605,6 +12605,9 @@ export function App({
                               )
                           : undefined
                       }
+                      onOpenLocalControlSettings={
+                        handleOpenLocalControlSettings
+                      }
                     />
                   )}
                 </div>

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5353,14 +5353,18 @@ export function App({
   >(null);
   const activePanelRef = useRef(activePanel);
   // Deep-link target for the Settings panel (e.g. 'Daemon' from the Local
-  // Control QR popover); cleared when the panel closes.
+  // Control QR popover). Cleared on any panel close/switch, not just
+  // closePanel — several paths call setActivePanel directly (approval
+  // overlay auto-close, openScheduledTasks, openSplitView, ...).
   const [settingsInitialCategory, setSettingsInitialCategory] = useState<
     string | undefined
   >();
-  const closePanel = useCallback(() => {
-    setActivePanel(null);
-    setSettingsInitialCategory(undefined);
-  }, []);
+  useEffect(() => {
+    if (activePanel !== 'settings') {
+      setSettingsInitialCategory(undefined);
+    }
+  }, [activePanel]);
+  const closePanel = useCallback(() => setActivePanel(null), []);
   const handleUseSkill = useCallback(
     (name: string) => {
       closePanel();

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -12573,6 +12573,8 @@ export function App({
                                 ),
                             }
                           : {}),
+                        onOpenLocalControlSettings:
+                          handleOpenLocalControlSettings,
                       })}
                     </div>
                   ) : (

--- a/packages/web-shell/client/components/ChatContextHeader.test.tsx
+++ b/packages/web-shell/client/components/ChatContextHeader.test.tsx
@@ -6,6 +6,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { I18nProvider } from '../i18n';
 import { ChatContextHeader } from './ChatContextHeader';
 
+// The QR entry reads the workspace connection from context.
+vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/webui/daemon-react-sdk')>();
+  return {
+    ...actual,
+    useWorkspace: () => ({
+      baseUrl: 'http://127.0.0.1:8080/',
+      token: 'test-token',
+    }),
+  };
+});
+
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 let container: HTMLDivElement | null = null;
@@ -126,5 +139,21 @@ describe('ChatContextHeader', () => {
     expect(
       view.querySelector('button[aria-label="Session token usage"]'),
     ).toBeNull();
+  });
+
+  it('shows the Local Control QR entry ahead of the other actions', () => {
+    const view = mount({
+      rightPanelAvailable: true,
+      onOpenLocalControlSettings: vi.fn(),
+    });
+    const actions = Array.from(
+      view.querySelectorAll<HTMLButtonElement>('button'),
+    );
+
+    expect(actions.map((button) => button.getAttribute('aria-label'))).toEqual([
+      'Mobile access',
+      'Toggle environment information',
+      'Toggle right panel',
+    ]);
   });
 });

--- a/packages/web-shell/client/components/ChatContextHeader.tsx
+++ b/packages/web-shell/client/components/ChatContextHeader.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { GaugeIcon, LayoutListIcon, PanelRightIcon } from 'lucide-react';
 import { useI18n } from '../i18n';
+import { LocalControlQrButton } from './LocalControlQrButton';
 import styles from './ChatContextHeader.module.css';
 
 interface ChatContextHeaderProps {
@@ -13,6 +14,8 @@ interface ChatContextHeaderProps {
   onToggleRightPanel: () => void;
   /** Opens the session token-usage panel; hidden when omitted. */
   onOpenTokenUsage?: () => void;
+  /** Shows the Local Control QR entry; hidden when omitted. */
+  onOpenLocalControlSettings?: () => void;
 }
 
 export function ChatContextHeader({
@@ -24,6 +27,7 @@ export function ChatContextHeader({
   onToggleEnvironment,
   onToggleRightPanel,
   onOpenTokenUsage,
+  onOpenLocalControlSettings,
 }: ChatContextHeaderProps) {
   const { t } = useI18n();
 
@@ -31,6 +35,12 @@ export function ChatContextHeader({
     <header className={styles.header} data-testid="chat-context-header">
       <div className={styles.content}>{content}</div>
       <div className={styles.actions}>
+        {onOpenLocalControlSettings && (
+          <LocalControlQrButton
+            onOpenSettings={onOpenLocalControlSettings}
+            className={styles.action}
+          />
+        )}
         {environmentAvailable && (
           <button
             type="button"

--- a/packages/web-shell/client/components/LocalControlQrButton.test.tsx
+++ b/packages/web-shell/client/components/LocalControlQrButton.test.tsx
@@ -50,6 +50,14 @@ vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
   };
 });
 
+const { writeClipboardText } = vi.hoisted(() => ({
+  writeClipboardText: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../utils/clipboard', () => ({
+  writeClipboardText,
+  warnClipboardWriteFailure: vi.fn(),
+}));
+
 const { I18nProvider } = await import('../i18n');
 const { LocalControlQrButton } = await import('./LocalControlQrButton');
 
@@ -102,6 +110,7 @@ async function openPopover(): Promise<void> {
 
 beforeEach(() => {
   vi.stubGlobal('fetch', vi.fn());
+  writeClipboardText.mockClear();
 });
 
 afterEach(() => {
@@ -159,5 +168,40 @@ describe('LocalControlQrButton', () => {
     await openPopover();
 
     expect(container.textContent).toContain('daemon unreachable');
+  });
+
+  it('shows the redacted hint when the daemon withholds the pairing URL', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      localControlResponse({ active: true, urlRedacted: true }),
+    );
+    mount();
+    await openPopover();
+
+    expect(container.textContent).toContain(
+      'The pairing URL is not shown here',
+    );
+  });
+
+  it('copies the pairing URL from the Copy button', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      localControlResponse({
+        active: true,
+        url: 'http://192.168.1.2:8080/ws#token=abc',
+        qrText: 'QR-TEXT',
+      }),
+    );
+    mount();
+    await openPopover();
+
+    const button = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((el) => el.textContent?.includes('Copy'));
+    if (!button) throw new Error('Copy button not found');
+    act(() => {
+      button.click();
+    });
+    expect(writeClipboardText).toHaveBeenCalledWith(
+      'http://192.168.1.2:8080/ws#token=abc',
+    );
   });
 });

--- a/packages/web-shell/client/components/LocalControlQrButton.test.tsx
+++ b/packages/web-shell/client/components/LocalControlQrButton.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, createElement, useContext, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+// The real popover shell is Radix, whose focus/scroll-lock effects never
+// settle under `act` in jsdom. Render trigger and content inline, wiring the
+// trigger click through a context so `open` state can be exercised.
+vi.mock('./ui/popover', async () => {
+  const React = await import('react');
+  const OpenContext = React.createContext<(open: boolean) => void>(() => {});
+  function Popover({
+    children,
+    onOpenChange,
+  }: {
+    children?: ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) {
+    return createElement(
+      OpenContext.Provider,
+      { value: onOpenChange },
+      children,
+    );
+  }
+  function PopoverTrigger({ children }: { children?: ReactNode }) {
+    const setOpen = useContext(OpenContext);
+    return createElement('div', { onClick: () => setOpen(true) }, children);
+  }
+  function PopoverContent({ children }: { children?: ReactNode }) {
+    return createElement('div', { 'data-test-popover-content': '' }, children);
+  }
+  return { Popover, PopoverTrigger, PopoverContent };
+});
+
+vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/webui/daemon-react-sdk')>();
+  return {
+    ...actual,
+    useWorkspace: () => ({
+      baseUrl: 'http://127.0.0.1:8080/',
+      token: 'test-token',
+    }),
+  };
+});
+
+const { I18nProvider } = await import('../i18n');
+const { LocalControlQrButton } = await import('./LocalControlQrButton');
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function localControlResponse(payload: object, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    text: () => Promise.resolve(JSON.stringify(payload)),
+  } as Response;
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function mount(onOpenSettings: () => void = vi.fn()): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      <I18nProvider language="en">
+        <LocalControlQrButton onOpenSettings={onOpenSettings} />
+      </I18nProvider>,
+    );
+  });
+  mounted.push({ root, container });
+}
+
+async function openPopover(): Promise<void> {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Mobile access"]',
+  );
+  if (!trigger) throw new Error('trigger button not found');
+  act(() => {
+    trigger.click();
+  });
+  await flush();
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.unstubAllGlobals();
+});
+
+describe('LocalControlQrButton', () => {
+  it('shows the QR code and pairing URL when Local Control is active', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      localControlResponse({
+        active: true,
+        url: 'http://192.168.1.2:8080/ws#token=abc',
+        qrText: 'QR-TEXT',
+      }),
+    );
+    mount();
+    await openPopover();
+
+    expect(fetch).toHaveBeenCalledWith(
+      new URL('http://127.0.0.1:8080/workspace/local-control'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(container.textContent).toContain('QR-TEXT');
+    expect(container.textContent).toContain(
+      'http://192.168.1.2:8080/ws#token=abc',
+    );
+  });
+
+  it('prompts to open Settings when Local Control is off', async () => {
+    vi.mocked(fetch).mockResolvedValue(localControlResponse({ active: false }));
+    const onOpenSettings = vi.fn();
+    mount(onOpenSettings);
+    await openPopover();
+
+    expect(container.textContent).toContain('Local Control is off');
+    const button = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((el) => el.textContent?.includes('Open Settings'));
+    if (!button) throw new Error('Open Settings button not found');
+    act(() => {
+      button.click();
+    });
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the error when the status request fails', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      localControlResponse({ error: 'daemon unreachable' }, false, 500),
+    );
+    mount();
+    await openPopover();
+
+    expect(container.textContent).toContain('daemon unreachable');
+  });
+});

--- a/packages/web-shell/client/components/LocalControlQrButton.tsx
+++ b/packages/web-shell/client/components/LocalControlQrButton.tsx
@@ -19,13 +19,17 @@ import {
 import { Button } from './ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { Spinner } from './ui/spinner';
+import { cn } from '@/lib/utils';
 
 interface LocalControlQrButtonProps {
   onOpenSettings: () => void;
+  /** Extra classes for the trigger, e.g. to match a host header's action style. */
+  className?: string;
 }
 
 export function LocalControlQrButton({
   onOpenSettings,
+  className,
 }: LocalControlQrButtonProps) {
   const { t } = useI18n();
   const { baseUrl, token } = useWorkspace();
@@ -61,6 +65,7 @@ export function LocalControlQrButton({
           type="button"
           variant="ghost"
           size="icon-xs"
+          className={cn(className)}
           aria-label={t('localControl.open')}
           title={t('localControl.open')}
         >

--- a/packages/web-shell/client/components/LocalControlQrButton.tsx
+++ b/packages/web-shell/client/components/LocalControlQrButton.tsx
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import { CopyIcon, QrCodeIcon } from 'lucide-react';
+import { useWorkspace } from '@qwen-code/webui/daemon-react-sdk';
+import { useI18n } from '../i18n';
+import {
+  warnClipboardWriteFailure,
+  writeClipboardText,
+} from '../utils/clipboard';
+import {
+  requestLocalControl,
+  type LocalControlStatus,
+} from './local-control-api';
+import { Button } from './ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
+import { Spinner } from './ui/spinner';
+
+interface LocalControlQrButtonProps {
+  onOpenSettings: () => void;
+}
+
+export function LocalControlQrButton({
+  onOpenSettings,
+}: LocalControlQrButtonProps) {
+  const { t } = useI18n();
+  const { baseUrl, token } = useWorkspace();
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<LocalControlStatus>();
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!open) return;
+    let ignore = false;
+    setStatus(undefined);
+    setError('');
+    requestLocalControl(baseUrl, token, 'GET', '/workspace/local-control')
+      .then((next) => {
+        if (!ignore) setStatus(next);
+      })
+      .catch((failure: unknown) => {
+        if (!ignore) {
+          setError(
+            failure instanceof Error ? failure.message : String(failure),
+          );
+        }
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [open, baseUrl, token]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label={t('localControl.open')}
+          title={t('localControl.open')}
+        >
+          <QrCodeIcon aria-hidden="true" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80">
+        {!status && !error && <Spinner />}
+        {status?.active && status.url && (
+          <div className="flex flex-col items-center gap-3">
+            {status.qrText && (
+              <pre
+                aria-label={t('settings.localControl.qr')}
+                className="w-fit overflow-hidden rounded-lg bg-white p-3 font-mono text-[7px] leading-[7px] tracking-normal text-black select-none"
+              >
+                {status.qrText}
+              </pre>
+            )}
+            <div className="w-full break-all rounded-md bg-muted px-3 py-2 font-mono text-xs">
+              {status.url}
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                void writeClipboardText(status.url!).catch(
+                  warnClipboardWriteFailure,
+                )
+              }
+            >
+              <CopyIcon aria-hidden="true" />
+              {t('common.copy')}
+            </Button>
+          </div>
+        )}
+        {status?.active && !status.url && status.urlRedacted && (
+          <p className="text-sm text-muted-foreground">
+            {t('settings.localControl.urlRedacted')}
+          </p>
+        )}
+        {status && !status.active && (
+          <div className="flex flex-col items-start gap-3">
+            <p className="text-sm text-muted-foreground">
+              {t('localControl.disabledHint')}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setOpen(false);
+                onOpenSettings();
+              }}
+            >
+              {t('localControl.openSettings')}
+            </Button>
+          </div>
+        )}
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/web-shell/client/components/local-control-api.ts
+++ b/packages/web-shell/client/components/local-control-api.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface LanCandidate {
+  interfaceName: string;
+  address: string;
+}
+
+export interface LocalControlStatus {
+  active: boolean;
+  url?: string;
+  /**
+   * Set when the daemon withheld the pairing URL from this response because
+   * the request carried no credentials (#9106); the URL is printed to the
+   * daemon terminal instead.
+   */
+  urlRedacted?: boolean;
+  qrText?: string;
+  interfaceName?: string;
+  address?: string;
+  sleepInhibited?: boolean;
+  encrypted?: boolean;
+  interfaces?: LanCandidate[];
+}
+
+function resolveLocalControlUrl(baseUrl: string, path: string): URL {
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL(path.replace(/^\/+/, ''), base);
+}
+
+export class LocalControlRequestError extends Error {
+  constructor(
+    message: string,
+    readonly payload?: LocalControlStatus,
+  ) {
+    super(message);
+    this.name = 'LocalControlRequestError';
+  }
+}
+
+export async function requestLocalControl(
+  baseUrl: string,
+  token: string | undefined,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: object,
+): Promise<LocalControlStatus> {
+  const headers = new Headers(
+    token ? { Authorization: `Bearer ${token}` } : undefined,
+  );
+  if (body) headers.set('Content-Type', 'application/json');
+  const response = await fetch(resolveLocalControlUrl(baseUrl, path), {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  let payload: (LocalControlStatus & { error?: string }) | undefined;
+  try {
+    payload = (text ? JSON.parse(text) : {}) as LocalControlStatus & {
+      error?: string;
+    };
+  } catch {
+    if (response.ok) throw new Error('Invalid Local Control response');
+  }
+  if (!response.ok) {
+    throw new LocalControlRequestError(
+      payload?.error?.trim() ||
+        response.statusText ||
+        `Local Control request failed (${response.status})`,
+      payload,
+    );
+  }
+  return payload!;
+}

--- a/packages/web-shell/client/components/messages/LocalControlSettingsCard.tsx
+++ b/packages/web-shell/client/components/messages/LocalControlSettingsCard.tsx
@@ -16,79 +16,12 @@ import {
   SelectValue,
 } from '../ui/select';
 import { Spinner } from '../ui/spinner';
-
-interface LanCandidate {
-  interfaceName: string;
-  address: string;
-}
-
-interface LocalControlStatus {
-  active: boolean;
-  url?: string;
-  /**
-   * Set when the daemon withheld the pairing URL from this response because
-   * the request carried no credentials (#9106); the URL is printed to the
-   * daemon terminal instead.
-   */
-  urlRedacted?: boolean;
-  qrText?: string;
-  interfaceName?: string;
-  address?: string;
-  sleepInhibited?: boolean;
-  encrypted?: boolean;
-  interfaces?: LanCandidate[];
-}
-
-function resolveLocalControlUrl(baseUrl: string, path: string): URL {
-  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-  return new URL(path.replace(/^\/+/, ''), base);
-}
-
-class LocalControlRequestError extends Error {
-  constructor(
-    message: string,
-    readonly payload?: LocalControlStatus,
-  ) {
-    super(message);
-    this.name = 'LocalControlRequestError';
-  }
-}
-
-async function requestLocalControl(
-  baseUrl: string,
-  token: string | undefined,
-  method: 'GET' | 'POST',
-  path: string,
-  body?: object,
-): Promise<LocalControlStatus> {
-  const headers = new Headers(
-    token ? { Authorization: `Bearer ${token}` } : undefined,
-  );
-  if (body) headers.set('Content-Type', 'application/json');
-  const response = await fetch(resolveLocalControlUrl(baseUrl, path), {
-    method,
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  const text = await response.text();
-  let payload: (LocalControlStatus & { error?: string }) | undefined;
-  try {
-    payload = (text ? JSON.parse(text) : {}) as LocalControlStatus & {
-      error?: string;
-    };
-  } catch {
-    if (response.ok) throw new Error('Invalid Local Control response');
-  }
-  if (!response.ok) {
-    throw new LocalControlRequestError(
-      payload?.error?.trim() ||
-        response.statusText ||
-        `Local Control request failed (${response.status})`,
-      payload,
-    );
-  }
-  return payload!;
-}
+import {
+  LocalControlRequestError,
+  requestLocalControl,
+  type LanCandidate,
+  type LocalControlStatus,
+} from '../local-control-api';
 
 function getLocalControlTarget(): string {
   const url = new URL(window.location.href);

--- a/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
@@ -235,7 +235,7 @@ describe('SettingsMessage initialCategory', () => {
     return el;
   }
 
-  it('selects the requested category on open', () => {
+  it('selects the requested category on open', async () => {
     // The Daemon category's Local Control card fetches status on mount.
     vi.stubGlobal(
       'fetch',
@@ -250,6 +250,10 @@ describe('SettingsMessage initialCategory', () => {
       makeState([boolSetting(), daemonSetting()], vi.fn()),
       { initialCategory: 'Daemon' },
     );
+    // Flush the card's status fetch under act so it doesn't warn.
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(activeCategoryButton(container).textContent).toContain('Daemon');
     vi.unstubAllGlobals();
@@ -261,6 +265,61 @@ describe('SettingsMessage initialCategory', () => {
     );
 
     expect(activeCategoryButton(container).textContent).toContain('General');
+  });
+
+  it('does not force the deep-linked category again after a manual switch', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.resolve(JSON.stringify({ active: false })),
+      }),
+    );
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    mounted.push({ root, container });
+    const renderWith = (state: SettingsMessageSettingsState) =>
+      act(() => {
+        root.render(
+          <I18nProvider language="en">
+            <SettingsMessage
+              settingsState={state}
+              embedded
+              initialCategory="Daemon"
+              onLanguageChange={noop}
+              onThemeChange={noop}
+              onSubDialog={noop}
+              chatWidthMode="1000"
+              onChatWidthModeChange={noop}
+            />
+          </I18nProvider>,
+        );
+      });
+
+    renderWith(makeState([boolSetting(), daemonSetting()], vi.fn()));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(activeCategoryButton(container).textContent).toContain('Daemon');
+
+    // The user manually switches to General.
+    const generalButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((el) => el.textContent?.includes('General'));
+    if (!generalButton) throw new Error('General category button not found');
+    act(() => {
+      generalButton.click();
+    });
+    expect(activeCategoryButton(container).textContent).toContain('General');
+
+    // A re-render with a fresh settings identity (re-running the deep-link
+    // effect) must not override the manual choice.
+    renderWith(makeState([boolSetting(), daemonSetting()], vi.fn()));
+    expect(activeCategoryButton(container).textContent).toContain('General');
+    vi.unstubAllGlobals();
   });
 });
 

--- a/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
@@ -267,6 +267,15 @@ describe('SettingsMessage initialCategory', () => {
     expect(activeCategoryButton(container).textContent).toContain('General');
   });
 
+  it('falls back to the first category for an unknown initialCategory', () => {
+    const container = renderPanel(
+      makeState([boolSetting(), daemonSetting()], vi.fn()),
+      { initialCategory: 'NoSuchCategory' },
+    );
+
+    expect(activeCategoryButton(container).textContent).toContain('General');
+  });
+
   it('does not force the deep-linked category again after a manual switch', async () => {
     vi.stubGlobal(
       'fetch',

--- a/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.dom.test.tsx
@@ -16,6 +16,21 @@ import {
 import type { ModelManagementProps } from './ModelManagementSection';
 import type { UseLiveVoiceSetupResult } from '../../live/useLiveVoiceSetup';
 
+// The Daemon category renders LocalControlSettingsCard, which reads the
+// workspace connection from context; stub it so the category can be
+// rendered without a DaemonWorkspaceProvider.
+vi.mock('@qwen-code/webui/daemon-react-sdk', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/webui/daemon-react-sdk')>();
+  return {
+    ...actual,
+    useWorkspace: () => ({
+      baseUrl: 'http://127.0.0.1:8080/',
+      token: 'test-token',
+    }),
+  };
+});
+
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -155,6 +170,7 @@ function renderPanel(
   overrides: Partial<{
     onSubDialog: (key: string, scope: 'workspace' | 'user') => void;
     modelManagement: ModelManagementProps;
+    initialCategory: string;
   }> = {},
 ): HTMLElement {
   return render(
@@ -162,6 +178,7 @@ function renderPanel(
       <SettingsMessage
         settingsState={state}
         embedded
+        initialCategory={overrides.initialCategory}
         onLanguageChange={noop}
         onThemeChange={noop}
         onSubDialog={overrides.onSubDialog ?? noop}
@@ -196,6 +213,56 @@ function switchButton(container: HTMLElement): HTMLButtonElement {
   if (!el) throw new Error('boolean switch not found');
   return el;
 }
+
+describe('SettingsMessage initialCategory', () => {
+  function daemonSetting(): DaemonSettingDescriptor {
+    return {
+      key: 'daemon.testFlag',
+      type: 'boolean',
+      label: 'Daemon Flag',
+      category: 'Daemon',
+      requiresRestart: false,
+      default: false,
+      values: { effective: false },
+    };
+  }
+
+  function activeCategoryButton(container: HTMLElement): HTMLButtonElement {
+    const el = container.querySelector<HTMLButtonElement>(
+      'button[aria-current="page"]',
+    );
+    if (!el) throw new Error('active category button not found');
+    return el;
+  }
+
+  it('selects the requested category on open', () => {
+    // The Daemon category's Local Control card fetches status on mount.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.resolve(JSON.stringify({ active: false })),
+      }),
+    );
+    const container = renderPanel(
+      makeState([boolSetting(), daemonSetting()], vi.fn()),
+      { initialCategory: 'Daemon' },
+    );
+
+    expect(activeCategoryButton(container).textContent).toContain('Daemon');
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to the first category without an initialCategory', () => {
+    const container = renderPanel(
+      makeState([boolSetting(), daemonSetting()], vi.fn()),
+    );
+
+    expect(activeCategoryButton(container).textContent).toContain('General');
+  });
+});
 
 describe('SettingsMessage user-scope editing', () => {
   it('persists a boolean toggle to the user scope from the User tab', async () => {

--- a/packages/web-shell/client/components/messages/SettingsMessage.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.tsx
@@ -2,7 +2,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -502,27 +501,18 @@ export function SettingsMessage({
   useEffect(() => {
     if (categories.length === 0) return;
     if (!categories.some((category) => category.id === activeCategory)) {
-      setActiveCategory(categories[0]!.id);
+      // A deep link (initialCategory) only matters while no valid category
+      // is selected, so it wins on mount but never overrides a later manual
+      // switch. Keeping this in one effect avoids two effects racing to set
+      // the initial category under StrictMode double-invocation.
+      const preferred =
+        initialCategory &&
+        categories.some((category) => category.id === initialCategory)
+          ? initialCategory
+          : categories[0]!.id;
+      setActiveCategory(preferred);
     }
-  }, [activeCategory, categories]);
-
-  // Deep link: apply the requested category once per value, after the
-  // fallback above so this setState wins when both run in the same batch.
-  // A ref (not a dep on activeCategory) keeps later manual category switches
-  // from being forced back.
-  const appliedInitialCategoryRef = useRef<string | undefined>(undefined);
-  useEffect(() => {
-    if (
-      !initialCategory ||
-      appliedInitialCategoryRef.current === initialCategory
-    ) {
-      return;
-    }
-    if (categories.some((category) => category.id === initialCategory)) {
-      appliedInitialCategoryRef.current = initialCategory;
-      setActiveCategory(initialCategory);
-    }
-  }, [initialCategory, categories]);
+  }, [activeCategory, categories, initialCategory]);
 
   useEffect(() => {
     if (error) setMessage(error.message);

--- a/packages/web-shell/client/components/messages/SettingsMessage.tsx
+++ b/packages/web-shell/client/components/messages/SettingsMessage.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
@@ -89,6 +90,8 @@ interface SettingsMessageProps {
   /** Model list/add/delete/select, rendered inside the Model category. */
   modelManagement?: ModelManagementProps;
   embedded?: boolean;
+  /** Category to select on open (deep link, e.g. 'Daemon'). */
+  initialCategory?: string;
 }
 
 export interface SettingsMessageSettingsState {
@@ -419,6 +422,7 @@ export function SettingsMessage({
   onChatWidthModeChange,
   modelManagement,
   embedded = false,
+  initialCategory,
 }: SettingsMessageProps) {
   const { language: selectedLanguage, t } = useI18n();
   const selectedTheme = useTheme();
@@ -501,6 +505,24 @@ export function SettingsMessage({
       setActiveCategory(categories[0]!.id);
     }
   }, [activeCategory, categories]);
+
+  // Deep link: apply the requested category once per value, after the
+  // fallback above so this setState wins when both run in the same batch.
+  // A ref (not a dep on activeCategory) keeps later manual category switches
+  // from being forced back.
+  const appliedInitialCategoryRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (
+      !initialCategory ||
+      appliedInitialCategoryRef.current === initialCategory
+    ) {
+      return;
+    }
+    if (categories.some((category) => category.id === initialCategory)) {
+      appliedInitialCategoryRef.current = initialCategory;
+      setActiveCategory(initialCategory);
+    }
+  }, [initialCategory, categories]);
 
   useEffect(() => {
     if (error) setMessage(error.message);

--- a/packages/web-shell/client/customization.tsx
+++ b/packages/web-shell/client/customization.tsx
@@ -166,6 +166,8 @@ export interface ChatHeaderRenderInfo {
   onRightPanelOpenChange: (open: boolean) => void;
   /** Opens token usage for the current session, when available. */
   onOpenTokenUsage?: () => void;
+  /** Opens Settings deep-linked to Local Control (Daemon category). */
+  onOpenLocalControlSettings?: () => void;
 }
 
 /**

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -3092,6 +3092,10 @@ const EN: Messages = {
   'settings.localControl.maySleep': 'This Mac may sleep',
   'settings.localControl.urlRedacted':
     'The pairing URL is not shown here because this daemon has no bearer token. It was printed to the terminal where the daemon is running — pair from there.',
+  'localControl.open': 'Mobile access',
+  'localControl.disabledHint':
+    'Local Control is off. Turn it on in Settings to pair a phone on the same network.',
+  'localControl.openSettings': 'Open Settings',
   'settings.models.title': 'Models',
   'settings.models.add': '+ Add Model',
   'settings.models.setCurrent': 'Set current',
@@ -6062,6 +6066,10 @@ const ZH: Messages = {
   'settings.localControl.maySleep': '这台 Mac 可能进入睡眠',
   'settings.localControl.urlRedacted':
     '由于该守护进程未配置 bearer token，配对 URL 不在此显示。它已打印到运行守护进程的终端，请到该终端获取配对 URL 完成配对。',
+  'localControl.open': '手机访问',
+  'localControl.disabledHint':
+    '本地控制未开启。请在设置中开启后，配对同一网络下的手机。',
+  'localControl.openSettings': '打开设置',
   'settings.models.title': '模型',
   'settings.models.add': '+ 增加模型',
   'settings.models.setCurrent': '设为当前',


### PR DESCRIPTION
## What this PR does

Adds a QR code button to the chat header in Web Shell — both the main single-session header and split-view pane headers. Clicking it opens a popover that shows the Local Control pairing QR code and URL (with a copy button) when Local Control is on. When Local Control is off, the popover explains that and offers an "Open Settings" button that jumps straight to the Daemon category of the Settings panel, where the feature can be enabled. The Settings panel now accepts an optional initial category so deep links like this land on the right section. The existing inline QR display inside the Daemon settings card is unchanged; both share the same extracted request helper, and no new frontend dependency is introduced (the QR text is still generated by the daemon).

## Why it's needed

The phone-pairing QR code was buried three levels deep (sidebar gear → Settings → Daemon → Local Control card) and only visible after the feature was already enabled, so many users never discovered that mobile access exists. A one-click entry in the chat header makes pairing discoverable from any conversation without exposing the token-bearing URL persistently.

## Reviewer Test Plan

### How to verify

1. Start the daemon and open Web Shell; a QR icon button should appear in the chat header (and in each pane header in split view).
2. With Local Control off, click the QR button: the popover should say Local Control is off and show "Open Settings"; clicking it should open the Settings panel already focused on the Daemon category, where Local Control can be turned on.
3. Turn on Local Control, then click the QR button again: the popover should show the QR code, the pairing URL, and a copy button; scanning the QR with a phone on the same network should pair as before.
4. Confirm the QR code in Settings → Daemon → Local Control still renders as before.

Expected: the QR button is always present in the chat header; popover content reflects the live Local Control state fetched on open. Observed: all flows above verified in Chromium (Playwright-driven, vite dev server + mock daemon) — screenshots below; the mock-daemon flow cannot exercise a real phone scan.

```
cd packages/web-shell && npx vitest run client/App.test.tsx client/components/ChatContextHeader.test.tsx client/components/LocalControlQrButton.test.tsx client/components/messages/SettingsMessage.dom.test.tsx client/components/ChatPane.test.tsx
# 698 tests, all passing
```

### Evidence (Before & After)

Before — the QR code only lived inside Settings → Daemon → Local Control, three levels deep:

![Before: QR in settings card](https://raw.githubusercontent.com/wenshao/qwen-code/689113066401faec3feef2da7d32c2fdc9d2efdd/pr-assets/10432/before-qr-in-settings.png)

After — QR entry in the chat header (top right):

![After: QR button in chat header](https://raw.githubusercontent.com/wenshao/qwen-code/689113066401faec3feef2da7d32c2fdc9d2efdd/pr-assets/10432/after-pane-header.png)

After — popover with the pairing QR code and URL when Local Control is on:

![After: popover with QR code](https://raw.githubusercontent.com/wenshao/qwen-code/689113066401faec3feef2da7d32c2fdc9d2efdd/pr-assets/10432/after-popover-active.png)

After — off-state popover with a jump to Settings:

![After: off-state popover](https://raw.githubusercontent.com/wenshao/qwen-code/689113066401faec3feef2da7d32c2fdc9d2efdd/pr-assets/10432/after-popover-off.png)

After — "Open Settings" lands directly on the Daemon category:

![After: settings deep link to Daemon](https://raw.githubusercontent.com/wenshao/qwen-code/689113066401faec3feef2da7d32c2fdc9d2efdd/pr-assets/10432/after-settings-deeplink.png)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

vitest (jsdom) unit tests; interactive verification in Playwright-driven Chromium against the vite dev server with a mock daemon.

## Risk & Scope

- Main risk or tradeoff: the built-in pane header actions are now always mounted (previously they only existed when the token usage opt-in was on); hosts overriding `renderPaneHeaderActions` or `renderChatHeader` are unaffected, and the token usage action still respects its opt-in.
- Not validated / out of scope: an actual phone scan pairing (mock daemon has no LAN listener); sidebar/status-bar entries were considered and intentionally left out.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在 Web Shell 的聊天头部新增一个二维码按钮——主单会话头部和分屏窗格头部都有。点击后弹出浮层：当本地控制（Local Control）已开启时，显示配对二维码和配对 URL（附复制按钮）；未开启时，浮层会说明情况并提供「打开设置」按钮，直接跳转到设置面板的守护进程（Daemon）分组开启该功能。设置面板新增了可选的初始分组参数，使这类深链能落到正确的分区。守护进程设置卡片里原有的内联二维码展示保持不变；两者共用抽取出来的请求辅助模块，且没有引入新的前端依赖（二维码文本仍由守护进程生成）。

## 为什么需要

手机配对二维码之前藏在三层路径之下（侧边栏齿轮 → 设置 → 守护进程 → 本地控制卡片），而且只有功能已开启后才可见，很多用户根本不知道有手机访问能力。在聊天头部提供一键入口后，用户在任何会话中都能发现配对功能，同时又不会让携带 token 的 URL 常驻暴露。

## 评审者验证计划

### 如何验证

1. 启动守护进程并打开 Web Shell，聊天头部应出现二维码图标按钮（分屏时每个窗格头部也有）。
2. 在本地控制未开启时点击二维码按钮：浮层应提示本地控制未开启并显示「打开设置」；点击后应打开设置面板并自动定位到守护进程分组，可在该处开启本地控制。
3. 开启本地控制后再次点击二维码按钮：浮层应显示二维码、配对 URL 和复制按钮；用同一网络下的手机扫码应能像以前一样完成配对。
4. 确认「设置 → 守护进程 → 本地控制」中的二维码仍照常渲染。

预期：二维码按钮始终出现在聊天头部；浮层内容反映打开时获取的本地控制实时状态。实际验证：上述全部流程已在 Chromium 中走通（Playwright 驱动，vite dev server + mock daemon）——截图见下；mock daemon 流程无法覆盖真实手机扫码。

### 前后对比（证据）

改前——二维码只藏在「设置 → 守护进程 → 本地控制」卡片里，三层路径之下（见第一张图）。

改后——聊天头部（右上角）的二维码入口；本地控制已开启时浮层直接展示配对二维码和 URL；未开启时浮层提供「打开设置」跳转；点击后设置面板直接落在守护进程分组（见后四张图）。

### 测试平台

仅 macOS（✅）；Windows、Linux 未测（⚠️）。

### 环境（可选）

vitest（jsdom）单元测试；Playwright 驱动的 Chromium + vite dev server + mock daemon 交互验证。

## 风险与范围

- 主要风险或取舍：内置窗格头部按钮现在始终挂载（此前仅在 token 用量开关开启时才存在）；通过 `renderPaneHeaderActions` 或 `renderChatHeader` 覆盖的宿主不受影响，token 用量按钮仍遵循其开关。
- 未验证 / 不在范围内：真实手机扫码配对（mock daemon 没有 LAN listener）；侧边栏 / 状态栏入口方案已考虑过并有意不纳入。
- 破坏性变更 / 迁移说明：无。

</details>
