### PR TITLE
ci(ecs): wait out npm publish propagation before updating the runner fleet

### DIFF
--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -18,8 +18,60 @@ permissions:
   contents: 'read'
 
 jobs:
+  # Resolving on a hosted runner, once, keeps the registry wait below off the
+  # ECS pools (which queue behind real review/triage work) and guarantees every
+  # pool installs the SAME version even when their jobs start hours apart.
+  resolve:
+    name: 'Resolve version'
+    if: "${{ github.repository == 'QwenLM/qwen-code' }}"
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 30
+    outputs:
+      version: '${{ steps.version.outputs.version }}'
+    steps:
+      - name: 'Resolve version'
+        id: 'version'
+        env:
+          INPUT_VERSION: '${{ inputs.version || github.event.client_payload.version }}'
+          # npm publishes asynchronously: `npm publish --provenance` returns
+          # "Your package is being processed and may take a few minutes to
+          # become available", and release.yml dispatches this workflow as soon
+          # as it returns. For v0.22.3 the gap was ~16 minutes (published
+          # 17:14Z, resolvable 17:30Z), so the single un-retried `npm view` this
+          # step used to run 404'd on 3 of the 4 pools and left the fleet split
+          # across two CLI versions until a maintainer noticed. Wait the
+          # registry out rather than losing the race.
+          RESOLVE_TIMEOUT_SECONDS: '1500'
+          RESOLVE_INTERVAL_SECONDS: '30'
+        run: |-
+          set -euo pipefail
+          specifier="@qwen-code/qwen-code@${INPUT_VERSION#v}"
+          if [[ "${specifier}" == '@qwen-code/qwen-code@' ]]; then
+            specifier='@qwen-code/qwen-code@latest'
+          fi
+          # Per-attempt stderr is held back so ~50 identical 404 blocks do not
+          # bury the log; the last one is replayed when the wait gives up.
+          err_log="$(mktemp)"
+          deadline=$(( SECONDS + RESOLVE_TIMEOUT_SECONDS ))
+          while :; do
+            version="$(npm view "${specifier}" version 2>"${err_log}" | tail -n 1)" || true
+            if [[ -n "${version}" ]]; then
+              break
+            fi
+            if (( SECONDS >= deadline )); then
+              cat "${err_log}" >&2
+              echo "::error::No published qwen version matches '${INPUT_VERSION:-latest}' after ${RESOLVE_TIMEOUT_SECONDS}s."
+              exit 1
+            fi
+            echo "'${specifier}' is not on the registry yet; retrying in ${RESOLVE_INTERVAL_SECONDS}s."
+            sleep "${RESOLVE_INTERVAL_SECONDS}"
+          done
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved qwen version: ${version}"
+
   update:
     name: 'Update Qwen on ${{ matrix.runner }}'
+    needs: 'resolve'
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
     strategy:
       matrix:
@@ -31,27 +83,9 @@ jobs:
       cancel-in-progress: false
     timeout-minutes: 10
     steps:
-      - name: 'Resolve version'
-        id: 'version'
-        env:
-          INPUT_VERSION: '${{ inputs.version || github.event.client_payload.version }}'
-        run: |-
-          set -euo pipefail
-          specifier="@qwen-code/qwen-code@${INPUT_VERSION#v}"
-          if [[ "${specifier}" == '@qwen-code/qwen-code@' ]]; then
-            specifier='@qwen-code/qwen-code@latest'
-          fi
-          version="$(npm view "${specifier}" version | tail -n 1)" || true
-          if [[ -z "${version}" ]]; then
-            echo "::error::No published qwen version matches '${INPUT_VERSION:-latest}'."
-            exit 1
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "Resolved qwen version: ${version}"
-
       - name: 'Update qwen'
         env:
-          VERSION: '${{ steps.version.outputs.version }}'
+          VERSION: '${{ needs.resolve.outputs.version }}'
         run: |-
           set -euo pipefail
           # The runner service resolves the system-wide qwen binary. Do not
@@ -80,7 +114,7 @@ jobs:
 
       - name: 'Verify version'
         env:
-          VERSION: '${{ steps.version.outputs.version }}'
+          VERSION: '${{ needs.resolve.outputs.version }}'
         run: |-
           set -euo pipefail
           qwen_path="$(command -v qwen)"

--- a/scripts/tests/update-ecs-runner-qwen-workflow.test.js
+++ b/scripts/tests/update-ecs-runner-qwen-workflow.test.js
@@ -4,15 +4,93 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-describe('ECS runner qwen update workflow', () => {
-  const workflow = readFileSync(
-    '.github/workflows/update-ecs-runner-qwen.yml',
-    'utf8',
-  );
+const workflow = readFileSync(
+  '.github/workflows/update-ecs-runner-qwen.yml',
+  'utf8',
+);
 
+function step(name) {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = workflow.match(
+    new RegExp(
+      `\\n\\s+- name:\\s*(['"])${escaped}\\1[\\s\\S]*?(?=\\n\\s+- name:\\s*['"]|\\n\\s{2}[a-zA-Z0-9_-]+:|$)`,
+    ),
+  );
+  return match?.[0] ?? '';
+}
+
+// The body of a step's `run: |-` block, dedented to column zero.
+function stepBody(name) {
+  const body = step(name).match(/run: \|-\n([\s\S]*)$/)?.[1] ?? '';
+  return body.replace(/^ {10}/gm, '');
+}
+
+// Runs the 'Resolve version' step body against a stubbed `npm` that 404s for
+// its first `failures` invocations and then reports `version`.
+function runResolve({ failures = 0, version = '0.22.3', env = {} } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'ecs-update-'));
+  try {
+    const counter = join(dir, 'attempts');
+    const npmStub = join(dir, 'npm');
+    writeFileSync(
+      npmStub,
+      [
+        '#!/usr/bin/env bash',
+        `attempt=$(( $(cat ${counter} 2>/dev/null || echo 0) + 1 ))`,
+        `echo "$attempt" > ${counter}`,
+        `if (( attempt <= ${failures} )); then`,
+        '  echo "npm error code E404" >&2',
+        '  echo "npm error 404 No match found for version" >&2',
+        '  exit 1',
+        'fi',
+        `echo '${version}'`,
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+    chmodSync(npmStub, 0o755);
+
+    const script = join(dir, 'resolve.sh');
+    writeFileSync(script, stepBody('Resolve version'));
+    const ghOutput = join(dir, 'github-output');
+    writeFileSync(ghOutput, '');
+
+    const result = spawnSync('bash', [script], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH ?? ''}`,
+        GITHUB_OUTPUT: ghOutput,
+        INPUT_VERSION: '0.22.3',
+        RESOLVE_TIMEOUT_SECONDS: '60',
+        RESOLVE_INTERVAL_SECONDS: '0',
+        ...env,
+      },
+    });
+    return {
+      status: result.status,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+      output: readFileSync(ghOutput, 'utf8'),
+      attempts: Number(readFileSync(counter, 'utf8').trim()),
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('ECS runner qwen update workflow', () => {
   it('installs without the selected runner npm prefix', () => {
     expect(workflow).toContain('cd "${RUNNER_TEMP:?}"');
     expect(workflow).toContain('sudo env -u NPM_CONFIG_PREFIX npm install -g');
@@ -36,5 +114,59 @@ describe('ECS runner qwen update workflow', () => {
     expect(workflow).toContain('for attempt in 1 2 3; do');
     expect(workflow).toContain('if [[ "${attempt}" -lt 3 ]]; then');
     expect(workflow).toContain('sudo rm -rf "${PKG_DIR}"/.qwen-code-*');
+  });
+
+  it('resolves once on a hosted runner and feeds every pool', () => {
+    // One resolution shared by the matrix is what keeps pools that start
+    // hours apart from installing different versions; it also keeps the
+    // registry wait off the ECS runners.
+    expect(workflow).toContain("    runs-on: 'ubuntu-latest'");
+    expect(workflow).toContain(
+      "      version: '${{ steps.version.outputs.version }}'",
+    );
+    expect(workflow).toContain("    needs: 'resolve'");
+    // Both consumers read the job output; a leftover step reference would
+    // silently expand to an empty version and install `@qwen-code/qwen-code@`.
+    const consumers = workflow.match(
+      /VERSION: '\$\{\{ needs\.resolve\.outputs\.version \}\}'/g,
+    );
+    expect(consumers).toHaveLength(2);
+    expect(workflow).not.toContain(
+      "VERSION: '${{ steps.version.outputs.version }}'",
+    );
+  });
+
+  it('waits out npm publish propagation instead of failing the race', () => {
+    // `npm publish --provenance` returns before the version is resolvable
+    // (~16 minutes for v0.22.3), and release.yml dispatches this workflow as
+    // soon as it returns.
+    const resolved = runResolve({ failures: 3 });
+    expect(resolved.status).toBe(0);
+    expect(resolved.attempts).toBe(4);
+    expect(resolved.output.trim()).toBe('version=0.22.3');
+    expect(resolved.stdout).toContain('is not on the registry yet');
+    // The per-attempt 404 noise stays out of the log on the happy path.
+    expect(resolved.stderr).not.toContain('E404');
+  });
+
+  it('fails with the registry error once the wait budget is spent', () => {
+    const resolved = runResolve({
+      failures: 99,
+      env: { RESOLVE_TIMEOUT_SECONDS: '0' },
+    });
+    expect(resolved.status).toBe(1);
+    expect(resolved.output.trim()).toBe('');
+    // The suppressed stderr is replayed, so the log still says *why*.
+    expect(resolved.stderr).toContain('npm error code E404');
+    // The annotation stays on stdout, where Actions parses workflow commands.
+    expect(resolved.stdout).toContain(
+      "::error::No published qwen version matches '0.22.3' after 0s.",
+    );
+  });
+
+  it('resolves the latest dist-tag when dispatched without a version', () => {
+    const resolved = runResolve({ env: { INPUT_VERSION: '' } });
+    expect(resolved.status).toBe(0);
+    expect(resolved.output.trim()).toBe('version=0.22.3');
   });
 });


### PR DESCRIPTION
## Problem

`Update ECS Runner Qwen` is what keeps the system-wide `qwen` on the ECS runner pools current. On the v0.22.3 release it failed on 3 of its 4 pools, and nothing noticed.

Timeline from [release run 33188987718](https://github.com/QwenLM/qwen-code/actions/runs/33188987718) and [update run 33193932104](https://github.com/QwenLM/qwen-code/actions/runs/33193932104):

| time (UTC) | event |
| --- | --- |
| `17:14:16` | `npm publish --provenance` returns `+ @qwen-code/qwen-code@0.22.3`, together with `Your package is being processed and may take a few minutes to become available.` |
| `17:16:39` | `release.yml` dispatches `repository_dispatch: npm-published` with version `0.22.3` |
| `17:16:47` – `17:17:13` | `Resolve version` runs `npm view @qwen-code/qwen-code@0.22.3 version` on `ecs-update-sg`, `ecs-update-64c`, `ecs-update-hk-1` → `npm error 404 No match found for version 0.22.3`, no retry, `exit 1` |
| `17:30:35` | the version actually becomes resolvable on the registry |
| `20:06:17` | `ecs-update-hk-2` — queued behind ~3 hours of other work — finally starts, resolves `0.22.3` and installs it |

npm's publish pipeline is asynchronous, so `npm publish` returning is not the same as the version being resolvable; here the gap was ~16 minutes. The single un-retried `npm view` lost that race.

The consequence is silent and long-lived. `qwen-code-pr-review.yml` and `qwen-triage.yml` install the CLI only when it is absent:

```bash
if command -v qwen >/dev/null 2>&1; then
  qwen --version
  exit 0          # the `@latest` install below is never reached
fi
```

On a self-hosted runner `/usr/bin/qwen` always exists, so the three stale pools kept reviewing PRs with `0.22.2` for a full day while `hk-2` ran `0.22.3` — e.g. [this review job on `ecs-qwen-runner-sg-18`](https://github.com/QwenLM/qwen-code/actions/runs/33219148469/job/99010269695) printed `0.22.2` more than five hours after the release.

## Change

Split the workflow into a `resolve` job and the existing `update` matrix:

- `resolve` runs on `ubuntu-latest` and polls `npm view` every 30s for up to 25 minutes, instead of failing on the first 404. Per-attempt stderr is suppressed so ~50 identical 404 blocks do not bury the log, and the last one is replayed if the wait is exhausted.
- The matrix consumes `needs.resolve.outputs.version`.

Resolving once on a hosted runner rather than per-pool has two benefits beyond the retry: the registry wait does not occupy ECS runners that queue behind real review and triage work, and every pool installs the *same* version even when their jobs start hours apart — which is exactly the divergence that produced the split fleet here.

Behaviour that is deliberately unchanged: an empty dispatch input still resolves the `latest` dist-tag; the `npm install -g` retry loop, the `NPM_CONFIG_PREFIX` handling and the `Verify version` check are untouched.

## Testing

`scripts/tests/update-ecs-runner-qwen-workflow.test.js` gains behavioural coverage: the `Resolve version` step body is extracted from the YAML and executed under `bash` against a stubbed `npm` that 404s a configurable number of times.

- resolves after transient 404s, writes `GITHUB_OUTPUT`, keeps the 404 noise out of the log
- exits 1 with the `::error::` annotation on stdout and the registry's stderr replayed once the budget is spent
- still resolves the `latest` dist-tag with no input version
- the wiring guard asserts both `VERSION:` consumers read `needs.resolve.outputs.version` (a leftover `steps.version.outputs.version` would expand to empty and install `@qwen-code/qwen-code@`)

Negative control: reverting `.github/workflows/update-ecs-runner-qwen.yml` to `main` fails 3 of the 4 new tests, and the 4th (`latest` dist-tag) passes on both as a non-regression guard.

```
✓ installs without the selected runner npm prefix
✓ runs only when this workflow changes on main
✓ annotates a retry and a terminal failure distinctly
✓ resolves once on a hosted runner and feeds every pool
✓ waits out npm publish propagation instead of failing the race
✓ fails with the registry error once the wait budget is spent
✓ resolves the latest dist-tag when dispatched without a version

Tests  7 passed (7)
```

The fleet itself was repaired out-of-band by a manual `workflow_dispatch` of the workflow; `ecs-update-sg` is back on `0.22.3` and the remaining pools are queued.

## Follow-up (not in this PR)

This workflow's failures are not covered by `main-ci-failure-issue.yml`, so a broken fleet update produces no issue and no notification. Worth wiring up separately.

<details>
<summary>中文说明</summary>

## 问题

`Update ECS Runner Qwen` 负责把 ECS runner 池上系统级的 `qwen` 升级到最新版。v0.22.3 发布时，它 4 个池挂了 3 个，而且没有任何人收到通知。

时间线（来自 [release run 33188987718](https://github.com/QwenLM/qwen-code/actions/runs/33188987718) 与 [update run 33193932104](https://github.com/QwenLM/qwen-code/actions/runs/33193932104)）：

| 时间 (UTC) | 事件 |
| --- | --- |
| `17:14:16` | `npm publish --provenance` 返回 `+ @qwen-code/qwen-code@0.22.3`，同时打印 `Your package is being processed and may take a few minutes to become available.` |
| `17:16:39` | `release.yml` 发出 `repository_dispatch: npm-published`，版本 `0.22.3` |
| `17:16:47` – `17:17:13` | `Resolve version` 在 `ecs-update-sg`、`ecs-update-64c`、`ecs-update-hk-1` 上执行 `npm view @qwen-code/qwen-code@0.22.3 version` → `npm error 404 No match found for version 0.22.3`，没有重试，直接 `exit 1` |
| `17:30:35` | 该版本才真正在 registry 上可解析 |
| `20:06:17` | `ecs-update-hk-2` 排队约 3 小时后才启动，此时解析成功并装上了 `0.22.3` |

npm 的发布流水线是异步的，`npm publish` 返回 ≠ 版本可解析，这次间隔约 16 分钟。那一次没有重试的 `npm view` 正好输在这个竞态上。

后果是静默且持续的。`qwen-code-pr-review.yml` 和 `qwen-triage.yml` 都是「不存在才安装」：

```bash
if command -v qwen >/dev/null 2>&1; then
  qwen --version
  exit 0          # 下面的 `@latest` 安装永远走不到
fi
```

self-hosted runner 上 `/usr/bin/qwen` 一直在，所以那 3 个没升级的池整整一天都在用 `0.22.2` 评审 PR，而 `hk-2` 用的是 `0.22.3`——例如[这个跑在 `ecs-qwen-runner-sg-18` 上的评审 job](https://github.com/QwenLM/qwen-code/actions/runs/33219148469/job/99010269695)，在发版 5 个多小时之后打印的仍然是 `0.22.2`。

## 改动

把 workflow 拆成 `resolve` job 和原有的 `update` 矩阵：

- `resolve` 跑在 `ubuntu-latest` 上，每 30 秒轮询一次 `npm view`，最长等待 25 分钟，而不是第一次 404 就失败。逐次的 stderr 被暂存，避免约 50 个重复的 404 段落淹没日志；等待耗尽时再把最后一次回放出来。
- 矩阵改为消费 `needs.resolve.outputs.version`。

只解析一次（而不是每个池各解析一次）除了重试之外还有两个好处：等待 registry 的时间不再占用要排队跑真实评审/triage 任务的 ECS runner；并且即使各池的 job 相隔数小时才启动，装的也是**同一个**版本——而这正是本次 fleet 版本割裂的直接成因。

刻意保持不变的行为：dispatch 时不填版本仍然解析 `latest` dist-tag；`npm install -g` 的重试循环、`NPM_CONFIG_PREFIX` 处理和 `Verify version` 校验都没有动。

## 测试

`scripts/tests/update-ecs-runner-qwen-workflow.test.js` 增加了行为级覆盖：从 YAML 中提取 `Resolve version` 的 step body，在 `bash` 下针对一个可配置 404 次数的 `npm` 桩执行。

- 若干次瞬时 404 之后成功解析，写入 `GITHUB_OUTPUT`，并且 404 噪音不进日志
- 预算耗尽后以 1 退出，`::error::` 注解落在 stdout，registry 的 stderr 被回放一次
- 不传版本时仍能解析 `latest` dist-tag
- 接线守卫断言两处 `VERSION:` 都读 `needs.resolve.outputs.version`（残留的 `steps.version.outputs.version` 会展开成空串，导致去装 `@qwen-code/qwen-code@`）

反向对照：把 `.github/workflows/update-ecs-runner-qwen.yml` 还原成 `main` 的版本后，4 个新用例挂 3 个；第 4 个（`latest` dist-tag）两边都过，它本来就是防回归守卫。

fleet 本身已通过手动 `workflow_dispatch` 带外修复：`ecs-update-sg` 已回到 `0.22.3`，其余池在排队。

## 后续（不在本 PR 内）

这个 workflow 的失败不在 `main-ci-failure-issue.yml` 的覆盖范围内，所以 fleet 更新挂掉既不会开 issue 也不会有通知，值得另开一个 PR 接上。

</details>
