### PR TITLE
fix(channels): apply approval mode to non-webhook sessions

### DIFF
--- a/packages/cli/src/commands/channel/daemon-worker.test.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.test.ts
@@ -1323,10 +1323,18 @@ describe('runChannelDaemonWorker', () => {
       'thread',
     );
     expect(mockRouterSetChannelScope).toHaveBeenCalledWith('feishu', 'single');
-    expect(mockRouterSetChannelApprovalMode).not.toHaveBeenCalled();
+    expect(mockRouterSetChannelApprovalMode).toHaveBeenCalledTimes(2);
+    expect(mockRouterSetChannelApprovalMode).toHaveBeenCalledWith(
+      'telegram',
+      'yolo',
+    );
+    expect(mockRouterSetChannelApprovalMode).toHaveBeenCalledWith(
+      'feishu',
+      undefined,
+    );
   });
 
-  it('applies channel approval mode only for webhook-enabled channels', async () => {
+  it('applies channel approval mode to every configured channel', async () => {
     const sdk = createSdk();
     mockParseConfiguredChannels.mockResolvedValueOnce([
       {
@@ -1350,9 +1358,13 @@ describe('runChannelDaemonWorker', () => {
       loadDaemonSdk: async () => sdk,
     });
 
-    expect(mockRouterSetChannelApprovalMode).toHaveBeenCalledTimes(1);
+    expect(mockRouterSetChannelApprovalMode).toHaveBeenCalledTimes(2);
     expect(mockRouterSetChannelApprovalMode).toHaveBeenCalledWith(
       'telegram',
+      'yolo',
+    );
+    expect(mockRouterSetChannelApprovalMode).toHaveBeenCalledWith(
+      'feishu',
       'yolo',
     );
   });

--- a/packages/cli/src/commands/channel/daemon-worker.ts
+++ b/packages/cli/src/commands/channel/daemon-worker.ts
@@ -604,9 +604,7 @@ export async function runChannelDaemonWorker(
     for (const { name, config } of parsed) {
       createdRouter.setChannelScope(name, config.sessionScope);
       createdRouter.setChannelLoopsEnabled(name, !config.multiSession);
-      if (config['webhooks']) {
-        createdRouter.setChannelApprovalMode(name, config.approvalMode);
-      }
+      createdRouter.setChannelApprovalMode(name, config.approvalMode);
     }
     const restoredRoutes = createdRouter.restoreRoutes();
     writeStdoutLine(


### PR DESCRIPTION
## What this PR does

This PR applies each daemon-backed channel's configured approval mode when initializing session routing, whether or not that channel also enables webhooks. New and restored sessions therefore use the same explicit channel policy.

## Why it's needed

Channel configuration already accepts an approval mode for ordinary interactive channels, but the daemon worker previously registered it only for webhook-enabled channels. A non-webhook channel could silently fall back to the workspace default, producing unexpected prompts or a more permissive policy than configured.

## Reviewer Test Plan

### How to verify

Configure a non-webhook channel with an approval mode that differs from the workspace default. Start a new conversation and confirm the resulting session uses the channel mode, then restart the channel worker and confirm the restored session keeps that same mode. Also verify that a webhook-enabled channel still uses its configured unattended mode.

### Evidence (Before & After)

Before: the regression tests showed that non-webhook channels never registered an approval mode, while webhook-enabled channels did.

After: the worker test suite verifies that every configured channel registers its approval mode, including non-webhook channels and channels without an explicit override. The full worker test file passes 94/94 tests, and the existing session creation, restoration, and bridge propagation tests pass 3/3 focused tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS 14.4.1, Node.js 25.2.1. Verified with the focused unit tests, the complete daemon worker test file, the repository build, and the repository typecheck.

## Risk & Scope

- Main risk or tradeoff: Channels with an explicit approval mode now override a differing workspace default as originally configured.
- Not validated / out of scope: Live DingTalk delivery and credential-backed daemon E2E were not run; native permission-card presentation is tracked separately.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #10387

<details>
<summary>中文说明</summary>

## 此 PR 做了什么

此 PR 在初始化会话路由时应用每个 daemon Channel 配置的审批模式，无论该 Channel 是否同时启用了 webhook。因此，新建和恢复的会话都会使用同一个显式 Channel 策略。

## 为什么需要此修改

Channel 配置已经允许普通交互式 Channel 设置审批模式，但 daemon worker 之前只为启用了 webhook 的 Channel 注册该配置。非 webhook Channel 会静默回退到工作空间默认值，从而产生意外的审批提示，或者使用比配置更宽松的策略。

## 评审测试计划

### 如何验证

配置一个不含 webhook、且审批模式与工作空间默认值不同的 Channel。创建新会话并确认实际会话使用 Channel 模式，然后重启 Channel worker，确认恢复后的会话仍保持相同模式。同时验证启用了 webhook 的 Channel 仍使用其配置的无人值守模式。

### 证据（修改前与修改后）

修改前：回归测试表明非 webhook Channel 从不注册审批模式，而启用了 webhook 的 Channel 会注册。

修改后：worker 测试套件验证每个已配置 Channel 都会注册其审批模式，包括非 webhook Channel 和没有显式覆盖值的 Channel。完整 worker 测试文件 94/94 通过，既有的会话新建、恢复和 bridge 透传聚焦测试 3/3 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 14.4.1，Node.js 25.2.1。已通过聚焦单元测试、完整 daemon worker 测试文件、仓库构建和仓库类型检查验证。

## 风险与范围

- 主要风险或权衡：显式配置审批模式的 Channel 现在会按原始配置覆盖不同的工作空间默认值。
- 未验证或范围外：未执行真实钉钉投递和需要凭证的 daemon E2E；原生权限卡片展示由另一 Issue 跟踪。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Closes #10387

</details>
