### PR TITLE
test(ci): stabilize shared-runner budgets and cron interactive checks

### DIFF
--- a/integration-tests/interactive/cron-interactive.test.ts
+++ b/integration-tests/interactive/cron-interactive.test.ts
@@ -91,15 +91,14 @@ function makeEnv(): NodeJS.ProcessEnv {
     );
 
     await session.idle(5000);
-    await session.send('Reply with exactly USERPRIORITY77 nothing else');
+    const userPriorityMarker = 'USERPRIORITY77';
+    await session.send(`Reply with exactly ${userPriorityMarker} nothing else`);
 
     await session.waitForScreen(
-      (scr) => scr.includes('USERPRIORITY77'),
+      (scr) =>
+        scr.indexOf(userPriorityMarker) !== scr.lastIndexOf(userPriorityMarker),
       'model response containing USERPRIORITY77',
     );
-
-    const screen = await session.screen();
-    expect(screen).toContain('Type your message');
   });
 
   it(

--- a/packages/core/src/utils/shellAstParser.test.ts
+++ b/packages/core/src/utils/shellAstParser.test.ts
@@ -510,6 +510,8 @@ describe('isShellCommandReadOnlyAST', () => {
 // =========================================================================
 
 describe('classifyShellCommandSafety', () => {
+  const maxClassificationCpuMs = 1000;
+
   it.each([
     'ls -la',
     'git status --short',
@@ -908,20 +910,23 @@ describe('classifyShellCommandSafety', () => {
     expect(await classifyShellCommandSafety(command)).toBe('unknown');
   });
 
-  it('classifies deeply nested redirected substitutions without repeated traversal', async () => {
+  it('classifies deeply nested redirected substitutions within the CPU budget', async () => {
     const commands = ['git status', 'git status'];
     for (let depth = 0; depth < 20; depth++) {
       commands[0] = `echo $(${commands[0]}) < /dev/null`;
       commands[1] = `< <(${commands[1]}) cat`;
     }
-    const startedAt = performance.now();
+    const startedCpuUsage = process.cpuUsage();
     await expect(
       Promise.all(commands.map(classifyShellCommandSafety)),
     ).resolves.toEqual(['unknown', 'unknown']);
-    expect(performance.now() - startedAt).toBeLessThan(1000);
+    const cpuUsage = process.cpuUsage(startedCpuUsage);
+    expect((cpuUsage.user + cpuUsage.system) / 1000).toBeLessThan(
+      maxClassificationCpuMs,
+    );
   });
 
-  it('classifies adversarial rule inputs in bounded time', async () => {
+  it('classifies adversarial rule inputs within the CPU budget', async () => {
     const backslashes = '\\'.repeat(10_000);
     const repeatedSed = 'p;'.repeat(10_000);
     const repeatedPrint = 'print value; '.repeat(10_000);
@@ -935,7 +940,7 @@ describe('classifyShellCommandSafety', () => {
       `find . ${repeatedFindExec}`,
       `git status ${unmatchedBraces}`,
     ];
-    const startedAt = performance.now();
+    const startedCpuUsage = process.cpuUsage();
     await expect(
       Promise.all(commands.map(classifyShellCommandSafety)),
     ).resolves.toEqual([
@@ -946,7 +951,10 @@ describe('classifyShellCommandSafety', () => {
       'unknown',
       'read-only',
     ]);
-    expect(performance.now() - startedAt).toBeLessThan(1000);
+    const cpuUsage = process.cpuUsage(startedCpuUsage);
+    expect((cpuUsage.user + cpuUsage.system) / 1000).toBeLessThan(
+      maxClassificationCpuMs,
+    );
   });
 });
 


### PR DESCRIPTION
## What this PR does

This PR fixes two test-only CI failures without changing production behavior:

- Shell safety performance guards now measure process CPU time instead of elapsed wall-clock time, so shared-runner scheduling pauses do not count as parser work. The same one-second budget and classification assertions remain in place.
- The cron user-priority interactive check now waits for the marker to appear a second time, proving that the model responded instead of matching the echoed user prompt. It no longer assumes that the composer must display the default `Type your message` placeholder, because a generated follow-up suggestion can legitimately replace it.

## Why it's needed

### Shared-runner CPU contention

The Ubuntu test job in [run 33392035277](https://github.com/QwenLM/qwen-code/actions/runs/33392035277/job/99489780194) failed with `expected 1445.8520749999998 to be less than 1000`. The previous wall-clock assertion counted time spent descheduled on the shared ECS host, producing a false performance failure even when classification consumed well under one second of CPU.

After this change, CPU-intensive algorithmic or ReDoS regressions still exceed the unchanged budget, while scheduler wait does not.

### Release cron interactive check

The no-sandbox integration job in [release run 33401719747](https://github.com/QwenLM/qwen-code/actions/runs/33401719747/job/99520307863) failed after the model successfully returned `USERPRIORITY77`. The composer displayed the valid follow-up suggestion `Cancel the cron job`, which replaced the default placeholder and tripped an unrelated assertion.

The previous wait could also match `USERPRIORITY77` inside the user's own prompt. After this change, the test requires a second occurrence from the model response and stops coupling cron behavior to dynamic composer placeholder text.

## Reviewer Test Plan

### How to verify

1. Run the focused shell safety suite and confirm all classification assertions pass while both adversarial input groups stay below the one-second process CPU budget.
2. Run the no-sandbox cron interactive suite with follow-up suggestions enabled. Confirm the user-priority case waits for the model response and passes whether the composer shows the default placeholder or a generated suggestion.

### Evidence

- Prettier and ESLint pass for both changed test files.
- Focused shell safety suite: 548 tests passed in 1.52 seconds.
- Independent focused replay of the two CPU-budget cases: 2 passed; the measured test work took 135 ms.
- The cron execution path was reviewed against the terminal harness: the user prompt supplies the first marker occurrence and the model response supplies the second. A real local cron E2E was not run because this worktree does not contain the required built CLI bundle; the no-sandbox CI/release runner remains the end-to-end verification gate.

### Tested on

| OS | Status |
| :---: | :---: |
| macOS | ✅ focused checks |
| Linux | ⏳ CI |
| Windows | N/A — test-only logic |

## Risk & Scope

- Production behavior is unchanged.
- Process CPU time intentionally detects computation regressions rather than wall-clock stalls.
- The cron check validates the behavior it names: user input is processed while cron is active. Follow-up suggestion rendering remains covered by its own UI tests.
- Other timeout-based flakes tracked in #10490 are out of scope.

## Linked Issues

Fixes #10637

Fixes #10646

Related to #10490

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这个 PR 合并修复两类仅影响测试的 CI 假失败，不修改生产行为：

- shell 安全分类性能防线改用进程 CPU 时间，不再把共享 runner 被抢占、等待调度的时间算成解析耗时；原有一秒预算和分类结果断言保持不变。
- cron 用户输入优先级交互测试改为等待标记第二次出现，确保匹配到模型回复，而不是用户输入回显；同时移除对固定 `Type your message` 占位符的依赖，因为 follow-up suggestion 合法地会替换该占位符。

## 为什么需要

[run 33392035277](https://github.com/QwenLM/qwen-code/actions/runs/33392035277/job/99489780194) 中，墙钟计时在共享 ECS runner 竞争时超过一秒并误报。改用 CPU 时间后，算法退化和 ReDoS 仍会消耗 CPU 并触发同一预算，而调度等待不会。

[release run 33401719747](https://github.com/QwenLM/qwen-code/actions/runs/33401719747/job/99520307863) 中，模型已经成功返回 `USERPRIORITY77`，但输入框显示了合法的 follow-up suggestion `Cancel the cron job`，固定 placeholder 断言因此失败。旧等待条件也可能直接匹配用户输入中的同名标记。新条件要求标记出现两次，从而确认模型确实响应，并解除 cron 测试与动态输入框文案的耦合。

## 验证

- 两个改动文件的 Prettier 与 ESLint 均通过。
- shell 安全分类聚焦测试 548 个全部通过，总耗时 1.52 秒。
- 两个 CPU 预算用例的独立聚焦重放通过，测试工作耗时 135 毫秒。
- 本 worktree 缺少构建后的 CLI bundle，因此未声称在本地跑过真实 cron E2E；no-sandbox CI/release runner 是最终端到端验证关口。

## 关联问题

Fixes #10637

Fixes #10646

Related to #10490

</details>
