### PR TITLE
docs(ci): explain why the review-pr sweep needs a whole-workspace quarantine

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -578,9 +578,12 @@ jobs:
             if [ -d "$stale_qwen" ] && [ ! -L "$stale_qwen" ]; then
               chmod -R u+w "$stale_qwen" 2>/dev/null || true
             fi
-            # If a foreign-owned directory cannot move to a different parent,
-            # quarantine the runner-owned workspace and recreate the checkout
-            # root. Warm contents are lost only on this unrecoverable path.
+            # A foreign-owned directory cannot always be renamed to a
+            # different parent: updating its .. entry can fail even when the
+            # workspace parent is writable. If that individual move fails,
+            # quarantine the runner-owned workspace itself, then recreate the
+            # empty checkout root. Warm contents are lost only on this
+            # otherwise unrecoverable path.
             rm -rf -- "$stale_qwen" 2>/dev/null ||
               sudo -n rm -rf -- "$stale_qwen" 2>/dev/null ||
               {


### PR DESCRIPTION
## What this PR does

Rewrites the comment above the quarantine fallback in the `review-pr` job's
`Clean stale .qwen before checkout` step. Comment only, zero executable lines
change.

## Why it's needed

I opened this against #10392 by mistake. The sweep that issue asks for is
already on `main`: #10214 (commit `379bef96`) added it to this workflow along
with the `cleanIdx < checkoutIdx` pin in
`scripts/tests/review-worktree-cleanup-workflow.test.js`, even though its
description said it was scoped to `ci.yml`. Nothing here changes behaviour, so
the `Fixes` link is gone and #10392 should be closed against #10214 instead.

What's left is still worth keeping on its own. The old comment stated the
fallback but not the reason it exists:

```
# If a foreign-owned directory cannot move to a different parent,
# quarantine the runner-owned workspace and recreate the checkout
# root. Warm contents are lost only on this unrecoverable path.
```

Reading that, the fallback looks redundant, since the `mv` right above it
already targets a writable parent. The missing piece is that renaming a
directory across parents also needs write permission on the directory being
moved, because the kernel has to update its `..` entry. For a root-owned
`.qwen.root-orig` the runner does not have that, and the preceding
`chmod -R u+w` cannot grant it either, so the individual `mv` fails with
`EACCES` even though the workspace parent is perfectly writable. That is the
case the whole-workspace quarantine exists to catch, and it was not obvious
from the code.

## Reviewer Test Plan

### How to verify

Read the diff. It touches `#` lines only. The comment-stripped `run:` body is
byte-identical to `main`:

```
git numstat main..HEAD -> 6 3 .github/workflows/qwen-code-pr-review.yml
```

### Evidence (Before & After)

N/A (comment-only change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: None. No executable line changes.
- Not validated / out of scope: The sweep's runtime behaviour, unchanged here and covered by the existing structural test.
- Breaking changes / migration notes: None

## Linked Issues

None. The actual fix for #10392 shipped in #10214.

<details>
<summary>中文说明</summary>

仅改写 `review-pr` 任务中 `Clean stale .qwen before checkout` 步骤里 quarantine
兜底逻辑上方的注释，无任何可执行行变化。

本 PR 最初错误地关联了 #10392。该 issue 要求的清理逻辑其实已经在 `main` 上
（#10214，commit `379bef96`），因此已移除 `Fixes` 关联，#10392 应改为指向
#10214 关闭。

保留注释改写的理由：旧注释只说明了兜底行为，没有说明它为何存在。关键点在于，
跨父目录重命名目录还需要对被移动目录本身有写权限（内核需更新其 `..` 项）。
对 root 所有的 `.qwen.root-orig`，runner 不具备该权限，前面的 `chmod -R u+w`
也无法赋予，因此即使工作区父目录可写，单独的 `mv` 仍会以 `EACCES` 失败。这正是
整体工作区 quarantine 所要处理的场景，而这一点从代码中并不显而易见。

</details>
