### PR TITLE
fix(web-shell): reconcile queued prompts across clients

### DIFF
--- a/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
@@ -633,6 +633,15 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     });
     const removal = deferred<{ removed: boolean }>();
     sdkMock.actions.removeMidTurnMessage.mockReturnValueOnce(removal.promise);
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'm-removing',
+          text: 'remove me',
+          state: 'running',
+        },
+      ],
+    });
     const harness = createHarness();
     try {
       await harness.render({ streamingState: 'responding' });
@@ -664,6 +673,108 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         await Promise.resolve();
       });
 
+      expect(harness.reportError).toHaveBeenCalledOnce();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('keeps a row visible when editing loses a race with prompt start', async () => {
+    sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+      messages: [{ messageId: 'm-editing', text: 'edit me' }],
+      settledMessageIds: [],
+      promotedMessageIds: [],
+    });
+    const removal = deferred<{ removed: boolean }>();
+    sdkMock.actions.removeMidTurnMessage.mockReturnValueOnce(removal.promise);
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'm-editing',
+          text: 'edit me',
+          state: 'running',
+        },
+      ],
+    });
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const row = harness.result().queuedPrompts[0]!;
+      await act(async () => {
+        void harness.result().editQueuedPrompt(row.id);
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts[0]?.isEditing).toBe(true);
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: 'client-before-reload',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-editing',
+              text: 'edit me',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts).toHaveLength(1);
+
+      await act(async () => {
+        removal.resolve({ removed: false });
+        await Promise.resolve();
+      });
+
+      expect(harness.reportError).toHaveBeenCalledOnce();
+      expect(harness.editor.setText).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('drops a settled server row after its pending action finishes', async () => {
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'p-settled-action',
+          text: 'already started',
+          state: 'queued',
+        },
+      ],
+    });
+    const removal = deferred<{ removed: boolean }>();
+    sdkMock.actions.removePendingPrompt.mockReturnValueOnce(removal.promise);
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const row = harness.result().queuedPrompts[0]!;
+      await act(async () => {
+        harness.result().removeQueuedPrompt(row.id);
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts[0]?.isRemoving).toBe(true);
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'turn_complete',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'p-settled-action',
+            },
+          },
+        ]);
+      });
+      expect(harness.result().queuedPrompts).toHaveLength(1);
+
+      await act(async () => {
+        removal.resolve({ removed: false });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
       expect(harness.reportError).toHaveBeenCalledOnce();
     } finally {
       await harness.dispose();
@@ -4423,6 +4534,55 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         payloadCompleteness: 'summary-only',
         images: [{ data: 'aW1n', media_type: 'image/png' }],
       });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('keeps an own-client summary-only row when its prompt starts', async () => {
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'p-summary-started',
+          text: 'look at both',
+          content: [
+            { type: 'image', data: 'aW1n', mimeType: 'image/png' },
+            {
+              type: 'image',
+              attachmentId: 'media-2',
+              mimeType: 'image/png',
+              size: 3,
+            },
+          ],
+          queuedAt: Date.now(),
+          state: 'queued' as const,
+        },
+      ],
+    });
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      expect(harness.result().queuedPrompts[0]?.payloadCompleteness).toBe(
+        'summary-only',
+      );
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: CLIENT_ID,
+            data: {
+              sessionId: 'session-a',
+              promptId: 'p-summary-started',
+              text: 'look at both',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toHaveLength(1);
+      expect(harness.store.appendLocalUserMessage).not.toHaveBeenCalled();
     } finally {
       await harness.dispose();
     }

--- a/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
@@ -781,6 +781,96 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
     }
   });
 
+  it('drops a server row after successful deletion', async () => {
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'p-delete-success',
+          text: 'delete me',
+          state: 'queued',
+        },
+      ],
+    });
+    const removal = deferred<{ removed: boolean }>();
+    sdkMock.actions.removePendingPrompt.mockReturnValueOnce(removal.promise);
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      sdkMock.actions.getPendingPrompts.mockResolvedValue({
+        pendingPrompts: [],
+      });
+      const row = harness.result().queuedPrompts[0]!;
+      await act(async () => {
+        harness.result().removeQueuedPrompt(row.id);
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts[0]?.isRemoving).toBe(true);
+
+      await act(async () => {
+        removal.resolve({ removed: true });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.reportError).not.toHaveBeenCalled();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('keeps a server row while deletion is in flight', async () => {
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'p-delete-race',
+          text: 'delete me',
+          state: 'queued',
+        },
+      ],
+    });
+    const removal = deferred<{ removed: boolean }>();
+    sdkMock.actions.removePendingPrompt.mockReturnValueOnce(removal.promise);
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      sdkMock.actions.getPendingPrompts.mockResolvedValue({
+        pendingPrompts: [],
+      });
+      const row = harness.result().queuedPrompts[0]!;
+      await act(async () => {
+        harness.result().removeQueuedPrompt(row.id);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: 'client-before-reload',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'p-other',
+              text: 'other prompt',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts).toHaveLength(1);
+      expect(harness.result().queuedPrompts[0]?.isRemoving).toBe(true);
+
+      await act(async () => {
+        removal.resolve({ removed: false });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+      expect(harness.reportError).toHaveBeenCalledOnce();
+    } finally {
+      await harness.dispose();
+    }
+  });
+
   it('keeps unrelated prompts from a response that crosses a terminal event', async () => {
     const harness = createHarness();
     try {

--- a/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
@@ -462,7 +462,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         pendingPrompts: Array<{
           promptId: string;
           text: string;
-          state: 'running';
+          state: 'queued';
         }>;
       }>();
       sdkMock.actions.getPendingPrompts.mockReturnValueOnce(pending.promise);
@@ -498,7 +498,7 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
             {
               promptId: 'm-complete',
               text: 'finish me',
-              state: 'running',
+              state: 'queued',
             },
           ],
         });
@@ -506,6 +506,165 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
       });
 
       expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not restore an errored prompt from an older pending response', async () => {
+    sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+      messages: [{ messageId: 'm-error', text: 'fail me' }],
+      settledMessageIds: [],
+      promotedMessageIds: [],
+    });
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const pending = deferred<{
+        pendingPrompts: Array<{
+          promptId: string;
+          text: string;
+          state: 'queued';
+        }>;
+      }>();
+      sdkMock.actions.getPendingPrompts.mockReturnValueOnce(pending.promise);
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: CLIENT_ID,
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-error',
+              text: 'fail me',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'turn_error',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-error',
+            },
+          },
+        ]);
+      });
+      await act(async () => {
+        pending.resolve({
+          pendingPrompts: [
+            {
+              promptId: 'm-error',
+              text: 'fail me',
+              state: 'queued',
+            },
+          ],
+        });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not restore a settled prompt from an older mid-turn snapshot', async () => {
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const snapshot = deferred<{
+        messages: Array<{ messageId: string; text: string }>;
+        settledMessageIds: string[];
+        promotedMessageIds: string[];
+      }>();
+      sdkMock.actions.getMidTurnMessages.mockReturnValueOnce(snapshot.promise);
+      await harness.render({ streamingState: 'idle' });
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: CLIENT_ID,
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-settled',
+              text: 'already settled',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'turn_complete',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-settled',
+            },
+          },
+        ]);
+      });
+      await act(async () => {
+        snapshot.resolve({
+          messages: [{ messageId: 'm-settled', text: 'already settled' }],
+          settledMessageIds: [],
+          promotedMessageIds: [],
+        });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('keeps a row visible when deletion loses a race with prompt start', async () => {
+    sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+      messages: [{ messageId: 'm-removing', text: 'remove me' }],
+      settledMessageIds: [],
+      promotedMessageIds: [],
+    });
+    const removal = deferred<{ removed: boolean }>();
+    sdkMock.actions.removeMidTurnMessage.mockReturnValueOnce(removal.promise);
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const row = harness.result().queuedPrompts[0]!;
+      await act(async () => {
+        harness.result().removeQueuedPrompt(row.id);
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts[0]?.isRemoving).toBe(true);
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: 'client-before-reload',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-removing',
+              text: 'remove me',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      expect(harness.result().queuedPrompts).toHaveLength(1);
+
+      await act(async () => {
+        removal.resolve({ removed: false });
+        await Promise.resolve();
+      });
+
+      expect(harness.reportError).toHaveBeenCalledOnce();
     } finally {
       await harness.dispose();
     }

--- a/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.midTurnReconcile.test.tsx
@@ -90,6 +90,14 @@ vi.mock('@qwen-code/web-shell/daemon-react-sdk', async () => {
 
 const CLIENT_ID = 'client-self';
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 interface HarnessOptions {
   connected?: boolean;
   writeBlocked?: boolean;
@@ -309,6 +317,263 @@ describe('useQueuedPrompts mid-turn reconciliation (session_mid_turn_message_que
         midTurnState: 'queued',
         midTurnMessageId: 'm1',
       });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('removes a started prompt after the client id changes without echoing it twice', async () => {
+    sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+      messages: [{ messageId: 'm-other', text: 'queued elsewhere' }],
+      settledMessageIds: [],
+      promotedMessageIds: [],
+    });
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'm-other',
+          text: 'queued elsewhere',
+          state: 'running',
+        },
+      ],
+    });
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: 'client-before-reload',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-other',
+              text: 'queued elsewhere',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+
+      expect(harness.store.appendLocalUserMessage).not.toHaveBeenCalled();
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('removes a cross-client started prompt when its refresh fails', async () => {
+    sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+      messages: [],
+      settledMessageIds: [],
+      promotedMessageIds: [],
+    });
+    sdkMock.actions.getPendingPrompts.mockResolvedValue({
+      pendingPrompts: [
+        {
+          promptId: 'm-other',
+          text: 'queued elsewhere',
+          state: 'queued',
+        },
+      ],
+    });
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      expect(harness.result().queuedPrompts).toMatchObject([
+        { serverPromptId: 'm-other', serverState: 'queued' },
+      ]);
+      sdkMock.actions.getPendingPrompts.mockRejectedValueOnce(
+        new Error('pending refresh failed'),
+      );
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: 'client-before-reload',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-other',
+              text: 'queued elsewhere',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not restore a started prompt from an older mid-turn snapshot', async () => {
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const snapshot = deferred<{
+        messages: Array<{ messageId: string; text: string }>;
+        settledMessageIds: string[];
+        promotedMessageIds: string[];
+      }>();
+      sdkMock.actions.getMidTurnMessages.mockReturnValueOnce(snapshot.promise);
+      await harness.render({ streamingState: 'idle' });
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-stale',
+              text: 'already started',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        snapshot.resolve({
+          messages: [{ messageId: 'm-stale', text: 'already started' }],
+          settledMessageIds: [],
+          promotedMessageIds: [],
+        });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('does not restore a completed prompt from an older pending response', async () => {
+    sdkMock.actions.getMidTurnMessages.mockResolvedValue({
+      messages: [{ messageId: 'm-complete', text: 'finish me' }],
+      settledMessageIds: [],
+      promotedMessageIds: [],
+    });
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const pending = deferred<{
+        pendingPrompts: Array<{
+          promptId: string;
+          text: string;
+          state: 'running';
+        }>;
+      }>();
+      sdkMock.actions.getPendingPrompts.mockReturnValueOnce(pending.promise);
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: CLIENT_ID,
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-complete',
+              text: 'finish me',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'turn_complete',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-complete',
+            },
+          },
+        ]);
+      });
+      await act(async () => {
+        pending.resolve({
+          pendingPrompts: [
+            {
+              promptId: 'm-complete',
+              text: 'finish me',
+              state: 'running',
+            },
+          ],
+        });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toEqual([]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('keeps unrelated prompts from a response that crosses a terminal event', async () => {
+    const harness = createHarness();
+    try {
+      await harness.render({ streamingState: 'responding' });
+      const pending = deferred<{
+        pendingPrompts: Array<{
+          promptId: string;
+          text: string;
+          state: 'queued' | 'running';
+        }>;
+      }>();
+      sdkMock.actions.getPendingPrompts.mockReturnValueOnce(pending.promise);
+
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'pending_prompt_started',
+            originatorClientId: CLIENT_ID,
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-complete',
+              text: 'finish me',
+            },
+          },
+        ]);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        sdkMock.publishPendingEvents([
+          {
+            type: 'turn_complete',
+            data: {
+              sessionId: 'session-a',
+              promptId: 'm-complete',
+            },
+          },
+        ]);
+      });
+      await act(async () => {
+        pending.resolve({
+          pendingPrompts: [
+            {
+              promptId: 'm-complete',
+              text: 'finish me',
+              state: 'running',
+            },
+            {
+              promptId: 'm-unrelated',
+              text: 'keep me',
+              state: 'queued',
+            },
+          ],
+        });
+        await Promise.resolve();
+      });
+
+      expect(harness.result().queuedPrompts).toMatchObject([
+        {
+          serverPromptId: 'm-unrelated',
+          text: 'keep me',
+          serverState: 'queued',
+        },
+      ]);
     } finally {
       await harness.dispose();
     }

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -564,7 +564,13 @@ export function useQueuedPrompts({
   const syncServerQueuedPrompts = useCallback(
     (serverQueued: DaemonPendingPromptSummary[], targetSessionId: string) => {
       const next = queuedPromptsRef.current.filter((p) => {
-        if (p.isEditing || p.isRemoving) return true;
+        if (
+          (p.isEditing || p.isRemoving) &&
+          (!p.serverPromptId ||
+            removingServerPromptIdsRef.current.has(p.serverPromptId))
+        ) {
+          return true;
+        }
         const promptId = p.serverPromptId ?? p.midTurnMessageId;
         if (promptId && settledServerPromptIdsRef.current.has(promptId)) {
           return false;

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -502,8 +502,10 @@ export function useQueuedPrompts({
   const removeDaemonOwnedPrompt = useCallback((promptId: string) => {
     const next = queuedPromptsRef.current.filter(
       (prompt) =>
-        prompt.serverPromptId !== promptId &&
-        prompt.midTurnMessageId !== promptId,
+        prompt.isEditing ||
+        prompt.isRemoving ||
+        (prompt.serverPromptId !== promptId &&
+          prompt.midTurnMessageId !== promptId),
     );
     if (next.length === queuedPromptsRef.current.length) return;
     queuedPromptsRef.current = next;

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -466,6 +466,7 @@ export function useQueuedPrompts({
   const submitAbortControllersRef = useRef<Set<AbortController>>(new Set());
   const removingServerPromptIdsRef = useRef<Set<string>>(new Set());
   const displayedServerPromptIdsRef = useRef<Set<string>>(new Set());
+  const settledServerPromptIdsRef = useRef<Set<string>>(new Set());
   const completionCallbacksRef = useRef<Map<string, () => void>>(new Map());
   const completedPromptIdsRef = useRef<Set<string>>(new Set());
   const completedPromptIdOrderRef = useRef<string[]>([]);
@@ -497,6 +498,35 @@ export function useQueuedPrompts({
         completedPromptIdsRef.current.delete(expiredPromptId);
     }
   }, []);
+
+  const removeDaemonOwnedPrompt = useCallback((promptId: string) => {
+    const next = queuedPromptsRef.current.filter(
+      (prompt) =>
+        prompt.serverPromptId !== promptId &&
+        prompt.midTurnMessageId !== promptId,
+    );
+    if (next.length === queuedPromptsRef.current.length) return;
+    queuedPromptsRef.current = next;
+    setQueuedPrompts(next);
+  }, []);
+
+  const hideSettledServerPrompt = useCallback(
+    (promptId: string) => {
+      displayedServerPromptIdsRef.current.delete(promptId);
+      settledServerPromptIdsRef.current.add(promptId);
+      while (
+        settledServerPromptIdsRef.current.size > MAX_COMPLETED_PROMPT_IDS
+      ) {
+        const oldestPromptId = settledServerPromptIdsRef.current
+          .values()
+          .next().value;
+        if (typeof oldestPromptId !== 'string') break;
+        settledServerPromptIdsRef.current.delete(oldestPromptId);
+      }
+      removeDaemonOwnedPrompt(promptId);
+    },
+    [removeDaemonOwnedPrompt],
+  );
 
   latestSessionIdRef.current = sessionId;
   latestWorkspaceCwdRef.current = workspaceCwd;
@@ -532,13 +562,20 @@ export function useQueuedPrompts({
   const syncServerQueuedPrompts = useCallback(
     (serverQueued: DaemonPendingPromptSummary[], targetSessionId: string) => {
       const next = queuedPromptsRef.current.filter((p) => {
+        const promptId = p.serverPromptId ?? p.midTurnMessageId;
+        if (promptId && settledServerPromptIdsRef.current.has(promptId)) {
+          return false;
+        }
         if (!p.serverPromptId) return true;
         return serverQueued.some(
           (server) => server.promptId === p.serverPromptId,
         );
       });
       for (const serverPrompt of serverQueued) {
-        if (removingServerPromptIdsRef.current.has(serverPrompt.promptId)) {
+        if (
+          removingServerPromptIdsRef.current.has(serverPrompt.promptId) ||
+          settledServerPromptIdsRef.current.has(serverPrompt.promptId)
+        ) {
           continue;
         }
         const existingIndex = next.findIndex(
@@ -738,7 +775,9 @@ export function useQueuedPrompts({
             prompt.midTurnMessageId !== undefined &&
             !prompt.isEditing &&
             !prompt.isRemoving &&
-            (settledIds.has(prompt.midTurnMessageId) ||
+            (displayedServerPromptIdsRef.current.has(prompt.midTurnMessageId) ||
+              settledServerPromptIdsRef.current.has(prompt.midTurnMessageId) ||
+              settledIds.has(prompt.midTurnMessageId) ||
               (applyPromoted && promotedIds.has(prompt.midTurnMessageId)))
           ),
       );
@@ -800,7 +839,13 @@ export function useQueuedPrompts({
       );
       const restoredRows: QueuedPrompt[] = [];
       for (const message of snapshot.messages) {
-        if (localIds.has(message.messageId)) continue;
+        if (
+          localIds.has(message.messageId) ||
+          displayedServerPromptIdsRef.current.has(message.messageId) ||
+          settledServerPromptIdsRef.current.has(message.messageId)
+        ) {
+          continue;
+        }
         // Prefer the in-memory admission's images; after a refresh only the
         // snapshot's media blocks remain.
         const salvaged = salvagedImages.get(message.messageId);
@@ -1107,6 +1152,7 @@ export function useQueuedPrompts({
     releaseChainRef.current = null;
     removingServerPromptIdsRef.current = new Set();
     displayedServerPromptIdsRef.current = new Set();
+    settledServerPromptIdsRef.current = new Set();
     pendingStartedByPromptIdRef.current = new Map();
     initialRefreshSessionIdRef.current = undefined;
     midTurnEnqueueAbortRef.current?.abort();
@@ -1251,9 +1297,13 @@ export function useQueuedPrompts({
             }
           }
         }
+        if (!shouldAppendLocalUserMessage) {
+          displayedServerPromptIdsRef.current.add(promptId);
+        }
+        removeDaemonOwnedPrompt(promptId);
         void refreshPendingPrompts();
       } else if (event.type === 'turn_complete') {
-        displayedServerPromptIdsRef.current.delete(promptId);
+        hideSettledServerPrompt(promptId);
         const callback = completionCallbacksRef.current.get(promptId);
         completionCallbacksRef.current.delete(promptId);
         if (callback) {
@@ -1265,7 +1315,7 @@ export function useQueuedPrompts({
           rememberCompletedPromptId(promptId);
         }
       } else if (event.type === 'turn_error') {
-        displayedServerPromptIdsRef.current.delete(promptId);
+        hideSettledServerPrompt(promptId);
         const callback = completionCallbacksRef.current.get(promptId);
         completionCallbacksRef.current.delete(promptId);
         if (callback) callback();
@@ -1274,7 +1324,7 @@ export function useQueuedPrompts({
         event.type === 'pending_prompt_completed' &&
         event.data.state === 'removed'
       ) {
-        displayedServerPromptIdsRef.current.delete(promptId);
+        hideSettledServerPrompt(promptId);
         const callback = completionCallbacksRef.current.get(promptId);
         completionCallbacksRef.current.delete(promptId);
         if (callback) callback();
@@ -1300,6 +1350,8 @@ export function useQueuedPrompts({
     refreshPendingPrompts,
     settleCompletionCallback,
     rememberCompletedPromptId,
+    hideSettledServerPrompt,
+    removeDaemonOwnedPrompt,
   ]);
 
   /**

--- a/packages/web-shell/client/hooks/useQueuedPrompts.ts
+++ b/packages/web-shell/client/hooks/useQueuedPrompts.ts
@@ -564,6 +564,7 @@ export function useQueuedPrompts({
   const syncServerQueuedPrompts = useCallback(
     (serverQueued: DaemonPendingPromptSummary[], targetSessionId: string) => {
       const next = queuedPromptsRef.current.filter((p) => {
+        if (p.isEditing || p.isRemoving) return true;
         const promptId = p.serverPromptId ?? p.midTurnMessageId;
         if (promptId && settledServerPromptIdsRef.current.has(promptId)) {
           return false;
@@ -599,6 +600,12 @@ export function useQueuedPrompts({
           !contentHasDegradedMedia(serverPrompt.content) &&
           !contentHasUnhydratedMedia(serverPrompt.content);
         if (existingIndex !== -1) {
+          if (
+            next[existingIndex]!.isEditing ||
+            next[existingIndex]!.isRemoving
+          ) {
+            continue;
+          }
           if (hasDisplayedPrompt) {
             next.splice(existingIndex, 1);
             continue;
@@ -1302,7 +1309,9 @@ export function useQueuedPrompts({
         if (!shouldAppendLocalUserMessage) {
           displayedServerPromptIdsRef.current.add(promptId);
         }
-        removeDaemonOwnedPrompt(promptId);
+        if (displayedServerPromptIdsRef.current.has(promptId)) {
+          removeDaemonOwnedPrompt(promptId);
+        }
         void refreshPendingPrompts();
       } else if (event.type === 'turn_complete') {
         hideSettledServerPrompt(promptId);

--- a/packages/web-shell/client/vite-config.test.ts
+++ b/packages/web-shell/client/vite-config.test.ts
@@ -49,6 +49,12 @@ describe('Web Shell MCP App development proxy', () => {
   });
 });
 
+describe('Web Shell standalone session development proxy', () => {
+  it('proxies standalone session routes to the daemon', () => {
+    expect(loadConfig().server?.proxy?.['/standalone']).toBeDefined();
+  });
+});
+
 describe('Web Shell client source proxy bypass', () => {
   it('serves session catalog source modules instead of proxying them', () => {
     const sessionProxy = loadConfig().server?.proxy?.['/session'];

--- a/packages/web-shell/client/vite-config.test.ts
+++ b/packages/web-shell/client/vite-config.test.ts
@@ -51,7 +51,8 @@ describe('Web Shell MCP App development proxy', () => {
 
 describe('Web Shell standalone session development proxy', () => {
   it('proxies standalone session routes to the daemon', () => {
-    expect(loadConfig().server?.proxy?.['/standalone']).toBeDefined();
+    const proxy = loadConfig().server?.proxy;
+    expect(proxy?.['/standalone/sessions']).toBe(proxy?.['/session']);
   });
 });
 

--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -90,7 +90,7 @@ export default defineConfig(({ command }) => ({
       // it the SPA fallback answers with index.html and the dialog fails JSON
       // parsing in dev.
       '/daemon/status': daemonProxy,
-      '/standalone': daemonProxy,
+      '/standalone/sessions': daemonProxy,
       '/session': daemonProxy,
       '/permission': daemonProxy,
       [QUALIFIED_VOICE_STREAM_PROXY]: { ...daemonProxy, ws: true },

--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -90,6 +90,7 @@ export default defineConfig(({ command }) => ({
       // it the SPA fallback answers with index.html and the dialog fails JSON
       // parsing in dev.
       '/daemon/status': daemonProxy,
+      '/standalone': daemonProxy,
       '/session': daemonProxy,
       '/permission': daemonProxy,
       [QUALIFIED_VOICE_STREAM_PROXY]: { ...daemonProxy, ws: true },


### PR DESCRIPTION
## What this PR does

This PR reconciles daemon-owned queued prompts by prompt identity instead of tying their visible lifecycle to the browser client that originally submitted them. A started or terminal prompt is removed immediately, and bounded settled-prompt tracking prevents older pending or mid-turn snapshots from restoring it while preserving unrelated prompts returned by the same request.

As a small adjacent development fix, it also forwards standalone-session API routes through the Web Shell Vite proxy so those requests return daemon JSON instead of the SPA HTML fallback.

## Why it's needed

When a session kept running while its browser page was closed and reopened, the new page used a different client id. A queued prompt started by the daemon could therefore remain visible in the pending list even though it had already entered the conversation. Concurrent snapshot responses could also restore a prompt after its start or completion event. In local development, the missing standalone-session proxy produced `Unexpected token '<'` because the client attempted to parse `index.html` as JSON.

## Reviewer Test Plan

### How to verify

Start a daemon-backed Web Shell session, submit prompt A, queue prompt B while A is running, then close and reopen the page before B starts. When the daemon starts B, confirm B disappears from the pending list without a duplicate local user message. Exercise a delayed pending or mid-turn refresh across B's start/completion and confirm B is not restored while unrelated queued prompts remain visible. In development mode, request `/standalone/sessions?size=50&archiveState=active` through the Vite origin and confirm the response is daemon JSON rather than HTML.

### Evidence (Before & After)

Before: a daemon-started prompt could remain in the pending list after a page reload changed the client id; stale snapshots could restore a completed row; the standalone-session development request returned `index.html` and failed JSON parsing.

After: prompt lifecycle updates are applied by prompt id across clients, stale responses cannot resurrect settled prompts, unrelated queue rows survive concurrent responses, and the standalone-session development request returns `200 application/json`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22 workspace development mode with the daemon on port 4172 and Vite on port 5175.

## Risk & Scope

- Main risk or tradeoff: settled prompt ids are retained in a bounded in-memory set for the active session owner so late responses can be filtered without unbounded growth.
- Not validated / out of scope: Windows and Linux browser E2E runs; daemon persistence and protocol semantics are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本 PR 按 prompt 身份协调 daemon 持有的排队消息，不再把其可见生命周期绑定到最初提交它的浏览器 client。prompt 开始执行或进入终态时会立即从待发送列表移除，并通过有界的已结束 prompt 记录阻止更早的 pending 或 mid-turn 快照将其恢复，同时保留同一响应中的其他无关 prompt。

另外顺手修复了一个相邻的开发环境问题：Web Shell 的 Vite 代理现在会转发 standalone session API，使这些请求返回 daemon JSON，而不是 SPA 的 HTML fallback。

## 为什么需要

当会话持续运行，而浏览器页面被关闭后重新打开时，新页面会使用不同的 client id。daemon 启动排队 prompt 后，它可能仍残留在待发送列表中，即使已经进入会话；并发返回的旧快照也可能在 prompt 开始或完成后将它重新恢复。在本地开发环境中，standalone session 代理缺失会返回 `index.html`，前端将其按 JSON 解析后出现 `Unexpected token '<'`。

## Reviewer 测试计划

### 验证方式

启动 daemon Web Shell 会话，发送 prompt A，并在 A 运行时排队 prompt B；在 B 开始前关闭并重新打开页面。daemon 启动 B 后，确认 B 从待发送列表消失，且不会产生重复的本地用户消息。让延迟的 pending 或 mid-turn 请求跨越 B 的开始或完成事件，确认 B 不会被恢复，同时其他无关排队 prompt 仍然保留。在开发模式下，通过 Vite origin 请求 `/standalone/sessions?size=50&archiveState=active`，确认响应是 daemon JSON 而不是 HTML。

### 前后证据

修复前：页面重新加载导致 client id 改变后，daemon 已启动的 prompt 可能残留在待发送列表；陈旧快照可能恢复已完成的行；开发环境中的 standalone session 请求返回 `index.html` 并触发 JSON 解析错误。

修复后：prompt 生命周期按 prompt id 跨 client 应用；陈旧响应无法复活已结束 prompt；并发响应中的其他队列项不会丢失；standalone session 开发请求返回 `200 application/json`。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境

Node.js 22 工作区开发模式，daemon 使用 4172 端口，Vite 使用 5175 端口。

## 风险与范围

- 主要风险或取舍：当前会话 owner 会在内存中保留有界的已结束 prompt id，用来过滤延迟响应，同时避免无限增长。
- 未验证或范围外：未运行 Windows 和 Linux 浏览器 E2E；daemon 持久化与协议语义没有变化。
- 破坏性变更或迁移说明：无。

## 关联 Issue

无

</details>
