### PR TITLE
fix(ci): coordinate Docker sandbox workloads on shared ECS hosts

### DIFF
--- a/.github/scripts/ci-runner-routing.test.mjs
+++ b/.github/scripts/ci-runner-routing.test.mjs
@@ -574,15 +574,19 @@ describe('e2e.yml e2e-test-linux runner routing', () => {
     assert.match(job.steps[heal].run, /chown -R .* "\$GITHUB_WORKSPACE"/);
     assert.match(job.steps[heal].run, /chmod -R u\+rwX/);
     assert.ok(heal < checkout, 'the heal must precede the checkout');
-    // Dangling-only prune at the end: always(), docker leg, pool only —
-    // and never a form that could remove tagged images other jobs use.
+    // Cleanup at the end: always(), docker leg, pool only. Tagged cleanup is
+    // restricted to old workflow-owned images; the general cleanup remains
+    // dangling-only so it cannot remove images from unrelated jobs.
     assert.ok(prune !== -1, 'the dangling prune must exist');
     assert.match(job.steps[prune].if, /always\(\)/);
     assert.match(job.steps[prune].if, /sandbox:docker/);
     assert.match(job.steps[prune].if, /runner\.environment == 'self-hosted'/);
+    assert.match(
+      job.steps[prune].run,
+      /docker image prune --all --force --filter 'label=org\.qwen-code\.ci\.sandbox=true' --filter 'until=24h'/,
+    );
     assert.match(job.steps[prune].run, /docker image prune --force/);
     assert.match(job.steps[prune].run, /until=24h/);
-    assert.doesNotMatch(job.steps[prune].run, /--all|-a\b/);
     // A failing prune must stay diagnosable: surface a warning instead of a
     // silent `|| true`, and keep the daemon's error out of /dev/null.
     assert.match(job.steps[prune].run, /\|\| echo "::warning::/);

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: 'Set up Docker'
         if: |-
-          ${{ matrix.sandbox == 'sandbox:docker' }}
+          ${{ matrix.sandbox == 'sandbox:docker' && runner.environment == 'github-hosted' }}
         uses: 'docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5' # ratchet:docker/setup-buildx-action@v4
 
       - name: 'Set up Podman'
@@ -170,44 +170,6 @@ jobs:
           registry: 'docker.io'
           username: '${{ secrets.DOCKERHUB_USERNAME }}'
           password: '${{ secrets.DOCKERHUB_TOKEN }}'
-
-      # The sandbox test script builds this image itself, but without `-s` it
-      # first re-runs install + build + bundle + pack on the host — all of which
-      # the steps above already did, and none of which the image consumes (the
-      # Dockerfile rebuilds and packs inside its own builder stage).
-      # continue-on-error is load-bearing: a failed first attempt must not
-      # pre-fail the job, or a successful retry below would still leave the
-      # shard red. The job only fails when the retry fails too.
-      - name: 'Build the sandbox image'
-        id: 'build-sandbox'
-        continue-on-error: true
-        if: |-
-          ${{ matrix.sandbox == 'sandbox:docker' }}
-        env:
-          # build_sandbox.js resolves the container command through
-          # sandbox_command.js, which exits non-zero on Linux when this is unset
-          # — the test script used to supply it.
-          QWEN_SANDBOX: 'docker'
-          # Without this, build_sandbox.js pipes docker build output to
-          # /dev/null — the longest step in the docker leg becomes undiagnosable.
-          VERBOSE: 'true'
-        run: |-
-          npm run build:sandbox -- -s
-
-      # One bounded retry: pool-runner docker builds hit transient
-      # environment failures — run 33139344576 died at this step on one
-      # runner (issue #10355) while the identical build passed on two
-      # sibling runners of the same run, and the re-run passed on another
-      # runner. A retry reuses the docker build cache and almost always
-      # passes; a genuine failure fails this step and with it the job.
-      - name: 'Build the sandbox image (retry)'
-        if: |-
-          ${{ steps.build-sandbox.outcome == 'failure' }}
-        env:
-          QWEN_SANDBOX: 'docker'
-          VERBOSE: 'true'
-        run: |-
-          npm run build:sandbox -- -s
 
       - name: 'Run E2E tests'
         env:
@@ -220,7 +182,65 @@ jobs:
           # shared-pool shard at one fork and exempts pressure-flake unhandled
           # errors.
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
+          QWEN_SANDBOX: "${{ matrix.sandbox == 'sandbox:docker' && 'docker' || 'false' }}"
+          BUILD_SANDBOX_FLAGS: '--label org.qwen-code.ci.sandbox=true'
         run: |-
+          set -euo pipefail
+
+          if [ '${{ matrix.sandbox }}' = 'sandbox:docker' ]; then
+            sandbox_image="$(node -p "require('./packages/cli/package.json').config.sandboxImageUri")-e2e-${GITHUB_SHA}"
+
+            build_image() {
+              npm run build:sandbox -- -s --no-prune -i "$sandbox_image"
+            }
+
+            acquire_daemon_write_lock() {
+              lock_deadline=$((SECONDS + 1800))
+              until flock --nonblock 9; do
+                if (( SECONDS >= lock_deadline )); then
+                  echo "::error::docker daemon write lock not acquired within 30 minutes"
+                  exit 1
+                fi
+                sleep 1
+              done
+            }
+
+            if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+              mkdir -p "${HOME}/.cache/qwen-code-ci"
+              exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-e2e-${GITHUB_SHA}.lock"
+              if ! flock --wait 1800 8; then
+                echo "::error::docker build coordinator lock not acquired within 30 minutes"
+                exit 1
+              fi
+              exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
+              if ! flock --shared --wait 1800 9; then
+                echo "::error::docker daemon read lock not acquired within 30 minutes"
+                exit 1
+              fi
+            fi
+
+            if ! docker image inspect "$sandbox_image" > /dev/null 2>&1; then
+              if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+                flock --unlock 9
+                acquire_daemon_write_lock
+              fi
+              docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
+              if ! build_image; then
+                echo "::warning::sandbox image build failed; retrying once"
+                build_image
+              fi
+            else
+              echo "Reusing sandbox image for ${GITHUB_SHA}"
+            fi
+
+            sandbox_image_id="$(docker image inspect --format '{{.Id}}' "$sandbox_image")"
+            export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
+            if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+              flock --shared 9
+              flock --unlock 8
+            fi
+          fi
+
           export TMPDIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
           if [ "${RUNNER_OS:-}" = "Linux" ]; then
             QWEN_CI_TMPDIR="$(mktemp -d /var/tmp/qwen-ci-XXXXXX 2>/dev/null || true)"
@@ -239,17 +259,21 @@ jobs:
             npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
           fi
 
-      # The sandbox build retags the same image name every run, so on a
-      # persistent runner the superseded layers go dangling and would
-      # accumulate. Dangling-only prune with an age floor: never touches
-      # tagged images other jobs on this machine may still use, and keeps
-      # the last day of layers as build cache for the next run. Hosted
-      # runners are ephemeral and skip this.
+      # Commit-qualified CI images are pruned under the exclusive daemon lock
+      # once they are older than a day. The cleanup is non-blocking so a shard
+      # finishing early cannot queue a writer ahead of another shard's reader.
       - name: 'Prune dangling docker images'
         if: |-
           ${{ always() && matrix.sandbox == 'sandbox:docker' && runner.environment == 'self-hosted' }}
         run: |-
-          docker image prune --force --filter 'until=24h' || echo "::warning::docker image prune failed on ${RUNNER_NAME:-this runner}; dangling images may accumulate"
+          mkdir -p "${HOME}/.cache/qwen-code-ci"
+          exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
+          if flock --nonblock 9; then
+            docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
+            docker image prune --force --filter 'until=24h' || echo "::warning::docker image prune failed on ${RUNNER_NAME:-this runner}; dangling images may accumulate"
+          else
+            echo "Docker cleanup skipped because the shared daemon is active"
+          fi
 
   e2e-test-macos:
     name: 'E2E Test - macOS - shard ${{ matrix.shard }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,26 +523,62 @@ jobs:
           npm run bundle
 
       - name: 'Set up Docker'
+        if: "${{ runner.environment != 'self-hosted' }}"
         uses: 'docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5' # ratchet:docker/setup-buildx-action@v4
 
-      - name: 'Build Sandbox'
+      - name: 'Run Docker Integration Tests'
         env:
           QWEN_SANDBOX: 'docker'
-        run: |-
-          npm run build:sandbox -- -s
-
-      - name: 'Run CLI Docker Integration Tests'
-        env:
+          BUILD_SANDBOX_FLAGS: '--label org.qwen-code.ci.sandbox=true'
           RUNNER_ENVIRONMENT: '${{ runner.environment }}'
         run: |-
+          set -euo pipefail
+          sandbox_revision="$(git rev-parse HEAD)"
+          sandbox_image="$(node -p "require('./packages/cli/package.json').config.sandboxImageUri")-release-${sandbox_revision}"
+
+          acquire_daemon_write_lock() {
+            lock_deadline=$((SECONDS + 1800))
+            until flock --nonblock 9; do
+              if (( SECONDS >= lock_deadline )); then
+                echo "::error::docker daemon write lock not acquired within 30 minutes"
+                exit 1
+              fi
+              sleep 1
+            done
+          }
+
+          if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+            mkdir -p "${HOME}/.cache/qwen-code-ci"
+            exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-release-${sandbox_revision}.lock"
+            if ! flock --wait 1800 8; then
+              echo "::error::docker build coordinator lock not acquired within 30 minutes"
+              exit 1
+            fi
+            exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
+            if ! flock --shared --wait 1800 9; then
+              echo "::error::docker daemon read lock not acquired within 30 minutes"
+              exit 1
+            fi
+          fi
+
+          if ! docker image inspect "$sandbox_image" > /dev/null 2>&1; then
+            if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+              flock --unlock 9
+              acquire_daemon_write_lock
+            fi
+            docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
+            npm run build:sandbox -- -s --no-prune -i "$sandbox_image"
+          fi
+          sandbox_image_id="$(docker image inspect --format '{{.Id}}' "$sandbox_image")"
+          export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
+          if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+            flock --shared 9
+            flock --unlock 8
+          fi
+
           # The package.json docker test scripts each rebuild the sandbox image.
           # Run vitest directly here so this job reuses the image built above.
           QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli
-
-      - name: 'Run Interactive Docker Integration Tests'
-        env:
-          RUNNER_ENVIRONMENT: '${{ runner.environment }}'
-        run: |-
           QWEN_SANDBOX=docker npx vitest run --root ./integration-tests interactive
 
   audio_capture_prebuilds:

--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -54,6 +54,11 @@ const argv = yargs(hideBin(process.argv))
     type: 'string',
     description:
       'Path to write the final image URI. Used for CI/CD pipeline integration.',
+  })
+  .option('prune', {
+    type: 'boolean',
+    default: true,
+    description: 'prune dangling images after the build',
   }).argv;
 
 let sandboxCommand;
@@ -171,4 +176,6 @@ function buildImage(imageName, dockerfile) {
 
 buildImage(image, dockerFile);
 
-execSync(`${sandboxCommand} image prune -f`, { stdio: 'ignore' });
+if (argv.prune) {
+  execSync(`${sandboxCommand} image prune -f`, { stdio: 'ignore' });
+}

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -10,6 +10,7 @@ import { parse } from 'yaml';
 
 describe('e2e workflow', () => {
   const workflow = readFileSync('.github/workflows/e2e.yml', 'utf8');
+  const buildSandboxScript = readFileSync('scripts/build_sandbox.js', 'utf8');
   const yml = parse(workflow);
 
   it('never cancels in-progress runs on main', () => {
@@ -33,57 +34,69 @@ describe('e2e workflow', () => {
     expect(group).toContain('github.head_ref || github.ref_name');
   });
 
-  describe('sandbox image build retry', () => {
-    // Run 33139344576 (issue #10355) died at 'Build the sandbox image' on one
-    // pool runner while the identical build passed on two sibling runners of
-    // the same run, and the re-run passed on another runner. The bounded retry
-    // keeps one transient environment failure from exiting the shard red.
+  describe('sandbox image preparation', () => {
     const steps = yml.jobs['e2e-test-linux'].steps;
-    const buildStep = steps.find(
-      (step) => step.name === 'Build the sandbox image',
-    );
-    const retryStep = steps.find(
-      (step) => step.name === 'Build the sandbox image (retry)',
-    );
+    const setupStep = steps.find((step) => step.name === 'Set up Docker');
+    const runStep = steps.find((step) => step.name === 'Run E2E tests');
 
-    it('keeps a failed first attempt from pre-failing the job', () => {
-      // Without continue-on-error a successful retry would leave the shard red
-      // (GitHub computes the job conclusion from every step conclusion).
-      expect(buildStep['continue-on-error']).toBe(true);
+    it('does not create one Buildx builder per self-hosted shard', () => {
+      expect(setupStep.if).toContain("runner.environment == 'github-hosted'");
     });
 
-    it('pins the first build step id the retry gate references', () => {
-      // steps.build-sandbox.outcome only resolves when this exact id exists;
-      // renaming the step would silently disable the retry.
-      expect(buildStep.id).toBe('build-sandbox');
-    });
-
-    it('gates the retry on the first attempt outcome only', () => {
-      expect(retryStep.if).toContain(
-        "steps.build-sandbox.outcome == 'failure'",
+    it('serializes image preparation on the shared Docker host', () => {
+      expect(runStep.run).toContain(
+        'docker-sandbox-build-e2e-${GITHUB_SHA}.lock',
       );
-      // failure() would be false once continue-on-error absorbs the first
-      // attempt, silently skipping the retry.
-      expect(retryStep.if).not.toContain('failure()');
+      expect(runStep.run).toContain('flock --wait 1800 8');
+      expect(runStep.run).toContain(
+        'exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"',
+      );
+      expect(runStep.run).toContain('flock --shared --wait 1800 9');
+      expect(runStep.run).toContain(
+        'if [ "$RUNNER_ENVIRONMENT" = \'self-hosted\' ]',
+      );
     });
 
-    it('lets a failed retry fail the job', () => {
-      // continue-on-error on the retry would absorb a genuine build failure
-      // and hand the test step a sandbox image that was never built.
-      expect(retryStep['continue-on-error']).toBeUndefined();
+    it('reuses a commit-qualified image', () => {
+      expect(runStep.env.BUILD_SANDBOX_FLAGS).toContain(
+        'org.qwen-code.ci.sandbox=true',
+      );
+      expect(runStep.run).toContain('sandboxImageUri")-e2e-${GITHUB_SHA}"');
+      expect(runStep.run).toContain('docker image inspect "$sandbox_image"');
     });
 
-    it('rebuilds with the same script and the same skip flag', () => {
-      expect(buildStep.run).toContain('npm run build:sandbox -- -s');
-      expect(retryStep.run).toContain('npm run build:sandbox -- -s');
+    it('pins each shard to the prepared image ID', () => {
+      expect(runStep.run).toContain("docker image inspect --format '{{.Id}}'");
+      expect(runStep.run).toContain(
+        'export QWEN_SANDBOX_IMAGE="$sandbox_image_id"',
+      );
     });
 
-    it('keeps the docker leg env on the retry', () => {
-      // Without QWEN_SANDBOX, build_sandbox.js cannot resolve the container
-      // command on Linux; without VERBOSE the retry's build log goes to
-      // /dev/null and a second failure is undiagnosable.
-      expect(retryStep.env.QWEN_SANDBOX).toBe('docker');
-      expect(retryStep.env.VERBOSE).toBe('true');
+    it('keeps one bounded retry without pruning the shared daemon', () => {
+      expect(runStep.run.match(/build_image/g)).toHaveLength(3);
+      expect(runStep.run).toContain(
+        'npm run build:sandbox -- -s --no-prune -i "$sandbox_image"',
+      );
+      expect(buildSandboxScript).toContain(".option('prune'");
+      expect(buildSandboxScript).toContain('if (argv.prune)');
+    });
+
+    it('keeps the Docker build environment', () => {
+      expect(runStep.env.QWEN_SANDBOX).toContain("'docker'");
+      expect(runStep.env.VERBOSE).toBe('true');
+    });
+
+    it('keeps the shared lock continuously through concurrent tests', () => {
+      const imageIdIndex = runStep.run.indexOf('sandbox_image_id=');
+      const downgradeIndex = runStep.run.indexOf('flock --shared 9');
+      const testIndex = runStep.run.indexOf('vitest run');
+      expect(imageIdIndex).toBeGreaterThanOrEqual(0);
+      expect(downgradeIndex).toBeGreaterThan(imageIdIndex);
+      expect(testIndex).toBeGreaterThan(downgradeIndex);
+      expect(runStep.run).toContain('until flock --nonblock 9');
+      expect(
+        yml.jobs['e2e-test-linux'].strategy['max-parallel'],
+      ).toBeUndefined();
     });
   });
 

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -881,6 +881,33 @@ describe('release workflow', () => {
     );
   });
 
+  it('coordinates Docker image use with other shared-pool workflows', () => {
+    const steps = releaseYaml.jobs.integration_docker.steps;
+    const setupStep = steps.find((step) => step.name === 'Set up Docker');
+    const testStep = steps.find(
+      (step) => step.name === 'Run Docker Integration Tests',
+    );
+
+    expect(setupStep.if).toBe("${{ runner.environment != 'self-hosted' }}");
+    expect(testStep.run).toContain(
+      'docker-sandbox-build-release-${sandbox_revision}.lock',
+    );
+    expect(testStep.run).toContain('flock --wait 1800 8');
+    expect(testStep.run).toContain(
+      'exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"',
+    );
+    expect(testStep.run).toContain('-release-${sandbox_revision}');
+    expect(testStep.run).toContain('--no-prune -i "$sandbox_image"');
+    expect(testStep.run).toContain(
+      'export QWEN_SANDBOX_IMAGE="$sandbox_image_id"',
+    );
+    expect(testStep.run).toContain('flock --shared --wait 1800 9');
+    expect(testStep.run).toContain('flock --shared 9');
+    expect(testStep.run).toContain('until flock --nonblock 9');
+    expect(testStep.run).toContain('integration-tests cli');
+    expect(testStep.run).toContain('integration-tests interactive');
+  });
+
   it('digest-pins every sandbox base image', () => {
     // integration_docker builds on the shared pool, whose docker daemon
     // store persists across jobs: a co-resident job can retag a mutable
@@ -1204,13 +1231,16 @@ describe('release lane runner routing', () => {
   });
 
   it('passes the runner environment to integration test configuration', () => {
-    for (const name of ['integration_none', 'integration_docker']) {
+    for (const [name, expectedSteps] of [
+      ['integration_none', 2],
+      ['integration_docker', 1],
+    ]) {
       const job = releaseYaml.jobs[name];
       expect(job.env.RUNNER_ENVIRONMENT, name).toBeUndefined();
       const testSteps = job.steps.filter((step) =>
         /(?:vitest|test:integration)/.test(String(step.run ?? '')),
       );
-      expect(testSteps, name).toHaveLength(2);
+      expect(testSteps, name).toHaveLength(expectedSteps);
       for (const step of testSteps) {
         expect(step.env.RUNNER_ENVIRONMENT, `${name}: ${step.name}`).toBe(
           '${{ runner.environment }}',


### PR DESCRIPTION
## What this PR does

This PR coordinates Docker sandbox preparation and execution across the logical self-hosted runners that share one physical ECS Docker daemon, without reducing the three-way E2E shard concurrency.

- Self-hosted lanes no longer create one Buildx builder per shard. GitHub-hosted fallback lanes retain the existing setup.
- E2E and release validation use commit-qualified local image tags and pin the test process to the resulting immutable image ID.
- A per-workflow, per-commit coordinator deduplicates image builds. A host-wide reader/writer lock gives builds and age-based cleanup exclusive daemon access while allowing all Docker test shards to hold shared access concurrently.
- Image inspection, optional build/retry, image-ID capture, and the Docker tests now run in one shell step, so there is no unlocked gap where another workflow can retag or prune the selected image.
- The sandbox builder can skip its immediate daemon-wide prune; shared-host workflows use labeled, age-bounded cleanup while holding the exclusive daemon lock instead.
- Release Docker validation participates in the same protocol, closing the other repository-owned build/prune path on the ECS pool.

## Why it's needed

The failing job is [E2E Test (Linux) - sandbox:docker - shard 3/3 in run 33351032808](https://github.com/QwenLM/qwen-code/actions/runs/33351032808/job/99364302226). Its fixed-session route test returned HTTP 500 three times over 30.3 seconds; that timing is consistent with three 10-second ACP channel initialization timeouts, while the same commit's non-Docker shard passed the case.

The three Docker shards ran as separate logical runners on the same physical ECS host and independently created Buildx builders and built the same mutable sandbox tag. A sibling shard logged a Docker API `context deadline exceeded` while Buildx inspected its builder container, and all three builds later unpacked/retagged the image at the same time. That shared-daemon build pressure is the concrete difference from the passing non-Docker path. Raising test timeouts or reducing the matrix would hide the symptom; it would not remove the competing builders, mutable tag, or global prune race.

The new lock protocol separates coordination from execution: same-commit shards briefly serialize only the image check/build, then retain shared daemon access while their tests run concurrently. A different commit or release build polls for exclusive access without queueing ahead of same-commit readers, so it cannot build or prune until active Docker tests finish.

## Reviewer Test Plan

### How to verify

1. Run the focused workflow contract tests and expect 39 passing tests with the single existing skip. They pin the self-hosted Buildx exclusion, commit-qualified tags, bounded retry, immutable image ID, coordinator and daemon lock modes, uninterrupted lock lifetime, release participation, and unchanged matrix parallelism.
2. Run the runner-routing contract and expect all 23 tests to pass. The cleanup remains self-hosted and Docker-only, and tagged deletion is restricted to workflow-labeled images older than 24 hours.
3. Inspect the first live ECS E2E run after merge. Expect only one build for a commit on each physical host, sibling shards to log image reuse, all three Docker Vitest shards to overlap in time, and no self-hosted Buildx setup step.
4. In a release validation overlapping an E2E run, expect the later image build to wait for the active shared test locks rather than building or pruning concurrently.

### Evidence (Before & After)

Before: the linked failing run launched three independent Buildx setup/build paths against one daemon and one mutable tag; the Docker shard's route test ended in repeated 500 responses after approximately 10 seconds per attempt.

After: local workflow contracts, runner-routing contracts, formatting, JavaScript syntax, extracted shell syntax, E2E workflow actionlint, and diff checks pass. Live shared-ECS behavior requires the first post-merge workflow run.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local workflow parsing and contract tests with the repository's existing dependencies; no local access to the shared ECS Docker daemon.

## Risk & Scope

- Main risk or tradeoff: image writers use a reader-favoring, bounded 30-minute acquisition loop so same-commit shards can join the shared test lock; sustained Docker test traffic can delay a new image build, which then fails with an explicit lock-timeout error instead of contending with active tests.
- Not validated / out of scope: the exact HTTP 500 response body was not captured by the failed test, so the ACP initialization timeout attribution is based on the three 10-second attempts plus the shared-Docker evidence. The first live ECS run is required to confirm the operational behavior. Workflows that only consume an existing container image and do not build or prune it are unchanged.
- Breaking changes / migration notes: none. GitHub-hosted fallback behavior remains available, and the Linux E2E matrix still has three Docker shards.

## Linked Issues

Fixes #10595

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 对同一台物理 ECS 上多个逻辑 self-hosted runner 共享 Docker daemon 的 sandbox 镜像准备与测试执行进行协调，同时保留现有的三个 E2E shard 并发。

- Self-hosted 通道不再让每个 shard 各自创建 Buildx builder；GitHub-hosted fallback 仍保留原有 setup。
- E2E 与 release 验证使用包含 commit 的本地镜像 tag，并让测试进程固定使用最终得到的不可变 image ID。
- 按 workflow 类型和 commit 划分的 coordinator 负责对同一镜像去重构建；宿主级读写锁让构建与按年龄清理独占 daemon，同时允许所有 Docker 测试 shard 并发持有共享锁。
- 镜像检查、必要的构建/重试、image ID 获取和 Docker 测试现在位于同一个 shell step 中，避免另一个 workflow 在中间的无锁窗口重打 tag 或删除已选镜像。
- Sandbox 构建器可以跳过构建结束后的 daemon 全局 prune；共享宿主 workflow 改为在持有 daemon 独占锁时，仅清理带 workflow 标签且超过保留时间的镜像。
- Release Docker 验证也使用同一协议，从而覆盖 ECS pool 中另一个由本仓库控制的镜像构建与 prune 路径。

## 为什么需要

失败任务是 [run 33351032808 中的 E2E Test (Linux) - sandbox:docker - shard 3/3](https://github.com/QwenLM/qwen-code/actions/runs/33351032808/job/99364302226)。其中固定 session 的 route 测试重试三次后仍返回 HTTP 500，总耗时 30.3 秒；这个时长与三次 10 秒 ACP channel initialize timeout 一致，而同一 commit 的非 Docker shard 可以通过该用例。

三个 Docker shard 以不同逻辑 runner 的身份运行在同一台物理 ECS 上，各自创建 Buildx builder，并同时构建同一个可变 sandbox tag。相邻 shard 的日志在 Buildx 检查 builder container 时直接出现 Docker API `context deadline exceeded`，随后三个构建又在同一时间解包并重打该镜像 tag。共享 daemon 上的构建压力是它与正常通过的非 Docker 路径之间的确定差异。单纯提高测试超时或降低 matrix 并发只会掩盖症状，无法消除多个 builder、可变 tag 和全局 prune 竞态。

新的锁协议将协调与执行分开：同一 commit 的 shard 只在镜像检查/构建阶段短暂串行，随后在测试期间并发持有 daemon 共享锁。不同 commit 或 release 的构建以不进入 writer 等待队列的方式轮询独占锁，因此不会排在同 commit reader 前面，也不能在 Docker 测试运行期间构建或 prune。

## 评审者测试计划

### 如何验证

1. 运行聚焦的 workflow 契约测试，预期 39 个测试通过，保留 1 个既有 skip。测试固定了 self-hosted 不运行 Buildx、commit 专属 tag、有界重试、不可变 image ID、coordinator/daemon 锁模式、连续锁生命周期、release 接入和 matrix 并发不变。
2. 运行 runner routing 契约，预期 23 个测试全部通过。清理步骤仍只在 self-hosted Docker 通道运行，带 tag 的删除仅作用于超过 24 小时的 workflow 标签镜像。
3. 合入后检查第一轮 ECS E2E：预期每台物理宿主对同一 commit 只构建一次，其他 shard 输出复用镜像，三个 Docker Vitest shard 的运行时间互相重叠，并且 self-hosted 不再执行 Buildx setup。
4. 当 release 验证与 E2E 重叠时，预期后到的镜像构建等待正在运行的共享测试锁，而不是与测试并发 build 或 prune。

### 证据（修复前/后）

修复前：链接中的失败 run 在同一个 daemon 和同一个可变 tag 上启动了三套独立的 Buildx setup/build；Docker shard 的 route 测试每次约 10 秒后返回 500，重试后仍失败。

修复后：本地 workflow 契约、runner routing 契约、格式检查、JavaScript 语法、抽取出的 shell 语法、E2E workflow actionlint 和 diff 检查均通过。共享 ECS 上的真实行为需要通过合入后的第一轮 workflow 确认。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

使用仓库已有依赖在本地完成 workflow 解析与契约测试；本地无法访问共享 ECS Docker daemon。

## 风险与范围

- 主要风险或权衡：镜像 writer 使用偏向 reader、最长 30 分钟的轮询获取方式，让同 commit shard 可以继续加入共享测试锁；如果 Docker 测试持续占用 daemon，新镜像构建可能延迟，超时后会给出明确的锁错误，而不是与活跃测试竞争资源。
- 未验证 / 超出范围：失败测试没有记录 HTTP 500 的响应 body，因此 ACP initialize timeout 的判断来自三次 10 秒尝试与共享 Docker 证据。实际运行效果需要第一轮 ECS workflow 验证。只消费已有容器镜像、不执行 build 或 prune 的 workflow 未做改动。
- 破坏性变更 / 迁移说明：无。GitHub-hosted fallback 仍可用，Linux E2E matrix 仍保留三个 Docker shard。

## 关联 Issue

Fixes #10595

</details>
