### PR TITLE
refactor(memory): deduplicate recall tokenization

### DIFF
--- a/docs/design/2026-08-31-shared-recall-tokenizer.md
+++ b/docs/design/2026-08-31-shared-recall-tokenizer.md
@@ -1,0 +1,89 @@
+# Shared Recall Tokenizer Primitives
+
+## Context
+
+Core auto-memory recall and channel memory recall independently implement
+NFKC normalization, lowercasing, and code-point bigram generation for CJK
+text. Keeping those mechanics duplicated makes it possible for equivalent
+memory text to normalize or split differently after a future change.
+
+The two callers are not otherwise equivalent. Their token policies and
+selection algorithms intentionally differ and must remain local.
+
+| Behavior                  | Core auto-memory                                     | Channel memory                               |
+| ------------------------- | ---------------------------------------------------- | -------------------------------------------- |
+| Unsafe invisible handling | Unchanged                                            | Replaced with spaces                         |
+| CJK runs                  | Han, Hiragana, Katakana, and Hangul may form one run | Each script forms a separate run             |
+| Other scripts             | Unicode letters, marks, and numbers                  | Latin letters and decimal numbers            |
+| Latin/number minimum      | Three code points                                    | Two code points                              |
+| Latin and numbers         | May form one token                                   | Separate namespaced terms                    |
+| CJK terms                 | Raw bigrams                                          | Script-namespaced bigrams                    |
+| Token bound               | First 32 and last 32 unique tokens                   | Unbounded set                                |
+| Matching                  | Query tokens against normalized document substrings  | Exact term overlap between message and entry |
+
+## Goals
+
+- Share the NFKC-plus-lowercase normalization primitive.
+- Share adjacent code-point bigram generation.
+- Keep a thin caller-specific tokenizer around each existing policy.
+- Preserve every current term, score, ordering rule, limit, and fallback.
+
+## Non-goals
+
+- Unifying the two token sets.
+- Changing recall ranking, scoring, limits, or fallback behavior.
+- Adding configuration or a tokenizer framework.
+- Redesigning memory storage or context assembly.
+
+## Proposed design
+
+Expose two side-effect-free helpers from a narrow channel-base subpath:
+
+- `normalizeRecallText(text)` returns `text.normalize('NFKC').toLowerCase()`.
+- `codePointBigrams(run)` yields each adjacent pair while iterating Unicode
+  code points rather than UTF-16 code units.
+
+Core keeps its combined CJK run expression, Unicode non-CJK token policy,
+deduplication, and 64-token edge bound. Channel memory keeps unsafe-invisible
+sanitization, per-script expressions, namespaces, minimum lengths, and its
+unbounded term set. These existing caller-specific functions are the thin
+adapters; no new class or configuration layer is needed.
+
+The selected package home is a side-effect-free
+`@qwen-code/channel-base/recallTokenizer` export. Channel-base cannot depend
+on core because channel plugins intentionally use channel-base as their only
+Qwen Code dependency. The reverse dependency has no source cycle and avoids a
+new publishable package. It does require building channel-base before core and
+declaring channel-base as a core build/test prerequisite.
+
+A dedicated shared package was considered and rejected for this change. It
+would require new build, lockfile, publication, release-order, and versioning
+surface for two small functions.
+
+Official triage on issue #9377 leaves this choice to the implementer and names
+this dependency direction as a natural option. The implementation can be
+validated locally while the external PR waits for maintainer feedback.
+
+## Downstream consumers
+
+Core auto-memory flows through `MemoryManager.recall` into `QwenClient`'s
+managed recall path used to assemble initial and tool-result model context.
+Channel memory flows through `ChannelBase` selection and prompt formatting;
+`PollingChannelBase` and the DingTalk, DWS, Feishu, GitHub, GitLab, QQBot,
+Telegram, WeCom, Weixin, and plugin-example adapters consume that path.
+
+The refactor must therefore keep both public selection functions unchanged:
+
+- `selectRelevantAutoMemoryDocuments`
+- `selectRelevantChannelMemory` and its prepared-index variant
+
+## Verification
+
+Characterization tests pin the intentional differences before extraction,
+including cross-script CJK runs, mixed letters and numbers, non-Latin scripts,
+NFKC input, and the core-only token bound. Primitive tests cover empty,
+single-code-point, BMP, and supplementary-plane input.
+
+After extraction, run the focused core and channel recall suites, then the
+repository build and typecheck. This is a behavior-preserving internal
+refactor, so no model-backed or TUI E2E flow should change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30223,6 +30223,7 @@
         "@opentelemetry/instrumentation-http": "^0.221.0",
         "@opentelemetry/instrumentation-undici": "^0.31.0",
         "@opentelemetry/sdk-node": "^0.221.0",
+        "@qwen-code/channel-base": "file:../channels/base",
         "@xterm/headless": "5.5.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.0",

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -14,6 +14,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./recallTokenizer": {
+      "types": "./dist/recall-tokenizer.d.ts",
+      "default": "./dist/recall-tokenizer.js"
     }
   },
   "files": [

--- a/packages/channels/base/src/channel-memory-recall.test.ts
+++ b/packages/channels/base/src/channel-memory-recall.test.ts
@@ -88,6 +88,41 @@ describe('selectRelevantChannelMemory', () => {
     ]);
   });
 
+  it('does not form bigrams across adjacent CJK scripts', () => {
+    const mixedScript = entry('mixed-script', longFact('漢あ'));
+
+    expect(selectRelevantChannelMemory('漢あ', [mixedScript])).toEqual([]);
+  });
+
+  it('tokenizes adjacent Latin letters and numbers as separate terms', () => {
+    const separated = entry('separated', longFact('abc 123'));
+
+    expect(selectRelevantChannelMemory('abc123', [separated])).toEqual([
+      separated,
+    ]);
+  });
+
+  it('does not tokenize alphabetic scripts outside Latin and CJK', () => {
+    const cyrillic = entry('cyrillic', longFact('развёртывания'));
+
+    expect(selectRelevantChannelMemory('развёртывания', [cyrillic])).toEqual(
+      [],
+    );
+  });
+
+  it('keeps terms from the middle of long messages', () => {
+    const tokens = Array.from({ length: 100 }, (_, index) => {
+      const first = String.fromCharCode(97 + Math.floor(index / 26));
+      const second = String.fromCharCode(97 + (index % 26));
+      return `token${first}${second}`;
+    });
+    const middle = entry('middle', longFact(tokens[50]!));
+
+    expect(selectRelevantChannelMemory(tokens.join(' '), [middle])).toEqual([
+      middle,
+    ]);
+  });
+
   it('treats punctuation, whitespace, and unsafe invisibles as separators', () => {
     const joined = entry(
       'joined',

--- a/packages/channels/base/src/channel-memory-recall.ts
+++ b/packages/channels/base/src/channel-memory-recall.ts
@@ -1,5 +1,6 @@
 import { PROMPT_UNSAFE_INVISIBLES } from './sanitize.js';
 import type { ChannelMemoryEntry } from './types.js';
+import { codePointBigrams, normalizeRecallText } from './recall-tokenizer.js';
 
 export const CHANNEL_MEMORY_RECALL_MAX_ENTRIES = 3;
 export const CHANNEL_MEMORY_RECALL_MAX_CODE_POINTS = 1_200;
@@ -26,10 +27,7 @@ export interface ChannelMemoryRecallIndex {
 }
 
 function normalize(text: string): string {
-  return text
-    .normalize('NFKC')
-    .toLowerCase()
-    .replace(PROMPT_UNSAFE_INVISIBLES, ' ');
+  return normalizeRecallText(text).replace(PROMPT_UNSAFE_INVISIBLES, ' ');
 }
 
 function terms(normalized: string): Set<string> {
@@ -57,8 +55,8 @@ function terms(normalized: string): Set<string> {
         : /\p{Script_Extensions=Katakana}/u.test(first)
           ? 'katakana'
           : 'hangul';
-    for (let index = 0; index + 1 < run.length; index += 1) {
-      result.add(`${namespace}:${run[index]}${run[index + 1]}`);
+    for (const bigram of codePointBigrams(match[0])) {
+      result.add(`${namespace}:${bigram}`);
     }
   }
 

--- a/packages/channels/base/src/recall-tokenizer.test.ts
+++ b/packages/channels/base/src/recall-tokenizer.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { codePointBigrams, normalizeRecallText } from './recall-tokenizer.js';
+
+describe('normalizeRecallText', () => {
+  it('applies NFKC normalization and lowercasing', () => {
+    expect(normalizeRecallText('ＡＢＣ ㍿')).toBe('abc 株式会社');
+  });
+});
+
+describe('codePointBigrams', () => {
+  it.each([
+    ['empty input', '', []],
+    ['one code point', '漢', []],
+    ['BMP input', '漢字仮', ['漢字', '字仮']],
+    ['supplementary-plane input', '😀漢字', ['😀漢', '漢字']],
+  ])('%s', (_name, input, expected) => {
+    expect(Array.from(codePointBigrams(input))).toEqual(expected);
+  });
+});

--- a/packages/channels/base/src/recall-tokenizer.ts
+++ b/packages/channels/base/src/recall-tokenizer.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function normalizeRecallText(text: string): string {
+  return text.normalize('NFKC').toLowerCase();
+}
+
+export function* codePointBigrams(text: string): Generator<string> {
+  let previous: string | undefined;
+  for (const codePoint of text) {
+    if (previous !== undefined) {
+      yield previous + codePoint;
+    }
+    previous = codePoint;
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,7 @@
     "@opentelemetry/instrumentation-http": "^0.221.0",
     "@opentelemetry/instrumentation-undici": "^0.31.0",
     "@opentelemetry/sdk-node": "^0.221.0",
+    "@qwen-code/channel-base": "file:../channels/base",
     "@xterm/headless": "5.5.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.0",

--- a/packages/core/src/memory/recall.test.ts
+++ b/packages/core/src/memory/recall.test.ts
@@ -379,6 +379,29 @@ describe('auto-memory relevant recall', () => {
     ).toEqual(['latin.md', 'han.md']);
   });
 
+  it('forms bigrams across adjacent CJK scripts', () => {
+    const mixedScript = memoryDoc(
+      'mixed-script.md',
+      'reference',
+      '漢あ',
+      '',
+      '',
+    );
+
+    expect(selectRelevantAutoMemoryDocuments('漢あ', [mixedScript])).toEqual([
+      mixedScript,
+    ]);
+  });
+
+  it('keeps adjacent letters and numbers in one token', () => {
+    const combined = memoryDoc('combined.md', 'reference', 'abc123', '', '');
+    const partial = memoryDoc('partial.md', 'reference', 'abc', '', '');
+
+    expect(
+      selectRelevantAutoMemoryDocuments('abc123', [partial, combined]),
+    ).toEqual([combined]);
+  });
+
   it('still ignores runs shorter than three characters', () => {
     const doc = memoryDoc('go.md', 'reference', 'go go go', '', '');
 

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -5,6 +5,10 @@
  */
 
 import * as path from 'node:path';
+import {
+  codePointBigrams,
+  normalizeRecallText,
+} from '@qwen-code/channel-base/recallTokenizer';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
@@ -102,10 +106,6 @@ const RECALL_TOKEN_RUN = new RegExp(
 /** Whether a matched run is CJK, and therefore bigram-tokenized. */
 const CJK_RUN_START = new RegExp(`^${CJK_CLASS}`, 'u');
 
-function normalizeRecallText(text: string): string {
-  return text.normalize('NFKC').toLowerCase();
-}
-
 function tokenize(text: string): string[] {
   const normalized = normalizeRecallText(text);
   const edgeSize = MAX_HEURISTIC_QUERY_TOKENS / 2;
@@ -131,10 +131,8 @@ function tokenize(text: string): string[] {
   for (const match of normalized.matchAll(RECALL_TOKEN_RUN)) {
     const run = match[0];
     if (CJK_RUN_START.test(run)) {
-      let previous = '';
-      for (const codePoint of run) {
-        if (previous) addToken(previous + codePoint);
-        previous = codePoint;
+      for (const bigram of codePointBigrams(run)) {
+        addToken(bigram);
       }
     } else {
       addToken(run);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -38,9 +38,9 @@ execSync('npm run generate', { stdio: 'inherit', cwd: root });
 const cliOnly = process.argv.includes('--cli-only');
 
 // Build in dependency order:
-// 1. core (foundation package, includes test-utils)
-// 2. web-templates (embeddable web templates - used by cli)
-// 3. channel-base (base channel infrastructure - used by channel adapters and cli)
+// 1. channel-base (recall primitives used by core; base for channel adapters)
+// 2. core (foundation package, includes test-utils)
+// 3. web-templates (embeddable web templates - used by cli)
 // 4. channel adapters (depend on channel-base)
 // 5. audio-capture (native microphone backend used by cli)
 // 6. acp-bridge (depends on core - used by cli)
@@ -51,9 +51,9 @@ const cliOnly = process.argv.includes('--cli-only');
 // 11. vscode-ide-companion (depends on webui)
 // 12. external-context integrations (private Qwen extensions)
 const buildOrder = [
+  'packages/channels/base',
   'packages/core',
   'packages/web-templates',
-  'packages/channels/base',
   'packages/channels/telegram',
   'packages/channels/weixin',
   'packages/channels/dingtalk',

--- a/scripts/tests/vitest-global-setup.test.js
+++ b/scripts/tests/vitest-global-setup.test.js
@@ -138,6 +138,16 @@ describe('vitest-global-setup prerequisite guard', () => {
     expect(missing[0]).toContain('has not been built');
   });
 
+  it('reports an unbuilt channel-base dist for core tests', () => {
+    root = buildFixtureRoot();
+    rmSync(path.join(root, 'packages/channels/base/dist/index.js'));
+
+    const missing = findMissingPrerequisites('packages/core', root);
+    expect(missing).toHaveLength(1);
+    expect(missing[0]).toContain('packages/channels/base');
+    expect(missing[0]).toContain('has not been built');
+  });
+
   it('names the fix command and the git-commit remedy only when applicable', () => {
     const withGenerated = formatPrerequisiteMessage([
       '  - packages/cli/src/generated/git-commit.ts: generated file does not exist',

--- a/scripts/vitest-global-setup.js
+++ b/scripts/vitest-global-setup.js
@@ -40,7 +40,7 @@ export const repoRoot = path.resolve(__dirname, '..');
 // scripts/tests/vitest-global-setup.test.js asserts the builtin channels of
 // channel-registry.ts stay covered.
 export const DIST_PREREQUISITES = {
-  'packages/core': ['packages/core'],
+  'packages/core': ['packages/channels/base', 'packages/core'],
   'packages/cli': [
     'packages/acp-bridge',
     'packages/web-templates',


### PR DESCRIPTION
## What this PR does

This PR extracts the dependency-free recall mechanics shared by core auto-memory and channel memory: NFKC/lowercase normalization and adjacent Unicode code-point bigrams. The helpers are exposed through a side-effect-free `@qwen-code/channel-base/recallTokenizer` subpath, while each caller keeps a thin local adapter for its existing token policy.

It also records the package-boundary decision, builds channel-base before core, declares the new workspace dependency and test prerequisite, and adds characterization coverage for the intentional differences between the two recall paths.

## Why it's needed

Both recall paths currently duplicate the same normalization and CJK-bigram mechanics, which lets equivalent memory text drift after future changes. The complete tokenizers are not parity-equivalent, so this change shares only the common primitives and preserves each caller's existing term output, scoring, ranking, limits, sanitization, and fallback behavior.

## Reviewer Test Plan

### How to verify

Run `npx vitest run src/memory/recall.test.ts src/memory/recall-eval.test.ts` from `packages/core`; all 61 tests should pass, including the cross-script CJK, mixed letter/number, Unicode-script, and bounded-token cases.

Run `npx vitest run src/recall-tokenizer.test.ts src/channel-memory-recall.test.ts src/channel-memory-recall-eval.test.ts` from `packages/channels/base`; all 32 tests should pass, including NFKC, BMP and supplementary-plane bigrams, per-script CJK boundaries, namespaced terms, and unbounded message terms.

From the repository root, run `npm run build`, `npm run typecheck`, and `npm run bundle`. Confirm that channel-base builds before core and that the exported tokenizer subpath resolves in both TypeScript and the CLI bundle.

### Evidence (Before & After)

N/A — internal behavior-preserving refactor with no UI or model-visible output change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Node.js 24.19.0 and npm 11.17.0 on Linux, without sandboxing.

## Risk & Scope

- Main risk or tradeoff: core now depends on a side-effect-free channel-base subpath, so channel-base must be built before core; the workspace build order and unit-test prerequisite guard enforce this.
- Not validated / out of scope: local macOS and Windows runs; changes to recall scoring, ranking, term thresholds, candidate limits, fallback behavior, public settings, or memory architecture.
- Breaking changes / migration notes: none; existing recall behavior and public settings are unchanged.

## Linked Issues

Fixes #9377

<details>
<summary>中文说明</summary>

## What this PR does

本 PR 抽取 core 自动记忆与 channel 记忆共同使用、且不依赖业务策略的召回机制：NFKC/小写标准化，以及基于 Unicode code point 的相邻二元组生成。共享帮助函数通过无副作用的 `@qwen-code/channel-base/recallTokenizer` 子路径导出，两侧调用方仍保留薄的本地适配层，以维持各自现有的 token 策略。

同时，本 PR 记录 package boundary 的选择，将 channel-base 调整为先于 core 构建，声明新的 workspace 依赖和测试前置条件，并为两条召回路径之间有意保留的差异补充 characterization tests。

## Why it's needed

两条召回路径目前重复实现相同的标准化和 CJK bigram 机制，未来修改时可能让等价的记忆文本产生漂移。两套完整 tokenizer 并不完全等价，因此本次只共享真正相同的底层原语，并保持各调用方现有的 term 输出、打分、排序、限制、清理和 fallback 行为。

## Reviewer Test Plan

### How to verify

在 `packages/core` 目录运行 `npx vitest run src/memory/recall.test.ts src/memory/recall-eval.test.ts`；61 个测试应全部通过，包括跨 CJK script、字母数字混合、Unicode script 和 token 上限场景。

在 `packages/channels/base` 目录运行 `npx vitest run src/recall-tokenizer.test.ts src/channel-memory-recall.test.ts src/channel-memory-recall-eval.test.ts`；32 个测试应全部通过，包括 NFKC、BMP 与 supplementary-plane bigram、按 script 分隔的 CJK 边界、带 namespace 的 term，以及不限制消息 term 数量的场景。

在仓库根目录运行 `npm run build`、`npm run typecheck` 和 `npm run bundle`。确认 channel-base 先于 core 构建，并且导出的 tokenizer 子路径能在 TypeScript 和 CLI bundle 中正确解析。

### Evidence (Before & After)

不适用——这是内部行为保持不变的重构，没有 UI 或模型可见输出变化。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

### Environment (optional)

Linux，Node.js 24.19.0，npm 11.17.0，未启用 sandbox。

## Risk & Scope

- 主要风险或取舍：core 现在依赖 channel-base 的无副作用子路径，因此 channel-base 必须先于 core 构建；workspace 构建顺序和单元测试前置检查已对此作出约束。
- 未验证或范围外：本地 macOS 和 Windows 验证；召回打分、排序、term 阈值、候选限制、fallback 行为、公开设置或记忆架构的变更。
- Breaking changes / 迁移说明：无；现有召回行为和公开设置保持不变。

## Linked Issues

Fixes #9377

</details>
