### PR TITLE
ci: serialize E2E tests on shared ECS runners

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -216,8 +216,9 @@ jobs:
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
           KEEP_OUTPUT: 'true'
           VERBOSE: 'true'
-          # Mapped for integration-tests/vitest.config.ts, which exempts
-          # self-hosted runners from pressure-flake unhandled errors.
+          # Mapped for integration-tests/vitest.config.ts, which caps each
+          # shared-pool shard at one fork and exempts pressure-flake unhandled
+          # errors.
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: |-
           export TMPDIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"

--- a/integration-tests/vitest.config.ts
+++ b/integration-tests/vitest.config.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const timeoutMinutes = Number(process.env['TB_TIMEOUT_MINUTES'] || '5');
 const testTimeoutMs = timeoutMinutes * 60 * 1000;
+const isSelfHostedRunner = process.env['RUNNER_ENVIRONMENT'] === 'self-hosted';
 
 export default defineConfig({
   test: {
@@ -30,8 +31,11 @@ export default defineConfig({
     pool: 'forks',
     poolOptions: {
       forks: {
-        minForks: 2,
-        maxForks: 4,
+        // Each ECS host runs several Actions runners. Keep every E2E shard to
+        // one child process there so concurrent jobs cannot multiply the host
+        // load and starve latency-sensitive integration paths.
+        minForks: isSelfHostedRunner ? 1 : 2,
+        maxForks: isSelfHostedRunner ? 1 : 4,
       },
     },
     // The worker->main `onTaskUpdate` RPC runs on a 60s budget; under
@@ -44,8 +48,7 @@ export default defineConfig({
     // the run; only unhandled errors stop being fatal — github-hosted Linux
     // (the nightly isolated legs) and local Linux runs keep the signal.
     dangerouslyIgnoreUnhandledErrors:
-      process.platform !== 'linux' ||
-      process.env['RUNNER_ENVIRONMENT'] === 'self-hosted',
+      process.platform !== 'linux' || isSelfHostedRunner,
   },
   resolve: {
     alias: {

--- a/scripts/tests/integration-vitest-config.test.ts
+++ b/scripts/tests/integration-vitest-config.test.ts
@@ -5,46 +5,56 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import integrationConfig from '../../integration-tests/vitest.config.js';
+
+const savedRunnerEnvironment = process.env['RUNNER_ENVIRONMENT'];
+
+afterEach(() => {
+  if (savedRunnerEnvironment === undefined) {
+    delete process.env['RUNNER_ENVIRONMENT'];
+  } else {
+    process.env['RUNNER_ENVIRONMENT'] = savedRunnerEnvironment;
+  }
+  vi.resetModules();
+});
+
+// The settings read RUNNER_ENVIRONMENT at config import time, so each case
+// re-imports the config under a controlled value instead of trusting the
+// ambient one.
+async function configFor(runnerEnvironment: string | undefined) {
+  vi.resetModules();
+  if (runnerEnvironment === undefined) {
+    delete process.env['RUNNER_ENVIRONMENT'];
+  } else {
+    process.env['RUNNER_ENVIRONMENT'] = runnerEnvironment;
+  }
+  const { default: config } = await import(
+    '../../integration-tests/vitest.config.js'
+  );
+  return config;
+}
 
 describe('integration Vitest config', () => {
-  it('limits the forks pool used by integration tests', () => {
-    expect(integrationConfig.test?.pool).toBe('forks');
-    expect(integrationConfig.test?.poolOptions?.forks).toEqual({
-      minForks: 2,
-      maxForks: 4,
+  it('serializes test files on shared self-hosted runners', async () => {
+    const config = await configFor('self-hosted');
+    expect(config.test?.pool).toBe('forks');
+    expect(config.test?.poolOptions?.forks).toEqual({
+      minForks: 1,
+      maxForks: 1,
     });
-    expect(integrationConfig.test?.poolOptions?.threads).toBeUndefined();
+    expect(config.test?.poolOptions?.threads).toBeUndefined();
+  });
+
+  it('keeps the existing fork limits outside the shared pool', async () => {
+    for (const environment of ['github-hosted', undefined]) {
+      const config = await configFor(environment);
+      expect(config.test?.poolOptions?.forks).toEqual({
+        minForks: 2,
+        maxForks: 4,
+      });
+    }
   });
 
   describe('unhandled-error exemption', () => {
-    const savedRunnerEnvironment = process.env['RUNNER_ENVIRONMENT'];
-
-    afterEach(() => {
-      if (savedRunnerEnvironment === undefined) {
-        delete process.env['RUNNER_ENVIRONMENT'];
-      } else {
-        process.env['RUNNER_ENVIRONMENT'] = savedRunnerEnvironment;
-      }
-      vi.resetModules();
-    });
-
-    // The flag reads RUNNER_ENVIRONMENT at config import time, so each case
-    // re-imports the config under a controlled value instead of trusting the
-    // ambient one.
-    async function configFor(runnerEnvironment: string | undefined) {
-      vi.resetModules();
-      if (runnerEnvironment === undefined) {
-        delete process.env['RUNNER_ENVIRONMENT'];
-      } else {
-        process.env['RUNNER_ENVIRONMENT'] = runnerEnvironment;
-      }
-      const { default: config } = await import(
-        '../../integration-tests/vitest.config.js'
-      );
-      return config;
-    }
-
     it('exempts self-hosted pool runners on every platform', async () => {
       // Dropping the self-hosted clause makes the shared pool's pressure
       // flakes exit all-green E2E runs red again (#10325).


### PR DESCRIPTION
## What this PR does

This change limits each integration-test shard to one Vitest fork when it runs on the shared self-hosted ECS pool. GitHub-hosted and local runs keep the existing two-to-four-fork range. A focused regression test pins both environments so later configuration changes cannot silently restore the shared-host oversubscription.

## Why it's needed

PR #9992 added an ACP auto-memory E2E assertion that the deterministic local-memory match reaches the first model request within the production 100 ms initial-recall budget. On the ECS pool, several Actions runners share one physical host and every E2E shard could additionally launch up to four Vitest child processes. Under that multiplied CPU and I/O pressure, the deterministic scan can lose its bounded wait even though the feature and the same test normally pass.

The failure in [run 33317457036](https://github.com/QwenLM/qwen-code/actions/runs/33317457036) is the same missing `ACP-MEMORY-ZEPHYR-4207` marker observed in [run 33279084999](https://github.com/QwenLM/qwen-code/actions/runs/33279084999). The earlier run predates PR #10552, so #10552 did not introduce this ACP failure. This is a shared-runner scheduling problem exposed by #9992's latency-sensitive coverage.

Serializing files inside each self-hosted shard removes the extra per-job process multiplier without changing application code, weakening the 100 ms production contract, or moving the job back to GitHub-hosted runners.

## Reviewer Test Plan

### How to verify

Load the integration-test configuration with `RUNNER_ENVIRONMENT=self-hosted` and confirm the forks pool is limited to exactly one worker. Load it with `RUNNER_ENVIRONMENT=github-hosted` or unset and confirm the existing two-to-four-worker range remains. In the E2E workflow, confirm the runner environment is passed to both sandbox command paths.

Focused verification completed locally: the configuration regression suite passed all 4 tests; ESLint, Prettier, and `git diff --check` also passed.

### Evidence (Before & After)

N/A — CI test-runner configuration only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local focused configuration test with the repository's pinned Vitest toolchain.

## Risk & Scope

- Main risk or tradeoff: self-hosted E2E shards trade some wall-clock speed for predictable resource use; three-way sharding and the existing 60-minute job limit remain unchanged.
- Not validated / out of scope: the full secret-backed E2E matrix can only run in GitHub Actions; application memory behavior and the production recall budget are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10566

Related failure: #10533

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

在共享的自托管 ECS 池上运行时，将每个集成测试 shard 限制为一个 Vitest fork。GitHub-hosted 和本地运行继续保持现有的 2–4 个 fork。新增聚焦回归测试固定这两种环境的行为，避免后续配置修改无意中恢复共享主机上的过度并发。

## 为什么需要

PR #9992 新增了 ACP 自动记忆 E2E 断言，要求确定性的本地记忆匹配在生产的 100 ms 初始召回预算内进入第一次模型请求。ECS 池中多个 Actions runner 共享同一台物理主机，而每个 E2E shard 还可以再启动最多 4 个 Vitest 子进程。CPU 和 I/O 压力被成倍放大后，即使功能和同一测试通常可以通过，确定性扫描也可能错过这个有上限的等待时间。

[run 33317457036](https://github.com/QwenLM/qwen-code/actions/runs/33317457036) 的失败与 [run 33279084999](https://github.com/QwenLM/qwen-code/actions/runs/33279084999) 中缺少 `ACP-MEMORY-ZEPHYR-4207` 标记的失败完全相同。较早的 run 发生在 PR #10552 之前，因此 #10552 并未引入本次 ACP 失败。这是 #9992 的延迟敏感覆盖暴露出的共享 runner 调度问题。

在每个自托管 shard 内串行运行测试文件，可以移除每个 job 额外放大的进程并发，同时不修改应用代码、不放宽生产的 100 ms 契约，也不把任务切回 GitHub-hosted runner。

## Reviewer 测试计划

### 如何验证

使用 `RUNNER_ENVIRONMENT=self-hosted` 加载集成测试配置，确认 forks pool 被严格限制为 1 个 worker。使用 `RUNNER_ENVIRONMENT=github-hosted` 或不设置该变量时，确认继续保持现有的 2–4 个 worker。在 E2E workflow 中确认 runner 环境变量会传递给两条 sandbox 命令路径。

本地聚焦验证已完成：配置回归测试 4 个全部通过；ESLint、Prettier 和 `git diff --check` 也全部通过。

### 证据（修改前后）

N/A — 仅修改 CI 测试 runner 配置。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

使用仓库锁定的 Vitest 工具链在本地运行聚焦配置测试。

## 风险与范围

- 主要风险或权衡：自托管 E2E shard 以部分运行时长换取可预测的资源使用；三路分片和现有 60 分钟 job 上限保持不变。
- 未验证 / 范围外：完整的密钥依赖 E2E matrix 只能在 GitHub Actions 中运行；应用记忆行为和生产召回预算均未修改。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10566

相关失败：#10533

</details>
