### PR TITLE
fix(review): readable bilingual disclosures for lint deferrals and caller prose

### DIFF
--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -6939,6 +6939,11 @@ describe('scriptLintGate — the deterministic gate reads the report', () => {
           path: '.github/workflows/ci.yml',
           tool: 'actionlint',
           reason: 'mapping unsupported <!-- qwen-review-deferred --> here',
+          // The zh half renders THIS leg when present — without a marker
+          // here, the loop below sanitised zh via the already-stripped
+          // English fallback and the `stripCommentGrammar(d.reasonZh)` call
+          // was never exercised: deleting it survived the whole suite.
+          reasonZh: '映射不支持 <!-- qwen-review-deferred --> 这里',
         },
       ],
       skipped: [
@@ -6954,6 +6959,9 @@ describe('scriptLintGate — the deterministic gate reads the report', () => {
     }
     expect(g.disclosed[0].en).toContain('qwen-review-deferred');
     expect(g.disclosed[0].en).toContain('mapping unsupported');
+    // Same invariant on the zh half: the text survives, the grammar is inert.
+    expect(g.disclosed[0].zh).toContain('qwen-review-deferred');
+    expect(g.disclosed[0].zh).toContain('映射不支持');
   });
 
   it.each([
@@ -7284,6 +7292,46 @@ describe('composeReview — the script-lint gate wired to the verdict', () => {
     );
     // the clean-approve copy is still there — the disclosure augments, it doesn't replace
     expect(r.body).toContain('No issues found. LGTM! ✅');
+  });
+
+  it('two deferred entries join per language, the reasonZh branch rendered whole', () => {
+    // Every other deferred fixture holds ONE entry, and a one-element join
+    // emits no separator — so the en '; ' join, the zh full-width '；' join
+    // and the reasonZh-carrying branch (the primary case: every report the
+    // current CLI writes carries `reasonZh`) were pinned by nothing; the
+    // single-entry test above reaches only the English-fallback branch. Two
+    // entries, one translated and one not, pin both composed sentences
+    // whole, separators included.
+    const p = gateReadyPlan(['verify', 'reverse-audit'], { han: true });
+    writeGateReport({
+      deferred: [
+        {
+          path: '.github/workflows/ci.yml',
+          tool: 'actionlint',
+          reason: 'source mapping not yet supported',
+          reasonZh: '尚未支持源映射',
+        },
+        {
+          path: '.github/workflows/release.yml',
+          tool: 'actionlint',
+          reason: 'source mapping not yet supported',
+        },
+      ],
+    });
+    const r = composeReview({
+      criticalsInline: 0,
+      suggestionsInline: 0,
+      planPath: p,
+      env: ENV,
+      modelId: MODEL,
+    });
+    expect(r.event).toBe('APPROVE');
+    expect(r.body).toContain(
+      'Not linted (tool limitation, not a blocker): `.github/workflows/ci.yml` — source mapping not yet supported; `.github/workflows/release.yml` — source mapping not yet supported.',
+    );
+    expect(r.body).toContain(
+      '未检查（工具限制，非阻断）：`.github/workflows/ci.yml`——尚未支持源映射；`.github/workflows/release.yml`——source mapping not yet supported。',
+    );
   });
 });
 

--- a/packages/cli/src/commands/review/compose-review.test.ts
+++ b/packages/cli/src/commands/review/compose-review.test.ts
@@ -1537,7 +1537,8 @@ describe('composeReview — event caps (round-7 Critical #2: caps must reach eve
     // prefix filter must not let it swallow a DIFFERENT reverse-audit scope
     // reported with its own reason — a whiffed chunk from the rounds that
     // DID run is exactly what a partially-run audit still owes the author.
-    const plan = coveredPlan();
+    // han: the caller-prose zh assertion below needs the Chinese half rendered.
+    const plan = coveredPlan(['verify', 'reverse-audit'], { han: true });
     writeBudgetStop(
       plan,
       {
@@ -1547,19 +1548,30 @@ describe('composeReview — event caps (round-7 Critical #2: caps must reach eve
       },
       3,
     );
-    const r = composeReview(
-      base({
-        planPath: plan,
-        unreviewedDimensions: [
-          "reverse audit — chunk 2's auditor returned nothing substantive twice",
-        ],
-      }),
-    );
+    // Not base(): its planPath default runs coveredPlan() again on the same
+    // path and would overwrite the han-stamped plan.
+    const r = composeReview({
+      planPath: plan,
+      env: ENV,
+      modelId: MODEL,
+      criticalsInline: 0,
+      suggestionsInline: 0,
+      unreviewedDimensions: [
+        "reverse audit — chunk 2's auditor returned nothing substantive twice",
+      ],
+    });
     expect(r.body).toContain(
       'Not reviewed: reverse audit — stopped before round 3 by the review time budget.',
     );
     expect(r.body).toContain(
       "Not reviewed: reverse audit — chunk 2's auditor returned nothing substantive twice.",
+    );
+    // Caller prose is untranslatable by construction, and the Chinese half
+    // SAYS so — an unmarked all-English sentence under 中文说明 read as a
+    // broken translation (#10567's posted body). The payload keeps its own
+    // English full stop.
+    expect(r.body).toContain(
+      "未审查（原文为英文）：reverse audit — chunk 2's auditor returned nothing substantive twice.",
     );
     // The marker's own disclosure still renders exactly once.
     expect(r.body.split('review time budget').length - 1).toBe(1);
@@ -6819,8 +6831,38 @@ describe('scriptLintGate — the deterministic gate reads the report', () => {
     expect(g.criticals).toEqual([]);
     expect(g.unreviewed).toEqual([]);
     expect(g.disclosed).toHaveLength(1);
-    expect(g.disclosed[0]).toContain('.github/workflows/ci.yml');
-    expect(g.disclosed[0]).toContain('source mapping not yet supported');
+    expect(g.disclosed[0].en).toContain('.github/workflows/ci.yml');
+    expect(g.disclosed[0].en).toContain('source mapping not yet supported');
+    // No "the executable-script lint" prefix: the body wraps this in a
+    // sentence that already opens "Not linted:", and the prefix rendered as
+    // "Not linted: the executable-script lint" — a lint not linted.
+    expect(g.disclosed[0].en).not.toContain('executable-script lint');
+    // No `reasonZh` in this report — the Chinese half falls back to the
+    // English reason rather than dropping the sentence.
+    expect(g.disclosed[0].zh).toContain('source mapping not yet supported');
+  });
+
+  it('a deferred entry with a reasonZh renders it in the Chinese half', () => {
+    const p = writePlan({
+      files: [{ path: '.github/workflows/ci.yml', kind: 'source' }],
+    });
+    writeReport({
+      deferred: [
+        {
+          path: '.github/workflows/ci.yml',
+          tool: 'actionlint',
+          reason: 'source mapping not yet supported',
+          reasonZh: '尚未支持源映射',
+        },
+      ],
+    });
+    const g = scriptLintGate(p);
+    expect(g.disclosed).toHaveLength(1);
+    expect(g.disclosed[0].en).toContain('source mapping not yet supported');
+    expect(g.disclosed[0].zh).toContain('尚未支持源映射');
+    expect(g.disclosed[0].zh).not.toContain('source mapping not yet supported');
+    // Both halves still carry the code-span path.
+    expect(g.disclosed[0].zh).toContain('.github/workflows/ci.yml');
   });
 
   it('ignores a cosmetic (style) or pre-existing (inDiff:false) finding', () => {
@@ -6873,12 +6915,14 @@ describe('scriptLintGate — the deterministic gate reads the report', () => {
     });
     const g = scriptLintGate(p);
     expect(g.disclosed).toHaveLength(1);
-    const d = g.disclosed[0];
-    expect(d).not.toContain('\n'); // newline stripped — cannot forge a body line
-    expect(d).not.toContain('`pwn`'); // the PR's own backticks stripped — cannot break out
-    // `@acme-team` sits INSIDE a code span (backtick … no backtick … backtick), so
-    // it is inert as a GitHub mention — the whole path rendered as one code span.
-    expect(d).toMatch(/`[^`\n]*@acme-team[^`\n]*`/);
+    // BOTH halves post — the Chinese one is not exempt from neutralisation.
+    for (const d of [g.disclosed[0].en, g.disclosed[0].zh]) {
+      expect(d).not.toContain('\n'); // newline stripped — cannot forge a body line
+      expect(d).not.toContain('`pwn`'); // the PR's own backticks stripped — cannot break out
+      // `@acme-team` sits INSIDE a code span (backtick … no backtick … backtick), so
+      // it is inert as a GitHub mention — the whole path rendered as one code span.
+      expect(d).toMatch(/`[^`\n]*@acme-team[^`\n]*`/);
+    }
   });
 
   it('report prose cannot smuggle live comment grammar into a disclosure', () => {
@@ -6903,12 +6947,13 @@ describe('scriptLintGate — the deterministic gate reads the report', () => {
       errored: [{ path: 'deploy.sh', tool: 'shell<!-- z -->check' }],
     });
     const g = scriptLintGate(p);
-    for (const line of [...g.disclosed, ...g.unreviewed]) {
+    const disclosedHalves = g.disclosed.flatMap((d) => [d.en, d.zh]);
+    for (const line of [...disclosedHalves, ...g.unreviewed]) {
       expect(line).not.toContain('<!--');
       expect(line).not.toContain('-->');
     }
-    expect(g.disclosed[0]).toContain('qwen-review-deferred');
-    expect(g.disclosed[0]).toContain('mapping unsupported');
+    expect(g.disclosed[0].en).toContain('qwen-review-deferred');
+    expect(g.disclosed[0].en).toContain('mapping unsupported');
   });
 
   it.each([
@@ -6965,7 +7010,7 @@ describe('scriptLintGate — the deterministic gate reads the report', () => {
     expect(g.disclosed).toHaveLength(1);
     expect(g.unreviewed[0]).toContain('42');
     expect(g.unreviewed[1]).toContain('undefined errored');
-    expect(g.disclosed[0]).toContain('[object Object]');
+    expect(g.disclosed[0].en).toContain('[object Object]');
   });
 
   it('reports an errored checker as unreviewed (fail closed)', () => {
@@ -7053,8 +7098,9 @@ describe('composeReview — the script-lint gate wired to the verdict', () => {
   // verifier (['reverse-audit']) to prove a finding stands with none.
   function gateReadyPlan(
     step45Keys: string[] = ['verify', 'reverse-audit'],
+    planOpts: Parameters<typeof coveredPlan>[1] = {},
   ): string {
-    const p = coveredPlan(step45Keys);
+    const p = coveredPlan(step45Keys, planOpts);
     const planObj = JSON.parse(readFileSync(p, 'utf8'));
     planObj.worktreePath = '.qwen/tmp/review-pr-1';
     writeFileSync(p, JSON.stringify(planObj));
@@ -7206,7 +7252,9 @@ describe('composeReview — the script-lint gate wired to the verdict', () => {
     // but MUST be surfaced in the body so the reader knows that shell went unlinted.
     // The gate reads the report as the sole authority, so the deferral is disclosed
     // from the report itself; the plan stays fully covered so the Approve stands.
-    const p = gateReadyPlan();
+    // han: the Chinese half only renders for a han-audience PR, and this test
+    // pins that half's sentence too.
+    const p = gateReadyPlan(['verify', 'reverse-audit'], { han: true });
     writeGateReport({
       deferred: [
         {
@@ -7224,8 +7272,16 @@ describe('composeReview — the script-lint gate wired to the verdict', () => {
       modelId: MODEL,
     });
     expect(r.event).toBe('APPROVE');
-    expect(r.body).toContain('.github/workflows/ci.yml');
-    expect(r.body).toContain('source mapping not yet supported');
+    // The whole composed sentence, both halves — pinned against the stutter
+    // #10567's posted body carried ("Not linted: the executable-script lint —
+    // … — not linted"): the wrapper says "Not linted" once, then path and
+    // reason, nothing else.
+    expect(r.body).toContain(
+      'Not linted (tool limitation, not a blocker): `.github/workflows/ci.yml` — source mapping not yet supported.',
+    );
+    expect(r.body).toContain(
+      '未检查（工具限制，非阻断）：`.github/workflows/ci.yml`——source mapping not yet supported。',
+    );
     // the clean-approve copy is still there — the disclosure augments, it doesn't replace
     expect(r.body).toContain('No issues found. LGTM! ✅');
   });

--- a/packages/cli/src/commands/review/compose-review.ts
+++ b/packages/cli/src/commands/review/compose-review.ts
@@ -3470,8 +3470,9 @@ function composeReviewBody(
   bodyCriticals.push(...ownAfterGateDedup);
   const modelBodyCriticals = [...bodyCriticals]; // input's, captured before the gate
   // Disclosed-but-non-capping notes from the gate (a deferred checker). Rendered
-  // in the body on every verdict, but never fed into the cap.
-  const gateDisclosed: string[] = [];
+  // in the body on every verdict, but never fed into the cap. Bilingual pairs —
+  // see `scriptLintGate` for why this channel can afford a real translation.
+  const gateDisclosed: Array<{ en: string; zh: string }> = [];
   // Test Plan rulings. Disclosed on every verdict and counted toward nothing —
   // see `testPlanGate` for why this one neither blocks nor caps.
   const testPlanNotes: string[] = [];
@@ -4878,12 +4879,17 @@ function composeReviewBody(
     });
   }
   for (const d of explainedCaller) {
-    // Caller prose, untranslatable by construction — quoted as-is in both,
-    // its comment grammar inert.
+    // Caller prose, untranslatable by construction — quoted as-is in both
+    // halves, its comment grammar inert. The Chinese label SAYS so: without
+    // the parenthetical, the 中文说明 block presented an all-English sentence
+    // as its translation (#10567's posted body), and the reader is left
+    // wondering whether the translation machinery broke. The payload keeps
+    // its own English full stop — closing an English sentence with "。" is
+    // the other half of that mismatch.
     const disclosed = stripCommentGrammar(d);
     notReviewedParts.push({
       en: `Not reviewed: ${disclosed}.`,
-      zh: `未审查：${disclosed}。`,
+      zh: `未审查（原文为英文）：${disclosed}.`,
     });
   }
   // Budget-gap disclosures, one BOUNDED sentence for all of them. Four
@@ -5180,8 +5186,8 @@ function composeReviewBody(
     ? [
         {
           trim: 2,
-          en: `Not linted (tool limitation, not a blocker): ${gateDisclosed.join('; ')}.`,
-          zh: `未检查（工具限制，非阻断）：${gateDisclosed.join('; ')}。`,
+          en: `Not linted (tool limitation, not a blocker): ${gateDisclosed.map((g) => g.en).join('; ')}.`,
+          zh: `未检查（工具限制，非阻断）：${gateDisclosed.map((g) => g.zh).join('；')}。`,
         },
       ]
     : [];
@@ -6232,14 +6238,17 @@ function structurallyValidReport(report: unknown): boolean {
 export function scriptLintGate(planPath: string): {
   criticals: string[];
   unreviewed: string[];
-  disclosed: string[];
+  disclosed: Array<{ en: string; zh: string }>;
 } {
   const criticals: string[] = [];
   const unreviewed: string[] = [];
   // Disclosed-but-NOT-capping: a `deferred` checker (actionlint) is a known tool
   // limitation, not a finding and not an unrun-checker gap — the reader is told a
   // workflow's embedded shell was not linted, but the verdict is not capped on it.
-  const disclosed: string[] = [];
+  // Bilingual, unlike the capping lists: these strings are machine-built from the
+  // report (no model prose), so the body's Chinese half can carry a real
+  // translation instead of the English line verbatim.
+  const disclosed: Array<{ en: string; zh: string }> = [];
   let plan: {
     prNumber?: unknown;
     files?: unknown;
@@ -6354,10 +6363,19 @@ export function scriptLintGate(planPath: string): {
   // A deferred checker (actionlint) is disclosed but does not cap — the reader is
   // told the workflow's embedded shell was not linted, without making every
   // workflow PR un-Approvable on a checker we deliberately decline to run.
+  // No "the executable-script lint —" prefix here: the body's own wrapper opens
+  // with "Not linted:", and naming the lint after that header rendered as
+  // "Not linted: the executable-script lint" — a sentence about not running a
+  // lint on a lint (#10567's posted body). The path and reason carry the facts.
   for (const d of report.deferred ?? []) {
-    disclosed.push(
-      `the executable-script lint — ${mdField(d.path)}: ${stripCommentGrammar(d.reason ?? `${d.tool} deferred`)}`,
-    );
+    const reason = stripCommentGrammar(d.reason ?? `${d.tool} deferred`);
+    disclosed.push({
+      en: `${mdField(d.path)} — ${reason}`,
+      // An older CLI's report has no `reasonZh`; English both halves beats a
+      // half-empty sentence. Its comment grammar goes inert like the reason's —
+      // the report is agent-rewritable prose either way.
+      zh: `${mdField(d.path)}——${d.reasonZh ? stripCommentGrammar(d.reasonZh) : reason}`,
+    });
   }
   return { criticals, unreviewed, disclosed };
 }

--- a/packages/cli/src/commands/review/script-lint.mock.test.ts
+++ b/packages/cli/src/commands/review/script-lint.mock.test.ts
@@ -283,6 +283,9 @@ describe('runScriptLint — refuses a path that escapes the worktree', () => {
     expect(r.checked).toEqual([]);
     expect(r.skipped).toHaveLength(1);
     expect(r.skipped[0].reason).toContain('outside the worktree');
+    // The body's "Not reviewed:" wrapper already says the file went
+    // unchecked — a "not linted" tail here posted the phrase twice.
+    expect(r.skipped[0].reason).not.toContain('not linted');
   });
 
   it('refuses a path whose ANCESTOR is a symlink out of the worktree (lexical is not enough)', () => {
@@ -306,6 +309,7 @@ describe('runScriptLint — refuses a path that escapes the worktree', () => {
     expect(r.checked).toEqual([]);
     expect(r.skipped).toHaveLength(1);
     expect(r.skipped[0].reason).toContain('outside the worktree');
+    expect(r.skipped[0].reason).not.toContain('not linted');
   });
 });
 

--- a/packages/cli/src/commands/review/script-lint.test.ts
+++ b/packages/cli/src/commands/review/script-lint.test.ts
@@ -177,8 +177,13 @@ describe('runScriptLint — graceful degradation and scoping', () => {
     // the phrase twice in one sentence (#10567's posted body).
     expect(r.deferred[0].reason).not.toContain('not linted');
     // The Chinese half of that wrapper sentence renders `reasonZh` — without
-    // it the 中文说明 block carried the English reason verbatim.
-    expect(r.deferred[0].reasonZh).toContain('actionlint');
+    // it the 中文说明 block carried the English reason verbatim. Pinned to the
+    // literal: a `toContain('actionlint')` fragment was satisfied by the
+    // ENGLISH reason too, so the exact defect this field exists to fix — an
+    // English string posing as the Chinese half — shipped green under it.
+    expect(r.deferred[0].reasonZh).toBe(
+      'actionlint 对 workflow 内嵌 shell 的源映射尚未支持',
+    );
     expect(r.ok).toBe(true);
   });
 
@@ -198,6 +203,10 @@ describe('runScriptLint — graceful degradation and scoping', () => {
     expect(r.skipped).toHaveLength(1);
     expect(r.skipped[0].tool).toBe('shellcheck');
     expect(r.skipped[0].reason).toContain('not a regular file');
+    // The body renders this under "Not reviewed:" — a "not linted" tail here
+    // posted the phrase twice in one sentence (the deferred reason's pin
+    // above guards its own copy; this guards the skipped one).
+    expect(r.skipped[0].reason).not.toContain('not linted');
   });
 
   it('checks nothing when no executable file changed', () => {

--- a/packages/cli/src/commands/review/script-lint.test.ts
+++ b/packages/cli/src/commands/review/script-lint.test.ts
@@ -172,6 +172,13 @@ describe('runScriptLint — graceful degradation and scoping', () => {
     expect(r.deferred).toHaveLength(1);
     expect(r.deferred[0].tool).toBe('actionlint');
     expect(r.deferred[0].reason).toContain('not yet supported');
+    // The reason must not restate "not linted" — the body renders it under a
+    // wrapper that already opens with "Not linted:", and a tail here posted
+    // the phrase twice in one sentence (#10567's posted body).
+    expect(r.deferred[0].reason).not.toContain('not linted');
+    // The Chinese half of that wrapper sentence renders `reasonZh` — without
+    // it the 中文说明 block carried the English reason verbatim.
+    expect(r.deferred[0].reasonZh).toContain('actionlint');
     expect(r.ok).toBe(true);
   });
 

--- a/packages/cli/src/commands/review/script-lint.ts
+++ b/packages/cli/src/commands/review/script-lint.ts
@@ -93,8 +93,19 @@ export interface ScriptLintReport {
    * capping — actionlint is installed on ~15% of PRs (every workflow change), and
    * capping all of them on a checker we choose not to run would make them
    * un-Approvable forever, which "install the tool" cannot fix.
+   *
+   * `reasonZh` is the same reason for the review body's Chinese half — the
+   * deferral is the one lint outcome rendered inside a translated sentence,
+   * and without it that sentence carried the English reason verbatim.
+   * Optional so a report written by an older CLI still renders (English both
+   * halves).
    */
-  deferred: Array<{ path: string; tool: LintTool; reason: string }>;
+  deferred: Array<{
+    path: string;
+    tool: LintTool;
+    reason: string;
+    reasonZh?: string;
+  }>;
   /**
    * True when every applicable linter ran cleanly **and** no finding on a changed
    * line is above `style` — `info`/`warning`/`error` all count against it (the
@@ -608,7 +619,7 @@ export function runScriptLint(
         skipped.push({
           path,
           tool: byName,
-          reason: 'path resolves outside the worktree — not linted',
+          reason: 'path resolves outside the worktree',
         });
       }
       continue;
@@ -623,11 +634,13 @@ export function runScriptLint(
       if (byName) {
         // Reason does NOT lead with the path — the gate prefixes `${path}:` when
         // it discloses, and leading with it here would print the path twice.
+        // Nor does it end with "not linted": the body renders every reason
+        // under a header that already says so ("Not reviewed:" / "Not
+        // linted:"), and a tail here posted the phrase twice in one sentence.
         skipped.push({
           path,
           tool: byName,
-          reason:
-            'not a regular file (symlink/fifo) or unreadable — not linted',
+          reason: 'not a regular file (symlink/fifo) or unreadable',
         });
       }
       continue;
@@ -647,8 +660,8 @@ export function runScriptLint(
       deferred.push({
         path,
         tool,
-        reason:
-          'actionlint embedded-shell source mapping is not yet supported — not linted',
+        reason: 'actionlint embedded-shell source mapping is not yet supported',
+        reasonZh: 'actionlint 对 workflow 内嵌 shell 的源映射尚未支持',
       });
       continue;
     }


### PR DESCRIPTION
## What this PR does

Makes the review body's disclosure sentences read cleanly in both languages. The deferred-checker disclosure no longer stutters: script-lint's deferral/skip reasons drop the `— not linted` tail that was written for a standalone context, and the disclosure drops the circular `the executable-script lint —` prefix, so the body's "Not linted:" wrapper states the fact once and the path and reason carry the rest. The body's Chinese half stops presenting untranslated English as its translation: the machine-built deferral disclosure becomes genuinely bilingual (`scriptLintGate` returns `{en, zh}` pairs, the report schema gains an optional `reasonZh` which the actionlint deferral supplies, and a report from an older CLI falls back to the English reason in both halves), while caller-prose "Not reviewed" entries — untranslatable free text by construction — get an honest Chinese label, `未审查（原文为英文）：`, and keep their own English full stop instead of closing an English sentence with `。`.

## Why it's needed

Both defects are visible verbatim in the review bot's posted round-1 body on #10567 (review 5061446682). It carried "Not linted (tool limitation, not a blocker): the executable-script lint — `.github/workflows/e2e.yml`: actionlint embedded-shell source mapping is not yet supported — not linted." — three layers each completing the sentence on their own — and its 中文说明 block rendered the same English sentences with only the labels translated, so the Chinese half added nothing and read like broken translation machinery.

## Reviewer Test Plan

### How to verify

Run the review-command suites from `packages/cli` (no build needed): `npx vitest run src/commands/review/script-lint.test.ts src/commands/review/script-lint.mock.test.ts src/commands/review/compose-review.test.ts`. The composed sentences are pinned whole in `compose-review.test.ts` ("a DEFERRED-only report keeps APPROVE…" and "two deferred entries join per language…"): a deferral must render as `Not linted (tool limitation, not a blocker): `.github/workflows/ci.yml` — source mapping not yet supported.` with the Chinese half `未检查（工具限制，非阻断）：`.github/workflows/ci.yml`——尚未支持源映射。` when `reasonZh` is present, and a caller-prose gap must render its Chinese line as `未审查（原文为英文）：…` (pinned in "the marker does not shadow other reverse-audit scopes…"). Each pin was additionally checked by mutation: re-appending either `— not linted` tail, substituting the English reason for `reasonZh`, dropping `stripCommentGrammar` from the `reasonZh` leg, or altering either join separator turns exactly the corresponding assertion red while the intact source stays green.

### Evidence (Before & After)

Before (posted on #10567, review 5061446682):

> Not linted (tool limitation, not a blocker): the executable-script lint — `.github/workflows/e2e.yml`: actionlint embedded-shell source mapping is not yet supported — not linted.

> 未检查（工具限制，非阻断）：the executable-script lint — `.github/workflows/e2e.yml`: actionlint embedded-shell source mapping is not yet supported — not linted。

After (pinned by the wired body tests):

> Not linted (tool limitation, not a blocker): `.github/workflows/e2e.yml` — actionlint embedded-shell source mapping is not yet supported.

> 未检查（工具限制，非阻断）：`.github/workflows/e2e.yml`——actionlint 对 workflow 内嵌 shell 的源映射尚未支持。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only — vitest run from `packages/cli`; no runtime or sandbox involved.

## Risk & Scope

- Main risk or tradeoff: the disclosed channel changes shape (`string[]` → `{en, zh}[]`), but it is consumed only by `composeReview`'s deferred block; the capping `unreviewed` channel deliberately stays string-typed. `reasonZh` is optional in the report schema, so a report written by an older CLI still renders (English in both halves).
- Not validated / out of scope: the posted-body wording changes take effect only once the reviewing bot runs a CLI with this change; the "build-and-test" dimension name in caller prose and the opener's zh join spacing are left as-is.
- Breaking changes / migration notes: none — the report schema change is additive and the disclosure shape is internal to `compose-review.ts`.

## Linked Issues

Prompted by the posted review body on #10567 (review 5061446682); no issue to close.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让 review 正文的披露语句在两种语言下都能干净地阅读。deferred-checker 披露不再重复：script-lint 的 deferral/skip 原因去掉了为独立语境写的 `— not linted` 尾巴，披露条目去掉了循环的 `the executable-script lint —` 前缀，正文的 "Not linted:" 包裹句只陈述一次事实，路径和原因承载其余信息。正文的中文半区不再把未翻译的英文当译文呈现：机器构建的 deferral 披露变为真正双语（`scriptLintGate` 返回 `{en, zh}` 对，report schema 新增可选 `reasonZh`，actionlint deferral 会提供该字段，旧版 CLI 写的 report 两半都回退英文原因）；而 caller 自由文本的 "Not reviewed" 条目本质上不可翻译，中文标签如实标注为 `未审查（原文为英文）：`，并保留英文句号，不再以 `。` 结束英文句子。

## 为什么需要

两个缺陷都原样出现在 review bot 于 #10567 发布的第 1 轮正文中（review 5061446682）。该正文出现了 "Not linted (tool limitation, not a blocker): the executable-script lint — `.github/workflows/e2e.yml`: actionlint embedded-shell source mapping is not yet supported — not linted." ——三层拼接各自补全了一遍句子——而其中文说明块只翻译了标签、解释部分原样保留英文，中文半区没有信息增量，读起来像翻译机制坏了。

## 审查者测试计划

### 如何验证

在 `packages/cli` 下运行 review 命令的测试套件（无需构建）：`npx vitest run src/commands/review/script-lint.test.ts src/commands/review/script-lint.mock.test.ts src/commands/review/compose-review.test.ts`。合成句在 `compose-review.test.ts` 中被整句钉住（"a DEFERRED-only report keeps APPROVE…" 与 "two deferred entries join per language…"）：deferral 必须渲染为 `Not linted (tool limitation, not a blocker): `.github/workflows/ci.yml` — source mapping not yet supported.`，`reasonZh` 存在时中文半区为 `未检查（工具限制，非阻断）：`.github/workflows/ci.yml`——尚未支持源映射。`；caller 自由文本缺口的中文行必须渲染为 `未审查（原文为英文）：…`（在 "the marker does not shadow other reverse-audit scopes…" 中钉住）。每个钉住都另经变异验证：把任一 `— not linted` 尾巴加回、用英文原因替换 `reasonZh`、从 `reasonZh` 分支移除 `stripCommentGrammar`、或改动任一 join 分隔符，都会让对应断言变红，而未变异源码保持全绿。

### 证据（Before & After）

Before（#10567 上已发布的 review 5061446682）：

> Not linted (tool limitation, not a blocker): the executable-script lint — `.github/workflows/e2e.yml`: actionlint embedded-shell source mapping is not yet supported — not linted.

> 未检查（工具限制，非阻断）：the executable-script lint — `.github/workflows/e2e.yml`: actionlint embedded-shell source mapping is not yet supported — not linted。

After（由 wired body 测试钉住）：

> Not linted (tool limitation, not a blocker): `.github/workflows/e2e.yml` — actionlint embedded-shell source mapping is not yet supported.

> 未检查（工具限制，非阻断）：`.github/workflows/e2e.yml`——actionlint 对 workflow 内嵌 shell 的源映射尚未支持。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

仅单元测试——在 `packages/cli` 下运行 vitest；不涉及运行时或沙箱。

## 风险与范围

- 主要风险或权衡：disclosed 通道形状变化（`string[]` → `{en, zh}[]`），但其唯一消费方是 `composeReview` 的 deferred block；封顶通道 `unreviewed` 有意保持字符串类型。report schema 中 `reasonZh` 为可选字段，旧版 CLI 写的 report 仍可渲染（两半均为英文）。
- 未验证 / 范围之外：已发布正文的措辞变化要等审查 bot 运行携带本改动的 CLI 后才生效；caller 自由文本中的 "build-and-test" 维度代号与 opener 中文拼接的空格问题保持原样。
- 破坏性变更 / 迁移说明：无——report schema 变更为增量式，披露形状是 `compose-review.ts` 的内部实现。

## 关联 Issue

由 #10567 上已发布的 review 正文（review 5061446682）触发；无需关闭的 issue。

</details>
