### PR TITLE
fix(cli): Defer provisional standalone reasoning options

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -6635,6 +6635,65 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     }
   });
 
+  it('defers standalone reasoning options until the generation config is available', async () => {
+    const sessionId = '11111111-1111-4111-8111-111111111111';
+    const innerConfig = await setupSessionMocks(sessionId);
+    innerConfig.getSessionSourceType = vi.fn().mockReturnValue('standalone');
+    innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+    innerConfig.getContentGeneratorConfig = vi.fn().mockReturnValue(undefined);
+    const { agent, agentPromise } = await bootInitializedAcpAgent(
+      makeSessionSettings(),
+      'trusted-capability',
+    );
+
+    try {
+      const session = (await agent.newSession({
+        cwd: '/tmp',
+        mcpServers: [],
+        _meta: {
+          [SESSION_SOURCE_META_KEY]: {
+            sourceType: 'standalone',
+            [DAEMON_OWNED_STANDALONE_CREATION_KEY]: true,
+          },
+        },
+      })) as {
+        configOptions: Array<{ id: string; options: Array<{ value: string }> }>;
+      };
+
+      expect(session.configOptions.map((option) => option.id)).toEqual([
+        'mode',
+        'model',
+      ]);
+      expect(innerConfig.refreshAuth).not.toHaveBeenCalled();
+
+      innerConfig.getContentGeneratorConfig.mockReturnValue({
+        thinkingMandatory: true,
+      });
+      const context = (await agent.extMethod(
+        SERVE_STATUS_EXT_METHODS.sessionContext,
+        { sessionId },
+      )) as {
+        state: {
+          configOptions: Array<{
+            id: string;
+            options: Array<{ value: string }>;
+          }>;
+        };
+      };
+      const reasoningOption = context.state.configOptions.find(
+        (option) => option.id === 'reasoning_effort',
+      );
+
+      expect(reasoningOption).toBeDefined();
+      expect(
+        reasoningOption?.options.some((option) => option.value === 'none'),
+      ).toBe(false);
+    } finally {
+      mockConnectionState.resolve();
+      await agentPromise;
+    }
+  });
+
   it('persists trusted direct Realtime dialogue without prompting the backend', async () => {
     const sessionId = 'session-A';
     await setupSessionMocks(sessionId);
@@ -21556,6 +21615,10 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
           messages: [{ role: 'user', parts: [{ text: 'restored' }] }],
         },
       });
+      innerConfig.getModel = vi.fn().mockReturnValue('qwen3.8-max');
+      innerConfig.getContentGeneratorConfig = vi
+        .fn()
+        .mockReturnValue(undefined);
       vi.mocked(loadSettings).mockReturnValue(settings);
       const { agent, agentPromise } = await spawnAgent('expected-capability');
 
@@ -21571,12 +21634,18 @@ describe('QwenAgent loadSession / unstable_resumeSession', () => {
             },
           },
         };
-        if (action === 'load') {
-          await agent.loadSession(request);
-        } else {
-          await agent.unstable_resumeSession(request);
-        }
+        const response = (
+          action === 'load'
+            ? await agent.loadSession(request)
+            : await agent.unstable_resumeSession(request)
+        ) as {
+          configOptions: Array<{ id: string }>;
+        };
 
+        expect(response.configOptions.map((option) => option.id)).toEqual([
+          'mode',
+          'model',
+        ]);
         expect(innerConfig.refreshAuth).not.toHaveBeenCalled();
         expect(innerConfig.activateProvisionalWorkspace).not.toHaveBeenCalled();
         expect(

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -13918,7 +13918,10 @@ class QwenAgent implements Agent {
       return [modeConfigOption, modelConfigOption];
     }
 
-    const generation = config.getContentGeneratorConfig();
+    const generation = config.getContentGeneratorConfig?.();
+    if (!generation) {
+      return [modeConfigOption, modelConfigOption];
+    }
     const modelReasoning = this.getModelReasoningConfiguration(
       config,
       currentModelId,


### PR DESCRIPTION
## What this PR does

Defers reasoning configuration options while a daemon-owned standalone session is still using its provisional configuration. Create, load, and resume responses expose the safe mode and model options until the content-generator configuration is available; after managed activation, the ordinary session-context refresh publishes the complete reasoning options.

Adds regression coverage for standalone create, load, and resume to verify that provisional responses do not initialize authentication or workspace state early, and that mandatory reasoning choices are restored once the live generation configuration exists.

## Why it's needed

The standalone WebShell flow can select a reasoning-capable model before authentication and LLM initialization intentionally occur during managed activation. The provisional ACP response previously dereferenced the missing generation configuration while building `reasoning_effort`, causing exact standalone create, load, or resume requests to fail with a `thinkingMandatory` TypeError and an HTTP 500 response.

## Reviewer Test Plan

### How to verify

1. Start a daemon-owned standalone create, load, or resume flow with a reasoning-capable model while the content-generator configuration is unavailable. Confirm the provisional response succeeds with mode and model options only, without refreshing authentication, activating the provisional workspace, or installing filesystem state early.
2. Make the generation configuration available and request the session context. Confirm `reasoning_effort` is present and a mandatory-thinking model does not expose the `none` choice.
3. Run `PATH=/Users/jinye.djy/.nvm/versions/node/v22.22.3/bin:$PATH npx vitest run src/acp-integration/acpAgent.test.ts -t 'defers standalone reasoning options|defers standalone restore side effects'` from `packages/cli`; expect all three selected tests to pass.

### Evidence (Before & After)

| | Before | After |
| --- | --- | --- |
| Provisional standalone create/load/resume | Building reasoning options dereferenced an unavailable generation configuration and could return HTTP 500. | The provisional response returns mode and model safely; exact standalone create returns HTTP 200. |
| Post-activation session context | Not reached when provisional option construction crashed. | Publishes the complete reasoning configuration once managed activation initializes the generation config. |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS with Node.js 22.22.3, Vitest, and a temporary real daemon environment. Repository build, typecheck, lint, changed-file formatting, the complete ACP agent unit suite, focused Node 22 regressions, and real-daemon standalone create/context checks passed.

## Risk & Scope

- Main risk or tradeoff: the initial provisional response temporarily omits `reasoning_effort`; the daemon bridge does not consume provisional configuration options, and the post-activation session-context refresh supplies the complete option set.
- Not validated / out of scope: Windows and Linux local runs, upstream model inference, WebShell UI changes, daemon lifecycle changes, authentication ordering changes, or automatic retry behavior.
- Breaking changes / migration notes: none. Existing non-standalone sessions retain their current authenticated configuration path.

## Linked Issues

Follow-up to #10514

Refs #8908

<details>
<summary>中文说明</summary>

## 本 PR 内容

当 daemon 管理的 standalone 会话仍在使用 provisional 配置时，暂缓提供 reasoning 配置选项。create、load 和 resume 响应会在 content-generator 配置可用前仅返回安全的 mode 和 model 选项；managed activation 完成后，常规 session-context 刷新会发布完整的 reasoning 选项。

新增 standalone create、load 和 resume 回归覆盖，验证 provisional 响应不会提前初始化认证或 workspace 状态，并验证 live generation 配置可用后会恢复 mandatory reasoning 选项。

## 背景与动机

Standalone WebShell 流程可以在 managed activation 执行认证和 LLM 初始化前选择支持 reasoning 的模型。此前 provisional ACP 响应在构造 `reasoning_effort` 时会解引用尚不存在的 generation 配置，导致精确 standalone create、load 或 resume 请求因 `thinkingMandatory` TypeError 而返回 HTTP 500。

## 评审验证方式

### 如何验证

1. 使用支持 reasoning 的模型启动 daemon 管理的 standalone create、load 或 resume，并让 content-generator 配置在 provisional 阶段保持不可用。确认 provisional 响应成功且仅包含 mode 和 model，同时不会提前刷新认证、激活 provisional workspace 或安装 filesystem 状态。
2. 让 generation 配置变为可用后请求 session context。确认存在 `reasoning_effort`，且 mandatory-thinking 模型不会暴露 `none` 选项。
3. 在 `packages/cli` 中运行 `PATH=/Users/jinye.djy/.nvm/versions/node/v22.22.3/bin:$PATH npx vitest run src/acp-integration/acpAgent.test.ts -t 'defers standalone reasoning options|defers standalone restore side effects'`，预期选中的 3 项测试全部通过。

### 证据（改动前后）

| | 改动前 | 改动后 |
| --- | --- | --- |
| Provisional standalone create/load/resume | 构造 reasoning 选项时会解引用不可用的 generation 配置，并可能返回 HTTP 500。 | Provisional 响应安全返回 mode 和 model；精确 standalone create 返回 HTTP 200。 |
| 激活后的 session context | Provisional 选项构造崩溃时无法到达该阶段。 | Managed activation 初始化 generation 配置后发布完整 reasoning 配置。 |

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|     🍏 macOS      |  ✅  |
|    🪟 Windows     |  ⚠️  |
|     🐧 Linux      |  ⚠️  |

### 环境（可选）

macOS、Node.js 22.22.3、Vitest，以及临时真实 daemon 环境。仓库构建、类型检查、全量 lint、改动文件格式检查、完整 ACP agent 单元测试、Node 22 定向回归和真实 daemon standalone create/context 检查均已通过。

## 风险与范围

- 主要风险或取舍：首次 provisional 响应会暂时省略 `reasoning_effort`；daemon bridge 不消费 provisional 配置选项，激活后的 session-context 刷新会提供完整选项集。
- 未验证/超出范围：未进行 Windows 和 Linux 本地运行或上游模型推理；不包含 WebShell UI、daemon 生命周期、认证顺序或自动重试行为的改动。
- 破坏性变更/迁移说明：无。现有非 standalone 会话继续使用当前的已认证配置路径。

## 关联问题

#10514 的后续修复

Refs #8908

</details>
