### PR TITLE
docs: add Agent Sessions to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you know Claude Code, you already know Qwen Code — and then some. We've put
 - [**Qwen Code Desktop**](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — Official desktop app for macOS, Windows, and Linux
 - [**AionUi**](https://github.com/iOfficeAI/AionUi) — A modern GUI for command-line AI tools including Qwen Code
 - [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop) — A cross-platform desktop/web/mobile UI for Qwen Code
-- [**Agent Sessions**](https://jazzyalex.github.io/agent-sessions/?campaign=github&ref=qwen-code-ecosystem) — Local-first macOS app to browse, search, and resume Qwen Code sessions alongside 14 other coding agents, with live quota-burn tracking
+- [**Agent Sessions**](https://github.com/jazzyalex/agent-sessions) — Local-first macOS app to browse, search, and resume Qwen Code sessions alongside 14 other coding agents
 
 - [**🦞 Qwen Code Claw**](https://github.com/openclaw/acpx) — Let other agents (Claude, Codex, etc.) delegate coding tasks to Qwen Code via ACP. Paste this prompt into your agent:
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ If you know Claude Code, you already know Qwen Code — and then some. We've put
 - [**Qwen Code Desktop**](https://github.com/QwenLM/qwen-code/releases/tag/desktop-latest) — Official desktop app for macOS, Windows, and Linux
 - [**AionUi**](https://github.com/iOfficeAI/AionUi) — A modern GUI for command-line AI tools including Qwen Code
 - [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop) — A cross-platform desktop/web/mobile UI for Qwen Code
+- [**Agent Sessions**](https://jazzyalex.github.io/agent-sessions/?campaign=github&ref=qwen-code-ecosystem) — Local-first macOS app to browse, search, and resume Qwen Code sessions alongside 14 other coding agents, with live quota-burn tracking
 
 - [**🦞 Qwen Code Claw**](https://github.com/openclaw/acpx) — Let other agents (Claude, Codex, etc.) delegate coding tasks to Qwen Code via ACP. Paste this prompt into your agent:
 


### PR DESCRIPTION
## What this PR does

Adds a single bullet for [Agent Sessions](https://github.com/jazzyalex/agent-sessions) to the `## Ecosystem` section of `README.md`, placed with the other desktop interfaces. One line, no other changes.

## Why it is needed

Agent Sessions is a free, MIT-licensed, open-source macOS app that reads Qwen Code's local session history for search, transcript review, and resume — alongside 14 other coding agents, so a Qwen Code user can review their Qwen work next to the rest of their history in one native app. It is local-only with no telemetry.

Discovery reads `~/.qwen/projects/<project>/chats/*.jsonl`, including `chats/archive/` and `QWEN_HOME` overrides. Resume is delegated to the installed Qwen Code CLI's own `--resume` for active sessions.

The Ecosystem section already lists desktop interfaces for Qwen Code (AionUi, Gemini CLI Desktop), so this entry fits the established category and format.

## Relationship to #10433

Filed as #10433 first, per CONTRIBUTING's issue-first rule. This repository's triage bot reviewed it and returned **"Verdict: accept for exploration ✅"**, independently verifying the integration against Qwen Code's actual storage layout (`Storage.getProjectDir()` + `chats`, cross-checked in `chatRecordingService.ts` / `sessionService.ts`) and confirming the project clears the community-traction bar that declined #2541. Its stated next step was "author to follow up with a PR" — this is that PR.

To be precise: that was the automated triage, not a maintainer decision. #10433 is still `status/ready-for-human`, and the call on whether to list this is entirely yours.

Closes #10433

## Disclosure

I maintain Agent Sessions and am proposing my own project for inclusion.

## Reviewer Test Plan

- Confirm the new bullet renders in the `## Ecosystem` section, in the same `- [**Name**](url) — description` format as its neighbours.
- Confirm the link resolves to the project site, and that the linked repo is MIT-licensed and actively maintained.
- `git diff` shows +1 line in `README.md` and nothing else.

## Screenshot / Demo

N/A — documentation-only; there is no user-facing change to Qwen Code itself. Screenshots of the application are on the linked project page.

---

## 这个 PR 做了什么

在 README 的 `## Ecosystem` 部分新增一行，列出 Agent Sessions，位置与其他桌面界面并列。仅一行改动。

## 为什么需要

Agent Sessions 是一个 MIT 许可的开源 macOS 应用，可在本地读取 Qwen Code 的会话历史，用于搜索、查看记录与恢复会话，同时支持另外 14 个编码代理，因此用户可以在一个原生应用中一起查看。完全本地运行，无任何遥测。

会话发现读取 `~/.qwen/projects/<project>/chats/*.jsonl`，包含 `chats/archive/` 以及 `QWEN_HOME` 覆盖路径；活动会话的恢复交由已安装的 Qwen Code CLI 自身的 `--resume` 处理。

Ecosystem 部分已包含 AionUi、Gemini CLI Desktop 等桌面界面，因此该条目符合现有分类与格式。

## 关于 #10433

已按 CONTRIBUTING 的要求先提交 issue #10433。本仓库的 triage 机器人给出的结论是 **“Verdict: accept for exploration ✅”**，并独立核实了该集成与 Qwen Code 实际存储结构一致，建议由作者提交 PR。需要说明的是：这是自动化 triage 的结论，并非维护者的决定；#10433 目前仍为 `status/ready-for-human`，是否收录完全由维护者决定。

## 声明

我是 Agent Sessions 的维护者，此为自荐。
