### PR TITLE
fix(workflow): tighten multi-workspace state boundaries

### DIFF
--- a/docs/design/experimental-session-plan-review.md
+++ b/docs/design/experimental-session-plan-review.md
@@ -9,8 +9,10 @@ and the existing permission lifecycle.
 ## Rollout
 
 `experimental.sessionWorkflow` is disabled by default. When disabled, Core,
-the ACP session, and the Web Shell retain their existing Todo, Agent, approval,
-and split-view behavior. No Workflow marker or revision context is created.
+the ACP session, and the Web Shell do not create Workflow markers, revision
+context, approval gates, or visualization surfaces. Todo updates preserve an
+active item's dependencies when `blockedBy` is omitted in every mode; this
+shared update behavior is not gated by the setting.
 
 When enabled, the existing `plan` mode is presented as **Plan & Review**. Plan
 Mode remains the execution gate: read-only investigation is allowed, mutating

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -3841,7 +3841,7 @@ const SETTINGS_SCHEMA = {
         requiresRestart: false,
         default: false,
         description:
-          'Enable the daemon Web Shell Session Workflow DAG and present Plan mode as Plan & Review. Disabled by default and does not change ordinary Todo or execution behavior.',
+          'Enable the daemon Web Shell Session Workflow DAG and present Plan mode as Plan & Review. Disabled by default; Workflow markers, approval gates, and visualization stay off until enabled. Todo updates preserve omitted active dependencies in every mode.',
         showInDialog: true,
       },
       cron: {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -4585,13 +4585,16 @@ describe('createServeApp', () => {
       // the primary.
       const primaryInvoke = vi.fn().mockResolvedValue(undefined);
       const secondaryInvoke = vi.fn().mockResolvedValue(undefined);
+      const primaryPublish = vi.fn();
+      const secondaryPublish = vi.fn();
       const primaryBridge = {
-        ...fakeBridge(),
+        ...fakeBridge({ knownClientIds: ['client-1'] }),
         invokeWorkspaceCommand: primaryInvoke,
-        publishWorkspaceEvent: vi.fn(),
+        publishWorkspaceEvent: primaryPublish,
       } as unknown as AcpSessionBridge;
       const secondaryBridge = {
         invokeWorkspaceCommand: secondaryInvoke,
+        publishWorkspaceEvent: secondaryPublish,
       } as unknown as AcpSessionBridge;
       const registry = createWorkspaceRegistry([
         makeWorkspaceRuntimeForTest({
@@ -4634,6 +4637,7 @@ describe('createServeApp', () => {
         .post('/workspace/settings')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('Authorization', 'Bearer secret')
+        .set('X-Qwen-Client-Id', 'client-1')
         .send({
           scope: 'user',
           key: 'experimental.sessionWorkflow',
@@ -4656,6 +4660,20 @@ describe('createServeApp', () => {
         SERVE_CONTROL_EXT_METHODS.workspaceSessionWorkflow,
         { enabled: expect.any(Boolean) },
       );
+      const expectedEvent = {
+        type: 'settings_changed',
+        data: {
+          key: 'experimental.sessionWorkflow',
+          value: true,
+          scope: 'user',
+        },
+        originatorClientId: 'client-1',
+      };
+      expect(primaryPublish).toHaveBeenCalledWith(expectedEvent);
+      expect(secondaryPublish).toHaveBeenCalledWith({
+        type: 'settings_changed',
+        data: expectedEvent.data,
+      });
     });
 
     it('classifies the daemon-owned Live runtime without exposing provenance', async () => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -2619,11 +2619,35 @@ export function createServeApp(
     clientId: string | undefined,
   ) => {
     invalidateServeFeaturesCache();
-    primaryBridge.publishWorkspaceEvent({
+    const event = {
       type: 'settings_changed',
       data: { key, value, scope },
-      ...(clientId ? { originatorClientId: clientId } : {}),
-    });
+    } as const;
+    const publish = (
+      bridge: AcpSessionBridge,
+      workspace: string,
+      originatorClientId?: string,
+    ) => {
+      try {
+        bridge.publishWorkspaceEvent({
+          ...event,
+          ...(originatorClientId ? { originatorClientId } : {}),
+        });
+      } catch (err) {
+        writeStderrLine(
+          `qwen serve: settings_changed broadcast to workspace ${workspace} failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    };
+
+    publish(primaryBridge, primaryBoundWorkspace, clientId);
+    if (scope !== 'user') return;
+    for (const runtime of workspaceRegistry.listAll()) {
+      if (runtime.primary) continue;
+      publish(runtime.bridge, runtime.workspaceCwd);
+    }
   };
 
   if (deps.persistSetting) {

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -3889,9 +3889,24 @@ describe('BackgroundAgentResumeService', () => {
       }
     });
     const { service, subagentManager } = createService();
-    subagentManager.createAgentHeadless.mockRejectedValue(
-      new Error('setup failed'),
-    );
+    const dispose = vi.fn().mockResolvedValue(undefined);
+    subagentManager.createAgentHeadless.mockResolvedValue({
+      subagent: {
+        execute: vi.fn(),
+        setExternalMessageProvider: vi.fn(() => {
+          throw new Error('setup failed');
+        }),
+        getCore: () => ({ getEventEmitter: () => new AgentEventEmitter() }),
+        getExecutionSummary: () => ({
+          totalTokens: 0,
+          outputTokens: 0,
+          totalDurationMs: 0,
+        }),
+        getTerminateMode: () => AgentTerminateMode.GOAL,
+        getFinalText: () => 'iterated',
+      },
+      dispose,
+    });
 
     await expect(
       service.reviveCompletedBackgroundAgent(agentId, 'keep going'),
@@ -4082,6 +4097,12 @@ describe('BackgroundAgentResumeService', () => {
       subagentName: 'researcher',
       resolvedApprovalMode: 'default',
     });
+    const stats = {
+      totalTokens: 42,
+      outputTokens: 17,
+      toolUses: 3,
+      durationMs: 1200,
+    };
     fs.writeFileSync(
       outputFile,
       JSON.stringify({
@@ -4106,7 +4127,7 @@ describe('BackgroundAgentResumeService', () => {
       outputFile,
       metaPath,
     });
-    registry.complete(agentId, 'All done');
+    registry.complete(agentId, 'All done', stats);
     // Populate the pre-revive UI state that must survive a failed revive.
     const activities = [
       { name: 'Read', description: 'read src/index.ts', at: 1 },
@@ -4131,6 +4152,10 @@ describe('BackgroundAgentResumeService', () => {
     // `recentActivities`, silently dropping the retained activities. The
     // completed snapshot must be restored instead.
     expect(restored?.recentActivities).toEqual(activities);
+    expect(restored?.stats).toEqual(stats);
+    const restoredMeta = readAgentMeta(metaPath);
+    expect(restoredMeta).not.toHaveProperty('stats');
+    expect(restoredMeta).not.toHaveProperty('recentActivities');
   });
 
   it('does not restore more completed agents than the terminal-agent cap', async () => {

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -1615,10 +1615,13 @@ export class BackgroundAgentResumeService {
       },
     );
     if (entry.metaPath) {
+      const meta = readAgentMeta(entry.metaPath);
       patchAgentMeta(entry.metaPath, {
         lastError: undefined,
         status: 'completed',
-        ...getAgentMetaTerminalSummary(entry.stats, entry.recentActivities),
+        ...(meta?.sessionWorkflow === true
+          ? getAgentMetaTerminalSummary(entry.stats, entry.recentActivities)
+          : {}),
       });
     }
     return restored;

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -3636,7 +3636,7 @@
           }
         },
         "sessionWorkflow": {
-          "description": "Enable the daemon Web Shell Session Workflow DAG and present Plan mode as Plan & Review. Disabled by default and does not change ordinary Todo or execution behavior.",
+          "description": "Enable the daemon Web Shell Session Workflow DAG and present Plan mode as Plan & Review. Disabled by default; Workflow markers, approval gates, and visualization stay off until enabled. Todo updates preserve omitted active dependencies in every mode.",
           "type": "boolean",
           "default": false
         },


### PR DESCRIPTION
## What this PR does

This follow-up to #8583 closes two state-boundary gaps found after merge. User-scoped settings notifications now reach every registered workspace runtime, while the requester's client identity remains local to the primary bridge. Failed completed-agent revival restores terminal workflow summaries only for sidecars explicitly marked as Session Workflow sessions. The rollout documentation also clarifies which behavior remains shared when the experiment is disabled.

## Why it's needed

A user-scoped Session Workflow write already updates the global settings file and live gates in sibling runtimes, but sibling Web Shells could keep a stale settings cache because only the primary bridge received `settings_changed`. Separately, the rollback path for an ordinary completed agent could copy workflow-only summary fields into its sidecar; removing the restore entirely would instead lose valid workflow summaries after a late setup failure.

## Reviewer Test Plan

### How to verify

1. In a daemon with primary and sibling workspace runtimes, persist a user-scoped Session Workflow setting and confirm both bridges receive the same public setting value. The primary event retains the validated requester ID; the sibling event does not expose that cross-bridge identity. Workspace-scoped writes remain confined to the primary runtime.
2. Force completed-agent revival to fail after Session Workflow setup has cleared the previous summary and confirm rollback restores the workflow summary.
3. Force the same rollback for an ordinary completed agent and confirm registry statistics and recent activities are restored in memory without being persisted as workflow summary fields in its sidecar.
4. Run `cd packages/cli && npx vitest run src/serve/server.test.ts src/serve/routes/workspace-settings.test.ts`, `cd packages/core && npx vitest run src/agents/background-agent-resume.test.ts`, `cd packages/cli && npx vitest run src/config/settingsSchema.test.ts`, followed by `npm run build && npm run typecheck` from the repository root.

### Evidence (Before & After)

N/A — this is event propagation and rollback-state handling with no visual redesign. Local verification passed 1,203 related CLI tests, 51 background-agent resume tests, 50 settings-schema tests, the focused post-review regression test, changed-file ESLint, the full build, and repository type checking.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

Local npm workspace with the repository-supported Node.js runtime; no sandbox.

## Risk & Scope

- Main risk or tradeoff: user-scoped setting notifications now fan out to all registered workspace bridges. Only the already-sanitized public value is sent, and cross-bridge requester identities are omitted.
- Not validated / out of scope: no browser screenshot was added because this follow-up does not change layout or rendering; platform-specific validation remains with CI.
- Breaking changes / migration notes: none. Workspace-scoped notifications and the feature's default-off behavior are unchanged.

## Linked Issues

Follow-up to #8583.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这是 #8583 合并后的跟进修复，补齐了两个状态边界问题。用户级设置通知现在会到达所有已注册的 workspace runtime，同时请求方的 client identity 只保留在 primary bridge 内。已完成 Agent 的恢复若失败，只有明确标记为 Session Workflow 的 sidecar 才会恢复终态工作流摘要。发布说明也进一步明确了实验关闭时仍然共享的行为。

## 为什么需要

用户级 Session Workflow 设置写入已经会更新全局设置文件和 sibling runtime 的实时开关，但此前只有 primary bridge 收到 `settings_changed`，因此 sibling Web Shell 的设置缓存可能保持过期状态。另一方面，普通已完成 Agent 的恢复回滚可能把仅属于工作流的摘要字段写入其 sidecar；如果完全取消摘要恢复，又会在较晚的初始化步骤失败时丢失真实工作流原有的摘要。

## Reviewer 测试计划

### 如何验证

1. 在同时包含 primary 与 sibling workspace runtime 的 daemon 中持久化一个用户级 Session Workflow 设置，确认两个 bridge 都收到相同的公开设置值。Primary 事件保留已验证的请求方 ID；sibling 事件不会跨 bridge 暴露该身份。Workspace 级写入仍只作用于 primary runtime。
2. 让已完成 Agent 的恢复在 Session Workflow 初始化清除旧摘要之后失败，确认回滚会恢复工作流摘要。
3. 对普通已完成 Agent 制造相同的回滚，确认 registry 中的统计和近期活动会在内存中恢复，但不会作为工作流摘要字段持久化到 sidecar。
4. 运行 `cd packages/cli && npx vitest run src/serve/server.test.ts src/serve/routes/workspace-settings.test.ts`、`cd packages/core && npx vitest run src/agents/background-agent-resume.test.ts`、`cd packages/cli && npx vitest run src/config/settingsSchema.test.ts`，随后在仓库根目录运行 `npm run build && npm run typecheck`。

### 前后证据

N/A——这是事件传播和回滚状态处理，不涉及视觉设计调整。本地验证已通过 1,203 个相关 CLI 测试、51 个后台 Agent 恢复测试、50 个设置 schema 测试、review 修复后的聚焦回归测试、改动文件 ESLint、完整构建和仓库类型检查。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

本地 npm workspace，使用仓库支持的 Node.js 运行时，未启用 sandbox。

## 风险与范围

- 主要风险或权衡：用户级设置通知现在会分发到所有已注册的 workspace bridge。发送的只有已经脱敏的公开值，且不会把请求方身份跨 bridge 传播。
- 未验证 / 范围外：本跟进不修改布局或渲染，因此没有添加浏览器截图；平台相关验证交由 CI 完成。
- 破坏性变更 / 迁移说明：无。Workspace 级通知和功能默认关闭的行为保持不变。

## 关联事项

#8583 的跟进修复。

</details>
