### PR TITLE
feat(external-context): Publish the Mem0 Extension package

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -47,7 +47,7 @@
 22037 release-sdk-python.yml
 19094 release-sdk.yml
 14546 release-vscode-companion.yml
-59855 release.yml
+62799 release.yml
 43717 repo-hygiene.yml
 1079 scorecard-monthly.yml
 10691 sdk-java.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -839,7 +839,7 @@ jobs:
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
           CI_BOT_PAT: '${{ secrets.CI_BOT_PAT }}'
         run: |-
-          git add package.json package-lock.json packages/*/package.json packages/channels/*/package.json integrations/*/package.json
+          git add package.json package-lock.json packages/*/package.json packages/channels/*/package.json integrations/*/package.json integrations/*/qwen-extension.json
           if git diff --staged --quiet; then
             echo "No version changes to commit"
           else
@@ -941,6 +941,28 @@ jobs:
           RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
           QWEN_STANDALONE_REQUIRE_AUDIO_CAPTURE_PREBUILD: "${{ github.repository == 'QwenLM/qwen-code' && '1' || '' }}"
         run: 'npm run package:standalone:release -- --version "${RELEASE_VERSION}" --out-dir dist/standalone'
+
+      # npm trusted publishing can only be configured after a package exists.
+      # Keep this disabled until the one-time bootstrap publish and trusted
+      # publisher setup are complete.
+      - name: 'Publish @qwen-code/external-context-mem0'
+        if: |-
+          ${{ github.repository == 'QwenLM/qwen-code' && vars.NPM_EXTERNAL_CONTEXT_MEM0_TRUSTED_PUBLISHING_ENABLED == 'true' }}
+        working-directory: 'integrations/external-context-mem0'
+        run: |-
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          PUBLISH_ARGS=(--access public "--tag=${NPM_TAG}")
+          if [[ "${IS_DRY_RUN}" == "true" ]]; then
+            PUBLISH_ARGS+=(--dry-run)
+          elif npm view "${PACKAGE_NAME}@${RELEASE_VERSION}" version >/dev/null 2>&1; then
+            echo "::notice::${PACKAGE_NAME}@${RELEASE_VERSION} already published; skipping"
+            exit 0
+          fi
+          npm publish --provenance "${PUBLISH_ARGS[@]}"
+        env:
+          RELEASE_VERSION: '${{ needs.prepare.outputs.release_version }}'
+          NPM_TAG: '${{ needs.prepare.outputs.npm_tag }}'
+          IS_DRY_RUN: '${{ needs.prepare.outputs.is_dry_run }}'
 
       - name: 'Publish @qwen-code/audio-capture'
         if: |-

--- a/docs/design/external-context-mem0-extension.md
+++ b/docs/design/external-context-mem0-extension.md
@@ -228,6 +228,26 @@ The npm package publishes only the bundled runtime, canonical schemas,
 Extension manifest, and README. It contains no administrator dialect, provider
 preset, provider identifier, or provider-specific contract fixture.
 
+The public package name is `@qwen-code/external-context-mem0`. Its package and
+Extension manifest versions follow the Qwen Code release version and are
+updated in the same release commit. Administrators can install the latest
+release with `qwen extensions install @qwen-code/external-context-mem0` or pin
+an explicit npm version. Installation never creates an instance file, dialect
+file, credential, or ordinary Qwen setting.
+
+The normal release workflow builds the self-contained bundle, checks whether
+the exact package version already exists, and publishes with the release's npm
+dist-tag and provenance. The package participates in the shared
+already-published guard so a partial release cannot be overwritten by a retry.
+Because npm requires a package to exist before trusted publishing can be
+configured, the publish step remains behind the
+`NPM_EXTERNAL_CONTEXT_MEM0_TRUSTED_PUBLISHING_ENABLED` repository variable
+until a maintainer completes the one-time public bootstrap publish and binds
+the package to the `release.yml` workflow in the `production-release`
+environment. The bootstrap should publish the first actual Qwen release that
+contains this change, not invent a second version line. Future releases use
+trusted publishing and require no npm token.
+
 When a service fits `DialectV1`, its administrator writes and validates a local
 dialect file. When it does not fit, the service owner publishes a separate MCP
 Extension implementing External Context MCP Profile v1. Qwen does not add a
@@ -243,7 +263,9 @@ built-in provider rollout for either case.
 3. **PR2:** Replace the unused registry with administrator-owned
    `InstanceConfigV2` and `DialectV1` files, while preserving the request engine
    and profile boundary.
-4. Design any portable write capability separately.
+4. **Distribution follow-up:** Publish the self-contained Extension through the
+   normal Qwen Code npm release without adding provider data or Core wiring.
+5. Design any portable write capability separately.
 
 There is no Qwen-maintained provider-preset PR3. Administrators own compatible
 dialect data; incompatible protocols use their own MCP Extension.

--- a/integrations/external-context-mem0/README.md
+++ b/integrations/external-context-mem0/README.md
@@ -5,6 +5,27 @@ for administrator-configured Mem0-compatible HTTP services. It validates a
 closed dialect grammar and uses a bounded HTTP request engine; it does not ship
 provider presets or provider-specific configuration.
 
+## Installation
+
+Install the published Extension with Qwen Code:
+
+```bash
+qwen extensions install @qwen-code/external-context-mem0
+```
+
+This command becomes available after the package's first registry release.
+
+Use an explicit package version when the deployment must remain pinned:
+
+```bash
+qwen extensions install @qwen-code/external-context-mem0@x.y.z
+```
+
+The Extension version follows the Qwen Code release version. Installing the
+package does not configure a memory service or install provider data; an
+administrator must supply the two files and credential environment described
+below.
+
 ## Configuration
 
 Set `QWEN_EXTERNAL_CONTEXT_MEM0_CONFIG` in the Extension process environment to

--- a/integrations/external-context-mem0/package.json
+++ b/integrations/external-context-mem0/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@qwen-code/external-context-mem0",
   "version": "0.22.3",
-  "private": true,
   "description": "Configurable Mem0-compatible External Context Extension",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/QwenLM/qwen-code.git",
+    "directory": "integrations/external-context-mem0"
+  },
   "type": "module",
   "engines": {
     "node": ">=22.0.0"

--- a/integrations/external-context-mem0/qwen-extension.json
+++ b/integrations/external-context-mem0/qwen-extension.json
@@ -8,7 +8,7 @@
     "en": "Configurable retrieval from an administrator-bound Mem0-compatible service",
     "zh": "从管理员绑定的 Mem0 兼容服务检索外部上下文"
   },
-  "version": "0.1.0",
+  "version": "0.22.3",
   "mcpServers": {
     "external-context-mem0": {
       "command": "node",

--- a/integrations/external-context-mem0/src/manifest.test.ts
+++ b/integrations/external-context-mem0/src/manifest.test.ts
@@ -28,6 +28,14 @@ describe('Mem0 Extension package', () => {
     expect(packageJson.scripts?.['build']).toContain('--bundle');
     expect(packageJson.files).toContain('dist/main.js');
     expect(packageJson.dependencies).toBeUndefined();
+    expect(packageJson.private).not.toBe(true);
+    expect(packageJson.name).toBe('@qwen-code/external-context-mem0');
+    expect(packageJson.version).toBe(manifest.version);
+    expect(packageJson.repository).toEqual({
+      type: 'git',
+      url: 'git+https://github.com/QwenLM/qwen-code.git',
+      directory: 'integrations/external-context-mem0',
+    });
   });
 
   it('ships only the runtime, schemas, manifest, and documentation', async () => {
@@ -43,11 +51,20 @@ describe('Mem0 Extension package', () => {
 });
 
 interface Manifest {
+  version?: string;
   mcpServers?: Record<string, Record<string, unknown>>;
   settings?: unknown;
 }
 
 interface PackageJson {
+  name?: string;
+  version?: string;
+  private?: boolean;
+  repository?: {
+    type?: string;
+    url?: string;
+    directory?: string;
+  };
   dependencies?: Record<string, string>;
   scripts?: Record<string, string>;
   files?: string[];

--- a/scripts/get-release-version.js
+++ b/scripts/get-release-version.js
@@ -182,6 +182,7 @@ function detectRollbackAndGetBaseline(npmDistTag) {
  */
 export const PUBLISHED_PACKAGES = [
   '@qwen-code/qwen-code',
+  '@qwen-code/external-context-mem0',
   '@qwen-code/audio-capture',
   '@qwen-code/channel-base',
   '@qwen-code/channel-dingtalk',

--- a/scripts/tests/get-release-version.test.js
+++ b/scripts/tests/get-release-version.test.js
@@ -738,6 +738,7 @@ describe('assertVersionUnreleased', () => {
     // release.yml so every consumer is reviewed together.
     expect(PUBLISHED_PACKAGES).toEqual([
       '@qwen-code/qwen-code',
+      '@qwen-code/external-context-mem0',
       '@qwen-code/audio-capture',
       '@qwen-code/channel-base',
       '@qwen-code/channel-dingtalk',

--- a/scripts/tests/package-scripts.test.js
+++ b/scripts/tests/package-scripts.test.js
@@ -65,6 +65,18 @@ describe('package scripts', () => {
     expect(buildOrder).toContain("'packages/qwen-live',");
   });
 
+  it('keeps the Mem0 Extension manifest aligned with release versions', () => {
+    const versionScript = readFileSync(
+      path.join(root, 'scripts/version.js'),
+      'utf8',
+    );
+
+    expect(versionScript).toContain(
+      "'integrations/external-context-mem0/qwen-extension.json'",
+    );
+    expect(versionScript).toContain('mem0Manifest.version = newVersion');
+  });
+
   it('keeps the serve fast-path bundle check outside unit test scripts', () => {
     const packageJson = readPackageJson();
 
@@ -515,6 +527,7 @@ describe('package scripts', () => {
     const publishJob = getWorkflowJob(workflow, 'publish');
 
     for (const stepName of [
+      'Publish @qwen-code/external-context-mem0',
       'Publish @qwen-code/audio-capture',
       'Publish @qwen-code/qwen-code',
       'Publish @qwen-code/channel-base',
@@ -557,6 +570,11 @@ describe('package scripts', () => {
       [
         '.github/workflows/release.yml',
         'publish',
+        'Publish @qwen-code/external-context-mem0',
+      ],
+      [
+        '.github/workflows/release.yml',
+        'publish',
         'Publish @qwen-code/audio-capture',
       ],
       [
@@ -589,6 +607,7 @@ describe('package scripts', () => {
     }
 
     for (const packageDirectory of [
+      'integrations/external-context-mem0',
       'packages/audio-capture',
       'packages/cli',
       'packages/channels/base',

--- a/scripts/tests/package-scripts.test.js
+++ b/scripts/tests/package-scripts.test.js
@@ -74,9 +74,15 @@ describe('package scripts', () => {
     expect(versionScript).toContain(
       "'integrations/external-context-mem0/qwen-extension.json'",
     );
+    expect(versionScript).toContain(
+      'const mem0Manifest = readJson(mem0ManifestPath);',
+    );
     expect(versionScript).toContain('mem0Manifest.version = newVersion');
     expect(versionScript).toContain(
       'writeJson(mem0ManifestPath, mem0Manifest);',
+    );
+    expect(versionScript).toContain(
+      "'npx prettier --experimental-cli --write integrations/external-context-mem0/qwen-extension.json'",
     );
   });
 

--- a/scripts/tests/package-scripts.test.js
+++ b/scripts/tests/package-scripts.test.js
@@ -75,6 +75,9 @@ describe('package scripts', () => {
       "'integrations/external-context-mem0/qwen-extension.json'",
     );
     expect(versionScript).toContain('mem0Manifest.version = newVersion');
+    expect(versionScript).toContain(
+      'writeJson(mem0ManifestPath, mem0Manifest);',
+    );
   });
 
   it('keeps the serve fast-path bundle check outside unit test scripts', () => {

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -1305,8 +1305,26 @@ describe('release workflow', () => {
 
   it('stages every integration package manifest after versioning', () => {
     expect(workflow).toContain(
-      'git add package.json package-lock.json packages/*/package.json packages/channels/*/package.json integrations/*/package.json',
+      'git add package.json package-lock.json packages/*/package.json packages/channels/*/package.json integrations/*/package.json integrations/*/qwen-extension.json',
     );
+  });
+
+  it('publishes the Mem0 Extension only after trusted publishing bootstrap', () => {
+    const publishSteps = releaseYaml.jobs.publish.steps;
+    const mem0Step = publishSteps.find(
+      (step) => step.name === 'Publish @qwen-code/external-context-mem0',
+    );
+    const audioStepIndex = publishSteps.findIndex(
+      (step) => step.name === 'Publish @qwen-code/audio-capture',
+    );
+
+    expect(mem0Step.if).toContain(
+      "vars.NPM_EXTERNAL_CONTEXT_MEM0_TRUSTED_PUBLISHING_ENABLED == 'true'",
+    );
+    expect(mem0Step['working-directory']).toBe(
+      'integrations/external-context-mem0',
+    );
+    expect(publishSteps.indexOf(mem0Step)).toBeLessThan(audioStepIndex);
   });
 
   it('fires the fleet-moving npm-published dispatch on stable releases only', () => {

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -77,6 +77,9 @@ const mem0ManifestPath = resolve(
 const mem0Manifest = readJson(mem0ManifestPath);
 mem0Manifest.version = newVersion;
 writeJson(mem0ManifestPath, mem0Manifest);
+run(
+  'npx prettier --experimental-cli --write integrations/external-context-mem0/qwen-extension.json',
+);
 
 // 6. Update the sandboxImageUri in the root package.json
 const rootPackageJson = readJson(rootPackageJsonPath);

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -69,7 +69,16 @@ for (const workspaceName of workspacesToVersion) {
 const rootPackageJsonPath = resolve(process.cwd(), 'package.json');
 const newVersion = readJson(rootPackageJsonPath).version;
 
-// 5. Update the sandboxImageUri in the root package.json
+// 5. Keep the published Mem0 Extension manifest aligned with its package.
+const mem0ManifestPath = resolve(
+  process.cwd(),
+  'integrations/external-context-mem0/qwen-extension.json',
+);
+const mem0Manifest = readJson(mem0ManifestPath);
+mem0Manifest.version = newVersion;
+writeJson(mem0ManifestPath, mem0Manifest);
+
+// 6. Update the sandboxImageUri in the root package.json
 const rootPackageJson = readJson(rootPackageJsonPath);
 if (rootPackageJson.config?.sandboxImageUri) {
   rootPackageJson.config.sandboxImageUri =
@@ -78,7 +87,7 @@ if (rootPackageJson.config?.sandboxImageUri) {
   writeJson(rootPackageJsonPath, rootPackageJson);
 }
 
-// 6. Update the sandboxImageUri in the cli package.json
+// 7. Update the sandboxImageUri in the cli package.json
 const cliPackageJsonPath = resolve(process.cwd(), 'packages/cli/package.json');
 const cliPackageJson = readJson(cliPackageJsonPath);
 if (cliPackageJson.config?.sandboxImageUri) {
@@ -90,7 +99,7 @@ if (cliPackageJson.config?.sandboxImageUri) {
   writeJson(cliPackageJsonPath, cliPackageJson);
 }
 
-// 7. Pin channel adapters' semver dependency on @qwen-code/channel-base to
+// 8. Pin channel adapters' semver dependency on @qwen-code/channel-base to
 // the exact new version. A caret range like ^0.21.0 does not match a
 // prerelease bump (e.g. 0.21.1-preview.0), so npm would replace the workspace
 // link with the stale registry package and the release build would compile
@@ -110,14 +119,14 @@ for (const entry of readdirSync(channelsDir)) {
   }
 }
 
-// 8. Refresh node_modules and package-lock.json against the pinned exact
+// 9. Refresh node_modules and package-lock.json against the pinned exact
 // versions so the adapters resolve channel-base to the workspace link again.
 // --ignore-scripts prevents the root `prepare` lifecycle from triggering a
 // redundant full build that fails with TS5055 when dist/ already exists from
 // the initial `npm ci` install.
 run('npm install --ignore-scripts');
 
-// 9. The per-workspace `npm version` reifies above nested a stale registry
+// 10. The per-workspace `npm version` reifies above nested a stale registry
 // copy of channel-base under each adapter while ranges briefly mismatched.
 // The install above cleans both lockfiles but can leave that directory on
 // disk, where it shadows the workspace link during tsc. Remove it.


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

This PR makes the existing retrieval-only `external-context-mem0` Extension installable as the public npm package `@qwen-code/external-context-mem0`. It keeps the package and Extension manifest aligned with the Qwen Code release version, adds the package to the shared published-version guard, and adds a provenance-enabled release step behind an explicit bootstrap gate. The published package contains only the bundled runtime, canonical schemas, manifest, and documentation; it does not contain provider presets or administrator configuration.

## Why it's needed

PR #10634 made administrator-owned Mem0 dialects usable but left the Extension private, so administrators still lacked a supported scoped npm installation and update path. Publishing the self-contained package closes that distribution gap without adding Qwen Core integration or Qwen-maintained Hologres, PolarDB, RDS, or other provider data.

## Reviewer Test Plan

### How to verify

- Build and test the Extension package and confirm all 49 package tests pass.
- Inspect the dry-run npm tarball and confirm it contains exactly six files: the README, bundled runtime, package metadata, Extension manifest, and two schemas, with no provider-specific dialect or administrator configuration.
- Install the package through a temporary npm registry into an isolated Qwen home with the released Qwen Code CLI and confirm the Extension list reports npm as the source and the expected release version.
- Start the installed bundle with temporary administrator-owned instance and dialect files plus a synthetic loopback HTTP provider, then confirm `initialize`, `tools/list`, and `context_search` produce the bounded request and normalized response. Confirm a running process retains its startup configuration, a restart loads the updated dialect, and invalid dialect errors do not expose paths or configuration values.
- Run the focused release/version script tests and confirm 102 tests pass with one existing host-specific skip, then run the repository build, typecheck, and lint checks.

### Evidence (Before & After)

N/A — this is package distribution and release automation work with no TUI change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS; Node.js 24.12.0; global Qwen Code 0.22.3; temporary loopback npm registry and synthetic HTTP provider.

## Risk & Scope

- Main risk or tradeoff: Release publishing depends on a one-time npm bootstrap and trusted-publisher setup. The workflow keeps publishing disabled until `NPM_EXTERNAL_CONTEXT_MEM0_TRUSTED_PUBLISHING_ENABLED` is explicitly enabled, publishes this package before the other npm packages, and includes it in the shared published-version guard so a partial release cannot be overwritten.
- Not validated / out of scope: A real npm.org publish and trusted-publisher configuration are intentionally left to the release administrator. Live provider services, provider presets, administrator configuration, Qwen Core wiring, write operations, and Auto Recall remain out of scope.
- Breaking changes / migration notes: None for the existing Extension runtime or administrator-owned configuration. The public package becomes available only after the one-time bootstrap publish and repository-variable enablement.

## Linked Issues

Related: #10634

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 将现有仅支持检索的 `external-context-mem0` Extension 调整为可通过公开 npm 包 `@qwen-code/external-context-mem0` 安装。它让 package 与 Extension manifest 始终和 Qwen Code 发布版本保持一致，将该包纳入统一的已发布版本保护，并在显式 bootstrap 开关后增加启用 provenance 的发布步骤。发布包只包含 bundle 后的运行时、规范 schema、manifest 和文档，不包含厂商 preset 或管理员配置。

## 为什么需要

PR #10634 已经支持管理员自有的 Mem0 dialect，但 Extension 仍为私有包，因此管理员仍缺少受支持的 scoped npm 安装和升级路径。发布这个自包含 package 可以补齐分发能力，同时不引入 Qwen Core 集成，也不由 Qwen 维护 Hologres、PolarDB、RDS 或其他厂商数据。

## Reviewer 测试计划

### 如何验证

- 构建并测试 Extension package，确认全部 49 个 package 测试通过。
- 检查 npm dry-run tarball，确认其中恰好只有六个文件：README、bundle 后的运行时、package 元数据、Extension manifest 和两个 schema，并且不包含任何厂商特定 dialect 或管理员配置。
- 使用已发布的 Qwen Code CLI，通过临时 npm registry 将该包安装到隔离的 Qwen home，确认 Extension 列表显示来源为 npm 且版本与预期发布版本一致。
- 使用临时的管理员自有 instance/dialect 文件和合成的本机 HTTP provider 启动已安装 bundle，确认 `initialize`、`tools/list` 和 `context_search` 生成受限请求并归一化响应；同时确认运行中的进程保持启动时配置，重启后加载更新的 dialect，非法 dialect 错误不会暴露路径或配置值。
- 运行聚焦的发布和版本脚本测试，确认 102 个测试通过、仅有 1 个既有的宿主环境相关 skip，然后运行仓库 build、typecheck 和 lint 检查。

### 证据（Before & After）

N/A——这是 package 分发和发布自动化工作，没有 TUI 变化。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

macOS；Node.js 24.12.0；全局 Qwen Code 0.22.3；临时本机 npm registry 和合成 HTTP provider。

## 风险与范围

- 主要风险或取舍：发布流程依赖一次性的 npm bootstrap 和 trusted publisher 配置。工作流会在显式启用 `NPM_EXTERNAL_CONTEXT_MEM0_TRUSTED_PUBLISHING_ENABLED` 前保持发布关闭，先于其他 npm package 发布此包，并将其纳入统一的已发布版本保护，避免覆盖部分完成的发布。
- 未验证 / 不在范围内：真实 npm.org 发布和 trusted publisher 配置有意留给发布管理员执行。真实 provider 服务、厂商 preset、管理员配置、Qwen Core 接线、写操作和 Auto Recall 均不在本 PR 范围内。
- 破坏性变更 / 迁移说明：现有 Extension 运行时和管理员自有配置没有破坏性变更。公开 package 只有在完成一次性 bootstrap 发布并启用仓库变量后才会可用。

## 关联事项

相关：#10634

</details>
