### PR TITLE
fix(web-shell,core): clear leaked test-run async under the unhandled-error gate

### DIFF
--- a/packages/web-shell/client/components/MessageTimestamp.tsx
+++ b/packages/web-shell/client/components/MessageTimestamp.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState, type ReactNode } from 'react';
+import { useCallback, type ReactNode } from 'react';
 import {
   warnClipboardWriteFailure,
   writeClipboardText,
 } from '../utils/clipboard';
+import { useCopiedFlash } from '../hooks/useCopiedFlash';
 import styles from './MessageTimestamp.module.css';
 
 interface MessageTimestampProps {
@@ -29,16 +30,15 @@ export function MessageTimestamp({
   copyText,
   copyTitle = 'Copy',
 }: MessageTimestampProps) {
-  const [copied, setCopied] = useState(false);
+  const [copied, flashCopied] = useCopiedFlash();
   const handleCopy = useCallback(() => {
     if (!copyText) return;
     void writeClipboardText(copyText)
       .then(() => {
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 2000);
+        flashCopied();
       })
       .catch(warnClipboardWriteFailure);
-  }, [copyText]);
+  }, [copyText, flashCopied]);
   if (timestamp === undefined && !copyText && !toolGroupSpacing) {
     return <>{children}</>;
   }

--- a/packages/web-shell/client/components/dialogs/GitLogDialog.tsx
+++ b/packages/web-shell/client/components/dialogs/GitLogDialog.tsx
@@ -23,6 +23,7 @@ import {
   warnClipboardWriteFailure,
   writeClipboardText,
 } from '../../utils/clipboard';
+import { useCopiedFlash } from '../../hooks/useCopiedFlash';
 import { timeAgo } from '../../utils/timeAgo';
 import { DialogShell } from './DialogShell';
 import styles from './GitLogDialog.module.css';
@@ -60,14 +61,13 @@ function CommitRow({
   const [detail, setDetail] = useState<DaemonGitCommitDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const [copied, flashCopied] = useCopiedFlash(1500);
   const cancelledRef = useRef(false);
 
   const copySha = () => {
     void writeClipboardText(entry.sha)
       .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        flashCopied();
       })
       .catch(warnClipboardWriteFailure);
   };

--- a/packages/web-shell/client/components/messages/AssistantMessage.test.tsx
+++ b/packages/web-shell/client/components/messages/AssistantMessage.test.tsx
@@ -564,6 +564,41 @@ describe('AssistantMessage markdown tables', () => {
   });
 });
 
+describe('AssistantMessage copy reset timer', () => {
+  it('leaves no pending reset timer behind on unmount', async () => {
+    vi.useFakeTimers();
+    const descriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+    try {
+      const container = render(
+        <AssistantMessage content="copy me" showFooterActions />,
+      );
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[title="Copy"]',
+      );
+      await act(async () => {
+        button?.click();
+        await Promise.resolve();
+      });
+      // The 2s reset is pending; unmounting must clear it, or it fires
+      // after the file's environment is torn down and the unit suites'
+      // unhandled-error gate turns an all-green run red.
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+      const { root, container: mountedContainer } = mounted.pop()!;
+      act(() => root.unmount());
+      mountedContainer.remove();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(navigator, 'clipboard', descriptor);
+      }
+    }
+  });
+});
+
 describe('AssistantMessage copy without the async Clipboard API (issue #9485)', () => {
   it('falls back to execCommand and still shows the copied state', async () => {
     const descriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');

--- a/packages/web-shell/client/components/messages/AssistantMessage.tsx
+++ b/packages/web-shell/client/components/messages/AssistantMessage.tsx
@@ -10,6 +10,7 @@ import {
   warnClipboardWriteFailure,
   writeClipboardText,
 } from '../../utils/clipboard';
+import { useCopiedFlash } from '../../hooks/useCopiedFlash';
 import type { DaemonSessionGenerationEvent } from '@qwen-code/sdk/daemon';
 import { Button } from '../ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
@@ -39,7 +40,7 @@ export const AssistantMessage = memo(function AssistantMessage({
 }: AssistantMessageProps) {
   const { t } = useI18n();
   const { renderAssistantTurnFooter } = useWebShellCustomization();
-  const [copied, setCopied] = useState(false);
+  const [copied, flashCopied] = useCopiedFlash();
   const [branchPending, setBranchPending] = useState(false);
   const showFooter = !!content && !isStreaming && showFooterActions;
   const customFooter = useMemo(
@@ -63,11 +64,10 @@ export const AssistantMessage = memo(function AssistantMessage({
   const handleCopy = useCallback(() => {
     void writeClipboardText(content)
       .then(() => {
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 2000);
+        flashCopied();
       })
       .catch(warnClipboardWriteFailure);
-  }, [content]);
+  }, [content, flashCopied]);
   return (
     <div className={styles.message}>
       {content && (

--- a/packages/web-shell/client/components/messages/Markdown.tsx
+++ b/packages/web-shell/client/components/messages/Markdown.tsx
@@ -15,6 +15,7 @@ import {
   warnClipboardWriteFailure,
   writeClipboardText,
 } from '../../utils/clipboard';
+import { useCopiedFlash } from '../../hooks/useCopiedFlash';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import type { Components, Options } from 'react-markdown';
 import { isMarkdownFenceClosed } from '@datafe-open/markdown-chart';
@@ -192,7 +193,7 @@ function MermaidBlock({ code }: { code: string }) {
   const [svg, setSvg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'diagram' | 'code'>('diagram');
-  const [copied, setCopied] = useState(false);
+  const [copied, flashCopied] = useCopiedFlash();
   const [zoom, setZoom] = useState(1);
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
@@ -321,8 +322,7 @@ function MermaidBlock({ code }: { code: string }) {
   const handleCopy = () => {
     void writeClipboardText(code)
       .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        flashCopied();
       })
       .catch(warnClipboardWriteFailure);
   };
@@ -432,7 +432,7 @@ function CodeBlock({
   const { t } = useI18n();
   const appTheme = useTheme();
   const [html, setHtml] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copied, flashCopied] = useCopiedFlash();
 
   const { label, lang, resolvedLang } = resolveFenceLanguage(
     extractRawFenceLanguage(className),
@@ -501,8 +501,7 @@ function CodeBlock({
   const handleCopy = () => {
     void writeClipboardText(code)
       .then(() => {
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        flashCopied();
       })
       .catch(warnClipboardWriteFailure);
   };

--- a/packages/web-shell/client/components/messages/SystemMessage.tsx
+++ b/packages/web-shell/client/components/messages/SystemMessage.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback } from 'react';
 import {
   CheckIcon,
   CircleCheckIcon,
@@ -12,6 +12,7 @@ import {
   warnClipboardWriteFailure,
   writeClipboardText,
 } from '../../utils/clipboard';
+import { useCopiedFlash } from '../../hooks/useCopiedFlash';
 import {
   ContextUsageMessage,
   parseContextUsageMessage,
@@ -112,15 +113,14 @@ export const SystemMessage = memo(function SystemMessage({
   onRetryClick,
 }: SystemMessageProps) {
   const { t } = useI18n();
-  const [copied, setCopied] = useState(false);
+  const [copied, flashCopied] = useCopiedFlash();
   const handleCopy = useCallback(() => {
     void writeClipboardText(content)
       .then(() => {
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 2000);
+        flashCopied();
       })
       .catch(warnClipboardWriteFailure);
-  }, [content]);
+  }, [content, flashCopied]);
   if (source === 'mid_turn_message_injected') {
     return (
       <UserMessage

--- a/packages/web-shell/client/hooks/useCopiedFlash.test.tsx
+++ b/packages/web-shell/client/hooks/useCopiedFlash.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useCopiedFlash } from './useCopiedFlash';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: Root;
+let container: HTMLDivElement;
+let latest: [boolean, () => void] | undefined;
+
+function Probe({ resetMs }: { resetMs?: number }) {
+  latest = useCopiedFlash(resetMs);
+  return null;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  latest = undefined;
+  act(() => {
+    root.render(<Probe />);
+  });
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+describe('useCopiedFlash', () => {
+  it('flashes and resets after the delay', () => {
+    act(() => latest![1]());
+    expect(latest![0]).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(latest![0]).toBe(false);
+  });
+
+  it('restarts the reset window on a re-flash', () => {
+    act(() => latest![1]());
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    act(() => latest![1]());
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    // The older reset must not cut the newer feedback short.
+    expect(latest![0]).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(latest![0]).toBe(false);
+  });
+
+  it('clears the pending reset on unmount', () => {
+    act(() => latest![1]());
+    act(() => {
+      root.unmount();
+    });
+    // A leaked timer would fire after the test environment is gone and
+    // fail the run through the unhandled-error gate.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/web-shell/client/hooks/useCopiedFlash.ts
+++ b/packages/web-shell/client/hooks/useCopiedFlash.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * The transient "copied" feedback every copy button shows: `flash()` turns
+ * the flag on and schedules the reset. The pending reset is cleared on
+ * unmount — a leaked timer fires after a test file's environment is torn
+ * down and, since the unit suites fail on unhandled errors, turns an
+ * all-green run red (`window is not defined` out of the reset callback).
+ * A re-flash restarts the window instead of letting the older reset cut
+ * the newer feedback short.
+ */
+export function useCopiedFlash(
+  resetMs = 2000,
+): [copied: boolean, flash: () => void] {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | undefined>(undefined);
+  useEffect(() => () => window.clearTimeout(timerRef.current), []);
+  const flash = useCallback(() => {
+    setCopied(true);
+    window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => setCopied(false), resetMs);
+  }, [resetMs]);
+  return [copied, flash];
+}


### PR DESCRIPTION
## What this PR does

Clears the "copied" feedback reset timer on unmount for every copy button in the Web Shell. A new `useCopiedFlash` hook owns the transient flag (`flash()` sets it and schedules the reset, a re-flash restarts the window, unmount clears the pending timer), and the six call sites that scheduled a bare `setTimeout(() => setCopied(false), …)` — `AssistantMessage`, `SystemMessage`, `MessageTimestamp`, both code-block copy buttons in `Markdown`, and `GitLogDialog` — now use it. `SessionOverviewPanel`'s `SessionIdCell` already carried this cleanup; the hook applies the same pattern everywhere.

Second instance of the same class (96c53f1): `packages/core`'s `archive-safety.test.ts` awaits `tar.c`, but the async file writer can emit a trailing write after its promise resolves (a hard-link entry's jobDone racing the stream end) — CI hit `Error: write after end` through it twice in a row, again with every test green. The fixtures now pack with `sync: true`; assertions unchanged.

## Why it's needed

`Test (ubuntu)` runs fail with all tests green: the copy tests click a copy button, the 2 s reset timer outlives the test file's jsdom environment, and the callback then throws `ReferenceError: window is not defined` out of `react-dom`'s state dispatch. Since #10443 aligned the unit suites on failing for unhandled errors, that single leaked timer turns an all-green run red — seen on `main` itself (run 33407726599's `Run tests and generate reports` step ends with `Test Files 241 passed`, `Tests 5406 passed`, `Errors 1 error`, exit 1, originating in `AssistantMessage.test.tsx`) and on any branch that merges current `main`.

## Reviewer Test Plan

### How to verify

1. On `main`, `cd packages/web-shell && npx vitest run --config vitest.config.ts` can end with `Errors 1 error` (`ReferenceError: window is not defined` at `AssistantMessage.tsx:67`) despite all tests passing — the timing depends on whether the worker tears the environment down within 2 s of the copy test. On this branch the run ends with no unhandled errors.
2. `npx vitest run client/hooks/useCopiedFlash.test.tsx client/components/messages client/components/MessageTimestamp.test.tsx client/components/dialogs/GitLogDialog.test.tsx` — 34 files / 773 tests green.
3. Discriminating tests: `useCopiedFlash › clears the pending reset on unmount` and `AssistantMessage copy reset timer › leaves no pending reset timer behind on unmount` both assert `vi.getTimerCount() === 0` after unmount — removing the hook's cleanup line turns exactly these two red (verified). `restarts the reset window on a re-flash` pins that a second copy is not cut short by the first copy's reset.
4. Behaviour is unchanged for users: the icon still flips to the check mark and resets after 2 s (1.5 s in the Git log dialog); the existing copy tests (including the #9485 execCommand fallback) pass untouched.

### Evidence (Before & After)

N/A (no user-visible change). Before: CI run 33407726599 on `Test (ubuntu)` — `Tests 5406 passed`, `Errors 1 error`, exit code 1. After: the same full suite ends with no unhandled errors.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests only (vitest/jsdom).

## Risk & Scope

- Main risk or tradeoff: the re-flash now restarts the reset window instead of letting the older timer cut the newer feedback short — a subtle behaviour improvement, pinned by its own test. Dep arrays gained the stable `flashCopied` callback where handlers use it.
- Not validated / out of scope: other leaked-timer classes elsewhere in the suites; this PR only closes the copy-feedback family.
- Breaking changes / migration notes: none.

## Linked Issues

The unhandled-error gate landed in #10443; the affected copy button family was extended by #10001.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

为 Web Shell 所有复制按钮在卸载时清理「已复制」反馈的重置计时器。新增 `useCopiedFlash` hook 承载这个瞬时标志（`flash()` 置位并调度重置、再次 flash 重开窗口、卸载清掉未决计时器），六个原先裸调 `setTimeout(() => setCopied(false), …)` 的调用点——`AssistantMessage`、`SystemMessage`、`MessageTimestamp`、`Markdown` 里两个代码块复制按钮、`GitLogDialog`——全部换用。`SessionOverviewPanel` 的 `SessionIdCell` 本就带此清理；hook 把同一范式推广到所有位置。

同类第二实例（96c53f1）：`packages/core` 的 `archive-safety.test.ts` 虽然 `await tar.c`，但其异步文件写入器可能在 promise 落定后再补一笔写入（硬链接条目的 jobDone 与流结束竞争）——CI 连续两次经它触发 `Error: write after end`，同样测试全绿。夹具改为 `sync: true` 打包；断言不变。

## 为什么需要

`Test (ubuntu)` 在测试全绿的情况下失败：复制测试点击按钮后，2 秒重置计时器活过了测试文件的 jsdom 环境，回调随后在 react-dom 的状态派发里抛出 `ReferenceError: window is not defined`。#10443 统一让单测套件对 unhandled error 判败后，这一个泄漏计时器就能把全绿运行打红——`main` 自身已中招（run 33407726599 的测试步骤以 `Test Files 241 passed`、`Tests 5406 passed`、`Errors 1 error`、exit 1 结束，错误源自 `AssistantMessage.test.tsx`），合入当前 `main` 的分支同样会中。

## 评审验证计划

### 如何验证

1. 在 `main` 上 `cd packages/web-shell && npx vitest run --config vitest.config.ts` 可能以 `Errors 1 error`（`AssistantMessage.tsx:67` 的 `window is not defined`）结束——是否触发取决于 worker 是否在复制测试后 2 秒内拆除环境。本分支上运行以零 unhandled error 结束。
2. `npx vitest run client/hooks/useCopiedFlash.test.tsx client/components/messages client/components/MessageTimestamp.test.tsx client/components/dialogs/GitLogDialog.test.tsx`——34 文件 / 773 用例全绿。
3. 判别测试：`useCopiedFlash › clears the pending reset on unmount` 与 `AssistantMessage copy reset timer › leaves no pending reset timer behind on unmount` 都断言卸载后 `vi.getTimerCount() === 0`——删掉 hook 的清理行恰好这两条变红（已验证）。`restarts the reset window on a re-flash` 钉住第二次复制不被第一次的重置截断。
4. 用户可见行为不变：图标仍翻成对勾并在 2 秒（Git log 对话框 1.5 秒）后复位；既有复制测试（含 #9485 的 execCommand 回退）原样通过。

### 证据（Before & After）

N/A（无用户可见变化）。Before：CI run 33407726599 的 `Test (ubuntu)`——`Tests 5406 passed`、`Errors 1 error`、退出码 1。After：同一全量套件以零 unhandled error 结束。

### 测试平台

macOS ✅；Windows ⚠️ 未测；Linux ⚠️ 未测（CI 覆盖）。

### 环境

仅单元测试（vitest/jsdom）。

## 风险与范围

- 主要风险或取舍：再次复制现在会重开重置窗口，而不是被旧计时器提前截断——细微的行为改进，有专属测试钉住。使用 `flashCopied` 的 handler 依赖数组补入了这个稳定回调。
- 未验证 / 范围外：套件里其它类别的计时器泄漏；本 PR 只闭合复制反馈这一族。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

unhandled-error 门由 #10443 引入；受影响的复制按钮族由 #10001 扩展。

</details>

