### PR TITLE
feat(channels): Improve fallback permission and error messages

### DIFF
--- a/docs/users/features/channels/dingtalk.md
+++ b/docs/users/features/channels/dingtalk.md
@@ -219,6 +219,6 @@ The multi-line layout above is what the agent sees in a 1:1 chat. In a group the
 
 This means DingTalk didn't include a reply endpoint in the message callback. This can happen if the bot's permissions are misconfigured. Check the bot's settings in the Developer Portal.
 
-### "Sorry, something went wrong processing your message"
+### "Unable to process this message"
 
-This usually means the agent encountered an error. Check the terminal output for details.
+The reply identifies the failure category and suggests a next step. If the problem continues, give the bot administrator the reference shown in the reply; the same reference appears beside the detailed error in the channel process log.

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -1197,8 +1197,8 @@ describe('ChannelBase', () => {
           kind: 'allow_always',
           name: 'Always Allow in project',
         },
-        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow once' },
-        { optionId: 'cancel', kind: 'reject_once', name: 'Deny' },
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'cancel', kind: 'reject_once', name: 'Reject' },
       ],
     ): void {
       (bridge as unknown as EventEmitter).emit('permissionRequest', {
@@ -1225,7 +1225,7 @@ describe('ChannelBase', () => {
           toolCall: {
             toolCallId: `tool-${requestId}`,
             kind: 'other',
-            title: 'AskUserQuestion: Ask user 1 question',
+            title: 'Ask user 1 question',
             rawInput: {
               questions: [
                 {
@@ -1457,7 +1457,7 @@ describe('ChannelBase', () => {
           toolCall: {
             toolCallId: 'tool-question',
             kind: 'other',
-            title: 'AskUserQuestion: Ask user 2 questions',
+            title: 'Ask user 2 questions',
             rawInput: { questions: [{ question: 'stale legacy question' }] },
             _meta: {
               toolName: 'ask_user_question',
@@ -1830,9 +1830,7 @@ describe('ChannelBase', () => {
       expect(ch.userInputPresentations).toHaveLength(1);
       expect(ch.sent[0]!.text).toContain('Permission required to run a tool');
       expect(ch.sent[0]!.text).toContain('Tool: ask_user_question');
-      expect(ch.sent[0]!.text).toContain(
-        'Action: AskUserQuestion: Ask user 1 question',
-      );
+      expect(ch.sent[0]!.text).toContain('Action: Ask user 1 question');
       expect(ch.sent[0]!.text).toContain('Parameters: questions (1 item)');
       expect(respondToPermissionMock()).not.toHaveBeenCalled();
 
@@ -2135,11 +2133,11 @@ describe('ChannelBase', () => {
       expect(ch.sent.at(-1)?.text).toContain('Tool: run_shell_command');
       expect(ch.sent.at(-1)?.text).toContain('Action: Run req-1');
       expect(ch.sent.at(-1)?.text).toContain('Parameters: command');
-      expect(ch.sent.at(-1)?.text).toContain('/approve        Allow once');
+      expect(ch.sent.at(-1)?.text).toContain('/approve        Allow');
       expect(ch.sent.at(-1)?.text).toContain(
         '/approve-always Always Allow in project',
       );
-      expect(ch.sent.at(-1)?.text).toContain('/deny           Deny');
+      expect(ch.sent.at(-1)?.text).toContain('/deny           Reject');
       expect(ch.sent.at(-1)?.text).not.toContain('Request: req-1');
       expect(ch.sent.at(-1)?.text).not.toContain('proceed_once');
       expect(ch.sent.at(-1)?.text).not.toContain('secret-token');
@@ -2150,6 +2148,46 @@ describe('ChannelBase', () => {
         outcome: { outcome: 'selected', optionId: 'proceed_once' },
       });
       expect(ch.sent.at(-1)?.text).toBe('Permission approved.');
+    });
+
+    it('uses stable fallbacks when permission labels sanitize to empty', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      (bridge as unknown as EventEmitter).emit('permissionRequest', {
+        requestId: 'req-empty-labels',
+        sessionId,
+        request: {
+          toolCall: {
+            toolCallId: 'tool-empty-labels',
+            kind: 'shell',
+            title: 42,
+            rawInput: { '\u0000\n[]': true },
+            _meta: { toolName: '\u0000\n' },
+          },
+          options: [
+            {
+              optionId: 'proceed_once',
+              kind: 'allow_once',
+              name: { trim: true },
+            },
+            {
+              optionId: 'cancel',
+              kind: 'reject_once',
+              name: '\u0000\n',
+            },
+          ],
+        },
+      });
+
+      expect(ch.sent.at(-1)?.text).toContain('Tool: shell');
+      expect(ch.sent.at(-1)?.text).toContain('Action: Tool use');
+      expect(ch.sent.at(-1)?.text).toContain('Parameters: unknown');
+      expect(ch.sent.at(-1)?.text).toContain('/approve        allow once');
+      expect(ch.sent.at(-1)?.text).toContain('/deny           deny');
+
+      emitPermission(sessionId, 'req-other');
+      await ch.handleInbound(envelope({ text: '/approve' }));
+      expect(ch.sent.at(-1)?.text).toContain('- req-empty-labels: Tool use');
     });
 
     it('cancels bridge permissions when the target no longer belongs to the channel', async () => {

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -1210,6 +1210,7 @@ describe('ChannelBase', () => {
             kind: 'shell',
             title: `Run ${requestId}`,
             rawInput: { command: 'echo secret-token' },
+            _meta: { toolName: 'run_shell_command' },
           },
           options,
         },
@@ -1828,6 +1829,11 @@ describe('ChannelBase', () => {
       await vi.waitFor(() => expect(ch.sent).toHaveLength(1));
       expect(ch.userInputPresentations).toHaveLength(1);
       expect(ch.sent[0]!.text).toContain('Permission required to run a tool');
+      expect(ch.sent[0]!.text).toContain('Tool: ask_user_question');
+      expect(ch.sent[0]!.text).toContain(
+        'Action: AskUserQuestion: Ask user 1 question',
+      );
+      expect(ch.sent[0]!.text).toContain('Parameters: questions (1 item)');
       expect(respondToPermissionMock()).not.toHaveBeenCalled();
 
       await active.finish();
@@ -2126,11 +2132,14 @@ describe('ChannelBase', () => {
       expect(ch.sent.at(-1)?.text).toContain(
         'Permission required to run a tool',
       );
-      expect(ch.sent.at(-1)?.text).toContain('Command:');
-      expect(ch.sent.at(-1)?.text).toContain('Run req-1');
-      expect(ch.sent.at(-1)?.text).toContain('/approve        allow once');
-      expect(ch.sent.at(-1)?.text).toContain('/approve-always always allow');
-      expect(ch.sent.at(-1)?.text).toContain('/deny           deny');
+      expect(ch.sent.at(-1)?.text).toContain('Tool: run_shell_command');
+      expect(ch.sent.at(-1)?.text).toContain('Action: Run req-1');
+      expect(ch.sent.at(-1)?.text).toContain('Parameters: command');
+      expect(ch.sent.at(-1)?.text).toContain('/approve        Allow once');
+      expect(ch.sent.at(-1)?.text).toContain(
+        '/approve-always Always Allow in project',
+      );
+      expect(ch.sent.at(-1)?.text).toContain('/deny           Deny');
       expect(ch.sent.at(-1)?.text).not.toContain('Request: req-1');
       expect(ch.sent.at(-1)?.text).not.toContain('proceed_once');
       expect(ch.sent.at(-1)?.text).not.toContain('secret-token');
@@ -2565,7 +2574,7 @@ describe('ChannelBase', () => {
       ]);
 
       expect(ch.sent.at(-1)?.text).toContain(
-        '/approve-always always allow for this project',
+        '/approve-always Always Allow in project',
       );
 
       await ch.handleInbound(envelope({ text: '/approve-always req-1' }));
@@ -2589,7 +2598,7 @@ describe('ChannelBase', () => {
       ]);
 
       expect(ch.sent.at(-1)?.text).toContain(
-        '/approve-always always allow for this user',
+        '/approve-always Always Allow for user',
       );
 
       await ch.handleInbound(envelope({ text: '/approve-always req-1' }));
@@ -2617,7 +2626,7 @@ describe('ChannelBase', () => {
       ]);
 
       expect(ch.sent.at(-1)?.text).toContain(
-        '/approve-always always allow for this user',
+        '/approve-always Always Allow for user',
       );
 
       await ch.handleInbound(envelope({ text: '/approve-always req-1' }));
@@ -3748,7 +3757,7 @@ describe('ChannelBase', () => {
           },
         });
         expect(ch.sent[0]!.text).toBe(
-          '[review] Permission required to run a tool\nRequest: req-123\n\nCommand:\nRun tests\n\nReply with:\n/approve req-123          allow once\n/approve-always req-123   always allow for this project\n/deny req-123             deny',
+          '[review] Permission required to run a tool\nRequest: req-123\n\nTool: unknown\nAction: Run tests\n\nReply with:\n/approve req-123          Allow once\n/approve-always req-123   Always\n/deny req-123             Deny',
         );
 
         ch.sent = [];

--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -2190,6 +2190,48 @@ describe('ChannelBase', () => {
       expect(ch.sent.at(-1)?.text).toContain('- req-empty-labels: Tool use');
     });
 
+    it('summarizes permission parameters with shape markers and overflow', async () => {
+      const ch = createChannel();
+      const sessionId = await startSession(ch);
+      const emitParams = (requestId: string, rawInput: unknown): void => {
+        (bridge as unknown as EventEmitter).emit('permissionRequest', {
+          requestId,
+          sessionId,
+          request: {
+            toolCall: {
+              toolCallId: `tool-${requestId}`,
+              kind: 'shell',
+              title: `Run ${requestId}`,
+              rawInput,
+              _meta: { toolName: 'run_shell_command' },
+            },
+            options: [
+              { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+              { optionId: 'cancel', kind: 'reject_once', name: 'Reject' },
+            ],
+          },
+        });
+      };
+
+      emitParams('req-params-mixed', {
+        config: { strict: true },
+        tags: ['alpha', 'beta'],
+        first: 1,
+        second: 2,
+        third: 3,
+      });
+      expect(ch.sent.at(-1)?.text).toContain(
+        'Parameters: config (object), tags (2 items), first, second, +1 more',
+      );
+
+      emitParams('req-params-short', { command: 'ls', timeout: 30 });
+      expect(ch.sent.at(-1)?.text).toContain('Parameters: command, timeout');
+      expect(ch.sent.at(-1)?.text).not.toContain('more');
+
+      emitParams('req-params-empty', {});
+      expect(ch.sent.at(-1)?.text).not.toContain('Parameters:');
+    });
+
     it('cancels bridge permissions when the target no longer belongs to the channel', async () => {
       const router = {
         getTarget: vi.fn(() => ({

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -2850,48 +2850,40 @@ export abstract class ChannelBase {
 
   private formatPermissionRequest(pending: PendingPermission): string {
     const { toolCall } = pending.request;
-    const title = this.permissionTitle(toolCall);
-    const toolName = this.permissionToolName(toolCall);
     const parameters = this.permissionParameterSummary(toolCall);
-    const approveOption = this.approvalOption(pending);
+    const approveLabel = this.permissionOptionLabel(
+      this.approvalOption(pending),
+      'allow once',
+    );
     const alwaysOption = this.approvalAlwaysOption(pending);
-    const denyOption = this.denialOption(pending);
-    if (pending.taskName) {
-      const replies = [
-        `/approve ${pending.requestId}          ${this.permissionOptionLabel(approveOption, 'allow once')}`,
-        ...(alwaysOption
-          ? [`/approve-always ${pending.requestId}   ${alwaysOption.label}`]
-          : []),
-        `/deny ${pending.requestId}             ${this.permissionOptionLabel(denyOption, 'deny')}`,
-      ];
-      return [
-        'Permission required to run a tool',
-        `Request: ${pending.requestId}`,
-        '',
-        `Tool: ${toolName}`,
-        `Action: ${title}`,
-        ...(parameters ? [`Parameters: ${parameters}`] : []),
-        '',
-        'Reply with:',
-        ...replies,
-      ].join('\n');
-    }
+    const denyLabel = this.permissionOptionLabel(
+      this.denialOption(pending),
+      'deny',
+    );
+    const requestSuffix = pending.taskName ? ` ${pending.requestId}` : '';
+    const replyPadding = pending.taskName
+      ? { approve: '          ', always: '   ', deny: '             ' }
+      : { approve: '        ', always: ' ', deny: '           ' };
     const replies = [
-      `/approve        ${this.permissionOptionLabel(approveOption, 'allow once')}`,
-      ...(alwaysOption ? [`/approve-always ${alwaysOption.label}`] : []),
-      `/deny           ${this.permissionOptionLabel(denyOption, 'deny')}`,
+      `/approve${requestSuffix}${replyPadding.approve}${approveLabel}`,
+      ...(alwaysOption
+        ? [
+            `/approve-always${requestSuffix}${replyPadding.always}${alwaysOption.label}`,
+          ]
+        : []),
+      `/deny${requestSuffix}${replyPadding.deny}${denyLabel}`,
     ];
-    const lines = [
+    return [
       'Permission required to run a tool',
+      ...(pending.taskName ? [`Request: ${pending.requestId}`] : []),
       '',
-      `Tool: ${toolName}`,
-      `Action: ${title}`,
+      `Tool: ${this.permissionToolName(toolCall)}`,
+      `Action: ${this.permissionTitle(toolCall)}`,
       ...(parameters ? [`Parameters: ${parameters}`] : []),
       '',
       'Reply with:',
       ...replies,
-    ];
-    return lines.join('\n');
+    ].join('\n');
   }
 
   private permissionTitle(

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -2851,36 +2851,42 @@ export abstract class ChannelBase {
   private formatPermissionRequest(pending: PendingPermission): string {
     const { toolCall } = pending.request;
     const title = sanitizeQuotedText(toolCall.title || 'Tool use', 160);
+    const toolName = this.permissionToolName(toolCall);
+    const parameters = this.permissionParameterSummary(toolCall);
+    const approveOption = this.approvalOption(pending);
     const alwaysOption = this.approvalAlwaysOption(pending);
+    const denyOption = this.denialOption(pending);
     if (pending.taskName) {
       const replies = [
-        `/approve ${pending.requestId}          allow once`,
+        `/approve ${pending.requestId}          ${this.permissionOptionLabel(approveOption, 'allow once')}`,
         ...(alwaysOption
           ? [`/approve-always ${pending.requestId}   ${alwaysOption.label}`]
           : []),
-        `/deny ${pending.requestId}             deny`,
+        `/deny ${pending.requestId}             ${this.permissionOptionLabel(denyOption, 'deny')}`,
       ];
       return [
         'Permission required to run a tool',
         `Request: ${pending.requestId}`,
         '',
-        'Command:',
-        title,
+        `Tool: ${toolName}`,
+        `Action: ${title}`,
+        ...(parameters ? [`Parameters: ${parameters}`] : []),
         '',
         'Reply with:',
         ...replies,
       ].join('\n');
     }
     const replies = [
-      '/approve        allow once',
+      `/approve        ${this.permissionOptionLabel(approveOption, 'allow once')}`,
       ...(alwaysOption ? [`/approve-always ${alwaysOption.label}`] : []),
-      '/deny           deny',
+      `/deny           ${this.permissionOptionLabel(denyOption, 'deny')}`,
     ];
     const lines = [
       'Permission required to run a tool',
       '',
-      'Command:',
-      title,
+      `Tool: ${toolName}`,
+      `Action: ${title}`,
+      ...(parameters ? [`Parameters: ${parameters}`] : []),
       '',
       'Reply with:',
       ...replies,
@@ -2888,16 +2894,72 @@ export abstract class ChannelBase {
     return lines.join('\n');
   }
 
-  private approvalOptionId(pending: PendingPermission): string | undefined {
+  private permissionToolName(
+    toolCall: PermissionRequestEvent['request']['toolCall'],
+  ): string {
+    const rawToolCall = toolCall as unknown as Record<string, unknown>;
+    const meta = isRecord(rawToolCall['_meta'])
+      ? rawToolCall['_meta']
+      : undefined;
+    const name =
+      typeof meta?.['toolName'] === 'string'
+        ? meta['toolName']
+        : typeof rawToolCall['kind'] === 'string'
+          ? rawToolCall['kind']
+          : 'unknown';
+    return sanitizeQuotedText(name, 120);
+  }
+
+  private permissionParameterSummary(
+    toolCall: PermissionRequestEvent['request']['toolCall'],
+  ): string | undefined {
+    const rawToolCall = toolCall as unknown as Record<string, unknown>;
+    const rawInput = isRecord(rawToolCall['rawInput'])
+      ? rawToolCall['rawInput']
+      : undefined;
+    if (!rawInput) return undefined;
+
+    const entries = Object.entries(rawInput);
+    if (entries.length === 0) return undefined;
+    const visible = entries.slice(0, 4).map(([key, value]) => {
+      const safeKey = sanitizeQuotedText(key, 48);
+      if (Array.isArray(value)) {
+        return `${safeKey} (${value.length} ${value.length === 1 ? 'item' : 'items'})`;
+      }
+      if (isRecord(value)) {
+        return `${safeKey} (object)`;
+      }
+      return safeKey;
+    });
+    if (entries.length > visible.length) {
+      visible.push(`+${entries.length - visible.length} more`);
+    }
+    return visible.join(', ');
+  }
+
+  private permissionOptionLabel(
+    option: PermissionOption | undefined,
+    fallback: string,
+  ): string {
+    return sanitizeQuotedText(option?.name?.trim() || fallback, 160);
+  }
+
+  private approvalOption(
+    pending: PendingPermission,
+  ): PermissionOption | undefined {
     const options = pending.request.options;
     return (
-      options.find((option) => option.kind === 'allow_once')?.optionId ??
+      options.find((option) => option.kind === 'allow_once') ??
       options.find(
         (option) =>
           option.optionId === 'proceed_once' &&
           (option as { kind?: string }).kind === undefined,
-      )?.optionId
+      )
     );
+  }
+
+  private approvalOptionId(pending: PendingPermission): string | undefined {
+    return this.approvalOption(pending)?.optionId;
   }
 
   private approvalAlwaysOption(
@@ -2915,7 +2977,10 @@ export abstract class ChannelBase {
     }
     return {
       optionId: option.optionId,
-      label: this.approvalAlwaysLabel(option),
+      label: this.permissionOptionLabel(
+        option,
+        this.approvalAlwaysLabel(option),
+      ),
     };
   }
 
@@ -2943,7 +3008,17 @@ export abstract class ChannelBase {
       | { outcome: 'selected'; optionId: string }
       | { outcome: 'cancelled' };
   } {
-    const option =
+    const option = this.denialOption(pending);
+    if (option) {
+      return { outcome: { outcome: 'selected', optionId: option.optionId } };
+    }
+    return { outcome: { outcome: 'cancelled' } };
+  }
+
+  private denialOption(
+    pending: PendingPermission,
+  ): PermissionOption | undefined {
+    return (
       pending.request.options.find(
         (candidate) => candidate.kind === 'reject_once',
       ) ??
@@ -2951,11 +3026,8 @@ export abstract class ChannelBase {
         (candidate) =>
           candidate.optionId === 'cancel' &&
           (candidate as { kind?: string }).kind === undefined,
-      );
-    if (option) {
-      return { outcome: { outcome: 'selected', optionId: option.optionId } };
-    }
-    return { outcome: { outcome: 'cancelled' } };
+      )
+    );
   }
 
   private async handlePermissionResponseCommand(

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -2850,7 +2850,7 @@ export abstract class ChannelBase {
 
   private formatPermissionRequest(pending: PendingPermission): string {
     const { toolCall } = pending.request;
-    const title = sanitizeQuotedText(toolCall.title || 'Tool use', 160);
+    const title = this.permissionTitle(toolCall);
     const toolName = this.permissionToolName(toolCall);
     const parameters = this.permissionParameterSummary(toolCall);
     const approveOption = this.approvalOption(pending);
@@ -2894,6 +2894,14 @@ export abstract class ChannelBase {
     return lines.join('\n');
   }
 
+  private permissionTitle(
+    toolCall: PermissionRequestEvent['request']['toolCall'],
+  ): string {
+    const rawTitle =
+      typeof toolCall.title === 'string' ? toolCall.title : undefined;
+    return sanitizeQuotedText(rawTitle || '', 160).trim() || 'Tool use';
+  }
+
   private permissionToolName(
     toolCall: PermissionRequestEvent['request']['toolCall'],
   ): string {
@@ -2901,13 +2909,12 @@ export abstract class ChannelBase {
     const meta = isRecord(rawToolCall['_meta'])
       ? rawToolCall['_meta']
       : undefined;
-    const name =
-      typeof meta?.['toolName'] === 'string'
-        ? meta['toolName']
-        : typeof rawToolCall['kind'] === 'string'
-          ? rawToolCall['kind']
-          : 'unknown';
-    return sanitizeQuotedText(name, 120);
+    for (const candidate of [meta?.['toolName'], rawToolCall['kind']]) {
+      if (typeof candidate !== 'string') continue;
+      const name = sanitizeQuotedText(candidate, 120).trim();
+      if (name) return name;
+    }
+    return 'unknown';
   }
 
   private permissionParameterSummary(
@@ -2922,7 +2929,7 @@ export abstract class ChannelBase {
     const entries = Object.entries(rawInput);
     if (entries.length === 0) return undefined;
     const visible = entries.slice(0, 4).map(([key, value]) => {
-      const safeKey = sanitizeQuotedText(key, 48);
+      const safeKey = sanitizeQuotedText(key, 48).trim() || 'unknown';
       if (Array.isArray(value)) {
         return `${safeKey} (${value.length} ${value.length === 1 ? 'item' : 'items'})`;
       }
@@ -2941,7 +2948,9 @@ export abstract class ChannelBase {
     option: PermissionOption | undefined,
     fallback: string,
   ): string {
-    return sanitizeQuotedText(option?.name?.trim() || fallback, 160);
+    const rawLabel = typeof option?.name === 'string' ? option.name : '';
+    const label = sanitizeQuotedText(rawLabel, 160).trim();
+    return label || fallback;
   }
 
   private approvalOption(
@@ -3050,7 +3059,7 @@ export abstract class ChannelBase {
         .map((id) => {
           const pending = this.pendingPermissions.get(id);
           const title = pending
-            ? `: ${sanitizeQuotedText(pending.request.toolCall.title || 'Tool use', 160)}`
+            ? `: ${this.permissionTitle(pending.request.toolCall)}`
             : '';
           const task = pending?.taskName ? `Task ${pending.taskName} — ` : '';
           return `- ${task}${sanitizeQuotedText(id, 128)}${title}`;

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -2473,7 +2473,7 @@ describe('DingtalkChannel parsed-message logging', () => {
       expect(reference).toBeDefined();
       expect(body.markdown.text).toBe(
         '\\[review\\]\n\n**Unable to process this message**\n\n' +
-          '**Status:** Agent is temporarily unavailable\n' +
+          '**Status:** Service is temporarily unavailable\n' +
           '**Next step:** Try again in a moment. If it keeps failing, contact the bot administrator.\n' +
           `**Reference:** \`${reference}\``,
       );
@@ -2491,12 +2491,14 @@ describe('DingtalkChannel parsed-message logging', () => {
     {
       name: 'configuration failures',
       error: Object.assign(new Error('request rejected'), { status: 401 }),
+      rawDetail: 'request rejected',
       status: 'Bot configuration error',
       nextStep: 'Contact the bot administrator.',
     },
     {
       name: 'cancelled requests',
       error: new Error('request aborted'),
+      rawDetail: 'request aborted',
       status: 'Request was cancelled',
       nextStep: 'Send the request again if you still need it.',
     },
@@ -2505,6 +2507,7 @@ describe('DingtalkChannel parsed-message logging', () => {
       error: Object.assign(new Error('request aborted after timeout'), {
         status: 504,
       }),
+      rawDetail: 'request aborted after timeout',
       status: 'Request timed out',
       nextStep: 'Try again. For a large request, split it into smaller parts.',
     },
@@ -2513,12 +2516,29 @@ describe('DingtalkChannel parsed-message logging', () => {
       error: Object.assign(new Error('request failed'), {
         body: 'overloaded',
       }),
-      status: 'Agent is busy',
+      rawDetail: 'overloaded',
+      status: 'Service is busy',
       nextStep: 'Try again in a moment.',
     },
     {
       name: 'unexpected failures',
       error: new Error('provider failed with secret-marker'),
+      rawDetail: 'secret-marker',
+      status: 'Processing failed',
+      nextStep:
+        'Try again. If it keeps failing, contact the bot administrator.',
+    },
+    {
+      name: 'opaque rejections',
+      error: new Proxy(
+        {},
+        {
+          get() {
+            throw new Error('getter secret-marker');
+          },
+        },
+      ),
+      rawDetail: 'secret-marker',
       status: 'Processing failed',
       nextStep:
         'Try again. If it keeps failing, contact the bot administrator.',
@@ -2560,7 +2580,7 @@ describe('DingtalkChannel parsed-message logging', () => {
       expect(body.markdown.text).toContain(
         `**Status:** ${testCase.status}\n**Next step:** ${testCase.nextStep}`,
       );
-      expect(body.markdown.text).not.toContain(testCase.error.message);
+      expect(body.markdown.text).not.toContain(testCase.rawDetail);
       expect(body.markdown.text).toMatch(/\*\*Reference:\*\* `[0-9a-f]{8}`$/);
     } finally {
       stderrSpy.mockRestore();

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -2543,6 +2543,93 @@ describe('DingtalkChannel parsed-message logging', () => {
       nextStep:
         'Try again. If it keeps failing, contact the bot administrator.',
     },
+    {
+      name: 'authentication keyword failures',
+      error: new Error('authentication failed'),
+      rawDetail: 'authentication failed',
+      status: 'Bot configuration error',
+      nextStep: 'Contact the bot administrator.',
+    },
+    {
+      name: 'timeout keyword failures',
+      error: new Error('request timed out'),
+      rawDetail: 'request timed out',
+      status: 'Request timed out',
+      nextStep: 'Try again. For a large request, split it into smaller parts.',
+    },
+    {
+      name: 'connection refused failures',
+      error: new Error('connect ECONNREFUSED 127.0.0.1:443'),
+      rawDetail: '127.0.0.1',
+      status: 'Service is temporarily unavailable',
+      nextStep:
+        'Try again in a moment. If it keeps failing, contact the bot administrator.',
+    },
+    {
+      name: 'connection timeout failures',
+      error: new Error('connect ETIMEDOUT 10.0.0.1:443'),
+      rawDetail: '10.0.0.1',
+      status: 'Service is temporarily unavailable',
+      nextStep:
+        'Try again in a moment. If it keeps failing, contact the bot administrator.',
+    },
+    {
+      name: 'fetch failures',
+      error: new Error('fetch failed'),
+      rawDetail: 'fetch failed',
+      status: 'Service is temporarily unavailable',
+      nextStep:
+        'Try again in a moment. If it keeps failing, contact the bot administrator.',
+    },
+    {
+      name: 'busy keyword failures',
+      error: new Error('too many requests'),
+      rawDetail: 'too many requests',
+      status: 'Service is busy',
+      nextStep: 'Try again in a moment.',
+    },
+    {
+      name: 'string rejections',
+      error: 'rate limit exceeded',
+      rawDetail: 'rate limit exceeded',
+      status: 'Service is busy',
+      nextStep: 'Try again in a moment.',
+    },
+    {
+      name: 'vanished daemon sessions',
+      error: { status: 404, body: { code: 'session_not_found' } },
+      rawDetail: 'session_not_found',
+      status: 'Service is temporarily unavailable',
+      nextStep:
+        'Try again in a moment. If it keeps failing, contact the bot administrator.',
+    },
+    {
+      name: 'bridge session errors',
+      error: Object.assign(new Error('No session with id "sess-1"'), {
+        name: 'SessionNotFoundError',
+        code: 'session_not_found',
+      }),
+      rawDetail: 'sess-1',
+      status: 'Service is temporarily unavailable',
+      nextStep:
+        'Try again in a moment. If it keeps failing, contact the bot administrator.',
+    },
+    {
+      name: 'agent session errors',
+      error: new Error('Session not found: sess-2'),
+      rawDetail: 'sess-2',
+      status: 'Service is temporarily unavailable',
+      nextStep:
+        'Try again in a moment. If it keeps failing, contact the bot administrator.',
+    },
+    {
+      name: 'rejections with non-string messages',
+      error: Object.assign(new Error('x'), { message: Symbol('boom') }),
+      rawDetail: 'boom',
+      status: 'Processing failed',
+      nextStep:
+        'Try again. If it keeps failing, contact the bot administrator.',
+    },
   ])('presents $name without exposing raw details', async (testCase) => {
     const channel = createChannel();
     vi.mocked(channel.handleInbound).mockRejectedValueOnce(testCase.error);

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -2433,7 +2433,7 @@ describe('DingtalkChannel unroutable-message logging', () => {
 describe('DingtalkChannel parsed-message logging', () => {
   it('labels the fallback when a named inbound turn rejects', async () => {
     const channel = createChannel();
-    const error = new Error('agent unavailable');
+    const error = new Error('agent unavailable: secret-token');
     vi.mocked(channel.handleInbound).mockRejectedValueOnce(error);
     Object.assign(channel, { inboundErrorSourceLabelForTest: '[review]' });
     const fetchSpy = vi
@@ -2467,9 +2467,101 @@ describe('DingtalkChannel parsed-message logging', () => {
       const body = JSON.parse(
         String((fetchSpy.mock.calls[0]![1] as RequestInit).body),
       );
+      const reference = body.markdown.text.match(
+        /\*\*Reference:\*\* `([0-9a-f]{8})`/,
+      )?.[1];
+      expect(reference).toBeDefined();
       expect(body.markdown.text).toBe(
-        '\\[review\\]\n\nSorry, something went wrong processing your message.',
+        '\\[review\\]\n\n**Unable to process this message**\n\n' +
+          '**Status:** Agent is temporarily unavailable\n' +
+          '**Next step:** Try again in a moment. If it keeps failing, contact the bot administrator.\n' +
+          `**Reference:** \`${reference}\``,
       );
+      expect(body.markdown.text).not.toContain('secret-token');
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`ref=${reference}`),
+      );
+    } finally {
+      stderrSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    {
+      name: 'configuration failures',
+      error: Object.assign(new Error('request rejected'), { status: 401 }),
+      status: 'Bot configuration error',
+      nextStep: 'Contact the bot administrator.',
+    },
+    {
+      name: 'cancelled requests',
+      error: new Error('request aborted'),
+      status: 'Request was cancelled',
+      nextStep: 'Send the request again if you still need it.',
+    },
+    {
+      name: 'timeouts',
+      error: Object.assign(new Error('request aborted after timeout'), {
+        status: 504,
+      }),
+      status: 'Request timed out',
+      nextStep: 'Try again. For a large request, split it into smaller parts.',
+    },
+    {
+      name: 'busy agents',
+      error: Object.assign(new Error('request failed'), {
+        body: 'overloaded',
+      }),
+      status: 'Agent is busy',
+      nextStep: 'Try again in a moment.',
+    },
+    {
+      name: 'unexpected failures',
+      error: new Error('provider failed with secret-marker'),
+      status: 'Processing failed',
+      nextStep:
+        'Try again. If it keeps failing, contact the bot administrator.',
+    },
+  ])('presents $name without exposing raw details', async (testCase) => {
+    const channel = createChannel();
+    vi.mocked(channel.handleInbound).mockRejectedValueOnce(testCase.error);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    const downstream = {
+      data: JSON.stringify({
+        msgId: 'failed-classified-turn',
+        conversationType: '1',
+        conversationId: 'cid123',
+        sessionWebhook:
+          'https://oapi.dingtalk.com/robot/send?access_token=token',
+        senderNick: 'Alice',
+        senderStaffId: 'staff-1',
+        senderId: 'sender-1',
+        isInAtList: false,
+        text: { content: 'hello' },
+      }),
+      headers: { messageId: 'failed-classified-turn' },
+    } as unknown as DWClientDownStream;
+
+    try {
+      (
+        channel as unknown as { onMessage(d: DWClientDownStream): void }
+      ).onMessage(downstream);
+      await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledOnce());
+
+      const body = JSON.parse(
+        String((fetchSpy.mock.calls[0]![1] as RequestInit).body),
+      );
+      expect(body.markdown.text).toContain(
+        `**Status:** ${testCase.status}\n**Next step:** ${testCase.nextStep}`,
+      );
+      expect(body.markdown.text).not.toContain(testCase.error.message);
+      expect(body.markdown.text).toMatch(/\*\*Reference:\*\* `[0-9a-f]{8}`$/);
     } finally {
       stderrSpy.mockRestore();
       fetchSpy.mockRestore();

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -595,6 +595,107 @@ const PROACTIVE_MSG_KEY = 'sampleMarkdown'; // DingTalk's built-in {title, text}
 const TOKEN_API = 'https://oapi.dingtalk.com/gettoken';
 const PROACTIVE_FETCH_TIMEOUT_MS = 15_000;
 const REPLY_FETCH_TIMEOUT_MS = 15_000;
+
+interface InboundErrorPresentation {
+  status: string;
+  nextStep: string;
+}
+
+function presentInboundError(error: unknown): InboundErrorPresentation {
+  const parts: string[] = [];
+  let status: number | undefined;
+
+  if (error instanceof Error) {
+    parts.push(error.name, error.message);
+  } else if (typeof error === 'string') {
+    parts.push(error);
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const record = error as Record<string, unknown>;
+    if (typeof record['code'] === 'string') parts.push(record['code']);
+    if (typeof record['status'] === 'number') status = record['status'];
+    const body = record['body'];
+    if (typeof body === 'string') {
+      parts.push(body);
+    } else if (typeof body === 'object' && body !== null) {
+      const bodyRecord = body as Record<string, unknown>;
+      for (const key of ['code', 'errorKind', 'message']) {
+        if (typeof bodyRecord[key] === 'string') parts.push(bodyRecord[key]);
+      }
+    }
+  }
+
+  const diagnostic = parts.join(' ').slice(0, 2000).toLowerCase();
+  if (
+    status === 401 ||
+    status === 403 ||
+    /unauthor|forbidden|authentication|credential|invalid.?token/.test(
+      diagnostic,
+    )
+  ) {
+    return {
+      status: 'Bot configuration error',
+      nextStep: 'Contact the bot administrator.',
+    };
+  }
+  if (
+    status === 408 ||
+    status === 504 ||
+    /timeout|timed?\s+out|deadline/.test(diagnostic)
+  ) {
+    return {
+      status: 'Request timed out',
+      nextStep: 'Try again. For a large request, split it into smaller parts.',
+    };
+  }
+  if (/cancel|abort/.test(diagnostic)) {
+    return {
+      status: 'Request was cancelled',
+      nextStep: 'Send the request again if you still need it.',
+    };
+  }
+  if (
+    status === 429 ||
+    /overload|rate.?limit|queue.?full|too many|busy|pending prompts full/.test(
+      diagnostic,
+    )
+  ) {
+    return {
+      status: 'Agent is busy',
+      nextStep: 'Try again in a moment.',
+    };
+  }
+  if (
+    status === 502 ||
+    status === 503 ||
+    /unavailable|econn|enotfound|network|socket|fetch failed|connection|session[_ ](?:not found|closing)|workspace[_ ]draining|transport closed/.test(
+      diagnostic,
+    )
+  ) {
+    return {
+      status: 'Agent is temporarily unavailable',
+      nextStep:
+        'Try again in a moment. If it keeps failing, contact the bot administrator.',
+    };
+  }
+  return {
+    status: 'Processing failed',
+    nextStep: 'Try again. If it keeps failing, contact the bot administrator.',
+  };
+}
+
+function formatInboundErrorMessage(error: unknown, reference: string): string {
+  const presentation = presentInboundError(error);
+  return [
+    '**Unable to process this message**',
+    '',
+    `**Status:** ${presentation.status}`,
+    `**Next step:** ${presentation.nextStep}`,
+    `**Reference:** \`${reference}\``,
+  ].join('\n');
+}
+
 // Extensions for generated media store names, keyed by the download's mime
 // type. The agent reads stored media via `read_file`, whose type detection is
 // extension-first: an extensionless name falls through to the binary content
@@ -2597,21 +2698,23 @@ export class DingtalkChannel extends ChannelBase {
           : this.handleInbound(envelope);
       processMessage.catch((err) => {
         // Don't await — stream callback should return quickly
+        const reference = randomUUID().slice(0, 8);
         process.stderr.write(
-          `[DingTalk:${this.name}] Error handling message: ${err}\n`,
+          `[DingTalk:${this.name}] Error handling message ref=${reference}: ${sanitizeLogText(
+            err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+            300,
+          )}\n`,
         );
+        const fallbackMessage = formatInboundErrorMessage(err, reference);
         const sourceLabel = this.getInboundErrorSourceLabel(envelope);
         const delivery = sourceLabel
           ? this.sendThreadMessage(
               chatId,
               envelope.threadId,
-              'Sorry, something went wrong processing your message.',
+              fallbackMessage,
               sourceLabel,
             )
-          : this.sendMessage(
-              chatId,
-              'Sorry, something went wrong processing your message.',
-            );
+          : this.sendMessage(chatId, fallbackMessage);
         delivery.catch(() => {});
       });
     } catch (err) {

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -605,25 +605,33 @@ function presentInboundError(error: unknown): InboundErrorPresentation {
   const parts: string[] = [];
   let status: number | undefined;
 
-  if (error instanceof Error) {
-    parts.push(error.name, error.message);
-  } else if (typeof error === 'string') {
-    parts.push(error);
-  }
+  try {
+    if (error instanceof Error) {
+      parts.push(error.name, error.message);
+    } else if (typeof error === 'string') {
+      parts.push(error);
+    }
 
-  if (typeof error === 'object' && error !== null) {
-    const record = error as Record<string, unknown>;
-    if (typeof record['code'] === 'string') parts.push(record['code']);
-    if (typeof record['status'] === 'number') status = record['status'];
-    const body = record['body'];
-    if (typeof body === 'string') {
-      parts.push(body);
-    } else if (typeof body === 'object' && body !== null) {
-      const bodyRecord = body as Record<string, unknown>;
-      for (const key of ['code', 'errorKind', 'message']) {
-        if (typeof bodyRecord[key] === 'string') parts.push(bodyRecord[key]);
+    if (typeof error === 'object' && error !== null) {
+      const record = error as Record<string, unknown>;
+      if (typeof record['code'] === 'string') parts.push(record['code']);
+      if (typeof record['status'] === 'number') status = record['status'];
+      const body = record['body'];
+      if (typeof body === 'string') {
+        parts.push(body);
+      } else if (typeof body === 'object' && body !== null) {
+        const bodyRecord = body as Record<string, unknown>;
+        for (const key of ['code', 'errorKind', 'message']) {
+          if (typeof bodyRecord[key] === 'string') parts.push(bodyRecord[key]);
+        }
       }
     }
+  } catch {
+    return {
+      status: 'Processing failed',
+      nextStep:
+        'Try again. If it keeps failing, contact the bot administrator.',
+    };
   }
 
   const diagnostic = parts.join(' ').slice(0, 2000).toLowerCase();
@@ -662,7 +670,7 @@ function presentInboundError(error: unknown): InboundErrorPresentation {
     )
   ) {
     return {
-      status: 'Agent is busy',
+      status: 'Service is busy',
       nextStep: 'Try again in a moment.',
     };
   }
@@ -674,7 +682,7 @@ function presentInboundError(error: unknown): InboundErrorPresentation {
     )
   ) {
     return {
-      status: 'Agent is temporarily unavailable',
+      status: 'Service is temporarily unavailable',
       nextStep:
         'Try again in a moment. If it keeps failing, contact the bot administrator.',
     };
@@ -2699,9 +2707,16 @@ export class DingtalkChannel extends ChannelBase {
       processMessage.catch((err) => {
         // Don't await — stream callback should return quickly
         const reference = randomUUID().slice(0, 8);
+        let errorSummary = 'Unknown error';
+        try {
+          errorSummary =
+            err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+        } catch {
+          // The user-facing fallback below must survive arbitrary rejections.
+        }
         process.stderr.write(
           `[DingTalk:${this.name}] Error handling message ref=${reference}: ${sanitizeLogText(
-            err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+            errorSummary,
             300,
           )}\n`,
         );

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -607,7 +607,8 @@ function presentInboundError(error: unknown): InboundErrorPresentation {
 
   try {
     if (error instanceof Error) {
-      parts.push(error.name, error.message);
+      if (typeof error.name === 'string') parts.push(error.name);
+      if (typeof error.message === 'string') parts.push(error.message);
     } else if (typeof error === 'string') {
       parts.push(error);
     }
@@ -677,7 +678,7 @@ function presentInboundError(error: unknown): InboundErrorPresentation {
   if (
     status === 502 ||
     status === 503 ||
-    /unavailable|econn|enotfound|network|socket|fetch failed|connection|session[_ ](?:not found|closing)|workspace[_ ]draining|transport closed/.test(
+    /unavailable|econn|enotfound|etimedout|network|socket|fetch failed|connection|session[_ ](?:not[ _]found|closing)|workspace[_ ]draining|transport closed/.test(
       diagnostic,
     )
   ) {


### PR DESCRIPTION
## What this PR does

Channel fallback permission prompts now identify the canonical tool, describe the requested action, summarize the parameter shape without exposing values, and use the exact user-facing labels supplied by the permission protocol. Persistent choices therefore show their real project or user scope instead of a generic always-allow label.

DingTalk processing failures now show a clear status, an appropriate next step, and a short reference that also appears beside the detailed process log. Raw exception text remains out of the channel reply so internal paths, provider details, and credentials are not exposed.

## Why it's needed

When a channel cannot present a native interaction card, the existing permission fallback shows only a generic command title. Users cannot tell which tool is requesting approval or what input shape it will receive. DingTalk failures are similarly opaque: the existing reply says only that something went wrong, leaving users without recovery guidance and administrators without a correlation key.

## Reviewer Test Plan

### How to verify

1. Trigger an `ask_user_question` request through a channel fallback and confirm the message shows `Tool: ask_user_question`, the action, and `Parameters: questions (1 item)`.
2. Trigger a shell permission request and confirm the message names `run_shell_command`, lists the `command` parameter without its value, and preserves approve, always-approve, and deny behavior.
3. Cause DingTalk turns to fail with unavailable, busy, timeout, cancellation, configuration, and unexpected errors; confirm each reply shows the expected status and recovery guidance.
4. Confirm each DingTalk failure reply contains an eight-character reference that matches the process log, while raw exception text and a test secret marker remain absent from the reply.
5. Repeat the failure in a named session and confirm its source label remains above the redesigned message.

### Evidence (Before & After)

Permission fallback before:

```text
Permission required to run a tool

Command:
Ask user 1 question

Reply with:
/approve        allow once
/deny           deny
```

Permission fallback after:

```text
Permission required to run a tool

Tool: ask_user_question
Action: Ask user 1 question
Parameters: questions (1 item)

Reply with:
/approve        Submit
/deny           Cancel
```

DingTalk error before:

```text
Sorry, something went wrong processing your message.
```

DingTalk error after:

```text
Unable to process this message

Status: Service is temporarily unavailable
Next step: Try again in a moment. If it keeps failing, contact the bot administrator.
Reference: 8f31c2a7
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js 22 workspace; 228 focused DingTalk tests and 624 focused channel-base tests passed, followed by a full build, full typecheck, and focused lint.

## Risk & Scope

- Main risk or tradeoff: Parameter names are newly visible in permission messages, while DingTalk failures use bounded categorization instead of raw exception text. Parameter names are sanitized and capped, parameter values remain omitted, and unknown failures degrade to a generic processing status.
- Not validated / out of scope: Native interactive-card layouts, raw parameter-value previews, and non-DingTalk error fallbacks are unchanged. A live DingTalk deployment was not available for end-to-end visual verification.
- Breaking changes / migration notes: None. Slash commands, permission option IDs, and DingTalk configuration are unchanged.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

渠道降级审批提示现在会显示规范工具名、说明待执行动作、在不暴露参数值的前提下概括参数结构，并使用权限协议提供的真实用户可见选项文案。因此，持久授权会展示实际的项目级或用户级范围，而不是笼统的“始终允许”。

钉钉消息处理失败时，现在会展示明确的失败状态、对应处理建议以及一个短引用号；该引用号也会出现在详细进程日志中。原始异常文本不会进入渠道回复，避免暴露内部路径、供应商细节或凭据。

## 为什么需要

当渠道无法展示原生交互卡片时，现有审批提示只显示笼统的命令标题，用户无法判断是哪个工具在申请权限，也不了解它将接收什么输入。钉钉错误同样不透明：现有回复只说处理失败，用户不知道如何恢复，管理员也缺少可关联日志的标识。

## Reviewer Test Plan

### 如何验证

1. 通过渠道降级路径触发 `ask_user_question`，确认消息显示 `Tool: ask_user_question`、执行动作以及 `Parameters: questions (1 item)`。
2. 触发 Shell 权限请求，确认消息显示 `run_shell_command`，只列出 `command` 参数名而不展示参数值，并保持单次允许、始终允许和拒绝行为不变。
3. 让钉钉会话分别出现服务不可用、繁忙、超时、取消、配置错误和未知错误，确认回复展示对应状态与恢复建议。
4. 确认每条钉钉错误回复都含八位引用号，且与进程日志一致；原始异常文本和测试敏感串不会进入回复。
5. 在命名会话中重复失败场景，确认来源标签仍显示在新版错误消息上方。

### 前后对比证据

审批提示修改前：

```text
Permission required to run a tool

Command:
Ask user 1 question

Reply with:
/approve        allow once
/deny           deny
```

审批提示修改后：

```text
Permission required to run a tool

Tool: ask_user_question
Action: Ask user 1 question
Parameters: questions (1 item)

Reply with:
/approve        Submit
/deny           Cancel
```

钉钉错误修改前：

```text
Sorry, something went wrong processing your message.
```

钉钉错误修改后：

```text
Unable to process this message

Status: Service is temporarily unavailable
Next step: Try again in a moment. If it keeps failing, contact the bot administrator.
Reference: 8f31c2a7
```

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

Node.js 22 工作区；钉钉聚焦测试 228 项、channel-base 聚焦测试 624 项均通过，随后完成全量构建、全量类型检查和聚焦 lint。

## 风险与范围

- 主要风险或权衡：审批消息会新增展示参数名，钉钉失败则使用受限分类而不展示原始异常。参数名会清理并限制长度，参数值仍不显示，未知错误会降级为通用处理失败状态。
- 未验证或范围外：原生交互卡片布局、原始参数值预览和非钉钉渠道的错误兜底保持不变；当前没有可用的钉钉线上部署进行端到端视觉验证。
- 破坏性变更或迁移说明：无。斜杠命令、权限选项 ID 和钉钉配置均未改变。

## 关联 Issue

无。

</details>
