### PR TITLE
test(cli): stabilize session deadline boundary test

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -2372,7 +2372,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     ['non-positive', () => 0],
     ['non-integer', () => Date.now() + 0.5],
     ['non-safe', () => Number.MAX_SAFE_INTEGER + 1],
-    ['beyond the timer range', () => Date.now() + 2_147_483_648],
+    ['beyond the timer range', () => Number.MAX_SAFE_INTEGER],
   ])(
     'rejects a %s trusted session initialization deadline before creating state',
     async (_label, deadline) => {


### PR DESCRIPTION
## What this PR does

This replaces the near-boundary timer-range test input with a positive safe integer that remains deterministically beyond Node.js's supported timer delay range. The assertion and production behavior are unchanged.

## Why it's needed

The regression test added in #10268 constructed a deadline only 1 ms beyond the maximum supported timer delay. Normal execution time between constructing and validating that value could consume the 1 ms margin, making the value valid and allowing session initialization to resolve. This caused the intermittent main CI failure tracked in #10555.

## Reviewer Test Plan

### How to verify

Run the timer-range deadline case repeatedly and confirm it always rejects with `invalid_session_initialization_deadline` before session state is created. Then run the complete ACP agent test file and confirm all cases pass.

### Evidence (Before & After)

Before: the focused case passed twice and then reproduced the main CI failure on the third run by resolving instead of rejecting. After: the focused case passed 3/3 runs, and the complete test file passed 535/535 cases.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.0 and Vitest 3.2.7 on macOS. Repository prepare/build, focused tests, the complete ACP agent test file, ESLint, Prettier, and diff checks passed locally.

## Risk & Scope

- Main risk or tradeoff: test-only change; the replacement remains a safe integer while providing a stable margin above the supported timer range.
- Not validated / out of scope: Windows and Linux were not run locally; GitHub Actions will provide those platform results.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #10555

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将接近边界的 timer range 测试输入替换为一个正的安全整数，并确保它始终明显超出 Node.js 支持的 timer delay 范围。断言和生产行为都没有变化。

## 为什么需要

#10268 中新增的回归测试构造了一个只比最大支持 timer delay 多 1 ms 的 deadline。从构造到校验之间的正常执行时间可能消耗这 1 ms 余量，使该值重新变为合法值，并让 session 初始化成功返回。这导致了 #10555 记录的 main CI 间歇性失败。

## Reviewer Test Plan

### 如何验证

重复运行 timer range deadline 用例，确认它始终在创建 session state 前以 `invalid_session_initialization_deadline` 拒绝。然后运行完整 ACP agent 测试文件，确认所有用例通过。

### 证据（修改前后）

修改前：聚焦用例前两次通过，第三次复现 main CI，表现为 promise 成功返回而不是拒绝。修改后：聚焦用例连续 3/3 次通过，完整测试文件 535/535 个用例通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 上使用 Node.js 22.22.0 和 Vitest 3.2.7。本地已通过仓库 prepare/build、聚焦测试、完整 ACP agent 测试文件、ESLint、Prettier 和 diff 检查。

## 风险与范围

- 主要风险或权衡：仅修改测试；替换值仍是安全整数，同时在支持的 timer range 之上保留稳定余量。
- 未验证 / 范围外：没有在本地运行 Windows 和 Linux；这些平台结果由 GitHub Actions 提供。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10555

</details>
