### PR TITLE
ci: update qwen on third Hong Kong ECS host

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,5 +4,8 @@ self-hosted-runner:
     - 'ecs-win'
     - 'ecs-update-sg'
     - 'ecs-update-64c'
+    - 'ecs-update-hk-1'
+    - 'ecs-update-hk-2'
+    - 'ecs-update-hk-3'
 
 config-variables: null

--- a/.github/scripts/web-shell-visuals-publish.test.mjs
+++ b/.github/scripts/web-shell-visuals-publish.test.mjs
@@ -230,6 +230,7 @@ function runHostingBlockIn(
   mkdirSync(runnerTemp, { recursive: true });
   mkdirSync(stage, { recursive: true });
   mkdirSync(join(work, 'scripts'), { recursive: true });
+  writeFileSync(join(work, 'package.json'), '{"type":"module"}\n');
   // The block installs its job-private ossutil copy from here; the stub
   // uploader never executes it, but the install must succeed.
   writeFileSync(join(runnerTemp, 'ossutil'), 'fake ossutil\n');
@@ -240,9 +241,8 @@ function runHostingBlockIn(
   writeFileSync(
     join(work, 'scripts', 'upload-aliyun-oss-assets.js'),
     [
-      "'use strict';",
-      "const { copyFileSync, mkdirSync, writeFileSync } = require('node:fs');",
-      "const { basename, join } = require('node:path');",
+      "import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs';",
+      "import { basename, join } from 'node:path';",
       "if (process.env.OSS_STUB_FAIL === '1') process.exit(1);",
       "const opts = { bucket: '', config: '', prefix: '' };",
       'const assets = [];',

--- a/.github/workflows/update-ecs-runner-qwen.yml
+++ b/.github/workflows/update-ecs-runner-qwen.yml
@@ -75,7 +75,7 @@ jobs:
     if: "${{ github.repository == 'QwenLM/qwen-code' }}"
     strategy:
       matrix:
-        runner: ['ecs-update-sg', 'ecs-update-64c', 'ecs-update-hk-1', 'ecs-update-hk-2']
+        runner: ['ecs-update-sg', 'ecs-update-64c', 'ecs-update-hk-1', 'ecs-update-hk-2', 'ecs-update-hk-3']
       fail-fast: false
     runs-on: ['self-hosted', 'linux', 'x64', '${{ matrix.runner }}']
     concurrency:

--- a/packages/web-shell/client/main-boot.test.tsx
+++ b/packages/web-shell/client/main-boot.test.tsx
@@ -22,7 +22,7 @@ vi.mock('react-dom/client', async (importOriginal) => ({
     },
   },
 }));
-vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+vi.mock('@qwen-code/web-shell/daemon-react-sdk', () => ({
   DaemonWorkspaceProvider: ({ children }: { children: ReactNode }) => children,
 }));
 vi.mock('./components/WorkspaceSessionProvider', () => ({


### PR DESCRIPTION
## What this PR does

Adds the third Hong Kong ECS host to the Qwen fleet updater. One dedicated runner on that host carries the `ecs-update-hk-3` label; the update job installs the resolved release into the shared system Qwen location used by all 20 runner services on the host.

## Why it's needed

The new host is already serving production `ecs-qwen` jobs, but the release updater currently targets only the Singapore, 64c, and first two Hong Kong host labels. Without this matrix entry, future npm releases would leave the new host on its provisioned Qwen version.

## Reviewer Test Plan

### How to verify

Confirm that the updater matrix includes `ecs-update-hk-3`, and that exactly one online runner on the new Hong Kong host has this label. On the next release or manual dispatch, the matrix should schedule one update job on that host and verify the shared `qwen` version.

### Evidence (Before & After)

Before: the new host's 20 production runners were online, but none could be selected by the updater matrix.

After: `ecs-qwen-runner-hk-j6cdqefjt78v0s9jngns-1` carries `ecs-update-hk-3`, and the workflow matrix targets that label.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

YAML parsing and `git diff --check` passed. GitHub reports all 20 runners on the host online.

## Risk & Scope

- Main risk or tradeoff: the updater gains one additional matrix job per release.
- Not validated / out of scope: a release was not published solely for this infrastructure check.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将第三台香港 ECS 宿主机加入 Qwen 集群更新任务。该宿主机上只有一个专用 runner 携带 `ecs-update-hk-3` 标签；更新任务会把已解析的发布版本安装到系统级共享 Qwen 路径，宿主机上的 20 个 runner 服务都会使用该版本。

## 为什么需要

新宿主机已经承接正式的 `ecs-qwen` 任务，但发布更新器目前只覆盖新加坡、64c 和前两台香港宿主机标签。缺少本 matrix 项时，后续 npm 发布不会更新这台新宿主机。

## Reviewer Test Plan

### 如何验证

确认 updater matrix 包含 `ecs-update-hk-3`，且新香港宿主机上恰好一个在线 runner 带有该标签。下次发布或手动 dispatch 时，应有一个 matrix 更新任务落到该宿主机并校验共享 `qwen` 版本。

### 前后证据

修改前：新宿主机的 20 个生产 runner 均在线，但 updater matrix 无法选中该宿主机。

修改后：`ecs-qwen-runner-hk-j6cdqefjt78v0s9jngns-1` 已带 `ecs-update-hk-3`，workflow matrix 也已包含该标签。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | N/A  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ✅  |

### 环境

YAML 解析和 `git diff --check` 均通过；GitHub 显示该宿主机的 20 个 runner 全部在线。

## 风险与范围

- 主要风险或权衡：每次发布增加一个 updater matrix job。
- 未验证或超出范围：没有为了本次基础设施检查单独发布版本。
- 破坏性变更或迁移说明：无。

## 关联 Issue

N/A

</details>