### PR TITLE
fix(ci): make shared ECS Vitest concurrency tunable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,12 +652,11 @@ jobs:
           NO_COLOR: true
           HOME: '${{ runner.temp }}/qwen-ci-home'
           USERPROFILE: '${{ runner.temp }}/qwen-ci-home'
-          # Every ecs-qwen runner sees the whole 128-core host. A percentage
-          # therefore multiplies across its 32 registrations instead of
-          # limiting one runner to its four-core share.
-          VITEST_MAX_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          # Bound each Vitest process on the shared ECS host. Operators can
+          # tune the maximum without changing this workflow.
+          VITEST_MAX_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && (vars.QWEN_CI_VITEST_MAX_WORKERS || '4') || '' }}"
           VITEST_MIN_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
-          VITEST_MAX_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          VITEST_MAX_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && (vars.QWEN_CI_VITEST_MAX_WORKERS || '4') || '' }}"
           VITEST_MIN_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
           OPENAI_API_KEY: ''
           DASHSCOPE_API_KEY: ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,6 +652,13 @@ jobs:
           NO_COLOR: true
           HOME: '${{ runner.temp }}/qwen-ci-home'
           USERPROFILE: '${{ runner.temp }}/qwen-ci-home'
+          # Every ecs-qwen runner sees the whole 128-core host. A percentage
+          # therefore multiplies across its 32 registrations instead of
+          # limiting one runner to its four-core share.
+          VITEST_MAX_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          VITEST_MIN_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
+          VITEST_MAX_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          VITEST_MIN_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
           OPENAI_API_KEY: ''
           DASHSCOPE_API_KEY: ''
           QWEN_API_KEY: ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,6 +385,13 @@ jobs:
           npm run typecheck
 
       - name: 'Run Workspace Tests'
+        env:
+          # Keep release validation within one runner's share of the same
+          # 128-core, 32-registration ECS host used by the main CI gate.
+          VITEST_MAX_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          VITEST_MIN_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
+          VITEST_MAX_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          VITEST_MIN_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
         run: |-
           npm run test:release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,11 +386,10 @@ jobs:
 
       - name: 'Run Workspace Tests'
         env:
-          # Keep release validation within one runner's share of the same
-          # 128-core, 32-registration ECS host used by the main CI gate.
-          VITEST_MAX_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          # Match the tunable per-process bound used by the main CI gate.
+          VITEST_MAX_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && (vars.QWEN_CI_VITEST_MAX_WORKERS || '4') || '' }}"
           VITEST_MIN_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
-          VITEST_MAX_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '4' || '' }}"
+          VITEST_MAX_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && (vars.QWEN_CI_VITEST_MAX_WORKERS || '4') || '' }}"
           VITEST_MIN_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
         run: |-
           npm run test:release

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -128,6 +128,28 @@ describe('no-AK integration CI wiring', () => {
     }
   });
 
+  it('caps every Vitest pool to one ECS runner share', () => {
+    const workflow = readFileSync(
+      path.join(ROOT, '.github/workflows/ci.yml'),
+      'utf8',
+    );
+    const testStep = getWorkflowStep(
+      getWorkflowJob(workflow, 'test'),
+      'Run tests and generate reports',
+    );
+
+    for (const [name, limit] of [
+      ['VITEST_MAX_THREADS', '4'],
+      ['VITEST_MIN_THREADS', '1'],
+      ['VITEST_MAX_FORKS', '4'],
+      ['VITEST_MIN_FORKS', '1'],
+    ]) {
+      expect(testStep).toContain(
+        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && '${limit}' || '' }}"`,
+      );
+    }
+  });
+
   it('defines a focused no-AK integration script', () => {
     const packageJson = JSON.parse(
       readFileSync(path.join(ROOT, 'package.json'), 'utf8'),

--- a/scripts/tests/no-ak-integration-ci.test.js
+++ b/scripts/tests/no-ak-integration-ci.test.js
@@ -128,7 +128,7 @@ describe('no-AK integration CI wiring', () => {
     }
   });
 
-  it('caps every Vitest pool to one ECS runner share', () => {
+  it('uses a tunable max for every Vitest pool on ECS', () => {
     const workflow = readFileSync(
       path.join(ROOT, '.github/workflows/ci.yml'),
       'utf8',
@@ -138,14 +138,14 @@ describe('no-AK integration CI wiring', () => {
       'Run tests and generate reports',
     );
 
-    for (const [name, limit] of [
-      ['VITEST_MAX_THREADS', '4'],
-      ['VITEST_MIN_THREADS', '1'],
-      ['VITEST_MAX_FORKS', '4'],
-      ['VITEST_MIN_FORKS', '1'],
-    ]) {
+    for (const name of ['VITEST_MAX_THREADS', 'VITEST_MAX_FORKS']) {
       expect(testStep).toContain(
-        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && '${limit}' || '' }}"`,
+        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && (vars.QWEN_CI_VITEST_MAX_WORKERS || '4') || '' }}"`,
+      );
+    }
+    for (const name of ['VITEST_MIN_THREADS', 'VITEST_MIN_FORKS']) {
+      expect(testStep).toContain(
+        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"`,
       );
     }
   });

--- a/scripts/tests/package-scripts.test.js
+++ b/scripts/tests/package-scripts.test.js
@@ -413,14 +413,14 @@ describe('package scripts', () => {
     );
     expect(workspaceTestStep).toContain('npm run test:release');
     expect(workspaceTestStep).not.toContain('npm run test:ci');
-    for (const [name, limit] of [
-      ['VITEST_MAX_THREADS', '4'],
-      ['VITEST_MIN_THREADS', '1'],
-      ['VITEST_MAX_FORKS', '4'],
-      ['VITEST_MIN_FORKS', '1'],
-    ]) {
+    for (const name of ['VITEST_MAX_THREADS', 'VITEST_MAX_FORKS']) {
       expect(workspaceTestStep).toContain(
-        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && '${limit}' || '' }}"`,
+        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && (vars.QWEN_CI_VITEST_MAX_WORKERS || '4') || '' }}"`,
+      );
+    }
+    for (const name of ['VITEST_MIN_THREADS', 'VITEST_MIN_FORKS']) {
+      expect(workspaceTestStep).toContain(
+        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"`,
       );
     }
   });

--- a/scripts/tests/package-scripts.test.js
+++ b/scripts/tests/package-scripts.test.js
@@ -413,6 +413,16 @@ describe('package scripts', () => {
     );
     expect(workspaceTestStep).toContain('npm run test:release');
     expect(workspaceTestStep).not.toContain('npm run test:ci');
+    for (const [name, limit] of [
+      ['VITEST_MAX_THREADS', '4'],
+      ['VITEST_MIN_THREADS', '1'],
+      ['VITEST_MAX_FORKS', '4'],
+      ['VITEST_MIN_FORKS', '1'],
+    ]) {
+      expect(workspaceTestStep).toContain(
+        `${name}: "\${{ startsWith(runner.name, 'ecs-qwen-') && '${limit}' || '' }}"`,
+      );
+    }
   });
 
   it('skips release install-time prepare and builds before publish bundling', () => {


### PR DESCRIPTION
## What this PR does

This PR bounds each Vitest process on shared `ecs-qwen-*` runners to one through `QWEN_CI_VITEST_MAX_WORKERS` workers for both thread and fork pools in the main CI unit-test job and the release quality job. The repository variable currently holds `4`; an unset variable falls back to `4`, and hosted runners keep their existing defaults.

The bound is inherited by every parallel workspace Vitest invocation. It is a per-process limit rather than an aggregate four-worker limit for the entire runner, so workspace-level parallelism remains intact while the largest process-level multipliers are removed.

## Why it's needed

The 128-core ECS hosts have many registered runners, and each runner sees the full host CPU count. The existing Core and CLI `25%` setting can therefore resolve to about 32 workers per Vitest process, while workspaces without an explicit setting can approach the host CPU count. Because the root test command also runs workspaces in parallel, several concurrent runner jobs can multiply this into hundreds of competing workers.

This is the failure shape in the main [CI test job from run 33452224969](https://github.com/QwenLM/qwen-code/actions/runs/33452224969/job/99687711308): unrelated suites failed together, normally fast tests took 15–60 seconds, and failures appeared across Core, CLI, browser-bundle, and Web Shell tests while disk, inode, and memory samples remained healthy. A later [main failure in run 33459716355](https://github.com/QwenLM/qwen-code/actions/runs/33459716355/job/99709117004) timed out an unchanged Web Shell boot test at 5,011 ms while its surrounding suite was 4.5–5.6 times slower than a green run.

The same pressure broke [release run 33455887802](https://github.com/QwenLM/qwen-code/actions/runs/33455887802/job/99696128500): integration and audio-prebuild jobs passed, but workspace tests produced nine Vitest worker RPC timeouts followed by unrelated CLI, Core, and Web Shell failures, including 93 Web Shell timeouts.

Using a repository variable keeps the safe default in source while allowing maintainers to tune future runs without another workflow change. It does not attempt automatic host-load scheduling; that belongs in runner provisioning or cgroup/cpuset configuration.

## Reviewer Test Plan

### How to verify

Confirm that the main Ubuntu unit-test step and release `Run Workspace Tests` step set both Vitest max pool variables from `vars.QWEN_CI_VITEST_MAX_WORKERS` with a `4` fallback only on `ecs-qwen-*` runners, keep both minimums at `1`, and leave hosted runners unchanged. Confirm that changing the repository variable affects newly started workflow jobs without modifying the workflow.

### Evidence (Before & After)

N/A — CI-only change. The two focused workflow suites passed 30 tests with 2 platform-specific skips. Prettier and ESLint passed for all changed files, and actionlint passed for the changed main CI workflow. Full/release actionlint remains blocked by pre-existing YAML alias diagnostics in the release workflow; the release workflow is parsed and its changed step is asserted by the focused regression suite.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 with the focused Vitest workflow suites; local formatting, linting, and actionlint for the main CI workflow. Repository variable `QWEN_CI_VITEST_MAX_WORKERS` is set to `4`.

## Risk & Scope

- Main risk or tradeoff: Large Vitest workspaces can take longer when the host is otherwise idle. The variable permits evidence-based tuning without code changes.
- Not validated / out of scope: This is a per-Vitest-process limit, not a strict aggregate runner CPU quota. Workspace processes still run in parallel, and CPU isolation for non-Vitest tools belongs in runner provisioning or cgroups.
- Breaking changes / migration notes: None. Production and hosted-runner behavior are unchanged.

## Linked Issues

Fixes #10665

Fixes #10669

Related to #10490, #10651, #10658, and #10663

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 为共享 `ecs-qwen-*` runner 上的每个 Vitest 进程设置最少 1、最多 `QWEN_CI_VITEST_MAX_WORKERS` 个 worker 的限制，同时覆盖 threads、forks、main CI 单元测试和 release 质量检查。仓库变量当前设置为 `4`；变量未设置时默认使用 `4`，GitHub hosted runner 继续使用原有默认值。

该限制会被所有并行 workspace 的 Vitest 进程继承。它是每个进程的限制，不是整个 runner 总共只能运行 4 个 worker；workspace 级并行仍然保留，但最大的单进程并发放大器会受到控制。

## 为什么需要这个改动

128 核 ECS 上注册了多个 runner，每个 runner 都能看到整台宿主机的 CPU 数量。Core 和 CLI 现有的 `25%` 配置因此可能让每个 Vitest 进程启动约 32 个 worker，没有显式配置的 workspace 甚至可能接近宿主机 CPU 数量。根测试命令还会并行执行多个 workspace，因此多个 runner job 同时运行时可能放大为数百个竞争 worker。

main 的 [run 33452224969](https://github.com/QwenLM/qwen-code/actions/runs/33452224969/job/99687711308) 中，互不相关的 suite 同时失败，通常很快的测试耗时达到 15–60 秒，Core、CLI、browser bundle 和 Web Shell 都出现失败，而磁盘、inode 和内存保持健康。后续 [run 33459716355](https://github.com/QwenLM/qwen-code/actions/runs/33459716355/job/99709117004) 中，一个代码未变化的 Web Shell boot 测试在 5,011 毫秒超时，整个相邻 suite 比绿色运行慢约 4.5–5.6 倍。

同样的压力也导致 [release run 33455887802](https://github.com/QwenLM/qwen-code/actions/runs/33455887802/job/99696128500) 失败：integration 和 audio prebuild 均通过，但 workspace 测试出现 9 个 Vitest worker RPC timeout，并产生大量互不相关的 CLI、Core 和 Web Shell 失败，其中 Web Shell 有 93 个超时。

使用 repository variable 可以在源码中保留安全默认值，同时允许维护者无需修改 workflow 就调整后续运行。它不会根据宿主机负载自动调度；自动资源控制仍应由 runner provisioning 或 cgroup/cpuset 完成。

## Reviewer Test Plan

### 如何验证

确认 main Ubuntu 单元测试 step 和 release 的 `Run Workspace Tests` step 仅在 `ecs-qwen-*` runner 上，从 `vars.QWEN_CI_VITEST_MAX_WORKERS` 读取 threads 和 forks 的最大值并在未设置时回退到 `4`，两个最小值保持为 `1`，hosted runner 保持原行为。确认修改仓库变量后，新启动的 workflow job 会读取新值而无需修改 workflow。

### 证据（改动前后）

不适用——仅修改 CI。两个聚焦 workflow suite 通过 30 个测试，另有 2 个平台相关测试跳过。所有改动文件均通过 Prettier 和 ESLint，main CI workflow 通过 actionlint。全仓/release actionlint 仍被 release workflow 中既有的 YAML alias 诊断阻塞；聚焦回归测试已经解析 release workflow 并断言本次修改的 step。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22，运行聚焦的 Vitest workflow suite，并在本地执行格式、lint 和 main CI workflow actionlint。仓库变量 `QWEN_CI_VITEST_MAX_WORKERS` 已设置为 `4`。

## 风险与范围

- 主要风险或取舍：宿主机空闲时，大型 Vitest workspace 可能比以前更慢；该变量允许后续根据证据调节，无需修改代码。
- 未验证 / 范围外：这是每个 Vitest 进程的限制，不是严格的 runner 总 CPU 配额。workspace 进程仍然并行，非 Vitest 工具的 CPU 隔离仍属于 runner provisioning 或 cgroup 范围。
- 破坏性改动 / 迁移说明：无。生产行为和 hosted runner 行为不变。

## 关联问题

Fixes #10665

Fixes #10669

Related to #10490, #10651, #10658, and #10663

</details>
