### PR TITLE
test(core): close the deferred test gaps recorded in #9930's review rounds

### DIFF
--- a/packages/cli/src/services/housekeeping/scheduler.ts
+++ b/packages/cli/src/services/housekeeping/scheduler.ts
@@ -272,49 +272,54 @@ async function drainNonInteractiveQueue(): Promise<void> {
     const abortController = new AbortController();
     activeNonInteractiveAbortController = abortController;
 
-    await sessionIdContext.exit(async () => {
-      try {
-        const result = await runOpenAILogCleanup(
-          job.target,
-          job.markerPath,
-          abortController.signal,
-        );
-        if (nonInteractiveStopping) return;
+    // No sessionIdContext.exit here: every path into this drain — the
+    // start-side kick, the .finally re-kick, and the retry timers — already
+    // runs context-free because startNonInteractiveOpenAILogHousekeeping
+    // exits the context around enqueue and the worker start, and timers
+    // registered inside that scope inherit it. A second wrapper here was
+    // unreachable defensive code no test could pin (recorded in #9930's
+    // round-4 review); the start-side exit is the single tested choke point.
+    try {
+      const result = await runOpenAILogCleanup(
+        job.target,
+        job.markerPath,
+        abortController.signal,
+      );
+      if (nonInteractiveStopping) continue;
 
-        switch (result.status) {
-          case 'completed':
-            scheduleNonInteractiveJob(job, RECURRING_INTERVAL_MS);
-            break;
-          case 'fresh':
-            scheduleNonInteractiveJob(
-              job,
-              Math.min(
-                RECURRING_INTERVAL_MS,
-                Math.max(NON_INTERACTIVE_LOCK_RETRY_MS, result.retryAfterMs),
-              ),
-            );
-            break;
-          case 'locked':
-            scheduleNonInteractiveJob(job, NON_INTERACTIVE_LOCK_RETRY_MS);
-            break;
-          case 'incomplete':
-            break;
-          default:
-            break;
-        }
-      } catch (err) {
-        debugLogger.error(
-          `non-interactive OpenAI log cleanup failed for ${job.target.logDir}`,
-          err,
-        );
-        if (!nonInteractiveStopping) {
-          scheduleNonInteractiveJob(job, NON_INTERACTIVE_FAILURE_RETRY_MS);
-        }
-      } finally {
-        activeNonInteractiveJob = undefined;
-        activeNonInteractiveAbortController = undefined;
+      switch (result.status) {
+        case 'completed':
+          scheduleNonInteractiveJob(job, RECURRING_INTERVAL_MS);
+          break;
+        case 'fresh':
+          scheduleNonInteractiveJob(
+            job,
+            Math.min(
+              RECURRING_INTERVAL_MS,
+              Math.max(NON_INTERACTIVE_LOCK_RETRY_MS, result.retryAfterMs),
+            ),
+          );
+          break;
+        case 'locked':
+          scheduleNonInteractiveJob(job, NON_INTERACTIVE_LOCK_RETRY_MS);
+          break;
+        case 'incomplete':
+          break;
+        default:
+          break;
       }
-    });
+    } catch (err) {
+      debugLogger.error(
+        `non-interactive OpenAI log cleanup failed for ${job.target.logDir}`,
+        err,
+      );
+      if (!nonInteractiveStopping) {
+        scheduleNonInteractiveJob(job, NON_INTERACTIVE_FAILURE_RETRY_MS);
+      }
+    } finally {
+      activeNonInteractiveJob = undefined;
+      activeNonInteractiveAbortController = undefined;
+    }
   }
 }
 

--- a/packages/cli/src/services/housekeeping/scheduler.ts
+++ b/packages/cli/src/services/housekeeping/scheduler.ts
@@ -278,7 +278,10 @@ async function drainNonInteractiveQueue(): Promise<void> {
     // exits the context around enqueue and the worker start, and timers
     // registered inside that scope inherit it. A second wrapper here was
     // unreachable defensive code no test could pin (recorded in #9930's
-    // round-4 review); the start-side exit is the single tested choke point.
+    // round-4 review); the single tested choke point is the start-side
+    // sessionIdContext.exit in startNonInteractiveOpenAILogHousekeeping. Any
+    // NEW way into this drain must enter through that exited scope, or it
+    // will start propagating a session id into process-scoped housekeeping.
     try {
       const result = await runOpenAILogCleanup(
         job.target,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -620,23 +620,22 @@ describe('Server Config (config.ts)', () => {
   // filesystem (writing into the actual global debug dir). Spy the full
   // surface the fallback/alias path touches — mkdir, appendFile, unlink,
   // symlink AND readlink — in one place so the two tests can't drift out of
-  // lockstep, then restore env + logger state on the way out. Only the
-  // appendFile spy is handed to the body; the rest exist purely to keep the
-  // test off disk.
+  // lockstep, then restore env + logger state on the way out. The body reads
+  // the appendFile spy back via vi.mocked(fs.promises.appendFile) — passing it
+  // as a typed callback argument runs into vi.spyOn's generic-overload return
+  // type, which the concrete spy is not assignable to (TS2345).
   async function withDebugFallbackIsolation(
-    run: (appendFileSpy: ReturnType<typeof vi.spyOn>) => Promise<void>,
+    run: () => Promise<void>,
   ): Promise<void> {
     const previousDebugLogFileEnv = process.env['QWEN_DEBUG_LOG_FILE'];
     const previousSessionIdEnv = process.env['QWEN_CODE_SESSION_ID'];
     const spies = [
       vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined),
+      vi.spyOn(fs.promises, 'appendFile').mockResolvedValue(undefined),
       vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined),
       vi.spyOn(fs.promises, 'symlink').mockResolvedValue(undefined),
       vi.spyOn(fs.promises, 'readlink').mockResolvedValue(''),
     ];
-    const appendFileSpy = vi
-      .spyOn(fs.promises, 'appendFile')
-      .mockResolvedValue(undefined);
     const restoreEnv = (key: string, previous: string | undefined) => {
       if (previous === undefined) {
         delete process.env[key];
@@ -647,9 +646,8 @@ describe('Server Config (config.ts)', () => {
     try {
       delete process.env['QWEN_DEBUG_LOG_FILE'];
       resetDebugLoggingState();
-      await run(appendFileSpy);
+      await run();
     } finally {
-      appendFileSpy.mockRestore();
       for (const spy of spies) spy.mockRestore();
       resetDebugLoggingState();
       setDebugLogSession(null);
@@ -659,7 +657,7 @@ describe('Server Config (config.ts)', () => {
   }
 
   it('does not replace the global debug fallback during daemon Config creation or rotation', async () => {
-    await withDebugFallbackIsolation(async (appendFileSpy) => {
+    await withDebugFallbackIsolation(async () => {
       const bootstrapSessionId = '550e8400-e29b-41d4-a716-446655440000';
       const daemonSessionId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
       const rotatedSessionId = '7ba7b810-9dad-11d1-80b4-00c04fd430c8';
@@ -676,13 +674,13 @@ describe('Server Config (config.ts)', () => {
       createDebugLogger('DAEMON_FALLBACK').info('process-scoped message');
 
       await vi.waitFor(() =>
-        expect(appendFileSpy).toHaveBeenCalledWith(
+        expect(vi.mocked(fs.promises.appendFile)).toHaveBeenCalledWith(
           Storage.getDebugLogPath(bootstrapSessionId),
           expect.stringContaining('[DAEMON_FALLBACK] process-scoped message'),
           'utf8',
         ),
       );
-      expect(appendFileSpy).not.toHaveBeenCalledWith(
+      expect(vi.mocked(fs.promises.appendFile)).not.toHaveBeenCalledWith(
         Storage.getDebugLogPath(rotatedSessionId),
         expect.stringContaining('[DAEMON_FALLBACK] process-scoped message'),
         'utf8',
@@ -695,7 +693,7 @@ describe('Server Config (config.ts)', () => {
     // rotates the Config OUTSIDE any sessionIdContext, and the process-wide
     // debug session must follow the rotated id — otherwise post-rotation
     // logs keep landing in the pre-rotation session's file.
-    await withDebugFallbackIsolation(async (appendFileSpy) => {
+    await withDebugFallbackIsolation(async () => {
       const initialSessionId = '550e8400-e29b-41d4-a716-446655440000';
       const rotatedSessionId = '7ba7b810-9dad-11d1-80b4-00c04fd430c8';
       // The fallback holds a live Config reference, so rotating the SAME
@@ -716,13 +714,13 @@ describe('Server Config (config.ts)', () => {
       createDebugLogger('CLI_ROTATION').info('post-rotation message');
 
       await vi.waitFor(() =>
-        expect(appendFileSpy).toHaveBeenCalledWith(
+        expect(vi.mocked(fs.promises.appendFile)).toHaveBeenCalledWith(
           Storage.getDebugLogPath(rotatedSessionId),
           expect.stringContaining('[CLI_ROTATION] post-rotation message'),
           'utf8',
         ),
       );
-      expect(appendFileSpy).not.toHaveBeenCalledWith(
+      expect(vi.mocked(fs.promises.appendFile)).not.toHaveBeenCalledWith(
         Storage.getDebugLogPath(interloperSessionId),
         expect.stringContaining('[CLI_ROTATION] post-rotation message'),
         'utf8',

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -680,6 +680,80 @@ describe('Server Config (config.ts)', () => {
     }
   });
 
+  it('claims the global debug fallback on un-contexted rotation (single-session CLI)', async () => {
+    // The other direction of the guard above: a single-session CLI /clear
+    // rotates the Config OUTSIDE any sessionIdContext, and the process-wide
+    // debug session must follow the rotated id — otherwise post-rotation
+    // logs keep landing in the pre-rotation session's file.
+    const previousDebugLogFileEnv = process.env['QWEN_DEBUG_LOG_FILE'];
+    const previousSessionIdEnv = process.env['QWEN_CODE_SESSION_ID'];
+    const initialSessionId = '550e8400-e29b-41d4-a716-446655440000';
+    const rotatedSessionId = '7ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    const mkdirSpy = vi
+      .spyOn(fs.promises, 'mkdir')
+      .mockResolvedValue(undefined);
+    const appendFileSpy = vi
+      .spyOn(fs.promises, 'appendFile')
+      .mockResolvedValue(undefined);
+    const unlinkSpy = vi
+      .spyOn(fs.promises, 'unlink')
+      .mockResolvedValue(undefined);
+    const symlinkSpy = vi
+      .spyOn(fs.promises, 'symlink')
+      .mockResolvedValue(undefined);
+
+    try {
+      delete process.env['QWEN_DEBUG_LOG_FILE'];
+      resetDebugLoggingState();
+      // The fallback holds a live Config reference, so rotating the SAME
+      // Config reroutes writes even without the rotation-time claim. The
+      // claim is load-bearing for RE-claiming: another Config (transcript
+      // replay, bootstrap) may have taken the fallback since, and an
+      // un-contexted rotation must hand it back to the rotating CLI Config.
+      const cliConfig = new Config({
+        ...baseParams,
+        sessionId: initialSessionId,
+      });
+      const interloperSessionId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+      new Config({ ...baseParams, sessionId: interloperSessionId });
+
+      cliConfig.startNewSession(rotatedSessionId);
+
+      process.env['QWEN_DEBUG_LOG_FILE'] = '1';
+      createDebugLogger('CLI_ROTATION').info('post-rotation message');
+
+      await vi.waitFor(() =>
+        expect(appendFileSpy).toHaveBeenCalledWith(
+          Storage.getDebugLogPath(rotatedSessionId),
+          expect.stringContaining('[CLI_ROTATION] post-rotation message'),
+          'utf8',
+        ),
+      );
+      expect(appendFileSpy).not.toHaveBeenCalledWith(
+        Storage.getDebugLogPath(interloperSessionId),
+        expect.stringContaining('[CLI_ROTATION] post-rotation message'),
+        'utf8',
+      );
+    } finally {
+      mkdirSpy.mockRestore();
+      appendFileSpy.mockRestore();
+      unlinkSpy.mockRestore();
+      symlinkSpy.mockRestore();
+      resetDebugLoggingState();
+      setDebugLogSession(null);
+      if (previousDebugLogFileEnv === undefined) {
+        delete process.env['QWEN_DEBUG_LOG_FILE'];
+      } else {
+        process.env['QWEN_DEBUG_LOG_FILE'] = previousDebugLogFileEnv;
+      }
+      if (previousSessionIdEnv === undefined) {
+        delete process.env['QWEN_CODE_SESSION_ID'];
+      } else {
+        process.env['QWEN_CODE_SESSION_ID'] = previousSessionIdEnv;
+      }
+    }
+  });
+
   describe('shell execution config', () => {
     it('allows explicitly clearing the configured pager', () => {
       const config = new Config(baseParams);

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -614,28 +614,55 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
-  it('does not replace the global debug fallback during daemon Config creation or rotation', async () => {
+  // Shared isolation for the debug-fallback tests below. The module-level
+  // vi.mock('node:fs') factory overrides only the sync fs API, so any
+  // un-spied fs.promises call the debug logger makes would hit the real
+  // filesystem (writing into the actual global debug dir). Spy the full
+  // surface the fallback/alias path touches — mkdir, appendFile, unlink,
+  // symlink AND readlink — in one place so the two tests can't drift out of
+  // lockstep, then restore env + logger state on the way out. Only the
+  // appendFile spy is handed to the body; the rest exist purely to keep the
+  // test off disk.
+  async function withDebugFallbackIsolation(
+    run: (appendFileSpy: ReturnType<typeof vi.spyOn>) => Promise<void>,
+  ): Promise<void> {
     const previousDebugLogFileEnv = process.env['QWEN_DEBUG_LOG_FILE'];
     const previousSessionIdEnv = process.env['QWEN_CODE_SESSION_ID'];
-    const bootstrapSessionId = '550e8400-e29b-41d4-a716-446655440000';
-    const daemonSessionId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-    const rotatedSessionId = '7ba7b810-9dad-11d1-80b4-00c04fd430c8';
-    const mkdirSpy = vi
-      .spyOn(fs.promises, 'mkdir')
-      .mockResolvedValue(undefined);
+    const spies = [
+      vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined),
+      vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined),
+      vi.spyOn(fs.promises, 'symlink').mockResolvedValue(undefined),
+      vi.spyOn(fs.promises, 'readlink').mockResolvedValue(''),
+    ];
     const appendFileSpy = vi
       .spyOn(fs.promises, 'appendFile')
       .mockResolvedValue(undefined);
-    const unlinkSpy = vi
-      .spyOn(fs.promises, 'unlink')
-      .mockResolvedValue(undefined);
-    const symlinkSpy = vi
-      .spyOn(fs.promises, 'symlink')
-      .mockResolvedValue(undefined);
-
+    const restoreEnv = (key: string, previous: string | undefined) => {
+      if (previous === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous;
+      }
+    };
     try {
       delete process.env['QWEN_DEBUG_LOG_FILE'];
       resetDebugLoggingState();
+      await run(appendFileSpy);
+    } finally {
+      appendFileSpy.mockRestore();
+      for (const spy of spies) spy.mockRestore();
+      resetDebugLoggingState();
+      setDebugLogSession(null);
+      restoreEnv('QWEN_DEBUG_LOG_FILE', previousDebugLogFileEnv);
+      restoreEnv('QWEN_CODE_SESSION_ID', previousSessionIdEnv);
+    }
+  }
+
+  it('does not replace the global debug fallback during daemon Config creation or rotation', async () => {
+    await withDebugFallbackIsolation(async (appendFileSpy) => {
+      const bootstrapSessionId = '550e8400-e29b-41d4-a716-446655440000';
+      const daemonSessionId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+      const rotatedSessionId = '7ba7b810-9dad-11d1-80b4-00c04fd430c8';
       new Config({ ...baseParams, sessionId: bootstrapSessionId });
       const daemonConfig = sessionIdContext.run(
         daemonSessionId,
@@ -660,24 +687,7 @@ describe('Server Config (config.ts)', () => {
         expect.stringContaining('[DAEMON_FALLBACK] process-scoped message'),
         'utf8',
       );
-    } finally {
-      mkdirSpy.mockRestore();
-      appendFileSpy.mockRestore();
-      unlinkSpy.mockRestore();
-      symlinkSpy.mockRestore();
-      resetDebugLoggingState();
-      setDebugLogSession(null);
-      if (previousDebugLogFileEnv === undefined) {
-        delete process.env['QWEN_DEBUG_LOG_FILE'];
-      } else {
-        process.env['QWEN_DEBUG_LOG_FILE'] = previousDebugLogFileEnv;
-      }
-      if (previousSessionIdEnv === undefined) {
-        delete process.env['QWEN_CODE_SESSION_ID'];
-      } else {
-        process.env['QWEN_CODE_SESSION_ID'] = previousSessionIdEnv;
-      }
-    }
+    });
   });
 
   it('claims the global debug fallback on un-contexted rotation (single-session CLI)', async () => {
@@ -685,26 +695,9 @@ describe('Server Config (config.ts)', () => {
     // rotates the Config OUTSIDE any sessionIdContext, and the process-wide
     // debug session must follow the rotated id — otherwise post-rotation
     // logs keep landing in the pre-rotation session's file.
-    const previousDebugLogFileEnv = process.env['QWEN_DEBUG_LOG_FILE'];
-    const previousSessionIdEnv = process.env['QWEN_CODE_SESSION_ID'];
-    const initialSessionId = '550e8400-e29b-41d4-a716-446655440000';
-    const rotatedSessionId = '7ba7b810-9dad-11d1-80b4-00c04fd430c8';
-    const mkdirSpy = vi
-      .spyOn(fs.promises, 'mkdir')
-      .mockResolvedValue(undefined);
-    const appendFileSpy = vi
-      .spyOn(fs.promises, 'appendFile')
-      .mockResolvedValue(undefined);
-    const unlinkSpy = vi
-      .spyOn(fs.promises, 'unlink')
-      .mockResolvedValue(undefined);
-    const symlinkSpy = vi
-      .spyOn(fs.promises, 'symlink')
-      .mockResolvedValue(undefined);
-
-    try {
-      delete process.env['QWEN_DEBUG_LOG_FILE'];
-      resetDebugLoggingState();
+    await withDebugFallbackIsolation(async (appendFileSpy) => {
+      const initialSessionId = '550e8400-e29b-41d4-a716-446655440000';
+      const rotatedSessionId = '7ba7b810-9dad-11d1-80b4-00c04fd430c8';
       // The fallback holds a live Config reference, so rotating the SAME
       // Config reroutes writes even without the rotation-time claim. The
       // claim is load-bearing for RE-claiming: another Config (transcript
@@ -734,24 +727,7 @@ describe('Server Config (config.ts)', () => {
         expect.stringContaining('[CLI_ROTATION] post-rotation message'),
         'utf8',
       );
-    } finally {
-      mkdirSpy.mockRestore();
-      appendFileSpy.mockRestore();
-      unlinkSpy.mockRestore();
-      symlinkSpy.mockRestore();
-      resetDebugLoggingState();
-      setDebugLogSession(null);
-      if (previousDebugLogFileEnv === undefined) {
-        delete process.env['QWEN_DEBUG_LOG_FILE'];
-      } else {
-        process.env['QWEN_DEBUG_LOG_FILE'] = previousDebugLogFileEnv;
-      }
-      if (previousSessionIdEnv === undefined) {
-        delete process.env['QWEN_CODE_SESSION_ID'];
-      } else {
-        process.env['QWEN_CODE_SESSION_ID'] = previousSessionIdEnv;
-      }
-    }
+    });
   });
 
   describe('shell execution config', () => {

--- a/packages/core/src/utils/debugLogger.test.ts
+++ b/packages/core/src/utils/debugLogger.test.ts
@@ -574,6 +574,53 @@ describe('debugLogger', () => {
       vi.mocked(fs.readlink).mockResolvedValue('');
     });
 
+    it('recovers from the streak cap when a later alias update succeeds', async () => {
+      // The cap must behave like a circuit breaker, not a latch: a capped
+      // streak still attempts on a session CHANGE (different dedup key), and
+      // one success re-opens retries for subsequent transient failures.
+      resetDebugLoggingState();
+      const otherSession = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+      vi.mocked(fs.symlink).mockResolvedValue(undefined);
+      vi.mocked(fs.readlink)
+        // A's three failures reach the cap.
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        .mockRejectedValueOnce(new Error('ENOENT'))
+        // B's attempt succeeds and resets the streak.
+        .mockResolvedValueOnce('6ba7b810-9dad-11d1-80b4-00c04fd430c8.txt')
+        // A's post-recovery failure must retry again.
+        .mockRejectedValue(new Error('ENOENT'));
+
+      setDebugLogSession(uuidSession);
+      await vi.runAllTimersAsync();
+      const logger = createDebugLogger();
+      logger.info('A failure 2');
+      await vi.runAllTimersAsync();
+      logger.info('A failure 3');
+      await vi.runAllTimersAsync();
+      logger.info('A at cap — sticky');
+      await vi.runAllTimersAsync();
+      expect(fs.symlink).toHaveBeenCalledTimes(3);
+
+      // Session change: the capped streak must not block B's attempt.
+      sessionIdContext.run(otherSession, () => {
+        logger.info('B succeeds');
+      });
+      await vi.runAllTimersAsync();
+      expect(fs.symlink).toHaveBeenCalledTimes(4);
+
+      // B's success re-opened the breaker: A's next failure retries again.
+      logger.info('A fails after recovery');
+      await vi.runAllTimersAsync();
+      logger.info('A retries');
+      await vi.runAllTimersAsync();
+      expect(fs.symlink).toHaveBeenCalledTimes(6);
+
+      // Restore the factory defaults for later tests.
+      vi.mocked(fs.symlink).mockResolvedValue(undefined);
+      vi.mocked(fs.readlink).mockResolvedValue('');
+    });
+
     it('does not let a stale failed update clear a newer session marker', async () => {
       resetDebugLoggingState();
       vi.clearAllMocks();


### PR DESCRIPTION
## What this PR does

Closes the three test gaps that #9930's review rounds 3–4 recorded as non-blocking deferrals, submitted by the same author as a follow-through. Two gaps become mutation-killing tests; the third — an `sessionIdContext.exit` wrapper the review probe showed to be mutation-unreachable — is removed as dead defensive code rather than left permanently unpinnable.

## Why it's needed

Deferred review findings rot unless someone owns them. All three were recorded against code this author shipped in #9930, so closing them here keeps the debug-log-routing work fully pinned:

- **Rotation fallback branch** (round-4: "deletion mutant survives all 579 tests"): the fallback holds a live `Config` reference, so rotating the same Config reroutes writes even without the rotation-time claim — the claim is only observable when another Config (transcript replay, bootstrap) took the fallback in between and the un-contexted rotation must re-claim it. The new test drives exactly that interloper scenario.
- **Streak-cap recovery** (round-3: "circuit-breaker mutant survives all 40 tests"): the cap must act as a circuit breaker, not a latch — a capped streak still attempts on a session change, and one success re-opens retries for later transient failures.
- **Drain-side `sessionIdContext.exit`** (round-4: "mutation-unreachable"): every path into the drain — the start-side kick, the `.finally` re-kick, and the retry timers — already runs context-free behind the start-side exit in `startNonInteractiveOpenAILogHousekeeping` (timers registered inside that scope inherit it). A second wrapper was unreachable defensive code no test could pin, so it is removed; the start-side exit remains the single tested choke point. The inner `return` becomes `continue`, which is behaviorally identical (`finally` still runs, then the `while` condition ends the loop).

## Reviewer Test Plan

### How to verify

1. `cd packages/core && npx vitest run src/config/config.test.ts src/utils/debugLogger.test.ts` → 621/621.
2. `cd packages/cli && npx vitest run src/services/housekeeping/non-interactive-scheduler.test.ts` → 14/14 (unchanged tests still pass against the simplified drain).
3. Mutation checks (both re-run locally at this head):
   - delete the rotation-path `setDebugLogSession(this)` guard block in `config.ts` → `claims the global debug fallback on un-contexted rotation` fails;
   - insert `if (aliasFailureStreak >= MAX_CONSECUTIVE_ALIAS_FAILURES) return;` before alias scheduling in `debugLogger.ts` → `recovers from the streak cap when a later alias update succeeds` fails.

### Evidence (Before & After)

Before: both mutants survive the full suites (as recorded in #9930's round-3/round-4 review ledgers). After: each mutant fails its named test; real code passes 621/621 + 14/14. No user-visible TUI change — N/A for screenshots.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

vitest from each package dir on macOS (Darwin 25.4.0, Node 22). N/A beyond unit tests.

## Risk & Scope

- Main risk or tradeoff: the drain-side wrapper removal is the only production change; behavior is identical on every reachable path (argued above, and the existing drain-side context test still passes). If a future caller ever kicks the worker from inside a bound session context, the invariant now lives solely in the start-side exit — which is the pinned, documented choke point.
- Not validated / out of scope: macOS/Windows CI lanes (skipped for fork PRs); no changes to the #9930 routing semantics themselves.
- Breaking changes / migration notes: none.

## Linked Issues

Relates to #9535, #9538, #9930 (closes the deferred items recorded in #9930's round-3/round-4 reviews; no standalone issue was filed since the findings live in those review ledgers).

<details>
<summary>中文说明</summary>

**本 PR 做了什么**：收掉 #9930 评审第 3、4 轮记录在案的三条非阻塞遗留（同一作者跟进）。两条补上可杀变异体的测试；第三条（评审探针证明"变异不可达"的 drain 侧 `sessionIdContext.exit` 包装）按死防御代码移除，而非留下永远无法钉住的缺口。

**为什么需要**：deferred 评审发现无人认领就会腐烂。三条都出自本作者在 #9930 交付的代码：(1) rotation 回退分支——全局回退持有 Config 活引用，只有"另一个 Config 中途抢走回退、无上下文 rotation 必须抢回"的场景能观察到该调用，新测试正是驱动这个闯入者场景（删除变异体现在会红）；(2) streak 上限恢复——上限必须是断路器而非闩锁：触顶后换会话仍要尝试，一次成功即重开重试（永不再试的闩锁变异体现在会红）；(3) drain 侧 exit——进入 drain 的所有路径（start 侧启动、.finally 重启、重试定时器）都已在 start 侧 exit 之后运行、天然无上下文，第二层包装不可达故移除；内层 `return` 改为行为等价的 `continue`。

**验证**：core 621/621、cli scheduler 14/14；两个变异体均被点名测试杀死；typecheck/ESLint/Prettier 干净。macOS 本地已测，Windows/Linux 交 CI。

**风险与范围**：唯一生产改动是移除不可达包装，所有可达路径行为不变（现有 drain 侧上下文测试仍通过）；不变更 #9930 的路由语义本身。无破坏性变更。

**关联**：#9535、#9538、#9930（收掉其 round-3/4 评审台账中的 deferred 项；发现记录在评审台账中，故未另开 issue）。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
