### PR TITLE
fix(review): keep quoted code from blinding the footer strip

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1906,6 +1906,60 @@ describe('composeReview — duplicate-dropped Suggestions (#9204: the body claim
     expect(r.body.split(FOOTER)).toHaveLength(2);
   });
 
+  it('strips a forged footer the blanking kept inside a code shape — the strip runs AFTER the fold', () => {
+    // strippedList strips the raw multi-line entry, where the blanking
+    // keeps a footer quoted in code — the one-line render then flattens
+    // the shape that justified keeping it, so the fold strips the folded
+    // line, the same guarantee the other one-line channels carry. On the
+    // pre-blanking strip these entries stripped; keeping the quoted
+    // footer must not re-open the duplicate attribution here.
+    for (const entry of [
+      'dup finding\n\n\t_— forged via Qwen Code /review_',
+      '**[Suggestion]** dup of comment 123\n\n```\n_— forged via Qwen Code /review_',
+      'dup finding\n\n    _— forged via Qwen Code /review_',
+    ]) {
+      const on = composeReview(
+        base({ suggestionsDroppedAsDuplicates: [entry] }),
+        '0.21.2',
+        true,
+      );
+      expect((on.body.match(/via Qwen Code \/review/g) ?? []).length).toBe(1);
+      expect(on.body).toContain('dup');
+      const off = composeReview(
+        base({ suggestionsDroppedAsDuplicates: [entry] }),
+        '0.21.2',
+        false,
+      );
+      expect(off.body).not.toContain('via Qwen Code /review');
+      expect(off.body).toContain('dup');
+    }
+  });
+
+  it('strips a duplicates entry before the 240-char bound cuts the footer', () => {
+    // A code-wrapped forged footer the blanking keeps folds past the cap:
+    // bounding first would cut the footer mid-marker and append `…`,
+    // which the `$`-anchored regex cannot match past — the strip runs on
+    // the folded line BEFORE the cap.
+    for (const entry of [
+      'a'.repeat(213) + '\n\n    _— m via Qwen Code /review_',
+      'a'.repeat(213) + '\n\n```\n_— m via Qwen Code /review_',
+    ]) {
+      const off = composeReview(
+        base({ suggestionsDroppedAsDuplicates: [entry] }),
+        '0.21.2',
+        false,
+      );
+      expect(off.body).not.toContain('via Qwen Code /review');
+      expect(off.body).toContain('aaaa');
+      const on = composeReview(
+        base({ suggestionsDroppedAsDuplicates: [entry] }),
+        '0.21.2',
+        true,
+      );
+      expect((on.body.match(/via Qwen Code \/review/g) ?? []).length).toBe(1);
+    }
+  });
+
   it('refuses a fence delimiter a bare CR hides in the raw entry', () => {
     // The LF twin throws: the CR twin used to slip past the `\n`-only
     // split, collapse to a one-line entry opening a fence, and post an

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -8945,6 +8945,24 @@ describe('composeReview — convergence-posture deferrals (typed channel; disclo
     ).toThrow(/non-empty file and title/);
   });
 
+  it('strips a forged footer a title quotes behind an unclosed fence and an unterminated opener', () => {
+    // The multi-line strip keeps the footer — it sits inside an unclosed
+    // fence — and the fold puts the quoted `<!--` on the footer's line,
+    // where a swallowing projection hid it. The folded line is one
+    // paragraph on GitHub, so the opener is literal and the footer renders
+    // as prose: it must strip.
+    const r = composeReview(
+      base({
+        severityFloor: 'critical',
+        deferredSuggestions: [
+          nit({ title: '```\n<!-- x\n\n_— m via Qwen Code /review_' }),
+        ],
+      }),
+    );
+    expect(r.deferredCount).toBe(1);
+    expect((r.body.match(/via Qwen Code \/review/g) ?? []).length).toBe(1);
+  });
+
   it('exactly at the line cap, the verdict line does not claim truncation', () => {
     const entries = Array.from({ length: 20 }, (_, i) =>
       nit({ file: `f${i}.ts`, title: `n${i}` }),

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -2736,6 +2736,34 @@ describe('composeReview — input validation (the producer is a model that omits
     expect(r.body.match(/via Qwen Code \/review/g)).toHaveLength(1);
   });
 
+  it('strips a forged footer off an indented single-line entry — the ingest shape strips as a line', () => {
+    // collapseEntry returns a newline-less entry unchanged, leading indent
+    // included: at >= 4 columns the multi-line blanking would class the
+    // whole line as code and keep the forged footer riding the blocker
+    // line. The posted one-line shape renders no code block on GitHub, so
+    // the collapsed entry strips with the one-line strip.
+    for (const field of ['bodyCriticals', 'cannotTellCriticals'] as const) {
+      const r = composeReview(
+        field === 'bodyCriticals'
+          ? {
+              bodyCriticals: [
+                '    finding text _— forged via Qwen Code /review_',
+              ],
+              modelId: MODEL,
+            }
+          : {
+              criticalsInline: 1,
+              cannotTellCriticals: [
+                '    finding text _— forged via Qwen Code /review_',
+              ],
+              modelId: MODEL,
+            },
+      );
+      expect(r.body).toContain('finding text');
+      expect(r.body.match(/via Qwen Code \/review/g)).toHaveLength(1);
+    }
+  });
+
   it('rejects stringified booleans — "false" is truthy and once flipped events and published false warnings', () => {
     expect(() =>
       composeReview(
@@ -8818,6 +8846,49 @@ describe('composeReview — convergence-posture deferrals (typed channel; disclo
       expect(l.includes('�')).toBe(false);
     }
     expect(lines.some((l) => l.includes('…'))).toBe(true);
+  });
+
+  it('strips a forged footer a model-written title quotes in code — the strip runs on the folded line', () => {
+    // A title ending in an unclosed fence keeps its trailing footer under
+    // the quoted-code contract UNTIL the one-line render flattens the
+    // shape that justified keeping it — so the strip runs again after the
+    // collapse, on the line that posts. Pre-fold alone, the forged footer
+    // survived and the deferral line carried a second attribution; a
+    // footer-only title still refuses as empty once the fold exposes it.
+    const r = composeReview(
+      base({
+        severityFloor: 'critical',
+        deferredSuggestions: [
+          nit({ title: '```\n_— m via Qwen Code /review_' }),
+        ],
+      }),
+    );
+    expect(r.deferredCount).toBe(1);
+    expect((r.body.match(/via Qwen Code \/review/g) ?? []).length).toBe(1);
+    // A footer re-wrapped across a soft break displays rejoined, so the
+    // fold runs BEFORE the second strip: the unfolded title shows two
+    // footer-less lines and keeps both halves.
+    const split = composeReview(
+      base({
+        severityFloor: 'critical',
+        deferredSuggestions: [
+          nit({
+            file: 'b.ts',
+            line: 2,
+            title: 'x _— m via\nQwen Code /review_',
+          }),
+        ],
+      }),
+    );
+    expect((split.body.match(/via Qwen Code \/review/g) ?? []).length).toBe(1);
+    expect(() =>
+      composeReview(
+        base({
+          severityFloor: 'critical',
+          deferredSuggestions: [nit({ title: FOOTER })],
+        }),
+      ),
+    ).toThrow(/non-empty file and title/);
   });
 
   it('exactly at the line cap, the verdict line does not claim truncation', () => {
@@ -17417,6 +17488,31 @@ describe('floor enforcement — the Critical arm (#10291)', () => {
         'R6-1: sparse checkout wedges the round Only a sparse clone reaches it.',
     });
     expect(entries[1].severity).toBe('Suggestion');
+  });
+
+  it('floorEnforcedReroute strips the shape that posts — the fold flattens a kept-in-code footer', () => {
+    // A drafted Suggestion whose body ends in an unclosed fence keeps its
+    // trailing footer under the quoted-code contract, but the one-line
+    // collapse destroys the code shape — the record strips again AFTER
+    // the fold, or the folded title carries the forged attribution.
+    const { entries } = floorEnforcedReroute('critical', false, 0, [
+      {
+        path: 'a.ts',
+        line: 12,
+        body: '**[Suggestion]** tidy\n\n```\n_— m via Qwen Code /review_',
+      },
+      {
+        path: 'b.ts',
+        line: 13,
+        body: '**[Suggestion]** tidy\n\n_— m via\nQwen Code /review_',
+      },
+    ]);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].title).toBe('tidy ```');
+    expect(entries[1].title).toBe('tidy');
+    for (const e of entries) {
+      expect(e.title).not.toContain('via Qwen Code /review');
+    }
   });
 
   it('deferrableFindingsInline counts the tagged Critical the floor would move — and only that one', () => {

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -730,18 +730,26 @@ function collapseToLine(text: string): string {
 
 /**
  * The per-entry bound the deferred, relocated, duplicate-dropped, AND
- * cannot-tell exits apply: collapse line endings, cap at
- * MAX_DEFERRED_SUGGESTION_CHARS
- * without splitting a surrogate pair, mark a trim with an ellipsis. The
- * relocation exit once bypassed all of it (round-9 finding): twenty-five
- * relocated 4,000-char titles spliced ~100 KB of unbounded model text into
- * the body — the whole review lost at GitHub's 65,536 limit, precisely what
- * the cap on the deferred exit was added to prevent. The free-form
- * bodyCriticals exit is the exception: its entries are the review's only
- * copy of their Criticals, quoted as-is and left unbounded.
+ * cannot-tell exits apply: collapse line endings, strip a trailing footer
+ * the collapse exposed, cap at MAX_DEFERRED_SUGGESTION_CHARS without
+ * splitting a surrogate pair, mark a trim with an ellipsis. The relocation
+ * exit once bypassed all of it (round-9 finding): twenty-five relocated
+ * 4,000-char titles spliced ~100 KB of unbounded model text into the body
+ * — the whole review lost at GitHub's 65,536 limit, precisely what the cap
+ * on the deferred exit was added to prevent. The free-form bodyCriticals
+ * exit is the exception: its entries are the review's only copy of their
+ * Criticals, quoted as-is and left unbounded.
+ *
+ * The footer strip is the folded line's OWN guarantee, applied here so no
+ * exit can reach the fold without it: the multi-line strip keeps a footer
+ * that sits in quoted code, and the collapse flattens that code shape into
+ * a posted line — the duplicates entries reach this fold through
+ * `quotedProse` alone, with no ingest-time line strip ahead of them. It
+ * runs BEFORE the cap, whose ellipsis would break the `$`-anchored match
+ * when the cut lands inside the footer.
  */
 function boundDeferredLine(rendered: string): string {
-  const collapsed = collapseToLine(rendered);
+  const collapsed = stripReviewFooterLine(collapseToLine(rendered));
   let oneLine = collapsed.slice(0, MAX_DEFERRED_SUGGESTION_CHARS);
   // The cap slices UTF-16 code units; a cut landing inside a surrogate pair
   // leaves a lone high surrogate that serializes as U+FFFD into the posted

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -136,6 +136,7 @@ import {
   stripFooterSpans,
   stripForUnattributedPost,
   stripReviewFooter,
+  stripReviewFooterLine,
 } from './lib/review-footer.js';
 import { operatorReviewSettings } from './lib/review-settings.js';
 import { recordedSeverityFloor } from './lib/authorization.js';
@@ -776,9 +777,16 @@ function toDeferredEntries(value: unknown): DeferredEntry[] {
     }
     const o = raw as Record<string, unknown>;
     const file = typeof o['file'] === 'string' ? o['file'].trim() : '';
+    // Strip again AFTER the fold: the one-line render flattens a footer
+    // the strip kept as quoted code (an unclosed fence, an indented block)
+    // into a single line, destroying the shape that justified keeping it
+    // — a trailing footer is still trailing once collapsed, so the folded
+    // line is the shape to strip.
     const title =
       typeof o['title'] === 'string'
-        ? stripReviewFooter(o['title']).trim()
+        ? stripReviewFooterLine(
+            collapseToLine(stripReviewFooter(o['title'])),
+          ).trim()
         : '';
     const source = o['source'];
     const severity = o['severity'];
@@ -1156,8 +1164,12 @@ export function floorEnforcedReroute(
     const record = critical
       ? readClaimHead(first).stripped.replace(head.sourceText ?? '', '')
       : first;
-    const title = collapseToLine(
-      stripReviewFooter(record + (nl === -1 ? '' : stripped.slice(nl))),
+    // Strip again AFTER the fold — the collapsed line is the shape that
+    // posts, for the reason toDeferredEntries states.
+    const title = stripReviewFooterLine(
+      collapseToLine(
+        stripReviewFooter(record + (nl === -1 ? '' : stripped.slice(nl))),
+      ),
     );
     indices.push(i);
     entries.push({
@@ -3392,8 +3404,10 @@ function ingestEntryList(value: unknown, field: string): string[] {
   }
   // No emptiness filter: an entry that normalizes to nothing must reach
   // the renders-nothing gates and fail the draft, not vanish — see the
-  // invariant at the gates below.
-  return raw.map(collapseEntry).map(stripReviewFooter);
+  // invariant at the gates below. The collapsed entry is ONE line the
+  // channel posts as-is, so it strips as a line: an indented entry is not
+  // the code block the multi-line strip would keep a footer inside.
+  return raw.map(collapseEntry).map(stripReviewFooterLine);
 }
 
 /**

--- a/packages/cli/src/commands/review/lib/review-footer.test.ts
+++ b/packages/cli/src/commands/review/lib/review-footer.test.ts
@@ -393,6 +393,35 @@ describe('the review footer and the regex that strips it', () => {
       ).toBe('a finding\r\r    code');
     });
 
+    it('a comment splitting the marker phrase is seen through — the `<` gate admits it', () => {
+      // The projection drops a closed comment whole, so the halves of the
+      // phrase display rejoined; the body carries neither a literal
+      // `/review` nor an `&`, and only the `<` arm of the gate lets it
+      // reach the projection at all.
+      expect(
+        stripReviewFooter('finding\n\n_— m via Qwen Code /<!-- x -->review_'),
+      ).toBe('finding');
+      expect(
+        stripReviewFooter('finding\n\n_— m via Qwen Code /rev<!-- x -->iew_'),
+      ).toBe('finding');
+    });
+
+    it('the block-only parse stays cheap on a hostile one-line body', () => {
+      // The blanking parses the WHOLE body (a fence's state is only
+      // knowable from where it opened), so the parse must stay block-only:
+      // with markdown-it's inline pass on, a 256 KiB run of `[` measured
+      // ~400 ms against ~1 ms with it off. The bound is the property under
+      // test — an output assertion alone cannot see the guard.
+      const run = '['.repeat(4 * 65536);
+      const start = performance.now();
+      expect(stripReviewFooter(`${run}\n\n_— m via Qwen Code /review_`)).toBe(
+        run,
+      );
+      expectWithinLatencyBudget(performance.now() - start, 40, {
+        poolMultiplier: 5,
+      });
+    });
+
     it('a refusing run of truncated footers stays linear — no partition enumeration', () => {
       // The optional closing paren must not leave the version content
       // unbounded: with an unrestricted run, each truncated footer's
@@ -417,6 +446,35 @@ describe('the review footer and the regex that strips it', () => {
   });
 
   describe("stripReviewFooterLine — the one-line channels' shape", () => {
+    it('an unterminated comment opener on the folded line is literal text, not a swallow', () => {
+      // A folded line is one paragraph with no later line for a closer to
+      // sit on, so CommonMark's inline HTML rule never fires: GitHub escapes
+      // the opener and renders the forged footer after it as prose. The
+      // fold puts a witness block's quoted `<!--` on the footer's own line
+      // — the trigger this strip exists for, arriving through the one-line
+      // channels. A `~~~` or unclosed fence and an indented block fold to
+      // this shape; a ``` run does not, because the projection masks it as
+      // a code span.
+      expect(
+        stripReviewFooterLine('x ~~~ <!-- x ~~~ _— m via Qwen Code /review_'),
+      ).toBe('x ~~~ <!-- x ~~~');
+      expect(
+        stripReviewFooterLine('x <!-- x _— m via Qwen Code /review_'),
+      ).toBe('x <!-- x');
+      // A closed comment still drops whole: a footer after it strips, one
+      // inside it is invisible either way.
+      expect(
+        stripReviewFooterLine('x <!-- hidden --> _— m via Qwen Code /review_'),
+      ).toBe('x');
+      const hidden = 'x <!-- _— m via Qwen Code /review_ -->';
+      expect(stripReviewFooterLine(hidden)).toBe(hidden);
+      // The multi-line strip keeps the aggressive reading: a line-leading
+      // opener opens a comment block running to the end of the input, and
+      // the footer inside it renders as nothing.
+      const swallowed = 'x\n<!-- y\n_— m via Qwen Code /review_';
+      expect(stripReviewFooter(swallowed)).toBe(swallowed);
+    });
+
     it('strips a trailing footer a folded line carries — a single line is no block quotation', () => {
       // The one-line channels (folded deferral titles, reroute records,
       // relocated claims, ingested entries) flatten every code shape

--- a/packages/cli/src/commands/review/lib/review-footer.test.ts
+++ b/packages/cli/src/commands/review/lib/review-footer.test.ts
@@ -21,6 +21,7 @@ import {
   stripForgedFooterLines,
   stripParagraphMarkers,
   stripReviewFooter,
+  stripReviewFooterLine,
   swallowsAppendedMarker,
 } from './review-footer.js';
 import { CANONICAL_LGTM_RE } from '../pr-context.js';
@@ -199,6 +200,199 @@ describe('the review footer and the regex that strips it', () => {
       );
     });
 
+    it('an unterminated comment opener quoted in code does not blind the strip', () => {
+      // A witness block quoting an HTML marker cut short — what a review of
+      // a dedup marker posts — leaves a `<!--` with no `-->` in the body.
+      // Projected, that opener runs to the END of the input and takes the
+      // trailing footer with it, so the strip saw no footer, left the
+      // model's own, and the canonical one posted beside it as a second
+      // attribution line. Inside a fence the opener is literal text on
+      // GitHub and both footers render.
+      const witness = 'Witness:\n```\njq: error … ("<!-- ecs-f…") cannot\n```';
+      expect(
+        stripReviewFooter(`${witness}\n\n_— m via Qwen Code /review_`),
+      ).toBe(witness);
+    });
+
+    it('a footer inside code is a quotation, not a trailing footer', () => {
+      // The same blanking, in the direction the other strips already take:
+      // code content is a quotation, so a footer inside an unclosed fence
+      // or an indented block is not the attribution this strip removes.
+      for (const quoted of [
+        '```\n_— m via Qwen Code /review (v1)_',
+        'a finding\n\n    _— m via Qwen Code /review (v1)_',
+      ]) {
+        expect(stripReviewFooter(quoted)).toBe(quoted);
+      }
+    });
+
+    it('an unterminated opener in a fence info string does not blind the strip', () => {
+      // GitHub renders neither the fence delimiters nor an opener's info
+      // string, so the delimiters blank with the content: a `<!--` lodged
+      // in the info string would otherwise stay in the projection, run to
+      // the end of the input, and hide the trailing footer.
+      expect(
+        stripReviewFooter(
+          '```js <!--\ncode\n```\n\n_— m via Qwen Code /review_',
+        ),
+      ).toBe('```js <!--\ncode\n```');
+      expect(
+        stripReviewFooter(
+          '~~~js <!--\ncode\n~~~\n\n_— m via Qwen Code /review_',
+        ),
+      ).toBe('~~~js <!--\ncode\n~~~');
+    });
+
+    it('classifies code versus prose with a CommonMark parser, not a hand model', () => {
+      // An indented code block cannot interrupt a paragraph, so a 4-space
+      // line right after a paragraph line is a lazy continuation GitHub
+      // renders visibly; inside a list item the code threshold sits at the
+      // item's content indent; a leading tab is the 4-column stop and IS
+      // code. A hand-built scan read the first two as code (blanking them
+      // kept the forged footer) and the tab as prose (an unterminated
+      // `<!--` quoted in it then blinded the strip).
+      expect(
+        stripReviewFooter('a finding\n    _— m via Qwen Code /review_'),
+      ).toBe('a finding');
+      expect(stripReviewFooter('- item\n    _— m via Qwen Code /review_')).toBe(
+        '- item',
+      );
+      expect(
+        stripReviewFooter('1. finding\n\n    _— m via Qwen Code /review (v1)_'),
+      ).toBe('1. finding');
+      expect(
+        stripReviewFooter('> finding\n    _— m via Qwen Code /review_'),
+      ).toBe('> finding');
+      expect(
+        stripReviewFooter('-   item\n\n      _— m via Qwen Code /review_'),
+      ).toBe('-   item');
+      expect(
+        stripReviewFooter(
+          '- item\n\n  > quoted\n\n    _— m via Qwen Code /review_',
+        ),
+      ).toBe('- item\n\n  > quoted');
+      expect(
+        stripReviewFooter('para\n- item\n\n _— m via Qwen Code /review_'),
+      ).toBe('para\n- item');
+      expect(
+        stripReviewFooter('finding\n===\n\n_— m via Qwen Code /review_'),
+      ).toBe('finding\n===');
+      expect(
+        stripReviewFooter(
+          '- x\n ```\n code\n ```\n\n_— m via Qwen Code /review_',
+        ),
+      ).toBe('- x\n ```\n code\n ```');
+      const tabQuoted = 'a finding\n\n\t_— m via Qwen Code /review_';
+      expect(stripReviewFooter(tabQuoted)).toBe(tabQuoted);
+      expect(
+        stripReviewFooter('a finding\n\n\t<!--\n\n_— m via Qwen Code /review_'),
+      ).toBe('a finding\n\n\t<!--');
+      // A >= 4-column `<div>` line is indented code, not an HTML block.
+      expect(
+        stripReviewFooter(
+          'x\n\n    <div>\n    <!-- y\n\n_— m via Qwen Code /review_',
+        ),
+      ).toBe('x\n\n    <div>\n    <!-- y');
+    });
+
+    it('pins the keep side of the classifier — breaks, headings, and the list code threshold', () => {
+      // A heading or thematic break interrupts a paragraph, so a 4-space
+      // footer line after one is an indented code block the strip keeps,
+      // and inside a list item the code threshold rises by the item's
+      // content indent. Unpinned, a dropped check would silently delete
+      // footer lines GitHub renders as code.
+      const keep = (body: string): void => {
+        expect(stripReviewFooter(body)).toBe(body);
+      };
+      keep('a finding\n---\n    _— m via Qwen Code /review_');
+      keep('# h\n    _— m via Qwen Code /review_');
+      keep('a finding\n## h\n    _— m via Qwen Code /review_');
+      keep('- item\n\n        _— m via Qwen Code /review_');
+      keep('- item\n# h\n\n    _— m via Qwen Code /review (v1)_');
+    });
+
+    it('a comment closer quoted in a raw-HTML block still closes the projected comment', () => {
+      // The dual of the hole the blanking fixes: a line-leading `<!--`
+      // opens a CommonMark comment block that runs to the line holding
+      // `-->` — a fence delimiter inside it is block content, not a fence.
+      // The parser sees that; a hand scan read the delimiter as opening a
+      // fence, blanked the closer line, and the opener then ran to the end
+      // of the input and kept the real trailing footer. The PI and CDATA
+      // twins hold their lines the same way, and the comment renders
+      // nothing, so the cut may span it.
+      expect(
+        stripReviewFooter('<!--\n```\n-->\n\n_— m via Qwen Code /review_'),
+      ).toBe('<!--\n```\n-->');
+      expect(
+        stripReviewFooter('<!--\n    -->\n\n_— m via Qwen Code /review_'),
+      ).toBe('<!--\n    -->');
+      expect(
+        stripReviewFooter('<!--\n```x -->\n_— m via Qwen Code /review_'),
+      ).toBe('<!--\n```x -->');
+      expect(
+        stripReviewFooter('<?\n```x ?>\n_— m via Qwen Code /review_'),
+      ).toBe('<?\n```x ?>');
+      expect(
+        stripReviewFooter('<![CDATA[\n```x ]]>\n_— m via Qwen Code /review_'),
+      ).toBe('<![CDATA[\n```x ]]>');
+      expect(
+        stripReviewFooter(
+          '[Suggestion] tidy\n<!--\n```x -->\n_— forged via Qwen Code /review_',
+        ),
+      ).toBe('[Suggestion] tidy');
+    });
+
+    it('a dangling opener after the trailing footer does not break the anchor', () => {
+      // A looping model truncates a forged footer mid-character and a
+      // dangling `<!--` can ride the footer's own line or a later one. The
+      // projection swallows an unclosed opener to the end of the input, so
+      // nothing visible follows the footer and the `$` anchor holds — the
+      // attribution-off anywhere strip reads the same projection.
+      expect(stripReviewFooter('x\n\n_— m via Qwen Code /review_ <!--')).toBe(
+        'x',
+      );
+      expect(stripReviewFooter('x\n\n_— m via Qwen Code /review_\n<!--')).toBe(
+        'x',
+      );
+      expect(stripForgedFooterLines('_— m via Qwen Code /review_ <!--')).toBe(
+        '',
+      );
+    });
+
+    it('blanks from the body start, not the tail — a fence straddling the tail bound keeps its state', () => {
+      // The blanking scans from the body's START: a fence opened before
+      // the STRIP_TAIL_LIMIT tail window keeps its state across the
+      // boundary. A tail-only scan would read the quoted code as ordinary
+      // text and the unblanked opener would swallow the trailing footer —
+      // the fixture must exceed the bound with the fence opening ahead of
+      // it and the comment's opener inside it.
+      const fillerA = 'a'.repeat(4000);
+      const fillerB = 'b'.repeat(4500);
+      const quoted =
+        'W:\n```\n' + fillerA + '\n<!--\n' + fillerB + '\n-->\n```';
+      const body = quoted + '\n\n_— m via Qwen Code /review_';
+      expect(body.length).toBeGreaterThan(8192);
+      expect(stripReviewFooter(body)).toBe(quoted);
+    });
+
+    it('keeps CRLF and bare-CR endings byte-identical when it strips', () => {
+      // The blanking reattaches each line's own ending and the cut slices
+      // the ORIGINAL bytes — unlike the sibling strips, which normalize
+      // CRLF to LF on the rejoin. Both a fenced and an indented quotation
+      // must survive the blanking's length arithmetic under CRLF and bare
+      // CR alike.
+      expect(
+        stripReviewFooter(
+          'a finding\r\n\r\n```\r\ncode\r\n```\r\n\r\n_— m via Qwen Code /review_',
+        ),
+      ).toBe('a finding\r\n\r\n```\r\ncode\r\n```');
+      expect(
+        stripReviewFooter(
+          'a finding\r\r    code\r\r_— m via Qwen Code /review_',
+        ),
+      ).toBe('a finding\r\r    code');
+    });
+
     it('a refusing run of truncated footers stays linear — no partition enumeration', () => {
       // The optional closing paren must not leave the version content
       // unbounded: with an unrestricted run, each truncated footer's
@@ -222,7 +416,56 @@ describe('the review footer and the regex that strips it', () => {
     }, 20_000);
   });
 
+  describe("stripReviewFooterLine — the one-line channels' shape", () => {
+    it('strips a trailing footer a folded line carries — a single line is no block quotation', () => {
+      // The one-line channels (folded deferral titles, reroute records,
+      // relocated claims, ingested entries) flatten every code shape
+      // before they post, so the blanking the multi-line strip applies
+      // cannot keep a footer here: a fence delimiter leading the line is
+      // posted text, and the forged attribution must not ride it.
+      expect(
+        stripReviewFooterLine('tidy ``` _— m via Qwen Code /review_'),
+      ).toBe('tidy ```');
+      expect(stripReviewFooterLine('``` _— m via Qwen Code /review_')).toBe(
+        '```',
+      );
+      expect(
+        stripReviewFooterLine('    finding _— m via Qwen Code /review_'),
+      ).toBe('    finding');
+    });
+
+    it('keeps a footer an inline code span quotes on the line', () => {
+      // Inline code renders visibly — the projection masks it, so a
+      // quoted footer stays while a forged one outside the span strips.
+      const quoted = 'see `_— m via Qwen Code /review_` quoted above';
+      expect(stripReviewFooterLine(quoted)).toBe(quoted);
+      expect(
+        stripReviewFooterLine('x `code` _— m via Qwen Code /review_'),
+      ).toBe('x `code`');
+    });
+  });
+
   describe('stripForgedFooterLines — the attribution-off anywhere strip', () => {
+    it('classifies through the CommonMark parser like the trailing strip', () => {
+      // The line-aware strips read the same token map as the blanking: a
+      // fence inside an open list item measures its indent against the
+      // item's content indent (the quoted footer stays), a setext
+      // underline ends the paragraph (the 4-space line after it is a code
+      // block the strip keeps), and the item's content indent is the
+      // ACTUAL whitespace after the marker — two tabs past a 5-column
+      // indent is item prose, not code.
+      const fenceInList =
+        '- item\n\n    ```\n    _— m via Qwen Code /review_\n    ```\n\nmore';
+      expect(stripForUnattributedPost(fenceInList)).toBe(fenceInList);
+      const setext = 'para\n===\n    _— m via Qwen Code /review_';
+      expect(stripForUnattributedPost(setext)).toBe(setext);
+      expect(
+        stripForUnattributedPost(
+          '-    para\n\n\t\t_— m via Qwen Code /review_',
+        ),
+      ).toBe('-    para');
+    });
+
     it('strips a forged footer on the very first line', () => {
       expect(
         stripForgedFooterLines(
@@ -553,6 +796,20 @@ describe('the review footer and the regex that strips it', () => {
       );
       expect(swallowsAppendedMarker('plain claim')).toBe(false);
       expect(swallowsAppendedMarker('')).toBe(false);
+      // A comment/PI/declaration/CDATA block left open swallows the
+      // appended marker to NOTHING — the exposure this gate refuses is a
+      // marker that renders VISIBLE, so only the tag-based blocks (the
+      // <pre> control above) count.
+      expect(swallowsAppendedMarker('**[Critical]** x\n\n<!-- note')).toBe(
+        false,
+      );
+      expect(swallowsAppendedMarker('**[Critical]** x\n\n<? note')).toBe(false);
+      expect(swallowsAppendedMarker('**[Critical]** x\n\n<!DOCTYPE x')).toBe(
+        false,
+      );
+      expect(swallowsAppendedMarker('**[Critical]** x\n\n<![CDATA[ note')).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/cli/src/commands/review/lib/review-footer.ts
+++ b/packages/cli/src/commands/review/lib/review-footer.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import MarkdownIt from 'markdown-it';
+
 import { stripSeverityPrefix } from './inline-counts.js';
 
 // The attribution footer every posted review carries, stated once.
@@ -432,51 +434,122 @@ const STRIP_TAIL_LIMIT = 8192;
  * the marker phrase cannot hide a trailing forged footer (or forge one:
  * the cut maps back to the original bytes) — and the projection of a
  * marker-less tail returns the body byte-identical without the regex.
+ * Quoted code is blanked out of the projection first, for the reason
+ * `blankQuotedCode` states; a body that cannot project the marker at all
+ * returns before paying for that structural scan.
  */
 export function stripReviewFooter(body: string): string {
-  const tail = body.slice(-STRIP_TAIL_LIMIT);
+  if (!canProjectFooterMarker(body)) return body;
+  return stripTrailingFooter(body, blankQuotedCode(body));
+}
+
+/**
+ * The trailing strip for ONE folded line — the shape the one-line channels
+ * post: `compose-review`'s collapsed deferral titles, reroute records and
+ * ingested entries, and `submit`'s relocated claim. A folded line carries
+ * no block structure — the collapse flattened it — so a footer on it is
+ * never the quotation `stripReviewFooter`'s blanking keeps: a fence
+ * delimiter leading the line is posted text, not a code edge, and must
+ * not blind the strip.
+ */
+export function stripReviewFooterLine(line: string): string {
+  return stripTrailingFooter(line, line);
+}
+
+/**
+ * Whether the string can project the footer marker at all: the projection
+ * assembles it only out of literal characters, entity decodes (which need
+ * a literal `&`), or a dropped comment joining the halves a literal `<`
+ * sits between. `/review`, not FOOTER_MARKER: re-wrapping can split the
+ * phrase across a soft break, and only `/review` survives every split
+ * point short of the word itself.
+ */
+function canProjectFooterMarker(s: string): boolean {
+  return s.includes('/review') || s.includes('&') || s.includes('<');
+}
+
+/**
+ * The strip proper. `scanned` is `body` with its quoted code blanked — or
+ * `body` itself — and the SAME length, so an index into the projection of
+ * its tail is an index into the original bytes the cut slices.
+ */
+function stripTrailingFooter(body: string, scanned: string): string {
+  const tail = scanned.slice(-STRIP_TAIL_LIMIT);
   const proj = projectInvisibles(tail);
   if (!proj.text.includes(FOOTER_MARKER)) return body;
   const m = REVIEW_FOOTER_RE.exec(proj.text);
   if (m === null) return body;
   const keep = proj.starts[m.index];
-  return body.slice(0, body.length - tail.length) + tail.slice(0, keep);
+  return body.slice(0, body.length - tail.length + keep);
 }
+
+/**
+ * The body's code lines blanked to same-length NULs — fenced and indented
+ * code, fence delimiters included — in the one shape a trailing-anchored
+ * strip can use: blanking is length-preserving, so the projection's index
+ * map still points into the original bytes.
+ *
+ * Code content is a quotation. GitHub renders it literally, so it can
+ * neither BE attribution nor hide any: unblanked, a `<!--` with no `-->`
+ * quoted in a witness block (a review of an HTML marker quotes exactly
+ * that) projects as a comment running to the END of the input and takes
+ * the real trailing footer out of the projection with it — the strip then
+ * sees no footer, leaves the model's own, and the canonical one lands
+ * beside it as a second attribution line. The delimiters blank with the
+ * content: GitHub renders neither them nor an opener's info string, and a
+ * `<!--` lodged in the info string would blind the strip the same way.
+ *
+ * Scanned from the body's START, not from the tail the strip matches on: a
+ * fence's state is only knowable from where it opened, and a tail cut
+ * inside one reads its code as ordinary text. The scan is one linear pass,
+ * so the tail bound the regex needs is untouched.
+ */
+function blankQuotedCode(body: string): string {
+  const scanned = scanLines(body);
+  if (!scanned.some(({ kind }) => kind === 'fence' || kind === 'code')) {
+    return body;
+  }
+  const endings = body.match(LINE_ENDING_RE) ?? [];
+  return scanned
+    .map(
+      ({ line, kind }, i) =>
+        (kind === 'fence' || kind === 'code'
+          ? '\u0000'.repeat(line.length)
+          : line) + (endings[i] ?? ''),
+    )
+    .join('');
+}
+
+/**
+ * Every CommonMark line ending — `\n`, `\r\n`, and a bare `\r`. The one
+ * spelling for the scan and the blanking: both index lines the parser
+ * counted under the same definition (it normalizes all three to one line
+ * break), so a second spelling would misalign the two. Carries the `g`
+ * flag; `.split()` clones the regex and `.match()` resets `lastIndex`, so
+ * both are safe call sites.
+ */
+const LINE_ENDING_RE = /\r\n?|\n/g;
+
+/**
+ * The CommonMark classifier every line-aware strip reads. `html: true` is
+ * load-bearing: with raw-HTML blocks parsed as paragraphs instead, a fence
+ * delimiter inside `<div>…</div>` would open code state GitHub does not
+ * render. Same construction as `audit-layers.ts`. Only `token.type` and
+ * `token.map` are read, and the `block` core rule produces both — the
+ * inline pass is pure cost (and quadratic on some one-line bodies), so it
+ * is off.
+ */
+const BLOCK_PARSER = new MarkdownIt({ html: true });
+BLOCK_PARSER.core.ruler.disable(['inline']);
 
 /** The blockquote prefix a line can carry, at any nesting depth. */
 const QUOTE_PREFIX_RE = /^[ \t]{0,3}(?:>[ \t]*)+/;
 
-/** Fence delimiter runs (``` or ~~~), openers and closers alike. */
-const FENCE_RUN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
-
-/** A fence CLOSER: same shape, nothing but trailing whitespace after it. */
-const FENCE_CLOSE_RE = /^[ \t]{0,3}(`{3,}|~{3,})[ \t]*\r?$/;
-
-// The CommonMark type-6 block-level tag names, opening or closing.
-const HTML_BLOCK_TAG_NAMES =
-  '(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)';
-
-/**
- * The simple HTML-block opener the line-map tracks (see `scanLines`): an
- * opening tag, or a CLOSING block-level tag — `</div>` alone on a line
- * starts a blank-line-terminated HTML block exactly as `<div>` does.
- */
-const HTML_BLOCK_OPEN_RE = new RegExp(
-  `^(?:<[A-Za-z][^>]*>?|</${HTML_BLOCK_TAG_NAMES}[ \\t]*>)[ \\t]*\\r?$`,
-  'i',
-);
-
-/** The type-1 openers: their blocks end at the closing tag, not a blank line. */
-const HTML_TYPE1_OPEN_RE = /^<(pre|script|style|textarea)\b/i;
-
-/** Structural classes a line falls into, in scan order. */
+/** Structural classes a line falls into. */
 type LineKind =
   | 'text' // ordinary line — a strip's map applies
-  | 'htmlOpen' // opens a simple HTML block — kept verbatim
-  | 'html' // HTML-block content — mapped: renders VISIBLY on GitHub
-  | 'htmlEnd' // the blank line closing an HTML block — kept
-  | 'fenceEdge' // a fence opener or closer — kept
-  | 'fence' // fenced-code content — kept (a quotation)
+  | 'html' // tag-based HTML-block content — mapped: renders VISIBLY on GitHub
+  | 'fence' // fenced-code line, delimiters included — kept (a quotation)
   | 'code'; // indented-code content — kept (a quotation)
 
 interface ScannedLine {
@@ -490,114 +563,73 @@ interface ScannedLine {
 }
 
 /**
- * One structural pass over the body, shared by every line-aware strip:
- * markdown constructs under which a footer/marker-shaped line is a
- * QUOTATION, not attribution, classified identically everywhere.
+ * One structural pass over the body, shared by every line-aware strip and
+ * the blanking: which lines GitHub renders as code (the quotations the
+ * maps keep and the blanking hides), which as visible HTML-block content,
+ * and which as ordinary text the maps apply to — classified identically
+ * everywhere.
  *
- * Blockquote-wrapped lines classify on their CONTENT, after the `>` prefix
- * — `quoteBlock` in pr-context quotes every earlier comment containing code
- * as `> ``` …`, and a scanner that never sees past the `>` reaches inside
- * quoted code and corrupts it. Fences track their quote depth for the same
- * reason: a shallower depth ends the quoted block carrying the fence. A
- * DEEPER depth inside an open fence does not — a `>`-prefixed line inside a
- * fenced code block is literal code content on GitHub, and the fence stays
- * open past it; the closer must carry the opener's own depth for the same
- * reason.
+ * The classification is the CommonMark parser's token map, not a hand
+ * model of the block grammar. The scan this replaced tracked fences and
+ * HTML blocks itself and disagreed with the renderers on lazy continuation
+ * (an indented line right after a paragraph line is prose, not code), on
+ * list content indents and tab stops, and on fence delimiters inside a
+ * raw-HTML block — each disagreement kept a forged footer the render
+ * showed, or hid one it rendered as code. A fence token's map covers its
+ * delimiters too, so they classify with their content. Blockquotes and
+ * list items are the parser's containers: a `> ```` quotation of an earlier
+ * round's comment (`quoteBlock` in pr-context) is code at its depth.
  *
- * The fence state is the opener's delimiter character and run length:
- * CommonMark closes a fence only on the same character, at least the
- * opener's length, with no info string — a bare boolean inverts parity on
- * nested/mixed quotes, exactly the 'quoting an earlier round' shape these
- * strips exist for. It also never OPENS a backtick fence whose info string
- * carries a backtick — CommonMark forbids that spelling, so the line is
- * ordinary paragraph text (tilde fences may carry one). Lines inside a
- * simple HTML block (`<div>`, `</div>`, … until the next blank line;
- * `<pre>`/`<script>`/`<style>`/`<textarea>` until their closing tag) render
- * VISIBLY on GitHub, so the state only stops a fence-shaped line inside one
- * from toggling fence state — and a `>`-only line is not the blank line
- * that ends such a block.
+ * Tag-based HTML blocks (`<div>`, `<details>`, `<pre>` …) render their
+ * content visibly, so it maps like text — the one droppable quotation kind
+ * — and is what the marker-exposure gate counts. The raw kinds (a comment,
+ * PI, declaration or CDATA block) render nothing; they were never modeled
+ * and classify as text, where the projection's own comment handling
+ * applies.
+ *
+ * Blockquote-wrapped lines keep their prefix on `line`, their content on
+ * `content`, and their prefix depth on `depth`: the maps match quoted
+ * shapes at any depth, and a paragraph run ends where the depth changes.
  *
  * Splits on every CommonMark line ending — `\n`, `\r\n`, and a bare
- * `\r`: GitHub renders all three as a line break, and a `\n`-only scan
- * read the CR twins of these bodies as one line, leaving a forged footer
- * or a hollow fence the LF twin strips or refuses.
+ * `\r`: the parser normalizes all three to one line break, so its map and
+ * this split stay aligned, and the CR twins of these bodies classify like
+ * the LF ones.
  */
 function scanLines(body: string): ScannedLine[] {
-  let fence: { char: string; len: number; depth: number } | null = null;
-  let html: { endRe: RegExp | null } | null = null;
-  const out: ScannedLine[] = [];
-  for (const line of body.split(/\r\n?|\n/)) {
+  const lines = body.split(LINE_ENDING_RE);
+  const kinds: LineKind[] = new Array<LineKind>(lines.length).fill('text');
+  for (const token of BLOCK_PARSER.parse(body, {})) {
+    if (token.map === null) continue;
+    let kind: LineKind;
+    if (token.type === 'fence') kind = 'fence';
+    else if (token.type === 'code_block') kind = 'code';
+    else if (token.type === 'html_block') {
+      // A block opens at its first `<`, past any container prefix. Only a
+      // tag opens the visible kind; `<!--`, `<?`, `<!X` and `<![CDATA[`
+      // open the render-nothing kinds, which stay text.
+      const opener = lines[token.map[0]];
+      if (!/^<[A-Za-z/]/.test(opener.slice(Math.max(opener.indexOf('<'), 0)))) {
+        continue;
+      }
+      kind = 'html';
+    } else continue;
+    for (let l = token.map[0]; l < token.map[1]; l += 1) kinds[l] = kind;
+  }
+  return lines.map((line, i) => {
     const quote = QUOTE_PREFIX_RE.exec(line);
     const depth = quote === null ? 0 : quote[0].split('>').length - 1;
     const content = quote === null ? line : line.slice(quote[0].length);
-    const trimmed = content.trimStart();
-    if (html !== null) {
-      const closes =
-        html.endRe === null ? line.trim() === '' : html.endRe.test(line);
-      if (closes && html.endRe === null) {
-        html = null;
-        out.push({ line, kind: 'htmlEnd', depth, content });
-      } else {
-        out.push({ line, kind: 'html', depth, content });
-        if (closes) html = null;
-      }
-      continue;
-    }
-    if (fence !== null && depth < fence.depth) {
-      // The quoted block carrying the fence ended; reclassify outside it.
-      fence = null;
-    }
-    if (fence !== null) {
-      const close = FENCE_CLOSE_RE.exec(content);
-      if (
-        close !== null &&
-        depth === fence.depth &&
-        close[1]![0] === fence.char &&
-        close[1]!.length >= fence.len
-      ) {
-        fence = null;
-        out.push({ line, kind: 'fenceEdge', depth, content });
-      } else {
-        out.push({ line, kind: 'fence', depth, content });
-      }
-      continue;
-    }
-    if (HTML_BLOCK_OPEN_RE.test(trimmed)) {
-      const t1 = HTML_TYPE1_OPEN_RE.exec(trimmed);
-      html =
-        t1 === null
-          ? { endRe: null }
-          : { endRe: new RegExp(`</${t1[1]}\\s*>`, 'i') };
-      out.push({ line, kind: 'htmlOpen', depth, content });
-      continue;
-    }
-    const open = FENCE_RUN_RE.exec(content);
-    if (open !== null) {
-      // A backtick in a BACKTICK fence's info string is no fence at all —
-      // the line is ordinary text; tilde fences may carry one.
-      if (
-        !(open[1]![0] === '`' && content.slice(open[0].length).includes('`'))
-      ) {
-        fence = { char: open[1]![0]!, len: open[1]!.length, depth };
-        out.push({ line, kind: 'fenceEdge', depth, content });
-        continue;
-      }
-    }
-    if (/^[ \t]{4}/.test(content)) {
-      out.push({ line, kind: 'code', depth, content });
-      continue;
-    }
-    out.push({ line, kind: 'text', depth, content });
-  }
-  return out;
+    return { line, kind: kinds[i], depth, content };
+  });
 }
 
 /**
  * Line-map shared by the anywhere-strips: `map` returns the replacement
- * line, or null to drop it. Fenced code, indented code, fence edges, and
- * HTML-block openers/closers are quotations — kept verbatim; HTML-block
- * CONTENT renders visibly, so it maps like text. A body where nothing
- * changed is returned byte-identical.
+ * line, or null to drop it. Fenced code (delimiters included) and indented
+ * code are quotations — kept verbatim; HTML-block CONTENT renders visibly,
+ * so it maps like text. A body where nothing changed is returned
+ * byte-identical.
  */
 function mapLinesAware(
   body: string,
@@ -747,7 +779,7 @@ export function rendersAsNothing(text: string): boolean {
     stripped = next;
   }
   const kept: string[] = [];
-  const lines = stripped.split(/\r\n?|\n/);
+  const lines = stripped.split(LINE_ENDING_RE);
   for (let i = 0; i < lines.length; i += 1) {
     const l = lines[i]!;
     if (/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*\r?$/.test(l)) continue;

--- a/packages/cli/src/commands/review/lib/review-footer.ts
+++ b/packages/cli/src/commands/review/lib/review-footer.ts
@@ -159,8 +159,22 @@ interface Projection {
  * no code span in CommonMark and stays literal. The strips used to match
  * the raw bytes and disagreed with their own `rendersAsNothing` gate, which
  * projects first — one projection for all of them ends the disagreement.
+ *
+ * An UNCLOSED comment opener has two readings, and the caller picks. In a
+ * multi-line body it runs to the end of the input (`'swallow'`): a
+ * line-leading opener opens a comment block GitHub renders as nothing to
+ * the end, and the attribution-off line strips rely on that reading to
+ * remove a forged footer trailed by junk. On a folded SINGLE line
+ * (`'literal'`) there is no later line for a closer to sit on, so
+ * CommonMark's inline HTML rule never fires: GitHub escapes the opener to
+ * literal text and everything after it renders as prose — swallowing there
+ * hid a forged footer the render shows, on the one-line channels whose fold
+ * puts a witness block's quoted `<!--` on the footer's own line.
  */
-function projectInvisibles(input: string): Projection {
+function projectInvisibles(
+  input: string,
+  unclosedOpener: 'swallow' | 'literal' = 'swallow',
+): Projection {
   let text = '';
   const starts: number[] = [];
   const ends: number[] = [];
@@ -207,6 +221,11 @@ function projectInvisibles(input: string): Projection {
     }
     if (ch === '<' && input.startsWith('<!--', i)) {
       const close = input.indexOf('-->', i + 4);
+      if (close === -1 && unclosedOpener === 'literal') {
+        push('<!--', i, i + 4);
+        i += 4;
+        continue;
+      }
       i = close === -1 ? n : close + 3;
       continue;
     }
@@ -428,7 +447,10 @@ const STRIP_TAIL_LIMIT = 8192;
  * line and stays inside that bound. Shared by both strip sites —
  * `compose-review`'s drafted entries and `submit`'s inline comments —
  * because one guard is one guard, and a second copy is how one site
- * eventually forgets it.
+ * eventually forgets it. The tail bound is the REGEX's: the blanking ahead
+ * of it reads the whole body — a fence's state is only knowable from where
+ * it opened — in one linear, block-only parse, a few milliseconds at
+ * GitHub's 65,536-character comment cap.
  *
  * The match runs on the displayed projection — a comment or entity inside
  * the marker phrase cannot hide a trailing forged footer (or forge one:
@@ -450,10 +472,12 @@ export function stripReviewFooter(body: string): string {
  * no block structure — the collapse flattened it — so a footer on it is
  * never the quotation `stripReviewFooter`'s blanking keeps: a fence
  * delimiter leading the line is posted text, not a code edge, and must
- * not blind the strip.
+ * not blind the strip. Nor may an unterminated `<!--` the fold carried
+ * onto the line: it is literal text on a single line (the projection's
+ * `'literal'` reading), and the footer after it renders as prose.
  */
 export function stripReviewFooterLine(line: string): string {
-  return stripTrailingFooter(line, line);
+  return stripTrailingFooter(line, line, 'literal');
 }
 
 /**
@@ -473,9 +497,13 @@ function canProjectFooterMarker(s: string): boolean {
  * `body` itself — and the SAME length, so an index into the projection of
  * its tail is an index into the original bytes the cut slices.
  */
-function stripTrailingFooter(body: string, scanned: string): string {
+function stripTrailingFooter(
+  body: string,
+  scanned: string,
+  unclosedOpener: 'swallow' | 'literal' = 'swallow',
+): string {
   const tail = scanned.slice(-STRIP_TAIL_LIMIT);
-  const proj = projectInvisibles(tail);
+  const proj = projectInvisibles(tail, unclosedOpener);
   if (!proj.text.includes(FOOTER_MARKER)) return body;
   const m = REVIEW_FOOTER_RE.exec(proj.text);
   if (m === null) return body;
@@ -536,8 +564,9 @@ const LINE_ENDING_RE = /\r\n?|\n/g;
  * delimiter inside `<div>…</div>` would open code state GitHub does not
  * render. Same construction as `audit-layers.ts`. Only `token.type` and
  * `token.map` are read, and the `block` core rule produces both — the
- * inline pass is pure cost (and quadratic on some one-line bodies), so it
- * is off.
+ * inline pass is pure cost, two orders of magnitude on hostile one-line
+ * bodies (a 256 KiB run of `[` measured ~1 ms block-only, ~400 ms with the
+ * inline pass; linear either way), so it is off. A test bounds the cost.
  */
 const BLOCK_PARSER = new MarkdownIt({ html: true });
 BLOCK_PARSER.core.ruler.disable(['inline']);

--- a/packages/cli/src/commands/review/submit.test.ts
+++ b/packages/cli/src/commands/review/submit.test.ts
@@ -842,6 +842,60 @@ describe('the user-authorized fast path binds a recorded Aone target (round-6 wi
   });
 });
 
+describe('an unanchorable Aone blocker relocates without its forged footer', () => {
+  let savedGhHost: string | undefined;
+  let capturedDiff: string | undefined;
+  beforeEach(() => {
+    savedGhHost = process.env['GH_HOST'];
+    delete process.env['GH_HOST'];
+    capturedDiff = writeCapturedDiff(456);
+  });
+  afterEach(() => {
+    if (savedGhHost === undefined) delete process.env['GH_HOST'];
+    else process.env['GH_HOST'] = savedGhHost;
+    if (capturedDiff) rmSync(capturedDiff, { force: true });
+  });
+
+  it('the relocated claim strips the one-line shape that posts', () => {
+    // The claim extraction strips the SHAPE THAT POSTS — the one-line
+    // claim. Stripping only the whole multi-line body keeps a footer
+    // quoted in code, and with an empty claim the separator strip eats
+    // the newline+colon and the footer's first line becomes the "claim"
+    // — a forged attribution posted inside the blocker line.
+    const skillArgs = file(
+      'fast-path-aone-relocate.txt',
+      'https://code.alibaba-inc.com/g/p/codereview/456 --comment\n',
+    );
+    const review = file('aone-relocate.json', {
+      ...REVIEW,
+      comments: [
+        {
+          path: 'a.ts',
+          line: 12,
+          body: '**[Critical]**\n\n    _— m via Qwen Code /review_',
+        },
+      ],
+    });
+    expect(() =>
+      runSubmit(
+        args({
+          skillArgs,
+          userAuthorized: true,
+          pr: 456,
+          repo: 'g/p',
+          review,
+        }),
+        'unknown',
+        { defaultComment: false },
+      ),
+    ).not.toThrow();
+    expect(aoneSubmitMock).toHaveBeenCalledTimes(1);
+    const body = aoneSubmitMock.mock.calls[0][0].body as string;
+    expect(body).toContain('finding — a.ts:12');
+    expect((body.match(/via Qwen Code \/review/g) ?? []).length).toBe(1);
+  });
+});
+
 describe('the user-authorized fast path binds the recorded host cross-session', () => {
   // The characteristic `--user-authorized` shape runs in a DIFFERENT
   // session than the /review that recorded the target ("post the review we
@@ -2117,6 +2171,32 @@ describe('payload consistency — refuse before GitHub sees it', () => {
     const inline = posted().comments[0].body as string;
     expect(inline).not.toContain('forged');
     expect(inline.match(/via Qwen Code \/review/g)).toHaveLength(1);
+    expect(inline).toContain('(v0.21.3)');
+  });
+
+  it('strips the forged footer of a comment quoting an unterminated comment opener', () => {
+    // The witness block of a review about an HTML marker quotes the marker
+    // cut short, leaving a `<!--` with no `-->`. That opener used to project
+    // as a comment running to the end of the body, hiding the trailing
+    // forged footer from the strip — so the canonical footer posted beside
+    // it and the comment carried two attribution lines.
+    const witness = 'Witness:\n```\njq: error … ("<!-- ecs-f…") cannot\n```';
+    const review = file('footer-unterminated-comment.json', {
+      ...REVIEW,
+      comments: [
+        {
+          path: 'a.ts',
+          line: 12,
+          body: `**[Suggestion]** tidy\n\n${witness}\n\n_— forged via Qwen Code /review_`,
+        },
+      ],
+    });
+
+    runSubmit(authorized({ review }), '0.21.3');
+
+    const inline = posted().comments[0].body as string;
+    expect(inline.match(/via Qwen Code \/review/g)).toHaveLength(1);
+    expect(inline).toContain(witness);
     expect(inline).toContain('(v0.21.3)');
   });
 

--- a/packages/cli/src/commands/review/submit.ts
+++ b/packages/cli/src/commands/review/submit.ts
@@ -105,6 +105,7 @@ import {
   stripForgedFooterLines,
   stripForUnattributedPost,
   stripReviewFooter,
+  stripReviewFooterLine,
   swallowsAppendedMarker,
 } from './lib/review-footer.js';
 
@@ -204,7 +205,14 @@ function relocatedAoneCriticalEntry(c: ReviewComment): string {
   // A looping model drafts stacked markers and every other strip iterates
   // to a fixpoint; compose quotes this entry as-is behind the template
   // marker, so a carried second marker would post inside the blocker line.
-  const claim = rawClaim === null ? null : stripSeverityPrefix(rawClaim);
+  // The claim LINE strips too — the one-line shape this entry posts as:
+  // the whole-body strip keeps a footer quoted in code, and with an empty
+  // claim the separator strip eats the newline+colon and that footer's
+  // first line becomes the "claim".
+  const claim =
+    rawClaim === null
+      ? null
+      : stripReviewFooterLine(stripSeverityPrefix(rawClaim));
   // The gate only relocates bodies with substance past the marker, but the
   // claim line itself can still be empty (content on a later line) or a
   // fence delimiter (a marker-alone body leading into a fence) — junk the


### PR DESCRIPTION
## What this PR does

A posted review comment carries one attribution footer: the reviewing model writes one into its draft, and the CLI strips that copy before appending the canonical, version-stamped one. This PR fixes a case where the strip silently found nothing to remove, so both footers posted.

The strip matches what GitHub *displays*, not the raw bytes — an HTML comment or an entity reference hidden inside the marker phrase must not shield a forged footer. In that displayed projection, a comment opener with no closer runs to the end of the input, which is what a browser does with it. Inside a code fence it does not: GitHub renders fenced content literally, opener and all. The projection did not make that distinction, so an unterminated `<!--` quoted anywhere in a witness block swallowed the trailing footer along with everything after it, the strip saw no footer to remove, and the canonical one landed beside the model's own.

Three changes, all in `packages/cli/src/commands/review/`:

- **Blank quoted code before projecting.** Fenced and indented code — delimiters included, since GitHub renders neither them nor an opener's info string — is replaced with same-length NULs before the projection, so the cut still maps back to the original bytes. Code content is a quotation: it can neither be attribution nor hide any.
- **Classify code with the CommonMark parser, not a hand model.** Which lines are code is now `markdown-it`'s block token map (already a `packages/cli` dependency, same construction as `audit-layers.ts`). The hand-built scanner the line-aware strips shared disagreed with the renderers on lazy continuation (an indented line right after a paragraph line is prose), list content indents, tab stops, and fence delimiters inside raw-HTML blocks — and once the blanking trusted it, each disagreement kept a forged footer the render showed. The scanner goes away; every strip in the file reads the same map.
- **The one-line channels strip again after the fold.** `compose-review`'s deferral titles, reroute records, ingested entries and duplicate-dropped entries, and `submit`'s relocated claim collapse multi-line text to one posted line, which flattens a footer the blanking kept as quoted code. The trailing strip now runs on the folded line as well (`stripReviewFooterLine`, no blanking: a folded line has no block structure) — at the ingest sites, and as the fold's own guarantee inside `boundDeferredLine`, the per-entry bound every deferred, relocated, duplicate-dropped and cannot-tell exit passes through, ahead of its character cap. The duplicates channel reaches that fold with no ingest-time strip ahead of it, which is why the guarantee lives at the choke point rather than per exit. On a folded line an unterminated `<!--` is read as literal text — a single line has no later line for a closer, so CommonMark's inline HTML rule never fires and GitHub escapes it — where the multi-line strips keep reading it as a comment running to the end of the input; the fold puts a witness block's quoted opener on the footer's own line, and swallowing there hid the footer.

## Why it's needed

It happened on a real review, on a comment whose subject was an HTML dedup marker — its witness block quoted the marker cut short, which is exactly the shape that trips this. The comment posted with two footers, one of them the model's own unversioned copy: https://github.com/QwenLM/qwen-code/pull/10445#discussion_r3885165818

The blind spot is not limited to that shape. Any review that quotes an unterminated comment opener in its evidence — reviews of HTML markers, of templating that emits them, of the truncated output of a tool that prints one — loses the strip for that comment, and the duplicate attribution is what the version stamp exists to prevent. The same strip also normalizes bodies for the dedup and re-check lookups, so a body it cannot normalize is a body those lookups can mismatch.

## Reviewer Test Plan

### How to verify

Reproduce on the real comment: fetch that comment body, cut the canonical footer the CLI appended, and run `stripReviewFooter` over what remains (the model's draft, ending in its own footer). On `main` it comes back byte-identical — 3006 characters in, 3006 out, one forged footer still trailing. With this change it strips to 2967 characters, ends at `</details>`, and carries no footer. Neutralizing the quoted opener (`<!- -`) makes `main` strip too — the opener is the whole trigger.

Minimal shape, if you would rather not fetch the comment: a body of ```` ```\n<!-- x\n```\n\n_— m via Qwen Code /review_ ```` strips to the fenced block.

Unit tests: `cd packages/cli && npx vitest run src/commands/review/` — 117 files, 5757 tests pass (18 skipped). Every new guard was mutation-verified by reverting it and re-running:

- no blanking (`stripTrailingFooter(body, body)`) — 7 tests red across `review-footer.test.ts` and `submit.test.ts`;
- raw-HTML block kinds counted as visible HTML — 3 tests red (the marker-swallow gate and the marker-line strip);
- the three `compose-review` ingest-site strips reverted — 3 tests red;
- the `boundDeferredLine` fold strip reverted — 2 tests red (the duplicates channel, with and without the character cap in play);
- the folded line's literal reading of an unterminated `<!--` reverted — 2 tests red (the `~~~`/indented fold shapes, and an unclosed-fence deferred title through `composeReview`);
- the `<` arm of the marker gate dropped — 1 test red (a marker phrase split by a closed comment);
- markdown-it's inline pass re-enabled — 1 test red (a 256 KiB one-line body must strip within 40 ms; measured 1.2 ms block-only, 395 ms with the inline pass);
- the `submit` claim-line strip reverted — 1 test red.

`eslint --max-warnings 0` and `prettier --check` pass on the six changed files.

### Evidence (Before & After)

N/A — not user-visible in the TUI. The observable difference is the posted comment body, covered by the witness replay above and the submit-level test asserting exactly one `via Qwen Code /review` in the posted payload with the witness block intact.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only.

## Risk & Scope

- **Behavior changes.** (1) A trailing footer that is itself code content — inside an unclosed fence, or in an indented block — is now left alone; it renders as code on GitHub, not as attribution, which is the rule every other strip in this file already follows. (2) The line-aware strips (`stripForgedFooterLines`, `stripCommentMarkerLines`, `stripParagraphMarkers`, the span strips, `swallowsAppendedMarker`) now classify code through the parser, so the shapes where the hand scanner disagreed with GitHub — lazy continuations, list content indents, tab-indented code, fence-looking lines inside a raw-HTML block — flip toward what the render shows. (3) The one-line channels strip after the fold. Each is pinned by tests.
- **Known limits, deliberately out of scope** — pre-existing on `main`, with one narrow exception named below: in a multi-line body the projection still takes an unterminated `<!--` in ordinary prose as running to the end of the input (GitHub escapes a mid-line one as literal text; the attribution-off line strips rely on the aggressive reading to remove a forged footer trailed by junk — only the folded single-line channels read it literally); a `-->` quoted in a *later* code block therefore no longer closes such an opener, where `main` happened to strip by reading the quoted closer — that mid-line-opener shape is the one regression this PR accepts, at the cost of one cosmetic duplicate line (the line-leading twin is handled: the parser reads it as an HTML block and the quoted closer still closes); the marker phrase is matched on one literal spelling; a closed comment spanning a paragraph break is still dropped whole. The strip is best-effort sanitation of the reviewing model's own draft — a miss costs a duplicate attribution line, which is why over-stripping visible content is the failure mode this PR avoids.
- **Takeover note.** Under `autofix/takeover` this PR ran 14 review rounds, and the diff grew from 79 to ~1,300 source lines as each round hardened the machinery the previous round added (a render-faithful raw-HTML projection, opener neutralization, paragraph-bound closers, terminator fail-open guards, fence-residue gates) — with the next round's Criticals landing in that new code. I reset the branch to the shape above: the original fix, the parser delegation the loop introduced (which retired the five confirmed round-1 defects), and the fold-site strips (round-1 R1-9). Everything else is dropped rather than fixed; the loop's last head is preserved at `archive/pr10458-loop-round14` (d69deb958a) for reference.
- Breaking changes / migration notes: none.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

一条发布出去的评审评论只带一条署名 footer:模型在草稿里写一条,CLI 在追加带版本号的规范 footer 之前把模型那条剥掉。本 PR 修的是剥离步骤悄悄什么都没剥掉、于是两条 footer 同时发出去的情况。

剥离匹配的是 GitHub **显示**出来的内容,而不是原始字节——藏在标记短语里的 HTML 注释或实体引用不能给伪造 footer 当挡箭牌。在这个显示投影里,没有闭合的注释起始符会一直吞到输入末尾,这也是浏览器的行为。但在代码围栏里不是这样:GitHub 把围栏内容原样渲染,包括那个起始符。投影没有区分这一点,于是 witness 代码块里任何一个未闭合的 `<!--` 都会把它后面的一切连同末尾的 footer 一起吞掉,剥离步骤看不到 footer 可剥,规范 footer 就落在了模型自己那条旁边。

三处改动,全部在 `packages/cli/src/commands/review/` 下:

- **投影之前先把引用的代码置空。** 围栏代码和缩进代码——包括围栏分隔行,因为 GitHub 既不渲染分隔符也不渲染 info string——在投影前替换成等长的 NUL,这样剪切位置仍然映射回原始字节。代码内容是引用:它既不可能是署名,也藏不住署名。
- **用 CommonMark 解析器而不是手工模型判定代码行。** 哪些行是代码现在由 `markdown-it` 的块级 token map 决定(它已是 `packages/cli` 的依赖,与 `audit-layers.ts` 同一构造)。行级 strip 共用的手写扫描器在懒续行(段落行紧跟的缩进行是正文)、列表内容缩进、tab 制表位、原始 HTML 块内的围栏分隔行这几处都与渲染器不一致——一旦置空信任了它,每一处不一致都会留下一条渲染可见的伪造 footer。手写扫描器整体删除;文件里所有 strip 读同一份 map。
- **单行通道在折叠之后再剥一次。** `compose-review` 的 deferral 标题、reroute 记录、摄入的条目、重复项条目,以及 `submit` 的 relocated claim,都会把多行文本折叠成一行发出去,这会把置空保留下来的"代码内 footer"压平。尾部剥离现在也在折叠后的行上跑一次(`stripReviewFooterLine`,不置空:折叠后的行没有块结构)——摄入站点各跑一次,并作为折叠自身的保证放在 `boundDeferredLine` 里,即 deferred / relocated / 重复项 / cannot-tell 每个出口都要经过的逐条上界,且在字符截断之前。重复项通道到达这个折叠时前面没有任何摄入时剥离,所以这条保证放在汇点而不是逐出口补。折叠后的单行里,未闭合的 `<!--` 按字面文本处理——单行没有后续行可放闭合符,CommonMark 的行内 HTML 规则不会触发,GitHub 会把它转义——而多行剥离仍把它视作吞到输入末尾的注释;折叠会把 witness 块里引用的起始符放到 footer 同一行,在那里吞掉就会藏住 footer。

## 为什么需要

这在一次真实评审里发生了,而且发生在一条主题恰好是 HTML 去重标记的评论上——它的 witness 代码块引用了被截断的标记,正是触发这个问题的形状。那条评论带着两条 footer 发了出去,其中一条是模型自己写的不带版本号的副本:https://github.com/QwenLM/qwen-code/pull/10445#discussion_r3885165818

盲区不止这一种形状。任何在证据里引用了未闭合注释起始符的评审——评审 HTML 标记、评审会生成这类标记的模板、评审某个打印它的工具被截断的输出——都会对那条评论失去剥离能力,而重复署名正是版本戳要防的东西。同一个剥离函数还负责把正文归一化后用于去重和复检查找,所以一个归一化不了的正文,也是这些查找可能错配的正文。

## 评审者测试计划

### 如何验证

在真实评论上复现:取回那条评论正文,截掉 CLI 追加的规范 footer,对剩下的部分(模型草稿,以它自己的 footer 结尾)跑 `stripReviewFooter`。在 `main` 上它逐字节原样返回——3006 个字符进、3006 个字符出,伪造 footer 仍在末尾。改动之后剥到 2967 个字符,结尾停在 `</details>`,不再带任何 footer。把被引用的起始符改掉(`<!- -`),`main` 也能剥——起始符就是全部诱因。

不想去取评论的话,最小形状是:正文 ```` ```\n<!-- x\n```\n\n_— m via Qwen Code /review_ ```` 会被剥到只剩围栏块。

单测:`cd packages/cli && npx vitest run src/commands/review/` —— 117 个文件、5757 个用例通过(18 个跳过)。每个新增守卫都做了突变验证(去掉它再跑一遍):

- 不置空(`stripTrailingFooter(body, body)`)—— `review-footer.test.ts` 与 `submit.test.ts` 共 7 个用例变红;
- 原始 HTML 块种类按可见 HTML 计 —— 3 个用例变红(标记吞没门与标记行剥离);
- 还原 `compose-review` 三处摄入站点剥离 —— 3 个用例变红;
- 还原 `boundDeferredLine` 的折叠剥离 —— 2 个用例变红(重复项通道,含/不含字符截断两种);
- 还原折叠行对未闭合 `<!--` 的字面读法 —— 2 个用例变红(`~~~`/缩进折叠形状,以及经 `composeReview` 的未闭合围栏 deferred 标题);
- 去掉标记门的 `<` 分支 —— 1 个用例变红(被闭合注释切开的标记短语);
- 重新打开 markdown-it 的 inline pass —— 1 个用例变红(256 KiB 单行正文须在 40 ms 内剥完;实测 block-only 1.2 ms,开 inline 395 ms);
- 还原 `submit` 的 claim 行剥离 —— 1 个用例变红。

六个改动文件通过 `eslint --max-warnings 0` 与 `prettier --check`。

### 证据(前后对比)

N/A —— TUI 里看不到。可观察的差别是发布出去的评论正文,由上面的真实评论回放和 submit 层测试(断言发布载荷中恰有一条 `via Qwen Code /review` 且 witness 块完整)覆盖。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境(可选)

仅单元测试。

## 风险与范围

- **行为变化。** (1) 本身就是代码内容的末尾 footer——在未闭合围栏里,或在缩进块里——现在会被留下;它在 GitHub 上按代码渲染而不是按署名渲染,这与本文件里其它每个 strip 早已遵循的规则一致。(2) 行级 strip(`stripForgedFooterLines`、`stripCommentMarkerLines`、`stripParagraphMarkers`、span strip、`swallowsAppendedMarker`)现在通过解析器判定代码,所以手写扫描器与 GitHub 不一致的那些形状——懒续行、列表内容缩进、tab 缩进代码、原始 HTML 块内形似围栏的行——都朝渲染结果的方向翻转。(3) 单行通道在折叠后再剥一次。每一条都有测试钉住。
- **已知限制,刻意不在范围内** —— `main` 上既有行为,仅下述一处窄例外:多行正文里,普通正文中未闭合的 `<!--` 投影仍视作吞到输入末尾(行中的 GitHub 会转义成字面文本;attribution-off 的行级剥离依赖这种激进读法去掉后面跟着杂字的伪造 footer——只有折叠后的单行通道按字面读);因此**后面**代码块里引用的 `-->` 不再能闭合这样的起始符,而 `main` 在这个形状上恰好靠读到被引用的闭合符剥掉了——这个"行中起始符"形状是本 PR 接受的唯一一处回退,代价是一条外观上的重复行(行首的孪生形状已处理:解析器把它读成 HTML 块,被引用的闭合符仍能闭合);标记短语只按一种字面拼写匹配;跨段落边界的闭合注释仍整体丢弃。这个 strip 是对评审模型自身草稿的尽力清理——漏掉一次的代价是一条重复署名行,这正是本 PR 要避免"多剥掉可见内容"这种更糟失败模式的原因。
- **接手说明。** 在 `autofix/takeover` 下本 PR 跑了 14 轮评审,diff 从 79 行涨到约 1,300 行源码——每一轮都在加固上一轮新加的机器(渲染保真的原始 HTML 投影、起始符中和、段落边界闭合搜索、终止符 fail-open 守卫、围栏残留门),而下一轮的 Critical 又落在这些新代码里。我把分支重置成上面的形状:原始修复、loop 引入的解析器委托(它消掉了第 1 轮确认的五个缺陷)、以及折叠站点剥离(第 1 轮 R1-9)。其余全部舍弃而不是修补;loop 的最后 head 保留在 `archive/pr10458-loop-round14`(d69deb958a)供查阅。
- 破坏性变更 / 迁移说明:无。

## 关联 Issue

无。

</details>
