### PR TITLE
fix(vscode): localize untitled session search

### DIFF
--- a/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.test.tsx
@@ -19,7 +19,7 @@ const t = createChromeStrings('en');
 
 function makeSession(
   sessionId: string,
-  displayName: string,
+  displayName?: string,
 ): DaemonSessionSummary {
   const stamp = new Date().toISOString();
   return {
@@ -33,7 +33,15 @@ function makeSession(
 
 const mounted: Array<{ container: HTMLElement; root: Root }> = [];
 
-async function renderDropdown() {
+async function renderDropdown({
+  strings = t,
+  sessions = [makeSession('s1', 'First'), makeSession('s2', 'Second')],
+  searchQuery = '',
+}: {
+  strings?: ReturnType<typeof createChromeStrings>;
+  sessions?: readonly DaemonSessionSummary[];
+  searchQuery?: string;
+} = {}) {
   const onClose = vi.fn();
   const onSelect = vi.fn();
   const onRename = vi.fn(async () => {});
@@ -43,10 +51,10 @@ async function renderDropdown() {
   await act(async () => {
     root.render(
       <SessionHistoryDropdown
-        t={t}
-        sessions={[makeSession('s1', 'First'), makeSession('s2', 'Second')]}
+        t={strings}
+        sessions={sessions}
         currentSessionId="s1"
-        searchQuery=""
+        searchQuery={searchQuery}
         loading={false}
         hasMore={false}
         onSearchChange={() => {}}
@@ -68,6 +76,27 @@ afterEach(() => {
     act(() => root.unmount());
     container.remove();
   }
+});
+
+describe('SessionHistoryDropdown search', () => {
+  it('matches untitled sessions by the localized label users see', async () => {
+    const strings = createChromeStrings('zh-CN');
+    const { container } = await renderDropdown({
+      strings,
+      sessions: [
+        makeSession('missing-title'),
+        makeSession('empty-title', ''),
+        makeSession('named', 'Named session'),
+      ],
+      searchQuery: strings('session.untitled'),
+    });
+
+    expect(
+      Array.from(container.querySelectorAll('[data-session-id]'), (row) =>
+        row.getAttribute('data-session-id'),
+      ),
+    ).toEqual(['missing-title', 'empty-title']);
+  });
 });
 
 describe('SessionHistoryDropdown focus management', () => {

--- a/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.test.tsx
@@ -91,11 +91,20 @@ describe('SessionHistoryDropdown search', () => {
       searchQuery: strings('session.untitled'),
     });
 
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-session-id]'),
+    );
+    expect(rows.map((row) => row.dataset.sessionId)).toEqual([
+      'missing-title',
+      'empty-title',
+    ]);
     expect(
-      Array.from(container.querySelectorAll('[data-session-id]'), (row) =>
-        row.getAttribute('data-session-id'),
+      rows.map(
+        (row) =>
+          row.querySelector<HTMLElement>('span:not(.qwen-session-row-actions)')
+            ?.textContent,
       ),
-    ).toEqual(['missing-title', 'empty-title']);
+    ).toEqual([strings('session.untitled'), strings('session.untitled')]);
   });
 });
 

--- a/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.test.tsx
@@ -106,6 +106,21 @@ describe('SessionHistoryDropdown search', () => {
       ),
     ).toEqual([strings('session.untitled'), strings('session.untitled')]);
   });
+
+  it('matches a session by its own display name', async () => {
+    const { container } = await renderDropdown({
+      sessions: [
+        makeSession('report', 'Quarterly report'),
+        makeSession('missing-title'),
+      ],
+      searchQuery: 'quarterly',
+    });
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-session-id]'),
+    );
+    expect(rows.map((row) => row.dataset.sessionId)).toEqual(['report']);
+  });
 });
 
 describe('SessionHistoryDropdown focus management', () => {

--- a/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.tsx
@@ -180,7 +180,7 @@ export function SessionHistoryDropdown({
 
   const filtered = searchQuery.trim()
     ? sessions.filter((session) =>
-        (session.displayName ?? 'Untitled')
+        (session.displayName || t('session.untitled'))
           .toLowerCase()
           .includes(searchQuery.trim().toLowerCase()),
       )

--- a/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/SessionHistoryDropdown.tsx
@@ -178,9 +178,12 @@ export function SessionHistoryDropdown({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [onClose]);
 
+  const getSessionLabel = (session: DaemonSessionSummary) =>
+    session.displayName || t('session.untitled');
+
   const filtered = searchQuery.trim()
     ? sessions.filter((session) =>
-        (session.displayName || t('session.untitled'))
+        getSessionLabel(session)
           .toLowerCase()
           .includes(searchQuery.trim().toLowerCase()),
       )
@@ -493,7 +496,7 @@ export function SessionHistoryDropdown({
                           fontWeight: active ? 600 : 400,
                         }}
                       >
-                        {session.displayName || t('session.untitled')}
+                        {getSessionLabel(session)}
                       </span>
                     )}
 


### PR DESCRIPTION
## What this PR does

This change makes session-history search use the same localized fallback label that each untitled row displays. Missing and empty display names keep the existing falsy fallback behavior, and the label is now derived in one place for both filtering and rendering. The regression test verifies both the matching sessions and the localized text visible in each result.

## Why it's needed

In a localized UI, untitled sessions render with the translated label, but search previously compared a missing title against the hard-coded English string `Untitled`. As a result, searching for the exact label visible in the UI, such as `未命名`, returned no matches. Sharing the label derivation also prevents the filter and rendered row from drifting apart again.

## Reviewer Test Plan

### How to verify

Use the VS Code companion in the Chinese locale with one session whose display name is missing, one whose display name is an empty string, and one named session. Open session history and search for `未命名`. Confirm that both untitled sessions remain visible, both rows display `未命名`, and the named session is excluded.

The focused regression test also checks these three outcomes. As a mutation check, changing the fallback from falsy to nullish makes the empty-name assertion fail, while changing only the rendered fallback to `Untitled` makes the visible-text assertion fail.

### Evidence (Before & After)

![Before: searching 未命名 returns no matches. After: both untitled sessions are returned and display 未命名.](https://raw.githubusercontent.com/dvd233/qwen-code/f796ab73a63082c37c0fd1d981feffd781d710e9/10382-localized-session-search-before-after.png)

The before/after image uses the actual session-history component with the same Chinese locale and session fixtures as the regression scenario.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows 11, Node.js 24.15.0, Vitest 3.2.7. The VS Code companion workspace passed all 489 tests and its TypeScript, ESLint, and bundle build.

## Risk & Scope

- Main risk or tradeoff: Low. The change preserves the row's existing fallback semantics and reuses that same label for search.
- Not validated / out of scope: Manual extension-host verification on macOS and Linux; unrelated session-history behavior.
- Breaking changes / migration notes: None.

## Linked Issues

Related to #10382, specifically the [localized session-history search finding recorded in its follow-up comment](https://github.com/QwenLM/qwen-code/issues/10382#issuecomment-5455917911). This PR does not close the umbrella issue, which tracks several independent findings.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本改动让会话历史搜索使用每个未命名行实际展示的同一个本地化回退标签。缺失与空字符串显示名称继续保持既有的假值回退语义，并且过滤与渲染现在只在一处派生标签。回归测试同时验证匹配到的会话和每条结果实际显示的本地化文本。

## 为什么需要此改动

在本地化界面中，未命名会话会显示翻译后的标签，但搜索此前会把缺失标题与硬编码英文字符串 `Untitled` 比较。因此，搜索界面中实际可见的标签（例如 `未命名`）不会返回任何结果。共享标签派生也可以防止过滤逻辑与行渲染再次发生漂移。

## Reviewer 测试计划

### 如何验证

在中文语言环境的 VS Code companion 中准备三个会话：一个缺少显示名称、一个显示名称为空字符串、一个有正常名称。打开会话历史并搜索 `未命名`。确认两个未命名会话都保持可见、两行都显示 `未命名`，且有名称的会话被排除。

聚焦回归测试也会检查这三个结果。突变验证中，把假值回退改成空值回退会使空名称断言失败；只把渲染侧回退改成 `Untitled` 会使可见文本断言失败。

### 证据（修改前与修改后）

![修改前：搜索未命名没有结果；修改后：两个未命名会话都会返回并显示未命名。](https://raw.githubusercontent.com/dvd233/qwen-code/f796ab73a63082c37c0fd1d981feffd781d710e9/10382-localized-session-search-before-after.png)

修改前后对比图使用真实的会话历史组件，并采用与回归场景相同的中文语言环境和会话夹具。

### 已测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|      macOS       | ⚠️ 未测试 |
|     Windows      | ✅ 已测试 |
|      Linux       | ⚠️ 未测试 |

### 环境（可选）

Windows 11、Node.js 24.15.0、Vitest 3.2.7。VS Code companion workspace 的 489 项测试全部通过，TypeScript、ESLint 与 bundle build 也通过。

## 风险与范围

- 主要风险或取舍：低。本改动保留行渲染既有的回退语义，并让搜索复用同一个标签。
- 未验证或超出范围：未在 macOS 与 Linux 上进行扩展宿主手工验证；其他无关的会话历史行为不在本 PR 范围内。
- 破坏性变更或迁移说明：无。

## 关联 Issue

关联 #10382，具体对应其后续评论中记录的[本地化会话历史搜索问题](https://github.com/QwenLM/qwen-code/issues/10382#issuecomment-5455917911)。本 PR 不会关闭这个汇总 issue，因为其中还跟踪了多个彼此独立的问题。

</details>
