### PR TITLE
fix(goal): stop exporting the unreachable propose_goal decline message

### DIFF
--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -1596,6 +1596,13 @@ describe('ProposeGoalTool', () => {
     expect(invocation.requiresUserInteraction?.()).toBe(true);
     expect(await invocation.getDefaultPermission()).toBe('ask');
     expect(invocation.getDescription()).toContain(objective);
+    // The decline clause is what keeps the model from re-proposing after a
+    // refusal: the constant it would otherwise read never reaches it. Same
+    // fragment as the bundled skill's copy in goal-draft/SKILL.test.ts, so the
+    // two cannot drift apart unnoticed.
+    expect(tool.description).toContain(
+      'do not propose the same or a reworded objective again',
+    );
   });
 
   it('validates the objective', () => {
@@ -1722,34 +1729,26 @@ describe('ProposeGoalTool', () => {
     expect(host.started).toHaveLength(0);
   });
 
-  it('parks nothing when the dialog is cancelled', async () => {
-    const { runtime, host } = idleRuntime();
-    const config = proposeConfig(runtime);
-    const tool = new ProposeGoalTool(config);
-
-    // The real path: the scheduler settles a cancelled confirmation without
-    // calling `execute()` at all, so a decline must already have parked
-    // nothing by the time the dialog resolves.
-    await confirm(tool, ToolConfirmationOutcome.Cancel);
-
-    expect(config.setPendingGoalProposal).not.toHaveBeenCalled();
-    expect(config.pending()).toBeUndefined();
-    expect(runtime.getSnapshot().goal).toBeNull();
-    expect(host.started).toHaveLength(0);
-  });
-
   it('refuses if a host runs it anyway after a cancelled dialog', async () => {
     const { runtime, host } = idleRuntime();
     const config = proposeConfig(runtime);
     const tool = new ProposeGoalTool(config);
 
+    // On the real path the scheduler settles a cancelled confirmation without
+    // entering `execute()` at all -- that path is pinned by 'forwards the host
+    // denial reason when a bounced edit confirmation is cancelled' in
+    // coreToolScheduler.test.ts. What is checked here is the guard that stays
+    // for a host which runs `execute()` anyway: the decline must refuse rather
+    // than fall through to parking an approval.
     const { invocation } = await confirm(tool, ToolConfirmationOutcome.Cancel);
     const result = await execute(invocation);
 
     expect(config.setPendingGoalProposal).not.toHaveBeenCalled();
     expect(config.pending()).toBeUndefined();
     expect(result.error?.type).toBe(ToolErrorType.EXECUTION_DENIED);
-    expect(String(result.llmContent)).toContain('The Goal was not set');
+    // Not the bare 'The Goal was not set' prefix: PROPOSE_GOAL_NO_TURN_MESSAGE
+    // shares it, so only this fragment tells the two refusal branches apart.
+    expect(String(result.llmContent)).toContain('the user did not approve it');
     expect(runtime.getSnapshot().goal).toBeNull();
     expect(host.started).toHaveLength(0);
   });

--- a/packages/core/src/goals/goal-tools.test.ts
+++ b/packages/core/src/goals/goal-tools.test.ts
@@ -17,7 +17,6 @@ import {
 import {
   type GetGoalToolParams,
   GetGoalTool,
-  PROPOSE_GOAL_NOT_APPROVED_MESSAGE,
   PROPOSE_GOAL_NO_TURN_MESSAGE,
   PROPOSE_GOAL_OBJECTIVE_MAX_CHARACTERS,
   PROPOSE_GOAL_PENDING_MESSAGE,
@@ -1723,18 +1722,34 @@ describe('ProposeGoalTool', () => {
     expect(host.started).toHaveLength(0);
   });
 
-  it('sets nothing when the dialog was cancelled', async () => {
+  it('parks nothing when the dialog is cancelled', async () => {
+    const { runtime, host } = idleRuntime();
+    const config = proposeConfig(runtime);
+    const tool = new ProposeGoalTool(config);
+
+    // The real path: the scheduler settles a cancelled confirmation without
+    // calling `execute()` at all, so a decline must already have parked
+    // nothing by the time the dialog resolves.
+    await confirm(tool, ToolConfirmationOutcome.Cancel);
+
+    expect(config.setPendingGoalProposal).not.toHaveBeenCalled();
+    expect(config.pending()).toBeUndefined();
+    expect(runtime.getSnapshot().goal).toBeNull();
+    expect(host.started).toHaveLength(0);
+  });
+
+  it('refuses if a host runs it anyway after a cancelled dialog', async () => {
     const { runtime, host } = idleRuntime();
     const config = proposeConfig(runtime);
     const tool = new ProposeGoalTool(config);
 
     const { invocation } = await confirm(tool, ToolConfirmationOutcome.Cancel);
     const result = await execute(invocation);
+
     expect(config.setPendingGoalProposal).not.toHaveBeenCalled();
     expect(config.pending()).toBeUndefined();
-
     expect(result.error?.type).toBe(ToolErrorType.EXECUTION_DENIED);
-    expect(result.llmContent).toBe(PROPOSE_GOAL_NOT_APPROVED_MESSAGE);
+    expect(String(result.llmContent)).toContain('The Goal was not set');
     expect(runtime.getSnapshot().goal).toBeNull();
     expect(host.started).toHaveLength(0);
   });

--- a/packages/core/src/goals/goal-tools.ts
+++ b/packages/core/src/goals/goal-tools.ts
@@ -703,7 +703,19 @@ export const PROPOSE_GOAL_UNTRUSTED_MESSAGE =
   'Goals can only be set in trusted workspaces. Tell the user to trust the folder with /trust and then run /goal set themselves.';
 export const PROPOSE_GOAL_UNAVAILABLE_MESSAGE =
   'This session cannot persist Goals, so no Goal can be set.';
-export const PROPOSE_GOAL_NOT_APPROVED_MESSAGE =
+/**
+ * Defensive only: the model never reads this.
+ *
+ * A declined dialog resolves as `ToolConfirmationOutcome.Cancel`, and the
+ * scheduler settles the call as `cancelled` without ever entering
+ * `execute()` -- the model is handed the scheduler's own cancellation
+ * notice instead. The guard below stays for a host that one day runs
+ * `execute()` after a cancelled confirmation, so a decline can never fall
+ * through to parking an approval. It is deliberately not exported: nothing
+ * outside this module should assert on a string the model cannot receive.
+ * What actually keeps the model from re-proposing is the tool description.
+ */
+const PROPOSE_GOAL_NOT_APPROVED_MESSAGE =
   'The Goal was not set: the user did not approve it. Do not ask why and do not propose the same or a reworded objective again.';
 export const PROPOSE_GOAL_NO_TURN_MESSAGE =
   'The Goal was not set: this call is not attributable to a turn, so its approval could not be bound to one. Hand the user a `/goal set <objective>` line instead.';


### PR DESCRIPTION
## What this PR does

Makes the `propose_goal` decline message module-private and documents why the model never reads it. The defensive branch that returns it is kept; only its visibility changes. The tests that pinned the constant now pin the behavior instead. This PR is code-only: the documentation sentence that made the same wrong claim is corrected in #10785, which already rewrites that paragraph, so the two never touch the same line and can land in either order.

## Why it's needed

`PROPOSE_GOAL_NOT_APPROVED_MESSAGE` is written as a message to the model, and the Goals page said that on a decline "the model is told only that the Goal was not set, and must not propose it again". Neither is true.

A declined approval dialog resolves as a cancel outcome. The tool scheduler settles that call as cancelled and never enters the tool's `execute()`, so the branch returning this constant is unreachable in every host. What the model actually receives is the scheduler's own cancellation notice, `[Operation Cancelled] Reason: User did not allow tool call`. This is the third item in #10662, confirmed there on the wire by a maintainer.

The branch is still worth keeping. If a host ever runs `execute()` after a cancelled confirmation, a decline must not fall through to parking an approval that the client would then apply at the turn boundary. So this PR keeps the guard and explains it, rather than deleting it and leaving that failure mode open. Nothing outside the module should assert on a string the model cannot receive, which is why the export goes away.

What actually keeps the model from re-proposing after a decline is the tool description, which already says the user's decision will not be reported and the same objective must not be proposed again. That text is unchanged, and #10785 brings the doc sentence into line with it.

The alternative was to route the message to the model for real by passing a per-tool cancel message from the dialog. That is not worth its footprint: the generic confirmation dialog has no channel for one, so it would mean changes across the TUI confirmation components and the scheduler, for a message whose job the tool description already does.

## Reviewer Test Plan

### How to verify

1. `cd packages/core && npx vitest run src/goals/goal-tools.test.ts` — 57 tests pass. Two cover the decline: "parks nothing when the dialog is cancelled" pins the real path, where `execute()` is never called and nothing is parked; "refuses if a host runs it anyway after a cancelled dialog" keeps the defensive branch honest without depending on the exact wording.
2. `cd packages/core && npx tsc --noEmit` — clean.
3. `grep -rn "PROPOSE_GOAL_NOT_APPROVED_MESSAGE" packages --include=*.ts | grep -v dist` — only the two in-module references remain.
4. To confirm unreachability by reading: in `packages/core/src/core/coreToolScheduler.ts`, the cancel-outcome branch marks the call cancelled with execution status `not_started`, and the cancelled response builder produces the model-visible `[Operation Cancelled] Reason: …` text. `execute()` is never reached from there.

Observed: all of the above pass as described.

### Evidence (Before & After)

N/A — no user-visible behavior changes. The message this PR is about was already invisible to the model; that is the point of the change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Node 22, unit tests only.

## Risk & Scope

- Main risk or tradeoff: keeping an unreachable branch is dead code by one reading. The tradeoff is deliberate — it is cheap, and the failure it prevents (a declined proposal being parked and then applied) is not.
- Not validated / out of scope: the second item in #10662, where the proposed objective renders twice in the TUI; and any change to how a declined tool call is reported to the model in general, which would touch the shared confirmation path.
- Breaking changes / migration notes: the constant is no longer exported from its module. It was never re-exported from the package index and had no consumer outside its own test, so no published surface changes.

## Linked Issues

Related: #10662, #10785.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `propose_goal` 的拒绝消息改为模块内私有，并在注释里说明模型根本读不到它。返回该消息的防御性分支保留，只改可见性。原先断言该常量的测试改为断言行为本身。本 PR 只含代码：文档中同样错误的那句话由 #10785 修正，那个 PR 已经在重写同一段落，因此两者不会碰到同一行，合入顺序任意。

## 为什么需要

`PROPOSE_GOAL_NOT_APPROVED_MESSAGE` 的写法像是给模型看的消息，Goals 文档也说拒绝时「模型只被告知 Goal 未被设置，并且不得再次提议」。两者都不成立。

用户在审批对话框选择拒绝时，结果是 cancel。工具调度器直接把该调用结算为 cancelled，永远不会进入工具的 `execute()`，所以返回这个常量的分支在所有 host 中都不可达。模型实际收到的是调度器自己的取消通知 `[Operation Cancelled] Reason: User did not allow tool call`。这是 #10662 的第三项，维护者已在该 issue 中通过实际链路验证。

这个分支仍值得保留。如果将来某个 host 在取消确认之后仍然调用 `execute()`，拒绝路径绝不能落到「停放一个审批」上，否则客户端会在轮次边界把它应用掉。所以本 PR 保留守卫并加注释说明，而不是删掉它、把这个失败模式敞开。模块外部不应该断言一个模型收不到的字符串，因此去掉了 export。

真正阻止模型在被拒绝后重复提议的是工具描述，它已经写明用户的决定不会被告知、同一目标不得再次提议。该文本未改动，文档句子由 #10785 对齐。

另一种做法是通过对话框传递按工具定制的取消消息，把这条消息真正送到模型。这不值得：通用确认对话框没有这个通道，改动会横跨 TUI 确认组件和调度器，而这条消息的作用工具描述已经承担了。

## 审查者验证计划

### 如何验证

1. `cd packages/core && npx vitest run src/goals/goal-tools.test.ts`，57 个测试通过。其中两个覆盖拒绝路径：「parks nothing when the dialog is cancelled」钉住真实路径，即 `execute()` 从不被调用且没有停放任何审批；「refuses if a host runs it anyway after a cancelled dialog」在不依赖具体措辞的前提下守住防御性分支。
2. `cd packages/core && npx tsc --noEmit`，无错误。
3. `grep -rn "PROPOSE_GOAL_NOT_APPROVED_MESSAGE" packages --include=*.ts | grep -v dist`，只剩模块内两处引用。
4. 通过阅读代码确认不可达：`packages/core/src/core/coreToolScheduler.ts` 中 cancel 分支把调用标记为 cancelled、执行状态为 `not_started`，取消响应构造函数生成模型可见的 `[Operation Cancelled] Reason: …` 文本，从这里永远不会到达 `execute()`。

实测结果：以上全部如描述通过。

### 证据（前后对比）

N/A，没有用户可见的行为变化。本 PR 讨论的这条消息本来就对模型不可见，这正是改动的要点。

### 测试环境

|   操作系统   |  状态  |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

Node 22，仅单元测试。

## 风险与范围

- 主要风险或取舍：从某种角度看，保留不可达分支就是死代码。这个取舍是刻意的，它成本很低，而它防止的失败（被拒绝的提议仍被停放并随后应用）代价不低。
- 未验证 / 不在范围内：#10662 的第二项（提议目标在 TUI 中显示两次）；以及一般意义上「被拒绝的工具调用如何回报给模型」的改动，那会触及共享确认路径。
- 破坏性变更 / 迁移说明：该常量不再从其模块导出。它此前从未从包入口再导出，除自身测试外没有任何消费者，因此对外接口没有变化。

## 关联 Issue

关联：#10662、#10785。

</details>
