### PR TITLE
fix(ci): make the Release workflow dispatchable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,7 +401,6 @@ jobs:
       OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
       OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
       OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-      RUNNER_ENVIRONMENT: '${{ runner.environment }}'
 
     steps:
       # Shared ECS runners can retain root-owned files from an earlier
@@ -447,10 +446,14 @@ jobs:
           npm run bundle
 
       - name: 'Run CLI Integration Tests'
+        env:
+          RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: |-
           npm run test:integration:cli:sandbox:none
 
       - name: 'Run Interactive Integration Tests'
+        env:
+          RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: |-
           npm run test:integration:interactive:sandbox:none
 
@@ -467,7 +470,6 @@ jobs:
       OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
       OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
       OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-      RUNNER_ENVIRONMENT: '${{ runner.environment }}'
 
     steps:
       # Shared ECS runners can retain root-owned files from an earlier
@@ -530,12 +532,16 @@ jobs:
           npm run build:sandbox -- -s
 
       - name: 'Run CLI Docker Integration Tests'
+        env:
+          RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: |-
           # The package.json docker test scripts each rebuild the sandbox image.
           # Run vitest directly here so this job reuses the image built above.
           QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli
 
       - name: 'Run Interactive Docker Integration Tests'
+        env:
+          RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: |-
           QWEN_SANDBOX=docker npx vitest run --root ./integration-tests interactive
 

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -1205,9 +1205,17 @@ describe('release lane runner routing', () => {
 
   it('passes the runner environment to integration test configuration', () => {
     for (const name of ['integration_none', 'integration_docker']) {
-      expect(releaseYaml.jobs[name].env.RUNNER_ENVIRONMENT, name).toBe(
-        '${{ runner.environment }}',
+      const job = releaseYaml.jobs[name];
+      expect(job.env.RUNNER_ENVIRONMENT, name).toBeUndefined();
+      const testSteps = job.steps.filter((step) =>
+        /(?:vitest|test:integration)/.test(String(step.run ?? '')),
       );
+      expect(testSteps, name).toHaveLength(2);
+      for (const step of testSteps) {
+        expect(step.env.RUNNER_ENVIRONMENT, `${name}: ${step.name}`).toBe(
+          '${{ runner.environment }}',
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## What this PR does

This change moves the runner-environment mapping from the Release integration jobs to the four steps that actually invoke Vitest. The shared ECS path still receives `RUNNER_ENVIRONMENT=self-hosted` and uses the single-fork limit from #10567, while the workflow is valid for GitHub to parse. The regression test now rejects job-level placement and pins both test steps in each integration job.

## Why it's needed

#10592 placed `${{ runner.environment }}` in job-level `env`, where the `runner` context is unavailable. GitHub therefore rejected every Release dispatch before creating a run with `HTTP 422: Unrecognized named-value: 'runner'` at both integration jobs. Step-level `env` supports the context and preserves the intended behavior.

No nightly release, npm package, GitHub Release, or tag was created by the failed dispatch.

## Reviewer Test Plan

### How to verify

Confirm that neither integration job has a job-level `RUNNER_ENVIRONMENT`, and that its CLI and Interactive Vitest steps each map `${{ runner.environment }}`. The workflow-contract test should reject moving the mapping back to job scope. Actionlint should report the two runner-context errors on the #10592 merge commit and no runner-context error on this branch.

Local verification: ESLint passed; the focused workflow and integration configuration suites passed 32 tests with one platform-conditional skip; Prettier and `git diff --check` passed. Actionlint reports no runner-context error after the change; its remaining YAML-anchor and SC2129 diagnostics predate this PR.

### Evidence (Before & After)

N/A — CI workflow configuration only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local workflow parsing and focused configuration tests using the repository's pinned toolchain.

## Risk & Scope

- Main risk or tradeoff: the environment mapping is repeated on four steps instead of inherited once at job scope because GitHub does not expose the runner context there.
- Not validated / out of scope: a real nightly dispatch remains blocked until this PR is merged; no release was attempted from the unmerged branch.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #10592

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 runner 环境映射从 Release 集成测试 job 移到四个实际调用 Vitest 的 step。共享 ECS 路径仍会收到 `RUNNER_ENVIRONMENT=self-hosted` 并使用 #10567 的单 fork 限制，同时 workflow 可以被 GitHub 正常解析。回归测试现在会拒绝 job 级接线，并固定两个集成测试 job 中的全部测试 step。

## 为什么需要

#10592 把 `${{ runner.environment }}` 放在 job 级 `env`，但该位置无法使用 `runner` 上下文。因此 GitHub 在创建 run 前就以 `HTTP 422: Unrecognized named-value: 'runner'` 拒绝了所有 Release dispatch，两处错误分别位于两个集成测试 job。step 级 `env` 支持该上下文，并能保留原本的行为。

失败的 dispatch 没有创建 nightly release、npm 包、GitHub Release 或 tag。

## Reviewer 测试计划

### 如何验证

确认两个集成测试 job 的 job 级环境中都没有 `RUNNER_ENVIRONMENT`，而其中的 CLI 和 Interactive Vitest step 均映射 `${{ runner.environment }}`。workflow contract 测试应能阻止该映射再次移回 job 级。在 #10592 合入提交上运行 actionlint 应出现两处 runner context 错误，在本分支上则不再出现。

本地验证：ESLint 通过；聚焦的 workflow 和集成配置测试共 32 个通过、1 个平台条件跳过；Prettier 和 `git diff --check` 通过。修改后 actionlint 不再报告 runner context 错误；剩余的 YAML anchor 与 SC2129 诊断均早于本 PR 存在。

### 证据（修改前后）

N/A——仅修改 CI workflow 配置。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

使用仓库锁定的工具链进行本地 workflow 解析与聚焦配置测试。

## 风险与范围

- 主要风险或权衡：由于 GitHub 在 job 级不提供 runner context，环境映射需要在四个 step 上重复，而不能在 job 级继承一次。
- 未验证 / 范围外：真实 nightly dispatch 在本 PR 合入前仍被阻塞；没有从未合入分支尝试发布。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#10592 的后续修复

</details>
