### PR TITLE
fix(test): probe the native directory picker once at daemon spawn time

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -61,6 +61,12 @@ let homeDir = '';
 let port = 0;
 let base = '';
 let client: DaemonClient;
+// The daemon evaluates isNativeDirectoryPickerAvailable() in its own process
+// at boot. Probe once at spawn time (same host, same uid, same relevant env)
+// so the expectation matches the daemon's boot-time view; re-probing at
+// assertion time minutes later diverged when the host's GUI session state
+// drifted mid-run (red macOS E2E runs after #9406, tracked in #10453).
+let nativeDirectoryPickerAtBoot = false;
 
 function writePersistedTranscript(
   sessionId: string,
@@ -112,6 +118,7 @@ function chatRecord(
 
 beforeAll(async () => {
   homeDir = mkdtempSync(path.join(tmpdir(), 'qwen-serve-routes-home-'));
+  nativeDirectoryPickerAtBoot = isNativeDirectoryPickerAvailable();
   daemon = spawn(
     process.execPath,
     [
@@ -296,7 +303,8 @@ describe('qwen serve — capabilities envelope', () => {
     // `workspace_voice_transcription`, `rate_limit`, `channel_reload`.
     // `native_directory_picker` is host-conditional (the daemon host's GUI
     // environment, not a spawn flag) and is spliced at its registry
-    // position below.
+    // position below, using the boot-time probe captured when the daemon
+    // was spawned rather than a fresh probe at assertion time.
     // Pool tags (`mcp_workspace_pool`, `mcp_pool_restart`) ARE present
     // because the workspace MCP pool is on by default, as are
     // `workspace_settings`, `workspace_permissions`, `workspace_voice`,
@@ -414,9 +422,7 @@ describe('qwen serve — capabilities envelope', () => {
       'persistent_workspace_registration',
       'workspace_display_name',
       'workspace_runtime_removal',
-      ...(isNativeDirectoryPickerAvailable()
-        ? ['native_directory_picker']
-        : []),
+      ...(nativeDirectoryPickerAtBoot ? ['native_directory_picker'] : []),
       'workspace_qualified_rest_core',
       'extension_management_v2',
       'extension_git_credentials',


### PR DESCRIPTION
## What this PR does

The capabilities-envelope E2E in `qwen-serve-routes.test.ts` now captures `isNativeDirectoryPickerAvailable()` once at daemon spawn time and derives the expected `native_directory_picker` splice from that captured value, instead of re-running the probe at assertion time.

## Why it's needed

Since #9406, `native_directory_picker` is host-conditional: the daemon probes its own GUI session state at boot and advertises accordingly. The test side re-probed at assertion time, minutes later. When the host's GUI/console session state drifts mid-run, the two probes disagree and the exact-equality baseline assertion fails on `native_directory_picker`. That is exactly what happened on three consecutive main E2E runs after #9406 landed (commits c13aa351, 045ae1fc, 48ec0083; tracked in #10450 and #10453, with the autofix bisect pointing at #9406), always on `E2E Test - macOS - shard 2/2` where this test lives. The autofix agent stopped there because the Linux runner cannot reproduce the macOS lane. Probing at spawn time aligns the test's view with the daemon's boot-time view and removes the drift window.

## Reviewer Test Plan

### How to verify

Run `QWEN_SANDBOX=false npx vitest run --root ./integration-tests cli/qwen-serve-routes.test.ts`. All 37 tests pass regardless of whether the host advertises the picker: the expectation is derived from the same probe the daemon evaluates at boot (same host, same uid, same relevant env), so the two can no longer diverge over the course of the run.

### Evidence (Before & After)

Before: run 33228441400 (main 48ec0083), `E2E Test - macOS - shard 2/2` — `capabilities envelope > advertises all baseline capabilities` fails: expected 114 features, received 113, `native_directory_picker` missing. Same failure in runs 33223243993 and 33226533764. After: locally on Linux (host without GUI, probe false on both sides) the file passes 37/37; the macOS true branch is verified by the CI macOS lane.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  | ✅ 37/37 focused E2E |

### Environment (optional)

QWEN_SANDBOX=false vitest against the bundled CLI.

## Risk & Scope

- Main risk or tradeoff: the expectation reflects boot-time GUI state instead of assertion-time state; a console-state change during the run is no longer observable by this test — which is exactly the flake being removed.
- Not validated / out of scope: the macOS true branch is not verified locally; the CI macOS lane covers it.
- Breaking changes / migration notes: none; test-only change.

## Linked Issues

Fixes #10453. Same failure class as #10450.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

`qwen-serve-routes.test.ts` 的 capabilities envelope E2E 现在只在 daemon 启动时探测一次 `isNativeDirectoryPickerAvailable()`，并用这个捕获值决定期望列表中是否拼接 `native_directory_picker`，而不是在断言时再次探测。

## 为什么需要

自 #9406 起，`native_directory_picker` 按主机 GUI 会话状态动态判定：daemon 在启动时探测并据此决定是否广播。测试侧过去在断言时（数分钟后）重新探测。当主机的 GUI/console 会话状态在运行中途漂移时，两次探测结论不一致，严格相等的基线断言就会在 `native_directory_picker` 上失败。这正是 #9406 落地后连续三次 main E2E 运行（提交 c13aa351、045ae1fc、48ec0083，见 #10450 与 #10453，autofix 二分指向 #9406）的失败形态，且始终发生在该测试所在的 `E2E Test - macOS - shard 2/2`。autofix 代理因 Linux runner 无法复现 macOS 通道而停止。把探测提前到启动时刻，使测试与 daemon 的视角一致，消除漂移窗口。

## 评审测试计划

### 如何验证

运行 `QWEN_SANDBOX=false npx vitest run --root ./integration-tests cli/qwen-serve-routes.test.ts`。无论主机是否广播该能力，37 个测试全部通过：期望值取自 daemon 启动时评估的同一探测（同主机、同 uid、同相关环境），两侧不会再在运行过程中出现分歧。

### 证据（前后对比）

修复前：运行 33228441400（main 48ec0083），`E2E Test - macOS - shard 2/2`——`capabilities envelope > advertises all baseline capabilities` 失败：期望 114 项、实收 113 项，缺 `native_directory_picker`；运行 33223243993 与 33226533764 相同。修复后：本地 Linux（无 GUI 主机，两侧探测均为 false）该文件 37/37 通过；macOS 真分支由 CI macOS 通道验证。

### 测试环境

| 操作系统 | 状态 |
| :---: | :---: |
| 🍏 macOS | ⚠️ 未测 |
| 🪟 Windows | N/A |
| 🐧 Linux | ✅ 37/37 聚焦 E2E |

### 环境（可选）

QWEN_SANDBOX=false vitest，使用打包后的 CLI。

## 风险与范围

- 主要风险或取舍：期望值反映启动时刻的 GUI 状态而非断言时刻；运行期间的 console 状态变化不再被本测试观测——这恰是要消除的 flake。
- 未验证/超出范围：macOS 真分支未在本地验证，由 CI macOS 通道覆盖。
- 破坏性变更/迁移说明：无，纯测试改动。

## 关联 Issue

Fixes #10453。与 #10450 为同一失败形态。

</details>
