### PR TITLE
ci: split the static checks out of the Linux Test job

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -19,7 +19,7 @@
 9256 build-and-publish-image.yml
 49610 cd-cua-driver.yml
 2076 cd-mobile-mcp.yml
-98043 ci.yml
+118157 ci.yml
 1482 codeql.yml
 9389 comment-attachment-guard.yml
 31677 desktop-release.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,8 +205,8 @@ jobs:
     # clause (head.repo.full_name == github.repository) is empty on push. Do
     # not "normalise" that clause into the event allowlist — it also keeps
     # fork PRs out, and dorny/test-reporter needs `checks: write`, which
-    # fork-event runs do not have. So a push run is lint, static analysis and
-    # unit tests.
+    # fork-event runs do not have. So a push run is unit tests here plus the
+    # static_checks lane below.
     if: "${{ !cancelled() && github.event_name != 'schedule' }}"
     runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
     # Shared ECS hosts can stretch the normally 25-minute lane beyond an hour
@@ -488,103 +488,6 @@ jobs:
           echo "npm cache: ${cache_dir}"
           du -sh "${cache_dir}" 2>/dev/null || true
 
-      - name: 'Audit critical runtime dependencies'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run audit:runtime:critical'
-
-      - name: 'Check lockfile'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run check:lockfile'
-
-      - name: 'Check desktop workspace isolation'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run check:desktop-isolation'
-
-      - name: 'Check TUI dependency direction'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run check:tui-dep-direction'
-
-      - name: 'Install linters'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node scripts/lint.js --setup'
-
-      - name: 'Run ESLint'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node scripts/lint.js --eslint'
-
-      - name: 'Run actionlint'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        timeout-minutes: 5
-        run: 'node scripts/lint.js --actionlint'
-
-      - name: 'Run shellcheck'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node scripts/lint.js --shellcheck'
-
-      - name: 'Run yamllint'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node scripts/lint.js --yamllint'
-
-      - name: 'Run Prettier'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node scripts/lint.js --prettier'
-
-      - name: 'Run sensitive keyword linter'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node scripts/lint.js --sensitive-keywords'
-
-      - name: 'Run i18n check'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run check-i18n'
-
-      - name: 'Generate settings schema'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run generate:settings-schema'
-
-      - name: 'Check settings schema is up-to-date'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: |-
-          if [[ -n $(git status --porcelain packages/vscode-ide-companion/schemas/settings.schema.json) ]]; then
-            echo "Error: settings.schema.json is out of date."
-            echo "Please run: npm run generate:settings-schema"
-            echo "Then commit the updated schema file."
-            git diff packages/vscode-ide-companion/schemas/settings.schema.json
-            exit 1
-          fi
-          echo "Settings schema is up-to-date"
-
-      - name: 'Generate VS Code companion notices'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run generate:notices --workspace=qwen-code-vscode-ide-companion'
-
-      - name: 'Check VS Code companion notices are up-to-date'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: |-
-          if [[ -n $(git status --porcelain packages/vscode-ide-companion/NOTICES.txt) ]]; then
-            echo "Error: NOTICES.txt is out of date."
-            echo "Please run: npm run generate:notices --workspace=qwen-code-vscode-ide-companion"
-            echo "Then commit the updated file."
-            git diff --stat packages/vscode-ide-companion/NOTICES.txt
-            exit 1
-          fi
-          echo "NOTICES.txt is up-to-date"
-
-      # Keep this Linux-only PR gate explicit. macOS/Windows merge-queue jobs run
-      # npm run test:ci only, so they intentionally do not repeat this
-      # platform-independent bundle closure check.
-      - name: 'Check serve fast-path bundle closure'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'npm run check:serve-fast-path-bundle'
-
-      # The `github_ci_only` profile runs the .github/scripts helper tests, but a
-      # `full` PR that touches those scripts skips that path and `npm run
-      # test:ci` (vitest) does not collect `node:test` files — so run them here
-      # too, or a compositor/publisher change could pass CI without its
-      # regression tests. Linux-only (they're platform-independent).
-      - name: 'Run .github/scripts helper tests'
-        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
-        run: 'node --test --test-concurrency=1 ${{ env.HELPER_TESTS }}'
-
       # The install-script packaging suite needs zip/unzip, and throws on a
       # CI host that ships neither, so a silent skip there is impossible.
       # tmux is PRE-LANDED for #8388: that PR's capture-tui carries a
@@ -733,6 +636,369 @@ jobs:
         with:
           name: 'coverage-reports-22.x-ubuntu-latest'
           path: 'packages/*/coverage'
+
+  static_checks:
+    name: 'Static Checks (ubuntu-latest, Node 22.x)'
+    needs: 'classify_pr'
+    # Split out of `test` so lint, formatting, schema drift, the bundle
+    # closure and the helper tests stop spending the unit-test lane's clock:
+    # on the slower ECS hosts they cost ~20-50 minutes before the first test
+    # ran, and the suite then hit the job ceiling mid-run (observed on sg with
+    # the host near-idle, so the cost is intrinsic host speed, not
+    # contention). Both jobs pay one `npm ci` and run in parallel, so the
+    # Test lane's wall clock drops by the whole static block. Same trigger
+    # condition as `test`: a post-merge push run still gets lint and static
+    # analysis, just in this lane (scripts/tests/ci-platform-lanes.test.js
+    # pins push to exactly classify_pr + test + static_checks).
+    # `ci_profile` is classified here a second time (one extra changed-files
+    # listing) because consuming test's output would serialize the lanes —
+    # the parallelism is the point. Both classifications see the same head
+    # SHA; a mid-run push cancels this run via the workflow concurrency
+    # group before the answers could diverge.
+    if: "${{ !cancelled() && github.event_name != 'schedule' }}"
+    runs-on: '${{ fromJSON(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'') }}'
+    # Budget from the same per-host measurements as test's 90: the slowest
+    # host (64c) needs ~25-30 min for npm ci plus ~25 for the static block;
+    # hosted runners do the whole job in ~25.
+    timeout-minutes: '${{ fromJSON(contains(needs.classify_pr.outputs.ubuntu_runner || ''["ubuntu-latest"]'', ''ecs-qwen'') && ''75'' || ''45'') }}'
+    permissions:
+      contents: 'read'
+    steps:
+      # Pre-checkout cleanup: a previous containerised job (e.g. qwen-triage
+      # verify) may leave root-owned, read-only files anywhere in the workspace.
+      # Restore ownership and write permission unconditionally so the checkout
+      # below can wipe the tree without EACCES. Do not gate this behind a
+      # .qwen/.git probe: poisoning is workspace-wide (root-owned node_modules/
+      # dist with no .qwen/.git), so a probe reports "healthy" and skips the
+      # recovery exactly when it is needed.
+      - name: 'Restore workspace ownership'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        run: |-
+          set -uo pipefail
+          RUNNER_UID="$(id -u)"
+          RUNNER_GID="$(id -g)"
+          if [ "$RUNNER_UID" != "0" ]; then
+            chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chown -R "$RUNNER_UID:$RUNNER_GID" "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace ownership; checkout may fail on leftover root-owned files"
+          fi
+          chmod -R u+rwX "$GITHUB_WORKSPACE" 2>/dev/null || sudo -n chmod -R u+rwX "$GITHUB_WORKSPACE" || echo "::warning::could not restore workspace write permissions; checkout may fail on leftover read-only files"
+
+      # Remove .qwen/ and its recovery backup left by a previous job so
+      # actions/checkout doesn't trip on restrictive permissions.
+      # `.qwen.root-orig` is emitted by recovery tooling OUTSIDE this repo —
+      # nothing here produces it (git grep matches only these sweep copies
+      # and their pins in scripts/tests/review-worktree-cleanup-workflow.
+      # test.js). It is the backup name a cancelled verify's recovery leaves
+      # after renaming an unreadable, root-owned `.qwen` aside (observed on
+      # the shared pool; first recorded around review run 33146730771). If
+      # that producer's naming changes or a third residue name appears,
+      # update the for-loop list in every sweep copy or the checkout
+      # poisoning this sweep exists for silently recurs.
+      - name: 'Clean stale .qwen before checkout'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        run: |-
+          set -uo pipefail
+          for stale_qwen in "$GITHUB_WORKSPACE/.qwen" "$GITHUB_WORKSPACE/.qwen.root-orig"; do
+            if [ ! -e "$stale_qwen" ] && [ ! -L "$stale_qwen" ]; then
+              continue
+            fi
+            if [ -d "$stale_qwen" ] && [ ! -L "$stale_qwen" ]; then
+              chmod -R u+w "$stale_qwen" 2>/dev/null || true
+            fi
+            # A foreign-owned directory cannot always be renamed to a
+            # different parent: updating its .. entry can fail even when the
+            # workspace parent is writable. If that individual move fails,
+            # quarantine the runner-owned workspace itself, then recreate the
+            # empty checkout root. Warm contents are lost only on this
+            # otherwise unrecoverable path.
+            rm -rf -- "$stale_qwen" 2>/dev/null ||
+              sudo -n rm -rf -- "$stale_qwen" 2>/dev/null ||
+              {
+                quarantine="$(dirname -- "$GITHUB_WORKSPACE")/_qwen-quarantine"
+                mkdir -p "$quarantine" 2>/dev/null || true
+                stale_name="$(basename -- "$stale_qwen")"
+                if mv -- "$stale_qwen" "$quarantine/${stale_name#\.}-$(date -u +%Y%m%dT%H%M%SZ)-$$" 2>/dev/null; then
+                  echo "::warning::could not delete leaked $stale_name; moved it to $quarantine so this checkout can proceed — that directory needs manual cleanup"
+                else
+                  workspace_quarantine="$quarantine/workspace-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+                  if mv -- "$GITHUB_WORKSPACE" "$workspace_quarantine" 2>/dev/null &&
+                     mkdir -p "$GITHUB_WORKSPACE" 2>/dev/null &&
+                     cd "$GITHUB_WORKSPACE"; then
+                    echo "::warning::could not delete leaked $stale_name; moved the whole workspace to $workspace_quarantine so this checkout can proceed — that directory needs manual cleanup"
+                    break
+                  else
+                    echo "::warning::leaked $stale_name survived every recovery; runner needs manual cleanup"
+                  fi
+                fi
+              }
+          done
+          # Interrupted reviews leave worktree registrations under .qwen/tmp/
+          # and qwen-review/* branches behind. prune drops registrations whose
+          # directories the rm above removed; worktree remove --force then
+          # clears any still-registered leftover directory (--force tolerates
+          # dirty contents), since a branch checked out in a live worktree
+          # cannot be deleted. If removal still fails, the registration
+          # survives and the branch delete below warns. The sweep deletes all
+          # review artifacts, not just the current PR's: safe because a runner
+          # executes one job at a time. Kept inline rather than a shared
+          # script: this runs pre-checkout on shared runners, where leftover
+          # workspace files are untrusted.
+          if [ -e "$GITHUB_WORKSPACE/.git" ]; then
+            GIT_SAFE=(git -c core.hooksPath=/dev/null -c core.fsmonitor= -C "$GITHUB_WORKSPACE")
+            "${GIT_SAFE[@]}" worktree prune -v || true
+            "${GIT_SAFE[@]}" worktree list --porcelain \
+              | awk '$1 == "worktree" && index($0, "/.qwen/tmp/review-pr-") > 0 { sub(/^worktree /, ""); print }' \
+              | while read -r worktree; do
+                  [ -n "$worktree" ] || continue
+                  # Registered paths come from leftover git metadata and are
+                  # untrusted: the awk filter above matched by substring, so reject
+                  # `..` traversal and re-anchor to the review prefix before the
+                  # destructive remove.
+                  case "$worktree" in
+                    */../*|../*|*/..)
+                      echo "::warning::skipping suspicious review worktree path: $worktree"
+                      continue
+                      ;;
+                    "$GITHUB_WORKSPACE/.qwen/tmp/review-pr-"*) : ;;
+                    *)
+                      echo "::warning::skipping unexpected review worktree path: $worktree"
+                      continue
+                      ;;
+                  esac
+                  "${GIT_SAFE[@]}" worktree remove --force "$worktree" ||
+                    echo "::warning::could not remove review worktree: $worktree"
+                done || true
+            "${GIT_SAFE[@]}" worktree prune -v || true
+            "${GIT_SAFE[@]}" for-each-ref --format='%(refname:short)' 'refs/heads/qwen-review/*' \
+              | while read -r stale_ref; do
+                  if [ -n "$stale_ref" ]; then
+                    "${GIT_SAFE[@]}" branch -D "$stale_ref" ||
+                      echo "::warning::could not remove review branch: $stale_ref"
+                  fi
+                done || true
+          fi
+
+      # On PRs, check out refs/pull/N/head (the immutable PR head, published the
+      # instant the branch is pushed) instead of github.ref. github.ref is the
+      # merge ref (refs/pull/N/merge), which GitHub rebuilds asynchronously and
+      # can serve stale for minutes after a push, repeatedly flaking this gate.
+      # Merge queue refs are ephemeral; check out the event head SHA directly so
+      # slow hosted runners do not fail after the queue branch is removed.
+      # Non-PR/non-queue events keep github.ref.
+      - name: 'Checkout'
+        id: 'checkout'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+        with:
+          # Pin push runs to the event SHA: the `github.ref` fallback resolves
+          # `refs/heads/main` at fetch time — a moving tip — while the check run
+          # attaches to the triggering commit, so the lane would validate a tree
+          # it does not report on. Nothing detects that (the checkout-head
+          # verifier is gated to pull_request / merge_group, and its ancestor
+          # check passes for a newer tip regardless), and merges land close
+          # enough together to hit it routinely. Regressions are still caught —
+          # the tested tree is a descendant — but attribution breaks: red on a
+          # clean commit, autofix filed against the wrong merge. `e2e.yml` pins
+          # the event SHA by taking actions/checkout's default.
+          ref: "${{ github.event.inputs.branch_ref || (github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number)) || (github.event_name == 'merge_group' && github.event.merge_group.head_sha) || (github.event_name == 'push' && github.sha) || github.ref }}"
+          # Shallow: nothing here walks git history except on demand (the
+          # verify guard below checks head.sha == HEAD; the size gate and its
+          # vitest mirror fetch the PR's base commit at depth 1 when the
+          # baseline went stale; everything else touches only the working
+          # tree). On the in-repo ECS runner a full-history clone is the
+          # heaviest transfer and chokes the squid egress proxy, flaking
+          # checkout. depth 1 is enough.
+          fetch-depth: 1
+
+      # Guard against a stale checkout (e.g. a caching egress proxy serving an old
+      # ref) silently testing the wrong tree. Cheap: one merge-base, sub-second.
+      # Also runs in the merge queue — now that the queue's Ubuntu checkout is on
+      # ECS/squid, a wrong-tree pass would merge bad code.
+      - name: 'Verify checkout includes expected head commit'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
+        uses: './.github/actions/verify-checkout-head'
+        with:
+          expected_sha: "${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || github.event.pull_request.head.sha }}"
+
+      - name: 'Classify CI profile'
+        id: 'ci_profile'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+        env:
+          GH_TOKEN: '${{ github.token }}'
+          PR_NUMBER: "${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}"
+          IS_SAME_REPO_PR: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}"
+        run: |-
+          profile=full
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && -n "${PR_NUMBER}" ]]; then
+            if [[ "${IS_SAME_REPO_PR}" == "true" ]]; then
+              # Fetch + classify through the shared wrapper (also used by the
+              # review workflow's docs-only gate) so the classifier's input
+              # contract lives in one place. Exit 2 = listing failed,
+              # 3 = classifier failed.
+              set +e
+              profile="$(.github/scripts/ci/classify-pr-profile.sh "${GITHUB_REPOSITORY}" "${PR_NUMBER}")"
+              classify_rc=$?
+              set -e
+              if [ "$classify_rc" -eq 2 ]; then
+                echo "::warning::Unable to list PR changed files; running full CI."
+                profile=full
+              elif [ "$classify_rc" -ne 0 ]; then
+                echo "::error::CI profile classifier exited non-zero; running full CI."
+                profile=full
+              fi
+            else
+              echo "Fork PR detected; running full CI."
+            fi
+          fi
+          echo "ci_profile=${profile}" >> "${GITHUB_OUTPUT}"
+          echo "Selected CI profile: ${profile}"
+
+      - name: 'Set up Node.js 22.x (hosted)'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'github-hosted' }}"
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: 'Use pre-installed Node.js (self-hosted)'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}"
+        uses: './.github/actions/self-hosted-node'
+
+      - name: 'Configure persistent npm cache (self-hosted)'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${HOME}/.cache/qwen-code/npm"
+          mkdir -p "${cache_dir}"
+          echo "NPM_CONFIG_CACHE=${cache_dir}" >> "${GITHUB_ENV}"
+          echo "Using persistent npm cache at ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
+
+      - name: 'Configure npm for rate limiting'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: |-
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm config set fetch-retries 5
+          npm config set fetch-timeout 300000
+
+      # Fail fast on a saturated self-hosted host instead of dying on ENOSPC
+      # mid-install (#10035): the workspace cleaner skips busy runners, so a
+      # busy fleet can hit 100% while jobs keep being admitted. Gating before
+      # `npm ci` turns that into a clear, retryable reschedule onto a host
+      # with headroom, instead of a corrupted half-run.
+      - name: 'Disk floor gate (self-hosted)'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}"
+        run: 'bash .github/scripts/check-disk-floor.sh "${GITHUB_WORKSPACE}" "${RUNNER_TEMP:-/tmp}"'
+
+      - name: 'Install dependencies'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: |-
+          npm ci --prefer-offline --no-audit --progress=false
+
+      - name: 'Report npm cache usage (self-hosted)'
+        if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' && runner.environment == 'self-hosted' }}"
+        run: |-
+          cache_dir="${NPM_CONFIG_CACHE:-$(npm config get cache)}"
+          echo "npm cache: ${cache_dir}"
+          du -sh "${cache_dir}" 2>/dev/null || true
+
+      - name: 'Audit critical runtime dependencies'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run audit:runtime:critical'
+
+      - name: 'Check lockfile'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run check:lockfile'
+
+      - name: 'Check desktop workspace isolation'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run check:desktop-isolation'
+
+      - name: 'Check TUI dependency direction'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run check:tui-dep-direction'
+
+      - name: 'Install linters'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'node scripts/lint.js --setup'
+
+      - name: 'Run ESLint'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'node scripts/lint.js --eslint'
+
+      - name: 'Run actionlint'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        timeout-minutes: 5
+        run: 'node scripts/lint.js --actionlint'
+
+      - name: 'Run shellcheck'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'node scripts/lint.js --shellcheck'
+
+      - name: 'Run yamllint'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'node scripts/lint.js --yamllint'
+
+      - name: 'Run Prettier'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'node scripts/lint.js --prettier'
+
+      - name: 'Run sensitive keyword linter'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'node scripts/lint.js --sensitive-keywords'
+
+      - name: 'Run i18n check'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run check-i18n'
+
+      - name: 'Generate settings schema'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run generate:settings-schema'
+
+      - name: 'Check settings schema is up-to-date'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: |-
+          if [[ -n $(git status --porcelain packages/vscode-ide-companion/schemas/settings.schema.json) ]]; then
+            echo "Error: settings.schema.json is out of date."
+            echo "Please run: npm run generate:settings-schema"
+            echo "Then commit the updated schema file."
+            git diff packages/vscode-ide-companion/schemas/settings.schema.json
+            exit 1
+          fi
+          echo "Settings schema is up-to-date"
+
+      - name: 'Generate VS Code companion notices'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run generate:notices --workspace=qwen-code-vscode-ide-companion'
+
+      - name: 'Check VS Code companion notices are up-to-date'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: |-
+          if [[ -n $(git status --porcelain packages/vscode-ide-companion/NOTICES.txt) ]]; then
+            echo "Error: NOTICES.txt is out of date."
+            echo "Please run: npm run generate:notices --workspace=qwen-code-vscode-ide-companion"
+            echo "Then commit the updated file."
+            git diff --stat packages/vscode-ide-companion/NOTICES.txt
+            exit 1
+          fi
+          echo "NOTICES.txt is up-to-date"
+
+      # Keep this Linux-only PR gate explicit. macOS/Windows merge-queue jobs run
+      # npm run test:ci only, so they intentionally do not repeat this
+      # platform-independent bundle closure check.
+      - name: 'Check serve fast-path bundle closure'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'npm run check:serve-fast-path-bundle'
+
+      # The `github_ci_only` profile runs the .github/scripts helper tests, but a
+      # `full` PR that touches those scripts skips that path and `npm run
+      # test:ci` (vitest) does not collect `node:test` files — so run them here
+      # too, or a compositor/publisher change could pass CI without its
+      # regression tests. Linux-only (they're platform-independent).
+      - name: 'Run .github/scripts helper tests'
+        if: "${{ needs.classify_pr.outputs.skip_ci != 'true' && steps.ci_profile.outputs.ci_profile == 'full' }}"
+        run: 'node --test --test-concurrency=1 ${{ env.HELPER_TESTS }}'
 
   web_shell_e2e_smoke:
     name: 'web-shell E2E Smoke (ubuntu-latest, Node 22.x)'

--- a/scripts/tests/ci-platform-lanes.test.js
+++ b/scripts/tests/ci-platform-lanes.test.js
@@ -37,7 +37,7 @@ const failureIssue = parse(
 // `on:` parses as the boolean true in YAML 1.1.
 const triggers = ci[true] ?? ci['on'];
 const LANES = ['test_macos', 'test_windows'];
-const PUSH_JOBS = ['classify_pr', 'test'];
+const PUSH_JOBS = ['classify_pr', 'test', 'static_checks'];
 const condOf = (job) => String(ci.jobs[job].if ?? '');
 
 // The extended ceilings are scoped to the ECS pool: `runs-on` falls back to
@@ -78,6 +78,16 @@ it('keeps the shared Linux test lane above its contention budget on ECS', () => 
 it('keeps the shared Linux test lane on its pre-contention ceiling when hosted', () => {
   expect(timeoutMinutesOn('test', HOSTED_RUNNER)).toBe(60);
   expect(timeoutMinutesOn('test', '')).toBe(60);
+});
+
+it('keeps the static-checks lane on its per-pool budgets', () => {
+  // Split from `test` so the ~20-50 minute static block stops spending the
+  // unit-test lane's clock; same trigger condition, so a push run keeps
+  // lint and static analysis post-merge.
+  expect(condOf('static_checks')).toBe(condOf('test'));
+  expect(timeoutMinutesOn('static_checks', ECS_RUNNER)).toBe(75);
+  expect(timeoutMinutesOn('static_checks', HOSTED_RUNNER)).toBe(45);
+  expect(timeoutMinutesOn('static_checks', '')).toBe(45);
 });
 
 it('keeps the no-AK gate above its dependency-install budget on ECS', () => {


### PR DESCRIPTION
## What this PR does

Splits the Linux Test job in two. A new `static_checks` job takes the entire static block — dependency audit, lockfile, workspace-isolation and dep-direction checks, ESLint, actionlint, shellcheck, yamllint, Prettier, the sensitive-keyword and i18n linters, settings-schema and NOTICES drift checks, the serve fast-path bundle closure, and the `.github/scripts` helper tests. `test` keeps checkout, profile classification, `npm ci`, the unit-test suite and its reporting/coverage tail. The two jobs run in parallel from their own checkout and `npm ci`.

Lane budgets follow the same per-host measurements as Test's existing 90/60 split: `static_checks` gets 75 minutes on the ECS pool (the slowest host needs ~25-30 for `npm ci` plus ~25 for the static block) and 45 hosted. `scripts/tests/ci-platform-lanes.test.js` pins the new lane's trigger condition to Test's, its two budgets, and now expects a push run to reach exactly `classify_pr` + `test` + `static_checks`.

## Why it's needed

The Test job spent 20–50 minutes on static checks before the first unit test ran. Measured step timings on the self-hosted hosts:

| host | npm ci | static block | total preamble | tests then get |
| --- | ---: | ---: | ---: | ---: |
| hk-j6cdq (fast) | 3–5 min | ~8 min | ~11 min | 79 min ✅ |
| sg / hk-…6t | 12–13 min | ~20 min | ~33 min | 57 min ❌ |
| 64c | 23–31 min | ~25 min | ~50 min | 40 min ❌ |

`sg` has **never completed** the ubuntu Test lane. The decisive sample: a run on `sg-21` whose host was near-idle — 1–2 concurrent jobs for 80 of its 90 minutes, measured across every workflow on that host — still spent 12.8 min on `npm ci` (identical to the host's fully-loaded median) and was cancelled at the ceiling with the suite unfinished. Idle equals loaded, so the cost is intrinsic host speed; neither runner-density cuts nor further timeout raises can recover it. Removing the static block from the lane is the one repo-side change that lets those hosts finish: ~13 min install + tests against 90 minutes fits.

The split also stops a red static check from costing an hour: an ESLint or Prettier failure now reports from a lane that reaches it in minutes on any host, instead of after the full preamble.

## What deliberately stays in `test`

- **`ci_profile` output and its classification step** — `web_shell_e2e_smoke`, `integration_no_ak` and `post_coverage_comment` consume `needs.test.outputs.ci_profile`; all unchanged. `static_checks` classifies its profile a second time (one extra changed-files listing) because a `needs` edge on Test would serialize the lanes, and the parallelism is the point. Both classifications see the same head SHA; a mid-run push cancels the run through the workflow concurrency group before the answers could diverge.
- **The `github_ci_only` and docs-only fast paths, and the workflow-size gate** — single copies, gated as before. On those profiles every `static_checks` step skips and the job greens in seconds.
- **The tmux/zip install and the whole reporting tail** (disk-pressure samples, Chrome-extension artifact scan, test reporter, coverage upload).

The `.size-baseline` entry for ci.yml is bumped in this PR (98,043 → 118,157 bytes; the growth is the duplicated checkout/install preamble) per the ratchet's same-PR rule.

## Reviewer Test Plan

### How to verify

1. `npx vitest run scripts/tests/ci-platform-lanes.test.js` — 30 pass, including the new lane pins (condition identity with `test`, 75/45 budgets, push reaching exactly the three jobs).
2. `node --test .github/scripts/ci-runner-routing.test.mjs` — 23 pass; `npx vitest run scripts/tests/workflow-size.test.js` — 198 pass with the bumped baseline.
3. Structural check: parse ci.yml and diff the step-name lists — `static_checks` carries exactly the 18 moved steps plus the shared preamble; `test` keeps 22 steps; no step exists in both except the preamble.
4. On this PR's own run: `Static Checks (ubuntu-latest, Node 22.x)` and `Test (ubuntu-latest, Node 22.x)` start in parallel; Test's `Run tests and generate reports` begins right after `npm ci`.

### Verification notes

`qwen-triage-workflow.test.mjs` reports the same 36 failures on this branch and on a clean `origin/main` worktree (environment-dependent; counted identical both sides). Prettier clean on changed files; YAML re-parsed and job/step structure diffed programmatically. actionlint is not installed locally — covered by the lane itself on this PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

## Risk & Scope

- **Main cost**: one extra `npm ci` per run (3–30 min of machine time depending on host, in parallel — wall clock still drops). With the npm cache shared per-host, the second install is mostly cache hits.
- **Two classifications could race** a mid-run push; bounded by the concurrency group's cancel-in-progress as described above.
- **Post-merge contract preserved**: a push to main runs both lanes, so lint/static coverage on main is unchanged (pinned by the updated push-jobs assertion).
- **Not addressed here**: macOS/Windows Test lanes are untouched (they never ran the static block); the intrinsic slowness of sg/64c is an ops matter tracked separately.

<details>
<summary>中文说明</summary>

## 本 PR 的改动

把 Linux Test job 一分为二。新的 `static_checks` job 承担全部静态块——依赖审计、lockfile、workspace 隔离与依赖方向检查、ESLint、actionlint、shellcheck、yamllint、Prettier、敏感词与 i18n 检查、settings-schema 与 NOTICES 漂移检查、serve fast-path bundle 闭包、`.github/scripts` helper 测试。`test` 保留检出、profile 分类、`npm ci`、单测套件及其报告/覆盖率尾部。两个 job 各自检出、各自 `npm ci`，并行运行。

预算沿用 Test 现有 90/60 的同一套按宿主机实测：`static_checks` 在 ECS 池 75 分钟（最慢宿主机 `npm ci` 约 25–30 + 静态块约 25），托管 45 分钟。`scripts/tests/ci-platform-lanes.test.js` 钉住新 lane 的触发条件与 Test 一致、两档预算数值，并将 push 事件可达 job 更新为恰好 `classify_pr` + `test` + `static_checks`。

## 为什么需要

Test job 在第一个单测跑起来之前要花 20–50 分钟做静态检查。自建宿主机的实测见上方英文表格。

`sg` **从未跑完过** ubuntu Test lane。决定性样本：`sg-21` 上的一次运行，宿主机 90 分钟里有 80 分钟只有 1–2 个并发 job（对该宿主机上所有工作流统计）——`npm ci` 仍花了 12.8 分钟（与满载中位完全一致），最终在上限处被砍、套件未跑完。空载等于满载，说明慢是机器固有属性；降密度、继续提超时都救不回来。把静态块挪出去是仓库侧唯一能让这些宿主机跑完的改法：约 13 分钟安装 + 测试对 90 分钟预算，第一次能装下。

拆分同时让静态检查的红不再花一小时才报：ESLint/Prettier 失败现在从一条任何宿主机都能几分钟到达的 lane 报出。

## 刻意留在 `test` 里的

- **`ci_profile` output 与分类步骤**——`web_shell_e2e_smoke`、`integration_no_ak`、`post_coverage_comment` 消费 `needs.test.outputs.ci_profile`，全部不变。`static_checks` 自己再分类一次（多一次 changed-files listing），因为对 Test 建 `needs` 边会把两条 lane 串行化，而并行正是目的。两次分类看到同一个 head SHA；运行中途的 push 会先经 concurrency group 取消本次运行。
- **`github_ci_only` 与 docs-only 快路径、workflow 体积门**——单份拷贝，门控如旧。这些 profile 下 `static_checks` 全步骤跳过，数秒转绿。
- **tmux/zip 安装与整个报告尾部**（磁盘压力采样、Chrome 扩展产物扫描、测试报告、覆盖率上传）。

ci.yml 的 `.size-baseline` 按棘轮规则在本 PR 内同步更新（98,043 → 118,157 字节；增量是复制的检出/安装前置）。

## 审查测试计划

1. `npx vitest run scripts/tests/ci-platform-lanes.test.js` —— 30 通过，含新 lane 的钉子（条件与 `test` 恒等、75/45 预算、push 恰好可达三个 job）。
2. `node --test .github/scripts/ci-runner-routing.test.mjs` —— 23 通过；`npx vitest run scripts/tests/workflow-size.test.js` —— 基线更新后 198 通过。
3. 结构校验：解析 ci.yml 并对比步骤名清单——`static_checks` 恰好携带 18 个迁移步骤加共享前置；`test` 保留 22 步；除前置外无重复。
4. 在本 PR 自己的运行上：两条 lane 并行开跑，Test 的 `Run tests and generate reports` 紧跟 `npm ci` 之后。

### 验证说明

`qwen-triage-workflow.test.mjs` 在本分支与干净 `origin/main` worktree 上报同样 36 个失败（环境依赖；两侧计数一致）。改动文件 Prettier 干净；YAML 重新解析并程序化对比了 job/步骤结构。本地无 actionlint——由本 PR 自己的 lane 覆盖。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

## 风险与范围

- **主要成本**：每次运行多一份 `npm ci`（按宿主机 3–30 分钟机时，并行执行——墙钟仍是下降的）。宿主机级共享 npm 缓存下，第二次安装基本是缓存命中。
- **两次分类可能与运行中途的 push 竞争**；由 concurrency group 的 cancel-in-progress 兜底，见上。
- **合入后契约保持**：push 到 main 两条 lane 都跑，main 上的 lint/静态覆盖不变（由更新后的 push-jobs 断言钉住）。
- **不在本 PR 内**：macOS/Windows Test lane 未动（它们本就不跑静态块）；sg/64c 的固有慢速是运维侧问题，另行跟踪。

</details>
