### PR TITLE
fix(cua): restore legacy Windows installer compatibility

### DIFF
--- a/packages/cua-driver/scripts/install.ps1
+++ b/packages/cua-driver/scripts/install.ps1
@@ -121,6 +121,8 @@ $ThemeBinaryName = "cua-cursor-theme.exe"
 $Script:CuaDriverRsBakedVersion = "0.20.3"
 # ~~~ END_BAKED_VERSION ~~~
 $CursorThemeRequiredFrom = [version]"0.12.7"
+$LegacyUiaRequiredFrom = [version]"0.2.8"
+$SignedUiaRequiredFrom = [version]"0.20.3"
 
 # ---------- Path resolution ------------------------------------------------
 
@@ -1385,6 +1387,8 @@ Write-Step "  target      : $target"
 $Script:CuaDriverRsSelectedChannel = Resolve-SelectedChannel
 $version = Resolve-Version
 $versionedDir = Join-Path $ReleasesDir "$version-$target"
+$requiresSignedUia = [version]$version -ge $SignedUiaRequiredFrom
+$requiresLegacyUia = [version]$version -ge $LegacyUiaRequiredFrom -and -not $requiresSignedUia
 
 # If the per-version dir is already populated, skip the download — the
 # binary is immutable per version, so a repeat install is a no-op apart
@@ -1392,9 +1396,16 @@ $versionedDir = Join-Path $ReleasesDir "$version-$target"
 $skipDownload = $false
 $uiaSecureDir = Join-Path $env:ProgramFiles "Qwen\CuaDriver\$version"
 $uiaSecurePath = Join-Path $uiaSecureDir 'qwen-cua-driver-uia.exe'
-if ((Test-Path -LiteralPath (Join-Path $versionedDir $BinaryName)) -and
-    (Test-Path -LiteralPath $uiaSecurePath) -and
-    (Get-AuthenticodeSignature -LiteralPath $uiaSecurePath).Status -eq 'Valid') {
+$hasRequiredUia = $true
+if ($requiresSignedUia) {
+    $hasRequiredUia = (Test-Path -LiteralPath $uiaSecurePath) -and
+        (Get-AuthenticodeSignature -LiteralPath $uiaSecurePath).Status -eq 'Valid'
+}
+elseif ($requiresLegacyUia) {
+    $hasRequiredUia = (Test-Path -LiteralPath (Join-Path $versionedDir 'qwen-cua-driver-uia.exe')) -or
+        (Test-Path -LiteralPath (Join-Path $versionedDir 'cua-driver-uia.exe'))
+}
+if ((Test-Path -LiteralPath (Join-Path $versionedDir $BinaryName)) -and $hasRequiredUia) {
     Write-Step "release $version is already on disk at $versionedDir (skipping download)"
     $skipDownload = $true
 }
@@ -1411,6 +1422,8 @@ if (-not $skipDownload) {
         if ($asset.Version -ne $version) {
             $version = $asset.Version
             $versionedDir = Join-Path $ReleasesDir "$version-$target"
+            $requiresSignedUia = [version]$version -ge $SignedUiaRequiredFrom
+            $requiresLegacyUia = [version]$version -ge $LegacyUiaRequiredFrom -and -not $requiresSignedUia
             $uiaSecureDir = Join-Path $env:ProgramFiles "Qwen\CuaDriver\$version"
             $uiaSecurePath = Join-Path $uiaSecureDir 'qwen-cua-driver-uia.exe'
         }
@@ -1435,29 +1448,40 @@ if (-not $skipDownload) {
             }
             Write-Step "installed $versionedDir\$BinaryName (version $version, target $target)"
         }
-        # The UIAccess worker is required for foreground acquisition and input
-        # delivery. Windows only grants uiAccess to a signed binary installed
-        # under a secure system path, so do not fall back to the per-user
-        # release directory.
-        $uiaStage = Join-Path $stageDir 'qwen-cua-driver-uia.exe'
-        if (-not (Test-Path -LiteralPath $uiaStage)) {
-            throw "release archive is missing required qwen-cua-driver-uia.exe"
-        }
-        $uiaSignature = Get-AuthenticodeSignature -LiteralPath $uiaStage
-        if ($uiaSignature.Status -ne 'Valid') {
-            throw "qwen-cua-driver-uia.exe has invalid Authenticode status $($uiaSignature.Status)"
-        }
-        if (Test-Path -LiteralPath $uiaSecurePath) {
-            $installedSignature = Get-AuthenticodeSignature -LiteralPath $uiaSecurePath
-            if ($installedSignature.Status -ne 'Valid') {
-                throw "installed qwen-cua-driver-uia.exe has invalid Authenticode status $($installedSignature.Status)"
+        if (-not $requiresSignedUia) {
+            foreach ($legacyUiaName in @('qwen-cua-driver-uia.exe', 'cua-driver-uia.exe')) {
+                $legacyUiaStage = Join-Path $stageDir $legacyUiaName
+                if (Test-Path -LiteralPath $legacyUiaStage) {
+                    Copy-Item -LiteralPath $legacyUiaStage -Destination (Join-Path $versionedDir $legacyUiaName) -Force
+                    Write-Step "installed $versionedDir\$legacyUiaName (legacy uiAccess worker)"
+                    break
+                }
             }
-            Write-Step "signed uiAccess worker already installed at $uiaSecurePath"
         }
-        else {
-            New-Item -ItemType Directory -Force -Path $uiaSecureDir | Out-Null
-            Copy-Item -LiteralPath $uiaStage -Destination $uiaSecurePath
-            Write-Step "installed $uiaSecurePath (signed uiAccess worker)"
+        if ($requiresSignedUia) {
+            # The UIAccess worker is required for foreground acquisition and
+            # input delivery. Windows only grants uiAccess to a signed binary
+            # installed under a secure system path.
+            $uiaStage = Join-Path $stageDir 'qwen-cua-driver-uia.exe'
+            if (-not (Test-Path -LiteralPath $uiaStage)) {
+                throw "release archive is missing required qwen-cua-driver-uia.exe"
+            }
+            $uiaSignature = Get-AuthenticodeSignature -LiteralPath $uiaStage
+            if ($uiaSignature.Status -ne 'Valid') {
+                throw "qwen-cua-driver-uia.exe has invalid Authenticode status $($uiaSignature.Status)"
+            }
+            if (Test-Path -LiteralPath $uiaSecurePath) {
+                $installedSignature = Get-AuthenticodeSignature -LiteralPath $uiaSecurePath
+                if ($installedSignature.Status -ne 'Valid') {
+                    throw "installed qwen-cua-driver-uia.exe has invalid Authenticode status $($installedSignature.Status)"
+                }
+                Write-Step "signed uiAccess worker already installed at $uiaSecurePath"
+            }
+            else {
+                New-Item -ItemType Directory -Force -Path $uiaSecureDir | Out-Null
+                Copy-Item -LiteralPath $uiaStage -Destination $uiaSecurePath
+                Write-Step "installed $uiaSecurePath (signed uiAccess worker)"
+            }
         }
     }
     finally {

--- a/scripts/tests/cua-driver-release-workflow.test.js
+++ b/scripts/tests/cua-driver-release-workflow.test.js
@@ -54,4 +54,25 @@ describe('CUA SDK release workflow', () => {
       /^\$Script:CuaDriverRsBakedVersion = "[^"\n]+"$/mu,
     );
   });
+
+  it('keeps historical Windows UIAccess assets installable', () => {
+    expect(powershellInstaller).toContain(
+      '$SignedUiaRequiredFrom = [version]"0.20.3"',
+    );
+    expect(powershellInstaller).toContain(
+      '$LegacyUiaRequiredFrom = [version]"0.2.8"',
+    );
+    expect(powershellInstaller).toMatch(
+      /\$requiresSignedUia = \[version\]\$version -ge \$SignedUiaRequiredFrom/,
+    );
+    expect(powershellInstaller).toMatch(
+      /elseif \(\$requiresLegacyUia\) \{[\s\S]*?cua-driver-uia\.exe/,
+    );
+    expect(powershellInstaller).toContain(
+      "@('qwen-cua-driver-uia.exe', 'cua-driver-uia.exe')",
+    );
+    expect(powershellInstaller).toMatch(
+      /if \(\$requiresSignedUia\) \{[\s\S]*?release archive is missing required qwen-cua-driver-uia\.exe[\s\S]*?Get-AuthenticodeSignature/,
+    );
+  });
 });


### PR DESCRIPTION
## What this PR does

Restores the mutable Windows installer’s compatibility with historical CUA Driver releases. Versions that predate the signed UIAccess contract accept either historical worker filename in the per-version install directory, while releases from 0.20.3 onward retain the existing signed-worker and secure-path requirements. Re-running the installer also repairs the partial state left by the regression, where the main executable had already been copied before worker validation failed.

## Why it's needed

The 0.20.3 UIAccess hardening made the current installer unconditionally require `qwen-cua-driver-uia.exe`. Published 0.7.0–0.7.3 Windows archives instead contain `cua-driver-uia.exe`, so every explicit 0.7.x pin failed after extraction. Because the installer is intentionally mutable and supports exact historical version pins, its asset contract must follow the selected release rather than only the latest release layout.

## Reviewer Test Plan

### How to verify

Run `npx vitest run --config ./scripts/tests/vitest.config.ts ./scripts/tests/cua-driver-release-workflow.test.js` and `uv run --with pytest python -m pytest packages/cua-driver/scripts/tests/test_install_version_fallback.py -q`. The focused workflow suite should report 6/6 passing, and the installer fallback suite should report 33 passing with 5 PowerShell-dependent tests skipped on a host without PowerShell. The independent reproduction additionally downloads the real 0.7.0, 0.7.1, 0.7.2, and 0.7.3 Windows x86_64 release archives and confirms both fresh-install compatibility and repair of the prior partial-install state. On Windows, reviewers can pin one of those versions with `$env:CUA_DRIVER_RS_VERSION='0.7.3'` and run this branch's installer; the selected historical version should install without requiring the 0.20.3 worker name or Authenticode contract.

### Evidence (Before & After)

Before: all four published 0.7.x Windows x86_64 archives fail the current installer contract because they contain `cua-driver-uia.exe` instead of the unconditionally required `qwen-cua-driver-uia.exe`. After: all four real archive layouts satisfy the version-aware contract, and a rerun repairs the main-binary-only state left by the previous failure. N/A for screenshots because this is a non-UI installer fix.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS test-script validation against the current installer and actual GitHub Release archives; full repository `npm run build` and `npm run bundle` also pass. The available Windows test endpoints were unreachable, so no Windows PowerShell E2E is claimed.

## Risk & Scope

- Main risk or tradeoff: compatibility is selected by explicit release boundaries: the historical worker begins at 0.2.8, and the signed secure-path contract begins at 0.20.3.
- Not validated / out of scope: Windows PowerShell E2E was unavailable. The existing 0.20.3+ signature policy and release signing state are intentionally unchanged; the currently published 0.20.3 worker has no embedded PE certificate and remains rejected by that existing strict gate.
- Breaking changes / migration notes: None. The 0.20.3+ strict path is preserved.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

恢复可变 Windows 安装脚本对历史 CUA Driver 版本的兼容。对于早于签名 UIAccess 契约的版本，允许在版本安装目录中使用任一历史 worker 文件名；从 0.20.3 开始的版本仍保留现有的签名 worker 和安全路径要求。重新运行安装脚本时，还会修复该回归留下的半安装状态：此前主程序已经复制，但随后 worker 校验失败。

## 为什么需要

0.20.3 的 UIAccess 加固让当前安装脚本无条件要求 `qwen-cua-driver-uia.exe`。已发布的 0.7.0–0.7.3 Windows 压缩包实际包含的是 `cua-driver-uia.exe`，因此所有显式指定的 0.7.x 版本都会在解压后失败。该安装脚本本身是可变的，并支持精确指定历史版本，所以它的资产契约必须跟随所选择的 release，而不能只符合最新 release 的布局。

## Reviewer 测试计划

### 如何验证

运行 `npx vitest run --config ./scripts/tests/vitest.config.ts ./scripts/tests/cua-driver-release-workflow.test.js` 和 `uv run --with pytest python -m pytest packages/cua-driver/scripts/tests/test_install_version_fallback.py -q`。聚焦 workflow 测试应为 6/6 通过；在没有 PowerShell 的主机上，安装脚本 fallback 测试应为 33 个通过、5 个依赖 PowerShell 的测试跳过。独立复现还下载了真实的 0.7.0、0.7.1、0.7.2、0.7.3 Windows x86_64 release 压缩包，并确认首次安装兼容性以及对旧回归所留半安装状态的修复。在 Windows 上，Reviewer 可以通过 `$env:CUA_DRIVER_RS_VERSION='0.7.3'` 指定其中一个版本并运行本分支安装脚本；该历史版本应能安装，且不要求 0.20.3 的 worker 文件名或 Authenticode 契约。

### 修复前后证据

修复前：四个已发布的 0.7.x Windows x86_64 压缩包都无法满足当前安装脚本契约，因为它们包含 `cua-driver-uia.exe`，而脚本无条件要求 `qwen-cua-driver-uia.exe`。修复后：四个真实压缩包布局均满足按版本区分的契约，重新运行脚本也能修复此前仅留下主程序的状态。该改动不是 UI 改动，因此截图不适用。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  | N/A  |

### 环境（可选）

在 macOS 上使用当前安装脚本和真实 GitHub Release 压缩包进行了 test-script 验证；完整仓库的 `npm run build` 和 `npm run bundle` 也通过。现有 Windows 测试端点不可达，因此不宣称已完成 Windows PowerShell E2E。

## 风险和范围

- 主要风险或权衡：兼容策略依赖明确的 release 版本边界；历史 worker 从 0.2.8 开始，签名安全路径契约从 0.20.3 开始。
- 未验证或不在范围内：无法进行 Windows PowerShell E2E。现有 0.20.3+ 签名策略和 release 签名状态保持不变；当前公开的 0.20.3 worker 没有嵌入 PE 证书，仍会被该现有严格门禁拒绝。
- 破坏性变更或迁移说明：无。0.20.3+ 的严格路径保持不变。

## 关联 Issue

无。

</details>
