### PR TITLE
feat(opentui): bundle assets, CI matrix and parity tooling (Batch 7)

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -59,7 +59,7 @@
 10920 sync-desktop-to-oss.yml
 10018 sync-live-host-to-oss.yml
 10138 sync-release-to-oss.yml
-2190 tui-parity.yml
+2508 tui-parity.yml
 7187 update-ecs-runner-qwen.yml
 2307 web-shell-visuals-cleanup.yml
 20047 web-shell-visuals-publish.yml

--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -59,6 +59,7 @@
 10920 sync-desktop-to-oss.yml
 10018 sync-live-host-to-oss.yml
 10138 sync-release-to-oss.yml
+2190 tui-parity.yml
 7187 update-ecs-runner-qwen.yml
 2307 web-shell-visuals-cleanup.yml
 20047 web-shell-visuals-publish.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -395,9 +395,9 @@ jobs:
       # QWEN_TUI_RENDERER=opentui (plus QWEN_TUI_RENDERER_STRICT) for every
       # spawned CLI, so a boot that silently fell back to ink fails the leg
       # instead of passing as a false green. The version matches
-      # DEFAULT_BUN_VERSION in scripts/build-standalone-release.js (the Bun
-      # standalone archives ship) and is pinned, not 'latest', so an upstream
-      # Bun release cannot flip this gating leg red on its own.
+      # DEFAULT_BUN_VERSION in scripts/build-standalone-release.js (the
+      # --runtime=bun archive flavor) and is pinned, not 'latest', so an
+      # upstream Bun release cannot flip this gating leg red on its own.
       - name: 'Set up Bun'
         uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -394,11 +394,14 @@ jobs:
       # node build cannot load node:ffi. The renderer matrix also pins
       # QWEN_TUI_RENDERER=opentui (plus QWEN_TUI_RENDERER_STRICT) for every
       # spawned CLI, so a boot that silently fell back to ink fails the leg
-      # instead of passing as a false green.
+      # instead of passing as a false green. The version matches
+      # DEFAULT_BUN_VERSION in scripts/build-standalone-release.js (the Bun
+      # standalone archives ship) and is pinned, not 'latest', so an upstream
+      # Bun release cannot flip this gating leg red on its own.
       - name: 'Set up Bun'
         uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
         with:
-          bun-version: 'latest'
+          bun-version: '1.3.14'
 
       - name: 'Configure npm for rate limiting'
         run: |-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -257,14 +257,16 @@ jobs:
               trap 'rm -rf "$TMPDIR" 2>/dev/null || true' EXIT
             fi
           fi
+          # QWEN_E2E_RENDERER=ink pins the baseline leg of the renderer
+          # matrix; the opentui leg runs in e2e-interactive-opentui below.
           # The docker leg runs vitest directly instead of through
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
+            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
           else
             run_shard() {
-              npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
+              QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
             }
             # One bounded retry: pool runners' sandbox:none shards die under
             # shared-host pressure with every test green and no vitest FAIL
@@ -365,7 +367,69 @@ jobs:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-        run: 'npx cross-env VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --shard="${{ matrix.shard }}"'
+        run: 'npx cross-env QWEN_E2E_RENDERER=ink VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --shard="${{ matrix.shard }}"'
+
+  e2e-interactive-opentui:
+    name: 'E2E Interactive - OpenTUI renderer (bun)'
+    runs-on: 'ubuntu-latest'
+    # Same rationale as e2e-test-linux: a wedged run must free the runner.
+    timeout-minutes: 60
+    # Skip on fork PRs (no secrets) — see e2e-test-linux above.
+    if: |-
+      ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+
+      - name: 'Set up Node.js'
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+          registry-url: 'https://registry.npmjs.org/'
+
+      # The opentui renderer leg runs the CLI bundle under bun: the locked
+      # @opentui/core loads its native renderer through bun:ffi, and the CI
+      # node build cannot load node:ffi. The renderer matrix also pins
+      # QWEN_TUI_RENDERER=opentui (plus QWEN_TUI_RENDERER_STRICT) for every
+      # spawned CLI, so a boot that silently fell back to ink fails the leg
+      # instead of passing as a false green.
+      - name: 'Set up Bun'
+        uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
+        with:
+          bun-version: 'latest'
+
+      - name: 'Configure npm for rate limiting'
+        run: |-
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+          npm config set fetch-retries 5
+          npm config set fetch-timeout 300000
+
+      - name: 'Install dependencies'
+        env:
+          QWEN_SKIP_PREPARE: '1'
+        run: |-
+          npm ci --prefer-offline --no-audit --progress=false
+
+      - name: 'Build project'
+        run: |-
+          npm run build
+
+      - name: 'Bundle CLI for E2E tests'
+        run: |-
+          npm run bundle
+
+      - name: 'Run interactive E2E tests (OpenTUI)'
+        env:
+          OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
+          OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
+          OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+          KEEP_OUTPUT: 'true'
+          VERBOSE: 'true'
+        run: |-
+          npx cross-env QWEN_E2E_RENDERER=opentui QWEN_SANDBOX=false vitest run --root ./integration-tests interactive --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts'
 
   isolated-nightly:
     name: '${{ matrix.label }} (nightly)'

--- a/.github/workflows/tui-parity.yml
+++ b/.github/workflows/tui-parity.yml
@@ -1,0 +1,60 @@
+name: 'tui-parity'
+
+on:
+  pull_request:
+    paths:
+      - 'packages/cli/**'
+      - 'scripts/tui-parity/**'
+  workflow_dispatch:
+
+jobs:
+  parity:
+    name: 'TUI parity snapshots (ink vs opentui)'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+      - uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+      - uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
+        with:
+          bun-version: 'latest'
+      - name: 'Install dependencies'
+        env:
+          QWEN_SKIP_PREPARE: '1'
+        run: |-
+          npm ci --prefer-offline --no-audit --progress=false
+      - name: 'Build cli'
+        run: 'npm run build --workspace packages/cli'
+      - name: 'Component parity snapshots (ink vs opentui)'
+        run: 'bash scripts/tui-parity/component-parity.sh'
+
+  noflicker:
+    name: 'OpenTUI no-flicker gate'
+    # No-flicker gate; always runs. With secrets.QWEN_API_KEY it drives a
+    # real model conversation; without it (fork PRs never receive secrets)
+    # accept-noflicker.sh falls back to the offline scripted-stream gate.
+    runs-on: 'ubuntu-latest'
+    env:
+      QWEN_API_KEY: '${{ secrets.QWEN_API_KEY }}'
+    steps:
+      - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
+      - uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+      - uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
+        with:
+          bun-version: 'latest'
+      - name: 'Install dependencies'
+        env:
+          QWEN_SKIP_PREPARE: '1'
+        run: |-
+          npm ci --prefer-offline --no-audit --progress=false
+      - name: 'Build cli'
+        run: 'npm run build --workspace packages/cli'
+      - name: 'OpenTUI no-flicker gate (0 clears, balanced DEC2026)'
+        run: 'bash scripts/tui-parity/accept-noflicker.sh'

--- a/.github/workflows/tui-parity.yml
+++ b/.github/workflows/tui-parity.yml
@@ -18,9 +18,12 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
+      # Pinned to DEFAULT_BUN_VERSION (scripts/build-standalone-release.js),
+      # the Bun standalone archives ship: a gating parity check must not
+      # silently follow 'latest'.
       - uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
         with:
-          bun-version: 'latest'
+          bun-version: '1.3.14'
       - name: 'Install dependencies'
         env:
           QWEN_SKIP_PREPARE: '1'
@@ -46,9 +49,12 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
+      # Pinned to DEFAULT_BUN_VERSION (scripts/build-standalone-release.js),
+      # the Bun standalone archives ship: a gating parity check must not
+      # silently follow 'latest'.
       - uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
         with:
-          bun-version: 'latest'
+          bun-version: '1.3.14'
       - name: 'Install dependencies'
         env:
           QWEN_SKIP_PREPARE: '1'

--- a/.github/workflows/tui-parity.yml
+++ b/.github/workflows/tui-parity.yml
@@ -27,7 +27,7 @@ jobs:
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
       - name: 'Build cli'
-        run: 'npm run build --workspace packages/cli'
+        run: 'npm run build'
       - name: 'Component parity snapshots (ink vs opentui)'
         run: 'bash scripts/tui-parity/component-parity.sh'
 
@@ -55,6 +55,6 @@ jobs:
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
       - name: 'Build cli'
-        run: 'npm run build --workspace packages/cli'
+        run: 'npm run build'
       - name: 'OpenTUI no-flicker gate (0 clears, balanced DEC2026)'
         run: 'bash scripts/tui-parity/accept-noflicker.sh'

--- a/.github/workflows/tui-parity.yml
+++ b/.github/workflows/tui-parity.yml
@@ -18,8 +18,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
-      # Pinned to DEFAULT_BUN_VERSION (scripts/build-standalone-release.js),
-      # the Bun standalone archives ship: a gating parity check must not
+      # Pinned to DEFAULT_BUN_VERSION (scripts/build-standalone-release.js,
+      # the --runtime=bun archive flavor): a gating parity check must not
       # silently follow 'latest'.
       - uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
         with:
@@ -49,8 +49,8 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
-      # Pinned to DEFAULT_BUN_VERSION (scripts/build-standalone-release.js),
-      # the Bun standalone archives ship: a gating parity check must not
+      # Pinned to DEFAULT_BUN_VERSION (scripts/build-standalone-release.js,
+      # the --runtime=bun archive flavor): a gating parity check must not
       # silently follow 'latest'.
       - uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
         with:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,7 @@ export default tseslint.config(
       'docs-site/.next/**',
       'docs-site/out/**',
       '.qwen/**',
+      'scripts/codemod/fixtures/**', // codemod test data; intentionally non-idiomatic ink input/output
       'packages/desktop-shell/runtime/**',
       'packages/desktop-shell/src-tauri/target/**',
       'packages/live-host/**', // standalone Electron app with its own Node test conventions

--- a/integration-tests/interactive/interactive-session.ts
+++ b/integration-tests/interactive/interactive-session.ts
@@ -26,6 +26,11 @@ const { Terminal } = xtermHeadless;
 type Terminal = InstanceType<typeof Terminal>;
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  e2eRendererEnv,
+  pickE2eRenderer,
+  resolveE2eCliCommand,
+} from '../renderer-matrix.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -91,7 +96,13 @@ export class InteractiveSession {
 
     const baseEnv = { ...process.env };
     delete baseEnv['NO_COLOR'];
-    const env = options?.env ?? baseEnv;
+    // The renderer matrix pins QWEN_TUI_RENDERER last so a test's own env
+    // cannot silently switch the renderer mid-matrix.
+    const env = {
+      ...baseEnv,
+      ...options?.env,
+      ...e2eRendererEnv(pickE2eRenderer()),
+    };
 
     const terminal = new Terminal({
       cols,
@@ -101,13 +112,17 @@ export class InteractiveSession {
     });
 
     const bundlePath = join(__dirname, '..', '..', 'dist/cli.js');
-    const ptyProcess = pty.spawn('node', [bundlePath, ...args], {
-      name: 'xterm-256color',
-      cols,
-      rows,
-      cwd,
-      env: env as Record<string, string>,
-    });
+    const ptyProcess = pty.spawn(
+      resolveE2eCliCommand(pickE2eRenderer()),
+      [bundlePath, ...args],
+      {
+        name: 'xterm-256color',
+        cols,
+        rows,
+        cwd,
+        env: env as Record<string, string>,
+      },
+    );
 
     const session = new InteractiveSession(ptyProcess, terminal);
     await session.waitFor('Type your message', 30_000);

--- a/integration-tests/renderer-matrix.test.ts
+++ b/integration-tests/renderer-matrix.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  E2E_RENDERER_ENV_VAR,
+  e2eRendererEnv,
+  pickE2eRenderer,
+  resolveE2eCliCommand,
+} from './renderer-matrix.js';
+
+describe('renderer-matrix', () => {
+  it('defaults to ink so node-only runners keep their behavior', () => {
+    expect(pickE2eRenderer({})).toBe('ink');
+    expect(pickE2eRenderer({ [E2E_RENDERER_ENV_VAR]: '' })).toBe('ink');
+    expect(pickE2eRenderer({ [E2E_RENDERER_ENV_VAR]: 'garbage' })).toBe('ink');
+  });
+
+  it('opts into opentui via QWEN_E2E_RENDERER', () => {
+    expect(pickE2eRenderer({ [E2E_RENDERER_ENV_VAR]: 'opentui' })).toBe(
+      'opentui',
+    );
+    // Whitespace and case are tolerated — humans type these by hand.
+    expect(pickE2eRenderer({ [E2E_RENDERER_ENV_VAR]: '  OpenTUI ' })).toBe(
+      'opentui',
+    );
+  });
+
+  it('pins the renderer through the product env var', () => {
+    expect(e2eRendererEnv('ink')).toEqual({ QWEN_TUI_RENDERER: 'ink' });
+    expect(e2eRendererEnv('opentui')).toEqual({
+      QWEN_TUI_RENDERER: 'opentui',
+      QWEN_TUI_RENDERER_STRICT: '1',
+    });
+  });
+
+  it('uses node for ink', () => {
+    expect(resolveE2eCliCommand('ink')).toBe('node');
+  });
+});

--- a/integration-tests/renderer-matrix.test.ts
+++ b/integration-tests/renderer-matrix.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   E2E_RENDERER_ENV_VAR,
   e2eRendererEnv,
@@ -12,7 +12,21 @@ import {
   resolveE2eCliCommand,
 } from './renderer-matrix.js';
 
+const mockSpawnSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawnSync: mockSpawnSync,
+  };
+});
+
 describe('renderer-matrix', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('defaults to ink so node-only runners keep their behavior', () => {
     expect(pickE2eRenderer({})).toBe('ink');
     expect(pickE2eRenderer({ [E2E_RENDERER_ENV_VAR]: '' })).toBe('ink');
@@ -39,5 +53,28 @@ describe('renderer-matrix', () => {
 
   it('uses node for ink', () => {
     expect(resolveE2eCliCommand('ink')).toBe('node');
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('uses bun for opentui when bun is on PATH', () => {
+    mockSpawnSync.mockReturnValueOnce({ error: null, status: 0 });
+
+    expect(resolveE2eCliCommand('opentui')).toBe('bun');
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'bun',
+      ['--version'],
+      expect.anything(),
+    );
+  });
+
+  it('fails with an actionable error for opentui without bun', () => {
+    mockSpawnSync.mockReturnValueOnce({
+      error: new Error('spawn bun ENOENT'),
+      status: null,
+    });
+
+    expect(() => resolveE2eCliCommand('opentui')).toThrow(
+      /QWEN_E2E_RENDERER=opentui requires bun/,
+    );
   });
 });

--- a/integration-tests/renderer-matrix.ts
+++ b/integration-tests/renderer-matrix.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Renderer matrix for interactive E2E tests.
+ *
+ * `QWEN_E2E_RENDERER` selects which renderer the interactive suite drives:
+ *   - 'ink' (default): node runs dist/cli.js with QWEN_TUI_RENDERER=ink.
+ *   - 'opentui': bun runs dist/cli.js with QWEN_TUI_RENDERER=opentui.
+ *
+ * The overlay pins the renderer for the spawned CLI, and the opentui leg
+ * also sets QWEN_TUI_RENDERER_STRICT: the product gate (selectTuiRenderer)
+ * silently falls back to ink on a runtime that cannot load the native
+ * renderer, and strict mode turns that fallback into a loud startup failure
+ * — so a green opentui run really exercised the OpenTUI renderer, and a
+ * green ink run cannot have been served by a fallback.
+ *
+ * The default stays 'ink' until the ink removal lands: every existing
+ * runner (node-only CI legs, developer machines without bun) keeps its
+ * current behavior, and the opentui leg is opted into via env or the
+ * `test:integration:interactive:opentui:*` scripts.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+export type E2eRenderer = 'ink' | 'opentui';
+
+export const E2E_RENDERER_ENV_VAR = 'QWEN_E2E_RENDERER';
+
+export function pickE2eRenderer(
+  env: NodeJS.ProcessEnv = process.env,
+): E2eRenderer {
+  const requested = env[E2E_RENDERER_ENV_VAR]?.trim().toLowerCase();
+  if (requested === 'opentui') return 'opentui';
+  return 'ink';
+}
+
+/**
+ * Command that launches the CLI bundle under the selected renderer: node for
+ * ink, bun for opentui (the locked @opentui/core needs bun:ffi — CI node
+ * builds cannot load node:ffi).
+ */
+export function resolveE2eCliCommand(renderer: E2eRenderer): string {
+  if (renderer === 'ink') return 'node';
+  const probe = spawnSync('bun', ['--version'], { encoding: 'utf-8' });
+  if (probe.error || probe.status !== 0) {
+    throw new Error(
+      `${E2E_RENDERER_ENV_VAR}=opentui requires bun to load the OpenTUI ` +
+        `native renderer, but \`bun\` was not found on PATH. Install bun ` +
+        `(https://bun.sh) or unset ${E2E_RENDERER_ENV_VAR}.`,
+    );
+  }
+  return 'bun';
+}
+
+/**
+ * Env overlay pinning the renderer for a spawned CLI process. The opentui
+ * leg carries QWEN_TUI_RENDERER_STRICT so a boot-time ink fallback fails the
+ * run instead of passing as a false green (see the module docs).
+ */
+export function e2eRendererEnv(renderer: E2eRenderer): Record<string, string> {
+  if (renderer === 'opentui') {
+    return { QWEN_TUI_RENDERER: renderer, QWEN_TUI_RENDERER_STRICT: '1' };
+  }
+  return { QWEN_TUI_RENDERER: renderer };
+}

--- a/integration-tests/test-helper.ts
+++ b/integration-tests/test-helper.ts
@@ -15,6 +15,11 @@ import { EOL } from 'node:os';
 import * as pty from '@lydell/node-pty';
 import stripAnsi from 'strip-ansi';
 import type { FakeOpenAIServerOptions } from './fake-openai-server.js';
+import {
+  e2eRendererEnv,
+  pickE2eRenderer,
+  resolveE2eCliCommand,
+} from './renderer-matrix.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -903,7 +908,16 @@ export class TestRig {
     ptyProcess: pty.IPty;
     promise: Promise<{ exitCode: number; signal?: number; output: string }>;
   } {
-    const { command, initialArgs } = this._getCommandAndArgs(['--yolo']);
+    const renderer = pickE2eRenderer();
+    const { command: cliCommand, initialArgs } = this._getCommandAndArgs([
+      '--yolo',
+    ]);
+    // The renderer matrix swaps node for bun only when driving the repo
+    // bundle directly; installed-release runs keep their own launcher and
+    // still get the pinned QWEN_TUI_RENDERER below.
+    const isNpmRelease =
+      process.env.INTEGRATION_TEST_USE_INSTALLED_GEMINI === 'true';
+    const command = isNpmRelease ? cliCommand : resolveE2eCliCommand(renderer);
     const commandArgs = [...initialArgs, ...args];
 
     this._interactiveOutput = ''; // Reset output for the new run
@@ -913,7 +927,10 @@ export class TestRig {
       cols: 80,
       rows: 30,
       cwd: this.testDir!,
-      env: process.env as { [key: string]: string },
+      env: {
+        ...process.env,
+        ...e2eRendererEnv(renderer),
+      } as { [key: string]: string },
     });
 
     ptyProcess.onData((data) => {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:integration:cli:sandbox:none": "cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests cli",
     "test:integration:cli:sandbox:docker": "cross-env QWEN_SANDBOX=docker npm run build:sandbox && QWEN_SANDBOX=docker vitest run --root ./integration-tests cli",
     "test:integration:interactive:sandbox:none": "cross-env QWEN_SANDBOX=false vitest run --root ./integration-tests interactive",
+    "test:integration:interactive:opentui:sandbox:none": "cross-env QWEN_E2E_RENDERER=opentui QWEN_SANDBOX=false vitest run --root ./integration-tests interactive",
     "test:integration:interactive:sandbox:docker": "cross-env QWEN_SANDBOX=docker npm run build:sandbox && QWEN_SANDBOX=docker vitest run --root ./integration-tests interactive",
     "test:terminal-bench": "cross-env VERBOSE=true KEEP_OUTPUT=true vitest run --config ./vitest.terminal-bench.config.ts --root ./integration-tests",
     "test:terminal-bench:oracle": "cross-env VERBOSE=true KEEP_OUTPUT=true vitest run --config ./vitest.terminal-bench.config.ts --root ./integration-tests -t 'oracle'",

--- a/packages/cli/scripts/opentui-command-parity.ts
+++ b/packages/cli/scripts/opentui-command-parity.ts
@@ -1,0 +1,44 @@
+/**
+ * Functional parity matrix (M5-②): build a REAL Config from the user's
+ * ~/.qwen/settings.json (loadSettings + loadCliConfig), load the interactive
+ * command registry exactly as the OpenTUI dispatcher does, and assert the key
+ * slash commands are present. This is the functional (command-surface) parity
+ * guard. Run: bun packages/cli/scripts/opentui-command-parity.ts
+ */
+import { loadSettings } from '../src/config/settings.js';
+import { loadCliConfig } from '../src/config/config.js';
+import { loadInteractiveCommands } from '../src/ui/opentui/slash-dispatch.js';
+
+const KEY_COMMANDS = [
+  'help',
+  'stats',
+  'skills',
+  'model',
+  'theme',
+  'settings',
+  'permissions',
+  'approval-mode',
+  'effort',
+  'memory',
+  'statusline',
+  'clear',
+];
+
+async function main() {
+  const cwd = process.cwd();
+  const loaded = loadSettings(cwd);
+  const config = await loadCliConfig(loaded.merged as never, {} as never, cwd);
+  const cmds = await loadInteractiveCommands(config);
+  const names = new Set(cmds.map((c) => c.name));
+  console.log(`interactive commands loaded: ${names.size}`);
+  let ok = true;
+  for (const k of KEY_COMMANDS) {
+    const present = names.has(k);
+    console.log(`/${k.padEnd(14)} ${present ? 'Y' : 'N'}`);
+    if (!present) ok = false;
+  }
+  console.log(ok ? 'COMMAND PARITY PASS' : 'COMMAND PARITY FAIL');
+  process.exit(ok ? 0 : 1);
+}
+
+void main();

--- a/packages/cli/scripts/opentui-component-parity.tsx
+++ b/packages/cli/scripts/opentui-component-parity.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable no-control-regex, react/no-unknown-property */
+/** @jsxImportSource @opentui/react */
+/**
+ * Component-level parity snapshot (M5): renders the SAME logical fragment under
+ * the original Ink renderer (ink-testing-library lastFrame) and the OpenTUI
+ * port (headless test renderer captureCharFrame), strips ANSI, and compares
+ * layout/text. Run with: bun packages/cli/scripts/opentui-component-parity.tsx
+ * Exit 0 = parity, 1 = drift.
+ */
+import { createElement } from 'react';
+import { render as inkRender } from 'ink-testing-library';
+import { Box as IBox, Text as IText } from 'ink';
+import { testRender } from '@opentui/react/test-utils';
+
+const stripAnsi = (s: string) =>
+  s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+const norm = (s: string) =>
+  stripAnsi(s)
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => l.trim() !== '')
+    .join('\n');
+
+// Reference: the ink StatsDisplay StatRow shape (28-wide label gutter + value).
+const inkNode = createElement(
+  IBox,
+  null,
+  createElement(IBox, { width: 28 }, createElement(IText, null, 'Session ID:')),
+  createElement(IText, null, 'abc-123'),
+);
+
+// The OpenTUI port equivalent (Row in dialogs-stats-skills).
+const opentuiNode = (
+  <box flexDirection="row">
+    <box width={28}>
+      <text>{'Session ID:'}</text>
+    </box>
+    <box flexGrow={1}>
+      <text>{'abc-123'}</text>
+    </box>
+  </box>
+);
+
+async function main() {
+  const ink = inkRender(inkNode as never);
+  const inkFrame = norm(ink.lastFrame() ?? '');
+  const setup = await testRender(opentuiNode as never, {
+    width: 60,
+    height: 5,
+  });
+  await (setup as { waitForVisualIdle?: () => Promise<unknown> })
+    .waitForVisualIdle?.()
+    .catch(() => {});
+  const otFrame = norm(
+    (setup as { captureCharFrame: () => string }).captureCharFrame(),
+  );
+  console.log('--- ink ---\n' + inkFrame);
+  console.log('--- opentui ---\n' + otFrame);
+  const pass = inkFrame === otFrame;
+  console.log(pass ? 'PARITY PASS' : 'PARITY FAIL');
+  process.exit(pass ? 0 : 1);
+}
+
+void main();

--- a/packages/cli/scripts/opentui-demo-harness.tsx
+++ b/packages/cli/scripts/opentui-demo-harness.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable react/no-unknown-property */
+/** @jsxImportSource @opentui/react */
+/**
+ * Offline no-flicker harness: mounts a representative streaming transcript on
+ * a real CLI renderer so a PTY capture can measure the actual emitted byte
+ * stream (full-screen clears, DEC 2026 balance). Needs no model credentials,
+ * so it runs on fork PRs where secrets.QWEN_API_KEY is unavailable — the
+ * live-model equivalent drives `packages/cli/dist/index.js` with
+ * QWEN_TUI_RENDERER=opentui (opentui-noflicker.scenario.json). Exits cleanly
+ * on its own — the runner treats timed-out captures as failures.
+ *
+ * Lives under packages/cli (like the other opentui parity scripts) so bun
+ * resolves @opentui/* from the workspace's node_modules.
+ *
+ * Run with: bun packages/cli/scripts/opentui-demo-harness.tsx
+ */
+import { useEffect, useState } from 'react';
+import { createCliRenderer } from '@opentui/core';
+import { createRoot } from '@opentui/react';
+
+const DEMO_RUN_MS = 20000;
+const CHUNK_DELAY_MS = 80;
+
+// Scripted "model reply": streamed in line chunks at a chat-like cadence,
+// with a fenced code block and a dim status line so the capture exercises
+// more than one style of frame update.
+const SCRIPT = [
+  'The OpenTUI renderer keeps a virtual scrollbox as the single',
+  'viewport: ink patch mode and the <Static> escape hatch are',
+  'retired on this path.',
+  '',
+  'Cell-level diffing means a streaming reply only repaints the',
+  'cells that changed — never the whole screen:',
+  '',
+  '```',
+  'while (incoming) {',
+  '  const cells = diff(prevFrame, nextFrame);',
+  '  write(coalesce(cells)); // zero erase sequences',
+  '}',
+  '```',
+  '',
+  'DEC 2026 synchronized output frames the update so the terminal',
+  'never shows a half-painted screen, and the byte stream stays',
+  'balanced: one begin, one end, every time.',
+  '',
+  'Mouse selection, wheel scrolling and caret placement are',
+  'first-class: hover highlights, drag selects, copy on release.',
+  '',
+  'This stream is scripted; it exists so the no-flicker gate can',
+  'measure the renderer without model credentials.',
+];
+
+function DemoStream() {
+  const [sent, setSent] = useState(1);
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setSent((n) => (n >= SCRIPT.length ? n : n + 1));
+    }, CHUNK_DELAY_MS);
+    return () => clearInterval(timer);
+  }, []);
+  return (
+    <box flexDirection="column" padding={1}>
+      {SCRIPT.slice(0, sent).map((line, index) => (
+        <text key={index}>{line}</text>
+      ))}
+      <box marginTop={1}>
+        <text fg="#808080">
+          {sent >= SCRIPT.length ? 'Ready.' : 'Streaming…'}
+        </text>
+      </box>
+    </box>
+  );
+}
+
+// Same renderer construction the product entry uses (start-opentui-ui.tsx):
+// no Ctrl-C exit (the harness stops itself), mouse enabled.
+const renderer = await createCliRenderer({
+  exitOnCtrlC: false,
+  useMouse: true,
+});
+createRoot(renderer).render(<DemoStream />);
+setTimeout(() => process.exit(0), DEMO_RUN_MS);

--- a/packages/cli/scripts/opentui-stats-parity.tsx
+++ b/packages/cli/scripts/opentui-stats-parity.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable no-control-regex */
+/** @jsxImportSource @opentui/react */
+/**
+ * Real-component cross-renderer parity snapshot (M5): renders the ORIGINAL ink
+ * StatsDisplay (inside SessionStatsProvider) and the OpenTUI port
+ * (OpenTuiStatsDialog) with the SAME (reset) uiTelemetryService, then asserts
+ * the shared Session rows/labels appear in BOTH frames. Whole-frame equality is
+ * the wrong assertion for a port (cosmetic chrome differs); row-level presence
+ * of the same data is the meaningful cross-renderer check.
+ * Run: bun packages/cli/scripts/opentui-stats-parity.tsx  (exit 0 = parity)
+ */
+import { createElement } from 'react';
+import { render as inkRender } from 'ink-testing-library';
+import { uiTelemetryService } from '@qwen-code/qwen-code-core';
+import { testRender } from '@opentui/react/test-utils';
+import { SessionStatsProvider } from '../src/ui/contexts/SessionContext.js';
+import { SessionTab } from '../src/ui/components/StatsSessionTab.js';
+import { OpenTuiStatsDialog } from '../src/ui/opentui/dialogs-stats-skills.js';
+
+const stripAnsi = (s: string) =>
+  s.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+
+const LABELS = [
+  'Interaction Summary',
+  'Performance',
+  'Session ID:',
+  'Tool Calls:',
+  'Success Rate:',
+  'Tokens',
+];
+
+async function main() {
+  uiTelemetryService.reset();
+
+  const ink = inkRender(
+    createElement(SessionStatsProvider, null, createElement(SessionTab)),
+  );
+  const inkFrame = stripAnsi(ink.lastFrame() ?? '');
+
+  const setup = await testRender(
+    <OpenTuiStatsDialog config={undefined} onClose={() => {}} />,
+    { width: 90, height: 40 },
+  );
+  await (setup as { waitForVisualIdle?: () => Promise<unknown> })
+    .waitForVisualIdle?.()
+    .catch(() => {});
+  const otFrame = stripAnsi(
+    (setup as { captureCharFrame: () => string }).captureCharFrame(),
+  );
+
+  let ok = true;
+  for (const label of LABELS) {
+    const inInk = inkFrame.includes(label);
+    const inOt = otFrame.includes(label);
+    console.log(
+      `${label.padEnd(22)} ink=${inInk ? 'Y' : 'N'} opentui=${inOt ? 'Y' : 'N'}`,
+    );
+    if (!inInk || !inOt) ok = false;
+  }
+  console.log(ok ? 'STATS PARITY PASS' : 'STATS PARITY FAIL');
+  process.exit(ok ? 0 : 1);
+}
+
+void main();

--- a/packages/cli/src/llm.test.tsx
+++ b/packages/cli/src/llm.test.tsx
@@ -63,6 +63,14 @@ const lspConfigWatcherMock = vi.hoisted(() => ({
     stopWatching: ReturnType<typeof vi.fn>;
   }>,
 }));
+const mockSelectTuiRenderer = vi.hoisted(() =>
+  vi.fn(() => ({
+    renderer: 'ink' as 'ink' | 'opentui',
+    reason: 'no renderer requested',
+    strict: false,
+  })),
+);
+const mockStartOpenTuiUI = vi.hoisted(() => vi.fn());
 
 const sessionRegistryConfigStub = {
   getTargetDir: () => '/tmp/project',
@@ -279,6 +287,24 @@ vi.mock('./config/extension-file-watcher.js', () => ({
     stopWatching() {}
   },
 }));
+
+// The OpenTUI entry touches the native FFI at module scope — it must never
+// load inside this suite, so the mock is total (no importOriginal).
+vi.mock('./ui/opentui/start-opentui-ui.js', () => ({
+  startOpenTuiUI: mockStartOpenTuiUI,
+}));
+
+// Only the gate function is replaced; the real module supplies the env-var
+// name constants the dispatch error messages are asserted against. The
+// default keeps every pre-existing main() test on the ink path.
+vi.mock('./ui/opentui/renderer-selection.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./ui/opentui/renderer-selection.js')>();
+  return {
+    ...actual,
+    selectTuiRenderer: mockSelectTuiRenderer,
+  };
+});
 
 function withLspDisabledConfig<T extends object>(
   config: T,
@@ -1638,6 +1664,214 @@ describe('llm.tsx main function', () => {
     expect(mockStartNonInteractiveOpenAILogHousekeeping).toHaveBeenCalledTimes(
       2,
     );
+  });
+});
+
+describe('llm.tsx OpenTUI renderer dispatch', () => {
+  let originalEnvNoRelaunch: string | undefined;
+  let initialSigintListeners: NodeJS.SignalsListener[];
+  let initialSigtermListeners: NodeJS.SignalsListener[];
+
+  beforeEach(() => {
+    originalEnvNoRelaunch = process.env['QWEN_CODE_NO_RELAUNCH'];
+    process.env['QWEN_CODE_NO_RELAUNCH'] = 'true';
+    initialSigintListeners = process.listeners(
+      'SIGINT',
+    ) as NodeJS.SignalsListener[];
+    initialSigtermListeners = process.listeners(
+      'SIGTERM',
+    ) as NodeJS.SignalsListener[];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (!(process.stdin as any).setRawMode) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.stdin as any).setRawMode = vi.fn();
+    }
+    vi.spyOn(process.stdin, 'setRawMode');
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    Object.defineProperty(process.stdin, 'isRaw', {
+      value: false,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    for (const listener of process.listeners('SIGINT')) {
+      if (
+        !initialSigintListeners.includes(listener as NodeJS.SignalsListener)
+      ) {
+        process.removeListener('SIGINT', listener);
+      }
+    }
+    for (const listener of process.listeners('SIGTERM')) {
+      if (
+        !initialSigtermListeners.includes(listener as NodeJS.SignalsListener)
+      ) {
+        process.removeListener('SIGTERM', listener);
+      }
+    }
+    if (originalEnvNoRelaunch !== undefined) {
+      process.env['QWEN_CODE_NO_RELAUNCH'] = originalEnvNoRelaunch;
+    } else {
+      delete process.env['QWEN_CODE_NO_RELAUNCH'];
+    }
+    vi.restoreAllMocks();
+  });
+
+  // Drives main() to the renderer dispatch: interactive config, no
+  // relaunch, TTY stdin — the same harness the kitty-protocol tests use.
+  const interactiveMainSetup = async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const initializerModule = await import('./core/initializer.js');
+    const initializeAppSpy = vi
+      .spyOn(initializerModule, 'initializeApp')
+      .mockResolvedValue({
+        authError: null,
+        themeError: null,
+        shouldOpenAuthDialog: false,
+        memoryFileCount: 0,
+      });
+    vi.mocked(loadCliConfig).mockResolvedValue({
+      ...sessionRegistryConfigStub,
+      isInteractive: () => true,
+      getQuestion: () => '',
+      getSandbox: () => false,
+      getDebugMode: () => false,
+      getListExtensions: () => false,
+      getMcpServers: () => ({}),
+      getTopTierMcpServers: () => undefined,
+      getModelProvidersConfig: () => undefined,
+      initialize: vi.fn(),
+      waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getScreenReader: () => false,
+      getMemoryFileCount: () => 0,
+      getWarnings: () => [],
+      isSafeMode: () => false,
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getUsageStatisticsEnabled: () => true,
+      getSessionId: () => 'test-session-id',
+      isTelemetryInitializationDeferred: () => true,
+    } as unknown as Config);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(parseArguments).mockResolvedValue({
+      model: undefined,
+      sandbox: undefined,
+      sandboxImage: undefined,
+      debug: undefined,
+      prompt: undefined,
+      promptInteractive: undefined,
+      systemPrompt: undefined,
+      appendSystemPrompt: undefined,
+      outputStyle: undefined,
+      query: undefined,
+      yolo: undefined,
+      bare: undefined,
+      approvalMode: undefined,
+      telemetry: undefined,
+      telemetryTarget: undefined,
+      telemetryOtlpEndpoint: undefined,
+      telemetryOtlpProtocol: undefined,
+      telemetryLogPrompts: undefined,
+      telemetryOutfile: undefined,
+      allowedMcpServerNames: undefined,
+      mcpConfig: undefined,
+      allowedTools: undefined,
+      acp: undefined,
+      experimentalAcp: undefined,
+      extensions: undefined,
+      listExtensions: undefined,
+      openaiLogging: undefined,
+      openaiApiKey: undefined,
+      openaiBaseUrl: undefined,
+      openaiLoggingDir: undefined,
+      proxy: undefined,
+      includeDirectories: undefined,
+      screenReader: undefined,
+      inputFormat: undefined,
+      outputFormat: undefined,
+      includePartialMessages: undefined,
+      continue: undefined,
+      resume: undefined,
+      coreTools: undefined,
+      excludeTools: undefined,
+      disabledSlashCommands: undefined,
+      authType: undefined,
+      maxSessionTurns: undefined,
+      maxWallTime: undefined,
+      maxToolCalls: undefined,
+      maxSubagentDepth: undefined,
+      experimentalLsp: undefined,
+      restoreAskUserQuestion: undefined,
+      channel: undefined,
+      chatRecording: undefined,
+      sessionId: undefined,
+      fallbackModel: undefined,
+    });
+    return initializeAppSpy;
+  };
+
+  const selectOpentui = (strict: boolean) => {
+    mockSelectTuiRenderer.mockReturnValueOnce({
+      renderer: 'opentui',
+      reason: 'requested via QWEN_TUI_RENDERER=opentui',
+      strict,
+    });
+  };
+
+  it('strict mode fails loudly when the OpenTUI entry declines to start', async () => {
+    await interactiveMainSetup();
+    selectOpentui(true);
+    mockStartOpenTuiUI.mockResolvedValue(false);
+
+    await expect(main()).rejects.toThrow(
+      /QWEN_TUI_RENDERER_STRICT forbids the ink fallback/,
+    );
+    // The dispatch rejected before the ink UI could mount.
+    expect(mockStartPostRenderPrefetches).not.toHaveBeenCalled();
+  });
+
+  it('strict mode rethrows OpenTUI boot failures', async () => {
+    await interactiveMainSetup();
+    selectOpentui(true);
+    const bootError = new Error('opentui boot exploded');
+    mockStartOpenTuiUI.mockRejectedValue(bootError);
+
+    await expect(main()).rejects.toThrow('opentui boot exploded');
+    expect(mockStartPostRenderPrefetches).not.toHaveBeenCalled();
+  });
+
+  it('falls back to ink without strict mode when the OpenTUI entry declines', async () => {
+    await interactiveMainSetup();
+    selectOpentui(false);
+    // The entry writes its own stderr warning when it declines; llm.tsx
+    // only falls through to startInteractiveUI, proven by the post-render
+    // prefetch hook inside it running.
+    mockStartOpenTuiUI.mockResolvedValue(false);
+
+    await main();
+
+    expect(mockStartPostRenderPrefetches).toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/llm.tsx
+++ b/packages/cli/src/llm.tsx
@@ -1213,7 +1213,7 @@ export async function main() {
       // is load-bearing: importing the entry evaluates opentui modules whose
       // module scope touches the native FFI, which can still throw on a
       // runtime that passed the version gate.
-      const { selectTuiRenderer } = await import(
+      const { selectTuiRenderer, TUI_RENDERER_STRICT_ENV_VAR } = await import(
         './ui/opentui/renderer-selection.js'
       );
       const selection = selectTuiRenderer();
@@ -1237,7 +1237,18 @@ export async function main() {
             clearCorruptionEnvVars();
             return;
           }
+          // The entry returned false: it already warned on stderr. Strict
+          // mode turns that fallback into a loud failure too, so an E2E
+          // renderer-matrix leg cannot pass green on ink.
+          if (selection.strict) {
+            throw new Error(
+              `OpenTUI failed to start and ${TUI_RENDERER_STRICT_ENV_VAR} forbids the ink fallback`,
+            );
+          }
         } catch (err) {
+          if (selection.strict) {
+            throw err;
+          }
           debugLogger.error('OpenTUI boot failed; falling back to ink:', err);
           writeStderrLine(
             `Warning: OpenTUI failed to start — ${err instanceof Error ? err.message : String(err)} (falling back to ink)`,

--- a/packages/cli/src/ui/opentui/opentui-assets.test.ts
+++ b/packages/cli/src/ui/opentui/opentui-assets.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Verifies the OpenTUI asset relocation gate that restores tree-sitter
+ * syntax highlighting in bundled builds: the package name / asset-key
+ * derivation and the all-or-nothing `OTUI_ASSET_ROOT` activation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import {
+  OPENTUI_ASSETS_DIRNAME,
+  configureOpenTuiAssetRoot,
+  openTuiNativeAssetPackageName,
+  requiredOpenTuiAssetKeys,
+} from './opentui-assets.js';
+
+describe('openTuiNativeAssetPackageName', () => {
+  it('mirrors @opentui/core platform package naming', () => {
+    expect(openTuiNativeAssetPackageName('darwin', 'arm64', {})).toBe(
+      '@opentui/core-darwin-arm64',
+    );
+    expect(openTuiNativeAssetPackageName('darwin', 'x64', {})).toBe(
+      '@opentui/core-darwin-x64',
+    );
+    expect(openTuiNativeAssetPackageName('linux', 'x64', {})).toBe(
+      '@opentui/core-linux-x64',
+    );
+    expect(openTuiNativeAssetPackageName('win32', 'x64', {})).toBe(
+      '@opentui/core-win32-x64',
+    );
+  });
+
+  it('selects the musl variant only on Linux with OPENTUI_LIBC=musl', () => {
+    expect(
+      openTuiNativeAssetPackageName('linux', 'arm64', { OPENTUI_LIBC: 'musl' }),
+    ).toBe('@opentui/core-linux-arm64-musl');
+    expect(
+      openTuiNativeAssetPackageName('linux', 'x64', { OPENTUI_LIBC: 'glibc' }),
+    ).toBe('@opentui/core-linux-x64');
+    expect(
+      openTuiNativeAssetPackageName('darwin', 'arm64', {
+        OPENTUI_LIBC: 'musl',
+      }),
+    ).toBe('@opentui/core-darwin-arm64');
+  });
+
+  it('returns undefined outside the supported platform/arch matrix', () => {
+    expect(openTuiNativeAssetPackageName('freebsd', 'x64', {})).toBeUndefined();
+    expect(openTuiNativeAssetPackageName('darwin', 'ia32', {})).toBeUndefined();
+  });
+});
+
+describe('requiredOpenTuiAssetKeys', () => {
+  it('covers the native library, parser worker, grammars and wasm runtime', () => {
+    const keys = requiredOpenTuiAssetKeys('darwin', 'arm64', {});
+    expect(keys).toBeDefined();
+    expect(keys).toContain('@opentui/core-darwin-arm64/libopentui.dylib');
+    expect(keys).toContain('@opentui/core/parser.worker.js');
+    expect(keys).toContain('web-tree-sitter/tree-sitter.wasm');
+    expect(keys).toContain(
+      '@opentui/core/assets/markdown/tree-sitter-markdown.wasm',
+    );
+    expect(keys).toContain(
+      '@opentui/core/assets/typescript/tree-sitter-typescript.wasm',
+    );
+  });
+
+  it('uses the platform library file name', () => {
+    expect(requiredOpenTuiAssetKeys('linux', 'x64', {})).toContain(
+      '@opentui/core-linux-x64/libopentui.so',
+    );
+    expect(requiredOpenTuiAssetKeys('win32', 'x64', {})).toContain(
+      '@opentui/core-win32-x64/opentui.dll',
+    );
+  });
+
+  it('returns undefined on unsupported platforms', () => {
+    expect(requiredOpenTuiAssetKeys('aix', 'ppc64', {})).toBeUndefined();
+  });
+});
+
+describe('configureOpenTuiAssetRoot', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'opentui-assets-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /** Writes every required asset file under `<bundleDir>/opentui-assets`. */
+  function seedCompleteTree(bundleDir: string, platform: string): void {
+    const keys = requiredOpenTuiAssetKeys(platform, 'arm64', {}) ?? [];
+    for (const key of keys) {
+      const filePath = join(bundleDir, OPENTUI_ASSETS_DIRNAME, key);
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(filePath, 'asset');
+    }
+  }
+
+  it('sets OTUI_ASSET_ROOT when the relocated tree is complete', () => {
+    seedCompleteTree(tempDir, 'darwin');
+    const env: NodeJS.ProcessEnv = {};
+    const root = configureOpenTuiAssetRoot(tempDir, env, 'darwin', 'arm64');
+    expect(root).toBe(join(tempDir, OPENTUI_ASSETS_DIRNAME));
+    expect(env['OTUI_ASSET_ROOT']).toBe(join(tempDir, OPENTUI_ASSETS_DIRNAME));
+  });
+
+  it('leaves the environment alone when any asset is missing', () => {
+    seedCompleteTree(tempDir, 'darwin');
+    // Remove one grammar file: the gate must refuse rather than point
+    // OTUI_ASSET_ROOT at an incomplete tree (@opentui/core throws on any
+    // missing key under a configured root).
+    rmSync(
+      join(
+        tempDir,
+        OPENTUI_ASSETS_DIRNAME,
+        '@opentui/core/assets/markdown/tree-sitter-markdown.wasm',
+      ),
+    );
+    const env: NodeJS.ProcessEnv = {};
+    const root = configureOpenTuiAssetRoot(tempDir, env, 'darwin', 'arm64');
+    expect(root).toBeUndefined();
+    expect(env['OTUI_ASSET_ROOT']).toBeUndefined();
+  });
+
+  it('leaves the environment alone when the asset dir does not exist', () => {
+    const env: NodeJS.ProcessEnv = {};
+    expect(
+      configureOpenTuiAssetRoot(tempDir, env, 'darwin', 'arm64'),
+    ).toBeUndefined();
+    expect(env['OTUI_ASSET_ROOT']).toBeUndefined();
+  });
+
+  it('keeps a pre-existing OTUI_ASSET_ROOT untouched', () => {
+    seedCompleteTree(tempDir, 'darwin');
+    const env: NodeJS.ProcessEnv = { OTUI_ASSET_ROOT: '/custom/root' };
+    const root = configureOpenTuiAssetRoot(tempDir, env, 'darwin', 'arm64');
+    expect(root).toBe('/custom/root');
+    expect(env['OTUI_ASSET_ROOT']).toBe('/custom/root');
+  });
+
+  it('skips unsupported platforms even with a complete tree', () => {
+    seedCompleteTree(tempDir, 'darwin');
+    const env: NodeJS.ProcessEnv = {};
+    expect(
+      configureOpenTuiAssetRoot(tempDir, env, 'sunos', 'sparc'),
+    ).toBeUndefined();
+    expect(env['OTUI_ASSET_ROOT']).toBeUndefined();
+  });
+});

--- a/packages/cli/src/ui/opentui/opentui-assets.ts
+++ b/packages/cli/src/ui/opentui/opentui-assets.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OpenTUI runtime asset relocation for bundled builds.
+ *
+ * @opentui/core resolves its tree-sitter assets (parser worker, grammar
+ * wasm/scm files, `web-tree-sitter/tree-sitter.wasm`, the native render
+ * library) through `OTUI_ASSET_ROOT` when that variable is set, and falls
+ * back to package-relative paths (`new URL('./assets/…', import.meta.url)`)
+ * otherwise. The package-relative fallback works when @opentui/core lives in
+ * `node_modules`, but in the esbuild single-file bundle `import.meta.url`
+ * points into `dist/`, so every asset lookup misses and code-block syntax
+ * highlighting silently degrades to single-color output.
+ *
+ * The bundle step (`scripts/copy_bundle_assets.js`) therefore ships the
+ * assets next to the bundle under `<bundleDir>/opentui-assets/<asset key>`,
+ * and THIS module points `OTUI_ASSET_ROOT` at that directory — but only when
+ * the directory is complete for the current platform. Setting the variable
+ * with any key missing would make @opentui/core throw on every lookup
+ * (including the native library), so an incomplete tree falls back to the
+ * package-relative behavior instead.
+ *
+ * This module must initialize before `@opentui/core` is imported anywhere:
+ * the native-library path is resolved during @opentui/core's own module
+ * evaluation. `start-opentui-ui.tsx` imports it ahead of its own
+ * `@opentui/core` import for exactly that reason; keep this file free of
+ * `@opentui/*` imports.
+ */
+
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveBundleDir } from '@qwen-code/qwen-code-core';
+
+/** Directory name the bundle step writes the relocated assets into. */
+export const OPENTUI_ASSETS_DIRNAME = 'opentui-assets';
+
+/** Native library file name per platform (mirrors @opentui/core). */
+export const OPENTUI_NATIVE_LIBRARY_FILE: Readonly<Record<string, string>> = {
+  darwin: 'libopentui.dylib',
+  linux: 'libopentui.so',
+  win32: 'opentui.dll',
+};
+
+/**
+ * The `@opentui/core-<platform>-<arch>` package name the current runtime
+ * loads its native library from, including the `-musl` variant selected via
+ * `OPENTUI_LIBC=musl` on Linux. Undefined on unsupported platform/arch
+ * combinations (same support matrix as @opentui/core's asset descriptor).
+ */
+export function openTuiNativeAssetPackageName(
+  platform: string = process.platform,
+  arch: string = process.arch,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (!Object.hasOwn(OPENTUI_NATIVE_LIBRARY_FILE, platform)) {
+    return undefined;
+  }
+  if (arch !== 'arm64' && arch !== 'x64') {
+    return undefined;
+  }
+  const musl =
+    platform === 'linux' && env['OPENTUI_LIBC'] === 'musl' ? '-musl' : '';
+  return `@opentui/core-${platform}-${arch}${musl}`;
+}
+
+/**
+ * Every asset key the renderer resolves through `OTUI_ASSET_ROOT` on this
+ * platform: the native library, the tree-sitter parser worker, all bundled
+ * grammar assets and the web-tree-sitter runtime. All of them must exist
+ * under the root or the variable must stay unset (see module docs).
+ */
+export function requiredOpenTuiAssetKeys(
+  platform: string = process.platform,
+  arch: string = process.arch,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] | undefined {
+  const nativePackage = openTuiNativeAssetPackageName(platform, arch, env);
+  const libraryFile = OPENTUI_NATIVE_LIBRARY_FILE[platform];
+  if (!nativePackage || !libraryFile) {
+    return undefined;
+  }
+  return [
+    `${nativePackage}/${libraryFile}`,
+    '@opentui/core/parser.worker.js',
+    '@opentui/core/assets/javascript/highlights.scm',
+    '@opentui/core/assets/javascript/tree-sitter-javascript.wasm',
+    '@opentui/core/assets/typescript/highlights.scm',
+    '@opentui/core/assets/typescript/tree-sitter-typescript.wasm',
+    '@opentui/core/assets/markdown/highlights.scm',
+    '@opentui/core/assets/markdown/injections.scm',
+    '@opentui/core/assets/markdown/tree-sitter-markdown.wasm',
+    '@opentui/core/assets/markdown_inline/highlights.scm',
+    '@opentui/core/assets/markdown_inline/tree-sitter-markdown_inline.wasm',
+    '@opentui/core/assets/zig/highlights.scm',
+    '@opentui/core/assets/zig/tree-sitter-zig.wasm',
+    'web-tree-sitter/tree-sitter.wasm',
+  ];
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Points `OTUI_ASSET_ROOT` at `<bundleDir>/opentui-assets` when that tree is
+ * complete for the current platform; otherwise leaves the environment alone.
+ * Returns the root that is in effect afterwards (pre-existing values win).
+ */
+export function configureOpenTuiAssetRoot(
+  bundleDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: string = process.platform,
+  arch: string = process.arch,
+): string | undefined {
+  const existing = env['OTUI_ASSET_ROOT'];
+  if (existing) {
+    return existing;
+  }
+  const keys = requiredOpenTuiAssetKeys(platform, arch, env);
+  if (!keys) {
+    return undefined;
+  }
+  const root = join(bundleDir, OPENTUI_ASSETS_DIRNAME);
+  for (const key of keys) {
+    if (!isFile(join(root, key))) {
+      return undefined;
+    }
+  }
+  env['OTUI_ASSET_ROOT'] = root;
+  return root;
+}
+
+// Side effect: configure the asset root as early as possible. start-opentui-ui
+// imports this module before '@opentui/core', whose module evaluation
+// resolves the native library path exactly once.
+configureOpenTuiAssetRoot(resolveBundleDir(import.meta.url));

--- a/packages/cli/src/ui/opentui/renderer-selection.test.ts
+++ b/packages/cli/src/ui/opentui/renderer-selection.test.ts
@@ -10,6 +10,7 @@ import {
   isOpenTuiRuntimeSupported,
   parseVersion,
   selectTuiRenderer,
+  TUI_RENDERER_STRICT_ENV_VAR,
 } from './renderer-selection.js';
 
 describe('parseVersion', () => {
@@ -107,6 +108,41 @@ describe('selectTuiRenderer', () => {
     const selection = selectTuiRenderer('opentui', unsupported);
     expect(selection.renderer).toBe('ink');
     expect(selection.reason).toContain('native FFI');
+  });
+
+  it('strict mode throws instead of falling back', () => {
+    expect(() =>
+      selectTuiRenderer('opentui', unsupported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: '1',
+      }),
+    ).toThrow(TUI_RENDERER_STRICT_ENV_VAR);
+    expect(() =>
+      selectTuiRenderer('opentui', unsupported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: 'true',
+      }),
+    ).toThrow('native FFI');
+  });
+
+  it('strict mode only affects an explicit opentui request', () => {
+    // Unset/ink requests must keep the silent ink selection even under
+    // strict — the matrix leg that pins ink must not start failing.
+    expect(
+      selectTuiRenderer(undefined, unsupported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: '1',
+      }).renderer,
+    ).toBe('ink');
+    expect(
+      selectTuiRenderer('ink', unsupported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: '1',
+      }).renderer,
+    ).toBe('ink');
+    // Strict off (or any other value) keeps the silent fallback.
+    expect(
+      selectTuiRenderer('opentui', unsupported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: '0',
+      }).renderer,
+    ).toBe('ink');
+    expect(selectTuiRenderer('opentui', unsupported, {}).renderer).toBe('ink');
   });
 
   it('keeps ink when the flag explicitly asks for ink', () => {

--- a/packages/cli/src/ui/opentui/renderer-selection.test.ts
+++ b/packages/cli/src/ui/opentui/renderer-selection.test.ts
@@ -148,4 +148,25 @@ describe('selectTuiRenderer', () => {
   it('keeps ink when the flag explicitly asks for ink', () => {
     expect(selectTuiRenderer('ink', supported).renderer).toBe('ink');
   });
+
+  it('reports strict in every selection path', () => {
+    expect(
+      selectTuiRenderer('opentui', supported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: '1',
+      }).strict,
+    ).toBe(true);
+    expect(
+      selectTuiRenderer('opentui', supported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: 'false',
+      }).strict,
+    ).toBe(false);
+    expect(selectTuiRenderer('opentui', supported).strict).toBe(false);
+    // Present even on ink selections: the dispatcher consults the field when
+    // the OpenTUI entry fails to boot, regardless of the probe outcome.
+    expect(
+      selectTuiRenderer(undefined, supported, {
+        [TUI_RENDERER_STRICT_ENV_VAR]: 'true',
+      }).strict,
+    ).toBe(true);
+  });
 });

--- a/packages/cli/src/ui/opentui/renderer-selection.ts
+++ b/packages/cli/src/ui/opentui/renderer-selection.ts
@@ -23,6 +23,15 @@
 /** The environment variable that selects the TUI renderer. */
 export const TUI_RENDERER_ENV_VAR = 'QWEN_TUI_RENDERER';
 
+/**
+ * Turns the unsupported-runtime ink fallback into a hard failure. The silent
+ * fallback is the right user-facing behavior, but the renderer-matrix E2E
+ * legs need "green run really exercised opentui": with this set, an explicit
+ * opentui request on a runtime that cannot load the native renderer throws
+ * instead of serving ink. Never set it in product defaults.
+ */
+export const TUI_RENDERER_STRICT_ENV_VAR = 'QWEN_TUI_RENDERER_STRICT';
+
 /** The only non-default renderer value this gate recognizes. */
 export const OPEN_TUI_RENDERER_VALUE = 'opentui';
 
@@ -108,10 +117,17 @@ export function isOpenTuiRuntimeSupported(
  * the flag explicitly requests it AND the runtime can support it. Any other
  * combination — unset flag, an unrecognized value, or an unsupported runtime —
  * keeps ink, which remains the default renderer throughout the migration.
+ *
+ * The one exception is {@link TUI_RENDERER_STRICT_ENV_VAR}: set by the E2E
+ * renderer matrix, it turns the unsupported-runtime ink fallback into a throw
+ * so a matrix leg cannot pass while a fallback secretly served ink. This
+ * function is called before the dispatcher's own try/catch, so the throw
+ * surfaces as a loud startup failure.
  */
 export function selectTuiRenderer(
   envValue: string | undefined = process.env[TUI_RENDERER_ENV_VAR],
   probe?: RuntimeVersionProbe,
+  env: NodeJS.ProcessEnv = process.env,
 ): RendererSelection {
   const requested = envValue?.trim().toLowerCase();
   if (requested !== OPEN_TUI_RENDERER_VALUE) {
@@ -123,6 +139,14 @@ export function selectTuiRenderer(
     };
   }
   if (!isOpenTuiRuntimeSupported(probe)) {
+    const strict = env[TUI_RENDERER_STRICT_ENV_VAR]?.trim().toLowerCase();
+    if (strict === '1' || strict === 'true') {
+      throw new Error(
+        `${TUI_RENDERER_ENV_VAR}=${OPEN_TUI_RENDERER_VALUE} was requested, but this runtime cannot initialize the OpenTUI native FFI ` +
+          `(needs Bun >= ${MIN_BUN_VERSION} or Node >= ${MIN_NODE_VERSION}) and ` +
+          `${TUI_RENDERER_STRICT_ENV_VAR} forbids the silent ink fallback`,
+      );
+    }
     return {
       renderer: 'ink',
       reason: `OpenTUI requested but the runtime cannot initialize its native FFI (needs Bun >= ${MIN_BUN_VERSION} or Node >= ${MIN_NODE_VERSION})`,

--- a/packages/cli/src/ui/opentui/renderer-selection.ts
+++ b/packages/cli/src/ui/opentui/renderer-selection.ts
@@ -24,11 +24,12 @@
 export const TUI_RENDERER_ENV_VAR = 'QWEN_TUI_RENDERER';
 
 /**
- * Turns the unsupported-runtime ink fallback into a hard failure. The silent
- * fallback is the right user-facing behavior, but the renderer-matrix E2E
- * legs need "green run really exercised opentui": with this set, an explicit
- * opentui request on a runtime that cannot load the native renderer throws
- * instead of serving ink. Never set it in product defaults.
+ * Turns the ink fallback into a hard failure. The silent fallback is the
+ * right user-facing behavior, but the renderer-matrix E2E legs need "green
+ * run really exercised opentui": with this set, an explicit opentui request
+ * that cannot be served — the runtime cannot load the native renderer, or
+ * the OpenTUI entry fails to boot — throws instead of serving ink. Never set
+ * it in product defaults.
  */
 export const TUI_RENDERER_STRICT_ENV_VAR = 'QWEN_TUI_RENDERER_STRICT';
 
@@ -41,6 +42,12 @@ export interface RendererSelection {
   renderer: TuiRendererChoice;
   /** Human-readable reason, for debug logging. Never shown to the user. */
   reason: string;
+  /**
+   * Whether QWEN_TUI_RENDERER_STRICT forbids ink fallbacks after the probe
+   * too: the dispatcher consults this when the OpenTUI entry fails to boot
+   * and re-throws instead of serving ink.
+   */
+  strict: boolean;
 }
 
 /** Minimum runtime versions that can initialize the OpenTUI native FFI. */
@@ -122,7 +129,9 @@ export function isOpenTuiRuntimeSupported(
  * renderer matrix, it turns the unsupported-runtime ink fallback into a throw
  * so a matrix leg cannot pass while a fallback secretly served ink. This
  * function is called before the dispatcher's own try/catch, so the throw
- * surfaces as a loud startup failure.
+ * surfaces as a loud startup failure. The flag also survives into
+ * {@link RendererSelection.strict} so the dispatcher can block the
+ * boot-failure fallback the same way.
  */
 export function selectTuiRenderer(
   envValue: string | undefined = process.env[TUI_RENDERER_ENV_VAR],
@@ -130,17 +139,19 @@ export function selectTuiRenderer(
   env: NodeJS.ProcessEnv = process.env,
 ): RendererSelection {
   const requested = envValue?.trim().toLowerCase();
+  const strictValue = env[TUI_RENDERER_STRICT_ENV_VAR]?.trim().toLowerCase();
+  const strict = strictValue === '1' || strictValue === 'true';
   if (requested !== OPEN_TUI_RENDERER_VALUE) {
     return {
       renderer: 'ink',
       reason: requested
         ? `${TUI_RENDERER_ENV_VAR}=${envValue} is not "${OPEN_TUI_RENDERER_VALUE}"`
         : `${TUI_RENDERER_ENV_VAR} is not set`,
+      strict,
     };
   }
   if (!isOpenTuiRuntimeSupported(probe)) {
-    const strict = env[TUI_RENDERER_STRICT_ENV_VAR]?.trim().toLowerCase();
-    if (strict === '1' || strict === 'true') {
+    if (strict) {
       throw new Error(
         `${TUI_RENDERER_ENV_VAR}=${OPEN_TUI_RENDERER_VALUE} was requested, but this runtime cannot initialize the OpenTUI native FFI ` +
           `(needs Bun >= ${MIN_BUN_VERSION} or Node >= ${MIN_NODE_VERSION}) and ` +
@@ -150,10 +161,12 @@ export function selectTuiRenderer(
     return {
       renderer: 'ink',
       reason: `OpenTUI requested but the runtime cannot initialize its native FFI (needs Bun >= ${MIN_BUN_VERSION} or Node >= ${MIN_NODE_VERSION})`,
+      strict,
     };
   }
   return {
     renderer: 'opentui',
     reason: `${TUI_RENDERER_ENV_VAR}=${OPEN_TUI_RENDERER_VALUE} on a supported runtime`,
+    strict,
   };
 }

--- a/packages/cli/src/ui/opentui/start-opentui-ui.tsx
+++ b/packages/cli/src/ui/opentui/start-opentui-ui.tsx
@@ -29,6 +29,10 @@ import {
   useRef,
   useState,
 } from 'react';
+// Must evaluate before '@opentui/core': the asset-root side effect has to be
+// in place before @opentui/core's module evaluation resolves the native
+// library path (see opentui-assets.ts).
+import './opentui-assets.js';
 import {
   createCliRenderer,
   type CliRenderer,

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -41,6 +41,8 @@
     "src/**/*.ts",
     "src/**/*.tsx",
     "src/**/*.json",
+    "scripts/**/*.ts",
+    "scripts/**/*.tsx",
     "./package.json",
     "../core/src/utils/toml-to-markdown-converter.test.ts",
     "../core/src/utils/toml-to-markdown-converter.ts"

--- a/scripts/build-standalone-release.js
+++ b/scripts/build-standalone-release.js
@@ -57,10 +57,10 @@ const RELEASE_TARGETS = [
 ];
 const EXPECTED_ARCHIVE_COUNT = RELEASE_TARGETS.length;
 
-// Temporary OpenTUI preview: standalone archives ship the Bun runtime by
-// default because the OpenTUI renderer needs bun:ffi (Node without FFI falls
-// back to ink). Pass --runtime=node to restore classic Node.js packaging.
-const DEFAULT_RUNTIME = 'bun';
+// Classic Node.js packaging stays the default. --runtime=bun opts into the
+// temporary OpenTUI preview (the renderer needs bun:ffi; Node without FFI
+// falls back to ink).
+const DEFAULT_RUNTIME = 'node';
 const DEFAULT_BUN_VERSION = '1.3.14';
 const BUN_RELEASE_BASE_URL = 'https://github.com/oven-sh/bun/releases/download';
 
@@ -125,9 +125,9 @@ async function main() {
     await downloadFile(`${runtimeDistUrl}/SHASUMS256.txt`, checksumsPath);
     const checksums = parseChecksums(fs.readFileSync(checksumsPath, 'utf8'));
     const nativeModulesDir = stageClipboardPackages(runtimeDir);
-    // Only the bun runtime consumes the staged OpenTUI packages; the
-    // --runtime=node escape hatch must not install them (nor fail on a
-    // missing lockfile entry) at all.
+    // Only the bun runtime consumes the staged OpenTUI packages; the classic
+    // Node packaging must not install them (nor fail on a missing lockfile
+    // entry) at all.
     const opentuiModulesDir =
       runtime === 'bun' ? stageOpenTuiPackages(runtimeDir) : undefined;
 
@@ -486,8 +486,8 @@ Options:
   --out-dir PATH         Output directory. Defaults to dist/standalone.
   --runtime-dir PATH     Temporary Node.js runtime download directory.
   --node-version VERSION Node.js version to download. Defaults to current Node.
-  --runtime RUNTIME      Runtime to bundle: "bun" (default, temporary OpenTUI
-                         preview) or "node" (classic packaging).
+  --runtime RUNTIME      Runtime to bundle: "node" (classic packaging) or
+                         "bun" (temporary OpenTUI preview).
   --bun-version VERSION  Bun version to download. Defaults to ${DEFAULT_BUN_VERSION}.
 `);
 }

--- a/scripts/build-standalone-release.js
+++ b/scripts/build-standalone-release.js
@@ -28,25 +28,58 @@ const RELEASE_TARGETS = [
     qwenTarget: 'darwin-arm64',
     nodeTarget: 'darwin-arm64',
     nodeArchiveExtension: 'tar.gz',
+    bunAsset: 'bun-darwin-aarch64',
   },
   {
     qwenTarget: 'darwin-x64',
     nodeTarget: 'darwin-x64',
     nodeArchiveExtension: 'tar.gz',
+    bunAsset: 'bun-darwin-x64',
   },
   {
     qwenTarget: 'linux-arm64',
     nodeTarget: 'linux-arm64',
     nodeArchiveExtension: 'tar.xz',
+    bunAsset: 'bun-linux-aarch64',
   },
   {
     qwenTarget: 'linux-x64',
     nodeTarget: 'linux-x64',
     nodeArchiveExtension: 'tar.xz',
+    bunAsset: 'bun-linux-x64',
   },
-  { qwenTarget: 'win-x64', nodeTarget: 'win-x64', nodeArchiveExtension: 'zip' },
+  {
+    qwenTarget: 'win-x64',
+    nodeTarget: 'win-x64',
+    nodeArchiveExtension: 'zip',
+    bunAsset: 'bun-windows-x64',
+  },
 ];
 const EXPECTED_ARCHIVE_COUNT = RELEASE_TARGETS.length;
+
+// Temporary OpenTUI preview: standalone archives ship the Bun runtime by
+// default because the OpenTUI renderer needs bun:ffi (Node without FFI falls
+// back to ink). Pass --runtime=node to restore classic Node.js packaging.
+const DEFAULT_RUNTIME = 'bun';
+const DEFAULT_BUN_VERSION = '1.3.14';
+const BUN_RELEASE_BASE_URL = 'https://github.com/oven-sh/bun/releases/download';
+
+// Temporary OpenTUI preview: the bundled OpenTUI backend resolves its native
+// render library at runtime via `import('@opentui/core-<platform>-<arch>')`,
+// so each standalone archive must ship the matching platform package(s).
+// Stage every platform variant (like the clipboard addons) because release
+// packaging cross-builds all targets from a single host. Declared before the
+// top-level `main()` call below (ESM const TDZ).
+const OPENTUI_PLATFORM_PACKAGES = [
+  '@opentui/core-darwin-arm64',
+  '@opentui/core-darwin-x64',
+  '@opentui/core-linux-arm64',
+  '@opentui/core-linux-arm64-musl',
+  '@opentui/core-linux-x64',
+  '@opentui/core-linux-x64-musl',
+  '@opentui/core-win32-arm64',
+  '@opentui/core-win32-x64',
+];
 
 if (isMainModule()) {
   try {
@@ -64,7 +97,13 @@ async function main() {
     return;
   }
 
+  const runtime = args.runtime || DEFAULT_RUNTIME;
+  if (runtime !== 'node' && runtime !== 'bun') {
+    fail('--runtime must be either "node" or "bun"');
+  }
+
   const nodeVersion = args.nodeVersion || process.versions.node;
+  const bunVersion = args.bunVersion || DEFAULT_BUN_VERSION;
   const outDir = path.resolve(
     args.outDir || path.join(rootDir, 'dist', 'standalone'),
   );
@@ -73,20 +112,25 @@ async function main() {
   );
   fs.mkdirSync(runtimeParent, { recursive: true });
   const runtimeDir = fs.mkdtempSync(
-    path.join(runtimeParent, 'qwen-node-runtime-'),
+    path.join(runtimeParent, `qwen-${runtime}-runtime-`),
   );
   const nodeDistUrl = `https://nodejs.org/dist/v${nodeVersion}`;
+  const bunDistUrl = `${BUN_RELEASE_BASE_URL}/bun-v${bunVersion}`;
+  const runtimeDistUrl = runtime === 'bun' ? bunDistUrl : nodeDistUrl;
 
   try {
     fs.mkdirSync(outDir, { recursive: true });
     const checksumsPath = path.join(runtimeDir, 'SHASUMS256.txt');
-    await downloadFile(`${nodeDistUrl}/SHASUMS256.txt`, checksumsPath);
+    await downloadFile(`${runtimeDistUrl}/SHASUMS256.txt`, checksumsPath);
     const checksums = parseChecksums(fs.readFileSync(checksumsPath, 'utf8'));
     const nativeModulesDir = stageClipboardPackages(runtimeDir);
+    const opentuiModulesDir = stageOpenTuiPackages(runtimeDir);
 
     for (const target of RELEASE_TARGETS) {
       await packageTarget({
         ...target,
+        runtime,
+        bunDistUrl,
         nodeDistUrl,
         nodeVersion,
         outDir,
@@ -94,6 +138,7 @@ async function main() {
         runtimeDir,
         checksums,
         nativeModulesDir,
+        opentuiModulesDir,
       });
     }
 
@@ -112,6 +157,9 @@ async function packageTarget({
   qwenTarget,
   nodeTarget,
   nodeArchiveExtension,
+  bunAsset,
+  runtime,
+  bunDistUrl,
   nodeDistUrl,
   nodeVersion,
   outDir,
@@ -119,12 +167,26 @@ async function packageTarget({
   runtimeDir,
   checksums,
   nativeModulesDir,
+  opentuiModulesDir,
 }) {
-  const archiveName = `node-v${nodeVersion}-${nodeTarget}.${nodeArchiveExtension}`;
+  let archiveName;
+  let archiveUrlBase;
+  if (runtime === 'bun') {
+    archiveName = `${bunAsset}.zip`;
+    archiveUrlBase = bunDistUrl;
+  } else {
+    archiveName = `node-v${nodeVersion}-${nodeTarget}.${nodeArchiveExtension}`;
+    archiveUrlBase = nodeDistUrl;
+  }
   const archivePath = path.join(runtimeDir, archiveName);
 
-  await downloadFile(`${nodeDistUrl}/${archiveName}`, archivePath);
-  await verifyNodeArchive(archivePath, archiveName, checksums);
+  await downloadFile(`${archiveUrlBase}/${archiveName}`, archivePath);
+  await verifyNodeArchive(
+    archivePath,
+    archiveName,
+    checksums,
+    runtime === 'bun' ? 'Bun' : 'Node.js',
+  );
 
   const args = [
     'scripts/create-standalone-package.js',
@@ -138,6 +200,10 @@ async function packageTarget({
     outDir,
     '--skip-checksums',
   ];
+  if (runtime === 'bun') {
+    args.push('--runtime', 'bun');
+    args.push('--opentui-modules-dir', opentuiModulesDir);
+  }
   if (releaseVersion) {
     args.push('--version', releaseVersion);
   }
@@ -205,6 +271,55 @@ function stageClipboardPackages(runtimeDir) {
   return path.join(installDir, 'node_modules');
 }
 
+// Temporary OpenTUI preview: the bundled OpenTUI backend resolves its native
+// render library at runtime via `import('@opentui/core-<platform>-<arch>')`,
+// so each standalone archive must ship the matching platform package(s).
+function readOpenTuiPackageSpecs() {
+  const packageLock = JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'package-lock.json'), 'utf8'),
+  );
+
+  return OPENTUI_PLATFORM_PACKAGES.map((packageName) => {
+    const version =
+      packageLock.packages?.[`node_modules/${packageName}`]?.version;
+    if (!version) {
+      fail(`OpenTUI platform package version is not locked for ${packageName}`);
+    }
+    return `${packageName}@${version}`;
+  });
+}
+
+function stageOpenTuiPackages(runtimeDir) {
+  const installDir = path.join(runtimeDir, 'opentui-modules');
+  fs.mkdirSync(installDir, { recursive: true });
+  console.log('Staging standalone OpenTUI native packages');
+  const npmExecPath = process.env.npm_execpath;
+  if (!npmExecPath) {
+    fail('npm_execpath is unavailable; run package:standalone:release via npm');
+  }
+  execFileSync(
+    process.execPath,
+    [
+      npmExecPath,
+      'install',
+      '--prefix',
+      installDir,
+      '--package-lock=false',
+      '--no-save',
+      '--ignore-scripts',
+      '--force',
+      '--no-audit',
+      '--no-fund',
+      ...readOpenTuiPackageSpecs(),
+    ],
+    {
+      cwd: rootDir,
+      stdio: 'inherit',
+    },
+  );
+  return path.join(installDir, 'node_modules');
+}
+
 async function downloadFile(url, destination) {
   console.log(`Downloading ${url}`);
   const response = await fetch(url);
@@ -233,10 +348,11 @@ function parseChecksums(content) {
   return checksums;
 }
 
-async function verifyNodeArchive(archivePath, archiveName, checksums) {
+async function verifyNodeArchive(archivePath, archiveName, checksums, label) {
+  const runtimeLabel = label || 'Node.js';
   const expected = checksums.get(archiveName);
   if (!expected) {
-    fail(`Node.js SHASUMS256.txt does not list ${archiveName}`);
+    fail(`${runtimeLabel} SHASUMS256.txt does not list ${archiveName}`);
   }
 
   const actual = await sha256File(archivePath);
@@ -244,7 +360,7 @@ async function verifyNodeArchive(archivePath, archiveName, checksums) {
     fail(`Checksum verification failed for ${archiveName}`);
   }
 
-  console.log(`Verified Node.js runtime checksum for ${archiveName}`);
+  console.log(`Verified ${runtimeLabel} runtime checksum for ${archiveName}`);
 }
 
 async function sha256File(filePath) {
@@ -301,6 +417,8 @@ function parseArgs(argv) {
   const args = {
     help: false,
     nodeVersion: undefined,
+    bunVersion: undefined,
+    runtime: undefined,
     outDir: undefined,
     runtimeDir: undefined,
     version: undefined,
@@ -315,6 +433,14 @@ function parseArgs(argv) {
         break;
       case '--node-version':
         args.nodeVersion = readOptionValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--bun-version':
+        args.bunVersion = readOptionValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--runtime':
+        args.runtime = readOptionValue(argv, index, arg);
         index += 1;
         break;
       case '--out-dir':
@@ -355,6 +481,9 @@ Options:
   --out-dir PATH         Output directory. Defaults to dist/standalone.
   --runtime-dir PATH     Temporary Node.js runtime download directory.
   --node-version VERSION Node.js version to download. Defaults to current Node.
+  --runtime RUNTIME      Runtime to bundle: "bun" (default, temporary OpenTUI
+                         preview) or "node" (classic packaging).
+  --bun-version VERSION  Bun version to download. Defaults to ${DEFAULT_BUN_VERSION}.
 `);
 }
 

--- a/scripts/build-standalone-release.js
+++ b/scripts/build-standalone-release.js
@@ -68,15 +68,16 @@ const BUN_RELEASE_BASE_URL = 'https://github.com/oven-sh/bun/releases/download';
 // render library at runtime via `import('@opentui/core-<platform>-<arch>')`,
 // so each standalone archive must ship the matching platform package(s).
 // Stage every platform variant (like the clipboard addons) because release
-// packaging cross-builds all targets from a single host. Declared before the
+// packaging cross-builds all targets from a single host. Linux is glibc-only
+// on purpose: RELEASE_TARGETS bundles glibc-linked Bun binaries that cannot
+// start on musl hosts, so the -musl render packages would be dead weight
+// claiming support the archive cannot deliver. Declared before the
 // top-level `main()` call below (ESM const TDZ).
 const OPENTUI_PLATFORM_PACKAGES = [
   '@opentui/core-darwin-arm64',
   '@opentui/core-darwin-x64',
   '@opentui/core-linux-arm64',
-  '@opentui/core-linux-arm64-musl',
   '@opentui/core-linux-x64',
-  '@opentui/core-linux-x64-musl',
   '@opentui/core-win32-arm64',
   '@opentui/core-win32-x64',
 ];
@@ -124,7 +125,11 @@ async function main() {
     await downloadFile(`${runtimeDistUrl}/SHASUMS256.txt`, checksumsPath);
     const checksums = parseChecksums(fs.readFileSync(checksumsPath, 'utf8'));
     const nativeModulesDir = stageClipboardPackages(runtimeDir);
-    const opentuiModulesDir = stageOpenTuiPackages(runtimeDir);
+    // Only the bun runtime consumes the staged OpenTUI packages; the
+    // --runtime=node escape hatch must not install them (nor fail on a
+    // missing lockfile entry) at all.
+    const opentuiModulesDir =
+      runtime === 'bun' ? stageOpenTuiPackages(runtimeDir) : undefined;
 
     for (const target of RELEASE_TARGETS) {
       await packageTarget({

--- a/scripts/codemod/codemod.test.mjs
+++ b/scripts/codemod/codemod.test.mjs
@@ -4,20 +4,27 @@ import { spawnSync } from 'node:child_process';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { format } from 'prettier';
 import { transformSource } from './ink-to-opentui.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const codemod = join(here, 'ink-to-opentui.mjs');
 const before = readFileSync(join(here, 'fixtures', 'before.tsx'), 'utf8');
 const after = readFileSync(join(here, 'fixtures', 'after.tsx'), 'utf8');
+const config = JSON.parse(
+  readFileSync(join(here, '..', '..', '.prettierrc.json'), 'utf8'),
+);
+// The fixture is the codemod output plus prettier formatting, so compare after
+// normalizing both sides (prettier 3's format() is async-only).
+const normalize = (src) => format(src, { ...config, parser: 'typescript' });
 
 let failures = 0;
 let count = 0;
 
-function test(name, fn) {
+async function test(name, fn) {
   count++;
   try {
-    fn();
+    await fn();
     console.log(`ok ${count} - ${name}`);
   } catch (err) {
     failures++;
@@ -30,20 +37,20 @@ function runCli(args) {
   return spawnSync(process.execPath, [codemod, ...args], { encoding: 'utf8' });
 }
 
-test('fixture: transform matches after.tsx', () => {
+await test('fixture: transform matches after.tsx', async () => {
   const res = transformSource(before);
   assert.equal(res.changed, true);
-  assert.equal(res.output, after);
+  assert.equal(await normalize(res.output), await normalize(after));
   assert.equal(res.notes.length, 0);
 });
 
-test('fixture: idempotent on after.tsx', () => {
+await test('fixture: idempotent on after.tsx', () => {
   const res = transformSource(after);
   assert.equal(res.changed, false);
   assert.equal(res.output, after);
 });
 
-test('fixture: stats count renamed elements and collected props', () => {
+await test('fixture: stats count renamed elements and collected props', () => {
   const res = transformSource(before);
   assert.equal(res.stats.box, 5);
   assert.equal(res.stats.text, 3);
@@ -56,7 +63,7 @@ mkdirSync(tmpDir, { recursive: true });
 const tmpFile = join(tmpDir, 'sample.tsx');
 
 try {
-  test('cli: default is dry-run and writes nothing', () => {
+  await test('cli: default is dry-run and writes nothing', () => {
     writeFileSync(tmpFile, before);
     const r = runCli([tmpFile]);
     assert.equal(r.status, 0, r.stderr);
@@ -65,23 +72,26 @@ try {
     assert.equal(readFileSync(tmpFile, 'utf8'), before);
   });
 
-  test('cli: --dry-run writes nothing', () => {
+  await test('cli: --dry-run writes nothing', () => {
     writeFileSync(tmpFile, before);
     const r = runCli(['--dry-run', tmpFile]);
     assert.equal(r.status, 0, r.stderr);
     assert.equal(readFileSync(tmpFile, 'utf8'), before);
   });
 
-  test('cli: --apply rewrites to fixture after.tsx', () => {
+  await test('cli: --apply rewrites to fixture after.tsx', async () => {
     writeFileSync(tmpFile, before);
     const r = runCli(['--apply', tmpFile]);
     assert.equal(r.status, 0, r.stderr);
     assert.match(r.stdout, /\[apply\]/);
     assert.match(r.stdout, /written/);
-    assert.equal(readFileSync(tmpFile, 'utf8'), after);
+    assert.equal(
+      await normalize(readFileSync(tmpFile, 'utf8')),
+      await normalize(after),
+    );
   });
 
-  test('cli: directory input is scanned', () => {
+  await test('cli: directory input is scanned', () => {
     writeFileSync(tmpFile, before);
     const r = runCli(['--dry-run', tmpDir]);
     assert.equal(r.status, 0, r.stderr);
@@ -92,14 +102,14 @@ try {
   rmSync(tmpDir, { recursive: true, force: true });
 }
 
-test('manual: spread attribute keeps props, still renames', () => {
+await test('manual: spread attribute keeps props, still renames', () => {
   const src = 'const x = <Box {...rest} padding={1}>hi</Box>;';
   const res = transformSource(src);
   assert.equal(res.output, 'const x = <box {...rest} padding={1}>hi</box>;');
   assert.ok(res.notes.some((nt) => /spread/.test(nt.msg)));
 });
 
-test('manual: malformed attribute leaves file unchanged', () => {
+await test('manual: malformed attribute leaves file unchanged', () => {
   const src = 'const x = <Box padding=1>bad</Box>;';
   const res = transformSource(src);
   assert.equal(res.output, src);
@@ -107,7 +117,7 @@ test('manual: malformed attribute leaves file unchanged', () => {
   assert.equal(res.notes.length, 1);
 });
 
-test('manual: existing style with spread renames only', () => {
+await test('manual: existing style with spread renames only', () => {
   const src = 'const x = <Box style={{ ...base }} padding={1}>hi</Box>;';
   const res = transformSource(src);
   assert.equal(
@@ -119,7 +129,7 @@ test('manual: existing style with spread renames only', () => {
   );
 });
 
-test('manual: conflicting key in existing style object', () => {
+await test('manual: conflicting key in existing style object', () => {
   const src = 'const x = <Box style={{ padding: 4 }} padding={1}>x</Box>;';
   const res = transformSource(src);
   assert.equal(
@@ -129,7 +139,7 @@ test('manual: conflicting key in existing style object', () => {
   assert.ok(res.notes.some((nt) => /already present/.test(nt.msg)));
 });
 
-test('manual: non-object style expression is not merged', () => {
+await test('manual: non-object style expression is not merged', () => {
   const src = 'const x = <Box style={baseStyle} padding={1}>x</Box>;';
   const res = transformSource(src);
   assert.equal(
@@ -139,14 +149,14 @@ test('manual: non-object style expression is not merged', () => {
   assert.ok(res.notes.length >= 1);
 });
 
-test('manual: mismatched closing tag leaves file unchanged', () => {
+await test('manual: mismatched closing tag leaves file unchanged', () => {
   const src = 'const x = <Box>a</Text>;';
   const res = transformSource(src);
   assert.equal(res.output, src);
   assert.ok(res.notes.length >= 1);
 });
 
-test('ignore: generics, foreign tags and strings untouched', () => {
+await test('ignore: generics, foreign tags and strings untouched', () => {
   const src = [
     'const r = useRef<Box>(null);',
     'const v = <div className="a"><span>hi</span></div>;',
@@ -158,7 +168,7 @@ test('ignore: generics, foreign tags and strings untouched', () => {
   assert.equal(res.output, src);
 });
 
-test('regex mask: closing-tag slash is not a regex start', () => {
+await test('regex mask: closing-tag slash is not a regex start', () => {
   const src =
     'const a = <Box>x</Box>; const b = <Text>y</Text>; const half = n / 2;';
   const res = transformSource(src);
@@ -170,14 +180,14 @@ test('regex mask: closing-tag slash is not a regex start', () => {
   assert.equal(res.notes.length, 0);
 });
 
-test('manual: string style value with backslash is not copied verbatim', () => {
+await test('manual: string style value with backslash is not copied verbatim', () => {
   const src = 'const x = <Box margin="a\\b" padding={1}>x</Box>';
   const res = transformSource(src);
   assert.equal(res.output, 'const x = <box margin="a\\b" padding={1}>x</box>');
   assert.ok(res.notes.some((nt) => /escape\/entity semantics/.test(nt.msg)));
 });
 
-test('manual: string style value with HTML entity is not copied verbatim', () => {
+await test('manual: string style value with HTML entity is not copied verbatim', () => {
   const src = 'const x = <Box margin="1&nbsp;2">x</Box>';
   const res = transformSource(src);
   assert.equal(res.output, 'const x = <box margin="1&nbsp;2">x</box>');

--- a/scripts/codemod/codemod.test.mjs
+++ b/scripts/codemod/codemod.test.mjs
@@ -1,0 +1,191 @@
+// Self-test for ink-to-opentui.mjs. Run with: node scripts/codemod/codemod.test.mjs
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { transformSource } from './ink-to-opentui.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const codemod = join(here, 'ink-to-opentui.mjs');
+const before = readFileSync(join(here, 'fixtures', 'before.tsx'), 'utf8');
+const after = readFileSync(join(here, 'fixtures', 'after.tsx'), 'utf8');
+
+let failures = 0;
+let count = 0;
+
+function test(name, fn) {
+  count++;
+  try {
+    fn();
+    console.log(`ok ${count} - ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`FAIL ${count} - ${name}`);
+    console.error(err && err.message ? err.message : err);
+  }
+}
+
+function runCli(args) {
+  return spawnSync(process.execPath, [codemod, ...args], { encoding: 'utf8' });
+}
+
+test('fixture: transform matches after.tsx', () => {
+  const res = transformSource(before);
+  assert.equal(res.changed, true);
+  assert.equal(res.output, after);
+  assert.equal(res.notes.length, 0);
+});
+
+test('fixture: idempotent on after.tsx', () => {
+  const res = transformSource(after);
+  assert.equal(res.changed, false);
+  assert.equal(res.output, after);
+});
+
+test('fixture: stats count renamed elements and collected props', () => {
+  const res = transformSource(before);
+  assert.equal(res.stats.box, 5);
+  assert.equal(res.stats.text, 3);
+  assert.equal(res.stats.propsCollected, 12);
+  assert.equal(res.stats.styleTags, 5);
+});
+
+const tmpDir = join(here, '.tmp-test');
+mkdirSync(tmpDir, { recursive: true });
+const tmpFile = join(tmpDir, 'sample.tsx');
+
+try {
+  test('cli: default is dry-run and writes nothing', () => {
+    writeFileSync(tmpFile, before);
+    const r = runCli([tmpFile]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /\[dry-run\]/);
+    assert.match(r.stdout, /dry-run, nothing written/);
+    assert.equal(readFileSync(tmpFile, 'utf8'), before);
+  });
+
+  test('cli: --dry-run writes nothing', () => {
+    writeFileSync(tmpFile, before);
+    const r = runCli(['--dry-run', tmpFile]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(readFileSync(tmpFile, 'utf8'), before);
+  });
+
+  test('cli: --apply rewrites to fixture after.tsx', () => {
+    writeFileSync(tmpFile, before);
+    const r = runCli(['--apply', tmpFile]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /\[apply\]/);
+    assert.match(r.stdout, /written/);
+    assert.equal(readFileSync(tmpFile, 'utf8'), after);
+  });
+
+  test('cli: directory input is scanned', () => {
+    writeFileSync(tmpFile, before);
+    const r = runCli(['--dry-run', tmpDir]);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /sample\.tsx/);
+    assert.equal(readFileSync(tmpFile, 'utf8'), before);
+  });
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true });
+}
+
+test('manual: spread attribute keeps props, still renames', () => {
+  const src = 'const x = <Box {...rest} padding={1}>hi</Box>;';
+  const res = transformSource(src);
+  assert.equal(res.output, 'const x = <box {...rest} padding={1}>hi</box>;');
+  assert.ok(res.notes.some((nt) => /spread/.test(nt.msg)));
+});
+
+test('manual: malformed attribute leaves file unchanged', () => {
+  const src = 'const x = <Box padding=1>bad</Box>;';
+  const res = transformSource(src);
+  assert.equal(res.output, src);
+  assert.equal(res.changed, false);
+  assert.equal(res.notes.length, 1);
+});
+
+test('manual: existing style with spread renames only', () => {
+  const src = 'const x = <Box style={{ ...base }} padding={1}>hi</Box>;';
+  const res = transformSource(src);
+  assert.equal(
+    res.output,
+    'const x = <box style={{ ...base }} padding={1}>hi</box>;',
+  );
+  assert.ok(
+    res.notes.some((nt) => /spread inside existing style object/.test(nt.msg)),
+  );
+});
+
+test('manual: conflicting key in existing style object', () => {
+  const src = 'const x = <Box style={{ padding: 4 }} padding={1}>x</Box>;';
+  const res = transformSource(src);
+  assert.equal(
+    res.output,
+    'const x = <box style={{ padding: 4 }} padding={1}>x</box>;',
+  );
+  assert.ok(res.notes.some((nt) => /already present/.test(nt.msg)));
+});
+
+test('manual: non-object style expression is not merged', () => {
+  const src = 'const x = <Box style={baseStyle} padding={1}>x</Box>;';
+  const res = transformSource(src);
+  assert.equal(
+    res.output,
+    'const x = <box style={baseStyle} padding={1}>x</box>;',
+  );
+  assert.ok(res.notes.length >= 1);
+});
+
+test('manual: mismatched closing tag leaves file unchanged', () => {
+  const src = 'const x = <Box>a</Text>;';
+  const res = transformSource(src);
+  assert.equal(res.output, src);
+  assert.ok(res.notes.length >= 1);
+});
+
+test('ignore: generics, foreign tags and strings untouched', () => {
+  const src = [
+    'const r = useRef<Box>(null);',
+    'const v = <div className="a"><span>hi</span></div>;',
+    'const s = "<Box>not jsx</Box>";',
+    '',
+  ].join('\n');
+  const res = transformSource(src);
+  assert.equal(res.changed, false);
+  assert.equal(res.output, src);
+});
+
+test('regex mask: closing-tag slash is not a regex start', () => {
+  const src =
+    'const a = <Box>x</Box>; const b = <Text>y</Text>; const half = n / 2;';
+  const res = transformSource(src);
+  assert.equal(
+    res.output,
+    'const a = <box>x</box>; const b = <text>y</text>; const half = n / 2;',
+  );
+  assert.equal(res.stats.text, 1);
+  assert.equal(res.notes.length, 0);
+});
+
+test('manual: string style value with backslash is not copied verbatim', () => {
+  const src = 'const x = <Box margin="a\\b" padding={1}>x</Box>';
+  const res = transformSource(src);
+  assert.equal(res.output, 'const x = <box margin="a\\b" padding={1}>x</box>');
+  assert.ok(res.notes.some((nt) => /escape\/entity semantics/.test(nt.msg)));
+});
+
+test('manual: string style value with HTML entity is not copied verbatim', () => {
+  const src = 'const x = <Box margin="1&nbsp;2">x</Box>';
+  const res = transformSource(src);
+  assert.equal(res.output, 'const x = <box margin="1&nbsp;2">x</box>');
+  assert.ok(res.notes.some((nt) => /escape\/entity semantics/.test(nt.msg)));
+});
+
+if (failures > 0) {
+  console.error(`# ${failures}/${count} test(s) failed`);
+  process.exit(1);
+}
+console.log(`# ${count}/${count} tests passed`);

--- a/scripts/codemod/fixtures/after.tsx
+++ b/scripts/codemod/fixtures/after.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+export function App() {
+  return (
+    <box style={{ flexDirection: 'column' }} key="root">
+      <box style={{ padding: 2, gap: 1 }}>
+        <text color="green">hello</text>
+      </box>
+      <box style={{ overflow: 'hidden', flexGrow: 1, width: '50%' }}>
+        <text>world</text>
+      </box>
+      <box style={{ alignItems: 'center', justifyContent: 'center' }}>
+        <text bold>status</text>
+        <box
+          style={{
+            height: 3,
+            borderStyle: 'round',
+            borderColor: 'cyan',
+            backgroundColor: 'blue',
+            margin: 1,
+          }}
+        />
+      </box>
+    </box>
+  );
+}

--- a/scripts/codemod/fixtures/before.tsx
+++ b/scripts/codemod/fixtures/before.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+
+export function App() {
+  return (
+    <Box flexDirection="column" key="root">
+      <Box padding={2} gap={1}>
+        <Text color="green">hello</Text>
+      </Box>
+      <Box style={{ overflow: 'hidden' }} flexGrow={1} width="50%">
+        <Text>world</Text>
+      </Box>
+      <Box alignItems="center" justifyContent="center">
+        <Text bold>status</Text>
+        <Box
+          height={3}
+          borderStyle="round"
+          borderColor="cyan"
+          backgroundColor="blue"
+          margin={1}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/scripts/codemod/ink-to-opentui.mjs
+++ b/scripts/codemod/ink-to-opentui.mjs
@@ -1,0 +1,902 @@
+#!/usr/bin/env node
+//
+// ink-to-opentui.mjs — conservative ink -> opentui JSX codemod (pure Node).
+//
+// - Dry-run by default: prints a per-file change plan, writes nothing.
+// - With --apply, writes changed files in place.
+// - Renames <Box>/<Text> to <box>/<text>.
+// - Moves known style props into style={{...}} and merges them into an
+//   existing plain-object style attribute when present.
+// - Anything that cannot be judged safely is reported as MANUAL and left
+//   unchanged (per tag, or for the whole file).
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const TAGS = { Box: 'box', Text: 'text' };
+
+const STYLE_PROPS = new Set([
+  'flexDirection',
+  'padding',
+  'margin',
+  'gap',
+  'justifyContent',
+  'alignItems',
+  'borderStyle',
+  'borderColor',
+  'backgroundColor',
+  'width',
+  'height',
+  'flexGrow',
+  'flexShrink',
+]);
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  'build',
+  'coverage',
+  '.next',
+  '.turbo',
+]);
+
+const IDENT = /[A-Za-z0-9_$]/;
+const IDENT_START = /[A-Za-z_$]/;
+const isIdentStart = (c) => c !== undefined && IDENT_START.test(c);
+
+function lineOf(src, idx) {
+  let line = 1;
+  for (let i = 0; i < idx && i < src.length; i++) {
+    if (src[i] === '\n') line++;
+  }
+  return line;
+}
+
+// Builds a code mask over the source: code[i] === 1 means real code,
+// 0 means string/template body/comment. comment[i] === 1 marks comments.
+// Template literal interpolations are treated as code.
+function buildMask(src) {
+  const n = src.length;
+  const code = new Uint8Array(n).fill(1);
+  const comment = new Uint8Array(n);
+  let i = 0;
+  let lastCodeChar = '';
+  let wordBuf = '';
+
+  // '<' and '>' are deliberately absent: in JSX-bearing sources a '/' right
+  // after a closing tag (`</View> ... /`) or an opening bracket would start
+  // scanRegex, mask past the tag, and swallow everything up to the next
+  // stray '/'. A regex literal after a comparison operator (`a < /re/`) is
+  // not a shape real code writes.
+  const REGEX_PRECEDING = new Set([
+    '(',
+    ',',
+    '=',
+    ':',
+    '[',
+    '!',
+    '&',
+    '|',
+    '?',
+    '{',
+    '}',
+    ';',
+    '+',
+    '-',
+    '*',
+    '%',
+    '~',
+    '^',
+  ]);
+  const REGEX_KEYWORDS = new Set([
+    'return',
+    'typeof',
+    'instanceof',
+    'in',
+    'of',
+    'new',
+    'delete',
+    'void',
+    'throw',
+    'case',
+    'do',
+    'else',
+    'yield',
+    'await',
+  ]);
+
+  const mask = (a, b, isComment) => {
+    for (let x = a; x < b && x < n; x++) {
+      code[x] = 0;
+      if (isComment) comment[x] = 1;
+    }
+  };
+
+  function scanString(quote) {
+    const start = i;
+    i++;
+    while (i < n) {
+      const c = src[i];
+      if (c === '\\') {
+        i += 2;
+        continue;
+      }
+      if (c === quote) {
+        i++;
+        break;
+      }
+      if (c === '\n') break;
+      i++;
+    }
+    mask(start, i);
+    lastCodeChar = quote;
+    wordBuf = '';
+  }
+
+  function scanTemplateBody() {
+    while (i < n) {
+      const c = src[i];
+      if (c === '\\') {
+        code[i] = 0;
+        if (i + 1 < n) code[i + 1] = 0;
+        i += 2;
+        continue;
+      }
+      if (c === '`') {
+        code[i] = 0;
+        i++;
+        return;
+      }
+      if (c === '$' && src[i + 1] === '{') {
+        code[i] = 0;
+        code[i + 1] = 0;
+        i += 2;
+        scanInterp();
+        continue;
+      }
+      code[i] = 0;
+      i++;
+    }
+  }
+
+  function scanInterp() {
+    let depth = 0;
+    while (i < n) {
+      const c = src[i];
+      if (c === "'" || c === '"') {
+        scanString(c);
+        continue;
+      }
+      if (c === '`') {
+        code[i] = 0;
+        i++;
+        scanTemplateBody();
+        continue;
+      }
+      if (c === '/' && (src[i + 1] === '/' || src[i + 1] === '*')) {
+        scanComment();
+        continue;
+      }
+      if (c === '{') {
+        depth++;
+        i++;
+        continue;
+      }
+      if (c === '}') {
+        if (depth === 0) {
+          code[i] = 0;
+          i++;
+          return;
+        }
+        depth--;
+        i++;
+        continue;
+      }
+      i++;
+    }
+  }
+
+  function scanComment() {
+    const start = i;
+    if (src[i + 1] === '/') {
+      while (i < n && src[i] !== '\n') i++;
+    } else {
+      i += 2;
+      while (i < n && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i = Math.min(n, i + 2);
+    }
+    mask(start, i, true);
+  }
+
+  function regexAllowed() {
+    if (wordBuf !== '') return REGEX_KEYWORDS.has(wordBuf);
+    return REGEX_PRECEDING.has(lastCodeChar);
+  }
+
+  function scanRegex() {
+    const start = i;
+    i++;
+    let inClass = false;
+    let closed = false;
+    while (i < n) {
+      const c = src[i];
+      if (c === '\\') {
+        i += 2;
+        continue;
+      }
+      if (c === '\n') break;
+      if (inClass) {
+        if (c === ']') inClass = false;
+        i++;
+        continue;
+      }
+      if (c === '[') {
+        inClass = true;
+        i++;
+        continue;
+      }
+      if (c === '/') {
+        i++;
+        closed = true;
+        break;
+      }
+      i++;
+    }
+    if (!closed) {
+      i = start + 1;
+      return false;
+    }
+    while (i < n && /[dgimsuvy]/.test(src[i])) i++;
+    mask(start, i);
+    return true;
+  }
+
+  while (i < n) {
+    const c = src[i];
+    if (c === "'" || c === '"') {
+      scanString(c);
+      continue;
+    }
+    if (c === '`') {
+      code[i] = 0;
+      i++;
+      scanTemplateBody();
+      lastCodeChar = '`';
+      wordBuf = '';
+      continue;
+    }
+    if (c === '/' && (src[i + 1] === '/' || src[i + 1] === '*')) {
+      scanComment();
+      wordBuf = '';
+      continue;
+    }
+    if (c === '/' && regexAllowed() && scanRegex()) {
+      lastCodeChar = '/';
+      wordBuf = '';
+      continue;
+    }
+    if (IDENT.test(c)) {
+      wordBuf += c;
+      lastCodeChar = c;
+    } else {
+      wordBuf = '';
+      if (!/\s/.test(c)) lastCodeChar = c;
+    }
+    i++;
+  }
+
+  return { code, comment };
+}
+
+// Returns the index of the '}' matching the '{' at openIdx, or -1.
+function scanBalanced(src, code, openIdx) {
+  let depth = 0;
+  for (let i = openIdx; i < src.length; i++) {
+    if (!code[i]) continue;
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+// Parses the opening tag that starts with '<' at lt. Returns
+// { name, nameEnd, attrs, selfClosing, end } or { name, nameEnd, error }.
+function parseOpenTag(src, code, comment, lt) {
+  const n = src.length;
+  let i = lt + 1;
+  while (i < n && code[i] && IDENT.test(src[i])) i++;
+  const name = src.slice(lt + 1, i);
+  const nameEnd = i;
+  const attrs = [];
+
+  const skipInsignificant = () => {
+    while (i < n) {
+      if (code[i]) {
+        if (/\s/.test(src[i])) {
+          i++;
+          continue;
+        }
+        return true;
+      }
+      if (comment[i]) {
+        i++;
+        continue;
+      }
+      return false;
+    }
+    return false;
+  };
+
+  for (;;) {
+    if (!skipInsignificant()) {
+      return {
+        name,
+        nameEnd,
+        error:
+          i >= n
+            ? 'unterminated opening tag'
+            : 'unexpected string in opening tag',
+      };
+    }
+    const c = src[i];
+    if (c === '>')
+      return { name, nameEnd, attrs, selfClosing: false, end: i + 1 };
+    if (c === '/' && src[i + 1] === '>') {
+      return { name, nameEnd, attrs, selfClosing: true, end: i + 2 };
+    }
+    if (c === '{') {
+      let p = i + 1;
+      while (p < n && (comment[p] || (code[p] && /\s/.test(src[p])))) p++;
+      if (src.slice(p, p + 3) !== '...') {
+        return { name, nameEnd, error: 'expected spread attribute in {...}' };
+      }
+      const closeIdx = scanBalanced(src, code, i);
+      if (closeIdx === -1) {
+        return {
+          name,
+          nameEnd,
+          error: 'unbalanced braces in spread attribute',
+        };
+      }
+      attrs.push({ kind: 'spread', start: i, end: closeIdx + 1 });
+      i = closeIdx + 1;
+      continue;
+    }
+    if (!isIdentStart(c)) {
+      return {
+        name,
+        nameEnd,
+        error: `unexpected character in opening tag: ${JSON.stringify(c)}`,
+      };
+    }
+    const ns = i;
+    while (i < n && code[i] && /[A-Za-z0-9_$-]/.test(src[i])) i++;
+    const aname = src.slice(ns, i);
+    let q = i;
+    while (q < n && code[q] && /\s/.test(src[q])) q++;
+    if (src[q] === '=') {
+      q++;
+      while (q < n && code[q] && /\s/.test(src[q])) q++;
+      const qc = src[q];
+      if (qc === '"' || qc === "'") {
+        let r = q + 1;
+        while (r < n && src[r] !== qc) {
+          if (src[r] === '\\') r++;
+          r++;
+        }
+        if (r >= n)
+          return {
+            name,
+            nameEnd,
+            error: `unterminated value for attribute ${aname}`,
+          };
+        attrs.push({
+          kind: 'string',
+          name: aname,
+          start: ns,
+          end: r + 1,
+          valueStart: q,
+          valueEnd: r + 1,
+        });
+        i = r + 1;
+      } else if (qc === '{') {
+        const closeIdx = scanBalanced(src, code, q);
+        if (closeIdx === -1) {
+          return {
+            name,
+            nameEnd,
+            error: `unbalanced braces in attribute ${aname}`,
+          };
+        }
+        attrs.push({
+          kind: 'expr',
+          name: aname,
+          start: ns,
+          end: closeIdx + 1,
+          innerStart: q + 1,
+          innerEnd: closeIdx,
+        });
+        i = closeIdx + 1;
+      } else {
+        return {
+          name,
+          nameEnd,
+          error: `malformed value for attribute ${aname}`,
+        };
+      }
+    } else {
+      attrs.push({ kind: 'boolean', name: aname, start: ns, end: i });
+    }
+  }
+}
+
+// Inspects an existing style object literal interior [start, end).
+// Returns { keys } or { error } when the interior is too risky to merge.
+function analyzeStyleObject(src, code, comment, start, end) {
+  const keys = [];
+  let i = start;
+
+  const skipWs = () => {
+    while (i < end) {
+      if (code[i]) {
+        if (/\s/.test(src[i])) {
+          i++;
+          continue;
+        }
+        return null;
+      }
+      if (comment[i]) return 'comment inside existing style object';
+      return null;
+    }
+    return null;
+  };
+
+  for (;;) {
+    let err = skipWs();
+    if (err) return { error: err };
+    if (i >= end) return { keys };
+    if (!code[i]) {
+      if (src[i] !== '"' && src[i] !== "'") {
+        return { error: 'unsupported expression inside existing style object' };
+      }
+      const q = src[i];
+      let r = i + 1;
+      while (r < end && src[r] !== q) {
+        if (src[r] === '\\') r++;
+        r++;
+      }
+      if (r >= end)
+        return { error: 'unterminated string inside existing style object' };
+      keys.push(src.slice(i + 1, r));
+      i = r + 1;
+    } else {
+      const c = src[i];
+      if (c === '.' && src.slice(i, i + 3) === '...') {
+        return { error: 'spread inside existing style object' };
+      }
+      if (!/[A-Za-z0-9_$]/.test(c)) {
+        return { error: 'unsupported key inside existing style object' };
+      }
+      let r = i;
+      while (r < end && code[r] && IDENT.test(src[r])) r++;
+      keys.push(src.slice(i, r));
+      i = r;
+    }
+    err = skipWs();
+    if (err) return { error: err };
+    if (i >= end || !code[i] || src[i] !== ':') {
+      return { error: 'unsupported entry inside existing style object' };
+    }
+    i++;
+    let depth = 0;
+    let saw = false;
+    while (i < end) {
+      if (!code[i]) {
+        if (comment[i])
+          return { error: 'comment inside existing style object' };
+        saw = true;
+        i++;
+        continue;
+      }
+      const c = src[i];
+      if (c === '{' || c === '[' || c === '(') depth++;
+      else if (c === '}' || c === ']' || c === ')') {
+        if (depth === 0)
+          return { error: 'unbalanced value inside existing style object' };
+        depth--;
+      } else if (c === ',' && depth === 0) {
+        break;
+      }
+      if (!/\s/.test(c)) saw = true;
+      i++;
+    }
+    if (!saw) return { error: 'empty value inside existing style object' };
+    if (i < end && code[i] && src[i] === ',') {
+      i++;
+      continue;
+    }
+  }
+}
+
+// Builds the style-collection plan for one opening tag, or null when there
+// is nothing safe to collect (pushing a MANUAL note when applicable).
+function planStyleCollection(src, code, comment, open, notes) {
+  const attrs = open.attrs;
+  const collectedIdx = [];
+  let hasSpread = false;
+  attrs.forEach((a, idx) => {
+    if (a.kind === 'spread') hasSpread = true;
+    else if (STYLE_PROPS.has(a.name)) collectedIdx.push(idx);
+  });
+  if (collectedIdx.length === 0) return null;
+
+  const line = lineOf(src, open.start);
+  const tag = `<${open.name}>`;
+  const manual = (msg) => {
+    notes.push({ line, msg: `${msg} on ${tag} — left for manual migration` });
+    return null;
+  };
+
+  if (hasSpread) return manual('spread attribute(s) present');
+  const seen = new Set();
+  for (const idx of collectedIdx) {
+    const nm = attrs[idx].name;
+    if (seen.has(nm)) return manual(`duplicate style prop '${nm}'`);
+    seen.add(nm);
+  }
+  const styleIdxs = [];
+  attrs.forEach((a, idx) => {
+    if (a.name === 'style') styleIdxs.push(idx);
+  });
+  if (styleIdxs.length > 1) return manual('multiple style attributes');
+
+  const entries = [];
+  for (const idx of collectedIdx) {
+    const a = attrs[idx];
+    let raw;
+    if (a.kind === 'string') {
+      raw = src.slice(a.valueStart, a.valueEnd);
+      // A JSX string attribute and the JS string literal it gets pasted
+      // into decode '\' escapes and '&…;' entities with opposite
+      // semantics (JSX keeps a lone backslash literal and decodes
+      // entities; JS re-parses escapes and keeps entities literal), so a
+      // value carrying either marker cannot be copied verbatim into the
+      // generated style object.
+      const inner = raw.length >= 2 ? raw.slice(1, -1) : '';
+      if (inner.includes('\\') || inner.includes('&')) {
+        return manual(
+          `style prop '${a.name}' has a string value with JSX-specific escape/entity semantics`,
+        );
+      }
+    } else if (a.kind === 'expr') {
+      raw = src.slice(a.innerStart, a.innerEnd).trim();
+      if (raw === '')
+        return manual(`empty expression for style prop '${a.name}'`);
+    } else {
+      return manual(`boolean shorthand style prop '${a.name}'`);
+    }
+    entries.push(`${a.name}: ${raw}`);
+  }
+
+  let slotIdx;
+  let merged;
+  if (styleIdxs.length === 1) {
+    slotIdx = styleIdxs[0];
+    const s = attrs[slotIdx];
+    if (s.kind !== 'expr')
+      return manual('existing style attribute is not an object expression');
+    const inner = src.slice(s.innerStart, s.innerEnd);
+    const t = inner.trim();
+    if (!t.startsWith('{') || !t.endsWith('}')) {
+      return manual('existing style attribute is not a plain object literal');
+    }
+    const objOpen = s.innerStart + inner.indexOf('{');
+    const objClose = s.innerStart + inner.lastIndexOf('}');
+    const analysis = analyzeStyleObject(
+      src,
+      code,
+      comment,
+      objOpen + 1,
+      objClose,
+    );
+    if (analysis.error)
+      return manual(`existing style object: ${analysis.error}`);
+    const collectedNames = collectedIdx.map((idx) => attrs[idx].name);
+    const conflict = analysis.keys.find((k) => collectedNames.includes(k));
+    if (conflict !== undefined) {
+      return manual(`key '${conflict}' already present in style object`);
+    }
+    let base = src.slice(objOpen + 1, objClose).trim();
+    if (base.endsWith(',')) base = base.slice(0, -1).trimEnd();
+    merged =
+      base === '' ? entries.join(', ') : `${base}, ${entries.join(', ')}`;
+  } else {
+    slotIdx = collectedIdx[0];
+    merged = entries.join(', ');
+  }
+
+  const remove = new Set(collectedIdx.filter((idx) => idx !== slotIdx));
+  return {
+    slotIdx,
+    remove,
+    styleText: `style={{ ${merged} }}`,
+    count: collectedIdx.length,
+  };
+}
+
+function renderOpenTag(src, open, plan) {
+  const parts = [];
+  open.attrs.forEach((a, idx) => {
+    if (plan.remove.has(idx)) return;
+    if (idx === plan.slotIdx) {
+      parts.push(plan.styleText);
+      return;
+    }
+    parts.push(src.slice(a.start, a.end));
+  });
+  const name = TAGS[open.name];
+  return `<${name}${parts.length ? ' ' + parts.join(' ') : ''}${open.selfClosing ? ' />' : '>'}`;
+}
+
+// Transforms one source string. Returns
+// { output, changed, notes: [{line, msg}], stats: {box, text, propsCollected, styleTags} }.
+export function transformSource(src) {
+  const { code, comment } = buildMask(src);
+  const notes = [];
+  const zeroStats = () => ({
+    box: 0,
+    text: 0,
+    propsCollected: 0,
+    styleTags: 0,
+  });
+  const bail = (msg, at) => ({
+    output: src,
+    changed: false,
+    notes: [...notes, { line: lineOf(src, at), msg }],
+    stats: zeroStats(),
+  });
+
+  const n = src.length;
+  const events = [];
+  for (let k = 0; k < n; k++) {
+    if (!code[k] || src[k] !== '<') continue;
+    if (src[k + 1] === '/') {
+      let j = k + 2;
+      while (j < n && IDENT.test(src[j])) j++;
+      const nm = src.slice(k + 2, j);
+      if (!(nm in TAGS)) continue;
+      let g = j;
+      while (g < n && /\s/.test(src[g])) g++;
+      if (src[g] !== '>') continue;
+      events.push({ type: 'close', name: nm, start: k, end: g + 1 });
+      k = g;
+      continue;
+    }
+    if (!isIdentStart(src[k + 1])) continue;
+    if (k > 0 && code[k - 1] && IDENT.test(src[k - 1])) continue;
+    let j = k + 1;
+    while (j < n && IDENT.test(src[j])) j++;
+    const nm = src.slice(k + 1, j);
+    if (!(nm in TAGS)) continue;
+    if (src[j] === '.') {
+      notes.push({
+        line: lineOf(src, k),
+        msg: `member element <${nm}....> — left for manual migration`,
+      });
+      continue;
+    }
+    const parsed = parseOpenTag(src, code, comment, k);
+    if (parsed.error) {
+      return bail(
+        `could not parse <${nm}> (${parsed.error}) — file left unchanged`,
+        k,
+      );
+    }
+    events.push({ type: 'open', name: nm, start: k, ...parsed });
+  }
+
+  const stack = [];
+  const elements = [];
+  for (const ev of events) {
+    if (ev.type === 'open') {
+      if (ev.selfClosing) elements.push({ open: ev, close: null });
+      else stack.push(ev);
+      continue;
+    }
+    const top = stack.pop();
+    if (!top || top.name !== ev.name) {
+      return bail(
+        `mismatched closing tag </${ev.name}> — file left unchanged`,
+        ev.start,
+      );
+    }
+    elements.push({ open: top, close: ev });
+  }
+  if (stack.length > 0) {
+    const top = stack[stack.length - 1];
+    return bail(`unclosed <${top.name}> — file left unchanged`, top.start);
+  }
+
+  const stats = zeroStats();
+  const edits = [];
+  for (const el of elements) {
+    const plan = planStyleCollection(src, code, comment, el.open, notes);
+    if (plan) {
+      edits.push({
+        start: el.open.start,
+        end: el.open.end,
+        text: renderOpenTag(src, el.open, plan),
+      });
+      stats.propsCollected += plan.count;
+      stats.styleTags++;
+    } else {
+      edits.push({
+        start: el.open.start + 1,
+        end: el.open.start + 1 + el.open.name.length,
+        text: TAGS[el.open.name],
+      });
+    }
+    if (el.close) {
+      edits.push({
+        start: el.close.start + 2,
+        end: el.close.start + 2 + el.close.name.length,
+        text: TAGS[el.close.name],
+      });
+    }
+    if (el.open.name === 'Box') stats.box++;
+    else stats.text++;
+  }
+
+  edits.sort((a, b) => a.start - b.start);
+  let out = '';
+  let last = 0;
+  for (const e of edits) {
+    if (e.start < last) return bail('internal error: overlapping edits', 0);
+    out += src.slice(last, e.start) + e.text;
+    last = e.end;
+  }
+  out += src.slice(last);
+
+  return { output: out, changed: out !== src, notes, stats };
+}
+
+function collectFiles(targets) {
+  const out = [];
+  const seen = new Set();
+  const push = (p) => {
+    if (!seen.has(p)) {
+      seen.add(p);
+      out.push(p);
+    }
+  };
+  const walk = (dir) => {
+    for (const ent of readdirSync(dir, { withFileTypes: true })) {
+      if (ent.name.startsWith('.') || SKIP_DIRS.has(ent.name)) continue;
+      const p = join(dir, ent.name);
+      if (ent.isDirectory()) walk(p);
+      else if (ent.isFile() && /\.(tsx|jsx)$/.test(ent.name)) push(p);
+    }
+  };
+  for (const t of targets) {
+    const st = statSync(t, { throwIfNoEntry: false });
+    if (!st) throw new Error(`no such file or directory: ${t}`);
+    if (st.isDirectory()) walk(t);
+    else if (/\.(tsx|jsx)$/.test(t)) push(t);
+    else console.error(`warning: skipping ${t} (not .tsx/.jsx)`);
+  }
+  return out;
+}
+
+function usage() {
+  return [
+    'Usage: node ink-to-opentui.mjs [--dry-run|--apply] <file-or-dir>...',
+    '',
+    'Conservative ink -> opentui JSX codemod.',
+    '  --dry-run (default)  report planned changes per file, write nothing',
+    '  --apply              write changes to files',
+    '',
+    'Renames <Box>/<Text> to <box>/<text> and moves known style props into',
+    'style={{...}}. Anything unsafe is reported as MANUAL and left unchanged.',
+    '',
+  ].join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let apply = false;
+  const targets = [];
+  for (const a of args) {
+    if (a === '-h' || a === '--help') {
+      process.stdout.write(usage());
+      return;
+    }
+    if (a === '--apply') apply = true;
+    else if (a === '--dry-run') apply = false;
+    else if (a.startsWith('-')) {
+      console.error(`unknown option: ${a}\n\n${usage()}`);
+      process.exit(2);
+    } else targets.push(a);
+  }
+  if (targets.length === 0) {
+    console.error(usage());
+    process.exit(2);
+  }
+  let files;
+  try {
+    files = collectFiles(targets);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(2);
+  }
+  if (files.length === 0) {
+    console.error('no .tsx/.jsx input files found');
+    process.exit(2);
+  }
+  const mode = apply ? 'apply' : 'dry-run';
+  const totals = {
+    files: files.length,
+    changed: 0,
+    box: 0,
+    text: 0,
+    props: 0,
+    styleTags: 0,
+    manual: 0,
+  };
+  let ioError = false;
+  for (const f of files) {
+    let src;
+    try {
+      src = readFileSync(f, 'utf8');
+    } catch (err) {
+      console.error(`[${mode}] ${f}\n  error: ${err.message}`);
+      ioError = true;
+      continue;
+    }
+    const res = transformSource(src);
+    console.log(`[${mode}] ${f}`);
+    console.log(
+      `  rename: ${res.stats.box + res.stats.text} element(s) (box: ${res.stats.box}, text: ${res.stats.text})`,
+    );
+    console.log(
+      `  style: ${res.stats.propsCollected} prop(s) collected into style on ${res.stats.styleTags} tag(s)`,
+    );
+    for (const note of res.notes)
+      console.log(`  MANUAL (line ${note.line}): ${note.msg}`);
+    if (!res.changed) console.log('  no changes');
+    else if (apply) {
+      try {
+        writeFileSync(f, res.output);
+        console.log('  written');
+      } catch (err) {
+        console.error(`  error writing file: ${err.message}`);
+        ioError = true;
+        continue;
+      }
+    }
+    totals.box += res.stats.box;
+    totals.text += res.stats.text;
+    totals.props += res.stats.propsCollected;
+    totals.styleTags += res.stats.styleTags;
+    totals.manual += res.notes.length;
+    if (res.changed) totals.changed++;
+  }
+  const suffix = apply ? '' : ' — dry-run, nothing written';
+  console.log(
+    `Summary (${mode}): ${totals.files} file(s), ${totals.changed} changed, ` +
+      `${totals.box + totals.text} element(s) renamed (box: ${totals.box}, text: ${totals.text}), ` +
+      `${totals.props} prop(s) collected, ${totals.manual} MANUAL note(s)${suffix}`,
+  );
+  if (ioError) process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -317,6 +317,10 @@ function stampReviewSourceDigest(root, distDir) {
 export function copyOpenTuiAssets({ root = defaultRoot, distDir } = {}) {
   distDir ??= join(root, 'dist');
   const destRoot = join(distDir, 'opentui-assets');
+  // Start from a clean tree: the runtime gate below checks key existence
+  // only, so a tree left by an earlier bundle would still satisfy it and
+  // ship stale native libraries after the installed platform set changed.
+  fs.rmSync(destRoot, { recursive: true, force: true });
 
   // @opentui/core may sit in the root node_modules or be hoisted into
   // packages/cli/node_modules (it is a cli dependency); try both anchors.

--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -35,6 +35,7 @@ import {
   extname,
 } from 'node:path';
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
 import fs from 'node:fs';
@@ -290,6 +291,146 @@ function stampReviewSourceDigest(root, distDir) {
   console.log(`Stamped the review source digest over ${count} files.`);
 }
 
+/**
+ * OpenTUI renderer runtime assets (tree-sitter grammars, the parser worker,
+ * `web-tree-sitter` runtime and the native render library) relocated next to
+ * the bundle.
+ *
+ * In the esbuild single-file bundle @opentui/core's package-relative asset
+ * fallback (`new URL('./assets/…', import.meta.url)`) points into `dist/`
+ * and misses, so code-block syntax highlighting degrades to single color.
+ * The runtime (`packages/cli/src/ui/opentui/opentui-assets.ts`) therefore
+ * points `OTUI_ASSET_ROOT` at `dist/opentui-assets/` — but only when the tree
+ * there is complete, because @opentui/core throws on any missing key under a
+ * configured root (including the native library). This copier writes the
+ * assets under exactly the keys that module checks:
+ *
+ *   opentui-assets/@opentui/core/parser.worker.js
+ *   opentui-assets/@opentui/core/assets/<lang>/<file>
+ *   opentui-assets/@opentui/core-<platform>-<arch>[ -musl]/libopentui.*
+ *   opentui-assets/web-tree-sitter/tree-sitter.wasm
+ *
+ * Returns the list of destination-relative keys copied (empty on skip) so
+ * callers/tests can assert on it. Never fails the bundle: a missing
+ * @opentui/core (e.g. an install without the renderer) only warns.
+ */
+export function copyOpenTuiAssets({ root = defaultRoot, distDir } = {}) {
+  distDir ??= join(root, 'dist');
+  const destRoot = join(distDir, 'opentui-assets');
+
+  // @opentui/core may sit in the root node_modules or be hoisted into
+  // packages/cli/node_modules (it is a cli dependency); try both anchors.
+  const anchors = [
+    join(root, 'package.json'),
+    join(root, 'packages', 'cli', 'package.json'),
+  ];
+  let coreEntry;
+  for (const anchor of anchors) {
+    if (!existsSync(anchor)) continue;
+    try {
+      coreEntry = createRequire(anchor).resolve('@opentui/core');
+      break;
+    } catch {
+      // try the next anchor
+    }
+  }
+  if (!coreEntry) {
+    console.warn(
+      'Warning: @opentui/core is not resolvable; skipped OpenTUI assets',
+    );
+    return [];
+  }
+  const coreDir = dirname(coreEntry);
+  const coreRequire = createRequire(join(coreDir, 'package.json'));
+
+  const copied = [];
+  const copyToKey = (source, key) => {
+    if (!existsSync(source) || !statSync(source).isFile()) {
+      console.warn(`Warning: OpenTUI asset missing at ${source}; skipped`);
+      return;
+    }
+    const destPath = join(destRoot, key);
+    mkdirSync(dirname(destPath), { recursive: true });
+    copyFileSync(source, destPath);
+    copied.push(key);
+  };
+
+  // 1. The tree-sitter parser worker (self-contained bundle).
+  copyToKey(
+    join(coreDir, 'parser.worker.js'),
+    '@opentui/core/parser.worker.js',
+  );
+
+  // 2. Grammar assets: assets/<lang>/{highlights.scm,injections.scm,*.wasm}.
+  const assetsDir = join(coreDir, 'assets');
+  if (existsSync(assetsDir)) {
+    for (const lang of fs.readdirSync(assetsDir)) {
+      const langDir = join(assetsDir, lang);
+      if (!statSync(langDir).isDirectory()) continue;
+      for (const file of fs.readdirSync(langDir)) {
+        copyToKey(join(langDir, file), `@opentui/core/assets/${lang}/${file}`);
+      }
+    }
+  } else {
+    console.warn(`Warning: OpenTUI grammar assets not found at ${assetsDir}`);
+  }
+
+  // 3. The web-tree-sitter runtime wasm (peer dependency of @opentui/core).
+  let wasmSource;
+  try {
+    wasmSource = coreRequire.resolve('web-tree-sitter/tree-sitter.wasm');
+  } catch {
+    try {
+      wasmSource = join(
+        dirname(coreRequire.resolve('web-tree-sitter')),
+        'tree-sitter.wasm',
+      );
+    } catch {
+      wasmSource = undefined;
+    }
+  }
+  if (wasmSource) {
+    copyToKey(wasmSource, 'web-tree-sitter/tree-sitter.wasm');
+  } else {
+    console.warn(
+      'Warning: web-tree-sitter is not resolvable; skipped its wasm asset',
+    );
+  }
+
+  // 4. Native render libraries for every installed @opentui platform package
+  //    (core-darwin-arm64, core-linux-x64-musl, …). The runtime only needs
+  //    the current platform's, but shipping the installed set keeps the
+  //    completeness check satisfiable wherever the bundle runs next. The
+  //    platform packages live beside @opentui/core or hoisted at the repo
+  //    root; scan both scope directories.
+  const scopeDirs = [dirname(coreDir), join(root, 'node_modules', '@opentui')];
+  const seenPackages = new Set();
+  for (const scopeDir of scopeDirs) {
+    if (!existsSync(scopeDir)) continue;
+    for (const entry of fs.readdirSync(scopeDir)) {
+      if (!entry.startsWith('core-') || seenPackages.has(entry)) continue;
+      const packageDir = join(scopeDir, entry);
+      if (!statSync(packageDir).isDirectory()) continue;
+      let copiedFromPackage = false;
+      for (const file of fs.readdirSync(packageDir)) {
+        if (!/\.(dylib|so|dll)$/.test(file)) continue;
+        copyToKey(join(packageDir, file), `@opentui/${entry}/${file}`);
+        copiedFromPackage = true;
+      }
+      if (copiedFromPackage) seenPackages.add(entry);
+    }
+  }
+
+  if (copied.length > 0) {
+    console.log(
+      `Copied ${copied.length} OpenTUI runtime assets to dist/opentui-assets/`,
+    );
+  } else {
+    console.warn('Warning: no OpenTUI runtime assets were copied');
+  }
+  return copied;
+}
+
 export function copyBundleAssets({ root = defaultRoot } = {}) {
   const distDir = join(root, 'dist');
   const coreVendorDir = join(root, 'packages', 'core', 'vendor');
@@ -368,6 +509,12 @@ export function copyBundleAssets({ root = defaultRoot } = {}) {
   } else {
     console.warn(`Warning: Locales directory not found at ${localesDir}`);
   }
+
+  // Copy the OpenTUI renderer's runtime assets (tree-sitter grammars, parser
+  // worker, web-tree-sitter wasm, native render library) so the bundled
+  // renderer can point OTUI_ASSET_ROOT at dist/opentui-assets/ and keep
+  // code-block syntax highlighting. Warn-and-skip when unavailable.
+  copyOpenTuiAssets({ root, distDir });
 
   // Copy extension templates so bundled dist/cli.js can scaffold
   // `/extensions new` from the runtime examples directory.

--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -169,7 +169,7 @@ async function main() {
     fs.mkdirSync(packageRoot, { recursive: true });
     fs.mkdirSync(runtimeExtractDir, { recursive: true });
 
-    copyRuntimeAssets(packageRoot, outDir);
+    copyRuntimeAssets(packageRoot, outDir, args.runtime);
     copyNativeAddon(packageRoot, target);
     copyClipboardAddon(packageRoot, target, args.nativeModulesDir);
     if (args.runtime === 'bun') {
@@ -337,11 +337,16 @@ function readPackageVersion() {
   return packageJson.version;
 }
 
-function copyRuntimeAssets(packageRoot, outDir) {
+function copyRuntimeAssets(packageRoot, outDir, runtime) {
   const libDir = path.join(packageRoot, 'lib');
   const skippedDistEntry = topLevelDistEntryForPath(outDir);
   fs.mkdirSync(libDir, { recursive: true });
 
+  // Classic Node packaging carries no renderer payload: the OpenTUI backend
+  // needs bun:ffi, and cross-built archives would hold another platform's
+  // native library, so the all-or-nothing asset gate could never activate.
+  // (--runtime=bun copies it here and prunes it to the target's libraries in
+  // copyOpenTuiAddon.)
   for (const entry of fs.readdirSync(distDir)) {
     // Standalone rebuilds a clean, target-trimmed lib/node_modules via the
     // native addon copy steps. If a local dist/node_modules exists from older
@@ -351,6 +356,7 @@ function copyRuntimeAssets(packageRoot, outDir) {
       entry === skippedDistEntry ||
       entry === '.DS_Store' ||
       entry === 'node_modules' ||
+      (entry === 'opentui-assets' && runtime !== 'bun') ||
       DIST_NPM_PACKAGE_ONLY_ENTRIES.has(entry)
     ) {
       continue;
@@ -541,6 +547,25 @@ function copyOpenTuiAddon(packageRoot, target, opentuiModulesDir) {
         path.join(packageSrc, library),
         path.join(assetDestDir, library),
       );
+    }
+  }
+
+  // The relocated tree ships the BUILD host's platform library; any other
+  // platform package directory is dead weight the runtime can never load.
+  if (packageNames.length > 0) {
+    const targetBasenames = new Set(
+      packageNames.map((packageName) => packageName.split('/')[1]),
+    );
+    const scopeDir = path.join(assetRoot, '@opentui');
+    if (fs.existsSync(scopeDir)) {
+      for (const entry of fs.readdirSync(scopeDir)) {
+        if (/^core-/.test(entry) && !targetBasenames.has(entry)) {
+          fs.rmSync(path.join(scopeDir, entry), {
+            recursive: true,
+            force: true,
+          });
+        }
+      }
     }
   }
 

--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -56,6 +56,20 @@ const TARGET_CLIPBOARD_PACKAGE = new Map([
   ['win-x64', '@teddyzhu/clipboard-win32-x64-msvc'],
 ]);
 
+// Temporary OpenTUI preview: platform packages whose native render library is
+// resolved at runtime via `import('@opentui/core-<platform>-<arch>')`. Linux
+// targets carry both glibc and musl variants (selected via OPENTUI_LIBC).
+const TARGET_OPENTUI_PACKAGES = new Map([
+  ['darwin-arm64', ['@opentui/core-darwin-arm64']],
+  ['darwin-x64', ['@opentui/core-darwin-x64']],
+  [
+    'linux-arm64',
+    ['@opentui/core-linux-arm64', '@opentui/core-linux-arm64-musl'],
+  ],
+  ['linux-x64', ['@opentui/core-linux-x64', '@opentui/core-linux-x64-musl']],
+  ['win-x64', ['@opentui/core-win32-x64']],
+]);
+
 const DIST_REQUIRED_PATHS = [
   'cli.js',
   'cli-entry.js',
@@ -84,6 +98,12 @@ const DIST_ALLOWED_ENTRIES = new Set([
   'review-sources.sha256',
   'locales',
   'examples',
+  // OpenTUI renderer runtime assets (tree-sitter grammars, parser worker,
+  // web-tree-sitter wasm, native render library) relocated by
+  // copy_bundle_assets.js; the bundled renderer sets OTUI_ASSET_ROOT to this
+  // directory for code-block syntax highlighting. copyOpenTuiAddon syncs the
+  // target's native library into it.
+  'opentui-assets',
   // Web Shell SPA served at the daemon root by `qwen serve` (index.html +
   // assets/). Copied into dist/web-shell/ by copy_bundle_assets.js when the
   // web-shell workspace has been built; optional, so it's allowed but not
@@ -120,6 +140,10 @@ async function main() {
     fail(`--target must be one of: ${Array.from(TARGETS.keys()).join(', ')}`);
   }
 
+  if (args.runtime !== 'node' && args.runtime !== 'bun') {
+    fail('--runtime must be either "node" or "bun"');
+  }
+
   if (!args.nodeArchive) {
     fail('--node-archive is required');
   }
@@ -149,15 +173,24 @@ async function main() {
     copyRuntimeAssets(packageRoot, outDir);
     copyNativeAddon(packageRoot, target);
     copyClipboardAddon(packageRoot, target, args.nativeModulesDir);
+    if (args.runtime === 'bun') {
+      copyOpenTuiAddon(packageRoot, target, args.opentuiModulesDir);
+    }
     extractNodeArchive(nodeArchive, runtimeExtractDir);
     const nodeDir = path.join(packageRoot, 'node');
-    copyExtractedNode(runtimeExtractDir, nodeDir);
+    if (args.runtime === 'bun') {
+      installBunRuntime(runtimeExtractDir, nodeDir, target);
+      validateBunRuntime(target, packageRoot);
+    } else {
+      copyExtractedNode(runtimeExtractDir, nodeDir);
+    }
     validateNodeRuntime(target, nodeDir);
-    writeShims(packageRoot);
+    writeShims(packageRoot, args.runtime);
     writeManifest(packageRoot, {
       version,
       target,
       nodeArchive: path.basename(nodeArchive),
+      runtime: args.runtime,
     });
 
     if (fs.existsSync(outputPath)) {
@@ -187,8 +220,10 @@ function parseArgs(argv) {
   const args = {
     help: false,
     nativeModulesDir: undefined,
+    opentuiModulesDir: undefined,
     outDir: undefined,
     nodeArchive: undefined,
+    runtime: 'node',
     skipChecksums: false,
     target: undefined,
     version: undefined,
@@ -205,12 +240,20 @@ function parseArgs(argv) {
         args.target = readOptionValue(argv, index, arg);
         index += 1;
         break;
+      case '--runtime':
+        args.runtime = readOptionValue(argv, index, arg);
+        index += 1;
+        break;
       case '--node-archive':
         args.nodeArchive = readOptionValue(argv, index, arg);
         index += 1;
         break;
       case '--native-modules-dir':
         args.nativeModulesDir = readOptionValue(argv, index, arg);
+        index += 1;
+        break;
+      case '--opentui-modules-dir':
+        args.opentuiModulesDir = readOptionValue(argv, index, arg);
         index += 1;
         break;
       case '--out-dir':
@@ -248,10 +291,18 @@ Usage:
 
 Options:
   --target TARGET         One of: ${Array.from(TARGETS.keys()).join(', ')}
+  --runtime RUNTIME       Runtime archive flavor: "node" (default) or "bun".
+                          Temporary OpenTUI preview: "bun" installs the Bun
+                          binary at the bundled runtime path so the OpenTUI
+                          renderer (needs bun:ffi) works standalone.
   --node-archive PATH     Downloaded Node.js runtime archive.
   --native-modules-dir DIR
                           Staged native node_modules directory. Missing
                           clipboard packages are fatal when this is supplied.
+  --opentui-modules-dir DIR
+                          Staged node_modules directory holding @opentui
+                          platform packages. Used with --runtime bun; missing
+                          packages are fatal when this is supplied.
   --out-dir DIR           Output directory. Defaults to dist/standalone.
   --version VERSION       Qwen Code version. Defaults to package.json version.
   --skip-checksums        Do not update SHA256SUMS. Used by release packaging.
@@ -442,6 +493,61 @@ function copyClipboardAddon(packageRoot, target, nativeModulesDir) {
   assertNoSymlinks(
     modulesDest,
     'Bundled clipboard addon still contains symlinks.',
+  );
+}
+
+// Temporary OpenTUI preview: bundle the target's @opentui platform package(s)
+// into lib/node_modules so the backend's runtime
+// `import('@opentui/core-<platform>-<arch>')` resolves inside the archive.
+function copyOpenTuiAddon(packageRoot, target, opentuiModulesDir) {
+  const packageNames = TARGET_OPENTUI_PACKAGES.get(target) || [];
+  const modulesSrc = path.resolve(
+    opentuiModulesDir || path.join(rootDir, 'node_modules'),
+  );
+  const modulesDest = path.join(packageRoot, 'lib', 'node_modules');
+  // The relocated OpenTUI asset root written by copy_bundle_assets.js carries
+  // only the BUILD host's native library; sync this TARGET's libraries into
+  // it so the runtime's OTUI_ASSET_ROOT completeness check (which includes
+  // the native library) passes inside the archive.
+  const assetRoot = path.join(packageRoot, 'lib', 'opentui-assets');
+  const copyOpts = {
+    recursive: true,
+    dereference: true,
+    verbatimSymlinks: false,
+  };
+
+  for (const packageName of packageNames) {
+    const packageSrc = path.join(modulesSrc, packageName);
+    const nativeLibraries = fs.existsSync(path.join(packageSrc, 'package.json'))
+      ? fs
+          .readdirSync(packageSrc)
+          .filter((entry) => /\.(dylib|so|dll)$/.test(entry))
+      : [];
+
+    if (nativeLibraries.length === 0) {
+      const message = `OpenTUI platform package ${packageName} for ${target} is missing from ${modulesSrc}`;
+      if (opentuiModulesDir) {
+        fail(`Required ${message}`);
+      }
+      console.warn(`[standalone] ${message}; OpenTUI renderer unavailable.`);
+      continue;
+    }
+
+    fs.cpSync(packageSrc, path.join(modulesDest, packageName), copyOpts);
+
+    for (const library of nativeLibraries) {
+      const assetDestDir = path.join(assetRoot, packageName);
+      fs.mkdirSync(assetDestDir, { recursive: true });
+      fs.copyFileSync(
+        path.join(packageSrc, library),
+        path.join(assetDestDir, library),
+      );
+    }
+  }
+
+  assertNoSymlinks(
+    modulesDest,
+    'Bundled OpenTUI addon still contains symlinks.',
   );
 }
 
@@ -669,24 +775,108 @@ function validateNodeRuntime(target, nodeDir) {
   }
 }
 
-function writeShims(packageRoot) {
+function validateBunRuntime(target, packageRoot) {
+  const relativePath =
+    target === 'win-x64'
+      ? path.join('bun', 'bun.exe')
+      : path.join('bun', 'bin', 'bun');
+  const executablePath = path.join(packageRoot, relativePath);
+
+  if (!fs.existsSync(executablePath)) {
+    fail(`Bun runtime for ${target} must contain ${relativePath}.`);
+  }
+
+  if (target !== 'win-x64') {
+    const mode = fs.statSync(executablePath).mode;
+    if ((mode & 0o111) === 0) {
+      fail(
+        `Bun runtime for ${target} must provide executable ${relativePath}.`,
+      );
+    }
+  }
+}
+
+// Temporary OpenTUI preview support: Bun release archives contain a single
+// executable (`bun` / `bun.exe`). It is installed under `bun/` and launched
+// by that name — Bun invoked as `node` enters its node-compat CLI mode,
+// which breaks the interactive TUI. A placeholder is also placed at the
+// classic `node/bin/node` path so installer scripts that validate that
+// layout keep working unchanged. It must be a REGULAR file: the installers
+// refuse archives containing symlinks or hardlinks, and a hardlink mirror
+// tripped exactly that check. Unix gets a tiny exec shim (zero size cost);
+// Windows gets a plain copy because a `.sh` shim cannot impersonate an exe.
+function installBunRuntime(extractDir, nodeDir, target) {
+  const executableName = target === 'win-x64' ? 'bun.exe' : 'bun';
+  const sourcePath = findFileRecursive(extractDir, executableName);
+  if (!sourcePath) {
+    fail(`Bun runtime archive did not contain ${executableName}.`);
+  }
+
+  const targetConfig = TARGETS.get(target);
+  const packageRoot = path.dirname(nodeDir);
+  const bunRelativePath =
+    target === 'win-x64'
+      ? path.join('bun', 'bun.exe')
+      : path.join('bun', 'bin', 'bun');
+  const bunPath = path.join(packageRoot, bunRelativePath);
+  fs.mkdirSync(path.dirname(bunPath), { recursive: true });
+  fs.copyFileSync(sourcePath, bunPath);
+  fs.chmodSync(bunPath, 0o755);
+
+  // Installer-script compatibility mirror at the Node.js layout path.
+  const compatPath = path.join(nodeDir, ...targetConfig.nodeExecutable);
+  fs.mkdirSync(path.dirname(compatPath), { recursive: true });
+  if (target === 'win-x64') {
+    fs.copyFileSync(bunPath, compatPath);
+  } else {
+    fs.writeFileSync(
+      compatPath,
+      '#!/usr/bin/env sh\n' +
+        '# OpenTUI preview: the bundled runtime is Bun; this placeholder keeps\n' +
+        '# installers that validate the classic Node.js layout working.\n' +
+        'exec "$(dirname "$0")/../../bun/bin/bun" "$@"\n',
+    );
+  }
+  fs.chmodSync(compatPath, 0o755);
+}
+
+function findFileRecursive(dir, fileName) {
+  for (const entry of fs.readdirSync(dir)) {
+    const fullPath = path.join(dir, entry);
+    if (fs.statSync(fullPath).isDirectory()) {
+      const nested = findFileRecursive(fullPath, fileName);
+      if (nested) {
+        return nested;
+      }
+    } else if (entry === fileName) {
+      return fullPath;
+    }
+  }
+  return undefined;
+}
+
+function writeShims(packageRoot, runtime) {
   const binDir = path.join(packageRoot, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
 
+  const unixRuntime =
+    runtime === 'bun' ? '$ROOT/bun/bin/bun' : '$ROOT/node/bin/node';
   const unixShim = `#!/usr/bin/env sh
 set -e
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-QWEN_CODE_LAUNCHER_PATH="$ROOT/bin/qwen" exec "$ROOT/node/bin/node" "$ROOT/lib/cli-entry.js" "$@"
+QWEN_CODE_LAUNCHER_PATH="$ROOT/bin/qwen" exec "${unixRuntime}" "$ROOT/lib/cli-entry.js" "$@"
 `;
   const unixShimPath = path.join(binDir, 'qwen');
   fs.writeFileSync(unixShimPath, unixShim);
   fs.chmodSync(unixShimPath, 0o755);
 
+  const windowsRuntime =
+    runtime === 'bun' ? '%ROOT%\\bun\\bun.exe' : '%ROOT%\\node\\node.exe';
   const windowsShim = `@echo off
 setlocal
 set "ROOT=%~dp0.."
 set "QWEN_CODE_LAUNCHER_PATH=%ROOT%\\bin\\qwen.cmd"
-"%ROOT%\\node\\node.exe" "%ROOT%\\lib\\cli-entry.js" %*
+"${windowsRuntime}" "%ROOT%\\lib\\cli-entry.js" %*
 exit /b %ERRORLEVEL%
 `;
   fs.writeFileSync(path.join(binDir, 'qwen.cmd'), windowsShim);
@@ -701,6 +891,7 @@ function writeManifest(packageRoot, manifest) {
         name: '@qwen-code/qwen-code',
         version: manifest.version,
         target: manifest.target,
+        runtime: manifest.runtime || 'node',
         nodeArchive: manifest.nodeArchive,
         createdAt: new Date().toISOString(),
       },

--- a/scripts/create-standalone-package.js
+++ b/scripts/create-standalone-package.js
@@ -58,15 +58,14 @@ const TARGET_CLIPBOARD_PACKAGE = new Map([
 
 // Temporary OpenTUI preview: platform packages whose native render library is
 // resolved at runtime via `import('@opentui/core-<platform>-<arch>')`. Linux
-// targets carry both glibc and musl variants (selected via OPENTUI_LIBC).
+// is glibc-only: the bundled Bun runtime is glibc-linked and cannot start on
+// musl hosts, so shipping -musl render packages would claim support the
+// archive cannot deliver.
 const TARGET_OPENTUI_PACKAGES = new Map([
   ['darwin-arm64', ['@opentui/core-darwin-arm64']],
   ['darwin-x64', ['@opentui/core-darwin-x64']],
-  [
-    'linux-arm64',
-    ['@opentui/core-linux-arm64', '@opentui/core-linux-arm64-musl'],
-  ],
-  ['linux-x64', ['@opentui/core-linux-x64', '@opentui/core-linux-x64-musl']],
+  ['linux-arm64', ['@opentui/core-linux-arm64']],
+  ['linux-x64', ['@opentui/core-linux-x64']],
   ['win-x64', ['@opentui/core-win32-x64']],
 ]);
 

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -326,6 +326,13 @@ function writeDistPackageJson(rootDir, distDir) {
       'examples',
       'bundled',
       'web-shell',
+      // OpenTUI renderer runtime assets (tree-sitter grammars, parser worker,
+      // web-tree-sitter wasm) are intentionally NOT published in the npm
+      // package: npm installs run on Node, where the runtime gate falls back
+      // to ink, so the assets would be dead weight (~22MB on the linux CI
+      // platform's native render library alone) against the unpacked-size
+      // budget. Standalone archives (which bake Bun and do render OpenTUI)
+      // carry them via create-standalone-package.js instead.
     ],
     config: rootPackageJson.config,
     dependencies: {},

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -327,12 +327,16 @@ function writeDistPackageJson(rootDir, distDir) {
       'bundled',
       'web-shell',
       // OpenTUI renderer runtime assets (tree-sitter grammars, parser worker,
-      // web-tree-sitter wasm) are intentionally NOT published in the npm
-      // package: npm installs run on Node, where the runtime gate falls back
-      // to ink, so the assets would be dead weight (~22MB on the linux CI
-      // platform's native render library alone) against the unpacked-size
-      // budget. Standalone archives (which bake Bun and do render OpenTUI)
-      // carry them via create-standalone-package.js instead.
+      // web-tree-sitter wasm, native render library) are intentionally NOT
+      // published in the npm package — a multi-megabyte tree dominated by the
+      // native render library — against the unpacked-size budget. An npm
+      // install also has no @opentui/core dependency to resolve the assets
+      // against: below the runtime floor (Node < 26.4.0) the renderer gate
+      // never selects opentui, and at or above it, QWEN_TUI_RENDERER=opentui
+      // selects the renderer, the boot fails on the missing asset tree, and
+      // a stderr warning falls back to ink on every startup. The opt-in Bun
+      // standalone flavor (--runtime=bun) carries the assets via
+      // create-standalone-package.js instead.
     ],
     config: rootPackageJson.config,
     dependencies: {},

--- a/scripts/pty-e2e.sh
+++ b/scripts/pty-e2e.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 # PTY 自动化 E2E：模拟键盘输入+读屏，复用本机 qwen 配置/凭据做真实模型调用，无需人工。
 # 用法: scripts/pty-e2e.sh "你的提示" [wait_sec]
+set -euo pipefail
 PROMPT="${1:-hi}"; WAIT="${2:-20}"
-OUT=/tmp/pty-e2e.log
-cat > /tmp/pty-e2e.exp <<EXP
+OUT=$(mktemp /tmp/pty-e2e.XXXXXX.log)
+EXP=$(mktemp /tmp/pty-e2e.exp.XXXXXX)
+trap 'rm -f "$OUT" "$EXP"' EXIT
+# $PROMPT 会被展开进 expect 的 TCL 源码；TCL 双引号字符串里 \ " $ [ 都
+# 有替换语义（$var 与 [command] 可注入），四个字符都要先转义。
+ESCAPED_PROMPT=$(printf '%s' "$PROMPT" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\$/\\$/g' -e 's/\[/\\[/g')
+cat > "$EXP" <<EXP
 set timeout $WAIT
 log_file -a $OUT
 spawn qwen2
 sleep 3
-send "$PROMPT"
+send "$ESCAPED_PROMPT"
 sleep 1
 send "\r"
 sleep $WAIT
@@ -16,7 +22,6 @@ send "\x03"
 sleep 1
 close
 EXP
-rm -f $OUT
-expect /tmp/pty-e2e.exp >/dev/null 2>&1
-echo "=== 输入是否显示 ==="; tr -c '[:print:]\n' ' ' < $OUT | grep -c "$PROMPT"
-echo "=== 是否有模型回复/工具/错误 ==="; tr -c '[:print:]\n' ' ' < $OUT | grep -a -oE "live error|Error|✗|✓|Read|Bash|markdown|qwen3|Thinking" | sort | uniq -c | head
+expect "$EXP" >/dev/null 2>&1 || true
+echo "=== 输入是否显示 ==="; tr -c '[:print:]\n' ' ' < "$OUT" | grep -cF -- "$PROMPT" || true
+echo "=== 是否有模型回复/工具/错误 ==="; tr -c '[:print:]\n' ' ' < "$OUT" | grep -a -oE "live error|Error|✗|✓|Read|Bash|markdown|qwen3|Thinking" | sort | uniq -c | head || true

--- a/scripts/pty-e2e.sh
+++ b/scripts/pty-e2e.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PTY 自动化 E2E：模拟键盘输入+读屏，复用本机 qwen 配置/凭据做真实模型调用，无需人工。
+# 用法: scripts/pty-e2e.sh "你的提示" [wait_sec]
+PROMPT="${1:-hi}"; WAIT="${2:-20}"
+OUT=/tmp/pty-e2e.log
+cat > /tmp/pty-e2e.exp <<EXP
+set timeout $WAIT
+log_file -a $OUT
+spawn qwen2
+sleep 3
+send "$PROMPT"
+sleep 1
+send "\r"
+sleep $WAIT
+send "\x03"
+sleep 1
+close
+EXP
+rm -f $OUT
+expect /tmp/pty-e2e.exp >/dev/null 2>&1
+echo "=== 输入是否显示 ==="; tr -c '[:print:]\n' ' ' < $OUT | grep -c "$PROMPT"
+echo "=== 是否有模型回复/工具/错误 ==="; tr -c '[:print:]\n' ' ' < $OUT | grep -a -oE "live error|Error|✗|✓|Read|Bash|markdown|qwen3|Thinking" | sort | uniq -c | head

--- a/scripts/tests/copy-bundle-openTui-assets.test.js
+++ b/scripts/tests/copy-bundle-openTui-assets.test.js
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Verifies copy_bundle_assets.js relocates the OpenTUI renderer runtime
+ * assets (parser worker, tree-sitter grammars, web-tree-sitter wasm and the
+ * native render library) into dist/opentui-assets under exactly the keys the
+ * runtime gate (packages/cli/src/ui/opentui/opentui-assets.ts) checks before
+ * pointing OTUI_ASSET_ROOT at them.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { copyOpenTuiAssets } from '../copy_bundle_assets.js';
+
+function seedOpentuiPackages(root) {
+  const coreDir = join(root, 'node_modules', '@opentui', 'core');
+  mkdirSync(coreDir, { recursive: true });
+  writeFileSync(
+    join(coreDir, 'package.json'),
+    JSON.stringify({ name: '@opentui/core', main: 'index.node.js' }),
+  );
+  writeFileSync(join(coreDir, 'index.node.js'), 'module.exports = {};');
+  writeFileSync(join(coreDir, 'parser.worker.js'), '// worker');
+  for (const [lang, files] of [
+    ['javascript', ['highlights.scm', 'tree-sitter-javascript.wasm']],
+    [
+      'markdown',
+      ['highlights.scm', 'injections.scm', 'tree-sitter-markdown.wasm'],
+    ],
+  ]) {
+    const langDir = join(coreDir, 'assets', lang);
+    mkdirSync(langDir, { recursive: true });
+    for (const file of files) {
+      writeFileSync(join(langDir, file), `${lang}/${file}`);
+    }
+  }
+
+  const platformDir = join(
+    root,
+    'node_modules',
+    '@opentui',
+    'core-darwin-arm64',
+  );
+  mkdirSync(platformDir, { recursive: true });
+  writeFileSync(
+    join(platformDir, 'package.json'),
+    JSON.stringify({ name: '@opentui/core-darwin-arm64' }),
+  );
+  writeFileSync(join(platformDir, 'libopentui.dylib'), 'native');
+
+  const treeSitterDir = join(root, 'node_modules', 'web-tree-sitter');
+  mkdirSync(treeSitterDir, { recursive: true });
+  writeFileSync(
+    join(treeSitterDir, 'package.json'),
+    JSON.stringify({ name: 'web-tree-sitter', main: 'tree-sitter.js' }),
+  );
+  writeFileSync(join(treeSitterDir, 'tree-sitter.js'), '');
+  writeFileSync(join(treeSitterDir, 'tree-sitter.wasm'), 'wasm');
+}
+
+describe('copyOpenTuiAssets', () => {
+  it('copies the runtime assets under the exact OTUI_ASSET_ROOT keys', () => {
+    const root = mkdtempSync(join(tmpdir(), 'opentui-bundle-assets-'));
+    try {
+      writeFileSync(join(root, 'package.json'), JSON.stringify({}));
+      seedOpentuiPackages(root);
+
+      const copied = copyOpenTuiAssets({ root });
+
+      const dest = join(root, 'dist', 'opentui-assets');
+      expect(copied).toContain('@opentui/core/parser.worker.js');
+      expect(copied).toContain(
+        '@opentui/core/assets/javascript/tree-sitter-javascript.wasm',
+      );
+      expect(copied).toContain('@opentui/core/assets/markdown/injections.scm');
+      expect(copied).toContain('web-tree-sitter/tree-sitter.wasm');
+      expect(copied).toContain('@opentui/core-darwin-arm64/libopentui.dylib');
+      for (const key of copied) {
+        expect(existsSync(join(dest, key)), key).toBe(true);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('warns and skips (never fails the bundle) without @opentui/core', () => {
+    const root = mkdtempSync(join(tmpdir(), 'opentui-bundle-assets-'));
+    try {
+      writeFileSync(join(root, 'package.json'), JSON.stringify({}));
+      const copied = copyOpenTuiAssets({ root });
+      expect(copied).toEqual([]);
+      expect(existsSync(join(root, 'dist', 'opentui-assets'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/tests/copy-bundle-openTui-assets.test.js
+++ b/scripts/tests/copy-bundle-openTui-assets.test.js
@@ -21,7 +21,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { copyOpenTuiAssets } from '../copy_bundle_assets.js';
 
 function seedOpentuiPackages(root) {
@@ -102,6 +102,45 @@ describe('copyOpenTuiAssets', () => {
       const copied = copyOpenTuiAssets({ root });
       expect(copied).toEqual([]);
       expect(existsSync(join(root, 'dist', 'opentui-assets'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('drops a stale tree from an earlier bundle', () => {
+    const root = mkdtempSync(join(tmpdir(), 'opentui-bundle-assets-'));
+    try {
+      writeFileSync(join(root, 'package.json'), JSON.stringify({}));
+      seedOpentuiPackages(root);
+      // Simulate a leftover from an earlier bundle whose source set still
+      // included a platform this install no longer carries: the runtime
+      // gate checks key existence only, so it must not survive a re-copy.
+      const staleKey = '@opentui/core-linux-x64-musl/libopentui.so';
+      const stalePath = join(
+        root,
+        'dist',
+        'opentui-assets',
+        ...staleKey.split('/'),
+      );
+      mkdirSync(dirname(stalePath), { recursive: true });
+      writeFileSync(stalePath, 'stale');
+
+      const copied = copyOpenTuiAssets({ root });
+
+      expect(copied).not.toContain(staleKey);
+      expect(existsSync(stalePath)).toBe(false);
+      expect(
+        existsSync(
+          join(
+            root,
+            'dist',
+            'opentui-assets',
+            '@opentui',
+            'core-darwin-arm64',
+            'libopentui.dylib',
+          ),
+        ),
+      ).toBe(true);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/tmux-compare.sh
+++ b/scripts/tmux-compare.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# tmux 前后对比 harness：左 pane 跑原版 qwen（ink），右 pane 跑 qwen2（opentui），
+# 发送相同输入，抓取两 pane 输出做对比（渲染/闪屏/鼠标/显示 parity 自测）。
+# 用法: ./tmux-compare.sh [prompt]   （需本机 qwen-code 凭据跑真实任务；无凭据时用 qwen2-demo）
+set -euo pipefail
+PROMPT="${1:-hi}"
+SESS=qwcmp
+S=$(command -v qwen || true)
+S2=$(command -v qwen2 || true)
+tmux kill-session -t $SESS 2>/dev/null || true
+tmux new-session -d -s $SESS -x 120 -y 40 \; \
+  split-window -h \; \
+  select-layout tiled >/dev/null
+tmux send-keys -t $SESS:0.0 "$S" Enter
+tmux send-keys -t $SESS:0.1 "$S2" Enter
+sleep 6
+# 发送相同 prompt
+tmux send-keys -t $SESS:0.0 "$PROMPT" Enter
+tmux send-keys -t $SESS:0.1 "$PROMPT" Enter
+sleep 12
+tmux capture-pane -p -t $SESS:0.0 > /tmp/qwen-ink.txt
+tmux capture-pane -p -t $SESS:0.1 > /tmp/qwen-opentui.txt
+tmux kill-session -t $SESS 2>/dev/null || true
+echo "=== ink (original) ==="; tail -20 /tmp/qwen-ink.txt
+echo "=== opentui (qwen2) ==="; tail -20 /tmp/qwen-opentui.txt
+echo "=== diff (behavior) ==="; diff /tmp/qwen-ink.txt /tmp/qwen-opentui.txt | head -40 || true

--- a/scripts/tmux-compare.sh
+++ b/scripts/tmux-compare.sh
@@ -7,6 +7,13 @@ PROMPT="${1:-hi}"
 SESS=qwcmp
 S=$(command -v qwen || true)
 S2=$(command -v qwen2 || true)
+if [ -z "$S" ] || [ -z "$S2" ]; then
+  echo "需要 qwen 和 qwen2 都在 PATH 中（当前: qwen=${S:-缺失}, qwen2=${S2:-缺失}）" >&2
+  exit 1
+fi
+INK_OUT=$(mktemp /tmp/qwen-ink.XXXXXX.txt)
+OTUI_OUT=$(mktemp /tmp/qwen-opentui.XXXXXX.txt)
+trap 'rm -f "$INK_OUT" "$OTUI_OUT"' EXIT
 tmux kill-session -t $SESS 2>/dev/null || true
 tmux new-session -d -s $SESS -x 120 -y 40 \; \
   split-window -h \; \
@@ -18,9 +25,9 @@ sleep 6
 tmux send-keys -t $SESS:0.0 "$PROMPT" Enter
 tmux send-keys -t $SESS:0.1 "$PROMPT" Enter
 sleep 12
-tmux capture-pane -p -t $SESS:0.0 > /tmp/qwen-ink.txt
-tmux capture-pane -p -t $SESS:0.1 > /tmp/qwen-opentui.txt
+tmux capture-pane -p -t $SESS:0.0 > "$INK_OUT"
+tmux capture-pane -p -t $SESS:0.1 > "$OTUI_OUT"
 tmux kill-session -t $SESS 2>/dev/null || true
-echo "=== ink (original) ==="; tail -20 /tmp/qwen-ink.txt
-echo "=== opentui (qwen2) ==="; tail -20 /tmp/qwen-opentui.txt
-echo "=== diff (behavior) ==="; diff /tmp/qwen-ink.txt /tmp/qwen-opentui.txt | head -40 || true
+echo "=== ink (original) ==="; tail -20 "$INK_OUT"
+echo "=== opentui (qwen2) ==="; tail -20 "$OTUI_OUT"
+echo "=== diff (behavior) ==="; diff "$INK_OUT" "$OTUI_OUT" | head -40 || true

--- a/scripts/tui-parity/README.md
+++ b/scripts/tui-parity/README.md
@@ -1,0 +1,195 @@
+# TUI parity harness
+
+Deterministic, dependency-light harness that compares a base CLI capture
+(current Ink behavior) against a fixed CLI capture (OpenTUI behavior) with
+machine-checkable metrics and reviewable artifacts. Node built-ins plus the
+repository's existing `@lydell/node-pty` capability for PTY allocation.
+
+## Runner contract
+
+```bash
+node scripts/tui-parity/runner.mjs \
+  --scenario <file|dir> ... \
+  --out <dir> \
+  [--base '<command>'] [--fixed '<command>']
+```
+
+- `--scenario` is a `*.scenario.json` file or a directory of them. `--out` is
+  the artifact directory. Exit codes: 0 pass, 1 threshold/capture failure,
+  2 usage or validation error.
+- `--base` / `--fixed` override the scenario commands (single scenario only).
+  This is the real-CLI contract: point base at the Ink build and fixed at the
+  OpenTUI build with the same scenario parameters. Overrides always capture
+  through a native PTY. Relative `.js/.mjs/.cjs` script paths after `node`
+  resolve against the repository root. The final resolved argv (after any
+  override) is re-validated before anything is captured: declared
+  `compareParams` must be present and equal on both sides, and terminal-size
+  flags must match the capture geometry. A divergent override aborts the run
+  with a parameter-binding error instead of executing under a stale
+  "validated" claim.
+- Base and fixed always share the scenario's terminal size, timeout, stdin
+  input, environment, and thresholds. Scenarios that attach per-side
+  parameters are rejected. `compareParams` names argv flags whose values are
+  extracted, normalised (`--flag value` and `--flag=value` are equivalent),
+  and required to be present and equal on both sides; terminal-size flags
+  (`--rows`/`--lines`/`--columns`/`--cols`) must additionally match
+  `terminal.rows`/`terminal.columns`. Any mismatch fails validation before
+  anything runs.
+
+### Native TTY capture is enforced
+
+Plain argv commands are captured through a **native PTY** allocated by the
+harness (`@lydell/node-pty`, rows/columns and `TERM` from the scenario). The
+child therefore runs with a real TTY, and each side's `summary.json` records
+the evidence (`capture.tty`: mode, backend, allocated, rows, columns,
+handshake). If no PTY backend is available, direct capture is **refused**
+with `native TTY capture refused: ...`; the harness never silently falls back
+to non-TTY pipes for a real CLI. Two explicit waivers exist, both recorded in
+artifacts and reports:
+
+- `"pty": "fixture"` — the command is a deterministic fixture that needs no
+  TTY (the harness's own emitters). Captured over pipes and clearly marked
+  as waived; real-CLI captures may not use this mode.
+- `"pty": "wrapped"` — the command already runs inside a caller-supplied PTY
+  wrapper (expect, tmux, `script`, or `lib/tty-handshake.mjs`). The harness
+  generates a per-run nonce in `TUI_PARITY_PTY_NONCE` and verifies that the
+  captured stream contains the matching
+  `ESC ] 697 ; tty-handshake ; <nonce> BEL` marker. `lib/tty-handshake.mjs`
+  emits that marker only when its stdout really is a TTY, and refuses
+  otherwise. A missing handshake fails the side.
+
+`TUI_PARITY_NO_PTY=1` forces the no-backend path in tests.
+
+## Scenario schema
+
+```json
+{
+  "id": "kebab-case-id",
+  "description": "what is being compared",
+  "terminal": { "rows": 12, "columns": 40 },
+  "timeoutMs": 10000,
+  "input": [{ "data": "\r", "delayMs": 0 }],
+  "env": { "KEY": "value" },
+  "compareParams": ["--frames", "--rows"],
+  "commands": {
+    "base": ["argv", "captured through a native PTY"],
+    "fixed": { "argv": ["argv..."], "pty": "fixture" }
+  },
+  "thresholds": { "maxFullScreenClears": 0 },
+  "proves": "what a passing run proves",
+  "doesNotProve": "what it cannot prove"
+}
+```
+
+`commands.<side>` is either a plain argv array (native PTY capture) or an
+object with `argv` and optional `pty` (`"fixture"` or `"wrapped"`). Any other
+per-side key is rejected.
+
+Thresholds (all optional, evaluated per side): `maxFullScreenClears`,
+`maxPartialScreenErases`, `maxLineErases`, `maxDuplicateEvents`,
+`maxDec2026Unbalanced` (integers >= 0), and `requireSync`,
+`requireEventMarkers`, `requireExitCodeZero` (booleans; the exit-code
+requirement defaults to true; spawn failures, timeouts, PTY refusals, and
+unverified handshakes always fail a side).
+
+## Metrics
+
+Counted from each side's raw stdout:
+
+- Full-screen clear opcodes: `ESC[2J`, `ESC[3J`, RIS (`ESC c`).
+- Line erases: `ESC[K` in modes 0/1/2; partial screen erases `ESC[J` modes
+  0/1 tracked separately.
+- DEC 2026 synchronised-output begin/end (`ESC[?2026h` / `ESC[?2026l`) plus
+  an unbalanced count for stray ends and unclosed begins. `requireSync`
+  accepts a stream only if at least one begin exists, pairs balance, and —
+  when live-output event markers are measured — every marker occurrence was
+  emitted inside an active DEC 2026 interval. Coverage is measured per event,
+  not inferred from counts: empty begin/end pairs that wrap no events and
+  markers emitted outside every interval fail `requireSync` even when the
+  begin count equals the unique event count.
+- Live-output event markers using OSC `697;<id>;<seq>` (BEL or ST
+  terminated). A marker whose `(id, seq)` was already seen is a duplicate.
+  Each marker occurrence is additionally classified as covered (inside an
+  active DEC 2026 interval) or unwrapped (outside every interval), and both
+  counts are reported. Without markers the duplicate count is reported as not
+  measurable.
+- Process exit code, signal, timeout, and duration.
+
+Timeout handling tracks and clears every pending input timer, and kills the
+capture process tree where supported (SIGTERM to the process group, SIGKILL
+after a 1s grace). The kill escalation survives the main child closing: the
+SIGKILL step is not cancelled when the captured command exits, and after it
+fires the harness re-probes the process group until it is confirmed gone
+(bounded). A descendant that ignores SIGTERM and detaches stdio therefore
+cannot outlive the capture, and a capture cannot linger on delayed input or
+orphaned descendants.
+
+`proves` and `doesNotProve` are mandatory scenario fields and are copied
+verbatim into every report, so each scenario states what its result does and
+does not demonstrate.
+
+## Artifacts
+
+Per run under `--out`:
+
+```
+run-summary.json
+<scenario-id>/
+  base|fixed/
+    raw.ansi        exact captured stdout
+    stderr.txt      captured stderr (empty for PTY captures: a real
+                    terminal merges stderr into the PTY stream)
+    screen.txt      final screen from the built-in terminal model
+    summary.json    capture metadata (incl. tty evidence), metrics,
+                    verdict, reasons
+  comparison.json   side-by-side metrics, deltas, outcome
+  report.md         reviewer-facing report
+```
+
+Outcomes: `base-fails-fixed-passes` (evidence that the fix removes the
+defect), `both-pass` (no base-side defect exhibited), `fixed-fails`
+(threshold violation), `capture-error` (spawn failure, refusal, or timeout).
+The run passes only on the first two.
+
+## Fixtures and tests
+
+- `fixtures/emitters/tui-emitter.mjs` is a deterministic emitter: identical
+  flags produce identical bytes, and its flags inject the exact defects the
+  metrics count (`--clears-per-frame`, `--scrollback-clears`, `--dups`,
+  `--sync`, `--hang-ms`, `--exit-code`). `--tree-hang` spawns an idle
+  grandchild and hangs, to exercise process-tree kill on timeout.
+  `--stubborn-hang` spawns a grandchild that ignores SIGTERM and detaches its
+  stdio, then hangs; it exercises kill escalation that must survive the main
+  child closing.
+- `fixtures/wrappers/pty-launcher.mjs` wraps a command in a PTY, standing in
+  for external wrappers in handshake tests.
+- `fixtures/scenarios/stream-redraw.scenario.json` reproduces a failing base
+  and passing fixed side without launching the real CLI.
+
+```bash
+node --test scripts/tui-parity/test   # unit + end-to-end tests
+node scripts/tui-parity/self-test.mjs # full pipeline self-check
+```
+
+Tests cover the PTY refusal and the native/wrapped happy paths, divergent
+`compareParams` (including `--rows`/`--columns`), per-side parameter
+rejection, and a bounded regression test where `input.delayMs` exceeds
+`timeoutMs`. They also lock in the three adversarial counterexamples as
+regressions: empty DEC 2026 pairs plus unwrapped event markers can never
+satisfy `requireSync`; a descendant that ignores SIGTERM and detaches stdio
+is still reaped after the main child closes (fixture and native PTY); and a
+`--base`/`--fixed` override that diverges from `compareParams` or the capture
+geometry aborts before anything runs. Fixture results are evidence about the
+harness and its metrics, not about the products. Real-CLI parity claims
+require running the same harness with real base/fixed commands through the
+native PTY contract.
+
+## Normalization limits
+
+The built-in terminal model supports printable text, CR/LF/BS/TAB, cursor
+movement, ED/EL/IL/DL/ICH/DCH/ECH, SGR (ignored), alternate screen
+(47/1047/1049), and RIS. Scroll regions, double-width characters, and
+wide-grapheme measurement are not modeled; `screen.txt` is a review aid, and
+the machine-checkable part of the harness is the metric counts. PTY captures
+apply the terminal line discipline (e.g. LF echoed as CRLF); metrics count
+opcodes, not whitespace, so this does not change threshold semantics.

--- a/scripts/tui-parity/accept-noflicker.sh
+++ b/scripts/tui-parity/accept-noflicker.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# M6 pre-acceptance: run the OpenTUI no-flicker scenario and assert the
+# renderer streams with ZERO full-screen clears and balanced DEC 2026.
+# Requires: bun on PATH. With QWEN_API_KEY the gate drives a real model
+# conversation; without it (e.g. fork PRs, which never receive secrets) it
+# falls back to the offline scripted-stream gate.
+# Usage: scripts/tui-parity/accept-noflicker.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "SKIP: bun not on PATH (OpenTUI requires bun)." >&2
+  exit 77
+fi
+if [ ! -f packages/cli/dist/index.js ]; then
+  echo "SKIP: packages/cli/dist/index.js missing (run npm run build)." >&2
+  exit 77
+fi
+
+OUT="${OUT:-/tmp/opentui-noflicker-out}"
+if [ -n "${QWEN_API_KEY:-}" ]; then
+  SCENARIO="scripts/tui-parity/fixtures/scenarios/opentui-noflicker.scenario.json"
+else
+  echo "INFO: QWEN_API_KEY not set — running offline scripted-stream gate." >&2
+  SCENARIO="scripts/tui-parity/fixtures/scenarios/opentui-noflicker-offline.scenario.json"
+fi
+node scripts/tui-parity/runner.mjs --scenario "$SCENARIO" --out "$OUT"
+
+echo "PASS: opentui no-flicker gate (0 full-screen clears, balanced DEC 2026). Report: $OUT"

--- a/scripts/tui-parity/component-parity.sh
+++ b/scripts/tui-parity/component-parity.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# M5 component-level parity snapshot: render the same fragment under Ink and
+# OpenTUI (headless) and diff layout/text. Requires bun. Exit 0 = parity.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+if ! command -v bun >/dev/null 2>&1; then
+  echo "SKIP: bun not on PATH." >&2
+  exit 77
+fi
+bun packages/cli/scripts/opentui-component-parity.tsx
+bun packages/cli/scripts/opentui-stats-parity.tsx
+bun packages/cli/scripts/opentui-command-parity.ts

--- a/scripts/tui-parity/fixtures/emitters/tui-emitter.mjs
+++ b/scripts/tui-parity/fixtures/emitters/tui-emitter.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Deterministic fixture TUI for the parity harness.
+// Same flags => identical bytes.
+// Flags:
+//   --frames N            frames to render (default 3)
+//   --clears-per-frame N  ESC[2J full-screen clears before each frame
+//   --scrollback-clears N ESC[3J clears emitted once at start (default 0)
+//   --el-mode 0|1|2       ESC[K mode used while erasing lines (default 0)
+//   --no-line-erases      skip ESC[K entirely
+//   --dups N              duplicate event markers per frame (default 0)
+//   --sync                wrap each frame in DEC 2026 begin/end
+//   --exit-code N         process exit code (default 0)
+//   --hang-ms N           sleep after the last frame before exit (default 0)
+//   --tree-hang           spawn an idle grandchild and hang, to exercise
+//                         process-tree kill on capture timeout
+//   --stubborn-hang       spawn a grandchild that ignores SIGTERM and detaches
+//                         stdio, print its pid, then hang; exercises kill
+//                         escalation that must survive the main child closing
+//   --rows N              override $LINES (default 24)
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+function parseArgs(argv) {
+  const opts = {
+    frames: 3,
+    clearsPerFrame: 0,
+    scrollbackClears: 0,
+    elMode: 0,
+    lineErases: true,
+    dups: 0,
+    sync: false,
+    exitCode: 0,
+    hangMs: 0,
+    treeHang: false,
+    stubbornHang: false,
+    rows: null,
+  };
+  const value = (flag, index) => {
+    const v = Number.parseInt(argv[index + 1], 10);
+    if (Number.isNaN(v)) {
+      console.error(`tui-emitter: missing numeric value for ${flag}`);
+      process.exit(2);
+    }
+    return v;
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    switch (flag) {
+      case '--frames':
+        opts.frames = value(flag, i);
+        i += 1;
+        break;
+      case '--clears-per-frame':
+        opts.clearsPerFrame = value(flag, i);
+        i += 1;
+        break;
+      case '--scrollback-clears':
+        opts.scrollbackClears = value(flag, i);
+        i += 1;
+        break;
+      case '--el-mode':
+        opts.elMode = value(flag, i);
+        i += 1;
+        break;
+      case '--no-line-erases':
+        opts.lineErases = false;
+        break;
+      case '--dups':
+        opts.dups = value(flag, i);
+        i += 1;
+        break;
+      case '--sync':
+        opts.sync = true;
+        break;
+      case '--exit-code':
+        opts.exitCode = value(flag, i);
+        i += 1;
+        break;
+      case '--hang-ms':
+        opts.hangMs = value(flag, i);
+        i += 1;
+        break;
+      case '--tree-hang':
+        opts.treeHang = true;
+        break;
+      case '--stubborn-hang':
+        opts.stubbornHang = true;
+        break;
+      case '--rows':
+        opts.rows = value(flag, i);
+        i += 1;
+        break;
+      default:
+        console.error(`tui-emitter: unknown flag ${flag}`);
+        process.exit(2);
+    }
+  }
+  return opts;
+}
+
+const opts = parseArgs(process.argv.slice(2));
+
+if (opts.stubbornHang) {
+  // Ignores SIGTERM and detaches stdio, but stays in the capture's process
+  // group, so only a SIGKILL that survives the main child closing can reap it.
+  const stubborn = spawn(
+    process.execPath,
+    ['-e', "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);"],
+    { stdio: 'ignore' },
+  );
+  process.stdout.write(`STUBBORN=${stubborn.pid}\n`);
+  setTimeout(() => {}, 60000);
+  process.exitCode = opts.exitCode;
+} else if (opts.treeHang) {
+  const grandchild = spawn(
+    process.execPath,
+    ['-e', 'setTimeout(() => {}, 60000)'],
+    { stdio: 'inherit' },
+  );
+  process.stdout.write(`GRANDCHILD=${grandchild.pid}\n`);
+  setTimeout(() => {}, 60000);
+  process.exitCode = opts.exitCode;
+} else {
+  main(opts);
+}
+
+function main(opts) {
+  const rows =
+    opts.rows ?? (Number.parseInt(process.env.LINES ?? '', 10) || 24);
+
+  const out = (text) => process.stdout.write(text);
+  const marker = (seq) => out(`\x1b]697;live-line;${seq}\x07`);
+
+  for (let k = 0; k < opts.scrollbackClears; k += 1) out('\x1b[3J');
+
+  const contentRows = Math.max(1, rows - 1);
+  let seq = 0;
+  for (let frame = 1; frame <= opts.frames; frame += 1) {
+    if (opts.sync) out('\x1b[?2026h');
+    if (opts.clearsPerFrame > 0) {
+      for (let k = 0; k < opts.clearsPerFrame; k += 1) out('\x1b[2J');
+    }
+    out('\x1b[H');
+    for (let r = 1; r <= contentRows; r += 1) {
+      out(`\x1b[${r};1H`);
+      out(`frame=${frame} row=${r}`);
+      if (opts.lineErases) out(`\x1b[${opts.elMode}K`);
+    }
+    seq += 1;
+    marker(seq);
+    for (let d = 0; d < opts.dups; d += 1) marker(seq);
+    if (opts.sync) out('\x1b[?2026l');
+  }
+  out('\n');
+
+  if (opts.hangMs > 0) {
+    setTimeout(() => process.exit(opts.exitCode), opts.hangMs);
+  } else {
+    process.exitCode = opts.exitCode;
+  }
+}

--- a/scripts/tui-parity/fixtures/scenarios/opentui-noflicker-offline.scenario.json
+++ b/scripts/tui-parity/fixtures/scenarios/opentui-noflicker-offline.scenario.json
@@ -1,0 +1,33 @@
+{
+  "id": "opentui-noflicker-offline",
+  "description": "Offline OpenTUI no-flicker gate: the real OpenTUI backend streams its scripted demo (no model credentials) with ZERO full-screen clears and balanced DEC 2026 under PTY capture. Runs on fork PRs where secrets.QWEN_API_KEY is unavailable; maintainers with credentials get the live-model opentui-noflicker gate instead.",
+  "proves": "fixed (real OpenTUI renderer, scripted stream) has 0 full-screen clears and 0 unbalanced DEC 2026; base (fixture emitter with injected defects) is the reference.",
+  "doesNotProve": "live-model streaming behavior; visual identity; ink-vs-opentui parity.",
+  "terminal": { "rows": 30, "columns": 100 },
+  "timeoutMs": 30000,
+  "input": [],
+  "env": { "TERM": "xterm-256color" },
+  "compareParams": [],
+  "commands": {
+    "base": {
+      "argv": [
+        "node",
+        "scripts/tui-parity/fixtures/emitters/tui-emitter.mjs",
+        "--frames",
+        "3",
+        "--clears-per-frame",
+        "1",
+        "--dups",
+        "2"
+      ]
+    },
+    "fixed": {
+      "argv": ["bun", "packages/cli/scripts/opentui-demo-harness.tsx"]
+    }
+  },
+  "thresholds": {
+    "maxFullScreenClears": 0,
+    "maxDuplicateEvents": 3,
+    "maxDec2026Unbalanced": 0
+  }
+}

--- a/scripts/tui-parity/fixtures/scenarios/opentui-noflicker.scenario.json
+++ b/scripts/tui-parity/fixtures/scenarios/opentui-noflicker.scenario.json
@@ -1,0 +1,32 @@
+{
+  "id": "opentui-noflicker",
+  "description": "OpenTUI renderer must stream with ZERO full-screen clears (no flicker) and balanced DEC 2026, vs the Ink baseline.",
+  "proves": "fixed (OpenTUI, bun) has 0 full-screen clears and 0 unbalanced DEC 2026; base (Ink, node) is the reference.",
+  "doesNotProve": "visual identity; model correctness.",
+  "terminal": { "rows": 30, "columns": 100 },
+  "timeoutMs": 60000,
+  "input": [
+    { "data": "用一句话介绍你自己", "delayMs": 2000 },
+    { "data": "\r", "delayMs": 2000 },
+    { "data": "/quit\r", "delayMs": 20000 }
+  ],
+  "env": { "TERM": "xterm-256color" },
+  "compareParams": [],
+  "commands": {
+    "base": { "argv": ["node", "packages/cli/dist/index.js"] },
+    "fixed": {
+      "argv": [
+        "env",
+        "QWEN_TUI_RENDERER=opentui",
+        "QWEN_TUI_RENDERER_STRICT=1",
+        "bun",
+        "packages/cli/dist/index.js"
+      ]
+    }
+  },
+  "thresholds": {
+    "maxFullScreenClears": 0,
+    "maxDuplicateEvents": 3,
+    "maxDec2026Unbalanced": 0
+  }
+}

--- a/scripts/tui-parity/fixtures/scenarios/real-stream.scenario.json
+++ b/scripts/tui-parity/fixtures/scenarios/real-stream.scenario.json
@@ -1,0 +1,38 @@
+{
+  "id": "real-stream",
+  "description": "Real model stream via existing qwen-code config: fixed (OpenTUI) must stream with no full-screen clears / duplicate live-output vs base (Ink).",
+  "proves": "with the user's real config, fixed side streams with <= base full-screen clears and duplicate live-output, balanced DEC 2026.",
+  "doesNotProve": "visual identity; model correctness.",
+  "terminal": {
+    "rows": 30,
+    "columns": 100
+  },
+  "timeoutMs": 60000,
+  "input": [
+    {
+      "data": "用一句话介绍你自己",
+      "delayMs": 2000
+    },
+    {
+      "data": "\r",
+      "delayMs": 2000
+    }
+  ],
+  "env": {
+    "TERM": "xterm-256color"
+  },
+  "compareParams": [],
+  "commands": {
+    "base": {
+      "argv": ["node", "packages/cli/dist/index.js"]
+    },
+    "fixed": {
+      "argv": ["node", "packages/cli/dist/index.js"]
+    }
+  },
+  "thresholds": {
+    "maxFullScreenClears": 2,
+    "maxDuplicateEvents": 3,
+    "maxDec2026Unbalanced": 0
+  }
+}

--- a/scripts/tui-parity/fixtures/scenarios/startup.scenario.json
+++ b/scripts/tui-parity/fixtures/scenarios/startup.scenario.json
@@ -1,0 +1,42 @@
+{
+  "id": "startup-banner",
+  "description": "Startup/banner: fixed (OpenTUI) must not full-clear or duplicate the banner vs base (Ink).",
+  "proves": "fixed side startup emits no more full-screen clears / duplicate live-output than base under identical terminal geometry.",
+  "doesNotProve": "model-streaming behavior (no model stream in this scenario); visual identity.",
+  "terminal": { "rows": 24, "columns": 80 },
+  "timeoutMs": 8000,
+  "input": [],
+  "env": {},
+  "compareParams": [],
+  "commands": {
+    "base": {
+      "argv": [
+        "node",
+        "scripts/tui-parity/fixtures/emitters/tui-emitter.mjs",
+        "--frames",
+        "1",
+        "--clears-per-frame",
+        "0",
+        "--dups",
+        "0"
+      ]
+    },
+    "fixed": {
+      "argv": [
+        "node",
+        "scripts/tui-parity/fixtures/emitters/tui-emitter.mjs",
+        "--frames",
+        "1",
+        "--clears-per-frame",
+        "0",
+        "--dups",
+        "0"
+      ]
+    }
+  },
+  "thresholds": {
+    "maxFullScreenClears": 1,
+    "maxDuplicateEvents": 1,
+    "maxDec2026Unbalanced": 0
+  }
+}

--- a/scripts/tui-parity/fixtures/scenarios/stream-redraw.scenario.json
+++ b/scripts/tui-parity/fixtures/scenarios/stream-redraw.scenario.json
@@ -1,0 +1,48 @@
+{
+  "id": "stream-redraw",
+  "description": "Streaming live-output redraw: the fixed side must redraw incrementally with no full-screen clears, no duplicate live-output events, and every frame wrapped in balanced DEC 2026 synchronised-output pairs.",
+  "terminal": {
+    "rows": 12,
+    "columns": 40
+  },
+  "timeoutMs": 10000,
+  "input": [],
+  "env": {},
+  "compareParams": ["--frames"],
+  "commands": {
+    "base": {
+      "argv": [
+        "node",
+        "scripts/tui-parity/fixtures/emitters/tui-emitter.mjs",
+        "--frames",
+        "3",
+        "--clears-per-frame",
+        "1",
+        "--dups",
+        "2"
+      ],
+      "pty": "fixture"
+    },
+    "fixed": {
+      "argv": [
+        "node",
+        "scripts/tui-parity/fixtures/emitters/tui-emitter.mjs",
+        "--frames",
+        "3",
+        "--sync"
+      ],
+      "pty": "fixture"
+    }
+  },
+  "thresholds": {
+    "maxFullScreenClears": 0,
+    "maxLineErases": 60,
+    "maxDuplicateEvents": 0,
+    "maxDec2026Unbalanced": 0,
+    "requireSync": true,
+    "requireEventMarkers": true,
+    "requireExitCodeZero": true
+  },
+  "proves": "Under identical scenario parameters (terminal size, timeout, input, and the --frames comparison parameter validated equal on both sides), the fixed-side stream contains zero full-screen clears (ESC[2J/ESC[3J/RIS), zero duplicate live-output event markers (OSC 697), and balanced DEC 2026 synchronised-output begin/end pairs around every frame, while the base side exhibits all three defects. Incremental line erase stays within the configured budget.",
+  "doesNotProve": "Visual pixel parity, real Ink or OpenTUI product behavior (deterministic fixture emitters stand in for the real CLIs; fixture captures waive the native PTY contract), latency or throughput characteristics, behavior under a real PTY or alternate fonts/locales, and any model-driven UI path."
+}

--- a/scripts/tui-parity/fixtures/wrappers/pty-launcher.mjs
+++ b/scripts/tui-parity/fixtures/wrappers/pty-launcher.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Test-fixture PTY wrapper: allocates a PTY with the repository node-pty
+// capability and runs the given command inside it, streaming the PTY output
+// to stdout. Stands in for external wrappers such as expect, tmux, or script
+// so the harness's "wrapped" handshake verification is testable on any
+// platform without extra tooling.
+import process from 'node:process';
+import { loadPtyBackend } from '../../lib/capture.mjs';
+
+const argv = process.argv.slice(2);
+const backend = loadPtyBackend();
+if (!backend) {
+  console.error('pty-launcher: no PTY backend available');
+  process.exit(2);
+}
+if (argv.length === 0) {
+  console.error('pty-launcher: missing the command to wrap');
+  process.exit(2);
+}
+
+const rows = Number.parseInt(process.env.LINES ?? '24', 10) || 24;
+const cols = Number.parseInt(process.env.COLUMNS ?? '80', 10) || 80;
+const ptyProc = backend.spawn(argv[0], argv.slice(1), {
+  name: process.env.TERM ?? 'xterm-256color',
+  cols,
+  rows,
+  env: { ...process.env },
+});
+ptyProc.onData((chunk) => process.stdout.write(chunk));
+process.stdin.on('data', (chunk) => {
+  try {
+    ptyProc.write(chunk.toString());
+  } catch {
+    /* PTY already closed */
+  }
+});
+ptyProc.onExit(({ exitCode }) => {
+  setImmediate(() => process.exit(exitCode ?? 0));
+});

--- a/scripts/tui-parity/lib/ansi-metrics.mjs
+++ b/scripts/tui-parity/lib/ansi-metrics.mjs
@@ -1,0 +1,176 @@
+const CURSOR_MOVES = new Set([
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'd',
+  'f',
+]);
+
+export function analyzeAnsi(raw) {
+  const m = {
+    bytes: Buffer.byteLength(raw, 'utf8'),
+    printableChars: 0,
+    controlChars: { cr: 0, lf: 0, bs: 0, tab: 0, bel: 0, other: 0 },
+    sequences: { csi: 0, osc: 0, otherEsc: 0 },
+    fullScreenClears: { csi2J: 0, csi3J: 0, ris: 0, total: 0 },
+    partialScreenErases: 0,
+    lineErases: { toEnd: 0, toStart: 0, whole: 0, total: 0 },
+    dec2026: { begin: 0, end: 0, unbalanced: 0 },
+    events: {
+      markersPresent: false,
+      total: 0,
+      unique: 0,
+      duplicates: 0,
+      covered: 0,
+      unwrapped: 0,
+    },
+    cursorMoves: 0,
+    sgrChanges: 0,
+  };
+
+  const seenEvents = new Set();
+  let syncDepth = 0;
+  let i = 0;
+
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch !== '\x1b') {
+      if (ch === '\r') m.controlChars.cr += 1;
+      else if (ch === '\n') m.controlChars.lf += 1;
+      else if (ch === '\b') m.controlChars.bs += 1;
+      else if (ch === '\t') m.controlChars.tab += 1;
+      else if (ch === '\x07') m.controlChars.bel += 1;
+      else if (ch < ' ') m.controlChars.other += 1;
+      else m.printableChars += 1;
+      i += 1;
+      continue;
+    }
+
+    const next = raw[i + 1];
+    if (next === undefined) {
+      m.sequences.otherEsc += 1;
+      i += 1;
+      continue;
+    }
+
+    if (next === '[') {
+      m.sequences.csi += 1;
+      let j = i + 2;
+      let priv = '';
+      while (j < raw.length && raw[j] >= '<' && raw[j] <= '?') {
+        priv += raw[j];
+        j += 1;
+      }
+      const paramStart = j;
+      while (
+        j < raw.length &&
+        ((raw[j] >= '0' && raw[j] <= '9') || raw[j] === ';')
+      ) {
+        j += 1;
+      }
+      const paramText = raw.slice(paramStart, j);
+      while (j < raw.length && raw[j] >= ' ' && raw[j] <= '/') {
+        j += 1;
+      }
+      const final = j < raw.length ? raw[j] : '';
+      j += 1;
+      i = j;
+      const params =
+        paramText === ''
+          ? []
+          : paramText.split(';').map((part) => {
+              const n = Number.parseInt(part, 10);
+              return Number.isNaN(n) ? 0 : n;
+            });
+      const p0 = params.length > 0 ? params[0] : 0;
+
+      if (final === 'J') {
+        if (p0 === 2) m.fullScreenClears.csi2J += 1;
+        else if (p0 === 3) m.fullScreenClears.csi3J += 1;
+        else m.partialScreenErases += 1;
+      } else if (final === 'K') {
+        if (p0 === 1) m.lineErases.toStart += 1;
+        else if (p0 === 2) m.lineErases.whole += 1;
+        else m.lineErases.toEnd += 1;
+        m.lineErases.total += 1;
+      } else if (
+        (final === 'h' || final === 'l') &&
+        priv === '?' &&
+        params.includes(2026)
+      ) {
+        if (final === 'h') {
+          m.dec2026.begin += 1;
+          syncDepth += 1;
+        } else {
+          m.dec2026.end += 1;
+          if (syncDepth > 0) syncDepth -= 1;
+          else m.dec2026.unbalanced += 1;
+        }
+      } else if (CURSOR_MOVES.has(final)) {
+        m.cursorMoves += 1;
+      } else if (final === 'm') {
+        m.sgrChanges += 1;
+      }
+      continue;
+    }
+
+    if (next === ']') {
+      m.sequences.osc += 1;
+      let j = i + 2;
+      let payload = '';
+      while (j < raw.length) {
+        if (raw[j] === '\x07') {
+          j += 1;
+          break;
+        }
+        if (raw[j] === '\x1b' && raw[j + 1] === '\\') {
+          j += 2;
+          break;
+        }
+        payload += raw[j];
+        j += 1;
+      }
+      i = j;
+      // Private namespace OSC 697;id;seq marks one live-output event. Each
+      // occurrence is classified by whether it landed inside an active DEC
+      // 2026 sync interval, so coverage is measured per event, not inferred
+      // from begin/end counts.
+      if (payload.startsWith('697;')) {
+        const body = payload.slice(4);
+        const sep = body.indexOf(';');
+        const id = sep === -1 ? body : body.slice(0, sep);
+        const seq = sep === -1 ? '' : body.slice(sep + 1);
+        m.events.total += 1;
+        if (syncDepth > 0) m.events.covered += 1;
+        else m.events.unwrapped += 1;
+        const key = `${id}\u0000${seq}`;
+        if (seenEvents.has(key)) m.events.duplicates += 1;
+        else seenEvents.add(key);
+      }
+      continue;
+    }
+
+    if (next === 'c') {
+      m.fullScreenClears.ris += 1;
+      i += 2;
+      continue;
+    }
+
+    m.sequences.otherEsc += 1;
+    i += 2;
+  }
+
+  m.dec2026.unbalanced += syncDepth;
+  m.fullScreenClears.total =
+    m.fullScreenClears.csi2J +
+    m.fullScreenClears.csi3J +
+    m.fullScreenClears.ris;
+  m.events.unique = seenEvents.size;
+  m.events.markersPresent = m.events.total > 0;
+  return m;
+}

--- a/scripts/tui-parity/lib/capture.mjs
+++ b/scripts/tui-parity/lib/capture.mjs
@@ -67,6 +67,13 @@ function spawnScriptPty(cmd, args, opts = {}) {
       }
     },
     write: (d) => child.stdin.write(d),
+    destroy: () => {
+      try {
+        child.kill();
+      } catch {
+        // already dead — nothing further to do
+      }
+    },
   };
 }
 
@@ -195,20 +202,19 @@ export function capture(command, options = {}) {
     let nonce = null;
     if (tty === 'script') {
       // script(1)-based PTY: some renderers (OpenTUI) accept a script-allocated
-      // PTY but not the node-pty backend. Capture script's stdout as the stream.
-      const tmp = `/tmp/tui-parity-script-${randomUUID()}.log`;
+      // PTY but not the node-pty backend. Route through spawnScriptPty so the
+      // argv form follows the platform (the trailing-positional form below
+      // only works on BSD script(1); util-linux rejects it).
       ttyEvidence.backend = 'script';
-      ttyEvidence.allocated = true;
       try {
-        child = spawn('script', ['-q', tmp, ...command], {
-          stdio: ['pipe', 'pipe', 'pipe'],
-          detached: true,
+        ptyProc = spawnScriptPty(command[0], command.slice(1), {
           env: childEnv,
         });
       } catch (err) {
         settle({ spawnError: err.message });
         return;
       }
+      ttyEvidence.allocated = true;
     } else if (tty === 'native') {
       backend = loadPtyBackend();
       if (!backend) {

--- a/scripts/tui-parity/lib/capture.mjs
+++ b/scripts/tui-parity/lib/capture.mjs
@@ -1,0 +1,378 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
+import process from 'node:process';
+
+const KILL_GRACE_MS = 1000;
+const TREE_VERIFY_ATTEMPTS = 8;
+const TREE_VERIFY_INTERVAL_MS = 250;
+
+// POSIX single-quote escaping for the util-linux `script -c` command
+// string, which is re-parsed by a shell.
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+// The native PTY backend comes from @lydell/node-pty, a declared repository
+// dependency. TUI_PARITY_NO_PTY=1 forces unavailability to exercise the
+// refusal path in tests.
+export function loadPtyBackend() {
+  if (process.env.TUI_PARITY_NO_PTY === '1') return null;
+  // script(1)-allocated PTY is opt-in (TUI_PARITY_PTY=script) for renderers that
+  // reject node-pty; default remains node-pty (works for Ink).
+  if (process.env.TUI_PARITY_PTY === 'script') {
+    return { kind: 'script', spawn: spawnScriptPty };
+  }
+  try {
+    const require = createRequire(import.meta.url);
+    const mod = require('@lydell/node-pty');
+    const spawnFn = mod?.spawn ?? mod?.default?.spawn;
+    if (typeof spawnFn !== 'function') return null;
+    return { kind: 'node-pty', spawn: spawnFn };
+  } catch {
+    return null;
+  }
+}
+
+// Wrap script(1) so it exposes the node-pty-like interface (onData/kill/p).
+function spawnScriptPty(cmd, args, opts = {}) {
+  const tmp = `/tmp/tui-parity-script-${randomUUID()}.log`;
+  // BSD script(1) (macOS) takes the command as trailing positionals;
+  // util-linux script(1) rejects that ("unexpected number of arguments")
+  // and needs `-c` with one shell command string (quote each argv piece so
+  // spaces survive the extra shell parse). `-e` propagates the child's
+  // exit status, matching the node-pty path's semantics.
+  const darwin = process.platform === 'darwin';
+  const scriptArgs = darwin
+    ? ['-q', tmp, cmd, ...args]
+    : ['-q', '-e', '-c', [cmd, ...args].map(shellQuote).join(' '), tmp];
+  const child = spawn('script', scriptArgs, {
+    env: opts.env ?? process.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return {
+    pid: child.pid,
+    onData: (cb) => child.stdout.on('data', (d) => cb(d.toString('utf8'))),
+    onExit: (cb) =>
+      child.on('exit', (code, sig) => cb({ exitCode: code, signal: sig })),
+    kill: (sig) => {
+      try {
+        process.kill(-child.pid, sig);
+      } catch {
+        try {
+          child.kill(sig);
+        } catch {
+          // already dead — nothing further to signal
+        }
+      }
+    },
+    write: (d) => child.stdin.write(d),
+  };
+}
+
+export function handshakeMarkerFound(stdoutText, nonce) {
+  const prefix = `\x1b]697;tty-handshake;${nonce}`;
+  let index = stdoutText.indexOf(prefix);
+  while (index !== -1) {
+    const next = stdoutText[index + prefix.length];
+    const next2 = stdoutText[index + prefix.length + 1];
+    if (next === '\x07' || (next === '\x1b' && next2 === '\\')) return true;
+    index = stdoutText.indexOf(prefix, index + 1);
+  }
+  return false;
+}
+
+export const PTY_REFUSAL =
+  'native TTY capture refused: no PTY backend is available, and the harness ' +
+  'captures real-CLI commands through a native PTY instead of non-TTY pipes; ' +
+  'use the repository node-pty capability, or declare the command with ' +
+  '"pty": "fixture" (deterministic fixtures) or "pty": "wrapped" (a PTY ' +
+  'wrapper that completes the tty-handshake)';
+
+// tty modes:
+//   'native'  - the harness allocates a real PTY (enforced real-CLI contract)
+//   'fixture' - deterministic fixture that needs no TTY; pipe capture, waived
+//   'wrapped' - argv runs inside a caller-supplied PTY wrapper; the harness
+//               captures over pipes and verifies the tty-handshake marker
+export function capture(command, options = {}) {
+  const {
+    rows = 24,
+    columns = 80,
+    timeoutMs = 10000,
+    input = [],
+    env = {},
+    tty = 'native',
+  } = options;
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+
+    const timers = new Set();
+    const later = (fn, ms) => {
+      const handle = setTimeout(() => {
+        timers.delete(handle);
+        fn();
+      }, ms);
+      timers.add(handle);
+      return handle;
+    };
+    const clearAllTimers = () => {
+      for (const handle of timers) clearTimeout(handle);
+      timers.clear();
+    };
+
+    // Kill escalation timers survive settle: the main child closing must not
+    // cancel the SIGKILL step, or a descendant that ignores SIGTERM and does
+    // not hold the capture stdio would outlive the capture.
+    const killTimers = new Set();
+    const escalate = (fn, ms) => {
+      const handle = setTimeout(() => {
+        killTimers.delete(handle);
+        fn();
+      }, ms);
+      killTimers.add(handle);
+      return handle;
+    };
+    const cancelEscalation = () => {
+      for (const handle of killTimers) clearTimeout(handle);
+      killTimers.clear();
+    };
+
+    const ttyEvidence = {
+      mode: tty,
+      backend: null,
+      allocated: false,
+      rows,
+      columns,
+      handshake: null,
+    };
+    const result = {
+      command,
+      spawned: false,
+      spawnError: null,
+      stdoutText: '',
+      stderrText: '',
+      stdoutBytes: 0,
+      stderrBytes: 0,
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      timeoutMs,
+      tty: ttyEvidence,
+    };
+    let done = false;
+    let pid;
+    const groupAlive = () => {
+      if (!Number.isInteger(pid)) return false;
+      try {
+        process.kill(-pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    const settle = (fields) => {
+      done = true;
+      clearAllTimers();
+      // A timed-out capture keeps kill escalation pending until the process
+      // group is confirmed gone; only cancel it when nothing is left to kill,
+      // so the SIGKILL step survives the main child closing.
+      if (!groupAlive()) cancelEscalation();
+      resolve({ ...result, durationMs: Date.now() - startedAt, ...fields });
+    };
+
+    const childEnv = {
+      ...process.env,
+      ...env,
+      TERM: env.TERM ?? 'xterm-256color',
+      LINES: String(rows),
+      COLUMNS: String(columns),
+      TUI_PARITY: '1',
+    };
+
+    let backend = null;
+    let ptyProc = null;
+    let child = null;
+    let nonce = null;
+    if (tty === 'script') {
+      // script(1)-based PTY: some renderers (OpenTUI) accept a script-allocated
+      // PTY but not the node-pty backend. Capture script's stdout as the stream.
+      const tmp = `/tmp/tui-parity-script-${randomUUID()}.log`;
+      ttyEvidence.backend = 'script';
+      ttyEvidence.allocated = true;
+      try {
+        child = spawn('script', ['-q', tmp, ...command], {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          detached: true,
+          env: childEnv,
+        });
+      } catch (err) {
+        settle({ spawnError: err.message });
+        return;
+      }
+    } else if (tty === 'native') {
+      backend = loadPtyBackend();
+      if (!backend) {
+        settle({ spawnError: PTY_REFUSAL });
+        return;
+      }
+      ttyEvidence.backend = backend.kind;
+      try {
+        ptyProc = backend.spawn(command[0], command.slice(1), {
+          name: childEnv.TERM,
+          cols: columns,
+          rows,
+          env: childEnv,
+        });
+      } catch (err) {
+        settle({ spawnError: err.message });
+        return;
+      }
+      ttyEvidence.allocated = true;
+    } else {
+      if (tty === 'wrapped') {
+        nonce = randomUUID();
+        childEnv.TUI_PARITY_PTY_NONCE = nonce;
+      }
+      try {
+        child = spawn(command[0], command.slice(1), {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          detached: true,
+          env: childEnv,
+        });
+      } catch (err) {
+        settle({ spawnError: err.message });
+        return;
+      }
+    }
+
+    const chunks = [];
+    const stderrChunks = [];
+    if (ptyProc) {
+      // A PTY merges stderr into the terminal stream, as a real terminal sees.
+      ptyProc.onData((chunk) => chunks.push(Buffer.from(chunk)));
+    } else {
+      child.stdout.on('data', (chunk) => chunks.push(chunk));
+      child.stderr.on('data', (chunk) => stderrChunks.push(chunk));
+    }
+
+    let timedOut = false;
+    pid = ptyProc ? ptyProc.pid : child.pid;
+    const signalPid = (target, signal) => {
+      try {
+        process.kill(target, signal);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+    const killTree = (signal) => {
+      if (!Number.isInteger(pid)) return;
+      if (signalPid(-pid, signal)) return;
+      if (signalPid(pid, signal)) return;
+      if (ptyProc) {
+        try {
+          ptyProc.kill(signal);
+        } catch {
+          /* best effort */
+        }
+      }
+    };
+    later(() => {
+      timedOut = true;
+      killTree('SIGTERM');
+      escalate(() => {
+        killTree('SIGKILL');
+        // Explicitly confirm the process group is gone instead of trusting
+        // the main child's exit; a descendant that ignored SIGTERM must not
+        // survive the capture. Bounded so the harness cannot linger.
+        let attemptsLeft = TREE_VERIFY_ATTEMPTS;
+        const verify = () => {
+          if (!groupAlive()) {
+            cancelEscalation();
+            return;
+          }
+          attemptsLeft -= 1;
+          if (attemptsLeft <= 0) {
+            cancelEscalation();
+            return;
+          }
+          killTree('SIGKILL');
+          escalate(verify, TREE_VERIFY_INTERVAL_MS);
+        };
+        escalate(verify, TREE_VERIFY_INTERVAL_MS);
+      }, KILL_GRACE_MS);
+    }, timeoutMs);
+
+    const writeInput = (index) => {
+      if (done) return;
+      if (index >= input.length) {
+        if (child) {
+          try {
+            child.stdin.end();
+          } catch {
+            /* already closed */
+          }
+        }
+        return;
+      }
+      const step = input[index];
+      const delay = Number.isInteger(step.delayMs) ? step.delayMs : 0;
+      later(() => {
+        if (done) return;
+        try {
+          if (ptyProc) ptyProc.write(step.data ?? '');
+          else child.stdin.write(step.data ?? '');
+        } catch {
+          /* child already gone */
+        }
+        writeInput(index + 1);
+      }, delay);
+    };
+    writeInput(0);
+
+    const finish = (fields) => {
+      if (done) return;
+      const stdoutBuf = Buffer.concat(chunks);
+      const stderrBuf = Buffer.concat(stderrChunks);
+      if (nonce) {
+        ttyEvidence.handshake = handshakeMarkerFound(
+          stdoutBuf.toString('utf8'),
+          nonce,
+        )
+          ? 'verified'
+          : 'missing';
+      }
+      if (ptyProc) {
+        try {
+          ptyProc.destroy();
+        } catch {
+          /* best effort */
+        }
+      }
+      settle({
+        spawned: true,
+        pid,
+        stdoutText: stdoutBuf.toString('utf8'),
+        stderrText: stderrBuf.toString('utf8'),
+        stdoutBytes: stdoutBuf.length,
+        stderrBytes: stderrBuf.length,
+        timedOut,
+        ...fields,
+      });
+    };
+
+    if (ptyProc) {
+      ptyProc.onExit(({ exitCode, signal }) => {
+        const normalized =
+          signal === 0 || signal === '' || signal == null ? null : signal;
+        // One tick lets the PTY reader drain final output before closing.
+        setImmediate(() => finish({ exitCode, signal: normalized }));
+      });
+    } else {
+      child.on('error', (err) =>
+        finish({ spawned: false, spawnError: err.message }),
+      );
+      child.on('close', (exitCode, signal) => finish({ exitCode, signal }));
+    }
+  });
+}

--- a/scripts/tui-parity/lib/normalize.mjs
+++ b/scripts/tui-parity/lib/normalize.mjs
@@ -1,0 +1,279 @@
+const makeRow = (columns) => new Array(columns).fill(' ');
+const makeGrid = (rows, columns) =>
+  Array.from({ length: rows }, () => makeRow(columns));
+
+export function renderFinalScreen(raw, { rows = 24, columns = 80 } = {}) {
+  const main = makeGrid(rows, columns);
+  let alt = null;
+  let grid = main;
+  const cur = { r: 0, c: 0 };
+  let savedCursor = null;
+
+  const clamp = (value, max) => Math.max(0, Math.min(value, max));
+  const clampCursor = () => {
+    cur.r = clamp(cur.r, rows - 1);
+    cur.c = clamp(cur.c, columns - 1);
+  };
+  const linefeed = () => {
+    if (cur.r >= rows - 1) {
+      grid.shift();
+      grid.push(makeRow(columns));
+    } else {
+      cur.r += 1;
+    }
+  };
+  const put = (ch) => {
+    if (cur.c >= columns) {
+      cur.c = 0;
+      linefeed();
+    }
+    grid[cur.r][cur.c] = ch;
+    cur.c += 1;
+  };
+  const fillRow = (r, from, to) => {
+    for (let c = from; c <= to; c += 1) grid[r][c] = ' ';
+  };
+  const eraseDisplay = (mode) => {
+    if (mode === 0) {
+      fillRow(cur.r, cur.c, columns - 1);
+      for (let r = cur.r + 1; r < rows; r += 1) fillRow(r, 0, columns - 1);
+    } else if (mode === 1) {
+      for (let r = 0; r < cur.r; r += 1) fillRow(r, 0, columns - 1);
+      fillRow(cur.r, 0, cur.c);
+    } else {
+      for (let r = 0; r < rows; r += 1) fillRow(r, 0, columns - 1);
+    }
+  };
+  const enterAltScreen = () => {
+    if (alt) return;
+    alt = makeGrid(rows, columns);
+    savedCursor = { r: cur.r, c: cur.c };
+    grid = alt;
+    cur.r = 0;
+    cur.c = 0;
+  };
+  const leaveAltScreen = () => {
+    if (!alt) return;
+    alt = null;
+    grid = main;
+    if (savedCursor) {
+      cur.r = savedCursor.r;
+      cur.c = savedCursor.c;
+      savedCursor = null;
+    }
+    clampCursor();
+  };
+
+  let i = 0;
+  while (i < raw.length) {
+    const ch = raw[i];
+    if (ch !== '\x1b') {
+      if (ch === '\n') linefeed();
+      else if (ch === '\r') cur.c = 0;
+      else if (ch === '\b') cur.c = Math.max(0, cur.c - 1);
+      else if (ch === '\t')
+        cur.c = clamp((Math.floor(cur.c / 8) + 1) * 8, columns - 1);
+      else if (ch >= ' ') put(ch);
+      i += 1;
+      continue;
+    }
+
+    const next = raw[i + 1];
+    if (next === undefined) {
+      i += 1;
+      continue;
+    }
+
+    if (next === '[') {
+      let j = i + 2;
+      let priv = '';
+      while (j < raw.length && raw[j] >= '<' && raw[j] <= '?') {
+        priv += raw[j];
+        j += 1;
+      }
+      const paramStart = j;
+      // `:` is the CSI sub-parameter separator (SGR `38:2::r:g:b`); without
+      // it the scan stops at the first colon and the rest of the sequence
+      // leaks into the grid as printable text.
+      while (
+        j < raw.length &&
+        ((raw[j] >= '0' && raw[j] <= '9') || raw[j] === ';' || raw[j] === ':')
+      ) {
+        j += 1;
+      }
+      const paramText = raw.slice(paramStart, j);
+      while (j < raw.length && raw[j] >= ' ' && raw[j] <= '/') {
+        j += 1;
+      }
+      const final = j < raw.length ? raw[j] : '';
+      j += 1;
+      i = j;
+      const params =
+        paramText === ''
+          ? []
+          : paramText.split(';').map((part) => {
+              const n = Number.parseInt(part, 10);
+              return Number.isNaN(n) ? 0 : n;
+            });
+      const paramAt = (index, dflt) =>
+        params.length > index && params[index] > 0 ? params[index] : dflt;
+      const n1 = paramAt(0, 1);
+
+      switch (final) {
+        case 'A':
+          cur.r -= n1;
+          break;
+        case 'B':
+        case 'e':
+          cur.r += n1;
+          break;
+        case 'C':
+        case 'a':
+          cur.c += n1;
+          break;
+        case 'D':
+          cur.c -= n1;
+          break;
+        case 'E':
+          cur.r += n1;
+          cur.c = 0;
+          break;
+        case 'F':
+          cur.r -= n1;
+          cur.c = 0;
+          break;
+        case 'G':
+        case '`':
+          cur.c = paramAt(0, 1) - 1;
+          break;
+        case 'd':
+          cur.r = paramAt(0, 1) - 1;
+          break;
+        case 'H':
+        case 'f':
+          cur.r = paramAt(0, 1) - 1;
+          cur.c = paramAt(1, 1) - 1;
+          break;
+        case 'J':
+          eraseDisplay(paramAt(0, 0));
+          break;
+        case 'K': {
+          const mode = paramAt(0, 0);
+          if (mode === 0) fillRow(cur.r, cur.c, columns - 1);
+          else if (mode === 1) fillRow(cur.r, 0, cur.c);
+          else fillRow(cur.r, 0, columns - 1);
+          break;
+        }
+        case 'L': {
+          const count = Math.min(paramAt(0, 1), rows - cur.r);
+          const blanks = Array.from({ length: count }, () => makeRow(columns));
+          grid.splice(cur.r, 0, ...blanks);
+          grid.splice(rows, grid.length - rows);
+          break;
+        }
+        case 'M': {
+          const count = Math.min(paramAt(0, 1), rows - cur.r);
+          grid.splice(cur.r, count);
+          while (grid.length < rows) grid.push(makeRow(columns));
+          break;
+        }
+        case '@': {
+          const count = Math.min(paramAt(0, 1), columns - cur.c);
+          grid[cur.r].splice(cur.c, 0, ...new Array(count).fill(' '));
+          grid[cur.r].splice(columns, grid[cur.r].length - columns);
+          break;
+        }
+        case 'P': {
+          const count = Math.min(paramAt(0, 1), columns - cur.c);
+          grid[cur.r].splice(cur.c, count);
+          while (grid[cur.r].length < columns) grid[cur.r].push(' ');
+          break;
+        }
+        case 'X': {
+          const count = Math.min(paramAt(0, 1), columns - cur.c);
+          fillRow(cur.r, cur.c, cur.c + count - 1);
+          break;
+        }
+        case 'h':
+        case 'l':
+          if (priv === '?') {
+            for (const p of params) {
+              if (final === 'h' && (p === 1049 || p === 1047 || p === 47))
+                enterAltScreen();
+              else if (final === 'l' && (p === 1049 || p === 1047 || p === 47))
+                leaveAltScreen();
+            }
+          }
+          break;
+        default:
+          break;
+      }
+      clampCursor();
+      continue;
+    }
+
+    if (next === ']') {
+      let j = i + 2;
+      while (j < raw.length) {
+        if (raw[j] === '\x07') {
+          j += 1;
+          break;
+        }
+        if (raw[j] === '\x1b' && raw[j + 1] === '\\') {
+          j += 2;
+          break;
+        }
+        j += 1;
+      }
+      i = j;
+      continue;
+    }
+
+    if (next === 'c') {
+      alt = null;
+      grid = main;
+      for (let r = 0; r < rows; r += 1) main[r] = makeRow(columns);
+      cur.r = 0;
+      cur.c = 0;
+      i += 2;
+      continue;
+    }
+
+    // String sequences (DCS `ESC P`, SOS `ESC X`, PM `ESC ^`, APC `ESC _`):
+    // consume through ST (`ESC \`) or BEL so payloads stay out of the grid.
+    if (next === 'P' || next === 'X' || next === '^' || next === '_') {
+      let j = i + 2;
+      while (j < raw.length) {
+        if (raw[j] === '\x07') {
+          j += 1;
+          break;
+        }
+        if (raw[j] === '\x1b' && raw[j + 1] === '\\') {
+          j += 2;
+          break;
+        }
+        j += 1;
+      }
+      i = j;
+      continue;
+    }
+
+    // Intermediate-byte sequences (charset designation `ESC ( B`,
+    // `ESC ) 0`, …): consume ESC + the 0x20–0x2F intermediates + the final
+    // byte. The old 2-byte fallback below leaked the tail (e.g. `B`) into
+    // the grid as printable text.
+    if (next >= ' ' && next <= '/') {
+      let j = i + 1;
+      while (j < raw.length && raw[j] >= ' ' && raw[j] <= '/') j += 1;
+      if (j < raw.length) j += 1;
+      i = j;
+      continue;
+    }
+
+    i += 2;
+  }
+
+  const lines = grid.map((row) => row.join('').replace(/[ ]+$/, ''));
+  while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return lines.join('\n');
+}

--- a/scripts/tui-parity/lib/scenario.mjs
+++ b/scripts/tui-parity/lib/scenario.mjs
@@ -1,0 +1,407 @@
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const TOP_LEVEL_KEYS = new Set([
+  'id',
+  'description',
+  'terminal',
+  'timeoutMs',
+  'input',
+  'env',
+  'commands',
+  'compareParams',
+  'thresholds',
+  'proves',
+  'doesNotProve',
+]);
+const INTEGER_THRESHOLD_KEYS = [
+  'maxFullScreenClears',
+  'maxPartialScreenErases',
+  'maxLineErases',
+  'maxDuplicateEvents',
+  'maxDec2026Unbalanced',
+];
+const BOOLEAN_THRESHOLD_KEYS = [
+  'requireSync',
+  'requireEventMarkers',
+  'requireExitCodeZero',
+];
+const SIDE_OBJECT_KEYS = new Set(['argv', 'pty']);
+const SIDE_PTY_MODES = new Set(['fixture', 'wrapped']);
+const SHARED_SCENARIO_KEYS = new Set([
+  'id',
+  'description',
+  'terminal',
+  'timeoutMs',
+  'input',
+  'env',
+  'commands',
+  'compareParams',
+  'thresholds',
+  'proves',
+  'doesNotProve',
+]);
+const COMPARE_PARAM_RE = /^--[A-Za-z0-9][A-Za-z0-9-]*$/;
+const TERMINAL_PARAM_TO_DIMENSION = {
+  '--rows': 'rows',
+  '--lines': 'rows',
+  '--columns': 'columns',
+  '--cols': 'columns',
+};
+
+export function extractFlagValues(argv, flag) {
+  const values = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === flag) {
+      values.push(argv[i + 1] ?? '');
+      i += 1;
+    } else if (typeof token === 'string' && token.startsWith(`${flag}=`)) {
+      values.push(token.slice(flag.length + 1));
+    }
+  }
+  return values;
+}
+
+export function validateCompareParams(
+  compareParams,
+  base,
+  fixed,
+  terminal,
+  problems,
+) {
+  for (const flag of compareParams) {
+    const baseValues = extractFlagValues(base.argv, flag);
+    const fixedValues = extractFlagValues(fixed.argv, flag);
+    if (baseValues.length === 0 && fixedValues.length === 0) {
+      problems.push(
+        `compareParams: "${flag}" is missing from commands.base and commands.fixed`,
+      );
+      continue;
+    }
+    if (baseValues.length === 0) {
+      problems.push(`compareParams: "${flag}" is missing from commands.base`);
+      continue;
+    }
+    if (fixedValues.length === 0) {
+      problems.push(`compareParams: "${flag}" is missing from commands.fixed`);
+      continue;
+    }
+    if (JSON.stringify(baseValues) !== JSON.stringify(fixedValues)) {
+      problems.push(
+        `compareParams: "${flag}" differs between base (${baseValues.join(', ')}) ` +
+          `and fixed (${fixedValues.join(', ')}); declared comparison ` +
+          'parameters must be equal on both sides',
+      );
+      continue;
+    }
+    const dimension = TERMINAL_PARAM_TO_DIMENSION[flag];
+    if (dimension) {
+      for (const value of baseValues) {
+        if (
+          !/^\d+$/.test(value) ||
+          Number.parseInt(value, 10) !== terminal[dimension]
+        ) {
+          problems.push(
+            `compareParams: "${flag}" value "${value}" does not match ` +
+              `terminal.${dimension} (${terminal[dimension]})`,
+          );
+          break;
+        }
+      }
+    }
+  }
+}
+
+// Checks only the terminal-size flags present in argv, independent of
+// compareParams. Used to bind override-supplied argv to the capture geometry.
+export function validateTerminalFlags(argv, terminal, label, problems) {
+  for (const [flag, dimension] of Object.entries(TERMINAL_PARAM_TO_DIMENSION)) {
+    for (const value of extractFlagValues(argv, flag)) {
+      if (
+        !/^\d+$/.test(value) ||
+        Number.parseInt(value, 10) !== terminal[dimension]
+      ) {
+        problems.push(
+          `${label}: "${flag}" value "${value}" does not match ` +
+            `terminal.${dimension} (${terminal[dimension]})`,
+        );
+        break;
+      }
+    }
+  }
+}
+
+export function parseSideCommand(name, raw, problems) {
+  if (raw === undefined) {
+    problems.push(`commands.${name} is required`);
+    return null;
+  }
+  if (Array.isArray(raw)) {
+    if (
+      raw.length === 0 ||
+      !raw.every((part) => typeof part === 'string' && part.length > 0)
+    ) {
+      problems.push(
+        `commands.${name} must be a non-empty array of non-empty strings`,
+      );
+      return null;
+    }
+    return { argv: raw, pty: 'native' };
+  }
+  if (typeof raw === 'object' && raw !== null) {
+    for (const key of Object.keys(raw)) {
+      if (SIDE_OBJECT_KEYS.has(key)) continue;
+      if (SHARED_SCENARIO_KEYS.has(key)) {
+        problems.push(
+          `commands.${name} may not define "${key}": ` +
+            'base and fixed share all scenario parameters',
+        );
+      } else {
+        problems.push(`unknown commands.${name} key "${key}"`);
+      }
+    }
+    const argv = raw.argv;
+    if (
+      !Array.isArray(argv) ||
+      argv.length === 0 ||
+      !argv.every((part) => typeof part === 'string' && part.length > 0)
+    ) {
+      problems.push(
+        `commands.${name}.argv must be a non-empty array of non-empty strings`,
+      );
+      return null;
+    }
+    let pty = 'native';
+    if (raw.pty !== undefined) {
+      if (!SIDE_PTY_MODES.has(raw.pty)) {
+        problems.push(
+          `commands.${name}.pty must be "fixture" or "wrapped" ` +
+            '(plain argv arrays always capture through a native PTY)',
+        );
+      } else {
+        pty = raw.pty;
+      }
+    }
+    return { argv, pty };
+  }
+  problems.push(
+    `commands.${name} must be an argv array or an object with "argv" and optional "pty"`,
+  );
+  return null;
+}
+
+export function validateScenario(input, label = 'scenario') {
+  const problems = [];
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    throw new Error(`scenario ${label}: must be a JSON object`);
+  }
+  for (const key of Object.keys(input)) {
+    if (!TOP_LEVEL_KEYS.has(key)) {
+      problems.push(`unknown top-level key "${key}"`);
+    }
+  }
+  if (typeof input.id !== 'string' || !/^[a-z0-9][a-z0-9-]*$/.test(input.id)) {
+    problems.push('id must be a kebab-case string ([a-z0-9-])');
+  }
+  if (typeof input.description !== 'string' || input.description.length === 0) {
+    problems.push('description is required');
+  }
+  if (typeof input.proves !== 'string' || input.proves.length === 0) {
+    problems.push('proves is required (what this scenario proves)');
+  }
+  if (
+    typeof input.doesNotProve !== 'string' ||
+    input.doesNotProve.length === 0
+  ) {
+    problems.push(
+      'doesNotProve is required (what this scenario does not prove)',
+    );
+  }
+
+  const terminal = input.terminal;
+  let rows = 24;
+  let columns = 80;
+  if (typeof terminal !== 'object' || terminal === null) {
+    problems.push('terminal with rows and columns is required');
+  } else {
+    for (const key of Object.keys(terminal)) {
+      if (key !== 'rows' && key !== 'columns')
+        problems.push(`unknown terminal key "${key}"`);
+    }
+    if (
+      !Number.isInteger(terminal.rows) ||
+      terminal.rows < 1 ||
+      terminal.rows > 1000
+    ) {
+      problems.push('terminal.rows must be an integer in 1..1000');
+    } else rows = terminal.rows;
+    if (
+      !Number.isInteger(terminal.columns) ||
+      terminal.columns < 1 ||
+      terminal.columns > 1000
+    ) {
+      problems.push('terminal.columns must be an integer in 1..1000');
+    } else columns = terminal.columns;
+  }
+
+  let timeoutMs = 10000;
+  if (input.timeoutMs !== undefined) {
+    if (!Number.isInteger(input.timeoutMs) || input.timeoutMs <= 0) {
+      problems.push('timeoutMs must be a positive integer');
+    } else timeoutMs = input.timeoutMs;
+  }
+
+  let scenarioInput = [];
+  if (input.input !== undefined) {
+    if (!Array.isArray(input.input)) problems.push('input must be an array');
+    else {
+      scenarioInput = input.input;
+      input.input.forEach((step, index) => {
+        if (typeof step !== 'object' || step === null) {
+          problems.push(`input[${index}] must be an object`);
+          return;
+        }
+        if (typeof step.data !== 'string') {
+          problems.push(`input[${index}].data must be a string`);
+        }
+        if (
+          step.delayMs !== undefined &&
+          (!Number.isInteger(step.delayMs) || step.delayMs < 0)
+        ) {
+          problems.push(`input[${index}].delayMs must be an integer >= 0`);
+        }
+      });
+    }
+  }
+
+  let env = {};
+  if (input.env !== undefined) {
+    if (typeof input.env !== 'object' || input.env === null) {
+      problems.push('env must be an object of strings');
+    } else {
+      env = input.env;
+      for (const [key, value] of Object.entries(input.env)) {
+        if (typeof value !== 'string')
+          problems.push(`env.${key} must be a string`);
+      }
+    }
+  }
+
+  let commands = { base: null, fixed: null };
+  if (typeof input.commands !== 'object' || input.commands === null) {
+    problems.push('commands with base and fixed argv is required');
+  } else {
+    for (const key of Object.keys(input.commands)) {
+      if (key !== 'base' && key !== 'fixed')
+        problems.push(`unknown commands key "${key}"`);
+    }
+    commands = {
+      base: parseSideCommand('base', input.commands.base, problems),
+      fixed: parseSideCommand('fixed', input.commands.fixed, problems),
+    };
+  }
+
+  let compareParams = [];
+  if (input.compareParams !== undefined) {
+    if (!Array.isArray(input.compareParams)) {
+      problems.push('compareParams must be an array of "--flag" strings');
+    } else {
+      compareParams = input.compareParams;
+      for (const flag of compareParams) {
+        if (typeof flag !== 'string' || !COMPARE_PARAM_RE.test(flag)) {
+          problems.push(
+            `compareParams entries must be strings matching --<flag> (got ${JSON.stringify(flag)})`,
+          );
+        }
+      }
+    }
+  }
+  if (
+    commands.base &&
+    commands.fixed &&
+    compareParams.length > 0 &&
+    compareParams.every(
+      (flag) => typeof flag === 'string' && COMPARE_PARAM_RE.test(flag),
+    )
+  ) {
+    validateCompareParams(
+      compareParams,
+      commands.base,
+      commands.fixed,
+      { rows, columns },
+      problems,
+    );
+  }
+
+  let thresholds = {};
+  if (input.thresholds !== undefined) {
+    if (typeof input.thresholds !== 'object' || input.thresholds === null) {
+      problems.push('thresholds must be an object');
+    } else {
+      thresholds = input.thresholds;
+      for (const [key, value] of Object.entries(input.thresholds)) {
+        if (INTEGER_THRESHOLD_KEYS.includes(key)) {
+          if (!Number.isInteger(value) || value < 0) {
+            problems.push(`thresholds.${key} must be an integer >= 0`);
+          }
+        } else if (BOOLEAN_THRESHOLD_KEYS.includes(key)) {
+          if (typeof value !== 'boolean') {
+            problems.push(`thresholds.${key} must be a boolean`);
+          }
+        } else {
+          problems.push(`unknown thresholds key "${key}"`);
+        }
+      }
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(`scenario ${label}: ${problems.join('; ')}`);
+  }
+  return {
+    id: input.id,
+    description: input.description,
+    terminal: { rows, columns },
+    timeoutMs,
+    input: scenarioInput,
+    env,
+    commands,
+    compareParams,
+    thresholds,
+    proves: input.proves,
+    doesNotProve: input.doesNotProve,
+  };
+}
+
+export async function loadScenarioFile(file) {
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(file, 'utf8'));
+  } catch (err) {
+    throw new Error(`scenario ${file}: ${err.message}`);
+  }
+  return validateScenario(parsed, file);
+}
+
+export async function loadScenarios(paths) {
+  const loaded = [];
+  for (const p of paths) {
+    const info = await stat(p);
+    if (info.isDirectory()) {
+      const entries = (await readdir(p))
+        .filter((name) => name.endsWith('.scenario.json'))
+        .sort();
+      if (entries.length === 0) {
+        throw new Error(`no *.scenario.json files found in ${p}`);
+      }
+      for (const name of entries) {
+        const file = join(p, name);
+        loaded.push({ file, scenario: await loadScenarioFile(file) });
+      }
+    } else {
+      loaded.push({ file: p, scenario: await loadScenarioFile(p) });
+    }
+  }
+  return loaded;
+}

--- a/scripts/tui-parity/lib/tty-handshake.mjs
+++ b/scripts/tui-parity/lib/tty-handshake.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// PTY wrapper handshake helper. Run this script INSIDE a real PTY (for
+// example via expect, tmux, or `script`); it verifies that its own stdout is
+// a TTY, emits the run's tty-handshake marker, and then execs the wrapped
+// command with inherited stdio. The parity harness sets TUI_PARITY_PTY_NONCE
+// and verifies the marker in the captured stream; without both the TTY and
+// the nonce it refuses instead of claiming PTY capture.
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+const argv = process.argv.slice(2);
+const nonce = process.env.TUI_PARITY_PTY_NONCE ?? '';
+
+if (argv.length === 0) {
+  console.error('tty-handshake: missing the wrapped command');
+  process.exit(2);
+}
+if (!process.stdout.isTTY) {
+  console.error(
+    'tty-handshake: stdout is not a TTY; refusing to claim PTY capture',
+  );
+  process.exit(2);
+}
+if (nonce === '') {
+  console.error(
+    'tty-handshake: TUI_PARITY_PTY_NONCE is not set; the parity harness ' +
+      'must start this capture in "wrapped" mode',
+  );
+  process.exit(2);
+}
+
+process.stdout.write(`\x1b]697;tty-handshake;${nonce}\x07`);
+const child = spawn(argv[0], argv.slice(1), { stdio: 'inherit' });
+child.on('close', (code, signal) => {
+  process.exit(code ?? (signal ? 1 : 0));
+});

--- a/scripts/tui-parity/runner.mjs
+++ b/scripts/tui-parity/runner.mjs
@@ -1,0 +1,588 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { analyzeAnsi } from './lib/ansi-metrics.mjs';
+import { capture } from './lib/capture.mjs';
+import { renderFinalScreen } from './lib/normalize.mjs';
+import {
+  loadScenarios,
+  validateCompareParams,
+  validateTerminalFlags,
+} from './lib/scenario.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function resolveCommand(argv) {
+  const out = [...argv];
+  if (
+    out.length >= 2 &&
+    out[0] === 'node' &&
+    !isAbsolute(out[1]) &&
+    /\.(mjs|cjs|js)$/.test(out[1])
+  ) {
+    out[1] = resolve(REPO_ROOT, out[1]);
+  }
+  return out;
+}
+
+export function splitCommandLine(text) {
+  const parts = [];
+  let current = '';
+  let quote = null;
+  let started = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      started = true;
+      continue;
+    }
+    if (ch === '\\' && i + 1 < text.length) {
+      current += text[i + 1];
+      i += 1;
+      started = true;
+      continue;
+    }
+    if (ch === ' ' || ch === '\t') {
+      if (started) {
+        parts.push(current);
+        current = '';
+        started = false;
+      }
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (started) parts.push(current);
+  return parts;
+}
+
+// Re-validates the commands that will actually execute, AFTER any
+// --base/--fixed overrides have replaced the scenario commands. Scenario-load
+// validation only saw the original scenario argv; a divergent override would
+// otherwise run while the report still claimed the compareParams were checked.
+// Throws before anything is captured.
+export function validateFinalParams(
+  scenario,
+  baseCommand,
+  fixedCommand,
+  overrides = {},
+) {
+  const problems = [];
+  const compareParams = scenario.compareParams ?? [];
+  const baseArgv = resolveCommand(baseCommand.argv);
+  const fixedArgv = resolveCommand(fixedCommand.argv);
+  if (compareParams.length > 0) {
+    validateCompareParams(
+      compareParams,
+      { argv: baseArgv },
+      { argv: fixedArgv },
+      scenario.terminal,
+      problems,
+    );
+  }
+  validateTerminalFlags(baseArgv, scenario.terminal, 'commands.base', problems);
+  validateTerminalFlags(
+    fixedArgv,
+    scenario.terminal,
+    'commands.fixed',
+    problems,
+  );
+  if (problems.length > 0) {
+    const overridden = ['base', 'fixed']
+      .filter((side) => overrides[side])
+      .map((side) => `--${side}`);
+    const subject =
+      overridden.length > 0
+        ? `${overridden.join(' and ')} override(s)`
+        : 'the final command';
+    throw new Error(
+      `${subject} failed parameter binding on the final resolved argv: ` +
+        problems.join('; '),
+    );
+  }
+}
+
+export const METRIC_VIEWS = {
+  fullScreenClears: (met) => met.fullScreenClears.total,
+  partialScreenErases: (met) => met.partialScreenErases,
+  lineErases: (met) => met.lineErases.total,
+  dec2026Unbalanced: (met) => met.dec2026.unbalanced,
+  duplicateEvents: (met) => met.events.duplicates,
+  eventMarkers: (met) => met.events.total,
+  unwrappedEvents: (met) => met.events.unwrapped,
+  printableChars: (met) => met.printableChars,
+  stdoutBytes: (met) => met.bytes,
+};
+
+export function evaluateSide(metrics, cap, thresholds = {}) {
+  const reasons = [];
+  const check = (name, value, max) => {
+    if (max !== undefined && value > max) {
+      reasons.push(`${name}=${value} exceeds threshold max ${max}`);
+    }
+  };
+  if (cap.spawnError) reasons.push(`spawn failed: ${cap.spawnError}`);
+  if (cap.timedOut) reasons.push(`timed out after ${cap.timeoutMs}ms`);
+  if (cap.tty?.mode === 'wrapped' && cap.tty.handshake !== 'verified') {
+    reasons.push(
+      'PTY wrapper handshake not verified: captured stdout contains no ' +
+        "tty-handshake OSC 697 marker with this run's nonce, so native TTY " +
+        'capture is not proven for this side',
+    );
+  }
+  if ((thresholds.requireExitCodeZero ?? true) && cap.exitCode !== 0) {
+    reasons.push(`exit code ${cap.exitCode ?? 'null'} != 0`);
+  }
+  check(
+    'fullScreenClears',
+    metrics.fullScreenClears.total,
+    thresholds.maxFullScreenClears,
+  );
+  check('lineErases', metrics.lineErases.total, thresholds.maxLineErases);
+  check(
+    'partialScreenErases',
+    metrics.partialScreenErases,
+    thresholds.maxPartialScreenErases,
+  );
+  check(
+    'duplicateEvents',
+    metrics.events.duplicates,
+    thresholds.maxDuplicateEvents,
+  );
+  check(
+    'dec2026Unbalanced',
+    metrics.dec2026.unbalanced,
+    thresholds.maxDec2026Unbalanced,
+  );
+  if (thresholds.requireSync) {
+    if (metrics.dec2026.begin === 0) {
+      reasons.push('requireSync: no DEC 2026 begin sequence found');
+    }
+    if (metrics.dec2026.unbalanced !== 0) {
+      reasons.push(
+        `requireSync: DEC 2026 pairs unbalanced by ${metrics.dec2026.unbalanced}`,
+      );
+    }
+    // Coverage is measured per event occurrence: a marker only counts as
+    // synced when it was emitted inside an active DEC 2026 interval. Empty
+    // begin/end pairs and unwrapped markers can never prove coverage, even
+    // when the begin count matches the unique event count.
+    if (metrics.events.markersPresent && metrics.events.unwrapped > 0) {
+      reasons.push(
+        `requireSync: ${metrics.events.unwrapped} live-output event ` +
+          'marker(s) were emitted outside any DEC 2026 sync interval; sync ' +
+          'brackets must wrap every measured event',
+      );
+    }
+  }
+  if (thresholds.requireEventMarkers && !metrics.events.markersPresent) {
+    reasons.push('requireEventMarkers: no OSC 697 event markers found');
+  }
+  return { verdict: reasons.length === 0 ? 'pass' : 'fail', reasons };
+}
+
+const PASSING_OUTCOMES = new Set(['base-fails-fixed-passes', 'both-pass']);
+
+export function buildComparison(
+  scenario,
+  base,
+  fixed,
+  generatedAt,
+  overridesApplied = { base: false, fixed: false },
+) {
+  const captureOk = (side) => side.capture.spawned && !side.capture.timedOut;
+  let outcome;
+  if (!captureOk(base) || !captureOk(fixed)) outcome = 'capture-error';
+  else if (fixed.eval.verdict === 'fail') outcome = 'fixed-fails';
+  else if (base.eval.verdict === 'fail') outcome = 'base-fails-fixed-passes';
+  else outcome = 'both-pass';
+  const deltas = {};
+  for (const [key, view] of Object.entries(METRIC_VIEWS)) {
+    deltas[key] = view(base.metrics) - view(fixed.metrics);
+  }
+  return {
+    scenarioId: scenario.id,
+    description: scenario.description,
+    generatedAt,
+    terminal: scenario.terminal,
+    timeoutMs: scenario.timeoutMs,
+    compareParams: scenario.compareParams ?? [],
+    overridesApplied,
+    commands: { base: base.command, fixed: fixed.command },
+    sides: {
+      base: summarizeSide(base),
+      fixed: summarizeSide(fixed),
+    },
+    baseVerdict: base.eval.verdict,
+    fixedVerdict: fixed.eval.verdict,
+    deltas,
+    outcome,
+    harnessPass: PASSING_OUTCOMES.has(outcome),
+    proves: scenario.proves,
+    doesNotProve: scenario.doesNotProve,
+  };
+}
+
+function summarizeSide(side) {
+  const cap = side.capture;
+  return {
+    command: side.command,
+    capture: {
+      spawned: cap.spawned,
+      spawnError: cap.spawnError,
+      exitCode: cap.exitCode,
+      signal: cap.signal,
+      timedOut: cap.timedOut,
+      timeoutMs: cap.timeoutMs,
+      durationMs: cap.durationMs,
+      stdoutBytes: cap.stdoutBytes,
+      stderrBytes: cap.stderrBytes,
+      tty: cap.tty,
+    },
+    metrics: side.metrics,
+    screen: side.screen,
+    verdict: side.eval.verdict,
+    reasons: side.eval.reasons,
+  };
+}
+
+function describeTty(tty) {
+  if (!tty) return 'unknown';
+  if (tty.mode === 'native') {
+    return tty.allocated
+      ? `native PTY (${tty.backend}, ${tty.rows}x${tty.columns})`
+      : 'native PTY refused (no backend)';
+  }
+  if (tty.mode === 'wrapped') return `wrapped (handshake ${tty.handshake})`;
+  return 'fixture (pipe capture, TTY waived)';
+}
+
+export function renderReport(comparison) {
+  const c = comparison;
+  const lines = [];
+  lines.push(`# TUI parity report: ${c.scenarioId}`);
+  lines.push('');
+  lines.push(c.description);
+  lines.push('');
+  lines.push(`- Generated: ${c.generatedAt}`);
+  lines.push(
+    `- Terminal: ${c.terminal.rows} rows x ${c.terminal.columns} columns, timeout ${c.timeoutMs}ms`,
+  );
+  lines.push(
+    `- Outcome: **${c.outcome}** (base=${c.baseVerdict}, fixed=${c.fixedVerdict})`,
+  );
+  lines.push('');
+  lines.push('## Commands');
+  lines.push('');
+  lines.push(`- base: \`${c.commands.base.join(' ')}\``);
+  lines.push(`- fixed: \`${c.commands.fixed.join(' ')}\``);
+  const overriddenSides = ['base', 'fixed'].filter(
+    (side) => c.overridesApplied?.[side],
+  );
+  if (overriddenSides.length > 0) {
+    lines.push(
+      `- Overrides applied to: ${overriddenSides.join(', ')}. Final resolved ` +
+        'commands were re-validated for compareParams and terminal dimensions ' +
+        'after the override, before capture.',
+    );
+  }
+  if (c.compareParams.length > 0) {
+    lines.push(
+      `- Declared comparison parameters (validated equal on the final commands that ran): ${c.compareParams.join(' ')}`,
+    );
+  }
+  lines.push(
+    `- Capture: base ${describeTty(c.sides.base.capture.tty)}, fixed ${describeTty(c.sides.fixed.capture.tty)}`,
+  );
+  lines.push('');
+  lines.push('## Metrics (stdout)');
+  lines.push('');
+  lines.push('| metric | base | fixed | delta (base-fixed) |');
+  lines.push('| --- | ---: | ---: | ---: |');
+  for (const [key, view] of Object.entries(METRIC_VIEWS)) {
+    lines.push(
+      `| ${key} | ${view(c.sides.base.metrics)} | ${view(c.sides.fixed.metrics)} | ${c.deltas[key]} |`,
+    );
+  }
+  lines.push('');
+  lines.push('## Thresholds (fixed side)');
+  lines.push('');
+  if (c.sides.fixed.verdict === 'pass') {
+    lines.push('All configured fixed-side thresholds satisfied.');
+  } else {
+    for (const reason of c.sides.fixed.reasons) {
+      lines.push(`- VIOLATED: ${reason}`);
+    }
+  }
+  if (c.sides.base.reasons.length > 0) {
+    lines.push('');
+    lines.push('Base-side observations:');
+    for (const reason of c.sides.base.reasons) {
+      lines.push(`- ${reason}`);
+    }
+  }
+  lines.push('');
+  lines.push('## What this scenario proves');
+  lines.push('');
+  lines.push(c.proves);
+  lines.push('');
+  lines.push('## What this scenario does not prove');
+  lines.push('');
+  lines.push(c.doesNotProve);
+  lines.push('');
+  lines.push('## Artifacts');
+  lines.push('');
+  const sideFiles = ['raw.ansi', 'stderr.txt', 'screen.txt', 'summary.json'];
+  for (const side of ['base', 'fixed']) {
+    for (const name of sideFiles) {
+      lines.push(`- ${side}/${name}`);
+    }
+  }
+  lines.push('- comparison.json');
+  lines.push('- report.md');
+  lines.push('');
+  return lines.join('\n');
+}
+
+async function writeSide(dir, summary, rawText, stderrText, screen) {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'raw.ansi'), rawText);
+  await writeFile(join(dir, 'stderr.txt'), stderrText);
+  await writeFile(join(dir, 'screen.txt'), screen === '' ? '' : `${screen}\n`);
+  await writeFile(
+    join(dir, 'summary.json'),
+    `${JSON.stringify(summary, null, 2)}\n`,
+  );
+}
+
+async function runSide(scenario, sideName, command, scenarioDir) {
+  const resolved = resolveCommand(command.argv);
+  const cap = await capture(resolved, {
+    rows: scenario.terminal.rows,
+    columns: scenario.terminal.columns,
+    timeoutMs: scenario.timeoutMs,
+    input: scenario.input,
+    env: scenario.env,
+    tty: command.pty,
+  });
+  const metrics = analyzeAnsi(cap.stdoutText);
+  const screen = renderFinalScreen(cap.stdoutText, {
+    rows: scenario.terminal.rows,
+    columns: scenario.terminal.columns,
+  });
+  const evalResult = evaluateSide(metrics, cap, scenario.thresholds);
+  await writeSide(
+    join(scenarioDir, sideName),
+    {
+      scenarioId: scenario.id,
+      side: sideName,
+      command: resolved,
+      capture: {
+        spawned: cap.spawned,
+        spawnError: cap.spawnError,
+        exitCode: cap.exitCode,
+        signal: cap.signal,
+        timedOut: cap.timedOut,
+        timeoutMs: cap.timeoutMs,
+        durationMs: cap.durationMs,
+        stdoutBytes: cap.stdoutBytes,
+        stderrBytes: cap.stderrBytes,
+        tty: cap.tty,
+      },
+      metrics,
+      verdict: evalResult.verdict,
+      reasons: evalResult.reasons,
+    },
+    cap.stdoutText,
+    cap.stderrText,
+    screen,
+  );
+  return { command: resolved, capture: cap, metrics, screen, eval: evalResult };
+}
+
+export async function runScenario(scenario, outDir, overrides = {}) {
+  const scenarioDir = join(outDir, scenario.id);
+  const generatedAt = new Date().toISOString();
+  const wrapOverride = (argv) => (argv ? { argv, pty: 'native' } : undefined);
+  const baseCommand = wrapOverride(overrides.base) ?? scenario.commands.base;
+  const fixedCommand = wrapOverride(overrides.fixed) ?? scenario.commands.fixed;
+  validateFinalParams(scenario, baseCommand, fixedCommand, overrides);
+  const base = await runSide(scenario, 'base', baseCommand, scenarioDir);
+  const fixed = await runSide(scenario, 'fixed', fixedCommand, scenarioDir);
+  const comparison = buildComparison(scenario, base, fixed, generatedAt, {
+    base: Boolean(overrides.base),
+    fixed: Boolean(overrides.fixed),
+  });
+  await writeFile(
+    join(scenarioDir, 'comparison.json'),
+    `${JSON.stringify(comparison, null, 2)}\n`,
+  );
+  await writeFile(join(scenarioDir, 'report.md'), renderReport(comparison));
+  return comparison;
+}
+
+export async function runScenarios({
+  paths,
+  outDir,
+  baseOverride,
+  fixedOverride,
+}) {
+  const errors = [];
+  let entries;
+  try {
+    entries = await loadScenarios(paths);
+  } catch (err) {
+    errors.push(err.message);
+    entries = [];
+  }
+  const results = [];
+  for (const entry of entries) {
+    try {
+      results.push(
+        await runScenario(entry.scenario, outDir, {
+          base: baseOverride,
+          fixed: fixedOverride,
+        }),
+      );
+    } catch (err) {
+      errors.push(`${entry.file}: ${err.message}`);
+    }
+  }
+  const overall =
+    errors.length > 0
+      ? 'error'
+      : results.length > 0 && results.every((c) => c.harnessPass)
+        ? 'pass'
+        : 'fail';
+  await mkdir(outDir, { recursive: true });
+  await writeFile(
+    join(outDir, 'run-summary.json'),
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        overall,
+        errors,
+        scenarios: results.map((c) => ({
+          scenarioId: c.scenarioId,
+          outcome: c.outcome,
+          baseVerdict: c.baseVerdict,
+          fixedVerdict: c.fixedVerdict,
+          proves: c.proves,
+          doesNotProve: c.doesNotProve,
+        })),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return { overall, scenarios: results, errors };
+}
+
+function printUsage() {
+  console.log(
+    [
+      'Usage: node scripts/tui-parity/runner.mjs --scenario <file|dir> [...] --out <dir>',
+      '',
+      'Options:',
+      '  --scenario <path>  Scenario JSON file, or a directory containing',
+      '                     *.scenario.json files. Repeatable.',
+      '  --out <dir>        Artifact output directory.',
+      '  --base <command>   Override the base command (single scenario only).',
+      '  --fixed <command>  Override the fixed command (single scenario only).',
+      '  --help             Show this help.',
+      '',
+      'Commands are captured through a native PTY (the real-CLI contract).',
+      'A scenario may waive the PTY for deterministic fixtures ("pty":',
+      '"fixture") or prove a caller-supplied PTY wrapper via the',
+      'tty-handshake ("pty": "wrapped").',
+      '',
+      'Exit codes: 0 all scenarios pass, 1 threshold/capture failure,',
+      '            2 usage or validation error.',
+    ].join('\n'),
+  );
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const opts = { scenarios: [], out: null, base: null, fixed: null };
+  for (let i = 0; i < args.length; i += 1) {
+    const flag = args[i];
+    if (flag === '--help' || flag === '-h') {
+      printUsage();
+      return 0;
+    }
+    const nextValue = () => {
+      const value = args[++i];
+      if (value === undefined) {
+        throw new Error(`missing value for ${flag}`);
+      }
+      return value;
+    };
+    if (flag === '--scenario') opts.scenarios.push(nextValue());
+    else if (flag === '--out') opts.out = nextValue();
+    else if (flag === '--base') opts.base = splitCommandLine(nextValue());
+    else if (flag === '--fixed') opts.fixed = splitCommandLine(nextValue());
+    else {
+      console.error(`unknown argument: ${flag}`);
+      printUsage();
+      return 2;
+    }
+  }
+  if (opts.scenarios.length === 0 || opts.out === null) {
+    console.error('--scenario and --out are required');
+    printUsage();
+    return 2;
+  }
+  if ((opts.base || opts.fixed) && opts.scenarios.length > 1) {
+    console.error('--base/--fixed overrides apply to a single --scenario only');
+    return 2;
+  }
+  if (opts.base && opts.base.length === 0) {
+    console.error('--base command is empty');
+    return 2;
+  }
+  if (opts.fixed && opts.fixed.length === 0) {
+    console.error('--fixed command is empty');
+    return 2;
+  }
+  const result = await runScenarios({
+    paths: opts.scenarios,
+    outDir: opts.out,
+    baseOverride: opts.base,
+    fixedOverride: opts.fixed,
+  });
+  for (const error of result.errors) console.error(`error: ${error}`);
+  for (const c of result.scenarios) {
+    console.log(
+      `${c.scenarioId}: outcome=${c.outcome} base=${c.baseVerdict} fixed=${c.fixedVerdict}`,
+    );
+  }
+  console.log(`overall: ${result.overall}`);
+  if (result.overall === 'pass') return 0;
+  if (result.overall === 'fail') return 1;
+  return 2;
+}
+
+const isMainEntry =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMainEntry) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 2;
+    },
+  );
+}

--- a/scripts/tui-parity/self-test.mjs
+++ b/scripts/tui-parity/self-test.mjs
@@ -1,0 +1,445 @@
+#!/usr/bin/env node
+// End-to-end self-test of the parity harness against its deterministic
+// fixtures. Runs both the library API and the CLI, and exits non-zero on
+// any failure.
+import { spawn } from 'node:child_process';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { runScenarios } from './runner.mjs';
+import { capture, PTY_REFUSAL } from './lib/capture.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const scenarioPath = join(
+  here,
+  'fixtures',
+  'scenarios',
+  'stream-redraw.scenario.json',
+);
+const launcherPath = join(here, 'fixtures', 'wrappers', 'pty-launcher.mjs');
+const handshakePath = join(here, 'lib', 'tty-handshake.mjs');
+
+let failures = 0;
+function check(name, condition, extra = '') {
+  if (condition) {
+    console.log(`ok - ${name}`);
+  } else {
+    failures += 1;
+    console.error(`FAIL - ${name}${extra === '' ? '' : `: ${extra}`}`);
+  }
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+
+async function fileExists(file) {
+  try {
+    await stat(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function cli(args, cwd) {
+  return new Promise((resolveExit) => {
+    const child = spawn(process.execPath, [join(here, 'runner.mjs'), ...args], {
+      cwd,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('close', (code) => resolveExit({ code, stdout, stderr }));
+  });
+}
+
+async function main() {
+  const work = await mkdtemp(join(tmpdir(), 'tui-parity-selftest-'));
+  try {
+    const outPass = join(work, 'run-pass');
+    const pass = await runScenarios({
+      paths: [scenarioPath],
+      outDir: outPass,
+    });
+    check(
+      'overall pass for committed fixture scenario',
+      pass.overall === 'pass',
+      pass.overall,
+    );
+    const comparison = pass.scenarios[0];
+    check(
+      'outcome is base-fails-fixed-passes',
+      comparison?.outcome === 'base-fails-fixed-passes',
+      comparison?.outcome,
+    );
+    check('base verdict fail', comparison?.baseVerdict === 'fail');
+    check('fixed verdict pass', comparison?.fixedVerdict === 'pass');
+    check(
+      'base full-screen clears detected',
+      (comparison?.deltas.fullScreenClears ?? 0) > 0,
+    );
+    check(
+      'base duplicate events detected',
+      (comparison?.deltas.duplicateEvents ?? 0) > 0,
+    );
+    check(
+      'comparison records the declared comparison parameters',
+      JSON.stringify(comparison?.compareParams) ===
+        JSON.stringify(['--frames']),
+      JSON.stringify(comparison?.compareParams),
+    );
+
+    const sideFiles = ['raw.ansi', 'stderr.txt', 'screen.txt', 'summary.json'];
+    for (const side of ['base', 'fixed']) {
+      for (const name of sideFiles) {
+        check(
+          `artifact ${side}/${name} exists`,
+          await fileExists(join(outPass, 'stream-redraw', side, name)),
+        );
+      }
+    }
+    for (const name of ['comparison.json', 'report.md']) {
+      check(
+        `artifact stream-redraw/${name} exists`,
+        await fileExists(join(outPass, 'stream-redraw', name)),
+      );
+    }
+    check(
+      'artifact run-summary.json exists',
+      await fileExists(join(outPass, 'run-summary.json')),
+    );
+
+    const comparisonFile = await readJson(
+      join(outPass, 'stream-redraw', 'comparison.json'),
+    );
+    check(
+      'comparison states what the scenario proves',
+      typeof comparisonFile.proves === 'string' &&
+        comparisonFile.proves.length > 0,
+    );
+    check(
+      'comparison states what the scenario does not prove',
+      typeof comparisonFile.doesNotProve === 'string' &&
+        comparisonFile.doesNotProve.length > 0,
+    );
+    const baseSummary = await readJson(
+      join(outPass, 'stream-redraw', 'base', 'summary.json'),
+    );
+    check(
+      'base side metrics recorded',
+      baseSummary.metrics.fullScreenClears.total >= 3,
+    );
+    check(
+      'fixture capture records its waived TTY mode',
+      baseSummary.capture.tty?.mode === 'fixture' &&
+        baseSummary.capture.tty?.allocated === false,
+      JSON.stringify(baseSummary.capture.tty),
+    );
+    const fixedScreen = await readFile(
+      join(outPass, 'stream-redraw', 'fixed', 'screen.txt'),
+      'utf8',
+    );
+    check(
+      'fixed final screen shows last frame',
+      fixedScreen.includes('frame=3'),
+    );
+
+    const outDeterminism = join(work, 'run-determinism');
+    await runScenarios({ paths: [scenarioPath], outDir: outDeterminism });
+    for (const side of ['base', 'fixed']) {
+      const first = await readFile(
+        join(outPass, 'stream-redraw', side, 'raw.ansi'),
+      );
+      const second = await readFile(
+        join(outDeterminism, 'stream-redraw', side, 'raw.ansi'),
+      );
+      check(`deterministic ${side} capture`, first.equals(second));
+    }
+
+    const nativeProbe =
+      'process.stdout.write(JSON.stringify({isTTY: process.stdout.isTTY, ' +
+      'rows: process.stdout.rows}))';
+    const nativeCap = await capture([process.execPath, '-e', nativeProbe], {
+      rows: 8,
+      columns: 24,
+      timeoutMs: 8000,
+      tty: 'native',
+    });
+    check('native PTY capture allocates a real TTY', nativeCap.tty.allocated);
+    check(
+      'child under native capture sees isTTY=true with scenario rows',
+      /"isTTY":true/.test(nativeCap.stdoutText) &&
+        /"rows":8/.test(nativeCap.stdoutText),
+      nativeCap.stdoutText,
+    );
+
+    process.env.TUI_PARITY_NO_PTY = '1';
+    let refusedCap;
+    try {
+      refusedCap = await capture([process.execPath, '-e', nativeProbe], {
+        rows: 8,
+        columns: 24,
+        timeoutMs: 2000,
+        tty: 'native',
+      });
+    } finally {
+      delete process.env.TUI_PARITY_NO_PTY;
+    }
+    check(
+      'native capture is refused without a PTY backend',
+      refusedCap.spawned === false && refusedCap.spawnError === PTY_REFUSAL,
+      refusedCap.spawnError,
+    );
+
+    const wrappedCap = await capture(
+      [
+        process.execPath,
+        launcherPath,
+        process.execPath,
+        handshakePath,
+        process.execPath,
+        '-e',
+        "process.stdout.write('wrapped-' + process.stdout.isTTY + '\\n')",
+      ],
+      { rows: 8, columns: 24, timeoutMs: 15000, tty: 'wrapped' },
+    );
+    check(
+      'wrapped capture verifies the PTY handshake inside a real PTY',
+      wrappedCap.tty.handshake === 'verified' &&
+        /wrapped-true/.test(wrappedCap.stdoutText),
+      JSON.stringify({
+        handshake: wrappedCap.tty.handshake,
+        stdout: wrappedCap.stdoutText.slice(0, 120),
+      }),
+    );
+
+    const divergedFixture = await readJson(scenarioPath);
+    divergedFixture.id = 'fixed-violates';
+    divergedFixture.commands.fixed = {
+      ...divergedFixture.commands.fixed,
+      argv: [...divergedFixture.commands.fixed.argv, '--clears-per-frame', '2'],
+    };
+    const violatesPath = join(work, 'fixed-violates.scenario.json');
+    await writeFile(violatesPath, JSON.stringify(divergedFixture, null, 2));
+    const violates = await runScenarios({
+      paths: [violatesPath],
+      outDir: join(work, 'run-fixed-violates'),
+    });
+    check(
+      'overall fail when fixed exceeds thresholds',
+      violates.overall === 'fail',
+      violates.overall,
+    );
+    check(
+      'outcome is fixed-fails',
+      violates.scenarios[0]?.outcome === 'fixed-fails',
+      violates.scenarios[0]?.outcome,
+    );
+
+    const divergedParams = await readJson(scenarioPath);
+    divergedParams.id = 'diverged-params';
+    divergedParams.commands.base = {
+      ...divergedParams.commands.base,
+      env: { FORCE_COLOR: '0' },
+    };
+    const divergedPath = join(work, 'diverged-params.scenario.json');
+    await writeFile(divergedPath, JSON.stringify(divergedParams, null, 2));
+    const diverged = await runScenarios({
+      paths: [divergedPath],
+      outDir: join(work, 'run-diverged-params'),
+    });
+    check(
+      'divergent per-side parameters are an error',
+      diverged.overall === 'error',
+      diverged.overall,
+    );
+    check(
+      'error names the shared-parameter contract',
+      diverged.errors.join(' ').includes('share'),
+      diverged.errors.join(' '),
+    );
+
+    const divergedRows = await readJson(scenarioPath);
+    divergedRows.id = 'diverged-rows';
+    divergedRows.compareParams = ['--frames', '--rows'];
+    divergedRows.commands.base = {
+      ...divergedRows.commands.base,
+      argv: [...divergedRows.commands.base.argv, '--rows', '12'],
+    };
+    divergedRows.commands.fixed = {
+      ...divergedRows.commands.fixed,
+      argv: [...divergedRows.commands.fixed.argv, '--rows', '99'],
+    };
+    const divergedRowsPath = join(work, 'diverged-rows.scenario.json');
+    await writeFile(divergedRowsPath, JSON.stringify(divergedRows, null, 2));
+    const divergedRowsRun = await runScenarios({
+      paths: [divergedRowsPath],
+      outDir: join(work, 'run-diverged-rows'),
+    });
+    check(
+      'divergent --rows comparison parameters are an error',
+      divergedRowsRun.overall === 'error',
+      divergedRowsRun.overall,
+    );
+    check(
+      'error names the differing rows values',
+      divergedRowsRun.errors.join(' ').includes('"--rows" differs'),
+      divergedRowsRun.errors.join(' '),
+    );
+
+    check(
+      'cli exits 0 for the passing fixture scenario',
+      (
+        await cli(
+          ['--scenario', scenarioPath, '--out', join(work, 'cli-pass')],
+          repoRoot,
+        )
+      ).code === 0,
+    );
+    check(
+      'cli exits 1 when fixed exceeds thresholds',
+      (
+        await cli(
+          ['--scenario', violatesPath, '--out', join(work, 'cli-fail')],
+          repoRoot,
+        )
+      ).code === 1,
+    );
+    check(
+      'cli exits 2 for missing arguments',
+      (await cli(['--scenario', scenarioPath], repoRoot)).code === 2,
+    );
+    const overridesDir = join(work, 'cli-overrides');
+    await mkdir(overridesDir, { recursive: true });
+    const emitterCmd = (flags) =>
+      `"${process.execPath}" ` +
+      `scripts/tui-parity/fixtures/emitters/tui-emitter.mjs ${flags}`;
+    const overrideCode = await cli(
+      [
+        '--scenario',
+        scenarioPath,
+        '--out',
+        overridesDir,
+        '--base',
+        emitterCmd('--frames 1 --sync'),
+        '--fixed',
+        emitterCmd('--frames 1 --sync'),
+      ],
+      repoRoot,
+    );
+    const overrideSummary = await readJson(
+      join(overridesDir, 'run-summary.json'),
+    );
+    check(
+      'cli command overrides run through native PTY capture',
+      overrideCode.code === 0,
+    );
+    check(
+      'cli override outcome is both-pass',
+      overrideSummary.scenarios[0]?.outcome === 'both-pass',
+      JSON.stringify(overrideSummary.scenarios),
+    );
+    const overrideBaseSummary = await readJson(
+      join(overridesDir, 'stream-redraw', 'base', 'summary.json'),
+    );
+    check(
+      'cli override capture records native PTY evidence',
+      overrideBaseSummary.capture.tty?.mode === 'native' &&
+        overrideBaseSummary.capture.tty?.allocated === true,
+      JSON.stringify(overrideBaseSummary.capture.tty),
+    );
+
+    // Adversarial counterexample: scenario validation saw equal compareParams,
+    // but the overrides diverge. The final resolved argv must be re-validated
+    // after overrides, so the run must abort before anything is captured.
+    const divergentOverride = await cli(
+      [
+        '--scenario',
+        scenarioPath,
+        '--out',
+        join(work, 'cli-override-divergent'),
+        '--base',
+        emitterCmd('--frames 1 --sync'),
+        '--fixed',
+        emitterCmd('--frames 4 --sync'),
+      ],
+      repoRoot,
+    );
+    check(
+      'cli override diverging from compareParams exits 2',
+      divergentOverride.code === 2,
+      `code=${divergentOverride.code} stderr=${divergentOverride.stderr}`,
+    );
+    check(
+      'cli override mismatch names parameter binding on the final argv',
+      divergentOverride.stderr.includes('parameter binding') &&
+        divergentOverride.stderr.includes('"--frames" differs'),
+      divergentOverride.stderr,
+    );
+    check(
+      'cli override mismatch runs nothing',
+      !(await fileExists(
+        join(
+          work,
+          'cli-override-divergent',
+          'stream-redraw',
+          'base',
+          'raw.ansi',
+        ),
+      )),
+    );
+
+    const dimensionOverride = await cli(
+      [
+        '--scenario',
+        scenarioPath,
+        '--out',
+        join(work, 'cli-override-dimension'),
+        '--base',
+        emitterCmd('--frames 3 --sync --rows 99'),
+      ],
+      repoRoot,
+    );
+    check(
+      'cli override with a mismatched terminal-size flag exits 2',
+      dimensionOverride.code === 2,
+      `code=${dimensionOverride.code} stderr=${dimensionOverride.stderr}`,
+    );
+    check(
+      'cli override dimension mismatch names the capture geometry',
+      dimensionOverride.stderr.includes('"--rows" value "99"') &&
+        dimensionOverride.stderr.includes('terminal.rows'),
+      dimensionOverride.stderr,
+    );
+  } finally {
+    await rm(work, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.error(`self-test: ${failures} check(s) failed`);
+    process.exitCode = 1;
+  } else {
+    console.log('self-test: all checks passed');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/scripts/tui-parity/test/ansi-metrics.test.mjs
+++ b/scripts/tui-parity/test/ansi-metrics.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { analyzeAnsi } from '../lib/ansi-metrics.mjs';
+
+const ESC = '\x1b';
+
+test('counts full-screen clear opcodes', () => {
+  const m = analyzeAnsi(`${ESC}[2J${ESC}[3J${ESC}[3J${ESC}c${ESC}[J${ESC}[1J`);
+  assert.equal(m.fullScreenClears.csi2J, 1);
+  assert.equal(m.fullScreenClears.csi3J, 2);
+  assert.equal(m.fullScreenClears.ris, 1);
+  assert.equal(m.fullScreenClears.total, 4);
+  assert.equal(m.partialScreenErases, 2);
+});
+
+test('counts line erase modes', () => {
+  const m = analyzeAnsi(`${ESC}[K${ESC}[0K${ESC}[1K${ESC}[2K`);
+  assert.equal(m.lineErases.toEnd, 2);
+  assert.equal(m.lineErases.toStart, 1);
+  assert.equal(m.lineErases.whole, 1);
+  assert.equal(m.lineErases.total, 4);
+});
+
+test('tracks balanced DEC 2026 pairs', () => {
+  const m = analyzeAnsi(
+    `${ESC}[?2026hframe${ESC}[?2026l${ESC}[?2026hframe${ESC}[?2026l`,
+  );
+  assert.equal(m.dec2026.begin, 2);
+  assert.equal(m.dec2026.end, 2);
+  assert.equal(m.dec2026.unbalanced, 0);
+});
+
+test('tracks unbalanced DEC 2026 pairs', () => {
+  const unclosed = analyzeAnsi(`${ESC}[?2026hframe`);
+  assert.equal(unclosed.dec2026.unbalanced, 1);
+  const strayEnd = analyzeAnsi(`${ESC}[?2026lframe`);
+  assert.equal(strayEnd.dec2026.unbalanced, 1);
+  const endThenBegin = analyzeAnsi(`${ESC}[?2026l${ESC}[?2026h`);
+  assert.equal(endThenBegin.dec2026.unbalanced, 2);
+});
+
+test('counts duplicate event markers', () => {
+  const raw =
+    `${ESC}]697;live-line;1\x07` +
+    `${ESC}]697;live-line;2\x07` +
+    `${ESC}]697;live-line;1\x07` +
+    `${ESC}]697;live-line;2\x07`;
+  const m = analyzeAnsi(raw);
+  assert.equal(m.events.total, 4);
+  assert.equal(m.events.unique, 2);
+  assert.equal(m.events.duplicates, 2);
+  assert.equal(m.events.markersPresent, true);
+});
+
+test('reports absent event markers', () => {
+  const m = analyzeAnsi('hello world');
+  assert.equal(m.events.markersPresent, false);
+  assert.equal(m.events.duplicates, 0);
+});
+
+test('accepts OSC terminated by ESC backslash', () => {
+  const m = analyzeAnsi(`${ESC}]697;tok;9${ESC}\\tail`);
+  assert.equal(m.events.total, 1);
+  assert.equal(m.events.unique, 1);
+  assert.equal(m.printableChars, 4);
+});
+
+test('accounts control and printable characters', () => {
+  const m = analyzeAnsi('ab\r\nc\x07\td\b');
+  assert.equal(m.printableChars, 4);
+  assert.equal(m.controlChars.cr, 1);
+  assert.equal(m.controlChars.lf, 1);
+  assert.equal(m.controlChars.bel, 1);
+  assert.equal(m.controlChars.tab, 1);
+  assert.equal(m.controlChars.bs, 1);
+});
+
+test('counts cursor moves and SGR sequences', () => {
+  const m = analyzeAnsi(`${ESC}[1;1H${ESC}[12;40H${ESC}[31m${ESC}[0m`);
+  assert.equal(m.cursorMoves, 2);
+  assert.equal(m.sgrChanges, 2);
+});

--- a/scripts/tui-parity/test/index.mjs
+++ b/scripts/tui-parity/test/index.mjs
@@ -1,0 +1,3 @@
+import './ansi-metrics.test.mjs';
+import './normalize.test.mjs';
+import './runner.test.mjs';

--- a/scripts/tui-parity/test/normalize.test.mjs
+++ b/scripts/tui-parity/test/normalize.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { renderFinalScreen } from '../lib/normalize.mjs';
+
+const ESC = '\x1b';
+const screen = { rows: 4, columns: 12 };
+
+test('renders plain text', () => {
+  assert.equal(renderFinalScreen('hello', screen), 'hello');
+});
+
+test('handles CR/LF line structure', () => {
+  assert.equal(renderFinalScreen('abc\r\ndef', screen), 'abc\ndef');
+});
+
+test('applies cursor addressing', () => {
+  assert.equal(renderFinalScreen(`abc${ESC}[2;1HXY`, screen), 'abc\nXY');
+});
+
+test('clears the screen with ESC[2J', () => {
+  assert.equal(
+    renderFinalScreen(`frame-1${ESC}[2J${ESC}[Hframe-2`, screen),
+    'frame-2',
+  );
+});
+
+test('line erase removes trailing cells', () => {
+  assert.equal(renderFinalScreen(`abcdefgh${ESC}[1;3H${ESC}[K`, screen), 'ab');
+});
+
+test('scrolls when linefeeding at the bottom row', () => {
+  assert.equal(
+    renderFinalScreen('a\r\nb\r\nc\r\nd\r\ne', screen),
+    'b\nc\nd\ne',
+  );
+});
+
+test('alternate screen restores the main buffer', () => {
+  const raw = `main${ESC}[?1049halt-screen${ESC}[?1049l`;
+  assert.equal(renderFinalScreen(raw, screen), 'main');
+});
+
+test('strips trailing blanks and blank lines', () => {
+  assert.equal(
+    renderFinalScreen(`abc${ESC}[2;5H   ${ESC}[3;1H   `, screen),
+    'abc',
+  );
+});
+
+test('linefeed keeps the column, CR resets it', () => {
+  assert.equal(renderFinalScreen('x\ny\rz', screen), 'x\nzy');
+});
+
+test('inserts and deletes lines', () => {
+  assert.equal(
+    renderFinalScreen(`a\r\nb\r\nc${ESC}[1;1H${ESC}[M`, screen),
+    'b\nc',
+  );
+  assert.equal(
+    renderFinalScreen(`a\r\nb\r\nc${ESC}[1;1H${ESC}[LX`, screen),
+    'X\na\nb\nc',
+  );
+});
+
+test('SGR colon sub-parameters are consumed, not printed', () => {
+  const raw = `${ESC}[38:2::255:0:0mred${ESC}[0m`;
+  assert.equal(renderFinalScreen(raw, screen), 'red');
+});
+
+test('charset designation consumes the final byte', () => {
+  assert.equal(renderFinalScreen(`${ESC}(Bok`, screen), 'ok');
+});
+
+test('string sequence payloads stay out of the grid', () => {
+  for (const finalByte of ['P', 'X', '^', '_']) {
+    const raw = `${ESC}${finalByte}payload${ESC}\\ok`;
+    assert.equal(renderFinalScreen(raw, screen), 'ok', `ESC ${finalByte}`);
+  }
+});

--- a/scripts/tui-parity/test/package.json
+++ b/scripts/tui-parity/test/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "index.mjs"
+}

--- a/scripts/tui-parity/test/runner.test.mjs
+++ b/scripts/tui-parity/test/runner.test.mjs
@@ -1,0 +1,936 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import {
+  runScenario,
+  runScenarios,
+  splitCommandLine,
+  evaluateSide,
+  validateFinalParams,
+} from '../runner.mjs';
+import { extractFlagValues, validateScenario } from '../lib/scenario.mjs';
+import { capture, PTY_REFUSAL } from '../lib/capture.mjs';
+import { analyzeAnsi } from '../lib/ansi-metrics.mjs';
+
+const EMITTER = [
+  'node',
+  'scripts/tui-parity/fixtures/emitters/tui-emitter.mjs',
+];
+const EMITTER_PATH = fileURLToPath(
+  new URL('../fixtures/emitters/tui-emitter.mjs', import.meta.url),
+);
+const HANDSHAKE_PATH = fileURLToPath(
+  new URL('../lib/tty-handshake.mjs', import.meta.url),
+);
+const PTY_LAUNCHER_PATH = fileURLToPath(
+  new URL('../fixtures/wrappers/pty-launcher.mjs', import.meta.url),
+);
+
+const fixtureCommand = (...flags) => ({
+  argv: [...EMITTER, ...flags],
+  pty: 'fixture',
+});
+
+function scenarioFixture(overrides = {}) {
+  return {
+    id: 'synthetic',
+    description: 'synthetic test scenario',
+    terminal: { rows: 6, columns: 30 },
+    timeoutMs: 5000,
+    commands: {
+      base: fixtureCommand('--frames', '2', '--clears-per-frame', '1'),
+      fixed: fixtureCommand('--frames', '2', '--sync'),
+    },
+    thresholds: {
+      maxFullScreenClears: 0,
+      maxDuplicateEvents: 0,
+      requireSync: true,
+      requireEventMarkers: true,
+    },
+    proves: 'synthetic statement of what this proves',
+    doesNotProve: 'synthetic statement of what this does not prove',
+    ...overrides,
+  };
+}
+
+async function withWorkdir(fn) {
+  const work = await mkdtemp(join(tmpdir(), 'tui-parity-test-'));
+  try {
+    await fn(work);
+  } finally {
+    await rm(work, { recursive: true, force: true });
+  }
+}
+
+async function writeScenario(work, scenario) {
+  const file = join(work, `${scenario.id}.scenario.json`);
+  await writeFile(file, JSON.stringify(scenario, null, 2));
+  return file;
+}
+
+test('base fails and fixed passes under shared parameters', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = validateScenario(scenarioFixture());
+    const comparison = await runScenario(scenario, work);
+    assert.equal(comparison.outcome, 'base-fails-fixed-passes');
+    assert.equal(comparison.harnessPass, true);
+    assert.equal(comparison.baseVerdict, 'fail');
+    assert.equal(comparison.fixedVerdict, 'pass');
+    assert.ok(comparison.deltas.fullScreenClears > 0);
+    assert.equal(comparison.compareParams.length, 0);
+    const raw = await readFile(
+      join(work, 'synthetic', 'base', 'raw.ansi'),
+      'utf8',
+    );
+    // eslint-disable-next-line no-control-regex
+    assert.match(raw, /\x1b\[2J/);
+    const comparisonFile = JSON.parse(
+      await readFile(join(work, 'synthetic', 'comparison.json'), 'utf8'),
+    );
+    assert.equal(comparisonFile.outcome, 'base-fails-fixed-passes');
+    assert.equal(comparisonFile.sides.base.capture.tty.mode, 'fixture');
+  });
+});
+
+test('capture timeout is a capture error and fails the harness', async () => {
+  await withWorkdir(async (work) => {
+    const file = await writeScenario(
+      work,
+      scenarioFixture({
+        id: 'hangs',
+        timeoutMs: 300,
+        commands: {
+          base: fixtureCommand('--frames', '1', '--sync'),
+          fixed: fixtureCommand('--frames', '1', '--sync', '--hang-ms', '4000'),
+        },
+      }),
+    );
+    const result = await runScenarios({
+      paths: [file],
+      outDir: join(work, 'out-api'),
+    });
+    assert.equal(result.overall, 'fail');
+    assert.equal(result.scenarios[0].outcome, 'capture-error');
+    assert.equal(result.scenarios[0].sides.fixed.capture.timedOut, true);
+  });
+});
+
+test('non-zero fixed exit code fails the fixed side', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = validateScenario(
+      scenarioFixture({
+        id: 'bad-exit',
+        commands: {
+          base: fixtureCommand('--frames', '1', '--sync'),
+          fixed: fixtureCommand('--frames', '1', '--sync', '--exit-code', '3'),
+        },
+      }),
+    );
+    const comparison = await runScenario(scenario, join(work, 'out'));
+    assert.equal(comparison.outcome, 'fixed-fails');
+    assert.equal(comparison.harnessPass, false);
+    assert.ok(
+      comparison.sides.fixed.reasons.some((reason) =>
+        reason.includes('exit code 3'),
+      ),
+    );
+  });
+});
+
+test('runScenarios fails when fixed exceeds thresholds', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = scenarioFixture({
+      id: 'fixed-violates',
+      commands: {
+        base: fixtureCommand('--frames', '1', '--sync'),
+        fixed: fixtureCommand(
+          '--frames',
+          '1',
+          '--sync',
+          '--clears-per-frame',
+          '2',
+        ),
+      },
+    });
+    const file = await writeScenario(work, scenario);
+    const result = await runScenarios({
+      paths: [file],
+      outDir: join(work, 'out'),
+    });
+    assert.equal(result.overall, 'fail');
+    assert.equal(result.scenarios[0].outcome, 'fixed-fails');
+  });
+});
+
+test('runScenarios reports validation errors without running', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = scenarioFixture({ id: 'divergent' });
+    scenario.commands.base = {
+      ...scenario.commands.base,
+      env: { TERM: 'dumb' },
+    };
+    const file = await writeScenario(work, scenario);
+    const result = await runScenarios({
+      paths: [file],
+      outDir: join(work, 'out'),
+    });
+    assert.equal(result.overall, 'error');
+    assert.ok(result.errors.join(' ').includes('share'));
+    assert.equal(result.scenarios.length, 0);
+  });
+});
+
+test('runScenarios rejects divergent comparison parameters', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = scenarioFixture({
+      id: 'divergent-params',
+      compareParams: ['--rows'],
+      commands: {
+        base: fixtureCommand('--frames', '1', '--sync', '--rows', '6'),
+        fixed: fixtureCommand('--frames', '1', '--sync', '--rows', '99'),
+      },
+    });
+    const file = await writeScenario(work, scenario);
+    const result = await runScenarios({
+      paths: [file],
+      outDir: join(work, 'out'),
+    });
+    assert.equal(result.overall, 'error');
+    assert.match(
+      result.errors.join(' '),
+      /compareParams: "--rows" differs between base \(6\) and fixed \(99\)/,
+    );
+    assert.equal(result.scenarios.length, 0);
+  });
+});
+
+test('native TTY command is refused when no PTY backend exists', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = scenarioFixture({
+      id: 'no-pty',
+      timeoutMs: 3000,
+      commands: {
+        base: ['node', '-e', 'process.exit(0)'],
+        fixed: fixtureCommand('--frames', '1', '--sync'),
+      },
+    });
+    process.env.TUI_PARITY_NO_PTY = '1';
+    try {
+      const comparison = await runScenario(
+        validateScenario(scenario),
+        join(work, 'out'),
+      );
+      assert.equal(comparison.outcome, 'capture-error');
+      assert.equal(comparison.harnessPass, false);
+      assert.equal(comparison.sides.base.capture.spawned, false);
+      assert.match(
+        comparison.sides.base.capture.spawnError,
+        /native TTY capture refused/,
+      );
+      assert.equal(comparison.sides.base.capture.tty.allocated, false);
+      assert.equal(comparison.sides.fixed.verdict, 'pass');
+    } finally {
+      delete process.env.TUI_PARITY_NO_PTY;
+    }
+  });
+});
+
+test('captures are deterministic across runs', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = validateScenario(scenarioFixture({ id: 'determinism' }));
+    const first = await runScenario(scenario, join(work, 'one'));
+    const second = await runScenario(scenario, join(work, 'two'));
+    assert.equal(first.outcome, 'base-fails-fixed-passes');
+    assert.equal(second.outcome, 'base-fails-fixed-passes');
+    for (const side of ['base', 'fixed']) {
+      const a = await readFile(
+        join(work, 'one', 'determinism', side, 'raw.ansi'),
+      );
+      const b = await readFile(
+        join(work, 'two', 'determinism', side, 'raw.ansi'),
+      );
+      assert.ok(a.equals(b), `${side} capture differs between runs`);
+    }
+  });
+});
+
+test('spawn errors are reported as capture errors', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = validateScenario(
+      scenarioFixture({
+        id: 'no-binary',
+        commands: {
+          base: { argv: ['tui-parity-no-such-binary'], pty: 'fixture' },
+          fixed: fixtureCommand('--frames', '1', '--sync'),
+        },
+      }),
+    );
+    const comparison = await runScenario(scenario, join(work, 'out'));
+    assert.equal(comparison.outcome, 'capture-error');
+    assert.equal(comparison.sides.base.capture.spawned, false);
+    assert.ok(comparison.sides.base.capture.spawnError);
+  });
+});
+
+test('splitCommandLine handles quotes and escapes', () => {
+  assert.deepEqual(splitCommandLine('node a.mjs --x "two words"'), [
+    'node',
+    'a.mjs',
+    '--x',
+    'two words',
+  ]);
+  assert.deepEqual(splitCommandLine("node 'single quoted' \\space"), [
+    'node',
+    'single quoted',
+    'space',
+  ]);
+  assert.deepEqual(splitCommandLine('  node   a.mjs  '), ['node', 'a.mjs']);
+});
+
+test('native capture allocates a real PTY with TTY evidence', async () => {
+  const probe =
+    'process.stdout.write(JSON.stringify({isTTY: process.stdout.isTTY, ' +
+    'rows: process.stdout.rows, cols: process.stdout.columns}))';
+  const cap = await capture([process.execPath, '-e', probe], {
+    rows: 12,
+    columns: 40,
+    timeoutMs: 8000,
+    tty: 'native',
+  });
+  assert.equal(cap.spawned, true, cap.spawnError);
+  assert.deepEqual(cap.tty, {
+    mode: 'native',
+    backend: 'node-pty',
+    allocated: true,
+    rows: 12,
+    columns: 40,
+    handshake: null,
+  });
+  const evidence = JSON.parse(cap.stdoutText.trim());
+  assert.equal(evidence.isTTY, true, 'child must see a real TTY');
+  assert.equal(evidence.rows, 12);
+  assert.equal(evidence.cols, 40);
+  assert.equal(cap.exitCode, 0);
+  assert.equal(cap.timedOut, false);
+});
+
+test('native capture is refused without a PTY backend', async () => {
+  process.env.TUI_PARITY_NO_PTY = '1';
+  try {
+    const cap = await capture([process.execPath, '-e', 'process.exit(0)'], {
+      rows: 4,
+      columns: 20,
+      timeoutMs: 2000,
+      tty: 'native',
+    });
+    assert.equal(cap.spawned, false);
+    assert.equal(cap.tty.allocated, false);
+    assert.equal(cap.spawnError, PTY_REFUSAL);
+    assert.match(cap.spawnError, /native TTY capture refused/);
+  } finally {
+    delete process.env.TUI_PARITY_NO_PTY;
+  }
+});
+
+test('wrapped capture verifies the PTY handshake marker', async () => {
+  const cap = await capture(
+    [
+      process.execPath,
+      PTY_LAUNCHER_PATH,
+      process.execPath,
+      HANDSHAKE_PATH,
+      process.execPath,
+      '-e',
+      "process.stdout.write('wrapped-' + process.stdout.isTTY + '\\n')",
+    ],
+    { rows: 8, columns: 24, timeoutMs: 15000, tty: 'wrapped' },
+  );
+  assert.equal(
+    cap.tty.handshake,
+    'verified',
+    JSON.stringify({
+      handshake: cap.tty.handshake,
+      exitCode: cap.exitCode,
+      stderr: cap.stderrText.slice(0, 200),
+      stdout: cap.stdoutText.slice(0, 200),
+    }),
+  );
+  assert.match(cap.stdoutText, /wrapped-true/);
+  assert.equal(cap.exitCode, 0);
+});
+
+test('wrapped capture without a real PTY fails the handshake', async () => {
+  const cap = await capture(
+    [
+      process.execPath,
+      HANDSHAKE_PATH,
+      process.execPath,
+      '-e',
+      "process.stdout.write('no-tty\\n')",
+    ],
+    { rows: 4, columns: 20, timeoutMs: 5000, tty: 'wrapped' },
+  );
+  assert.equal(cap.tty.handshake, 'missing');
+  assert.notEqual(cap.exitCode, 0);
+  const evalResult = evaluateSide(analyzeAnsi(cap.stdoutText), cap, {});
+  assert.equal(evalResult.verdict, 'fail');
+  assert.ok(
+    evalResult.reasons.some((reason) => reason.includes('handshake')),
+    evalResult.reasons.join('; '),
+  );
+});
+
+test('timeout clears pending input timers and stays bounded', async () => {
+  const baselineTimeouts = process
+    .getActiveResourcesInfo()
+    .filter((resource) => resource === 'Timeout').length;
+  const started = Date.now();
+  const cap = await capture(
+    [process.execPath, EMITTER_PATH, '--hang-ms', '30000'],
+    {
+      rows: 6,
+      columns: 30,
+      timeoutMs: 300,
+      input: [{ data: 'x', delayMs: 5000 }],
+      tty: 'fixture',
+    },
+  );
+  assert.equal(cap.timedOut, true);
+  assert.ok(
+    cap.durationMs < 3000,
+    `capture lingered ${cap.durationMs}ms; input timer may be holding it`,
+  );
+  assert.ok(Date.now() - started < 3000);
+  await new Promise((resolve) => setImmediate(resolve));
+  const leaked = process
+    .getActiveResourcesInfo()
+    .filter((resource) => resource === 'Timeout').length;
+  assert.ok(
+    leaked <= baselineTimeouts,
+    `leaked ${leaked - baselineTimeouts} pending timer(s): ` +
+      process.getActiveResourcesInfo().join(', '),
+  );
+});
+
+test('timeout kill reaches child process trees', async () => {
+  const cap = await capture([process.execPath, EMITTER_PATH, '--tree-hang'], {
+    rows: 4,
+    columns: 30,
+    timeoutMs: 2000,
+    tty: 'fixture',
+  });
+  assert.equal(cap.timedOut, true);
+  const match = /GRANDCHILD=(\d+)/.exec(cap.stdoutText);
+  assert.ok(match, `no grandchild pid in capture: ${cap.stdoutText}`);
+  const grandchildPid = Number(match[1]);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  let alive = true;
+  try {
+    process.kill(grandchildPid, 0);
+  } catch {
+    alive = false;
+  }
+  assert.equal(alive, false, `grandchild ${grandchildPid} survived the kill`);
+});
+
+test('timeout kill reaches process trees under native PTY capture', async () => {
+  const cap = await capture([process.execPath, EMITTER_PATH, '--tree-hang'], {
+    rows: 4,
+    columns: 30,
+    timeoutMs: 2000,
+    tty: 'native',
+  });
+  assert.equal(cap.timedOut, true);
+  const match = /GRANDCHILD=(\d+)/.exec(cap.stdoutText);
+  assert.ok(match, `no grandchild pid in capture: ${cap.stdoutText}`);
+  const grandchildPid = Number(match[1]);
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  let alive = true;
+  try {
+    process.kill(grandchildPid, 0);
+  } catch {
+    alive = false;
+  }
+  assert.equal(alive, false, `grandchild ${grandchildPid} survived the kill`);
+});
+
+// Adversarial counterexample: the main child closes under SIGTERM, which used
+// to cancel the pending SIGKILL escalation. A descendant that ignores SIGTERM
+// and detaches stdio then survived the capture.
+async function expectStubbornDescendantReaped(tty) {
+  const cap = await capture(
+    [process.execPath, EMITTER_PATH, '--stubborn-hang'],
+    {
+      rows: 4,
+      columns: 30,
+      // Generous so slow parallel test-file startups cannot race the
+      // fixture's first write; the escalation behavior itself is unaffected.
+      timeoutMs: 3000,
+      tty,
+    },
+  );
+  assert.equal(cap.timedOut, true);
+  const match = /STUBBORN=(\d+)/.exec(cap.stdoutText);
+  assert.ok(match, `no stubborn pid in capture: ${cap.stdoutText}`);
+  const stubbornPid = Number(match[1]);
+  const deadline = Date.now() + 5000;
+  let alive = true;
+  while (alive && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    try {
+      process.kill(stubbornPid, 0);
+    } catch {
+      alive = false;
+    }
+  }
+  assert.equal(
+    alive,
+    false,
+    `stubborn descendant ${stubbornPid} survived: SIGKILL escalation was ` +
+      'cancelled when the main child closed',
+  );
+}
+
+test('timeout SIGKILL escalation survives the main child closing (fixture)', async () => {
+  await expectStubbornDescendantReaped('fixture');
+});
+
+test('timeout SIGKILL escalation survives the main child closing (native PTY)', async () => {
+  await expectStubbornDescendantReaped('native');
+});
+
+test('scripted input is delivered to a fixture capture', async () => {
+  // Echo per byte so the assertion does not depend on how the pipe chunks
+  // the two writes together when the child starts slowly.
+  const echoCode =
+    "let buf='';process.stdin.on('data',(c)=>{const s=c.toString();buf+=s;" +
+    "for(const ch of s)process.stdout.write('ECHO<'+ch+'>');});" +
+    "process.stdin.on('end',()=>process.stdout.write('DONE<'+buf+'>'));";
+  const cap = await capture([process.execPath, '-e', echoCode], {
+    rows: 6,
+    columns: 30,
+    timeoutMs: 8000,
+    tty: 'fixture',
+    input: [
+      { data: 'hello', delayMs: 50 },
+      { data: 'Q', delayMs: 300 },
+    ],
+  });
+  assert.equal(cap.timedOut, false);
+  assert.equal(cap.exitCode, 0, cap.spawnError ?? cap.stdoutText);
+  assert.ok(
+    cap.stdoutText.indexOf('ECHO<h>') !== -1 &&
+      cap.stdoutText.indexOf('ECHO<Q>') > cap.stdoutText.indexOf('ECHO<h>'),
+    `input steps arrived out of order or missing: ${cap.stdoutText}`,
+  );
+  assert.match(cap.stdoutText, /DONE<helloQ>/);
+});
+
+test('scripted input is delivered through a native PTY', async () => {
+  const echoCode =
+    "let buf='';process.stdin.on('data',(c)=>{buf+=c.toString();" +
+    "process.stdout.write('ECHO<'+c.toString().trim()+'>');" +
+    "if(buf.includes('Q'))setTimeout(()=>process.exit(0),100);});";
+  const cap = await capture([process.execPath, '-e', echoCode], {
+    rows: 6,
+    columns: 30,
+    timeoutMs: 8000,
+    tty: 'native',
+    input: [
+      { data: 'hello\r', delayMs: 100 },
+      { data: 'Q\r', delayMs: 100 },
+    ],
+  });
+  assert.equal(cap.spawned, true, cap.spawnError);
+  assert.equal(cap.timedOut, false);
+  assert.equal(cap.exitCode, 0);
+  assert.equal(cap.tty.allocated, true);
+  assert.match(cap.stdoutText, /ECHO<hello>/);
+  assert.match(cap.stdoutText, /ECHO<Q>/);
+});
+
+test('requireSync measures event-to-sync coverage, not begin counts', () => {
+  const cap = { spawned: true, timedOut: false, exitCode: 0 };
+  const B = '\x1b[?2026h';
+  const E = '\x1b[?2026l';
+  const marker = (seq) => `\x1b]697;live-line;${seq}\x07`;
+
+  // Adversarial counterexample: three empty begin/end pairs balance the
+  // stream and match the unique event count, but no marker is inside any
+  // interval. This used to pass the begin-count heuristic.
+  const emptyPairs = analyzeAnsi(
+    `${B}${E}${B}${E}${B}${E}${marker(1)}${marker(2)}${marker(3)}`,
+  );
+  assert.equal(emptyPairs.dec2026.begin, 3);
+  assert.equal(emptyPairs.dec2026.unbalanced, 0);
+  assert.equal(emptyPairs.events.unique, 3);
+  assert.equal(emptyPairs.events.covered, 0);
+  assert.equal(emptyPairs.events.unwrapped, 3);
+  const emptyPairsEval = evaluateSide(emptyPairs, cap, { requireSync: true });
+  assert.equal(emptyPairsEval.verdict, 'fail');
+  assert.ok(
+    emptyPairsEval.reasons.some((reason) => reason.includes('requireSync')),
+    emptyPairsEval.reasons.join('; '),
+  );
+
+  // Partially bracketed frames: markers outside every interval.
+  const partial = analyzeAnsi(
+    `${B}f1${E}${B}f2${E}f3${marker(1)}${marker(2)}${marker(3)}`,
+  );
+  const partialEval = evaluateSide(partial, cap, { requireSync: true });
+  assert.equal(partialEval.verdict, 'fail');
+  assert.ok(
+    partialEval.reasons.some((reason) => reason.includes('requireSync')),
+    partialEval.reasons.join('; '),
+  );
+
+  // A single marker outside an interval fails even when the rest are covered.
+  const oneOutside = analyzeAnsi(
+    `${B}f1${marker(1)}${E}${B}f2${marker(2)}${E}${marker(3)}`,
+  );
+  assert.equal(oneOutside.events.unwrapped, 1);
+  assert.equal(
+    evaluateSide(oneOutside, cap, { requireSync: true }).verdict,
+    'fail',
+  );
+
+  // Markers inside every interval pass.
+  const full = analyzeAnsi(
+    `${B}f1${marker(1)}${E}${B}f2${marker(2)}${E}${B}f3${marker(3)}${E}`,
+  );
+  assert.equal(full.events.covered, 3);
+  assert.equal(full.events.unwrapped, 0);
+  assert.equal(evaluateSide(full, cap, { requireSync: true }).verdict, 'pass');
+});
+
+test('fixture capture records its waived TTY mode', async () => {
+  const cap = await capture([process.execPath, EMITTER_PATH, '--frames', '1'], {
+    rows: 6,
+    columns: 30,
+    timeoutMs: 5000,
+    tty: 'fixture',
+  });
+  assert.equal(cap.spawned, true, cap.spawnError);
+  assert.equal(cap.exitCode, 0);
+  assert.deepEqual(cap.tty, {
+    mode: 'fixture',
+    backend: null,
+    allocated: false,
+    rows: 6,
+    columns: 30,
+    handshake: null,
+  });
+});
+
+test('accepts a valid scenario and applies defaults', () => {
+  const scenario = validateScenario(scenarioFixture());
+  assert.equal(scenario.timeoutMs, 5000);
+  assert.deepEqual(scenario.input, []);
+  assert.deepEqual(scenario.env, {});
+  assert.deepEqual(scenario.compareParams, []);
+  assert.equal(scenario.commands.base.pty, 'fixture');
+});
+
+test('plain argv commands require native PTY capture', () => {
+  const scenario = scenarioFixture();
+  scenario.commands.base = ['node', 'base.mjs'];
+  scenario.commands.fixed = ['node', 'fixed.mjs'];
+  const parsed = validateScenario(scenario);
+  assert.equal(parsed.commands.base.pty, 'native');
+  assert.equal(parsed.commands.fixed.pty, 'native');
+});
+
+test('accepts fixture and wrapped PTY waivers', () => {
+  const scenario = scenarioFixture();
+  scenario.commands.base = { argv: ['node', 'base.mjs'], pty: 'fixture' };
+  scenario.commands.fixed = { argv: ['node', 'fixed.mjs'], pty: 'wrapped' };
+  const parsed = validateScenario(scenario);
+  assert.equal(parsed.commands.base.pty, 'fixture');
+  assert.equal(parsed.commands.fixed.pty, 'wrapped');
+});
+
+test('rejects invalid pty modes', () => {
+  const scenario = scenarioFixture();
+  scenario.commands.base = { argv: ['node', 'base.mjs'], pty: 'pipes' };
+  assert.throws(
+    () => validateScenario(scenario),
+    /commands\.base\.pty must be "fixture" or "wrapped"/,
+  );
+});
+
+test('rejects per-side parameters on fixed', () => {
+  const scenario = scenarioFixture();
+  scenario.commands.fixed = {
+    argv: ['node', 'fixed.mjs'],
+    terminal: { rows: 1, columns: 1 },
+  };
+  assert.throws(
+    () => validateScenario(scenario),
+    /base and fixed share all scenario parameters/,
+  );
+});
+
+test('rejects missing or malformed commands', () => {
+  const missing = scenarioFixture();
+  delete missing.commands.fixed;
+  assert.throws(() => validateScenario(missing), /commands\.fixed is required/);
+
+  const empty = scenarioFixture();
+  empty.commands.base = [];
+  assert.throws(
+    () => validateScenario(empty),
+    /commands\.base must be a non-empty array/,
+  );
+
+  const missingArgv = scenarioFixture();
+  missingArgv.commands.base = { pty: 'fixture' };
+  assert.throws(
+    () => validateScenario(missingArgv),
+    /commands\.base\.argv must be a non-empty array/,
+  );
+});
+
+test('rejects malformed terminal and timeout', () => {
+  const badTerminal = scenarioFixture();
+  badTerminal.terminal.rows = 0;
+  assert.throws(() => validateScenario(badTerminal), /terminal\.rows/);
+
+  const badTimeout = scenarioFixture();
+  badTimeout.timeoutMs = -5;
+  assert.throws(() => validateScenario(badTimeout), /timeoutMs/);
+});
+
+test('rejects malformed thresholds', () => {
+  const negative = scenarioFixture();
+  negative.thresholds = { maxFullScreenClears: -1 };
+  assert.throws(
+    () => validateScenario(negative),
+    /thresholds\.maxFullScreenClears/,
+  );
+
+  const wrongType = scenarioFixture();
+  wrongType.thresholds = { requireSync: 'yes' };
+  assert.throws(() => validateScenario(wrongType), /thresholds\.requireSync/);
+
+  const unknown = scenarioFixture();
+  unknown.thresholds = { maxEverything: 1 };
+  assert.throws(() => validateScenario(unknown), /unknown thresholds key/);
+});
+
+test('rejects unknown top-level keys and bad ids', () => {
+  const unknownKey = scenarioFixture();
+  unknownKey.bonus = true;
+  assert.throws(() => validateScenario(unknownKey), /unknown top-level key/);
+
+  const badId = scenarioFixture();
+  badId.id = 'Bad Id';
+  assert.throws(() => validateScenario(badId), /kebab-case/);
+});
+
+test('requires proves and doesNotProve', () => {
+  const noProves = scenarioFixture();
+  delete noProves.proves;
+  assert.throws(() => validateScenario(noProves), /proves is required/);
+
+  const noDoesNotProve = scenarioFixture();
+  delete noDoesNotProve.doesNotProve;
+  assert.throws(
+    () => validateScenario(noDoesNotProve),
+    /doesNotProve is required/,
+  );
+});
+
+test('extractFlagValues normalizes --flag value and --flag=value', () => {
+  assert.deepEqual(
+    extractFlagValues(
+      ['a', '--rows', '12', '--rows=99', '--rowsy', 'x'],
+      '--rows',
+    ),
+    ['12', '99'],
+  );
+  assert.deepEqual(extractFlagValues(['a'], '--rows'), []);
+});
+
+test('rejects divergent rows between sides (compareParams)', () => {
+  const scenario = scenarioFixture();
+  scenario.terminal = { rows: 12, columns: 30 };
+  scenario.compareParams = ['--rows'];
+  scenario.commands.base = {
+    argv: ['node', 'base.mjs', '--rows', '12'],
+    pty: 'fixture',
+  };
+  scenario.commands.fixed = {
+    argv: ['node', 'fixed.mjs', '--rows', '99'],
+    pty: 'fixture',
+  };
+  assert.throws(
+    () => validateScenario(scenario),
+    /compareParams: "--rows" differs between base \(12\) and fixed \(99\)/,
+  );
+});
+
+test('rejects divergent columns between sides (compareParams)', () => {
+  const scenario = scenarioFixture();
+  scenario.compareParams = ['--columns'];
+  scenario.commands.base = {
+    argv: ['node', 'base.mjs', '--columns', '24'],
+    pty: 'fixture',
+  };
+  scenario.commands.fixed = {
+    argv: ['node', 'fixed.mjs', '--columns=36'],
+    pty: 'fixture',
+  };
+  assert.throws(
+    () => validateScenario(scenario),
+    /compareParams: "--columns" differs between base \(24\) and fixed \(36\)/,
+  );
+});
+
+test('accepts equal comparison parameters across value spellings', () => {
+  const scenario = scenarioFixture();
+  scenario.terminal = { rows: 12, columns: 24 };
+  scenario.compareParams = ['--rows', '--columns'];
+  scenario.commands.base = {
+    argv: ['node', 'base.mjs', '--rows', '12', '--columns=24'],
+    pty: 'fixture',
+  };
+  scenario.commands.fixed = {
+    argv: ['node', 'fixed.mjs', '--rows=12', '--columns', '24'],
+    pty: 'fixture',
+  };
+  const parsed = validateScenario(scenario);
+  assert.deepEqual(parsed.compareParams, ['--rows', '--columns']);
+});
+
+test('rejects a comparison parameter missing from one side', () => {
+  const scenario = scenarioFixture();
+  scenario.compareParams = ['--rows'];
+  scenario.commands.base = {
+    argv: ['node', 'base.mjs', '--rows', '8'],
+    pty: 'fixture',
+  };
+  scenario.commands.fixed = { argv: ['node', 'fixed.mjs'], pty: 'fixture' };
+  assert.throws(
+    () => validateScenario(scenario),
+    /compareParams: "--rows" is missing from commands\.fixed/,
+  );
+});
+
+test('rejects comparison parameter values that contradict the terminal', () => {
+  const scenario = scenarioFixture();
+  scenario.terminal = { rows: 8, columns: 30 };
+  scenario.compareParams = ['--rows'];
+  scenario.commands.base = {
+    argv: ['node', 'base.mjs', '--rows', '12'],
+    pty: 'fixture',
+  };
+  scenario.commands.fixed = {
+    argv: ['node', 'fixed.mjs', '--rows', '12'],
+    pty: 'fixture',
+  };
+  assert.throws(
+    () => validateScenario(scenario),
+    /compareParams: "--rows" value "12" does not match terminal\.rows \(8\)/,
+  );
+});
+
+test('rejects malformed compareParams entries', () => {
+  const scenario = scenarioFixture();
+  scenario.compareParams = ['rows'];
+  assert.throws(
+    () => validateScenario(scenario),
+    /compareParams entries must be strings matching --<flag>/,
+  );
+});
+
+function scenarioWithCompareParams() {
+  return scenarioFixture({
+    id: 'override-binding',
+    compareParams: ['--frames'],
+    commands: {
+      base: fixtureCommand('--frames', '2'),
+      fixed: fixtureCommand('--frames', '2'),
+    },
+    thresholds: { requireSync: false },
+  });
+}
+
+test('overrides must satisfy compareParams on the final resolved argv', () => {
+  const scenario = validateScenario(scenarioWithCompareParams());
+  assert.throws(
+    () =>
+      validateFinalParams(
+        scenario,
+        { argv: ['node', 'base.mjs', '--frames', '2'] },
+        { argv: ['node', 'fixed.mjs', '--frames', '3'] },
+        { base: true, fixed: true },
+      ),
+    /override\(s\) failed parameter binding on the final resolved argv: compareParams: "--frames" differs between base \(2\) and fixed \(3\)/,
+  );
+});
+
+test('overrides that drop a compareParam are rejected', () => {
+  const scenario = validateScenario(scenarioWithCompareParams());
+  assert.throws(
+    () =>
+      validateFinalParams(
+        scenario,
+        { argv: ['node', 'base.mjs', '--frames', '2'] },
+        { argv: ['node', 'fixed.mjs'] },
+        { fixed: true },
+      ),
+    /compareParams: "--frames" is missing from commands\.fixed/,
+  );
+});
+
+test('overrides must keep terminal-size flags bound to the capture geometry', () => {
+  const scenario = validateScenario(scenarioWithCompareParams());
+  assert.throws(
+    () =>
+      validateFinalParams(
+        scenario,
+        { argv: ['node', 'base.mjs', '--frames', '2', '--rows', '99'] },
+        { argv: ['node', 'fixed.mjs', '--frames', '2'] },
+        { base: true },
+      ),
+    /commands\.base: "--rows" value "99" does not match terminal\.rows \(6\)/,
+  );
+});
+
+test('runScenario rejects divergent overrides before anything runs', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = validateScenario(scenarioWithCompareParams());
+    await assert.rejects(
+      runScenario(scenario, join(work, 'out'), {
+        base: ['node', 'base.mjs', '--frames', '2'],
+        fixed: ['node', 'fixed.mjs', '--frames', '3'],
+      }),
+      /parameter binding/,
+    );
+  });
+});
+
+test('runScenario records which sides were overridden', async () => {
+  await withWorkdir(async (work) => {
+    const scenario = validateScenario(
+      scenarioFixture({
+        id: 'override-record',
+        commands: {
+          base: fixtureCommand('--frames', '1'),
+          fixed: fixtureCommand('--frames', '1'),
+        },
+        thresholds: { requireSync: false },
+      }),
+    );
+    const comparison = await runScenario(scenario, join(work, 'out'), {
+      // A fixture-mode emitter override keeps both sides deterministic.
+      base: [process.execPath, EMITTER_PATH, '--frames', '1'],
+      fixed: undefined,
+    });
+    assert.deepEqual(comparison.overridesApplied, { base: true, fixed: false });
+  });
+});


### PR DESCRIPTION
## What this PR does

Batch 7 of the ink→OpenTUI migration (#8662): the build, CI and parity tooling the renderer needs to be shipped and verified. Ink remains the default renderer and user-facing behavior is unchanged.

Bundled builds silently lose code-block syntax highlighting because the OpenTUI runtime resolves its tree-sitter assets package-relatively, which misses inside the esbuild bundle. This PR relocates the runtime assets (parser worker, grammar wasms/scm, the web-tree-sitter runtime, the native render library) next to the bundle, and only activates the relocated root when the tree is complete for the running platform — the runtime throws on any missing asset, so an incomplete relocation must fall back instead of half-configuring. Standalone archives gain an opt-in Bun runtime flavor (`--runtime=bun`, the renderer needs bun:ffi) that stages the per-target OpenTUI platform packages; classic Node.js packaging remains the default.

The renderer matrix drives interactive E2E under node+ink and bun+opentui. Because the renderer gate silently falls back to ink on an unsupported runtime, a green opentui leg could be a false green; a new strict mode turns that fallback into a loud startup failure for the matrix legs only. The user-facing fallback stays silent.

Parity tooling: a workflow with component snapshots and a no-flicker gate (zero full-screen clears, balanced DEC 2026) that degrades to an offline scripted-stream gate when model credentials are unavailable, an ink→opentui codemod with a self-test, the PTY/tmux comparison harnesses, and the CLI scripts tree is now covered by the package typecheck.

## Why it's needed

Without the asset pipeline, every bundled install of the renderer would ship degraded (single-color code blocks) with no signal as to why. Without the strict mode, the E2E matrix cannot distinguish "opentui really ran" from "opentui failed and ink was served", which would make the migration's verification claim untrustworthy. These are the pieces #8662 lists under the Build & CI milestone; the batches before this one land the runtime itself.

## Reviewer Test Plan

### How to verify

- Build and bundle, then confirm the relocated asset tree appears under dist with the native library, parser worker, grammar assets and web-tree-sitter wasm all present.
- Run the offline no-flicker gate; it should report the fixture base failing (it injects defects) and the real renderer passing, with an overall pass.
- Run the parity scripts under bun; command parity should print a per-command table ending in PASS.
- Run the renderer-matrix unit tests and the strict-mode tests; strict mode should throw only for an explicit opentui request on an unsupported runtime, never for the default or an explicit ink request.

### Evidence (Before & After)

N/A (tooling and packaging; no user-visible TUI change). Offline no-flicker gate run locally: `outcome=base-fails-fixed-passes base=fail fixed=pass / overall: pass`. Command parity: `COMMAND PARITY PASS`. Asset tree: 14 keys copied under dist/opentui-assets.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

⚠️ = only via unit tests and typecheck; the standalone packaging paths for Windows/Linux run in release CI.

### Environment (optional)

Full build + bundle + typecheck + lint green locally; the full scripts suite passes except three long-running installer/autofix tests that time out under local parallel load but pass in isolation (no file overlap with this diff).

## Risk & Scope

- Main risk or tradeoff: the new CI leg adds bun-based E2E minutes; the no-flicker workflow runs on every CLI-touching PR.
- Not validated / out of scope: live-model no-flicker capture (requires credentials, exercised in CI), the release run of the opt-in Bun archive flavor (`--runtime=bun`).
- Breaking changes / migration notes: none — the default renderer and standalone packaging behavior are unchanged; `--runtime=bun` adds an opt-in Bun archive flavor (the renderer needs bun:ffi) that carries the OpenTUI platform packages.

## Linked Issues

Part of #8662 (Build & CI milestone).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

ink→OpenTUI 迁移的第 7 批（#8662）：渲染器落地所需的构建、CI 与 parity 工具链。ink 仍是默认渲染器，用户可见行为不变。

打包产物会静默丢失代码块语法高亮：OpenTUI 运行时按包内相对路径解析 tree-sitter 资产，在 esbuild bundle 内必然落空。本批把运行时资产（parser worker、语法 wasm/scm、web-tree-sitter、原生渲染库）重定位到 bundle 旁边，且只有当资产树对当前平台完整时才启用重定位根——运行时对缺失资产会抛错，因此不完整的重定位必须回退而不是半配置。独立发布包获得一个可选的 Bun 运行时口味（`--runtime=bun`，渲染器需要 bun:ffi），并随之打包按目标平台的 OpenTUI 原生包；经典 Node.js 打包保持默认。

渲染器矩阵在 node+ink 与 bun+opentui 两条腿下驱动交互式 E2E。由于渲染器门控在不支持的运行时会静默回退到 ink，绿色的 opentui 腿可能是假绿；新增的 strict 模式仅对矩阵腿把该回退变成响亮的启动失败。用户侧默认回退保持静默。

Parity 工具：包含组件快照与无闪屏门禁（零全屏清屏、DEC 2026 配平）的 workflow，在无模型凭据时降级为离线脚本流门禁；ink→opentui codemod 及其自测；PTY/tmux 对比 harness；CLI scripts 目录纳入包级 typecheck。

## 为什么需要

没有资产管线，每个打包安装的渲染器都带着静默降级（单色代码块）且无从排查；没有 strict 模式，E2E 矩阵无法区分"opentui 真的跑了"和"opentui 失败后由 ink 顶替"，迁移的验证主张不可信。这些是 #8662 Build & CI 里程碑列出的内容。

## 评审者测试计划

本地已全量 build + bundle + typecheck + lint 通过；离线无闪屏门禁本地跑通（`overall: pass`，注入缺陷的 base 正确判 fail）；命令 parity PASS；资产树 14 个键全部落位。完整 scripts 套件除三个本地并行负载下的安装器/autofix 超时（隔离重跑全绿、与本 diff 无文件交集）外全过。Windows/Linux 仅经单测与 typecheck 覆盖，独立发布路径由发布 CI 验证。

## 风险与范围

- 主要风险：新增 CI 腿增加 bun E2E 分钟数；无闪屏 workflow 会在触及 CLI 的 PR 上运行。
- 未验证/超出范围：真实模型的无闪屏采集（需凭据，由 CI 行使）、Bun 口味独立包（`--runtime=bun`）的实际发布运行。
- 破坏性变更：无——默认渲染器与独立发布包的打包行为均不变；`--runtime=bun` 是新增的可选 Bun 归档口味（渲染器需要 bun:ffi，随包附带 OpenTUI 平台包）。

## 关联 Issue

#8662（Build & CI 里程碑）。

</details>


