### PR TITLE
test(sdk-java): close the connection on body-less fixture responses

### DIFF
--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/daemon/DaemonSessionClientTest.java
@@ -261,14 +261,10 @@ class DaemonSessionClientTest {
         CountDownLatch cancelReceived = new CountDownLatch(1);
         server.createContext("/session/session-1/cancel", exchange -> {
             cancelReceived.countDown();
-            exchange.getResponseHeaders().set("Connection", "close");
-            exchange.sendResponseHeaders(204, -1);
-            exchange.close();
+            sendNoContent(exchange, 204);
         });
-        server.createContext("/session/session-1/detach",
-                noContentAndCloseConnection());
-        server.createContext("/session/session-2/detach",
-                noContentAndCloseConnection());
+        server.createContext("/session/session-1/detach", noContent());
+        server.createContext("/session/session-2/detach", noContent());
 
         try (DaemonClient daemon = newClient();
                 DaemonSessionClient first = daemon.createSession()) {
@@ -312,8 +308,7 @@ class DaemonSessionClientTest {
             detachedClient.set(exchange.getRequestHeaders()
                     .getFirst("X-Qwen-Client-Id"));
             detachReceived.countDown();
-            exchange.sendResponseHeaders(204, -1);
-            exchange.close();
+            sendNoContent(exchange, 204);
         });
 
         DaemonClient daemon = newClient();
@@ -631,8 +626,7 @@ class DaemonSessionClientTest {
             } else if (attempt == 2) {
                 exchange.getResponseHeaders().set("Content-Type",
                         "text/event-stream");
-                exchange.sendResponseHeaders(200, -1);
-                exchange.close();
+                sendNoContent(exchange, 200);
             } else {
                 sendSse(exchange, terminalEvent(1));
             }
@@ -1068,10 +1062,8 @@ class DaemonSessionClientTest {
         server.createContext("/session/session-1/prompt", exchange ->
                 sendJson(exchange, 202,
                         "{\"promptId\":\"prompt-1\",\"lastEventId\":0}"));
-        server.createContext("/session/session-1/events", exchange -> {
-            exchange.sendResponseHeaders(204, -1);
-            exchange.close();
-        });
+        server.createContext("/session/session-1/events", exchange ->
+                sendNoContent(exchange, 204));
         server.createContext("/session/session-1/detach", noContent());
 
         try (DaemonClient daemon = newClient();
@@ -1217,8 +1209,7 @@ class DaemonSessionClientTest {
         });
         server.createContext("/session/session-1/cancel", exchange -> {
             cancels.incrementAndGet();
-            exchange.sendResponseHeaders(204, -1);
-            exchange.close();
+            sendNoContent(exchange, 204);
         });
         server.createContext("/session/session-1/detach", noContent());
 
@@ -1629,8 +1620,7 @@ class DaemonSessionClientTest {
         server.createContext("/session/session-1", exchange -> {
             if ("DELETE".equals(exchange.getRequestMethod())) {
                 deletes.incrementAndGet();
-                exchange.sendResponseHeaders(204, -1);
-                exchange.close();
+                sendNoContent(exchange, 204);
                 return;
             }
             sendJson(exchange, 404, "{}");
@@ -1908,8 +1898,7 @@ class DaemonSessionClientTest {
                 sendSse(exchange, terminalEvent(1)));
         server.createContext("/session/session-1/detach", exchange -> {
             detaches.incrementAndGet();
-            exchange.sendResponseHeaders(204, -1);
-            exchange.close();
+            sendNoContent(exchange, 204);
         });
 
         try (DaemonClient daemon = newClient()) {
@@ -2277,8 +2266,7 @@ class DaemonSessionClientTest {
                     sendSse(exchange, terminalEventForSession(1, sessionId)));
             server.createContext("/session/" + sessionId + "/cancel", exchange -> {
                 mutationRequests.incrementAndGet();
-                exchange.sendResponseHeaders(204, -1);
-                exchange.close();
+                sendNoContent(exchange, 204);
             });
             server.createContext("/session/" + sessionId + "/heartbeat", exchange -> {
                 mutationRequests.incrementAndGet();
@@ -2295,8 +2283,7 @@ class DaemonSessionClientTest {
                 detachingSession.compareAndSet(null, sessionId);
                 detachStarted.countDown();
                 await(releaseDetach);
-                exchange.sendResponseHeaders(204, -1);
-                exchange.close();
+                sendNoContent(exchange, 204);
             });
         }
 
@@ -2946,18 +2933,24 @@ class DaemonSessionClientTest {
     }
 
     private static HttpHandler noContent() {
-        return exchange -> {
-            exchange.sendResponseHeaders(204, -1);
-            exchange.close();
-        };
+        return exchange -> sendNoContent(exchange, 204);
     }
 
-    private static HttpHandler noContentAndCloseConnection() {
-        return exchange -> {
-            exchange.getResponseHeaders().set("Connection", "close");
-            exchange.sendResponseHeaders(204, -1);
-            exchange.close();
-        };
+    /**
+     * Sends a body-less response and ends the connection with it. On Java 11
+     * the JDK's own HTTP server drops the connection after a response that
+     * carries no body, while the Java 11 HttpClient keeps that same connection
+     * in its pool; whichever request reuses it next reads EOF before any
+     * response byte and fails with "HTTP/1.1 header parser received no bytes".
+     * Marking these responses non-persistent keeps the client from pooling a
+     * connection the fixture is about to drop. Newer JDKs do this in neither
+     * role, and neither does the daemon the fixture stands in for.
+     */
+    private static void sendNoContent(HttpExchange exchange, int status)
+            throws IOException {
+        exchange.getResponseHeaders().set("Connection", "close");
+        exchange.sendResponseHeaders(status, -1);
+        exchange.close();
     }
 
     private static void sendJson(HttpExchange exchange, int status, String body)


### PR DESCRIPTION
## What this PR does

Every body-less response in the daemon client test fixture now ends its connection along with the response, through one shared helper. That helper absorbs the one-off "close the connection" variant added for a single test's detach handlers in #10365, and the ten body-less responses that were written out by hand elsewhere in the fixture now go through it too.

## Why it's needed

The Java 11 lane of SDK Java fails intermittently, and always the same way: a test tears its session down, and the detach or destroy call raises `DetachOutcomeUnknownException` / `MutationOutcomeUnknownException` wrapping `HTTP/1.1 header parser received no bytes`. Over the last day alone it has hit three different test methods on three unrelated branches — the backpressure test on this week's web-shell branch, the destroy-after-detach test twice, and the heartbeat fairness test — a fourth reproduces locally, and #10365 patched a fifth two days ago. The same runs stay green on Java 17, Java 21, macOS and Windows.

The cause is the fixture, not the SDK. On Java 11 the JDK's own HTTP server drops the TCP connection after it answers with no body at all, which is what a 204 detach, a 204 cancel, a 204 session delete and an empty event stream all do here. The Java 11 HttpClient keeps that same connection in its pool regardless, so the next request the SDK sends over it reads EOF before a single response byte arrives. Because that request is a non-idempotent mutation, the SDK deliberately does not retry it and reports the outcome as unknown — correct behaviour, reached for a reason that only exists inside the test fixture.

Pairing the two halves across JDKs confirms both of them have to be Java 11 for this to happen: a Java 11 server with a Java 21 client never fails, and neither does a Java 21 server with a Java 11 client. The daemon the SDK actually talks to is the Node serve process, so nothing outside these tests is exposed, and newer JDKs are unaffected in both roles.

Marking these responses non-persistent removes the race outright — the client is told the connection is finished, so it never pools a connection the fixture is about to drop. That is what #10365 did for two handlers; this change applies it wherever the fixture answers without a body, so the next body-less response added to the fixture cannot reintroduce the flake.

## Reviewer Test Plan

### How to verify

Run the daemon client tests on Java 11, repeatedly and pinned to a single core so the race has room to land: `taskset -c 2 mvn --batch-mode --no-transfer-progress clean test` from `packages/sdk-java/qwencode`, or drive the three most affected test methods in a loop through the JUnit launcher. Before the change the teardown failures reproduce within a handful of rounds; after it they stop. A reviewer only wants to see the suite stay green and the loop stop failing — no behaviour of the SDK changes.

### Evidence (Before & After)

Java 11 (Temurin 11.0.32.1), same machine, each row run identically before and after:

| Harness | Before | After |
| --- | --- | --- |
| 200 rounds of the three test methods seen failing in CI, pinned to one core | 50 rounds failed | 0 rounds failed |
| 12 full runs of the test class, pinned to two cores | 1 run failed | 0 runs failed |
| Full module suite, 129 tests | green | green |

One core is what makes this land quickly; on two cores the class-level loop only fails every dozen runs, which is roughly the rate CI shows.

Failure signature before the change, identical to CI: `DetachOutcomeUnknownException: POST /session/:id/detach may have reached the daemon; the SDK did not retry it`, caused by `HTTP/1.1 header parser received no bytes`.

Cross-JDK pairing of a body-less response followed by a POST, 150 iterations each: Java 11 server + Java 11 client — 48 failures; Java 11 server + Java 21 client — 0; Java 21 server + Java 11 client — 0; Java 21 both — 0.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️ not tested  |
| 🪟 Windows |  ⚠️ not tested  |
|  🐧 Linux  |  ✅ tested  |

### Environment (optional)

Temurin 11.0.32.1 and Maven 3.9, unit tests only.

## Risk & Scope

- Main risk or tradeoff: the fixture no longer keeps a connection alive across a body-less response, so the tests exercise one TCP connection per request in those spots. Nothing asserted connection reuse, and the SDK path under test is unchanged. The extra connections cost nothing measurable — five full runs of the class took 81.6s before and 82.7s after.
- Not validated / out of scope: the Java 17 and Java 21 lanes were not stressed locally — they never reproduced this — and the SDK itself is untouched.
- Seen while verifying, unrelated: the Java 21 lane failed once on this PR's first run in a different spot, the one-second latch in the stopped-prompt observer test, on a runner where the class took 30s instead of the usual 21s; it passed on re-run, that assertion is reached before any body-less response comes into play, and 60 local rounds of it failed in neither arm. A separate slow-runner flake, not this one.
- Breaking changes / migration notes: none, test-only change.

## Linked Issues

Follow-up to #10365, which fixed the same failure for two handlers of one test.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

daemon 客户端测试夹具里所有"无响应体"的返回，现在都通过同一个辅助方法在响应的同时结束连接。该辅助方法吸收了 #10365 为某个测试的两个 detach handler 单独加的"关闭连接"变体，夹具里另外十处手写的无响应体返回也一并改为走它。

## 为什么需要

SDK Java 的 Java 11 lane 会间歇性失败，而且失败形态始终一样：测试在拆除 session 时，detach 或 destroy 调用抛出 `DetachOutcomeUnknownException` / `MutationOutcomeUnknownException`，内层是 `HTTP/1.1 header parser received no bytes`。仅最近一天，它就在三个互不相关的分支上命中了三个不同的测试方法——backpressure 测试、destroy-after-detach 测试（两次）、heartbeat 公平性测试；第四个在本地可以复现，而 #10365 两天前刚修过第五个。同一次 run 里 Java 17、Java 21、macOS 和 Windows 都是绿的。

根因在夹具，不在 SDK。Java 11 上 JDK 自带的 HTTP server 在回复一个完全没有响应体的响应之后会断掉 TCP 连接，而这里的 204 detach、204 cancel、204 session delete 和空事件流全都是这种响应。Java 11 的 HttpClient 却仍然把这条连接留在连接池里，于是 SDK 下一个复用它的请求还没读到任何响应字节就先读到 EOF。由于该请求是非幂等的 mutation，SDK 按设计不重试，只报告结果未知——行为本身是对的，只是触发它的原因只存在于测试夹具中。

把 server 和 client 两端跨 JDK 组合可以确认必须两端都是 Java 11 才会复现：Java 11 server 配 Java 21 client 不会失败，Java 21 server 配 Java 11 client 同样不会。SDK 真正对接的 daemon 是 Node 的 serve 进程，所以这些测试之外不受影响，更高版本的 JDK 在两个角色上都不受影响。

把这些响应标记为非持久连接可以直接消除竞态——客户端被告知连接已结束，就不会再去复用一条夹具马上要断掉的连接。#10365 对两个 handler 做的正是这件事；本次改动把它推广到夹具中所有无响应体的返回，这样以后新增的无响应体返回也不会把这个 flake 带回来。

## 评审验证计划

### 如何验证

在 Java 11 上反复跑 daemon 客户端测试，并绑定到单核以便竞态有机会出现：在 `packages/sdk-java/qwencode` 下执行 `taskset -c 2 mvn --batch-mode --no-transfer-progress clean test`，或者用 JUnit launcher 循环驱动受影响最多的那三个测试方法。改动前，拆除阶段的失败几轮之内就会复现；改动后不再出现。评审只需确认测试套件保持绿色、循环不再失败——SDK 的行为没有任何变化。

### 证据（改动前后）

Java 11（Temurin 11.0.32.1），同一台机器，每一行在改动前后用完全相同的方式运行：

| 手法 | 改动前 | 改动后 |
| --- | --- | --- |
| CI 中失败过的三个测试方法跑 200 轮，绑定到单核 | 50 轮失败 | 0 轮失败 |
| 整个测试类跑 12 次完整测试，绑定到双核 | 1 次失败 | 0 次失败 |
| 整个模块测试套件，129 个测试 | 绿 | 绿 |

绑定到单核才能让问题快速复现；双核下类级别的循环大约每十几次才失败一次，与 CI 上观察到的频率接近。

改动前的失败签名与 CI 完全一致：`DetachOutcomeUnknownException: POST /session/:id/detach may have reached the daemon; the SDK did not retry it`，起因是 `HTTP/1.1 header parser received no bytes`。

"无响应体响应 + 随后一个 POST"的跨 JDK 组合各跑 150 次：Java 11 server + Java 11 client——48 次失败；Java 11 server + Java 21 client——0；Java 21 server + Java 11 client——0；两端 Java 21——0。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  ⚠️ 未测试  |
| 🪟 Windows |  ⚠️ 未测试  |
|  🐧 Linux  |  ✅ 已测试  |

### 环境（可选）

Temurin 11.0.32.1 与 Maven 3.9，仅单元测试。

## 风险与范围

- 主要风险或取舍：夹具在无响应体的返回处不再保持连接存活，这些位置变成每个请求一条 TCP 连接。原本没有任何断言依赖连接复用，被测的 SDK 代码路径也没有变化。多出来的连接开销可以忽略——整个测试类连跑五轮，改动前 81.6s，改动后 82.7s。
- 未验证 / 不在范围内：Java 17 与 Java 21 lane 未在本地做压力测试——它们从未复现过该问题；SDK 本身未做改动。
- 验证过程中遇到的无关现象：本 PR 第一次 CI 运行时 Java 21 lane 在另一个位置失败了一次——stopped-prompt observer 测试里那个 1 秒的 latch，当时该测试类在那台 runner 上跑了 30s 而非通常的 21s；重跑即通过。该断言在任何无响应体的返回参与之前就已到达，本地跑 60 轮在改动前后两侧都没有失败。这是另一个与慢 runner 有关的 flake，与本次问题无关。
- 破坏性变更 / 迁移说明：无，纯测试改动。

## 关联 Issue

是 #10365 的后续，该 PR 为某个测试的两个 handler 修复了同一个问题。

</details>
