### PR TITLE
fix(cli): preserve startup banner when opening short dialogs

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3654,6 +3654,11 @@ export const AppContainer = (props: AppContainerProps) => {
   // (agents launching / finishing / focus), so `controlsHeight` — and thus
   // `availableTerminalHeight` — never goes stale below the composer. See
   // getLiveAgentPanelLayoutKey for the full rationale (#5798).
+  // We must re-measure whenever a dialog changes or grows (#8124).
+  const dialogLayoutKey = dialogsVisible
+    ? `${isMcpApprovalDialogOpen ? `mcp:${mcpApprovalRemaining}:${currentMcpApproval?.name ?? ''}` : ''}|${shellConfirmationRequest?.commands.join(',') ?? ''}|${confirmationRequest?.prompt ?? ''}|${providerUpdateRequest?.entries.length ?? ''}`
+    : 'hidden';
+
   const liveAgentPanelLayoutKey = getLiveAgentPanelLayoutKey(
     bgTaskEntries,
     bgLivePanelFocused,
@@ -3681,6 +3686,7 @@ export const AppContainer = (props: AppContainerProps) => {
     dialogsVisible,
     stickyTodosLayoutKey,
     liveAgentPanelLayoutKey,
+    dialogLayoutKey,
     // Composer and update notification height also shift with these; without
     // them the footer isn't re-measured during a streaming turn and the VP
     // viewport bottom clips.

--- a/packages/cli/src/ui/app-container-controls-dep.test.ts
+++ b/packages/cli/src/ui/app-container-controls-dep.test.ts
@@ -58,6 +58,8 @@ describe('AppContainer controls-height measurement wiring', () => {
     expect(deps).toContain('stickyTodosLayoutKey');
     // The fix: dropping this entry re-introduces the non-VP overflow flicker.
     expect(deps).toContain('liveAgentPanelLayoutKey');
+    // R3-1 fix: re-measure when height-constrained dialogs change their inner row counts
+    expect(deps).toContain('dialogLayoutKey');
   });
 
   it('computes liveAgentPanelLayoutKey from the live agent roster', () => {
@@ -65,6 +67,16 @@ describe('AppContainer controls-height measurement wiring', () => {
     // whitespace-tolerantly so prettier reformatting can't break the guard.
     expect(source).toMatch(
       /liveAgentPanelLayoutKey\s*=\s*getLiveAgentPanelLayoutKey\(\s*bgTaskEntries\s*,\s*bgLivePanelFocused\s*,?\s*\)/,
+    );
+  });
+
+  it('computes dialogLayoutKey capturing shell commands to ensure re-bounds', () => {
+    expect(source).toMatch(
+      /shellConfirmationRequest\?\.commands\.join\(',',?\)/,
+    );
+    // Escape string matching to verify the mcpApprovalRemaining part of the layout key
+    expect(source).toContain(
+      'mcp:${mcpApprovalRemaining}:${currentMcpApproval?.name',
     );
   });
 });

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
@@ -208,6 +208,29 @@ describe('DefaultAppLayout', () => {
     expect(output).not.toContain('DialogManager 20');
   });
 
+  it('keeps a short dialog at its natural height', () => {
+    mockedUseAgentViewState.mockReturnValue({
+      activeView: 'main',
+      agents: new Map(),
+    });
+
+    const constrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+    });
+    const unconstrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+      constrainHeight: false,
+    });
+
+    expect(frameHeight(constrained.lastFrame() ?? '')).toBe(
+      frameHeight(unconstrained.lastFrame() ?? ''),
+    );
+  });
+
   it('does not cap a tall dialog when height constraints are disabled', () => {
     mockedUseAgentViewState.mockReturnValue({
       activeView: 'main',

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -90,6 +90,8 @@ export const DefaultAppLayout: React.FC = () => {
                 marginX={2}
                 flexDirection="column"
                 width={uiState.mainAreaWidth}
+                // Max height, not fixed height: a padded full-height frame triggers
+                // Ink's full-clear repaint and wipes the startup banner.
                 maxHeight={dialogHeight}
                 overflow={uiState.constrainHeight ? 'hidden' : undefined}
               >

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -90,7 +90,7 @@ export const DefaultAppLayout: React.FC = () => {
                 marginX={2}
                 flexDirection="column"
                 width={uiState.mainAreaWidth}
-                height={dialogHeight}
+                maxHeight={dialogHeight}
                 overflow={uiState.constrainHeight ? 'hidden' : undefined}
               >
                 <DialogManager

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.test.tsx
@@ -180,6 +180,26 @@ describe('ScreenReaderAppLayout', () => {
     expect(output).not.toContain('DialogManager 20');
   });
 
+  it('keeps a short dialog at its natural height', () => {
+    const constrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+      staticExtraHeight: 3,
+    });
+    const unconstrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+      staticExtraHeight: 3,
+      constrainHeight: false,
+    });
+
+    expect(frameHeight(constrained.lastFrame() ?? '')).toBe(
+      frameHeight(unconstrained.lastFrame() ?? ''),
+    );
+  });
+
   it('does not cap a tall dialog when height constraints are disabled', () => {
     dialogManagerMockState.lineCount = 20;
     const terminalHeight = 8;

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
@@ -54,7 +54,7 @@ export const ScreenReaderAppLayout: React.FC = () => {
           marginX={2}
           flexDirection="column"
           width={uiState.mainAreaWidth}
-          height={dialogHeight}
+          maxHeight={dialogHeight}
           overflow={uiState.constrainHeight ? 'hidden' : undefined}
         >
           <DialogManager

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
@@ -54,6 +54,8 @@ export const ScreenReaderAppLayout: React.FC = () => {
           marginX={2}
           flexDirection="column"
           width={uiState.mainAreaWidth}
+          // Max height, not fixed height: a padded full-height frame triggers
+          // Ink's full-clear repaint and wipes the startup banner.
           maxHeight={dialogHeight}
           overflow={uiState.constrainHeight ? 'hidden' : undefined}
         >


### PR DESCRIPTION
## What this PR does

Keeps constrained dialogs at their natural height when their content fits, while retaining the existing maximum-height clipping for dialogs that exceed the available terminal space.

## Why it's needed

The dialog container used the calculated row budget as a fixed height. A short startup prompt was therefore padded to nearly the full terminal height. Combined with the committed startup banner, that oversized frame overflowed the viewport and triggered Ink's full-terminal clear path. Repainting the oversized frame then scrolled the banner's first rows out of view, which appeared as an intermittently truncated first paint.

Using the row budget as a maximum instead of a required height avoids the unnecessary overflow without changing how tall dialogs are constrained.

## Reviewer Test Plan

### How to verify

Start the interactive CLI with a pending built-in provider update and height constraints enabled. The startup banner should remain fully visible when the update prompt appears. Dismiss the prompt and confirm the normal composer appears without duplicate banner output. Also open a dialog taller than the terminal and confirm that it remains clipped to the available rows. With height constraints disabled, confirm that tall dialogs retain their existing uncapped behavior.

### Evidence (Before & After)

Before: a one-line dialog in a 24-row terminal produced a 24-row layout, consuming the entire viewport and displacing the top of the startup banner.

After: the same constrained short dialog matches its natural unconstrained height (3 rows in the regression fixture), while the existing tall-dialog tests continue to verify clipping.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 24.18.0 on Windows 11. Verified against the historical nightly from the original report and the current main branch.

## Risk & Scope

- Main risk or tradeoff: short dialogs no longer fill unused vertical space; tall dialogs preserve the existing cap and clipping behavior.
- Not validated / out of scope: reporter-specific provider credentials and terminal combinations; the reporter can confirm the original end-to-end launch configuration.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #8124

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当受高度约束的对话框内容能够放入终端时，让对话框保持其自然高度；当对话框超过可用终端空间时，继续沿用现有的最大高度裁剪行为。

## 为什么需要

对话框容器此前把计算出的行数预算当作固定高度。因此，一个很短的启动提示也会被填充到接近整个终端的高度。它与已经提交的启动横幅叠加后会超过视口，并触发 Ink 的全终端清屏路径。随后重新绘制这个过高的帧时，横幅顶部几行会被滚出可见区域，看起来就像首次绘制偶发截断。

把行数预算作为最大高度而不是强制高度，可以避免不必要的溢出，同时不改变高对话框的约束方式。

## 评审测试计划

### 如何验证

在存在待处理内置 provider 更新并启用高度约束的情况下启动交互式 CLI。更新提示出现时，启动横幅应保持完整可见。关闭提示后，确认普通输入框出现，并且横幅没有重复输出。再打开一个高于终端的对话框，确认它仍被裁剪到可用行数。关闭高度约束后，确认高对话框仍保持原有的不封顶行为。

### 证据（修复前后）

修复前：在 24 行终端中，一个单行对话框会生成 24 行布局，占满整个视口并挤掉启动横幅顶部。

修复后：同一个受约束的短对话框与其自然的非约束高度一致（回归测试中为 3 行），现有高对话框测试仍验证裁剪行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows |  ✅  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Windows 11，Node.js 24.18.0。已在原始报告使用的历史 nightly 和当前 main 分支上验证。

## 风险与范围

- 主要风险或权衡：短对话框不再填满未使用的垂直空间；高对话框保留现有的高度上限和裁剪行为。
- 未验证或超出范围：报告者特定的 provider 凭据和终端组合；报告者可以确认原始端到端启动配置。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #8124

</details>
