### PR TITLE
fix(ci): stop stable releases from disabling per-workspace test retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -523,10 +523,19 @@ jobs:
           VITEST_MIN_THREADS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
           VITEST_MAX_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && (vars.QWEN_CI_VITEST_MAX_WORKERS || '4') || '' }}"
           VITEST_MIN_FORKS: "${{ startsWith(runner.name, 'ecs-qwen-') && '1' || '' }}"
-          # Nightly and preview releases may absorb a transient timing failure;
-          # stable releases remain strict and never retry a failed test.
-          VITEST_RETRY: "${{ (needs.prepare.outputs.is_nightly == 'true' || needs.prepare.outputs.is_preview == 'true') && '2' || '0' }}"
-        run: 'npm run test:release:workspaces -- --shard=${{ matrix.shard }}/3 --passWithNoTests --retry="${VITEST_RETRY}"'
+          # Nightly and preview releases may absorb a transient timing
+          # failure. Stable releases add no retry of their own and stay on
+          # whatever each workspace's Vitest config asks for; the flag is
+          # omitted rather than set to 0, because a command-line --retry=0
+          # outranks the config and would disable a workspace's deliberate
+          # retry (packages/sdk-typescript) on the release lane alone.
+          VITEST_RETRY: "${{ (needs.prepare.outputs.is_nightly == 'true' || needs.prepare.outputs.is_preview == 'true') && '2' || '' }}"
+        run: |-
+          retry_arg=()
+          if [ -n "${VITEST_RETRY}" ]; then
+            retry_arg=("--retry=${VITEST_RETRY}")
+          fi
+          npm run test:release:workspaces -- --shard=${{ matrix.shard }}/3 --passWithNoTests "${retry_arg[@]}"
 
   quality_scripts:
     name: 'Quality Checks (Scripts)'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: 'Mark stale issues and pull requests'
 
 # Run as a daily cron at 00:30 UTC (Beijing time 08:30).
-# Avoid the top of the hour to dodge GitHub's high-contention window,
-# and stay 30 minutes after release.yml (00:00 UTC) to reduce overlap.
+# Avoid the top of the hour to dodge GitHub's high-contention window.
+# This no longer trails the nightly release, which moved to 21:00 UTC.
 on:
   schedule:
     - cron: '30 0 * * *'

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -537,11 +537,11 @@ describe('release workflow', () => {
     const testStep = job.steps.find(
       (step) => step.name === 'Run Workspace Tests',
     );
-    expect(testStep.run).toBe(
-      'npm run test:release:workspaces -- --shard=${{ matrix.shard }}/3 --passWithNoTests --retry="${VITEST_RETRY}"',
+    expect(testStep.run).toContain(
+      'npm run test:release:workspaces -- --shard=${{ matrix.shard }}/3 --passWithNoTests "${retry_arg[@]}"',
     );
     expect(testStep.env.VITEST_RETRY).toBe(
-      "${{ (needs.prepare.outputs.is_nightly == 'true' || needs.prepare.outputs.is_preview == 'true') && '2' || '0' }}",
+      "${{ (needs.prepare.outputs.is_nightly == 'true' || needs.prepare.outputs.is_preview == 'true') && '2' || '' }}",
     );
 
     const workspacePackages = getTestCiWorkspaces();
@@ -556,6 +556,58 @@ describe('release workflow', () => {
         packageJson.scripts['test:ci'].split('&&').pop()?.trim(),
         path,
       ).toMatch(/^vitest run(?:\s|$)/);
+    }
+  });
+
+  it('passes --retry only when the release schedule asks for one', () => {
+    // The flag reaches every workspace's vitest, where a command line option
+    // outranks the config. Passing --retry=0 on stable releases would switch
+    // off a workspace's own retry (packages/sdk-typescript) on this lane
+    // alone, so the stable path must omit the flag rather than zero it.
+    const testStep = releaseYaml.jobs.workspace_tests.steps.find(
+      (step) => step.name === 'Run Workspace Tests',
+    );
+    const script = testStep.run.replaceAll('${{ matrix.shard }}', '1');
+
+    for (const [retry, expected] of [
+      ['2', '--retry=2'],
+      ['', null],
+    ]) {
+      const dir = mkdtempSync(join(tmpdir(), 'release-retry-'));
+      try {
+        const stub = join(dir, 'npm');
+        writeFileSync(stub, '#!/bin/sh\nprintf "%s\\n" "$@"\n');
+        chmodSync(stub, 0o755);
+
+        const result = spawnSync(
+          'bash',
+          ['-e', '-o', 'pipefail', '-c', script],
+          {
+            env: {
+              ...process.env,
+              PATH: `${dir}:${process.env['PATH']}`,
+              VITEST_RETRY: retry,
+            },
+            encoding: 'utf8',
+          },
+        );
+
+        expect(result.status, result.stderr).toBe(0);
+        const args = result.stdout.trim().split('\n');
+        expect(args, retry).toContain('--passWithNoTests');
+        // An empty positional would reach vitest as a test-name filter.
+        expect(args, retry).not.toContain('');
+        if (expected) {
+          expect(args, retry).toContain(expected);
+        } else {
+          expect(
+            args.some((arg) => arg.startsWith('--retry')),
+            retry,
+          ).toBe(false);
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     }
   });
 

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -576,7 +576,7 @@ describe('release workflow', () => {
       const dir = mkdtempSync(join(tmpdir(), 'release-retry-'));
       try {
         const stub = join(dir, 'npm');
-        writeFileSync(stub, '#!/bin/sh\nprintf "%s\\n" "$@"\n');
+        writeFileSync(stub, '#!/bin/sh\nprintf "%s\\0" "$@"\n');
         chmodSync(stub, 0o755);
 
         const result = spawnSync(
@@ -593,7 +593,8 @@ describe('release workflow', () => {
         );
 
         expect(result.status, result.stderr).toBe(0);
-        const args = result.stdout.trim().split('\n');
+        const args = result.stdout.split('\0');
+        expect(args.pop()).toBe('');
         expect(args, retry).toContain('--passWithNoTests');
         // An empty positional would reach vitest as a test-name filter.
         expect(args, retry).not.toContain('');


### PR DESCRIPTION
## What this PR does

The release workspace shards stop passing `--retry=0` on stable releases. The flag is now omitted entirely there, and still set to 2 for nightly and preview runs. A behavioral test executes the step's script with each schedule's value and asserts which arguments reach the test runner.

Also refreshes the comment at the top of the stale-issues workflow, which still justified its 00:30 UTC schedule as trailing a nightly release that no longer runs at 00:00 UTC.

## Why it's needed

A command line `--retry` outranks a workspace's own Vitest configuration. The SDK package deliberately configures two retries for itself, and every lane honours that except the stable release lane, which was explicitly zeroing it. That made stable releases stricter than the pull request CI they were validated against: a flake the repository has already decided to absorb could block a real release. Nightly and preview keep the deliberate two retries added for shared-host timing noise.

The stale workflow comment is only documentation, but it now asserts a relationship that no longer exists, and the next person tuning either cron would reason from it.

## Reviewer Test Plan

### How to verify

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/release-workflow.test.js` passes, 45 tests with one skip.
- The new case is mutation-verified: restoring the previous shape (`--retry="${VITEST_RETRY}"` with `0` on the stable branch) turns it and the shard pin red.
- Reading the workflow: nightly and preview still resolve the retry value to 2; stable resolves to empty and the argument never appears.

### Evidence (Before & After)

N/A (CI configuration). Before, a stable release ran the SDK package as `vitest run --retry=0`. After, it runs `vitest run` and the package's own `retry: 2` applies, as it already does everywhere else.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: stable releases now inherit whatever retry each workspace configures. Only the SDK package configures one today, at two retries, and that is the value its own CI has always used.
- Not validated / out of scope: the single-host release routing from #10765 is unchanged here. A separate concern from that review, that a host outage can let one scheduled release cancel another without opening a failure issue, is not addressed by this PR.
- Breaking changes / migration notes: none.

## Linked Issues

Follows up on #10765.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

release 的 workspace 分片不再在稳定版发布时传 `--retry=0`，该场景下完全不传这个参数；nightly 和 preview 仍然是 2。新增一个行为测试，用各个发布场景对应的值执行该步骤的脚本，断言最终传给测试运行器的参数。

同时更新 stale workflow 顶部的注释，它仍然以"排在 00:00 UTC 的 nightly 发布之后"来解释自己的 00:30 UTC 排程，而 nightly 已经不在那个时间了。

## 为什么需要

命令行的 `--retry` 优先级高于各 workspace 自己的 Vitest 配置。SDK 包有意为自己配置了两次重试，除稳定版发布通道外的所有通道都遵循它，而稳定版通道显式把它清零。这让稳定版发布比它所验证的 PR CI 更严格：一个仓库已经决定容忍的抖动会卡住真正的发布。nightly 和 preview 保留为共享机器时间抖动而加的两次重试。

stale workflow 的注释只是文档，但它现在断言了一个不存在的关系，下一个调整任一 cron 的人会据此做出错误推断。

## 评审验证方案

### 如何验证

- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/release-workflow.test.js` 通过，45 个用例，1 个跳过。
- 新用例经过变异验证：把之前的写法（稳定分支为 `0` 的 `--retry="${VITEST_RETRY}"`）改回去，该用例和分片固定断言都会变红。
- 阅读 workflow：nightly 和 preview 的重试值仍解析为 2；稳定版解析为空，参数不会出现。

### 前后证据

N/A（CI 配置）。之前稳定版发布以 `vitest run --retry=0` 运行 SDK 包。之后运行 `vitest run`，该包自己的 `retry: 2` 生效，与其他所有地方一致。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

## 风险与范围

- 主要风险或取舍：稳定版发布现在继承各 workspace 配置的重试次数。目前只有 SDK 包配置了，为两次，而这正是它自身 CI 一直使用的值。
- 未验证 / 不在范围内：#10765 的单机路由未做改动。该次评审中另一个问题（机器故障时一次定时发布可能取消另一次且不开失败 issue）本 PR 不涉及。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

跟进 #10765。

</details>

https://claude.ai/code/session_01AWWgJEqafyAT1Mc75T8N7h
