### PR TITLE
fix(core): double-check parent abort after listener registration

### DIFF
--- a/packages/core/src/utils/abortController.test.ts
+++ b/packages/core/src/utils/abortController.test.ts
@@ -104,6 +104,25 @@ describe('createChildAbortController', () => {
     const child = createChildAbortController(parent, 123);
     expect(getMaxListeners(child.signal)).toBe(123);
   });
+
+  it('cleans up and aborts child if parent is aborted at registration', () => {
+    const parent = createAbortController();
+    const originalAddEventListener = parent.signal.addEventListener.bind(
+      parent.signal,
+    );
+    vi.spyOn(parent.signal, 'addEventListener').mockImplementation(
+      (type, listener, options) => {
+        originalAddEventListener(type, listener, options);
+        if (type === 'abort') {
+          parent.abort('interleaved-abort');
+        }
+      },
+    );
+    const child = createChildAbortController(parent);
+    expect(child.signal.aborted).toBe(true);
+    expect(child.signal.reason).toBe('interleaved-abort');
+    expect(getEventListeners(parent.signal, 'abort').length).toBe(0);
+  });
 });
 
 describe('combineAbortSignals', () => {

--- a/packages/core/src/utils/abortController.ts
+++ b/packages/core/src/utils/abortController.ts
@@ -84,6 +84,11 @@ export function createChildAbortController(
 
   parentSignal.addEventListener('abort', handler, { once: true });
 
+  if (parentSignal.aborted) {
+    weakParent.deref()?.removeEventListener('abort', handler);
+    child.abort(parentSignal.reason);
+  }
+
   child.signal.addEventListener(
     'abort',
     () => {


### PR DESCRIPTION
## What this PR does

Adds a post-registration abort check to `createChildAbortController`, matching the same defensive pattern already used in `combineAbortSignals` in the same file.

## Why it's needed

`createChildAbortController` checks `parentSignal.aborted` before registering the abort listener. If the parent aborts right after that check, before `addEventListener` completes, the child controller does not get aborted and the handler remains attached to the parent signal.

`combineAbortSignals` in the same file already includes a re-check for this (lines 128-131). Adding the post-registration check here keeps the behavior consistent across helper functions:

```ts
if (parentSignal.aborted) {
  weakParent.deref()?.removeEventListener('abort', handler);
  child.abort(parentSignal.reason);
}
```

## Reviewer Test Plan

### How to verify

Run the abortController unit test suite:

```bash
cd packages/core && npx vitest run src/utils/abortController.test.ts
```

Added a test covering parent abort during registration to verify immediate child abort and listener cleanup.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: None. `removeEventListener` is idempotent and child abort cleanup remains unchanged.
- Not validated / out of scope: N/A
- Breaking changes / migration notes: None

## Linked Issues

Fixes #10262

<details>
<summary>中文说明</summary>

在 `createChildAbortController` 中添加注册后的二次检查，与同文件中 `combineAbortSignals` 已有的防御模式保持一致。

如果父信号在初始检查和 `addEventListener` 之间中止，子控制器不会被中止且监听器会泄漏。添加注册后的 `parentSignal.aborted` 检查可以立即清理并传播中止。

</details>
