### PR TITLE
feat(web-shell): Add standalone chats

### DIFF
--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -11,16 +11,17 @@ sessions through their full lifecycle; standalone chats hide every
 project-only surface. No behavior falls back to the primary workspace unless
 the daemon lacks `standalone_sessions_v1`.
 
-This PR touches `packages/web-shell` (product UI) and, only where a typed
-hole is found, `packages/webui` (PR5 provider surface). It adds no daemon
-route and no SDK method.
+This PR touches only `packages/web-shell`. The #9811 WebShell cutover
+(`fe34a5cf22`) moved the PR5 provider surface from `packages/webui` into
+`packages/web-shell/client/daemon/session/`, so PR6 is fully contained in one
+package. It adds no daemon route and no SDK method.
 
 Suggested title: `feat(web-shell): Add standalone chats`.
 
 ## Merged Contract This PR Consumes
 
 Verified against `origin/main` (PR3 `34a6e918b6`, PR4 `7357136dd1`, PR5
-`ac761e11c2`).
+`ac761e11c2`, cutover `fe34a5cf22`).
 
 ### Daemon (packages/cli/src/serve)
 
@@ -30,8 +31,12 @@ Verified against `origin/main` (PR3 `34a6e918b6`, PR4 `7357136dd1`, PR5
   `POST .../load`, `POST .../resume`, `POST .../repair-directory`,
   `PATCH .../metadata`, `GET .../export`, `POST .../archive`,
   `POST .../unarchive`, `POST .../delete`.
-- Capability `standalone_sessions_v1` advertised from
-  `capabilities.ts:136` only when the full dependency set is installed.
+- Capability `standalone_sessions_v1` registered at
+  `capabilities.ts:136`, advertised only when the full dependency set is
+  installed.
+- Standalone creation rejects workspace-only request keys (`cwd`,
+  `workspaceCwd`, `sourceType`, `sourceId`, `sessionScope`, `branch`,
+  `worktree`) with `400 invalid_request`.
 
 ### SDK (packages/sdk-typescript/src/daemon)
 
@@ -39,7 +44,8 @@ Verified against `origin/main` (PR3 `34a6e918b6`, PR4 `7357136dd1`, PR5
   (`standalone-sessions.ts:16`).
 - `DaemonClient`: `createStandaloneSession` (generates the UUID, wraps
   response loss into `DaemonStandaloneCreationOutcomeUnknownError` carrying
-  `sessionId` + exact-lookup `recovery`, never auto-retries),
+  `sessionId` + exact-lookup `recovery`, never auto-retries; accepts only
+  `sessionId?`, `modelServiceId?`, `approvalMode?`),
   `listStandaloneSessions(Page)`, `getStandaloneSession` (exact lookup:
   creating / summary / not-found), `loadStandaloneSession`,
   `resumeStandaloneSession`, `repairStandaloneSessionDirectory`,
@@ -52,7 +58,7 @@ Verified against `origin/main` (PR3 `34a6e918b6`, PR4 `7357136dd1`, PR5
 resumeStandalone` statics and the `{ kind: 'standalone' }` restore
   strategy (`DaemonSessionClient.ts:444-485`, restore dispatch at :710).
 
-### WebUI provider (packages/webui/src/daemon/session)
+### Session provider (packages/web-shell/client/daemon/session, post-#9811)
 
 - `DaemonProductSessionContext` (`types.ts:71`):
   `{ kind: 'workspace'; cwd } | { kind: 'standalone' } | { kind: 'live' }`.
@@ -62,6 +68,10 @@ resumeStandalone` statics and the `{ kind: 'standalone' }` restore
   `options.sessionContext` (types.ts:438-471). Standalone create is not
   retried and is exempt from the generic 30 s action timeout; Live create is
   rejected by this provider.
+- The standalone creation lane (`createDetachedStandaloneSession`,
+  `DaemonSessionProvider.tsx:3968`) forwards only `modelServiceId` and
+  `approvalMode` to `DaemonSessionClient.createStandalone` — workspace-only
+  fields never reach the daemon.
 - Connection state exposes `sessionContext` and
   `standaloneSession?: DaemonStandaloneConnectionState`
   (`{ projectlessOutputDirectory?, workingDirectory?, creationRecovery?,
@@ -88,46 +98,55 @@ explicit context:
 | Current-session **New Chat**                     | Inherit explicit context |
 | Live Voice                                       | `live`                   |
 
-Implementation map (`packages/web-shell/client`, line numbers from
-`origin/main`; `packages/web-shell` currently has zero `sessionContext`
-references and passes legacy `workspaceCwd` everywhere):
+Implementation map (`packages/web-shell/client`, line numbers verified
+against `origin/main` after the #9811 cutover; the product UI currently has
+zero `sessionContext` references and passes legacy `workspaceCwd`
+everywhere):
 
 - **Home / global New Chat** — sidebar primary nav `handleNewSession()`
-  (`components/sidebar/WebShellSidebar.tsx:5084-5103`) →
-  `createNewSession()` (`App.tsx:8543`). Today this only clears; creation is
+  (call site `components/sidebar/WebShellSidebar.tsx:5097`) →
+  `createNewSession()` (`App.tsx:8641`). Today this only clears; creation is
   lazy. With capability, it sets pending context `{ kind: 'standalone' }`.
-  The Home first-prompt path (`ensureSessionForPrompt`, `App.tsx:6095`,
-  target-cwd resolution at `6126-6140` →
+  The Home first-prompt path (`ensureSessionForPrompt`, `App.tsx:6179`,
+  target-cwd resolution inside it →
   `utils/sessionPreparation.ts#createAndAttachSessionForPrompt`) consumes
   the pending context instead of resolving locked/selected/primary cwd.
+- **Standalone creation omits workspace-only fields** (review P1).
+  `createAndAttachSessionForPrompt` always passes
+  `sourceType: WEB_SHELL_SESSION_SOURCE_TYPE` and may pass
+  `worktree`/`branch`; the daemon rejects all of these on the standalone
+  route, and the provider's standalone lane accepts neither. The creation
+  flow therefore branches: a standalone pending context dispatches
+  `createSession({ sessionContext: { kind: 'standalone' }, approvalMode? })`
+  only — never the generic helper's `sourceType`/`worktree`/`branch`
+  payload. Tests assert the exact request body for both branches.
 - **Project-scoped New Chat** — `handleNewSession(wsCwd)`
-  (`WebShellSidebar.tsx:5509-5514`) → `createNewSession(workspaceCwd)`;
+  (`WebShellSidebar.tsx:5514`) → `createNewSession(workspaceCwd)`;
   unchanged, pending context `{ kind: 'workspace', cwd }`.
-- **Goals** — `onCreateGoal` (`App.tsx:13080-13142`) allocates through
+- **Goals** — `onCreateGoal` (`App.tsx:13223`) allocates through
   `createNewSession(undefined, { keepView: true })` +
   `ensureSessionForPrompt`; stays workspace-bound (locked/selected/primary
   cwd), ignoring any standalone pending context.
-- **Git** — `resolveSessionForWorkspace` (`App.tsx:6574-6614`) and the
-  composer git chips (`gitModeIntent`, `App.tsx:6060`, gated by
-  `gitModeEligible` at `6679-6681`); stays workspace-bound.
+- **Git** — `resolveSessionForWorkspace` (`App.tsx:6661`) and the composer
+  git chips (gated by `gitModeEligible`, `App.tsx:6763`); stays
+  workspace-bound.
 - **Current-session New Chat** — `createNewSession()` inherits the active
   `connection.sessionContext`: standalone → pending standalone, workspace →
   pending workspace with the current cwd (today's behavior). A Live current
-  session maps to pending **standalone** (open decision, reviewer
-  confirmation requested): the provider deliberately does not create Live
-  sessions, and a fresh text chat from a voice session is projectless like
-  standalone — strict "inherit" would require Live creation the provider
-  rejects.
+  session routes through the existing Live-specific `startLive('new')` path
+  (`client/live/useLiveVoice`), never a silent remap to standalone — the
+  routing contract's "inherit explicit context" row stays intact (review
+  P1).
 - **Split view** — each pane owns a `DaemonSessionProvider`
-  (`components/SplitView.tsx`, pane keying at :234-247); panes receive the
-  pane's explicit context alongside `sessionId` so a standalone chat can be
-  opened beside a workspace chat without cross-contamination.
+  (`components/SplitView.tsx:464`); panes receive the pane's explicit
+  context alongside `sessionId` so a standalone chat can be opened beside a
+  workspace chat without cross-contamination.
 - **Context propagation** — `WorkspaceSessionProvider`
   (`components/WorkspaceSessionProvider.tsx`) still passes legacy
   `workspaceCwd` into `DaemonSessionProvider`; PR6 passes the resolved
   `sessionContext` prop instead (the provider normalizes legacy cwd at its
   compatibility boundary, so both forms remain valid during the cutover).
-- **Loading existing sessions** — `loadSidebarSession` (`App.tsx:9016`)
+- **Loading existing sessions** — `loadSidebarSession` (`App.tsx:9114`)
   currently passes `{ workspaceCwd }`; for standalone entries it calls
   `loadSession(id, { sessionContext: { kind: 'standalone' } })`.
 
@@ -136,16 +155,26 @@ untouched.
 
 ## Capability Dual Behavior
 
-- Read the capability from `useWorkspace().capabilities.features` —
-  `DaemonWorkspaceProvider` fetches `client.capabilities()` once at
-  startup, before any session exists, so entry points (which fire before a
-  session) must not rely on the session-scoped `connection.capabilities`.
-  Compare against `STANDALONE_SESSIONS_CAPABILITY` from
-  `@qwen-code/sdk/daemon`.
-- **Capability absent** (old daemon): preserve legacy behavior — global New
+Read the capability from `useWorkspace().capabilities.features` —
+`DaemonWorkspaceProvider` fetches `client.capabilities()` once at startup,
+before any session exists, so entry points (which fire before a session)
+must not rely on the session-scoped `connection.capabilities`. Compare
+against `STANDALONE_SESSIONS_CAPABILITY` from `@qwen-code/sdk/daemon`.
+
+The capability value is tri-state (review P1), and only one state may fall
+back to legacy behavior:
+
+- **Loading** (`capabilities === undefined` while the startup fetch is in
+  flight): Home and global New Chat wait — the standalone decision is
+  disabled, not defaulted. Treating loading as absent could silently create
+  a primary-workspace session on a capable daemon.
+- **Loaded-absent** (old daemon): preserve legacy behavior — global New
   Chat targets the primary workspace. Do not call any standalone route. An
-  informational hint that standalone chats need a daemon upgrade is allowed.
-- **Capability present, creation fails**: display the structured error and
+  informational hint that standalone chats need a daemon upgrade is
+  allowed.
+- **Load error**: fail closed with an explicit retry; no session creation
+  in either context until capabilities resolve.
+- **Loaded-present, creation fails**: display the structured error and
   preserve standalone intent for retry. Never silently create a
   primary-workspace session; never downgrade the context after a `503`
   ownership/runtime failure or a `409` directory conflict.
@@ -159,18 +188,24 @@ intent:
 
 - A new App-level `pendingSessionContext:
 DaemonProductSessionContext | undefined` state, set by every entry point
-  above and cleared on consume. Pending context is a
-  `DaemonProductSessionContext`, never a bare `undefined` cwd — "no cwd
-  yet" is not standalone semantics.
-- `ensureSessionForPrompt` (`App.tsx:6095`) prefers the pending context:
-  `{ kind: 'standalone' }` → `createSession({ sessionContext })`; a
-  workspace pending context → today's exact-cwd path; none → legacy
-  locked/selected/primary resolution.
-- Switching away and back before first prompt retains the pending context
-  verbatim; `loadSidebarSession` / `switchWorkspace` (`App.tsx:8605`)
-  overwrite it with the loaded session's explicit context.
-- The provider's own deferred path (`shouldDeferInitialSessionCreation`,
-  webui) keeps working unchanged underneath.
+  above. Pending context is a `DaemonProductSessionContext`, never a bare
+  `undefined` cwd — "no cwd yet" is not standalone semantics.
+- `ensureSessionForPrompt` (`App.tsx:6179`) prefers the pending context:
+  `{ kind: 'standalone' }` → the standalone creation branch (no
+  workspace-only fields); a workspace pending context → today's exact-cwd
+  path; none → legacy locked/selected/primary resolution.
+- **Pending context stays authoritative until attach commits** (review
+  P1). Ordinary `409`/`503` creation failures do not publish a standalone
+  connection context, and a cleared provider can still hold the previous
+  workspace context — so routing and draft-UI gates read
+  `pendingSessionContext ?? connection.sessionContext`, and the pending
+  state is cleared only after create-and-attach completes successfully. A
+  failed attempt leaves the pending standalone intent (and its error)
+  visible for retry.
+- `loadSidebarSession` / `switchWorkspace` (`App.tsx:8703`) overwrite the
+  pending context with the loaded session's explicit context.
+- The provider's own deferred path (`shouldDeferInitialSessionCreation`)
+  keeps working unchanged underneath.
 
 ## Recents and Lifecycle Actions
 
@@ -179,20 +214,27 @@ DaemonProductSessionContext | undefined` state, set by every entry point
   today: `useScopedSessions` / `useWebShellSessions`
   (`session-catalog/session-catalog-hooks.ts`) are keyed by
   `SessionCatalogQuery { routeKind, workspaceCwd }`
-  (`session-catalog/session-catalog-store.ts:9-13`) — workspace-scoped by
+  (`session-catalog/session-catalog-store.ts:11`) — workspace-scoped by
   construction. PR6 adds a standalone catalog lane fed by
   `listStandaloneSessionsPage` (cursor pagination, `archiveState` filter)
   rather than forcing standalone rows through the workspace catalog store.
   Live sessions and project sessions keep their existing groups; standalone
   children (sub-sessions with `parentSessionId`) never appear.
+- **The internal Conversations cwd never leaks through Recents** (review
+  P2). Standalone summaries retain an internal `workspaceCwd` for protocol
+  routing, and the existing session-details row renders `workspaceCwd` as a
+  project folder. Recents rows therefore use a standalone-specific view
+  model that drops `workspaceCwd` entirely, and a standalone-specific
+  action dispatch that never passes it to project details, navigation, or
+  workspace resolvers.
 - Per-session actions reuse the existing
   `WebShellSidebarSessionActionItem` menu pattern
-  (`WebShellSidebar.tsx:270-284`: details | rename | export | delete | pin
-  | archive) but dispatch to the standalone SDK routes:
-  **rename** (`renameStandaloneSession`), **export**
-  (`exportStandaloneSession`), **archive** / **unarchive** (batch routes),
-  **delete** (`deleteStandaloneSessions`). Workspace-only actions (pin,
-  group) are not offered on standalone rows.
+  (`WebShellSidebar.tsx:270`: details | rename | export | delete | pin |
+  archive) but dispatch to the standalone SDK routes: **rename**
+  (`renameStandaloneSession`), **export** (`exportStandaloneSession`),
+  **archive** / **unarchive** (batch routes), **delete**
+  (`deleteStandaloneSessions`). Workspace-only actions (pin, group) are not
+  offered on standalone rows.
 - Delete retains the existing second-confirmation dialog pattern
   (`DeleteSessionDialog`) and states that the transcript and private files
   are removed. On success the session leaves Recents even when the response
@@ -207,28 +249,29 @@ pin/group controls, and attachments/uploads (standalone MVP excludes
 uploads). Model, approval, tool, permission, transcript, and supported
 metadata controls remain.
 
-- Gate on `connection.sessionContext?.kind` from the provider — the same
-  value that drove routing — never on the presence of a cwd. The
+- Gate on the effective context (`pendingSessionContext ??
+connection.sessionContext`) so draft standalone chats hide project
+  surfaces before the session exists — never on the presence of a cwd. The
   established pattern to extend is `ordinaryWorkspaces` /
-  `isKnownLiveWorkspaceCwd` (`App.tsx:2330-2338`), which already hides
-  project UI for the Live runtime; PR6 generalizes it to
-  "current chat is not a workspace context".
+  `isKnownLiveWorkspaceCwd` (`App.tsx:2401-2405`), which already hides
+  project UI for the Live runtime; PR6 generalizes it to "current chat is
+  not a workspace context".
 - Component list (`origin/main`): composer workspace selector
-  (`components/WorkspaceSelector.tsx`, rendered `ChatEditor.tsx:3087`);
+  (`components/WorkspaceSelector.tsx`, rendered `ChatEditor.tsx:3116`);
   Git chips/popovers (`GitBranchIndicator`, `GitModePopover`,
-  `BranchPickerPopover`, `ChatEditor.tsx:3119-3154`, gated by
-  `gitBranchVisible` / `gitModeEligible`); Git dialogs (`GitDialog` et al.,
-  `App.tsx:12143`); project settings panel (`openPanel('settings')` +
-  workspace-scoped `useSettings`); @-mention file browser
-  (`components/AtMentionPanel.tsx`, `hooks/useAtMentionMenu.ts`); pin/group
-  controls (`SESSION_ORGANIZATION_FEATURE` sidebar grouping).
+  `BranchPickerPopover`, gated by `gitBranchVisible`,
+  `ChatEditor.tsx:2435`); Git dialogs (`GitDialog` et al.); project
+  settings panel (`openPanel('settings')` + workspace-scoped
+  `useSettings`); @-mention file browser (`components/AtMentionPanel.tsx`,
+  `hooks/useAtMentionMenu.ts`); pin/group controls
+  (`SESSION_ORGANIZATION_FEATURE` sidebar grouping).
 - Uploads have two lanes, both hidden in the standalone MVP: (1) workspace
   file upload — `hooks/useFileUpload.ts` → `client.uploadWorkspaceFile`,
   rendered via `composer/AddMenu.tsx` and the @-panel "Upload file" item,
   already kill-switched by `fileUploadEnabled` and the
-  `workspace_file_upload` capability (`ChatEditor.tsx:1557-1586`); (2)
+  `workspace_file_upload` capability (`ChatEditor.tsx:1585-1588`); (2)
   inline prompt attachments — pasted/dropped images and text files in
-  `useComposerCore.ts` (`pastedImages`/`pastedFiles`, :1711-1714). The
+  `useComposerCore.ts` (`pastedImages`/`pastedFiles`, :1718-1719). The
   acceptance matrix keeps all attachments out of standalone MVP; lane 2 is
   session-scoped, so it needs an explicit context check, not a capability
   check.
@@ -239,10 +282,10 @@ metadata controls remain.
 ## Deep Links
 
 There is no router library: `main.tsx` + `utils/sessionPath.ts` own the
-`/session/<id>?workspace=<workspaceId>` scheme
-(`parseSessionId`/`buildSessionPathname`), and the App reports context
-upward through `onSessionIdChange(connection.sessionId, workspaceId,
-reportedWorkspaceCwd)` (`App.tsx:8156-8196`) so `main.tsx` can
+`/session/<id>?workspace=<workspaceId>` scheme (`getSessionIdFromUrl` /
+`getWorkspaceIdFromUrl`, `main.tsx:83-87`;
+`parseSessionId`/`buildSessionPathname`), and the App reports context
+upward through `onSessionIdChange` (`App.tsx:8282`) so `main.tsx` can
 `replaceState` the URL.
 
 - New standalone links carry an explicit context parameter:
@@ -251,12 +294,21 @@ reportedWorkspaceCwd)` (`App.tsx:8156-8196`) so `main.tsx` can
   session. Legacy context-free links keep today's workspace resolution —
   standalone sessions did not exist before this feature, so no migration is
   needed.
-- A `context=standalone` cold load resolves only after the standalone
-  read path is ready, and then only through exact `getStandaloneSession`
-  semantics: `creating` shows a resolving state, a summary loads the
-  session, not-found shows the existing missing-session UI
-  (`connection.missingSession` → `showMissingSessionState`). It never
-  guesses the primary workspace.
+- A `context=standalone` cold load resolves only after the standalone read
+  path is ready, and then only through exact `getStandaloneSession`
+  semantics: a summary loads the session, not-found shows the existing
+  missing-session UI (`connection.missingSession` →
+  `showMissingSessionState`). It never guesses the primary workspace.
+- **A `creating` lookup must reach a terminal state** (review P2): the
+  resolver polls exact lookup with bounded backoff (e.g. up to 30 s, capped
+  attempts) and then stops at an explicit **Retry** action; it never hangs
+  in the resolving state forever.
+- **Fail-closed edge cases** (review P2): a `?context=standalone` link
+  carrying a conflicting `?workspace=` parameter is rejected, not
+  reconciled; on a daemon without the capability, a standalone link shows
+  the "requires a daemon upgrade" state instead of resolving anywhere; on a
+  capable daemon whose Conversations runtime is unavailable (`503`), the
+  structured error is shown with retry.
 - `onSessionIdChange` becomes context-aware: standalone sessions report
   `context=standalone` and drop `workspaceId`; workspace and Live links
   keep their existing resolvers. PR5's switching semantics already
@@ -269,12 +321,17 @@ Render the typed PR5 state instead of parsing strings:
 
 - `standaloneSession.workingDirectory.state === 'recreated'` → warning that
   the transcript survived but previous files were not recovered.
-- `standaloneSession.errorCode` → `working_directory_missing` /
-  `working_directory_compromised` → offer explicit **repair**
-  (`repairStandaloneSessionDirectory`); repair never replays a prompt.
-- `standaloneSession.creationRecovery` → outcome-unknown banner exposing the
-  reserved UUID with a "check status" retry that performs exact lookup, plus
-  a terminal error path when lookup reports not-found.
+- `standaloneSession.errorCode === 'working_directory_missing'` → offer
+  explicit **repair** (`repairStandaloneSessionDirectory`); repair never
+  replays a prompt.
+- `standaloneSession.errorCode === 'working_directory_compromised'` →
+  **fail-closed blocking state** (review P1): the service rejects an
+  existing compromised path instead of recreating it, so no Repair action
+  is offered — the user gets terminal guidance (export the transcript,
+  delete the session) instead.
+- `standaloneSession.creationRecovery` → outcome-unknown banner exposing
+  the reserved UUID with a "check status" retry that performs exact lookup,
+  plus a terminal error path when lookup reports not-found.
 - Delete responses carrying `fileCleanupPending` → non-blocking notice that
   file cleanup will finish automatically; the transcript is already gone.
 
@@ -283,28 +340,39 @@ Render the typed PR5 state instead of parsing strings:
 - No daemon or SDK change; PR6 is UI-only against the merged v1 contract.
 - Old daemon → legacy primary behavior everywhere; old WebShell against a
   new daemon → unchanged (it never calls standalone routes).
-- `@qwen-code/webui` already re-exports the standalone types through
-  `daemon-react-sdk`; if WebShell imports SDK standalone methods directly,
-  align the SDK peer minimum with the first release containing PR4 (same
-  caveat PR5 recorded).
+- Post-#9811, the provider and the product UI live in the same package, so
+  no cross-package release-ordering caveat applies.
 
 ## Verification
 
-Unit/component (vitest):
+Unit/component (vitest, `packages/web-shell`):
 
 - Entry-point → context mapping for every row of the routing table,
-  including current-session inheritance of each kind.
-- Capability absent → legacy path, zero standalone requests issued
-  (assertable via the e2e `mockDaemon` request log and unit-level SDK
-  mocks).
-- Capable-daemon failure → error rendered, pending standalone intent
-  retained, no primary-workspace create issued.
+  including current-session inheritance (workspace, standalone) and Live
+  routing through `startLive('new')`.
+- Standalone creation request body asserted exactly: no `workspaceCwd`,
+  `sourceType`, `worktree`, or `branch` (review P1); workspace creation
+  keeps them.
+- Capability tri-state: loading creates nothing in any context;
+  loaded-absent takes the legacy path with zero standalone requests
+  (assertable via the e2e `mockDaemon` request log); load error fails
+  closed with retry (review P1).
+- Capable-daemon creation failure → error rendered, **pending standalone
+  intent retained** and still authoritative for gates, no primary-workspace
+  create issued (review P1).
 - Recents list/rename/export/archive/unarchive/delete flows, child
-  exclusion, `fileCleanupPending` removal semantics.
-- Surface hiding per context kind; uploads unavailable in standalone.
-- Deep-link resolution ordering (catalog readiness) and not-found UI.
-- `recreated` warning, repair offer, creation-recovery banner rendering
-  from the typed connection state.
+  exclusion, `fileCleanupPending` removal semantics, and the standalone
+  view model never exposing the internal cwd to details/navigation
+  (review P2).
+- Surface hiding per effective context — including the draft standalone
+  chat before first prompt; uploads unavailable in standalone.
+- Deep links: `creating` polls to a terminal state and stops at Retry;
+  conflicting `?workspace=` + `context=standalone` rejected; incapable
+  daemon shows upgrade state; not-found shows the missing-session UI
+  (review P2).
+- `recreated` warning, repair offered only for `working_directory_missing`,
+  `working_directory_compromised` rendered fail-closed without a repair
+  action (review P1), creation-recovery banner rendering from typed state.
 
 E2E (Playwright, `packages/web-shell/client/e2e`):
 
@@ -312,15 +380,15 @@ E2E (Playwright, `packages/web-shell/client/e2e`):
   `standalone_sessions_v1` capability toggle and the standalone route
   family; add `web-shell.standalone.spec.ts` covering: Home New Chat →
   standalone create body asserted; project New Chat → workspace create;
-  Recents lifecycle; old-daemon fallback; capable-daemon failure.
+  Recents lifecycle; capability loading/absent/error states; capable-daemon
+  failure with retained intent.
 - Manual E2E plan recorded at
   `.qwen/e2e-tests/2026-08-29-webshell-standalone-chats.md` and dry-run
   against a real `qwen serve` daemon before merge, per repo workflow.
 
-Commands: `cd packages/webui && npx vitest run <file>`, `cd
-packages/web-shell && npm run verify` (lint + format:check + typecheck +
-test:ci) and `npm run test:e2e`, then root `npm run build && npm run
-typecheck`.
+Commands: `cd packages/web-shell && npx vitest run <file>` for focused
+tests, `npm run verify` (lint + format:check + typecheck + test:ci) and
+`npm run test:e2e`, then root `npm run build && npm run typecheck`.
 
 ## Scope Boundary
 
@@ -330,5 +398,5 @@ durable standalone scheduling, storage quotas, or child-session management
 UI. `SessionOverviewPanel` and `ResumeDialog` remain workspace-scoped in
 this PR; the top-level Recents group lives in the sidebar only. It does not
 change daemon lifecycle behavior, the SDK contract, or the PR5 provider
-switching semantics; any typed gap discovered in the PR5 surface is raised
-as a follow-up rather than patched into this PR's UI work.
+switching semantics; any typed gap discovered in the provider surface is
+raised as a follow-up rather than patched into this PR's UI work.

--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -120,6 +120,17 @@ everywhere):
   `createSession({ sessionContext: { kind: 'standalone' }, approvalMode? })`
   only — never the generic helper's `sourceType`/`worktree`/`branch`
   payload. Tests assert the exact request body for both branches.
+- **Every new-session caller passes explicit intent** (review P1): global
+  New Chat, current-session New Chat, `/new`, `/clear`, the new-session
+  suggestion, and the shell API all reach the same `createNewSession()`
+  today, and Goals passes an undefined cwd while needing workspace — with a
+  workspace active context, the callee cannot distinguish global standalone
+  creation from current-session workspace inheritance. The caller contract
+  becomes an explicit intent: `{ kind: 'global' }` (Home/global New Chat →
+  standalone when capable), `{ kind: 'inherit' }` (current-session
+  entries), or an explicit `{ kind: 'workspace', cwd }` (project New Chat,
+  Goals). Intent is never inferred from an undefined cwd or current state,
+  and every real callsite is covered by tests.
 - **Project-scoped New Chat** — `handleNewSession(wsCwd)`
   (`WebShellSidebar.tsx:5514`) → `createNewSession(workspaceCwd)`;
   unchanged, pending context `{ kind: 'workspace', cwd }`.
@@ -130,19 +141,25 @@ everywhere):
 - **Git** — `resolveSessionForWorkspace` (`App.tsx:6661`) and the composer
   git chips (gated by `gitModeEligible`, `App.tsx:6763`); stays
   workspace-bound.
-- **Current-session New Chat** — `createNewSession()` inherits the active
-  `connection.sessionContext`: standalone → pending standalone, workspace →
-  pending workspace with the current cwd (today's behavior). A Live current
-  session routes through the existing Live-specific `startLive('new')` path
-  (`client/live/useLiveVoice`), never a silent remap to standalone — the
-  routing contract's "inherit explicit context" row stays intact (review
-  P1).
-- **Split view excludes standalone sessions in PR6** (review P1): pane
-  identity is persisted as bare `sessionId` strings (split URL,
-  sessionStorage) and pane ownership derives from workspace catalogs, so a
-  standalone pane has no context source after a cold split URL or refresh
-  and would fall through to workspace resolution. Standalone rows get no
-  split entry point; context-bearing pane descriptors are a follow-up.
+- **Current-session New Chat** (`{ kind: 'inherit' }`) — inherits the
+  active `connection.sessionContext`: standalone → pending standalone,
+  workspace → pending workspace with the current cwd (today's behavior). A
+  Live current session routes through the existing Live-specific
+  `startLive('new')` path (`client/live/useLiveVoice`) before any clearing,
+  never a silent remap to standalone — the routing contract's "inherit
+  explicit context" row stays intact (review P1).
+- **Split view excludes standalone sessions in PR6, at every ingress**
+  (review P1): pane identity is persisted as bare `sessionId` strings
+  (split URL, sessionStorage) and pane ownership derives from workspace
+  catalogs, so a standalone pane has no context source after a cold split
+  URL or refresh and would fall through to workspace resolution. Blocking
+  only the Recents row is insufficient — the global footer button can seed
+  the current `connection.sessionId`, and `?split=`, sessionStorage
+  restoration, and externally controlled `splitSessionIds` can all inject a
+  bare standalone ID. PR6 disables the global Split View entry for
+  non-workspace effective contexts and rejects or sanitizes standalone IDs
+  at every seed, URL, storage, and controlled-prop boundary before panes
+  mount. Context-bearing pane descriptors are a follow-up.
 - **Context propagation** — `WorkspaceSessionProvider`
   (`components/WorkspaceSessionProvider.tsx`) still passes legacy
   `workspaceCwd` into `DaemonSessionProvider`; PR6 passes the resolved
@@ -317,11 +334,20 @@ upward through `onSessionIdChange` (`App.tsx:8282`) so `main.tsx` can
   session. Legacy context-free links keep today's workspace resolution —
   standalone sessions did not exist before this feature, so no migration is
   needed.
-- A `context=standalone` cold load resolves only after the standalone read
-  path is ready, and then only through exact `getStandaloneSession`
-  semantics: a summary loads the session, not-found shows the existing
-  missing-session UI (`connection.missingSession` →
-  `showMissingSessionState`). It never guesses the primary workspace.
+- **Resolution happens at the root, before the session provider mounts**
+  (review P1): `main.tsx` passes the URL sessionId into
+  `WorkspaceSessionProvider`, which mounts `DaemonSessionProvider` outside
+  App — with no explicit context, `resolveProviderSessionContext` would
+  inherit the primary workspace and start a workspace restore before any
+  App-level lookup exists. The root therefore parses and validates
+  `context` alongside the session id, passes the explicit context through
+  `WorkspaceSessionProvider`, and for `context=standalone` suppresses
+  provider session loading until exact `getStandaloneSession` lookup
+  selects the route: a summary mounts the provider with
+  `{ kind: 'standalone' }`, not-found shows the existing missing-session
+  UI (`connection.missingSession` → `showMissingSessionState`). It never
+  guesses the primary workspace, and a cold-load test asserts zero
+  workspace-load requests.
 - **A `creating` lookup must reach a terminal state** (review P2): the
   resolver polls exact lookup with bounded backoff (e.g. up to 30 s, capped
   attempts) and then stops at an explicit **Retry** action; it never hangs
@@ -330,9 +356,9 @@ upward through `onSessionIdChange` (`App.tsx:8282`) so `main.tsx` can
   the provider's generation guard only orders loads after they start, but
   exact lookup and polling happen before `loadSession`, so a delayed
   `creating` poll resolving after the user opened another session would
-  start a load that incorrectly wins. An App-level route-resolution token
-  is invalidated on every navigation and checked before each poll and
-  immediately before `loadSession`.
+  start a load that incorrectly wins. A route-resolution token held by the
+  root resolver (above the provider) is invalidated on every navigation and
+  checked before each poll and immediately before `loadSession`.
 - **Fail-closed edge cases** (review P2): a `?context=standalone` link
   carrying a conflicting `?workspace=` parameter is rejected, not
   reconciled; on a daemon without the capability, a standalone link shows
@@ -368,9 +394,17 @@ Render the typed PR5 state instead of parsing strings:
   existing compromised path instead of recreating it, so no Repair action
   is offered — the user gets terminal guidance (export the transcript,
   delete the session) instead.
-- `standaloneSession.creationRecovery` → outcome-unknown banner exposing
-  the reserved UUID with a "check status" retry that performs exact lookup,
-  plus a terminal error path when lookup reports not-found.
+- `standaloneSession.creationRecovery` → a complete outcome-unknown
+  recovery state machine (review P1). The provider publishes the reserved
+  UUID as `connection.sessionId` without an attached session, so
+  `ensureSessionForPrompt` would no-op on the existing id while submission
+  fails on the empty session ref — ordinary submission and unconfirmed
+  new-session actions are therefore blocked while recovery is unresolved.
+  The owner-guarded **Check Status** action performs exact lookup with
+  transitions for every recovery state: `creating` → bounded polling;
+  `existing` → load and attach the same id; `absent` → an explicit
+  user-triggered retry (never an automatic create); `unknown` → a
+  persistent recovery UI. All four transitions are tested.
 - Delete responses carrying `fileCleanupPending` → non-blocking notice that
   file cleanup will finish automatically; the transcript is already gone.
 
@@ -423,6 +457,18 @@ Unit/component (vitest, `packages/web-shell`):
   (review P1).
 - Archived standalone lane lists and refreshes after lifecycle actions;
   partial-success batch envelopes handled per action (review P2).
+- Cold `context=standalone` load issues zero workspace-load requests, with
+  resolution completed at the root before the provider mounts (review P1).
+- Every new-session callsite passes explicit intent; no path infers intent
+  from an undefined cwd or current state (review P1).
+- Split View ingresses: footer entry disabled for non-workspace effective
+  contexts; `?split=<standalone-id>`, sessionStorage restoration, and
+  controlled-prop injection rejected or sanitized before panes mount
+  (review P1).
+- Outcome-unknown recovery: all four states (creating / existing / absent /
+  unknown) transition correctly, ordinary submission and unconfirmed
+  new-session actions are blocked while recovery is unresolved, and no
+  automatic re-create ever fires (review P1).
 
 E2E (Playwright, `packages/web-shell/client/e2e`):
 

--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -132,12 +132,14 @@ everywhere):
   Goals). Intent is never inferred from an undefined cwd or current state,
   and every real callsite is covered by tests.
 - **Project-scoped New Chat** — `handleNewSession(wsCwd)`
-  (`WebShellSidebar.tsx:5514`) → `createNewSession(workspaceCwd)`;
-  unchanged, pending context `{ kind: 'workspace', cwd }`.
-- **Goals** — `onCreateGoal` (`App.tsx:13223`) allocates through
-  `createNewSession(undefined, { keepView: true })` +
-  `ensureSessionForPrompt`; stays workspace-bound (locked/selected/primary
-  cwd), ignoring any standalone pending context.
+  (`WebShellSidebar.tsx:5514`) → `createNewSession({ kind: 'workspace',
+cwd: wsCwd })` under the new intent contract.
+- **Goals** — `onCreateGoal` (`App.tsx:13223`) first resolves the target
+  cwd exactly as today (locked ?? selected ?? primary), then calls
+  `createNewSession({ kind: 'workspace', cwd: resolved },
+{ keepView: true })` + `ensureSessionForPrompt`; stays workspace-bound,
+  ignoring any standalone pending context. It never passes a bare
+  `undefined` cwd.
 - **Git** — `resolveSessionForWorkspace` (`App.tsx:6661`) and the composer
   git chips (gated by `gitModeEligible`, `App.tsx:6763`); stays
   workspace-bound.
@@ -159,7 +161,15 @@ everywhere):
   bare standalone ID. PR6 disables the global Split View entry for
   non-workspace effective contexts and rejects or sanitizes standalone IDs
   at every seed, URL, storage, and controlled-prop boundary before panes
-  mount. Context-bearing pane descriptors are a follow-up.
+  mount. Because bare ids carry no context, sanitization uses a fail-closed
+  async classifier before panes mount: on a capable daemon, an unmapped id
+  is exact-checked via `getStandaloneSession` — standalone or `creating`
+  ids are rejected, and only a `404` continues through workspace ownership
+  resolution. The classifier has a cancellable pending state, treats lookup
+  errors as rejection, and hands the controlled host the sanitized set so
+  it cannot immediately re-inject a stripped id. Delayed-catalog and
+  controlled-prop tests cover this. Context-bearing pane descriptors are a
+  follow-up.
 - **Context propagation** — `WorkspaceSessionProvider`
   (`components/WorkspaceSessionProvider.tsx`) still passes legacy
   `workspaceCwd` into `DaemonSessionProvider`; PR6 passes the resolved
@@ -288,6 +298,19 @@ connection.sessionContext`) so draft standalone chats hide project
   `isKnownLiveWorkspaceCwd` (`App.tsx:2401-2405`), which already hides
   project UI for the Live runtime; PR6 generalizes it to "current chat is
   not a workspace context".
+- **Composer state is isolated, not just hidden** (review P1/P2): clearing
+  a workspace session preserves `connection.commands`/`skills`, and
+  `createNewSession` with no cwd reloads primary-workspace skills, while
+  `atWorkspaceCwd` falls back to the primary workspace when no session
+  exists — so `useComposerCore` would select workspace-scoped draft and
+  input-history keys and expose project commands/skills in a standalone
+  draft. Commands, skills, `atWorkspaceCwd`, and composer storage identity
+  all derive from the effective product context: a standalone draft skips
+  the workspace skill reload, keeps only local built-in commands before
+  attach, uses a standalone-specific draft/history identity with no primary
+  fallback, and after attach uses only the standalone session's
+  session-supported data. Covered by a workspace→standalone transition test
+  with stale commands, skills, draft, and history snapshots.
 - Component list (`origin/main`): composer workspace selector
   (`components/WorkspaceSelector.tsx`, rendered `ChatEditor.tsx:3116`);
   Git chips/popovers (`GitBranchIndicator`, `GitModePopover`,
@@ -343,9 +366,14 @@ upward through `onSessionIdChange` (`App.tsx:8282`) so `main.tsx` can
   `context` alongside the session id, passes the explicit context through
   `WorkspaceSessionProvider`, and for `context=standalone` suppresses
   provider session loading until exact `getStandaloneSession` lookup
-  selects the route: a summary mounts the provider with
-  `{ kind: 'standalone' }`, not-found shows the existing missing-session
-  UI (`connection.missingSession` → `showMissingSessionState`). It never
+  selects the route: an active summary mounts the provider with
+  `{ kind: 'standalone' }`, while an **archived** summary is never loaded
+  directly (review P1) — `getStandaloneSession` returns active and archived
+  summaries alike, but the daemon rejects load/resume with
+  `session_archived`. The flow renders the archived state, runs Unarchive,
+  verifies the target id in the per-id success array, and only then mounts
+  and loads. Not-found shows the existing missing-session UI
+  (`connection.missingSession` → `showMissingSessionState`). It never
   guesses the primary workspace, and a cold-load test asserts zero
   workspace-load requests.
 - **A `creating` lookup must reach a terminal state** (review P2): the
@@ -402,9 +430,13 @@ Render the typed PR5 state instead of parsing strings:
   new-session actions are therefore blocked while recovery is unresolved.
   The owner-guarded **Check Status** action performs exact lookup with
   transitions for every recovery state: `creating` → bounded polling;
-  `existing` → load and attach the same id; `absent` → an explicit
-  user-triggered retry (never an automatic create); `unknown` → a
-  persistent recovery UI. All four transitions are tested.
+  `existing` → load and attach the same id, branching on `isArchived`
+  first — an archived summary renders the archived state, runs Unarchive,
+  verifies the per-id success array, and only then loads, because the
+  daemon rejects direct loads with `session_archived` (review P1);
+  `absent` → an explicit user-triggered retry (never an automatic create);
+  `unknown` → a persistent recovery UI. All four transitions are tested,
+  including archived summaries on both the cold-link and recovery paths.
 - Delete responses carrying `fileCleanupPending` → non-blocking notice that
   file cleanup will finish automatically; the transcript is already gone.
 
@@ -469,6 +501,15 @@ Unit/component (vitest, `packages/web-shell`):
   unknown) transition correctly, ordinary submission and unconfirmed
   new-session actions are blocked while recovery is unresolved, and no
   automatic re-create ever fires (review P1).
+- Archived exact-lookup summaries are never loaded directly: both the
+  cold-link and outcome-recovery flows branch on `isArchived`, unarchive
+  with per-id success verification, and only then load (review P1).
+- Workspace→standalone draft transition isolates composer commands, skills,
+  `atWorkspaceCwd`, draft, and input history with stale snapshots present
+  (review P1/P2).
+- Split View bare-id classifier: delayed catalogs, standalone/`creating`
+  rejection, only `404` continues to workspace ownership resolution, and a
+  controlled host cannot re-inject sanitized ids (review P1).
 
 E2E (Playwright, `packages/web-shell/client/e2e`):
 

--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -1,0 +1,334 @@
+# Standalone PR6 WebShell Product UI Plan
+
+## Goal
+
+Turn the explicit daemon session contexts delivered by PR5 (#10418) into the
+visible standalone-chat product defined by
+`docs/design/standalone-daemon-sessions.md` (§PR6). Home and global **New
+Chat** create standalone sessions on capable daemons; project-scoped entry
+points stay workspace-bound; a top-level **Recents** group manages standalone
+sessions through their full lifecycle; standalone chats hide every
+project-only surface. No behavior falls back to the primary workspace unless
+the daemon lacks `standalone_sessions_v1`.
+
+This PR touches `packages/web-shell` (product UI) and, only where a typed
+hole is found, `packages/webui` (PR5 provider surface). It adds no daemon
+route and no SDK method.
+
+Suggested title: `feat(web-shell): Add standalone chats`.
+
+## Merged Contract This PR Consumes
+
+Verified against `origin/main` (PR3 `34a6e918b6`, PR4 `7357136dd1`, PR5
+`ac761e11c2`).
+
+### Daemon (packages/cli/src/serve)
+
+- Routes registered by `registerStandaloneSessionRoutes`
+  (`routes/standalone-sessions.ts:247`):
+  `POST/GET /standalone/sessions`, `GET /standalone/sessions/:id`,
+  `POST .../load`, `POST .../resume`, `POST .../repair-directory`,
+  `PATCH .../metadata`, `GET .../export`, `POST .../archive`,
+  `POST .../unarchive`, `POST .../delete`.
+- Capability `standalone_sessions_v1` advertised from
+  `capabilities.ts:136` only when the full dependency set is installed.
+
+### SDK (packages/sdk-typescript/src/daemon)
+
+- `STANDALONE_SESSIONS_CAPABILITY = 'standalone_sessions_v1'`
+  (`standalone-sessions.ts:16`).
+- `DaemonClient`: `createStandaloneSession` (generates the UUID, wraps
+  response loss into `DaemonStandaloneCreationOutcomeUnknownError` carrying
+  `sessionId` + exact-lookup `recovery`, never auto-retries),
+  `listStandaloneSessions(Page)`, `getStandaloneSession` (exact lookup:
+  creating / summary / not-found), `loadStandaloneSession`,
+  `resumeStandaloneSession`, `repairStandaloneSessionDirectory`,
+  `renameStandaloneSession`, `exportStandaloneSession`,
+  `archiveStandaloneSessions`, `unarchiveStandaloneSessions`,
+  `deleteStandaloneSessions` (batch result with `removed`, `notFound`,
+  `errors`, `fileCleanupPending`). All standalone methods are
+  capability-gated.
+- `DaemonSessionClient.createStandalone / loadStandalone /
+resumeStandalone` statics and the `{ kind: 'standalone' }` restore
+  strategy (`DaemonSessionClient.ts:444-485`, restore dispatch at :710).
+
+### WebUI provider (packages/webui/src/daemon/session)
+
+- `DaemonProductSessionContext` (`types.ts:71`):
+  `{ kind: 'workspace'; cwd } | { kind: 'standalone' } | { kind: 'live' }`.
+- `DaemonSessionProviderProps.sessionContext` (types.ts:160) alongside
+  legacy `workspaceCwd`; conflicts throw before any request.
+- Actions `createSession` / `loadSession` / `resumeSession` accept
+  `options.sessionContext` (types.ts:438-471). Standalone create is not
+  retried and is exempt from the generic 30 s action timeout; Live create is
+  rejected by this provider.
+- Connection state exposes `sessionContext` and
+  `standaloneSession?: DaemonStandaloneConnectionState`
+  (`{ projectlessOutputDirectory?, workingDirectory?, creationRecovery?,
+errorCode? }`, types.ts:76-82, 94-98). Directory error codes are copied
+  into `standaloneSession.errorCode` for UI branching.
+- `session-context.ts` helpers: `resolveProviderSessionContext`,
+  `resolveActionSessionContext`, `sessionContextKey`,
+  `restoreSessionContextMatches`, `getDaemonErrorCode`,
+  `isDaemonErrorExplicitlyNonRetryable`, `getStandaloneConnectionState`.
+- PR5 isolation guarantee: standalone/Live sessions skip workspace
+  providers, skills, ACP preheat, Git status, and workspace event
+  invalidation inside the provider already.
+
+## Entry-Point Routing
+
+Fixed by the umbrella contract; PR6 wires each visible entry point to an
+explicit context:
+
+| Entry point                                      | New-session context      |
+| ------------------------------------------------ | ------------------------ |
+| Home / global **New Chat**                       | `standalone`             |
+| **New Chat** inside a selected or locked project | `workspace`              |
+| Goals and Git entry points                       | `workspace`              |
+| Current-session **New Chat**                     | Inherit explicit context |
+| Live Voice                                       | `live`                   |
+
+Implementation map (`packages/web-shell/client`, line numbers from
+`origin/main`; `packages/web-shell` currently has zero `sessionContext`
+references and passes legacy `workspaceCwd` everywhere):
+
+- **Home / global New Chat** — sidebar primary nav `handleNewSession()`
+  (`components/sidebar/WebShellSidebar.tsx:5084-5103`) →
+  `createNewSession()` (`App.tsx:8543`). Today this only clears; creation is
+  lazy. With capability, it sets pending context `{ kind: 'standalone' }`.
+  The Home first-prompt path (`ensureSessionForPrompt`, `App.tsx:6095`,
+  target-cwd resolution at `6126-6140` →
+  `utils/sessionPreparation.ts#createAndAttachSessionForPrompt`) consumes
+  the pending context instead of resolving locked/selected/primary cwd.
+- **Project-scoped New Chat** — `handleNewSession(wsCwd)`
+  (`WebShellSidebar.tsx:5509-5514`) → `createNewSession(workspaceCwd)`;
+  unchanged, pending context `{ kind: 'workspace', cwd }`.
+- **Goals** — `onCreateGoal` (`App.tsx:13080-13142`) allocates through
+  `createNewSession(undefined, { keepView: true })` +
+  `ensureSessionForPrompt`; stays workspace-bound (locked/selected/primary
+  cwd), ignoring any standalone pending context.
+- **Git** — `resolveSessionForWorkspace` (`App.tsx:6574-6614`) and the
+  composer git chips (`gitModeIntent`, `App.tsx:6060`, gated by
+  `gitModeEligible` at `6679-6681`); stays workspace-bound.
+- **Current-session New Chat** — `createNewSession()` inherits the active
+  `connection.sessionContext`: standalone → pending standalone, workspace →
+  pending workspace with the current cwd (today's behavior). A Live current
+  session maps to pending **standalone** (open decision, reviewer
+  confirmation requested): the provider deliberately does not create Live
+  sessions, and a fresh text chat from a voice session is projectless like
+  standalone — strict "inherit" would require Live creation the provider
+  rejects.
+- **Split view** — each pane owns a `DaemonSessionProvider`
+  (`components/SplitView.tsx`, pane keying at :234-247); panes receive the
+  pane's explicit context alongside `sessionId` so a standalone chat can be
+  opened beside a workspace chat without cross-contamination.
+- **Context propagation** — `WorkspaceSessionProvider`
+  (`components/WorkspaceSessionProvider.tsx`) still passes legacy
+  `workspaceCwd` into `DaemonSessionProvider`; PR6 passes the resolved
+  `sessionContext` prop instead (the provider normalizes legacy cwd at its
+  compatibility boundary, so both forms remain valid during the cutover).
+- **Loading existing sessions** — `loadSidebarSession` (`App.tsx:9016`)
+  currently passes `{ workspaceCwd }`; for standalone entries it calls
+  `loadSession(id, { sessionContext: { kind: 'standalone' } })`.
+
+Legacy callers that pass only `workspaceCwd` keep today's behavior
+untouched.
+
+## Capability Dual Behavior
+
+- Read the capability from `useWorkspace().capabilities.features` —
+  `DaemonWorkspaceProvider` fetches `client.capabilities()` once at
+  startup, before any session exists, so entry points (which fire before a
+  session) must not rely on the session-scoped `connection.capabilities`.
+  Compare against `STANDALONE_SESSIONS_CAPABILITY` from
+  `@qwen-code/sdk/daemon`.
+- **Capability absent** (old daemon): preserve legacy behavior — global New
+  Chat targets the primary workspace. Do not call any standalone route. An
+  informational hint that standalone chats need a daemon upgrade is allowed.
+- **Capability present, creation fails**: display the structured error and
+  preserve standalone intent for retry. Never silently create a
+  primary-workspace session; never downgrade the context after a `503`
+  ownership/runtime failure or a `409` directory conflict.
+
+## Deferred Creation and Pending Context
+
+WebShell creates the daemon session lazily on first prompt for the Home
+flow (`createNewSession` only clears; `ensureSessionForPrompt` materializes
+on submit). PR6 stores an explicit pending context alongside that deferred
+intent:
+
+- A new App-level `pendingSessionContext:
+DaemonProductSessionContext | undefined` state, set by every entry point
+  above and cleared on consume. Pending context is a
+  `DaemonProductSessionContext`, never a bare `undefined` cwd — "no cwd
+  yet" is not standalone semantics.
+- `ensureSessionForPrompt` (`App.tsx:6095`) prefers the pending context:
+  `{ kind: 'standalone' }` → `createSession({ sessionContext })`; a
+  workspace pending context → today's exact-cwd path; none → legacy
+  locked/selected/primary resolution.
+- Switching away and back before first prompt retains the pending context
+  verbatim; `loadSidebarSession` / `switchWorkspace` (`App.tsx:8605`)
+  overwrite it with the loaded session's explicit context.
+- The provider's own deferred path (`shouldDeferInitialSessionCreation`,
+  webui) keeps working unchanged underneath.
+
+## Recents and Lifecycle Actions
+
+- Add a top-level **Recents** group in the sidebar
+  (`components/sidebar/WebShellSidebar.tsx`). No cross-context list exists
+  today: `useScopedSessions` / `useWebShellSessions`
+  (`session-catalog/session-catalog-hooks.ts`) are keyed by
+  `SessionCatalogQuery { routeKind, workspaceCwd }`
+  (`session-catalog/session-catalog-store.ts:9-13`) — workspace-scoped by
+  construction. PR6 adds a standalone catalog lane fed by
+  `listStandaloneSessionsPage` (cursor pagination, `archiveState` filter)
+  rather than forcing standalone rows through the workspace catalog store.
+  Live sessions and project sessions keep their existing groups; standalone
+  children (sub-sessions with `parentSessionId`) never appear.
+- Per-session actions reuse the existing
+  `WebShellSidebarSessionActionItem` menu pattern
+  (`WebShellSidebar.tsx:270-284`: details | rename | export | delete | pin
+  | archive) but dispatch to the standalone SDK routes:
+  **rename** (`renameStandaloneSession`), **export**
+  (`exportStandaloneSession`), **archive** / **unarchive** (batch routes),
+  **delete** (`deleteStandaloneSessions`). Workspace-only actions (pin,
+  group) are not offered on standalone rows.
+- Delete retains the existing second-confirmation dialog pattern
+  (`DeleteSessionDialog`) and states that the transcript and private files
+  are removed. On success the session leaves Recents even when the response
+  carries `fileCleanupPending`; that subset is surfaced as a non-blocking
+  notice, not a blocking error.
+
+## Project-Only Surface Hiding
+
+In a standalone (or Live) chat, hide: workspace/project selector, Git
+status/branch/worktree controls, project file browser, project settings,
+pin/group controls, and attachments/uploads (standalone MVP excludes
+uploads). Model, approval, tool, permission, transcript, and supported
+metadata controls remain.
+
+- Gate on `connection.sessionContext?.kind` from the provider — the same
+  value that drove routing — never on the presence of a cwd. The
+  established pattern to extend is `ordinaryWorkspaces` /
+  `isKnownLiveWorkspaceCwd` (`App.tsx:2330-2338`), which already hides
+  project UI for the Live runtime; PR6 generalizes it to
+  "current chat is not a workspace context".
+- Component list (`origin/main`): composer workspace selector
+  (`components/WorkspaceSelector.tsx`, rendered `ChatEditor.tsx:3087`);
+  Git chips/popovers (`GitBranchIndicator`, `GitModePopover`,
+  `BranchPickerPopover`, `ChatEditor.tsx:3119-3154`, gated by
+  `gitBranchVisible` / `gitModeEligible`); Git dialogs (`GitDialog` et al.,
+  `App.tsx:12143`); project settings panel (`openPanel('settings')` +
+  workspace-scoped `useSettings`); @-mention file browser
+  (`components/AtMentionPanel.tsx`, `hooks/useAtMentionMenu.ts`); pin/group
+  controls (`SESSION_ORGANIZATION_FEATURE` sidebar grouping).
+- Uploads have two lanes, both hidden in the standalone MVP: (1) workspace
+  file upload — `hooks/useFileUpload.ts` → `client.uploadWorkspaceFile`,
+  rendered via `composer/AddMenu.tsx` and the @-panel "Upload file" item,
+  already kill-switched by `fileUploadEnabled` and the
+  `workspace_file_upload` capability (`ChatEditor.tsx:1557-1586`); (2)
+  inline prompt attachments — pasted/dropped images and text files in
+  `useComposerCore.ts` (`pastedImages`/`pastedFiles`, :1711-1714). The
+  acceptance matrix keeps all attachments out of standalone MVP; lane 2 is
+  session-scoped, so it needs an explicit context check, not a capability
+  check.
+- Live chats get the same treatment through the same gate; PR5 already
+  skips workspace providers/skills/Git/preheat for non-workspace contexts
+  inside the provider, so this PR only hides the visible controls.
+
+## Deep Links
+
+There is no router library: `main.tsx` + `utils/sessionPath.ts` own the
+`/session/<id>?workspace=<workspaceId>` scheme
+(`parseSessionId`/`buildSessionPathname`), and the App reports context
+upward through `onSessionIdChange(connection.sessionId, workspaceId,
+reportedWorkspaceCwd)` (`App.tsx:8156-8196`) so `main.tsx` can
+`replaceState` the URL.
+
+- New standalone links carry an explicit context parameter:
+  `/session/<id>?context=standalone` (no `?workspace=`). UUIDs are reserved
+  daemon-wide, so a context-tagged link can never collide with a workspace
+  session. Legacy context-free links keep today's workspace resolution —
+  standalone sessions did not exist before this feature, so no migration is
+  needed.
+- A `context=standalone` cold load resolves only after the standalone
+  read path is ready, and then only through exact `getStandaloneSession`
+  semantics: `creating` shows a resolving state, a summary loads the
+  session, not-found shows the existing missing-session UI
+  (`connection.missingSession` → `showMissingSessionState`). It never
+  guesses the primary workspace.
+- `onSessionIdChange` becomes context-aware: standalone sessions report
+  `context=standalone` and drop `workspaceId`; workspace and Live links
+  keep their existing resolvers. PR5's switching semantics already
+  serialize cross-context commits, so a late-arriving resolution cannot
+  overwrite a newer target.
+
+## Standalone State Surfacing
+
+Render the typed PR5 state instead of parsing strings:
+
+- `standaloneSession.workingDirectory.state === 'recreated'` → warning that
+  the transcript survived but previous files were not recovered.
+- `standaloneSession.errorCode` → `working_directory_missing` /
+  `working_directory_compromised` → offer explicit **repair**
+  (`repairStandaloneSessionDirectory`); repair never replays a prompt.
+- `standaloneSession.creationRecovery` → outcome-unknown banner exposing the
+  reserved UUID with a "check status" retry that performs exact lookup, plus
+  a terminal error path when lookup reports not-found.
+- Delete responses carrying `fileCleanupPending` → non-blocking notice that
+  file cleanup will finish automatically; the transcript is already gone.
+
+## Compatibility and Rollout
+
+- No daemon or SDK change; PR6 is UI-only against the merged v1 contract.
+- Old daemon → legacy primary behavior everywhere; old WebShell against a
+  new daemon → unchanged (it never calls standalone routes).
+- `@qwen-code/webui` already re-exports the standalone types through
+  `daemon-react-sdk`; if WebShell imports SDK standalone methods directly,
+  align the SDK peer minimum with the first release containing PR4 (same
+  caveat PR5 recorded).
+
+## Verification
+
+Unit/component (vitest):
+
+- Entry-point → context mapping for every row of the routing table,
+  including current-session inheritance of each kind.
+- Capability absent → legacy path, zero standalone requests issued
+  (assertable via the e2e `mockDaemon` request log and unit-level SDK
+  mocks).
+- Capable-daemon failure → error rendered, pending standalone intent
+  retained, no primary-workspace create issued.
+- Recents list/rename/export/archive/unarchive/delete flows, child
+  exclusion, `fileCleanupPending` removal semantics.
+- Surface hiding per context kind; uploads unavailable in standalone.
+- Deep-link resolution ordering (catalog readiness) and not-found UI.
+- `recreated` warning, repair offer, creation-recovery banner rendering
+  from the typed connection state.
+
+E2E (Playwright, `packages/web-shell/client/e2e`):
+
+- Extend `utils/mockDaemon.ts` scenario with a
+  `standalone_sessions_v1` capability toggle and the standalone route
+  family; add `web-shell.standalone.spec.ts` covering: Home New Chat →
+  standalone create body asserted; project New Chat → workspace create;
+  Recents lifecycle; old-daemon fallback; capable-daemon failure.
+- Manual E2E plan recorded at
+  `.qwen/e2e-tests/2026-08-29-webshell-standalone-chats.md` and dry-run
+  against a real `qwen serve` daemon before merge, per repo workflow.
+
+Commands: `cd packages/webui && npx vitest run <file>`, `cd
+packages/web-shell && npm run verify` (lint + format:check + typecheck +
+test:ci) and `npm run test:e2e`, then root `npm run build && npm run
+typecheck`.
+
+## Scope Boundary
+
+PR6 does not add: standalone attachments/uploads (waits on the workspace
+upload follow-up), moving/forking a standalone session into a project,
+durable standalone scheduling, storage quotas, or child-session management
+UI. `SessionOverviewPanel` and `ResumeDialog` remain workspace-scoped in
+this PR; the top-level Recents group lives in the sidebar only. It does not
+change daemon lifecycle behavior, the SDK contract, or the PR5 provider
+switching semantics; any typed gap discovered in the PR5 surface is raised
+as a follow-up rather than patched into this PR's UI work.

--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -143,6 +143,13 @@ cwd: wsCwd })` under the new intent contract.
 - **Git** — `resolveSessionForWorkspace` (`App.tsx:6661`) and the composer
   git chips (gated by `gitModeEligible`, `App.tsx:6763`); stays
   workspace-bound.
+- **Scheduled Tasks and other workspace-maintenance callers** (review P1):
+  `ScheduledTasksDialog.onCreateViaChat` resolves an explicit workspace cwd
+  and passes `{ kind: 'workspace', cwd }` — durable standalone scheduling
+  is out of scope, so an active standalone context must never choose
+  inherit/global here. The same rule audits every remaining
+  workspace-maintenance callsite, with a standalone→Scheduled-Tasks
+  regression test.
 - **Current-session New Chat** (`{ kind: 'inherit' }`) — inherits the
   active `connection.sessionContext`: standalone → pending standalone,
   workspace → pending workspace with the current cwd (today's behavior). A
@@ -311,6 +318,24 @@ connection.sessionContext`) so draft standalone chats hide project
   fallback, and after attach uses only the standalone session's
   session-supported data. Covered by a workspace→standalone transition test
   with stale commands, skills, draft, and history snapshots.
+- **Workspace effects and slash-command handlers gate on context too**
+  (review P1): a sessionless App derives `activeWorkspaceCwd` from
+  locked/selected/primary and starts the Git-status effect, and `/diff`,
+  `/log`, `/prs`, `/settings`, `/schedule`, `/memory add` can open or
+  default to workspace-scoped flows — hidden controls alone leave these
+  live against the primary workspace. A workspace-eligible cwd is derived
+  only when `effectiveContext.kind === 'workspace'` and gates background
+  effects, command discovery, and submit-time handlers; tests assert zero
+  workspace requests or panels from both pending and attached standalone
+  contexts.
+- **The legacy input-history fallback is disabled for standalone
+  identities** (review P1): `useComposerCore`/`useInputHistory` fall back
+  to the unscoped `qwen-web-shell-history` key whenever a scoped history is
+  empty, so a standalone-specific key alone would still surface legacy
+  workspace-era prompts. The fallback policy becomes
+  product-context-aware — no legacy/global fallback for a non-workspace
+  history identity — tested with an empty standalone history while the
+  legacy key is populated.
 - Component list (`origin/main`): composer workspace selector
   (`components/WorkspaceSelector.tsx`, rendered `ChatEditor.tsx:3116`);
   Git chips/popovers (`GitBranchIndicator`, `GitModePopover`,
@@ -510,6 +535,13 @@ Unit/component (vitest, `packages/web-shell`):
 - Split View bare-id classifier: delayed catalogs, standalone/`creating`
   rejection, only `404` continues to workspace ownership resolution, and a
   controlled host cannot re-inject sanitized ids (review P1).
+- Pending and attached standalone contexts issue zero workspace requests or
+  panels (Git-status effect, `/diff`, `/log`, `/prs`, `/settings`,
+  `/schedule`, `/memory`) (review P1).
+- Empty standalone input history stays empty while the legacy global
+  history key is populated (review P1).
+- `ScheduledTasksDialog.onCreateViaChat` forces workspace intent even from
+  an active standalone context (review P1).
 
 E2E (Playwright, `packages/web-shell/client/e2e`):
 

--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -328,6 +328,15 @@ connection.sessionContext`) so draft standalone chats hide project
   effects, command discovery, and submit-time handlers; tests assert zero
   workspace requests or panels from both pending and attached standalone
   contexts.
+- **Generic transcript branching is excluded from standalone** (review
+  P1): `/branch` and the per-message Branch action call
+  `POST /session/:id/branch`, whose route is registered with
+  `rejectStandalone: true` (`packages/cli/src/serve/routes/session.ts`) —
+  the action deterministically fails for standalone sessions. Pending and
+  attached standalone contexts omit the Branch action, drop `/branch` from
+  command discovery, and block its submit-time handler; tests assert no
+  generic branch request is issued. `/fork` stays separate — guarded
+  background fork-agent work is supported.
 - **The legacy input-history fallback is disabled for standalone
   identities** (review P1): `useComposerCore`/`useInputHistory` fall back
   to the unscoped `qwen-web-shell-history` key whenever a scoped history is
@@ -542,6 +551,13 @@ Unit/component (vitest, `packages/web-shell`):
   history key is populated (review P1).
 - `ScheduledTasksDialog.onCreateViaChat` forces workspace intent even from
   an active standalone context (review P1).
+- Standalone contexts omit the Branch action, drop `/branch` from
+  discovery, and block its handler — zero generic branch requests;
+  `/fork` remains available (review P1).
+- Session-overview, `/resume`, `/delete`, `/release` ingresses hidden or
+  blocked from pending and attached standalone contexts; `/resume <id>`
+  for a standalone session routes only through the explicit standalone
+  context (review P1).
 
 E2E (Playwright, `packages/web-shell/client/e2e`):
 
@@ -565,7 +581,17 @@ PR6 does not add: standalone attachments/uploads (waits on the workspace
 upload follow-up), moving/forking a standalone session into a project,
 durable standalone scheduling, storage quotas, or child-session management
 UI. `SessionOverviewPanel` and `ResumeDialog` remain workspace-scoped in
-this PR; the top-level Recents group lives in the sidebar only. Split View
+this PR, and every ingress to them is gated (review P1): bare `/resume`,
+`/delete`, and `/release` mount workspace dialogs keyed by
+`lockedWorkspaceCwd`, and when it is undefined `useScopedSessions` selects
+the primary WebShell catalog — so `/delete` could act on unrelated
+workspace sessions from a standalone context. Non-workspace effective
+contexts hide or block the sidebar `canOpenSessionsOverview` entry,
+`shellApi.openSessionOverview()`, and the bare workspace dialog commands,
+issuing zero legacy catalog or destructive requests; `/resume <id>` for a
+standalone session routes only through the explicit standalone context.
+Both pending and attached standalone states are tested. The top-level
+Recents group lives in the sidebar only. Split View
 stays workspace-only (context-bearing pane descriptors are a follow-up).
 The one in-scope provider change is the prompt-admission error-code capture
 plus repair-and-reload transition, because the Repair UI depends on it; any

--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -337,6 +337,19 @@ connection.sessionContext`) so draft standalone chats hide project
   command discovery, and block its submit-time handler; tests assert no
   generic branch request is issued. `/fork` stays separate — guarded
   background fork-agent work is supported.
+- **The workspace Web Terminal is gated off in non-workspace contexts**
+  (review P1): `webTerminalAvailable` (`App.tsx:3206`) checks only the
+  `web_terminal` capability, but a standalone connection exposes no product
+  `workspaceCwd`, so `TerminalPanel` would open the terminal route without
+  a cwd and the daemon rejects it with `Terminal workspace unavailable` —
+  the generic route resolves only registered trusted workspaces. Standalone
+  sessions still run ordinary Shell/tool commands in their private
+  directory through the session permission pipeline; this gates only the
+  separate terminal surface. Terminal availability and the open handler
+  require `effectiveContext.kind === 'workspace'`, inherited terminal tabs
+  are discarded or closed when entering a non-workspace context, and tests
+  assert pending and attached standalone/Live contexts create no terminal
+  WebSocket while workspace terminals remain unchanged.
 - **The legacy input-history fallback is disabled for standalone
   identities** (review P1): `useComposerCore`/`useInputHistory` fall back
   to the unscoped `qwen-web-shell-history` key whenever a scoped history is
@@ -558,6 +571,8 @@ Unit/component (vitest, `packages/web-shell`):
   blocked from pending and attached standalone contexts; `/resume <id>`
   for a standalone session routes only through the explicit standalone
   context (review P1).
+- Standalone and Live contexts create no terminal WebSocket and discard
+  inherited terminal tabs; workspace terminals unchanged (review P1).
 
 E2E (Playwright, `packages/web-shell/client/e2e`):
 

--- a/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
+++ b/docs/plans/2026-08-29-standalone-pr6-webshell-ui.md
@@ -137,10 +137,12 @@ everywhere):
   (`client/live/useLiveVoice`), never a silent remap to standalone — the
   routing contract's "inherit explicit context" row stays intact (review
   P1).
-- **Split view** — each pane owns a `DaemonSessionProvider`
-  (`components/SplitView.tsx:464`); panes receive the pane's explicit
-  context alongside `sessionId` so a standalone chat can be opened beside a
-  workspace chat without cross-contamination.
+- **Split view excludes standalone sessions in PR6** (review P1): pane
+  identity is persisted as bare `sessionId` strings (split URL,
+  sessionStorage) and pane ownership derives from workspace catalogs, so a
+  standalone pane has no context source after a cold split URL or refresh
+  and would fall through to workspace resolution. Standalone rows get no
+  split entry point; context-bearing pane descriptors are a follow-up.
 - **Context propagation** — `WorkspaceSessionProvider`
   (`components/WorkspaceSessionProvider.tsx`) still passes legacy
   `workspaceCwd` into `DaemonSessionProvider`; PR6 passes the resolved
@@ -240,6 +242,19 @@ DaemonProductSessionContext | undefined` state, set by every entry point
   are removed. On success the session leaves Recents even when the response
   carries `fileCleanupPending`; that subset is surfaced as a non-blocking
   notice, not a blocking error.
+- **Archived standalone sessions stay reachable** (review P2): the lazy
+  Archived section gains a standalone `archiveState=archived` lane — today
+  that section is backed by workspace catalogs only, while the umbrella
+  contract requires archived standalone sessions to remain visible. Because
+  PR5 deliberately skips workspace event invalidation for standalone
+  contexts, the standalone lanes refresh explicitly after create, prompt
+  completion, and every lifecycle action.
+- **Batch outcomes are interpreted per session id** (review P2): archive,
+  unarchive, and delete return partial-success envelopes even with HTTP 200. The catalog updates only when the target id appears in
+  `archived`/`alreadyArchived`, `unarchived`/`alreadyActive`, or
+  `removed`/`notFound` as appropriate; an id in `errors` keeps its row and
+  surfaces the per-session code/message. `fileCleanupPending` is only an
+  additional notice for an otherwise removed id.
 
 ## Project-Only Surface Hiding
 
@@ -275,6 +290,14 @@ connection.sessionContext`) so draft standalone chats hide project
   acceptance matrix keeps all attachments out of standalone MVP; lane 2 is
   session-scoped, so it needs an explicit context check, not a capability
   check.
+- **Attachments held across a context switch are dropped, not carried**
+  (review P1): hiding paste/drop/upload controls does not clear
+  `pastedImages`/`pastedFiles` already held by `useComposerCore`, and
+  `createNewSession` does not clear them either — files added in a
+  workspace could otherwise ride into the first standalone prompt.
+  Switching into a standalone draft clears held attachments with a visible
+  notice, and a submit-time non-workspace guard blocks stale or
+  programmatically supplied attachments from reaching a standalone session.
 - Live chats get the same treatment through the same gate; PR5 already
   skips workspace providers/skills/Git/preheat for non-workspace contexts
   inside the provider, so this PR only hides the visible controls.
@@ -303,6 +326,13 @@ upward through `onSessionIdChange` (`App.tsx:8282`) so `main.tsx` can
   resolver polls exact lookup with bounded backoff (e.g. up to 30 s, capped
   attempts) and then stops at an explicit **Retry** action; it never hangs
   in the resolving state forever.
+- **Stale resolution is canceled before it starts a load** (review P1):
+  the provider's generation guard only orders loads after they start, but
+  exact lookup and polling happen before `loadSession`, so a delayed
+  `creating` poll resolving after the user opened another session would
+  start a load that incorrectly wins. An App-level route-resolution token
+  is invalidated on every navigation and checked before each poll and
+  immediately before `loadSession`.
 - **Fail-closed edge cases** (review P2): a `?context=standalone` link
   carrying a conflicting `?workspace=` parameter is rejected, not
   reconciled; on a daemon without the capability, a standalone link shows
@@ -323,7 +353,16 @@ Render the typed PR5 state instead of parsing strings:
   the transcript survived but previous files were not recovered.
 - `standaloneSession.errorCode === 'working_directory_missing'` → offer
   explicit **repair** (`repairStandaloneSessionDirectory`); repair never
-  replays a prompt.
+  replays a prompt. This requires one small provider/App transition in PR6
+  scope (review P1): today `sendPrompt`'s catch surfaces the
+  prompt-admission `409` only as a generic notice and never copies its
+  typed code into `standaloneSession`, and the SDK repair call neither
+  clears provider error state nor reloads the session — so the Repair UI
+  could neither reliably appear nor reliably unblock. PR6 captures the
+  typed code into `standaloneSession.errorCode` on prompt-admission
+  rejection, owner-guards Repair to the affected session, and on success
+  reloads the same standalone session, clearing the error only after the
+  reload commits.
 - `standaloneSession.errorCode === 'working_directory_compromised'` →
   **fail-closed blocking state** (review P1): the service rejects an
   existing compromised path instead of recreating it, so no Repair action
@@ -373,6 +412,17 @@ Unit/component (vitest, `packages/web-shell`):
 - `recreated` warning, repair offered only for `working_directory_missing`,
   `working_directory_compromised` rendered fail-closed without a repair
   action (review P1), creation-recovery banner rendering from typed state.
+- Prompt-admission `working_directory_missing` reaches
+  `standaloneSession.errorCode`, Repair is owner-guarded to the affected
+  session, and success reloads the same session and clears the error
+  (review P1).
+- A delayed `creating` poll canceled by a user session switch never starts
+  a load (review P1).
+- Context switch clears held composer attachments with a visible notice;
+  the submit-time guard rejects stale or programmatic attachments
+  (review P1).
+- Archived standalone lane lists and refreshes after lifecycle actions;
+  partial-success batch envelopes handled per action (review P2).
 
 E2E (Playwright, `packages/web-shell/client/e2e`):
 
@@ -396,7 +446,10 @@ PR6 does not add: standalone attachments/uploads (waits on the workspace
 upload follow-up), moving/forking a standalone session into a project,
 durable standalone scheduling, storage quotas, or child-session management
 UI. `SessionOverviewPanel` and `ResumeDialog` remain workspace-scoped in
-this PR; the top-level Recents group lives in the sidebar only. It does not
-change daemon lifecycle behavior, the SDK contract, or the PR5 provider
-switching semantics; any typed gap discovered in the provider surface is
-raised as a follow-up rather than patched into this PR's UI work.
+this PR; the top-level Recents group lives in the sidebar only. Split View
+stays workspace-only (context-bearing pane descriptors are a follow-up).
+The one in-scope provider change is the prompt-admission error-code capture
+plus repair-and-reload transition, because the Repair UI depends on it; any
+other typed gap discovered in the provider surface is raised as a
+follow-up. It does not change daemon lifecycle behavior, the SDK contract,
+or the PR5 provider switching semantics.

--- a/packages/web-shell/README.md
+++ b/packages/web-shell/README.md
@@ -134,8 +134,9 @@ export function QwenCodePanel() {
       baseUrl="http://127.0.0.1:4170"
       token="your-bearer-token"
       sessionId="838e1811-9f84-4848-9915-d9a7f01ff5c6"
-      onSessionIdChange={(sessionId) => {
-        console.log('current session:', sessionId);
+      sessionContext={{ kind: 'standalone' }}
+      onSessionIdChange={(sessionId, _workspaceId, _workspaceCwd, context) => {
+        console.log('current session:', sessionId, context);
       }}
       onSessionCreated={async (sessionId) => {
         await registerSession(sessionId);
@@ -212,27 +213,28 @@ const projection = projectChatRecordsToDaemonTranscript(records);
 
 包含 `WebShell` 的所有 Props，加上 Provider 配置：
 
-| 属性                 | 类型      | 说明                                                                                                    |
-| -------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
-| `baseUrl`            | `string`  | daemon API 地址，未传时使用 `window.location.origin`                                                    |
-| `token`              | `string`  | daemon API Bearer token                                                                                 |
-| `sessionId`          | `string`  | 要连接的 session id；未传或 `undefined` 时保持空页面                                                    |
-| `workspaceId`        | `string`  | 已注册工作区 id，主要用于定位已有 session；不会注册或锁定工作区                                         |
-| `workspaceCwd`       | `string`  | 已注册工作区路径，语义同 `workspaceId`；不会注册或锁定工作区，且优先于 `workspaceId`                    |
-| `lockWorkspaceCwd`   | `string`  | 锁定到指定工作区路径；未注册时自动持久注册，并隐藏其他工作区及添加、移除和选择入口                      |
-| `restartSseOnPrompt` | `boolean` | 每次 prompt 被 daemon 接收后重建存活 SSE 流；流断开时提交 prompt 总会立即重建（与此开关无关）；默认关闭 |
+| 属性                 | 类型                          | 说明                                                                                                    |
+| -------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `baseUrl`            | `string`                      | daemon API 地址，未传时使用 `window.location.origin`                                                    |
+| `token`              | `string`                      | daemon API Bearer token                                                                                 |
+| `sessionId`          | `string`                      | 要连接的 session id；未传或 `undefined` 时保持空页面                                                    |
+| `workspaceId`        | `string`                      | 已注册工作区 id，主要用于定位已有 session；不会注册或锁定工作区                                         |
+| `workspaceCwd`       | `string`                      | 已注册工作区路径，语义同 `workspaceId`；不会注册或锁定工作区，且优先于 `workspaceId`                    |
+| `sessionContext`     | `DaemonProductSessionContext` | 显式产品上下文；standalone 或 Live 上下文不能同时传 `workspaceId`、`workspaceCwd` 或 `lockWorkspaceCwd` |
+| `lockWorkspaceCwd`   | `string`                      | 锁定到指定工作区路径；未注册时自动持久注册，并隐藏其他工作区及添加、移除和选择入口                      |
+| `restartSseOnPrompt` | `boolean`                     | 每次 prompt 被 daemon 接收后重建存活 SSE 流；流断开时提交 prompt 总会立即重建（与此开关无关）；默认关闭 |
 
 ### WebShell
 
-| 属性                | 类型                                                                                    | 说明                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `onSessionIdChange` | `(sessionId: string \| undefined, workspaceId?: string, workspaceCwd?: string) => void` | 当前 session 或工作区变化时触发                                                  |
-| `onSessionCreated`  | `(sessionId: string) => Promise<void> \| void`                                          | 新 session 创建后触发；完成前会阻塞 session 初始化和 prompt 提交，最长等待 30 秒 |
-| `theme`             | `'dark' \| 'light'`                                                                     | UI 主题，默认 `dark`                                                             |
-| `onThemeChange`     | `(theme: WebShellTheme) => void`                                                        | `/theme` 命令切换主题后触发                                                      |
-| `language`          | `'en' \| 'zh-CN' \| 'zh' \| 'zh-cn'`                                                    | UI 语言                                                                          |
-| `onLanguageChange`  | `(language: WebShellLanguage) => void`                                                  | `/language ui` 切换 UI 语言后触发                                                |
-| `onSlashCommand`    | `(command: WebShellSlashCommand) => boolean \| void`                                    | 斜杠命令进入默认处理前触发；返回 `true` 时由宿主接管并跳过默认行为               |
+| 属性                | 类型                                                                                                                                  | 说明                                                                                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `onSessionIdChange` | `(sessionId: string \| undefined, workspaceId?: string, workspaceCwd?: string, sessionContext?: DaemonProductSessionContext) => void` | 当前 session、工作区或显式产品上下文变化时触发；standalone 和 Live 通过第四个参数上报 |
+| `onSessionCreated`  | `(sessionId: string) => Promise<void> \| void`                                                                                        | 新 session 创建后触发；完成前会阻塞 session 初始化和 prompt 提交，最长等待 30 秒      |
+| `theme`             | `'dark' \| 'light'`                                                                                                                   | UI 主题，默认 `dark`                                                                  |
+| `onThemeChange`     | `(theme: WebShellTheme) => void`                                                                                                      | `/theme` 命令切换主题后触发                                                           |
+| `language`          | `'en' \| 'zh-CN' \| 'zh' \| 'zh-cn'`                                                                                                  | UI 语言                                                                               |
+| `onLanguageChange`  | `(language: WebShellLanguage) => void`                                                                                                | `/language ui` 切换 UI 语言后触发                                                     |
+| `onSlashCommand`    | `(command: WebShellSlashCommand) => boolean \| void`                                                                                  | 斜杠命令进入默认处理前触发；返回 `true` 时由宿主接管并跳过默认行为                    |
 
 宿主可以监听命令，也可以返回 `true` 接管对应操作：
 

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -68,11 +68,21 @@ type MockConnection = {
   error?: string;
   errorStatus?: number;
   missingSession?: boolean;
+  sessionContext?:
+    | { kind: 'workspace'; cwd: string }
+    | { kind: 'standalone' }
+    | { kind: 'live' };
   gitBranch?: string;
   gitStatus?: DaemonWorkspaceGitStatus;
   voiceTarget?: VoiceWorkspaceTarget;
   voiceStatusRevision?: VoiceStatusRevision;
   goalState?: GoalSnapshotV2;
+  standaloneSession?: {
+    creationRecovery?: {
+      state: 'creating';
+      sessionId: string;
+    };
+  };
 };
 
 function activeGoalSnapshot(
@@ -128,6 +138,7 @@ type ChatEditorTestProps = {
   voiceTarget?: VoiceWorkspaceTarget;
   voiceStatusRevision?: VoiceStatusRevision;
   placeholderText?: string;
+  sessionName?: string;
   workspaces?: Array<{
     id: string;
     cwd: string;
@@ -136,6 +147,8 @@ type ChatEditorTestProps = {
     trusted: boolean;
   }>;
   atWorkspaceCwd?: string;
+  composerScopeKey?: string;
+  workspaceFeaturesEnabled?: boolean;
   selectedWorkspaceCwd?: string;
   onSelectWorkspace?: (cwd: string | undefined) => void;
   onCreateScratchWorkspace?: () => void;
@@ -259,6 +272,18 @@ const {
     sessionStatus: vi.fn(() =>
       Promise.resolve({ workspaceCwd: '/tmp/project' }),
     ),
+    startLive: vi.fn().mockResolvedValue({
+      v: 1,
+      available: true,
+      state: 'listening',
+      shortcut: 'Command+Q',
+    }),
+    getStandaloneSession: vi.fn().mockResolvedValue({
+      sessionId: 'session-1',
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: false,
+    }),
     listWorkspaceSessions: vi.fn(() => Promise.resolve([])),
     createSideTaskSession: vi.fn().mockResolvedValue({
       sessionId: 'side-session-1',
@@ -266,6 +291,13 @@ const {
       displayName: 'Side task',
     }),
     detachSession: vi.fn().mockResolvedValue(undefined),
+    renameStandaloneSession: vi.fn().mockResolvedValue(undefined),
+    unarchiveStandaloneSessions: vi.fn().mockResolvedValue({
+      unarchived: [],
+      alreadyActive: [],
+      notFound: [],
+      errors: [],
+    }),
     resolveSubagentSession: vi
       .fn()
       .mockRejectedValue(new Error('Subagent details unavailable')),
@@ -335,6 +367,7 @@ const {
       capabilities: {
         workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
       },
+      status: 'connected' as 'connected' | 'error',
       client: workspaceClient,
       refreshCapabilities: vi.fn(),
     },
@@ -419,6 +452,7 @@ const {
       latestToastHostElevated: false,
       latestStatusBarTasks: null as DaemonSessionMonitorTaskStatus[] | null,
       latestStatusBarOnOpenTasks: null as (() => void) | null,
+      latestStatusBarHideSettings: false,
       latestMessageListProps: null as {
         messages?: Array<{
           role?: string;
@@ -484,6 +518,12 @@ const {
         onOpenMonitor?: (task: DaemonSessionMonitorTaskStatus) => void;
       } | null,
       settings: [] as DaemonSettingDescriptor[],
+      latestSettingsHookOptions: undefined as
+        | { autoLoad?: boolean; enabled?: boolean }
+        | undefined,
+      latestProvidersHookOptions: undefined as
+        | { autoLoad?: boolean; enabled?: boolean }
+        | undefined,
       workspaceEventSignals: {
         artifactsVersion: 0,
         extensionsVersion: 0,
@@ -581,19 +621,25 @@ vi.mock('@qwen-code/web-shell/daemon-react-sdk', () => {
     }),
     useSessionNotices: () => ({ notices: [], dismissNotice: vi.fn() }),
     usePromptStatus: () => 'idle',
-    useSettings: () => ({
-      settings: testState.settings,
-      setValue: settingsSetValue,
-      reload: settingsReload,
-      loading: false,
-    }),
-    useProviders: () => ({
-      providers: [],
-      current: undefined,
-      loading: false,
-      error: undefined,
-      reload: vi.fn().mockResolvedValue(undefined),
-    }),
+    useSettings: (options?: { autoLoad?: boolean; enabled?: boolean }) => {
+      testState.latestSettingsHookOptions = options;
+      return {
+        settings: testState.settings,
+        setValue: settingsSetValue,
+        reload: settingsReload,
+        loading: false,
+      };
+    },
+    useProviders: (options?: { autoLoad?: boolean; enabled?: boolean }) => {
+      testState.latestProvidersHookOptions = options;
+      return {
+        providers: [],
+        current: undefined,
+        loading: false,
+        error: undefined,
+        reload: vi.fn().mockResolvedValue(undefined),
+      };
+    },
     useStreamingState: () => testState.streamingState,
     useTranscriptBlocks: () => testState.blocks,
     useTranscriptHistory: () => ({
@@ -625,6 +671,7 @@ vi.mock('@qwen-code/sdk/daemon', () => {
   return {
     DaemonHttpError,
     DAEMON_GOAL_STATUS_SENTINEL_PREFIX: 'qwen-goal-status:',
+    STANDALONE_SESSIONS_CAPABILITY: 'standalone_sessions_v1',
     isDaemonTurnError: (error: unknown) =>
       typeof error === 'object' &&
       error !== null &&
@@ -636,6 +683,13 @@ vi.mock('@qwen-code/sdk/daemon', () => {
       error.body !== null &&
       (error.body as Record<string, unknown>)['code'] ===
         'branch_point_invalid',
+    isStandaloneSessionNotFoundError: (error: unknown): boolean =>
+      error instanceof DaemonHttpError &&
+      error.status === 404 &&
+      typeof error.body === 'object' &&
+      error.body !== null &&
+      (error.body as Record<string, unknown>)['code'] ===
+        'standalone_session_not_found',
   };
 });
 
@@ -1095,7 +1149,7 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
       onOpenSessions?: () => void;
       onOpenSplitView?: () => void;
       onMobileClose?: () => void;
-      onNewSession?: () => Promise<boolean> | boolean;
+      onNewSession?: (workspaceCwd?: string) => Promise<boolean> | boolean;
       onNewWorktreeSession?: (
         workspaceCwd?: string,
       ) => Promise<boolean> | boolean | void;
@@ -1104,6 +1158,7 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
       onSelectCurrentSession?: () => void;
       onSessionsDeleted?: (sessionIds: string[]) => void;
       onOpenAddWorkspace?: () => void;
+      onThemeChange?: (theme: 'light' | 'dark') => void;
       showSessionSourceSwitch?: boolean;
     }) => {
       // Expose the Daemon Status / Session Overview openers so tests can
@@ -1117,6 +1172,15 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
             props.showSessionSourceSwitch,
           ),
         },
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'change-sidebar-theme',
+            type: 'button',
+            onClick: () => props.onThemeChange?.('dark'),
+          },
+          'change theme',
+        ),
         React.createElement(
           'button',
           {
@@ -1134,6 +1198,15 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
             onClick: props.onNewSession,
           },
           'new session',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'new-session-primary-workspace',
+            type: 'button',
+            onClick: () => void props.onNewSession?.('/workspace'),
+          },
+          'new session in primary workspace',
         ),
         React.createElement(
           'button',
@@ -1342,9 +1415,11 @@ vi.doMock('./components/StatusBar', async () => {
     StatusBar: (props: {
       tasks?: DaemonSessionMonitorTaskStatus[];
       onOpenTasks?: () => void;
+      hideSettings?: boolean;
     }) => {
       testState.latestStatusBarTasks = props.tasks ?? [];
       testState.latestStatusBarOnOpenTasks = props.onOpenTasks ?? null;
+      testState.latestStatusBarHideSettings = props.hideSettings ?? false;
       return React.createElement('div');
     },
   };
@@ -5259,6 +5334,7 @@ beforeEach(() => {
   mockConnection.error = undefined;
   mockConnection.errorStatus = undefined;
   mockConnection.missingSession = false;
+  mockConnection.sessionContext = undefined;
   mockConnection.commands = [];
   mockConnection.skills = [];
   mockConnection.loadingTranscript = false;
@@ -5272,6 +5348,7 @@ beforeEach(() => {
   // A loaded session always carries a Goal snapshot; tests that exercise the
   // hydration window (goalState still unknown) set it back to undefined.
   mockConnection.goalState = { v: 2, activity: 'idle', goal: null };
+  mockConnection.standaloneSession = undefined;
   testState.ownerVersion = 0;
   testState.workspaceEventSignals = {
     artifactsVersion: 0,
@@ -5283,6 +5360,7 @@ beforeEach(() => {
   mockWorkspace.capabilities = {
     workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
   };
+  mockWorkspace.status = 'connected';
   mockWorkspace.refreshCapabilities.mockReset();
   mockWorkspace.refreshCapabilities.mockResolvedValue(
     mockWorkspace.capabilities,
@@ -5303,6 +5381,20 @@ beforeEach(() => {
   mockWorkspace.client.sessionStatus.mockResolvedValue({
     workspaceCwd: '/tmp/project',
   });
+  mockWorkspace.client.startLive.mockReset();
+  mockWorkspace.client.startLive.mockResolvedValue({
+    v: 1,
+    available: true,
+    state: 'listening',
+    shortcut: 'Command+Q',
+  });
+  mockWorkspace.client.getStandaloneSession.mockReset();
+  mockWorkspace.client.getStandaloneSession.mockResolvedValue({
+    sessionId: 'session-1',
+    sourceType: 'standalone',
+    context: { kind: 'standalone' },
+    isArchived: false,
+  });
   mockWorkspace.client.listWorkspaceSessions.mockReset();
   mockWorkspace.client.listWorkspaceSessions.mockResolvedValue([]);
   mockWorkspace.client.createSideTaskSession.mockReset();
@@ -5311,6 +5403,15 @@ beforeEach(() => {
   );
   mockWorkspace.client.detachSession.mockReset();
   mockWorkspace.client.detachSession.mockResolvedValue(undefined);
+  mockWorkspace.client.renameStandaloneSession.mockReset();
+  mockWorkspace.client.renameStandaloneSession.mockResolvedValue(undefined);
+  mockWorkspace.client.unarchiveStandaloneSessions.mockReset();
+  mockWorkspace.client.unarchiveStandaloneSessions.mockResolvedValue({
+    unarchived: [],
+    alreadyActive: [],
+    notFound: [],
+    errors: [],
+  });
   for (const method of Object.values(sessionCatalogController)) {
     method.mockReset();
   }
@@ -5337,6 +5438,7 @@ beforeEach(() => {
   testState.latestToastHostElevated = false;
   testState.latestStatusBarTasks = null;
   testState.latestStatusBarOnOpenTasks = null;
+  testState.latestStatusBarHideSettings = false;
   testState.latestMessageListProps = null;
   testState.latestBtwMessageProps = null;
   testState.latestAddWorkspaceDialogProps = null;
@@ -5354,6 +5456,8 @@ beforeEach(() => {
   testState.backgroundTasks = [];
   testState.latestMonitorDetailsOnOpen = null;
   testState.settings = [];
+  testState.latestSettingsHookOptions = undefined;
+  testState.latestProvidersHookOptions = undefined;
   testState.latestSettingsState = null;
   testState.latestSettingsInitialCategory = undefined;
   testState.latestModelManagement = null;
@@ -8348,6 +8452,27 @@ describe('App session callbacks', () => {
     });
   });
 
+  it('does not query a workspace catalog for a Live session title', async () => {
+    mockConnection.sessionContext = { kind: 'live' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.displayName = undefined;
+    mockWorkspace.client.sessionStatus.mockResolvedValue({
+      sessionId: 'session-1',
+      workspaceCwd: '/internal/conversations',
+      displayName: 'Live conversation',
+    });
+
+    const { container } = renderApp();
+
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-testid="chat-context-header"]')
+          ?.textContent,
+      ).toContain('Live conversation');
+    });
+    expect(mockWorkspace.client.listWorkspaceSessions).not.toHaveBeenCalled();
+  });
+
   it('does not expose cached metadata after a same-id workspace switch', async () => {
     mockConnection.displayName = undefined;
     const sourceStatus = deferred<{
@@ -8517,6 +8642,21 @@ describe('App session callbacks', () => {
       container.querySelector('[data-testid="inline-panel"]'),
     ).not.toBeNull();
     expect(testState.latestSettingsInitialCategory).toBe('Daemon');
+  });
+
+  it('omits the workspace settings deep link from a standalone chat header', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    const renderChatHeader = vi.fn(() => null);
+    renderApp({ renderChatHeader });
+    await flush();
+
+    expect(renderChatHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceCwd: undefined,
+        onOpenLocalControlSettings: undefined,
+      }),
+    );
   });
 
   it('opens Settings deep-linked to Daemon from the main chat header QR entry', async () => {
@@ -9743,6 +9883,202 @@ describe('App session callbacks', () => {
     );
   });
 
+  it('reports explicit non-workspace contexts to the host', async () => {
+    mockConnection.workspaceCwd = '';
+    mockConnection.sessionContext = { kind: 'live' };
+    const onSessionIdChange = vi.fn();
+
+    const { rerender } = renderApp({ onSessionIdChange });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenLastCalledWith(
+      'session-1',
+      undefined,
+      undefined,
+      { kind: 'live' },
+    );
+
+    act(() => {
+      mockConnection.sessionContext = { kind: 'standalone' };
+      rerender({ onSessionIdChange });
+    });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenLastCalledWith(
+      'session-1',
+      undefined,
+      undefined,
+      { kind: 'standalone' },
+    );
+  });
+
+  it('reports a pending standalone context after the current session clears', async () => {
+    mockConnection.sessionContext = { kind: 'workspace', cwd: '/tmp/project' };
+    mockConnection.capabilities.features = ['standalone_sessions_v1'];
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    };
+    const shellRef = createRef<WebShellApi>();
+    const onSessionIdChange = vi.fn();
+    const { rerender } = renderApp({ onSessionIdChange, shellRef });
+    await flush();
+
+    await act(async () => {
+      await shellRef.current?.createNewSession();
+    });
+    expect(mockSessionActions.clearSession).toHaveBeenCalledOnce();
+
+    act(() => {
+      mockConnection.sessionId = undefined;
+      rerender({ onSessionIdChange, shellRef });
+    });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenLastCalledWith(
+      undefined,
+      undefined,
+      undefined,
+      { kind: 'standalone' },
+    );
+  });
+
+  it('keeps a primary workspace row New Task workspace-scoped on a capable daemon', async () => {
+    mockConnection.sessionId = undefined;
+    mockConnection.sessionContext = { kind: 'workspace', cwd: '/workspace' };
+    mockConnection.capabilities.features = ['standalone_sessions_v1'];
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/workspace',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="new-session-primary-workspace"]',
+        )!
+        .click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('workspace prompt');
+      await vi.waitFor(() => {
+        expect(mockSessionActions.createSession).toHaveBeenCalled();
+      });
+    });
+
+    expect(mockSessionActions.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceCwd: '/workspace',
+        sessionContext: { kind: 'workspace', cwd: '/workspace' },
+      }),
+    );
+    expect(mockSessionActions.createSession).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionContext: { kind: 'standalone' } }),
+    );
+  });
+
+  it('retries failed capabilities before routing a global new session', async () => {
+    mockWorkspace.status = 'error';
+    mockWorkspace.capabilities =
+      undefined as unknown as typeof mockWorkspace.capabilities;
+    mockWorkspace.refreshCapabilities.mockResolvedValue({
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    });
+    const shellRef = createRef<WebShellApi>();
+    const onSessionIdChange = vi.fn();
+    const { rerender } = renderApp({ onSessionIdChange, shellRef });
+    await flush();
+
+    let created: boolean | undefined;
+    await act(async () => {
+      created = await shellRef.current?.createNewSession();
+    });
+
+    expect(created).toBe(true);
+    expect(mockWorkspace.refreshCapabilities).toHaveBeenCalledOnce();
+    expect(mockSessionActions.clearSession).toHaveBeenCalledOnce();
+
+    act(() => {
+      mockConnection.sessionId = undefined;
+      rerender({ onSessionIdChange, shellRef });
+    });
+    await flush();
+
+    expect(onSessionIdChange).toHaveBeenLastCalledWith(
+      undefined,
+      undefined,
+      undefined,
+      { kind: 'standalone' },
+    );
+  });
+
+  it('does not expose stale workspace session commands in a pending standalone draft', async () => {
+    mockConnection.sessionContext = { kind: 'workspace', cwd: '/tmp/project' };
+    mockConnection.commands = [
+      skillCommandFixture('workspace-review', 'Review this workspace'),
+      {
+        name: 'workspace-deploy',
+        description: 'Deploy this workspace',
+        source: 'project-command',
+      },
+    ];
+    mockConnection.skills = ['workspace-review'];
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    };
+    const shellRef = createRef<WebShellApi>();
+    renderApp({ shellRef });
+    await flush();
+
+    await act(async () => {
+      await shellRef.current?.createNewSession();
+    });
+
+    expect(testState.latestChatEditorProps?.skills).toEqual([]);
+    expect(testState.latestChatEditorProps?.commands).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'workspace-review' }),
+        expect.objectContaining({ name: 'workspace-deploy' }),
+      ]),
+    );
+    expect(testState.latestChatEditorProps?.commands).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'status' })]),
+    );
+  });
+
   it('does not report a session with the previous workspace while loading', async () => {
     mockConnection.sessionId = 'session-2';
     mockConnection.workspaceCwd = '/workspace';
@@ -10059,6 +10395,70 @@ describe('App session callbacks', () => {
     expect(
       container.querySelectorAll('[data-testid="add-workspace-dialog"]'),
     ).toHaveLength(1);
+  });
+
+  it('closes the Add workspace dialog when navigation enters a standalone chat', async () => {
+    mockWorkspace.capabilities = {
+      features: ['dynamic_workspace_registration', 'standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onOpenExistingWorkspace?.();
+    });
+    expect(
+      container.querySelector('[data-testid="add-workspace-dialog"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      mockConnection.sessionContext = { kind: 'standalone' };
+      mockConnection.workspaceCwd = '';
+      rerender();
+    });
+
+    expect(
+      container.querySelector('[data-testid="add-workspace-dialog"]'),
+    ).toBeNull();
+  });
+
+  it('closes workspace model settings when navigation enters a standalone chat', async () => {
+    const { container, rerender } = renderApp();
+    await flush();
+    testState.prompt = '/settings';
+    await clickSubmit(container);
+    await flush();
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-fast-model"]')
+        ?.click();
+    });
+    expect(
+      container.querySelector('[data-testid="model-select"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      mockConnection.sessionContext = { kind: 'standalone' };
+      mockConnection.workspaceCwd = '';
+      rerender();
+    });
+
+    expect(container.querySelector('[data-testid="model-select"]')).toBeNull();
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalledWith(
+      expect.stringContaining('/model --fast'),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it('omits the directory picker on headless daemon hosts', async () => {
@@ -10542,7 +10942,48 @@ describe('App session callbacks', () => {
     );
   });
 
-  it('revalidates a draft workspace before its cleanup effect runs', async () => {
+  it('creates the first prompt in a newly selected secondary workspace', async () => {
+    mockConnection.sessionId = undefined;
+    mockConnection.sessionContext = { kind: 'workspace', cwd: '/tmp/project' };
+    mockWorkspace.capabilities = {
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onSelectWorkspace?.('/work/secondary');
+    });
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('secondary prompt');
+      await vi.waitFor(() => {
+        expect(mockSessionActions.createSession).toHaveBeenCalled();
+      });
+    });
+
+    expect(mockSessionActions.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceCwd: '/work/secondary',
+        sessionContext: { kind: 'workspace', cwd: '/work/secondary' },
+      }),
+    );
+  });
+
+  it('rejects an untrusted draft workspace before its cleanup effect runs', async () => {
+    const onToast = vi.fn();
     mockConnection.sessionId = undefined;
     const secondaryWorkspace = {
       id: 'secondary',
@@ -10561,7 +11002,7 @@ describe('App session callbacks', () => {
         secondaryWorkspace,
       ],
     } as typeof mockWorkspace.capabilities;
-    renderApp();
+    renderApp({ onToast });
     await flush();
 
     act(() => {
@@ -10571,27 +11012,19 @@ describe('App session callbacks', () => {
     // and the create-time trust guard, rather than the cleanup effect, is tested.
     secondaryWorkspace.trusted = false;
 
-    await act(async () => {
-      testState.latestChatEditorProps?.onSubmit('primary prompt');
-      await vi.waitFor(() => {
-        expect(mockSessionActions.createSession).toHaveBeenCalled();
-      });
+    act(() => {
+      testState.latestChatEditorProps?.onSubmit('blocked prompt');
     });
-    expect(mockSessionActions.createSession).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceCwd: '/tmp/project' }),
-    );
-    const promptOptions = mockSessionActions.sendPrompt.mock.calls.at(
-      -1,
-    )?.[1] as { onAdmitted?: () => void } | undefined;
-    act(() => promptOptions?.onAdmitted?.());
-    expect(sessionCatalogController.promptAdmitted).toHaveBeenCalledWith(
-      '/tmp/project',
-      expect.any(String),
-    );
-    expect(sessionCatalogController.promptAdmitted).not.toHaveBeenCalledWith(
-      '/work/secondary',
-      expect.any(String),
-    );
+    await vi.waitFor(() => {
+      expect(onToast).toHaveBeenCalledWith(
+        'error',
+        'The selected workspace is unavailable or untrusted',
+      );
+    });
+
+    expect(mockSessionActions.createSession).not.toHaveBeenCalled();
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(sessionCatalogController.promptAdmitted).not.toHaveBeenCalled();
   });
 
   it('does not start a new chat when selecting the active workspace', async () => {
@@ -12567,6 +13000,35 @@ describe('App session callbacks', () => {
     },
   );
 
+  it('preserves standalone context when leaving a missing-session route', async () => {
+    mockConnection.status = 'disconnected';
+    mockConnection.sessionId = undefined;
+    mockConnection.error = 'Session load failed';
+    mockConnection.errorStatus = 404;
+    mockConnection.missingSession = true;
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+    };
+    const onSessionIdChange = vi.fn();
+    const { container } = renderApp({ onSessionIdChange });
+    await flush();
+
+    await act(async () => {
+      Array.from(container.querySelectorAll('button'))
+        .find((button) => button.textContent === 'New session')
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(onSessionIdChange).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      undefined,
+      { kind: 'standalone' },
+    );
+  });
+
   it('dispatches an automatic recap when the session remains active', async () => {
     const { recap } = await triggerAutoRecap();
     await act(async () => {
@@ -12851,7 +13313,20 @@ describe('App session callbacks', () => {
     expect(editorFocus).toHaveBeenCalledOnce();
   });
 
-  it('opens a Live session in its owning Conversations workspace', async () => {
+  it('opens a Live session through its explicit product context', async () => {
+    mockWorkspace.capabilities = {
+      features: ['multi_workspace_sessions'],
+      workspaces: [
+        { id: 'primary', cwd: '/workspace', primary: true, trusted: true },
+        {
+          id: 'live',
+          cwd: '/Users/test/Documents/Qwen Code/Conversations',
+          primary: false,
+          trusted: true,
+          kind: 'live',
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
     renderApp();
     await flush();
 
@@ -12870,10 +13345,77 @@ describe('App session callbacks', () => {
     expect(mockSessionActions.loadSession).toHaveBeenCalledWith(
       'live-coordinator',
       {
-        workspaceCwd: '/Users/test/Documents/Qwen Code/Conversations',
+        workspaceCwd: undefined,
+        sessionContext: { kind: 'live' },
       },
     );
     expect(mockSessionActions.loadSession).toHaveBeenCalledOnce();
+  });
+
+  it('opens a session link through the current standalone product context', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    renderApp();
+    await flush();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('qwen:open-session', {
+          detail: 'standalone-child',
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith(
+      'standalone-child',
+      {
+        workspaceCwd: undefined,
+        sessionContext: { kind: 'standalone' },
+      },
+    );
+    expect(mockSessionActions.loadSession).toHaveBeenCalledOnce();
+  });
+
+  it('hides stale standalone recovery state while switching to a workspace session', async () => {
+    const load = deferred<void>();
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.standaloneSession = {
+      creationRecovery: { state: 'creating', sessionId: 'session-1' },
+    };
+    mockSessionActions.loadSession.mockReturnValueOnce(load.promise);
+    const { container } = renderApp();
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="standalone-creation-recovery"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('qwen:open-session', {
+          detail: {
+            sessionId: 'workspace-session',
+            workspaceCwd: '/workspace',
+          },
+        }),
+      );
+    });
+    await flush();
+
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith(
+      'workspace-session',
+      {
+        workspaceCwd: '/workspace',
+        sessionContext: { kind: 'workspace', cwd: '/workspace' },
+      },
+    );
+    expect(
+      container.querySelector('[data-testid="standalone-creation-recovery"]'),
+    ).toBeNull();
+
+    await act(async () => load.resolve());
   });
 
   it('does not steal focus when an approval appears before deferred session focus', async () => {
@@ -14233,6 +14775,184 @@ describe('App session callbacks', () => {
       }),
     );
     expect(editorInsertText).not.toHaveBeenCalled();
+  });
+
+  it('waits for the replacement Live session before sending an accepted new-topic suggestion', async () => {
+    vi.useFakeTimers();
+    mockConnection.sessionId = 'live-session-current';
+    mockConnection.sessionContext = { kind: 'live' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.capabilities.features = ['session_generation'];
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).tokenCount = 600;
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).contextWindow = 1000;
+    testState.messages = Array.from({ length: 8 }, (_, index) => ({
+      id: `live-message-${index}`,
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `existing Live topic ${index} about the current conversation`,
+      timestamp: index,
+    }));
+    const suggestedPrompt = 'Start a different Live conversation about tests';
+    testState.prompt = suggestedPrompt;
+    mockSessionActions.generateSessionContent.mockImplementation(
+      async function* () {
+        yield {
+          type: 'delta',
+          requestId: 'live-suggestion',
+          seq: 0,
+          text: JSON.stringify({
+            suggestion: 'new_session',
+            confidence: 0.91,
+          }),
+        };
+        yield {
+          type: 'done',
+          requestId: 'live-suggestion',
+          model: 'fast-model',
+          modelSource: 'fast',
+        };
+      },
+    );
+    const onSessionIdChange = vi.fn();
+    const { container, rerender } = renderApp({ onSessionIdChange });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onInputTextChange?.(testState.prompt);
+    });
+    await flush();
+    act(() => {
+      vi.advanceTimersByTime(121);
+    });
+    await flush();
+    act(() => {
+      vi.advanceTimersByTime(701);
+    });
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="new-session-suggestion-start"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(mockWorkspace.client.startLive).toHaveBeenCalledWith('new');
+    expect(mockSessionActions.clearSession).not.toHaveBeenCalled();
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(onSessionIdChange).not.toHaveBeenCalledWith(undefined);
+
+    act(() => {
+      mockConnection.sessionId = 'live-session-next';
+      rerender({ onSessionIdChange });
+    });
+    await flush();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      suggestedPrompt,
+      expect.any(Object),
+    );
+  });
+
+  it('cancels an accepted Live new-topic suggestion after leaving Live', async () => {
+    vi.useFakeTimers();
+    mockConnection.sessionId = 'live-session-current';
+    mockConnection.sessionContext = { kind: 'live' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.capabilities.features = ['session_generation'];
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).tokenCount = 600;
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).contextWindow = 1000;
+    testState.messages = Array.from({ length: 8 }, (_, index) => ({
+      id: `live-message-${index}`,
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `existing Live topic ${index} about the current conversation`,
+      timestamp: index,
+    }));
+    testState.prompt = 'Start a different Live conversation about tests';
+    mockSessionActions.generateSessionContent.mockImplementation(
+      async function* () {
+        yield {
+          type: 'delta',
+          requestId: 'live-suggestion',
+          seq: 0,
+          text: JSON.stringify({
+            suggestion: 'new_session',
+            confidence: 0.91,
+          }),
+        };
+        yield {
+          type: 'done',
+          requestId: 'live-suggestion',
+          model: 'fast-model',
+          modelSource: 'fast',
+        };
+      },
+    );
+    const { container, rerender } = renderApp();
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onInputTextChange?.(testState.prompt);
+    });
+    await flush();
+    act(() => {
+      vi.advanceTimersByTime(121);
+    });
+    await flush();
+    act(() => {
+      vi.advanceTimersByTime(701);
+    });
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="new-session-suggestion-start"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      mockConnection.sessionId = 'workspace-session';
+      mockConnection.sessionContext = {
+        kind: 'workspace',
+        cwd: '/workspace',
+      };
+      rerender();
+    });
+    await flush();
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
   });
 
   it('suggests sending a side question with BTW and clears the accepted draft', async () => {
@@ -19255,7 +19975,6 @@ describe('App session callbacks', () => {
     const onSessionIdChange = vi.fn();
     const { container, rerender } = renderApp({ onSessionIdChange });
     await flush();
-
     await act(async () => {
       container
         .querySelector<HTMLButtonElement>(
@@ -19473,6 +20192,35 @@ describe('App session callbacks', () => {
     expect(
       container.querySelector('[data-testid="split-initial"]')?.textContent,
     ).toBe('s1,s2');
+  });
+
+  it('waits for workspace capabilities before classifying controlled split ids', async () => {
+    mockWorkspace.capabilities =
+      undefined as unknown as typeof mockWorkspace.capabilities;
+    const onSplitSessionIdsChange = vi.fn();
+    const props = {
+      sidebar: false as const,
+      splitSessionIds: ['workspace-session'],
+      onSplitSessionIdsChange,
+    };
+    const { container, rerender } = renderApp(props);
+    await flush();
+
+    expect(onSplitSessionIdsChange).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).toBeNull();
+
+    mockWorkspace.capabilities = {
+      workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+    };
+    rerender(props);
+    await flush();
+
+    expect(onSplitSessionIdsChange).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="split-initial"]')?.textContent,
+    ).toBe('workspace-session');
   });
 
   it('dedupes and caps external split session ids', async () => {
@@ -19804,6 +20552,60 @@ describe('App session callbacks', () => {
     );
   });
 
+  it('does not let stale split classification replace a newer direct open', async () => {
+    const classification = deferred<never>();
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspace.client.getStandaloneSession.mockReturnValueOnce(
+      classification.promise,
+    );
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ shellRef });
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="open-sessions-overview"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+    act(() => {
+      testState.latestSessionOverviewProps?.onOpenSplit?.(['older-session']);
+      shellRef.current?.openSplitView();
+    });
+    await flush();
+
+    expect(
+      container.querySelector('[data-testid="split-initial"]')?.textContent,
+    ).toBe('session-1');
+
+    await act(async () => {
+      classification.reject(
+        new DaemonHttpError(
+          404,
+          { code: 'standalone_session_not_found' },
+          'not found',
+        ),
+      );
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="split-initial"]')?.textContent,
+    ).toBe('session-1');
+  });
+
   it('requests controlled split ids from the external shell ref', async () => {
     const onSplitSessionIdsChange = vi.fn();
     const shellRef = createRef<WebShellApi>();
@@ -19824,6 +20626,27 @@ describe('App session callbacks', () => {
     expect(
       container.querySelector('[data-testid="split-view-page"]'),
     ).toBeNull();
+  });
+
+  it('does not request controlled split ids from a standalone shell context', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    const onSplitSessionIdsChange = vi.fn();
+    const shellRef = createRef<WebShellApi>();
+    renderApp({
+      sidebar: false,
+      splitSessionIds: [],
+      onSplitSessionIdsChange,
+      shellRef,
+    });
+    await flush();
+
+    act(() => {
+      shellRef.current?.openSplitView();
+    });
+    await flush();
+
+    expect(onSplitSessionIdsChange).not.toHaveBeenCalled();
   });
 
   it('assigns and clears the external shell object ref', async () => {
@@ -22725,6 +23548,273 @@ describe('App session callbacks', () => {
       sessionId: 'session-1',
       newName: 'Catalog title',
     });
+  });
+
+  it('uses the exact standalone route for /rename in a standalone chat', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.displayName = 'Old standalone title';
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+
+    testState.prompt = '/rename Standalone title';
+    await clickSubmit(container);
+    await flush();
+
+    expect(mockWorkspace.client.renameStandaloneSession).toHaveBeenCalledWith(
+      'session-1',
+      'Standalone title',
+    );
+    expect(mockSessionActions.renameSession).not.toHaveBeenCalled();
+    expect(testState.latestChatEditorProps?.sessionName).toBe(
+      'Standalone title',
+    );
+  });
+
+  it('rejects programmatic attachments in a standalone chat', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    const onToast = vi.fn();
+    renderApp({ onToast });
+    await flush();
+
+    let accepted: boolean | void;
+    act(() => {
+      accepted = testState.latestChatEditorProps?.onSubmit('hello', [
+        { data: 'image-data', media_type: 'image/png' },
+      ]);
+    });
+
+    expect(accepted).toBe(false);
+    expect(rawEnqueuePrompt).not.toHaveBeenCalled();
+    expect(onToast).toHaveBeenCalledWith('warning', expect.any(String));
+  });
+
+  it('does not dispatch workspace management commands in a standalone chat', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    const onToast = vi.fn();
+    const { container } = renderApp({ onToast });
+    await flush();
+
+    expect(testState.latestSettingsHookOptions).toEqual({
+      autoLoad: false,
+      enabled: false,
+    });
+    expect(testState.latestProvidersHookOptions).toEqual({
+      autoLoad: false,
+      enabled: false,
+    });
+    expect(testState.latestChatEditorProps).toMatchObject({
+      builtinAtProviders: false,
+      composerScopeKey: 'standalone',
+      workspaceFeaturesEnabled: false,
+    });
+    expect(testState.latestStatusBarHideSettings).toBe(true);
+
+    for (const command of [
+      '/mcp',
+      '/skills',
+      '/tools',
+      '/agents',
+      '/extensions manage',
+      '/model --vision qwen-vl',
+      '/resume',
+      '/delete',
+      '/release',
+    ]) {
+      act(() => {
+        expect(testState.latestChatEditorProps?.onSubmit(command)).toBe(true);
+      });
+    }
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="change-sidebar-theme"]',
+        )
+        ?.click();
+    });
+    act(() => {
+      expect(testState.latestChatEditorProps?.onSubmit('/status')).toBe(true);
+    });
+    await flush();
+
+    expect(mockWorkspaceActions.loadMcpStatus).not.toHaveBeenCalled();
+    expect(mockWorkspaceActions.loadPreflight).not.toHaveBeenCalled();
+    expect(mockWorkspaceActions.loadProviders).not.toHaveBeenCalled();
+    expect(mockWorkspaceActions.loadEnv).not.toHaveBeenCalled();
+    expect(settingsSetValue).not.toHaveBeenCalled();
+    expect(mockSessionActions.loadSession).not.toHaveBeenCalled();
+    expect(onToast).toHaveBeenCalledTimes(9);
+  });
+
+  it('allows ordinary shell commands in a standalone chat', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    renderApp();
+    await flush();
+
+    act(() => {
+      expect(testState.latestChatEditorProps?.onSubmit('!pwd')).toBe(true);
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendShellCommand).toHaveBeenCalledWith('pwd');
+    });
+
+    expect(sessionCatalogController.invalidateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('routes an exact /resume through the standalone context', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    renderApp();
+    await flush();
+
+    act(() => {
+      expect(
+        testState.latestChatEditorProps?.onSubmit(
+          '/resume standalone-session-2',
+        ),
+      ).toBe(true);
+    });
+    await flush();
+
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith(
+      'standalone-session-2',
+      {
+        workspaceCwd: undefined,
+        sessionContext: { kind: 'standalone' },
+      },
+    );
+  });
+
+  it('routes /new through the existing Live-specific path', async () => {
+    mockConnection.sessionContext = { kind: 'live' };
+    mockConnection.workspaceCwd = '';
+    renderApp();
+    await flush();
+
+    act(() => {
+      expect(testState.latestChatEditorProps?.onSubmit('/new')).toBe(true);
+    });
+    await flush();
+
+    expect(mockWorkspace.client.startLive).toHaveBeenCalledOnce();
+    expect(mockWorkspace.client.startLive).toHaveBeenCalledWith('new');
+    expect(mockSessionActions.clearSession).not.toHaveBeenCalled();
+  });
+
+  it('creates an explicit standalone draft without workspace-only fields', async () => {
+    mockConnection.sessionId = undefined;
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/workspace',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    renderApp();
+    await flush();
+
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('first standalone prompt');
+      await vi.waitFor(() => {
+        expect(mockSessionActions.createSession).toHaveBeenCalledOnce();
+      });
+    });
+
+    expect(mockSessionActions.createSession).toHaveBeenCalledWith({
+      sessionContext: { kind: 'standalone' },
+      approvalMode: 'default',
+    });
+    await vi.waitFor(() => {
+      expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+        'first standalone prompt',
+        expect.any(Object),
+      );
+    });
+  });
+
+  it('ignores a stale standalone unarchive result after navigation', async () => {
+    const sourceSessionId = 'standalone-recovery-source';
+    const nextSessionId = 'standalone-recovery-next';
+    const unarchive = deferred<{
+      unarchived: string[];
+      alreadyActive: string[];
+      notFound: string[];
+      errors: Array<{ sessionId: string; message: string }>;
+    }>();
+    mockConnection.sessionId = sourceSessionId;
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.standaloneSession = {
+      creationRecovery: { state: 'creating', sessionId: sourceSessionId },
+    };
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspace.client.getStandaloneSession.mockResolvedValue({
+      sessionId: sourceSessionId,
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: true,
+    });
+    mockWorkspace.client.unarchiveStandaloneSessions.mockReturnValueOnce(
+      unarchive.promise,
+    );
+    const { container, rerender } = renderApp();
+    await flush();
+
+    const buttonNamed = (label: string) =>
+      Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => button.textContent?.trim() === label,
+      );
+    await act(async () => {
+      buttonNamed('Check status')?.click();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => {
+      expect(buttonNamed('Unarchive')).toBeDefined();
+    });
+    act(() => buttonNamed('Unarchive')?.click());
+    expect(
+      mockWorkspace.client.unarchiveStandaloneSessions,
+    ).toHaveBeenCalledWith([sourceSessionId]);
+
+    act(() => {
+      testState.ownerVersion += 1;
+      mockConnection.sessionId = nextSessionId;
+      mockConnection.standaloneSession = {
+        creationRecovery: { state: 'creating', sessionId: nextSessionId },
+      };
+      rerender();
+    });
+    await flush();
+    await act(async () => {
+      unarchive.resolve({
+        unarchived: [],
+        alreadyActive: [],
+        notFound: [sourceSessionId],
+        errors: [],
+      });
+      await unarchive.promise;
+    });
+
+    expect(container.textContent).toContain('Creation may have succeeded');
+    expect(container.textContent).not.toContain(
+      'No conversation exists for the reserved ID',
+    );
   });
 
   it('reconciles a confirmed rename after its source attachment is replaced', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -11014,6 +11014,58 @@ describe('App session callbacks', () => {
     );
   });
 
+  it('does not retarget a settled standalone session when a stale workspace selection becomes untrusted', async () => {
+    mockConnection.sessionId = 'standalone-a';
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const view = renderApp({
+      initialSelectedWorkspaceCwd: '/work/secondary',
+    });
+    await flush();
+
+    mockWorkspace.capabilities = {
+      ...mockWorkspace.capabilities,
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'secondary',
+          cwd: '/work/secondary',
+          primary: false,
+          trusted: false,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    view.rerender({ initialSelectedWorkspaceCwd: '/work/secondary' });
+    await flush();
+
+    expect(testState.latestChatEditorProps).toMatchObject({
+      composerScopeKey: 'standalone',
+      workspaceFeaturesEnabled: false,
+    });
+  });
+
   it('creates the first prompt in a newly selected secondary workspace', async () => {
     mockConnection.sessionId = undefined;
     mockConnection.sessionContext = { kind: 'workspace', cwd: '/tmp/project' };
@@ -14939,6 +14991,201 @@ describe('App session callbacks', () => {
       suggestedPrompt,
       expect.any(Object),
     );
+  });
+
+  it('uses the locked workspace path when accepting a Live-context new-topic suggestion', async () => {
+    vi.useFakeTimers();
+    mockConnection.sessionId = 'live-session-current';
+    mockConnection.sessionContext = { kind: 'live' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.capabilities.features = ['session_generation'];
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).tokenCount = 600;
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).contextWindow = 1000;
+    testState.messages = Array.from({ length: 8 }, (_, index) => ({
+      id: `locked-live-message-${index}`,
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `existing Live topic ${index} about the current conversation`,
+      timestamp: index,
+    }));
+    const suggestedPrompt = 'Start a workspace conversation about tests';
+    testState.prompt = suggestedPrompt;
+    mockSessionActions.clearSession.mockImplementation(async () => {
+      mockConnection.sessionId = undefined;
+    });
+    mockSessionActions.generateSessionContent.mockImplementation(
+      async function* () {
+        yield {
+          type: 'delta',
+          requestId: 'locked-live-suggestion',
+          seq: 0,
+          text: JSON.stringify({
+            suggestion: 'new_session',
+            confidence: 0.91,
+          }),
+        };
+        yield {
+          type: 'done',
+          requestId: 'locked-live-suggestion',
+          model: 'fast-model',
+          modelSource: 'fast',
+        };
+      },
+    );
+    const onSessionIdChange = vi.fn();
+    const { container } = renderApp({
+      lockedWorkspaceCwd: '/tmp/project',
+      onSessionIdChange,
+    });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onInputTextChange?.(testState.prompt);
+    });
+    await flush();
+    act(() => vi.advanceTimersByTime(821));
+    await flush();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="new-session-suggestion-start"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+    act(() => vi.runOnlyPendingTimers());
+    await flush();
+
+    expect(mockWorkspace.client.startLive).not.toHaveBeenCalled();
+    expect(mockSessionActions.clearSession).toHaveBeenCalledOnce();
+    expect(onSessionIdChange).toHaveBeenCalledWith(undefined);
+    expect(mockSessionActions.sendPrompt).toHaveBeenCalledWith(
+      suggestedPrompt,
+      expect.any(Object),
+    );
+  });
+
+  it('cancels an accepted Live new-topic suggestion when a newer global new-chat request wins', async () => {
+    vi.useFakeTimers();
+    const startLive = deferred<{
+      v: 1;
+      available: true;
+      state: 'listening';
+      shortcut: string;
+    }>();
+    mockConnection.sessionId = 'live-session-current';
+    mockConnection.sessionContext = { kind: 'live' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.capabilities.features = ['session_generation'];
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).tokenCount = 600;
+    (
+      mockConnection as typeof mockConnection & {
+        tokenCount?: number;
+        contextWindow?: number;
+      }
+    ).contextWindow = 1000;
+    testState.messages = Array.from({ length: 8 }, (_, index) => ({
+      id: `cancelled-live-message-${index}`,
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: `existing Live topic ${index} about the current conversation`,
+      timestamp: index,
+    }));
+    testState.prompt = 'Start a different Live conversation about tests';
+    mockWorkspace.client.startLive.mockReturnValueOnce(startLive.promise);
+    mockSessionActions.clearSession.mockImplementation(async () => {
+      mockConnection.sessionId = undefined;
+    });
+    mockSessionActions.generateSessionContent.mockImplementation(
+      async function* () {
+        yield {
+          type: 'delta',
+          requestId: 'cancelled-live-suggestion',
+          seq: 0,
+          text: JSON.stringify({
+            suggestion: 'new_session',
+            confidence: 0.91,
+          }),
+        };
+        yield {
+          type: 'done',
+          requestId: 'cancelled-live-suggestion',
+          model: 'fast-model',
+          modelSource: 'fast',
+        };
+      },
+    );
+    const shellRef = createRef<WebShellApi>();
+    const { container } = renderApp({ shellRef });
+    await flush();
+
+    act(() => {
+      testState.latestChatEditorProps?.onInputTextChange?.(testState.prompt);
+    });
+    await flush();
+    act(() => vi.advanceTimersByTime(821));
+    await flush();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="new-session-suggestion-start"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await shellRef.current?.createNewSession();
+    });
+    await act(async () => {
+      startLive.resolve({
+        v: 1,
+        available: true,
+        state: 'listening',
+        shortcut: 'Command+Q',
+      });
+      await startLive.promise;
+    });
+    act(() => vi.runOnlyPendingTimers());
+    await flush();
+
+    expect(mockSessionActions.sendPrompt).not.toHaveBeenCalled();
+    expect(testState.latestChatEditorProps?.disabled).toBe(false);
   });
 
   it('cancels an accepted Live new-topic suggestion after leaving Live', async () => {

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -20798,6 +20798,70 @@ describe('App session callbacks', () => {
     expect(loadSplitSessions()).toEqual([]);
   });
 
+  it('does not let stale split classification replace a sidebar session load', async () => {
+    const classification = deferred<never>();
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspace.client.getStandaloneSession.mockReturnValueOnce(
+      classification.promise,
+    );
+    const { container } = renderApp();
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="open-sessions-overview"]',
+        )
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      testState.latestSessionOverviewProps?.onOpenSplit?.(['older-session']);
+      await vi.waitFor(() => {
+        expect(mockWorkspace.client.getStandaloneSession).toHaveBeenCalledWith(
+          'older-session',
+        );
+      });
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="load-session"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    await act(async () => {
+      classification.reject(
+        new DaemonHttpError(
+          404,
+          { code: 'standalone_session_not_found' },
+          'not found',
+        ),
+      );
+      await Promise.resolve();
+    });
+
+    expect(mockSessionActions.loadSession).toHaveBeenCalledWith(
+      'session-2',
+      expect.any(Object),
+    );
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).toBeNull();
+    expect(loadSplitSessions()).toEqual([]);
+  });
+
   it('requests controlled split ids from the external shell ref', async () => {
     const onSplitSessionIdsChange = vi.fn();
     const shellRef = createRef<WebShellApi>();

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -82,6 +82,7 @@ type MockConnection = {
       state: 'creating';
       sessionId: string;
     };
+    errorCode?: 'working_directory_missing';
   };
 };
 
@@ -298,6 +299,7 @@ const {
       notFound: [],
       errors: [],
     }),
+    repairStandaloneSessionDirectory: vi.fn().mockResolvedValue(undefined),
     resolveSubagentSession: vi
       .fn()
       .mockRejectedValue(new Error('Subagent details unavailable')),
@@ -5412,6 +5414,10 @@ beforeEach(() => {
     notFound: [],
     errors: [],
   });
+  mockWorkspace.client.repairStandaloneSessionDirectory.mockReset();
+  mockWorkspace.client.repairStandaloneSessionDirectory.mockResolvedValue(
+    undefined,
+  );
   for (const method of Object.values(sessionCatalogController)) {
     method.mockReset();
   }
@@ -9947,6 +9953,58 @@ describe('App session callbacks', () => {
       undefined,
       undefined,
       { kind: 'standalone' },
+    );
+  });
+
+  it('keeps a newer standalone draft when an older session load fails', async () => {
+    const load = deferred<void>();
+    mockConnection.sessionContext = { kind: 'workspace', cwd: '/tmp/project' };
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    mockSessionActions.loadSession.mockReturnValueOnce(load.promise);
+    const shellRef = createRef<WebShellApi>();
+    const { rerender } = renderApp({ shellRef });
+    await flush();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('qwen:open-session', {
+          detail: { sessionId: 'stale-session', workspaceCwd: '/tmp/project' },
+        }),
+      );
+    });
+    await vi.waitFor(() =>
+      expect(mockSessionActions.loadSession).toHaveBeenCalled(),
+    );
+    await act(async () => {
+      expect(await shellRef.current?.createNewSession()).toBe(true);
+    });
+    act(() => {
+      mockConnection.sessionId = undefined;
+      rerender({ shellRef });
+    });
+    await act(async () => {
+      load.reject(new Error('stale load failed'));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      testState.latestChatEditorProps?.onSubmit('standalone prompt');
+      await vi.waitFor(() =>
+        expect(mockSessionActions.createSession).toHaveBeenCalled(),
+      );
+    });
+
+    expect(mockSessionActions.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionContext: { kind: 'standalone' } }),
     );
   });
 
@@ -21552,6 +21610,29 @@ describe('App session callbacks', () => {
     }
   });
 
+  it('does not restore over a consumed split deep link after capabilities refresh', async () => {
+    window.history.pushState({}, '', '/?split=s1,s2');
+    try {
+      const { container, rerender } = renderApp();
+      await flush();
+      saveSplitSessions(['stale-split']);
+      act(() => {
+        mockWorkspace.capabilities = {
+          ...mockWorkspace.capabilities,
+          features: [...(mockWorkspace.capabilities?.features ?? [])],
+        } as typeof mockWorkspace.capabilities;
+        rerender();
+      });
+      await flush();
+
+      expect(
+        container.querySelector('[data-testid="split-initial"]')?.textContent,
+      ).toBe('s1,s2');
+    } finally {
+      window.history.pushState({}, '', '/');
+    }
+  });
+
   it('lets controlled split session ids take precedence over a ?split= URL', async () => {
     window.history.pushState({}, '', '/?split=s1,s2');
     try {
@@ -23622,6 +23703,7 @@ describe('App session callbacks', () => {
       '/tools',
       '/agents',
       '/extensions manage',
+      '/goal',
       '/model --vision qwen-vl',
       '/resume',
       '/delete',
@@ -23649,7 +23731,7 @@ describe('App session callbacks', () => {
     expect(mockWorkspaceActions.loadEnv).not.toHaveBeenCalled();
     expect(settingsSetValue).not.toHaveBeenCalled();
     expect(mockSessionActions.loadSession).not.toHaveBeenCalled();
-    expect(onToast).toHaveBeenCalledTimes(9);
+    expect(onToast).toHaveBeenCalledTimes(10);
   });
 
   it('allows ordinary shell commands in a standalone chat', async () => {
@@ -23814,6 +23896,83 @@ describe('App session callbacks', () => {
     expect(container.textContent).toContain('Creation may have succeeded');
     expect(container.textContent).not.toContain(
       'No conversation exists for the reserved ID',
+    );
+  });
+
+  it('reports a recovered standalone load failure without reverting to archived', async () => {
+    const sessionId = 'standalone-recovery-source';
+    mockConnection.sessionId = sessionId;
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.standaloneSession = {
+      creationRecovery: { state: 'creating', sessionId },
+    };
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [{ id: 'primary', cwd: '/workspace', primary: true }],
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspace.client.getStandaloneSession.mockResolvedValue({
+      sessionId,
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: true,
+    });
+    mockWorkspace.client.unarchiveStandaloneSessions.mockResolvedValue({
+      unarchived: [sessionId],
+      alreadyActive: [],
+      notFound: [],
+      errors: [],
+    });
+    mockSessionActions.loadSession.mockRejectedValue(new Error('load failed'));
+    const onToast = vi.fn();
+    const { container } = renderApp({ onToast });
+    await flush();
+    const buttonNamed = (label: string) =>
+      Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => button.textContent?.trim() === label,
+      );
+    await act(async () => buttonNamed('Check status')?.click());
+    await vi.waitFor(() => expect(buttonNamed('Unarchive')).toBeDefined());
+
+    await act(async () => buttonNamed('Unarchive')?.click());
+
+    expect(container.textContent).not.toContain(
+      'The recovered conversation is archived',
+    );
+    expect(onToast).toHaveBeenCalledWith('error', 'load failed');
+    expect(onToast).not.toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Failed to unarchive'),
+    );
+  });
+
+  it('re-enables standalone directory repair after reload replaces the owner', async () => {
+    mockConnection.sessionContext = { kind: 'standalone' };
+    mockConnection.workspaceCwd = '';
+    mockConnection.standaloneSession = {
+      errorCode: 'working_directory_missing',
+    };
+    mockSessionActions.reloadSession.mockImplementationOnce(async () => {
+      testState.ownerVersion += 1;
+    });
+    const onToast = vi.fn();
+    const { container } = renderApp({ onToast });
+    await flush();
+    const repairButton = () =>
+      Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => button.textContent?.trim() === 'Repair directory',
+      );
+
+    await act(async () => repairButton()?.click());
+
+    expect(
+      mockWorkspace.client.repairStandaloneSessionDirectory,
+    ).toHaveBeenCalledWith('session-1');
+    expect(repairButton()).toBeDefined();
+    expect(repairButton()?.disabled).toBe(false);
+    expect(onToast).toHaveBeenCalledWith(
+      'info',
+      'The private working directory was repaired.',
     );
   });
 

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -1157,6 +1157,7 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
       ) => Promise<boolean> | boolean | void;
       onSelectWorkspace?: (workspaceCwd: string | undefined) => void;
       onLoadSession?: (sessionId: string) => Promise<void> | void;
+      onLoadStandaloneSession?: (sessionId: string) => Promise<void> | void;
       onSelectCurrentSession?: () => void;
       onSessionsDeleted?: (sessionIds: string[]) => void;
       onOpenAddWorkspace?: () => void;
@@ -1245,6 +1246,19 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
             onClick: () => props.onLoadSession?.('session-2'),
           },
           'load session',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'load-standalone-session',
+            type: 'button',
+            onClick: () => {
+              void Promise.resolve(
+                props.onLoadStandaloneSession?.('standalone-session-2'),
+              ).catch(() => undefined);
+            },
+          },
+          'load standalone session',
         ),
         React.createElement(
           'button',
@@ -20461,6 +20475,116 @@ describe('App session callbacks', () => {
     ).toBe('Session Overview');
   });
 
+  it('does not reopen a controlled split after exit while classification is pending', async () => {
+    const classification = deferred<never>();
+    const notStandalone = new DaemonHttpError(
+      404,
+      { code: 'standalone_session_not_found' },
+      'not found',
+    );
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspace.client.getStandaloneSession
+      .mockRejectedValueOnce(notStandalone)
+      .mockReturnValueOnce(classification.promise);
+    const onSplitSessionIdsChange = vi.fn();
+    const { container, rerender } = renderApp({
+      sidebar: false,
+      splitSessionIds: ['current-session'],
+      onSplitSessionIdsChange,
+    });
+    await flush();
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).not.toBeNull();
+
+    rerender({
+      sidebar: false,
+      splitSessionIds: ['older-session'],
+      onSplitSessionIdsChange,
+    });
+    await vi.waitFor(() => {
+      expect(mockWorkspace.client.getStandaloneSession).toHaveBeenCalledWith(
+        'older-session',
+      );
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="split-back"]')
+        ?.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      classification.reject(notStandalone);
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).toBeNull();
+    expect(onSplitSessionIdsChange).toHaveBeenCalledWith([]);
+  });
+
+  it('keeps controlled split ids while a standalone navigation can still fail', async () => {
+    const notStandalone = new DaemonHttpError(
+      404,
+      { code: 'standalone_session_not_found' },
+      'not found',
+    );
+    mockWorkspace.capabilities = {
+      features: ['standalone_sessions_v1'],
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: true,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    mockWorkspace.client.getStandaloneSession.mockRejectedValue(notStandalone);
+    const load = deferred<void>();
+    mockSessionActions.loadSession.mockReturnValueOnce(load.promise);
+    const onSplitSessionIdsChange = vi.fn();
+    const { container } = renderApp({
+      sidebar: true,
+      splitSessionIds: ['s1', 's2'],
+      onSplitSessionIdsChange,
+    });
+    await flush();
+    onSplitSessionIdsChange.mockClear();
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="load-standalone-session"]',
+        )
+        ?.click();
+    });
+    await flush();
+
+    expect(onSplitSessionIdsChange).not.toHaveBeenCalledWith([]);
+    await act(async () => {
+      load.reject(notStandalone);
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(onSplitSessionIdsChange).not.toHaveBeenCalledWith([]);
+    expect(
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).not.toBeNull();
+  });
+
   it('notifies external callers when split session ids change inside WebShell', async () => {
     const onSplitSessionIdsChange = vi.fn();
     const { container, rerender } = renderApp({
@@ -20626,8 +20750,7 @@ describe('App session callbacks', () => {
     mockWorkspace.client.getStandaloneSession.mockReturnValueOnce(
       classification.promise,
     );
-    const shellRef = createRef<WebShellApi>();
-    const { container } = renderApp({ shellRef });
+    const { container } = renderApp();
     await flush();
 
     await act(async () => {
@@ -20638,15 +20761,25 @@ describe('App session callbacks', () => {
         ?.click();
       await Promise.resolve();
     });
-    act(() => {
+    await act(async () => {
       testState.latestSessionOverviewProps?.onOpenSplit?.(['older-session']);
-      shellRef.current?.openSplitView();
+      await vi.waitFor(() => {
+        expect(mockWorkspace.client.getStandaloneSession).toHaveBeenCalledWith(
+          'older-session',
+        );
+      });
+    });
+    act(() => {
+      testState.latestSessionOverviewProps?.onOpenSession?.(
+        'session-2',
+        '/tmp/project',
+      );
     });
     await flush();
 
     expect(
-      container.querySelector('[data-testid="split-initial"]')?.textContent,
-    ).toBe('session-1');
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).toBeNull();
 
     await act(async () => {
       classification.reject(
@@ -20660,8 +20793,9 @@ describe('App session callbacks', () => {
     });
 
     expect(
-      container.querySelector('[data-testid="split-initial"]')?.textContent,
-    ).toBe('session-1');
+      container.querySelector('[data-testid="split-view-page"]'),
+    ).toBeNull();
+    expect(loadSplitSessions()).toEqual([]);
   });
 
   it('requests controlled split ids from the external shell ref', async () => {
@@ -23790,6 +23924,46 @@ describe('App session callbacks', () => {
     expect(mockSessionActions.clearSession).not.toHaveBeenCalled();
   });
 
+  it('keeps a legacy Live runtime cwd out of workspace product context', async () => {
+    mockConnection.sessionContext = undefined;
+    mockConnection.workspaceCwd = '/internal/conversations';
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/workspace',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/workspace',
+          primary: true,
+          trusted: true,
+        },
+        {
+          id: 'live',
+          cwd: '/internal/conversations',
+          primary: false,
+          trusted: true,
+          kind: 'live',
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+
+    renderApp();
+    await flush();
+
+    expect(testState.latestChatEditorProps).toMatchObject({
+      atWorkspaceCwd: undefined,
+      composerScopeKey: 'live',
+      workspaceFeaturesEnabled: false,
+    });
+    expect(testState.latestSettingsHookOptions).toEqual({
+      autoLoad: false,
+      enabled: false,
+    });
+    expect(testState.latestProvidersHookOptions).toEqual({
+      autoLoad: false,
+      enabled: false,
+    });
+  });
+
   it('creates an explicit standalone draft without workspace-only fields', async () => {
     mockConnection.sessionId = undefined;
     mockConnection.sessionContext = { kind: 'standalone' };
@@ -26334,6 +26508,37 @@ describe('App /goal command', () => {
     expect(container.querySelector('[data-testid="goals-page"]')).toBeNull();
   });
 
+  it('does not create a goal session in an untrusted primary workspace', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: false,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+
+    testState.prompt = '/goal';
+    await clickSubmit(container);
+    await flush();
+    const onCreateGoal = testState.latestGoalsProps?.onCreateGoal;
+    if (!onCreateGoal) throw new Error('onCreateGoal was not captured');
+    mockSessionActions.clearSession.mockClear();
+    mockSessionActions.controlGoal.mockClear();
+
+    await act(async () => {
+      await onCreateGoal('all tests pass');
+    });
+
+    expect(mockSessionActions.clearSession).not.toHaveBeenCalled();
+    expect(mockSessionActions.controlGoal).not.toHaveBeenCalled();
+  });
+
   it.each(['resolve', 'reject'] as const)(
     'ignores a stale Goal edit %s after the session changes',
     async (outcome) => {
@@ -27332,6 +27537,36 @@ describe('App manual-run orchestration (scheduled tasks)', () => {
       await new Promise((r) => setTimeout(r, 0));
     });
     expect(editorInsertText).toHaveBeenCalled();
+  });
+
+  it('does not start task creation in an untrusted primary workspace', async () => {
+    mockWorkspace.capabilities = {
+      workspaceCwd: '/tmp/project',
+      workspaces: [
+        {
+          id: 'primary',
+          cwd: '/tmp/project',
+          primary: true,
+          trusted: false,
+        },
+      ],
+    } as typeof mockWorkspace.capabilities;
+    const { container } = renderApp();
+    await flush();
+    testState.prompt = '/schedule';
+    await clickSubmit(container);
+    await flush();
+    const onCreateViaChat =
+      testState.latestScheduledTasksProps?.onCreateViaChat;
+    if (!onCreateViaChat) throw new Error('onCreateViaChat was not captured');
+    mockSessionActions.clearSession.mockClear();
+    editorInsertText.mockClear();
+
+    act(() => onCreateViaChat());
+    await flush();
+
+    expect(mockSessionActions.clearSession).not.toHaveBeenCalled();
+    expect(editorInsertText).not.toHaveBeenCalled();
   });
 
   it('"create via chat" does NOT prime the composer when the new session fails', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -1343,6 +1343,7 @@ const NON_WORKSPACE_BLOCKED_COMMANDS = new Set([
   'delete',
   'diff',
   'extensions',
+  'goal',
   'log',
   'memory',
   'mcp',
@@ -2668,8 +2669,12 @@ export function App({
   const standaloneDirectoryErrorCode = effectiveStandaloneSession?.errorCode;
   const [standaloneRecoveryResolution, setStandaloneRecoveryResolution] =
     useState<StandaloneRecoveryResolution>('idle');
+  const standaloneRecoveryRequestRef = useRef(0);
   const [standaloneRepairBusy, setStandaloneRepairBusy] = useState(false);
+  const standaloneRepairRequestRef = useRef(0);
   useEffect(() => {
+    standaloneRecoveryRequestRef.current += 1;
+    standaloneRepairRequestRef.current += 1;
     setStandaloneRecoveryResolution('idle');
     setStandaloneRepairBusy(false);
   }, [connection.sessionId]);
@@ -6012,11 +6017,13 @@ export function App({
   );
   const resolvedPaneHeaderActions =
     renderPaneHeaderActions ?? defaultPaneHeaderActions;
+  const splitBootstrapHandledRef = useRef(false);
   // A `?split=a,b` URL (opened in a new tab from the overview) enters the split
   // view with those sessions on load. Consume the param once so a later reload
   // or exit doesn't force the split back on.
   useEffect(() => {
-    if (!workspace.capabilities) return;
+    if (!workspace.capabilities || splitBootstrapHandledRef.current) return;
+    splitBootstrapHandledRef.current = true;
     const ids = parseSplitSessionIds(window.location.search);
     if (ids.length > 0) {
       const url = new URL(window.location.href);
@@ -9158,6 +9165,7 @@ export function App({
   );
 
   const composerFocusRequestRef = useRef(0);
+  const sessionOpenInvocationRef = useRef(0);
   const scheduleComposerFocus = useCallback((sessionId?: string) => {
     const request = ++composerFocusRequestRef.current;
     window.setTimeout(() => {
@@ -9196,6 +9204,7 @@ export function App({
         pushToast('warning', t('session.recoveryBlocksAction'));
         return false;
       }
+      const invocation = ++sessionOpenInvocationRef.current;
       let nextContext: DaemonProductSessionContext | undefined;
       let availableWorkspaces = workspacesRef.current;
       if (intent.kind === 'workspace') {
@@ -9261,10 +9270,12 @@ export function App({
             : undefined;
         }
       }
+      if (sessionOpenInvocationRef.current !== invocation) return false;
       const targetWorkspaceCwd =
         nextContext?.kind === 'workspace' ? nextContext.cwd : undefined;
       const previousPendingContext = pendingSessionContextRef.current;
       setPendingSessionContext(nextContext);
+      setSidebarSwitchingSessionId(null);
       composerSourceVersionRef.current += 1;
       selectedWorkspaceCwdRef.current = targetWorkspaceCwd;
       setSelectedWorkspaceCwd(targetWorkspaceCwd);
@@ -9308,7 +9319,12 @@ export function App({
         setSessionBranch(undefined);
         return true;
       } catch (error) {
-        setPendingSessionContext(previousPendingContext);
+        if (
+          sessionOpenInvocationRef.current === invocation &&
+          pendingSessionContextRef.current === nextContext
+        ) {
+          setPendingSessionContext(previousPendingContext);
+        }
         if (composerFocusRequestRef.current === focusRequest) {
           composerFocusRequestRef.current += 1;
         }
@@ -9852,7 +9868,6 @@ export function App({
     }
   }, [createNewSession, onSessionIdChange]);
 
-  const sessionOpenInvocationRef = useRef(0);
   const loadSidebarSession = useCallback(
     async (
       sessionId: string,
@@ -9887,12 +9902,18 @@ export function App({
                 : workspaceCwd,
           sessionContext: targetContext,
         });
-        if (sessionOpenInvocationRef.current === invocation) {
+        if (
+          sessionOpenInvocationRef.current === invocation &&
+          pendingSessionContextRef.current === targetContext
+        ) {
           composerSourceVersionRef.current += 1;
           setPendingSessionContext(undefined);
         }
       } catch (error) {
-        if (sessionOpenInvocationRef.current === invocation) {
+        if (
+          sessionOpenInvocationRef.current === invocation &&
+          pendingSessionContextRef.current === targetContext
+        ) {
           setSidebarSwitchingSessionId(null);
           setPendingSessionContext(previousPendingContext);
         }
@@ -9973,15 +9994,16 @@ export function App({
       connectionRef.current.standaloneSession?.creationRecovery,
     );
     if (!sessionId || standaloneRecoveryResolution === 'checking') return;
-    const owner = sessionOwnerGuard.capture();
+    const request = ++standaloneRecoveryRequestRef.current;
+    const isCurrent = () =>
+      standaloneRecoveryRequestRef.current === request &&
+      connectionRef.current.sessionId === sessionId;
     setStandaloneRecoveryResolution('checking');
     try {
       const result = await workspace.client.unarchiveStandaloneSessions([
         sessionId,
       ]);
-      if (!owner.isCurrent() || connectionRef.current.sessionId !== sessionId) {
-        return;
-      }
+      if (!isCurrent()) return;
       if (
         !result.unarchived.includes(sessionId) &&
         !result.alreadyActive.includes(sessionId)
@@ -9995,16 +10017,22 @@ export function App({
         );
         throw new Error(failure?.message ?? t('session.unarchiveFailed'));
       }
-      await loadSidebarSession(sessionId, undefined, { kind: 'standalone' });
     } catch (error) {
-      if (!owner.isCurrent()) return;
+      if (!isCurrent()) return;
       setStandaloneRecoveryResolution('archived');
       reportError(error, t('session.unarchiveFailed'));
+      return;
+    }
+    try {
+      await loadSidebarSession(sessionId, undefined, { kind: 'standalone' });
+    } catch (error) {
+      if (!isCurrent()) return;
+      setStandaloneRecoveryResolution('unknown');
+      reportError(error, t('session.recoveryCheckFailed'));
     }
   }, [
     loadSidebarSession,
     reportError,
-    sessionOwnerGuard,
     standaloneRecoveryResolution,
     t,
     workspace.client,
@@ -10026,6 +10054,7 @@ export function App({
       return;
     }
     const owner = sessionOwnerGuard.capture();
+    const request = ++standaloneRepairRequestRef.current;
     setStandaloneRepairBusy(true);
     try {
       await workspace.client.repairStandaloneSessionDirectory(sessionId);
@@ -10033,15 +10062,23 @@ export function App({
         return;
       }
       await sessionActions.reloadSession(new AbortController().signal);
-      if (owner.isCurrent() && connectionRef.current.sessionId === sessionId) {
+      if (
+        standaloneRepairRequestRef.current === request &&
+        connectionRef.current.sessionId === sessionId
+      ) {
         pushToast('info', t('session.repairSucceeded'));
       }
     } catch (error) {
-      if (owner.isCurrent()) {
+      if (
+        standaloneRepairRequestRef.current === request &&
+        connectionRef.current.sessionId === sessionId
+      ) {
         reportError(error, t('session.repairFailed'));
       }
     } finally {
-      if (owner.isCurrent()) setStandaloneRepairBusy(false);
+      if (standaloneRepairRequestRef.current === request) {
+        setStandaloneRepairBusy(false);
+      }
     }
   }, [
     pushToast,
@@ -13981,11 +14018,12 @@ export function App({
                           closePanel();
                           return;
                         }
-                        const openInvocation = sessionOpenInvocationRef.current;
-                        void createNewSession({
+                        const creation = createNewSession({
                           kind: 'workspace',
                           cwd: currentWorkspaceCwd,
-                        }).then(
+                        });
+                        const openInvocation = sessionOpenInvocationRef.current;
+                        void creation.then(
                           (created) => {
                             const latest = connectionRef.current;
                             const latestWorkspaceCwd =

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -33,12 +33,15 @@ import {
   type DaemonSessionNotice,
   type DaemonSessionOwnerSnapshot,
   type DaemonReasoningControls,
+  type DaemonProductSessionContext,
   type DaemonStreamingState,
 } from '@qwen-code/web-shell/daemon-react-sdk';
 import {
   DaemonHttpError,
   isDaemonTurnError,
+  isStandaloneSessionNotFoundError,
   isStaleBranchPointError,
+  STANDALONE_SESSIONS_CAPABILITY,
 } from '@qwen-code/sdk/daemon';
 import type {
   DaemonInputAnnotation,
@@ -51,6 +54,8 @@ import type {
   DaemonSessionTaskStatus,
   DaemonSessionArtifact,
   DaemonSessionSummary,
+  DaemonStandaloneCreationRecovery,
+  DaemonStandaloneSessionLookup,
   DaemonWorkspaceCapability,
   DaemonWorkspaceGitStatus,
   GoalSnapshotV2,
@@ -58,6 +63,7 @@ import type {
 } from '@qwen-code/sdk/daemon';
 
 import { isGoalGateBlocked as isGoalGateBlockedFor } from './utils/goalGate';
+import { keepWorkspaceSplitSessionIds } from './utils/standalone-session-routing';
 import { type SessionGitIntent } from './components/GitModePopover';
 import { gitModeIntentMustReset } from './utils/gitModeIntent';
 import { LocalControlQrButton } from './components/LocalControlQrButton';
@@ -1000,6 +1006,7 @@ export interface WebShellProps {
     sessionId: string | undefined,
     workspaceId?: string,
     workspaceCwd?: string,
+    sessionContext?: DaemonProductSessionContext,
   ) => void;
   /** Called when the active session id or display name changes. */
   onSessionInfoChange?: (session: {
@@ -1261,6 +1268,7 @@ interface AppProps extends WebShellProps {
 type SessionActionsWithCreate = {
   createSession: (options?: {
     workspaceCwd?: string;
+    sessionContext?: DaemonProductSessionContext;
     approvalMode?: string;
     sourceType?: string;
     worktree?: { slug?: string };
@@ -1274,6 +1282,29 @@ type SessionActionsWithCreate = {
   clearSession: () => Promise<void>;
   releaseSession: (sessionId: string) => Promise<void>;
 };
+
+type NewSessionIntent =
+  | { kind: 'global' }
+  | { kind: 'inherit' }
+  | { kind: 'workspace'; cwd: string };
+
+type StandaloneRecoveryResolution =
+  | 'idle'
+  | 'checking'
+  | 'creating'
+  | 'absent'
+  | 'unknown'
+  | 'archived';
+
+const STANDALONE_RECOVERY_POLL_DELAYS_MS = [250, 500, 1000, 2000, 4000];
+
+function getStandaloneRecoverySessionId(
+  recovery: DaemonStandaloneCreationRecovery | undefined,
+): string | undefined {
+  return recovery?.state === 'existing'
+    ? recovery.session.sessionId
+    : recovery?.sessionId;
+}
 
 type PendingReasoningIntent = {
   modelId: string;
@@ -1305,6 +1336,24 @@ const emptyComposerApi: WebShellComposerApi = {
   clear: () => {},
   submit: () => {},
 };
+
+const NON_WORKSPACE_BLOCKED_COMMANDS = new Set([
+  'agents',
+  'branch',
+  'delete',
+  'diff',
+  'extensions',
+  'log',
+  'memory',
+  'mcp',
+  'prs',
+  'release',
+  'resume',
+  'schedule',
+  'settings',
+  'skills',
+  'tools',
+]);
 
 const EMPTY_BOTTOM_STATUS_ITEMS: readonly WebShellBottomStatusItem[] = [];
 const EMPTY_ADDITIONAL_SLASH_COMMANDS: readonly CommandInfo[] = [];
@@ -2524,6 +2573,12 @@ export function App({
   artifactWorkspaceCwdRef.current = artifactWorkspaceCwd;
   artifactWorkspaceActionsRef.current = artifactWorkspaceActions;
   workspaceCapabilitiesRef.current = workspace.capabilities;
+  const workspaceCapabilitiesReady =
+    workspace.capabilities !== undefined && workspace.status !== 'error';
+  const standaloneSessionsSupported =
+    workspace.capabilities?.features?.includes(
+      STANDALONE_SESSIONS_CAPABILITY,
+    ) === true;
   const dynamicWorkspaceRegistrationSupported =
     workspace.capabilities?.features?.includes(
       'dynamic_workspace_registration',
@@ -2571,9 +2626,64 @@ export function App({
   >(initialSelectedWorkspaceCwd);
   const selectedWorkspaceCwdRef = useRef(selectedWorkspaceCwd);
   selectedWorkspaceCwdRef.current = selectedWorkspaceCwd;
+  const [pendingSessionContext, setPendingSessionContextState] = useState<
+    DaemonProductSessionContext | undefined
+  >(undefined);
+  const pendingSessionContextRef = useRef(pendingSessionContext);
+  const setPendingSessionContext = useCallback(
+    (context: DaemonProductSessionContext | undefined) => {
+      pendingSessionContextRef.current = context;
+      setPendingSessionContextState(context);
+    },
+    [],
+  );
+  const legacyWorkspaceContextCwd =
+    connection.workspaceCwd ||
+    lockedWorkspaceCwd ||
+    selectedWorkspaceCwd ||
+    ordinaryWorkspaces.find((entry) => entry.primary)?.cwd ||
+    workspace.capabilities?.workspaceCwd;
+  const effectiveSessionContext = useMemo(
+    () =>
+      pendingSessionContext ??
+      connection.sessionContext ??
+      (legacyWorkspaceContextCwd
+        ? { kind: 'workspace' as const, cwd: legacyWorkspaceContextCwd }
+        : undefined),
+    [
+      connection.sessionContext,
+      legacyWorkspaceContextCwd,
+      pendingSessionContext,
+    ],
+  );
+  const workspaceContextActive = effectiveSessionContext?.kind === 'workspace';
+  const effectiveStandaloneSession =
+    effectiveSessionContext?.kind === 'standalone'
+      ? connection.standaloneSession
+      : undefined;
+  const standaloneCreationRecovery =
+    effectiveStandaloneSession?.creationRecovery;
+  const standaloneWorkingDirectory =
+    effectiveStandaloneSession?.workingDirectory;
+  const standaloneDirectoryErrorCode = effectiveStandaloneSession?.errorCode;
+  const [standaloneRecoveryResolution, setStandaloneRecoveryResolution] =
+    useState<StandaloneRecoveryResolution>('idle');
+  const [standaloneRepairBusy, setStandaloneRepairBusy] = useState(false);
+  useEffect(() => {
+    setStandaloneRecoveryResolution('idle');
+    setStandaloneRepairBusy(false);
+  }, [connection.sessionId]);
   const [selectedWorkspaceGitStatus, setSelectedWorkspaceGitStatus] = useState<
     DaemonWorkspaceGitStatus | undefined
   >(undefined);
+  /** Git mode intent for the next lazily-created session (branch or worktree). */
+  const [gitModeIntent, setGitModeIntent] = useState<SessionGitIntent>({
+    mode: 'current',
+  });
+  const gitModeIntentRef = useRef(gitModeIntent);
+  useEffect(() => {
+    gitModeIntentRef.current = gitModeIntent;
+  }, [gitModeIntent]);
 
   useEffect(() => {
     if (!workspace.capabilities || !selectedWorkspaceCwd) return;
@@ -2581,10 +2691,23 @@ export function App({
       (entry) => entry.cwd === selectedWorkspaceCwd,
     );
     if (selected?.trusted) return;
+    const primaryCwd = ordinaryWorkspaces.find(
+      (entry) => entry.primary && entry.trusted !== false,
+    )?.cwd;
     composerSourceVersionRef.current += 1;
     selectedWorkspaceCwdRef.current = undefined;
     setSelectedWorkspaceCwd(undefined);
-  }, [ordinaryWorkspaces, selectedWorkspaceCwd, workspace.capabilities]);
+    setPendingSessionContext(
+      primaryCwd ? { kind: 'workspace', cwd: primaryCwd } : undefined,
+    );
+    gitModeIntentRef.current = { mode: 'current' };
+    setGitModeIntent({ mode: 'current' });
+  }, [
+    ordinaryWorkspaces,
+    selectedWorkspaceCwd,
+    setPendingSessionContext,
+    workspace.capabilities,
+  ]);
   // The workspace the chip's status was last fetched for. On a workspace switch
   // we clear the status immediately so the chip never shows the previous repo's
   // branch/dirty counts while the new fetch is in flight; same-workspace
@@ -2642,9 +2765,51 @@ export function App({
     ) {
       return;
     }
+    if (connection.sessionContext?.kind === 'standalone') {
+      workspace.client
+        .getStandaloneSession(sid)
+        .then((summary) => {
+          if (
+            'state' in summary ||
+            sessionStatusRequestRef.current !== requestId ||
+            worktreeSessionKeyRef.current !== sessionKey ||
+            !owner.isCurrent()
+          ) {
+            return;
+          }
+          setSessionWorktree(undefined);
+          setSessionBranch(undefined);
+          setSessionStatusDisplayName(summary.displayName);
+          setCurrentSessionSummary(summary);
+        })
+        .catch(() => {
+          if (
+            sessionStatusRequestRef.current === requestId &&
+            worktreeSessionKeyRef.current === sessionKey &&
+            owner.isCurrent()
+          ) {
+            setSessionStatusDisplayName(undefined);
+            setCurrentSessionSummary(undefined);
+          }
+        });
+      return;
+    }
     workspace.client
       .sessionStatus(sid)
       .then((summary) => {
+        if (connection.sessionContext?.kind === 'live') {
+          if (
+            sessionStatusRequestRef.current === requestId &&
+            worktreeSessionKeyRef.current === sessionKey &&
+            owner.isCurrent()
+          ) {
+            setSessionWorktree(undefined);
+            setSessionBranch(undefined);
+            setSessionStatusDisplayName(summary.displayName);
+            setCurrentSessionSummary(summary);
+          }
+          return;
+        }
         if (
           sessionStatusRequestRef.current === requestId &&
           worktreeSessionKeyRef.current === sessionKey &&
@@ -2698,6 +2863,7 @@ export function App({
     connection.clientId,
     connection.loadingTranscript,
     connection.sessionId,
+    connection.sessionContext,
     connection.status,
     connection.workspaceCwd,
     logicalSessionKey,
@@ -2709,21 +2875,27 @@ export function App({
   // picked for the next session (locked / selected / primary). Computed once
   // and shared by the git-status effect and the Changes-dialog entry point so
   // the chip and the dialog always target the same repo.
-  const activeWorkspaceCwd = useMemo(
-    () =>
-      connection.sessionId
-        ? connection.workspaceCwd
-        : (lockedWorkspaceCwd ??
+  const activeWorkspaceCwd = useMemo(() => {
+    if (!workspaceContextActive) return undefined;
+    const explicitContext = pendingSessionContext ?? connection.sessionContext;
+    if (explicitContext?.kind === 'workspace') {
+      return explicitContext.cwd;
+    }
+    return connection.sessionId
+      ? connection.workspaceCwd
+      : (lockedWorkspaceCwd ??
           selectedWorkspaceCwd ??
-          ordinaryWorkspaces.find((entry) => entry.primary)?.cwd),
-    [
-      connection.sessionId,
-      connection.workspaceCwd,
-      lockedWorkspaceCwd,
-      selectedWorkspaceCwd,
-      ordinaryWorkspaces,
-    ],
-  );
+          ordinaryWorkspaces.find((entry) => entry.primary)?.cwd);
+  }, [
+    connection.sessionId,
+    connection.workspaceCwd,
+    connection.sessionContext,
+    lockedWorkspaceCwd,
+    selectedWorkspaceCwd,
+    ordinaryWorkspaces,
+    pendingSessionContext,
+    workspaceContextActive,
+  ]);
   // Worktree sessions query git status with the worktree path (?cwd=
   // parameter); the chip prefers the live branch from that status, falling
   // back to the creation-time sessionWorktree.branch.
@@ -2913,6 +3085,9 @@ export function App({
   const lastNotifiedSessionIdRef = useRef<string | undefined>(undefined);
   const lastNotifiedWorkspaceIdRef = useRef<string | undefined>(undefined);
   const lastNotifiedWorkspaceCwdRef = useRef<string | undefined>(undefined);
+  const lastNotifiedNonWorkspaceContextRef = useRef<
+    'standalone' | 'live' | undefined
+  >(undefined);
   const displayMessages = useMemo(
     () => buildDisplayMessages(messages, recapMessage),
     [messages, recapMessage],
@@ -3241,12 +3416,32 @@ export function App({
     setArtifactPanelFullscreen(false);
   }, [logicalSessionKey]);
   const sideTasksAvailable =
+    workspaceContextActive &&
     Boolean(connection.sessionId && connection.workspaceCwd) &&
     connection.capabilities?.features.includes(SESSION_SIDE_TASK_FEATURE) ===
       true;
   const webTerminalAvailable =
+    workspaceContextActive &&
     rightPanelItems.includes('terminal') &&
     connection.capabilities?.features.includes('web_terminal') === true;
+  useEffect(() => {
+    if (workspaceContextActive) return;
+    const terminalIds = artifactPanelTabs
+      .filter((tab) => tab.kind === 'terminal')
+      .map((tab) => tab.id);
+    if (terminalIds.length === 0) return;
+    for (const terminalId of terminalIds) releaseWebTerminal(terminalId);
+    setArtifactPanelTabs((tabs) =>
+      tabs.filter((tab) => tab.kind !== 'terminal'),
+    );
+    if (
+      activeArtifactPanelTabId &&
+      terminalIds.includes(activeArtifactPanelTabId)
+    ) {
+      setActiveArtifactPanelTabId(null);
+      setArtifactPanelOpen(false);
+    }
+  }, [activeArtifactPanelTabId, artifactPanelTabs, workspaceContextActive]);
   const [sideTaskCatalog, setSideTaskCatalog] = useState<SideTaskCatalogState>({
     items: [],
     loaded: false,
@@ -5057,13 +5252,30 @@ export function App({
   );
   useEffect(() => {
     if (!connected) return;
+    if (!workspaceContextActive) {
+      loadedSkillsRequestRef.current += 1;
+      setLoadedSkills([]);
+      setLoadedSkillsReady(true);
+      setLoadedSkillsFallback(undefined);
+      return;
+    }
     void reloadLoadedSkills(connection.workspaceCwd);
-  }, [connected, connection.workspaceCwd, reloadLoadedSkills]);
+  }, [
+    connected,
+    connection.workspaceCwd,
+    reloadLoadedSkills,
+    workspaceContextActive,
+  ]);
   const handledSkillMutationKeysRef = useRef(new Set<string>());
   const pendingSkillTogglesByContextRef = useRef(
     new Map<string, Array<{ name: string; enabled: boolean }>>(),
   );
   useEffect(() => {
+    if (!workspaceContextActive) {
+      handledSkillMutationKeysRef.current.clear();
+      pendingSkillTogglesByContextRef.current.clear();
+      return;
+    }
     if (!connected) {
       handledSkillMutationKeysRef.current.clear();
       return;
@@ -5160,6 +5372,7 @@ export function App({
     reloadLoadedSkills,
     workspaceEventSignals?.lastSkillMutation,
     workspaceEventSignals?.skillMutationsByCwd,
+    workspaceContextActive,
   ]);
   useEffect(() => {
     if (!loadedSkillsFallback) return;
@@ -5451,6 +5664,7 @@ export function App({
   // Latest pane list, readable from the shrink-close effect without making it a
   // dependency (it changes on every pane add/remove).
   const splitSessionIdsRef = useRef<string[]>(splitSessionIds);
+  const splitClassificationGenerationRef = useRef(0);
   splitSessionIdsRef.current = splitSessionIds;
   const previousSplitSessionIdsRef = useRef<string[]>(splitSessionIds);
   useEffect(() => {
@@ -5495,6 +5709,40 @@ export function App({
     }
   }, [activePanel]);
   const closePanel = useCallback(() => setActivePanel(null), []);
+  useEffect(() => {
+    if (workspaceContextActive) return;
+    splitClassificationGenerationRef.current += 1;
+    setSplitSessionIds([]);
+    if (
+      activePanel === 'settings' ||
+      activePanel === 'sessions' ||
+      activePanel === 'extensions' ||
+      activePanel === 'mcp' ||
+      activePanel === 'skills' ||
+      activePanel === 'agents' ||
+      activePanel === 'plugins' ||
+      activePanel === 'channels'
+    ) {
+      setActivePanel(null);
+    }
+    setShowResumeDialog(false);
+    setShowDeleteDialog(false);
+    setShowReleaseDialog(false);
+    setShowMemoryDialog(false);
+    setShowAddWorkspaceDialog(false);
+    setGitDialog(undefined);
+    if (modelDialogMode && modelDialogMode !== 'main') {
+      setModelDialogMode(null);
+    }
+    setShowFallbacksDialog(false);
+    if (
+      mainView === 'scheduledTasks' ||
+      mainView === 'goals' ||
+      mainView === 'split'
+    ) {
+      setMainView('chat');
+    }
+  }, [activePanel, mainView, modelDialogMode, workspaceContextActive]);
   const handleUseSkill = useCallback(
     (name: string) => {
       closePanel();
@@ -5555,28 +5803,69 @@ export function App({
     setForceMobileDrawer(true);
     setMobileDrawerOpen(true);
   }, [sidebarOptions.enabled]);
+  const sanitizeSplitSessionIds = useCallback(
+    async (sessionIds: readonly string[]): Promise<string[]> => {
+      const requested = Array.from(new Set(sessionIds.filter(Boolean))).slice(
+        0,
+        MAX_SPLIT_PANES,
+      );
+      if (requested.length === 0) return [];
+      return keepWorkspaceSplitSessionIds(
+        workspace.client,
+        workspace.capabilities,
+        requested,
+      );
+    },
+    [workspace.capabilities, workspace.client],
+  );
   // Open the in-window split view showing 2+ sessions side by side. `splitSessionIds`
   // is the live pane set — SplitView mirrors add/remove back into it via
   // onPanesChange — so it must be preserved across entries, not blindly reset.
   const openSplitView = useCallback(
     (sessionIds?: readonly string[]) => {
+      if (!workspaceContextActive) return;
       setActivePanel(null);
-      setSplitSessionIds((prev) => {
-        // An explicit selection (the overview, or a `?split=` URL) replaces the
-        // split with exactly those sessions.
-        const requested = Array.from(
-          new Set((sessionIds ?? []).filter(Boolean)),
-        ).slice(0, MAX_SPLIT_PANES);
-        if (requested.length > 0) return requested;
-        // No selection (the toolbar "Open Split View" button): restore the split
-        // the user already had so switching away and back doesn't clear it; fall
-        // back to the current session when there is nothing to restore.
-        if (prev.length > 0) return prev;
-        return connection.sessionId ? [connection.sessionId] : [];
+      const requested = Array.from(
+        new Set((sessionIds ?? []).filter(Boolean)),
+      ).slice(0, MAX_SPLIT_PANES);
+      const generation = splitClassificationGenerationRef.current + 1;
+      splitClassificationGenerationRef.current = generation;
+      if (requested.length === 0) {
+        const currentWorkspaceSessionId =
+          connection.sessionId !== undefined &&
+          (connection.sessionContext?.kind === 'workspace' ||
+            (connection.sessionContext === undefined &&
+              connection.workspaceCwd !== undefined))
+            ? connection.sessionId
+            : undefined;
+        setSplitSessionIds((previous) =>
+          previous.length > 0
+            ? previous
+            : currentWorkspaceSessionId
+              ? [currentWorkspaceSessionId]
+              : [],
+        );
+        setMainView('split');
+        return;
+      }
+      void sanitizeSplitSessionIds(requested).then((sanitized) => {
+        if (
+          splitClassificationGenerationRef.current !== generation ||
+          sanitized.length === 0
+        ) {
+          return;
+        }
+        setSplitSessionIds(sanitized);
+        setMainView('split');
       });
-      setMainView('split');
     },
-    [connection.sessionId],
+    [
+      connection.sessionContext,
+      connection.sessionId,
+      connection.workspaceCwd,
+      sanitizeSplitSessionIds,
+      workspaceContextActive,
+    ],
   );
   const externalSplitSignature = useMemo(() => {
     const requested = Array.from(
@@ -5588,6 +5877,7 @@ export function App({
   const onSplitSessionIdsChangeRef = useRef(onSplitSessionIdsChange);
   onSplitSessionIdsChangeRef.current = onSplitSessionIdsChange;
   const requestOpenSplitView = useCallback(() => {
+    if (!workspaceContextActive) return;
     if (!externalSplitControlled) {
       openSplitView();
       return;
@@ -5604,22 +5894,56 @@ export function App({
     externalSplitControlled,
     openSplitView,
     splitSessionIds,
+    workspaceContextActive,
   ]);
   useEffect(() => {
     if (!externalSplitControlled) return;
     const requested = externalSplitSignature
       ? externalSplitSignature.split('\0')
       : [];
-    setSplitSessionIds((prev) =>
-      areSessionIdsEqual(prev, requested) ? prev : requested,
-    );
-    if (requested.length > 0) {
-      setActivePanel((prev) => (prev === null ? prev : null));
-      setMainView((prev) => (prev === 'split' ? prev : 'split'));
-    } else {
-      setMainView((prev) => (prev === 'split' ? 'chat' : prev));
+    const generation = splitClassificationGenerationRef.current + 1;
+    splitClassificationGenerationRef.current = generation;
+    if (requested.length === 0) {
+      setSplitSessionIds([]);
+      setMainView((previous) => (previous === 'split' ? 'chat' : previous));
+      return;
     }
-  }, [externalSplitControlled, externalSplitSignature]);
+    if (!workspaceContextActive) {
+      if (
+        effectiveSessionContext === undefined &&
+        !workspaceCapabilitiesReady
+      ) {
+        return;
+      }
+      setSplitSessionIds([]);
+      setMainView((previous) => (previous === 'split' ? 'chat' : previous));
+      onSplitSessionIdsChangeRef.current?.([]);
+      return;
+    }
+    if (!workspaceCapabilitiesReady) return;
+    void sanitizeSplitSessionIds(requested).then((sanitized) => {
+      if (splitClassificationGenerationRef.current !== generation) return;
+      setSplitSessionIds((previous) =>
+        areSessionIdsEqual(previous, sanitized) ? previous : sanitized,
+      );
+      if (!areSessionIdsEqual(requested, sanitized)) {
+        onSplitSessionIdsChangeRef.current?.(sanitized);
+      }
+      if (sanitized.length > 0) {
+        setActivePanel((previous) => (previous === null ? previous : null));
+        setMainView((previous) => (previous === 'split' ? previous : 'split'));
+      } else {
+        setMainView((previous) => (previous === 'split' ? 'chat' : previous));
+      }
+    });
+  }, [
+    externalSplitControlled,
+    externalSplitSignature,
+    effectiveSessionContext,
+    sanitizeSplitSessionIds,
+    workspaceCapabilitiesReady,
+    workspaceContextActive,
+  ]);
   const handleSplitPanesChange = useCallback(
     (sessionIds: string[]) => {
       const nextIds = new Set(sessionIds);
@@ -5692,6 +6016,7 @@ export function App({
   // view with those sessions on load. Consume the param once so a later reload
   // or exit doesn't force the split back on.
   useEffect(() => {
+    if (!workspace.capabilities) return;
     const ids = parseSplitSessionIds(window.location.search);
     if (ids.length > 0) {
       const url = new URL(window.location.href);
@@ -5709,7 +6034,7 @@ export function App({
     if (externalSplitControlled) return;
     const saved = loadSplitSessions();
     if (saved.length > 0) openSplitView(saved);
-  }, [externalSplitControlled, openSplitView]);
+  }, [externalSplitControlled, openSplitView, workspace.capabilities]);
   // Mirror the live split session set to per-tab storage while the split is the
   // active view, so a refresh restores exactly these panes. Not written when the
   // split is merely folded by a shrink (mainView flips to 'chat' transiently) —
@@ -6079,7 +6404,14 @@ export function App({
   );
   const refreshActiveSessionDisplayName = useCallback(async () => {
     const activeConnection = connectionRef.current;
-    if (!activeConnection.sessionId || !activeConnection.workspaceCwd) return;
+    if (
+      !activeConnection.sessionId ||
+      !activeConnection.workspaceCwd ||
+      (activeConnection.sessionContext &&
+        activeConnection.sessionContext.kind !== 'workspace')
+    ) {
+      return;
+    }
     const owner = sessionOwnerGuard.capture();
     try {
       const page = await loadSessionCatalogOnce(
@@ -6169,7 +6501,10 @@ export function App({
     pushToast('info', t('localCommand.noSession'));
     return false;
   }, [pushToast, t]);
-  const sessionDisplayName = connection.displayName ?? sessionStatusDisplayName;
+  const sessionDisplayName =
+    connection.sessionContext?.kind === 'standalone'
+      ? (sessionStatusDisplayName ?? connection.displayName)
+      : (connection.displayName ?? sessionStatusDisplayName);
   useEffect(() => {
     onSessionInfoChange?.({
       sessionId: connection.sessionId,
@@ -6223,19 +6558,12 @@ export function App({
       }
     | undefined
   >(undefined);
-  /** Git mode intent for the next lazily-created session (branch or worktree). */
-  const [gitModeIntent, setGitModeIntent] = useState<SessionGitIntent>({
-    mode: 'current',
-  });
-  const gitModeIntentRef = useRef(gitModeIntent);
-  useEffect(() => {
-    gitModeIntentRef.current = gitModeIntent;
-  }, [gitModeIntent]);
   const newSessionSuggestionSubmitTokenRef = useRef(0);
   const pendingNewSessionSuggestionSubmitRef = useRef<{
     token: number;
     sourceSessionId: string | undefined;
-    sessionClearCompleted: boolean;
+    mode: 'cleared' | 'live';
+    newSessionReady: boolean;
     submitScheduled: boolean;
   } | null>(null);
   const onSessionCreatedRef = useRef(onSessionCreated);
@@ -6290,25 +6618,52 @@ export function App({
           : undefined;
       const modeId =
         currentModeRef.current || connectionRef.current.currentMode;
-      const primaryWorkspaceCwd = ordinaryWorkspaces.find(
+      const requestedSessionContext =
+        pendingSessionContextRef.current ??
+        connectionRef.current.sessionContext;
+      const availableWorkspaces = workspacesRef.current;
+      const primaryWorkspaceCwd = availableWorkspaces.find(
         (entry) => entry.primary,
       )?.cwd;
       const requestedWorkspaceCwd = selectedWorkspaceCwdRef.current;
       const acceptedWorkspaceCwd = requestedWorkspaceCwd
-        ? ordinaryWorkspaces.find(
+        ? availableWorkspaces.find(
             (entry) =>
-              entry.cwd === requestedWorkspaceCwd && entry.trusted === true,
+              entry.cwd === requestedWorkspaceCwd && entry.trusted !== false,
           )?.cwd
         : undefined;
       const targetWorkspaceCwd =
-        ordinaryWorkspaces.find((entry) => entry.cwd === lockedWorkspaceCwd)
-          ?.cwd ??
-        acceptedWorkspaceCwd ??
-        primaryWorkspaceCwd;
+        requestedSessionContext?.kind === 'workspace'
+          ? (availableWorkspaces.find(
+              (entry) =>
+                entry.cwd === requestedSessionContext.cwd &&
+                entry.trusted !== false,
+            )?.cwd ??
+            (requestedSessionContext.cwd === connectionRef.current.workspaceCwd
+              ? requestedSessionContext.cwd
+              : undefined))
+          : requestedSessionContext?.kind === 'standalone'
+            ? undefined
+            : (availableWorkspaces.find(
+                (entry) => entry.cwd === lockedWorkspaceCwd,
+              )?.cwd ??
+              acceptedWorkspaceCwd ??
+              primaryWorkspaceCwd);
+      if (
+        requestedSessionContext?.kind === 'workspace' &&
+        !targetWorkspaceCwd
+      ) {
+        throw new Error('The selected workspace is unavailable or untrusted');
+      }
+      const creationSessionContext: DaemonProductSessionContext | undefined =
+        requestedSessionContext ??
+        (targetWorkspaceCwd
+          ? { kind: 'workspace', cwd: targetWorkspaceCwd }
+          : undefined);
       const catalogWorkspaceCwd =
-        targetWorkspaceCwd ??
-        workspace.workspaceCwd ??
-        connectionRef.current.workspaceCwd;
+        creationSessionContext?.kind === 'workspace'
+          ? creationSessionContext.cwd
+          : undefined;
       try {
         await createAndAttachSessionForPrompt({
           sessionActions: sessionActions as typeof sessionActions &
@@ -6317,11 +6672,14 @@ export function App({
           reasoningEffort,
           modeId,
           workspaceCwd: targetWorkspaceCwd,
+          sessionContext: creationSessionContext,
           worktree:
+            creationSessionContext?.kind === 'workspace' &&
             gitModeIntentRef.current.mode === 'worktree'
               ? { slug: gitModeIntentRef.current.slug }
               : undefined,
           branch:
+            creationSessionContext?.kind === 'workspace' &&
             gitModeIntentRef.current.mode === 'branch'
               ? { name: gitModeIntentRef.current.name }
               : undefined,
@@ -6356,6 +6714,9 @@ export function App({
           if (pendingReasoningIntentRef.current === reasoningIntent) {
             setPendingReasoningIntent(undefined);
           }
+          if (pendingSessionContextRef.current === requestedSessionContext) {
+            setPendingSessionContext(undefined);
+          }
         });
       } catch (error) {
         if (allocatedSessionId && catalogWorkspaceCwd) {
@@ -6366,7 +6727,9 @@ export function App({
       // One-shot: the picker targets only the *next* new session, so clear
       // it after creation. The next new chat defaults back to the primary
       // workspace unless the user picks one again.
-      setSelectedWorkspaceCwd(undefined);
+      if (creationSessionContext?.kind === 'workspace') {
+        setSelectedWorkspaceCwd(undefined);
+      }
       return allocatedSessionId;
     })();
     createSessionPromiseRef.current = promise;
@@ -6382,9 +6745,8 @@ export function App({
     lockedWorkspaceCwd,
     sessionActions,
     sessionCatalogController,
+    setPendingSessionContext,
     setPendingReasoningIntent,
-    workspace.workspaceCwd,
-    ordinaryWorkspaces,
   ]);
   const onSubmitBeforeRef = useRef(onSubmitBefore);
   onSubmitBeforeRef.current = onSubmitBefore;
@@ -6393,8 +6755,15 @@ export function App({
   const onSlashCommandRef = useRef(onSlashCommand);
   onSlashCommandRef.current = onSlashCommand;
   const getComposerWorkspaceCwd = useCallback(() => {
+    const productContext =
+      pendingSessionContextRef.current ?? connectionRef.current.sessionContext;
+    if (productContext && productContext.kind !== 'workspace') {
+      return undefined;
+    }
     if (connectionRef.current.sessionId) {
-      return connectionRef.current.workspaceCwd;
+      return productContext?.kind === 'workspace'
+        ? productContext.cwd
+        : connectionRef.current.workspaceCwd;
     }
     return (
       workspacesRef.current.find((entry) => entry.cwd === lockedWorkspaceCwd)
@@ -6934,21 +7303,24 @@ export function App({
     dialogOpen || mainView !== 'chat' || artifactPanelFullscreen;
   const mainVoiceTarget = useMemo(
     () =>
-      resolveVoiceWorkspaceTarget({
-        capabilities: workspace.capabilities,
-        intendedCwd: activeWorkspaceCwd,
-        sessionId: connection.sessionId,
-        workspaces:
-          workspace.capabilities?.workspaces || lockedWorkspaceCapability
-            ? ordinaryWorkspaces
-            : undefined,
-      }),
+      workspaceContextActive
+        ? resolveVoiceWorkspaceTarget({
+            capabilities: workspace.capabilities,
+            intendedCwd: activeWorkspaceCwd,
+            sessionId: connection.sessionId,
+            workspaces:
+              workspace.capabilities?.workspaces || lockedWorkspaceCapability
+                ? ordinaryWorkspaces
+                : undefined,
+          })
+        : undefined,
     [
       activeWorkspaceCwd,
       connection.sessionId,
       lockedWorkspaceCapability,
       workspace.capabilities,
       ordinaryWorkspaces,
+      workspaceContextActive,
     ],
   );
   const [voiceUserRevision, setVoiceUserRevision] = useState(0);
@@ -7601,9 +7973,13 @@ export function App({
   }, []);
 
   const workspaceSettingsState = useSettings({
-    autoLoad: true,
+    autoLoad: workspaceContextActive,
+    enabled: workspaceContextActive,
   });
-  const providersState = useProviders({ autoLoad: true });
+  const providersState = useProviders({
+    autoLoad: workspaceContextActive,
+    enabled: workspaceContextActive,
+  });
   // useProviders returns a fresh object each render, but its `reload` identity is
   // stable — pull it out so callbacks can depend on the function alone without
   // re-creating on every render (and without an exhaustive-deps warning).
@@ -7615,10 +7991,14 @@ export function App({
     setModelActionBusy(false);
   }, [logicalSessionKey]);
   const {
-    settings: workspaceSettings,
+    settings: loadedWorkspaceSettings,
     setValue: setWorkspaceSetting,
     reload: reloadWorkspaceSettings,
   } = workspaceSettingsState;
+  const workspaceSettings = useMemo(
+    () => (workspaceContextActive ? loadedWorkspaceSettings : []),
+    [loadedWorkspaceSettings, workspaceContextActive],
+  );
   const liveSetup = useLiveVoiceSetup(
     workspaceSettings.some(
       (setting) => setting.key === 'experimental.liveVoice.enabled',
@@ -8300,7 +8680,11 @@ export function App({
         lastTurnErrorIdRef.current != null
           ? new Error(`Turn error (block ${lastTurnErrorIdRef.current})`)
           : undefined;
-      if (workspaceCwd) {
+      const productContext = connectionRef.current.sessionContext;
+      if (
+        workspaceCwd &&
+        (!productContext || productContext.kind === 'workspace')
+      ) {
         sessionCatalogController.turnCompleted(workspaceCwd, sessionId);
         if (!sessionDisplayName) {
           scheduleDelayedActiveSessionDisplayNameRefresh(
@@ -8363,12 +8747,16 @@ export function App({
 
   useEffect(() => {
     if (connection.loadingTranscript) return;
+    if (connection.standaloneSession?.creationRecovery) {
+      return;
+    }
     if (!connection.sessionId && connection.missingSession) {
       // Keep the dead-session route visible until the user explicitly starts a
       // new chat; clearing it here would immediately hide the recovery state.
       lastNotifiedSessionIdRef.current = connection.sessionId;
       lastNotifiedWorkspaceIdRef.current = undefined;
       lastNotifiedWorkspaceCwdRef.current = undefined;
+      lastNotifiedNonWorkspaceContextRef.current = undefined;
       return;
     }
     const reportedWorkspaceCwd = connection.sessionId
@@ -8382,28 +8770,47 @@ export function App({
       activeWorkspace && !activeWorkspace.primary
         ? activeWorkspace.id
         : undefined;
+    const reportedSessionContext = connection.sessionId
+      ? connection.sessionContext
+      : (pendingSessionContext ?? connection.sessionContext);
+    const nonWorkspaceContext =
+      reportedSessionContext?.kind === 'standalone' ||
+      reportedSessionContext?.kind === 'live'
+        ? reportedSessionContext.kind
+        : undefined;
     if (
       lastNotifiedSessionIdRef.current === connection.sessionId &&
       lastNotifiedWorkspaceIdRef.current === workspaceId &&
-      lastNotifiedWorkspaceCwdRef.current === reportedWorkspaceCwd
+      lastNotifiedWorkspaceCwdRef.current === reportedWorkspaceCwd &&
+      lastNotifiedNonWorkspaceContextRef.current === nonWorkspaceContext
     ) {
       return;
     }
     lastNotifiedSessionIdRef.current = connection.sessionId;
     lastNotifiedWorkspaceIdRef.current = workspaceId;
     lastNotifiedWorkspaceCwdRef.current = reportedWorkspaceCwd;
-    onSessionIdChange?.(
-      connection.sessionId,
-      workspaceId,
-      reportedWorkspaceCwd,
-    );
+    lastNotifiedNonWorkspaceContextRef.current = nonWorkspaceContext;
+    if (nonWorkspaceContext) {
+      onSessionIdChange?.(connection.sessionId, undefined, undefined, {
+        kind: nonWorkspaceContext,
+      });
+    } else {
+      onSessionIdChange?.(
+        connection.sessionId,
+        workspaceId,
+        reportedWorkspaceCwd,
+      );
+    }
   }, [
     connection.missingSession,
     connection.loadingTranscript,
     connection.sessionId,
+    connection.sessionContext,
+    connection.standaloneSession?.creationRecovery,
     connection.workspaceCwd,
     onSessionIdChange,
     activeWorkspaceCwd,
+    pendingSessionContext,
     workspace.capabilities,
     workspaces,
   ]);
@@ -8431,6 +8838,11 @@ export function App({
       };
       if (workspaceCwd) {
         sessionCatalogController.renamed(workspaceCwd, sessionId, displayName);
+      } else if (
+        connectionRef.current.sessionId === sessionId &&
+        connectionRef.current.sessionContext?.kind === 'standalone'
+      ) {
+        setSessionStatusDisplayName(displayName);
       }
     },
     [sessionCatalogController],
@@ -8455,7 +8867,11 @@ export function App({
       reconciled.sessionId === sessionId &&
       reconciled.displayName === displayName;
     if (!alreadyReconciled) {
-      if (connection.workspaceCwd) {
+      if (
+        connection.workspaceCwd &&
+        (!connection.sessionContext ||
+          connection.sessionContext.kind === 'workspace')
+      ) {
         sessionCatalogController.renamed(
           connection.workspaceCwd,
           sessionId,
@@ -8471,6 +8887,7 @@ export function App({
   }, [
     connection.displayName,
     connection.sessionId,
+    connection.sessionContext,
     connection.workspaceCwd,
     logicalSessionKey,
     sessionCatalogController,
@@ -8647,6 +9064,10 @@ export function App({
   const pendingBranchRequestsRef = useRef(new Map<string, Promise<void>>());
   const branchCurrentSession = useCallback(
     (name?: string, atRecordId?: string) => {
+      if (!workspaceContextActive) {
+        pushToast('info', t('session.workspaceActionUnavailable'));
+        return;
+      }
       if (sessionWriteBlocked) return;
       if (!requireActiveSessionForLocalCommand()) return;
       const sourceSessionId = connectionRef.current.sessionId;
@@ -8726,6 +9147,7 @@ export function App({
       store,
       t,
       transcriptReloadSupported,
+      workspaceContextActive,
     ],
   );
   const handleBranchCurrentSession = useCallback(
@@ -8753,22 +9175,96 @@ export function App({
   }, []);
   const createNewSession = useCallback(
     async (
-      workspaceCwd?: string,
+      intent: NewSessionIntent,
+      /** Preserve the current full-page view and/or active panel while clearing. */
       opts?: {
-        /** Preserve the current full-page view and/or active panel while clearing. */
         keepView?: boolean;
         keepPanel?: boolean;
+        allowRecoveryReset?: boolean;
         /**
-         * Git mode the new draft starts with. Set here, in the same
-         * synchronous step that resets the previous intent, so the very
-         * first prompt — even one submitted while the clear is still in
-         * flight — sees it, and no later arm can land on a draft that has
-         * since been re-targeted or turned into a session.
+         * Git mode the new workspace draft starts with. Set here, in the same
+         * synchronous step that resets the previous intent, so the first
+         * prompt sees it even while the clear is still in flight.
          */
         gitIntent?: SessionGitIntent;
       },
     ) => {
-      const targetWorkspaceCwd = lockedWorkspaceCwd ?? workspaceCwd;
+      if (
+        connectionRef.current.standaloneSession?.creationRecovery &&
+        !opts?.allowRecoveryReset
+      ) {
+        pushToast('warning', t('session.recoveryBlocksAction'));
+        return false;
+      }
+      let nextContext: DaemonProductSessionContext | undefined;
+      let availableWorkspaces = workspacesRef.current;
+      if (intent.kind === 'workspace') {
+        nextContext = { kind: 'workspace', cwd: intent.cwd };
+      } else if (lockedWorkspaceCwd) {
+        nextContext = { kind: 'workspace', cwd: lockedWorkspaceCwd };
+      } else if (intent.kind === 'inherit') {
+        nextContext =
+          pendingSessionContextRef.current ??
+          connectionRef.current.sessionContext ??
+          (connectionRef.current.workspaceCwd
+            ? {
+                kind: 'workspace',
+                cwd: connectionRef.current.workspaceCwd,
+              }
+            : undefined);
+        if (nextContext?.kind === 'live') {
+          gitModeIntentRef.current = { mode: 'current' };
+          setGitModeIntent({ mode: 'current' });
+          try {
+            await workspace.client.startLive('new');
+            return true;
+          } catch (error) {
+            reportError(error, 'Failed to start a new Live chat');
+            return false;
+          }
+        }
+      } else {
+        let capabilities = workspaceCapabilitiesRef.current;
+        if (workspace.status === 'error') {
+          if (!refreshWorkspaceCapabilities) {
+            pushToast('info', t('session.capabilitiesFailed'));
+            return false;
+          }
+          try {
+            capabilities = await refreshWorkspaceCapabilities();
+          } catch (error) {
+            reportError(error, t('session.capabilitiesFailed'));
+            return false;
+          }
+        } else if (!workspaceCapabilitiesReady) {
+          pushToast('info', t('common.loading'));
+          return false;
+        }
+        if (!capabilities) {
+          pushToast('info', t('session.capabilitiesFailed'));
+          return false;
+        }
+        availableWorkspaces = (capabilities.workspaces ?? []).filter(
+          (entry) => entry.kind !== 'live',
+        );
+        if (
+          capabilities.features?.includes(STANDALONE_SESSIONS_CAPABILITY) ===
+          true
+        ) {
+          nextContext = { kind: 'standalone' };
+        } else {
+          const primaryCwd = availableWorkspaces.find(
+            (entry) => entry.primary && entry.trusted !== false,
+          )?.cwd;
+          nextContext = primaryCwd
+            ? { kind: 'workspace', cwd: primaryCwd }
+            : undefined;
+        }
+      }
+      const targetWorkspaceCwd =
+        nextContext?.kind === 'workspace' ? nextContext.cwd : undefined;
+      const previousPendingContext = pendingSessionContextRef.current;
+      setPendingSessionContext(nextContext);
       composerSourceVersionRef.current += 1;
       selectedWorkspaceCwdRef.current = targetWorkspaceCwd;
       setSelectedWorkspaceCwd(targetWorkspaceCwd);
@@ -8776,9 +9272,10 @@ export function App({
       // leaks into the next created session; a caller-supplied intent takes
       // its place. The ref is written too so a prompt admitted before the
       // next render reads the same answer.
-      const nextGitIntent: SessionGitIntent = opts?.gitIntent ?? {
-        mode: 'current',
-      };
+      const nextGitIntent: SessionGitIntent =
+        nextContext?.kind === 'workspace'
+          ? (opts?.gitIntent ?? { mode: 'current' })
+          : { mode: 'current' };
       gitModeIntentRef.current = nextGitIntent;
       setGitModeIntent(nextGitIntent);
       // Close the drawer before awaiting so a failed createSession() doesn't leave
@@ -8801,7 +9298,9 @@ export function App({
         focusRequest = scheduleComposerFocus();
         await Promise.all([
           clearPromise,
-          reloadLoadedSkills(targetWorkspaceCwd),
+          nextContext?.kind === 'workspace'
+            ? reloadLoadedSkills(targetWorkspaceCwd)
+            : Promise.resolve(undefined),
         ]);
         // Clear after successful clearSession — if it rejects, the old
         // session's worktree/branch state is preserved.
@@ -8809,6 +9308,7 @@ export function App({
         setSessionBranch(undefined);
         return true;
       } catch (error) {
+        setPendingSessionContext(previousPendingContext);
         if (composerFocusRequestRef.current === focusRequest) {
           composerFocusRequestRef.current += 1;
         }
@@ -8820,10 +9320,17 @@ export function App({
       closeMobileDrawer,
       closePanel,
       lockedWorkspaceCwd,
+      pushToast,
       reportError,
+      refreshWorkspaceCapabilities,
       reloadLoadedSkills,
       scheduleComposerFocus,
+      setPendingSessionContext,
       sessionActions,
+      t,
+      workspaceCapabilitiesReady,
+      workspace.client,
+      workspace.status,
     ],
   );
   /**
@@ -8851,7 +9358,8 @@ export function App({
         }
         if (connectionRef.current.sessionId) {
           if (connectionRef.current.workspaceCwd === targetCwd) return;
-          await createNewSession(workspaceCwd);
+          if (!targetCwd) return;
+          await createNewSession({ kind: 'workspace', cwd: targetCwd });
           return;
         }
         // The composer picker fires for its checked row too; re-selecting
@@ -8862,16 +9370,22 @@ export function App({
         composerSourceVersionRef.current += 1;
         selectedWorkspaceCwdRef.current = workspaceCwd;
         setSelectedWorkspaceCwd(workspaceCwd);
+        setPendingSessionContext(
+          targetCwd ? { kind: 'workspace', cwd: targetCwd } : undefined,
+        );
         // The intent was armed for the previous draft workspace; a switch
         // must not carry a branch/worktree request over to another repo.
-        if (!sameTarget) setGitModeIntent({ mode: 'current' });
+        if (!sameTarget) {
+          gitModeIntentRef.current = { mode: 'current' };
+          setGitModeIntent({ mode: 'current' });
+        }
       } finally {
         if (workspaceSwitchTokenRef.current === token) {
           workspaceSwitchTokenRef.current = null;
         }
       }
     },
-    [createNewSession],
+    [createNewSession, setPendingSessionContext],
   );
 
   /** Refreshes once and switches only from the accepted capability snapshot. */
@@ -9088,20 +9602,31 @@ export function App({
 
       const activeSessionId = connectionRef.current.sessionId;
       if (
-        pending.sourceSessionId !== undefined &&
-        activeSessionId !== undefined &&
-        activeSessionId !== pending.sourceSessionId
+        (pending.mode === 'cleared' &&
+          pending.sourceSessionId !== undefined &&
+          activeSessionId !== undefined &&
+          activeSessionId !== pending.sourceSessionId) ||
+        (pending.mode === 'live' &&
+          activeSessionId !== undefined &&
+          activeSessionId !== pending.sourceSessionId &&
+          connectionRef.current.sessionContext?.kind !== 'live')
       ) {
         pendingNewSessionSuggestionSubmitRef.current = null;
         setIsStartingNewSessionSuggestion(false);
         return;
       }
 
-      if (!pending.sessionClearCompleted) {
+      if (!pending.newSessionReady) {
         return;
       }
 
-      if (activeSessionId !== undefined) {
+      if (
+        pending.mode === 'live'
+          ? activeSessionId === undefined ||
+            activeSessionId === pending.sourceSessionId ||
+            connectionRef.current.sessionContext?.kind !== 'live'
+          : activeSessionId !== undefined
+      ) {
         return;
       }
 
@@ -9118,7 +9643,14 @@ export function App({
         if (!latestPending || latestPending.token !== pending.token) {
           return;
         }
-        if (connectionRef.current.sessionId !== undefined) {
+        const latestSessionId = connectionRef.current.sessionId;
+        if (
+          latestPending.mode === 'live'
+            ? latestSessionId === undefined ||
+              latestSessionId === latestPending.sourceSessionId ||
+              connectionRef.current.sessionContext?.kind !== 'live'
+            : latestSessionId !== undefined
+        ) {
           pendingNewSessionSuggestionSubmitRef.current = null;
           setIsStartingNewSessionSuggestion(false);
           return;
@@ -9151,13 +9683,19 @@ export function App({
     setIsStartingNewSessionSuggestion(true);
     const token = newSessionSuggestionSubmitTokenRef.current + 1;
     newSessionSuggestionSubmitTokenRef.current = token;
+    const mode =
+      (pendingSessionContextRef.current ?? connectionRef.current.sessionContext)
+        ?.kind === 'live'
+        ? 'live'
+        : 'cleared';
     pendingNewSessionSuggestionSubmitRef.current = {
       token,
       sourceSessionId: connectionRef.current.sessionId,
-      sessionClearCompleted: false,
+      mode,
+      newSessionReady: false,
       submitScheduled: false,
     };
-    void createNewSession().then((created) => {
+    void createNewSession({ kind: 'inherit' }).then((created) => {
       const pending = pendingNewSessionSuggestionSubmitRef.current;
       if (!created || pending?.token !== token) {
         if (pending?.token === token) {
@@ -9168,9 +9706,16 @@ export function App({
       }
       pendingNewSessionSuggestionSubmitRef.current = {
         ...pending,
-        sessionClearCompleted: true,
+        newSessionReady: true,
       };
-      onSessionIdChange?.(undefined);
+      if (mode === 'cleared') {
+        const nextContext = pendingSessionContextRef.current;
+        if (nextContext?.kind === 'standalone') {
+          onSessionIdChange?.(undefined, undefined, undefined, nextContext);
+        } else {
+          onSessionIdChange?.(undefined);
+        }
+      }
       flushPendingNewSessionSuggestionSubmit(token);
     });
   }, [
@@ -9258,11 +9803,12 @@ export function App({
         requestOpenSplitView();
       },
       openSessionOverview: () => {
+        if (!workspaceContextActive) return;
         closeMobileDrawer();
         openPanel('sessions');
       },
       openSessionDrawer,
-      createNewSession: () => createNewSession(),
+      createNewSession: () => createNewSession({ kind: 'global' }),
       createSideTask,
       respondToPendingPermission,
     }),
@@ -9274,6 +9820,7 @@ export function App({
       openSessionDrawer,
       requestOpenSplitView,
       respondToPendingPermission,
+      workspaceContextActive,
     ],
   );
   useEffect(() => {
@@ -9290,9 +9837,14 @@ export function App({
     creatingMissingSessionRef.current = true;
     setIsCreatingMissingSession(true);
     try {
-      const success = await createNewSession();
+      const success = await createNewSession({ kind: 'global' });
       if (success) {
-        onSessionIdChange?.(undefined);
+        const nextContext = pendingSessionContextRef.current;
+        if (nextContext?.kind === 'standalone') {
+          onSessionIdChange?.(undefined, undefined, undefined, nextContext);
+        } else {
+          onSessionIdChange?.(undefined);
+        }
       }
     } finally {
       creatingMissingSessionRef.current = false;
@@ -9302,8 +9854,21 @@ export function App({
 
   const sessionOpenInvocationRef = useRef(0);
   const loadSidebarSession = useCallback(
-    async (sessionId: string, workspaceCwd?: string) => {
+    async (
+      sessionId: string,
+      workspaceCwd?: string,
+      sessionContext?: DaemonProductSessionContext,
+    ) => {
       const invocation = ++sessionOpenInvocationRef.current;
+      const previousPendingContext = pendingSessionContextRef.current;
+      const targetContext =
+        sessionContext ??
+        (workspaceCwd
+          ? isKnownLiveWorkspaceCwd(workspaceCwd)
+            ? ({ kind: 'live' } as const)
+            : ({ kind: 'workspace', cwd: workspaceCwd } as const)
+          : undefined);
+      setPendingSessionContext(targetContext);
       composerFocusRequestRef.current += 1;
       setSidebarSwitchingSessionId(sessionId);
       closeMobileDrawer();
@@ -9313,19 +9878,180 @@ export function App({
       // Explicit navigation cancels any pending shrink-fold split restore.
       splitFoldedByShrinkRef.current = false;
       try {
-        await sessionActions.loadSession(sessionId, { workspaceCwd });
+        await sessionActions.loadSession(sessionId, {
+          workspaceCwd:
+            targetContext?.kind === 'workspace'
+              ? targetContext.cwd
+              : targetContext
+                ? undefined
+                : workspaceCwd,
+          sessionContext: targetContext,
+        });
         if (sessionOpenInvocationRef.current === invocation) {
           composerSourceVersionRef.current += 1;
+          setPendingSessionContext(undefined);
         }
       } catch (error) {
         if (sessionOpenInvocationRef.current === invocation) {
           setSidebarSwitchingSessionId(null);
+          setPendingSessionContext(previousPendingContext);
         }
         throw error;
       }
     },
-    [closeMobileDrawer, closePanel, sessionActions],
+    [
+      closeMobileDrawer,
+      closePanel,
+      isKnownLiveWorkspaceCwd,
+      sessionActions,
+      setPendingSessionContext,
+    ],
   );
+
+  const handleCheckStandaloneRecovery = useCallback(async () => {
+    const recovery = connectionRef.current.standaloneSession?.creationRecovery;
+    const sessionId = getStandaloneRecoverySessionId(recovery);
+    if (!sessionId || standaloneRecoveryResolution === 'checking') return;
+    const owner = sessionOwnerGuard.capture();
+    const isCurrent = () =>
+      owner.isCurrent() &&
+      connectionRef.current.sessionId === sessionId &&
+      getStandaloneRecoverySessionId(
+        connectionRef.current.standaloneSession?.creationRecovery,
+      ) === sessionId;
+    setStandaloneRecoveryResolution('checking');
+    try {
+      for (let attempt = 0; ; attempt += 1) {
+        let lookup: DaemonStandaloneSessionLookup;
+        try {
+          lookup = await workspace.client.getStandaloneSession(sessionId);
+        } catch (error) {
+          if (!isCurrent()) return;
+          if (isStandaloneSessionNotFoundError(error)) {
+            setStandaloneRecoveryResolution('absent');
+            return;
+          }
+          setStandaloneRecoveryResolution('unknown');
+          reportError(error, t('session.recoveryCheckFailed'));
+          return;
+        }
+        if (!isCurrent()) return;
+        if (!('state' in lookup)) {
+          if (lookup.isArchived) {
+            setStandaloneRecoveryResolution('archived');
+            return;
+          }
+          await loadSidebarSession(sessionId, undefined, {
+            kind: 'standalone',
+          });
+          return;
+        }
+        const delay = STANDALONE_RECOVERY_POLL_DELAYS_MS[attempt];
+        if (delay === undefined) {
+          setStandaloneRecoveryResolution('creating');
+          return;
+        }
+        await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
+        if (!isCurrent()) return;
+      }
+    } catch (error) {
+      if (!isCurrent()) return;
+      setStandaloneRecoveryResolution('unknown');
+      reportError(error, t('session.recoveryCheckFailed'));
+    }
+  }, [
+    loadSidebarSession,
+    reportError,
+    sessionOwnerGuard,
+    standaloneRecoveryResolution,
+    t,
+    workspace.client,
+  ]);
+
+  const handleUnarchiveRecoveredStandalone = useCallback(async () => {
+    const sessionId = getStandaloneRecoverySessionId(
+      connectionRef.current.standaloneSession?.creationRecovery,
+    );
+    if (!sessionId || standaloneRecoveryResolution === 'checking') return;
+    const owner = sessionOwnerGuard.capture();
+    setStandaloneRecoveryResolution('checking');
+    try {
+      const result = await workspace.client.unarchiveStandaloneSessions([
+        sessionId,
+      ]);
+      if (!owner.isCurrent() || connectionRef.current.sessionId !== sessionId) {
+        return;
+      }
+      if (
+        !result.unarchived.includes(sessionId) &&
+        !result.alreadyActive.includes(sessionId)
+      ) {
+        if (result.notFound.includes(sessionId)) {
+          setStandaloneRecoveryResolution('absent');
+          return;
+        }
+        const failure = result.errors.find(
+          (entry) => entry.sessionId === sessionId,
+        );
+        throw new Error(failure?.message ?? t('session.unarchiveFailed'));
+      }
+      await loadSidebarSession(sessionId, undefined, { kind: 'standalone' });
+    } catch (error) {
+      if (!owner.isCurrent()) return;
+      setStandaloneRecoveryResolution('archived');
+      reportError(error, t('session.unarchiveFailed'));
+    }
+  }, [
+    loadSidebarSession,
+    reportError,
+    sessionOwnerGuard,
+    standaloneRecoveryResolution,
+    t,
+    workspace.client,
+  ]);
+
+  const handleRetryStandaloneCreation = useCallback(() => {
+    void createNewSession({ kind: 'inherit' }, { allowRecoveryReset: true });
+  }, [createNewSession]);
+
+  const handleRepairStandaloneDirectory = useCallback(async () => {
+    const current = connectionRef.current;
+    const sessionId = current.sessionId;
+    if (
+      !sessionId ||
+      current.sessionContext?.kind !== 'standalone' ||
+      current.standaloneSession?.errorCode !== 'working_directory_missing' ||
+      standaloneRepairBusy
+    ) {
+      return;
+    }
+    const owner = sessionOwnerGuard.capture();
+    setStandaloneRepairBusy(true);
+    try {
+      await workspace.client.repairStandaloneSessionDirectory(sessionId);
+      if (!owner.isCurrent() || connectionRef.current.sessionId !== sessionId) {
+        return;
+      }
+      await sessionActions.reloadSession(new AbortController().signal);
+      if (owner.isCurrent() && connectionRef.current.sessionId === sessionId) {
+        pushToast('info', t('session.repairSucceeded'));
+      }
+    } catch (error) {
+      if (owner.isCurrent()) {
+        reportError(error, t('session.repairFailed'));
+      }
+    } finally {
+      if (owner.isCurrent()) setStandaloneRepairBusy(false);
+    }
+  }, [
+    pushToast,
+    reportError,
+    sessionActions,
+    sessionOwnerGuard,
+    standaloneRepairBusy,
+    t,
+    workspace.client,
+  ]);
 
   // Clicking a card in the Session Overview panel switches the current window
   // to that session. loadSidebarSession already closes the panel, so this just
@@ -9335,7 +10061,14 @@ export function App({
       // Explicit navigation cancels any pending shrink-fold split restore.
       splitFoldedByShrinkRef.current = false;
       setMainView('chat');
-      void loadSidebarSession(sessionId, workspaceCwd).catch(
+      const currentContext =
+        pendingSessionContextRef.current ??
+        connectionRef.current.sessionContext;
+      const inheritedContext =
+        workspaceCwd === undefined && currentContext?.kind !== 'workspace'
+          ? currentContext
+          : undefined;
+      void loadSidebarSession(sessionId, workspaceCwd, inheritedContext).catch(
         (error: unknown) => {
           reportError(error, 'Failed to open session');
         },
@@ -9902,6 +10635,23 @@ export function App({
     ) => {
       if (sessionWriteBlockedRef.current) return false;
       if (
+        !workspaceContextActive &&
+        ((images?.length ?? 0) > 0 || (files?.length ?? 0) > 0)
+      ) {
+        pushToast('warning', t('composerAdd.file.attachDisabled'));
+        return false;
+      }
+      if (
+        connectionRef.current.standaloneSession?.creationRecovery ||
+        connectionRef.current.standaloneSession?.errorCode ===
+          'working_directory_missing' ||
+        connectionRef.current.standaloneSession?.errorCode ===
+          'working_directory_compromised'
+      ) {
+        pushToast('warning', t('session.recoveryBlocksAction'));
+        return false;
+      }
+      if (
         unknownPromptAdmissionRef.current?.payloadAvailable &&
         unknownPromptAdmissionRef.current.sessionId ===
           connectionRef.current.sessionId
@@ -10080,6 +10830,18 @@ export function App({
         const match = text.match(SLASH_COMMAND_PATTERN);
         if (match) {
           const cmd = match[1];
+          const standaloneResumeSessionId =
+            cmd === 'resume' && effectiveSessionContext?.kind === 'standalone'
+              ? text.slice(match[0].length).trim()
+              : '';
+          if (
+            !workspaceContextActive &&
+            NON_WORKSPACE_BLOCKED_COMMANDS.has(cmd) &&
+            !standaloneResumeSessionId
+          ) {
+            pushToast('info', t('session.workspaceActionUnavailable'));
+            return true;
+          }
           if (hiddenCommands.has(normalizeHiddenCommand(cmd))) {
             if (commandBlocked) {
               return enqueueBlockedCommand(text);
@@ -10314,6 +11076,13 @@ export function App({
           }
           if (cmd === 'model') {
             const modelArg = text.slice(match[0].length).trim();
+            if (
+              !workspaceContextActive &&
+              /^(?:--fast|--voice|--vision)(?:\s|$)/.test(modelArg)
+            ) {
+              pushToast('info', t('session.workspaceActionUnavailable'));
+              return true;
+            }
             if (modelArg === '--fast') {
               setModelDialogMode('fast');
               return true;
@@ -10683,11 +11452,11 @@ export function App({
             return true;
           }
           if (cmd === 'clear') {
-            createNewSession();
+            void createNewSession({ kind: 'inherit' });
             return true;
           }
           if (cmd === 'new' || cmd === 'reset') {
-            createNewSession();
+            void createNewSession({ kind: 'inherit' });
             return true;
           }
           if (cmd === 'rename') {
@@ -10713,12 +11482,18 @@ export function App({
             const renamedSessionId = connectionRef.current.sessionId;
             const renamedWorkspaceCwd = connectionRef.current.workspaceCwd;
             const owner = sessionOwnerGuard.capture();
-            sessionActions
-              .renameSession(displayName)
+            const renamePromise =
+              effectiveSessionContext?.kind === 'standalone' && renamedSessionId
+                ? workspace.client.renameStandaloneSession(
+                    renamedSessionId,
+                    displayName,
+                  )
+                : sessionActions.renameSession(displayName);
+            renamePromise
               .then(() => {
                 if (renamedSessionId) {
                   reconcileCatalogRename(
-                    renamedWorkspaceCwd,
+                    workspaceContextActive ? renamedWorkspaceCwd : undefined,
                     renamedSessionId,
                     displayName,
                   );
@@ -10732,7 +11507,7 @@ export function App({
                 ]);
               })
               .catch((error: unknown) => {
-                if (renamedWorkspaceCwd) {
+                if (workspaceContextActive && renamedWorkspaceCwd) {
                   sessionCatalogController.invalidateWorkspace(
                     renamedWorkspaceCwd,
                   );
@@ -10745,7 +11520,13 @@ export function App({
           if (cmd === 'resume') {
             const sessionId = text.slice(match[0].length).trim();
             if (sessionId) {
-              loadSidebarSession(sessionId).catch((error: unknown) => {
+              loadSidebarSession(
+                sessionId,
+                undefined,
+                effectiveSessionContext?.kind === 'standalone'
+                  ? { kind: 'standalone' }
+                  : undefined,
+              ).catch((error: unknown) => {
                 reportError(error, 'Failed to load session');
               });
             } else {
@@ -10799,11 +11580,14 @@ export function App({
           }
           if (cmd === 'status' || cmd === 'about') {
             echoLocalCommandIfIdle(text);
-            Promise.all([
-              workspaceActions.loadPreflight().catch(() => null),
-              workspaceActions.loadProviders().catch(() => null),
-              workspaceActions.loadEnv().catch(() => null),
-            ])
+            (workspaceContextActive
+              ? Promise.all([
+                  workspaceActions.loadPreflight().catch(() => null),
+                  workspaceActions.loadProviders().catch(() => null),
+                  workspaceActions.loadEnv().catch(() => null),
+                ])
+              : Promise.resolve([null, null, null] as const)
+            )
               .then(([preflight, providers, env]) => {
                 const sys = collectSystemInfo(preflight, env);
 
@@ -10867,10 +11651,13 @@ export function App({
           if (cmd === 'bug') {
             const bugTitle = text.slice(match[0].length).trim();
             if (echoOrDeferLocalCommand(text, images)) return true;
-            Promise.all([
-              workspaceActions.loadPreflight().catch(() => null),
-              workspaceActions.loadEnv().catch(() => null),
-            ])
+            (workspaceContextActive
+              ? Promise.all([
+                  workspaceActions.loadPreflight().catch(() => null),
+                  workspaceActions.loadEnv().catch(() => null),
+                ])
+              : Promise.resolve([null, null] as const)
+            )
               .then(([preflight, env]) => {
                 const sys = collectSystemInfo(preflight, env);
                 const qwenCodeVersion =
@@ -11063,6 +11850,9 @@ export function App({
       showContextUsage,
       t,
       workspaceActions,
+      workspace.client,
+      workspaceContextActive,
+      effectiveSessionContext,
       updateFailedPrompt,
       updateUnknownPromptAdmission,
       isGoalGateBlocked,
@@ -11571,8 +12361,14 @@ export function App({
     };
   }, [resetEscapeState]);
 
+  const standaloneInteractionBlocked = Boolean(
+    standaloneCreationRecovery ||
+      standaloneDirectoryErrorCode === 'working_directory_missing' ||
+      standaloneDirectoryErrorCode === 'working_directory_compromised',
+  );
   const isDisabled =
     sessionWriteBlocked ||
+    standaloneInteractionBlocked ||
     shouldDisableComposerInput({
       pendingApproval: pendingApproval !== null,
       isPreparingPrompt,
@@ -11775,6 +12571,7 @@ export function App({
 
   const handleCloseAuthDialog = useCallback(() => {
     setShowAuthDialog(false);
+    if (!workspaceContextActive) return;
     // The provider install flow doesn't broadcast a settings change, so refresh
     // the model list on close to surface any newly added models. Log a failed
     // reload (leaves stale model data) rather than swallowing it.
@@ -11784,11 +12581,12 @@ export function App({
         err,
       );
     });
-  }, [reloadProviders]);
+  }, [reloadProviders, workspaceContextActive]);
 
   const handleFallbacksConfirm = useCallback(
     (baseIds: string[]) => {
       setShowFallbacksDialog(false);
+      if (!workspaceContextActive) return;
       setWorkspaceSetting(
         modelSettingScope,
         'modelFallbacks',
@@ -11822,11 +12620,13 @@ export function App({
       reportError,
       store,
       t,
+      workspaceContextActive,
     ],
   );
 
   const handleFastModelSelect = useCallback(
     (modelId: string) => {
+      if (!workspaceContextActive) return;
       if (
         streamingState !== 'idle' ||
         sessionHasActivePromptRef.current ||
@@ -11888,6 +12688,7 @@ export function App({
       modelSettingScope,
       sessionOwnerGuard,
       isGoalGateBlocked,
+      workspaceContextActive,
     ],
   );
 
@@ -11917,6 +12718,7 @@ export function App({
 
   const handleVisionModelSelect = useCallback(
     (modelId: string) => {
+      if (!workspaceContextActive) return;
       // Model IDs from the picker arrive in ACP format: `modelId(authType)`.
       // Core's resolveVisionModelSelection() expects `authType:modelId`.
       const encoded = encodeVisionModelForSetting(modelId);
@@ -11924,7 +12726,13 @@ export function App({
         (error: unknown) => reportError(error, t('model.setVision')),
       );
     },
-    [modelSettingScope, reportError, setWorkspaceSetting, t],
+    [
+      modelSettingScope,
+      reportError,
+      setWorkspaceSetting,
+      t,
+      workspaceContextActive,
+    ],
   );
 
   const modelHandlers: Record<ModelDialogMode, (id: string) => void> = {
@@ -11945,37 +12753,52 @@ export function App({
   }, [modelDialogMode, showFallbacksDialog, showAuthDialog]);
 
   const useWorkspaceSkillSnapshot =
+    workspaceContextActive &&
     loadedSkillsReady &&
     (!connection.sessionId ||
       connection.skills === undefined ||
       (loadedSkillsFallback?.sessionId === connection.sessionId &&
         loadedSkillsFallback.workspaceCwd === connection.workspaceCwd));
-  const composerSkills = useMemo(
-    () =>
-      useWorkspaceSkillSnapshot
-        ? loadedSkills
-        : availableSessionSkillInfos(
+  const composerSkills = useMemo(() => {
+    if (!workspaceContextActive) {
+      return pendingSessionContext === undefined && connection.sessionId
+        ? availableSessionSkillInfos(
             connection.skills ?? [],
             connection.commands ?? [],
-          ),
-    [
-      connection.commands,
-      connection.skills,
-      loadedSkills,
-      useWorkspaceSkillSnapshot,
-    ],
-  );
+          )
+        : [];
+    }
+    return useWorkspaceSkillSnapshot
+      ? loadedSkills
+      : availableSessionSkillInfos(
+          connection.skills ?? [],
+          connection.commands ?? [],
+        );
+  }, [
+    connection.commands,
+    connection.sessionId,
+    connection.skills,
+    loadedSkills,
+    pendingSessionContext,
+    useWorkspaceSkillSnapshot,
+    workspaceContextActive,
+  ]);
   const commands = useMemo(() => {
     const previousSkillNames = new Set(
       (connection.skills ?? []).map((skill) => skill.toLowerCase()),
     );
+    const connectionCommands =
+      !workspaceContextActive &&
+      (pendingSessionContext !== undefined || !connection.sessionId)
+        ? []
+        : (connection.commands ?? []);
     const retainedCommands = useWorkspaceSkillSnapshot
-      ? (connection.commands ?? []).filter(
+      ? connectionCommands.filter(
           (command) =>
             command.source !== 'skill' &&
             !previousSkillNames.has(command.name.toLowerCase()),
         )
-      : (connection.commands ?? []);
+      : connectionCommands;
     const refreshedSkillCommands = useWorkspaceSkillSnapshot
       ? loadedSkills.map((skill) => ({
           name: skill.name,
@@ -11995,6 +12818,11 @@ export function App({
       t,
     )
       .filter(
+        (command) =>
+          workspaceContextActive ||
+          !NON_WORKSPACE_BLOCKED_COMMANDS.has(command.name.toLowerCase()),
+      )
+      .filter(
         (command) => !hiddenCommands.has(normalizeHiddenCommand(command.name)),
       )
       .map((command) => {
@@ -12009,18 +12837,21 @@ export function App({
   }, [
     additionalSlashCommands,
     connection.commands,
+    connection.sessionId,
     connection.skills,
     hiddenCommands,
     loadedSkills,
+    pendingSessionContext,
     sideTasksAvailable,
     t,
     useWorkspaceSkillSnapshot,
+    workspaceContextActive,
   ]);
 
   const welcomeHeaderProps = useMemo(
     () => ({
       version: connection.capabilities?.qwenCodeVersion || '',
-      cwd: connection.workspaceCwd || '',
+      cwd: workspaceContextActive ? connection.workspaceCwd || '' : '',
       currentModel,
       currentMode,
       hideTips: hideTipsSetting?.values.effective === true,
@@ -12031,6 +12862,7 @@ export function App({
       currentModel,
       currentMode,
       hideTipsSetting?.values.effective,
+      workspaceContextActive,
     ],
   );
 
@@ -12394,7 +13226,7 @@ export function App({
               elevated={artifactPanelFullscreen}
             />
           )}
-          {showResumeDialog && (
+          {workspaceContextActive && showResumeDialog && (
             <DialogShell
               title={t('resume.title')}
               size="lg"
@@ -12411,7 +13243,8 @@ export function App({
               />
             </DialogShell>
           )}
-          {modelDialogMode && (
+          {modelDialogMode &&
+            (workspaceContextActive || modelDialogMode === 'main') && (
             <DialogShell
               title={t(MODE_TITLE_KEY[modelDialogMode])}
               size="lg"
@@ -12466,7 +13299,7 @@ export function App({
               <ToolsDialog />
             </DialogShell>
           )}
-          {gitDialog && (
+          {workspaceContextActive && gitDialog && (
             <GitDialog
               key={`${gitDialog.workspaceCwd}:${gitDialog.gitCwd ?? ''}:${gitDialog.view}`}
               workspaceCwd={gitDialog.workspaceCwd}
@@ -12502,7 +13335,7 @@ export function App({
               />
             </DialogShell>
           )}
-          {showMemoryDialog && (
+          {workspaceContextActive && showMemoryDialog && (
             <DialogShell
               title={t('memory.menu')}
               size="lg"
@@ -12571,7 +13404,7 @@ export function App({
               />
             </DialogShell>
           )}
-          {showFallbacksDialog && (
+          {workspaceContextActive && showFallbacksDialog && (
             <DialogShell
               title={t('settings.models.fallbacks.title')}
               size="md"
@@ -12586,7 +13419,7 @@ export function App({
               />
             </DialogShell>
           )}
-          {showDeleteDialog && (
+          {workspaceContextActive && showDeleteDialog && (
             <DialogShell
               title={t('delete.title')}
               size="lg"
@@ -12618,7 +13451,7 @@ export function App({
               />
             </DialogShell>
           )}
-          {showReleaseDialog && (
+          {workspaceContextActive && showReleaseDialog && (
             <DialogShell
               title={t('release.title')}
               size="lg"
@@ -12660,7 +13493,9 @@ export function App({
               />
             </DialogShell>
           )}
-          {!lockedWorkspaceCwd && showAddWorkspaceDialog && (
+          {workspaceContextActive &&
+            !lockedWorkspaceCwd &&
+            showAddWorkspaceDialog && (
             <AddWorkspaceDialog
               onClose={() => setShowAddWorkspaceDialog(false)}
               onAdd={handleAddWorkspace}
@@ -12773,26 +13608,49 @@ export function App({
                     closeMobileDrawer();
                     openPanel('sessions');
                   }}
-                  canOpenSessionsOverview
+                  canOpenSessionsOverview={workspaceContextActive}
                   onOpenSplitView={() => {
                     closeMobileDrawer();
                     openSplitView();
                   }}
-                  canOpenSplitView={isLargeScreen}
+                  canOpenSplitView={isLargeScreen && workspaceContextActive}
                   theme={selectedTheme}
                   onThemeChange={(theme) => {
                     handleThemeChange(theme);
-                    void setWorkspaceSetting(
-                      'workspace',
-                      THEME_SETTING_KEY,
-                      webShellThemeToSettingValue(theme),
-                    );
+                    if (workspaceContextActive) {
+                      void setWorkspaceSetting(
+                        'workspace',
+                        THEME_SETTING_KEY,
+                        webShellThemeToSettingValue(theme),
+                      );
+                    }
                   }}
-                  onNewSession={(workspaceCwd) => createNewSession(workspaceCwd)}
+                  onNewSession={(workspaceCwd) =>
+                    createNewSession(
+                      typeof workspaceCwd === 'string'
+                        ? { kind: 'workspace', cwd: workspaceCwd }
+                        : { kind: 'global' },
+                    )
+                  }
+                  globalNewSessionUsesStandalone={
+                    standaloneSessionsSupported && !lockedWorkspaceCwd
+                  }
                   onLoadSession={(sessionId, workspaceCwd) => {
                     setMainView('chat');
                     return loadSidebarSession(sessionId, workspaceCwd);
                   }}
+                  onLoadStandaloneSession={(sessionId) => {
+                    setMainView('chat');
+                    return loadSidebarSession(
+                      sessionId,
+                      undefined,
+                      { kind: 'standalone' },
+                    );
+                  }}
+                  onStandaloneNotice={(message) =>
+                    pushToast('info', message)
+                  }
+                  projectFeaturesEnabled={workspaceContextActive}
                   onSelectCurrentSession={() => {
                     closeMobileDrawer();
                     setMainView('chat');
@@ -12806,9 +13664,26 @@ export function App({
                   onMobileClose={closeMobileDrawer}
                   selectedWorkspaceCwd={selectedWorkspaceCwd}
                   onSelectWorkspace={(workspaceCwd) => {
+                    const targetWorkspaceCwd =
+                      workspaceCwd ??
+                      workspacesRef.current.find(
+                        (entry) =>
+                          entry.primary && entry.trusted !== false,
+                      )?.cwd;
+                    const sameTarget =
+                      workspaceCwd === selectedWorkspaceCwdRef.current;
+                    composerSourceVersionRef.current += 1;
+                    selectedWorkspaceCwdRef.current = workspaceCwd;
                     setSelectedWorkspaceCwd(workspaceCwd);
-                    // Same one-shot rule as the composer's own selector.
-                    setGitModeIntent({ mode: 'current' });
+                    setPendingSessionContext(
+                      targetWorkspaceCwd
+                        ? { kind: 'workspace', cwd: targetWorkspaceCwd }
+                        : undefined,
+                    );
+                    if (!sameTarget) {
+                      gitModeIntentRef.current = { mode: 'current' };
+                      setGitModeIntent({ mode: 'current' });
+                    }
                   }}
                   onOpenGitDiff={(workspaceCwd) =>
                     setGitDialog({
@@ -12847,15 +13722,26 @@ export function App({
                     closeMobileDrawer();
                     openPanel(target);
                   }}
-                  onNewWorktreeSession={(workspaceCwd) =>
+                  onNewWorktreeSession={(workspaceCwd) => {
                     // The intent travels with the draft it belongs to: set
                     // inside createNewSession's synchronous step, it is what
                     // the first prompt reads, and any later session start or
                     // workspace switch resets it like any other intent.
-                    createNewSession(workspaceCwd, {
-                      gitIntent: { mode: 'worktree' },
-                    })
-                  }
+                    const targetWorkspaceCwd =
+                      workspaceCwd ??
+                      lockedWorkspaceCwd ??
+                      workspacesRef.current.find(
+                        (entry) =>
+                          entry.primary && entry.trusted !== false,
+                      )?.cwd;
+                    if (!targetWorkspaceCwd) return false;
+                    return createNewSession(
+                      { kind: 'workspace', cwd: targetWorkspaceCwd },
+                      {
+                        gitIntent: { mode: 'worktree' },
+                      },
+                    );
+                  }}
                   branding={sidebarOptions.branding}
                   primaryNav={sidebarOptions.primaryNav}
                   showSessionSourceSwitch={
@@ -12913,7 +13799,9 @@ export function App({
                       {renderChatHeader({
                         sessionId: connection.sessionId,
                         sessionName: sessionDisplayName,
-                        workspaceCwd: connection.workspaceCwd,
+                        workspaceCwd: workspaceContextActive
+                          ? connection.workspaceCwd
+                          : undefined,
                         items: chatHeaderItems,
                         environmentPanelOpen: environmentPanelVisible,
                         rightPanelOpen: artifactPanelOpen,
@@ -12929,8 +13817,9 @@ export function App({
                                 ),
                             }
                           : {}),
-                        onOpenLocalControlSettings:
-                          handleOpenLocalControlSettings,
+                        onOpenLocalControlSettings: workspaceContextActive
+                          ? handleOpenLocalControlSettings
+                          : undefined,
                       })}
                     </div>
                   ) : (
@@ -12964,7 +13853,9 @@ export function App({
                           : undefined
                       }
                       onOpenLocalControlSettings={
-                        handleOpenLocalControlSettings
+                        workspaceContextActive
+                          ? handleOpenLocalControlSettings
+                          : undefined
                       }
                     />
                   )}
@@ -13032,7 +13923,8 @@ export function App({
                     </svg>
                   </button>
                 )}
-              {activePanel && (
+              {activePanel &&
+                (workspaceContextActive || activePanel === 'status') && (
                 <section
                   className={styles.panelHost}
                   role="region"
@@ -13078,14 +13970,22 @@ export function App({
                         // split restore.
                         splitFoldedByShrinkRef.current = false;
                         const current = connectionRef.current;
+                        const currentSessionId = current.sessionId;
                         const currentWorkspaceCwd =
                           current.workspaceCwd ||
                           lockedWorkspaceCwd ||
                           workspacesRef.current.find(
                             (entry) => entry.primary,
                           )?.cwd;
+                        if (!currentWorkspaceCwd) {
+                          closePanel();
+                          return;
+                        }
                         const openInvocation = sessionOpenInvocationRef.current;
-                        void createNewSession(currentWorkspaceCwd).then(
+                        void createNewSession({
+                          kind: 'workspace',
+                          cwd: currentWorkspaceCwd,
+                        }).then(
                           (created) => {
                             const latest = connectionRef.current;
                             const latestWorkspaceCwd =
@@ -13099,7 +13999,7 @@ export function App({
                               sessionOpenInvocationRef.current ===
                                 openInvocation &&
                               (latest.sessionId === undefined ||
-                                (latest.sessionId === current.sessionId &&
+                                (latest.sessionId === currentSessionId &&
                                   latestWorkspaceCwd === currentWorkspaceCwd))
                             ) {
                               onSessionIdChange?.(undefined);
@@ -13269,7 +14169,10 @@ export function App({
                             return;
                           }
                           const cleared = await createNewSession(
-                            removed.workspaceCwd || undefined,
+                            {
+                              kind: 'workspace',
+                              cwd: removed.workspaceCwd,
+                            },
                             {
                               keepView: true,
                               keepPanel: true,
@@ -13302,7 +14205,7 @@ export function App({
                   </div>
                 </section>
               )}
-              {mainView === 'scheduledTasks' && (
+              {workspaceContextActive && mainView === 'scheduledTasks' && (
                 <div
                   className={styles.fullPage}
                   data-testid="scheduled-tasks-page"
@@ -13365,7 +14268,16 @@ export function App({
                         // describe the task in natural language; the agent
                         // creates it via its cron_create tool. Focus is deferred
                         // so the new session's composer is mounted/visible first.
-                        void createNewSession().then((created) => {
+                        const targetCwd =
+                          lockedWorkspaceCwd ??
+                          selectedWorkspaceCwd ??
+                          ordinaryWorkspaces.find((entry) => entry.primary)
+                            ?.cwd;
+                        if (!targetCwd) return;
+                        void createNewSession({
+                          kind: 'workspace',
+                          cwd: targetCwd,
+                        }).then((created) => {
                           // If the new session couldn't be started,
                           // createNewSession already surfaced the error — do NOT
                           // prime the (still-current) session with the task
@@ -13396,7 +14308,7 @@ export function App({
                   </div>
                 </div>
               )}
-              {mainView === 'goals' && (
+              {workspaceContextActive && mainView === 'goals' && (
                 <div className={styles.fullPage} data-testid="goals-page">
                   <div className={styles.fullPageHeader}>
                     <button
@@ -13433,9 +14345,16 @@ export function App({
                           connectionRef.current.sessionId === stranded;
                         if (!canReuseStranded) {
                           strandedGoalSessionRef.current = undefined;
-                          const created = await createNewSession(undefined, {
-                            keepView: true,
-                          });
+                          const targetCwd =
+                            lockedWorkspaceCwd ??
+                            selectedWorkspaceCwd ??
+                            ordinaryWorkspaces.find((entry) => entry.primary)
+                              ?.cwd;
+                          if (!targetCwd) return false;
+                          const created = await createNewSession(
+                            { kind: 'workspace', cwd: targetCwd },
+                            { keepView: true },
+                          );
                           if (!created) return false;
                         }
                         const allocationOwner = sessionOwnerGuard.capture();
@@ -13505,7 +14424,7 @@ export function App({
                   </div>
                 </div>
               )}
-              {mainView === 'split' && (
+              {workspaceContextActive && mainView === 'split' && (
                 <div className={styles.fullPage} data-testid="split-view-page">
                   {/* The outer session's approval overlay is suppressed under the
                       split (it would own ghost keyboard shortcuts). If that
@@ -13917,6 +14836,125 @@ export function App({
                             : styles.composer
                         }
                       >
+                        {standaloneCreationRecovery && (
+                          <div
+                            className={styles.composerActionTip}
+                            role="alert"
+                            data-testid="standalone-creation-recovery"
+                          >
+                            <span
+                              className={styles.composerActionTipIcon}
+                              aria-hidden="true"
+                            >
+                              !
+                            </span>
+                            <span className={styles.composerActionTipText}>
+                              {standaloneRecoveryResolution === 'checking'
+                                ? t('session.recoveryChecking')
+                                : standaloneRecoveryResolution === 'creating'
+                                  ? t('session.recoveryStillCreating')
+                                  : standaloneRecoveryResolution === 'absent'
+                                    ? t('session.recoveryAbsent')
+                                    : standaloneRecoveryResolution ===
+                                        'unknown'
+                                      ? t('session.recoveryUnknown')
+                                      : standaloneRecoveryResolution ===
+                                          'archived'
+                                        ? t('session.recoveryArchived')
+                                        : t('session.recoveryPending')}
+                            </span>
+                            <div className={styles.composerActionTipActions}>
+                              {standaloneRecoveryResolution === 'archived' ? (
+                                <button
+                                  type="button"
+                                  className={`${styles.composerActionTipButton} ${styles.composerActionTipButtonPrimary}`}
+                                  onClick={() =>
+                                    void handleUnarchiveRecoveredStandalone()
+                                  }
+                                >
+                                  {t('session.unarchive')}
+                                </button>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className={`${styles.composerActionTipButton} ${styles.composerActionTipButtonPrimary}`}
+                                  disabled={
+                                    standaloneRecoveryResolution === 'checking'
+                                  }
+                                  onClick={() =>
+                                    void handleCheckStandaloneRecovery()
+                                  }
+                                >
+                                  {t('session.checkStatus')}
+                                </button>
+                              )}
+                              {standaloneRecoveryResolution === 'absent' && (
+                                <button
+                                  type="button"
+                                  className={styles.composerActionTipButton}
+                                  onClick={handleRetryStandaloneCreation}
+                                >
+                                  {t('session.retryCreation')}
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        )}
+                        {standaloneWorkingDirectory?.state === 'recreated' && (
+                          <div
+                            className={styles.composerActionTip}
+                            role="status"
+                            data-testid="standalone-directory-recreated"
+                          >
+                            <span
+                              className={styles.composerActionTipIcon}
+                              aria-hidden="true"
+                            >
+                              !
+                            </span>
+                            <span className={styles.composerActionTipText}>
+                              {t('session.directoryRecreated')}
+                            </span>
+                          </div>
+                        )}
+                        {standaloneDirectoryErrorCode ===
+                          'working_directory_missing' && (
+                          <div
+                            className={styles.composerActionTip}
+                            role="alert"
+                            data-testid="standalone-directory-missing"
+                          >
+                            <span className={styles.composerActionTipText}>
+                              {t('session.directoryMissing')}
+                            </span>
+                            <div className={styles.composerActionTipActions}>
+                              <button
+                                type="button"
+                                className={`${styles.composerActionTipButton} ${styles.composerActionTipButtonPrimary}`}
+                                disabled={standaloneRepairBusy}
+                                onClick={() =>
+                                  void handleRepairStandaloneDirectory()
+                                }
+                              >
+                                {standaloneRepairBusy
+                                  ? t('session.repairing')
+                                  : t('session.repair')}
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                        {standaloneDirectoryErrorCode ===
+                          'working_directory_compromised' && (
+                          <div
+                            className={styles.composerActionTip}
+                            role="alert"
+                            data-testid="standalone-directory-compromised"
+                          >
+                            <span className={styles.composerActionTipText}>
+                              {t('session.directoryCompromised')}
+                            </span>
+                          </div>
+                        )}
                         {streamingState !== 'idle' ||
                         sessionHasActivePrompt ? (
                           suppressFailedPromptRetryStreaming ? null : (
@@ -14101,7 +15139,9 @@ export function App({
                           skills={composerSkills}
                           slashCommandCategoryOrder={slashCommandCategoryOrder}
                           autoSubmitSlashCommands={autoSubmitSlashCommands}
-                          builtinAtProviders={builtinAtProviders}
+                          builtinAtProviders={
+                            workspaceContextActive ? builtinAtProviders : false
+                          }
                           atProviders={atProviders}
                           composerTagIcons={composerTagIcons}
                           voiceTarget={
@@ -14117,12 +15157,26 @@ export function App({
                           currentMode={currentMode}
                           sessionWorkflowEnabled={sessionWorkflowEnabled}
                           currentModel={currentModel}
-                          gitBranch={activeGitBranch}
-                          gitWorktree={Boolean(sessionWorktree)}
-                          gitCwd={sessionWorktree?.path}
+                          gitBranch={
+                            workspaceContextActive
+                              ? activeGitBranch
+                              : undefined
+                          }
+                          gitWorktree={
+                            workspaceContextActive && Boolean(sessionWorktree)
+                          }
+                          gitCwd={
+                            workspaceContextActive
+                              ? sessionWorktree?.path
+                              : undefined
+                          }
                           gitModeIntent={gitModeEligible ? gitModeIntent : undefined}
                           onGitModeIntentChange={gitModeEligible ? setGitModeIntent : undefined}
-                          gitStatus={selectedWorkspaceGitStatus}
+                          gitStatus={
+                            workspaceContextActive
+                              ? selectedWorkspaceGitStatus
+                              : undefined
+                          }
                           onOpenGitDiff={
                             gitDiffWorkspaceCwd
                               ? handleOpenGitDiff
@@ -14154,44 +15208,68 @@ export function App({
                                 ? handleWelcomeReasoningEffort
                                 : undefined
                           }
-                          workspaces={composerWorkspaces}
+                          workspaces={
+                            workspaceContextActive
+                              ? composerWorkspaces
+                              : undefined
+                          }
                           selectedWorkspaceCwd={
-                            connection.sessionId
-                              ? ordinaryWorkspaces.find(
-                                  (entry) =>
-                                    entry.cwd === connection.workspaceCwd &&
-                                    !entry.primary,
-                                )?.cwd
-                              : selectedWorkspaceCwd
+                            workspaceContextActive
+                              ? connection.sessionId
+                                ? ordinaryWorkspaces.find(
+                                    (entry) =>
+                                      entry.cwd === connection.workspaceCwd &&
+                                      !entry.primary,
+                                  )?.cwd
+                                : selectedWorkspaceCwd
+                              : undefined
                           }
-                          workspaceSelectionDisabled={false}
+                          workspaceSelectionDisabled={!workspaceContextActive}
                           atWorkspaceCwd={
-                            ordinaryWorkspaces.find(
-                              (entry) => entry.cwd === lockedWorkspaceCwd,
-                            )?.cwd ??
-                            (connection.sessionId
-                              ? isKnownLiveWorkspaceCwd(
-                                  connection.workspaceCwd,
-                                )
-                                ? undefined
-                                : connection.workspaceCwd
-                              : (selectedWorkspaceCwd ??
-                                ordinaryWorkspaces.find(
-                                  (entry) => entry.primary,
-                                )?.cwd))
+                            workspaceContextActive
+                              ? (ordinaryWorkspaces.find(
+                                  (entry) => entry.cwd === lockedWorkspaceCwd,
+                                )?.cwd ??
+                                (connection.sessionId
+                                  ? connection.workspaceCwd
+                                  : (selectedWorkspaceCwd ??
+                                    ordinaryWorkspaces.find(
+                                      (entry) => entry.primary,
+                                    )?.cwd)))
+                              : undefined
                           }
-                          onSelectWorkspace={handleSelectComposerWorkspace}
+                          composerScopeKey={
+                            effectiveSessionContext?.kind === 'standalone'
+                              ? 'standalone'
+                              : effectiveSessionContext?.kind === 'live'
+                                ? 'live'
+                                : undefined
+                          }
+                          workspaceFeaturesEnabled={workspaceContextActive}
+                          onSelectWorkspace={
+                            workspaceContextActive
+                              ? handleSelectComposerWorkspace
+                              : undefined
+                          }
                           scratchWorkspaceSupported={
+                            workspaceContextActive &&
                             scratchWorkspaceRegistrationSupported
                           }
                           existingFolderWorkspaceSupported={
+                            workspaceContextActive &&
                             dynamicWorkspaceRegistrationSupported
                           }
                           workspaceMutationBusy={workspaceMutationBusy}
                           onCreateScratchWorkspace={
-                            handleCreateComposerScratchWorkspace
+                            workspaceContextActive
+                              ? handleCreateComposerScratchWorkspace
+                              : undefined
                           }
-                          onOpenExistingWorkspace={handleOpenExistingWorkspace}
+                          onOpenExistingWorkspace={
+                            workspaceContextActive
+                              ? handleOpenExistingWorkspace
+                              : undefined
+                          }
                           onChatWidthModeChange={handleChatWidthModeChange}
                           sessionId={connection.sessionId}
                           sessionName={sessionDisplayName}
@@ -14297,7 +15375,9 @@ export function App({
                               ? backgroundTasks
                               : []
                           }
-                          hideSettings={hideSettings}
+                          hideSettings={
+                            hideSettings || !workspaceContextActive
+                          }
                           onToggleShortcuts={handleToggleShortcuts}
                           compact={true}
                         />
@@ -14325,13 +15405,23 @@ export function App({
               <EnvironmentPanel
                 floating={!environmentPanelFits}
                 hidden={!environmentPanelVisible || artifactPanelFullscreen}
-                workspaceCwd={sessionWorktree?.path ?? activeWorkspaceCwd}
-                gitWorkspaceCwd={
-                  connection.sessionId ? gitDiffWorkspaceCwd : undefined
+                workspaceCwd={
+                  workspaceContextActive
+                    ? (sessionWorktree?.path ?? activeWorkspaceCwd)
+                    : undefined
                 }
-                gitCwd={sessionWorktree?.path}
-                branch={activeGitBranch}
-                gitStatus={selectedWorkspaceGitStatus}
+                gitWorkspaceCwd={
+                  workspaceContextActive && connection.sessionId
+                    ? gitDiffWorkspaceCwd
+                    : undefined
+                }
+                gitCwd={
+                  workspaceContextActive ? sessionWorktree?.path : undefined
+                }
+                branch={workspaceContextActive ? activeGitBranch : undefined}
+                gitStatus={
+                  workspaceContextActive ? selectedWorkspaceGitStatus : undefined
+                }
                 tasks={sessionTasks}
                 agentTasks={environmentAgentTasks}
                 items={environmentPanelItems}

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2493,6 +2493,13 @@ export function App({
     () => workspaces.filter((entry) => entry.kind !== 'live'),
     [workspaces],
   );
+  const trustedPrimaryWorkspaceCwd = useMemo(
+    () =>
+      ordinaryWorkspaces.find(
+        (entry) => entry.primary && entry.trusted !== false,
+      )?.cwd,
+    [ordinaryWorkspaces],
+  );
   const isKnownLiveWorkspaceCwd = useCallback(
     (cwd: string | undefined) =>
       cwd !== undefined &&
@@ -2627,6 +2634,15 @@ export function App({
   >(initialSelectedWorkspaceCwd);
   const selectedWorkspaceCwdRef = useRef(selectedWorkspaceCwd);
   selectedWorkspaceCwdRef.current = selectedWorkspaceCwd;
+  const resolveWorkspaceMaintenanceTargetCwd = useCallback(() => {
+    const preferredCwd = lockedWorkspaceCwd ?? selectedWorkspaceCwdRef.current;
+    if (preferredCwd) {
+      return ordinaryWorkspaces.find(
+        (entry) => entry.cwd === preferredCwd && entry.trusted !== false,
+      )?.cwd;
+    }
+    return trustedPrimaryWorkspaceCwd;
+  }, [lockedWorkspaceCwd, ordinaryWorkspaces, trustedPrimaryWorkspaceCwd]);
   const [pendingSessionContext, setPendingSessionContextState] = useState<
     DaemonProductSessionContext | undefined
   >(undefined);
@@ -2642,22 +2658,34 @@ export function App({
     connection.workspaceCwd ||
     lockedWorkspaceCwd ||
     selectedWorkspaceCwd ||
-    ordinaryWorkspaces.find((entry) => entry.primary)?.cwd ||
+    trustedPrimaryWorkspaceCwd ||
     workspace.capabilities?.workspaceCwd;
-  const effectiveSessionContext = useMemo(
+  const settledSessionContext = useMemo<
+    DaemonProductSessionContext | undefined
+  >(
     () =>
-      pendingSessionContext ??
       connection.sessionContext ??
-      (legacyWorkspaceContextCwd
-        ? { kind: 'workspace' as const, cwd: legacyWorkspaceContextCwd }
-        : undefined),
+      (isKnownLiveWorkspaceCwd(connection.workspaceCwd)
+        ? { kind: 'live' }
+        : legacyWorkspaceContextCwd
+          ? { kind: 'workspace', cwd: legacyWorkspaceContextCwd }
+          : undefined),
     [
       connection.sessionContext,
+      connection.workspaceCwd,
+      isKnownLiveWorkspaceCwd,
       legacyWorkspaceContextCwd,
-      pendingSessionContext,
     ],
   );
+  const effectiveSessionContext = useMemo(
+    () => pendingSessionContext ?? settledSessionContext,
+    [pendingSessionContext, settledSessionContext],
+  );
   const workspaceContextActive = effectiveSessionContext?.kind === 'workspace';
+  const pendingNonWorkspaceNavigation =
+    pendingSessionContext !== undefined &&
+    pendingSessionContext.kind !== 'workspace' &&
+    settledSessionContext?.kind === 'workspace';
   const effectiveStandaloneSession =
     effectiveSessionContext?.kind === 'standalone'
       ? connection.standaloneSession
@@ -2888,17 +2916,13 @@ export function App({
     }
     return connection.sessionId
       ? connection.workspaceCwd
-      : (lockedWorkspaceCwd ??
-          selectedWorkspaceCwd ??
-          ordinaryWorkspaces.find((entry) => entry.primary)?.cwd);
+      : resolveWorkspaceMaintenanceTargetCwd();
   }, [
     connection.sessionId,
     connection.workspaceCwd,
     connection.sessionContext,
-    lockedWorkspaceCwd,
-    selectedWorkspaceCwd,
-    ordinaryWorkspaces,
     pendingSessionContext,
+    resolveWorkspaceMaintenanceTargetCwd,
     workspaceContextActive,
   ]);
   // Worktree sessions query git status with the worktree path (?cwd=
@@ -5914,6 +5938,7 @@ export function App({
       return;
     }
     if (!workspaceContextActive) {
+      if (pendingNonWorkspaceNavigation) return;
       if (
         effectiveSessionContext === undefined &&
         !workspaceCapabilitiesReady
@@ -5945,6 +5970,7 @@ export function App({
     externalSplitControlled,
     externalSplitSignature,
     effectiveSessionContext,
+    pendingNonWorkspaceNavigation,
     sanitizeSplitSessionIds,
     workspaceCapabilitiesReady,
     workspaceContextActive,
@@ -5972,6 +5998,7 @@ export function App({
   // close) doesn't re-fire on every App re-render. Back from the split returns
   // to the Session Overview — the hub the split is launched from.
   const handleSplitExit = useCallback(() => {
+    splitClassificationGenerationRef.current += 1;
     notifyControlledSplitClose();
     // The user left the split of their own accord, so a refresh must not bring
     // it back. (A shrink-fold is transient and deliberately doesn't clear it.)
@@ -6630,7 +6657,7 @@ export function App({
         connectionRef.current.sessionContext;
       const availableWorkspaces = workspacesRef.current;
       const primaryWorkspaceCwd = availableWorkspaces.find(
-        (entry) => entry.primary,
+        (entry) => entry.primary && entry.trusted !== false,
       )?.cwd;
       const requestedWorkspaceCwd = selectedWorkspaceCwdRef.current;
       const acceptedWorkspaceCwd = requestedWorkspaceCwd
@@ -6646,7 +6673,11 @@ export function App({
                 entry.cwd === requestedSessionContext.cwd &&
                 entry.trusted !== false,
             )?.cwd ??
-            (requestedSessionContext.cwd === connectionRef.current.workspaceCwd
+            (requestedSessionContext.cwd ===
+              connectionRef.current.workspaceCwd &&
+            availableWorkspaces.find(
+              (entry) => entry.cwd === requestedSessionContext.cwd,
+            )?.trusted !== false
               ? requestedSessionContext.cwd
               : undefined))
           : requestedSessionContext?.kind === 'standalone'
@@ -10095,6 +10126,7 @@ export function App({
   // returns to the chat view and reports load failures.
   const handleOpenSessionFromOverview = useCallback(
     (sessionId: string, workspaceCwd?: string) => {
+      splitClassificationGenerationRef.current += 1;
       // Explicit navigation cancels any pending shrink-fold split restore.
       splitFoldedByShrinkRef.current = false;
       setMainView('chat');
@@ -14307,10 +14339,7 @@ export function App({
                         // creates it via its cron_create tool. Focus is deferred
                         // so the new session's composer is mounted/visible first.
                         const targetCwd =
-                          lockedWorkspaceCwd ??
-                          selectedWorkspaceCwd ??
-                          ordinaryWorkspaces.find((entry) => entry.primary)
-                            ?.cwd;
+                          resolveWorkspaceMaintenanceTargetCwd();
                         if (!targetCwd) return;
                         void createNewSession({
                           kind: 'workspace',
@@ -14384,10 +14413,7 @@ export function App({
                         if (!canReuseStranded) {
                           strandedGoalSessionRef.current = undefined;
                           const targetCwd =
-                            lockedWorkspaceCwd ??
-                            selectedWorkspaceCwd ??
-                            ordinaryWorkspaces.find((entry) => entry.primary)
-                              ?.cwd;
+                            resolveWorkspaceMaintenanceTargetCwd();
                           if (!targetCwd) return false;
                           const created = await createNewSession(
                             { kind: 'workspace', cwd: targetCwd },
@@ -15270,10 +15296,7 @@ export function App({
                                 )?.cwd ??
                                 (connection.sessionId
                                   ? connection.workspaceCwd
-                                  : (selectedWorkspaceCwd ??
-                                    ordinaryWorkspaces.find(
-                                      (entry) => entry.primary,
-                                    )?.cwd)))
+                                  : resolveWorkspaceMaintenanceTargetCwd()))
                               : undefined
                           }
                           composerScopeKey={

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -5737,7 +5737,10 @@ export function App({
       setSettingsInitialCategory(undefined);
     }
   }, [activePanel]);
-  const closePanel = useCallback(() => setActivePanel(null), []);
+  const closePanel = useCallback(() => {
+    splitClassificationGenerationRef.current += 1;
+    setActivePanel(null);
+  }, []);
   useEffect(() => {
     if (workspaceContextActive) return;
     splitClassificationGenerationRef.current += 1;
@@ -5801,6 +5804,7 @@ export function App({
         | 'agents'
         | 'channels',
     ) => {
+      splitClassificationGenerationRef.current += 1;
       setMainView('chat');
       setActivePanel(panel);
     },
@@ -5818,15 +5822,18 @@ export function App({
     });
   }, [workspaceActions]);
   const openScheduledTasks = useCallback(() => {
+    splitClassificationGenerationRef.current += 1;
     setActivePanel(null);
     setMainView('scheduledTasks');
   }, []);
   const openGoals = useCallback(() => {
+    splitClassificationGenerationRef.current += 1;
     setActivePanel(null);
     setMainView('goals');
   }, []);
   const openSessionDrawer = useCallback(() => {
     if (!sidebarOptions.enabled) return;
+    splitClassificationGenerationRef.current += 1;
     setActivePanel(null);
     setMainView('chat');
     setForceMobileDrawer(true);
@@ -9235,6 +9242,7 @@ export function App({
         pushToast('warning', t('session.recoveryBlocksAction'));
         return false;
       }
+      splitClassificationGenerationRef.current += 1;
       const invocation = ++sessionOpenInvocationRef.current;
       let nextContext: DaemonProductSessionContext | undefined;
       let availableWorkspaces = workspacesRef.current;
@@ -9403,6 +9411,7 @@ export function App({
           );
           if (!target?.trusted) return;
         }
+        splitClassificationGenerationRef.current += 1;
         if (connectionRef.current.sessionId) {
           if (connectionRef.current.workspaceCwd === targetCwd) return;
           if (!targetCwd) return;
@@ -9905,6 +9914,7 @@ export function App({
       workspaceCwd?: string,
       sessionContext?: DaemonProductSessionContext,
     ) => {
+      splitClassificationGenerationRef.current += 1;
       const invocation = ++sessionOpenInvocationRef.current;
       const previousPendingContext = pendingSessionContextRef.current;
       const targetContext =
@@ -13733,6 +13743,7 @@ export function App({
                   onMobileClose={closeMobileDrawer}
                   selectedWorkspaceCwd={selectedWorkspaceCwd}
                   onSelectWorkspace={(workspaceCwd) => {
+                    splitClassificationGenerationRef.current += 1;
                     const targetWorkspaceCwd =
                       workspaceCwd ??
                       workspacesRef.current.find(

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -2719,7 +2719,13 @@ export function App({
   }, [gitModeIntent]);
 
   useEffect(() => {
-    if (!workspace.capabilities || !selectedWorkspaceCwd) return;
+    if (
+      !workspace.capabilities ||
+      !selectedWorkspaceCwd ||
+      !workspaceContextActive
+    ) {
+      return;
+    }
     const selected = ordinaryWorkspaces.find(
       (entry) => entry.cwd === selectedWorkspaceCwd,
     );
@@ -2740,6 +2746,7 @@ export function App({
     selectedWorkspaceCwd,
     setPendingSessionContext,
     workspace.capabilities,
+    workspaceContextActive,
   ]);
   // The workspace the chip's status was last fetched for. On a workspace switch
   // we clear the status immediately so the chip never shows the previous repo's
@@ -9265,8 +9272,9 @@ export function App({
           setGitModeIntent({ mode: 'current' });
           try {
             await workspace.client.startLive('new');
-            return true;
+            return sessionOpenInvocationRef.current === invocation;
           } catch (error) {
+            if (sessionOpenInvocationRef.current !== invocation) return false;
             reportError(error, 'Failed to start a new Live chat');
             return false;
           }
@@ -9740,6 +9748,7 @@ export function App({
     const token = newSessionSuggestionSubmitTokenRef.current + 1;
     newSessionSuggestionSubmitTokenRef.current = token;
     const mode =
+      !lockedWorkspaceCwd &&
       (pendingSessionContextRef.current ?? connectionRef.current.sessionContext)
         ?.kind === 'live'
         ? 'live'
@@ -9779,6 +9788,7 @@ export function App({
     dismissNewSessionSuggestion,
     flushPendingNewSessionSuggestionSubmit,
     isStartingNewSessionSuggestion,
+    lockedWorkspaceCwd,
     newSessionSuggestion,
     onSessionIdChange,
     suppressNewSessionSuggestion,

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -396,6 +396,8 @@ interface ChatEditorRenderProps {
   onShowContextUsage?: () => void;
   disabled?: boolean;
   atWorkspaceCwd?: string;
+  composerScopeKey?: string;
+  workspaceFeaturesEnabled?: boolean;
   sessionId?: string;
   customization?: WebShellCustomization;
   builtinAtProviders?: WebShellCustomization['builtinAtProviders'];
@@ -1172,6 +1174,24 @@ describe('ChatEditor git branch toolbar integration', () => {
 });
 
 describe('ChatEditor workspace toolbar integration', () => {
+  it('keeps legacy history fallback for Live but isolates standalone drafts', () => {
+    renderChatEditor({
+      composerScopeKey: 'live',
+      workspaceFeaturesEnabled: false,
+    });
+    expect(
+      latestComposerCoreOptions.current?.disableLegacyHistoryFallback,
+    ).toBe(false);
+
+    renderChatEditor({
+      composerScopeKey: 'standalone',
+      workspaceFeaturesEnabled: false,
+    });
+    expect(
+      latestComposerCoreOptions.current?.disableLegacyHistoryFallback,
+    ).toBe(true);
+  });
+
   it('shows the workspace indicator when the workspace action is visible', () => {
     const container = renderChatEditor({
       workspaceName: 'api',

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -1706,7 +1706,7 @@ export const ChatEditor = memo(
       atProviders: resolvedAtProviders,
       atWorkspaceCwd,
       composerScopeKey,
-      disableLegacyHistoryFallback: !workspaceFeaturesEnabled,
+      disableLegacyHistoryFallback: composerScopeKey === 'standalone',
       attachmentsEnabled: workspaceFeaturesEnabled,
       workspaceFeaturesEnabled,
       composerTagIcons,

--- a/packages/web-shell/client/components/ChatEditor.tsx
+++ b/packages/web-shell/client/components/ChatEditor.tsx
@@ -260,6 +260,8 @@ interface ChatEditorProps {
   onCreateScratchWorkspace?: () => void;
   onOpenExistingWorkspace?: () => void;
   atWorkspaceCwd?: string;
+  composerScopeKey?: string;
+  workspaceFeaturesEnabled?: boolean;
   onChatWidthModeChange?: (mode: '1000' | 'wide') => void;
   onFocusFooter?: () => boolean;
   dialogOpen?: boolean;
@@ -1525,6 +1527,8 @@ export const ChatEditor = memo(
       onCreateScratchWorkspace,
       onOpenExistingWorkspace,
       atWorkspaceCwd,
+      composerScopeKey,
+      workspaceFeaturesEnabled = true,
       onChatWidthModeChange,
       onFocusFooter,
       dialogOpen = false,
@@ -1579,7 +1583,7 @@ export const ChatEditor = memo(
     // item can be capability-gated (hidden on daemons without the feature).
     const uploadWorkspace = useOptionalWorkspace();
     const uploadTarget = useMemo(() => {
-      if (!uploadWorkspace) return undefined;
+      if (!uploadWorkspace || !workspaceFeaturesEnabled) return undefined;
       // The host prop can force-disable upload even when the daemon advertises
       // the capability; it does NOT bypass the capability check. Both must
       // allow: `fileUploadEnabled === false` short-circuits, otherwise the
@@ -1607,7 +1611,12 @@ export const ChatEditor = memo(
       if (primaryMatches.length !== 1 || primaryMatches[0].trusted !== true)
         return undefined;
       return { client: uploadWorkspace.client, targetKey: '<primary>' };
-    }, [uploadWorkspace, atWorkspaceCwd, fileUploadEnabled]);
+    }, [
+      uploadWorkspace,
+      atWorkspaceCwd,
+      fileUploadEnabled,
+      workspaceFeaturesEnabled,
+    ]);
     const uploadEnabled = uploadTarget !== undefined;
     const maxUploadBytes =
       uploadWorkspace?.capabilities?.limits?.maxWorkspaceFileUploadBytes ??
@@ -1675,7 +1684,7 @@ export const ChatEditor = memo(
       cycleModeOnTab,
       onToggleShortcuts,
       disabled,
-      fileDragEnabled: fileUploadEnabled !== false,
+      fileDragEnabled: workspaceFeaturesEnabled && fileUploadEnabled !== false,
       placeholderText,
       commands,
       skills,
@@ -1696,6 +1705,10 @@ export const ChatEditor = memo(
       builtinAtProviders: resolvedBuiltinAtProviders,
       atProviders: resolvedAtProviders,
       atWorkspaceCwd,
+      composerScopeKey,
+      disableLegacyHistoryFallback: !workspaceFeaturesEnabled,
+      attachmentsEnabled: workspaceFeaturesEnabled,
+      workspaceFeaturesEnabled,
       composerTagIcons,
       parseUserMessageContent,
       renderComposerTag,
@@ -3103,7 +3116,9 @@ export const ChatEditor = memo(
                         ),
                         Boolean(skills?.length),
                       ])}
-                      addFileAvailable={fileUploadEnabled !== false}
+                      addFileAvailable={
+                        workspaceFeaturesEnabled && fileUploadEnabled !== false
+                      }
                       uploadAvailable={uploadEnabled}
                       onAddFiles={handleAddMenuFiles}
                       onFilePickerCancel={focusComposer}

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -518,6 +518,163 @@ describe('WorkspaceSessionProvider targets', () => {
     expect(mocks.providerMounts).toBe(1);
   });
 
+  it('accepts normalized daemon ids when unarchiving a mixed-case deep link', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+      client: {
+        getStandaloneSession: mocks.getStandaloneSession,
+        unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+      },
+    };
+    mocks.getStandaloneSession.mockResolvedValue({
+      sessionId: 'standalone-a',
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: true,
+    });
+    mocks.unarchiveStandaloneSessions.mockResolvedValue({
+      unarchived: ['standalone-a'],
+      alreadyActive: [],
+      resolvedConflicts: [],
+      notFound: [],
+      errors: [],
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="Standalone-A"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('This conversation is archived'),
+    );
+    const unarchive = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Unarchive',
+    );
+
+    await act(async () => unarchive?.click());
+
+    expect(mocks.unarchiveStandaloneSessions).toHaveBeenCalledWith([
+      'Standalone-A',
+    ]);
+    expect(mocks.providerMounts).toBe(1);
+  });
+
+  it('ignores a stale unarchive result after navigating to another standalone session', async () => {
+    let resolveUnarchive!: (value: {
+      unarchived: string[];
+      alreadyActive: string[];
+      resolvedConflicts: string[];
+      notFound: string[];
+      errors: Array<{ sessionId: string; message: string }>;
+    }) => void;
+    let resolveNextLookup!: (value: {
+      sessionId: string;
+      sourceType: 'standalone';
+      context: { kind: 'standalone' };
+      isArchived: boolean;
+    }) => void;
+    const unarchivePromise = new Promise<
+      Parameters<typeof resolveUnarchive>[0]
+    >((resolve) => {
+      resolveUnarchive = resolve;
+    });
+    const nextLookupPromise = new Promise<
+      Parameters<typeof resolveNextLookup>[0]
+    >((resolve) => {
+      resolveNextLookup = resolve;
+    });
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+      client: {
+        getStandaloneSession: mocks.getStandaloneSession,
+        unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+      },
+    };
+    mocks.getStandaloneSession.mockImplementation((requestedSessionId) =>
+      requestedSessionId === 'standalone-a'
+        ? Promise.resolve({
+            sessionId: 'standalone-a',
+            sourceType: 'standalone',
+            context: { kind: 'standalone' },
+            isArchived: true,
+          })
+        : nextLookupPromise,
+    );
+    mocks.unarchiveStandaloneSessions.mockReturnValue(unarchivePromise);
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('This conversation is archived'),
+    );
+    const unarchive = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Unarchive',
+    );
+    act(() => unarchive?.click());
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-b"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+    await vi.waitFor(() =>
+      expect(mocks.getStandaloneSession).toHaveBeenCalledWith('standalone-b'),
+    );
+    await act(async () => {
+      resolveUnarchive({
+        unarchived: ['standalone-a'],
+        alreadyActive: [],
+        resolvedConflicts: [],
+        notFound: [],
+        errors: [],
+      });
+      await unarchivePromise;
+    });
+
+    expect(container.textContent).toContain('Opening conversation');
+    expect(mocks.providerMounts).toBe(0);
+
+    await act(async () => {
+      resolveNextLookup({
+        sessionId: 'standalone-b',
+        sourceType: 'standalone',
+        context: { kind: 'standalone' },
+        isArchived: true,
+      });
+      await nextLookupPromise;
+    });
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('This conversation is archived'),
+    );
+    expect(mocks.providerMounts).toBe(0);
+  });
+
   it('shows not found when an archived deep link disappears during unarchive', async () => {
     mocks.workspace = {
       ...mocks.workspace,

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -210,6 +210,29 @@ describe('WorkspaceSessionProvider targets', () => {
     });
   });
 
+  it('drops an unavailable explicit context for a primary new session', async () => {
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="session-missing"
+          sessionContext={{ kind: 'workspace', cwd: '/work/missing' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+
+    const startFresh = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'New session',
+    );
+    await act(async () => startFresh?.click());
+
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: undefined,
+      sessionContext: undefined,
+      workspaceCwd: undefined,
+    });
+  });
+
   it('does not keep the previous app visible while a target is unresolved', async () => {
     const onSessionIdChange = await renderTarget('session-a', '/work/a');
     mocks.workspace = {

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -4,6 +4,7 @@ import { act, type ReactNode, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DaemonHttpError } from '@qwen-code/sdk/daemon';
+import type { WebShellProps } from '../App';
 
 const mocks = vi.hoisted(() => ({
   connection: {
@@ -492,6 +493,143 @@ describe('WorkspaceSessionProvider targets', () => {
       'standalone-a',
     ]);
     expect(mocks.providerMounts).toBe(1);
+  });
+
+  it('shows not found when an archived deep link disappears during unarchive', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+      client: {
+        getStandaloneSession: mocks.getStandaloneSession,
+        unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+      },
+    };
+    mocks.getStandaloneSession.mockResolvedValue({
+      sessionId: 'standalone-a',
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: true,
+    });
+    mocks.unarchiveStandaloneSessions.mockResolvedValue({
+      unarchived: [],
+      alreadyActive: [],
+      notFound: ['standalone-a'],
+      errors: [],
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain('This conversation is archived'),
+    );
+    const unarchive = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Unarchive',
+    );
+
+    await act(async () => unarchive?.click());
+
+    expect(container.textContent).toContain('Conversation not found');
+    expect(mocks.providerMounts).toBe(0);
+  });
+
+  it('keeps a resolved standalone provider mounted across language and capability refreshes', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+      },
+    };
+    mocks.getStandaloneSession.mockResolvedValue({
+      sessionId: 'standalone-a',
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: false,
+    });
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{ language: 'en' }}
+        />,
+      );
+    });
+    await vi.waitFor(() => expect(mocks.providerMounts).toBe(1));
+
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+      },
+    };
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{ language: 'zh-CN' }}
+        />,
+      );
+    });
+
+    expect(mocks.getStandaloneSession).toHaveBeenCalledOnce();
+    expect(mocks.providerMounts).toBe(1);
+    expect(mocks.providerUnmounts).toBe(0);
+  });
+
+  it('trusts a standalone session id reported by the mounted App', async () => {
+    const onSessionIdChange = vi.fn();
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+      },
+    };
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{ onSessionIdChange }}
+        />,
+      );
+    });
+    expect(mocks.providerMounts).toBe(1);
+    const reportedChange = mocks.appProps.at(-1)?.['onSessionIdChange'] as
+      | NonNullable<WebShellProps['onSessionIdChange']>
+      | undefined;
+    act(() => {
+      reportedChange?.('standalone-created', undefined, undefined, {
+        kind: 'standalone',
+      });
+    });
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-created"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{ onSessionIdChange }}
+        />,
+      );
+    });
+
+    expect(onSessionIdChange).toHaveBeenCalled();
+    expect(mocks.getStandaloneSession).not.toHaveBeenCalled();
+    expect(mocks.providerMounts).toBe(1);
+    expect(mocks.providerUnmounts).toBe(0);
   });
 
   it('rejects conflicting standalone and workspace targets', async () => {

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.test.tsx
@@ -3,6 +3,7 @@
 import { act, type ReactNode, useEffect } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DaemonHttpError } from '@qwen-code/sdk/daemon';
 
 const mocks = vi.hoisted(() => ({
   connection: {
@@ -23,6 +24,8 @@ const mocks = vi.hoisted(() => ({
     refreshCapabilities: vi.fn(async () => undefined),
   } as Record<string, unknown>,
   addWorkspace: vi.fn(),
+  getStandaloneSession: vi.fn(),
+  unarchiveStandaloneSessions: vi.fn(),
   providerMounts: 0,
   providerUnmounts: 0,
   providerProps: [] as Array<Record<string, unknown>>,
@@ -82,6 +85,12 @@ describe('WorkspaceSessionProvider targets', () => {
       refreshCapabilities: vi.fn(async () => undefined),
     };
     mocks.addWorkspace.mockReset();
+    mocks.getStandaloneSession.mockReset();
+    mocks.unarchiveStandaloneSessions.mockReset();
+    mocks.workspace.client = {
+      getStandaloneSession: mocks.getStandaloneSession,
+      unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+    };
     mocks.providerMounts = 0;
     mocks.providerUnmounts = 0;
     mocks.providerProps = [];
@@ -158,6 +167,46 @@ describe('WorkspaceSessionProvider targets', () => {
     appReport('session-b', 'b', '/work/b');
     expect(onSessionIdChange).toHaveBeenCalledWith('session-b', 'b', '/work/b');
     expect(onSessionIdChange).toHaveBeenCalledOnce();
+  });
+
+  it('preserves an explicit workspace context for provider conflict checks', async () => {
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="session-b"
+          workspaceCwd="/work/b"
+          sessionContext={{ kind: 'workspace', cwd: '/work/a' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-b',
+      sessionContext: { kind: 'workspace', cwd: '/work/a' },
+      workspaceCwd: '/work/b',
+    });
+  });
+
+  it('resolves an explicit workspace context through the workspace gate', async () => {
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="session-b"
+          sessionContext={{ kind: 'workspace', cwd: '/work/b' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'session-b',
+      sessionContext: { kind: 'workspace', cwd: '/work/b' },
+      workspaceCwd: '/work/b',
+    });
+    expect(mocks.appProps.at(-1)).toMatchObject({
+      initialSelectedWorkspaceCwd: '/work/b',
+    });
   });
 
   it('does not keep the previous app visible while a target is unresolved', async () => {
@@ -259,5 +308,208 @@ describe('WorkspaceSessionProvider targets', () => {
 
     expect(mocks.providerMounts).toBe(1);
     expect(mocks.providerUnmounts).toBe(0);
+  });
+
+  it('exact-checks a standalone deep link before mounting its provider', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+      client: {
+        getStandaloneSession: mocks.getStandaloneSession,
+        unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+      },
+    };
+    mocks.getStandaloneSession.mockResolvedValue({
+      sessionId: 'standalone-a',
+      workspaceCwd: '/internal/conversations/standalone-a',
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: false,
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(mocks.getStandaloneSession).toHaveBeenCalledWith('standalone-a'),
+      );
+    });
+    await act(async () => Promise.resolve());
+
+    expect(mocks.providerMounts).toBe(1);
+    expect(mocks.providerProps.at(-1)).toMatchObject({
+      sessionId: 'standalone-a',
+      sessionContext: { kind: 'standalone' },
+    });
+    expect(mocks.providerProps.at(-1)).not.toHaveProperty('workspaceCwd');
+  });
+
+  it('never calls a standalone route when the capability is absent', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: [],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+      client: {
+        getStandaloneSession: mocks.getStandaloneSession,
+        unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+      },
+    };
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+
+    expect(mocks.getStandaloneSession).not.toHaveBeenCalled();
+    expect(mocks.providerMounts).toBe(0);
+    expect(container.textContent).toContain(
+      'Standalone conversations are unavailable',
+    );
+  });
+
+  it('offers a standalone draft when an exact deep link is missing', async () => {
+    const onSessionIdChange = vi.fn();
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+      client: {
+        getStandaloneSession: mocks.getStandaloneSession,
+        unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+      },
+    };
+    mocks.getStandaloneSession.mockRejectedValue(
+      new DaemonHttpError(
+        404,
+        { code: 'standalone_session_not_found' },
+        'not found',
+      ),
+    );
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-missing"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{ onSessionIdChange }}
+        />,
+      );
+    });
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(container.textContent).toContain('Conversation not found'),
+      );
+    });
+
+    const startFresh = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'New session',
+    );
+    await act(async () => startFresh?.click());
+
+    expect(onSessionIdChange).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      undefined,
+      { kind: 'standalone' },
+    );
+    expect(mocks.providerMounts).toBe(0);
+  });
+
+  it('requires an explicit successful unarchive before mounting an archived deep link', async () => {
+    mocks.workspace = {
+      ...mocks.workspace,
+      capabilities: {
+        workspaceCwd: '/work/a',
+        features: ['standalone_sessions_v1'],
+        workspaces: [{ id: 'a', cwd: '/work/a', primary: true, trusted: true }],
+      },
+      client: {
+        getStandaloneSession: mocks.getStandaloneSession,
+        unarchiveStandaloneSessions: mocks.unarchiveStandaloneSessions,
+      },
+    };
+    mocks.getStandaloneSession.mockResolvedValue({
+      sessionId: 'standalone-a',
+      workspaceCwd: '/internal/conversations/standalone-a',
+      sourceType: 'standalone',
+      context: { kind: 'standalone' },
+      isArchived: true,
+    });
+    mocks.unarchiveStandaloneSessions.mockResolvedValue({
+      unarchived: ['standalone-a'],
+      alreadyActive: [],
+      resolvedConflicts: [],
+      notFound: [],
+      errors: [],
+    });
+
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+    await act(async () => {
+      await vi.waitFor(() =>
+        expect(container.textContent).toContain(
+          'This conversation is archived',
+        ),
+      );
+    });
+    expect(mocks.providerMounts).toBe(0);
+
+    const unarchive = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Unarchive',
+    );
+    await act(async () => unarchive?.click());
+
+    expect(mocks.unarchiveStandaloneSessions).toHaveBeenCalledWith([
+      'standalone-a',
+    ]);
+    expect(mocks.providerMounts).toBe(1);
+  });
+
+  it('rejects conflicting standalone and workspace targets', async () => {
+    await act(async () => {
+      root.render(
+        <WorkspaceSessionProvider
+          sessionId="standalone-a"
+          workspaceId="a"
+          sessionContext={{ kind: 'standalone' }}
+          webShellProps={{}}
+        />,
+      );
+    });
+
+    expect(mocks.getStandaloneSession).not.toHaveBeenCalled();
+    expect(mocks.providerMounts).toBe(0);
+    expect(container.textContent).toContain(
+      'A standalone or Live conversation link cannot include a workspace target.',
+    );
   });
 });

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -1,11 +1,18 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { WifiOffIcon } from 'lucide-react';
 import {
   DaemonSessionProvider,
   useWorkspace,
   useWorkspaceActions,
+  type DaemonProductSessionContext,
 } from '@qwen-code/web-shell/daemon-react-sdk';
-import type { DaemonWorkspaceCapability } from '@qwen-code/sdk/daemon';
+import {
+  isStandaloneSessionNotFoundError,
+  STANDALONE_SESSIONS_CAPABILITY,
+  type DaemonStandaloneSessionLookup,
+  type DaemonStandaloneSessionSummary,
+  type DaemonWorkspaceCapability,
+} from '@qwen-code/sdk/daemon';
 import { App, type WebShellProps } from '../App';
 import {
   WEB_SHELL_HISTORY_PAGE_SIZE,
@@ -18,6 +25,7 @@ interface WorkspaceSessionProviderProps {
   sessionId?: string;
   workspaceId?: string;
   workspaceCwd?: string;
+  sessionContext?: DaemonProductSessionContext;
   lockWorkspaceCwd?: string;
   clientId?: string;
   restartSseOnPrompt?: boolean;
@@ -25,10 +33,56 @@ interface WorkspaceSessionProviderProps {
   webShellProps: WebShellProps;
 }
 
-export function WorkspaceSessionProvider({
+export function WorkspaceSessionProvider(props: WorkspaceSessionProviderProps) {
+  const {
+    sessionId,
+    workspaceId,
+    workspaceCwd,
+    sessionContext,
+    lockWorkspaceCwd,
+    clientId,
+    restartSseOnPrompt,
+    historyPageSize = WEB_SHELL_HISTORY_PAGE_SIZE,
+    webShellProps,
+  } = props;
+  const t = getTranslator(normalizeLanguage(webShellProps.language));
+  const contextConflictsWithWorkspace =
+    sessionContext?.kind !== undefined &&
+    sessionContext.kind !== 'workspace' &&
+    Boolean(lockWorkspaceCwd || workspaceCwd || workspaceId);
+
+  if (contextConflictsWithWorkspace) {
+    return (
+      <WorkspaceUnavailableState
+        title={t('session.loadFailed')}
+        description={t('session.contextConflict')}
+        theme={webShellProps.theme}
+        icon={<WifiOffIcon />}
+      />
+    );
+  }
+
+  if (sessionContext?.kind === 'standalone') {
+    return (
+      <StandaloneSessionGate
+        key={sessionId ?? 'standalone-draft'}
+        sessionId={sessionId}
+        clientId={clientId}
+        restartSseOnPrompt={restartSseOnPrompt}
+        historyPageSize={historyPageSize}
+        webShellProps={webShellProps}
+      />
+    );
+  }
+
+  return <WorkspaceSessionProviderWorkspace {...props} />;
+}
+
+function WorkspaceSessionProviderWorkspace({
   sessionId,
   workspaceId,
   workspaceCwd,
+  sessionContext,
   lockWorkspaceCwd,
   clientId,
   restartSseOnPrompt,
@@ -52,12 +106,14 @@ export function WorkspaceSessionProvider({
   >(undefined);
   useEffect(
     () => setUsePrimaryNewSession(false),
-    [sessionId, lockWorkspaceCwd, workspaceCwd, workspaceId],
+    [sessionContext, sessionId, lockWorkspaceCwd, workspaceCwd, workspaceId],
   );
   const effectiveSessionId = usePrimaryNewSession ? undefined : sessionId;
   const effectiveWorkspaceCwd = usePrimaryNewSession
     ? undefined
-    : (lockWorkspaceCwd ?? workspaceCwd);
+    : (lockWorkspaceCwd ??
+      workspaceCwd ??
+      (sessionContext?.kind === 'workspace' ? sessionContext.cwd : undefined));
   const effectiveWorkspaceId = effectiveWorkspaceCwd ? undefined : workspaceId;
   const pathWorkspace = useMemo(() => {
     const listedWorkspace = workspace.capabilities?.workspaces?.find(
@@ -94,6 +150,7 @@ export function WorkspaceSessionProvider({
     () => getTranslator(normalizeLanguage(webShellProps.language)),
     [webShellProps.language],
   );
+
   useEffect(() => {
     if (!lockWorkspaceCwd || !workspace.capabilities || pathWorkspace) return;
     if (registeredWorkspace?.requestedCwd === lockWorkspaceCwd) return;
@@ -229,7 +286,17 @@ export function WorkspaceSessionProvider({
     <DaemonSessionProvider
       key="main-session"
       sessionId={effectiveSessionId}
-      workspaceCwd={targetWorkspace?.cwd}
+      sessionContext={
+        sessionContext ??
+        (targetWorkspace
+          ? { kind: 'workspace', cwd: targetWorkspace.cwd }
+          : undefined)
+      }
+      workspaceCwd={
+        sessionContext?.kind === 'workspace' || !sessionContext
+          ? targetWorkspace?.cwd
+          : undefined
+      }
       clientId={clientId}
       historyPageSize={historyPageSize}
       subagentTranscriptMode="summary"
@@ -248,6 +315,257 @@ export function WorkspaceSessionProvider({
         lockedWorkspaceCapability={
           lockWorkspaceCwd ? targetWorkspace : undefined
         }
+      />
+    </DaemonSessionProvider>
+  );
+}
+
+const STANDALONE_LOOKUP_DELAYS_MS = [250, 500, 1000, 2000, 4000, 4000];
+
+type StandaloneResolution =
+  | { status: 'loading' }
+  | { status: 'ready' }
+  | { status: 'archived'; lookup: DaemonStandaloneSessionSummary }
+  | { status: 'not-found' }
+  | { status: 'error'; error: Error };
+
+function StandaloneSessionGate({
+  sessionId,
+  clientId,
+  restartSseOnPrompt,
+  historyPageSize,
+  webShellProps,
+}: {
+  sessionId?: string;
+  clientId?: string;
+  restartSseOnPrompt?: boolean;
+  historyPageSize: number;
+  webShellProps: WebShellProps;
+}) {
+  const workspace = useWorkspace();
+  const [attempt, setAttempt] = useState(0);
+  const [resolution, setResolution] = useState<StandaloneResolution>(() =>
+    sessionId ? { status: 'loading' } : { status: 'ready' },
+  );
+  const resolutionGenerationRef = useRef(0);
+  const t = useMemo(
+    () => getTranslator(normalizeLanguage(webShellProps.language)),
+    [webShellProps.language],
+  );
+
+  const resolveSession = useCallback(
+    async (generation: number) => {
+      if (!sessionId) {
+        if (resolutionGenerationRef.current === generation) {
+          setResolution({ status: 'ready' });
+        }
+        return;
+      }
+
+      if (resolutionGenerationRef.current === generation) {
+        setResolution({ status: 'loading' });
+      }
+      for (let index = 0; ; index += 1) {
+        let lookup: DaemonStandaloneSessionLookup;
+        try {
+          lookup = await workspace.client.getStandaloneSession(sessionId);
+        } catch (error) {
+          if (resolutionGenerationRef.current !== generation) return;
+          if (isStandaloneSessionNotFoundError(error)) {
+            setResolution({ status: 'not-found' });
+            return;
+          }
+          setResolution({
+            status: 'error',
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+          return;
+        }
+
+        if (resolutionGenerationRef.current !== generation) return;
+
+        if (!('state' in lookup)) {
+          setResolution(
+            lookup.isArchived
+              ? { status: 'archived', lookup }
+              : { status: 'ready' },
+          );
+          return;
+        }
+        const delay = STANDALONE_LOOKUP_DELAYS_MS[index];
+        if (delay === undefined) {
+          setResolution({
+            status: 'error',
+            error: new Error(t('session.stillCreating')),
+          });
+          return;
+        }
+        await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
+        if (resolutionGenerationRef.current !== generation) return;
+      }
+    },
+    [sessionId, t, workspace.client],
+  );
+
+  useEffect(() => {
+    if (
+      !workspace.capabilities?.features?.includes(
+        STANDALONE_SESSIONS_CAPABILITY,
+      )
+    ) {
+      return;
+    }
+    const generation = resolutionGenerationRef.current + 1;
+    resolutionGenerationRef.current = generation;
+    void resolveSession(generation);
+    return () => {
+      if (resolutionGenerationRef.current === generation) {
+        resolutionGenerationRef.current += 1;
+      }
+    };
+  }, [attempt, resolveSession, workspace.capabilities?.features]);
+
+  const capabilities = workspace.capabilities;
+  if (workspace.status === 'error') {
+    return (
+      <WorkspaceUnavailableState
+        title={t('session.loadFailed')}
+        description={t('session.capabilitiesFailed')}
+        actionLabel={t('common.retry')}
+        theme={webShellProps.theme}
+        icon={<WifiOffIcon />}
+        onAction={() => {
+          void workspace.refreshCapabilities?.().catch(() => {});
+        }}
+      />
+    );
+  }
+  if (!capabilities) {
+    return (
+      <div
+        data-web-shell-root
+        data-web-shell-shadcn
+        className={`flex min-h-32 w-full items-center justify-center gap-2 text-sm text-muted-foreground ${webShellProps.theme === 'dark' ? 'dark' : ''}`}
+        role="status"
+        aria-live="polite"
+      >
+        <Spinner />
+        <span>{t('common.loading')}</span>
+      </div>
+    );
+  }
+  if (!capabilities.features?.includes(STANDALONE_SESSIONS_CAPABILITY)) {
+    return (
+      <WorkspaceUnavailableState
+        title={t('session.standaloneUnavailable')}
+        description={t('session.standaloneUpgradeRequired')}
+        theme={webShellProps.theme}
+        icon={<WifiOffIcon />}
+      />
+    );
+  }
+  if (resolution.status === 'loading') {
+    return (
+      <div
+        data-web-shell-root
+        data-web-shell-shadcn
+        className={`flex min-h-32 w-full items-center justify-center gap-2 text-sm text-muted-foreground ${webShellProps.theme === 'dark' ? 'dark' : ''}`}
+        role="status"
+        aria-live="polite"
+      >
+        <Spinner />
+        <span>{t('session.resolving')}</span>
+      </div>
+    );
+  }
+  if (resolution.status === 'not-found') {
+    return (
+      <WorkspaceUnavailableState
+        title={t('session.notFound')}
+        description={t('session.notFoundDescription')}
+        actionLabel={
+          webShellProps.onSessionIdChange ? t('session.new') : undefined
+        }
+        theme={webShellProps.theme}
+        icon={<WifiOffIcon />}
+        onAction={
+          webShellProps.onSessionIdChange
+            ? () => {
+                webShellProps.onSessionIdChange?.(
+                  undefined,
+                  undefined,
+                  undefined,
+                  { kind: 'standalone' },
+                );
+              }
+            : undefined
+        }
+      />
+    );
+  }
+  if (resolution.status === 'error') {
+    return (
+      <WorkspaceUnavailableState
+        title={t('session.loadFailed')}
+        description={resolution.error.message}
+        actionLabel={t('common.retry')}
+        theme={webShellProps.theme}
+        icon={<WifiOffIcon />}
+        onAction={() => setAttempt((current) => current + 1)}
+      />
+    );
+  }
+  if (resolution.status === 'archived') {
+    return (
+      <WorkspaceUnavailableState
+        title={t('session.archived')}
+        description={t('session.archivedDescription')}
+        actionLabel={t('session.unarchive')}
+        theme={webShellProps.theme}
+        onAction={() => {
+          void workspace.client
+            .unarchiveStandaloneSessions([sessionId!])
+            .then((result) => {
+              if (
+                result.unarchived.includes(sessionId!) ||
+                result.alreadyActive.includes(sessionId!)
+              ) {
+                setResolution({ status: 'ready' });
+                return;
+              }
+              const failure = result.errors.find(
+                (entry) => entry.sessionId === sessionId,
+              );
+              throw new Error(failure?.message ?? t('session.unarchiveFailed'));
+            })
+            .catch((error: unknown) => {
+              setResolution({
+                status: 'error',
+                error:
+                  error instanceof Error ? error : new Error(String(error)),
+              });
+            });
+        }}
+      />
+    );
+  }
+
+  return (
+    <DaemonSessionProvider
+      key="main-session"
+      sessionId={sessionId}
+      sessionContext={{ kind: 'standalone' }}
+      clientId={clientId}
+      historyPageSize={historyPageSize}
+      subagentTranscriptMode="summary"
+      maxBlocks={WEB_SHELL_MAX_TRANSCRIPT_BLOCKS}
+      suppressOwnUserEcho
+      restartEventStreamOnPrompt={restartSseOnPrompt}
+    >
+      <App
+        {...webShellProps}
+        historyPageSize={historyPageSize}
+        restartSseOnPrompt={restartSseOnPrompt}
       />
     </DaemonSessionProvider>
   );

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -316,10 +316,12 @@ function WorkspaceSessionProviderWorkspace({
       key="main-session"
       sessionId={effectiveSessionId}
       sessionContext={
-        sessionContext ??
-        (targetWorkspace
-          ? { kind: 'workspace', cwd: targetWorkspace.cwd }
-          : undefined)
+        usePrimaryNewSession
+          ? undefined
+          : (sessionContext ??
+            (targetWorkspace
+              ? { kind: 'workspace', cwd: targetWorkspace.cwd }
+              : undefined))
       }
       workspaceCwd={
         sessionContext?.kind === 'workspace' || !sessionContext

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -571,26 +571,31 @@ function StandaloneSessionGate({
         actionLabel={t('session.unarchive')}
         theme={webShellProps.theme}
         onAction={() => {
+          const requestedSessionId = sessionId!;
+          const normalizedSessionId = requestedSessionId.toLowerCase();
+          const generation = resolutionGenerationRef.current;
           void workspace.client
-            .unarchiveStandaloneSessions([sessionId!])
+            .unarchiveStandaloneSessions([requestedSessionId])
             .then((result) => {
+              if (resolutionGenerationRef.current !== generation) return;
               if (
-                result.unarchived.includes(sessionId!) ||
-                result.alreadyActive.includes(sessionId!)
+                result.unarchived.includes(normalizedSessionId) ||
+                result.alreadyActive.includes(normalizedSessionId)
               ) {
                 setResolution({ status: 'ready' });
                 return;
               }
-              if (result.notFound?.includes(sessionId!)) {
+              if (result.notFound?.includes(normalizedSessionId)) {
                 setResolution({ status: 'not-found' });
                 return;
               }
               const failure = result.errors.find(
-                (entry) => entry.sessionId === sessionId,
+                (entry) => entry.sessionId === normalizedSessionId,
               );
               throw new Error(failure?.message ?? t('session.unarchiveFailed'));
             })
             .catch((error: unknown) => {
+              if (resolutionGenerationRef.current !== generation) return;
               setResolution({
                 status: 'error',
                 error:

--- a/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
+++ b/packages/web-shell/client/components/WorkspaceSessionProvider.tsx
@@ -45,6 +45,30 @@ export function WorkspaceSessionProvider(props: WorkspaceSessionProviderProps) {
     historyPageSize = WEB_SHELL_HISTORY_PAGE_SIZE,
     webShellProps,
   } = props;
+  const onSessionIdChange = webShellProps.onSessionIdChange;
+  const attachedStandaloneSessionIdRef = useRef<string | undefined>(undefined);
+  const handleSessionIdChange = useCallback<
+    NonNullable<WebShellProps['onSessionIdChange']>
+  >(
+    (nextSessionId, nextWorkspaceId, nextWorkspaceCwd, nextSessionContext) => {
+      attachedStandaloneSessionIdRef.current =
+        nextSessionContext?.kind === 'standalone' ? nextSessionId : undefined;
+      onSessionIdChange?.(
+        nextSessionId,
+        nextWorkspaceId,
+        nextWorkspaceCwd,
+        nextSessionContext,
+      );
+    },
+    [onSessionIdChange],
+  );
+  if (
+    sessionContext?.kind !== 'standalone' ||
+    (attachedStandaloneSessionIdRef.current !== undefined &&
+      attachedStandaloneSessionIdRef.current !== sessionId)
+  ) {
+    attachedStandaloneSessionIdRef.current = undefined;
+  }
   const t = getTranslator(normalizeLanguage(webShellProps.language));
   const contextConflictsWithWorkspace =
     sessionContext?.kind !== undefined &&
@@ -65,12 +89,17 @@ export function WorkspaceSessionProvider(props: WorkspaceSessionProviderProps) {
   if (sessionContext?.kind === 'standalone') {
     return (
       <StandaloneSessionGate
-        key={sessionId ?? 'standalone-draft'}
         sessionId={sessionId}
+        attachedSessionId={attachedStandaloneSessionIdRef.current}
         clientId={clientId}
         restartSseOnPrompt={restartSseOnPrompt}
         historyPageSize={historyPageSize}
-        webShellProps={webShellProps}
+        webShellProps={{
+          ...webShellProps,
+          onSessionIdChange: onSessionIdChange
+            ? handleSessionIdChange
+            : undefined,
+        }}
       />
     );
   }
@@ -327,16 +356,19 @@ type StandaloneResolution =
   | { status: 'ready' }
   | { status: 'archived'; lookup: DaemonStandaloneSessionSummary }
   | { status: 'not-found' }
+  | { status: 'still-creating' }
   | { status: 'error'; error: Error };
 
 function StandaloneSessionGate({
   sessionId,
+  attachedSessionId,
   clientId,
   restartSseOnPrompt,
   historyPageSize,
   webShellProps,
 }: {
   sessionId?: string;
+  attachedSessionId?: string;
   clientId?: string;
   restartSseOnPrompt?: boolean;
   historyPageSize: number;
@@ -347,15 +379,32 @@ function StandaloneSessionGate({
   const [resolution, setResolution] = useState<StandaloneResolution>(() =>
     sessionId ? { status: 'loading' } : { status: 'ready' },
   );
+  const [resolutionSessionId, setResolutionSessionId] = useState(sessionId);
   const resolutionGenerationRef = useRef(0);
   const t = useMemo(
     () => getTranslator(normalizeLanguage(webShellProps.language)),
     [webShellProps.language],
   );
 
-  const resolveSession = useCallback(
-    async (generation: number) => {
+  const standaloneSupported =
+    workspace.capabilities?.features?.includes(
+      STANDALONE_SESSIONS_CAPABILITY,
+    ) === true;
+
+  useEffect(() => {
+    if (!standaloneSupported) return;
+    const generation = resolutionGenerationRef.current + 1;
+    resolutionGenerationRef.current = generation;
+    setResolutionSessionId(sessionId);
+    const resolveSession = async () => {
       if (!sessionId) {
+        if (resolutionGenerationRef.current === generation) {
+          setResolution({ status: 'ready' });
+        }
+        return;
+      }
+
+      if (attachedSessionId === sessionId) {
         if (resolutionGenerationRef.current === generation) {
           setResolution({ status: 'ready' });
         }
@@ -394,36 +443,26 @@ function StandaloneSessionGate({
         }
         const delay = STANDALONE_LOOKUP_DELAYS_MS[index];
         if (delay === undefined) {
-          setResolution({
-            status: 'error',
-            error: new Error(t('session.stillCreating')),
-          });
+          setResolution({ status: 'still-creating' });
           return;
         }
         await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
         if (resolutionGenerationRef.current !== generation) return;
       }
-    },
-    [sessionId, t, workspace.client],
-  );
-
-  useEffect(() => {
-    if (
-      !workspace.capabilities?.features?.includes(
-        STANDALONE_SESSIONS_CAPABILITY,
-      )
-    ) {
-      return;
-    }
-    const generation = resolutionGenerationRef.current + 1;
-    resolutionGenerationRef.current = generation;
-    void resolveSession(generation);
+    };
+    void resolveSession();
     return () => {
       if (resolutionGenerationRef.current === generation) {
         resolutionGenerationRef.current += 1;
       }
     };
-  }, [attempt, resolveSession, workspace.capabilities?.features]);
+  }, [
+    attempt,
+    attachedSessionId,
+    sessionId,
+    standaloneSupported,
+    workspace.client,
+  ]);
 
   const capabilities = workspace.capabilities;
   if (workspace.status === 'error') {
@@ -454,7 +493,7 @@ function StandaloneSessionGate({
       </div>
     );
   }
-  if (!capabilities.features?.includes(STANDALONE_SESSIONS_CAPABILITY)) {
+  if (!standaloneSupported) {
     return (
       <WorkspaceUnavailableState
         title={t('session.standaloneUnavailable')}
@@ -464,7 +503,10 @@ function StandaloneSessionGate({
       />
     );
   }
-  if (resolution.status === 'loading') {
+  if (
+    (resolutionSessionId !== sessionId && attachedSessionId !== sessionId) ||
+    resolution.status === 'loading'
+  ) {
     return (
       <div
         data-web-shell-root
@@ -503,11 +545,15 @@ function StandaloneSessionGate({
       />
     );
   }
-  if (resolution.status === 'error') {
+  if (resolution.status === 'error' || resolution.status === 'still-creating') {
     return (
       <WorkspaceUnavailableState
         title={t('session.loadFailed')}
-        description={resolution.error.message}
+        description={
+          resolution.status === 'still-creating'
+            ? t('session.stillCreating')
+            : resolution.error.message
+        }
         actionLabel={t('common.retry')}
         theme={webShellProps.theme}
         icon={<WifiOffIcon />}
@@ -531,6 +577,10 @@ function StandaloneSessionGate({
                 result.alreadyActive.includes(sessionId!)
               ) {
                 setResolution({ status: 'ready' });
+                return;
+              }
+              if (result.notFound?.includes(sessionId!)) {
+                setResolution({ status: 'not-found' });
                 return;
               }
               const failure = result.errors.find(

--- a/packages/web-shell/client/components/WorkspaceUnavailableState.tsx
+++ b/packages/web-shell/client/components/WorkspaceUnavailableState.tsx
@@ -13,8 +13,8 @@ import {
 interface WorkspaceUnavailableStateProps {
   title: string;
   description: string;
-  actionLabel: string;
-  onAction: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
   theme?: 'dark' | 'light';
   icon?: ReactNode;
 }
@@ -39,9 +39,11 @@ export function WorkspaceUnavailableState({
           <EmptyTitle>{title}</EmptyTitle>
           <EmptyDescription>{description}</EmptyDescription>
         </EmptyHeader>
-        <EmptyContent>
-          <Button onClick={onAction}>{actionLabel}</Button>
-        </EmptyContent>
+        {actionLabel && onAction ? (
+          <EmptyContent>
+            <Button onClick={onAction}>{actionLabel}</Button>
+          </EmptyContent>
+        ) : null}
       </Empty>
     </div>
   );

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
@@ -227,6 +227,62 @@ describe('StandaloneRecents', () => {
     ).toHaveLength(1);
   });
 
+  it('preserves appended archived pages across collapse and reopen', async () => {
+    mocks.list.mockImplementation(
+      async ({
+        archiveState,
+        cursor,
+      }: {
+        archiveState: string;
+        cursor?: string;
+      }) => {
+        if (archiveState === 'active') {
+          return { sessions: [summary('active', 'Active chat')] };
+        }
+        return cursor === 'archived-page-2'
+          ? {
+              sessions: [
+                summary('archived-2', 'Archived page two', {
+                  isArchived: true,
+                }),
+              ],
+            }
+          : {
+              sessions: [
+                summary('archived-1', 'Archived page one', {
+                  isArchived: true,
+                }),
+              ],
+              nextCursor: 'archived-page-2',
+            };
+      },
+    );
+    await render();
+    const archivedToggle = Array.from(
+      container.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('sidebar.archivedTitle'));
+
+    await act(async () => archivedToggle?.click());
+    const showAll = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'sidebar.showAllSessions',
+    );
+    await act(async () => showAll?.click());
+    expect(container.textContent).toContain('Archived page two');
+
+    await act(async () => archivedToggle?.click());
+    await act(async () => archivedToggle?.click());
+
+    expect(container.textContent).toContain('Archived page two');
+    expect(container.textContent).not.toContain('sidebar.showAllSessions');
+    expect(
+      mocks.list.mock.calls.filter(
+        ([options]) =>
+          options.archiveState === 'archived' &&
+          options.cursor === 'archived-page-2',
+      ),
+    ).toHaveLength(1);
+  });
+
   it('reports a failed standalone session open', async () => {
     const error = new Error('load failed');
     const { onError } = await render({

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   archive: vi.fn(),
   unarchive: vi.fn(),
   rename: vi.fn(),
+  exportSession: vi.fn(),
   t: vi.fn((key: string) => key),
   workspace: {} as Record<string, unknown>,
 }));
@@ -65,7 +66,22 @@ describe('StandaloneRecents', () => {
     mocks.archive.mockReset();
     mocks.unarchive.mockReset();
     mocks.rename.mockReset();
+    mocks.exportSession.mockReset();
     mocks.rename.mockResolvedValue(undefined);
+    mocks.exportSession.mockResolvedValue({
+      content: '<p>chat</p>',
+      filename: 'chat.html',
+      mimeType: 'text/html',
+    });
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:standalone-export'),
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
     mocks.list.mockImplementation(
       async ({ archiveState }: { archiveState: string }) => ({
         sessions:
@@ -84,6 +100,7 @@ describe('StandaloneRecents', () => {
         archiveStandaloneSessions: mocks.archive,
         unarchiveStandaloneSessions: mocks.unarchive,
         renameStandaloneSession: mocks.rename,
+        exportStandaloneSession: mocks.exportSession,
       },
     };
     container = document.createElement('div');
@@ -94,6 +111,7 @@ describe('StandaloneRecents', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.restoreAllMocks();
   });
 
   async function render(
@@ -148,6 +166,65 @@ describe('StandaloneRecents', () => {
       archiveState: 'archived',
       pageSize: 50,
     });
+  });
+
+  it('preserves appended active pages across export and archived expansion', async () => {
+    mocks.list.mockImplementation(
+      async ({
+        archiveState,
+        cursor,
+      }: {
+        archiveState: string;
+        cursor?: string;
+      }) => {
+        if (archiveState === 'archived') {
+          return {
+            sessions: [
+              summary('archived', 'Archived chat', { isArchived: true }),
+            ],
+          };
+        }
+        return cursor === 'page-2'
+          ? { sessions: [summary('page-2', 'Page two chat')] }
+          : {
+              sessions: [summary('page-1', 'Page one chat')],
+              nextCursor: 'page-2',
+            };
+      },
+    );
+    await render();
+    const showAll = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'sidebar.showAllSessions',
+    );
+    await act(async () => showAll?.click());
+    expect(container.textContent).toContain('Page two chat');
+
+    const exportButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button'),
+    ).filter((button) => button.textContent === 'sidebar.export');
+    await act(async () => exportButtons.at(-1)?.click());
+    await vi.waitFor(() => expect(mocks.exportSession).toHaveBeenCalledOnce());
+    expect(container.textContent).toContain('Page two chat');
+    expect(
+      mocks.list.mock.calls.filter(
+        ([options]) =>
+          options.archiveState === 'active' && options.cursor === undefined,
+      ),
+    ).toHaveLength(1);
+
+    const archivedToggle = Array.from(
+      container.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('sidebar.archivedTitle'));
+    await act(async () => archivedToggle?.click());
+
+    expect(container.textContent).toContain('Page two chat');
+    expect(container.textContent).toContain('Archived chat');
+    expect(
+      mocks.list.mock.calls.filter(
+        ([options]) =>
+          options.archiveState === 'active' && options.cursor === undefined,
+      ),
+    ).toHaveLength(1);
   });
 
   it('reports a failed standalone session open', async () => {

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
@@ -8,6 +8,7 @@ import { STANDALONE_SESSIONS_CAPABILITY } from '@qwen-code/sdk/daemon';
 const mocks = vi.hoisted(() => ({
   list: vi.fn(),
   archive: vi.fn(),
+  unarchive: vi.fn(),
   rename: vi.fn(),
   t: vi.fn((key: string) => key),
   workspace: {} as Record<string, unknown>,
@@ -62,6 +63,7 @@ describe('StandaloneRecents', () => {
   beforeEach(() => {
     mocks.list.mockReset();
     mocks.archive.mockReset();
+    mocks.unarchive.mockReset();
     mocks.rename.mockReset();
     mocks.rename.mockResolvedValue(undefined);
     mocks.list.mockImplementation(
@@ -80,6 +82,7 @@ describe('StandaloneRecents', () => {
       client: {
         listStandaloneSessionsPage: mocks.list,
         archiveStandaloneSessions: mocks.archive,
+        unarchiveStandaloneSessions: mocks.unarchive,
         renameStandaloneSession: mocks.rename,
       },
     };
@@ -179,6 +182,50 @@ describe('StandaloneRecents', () => {
       'sidebar.standaloneActionFailed',
     );
     expect(container.textContent).toContain('Active chat');
+  });
+
+  it('treats an already-missing archive target as terminal success', async () => {
+    mocks.archive.mockResolvedValue({
+      archived: [],
+      alreadyArchived: [],
+      notFound: ['active'],
+      errors: [],
+    });
+    const { onError } = await render();
+    const archiveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('sidebar.archive'),
+    );
+
+    await act(async () => archiveButton?.click());
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(mocks.list).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats an already-missing unarchive target as terminal success', async () => {
+    mocks.unarchive.mockResolvedValue({
+      unarchived: [],
+      alreadyActive: [],
+      notFound: ['archived'],
+      errors: [],
+    });
+    const { onError } = await render();
+    const archivedToggle = Array.from(
+      container.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('sidebar.archivedTitle'));
+    await act(async () => archivedToggle?.click());
+    const unarchiveButton = Array.from(
+      container.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('sidebar.unarchive'));
+
+    await act(async () => unarchiveButton?.click());
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(mocks.list).toHaveBeenCalledWith({
+      archiveState: 'archived',
+      pageSize: 50,
+    });
+    expect(mocks.list.mock.calls.length).toBeGreaterThan(2);
   });
 
   it('dispatches a lifecycle action only once before React commits busy state', async () => {

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STANDALONE_SESSIONS_CAPABILITY } from '@qwen-code/sdk/daemon';
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  archive: vi.fn(),
+  rename: vi.fn(),
+  t: vi.fn((key: string) => key),
+  workspace: {} as Record<string, unknown>,
+}));
+
+vi.mock('@qwen-code/web-shell/daemon-react-sdk', () => ({
+  useStreamingState: () => 'idle',
+  useWorkspace: () => mocks.workspace,
+}));
+
+vi.mock('../../i18n', () => ({
+  useI18n: () => ({ t: mocks.t }),
+}));
+
+vi.mock('../dialogs/DialogShell', () => ({
+  DialogShell: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuGroup: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => children,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+  }) => <button onClick={onSelect}>{children}</button>,
+}));
+
+import { StandaloneRecents } from './StandaloneRecents';
+
+const summary = (
+  sessionId: string,
+  displayName: string,
+  extra: Record<string, unknown> = {},
+) => ({
+  sessionId,
+  displayName,
+  workspaceCwd: `/private/standalone/${sessionId}`,
+  sourceType: 'standalone',
+  context: { kind: 'standalone' },
+  ...extra,
+});
+
+describe('StandaloneRecents', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.list.mockReset();
+    mocks.archive.mockReset();
+    mocks.rename.mockReset();
+    mocks.rename.mockResolvedValue(undefined);
+    mocks.list.mockImplementation(
+      async ({ archiveState }: { archiveState: string }) => ({
+        sessions:
+          archiveState === 'archived'
+            ? [summary('archived', 'Archived chat', { isArchived: true })]
+            : [
+                summary('active', 'Active chat'),
+                summary('child', 'Child chat', { parentSessionId: 'active' }),
+              ],
+      }),
+    );
+    mocks.workspace = {
+      capabilities: { features: [STANDALONE_SESSIONS_CAPABILITY] },
+      client: {
+        listStandaloneSessionsPage: mocks.list,
+        archiveStandaloneSessions: mocks.archive,
+        renameStandaloneSession: mocks.rename,
+      },
+    };
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(
+    options: {
+      onError?: (error: unknown, message: string) => void;
+      onRenameSession?: (sessionId: string, displayName: string) => void;
+      onLoadSession?: (sessionId: string) => Promise<void> | void;
+    } = {},
+  ) {
+    const onError = options.onError ?? vi.fn();
+    const onRenameSession = options.onRenameSession ?? vi.fn();
+    await act(async () => {
+      root.render(
+        <StandaloneRecents
+          collapsed={false}
+          onExpand={vi.fn()}
+          onLoadSession={options.onLoadSession ?? vi.fn()}
+          onError={onError}
+          onRenameSession={onRenameSession}
+          onNotice={vi.fn()}
+        />,
+      );
+    });
+    return { onError, onRenameSession };
+  }
+
+  it('lists only top-level active chats without exposing the internal cwd', async () => {
+    await render();
+
+    expect(container.textContent).toContain('Active chat');
+    expect(container.textContent).not.toContain('Child chat');
+    expect(container.textContent).not.toContain('/private/standalone');
+    expect(mocks.list).toHaveBeenCalledWith({
+      archiveState: 'active',
+      pageSize: 50,
+    });
+    expect(mocks.list).not.toHaveBeenCalledWith(
+      expect.objectContaining({ archiveState: 'archived' }),
+    );
+  });
+
+  it('loads archived chats only after the archived lane is expanded', async () => {
+    await render();
+    const archivedToggle = Array.from(
+      container.querySelectorAll('button'),
+    ).find((button) => button.textContent?.includes('sidebar.archivedTitle'));
+
+    await act(async () => archivedToggle?.click());
+
+    expect(container.textContent).toContain('Archived chat');
+    expect(mocks.list).toHaveBeenCalledWith({
+      archiveState: 'archived',
+      pageSize: 50,
+    });
+  });
+
+  it('reports a failed standalone session open', async () => {
+    const error = new Error('load failed');
+    const { onError } = await render({
+      onLoadSession: vi.fn().mockRejectedValue(error),
+    });
+    const sessionButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Active chat',
+    );
+
+    await act(async () => sessionButton?.click());
+
+    expect(onError).toHaveBeenCalledWith(error, 'session.loadFailed');
+  });
+
+  it('keeps a row visible when a batch archive reports an item error', async () => {
+    mocks.archive.mockResolvedValue({
+      archived: [],
+      alreadyArchived: [],
+      errors: [{ sessionId: 'active', code: 'busy', message: 'still running' }],
+    });
+    const { onError } = await render();
+    const archiveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('sidebar.archive'),
+    );
+
+    await act(async () => archiveButton?.click());
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'still running' }),
+      'sidebar.standaloneActionFailed',
+    );
+    expect(container.textContent).toContain('Active chat');
+  });
+
+  it('dispatches a lifecycle action only once before React commits busy state', async () => {
+    let resolveArchive:
+      | ((value: {
+          archived: string[];
+          alreadyArchived: string[];
+          errors: unknown[];
+        }) => void)
+      | undefined;
+    mocks.archive.mockReturnValue(
+      new Promise((resolve) => {
+        resolveArchive = resolve;
+      }),
+    );
+    await render();
+    const archiveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('sidebar.archive'),
+    );
+
+    act(() => {
+      archiveButton?.click();
+      archiveButton?.click();
+    });
+
+    expect(mocks.archive).toHaveBeenCalledOnce();
+    await act(async () => {
+      resolveArchive?.({
+        archived: ['active'],
+        alreadyArchived: [],
+        errors: [],
+      });
+      await Promise.resolve();
+    });
+  });
+
+  it('reports a confirmed rename after the exact standalone route succeeds', async () => {
+    const { onRenameSession } = await render();
+    const renameButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.includes('sidebar.rename'),
+    );
+
+    await act(async () => renameButton?.click());
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+    await act(async () => {
+      if (!input) return;
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(input, 'Renamed chat');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      input
+        ?.closest('form')
+        ?.dispatchEvent(
+          new Event('submit', { bubbles: true, cancelable: true }),
+        );
+      await Promise.resolve();
+    });
+
+    expect(mocks.rename).toHaveBeenCalledWith('active', 'Renamed chat');
+    expect(onRenameSession).toHaveBeenCalledWith('active', 'Renamed chat');
+  });
+});

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
@@ -1,0 +1,618 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  ArchiveIcon,
+  DownloadIcon,
+  EllipsisIcon,
+  MessageSquareIcon,
+  PencilIcon,
+  RotateCcwIcon,
+  Trash2Icon,
+} from 'lucide-react';
+import {
+  STANDALONE_SESSIONS_CAPABILITY,
+  type DaemonSessionArchiveState,
+  type DaemonStandaloneSessionSummary,
+} from '@qwen-code/sdk/daemon';
+import {
+  useStreamingState,
+  useWorkspace,
+} from '@qwen-code/web-shell/daemon-react-sdk';
+import { useI18n } from '../../i18n';
+import { DialogShell } from '../dialogs/DialogShell';
+import { Button } from '../ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import { Input } from '../ui/input';
+
+interface StandaloneRecentsProps {
+  collapsed: boolean;
+  onExpand: () => void;
+  currentSessionId?: string;
+  onLoadSession: (sessionId: string) => Promise<void> | void;
+  onRenameSession?: (sessionId: string, displayName: string) => void;
+  onError: (error: unknown, fallback: string) => void;
+  onNotice: (message: string) => void;
+}
+
+const PAGE_SIZE = 50;
+
+function sessionLabel(session: DaemonStandaloneSessionSummary): string {
+  return session.displayName?.trim() || session.sessionId.slice(0, 8);
+}
+
+function withoutChildren(
+  sessions: readonly DaemonStandaloneSessionSummary[],
+): DaemonStandaloneSessionSummary[] {
+  return sessions.filter((session) => !session.parentSessionId);
+}
+
+function appendUnique(
+  current: readonly DaemonStandaloneSessionSummary[],
+  incoming: readonly DaemonStandaloneSessionSummary[],
+): DaemonStandaloneSessionSummary[] {
+  const known = new Set(current.map((session) => session.sessionId));
+  return [
+    ...current,
+    ...incoming.filter((session) => !known.has(session.sessionId)),
+  ];
+}
+
+function downloadExport(result: {
+  content: string;
+  filename: string;
+  mimeType: string;
+}): void {
+  const url = URL.createObjectURL(
+    new Blob([result.content], { type: result.mimeType || 'text/html' }),
+  );
+  try {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = result.filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export function StandaloneRecents({
+  collapsed,
+  onExpand,
+  currentSessionId,
+  onLoadSession,
+  onRenameSession,
+  onError,
+  onNotice,
+}: StandaloneRecentsProps) {
+  const workspace = useWorkspace();
+  const streamingState = useStreamingState();
+  const previousStreamingStateRef = useRef(streamingState);
+  const loadGenerationRef = useRef(0);
+  const busySessionIdRef = useRef<string | undefined>(undefined);
+  const { t } = useI18n();
+  const [active, setActive] = useState<DaemonStandaloneSessionSummary[]>([]);
+  const [archived, setArchived] = useState<DaemonStandaloneSessionSummary[]>(
+    [],
+  );
+  const [activeCursor, setActiveCursor] = useState<string>();
+  const [archivedCursor, setArchivedCursor] = useState<string>();
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState<DaemonSessionArchiveState>();
+  const [busySessionId, setBusySessionId] = useState<string>();
+  const [renameCandidate, setRenameCandidate] =
+    useState<DaemonStandaloneSessionSummary>();
+  const [renameValue, setRenameValue] = useState('');
+  const [deleteCandidate, setDeleteCandidate] =
+    useState<DaemonStandaloneSessionSummary>();
+  const supported =
+    workspace.capabilities?.features?.includes(
+      STANDALONE_SESSIONS_CAPABILITY,
+    ) === true;
+
+  const load = useCallback(async () => {
+    if (!supported) return;
+    const generation = loadGenerationRef.current + 1;
+    loadGenerationRef.current = generation;
+    setLoadingMore(undefined);
+    setLoading(true);
+    try {
+      const [activePage, archivedPage] = await Promise.all([
+        workspace.client.listStandaloneSessionsPage({
+          archiveState: 'active',
+          pageSize: PAGE_SIZE,
+        }),
+        archivedExpanded
+          ? workspace.client.listStandaloneSessionsPage({
+              archiveState: 'archived',
+              pageSize: PAGE_SIZE,
+            })
+          : undefined,
+      ]);
+      if (loadGenerationRef.current !== generation) return;
+      setActive(withoutChildren(activePage.sessions));
+      setActiveCursor(activePage.nextCursor);
+      if (archivedPage) {
+        setArchived(withoutChildren(archivedPage.sessions));
+        setArchivedCursor(archivedPage.nextCursor);
+      }
+    } catch (error) {
+      if (loadGenerationRef.current !== generation) return;
+      onError(error, t('sidebar.standaloneLoadFailed'));
+    } finally {
+      if (loadGenerationRef.current === generation) setLoading(false);
+    }
+  }, [archivedExpanded, onError, supported, t, workspace.client]);
+
+  const loadMore = useCallback(
+    async (archiveState: DaemonSessionArchiveState, cursor: string) => {
+      if (loadingMore) return;
+      const generation = loadGenerationRef.current;
+      setLoadingMore(archiveState);
+      try {
+        const page = await workspace.client.listStandaloneSessionsPage({
+          archiveState,
+          cursor,
+          pageSize: PAGE_SIZE,
+        });
+        if (loadGenerationRef.current !== generation) return;
+        const sessions = withoutChildren(page.sessions);
+        if (archiveState === 'active') {
+          setActive((current) => appendUnique(current, sessions));
+          setActiveCursor(page.nextCursor);
+        } else {
+          setArchived((current) => appendUnique(current, sessions));
+          setArchivedCursor(page.nextCursor);
+        }
+      } catch (error) {
+        if (loadGenerationRef.current !== generation) return;
+        onError(error, t('sidebar.standaloneLoadFailed'));
+      } finally {
+        if (loadGenerationRef.current === generation) setLoadingMore(undefined);
+      }
+    },
+    [loadingMore, onError, t, workspace.client],
+  );
+
+  useEffect(() => {
+    void load();
+  }, [currentSessionId, load]);
+
+  useEffect(() => {
+    const previous = previousStreamingStateRef.current;
+    previousStreamingStateRef.current = streamingState;
+    if (previous !== 'idle' && streamingState === 'idle') void load();
+  }, [load, streamingState]);
+
+  const run = useCallback(
+    async (
+      sessionId: string,
+      action: () => Promise<void>,
+    ): Promise<boolean> => {
+      if (busySessionIdRef.current) return false;
+      busySessionIdRef.current = sessionId;
+      setBusySessionId(sessionId);
+      try {
+        await action();
+        await load();
+        return true;
+      } catch (error) {
+        onError(error, t('sidebar.standaloneActionFailed'));
+        return false;
+      } finally {
+        busySessionIdRef.current = undefined;
+        setBusySessionId(undefined);
+      }
+    },
+    [load, onError, t],
+  );
+
+  const archiveSession = useCallback(
+    async (session: DaemonStandaloneSessionSummary) => {
+      await run(session.sessionId, async () => {
+        const result = await workspace.client.archiveStandaloneSessions([
+          session.sessionId,
+        ]);
+        if (
+          result.archived.includes(session.sessionId) ||
+          result.alreadyArchived.includes(session.sessionId)
+        ) {
+          return;
+        }
+        const failure = result.errors.find(
+          (entry) => entry.sessionId === session.sessionId,
+        );
+        throw new Error(
+          failure?.message ?? t('sidebar.standaloneActionFailed'),
+        );
+      });
+    },
+    [run, t, workspace.client],
+  );
+
+  const unarchiveSession = useCallback(
+    async (session: DaemonStandaloneSessionSummary) => {
+      await run(session.sessionId, async () => {
+        const result = await workspace.client.unarchiveStandaloneSessions([
+          session.sessionId,
+        ]);
+        if (
+          result.unarchived.includes(session.sessionId) ||
+          result.alreadyActive.includes(session.sessionId)
+        ) {
+          return;
+        }
+        const failure = result.errors.find(
+          (entry) => entry.sessionId === session.sessionId,
+        );
+        throw new Error(
+          failure?.message ?? t('sidebar.standaloneActionFailed'),
+        );
+      });
+    },
+    [run, t, workspace.client],
+  );
+
+  const deleteSession = useCallback(
+    async (session: DaemonStandaloneSessionSummary): Promise<boolean> =>
+      await run(session.sessionId, async () => {
+        const result = await workspace.client.deleteStandaloneSessions([
+          session.sessionId,
+        ]);
+        if (
+          !result.removed.includes(session.sessionId) &&
+          !result.notFound.includes(session.sessionId)
+        ) {
+          const failure = result.errors.find(
+            (entry) => entry.sessionId === session.sessionId,
+          );
+          throw new Error(
+            failure?.message ?? t('sidebar.standaloneActionFailed'),
+          );
+        }
+        if (result.fileCleanupPending.includes(session.sessionId)) {
+          onNotice(t('sidebar.standaloneCleanupPending'));
+        }
+      }),
+    [onNotice, run, t, workspace.client],
+  );
+
+  const openSession = useCallback(
+    async (sessionId: string) => {
+      try {
+        await onLoadSession(sessionId);
+      } catch (error) {
+        onError(error, t('session.loadFailed'));
+      }
+    },
+    [onError, onLoadSession, t],
+  );
+
+  if (!supported) return null;
+  if (collapsed) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        title={t('sidebar.recents')}
+        aria-label={t('sidebar.recents')}
+        onClick={onExpand}
+      >
+        <MessageSquareIcon />
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <section className="px-2 pb-3" aria-label={t('sidebar.recents')}>
+        <div className="flex items-center justify-between px-2 py-1 text-xs font-medium text-muted-foreground">
+          <span>{t('sidebar.recents')}</span>
+          {loading && <span>{t('common.loading')}</span>}
+        </div>
+        <div className="flex flex-col gap-0.5">
+          {active.map((session) => {
+            const isCurrent = session.sessionId === currentSessionId;
+            return (
+              <StandaloneRow
+                key={session.sessionId}
+                session={session}
+                active={isCurrent}
+                busy={busySessionId === session.sessionId}
+                onOpen={() => void openSession(session.sessionId)}
+                onRename={() => {
+                  setRenameCandidate(session);
+                  setRenameValue(sessionLabel(session));
+                }}
+                onExport={() => {
+                  void run(session.sessionId, async () => {
+                    downloadExport(
+                      await workspace.client.exportStandaloneSession(
+                        session.sessionId,
+                        { format: 'html' },
+                      ),
+                    );
+                  });
+                }}
+                onArchive={
+                  isCurrent ? undefined : () => void archiveSession(session)
+                }
+                onDelete={
+                  isCurrent ? undefined : () => setDeleteCandidate(session)
+                }
+              />
+            );
+          })}
+        </div>
+        {!loading && active.length === 0 && (
+          <div className="px-2 py-1 text-xs text-muted-foreground">
+            {t('sidebar.noRecents')}
+          </div>
+        )}
+        {activeCursor && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full"
+            disabled={loadingMore === 'active'}
+            onClick={() => void loadMore('active', activeCursor)}
+          >
+            {t('sidebar.showAllSessions')}
+          </Button>
+        )}
+        <button
+          type="button"
+          className="mt-1 flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs text-muted-foreground hover:bg-muted"
+          aria-expanded={archivedExpanded}
+          onClick={() => setArchivedExpanded((value) => !value)}
+        >
+          <ArchiveIcon size={13} />
+          {t('sidebar.archivedTitle')}
+        </button>
+        {archivedExpanded && archived.length === 0 && !loading && (
+          <div className="px-2 py-1 text-xs text-muted-foreground">
+            {t('sidebar.archivedEmpty')}
+          </div>
+        )}
+        {archivedExpanded &&
+          archived.map((session) => (
+            <StandaloneRow
+              key={session.sessionId}
+              session={session}
+              active={false}
+              busy={busySessionId === session.sessionId}
+              onOpen={() => undefined}
+              onExport={() => {
+                void run(session.sessionId, async () => {
+                  downloadExport(
+                    await workspace.client.exportStandaloneSession(
+                      session.sessionId,
+                      { format: 'html' },
+                    ),
+                  );
+                });
+              }}
+              onUnarchive={() => void unarchiveSession(session)}
+              onDelete={() => setDeleteCandidate(session)}
+            />
+          ))}
+        {archivedExpanded && archivedCursor && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full"
+            disabled={loadingMore === 'archived'}
+            onClick={() => void loadMore('archived', archivedCursor)}
+          >
+            {t('sidebar.showAllSessions')}
+          </Button>
+        )}
+      </section>
+      {renameCandidate && (
+        <DialogShell
+          title={t('sidebar.rename')}
+          size="sm"
+          onClose={() => setRenameCandidate(undefined)}
+        >
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const displayName = renameValue.trim();
+              if (!displayName) return;
+              void run(renameCandidate.sessionId, async () => {
+                await workspace.client.renameStandaloneSession(
+                  renameCandidate.sessionId,
+                  displayName,
+                );
+                onRenameSession?.(renameCandidate.sessionId, displayName);
+              }).then((succeeded) => {
+                if (succeeded) setRenameCandidate(undefined);
+              });
+            }}
+          >
+            <Input
+              autoFocus
+              value={renameValue}
+              onChange={(event) => setRenameValue(event.target.value)}
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setRenameCandidate(undefined)}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button type="submit" disabled={!renameValue.trim()}>
+                {t('common.save')}
+              </Button>
+            </div>
+          </form>
+        </DialogShell>
+      )}
+      {deleteCandidate && (
+        <DialogShell
+          title={t('sidebar.delete')}
+          size="sm"
+          onClose={() => setDeleteCandidate(undefined)}
+        >
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              {t('sidebar.standaloneDeleteConfirm')}
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setDeleteCandidate(undefined)}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => {
+                  void deleteSession(deleteCandidate).then((succeeded) => {
+                    if (succeeded) setDeleteCandidate(undefined);
+                  });
+                }}
+              >
+                {t('sidebar.delete')}
+              </Button>
+            </div>
+          </div>
+        </DialogShell>
+      )}
+    </>
+  );
+}
+
+function StandaloneRow({
+  session,
+  active,
+  busy,
+  onOpen,
+  onRename,
+  onExport,
+  onArchive,
+  onUnarchive,
+  onDelete,
+}: {
+  session: DaemonStandaloneSessionSummary;
+  active: boolean;
+  busy: boolean;
+  onOpen: () => void;
+  onRename?: () => void;
+  onExport: () => void;
+  onArchive?: () => void;
+  onUnarchive?: () => void;
+  onDelete?: () => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <div
+      className={`group flex items-center rounded px-1 ${active ? 'bg-muted' : 'hover:bg-muted/60'}`}
+    >
+      <button
+        type="button"
+        className="min-w-0 flex-1 truncate px-1 py-1.5 text-left text-sm"
+        title={sessionLabel(session)}
+        disabled={busy || session.isArchived === true}
+        onClick={onOpen}
+      >
+        {sessionLabel(session)}
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7"
+            aria-label={t('sidebar.sessionActions')}
+            disabled={busy}
+          >
+            <EllipsisIcon size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuGroup>
+            {onRename && (
+              <StandaloneAction
+                icon={<PencilIcon />}
+                label={t('sidebar.rename')}
+                onClick={onRename}
+              />
+            )}
+            <StandaloneAction
+              icon={<DownloadIcon />}
+              label={t('sidebar.export')}
+              onClick={onExport}
+            />
+            {onArchive && (
+              <StandaloneAction
+                icon={<ArchiveIcon />}
+                label={t('sidebar.archive')}
+                onClick={onArchive}
+              />
+            )}
+            {onUnarchive && (
+              <StandaloneAction
+                icon={<RotateCcwIcon />}
+                label={t('sidebar.unarchive')}
+                onClick={onUnarchive}
+              />
+            )}
+            {onDelete && (
+              <StandaloneAction
+                icon={<Trash2Icon />}
+                label={t('sidebar.delete')}
+                onClick={onDelete}
+                danger
+              />
+            )}
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+function StandaloneAction({
+  icon,
+  label,
+  onClick,
+  danger = false,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+}) {
+  return (
+    <DropdownMenuItem
+      className={danger ? 'text-destructive focus:text-destructive' : undefined}
+      onSelect={onClick}
+    >
+      <span className="size-4">{icon}</span>
+      {label}
+    </DropdownMenuItem>
+  );
+}

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
@@ -228,7 +228,8 @@ export function StandaloneRecents({
         ]);
         if (
           result.archived.includes(session.sessionId) ||
-          result.alreadyArchived.includes(session.sessionId)
+          result.alreadyArchived.includes(session.sessionId) ||
+          result.notFound?.includes(session.sessionId)
         ) {
           return;
         }
@@ -251,7 +252,8 @@ export function StandaloneRecents({
         ]);
         if (
           result.unarchived.includes(session.sessionId) ||
-          result.alreadyActive.includes(session.sessionId)
+          result.alreadyActive.includes(session.sessionId) ||
+          result.notFound?.includes(session.sessionId)
         ) {
           return;
         }

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
@@ -121,6 +121,8 @@ export function StandaloneRecents({
   const [archived, setArchived] = useState<DaemonStandaloneSessionSummary[]>(
     [],
   );
+  const archivedRef = useRef(archived);
+  archivedRef.current = archived;
   const [activeCursor, setActiveCursor] = useState<string>();
   const [archivedCursor, setArchivedCursor] = useState<string>();
   const [archivedExpanded, setArchivedExpanded] = useState(false);
@@ -171,29 +173,41 @@ export function StandaloneRecents({
     [onError, supported, t, workspace.client],
   );
 
-  const loadArchived = useCallback(async () => {
-    if (!supported) return;
-    const generation = archivedLoadGenerationRef.current + 1;
-    archivedLoadGenerationRef.current = generation;
-    setLoadingMore((current) => (current === 'archived' ? undefined : current));
-    setLoadingArchived(true);
-    try {
-      const page = await workspace.client.listStandaloneSessionsPage({
-        archiveState: 'archived',
-        pageSize: PAGE_SIZE,
-      });
-      if (archivedLoadGenerationRef.current !== generation) return;
-      setArchived(withoutChildren(page.sessions));
-      setArchivedCursor(page.nextCursor);
-    } catch (error) {
-      if (archivedLoadGenerationRef.current !== generation) return;
-      onError(error, t('sidebar.standaloneLoadFailed'));
-    } finally {
-      if (archivedLoadGenerationRef.current === generation) {
-        setLoadingArchived(false);
+  const loadArchived = useCallback(
+    async (preserveArchivedPages = false) => {
+      if (!supported) return;
+      const generation = archivedLoadGenerationRef.current + 1;
+      archivedLoadGenerationRef.current = generation;
+      setLoadingMore((current) =>
+        current === 'archived' ? undefined : current,
+      );
+      setLoadingArchived(true);
+      try {
+        const page = await workspace.client.listStandaloneSessionsPage({
+          archiveState: 'archived',
+          pageSize: PAGE_SIZE,
+        });
+        if (archivedLoadGenerationRef.current !== generation) return;
+        const archivedSessions = withoutChildren(page.sessions);
+        const preserveLoadedPages =
+          preserveArchivedPages && archivedRef.current.length > 0;
+        setArchived((current) =>
+          preserveLoadedPages
+            ? mergeRefreshedPage(current, archivedSessions)
+            : archivedSessions,
+        );
+        if (!preserveLoadedPages) setArchivedCursor(page.nextCursor);
+      } catch (error) {
+        if (archivedLoadGenerationRef.current !== generation) return;
+        onError(error, t('sidebar.standaloneLoadFailed'));
+      } finally {
+        if (archivedLoadGenerationRef.current === generation) {
+          setLoadingArchived(false);
+        }
       }
-    }
-  }, [onError, supported, t, workspace.client]);
+    },
+    [onError, supported, t, workspace.client],
+  );
 
   const loadMore = useCallback(
     async (archiveState: DaemonSessionArchiveState, cursor: string) => {
@@ -251,7 +265,7 @@ export function StandaloneRecents({
   }, [currentSessionId, load]);
 
   useEffect(() => {
-    if (archivedExpanded) void loadArchived();
+    if (archivedExpanded) void loadArchived(true);
   }, [archivedExpanded, loadArchived]);
 
   useEffect(() => {

--- a/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
+++ b/packages/web-shell/client/components/sidebar/StandaloneRecents.tsx
@@ -68,6 +68,17 @@ function appendUnique(
   ];
 }
 
+function mergeRefreshedPage(
+  current: readonly DaemonStandaloneSessionSummary[],
+  refreshed: readonly DaemonStandaloneSessionSummary[],
+): DaemonStandaloneSessionSummary[] {
+  const refreshedIds = new Set(refreshed.map((session) => session.sessionId));
+  return [
+    ...refreshed,
+    ...current.filter((session) => !refreshedIds.has(session.sessionId)),
+  ];
+}
+
 function downloadExport(result: {
   content: string;
   filename: string;
@@ -101,16 +112,20 @@ export function StandaloneRecents({
   const streamingState = useStreamingState();
   const previousStreamingStateRef = useRef(streamingState);
   const loadGenerationRef = useRef(0);
+  const archivedLoadGenerationRef = useRef(0);
   const busySessionIdRef = useRef<string | undefined>(undefined);
   const { t } = useI18n();
   const [active, setActive] = useState<DaemonStandaloneSessionSummary[]>([]);
+  const activeRef = useRef(active);
+  activeRef.current = active;
   const [archived, setArchived] = useState<DaemonStandaloneSessionSummary[]>(
     [],
   );
   const [activeCursor, setActiveCursor] = useState<string>();
   const [archivedCursor, setArchivedCursor] = useState<string>();
   const [archivedExpanded, setArchivedExpanded] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [loadingActive, setLoadingActive] = useState(false);
+  const [loadingArchived, setLoadingArchived] = useState(false);
   const [loadingMore, setLoadingMore] = useState<DaemonSessionArchiveState>();
   const [busySessionId, setBusySessionId] = useState<string>();
   const [renameCandidate, setRenameCandidate] =
@@ -122,45 +137,71 @@ export function StandaloneRecents({
     workspace.capabilities?.features?.includes(
       STANDALONE_SESSIONS_CAPABILITY,
     ) === true;
+  const loading = loadingActive || (archivedExpanded && loadingArchived);
 
-  const load = useCallback(async () => {
-    if (!supported) return;
-    const generation = loadGenerationRef.current + 1;
-    loadGenerationRef.current = generation;
-    setLoadingMore(undefined);
-    setLoading(true);
-    try {
-      const [activePage, archivedPage] = await Promise.all([
-        workspace.client.listStandaloneSessionsPage({
+  const load = useCallback(
+    async (preserveActivePages = false) => {
+      if (!supported) return;
+      const generation = loadGenerationRef.current + 1;
+      loadGenerationRef.current = generation;
+      setLoadingMore((current) => (current === 'active' ? undefined : current));
+      setLoadingActive(true);
+      try {
+        const activePage = await workspace.client.listStandaloneSessionsPage({
           archiveState: 'active',
           pageSize: PAGE_SIZE,
-        }),
-        archivedExpanded
-          ? workspace.client.listStandaloneSessionsPage({
-              archiveState: 'archived',
-              pageSize: PAGE_SIZE,
-            })
-          : undefined,
-      ]);
-      if (loadGenerationRef.current !== generation) return;
-      setActive(withoutChildren(activePage.sessions));
-      setActiveCursor(activePage.nextCursor);
-      if (archivedPage) {
-        setArchived(withoutChildren(archivedPage.sessions));
-        setArchivedCursor(archivedPage.nextCursor);
+        });
+        if (loadGenerationRef.current !== generation) return;
+        const activeSessions = withoutChildren(activePage.sessions);
+        const preserveLoadedPages =
+          preserveActivePages && activeRef.current.length > 0;
+        setActive((current) =>
+          preserveLoadedPages
+            ? mergeRefreshedPage(current, activeSessions)
+            : activeSessions,
+        );
+        if (!preserveLoadedPages) setActiveCursor(activePage.nextCursor);
+      } catch (error) {
+        if (loadGenerationRef.current !== generation) return;
+        onError(error, t('sidebar.standaloneLoadFailed'));
+      } finally {
+        if (loadGenerationRef.current === generation) setLoadingActive(false);
       }
+    },
+    [onError, supported, t, workspace.client],
+  );
+
+  const loadArchived = useCallback(async () => {
+    if (!supported) return;
+    const generation = archivedLoadGenerationRef.current + 1;
+    archivedLoadGenerationRef.current = generation;
+    setLoadingMore((current) => (current === 'archived' ? undefined : current));
+    setLoadingArchived(true);
+    try {
+      const page = await workspace.client.listStandaloneSessionsPage({
+        archiveState: 'archived',
+        pageSize: PAGE_SIZE,
+      });
+      if (archivedLoadGenerationRef.current !== generation) return;
+      setArchived(withoutChildren(page.sessions));
+      setArchivedCursor(page.nextCursor);
     } catch (error) {
-      if (loadGenerationRef.current !== generation) return;
+      if (archivedLoadGenerationRef.current !== generation) return;
       onError(error, t('sidebar.standaloneLoadFailed'));
     } finally {
-      if (loadGenerationRef.current === generation) setLoading(false);
+      if (archivedLoadGenerationRef.current === generation) {
+        setLoadingArchived(false);
+      }
     }
-  }, [archivedExpanded, onError, supported, t, workspace.client]);
+  }, [onError, supported, t, workspace.client]);
 
   const loadMore = useCallback(
     async (archiveState: DaemonSessionArchiveState, cursor: string) => {
       if (loadingMore) return;
-      const generation = loadGenerationRef.current;
+      const generation =
+        archiveState === 'active'
+          ? loadGenerationRef.current
+          : archivedLoadGenerationRef.current;
       setLoadingMore(archiveState);
       try {
         const page = await workspace.client.listStandaloneSessionsPage({
@@ -168,7 +209,13 @@ export function StandaloneRecents({
           cursor,
           pageSize: PAGE_SIZE,
         });
-        if (loadGenerationRef.current !== generation) return;
+        if (
+          (archiveState === 'active'
+            ? loadGenerationRef.current
+            : archivedLoadGenerationRef.current) !== generation
+        ) {
+          return;
+        }
         const sessions = withoutChildren(page.sessions);
         if (archiveState === 'active') {
           setActive((current) => appendUnique(current, sessions));
@@ -178,36 +225,57 @@ export function StandaloneRecents({
           setArchivedCursor(page.nextCursor);
         }
       } catch (error) {
-        if (loadGenerationRef.current !== generation) return;
+        if (
+          (archiveState === 'active'
+            ? loadGenerationRef.current
+            : archivedLoadGenerationRef.current) !== generation
+        ) {
+          return;
+        }
         onError(error, t('sidebar.standaloneLoadFailed'));
       } finally {
-        if (loadGenerationRef.current === generation) setLoadingMore(undefined);
+        if (
+          (archiveState === 'active'
+            ? loadGenerationRef.current
+            : archivedLoadGenerationRef.current) === generation
+        ) {
+          setLoadingMore(undefined);
+        }
       }
     },
     [loadingMore, onError, t, workspace.client],
   );
 
   useEffect(() => {
-    void load();
+    void load(true);
   }, [currentSessionId, load]);
+
+  useEffect(() => {
+    if (archivedExpanded) void loadArchived();
+  }, [archivedExpanded, loadArchived]);
 
   useEffect(() => {
     const previous = previousStreamingStateRef.current;
     previousStreamingStateRef.current = streamingState;
-    if (previous !== 'idle' && streamingState === 'idle') void load();
+    if (previous !== 'idle' && streamingState === 'idle') void load(true);
   }, [load, streamingState]);
+
+  const refreshLists = useCallback(async () => {
+    await Promise.all([load(), archivedExpanded ? loadArchived() : undefined]);
+  }, [archivedExpanded, load, loadArchived]);
 
   const run = useCallback(
     async (
       sessionId: string,
       action: () => Promise<void>,
+      refresh = true,
     ): Promise<boolean> => {
       if (busySessionIdRef.current) return false;
       busySessionIdRef.current = sessionId;
       setBusySessionId(sessionId);
       try {
         await action();
-        await load();
+        if (refresh) await refreshLists();
         return true;
       } catch (error) {
         onError(error, t('sidebar.standaloneActionFailed'));
@@ -217,7 +285,7 @@ export function StandaloneRecents({
         setBusySessionId(undefined);
       }
     },
-    [load, onError, t],
+    [onError, refreshLists, t],
   );
 
   const archiveSession = useCallback(
@@ -341,14 +409,18 @@ export function StandaloneRecents({
                   setRenameValue(sessionLabel(session));
                 }}
                 onExport={() => {
-                  void run(session.sessionId, async () => {
-                    downloadExport(
-                      await workspace.client.exportStandaloneSession(
-                        session.sessionId,
-                        { format: 'html' },
-                      ),
-                    );
-                  });
+                  void run(
+                    session.sessionId,
+                    async () => {
+                      downloadExport(
+                        await workspace.client.exportStandaloneSession(
+                          session.sessionId,
+                          { format: 'html' },
+                        ),
+                      );
+                    },
+                    false,
+                  );
                 }}
                 onArchive={
                   isCurrent ? undefined : () => void archiveSession(session)
@@ -400,14 +472,18 @@ export function StandaloneRecents({
               busy={busySessionId === session.sessionId}
               onOpen={() => undefined}
               onExport={() => {
-                void run(session.sessionId, async () => {
-                  downloadExport(
-                    await workspace.client.exportStandaloneSession(
-                      session.sessionId,
-                      { format: 'html' },
-                    ),
-                  );
-                });
+                void run(
+                  session.sessionId,
+                  async () => {
+                    downloadExport(
+                      await workspace.client.exportStandaloneSession(
+                        session.sessionId,
+                        { format: 'html' },
+                      ),
+                    );
+                  },
+                  false,
+                );
               }}
               onUnarchive={() => void unarchiveSession(session)}
               onDelete={() => setDeleteCandidate(session)}
@@ -438,13 +514,27 @@ export function StandaloneRecents({
               event.preventDefault();
               const displayName = renameValue.trim();
               if (!displayName) return;
-              void run(renameCandidate.sessionId, async () => {
-                await workspace.client.renameStandaloneSession(
-                  renameCandidate.sessionId,
-                  displayName,
-                );
-                onRenameSession?.(renameCandidate.sessionId, displayName);
-              }).then((succeeded) => {
+              void run(
+                renameCandidate.sessionId,
+                async () => {
+                  await workspace.client.renameStandaloneSession(
+                    renameCandidate.sessionId,
+                    displayName,
+                  );
+                  const updateName = (
+                    sessions: readonly DaemonStandaloneSessionSummary[],
+                  ) =>
+                    sessions.map((session) =>
+                      session.sessionId === renameCandidate.sessionId
+                        ? { ...session, displayName }
+                        : session,
+                    );
+                  setActive(updateName);
+                  setArchived(updateName);
+                  onRenameSession?.(renameCandidate.sessionId, displayName);
+                },
+                false,
+              ).then((succeeded) => {
                 if (succeeded) setRenameCandidate(undefined);
               });
             }}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -2820,6 +2820,15 @@ export function WebShellSidebar({
     }
   }, [cancelRename, collapsed, collapsedSessionsOpen]);
 
+  useEffect(() => {
+    if (projectFeaturesEnabled) return;
+    setCollapsedSessionsOpen(false);
+    setSearchOpen(false);
+    setSearchQuery('');
+    cancelRename();
+    setGroupMenu(null);
+  }, [cancelRename, projectFeaturesEnabled]);
+
   const saveRename = useCallback(() => {
     const nextName = editingName.trim();
     if (

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -126,6 +126,7 @@ import {
 } from '../../session-catalog/session-catalog-hooks';
 import { type SessionCatalogQuery } from '../../session-catalog/session-catalog-store';
 import { useWorkspaceSessionLiveState } from '../../session-catalog/workspace-session-live-state';
+import { StandaloneRecents } from './StandaloneRecents';
 
 const SIDEBAR_WIDTH_STORAGE_KEY = 'qwen-code-web-shell-sidebar-width';
 const SIDEBAR_DEFAULT_WIDTH = 260;
@@ -390,13 +391,14 @@ interface WebShellSidebarProps {
   /** Whether to offer the in-window split view (large screens only). */
   canOpenSplitView?: boolean;
   onNewSession: (workspaceCwd?: string) => Promise<boolean> | boolean;
+  globalNewSessionUsesStandalone?: boolean;
   onLoadSession: (
     sessionId: string,
     workspaceCwd?: string,
   ) => Promise<void> | void;
   onSelectCurrentSession?: () => void;
   onSessionRenameConfirmed?: (
-    workspaceCwd: string,
+    workspaceCwd: string | undefined,
     sessionId: string,
     displayName: string,
   ) => void;
@@ -454,6 +456,9 @@ interface WebShellSidebarProps {
   onNewWorktreeSession?: (
     workspaceCwd?: string,
   ) => Promise<boolean> | boolean | void;
+  projectFeaturesEnabled?: boolean;
+  onLoadStandaloneSession?: (sessionId: string) => Promise<void> | void;
+  onStandaloneNotice?: (message: string) => void;
 }
 
 function cx(...classes: Array<string | false | undefined>): string {
@@ -882,6 +887,7 @@ export function WebShellSidebar({
   onOpenSplitView,
   canOpenSplitView,
   onNewSession,
+  globalNewSessionUsesStandalone = false,
   onLoadSession,
   onSelectCurrentSession,
   onSessionRenameConfirmed,
@@ -908,6 +914,9 @@ export function WebShellSidebar({
   workspaceOverview,
   onOpenWorkspaceManagement,
   onNewWorktreeSession,
+  projectFeaturesEnabled = true,
+  onLoadStandaloneSession,
+  onStandaloneNotice,
 }: WebShellSidebarProps) {
   const { t } = useI18n();
   const connection = useConnection();
@@ -927,10 +936,11 @@ export function WebShellSidebar({
     [primaryNavOptions?.items],
   );
   const hasScrollingPrimaryNav =
-    primaryNavItems.has('plugins') ||
-    primaryNavItems.has('channels') ||
-    primaryNavItems.has('scheduledTasks') ||
-    primaryNavItems.has('goals') ||
+    (projectFeaturesEnabled &&
+      (primaryNavItems.has('plugins') ||
+        primaryNavItems.has('channels') ||
+        primaryNavItems.has('scheduledTasks') ||
+        primaryNavItems.has('goals'))) ||
     Boolean(primaryNavOptions?.render);
   const sessionActionItems = useMemo(
     () => new Set(sessionActionsOptions?.items ?? DEFAULT_SESSION_ACTION_ITEMS),
@@ -946,7 +956,8 @@ export function WebShellSidebar({
   const shouldRenderBrand =
     branding !== false && !(mobileOpen && (branding?.hideWhenCompact ?? true));
   const organizationEnabled = Boolean(
-    connection.capabilities?.features?.includes(SESSION_ORGANIZATION_FEATURE),
+    projectFeaturesEnabled &&
+      connection.capabilities?.features?.includes(SESSION_ORGANIZATION_FEATURE),
   );
   const sourceMetadataEnabled = Boolean(
     connection.capabilities?.features?.includes('session_source_metadata'),
@@ -964,7 +975,8 @@ export function WebShellSidebar({
       : 'default'
     : undefined;
   const channelGroupingEnabled = Boolean(
-    selectedSessionSource === 'channel' &&
+    projectFeaturesEnabled &&
+      selectedSessionSource === 'channel' &&
       workspace.capabilities?.features.includes('channel_management'),
   );
   const {
@@ -990,7 +1002,8 @@ export function WebShellSidebar({
       'workspace_session_live_state',
     ) && typeof workspace.client.getWorkspaceSessionLiveState === 'function',
   );
-  const sessionCatalogRequestsEnabled = connection.capabilities !== undefined;
+  const sessionCatalogRequestsEnabled =
+    projectFeaturesEnabled && connection.capabilities !== undefined;
   const workspaceSessionMetadataEnabled = Boolean(
     connection.capabilities?.features?.includes('workspace_session_metadata'),
   );
@@ -1060,7 +1073,9 @@ export function WebShellSidebar({
     [channelGroupingEnabled, displayedWorkspaces, organizationEnabled],
   );
   const workspaceSessionLiveStateEnabled =
-    workspaceSessionLiveStateSupported && liveStateWorkspaceCwds.length > 0;
+    projectFeaturesEnabled &&
+    workspaceSessionLiveStateSupported &&
+    liveStateWorkspaceCwds.length > 0;
   const primaryWorkspaceSessionLiveStateEnabled = Boolean(
     workspaceSessionLiveStateEnabled &&
       primaryWorkspaceCwd &&
@@ -2648,7 +2663,11 @@ export function WebShellSidebar({
           const created = await onNewSession(workspaceCwd);
           if (created) {
             bumpWorkspaceReload();
-            const ownerCwd = workspaceCwd ?? primaryWorkspaceCwd;
+            const ownerCwd =
+              workspaceCwd ??
+              (globalNewSessionUsesStandalone
+                ? undefined
+                : primaryWorkspaceCwd);
             if (ownerCwd) {
               sessionCatalogController.refreshWorkspace(ownerCwd);
             }
@@ -2665,6 +2684,7 @@ export function WebShellSidebar({
     },
     [
       bumpWorkspaceReload,
+      globalNewSessionUsesStandalone,
       onError,
       onNewSession,
       primaryWorkspaceCwd,
@@ -5312,7 +5332,7 @@ export function WebShellSidebar({
         >
           {hasScrollingPrimaryNav && (
             <div className={styles.primaryNav}>
-              {primaryNavItems.has('plugins') && (
+              {projectFeaturesEnabled && primaryNavItems.has('plugins') && (
                 <button
                   className={styles.pluginButton}
                   type="button"
@@ -5326,7 +5346,7 @@ export function WebShellSidebar({
                   {!collapsed && <span>{t('sidebar.plugins')}</span>}
                 </button>
               )}
-              {primaryNavItems.has('channels') && (
+              {projectFeaturesEnabled && primaryNavItems.has('channels') && (
                 <button
                   className={styles.pluginButton}
                   type="button"
@@ -5340,21 +5360,22 @@ export function WebShellSidebar({
                   {!collapsed && <span>{t('sidebar.channels')}</span>}
                 </button>
               )}
-              {primaryNavItems.has('scheduledTasks') && (
-                <button
-                  className={styles.pluginButton}
-                  type="button"
-                  title={t('sidebar.scheduledTasks')}
-                  aria-label={t('sidebar.scheduledTasks')}
-                  onClick={onOpenScheduledTasks}
-                >
-                  <span className={styles.navIcon}>
-                    <CalendarClockIcon size={16} strokeWidth={1.2} />
-                  </span>
-                  {!collapsed && <span>{t('sidebar.scheduledTasks')}</span>}
-                </button>
-              )}
-              {primaryNavItems.has('goals') && (
+              {projectFeaturesEnabled &&
+                primaryNavItems.has('scheduledTasks') && (
+                  <button
+                    className={styles.pluginButton}
+                    type="button"
+                    title={t('sidebar.scheduledTasks')}
+                    aria-label={t('sidebar.scheduledTasks')}
+                    onClick={onOpenScheduledTasks}
+                  >
+                    <span className={styles.navIcon}>
+                      <CalendarClockIcon size={16} strokeWidth={1.2} />
+                    </span>
+                    {!collapsed && <span>{t('sidebar.scheduledTasks')}</span>}
+                  </button>
+                )}
+              {projectFeaturesEnabled && primaryNavItems.has('goals') && (
                 <button
                   className={styles.pluginButton}
                   type="button"
@@ -5371,526 +5392,553 @@ export function WebShellSidebar({
               {primaryNavOptions?.render?.()}
             </div>
           )}
-          <SidebarSessionSurface
-            collapsed={collapsed}
-            label={t('sidebar.project')}
-            status={collapsedSessionStatus}
-            statusLabel={collapsedSessionStatusLabel}
-            width={sidebarWidth}
-            open={collapsedSessionsOpen}
-            onOpenChange={setCollapsedSessionsOpen}
-            isCloseBlocked={isCollapsedCloseBlocked}
-          >
-            {showSessionSourceSwitch && sourceMetadataEnabled && (
-              <Tabs
-                className="px-2 pb-2"
-                value={sessionSource}
-                onValueChange={(value) =>
-                  setSessionSource(value as SidebarSessionSource)
-                }
-              >
-                <TabsList
-                  className="w-full"
-                  aria-label={t('sidebar.sessionSource')}
+          {onLoadStandaloneSession && onStandaloneNotice && (
+            <StandaloneRecents
+              collapsed={collapsed}
+              onExpand={() => onCollapsedChange(false)}
+              currentSessionId={connection.sessionId}
+              onLoadSession={onLoadStandaloneSession}
+              onRenameSession={(sessionId, displayName) =>
+                onSessionRenameConfirmed?.(undefined, sessionId, displayName)
+              }
+              onError={onError}
+              onNotice={onStandaloneNotice}
+            />
+          )}
+          {projectFeaturesEnabled && (
+            <SidebarSessionSurface
+              collapsed={collapsed}
+              label={t('sidebar.project')}
+              status={collapsedSessionStatus}
+              statusLabel={collapsedSessionStatusLabel}
+              width={sidebarWidth}
+              open={collapsedSessionsOpen}
+              onOpenChange={setCollapsedSessionsOpen}
+              isCloseBlocked={isCollapsedCloseBlocked}
+            >
+              {showSessionSourceSwitch && sourceMetadataEnabled && (
+                <Tabs
+                  className="px-2 pb-2"
+                  value={sessionSource}
+                  onValueChange={(value) =>
+                    setSessionSource(value as SidebarSessionSource)
+                  }
                 >
-                  <TabsTrigger value="default">
-                    <ListTodoIcon />
-                    {t('sidebar.sessionSource.tasks')}
-                  </TabsTrigger>
-                  <TabsTrigger value="channel">
-                    <MessageCircleIcon />
-                    {t('sidebar.sessionSource.channels')}
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-            )}
-            {selectedSessionSource !== 'channel' &&
-              pinnedSessions.length > 0 && (
-                <>
-                  <div className={styles.projectsHeader}>
-                    <button
-                      className={styles.projectsHeaderToggle}
-                      type="button"
-                      aria-expanded={pinnedExpanded}
-                      onClick={() => setPinnedExpanded((expanded) => !expanded)}
-                    >
-                      <span>{t('sidebar.pinnedSessions')}</span>
-                      <IconChevron expanded={pinnedExpanded} />
-                    </button>
-                  </div>
-                  {pinnedExpanded && (
-                    <div className={styles.pinnedSessionList}>
-                      {pinnedSessions.map((session) =>
-                        renderSessionRow(session),
-                      )}
-                    </div>
-                  )}
-                </>
+                  <TabsList
+                    className="w-full"
+                    aria-label={t('sidebar.sessionSource')}
+                  >
+                    <TabsTrigger value="default">
+                      <ListTodoIcon />
+                      {t('sidebar.sessionSource.tasks')}
+                    </TabsTrigger>
+                    <TabsTrigger value="channel">
+                      <MessageCircleIcon />
+                      {t('sidebar.sessionSource.channels')}
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
               )}
-            {liveWorkspaces.map((ws) => (
-              <WorkspaceSection
-                key={ws.id}
-                workspace={ws}
-                renderHeader={(expanded) => (
+              {selectedSessionSource !== 'channel' &&
+                pinnedSessions.length > 0 && (
                   <>
-                    <RadioTowerIcon
-                      size={16}
-                      strokeWidth={1.2}
-                      aria-hidden="true"
-                    />
-                    <span className={styles.liveWorkspaceLabel}>
-                      {t('sidebar.live')}
-                    </span>
-                    {expanded ? (
-                      <ChevronDownIcon
-                        size={15}
-                        strokeWidth={1.8}
-                        aria-hidden="true"
-                      />
-                    ) : (
-                      <ChevronRightIcon
-                        size={15}
-                        strokeWidth={1.8}
-                        aria-hidden="true"
-                      />
+                    <div className={styles.projectsHeader}>
+                      <button
+                        className={styles.projectsHeaderToggle}
+                        type="button"
+                        aria-expanded={pinnedExpanded}
+                        onClick={() =>
+                          setPinnedExpanded((expanded) => !expanded)
+                        }
+                      >
+                        <span>{t('sidebar.pinnedSessions')}</span>
+                        <IconChevron expanded={pinnedExpanded} />
+                      </button>
+                    </div>
+                    {pinnedExpanded && (
+                      <div className={styles.pinnedSessionList}>
+                        {pinnedSessions.map((session) =>
+                          renderSessionRow(session),
+                        )}
+                      </div>
                     )}
                   </>
                 )}
-                client={workspace.client}
-                reloadToken={workspaceSessionsReloadToken}
-                untrustedLabel={t('sidebar.workspaceUntrusted')}
-                readOnlyLabel={t('sidebar.workspaceReadOnly')}
-                trustToOpenLabel={t('sidebar.workspaceTrustToOpen')}
-                noSessionsLabel={t('sidebar.noSessions')}
-                loadErrorLabel={t('sidebar.loadFailed')}
-                organizationEnabled={false}
-                sessionCatalogRequestsEnabled={sessionCatalogRequestsEnabled}
-                sessionLiveStateEnabled={
-                  workspaceSessionLiveStateEnabled &&
-                  liveStateWorkspaceCwdSet.has(ws.cwd)
-                }
-                sourceType={sourceMetadataEnabled ? 'default' : undefined}
-                channelGroupingEnabled={false}
-                ungroupedLabel={t('sidebar.groupUngrouped')}
-                excludePinned={selectedSessionSource !== 'channel'}
-                mapSession={applyOptimisticPin}
-                limitSessions={editingSessionIdentity === null}
-                autoExpandKey={
-                  autoExpandWorkspace?.id === ws.id
-                    ? autoExpandWorkspace.key
-                    : undefined
-                }
-                renderSession={(session) =>
-                  renderSessionRow({ ...session, workspaceCwd: ws.cwd })
-                }
-                showSessionDetails={sessionActionItems.has('details')}
-              />
-            ))}
-            {!hideProjectHeader && (
-              <div className={styles.projectsHeader}>
-                <button
-                  className={styles.projectsHeaderToggle}
-                  type="button"
-                  aria-expanded={projectsExpanded}
-                  onClick={() => {
-                    const nextExpanded = !projectsExpanded;
-                    writeWorkspaceExpanded('projects', nextExpanded);
-                    setProjectsExpanded(nextExpanded);
-                  }}
-                >
-                  <span>{t('sidebar.project')}</span>
-                  {workspaceOverviewEnabled && projectWorkspaces.length > 1 && (
-                    <span
-                      className={styles.projectsHeaderCount}
-                      aria-label={t('sidebar.workspaceCount', {
-                        count: projectWorkspaces.length,
-                      })}
-                      title={t('sidebar.workspaceCount', {
-                        count: projectWorkspaces.length,
-                      })}
-                    >
-                      {projectWorkspaces.length}
-                    </span>
+              {liveWorkspaces.map((ws) => (
+                <WorkspaceSection
+                  key={ws.id}
+                  workspace={ws}
+                  renderHeader={(expanded) => (
+                    <>
+                      <RadioTowerIcon
+                        size={16}
+                        strokeWidth={1.2}
+                        aria-hidden="true"
+                      />
+                      <span className={styles.liveWorkspaceLabel}>
+                        {t('sidebar.live')}
+                      </span>
+                      {expanded ? (
+                        <ChevronDownIcon
+                          size={15}
+                          strokeWidth={1.8}
+                          aria-hidden="true"
+                        />
+                      ) : (
+                        <ChevronRightIcon
+                          size={15}
+                          strokeWidth={1.8}
+                          aria-hidden="true"
+                        />
+                      )}
+                    </>
                   )}
-                  <IconChevron expanded={projectsExpanded} />
-                </button>
-                <div className={styles.projectsHeaderActions}>
+                  client={workspace.client}
+                  reloadToken={workspaceSessionsReloadToken}
+                  untrustedLabel={t('sidebar.workspaceUntrusted')}
+                  readOnlyLabel={t('sidebar.workspaceReadOnly')}
+                  trustToOpenLabel={t('sidebar.workspaceTrustToOpen')}
+                  noSessionsLabel={t('sidebar.noSessions')}
+                  loadErrorLabel={t('sidebar.loadFailed')}
+                  organizationEnabled={false}
+                  sessionCatalogRequestsEnabled={sessionCatalogRequestsEnabled}
+                  sessionLiveStateEnabled={
+                    workspaceSessionLiveStateEnabled &&
+                    liveStateWorkspaceCwdSet.has(ws.cwd)
+                  }
+                  sourceType={sourceMetadataEnabled ? 'default' : undefined}
+                  channelGroupingEnabled={false}
+                  ungroupedLabel={t('sidebar.groupUngrouped')}
+                  excludePinned={selectedSessionSource !== 'channel'}
+                  mapSession={applyOptimisticPin}
+                  limitSessions={editingSessionIdentity === null}
+                  autoExpandKey={
+                    autoExpandWorkspace?.id === ws.id
+                      ? autoExpandWorkspace.key
+                      : undefined
+                  }
+                  renderSession={(session) =>
+                    renderSessionRow({ ...session, workspaceCwd: ws.cwd })
+                  }
+                  showSessionDetails={sessionActionItems.has('details')}
+                />
+              ))}
+              {!hideProjectHeader && (
+                <div className={styles.projectsHeader}>
                   <button
-                    className={styles.projectsHeaderAction}
+                    className={styles.projectsHeaderToggle}
                     type="button"
-                    title={t('sidebar.search')}
-                    aria-label={t('sidebar.search')}
+                    aria-expanded={projectsExpanded}
                     onClick={() => {
-                      setSearchOpen((open) => {
-                        if (open) setSearchQuery('');
-                        return !open;
-                      });
-                      setProjectsExpanded(true);
+                      const nextExpanded = !projectsExpanded;
+                      writeWorkspaceExpanded('projects', nextExpanded);
+                      setProjectsExpanded(nextExpanded);
                     }}
                   >
-                    <SearchIcon />
+                    <span>{t('sidebar.project')}</span>
+                    {workspaceOverviewEnabled &&
+                      projectWorkspaces.length > 1 && (
+                        <span
+                          className={styles.projectsHeaderCount}
+                          aria-label={t('sidebar.workspaceCount', {
+                            count: projectWorkspaces.length,
+                          })}
+                          title={t('sidebar.workspaceCount', {
+                            count: projectWorkspaces.length,
+                          })}
+                        >
+                          {projectWorkspaces.length}
+                        </span>
+                      )}
+                    <IconChevron expanded={projectsExpanded} />
                   </button>
-                  {!lockedWorkspaceCwd && onOpenAddWorkspace && (
+                  <div className={styles.projectsHeaderActions}>
                     <button
                       className={styles.projectsHeaderAction}
                       type="button"
-                      title={t('sidebar.addWorkspace')}
-                      aria-label={t('sidebar.addWorkspace')}
-                      onClick={onOpenAddWorkspace}
+                      title={t('sidebar.search')}
+                      aria-label={t('sidebar.search')}
+                      onClick={() => {
+                        setSearchOpen((open) => {
+                          if (open) setSearchQuery('');
+                          return !open;
+                        });
+                        setProjectsExpanded(true);
+                      }}
                     >
-                      <PlusIcon />
+                      <SearchIcon />
                     </button>
-                  )}
+                    {!lockedWorkspaceCwd && onOpenAddWorkspace && (
+                      <button
+                        className={styles.projectsHeaderAction}
+                        type="button"
+                        title={t('sidebar.addWorkspace')}
+                        aria-label={t('sidebar.addWorkspace')}
+                        onClick={onOpenAddWorkspace}
+                      >
+                        <PlusIcon />
+                      </button>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
-            {searchOpen && !hideProjectHeader && (
-              <div className={styles.projectSearch}>
-                <SearchIcon aria-hidden="true" />
-                <Input
-                  value={searchQuery}
-                  placeholder={t('sidebar.searchPlaceholder')}
-                  aria-label={t('sidebar.search')}
-                  autoFocus
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Escape') {
-                      setSearchQuery('');
-                      setSearchOpen(false);
-                    }
-                  }}
-                />
-              </div>
-            )}
-            {projectsExpanded && (
-              <>
-                <div className={styles.workspacePicker}>
-                  <div className={styles.workspaceList}>
-                    {projectWorkspaces.map((ws) => (
-                      <Fragment key={ws.id}>
-                        <WorkspaceSection
-                          workspace={ws}
-                          renderHeader={
-                            lockedWorkspaceCwd && lockedWorkspaceOptions?.render
-                              ? (expanded) =>
-                                  lockedWorkspaceOptions.render?.(ws, {
-                                    expanded,
-                                  })
-                              : undefined
-                          }
-                          client={workspace.client}
-                          reloadToken={workspaceSessionsReloadToken}
-                          untrustedLabel={t('sidebar.workspaceUntrusted')}
-                          readOnlyLabel={t('sidebar.workspaceReadOnly')}
-                          trustToOpenLabel={t('sidebar.workspaceTrustToOpen')}
-                          noSessionsLabel={t('sidebar.noSessions')}
-                          loadErrorLabel={t('sidebar.loadFailed')}
-                          organizationEnabled={organizationEnabled}
-                          sessionCatalogRequestsEnabled={
-                            sessionCatalogRequestsEnabled
-                          }
-                          sessionGroupCatalog={
-                            workspaceSessionLiveStateEnabled &&
-                            liveStateWorkspaceCwdSet.has(ws.cwd)
-                              ? liveStateGroupCatalogs.get(ws.cwd)
-                              : undefined
-                          }
-                          sessionLiveStateEnabled={
-                            workspaceSessionLiveStateEnabled &&
-                            liveStateWorkspaceCwdSet.has(ws.cwd)
-                          }
-                          sourceType={selectedSessionSource}
-                          channelGroupingEnabled={channelGroupingEnabled}
-                          ungroupedLabel={t('sidebar.groupUngrouped')}
-                          onRenameGroup={
-                            canOrganizeWorkspace(ws.cwd)
-                              ? handleRenameGroup
-                              : undefined
-                          }
-                          onDeleteGroup={
-                            canOrganizeWorkspace(ws.cwd)
-                              ? handleDeleteGroup
-                              : undefined
-                          }
-                          renameGroupLabel={t('sidebar.groupRename')}
-                          deleteGroupLabel={t('sidebar.groupDelete')}
-                          groupActionsDisabled={groupBusy}
-                          excludePinned={selectedSessionSource !== 'channel'}
-                          mapSession={applyOptimisticPin}
-                          limitSessions={editingSessionIdentity === null}
-                          onOpenGitDiff={onOpenGitDiff}
-                          onOpenCommit={onOpenCommit}
-                          searchQuery={searchQuery}
-                          expanded={ws.primary ? projectExpanded : undefined}
-                          autoExpandKey={
-                            autoExpandWorkspace?.id === ws.id
-                              ? autoExpandWorkspace?.key
-                              : undefined
-                          }
-                          onExpandedChange={
-                            ws.primary
-                              ? (expanded) => {
-                                  writeWorkspaceExpanded(
-                                    primaryWorkspaceExpansionId,
-                                    expanded,
-                                  );
-                                  setProjectExpanded(expanded);
-                                }
-                              : undefined
-                          }
-                          renderSessions={!ws.primary}
-                          renderSession={(session) =>
-                            renderSessionRow(
-                              {
-                                ...session,
-                                workspaceCwd: ws.cwd,
-                              },
-                              {
-                                // Pinned members also render in the
-                                // sidebar-level Pinned section; while that
-                                // section is expanded its row hosts the
-                                // rename form, so this duplicate row must
-                                // not mount a second autofocused input.
-                                // Channel mode has no Pinned section, so
-                                // the workspace row is the only copy and
-                                // must stay editable. The suppression also
-                                // requires the Pinned section to actually
-                                // carry the member: `pinnedSessions` merges
-                                // only the pinned catalog pages and the
-                                // primary sessions page, never this
-                                // workspace's own page, so before the
-                                // pinned page settles (or while it errors)
-                                // this row is the only copy and must host
-                                // the form itself.
-                                renameFormDisabled:
-                                  selectedSessionSource !== 'channel' &&
-                                  Boolean(session.isPinned) &&
-                                  pinnedExpanded &&
-                                  pinnedSessions.some(
-                                    (candidate) =>
-                                      getIdentityForSession(candidate) ===
-                                      getIdentityForSession(session),
-                                  ),
-                              },
-                            )
-                          }
-                          showSessionDetails={sessionActionItems.has('details')}
-                          overviewEnabled={workspaceOverviewEnabled}
-                          overviewItems={workspaceOverviewItems}
-                          compact={footerTight}
-                          gitBranchWanted={
-                            Boolean(onNewWorktreeSession) && !lockedWorkspaceCwd
-                          }
-                          sessionStats={
-                            ws.primary
-                              ? (primarySessionStats ?? null)
-                              : undefined
-                          }
-                          // A locked sidebar with a custom header renders no
-                          // action area, so wire nothing: the section then
-                          // skips the git poll that only feeds these actions.
-                          headerActions={
-                            lockedWorkspaceCwd && lockedWorkspaceOptions?.render
-                              ? undefined
-                              : (visible, { overview, gitBranch }) => {
-                                  const canRemove =
-                                    !lockedWorkspaceCwd &&
-                                    workspaceRemovalEnabled &&
-                                    !ws.primary &&
-                                    ws.removable === true;
-                                  if (!ws.trusted && !canRemove) return null;
-                                  const wsCwd = ws.primary ? undefined : ws.cwd;
-                                  const realPath = isAbsolutePath(ws.cwd);
-                                  // A display name persists only for registration-backed
-                                  // rows; the daemon's bound (primary) workspace has no
-                                  // registration id, so a rename there would live in
-                                  // memory until the next restart. Trust is not required:
-                                  // the name is registry metadata, not runtime access.
-                                  const canRename =
-                                    !lockedWorkspaceCwd &&
-                                    workspaceRenameEnabled &&
-                                    realPath &&
-                                    !ws.primary;
-                                  // Management pages read the connection's bound
-                                  // workspace, so only the primary row can open
-                                  // its own view today (#10399, layer B1).
-                                  const canManage =
-                                    ws.primary &&
-                                    ws.trusted &&
-                                    Boolean(onOpenWorkspaceManagement);
-                                  const menuActions: WorkspaceMenuActions = {
-                                    ...(canRename
-                                      ? {
-                                          rename: () =>
-                                            requestWorkspaceRename(ws),
+              )}
+              {searchOpen && !hideProjectHeader && (
+                <div className={styles.projectSearch}>
+                  <SearchIcon aria-hidden="true" />
+                  <Input
+                    value={searchQuery}
+                    placeholder={t('sidebar.searchPlaceholder')}
+                    aria-label={t('sidebar.search')}
+                    autoFocus
+                    onChange={(event) => setSearchQuery(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Escape') {
+                        setSearchQuery('');
+                        setSearchOpen(false);
+                      }
+                    }}
+                  />
+                </div>
+              )}
+              {projectsExpanded && (
+                <>
+                  <div className={styles.workspacePicker}>
+                    <div className={styles.workspaceList}>
+                      {projectWorkspaces.map((ws) => (
+                        <Fragment key={ws.id}>
+                          <WorkspaceSection
+                            workspace={ws}
+                            renderHeader={
+                              lockedWorkspaceCwd &&
+                              lockedWorkspaceOptions?.render
+                                ? (expanded) =>
+                                    lockedWorkspaceOptions.render?.(ws, {
+                                      expanded,
+                                    })
+                                : undefined
+                            }
+                            client={workspace.client}
+                            reloadToken={workspaceSessionsReloadToken}
+                            untrustedLabel={t('sidebar.workspaceUntrusted')}
+                            readOnlyLabel={t('sidebar.workspaceReadOnly')}
+                            trustToOpenLabel={t('sidebar.workspaceTrustToOpen')}
+                            noSessionsLabel={t('sidebar.noSessions')}
+                            loadErrorLabel={t('sidebar.loadFailed')}
+                            organizationEnabled={organizationEnabled}
+                            sessionCatalogRequestsEnabled={
+                              sessionCatalogRequestsEnabled
+                            }
+                            sessionGroupCatalog={
+                              workspaceSessionLiveStateEnabled &&
+                              liveStateWorkspaceCwdSet.has(ws.cwd)
+                                ? liveStateGroupCatalogs.get(ws.cwd)
+                                : undefined
+                            }
+                            sessionLiveStateEnabled={
+                              workspaceSessionLiveStateEnabled &&
+                              liveStateWorkspaceCwdSet.has(ws.cwd)
+                            }
+                            sourceType={selectedSessionSource}
+                            channelGroupingEnabled={channelGroupingEnabled}
+                            ungroupedLabel={t('sidebar.groupUngrouped')}
+                            onRenameGroup={
+                              canOrganizeWorkspace(ws.cwd)
+                                ? handleRenameGroup
+                                : undefined
+                            }
+                            onDeleteGroup={
+                              canOrganizeWorkspace(ws.cwd)
+                                ? handleDeleteGroup
+                                : undefined
+                            }
+                            renameGroupLabel={t('sidebar.groupRename')}
+                            deleteGroupLabel={t('sidebar.groupDelete')}
+                            groupActionsDisabled={groupBusy}
+                            excludePinned={selectedSessionSource !== 'channel'}
+                            mapSession={applyOptimisticPin}
+                            limitSessions={editingSessionIdentity === null}
+                            onOpenGitDiff={onOpenGitDiff}
+                            onOpenCommit={onOpenCommit}
+                            searchQuery={searchQuery}
+                            expanded={ws.primary ? projectExpanded : undefined}
+                            autoExpandKey={
+                              autoExpandWorkspace?.id === ws.id
+                                ? autoExpandWorkspace?.key
+                                : undefined
+                            }
+                            onExpandedChange={
+                              ws.primary
+                                ? (expanded) => {
+                                    writeWorkspaceExpanded(
+                                      primaryWorkspaceExpansionId,
+                                      expanded,
+                                    );
+                                    setProjectExpanded(expanded);
+                                  }
+                                : undefined
+                            }
+                            renderSessions={!ws.primary}
+                            renderSession={(session) =>
+                              renderSessionRow(
+                                {
+                                  ...session,
+                                  workspaceCwd: ws.cwd,
+                                },
+                                {
+                                  // Pinned members also render in the
+                                  // sidebar-level Pinned section; while that
+                                  // section is expanded its row hosts the
+                                  // rename form, so this duplicate row must
+                                  // not mount a second autofocused input.
+                                  // Channel mode has no Pinned section, so
+                                  // the workspace row is the only copy and
+                                  // must stay editable. The suppression also
+                                  // requires the Pinned section to actually
+                                  // carry the member: `pinnedSessions` merges
+                                  // only the pinned catalog pages and the
+                                  // primary sessions page, never this
+                                  // workspace's own page, so before the
+                                  // pinned page settles (or while it errors)
+                                  // this row is the only copy and must host
+                                  // the form itself.
+                                  renameFormDisabled:
+                                    selectedSessionSource !== 'channel' &&
+                                    Boolean(session.isPinned) &&
+                                    pinnedExpanded &&
+                                    pinnedSessions.some(
+                                      (candidate) =>
+                                        getIdentityForSession(candidate) ===
+                                        getIdentityForSession(session),
+                                    ),
+                                },
+                              )
+                            }
+                            showSessionDetails={sessionActionItems.has(
+                              'details',
+                            )}
+                            overviewEnabled={workspaceOverviewEnabled}
+                            overviewItems={workspaceOverviewItems}
+                            compact={footerTight}
+                            gitBranchWanted={
+                              Boolean(onNewWorktreeSession) &&
+                              !lockedWorkspaceCwd
+                            }
+                            sessionStats={
+                              ws.primary
+                                ? (primarySessionStats ?? null)
+                                : undefined
+                            }
+                            // A locked sidebar with a custom header renders no
+                            // action area, so wire nothing: the section then
+                            // skips the git poll that only feeds these actions.
+                            headerActions={
+                              lockedWorkspaceCwd &&
+                              lockedWorkspaceOptions?.render
+                                ? undefined
+                                : (visible, { overview, gitBranch }) => {
+                                    const canRemove =
+                                      !lockedWorkspaceCwd &&
+                                      workspaceRemovalEnabled &&
+                                      !ws.primary &&
+                                      ws.removable === true;
+                                    if (!ws.trusted && !canRemove) return null;
+                                    const wsCwd = ws.cwd;
+                                    const realPath = isAbsolutePath(ws.cwd);
+                                    // A display name persists only for registration-backed
+                                    // rows; the daemon's bound (primary) workspace has no
+                                    // registration id, so a rename there would live in
+                                    // memory until the next restart. Trust is not required:
+                                    // the name is registry metadata, not runtime access.
+                                    const canRename =
+                                      !lockedWorkspaceCwd &&
+                                      workspaceRenameEnabled &&
+                                      realPath &&
+                                      !ws.primary;
+                                    // Management pages read the connection's bound
+                                    // workspace, so only the primary row can open
+                                    // its own view today (#10399, layer B1).
+                                    const canManage =
+                                      ws.primary &&
+                                      ws.trusted &&
+                                      Boolean(onOpenWorkspaceManagement);
+                                    const menuActions: WorkspaceMenuActions = {
+                                      ...(canRename
+                                        ? {
+                                            rename: () =>
+                                              requestWorkspaceRename(ws),
+                                          }
+                                        : {}),
+                                      ...(realPath
+                                        ? {
+                                            copyPath: () =>
+                                              copyWorkspacePath(ws),
+                                          }
+                                        : {}),
+                                      ...(ws.trusted
+                                        ? {
+                                            newSession: () =>
+                                              handleNewSession(wsCwd),
+                                          }
+                                        : {}),
+                                      // A worktree needs a git repository; without a
+                                      // branch the composer never shows the armed
+                                      // intent and the daemon rejects the session.
+                                      ...(ws.trusted &&
+                                      onNewWorktreeSession &&
+                                      gitBranch
+                                        ? {
+                                            newWorktreeSession: () =>
+                                              handleNewWorktreeSession(wsCwd),
+                                          }
+                                        : {}),
+                                      ...(canManage
+                                        ? {
+                                            openManagement: (
+                                              target: WorkspaceManagementTarget,
+                                            ) =>
+                                              onOpenWorkspaceManagement?.(
+                                                target,
+                                                ws.cwd,
+                                              ),
+                                          }
+                                        : {}),
+                                      ...(ws.trusted && realPath
+                                        ? {
+                                            reload: () =>
+                                              reloadWorkspaceRuntime(ws),
+                                          }
+                                        : {}),
+                                      ...(canRemove
+                                        ? {
+                                            remove: () =>
+                                              requestWorkspaceRemoval(ws),
+                                          }
+                                        : {}),
+                                    };
+                                    return (
+                                      <div
+                                        className={
+                                          styles.workspaceHeaderActions
                                         }
-                                      : {}),
-                                    ...(realPath
-                                      ? {
-                                          copyPath: () => copyWorkspacePath(ws),
-                                        }
-                                      : {}),
-                                    ...(ws.trusted
-                                      ? {
-                                          newSession: () =>
-                                            handleNewSession(wsCwd),
-                                        }
-                                      : {}),
-                                    // A worktree needs a git repository; without a
-                                    // branch the composer never shows the armed
-                                    // intent and the daemon rejects the session.
-                                    ...(ws.trusted &&
-                                    onNewWorktreeSession &&
-                                    gitBranch
-                                      ? {
-                                          newWorktreeSession: () =>
-                                            handleNewWorktreeSession(wsCwd),
-                                        }
-                                      : {}),
-                                    ...(canManage
-                                      ? {
-                                          openManagement: (
-                                            target: WorkspaceManagementTarget,
-                                          ) =>
-                                            onOpenWorkspaceManagement?.(
-                                              target,
-                                              ws.cwd,
-                                            ),
-                                        }
-                                      : {}),
-                                    ...(ws.trusted && realPath
-                                      ? {
-                                          reload: () =>
-                                            reloadWorkspaceRuntime(ws),
-                                        }
-                                      : {}),
-                                    ...(canRemove
-                                      ? {
-                                          remove: () =>
-                                            requestWorkspaceRemoval(ws),
-                                        }
-                                      : {}),
-                                  };
-                                  return (
-                                    <div
-                                      className={styles.workspaceHeaderActions}
-                                      style={{
-                                        visibility:
-                                          visible ||
-                                          openWorkspaceMenuId === ws.id
-                                            ? 'visible'
-                                            : 'hidden',
-                                      }}
-                                    >
-                                      {ws.trusted && (
-                                        <>
-                                          {canOrganizeWorkspace(ws.cwd) && (
+                                        style={{
+                                          visibility:
+                                            visible ||
+                                            openWorkspaceMenuId === ws.id
+                                              ? 'visible'
+                                              : 'hidden',
+                                        }}
+                                      >
+                                        {ws.trusted && (
+                                          <>
+                                            {canOrganizeWorkspace(ws.cwd) && (
+                                              <button
+                                                className={
+                                                  styles.workspaceHeaderAction
+                                                }
+                                                type="button"
+                                                title={t('sidebar.groupCreate')}
+                                                aria-label={t(
+                                                  'sidebar.groupCreate',
+                                                )}
+                                                onClick={(event) => {
+                                                  event.preventDefault();
+                                                  event.stopPropagation();
+                                                  if (ws.primary) {
+                                                    handleCreateGroup();
+                                                  } else {
+                                                    handleCreateWorkspaceGroup(
+                                                      ws.cwd,
+                                                    );
+                                                  }
+                                                }}
+                                              >
+                                                <PlusIcon
+                                                  size={16}
+                                                  strokeWidth={1.2}
+                                                />
+                                              </button>
+                                            )}
                                             <button
                                               className={
                                                 styles.workspaceHeaderAction
                                               }
                                               type="button"
-                                              title={t('sidebar.groupCreate')}
-                                              aria-label={t(
-                                                'sidebar.groupCreate',
-                                              )}
+                                              title={t('sidebar.newTask')}
+                                              aria-label={t('sidebar.newTask')}
                                               onClick={(event) => {
                                                 event.preventDefault();
                                                 event.stopPropagation();
-                                                if (ws.primary) {
-                                                  handleCreateGroup();
-                                                } else {
-                                                  handleCreateWorkspaceGroup(
-                                                    ws.cwd,
-                                                  );
-                                                }
+                                                handleNewSession(wsCwd);
                                               }}
                                             >
-                                              <PlusIcon
+                                              <SquarePenIcon
                                                 size={16}
                                                 strokeWidth={1.2}
                                               />
                                             </button>
-                                          )}
-                                          <button
-                                            className={
-                                              styles.workspaceHeaderAction
-                                            }
-                                            type="button"
-                                            title={t('sidebar.newTask')}
-                                            aria-label={t('sidebar.newTask')}
-                                            onClick={(event) => {
-                                              event.preventDefault();
-                                              event.stopPropagation();
-                                              handleNewSession(wsCwd);
-                                            }}
-                                          >
-                                            <SquarePenIcon
-                                              size={16}
-                                              strokeWidth={1.2}
-                                            />
-                                          </button>
-                                        </>
-                                      )}
-                                      {/* A locked (embedded) sidebar keeps its
+                                          </>
+                                        )}
+                                        {/* A locked (embedded) sidebar keeps its
                                     action area to the session controls the
                                     host already expects. */}
-                                      {!lockedWorkspaceCwd && (
-                                        <WorkspaceMenu
-                                          workspace={ws}
-                                          actions={menuActions}
-                                          overview={overview}
-                                          disabled={
-                                            (workspaceRemovalSubmitting &&
-                                              workspaceRemovalCandidate?.id ===
-                                                ws.id) ||
-                                            (workspaceRenameSubmitting &&
-                                              workspaceRenameCandidate?.id ===
-                                                ws.id)
-                                          }
-                                          triggerClassName={
-                                            styles.workspaceHeaderAction
-                                          }
-                                          contentStyle={
-                                            SESSION_MENU_PORTAL_STYLE
-                                          }
-                                          onOpenChange={(open) => {
-                                            handleSessionMenuOpenChange(open);
-                                            setOpenWorkspaceMenuId((current) =>
-                                              open
-                                                ? ws.id
-                                                : current === ws.id
-                                                  ? null
-                                                  : current,
-                                            );
-                                          }}
-                                          onPointerDownOutside={
-                                            handleSessionMenuPointerDownOutside
-                                          }
-                                          onCloseAutoFocus={
-                                            handleSessionMenuCloseAutoFocus
-                                          }
-                                        />
-                                      )}
-                                    </div>
-                                  );
-                                }
-                          }
-                        />
-                        {ws.primary &&
-                        (projectExpanded || searchQuery.trim()) ? (
-                          <div className={styles.workspaceSessionBody}>
-                            {body}
-                          </div>
-                        ) : null}
-                      </Fragment>
-                    ))}
+                                        {!lockedWorkspaceCwd && (
+                                          <WorkspaceMenu
+                                            workspace={ws}
+                                            actions={menuActions}
+                                            overview={overview}
+                                            disabled={
+                                              (workspaceRemovalSubmitting &&
+                                                workspaceRemovalCandidate?.id ===
+                                                  ws.id) ||
+                                              (workspaceRenameSubmitting &&
+                                                workspaceRenameCandidate?.id ===
+                                                  ws.id)
+                                            }
+                                            triggerClassName={
+                                              styles.workspaceHeaderAction
+                                            }
+                                            contentStyle={
+                                              SESSION_MENU_PORTAL_STYLE
+                                            }
+                                            onOpenChange={(open) => {
+                                              handleSessionMenuOpenChange(open);
+                                              setOpenWorkspaceMenuId(
+                                                (current) =>
+                                                  open
+                                                    ? ws.id
+                                                    : current === ws.id
+                                                      ? null
+                                                      : current,
+                                              );
+                                            }}
+                                            onPointerDownOutside={
+                                              handleSessionMenuPointerDownOutside
+                                            }
+                                            onCloseAutoFocus={
+                                              handleSessionMenuCloseAutoFocus
+                                            }
+                                          />
+                                        )}
+                                      </div>
+                                    );
+                                  }
+                            }
+                          />
+                          {ws.primary &&
+                          (projectExpanded || searchQuery.trim()) ? (
+                            <div className={styles.workspaceSessionBody}>
+                              {body}
+                            </div>
+                          ) : null}
+                        </Fragment>
+                      ))}
+                    </div>
                   </div>
-                </div>
-              </>
-            )}
-            {archivedSection}
-          </SidebarSessionSurface>
+                </>
+              )}
+              {archivedSection}
+            </SidebarSessionSurface>
+          )}
         </div>
 
         {(footer !== false || mobileOpen) && (
@@ -5903,7 +5951,7 @@ export function WebShellSidebar({
           >
             <div className={styles.footerPrimary}>
               {footer && typeof footer === 'object' && footer.render?.()}
-              {footerItems.has('settings') && (
+              {projectFeaturesEnabled && footerItems.has('settings') && (
                 <button
                   className={styles.footerButton}
                   type="button"
@@ -5963,7 +6011,8 @@ export function WebShellSidebar({
                   )}
                 </button>
               )}
-              {canOpenSessionsOverview &&
+              {projectFeaturesEnabled &&
+                canOpenSessionsOverview &&
                 footerItems.has('sessionsOverview') && (
                   <button
                     className={styles.collapseButton}
@@ -5975,17 +6024,19 @@ export function WebShellSidebar({
                     <LayoutGridIcon size={16} strokeWidth={1.2} />
                   </button>
                 )}
-              {canOpenSplitView && footerItems.has('splitView') && (
-                <button
-                  className={styles.collapseButton}
-                  type="button"
-                  title={t('sidebar.splitView')}
-                  aria-label={t('sidebar.splitView')}
-                  onClick={onOpenSplitView}
-                >
-                  <Columns2Icon size={16} strokeWidth={1.2} />
-                </button>
-              )}
+              {projectFeaturesEnabled &&
+                canOpenSplitView &&
+                footerItems.has('splitView') && (
+                  <button
+                    className={styles.collapseButton}
+                    type="button"
+                    title={t('sidebar.splitView')}
+                    aria-label={t('sidebar.splitView')}
+                    onClick={onOpenSplitView}
+                  >
+                    <Columns2Icon size={16} strokeWidth={1.2} />
+                  </button>
+                )}
               {footerItems.has('daemonStatus') && (
                 <button
                   className={styles.collapseButton}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -417,6 +417,7 @@ function renderSidebar(
     onNewWorktreeSession?: (cwd?: string) => void;
     onOpenAddWorkspace?: () => void;
     onNewSession?: (workspaceCwd?: string) => boolean;
+    globalNewSessionUsesStandalone?: boolean;
     onLoadSession?: (sessionId: string, workspaceCwd?: string) => void;
     workspaces?: DaemonWorkspaceCapability[];
     lockedWorkspaceCwd?: string;
@@ -424,6 +425,7 @@ function renderSidebar(
       render?: (workspace: DaemonWorkspaceCapability) => ReactNode;
     };
     showSessionSourceSwitch?: boolean;
+    projectFeaturesEnabled?: boolean;
     sessionActions?: {
       items?: readonly (
         | 'pin'
@@ -451,6 +453,9 @@ function renderSidebar(
           onOpenSessions={() => {}}
           onOpenSplitView={() => {}}
           onNewSession={overrides.onNewSession ?? (() => false)}
+          globalNewSessionUsesStandalone={
+            overrides.globalNewSessionUsesStandalone
+          }
           onLoadSession={overrides.onLoadSession ?? (() => {})}
           onError={overrides.onError ?? (() => {})}
           selectedWorkspaceCwd={overrides.selectedWorkspaceCwd}
@@ -464,6 +469,7 @@ function renderSidebar(
           lockedWorkspaceCwd={overrides.lockedWorkspaceCwd}
           lockedWorkspace={overrides.lockedWorkspace}
           showSessionSourceSwitch={overrides.showSessionSourceSwitch}
+          projectFeaturesEnabled={overrides.projectFeaturesEnabled}
           sessionActions={overrides.sessionActions}
         />
       </I18nProvider>,
@@ -1601,6 +1607,44 @@ describe('WebShellSidebar workspace removal', () => {
       await Promise.resolve();
     });
     expect(onNewSession).toHaveBeenCalledWith('/tmp/other');
+  });
+
+  it('does not refresh the primary workspace after a standalone global New Task', async () => {
+    const onNewSession = vi.fn(() => true);
+    renderSidebar({
+      globalNewSessionUsesStandalone: true,
+      onNewSession,
+    });
+    const globalNewTask = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="New task"]',
+    );
+    expect(globalNewTask).not.toBeNull();
+
+    await act(async () => {
+      click(globalNewTask!);
+      await Promise.resolve();
+    });
+
+    expect(onNewSession).toHaveBeenCalledWith(undefined);
+    expect(refreshWorkspaceSessionCatalog).not.toHaveBeenCalled();
+  });
+
+  it('hides workspace management navigation outside workspace contexts', () => {
+    connection.capabilities = {
+      ...capabilities,
+      features: [...capabilities.features, 'session_organization'],
+    };
+    workspace.capabilities = connection.capabilities;
+    renderSidebar({ projectFeaturesEnabled: false });
+
+    expect(container.querySelector('button[aria-label="Plugins"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Channels"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Settings"]')).toBeNull();
+    expect(workspaceActions.listSessionGroups).not.toHaveBeenCalled();
+    expect(useChannels).toHaveBeenLastCalledWith({
+      autoLoad: false,
+      enabled: false,
+    });
   });
 
   it('shows a native tooltip for the workspace create-group action', async () => {
@@ -3211,9 +3255,11 @@ describe('WebShellSidebar workspace removal', () => {
         branch: cwd === '/tmp/other' ? 'main' : null,
       }),
     }));
+    const onNewSession = vi.fn(() => true);
     const onNewWorktreeSession = vi.fn();
     renderSidebar({
       onOpenGitDiff: vi.fn(),
+      onNewSession,
       onNewWorktreeSession,
       workspaces: [
         ...capabilities.workspaces,
@@ -3238,9 +3284,17 @@ describe('WebShellSidebar workspace removal', () => {
     ).find((element) => element.textContent === 'New worktree task');
     act(() => click(worktree!));
     expect(onNewWorktreeSession).toHaveBeenCalledWith('/tmp/other');
+    await act(async () => {
+      await Promise.resolve();
+    });
     act(() => click(workspaceAction('/tmp/project')!));
     expect(menuItemLabels()).toContain('New task');
     expect(menuItemLabels()).not.toContain('New worktree task');
+    const primaryNewTask = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((element) => element.textContent === 'New task');
+    act(() => click(primaryNewTask!));
+    expect(onNewSession).toHaveBeenCalledWith('/tmp/project');
     act(() => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     });
@@ -3249,6 +3303,32 @@ describe('WebShellSidebar workspace removal', () => {
     act(() => click(workspaceAction('/tmp/plain')!));
     expect(menuItemLabels()).toContain('New task');
     expect(menuItemLabels()).not.toContain('New worktree task');
+  });
+
+  it('passes the explicit primary cwd to a primary workspace worktree task', async () => {
+    const previous = workspace.client.workspaceByCwd.getMockImplementation();
+    workspace.client.workspaceByCwd.mockImplementation((cwd: string) => ({
+      ...(previous?.(cwd) ?? {}),
+      workspaceGit: vi.fn().mockResolvedValue({
+        v: 2,
+        workspaceCwd: cwd,
+        branch: 'main',
+      }),
+    }));
+    const onNewWorktreeSession = vi.fn();
+    renderSidebar({ onNewWorktreeSession });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => click(workspaceAction('/tmp/project')!));
+    const worktree = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((element) => element.textContent === 'New worktree task');
+    act(() => click(worktree!));
+
+    expect(onNewWorktreeSession).toHaveBeenCalledWith('/tmp/project');
   });
 
   it('treats a failed capabilities refresh after a rename as converged', async () => {

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -1647,6 +1647,31 @@ describe('WebShellSidebar workspace removal', () => {
     });
   });
 
+  it('clears project search state while project features are hidden', async () => {
+    active.sessions = [
+      {
+        sessionId: 'visible-session',
+        displayName: 'Visible session',
+        workspaceCwd: '/tmp/project',
+        sourceType: 'default',
+      },
+    ];
+    renderSidebar();
+    await ensureWorkspaceExpanded('project');
+    const searchInput = await openSessionSearch();
+    await act(async () => {
+      setInputValue(searchInput, 'missing');
+      await Promise.resolve();
+    });
+
+    renderSidebar({ projectFeaturesEnabled: false });
+    renderSidebar({ projectFeaturesEnabled: true });
+    await act(async () => Promise.resolve());
+
+    expect(container.querySelector('input')).toBeNull();
+    expect(container.textContent).toContain('Visible session');
+  });
+
   it('shows a native tooltip for the workspace create-group action', async () => {
     connection.capabilities = {
       ...capabilities,

--- a/packages/web-shell/client/daemon/session/actions.test.ts
+++ b/packages/web-shell/client/daemon/session/actions.test.ts
@@ -2733,6 +2733,90 @@ describe('createDaemonSessionActions', () => {
     );
   });
 
+  it('publishes standalone working-directory admission failures', async () => {
+    const session = createMockSession('standalone-a');
+    session.submitPrompt.mockRejectedValueOnce(
+      new DaemonHttpError(
+        409,
+        { code: 'working_directory_missing' },
+        'working directory missing',
+      ),
+    );
+    const { actions, getConnection } = createActionsHarness({
+      session,
+      connection: {
+        status: 'connected',
+        sessionId: 'standalone-a',
+        sessionContext: { kind: 'standalone' },
+        standaloneSession: { workingDirectory: { state: 'ready' } },
+      },
+    });
+
+    await expect(actions.sendPrompt('look')).rejects.toThrow(
+      'working directory missing',
+    );
+
+    expect(getConnection().standaloneSession).toEqual({
+      workingDirectory: { state: 'ready' },
+      errorCode: 'working_directory_missing',
+    });
+  });
+
+  it('publishes standalone working-directory shell failures', async () => {
+    const session = createMockSession('standalone-shell');
+    session.shellCommand.mockRejectedValueOnce(
+      new DaemonHttpError(
+        409,
+        { code: 'working_directory_compromised' },
+        'working directory compromised',
+      ),
+    );
+    const { actions, getConnection } = createActionsHarness({
+      session,
+      connection: {
+        status: 'connected',
+        sessionId: 'standalone-shell',
+        sessionContext: { kind: 'standalone' },
+        standaloneSession: { workingDirectory: { state: 'ready' } },
+      },
+    });
+
+    await expect(actions.sendShellCommand('pwd')).rejects.toThrow(
+      'working directory compromised',
+    );
+
+    expect(getConnection().standaloneSession).toEqual({
+      workingDirectory: { state: 'ready' },
+      errorCode: 'working_directory_compromised',
+    });
+  });
+
+  it('does not publish workspace prompt admission failures as standalone state', async () => {
+    const session = createMockSession('workspace-a');
+    session.submitPrompt.mockRejectedValueOnce(
+      new DaemonHttpError(
+        409,
+        { code: 'working_directory_compromised' },
+        'working directory compromised',
+      ),
+    );
+    const { actions, getConnection } = createActionsHarness({
+      session,
+      connection: {
+        status: 'connected',
+        sessionId: 'workspace-a',
+        workspaceCwd: '/workspace',
+        sessionContext: { kind: 'workspace', cwd: '/workspace' },
+      },
+    });
+
+    await expect(actions.submitPrompt('look')).rejects.toThrow(
+      'working directory compromised',
+    );
+
+    expect(getConnection().standaloneSession).toBeUndefined();
+  });
+
   it('keeps uploaded attachments when prompt admission is uncertain', async () => {
     const session = createMockSession('session-a');
     session.submitPrompt.mockRejectedValueOnce(new TypeError('fetch failed'));
@@ -3731,6 +3815,7 @@ function createMockSession(
     })),
     removeAttachment: vi.fn(async () => true),
     removePendingPrompt: vi.fn(async () => ({ removed: true })),
+    shellCommand: vi.fn(async () => ({ promptId: 'shell-prompt-1' })),
     submitPrompt: vi.fn(async () => ({ promptId: 'prompt-1' })),
     supportedCommands: vi.fn(async () => supportedCommandsStatus(sessionId)),
     stats: vi.fn(),

--- a/packages/web-shell/client/daemon/session/actions.ts
+++ b/packages/web-shell/client/daemon/session/actions.ts
@@ -368,6 +368,31 @@ export function createDaemonSessionActions({
   let attachmentSessionId = sessionRef.current?.sessionId;
   let attachmentClientId = sessionRef.current?.clientId;
 
+  function publishStandaloneWorkingDirectoryError(
+    sessionId: string,
+    error: unknown,
+  ): void {
+    const errorCode = getDaemonErrorCode(error);
+    if (
+      errorCode !== 'working_directory_missing' &&
+      errorCode !== 'working_directory_compromised'
+    ) {
+      return;
+    }
+    setConnection((current) =>
+      current.sessionId === sessionId &&
+      current.sessionContext?.kind === 'standalone'
+        ? {
+            ...current,
+            standaloneSession: {
+              ...current.standaloneSession,
+              errorCode,
+            },
+          }
+        : current,
+    );
+  }
+
   function trackSessionConfigMutation<T>(
     session: DaemonSessionClient,
     operation: Promise<T>,
@@ -902,6 +927,7 @@ export function createDaemonSessionActions({
             ctrl.signal,
           );
         } catch (error) {
+          publishStandaloneWorkingDirectoryError(sessionId, error);
           const definiteRejection = isDefinitePromptAdmissionRejection(error);
           if (definiteRejection) {
             await removeUploadedAttachments(session, uploaded.references);
@@ -1050,6 +1076,7 @@ export function createDaemonSessionActions({
           promptRequest as Parameters<typeof session.submitPrompt>[0],
         );
       } catch (error) {
+        publishStandaloneWorkingDirectoryError(session.sessionId, error);
         const definiteRejection = isDefinitePromptAdmissionRejection(error);
         if (definiteRejection) {
           await removeUploadedAttachments(session, uploaded.references);
@@ -2211,6 +2238,7 @@ export function createDaemonSessionActions({
       try {
         return await session.shellCommand(command, ctrl.signal);
       } catch (error) {
+        publishStandaloneWorkingDirectoryError(session.sessionId, error);
         throw dispatchActionError(
           addNotice,
           'Shell command failed',

--- a/packages/web-shell/client/e2e/utils/mockDaemon.ts
+++ b/packages/web-shell/client/e2e/utils/mockDaemon.ts
@@ -17,6 +17,9 @@ import {
   type DaemonSessionCatalogVersion,
   type DaemonSessionState,
   type DaemonSessionSummary,
+  type DaemonRestoredStandaloneSession,
+  type DaemonStandaloneSession,
+  type DaemonStandaloneSessionSummary,
   type DaemonWorkspaceExtensionsStatus,
   type DaemonWorkspaceFile,
   type DaemonGitHubPullRequestList,
@@ -77,6 +80,12 @@ export interface WebShellDaemonScenario {
   pairingApprovals: Record<string, string[]>;
   pairingGroupApprovals: Record<string, string[]>;
   sessions: DaemonSessionSummary[];
+  standaloneSessions: DaemonStandaloneSessionSummary[];
+  standaloneCreateError?: {
+    status: number;
+    code: string;
+    message: string;
+  };
   sessionGroups: DaemonSessionGroup[];
   sessionCatalogVersion: DaemonSessionCatalogVersion;
   events: DaemonEvent[];
@@ -409,6 +418,8 @@ export function createWebShellDaemonScenario(
     pairingApprovals: overrides.pairingApprovals ?? {},
     pairingGroupApprovals: overrides.pairingGroupApprovals ?? {},
     sessions,
+    standaloneSessions: overrides.standaloneSessions ?? [],
+    standaloneCreateError: overrides.standaloneCreateError,
     sessionGroups: overrides.sessionGroups ?? [],
     sessionCatalogVersion: overrides.sessionCatalogVersion ?? {
       generation: 'web-shell-e2e',
@@ -729,6 +740,10 @@ function isDaemonPath(path: string): boolean {
     /^\/workspaces\/.+\/github\/(prs\/create|default-branch)\/?$/.test(path) ||
     /^\/workspace\/github\/(prs\/create|default-branch)\/?$/.test(path) ||
     path === '/session' ||
+    path === '/standalone/sessions' ||
+    /^\/standalone\/sessions\/[^/]+(?:\/(?:load|resume|repair-directory|metadata|export))?\/?$/.test(
+      path,
+    ) ||
     path === '/goals' ||
     /^\/file\/?$/.test(path) ||
     /^\/session\/[^/]+\/artifacts\/?$/.test(path) ||
@@ -883,6 +898,38 @@ function isDaemonRoute(method: string, path: string): boolean {
     return true;
   }
   if (method === 'POST' && path === '/session') return true;
+  if (
+    path === '/standalone/sessions' &&
+    (method === 'GET' || method === 'POST')
+  ) {
+    return true;
+  }
+  if (
+    method === 'POST' &&
+    /^\/standalone\/sessions\/(archive|unarchive|delete)\/?$/.test(path)
+  ) {
+    return true;
+  }
+  if (
+    method === 'GET' &&
+    /^\/standalone\/sessions\/[^/]+(?:\/export)?\/?$/.test(path)
+  ) {
+    return true;
+  }
+  if (
+    method === 'POST' &&
+    /^\/standalone\/sessions\/[^/]+\/(load|resume|repair-directory)\/?$/.test(
+      path,
+    )
+  ) {
+    return true;
+  }
+  if (
+    method === 'PATCH' &&
+    /^\/standalone\/sessions\/[^/]+\/metadata\/?$/.test(path)
+  ) {
+    return true;
+  }
   if (method === 'GET' && path === '/goals') return true;
   if (
     (method === 'GET' || method === 'POST') &&
@@ -1530,6 +1577,162 @@ async function handleDaemonRoute(
     });
     return;
   }
+  if (path === '/standalone/sessions') {
+    if (method === 'GET') {
+      const archiveState = searchParams.get('archiveState') ?? 'active';
+      await json(route, {
+        sessions: scenario.standaloneSessions.filter((session) =>
+          archiveState === 'archived'
+            ? session.isArchived === true
+            : session.isArchived !== true,
+        ),
+      });
+      return;
+    }
+    if (scenario.standaloneCreateError) {
+      await json(
+        route,
+        {
+          code: scenario.standaloneCreateError.code,
+          message: scenario.standaloneCreateError.message,
+        },
+        scenario.standaloneCreateError.status,
+      );
+      return;
+    }
+    const sessionId = readStringField(body, 'sessionId');
+    if (!sessionId) {
+      await badRequest(route, 'Standalone sessionId is required.');
+      return;
+    }
+    let summary = scenario.standaloneSessions.find(
+      (session) => session.sessionId === sessionId,
+    );
+    if (!summary) {
+      summary = standaloneSummary(scenario, sessionId);
+      scenario.standaloneSessions.unshift(summary);
+    }
+    await json(route, standaloneSessionEnvelope(scenario, summary, false), 201);
+    return;
+  }
+
+  const standaloneBatchMatch = path.match(
+    /^\/standalone\/sessions\/(archive|unarchive|delete)\/?$/,
+  );
+  if (method === 'POST' && standaloneBatchMatch) {
+    const action = standaloneBatchMatch[1];
+    const sessionIds = readStringArrayField(body, 'sessionIds');
+    const found = sessionIds.filter((sessionId) =>
+      scenario.standaloneSessions.some(
+        (session) => session.sessionId === sessionId,
+      ),
+    );
+    const notFound = sessionIds.filter(
+      (sessionId) => !found.includes(sessionId),
+    );
+    if (action === 'delete') {
+      scenario.standaloneSessions = scenario.standaloneSessions.filter(
+        (session) => !found.includes(session.sessionId),
+      );
+      await json(route, {
+        removed: found,
+        notFound,
+        errors: [],
+        fileCleanupPending: [],
+      });
+      return;
+    }
+    const targetArchived = action === 'archive';
+    const changed: string[] = [];
+    const unchanged: string[] = [];
+    scenario.standaloneSessions = scenario.standaloneSessions.map((session) => {
+      if (!found.includes(session.sessionId)) return session;
+      if (Boolean(session.isArchived) === targetArchived) {
+        unchanged.push(session.sessionId);
+        return session;
+      }
+      changed.push(session.sessionId);
+      return { ...session, isArchived: targetArchived, updatedAt: now };
+    });
+    await json(
+      route,
+      action === 'archive'
+        ? {
+            archived: changed,
+            alreadyArchived: unchanged,
+            notFound,
+            errors: [],
+          }
+        : {
+            unarchived: changed,
+            alreadyActive: unchanged,
+            notFound,
+            errors: [],
+          },
+    );
+    return;
+  }
+
+  const standaloneMatch = path.match(
+    /^\/standalone\/sessions\/([^/]+)(?:\/(load|resume|repair-directory|metadata|export))?\/?$/,
+  );
+  if (standaloneMatch) {
+    const sessionId = decodeURIComponent(standaloneMatch[1]);
+    const action = standaloneMatch[2];
+    const index = scenario.standaloneSessions.findIndex(
+      (session) => session.sessionId === sessionId,
+    );
+    const summary = scenario.standaloneSessions[index];
+    if (!summary) {
+      await json(
+        route,
+        {
+          code: 'standalone_session_not_found',
+          message: `Standalone session ${sessionId} was not found.`,
+        },
+        404,
+      );
+      return;
+    }
+    if (method === 'GET' && !action) {
+      await json(route, summary);
+      return;
+    }
+    if (method === 'POST' && (action === 'load' || action === 'resume')) {
+      await json(route, restoredStandaloneSessionEnvelope(scenario, summary));
+      return;
+    }
+    if (method === 'POST' && action === 'repair-directory') {
+      await json(route, {
+        sessionId,
+        projectlessOutputDirectory: standaloneOutputDirectory(sessionId),
+        workingDirectory: { state: 'ready' },
+      });
+      return;
+    }
+    if (method === 'PATCH' && action === 'metadata') {
+      const displayName = readStringField(body, 'displayName') ?? '';
+      scenario.standaloneSessions[index] = {
+        ...summary,
+        displayName,
+        updatedAt: now,
+      };
+      await json(route, { sessionId, displayName });
+      return;
+    }
+    if (method === 'GET' && action === 'export') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        headers: {
+          'access-control-allow-origin': '*',
+          'content-disposition': `attachment; filename="${sessionId}.html"`,
+        },
+        body: `<p>${summary.displayName ?? sessionId}</p>`,
+      });
+      return;
+    }
+  }
   if (method === 'POST' && path === '/session') {
     await json(route, sessionEnvelope(scenario, { attached: false }));
     return;
@@ -1843,6 +2046,60 @@ function sessionEnvelope(
   };
 }
 
+function standaloneOutputDirectory(sessionId: string): string {
+  return `/tmp/qwen-web-shell-standalone/${sessionId}`;
+}
+
+function standaloneSummary(
+  scenario: WebShellDaemonScenario,
+  sessionId: string,
+): DaemonStandaloneSessionSummary {
+  return {
+    sessionId,
+    workspaceCwd: standaloneOutputDirectory(sessionId),
+    sourceType: 'standalone',
+    context: { kind: 'standalone' },
+    createdAt: now,
+    updatedAt: now,
+    displayName: `Standalone ${scenario.standaloneSessions.length + 1}`,
+    clientCount: 1,
+    hasActivePrompt: false,
+    isArchived: false,
+  };
+}
+
+function standaloneSessionEnvelope(
+  scenario: WebShellDaemonScenario,
+  summary: DaemonStandaloneSessionSummary,
+  attached: boolean,
+): DaemonStandaloneSession {
+  return {
+    sessionId: summary.sessionId,
+    workspaceCwd: summary.workspaceCwd,
+    attached,
+    clientId: scenario.clientId,
+    createdAt: summary.createdAt ?? now,
+    hasActivePrompt: false,
+    sourceType: 'standalone',
+    context: { kind: 'standalone' },
+    projectlessOutputDirectory: standaloneOutputDirectory(summary.sessionId),
+    workingDirectory: { state: 'ready' },
+  };
+}
+
+function restoredStandaloneSessionEnvelope(
+  scenario: WebShellDaemonScenario,
+  summary: DaemonStandaloneSessionSummary,
+): DaemonRestoredStandaloneSession {
+  return {
+    ...standaloneSessionEnvelope(scenario, summary, true),
+    state: { ...scenario.state, displayName: summary.displayName },
+    compactedReplay: [],
+    liveJournal: [],
+    lastEventId: 0,
+  };
+}
+
 function restoredSessionEnvelope(
   scenario: WebShellDaemonScenario,
   sessionId: string,
@@ -1969,6 +2226,13 @@ function readStringField(body: unknown, key: string): string | undefined {
   return typeof value === 'string' && value.trim().length > 0
     ? value
     : undefined;
+}
+
+function readStringArrayField(body: unknown, key: string): string[] {
+  const value = getRecordValue(body, key);
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : [];
 }
 
 function nextRevision(revision: string): string {

--- a/packages/web-shell/client/e2e/web-shell.standalone.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.standalone.spec.ts
@@ -1,0 +1,272 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import {
+  createWebShellDaemonScenario,
+  installMockDaemon,
+  replayCompleteEvent,
+  type DaemonRequestRecord,
+  type MockDaemonController,
+  type WebShellDaemonScenario,
+} from './utils/mockDaemon';
+
+const standaloneFeatures = [
+  'session_events',
+  'permission_vote',
+  'session_permission_vote',
+  'session_scope_override',
+  'session_source_metadata',
+  'standalone_sessions_v1',
+];
+
+test('global New task creates an exact standalone session @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    capabilities: { features: standaloneFeatures },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoNewTask(page);
+  await fillComposer(page, 'Start a standalone conversation');
+  await page.locator('[data-web-shell-composer-submit]').click();
+
+  const create = await waitForRequest(
+    daemon,
+    (request) =>
+      request.method === 'POST' && request.path === '/standalone/sessions',
+  );
+  const body = requestBody(create);
+  expect(Object.keys(body).sort()).toEqual(['approvalMode', 'sessionId']);
+  expect(body['approvalMode']).toBe('default');
+  expect(body['sessionId']).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  );
+  expect(daemon.requests).not.toContainEqual(
+    expect.objectContaining({ method: 'POST', path: '/session' }),
+  );
+
+  const sessionId = String(body['sessionId']);
+  await expect(page).toHaveURL(
+    new RegExp(
+      `/session/${sessionId.replaceAll('-', '\\-')}\\?context=standalone$`,
+    ),
+  );
+});
+
+test('global New task preserves the legacy primary route without the capability @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario();
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoNewTask(page);
+  await fillComposer(page, 'Start a legacy conversation');
+  await page.locator('[data-web-shell-composer-submit]').click();
+
+  await waitForRequest(
+    daemon,
+    (request) => request.method === 'POST' && request.path === '/session',
+  );
+  expect(
+    daemon.requests.filter((request) =>
+      request.path.startsWith('/standalone/sessions'),
+    ),
+  ).toEqual([]);
+});
+
+test('an uncertain standalone create stays recoverable and is never retried @smoke', async ({
+  page,
+}, testInfo) => {
+  const scenario = createWebShellDaemonScenario({
+    capabilities: { features: standaloneFeatures },
+    standaloneCreateError: {
+      status: 500,
+      code: 'standalone_creation_outcome_unknown',
+      message: 'creation outcome is unknown',
+    },
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await gotoNewTask(page);
+  await fillComposer(page, 'Do not duplicate this conversation');
+  await page.locator('[data-web-shell-composer-submit]').click();
+
+  await expect(page.getByText('Creation may have succeeded')).toBeVisible();
+  expect(
+    daemon.requests.filter(
+      (request) =>
+        request.method === 'POST' && request.path === '/standalone/sessions',
+    ),
+  ).toHaveLength(1);
+  expect(daemon.requests).not.toContainEqual(
+    expect.objectContaining({ method: 'POST', path: '/session' }),
+  );
+
+  await expect(page.locator('[data-web-shell-composer-submit]')).toBeDisabled();
+  await page
+    .getByRole('button', { name: 'New task', exact: true })
+    .first()
+    .click();
+  expect(
+    daemon.requests.filter(
+      (request) =>
+        request.method === 'POST' && request.path === '/standalone/sessions',
+    ),
+  ).toHaveLength(1);
+});
+
+test('standalone Recents keeps lifecycle actions on exact standalone routes @smoke', async ({
+  page,
+}, testInfo) => {
+  const currentSessionId = '11111111-1111-4111-8111-111111111111';
+  const otherSessionId = '22222222-2222-4222-8222-222222222222';
+  const scenario = createWebShellDaemonScenario({
+    sessionId: currentSessionId,
+    capabilities: { features: standaloneFeatures },
+    standaloneSessions: [
+      standaloneSummary(currentSessionId, 'Current conversation'),
+      standaloneSummary(otherSessionId, 'Other conversation'),
+    ],
+  });
+  const daemon = await installScenario(page, scenario, testInfo);
+
+  await page.goto(
+    `/session/${encodeURIComponent(currentSessionId)}?context=standalone`,
+  );
+  await expect(page.locator('[data-web-shell-root]')).toBeVisible();
+  const connection = await daemon.sse.waitForConnection(currentSessionId);
+  await daemon.sendEvent(
+    replayCompleteEvent({ sessionId: connection.sessionId, replayedCount: 0 }),
+  );
+  await expect(
+    page.getByText('Other conversation', { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText(`/tmp/standalone/${otherSessionId}`)).toHaveCount(
+    0,
+  );
+
+  await openSessionAction(page, 'Other conversation', 'Rename');
+  const renameDialog = page.getByRole('dialog', { name: 'Rename' });
+  await renameDialog.getByRole('textbox').fill('Renamed conversation');
+  await renameDialog.getByRole('button', { name: 'Save' }).click();
+  await expect(
+    page.getByText('Renamed conversation', { exact: true }),
+  ).toBeVisible();
+
+  const download = page.waitForEvent('download');
+  await openSessionAction(
+    page,
+    'Renamed conversation',
+    'Export conversation record',
+  );
+  await expect((await download).suggestedFilename()).toBe(
+    `${otherSessionId}.html`,
+  );
+
+  await openSessionAction(page, 'Renamed conversation', 'Archive');
+  await expect(
+    page.getByText('Renamed conversation', { exact: true }),
+  ).toHaveCount(0);
+  await page.getByRole('button', { name: 'Archived', exact: true }).click();
+  await expect(
+    page.getByText('Renamed conversation', { exact: true }),
+  ).toBeVisible();
+
+  await openSessionAction(page, 'Renamed conversation', 'Restore');
+  await expect(
+    page.getByText('Renamed conversation', { exact: true }),
+  ).toBeVisible();
+  await openSessionAction(page, 'Renamed conversation', 'Delete');
+  const deleteDialog = page.getByRole('dialog', { name: 'Delete' });
+  await deleteDialog.getByRole('button', { name: 'Delete' }).click();
+  await expect(
+    page.getByText('Renamed conversation', { exact: true }),
+  ).toHaveCount(0);
+
+  expect(
+    daemon.requests.map((request) => `${request.method} ${request.path}`),
+  ).toEqual(
+    expect.arrayContaining([
+      `PATCH /standalone/sessions/${otherSessionId}/metadata`,
+      `GET /standalone/sessions/${otherSessionId}/export`,
+      'POST /standalone/sessions/archive',
+      'POST /standalone/sessions/unarchive',
+      'POST /standalone/sessions/delete',
+    ]),
+  );
+});
+
+async function installScenario(
+  page: Page,
+  scenario: WebShellDaemonScenario,
+  testInfo: TestInfo,
+): Promise<MockDaemonController> {
+  return installMockDaemon(page, scenario, {
+    baseURL: String(testInfo.project.use.baseURL),
+  });
+}
+
+async function gotoNewTask(page: Page): Promise<void> {
+  await page.goto('/');
+  await expect(page.locator('[data-web-shell-root]')).toBeVisible();
+  const newTask = page
+    .getByRole('button', { name: 'New task', exact: true })
+    .first();
+  await expect(newTask).toBeEnabled();
+  await newTask.click();
+}
+
+async function fillComposer(page: Page, text: string): Promise<void> {
+  const editor = page.locator('[data-web-shell-composer-editor] .cm-content');
+  await editor.click();
+  await page.keyboard.type(text);
+}
+
+async function openSessionAction(
+  page: Page,
+  sessionName: string,
+  actionName: string,
+): Promise<void> {
+  const row = page
+    .getByRole('button', { name: sessionName, exact: true })
+    .locator('..');
+  await row.getByRole('button', { name: 'Conversation actions' }).click();
+  await page.getByRole('menuitem', { name: actionName, exact: true }).click();
+}
+
+function standaloneSummary(sessionId: string, displayName: string) {
+  return {
+    sessionId,
+    workspaceCwd: `/tmp/standalone/${sessionId}`,
+    sourceType: 'standalone' as const,
+    context: { kind: 'standalone' as const },
+    createdAt: '2026-08-31T00:00:00.000Z',
+    updatedAt: '2026-08-31T00:00:00.000Z',
+    displayName,
+    clientCount: 0,
+    hasActivePrompt: false,
+    isArchived: false,
+  };
+}
+
+async function waitForRequest(
+  daemon: MockDaemonController,
+  predicate: (request: DaemonRequestRecord) => boolean,
+): Promise<DaemonRequestRecord> {
+  await expect.poll(() => daemon.requests.some(predicate)).toBe(true);
+  const request = daemon.requests.find(predicate);
+  if (!request) throw new Error('Expected daemon request was not recorded.');
+  return request;
+}
+
+function requestBody(request: DaemonRequestRecord): Record<string, unknown> {
+  if (
+    typeof request.body !== 'object' ||
+    request.body === null ||
+    Array.isArray(request.body)
+  ) {
+    throw new Error(
+      `Expected an object body for ${request.method} ${request.path}`,
+    );
+  }
+  return request.body as Record<string, unknown>;
+}

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -32,10 +32,13 @@ function Harness({
   followupState,
   sessionId,
   atWorkspaceCwd,
+  composerScopeKey,
+  disableLegacyHistoryFallback,
   commands,
   onImageIngestionNotice,
   workspaceUploadBusy,
   fileDragEnabled,
+  attachmentsEnabled,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit: ReturnType<typeof vi.fn>;
@@ -50,10 +53,13 @@ function Harness({
   };
   sessionId?: string;
   atWorkspaceCwd?: string;
+  composerScopeKey?: string;
+  disableLegacyHistoryFallback?: boolean;
   commands?: UseComposerCoreOptions['commands'];
   onImageIngestionNotice?: UseComposerCoreOptions['onImageIngestionNotice'];
   workspaceUploadBusy?: boolean;
   fileDragEnabled?: UseComposerCoreOptions['fileDragEnabled'];
+  attachmentsEnabled?: UseComposerCoreOptions['attachmentsEnabled'];
 }) {
   const composer = useComposerCore({
     onSubmit,
@@ -66,11 +72,14 @@ function Harness({
     followupState,
     sessionId,
     atWorkspaceCwd,
+    composerScopeKey,
+    disableLegacyHistoryFallback,
     composerInput,
     composerInputVersion: composerInput ? 1 : undefined,
     onImageIngestionNotice,
     workspaceUploadBusy,
     fileDragEnabled,
+    attachmentsEnabled,
   });
   latest = composer;
 
@@ -91,10 +100,13 @@ async function mount({
   followupState,
   sessionId,
   atWorkspaceCwd,
+  composerScopeKey,
+  disableLegacyHistoryFallback,
   commands,
   onImageIngestionNotice,
   workspaceUploadBusy,
   fileDragEnabled,
+  attachmentsEnabled,
 }: {
   composerInput?: WebShellComposerInput;
   onSubmit?: ReturnType<typeof vi.fn>;
@@ -109,10 +121,13 @@ async function mount({
   };
   sessionId?: string;
   atWorkspaceCwd?: string;
+  composerScopeKey?: string;
+  disableLegacyHistoryFallback?: boolean;
   commands?: UseComposerCoreOptions['commands'];
   onImageIngestionNotice?: UseComposerCoreOptions['onImageIngestionNotice'];
   workspaceUploadBusy?: boolean;
   fileDragEnabled?: UseComposerCoreOptions['fileDragEnabled'];
+  attachmentsEnabled?: UseComposerCoreOptions['attachmentsEnabled'];
 } = {}) {
   container = document.createElement('div');
   document.body.append(container);
@@ -121,6 +136,7 @@ async function mount({
   let currentPortalRoot: HTMLElement | null = null;
   let currentSessionId = sessionId;
   let currentWorkspaceCwd = atWorkspaceCwd;
+  let currentAttachmentsEnabled = attachmentsEnabled;
   const render = () => {
     root!.render(
       <WebShellPortalRootContext.Provider value={currentPortalRoot}>
@@ -135,10 +151,13 @@ async function mount({
             followupState={followupState}
             sessionId={currentSessionId}
             atWorkspaceCwd={currentWorkspaceCwd}
+            composerScopeKey={composerScopeKey}
+            disableLegacyHistoryFallback={disableLegacyHistoryFallback}
             commands={commands}
             onImageIngestionNotice={onImageIngestionNotice}
             workspaceUploadBusy={workspaceUploadBusy}
             fileDragEnabled={fileDragEnabled}
+            attachmentsEnabled={currentAttachmentsEnabled}
           />
         </I18nProvider>
       </WebShellPortalRootContext.Provider>,
@@ -163,6 +182,10 @@ async function mount({
       act(() => render());
     },
     rerender() {
+      act(() => render());
+    },
+    setAttachmentsEnabled(enabled: boolean) {
+      currentAttachmentsEnabled = enabled;
       act(() => render());
     },
   };
@@ -420,6 +443,34 @@ describe('useComposerCore history and drafts', () => {
           '[]',
       ),
     ).toEqual(['prompt from b']);
+  });
+
+  it('isolates standalone history without falling back to legacy workspace prompts', async () => {
+    const scope = 'standalone';
+    localStorage.setItem(
+      getPromptHistoryStorageKey(),
+      JSON.stringify(['legacy workspace prompt']),
+    );
+    await mount({
+      sessionId: 'session-a',
+      composerScopeKey: scope,
+      disableLegacyHistoryFallback: true,
+    });
+
+    act(() => pressHistoryKey('ArrowUp'));
+    expect(latest!.getText()).toBe('');
+
+    act(() => {
+      latest!.setText('standalone prompt');
+      latest!.submitText();
+      pressHistoryKey('ArrowUp');
+    });
+    expect(latest!.getText()).toBe('standalone prompt');
+    expect(
+      JSON.parse(
+        localStorage.getItem(getPromptHistoryStorageKey(scope)) ?? '[]',
+      ),
+    ).toEqual(['standalone prompt']);
   });
 
   it('resets history navigation when the session changes', async () => {
@@ -875,6 +926,45 @@ describe('useComposerCore paste', () => {
     expect(latest!.pastedFiles).toMatchObject([
       { name: 'notes.txt', data: files[1] },
     ]);
+  });
+
+  it('drops held attachments with a notice when attachments become unavailable', async () => {
+    const onImageIngestionNotice = vi.fn();
+    const mounted = await mount({ onImageIngestionNotice });
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      expect(latest!.ingestFiles([file])).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(latest!.pastedFiles).toHaveLength(1);
+
+    mounted.setAttachmentsEnabled(false);
+
+    expect(latest!.pastedImages).toEqual([]);
+    expect(latest!.pastedFiles).toEqual([]);
+    expect(onImageIngestionNotice).toHaveBeenCalledWith(
+      'warning',
+      expect.any(String),
+    );
+  });
+
+  it('rejects new attachment ingestion while attachments are unavailable', async () => {
+    const onImageIngestionNotice = vi.fn();
+    await mount({ attachmentsEnabled: false, onImageIngestionNotice });
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      expect(latest!.ingestFiles([file])).toBe(true);
+      await Promise.resolve();
+    });
+
+    expect(latest!.pastedImages).toEqual([]);
+    expect(latest!.pastedFiles).toEqual([]);
+    expect(onImageIngestionNotice).toHaveBeenCalledWith(
+      'warning',
+      expect.any(String),
+    );
   });
 
   it('claims image drops, blocks submit while reading, and submits image-only', async () => {

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -473,6 +473,21 @@ describe('useComposerCore history and drafts', () => {
     ).toEqual(['standalone prompt']);
   });
 
+  it('keeps legacy prompt history available in the Live scope', async () => {
+    localStorage.setItem(
+      getPromptHistoryStorageKey(),
+      JSON.stringify(['legacy Live prompt']),
+    );
+    await mount({
+      sessionId: 'session-a',
+      composerScopeKey: 'live',
+      disableLegacyHistoryFallback: false,
+    });
+
+    act(() => pressHistoryKey('ArrowUp'));
+    expect(latest!.getText()).toBe('legacy Live prompt');
+  });
+
   it('resets history navigation when the session changes', async () => {
     const mounted = await mount({
       sessionId: 'session-a',

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -1127,6 +1127,10 @@ export interface UseComposerCoreOptions {
   builtinAtProviders?: WebShellBuiltinAtProvidersConfig;
   atProviders?: readonly WebShellAtProvider[];
   atWorkspaceCwd?: string;
+  composerScopeKey?: string;
+  disableLegacyHistoryFallback?: boolean;
+  attachmentsEnabled?: boolean;
+  workspaceFeaturesEnabled?: boolean;
   composerTagIcons?: WebShellComposerTagIconMap;
   parseUserMessageContent?: UserMessageContentParser;
   renderComposerTag?: ComposerTagRenderer;
@@ -1427,6 +1431,10 @@ export function useComposerCore(
     builtinAtProviders,
     atProviders,
     atWorkspaceCwd,
+    composerScopeKey,
+    disableLegacyHistoryFallback = false,
+    attachmentsEnabled = true,
+    workspaceFeaturesEnabled = true,
     composerTagIcons,
     parseUserMessageContent,
     renderComposerTag,
@@ -1442,15 +1450,17 @@ export function useComposerCore(
   const workspace = useOptionalWorkspace();
   const { language, t } = useI18n();
   const portalRoot = useWebShellPortalRoot();
-  const promptHistoryStorageKey = getPromptHistoryStorageKey(atWorkspaceCwd);
+  const storageScopeKey = composerScopeKey ?? atWorkspaceCwd;
+  const promptHistoryStorageKey = getPromptHistoryStorageKey(storageScopeKey);
   const legacyPromptHistoryStorageKey = getPromptHistoryStorageKey();
   const promptHistoryFallbackStorageKey =
+    disableLegacyHistoryFallback ||
     promptHistoryStorageKey === legacyPromptHistoryStorageKey
       ? undefined
       : legacyPromptHistoryStorageKey;
   const composerDraftStorageKey = getComposerDraftStorageKey(
     sessionId,
-    atWorkspaceCwd,
+    storageScopeKey,
   );
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -1470,7 +1480,7 @@ export function useComposerCore(
   const skipNextRestoredAnnotationMappingRef = useRef(false);
   const draftIdentityRef = useRef({
     sessionId,
-    workspaceCwd: atWorkspaceCwd,
+    workspaceCwd: storageScopeKey,
     storageKey: composerDraftStorageKey,
   });
   const unscopedDraftEditedRef = useRef(false);
@@ -1530,6 +1540,8 @@ export function useComposerCore(
   disabledRef.current = disabled;
   const fileDragEnabledRef = useRef(fileDragEnabled);
   fileDragEnabledRef.current = fileDragEnabled;
+  const attachmentsEnabledRef = useRef(attachmentsEnabled);
+  attachmentsEnabledRef.current = attachmentsEnabled;
   const workspaceUploadBusyRef = useRef(workspaceUploadBusy);
   workspaceUploadBusyRef.current = workspaceUploadBusy;
   const commandsRef = useRef(commands);
@@ -1559,7 +1571,9 @@ export function useComposerCore(
   const workspaceActionsRef = useRef<AtMentionWorkspaceActions | undefined>(
     undefined,
   );
-  if (workspace && atWorkspaceCwd) {
+  if (!workspaceFeaturesEnabled) {
+    workspaceActionsRef.current = undefined;
+  } else if (workspace && atWorkspaceCwd) {
     const client = workspace.client.workspaceByCwd(atWorkspaceCwd);
     workspaceActionsRef.current = {
       ...workspace.actions,
@@ -1765,9 +1779,25 @@ export function useComposerCore(
     },
     [],
   );
+  useEffect(() => {
+    if (attachmentsEnabled) return;
+    const hadAttachments =
+      pastedImagesRef.current.length > 0 || pastedFilesRef.current.length > 0;
+    resetImageIngestion();
+    if (hadAttachments) {
+      emitImageIngestionNotice('warning', t('composerAdd.file.attachDisabled'));
+    }
+  }, [attachmentsEnabled, emitImageIngestionNotice, resetImageIngestion, t]);
   const enqueueExtractedTransfer = useCallback(
     (transfer: ExtractedFileTransfer) => {
       if (!transfer.claimed) return false;
+      if (!attachmentsEnabledRef.current) {
+        emitImageIngestionNotice(
+          'warning',
+          tRef.current('composerAdd.file.attachDisabled'),
+        );
+        return true;
+      }
       if (disabledRef.current) return true;
 
       const lane = imageIngestionLaneRef.current;
@@ -2607,6 +2637,14 @@ export function useComposerCore(
     const tags = tagsOverride ?? composerTagsRef.current;
     const images = pastedImagesRef.current;
     const files = pastedFilesRef.current;
+    if (
+      !attachmentsEnabledRef.current &&
+      (images.length > 0 || files.length > 0)
+    ) {
+      emitImageIngestionNotice('warning', t('composerAdd.file.attachDisabled'));
+      resetImageIngestion();
+      return true;
+    }
     if (
       !rawText &&
       tags.length === 0 &&
@@ -3449,7 +3487,7 @@ export function useComposerCore(
     const view = viewRef.current;
     const sessionChanged = previousDraftIdentity.sessionId !== sessionId;
     const workspaceChanged =
-      previousDraftIdentity.workspaceCwd !== atWorkspaceCwd;
+      previousDraftIdentity.workspaceCwd !== storageScopeKey;
     const draftStorageChanged =
       previousDraftIdentity.storageKey !== composerDraftStorageKey;
     const wasBrowsingHistory = historyBrowseActiveRef.current;
@@ -3477,7 +3515,7 @@ export function useComposerCore(
     }
     draftIdentityRef.current = {
       sessionId,
-      workspaceCwd: atWorkspaceCwd,
+      workspaceCwd: storageScopeKey,
       storageKey: composerDraftStorageKey,
     };
 
@@ -3491,7 +3529,7 @@ export function useComposerCore(
       sessionId === undefined &&
       previousDraftIdentity.workspaceCwd === undefined &&
       previousDraftIdentity.storageKey === undefined &&
-      atWorkspaceCwd !== undefined &&
+      storageScopeKey !== undefined &&
       (unscopedDraftEditedRef.current || storedDraft === null);
     unscopedDraftEditedRef.current = false;
     const nextText = adoptUnscopedInMemoryDraft
@@ -3515,7 +3553,7 @@ export function useComposerCore(
       unscopedDraftEditedRef.current = false;
     }
   }, [
-    atWorkspaceCwd,
+    storageScopeKey,
     clearPromptHistoryDraftTags,
     composerDraftStorageKey,
     isTouchComposer,

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -615,6 +615,53 @@ const EN: Messages = {
   'common.invalid': 'invalid',
   'common.loading': 'Loading...',
   'common.retry': 'Try again',
+  'session.archived': 'This conversation is archived',
+  'session.archivedDescription':
+    'Unarchive it before opening the conversation.',
+  'session.capabilitiesFailed':
+    'The daemon capabilities could not be loaded. Try again before opening this conversation.',
+  'session.contextConflict':
+    'A standalone or Live conversation link cannot include a workspace target.',
+  'session.loadFailed': 'Failed to load conversation',
+  'session.notFound': 'Conversation not found',
+  'session.notFoundDescription':
+    'This standalone conversation no longer exists.',
+  'session.resolving': 'Opening conversation...',
+  'session.standaloneUnavailable': 'Standalone conversations are unavailable',
+  'session.standaloneUpgradeRequired':
+    'Upgrade the daemon to open standalone conversations.',
+  'session.stillCreating':
+    'The conversation is still being created. Try checking again.',
+  'session.recoveryPending':
+    'Creation may have succeeded, but the result could not be confirmed. Sending is paused to avoid creating a duplicate conversation.',
+  'session.recoveryChecking': 'Checking the reserved conversation ID...',
+  'session.recoveryStillCreating':
+    'The conversation is still being created. Check again in a moment.',
+  'session.recoveryAbsent':
+    'No conversation exists for the reserved ID. You can explicitly start a fresh conversation.',
+  'session.recoveryUnknown':
+    'The creation result is still unknown. Check again before starting another conversation.',
+  'session.recoveryArchived':
+    'The recovered conversation is archived. Unarchive it before opening.',
+  'session.recoveryCheckFailed': 'Failed to check conversation creation',
+  'session.recoveryBlocksAction':
+    'Resolve the pending standalone conversation state before continuing.',
+  'session.checkStatus': 'Check status',
+  'session.retryCreation': 'Start a fresh conversation',
+  'session.directoryRecreated':
+    'The transcript was recovered, but files from the previous private directory were not available.',
+  'session.directoryMissing':
+    "This conversation's private working directory is missing. Repair it before sending another prompt.",
+  'session.directoryCompromised':
+    'This private working directory is unsafe and cannot be repaired automatically. Export the transcript, then delete the conversation.',
+  'session.repair': 'Repair directory',
+  'session.repairing': 'Repairing...',
+  'session.repairFailed': 'Failed to repair the private working directory',
+  'session.repairSucceeded': 'The private working directory was repaired.',
+  'session.unarchive': 'Unarchive',
+  'session.unarchiveFailed': 'Failed to unarchive this conversation.',
+  'session.workspaceActionUnavailable':
+    'This action is available only in project conversations.',
   'common.save': 'save',
   'common.navigate': '↑↓ to navigate',
   'common.next': 'next',
@@ -1486,6 +1533,15 @@ const EN: Messages = {
   'sidebar.archiveRunningDisabled':
     'A running session cannot be archived; archiving would end its turn',
   'sidebar.archivedTitle': 'Archived',
+  'sidebar.recents': 'Recents',
+  'sidebar.noRecents': 'No recent conversations',
+  'sidebar.sessionActions': 'Conversation actions',
+  'sidebar.standaloneLoadFailed': 'Failed to load recent conversations',
+  'sidebar.standaloneActionFailed': 'Conversation action failed',
+  'sidebar.standaloneDeleteConfirm':
+    'Delete this conversation and its private files?',
+  'sidebar.standaloneCleanupPending':
+    'The conversation was deleted. Private file cleanup will finish automatically.',
   'sidebar.archivedEmpty': 'No archived sessions.',
   'sidebar.archiveFailed': 'Failed to archive session',
   'sidebar.unarchiveFailed': 'Failed to restore session',
@@ -3887,6 +3943,43 @@ const ZH: Messages = {
   'common.invalid': '无效',
   'common.loading': '加载中...',
   'common.retry': '重试',
+  'session.archived': '该会话已归档',
+  'session.archivedDescription': '需要先取消归档，才能打开该会话。',
+  'session.capabilitiesFailed': '无法加载 Daemon 能力。请重试后再打开该会话。',
+  'session.contextConflict': 'Standalone 或 Live 会话链接不能同时指定工作区。',
+  'session.loadFailed': '会话加载失败',
+  'session.notFound': '会话不存在',
+  'session.notFoundDescription': '该 Standalone 会话已不存在。',
+  'session.resolving': '正在打开会话...',
+  'session.standaloneUnavailable': 'Standalone 会话不可用',
+  'session.standaloneUpgradeRequired':
+    '请升级 Daemon 后再打开 Standalone 会话。',
+  'session.stillCreating': '会话仍在创建中，请稍后重试。',
+  'session.recoveryPending':
+    '创建可能已成功，但结果尚未确认。为避免重复创建，当前已暂停发送。',
+  'session.recoveryChecking': '正在检查预留的会话 ID...',
+  'session.recoveryStillCreating': '会话仍在创建中，请稍后再次检查。',
+  'session.recoveryAbsent':
+    '预留 ID 对应的会话不存在，可以显式开始一个新会话。',
+  'session.recoveryUnknown': '创建结果仍不确定，请再次检查后再开始其他会话。',
+  'session.recoveryArchived': '恢复到的会话已归档，请先取消归档。',
+  'session.recoveryCheckFailed': '检查会话创建状态失败',
+  'session.recoveryBlocksAction':
+    '请先处理待确认的 Standalone 会话状态，再继续操作。',
+  'session.checkStatus': '检查状态',
+  'session.retryCreation': '开始新会话',
+  'session.directoryRecreated':
+    '会话记录已恢复，但之前私有目录中的文件未能恢复。',
+  'session.directoryMissing': '该会话的私有工作目录缺失，请修复后再发送消息。',
+  'session.directoryCompromised':
+    '该私有工作目录存在安全风险，无法自动修复。请先导出会话记录，再删除该会话。',
+  'session.repair': '修复目录',
+  'session.repairing': '修复中...',
+  'session.repairFailed': '修复私有工作目录失败',
+  'session.repairSucceeded': '私有工作目录已修复。',
+  'session.unarchive': '取消归档',
+  'session.unarchiveFailed': '取消归档失败。',
+  'session.workspaceActionUnavailable': '该操作仅适用于项目会话。',
   'common.save': '保存',
   'common.navigate': '↑↓ 导航',
   'common.next': '下一步',
@@ -4696,6 +4789,14 @@ const ZH: Messages = {
   'sidebar.archiveRunningDisabled':
     '不能归档运行中的会话，归档会终止其当前回合',
   'sidebar.archivedTitle': '已归档',
+  'sidebar.recents': '最近会话',
+  'sidebar.noRecents': '暂无最近会话',
+  'sidebar.sessionActions': '会话操作',
+  'sidebar.standaloneLoadFailed': '最近会话加载失败',
+  'sidebar.standaloneActionFailed': '会话操作失败',
+  'sidebar.standaloneDeleteConfirm': '删除该会话及其私有文件？',
+  'sidebar.standaloneCleanupPending':
+    '会话已删除，私有文件清理将在后台自动完成。',
   'sidebar.archivedEmpty': '没有已归档的会话。',
   'sidebar.archiveFailed': '归档会话失败',
   'sidebar.unarchiveFailed': '恢复会话失败',

--- a/packages/web-shell/client/index.tsx
+++ b/packages/web-shell/client/index.tsx
@@ -1,5 +1,8 @@
 import { type ReactNode } from 'react';
-import { DaemonWorkspaceProvider } from '@qwen-code/web-shell/daemon-react-sdk';
+import {
+  DaemonWorkspaceProvider,
+  type DaemonProductSessionContext,
+} from '@qwen-code/web-shell/daemon-react-sdk';
 import { App, type WebShellProps } from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { RootErrorFallback } from './components/RootErrorFallback';
@@ -20,6 +23,8 @@ export interface WebShellWithProvidersProps extends WebShellProps {
   workspaceId?: string;
   /** Registered daemon workspace path for the session. Takes precedence over workspaceId. */
   workspaceCwd?: string;
+  /** Explicit product context. Use standalone without workspaceId/workspaceCwd. */
+  sessionContext?: DaemonProductSessionContext;
   /**
    * Workspace path to lock this shell to. Missing paths are registered
    * persistently before rendering. Takes precedence over workspaceCwd and workspaceId.
@@ -96,6 +101,7 @@ export function WebShellWithProviders(props: WebShellWithProvidersProps) {
     sessionId,
     workspaceId,
     workspaceCwd,
+    sessionContext,
     lockWorkspaceCwd,
     clientId,
     restartSseOnPrompt,
@@ -117,6 +123,7 @@ export function WebShellWithProviders(props: WebShellWithProvidersProps) {
           sessionId={sessionId}
           workspaceId={workspaceId}
           workspaceCwd={workspaceCwd}
+          sessionContext={sessionContext}
           lockWorkspaceCwd={lockWorkspaceCwd}
           clientId={clientId}
           restartSseOnPrompt={restartSseOnPrompt}

--- a/packages/web-shell/client/main.test.tsx
+++ b/packages/web-shell/client/main.test.tsx
@@ -3,11 +3,13 @@
 import { act, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DaemonProductSessionContext } from '@qwen-code/web-shell/daemon-react-sdk';
 import type { WebShellProps } from './App';
 
 interface CapturedWorkspaceSessionProps {
   sessionId?: string;
   workspaceId?: string;
+  sessionContext?: DaemonProductSessionContext;
   webShellProps: WebShellProps;
 }
 
@@ -75,5 +77,88 @@ describe('StandaloneApp', () => {
     expect(
       testState.props?.webShellProps.composerToolbarAdditionalActions,
     ).toEqual(['addMenu']);
+  });
+
+  it('round-trips standalone context without a workspace selector', () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/session/standalone-a?context=standalone',
+    );
+    act(() => root.render(<StandaloneApp daemonToken="token" />));
+
+    expect(testState.props).toMatchObject({
+      sessionId: 'standalone-a',
+      sessionContext: { kind: 'standalone' },
+    });
+    expect(testState.props?.workspaceId).toBeUndefined();
+
+    act(() => {
+      testState.props?.webShellProps.onSessionIdChange?.(
+        'standalone-b',
+        undefined,
+        undefined,
+        { kind: 'standalone' },
+      );
+    });
+
+    expect(window.location.pathname).toBe('/session/standalone-b');
+    expect(new URLSearchParams(window.location.search).get('context')).toBe(
+      'standalone',
+    );
+    expect(new URLSearchParams(window.location.search).has('workspace')).toBe(
+      false,
+    );
+  });
+
+  it('keeps standalone context in the URL for an unallocated draft', () => {
+    act(() => root.render(<StandaloneApp daemonToken="token" />));
+
+    act(() => {
+      testState.props?.webShellProps.onSessionIdChange?.(
+        undefined,
+        undefined,
+        undefined,
+        { kind: 'standalone' },
+      );
+    });
+
+    expect(testState.props).toMatchObject({
+      sessionId: undefined,
+      workspaceId: undefined,
+      sessionContext: { kind: 'standalone' },
+    });
+    expect(window.location.pathname).toBe('/');
+    expect(new URLSearchParams(window.location.search).get('context')).toBe(
+      'standalone',
+    );
+  });
+
+  it('round-trips Live context without exposing its internal workspace', () => {
+    window.history.replaceState(null, '', '/session/live-a?context=live');
+    act(() => root.render(<StandaloneApp daemonToken="token" />));
+
+    expect(testState.props).toMatchObject({
+      sessionId: 'live-a',
+      sessionContext: { kind: 'live' },
+    });
+    expect(testState.props?.workspaceId).toBeUndefined();
+
+    act(() => {
+      testState.props?.webShellProps.onSessionIdChange?.(
+        'live-b',
+        undefined,
+        undefined,
+        { kind: 'live' },
+      );
+    });
+
+    expect(window.location.pathname).toBe('/session/live-b');
+    expect(new URLSearchParams(window.location.search).get('context')).toBe(
+      'live',
+    );
+    expect(new URLSearchParams(window.location.search).has('workspace')).toBe(
+      false,
+    );
   });
 });

--- a/packages/web-shell/client/main.tsx
+++ b/packages/web-shell/client/main.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { useCallback, useEffect, useState } from 'react';
-import { DaemonWorkspaceProvider } from '@qwen-code/web-shell/daemon-react-sdk';
+import {
+  DaemonWorkspaceProvider,
+  type DaemonProductSessionContext,
+} from '@qwen-code/web-shell/daemon-react-sdk';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { RootErrorFallback } from './components/RootErrorFallback';
 import { WorkspaceSessionProvider } from './components/WorkspaceSessionProvider';
@@ -90,16 +93,32 @@ function getWorkspaceIdFromUrl(): string | undefined {
   );
 }
 
+function getSessionContextFromUrl(): DaemonProductSessionContext | undefined {
+  const context = new URLSearchParams(window.location.search).get('context');
+  return context === 'standalone' || context === 'live'
+    ? { kind: context }
+    : undefined;
+}
+
 function replaceStandaloneSessionUrl(
   sessionId: string | undefined,
   workspaceId?: string,
+  sessionContext?: DaemonProductSessionContext,
 ): void {
   const url = new URL(window.location.href);
   url.pathname = buildSessionPathname(url.pathname, sessionId);
-  if (sessionId && workspaceId) {
+  if (
+    sessionContext?.kind === 'standalone' ||
+    sessionContext?.kind === 'live'
+  ) {
+    url.searchParams.set('context', sessionContext.kind);
+    url.searchParams.delete('workspace');
+  } else if (sessionId && workspaceId) {
     url.searchParams.set('workspace', workspaceId);
+    url.searchParams.delete('context');
   } else {
     url.searchParams.delete('workspace');
+    url.searchParams.delete('context');
   }
   // Strip one-shot query params so bookmarked / shared URLs do not
   // permanently override stored preferences on every page load.
@@ -124,6 +143,9 @@ export function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
   const [workspaceId, setWorkspaceId] = useState<string | undefined>(() =>
     getWorkspaceIdFromUrl(),
   );
+  const [sessionContext, setSessionContext] = useState<
+    DaemonProductSessionContext | undefined
+  >(() => getSessionContextFromUrl());
   const baseUrl = DAEMON_BASE_URL || window.location.origin;
   // Keep the <html> theme class and <meta name="theme-color"> in sync with
   // the React theme so mobile status bars / overscroll backgrounds stay
@@ -147,10 +169,25 @@ export function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
     storeLanguage(nextLanguage);
   }, []);
   const handleSessionIdChange = useCallback(
-    (nextSessionId?: string, nextWorkspaceId?: string) => {
+    (
+      nextSessionId?: string,
+      nextWorkspaceId?: string,
+      _nextWorkspaceCwd?: string,
+      nextSessionContext?: DaemonProductSessionContext,
+    ) => {
       setSessionId(nextSessionId);
-      setWorkspaceId(nextWorkspaceId);
-      replaceStandaloneSessionUrl(nextSessionId, nextWorkspaceId);
+      const nonWorkspaceContext =
+        nextSessionContext?.kind === 'standalone' ||
+        nextSessionContext?.kind === 'live'
+          ? nextSessionContext
+          : undefined;
+      setSessionContext(nonWorkspaceContext);
+      setWorkspaceId(nonWorkspaceContext ? undefined : nextWorkspaceId);
+      replaceStandaloneSessionUrl(
+        nextSessionId,
+        nextWorkspaceId,
+        nonWorkspaceContext,
+      );
     },
     [],
   );
@@ -166,6 +203,7 @@ export function StandaloneApp({ daemonToken }: { daemonToken?: string }) {
         <WorkspaceSessionProvider
           sessionId={sessionId}
           workspaceId={workspaceId}
+          sessionContext={sessionContext}
           webShellProps={{
             theme,
             onThemeChange: handleThemeChange,

--- a/packages/web-shell/client/utils/sessionPreparation.test.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.test.ts
@@ -66,6 +66,25 @@ describe('createAndAttachSessionForPrompt', () => {
     expect(actions.setModel).toHaveBeenCalledWith('qwen3');
   });
 
+  it('creates standalone sessions without workspace-only fields', async () => {
+    const actions = createActions();
+
+    await prepareSession({
+      sessionActions: actions,
+      modeId: 'yolo',
+      workspaceCwd: '/must-not-leak',
+      sessionContext: { kind: 'standalone' },
+      worktree: { slug: 'must-not-leak' },
+      branch: { name: 'must-not-leak' },
+      sessionSourceType: 'must-not-leak',
+    });
+
+    expect(actions.createSession).toHaveBeenCalledWith({
+      sessionContext: { kind: 'standalone' },
+      approvalMode: 'yolo',
+    });
+  });
+
   it('applies an explicit reasoning effort after the model and before resolving', async () => {
     const order: string[] = [];
     const actions = createActions({

--- a/packages/web-shell/client/utils/sessionPreparation.ts
+++ b/packages/web-shell/client/utils/sessionPreparation.ts
@@ -1,6 +1,7 @@
 import {
   DAEMON_APPROVAL_MODES,
   type DaemonApprovalMode,
+  type DaemonProductSessionContext,
 } from '@qwen-code/web-shell/daemon-react-sdk';
 import type { ReasoningSelection } from '@qwen-code/sdk/daemon';
 import { WEB_SHELL_SESSION_SOURCE_TYPE } from '../constants/sessions';
@@ -10,6 +11,7 @@ const SESSION_CREATED_CALLBACK_TIMEOUT_MS = 30_000;
 type PromptSessionActions = {
   createSession: (options?: {
     workspaceCwd?: string;
+    sessionContext?: DaemonProductSessionContext;
     approvalMode?: DaemonApprovalMode;
     sourceType?: string;
     worktree?: { slug?: string };
@@ -39,6 +41,7 @@ export async function createAndAttachSessionForPrompt({
   reasoningEffort,
   modeId,
   workspaceCwd,
+  sessionContext,
   worktree,
   branch,
   sessionSourceType = WEB_SHELL_SESSION_SOURCE_TYPE,
@@ -52,6 +55,7 @@ export async function createAndAttachSessionForPrompt({
   reasoningEffort?: ReasoningSelection;
   modeId?: string;
   workspaceCwd?: string;
+  sessionContext?: DaemonProductSessionContext;
   worktree?: { slug?: string };
   branch?: { name: string };
   /**
@@ -79,13 +83,21 @@ export async function createAndAttachSessionForPrompt({
     sessionId,
     worktree: worktreeInfo,
     branch: branchInfo,
-  } = await sessionActions.createSession({
-    workspaceCwd,
-    sourceType: sessionSourceType,
-    ...(approvalMode ? { approvalMode } : {}),
-    ...(worktree ? { worktree } : {}),
-    ...(branch ? { branch } : {}),
-  });
+  } = await sessionActions.createSession(
+    sessionContext?.kind === 'standalone'
+      ? {
+          sessionContext,
+          ...(approvalMode ? { approvalMode } : {}),
+        }
+      : {
+          workspaceCwd,
+          sessionContext,
+          sourceType: sessionSourceType,
+          ...(approvalMode ? { approvalMode } : {}),
+          ...(worktree ? { worktree } : {}),
+          ...(branch ? { branch } : {}),
+        },
+  );
   onSessionAllocated?.(sessionId);
   let preparationStep = 'prepare new session';
   try {

--- a/packages/web-shell/client/utils/standalone-session-routing.test.ts
+++ b/packages/web-shell/client/utils/standalone-session-routing.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DaemonHttpError,
+  STANDALONE_SESSIONS_CAPABILITY,
+  type DaemonClient,
+  type DaemonCapabilities,
+} from '@qwen-code/sdk/daemon';
+
+import { keepWorkspaceSplitSessionIds } from './standalone-session-routing';
+
+const capable = {
+  features: [STANDALONE_SESSIONS_CAPABILITY],
+} as DaemonCapabilities;
+
+describe('keepWorkspaceSplitSessionIds', () => {
+  it('fails closed while capabilities are unresolved', async () => {
+    const getStandaloneSession = vi.fn();
+
+    await expect(
+      keepWorkspaceSplitSessionIds(
+        { getStandaloneSession } as unknown as DaemonClient,
+        undefined,
+        ['workspace-session'],
+      ),
+    ).resolves.toEqual([]);
+    expect(getStandaloneSession).not.toHaveBeenCalled();
+  });
+
+  it('preserves legacy workspace ids when standalone is unsupported', async () => {
+    const getStandaloneSession = vi.fn();
+
+    await expect(
+      keepWorkspaceSplitSessionIds(
+        { getStandaloneSession } as unknown as DaemonClient,
+        { features: [] } as unknown as DaemonCapabilities,
+        ['one', 'one', 'two'],
+      ),
+    ).resolves.toEqual(['one', 'two']);
+    expect(getStandaloneSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps only ids proven absent from the standalone registry', async () => {
+    const getStandaloneSession = vi.fn(async (sessionId: string) => {
+      if (sessionId === 'standalone') {
+        return { state: 'creating', sessionId };
+      }
+      if (sessionId === 'workspace') {
+        throw new DaemonHttpError(
+          404,
+          { code: 'standalone_session_not_found' },
+          'not found',
+        );
+      }
+      throw new DaemonHttpError(500, { code: 'internal_error' }, 'unavailable');
+    });
+
+    await expect(
+      keepWorkspaceSplitSessionIds(
+        { getStandaloneSession } as unknown as DaemonClient,
+        capable,
+        ['standalone', 'workspace', 'unknown'],
+      ),
+    ).resolves.toEqual(['workspace']);
+  });
+});

--- a/packages/web-shell/client/utils/standalone-session-routing.ts
+++ b/packages/web-shell/client/utils/standalone-session-routing.ts
@@ -1,0 +1,30 @@
+import {
+  isStandaloneSessionNotFoundError,
+  STANDALONE_SESSIONS_CAPABILITY,
+  type DaemonClient,
+  type DaemonCapabilities,
+} from '@qwen-code/sdk/daemon';
+
+export async function keepWorkspaceSplitSessionIds(
+  client: DaemonClient,
+  capabilities: DaemonCapabilities | undefined,
+  sessionIds: readonly string[],
+): Promise<string[]> {
+  const requested = Array.from(new Set(sessionIds.filter(Boolean)));
+  if (requested.length === 0 || !capabilities) return [];
+  if (!capabilities.features?.includes(STANDALONE_SESSIONS_CAPABILITY)) {
+    return requested;
+  }
+
+  const classifications = await Promise.all(
+    requested.map(async (sessionId) => {
+      try {
+        await client.getStandaloneSession(sessionId);
+        return false;
+      } catch (error) {
+        return isStandaloneSessionNotFoundError(error);
+      }
+    }),
+  );
+  return requested.filter((_, index) => classifications[index]);
+}


### PR DESCRIPTION
## What this PR does

Implements the approved PR6 plan and makes standalone chats a first-class WebShell product context. Global New task creates an exact standalone session when `standalone_sessions_v1` is available, while project, Goals, and Git entry points remain workspace-scoped and older daemons retain the legacy primary-workspace route only when the capability is absent. Explicit standalone and Live navigation never falls back to the primary workspace.

Adds top-level standalone Recents with active and archived pagination plus rename, export, archive, unarchive, and delete actions. Deep links carry an explicit context, validate the exact standalone session before mounting the provider, unarchive archived sessions before attach, and preserve standalone recovery UI for missing, compromised, recreated-directory, cleanup-pending, and outcome-unknown states. Standalone creation is not automatically retried or hidden behind the generic action timeout.

Separates workspace, standalone, and Live UI behavior. Non-workspace chats skip project-only navigation, workspace settings, Git state, split view, workspace invalidation, file references, uploads, and Web Terminal surfaces. Attached standalone sessions still expose their daemon-supported slash commands, skills, Shell, and ordinary tools; only workspace-dependent surfaces are removed. Composer drafts and history are isolated by product context, stale transitions cannot publish data into the newly selected context, and the public React entry point can receive and report `sessionContext` for host routing.

## Why it's needed

The earlier standalone sequence delivered daemon routes, capability advertisement, SDK methods, and explicit React provider contexts, but users still had no WebShell path to create, find, reopen, or manage a workspace-independent chat. This change completes the user-facing slice while preserving old-daemon compatibility and the existing project workflow. It also keeps failure semantics explicit: capability loading fails closed, uncertain creation remains recoverable by exact session ID, directory recovery is typed, and standalone routes never leak an internal cwd into product workspace state.

## Reviewer Test Plan

### How to verify

1. With `standalone_sessions_v1`, use global New task and confirm one exact standalone session is created, the URL carries `context=standalone`, no workspace parameter is added, and the session appears under top-level Recents.
2. Without the capability, confirm global New task follows the existing primary-workspace behavior; with capability loading or capability lookup failure, confirm creation waits or fails closed rather than falling back.
3. Open, archive, unarchive, rename, export, and delete standalone rows, including archived pagination, and confirm every action targets the exact standalone route while child sessions are excluded.
4. Open standalone and Live chats and confirm project-only navigation, Git/settings controls, split view, attachments, file references, uploads, and Web Terminal are unavailable. In an attached standalone session, confirm session-supported commands, skills, Shell, and ordinary tools still work.
5. Exercise exact standalone deep links for active, archived, creating, missing, compromised, recreated-directory, cleanup-pending, and outcome-unknown sessions. Confirm archived sessions unarchive before attach, uncertain creation is never retried automatically, and navigation during an in-flight transition cannot publish stale transcript or recovery state.
6. Verify project New task, Goals, Git, and workspace session links remain exact-workspace flows, while the public callback and root URL preserve explicit standalone and Live context.

### Evidence (Before & After)

| | Before | After |
| --- | --- | --- |
| Global New task | Started the legacy primary-workspace flow. | Creates an exact standalone session when capability-gated, with legacy behavior only when the capability is absent. |
| Session discovery | No product-level standalone catalog or lifecycle UI. | Top-level active and archived Recents expose exact standalone lifecycle actions. |
| Routing and recovery | Standalone IDs had no explicit WebShell routing or typed recovery surface. | Context-explicit deep links validate exact state and render bounded recovery without workspace fallback. |
| Product isolation | Workspace-only controls could remain reachable from non-workspace contexts. | Standalone and Live hide workspace-only surfaces while retaining session-supported commands and tools. |

Automated evidence: the full WebShell unit coverage run passed 5,290 tests; the full Playwright suite passed 66 tests with 1 intentional skip; after rebasing onto current `main`, 941 focused unit tests and all 6 standalone/split E2E tests passed again.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js 22.22.3, Vitest, Playwright Chromium, and the deterministic mock daemon. Repository `npm run build` and `npm run typecheck` passed after the final rebase; WebShell lint passed with zero warnings, and every changed file passed Prettier. The package-wide format check still reports nine unchanged pre-existing files, so this PR does not rewrite unrelated formatting.

## Risk & Scope

- Main risk or tradeoff: product-context orchestration touches the central WebShell application and session provider, so regressions could affect navigation or stale async transitions; focused ownership, failure-path, public-surface, browser-bundle, unit, and E2E coverage guard those boundaries.
- Not validated / out of scope: no real-daemon manual UI recording, Windows or Linux local run, Global Recents beyond standalone sessions, lifecycle menus outside standalone Recents, standalone uploads, durable scheduling changes, daemon lifecycle changes, or the separate WebShell cutover tracked by #9811.
- Breaking changes / migration notes: none. The public context input is optional, older daemons keep their legacy route when the standalone capability is absent, and explicit non-workspace contexts deliberately fail closed rather than falling back to a workspace.

## Linked Issues

Refs #8908

<details>
<summary>中文说明</summary>

## 本 PR 内容

按照已通过评审的 PR6 方案完成实现，使 standalone 聊天成为 WebShell 中的一等产品上下文。当 daemon 提供 `standalone_sessions_v1` capability 时，全局 New task 会创建一个精确的 standalone 会话；项目、Goals 和 Git 入口仍严格绑定 workspace；只有 capability 确实缺失时，旧 daemon 才继续走原有的主 workspace 路由。显式 standalone 和 Live 导航绝不会回退到主 workspace。

新增顶层 standalone Recents，支持 active/archived 分页，以及重命名、导出、归档、取消归档和删除。深链携带显式上下文，在挂载 provider 前校验精确 standalone 会话，对已归档会话先取消归档再 attach，并为会话缺失、目录受损、目录已重建、清理待完成和创建结果未知等状态保留 standalone 恢复界面。standalone 创建不会自动重试，也不会被通用 action timeout 掩盖。

明确区分 workspace、standalone 和 Live 的 UI 行为。非 workspace 聊天会跳过项目专属导航、workspace 设置、Git 状态、分屏、workspace 失效刷新、文件引用、上传和 Web Terminal。已 attach 的 standalone 会话仍会暴露 daemon 支持的 slash commands、skills、Shell 和普通工具；移除的只是依赖 workspace 的界面。输入草稿与历史按产品上下文隔离，过期异步切换不能把数据发布到新选择的上下文，公共 React 入口也可接收并回报 `sessionContext`，供宿主完成路由。

## 背景与动机

此前的 standalone 序列已经交付 daemon 路由、capability 广告、SDK 方法和显式 React provider 上下文，但用户仍无法在 WebShell 中创建、发现、重新打开或管理一个不依赖 workspace 的聊天。本改动完成面向用户的最后一段，同时保留旧 daemon 兼容性和现有项目工作流。失败语义也保持显式：capability 加载失败时 fail closed，创建结果不确定时可通过精确 session ID 恢复，目录恢复使用类型化状态，standalone 路由绝不会把内部 cwd 泄露成产品 workspace 状态。

## 评审验证方式

### 如何验证

1. 在具备 `standalone_sessions_v1` 的 daemon 上使用全局 New task，确认只创建一个精确 standalone 会话，URL 包含 `context=standalone`，不附带 workspace 参数，并且会话出现在顶层 Recents 中。
2. 在 capability 缺失时，确认全局 New task 保持原有主 workspace 行为；在 capability 正在加载或查询失败时，确认创建会等待或 fail closed，而不是回退。
3. 对 standalone 列表执行打开、归档、取消归档、重命名、导出和删除，并覆盖 archived 分页；确认每个操作都命中精确 standalone 路由，且子会话不会进入目录。
4. 打开 standalone 和 Live 聊天，确认项目专属导航、Git/设置控件、分屏、附件、文件引用、上传和 Web Terminal 均不可用；在已 attach 的 standalone 会话中，确认会话支持的命令、skills、Shell 和普通工具仍可运行。
5. 分别打开 active、archived、creating、missing、compromised、目录已重建、清理待完成和创建结果未知状态的精确 standalone 深链；确认 archived 会话先取消归档再 attach，创建不确定时不会自动重试，并且在异步切换期间导航不会发布过期 transcript 或恢复状态。
6. 验证项目 New task、Goals、Git 和 workspace 会话链接仍走精确 workspace 流程，同时公共回调与根 URL 会保留显式 standalone 和 Live 上下文。

### 证据（改动前后）

| | 改动前 | 改动后 |
| --- | --- | --- |
| 全局 New task | 启动旧的主 workspace 流程。 | capability 满足时创建精确 standalone 会话；仅 capability 缺失时保留旧行为。 |
| 会话发现 | 没有产品级 standalone 目录或生命周期 UI。 | 顶层 active/archived Recents 提供精确 standalone 生命周期操作。 |
| 路由与恢复 | standalone ID 没有显式 WebShell 路由或类型化恢复界面。 | 携带上下文的深链校验精确状态，并在不回退 workspace 的前提下提供有界恢复。 |
| 产品隔离 | 非 workspace 上下文仍可能触达 workspace 专属控件。 | standalone 和 Live 隐藏 workspace 专属界面，同时保留会话支持的命令与工具。 |

自动化证据：完整 WebShell 单元覆盖运行通过 5,290 项测试；完整 Playwright 套件通过 66 项，另有 1 项预期跳过；rebase 到当前 `main` 后再次通过 941 项关键单元测试以及全部 6 项 standalone/split E2E 测试。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS、Node.js 22.22.3、Vitest、Playwright Chromium，以及确定性的 mock daemon。最终 rebase 后，仓库级 `npm run build` 和 `npm run typecheck` 均通过；WebShell lint 零告警，所有本次改动文件均通过 Prettier。package 全量 format check 仍报告 9 个未改动的历史文件，因此本 PR 不会为格式化而重写无关代码。

## 风险与范围

- 主要风险或取舍：产品上下文编排触及 WebShell 中央应用和 session provider，因此潜在回归集中在导航和过期异步切换；针对 ownership、失败路径、公共接口、浏览器 bundle、单元和 E2E 的覆盖用于守住这些边界。
- 未验证/超出范围：未进行真实 daemon 的手工 UI 录屏、Windows 或 Linux 本地运行；不包含 standalone 以外的 Global Recents、standalone Recents 之外的生命周期菜单、standalone 上传、持久调度改动、daemon 生命周期改动，也不包含 #9811 跟踪的独立 WebShell cutover。
- 破坏性变更/迁移说明：无。公共上下文输入为可选项；旧 daemon 在 capability 缺失时继续使用旧路由；显式非 workspace 上下文会有意 fail closed，而不会回退到 workspace。

## 关联问题

Refs #8908

</details>
