### PR TITLE
test(ci): isolate visuals publisher fixtures from parent package scopes

### DIFF
--- a/.github/scripts/web-shell-visuals-publish.test.mjs
+++ b/.github/scripts/web-shell-visuals-publish.test.mjs
@@ -202,7 +202,10 @@ function runHostingBlock(
     runAttempt = '1',
   } = {},
 ) {
-  const dir = mkdtempSync(join(tmpdir(), 'visuals-hosting-'));
+  const scopeRoot = mkdtempSync(join(tmpdir(), 'visuals-hosting-scope-'));
+  const dir = join(scopeRoot, 'fixture');
+  writeFileSync(join(scopeRoot, 'package.json'), '{"type":"commonjs"}\n');
+  mkdirSync(dir);
   try {
     return runHostingBlockIn(dir, hasImages, {
       publicBaseUrl,
@@ -213,7 +216,7 @@ function runHostingBlock(
   } finally {
     // The fixture used to leak a mkdtemp dir per call; capture everything
     // the assertions need inside, then tear it down.
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(scopeRoot, { recursive: true, force: true });
   }
 }
 

--- a/.github/scripts/web-shell-visuals-publish.test.mjs
+++ b/.github/scripts/web-shell-visuals-publish.test.mjs
@@ -230,6 +230,7 @@ function runHostingBlockIn(
   mkdirSync(runnerTemp, { recursive: true });
   mkdirSync(stage, { recursive: true });
   mkdirSync(join(work, 'scripts'), { recursive: true });
+  writeFileSync(join(work, 'package.json'), '{"type":"module"}\n');
   // The block installs its job-private ossutil copy from here; the stub
   // uploader never executes it, but the install must succeed.
   writeFileSync(join(runnerTemp, 'ossutil'), 'fake ossutil\n');
@@ -240,9 +241,8 @@ function runHostingBlockIn(
   writeFileSync(
     join(work, 'scripts', 'upload-aliyun-oss-assets.js'),
     [
-      "'use strict';",
-      "const { copyFileSync, mkdirSync, writeFileSync } = require('node:fs');",
-      "const { basename, join } = require('node:path');",
+      "import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs';",
+      "import { basename, join } from 'node:path';",
       "if (process.env.OSS_STUB_FAIL === '1') process.exit(1);",
       "const opts = { bucket: '', config: '', prefix: '' };",
       'const assets = [];',


### PR DESCRIPTION
## What this PR does

Makes the web-shell visual publisher test harness define its own ESM package boundary and use an ESM uploader stub. The harness now runs inside a deliberately conflicting CommonJS parent scope, so package-scope leakage is covered deterministically.

## Why it's needed

The second CI attempt for #10394 failed four helper tests because the temporary fixture inherited `/tmp/package.json` from the self-hosted runner. Node treated the fixture's CommonJS `.js` stub as ESM and rejected `require`. Temporary test fixtures must not depend on package metadata outside their own directory tree.

## Reviewer Test Plan

### How to verify

Run `node --test .github/scripts/web-shell-visuals-publish.test.mjs`. All 34 tests should pass, including the hosting-block cases under the conflicting parent package scope.

### Evidence (Before & After)

N/A — test-only change. Before the fix, the affected CI attempt failed four hosting-block cases with `ReferenceError: require is not defined in ES module scope`; after the fix, the focused suite passes 34/34.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  | CI pending |

### Environment (optional)

Node.js 22.

## Risk & Scope

- Main risk or tradeoff: The test stub now matches the production uploader's ESM module format instead of using CommonJS.
- Not validated / out of scope: Full repository test suite; the focused helper suite and formatting check passed locally.
- Breaking changes / migration notes: None. Test-only change.

## Linked Issues

Follow-up to #10394.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 Web Shell 视觉发布测试夹具显式定义自己的 ESM package 边界，并使用 ESM uploader stub。夹具现在会运行在一个故意冲突的 CommonJS 父级 scope 下，因此 package scope 泄漏会被稳定覆盖。

## 为什么需要

#10394 的第二次 CI 尝试中有四个 helper 测试失败，原因是临时夹具继承了自托管 runner 的 `/tmp/package.json`。Node 将夹具中的 CommonJS `.js` stub 识别为 ESM，导致 `require` 报错。临时测试夹具不应依赖自身目录树以外的 package 元数据。

## Reviewer 测试计划

### 如何验证

运行 `node --test .github/scripts/web-shell-visuals-publish.test.mjs`。包括冲突父级 package scope 场景在内的 34 个测试应全部通过。

### Before & After 证据

不适用——仅测试改动。修复前，对应 CI 尝试中的四个 hosting-block 用例报错 `ReferenceError: require is not defined in ES module scope`；修复后，聚焦测试 34/34 通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | CI 待验证 |

### 环境

Node.js 22。

## 风险与范围

- 主要风险或取舍：测试 stub 现在与生产 uploader 一样使用 ESM，而不是 CommonJS。
- 未验证或范围外：未运行仓库全量测试；本地聚焦 helper 测试和格式检查已通过。
- 破坏性变更或迁移说明：无。仅测试改动。

## 关联问题

#10394 的后续修复。

</details>
