### PR TITLE
test: harden release timing-sensitive waits

### DIFF
--- a/packages/cli/src/agent-view/supervisor-process.test.ts
+++ b/packages/cli/src/agent-view/supervisor-process.test.ts
@@ -5205,7 +5205,7 @@ async function waitFor(
   predicate: () => boolean,
   subscribe?: (notify: () => void) => void,
 ): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt++) {
+  for (let attempt = 0; attempt < 500; attempt++) {
     if (predicate()) return;
     await new Promise<void>((resolve) => {
       subscribe?.(resolve);

--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -1425,6 +1425,7 @@ describe('MessageList — turn collapse (DOM)', () => {
         await Promise.resolve();
       });
       await nextFrame();
+      await nextFrame();
       expect(has(c, 't1')).toBe(true);
 
       // Page 2 anchors on the now-visible t1 row while the fetch is in flight.
@@ -1445,6 +1446,7 @@ describe('MessageList — turn collapse (DOM)', () => {
         await Promise.resolve();
       });
       await nextFrame();
+      await nextFrame();
       expect(isCollapsed(c, 't1')).toBe(true);
 
       // ...and pagination is not stuck: a third load still fires.
@@ -1464,6 +1466,8 @@ describe('MessageList — turn collapse (DOM)', () => {
         resolveLoad();
         await Promise.resolve();
       });
+      await nextFrame();
+      await nextFrame();
       // ...page 4 then completes that turn's head while its tail is already
       // on screen, so it stays expanded.
       // Re-top the container: re-renders snap it to the bottom while


### PR DESCRIPTION
## What this PR does

This PR hardens the two timing-sensitive unit-test boundaries that blocked the nightly release. Agent View supervisor tests now keep their readiness polling bounded but tolerate shared-runner delays beyond 500 ms, and the Web Shell pagination scenario waits for React's render and anchor-cleanup frames to settle before starting each subsequent page.

## Why it's needed

Nightly release run #33361682601 reached all test gates, but the quality job failed when one supervisor attach response arrived after the test helper's short polling budget and one pagination assertion ran before the previous load's animation-frame cleanup completed. Both integration jobs passed, the same commit's normal CI passed, and the publish job never ran. These waits preserve the existing behavioral assertions while removing assumptions about runner speed and single-frame scheduling.

## Reviewer Test Plan

### How to verify

- Repeat the stopped-session attach recovery scenario under the ECS worker limit. Each run should receive the attach response instead of timing out while the failure path remains bounded.
- Repeat the anchored-turn pagination scenario. Each completed page should settle before the next load, while the explicit collapse, call-count, visibility, and expansion assertions continue to pass.
- Run the surrounding Web Shell test file and confirm all 158 scenarios pass.

### Evidence (Before & After)

Before: release run #33361682601 failed the two targeted timing-sensitive tests and skipped publishing.

After: each targeted test passed 5/5 consecutive local runs; the surrounding Web Shell test file passed 158/158. UI verification: N/A because this changes test synchronization only and does not change rendered behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.0 and Vitest 3.2.7. The Agent View repetition used an ECS-style runner name so its existing worker limit was active.

## Risk & Scope

- Main risk or tradeoff: a genuinely missing asynchronous condition can now take up to roughly 5 seconds to fail in the shared supervisor test helper instead of roughly 500 ms; this remains below the suite's 15-second local and 60-second ECS test ceilings.
- Not validated / out of scope: no real nightly release was rerun. One unrelated temporary-directory cleanup scenario produced `ENOTEMPTY` during the full Agent View file run and passed immediately in isolation; this PR does not change that scenario.
- Breaking changes / migration notes: N/A.

## Linked Issues

Fixes #10608

<details>
<summary>中文说明</summary>

## 此 PR 的改动

此 PR 加固了阻塞 nightly 发布的两个时序敏感单测边界。Agent View supervisor 测试的就绪轮询仍然有明确上限，但现在可以容忍共享 runner 上超过 500 毫秒的延迟；Web Shell 分页场景会等待 React 渲染和锚点清理帧完全结束，再开始后续分页。

## 为什么需要这个改动

Nightly 发布运行 #33361682601 已进入全部测试门禁，但 quality job 中一个 supervisor attach 响应超过了测试 helper 的短轮询预算，另一个分页断言在上一轮加载的 animation-frame 清理完成前执行，因此失败。两个 integration job 都已通过，同一提交的常规 CI 也通过，publish job 从未执行。本改动保留原有行为断言，只移除对 runner 速度和单帧调度的假设。

## Reviewer 测试计划

### 如何验证

- 在 ECS worker 限制下重复执行 stopped-session attach 恢复场景。每次都应收到 attach 响应，而不是超时，同时失败路径仍保持有界。
- 重复执行 anchored-turn 分页场景。每一页完成后都应在下一次加载前稳定下来，同时显式折叠、调用次数、可见性和展开状态断言继续通过。
- 运行相邻的 Web Shell 测试文件，确认 158 个场景全部通过。

### 证据（修改前与修改后）

修改前：发布运行 #33361682601 的两个目标时序敏感测试失败，发布被跳过。

修改后：两个目标测试分别连续执行 5 次，均为 5/5 通过；相邻的 Web Shell 测试文件 158/158 通过。UI 验证：N/A，因为本改动只调整测试同步，不改变渲染行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22.22.0 和 Vitest 3.2.7。Agent View 重复验证使用了 ECS 风格的 runner 名称，因此启用了现有 worker 限制。

## 风险与范围

- 主要风险或取舍：如果异步条件确实永远不会出现，共享 supervisor 测试 helper 现在大约 5 秒后失败，而不是大约 500 毫秒；仍低于测试套件本地 15 秒和 ECS 60 秒的上限。
- 未验证 / 不在范围内：没有重新执行真实 nightly 发布。Agent View 整文件运行时，一个无关的临时目录清理场景出现过 `ENOTEMPTY`，隔离后立即通过；本 PR 不修改该场景。
- 破坏性变更 / 迁移说明：N/A。

## 关联 Issue

Fixes #10608

</details>
