### PR TITLE
fix(cua): publish unsigned Windows UIAccess worker

### DIFF
--- a/.github/workflows/cd-cua-driver.yml
+++ b/.github/workflows/cd-cua-driver.yml
@@ -9,10 +9,9 @@ name: 'CD: Qwen CUA Driver'
 #                   (APPLE_NOTARY_API_KEY_P8_BASE64 / _KEY_ID / _ISSUER_ID)
 #     The Developer ID Application identity is auto-discovered from the
 #     imported cert (no DEVELOPER_NAME secret needed).
-# The Windows UIAccess worker is Authenticode-signed. Release builds require
-# the repository Windows signing certificate; dry runs use an ephemeral test
-# certificate so packaging and installation verification exercise the same
-# signed-worker contract without producing a releasable artifact.
+# Windows archives carry the unsigned UIAccess worker. Deployments that need
+# UIAccess must sign and trust that worker on the target machine before placing
+# it under the secure Program Files path required by Windows.
 #
 # Artifact convention used by the @qwen-code/cua-sdk native installer:
 #   macOS  : cua-driver-rs-<v>-darwin-{arm64,x86_64,universal}.tar.gz
@@ -277,7 +276,7 @@ jobs:
           path: 'packages/cua-driver/rust/release/cua-driver-rs-*-linux-${{ matrix.arch }}*.tar.gz'
           if-no-files-found: 'error'
 
-  # ── Windows (x86_64 + arm64) — SIGNED UIAccess worker ────────────────────
+  # ── Windows (x86_64 + arm64) — unsigned UIAccess worker ────────────────────
   build-windows:
     name: 'windows-${{ matrix.arch }}'
     needs: ['validate-version']
@@ -325,7 +324,12 @@ jobs:
             cua-driver-windows-${{ matrix.arch }}-
       - name: 'Build (release)'
         working-directory: 'packages/cua-driver/rust'
-        run: 'cargo build -p cua-driver -p cursor-theme-cli -p cua-driver-uia -p cua-driver-sdk --release --locked --target ${{ matrix.target }}'
+        shell: 'pwsh'
+        run: |
+          # A cached target may contain a worker mutated by an earlier signing
+          # job. Remove the final PE so Cargo always relinks an unsigned worker.
+          Remove-Item "target/${{ matrix.target }}/release/cua-driver-uia.exe" -Force -ErrorAction SilentlyContinue
+          cargo build -p cua-driver -p cursor-theme-cli -p cua-driver-uia -p cua-driver-sdk --release --locked --target ${{ matrix.target }}
       - name: 'Build Electron-compatible Node runtime'
         working-directory: 'packages/cua-driver'
         shell: 'bash'
@@ -334,64 +338,16 @@ jobs:
           node scripts/build-node-runtime.mjs \
             --target "${{ matrix.target }}" \
             --output "rust/target/${{ matrix.target }}/release/cua_driver_node_runtime.node"
-      - name: 'Sign UIAccess worker'
+      - name: 'Verify unsigned UIAccess worker'
         shell: 'pwsh'
-        env:
-          WINDOWS_CERTIFICATE: '${{ secrets.WINDOWS_CERTIFICATE }}'
-          WINDOWS_CERTIFICATE_PASSWORD: '${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}'
-          LEGACY_WIN_CSC_LINK: '${{ secrets.WIN_CSC_LINK }}'
-          LEGACY_WIN_CSC_KEY_PASSWORD: '${{ secrets.WIN_CSC_KEY_PASSWORD }}'
         run: |
           $worker = "packages/cua-driver/rust/target/${{ matrix.target }}/release/cua-driver-uia.exe"
-          $primaryIncomplete = ([bool]$env:WINDOWS_CERTIFICATE) -ne ([bool]$env:WINDOWS_CERTIFICATE_PASSWORD)
-          $legacyIncomplete = ([bool]$env:LEGACY_WIN_CSC_LINK) -ne ([bool]$env:LEGACY_WIN_CSC_KEY_PASSWORD)
-          if ($primaryIncomplete -or $legacyIncomplete) {
-            throw 'Incomplete Windows signing configuration.'
+          if (-not (Test-Path -LiteralPath $worker -PathType Leaf)) {
+            throw 'Windows build did not produce cua-driver-uia.exe'
           }
-
-          $certificate = $null
-          if ($env:WINDOWS_CERTIFICATE -and $env:WINDOWS_CERTIFICATE_PASSWORD) {
-            $pfx = $env:WINDOWS_CERTIFICATE
-            $pfxPassword = $env:WINDOWS_CERTIFICATE_PASSWORD
-          } elseif ($env:LEGACY_WIN_CSC_LINK -and $env:LEGACY_WIN_CSC_KEY_PASSWORD) {
-            $pfx = $env:LEGACY_WIN_CSC_LINK
-            $pfxPassword = $env:LEGACY_WIN_CSC_KEY_PASSWORD
-          } elseif ('${{ inputs.dry_run }}' -eq 'true') {
-            $certificate = New-SelfSignedCertificate -Type CodeSigningCert -Subject 'CN=Qwen CUA Driver CI Test' -CertStoreLocation Cert:\CurrentUser\My
-            $cer = Join-Path $env:RUNNER_TEMP 'qwen-cua-driver-ci-test.cer'
-            Export-Certificate -Cert $certificate -FilePath $cer | Out-Null
-            Import-Certificate -FilePath $cer -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
-            Import-Certificate -FilePath $cer -CertStoreLocation Cert:\CurrentUser\TrustedPublisher | Out-Null
-          } else {
-            throw 'A Windows signing certificate is required for a CUA release.'
-          }
-
-          if (-not $certificate) {
-            $path = Join-Path $env:RUNNER_TEMP 'qwen-cua-driver.pfx'
-            [IO.File]::WriteAllBytes($path, [Convert]::FromBase64String($pfx))
-            $password = ConvertTo-SecureString $pfxPassword -AsPlainText -Force
-            $imported = @(Import-PfxCertificate -FilePath $path -CertStoreLocation Cert:\CurrentUser\My -Password $password)
-            $certificate = $imported |
-              Where-Object {
-                $_.HasPrivateKey -and
-                $_.EnhancedKeyUsageList.ObjectId.Value -contains '1.3.6.1.5.5.7.3.3'
-              } |
-              Select-Object -First 1
-            if (-not $certificate) {
-              throw 'The Windows PFX does not contain a code-signing certificate with a private key.'
-            }
-          }
-
-          $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Filter signtool.exe -Recurse |
-            Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
-            Sort-Object FullName -Descending |
-            Select-Object -First 1
-          if (-not $signtool) { throw 'signtool.exe was not found' }
-          & $signtool.FullName sign /sha1 $certificate.Thumbprint /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $worker
-          if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
           $signature = Get-AuthenticodeSignature -LiteralPath $worker
-          if ($signature.Status -ne 'Valid') {
-            throw "UIAccess worker signature status is $($signature.Status)"
+          if ($signature.Status -ne 'NotSigned') {
+            throw "Release worker must be unsigned for target-machine signing; status is $($signature.Status)"
           }
       - name: 'Package'
         working-directory: 'packages/cua-driver/rust'
@@ -876,8 +832,9 @@ jobs:
 
             - **macOS**: codesigned + notarized universal binary + `QwenCuaDriver.app`
             - **Linux**: unsigned (x86_64 + arm64, glibc 2.31 floor)
-            - **Windows**: signed UIAccess worker + native SDK payload
-              (x86_64 + arm64)
+            - **Windows**: unsigned UIAccess worker + native SDK payload
+              (x86_64 + arm64); deployments must sign and trust the worker
+              on the target machine before UIAccess activation
             - **Node.js**: the same workflow publishes `@qwen-code/cua-sdk`
               after a clean install against these release assets and publishes
               the independently versioned `@qwen-code/node-repl-mcp` package

--- a/packages/cua-driver/rust/crates/cua-driver-uia/cua-driver-uia.manifest
+++ b/packages/cua-driver/rust/crates/cua-driver-uia/cua-driver-uia.manifest
@@ -20,8 +20,9 @@
                EnableSecureUIAPaths=0 set by an admin
 
           Development builds use a separately named local worker. Release
-          builds are signed by Qwen's Windows release certificate and install
-          the worker under \Program Files\Qwen\CuaDriver\<version>\.
+          archives carry an unsigned worker; deployments must sign and trust it
+          on the target machine before installing it under
+          \Program Files\Qwen\CuaDriver\<version>\.
         -->
         <requestedExecutionLevel level="asInvoker" uiAccess="true"/>
       </requestedPrivileges>

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -118,15 +118,16 @@ describe('CUA release workflow', () => {
     );
   });
 
-  it('requires the signed Windows UIAccess worker in release artifacts', () => {
+  it('ships the Windows UIAccess worker for target-machine signing', () => {
     expect(cuaReleaseWorkflow).toMatch(
-      /Build \(release\)[\s\S]*?Sign UIAccess worker[\s\S]*?Get-AuthenticodeSignature[\s\S]*?qwen-cua-driver-uia\.exe[\s\S]*?release artifact contract/,
+      /Build \(release\)[\s\S]*?Remove-Item[^\n]*cua-driver-uia\.exe[^\n]*\n[^\n]*cargo build[\s\S]*?Verify unsigned UIAccess worker/,
     );
-    expect(cuaReleaseWorkflow).toContain(
-      'A Windows signing certificate is required for a CUA release.',
+    expect(cuaReleaseWorkflow).toMatch(
+      /Build \(release\)[\s\S]*?Verify unsigned UIAccess worker[\s\S]*?Get-AuthenticodeSignature[\s\S]*?NotSigned[\s\S]*?qwen-cua-driver-uia\.exe[\s\S]*?release artifact contract/,
     );
+    expect(cuaReleaseWorkflow).not.toMatch(/WINDOWS_CERTIFICATE|WIN_CSC_LINK/);
     expect(cuaReleaseWorkflow).toContain(
-      '- **Windows**: signed UIAccess worker + native SDK payload',
+      '- **Windows**: unsigned UIAccess worker + native SDK payload',
     );
   });
 


### PR DESCRIPTION
## What this PR does

Publishes the Windows UIAccess worker in CUA release archives as an explicitly unsigned binary. Windows release jobs now delete any cached worker before rebuilding it, verify that the rebuilt worker is unsigned, and preserve the existing archive layout so deployment environments can sign and trust it on the target machine.

The SDK installer and runtime fail-closed checks remain unchanged: an unsigned or invalid worker is still rejected at installation and runtime, so UIAccess cannot silently run without the target deployment completing its signing and trust step.

## Why it's needed

The 0.20.3 release failed because the Windows release jobs required repository signing-certificate secrets that are not available. The upstream driver build itself succeeds and the target RecreationBench environment can establish trust locally, so requiring a production certificate during artifact publication blocks a usable target-signing workflow without improving the runtime trust boundary.

## Reviewer Test Plan

### How to verify

Run the targeted release-workflow tests and confirm that the Windows jobs rebuild the worker after cache restoration, reject a pre-signed worker during publication, include the unsigned worker in both release archives, and no longer reference Windows certificate secrets. Confirm separately that the existing Windows SDK installation and runtime paths still reject a worker whose Authenticode status is not valid.

Commands run locally:

```text
node_modules/.bin/vitest run --config scripts/tests/vitest.config.ts scripts/tests/release-workflow.test.js scripts/tests/cua-driver-release-workflow.test.js
actionlint .github/workflows/cd-cua-driver.yml
yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}' .github/workflows/cd-cua-driver.yml
node_modules/.bin/prettier --check .github/workflows/cd-cua-driver.yml packages/cua-driver/rust/crates/cua-driver-uia/cua-driver-uia.manifest scripts/tests/release-workflow.test.js
```

Observed result: 35 tests passed, 1 test skipped; workflow lint, YAML lint, formatting, and diff checks passed.

### Evidence (Before & After)

Before: the Windows release jobs stopped after compilation with `A Windows signing certificate is required for a CUA release.` and no 0.20.3 release artifacts or npm packages were published.

After: the workflow contract permits publication only when the freshly rebuilt UIAccess worker is unsigned, while target installation and runtime validation continue to require a valid signature.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Node.js workspace tests and static GitHub Actions validation on macOS. The actual Windows release path is expected to be validated by PR CI.

## Risk & Scope

- Main risk or tradeoff: Windows consumers must sign and trust the worker on the target machine before installing the SDK package; otherwise the existing fail-closed checks intentionally reject it.
- Not validated / out of scope: target-machine self-signing in RecreationBench and a full package publication run are not part of this PR.
- Breaking changes / migration notes: release archives now intentionally carry an unsigned Windows UIAccess worker; deployments that need UIAccess must complete their target signing and trust step before installation.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Windows CUA 发布产物现在会明确携带未签名的 UIAccess worker。Windows 发布任务会先删除缓存中可能存在的 worker，再重新构建并验证新产物确实未签名，同时保持现有压缩包结构不变，以便部署环境在目标机器上完成签名和信任配置。

SDK 安装器和运行时的 fail-closed 校验保持不变：未签名或签名无效的 worker 仍会在安装和运行阶段被拒绝，因此目标部署未完成签名与信任步骤时，UIAccess 不会被静默启用。

## 为什么需要这个 PR

0.20.3 发布失败的原因是 Windows 发布任务强制要求仓库中并不存在的签名证书 secret。上游 driver 本身能够正常构建，目标 RecreationBench 环境也可以在本机建立信任，因此在发布阶段强制要求生产证书只会阻断目标机器签名方案，并不会增强运行时信任边界。

## Reviewer 测试计划

### 如何验证

运行定向发布工作流测试，确认 Windows 任务会在恢复缓存后重新构建 worker、在发布阶段拒绝已经签名的 worker、在两个发布压缩包中保留未签名 worker，并且不再引用 Windows 证书 secret。再单独确认现有 Windows SDK 安装和运行路径仍会拒绝 Authenticode 状态不是 Valid 的 worker。

本地运行的命令：

```text
node_modules/.bin/vitest run --config scripts/tests/vitest.config.ts scripts/tests/release-workflow.test.js scripts/tests/cua-driver-release-workflow.test.js
actionlint .github/workflows/cd-cua-driver.yml
yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}' .github/workflows/cd-cua-driver.yml
node_modules/.bin/prettier --check .github/workflows/cd-cua-driver.yml packages/cua-driver/rust/crates/cua-driver-uia/cua-driver-uia.manifest scripts/tests/release-workflow.test.js
```

结果：35 个测试通过，1 个测试跳过；workflow lint、YAML lint、格式检查和 diff 检查均通过。

### 前后对比证据

修改前：Windows 发布任务在编译完成后以 `A Windows signing certificate is required for a CUA release.` 终止，0.20.3 的 release 产物和 npm 包均未发布。

修改后：只有新鲜重建且确认未签名的 UIAccess worker 才允许进入发布产物，同时目标安装和运行时仍要求有效签名。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  | N/A  |

### 环境（可选）

在 macOS 上运行 Node.js workspace 测试和 GitHub Actions 静态校验。真实 Windows 发布路径由 PR CI 验证。

## 风险与范围

- 主要风险或取舍：Windows 使用方必须在目标机器上完成 worker 签名与信任后再安装 SDK 包；否则现有 fail-closed 校验会按预期拒绝该 worker。
- 未验证或不在范围内：RecreationBench 目标机器自签实现和完整包发布不属于这个 PR。
- 破坏性变更或迁移说明：发布压缩包现在会有意携带未签名的 Windows UIAccess worker；需要 UIAccess 的部署必须先在目标机器完成签名和信任步骤。

## 关联 Issue

N/A

</details>
