### PR TITLE
docs(serve): Document tool PATH for managed daemons

### DIFF
--- a/docs/users/qwen-serve-deploy-local.md
+++ b/docs/users/qwen-serve-deploy-local.md
@@ -50,7 +50,7 @@ independent.
 
 ## Linux: systemd user unit
 
-> **Find your `qwen` binary first.** The unit file's `ExecStart=` must hold an **absolute path** — service managers don't read your shell's `PATH`. Run `which qwen` to discover it. Common locations: `/usr/local/bin/qwen` (Linuxbrew, manual installs), `~/.nvm/versions/node/vX.Y.Z/bin/qwen` (nvm), `~/.fnm/aliases/default/bin/qwen` (fnm), `~/.volta/bin/qwen` (Volta). Substitute the actual path everywhere the templates below show `/PATH/TO/qwen`.
+> **Find your `qwen` binary and trusted tool directories first.** The unit file's `ExecStart=` must hold an **absolute path**, and its explicit `PATH` must include trusted directories for tools that daemon sessions need, such as `gh`, `git`, `npm`, and the `node` interpreter used by a script-based `qwen` launcher. Service managers don't read your shell profile. Run `which qwen gh git npm node` in your normal shell, then substitute the actual executable and directories everywhere the template below shows `/PATH/TO/qwen` and `/PATH/TO/USER/BIN`.
 
 `~/.config/systemd/user/qwen-serve.service`:
 
@@ -65,6 +65,9 @@ Type=simple
 WorkingDirectory=%h/project-a
 # Run `which qwen` to find the absolute path. systemd does NOT read $PATH.
 ExecStart=/PATH/TO/qwen serve --hostname 127.0.0.1 --port 4170 --workspace %h/project-a --workspace %h/project-b
+# Replace the first entry with trusted directories that contain qwen's
+# interpreter and user-installed tools. systemd does not read shell profiles.
+Environment=PATH=/PATH/TO/USER/BIN:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 # Read the bearer token from a chmod 600 file rather than inlining it
 # in the unit. `Environment=` would expose the token in the unit file
 # (typically 644 = world-readable). EnvironmentFile keeps the token in
@@ -99,11 +102,11 @@ systemctl --user disable --now qwen-serve.service
 
 Without `loginctl enable-linger`, the user-level systemd instance shuts down when the user logs out and only restarts on next login — on a headless dev box the daemon would not survive an SSH session ending. `enable-linger` is what makes "across reboots" actually work.
 
-**System-wide alternative** (shared dev hosts, less common): drop the unit at `/etc/systemd/system/qwen-serve@.service` with `User=%i`, manage via `sudo systemctl enable --now qwen-serve@<username>.service`. Same `[Service]` body otherwise — but world-readable `Environment=` exposure is even more problematic at this level, so always use `EnvironmentFile=` pointing at the user's `chmod 600` file. Pick user-level + linger for single-user workstations.
+**System-wide alternative** (shared dev hosts, less common): drop the unit at `/etc/systemd/system/qwen-serve@.service` with `User=%i`, manage via `sudo systemctl enable --now qwen-serve@<username>.service`. Same `[Service]` body otherwise. The non-sensitive `PATH` can remain in `Environment=`, but never put the bearer token there: use `EnvironmentFile=` pointing at the user's `chmod 600` file. Pick user-level + linger for single-user workstations.
 
 ## macOS: launchd user agent
 
-> **Find your `qwen` binary first.** Same constraint as systemd — `ProgramArguments` must hold an **absolute path**. Run `which qwen` to discover it. Common locations on macOS: `/opt/homebrew/bin/qwen` (Homebrew on Apple Silicon), `/usr/local/bin/qwen` (Homebrew on Intel, manual installs), `~/.nvm/versions/node/vX.Y.Z/bin/qwen` (nvm), `~/.volta/bin/qwen` (Volta). Substitute below where the template shows `/PATH/TO/qwen`.
+> **Find your `qwen` binary and trusted tool directories first.** Same constraint as systemd: `ProgramArguments` must hold an **absolute path**, while `EnvironmentVariables.PATH` must include trusted directories containing tools daemon sessions need. Run `which qwen gh git npm node` in your normal shell. Common locations on macOS include `/opt/homebrew/bin` (Homebrew on Apple Silicon), `/usr/local/bin` (Homebrew on Intel and manual installs), `~/.nvm/versions/node/vX.Y.Z/bin` (nvm), and `~/.volta/bin` (Volta). Substitute the actual absolute paths below; launchd does not expand `~` or shell variables.
 
 `~/Library/LaunchAgents/com.qwenlm.qwen-serve.plist`:
 
@@ -133,6 +136,10 @@ Without `loginctl enable-linger`, the user-level systemd instance shuts down whe
   <string>/Users/YOUR-USERNAME/project-a</string>
   <key>EnvironmentVariables</key>
   <dict>
+    <!-- launchd does not read shell profiles. Replace the first entry with
+         trusted directories containing qwen's interpreter and user tools. -->
+    <key>PATH</key>
+    <string>/PATH/TO/USER/BIN:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
     <!-- DO NOT COMMIT this file with a real token. Also chmod 600 the
          plist itself so the inlined token is not world-readable. -->
     <key>QWEN_SERVER_TOKEN</key>
@@ -179,6 +186,8 @@ tail -f ~/Library/Logs/qwen-serve/out.log ~/Library/Logs/qwen-serve/err.log
 ```
 
 After editing the plist (e.g., rotating the token) you must `unload` then `load` again — `launchctl` does not auto-reload on plist changes the way `systemd daemon-reload` does. Note: each `load` truncates the log files, so save them off if you're investigating an incident before rotating.
+
+After starting or restarting either service, open a new daemon session and verify that the tools it needs resolve without changing `PATH` inside the command, for example `command -v gh`. If a tool is missing, add its trusted, absolute containing directory to the service-level `PATH` and reload the service; do not rely on `~/.zshrc`, `~/.bashrc`, or another interactive-shell profile.
 
 ## tmux session (interactive supervision)
 


### PR DESCRIPTION
## What this PR does

This PR documents an explicit trusted tool PATH for qwen serve processes managed by systemd or launchd. It adds service examples that keep qwen's interpreter and common daemon-session tools resolvable, clarifies that bearer tokens still belong in protected environment files, and adds a post-restart command lookup check.

## Why it's needed

Service managers do not load interactive shell profiles. A daemon can therefore start successfully through an absolute qwen path while ACP shell commands cannot resolve user-installed tools such as gh. Agents may then work around the missing executable by modifying PATH inline, which can interact with the daemon's conservative Git worktree guard and deny otherwise harmless commands whose request data mentions Git. A complete service-level PATH prevents that failure mode without weakening the guard.

## Reviewer Test Plan

### How to verify

Review the systemd and launchd examples and confirm that each sets an explicit PATH using trusted absolute tool directories, keeps bearer-token handling separate, and instructs users to reload the service and verify `command -v gh` from a new daemon session. The embedded launchd plist example should pass `plutil -lint`, and the Markdown should pass Prettier.

### Evidence (Before & After)

N/A — documentation-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | N/A |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS 26.4.1 arm64; launchd-managed qwen serve; Node.js v24.12.0; GitHub CLI 2.92.0. Verified daemon health on 127.0.0.1:4170, bare gh resolution through the service PATH, Prettier formatting, `git diff --check`, and plist syntax with `plutil -lint`.

## Risk & Scope

- Main risk or tradeoff: The example PATH values are illustrative and operators must replace placeholders with trusted directories appropriate to their installation.
- Not validated / out of scope: The systemd example was reviewed but not executed on Linux; Windows service deployment and changes to the daemon Git guard are out of scope.
- Breaking changes / migration notes: None. Existing deployments continue to work, while affected operators must reload their service after adding the PATH entry.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为由 systemd 或 launchd 管理的 qwen serve 进程补充显式、可信的工具 PATH 配置说明。示例确保 qwen 所需解释器和 daemon 会话常用工具可被解析，明确 bearer token 仍应存放在受保护的环境文件中，并增加服务重启后的命令查找验证步骤。

## 为什么需要

服务管理器不会加载交互式 shell 配置。即使 daemon 能通过 qwen 的绝对路径成功启动，ACP shell 命令仍可能无法找到 gh 等用户安装工具。Agent 随后可能通过在命令中临时修改 PATH 来绕过缺失工具，这会与 daemon 保守的 Git worktree guard 发生交互，使请求数据中仅仅提到 Git 的无害命令也被拒绝。配置完整的服务级 PATH 可以在不削弱 guard 的情况下避免这一故障。

## Reviewer 测试计划

### 如何验证

检查 systemd 与 launchd 示例，确认两者都通过可信的绝对工具目录设置显式 PATH，将 bearer token 的处理保持独立，并要求用户重载服务后在新 daemon 会话中验证 `command -v gh`。嵌入的 launchd plist 示例应通过 `plutil -lint`，Markdown 应通过 Prettier。

### 证据（修改前后）

N/A — 仅文档变更。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|    🍏 macOS      | ✅ 已测试 |
|    🪟 Windows    | N/A |
|    🐧 Linux      | ⚠️ 未测试 |

### 环境（可选）

macOS 26.4.1 arm64；launchd 管理的 qwen serve；Node.js v24.12.0；GitHub CLI 2.92.0。已验证 127.0.0.1:4170 上的 daemon 健康状态、服务 PATH 对裸 gh 的解析、Prettier 格式、`git diff --check`，以及使用 `plutil -lint` 校验 plist 语法。

## 风险与范围

- 主要风险或权衡：示例 PATH 值仅供参考，运维人员必须根据实际安装位置替换占位符，并只使用可信目录。
- 未验证或范围外：systemd 示例已经审阅但未在 Linux 上实际执行；Windows 服务部署及 daemon Git guard 的修改不在范围内。
- 破坏性变更或迁移说明：无。现有部署继续工作；受影响的运维人员添加 PATH 后需要重载服务。

## 关联问题

N/A

</details>
