### PR TITLE
fix(sdk): bump the browser daemon bundle budget to 217KB

### DIFF
--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -121,7 +121,10 @@ const rootDir = join(__dirname, '..');
 // measured combined bundle bounded here.
 // Bumped from 215KB to 216KB for the daemon JSON-RPC error-detail surfacing
 // (structured `code`/`data` forwarding in the error payload).
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 216 * 1024;
+// Bumped from 216KB to 217KB for the workspace-scoped extension skill state
+// surface (extensionState/setExtensionState and their wire types):
+// measured 221,287 bytes, 103 past the old gate.
+const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 217 * 1024;
 // The opt-in `daemon/transports` browser bundle legitimately ships the concrete
 // ACP transports (AcpHttpTransport/AcpWsTransport/AutoReconnect + negotiate), so
 // it's larger than the default barrel — but still budgeted so a future PR can't


### PR DESCRIPTION
## What this PR does

Raises the browser-safe daemon bundle budget in `packages/sdk-typescript/scripts/build.js` from 216KB (221,184 bytes) to 217KB (222,208 bytes), with the file's usual bump-line comment naming what grew and by how much. One constant, nothing else.

## Why it's needed

`main` is red for every PR right now: #10600 (workspace-scoped extension skill state — `extensionState`/`setExtensionState` and their wire types) grew the browser daemon bundle from 220,220 to 221,287 bytes, 103 bytes past the 216KB gate that #10602 recorded two days ago. Since the check runs inside the sdk's build script, which runs from the root `prepare` hook, **every `npm ci` on current main fails** — the "Install dependencies" step of Test / Integration / web-shell E2E is failing on main itself (auto-filed as #10623 and #10625) and on every PR that merges current main. Same incident class and same fix shape as #10602: bump by 1KB to cover the measured size with minimal headroom (921 bytes, vs #10602's 964).

## Reviewer Test Plan

### How to verify

- `npm run build --workspace=packages/sdk-typescript` on current main: fails with `Browser daemon SDK bundle is 221287 bytes; expected <= 221184`. On this branch: passes.
- The gate still guards: the measured bundle (221,287) sits 921 bytes under the new cap, so the next accidental growth of ≥1KB fails the build again.

### Evidence (Before & After)

Before (main `954f3a92ce`, and this PR's base): CI `Test (ubuntu-latest, Node 22.x)` run 33380224215 — `Error: Browser daemon SDK bundle is 221287 bytes; expected <= 221184` in "Install dependencies"; identical failure on 569756ee50 (run 33379480756). Last green main commit is d6878a84e8, immediately before #10600.

After (this branch, local): `npm run build --workspace=packages/sdk-typescript` completes; `stat -f%z dist/daemon/index.js` → 221,287 ≤ 222,208.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `npm run build --workspace=packages/sdk-typescript`, Node 24.18.1 / npm 11.16.0.

## Risk & Scope

- Main risk or tradeoff: none beyond admitting the 1,067-byte growth #10600 already shipped; the budget keeps guarding against the next accidental jump.
- Not validated / out of scope: shrinking the daemon bundle instead of bumping (the growth is a deliberate API surface, same judgement as #10602).
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10623
Fixes #10625

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `packages/sdk-typescript/scripts/build.js` 里浏览器安全 daemon bundle 的预算从 216KB（221,184 字节）提高到 217KB（222,208 字节），并按该文件惯例加一行 bump 注释说明增长来源与幅度。只改一个常量。

## 为什么需要

`main` 当前对所有 PR 都是红的：#10600（workspace 级 extension skill 状态——`extensionState`/`setExtensionState` 及其 wire 类型）把浏览器 daemon bundle 从 220,220 涨到 221,287 字节，超出 #10602 两天前记录的 216KB 门 103 字节。该检查在 sdk 构建脚本内、由根 `prepare` 钩子触发，因此**当前 main 上每次 `npm ci` 都失败**——Test / Integration / web-shell E2E 的「Install dependencies」在 main 自身（bot 自动开了 #10623、#10625）以及所有合入当前 main 的 PR 上都在挂。与 #10602 同类事故、同款修法：提高 1KB，以最小余量覆盖实测尺寸（余 921 字节，#10602 当时余 964）。

## 评审测试计划

### 如何验证

- 在当前 main 上 `npm run build --workspace=packages/sdk-typescript`：失败并报 `Browser daemon SDK bundle is 221287 bytes; expected <= 221184`。在本分支上：通过。
- 门仍在守卫：实测 bundle（221,287）距新上限 921 字节，下一次 ≥1KB 的意外增长仍会打红构建。

### 证据（Before & After）

Before（main `954f3a92ce`，即本 PR 的 base）：CI `Test (ubuntu-latest, Node 22.x)` run 33380224215——「Install dependencies」内 `Error: Browser daemon SDK bundle is 221287 bytes; expected <= 221184`；569756ee50 上同样失败（run 33379480756）。最后一个绿的 main commit 是 d6878a84e8，恰在 #10600 之前。

After（本分支，本地）：`npm run build --workspace=packages/sdk-typescript` 完成；`stat -f%z dist/daemon/index.js` → 221,287 ≤ 222,208。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 `npm run build --workspace=packages/sdk-typescript`，Node 24.18.1 / npm 11.16.0。

## 风险与范围

- 主要风险/取舍：除了接受 #10600 已经带来的 1,067 字节增长外没有别的；预算继续防住下一次意外跳变。
- 未验证/范围外：改为缩减 daemon bundle 而非提预算（该增长是有意的 API 面，判断同 #10602）。
- 破坏性变更/迁移：无。

## 关联 Issue

Fixes #10623
Fixes #10625

</details>
