### PR TITLE
fix(cli): keep Ctrl+C exit warning from overflowing shorter terminals

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3736,6 +3736,9 @@ export const AppContainer = (props: AppContainerProps) => {
     dialogsVisible,
     stickyTodosLayoutKey,
     liveAgentPanelLayoutKey,
+    ctrlCPressedOnce,
+    ctrlDPressedOnce,
+    showEscapePrompt,
     // Composer and update notification height also shift with these; without
     // them the footer isn't re-measured during a streaming turn and the VP
     // viewport bottom clips.

--- a/packages/cli/src/ui/app-container-controls-dep.test.ts
+++ b/packages/cli/src/ui/app-container-controls-dep.test.ts
@@ -58,6 +58,12 @@ describe('AppContainer controls-height measurement wiring', () => {
     expect(deps).toContain('stickyTodosLayoutKey');
     // The fix: dropping this entry re-introduces the non-VP overflow flicker.
     expect(deps).toContain('liveAgentPanelLayoutKey');
+    // Ctrl+C/D and Esc prompts change footer rows (status-line override).
+    // Missing these lets MainContent keep the pre-prompt height for a frame
+    // and overflow the terminal — Ink then full-clears at stdout.rows.
+    expect(deps).toContain('ctrlCPressedOnce');
+    expect(deps).toContain('ctrlDPressedOnce');
+    expect(deps).toContain('showEscapePrompt');
   });
 
   it('computes liveAgentPanelLayoutKey from the live agent roster', () => {

--- a/packages/cli/src/ui/components/ExitWarning.test.tsx
+++ b/packages/cli/src/ui/components/ExitWarning.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render } from 'ink-testing-library';
+import { ExitWarning } from './ExitWarning.js';
+import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
+
+function frameHeight(frame: string): number {
+  return frame.length === 0 ? 0 : frame.split('\n').length;
+}
+
+const renderWarning = (overrides: Partial<UIState> = {}) =>
+  render(
+    <UIStateContext.Provider
+      value={
+        {
+          dialogsVisible: false,
+          ctrlCPressedOnce: false,
+          ctrlDPressedOnce: false,
+          ...overrides,
+        } as UIState
+      }
+    >
+      <ExitWarning />
+    </UIStateContext.Provider>,
+  );
+
+describe('ExitWarning', () => {
+  it('renders nothing when no exit is armed', () => {
+    const { lastFrame } = renderWarning();
+    expect(lastFrame() ?? '').toBe('');
+  });
+
+  it('renders a single-row Ctrl+C warning over a dialog, with no extra spacer', () => {
+    const { lastFrame } = renderWarning({
+      dialogsVisible: true,
+      ctrlCPressedOnce: true,
+    });
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Press Ctrl+C again to exit.');
+    expect(frameHeight(frame)).toBe(1);
+  });
+
+  it('renders a single-row Ctrl+D warning over a dialog, with no extra spacer', () => {
+    const { lastFrame } = renderWarning({
+      dialogsVisible: true,
+      ctrlDPressedOnce: true,
+    });
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Press Ctrl+D again to exit.');
+    expect(frameHeight(frame)).toBe(1);
+  });
+});

--- a/packages/cli/src/ui/components/ExitWarning.tsx
+++ b/packages/cli/src/ui/components/ExitWarning.tsx
@@ -8,6 +8,7 @@ import type React from 'react';
 import { Text } from 'ink';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { theme } from '../semantic-colors.js';
+import { t } from '../../i18n/index.js';
 
 export const ExitWarning: React.FC = () => {
   const uiState = useUIState();
@@ -19,12 +20,16 @@ export const ExitWarning: React.FC = () => {
   // off. Keep this to a single replacement row (matches Footer).
   if (uiState.ctrlCPressedOnce) {
     return (
-      <Text color={theme.status.warning}>Press Ctrl+C again to exit.</Text>
+      <Text color={theme.status.warning}>
+        {t('Press Ctrl+C again to exit.')}
+      </Text>
     );
   }
   if (uiState.ctrlDPressedOnce) {
     return (
-      <Text color={theme.status.warning}>Press Ctrl+D again to exit.</Text>
+      <Text color={theme.status.warning}>
+        {t('Press Ctrl+D again to exit.')}
+      </Text>
     );
   }
   return null;

--- a/packages/cli/src/ui/components/ExitWarning.tsx
+++ b/packages/cli/src/ui/components/ExitWarning.tsx
@@ -5,25 +5,27 @@
  */
 
 import type React from 'react';
-import { Box, Text } from 'ink';
+import { Text } from 'ink';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { theme } from '../semantic-colors.js';
 
 export const ExitWarning: React.FC = () => {
   const uiState = useUIState();
-  return (
-    <>
-      {uiState.dialogsVisible && uiState.ctrlCPressedOnce && (
-        <Box marginTop={1}>
-          <Text color={theme.status.warning}>Press Ctrl+C again to exit.</Text>
-        </Box>
-      )}
-
-      {uiState.dialogsVisible && uiState.ctrlDPressedOnce && (
-        <Box marginTop={1}>
-          <Text color={theme.status.warning}>Press Ctrl+D again to exit.</Text>
-        </Box>
-      )}
-    </>
-  );
+  if (!uiState.dialogsVisible) {
+    return null;
+  }
+  // No marginTop: a spacer row on top of a near-full dialog overflows the
+  // terminal, Ink full-clears at stdout.rows, and the startup banner scrolls
+  // off. Keep this to a single replacement row (matches Footer).
+  if (uiState.ctrlCPressedOnce) {
+    return (
+      <Text color={theme.status.warning}>Press Ctrl+C again to exit.</Text>
+    );
+  }
+  if (uiState.ctrlDPressedOnce) {
+    return (
+      <Text color={theme.status.warning}>Press Ctrl+D again to exit.</Text>
+    );
+  }
+  return null;
 };

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -677,6 +677,29 @@ describe('<Footer />', () => {
       expect(frame).not.toContain('? for shortcuts');
     });
 
+    it('does not change footer height when Ctrl+C exit warning overrides a two-line status line', () => {
+      useStatusLineMock.mockReturnValue({
+        lines: ['model-name (main) ctx:34%', '████░░░░ 34% context'],
+        useThemeColors: false,
+        respectUserColors: false,
+        hideContextIndicator: false,
+      });
+      const idle = renderAtLayoutWidth(120, createMockUIState());
+      const armed = renderAtLayoutWidth(
+        120,
+        createMockUIState({ ctrlCPressedOnce: true }),
+      );
+      const idleFrame = stripAnsi(idle.lastFrame());
+      const armedFrame = stripAnsi(armed.lastFrame());
+      const lineCount = (frame: string) =>
+        frame.length === 0 ? 0 : frame.split('\n').length;
+
+      expect(armedFrame).toContain('Press Ctrl+C again to exit.');
+      expect(lineCount(armedFrame)).toBe(lineCount(idleFrame));
+      idle.unmount();
+      armed.unmount();
+    });
+
     it('suppresses hint when status line is active', () => {
       useStatusLineMock.mockReturnValue({
         lines: ['status info'],

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -700,6 +700,63 @@ describe('<Footer />', () => {
       armed.unmount();
     });
 
+    it('does not change footer height when Ctrl+D exit warning overrides a two-line status line', () => {
+      // Mirrors the Ctrl+C case above -- exitWarningText (Footer.tsx) has a
+      // separate ctrlDPressedOnce branch that was previously untested here,
+      // so a mutant dropping it would pass the whole suite.
+      useStatusLineMock.mockReturnValue({
+        lines: ['model-name (main) ctx:34%', '████░░░░ 34% context'],
+        useThemeColors: false,
+        respectUserColors: false,
+        hideContextIndicator: false,
+      });
+      const idle = renderAtLayoutWidth(120, createMockUIState());
+      const armed = renderAtLayoutWidth(
+        120,
+        createMockUIState({ ctrlDPressedOnce: true }),
+      );
+      const idleFrame = stripAnsi(idle.lastFrame());
+      const armedFrame = stripAnsi(armed.lastFrame());
+      const lineCount = (frame: string) =>
+        frame.length === 0 ? 0 : frame.split('\n').length;
+
+      expect(armedFrame).toContain('Press Ctrl+D again to exit.');
+      expect(lineCount(armedFrame)).toBe(lineCount(idleFrame));
+      idle.unmount();
+      armed.unmount();
+    });
+
+    it('does not change footer height when a wrapping status line arms the exit warning at a narrow width', () => {
+      // The two tests above use two SHORT status lines at width 120, where
+      // nothing soft-wraps -- they cannot catch a budget that counts logical
+      // lines instead of rendered rows. This uses one LONG line at a narrow
+      // width so the idle status box itself wraps to more than one row,
+      // matching the PR review's witness scenario (width 60, one wrapping
+      // logical status line): must still be the same height once armed.
+      useStatusLineMock.mockReturnValue({
+        lines: [
+          'model-name (main) branch:feature/very-long-branch-name ctx:34%',
+        ],
+        useThemeColors: false,
+        respectUserColors: false,
+        hideContextIndicator: false,
+      });
+      const idle = renderAtLayoutWidth(60, createMockUIState());
+      const armed = renderAtLayoutWidth(
+        60,
+        createMockUIState({ ctrlCPressedOnce: true }),
+      );
+      const idleFrame = stripAnsi(idle.lastFrame());
+      const armedFrame = stripAnsi(armed.lastFrame());
+      const lineCount = (frame: string) =>
+        frame.length === 0 ? 0 : frame.split('\n').length;
+
+      expect(armedFrame).toContain('Press Ctrl+C again to exit.');
+      expect(lineCount(armedFrame)).toBe(lineCount(idleFrame));
+      idle.unmount();
+      armed.unmount();
+    });
+
     it('suppresses hint when status line is active', () => {
       useStatusLineMock.mockReturnValue({
         lines: ['status info'],

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -99,6 +99,15 @@ export const Footer: React.FC<FooterProps> = ({ containerRef }) => {
   // Hide "? for shortcuts" when a custom status line is active (it already
   // occupies the footer, so the hint is redundant). Matches upstream behavior.
   const suppressHint = statusLineLines.length > 0;
+  const statusRowCount =
+    statusLineLines.length > 0
+      ? Math.min(MAX_STATUS_LINES, statusLineLines.length)
+      : 0;
+  const exitWarningText = uiState.ctrlCPressedOnce
+    ? t('Press Ctrl+C again to exit.')
+    : uiState.ctrlDPressedOnce
+      ? t('Press Ctrl+D again to exit.')
+      : null;
 
   // MCP init progress lives in this row (not a standalone component above the
   // input) so the live area's height is constant in the default case, avoiding
@@ -109,11 +118,14 @@ export const Footer: React.FC<FooterProps> = ({ containerRef }) => {
   // `configInitMessage` is placed ahead of `showAutoAcceptIndicator` so users
   // launched with YOLO / auto-accept-edits still see the ~1s startup progress;
   // the approval-mode indicator takes over as soon as init finishes.
-  const leftBottomContent = uiState.ctrlCPressedOnce ? (
-    <Text color={theme.status.warning}>{t('Press Ctrl+C again to exit.')}</Text>
-  ) : uiState.ctrlDPressedOnce ? (
-    <Text color={theme.status.warning}>{t('Press Ctrl+D again to exit.')}</Text>
-  ) : uiState.showEscapePrompt ? (
+  // When a status line is present, the Ctrl+C/D warning overrides it in
+  // place (same row budget) so the live region does not change height.
+  // Unmounting those rows used to shrink the footer, Ink full-cleared at
+  // stdout.rows, and the startup banner scrolled off the viewport.
+  const leftBottomContent =
+    exitWarningText && statusRowCount === 0 ? (
+      <Text color={theme.status.warning}>{exitWarningText}</Text>
+    ) : uiState.showEscapePrompt ? (
     <Text color={theme.text.secondary}>{t('Press Esc again to clear.')}</Text>
   ) : pasteProgress.active ? (
     <PasteProgressBar progress={pasteProgress} />
@@ -228,28 +240,31 @@ export const Footer: React.FC<FooterProps> = ({ containerRef }) => {
         flexShrink={isNarrow ? 0 : 1}
         minWidth={0}
       >
-        {statusLineLines.length > 0 &&
-          !uiState.ctrlCPressedOnce &&
-          !uiState.ctrlDPressedOnce && (
+        {statusRowCount > 0 && (
             <Box
               flexDirection="column"
+              height={exitWarningText ? statusRowCount : undefined}
               maxHeight={MAX_STATUS_LINES}
               overflow="hidden"
               width="100%"
             >
-              <Text
-                color={
-                  respectUserColors
-                    ? undefined
-                    : useThemeColors
-                      ? theme.text.accent
-                      : undefined
-                }
-                dimColor={respectUserColors ? false : !useThemeColors}
-                wrap="wrap"
-              >
-                {statusLineLines.join('\n')}
-              </Text>
+              {exitWarningText ? (
+                <Text color={theme.status.warning}>{exitWarningText}</Text>
+              ) : (
+                <Text
+                  color={
+                    respectUserColors
+                      ? undefined
+                      : useThemeColors
+                        ? theme.text.accent
+                        : undefined
+                  }
+                  dimColor={respectUserColors ? false : !useThemeColors}
+                  wrap="wrap"
+                >
+                  {statusLineLines.join('\n')}
+                </Text>
+              )}
             </Box>
           )}
         {/* Built-in worktree indicator. Shown by default whenever a

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -7,6 +7,7 @@
 import type React from 'react';
 import { type RefObject, useRef } from 'react';
 import { type DOMElement, Box, Text, useBoxMetrics } from 'ink';
+import wrapAnsi from 'wrap-ansi';
 import { theme } from '../semantic-colors.js';
 import { ContextUsageDisplay } from './ContextUsageDisplay.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
@@ -99,9 +100,27 @@ export const Footer: React.FC<FooterProps> = ({ containerRef }) => {
   // Hide "? for shortcuts" when a custom status line is active (it already
   // occupies the footer, so the hint is redundant). Matches upstream behavior.
   const suppressHint = statusLineLines.length > 0;
+  // Budget on wrapped visual rows, not logical lines: a single logical
+  // status line can soft-wrap to more than one rendered row (the idle box
+  // below renders with wrap="wrap" clipped at maxHeight={MAX_STATUS_LINES}),
+  // so counting logical lines alone under-counts the armed height and the
+  // footer still loses a row when the exit warning arms -- the exact bug
+  // this PR exists to fix, just for a status line that wraps.
   const statusRowCount =
     statusLineLines.length > 0
-      ? Math.min(MAX_STATUS_LINES, statusLineLines.length)
+      ? Math.min(
+          MAX_STATUS_LINES,
+          statusLineLines.reduce(
+            (rows, line) =>
+              rows +
+              wrapAnsi(
+                line,
+                Math.max(1, statusLineWidth ?? terminalWidth - 4),
+                { trim: false, hard: true },
+              ).split('\n').length,
+            0,
+          ),
+        )
       : 0;
   const exitWarningText = uiState.ctrlCPressedOnce
     ? t('Press Ctrl+C again to exit.')
@@ -126,48 +145,48 @@ export const Footer: React.FC<FooterProps> = ({ containerRef }) => {
     exitWarningText && statusRowCount === 0 ? (
       <Text color={theme.status.warning}>{exitWarningText}</Text>
     ) : uiState.showEscapePrompt ? (
-    <Text color={theme.text.secondary}>{t('Press Esc again to clear.')}</Text>
-  ) : pasteProgress.active ? (
-    <PasteProgressBar progress={pasteProgress} />
-  ) : uiState.rewindEscPending ? (
-    <Text color={theme.text.secondary}>
-      {t('Press Esc again to rewind conversation.')}
-    </Text>
-  ) : vimEnabled && vimMode === 'INSERT' ? (
-    <Text color={theme.text.secondary}>-- INSERT --</Text>
-  ) : vimEnabled && vimMode === 'NORMAL' ? (
-    <Text color={theme.text.secondary}>-- NORMAL --</Text>
-  ) : uiState.shellModeActive ? (
-    <ShellModeIndicator />
-  ) : configInitMessage ? (
-    <Text color={theme.text.secondary}>
-      <Spinner /> {configInitMessage}
-    </Text>
-  ) : uiState.startupIdeConnectionStatus.state === 'connecting' ? (
-    <Text color={theme.text.secondary}>
-      <Spinner /> {t('IDE connecting... context may be unavailable')}
-    </Text>
-  ) : uiState.startupIdeConnectionStatus.state === 'failed' ? (
-    <Text color={theme.status.warning}>
-      {t('IDE connection unavailable: {{message}}', {
-        message: uiState.startupIdeConnectionStatus.message,
-      })}
-    </Text>
-  ) : uiState.streamingState === StreamingState.Responding ? (
-    <Text color={theme.text.secondary}>
-      {t('Enter to steer · Ctrl+Q to queue')}
-      {showAutoAcceptIndicator !== undefined && (
-        <>
-          {' · '}
-          <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
-        </>
-      )}
-    </Text>
-  ) : showAutoAcceptIndicator !== undefined ? (
-    <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
-  ) : suppressHint ? null : (
-    <Text color={theme.text.secondary}>{t('? for shortcuts')}</Text>
-  );
+      <Text color={theme.text.secondary}>{t('Press Esc again to clear.')}</Text>
+    ) : pasteProgress.active ? (
+      <PasteProgressBar progress={pasteProgress} />
+    ) : uiState.rewindEscPending ? (
+      <Text color={theme.text.secondary}>
+        {t('Press Esc again to rewind conversation.')}
+      </Text>
+    ) : vimEnabled && vimMode === 'INSERT' ? (
+      <Text color={theme.text.secondary}>-- INSERT --</Text>
+    ) : vimEnabled && vimMode === 'NORMAL' ? (
+      <Text color={theme.text.secondary}>-- NORMAL --</Text>
+    ) : uiState.shellModeActive ? (
+      <ShellModeIndicator />
+    ) : configInitMessage ? (
+      <Text color={theme.text.secondary}>
+        <Spinner /> {configInitMessage}
+      </Text>
+    ) : uiState.startupIdeConnectionStatus.state === 'connecting' ? (
+      <Text color={theme.text.secondary}>
+        <Spinner /> {t('IDE connecting... context may be unavailable')}
+      </Text>
+    ) : uiState.startupIdeConnectionStatus.state === 'failed' ? (
+      <Text color={theme.status.warning}>
+        {t('IDE connection unavailable: {{message}}', {
+          message: uiState.startupIdeConnectionStatus.message,
+        })}
+      </Text>
+    ) : uiState.streamingState === StreamingState.Responding ? (
+      <Text color={theme.text.secondary}>
+        {t('Enter to steer · Ctrl+Q to queue')}
+        {showAutoAcceptIndicator !== undefined && (
+          <>
+            {' · '}
+            <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
+          </>
+        )}
+      </Text>
+    ) : showAutoAcceptIndicator !== undefined ? (
+      <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
+    ) : suppressHint ? null : (
+      <Text color={theme.text.secondary}>{t('? for shortcuts')}</Text>
+    );
 
   const rightItems: Array<{ key: string; node: React.ReactNode }> = [];
   if (sandboxInfo) {
@@ -241,32 +260,32 @@ export const Footer: React.FC<FooterProps> = ({ containerRef }) => {
         minWidth={0}
       >
         {statusRowCount > 0 && (
-            <Box
-              flexDirection="column"
-              height={exitWarningText ? statusRowCount : undefined}
-              maxHeight={MAX_STATUS_LINES}
-              overflow="hidden"
-              width="100%"
-            >
-              {exitWarningText ? (
-                <Text color={theme.status.warning}>{exitWarningText}</Text>
-              ) : (
-                <Text
-                  color={
-                    respectUserColors
-                      ? undefined
-                      : useThemeColors
-                        ? theme.text.accent
-                        : undefined
-                  }
-                  dimColor={respectUserColors ? false : !useThemeColors}
-                  wrap="wrap"
-                >
-                  {statusLineLines.join('\n')}
-                </Text>
-              )}
-            </Box>
-          )}
+          <Box
+            flexDirection="column"
+            height={exitWarningText ? statusRowCount : undefined}
+            maxHeight={MAX_STATUS_LINES}
+            overflow="hidden"
+            width="100%"
+          >
+            {exitWarningText ? (
+              <Text color={theme.status.warning}>{exitWarningText}</Text>
+            ) : (
+              <Text
+                color={
+                  respectUserColors
+                    ? undefined
+                    : useThemeColors
+                      ? theme.text.accent
+                      : undefined
+                }
+                dimColor={respectUserColors ? false : !useThemeColors}
+                wrap="wrap"
+              >
+                {statusLineLines.join('\n')}
+              </Text>
+            )}
+          </Box>
+        )}
         {/* Built-in worktree indicator. Shown by default whenever a
             worktree is active so the user always has a UI affordance,
             even when a custom statusline is configured — their script

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
@@ -208,6 +208,29 @@ describe('DefaultAppLayout', () => {
     expect(output).not.toContain('DialogManager 20');
   });
 
+  it('keeps a short dialog at its natural height', () => {
+    mockedUseAgentViewState.mockReturnValue({
+      activeView: 'main',
+      agents: new Map(),
+    });
+
+    const constrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+    });
+    const unconstrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+      constrainHeight: false,
+    });
+
+    expect(frameHeight(constrained.lastFrame() ?? '')).toBe(
+      frameHeight(unconstrained.lastFrame() ?? ''),
+    );
+  });
+
   it('does not cap a tall dialog when height constraints are disabled', () => {
     mockedUseAgentViewState.mockReturnValue({
       activeView: 'main',

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -90,7 +90,9 @@ export const DefaultAppLayout: React.FC = () => {
                 marginX={2}
                 flexDirection="column"
                 width={uiState.mainAreaWidth}
-                height={dialogHeight}
+                // Max height, not fixed height: a padded full-height frame triggers
+                // Ink's full-clear repaint and wipes the startup banner.
+                maxHeight={dialogHeight}
                 overflow={uiState.constrainHeight ? 'hidden' : undefined}
               >
                 <DialogManager

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.test.tsx
@@ -180,6 +180,26 @@ describe('ScreenReaderAppLayout', () => {
     expect(output).not.toContain('DialogManager 20');
   });
 
+  it('keeps a short dialog at its natural height', () => {
+    const constrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+      staticExtraHeight: 3,
+    });
+    const unconstrained = renderLayout({
+      ...baseUIState,
+      dialogsVisible: true,
+      terminalHeight: 24,
+      staticExtraHeight: 3,
+      constrainHeight: false,
+    });
+
+    expect(frameHeight(constrained.lastFrame() ?? '')).toBe(
+      frameHeight(unconstrained.lastFrame() ?? ''),
+    );
+  });
+
   it('does not cap a tall dialog when height constraints are disabled', () => {
     dialogManagerMockState.lineCount = 20;
     const terminalHeight = 8;

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
@@ -54,7 +54,9 @@ export const ScreenReaderAppLayout: React.FC = () => {
           marginX={2}
           flexDirection="column"
           width={uiState.mainAreaWidth}
-          height={dialogHeight}
+          // Max height, not fixed height: a padded full-height frame triggers
+          // Ink's full-clear repaint and wipes the startup banner.
+          maxHeight={dialogHeight}
           overflow={uiState.constrainHeight ? 'hidden' : undefined}
         >
           <DialogManager


### PR DESCRIPTION
Fixes #10718

## What this PR does

Stops the first Ctrl+C ("Press Ctrl+C again to exit.") from changing live-region height, which made Ink full-clear at `process.stdout.rows` and scroll the startup banner off host tabs whose visible height is shorter than the PTY (Sublime Text Terminus is one such host).

- Footer: when a custom status line is present, the exit warning overrides those rows in place (same row budget) instead of unmounting them.
- ExitWarning: no marginTop spacer; single replacement row over dialogs.
- Constrained dialogs: `maxHeight={dialogHeight}` instead of a padded fixed height.
- AppContainer re-measures footer height when Ctrl+C/D or Esc prompts arm.

## Why it's needed

With `ui.useTerminalBuffer: false` and a two-line custom status line, first Ctrl+C unmounted the status rows. Ink then rewrote 53 PTY rows into a ~47-row tab. Auto-follow showed the bottom of that dump: line 5 became the top and the 4-line QWEN banner disappeared.

## Reviewer Test Plan

### How to verify

- `cd packages/cli && npx vitest run src/ui/components/ExitWarning.test.tsx src/ui/components/Footer.test.tsx src/ui/app-container-controls-dep.test.ts src/ui/layouts/DefaultAppLayout.test.tsx src/ui/layouts/ScreenReaderAppLayout.test.tsx --coverage.enabled=false`
- Manually: idle prompt, two-line status line, `ui.useTerminalBuffer: false`, host tab a few rows shorter than `stdout.rows`. Press Ctrl+C once. Banner stays on line 1; warning appears; footer height does not change.

### Evidence (Before & After)

**Before:** Ctrl+C painted a full PTY-height frame; in a Sublime Terminus tab the banner scrolled off and line 5 was the top while the exit prompt was showing.

**After:** same host, patched clone — exit line sits under the static banner; line 1 remains the top. Confirmed in-session by the reporter (`Qwen (repo)` profile).

### Tested on

| OS | Status |
| --- | --- |
| Windows | ✅ (Sublime Text Terminus tab, PTY 53 rows / ~47 visible) |
| macOS | ⚠️ not re-run |
| Linux | ⚠️ not re-run |

## Risk & Scope

- Main tradeoff: during the armed Ctrl+C/D window, a custom status line is replaced by the warning instead of stacking extra rows.
- Worktree / workflow-keyword rows still hide on Ctrl+C (pre-existing). The reported overflow was the status-line unmount.
- No breaking CLI flags.

## Linked Issues

Fixes #10718. Related layout work: #10500 (short dialogs vs startup banner).
