### PR TITLE
fix(web-shell): remove duplicate language declaration in ChatEditor.test.tsx

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -404,7 +404,6 @@ interface ChatEditorRenderProps {
   builtinAtProviders?: WebShellCustomization['builtinAtProviders'];
   atProviders?: WebShellCustomization['atProviders'];
   skills?: Array<{ name: string; description: string }>;
-  language?: WebShellLanguage;
   reasoning?: DaemonReasoningControls;
   onSelectReasoningEffort?: (value: ReasoningSelection) => Promise<void> | void;
 }
@@ -422,7 +421,6 @@ function renderChatEditorInto(
     language = 'en',
     renderComposerTagTooltip,
     onComposerTagClick,
-    language = 'en',
     ...chatEditorProps
   } = props;
   if (composerTags) {


### PR DESCRIPTION
## What this PR does

Removes the duplicate `language` declarations in `packages/web-shell/client/components/ChatEditor.test.tsx`. The `Add standalone chats` (#10514) and `session workflow cockpit` (#8583) merges each added a `language` member, and the second merge kept both copies: the `ChatEditorRenderProps` interface declared `language?: WebShellLanguage;` twice and `renderChatEditorInto` destructured `language = 'en',` twice. esbuild rejects the redeclaration (`The symbol "language" has already been declared`), so the web-shell suite fails at transform time. This PR removes one duplicate from each location (2 lines total); the remaining single declaration is still used at `<I18nProvider language={language}>`.

## Why it's needed

The redeclaration is a deterministic esbuild compile failure that reds the `Test (ubuntu-latest, Node 22.x)` job on `main` CI (see run https://github.com/QwenLM/qwen-code/actions/runs/33515371387). Removing the duplicate is the minimal complete fix and unblocks CI for every PR that runs the web-shell suite.

## Reviewer Test Plan

### How to verify

1. On `main`, run the web-shell suite (or `npm run build` inside `packages/web-shell`) and observe the esbuild transform error `The symbol "language" has already been declared` in `ChatEditor.test.tsx`.
2. Apply this PR and re-run: the transform error is gone and the suite runs. CI on this PR confirms it end to end.

### Evidence (Before & After)

N/A — test-file compile fix, no user-visible output change; CI status of the web-shell suite is the evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

Verification is delegated to CI (`Test (ubuntu-latest, Node 22.x)`) since the failure and fix are deterministic compile-time behavior.

### Environment (optional)

N/A (unit test compile fix).

## Risk & Scope

- Main risk or tradeoff: none — removes two exact duplicate declarations; semantics are unchanged.
- Not validated / out of scope: no local OS runs; relies on CI for the web-shell suite.
- Breaking changes / migration notes: none.

## Linked Issues

No tracking issue; repairs `main` CI red introduced by the #10514 / #8583 merge overlap.

<details>
<summary>中文说明</summary>

本 PR 删除 `packages/web-shell/client/components/ChatEditor.test.tsx` 中重复的 `language` 声明。`Add standalone chats`（#10514）与 `session workflow cockpit`（#8583）两次合并各自添加了 `language` 成员，第二次合并保留了两份拷贝：`ChatEditorRenderProps` 接口重复声明了 `language?: WebShellLanguage;`，`renderChatEditorInto` 重复解构了 `language = 'en',`。esbuild 拒绝重复声明（`The symbol "language" has already been declared`），导致 web-shell 套件在 transform 阶段失败、`Test (ubuntu-latest, Node 22.x)` 变红。本 PR 各删除一处重复（共 2 行），保留的单个声明仍被 `<I18nProvider language={language}>` 使用。

为什么需要：这是确定性的 esbuild 编译失败，会让 main 的 CI 变红（见 run 33515371387），删除重复是最小且完整的修复，能解开所有跑 web-shell 套件的 PR。

验证方式：在 main 上跑 web-shell 套件可复现 transform 报错；应用本 PR 后报错消失，由 CI 端到端确认。Evidence：N/A（测试文件编译修复，无可见输出变化）。本地未在各操作系统实测，依赖 CI。

风险与范围：无风险——仅删除两处完全重复的声明，语义不变；不在范围内：本地各 OS 运行；无破坏性变更。

无关联 issue；修复 #10514 / #8583 合并重叠引入的 main CI 红。

</details>
