### PR TITLE
fix(test): make the queued-submission drain reachable through a rendered AppContainer

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -67,6 +67,7 @@ import ansiEscapes from 'ansi-escapes';
 import {
   type Config,
   makeFakeConfig,
+  MCPDiscoveryState,
   SendMessageType,
   type LlmClient,
   type GoalTurnHost,
@@ -115,7 +116,13 @@ vi.mock('ink', async (importOriginal) => {
   return {
     ...actual,
     useStdout: () => ({ stdout: mockStdout }),
-    measureElement: vi.fn(),
+    // Must return a measurement, not undefined: AppContainer's footer
+    // re-measurement layout effect dereferences `.height` on the result.
+    // An undefined return throws inside the commit; ink's error handling
+    // catches it, tears down the AppContainer tree, and renders an error
+    // panel in its place, so NO post-mount state update is ever observed
+    // (#10430).
+    measureElement: vi.fn(() => ({ width: 80, height: 5 })),
   };
 });
 
@@ -136,6 +143,25 @@ function TestContextConsumer() {
 vi.mock('./App.js', () => ({
   App: TestContextConsumer,
 }));
+
+/**
+ * AppContainer's config-initialization effect is async: it awaits
+ * `config.initialize()` and `waitForGoalRuntime(config)` before flipping
+ * `isConfigInitialized`. Effects gated on that flag — notably the
+ * queued-submission drain — only see the flip on the re-render that
+ * follows, so tests that render `AppContainer` must wait for it before
+ * asserting on post-init behaviour (#10430).
+ */
+async function flushConfigInitialization() {
+  // Real config I/O (session writer, goal runtime) backs this flip; give
+  // it a generous bound instead of vi.waitFor's 1s default.
+  await vi.waitFor(
+    () => {
+      expect(capturedUIState?.isConfigInitialized).toBe(true);
+    },
+    { timeout: 10000 },
+  );
+}
 
 // AppContainer reads the peer inbox through this hook; a holder keeps the
 // value swappable without wrapping every render in a provider.
@@ -414,15 +440,32 @@ describe('AppContainer State Management', () => {
       needsRestart: false,
       restartReason: 'NONE',
     });
+    // Complete UseMessageQueueReturn shape. AppContainer destructures all
+    // of these and passes the drain fields straight into
+    // useQueuedSubmissionDrain; a mock missing them leaves the drain with
+    // undefined inputs, so no rendered test could ever exercise it. The
+    // idle defaults (count 0, pop -> null) keep the drain quiescent for
+    // tests that don't queue anything (#10430).
     mockedUseMessageQueue.mockReturnValue({
       removeGoalTurns: vi.fn().mockReturnValue([]),
       messageQueue: [],
+      pendingSubmissionCount: 0,
       addMessage: vi.fn(),
+      addPeerMessage: vi.fn(),
+      enqueueGoalTurn: vi.fn(),
+      peekNextUserBatchKey: vi.fn(),
+      hasQueuedUserMessages: vi.fn().mockReturnValue(false),
+      getPendingSubmissionCount: vi.fn().mockReturnValue(0),
+      getQueuedPeerCount: vi.fn().mockReturnValue(0),
+      claimGoalTurn: vi.fn(),
+      claimDirectUserAdmission: vi.fn(),
       clearQueue: vi.fn(),
       getQueuedMessagesText: vi.fn().mockReturnValue(''),
       popAllMessages: vi.fn().mockReturnValue(null),
+      popNextSubmission: vi.fn().mockReturnValue(null),
+      restoreMessages: vi.fn(),
+      restorePeerMessage: vi.fn(),
       drainQueue: vi.fn().mockReturnValue([]),
-      popNextTurn: vi.fn().mockReturnValue(null),
     });
     mockedUseAutoAcceptIndicator.mockReturnValue(false);
     mockedUseGitBranchName.mockReturnValue('main');
@@ -1383,7 +1426,10 @@ describe('AppContainer State Management', () => {
       expect(capturedUIState.historyRemountKey).toBe(remountKeyBefore);
 
       vi.useRealTimers();
-      (measureElement as Mock).mockReturnValue(undefined);
+      // mockReset() restores the shared default (a real measurement);
+      // leaving an `undefined` override here would re-break every render
+      // test that runs after this one (#10430).
+      (measureElement as Mock).mockReset();
     });
 
     it('handleClearScreen avoids a second clearTerminal write', () => {
@@ -2137,6 +2183,90 @@ describe('AppContainer State Management', () => {
           }),
         );
       });
+    });
+
+    it('drains a queued submission through a rendered AppContainer (#10430)', async () => {
+      const submitQuery = vi.fn().mockResolvedValue(undefined);
+      mockedUseLlmStream.mockReturnValue({
+        streamingState: StreamingState.Idle,
+        submitQuery,
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+        streamingResponseLengthRef: { current: 0 },
+        isReceivingContent: false,
+      });
+      let popped = false;
+      const popNextSubmission = vi.fn(() => {
+        if (popped) return null;
+        popped = true;
+        return {
+          kind: 'user' as const,
+          modelText: 'queued before startup settled',
+          turnKey: 'message-queue:startup-queued',
+        };
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        removeGoalTurns: vi.fn().mockReturnValue([]),
+        messageQueue: [],
+        pendingSubmissionCount: 1,
+        addMessage: vi.fn(),
+        addPeerMessage: vi.fn(),
+        enqueueGoalTurn: vi.fn(),
+        peekNextUserBatchKey: vi.fn(),
+        hasQueuedUserMessages: vi.fn().mockReturnValue(false),
+        getPendingSubmissionCount: vi.fn(() => (popped ? 0 : 1)),
+        getQueuedPeerCount: vi.fn().mockReturnValue(0),
+        claimGoalTurn: vi.fn(),
+        claimDirectUserAdmission: vi.fn(),
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        popNextSubmission,
+        restoreMessages: vi.fn(),
+        restorePeerMessage: vi.fn(),
+        drainQueue: vi.fn().mockReturnValue([]),
+      });
+      vi.spyOn(mockConfig, 'initialize').mockResolvedValue(undefined);
+      // The profile-finalize effect runs on the init flip and dereferences
+      // the tool registry's MCP client manager; without a stub the effect
+      // throws mid-commit, React aborts the passive flush, and the drain
+      // effect never observes the flip (#10430).
+      vi.spyOn(mockConfig, 'getToolRegistry').mockReturnValue({
+        getMcpClientManager: () => ({
+          getDiscoveryState: () => MCPDiscoveryState.COMPLETED,
+        }),
+      } as unknown as ReturnType<Config['getToolRegistry']>);
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // Async config init gates the drain; wait for the gate to flip on a
+      // live re-render before expecting drain activity.
+      await flushConfigInitialization();
+
+      await vi.waitFor(
+        () => {
+          expect(popNextSubmission).toHaveBeenCalledWith('normal');
+        },
+        { timeout: 5000 },
+      );
+      expect(submitQuery).toHaveBeenCalledWith(
+        'queued before startup settled',
+        SendMessageType.UserQuery,
+        undefined,
+        expect.objectContaining({
+          userAdmission: { turnKey: 'message-queue:startup-queued' },
+        }),
+      );
     });
 
     it('marks Ctrl+Q submissions to wait for the idle boundary', () => {


### PR DESCRIPTION
## What this PR does

Makes the queued-submission drain drivable through a rendered `AppContainer` in tests. All changes are test scaffolding in `packages/cli/src/ui/AppContainer.test.tsx`; no production code is touched. The shared ink `measureElement` mock now returns a real measurement instead of `undefined`: AppContainer's footer re-measurement layout effect dereferences `.height` on the result, and the `undefined` return threw inside the first commit, after which ink's error handling tore the whole AppContainer tree down — so no post-mount state update was ever observable by any rendered test. The new regression test additionally stubs `config.getToolRegistry()`, because the profile-finalize effect that fires on the `isConfigInitialized` flip dereferences `getToolRegistry().getMcpClientManager()` and otherwise aborts the passive-effect flush before the drain effect can observe the flip. The shared `useMessageQueue` mock is completed to the full `UseMessageQueueReturn` shape (idle defaults keep non-drain tests quiescent) and drops the stale `popNextTurn` field that does not exist on the interface. A `flushConfigInitialization()` helper is added, and the #8004 test's `measureElement` restore switches from `mockReturnValue(undefined)` to `mockReset()` so its override no longer leaks into later tests.

## Why it's needed

Per #10430, no test in the repository could drive the queued-submission drain through a rendered `AppContainer`: every existing drain test calls `useQueuedSubmissionDrain` directly via `renderHook`, so the drain wiring at the AppContainer call site had zero coverage. Removing a drain argument at the call site (e.g. `popNextSubmission`) failed no test anywhere in the repo.

## Reviewer Test Plan

### How to verify

- Red on baseline: with the old scaffolding, a test that renders `AppContainer` with `pendingSubmissionCount: 1` and a `popNextSubmission` returning one queued user submission waits forever — observed `AssertionError: expected "spy" to be called with arguments: [ 'normal' ]`, `Number of calls: 0`.
- Green with this PR: `cd packages/cli && npx vitest run src/ui/AppContainer.test.tsx` → `Tests 167 passed (167)`, including the new `drains a queued submission through a rendered AppContainer (#10430)`, which asserts the queued submission is popped with `'normal'` and handed to `submitQuery` with the `userAdmission` turn key once config init settles.
- Mutation check (issue's motivation case): temporarily removing `popNextSubmission` from the `useQueuedSubmissionDrain` call site in `AppContainer.tsx` makes the new test fail (1 failed), so the call-site wiring is now covered.
- `npm run typecheck` (cli package) passes; `npx eslint src/ui/AppContainer.test.tsx` and `npx prettier --check src/ui/AppContainer.test.tsx` both pass.

### Evidence (Before & After)

N/A — test-only change, no user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only: Node v24.19.0, `npx vitest run` in `packages/cli` on Linux.

## Risk & Scope

- Main risk or tradeoff: the shared `measureElement` and `useMessageQueue` mocks now behave more like production, so rendered tests that previously ran against a tree that died on the first commit now exercise real post-mount behavior. Full file re-run: 167/167 pass.
- Not validated / out of scope: production code is unchanged, so real-terminal drain behavior is unaffected. Goal-control `priority` mode and peer/goal submission kinds remain covered by the existing renderHook suites; draining those kinds through a rendered AppContainer is left for follow-up if desired.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10430

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让测试能够通过渲染出来的 `AppContainer` 驱动 queued-submission drain。所有改动都在 `packages/cli/src/ui/AppContainer.test.tsx` 的测试脚手架里，不碰任何生产代码。共享的 ink `measureElement` mock 现在返回真实测量值而不是 `undefined`：AppContainer 的 footer 重测量 layout effect 会对结果解引用 `.height`，原来返回 `undefined` 会在首次 commit 里抛错，随后 ink 的错误处理把整个 AppContainer 树拆掉——任何渲染型测试都观察不到 mount 之后的状态更新。新的回归测试还额外 stub 了 `config.getToolRegistry()`，因为 `isConfigInitialized` 翻转时触发的 profile-finalize effect 会解引用 `getToolRegistry().getMcpClientManager()`，不 stub 的话会在 commit 中途抛错、中断 passive effect 队列，drain effect 根本观察不到翻转。共享的 `useMessageQueue` mock 补全为完整的 `UseMessageQueueReturn` 形状（idle 默认值保证不排队的测试保持安静），并删掉了接口里根本不存在的过时字段 `popNextTurn`。新增 `flushConfigInitialization()` helper；#8004 测试对 `measureElement` 的还原从 `mockReturnValue(undefined)` 改为 `mockReset()`，避免它的覆盖值泄漏到后续测试。

## 为什么需要

按 #10430：整个仓库没有任何测试能通过渲染出来的 `AppContainer` 驱动 queued-submission drain，现有 drain 测试全部是 renderHook 直调 `useQueuedSubmissionDrain`，AppContainer 调用点的 drain 接线零覆盖——把调用点的任一 drain 参数（如 `popNextSubmission`）删掉，仓库里没有任何测试会失败。

## 评审验证计划

### 如何验证

- 基线红测试：旧脚手架下，渲染 `AppContainer` 并令 `pendingSubmissionCount: 1`、`popNextSubmission` 返回一条排队的用户 submission，无论等多久 `popNextSubmission` 都不会被调用——实测 `AssertionError: expected "spy" to be called with arguments: [ 'normal' ]`，`Number of calls: 0`。
- 本 PR 后绿：`cd packages/cli && npx vitest run src/ui/AppContainer.test.tsx` → `Tests 167 passed (167)`，包含新增的 `drains a queued submission through a rendered AppContainer (#10430)`：断言 config init 落定后，排队的 submission 以 `'normal'` 被 pop 并带 `userAdmission` turn key 交给 `submitQuery`。
- 突变检查（issue 的动机案例）：临时删掉 `AppContainer.tsx` 中 `useQueuedSubmissionDrain` 调用点的 `popNextSubmission`，新测试失败（1 failed），调用点接线从此有覆盖。
- `npm run typecheck`（cli 包）通过；`npx eslint src/ui/AppContainer.test.tsx` 与 `npx prettier --check src/ui/AppContainer.test.tsx` 均通过。

### 前后对比证据

N/A——纯测试改动，无用户可见行为。

### 测试环境

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单测：Linux 上 Node v24.19.0，在 `packages/cli` 下 `npx vitest run`。

## 风险与范围

- 主要风险/权衡：共享的 `measureElement` 与 `useMessageQueue` mock 现在更接近生产行为，原本在首次 commit 就死树的渲染型测试现在会真正跑 mount 后的行为。全文件重跑 167/167 通过。
- 未验证/超出范围：生产代码未变，真实终端的 drain 行为不受影响。Goal 控制 `priority` 模式与 peer/goal 类型 submission 仍由既有 renderHook 套件覆盖；是否让它们也走渲染型 AppContainer 留作后续可选跟进。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #10430

</details>
