### PR TITLE
ci: apply shared-runner integration limits to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,7 @@ jobs:
       OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
       OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
       OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+      RUNNER_ENVIRONMENT: '${{ runner.environment }}'
 
     steps:
       # Shared ECS runners can retain root-owned files from an earlier
@@ -466,6 +467,7 @@ jobs:
       OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
       OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
       OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+      RUNNER_ENVIRONMENT: '${{ runner.environment }}'
 
     steps:
       # Shared ECS runners can retain root-owned files from an earlier

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -1203,6 +1203,14 @@ describe('release lane runner routing', () => {
     }
   });
 
+  it('passes the runner environment to integration test configuration', () => {
+    for (const name of ['integration_none', 'integration_docker']) {
+      expect(releaseYaml.jobs[name].env.RUNNER_ENVIRONMENT, name).toBe(
+        '${{ runner.environment }}',
+      );
+    }
+  });
+
   it('keeps publishing and failure notification on hosted runners', () => {
     expect(releaseYaml.jobs.publish['runs-on']).toBe('ubuntu-latest');
     expect(releaseYaml.jobs.publish['runs-on']).not.toContain('ecs-qwen');


### PR DESCRIPTION
## What this PR does

This change passes the actual GitHub runner environment into both Release integration jobs, so the shared self-hosted ECS path uses the single-fork integration-test limit introduced by #10567 while the hosted fallback keeps the existing two-to-four-fork range. A workflow regression test pins the mapping for both the no-sandbox and Docker jobs.

## Why it's needed

Release run 33282281913 failed when two `qwen serve` integration tests repeatedly exceeded the existing 10-second ACP initialization budget under shared-host contention. The Release jobs run on the same ECS pool addressed by #10567, but they did not export `RUNNER_ENVIRONMENT`; as a result, the integration-test configuration still selected two-to-four Vitest forks there and the new contention limit never applied to Release. This closes that wiring gap without changing the production timeout or weakening the tests.

## Reviewer Test Plan

### How to verify

Confirm that both Release integration jobs expose the real runner environment to the integration-test process. On a self-hosted runner, the configuration should resolve to one Vitest fork; on the hosted fallback, it should remain at two-to-four forks. The focused workflow and integration configuration suites should stay green.

Local verification: ESLint passed for the changed test; the two focused suites passed 32 tests with one platform-conditional skip; Prettier and `git diff --check` passed.

### Evidence (Before & After)

N/A — CI workflow configuration only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local focused workflow-contract and Vitest-configuration tests using the repository's pinned toolchain.

## Risk & Scope

- Main risk or tradeoff: Release integration tests on the shared ECS pool trade some wall-clock speed for predictable resource use; the existing 120-minute job ceiling remains unchanged.
- Not validated / out of scope: actual shared-host contention can only be observed in post-merge Release runs; application timeout behavior is unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10535

Related: #10567

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将实际的 GitHub runner 环境传给 Release 的两个集成测试 job，使共享自托管 ECS 路径能够使用 #10567 引入的单 fork 限制，而托管 fallback 继续保持原有的 2–4 个 fork。新增 workflow 回归测试，固定无沙箱和 Docker 两个 job 的变量接线。

## 为什么需要

Release run 33282281913 中，两个 `qwen serve` 集成测试在共享主机资源竞争下反复超过现有的 10 秒 ACP 初始化预算。Release job 使用的正是 #10567 针对的 ECS 池，但此前没有导出 `RUNNER_ENVIRONMENT`；因此集成测试配置仍在该环境选择 2–4 个 Vitest fork，新的资源竞争限制没有作用于 Release。本 PR 补齐这处接线，不修改生产超时，也不弱化测试。

## Reviewer 测试计划

### 如何验证

确认 Release 的两个集成测试 job 都会把真实 runner 环境传给集成测试进程。在自托管 runner 上，配置应解析为一个 Vitest fork；在托管 fallback 上，应保持 2–4 个 fork。聚焦的 workflow 与集成配置测试应保持通过。

本地验证：修改的测试文件已通过 ESLint；两个聚焦测试套件共 32 个测试通过、1 个平台条件跳过；Prettier 和 `git diff --check` 均通过。

### 证据（修改前后）

N/A——仅修改 CI workflow 配置。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

使用仓库锁定的工具链在本地运行聚焦的 workflow contract 与 Vitest 配置测试。

## 风险与范围

- 主要风险或权衡：共享 ECS 池上的 Release 集成测试以部分墙钟时间换取可预测的资源使用；现有 120 分钟 job 上限保持不变。
- 未验证 / 范围外：真实共享主机资源竞争只能在合入后的 Release run 中观察；应用层超时行为保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10535

相关：#10567

</details>
