### PR TITLE
test(web-shell): fix daemon SDK mock path

### DIFF
--- a/packages/web-shell/client/main-boot.test.tsx
+++ b/packages/web-shell/client/main-boot.test.tsx
@@ -22,7 +22,7 @@ vi.mock('react-dom/client', async (importOriginal) => ({
     },
   },
 }));
-vi.mock('@qwen-code/webui/daemon-react-sdk', () => ({
+vi.mock('@qwen-code/web-shell/daemon-react-sdk', () => ({
   DaemonWorkspaceProvider: ({ children }: { children: ReactNode }) => children,
 }));
 vi.mock('./components/WorkspaceSessionProvider', () => ({


### PR DESCRIPTION
## What this PR does

Updates the Web Shell boot regression test to mock the daemon React SDK from its current package entrypoint.

## Why it's needed

The daemon React SDK moved out of the legacy Web UI package, but this test kept the old mock target. Vitest now rejects that removed package subpath before the two boot tests can run, which breaks the Ubuntu CI job on `main`.

## Reviewer Test Plan

### How to verify

Run the focused Web Shell boot regression test and confirm both boot scenarios pass without the `Missing "./daemon-react-sdk" specifier` error.

### Evidence (Before & After)

Before: the Web Shell suite reports one unhandled module-resolution error and skips the two boot tests.

After: the focused boot regression test passes both tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`npx vitest run client/main-boot.test.tsx --config vitest.config.ts` — 1 test file passed, 2 tests passed. Repository lint also passed.

## Risk & Scope

- Main risk or tradeoff: Minimal; this only corrects a stale test mock target.
- Not validated / out of scope: Full Web Shell E2E and full repository test suites were not run locally.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 Web Shell 启动回归测试中的 daemon React SDK mock 更新为当前实际使用的 package entrypoint。

## 为什么需要

daemon React SDK 已从旧的 Web UI package 迁出，但该测试仍保留旧的 mock 目标。Vitest 会在两个启动测试执行前拒绝这个已移除的 package 子路径，导致 `main` 上的 Ubuntu CI 失败。

## Reviewer Test Plan

### 如何验证

运行 Web Shell 启动回归定向测试，确认两个启动场景都通过，且不再出现 `Missing "./daemon-react-sdk" specifier` 错误。

### 证据（修改前后）

修改前：Web Shell 测试报告一个未处理的模块解析错误，两个启动测试未执行。

修改后：启动回归定向测试的两个测试均通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

`npx vitest run client/main-boot.test.tsx --config vitest.config.ts` — 1 个测试文件通过，2 个测试通过。仓库 lint 也已通过。

## 风险与范围

- 主要风险或取舍：很小；这里只修正了过期的测试 mock 目标。
- 未验证 / 范围外：本地未运行完整 Web Shell E2E 和完整仓库测试套件。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

无

</details>
