### PR TITLE
fix(core): keep image views working with sharp releases older than 0.34

### DIFF
--- a/packages/core/src/utils/image-view.test.ts
+++ b/packages/core/src/utils/image-view.test.ts
@@ -10,6 +10,7 @@ import path from 'node:path';
 import sharp from 'sharp';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  orientedSize,
   renderImageOverview,
   renderNormalizedImageCrop,
 } from './image-view.js';
@@ -118,5 +119,116 @@ describe('image views', () => {
     await expect(renderImageOverview(filePath, signal)).rejects.toMatchObject({
       code: 'decode_failed',
     });
+  });
+});
+
+describe('orientedSize', () => {
+  it('prefers metadata.autoOrient when present (sharp >= 0.34)', () => {
+    expect(
+      orientedSize({
+        width: 60,
+        height: 100,
+        autoOrient: { width: 100, height: 60 },
+      }),
+    ).toEqual({ width: 100, height: 60 });
+  });
+
+  it('keeps stored axes for orientations 1-4 when autoOrient is missing (sharp < 0.34)', () => {
+    for (const orientation of [1, 2, 3, 4]) {
+      expect(
+        orientedSize({
+          width: 100,
+          height: 60,
+          orientation,
+        }),
+      ).toEqual({ width: 100, height: 60 });
+    }
+  });
+
+  it('swaps stored axes for orientations 5-8 when autoOrient is missing (sharp < 0.34)', () => {
+    for (const orientation of [5, 6, 7, 8]) {
+      expect(
+        orientedSize({
+          width: 100,
+          height: 60,
+          orientation,
+        }),
+      ).toEqual({ width: 60, height: 100 });
+    }
+  });
+
+  it('falls back to stored size when neither autoOrient nor orientation is present', () => {
+    expect(orientedSize({ width: 320, height: 240 })).toEqual({
+      width: 320,
+      height: 240,
+    });
+  });
+});
+
+describe('image views with EXIF orientation', () => {
+  let root: string;
+  const signal = new AbortController().signal;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'image-view-exif-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  // Stored pixels are 100x60 but EXIF orientation 6 rotates the displayed
+  // image to 60x100. The view must be sized and cropped in oriented space.
+  async function writeRotatedJpeg(name: string): Promise<string> {
+    const filePath = path.join(root, name);
+    await sharp({
+      create: {
+        width: 100,
+        height: 60,
+        channels: 3,
+        background: '#306090',
+      },
+    })
+      .jpeg()
+      .withMetadata({ orientation: 6 })
+      .toFile(filePath);
+    return filePath;
+  }
+
+  it('reports oriented source size for an EXIF-rotated overview', async () => {
+    const filePath = await writeRotatedJpeg('exif-overview.jpg');
+
+    const view = await renderImageOverview(filePath, signal);
+
+    expect(view).toMatchObject({
+      sourceWidth: 60,
+      sourceHeight: 100,
+      selectedWidth: 60,
+      selectedHeight: 100,
+      outputWidth: 60,
+      outputHeight: 100,
+    });
+  });
+
+  it('crops an EXIF-rotated image in oriented coordinates', async () => {
+    const filePath = await writeRotatedJpeg('exif-crop.jpg');
+
+    // Oriented size is 60x100, so this selects the 30x50 top-left quadrant.
+    const view = await renderNormalizedImageCrop(
+      filePath,
+      { x1: 0, y1: 0, x2: 500, y2: 500 },
+      signal,
+    );
+
+    expect(view).toMatchObject({
+      sourceWidth: 60,
+      sourceHeight: 100,
+      selectedWidth: 30,
+      selectedHeight: 50,
+      outputWidth: 240,
+      outputHeight: 400,
+    });
+    const metadata = await sharp(view.bytes).metadata();
+    expect(metadata).toMatchObject({ width: 240, height: 400 });
   });
 });

--- a/packages/core/src/utils/image-view.ts
+++ b/packages/core/src/utils/image-view.ts
@@ -65,6 +65,43 @@ export class ImageViewError extends Error {
   }
 }
 
+/**
+ * The metadata fields `orientedSize` depends on.
+ *
+ * sharp >= 0.34 always provides them, but older releases that may still be
+ * installed for compatibility with legacy hosts (for example sharp 0.32.x,
+ * the last series whose prebuilt libvips loads on glibc 2.17 systems such
+ * as AliOS 7) omit `autoOrient`, so it is optional here even though sharp's
+ * current type declarations mark it as required.
+ */
+export interface OrientableMetadata {
+  width?: number;
+  height?: number;
+  orientation?: number;
+  autoOrient?: ImageSize;
+}
+
+/**
+ * Computes the size of the image after applying EXIF orientation.
+ *
+ * Prefers `metadata.autoOrient` (sharp >= 0.34). When that field is
+ * missing (sharp < 0.34), derives the oriented size from the stored
+ * dimensions and the EXIF orientation tag instead: orientations 5-8 swap
+ * the stored axes.
+ */
+export function orientedSize(metadata: OrientableMetadata): ImageSize {
+  const autoOrient = metadata.autoOrient;
+  if (autoOrient) {
+    return { width: autoOrient.width, height: autoOrient.height };
+  }
+  const width = metadata.width ?? 0;
+  const height = metadata.height ?? 0;
+  const orientation = metadata.orientation ?? 0;
+  return orientation >= 5 && orientation <= 8
+    ? { width: height, height: width }
+    : { width, height };
+}
+
 function fitsVisualBudget({ width, height }: ImageSize): boolean {
   return (
     width <= IMAGE_VIEW_MAX_EDGE &&
@@ -204,13 +241,17 @@ async function renderImageView(
   signal: AbortSignal,
 ): Promise<ImageView> {
   const { bytes, metadata, sharp } = prepared;
+  const sourceSize = orientedSize(metadata);
   let output: Buffer;
   try {
+    // `.rotate()` without an angle applies the EXIF orientation on every
+    // supported sharp release, including sharp < 0.33 where the
+    // `autoOrient` constructor option does not exist yet.
     output = await sharp(bytes, {
-      autoOrient: true,
       failOn: 'error',
       limitInputPixels: true,
     })
+      .rotate()
       .extract(selection)
       .resize(outputSize.width, outputSize.height, {
         fit: 'fill',
@@ -240,8 +281,8 @@ async function renderImageView(
   return {
     bytes: output,
     mimeType: 'image/jpeg',
-    sourceWidth: metadata.autoOrient.width,
-    sourceHeight: metadata.autoOrient.height,
+    sourceWidth: sourceSize.width,
+    sourceHeight: sourceSize.height,
     selectedWidth: selection.width,
     selectedHeight: selection.height,
     outputWidth: outputSize.width,
@@ -254,8 +295,9 @@ export async function renderImageOverview(
   signal: AbortSignal,
 ): Promise<ImageView> {
   const prepared = await prepareImage(filePath, signal);
-  const sourceWidth = prepared.metadata.autoOrient.width;
-  const sourceHeight = prepared.metadata.autoOrient.height;
+  const { width: sourceWidth, height: sourceHeight } = orientedSize(
+    prepared.metadata,
+  );
   const outputSize = boundedSize(sourceWidth, sourceHeight, 1);
   return renderImageView(
     filePath,
@@ -272,8 +314,9 @@ export async function renderNormalizedImageCrop(
   signal: AbortSignal,
 ): Promise<ImageView> {
   const prepared = await prepareImage(filePath, signal);
-  const sourceWidth = prepared.metadata.autoOrient.width;
-  const sourceHeight = prepared.metadata.autoOrient.height;
+  const { width: sourceWidth, height: sourceHeight } = orientedSize(
+    prepared.metadata,
+  );
   const left = Math.min(
     sourceWidth - 1,
     Math.max(0, Math.floor((region.x1 / 1000) * sourceWidth)),


### PR DESCRIPTION
### What does this PR do?

Keeps the image rendering pipeline (`read_file` image views and `zoom_image`) working when the installed sharp is older than 0.34, and applies EXIF orientation through an API that exists on every supported sharp release.

### Motivation

`metadata.autoOrient` was introduced in sharp 0.34. On installs that must stay on older sharp releases — for example because the prebuilt `@img/sharp-libvips` bundled with sharp >= 0.33 requires glibc >= 2.26 and cannot load on hosts with an older libc — every `read_file` of an image and every `zoom_image` call crashes with:

`TypeError: Cannot read properties of undefined (reading 'width')`

The failure affects all images (even tiny synthetic ones) because it happens after successful decoding, when the oriented size is read from metadata.

### Reviewer Test Plan

**How to verify**

1. In a scratch directory run `npm install sharp@0.32.6`.
2. Bundle `packages/core/src/utils/image-view.ts` with sharp marked as external, load it from that directory, and call `renderImageOverview()` / `renderNormalizedImageCrop()` on any JPEG.
3. Without this PR the call throws `Cannot read properties of undefined (reading 'width')`; with this PR it renders normally, and EXIF orientations 5–8 are reported and cropped in oriented coordinates.

**Before** (sharp 0.32.6): `renderImageOverview('/tmp/any-image.jpg')` → `TypeError: Cannot read properties of undefined (reading 'width')`

**After** (sharp 0.32.6): a 628×1536 JPEG overview renders; an EXIF orientation-6 (stored 100×60) image reports source size 60×100 and crops in oriented space (selected 30×50 → output 240×400), matching the behavior of sharp >= 0.34.

**Tests added**: `orientedSize` unit tests (autoOrient preferred; fallback derivation for EXIF orientations 1–4 and 5–8; missing fields) and EXIF-rotated overview/crop integration tests. Related suites pass locally: `image-view`, `zoom-image`, `fileUtils`.

**Tested on**

| Operating System | Status |
|------------------|--------|
| 🐧 Linux         | ✅ Tested |
| 🍎 macOS         | ⚠️ Not tested (change is platform-independent pure logic) |
| 🪟 Windows       | ⚠️ Not tested (change is platform-independent pure logic) |

### Possible Drawbacks / Risks and Scope

- Behavior with sharp >= 0.34 is unchanged: `metadata.autoOrient` is preferred whenever present, so the fallback path is never taken.
- `.rotate()` without an angle (available in all relevant sharp releases) was verified to behave identically to the `autoOrient` constructor option on both old (0.32.6) and new (0.34.x/0.35.x) sharp, including `extract()` operating in oriented space.
- No dependency, CLI, or public API changes; scope is limited to `packages/core/src/utils/image-view.ts` plus its tests.