### PR TITLE
fix(core): validate git pull option combinations and detached HEAD

### DIFF
--- a/docs/design/git-pull-dirty-worktree.md
+++ b/docs/design/git-pull-dirty-worktree.md
@@ -82,9 +82,17 @@ checks the SHA git reports as dropped — git has no identity-addressed
 drop — and if the slots shifted under it, the other entry is `git stash
 store`d back and ours is reported as kept; should even that store fail,
 the displaced entry's SHA and the command that brings it back are in the
-output. Every notice about a kept entry carries its SHA.
+output. Every notice about a kept entry carries its SHA. A stored-back
+entry lands on top of the stack rather than in its old slot — position is
+not part of any identity here, and the output says what happened — so a
+terminal relying on `git stash pop` order should read `git stash list`
+first.
 
-A plain pull — no option — is byte-for-byte the previous behavior.
+A plain pull — no option — runs the exact git invocation it always has;
+the only response-level change is that its `output` is now path-redacted
+like every other response. The three options are mutually exclusive:
+`stash`+`force` and `fetchOnly` combined with either are refused as 400s
+rather than silently dropping one of them.
 
 ## Non-goals (deliberate)
 

--- a/packages/cli/src/serve/routes/workspace-git-branches.test.ts
+++ b/packages/cli/src/serve/routes/workspace-git-branches.test.ts
@@ -107,6 +107,18 @@ describe('workspace Git branch routes', () => {
     expect(response.body.error).toBe('invalid_stash_force');
   });
 
+  it.each([{ stash: true }, { force: true }])(
+    'rejects combining fetchOnly with %o with 400',
+    async (extra) => {
+      const response = await request(app())
+        .post('/workspace/git/pull')
+        .send({ fetchOnly: true, ...extra });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('invalid_fetch_only_combination');
+    },
+  );
+
   it('rejects a checkout with a missing ref with 400', async () => {
     const response = await request(app())
       .post('/workspace/git/checkout')

--- a/packages/cli/src/serve/routes/workspace-git-branches.ts
+++ b/packages/cli/src/serve/routes/workspace-git-branches.ts
@@ -288,6 +288,13 @@ async function handlePull(
     });
     return;
   }
+  if (fetchOnly && (stash || force)) {
+    res.status(400).json({
+      error: 'invalid_fetch_only_combination',
+      message: 'fetchOnly cannot be combined with stash or force',
+    });
+    return;
+  }
   try {
     const result = await gitPull(cwd, { rebase, fetchOnly, stash, force }, env);
     // A successful stash pull can still carry git's notice about a failed

--- a/packages/core/src/utils/git-branches.test.ts
+++ b/packages/core/src/utils/git-branches.test.ts
@@ -921,6 +921,38 @@ describe('gitPull with a dirty working tree', () => {
     );
   });
 
+  it('rejects combining fetchOnly with stash or force instead of dropping them', async () => {
+    const dir = makeRepo();
+    await expect(
+      gitPull(dir, { fetchOnly: true, stash: true }),
+    ).rejects.toThrow(/cannot be combined/);
+    await expect(
+      gitPull(dir, { fetchOnly: true, force: true }),
+    ).rejects.toThrow(/cannot be combined/);
+  });
+
+  it('types the refusal on a detached HEAD without touching anything', async () => {
+    const { dir, clone } = makeUpstream();
+    remoteCommit(clone, 'remote-only.txt', 'remote\n');
+    git(dir, 'checkout', '-q', '--detach', 'HEAD');
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'local edit\n');
+    const headBefore = headSha(dir);
+
+    const stash = await expectPullFailure(
+      gitPull(dir, { stash: true }, hermeticEnv()),
+      'pull_failed',
+    );
+    await expectPullFailure(
+      gitPull(dir, { force: true }, hermeticEnv()),
+      'pull_failed',
+    );
+
+    expect(stash.message).toContain('HEAD is detached');
+    expect(headSha(dir)).toBe(headBefore);
+    expect(read(dir, 'a.txt')).toBe('local edit\n');
+    expect(stashList(dir)).toEqual([]);
+  });
+
   it('refuses stash and force pulls while a merge is in progress, keeping it', async () => {
     const { dir, clone } = makeUpstream();
     remoteCommit(clone, 'a.txt', 'remote\n');

--- a/packages/core/src/utils/git-branches.ts
+++ b/packages/core/src/utils/git-branches.ts
@@ -854,33 +854,13 @@ function pullArgs(opts?: GitPullOptions): string[] {
   return args;
 }
 
-/** The upstream ref configured for the checked-out branch, or ''. */
-async function configuredUpstream(
-  cwd: string,
-  env?: Readonly<Record<string, string | undefined>>,
-): Promise<string> {
-  try {
-    const branch = (
-      await runGit(cwd, ['symbolic-ref', '--quiet', '--short', 'HEAD'], env)
-    ).trim();
-    return (
-      await runGit(
-        cwd,
-        ['for-each-ref', '--format=%(upstream)', `refs/heads/${branch}`],
-        env,
-      )
-    ).trim();
-  } catch {
-    return '';
-  }
-}
-
 /**
  * SHA of the upstream tip, resolved after the flow's own fetch (so a
  * tracking ref pruned earlier is back if the remote branch exists again).
- * A branch with no upstream configured fails with git's own message, as a
- * plain pull always has; a configured upstream whose remote branch is
- * gone is a typed refusal — nothing has been touched at this point.
+ * A detached HEAD and a configured upstream whose remote branch is gone
+ * are typed refusals — nothing has been touched at this point; a branch
+ * with no upstream configured fails with git's own message, as a plain
+ * pull always has.
  */
 async function validatedUpstream(
   cwd: string,
@@ -888,13 +868,35 @@ async function validatedUpstream(
 ): Promise<string> {
   const sha = await upstreamSha(cwd, env);
   if (sha) return sha;
-  if (await configuredUpstream(cwd, env)) {
+  let branch: string;
+  try {
+    branch = (
+      await runGit(cwd, ['symbolic-ref', '--quiet', '--short', 'HEAD'], env)
+    ).trim();
+  } catch {
+    throw new GitPullFailure(
+      'pull_failed',
+      'cannot update: HEAD is detached; check out a branch from a terminal first',
+    );
+  }
+  const configured = (
+    await runGit(
+      cwd,
+      ['for-each-ref', '--format=%(upstream)', `refs/heads/${branch}`],
+      env,
+    ).catch(() => '')
+  ).trim();
+  if (configured) {
     throw new GitPullFailure(
       'pull_failed',
       'cannot update: the upstream branch no longer exists on the remote; nothing was changed',
     );
   }
+  // No upstream is configured: surface git's own message so the route
+  // classifies it as it always has.
   await runGit(cwd, ['rev-parse', '--abbrev-ref', '@{upstream}'], env);
+  // Reachable only when the upstream appeared between the probes; refuse
+  // conservatively instead of proceeding on a tip that was never validated.
   throw new GitPullFailure(
     'pull_failed',
     'cannot update: the upstream branch could not be resolved; nothing was changed',
@@ -1080,6 +1082,12 @@ export async function gitPull(
 ): Promise<GitPullResult> {
   if (opts?.stash && opts?.force) {
     throw new Error('stash and force are mutually exclusive');
+  }
+  if (opts?.fetchOnly && (opts?.stash || opts?.force)) {
+    // A fetch-only request has nothing to stash around or discard for;
+    // refuse rather than silently dropping the resolution the caller
+    // asked for.
+    throw new Error('fetchOnly cannot be combined with stash or force');
   }
   if (opts?.fetchOnly) {
     const output = await runGit(cwd, ['fetch', '--all', '--prune'], env);

--- a/packages/web-shell/client/components/BranchPickerPopover.test.tsx
+++ b/packages/web-shell/client/components/BranchPickerPopover.test.tsx
@@ -644,6 +644,9 @@ describe('BranchPickerPopover actions', () => {
       'cannot discard changes: the workspace is a subdirectory',
     );
     expect(footerText()).toContain('Stash Changes and Update');
+    // The daemon declared discarding impossible for this workspace; the
+    // action is gone rather than looping the same refusal.
+    expect(footerText()).not.toContain('Discard Changes and Update');
     expect(footerText()).not.toContain('Discard and Update');
   });
 

--- a/packages/web-shell/client/components/BranchPickerPopover.tsx
+++ b/packages/web-shell/client/components/BranchPickerPopover.tsx
@@ -300,8 +300,11 @@ export function BranchPickerPopover({
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [pullBlocked, setPullBlocked] = useState(false);
   const [confirmDiscard, setConfirmDiscard] = useState(false);
-  // Daemon explanation shown in the panel instead of the fixed blocked line,
-  // when the refusal carried one worth reading (a discard the daemon refused).
+  // Daemon explanation shown in the panel instead of the fixed blocked line
+  // when the refusal carried one worth reading — a discard the daemon
+  // refused (force_unsupported). While set, the Discard action is hidden:
+  // the daemon has declared it impossible for this workspace, so offering
+  // it again could only loop the same refusal.
   const [pullBlockedDetail, setPullBlockedDetail] = useState<string | null>(
     null,
   );
@@ -1007,14 +1010,16 @@ export function BranchPickerPopover({
                   )}
                   {t('branchPicker.pullStash')}
                 </button>
-                <button
-                  type="button"
-                  className={`${styles.pullBlockedButton} ${styles.pullBlockedButtonDanger}`}
-                  disabled={!!busyAction}
-                  onClick={() => setConfirmDiscard(true)}
-                >
-                  {t('branchPicker.pullDiscard')}
-                </button>
+                {pullBlockedDetail === null && (
+                  <button
+                    type="button"
+                    className={`${styles.pullBlockedButton} ${styles.pullBlockedButtonDanger}`}
+                    disabled={!!busyAction}
+                    onClick={() => setConfirmDiscard(true)}
+                  >
+                    {t('branchPicker.pullDiscard')}
+                  </button>
+                )}
                 <button
                   type="button"
                   className={styles.pullBlockedButton}


### PR DESCRIPTION
## What this PR does

Post-merge review follow-ups for the dirty-worktree git update (#10390), from [the post-merge code review](https://github.com/QwenLM/qwen-code/pull/10390#issuecomment-5487586761):

- **Option combinations are validated instead of silently resolved.** `{ fetchOnly: true, stash: true }` (or `force`) used to perform a bare fetch and drop the resolution the caller asked for, because the `fetchOnly` branch ran first. The route now refuses the combination with `400 invalid_fetch_only_combination`, and `gitPull` carries a mirrored guard, matching the existing `stash`+`force` exclusivity.
- **Detached HEAD is a typed refusal.** A stash/force pull on a detached HEAD surfaced git's raw `HEAD does not point to a branch` through an unclassified 500 (SDK-only surface — the UI already disables the row). It is now `409 pull_failed` ("HEAD is detached; check out a branch from a terminal first"), thrown before anything is touched.
- **`validatedUpstream` restructured.** The branch is resolved once and the configured upstream read inline; the no-upstream tail now documents the one probe race that can reach it instead of looking unreachable.
- **The resolution panel drops Discard after `force_unsupported`.** That refusal is permanent for a subdirectory workspace, so re-offering the action could only loop the same refusal; the panel keeps Stash (still viable) and Cancel, with the daemon's explanation.
- **Design doc**: a stored-back stash entry lands on top of the stack rather than its old slot (position is not identity here), and the plain-pull invariant is stated precisely — same git invocation as before; the `output` is path-redacted like every other response.

## Why it's needed

The silent `fetchOnly` win is the one Important finding from the post-merge review: the feature's own design refuses silent option drops in favor of typed codes, and the SDK now documents these options publicly, so a future caller can hit the combination. The rest closes the review's minor findings while they are fresh.

## Reviewer Test Plan

### How to verify

- Core (`cd packages/core && npx vitest run src/utils/git-branches.test.ts`, **97 passed**, 2 new): `fetchOnly`+`stash`/`force` both reject with "cannot be combined"; a detached-HEAD stash and force pull both refuse as typed `pull_failed` mentioning the detached HEAD, with HEAD, the edit, and the (empty) stash untouched.
- Route (`cd packages/cli && npx vitest run src/serve/routes/workspace-git-branches.test.ts`, **36 passed**, 2 new): both combinations → `400 invalid_fetch_only_combination`.
- Web Shell (`cd packages/web-shell && npx vitest run client/components/BranchPickerPopover.test.tsx`, **42 passed**): the `force_unsupported` panel test now also asserts the Discard action is absent while Stash remains.
- `tsc --noEmit` clean in core, cli, and web-shell; eslint clean on all changed files.

### Evidence (Before & After)

Behavioral surface is API-level plus one panel state reachable only for subdirectory workspaces driven via the SDK; pinned by the component test above rather than screenshots. Before: `POST /workspace/git/pull {"fetchOnly":true,"stash":true}` → 200 with a bare fetch. After: `400 {"error":"invalid_fetch_only_combination"}`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Unit tests against real local git repositories, as in #10390.

## Risk & Scope

- Main risk or tradeoff: the new 400 rejects requests that previously "succeeded" as a bare fetch — that success was a silent misinterpretation, and no in-repo caller sends the combination (the popover sends `stash`/`force` only from the resolution panel).
- Not validated / out of scope: the review's remaining note — verifying `parseDroppedStashSha`'s `Dropped refs/stash@{N} (<sha>)` format against Git for Windows — needs a Windows environment; the shim-based concurrency tests stay `skipIf(win32)`.
- Breaking changes / migration notes: none for documented usage; the option combination was never meaningful.

## Linked Issues

Follow-up to #10390.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

#10390（脏工作区 git 更新）合并后评审的后续修复，来自[合并后代码评审](https://github.com/QwenLM/qwen-code/pull/10390#issuecomment-5487586761)：

- **选项组合改为校验而非静默取舍。** `{ fetchOnly: true, stash: true }`（或 `force`）过去会因 `fetchOnly` 分支先行而只做裸 fetch、丢掉调用方要求的处理方式。路由现在以 `400 invalid_fetch_only_combination` 拒绝该组合，`gitPull` 内有对称守卫，与既有的 `stash`+`force` 互斥一致。
- **游离 HEAD 是 typed 拒绝。** 游离 HEAD 上的 stash/force pull 过去把 git 原始的 `HEAD does not point to a branch` 透传成未分类 500（仅 SDK 面可达——UI 已禁用该行）。现在在动任何东西之前就以 `409 pull_failed`（"HEAD 已游离，请先在终端检出分支"）拒绝。
- **`validatedUpstream` 重构。** 分支只解析一次、内联读取配置的上游；无上游尾部现在明确注明唯一可达它的探测竞态，而不是看起来不可达。
- **`force_unsupported` 后面板不再提供放弃。** 该拒绝对子目录工作区是永久的，再次提供只会循环同一拒绝；面板保留仍可用的 Stash 与取消，并显示 daemon 的解释。
- **设计文档**：回存的 stash 条目落在栈顶而非原槽位（此处位置不代表身份）；精确表述裸 pull 不变量——git 调用与之前完全相同，`output` 与其它响应一样做路径脱敏。

## 为什么需要

`fetchOnly` 静默胜出是合并后评审唯一的 Important 发现：该特性自身的设计就拒绝静默丢弃选项而偏向 typed 错误码，且 SDK 已公开记录这些选项，未来调用方可能踩中该组合。其余改动趁热收掉评审的 Minor 项。

## 评审测试计划

### 如何验证

- Core（`cd packages/core && npx vitest run src/utils/git-branches.test.ts`，**97 通过**，新增 2）：`fetchOnly`+`stash`/`force` 都以 "cannot be combined" 拒绝；游离 HEAD 上的 stash 与 force pull 都以 typed `pull_failed` 拒绝且消息提及游离 HEAD，HEAD、修改与（空）stash 均未动。
- 路由（`cd packages/cli && npx vitest run src/serve/routes/workspace-git-branches.test.ts`，**36 通过**，新增 2）：两种组合 → `400 invalid_fetch_only_combination`。
- Web Shell（`cd packages/web-shell && npx vitest run client/components/BranchPickerPopover.test.tsx`，**42 通过**）：`force_unsupported` 面板用例现在同时断言放弃按钮消失、Stash 保留。
- core、cli、web-shell 三包 `tsc --noEmit` 干净；改动文件 eslint 干净。

### 前后对比证据

行为面在 API 层，外加一个只有子目录工作区经 SDK 才可达的面板状态；由上述组件测试钉住，未截图。改动前：`POST /workspace/git/pull {"fetchOnly":true,"stash":true}` → 200 只做裸 fetch。改动后：`400 {"error":"invalid_fetch_only_combination"}`。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

与 #10390 相同，针对真实本地 git 仓库的单元测试。

## 风险与范围

- 主要风险或权衡：新 400 会拒绝过去"成功"（实为裸 fetch 的静默误解释）的请求；仓库内没有调用方发送该组合（弹窗只在面板内发送 `stash`/`force`）。
- 未验证 / 超出范围：评审剩下的一条——在 Git for Windows 上核对 `parseDroppedStashSha` 的 `Dropped refs/stash@{N} (<sha>)` 消息格式——需要 Windows 环境；垫片并发测试维持 `skipIf(win32)`。
- 破坏性变更 / 迁移说明：对文档化用法无；该选项组合从未有过有意义的语义。

## 关联 Issue

#10390 的后续。

</details>
