### PR TITLE
config: make goal readiness methods reject instead of throwing sync

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -3169,6 +3169,17 @@ describe('Server Config (config.ts)', () => {
       );
     });
 
+    it('rejects readiness when chat recording is disabled instead of throwing synchronously', async () => {
+      const config = new Config({ ...baseParams, chatRecording: false });
+
+      await expect(config.getGoalRuntimeReady()).rejects.toBeInstanceOf(
+        GoalPersistenceUnavailableError,
+      );
+      await expect(config.getGoalRuntimePrepared()).rejects.toBeInstanceOf(
+        GoalPersistenceUnavailableError,
+      );
+    });
+
     it('does not leak the canonical Goal runtime through subagent prototypes', async () => {
       const config = new Config({ ...baseParams, chatRecording: true });
       const canonical = config.getGoalRuntime();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -8354,15 +8354,15 @@ export class Config {
     return this.goalRuntime;
   }
 
-  getGoalRuntimeReady(): Promise<GoalRuntime> {
+  async getGoalRuntimeReady(): Promise<GoalRuntime> {
     const runtime = this.getGoalRuntime();
     if (!Object.hasOwn(this, 'goalRuntimeReady') || !this.goalRuntimeReady) {
-      return Promise.reject(new GoalPersistenceUnavailableError());
+      throw new GoalPersistenceUnavailableError();
     }
     return this.goalRuntimeReady.then(() => runtime);
   }
 
-  getGoalRuntimePrepared(): Promise<GoalRuntime> {
+  async getGoalRuntimePrepared(): Promise<GoalRuntime> {
     const runtime = this.getGoalRuntime();
     if (!this.sessionRestoreRuntime) return this.getGoalRuntimeReady();
     return runtime.getPreparedRestore().then(() => runtime);


### PR DESCRIPTION
## What this PR does

`Config.getGoalRuntimeReady()` and `Config.getGoalRuntimePrepared()` are typed to return a Promise, but when goal persistence is unavailable — i.e. when chat recording is disabled — the underlying `getGoalRuntime()` throws `GoalPersistenceUnavailableError` synchronously. Because neither method was `async`, that throw escaped before any `.then()`/`.catch()` attached to the returned promise could observe it, so a chaining caller received a synchronous exception instead of a rejection. This change marks both methods `async` and swaps the `Promise.reject(...)` in the disabled branch for an equivalent `throw`, so the failure now surfaces as a rejection, matching the contract documented in `goal-protocol.ts`.

## Why it's needed

The two methods are part of the public config surface, typed as Promise-returning, and `goal-protocol.ts` documents readiness as rejecting when goal persistence is unavailable. Throwing synchronously violates that documented contract and would crash any future `.then()`/`.catch()` caller; the existing caller in `client.ts` only survives because it happens to use try/catch. This is the deferred review finding from #10331 (originally flagged in #10317). Marking the methods `async` is the smallest change that makes runtime behavior match the type signature and the documentation.

## Reviewer Test Plan

### How to verify

Construct a `Config` with `chatRecording: false` and call both readiness methods:
- Before the fix: the call itself throws `GoalPersistenceUnavailableError` synchronously, so the promise never reaches a `.rejects`/`.catch()` handler and an `await expect(...).rejects...` assertion fails.
- After the fix: both methods return a rejected promise carrying `GoalPersistenceUnavailableError`.

The added regression test asserts exactly this and fails on the pre-fix code (it is non-vacuous):

```ts
const config = new Config({ ...baseParams, chatRecording: false });
await expect(config.getGoalRuntimeReady()).rejects.toBeInstanceOf(GoalPersistenceUnavailableError);
await expect(config.getGoalRuntimePrepared()).rejects.toBeInstanceOf(GoalPersistenceUnavailableError);
```

Run it with vitest in `packages/core`, filtered to `config.test.ts`.

### Evidence (Before & After)

N/A — non-UI change covered by unit tests, no user-visible before/after. The new test fails before the fix and passes after it.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested (vitest locally) |
|  🐧 Linux  | ✅ tested (CI ubuntu) |

### Environment (optional)

N/A — unit tests only.

## Risk & Scope

- Main risk or tradeoff: None material. A synchronous throw and a rejection behave identically under try/catch (the existing caller), so behavior for current callers is unchanged; only `.then()`/`.catch()` chaining callers observe the corrected rejection semantics.
- Not validated / out of scope: No other callers modified; goal runtime persistence behavior itself is untouched.
- Breaking changes / migration notes: None. This restores the documented behavior — a caller that relied on a Promise-typed method throwing synchronously was relying on a bug.

## Linked Issues

References #10331 (the deferred review finding from #10317), which tracks multiple findings — referenced without a closing keyword.

<details>
<summary>中文说明</summary>

## What this PR does

`Config.getGoalRuntimeReady()` 与 `Config.getGoalRuntimePrepared()` 的返回类型都是 Promise，但当 goal persistence 不可用（即 chat recording 被禁用）时，底层的 `getGoalRuntime()` 会同步抛出 `GoalPersistenceUnavailableError`。由于这两个方法原本都不是 `async`，这个同步抛出的异常会在返回的 Promise 上挂载的 `.then()`/`.catch()` 观察到之前就逃逸出去，因此使用链式调用的调用方拿到的是同步异常而不是 promise rejection。本次改动把两个方法都标记为 `async`，并把禁用分支中的 `Promise.reject(...)` 换成等价的 `throw`，使失败以 rejection 的形式呈现，与 `goal-protocol.ts` 中记录的契约一致。

## Why it's needed

这两个方法是公共 config 接口的一部分，类型为返回 Promise，而 `goal-protocol.ts` 记录了当 goal persistence 不可用时 readiness 会 reject。同步抛出违反了该文档契约，会让任何未来的 `.then()`/`.catch()` 调用方崩溃；现有的 `client.ts` 调用方只是恰好因为使用 try/catch 而没有暴露问题。这正是 #10331 遗留的 review finding（最初在 #10317 中标记）。把方法标记为 `async` 是让运行时行为与类型签名和文档保持一致的最小改动。

## Reviewer Test Plan

### How to verify

构造一个 `chatRecording: false` 的 `Config` 并调用两个 readiness 方法：
- 修复前：调用本身会同步抛出 `GoalPersistenceUnavailableError`，Promise 永远不会进入 `.rejects`/`.catch()` 处理分支，`await expect(...).rejects...` 断言会失败。
- 修复后：两个方法都会返回携带 `GoalPersistenceUnavailableError` 的 rejected promise。

新增的回归测试正是断言这一点，并且在修复前的代码上会失败（非空测试）：

```ts
const config = new Config({ ...baseParams, chatRecording: false });
await expect(config.getGoalRuntimeReady()).rejects.toBeInstanceOf(GoalPersistenceUnavailableError);
await expect(config.getGoalRuntimePrepared()).rejects.toBeInstanceOf(GoalPersistenceUnavailableError);
```

运行方式：在 `packages/core` 中运行 vitest，过滤到 `config.test.ts`。

### Evidence (Before & After)

N/A —— 非 UI 改动，由单元测试覆盖，无用户可见的前后差异。新测试在修复前失败、修复后通过。

### Tested on

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ✅ 已测试（本地 vitest） |
|  🐧 Linux  | ✅ 已测试（CI ubuntu） |

### Environment (optional)

N/A —— 仅单元测试。

## Risk & Scope

- 主要风险或权衡：没有实质风险。同步抛出与 rejection 在 try/catch（现有调用方）下表现相同，因此对当前调用方行为不变；只有 `.then()`/`.catch()` 链式调用方才能观察到纠正后的 rejection 语义。
- 未验证 / 范围外：未改动其他调用方；goal runtime persistence 本身行为未动。
- 破坏性变更 / 迁移说明：无。本改动是恢复文档所述行为——依赖 Promise 类型方法同步抛出的调用方原本依赖的是一个 bug。

## Linked Issues

引用 #10331（来自 #10317 的遗留 review finding），该 issue 跟踪多个问题，故不带关闭关键字引用。

</details>
