### PR TITLE
feat(acp-bridge): report which transport-guard budget fired on channel exit

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -12765,6 +12765,70 @@ describe('createAcpSessionBridge', () => {
     bridge.killAllSync();
   });
 
+  it('records which budget fired on a transport-guard channel exit', async () => {
+    const handle = makeChannel({ promptImpl: () => new Promise(() => {}) });
+    const failure = deferred<unknown>();
+    handle.channel = {
+      ...handle.channel,
+      transportFailed: failure.promise,
+      // Keep the process inside its termination grace window until we crash it.
+      kill: () => new Promise(() => {}),
+    };
+    const event = vi.fn();
+    const channelLifecycle = vi.fn();
+    const telemetry: BridgeTelemetry = {
+      captureContext: () => undefined,
+      runWithContext: async (_captured, fn) => await fn(),
+      withSpan: async (_operation, _attributes, fn) => await fn(),
+      event,
+      injectPromptContext: (request) => request,
+      metrics: {
+        sessionLifecycle: vi.fn(),
+        channelLifecycle,
+        promptQueueWait: vi.fn(),
+        promptDuration: vi.fn(),
+        cancelled: vi.fn(),
+      },
+    };
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+      telemetry,
+    });
+    const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+    const prompt = bridge.sendPrompt(first.sessionId, {
+      sessionId: first.sessionId,
+      prompt: [{ type: 'text', text: 'stay pending' }],
+    });
+    await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(1));
+    failure.resolve(
+      Object.assign(new Error('bounded transport queue failed'), {
+        code: 'ndjson_queue_limit_exceeded',
+        maxQueuedMessages: 256,
+        maxQueuedBytes: 67108864,
+        requiredBytes: 262144,
+        availableBytes: 0,
+      }),
+    );
+    await expect(prompt).rejects.toBeInstanceOf(BridgeChannelClosedError);
+    handle.crash({ exitCode: null, signalCode: 'SIGTERM' });
+    await vi.waitFor(() =>
+      expect(event).toHaveBeenCalledWith(
+        'channel.exited',
+        expect.objectContaining({
+          'qwen-code.daemon.channel.transport_failed': true,
+          'qwen-code.daemon.channel.transport_failure_initiated_teardown': true,
+          'qwen-code.daemon.channel.transport_error_code':
+            'ndjson_queue_limit_exceeded',
+          'qwen-code.daemon.channel.transport_error_maxQueuedMessages': 256,
+          'qwen-code.daemon.channel.transport_error_maxQueuedBytes': 67108864,
+          'qwen-code.daemon.channel.transport_error_requiredBytes': 262144,
+          'qwen-code.daemon.channel.transport_error_availableBytes': 0,
+        }),
+      ),
+    );
+    await bridge.shutdown();
+  });
+
   it('does not publish a channel whose transport fails during initialize', async () => {
     const failure = deferred<unknown>();
     const transportError = Object.assign(new Error('frame failed'), {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -319,6 +319,43 @@ function safeTransportFailureCode(error: unknown): string | undefined {
     : undefined;
 }
 
+/**
+ * Bounded numeric/enum context retained for telemetry and the `channel exited`
+ * breadcrumb when a transport guard fires. Mirrors `safeTransportFailureCode`:
+ * only known, safe fields from the guard error types (`NdJsonQueueLimitError`,
+ * `NdJsonFrameTooLargeError`, `AcpInboundHandlerLimitError`) are surfaced — never
+ * the raw error message — so operators can tell WHICH budget fired and how full,
+ * instead of only seeing the opaque `transport=<code>`.
+ */
+const TRANSPORT_FAILURE_DETAIL_NUMBER_KEYS = [
+  'maxQueuedMessages',
+  'maxQueuedBytes',
+  'maxActiveHandlers',
+  'maxActiveHandlerBytes',
+  'requiredBytes',
+  'availableBytes',
+  'limitBytes',
+  'observedBytes',
+] as const;
+
+function safeTransportFailureDetail(
+  error: unknown,
+): Record<string, number | string> | undefined {
+  if (!isRecord(error)) return undefined;
+  const detail: Record<string, number | string> = {};
+  for (const key of TRANSPORT_FAILURE_DETAIL_NUMBER_KEYS) {
+    const value = error[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      detail[key] = value;
+    }
+  }
+  const direction = error['direction'];
+  if (direction === 'sent' || direction === 'received') {
+    detail['direction'] = direction;
+  }
+  return Object.keys(detail).length > 0 ? detail : undefined;
+}
+
 function sessionSourceRequestMeta(
   sourceType: string | undefined,
   sourceId: string | undefined,
@@ -962,6 +999,8 @@ interface ChannelInfo {
   transportFailureInitiatedTeardown: boolean;
   /** Safe bounded code retained for telemetry; never the raw error message. */
   transportFailureCode?: string;
+  /** Safe bounded budget context for telemetry; never the raw error message. */
+  transportFailureDetail?: Record<string, number | string>;
   /**
    * Cached channel-close race for workspace-scoped status requests. Workspace
    * status can be polled frequently by dashboards, so keep one promise per
@@ -4601,6 +4640,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         }
         info.transportFailed = true;
         info.transportFailureCode = safeTransportFailureCode(error);
+        info.transportFailureDetail = safeTransportFailureDetail(error);
         info.isDying = true;
         info.channelLiveness?.stop();
         clearInFlightExtensionRefreshes(info.connection);
@@ -4707,12 +4747,28 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                     info.transportFailureCode,
                 }
               : {}),
+            ...(info.transportFailureDetail
+              ? Object.fromEntries(
+                  Object.entries(info.transportFailureDetail).map(
+                    ([key, value]) =>
+                      [
+                        `qwen-code.daemon.channel.transport_error_${key}`,
+                        value,
+                      ] as const,
+                  ),
+                )
+              : {}),
             ...(exitInfo?.signalCode
               ? { 'qwen-code.daemon.channel.signal': exitInfo.signalCode }
               : {}),
           });
+          const transportFailureDetailText = info.transportFailureDetail
+            ? ` ${Object.entries(info.transportFailureDetail)
+                .map(([key, value]) => `${key}=${value}`)
+                .join(' ')}`
+            : '';
           writeStderrLine(
-            `qwen serve: channel exited (code=${exitInfo?.exitCode ?? 'none'}, signal=${exitInfo?.signalCode ?? 'none'}, transport=${info.transportFailed ? (info.transportFailureCode ?? 'failed') : 'ok'}, ${sessions.length} session(s) torn down)`,
+            `qwen serve: channel exited (code=${exitInfo?.exitCode ?? 'none'}, signal=${exitInfo?.signalCode ?? 'none'}, transport=${info.transportFailed ? (info.transportFailureCode ?? 'failed') : 'ok'}${transportFailureDetailText}, ${sessions.length} session(s) torn down)`,
           );
         }
         for (const sid of sessions) {


### PR DESCRIPTION
## What this PR does

When a bounded NDJSON/handler transport guard trips and tears down an ACP channel, the daemon currently logs only `transport=<code>` (for example `transport=ndjson_queue_limit_exceeded`). This PR captures the guard error's bounded numeric context — which budget fired and how full it was — and emits it in both the `channel.exited` telemetry event and the `channel exited` stderr breadcrumb. It is observability-only: no behavior change, and the detail is only added when the guard error actually carries budget fields (real `NdJsonQueueLimitError` / `NdJsonFrameTooLargeError` / `AcpInboundHandlerLimitError`), so code-only errors keep the exact existing output.

## Why it's needed

Operators hitting `qwen serve: channel exited (... transport=ndjson_queue_limit_exceeded, N session(s) torn down)` (see #10162) currently cannot tell WHICH of the bounded budgets fired (decoded-queue message count vs retained wire bytes, inbound-handler capacity, prepared-response/outbound-operation bytes) nor the `required`/`available` bytes at the moment of failure. Root-causing these teardowns today requires log archaeology plus an external event-loop monitor, exactly as documented in the #10162 reproduction. Surfacing the budget detail in the one line the daemon already prints makes these failures diagnosable. Both #10162 and #10689 explicitly call out this diagnostics gap.

## Reviewer Test Plan

### How to verify

A new unit test, `records which budget fired on a transport-guard channel exit`, resolves a transport failure carrying budget fields and asserts the `channel.exited` telemetry event includes `transport_error_maxQueuedMessages` / `transport_error_maxQueuedBytes` / `transport_error_requiredBytes` / `transport_error_availableBytes`. Run it with:

```bash
npm -w packages/acp-bridge run test -- bridge.test.ts -t "records which budget fired"
```

The stderr breadcrumb for a budget-carrying failure now reads, for example:

```
qwen serve: channel exited (code=none, signal=SIGTERM, transport=ndjson_queue_limit_exceeded maxQueuedMessages=256 maxQueuedBytes=67108864 requiredBytes=262144 availableBytes=0, 1 session(s) torn down)
```

Failures without budget fields (the existing code-only mock errors used throughout the test suite) keep the exact prior format, so no existing assertion changes.

### Evidence (Before & After)

Non-UI change.
Before: `... transport=ndjson_queue_limit_exceeded, 1 session(s) torn down)`
After:  `... transport=ndjson_queue_limit_exceeded maxQueuedMessages=256 maxQueuedBytes=67108864 requiredBytes=262144 availableBytes=0, 1 session(s) torn down)`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests via `vitest` (`packages/acp-bridge`). `tsc --noEmit` and `eslint` clean for the changed files.

## Risk & Scope

- Main risk or tradeoff: none functional — observability only; the `channel exited` stderr line gains `key=value` pairs only when the guard error carries budget fields, and telemetry gains additive attributes.
- Not validated / out of scope: the fail-closed teardown behavior itself is unchanged (that is #10162's design question); no change to guard limits or semantics.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #10162, #10689 (both call out this diagnostics gap). This PR does not close either — it only closes the observability gap they describe.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当一个有界 NDJSON / handler 传输守卫触发并拆掉 ACP 通道时，daemon 目前只打印 `transport=<code>`（例如 `transport=ndjson_queue_limit_exceeded`）。本 PR 捕获守卫错误的有界数值上下文——是哪条预算触发、触发时有多满——并把它同时写进 `channel.exited` 遥测事件和 `channel exited` stderr 面包屑。纯可观测性改动：不改变任何行为；仅当守卫错误确实带预算字段时（真实的 `NdJsonQueueLimitError` / `NdJsonFrameTooLargeError` / `AcpInboundHandlerLimitError`）才追加 detail，只有 code 的错误保持原有输出不变。

## 为什么需要

线上遇到 `qwen serve: channel exited (... transport=ndjson_queue_limit_exceeded, N session(s) torn down)`（见 #10162）时，目前无法判断到底是哪一条有界预算触发（解码队列条数还是字节、入站 handler 容量、预置响应/出站操作字节），也拿不到触发瞬间的 `required`/`available` 字节。要定位这类拆通道只能靠翻日志 + 外部事件循环监控，正如 #10162 复现里做的那样。把预算细节直接写进 daemon 本来就打印的那一行，才能让这类失败可诊断。#10162 和 #10689 都明确指出了这个诊断缺口。

## 审阅者测试方案

### 如何验证

新增单测 `records which budget fired on a transport-guard channel exit`：用一个带预算字段的传输失败来 resolve，断言 `channel.exited` 遥测事件包含 `transport_error_maxQueuedMessages` / `transport_error_maxQueuedBytes` / `transport_error_requiredBytes` / `transport_error_availableBytes`。运行：

```bash
npm -w packages/acp-bridge run test -- bridge.test.ts -t "records which budget fired"
```

带预算字段的失败，其 stderr 面包屑现在形如：

```
qwen serve: channel exited (code=none, signal=SIGTERM, transport=ndjson_queue_limit_exceeded maxQueuedMessages=256 maxQueuedBytes=67108864 requiredBytes=262144 availableBytes=0, 1 session(s) torn down)
```

不带预算字段的失败（测试套件里现有的只有 code 的 mock 错误）保持原有格式不变，因此不改动任何既有断言。

### 证据（前后对比）

非 UI 改动。
改前：`... transport=ndjson_queue_limit_exceeded, 1 session(s) torn down)`
改后：`... transport=ndjson_queue_limit_exceeded maxQueuedMessages=256 maxQueuedBytes=67108864 requiredBytes=262144 availableBytes=0, 1 session(s) torn down)`

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

`vitest` 单测（`packages/acp-bridge`）。改动文件 `tsc --noEmit` 与 `eslint` 均通过。

## 风险与范围

- 主要风险/权衡：无功能性风险——纯可观测性；`channel exited` stderr 行仅在守卫错误带预算字段时追加 `key=value`，遥测仅新增附加属性。
- 未验证/超出范围：fail-closed 拆通道行为本身未变（那是 #10162 的设计问题）；不改动守卫上限或语义。
- 破坏性变更/迁移说明：无。

## 关联 Issue

关联 #10162、#10689（两者都指出该诊断缺口）。本 PR 不关闭它们——只补齐它们描述的可观测性缺口。

</details>
