### PR TITLE
test(integration): wait for ACP command update notification

### DIFF
--- a/integration-tests/cli/acp-integration.test.ts
+++ b/integration-tests/cli/acp-integration.test.ts
@@ -748,8 +748,15 @@ function setupAcpTest(
       })) as { sessionId: string };
       expect(newSession.sessionId).toBeTruthy();
 
-      // Wait for available_commands_update to be received
-      await delay(1000);
+      await rig.poll(
+        () =>
+          sessionUpdates.some(
+            (update) =>
+              update.update?.sessionUpdate === 'available_commands_update',
+          ),
+        5000,
+        100,
+      );
 
       // Verify available_commands_update is received
       const commandsUpdate = sessionUpdates.find(


### PR DESCRIPTION
## What this PR does

This PR replaces the fixed one-second sleep in the ACP command-update integration check with condition-based polling. The check now stops as soon as `available_commands_update` arrives and keeps the existing assertions that validate the command payload.

## Why it's needed

[Main E2E run 33259149948](https://github.com/QwenLM/qwen-code/actions/runs/33259149948) failed this check on all three attempts. The first two attempts reported ACP event-loop stalls of 1415.58 ms and 1190.13 ms, both longer than the fixed one-second wait, so the assertion inspected the notification list before the asynchronously queued update was delivered.

The failed run was triggered by the main commit that merged #9045, but #9045 did not change this ACP path. The fixed wait originated in #1113 and has also produced the earlier failure tracked by #10491. Runner load exposed the existing test race; this is not evidence that #9045 introduced an ACP product regression.

## Reviewer Test Plan

### How to verify

Run the focused ACP integration check with an OpenAI-shaped local test configuration. Confirm that session creation is followed by an `available_commands_update`, that the check returns as soon as the notification arrives, and that the `init` command assertions still pass. Repeating the focused check should not fail when delivery takes longer than one second but remains within the five-second bound.

### Evidence (Before & After)

Before: the Linux `sandbox:none` shard failed three times with `AssertionError: expected undefined to be defined` at the command-update assertion. Two attempts logged event-loop stalls longer than the fixed wait.

After: `npm run build` and `npm run bundle` passed. The focused ACP check passed four consecutive local runs. `git diff --check` and the Prettier check also passed.

UI verification: N/A — this PR changes only integration-test synchronization and does not affect user-visible behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.0, `QWEN_SANDBOX=false`, and a non-routable local OpenAI-shaped endpoint for the authentication-only setup. The full Linux CLI integration suite runs only for `merge_group`; the no-AK gate on the PR does not include this ACP file, so the focused local run is the direct verification until merge-queue execution.

## Risk & Scope

- Main risk or tradeoff: a real missing notification can take up to five seconds to fail instead of one second; successful delivery returns immediately.
- Not validated / out of scope: the full E2E matrix was not run locally because it depends on repository secrets. No production ACP behavior is changed.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10491
Fixes #10515

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 将 ACP 命令更新集成检查中固定的一秒等待改为基于条件的轮询。收到 `available_commands_update` 后检查会立即继续，同时保留现有断言来验证命令数据。

## 为什么需要这个改动

[main E2E run 33259149948](https://github.com/QwenLM/qwen-code/actions/runs/33259149948) 的该检查连续三次失败。前两次分别记录了 1415.58 毫秒和 1190.13 毫秒的 ACP 事件循环停顿，都超过了固定的一秒等待，因此异步排队的更新尚未送达时，断言就已经检查了通知列表。

失败 run 由合入 #9045 后的 main 提交触发，但 #9045 没有修改这条 ACP 路径。固定等待最早来自 #1113，之前 #10491 追踪的失败也属于同一问题。共享 runner 的负载暴露了既有的测试竞态，并不说明 #9045 引入了 ACP 产品回归。

## Reviewer 测试计划

### 验证方式

使用 OpenAI 形态的本地测试配置运行聚焦的 ACP 集成检查。确认创建 session 后能够收到 `available_commands_update`，通知到达后检查立即继续，并且针对 `init` 命令的现有断言仍然通过。重复运行时，即使通知耗时超过一秒，只要在五秒上限内到达，检查也不应失败。

### 前后证据

改动前：Linux `sandbox:none` 分片在命令更新断言处连续三次以 `AssertionError: expected undefined to be defined` 失败，其中两次事件循环停顿超过固定等待时间。

改动后：`npm run build` 和 `npm run bundle` 通过；聚焦的 ACP 检查在本地连续四次通过；`git diff --check` 和 Prettier 检查也通过。

UI 验证：不适用——本 PR 只修改集成测试同步方式，不影响用户可见行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22.22.0、`QWEN_SANDBOX=false`，认证初始化使用不可路由的本地 OpenAI 形态端点。完整的 Linux CLI 集成测试仅在 `merge_group` 触发；PR 的 no-AK gate 不包含这个 ACP 文件，因此在 Merge Queue 执行前，聚焦的本地测试是这条路径的直接验证。

## 风险与范围

- 主要风险或取舍：如果通知确实缺失，失败时间会由最多一秒变成最多五秒；正常收到通知时会立即继续。
- 未验证或范围外：完整 E2E 矩阵依赖仓库 secrets，因此未在本地运行。本 PR 不修改生产 ACP 行为。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #10491
Fixes #10515

</details>
