### PR TITLE
ci: allow full test jobs to finish on ECS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
     # unit tests.
     if: "${{ !cancelled() && github.event_name != 'schedule' }}"
     runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
-    timeout-minutes: 90
+    timeout-minutes: 120
     outputs:
       ci_profile: '${{ steps.ci_profile.outputs.ci_profile }}'
     permissions:
@@ -591,7 +591,7 @@ jobs:
       - name: 'Install tmux and zip tooling'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && runner.os == 'Linux' }}"
         # Bounded AND advisory: a stalled mirror or dpkg lock must neither
-        # hang the job toward its 90-minute cap nor red the required check —
+        # hang the job toward its 120-minute cap nor red the required check —
         # continue-on-error absorbs the step-level timeout. The apt calls
         # carry their OWN shorter bound (140 s + 140 s = 280 s < the 300 s
         # step cap) so the guard below still runs: when the step-level

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
     # unit tests.
     if: "${{ !cancelled() && github.event_name != 'schedule' }}"
     runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
-    timeout-minutes: 60
+    timeout-minutes: 90
     outputs:
       ci_profile: '${{ steps.ci_profile.outputs.ci_profile }}'
     permissions:
@@ -591,7 +591,7 @@ jobs:
       - name: 'Install tmux and zip tooling'
         if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && runner.os == 'Linux' }}"
         # Bounded AND advisory: a stalled mirror or dpkg lock must neither
-        # hang the job toward its 60-minute cap nor red the required check —
+        # hang the job toward its 90-minute cap nor red the required check —
         # continue-on-error absorbs the step-level timeout. The apt calls
         # carry their OWN shorter bound (140 s + 140 s = 280 s < the 300 s
         # step cap) so the guard below still runs: when the step-level


### PR DESCRIPTION
## What this PR does

Extends the full CI test job timeout from 60 to 120 minutes so slower ECS runners can finish the existing lint, build, and unit-test workload.

## Why it's needed

The post-merge CI investigation for #10541 produced runs where the required Ubuntu job exhausted both 60-minute and 90-minute budgets. In the latest run, helper tests passed and Vitest was still continuously executing `packages/web-shell/client/App.test.tsx` when GitHub canceled the job at exactly 90 minutes. The log showed no assertion failure, stalled test, disk pressure, or memory pressure; dependency installation and the serial workspace suite simply took longer on the selected ECS runner.

## Reviewer Test Plan

### How to verify

Confirm that the full test job has a 120-minute timeout and that the bounded advisory tooling step still has its independent 5-minute timeout. The new PR run should proceed past the previous 60- and 90-minute cutoffs and finish the unit-test step.

### Evidence (Before & After)

Before: [Qwen Code CI run 33300361843](https://github.com/QwenLM/qwen-code/actions/runs/33300361843) was canceled at the 60-minute job limit while Vitest was still reporting passing test files. [Qwen Code CI run 33307459607](https://github.com/QwenLM/qwen-code/actions/runs/33307459607) reproduced the same behavior at 90 minutes while the web-shell suite was still progressing.

After: the full test job has a 120-minute budget. N/A for UI evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ `actionlint .github/workflows/ci.yml` |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ pending this PR's CI run |

### Environment (optional)

Local workflow validation with actionlint 1.7.7.

## Risk & Scope

- Main risk or tradeoff: a genuinely stuck full test job can now occupy a runner for up to 60 additional minutes compared with the original limit.
- Not validated / out of scope: changing test parallelism or ECS runner performance.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #10541.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把完整 CI 测试 job 的超时时间从 60 分钟延长到 120 分钟，让较慢的 ECS runner 能完成现有的 lint、构建和单元测试工作负载。

## 为什么需要

对 #10541 合并后 CI 的排查发现，必需的 Ubuntu job 先后耗尽了 60 分钟和 90 分钟预算。在最新一次运行中，helper tests 已通过，Vitest 仍在持续执行 `packages/web-shell/client/App.test.tsx` 时，GitHub 在整 90 分钟处取消了 job。日志里没有断言失败、卡死测试、磁盘压力或内存压力；只是依赖安装和串行 workspace 测试套件在所选 ECS runner 上耗时更长。

## Reviewer Test Plan

### 如何验证

确认完整测试 job 的超时时间为 120 分钟，同时有界的 advisory 工具安装步骤仍保留独立的 5 分钟超时。新 PR 的运行应跨过之前的 60 分钟和 90 分钟截止点并完成单元测试步骤。

### 证据（修改前后）

修改前：[Qwen Code CI run 33300361843](https://github.com/QwenLM/qwen-code/actions/runs/33300361843) 在达到 60 分钟 job 上限时被取消，当时 Vitest 仍在持续报告通过的测试文件。[Qwen Code CI run 33307459607](https://github.com/QwenLM/qwen-code/actions/runs/33307459607) 在 90 分钟处复现了相同行为，当时 web-shell 测试套件仍在推进。

修改后：完整测试 job 获得 120 分钟预算。UI 证据不适用。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ `actionlint .github/workflows/ci.yml` |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ 等待这个 PR 的 CI 运行 |

### 环境（可选）

本地使用 actionlint 1.7.7 校验 workflow。

## 风险与范围

- 主要风险或权衡：与原始上限相比，真正卡死的完整测试 job 最多会额外占用 runner 60 分钟。
- 未验证 / 范围外：调整测试并行度或 ECS runner 性能。
- 破坏性变更 / 迁移说明：无。

## 关联问题

#10541 的后续修复。

</details>
