### PR TITLE
feat(daemon): name the saturated NDJSON budget in channel-teardown diagnostics

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -12768,6 +12768,69 @@ describe('createAcpSessionBridge', () => {
     bridge.killAllSync();
   });
 
+  it('records which budget fired on a transport-guard channel exit', async () => {
+    const neverPrompt = deferred<never>();
+    const handle = makeChannel({ promptImpl: () => neverPrompt.promise });
+    const failure = deferred<unknown>();
+    handle.channel = {
+      ...handle.channel,
+      transportFailed: failure.promise,
+      kill: () => deferred<never>().promise,
+    };
+    const event = vi.fn();
+    const channelLifecycle = vi.fn();
+    const telemetry: BridgeTelemetry = {
+      captureContext: () => undefined,
+      runWithContext: async (_captured, fn) => await fn(),
+      withSpan: async (_operation, _attributes, fn) => await fn(),
+      event,
+      injectPromptContext: (request) => request,
+      metrics: {
+        sessionLifecycle: vi.fn(),
+        channelLifecycle,
+        promptQueueWait: vi.fn(),
+        promptDuration: vi.fn(),
+        cancelled: vi.fn(),
+      },
+    };
+    const bridge = makeBridge({
+      channelFactory: async () => handle.channel,
+      telemetry,
+    });
+    const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+    const prompt = bridge.sendPrompt(first.sessionId, {
+      sessionId: first.sessionId,
+      prompt: [{ type: 'text', text: 'stay pending' }],
+    });
+    await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(1));
+    failure.resolve(
+      Object.assign(new Error('bounded transport queue failed'), {
+        code: 'ndjson_queue_limit_exceeded',
+        budget: 'prepared_response',
+        maxQueuedMessages: 256,
+        maxQueuedBytes: 67108864,
+        requiredBytes: 262144,
+        availableBytes: 0,
+      }),
+    );
+    await expect(prompt).rejects.toBeInstanceOf(BridgeChannelClosedError);
+    handle.crash({ exitCode: null, signalCode: 'SIGTERM' });
+    await vi.waitFor(() =>
+      expect(event).toHaveBeenCalledWith(
+        'channel.exited',
+        expect.objectContaining({
+          'qwen-code.daemon.channel.transport_failed': true,
+          'qwen-code.daemon.channel.transport_failure_initiated_teardown': true,
+          'qwen-code.daemon.channel.transport_error_code':
+            'ndjson_queue_limit_exceeded',
+          'qwen-code.daemon.channel.transport_error_detail':
+            'prepared_response:required=262144:available=0:cap=67108864',
+        }),
+      ),
+    );
+    await bridge.shutdown();
+  });
+
   it('does not publish a channel whose transport fails during initialize', async () => {
     const failure = deferred<unknown>();
     const transportError = Object.assign(new Error('frame failed'), {

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -56,6 +56,7 @@ import {
   extractErrorMessage,
   extractErrorCode,
 } from './bridge.js';
+import { NdJsonQueueLimitError } from './ndJsonStream.js';
 import {
   BridgeChannelClosedError,
   BridgeTimeoutError,
@@ -12748,6 +12749,10 @@ describe('createAcpSessionBridge', () => {
     failures[1]!.resolve(
       Object.assign(new Error('bounded transport queue failed'), {
         code: 'ndjson_queue_limit_exceeded',
+        budget: 'INVALID budget <script>',
+        maxQueuedBytes: 1.9,
+        requiredBytes: -5,
+        availableBytes: Number.NaN,
       }),
     );
     await expect(restore).rejects.toBeInstanceOf(BridgeChannelClosedError);
@@ -12764,7 +12769,26 @@ describe('createAcpSessionBridge', () => {
             'ndjson_frame_too_large',
         }),
       );
+      expect(event).toHaveBeenCalledWith(
+        'channel.exited',
+        expect.objectContaining({
+          'qwen-code.daemon.channel.transport_error_code':
+            'ndjson_queue_limit_exceeded',
+          'qwen-code.daemon.channel.transport_error_detail':
+            'unknown:required=0:available=?:cap=1',
+        }),
+      );
     });
+    const frameExitAttributes = event.mock.calls.find(
+      ([name, attributes]) =>
+        name === 'channel.exited' &&
+        (attributes as Record<string, unknown>)[
+          'qwen-code.daemon.channel.transport_error_code'
+        ] === 'ndjson_frame_too_large',
+    )?.[1] as Record<string, unknown> | undefined;
+    expect(frameExitAttributes).not.toHaveProperty(
+      'qwen-code.daemon.channel.transport_error_detail',
+    );
     bridge.killAllSync();
   });
 
@@ -12797,38 +12821,49 @@ describe('createAcpSessionBridge', () => {
       channelFactory: async () => handle.channel,
       telemetry,
     });
-    const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
-    const prompt = bridge.sendPrompt(first.sessionId, {
-      sessionId: first.sessionId,
-      prompt: [{ type: 'text', text: 'stay pending' }],
-    });
-    await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(1));
-    failure.resolve(
-      Object.assign(new Error('bounded transport queue failed'), {
-        code: 'ndjson_queue_limit_exceeded',
-        budget: 'prepared_response',
-        maxQueuedMessages: 256,
-        maxQueuedBytes: 67108864,
-        requiredBytes: 262144,
-        availableBytes: 0,
-      }),
-    );
-    await expect(prompt).rejects.toBeInstanceOf(BridgeChannelClosedError);
-    handle.crash({ exitCode: null, signalCode: 'SIGTERM' });
-    await vi.waitFor(() =>
-      expect(event).toHaveBeenCalledWith(
-        'channel.exited',
-        expect.objectContaining({
-          'qwen-code.daemon.channel.transport_failed': true,
-          'qwen-code.daemon.channel.transport_failure_initiated_teardown': true,
-          'qwen-code.daemon.channel.transport_error_code':
-            'ndjson_queue_limit_exceeded',
-          'qwen-code.daemon.channel.transport_error_detail':
-            'prepared_response:required=262144:available=0:cap=67108864',
-        }),
-      ),
-    );
-    await bridge.shutdown();
+    const stderr = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    try {
+      const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const prompt = bridge.sendPrompt(first.sessionId, {
+        sessionId: first.sessionId,
+        prompt: [{ type: 'text', text: 'stay pending' }],
+      });
+      await vi.waitFor(() => expect(handle.agent.promptCalls).toHaveLength(1));
+      failure.resolve(
+        new NdJsonQueueLimitError(
+          'prepared_response',
+          256,
+          67108864,
+          262144,
+          0,
+        ),
+      );
+      await expect(prompt).rejects.toBeInstanceOf(BridgeChannelClosedError);
+      handle.crash({ exitCode: null, signalCode: 'SIGTERM' });
+      await vi.waitFor(() =>
+        expect(event).toHaveBeenCalledWith(
+          'channel.exited',
+          expect.objectContaining({
+            'qwen-code.daemon.channel.transport_failed': true,
+            'qwen-code.daemon.channel.transport_failure_initiated_teardown': true,
+            'qwen-code.daemon.channel.transport_error_code':
+              'ndjson_queue_limit_exceeded',
+            'qwen-code.daemon.channel.transport_error_detail':
+              'prepared_response:required=262144:available=0:cap=67108864',
+          }),
+        ),
+      );
+      expect(stderr).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'transport_detail=prepared_response:required=262144:available=0:cap=67108864',
+        ),
+      );
+    } finally {
+      stderr.mockRestore();
+      await bridge.shutdown();
+    }
   });
 
   it('does not publish a channel whose transport fails during initialize', async () => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -118,6 +118,7 @@ import {
   StandaloneSessionSpawnError,
 } from './bridgeErrors.js';
 import type { BridgeChannelUnavailableReason } from './bridgeErrors.js';
+import type { NdJsonQueueLimitError } from './ndJsonStream.js';
 import {
   resolveSessionRestoreTimeoutMs,
   restoreRetryAfterSeconds,
@@ -317,6 +318,30 @@ function safeTransportFailureCode(error: unknown): string | undefined {
   return typeof code === 'string' && /^[a-z0-9_.-]{1,64}$/iu.test(code)
     ? code
     : undefined;
+}
+
+function safeTransportFailureDetail(error: unknown): string | undefined {
+  if (!isRecord(error) || error['code'] !== 'ndjson_queue_limit_exceeded') {
+    return undefined;
+  }
+  const queueError = error as Partial<NdJsonQueueLimitError>;
+  const budget = queueError.budget;
+  if (typeof budget !== 'string' || !/^[a-z0-9_.-]{1,64}$/iu.test(budget)) {
+    return undefined;
+  }
+  const numbers: string[] = [];
+  for (const value of [
+    queueError.requiredBytes,
+    queueError.availableBytes,
+    queueError.maxQueuedBytes,
+  ]) {
+    numbers.push(
+      typeof value === 'number' && Number.isFinite(value)
+        ? String(Math.max(0, Math.floor(value)))
+        : '?',
+    );
+  }
+  return `${budget}:required=${numbers[0]}:available=${numbers[1]}:cap=${numbers[2]}`;
 }
 
 function sessionSourceRequestMeta(
@@ -962,6 +987,12 @@ interface ChannelInfo {
   transportFailureInitiatedTeardown: boolean;
   /** Safe bounded code retained for telemetry; never the raw error message. */
   transportFailureCode?: string;
+  /**
+   * Bounded queue-budget detail for `ndjson_queue_limit_exceeded` transport
+   * failures: which budget fired plus required/available/cap bytes. Derived
+   * from typed error fields only; never the raw error message.
+   */
+  transportFailureDetail?: string;
   /**
    * Cached channel-close race for workspace-scoped status requests. Workspace
    * status can be polled frequently by dashboards, so keep one promise per
@@ -4601,6 +4632,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         }
         info.transportFailed = true;
         info.transportFailureCode = safeTransportFailureCode(error);
+        info.transportFailureDetail = safeTransportFailureDetail(error);
         info.isDying = true;
         info.channelLiveness?.stop();
         clearInFlightExtensionRefreshes(info.connection);
@@ -4707,12 +4739,18 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                     info.transportFailureCode,
                 }
               : {}),
+            ...(info.transportFailureDetail
+              ? {
+                  'qwen-code.daemon.channel.transport_error_detail':
+                    info.transportFailureDetail,
+                }
+              : {}),
             ...(exitInfo?.signalCode
               ? { 'qwen-code.daemon.channel.signal': exitInfo.signalCode }
               : {}),
           });
           writeStderrLine(
-            `qwen serve: channel exited (code=${exitInfo?.exitCode ?? 'none'}, signal=${exitInfo?.signalCode ?? 'none'}, transport=${info.transportFailed ? (info.transportFailureCode ?? 'failed') : 'ok'}, ${sessions.length} session(s) torn down)`,
+            `qwen serve: channel exited (code=${exitInfo?.exitCode ?? 'none'}, signal=${exitInfo?.signalCode ?? 'none'}, transport=${info.transportFailed ? (info.transportFailureCode ?? 'failed') : 'ok'}${info.transportFailureDetail ? `, transport_detail=${info.transportFailureDetail}` : ''}, ${sessions.length} session(s) torn down)`,
           );
         }
         for (const sid of sessions) {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -325,10 +325,11 @@ function safeTransportFailureDetail(error: unknown): string | undefined {
     return undefined;
   }
   const queueError = error as Partial<NdJsonQueueLimitError>;
-  const budget = queueError.budget;
-  if (typeof budget !== 'string' || !/^[a-z0-9_.-]{1,64}$/iu.test(budget)) {
-    return undefined;
-  }
+  const budget =
+    typeof queueError.budget === 'string' &&
+    /^[a-z0-9_.-]{1,64}$/iu.test(queueError.budget)
+      ? queueError.budget
+      : 'unknown';
   const numbers: string[] = [];
   for (const value of [
     queueError.requiredBytes,

--- a/packages/acp-bridge/src/ndJsonStream.test.ts
+++ b/packages/acp-bridge/src/ndJsonStream.test.ts
@@ -406,7 +406,10 @@ describe('ndJsonStream', () => {
     );
     await vi.waitFor(() =>
       expect(onTransportError).toHaveBeenCalledWith(
-        expect.any(NdJsonQueueLimitError),
+        expect.objectContaining({
+          code: 'ndjson_queue_limit_exceeded',
+          budget: 'decoded',
+        }),
       ),
     );
     expect(onTransportError).toHaveBeenCalledOnce();
@@ -767,7 +770,10 @@ describe('ndJsonStream', () => {
 
     await vi.waitFor(() =>
       expect(onTransportError).toHaveBeenCalledWith(
-        expect.any(NdJsonQueueLimitError),
+        expect.objectContaining({
+          code: 'ndjson_queue_limit_exceeded',
+          budget: 'inbound_request',
+        }),
       ),
     );
     clearInterval(timer);
@@ -1036,7 +1042,10 @@ describe('ndJsonStream', () => {
         method: 'agent/request',
         params: {},
       }),
-    ).rejects.toBeInstanceOf(NdJsonQueueLimitError);
+    ).rejects.toMatchObject({
+      code: 'ndjson_queue_limit_exceeded',
+      budget: 'outbound_request',
+    });
     expect(onTransportError).toHaveBeenCalledOnce();
     writer.releaseLock();
     await stream.readable.cancel();

--- a/packages/acp-bridge/src/ndJsonStream.ts
+++ b/packages/acp-bridge/src/ndJsonStream.ts
@@ -80,17 +80,25 @@ export class NdJsonFrameTooLargeError extends Error {
   }
 }
 
+export type NdJsonQueueBudget =
+  | 'decoded'
+  | 'inbound_request'
+  | 'outbound_request'
+  | 'prepared_response'
+  | 'outbound_operation';
+
 export class NdJsonQueueLimitError extends Error {
   readonly code = 'ndjson_queue_limit_exceeded';
 
   constructor(
+    readonly budget: NdJsonQueueBudget,
     readonly maxQueuedMessages: number,
     readonly maxQueuedBytes: number,
     readonly requiredBytes: number,
     readonly availableBytes: number,
   ) {
     super(
-      `NDJSON decoded queue is full ` +
+      `NDJSON ${budget} queue limit exceeded ` +
         `(required ${requiredBytes} bytes, available ${availableBytes} bytes)`,
     );
     this.name = 'NdJsonQueueLimitError';
@@ -290,6 +298,7 @@ function createBoundedReadable(
   ): Promise<void> => {
     const queueLimitError = (available: number) =>
       new NdJsonQueueLimitError(
+        'decoded',
         limits.maxQueuedMessages,
         limits.maxQueuedBytes,
         queueCharge,
@@ -733,6 +742,7 @@ class BoundedInboundRequestLedger {
       frameBytes > availableBytes
     ) {
       throw new NdJsonQueueLimitError(
+        'inbound_request',
         this.limits.maxQueuedMessages,
         this.limits.maxQueuedBytes,
         frameBytes,
@@ -774,6 +784,7 @@ class BoundedOutstandingRequestLedger {
       frameBytes > availableBytes
     ) {
       throw new NdJsonQueueLimitError(
+        'outbound_request',
         this.limits.maxQueuedMessages,
         this.limits.maxQueuedBytes,
         frameBytes,

--- a/packages/acp-bridge/src/spawnChannel.test.ts
+++ b/packages/acp-bridge/src/spawnChannel.test.ts
@@ -463,7 +463,7 @@ describe('createSpawnChannelFactory env policy', () => {
     ).not.toThrow();
     expect(() =>
       channel.transportGuard?.reservePreparedResponse(third),
-    ).toThrow('NDJSON decoded queue is full');
+    ).toThrow('NDJSON prepared_response queue limit exceeded');
 
     await expect(channel.transportFailed).resolves.toMatchObject({
       code: 'ndjson_queue_limit_exceeded',
@@ -505,7 +505,7 @@ describe('createSpawnChannelFactory env policy', () => {
 
     expect(() =>
       channel.transportGuard?.reservePreparedResponse(response),
-    ).toThrow('NDJSON decoded queue is full');
+    ).toThrow('NDJSON prepared_response queue limit exceeded');
     expect(elementReads).toBeLessThan(1_000);
     await expect(channel.transportFailed).resolves.toMatchObject({
       code: 'ndjson_queue_limit_exceeded',
@@ -528,7 +528,7 @@ describe('createSpawnChannelFactory env policy', () => {
 
     expect(() =>
       channel.transportGuard?.reservePreparedResponse(response),
-    ).toThrow('NDJSON decoded queue is full');
+    ).toThrow('NDJSON prepared_response queue limit exceeded');
     await expect(channel.transportFailed).resolves.toMatchObject({
       code: 'ndjson_queue_limit_exceeded',
     });

--- a/packages/acp-bridge/src/spawnChannel.test.ts
+++ b/packages/acp-bridge/src/spawnChannel.test.ts
@@ -467,11 +467,38 @@ describe('createSpawnChannelFactory env policy', () => {
 
     await expect(channel.transportFailed).resolves.toMatchObject({
       code: 'ndjson_queue_limit_exceeded',
+      budget: 'prepared_response',
     });
     await vi.waitFor(() =>
       expect(child.kill).toHaveBeenCalledWith(expectedTreeFallbackSignal()),
     );
     writer.releaseLock();
+  });
+
+  it('attributes outbound operation budget failures', async () => {
+    const child = createFakeChildProcess();
+    mockSpawn.mockReturnValue(child);
+    const channel = await createSpawnChannelFactory({
+      pipeLimits: {
+        maxFrameBytes: 4096,
+        maxQueuedMessages: 1,
+        maxQueuedBytes: 4096,
+      },
+    })('/tmp/project');
+
+    const release = channel.transportGuard?.reserveOutboundOperation([
+      'first',
+      {},
+    ]);
+    expect(() =>
+      channel.transportGuard?.reserveOutboundOperation(['second', {}]),
+    ).toThrow('NDJSON outbound_operation queue limit exceeded');
+    await expect(channel.transportFailed).resolves.toMatchObject({
+      code: 'ndjson_queue_limit_exceeded',
+      budget: 'outbound_operation',
+      maxQueuedMessages: 1,
+    });
+    release?.();
   });
 
   it('stops estimating a large response once its byte budget is exceeded', async () => {

--- a/packages/acp-bridge/src/spawnChannel.ts
+++ b/packages/acp-bridge/src/spawnChannel.ts
@@ -95,6 +95,7 @@ class PreparedResponseBudget {
       charge > availableBytes
     ) {
       throw new NdJsonQueueLimitError(
+        'prepared_response',
         this.limits.maxQueuedMessages,
         this.limits.maxQueuedBytes,
         charge,
@@ -180,6 +181,7 @@ class OutboundOperationBudget {
       charge > availableBytes
     ) {
       throw new NdJsonQueueLimitError(
+        'outbound_operation',
         this.limits.maxQueuedMessages,
         this.limits.maxQueuedBytes,
         charge,


### PR DESCRIPTION
## What this PR does

When the daemon's bounded NDJSON transport guard tears a channel down, the stderr line and the `channel.exited` telemetry event now say which of the five bounded budgets fired — the decoded-frame queue, the inbound-request ledger, the outbound-request ledger, the prepared-response ledger, or the outbound-operation ledger — together with the bytes required, the bytes available, and the configured byte cap. The queue-limit error carries this as typed fields, and the bridge derives a bounded `budget:required=…:available=…:cap=…` detail string from those typed fields only (never from the raw error message), appending it as `transport_detail=` to the `qwen serve: channel exited (…)` line and as a `qwen-code.daemon.channel.transport_error_detail` telemetry attribute.

## Why it's needed

On a production daemon (v0.22.2, one busy workspace), repeated `channel exited (…, transport=ndjson_queue_limit_exceeded, N session(s) torn down)` events tore down every session on the channel, and the log could not distinguish a stalled consumer (ACP child event-loop wedged for tens of seconds) from a genuine flood. Root-causing it took log archaeology plus an external event-loop monitor instead of one log line. This is the small diagnostics follow-up that issue #10162 identifies as the step that unblocks diagnosing the fail-closed blast radius.

## Reviewer Test Plan

### How to verify

Run the acp-bridge unit tests for the stream, the spawn channel, and the bridge. To see the new detail end to end, saturate the prepared-response budget the way the spawn-channel tests do: the thrown error message now names `prepared_response`, and a channel-exited line produced while that budget is saturated carries `transport_detail=prepared_response:required=…:available=…:cap=…` before the session count.

### Evidence (Before & After)

N/A — log/telemetry-only change; no user-visible UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment

Local unit tests via `npx vitest run` in `packages/acp-bridge`; full `npm run typecheck` green.

## Risk & Scope

- Main risk or tradeoff: the `channel exited` stderr line gains one comma-separated field before the session count; anything parsing the exact old format would need to tolerate it. The telemetry attribute is purely additive.
- Not validated / out of scope: Windows/Linux verified by CI only; graceful degradation instead of fail-closed teardown remains the separate product question in #10162.
- Breaking changes / migration notes: none; the error `code` (`ndjson_queue_limit_exceeded`) and all existing fields are unchanged.

## Linked Issues

Refs #10162 (does not close it; the fail-closed semantics themselves are the product question there).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当 daemon 的有界 NDJSON 传输守卫拆除 channel 时，stderr 日志行和 `channel.exited` 遥测事件现在会说明五个有界预算中是哪一个触发了拆除——解码帧队列、入站请求账本、出站请求账本、预置响应账本、出站操作账本——并附上所需字节数、可用字节数和配置的字节上限。队列超限错误以类型化字段携带这些信息，bridge 仅从这些类型化字段（绝不从原始错误消息）派生一个有界的 `budget:required=…:available=…:cap=…` 详情串，作为 `transport_detail=` 追加到 `qwen serve: channel exited (…)` 行，并作为 `qwen-code.daemon.channel.transport_error_detail` 遥测属性。

## 为什么需要

在一个生产 daemon（v0.22.2，单个繁忙 workspace）上，反复出现的 `channel exited (…, transport=ndjson_queue_limit_exceeded, N session(s) torn down)` 事件把 channel 上所有 session 一起拆掉，而日志无法区分"消费方卡死"（ACP 子进程事件循环卡死几十秒）与"真实洪泛"。定位根因只能靠翻日志考古加外部事件循环监控，而不是一行日志。这正是 issue #10162 指出的、能解锁诊断 fail-closed 爆炸半径的小型诊断增强。

## 评审测试计划

### 如何验证

运行 acp-bridge 的 stream、spawn channel、bridge 单元测试。要端到端看到新详情，可以像 spawn-channel 测试那样把预置响应预算打满：抛出的错误消息现在会点名 `prepared_response`，该预算饱和时产生的 channel-exited 行会在 session 数之前携带 `transport_detail=prepared_response:required=…:available=…:cap=…`。

### 证据（前后对比）

N/A —— 仅日志/遥测变更，无用户可见 UI。

### 测试环境

macOS ✅；Windows / Linux 由 CI 覆盖。

## 风险与范围

- 主要风险：`channel exited` stderr 行在 session 数之前多了一个逗号分隔字段；按旧格式精确解析的工具需要容忍它。遥测属性纯增量。
- 未验证/范围外：Windows/Linux 仅靠 CI；用优雅降级替代 fail-closed 拆除仍是 #10162 里独立的产品问题。
- 破坏性变更/迁移说明：无；错误 `code`（`ndjson_queue_limit_exceeded`）与所有既有字段不变。

## 关联 Issue

Refs #10162（不关闭；fail-closed 语义本身是该 issue 的产品问题）。

</details>