### PR TITLE
ci: isolate agent workflows on dedicated runners

### DIFF
--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -633,7 +633,7 @@ jobs:
     # Secret-bearing and executes agent-driven code, but the agent runs inside
     # the docker sandbox image and only ever writes a new branch as the
     # Full rationale → qwen-autofix.md#af-008
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name != ''pull_request'' && github.event_name != ''pull_request_review'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name != ''pull_request'' && github.event_name != ''pull_request_review'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-agent"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 180
     # route.issue_number is only set for forced dispatches; label events carry
     # the issue in the payload, and scan-and-pick runs (cron, unforced
@@ -3676,7 +3676,7 @@ jobs:
     # Secret-bearing and executes PR code, but every target is live-gated to
     # write+ (internal) authors at scan AND address time. That is an
     # Full rationale → qwen-autofix.md#af-038
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name != ''pull_request'' && github.event_name != ''pull_request_review'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name != ''pull_request'' && github.event_name != ''pull_request_review'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-agent"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     timeout-minutes: 345
     permissions:
       contents: 'read'

--- a/.github/workflows/qwen-autofix.yml
+++ b/.github/workflows/qwen-autofix.yml
@@ -842,14 +842,14 @@ jobs:
               exit 1
               ;;
           esac
-          # The label routing pins ecs-qwen, but a mis-labelled registration
-          # must not silently claim a PAT-bearing 300-minute job — assert the
-          # pool by name on the self-hosted branch too.
+          # The label routing pins ecs-agent. Existing relabelled hosts retain
+          # ecs-qwen names while future dedicated hosts may use ecs-agent, so
+          # accept both names and reject any other mis-labelled registration.
           if [[ "${RUNNER_ENVIRONMENT}" == 'self-hosted' ]]; then
             case "${RUNNER_NAME}" in
-              ecs-qwen-*) ;;
+              ecs-qwen-*|ecs-agent-*) ;;
               *)
-                echo "::error::self-hosted runner '${RUNNER_NAME}' is not an ecs-qwen pool member; refusing to run here."
+                echo "::error::self-hosted runner '${RUNNER_NAME}' is not an approved agent pool member; refusing to run here."
                 exit 1
                 ;;
             esac
@@ -2114,8 +2114,8 @@ jobs:
     env:
       REPO: '${{ github.repository }}'
       # Per-run home for the scan's API dumps. A fixed autofix* name (not
-      # mktemp's tmp.*) so the age sweep in the heavy jobs can reclaim it
-      # after a hard runner kill; cleaned normally by the always() step.
+      # mktemp's tmp.*) so this job's age sweep can reclaim it after a hard
+      # runner kill; cleaned normally by the always() step.
       # Full rationale → qwen-autofix.md#af-148
       WORKDIR: '/tmp/autofix-scan-${{ github.run_id }}'
     steps:
@@ -2156,6 +2156,9 @@ jobs:
             exit 1
           fi
 
+          # Reclaim hard-killed scan dirs on this persistent ecs-qwen pool;
+          # the agent jobs' sweep now runs on a separate ecs-agent pool.
+          find /tmp -maxdepth 1 -name 'autofix*' -mmin +1440 -exec rm -rf {} + 2>/dev/null || true
           # Pre-clean before create, mirroring the heavy jobs: run_id is
           # public and sequential, and mkdir -p alone would succeed over a
           # dir or symlink pre-planted on the shared pool /tmp — the scan's
@@ -3959,14 +3962,14 @@ jobs:
               exit 1
               ;;
           esac
-          # The label routing pins ecs-qwen, but a mis-labelled registration
-          # must not silently claim a PAT-bearing 345-minute job — assert the
-          # pool by name on the self-hosted branch too.
+          # The label routing pins ecs-agent. Existing relabelled hosts retain
+          # ecs-qwen names while future dedicated hosts may use ecs-agent, so
+          # accept both names and reject any other mis-labelled registration.
           if [[ "${RUNNER_ENVIRONMENT}" == 'self-hosted' ]]; then
             case "${RUNNER_NAME}" in
-              ecs-qwen-*) ;;
+              ecs-qwen-*|ecs-agent-*) ;;
               *)
-                echo "::error::self-hosted runner '${RUNNER_NAME}' is not an ecs-qwen pool member; refusing to run here."
+                echo "::error::self-hosted runner '${RUNNER_NAME}' is not an approved agent pool member; refusing to run here."
                 exit 1
                 ;;
             esac

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -439,7 +439,7 @@ jobs:
     # (default: 360); must stay above QWEN_REVIEW_MAX_TIMEOUT_MINUTES so
     # retry plus posting never hit the cap.
     timeout-minutes: '${{ fromJSON(vars.QWEN_REVIEW_JOB_TIMEOUT_MINUTES) }}'
-    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || fromJSON(''["ubuntu-latest"]'') }}'
+    runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'') && fromJSON(''["self-hosted", "linux", "x64", "ecs-agent"]'') || fromJSON(''["ubuntu-latest"]'') }}'
     permissions:
       contents: 'read'
       pull-requests: 'write'

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -9905,25 +9905,21 @@ exit 1
     );
   });
 
-  it('runs heavy autofix jobs on the ECS pool with hosted fallback', () => {
+  it('isolates agent jobs from builds with hosted fallback', () => {
     const workflowAndSkill = `${workflow}\n${readAutofixSkill()}`;
 
-    // Each heavy job routes to the persistent ECS pool (every target is
-    // live-gated to write+ internal authors and the ECS pool ships docker),
-    // with a hosted fallback for forks of this repo and when ECS routing is
-    // disabled. PR-family events additionally need a same-repo head or a
-    // write+ author — the fleet's ECS routing guard (ci.yml's classify_pr).
-    // Pin the exact expression so neither the repository guard nor the
-    // hosted fallback can be dropped silently.
+    // Agent execution uses the dedicated pool while the trusted-base build
+    // remains on the general ECS pool. Both retain the hosted fallback for
+    // forks and when ECS routing is disabled. Pin the exact expressions so
+    // neither the trust guard nor the fallback can be dropped silently.
     const ecsRunsOn =
       "runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name != ''pull_request'' && github.event_name != ''pull_request_review'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''[\"OWNER\",\"MEMBER\",\"COLLABORATOR\"]''), github.event.pull_request.author_association))) && fromJSON(''[\"self-hosted\", \"linux\", \"x64\", \"ecs-qwen\"]'') || fromJSON(''[\"ubuntu-latest\"]'') }}'";
-    const heavyJobRunsOn = {
-      'issue-autofix': issueAutofixJob,
-      'build-cli': buildCliJob,
-      'review-address': reviewAddressJob,
-    };
-    for (const runsOn of Object.values(heavyJobRunsOn)) {
-      expect(runsOn).toContain(ecsRunsOn);
+    const agentRunsOn = ecsRunsOn.replace('ecs-qwen', 'ecs-agent');
+    expect(buildCliJob).toContain(ecsRunsOn);
+    for (const agentJob of [issueAutofixJob, reviewAddressJob]) {
+      const runsOn = agentJob.match(/runs-on: .*/)?.[0] ?? '';
+      expect(runsOn).toBe(agentRunsOn);
+      expect(runsOn).not.toContain('ecs-qwen');
     }
     // The widened runner-environment guard is what lets ECS-routed runs pass
     // 'Check runner environment' at all — pin the accepted set in both jobs

--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -9963,6 +9963,8 @@ exit 1
       ) ?? [];
     expect(envCheckSteps).toHaveLength(2);
     for (const step of envCheckSteps) {
+      expect(step).toContain('ecs-qwen-*|ecs-agent-*) ;;');
+      expect(step).toContain('not an approved agent pool member');
       expect(step).toContain('docker info');
       expect(step).toContain('exit 1');
     }
@@ -9988,10 +9990,9 @@ exit 1
     expect(routeJob).not.toContain('actions/checkout');
     expect(reviewScanJob).not.toContain('actions/checkout');
     // The scan's per-run WORKDIR must not outlive the run on the pool:
-    // 0700 at creation and an always() cleanup step mirroring the heavy
-    // jobs' teardown. The value pins the autofix* prefix — the contract
-    // with the heavy jobs' age sweep, the only reclaim channel left after
-    // a hard runner kill.
+    // 0700 at creation, an age sweep on the same ecs-qwen pool, and an
+    // always() cleanup step mirroring the heavy jobs' teardown. The value
+    // pins the autofix* prefix used by both cleanup paths.
     expect(reviewScanJob).toContain(
       "WORKDIR: '/tmp/autofix-scan-${{ github.run_id }}'",
     );
@@ -9999,6 +10000,9 @@ exit 1
     // alone would accept a dir or symlink pre-planted on the shared /tmp.
     expect(reviewScanJob).toContain(
       'rm -rf "${WORKDIR}"\n          (umask 077; mkdir -p "${WORKDIR}")',
+    );
+    expect(reviewScanJob).toContain(
+      "find /tmp -maxdepth 1 -name 'autofix*' -mmin +1440 -exec rm -rf {} + 2>/dev/null || true",
     );
     // The fleet file lives inside WORKDIR so the always() step and the age
     // sweep reclaim it when the EXIT trap cannot (cancelled/killed run).

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -39,6 +39,18 @@ const botLogin =
     .jobs['review-config'].steps.find((s) => s.name === 'Set review constants')
     ?.run.match(/bot_login=([A-Za-z0-9-]+)/)?.[1] ?? '';
 
+describe('qwen pr review runner routing', () => {
+  it('isolates the long-running review job on the agent pool', () => {
+    const runsOn = String(parse(workflow).jobs['review-pr']['runs-on']);
+
+    expect(runsOn).toContain('["self-hosted", "linux", "x64", "ecs-agent"]');
+    expect(runsOn).toContain('["ubuntu-latest"]');
+    expect(runsOn).toContain("github.repository == 'QwenLM/qwen-code'");
+    expect(runsOn).toContain("vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true'");
+    expect(runsOn).not.toContain('ecs-qwen');
+  });
+});
+
 function runReviewStep() {
   const doc = parse(workflow);
   const step = doc.jobs['review-pr'].steps.find((s) => s.name === 'Run review');

--- a/scripts/tests/qwen-pr-review-workflow.test.js
+++ b/scripts/tests/qwen-pr-review-workflow.test.js
@@ -43,10 +43,9 @@ describe('qwen pr review runner routing', () => {
   it('isolates the long-running review job on the agent pool', () => {
     const runsOn = String(parse(workflow).jobs['review-pr']['runs-on']);
 
-    expect(runsOn).toContain('["self-hosted", "linux", "x64", "ecs-agent"]');
-    expect(runsOn).toContain('["ubuntu-latest"]');
-    expect(runsOn).toContain("github.repository == 'QwenLM/qwen-code'");
-    expect(runsOn).toContain("vars.MAINTAINER_ECS_RUNNER_DISABLED != 'true'");
+    expect(runsOn).toBe(
+      '${{ (github.repository == \'QwenLM/qwen-code\' && vars.MAINTAINER_ECS_RUNNER_DISABLED != \'true\') && fromJSON(\'["self-hosted", "linux", "x64", "ecs-agent"]\') || fromJSON(\'["ubuntu-latest"]\') }}',
+    );
     expect(runsOn).not.toContain('ecs-qwen');
   });
 });


### PR DESCRIPTION
## What this PR does

Routes the long-running PR review and Autofix agent execution jobs to a dedicated `ecs-agent` self-hosted runner pool. Lightweight routing jobs and the trusted-base CLI build remain on the general `ecs-qwen` pool, and all changed jobs preserve their existing hosted-runner fallback and trust guards.

A post-merge rollout is planned for 50 runners distributed across three pools: 10 selected from `ecs-qwen-runner-sg-1` through `ecs-qwen-runner-sg-25`, 25 HK runners split across both HK machine groups, and 15 `64c` runners. Until this PR merges, all planned runners remain on `ecs-qwen` and no runner carries `ecs-agent`. After merge, the selected runners will switch from `ecs-qwen` to `ecs-agent`; the planned set excludes every `ecs-update-*` runner and `sg-26` through `sg-40`.

## Why it's needed

Review and Autofix agent jobs can run for several hours. Sharing the same label as ordinary CI lets a burst of agent work consume the whole general pool, delaying normal checks and making the runner fleet appear stuck. Separate labels reserve capacity for each workload without changing the workflow trigger or authorization behavior.

## Reviewer Test Plan

### How to verify

Confirm that the long-running PR review job and both Autofix agent execution jobs select `self-hosted`, `linux`, `x64`, and `ecs-agent` for trusted repository runs. Confirm that lightweight routing and build jobs still select `ecs-qwen` and untrusted or disabled ECS paths still fall back to `ubuntu-latest`. Before merge, confirm that no runner carries `ecs-agent`; after merge, switch the planned 50 runners from `ecs-qwen` to `ecs-agent` and verify that the two labels do not overlap.

Workflow YAML parsing succeeded. The PR review workflow test suite passed with 181 tests (1 skipped), the two dedicated-pool routing regression tests passed, and all changed files passed Prettier and `git diff --check`.

### Evidence (Before & After)

N/A — CI routing only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js v22.22.0 with the repository's existing dependencies.

## Risk & Scope

- Main risk or tradeoff: Agent jobs may queue briefly after merge until the planned runner labels are applied; afterward they will queue only if all 50 dedicated runners are occupied, while ordinary CI capacity remains isolated.
- Not validated / out of scope: Changes to concurrency policy, stale-run cancellation, or automatic runner provisioning and autoscaling.
- Breaking changes / migration notes: The post-merge runner relabel is required; the hosted fallback remains available through the existing repository switch.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将长耗时的 PR review 和 Autofix agent 执行任务路由到专用的 `ecs-agent` 自托管 runner 池。轻量路由任务和可信 base 的 CLI 构建继续使用通用 `ecs-qwen` 池；所有修改过的任务都保留原有的托管 runner fallback 和信任校验。

合并后计划切换 50 台 runner，并分散在三个机器池：10 台从 `ecs-qwen-runner-sg-1` 至 `ecs-qwen-runner-sg-25` 中选取，25 台来自两组 HK 机器，15 台来自 `64c` 机器。在本 PR 合并前，计划中的机器全部保留 `ecs-qwen`，仓库中没有任何 runner 带 `ecs-agent`。合并后，再将这些机器从 `ecs-qwen` 切换到 `ecs-agent`；计划清单不包含任何 `ecs-update-*` runner，也不包含 `sg-26` 至 `sg-40`。

## 为什么需要

Review 和 Autofix agent 任务可能持续数小时。它们与普通 CI 共用标签时，一批 agent 任务可能占满通用池，拖延正常检查，并让 runner 集群看起来像是卡住。分离标签后，两类负载各自保留容量，同时不改变工作流触发和授权行为。

## Reviewer 测试计划

### 如何验证

确认长耗时的 PR review 任务和两个 Autofix agent 执行任务在可信仓库运行时选择 `self-hosted`、`linux`、`x64` 和 `ecs-agent`。确认轻量路由与构建任务继续选择 `ecs-qwen`，不可信或 ECS 被禁用时仍回退到 `ubuntu-latest`。合并前确认没有 runner 带 `ecs-agent`；合并后，将计划中的 50 台从 `ecs-qwen` 切换到 `ecs-agent`，并确认两个标签没有重叠。

工作流 YAML 解析成功。PR review 工作流测试套件通过 181 个测试（1 个跳过），两条专用池路由回归测试通过，所有修改文件均通过 Prettier 和 `git diff --check`。

### 证据（前后对比）

不适用——仅 CI 路由变更。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js v22.22.0，复用仓库现有依赖。

## 风险与范围

- 主要风险或权衡：PR 合并后到 runner 标签配置完成前，agent 任务可能短暂排队；配置完成后，只有 50 台专用 runner 全部被占用时才会排队，同时普通 CI 容量保持隔离。
- 未验证 / 范围外：并发策略、旧任务自动取消、runner 自动供应或弹性伸缩。
- 破坏性变更 / 迁移说明：PR 合并后必须执行 runner 标签切换；现有仓库开关仍可切换到托管 runner fallback。

## 关联 Issue

不适用

</details>
