### PR TITLE
feat(external-context): Load administrator-owned Mem0 dialects

### DIFF
--- a/docs/design/external-context-mem0-extension.md
+++ b/docs/design/external-context-mem0-extension.md
@@ -1,8 +1,8 @@
-# Configurable Mem0 Provider Extension
+# Administrator-configured Mem0 External Context Extension
 
-**Status:** Partially implemented through PR1 (no live presets)
+**Status:** PR2 implementation
 
-**Date:** 2026-08-26
+**Date:** 2026-08-28
 
 **Related profile:**
 [External Context Provider Extensions](./external-context-provider-extensions.md)
@@ -15,150 +15,138 @@
 Mem0-compatible services integrate through a self-contained local stdio
 Extension named `external-context-mem0`. The Extension implements External
 Context MCP Profile v1 and translates the fixed `context_search({ query })`
-contract into a bounded, versioned REST dialect selected by administrator
-configuration.
+contract through an administrator-owned, versioned dialect file.
+
+Qwen does not publish, select, or maintain provider presets. The instance file
+binds one endpoint, scope, credential environment-variable name, timeout, and
+absolute dialect path. The dialect file describes request and response
+differences within the existing closed `DialectV1` grammar. Its `id` is an
+administrator-managed audit label and has no registry or file-name semantics.
 
 External Context MCP Profile v1 remains the only public Qwen interoperability
-boundary. Qwen Core does not gain a provider registry, a public provider SDK,
+boundary. Qwen Core does not gain a provider registry, public provider SDK,
 dynamic module loading, or new third-party cases in its private
-`ProviderConfig` union. The existing direct `mem0-platform-v3` integration
-remains available for compatibility, but it does not become a registry for
-Mem0 product variants.
-
-This document defines the architecture and compatibility policy. PR1 adds the
-self-contained runtime skeleton, configuration schemas, packaging, and
-synthetic contract tests. Live provider presets and provider-specific tests
-remain later rollout steps.
+`ProviderConfig` union. The existing direct integration remains available for
+compatibility and is not modified by this design.
 
 ## Goals
 
-- Add common Mem0-compatible REST services through versioned preset data rather
-  than Qwen Core changes.
+- Let administrators connect retrieval-only compatible services without a
+  Qwen release or built-in provider data.
 - Keep the model-facing contract stable as `context_search({ query })` while
-  endpoint, credential, scope, timeout, and dialect remain operator-owned.
-- Give providers whose protocols do not fit the bounded REST grammar a clear
-  path to publish their own local or remote MCP Extension.
-- Preserve the current direct integration while a portable retrieval-only path
-  is introduced incrementally.
+  endpoint, credential, scope, timeout, and dialect remain administrator-owned.
+- Preserve the bounded request engine, response normalization, and failure
+  behavior already implemented by the Extension.
+- Give protocols outside the closed grammar a clear path to a separate local
+  or remote MCP Extension.
 
 ## Non-goals
 
-- Include live provider presets, provider-specific adapters, or
-  provider-specific tests in PR1.
-- Define a dynamic provider ABI, arbitrary request templates, JSONPath,
-  scripting, or custom executable hooks.
-- Probe V3, V2, and V1 endpoints automatically or silently fall back between
-  product versions.
-- Add memory creation, update, deletion, or Auto Recall behavior to the
-  portable Extension.
-- Migrate or remove the existing direct External Context provider.
+- Publish provider presets, provider-specific contract fixtures, or live
+  service credentials.
+- Add ordinary Qwen settings or Extension settings for the configuration path.
+- Define arbitrary request templates, JSONPath, scripting, custom headers, or
+  executable hooks.
+- Probe or fall back between upstream protocol versions.
+- Add memory creation, update, deletion, Auto Recall, redirects, or retries.
+- Migrate or remove the existing direct External Context integration.
 
 ## Architecture
 
 ```mermaid
 flowchart LR
     Q["Qwen Core"] --> P["External Context MCP Profile v1"]
-    P --> R["Provider-owned Remote MCP"]
-    P --> E["external-context-mem0 local stdio Extension"]
-    E --> C["Administrator-owned instance configuration"]
-    E --> D["Versioned bounded dialect preset"]
-    C --> X["Bounded request engine"]
-    D --> X
-    X --> S["Mem0-compatible service"]
+    P --> E["external-context-mem0 stdio Extension"]
+    I["Administrator-owned InstanceConfigV2"] --> E
+    D["Administrator-owned DialectV1"] --> E
+    E --> R["Bounded request engine"]
+    R --> S["Compatible HTTP service"]
 ```
 
-The local Extension owns the HTTP translation and ships as a self-contained
-artifact. Qwen sees only the MCP profile. A service with a protocol outside the
-bounded grammar owns a separate MCP implementation instead of extending the
-grammar or Qwen Core.
+The local Extension owns configuration loading and HTTP translation. Qwen sees
+only the MCP profile. A service that cannot fit the bounded dialect grammar
+owns a separate MCP implementation instead of expanding the grammar or Qwen
+Core.
 
 ## Version model
 
-Four independent version axes must remain explicit:
+Four independent version axes remain explicit:
 
 1. **MCP Profile version** defines the Qwen-to-Extension tool contract. This
-   proposal implements External Context MCP Profile v1.
-2. **Instance schema version** defines the operator configuration shape, such
-   as `schemaVersion: 1`.
-3. **Dialect version** defines preset interpretation, such as
-   `dialectVersion: 1`.
-4. **Upstream product or API version** belongs to the provider and may differ
-   between operations in one product.
+   Extension implements External Context MCP Profile v1.
+2. **Instance schema version** defines administrator binding. This design uses
+   `schemaVersion: 2`.
+3. **Dialect version** defines interpretation of the closed request and
+   response grammar. This design keeps `dialectVersion: 1` unchanged.
+4. **Upstream API version** belongs to the service and appears only in the
+   administrator's endpoint and static dialect path.
 
-An upstream product must not be labeled simply "V1", "V2", or "V3" at the
-Extension boundary. For example, a Hologres long-memory deployment can expose
-a mixture of versioned operation paths; its preset records the exact verified
-contract for each operation.
+An incompatible instance schema or dialect version fails closed. In
+particular, the old `schemaVersion: 1` plus `preset` shape is not retained as a
+compatibility branch because the shipped registry never provided a usable
+provider.
 
 ## Instance configuration
 
-An instance selects one immutable preset and supplies deployment-specific
-values. The following shape is illustrative; PR1's published canonical schema
-is authoritative.
+`InstanceConfigV2` supplies deployment-specific binding:
 
 ```json
 {
-  "schemaVersion": 1,
-  "preset": "aliyun-polardb-mysql-2026-08",
+  "schemaVersion": 2,
+  "dialectPath": "/etc/qwen/external-context/memory.dialect.json",
   "endpoint": {
-    "origin": "http://10.0.0.8:8080",
+    "origin": "https://memory.example.com",
     "basePath": "",
-    "allowInsecureHttp": true
+    "allowInsecureHttp": false
   },
   "credentialEnv": "MEMORY_API_KEY",
   "scope": {
-    "userId": "repository-memory",
-    "agentId": "qwen-code"
+    "userId": "repository-memory"
   },
   "timeoutMs": 5000
 }
 ```
 
-The endpoint is split into an origin and a base path so the implementation can
-validate the authority separately from path joining. Credentials are
-referenced by environment-variable name and are never stored in this document.
-Scope values are fixed operator input, not tool arguments. A preset declares
-which of `userId`, `agentId`, and `appId` it consumes; startup validation
-rejects a missing required value or a configured value that the preset does
-not use. For example, a Mem0 Platform V3 instance uses
-`"scope": { "appId": "shared-repository" }` instead of the PolarDB-oriented
-scope above.
+`QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` is supplied through the Extension process
+environment and points to this file by absolute path. It is not a normal Qwen
+setting. Managed deployments provide it through a system environment,
+controlled launcher, or pinned MCP configuration. Production files should
+normally live outside workspaces; a repository-owned file is trusted only when
+the repository is inside the deployment's administrative trust boundary.
 
-### Configuration ownership and loading
+`dialectPath` must also be absolute. The Extension does not resolve it relative
+to the instance file, interpolate environment variables, load URLs, search
+fallback locations, or watch for changes. Both files are capped at 64 KiB and
+read once during startup. Changes take effect only after restarting the
+Extension.
 
-One environment variable, `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG`, points to the
-absolute path of the instance JSON file. The local Extension reads and
-validates that file once at startup and fails closed before exposing its tool
-when the path is relative, the file is unavailable, the schema is unsupported,
-or the selected preset is unknown. The instance file can name the environment
-variable holding a credential, but cannot contain the credential value.
+The endpoint separates `origin` from `basePath` so authority validation remains
+independent of path joining. Scope values are fixed administrator input, not
+tool arguments. Every non-`omit` scope location in the dialect requires the
+matching instance value, while every `omit` location rejects a supplied value.
+Administrators choose fixed scope or `omit`; there is no optional-scope
+grammar.
 
-An Extension setting may populate this non-secret path after its
-installation-to-child-process behavior is covered by E2E. Managed deployments
-instead supply it through an administrator-owned launcher, system settings, or
-pinned MCP configuration. Repository-controlled configuration is trusted only
-when the repository itself is inside the deployment's trust boundary.
+Credentials are never stored in either file. `credentialEnv` names the process
+environment variable containing the credential, which is read only after both
+files and all semantic constraints validate.
 
-Each MCP server instance binds exactly one endpoint, preset, and scope. A
-deployment that needs several memory services registers separately named MCP
-server instances. The model does not choose or switch the provider for a call.
+## Dialect configuration
 
-## Dialect presets
-
-A preset describes only the small set of differences required to issue a
-retrieval request and normalize its response. For example:
+The second file conforms to the unchanged `DialectV1` schema. This synthetic
+example illustrates the contract without naming a provider:
 
 ```json
 {
   "dialectVersion": 1,
-  "id": "aliyun-polardb-mysql-2026-08",
+  "id": "organization-memory-v1",
   "auth": "authorization-token",
   "search": {
     "method": "POST",
-    "path": "/v2/memories/search",
+    "path": "/memories/search",
     "queryLocation": "json",
     "userIdLocation": "json.filters",
-    "agentIdLocation": "json",
+    "agentIdLocation": "omit",
     "appIdLocation": "omit",
     "limitField": "limit"
   },
@@ -174,155 +162,97 @@ retrieval request and normalize its response. For example:
 }
 ```
 
-The initial grammar is deliberately closed:
+The grammar stays deliberately closed:
 
-- Authentication is one of `authorization-token`, `authorization-bearer`, or
+- Authentication is `authorization-token`, `authorization-bearer`, or
   `x-api-key`.
-- Search uses `GET` or `POST`.
-- Query, user, agent, and app values use only `json`, `json.filters`, `query`,
-  or `omit` locations supported by the relevant field. Their request names are
-  selected from an explicit allowlist such as `query`, `user_id`, `agent_id`,
-  and `app_id`.
+- Search uses `GET` or `POST` with one static exact path.
+- Query, user, agent, and app values use only the enumerated `json`,
+  `json.filters`, `query`, or `omit` locations supported by each field.
 - Result limits use `top_k`, `limit`, or `omit`.
 - Response collections are `results` or a root array.
-- Identifier fields are selected from known simple names such as `id` and
-  `memory_id`; content fields are selected from `memory`, `content`, and
-  `text`. Other normalized fields follow the same explicit allowlist model.
-- Optional behaviors such as `threshold` and `rerank` are typed preset fields,
-  not free-form request fragments.
-- Request paths are static exact paths. Path joining preserves a required
-  trailing slash.
+- Response fields use only the explicit simple-name allowlists in the schema.
+- `threshold` and `rerank` are typed fields, not request fragments.
 
-Presets cannot define arbitrary headers, body interpolation, JSONPath, code,
-environment-variable expansion, redirects, or response transformations. If a
-new service requires one of those capabilities, it does not fit this grammar.
+The dialect cannot define arbitrary headers, body interpolation, JSONPath,
+code, environment-variable expansion, redirects, or response transformations.
+Its `id` does not have to match its file name or any value in the instance
+file. Administrators own its naming and versioning policy.
 
-Built-in preset identifiers include a provider and a stable contract version,
-for example:
+## Startup and failure behavior
 
-- `mem0-platform-v3`
-- `mem0-oss-rest-2026-08`
-- `aliyun-polardb-mysql-2026-08`
-- `aliyun-hologres-mem0-2.0.6`
-- `aliyun-rds-postgresql-memory-2026-08`
+Startup is deterministic:
 
-The names above reserve design intent; each preset lands only after its exact
-request and response contract is verified. A published identifier never
-silently changes to an incompatible mapping. A breaking mapping receives a new
-identifier.
+1. Read `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` from the process environment.
+2. Bounded-read and parse `InstanceConfigV2`.
+3. Require an absolute `dialectPath`, then bounded-read and parse `DialectV1`.
+4. Validate endpoint, HTTP opt-in, static paths, GET/JSON compatibility, and
+   scope consistency.
+5. Read the credential named by `credentialEnv`.
+6. Start the stdio MCP server with the existing bounded request engine.
 
-## Adding another service
+The process exposes no tool if any step fails. Errors use fixed categories for
+unavailable or invalid instance configuration, non-absolute dialect paths,
+unavailable or invalid dialect configuration, and invalid endpoint, path,
+scope, or dialect semantics. Messages never include the real path, endpoint,
+query, credential, or upstream response.
 
-The integration decision is mechanical:
+## Security and request boundary
 
-1. If the service fits the bounded grammar, add a versioned preset and contract
-   fixtures to the Extension package. Qwen Core does not change.
-2. If the service does not fit the grammar but can implement External Context
-   MCP Profile v1, publish a separate local or remote MCP Extension. Qwen Core
-   still does not change.
-3. Change the profile only when multiple independent implementations prove a
-   missing interoperable capability. A single provider exception is not
-   sufficient.
+- The model supplies only `query`; it cannot select the endpoint, credential,
+  scope, dialect, timeout, or result limit.
+- HTTPS is required by default. Plain HTTP requires explicit
+  `allowInsecureHttp` opt-in for a trusted private network.
+- Origin validation rejects embedded credentials, query strings, fragments,
+  and paths. Static paths reject traversal, percent encoding, control
+  characters, and ambiguous separators.
+- The request engine does not follow redirects, retry, probe protocol versions,
+  or cache responses.
+- Requests have a bounded timeout. Responses are capped at 1 MiB before JSON
+  parsing, normalized through fixed fields, and limited to five results.
+- Retrieved content is untrusted external context. Fixed scope values are
+  routing values, not authorization boundaries.
+- A local Extension runs with the Qwen process user's privileges. The Extension
+  package is a distribution unit, not a sandbox or a security binding.
 
-A later implementation may accept an administrator-owned custom preset file
-for retrieval-only deployments. Such a file must use an absolute path, pass
-the same closed schema and semantic validation as built-in presets, and contain
-neither credentials nor executable behavior. Custom presets do not expand the
-grammar and cannot enable write operations.
+## Retrieval-only boundary
 
-This keeps new data sources configurable where their differences are data, and
-plugin-owned where their differences require behavior. It avoids making every
-new provider a Qwen release while also avoiding an unbounded HTTP programming
-language in configuration.
+The manifest exposes exactly `context_search`. A dialect cannot enable memory
+creation, update, deletion, or Auto Recall. Write protocols require a separate
+future profile or Extension because their idempotency, duplication, timeout,
+and authorization semantics do not fit the retrieval grammar.
 
-## Security and failure behavior
+## Packaging and service ownership
 
-- The model supplies only `query`. It cannot select the endpoint, credential,
-  user, agent, filter, dialect, timeout, or result limit.
-- Credentials are read from the named process environment variable. Presets
-  and instance configuration never contain credential values.
-- HTTPS is required by default. Plain HTTP requires an explicit
-  `allowInsecureHttp` opt-in intended for trusted private networks.
-- Endpoint validation treats `origin` and `basePath` separately and rejects
-  embedded credentials, query strings, fragments, dot traversal, and encoded
-  traversal.
-- The request engine does not follow redirects, retry requests, probe protocol
-  versions, or cache provider responses.
-- The provider timeout is shorter than the enclosing MCP timeout so the
-  Extension can return a bounded error. A provider response is capped at 1 MiB
-  before parsing.
-- Error results redact the query, endpoint, credential, upstream response body,
-  and raw exception. Retrieved content remains untrusted external context.
-- Fixed `userId`, `agentId`, and `appId` values are routing values, not
-  authorization boundaries. Shared multi-user deployments should use a
-  provider-operated Remote MCP service with OAuth subject binding and
-  provider-side authorization.
-- Managed deployments enforce the exact Extension and environment through
-  operator-owned system settings or pinned MCP configuration. An Extension is
-  a distribution unit, not a security binding or sandbox; a local Extension
-  runs with the Qwen process user's privileges.
+The npm package publishes only the bundled runtime, canonical schemas,
+Extension manifest, and README. It contains no administrator dialect, provider
+preset, provider identifier, or provider-specific contract fixture.
 
-## Retrieval and write boundary
-
-The portable Mem0 Extension v1 manifest exposes exactly:
-
-```json
-{
-  "includeTools": ["context_search"]
-}
-```
-
-Memory creation, update, and deletion require a separate future profile or
-Extension. A custom preset cannot enable them. Write protocols differ in
-idempotency, duplicate handling, ambiguous timeout outcomes, asynchronous
-status, inference behavior, and identifier formats; treating them as another
-search mapping would hide data-loss and duplication risks.
-
-## Relationship to PR #9952
-
-[PR #9952](https://github.com/QwenLM/qwen-code/pull/9952) provides useful
-PolarDB protocol and test evidence. This proposal is independent of that
-branch and does not add a `polardb-mem0` case to the private `ProviderConfig`
-union.
-
-A later Extension implementation can port verified request fixtures and
-normalization cases without cherry-picking the full provider-specific change.
-If PR #9952 merges first, its behavior remains backward-compatible until a
-separate migration decision. If it does not merge, superseding it with the
-Extension requires an explicit maintainer decision; this design document alone
-does not make that decision.
+When a service fits `DialectV1`, its administrator writes and validates a local
+dialect file. When it does not fit, the service owner publishes a separate MCP
+Extension implementing External Context MCP Profile v1. Qwen does not add a
+built-in provider rollout for either case.
 
 ## Rollout
 
-1. **PR0:** Land this architecture decision and its link from the External
-   Context provider-extension proposal. No runtime behavior changes.
-2. **PR1:** Add the self-contained Extension skeleton, canonical instance and
-   dialect schemas, the bounded request engine, and contract tests against
-   synthetic fixtures. Do not enable a live provider.
-3. **PR2:** Add verified retrieval presets for Mem0 Platform V3 and PolarDB
-   MySQL.
-4. **PR3:** Add Hologres, Mem0 OSS, RDS PostgreSQL, and other presets only after
-   each contract is verified independently.
-5. Design any portable write capability separately.
+1. **PR0:** Record the Extension architecture and External Context profile
+   boundary.
+2. **PR1:** Add the self-contained retrieval runtime, canonical schemas,
+   bounded request engine, and synthetic contract tests with an intentionally
+   empty registry.
+3. **PR2:** Replace the unused registry with administrator-owned
+   `InstanceConfigV2` and `DialectV1` files, while preserving the request engine
+   and profile boundary.
+4. Design any portable write capability separately.
 
-Each implementation pull request remains independently reviewable and can be
-rolled back by disabling or uninstalling the Extension. No step silently
-migrates existing direct-provider configuration.
+There is no Qwen-maintained provider-preset PR3. Administrators own compatible
+dialect data; incompatible protocols use their own MCP Extension.
 
-## PR0 verification
+## Verification
 
-PR0 changes documentation only. It introduces no user-visible behavior and
-does not require an E2E plan. Verification consists of Markdown formatting,
-link consistency, `git diff --check`, and two consecutive clean design audits
-covering architecture boundaries, failure paths, compatibility,
-maintainability, complexity, security, testing strategy, and simpler
-alternatives.
-
-## PR1 verification
-
-PR1 keeps the built-in preset registry empty, so the shipped Extension fails
-closed instead of enabling a live provider. Verification covers the canonical
-schemas, startup configuration boundary, bounded request engine, normalized
-result profile, MCP tool surface, package build and typecheck, release wiring,
-and synthetic GET and POST dialect fixtures. Live provider verification
-belongs to the pull request that adds each preset.
+Verification covers both canonical schemas; 64 KiB file limits; unavailable,
+malformed, unsupported, relative, and semantically invalid configurations;
+credential ordering; synthetic GET and POST request contracts; response
+normalization; the MCP tool surface; real stdio MCP startup against a local
+synthetic HTTP service; restart-only reload behavior; package contents; build,
+typecheck, lint, and tests. No verification contacts a live provider service.

--- a/integrations/external-context-mem0/README.md
+++ b/integrations/external-context-mem0/README.md
@@ -1,37 +1,87 @@
 # Mem0 External Context Extension
 
-This package is the retrieval-only Extension defined by the
-[Configurable Mem0 Provider Extension](../../docs/design/external-context-mem0-extension.md)
-proposal. It implements the External Context MCP Profile v1 server, validates
-administrator-owned instance configuration and closed dialect definitions, and
-contains a bounded HTTP request engine.
+This package provides a retrieval-only External Context MCP Profile v1 server
+for administrator-configured Mem0-compatible HTTP services. It validates a
+closed dialect grammar and uses a bounded HTTP request engine; it does not ship
+provider presets or provider-specific configuration.
 
-This PR1 package intentionally ships no live provider preset. Its built-in
-preset registry is empty, so the process fails closed with an unknown-preset
-configuration error. Verified Mem0 Platform and PolarDB presets are staged for
-PR2. Do not install this intermediate package as a usable provider Extension.
+## Configuration
 
-## Configuration contract
+Set `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` in the Extension process environment to
+the absolute path of an administrator-owned instance JSON file. The instance
+file must conform to
+[`schemas/instance-config.schema.json`](./schemas/instance-config.schema.json)
+and reference a separate dialect JSON file by absolute `dialectPath`:
 
-`QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` must contain the absolute path of an
-instance JSON file conforming to
-[`schemas/instance-config.schema.json`](./schemas/instance-config.schema.json).
-The instance selects one immutable built-in preset and binds its endpoint,
-credential environment-variable name, scope, and timeout. Credential values
-never belong in the instance file.
+```json
+{
+  "schemaVersion": 2,
+  "dialectPath": "/etc/qwen/external-context/memory.dialect.json",
+  "endpoint": {
+    "origin": "https://memory.example.com",
+    "basePath": "",
+    "allowInsecureHttp": false
+  },
+  "credentialEnv": "MEMORY_API_KEY",
+  "scope": {
+    "userId": "repository-memory"
+  },
+  "timeoutMs": 5000
+}
+```
 
-Preset authors must conform to
-[`schemas/dialect.schema.json`](./schemas/dialect.schema.json). The schema and
-semantic validator intentionally support only the bounded request and response
+The dialect file must conform to
+[`schemas/dialect.schema.json`](./schemas/dialect.schema.json). This synthetic
+example describes one supported shape without identifying a provider:
+
+```json
+{
+  "dialectVersion": 1,
+  "id": "organization-memory-v1",
+  "auth": "authorization-bearer",
+  "search": {
+    "method": "POST",
+    "path": "/memories/search",
+    "queryLocation": "json",
+    "userIdLocation": "json.filters",
+    "agentIdLocation": "omit",
+    "appIdLocation": "omit",
+    "limitField": "limit"
+  },
+  "response": {
+    "collection": "results",
+    "idField": "id",
+    "contentField": "memory",
+    "titleField": "omit",
+    "uriField": "omit",
+    "scoreField": "score",
+    "updatedAtField": "omit"
+  }
+}
+```
+
+The administrator controls both files and the process environment. Production
+deployments should keep them outside ordinary workspaces and supply the
+instance path through a system environment, controlled launcher, or pinned MCP
+configuration. `dialectPath` is never resolved relative to the instance file,
+expanded from environment variables, or loaded from a URL.
+
+The credential value must exist only in the environment variable named by
+`credentialEnv`; neither JSON file may contain it. Both files are limited to
+64 KiB and are read once when the Extension starts. Restart the Extension after
+changing either file.
+
+The schema intentionally supports only the bounded request and response
 grammar recorded in the design. Protocols that require arbitrary templates,
-headers, JSONPath, redirects, or executable transformations must use a separate
-MCP Extension.
+headers, JSONPath, redirects, executable transformations, or write operations
+must use a separate MCP Extension.
 
 ## Development
 
 ```bash
 npm run test --workspace=@qwen-code/external-context-mem0
 npm run typecheck --workspace=@qwen-code/external-context-mem0
+npm run lint --workspace=@qwen-code/external-context-mem0
 npm run build --workspace=@qwen-code/external-context-mem0
 ```
 

--- a/integrations/external-context-mem0/schemas/instance-config.schema.json
+++ b/integrations/external-context-mem0/schemas/instance-config.schema.json
@@ -1,11 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Mem0 External Context instance configuration v1",
+  "title": "Mem0 External Context instance configuration v2",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schemaVersion",
-    "preset",
+    "dialectPath",
     "endpoint",
     "credentialEnv",
     "scope",
@@ -13,13 +13,11 @@
   ],
   "properties": {
     "schemaVersion": {
-      "const": 1
+      "const": 2
     },
-    "preset": {
+    "dialectPath": {
       "type": "string",
-      "minLength": 1,
-      "maxLength": 128,
-      "pattern": "^[a-z0-9]+(?:[a-z0-9.-]*[a-z0-9])?$"
+      "minLength": 1
     },
     "endpoint": {
       "type": "object",

--- a/integrations/external-context-mem0/src/config.ts
+++ b/integrations/external-context-mem0/src/config.ts
@@ -13,7 +13,7 @@ import {
 } from './schemas.js';
 import type {
   DialectV1,
-  InstanceConfigV1,
+  InstanceConfigV2,
   RuntimeConfiguration,
   ScopeLocation,
 } from './types.js';
@@ -21,10 +21,9 @@ import type {
 const CONFIG_ENV = 'QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG';
 const MAX_CONFIG_BYTES = 64 * 1024;
 
-export async function loadRuntimeConfiguration(options: {
-  presets: ReadonlyMap<string, unknown>;
-  env?: NodeJS.ProcessEnv;
-}): Promise<RuntimeConfiguration> {
+export async function loadRuntimeConfiguration(
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<RuntimeConfiguration> {
   const env = options.env ?? process.env;
   const configPath = readRequiredEnvironment(env, CONFIG_ENV);
   if (!isAbsolute(configPath)) {
@@ -33,15 +32,17 @@ export async function loadRuntimeConfiguration(options: {
     );
   }
 
-  const instance = parseInstanceConfig(await readConfigFile(configPath));
-  const preset = options.presets.get(instance.preset);
-  if (preset === undefined) {
-    throw new ConfigurationError('Mem0 extension preset is unknown.');
+  const instance = parseInstanceConfig(
+    await readConfigFile(configPath, 'instance'),
+  );
+  if (!isAbsolute(instance.dialectPath)) {
+    throw new ConfigurationError(
+      'Mem0 extension dialect path must be absolute.',
+    );
   }
-  const dialect = parseDialect(preset);
-  if (dialect.id !== instance.preset) {
-    throw new ConfigurationError('Mem0 extension preset is invalid.');
-  }
+  const dialect = parseDialect(
+    await readConfigFile(instance.dialectPath, 'dialect'),
+  );
 
   validateInstance(instance, dialect);
   return {
@@ -51,7 +52,10 @@ export async function loadRuntimeConfiguration(options: {
   };
 }
 
-async function readConfigFile(path: string): Promise<unknown> {
+async function readConfigFile(
+  path: string,
+  kind: 'instance' | 'dialect',
+): Promise<unknown> {
   let source: Buffer;
   let file: FileHandle | undefined;
   try {
@@ -71,23 +75,27 @@ async function readConfigFile(path: string): Promise<unknown> {
     source = source.subarray(0, offset);
   } catch {
     throw new ConfigurationError(
-      'Mem0 extension configuration is unavailable.',
+      `Mem0 extension ${kind} configuration is unavailable.`,
     );
   } finally {
     await file?.close().catch(() => undefined);
   }
   if (source.byteLength > MAX_CONFIG_BYTES) {
-    throw new ConfigurationError('Mem0 extension configuration is invalid.');
+    throw new ConfigurationError(
+      `Mem0 extension ${kind} configuration is invalid.`,
+    );
   }
   try {
     return JSON.parse(source.toString('utf8')) as unknown;
   } catch {
-    throw new ConfigurationError('Mem0 extension configuration is invalid.');
+    throw new ConfigurationError(
+      `Mem0 extension ${kind} configuration is invalid.`,
+    );
   }
 }
 
 function validateInstance(
-  instance: InstanceConfigV1,
+  instance: InstanceConfigV2,
   dialect: DialectV1,
 ): void {
   validateEndpoint(instance);
@@ -97,7 +105,7 @@ function validateInstance(
   validateScope(instance, dialect);
 }
 
-function validateEndpoint(instance: InstanceConfigV1): void {
+function validateEndpoint(instance: InstanceConfigV2): void {
   let origin: URL;
   try {
     origin = new URL(instance.endpoint.origin);
@@ -157,11 +165,11 @@ function validateDialectSemantics(dialect: DialectV1): void {
     dialect.search.appIdLocation,
   ];
   if (locations.some((location) => location.startsWith('json'))) {
-    throw new ConfigurationError('Mem0 extension preset is invalid.');
+    throw new ConfigurationError('Mem0 extension dialect is invalid.');
   }
 }
 
-function validateScope(instance: InstanceConfigV1, dialect: DialectV1): void {
+function validateScope(instance: InstanceConfigV2, dialect: DialectV1): void {
   requireScopeValue(instance.scope.userId, dialect.search.userIdLocation);
   requireScopeValue(instance.scope.agentId, dialect.search.agentIdLocation);
   requireScopeValue(instance.scope.appId, dialect.search.appIdLocation);
@@ -180,14 +188,14 @@ function readRequiredEnvironment(env: NodeJS.ProcessEnv, name: string): string {
   const trimmed = value?.trim();
   if (!value || !trimmed || trimmed === '${' + name + '}') {
     throw new ConfigurationError(
-      'Mem0 extension configuration is unavailable.',
+      'Mem0 extension instance configuration is unavailable.',
     );
   }
   return value;
 }
 
 export function buildSearchUrl(
-  instance: InstanceConfigV1,
+  instance: InstanceConfigV2,
   dialect: DialectV1,
 ): URL {
   const url = new URL(instance.endpoint.origin);

--- a/integrations/external-context-mem0/src/main.test.ts
+++ b/integrations/external-context-mem0/src/main.test.ts
@@ -45,6 +45,7 @@ describe('Mem0 extension startup', () => {
 
     await import('./main.js');
 
+    expect(loadRuntimeConfiguration).toHaveBeenCalledWith();
     expect(createRequestEngine).toHaveBeenCalledWith(runtime);
     expect(createMem0McpServer).toHaveBeenCalledWith({
       instance: runtime.instance,

--- a/integrations/external-context-mem0/src/main.ts
+++ b/integrations/external-context-mem0/src/main.ts
@@ -7,12 +7,11 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadRuntimeConfiguration } from './config.js';
 import { createMem0McpServer } from './mcp.js';
-import { builtInPresets } from './presets.js';
 import { createRequestEngine } from './request-engine.js';
 import { ConfigurationError } from './schemas.js';
 
 try {
-  const runtime = await loadRuntimeConfiguration({ presets: builtInPresets });
+  const runtime = await loadRuntimeConfiguration();
   const server = createMem0McpServer({
     instance: runtime.instance,
     search: createRequestEngine(runtime),

--- a/integrations/external-context-mem0/src/manifest.test.ts
+++ b/integrations/external-context-mem0/src/manifest.test.ts
@@ -6,7 +6,6 @@
 
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
-import { builtInPresets } from './presets.js';
 
 describe('Mem0 Extension package', () => {
   it('is self-contained and exposes only context_search', async () => {
@@ -31,8 +30,15 @@ describe('Mem0 Extension package', () => {
     expect(packageJson.dependencies).toBeUndefined();
   });
 
-  it('ships no live provider preset in PR1', () => {
-    expect([...builtInPresets]).toEqual([]);
+  it('ships only the runtime, schemas, manifest, and documentation', async () => {
+    const packageJson = await readJson('../package.json');
+
+    expect(packageJson.files).toEqual([
+      'dist/main.js',
+      'schemas',
+      'qwen-extension.json',
+      'README.md',
+    ]);
   });
 });
 

--- a/integrations/external-context-mem0/src/mcp.test.ts
+++ b/integrations/external-context-mem0/src/mcp.test.ts
@@ -214,8 +214,8 @@ async function connect(
     InMemoryTransport.createLinkedPair();
   const server = createMem0McpServer({
     instance: parseInstanceConfig({
-      schemaVersion: 1,
-      preset: 'synthetic-v1',
+      schemaVersion: 2,
+      dialectPath: '/administrator/synthetic-v1.dialect.json',
       endpoint: { origin: 'https://memory.example.com' },
       credentialEnv: 'SYNTHETIC_MEMORY_TOKEN',
       scope: {},

--- a/integrations/external-context-mem0/src/mcp.ts
+++ b/integrations/external-context-mem0/src/mcp.ts
@@ -11,10 +11,10 @@ import {
   outputSchema,
   renderResult,
 } from './profile.js';
-import type { InstanceConfigV1, SearchProvider } from './types.js';
+import type { InstanceConfigV2, SearchProvider } from './types.js';
 
 export function createMem0McpServer(runtime: {
-  instance: InstanceConfigV1;
+  instance: InstanceConfigV2;
   search: SearchProvider;
 }): McpServer {
   const server = new McpServer({

--- a/integrations/external-context-mem0/src/presets.ts
+++ b/integrations/external-context-mem0/src/presets.ts
@@ -1,7 +1,0 @@
-/**
- * @license
- * Copyright 2025 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
-
-export const builtInPresets: ReadonlyMap<string, unknown> = new Map();

--- a/integrations/external-context-mem0/src/request-engine.test.ts
+++ b/integrations/external-context-mem0/src/request-engine.test.ts
@@ -11,7 +11,7 @@ import { parseDialect, parseInstanceConfig } from './schemas.js';
 import type {
   DialectV1,
   ExternalContextItem,
-  InstanceConfigV1,
+  InstanceConfigV2,
   RuntimeConfiguration,
 } from './types.js';
 
@@ -243,7 +243,7 @@ describe('bounded Mem0 request engine', () => {
 });
 
 interface SyntheticFixture {
-  instance: InstanceConfigV1;
+  instance: InstanceConfigV2;
   dialect: DialectV1;
   credential: string;
   query: string;

--- a/integrations/external-context-mem0/src/schemas.test.ts
+++ b/integrations/external-context-mem0/src/schemas.test.ts
@@ -15,8 +15,9 @@ import {
   parseDialect,
   parseInstanceConfig,
 } from './schemas.js';
-import type { DialectV1, InstanceConfigV1 } from './types.js';
+import type { DialectV1, InstanceConfigV2 } from './types.js';
 
+const MAX_CONFIG_BYTES = 64 * 1024;
 const temporaryDirectories: string[] = [];
 
 afterEach(async () => {
@@ -28,7 +29,7 @@ afterEach(async () => {
 });
 
 describe('Mem0 Extension schemas', () => {
-  it('accepts both synthetic dialect contracts', async () => {
+  it('accepts InstanceConfigV2 and both synthetic dialect contracts', async () => {
     const ajv = new Ajv({ allErrors: true, strict: true });
     const [instanceSchema, dialectSchema, post, get] = await Promise.all([
       readJson('../schemas/instance-config.schema.json'),
@@ -44,19 +45,39 @@ describe('Mem0 Extension schemas', () => {
       expect(validateInstance.errors).toBeNull();
       expect(validateDialect(fixture.dialect)).toBe(true);
       expect(validateDialect.errors).toBeNull();
-      expect(parseInstanceConfig(fixture.instance).schemaVersion).toBe(1);
+      expect(parseInstanceConfig(fixture.instance).schemaVersion).toBe(2);
       expect(parseDialect(fixture.dialect).dialectVersion).toBe(1);
     }
   });
 
-  it('rejects executable or open-ended dialect fields', async () => {
+  it('rejects v1, v3, extra instance fields, and invalid dialects', async () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
+
+    expect(() =>
+      parseInstanceConfig({
+        ...fixture.instance,
+        schemaVersion: 1,
+        preset: 'legacy-preset-v1',
+      }),
+    ).toThrow('instance configuration is invalid');
+    expect(() =>
+      parseInstanceConfig({ ...fixture.instance, schemaVersion: 3 }),
+    ).toThrow('instance configuration is invalid');
+    expect(() =>
+      parseInstanceConfig({
+        ...fixture.instance,
+        apiKey: 'credential-must-not-be-stored-here',
+      }),
+    ).toThrow('instance configuration is invalid');
+    expect(() =>
+      parseDialect({ ...fixture.dialect, dialectVersion: 2 }),
+    ).toThrow('dialect configuration is invalid');
     expect(() =>
       parseDialect({
         ...fixture.dialect,
         headers: { 'x-tenant': '${MODEL_SELECTED_TENANT}' },
       }),
-    ).toThrow(ConfigurationError);
+    ).toThrow('dialect configuration is invalid');
     expect(() =>
       parseDialect({
         ...fixture.dialect,
@@ -65,27 +86,10 @@ describe('Mem0 Extension schemas', () => {
           contentField: '$.results[*].memory',
         },
       }),
-    ).toThrow(ConfigurationError);
-    expect(() =>
-      parseInstanceConfig({
-        ...fixture.instance,
-        apiKey: 'credential-must-not-be-stored-here',
-      }),
-    ).toThrow(ConfigurationError);
+    ).toThrow('dialect configuration is invalid');
   });
 
-  it('rejects unsupported instance and dialect versions', async () => {
-    const fixture = await readFixture('synthetic-filtered-post-v1.json');
-
-    expect(() =>
-      parseInstanceConfig({ ...fixture.instance, schemaVersion: 2 }),
-    ).toThrow(ConfigurationError);
-    expect(() =>
-      parseDialect({ ...fixture.dialect, dialectVersion: 2 }),
-    ).toThrow(ConfigurationError);
-  });
-
-  it('loads one preset, credential, endpoint, and scope at startup', async () => {
+  it('loads the instance, dialect, credential, endpoint, and scope at startup', async () => {
     const fixture = await readFixture('synthetic-query-get-v1.json');
     const instance = structuredClone(fixture.instance) as unknown as Record<
       string,
@@ -95,14 +99,13 @@ describe('Mem0 Extension schemas', () => {
     delete endpoint['basePath'];
     delete endpoint['allowInsecureHttp'];
     endpoint['origin'] = 'https://memory.example.com';
-    const configPath = await writeConfig(instance);
+    const { configPath } = await writeRuntimeConfiguration(
+      instance,
+      fixture.dialect,
+    );
 
     const runtime = await loadRuntimeConfiguration({
-      presets: new Map([[fixture.dialect.id, fixture.dialect]]),
-      env: {
-        QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-        SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-      },
+      env: runtimeEnvironment(configPath),
     });
 
     expect(runtime.instance.endpoint).toEqual({
@@ -114,53 +117,61 @@ describe('Mem0 Extension schemas', () => {
     expect(runtime.credential).toBe('runtime-token');
   });
 
-  it('fails closed for relative paths, unknown presets, and missing credentials', async () => {
+  it('treats the dialect id as an audit label rather than a lookup key', async () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
-    const presets = new Map([[fixture.dialect.id, fixture.dialect]]);
+    const dialect = { ...fixture.dialect, id: 'customer-audit-label-v1' };
+    const { configPath } = await writeRuntimeConfiguration(
+      fixture.instance,
+      dialect,
+    );
+
+    await expect(
+      loadRuntimeConfiguration({ env: runtimeEnvironment(configPath) }),
+    ).resolves.toMatchObject({ dialect: { id: 'customer-audit-label-v1' } });
+  });
+
+  it('fails closed for relative instance and dialect paths', async () => {
+    const fixture = await readFixture('synthetic-filtered-post-v1.json');
 
     await expect(
       loadRuntimeConfiguration({
-        presets,
-        env: { QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: 'relative.json' },
+        env: {
+          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: 'relative.json',
+        },
       }),
     ).rejects.toThrow('configuration path must be absolute');
 
-    const unknownPath = await writeConfig({
-      ...fixture.instance,
-      preset: 'unknown-v1',
-    });
-    await expect(
-      loadRuntimeConfiguration({
-        presets,
-        env: {
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: unknownPath,
-          SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-        },
-      }),
-    ).rejects.toThrow('preset is unknown');
-
-    const configPath = await writeConfig(fixture.instance);
-    await expect(
-      loadRuntimeConfiguration({
-        presets,
-        env: { QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath },
-      }),
-    ).rejects.toThrow('configuration is unavailable');
+    for (const dialectPath of [
+      'relative.json',
+      '${DIALECT_PATH}',
+      'https://memory.example.com/dialect.json',
+    ]) {
+      const { configPath } = await writeRuntimeConfiguration(
+        { ...fixture.instance, dialectPath },
+        fixture.dialect,
+        { preserveDialectPath: true },
+      );
+      await expect(
+        loadRuntimeConfiguration({ env: runtimeEnvironment(configPath) }),
+      ).rejects.toThrow('dialect path must be absolute');
+    }
   });
 
-  it('rejects blank and unresolved credentials', async () => {
+  it('rejects blank, unresolved, and missing credentials after validation', async () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
-    const presets = new Map([[fixture.dialect.id, fixture.dialect]]);
-    const configPath = await writeConfig(fixture.instance);
+    const { configPath } = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+    );
 
     for (const credential of [
+      undefined,
       '   ',
       '${SYNTHETIC_MEMORY_TOKEN}',
       '  ${SYNTHETIC_MEMORY_TOKEN}  ',
     ]) {
       await expect(
         loadRuntimeConfiguration({
-          presets,
           env: {
             QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
             SYNTHETIC_MEMORY_TOKEN: credential,
@@ -172,102 +183,151 @@ describe('Mem0 Extension schemas', () => {
     const preservedCredential = '  actual-token  ';
     await expect(
       loadRuntimeConfiguration({
-        presets,
         env: {
           QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
           SYNTHETIC_MEMORY_TOKEN: preservedCredential,
         },
       }),
     ).resolves.toMatchObject({ credential: preservedCredential });
+
+    const invalidDialect = {
+      ...fixture.dialect,
+      search: { ...fixture.dialect.search, path: '/safe/%2e' },
+    };
+    const invalid = await writeRuntimeConfiguration(
+      fixture.instance,
+      invalidDialect,
+    );
+    await expect(
+      loadRuntimeConfiguration({
+        env: { QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: invalid.configPath },
+      }),
+    ).rejects.toThrow('path is invalid');
   });
 
-  it('fails closed for unavailable, malformed, and oversized configuration files', async () => {
+  it('bounds unavailable, malformed, and oversized instance files', async () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
-    const presets = new Map([[fixture.dialect.id, fixture.dialect]]);
     const directory = await makeTemporaryDirectory();
-    const environment = {
-      SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-    };
 
     await expect(
       loadRuntimeConfiguration({
-        presets,
-        env: {
-          ...environment,
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: join(directory, 'missing.json'),
-        },
+        env: runtimeEnvironment(join(directory, 'missing.json')),
       }),
-    ).rejects.toThrow('configuration is unavailable');
-
-    const malformedPath = await writeConfigSource('{');
+    ).rejects.toThrow('instance configuration is unavailable');
     await expect(
-      loadRuntimeConfiguration({
-        presets,
-        env: {
-          ...environment,
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: malformedPath,
-        },
-      }),
-    ).rejects.toThrow('configuration is invalid');
+      loadRuntimeConfiguration({ env: runtimeEnvironment(directory) }),
+    ).rejects.toThrow('instance configuration is unavailable');
 
-    const exactLimitSource = JSON.stringify(fixture.instance).padEnd(
-      64 * 1024,
-      ' ',
+    const malformedPath = await writeStandaloneFile('instance.json', '{');
+    await expect(
+      loadRuntimeConfiguration({ env: runtimeEnvironment(malformedPath) }),
+    ).rejects.toThrow('instance configuration is invalid');
+
+    const exact = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+      {
+        instanceSource: (instance) =>
+          JSON.stringify(instance).padEnd(MAX_CONFIG_BYTES, ' '),
+      },
     );
-    const exactLimitPath = await writeConfigSource(exactLimitSource);
     await expect(
-      loadRuntimeConfiguration({
-        presets,
-        env: {
-          ...environment,
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: exactLimitPath,
-        },
-      }),
+      loadRuntimeConfiguration({ env: runtimeEnvironment(exact.configPath) }),
     ).resolves.toMatchObject({ dialect: { id: fixture.dialect.id } });
 
-    const oversizedPath = await writeConfigSource(`${exactLimitSource} `);
+    const oversized = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+      {
+        instanceSource: (instance) =>
+          JSON.stringify(instance).padEnd(MAX_CONFIG_BYTES + 1, ' '),
+      },
+    );
     await expect(
       loadRuntimeConfiguration({
-        presets,
-        env: {
-          ...environment,
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: oversizedPath,
-        },
+        env: runtimeEnvironment(oversized.configPath),
       }),
-    ).rejects.toThrow('configuration is invalid');
+    ).rejects.toThrow('instance configuration is invalid');
   });
 
-  it('rejects a preset whose id differs from its registry key', async () => {
+  it('bounds unavailable, malformed, and oversized dialect files', async () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
-    const configPath = await writeConfig(fixture.instance);
+    const missingDirectory = await makeTemporaryDirectory();
+    const missing = await writeRuntimeConfiguration(
+      {
+        ...fixture.instance,
+        dialectPath: join(missingDirectory, 'missing.json'),
+      },
+      fixture.dialect,
+      { preserveDialectPath: true },
+    );
+    await expect(
+      loadRuntimeConfiguration({ env: runtimeEnvironment(missing.configPath) }),
+    ).rejects.toThrow('dialect configuration is unavailable');
 
+    const unreadable = await writeRuntimeConfiguration(
+      { ...fixture.instance, dialectPath: missingDirectory },
+      fixture.dialect,
+      { preserveDialectPath: true },
+    );
     await expect(
       loadRuntimeConfiguration({
-        presets: new Map([
-          [
-            fixture.instance.preset,
-            { ...fixture.dialect, id: 'different-preset-v1' },
-          ],
-        ]),
-        env: {
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-          SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-        },
+        env: runtimeEnvironment(unreadable.configPath),
       }),
-    ).rejects.toThrow('preset is invalid');
+    ).rejects.toThrow('dialect configuration is unavailable');
+
+    const malformed = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+      { dialectSource: '{' },
+    );
+    await expect(
+      loadRuntimeConfiguration({
+        env: runtimeEnvironment(malformed.configPath),
+      }),
+    ).rejects.toThrow('dialect configuration is invalid');
+
+    const exact = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+      {
+        dialectSource: JSON.stringify(fixture.dialect).padEnd(
+          MAX_CONFIG_BYTES,
+          ' ',
+        ),
+      },
+    );
+    await expect(
+      loadRuntimeConfiguration({ env: runtimeEnvironment(exact.configPath) }),
+    ).resolves.toMatchObject({ dialect: { id: fixture.dialect.id } });
+
+    const oversized = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+      {
+        dialectSource: JSON.stringify(fixture.dialect).padEnd(
+          MAX_CONFIG_BYTES + 1,
+          ' ',
+        ),
+      },
+    );
+    await expect(
+      loadRuntimeConfiguration({
+        env: runtimeEnvironment(oversized.configPath),
+      }),
+    ).rejects.toThrow('dialect configuration is invalid');
   });
 
   it('joins a trailing-slash base path without introducing a double slash', async () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
     const instance = structuredClone(fixture.instance);
     instance.endpoint.basePath = '/tenant-a/';
-    const configPath = await writeConfig(instance);
+    const { configPath } = await writeRuntimeConfiguration(
+      instance,
+      fixture.dialect,
+    );
     const runtime = await loadRuntimeConfiguration({
-      presets: new Map([[fixture.dialect.id, fixture.dialect]]),
-      env: {
-        QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-        SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-      },
+      env: runtimeEnvironment(configPath),
     });
 
     expect(buildSearchUrl(runtime.instance, runtime.dialect).href).toBe(
@@ -277,14 +337,13 @@ describe('Mem0 Extension schemas', () => {
 
   it('accepts explicitly opted-in plain HTTP', async () => {
     const fixture = await readFixture('synthetic-query-get-v1.json');
-    const configPath = await writeConfig(fixture.instance);
+    const { configPath } = await writeRuntimeConfiguration(
+      fixture.instance,
+      fixture.dialect,
+    );
 
     const runtime = await loadRuntimeConfiguration({
-      presets: new Map([[fixture.dialect.id, fixture.dialect]]),
-      env: {
-        QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-        SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-      },
+      env: runtimeEnvironment(configPath),
     });
 
     expect(runtime.instance.endpoint).toMatchObject({
@@ -296,44 +355,44 @@ describe('Mem0 Extension schemas', () => {
   it.each([
     {
       name: 'plain HTTP without opt-in',
-      mutate: (instance: InstanceConfigV1) => {
+      mutate: (instance: InstanceConfigV2) => {
         instance.endpoint.origin = 'http://memory.internal';
         instance.endpoint.allowInsecureHttp = false;
       },
     },
     {
       name: 'credentials in the origin',
-      mutate: (instance: InstanceConfigV1) => {
+      mutate: (instance: InstanceConfigV2) => {
         instance.endpoint.origin = 'https://user:password@memory.example.com';
       },
     },
     {
       name: 'path in the origin',
-      mutate: (instance: InstanceConfigV1) => {
+      mutate: (instance: InstanceConfigV2) => {
         instance.endpoint.origin = 'https://memory.example.com/api';
       },
     },
     {
       name: 'query in the origin',
-      mutate: (instance: InstanceConfigV1) => {
+      mutate: (instance: InstanceConfigV2) => {
         instance.endpoint.origin = 'https://memory.example.com?tenant=x';
       },
     },
     {
       name: 'fragment in the origin',
-      mutate: (instance: InstanceConfigV1) => {
+      mutate: (instance: InstanceConfigV2) => {
         instance.endpoint.origin = 'https://memory.example.com#tenant';
       },
     },
     {
       name: 'encoded base-path traversal, including double encoding',
-      mutate: (instance: InstanceConfigV1) => {
+      mutate: (instance: InstanceConfigV2) => {
         instance.endpoint.basePath = '/safe/%252e%252e/private';
       },
     },
     {
       name: 'ambiguous double slash',
-      mutate: (instance: InstanceConfigV1) => {
+      mutate: (instance: InstanceConfigV2) => {
         instance.endpoint.basePath = '/safe//private';
       },
     },
@@ -341,16 +400,13 @@ describe('Mem0 Extension schemas', () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
     const instance = parseInstanceConfig(structuredClone(fixture.instance));
     mutate(instance);
-    const configPath = await writeConfig(instance);
+    const { configPath } = await writeRuntimeConfiguration(
+      instance,
+      fixture.dialect,
+    );
 
     await expect(
-      loadRuntimeConfiguration({
-        presets: new Map([[fixture.dialect.id, fixture.dialect]]),
-        env: {
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-          SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-        },
-      }),
+      loadRuntimeConfiguration({ env: runtimeEnvironment(configPath) }),
     ).rejects.toThrow(ConfigurationError);
   });
 
@@ -360,73 +416,71 @@ describe('Mem0 Extension schemas', () => {
     '/safe?tenant=x',
     '/safe\\private',
     '/safe//private',
-  ])('rejects unsafe preset search path %s', async (searchPath) => {
+  ])('rejects unsafe dialect search path %s', async (searchPath) => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
-    const dialect = structuredClone(fixture.dialect) as DialectV1;
+    const dialect = structuredClone(fixture.dialect);
     dialect.search.path = searchPath;
-    const configPath = await writeConfig(fixture.instance);
+    const { configPath } = await writeRuntimeConfiguration(
+      fixture.instance,
+      dialect,
+    );
 
     await expect(
-      loadRuntimeConfiguration({
-        presets: new Map([[dialect.id, dialect]]),
-        env: {
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-          SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-        },
-      }),
+      loadRuntimeConfiguration({ env: runtimeEnvironment(configPath) }),
     ).rejects.toThrow('path is invalid');
   });
 
-  it('rejects scope fields not consumed exactly by the preset', async () => {
+  it('rejects scope fields not consumed exactly by the dialect', async () => {
     const fixture = await readFixture('synthetic-filtered-post-v1.json');
     const missing = structuredClone(fixture.instance);
     delete missing.scope.userId;
-    const missingPath = await writeConfig(missing);
+    const missingRuntime = await writeRuntimeConfiguration(
+      missing,
+      fixture.dialect,
+    );
     await expect(
       loadRuntimeConfiguration({
-        presets: new Map([[fixture.dialect.id, fixture.dialect]]),
-        env: {
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: missingPath,
-          SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-        },
+        env: runtimeEnvironment(missingRuntime.configPath),
       }),
     ).rejects.toThrow('scope is invalid');
 
     const extra = structuredClone(fixture.instance);
     extra.scope.appId = 'model-must-not-select-this';
-    const extraPath = await writeConfig(extra);
+    const extraRuntime = await writeRuntimeConfiguration(
+      extra,
+      fixture.dialect,
+    );
     await expect(
       loadRuntimeConfiguration({
-        presets: new Map([[fixture.dialect.id, fixture.dialect]]),
-        env: {
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: extraPath,
-          SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-        },
+        env: runtimeEnvironment(extraRuntime.configPath),
       }),
     ).rejects.toThrow('scope is invalid');
   });
 
   it('rejects JSON placement in a GET dialect', async () => {
     const fixture = await readFixture('synthetic-query-get-v1.json');
-    const dialect = structuredClone(fixture.dialect) as DialectV1;
+    const dialect = structuredClone(fixture.dialect);
     dialect.search.queryLocation = 'json';
-    const configPath = await writeConfig(fixture.instance);
+    const { configPath } = await writeRuntimeConfiguration(
+      fixture.instance,
+      dialect,
+    );
 
     await expect(
-      loadRuntimeConfiguration({
-        presets: new Map([[dialect.id, dialect]]),
-        env: {
-          QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
-          SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
-        },
-      }),
-    ).rejects.toThrow('preset is invalid');
+      loadRuntimeConfiguration({ env: runtimeEnvironment(configPath) }),
+    ).rejects.toThrow('dialect is invalid');
   });
 });
 
 interface SyntheticFixture {
-  instance: InstanceConfigV1;
+  instance: InstanceConfigV2;
   dialect: DialectV1;
+}
+
+interface RuntimeWriteOptions {
+  preserveDialectPath?: boolean;
+  instanceSource?: (instance: unknown) => string | Buffer;
+  dialectSource?: string | Buffer;
 }
 
 async function readFixture(name: string): Promise<SyntheticFixture> {
@@ -439,14 +493,39 @@ async function readJson(relativePath: string): Promise<unknown> {
   ) as unknown;
 }
 
-async function writeConfig(value: unknown): Promise<string> {
-  return writeConfigSource(JSON.stringify(value));
+async function writeRuntimeConfiguration(
+  instance: unknown,
+  dialect: unknown,
+  options: RuntimeWriteOptions = {},
+): Promise<{ configPath: string; dialectPath: string }> {
+  const directory = await makeTemporaryDirectory();
+  const configPath = join(directory, 'instance.json');
+  const dialectPath = join(directory, 'dialect.json');
+  const configuredInstance = {
+    ...(instance as Record<string, unknown>),
+    dialectPath: options.preserveDialectPath
+      ? (instance as Record<string, unknown>)['dialectPath']
+      : dialectPath,
+  };
+  await writeFile(
+    dialectPath,
+    options.dialectSource ?? JSON.stringify(dialect),
+  );
+  await writeFile(
+    configPath,
+    options.instanceSource?.(configuredInstance) ??
+      JSON.stringify(configuredInstance),
+  );
+  return { configPath, dialectPath };
 }
 
-async function writeConfigSource(value: string | Buffer): Promise<string> {
+async function writeStandaloneFile(
+  name: string,
+  source: string | Buffer,
+): Promise<string> {
   const directory = await makeTemporaryDirectory();
-  const path = join(directory, 'config.json');
-  await writeFile(path, value);
+  const path = join(directory, name);
+  await writeFile(path, source);
   return path;
 }
 
@@ -454,4 +533,11 @@ async function makeTemporaryDirectory(): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), 'qwen-mem0-config-'));
   temporaryDirectories.push(directory);
   return directory;
+}
+
+function runtimeEnvironment(configPath: string): NodeJS.ProcessEnv {
+  return {
+    QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG: configPath,
+    SYNTHETIC_MEMORY_TOKEN: 'runtime-token',
+  };
 }

--- a/integrations/external-context-mem0/src/schemas.ts
+++ b/integrations/external-context-mem0/src/schemas.ts
@@ -9,7 +9,7 @@ import { Ajv, type ValidateFunction } from 'ajv';
 import dialectSchema from '../schemas/dialect.schema.json' with { type: 'json' };
 // eslint-disable-next-line import/no-internal-modules -- bundle the canonical package schema
 import instanceConfigSchema from '../schemas/instance-config.schema.json' with { type: 'json' };
-import type { DialectV1, InstanceConfigV1 } from './types.js';
+import type { DialectV1, InstanceConfigV2 } from './types.js';
 
 const ajv = new Ajv({ allErrors: true, strict: true });
 const validateInstance = ajv.compile(instanceConfigSchema);
@@ -17,15 +17,19 @@ const validateDialect = ajv.compile(dialectSchema);
 
 export class ConfigurationError extends Error {}
 
-export function parseInstanceConfig(value: unknown): InstanceConfigV1 {
-  requireValid(validateInstance, value);
-  const parsed = value as Omit<InstanceConfigV1, 'endpoint'> & {
+export function parseInstanceConfig(value: unknown): InstanceConfigV2 {
+  requireValid(
+    validateInstance,
+    value,
+    'Mem0 extension instance configuration is invalid.',
+  );
+  const parsed = value as Omit<InstanceConfigV2, 'endpoint'> & {
     endpoint: Omit<
-      InstanceConfigV1['endpoint'],
+      InstanceConfigV2['endpoint'],
       'basePath' | 'allowInsecureHttp'
     > &
       Partial<
-        Pick<InstanceConfigV1['endpoint'], 'basePath' | 'allowInsecureHttp'>
+        Pick<InstanceConfigV2['endpoint'], 'basePath' | 'allowInsecureHttp'>
       >;
   };
   return {
@@ -39,15 +43,20 @@ export function parseInstanceConfig(value: unknown): InstanceConfigV1 {
 }
 
 export function parseDialect(value: unknown): DialectV1 {
-  requireValid(validateDialect, value);
+  requireValid(
+    validateDialect,
+    value,
+    'Mem0 extension dialect configuration is invalid.',
+  );
   return value as DialectV1;
 }
 
 function requireValid(
   validate: ValidateFunction,
   value: unknown,
+  message: string,
 ): asserts value is object {
   if (!validate(value)) {
-    throw new ConfigurationError('Mem0 extension configuration is invalid.');
+    throw new ConfigurationError(message);
   }
 }

--- a/integrations/external-context-mem0/src/types.ts
+++ b/integrations/external-context-mem0/src/types.ts
@@ -11,9 +11,9 @@ export type AuthenticationKind =
 
 export type ScopeLocation = 'json' | 'json.filters' | 'query' | 'omit';
 
-export interface InstanceConfigV1 {
-  schemaVersion: 1;
-  preset: string;
+export interface InstanceConfigV2 {
+  schemaVersion: 2;
+  dialectPath: string;
   endpoint: {
     origin: string;
     basePath: string;
@@ -55,7 +55,7 @@ export interface DialectV1 {
 }
 
 export interface RuntimeConfiguration {
-  instance: InstanceConfigV1;
+  instance: InstanceConfigV2;
   dialect: DialectV1;
   credential: string;
 }

--- a/integrations/external-context-mem0/test/fixtures/synthetic-filtered-post-v1.json
+++ b/integrations/external-context-mem0/test/fixtures/synthetic-filtered-post-v1.json
@@ -1,7 +1,7 @@
 {
   "instance": {
-    "schemaVersion": 1,
-    "preset": "synthetic-filtered-post-v1",
+    "schemaVersion": 2,
+    "dialectPath": "/administrator/synthetic-filtered-post-v1.dialect.json",
     "endpoint": {
       "origin": "https://memory.example.com",
       "basePath": "/tenant-a",

--- a/integrations/external-context-mem0/test/fixtures/synthetic-query-get-v1.json
+++ b/integrations/external-context-mem0/test/fixtures/synthetic-query-get-v1.json
@@ -1,7 +1,7 @@
 {
   "instance": {
-    "schemaVersion": 1,
-    "preset": "synthetic-query-get-v1",
+    "schemaVersion": 2,
+    "dialectPath": "/administrator/synthetic-query-get-v1.dialect.json",
     "endpoint": {
       "origin": "http://memory.internal:8080",
       "allowInsecureHttp": true


### PR DESCRIPTION
## What this PR does

This PR changes the retrieval-only `external-context-mem0` Extension to load an administrator-owned `DialectV1` JSON file referenced by an absolute `dialectPath` in `InstanceConfigV2`. It removes the unused built-in preset registry while preserving the existing closed request grammar, bounded response normalization, External Context MCP Profile, and `context_search` tool surface.

The instance and dialect files are each limited to 64 KiB and read once at Extension startup. Endpoint, path, scope, and dialect semantics are validated before the credential named by `credentialEnv` is read. Errors remain fixed and redacted, and the package continues to contain no provider or customer dialect data.

## Why it's needed

PR #10149 intentionally shipped an empty preset registry, so administrators could not connect a compatible service without a new Qwen release. Administrator-owned dialect files make the existing bounded runtime usable while keeping Qwen out of the provider-preset business and keeping credentials out of Qwen settings and JSON configuration files.

## Reviewer Test Plan

### How to verify

1. Create an `InstanceConfigV2` file outside the workspace that references an absolute `DialectV1` file, set `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` plus the named credential environment variable, and start the bundled Extension. It should initialize successfully, expose only `context_search`, and send the exact bounded request described by the dialect with the administrator-fixed scope.
2. Modify the dialect while the Extension is running. The running process should retain its startup configuration; after restart, the new dialect should take effect.
3. Try a v1 `preset` configuration, a relative or URL dialect path, missing or malformed files, a file over 64 KiB, an unsupported dialect field, inconsistent scope placement, or a missing credential. Startup should fail closed with a fixed redacted category that does not reveal paths, endpoints, credentials, queries, or upstream responses.
4. Inspect the package dry-run output. It should contain only the bundle, schemas, manifest, README, and package metadata, with no provider-specific dialect or fixture.

Locally verified with 49 package tests, package and root typecheck/lint/build, a real bundled stdio MCP flow against a loopback synthetic HTTP service, restart-only reload assertions, redacted startup-failure assertions, formatting checks, and `npm pack --dry-run`.

### Evidence (Before & After)

N/A — this changes non-UI Extension configuration and runtime behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js 24.12.0 and npm 10.9.8, using the bundled stdio MCP server and a local loopback synthetic HTTP service.

## Risk & Scope

- Main risk or tradeoff: Administrators now own dialect correctness and file deployment, while Qwen accepts only the existing closed `DialectV1` grammar and treats the files and process environment as an administrative trust boundary.
- Not validated / out of scope: Provider-specific presets and fixtures, write operations, Auto Recall, retries, redirects, protocol probing, arbitrary templates, JSONPath, dynamic provider loading, Qwen Core changes, and ordinary Extension settings remain out of scope. Windows and Linux were not tested locally and are left to CI.
- Breaking changes / migration notes: `schemaVersion: 1` configurations using `preset` now fail closed. Administrators must migrate to `schemaVersion: 2` and provide an absolute `dialectPath`; credentials remain in the environment variable named by `credentialEnv`.

## Linked Issues

Related: #10113, #10149

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将只读检索的 `external-context-mem0` Extension 调整为加载管理员自有的 `DialectV1` JSON 文件，该文件由 `InstanceConfigV2` 中的绝对路径 `dialectPath` 引用。同时删除未实际使用的内置 preset registry，并保持现有封闭请求语法、有界响应归一化、External Context MCP Profile 和 `context_search` 工具接口不变。

实例文件和 dialect 文件分别限制为 64 KiB，并且只在 Extension 启动时读取一次。系统先校验 endpoint、路径、scope 和 dialect 语义，之后才读取 `credentialEnv` 指定的凭证。错误仍使用固定脱敏分类，发布包继续不包含任何厂商或客户 dialect 数据。

## 为什么需要

PR #10149 有意发布了空 preset registry，因此管理员无法在不等待新的 Qwen 版本时接入兼容服务。管理员自有 dialect 文件让现有有界运行时真正可用，同时避免 Qwen 维护厂商 preset，并确保凭证不进入 Qwen settings 或 JSON 配置文件。

## Reviewer 测试计划

### 如何验证

1. 在工作区外创建一个 `InstanceConfigV2` 文件并通过绝对路径引用 `DialectV1` 文件，设置 `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` 和指定的凭证环境变量，然后启动打包后的 Extension。它应成功初始化、只暴露 `context_search`，并按照 dialect 发送精确的有界请求，scope 固定由管理员配置。
2. 在 Extension 运行期间修改 dialect。当前进程应继续使用启动时配置；重启后，新 dialect 应生效。
3. 分别尝试 v1 `preset` 配置、相对路径或 URL dialect 路径、缺失或损坏文件、超过 64 KiB 的文件、不支持的 dialect 字段、不一致的 scope 位置或缺失凭证。启动应 fail closed，并只返回固定脱敏分类，不泄露路径、endpoint、凭证、query 或上游响应。
4. 检查 package dry-run 输出。内容应只有 bundle、schemas、manifest、README 和 package 元数据，不包含任何厂商专用 dialect 或 fixture。

本地已验证 49 个包级测试、包级和根仓库 typecheck/lint/build、基于本地 loopback 合成 HTTP 服务的真实 bundle stdio MCP 流程、仅重启加载新配置的断言、启动失败脱敏断言、格式检查以及 `npm pack --dry-run`。

### 证据（变更前后）

N/A — 本变更不涉及 UI，只调整 Extension 配置和运行时行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS，Node.js 24.12.0，npm 10.9.8；使用打包后的 stdio MCP server 和本地 loopback 合成 HTTP 服务。

## 风险与范围

- 主要风险或取舍：管理员负责 dialect 正确性和文件部署；Qwen 只接受现有封闭 `DialectV1` 语法，并将这些文件和进程环境视为管理员信任边界。
- 未验证 / 范围外：厂商专用 preset 和 fixture、写操作、Auto Recall、重试、重定向、协议探测、任意模板、JSONPath、动态 provider 加载、Qwen Core 改动和普通 Extension settings 均不在范围内。Windows 和 Linux 未在本地测试，交由 CI 验证。
- 破坏性变更 / 迁移说明：使用 `preset` 的 `schemaVersion: 1` 配置现在会 fail closed。管理员必须迁移到 `schemaVersion: 2` 并提供绝对 `dialectPath`；凭证继续仅存在于 `credentialEnv` 指定的环境变量中。

## 关联事项

相关：#10113、#10149

</details>
