### PR TITLE
fix(core): craft the hard-link tar fixture instead of packing it

### DIFF
--- a/packages/core/src/extension/archive-safety.test.ts
+++ b/packages/core/src/extension/archive-safety.test.ts
@@ -716,22 +716,31 @@ describe('assertTarArchiveLinksAreSafe', () => {
       },
     );
 
-    it.runIf(process.platform !== 'win32')(
-      'rejects a hard link even when it points inside the archive root',
-      async () => {
-        await fs.writeFile(path.join(root, 'original.txt'), 'y\n');
-        await fs.link(
-          path.join(root, 'original.txt'),
-          path.join(root, 'hard.txt'),
-        );
-        const archive = path.join(root, 'hard.tar');
-        await tar.c({ cwd: root, file: archive }, ['original.txt', 'hard.txt']);
+    // Crafted rather than packed with `tar.c`, and deliberately so: a hard
+    // link is the one fixture that drives tar's PENDINGLINKS path, where
+    // [JOBDONE] re-processes the pending job and re-enters [PROCESS]. Under
+    // CPU contention that second pass can reach the finalization branch after
+    // the pack already ended, and minipass throws `Error: write after end`
+    // from a stream nothing awaits. It escapes as an uncaught exception, and
+    // `dangerouslyIgnoreUnhandledErrors` is false on Linux, so the whole
+    // suite exits non-zero with every test still green — a release failure
+    // whose log contains no FAIL line (release run 33576013293: 211 files,
+    // 9480 tests passed, exit 1). Locally it reproduced 3 times in 28 runs
+    // with the cores saturated. The bytes below are exactly what tar writes
+    // for a hard link (typeflag '1', linkname pointing at the original), so
+    // the scanner is still being handed a real-world archive shape; it just
+    // is not produced by a pack this test would have to outlive.
+    it('rejects a hard link even when it points inside the archive root', async () => {
+      const archive = path.join(root, 'hard.tar');
+      await writeCraftedTar(archive, [
+        createTarFileHeader('original.txt', 0),
+        createTarFileHeader('hard.txt', 0, '1', 'original.txt'),
+      ]);
 
-        await expect(
-          assertTarArchiveLinksAreSafe(archive, undefined, allowLinks),
-        ).rejects.toThrow('unsupported link entry');
-      },
-    );
+      await expect(
+        assertTarArchiveLinksAreSafe(archive, undefined, allowLinks),
+      ).rejects.toThrow('unsupported link entry');
+    });
 
     it.runIf(process.platform !== 'win32')(
       'still rejects a contained symlink when the option is off',


### PR DESCRIPTION
## What this PR does

Builds the hard-link fixture in `archive-safety.test.ts` from crafted tar bytes instead of packing a real hard link with `tar.c`. One test changes; nothing in `src/` moves.

## Why it's needed

Release run 33576013293 (nightly `77d41f48d3`) failed with **211 test files and 9480 tests passing** and the job still exiting 1:

```
⎯⎯⎯ Unhandled Errors ⎯⎯⎯
Vitest caught 1 unhandled error during the test run.
Error: write after end
 ❯ wt.write        node_modules/tar/node_modules/minipass/src/index.ts:547:26
 ❯ wt.[process]    node_modules/tar/src/pack.ts:352:15
 ❯ wt.[jobDone]    node_modules/tar/src/pack.ts:378:17
 ❯ de.<anonymous>  node_modules/tar/src/pack.ts:464:38
This error originated in "src/extension/archive-safety.test.ts"
The latest test that might've caused the error is "rejects a hard link even when it points inside the archive root"
```

`packages/core/vitest.config.ts` sets `dangerouslyIgnoreUnhandledErrors: process.platform !== 'linux'`, so on Linux CI an unhandled error fails the run even when every test passed — and on macOS it is ignored, which is why this never shows up locally. The failure carries no `FAIL` line anywhere in the log, so from the release notification it is indistinguishable from a test failure.

The mechanism is in tar's pack queue. `[PROCESS]` finalizes the archive when the queue drains:

```js
if (this[ENDED] && this[QUEUE].length === 0 && this[JOBS] === 0) {
  if (this.zip) this.zip.end(EOF);
  else { super.write(EOF); super.end(); }   // minipass ends here
}
```

and `[JOBDONE]` has a path that only hard links reach:

```js
if (stat && stat.isFile() && stat.nlink > 1) {
  const pending = this[PENDINGLINKS].get(key);
  if (pending) { for (const job of pending) { job.pending = false; this[PROCESSJOB](job); } }
}
this[PROCESS]();
```

Packing a hard link therefore drives an extra `[JOBDONE]` → `[PROCESS]` pass, and when that pass reaches the finalization branch after the pack already ended, minipass throws `write after end` from a stream nothing awaits. It surfaces as an uncaught exception rather than a rejected promise, so `await tar.c(...)` cannot catch it.

This fixture is the only place in the repo that packs a hard link — the other `fs.link` callers (`session-writer-lease`, `loop-task-file`, `conversation-runtime-ownership`) never hand the link to tar, and the symlink fixtures here and in `github.test.ts` do not take the `PENDINGLINKS` path.

The scanner is still handed a real-world archive shape. Packing `['original.txt', 'hard.txt']` with tar 7.5.19 and dumping the headers gives:

```
{"offset":0,   "name":"original.txt", "typeflag":"0", "linkname":""}
{"offset":512, "name":"hard.txt",     "typeflag":"1", "linkname":"original.txt"}
```

which is byte-for-byte what `createTarFileHeader('hard.txt', 0, '1', 'original.txt')` produces. The test also no longer needs `fs.link`, so its `it.runIf(process.platform !== 'win32')` guard is gone and it now runs on Windows too.

## Reviewer Test Plan

### How to verify

The race only appears under CPU contention, which is why the release runners hit it and a laptop does not. To reproduce and to check the fix, saturate the cores and repeat the file:

```bash
for c in 1 2 3 4 5 6; do ( while :; do :; done ) & done
for i in $(seq 1 16); do
  npx vitest run --root packages/core src/extension/archive-safety.test.ts 2>&1 | grep -a "write after end"
done
kill %1 %2 %3 %4 %5 %6
```

On the parent commit this prints `Error: write after end` every few runs; on this branch it does not.

### Evidence (Before & After)

| | runs with cores saturated | runs that hit `write after end` |
| --- | --- | --- |
| parent commit | 28 | **3** (≈ 10.7%) |
| this branch | 32 | **0** |

Both reproductions attributed the error to the same test the CI failure named. On an idle machine the parent commit survived 30 runs without a hit, which is why this had to be chased with the cores pinned.

`npx vitest run --root packages/core src/extension/archive-safety.test.ts` — 36 passed, unchanged from the parent commit.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

Linux, 4 cores, run through a vitest config that skips the workspace build preflight (this box cannot build the whole workspace); the test file itself imports only `./archive-safety.js` and `tar`, so nothing in the run depends on `dist/`.

## Risk & Scope

- Main risk or tradeoff: the fixture is now crafted bytes rather than tar's own output, so if tar ever changed how it encodes a hard link this test would keep asserting the old shape. The header dump above pins what tar 7.5.19 writes, and the surrounding tests still exercise `tar.c` for every non-hard-link case.
- Not validated / out of scope: the same `write after end` shape could in principle come from another pack under contention; only the hard-link path is addressed here, because that is the one both the CI failure and the local reproduction pointed at. A release job that exits non-zero with no failing test is still reported as an ordinary quality failure — making that legible is a separate change.
- Breaking changes / migration notes: none.

## Linked Issues

Context: #10755 (the release failure this came from). The `quality` bucket has other, unrelated causes.

<details>
<summary>中文说明</summary>

## 此 PR 的作用

把 `archive-safety.test.ts` 里的硬链接 fixture 改成直接构造 tar 字节，而不是用 `tar.c` 打包一个真实硬链接。只改一个用例，`src/` 下没有任何改动。

## 为什么需要

release run 33576013293（nightly `77d41f48d3`）失败时，**211 个测试文件、9480 个用例全部通过**，job 仍然以 1 退出：

```
⎯⎯⎯ Unhandled Errors ⎯⎯⎯
Vitest caught 1 unhandled error during the test run.
Error: write after end
 ❯ wt.write        node_modules/tar/node_modules/minipass/src/index.ts:547:26
 ❯ wt.[process]    node_modules/tar/src/pack.ts:352:15
 ❯ wt.[jobDone]    node_modules/tar/src/pack.ts:378:17
 ❯ de.<anonymous>  node_modules/tar/src/pack.ts:464:38
This error originated in "src/extension/archive-safety.test.ts"
The latest test that might've caused the error is "rejects a hard link even when it points inside the archive root"
```

`packages/core/vitest.config.ts` 里 `dangerouslyIgnoreUnhandledErrors: process.platform !== 'linux'`，所以在 Linux CI 上，即使所有用例都通过，一个未捕获错误也会让整个运行失败；而 macOS 上它被忽略，这就是本地永远看不到它的原因。这种失败在日志里**没有任何 `FAIL` 行**，从发布通知上看与普通测试失败无法区分。

成因在 tar 的打包队列。`[PROCESS]` 在队列排空时收尾：

```js
if (this[ENDED] && this[QUEUE].length === 0 && this[JOBS] === 0) {
  if (this.zip) this.zip.end(EOF);
  else { super.write(EOF); super.end(); }   // minipass 在此 end
}
```

而 `[JOBDONE]` 里有一条只有硬链接会走的路径：

```js
if (stat && stat.isFile() && stat.nlink > 1) {
  const pending = this[PENDINGLINKS].get(key);
  if (pending) { for (const job of pending) { job.pending = false; this[PROCESSJOB](job); } }
}
this[PROCESS]();
```

打包硬链接因此会多触发一轮 `[JOBDONE]` → `[PROCESS]`；当这一轮在 pack 已经 end 之后到达收尾分支时，minipass 就从一个无人 await 的流里抛出 `write after end`。它以未捕获异常的形式冒出来，而不是 rejected promise，所以 `await tar.c(...)` 根本抓不住。

这个 fixture 是仓库里**唯一**打包硬链接的地方——其他 `fs.link` 调用方（`session-writer-lease`、`loop-task-file`、`conversation-runtime-ownership`）都不会把链接交给 tar，而这里和 `github.test.ts` 中的符号链接 fixture 不走 `PENDINGLINKS` 路径。

扫描器拿到的仍然是真实世界的归档形态。用 tar 7.5.19 打包 `['original.txt', 'hard.txt']` 并 dump 头部得到：

```
{"offset":0,   "name":"original.txt", "typeflag":"0", "linkname":""}
{"offset":512, "name":"hard.txt",     "typeflag":"1", "linkname":"original.txt"}
```

与 `createTarFileHeader('hard.txt', 0, '1', 'original.txt')` 生成的字节完全一致。该用例也不再需要 `fs.link`，因此去掉了 `it.runIf(process.platform !== 'win32')` 限制，现在在 Windows 上也会运行。

## 审阅者测试计划

### 如何验证

这个 race 只在 CPU 争抢下出现，这正是发布 runner 会中而本机不会中的原因。复现与验证方式是把核心跑满并重复执行：

```bash
for c in 1 2 3 4 5 6; do ( while :; do :; done ) & done
for i in $(seq 1 16); do
  npx vitest run --root packages/core src/extension/archive-safety.test.ts 2>&1 | grep -a "write after end"
done
kill %1 %2 %3 %4 %5 %6
```

在父提交上每几次就会打印一次 `Error: write after end`；在本分支上不会。

### 证据（前后对比）

| | 满载重跑次数 | 命中 `write after end` |
| --- | --- | --- |
| 父提交 | 28 | **3**（约 10.7%） |
| 本分支 | 32 | **0** |

两次本地复现归因到的用例与 CI 失败指认的完全相同。在空闲机器上，父提交连跑 30 次都没有命中，所以必须把核心占满才能追到它。

`npx vitest run --root packages/core src/extension/archive-safety.test.ts` —— 36 passed，与父提交一致。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ✅ 已测试 |

### 环境（可选）

Linux，4 核；通过一个跳过 workspace 构建前置检查的 vitest 配置运行（这台机器无法构建整个 workspace）。该测试文件本身只 import `./archive-safety.js` 和 `tar`，运行过程不依赖 `dist/`。

## 风险与范围

- 主要风险 / 取舍：fixture 现在是构造出来的字节而非 tar 自身的输出，因此若 tar 将来改变硬链接的编码方式，这个测试会继续断言旧形态。上面的头部 dump 固定了 tar 7.5.19 的写法，且周边用例对所有非硬链接场景仍然使用 `tar.c`。
- 未验证 / 不在范围内：同样的 `write after end` 形态原则上也可能来自争抢下的其他打包；此处只处理硬链接路径，因为 CI 失败与本地复现共同指向的就是它。另外，"job 非零退出但没有任何用例失败"目前仍被当作普通 quality 失败上报，让这类情况可读是另一个改动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

背景：#10755（本 PR 起因的那次发布失败）。`quality` 这一类还有其他无关成因。

</details>
