### PR TITLE
fix(cli): resolve the sessionCd folder-trust gate from the session workspace, not the stale this.settings cache

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4071,6 +4071,10 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       },
       getProjectRoot: vi.fn().mockReturnValue('/tmp'),
       getTargetDir: vi.fn().mockReturnValue('/tmp'),
+      // Per-session folder-trust flag (security.folderTrust.enabled of the
+      // admission workspace), bound once at Config construction. Default off;
+      // bootRelocatableSession overrides it to reflect the fed workspace.
+      getFolderTrust: vi.fn().mockReturnValue(false),
       isRestrictiveSandbox: vi.fn().mockReturnValue(false),
       relocateWorkingDirectory: vi.fn().mockResolvedValue({}),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
@@ -4479,6 +4483,13 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getTargetDir: vi.fn().mockReturnValue('/tmp'),
       isRestrictiveSandbox: vi.fn().mockReturnValue(false),
       relocateWorkingDirectory: vi.fn().mockResolvedValue({}),
+      // The gate reads config.getFolderTrust() (admission-workspace flag),
+      // so mirror the fed workspace's security.folderTrust.enabled here.
+      getFolderTrust: vi
+        .fn()
+        .mockReturnValue(
+          settings.merged.security?.folderTrust?.enabled ?? false,
+        ),
     });
     Object.assign(innerConfig.getLlmClient(), {
       addWorkingDirectoryChangedContext: vi.fn().mockResolvedValue(undefined),
@@ -5605,8 +5616,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       // "latest loaded" cache to a workspace that DISABLES folder trust.
       // Reading that cache in the cd gate (the pre-fix bug) would switch off
       // session A's trust check and admit the untrusted cd; the fix reads
-      // session A's own workspace settings (loadSettingsCached over the
-      // session's cwd), so the gate still enforces.
+      // config.getFolderTrust() (A's admission-workspace flag), so the gate
+      // still enforces.
       (agent as unknown as { settings: LoadedSettings }).settings =
         makeSessionSettings({
           mcpServers: {},
@@ -5661,6 +5672,50 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
             allowedRoots: [canonicalRoot],
           }),
         ).resolves.toMatchObject({ newCwd: canonicalTarget });
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    });
+  });
+
+  it('keeps the cd trust gate armed after the cwd drifts into a settings-less subdirectory', async () => {
+    // The gate must bind folder-trust to the ADMISSION workspace, not re-read
+    // it from the current cwd: a prior cd moves targetDir into a subdirectory
+    // that carries no `.qwen/settings.json`, so a cwd-keyed read would resolve
+    // disabled (isFolderTrustEnabled defaults to false) and disarm the gate
+    // for the rest of the session. config.getFolderTrust() stays true, so an
+    // untrusted cd is still rejected.
+    await withEmptyTrustedFolders(async (directory) => {
+      const root = path.join(directory, 'Conversations');
+      const target = path.join(root, 'conversation-subtree-drift');
+      await fs.mkdir(target, { recursive: true, mode: 0o700 });
+      const canonicalRoot = await fs.realpath(root);
+      const canonicalTarget = await fs.realpath(target);
+      const aSettings = makeSessionSettings({
+        mcpServers: {},
+        security: { folderTrust: { enabled: true } },
+      });
+      const { agent, agentPromise, sessionId, innerConfig } =
+        await bootRelocatableSession(aSettings, 'expected-capability');
+      // cwd has drifted into a subdirectory whose settings disable folder
+      // trust. A cwd-keyed gate would read this and skip; the admission-bound
+      // config.getFolderTrust() must not.
+      innerConfig.getTargetDir.mockReturnValue('/tmp/sub');
+      vi.mocked(loadSettings).mockImplementation((cwd?: string) =>
+        cwd === '/tmp/sub'
+          ? makeSessionSettings({ mcpServers: {} })
+          : aSettings,
+      );
+
+      try {
+        await expect(
+          agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionCd, {
+            sessionId,
+            path: canonicalTarget,
+            allowedRoots: [canonicalRoot],
+          }),
+        ).rejects.toThrow('Directory not trusted');
       } finally {
         mockConnectionState.resolve();
         await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4071,6 +4071,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       },
       getProjectRoot: vi.fn().mockReturnValue('/tmp'),
       getTargetDir: vi.fn().mockReturnValue('/tmp'),
+      // Per-session folder-trust flag, default off (folder trust disabled ⇒
+      // sessionCd's trust gate is skipped). Tests that exercise the gate feed
+      // a trusted-enabled workspace through bootRelocatableSession, which
+      // overrides this to reflect the fed settings.
+      getFolderTrust: vi.fn().mockReturnValue(false),
       isRestrictiveSandbox: vi.fn().mockReturnValue(false),
       relocateWorkingDirectory: vi.fn().mockResolvedValue({}),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
@@ -4479,6 +4484,15 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getTargetDir: vi.fn().mockReturnValue('/tmp'),
       isRestrictiveSandbox: vi.fn().mockReturnValue(false),
       relocateWorkingDirectory: vi.fn().mockResolvedValue({}),
+      // Mirror loadCliConfig: the per-session Config's folder-trust flag is
+      // `security.folderTrust.enabled` from the workspace it was admitted
+      // under. sessionCd's trust gate reads this, not the agent's
+      // latest-loaded `this.settings` cache.
+      getFolderTrust: vi
+        .fn()
+        .mockReturnValue(
+          settings.merged.security?.folderTrust?.enabled ?? false,
+        ),
     });
     Object.assign(innerConfig.getLlmClient(), {
       addWorkingDirectoryChangedContext: vi.fn().mockResolvedValue(undefined),
@@ -5569,6 +5583,48 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         settings,
         'expected-capability',
       );
+
+      try {
+        await expect(
+          agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionCd, {
+            sessionId,
+            path: canonicalTarget,
+            allowedRoots: [canonicalRoot],
+          }),
+        ).rejects.toThrow('Directory not trusted');
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    });
+  });
+
+  it('resolves the cd trust gate from the session workspace, not the stale this.settings cache', async () => {
+    await withEmptyTrustedFolders(async (directory) => {
+      const root = path.join(directory, 'Conversations');
+      const target = path.join(root, 'conversation-cross-workspace');
+      await fs.mkdir(target, { recursive: true, mode: 0o700 });
+      const canonicalRoot = await fs.realpath(root);
+      const canonicalTarget = await fs.realpath(target);
+      // Session A's workspace enables folder trust.
+      const aSettings = makeSessionSettings({
+        mcpServers: {},
+        security: { folderTrust: { enabled: true } },
+      });
+      const { agent, agentPromise, sessionId } = await bootRelocatableSession(
+        aSettings,
+        'expected-capability',
+      );
+      // A different workspace's activity has since refreshed the agent's
+      // "latest loaded" cache to a workspace that DISABLES folder trust.
+      // Reading that cache in the cd gate (the pre-fix bug) would switch off
+      // session A's trust check and admit the untrusted cd; the fix reads
+      // config.getFolderTrust(), which is A's own workspace flag.
+      (agent as unknown as { settings: LoadedSettings }).settings =
+        makeSessionSettings({
+          mcpServers: {},
+          security: { folderTrust: { enabled: false } },
+        });
 
       try {
         await expect(

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4071,11 +4071,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       },
       getProjectRoot: vi.fn().mockReturnValue('/tmp'),
       getTargetDir: vi.fn().mockReturnValue('/tmp'),
-      // Per-session folder-trust flag, default off (folder trust disabled ⇒
-      // sessionCd's trust gate is skipped). Tests that exercise the gate feed
-      // a trusted-enabled workspace through bootRelocatableSession, which
-      // overrides this to reflect the fed settings.
-      getFolderTrust: vi.fn().mockReturnValue(false),
       isRestrictiveSandbox: vi.fn().mockReturnValue(false),
       relocateWorkingDirectory: vi.fn().mockResolvedValue({}),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
@@ -4484,15 +4479,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       getTargetDir: vi.fn().mockReturnValue('/tmp'),
       isRestrictiveSandbox: vi.fn().mockReturnValue(false),
       relocateWorkingDirectory: vi.fn().mockResolvedValue({}),
-      // Mirror loadCliConfig: the per-session Config's folder-trust flag is
-      // `security.folderTrust.enabled` from the workspace it was admitted
-      // under. sessionCd's trust gate reads this, not the agent's
-      // latest-loaded `this.settings` cache.
-      getFolderTrust: vi
-        .fn()
-        .mockReturnValue(
-          settings.merged.security?.folderTrust?.enabled ?? false,
-        ),
     });
     Object.assign(innerConfig.getLlmClient(), {
       addWorkingDirectoryChangedContext: vi.fn().mockResolvedValue(undefined),
@@ -5619,7 +5605,8 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       // "latest loaded" cache to a workspace that DISABLES folder trust.
       // Reading that cache in the cd gate (the pre-fix bug) would switch off
       // session A's trust check and admit the untrusted cd; the fix reads
-      // config.getFolderTrust(), which is A's own workspace flag.
+      // session A's own workspace settings (loadSettingsCached over the
+      // session's cwd), so the gate still enforces.
       (agent as unknown as { settings: LoadedSettings }).settings =
         makeSessionSettings({
           mcpServers: {},
@@ -5634,6 +5621,46 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
             allowedRoots: [canonicalRoot],
           }),
         ).rejects.toThrow('Directory not trusted');
+      } finally {
+        mockConnectionState.resolve();
+        await agentPromise;
+      }
+    });
+  });
+
+  it('does not gate cd when the session workspace disables folder trust, even if the stale cache enables it', async () => {
+    // Mirror of the test above. Session A's own workspace DISABLES folder
+    // trust, while the stale `this.settings` cache holds a trust-ENABLED
+    // workspace. The gate must follow A's own settings and NOT gate the cd —
+    // otherwise a gate that OR-combined both sources would fail closed and
+    // spuriously reject an ordinary cd for a session whose workspace never
+    // asked for trust enforcement.
+    await withEmptyTrustedFolders(async (directory) => {
+      const root = path.join(directory, 'Conversations');
+      const target = path.join(root, 'conversation-trust-disabled');
+      await fs.mkdir(target, { recursive: true, mode: 0o700 });
+      const canonicalRoot = await fs.realpath(root);
+      const canonicalTarget = await fs.realpath(target);
+      // Session A's workspace disables folder trust.
+      const aSettings = makeSessionSettings({ mcpServers: {} });
+      const { agent, agentPromise, sessionId } = await bootRelocatableSession(
+        aSettings,
+        'expected-capability',
+      );
+      (agent as unknown as { settings: LoadedSettings }).settings =
+        makeSessionSettings({
+          mcpServers: {},
+          security: { folderTrust: { enabled: true } },
+        });
+
+      try {
+        await expect(
+          agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionCd, {
+            sessionId,
+            path: canonicalTarget,
+            allowedRoots: [canonicalRoot],
+          }),
+        ).resolves.toMatchObject({ newCwd: canonicalTarget });
       } finally {
         mockConnectionState.resolve();
         await agentPromise;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -307,7 +307,6 @@ import {
 } from '../i18n/index.js';
 import {
   isWorkspaceTrusted,
-  isFolderTrustEnabled,
   loadTrustedFolders,
 } from '../config/trustedFolders.js';
 import {
@@ -10156,18 +10155,19 @@ class QwenAgent implements Agent {
         const validateTrust = () => {
           if (
             managedTrustAllowed ||
-            // Read folder-trust from THIS session's own workspace, live — not
-            // the process-wide `this.settings` "latest loaded" cache, which in
-            // a multi-workspace daemon may hold another workspace's settings
-            // and would let a workspace that disables folder trust switch off
-            // this session's trust gate. `previousCwd` is the session's
-            // current workspace (captured before the cd); `loadSettingsCached`
-            // is fingerprint-invalidated, so a mid-session settings edit — e.g.
-            // an operator enabling folder trust and reloading to lock down — is
-            // honored on the next cd (a frozen admission-time flag would not
-            // be). Same per-request-settings pattern as the other cwd-scoped
-            // handlers in this file.
-            !isFolderTrustEnabled(loadSettingsCached(previousCwd).merged)
+            // Folder-trust enablement is bound to the workspace this session
+            // was admitted under: `config.getFolderTrust()` is
+            // `security.folderTrust.enabled` from that workspace, set once at
+            // construction and never moved by `relocateWorkingDirectory`.
+            // Deliberately NOT the process-wide `this.settings` cache (holds
+            // another workspace's value in a multi-workspace daemon — the bug
+            // this fixes), and deliberately NOT a live re-read keyed on the
+            // current cwd: a cd moves `targetDir` into a subdirectory that
+            // carries no `.qwen/settings.json`, so a cwd-keyed read resolves
+            // disabled after the first cd and disarms the gate for the rest of
+            // the session. `security.folderTrust.enabled` is `requiresRestart`,
+            // so binding it at admission matches its declared semantics.
+            !config.getFolderTrust()
           ) {
             trustValidated = true;
             return;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -307,6 +307,7 @@ import {
 } from '../i18n/index.js';
 import {
   isWorkspaceTrusted,
+  isFolderTrustEnabled,
   loadTrustedFolders,
 } from '../config/trustedFolders.js';
 import {
@@ -10155,16 +10156,18 @@ class QwenAgent implements Agent {
         const validateTrust = () => {
           if (
             managedTrustAllowed ||
-            // Per-session folder-trust, NOT the process-wide `this.settings`
-            // "latest loaded" cache: in a multi-workspace daemon that cache
-            // may hold another workspace's settings, so reading it here lets a
-            // workspace that disables folder trust switch off THIS session's
-            // trust gate and admit a cd into an untrusted directory.
-            // `config.getFolderTrust()` is this session's own
-            // `security.folderTrust.enabled` (loadCliConfig binds it per
-            // workspace at admission), matching the settings the session was
-            // created under.
-            !config.getFolderTrust()
+            // Read folder-trust from THIS session's own workspace, live — not
+            // the process-wide `this.settings` "latest loaded" cache, which in
+            // a multi-workspace daemon may hold another workspace's settings
+            // and would let a workspace that disables folder trust switch off
+            // this session's trust gate. `previousCwd` is the session's
+            // current workspace (captured before the cd); `loadSettingsCached`
+            // is fingerprint-invalidated, so a mid-session settings edit — e.g.
+            // an operator enabling folder trust and reloading to lock down — is
+            // honored on the next cd (a frozen admission-time flag would not
+            // be). Same per-request-settings pattern as the other cwd-scoped
+            // handlers in this file.
+            !isFolderTrustEnabled(loadSettingsCached(previousCwd).merged)
           ) {
             trustValidated = true;
             return;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -307,7 +307,6 @@ import {
 } from '../i18n/index.js';
 import {
   isWorkspaceTrusted,
-  isFolderTrustEnabled,
   loadTrustedFolders,
 } from '../config/trustedFolders.js';
 import {
@@ -10156,7 +10155,16 @@ class QwenAgent implements Agent {
         const validateTrust = () => {
           if (
             managedTrustAllowed ||
-            !isFolderTrustEnabled(this.settings.merged)
+            // Per-session folder-trust, NOT the process-wide `this.settings`
+            // "latest loaded" cache: in a multi-workspace daemon that cache
+            // may hold another workspace's settings, so reading it here lets a
+            // workspace that disables folder trust switch off THIS session's
+            // trust gate and admit a cd into an untrusted directory.
+            // `config.getFolderTrust()` is this session's own
+            // `security.folderTrust.enabled` (loadCliConfig binds it per
+            // workspace at admission), matching the settings the session was
+            // created under.
+            !config.getFolderTrust()
           ) {
             trustValidated = true;
             return;


### PR DESCRIPTION
## What this PR does

Makes the `sessionCd` control handler read its folder-trust gate from the per-session `Config` (`config.getFolderTrust()`) instead of the agent's process-wide `this.settings` "latest loaded" cache. One-line production change plus test-harness support and a regression test.

## Why it's needed

`security.folderTrust.enabled` is per-workspace configurable (it is not in `WORKSPACE_RESTRICTED_SETTINGS`), and `this.settings` is reassigned by every `newSession`/`loadSession`/`resumeSession` handler. So in a multi-workspace daemon, after workspace **B** (folder trust disabled) has any session activity, a `sessionCd` for a session admitted under workspace **A** (folder trust enabled) reads `isFolderTrustEnabled(this.settings.merged)` = B's value = `false`, skips the trust gate, and admits a `cd` into an untrusted directory. Folder trust is the guard against operating in directories the user hasn't trusted, so this is a trust-boundary bypass, not a cosmetic mix-up — and it persists until A's settings happen to be reloaded. `config.getFolderTrust()` is bound per workspace at admission (`config.ts:1376`), so it is definitionally the same predicate on the session's own workspace and pins the decision to the settings the session was created under. Full analysis and two disclosed related findings in #10469.

## Reviewer Test Plan

### How to verify

1. `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts` → 518/518. The new test `resolves the cd trust gate from the session workspace, not the stale this.settings cache` boots session A trust-enabled, then reassigns the agent's `this.settings` to a trust-disabled workspace (the cache-poisoning shape) and asserts a `cd` into an untrusted dir still throws `Directory not trusted`.
2. Mutation check: revert the gate to `isFolderTrustEnabled(this.settings.merged)` → that test fails (the untrusted `cd` is admitted); shipped code passes.
3. Existing `sessionCd` trust tests (`keeps ordinary cd subject to global folder trust`, the managed-relocation suite) still pass — the harness now mocks `Config.getFolderTrust` (default off; `bootRelocatableSession` reflects the fed workspace's `security.folderTrust.enabled`).

### Evidence (Before & After)

Probe from #10469 (production `loadSettingsCached` + `isFolderTrustEnabled`, two real `.qwen/settings.json`, no mocks):

```
Before (stale B cache):   gate enforced = false → untrusted cd ALLOWED
After  (session A's ws):  gate enforced = true  → untrusted cd REJECTED
```

No user-visible TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

### Environment (optional)

vitest from `packages/cli` on macOS (Darwin 25.4.0, Node 22); probe via `tsx`. Unit tests only.

## Risk & Scope

- Main risk or tradeoff: `config.getFolderTrust()` is a snapshot from session admission and is not refreshed by `relocateWorkingDirectory`. For a security gate that is the safer semantics (a session cannot `cd` into a trust-disabled workspace to relax its own gate), and it matches the workspace the session was created under — but it is a deliberate choice worth a reviewer's eye. `config.getFolderTrust()`'s JSDoc says "trusted" while the value is the feature-enabled flag; the value is correct, the doc is stale (noted for a separate cleanup).
- Not validated / out of scope: whether the gate should read `folderTrust.enabled` from user/system scope only (matching `settings.ts`/`daemon-trust-policy.ts`/`fast-path-settings.ts`) rather than merged — a security-policy decision disclosed in #10469; and the independent `config.ts:1377` cwd-less `isWorkspaceTrusted` finding, also in #10469. This PR fixes only the cross-workspace misrouting.
- Breaking changes / migration notes: none. Single-workspace daemons and workspaces without a folder-trust override are unaffected (same value either way).

## Linked Issues

Fixes #10469.

<details>
<summary>中文说明</summary>

**本 PR 做了什么**:让 `sessionCd` handler 的目录信任门改读 per-session 的 `config.getFolderTrust()`,而非 agent 进程级"最后加载"缓存 `this.settings`。生产改动一行,外加测试 harness 支持和一个回归测试。

**为什么需要**:`security.folderTrust.enabled` 是 per-workspace 可配置(不在 `WORKSPACE_RESTRICTED_SETTINGS`),`this.settings` 被每个 newSession/loadSession/resumeSession 刷新。多 workspace daemon 下,workspace B(未开信任)活动后,对在 workspace A(开信任)准入的 session 发 `sessionCd` 会读到 B 的 false → 跳过信任门 → 未信任目录 cd 被放行。folder trust 是防止在未信任目录操作的护栏,给错 session 关掉它是信任边界绕过,且持续到 A 的设置再次加载。`config.getFolderTrust()` 在准入时按 workspace 绑定(`config.ts:1376`),定义上就是该 session workspace 的同一判定,把决定钉在 session 创建时的 workspace。完整分析与两个相关发现见 #10469。

**验证**:`acpAgent.test.ts` 518/518;新测试 boot A(开信任)后把 `this.settings` 换成关信任的 workspace,断言未信任 cd 仍抛 `Directory not trusted`;变异验证:改回 `this.settings` 则未信任 cd 被放行。现有 sessionCd 信任测试仍全过(harness 现 mock `Config.getFolderTrust`,默认关,bootRelocatableSession 反映所喂 workspace)。Before/After 探针:读 B 缓存门 enforced=false → 放行;读 A workspace 门 enforced=true → 拒绝。macOS 已测,Windows/Linux 交 CI。

**风险与范围**:`config.getFolderTrust()` 是准入时快照,relocate 不刷新——对安全门是更安全的语义(cd 不能放松自己的门),但是刻意选择。JSDoc 说"trusted"而值是 feature-enabled flag,值正确、文档过时(另行清理)。不在范围:门是否应只读 user/system scope(#10469 的安全策略决策);`config.ts:1377` 漏传 cwd 的独立发现(也在 #10469)。无破坏性变更。

**关联**:Fixes #10469。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
