### PR TITLE
fix(sdk): bump the browser daemon bundle budget to 216KB

### DIFF
--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -119,7 +119,9 @@ const rootDir = join(__dirname, '..');
 // response validation, and outcome-unknown recovery surface.
 // Workflow task status and control APIs merge within this budget; keep the
 // measured combined bundle bounded here.
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 215 * 1024;
+// Bumped from 215KB to 216KB for the daemon JSON-RPC error-detail surfacing
+// (structured `code`/`data` forwarding in the error payload).
+const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 216 * 1024;
 // The opt-in `daemon/transports` browser bundle legitimately ships the concrete
 // ACP transports (AcpHttpTransport/AcpWsTransport/AutoReconnect + negotiate), so
 // it's larger than the default barrel — but still budgeted so a future PR can't


### PR DESCRIPTION
## Motivation

Since the SDK error-detail surfacing landed, `npm install` fails on main with `Browser daemon SDK bundle is 220220 bytes; expected <= 220160` — the workspace build script aborts, so the main branch's CI is red on its latest push run, and every PR against main inherits the same install failure (the OpenTUI migration PRs #10368/#10383 currently hit it on their retargeted runs). The bundle grew by ~4KB from that change, past the 215KB size gate.

## Changes

Raises the browser daemon bundle budget from 215KB to 216KB, with a bump-line comment recording the cause (daemon JSON-RPC error-detail surfacing), following the file's existing convention of one budgeted bump per landed feature. Verified locally: the SDK build completes and the measured bundle is 220,220 bytes against the new 221,184-byte ceiling.

**How to verify:** on a clean checkout of main, `npm install` fails with the bundle-size error; with this change, install and `npm run build --workspace=packages/sdk-typescript` succeed.

Reviewer Test Plan
- Expect `npm install` on this branch to succeed where main's fails.
- Expect the SDK build's size gate to pass with ~1KB headroom over the measured bundle.
- No runtime behavior changes — the budget constant only gates the build.