### PR TITLE
fix(serve): advertise the native directory picker during bootstrap

### DIFF
--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -34,6 +34,7 @@ import {
   waitForRuntimeStartingForShutdown,
 } from './run-qwen-serve.js';
 import { isBrowserAutomationMcpAvailable } from './cdp-mcp-command.js';
+import * as nativeDirectoryPicker from './native-directory-picker.js';
 import { loadServeFastPathEnvironment } from './fast-path-settings.js';
 import { loadEnvironment } from '../config/environment.js';
 import { RUNTIME_STARTUP_CANCELLED_MESSAGE } from './runtime-startup-errors.js';
@@ -10614,6 +10615,61 @@ describe('runQwenServe runtime startup failures', () => {
       mockTotalMemBytes.value = undefined;
     }
   });
+
+  it.each([true, false])(
+    'mirrors the native directory picker probe on the bootstrap envelopes (available: %s)',
+    async (available) => {
+      tmpDir = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), 'qws-bootstrap-picker-')),
+      );
+      // Keep the runtime from mounting so the bootstrap `/capabilities` and
+      // `/daemon/status` envelopes stay the ones being served.
+      vi.spyOn(acpBridge, 'createAcpSessionBridge').mockImplementation(() => {
+        throw new Error('runtime boom');
+      });
+      const probe = vi
+        .spyOn(nativeDirectoryPicker, 'isNativeDirectoryPickerAvailable')
+        .mockReturnValue(available);
+      const handle = await runQwenServe(
+        {
+          port: 0,
+          hostname: '127.0.0.1',
+          mode: 'http-bridge',
+          workspace: tmpDir,
+          maxSessions: 1,
+          serveWebShell: false,
+        },
+        { resolveOnListen: true },
+      );
+      try {
+        await expect(handle.runtimeReady).rejects.toThrow('runtime boom');
+        const probeCallsAfterBoot = probe.mock.calls.length;
+        const capabilities = (await (
+          await fetch(`${handle.url}/capabilities`)
+        ).json()) as { features: string[] };
+        const status = (await (
+          await fetch(`${handle.url}/daemon/status`)
+        ).json()) as { capabilities: { features: string[] } };
+        if (available) {
+          expect(capabilities.features).toContain('native_directory_picker');
+          expect(status.capabilities.features).toContain(
+            'native_directory_picker',
+          );
+        } else {
+          expect(capabilities.features).not.toContain(
+            'native_directory_picker',
+          );
+          expect(status.capabilities.features).not.toContain(
+            'native_directory_picker',
+          );
+        }
+        // Probed once while the bootstrap app was built, not per request.
+        expect(probe.mock.calls.length).toBe(probeCallsAfterBoot);
+      } finally {
+        await handle.close();
+      }
+    },
+  );
 
   it('shuts down a bridge when runtime mounting fails after bridge creation', async () => {
     tmpDir = fs.realpathSync(

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -112,6 +112,7 @@ import {
   getServeProtocolVersions,
   SERVE_CAPABILITY_REGISTRY,
 } from './capabilities.js';
+import { isNativeDirectoryPickerAvailable } from './native-directory-picker.js';
 import {
   EXTERNAL_TOOL_GUARD_PROVIDER_ATTACHED_VALUE,
   EXTERNAL_TOOL_GUARD_REQUIRED_VALUE,
@@ -2289,6 +2290,7 @@ function currentServeFeaturesForRunQwenServe(
   sessionArtifactsPersistenceAvailable: boolean,
   currentSessionSchedulingAvailable: boolean,
   env: Readonly<Record<string, string | undefined>>,
+  nativeDirectoryPickerAvailable: boolean,
 ): string[] {
   return getAdvertisedServeFeatures(undefined, {
     requireAuth: opts.requireAuth === true,
@@ -2315,8 +2317,10 @@ function currentServeFeaturesForRunQwenServe(
     channelManagementAvailable: true,
     persistentWorkspaceRegistrationAvailable: true,
     workspaceRuntimeRemovalAvailable: true,
-    // Advertise the same WS feature flags as the runtime path (serve-features.ts)
-    // so the bootstrap `/capabilities` window doesn't briefly under-report them.
+    // Advertise the same host-conditional and WS feature flags as the runtime
+    // path (serve-features.ts) so the bootstrap `/capabilities` window doesn't
+    // briefly under-report them.
+    nativeDirectoryPickerAvailable,
     clientMcpOverWsEnabled: opts.clientMcpOverWs === true,
     cdpTunnelOverWsEnabled: opts.cdpTunnelOverWs === true,
     browserAutomationMcpAvailable: isBrowserAutomationMcpAvailable(opts, env),
@@ -2332,6 +2336,7 @@ function createBootstrapCapabilities(input: {
   currentSessionSchedulingAvailable: boolean;
   permissionPolicy: PermissionPolicy | undefined;
   env: Readonly<Record<string, string | undefined>>;
+  nativeDirectoryPickerAvailable: boolean;
 }): CapabilitiesEnvelope {
   return {
     v: CAPABILITIES_SCHEMA_VERSION,
@@ -2346,6 +2351,7 @@ function createBootstrapCapabilities(input: {
       input.sessionArtifactsPersistenceAvailable,
       input.currentSessionSchedulingAvailable,
       input.env,
+      input.nativeDirectoryPickerAvailable,
     ),
     modelServices: [],
     workspaceCwd: input.boundWorkspace,
@@ -2566,6 +2572,11 @@ function createBootstrapServeApp(input: {
     onHealthServed,
   } = input;
   const app = express();
+  // The probe stats `/dev/console` (macOS) or scans `PATH` for `zenity`
+  // (Linux), and both bootstrap endpoints below rebuild their envelope per
+  // request, so evaluate it once here — the runtime path likewise probes once,
+  // at `createApp` time (server.ts).
+  const nativeDirectoryPickerAvailable = isNativeDirectoryPickerAvailable();
 
   installSameOriginOriginStrip(app, getPort);
   if (opts.allowOrigins && opts.allowOrigins.length > 0) {
@@ -2626,6 +2637,7 @@ function createBootstrapServeApp(input: {
         currentSessionSchedulingAvailable,
         permissionPolicy,
         env: process.env,
+        nativeDirectoryPickerAvailable,
       }),
     );
   });
@@ -2765,6 +2777,7 @@ function createBootstrapServeApp(input: {
           sessionArtifactsPersistenceAvailable,
           currentSessionSchedulingAvailable,
           process.env,
+          nativeDirectoryPickerAvailable,
         ),
       },
       runtime: {


### PR DESCRIPTION
## What this PR does

The fast-path bootstrap envelopes (`GET /capabilities` and the `capabilities.features` block of `GET /daemon/status`, both served until the runtime mounts) now advertise `native_directory_picker`, probed once while the bootstrap app is built.

## Why it's needed

#9406 made `native_directory_picker` host-conditional, but wired the probe only into the runtime path — `createApp` → `createServeFeatures` (`server.ts` / `server/serve-features.ts`). The bootstrap builder `currentServeFeaturesForRunQwenServe` never set the toggle, so the bootstrap window omitted the tag unconditionally, whatever the host's GUI state.

Two consequences:

1. **Product:** a client that reads `/capabilities` inside the bootstrap window hides the workspace **Browse** affordance (`web-shell/client/App.tsx` gates on this tag) on a host that can in fact open the native picker. The daemon takes ~1.5s here to swap in the runtime envelope, and the Web Shell reads capabilities on connect, so the window is real, not theoretical.
2. **CI:** `E2E Test - macOS - shard 2/2` has been red on every `main` push since #9406 landed — first red run is #9406's own push run (33223243993), green immediately before it. The capabilities-envelope E2E derives its expectation from the same probe and lands inside the bootstrap window, so the expectation gains a tag the bootstrap envelope can never carry. macOS is the only E2E lane where the probe returns true (Linux runners have no `DISPLAY`/`zenity`; there is no Windows E2E lane), which is why the failure is macOS-only.

This is the same class of gap the neighbouring comment in that function already guards against for the WS flags ("so the bootstrap `/capabilities` window doesn't briefly under-report them").

Fixes the E2E failures tracked in #10450 and #10453.

## Evidence

**The macOS-only failure reproduces on Linux** once the host satisfies the probe's Linux branch (`DISPLAY` set + an executable `zenity` on `PATH`). Same bundle, same test, before the fix:

```
AssertionError: expected [ 'health', 'daemon_status', …(116) ] to deeply equal [ 'health', 'daemon_status', …(117) ]
-   "native_directory_picker",
    "workspace_qualified_rest_core",
```

byte-for-byte the macOS CI diff. After the fix: `37 passed (37)` with the fake GUI, and `37 passed (37)` headless (the Linux CI shape), so neither host shape regresses.

**The bootstrap window is what the E2E reads.** Polling a real bundled daemon every 500 ms from `listening` (fake GUI host):

```
+30ms    x3   200  118 features  -      -        -       -
+1599ms  x37  200  125 features  picker dynamic  scratch sched
```

The 118-feature envelope carries neither `native_directory_picker` nor `dynamic_workspace_registration` / `scratch_workspace_registration` — that is the bootstrap envelope, and 118 is exactly the count CI reports as received. The runtime envelope (125) already advertised the picker correctly, which is why this only ever showed up as a bootstrap-window bug.

**Unit RED/GREEN.** The new `it.each([true, false])` case fails on `main` with `expected [ … ] to include 'native_directory_picker'` for the `available: true` arm and passes for `available: false`; both arms pass with the fix. It also asserts the probe is not re-run per request, since `/dev/console` stat + `PATH` scan used to sit on the hot path of every bootstrap capabilities/status call.

## Relation to #10456

#10456 targets the same red lane but reads the cause as probe *timing drift* — the test re-probing at assertion time while the daemon probed at boot — and moves the test-side probe to daemon spawn time. In the repro above both probes run in the same process, on the same host, seconds apart, and agree; the failure persists, because the bootstrap envelope omits the tag no matter when either side probes. So the test-side change alone leaves the lane red, and the daemon keeps under-reporting the capability to real clients. Happy to close mine if the author prefers to fold this into theirs — the production hunk is what matters.

## Reviewer Test Plan

Unit (no build needed):

```bash
cd packages/cli
npx vitest run src/serve/run-qwen-serve.test.ts -t "mirrors the native directory picker probe"
npx vitest run src/serve/run-qwen-serve.test.ts src/serve/server.test.ts   # 357 + 1103 pass
```

E2E with a GUI-capable host shape (reproduces the macOS lane on Linux):

```bash
npm run bundle
mkdir -p /tmp/fakebin && printf '#!/bin/sh\nexit 1\n' > /tmp/fakebin/zenity && chmod +x /tmp/fakebin/zenity
DISPLAY=:0 PATH=/tmp/fakebin:$PATH npx vitest run --root ./integration-tests cli/qwen-serve-routes.test.ts
```

Revert the `run-qwen-serve.ts` hunk and both commands go red on the picker assertion.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

fast-path bootstrap 的两个 envelope（runtime 挂载前对外服务的 `GET /capabilities` 和 `GET /daemon/status` 里的 `capabilities.features`）现在会带上 `native_directory_picker`，探针在 bootstrap app 构建时只算一次。

## 为什么需要

#9406 把 `native_directory_picker` 改成随宿主 GUI 环境决定，但只接到了 runtime 那条链路（`createApp` → `createServeFeatures`）。bootstrap 的构造器 `currentServeFeaturesForRunQwenServe` 从来不设这个开关，所以 bootstrap 窗口无论宿主是什么状态都不会带这个 tag。

两个后果：

1. **产品层面**：在 bootstrap 窗口读 `/capabilities` 的客户端，会在一台其实能弹出原生选择器的机器上把 workspace **Browse** 入口藏掉（`web-shell/client/App.tsx` 就是按这个 tag 判断的）。本机实测这个窗口约 1.5 秒，而 Web Shell 正是在连接时读 capabilities，所以窗口是真实存在的。
2. **CI 层面**：自 #9406 合入起，`main` 每次 push 的 `E2E Test - macOS - shard 2/2` 都是红的 —— 第一次红就是 #9406 自己的 push run（33223243993），之前一次是绿的。那条 capabilities E2E 的期望值来自同一个探针，而请求落在 bootstrap 窗口内，于是期望里多出一个 bootstrap envelope 永远给不出的 tag。macOS 是 E2E 里唯一探针为 true 的 lane（Linux runner 没有 `DISPLAY`/`zenity`，也没有 Windows E2E lane），所以只有 macOS 挂。

这跟该函数里已有的那条注释所防的是同一类问题（"so the bootstrap `/capabilities` window doesn't briefly under-report them"）。

修复 #10450、#10453 追踪的 E2E 失败。

## 证据

**这个"只在 macOS 出现"的失败可以在 Linux 上复现**：只要让宿主满足探针的 Linux 分支（设 `DISPLAY` + `PATH` 上有可执行的 `zenity`）。同一个 bundle、同一个测试，修复前的 diff 与 macOS CI 逐字一致；修复后：假 GUI 下 `37 passed (37)`，无头（Linux CI 形态）下同样 `37 passed (37)`。

**E2E 读到的确实是 bootstrap envelope**：对真实 bundled daemon 从 `listening` 开始每 500ms 轮询一次，`+30ms` 起是 118 个 feature（无 picker / dynamic / scratch），`+1599ms` 起变成 125 个（都有）。118 正是 CI 报告的 received 数量。runtime envelope 本来就正确带了 picker，所以这只是 bootstrap 窗口的漏配。

**单测 RED/GREEN**：新增的 `it.each([true, false])` 在 `main` 上 `available: true` 那条会挂（`to include 'native_directory_picker'`），`available: false` 通过；打上修复后两条都过。同时断言探针不会每请求重算 —— 以前 `/dev/console` stat 和 `PATH` 扫描落在每次 bootstrap capabilities/status 请求的热路径上。

## 与 #10456 的关系

#10456 针对的是同一条红 lane，但把原因判成探针的**时序漂移**（测试在断言时重新探测，daemon 在启动时探测），改法是把测试侧探针挪到 daemon spawn 时。而在上面的复现里，两侧探针在同一进程、同一宿主、相隔几秒、结果一致，失败照旧 —— 因为无论谁在什么时候探测，bootstrap envelope 都不带这个 tag。所以只改测试侧，lane 仍然是红的，daemon 也仍然在对真实客户端少报这个能力。如果作者更愿意把这个改动并进 #10456，我这边关掉也没问题 —— 关键是产品代码那一处。

## 评审验证步骤

见上方英文命令。把 `run-qwen-serve.ts` 的改动回退掉，两条命令都会在 picker 断言处变红。

</details>
