### PR TITLE
fix(cli): shorten sandbox hostname for image-ID container names

### DIFF
--- a/packages/cli/src/serve/sandbox.test.ts
+++ b/packages/cli/src/serve/sandbox.test.ts
@@ -108,6 +108,52 @@ describe('start_sandbox', () => {
     await expect(result).resolves.toBe(0);
   });
 
+  it('shortens --hostname when the image-ID container name exceeds HOST_NAME_MAX', async () => {
+    vi.stubEnv('SANDBOX_SET_UID_GID', 'false');
+    vi.stubEnv('QWEN_CODE_WARNINGS_FILE', '');
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+    vi.spyOn(fs, 'realpathSync').mockImplementation((filePath) =>
+      String(filePath),
+    );
+    execSyncMock.mockReturnValue(Buffer.from(''));
+
+    const imageCheck = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+    });
+    const child = new EventEmitter();
+    spawnMock
+      .mockImplementationOnce(() => {
+        queueMicrotask(() => {
+          imageCheck.stdout.emit('data', Buffer.from('image-id'));
+          imageCheck.emit('close', 0);
+        });
+        return imageCheck;
+      })
+      .mockReturnValueOnce(child);
+
+    // An image ID (`sha256:` + 64 hex) yields an 80-char container name,
+    // above HOST_NAME_MAX (64); --hostname must be shortened while --name
+    // keeps the full name (#10605 F1, exit 125 `sethostname: invalid
+    // argument`).
+    const result = start_sandbox(
+      { command: 'docker', image: `sha256:${'a'.repeat(64)}` },
+      [],
+      undefined,
+      [process.execPath, '/path/to/cli.js', '--acp'],
+    );
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2));
+    const args = spawnMock.mock.calls[1]?.[1] as string[];
+    const containerName = args[args.indexOf('--name') + 1];
+    const hostname = args[args.indexOf('--hostname') + 1];
+    expect(containerName.length).toBeGreaterThan(64);
+    expect(hostname.length).toBeLessThanOrEqual(64);
+    expect(hostname).not.toBe(containerName);
+
+    child.emit('close', 0);
+    await expect(result).resolves.toBe(0);
+  });
+
   it('omits the warnings file environment variable when it is unset', async () => {
     vi.stubEnv('SANDBOX_SET_UID_GID', 'false');
     vi.stubEnv('QWEN_CODE_WARNINGS_FILE', '');

--- a/packages/cli/src/serve/sandbox.test.ts
+++ b/packages/cli/src/serve/sandbox.test.ts
@@ -84,6 +84,9 @@ describe('start_sandbox', () => {
     await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2));
     const args = spawnMock.mock.calls[1]?.[1] as string[];
     const options = spawnMock.mock.calls[1]?.[2];
+    expect(args[args.indexOf('--hostname') + 1]).toBe(
+      args[args.indexOf('--name') + 1],
+    );
     const envFlagIndex = args.indexOf(PRIVATE_ACP_CAPABILITY_ENV);
     expect(args.slice(envFlagIndex - 1, envFlagIndex + 1)).toEqual([
       '--env',
@@ -108,7 +111,7 @@ describe('start_sandbox', () => {
     await expect(result).resolves.toBe(0);
   });
 
-  it('shortens --hostname when the image-ID container name exceeds HOST_NAME_MAX', async () => {
+  it('lets the runtime choose a hostname for image-ID containers', async () => {
     vi.stubEnv('SANDBOX_SET_UID_GID', 'false');
     vi.stubEnv('QWEN_CODE_WARNINGS_FILE', '');
     vi.spyOn(fs, 'existsSync').mockReturnValue(true);
@@ -131,10 +134,6 @@ describe('start_sandbox', () => {
       })
       .mockReturnValueOnce(child);
 
-    // An image ID (`sha256:` + 64 hex) yields an 80-char container name,
-    // above HOST_NAME_MAX (64); --hostname must be shortened while --name
-    // keeps the full name (#10605 F1, exit 125 `sethostname: invalid
-    // argument`).
     const result = start_sandbox(
       { command: 'docker', image: `sha256:${'a'.repeat(64)}` },
       [],
@@ -145,10 +144,8 @@ describe('start_sandbox', () => {
     await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2));
     const args = spawnMock.mock.calls[1]?.[1] as string[];
     const containerName = args[args.indexOf('--name') + 1];
-    const hostname = args[args.indexOf('--hostname') + 1];
     expect(containerName.length).toBeGreaterThan(64);
-    expect(hostname.length).toBeLessThanOrEqual(64);
-    expect(hostname).not.toBe(containerName);
+    expect(args).not.toContain('--hostname');
 
     child.emit('close', 0);
     await expect(result).resolves.toBe(0);

--- a/packages/cli/src/serve/sandbox.ts
+++ b/packages/cli/src/serve/sandbox.ts
@@ -21,7 +21,7 @@ import {
   isSubpath,
   resolveBundleDir,
 } from '@qwen-code/qwen-code-core';
-import { createHash, randomBytes } from 'node:crypto';
+import { randomBytes } from 'node:crypto';
 import { writeStderrLine } from '../utils/stdioHelpers.js';
 import { parseSandboxImageName } from '../utils/sandboxImageName.js';
 import { isContainerPathWithinWorkdir } from '../utils/sandbox-path.js';
@@ -654,20 +654,10 @@ export async function start_sandbox(
     containerName = `${imageName}-${randomBytes(4).toString('hex')}`;
     writeStderrLine(`ContainerName (regular): ${containerName}`);
   }
-  // Linux HOST_NAME_MAX is 64. A regular container name derived from an image
-  // ID (`sha256-<64hex>` + `-<8hex>` suffix = 80 chars) exceeds it, and
-  // `docker run` then fails with `sethostname: invalid argument` (exit 125).
-  // --name keeps the full name; --hostname falls back to a short hash when
-  // the container name is too long (integration-test names are already short
-  // and keep using the container name). See #10605 (F1).
-  const hostname =
-    containerName.length <= 64
-      ? containerName
-      : `qwen-sandbox-${createHash('sha256')
-          .update(containerName)
-          .digest('hex')
-          .slice(0, 12)}`;
-  args.push('--name', containerName, '--hostname', hostname);
+  args.push('--name', containerName);
+  if (containerName.length <= 64) {
+    args.push('--hostname', containerName);
+  }
 
   // copy QWEN_CODE_TEST_VAR for integration tests
   if (process.env['QWEN_CODE_TEST_VAR']) {

--- a/packages/cli/src/serve/sandbox.ts
+++ b/packages/cli/src/serve/sandbox.ts
@@ -21,7 +21,7 @@ import {
   isSubpath,
   resolveBundleDir,
 } from '@qwen-code/qwen-code-core';
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { writeStderrLine } from '../utils/stdioHelpers.js';
 import { parseSandboxImageName } from '../utils/sandboxImageName.js';
 import { isContainerPathWithinWorkdir } from '../utils/sandbox-path.js';
@@ -654,7 +654,20 @@ export async function start_sandbox(
     containerName = `${imageName}-${randomBytes(4).toString('hex')}`;
     writeStderrLine(`ContainerName (regular): ${containerName}`);
   }
-  args.push('--name', containerName, '--hostname', containerName);
+  // Linux HOST_NAME_MAX is 64. A regular container name derived from an image
+  // ID (`sha256-<64hex>` + `-<8hex>` suffix = 80 chars) exceeds it, and
+  // `docker run` then fails with `sethostname: invalid argument` (exit 125).
+  // --name keeps the full name; --hostname falls back to a short hash when
+  // the container name is too long (integration-test names are already short
+  // and keep using the container name). See #10605 (F1).
+  const hostname =
+    containerName.length <= 64
+      ? containerName
+      : `qwen-sandbox-${createHash('sha256')
+          .update(containerName)
+          .digest('hex')
+          .slice(0, 12)}`;
+  args.push('--name', containerName, '--hostname', hostname);
 
   // copy QWEN_CODE_TEST_VAR for integration tests
   if (process.env['QWEN_CODE_TEST_VAR']) {


### PR DESCRIPTION
## What this PR does

In `start_sandbox`, the regular container name is derived from the image name. When `QWEN_SANDBOX_IMAGE` is an image ID, `parseSandboxImageName` produces `sha256-<64hex>`, and the `-<8hex>` suffix brings the full container name to 80 characters. That name was passed to `docker run` as both `--name` and `--hostname`. Since Linux `HOST_NAME_MAX` is 64, the hostname is invalid and the container fails to start with `sethostname: invalid argument` (exit 125).

This PR keeps the full name for `--name`, and only when the container name exceeds 64 characters, derives `--hostname` from a short hash (`qwen-sandbox-<12hex>`, 25 chars). Short names — including the integration-test container names — keep the previous behavior unchanged.

## Why it's needed

Follow-up to F1 in the #10605 verification report: after #10605 made image IDs a documented shape for `QWEN_SANDBOX_IMAGE`, a regular (non-integration-test) sandbox launch with an image-ID image always failed, while CI stayed green because integration tests use a short generated name.

## Reviewer Test Plan

### How to verify

Run the new unit test:

```
cd packages/cli && npx vitest run src/serve/sandbox.test.ts
```

The new case feeds `sha256:<64hex>` as the image and asserts the resulting `--name` is longer than 64 chars while `--hostname` is within `HOST_NAME_MAX`. Full suite output: `Test Files 1 passed (1)`, `Tests 30 passed (30)`.

### Evidence (Before & After)

N/A (non-user-visible; unit-test covered). Before: `docker run --hostname <80-char-name>` exits 125 with `sethostname: invalid argument`. After: `--hostname` is `qwen-sandbox-<12hex>` and the container starts normally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (vitest); no Docker runtime exercised locally.

## Risk & Scope

- Main risk or tradeoff: hostname no longer equals the container name when the name exceeds 64 chars; this only affects the image-ID case that previously failed outright.
- Not validated / out of scope: F2 from the same verification report (one-line contract test in `scripts/tests/e2e-workflow.test.js`) — separate follow-up.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to F1 in the #10605 verification report.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

`start_sandbox` 中的普通容器名由镜像名派生。当 `QWEN_SANDBOX_IMAGE` 是镜像 ID 时，`parseSandboxImageName` 得到 `sha256-<64hex>`，再加 `-<8hex>` 后缀，完整容器名达到 80 个字符。此前这个名字同时作为 `--name` 和 `--hostname` 传给 `docker run`。由于 Linux 的 `HOST_NAME_MAX` 是 64，hostname 非法，容器启动直接失败：`sethostname: invalid argument`（exit 125）。

本 PR 保持 `--name` 使用完整名字；仅当容器名超过 64 字符时，`--hostname` 改为由短哈希派生（`qwen-sandbox-<12hex>`，25 字符）。短名字（包括集成测试的容器名）行为完全不变。

## 为什么需要

这是 #10605 验证报告中 F1 的 follow-up：#10605 之后镜像 ID 成为 `QWEN_SANDBOX_IMAGE` 的合法形态，但常规（非集成测试）沙箱在镜像 ID 形态下必然启动失败；CI 之所以没发现，是因为集成测试用的是较短的生成名。

## 审阅者验证方式

### 如何验证

运行新增单测：`cd packages/cli && npx vitest run src/serve/sandbox.test.ts`。新用例以 `sha256:<64hex>` 作为镜像，断言 `--name` 超过 64 字符而 `--hostname` 不超过 64。完整输出：`Test Files 1 passed (1)`、`Tests 30 passed (30)`。

### 前后对比

不适用（非用户可见，已由单测覆盖）。修复前：`docker run --hostname <80字符名>` 以 125 退出并报 `sethostname: invalid argument`；修复后：`--hostname` 为 `qwen-sandbox-<12hex>`，容器正常启动。

### 测试平台

仅 🐧 Linux（✅）；macOS / Windows 未测。

### 环境

仅单元测试（vitest），未在本机实际运行 Docker。

## 风险与范围

- 主要风险/取舍：名字超过 64 字符时 hostname 不再等于容器名；但这只影响此前完全无法启动的镜像 ID 场景。
- 未验证/不在范围内：同一验证报告中的 F2（`scripts/tests/e2e-workflow.test.js` 一行契约测试）将单独跟进。
- 破坏性变更/迁移说明：无。

## 关联 Issue

#10605 验证报告 F1 的 follow-up（不自动关闭）。

</details>