### PR TITLE
fix(web-shell): proxy standalone/live daemon routes in vite dev

### DIFF
--- a/packages/web-shell/client/vite-config.test.ts
+++ b/packages/web-shell/client/vite-config.test.ts
@@ -65,4 +65,39 @@ describe('Web Shell client source proxy bypass', () => {
       options.bypass?.(request, {} as unknown as ServerResponse, options),
     ).toBe(request.url);
   });
+
+  it('serves live source modules instead of proxying them', () => {
+    const liveProxy = loadConfig().server?.proxy?.['/live'];
+    expect(liveProxy).not.toBeTypeOf('string');
+    expect(liveProxy).toBeDefined();
+    const options = liveProxy as ProxyOptions;
+    const request = {
+      method: 'GET',
+      url: '/live/useLiveVoice.ts',
+      headers: { 'sec-fetch-dest': 'script' },
+    } as unknown as IncomingMessage;
+
+    expect(
+      options.bypass?.(request, {} as unknown as ServerResponse, options),
+    ).toBe(request.url);
+  });
+});
+
+describe('Web Shell daemon API proxy coverage', () => {
+  it.each(['/standalone', '/live'])('proxies %s API routes', (prefix) => {
+    const proxy = loadConfig().server?.proxy?.[prefix];
+    expect(proxy).not.toBeTypeOf('string');
+    expect(proxy).toBeDefined();
+    const options = proxy as ProxyOptions;
+    const request = {
+      method: 'GET',
+      url: `${prefix}/status`,
+      headers: { accept: '*/*' },
+    } as unknown as IncomingMessage;
+
+    // API fetches must NOT bypass to the shell; undefined means "proxy it".
+    expect(
+      options.bypass?.(request, {} as unknown as ServerResponse, options),
+    ).toBeUndefined();
+  });
 });

--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -14,7 +14,8 @@ const daemonProxy: ProxyOptions = {
     if (
       req.method === 'GET' &&
       (req.url?.startsWith('/extensions/') ||
-        req.url?.startsWith('/session-catalog/')) &&
+        req.url?.startsWith('/session-catalog/') ||
+        req.url?.startsWith('/live/')) &&
       /\.(?:[cm]?[jt]sx?|css|map)(?:\?|$)/.test(req.url)
     ) {
       return req.url;
@@ -111,6 +112,15 @@ export default defineConfig(({ command }) => ({
       // routes above — without it the SPA fallback returns index.html in dev and
       // the tab fails JSON parsing on `GET /usage/dashboard`.
       '/usage': daemonProxy,
+      // Standalone-session CRUD (`/standalone/sessions*`) — the sidebar's
+      // standalone sessions list/load/create. Without it the SPA fallback
+      // returns index.html in dev and clicking or creating a standalone
+      // session fails JSON parsing.
+      '/standalone': daemonProxy,
+      // Live voice routes (`/live/status`, `/live/setup`, ...). The prefix
+      // overlaps `client/live/*` source modules; the bypass above exempts
+      // those source files from proxying.
+      '/live': daemonProxy,
       // Voice dictation is a WebSocket (`/voice/stream`); `ws: true` makes the
       // dev proxy forward the HTTP upgrade to the daemon. Scope it to the exact
       // path — a bare `/voice` prefix would shadow the client's own


### PR DESCRIPTION
## What this PR does

Adds the missing `/standalone` and `/live` route prefixes to the Web Shell vite dev-server proxy allowlist, and extends the existing client-source bypass exemption (previously covering `/extensions/` and `/session-catalog/`) to `/live/` so vite keeps serving `client/live/*` source modules.

## Why it's needed

The vite dev proxy only forwards an explicit allowlist of daemon route prefixes. `/standalone/sessions*` and `/live/*` were missing, so in dev mode those API calls fell through to vite's SPA fallback, which serves `index.html` for `Accept: */*` requests. The client then failed JSON parsing with `Unexpected token '<', "<!doctype "... is not valid JSON` — most visibly when clicking a standalone session in the sidebar or creating a new one, and on Live voice status calls. The production daemon is unaffected (its SPA fallback only claims document navigations); this is a dev-mode-only breakage.

## Reviewer Test Plan

### How to verify

1. On `main`, run the daemon (`qwen serve --port 4170 --workspace <dir>`) and the Web Shell dev server (`cd packages/web-shell && npm run dev`), then open the dev URL and click a standalone session in the sidebar (or create a new standalone session) — an error toast `Unexpected token '<', "<!doctype "... is not valid JSON` appears.
2. Equivalent direct probe against the dev server: `curl -s -i -H 'Accept: */*' http://localhost:5173/standalone/sessions` returns `200 text/html` (the SPA shell) before this PR.
3. On this branch, repeat: the same endpoints return the daemon's JSON response (401 without a bearer token), the toast is gone, and standalone sessions load/create normally. `GET /live/useLiveVoice.ts` must still be served by vite as `text/javascript` (client source, not proxied).
4. Unit tests: `cd packages/web-shell && npx vitest run client/vite-config.test.ts` (6 tests pass).

### Evidence (Before & After)

Before (dev server on 5173, unpatched):

```
GET /standalone/sessions?limit=1  -> 200 text/html   (index.html — breaks JSON.parse)
GET /live/status                  -> 200 text/html
```

After (same daemon, vite started from this branch):

```
GET /standalone/sessions?limit=1  -> 401 application/json (daemon reachable; front-end attaches bearer)
GET /live/status                  -> 401 application/json
GET /live/useLiveVoice.ts         -> 200 text/javascript  (client source still served by vite)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `qwen serve` daemon (port 4170) + Web Shell vite dev server; verified both via unit tests and live HTTP probes against a vite instance started from this branch.

## Risk & Scope

- Main risk or tradeoff: the proxy allowlist remains a manual list — future daemon route prefixes need the same treatment; this PR follows the established per-prefix convention rather than redesigning it.
- Not validated / out of scope: other currently-unused-by-the-shell prefixes (e.g. `/acp`, `/language`, `/a2ui`) are also unproxied but have no Web Shell callers today; left as-is.
- Breaking changes / migration notes: none; dev-server config only, no production behavior change.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

给 Web Shell 的 vite 开发服务器代理允许列表补上缺失的 `/standalone` 和 `/live` 路由前缀，并把现有的客户端源码豁免规则（此前覆盖 `/extensions/` 和 `/session-catalog/`）扩展到 `/live/`，使 vite 继续正常服务 `client/live/*` 源码模块。

## 为什么需要

vite 开发代理只转发显式列出的 daemon 路由前缀。`/standalone/sessions*` 和 `/live/*` 之前缺失，导致开发模式下这些 API 请求落入 vite 的 SPA 回退——它对 `Accept: */*` 的请求也返回 `index.html`。客户端随后 JSON 解析失败，报出 `Unexpected token '<', "<!doctype "... is not valid JSON`——最明显的场景是在侧栏点击 standalone 会话或新建会话，以及 Live 语音状态调用。生产 daemon 不受影响（其 SPA 回退只认领文档导航请求）；这只是开发模式下的问题。

## 评审者验证计划

### 如何验证

1. 在 `main` 上启动 daemon（`qwen serve --port 4170 --workspace <dir>`）和 Web Shell 开发服务器（`cd packages/web-shell && npm run dev`），打开开发地址，在侧栏点击一个 standalone 会话（或新建一个）——会出现 `Unexpected token '<', "<!doctype "... is not valid JSON` 的错误提示。
2. 等价直接探测：`curl -s -i -H 'Accept: */*' http://localhost:5173/standalone/sessions` 在本 PR 之前返回 `200 text/html`（SPA 外壳页面）。
3. 在本分支上重复：相同端点返回 daemon 的 JSON 响应（无 bearer token 时为 401），错误提示消失，standalone 会话可正常加载/创建；`GET /live/useLiveVoice.ts` 必须仍由 vite 以 `text/javascript` 服务（客户端源码，未被代理走）。
4. 单元测试：`cd packages/web-shell && npx vitest run client/vite-config.test.ts`（6 个测试通过）。

### 证据（修复前后）

修复前（5173 上的开发服务器，未打补丁）：

```
GET /standalone/sessions?limit=1  -> 200 text/html   (index.html — 导致 JSON.parse 失败)
GET /live/status                  -> 200 text/html
```

修复后（同一 daemon，vite 从本分支启动）：

```
GET /standalone/sessions?limit=1  -> 401 application/json (daemon 可达；前端会附带 bearer)
GET /live/status                  -> 401 application/json
GET /live/useLiveVoice.ts         -> 200 text/javascript  (客户端源码仍由 vite 服务)
```

### 测试平台

macOS 已验证；Windows / Linux 未测试。

### 环境（可选）

本地 `qwen serve` daemon（端口 4170）+ Web Shell vite 开发服务器；通过单元测试和从本分支启动的 vite 实例的实时 HTTP 探测双重验证。

## 风险与范围

- 主要风险或取舍：代理允许列表仍是手工维护的清单——未来新增 daemon 路由前缀需要同样的补充；本 PR 遵循既有的逐前缀惯例，未做重新设计。
- 未验证 / 超出范围：其他目前未被 shell 调用的前缀（如 `/acp`、`/language`、`/a2ui`）同样未被代理，但今天 Web Shell 没有调用方；保持原样。
- 破坏性变更 / 迁移说明：无；仅开发服务器配置，不影响生产行为。

## 关联 Issue

无
</details>
