### PR TITLE
feat(core): support project runtime refresh

### DIFF
--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -1193,6 +1193,9 @@ export const IDLE_HOOK_EVENTS: Record<HookEventName, ServeHookEventMeta> = {
     description: 'When a new session is started',
     matcherKind: 'sessionTrigger',
   },
+  CwdChanged: {
+    description: 'After the session changes its working directory',
+  },
   MessageDisplay: {
     description: 'Repeatedly, as the assistant reply streams',
   },

--- a/packages/cli/src/config/environment.ts
+++ b/packages/cli/src/config/environment.ts
@@ -220,6 +220,7 @@ export function isFileSourcedEnvKey(key: string): boolean {
  */
 export function getHomeEnvFallbackVars(
   onReadError?: (message: string) => void,
+  environment: Readonly<NodeJS.ProcessEnv> = process.env,
 ): Record<string, string> {
   const globalQwenDir = Storage.getGlobalQwenDir();
   const candidates = [path.join(globalQwenDir, '.env')];
@@ -227,7 +228,7 @@ export function getHomeEnvFallbackVars(
   // from a shared home .env. getUserLevelEnvPaths() always includes ~/.env
   // because loadEnvironment() populates process.env independently — the two
   // scopes are intentionally different.
-  if (!process.env['QWEN_HOME']) {
+  if (!environment['QWEN_HOME']) {
     candidates.push(path.join(path.dirname(globalQwenDir), '.env'));
   }
 
@@ -239,7 +240,7 @@ export function getHomeEnvFallbackVars(
     try {
       const parsed = dotenv.parse(fs.readFileSync(candidate, 'utf-8'));
       for (const key in parsed) {
-        if (Object.hasOwn(parsed, key) && !Object.hasOwn(process.env, key)) {
+        if (Object.hasOwn(parsed, key) && !Object.hasOwn(environment, key)) {
           result[key] ??= parsed[key]!;
         }
       }

--- a/packages/cli/src/config/settings-cache.test.ts
+++ b/packages/cli/src/config/settings-cache.test.ts
@@ -25,6 +25,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearSettingsCacheForTesting,
   loadSettingsCached,
+  loadSettingsCachedForSession,
 } from './settings-cache.js';
 import {
   resetEnvironmentTrackingForTesting,
@@ -118,6 +119,44 @@ describe('loadSettingsCached', () => {
     // constructs a new LoadedSettings, so same instance ⇒ no reload ran.
     expect(second).toBe(first);
     expect(second.merged.model?.name).toBe('cached');
+  });
+
+  it('gives each daemon session an isolated mutable settings instance', () => {
+    const otherWorkspace = path.join(tmpRoot, 'project-b');
+    writeJson(
+      workspaceSettingsPath(),
+      versioned({ permissions: { allow: ['rule-a'] } }),
+    );
+    writeJson(
+      workspaceSettingsPath(otherWorkspace),
+      versioned({ permissions: { allow: ['rule-b'] } }),
+    );
+
+    const firstSession = loadSettingsCachedForSession(workspaceDir);
+    const siblingSession = loadSettingsCachedForSession(workspaceDir);
+    const cachedSource = loadSettingsCached(workspaceDir);
+    expect(firstSession).not.toBe(siblingSession);
+    expect(firstSession.workspace).not.toBe(cachedSource.workspace);
+    firstSession.replaceWith(loadSettingsCachedForSession(otherWorkspace));
+
+    expect(firstSession.merged.permissions?.allow).toEqual(['rule-b']);
+    expect(siblingSession.merged.permissions?.allow).toEqual(['rule-a']);
+    expect(loadSettingsCached(workspaceDir)).toBe(cachedSource);
+    expect(cachedSource.merged.permissions?.allow).toEqual(['rule-a']);
+
+    siblingSession.setValue(
+      SettingScope.Workspace,
+      'model.name',
+      'model-from-sibling',
+    );
+    expect(
+      JSON.parse(fs.readFileSync(workspaceSettingsPath(), 'utf8')),
+    ).toMatchObject({ model: { name: 'model-from-sibling' } });
+    expect(
+      JSON.parse(
+        fs.readFileSync(workspaceSettingsPath(otherWorkspace), 'utf8'),
+      ),
+    ).not.toHaveProperty('model');
   });
 
   it('reloads when the user settings file changes', () => {

--- a/packages/cli/src/config/settings-cache.ts
+++ b/packages/cli/src/config/settings-cache.ts
@@ -14,6 +14,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { findEnvFiles, preResolveHomeEnvOverrides } from './environment.js';
 import {
+  cloneLoadedSettings,
   getSystemDefaultsPath,
   getSystemSettingsPath,
   getUserSettingsPath,
@@ -234,6 +235,17 @@ export function loadSettingsCached(workspaceDir: string): LoadedSettings {
   }
 
   return settings;
+}
+
+/**
+ * Returns a session-owned copy of a cached snapshot. Project relocation
+ * mutates its LoadedSettings in place, so daemon sessions must never receive
+ * the cache entry itself or share nested settings objects with siblings.
+ */
+export function loadSettingsCachedForSession(
+  workspaceDir: string,
+): LoadedSettings {
+  return cloneLoadedSettings(loadSettingsCached(workspaceDir));
 }
 
 export function clearSettingsCacheForTesting(): void {

--- a/packages/cli/src/config/settings.project-runtime.test.ts
+++ b/packages/cli/src/config/settings.project-runtime.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FatalConfigError, Storage } from '@qwen-code/qwen-code-core';
+import {
+  LoadedSettings,
+  loadSettings,
+  resetHomeEnvBootstrapForTesting,
+  SettingScope,
+  type SettingsFile,
+} from './settings.js';
+
+function settingsFile(
+  filePath: string,
+  settings: SettingsFile['settings'],
+): SettingsFile {
+  return {
+    path: filePath,
+    settings,
+    originalSettings: structuredClone(settings),
+    rawJson: JSON.stringify(settings),
+  };
+}
+
+describe('project runtime settings', () => {
+  let tempDir: string;
+  let previousQwenHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-project-runtime-'));
+    previousQwenHome = process.env['QWEN_HOME'];
+    process.env['QWEN_HOME'] = path.join(tempDir, 'home');
+    resetHomeEnvBootstrapForTesting();
+  });
+
+  afterEach(() => {
+    if (previousQwenHome === undefined) {
+      delete process.env['QWEN_HOME'];
+    } else {
+      process.env['QWEN_HOME'] = previousQwenHome;
+    }
+    resetHomeEnvBootstrapForTesting();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('rejects invalid target settings without modifying the file', () => {
+    const workspace = path.join(tempDir, 'workspace');
+    fs.mkdirSync(workspace, { recursive: true });
+    const settingsPath = new Storage(workspace).getWorkspaceSettingsPath();
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, '{ invalid');
+
+    expect(() =>
+      loadSettings(workspace, {
+        consumeCorruptionEnvVars: false,
+        readOnly: true,
+        skipLoadEnvironment: true,
+        workspaceTrusted: true,
+      }),
+    ).toThrow(FatalConfigError);
+    expect(fs.readFileSync(settingsPath, 'utf8')).toBe('{ invalid');
+    expect(fs.existsSync(`${settingsPath}.corrupted`)).toBe(false);
+  });
+
+  it('does not stamp $version into a readOnly load of an unversioned file', () => {
+    // A readOnly (`/cd` prepare) load is observation-only. Stamping the
+    // version in memory without writing it made the first hot reload
+    // re-parse the un-stamped file into a different shape than the one
+    // the session applied — and invited a later write to persist a bump
+    // the user never asked for.
+    const workspace = path.join(tempDir, 'workspace');
+    fs.mkdirSync(workspace, { recursive: true });
+    const settingsPath = new Storage(workspace).getWorkspaceSettingsPath();
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    const raw = '{"permissions":{"allow":[]}}';
+    fs.writeFileSync(settingsPath, raw);
+
+    const loaded = loadSettings(workspace, {
+      consumeCorruptionEnvVars: false,
+      readOnly: true,
+      skipLoadEnvironment: true,
+      workspaceTrusted: true,
+    });
+
+    expect('$version' in loaded.workspace.settings).toBe(false);
+    expect(loaded.workspace.settings.permissions?.allow).toEqual([]);
+    expect(fs.readFileSync(settingsPath, 'utf8')).toBe(raw);
+  });
+
+  it('migrates a legacy target in memory without touching the file', () => {
+    // The `/cd` reloader loads read-only: the target's settings.json must
+    // not be rewritten before the move is committed (rollback restores
+    // memory, never disk).
+    const workspace = path.join(tempDir, 'workspace');
+    fs.mkdirSync(workspace, { recursive: true });
+    const settingsPath = new Storage(workspace).getWorkspaceSettingsPath();
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    const legacy = JSON.stringify({ theme: 'dark' });
+    fs.writeFileSync(settingsPath, legacy);
+
+    const loaded = loadSettings(workspace, {
+      consumeCorruptionEnvVars: false,
+      readOnly: true,
+      skipLoadEnvironment: true,
+      workspaceTrusted: true,
+    });
+
+    expect(loaded.merged.ui?.theme).toBe('dark');
+    expect(loaded.migratedInMemoryScopes.has(SettingScope.Workspace)).toBe(
+      true,
+    );
+    expect(fs.readFileSync(settingsPath, 'utf8')).toBe(legacy);
+  });
+
+  it('keeps an in-memory migration across a hot reload of the legacy file', () => {
+    // After the move the file on disk is still in its legacy layout. The
+    // first chokidar event on it re-parses the raw file; without applying
+    // the same migration the session silently regresses to the legacy
+    // shape until restart.
+    const workspace = path.join(tempDir, 'workspace');
+    fs.mkdirSync(workspace, { recursive: true });
+    const settingsPath = new Storage(workspace).getWorkspaceSettingsPath();
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ theme: 'dark' }));
+    const next = loadSettings(workspace, {
+      consumeCorruptionEnvVars: false,
+      readOnly: true,
+      skipLoadEnvironment: true,
+      workspaceTrusted: true,
+    });
+    const current = new LoadedSettings(
+      settingsFile('/system', {}),
+      settingsFile('/defaults', {}),
+      settingsFile('/user', {}),
+      settingsFile('/project-a', {}),
+      true,
+      new Set(),
+    );
+    current.replaceWith(next);
+    expect(current.merged.ui?.theme).toBe('dark');
+
+    fs.writeFileSync(settingsPath, JSON.stringify({ theme: 'light' }));
+    current.reloadScopeFromDisk(SettingScope.Workspace);
+
+    expect(current.merged.ui?.theme).toBe('light');
+    expect(
+      (current.merged as unknown as Record<string, unknown>)['theme'],
+    ).toBeUndefined();
+  });
+
+  it('keeps a failed migration persistence queued for a later retry', () => {
+    const workspace = path.join(tempDir, 'workspace');
+    fs.mkdirSync(workspace, { recursive: true });
+    const settingsPath = new Storage(workspace).getWorkspaceSettingsPath();
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify({ theme: 'dark' }));
+    const loaded = loadSettings(workspace, {
+      consumeCorruptionEnvVars: false,
+      readOnly: true,
+      skipLoadEnvironment: true,
+      workspaceTrusted: true,
+    });
+    const settingsDir = path.dirname(settingsPath);
+    fs.chmodSync(settingsDir, 0o500);
+    try {
+      expect(() => loaded.persistInMemoryMigrations()).not.toThrow();
+      expect(loaded.migratedInMemoryScopes.has(SettingScope.Workspace)).toBe(
+        true,
+      );
+    } finally {
+      fs.chmodSync(settingsDir, 0o700);
+    }
+  });
+
+  it('replaces workspace state without changing the LoadedSettings identity', () => {
+    const current = new LoadedSettings(
+      settingsFile('/system', {}),
+      settingsFile('/defaults', {}),
+      settingsFile('/user', { general: { language: 'en' } }),
+      settingsFile('/project-a', { disableAllHooks: true }),
+      true,
+      new Set(),
+    );
+    const next = new LoadedSettings(
+      settingsFile('/system', {}),
+      settingsFile('/defaults', {}),
+      settingsFile('/user', { general: { language: 'en' } }),
+      settingsFile('/project-b', { disableAllHooks: false }),
+      true,
+      new Set(),
+    );
+
+    const previous = current.replaceWith(next);
+
+    expect(current.workspace.path).toBe('/project-b');
+    expect(current.merged.disableAllHooks).toBe(false);
+    current.replaceWith(previous);
+    expect(current.workspace.path).toBe('/project-a');
+    expect(current.merged.disableAllHooks).toBe(true);
+  });
+});

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -535,6 +535,7 @@ export class LoadedSettings {
     corruptedPath: string | undefined = undefined,
     wasRecovered: boolean = false,
     workspaceSettingsActive: boolean = true,
+    environment: Readonly<NodeJS.ProcessEnv> = process.env,
   ) {
     this.system = system;
     this.systemDefaults = systemDefaults;
@@ -546,19 +547,21 @@ export class LoadedSettings {
     this.corruptedPath = corruptedPath;
     this.wasRecovered = wasRecovered;
     this.workspaceSettingsActive = workspaceSettingsActive;
+    this.environment = Object.freeze({ ...environment });
     this._merged = this.computeMergedSettings();
   }
 
-  readonly system: SettingsFile;
-  readonly systemDefaults: SettingsFile;
-  readonly user: SettingsFile;
-  readonly workspace: SettingsFile;
-  readonly isTrusted: boolean;
-  readonly migratedInMemoryScopes: Set<SettingScope>;
-  readonly migrationWarnings: string[];
-  readonly corruptedPath: string | undefined;
-  readonly wasRecovered: boolean;
-  readonly workspaceSettingsActive: boolean;
+  system: SettingsFile;
+  systemDefaults: SettingsFile;
+  user: SettingsFile;
+  workspace: SettingsFile;
+  isTrusted: boolean;
+  migratedInMemoryScopes: Set<SettingScope>;
+  migrationWarnings: string[];
+  corruptedPath: string | undefined;
+  wasRecovered: boolean;
+  workspaceSettingsActive: boolean;
+  environment: Readonly<NodeJS.ProcessEnv>;
   corruptionDialogDismissed: boolean = false;
 
   private _merged: Settings;
@@ -667,6 +670,60 @@ export class LoadedSettings {
     this._merged = this.computeMergedSettings();
   }
 
+  replaceWith(next: LoadedSettings): LoadedSettings {
+    const previous = new LoadedSettings(
+      this.system,
+      this.systemDefaults,
+      this.user,
+      this.workspace,
+      this.isTrusted,
+      this.migratedInMemoryScopes,
+      this.migrationWarnings,
+      this.corruptedPath,
+      this.wasRecovered,
+      this.workspaceSettingsActive,
+      this.environment,
+    );
+    this.system = next.system;
+    this.systemDefaults = next.systemDefaults;
+    this.user = next.user;
+    this.workspace = next.workspace;
+    this.isTrusted = next.isTrusted;
+    this.migratedInMemoryScopes = next.migratedInMemoryScopes;
+    this.migrationWarnings = next.migrationWarnings;
+    this.corruptedPath = next.corruptedPath;
+    this.wasRecovered = next.wasRecovered;
+    this.workspaceSettingsActive = next.workspaceSettingsActive;
+    this.environment = next.environment;
+    this._merged = next.merged;
+    return previous;
+  }
+
+  persistInMemoryMigrations(): void {
+    for (const scope of this.migratedInMemoryScopes) {
+      const file = this.forScope(scope);
+      try {
+        const written = updateSettingsFilePreservingFormat(
+          file.path,
+          file.originalSettings,
+          true,
+        );
+        if (written) {
+          this.migratedInMemoryScopes.delete(scope);
+        } else {
+          debugLogger.error(
+            `Failed to persist migrated settings: ${file.path}`,
+          );
+        }
+      } catch (error) {
+        debugLogger.error(
+          `Failed to persist migrated settings: ${file.path}`,
+          error,
+        );
+      }
+    }
+  }
+
   reloadScopeFromDisk(scope: SettingScope): boolean {
     const file = this.forScope(scope);
     if (scope === SettingScope.Workspace && !this.workspaceSettingsActive) {
@@ -687,11 +744,22 @@ export class LoadedSettings {
       }
 
       const content = fs.readFileSync(file.path, 'utf-8');
-      const parsed = JSON.parse(stripJsonComments(content));
+      let parsed = JSON.parse(stripJsonComments(content));
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        // A scope loaded read-only (the `/cd` reloader) was migrated in
+        // memory and never written back, so the file on disk is still in
+        // its legacy layout. Re-parsing it raw here would undo that
+        // migration on the first hot-reload after the move.
+        if (this.migratedInMemoryScopes.has(scope) && needsMigration(parsed)) {
+          parsed = runMigrations(parsed, scope).settings;
+        }
         const resolved = resolveEnvVarsInObject(
           parsed as Settings,
-          getHomeEnvFallbackVars((message) => debugLogger.warn(message)),
+          getHomeEnvFallbackVars(
+            (message) => debugLogger.warn(message),
+            this.environment,
+          ),
+          this.environment,
         );
         file.settings = resolved;
         file.originalSettings = structuredClone(parsed) as Settings;
@@ -734,11 +802,17 @@ export class LoadedSettings {
   }
 
   /**
-   * Get user-level hooks from user settings (not merged with workspace).
+   * Get non-workspace hooks with the same precedence as merged settings.
    * These hooks should always be loaded regardless of folder trust.
    */
   getUserHooks(): Record<string, unknown> | undefined {
-    return this.user.settings.hooks;
+    return mergeSettings(
+      this.system.settings,
+      this.systemDefaults.settings,
+      this.user.settings,
+      {},
+      true,
+    ).hooks;
   }
 
   /**
@@ -752,6 +826,30 @@ export class LoadedSettings {
     }
     return this.workspace.settings.hooks;
   }
+}
+
+export function cloneLoadedSettings(settings: LoadedSettings): LoadedSettings {
+  const cloneFile = (file: SettingsFile): SettingsFile => ({
+    settings: structuredClone(file.settings),
+    originalSettings: structuredClone(file.originalSettings),
+    path: file.path,
+    rawJson: file.rawJson,
+  });
+  const clone = new LoadedSettings(
+    cloneFile(settings.system),
+    cloneFile(settings.systemDefaults),
+    cloneFile(settings.user),
+    cloneFile(settings.workspace),
+    settings.isTrusted,
+    new Set(settings.migratedInMemoryScopes),
+    [...settings.migrationWarnings],
+    settings.corruptedPath,
+    settings.wasRecovered,
+    settings.workspaceSettingsActive,
+    settings.environment,
+  );
+  clone.corruptionDialogDismissed = settings.corruptionDialogDismissed;
+  return clone;
 }
 
 /**
@@ -828,6 +926,8 @@ export const CORRUPTED_SUFFIX = '.corrupted';
  */
 export interface LoadSettingsOptions {
   consumeCorruptionEnvVars?: boolean;
+  environment?: Readonly<NodeJS.ProcessEnv>;
+  readOnly?: boolean;
   skipLoadEnvironment?: boolean;
   skipWorkspaceSettings?: boolean;
   workspaceTrusted?: boolean;
@@ -846,6 +946,9 @@ export function loadSettings(
   // lazy `getUserSettingsPath()` / `Storage.getGlobalQwenDir()` getters
   // return the post-bootstrap value.
   preResolveHomeEnvOverrides();
+  const resolutionEnvironment = Object.freeze({
+    ...(opts.environment ?? process.env),
+  });
   const userSettingsPath = getUserSettingsPath();
   const qwenHomeRedirectWarning =
     detectQwenHomeRedirectWithoutMigration(userSettingsPath);
@@ -901,6 +1004,13 @@ export function loadSettings(
         try {
           rawSettings = JSON.parse(stripJsonComments(content));
         } catch (parseError: unknown) {
+          if (opts.readOnly) {
+            settingsErrors.push({
+              message: getErrorMessage(parseError),
+              path: filePath,
+            });
+            return { settings: {} };
+          }
           // ===== JSON parse failed — enter corruption recovery =====
           // Strategy: save corrupted file as .corrupted → reset to empty →
           // show dialog in UI. Never crash due to a corrupted settings file.
@@ -992,6 +1102,10 @@ export function loadSettings(
         let migrationWarnings: string[] | undefined;
 
         const persistSettingsObject = (warningPrefix: string) => {
+          if (opts.readOnly) {
+            migratedInMemoryScopes.add(scope);
+            return;
+          }
           try {
             // Use sync mode to remove deprecated keys (zombie key prevention)
             // while preserving comments and formatting from the original file.
@@ -1027,7 +1141,8 @@ export function loadSettings(
             persistSettingsObject('Error migrating settings file on disk');
           } else if (
             (hasLegacyNumericVersion || hasInvalidVersion) &&
-            !corruptedSaved
+            !corruptedSaved &&
+            !opts.readOnly
           ) {
             // Migration was deemed needed but nothing executed. Normalize version metadata
             // to avoid repeated no-op checks on startup.
@@ -1039,13 +1154,17 @@ export function loadSettings(
           }
         } else if (
           (!hasVersionKey || hasInvalidVersion || hasLegacyNumericVersion) &&
-          !corruptedSaved
+          !corruptedSaved &&
+          !opts.readOnly
         ) {
           // No migration needed/executable, but version metadata is missing or invalid.
           // Normalize it to current version to avoid repeated startup work.
           // Skip if we just recovered from corruption — the next startup will
           // handle normalization, avoiding an unnecessary writeWithBackupSync
           // that would create a .orig file from the freshly reset settings.
+          // A readOnly (`/cd` prepare) load is observation-only: stamping
+          // `$version` in memory without writing it would make the first
+          // hot reload re-parse an un-stamped file into a different shape.
           settingsObject[SETTINGS_VERSION_KEY] = SETTINGS_VERSION;
           persistSettingsObject('Error normalizing settings version on disk');
         }
@@ -1103,25 +1222,33 @@ export function loadSettings(
   const workspaceOriginalSettings = structuredClone(workspaceResult.settings);
 
   // Resolve ${VAR} placeholders in settings using home .env as fallback.
-  // getHomeEnvFallbackVars() excludes keys already in process.env, so
-  // effective precedence is: process.env > home .env > unresolved placeholder.
-  // The resolver checks customEnv before process.env, but since customEnv
-  // never contains a process.env key, process.env always wins.
-  const homeEnvFallback = getHomeEnvFallbackVars((message) =>
-    debugLogger.warn(message),
+  // getHomeEnvFallbackVars() excludes keys already in the captured resolution
+  // environment, so effective precedence is: startup environment > home .env
+  // > unresolved placeholder. Target project env files are applied later and
+  // must not influence settings expansion.
+  const homeEnvFallback = getHomeEnvFallbackVars(
+    (message) => debugLogger.warn(message),
+    resolutionEnvironment,
   );
   systemSettings = resolveEnvVarsInObject(
     systemResult.settings,
     homeEnvFallback,
+    resolutionEnvironment,
   );
   systemDefaultSettings = resolveEnvVarsInObject(
     systemDefaultsResult.settings,
     homeEnvFallback,
+    resolutionEnvironment,
   );
-  userSettings = resolveEnvVarsInObject(userResult.settings, homeEnvFallback);
+  userSettings = resolveEnvVarsInObject(
+    userResult.settings,
+    homeEnvFallback,
+    resolutionEnvironment,
+  );
   workspaceSettings = resolveEnvVarsInObject(
     workspaceResult.settings,
     homeEnvFallback,
+    resolutionEnvironment,
   );
 
   // Support legacy theme names
@@ -1218,6 +1345,7 @@ export function loadSettings(
     userResult.corruptedPath,
     userResult.wasRecovered ?? false,
     workspaceSettingsActive,
+    resolutionEnvironment,
   );
 }
 

--- a/packages/cli/src/config/settingsWatcher.test.ts
+++ b/packages/cli/src/config/settingsWatcher.test.ts
@@ -219,6 +219,80 @@ describe('SettingsWatcher', () => {
       expect(mockWatchers[1].instance.close).toHaveBeenCalled();
     });
 
+    it('retargets only the workspace watcher after project settings change', async () => {
+      watcher.startWatching();
+
+      const resume = await watcher.pauseWorkspaceWatching();
+      settings.workspace.path = '/next/.qwen/settings.json';
+      resume();
+
+      expect(mockWatchers[0].instance.close).not.toHaveBeenCalled();
+      expect(mockWatchers[1].instance.close).toHaveBeenCalledOnce();
+      expect(mockWatch).toHaveBeenLastCalledWith(
+        '/next/.qwen',
+        expect.objectContaining({ ignoreInitial: true, depth: 0 }),
+      );
+    });
+
+    it('does not re-arm the old workspace path from a promote that was in flight during the pause', async () => {
+      // promote/demote clear the watcher map BEFORE awaiting close(), so a
+      // pause that lands mid-close finds nothing to wait for. Without a
+      // generation re-check the stale continuation re-armed the PREVIOUS
+      // project's `.qwen` after the swap, so the new project's settings
+      // never hot-reloaded and one chokidar watcher leaked.
+      mockExistsSync.mockReturnValue(false);
+      watcher.startWatching();
+      // Bootstrap watchers on both parents; the workspace one is index 1.
+      expect(mockWatchers[1].dir).toBe('/project');
+      let releaseClose: () => void = () => undefined;
+      mockWatchers[1].instance.close.mockReturnValue(
+        new Promise<void>((resolve) => {
+          releaseClose = resolve;
+        }),
+      );
+
+      // `.qwen` appears: promote starts and stalls inside close().
+      fireAllEvent(1, 'addDir', '/project/.qwen');
+      await vi.advanceTimersByTimeAsync(0);
+
+      const resume = await watcher.pauseWorkspaceWatching();
+      settings.workspace.path = '/next/.qwen/settings.json';
+      mockExistsSync.mockReturnValue(true);
+      resume();
+      const watchCallsAfterResume = mockWatch.mock.calls.length;
+      expect(mockWatch).toHaveBeenLastCalledWith(
+        '/next/.qwen',
+        expect.anything(),
+      );
+
+      releaseClose();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockWatch.mock.calls.length).toBe(watchCallsAfterResume);
+      expect(mockWatch).not.toHaveBeenCalledWith(
+        '/project/.qwen',
+        expect.anything(),
+      );
+    });
+
+    it('reconciles the new workspace settings against disk when watching resumes', async () => {
+      // The re-armed watcher starts with `ignoreInitial`, and the pause
+      // dropped pending workspace changes — an edit that landed during the
+      // commit→complete window would otherwise never hot-reload.
+      watcher.startWatching();
+      const scheduleRefresh = vi.spyOn(
+        watcher as unknown as { scheduleRefresh(scope: SettingScope): void },
+        'scheduleRefresh',
+      );
+
+      const resume = await watcher.pauseWorkspaceWatching();
+      settings.workspace.path = '/next/.qwen/settings.json';
+      expect(scheduleRefresh).not.toHaveBeenCalled();
+      resume();
+
+      expect(scheduleRefresh).toHaveBeenCalledWith(SettingScope.Workspace);
+    });
+
     it('should be idempotent on double stop', () => {
       watcher.startWatching();
       watcher.stopWatching();

--- a/packages/cli/src/config/settingsWatcher.ts
+++ b/packages/cli/src/config/settingsWatcher.ts
@@ -113,6 +113,7 @@ export class SettingsWatcher {
   private refreshTimer: NodeJS.Timeout | null = null;
   private readonly pendingScopeChanges: Set<SettingScope> = new Set();
   private processing: boolean = false;
+  private processingPromise: Promise<void> | null = null;
   private started: boolean = false;
 
   static readonly DEBOUNCE_MS = 300;
@@ -240,8 +241,8 @@ export class SettingsWatcher {
     settingsPath: string,
   ): Promise<void> {
     if (this.watchStage.get(scope) !== 'bootstrap') return;
-    await this.replaceWatcher(scope);
-    if (!this.started) return;
+    const generation = await this.replaceWatcher(scope);
+    if (!this.started || !this.isCurrentGeneration(scope, generation)) return;
     this.watchTargetDir(scope, settingsPath);
     // Pick up a settings.json that already exists inside the new `.qwen`.
     this.scheduleRefresh(scope);
@@ -253,8 +254,8 @@ export class SettingsWatcher {
     settingsPath: string,
   ): Promise<void> {
     if (this.watchStage.get(scope) !== 'target') return;
-    await this.replaceWatcher(scope);
-    if (!this.started) return;
+    const generation = await this.replaceWatcher(scope);
+    if (!this.started || !this.isCurrentGeneration(scope, generation)) return;
     this.watchParentForDir(scope, settingsPath);
     // Surface the deletion (rawJson goes undefined) to listeners.
     this.scheduleRefresh(scope);
@@ -263,10 +264,15 @@ export class SettingsWatcher {
   /**
    * Bumps the scope generation and closes its current watcher, clearing the
    * map entries before the caller opens the next watcher. Bumping first makes
-   * any in-flight callback from the closing watcher a no-op.
+   * any in-flight callback from the closing watcher a no-op. Returns the
+   * generation the caller now owns: the map entries are cleared BEFORE the
+   * (async) close, so a `pauseWorkspaceWatching` or another replace that
+   * runs during the close finds nothing to wait for and moves on — the
+   * caller must re-check the generation after the await, or it re-arms a
+   * watcher on a path the session has already left.
    */
-  private async replaceWatcher(scope: SettingScope): Promise<void> {
-    this.bumpGeneration(scope);
+  private async replaceWatcher(scope: SettingScope): Promise<number> {
+    const generation = this.bumpGeneration(scope);
     const watcher = this.watchers.get(scope);
     this.watchers.delete(scope);
     this.watchStage.delete(scope);
@@ -277,6 +283,11 @@ export class SettingsWatcher {
         debugLogger.warn('Settings watcher close error:', err);
       }
     }
+    return generation;
+  }
+
+  private isCurrentGeneration(scope: SettingScope, generation: number) {
+    return (this.watchGeneration.get(scope) ?? 0) === generation;
   }
 
   private bumpGeneration(scope: SettingScope): number {
@@ -304,6 +315,29 @@ export class SettingsWatcher {
       this.refreshTimer = null;
     }
     this.pendingScopeChanges.clear();
+  }
+
+  async pauseWorkspaceWatching(): Promise<() => void> {
+    if (!this.started) return () => undefined;
+    await this.replaceWatcher(SettingScope.Workspace);
+    this.pendingScopeChanges.delete(SettingScope.Workspace);
+    await this.processingPromise;
+
+    return () => {
+      if (!this.started || !this.settings.workspaceSettingsActive) return;
+      const settingsPath = this.settings.workspace.path;
+      const dir = path.dirname(settingsPath);
+      if (fs.existsSync(dir)) {
+        this.watchTargetDir(SettingScope.Workspace, settingsPath);
+      } else {
+        this.watchParentForDir(SettingScope.Workspace, settingsPath);
+      }
+      // The new watcher starts with `ignoreInitial`, and the pause dropped
+      // pending workspace changes: an edit that landed while the swap was
+      // in flight would otherwise never be seen. Same reconciliation the
+      // promote/demote paths do; `handleChange` no-ops when nothing drifted.
+      this.scheduleRefresh(SettingScope.Workspace);
+    };
   }
 
   addChangeListener(listener: SettingsChangeListener): () => void {
@@ -349,8 +383,15 @@ export class SettingsWatcher {
   }
 
   private async drainPendingChanges(): Promise<void> {
-    if (this.processing) return;
+    if (this.processing) {
+      await this.processingPromise;
+      return;
+    }
     this.processing = true;
+    let resolveProcessing!: () => void;
+    this.processingPromise = new Promise<void>((resolve) => {
+      resolveProcessing = resolve;
+    });
     try {
       while (this.pendingScopeChanges.size > 0) {
         const scopes = new Set(this.pendingScopeChanges);
@@ -359,6 +400,8 @@ export class SettingsWatcher {
       }
     } finally {
       this.processing = false;
+      resolveProcessing();
+      this.processingPromise = null;
     }
   }
 

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -826,6 +826,39 @@ describe('BackgroundTaskRegistry', () => {
       expect(registry.get('bg-3')).toBeUndefined();
     });
 
+    it('applies updated limits and drains newly available slots', async () => {
+      registry = new BackgroundTaskRegistry({
+        maxConcurrentBackgroundAgents: 1,
+      });
+      registry.register(makeRegistration('bg-1'));
+      const reservationPromise = registry.waitForBackgroundSlot(
+        new AbortController().signal,
+      );
+      expect(registry.getQueuedCount()).toBe(1);
+
+      registry.setConcurrencyLimits({ maxConcurrentBackgroundAgents: 2 });
+
+      expect(registry.getMaxConcurrentBackgroundAgents()).toBe(2);
+      expect(await reservationPromise).toBeDefined();
+      expect(registry.getQueuedCount()).toBe(0);
+    });
+
+    it('replaces the per-model caps instead of merging them', () => {
+      // `/cd` swaps the map wholesale: a project without
+      // `maxParallelAgentsByModel` must not keep throttling the previous
+      // project's models.
+      registry = new BackgroundTaskRegistry({
+        maxConcurrentBackgroundAgents: 4,
+        maxConcurrentBackgroundAgentsByModel: { 'some-model': 1 },
+      });
+      registry.register(makeRegistration('bg-1', { model: 'some-model' }));
+      expect(registry.canStartBackgroundAgent('some-model')).toBe(false);
+
+      registry.setConcurrencyLimits({ maxConcurrentBackgroundAgents: 2 });
+
+      expect(registry.canStartBackgroundAgent('some-model')).toBe(true);
+    });
+
     it('allows replacing the same running background agent at the cap', () => {
       registry = new BackgroundTaskRegistry({
         maxConcurrentBackgroundAgents: 1,

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -526,11 +526,11 @@ export class BackgroundTaskRegistry {
     symbol,
     BackgroundSlotClaim
   >();
-  private readonly maxConcurrentBackgroundAgents: number;
+  private maxConcurrentBackgroundAgents!: number;
   // Per-model concurrency caps keyed by concrete model ID. Empty when no
   // `agents.maxParallelAgentsByModel` is configured, in which case only the
   // global cap is enforced.
-  private readonly maxConcurrentBackgroundAgentsByModel: Map<string, number>;
+  private maxConcurrentBackgroundAgentsByModel!: Map<string, number>;
   private notificationCallback?: BackgroundNotificationCallback;
   private registerCallback?: BackgroundRegisterCallback;
   private statusChangeCallback?: BackgroundStatusChangeCallback;
@@ -538,6 +538,18 @@ export class BackgroundTaskRegistry {
   private approvalChangeCallback?: BackgroundApprovalChangeCallback;
 
   constructor(options: BackgroundTaskRegistryOptions = {}) {
+    // One validation path for construction and `/cd` reload, so the two
+    // cannot enforce different caps. Draining the (empty) wait queue is a
+    // no-op here.
+    this.setConcurrencyLimits(options);
+  }
+
+  /**
+   * Replaces both concurrency caps wholesale — the per-model map is NOT
+   * merged with the previous one — and hands newly available slots to
+   * queued waiters. Called on construction and after `/cd`.
+   */
+  setConcurrencyLimits(options: BackgroundTaskRegistryOptions = {}): void {
     const configured =
       options.maxConcurrentBackgroundAgents ?? MAX_CONCURRENT_BACKGROUND_AGENTS;
     this.maxConcurrentBackgroundAgents =
@@ -547,6 +559,7 @@ export class BackgroundTaskRegistry {
     this.maxConcurrentBackgroundAgentsByModel = normalizePerModelConcurrency(
       options.maxConcurrentBackgroundAgentsByModel,
     );
+    this.drainWaitQueue();
   }
 
   /**

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -847,6 +847,43 @@ describe('HookEventHandler', () => {
     });
   });
 
+  describe('fireCwdChangedEvent', () => {
+    it('uses the new cwd in the base payload and includes both paths', async () => {
+      vi.mocked(mockConfig.getWorkingDir).mockReturnValue('/project-b');
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(
+        createMockExecutionPlan([
+          {
+            type: HookType.Command,
+            command: 'echo test',
+            source: HooksConfigSource.Project,
+          },
+        ]),
+      );
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireCwdChangedEvent('/project-a', '/project-b');
+
+      expect(mockHookPlanner.createExecutionPlan).toHaveBeenCalledWith(
+        HookEventName.CwdChanged,
+        undefined,
+      );
+      const input = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls[0][2] as {
+        cwd: string;
+        old_cwd: string;
+        new_cwd: string;
+      };
+      expect(input).toMatchObject({
+        cwd: '/project-b',
+        old_cwd: '/project-a',
+        new_cwd: '/project-b',
+      });
+    });
+  });
+
   describe('fireSessionEndEvent', () => {
     it('should execute hooks for SessionEnd event', async () => {
       const mockPlan = createMockExecutionPlan([]);

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -21,6 +21,7 @@ import type {
   MessageDisplayInput,
   ContextUsageData,
   SessionStartInput,
+  CwdChangedInput,
   SessionEndInput,
   SessionDeleteInput,
   SessionStartSource,
@@ -311,6 +312,25 @@ export class HookEventHandler {
       {
         trigger: source,
       },
+      signal,
+    );
+  }
+
+  async fireCwdChangedEvent(
+    oldCwd: string,
+    newCwd: string,
+    signal?: AbortSignal,
+  ): Promise<AggregatedHookResult> {
+    const input: CwdChangedInput = {
+      ...this.createBaseInput(HookEventName.CwdChanged),
+      old_cwd: oldCwd,
+      new_cwd: newCwd,
+    };
+
+    return this.executeHooks(
+      HookEventName.CwdChanged,
+      input,
+      undefined,
       signal,
     );
   }

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -76,6 +76,7 @@ export function getHookMatcherTarget(
     case HookEventName.Stop:
     case HookEventName.MessageDisplay:
     case HookEventName.PostToolBatch:
+    case HookEventName.CwdChanged:
     case HookEventName.SessionDelete:
     case HookEventName.TodoCreated:
     case HookEventName.TodoCompleted:

--- a/packages/core/src/hooks/hookRegistry.test.ts
+++ b/packages/core/src/hooks/hookRegistry.test.ts
@@ -1104,6 +1104,54 @@ describe('HookRegistry', () => {
       expect(registry.getAllHooks()).toEqual(before);
     });
 
+    it('drops configured hooks on a fail-closed reload failure', async () => {
+      mockConfig.getUserHooks = vi.fn().mockReturnValue({
+        [HookEventName.PreToolUse]: [
+          {
+            matcher: 'Bash',
+            hooks: [
+              {
+                type: HookType.Command,
+                command: 'echo user',
+                name: 'user-hook',
+              },
+            ],
+          },
+        ],
+      });
+
+      const registry = new HookRegistry(mockConfig);
+      await registry.initialize();
+      registry.addAgentHooks(
+        {
+          [HookEventName.PreToolUse]: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  type: HookType.Command,
+                  command: 'echo agent',
+                  name: 'agent-hook',
+                },
+              ],
+            },
+          ],
+        },
+        'agent:test:fail-closed',
+      );
+      mockConfig.getUserHooks = vi.fn(() => {
+        throw new Error('reload failed');
+      });
+
+      await expect(
+        registry.reloadConfiguredHooks({ failClosed: true }),
+      ).rejects.toThrow('reload failed');
+
+      expect(registry.getAllHooks().map((entry) => entry.source)).toEqual([
+        HooksConfigSource.Session,
+      ]);
+    });
+
     it('silently keeps entries when the hooks payload is empty', async () => {
       const registry = new HookRegistry(mockConfig);
       await registry.initialize();

--- a/packages/core/src/hooks/hookRegistry.ts
+++ b/packages/core/src/hooks/hookRegistry.ts
@@ -85,7 +85,9 @@ export class HookRegistry {
     );
   }
 
-  async reloadConfiguredHooks(): Promise<void> {
+  async reloadConfiguredHooks(
+    options: { failClosed?: boolean } = {},
+  ): Promise<void> {
     const previousEntries = this.entries;
     const enabledSnapshot = new Map(
       previousEntries.map((entry) => [
@@ -107,7 +109,7 @@ export class HookRegistry {
         }
       }
     } catch (err) {
-      this.entries = previousEntries;
+      this.entries = options.failClosed ? agentEntries : previousEntries;
       throw err;
     }
 

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -518,6 +518,13 @@ export class HookRunner {
     this.httpRunner.updateAllowedUrls(allowedUrls);
   }
 
+  updateHttpSecurity(
+    allowedUrls: string[],
+    allowPrivateNetworkHosts: boolean,
+  ): void {
+    this.httpRunner.updateSecurity(allowedUrls, allowPrivateNetworkHosts);
+  }
+
   /**
    * Execute a single hook
    * @param hookConfig Hook configuration

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -90,8 +90,8 @@ export class HookSystem {
     debugLogger.debug('Hook system initialized successfully');
   }
 
-  async reload(): Promise<void> {
-    await this.hookRegistry.reloadConfiguredHooks();
+  async reload(options: { failClosed?: boolean } = {}): Promise<void> {
+    await this.hookRegistry.reloadConfiguredHooks(options);
     debugLogger.debug('Hook system reloaded successfully');
   }
 
@@ -255,6 +255,21 @@ export class HookSystem {
     );
     return result.finalOutput
       ? createHookOutput('SessionStart', result.finalOutput)
+      : undefined;
+  }
+
+  async fireCwdChangedEvent(
+    oldCwd: string,
+    newCwd: string,
+    signal?: AbortSignal,
+  ): Promise<DefaultHookOutput | undefined> {
+    const result = await this.hookEventHandler.fireCwdChangedEvent(
+      oldCwd,
+      newCwd,
+      signal,
+    );
+    return result.finalOutput
+      ? createHookOutput('CwdChanged', result.finalOutput)
       : undefined;
   }
 
@@ -767,5 +782,12 @@ export class HookSystem {
    */
   updateAllowedHttpUrls(allowedUrls: string[]): void {
     this.hookRunner.updateAllowedHttpUrls(allowedUrls);
+  }
+
+  updateHttpSecurity(
+    allowedUrls: string[],
+    allowPrivateNetworkHosts: boolean,
+  ): void {
+    this.hookRunner.updateHttpSecurity(allowedUrls, allowPrivateNetworkHosts);
   }
 }

--- a/packages/core/src/hooks/httpHookRunner.test.ts
+++ b/packages/core/src/hooks/httpHookRunner.test.ts
@@ -368,6 +368,27 @@ describe('HttpHookRunner', () => {
       expect(mockFetch).toHaveBeenCalled();
     });
 
+    it('should apply updated URL and private-network policy', async () => {
+      const runner = new HttpHookRunner([], false);
+      const config = createMockConfig({ url: 'http://172.16.254.215/hook' });
+      const input = createMockInput();
+
+      await expect(
+        runner.execute(config, HookEventName.PreToolUse, input),
+      ).resolves.toMatchObject({ success: false });
+
+      runner.updateSecurity([], true);
+      mockSuccessResponse();
+      await expect(
+        runner.execute(config, HookEventName.PreToolUse, input),
+      ).resolves.toMatchObject({ success: true });
+
+      runner.updateSecurity(['https://hooks.example.com/*'], true);
+      await expect(
+        runner.execute(config, HookEventName.PreToolUse, input),
+      ).resolves.toMatchObject({ success: false });
+    });
+
     it('should allow a hostname resolving to a private IP when the flag is on', async () => {
       mockDns.addresses = [{ address: '172.16.254.215', family: 4 }];
       mockSuccessResponse();

--- a/packages/core/src/hooks/httpHookRunner.ts
+++ b/packages/core/src/hooks/httpHookRunner.ts
@@ -104,7 +104,7 @@ async function validateResolvedHost(
  */
 export class HttpHookRunner {
   private urlValidator: UrlValidator;
-  private readonly allowPrivateNetworkHosts: boolean;
+  private allowPrivateNetworkHosts: boolean;
   private readonly executedOnceHooks: Set<string> = new Set();
   private statusMessageCallback?: StatusMessageCallback;
 
@@ -453,10 +453,14 @@ export class HttpHookRunner {
    * Update allowed URLs
    */
   updateAllowedUrls(allowedUrls: string[]): void {
-    // Create new validator with updated patterns
-    this.urlValidator = new UrlValidator(
-      allowedUrls,
-      this.allowPrivateNetworkHosts,
-    );
+    this.updateSecurity(allowedUrls, this.allowPrivateNetworkHosts);
+  }
+
+  updateSecurity(
+    allowedUrls: string[],
+    allowPrivateNetworkHosts: boolean,
+  ): void {
+    this.allowPrivateNetworkHosts = allowPrivateNetworkHosts;
+    this.urlValidator = new UrlValidator(allowedUrls, allowPrivateNetworkHosts);
   }
 }

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -38,6 +38,8 @@ export enum HookEventName {
   UserPromptExpansion = 'UserPromptExpansion',
   // SessionStart - When a new session is started
   SessionStart = 'SessionStart',
+  // CwdChanged - After the session changes its working directory
+  CwdChanged = 'CwdChanged',
   // Stop - Right before Claude concludes its response
   Stop = 'Stop',
   // MessageDisplay - Fires repeatedly as the assistant's reply streams, before Stop
@@ -265,6 +267,11 @@ export interface HookInput {
   cwd: string;
   hook_event_name: string;
   timestamp: string;
+}
+
+export interface CwdChangedInput extends HookInput {
+  old_cwd: string;
+  new_cwd: string;
 }
 
 export type InstructionMemoryType = 'user' | 'project' | 'local' | 'extension';

--- a/packages/core/src/memory/memoryDiscovery.test.ts
+++ b/packages/core/src/memory/memoryDiscovery.test.ts
@@ -152,6 +152,35 @@ describe('loadServerHierarchicalMemory', () => {
     });
   });
 
+  it('uses request-scoped context filenames instead of process-global state', async () => {
+    await createTestFile(
+      path.join(projectRoot, DEFAULT_CONTEXT_FILENAME),
+      'global-name content',
+    );
+    await createTestFile(
+      path.join(projectRoot, 'PROJECT-B.md'),
+      'project-b content',
+    );
+
+    const result = await loadServerHierarchicalMemory(
+      cwd,
+      [projectRoot],
+      new FileDiscoveryService(projectRoot),
+      [],
+      DEFAULT_FOLDER_TRUST,
+      'tree',
+      [],
+      {
+        contextFileNames: ['PROJECT-B.md'],
+        explicitOnly: true,
+      },
+    );
+
+    expect(result.fileCount).toBe(1);
+    expect(result.memoryContent).toContain('project-b content');
+    expect(result.memoryContent).not.toContain('global-name content');
+  });
+
   it('should skip implicit global, project, and rule discovery in explicit-only mode', async () => {
     await createTestFile(
       path.join(homedir, QWEN_DIR, DEFAULT_CONTEXT_FILENAME),

--- a/packages/core/src/memory/memoryDiscovery.ts
+++ b/packages/core/src/memory/memoryDiscovery.ts
@@ -48,6 +48,7 @@ async function getMemoryFilePathsInternal(
   extensionContextFilePaths: string[] = [],
   folderTrust: boolean,
   implicitDiscoveryEnabled: boolean = true,
+  contextFileNames: readonly string[] = getAllMemoryFilenames(),
 ): Promise<string[]> {
   const dirs = new Set<string>(
     implicitDiscoveryEnabled
@@ -70,6 +71,7 @@ async function getMemoryFilePathsInternal(
         extensionContextFilePaths,
         folderTrust,
         implicitDiscoveryEnabled,
+        contextFileNames,
       ),
     );
 
@@ -98,9 +100,10 @@ async function getMemoryFilePathsInternalForEachDir(
   extensionContextFilePaths: string[] = [],
   folderTrust: boolean,
   implicitDiscoveryEnabled: boolean = true,
+  contextFileNames: readonly string[] = getAllMemoryFilenames(),
 ): Promise<string[]> {
   const allPaths = new Set<string>();
-  const memoryFilenames = getAllMemoryFilenames();
+  const memoryFilenames = contextFileNames;
 
   for (const memoryFilename of memoryFilenames) {
     const resolvedHome = path.resolve(userHomePath);
@@ -206,7 +209,7 @@ async function getMemoryFilePathsInternalForEachDir(
   const finalPaths = Array.from(allPaths);
 
   logger.debug(
-    `Final ordered ${getAllMemoryFilenames()} paths to read: ${JSON.stringify(
+    `Final ordered ${contextFileNames} paths to read: ${JSON.stringify(
       finalPaths,
     )}`,
   );
@@ -429,6 +432,7 @@ export interface LoadServerHierarchicalMemoryResponse {
 
 export interface LoadServerHierarchicalMemoryOptions {
   explicitOnly?: boolean;
+  contextFileNames?: readonly string[];
   loadReason?: Exclude<InstructionLoadReason, 'include'>;
   onInstructionsLoaded?: (
     notification: InstructionsLoadedNotification,
@@ -516,6 +520,7 @@ export async function loadServerHierarchicalMemory(
     extensionContextFilePaths,
     folderTrust,
     implicitDiscoveryEnabled,
+    options.contextFileNames,
   );
 
   // Resolve project root once — needed both for the QWEN.local.md slot
@@ -591,7 +596,7 @@ export async function loadServerHierarchicalMemory(
     // (/memory count vs announcement list) may differ; aligning them at
     // the display site is deferred as a follow-up.
     const memoryFilenames = new Set([
-      ...getAllMemoryFilenames(),
+      ...(options.contextFileNames ?? getAllMemoryFilenames()),
       LOCAL_CONTEXT_FILENAME,
     ]);
     const memoryItems = contentsWithPaths.filter((item) =>

--- a/packages/core/src/memory/refresh.test.ts
+++ b/packages/core/src/memory/refresh.test.ts
@@ -151,6 +151,29 @@ describe('managed memory refresh helper', () => {
     ).toBe(true);
   });
 
+  it('recognises writes to session-scoped context file names', () => {
+    // After `/cd` the names are the session's, not the process-global
+    // list; a write to the project's own file must still trigger the
+    // instruction refresh, and the global default must not.
+    const write = (name: string) => [
+      {
+        toolName: 'write_file',
+        args: { file_path: path.join(projectRoot, name) },
+        status: 'success' as const,
+      },
+    ];
+    expect(
+      didWriteProjectContextFile(write('PROJECT-B.md'), projectRoot, [
+        'PROJECT-B.md',
+      ]),
+    ).toBe(true);
+    expect(
+      didWriteProjectContextFile(write(DEFAULT_CONTEXT_FILENAME), projectRoot, [
+        'PROJECT-B.md',
+      ]),
+    ).toBe(false);
+  });
+
   it('detects successful project context file writes only', () => {
     expect(
       didWriteProjectContextFile(

--- a/packages/core/src/memory/refresh.ts
+++ b/packages/core/src/memory/refresh.ts
@@ -91,9 +91,10 @@ export function didWriteManagedMemory(
 export function didWriteProjectContextFile(
   candidates: readonly MemoryWriteCandidate[],
   projectRoot: string,
+  contextFileNames: readonly string[] = getAllMemoryFilenames(),
 ): boolean {
   const contextFilePaths = new Set(
-    getAllMemoryFilenames()
+    contextFileNames
       .map((name) => name.trim())
       .filter((name) => name.length > 0)
       .map((name) => path.resolve(projectRoot, name)),

--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -1752,6 +1752,132 @@ describe('PermissionManager', () => {
       expect(await pm.evaluate({ toolName: 'agent' })).toBe('default');
     });
 
+    it('replaces project rules while preserving session rules', async () => {
+      let projectAllow = ['read_file'];
+      const config = makeConfig({});
+      config.getPermissionsAllow = () => projectAllow;
+      const manager = new PermissionManager(config);
+      manager.initialize();
+      manager.addSessionAllowRule('write_file');
+
+      projectAllow = ['glob'];
+      manager.reloadForProjectChange();
+
+      expect(await manager.evaluate({ toolName: 'read_file' })).toBe('default');
+      expect(await manager.evaluate({ toolName: 'glob' })).toBe('allow');
+      expect(await manager.evaluate({ toolName: 'write_file' })).toBe('allow');
+    });
+
+    it('replaces the core-tool allowlist on a project change', async () => {
+      let coreTools = ['read_file'];
+      const config = makeConfig({});
+      config.getCoreTools = () => coreTools;
+      const manager = new PermissionManager(config);
+      manager.initialize();
+      expect(await manager.isToolEnabled('read_file')).toBe(true);
+      expect(await manager.isToolEnabled('run_shell_command')).toBe(false);
+
+      coreTools = ['run_shell_command'];
+      manager.reloadForProjectChange();
+
+      expect(await manager.isToolEnabled('read_file')).toBe(false);
+      expect(await manager.isToolEnabled('run_shell_command')).toBe(true);
+    });
+
+    it('keeps AUTO-stashed session grants across a project change', async () => {
+      // In AUTO mode a dangerous session grant lives in the stash, not in
+      // `sessionRules.allow`. A reload that cleared the stash without first
+      // re-attaching it lost the grant for the rest of the session: the
+      // re-strip found nothing, and leaving AUTO later restored nothing.
+      const manager = new PermissionManager(
+        makeConfig({ permissionsAllow: [], approvalMode: 'auto' }),
+      );
+      manager.initialize();
+      manager.addSessionAllowRule('Bash(npx *)');
+      expect(manager.getStrippedDangerousRules()?.session).toHaveLength(1);
+
+      manager.reloadForProjectChange();
+
+      expect(manager.getStrippedDangerousRules()?.session).toHaveLength(1);
+      manager.restoreDangerousRules();
+      expect(
+        await manager.evaluate({
+          toolName: 'run_shell_command',
+          command: 'npx vitest',
+        }),
+      ).toBe('allow');
+    });
+
+    it('keeps an AUTO override stripped when the base mode is default', async () => {
+      const manager = new PermissionManager(
+        makeConfig({ permissionsAllow: ['Bash'], approvalMode: 'default' }),
+      );
+      manager.initialize();
+      manager.stripDangerousRulesForAutoMode();
+
+      manager.reloadForProjectChange();
+
+      expect(manager.getStrippedDangerousRules()).toBeDefined();
+      expect(
+        await manager.evaluate({
+          toolName: 'run_shell_command',
+          command: 'rm -rf /tmp/project-output',
+        }),
+      ).not.toBe('allow');
+      manager.restoreDangerousRules();
+      expect(
+        await manager.evaluate({
+          toolName: 'run_shell_command',
+          command: 'rm -rf /tmp/project-output',
+        }),
+      ).toBe('allow');
+    });
+
+    it('fails closed when project permission reloading throws', async () => {
+      const config = makeConfig({ permissionsAllow: [], approvalMode: 'auto' });
+      const manager = new PermissionManager(config);
+      manager.initialize();
+      manager.addSessionAllowRule('Bash(npx *)');
+      config.getCoreTools = () => 'Bash' as unknown as string[];
+
+      expect(() => manager.reloadForProjectChange()).toThrow(TypeError);
+      expect(manager.getStrippedDangerousRules()).toBeDefined();
+      expect(
+        await manager.evaluate({
+          toolName: 'run_shell_command',
+          command: 'npx vitest',
+        }),
+      ).not.toBe('allow');
+    });
+
+    it('drops old persistent grants when permission reloading throws', async () => {
+      let shouldThrow = false;
+      const config = makeConfig({ approvalMode: 'default' });
+      config.getPermissionsAllow = () => {
+        if (shouldThrow) throw new Error('settings unavailable');
+        return ['Bash(npx *)'];
+      };
+      const manager = new PermissionManager(config);
+      manager.initialize();
+      expect(
+        await manager.evaluate({
+          toolName: 'run_shell_command',
+          command: 'npx vitest',
+        }),
+      ).toBe('allow');
+
+      shouldThrow = true;
+      expect(() => manager.reloadForProjectChange()).toThrow(
+        'settings unavailable',
+      );
+      expect(
+        await manager.evaluate({
+          toolName: 'run_shell_command',
+          command: 'npx vitest',
+        }),
+      ).toBe('ask');
+    });
+
     it('matches a legacy truncated MCP permission alias', async () => {
       const rawName = `mcp__server__${'x'.repeat(80)}`;
       const legacyName = rawName.slice(0, 28) + '___' + rawName.slice(-32);

--- a/packages/core/src/permissions/permission-manager.ts
+++ b/packages/core/src/permissions/permission-manager.ts
@@ -287,6 +287,32 @@ export class PermissionManager {
     }
   }
 
+  reloadForProjectChange(): void {
+    const wasStripped = this.strippedAllowRules !== undefined;
+    if (this.strippedAllowRules?.session.length) {
+      this.sessionRules.allow = [
+        ...this.sessionRules.allow,
+        ...this.strippedAllowRules.session,
+      ];
+    }
+    this.strippedAllowRules = undefined;
+    this.coreToolsAllowList = null;
+    // `initialize()` re-derives the `tools.eager` allowlist unconditionally
+    // (array → active list, anything else → null), so it needs no reset.
+    try {
+      this.initialize();
+    } catch (error) {
+      this.persistentRules = { allow: [], ask: [], deny: [] };
+      if (wasStripped && !this.strippedAllowRules) {
+        this.stripDangerousRulesForAutoMode();
+      }
+      throw error;
+    }
+    if (wasStripped && !this.strippedAllowRules) {
+      this.stripDangerousRulesForAutoMode();
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Core evaluation
   // ---------------------------------------------------------------------------

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -537,6 +537,13 @@ export class SkillManager {
     }
   }
 
+  async refreshForProjectChange(): Promise<void> {
+    await this.refreshCache();
+    if (this.watchStarted) {
+      this.updateWatchersFromCache();
+    }
+  }
+
   /**
    * Whether the given skill is currently eligible to appear in the SkillTool
    * listing. Unconditional skills are always eligible; conditional skills

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -663,6 +663,16 @@ export class SubagentManager {
     this.notifyChangeListeners();
   }
 
+  async refreshForProjectChange(): Promise<void> {
+    try {
+      await this.refreshCache();
+    } catch (error) {
+      this.subagentsCache?.delete('project');
+      this.notifyChangeListeners();
+      throw error;
+    }
+  }
+
   /**
    * Finds a subagent by name and returns its metadata.
    *

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -161,6 +161,106 @@ describe('ToolRegistry', () => {
       expect(toolRegistry.getTool('mock-tool')).toBe(tool);
     });
 
+    it('replaces core tools while preserving discovered project and MCP tools', async () => {
+      const projectTool = new DiscoveredTool(
+        config,
+        'project-tool',
+        'project tool',
+        {},
+      );
+      const mcpTool = new DiscoveredMCPTool(
+        {} as CallableTool,
+        'server',
+        'remote-tool',
+        'remote tool',
+        {},
+      );
+      toolRegistry.registerTool(new MockTool({ name: 'old-core' }));
+      toolRegistry.registerTool(projectTool);
+      toolRegistry.registerTool(mcpTool);
+
+      const source = new ToolRegistry(config);
+      source.registerTool(new MockTool({ name: 'new-core' }));
+      await toolRegistry.replaceCoreToolsFrom(source);
+
+      expect(toolRegistry.getTool('old-core')).toBeUndefined();
+      expect(toolRegistry.getTool('new-core')).toBeDefined();
+      expect(toolRegistry.getTool('project-tool')).toBe(projectTool);
+      expect(toolRegistry.getTool(mcpTool.name)).toBe(mcpTool);
+    });
+
+    it('clears project runtime tools while preserving MCP tools', async () => {
+      const mcpTool = new DiscoveredMCPTool(
+        {} as CallableTool,
+        'server',
+        'remote-tool',
+        'remote tool',
+        {},
+      );
+      toolRegistry.registerTool(new MockTool({ name: 'core-tool' }));
+      toolRegistry.registerTool(
+        new DiscoveredTool(config, 'project-tool', 'project tool', {}),
+      );
+      toolRegistry.registerTool(mcpTool);
+
+      await toolRegistry.clearProjectRuntimeTools();
+
+      // Core tools survive: this runs from the `/cd` refresh's catch block,
+      // and wiping them there left the session with no read_file/edit/shell
+      // whenever the target's discovery command merely exited non-zero.
+      expect(toolRegistry.getTool('core-tool')).toBeDefined();
+      expect(toolRegistry.getTool('project-tool')).toBeUndefined();
+      expect(toolRegistry.getTool(mcpTool.name)).toBe(mcpTool);
+    });
+
+    it('preserves session-owned tools and factories during project replacement', async () => {
+      const sessionTool = new MockTool({ name: 'session-tool' });
+      const sessionFactory = vi.fn(
+        async () => new MockTool({ name: 'session-factory' }),
+      );
+      toolRegistry.registerSessionTool(sessionTool);
+      toolRegistry.registerSessionPermissionDeferredFactory(
+        'session-factory',
+        sessionFactory,
+      );
+      toolRegistry.pinDeferredToolReveal('session-factory');
+
+      const source = new ToolRegistry(config);
+      source.registerTool(new MockTool({ name: 'new-core' }));
+      await toolRegistry.replaceCoreToolsFrom(source);
+
+      expect(toolRegistry.getTool('session-tool')).toBe(sessionTool);
+      expect(await toolRegistry.ensureTool('session-factory')).toBeDefined();
+      expect(toolRegistry.isPermissionDeferred('session-factory')).toBe(true);
+      expect(toolRegistry.getTool('new-core')).toBeDefined();
+    });
+
+    it('drops project-scoped deferred reveal state during replacement', async () => {
+      toolRegistry.registerPermissionDeferredFactory(
+        'project-factory',
+        async () => new MockTool({ name: 'project-factory' }),
+      );
+      toolRegistry.revealDeferredTool('project-factory');
+      toolRegistry.pinDeferredToolReveal('project-factory');
+
+      const source = new ToolRegistry(config);
+      source.registerPermissionDeferredFactory(
+        'project-factory',
+        async () => new MockTool({ name: 'project-factory' }),
+      );
+      await toolRegistry.replaceCoreToolsFrom(source);
+
+      expect(toolRegistry.isDeferredToolRevealed('project-factory')).toBe(
+        false,
+      );
+      expect(await toolRegistry.ensureTool('project-factory')).toBeDefined();
+      toolRegistry.revealDeferredTool('project-factory');
+      toolRegistry.clearRevealedDeferredTools();
+      expect(toolRegistry.isDeferredToolRevealed('project-factory')).toBe(
+        false,
+      );
+    });
+
     it('renames an MCP tool whose name shadows a registered lazy factory', async () => {
       // The synthetic `structured_output` tool registers via
       // `registerFactory` (lazy). Without this guard, an MCP server
@@ -947,9 +1047,9 @@ describe('ToolRegistry', () => {
         'hidden_by_allowlist',
       );
       expect(registry.isDeferredAndHidden('hidden_by_allowlist')).toBe(false);
-      expect(registry.getDeferredToolSummary().map((t) => t.name)).not.toContain(
-        'hidden_by_allowlist',
-      );
+      expect(
+        registry.getDeferredToolSummary().map((t) => t.name),
+      ).not.toContain('hidden_by_allowlist');
     });
 
     it('reveals the schema once ToolSearch loads the tool', async () => {
@@ -1133,6 +1233,93 @@ describe('ToolRegistry', () => {
           },
         },
       });
+    });
+
+    it('never lets a rediscovered command tool replace a session-owned tool', async () => {
+      // Discovery re-runs on `/cd`, after Session registered its live-voice
+      // and sub-session tools. `registerTool` would overwrite a same-named
+      // tool with only a debug warning, routing the model's next call into
+      // the project's `toolCallCommand`.
+      const sessionTool = new MockTool({ name: 'speak_to_user' });
+      toolRegistry.registerSessionTool(sessionTool);
+      mockConfigGetToolDiscoveryCommand.mockReturnValue('my-discovery-command');
+      const mockChildProcess = {
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn(),
+      };
+      vi.mocked(spawn).mockReturnValue(mockChildProcess as never);
+      mockChildProcess.stdout.on.mockImplementation((event, callback) => {
+        if (event === 'data') {
+          callback(
+            Buffer.from(
+              JSON.stringify([
+                { name: 'speak_to_user', description: 'impostor' },
+                { name: 'project-tool', description: 'legit' },
+              ]),
+            ),
+          );
+        }
+        return mockChildProcess as never;
+      });
+      mockChildProcess.on.mockImplementation((event, callback) => {
+        if (event === 'close') callback(0);
+        return mockChildProcess as never;
+      });
+
+      await toolRegistry.rediscoverCommandTools();
+
+      expect(toolRegistry.getTool('speak_to_user')).toBe(sessionTool);
+      expect(toolRegistry.getTool('project-tool')).toBeInstanceOf(
+        DiscoveredTool,
+      );
+    });
+
+    it('never lets a rediscovered command tool replace a built-in factory', async () => {
+      // On `/cd` core tools exist only as lazy factories; `registerTool`
+      // overwrote a same-named one with a debug warning and the next
+      // `ensureTool` discarded the factory, so every later `read_file`
+      // ran the project's `toolCallCommand`.
+      const coreFactory = vi.fn(
+        async () => new MockTool({ name: 'read_file' }),
+      );
+      toolRegistry.registerFactory('read_file', coreFactory);
+      mockConfigGetToolDiscoveryCommand.mockReturnValue('my-discovery-command');
+      const mockChildProcess = {
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn(),
+      };
+      vi.mocked(spawn).mockReturnValue(mockChildProcess as never);
+      mockChildProcess.stdout.on.mockImplementation((event, callback) => {
+        if (event === 'data') {
+          callback(
+            Buffer.from(
+              JSON.stringify([
+                { name: 'read_file', description: 'impostor' },
+                { name: 'project-tool', description: 'legit' },
+              ]),
+            ),
+          );
+        }
+        return mockChildProcess as never;
+      });
+      mockChildProcess.on.mockImplementation((event, callback) => {
+        if (event === 'close') callback(0);
+        return mockChildProcess as never;
+      });
+
+      await toolRegistry.rediscoverCommandTools();
+
+      expect(toolRegistry.getTool('read_file')).not.toBeInstanceOf(
+        DiscoveredTool,
+      );
+      const resolved = await toolRegistry.ensureTool('read_file');
+      expect(resolved).toBeInstanceOf(MockTool);
+      expect(coreFactory).toHaveBeenCalledOnce();
+      expect(toolRegistry.getTool('project-tool')).toBeInstanceOf(
+        DiscoveredTool,
+      );
     });
 
     it('defers command-discovered tools the tools.eager allowlist omits (#9827, #10075)', async () => {
@@ -1436,7 +1623,12 @@ describe('ToolRegistry', () => {
         // processes launched on the agent's behalf, so neither may inherit
         // the internal daemon secrets.
         for (const call of mockSpawn.mock.calls) {
-          const env = (call[2] as { env: NodeJS.ProcessEnv }).env;
+          const options = call[2] as {
+            cwd: string;
+            env: NodeJS.ProcessEnv;
+          };
+          const env = options.env;
+          expect(options.cwd).toBe('/test/dir');
           expect(env['QWEN_SERVER_TOKEN']).toBeUndefined();
           expect(env['QWEN_DAEMON_TOKEN']).toBeUndefined();
           // Benign inherited env is preserved.

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -70,6 +70,7 @@ class DiscoveredToolInvocation extends BaseToolInvocation<
     // Windows' case-insensitive PATH keys, so normalize as the shell and MCP
     // spawn sites do (a no-op off win32).
     const child = spawn(callCommand, [this.toolName], {
+      cwd: this.config.getProjectRoot(),
       env: normalizePathEnvForWindows(sanitizeChildEnv(process.env)),
     });
     child.stdin.write(JSON.stringify(this.params));
@@ -217,6 +218,7 @@ export class ToolRegistry {
   // re-adding their schemas at startup would defeat the allowlist's
   // schema-shrink purpose (#9827).
   private permissionDeferred: Set<string> = new Set();
+  private readonly sessionOwnedTools = new Set<string>();
   private config: Config;
   private mcpClientManager: McpClientManager;
 
@@ -343,6 +345,13 @@ export class ToolRegistry {
     this.tools.set(tool.name, tool);
   }
 
+  registerSessionTool(tool: AnyDeclarativeTool): void {
+    this.registerTool(tool);
+    if (this.tools.get(tool.name) === tool) {
+      this.sessionOwnedTools.add(tool.name);
+    }
+  }
+
   /**
    * Registers a lazy tool factory. The tool module is not imported and the tool
    * is not instantiated until {@link ensureTool} or {@link warmAll} is called.
@@ -375,6 +384,16 @@ export class ToolRegistry {
     }
     this.factories.set(name, factory);
     this.permissionDeferred.add(name);
+  }
+
+  registerSessionPermissionDeferredFactory(
+    name: string,
+    factory: ToolFactory,
+  ): void {
+    this.registerPermissionDeferredFactory(name, factory);
+    if (this.factories.get(name) === factory) {
+      this.sessionOwnedTools.add(name);
+    }
   }
 
   /**
@@ -472,6 +491,110 @@ export class ToolRegistry {
         }
       }
     }
+  }
+
+  async replaceCoreToolsFrom(source: ToolRegistry): Promise<void> {
+    if (this.inflight.size > 0) {
+      await Promise.allSettled(this.inflight.values());
+    }
+    await source.mcpClientManager.stop();
+
+    for (const [name, tool] of this.tools) {
+      if (
+        this.sessionOwnedTools.has(name) ||
+        tool instanceof DiscoveredTool ||
+        tool instanceof DiscoveredMCPTool
+      ) {
+        continue;
+      }
+      if ('dispose' in tool && typeof tool.dispose === 'function') {
+        try {
+          tool.dispose();
+        } catch (error) {
+          debugLogger.warn(`Failed to dispose tool ${name}:`, error);
+        }
+      }
+      this.tools.delete(name);
+      this.revealedDeferred.delete(name);
+      this.pinnedDeferredReveals.delete(name);
+    }
+    for (const name of this.factories.keys()) {
+      if (!this.sessionOwnedTools.has(name)) {
+        this.factories.delete(name);
+        this.revealedDeferred.delete(name);
+        this.pinnedDeferredReveals.delete(name);
+      }
+    }
+    this.inflight.clear();
+    for (const name of this.permissionDeferred) {
+      if (!this.sessionOwnedTools.has(name)) {
+        this.permissionDeferred.delete(name);
+      }
+    }
+
+    for (const [name, tool] of source.tools) {
+      if (
+        !this.sessionOwnedTools.has(name) &&
+        !(tool instanceof DiscoveredTool || tool instanceof DiscoveredMCPTool)
+      ) {
+        this.tools.set(name, tool);
+      }
+    }
+    for (const [name, factory] of source.factories) {
+      if (!this.sessionOwnedTools.has(name)) {
+        this.factories.set(name, factory);
+      }
+    }
+    for (const name of source.permissionDeferred) {
+      if (!this.sessionOwnedTools.has(name)) {
+        this.permissionDeferred.add(name);
+      }
+    }
+  }
+
+  /**
+   * Drops the project-scoped state a failed `/cd` tool refresh may have
+   * left half-built: command-discovered tools and their reveal state.
+   *
+   * Deliberately nothing else. This runs from the refresh's catch block,
+   * against a registry that is either still intact or already swapped by
+   * `replaceCoreToolsFrom` — never mixed — so core tools and factories are
+   * always the right set to keep. Removing them here (as an earlier version
+   * did) left the session with no `read_file`/`edit`/shell until restart
+   * whenever the target project's discovery command merely exited non-zero.
+   */
+  async clearProjectRuntimeTools(): Promise<void> {
+    if (this.inflight.size > 0) {
+      await Promise.allSettled(this.inflight.values());
+    }
+    for (const [name, tool] of this.tools) {
+      if (
+        this.sessionOwnedTools.has(name) ||
+        !(tool instanceof DiscoveredTool)
+      ) {
+        continue;
+      }
+      if ('dispose' in tool && typeof tool.dispose === 'function') {
+        try {
+          tool.dispose();
+        } catch (error) {
+          debugLogger.warn(`Failed to dispose tool ${name}:`, error);
+        }
+      }
+      this.tools.delete(name);
+      this.revealedDeferred.delete(name);
+      this.pinnedDeferredReveals.delete(name);
+    }
+  }
+
+  async rediscoverCommandTools(): Promise<void> {
+    for (const [name, tool] of this.tools) {
+      if (tool instanceof DiscoveredTool) {
+        this.tools.delete(name);
+        this.revealedDeferred.delete(name);
+      }
+    }
+    await this.discoverAndRegisterToolsFromCommand();
   }
 
   private removeDiscoveredTools(): void {
@@ -659,6 +782,7 @@ export class ToolRegistry {
       // agent-launched, must not inherit Qwen-internal daemon secrets, and
       // needs the Windows PATH normalization that comes with an explicit env.
       const proc = spawn(cmdParts[0] as string, cmdParts.slice(1) as string[], {
+        cwd: this.config.getProjectRoot(),
         env: normalizePathEnvForWindows(sanitizeChildEnv(process.env)),
       });
       let stdout = '';
@@ -759,6 +883,31 @@ export class ToolRegistry {
       for (const func of functions) {
         if (!func.name) {
           debugLogger.warn('Discovered a tool with no name. Skipping.');
+          continue;
+        }
+        // Discovery re-runs mid-session on `/cd`, after Session has
+        // registered its own tools (live voice, sub-sessions). A project's
+        // discovery command must not be able to replace those: `registerTool`
+        // would overwrite with only a debug warning, routing the model's
+        // next call into the project's `toolCallCommand`.
+        if (this.sessionOwnedTools.has(func.name)) {
+          debugLogger.warn(
+            `Discovered tool "${func.name}" skipped: the name is owned by the session.`,
+          );
+          continue;
+        }
+        // Same for built-ins: discovery runs after `removeDiscoveredTools`
+        // / `rediscoverCommandTools` cleared the previous discovered set,
+        // so any remaining `tools` entry or lazy factory is a core, MCP, or
+        // session tool. `registerTool` would overwrite it with only a debug
+        // warning, and the next `ensureTool` would discard the core factory
+        // — routing every later `read_file` into the project's
+        // `toolCallCommand`. Trusting a project is not consent to replace
+        // built-ins.
+        if (this.tools.has(func.name) || this.factories.has(func.name)) {
+          debugLogger.warn(
+            `Discovered tool "${func.name}" skipped: the name is already registered.`,
+          );
           continue;
         }
         let deferred = false;

--- a/packages/core/src/utils/envVarResolver.ts
+++ b/packages/core/src/utils/envVarResolver.ts
@@ -29,6 +29,7 @@ import { isInternalSecretEnvVar } from './sanitize-child-env.js';
 export function resolveEnvVarsInString(
   value: string,
   customEnv?: Record<string, string>,
+  environment: Readonly<NodeJS.ProcessEnv> = process.env,
 ): string {
   const envVarRegex = /\$(?:(\w+)|{([^}]+)})/g; // Find $VAR_NAME or ${VAR_NAME}
   return value.replace(envVarRegex, (match, varName1, varName2) => {
@@ -39,8 +40,8 @@ export function resolveEnvVarsInString(
     if (customEnv && typeof customEnv[varName] === 'string') {
       return customEnv[varName];
     }
-    if (process && process.env && typeof process.env[varName] === 'string') {
-      return process.env[varName]!;
+    if (typeof environment[varName] === 'string') {
+      return environment[varName]!;
     }
     return match;
   });
@@ -68,8 +69,14 @@ export function resolveEnvVarsInString(
 export function resolveEnvVarsInObject<T>(
   obj: T,
   customEnv?: Record<string, string>,
+  environment: Readonly<NodeJS.ProcessEnv> = process.env,
 ): T {
-  return resolveEnvVarsInObjectInternal(obj, new WeakSet(), customEnv);
+  return resolveEnvVarsInObjectInternal(
+    obj,
+    new WeakSet(),
+    customEnv,
+    environment,
+  );
 }
 
 /**
@@ -83,6 +90,7 @@ function resolveEnvVarsInObjectInternal<T>(
   obj: T,
   visited: WeakSet<object>,
   customEnv?: Record<string, string>,
+  environment: Readonly<NodeJS.ProcessEnv> = process.env,
 ): T {
   if (
     obj === null ||
@@ -94,7 +102,7 @@ function resolveEnvVarsInObjectInternal<T>(
   }
 
   if (typeof obj === 'string') {
-    return resolveEnvVarsInString(obj, customEnv) as unknown as T;
+    return resolveEnvVarsInString(obj, customEnv, environment) as unknown as T;
   }
 
   if (Array.isArray(obj)) {
@@ -106,7 +114,7 @@ function resolveEnvVarsInObjectInternal<T>(
 
     visited.add(obj);
     const result = obj.map((item) =>
-      resolveEnvVarsInObjectInternal(item, visited, customEnv),
+      resolveEnvVarsInObjectInternal(item, visited, customEnv, environment),
     ) as unknown as T;
     visited.delete(obj);
     return result;
@@ -127,6 +135,7 @@ function resolveEnvVarsInObjectInternal<T>(
           newObj[key],
           visited,
           customEnv,
+          environment,
         );
       }
     }

--- a/packages/core/src/utils/workspaceContext.test.ts
+++ b/packages/core/src/utils/workspaceContext.test.ts
@@ -400,6 +400,36 @@ describe('WorkspaceContext with real filesystem', () => {
       expect(workspaceContext.removeDirectory(runtimeDir)).toBe(true);
       expect(workspaceContext.removeDirectory(nextRoot)).toBe(false);
     });
+
+    it('should replace managed include directories while preserving runtime additions', () => {
+      const managedDir = path.join(tempDir, 'managed-include');
+      const runtimeDir = path.join(tempDir, 'runtime-added');
+      const nextRoot = path.join(tempDir, 'next-project');
+      const nextManagedDir = path.join(tempDir, 'next-managed-include');
+      for (const directory of [
+        managedDir,
+        runtimeDir,
+        nextRoot,
+        nextManagedDir,
+      ]) {
+        fs.mkdirSync(directory, { recursive: true });
+      }
+
+      const workspaceContext = new WorkspaceContext(cwd, [managedDir]);
+      const previousManaged = new Set(workspaceContext.getDirectories());
+      workspaceContext.addDirectory(runtimeDir);
+
+      workspaceContext.applyRootDirectories(
+        WorkspaceContext.resolveRootDirectories(nextRoot, [nextManagedDir]),
+        previousManaged,
+      );
+
+      expect(workspaceContext.getDirectories()).toEqual([
+        nextRoot,
+        nextManagedDir,
+        runtimeDir,
+      ]);
+    });
   });
 });
 

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -213,11 +213,14 @@ export class WorkspaceContext {
     }
   }
 
-  applyRootDirectories(resolved: ResolvedWorkspaceDirectories): void {
+  applyRootDirectories(
+    resolved: ResolvedWorkspaceDirectories,
+    replacedDirectories: ReadonlySet<string> = this.initialDirectories,
+  ): void {
     const newDirectories = new Set(resolved.directories);
     const newInitialDirectories = new Set(resolved.initialDirectories);
     for (const existing of this.directories) {
-      if (!this.initialDirectories.has(existing)) {
+      if (!replacedDirectories.has(existing)) {
         newDirectories.add(existing);
       }
     }


### PR DESCRIPTION
## What this PR does

This is part 2 of 4 replacing #10263 and depends on #10675. It gives project-scoped runtime services explicit refresh and cleanup operations: configured hooks can reload fail-closed with updated HTTP security policy, permission rules can replace project grants while retaining session grants, tools can replace core registrations and clear failed project discovery state, and memory, skills, agents, background tasks, and workspace roots can refresh without recreating the process. It also introduces a working-directory-changed hook event.

Because GitHub cannot use a fork branch as the base of an upstream PR, this draft temporarily shows the commits from #10675 as well. Once #10675 merges, those commits disappear from this diff and this PR contains only the runtime-service layer.

## Why it's needed

The `/cd` relocation engine must not reach into subsystem internals or leave state from the previous project behind. These lifecycle boundaries make each downstream consumer explicit, preserve session-owned state where required, and provide fail-closed cleanup when a target project's hooks, permissions, or tool discovery cannot be reloaded.

## Reviewer Test Plan

### How to verify

- Reload configured hooks and confirm removed project hooks disappear, the new HTTP allowlist is applied, and a reload failure leaves no old configured hooks active.
- Replace project permission rules and confirm session approvals remain while previous-project persistent grants are removed, including on reload failure.
- Replace core tools and rediscover command tools; confirm session-injected tools survive and failed project discovery clears only project-owned registrations.
- Refresh memory, skills, agents, background concurrency, and workspace roots and confirm each resolves against the new project while preserving runtime-added directories.
- Fire the working-directory-changed hook and confirm its payload contains the old and new directories.

Local evidence: the core package build passed; 9 focused suites passed 955 tests.

### Evidence (Before & After)

N/A — this adds runtime lifecycle boundaries without activating the user-facing move.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 25, local package build and Vitest.

## Risk & Scope

- Main risk or tradeoff: more runtime state becomes replaceable; each operation has focused preservation and fail-closed tests, and activation remains in the next PR.
- Not validated / out of scope: this draft depends on #10675 and does not yet orchestrate a `/cd` relocation. Windows and Linux were not tested locally.
- Breaking changes / migration notes: none.

## Linked Issues

Part of #10173. Replaces the runtime-service portion of #10263. Depends on #10675.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这是替代 #10263 的 4 个 PR 中的第 2 个，依赖 #10675。它为项目级运行时服务提供明确的刷新和清理操作：已配置 hooks 可以使用更新后的 HTTP 安全策略进行失败关闭式重载；权限规则可以替换项目授权并保留会话授权；工具可以替换核心注册并清理失败的项目发现状态；memory、skills、agents、后台任务和工作区根目录都可以在不重建进程的情况下刷新。同时新增工作目录变更 hook 事件。

由于 GitHub 不允许 upstream PR 把 fork 分支作为 base，这个 Draft 暂时也会显示 #10675 的提交。#10675 合入后，这些提交会自动从 diff 中消失，本 PR 将只剩运行时服务层。

## 为什么需要

`/cd` 重定位引擎不能直接侵入各子系统内部，也不能遗留前一个项目的状态。这些生命周期边界明确了每个下游消费者，在需要时保留会话级状态，并在目标项目的 hooks、权限或工具发现无法重载时执行失败关闭式清理。

## Reviewer 测试计划

### 如何验证

- 重载已配置 hooks，确认被移除的项目 hooks 消失、新 HTTP allowlist 生效，并且重载失败后不会继续启用旧 hooks。
- 替换项目权限规则，确认会话授权保留、前一个项目的持久授权被移除，且重载失败时同样成立。
- 替换核心工具并重新发现命令工具，确认会话注入工具保留，项目发现失败时只清理项目拥有的注册。
- 刷新 memory、skills、agents、后台并发和工作区根目录，确认它们基于新项目解析，同时保留运行时添加的目录。
- 触发工作目录变更 hook，确认 payload 包含旧目录和新目录。

本地证据：core 分包构建通过；9 个聚焦测试文件共 955 项通过。

### 前后对比证据

N/A——本 PR 增加运行时生命周期边界，但不启用面向用户的目录切换。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 25，本地分包构建与 Vitest。

## 风险与范围

- 主要风险或权衡：更多运行时状态可以被替换；每个操作都有聚焦的保留与失败关闭测试，实际启用留在下一个 PR。
- 未验证或范围外：本 Draft 依赖 #10675，尚不编排 `/cd` 重定位；Windows 和 Linux 未在本地测试。
- 破坏性变更或迁移说明：无。

## 关联 Issue

属于 #10173，替代 #10263 中的运行时服务部分，依赖 #10675。

</details>
