### PR TITLE
test(cli): stabilize the picker hang-up abort test on shared runners

### DIFF
--- a/packages/cli/src/serve/routes/workspace-management.test.ts
+++ b/packages/cli/src/serve/routes/workspace-management.test.ts
@@ -3201,9 +3201,14 @@ describe('POST /workspace-directory-picker', () => {
     });
     const req = request(app).post('/workspace-directory-picker').send({});
     req.end(() => {});
-    await new Promise((r) => setTimeout(r, 30));
+    // Shared-runner scheduling can delay the handler beyond any fixed sleep;
+    // wait for the picker to actually take the signal before hanging up.
+    await vi.waitFor(() => {
+      expect(observed).toBeDefined();
+    });
     req.abort();
-    await new Promise((r) => setTimeout(r, 60));
-    expect(observed?.aborted).toBe(true);
+    await vi.waitFor(() => {
+      expect(observed?.aborted).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## What this PR does

Replaces two fixed `setTimeout` sleeps in the `POST /workspace-directory-picker` hang-up test with the `vi.waitFor` polling that the rest of this test file already uses. The test now waits until the picker mock has actually received the request's `AbortSignal`, aborts the client request, and then waits until the signal reports `aborted` — instead of guessing 30 ms and 60 ms windows.

## Why it's needed

The main push lane failed on this test (run [33451462501](https://github.com/QwenLM/qwen-code/actions/runs/33451462501)) with `expected undefined to be true`: under shared ECS host contention the request handler did not reach the picker mock within the fixed 30 ms sleep, so `observed` was still `undefined` when the client aborted, and no later sleep could ever see an abort. The production route behavior is correct — only the test's timing guesses were fragile.

## Reviewer Test Plan

### How to verify

```
npm -w @qwen-code/qwen-code exec vitest run src/serve/routes/workspace-management.test.ts --config vitest.config.ts
```

All 132 tests pass; the target test passed 5 consecutive single-test runs locally. The assertions are unchanged — `observed` must be defined before the abort and `observed.aborted` must be `true` after it — so the test still pins that an in-flight picker is aborted when the client hangs up.

### Evidence (Before & After)

N/A (test-only change, no user-visible behavior).

Before: `FAIL ... > still aborts a picker that is genuinely in flight when the client hangs up → expected undefined to be true` (run 33451462501, ubuntu lane).
After: `✓ src/serve/routes/workspace-management.test.ts (132 tests)` locally.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest run`).

## Risk & Scope

- Main risk or tradeoff: `vi.waitFor` polls up to its default 1 s instead of a fixed 30 ms; the test can take marginally longer on slow hosts, which is the point.
- Not validated / out of scope: no production code changed; nothing else touched.
- Breaking changes / migration notes: none.

## Linked Issues

None — follow-up to the red push-lane run 33451462501.