### PR TITLE
fix(core): Harden surviving hook supervision

### DIFF
--- a/docs/design/2026-08-29-surviving-hook-supervisor-hardening.md
+++ b/docs/design/2026-08-29-surviving-hook-supervisor-hardening.md
@@ -1,0 +1,72 @@
+# Surviving hook supervisor hardening
+
+## Context
+
+PR #10288 made command hooks for `MessageDisplay`, `StopFailure`, and
+`SessionDelete` independent of the Qwen process by staging input and launching
+a detached Node supervisor. Issue #10386 tracks the non-blocking hardening work
+deferred from that PR.
+
+The current `main` already preserves a real hook exit code 124 when only the
+parent event loop is delayed, cleans staged input after an early supervisor
+exit, and documents generic asynchronous hooks as process-scoped. The remaining
+work is limited to the supervisor boundary, its timeout decision, Windows
+termination parity, and missing regression coverage.
+
+## Audited scope
+
+| Issue item                                    | Current status                                                           | This change                                                                                                                                          |
+| --------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Explicit argv boundary and timeout validation | Still reproducible                                                       | Add `--` after the eval source and reject non-positive or non-finite hook timeouts before dispatch                                                   |
+| Parent/supervisor teardown duplication        | Windows fallback behavior has drifted                                    | Keep the standalone eval boundary, share constants, and align success/error/throw fallback semantics                                                 |
+| Windows supervisor coverage                   | Entire real-process suite is skipped on Windows                          | Add a Windows-only real supervisor test that verifies liveness and descendant cleanup through taskkill                                               |
+| Near-deadline completion race                 | Still reproducible inside the supervisor                                 | Give child exit delivery the current event-loop turn before committing to timeout and let natural completion win when no termination signal was sent |
+| Loader environment isolation                  | `LD_PRELOAD` and `DYLD_INSERT_LIBRARIES` reach the internal Node process | Remove loader variables from the supervisor environment and pass them as inert JSON for restoration only in the configured hook                      |
+| Parent-side staged-input cleanup coverage     | Runtime behavior is already correct                                      | Add a regression test for a supervisor that closes before unlinking                                                                                  |
+| Generic async lifecycle compatibility         | Runtime, docs, and the final merged PR statement are already correct     | Keep generic async hooks process-scoped; no runtime or documentation change is needed                                                                |
+
+## Design
+
+The supervisor remains an eval program. Moving it to a separate executable
+asset would make the source easier to share but would add bundle and asset-copy
+requirements for a small internal process. Instead, the parent and supervisor
+continue to share termination constants, while tests pin the mirrored Windows
+fallback behavior.
+
+Hook timeout validation happens at `HookRunner.executeHook`, the common runtime
+boundary used by sequential, parallel, synchronous, and asynchronous dispatch.
+It does not change timeout units or defaults for any hook type.
+
+The parent removes `NODE_OPTIONS`, `LD_PRELOAD`, and
+`DYLD_INSERT_LIBRARIES` from the internal supervisor environment. Defined
+values are serialized as one JSON argv value. The supervisor restores those
+values only in the actual hook environment, so user-configured hook behavior is
+preserved without allowing loader configuration to alter the internal Node
+program.
+
+At the deadline, timeout handling is deferred to the check phase of the same
+event-loop turn. This lets a child exit already waiting for delivery update the
+supervisor state first. If the process group disappeared before a termination
+signal could be sent, the supervisor keeps the natural result rather than
+inventing a timeout. A genuinely live group is still terminated at the same
+configured deadline, apart from the bounded current-turn scheduling delay.
+
+## Verification
+
+- Unit tests reject invalid timeout values without spawning a hook, verify the
+  explicit argv separator and loader environment transfer, align Windows
+  fallback behavior, and prove parent cleanup after an early supervisor close.
+- POSIX process tests distinguish a real timeout from natural exit 0 and exit
+  124 within the supervisor's final poll interval.
+- A Windows-only process test launches the real supervisor and a hook descendant,
+  then verifies timeout cleanup through the real taskkill path.
+- Existing parent-exit, timeout, abort, input integrity, and process-scoped async
+  tests remain green.
+
+## Compatibility and risk
+
+Invalid configured timeouts now fail before hook dispatch instead of relying on
+platform timer coercion. Generic `async: true` command hooks remain scoped to
+the Qwen process as shipped by #10288; this is a compatibility clarification,
+not a new lifecycle change in this patch. Windows runtime verification depends
+on the repository's Windows test lane.

--- a/packages/core/src/hooks/hook-runner.process.test.ts
+++ b/packages/core/src/hooks/hook-runner.process.test.ts
@@ -5,7 +5,14 @@
  */
 
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -666,6 +673,106 @@ setInterval(() => {}, 1000);
       }
     }, 10_000);
 
+    it.each([0, 124])(
+      'preserves a natural exit %s within the final supervisor poll interval',
+      async (exitCode) => {
+        const tempDir = await mkdtemp(
+          join(tmpdir(), 'qwen-hook-deadline-race-'),
+        );
+        let hookPid: number | undefined;
+        let observedNaturalCompletion = false;
+
+        try {
+          const sleepDurations = [0.17, 0.18, 0.19, 0.2, 0.21, 0.18, 0.19, 0.2];
+          for (const [attempt, sleepDuration] of sleepDurations.entries()) {
+            const attemptDir = join(tempDir, String(attempt));
+            await mkdir(attemptDir, { recursive: true });
+            const hookPidPath = join(attemptDir, 'hook.pid');
+            const readyPath = join(attemptDir, 'hook.ready');
+            const completedPath = join(attemptDir, 'hook.completed');
+            const termPath = join(attemptDir, 'hook.term');
+            hookPid = undefined;
+            let hookGoneAt = Number.POSITIVE_INFINITY;
+            let resultAt = Number.NEGATIVE_INFINITY;
+            const runner = new HookRunner();
+            const resultPromise = runner.executeHook(
+              {
+                type: HookType.Command,
+                command: `trap 'printf term > ${JSON.stringify(termPath)}; exit 143' TERM; printf '%s' "$$" > ${JSON.stringify(hookPidPath)}; : > ${JSON.stringify(readyPath)}; sleep ${sleepDuration}; : > ${JSON.stringify(completedPath)}; exit ${exitCode}`,
+                source: HooksConfigSource.Project,
+                shell: 'bash',
+                timeout: 290,
+              },
+              HookEventName.SessionDelete,
+              {
+                session_id: 'surviving-deadline-race-test',
+                transcript_path: join(attemptDir, 'transcript.jsonl'),
+                cwd: attemptDir,
+                hook_event_name: HookEventName.SessionDelete,
+                timestamp: new Date().toISOString(),
+              },
+            );
+
+            await waitFor(async () => {
+              hookPid = await readPid(hookPidPath);
+              return (
+                hookPid !== undefined &&
+                (await readFile(readyPath, 'utf8').catch(() => undefined)) !==
+                  undefined
+              );
+            }, 5000);
+            const readyAt = Date.now();
+            const hookGonePromise = waitFor(
+              () => !isRunning(hookPid as number),
+              5000,
+            ).then(() => {
+              hookGoneAt = Date.now();
+            });
+            const observedResultPromise = resultPromise.then((result) => {
+              resultAt = Date.now();
+              return result;
+            });
+            const [result] = await Promise.all([
+              observedResultPromise,
+              hookGonePromise,
+            ]);
+            const completed =
+              (await readFile(completedPath, 'utf8').catch(() => undefined)) !==
+              undefined;
+            const terminated =
+              (await readFile(termPath, 'utf8').catch(() => undefined)) !==
+              undefined;
+            if (
+              completed &&
+              !terminated &&
+              hookGoneAt >= readyAt + 180 &&
+              hookGoneAt <= resultAt
+            ) {
+              observedNaturalCompletion = true;
+              expect(result).toMatchObject({
+                success: exitCode === 0,
+                exitCode,
+              });
+              expect(result.error).toBeUndefined();
+              break;
+            }
+          }
+
+          expect(observedNaturalCompletion).toBe(true);
+        } finally {
+          if (hookPid && isRunning(hookPid)) {
+            try {
+              process.kill(-hookPid, 'SIGKILL');
+            } catch {
+              // Already gone.
+            }
+          }
+          await rm(tempDir, { recursive: true, force: true });
+        }
+      },
+      15_000,
+    );
+
     it('isolates the supervisor from hook NODE_OPTIONS', async () => {
       const tempDir = await mkdtemp(join(tmpdir(), 'qwen-hook-node-options-'));
       const preloadPath = join(tempDir, 'preload.cjs');
@@ -896,7 +1003,7 @@ setInterval(() => {}, 1000);
             command,
             source: HooksConfigSource.Project,
             shell: 'bash',
-            timeout: 300,
+            timeout: 1000,
           },
           HookEventName.SessionDelete,
           input,
@@ -906,7 +1013,7 @@ setInterval(() => {}, 1000);
         expect(descendantPid).toBeDefined();
         expect(result).toMatchObject({
           success: false,
-          error: { message: 'Hook timed out after 300ms' },
+          error: { message: 'Hook timed out after 1000ms' },
         });
         await waitFor(() => !isRunning(descendantPid as number), 3000);
       } finally {
@@ -1029,5 +1136,137 @@ writeFileSync(process.argv[2], JSON.stringify({ bytes: Buffer.byteLength(input),
         await rm(tempDir, { recursive: true, force: true });
       }
     }, 10_000);
+  },
+);
+
+describe.skipIf(process.platform !== 'win32')(
+  'HookRunner surviving hook supervisor on Windows',
+  () => {
+    const quotePowerShellArg = (value: string) =>
+      `'${value.replaceAll("'", "''")}'`;
+    const getWindowsParentPid = (pid: number): number | undefined => {
+      const result = spawnSync(
+        'powershell',
+        [
+          '-NoProfile',
+          '-Command',
+          `(Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = ${pid}").ParentProcessId`,
+        ],
+        { encoding: 'utf8', windowsHide: true },
+      );
+      const parentPid = Number.parseInt(result.stdout?.trim() ?? '', 10);
+      return result.status === 0 &&
+        Number.isSafeInteger(parentPid) &&
+        parentPid > 0
+        ? parentPid
+        : undefined;
+    };
+
+    it('keeps the real supervisor alive and taskkills the hook tree on timeout', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'qwen-hook-windows-'));
+      const fixturePath = join(tempDir, 'hook.mjs');
+      const descendantPath = join(tempDir, 'descendant.mjs');
+      const hookRootPidPath = join(tempDir, 'hook-root.pid');
+      const fixturePidPath = join(tempDir, 'fixture.pid');
+      const descendantPidPath = join(tempDir, 'descendant.pid');
+      const readyPath = join(tempDir, 'descendant.ready');
+      let supervisorPid: number | undefined;
+      let hookRootPid: number | undefined;
+      let fixturePid: number | undefined;
+      let descendantPid: number | undefined;
+
+      try {
+        await writeFile(
+          fixturePath,
+          `import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+writeFileSync(process.argv[2], String(process.ppid));
+writeFileSync(process.argv[3], String(process.pid));
+const descendant = spawn(process.execPath, [process.argv[4], process.argv[5], process.argv[6]], { stdio: 'ignore', windowsHide: true });
+writeFileSync(process.argv[5], String(descendant.pid));
+setInterval(() => {}, 1000);
+`,
+        );
+        await writeFile(
+          descendantPath,
+          `import { writeFileSync } from 'node:fs';
+
+writeFileSync(process.argv[3], 'ready');
+setInterval(() => {}, 1000);
+`,
+        );
+        const command = [
+          '&',
+          quotePowerShellArg(process.execPath),
+          quotePowerShellArg(fixturePath),
+          quotePowerShellArg(hookRootPidPath),
+          quotePowerShellArg(fixturePidPath),
+          quotePowerShellArg(descendantPath),
+          quotePowerShellArg(descendantPidPath),
+          quotePowerShellArg(readyPath),
+        ].join(' ');
+        const runner = new HookRunner();
+        const resultPromise = runner.executeHook(
+          {
+            type: HookType.Command,
+            command,
+            source: HooksConfigSource.Project,
+            shell: 'powershell',
+            timeout: 10_000,
+          },
+          HookEventName.MessageDisplay,
+          {
+            session_id: 'surviving-windows-test',
+            transcript_path: join(tempDir, 'transcript.jsonl'),
+            cwd: tempDir,
+            hook_event_name: HookEventName.MessageDisplay,
+            timestamp: new Date().toISOString(),
+          },
+        );
+
+        await waitFor(async () => {
+          hookRootPid = await readPid(hookRootPidPath);
+          fixturePid = await readPid(fixturePidPath);
+          descendantPid = await readPid(descendantPidPath);
+          return (
+            hookRootPid !== undefined &&
+            fixturePid !== undefined &&
+            descendantPid !== undefined &&
+            (await readFile(readyPath, 'utf8').catch(() => '')) === 'ready'
+          );
+        }, 7500);
+        supervisorPid = getWindowsParentPid(hookRootPid as number);
+        expect(supervisorPid).toBeDefined();
+        expect(supervisorPid).not.toBe(process.pid);
+        expect(isRunning(supervisorPid as number)).toBe(true);
+
+        const result = await resultPromise;
+        expect(result.error?.message).toBe('Hook timed out after 10000ms');
+        await waitFor(
+          () =>
+            !isRunning(supervisorPid as number) &&
+            !isRunning(hookRootPid as number) &&
+            !isRunning(fixturePid as number) &&
+            !isRunning(descendantPid as number),
+          5000,
+        );
+      } finally {
+        const taskkill = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+        for (const pid of [
+          supervisorPid,
+          hookRootPid,
+          fixturePid,
+          descendantPid,
+        ]) {
+          if (pid && isRunning(pid)) {
+            spawnSync(taskkill, ['/f', '/t', '/pid', String(pid)], {
+              windowsHide: true,
+            });
+          }
+        }
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    }, 20_000);
   },
 );

--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -5,9 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, readdir, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { access } from 'node:fs/promises';
 import { HookRunner } from './hookRunner.js';
 import {
   HookEventName,
@@ -148,6 +146,26 @@ describe('HookRunner', () => {
   };
 
   describe('executeHook', () => {
+    it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+      'rejects invalid timeout %s before dispatch',
+      async (timeout) => {
+        const result = await hookRunner.executeHook(
+          {
+            type: HookType.Command,
+            command: 'echo test',
+            timeout,
+          },
+          HookEventName.PreToolUse,
+          createMockInput(),
+        );
+
+        expect(result.error?.message).toBe(
+          'Hook timeout must be a positive finite number',
+        );
+        expect(mockSpawn).not.toHaveBeenCalled();
+      },
+    );
+
     it('should return error when hook command is missing', async () => {
       const hookConfig: HookConfig = {
         type: HookType.Command,
@@ -1128,7 +1146,9 @@ describe('HookRunner', () => {
         expect(mockSpawn).toHaveBeenCalledTimes(2);
         for (const call of mockSpawn.mock.calls) {
           expect(call[0]).toBe(process.execPath);
-          expect(call[1]).toContain('--eval');
+          const evalIndex = call[1].indexOf('--eval');
+          expect(evalIndex).toBeGreaterThanOrEqual(0);
+          expect(call[1][evalIndex + 2]).toBe('--');
           expect(call[2].stdio).toEqual(['ignore', 'ignore', 'ignore', 'pipe']);
           expect(call[2].detached).toBe(true);
         }
@@ -1139,30 +1159,65 @@ describe('HookRunner', () => {
     );
 
     it('removes staged input when the supervisor spawn throws', async () => {
-      const tempDir = await mkdtemp(join(tmpdir(), 'qwen-hook-spawn-error-'));
-      const originalTmpDir = process.env['TMPDIR'];
-      process.env['TMPDIR'] = tempDir;
-      mockSpawn.mockImplementation(() => {
+      let stagedInputPath: string | undefined;
+      mockSpawn.mockImplementation((_executable, args: string[]) => {
+        stagedInputPath = args[args.indexOf('--') + 1];
         throw new Error('spawn failed');
       });
 
-      try {
-        const result = await hookRunner.executeHook(
-          hookConfig,
-          HookEventName.SessionDelete,
-          createMockInput({ hook_event_name: HookEventName.SessionDelete }),
-        );
+      const result = await hookRunner.executeHook(
+        hookConfig,
+        HookEventName.SessionDelete,
+        createMockInput({ hook_event_name: HookEventName.SessionDelete }),
+      );
 
-        expect(result.error?.message).toBe('spawn failed');
-        expect(await readdir(tempDir)).toEqual([]);
-      } finally {
-        if (originalTmpDir === undefined) {
-          delete process.env['TMPDIR'];
-        } else {
-          process.env['TMPDIR'] = originalTmpDir;
-        }
-        await rm(tempDir, { recursive: true, force: true });
-      }
+      expect(result.error?.message).toBe('spawn failed');
+      expect(stagedInputPath).toBeDefined();
+      await expect(access(stagedInputPath as string)).rejects.toThrow();
+    });
+
+    it('removes staged input when the supervisor closes before unlinking', async () => {
+      const supervisor = createControllableMockProcess();
+      mockSpawn.mockReturnValue(supervisor);
+
+      const resultPromise = hookRunner.executeHook(
+        hookConfig,
+        HookEventName.SessionDelete,
+        createMockInput({ hook_event_name: HookEventName.SessionDelete }),
+      );
+      const args = mockSpawn.mock.calls[0][1] as string[];
+      const stagedInputPath = args[args.indexOf('--') + 1];
+      await expect(access(stagedInputPath)).resolves.toBeUndefined();
+
+      supervisor.emit('close', 1);
+      const result = await resultPromise;
+
+      expect(result).toMatchObject({ success: false, exitCode: 1 });
+      await expect(access(stagedInputPath)).rejects.toThrow();
+    });
+
+    it('isolates the supervisor from loader variables passed to the hook', async () => {
+      mockSpawn.mockReturnValue(createMockProcess());
+      const loaderEnv = {
+        NODE_OPTIONS: '--require=/hook/preload.cjs',
+        LD_PRELOAD: '/hook/preload.so',
+        DYLD_INSERT_LIBRARIES: '/hook/preload.dylib',
+      };
+
+      await hookRunner.executeHook(
+        { ...hookConfig, env: loaderEnv },
+        HookEventName.StopFailure,
+        createMockInput({ hook_event_name: HookEventName.StopFailure }),
+      );
+
+      const args = mockSpawn.mock.calls[0][1] as string[];
+      const options = mockSpawn.mock.calls[0][2] as {
+        env: NodeJS.ProcessEnv;
+      };
+      expect(options.env).not.toHaveProperty('NODE_OPTIONS');
+      expect(options.env).not.toHaveProperty('LD_PRELOAD');
+      expect(options.env).not.toHaveProperty('DYLD_INSERT_LIBRARIES');
+      expect(JSON.parse(args.at(-1) as string)).toEqual(loaderEnv);
     });
 
     it('keeps output capture for process-scoped async hooks', async () => {

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -55,6 +55,12 @@ const HOOK_PROCESS_GROUP_POLL_MS = 50;
 const HOOK_CHILD_CLOSE_WAIT_MS = 1000;
 const WINDOWS_TASKKILL_TIMEOUT_MS = 2000;
 const WINDOWS_TASKKILL = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
+const WINDOWS_TASKKILL_ARGS_PREFIX = ['/f', '/t', '/pid'] as const;
+const SURVIVING_HOOK_LOADER_ENV_VARS = [
+  'NODE_OPTIONS',
+  'LD_PRELOAD',
+  'DYLD_INSERT_LIBRARIES',
+] as const;
 const SURVIVING_HOOK_TIMEOUT_EXIT_CODE = 124;
 const SURVIVING_HOOK_SUPERVISOR_GRACE_MS =
   HOOK_TERMINATE_GRACE_MS + HOOK_PROCESS_GROUP_POLL_MS * 2;
@@ -73,13 +79,13 @@ const [
   graceValue,
   executable,
   argsValue,
-  nodeOptionsValue,
+  loaderEnvValue,
 ] =
   process.argv.slice(1);
 const timeout = Number(timeoutValue);
 const grace = Number(graceValue);
 const args = JSON.parse(argsValue);
-const originalNodeOptions = JSON.parse(nodeOptionsValue);
+const originalLoaderEnv = JSON.parse(loaderEnvValue);
 const pollInterval = ${HOOK_PROCESS_GROUP_POLL_MS};
 const timeoutExitCode = ${SURVIVING_HOOK_TIMEOUT_EXIT_CODE};
 const signalExitCode = 143;
@@ -138,36 +144,50 @@ const waitForGroupExit = async () => {
   return !groupAlive();
 };
 
+const forceKillDirectHook = () => {
+  if (hook.exitCode !== null) return false;
+  try {
+    return hook.kill('SIGKILL');
+  } catch {
+    return false;
+  }
+};
+
 const terminateWindowsTree = () =>
   new Promise((resolve) => {
-    if (!hook?.pid) {
-      resolve();
+    if (!hook?.pid || hook.exitCode !== null) {
+      resolve(false);
       return;
     }
     const taskkill = ${JSON.stringify(WINDOWS_TASKKILL)};
-    execFile(
-      taskkill,
-      ['/f', '/t', '/pid', String(hook.pid)],
-      { windowsHide: true, timeout: ${WINDOWS_TASKKILL_TIMEOUT_MS} },
-      () => {
-        try {
-          hook.kill('SIGKILL');
-        } catch {}
-        resolve();
-      },
-    );
+    try {
+      execFile(
+        taskkill,
+        [...${JSON.stringify(WINDOWS_TASKKILL_ARGS_PREFIX)}, String(hook.pid)],
+        { windowsHide: true, timeout: ${WINDOWS_TASKKILL_TIMEOUT_MS} },
+        (error) => {
+          if (error) {
+            resolve(forceKillDirectHook());
+            return;
+          }
+          resolve(true);
+        },
+      );
+    } catch {
+      resolve(forceKillDirectHook());
+    }
   });
 
 const terminate = () => {
   if (terminationPromise) return terminationPromise;
   terminationPromise = (async () => {
     if (process.platform === 'win32') {
-      await terminateWindowsTree();
-      return;
+      return terminateWindowsTree();
     }
-    if (!signalGroup('SIGTERM')) return;
-    if (await waitForGroupExit()) return;
+    if (!signalGroup('SIGTERM')) return false;
+    if (await waitForGroupExit()) return true;
     signalGroup('SIGKILL');
+    return true;
   })();
   return terminationPromise;
 };
@@ -195,10 +215,12 @@ let inputFd;
 try {
   inputFd = openSync(inputPath, 'r');
   const hookEnv = { ...process.env };
-  if (originalNodeOptions === null) {
-    delete hookEnv.NODE_OPTIONS;
-  } else {
-    hookEnv.NODE_OPTIONS = originalNodeOptions;
+  for (const name of ${JSON.stringify(SURVIVING_HOOK_LOADER_ENV_VARS)}) {
+    if (Object.hasOwn(originalLoaderEnv, name)) {
+      hookEnv[name] = originalLoaderEnv[name];
+    } else {
+      delete hookEnv[name];
+    }
   }
   hook = spawn(executable, args, {
     cwd: process.cwd(),
@@ -239,10 +261,27 @@ pollHandle = setInterval(() => {
   }
 }, pollInterval);
 
-timeoutHandle = setTimeout(() => {
+const handleTimeout = () => {
+  if (finished || terminationExitCode !== undefined) return;
+  if (rootClosed && !groupAlive()) {
+    exit(rootExitCode, 'completed');
+    return;
+  }
   terminationExitCode = timeoutExitCode;
-  void terminate().then(() => exit(terminationExitCode, 'timed_out'));
-}, timeout);
+  void terminate().then((terminated) => {
+    if (finished) return;
+    if (!terminated) {
+      terminationExitCode = undefined;
+      if (rootClosed && !groupAlive()) {
+        exit(rootExitCode, 'completed');
+      }
+      return;
+    }
+    exit(timeoutExitCode, 'timed_out');
+  });
+};
+
+timeoutHandle = setTimeout(() => setImmediate(handleTimeout), timeout);
 `;
 
 const activePosixHookProcesses = new Set<ChildProcess>();
@@ -419,7 +458,7 @@ async function terminateWindowsHookProcessTree(
     try {
       execFile(
         WINDOWS_TASKKILL,
-        ['/f', '/t', '/pid', pid.toString()],
+        [...WINDOWS_TASKKILL_ARGS_PREFIX, pid.toString()],
         {
           windowsHide: true,
           timeout: WINDOWS_TASKKILL_TIMEOUT_MS,
@@ -549,6 +588,19 @@ export class HookRunner {
         outcome: 'cancelled',
         error: new Error(`Hook execution cancelled (aborted): ${hookId}`),
         duration: 0,
+      };
+    }
+
+    if (
+      hookConfig.timeout !== undefined &&
+      (!Number.isFinite(hookConfig.timeout) || hookConfig.timeout <= 0)
+    ) {
+      return {
+        hookConfig,
+        eventName,
+        success: false,
+        error: new Error('Hook timeout must be a positive finite number'),
+        duration: Date.now() - startTime,
       };
     }
 
@@ -1098,7 +1150,14 @@ export class HookRunner {
       if (survivesParentExit) {
         parentIndependentInputPath = createSurvivingHookInputFile(input);
         const supervisorEnv = { ...env };
-        delete supervisorEnv['NODE_OPTIONS'];
+        const hookLoaderEnv: Record<string, string> = {};
+        for (const name of SURVIVING_HOOK_LOADER_ENV_VARS) {
+          const value = supervisorEnv[name];
+          if (value !== undefined) {
+            hookLoaderEnv[name] = value;
+          }
+          delete supervisorEnv[name];
+        }
         try {
           child = spawn(
             process.execPath,
@@ -1106,12 +1165,13 @@ export class HookRunner {
               '--input-type=commonjs',
               '--eval',
               SURVIVING_HOOK_SUPERVISOR_SOURCE,
+              '--',
               parentIndependentInputPath,
               String(timeout),
               String(HOOK_TERMINATE_GRACE_MS),
               shellConfig.executable,
               JSON.stringify([...shellConfig.argsPrefix, command]),
-              JSON.stringify(env['NODE_OPTIONS'] ?? null),
+              JSON.stringify(hookLoaderEnv),
             ],
             {
               env: supervisorEnv,


### PR DESCRIPTION
## What this PR does

This PR hardens the parent-independent supervisor used by `MessageDisplay`, `StopFailure`, and `SessionDelete` command hooks. It validates configured timeouts before dispatch, adds an explicit Node argv separator, isolates the internal supervisor from loader environment variables while restoring them for the configured hook, and synchronizes the Windows taskkill fallback with the parent-side behavior.

At the deadline, the supervisor now lets already-delivered child completion win and reports timeout only when a process-tree termination action was actually sent. Natural exit 0 and a genuine hook exit 124 therefore retain their real outcomes within the final polling interval. The change also adds parent-side staged-input cleanup coverage and a Windows-only real-process test for supervisor liveness and descendant cleanup.

Generic `async: true` hooks remain process-scoped, matching the existing runtime, lifecycle documentation, and the final compatibility statement on #10288.

## Why it's needed

#10288 fixed the original parent-exit bug but intentionally deferred seven Suggestion-level hardening items after review round 5. The remaining gaps could let Node parse staged-input paths as options, coerce invalid timeouts, preload code into the internal supervisor, drift between parent and supervisor Windows cleanup, or misclassify a hook that had already exited naturally as timed out.

Closing these gaps makes the supervisor boundary deterministic without expanding the lifecycle contract or changing which hook events may outlive Qwen.

## Reviewer Test Plan

### How to verify

Run the HookRunner unit and real-process suites from the Core package. Confirm that invalid non-positive or non-finite timeouts fail without spawning, the supervisor argv includes `--`, loader variables are absent from the supervisor but preserved for the hook, and staged input is removed even when the supervisor closes before unlinking it.

Confirm that a hook completing within the final supervisor poll interval returns its natural exit 0 or 124 result, while a genuinely live hook still times out and its process group is reclaimed. On Windows, run the real-process test and confirm that the detached supervisor remains independently alive until timeout and taskkill removes the PowerShell hook root, fixture process, and descendant.

Expected result: all Core hooks tests pass; natural completion is never reported as timeout unless a termination action was actually sent; existing parent-exit, abort, descendant, input-integrity, and process-scoped async behavior remains unchanged.

### Evidence (Before & After)

N/A — non-UI process lifecycle hardening.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS Darwin 25.4.0 arm64; Node.js v22.22.3; npm 10.9.8. Core build and typecheck passed; all 786 locally runnable hooks tests passed with one Windows-only test skipped; focused HookRunner tests passed 93/93; changed-file ESLint, Prettier, and diff checks passed. An independent strengthened deadline probe passed 5/5. Full-repository build and typecheck remain blocked by the worktree's unchanged local dependency drift, including missing Ink selection extensions and generated Web UI dependencies.

## Risk & Scope

- Main risk or tradeoff: configured `NODE_OPTIONS`, `LD_PRELOAD`, and `DYLD_INSERT_LIBRARIES` are serialized through supervisor argv before being restored only for the actual hook; the values remain intentionally available to that hook.
- Not validated / out of scope: the Windows-only real-process branch was statically audited but cannot run on the local macOS host; CI must provide the dynamic Windows result. Existing untrappable host-failure and Windows root-before-descendant limitations from #10288 remain out of scope.
- Breaking changes / migration notes: hook timeout values must now be positive finite numbers. Invalid values return a non-fatal configuration failure and do not launch the hook. Generic asynchronous hook lifecycle behavior is unchanged.

## Linked Issues

Closes #10386.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 加固了 `MessageDisplay`、`StopFailure` 和 `SessionDelete` 命令 Hook 使用的父进程独立 supervisor。它会在分发前校验配置的 timeout，增加显式 Node argv 分隔符，隔离内部 supervisor 与动态加载环境变量并仅为配置的 Hook 恢复这些变量，同时让 Windows taskkill fallback 与父进程侧行为保持一致。

到达 deadline 时，supervisor 现在会优先采用已经送达的子进程完成结果，并且只有在确实发出进程树终止动作时才报告 timeout。因此，在最后一个轮询区间内自然 exit 0 或真实 exit 124 的 Hook 都会保留实际结果。本次改动还补充了父进程侧暂存输入清理覆盖，以及一个仅在 Windows 执行的真实进程测试，用于验证 supervisor 存活和后代进程清理。

普通 `async: true` Hook 继续保持进程级生命周期，与现有运行时、生命周期文档以及 #10288 最终兼容性说明一致。

## 为什么需要

#10288 修复了最初的父进程退出问题，但在第 5 轮评审后有意将七个 Suggestion 级加固项延期处理。剩余缺口可能导致 Node 将暂存输入路径解析为选项、非法 timeout 被平台计时器强制转换、动态加载配置注入内部 supervisor、父进程与 supervisor 的 Windows 清理行为漂移，或者已经自然退出的 Hook 被误判为 timeout。

关闭这些缺口可以让 supervisor 边界变得确定，同时不扩大生命周期契约，也不改变哪些 Hook 事件可以比 Qwen 存活更久。

## 审阅者测试计划

### 验证方法

在 Core 包中运行 HookRunner 单元测试和真实进程测试。确认非正数或非有限 timeout 会在不启动进程的情况下失败；supervisor argv 包含 `--`；动态加载变量不会进入 supervisor，但仍为真实 Hook 保留；即使 supervisor 在自行 unlink 前关闭，暂存输入也会被删除。

确认在 supervisor 最后一个轮询区间内完成的 Hook 会返回自然 exit 0 或 exit 124 结果，而真实存活的 Hook 仍会 timeout 并回收其进程组。在 Windows 上运行真实进程测试，确认 detached supervisor 会独立存活到 timeout，随后 taskkill 会删除 PowerShell Hook 根进程、fixture 进程和后代进程。

预期结果：全部 Core hooks 测试通过；除非确实发出了终止动作，否则自然完成不会被报告为 timeout；现有父进程退出、Abort、后代进程、输入完整性和进程级 async 行为保持不变。

### 证据（前后对比）

N/A — 非 UI 的进程生命周期加固。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS Darwin 25.4.0 arm64；Node.js v22.22.3；npm 10.9.8。Core 构建和类型检查通过；本地可运行的 786 个 hooks 测试全部通过，另有 1 个 Windows-only 测试跳过；HookRunner focused 测试 93/93 通过；变更文件的 ESLint、Prettier 和 diff 检查通过；独立强化 deadline 探针 5/5 通过。全仓库构建和类型检查仍被此 worktree 中未改动的本地依赖漂移阻塞，包括缺少 Ink selection 扩展和生成的 Web UI 依赖。

## 风险与范围

- 主要风险或权衡：配置的 `NODE_OPTIONS`、`LD_PRELOAD` 和 `DYLD_INSERT_LIBRARIES` 会通过 supervisor argv 序列化传递，之后仅为真实 Hook 恢复；这些值仍按设计对该 Hook 可用。
- 未验证 / 不在范围内：Windows-only 真实进程分支已经过静态审计，但无法在本地 macOS 主机执行，动态 Windows 结果需要由 CI 提供。#10288 已记录的不可捕获主机故障，以及 Windows 根进程先于后代退出的限制仍不在本次范围内。
- 破坏性变更 / 迁移说明：Hook timeout 现在必须是正有限数。非法值会返回非致命配置失败，并且不会启动 Hook。普通异步 Hook 的生命周期行为不变。

## 关联事项

关闭 #10386。

</details>
