### PR TITLE
fix(review): resolve branch-based Aone MR heads

### DIFF
--- a/docs/design/2026-08-15-review-aone-provider.md
+++ b/docs/design/2026-08-15-review-aone-provider.md
@@ -104,7 +104,9 @@ semantics (head-drift refusal, partial-post reporting, host binding).
   from the exact MR ref only after the cwd `origin` is proven to be the target
   Aone repository. Clone-less reads report the SHA as unavailable, while
   presubmit/comment-status and posting fail closed when a known branch cannot
-  be resolved.
+  be resolved. The `fetch-pr --remote` override may name another fetch remote,
+  but branch-head identity remains origin-bound; the target Aone repository
+  must therefore be configured as `origin` for branch-based MRs.
 
 ## Files affected
 

--- a/docs/design/2026-08-15-review-aone-provider.md
+++ b/docs/design/2026-08-15-review-aone-provider.md
@@ -11,17 +11,17 @@ is the motivating target. This phase adds the Aone read path so a local review
 of an Aone CR works end to end (diff + worktree + issue evidence + agent
 findings), and `--comment` on an Aone target refuses cleanly.
 
-## Verified platform facts (re-confirmed 2026-08-15 against `maxcompute/odps_src`)
+## Verified platform facts (re-confirmed 2026-08-29 across both Aone MR flows)
 
-| Capability     | a1 CLI / git                                                                                                                                  | Notes                                                                                                                                                                                                      |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| MR metadata    | `a1 repo mr view <global-id> --repo <g/p> -f json` → `mergeRequest{sourceBranch, targetBranch, title, description, detailUrl, author, state}` | `sourceBranch` is the head SHA (AGit-Flow); `targetBranch` is base; `detailUrl` = `https://code.alibaba-inc.com/<g>/<p>/codereview/<global-id>`; **no** additions/deletions/changedFiles (compute locally) |
-| Fetch ref      | `git fetch <remote> refs/merge-requests/<global-id>/head:<ref>`                                                                               | head SHA matches `sourceBranch`; merge-base vs `targetBranch` and `git diff` both computable (probe: MR 29295886 → 51 files, 2930+/114-)                                                                   |
-| id/iid         | `mr view`/`mr list` carry both `id` (global) and `iid`                                                                                        | refs/`mr view` key on the **global id**; Aone CR URL is `/codereview/<global-id>`                                                                                                                          |
-| Discussion     | `a1 repo mr comment list --mr <id> --repo <g/p> -f json` → array with `id, note, path, line, author, closed, outdated, isAiComment`           | **text is in `note`** (not `body`); `body` is empty                                                                                                                                                        |
-| Issue evidence | `a1 repo mr workitem list --mr <id>` → `[{id, subject, link, assigned_to}]`; `a1 project workitem get <id>` for body/comments                 | workitem id = the `#AONE_ID` in the commit title                                                                                                                                                           |
-| Diff listing   | `a1 repo mr diff <id>` (file list) / `<id> <file>` (per-file)                                                                                 | only needed in lightweight mode; the primary path diffs via git after fetching the ref                                                                                                                     |
-| CI status      | `a1 repo mr status <id>`                                                                                                                      | presubmit-equivalent (read-only)                                                                                                                                                                           |
+| Capability     | a1 CLI / git                                                                                                                                  | Notes                                                                                                                                                                                                 |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MR metadata    | `a1 repo mr view <global-id> --repo <g/p> -f json` → `mergeRequest{sourceBranch, targetBranch, title, description, detailUrl, author, state}` | `sourceBranch` is the full head SHA under AGit-Flow but a branch name under branch-based flow; there is no separate pre-merge head-SHA field. `targetBranch` is base; **no** diff stats are reported. |
+| Fetch ref      | `git fetch <remote> refs/merge-requests/<global-id>/head:<ref>`                                                                               | The exact MR ref is authoritative in both flows. A verified target clone can resolve it with `git ls-remote`; merge-base vs `targetBranch` and `git diff` are computable.                             |
+| id/iid         | `mr view`/`mr list` carry both `id` (global) and `iid`                                                                                        | refs/`mr view` key on the **global id**; Aone CR URL is `/codereview/<global-id>`                                                                                                                     |
+| Discussion     | `a1 repo mr comment list --mr <id> --repo <g/p> -f json` → array with `id, note, path, line, author, closed, outdated, isAiComment`           | **text is in `note`** (not `body`); `body` is empty                                                                                                                                                   |
+| Issue evidence | `a1 repo mr workitem list --mr <id>` → `[{id, subject, link, assigned_to}]`; `a1 project workitem get <id>` for body/comments                 | workitem id = the `#AONE_ID` in the commit title                                                                                                                                                      |
+| Diff listing   | `a1 repo mr diff <id>` (file list) / `<id> <file>` (per-file)                                                                                 | only needed in lightweight mode; the primary path diffs via git after fetching the ref                                                                                                                |
+| CI status      | `a1 repo mr status <id>`                                                                                                                      | presubmit-equivalent (read-only)                                                                                                                                                                      |
 
 ## Proposed scope (vertical slice — confirm before implementing)
 
@@ -34,7 +34,7 @@ findings), and `--comment` on an Aone target refuses cleanly.
    the repo coordinate is passed per call).
 2. `lib/platform/aone.ts` — implements `ReviewPlatformReader`:
    `resolveRepo` (parse the clone's origin URL → `gitlab.alibaba-inc.com/<g>/<p>`),
-   `getPrMeta` (mr view → sourceBranch/detailUrl), `getClosingIssues` (workitem
+   `getPrMeta` (mr view + verified MR-ref resolution → head SHA/detailUrl), `getClosingIssues` (workitem
    list), `getIssue` (workitem get), `fetchDiff` (git-based after fetching the
    ref; a1 per-file diff only for lightweight mode), `getCommentBody` (read
    `note` from comment list).
@@ -99,6 +99,12 @@ semantics (head-drift refusal, partial-post reporting, host binding).
   Aone branch. `a1 mr diff` is only the lightweight fallback.
 - **Global id is the review number.** Aone CR URLs carry the global id; the
   reader uses it for refs/`mr view`/comments/workitems.
+- **Head identity is flow-aware.** A full 40-hex `sourceBranch` is the
+  AGit-Flow head. Any other non-empty value is a branch label; its SHA is read
+  from the exact MR ref only after the cwd `origin` is proven to be the target
+  Aone repository. Clone-less reads report the SHA as unavailable, while
+  presubmit/comment-status and posting fail closed when a known branch cannot
+  be resolved.
 
 ## Files affected
 

--- a/docs/design/2026-08-21-review-aone-pr-context.md
+++ b/docs/design/2026-08-21-review-aone-pr-context.md
@@ -38,12 +38,12 @@ The Phase-2 facts table (probed 2026-08-13 against maxcompute/odps_src with
 a1 v0.1.90) already covers everything this phase reads, plus the a1 command
 surface re-checked 2026-08-21 via help (no auth needed):
 
-| Need               | a1 surface                                                                                                                                            | Notes                                                                                                       |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| MR metadata        | `a1 repo mr view <id> -f json` → `title, description, state, sourceBranch (head SHA under AGit-Flow), targetBranch, author, detailUrl`                | no additions/deletions stats — the context header degrades                                                  |
-| All comments       | `a1 repo mr comment list --mr <id> -f json [--sort asc]` → `id, note, author, closed, outdated, path, line, side, parentNoteId, isAiComment, isDraft` | one flat collection; `path` present ⇔ inline; NO pagination flags (full list returned); default sort `desc` |
-| Reviews / verdicts | none — no review object exists on Aone                                                                                                                | approvals surface only through `mr status` checks                                                           |
-| Current user       | `a1 auth whoami -f json` → `account`                                                                                                                  |                                                                                                             |
+| Need               | a1 surface                                                                                                                                            | Notes                                                                                                        |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| MR metadata        | `a1 repo mr view <id> -f json` → `title, description, state, sourceBranch, targetBranch, author, detailUrl`                                           | `sourceBranch` is a full SHA under AGit-Flow and a branch name otherwise; no separate head SHA or diff stats |
+| All comments       | `a1 repo mr comment list --mr <id> -f json [--sort asc]` → `id, note, author, closed, outdated, path, line, side, parentNoteId, isAiComment, isDraft` | one flat collection; `path` present ⇔ inline; NO pagination flags (full list returned); default sort `desc`  |
+| Reviews / verdicts | none — no review object exists on Aone                                                                                                                | approvals surface only through `mr status` checks                                                            |
+| Current user       | `a1 auth whoami -f json` → `account`                                                                                                                  |                                                                                                              |
 
 Probe-pending shapes RESOLVED 2026-08-21 against live MRs once a1 auth was
 restored:
@@ -57,11 +57,12 @@ restored:
 - The comment envelope also carries `updatedAt`, `adopted`, `labels` —
   unread.
 
-One NEW gap surfaced by the same E2E (filed as #9620, pre-existing, out of
-this phase's scope): `mr view` carries NO head-SHA field, and
-`sourceBranch` is a branch NAME on branch-based (non-AGit-Flow) MRs — the
-provider's sourceBranch-as-SHA assumption (facts table, submit's drift gate,
-`meta`'s headSha) only holds under AGit-Flow.
+One gap surfaced by the same E2E: `mr view` carries no separate head-SHA
+field, and `sourceBranch` is a branch name on branch-based MRs. Resolved for
+#9620: the provider now resolves the exact MR-head ref only from a verified
+target clone. Clone-less context keeps the branch name but renders the SHA as
+unavailable; safety and write paths fail closed if a known branch cannot be
+resolved.
 
 ## Design decisions
 
@@ -109,7 +110,7 @@ interface ReviewContext {
   authorLogin: string;
   state: string;
   baseRefName: string;
-  headRefName: string; // branch name (GitHub); Aone: sourceBranch — a bare SHA under AGit-Flow
+  headRefName: string; // branch name; under AGit-Flow, Aone's sourceBranch is a bare SHA
   headRefOid: string;
   additions?: number; // absent where the platform reports no stats
   deletions?: number;
@@ -167,12 +168,12 @@ One flat comment collection serves three GitHub channels:
 ### D3 — Metadata mapping
 
 From `mr view`: `title`, `description` → body, `author` → authorLogin,
-`state` passthrough, `targetBranch` → baseRefName, `sourceBranch` →
-headRefOid (it IS the head SHA under AGit-Flow). `headRefName` =
-`sourceBranch` as well: under AGit-Flow that string is the head SHA, and
-rendering `master ← <sha>` in the context header is truthful and
-informative; a non-AGit-Flow MR's real branch name renders the same way
-GitHub's does. Diff stats have no Aone source: the header line degrades to
+`state` passthrough, `targetBranch` → baseRefName, and trimmed `sourceBranch`
+→ headRefName. A full 40-hex `sourceBranch` also supplies headRefOid directly.
+For a branch name, headRefOid comes from
+`refs/merge-requests/<global-id>/head` only when the cwd `origin` is verified
+against the MR's full repository path; otherwise it is unavailable. Diff
+stats have no Aone source: the header line degrades to
 "not reported by the platform" instead of printing zeros (zeros would assert
 an empty diff). pr-context does not compute them locally — the worktree
 belongs to fetch-pr, and duplicating its merge-base arithmetic here would be
@@ -274,7 +275,7 @@ forced-cap pins flip to parity pins.
    un-paginated JSON payload; the 64 MiB aone-client bound covers it, but a
    monster thread's context file crosses the read_file threshold — the
    existing size warning + paging guidance already handles that shape.
-3. Branch-based (non-AGit-Flow) MRs carry a branch NAME in `sourceBranch`
-   and `mr view` exposes no head-SHA field — the provider's
-   sourceBranch-as-SHA assumption breaks on them (submit's drift gate then
-   refuses every post). Pre-existing, filed as #9620, out of this phase.
+3. ~~Branch-based MRs carry a branch name in `sourceBranch`, so the provider
+   cannot treat it as the head SHA.~~ Resolved for #9620 by verified clone-side
+   MR-ref resolution, honest clone-less degradation, and fail-closed safety
+   consumers.

--- a/packages/cli/src/commands/review/comment-status.ts
+++ b/packages/cli/src/commands/review/comment-status.ts
@@ -698,9 +698,9 @@ async function runCommentStatusAone(args: CommentStatusArgs): Promise<void> {
     // answer falling back to a fresh whoami.
     const gateAccount = ensureAoneAuthenticated();
 
-    // The same two-sample race detection as the GitHub path: `sourceBranch`
-    // IS the head under AGit-Flow, and an amend landing between the sample
-    // and the comment list pairs anchor facts with a stale drift comparison.
+    // The same two-sample race detection as the GitHub path: the provider
+    // resolves either AGit's source SHA or a branch MR's exact head ref, and
+    // a push between the sample and the comment list would stale the facts.
     const before = getMrAuthorAndHead(mrId, ownerRepo);
     const prAuthor = before.author;
     const liveHeadBefore = before.headSha;

--- a/packages/cli/src/commands/review/fetch-pr.test.ts
+++ b/packages/cli/src/commands/review/fetch-pr.test.ts
@@ -1241,11 +1241,15 @@ describe('fetch-pr report assembly', () => {
   };
 
   /** Serve the delta for `ANCHOR..head` and the full range for `BASE..head`. */
-  function servesBothRanges(full = FULL_DIFF, delta = DELTA_DIFF) {
+  function servesBothRanges(
+    full = FULL_DIFF,
+    delta = DELTA_DIFF,
+    head = 'f00df00df00d',
+  ) {
     producerMocks.gitRaw.mockImplementation((...args: string[]) =>
-      args.includes(`${ANCHOR}..f00df00df00d`)
+      args.includes(`${ANCHOR}..${head}`)
         ? Buffer.from(delta)
-        : args.includes(`${BASE}..f00df00df00d`)
+        : args.includes(`${BASE}..${head}`)
           ? Buffer.from(full)
           : Buffer.from(''),
     );
@@ -1269,7 +1273,7 @@ describe('fetch-pr report assembly', () => {
    * orphaned by the AGit-Flow amend. One shape, so the tests that refuse
    * it on GitHub and the tests that scope it on Aone cannot drift apart.
    */
-  function serveOrphanShape(): void {
+  function serveOrphanShape(head = 'f00df00df00d'): void {
     producerMocks.gitOpt.mockImplementation((...args: string[]) =>
       args[0] === 'cat-file' ? '' : args[0] === 'rev-parse' ? ANCHOR : null,
     );
@@ -1277,7 +1281,7 @@ describe('fetch-pr report assembly', () => {
       sha: BASE,
       baseFetchFailed: false,
     });
-    servesBothRanges();
+    servesBothRanges(FULL_DIFF, DELTA_DIFF, head);
   }
 
   it('pulls a still-clean importer of a changed file back into the scope', async () => {
@@ -2711,6 +2715,8 @@ describe('fetch-pr report assembly', () => {
     // it, a mocked `a1` serves auth + MR view, and the git probes answer
     // the orphan shape (existence yes, ancestry exit 1).
 
+    const AGIT_HEAD = 'f00d'.repeat(10);
+
     function serveAone(): void {
       producerMocks.execFileSync.mockImplementation(
         (cmd: string, args: string[]) => {
@@ -2718,7 +2724,7 @@ describe('fetch-pr report assembly', () => {
           if (args[0] === 'repo' && args[1] === 'mr' && args[2] === 'view') {
             return JSON.stringify({
               mergeRequest: {
-                sourceBranch: 'f00df00df00d',
+                sourceBranch: AGIT_HEAD,
                 targetBranch: 'main',
                 detailUrl:
                   'https://code.alibaba-inc.com/acme/widgets/codereview/42',
@@ -2729,7 +2735,13 @@ describe('fetch-pr report assembly', () => {
           return ''; // `auth whoami`
         },
       );
-      serveOrphanShape();
+      producerMocks.git.mockImplementation((...args: string[]) => {
+        if (args[0] === 'remote' && args[1] === 'get-url') {
+          return 'git@gitlab.alibaba-inc.com:acme/widgets.git';
+        }
+        return args[0] === 'rev-parse' ? AGIT_HEAD : '';
+      });
+      serveOrphanShape(AGIT_HEAD);
     }
 
     it('scopes an amend-orphaned anchor instead of refusing it', async () => {
@@ -2745,6 +2757,7 @@ describe('fetch-pr report assembly', () => {
         diffBase: BASE,
       });
       expect(report.diffPath).not.toBeNull();
+      expect(report.fetchedSha).toBe(AGIT_HEAD);
       // The published scope is the PR's own diff narrowed to the amend's
       // delta — the untouched file is dropped, exactly as the GitHub
       // incremental path narrows.
@@ -2755,6 +2768,11 @@ describe('fetch-pr report assembly', () => {
         'origin',
         'refs/merge-requests/42/head:qwen-review/pr-42',
       ]);
+      expect(
+        producerMocks.git.mock.calls.some(([command]) =>
+          String(command).startsWith('ls-remote'),
+        ),
+      ).toBe(false);
     });
 
     it('never asks an ancestry question on the Aone platform', async () => {

--- a/packages/cli/src/commands/review/fetch-pr.ts
+++ b/packages/cli/src/commands/review/fetch-pr.ts
@@ -1881,7 +1881,7 @@ export const fetchPrCommand: CommandModule = {
         type: 'string',
         default: 'origin',
         describe:
-          'Git remote to fetch from (use "upstream" for fork-based workflows)',
+          'Git remote to fetch from (use "upstream" for GitHub fork workflows; Aone branch-based MRs require the target repository at "origin")',
       })
       .option('out', {
         type: 'string',

--- a/packages/cli/src/commands/review/lib/platform/aone.test.ts
+++ b/packages/cli/src/commands/review/lib/platform/aone.test.ts
@@ -55,6 +55,10 @@ import {
 } from './aone.js';
 import { PINNED_DIFF_CONFIG, PINNED_DIFF_FLAGS } from '../diff-flags.js';
 
+const HEAD_SHA = '1111111111111111111111111111111111111111';
+const AMENDED_SHA = '2222222222222222222222222222222222222222';
+const STALE_SHA = '3333333333333333333333333333333333333333';
+
 describe('parseRemoteUrl hardening', () => {
   it('discards an explicit port instead of folding it into the path', () => {
     expect(
@@ -477,15 +481,16 @@ describe('aoneReader.getPrMeta — the live-head read behind meta.headSha', () =
   it('maps mr view onto PrMeta (head sha, web url)', () => {
     a1JsonMock.mockReturnValue({
       mergeRequest: {
-        sourceBranch: 'sha123',
+        sourceBranch: HEAD_SHA,
         detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
       },
     });
     expect(aoneReader.getPrMeta(7, 'g/p')).toEqual({
       number: 7,
-      headSha: 'sha123',
+      headSha: HEAD_SHA,
       webUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
     });
+    expect(gitMock).not.toHaveBeenCalled();
   });
 
   it('trims a padded sourceBranch — one normalization for every head read', () => {
@@ -495,9 +500,83 @@ describe('aoneReader.getPrMeta — the live-head read behind meta.headSha', () =
     // during review") on an MR that never moved — and as a submit-time
     // refusal at the pre-write gate (#9629 review).
     a1JsonMock.mockReturnValue({
-      mergeRequest: { sourceBranch: '  sha123\n', detailUrl: '' },
+      mergeRequest: { sourceBranch: `  ${HEAD_SHA}\n`, detailUrl: '' },
     });
-    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe('sha123');
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe(HEAD_SHA);
+  });
+
+  it('resolves a branch-based MR through the exact head ref of the matching clone', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+      },
+    });
+    gitMock.mockImplementation((...args: string[]) => {
+      if (args[0] === 'remote') {
+        return 'git@gitlab.alibaba-inc.com:g/p.git';
+      }
+      if (args[0] === 'ls-remote') {
+        return `${HEAD_SHA}\trefs/merge-requests/7/head`;
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`);
+    });
+
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe(HEAD_SHA);
+    expect(gitMock).toHaveBeenNthCalledWith(1, 'remote', 'get-url', 'origin');
+    expect(gitMock).toHaveBeenNthCalledWith(
+      2,
+      'ls-remote',
+      '--exit-code',
+      '--refs',
+      'origin',
+      'refs/merge-requests/7/head',
+    );
+  });
+
+  it('reports a branch head as unavailable outside the target clone', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+      },
+    });
+    gitMock.mockReturnValue('git@gitlab.alibaba-inc.com:other/p.git');
+
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe('');
+    expect(gitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not collapse a nested-group origin when proving the target repo', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        detailUrl:
+          'https://code.alibaba-inc.com/team-a/nested/g/p/codereview/7',
+      },
+    });
+    gitMock.mockReturnValue('git@gitlab.alibaba-inc.com:team-b/nested/g/p.git');
+
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe('');
+    expect(gitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    '',
+    `${HEAD_SHA}\trefs/merge-requests/8/head`,
+    `${HEAD_SHA}\trefs/merge-requests/7/head\n${HEAD_SHA}\trefs/merge-requests/7/head`,
+  ])('rejects malformed branch-head output %j', (output) => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+      },
+    });
+    gitMock.mockImplementation((...args: string[]) =>
+      args[0] === 'remote' ? 'git@gitlab.alibaba-inc.com:g/p.git' : output,
+    );
+
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe('');
   });
 });
 
@@ -509,14 +588,14 @@ describe('aoneReader.getFetchMeta / fetchHeadRefSpec', () => {
   it('maps mr view onto FetchMeta (head sha, base branch, never cross-repo)', () => {
     a1JsonMock.mockReturnValue({
       mergeRequest: {
-        sourceBranch: 'sha123',
+        sourceBranch: HEAD_SHA,
         targetBranch: 'master',
         description: 'desc',
         detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
       },
     });
     const meta = aoneReader.getFetchMeta(7, 'g/p');
-    expect(meta.headRefOid).toBe('sha123');
+    expect(meta.headRefOid).toBe(HEAD_SHA);
     expect(meta.baseRefName).toBe('master');
     expect(meta.isCrossRepository).toBe(false);
     expect(meta.body).toBe('desc');
@@ -531,9 +610,42 @@ describe('aoneReader.getFetchMeta / fetchHeadRefSpec', () => {
     // untrimmed copy read a padded server value as a different head
     // (#9629 review).
     a1JsonMock.mockReturnValue({
-      mergeRequest: { sourceBranch: '  sha123\n', targetBranch: 'master' },
+      mergeRequest: {
+        sourceBranch: `  ${HEAD_SHA}\n`,
+        targetBranch: 'master',
+      },
     });
-    expect(aoneReader.getFetchMeta(7, 'g/p').headRefOid).toBe('sha123');
+    expect(aoneReader.getFetchMeta(7, 'g/p').headRefOid).toBe(HEAD_SHA);
+  });
+
+  it('uses the resolved MR ref SHA for branch-based fetch metadata', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        targetBranch: 'master',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+      },
+    });
+    gitMock
+      .mockReturnValueOnce('git@gitlab.alibaba-inc.com:g/p.git')
+      .mockReturnValueOnce(`${HEAD_SHA}\trefs/merge-requests/7/head`);
+
+    expect(aoneReader.getFetchMeta(7, 'g/p').headRefOid).toBe(HEAD_SHA);
+  });
+
+  it('leaves a branch-based fetch OID empty when no target clone is available', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        targetBranch: 'master',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+      },
+    });
+    gitMock.mockImplementation(() => {
+      throw new Error('not a git clone');
+    });
+
+    expect(aoneReader.getFetchMeta(7, 'g/p').headRefOid).toBe('');
   });
 
   it('uses the merge-requests refspec with the global id', () => {
@@ -565,7 +677,7 @@ describe('aoneReader.getReviewContext / getCurrentUser', () => {
     a1JsonMock
       .mockReturnValueOnce({
         mergeRequest: {
-          sourceBranch: 'sha123',
+          sourceBranch: HEAD_SHA,
           targetBranch: 'master',
           title: 'a CR',
           description: 'the description',
@@ -642,7 +754,7 @@ describe('aoneReader.getReviewContext / getCurrentUser', () => {
     // the default-only list would reintroduce the resolved-blind hole.
     a1JsonMock
       .mockReturnValueOnce({
-        mergeRequest: { sourceBranch: 'sha123', targetBranch: 'master' },
+        mergeRequest: { sourceBranch: HEAD_SHA, targetBranch: 'master' },
       })
       .mockReturnValueOnce([{ id: 1, note: 'open' }])
       .mockReturnValueOnce({
@@ -663,11 +775,33 @@ describe('aoneReader.getReviewContext / getCurrentUser', () => {
     expect(ctx.state).toBe('opened');
     expect(ctx.baseRefName).toBe('master');
     // Under AGit-Flow sourceBranch IS the head SHA — both fields read it.
-    expect(ctx.headRefName).toBe('sha123');
-    expect(ctx.headRefOid).toBe('sha123');
+    expect(ctx.headRefName).toBe(HEAD_SHA);
+    expect(ctx.headRefOid).toBe(HEAD_SHA);
     expect(ctx.additions).toBeUndefined();
     expect(ctx.deletions).toBeUndefined();
     expect(ctx.changedFiles).toBeUndefined();
+  });
+
+  it('keeps a branch name separate from its resolved context head SHA', () => {
+    mockContext([], { sourceBranch: 'feature/fix-loop' });
+    gitMock
+      .mockReturnValueOnce('git@gitlab.alibaba-inc.com:g/p.git')
+      .mockReturnValueOnce(`${HEAD_SHA}\trefs/merge-requests/7/head`);
+
+    const ctx = aoneReader.getReviewContext(7, 'g/p');
+    expect(ctx.headRefName).toBe('feature/fix-loop');
+    expect(ctx.headRefOid).toBe(HEAD_SHA);
+    expect(gitMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('never relabels a branch name as the context head SHA without a target clone', () => {
+    mockContext([], { sourceBranch: 'feature/fix-loop' });
+    gitMock.mockReturnValue('git@gitlab.alibaba-inc.com:other/p.git');
+
+    const ctx = aoneReader.getReviewContext(7, 'g/p');
+    expect(ctx.headRefName).toBe('feature/fix-loop');
+    expect(ctx.headRefOid).toBe('');
+    expect(gitMock).toHaveBeenCalledTimes(1);
   });
 
   it('shapes the path-LESS comments as ledger carriers, chronologically', () => {
@@ -779,10 +913,10 @@ describe('aoneReader.getReviewContext / getCurrentUser', () => {
     // diverge from the trimmed reads every other subcommand reports — a
     // consumer comparing the two would reproduce the phantom-drift bug the
     // aoneHeadSha consolidation closed (#9629 review).
-    mockContext([], { sourceBranch: '  sha123\n' });
+    mockContext([], { sourceBranch: `  ${HEAD_SHA}\n` });
     const ctx = aoneReader.getReviewContext(7, 'g/p');
-    expect(ctx.headRefOid).toBe('sha123');
-    expect(ctx.headRefName).toBe('sha123');
+    expect(ctx.headRefOid).toBe(HEAD_SHA);
+    expect(ctx.headRefName).toBe(`  ${HEAD_SHA}\n`.trim());
   });
 
   it('tags the exit-0 a1.error/v1 envelope from the comment listing', () => {
@@ -792,7 +926,7 @@ describe('aoneReader.getReviewContext / getCurrentUser', () => {
     // envelope's actionable message instead of an untagged TypeError.
     a1JsonMock
       .mockReturnValueOnce({
-        mergeRequest: { sourceBranch: 'sha123', targetBranch: 'master' },
+        mergeRequest: { sourceBranch: HEAD_SHA, targetBranch: 'master' },
       })
       .mockReturnValueOnce({
         schemaVersion: 'a1.error/v1',
@@ -807,7 +941,7 @@ describe('aoneReader.getReviewContext / getCurrentUser', () => {
   it('tags the unexpected-shape refusal when the envelope has no message', () => {
     a1JsonMock
       .mockReturnValueOnce({
-        mergeRequest: { sourceBranch: 'sha123', targetBranch: 'master' },
+        mergeRequest: { sourceBranch: HEAD_SHA, targetBranch: 'master' },
       })
       .mockReturnValueOnce({ schemaVersion: 'a1.error/v1' });
     expect(() => aoneReader.getReviewContext(7, 'g/p')).toThrow(
@@ -928,13 +1062,13 @@ describe("getMrAuthorAndHead (the presubmit gate's Aone seam)", () => {
   it('reads the author account and the live head from ONE mr view fetch', () => {
     a1JsonMock.mockReturnValue({
       mergeRequest: {
-        sourceBranch: 'sha123',
+        sourceBranch: HEAD_SHA,
         author: { username: 'wenshao' },
       },
     });
     expect(getMrAuthorAndHead(29295886, 'maxcompute/odps_src')).toEqual({
       author: 'wenshao',
-      headSha: 'sha123',
+      headSha: HEAD_SHA,
     });
     expect(a1JsonMock).toHaveBeenCalledTimes(1);
     expect(a1JsonMock).toHaveBeenCalledWith(
@@ -951,14 +1085,14 @@ describe("getMrAuthorAndHead (the presubmit gate's Aone seam)", () => {
     // The GitHub path's `author: null` parity: a readable MR with no author
     // must yield isSelfPr false, not a throw that kills the presubmit.
     a1JsonMock.mockReturnValue({
-      mergeRequest: { sourceBranch: 'sha123' },
+      mergeRequest: { sourceBranch: HEAD_SHA },
     });
     expect(getMrAuthorAndHead(7, 'g/p')).toEqual({
       author: '',
-      headSha: 'sha123',
+      headSha: HEAD_SHA,
     });
     a1JsonMock.mockReturnValue({
-      mergeRequest: { sourceBranch: 'sha123', author: {} },
+      mergeRequest: { sourceBranch: HEAD_SHA, author: {} },
     });
     expect(getMrAuthorAndHead(7, 'g/p').author).toBe('');
   });
@@ -968,11 +1102,11 @@ describe("getMrAuthorAndHead (the presubmit gate's Aone seam)", () => {
     // reach `.toLowerCase()` outside presubmit's fetch try/catch and die
     // with no report. Parity with the gate's account read (`typeof === 'string'`).
     a1JsonMock.mockReturnValue({
-      mergeRequest: { sourceBranch: 'sha123', author: { username: 42 } },
+      mergeRequest: { sourceBranch: HEAD_SHA, author: { username: 42 } },
     });
     expect(getMrAuthorAndHead(7, 'g/p').author).toBe('');
     a1JsonMock.mockReturnValue({
-      mergeRequest: { sourceBranch: 'sha123', author: { username: null } },
+      mergeRequest: { sourceBranch: HEAD_SHA, author: { username: null } },
     });
     expect(getMrAuthorAndHead(7, 'g/p').author).toBe('');
   });
@@ -984,16 +1118,49 @@ describe("getMrAuthorAndHead (the presubmit gate's Aone seam)", () => {
     // for). Absent values report '' — drift stays off, isSelfPr false.
     a1JsonMock.mockReturnValue({
       mergeRequest: {
-        sourceBranch: '  sha123\n',
+        sourceBranch: `  ${HEAD_SHA}\n`,
         author: { username: '  wenshao\n' },
       },
     });
     expect(getMrAuthorAndHead(7, 'g/p')).toEqual({
       author: 'wenshao',
-      headSha: 'sha123',
+      headSha: HEAD_SHA,
     });
     a1JsonMock.mockReturnValue({ mergeRequest: { author: {} } });
     expect(getMrAuthorAndHead(7, 'g/p').headSha).toBe('');
+  });
+
+  it('resolves a branch head before presubmit or comment-status consumes it', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+        author: { username: 'wenshao' },
+      },
+    });
+    gitMock
+      .mockReturnValueOnce('git@gitlab.alibaba-inc.com:g/p.git')
+      .mockReturnValueOnce(`${HEAD_SHA}\trefs/merge-requests/7/head`);
+
+    expect(getMrAuthorAndHead(7, 'g/p')).toEqual({
+      author: 'wenshao',
+      headSha: HEAD_SHA,
+    });
+  });
+
+  it('fails closed when a known branch head cannot be resolved', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+        author: { username: 'wenshao' },
+      },
+    });
+    gitMock.mockReturnValue('git@gitlab.alibaba-inc.com:other/p.git');
+
+    expect(() => getMrAuthorAndHead(7, 'g/p')).toThrow(
+      /cannot resolve the live head SHA for branch "feature\/fix-loop"/,
+    );
   });
 
   it('rejects a malformed owner/repo before any a1 call', () => {
@@ -1354,14 +1521,14 @@ describe('submitAoneReview (the a1 write path)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mrView('sha-head');
+    mrView(HEAD_SHA);
     a1JsonOnceMock.mockReturnValue({ id: 100 });
   });
 
   const req = (over: Record<string, unknown> = {}) => ({
     prNumber: 7,
     ownerRepo: 'g/p',
-    commitId: 'sha-head',
+    commitId: HEAD_SHA,
     event: 'COMMENT' as const,
     body: 'summary body',
     comments: [
@@ -1496,7 +1663,7 @@ describe('submitAoneReview (the a1 write path)', () => {
   it('refuses BEFORE writing when the head drifted', () => {
     let caught: unknown;
     try {
-      submitAoneReview(req({ commitId: 'stale-sha' }));
+      submitAoneReview(req({ commitId: STALE_SHA }));
     } catch (err) {
       caught = err;
     }
@@ -1510,6 +1677,66 @@ describe('submitAoneReview (the a1 write path)', () => {
     );
     expect(a1JsonOnceMock).not.toHaveBeenCalled();
     expect(a1OnceMock).not.toHaveBeenCalled();
+  });
+
+  it('posts against a stable resolved branch head', () => {
+    mrView('feature/fix-loop');
+    gitMock.mockImplementation((...args: string[]) => {
+      if (args[0] === 'remote') {
+        return 'git@gitlab.alibaba-inc.com:g/p.git';
+      }
+      if (args[0] === 'ls-remote') {
+        return `${HEAD_SHA}\trefs/merge-requests/7/head`;
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`);
+    });
+
+    const result = submitAoneReview(req());
+    expect(result.postedInline).toBe(2);
+    expect(result.headMovedDuringPost).toBe(false);
+  });
+
+  it('refuses a moved branch head before any write', () => {
+    mrView('feature/fix-loop');
+    gitMock.mockImplementation((...args: string[]) =>
+      args[0] === 'remote'
+        ? 'git@gitlab.alibaba-inc.com:g/p.git'
+        : `${AMENDED_SHA}\trefs/merge-requests/7/head`,
+    );
+
+    expect(() => submitAoneReview(req())).toThrow(/the MR head moved/);
+    expect(a1JsonOnceMock).not.toHaveBeenCalled();
+    expect(a1OnceMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a branch whose head cannot be resolved before any write', () => {
+    mrView('feature/fix-loop');
+    gitMock.mockReturnValue('git@gitlab.alibaba-inc.com:other/p.git');
+
+    expect(() => submitAoneReview(req())).toThrow(
+      /^refusing to post: cannot resolve the live head SHA/,
+    );
+    expect(a1JsonOnceMock).not.toHaveBeenCalled();
+    expect(a1OnceMock).not.toHaveBeenCalled();
+  });
+
+  it('detects a branch head that moves during the write batch', () => {
+    mrView('feature/fix-loop');
+    const heads = [HEAD_SHA, AMENDED_SHA];
+    gitMock.mockImplementation((...args: string[]) => {
+      if (args[0] === 'remote') {
+        return 'git@gitlab.alibaba-inc.com:g/p.git';
+      }
+      if (args[0] === 'ls-remote') {
+        const sha = heads.shift();
+        return `${sha}\trefs/merge-requests/7/head`;
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`);
+    });
+
+    const result = submitAoneReview(req());
+    expect(result.postedInline).toBe(2);
+    expect(result.headMovedDuringPost).toBe(true);
   });
 
   it('an empty sourceBranch cannot gate — the post proceeds unanchored', () => {
@@ -1735,13 +1962,13 @@ describe('submitAoneReview (the a1 write path)', () => {
     a1JsonMock
       .mockReturnValueOnce({
         mergeRequest: {
-          sourceBranch: 'sha-head',
+          sourceBranch: HEAD_SHA,
           detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
         },
       })
       .mockReturnValueOnce({
         mergeRequest: {
-          sourceBranch: 'sha-amended',
+          sourceBranch: AMENDED_SHA,
           detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
         },
       });
@@ -1766,7 +1993,7 @@ describe('submitAoneReview (the a1 write path)', () => {
     a1JsonMock
       .mockReturnValueOnce({
         mergeRequest: {
-          sourceBranch: 'sha-head',
+          sourceBranch: HEAD_SHA,
           detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
         },
       })
@@ -1921,13 +2148,13 @@ describe('submitAoneReview (the a1 write path)', () => {
     a1JsonMock
       .mockReturnValueOnce({
         mergeRequest: {
-          sourceBranch: 'sha-head',
+          sourceBranch: HEAD_SHA,
           detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
         },
       })
       .mockReturnValueOnce({
         mergeRequest: {
-          sourceBranch: 'sha-amended',
+          sourceBranch: AMENDED_SHA,
           detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
         },
       });
@@ -1949,7 +2176,7 @@ describe('submitAoneReview (the a1 write path)', () => {
     a1JsonMock
       .mockReturnValueOnce({
         mergeRequest: {
-          sourceBranch: 'sha-head',
+          sourceBranch: HEAD_SHA,
           detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
         },
       })
@@ -2005,13 +2232,13 @@ describe('comment/status reads (the a1 backing for dedup)', () => {
   it('getMrAuthorAndHead reads author + sourceBranch off mr view', () => {
     a1JsonMock.mockReturnValue({
       mergeRequest: {
-        sourceBranch: 'head-sha',
+        sourceBranch: HEAD_SHA,
         author: { username: 'author-one' },
       },
     });
     expect(getMrAuthorAndHead(123, 'g/p')).toEqual({
       author: 'author-one',
-      headSha: 'head-sha',
+      headSha: HEAD_SHA,
     });
     expect(a1JsonMock).toHaveBeenCalledWith(
       'repo',

--- a/packages/cli/src/commands/review/lib/platform/aone.test.ts
+++ b/packages/cli/src/commands/review/lib/platform/aone.test.ts
@@ -58,6 +58,8 @@ import { PINNED_DIFF_CONFIG, PINNED_DIFF_FLAGS } from '../diff-flags.js';
 const HEAD_SHA = '1111111111111111111111111111111111111111';
 const AMENDED_SHA = '2222222222222222222222222222222222222222';
 const STALE_SHA = '3333333333333333333333333333333333333333';
+const UPPER_HEAD_SHA = 'ABCDEF0123456789ABCDEF0123456789ABCDEF01';
+const LOWER_HEAD_SHA = UPPER_HEAD_SHA.toLowerCase();
 
 describe('parseRemoteUrl hardening', () => {
   it('discards an explicit port instead of folding it into the path', () => {
@@ -493,6 +495,18 @@ describe('aoneReader.getPrMeta — the live-head read behind meta.headSha', () =
     expect(gitMock).not.toHaveBeenCalled();
   });
 
+  it('normalizes an uppercase AGit head without consulting git', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: UPPER_HEAD_SHA,
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+      },
+    });
+
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe(LOWER_HEAD_SHA);
+    expect(gitMock).not.toHaveBeenCalled();
+  });
+
   it('trims a padded sourceBranch — one normalization for every head read', () => {
     // Step 7's reviewed-SHA fallback reads meta.headSha while presubmit's
     // drift check compares the TRIMMED live head; the pre-fix untrimmed
@@ -517,12 +531,12 @@ describe('aoneReader.getPrMeta — the live-head read behind meta.headSha', () =
         return 'git@gitlab.alibaba-inc.com:g/p.git';
       }
       if (args[0] === 'ls-remote') {
-        return `${HEAD_SHA}\trefs/merge-requests/7/head`;
+        return `${UPPER_HEAD_SHA}\trefs/merge-requests/7/head`;
       }
       throw new Error(`unexpected git call: ${args.join(' ')}`);
     });
 
-    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe(HEAD_SHA);
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe(LOWER_HEAD_SHA);
     expect(gitMock).toHaveBeenNthCalledWith(1, 'remote', 'get-url', 'origin');
     expect(gitMock).toHaveBeenNthCalledWith(
       2,
@@ -532,6 +546,40 @@ describe('aoneReader.getPrMeta — the live-head read behind meta.headSha', () =
       'origin',
       'refs/merge-requests/7/head',
     );
+  });
+
+  it('resolves a branch when owner/repo is the only repository identity', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: { sourceBranch: 'feature/fix-loop' },
+    });
+    gitMock.mockImplementation((...args: string[]) => {
+      if (args[0] === 'remote') {
+        return 'git@gitlab.alibaba-inc.com:g/p.git';
+      }
+      if (args[0] === 'ls-remote') {
+        return `${HEAD_SHA}\trefs/merge-requests/7/head`;
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`);
+    });
+
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe(HEAD_SHA);
+  });
+
+  it('reports the head as unavailable when ls-remote fails', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: {
+        sourceBranch: 'feature/fix-loop',
+        detailUrl: 'https://code.alibaba-inc.com/g/p/codereview/7',
+      },
+    });
+    gitMock.mockImplementation((...args: string[]) => {
+      if (args[0] === 'remote') {
+        return 'git@gitlab.alibaba-inc.com:g/p.git';
+      }
+      throw new Error('ls-remote failed');
+    });
+
+    expect(aoneReader.getPrMeta(7, 'g/p').headSha).toBe('');
   });
 
   it('reports a branch head as unavailable outside the target clone', () => {
@@ -1400,6 +1448,23 @@ describe('aoneReader.fetchDiff', () => {
     expect(gitRawMock).not.toHaveBeenCalled();
   });
 
+  it('refuses a nested-group origin when the MR has no detailUrl', () => {
+    a1JsonMock.mockReturnValue({
+      mergeRequest: { sourceBranch: 'sha', targetBranch: 'master' },
+    });
+    gitMock.mockImplementation((...args: string[]) => {
+      if (args[0] === 'remote') {
+        return 'git@gitlab.alibaba-inc.com:team-x/nested/g/p.git';
+      }
+      return '';
+    });
+
+    expect(() => aoneReader.fetchDiff(7, 'g/p')).toThrow(
+      /not g\/p — run from inside a clone of the target repo/,
+    );
+    expect(gitRawMock).not.toHaveBeenCalled();
+  });
+
   it('accepts the matching nested-group clone via the detailUrl full path', () => {
     a1JsonMock.mockReturnValue({
       mergeRequest: {
@@ -1694,6 +1759,15 @@ describe('submitAoneReview (the a1 write path)', () => {
     const result = submitAoneReview(req());
     expect(result.postedInline).toBe(2);
     expect(result.headMovedDuringPost).toBe(false);
+  });
+
+  it('normalizes an uppercase AGit head and commit id before comparison', () => {
+    mrView(UPPER_HEAD_SHA);
+
+    const result = submitAoneReview(req({ commitId: UPPER_HEAD_SHA }));
+    expect(result.postedInline).toBe(2);
+    expect(result.headMovedDuringPost).toBe(false);
+    expect(gitMock).not.toHaveBeenCalled();
   });
 
   it('refuses a moved branch head before any write', () => {

--- a/packages/cli/src/commands/review/lib/platform/aone.ts
+++ b/packages/cli/src/commands/review/lib/platform/aone.ts
@@ -263,16 +263,11 @@ function mrHeadRefSpec(prNumber: number): string {
   return `refs/merge-requests/${prNumber}/head`;
 }
 
-/** The MR's live head SHA: under AGit-Flow `sourceBranch` IS the head.
- *  Stated ONCE for the provider — every read site (getMrAuthorAndHead,
- *  getPrMeta, getFetchMeta, getReviewContext, submit's pre-write drift
- *  gate, the head-moved-during-post re-read) routes through here.
- *  Hand-derived copies had already diverged on normalization (two of the
- *  five read untrimmed), and a padded server value then drifted against
- *  the trimmed reads — a phantom "PR head advanced during review" for an
- *  MR that never moved (#9629 review). */
-function aoneHeadSha(view: NonNullable<AoneMrView['mergeRequest']>): string {
-  return (view.sourceBranch ?? '').trim();
+const FULL_SHA_RE = /^[0-9a-f]{40}$/i;
+
+interface AoneHeadFacts {
+  source: string;
+  sha: string;
 }
 
 /**
@@ -320,6 +315,58 @@ function mrRepoPath(detailUrl: string | undefined): string | undefined {
     detailUrl.trim(),
   );
   return m?.[1]?.toLowerCase();
+}
+
+function currentOriginIdentity(): RepoIdentity | null {
+  try {
+    return parseRemoteUrl(git('remote', 'get-url', 'origin'));
+  } catch {
+    return null;
+  }
+}
+
+function originMatchesMr(
+  origin: RepoIdentity | null,
+  view: NonNullable<AoneMrView['mergeRequest']>,
+  ownerRepo: string,
+): boolean {
+  if (origin === null || !isAoneHostFamily(origin.host)) return false;
+  return (
+    origin.groupPath === (mrRepoPath(view.detailUrl) ?? ownerRepo.toLowerCase())
+  );
+}
+
+/**
+ * Aone exposes two `sourceBranch` shapes: a full SHA for AGit-Flow and a
+ * branch name for ordinary MRs. Resolve the latter only through the exact MR
+ * ref of a verified target-repository clone; otherwise report the SHA as
+ * unavailable instead of relabelling the branch name as a commit.
+ */
+function aoneHeadFacts(
+  prNumber: number,
+  ownerRepo: string,
+  view: NonNullable<AoneMrView['mergeRequest']>,
+): AoneHeadFacts {
+  const source = (view.sourceBranch ?? '').trim();
+  if (source === '') return { source, sha: '' };
+  if (FULL_SHA_RE.test(source)) {
+    return { source, sha: source.toLowerCase() };
+  }
+
+  if (!originMatchesMr(currentOriginIdentity(), view, ownerRepo)) {
+    return { source, sha: '' };
+  }
+
+  const ref = mrHeadRefSpec(prNumber);
+  try {
+    const out = git('ls-remote', '--exit-code', '--refs', 'origin', ref);
+    const match = /^([0-9a-f]{40})\t([^\n]+)$/i.exec(out);
+    return match?.[2] === ref
+      ? { source, sha: match[1].toLowerCase() }
+      : { source, sha: '' };
+  } catch {
+    return { source, sha: '' };
+  }
 }
 
 /**
@@ -438,7 +485,7 @@ export const aoneReader: ReviewPlatformReader = {
     const view = mrView(prNumber, ownerRepo);
     return {
       number: prNumber,
-      headSha: aoneHeadSha(view),
+      headSha: aoneHeadFacts(prNumber, ownerRepo, view).sha,
       webUrl: view.detailUrl ?? '',
     };
   },
@@ -496,23 +543,17 @@ export const aoneReader: ReviewPlatformReader = {
     // lightweight run from a DIFFERENT Aone clone would otherwise fetch the
     // ref from the wrong repository (ref-not-found, or a wrong MR's diff
     // written as evidence if the global id happens to exist there).
-    let originUrl: string | undefined;
-    try {
-      originUrl = git('remote', 'get-url', 'origin').trim();
-    } catch {
-      originUrl = undefined;
-    }
-    const originIdentity = originUrl ? parseRemoteUrl(originUrl) : null;
+    const originIdentity = currentOriginIdentity();
     // The MR view is consulted BEFORE the guard: its detailUrl names the
     // repo the MR actually lives in — authoritative identity, where the
     // seam's `ownerRepo` is only the collapsed last-two form. The collapse
     // is non-injective on nested-group platforms, so a different group's
     // same-tail clone would pass an owner/repo comparison and serve the
     // ref-fetch; comparing FULL paths (origin's parsed groupPath against
-    // the detailUrl's path) closes it. Without a detailUrl the guard falls
-    // back to the collapsed comparison (plus the host check).
+    // the detailUrl's path) closes it. Without a detailUrl only an origin
+    // whose full path equals ownerRepo is accepted; a nested path cannot be
+    // proven from the collapsed coordinate and fails closed.
     const view = mrView(prNumber, ownerRepo);
-    const mrPath = mrRepoPath(view.detailUrl);
     // The comparison carries the origin's HOST too — owner/repo equality
     // alone lets a same-named repo on a DIFFERENT platform pass the guard
     // and serve the ref-fetch. The host arm keys on the CANONICAL Aone
@@ -520,12 +561,7 @@ export const aoneReader: ReviewPlatformReader = {
     // accepts a dotted-FQDN origin as Aone, so the diff gate must too; a
     // harder comparison here refused a genuine clone with a misdirecting
     // remedy.
-    const sameRepo =
-      originIdentity !== null &&
-      isAoneHostFamily(originIdentity.host) &&
-      (mrPath !== undefined
-        ? originIdentity.groupPath === mrPath
-        : `${originIdentity.owner}/${originIdentity.repo}` === ownerRepo);
+    const sameRepo = originMatchesMr(originIdentity, view, ownerRepo);
     if (!sameRepo) {
       throw new Error(
         `the cwd clone is ${
@@ -695,7 +731,7 @@ export const aoneReader: ReviewPlatformReader = {
     checkOwnerRepo(ownerRepo);
     const view = mrView(prNumber, ownerRepo);
     return {
-      headRefOid: aoneHeadSha(view),
+      headRefOid: aoneHeadFacts(prNumber, ownerRepo, view).sha,
       baseRefName: view.targetBranch ?? 'master',
       // The reviewer clones the repo the CR lives in — never cross-repo.
       isCrossRepository: false,
@@ -707,6 +743,7 @@ export const aoneReader: ReviewPlatformReader = {
   getReviewContext(prNumber: number, ownerRepo: string): ReviewContext {
     checkOwnerRepo(ownerRepo);
     const view = mrView(prNumber, ownerRepo);
+    const head = aoneHeadFacts(prNumber, ownerRepo, view);
     // One flat collection serves the three GitHub channels; `--sort asc`
     // gives chronological order (the GitHub endpoints' natural order).
     // The full resolved-INCLUSIVE surface (default + `--resolved`, deduped
@@ -751,15 +788,8 @@ export const aoneReader: ReviewPlatformReader = {
       authorLogin: aoneCommentAuthor(view.author),
       state: view.state ?? '',
       baseRefName: view.targetBranch ?? 'master',
-      // Under AGit-Flow the head is a bare SHA and sourceBranch carries it;
-      // rendering `target ← <sha>` is truthful and informative. A
-      // non-AGit-Flow MR's real branch name renders the same way. Both
-      // fields route through the provider's ONE head normalization — a
-      // padded server value must not diverge from the trimmed reads every
-      // other subcommand reports (aoneHeadSha's docstring names the read
-      // sites; this one joins them).
-      headRefName: aoneHeadSha(view),
-      headRefOid: aoneHeadSha(view),
+      headRefName: head.source,
+      headRefOid: head.sha,
       // Aone reports no diff stats; the context header degrades.
       comments,
       verdicts: [],
@@ -866,8 +896,7 @@ export function aoneAccountName(author: unknown): string {
   return '';
 }
 
-/** The MR's author account and live head SHA (`sourceBranch` IS the head
- *  under AGit-Flow), from ONE `mr view` fetch. One call answers both
+/** The MR's author account and live head SHA, from ONE `mr view` fetch. One call answers both
  *  halves presubmit and comment-status need (self-PR detection /
  *  authorReplied + drift). A missing author (deleted account) reports '',
  *  which fails the self-PR comparison soft, like the GitHub path's
@@ -878,9 +907,16 @@ export function getMrAuthorAndHead(
 ): { author: string; headSha: string } {
   checkOwnerRepo(ownerRepo);
   const view = mrView(prNumber, ownerRepo);
+  const head = aoneHeadFacts(prNumber, ownerRepo, view);
+  if (head.source !== '' && head.sha === '') {
+    throw new Error(
+      `cannot resolve the live head SHA for branch ${JSON.stringify(head.source)} ` +
+        `of MR ${prNumber} in the current clone`,
+    );
+  }
   return {
     author: aoneAccountName(view.author),
-    headSha: aoneHeadSha(view),
+    headSha: head.sha,
   };
 }
 
@@ -1212,9 +1248,13 @@ function headMovedSinceCompose(
   commitId: string,
 ): boolean | undefined {
   try {
-    const afterHead = aoneHeadSha(mrView(prNumber, ownerRepo));
+    const afterHead = aoneHeadFacts(
+      prNumber,
+      ownerRepo,
+      mrView(prNumber, ownerRepo),
+    ).sha;
     if (afterHead === '') return undefined;
-    return afterHead !== commitId;
+    return afterHead !== commitId.toLowerCase();
   } catch {
     return undefined;
   }
@@ -1245,12 +1285,19 @@ export function submitAoneReview(req: AoneSubmitRequest): AoneSubmitResult {
   // here. Under AGit-Flow an update AMENDS the single commit: posting a
   // review composed against the orphaned head would pin every inline
   // comment at code the author already replaced. An empty sourceBranch
-  // cannot gate — nothing to compare against — and posts unanchored.
-  const liveHead = aoneHeadSha(view);
-  if (liveHead !== '' && liveHead !== req.commitId) {
+  // cannot gate — nothing to compare against — and posts unanchored. A
+  // known branch whose MR ref cannot be resolved fails closed instead.
+  const head = aoneHeadFacts(req.prNumber, req.ownerRepo, view);
+  if (head.source !== '' && head.sha === '') {
+    throw new Error(
+      `refusing to post: cannot resolve the live head SHA for branch ` +
+        `${JSON.stringify(head.source)} of MR ${req.prNumber} in the current clone.`,
+    );
+  }
+  if (head.sha !== '' && head.sha !== req.commitId.toLowerCase()) {
     throw new Error(
       `refusing to post: the MR head moved — the review was composed ` +
-        `against ${req.commitId}, but the live head is ${liveHead}. ` +
+        `against ${req.commitId}, but the live head is ${head.sha}. ` +
         `Re-review the new head before posting.`,
     );
   }

--- a/packages/cli/src/commands/review/lib/platform/types.ts
+++ b/packages/cli/src/commands/review/lib/platform/types.ts
@@ -111,8 +111,8 @@ export interface ReviewContext {
   authorLogin: string;
   state: string;
   baseRefName: string;
-  /** Branch name on GitHub. Aone: `sourceBranch` — a bare SHA under
-   *  AGit-Flow, rendered as `base ← <sha>`. */
+  /** Branch name on GitHub. Aone: trimmed `sourceBranch`, which is a bare SHA
+   *  under AGit-Flow and a branch name under branch-based flow. */
   headRefName: string;
   headRefOid: string;
   /** Absent where the platform reports no diff stats (Aone). */
@@ -130,7 +130,7 @@ export interface ReviewContext {
  * and computed locally from the fetched diff when absent.
  */
 export interface FetchMeta {
-  /** The head SHA. */
+  /** The head SHA; empty when the platform cannot resolve it safely. */
   headRefOid: string;
   /**
    * The head's branch name, when the platform has one (GitHub). AGit-Flow

--- a/packages/cli/src/commands/review/pr-context.test.ts
+++ b/packages/cli/src/commands/review/pr-context.test.ts
@@ -4046,6 +4046,23 @@ describe('prContextCommand handler — Aone routing', () => {
     expect(written).toContain('general chatter');
   });
 
+  it('renders an unresolved branch head as unavailable, never as a SHA', async () => {
+    (aoneStub.getReviewContext as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      {
+        ...structuredClone(aoneContext),
+        headRefName: 'feature/fix-loop',
+        headRefOid: '',
+      },
+    );
+
+    const written = await runHandler({
+      host: 'gitlab.alibaba-inc.com',
+    });
+    expect(written).toContain('`master` ← `feature/fix-loop`');
+    expect(written).toContain('- **HEAD SHA:** unavailable');
+    expect(written).not.toContain('- **HEAD SHA:** `feature/fix-loop`');
+  });
+
   it('recovers the machine ledger from a posted summary comment', async () => {
     const written = await runHandler({
       host: 'gitlab.alibaba-inc.com',

--- a/packages/cli/src/commands/review/pr-context.ts
+++ b/packages/cli/src/commands/review/pr-context.ts
@@ -2241,7 +2241,11 @@ export function buildMarkdown(
   parts.push(
     `- **Base → Head:** \`${meta.baseRefName}\` ← \`${meta.headRefName}\``,
   );
-  parts.push(`- **HEAD SHA:** \`${meta.headRefOid}\``);
+  parts.push(
+    meta.headRefOid === ''
+      ? '- **HEAD SHA:** unavailable'
+      : `- **HEAD SHA:** \`${meta.headRefOid}\``,
+  );
   parts.push(
     meta.changedFiles !== undefined
       ? `- **Diff:** ${meta.changedFiles} files, +${meta.additions}/-${meta.deletions}`

--- a/packages/cli/src/commands/review/presubmit.ts
+++ b/packages/cli/src/commands/review/presubmit.ts
@@ -10,9 +10,9 @@
 // downgrade decisions the LLM should apply when constructing the review
 // event. On an Aone target the command routes at the `a1` CLI instead and
 // emits the SAME report shape through the same shared writer: self-PR
-// detection (the gate's whoami account vs the MR author), head drift
-// (`sourceBranch` is the live head; no compare API, so `compare` stays
-// null), merge-gate classification, and the existing-comment dedup.
+// detection (the gate's whoami account vs the MR author), head drift (the
+// provider resolves AGit SHAs or a branch MR's exact head ref; no compare API,
+// so `compare` stays null), merge-gate classification, and comment dedup.
 
 import type { CommandModule } from 'yargs';
 import { writeFileSync, readFileSync } from 'node:fs';
@@ -1086,12 +1086,13 @@ function writePresubmitReport(input: {
 }
 
 /**
- * The Aone runner. The platform differences: identity and head come from
- * `mr view` (author username + `sourceBranch`), CI/gate state from
- * `mr status`, existing comments from `mr comment list` — and there is no
- * compare API, so a drifted head carries `compare: null` and the anchor-risk
- * ruling fails safe to at-risk (the skill restarts at the new head — under
- * AGit-Flow a moved head IS an amend that wants a re-review).
+ * The Aone runner. The platform differences: identity and head source come
+ * from `mr view`; a branch-based head SHA is resolved through the exact MR
+ * ref of a verified clone. CI/gate state comes from `mr status`, existing
+ * comments from `mr comment list` — and there is no compare API, so a drifted
+ * head carries `compare: null` and the anchor-risk ruling fails safe to
+ * at-risk (the skill restarts at the new head — under AGit-Flow a moved head
+ * IS an amend that wants a re-review).
  */
 async function runPresubmitAone(args: PresubmitArgs): Promise<void> {
   const {


### PR DESCRIPTION
## What this PR does

This change makes Aone review head identity aware of both platform flows. A full 40-hex `sourceBranch` remains the commit identity for AGit-Flow, while an ordinary branch name is preserved as a branch label and resolved through the exact merge-request head ref only when the current clone is proven to be the target Aone repository.

Read-only metadata now returns the real commit SHA when it can be established safely and reports it as unavailable otherwise, instead of relabelling a branch name as a SHA. Safety-sensitive consumers use the same resolved identity: presubmit and comment-status degrade when it cannot be established, and review submission refuses before any comment or approval write when the known branch head is unavailable or has moved.

## Why it's needed

Branch-based Aone merge requests expose a branch name in `sourceBranch`, unlike AGit-Flow merge requests, and do not expose a separate pre-merge head SHA. The previous implementation treated both shapes as a commit: metadata and context displayed a branch name as a SHA, resume and drift checks could report phantom movement, and every attempt to post a review to an unchanged branch-based merge request was refused as "the MR head moved." Resolving the platform's authoritative merge-request ref restores these flows without weakening the write gate or querying an unrelated repository.

## Reviewer Test Plan

### How to verify

Run `cd packages/cli && npx vitest run src/commands/review/lib/platform/aone.test.ts src/commands/review/pr-context.test.ts src/commands/review/presubmit.test.ts src/commands/review/comment-status.test.ts src/commands/review/meta.test.ts src/commands/review/fetch-pr.test.ts`; all 603 tests should pass. The regression cases verify AGit SHA passthrough, exact branch-head resolution, wrong and nested-repository rejection, malformed ref output, honest context rendering, stable submission, pre-write drift/refusal, and movement during a write batch.

From a clone of the Aone repository that owns a branch-based merge request, run `npm run dev -- review meta <mr-id> --repo <group/project> --host gitlab.alibaba-inc.com` and `npm run dev -- review pr-context <mr-id> <group/project> --host gitlab.alibaba-inc.com --out /tmp/aone-context.md`. Expect `headSha` and `HEAD SHA` to contain the same full commit from `refs/merge-requests/<mr-id>/head`, while Base → Head retains the branch name. Run the read commands outside that target clone and expect an empty metadata SHA / `HEAD SHA: unavailable`; a submit attempt from that state must refuse before writing.

### Evidence (Before & After)

Before, a real branch-based merge request reported `headSha: "feature/v3.18.6-remove-basebiz-hardcode"`, and presubmit compared that string with commit `5d8ef9268abc7187d285d1413214f7cbc04aebfe`, falsely setting `drifted: true`.

After, exact-source commands against a currently open branch-based Aone merge request preserve its branch label and render the SHA as unavailable from the unrelated Qwen Code clone. A local-only bare Git fixture with a matching Aone repository identity resolved the exact merge-request ref to a 40-hex commit. Stable, moved, and unresolved submission cases then confirmed that only the stable head enters the write batch; no live Aone write was performed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS / Darwin 25.6.0 arm64, Node v22.23.1, exact-source development CLI. `npm run build`, `npm run typecheck`, changed-path formatting/lint, and the six focused test files passed.

## Risk & Scope

- Main risk or tradeoff: Branch-based Aone metadata now performs a synchronous `git ls-remote` against the exact MR ref. The repository identity gate deliberately prefers an unavailable SHA over consulting an origin that cannot be proven to own the MR.
- Not validated / out of scope: No live Aone comment or approval was posted; Windows and Linux were not tested locally; the full repository test suite and bundle were not run.
- Breaking changes / migration notes: None. AGit-Flow keeps its existing no-query path; branch-based reads become accurate and unsafe write attempts fail closed with an actionable error.

## Linked Issues

Fixes #9620

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本改动让 Aone review 的 head 身份识别同时适配两种平台流程。完整 40 位十六进制的 `sourceBranch` 在 AGit-Flow 下仍直接作为 commit 身份；普通分支名则保留为分支标签，只有在当前 clone 被证明属于目标 Aone 仓库后，才通过精确的 merge-request head ref 解析真实 SHA。

只读元数据现在会在能够安全确认时返回真实 commit SHA，否则明确报告 unavailable，不再把分支名重新标成 SHA。安全敏感的消费者统一使用同一个解析结果：无法确认时 presubmit 与 comment-status 降级；已知分支无法解析或 head 已移动时，review submission 会在任何评论或 approval 写入之前拒绝。

## 为什么需要

分支型 Aone MR 的 `sourceBranch` 是分支名，与 AGit-Flow 不同，而且合并前没有独立的 head SHA 字段。此前实现把两种形态都当作 commit：meta 和 context 会把分支名显示成 SHA，resume 与 drift 检查可能产生虚假移动，而向未变化的分支型 MR 发布 review 也会永远被拒绝为 “the MR head moved”。从平台权威的 merge-request ref 解析 SHA，可以恢复这些流程，同时不削弱写入门禁，也不会查询无关仓库。

## 评审者测试计划

### 如何验证

运行 `cd packages/cli && npx vitest run src/commands/review/lib/platform/aone.test.ts src/commands/review/pr-context.test.ts src/commands/review/presubmit.test.ts src/commands/review/comment-status.test.ts src/commands/review/meta.test.ts src/commands/review/fetch-pr.test.ts`；应有 603 个测试全部通过。回归用例覆盖 AGit SHA 直通、精确分支 head 解析、错误仓库与嵌套路径拒绝、异常 ref 输出、context 如实渲染、稳定提交、写前漂移/拒绝，以及写入批次期间 head 移动。

在拥有分支型 MR 的 Aone 目标仓库 clone 中运行 `npm run dev -- review meta <mr-id> --repo <group/project> --host gitlab.alibaba-inc.com` 和 `npm run dev -- review pr-context <mr-id> <group/project> --host gitlab.alibaba-inc.com --out /tmp/aone-context.md`。预期 `headSha` 与 `HEAD SHA` 都是 `refs/merge-requests/<mr-id>/head` 对应的完整 commit，Base → Head 仍保留分支名。在该目标仓库之外运行只读命令，预期 meta SHA 为空、context 显示 `HEAD SHA: unavailable`；此状态下的 submit 必须在写入前拒绝。

### 前后对比证据

修复前，真实分支型 MR 会报告 `headSha: "feature/v3.18.6-remove-basebiz-hardcode"`，presubmit 还会用这个字符串与 commit `5d8ef9268abc7187d285d1413214f7cbc04aebfe` 比较，错误设置 `drifted: true`。

修复后，对当前 open 分支型 Aone MR 运行 exact-source 命令时，在无关的 Qwen Code clone 中会保留分支标签并把 SHA 显示为 unavailable。带有匹配 Aone 仓库身份的本地 bare Git 夹具则从精确 MR ref 解析出 40 位 commit。稳定、已移动和无法解析三种 submit 用例进一步确认只有稳定 head 会进入写入批次；没有执行真实 Aone 写入。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 运行环境（可选）

macOS / Darwin 25.6.0 arm64，Node v22.23.1，exact-source 开发 CLI。`npm run build`、`npm run typecheck`、改动路径的格式与 lint、六个聚焦测试文件均通过。

## 风险与范围

- 主要风险或权衡：分支型 Aone 元数据现在会对精确 MR ref 同步执行一次 `git ls-remote`。仓库身份门禁有意在无法证明 origin 属于该 MR 时返回 unavailable，而不是查询可能无关的 origin。
- 未验证 / 范围外：没有向真实 Aone 发布评论或 approval；未在 Windows 与 Linux 本地测试；未运行全仓测试套件与 bundle。
- 破坏性变更 / 迁移说明：无。AGit-Flow 保持原有的不查询路径；分支型读路径变得准确，不安全的写入尝试会给出可操作错误并 fail closed。

## 关联 Issue

Fixes #9620

</details>
