### PR TITLE
fix(sdk): make daemon browser bundle size advisory

### DIFF
--- a/packages/sdk-typescript/scripts/build.js
+++ b/packages/sdk-typescript/scripts/build.js
@@ -20,108 +20,8 @@ import esbuild from 'esbuild';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
-// Budget includes the DaemonTransport interface + DaemonTransportClosedError +
-// RestSseTransport (default transport, constructed by DaemonClient).
-// Bumped from 116KB to 118KB for the transport abstraction layer (~1.5KB).
-// Bumped from 118KB to 119KB for the mid-turn drain surface (enqueue methods +
-// `mid_turn_message_injected` event type/guard/registration, ~150 bytes).
-// Bumped from 119KB to 122KB for the workspace extension management surface
-// (install/update/enable/disable/uninstall/refresh/check update endpoints).
-// Bumped from 122KB to 124KB for daemon fork-session APIs/events.
-// Bumped from 124KB to 125KB for rewind/branch transcript/session APIs.
-// Bumped from 125KB to 126KB for the workspace permissions rules API
-// (workspacePermissions + set/add/remove rule methods + types, ~718 bytes).
-// Bumped from 126KB to 127KB for prompt clientId self-heal.
-// Bumped from 127KB to 130KB for daemon workspace voice, trust, permissions,
-// session LSP helper APIs, and the full daemon route table.
-// Bumped from 130KB to 131KB for the workspace MCP resources drill-down
-// (workspaceMcpResources client method + route + resource status types).
-// Bumped from 131KB to 132KB for the pending prompt queue feature.
-// Bumped from 132KB to 133KB for session archive/unarchive APIs and sessionless
-// workspace remember (managed memory client methods + event validation).
-// Bumped from 133KB to 136KB after merging session artifacts plus sessionless
-// workspace memory forget/dream APIs and event validation.
-// Bumped from 136KB to 138KB for persistent session artifact APIs after
-// merging the upstream daemon SDK surface.
-// Bumped from 138KB to 139KB for EventBus byte-backlog telemetry validation.
-// Bumped from 139KB to 140KB for history_truncated event validation and
-// transcript status projection.
-// Bumped from 140KB to 150KB after merging main: workspace ACP status/preheat
-// plus WorkspaceDaemonClient's workspace-qualified core REST helpers (Phase 3
-// file/status/settings/agents/session APIs).
-// Bumped from 150KB to 151KB for the paged session transcript REST helper.
-// Bumped from 151KB to 154KB for extension management v2 catalog, activation,
-// mutation, and operation-polling APIs (~2.3KB).
-// Bumped from 154KB to 155KB after merging workspace skill-toggle APIs.
-// Bumped from 155KB to 160KB to accommodate recent growth and reduce churn,
-// from repeated 1KB bumps as new daemon APIs are added.
-// Bumped from 160KB to 161KB after merging upstream main.
-// Bumped from 161KB to 167KB for the Web Shell git-diff and subagent REST helpers
-// (workspaceGitDiff / workspaceGitDiffFile on both client classes) and the
-// ChatRecord transcript projection in the default UI API.
-// Bumped from 167KB to 168KB for workspace-level streaming generation and
-// workspace trust status v2 SDK types, plus the daemon event-bus epoch token
-// fields (eventEpoch / onEpoch) and their docs across SDK transports.
-// Bumped from 168KB to 169KB for channel delivery alongside workspace-level
-// streaming generation.
-// Bumped from 169KB to 170KB after merging the event-bus and channel-delivery
-// additions.
-// Bumped from 170KB to 173KB for workspace-scoped Channel configuration,
-// lifecycle, startup, and pairing helpers on both daemon client classes.
-// Bumped from 173KB to 174KB for worktree gitCwd query parameters on the
-// workspace-qualified diff/log/commit-detail client methods.
-// Bumped from 174KB to 175KB for git branch listing/checkout/push/pull/commit
-// client methods on both daemon client classes.
-// Bumped from 175KB to 176KB for GitHub PR create + default-branch methods.
-// Bumped from 176KB to 177KB for concurrent session-cancellation coalescing in
-// DaemonSessionClient (#6930).
-// Bumped from 177KB to 178KB for workspace file byte-cursor paging after
-// merging the workspace pairing approval SDK surface.
-// Bumped from 178KB to 184KB for side-task session APIs and source metadata.
-// Bumped from 184KB to 185KB for the Live Voice lifecycle helpers on both
-// daemon client classes.
-// Bumped from 185KB to 186KB for daemon-owned mid-turn message APIs.
-// Bumped from 186KB to 188KB for the workspace file-upload surface
-// (`uploadWorkspaceFile` + XHR progress) on both daemon client classes.
-// Bumped from 188KB to 189KB for the session reasoning-effort config option
-// APIs merged in from main.
-// Bumped from 189KB to 190KB for historical branch sessions and transcript
-// branch-point projection merged with the upload and reasoning APIs.
-// Bumped from 190KB to 195KB for session attachment upload, cleanup, and hydration
-// merged with the branch-session APIs and the composer text-file attachment
-// metadata (#9180).
-// Bumped from 195KB to 196KB for transient-vs-gone media hydration errors and
-// the reference-only replay placeholder.
-// Bumped from 196KB to 197KB for the workspace session live-state daemon
-// surface (catalog version + live snapshot accessors), immutable,
-// identity-stable transcript block indexes used by browser renderers, and the
-// daemon transcript-retention work (replay-snapshot release + capped debug
-// payloads, #9303) landing on top of the session media references bundle.
-// Bumped from 197KB to 198KB for the unrecognized-diagnostic sidechannel
-// (`unrecognizedDiagnostics` routing + selector, #8823).
-// Bumped from 198KB to 199KB for persistent session attachment read/remove and
-// binary resource hydration.
-// Bumped from 199KB to 200KB for the session PR binding (`DaemonSessionPrInfo`
-// + validators).
-// Bumped from 199KB to 200KB for the retention byte budget (block byte
-// estimation + budget-aware trimming) and backing-store-detached string caps
-// (#9303 review round 3).
-// Bumped from 200KB to 206KB for the pagination/eviction reconciliation and the
-// #8823 × #9303 merge (#9303 review rounds 9-12): eviction-direction signal,
-// rewind truncation callback, trimmed tool/permission sentinel helpers,
-// record-boundary eviction snap, and the floor back-off — each bump budgeted
-// its own delta in isolation, and the combined feature sets land here. The
-// attachment read/remove + binary hydration feature that separately bumped
-// main to 199KB merges within this headroom, so no further bump is needed.
-// Bumped from 206KB to 208KB for transcript block change summaries used to
-// avoid complete Web Shell projection on every streamed text update.
-// Bumped from 208KB to 215KB for the complete standalone-session lifecycle,
-// response validation, and outcome-unknown recovery surface.
-// Workflow task status and control APIs merge within this budget; keep the
-// measured combined bundle bounded here.
-// Bumped from 215KB to 216KB for the daemon JSON-RPC error-detail surfacing
-// (structured `code`/`data` forwarding in the error payload).
-const MAX_DAEMON_BROWSER_BUNDLE_BYTES = 216 * 1024;
+// Report unexpected growth without blocking normal additions to the public API.
+const DAEMON_BROWSER_BUNDLE_WARNING_BYTES = 216 * 1024;
 // The opt-in `daemon/transports` browser bundle legitimately ships the concrete
 // ACP transports (AcpHttpTransport/AcpWsTransport/AutoReconnect + negotiate), so
 // it's larger than the default barrel — but still budgeted so a future PR can't
@@ -346,9 +246,10 @@ if (existsSync(licenseSource)) {
 
 function assertBrowserSafeBundle(filePath) {
   const size = statSync(filePath).size;
-  if (size > MAX_DAEMON_BROWSER_BUNDLE_BYTES) {
-    throw new Error(
-      `Browser daemon SDK bundle is ${size} bytes; expected <= ${MAX_DAEMON_BROWSER_BUNDLE_BYTES}`,
+  console.log(`Browser daemon SDK bundle is ${size} bytes`);
+  if (size > DAEMON_BROWSER_BUNDLE_WARNING_BYTES) {
+    console.warn(
+      `Browser daemon SDK bundle exceeds the ${DAEMON_BROWSER_BUNDLE_WARNING_BYTES}-byte warning threshold`,
     );
   }
   assertNoNodeBuiltins(filePath, 'Browser daemon SDK bundle');


### PR DESCRIPTION
## What this PR does

The default daemon browser bundle now reports its byte size on every build and emits a warning when it exceeds the existing 216 KiB threshold. Exceeding that threshold no longer fails the build. Browser compatibility remains enforced: Node-only imports still fail the build, and the separate transports and transcript bundle limits remain unchanged.

## Why it's needed

The default bundle grows as public daemon APIs are added. Keeping its hard limit aligned to the current size has required repeated 1 KiB budget bumps and can make `main` red when independently green API additions land together. The combined growth from #10593 and #10600 exceeded the limit by 103 bytes in [job 99449712424](https://github.com/QwenLM/qwen-code/actions/runs/33379480756/job/99449712424) and [job 99450718825](https://github.com/QwenLM/qwen-code/actions/runs/33380224215/job/99450718825), even though the generated bundle remained browser-compatible.

## Reviewer Test Plan

### How to verify

Build the TypeScript SDK after its workspace dependencies. Confirm that the build prints the measured default daemon browser bundle size, emits a warning above 216 KiB, completes successfully, and still runs the Node-only import scan.

### Evidence (Before & After)

Before: the 221,287-byte bundle failed because the hard limit was 221,184 bytes.

After: the focused build completed successfully and printed:

```text
Browser daemon SDK bundle is 221287 bytes
Browser daemon SDK bundle exceeds the 221184-byte warning threshold
```

UI verification: N/A. This changes a build-time SDK guard only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.0; focused core, ACP bridge, and TypeScript SDK builds.

## Risk & Scope

- Main risk or tradeoff: unexpected growth in the default daemon browser bundle becomes advisory instead of blocking.
- Not validated / out of scope: browser performance targets and API-level bundle splitting are not changed here.
- Breaking changes / migration notes: none. Node-only browser incompatibilities and the other browser bundle budgets still fail builds.

## Linked Issues

Fixes #10623
Fixes #10625

<details>
<summary>中文说明</summary>

## 本 PR 的改动

默认 daemon 浏览器 bundle 现在会在每次构建时输出实际字节数，超过现有 216 KiB 阈值时打印 warning，但不再让构建失败。浏览器兼容性仍然是硬约束：引入 Node-only 模块依旧会导致构建失败，独立的 transports 和 transcript bundle 限制也保持不变。

## 为什么需要这个改动

默认 bundle 会随着公开 daemon API 的增加而自然增长。过去把硬上限紧贴当前大小，导致需要反复进行 1 KiB 的预算调整；多个各自通过 CI 的 API 改动一起合入时，还可能使 `main` 变红。#10593 和 #10600 的组合增长在 [job 99449712424](https://github.com/QwenLM/qwen-code/actions/runs/33379480756/job/99449712424) 与 [job 99450718825](https://github.com/QwenLM/qwen-code/actions/runs/33380224215/job/99450718825) 中超过限制 103 字节，但生成的 bundle 仍然保持浏览器兼容。

## Reviewer Test Plan

### 如何验证

在构建 workspace 依赖后构建 TypeScript SDK。确认构建会打印默认 daemon 浏览器 bundle 的实际大小，超过 216 KiB 时给出 warning，构建仍然成功，并继续执行 Node-only 导入扫描。

### 验证证据（Before & After）

Before：bundle 大小为 221,287 字节，超过 221,184 字节硬上限，因此构建失败。

After：聚焦构建成功，并输出：

```text
Browser daemon SDK bundle is 221287 bytes
Browser daemon SDK bundle exceeds the 221184-byte warning threshold
```

UI 验证：N/A。本 PR 只修改 SDK 构建时检查。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22.22.0；聚焦构建 core、ACP bridge 和 TypeScript SDK。

## 风险与范围

- 主要风险或权衡：默认 daemon 浏览器 bundle 的异常增长由阻断改为提示。
- 未验证 / 不在范围：本 PR 不调整浏览器性能指标，也不拆分 API bundle。
- 破坏性改动 / 迁移说明：无。Node-only 浏览器不兼容和其他浏览器 bundle 预算仍然会让构建失败。

## 关联 Issue

Fixes #10623
Fixes #10625

</details>
