### PR TITLE
test(web-shell): mock the provider module main.tsx actually imports in the boot test

### DIFF
--- a/packages/web-shell/client/main-boot.test.tsx
+++ b/packages/web-shell/client/main-boot.test.tsx
@@ -22,7 +22,7 @@ vi.mock('react-dom/client', async (importOriginal) => ({
     },
   },
 }));
-vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+vi.mock('@qwen-code/web-shell/daemon-react-sdk', () => ({
   DaemonWorkspaceProvider: ({ children }: { children: ReactNode }) => children,
 }));
 vi.mock('./components/WorkspaceSessionProvider', () => ({


### PR DESCRIPTION
## What this PR does

`main-boot.test.tsx` mocks `@qwen-code/webui/daemon-react-sdk`, but `main.tsx` has imported `DaemonWorkspaceProvider` from `@qwen-code/web-shell/daemon-react-sdk` since the WebShell UI cutover (#9811), and the `webui` package no longer exports that path. Vitest resolves a `vi.mock` specifier even when nothing imports it, so the suite fails at collection with `Missing "./daemon-react-sdk" specifier in "@qwen-code/webui" package` and both boot tests are red on `main`. This points the mock at the module the boot actually loads.

## Why it's needed

Every PR's `Test (ubuntu)` job runs the web-shell unit suite; with this file failing at collection on `main`, the job cannot go green for anyone once the self-hosted pool gets through it.

## Reviewer Test Plan

### How to verify

`cd packages/web-shell && npx vitest run client/main-boot.test.tsx` — 2 failed on `main` (the missing-specifier error above), 2 passed with this change. Nothing else in the file changes; the mock's shape is unchanged.

### Evidence (Before & After)

N/A (test-only; the vitest output above).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: none — a one-line mock path in a test.
- Not validated / out of scope: nothing else.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #9811 and #10215 (the two commits whose combination left the mock pointing at a removed export).

<details>
<summary>中文说明</summary>

## 本 PR 的改动

`main-boot.test.tsx` mock 的是 `@qwen-code/webui/daemon-react-sdk`，但自 WebShell UI 切换（#9811）起 `main.tsx` 已从 `@qwen-code/web-shell/daemon-react-sdk` 导入 `DaemonWorkspaceProvider`，且 `webui` 包不再导出该路径。Vitest 即使没有模块导入也会解析 `vi.mock` 的说明符，因此该套件在收集阶段就报 `Missing "./daemon-react-sdk" specifier in "@qwen-code/webui" package`，`main` 上两个启动用例全红。本 PR 把 mock 指向启动时真正加载的模块。

## 为什么需要

每个 PR 的 `Test (ubuntu)` job 都跑 web-shell 单测；这个文件在 `main` 上收集即失败，一旦 self-hosted 池跑到它，任何 PR 的该 job 都无法变绿。

## 审查测试计划

### 如何验证

`cd packages/web-shell && npx vitest run client/main-boot.test.tsx`——`main` 上 2 失败（上述缺失说明符错误），本改动后 2 通过。文件中其它内容不变，mock 的形状不变。

### 证据（改动前后）

N/A（仅测试；见上述 vitest 输出）。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

N/A

## 风险与范围

- 主要风险或取舍：无——测试里的一行 mock 路径。
- 未验证 / 不在范围内：无。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#9811 与 #10215 的后续（两者叠加后 mock 指向了已移除的导出）。

</details>
