### PR TITLE
fix(cli): align OpenTUI output-style behavior

### DIFF
--- a/packages/cli/src/ui/opentui/commands-dispatch.test.ts
+++ b/packages/cli/src/ui/opentui/commands-dispatch.test.ts
@@ -297,6 +297,31 @@ describe('guards (ink handleSlashCommand parity)', () => {
       sentToModel: false,
     });
   });
+
+  it('hides only the bare /output-style invocation', async () => {
+    const commands = [
+      stub({
+        name: 'output-style',
+        action: (_context, args) =>
+          args
+            ? { type: 'message', messageType: 'info', content: args }
+            : { type: 'dialog', dialog: 'output-style' },
+      }),
+    ];
+
+    const { host: bareHost } = await dispatch('/output-style', commands);
+    expect(bareHost.items.some((item) => item.type === 'user')).toBe(false);
+
+    const { host: namedHost } = await dispatch(
+      '/output-style Concise',
+      commands,
+    );
+    expect(namedHost.items[0]).toMatchObject({
+      type: 'user',
+      text: '/output-style Concise',
+      sentToModel: false,
+    });
+  });
 });
 
 describe('shouldHideSlashCommandInvocation (slashCommandProcessor parity)', () => {
@@ -331,6 +356,7 @@ describe('shouldHideSlashCommandInvocation (slashCommandProcessor parity)', () =
 
   it.each([
     ['effort', ''],
+    ['output-style', ''],
     ['statusline', ''],
     ['model', ''],
     ['model', '--fast'],
@@ -345,6 +371,7 @@ describe('shouldHideSlashCommandInvocation (slashCommandProcessor parity)', () =
     ['model', 'qwen-max'],
     ['model', '--fast qwen3-coder-flash'],
     ['effort', 'high'],
+    ['output-style', 'Concise'],
     ['statusline', 'show'],
   ])('keeps /%s %j (work-performing)', (root, args) => {
     expect(shouldHideSlashCommandInvocation(cmd(root), [root], args)).toBe(

--- a/packages/cli/src/ui/opentui/commands-dispatch.ts
+++ b/packages/cli/src/ui/opentui/commands-dispatch.ts
@@ -107,6 +107,7 @@ const SLASH_COMMAND_ROOTS_HIDE_INVOCATION = new Set([
 const BARE_SLASH_COMMANDS_HIDE_INVOCATION = new Set([
   'effort',
   'model',
+  'output-style',
   'statusline',
 ]);
 

--- a/packages/cli/src/ui/opentui/dialogs-modes.test.tsx
+++ b/packages/cli/src/ui/opentui/dialogs-modes.test.tsx
@@ -1,0 +1,299 @@
+/** @jsxImportSource @opentui/react */
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BUILT_IN_OUTPUT_STYLES,
+  type Config,
+  type OutputStyleDefinition,
+} from '@qwen-code/qwen-code-core';
+import { SettingScope, type LoadedSettings } from '../../config/settings.js';
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    inputHandlers: [] as Array<(sequence: string) => boolean>,
+    keyboardHandlers: [] as Array<(key: unknown) => void>,
+  };
+  const renderer = {
+    addInputHandler(handler: (sequence: string) => boolean) {
+      state.inputHandlers.push(handler);
+    },
+    removeInputHandler(handler: (sequence: string) => boolean) {
+      const index = state.inputHandlers.indexOf(handler);
+      if (index >= 0) state.inputHandlers.splice(index, 1);
+    },
+  };
+  async function buildJsxRuntime() {
+    const React = await import('react');
+    const jsx = (
+      type: unknown,
+      props: { children?: unknown; key?: React.Key } | null,
+      key?: React.Key,
+    ) => {
+      const config = key === undefined ? props : { ...props, key };
+      const children = (config?.children ?? null) as React.ReactNode;
+      if (type === 'box' || type === 'text') {
+        return React.createElement(
+          type === 'box' ? 'div' : 'span',
+          key === undefined ? null : { key },
+          children,
+        );
+      }
+      return React.createElement(
+        type as React.ElementType,
+        config as Record<string, unknown>,
+        children,
+      );
+    };
+    return { jsx, jsxs: jsx, jsxDEV: jsx, Fragment: React.Fragment };
+  }
+  return { state, renderer, buildJsxRuntime };
+});
+
+vi.mock('@opentui/react', () => ({
+  useKeyboard: (handler: (key: unknown) => void) => {
+    mocks.state.keyboardHandlers.push(handler);
+  },
+  useRenderer: () => mocks.renderer,
+}));
+vi.mock('@opentui/react/jsx-runtime', () => mocks.buildJsxRuntime());
+vi.mock('@opentui/react/jsx-dev-runtime', () => mocks.buildJsxRuntime());
+vi.mock('./key-map.js', () => ({
+  toOriginalKey: (key: { name?: string }) => ({ name: key.name ?? '' }),
+}));
+vi.mock('./theme.js', () => ({
+  C: new Proxy({}, { get: () => '#ffffff' }),
+}));
+
+import { OpenTuiOutputStyleDialog } from './dialogs-modes.js';
+
+const CONCISE = BUILT_IN_OUTPUT_STYLES.find(
+  (style) => style.name === 'Concise',
+);
+if (!CONCISE) throw new Error('missing Concise output style');
+
+function createHarness(
+  options: {
+    current?: OutputStyleDefinition;
+    systemPrompt?: string;
+    setValue?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
+  let current = options.current;
+  const setOutputStyle = vi.fn((style: OutputStyleDefinition | undefined) => {
+    current = style;
+  });
+  const refreshSystemInstruction = vi.fn().mockResolvedValue(undefined);
+  const setValue = options.setValue ?? vi.fn();
+  const config = {
+    getOutputStyle: () => current,
+    getSystemPrompt: () => options.systemPrompt,
+    getExperimentalZedIntegration: () => false,
+    getInputFormat: () => undefined,
+    isInteractive: () => true,
+    getBareMode: () => false,
+    isSafeMode: () => false,
+    setOutputStyle,
+    getLlmClient: () => ({ refreshSystemInstruction }),
+  } as unknown as Config;
+  const settings = {
+    isTrusted: true,
+    workspace: { settings: { general: {} } },
+    setValue,
+  } as unknown as LoadedSettings;
+  return {
+    config,
+    settings,
+    setOutputStyle,
+    refreshSystemInstruction,
+    setValue,
+  };
+}
+
+function press(name: string) {
+  const handler = mocks.state.keyboardHandlers.at(-1);
+  if (!handler) throw new Error('no keyboard handler registered');
+  act(() => handler({ name }));
+}
+
+async function pressEsc(): Promise<boolean> {
+  const handler = mocks.state.inputHandlers.at(-1);
+  if (!handler) throw new Error('no raw input handler registered');
+  let consumed = false;
+  await act(async () => {
+    consumed = handler('\x1b');
+  });
+  return consumed;
+}
+
+describe('OpenTuiOutputStyleDialog', () => {
+  beforeEach(() => {
+    mocks.state.inputHandlers.length = 0;
+    mocks.state.keyboardHandlers.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps the configured style selected while a system prompt override is active', async () => {
+    const harness = createHarness({
+      current: CONCISE,
+      systemPrompt: 'Replace the base prompt.',
+    });
+    const onClose = vi.fn();
+    const notify = vi.fn();
+    render(
+      <OpenTuiOutputStyleDialog
+        config={harness.config}
+        settings={harness.settings}
+        onClose={onClose}
+        notify={notify}
+      />,
+    );
+
+    expect(screen.getByText('Concise').parentElement?.textContent).toContain(
+      '● Concise',
+    );
+    press('return');
+
+    await waitFor(() =>
+      expect(harness.setOutputStyle).toHaveBeenCalledWith(CONCISE),
+    );
+    expect(harness.refreshSystemInstruction).toHaveBeenCalledTimes(1);
+    expect(harness.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'general.outputStyle',
+      'Concise',
+      undefined,
+      { throwOnWriteFailure: true },
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining('Output style set to Concise'),
+    );
+  });
+
+  it('moves from default to Concise and applies it on Enter', async () => {
+    const harness = createHarness();
+    render(
+      <OpenTuiOutputStyleDialog
+        config={harness.config}
+        settings={harness.settings}
+        onClose={vi.fn()}
+        notify={vi.fn()}
+      />,
+    );
+
+    press('down');
+    press('return');
+
+    await waitFor(() =>
+      expect(harness.setOutputStyle).toHaveBeenCalledWith(CONCISE),
+    );
+  });
+
+  it('keeps and applies the configured style while QWEN_SYSTEM_MD is active', async () => {
+    vi.stubEnv('QWEN_SYSTEM_MD', '/tmp/replacement-system.md');
+    const harness = createHarness({ current: CONCISE });
+    const notify = vi.fn();
+    render(
+      <OpenTuiOutputStyleDialog
+        config={harness.config}
+        settings={harness.settings}
+        onClose={vi.fn()}
+        notify={notify}
+      />,
+    );
+
+    expect(screen.getByText('Concise').parentElement?.textContent).toContain(
+      '● Concise',
+    );
+    press('return');
+
+    await waitFor(() =>
+      expect(harness.setOutputStyle).toHaveBeenCalledWith(CONCISE),
+    );
+    expect(harness.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'general.outputStyle',
+      'Concise',
+      undefined,
+      { throwOnWriteFailure: true },
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining('saved but has no effect in this session'),
+    );
+  });
+
+  it('clears the configured style only after default is selected', async () => {
+    const harness = createHarness({ current: CONCISE });
+    render(
+      <OpenTuiOutputStyleDialog
+        config={harness.config}
+        settings={harness.settings}
+        onClose={vi.fn()}
+        notify={vi.fn()}
+      />,
+    );
+
+    press('up');
+    press('return');
+
+    await waitFor(() =>
+      expect(harness.setOutputStyle).toHaveBeenCalledWith(undefined),
+    );
+    expect(harness.setValue).toHaveBeenCalledWith(
+      SettingScope.User,
+      'general.outputStyle',
+      'default',
+      undefined,
+      { throwOnWriteFailure: true },
+    );
+  });
+
+  it('closes on Esc without changing or persisting the style', async () => {
+    const harness = createHarness({ current: CONCISE });
+    const onClose = vi.fn();
+    render(
+      <OpenTuiOutputStyleDialog
+        config={harness.config}
+        settings={harness.settings}
+        onClose={onClose}
+        notify={vi.fn()}
+      />,
+    );
+
+    expect(await pressEsc()).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(harness.setOutputStyle).not.toHaveBeenCalled();
+    expect(harness.setValue).not.toHaveBeenCalled();
+  });
+
+  it('notifies when persistence fails', async () => {
+    const setValue = vi.fn(() => {
+      throw new Error('disk full');
+    });
+    const harness = createHarness({ current: CONCISE, setValue });
+    const notify = vi.fn();
+    render(
+      <OpenTuiOutputStyleDialog
+        config={harness.config}
+        settings={harness.settings}
+        onClose={vi.fn()}
+        notify={notify}
+      />,
+    );
+
+    press('return');
+
+    await waitFor(() => expect(notify).toHaveBeenCalledWith('disk full'));
+    expect(harness.setOutputStyle).not.toHaveBeenCalled();
+    expect(harness.refreshSystemInstruction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/ui/opentui/dialogs-modes.tsx
+++ b/packages/cli/src/ui/opentui/dialogs-modes.tsx
@@ -19,7 +19,6 @@ import {
   APPROVAL_MODES,
   BUILT_IN_OUTPUT_STYLES,
   REASONING_EFFORT_TIERS,
-  resolveMainSessionOutputStyle,
   type ApprovalMode,
   type OutputStyleDefinition,
   type ReasoningEffort,
@@ -256,7 +255,7 @@ export function OpenTuiOutputStyleDialog(props: {
   // Unlike /effort, "no style configured" genuinely is the first entry
   // (default), so pre-selecting index 0 in that case tells the truth (ink
   // OutputStyleDialog parity).
-  const current = resolveMainSessionOutputStyle(config)?.name;
+  const current = config.getOutputStyle()?.name;
   const [sel, setSel] = useState(
     Math.max(
       0,


### PR DESCRIPTION
## What this PR does

This aligns the OpenTUI `/output-style` experience with Ink by keeping the configured style selected even when a system-prompt override temporarily makes it ineffective. It also hides bare picker invocations from the transcript while keeping argument-bearing invocations visible, and adds direct component coverage for selection, navigation, Enter, Esc, persistence, runtime application, and persistence failures.

## Why it's needed

With `--system-prompt` or `QWEN_SYSTEM_MD` active, the picker previously derived its selection from the temporarily effective style. That made a configured style appear as `default`, so pressing Enter without moving could overwrite the saved selection. OpenTUI also echoed the bare picker command even though Ink suppresses it.

## Reviewer Test Plan

### How to verify

1. Configure the `Concise` output style, start OpenTUI with either `--system-prompt` or `QWEN_SYSTEM_MD`, and open `/output-style`. Confirm that `Concise` is selected and pressing Enter preserves `Concise` in settings while reporting that the override makes it ineffective for the current session.
2. Starting from `default`, move to `Concise` and press Enter. Confirm that the setting is persisted, applied to the running session, and the system instruction is refreshed. Move back to `default` and confirm that only this explicit selection clears the configured style.
3. Press Esc and confirm that the dialog closes without changing settings. Make the settings write fail and confirm that the error is surfaced without changing the running style.
4. Invoke bare `/output-style` and confirm that no user invocation is added to the transcript. Invoke `/output-style Concise` and confirm that the argument-bearing invocation remains visible.

### Evidence (Before & After)

| Scenario | Before | After |
| --- | --- | --- |
| Configured `Concise` with a system-prompt override | Picker highlighted `default`; pressing Enter could persist `default` | Picker highlights `Concise`; pressing Enter preserves `Concise` and explains that the override makes it ineffective for this session |
| Bare `/output-style` | Invocation appeared in the OpenTUI transcript | Invocation is hidden, matching Ink; argument-bearing invocations remain visible |

Native OpenTUI was exercised under Bun with an isolated settings directory: `Concise` remained selected and persisted while a system-prompt override was active. The focused regression suite passed 109 tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local validation used Node.js 25.9.0 for focused tests, lint, the full build, and typecheck, plus Bun 1.3.13 for native OpenTUI interaction.

## Risk & Scope

- Main risk or tradeoff: The change only affects the OpenTUI picker's initial selection and transcript bookkeeping for `/output-style`; direct component and dispatcher tests pin both behaviors.
- Not validated / out of scope: Windows and Linux interaction were not run locally. User- and project-defined style catalog integration remains owned by #10761 and should consume its precedence-resolved catalog when that work lands.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #10767.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 让 OpenTUI 的 `/output-style` 体验与 Ink 对齐：即使系统提示词覆盖暂时让已配置样式不生效，选择器仍会保持选中该配置。它还会从转写记录中隐藏只用于打开选择器的裸命令，同时保留带参数命令，并新增直接组件测试，覆盖初始选中、导航、Enter、Esc、持久化、运行时应用和持久化失败。

## 为什么需要

启用 `--system-prompt` 或 `QWEN_SYSTEM_MD` 时，选择器此前根据当前临时生效的样式推导选中项。这会让已配置样式显示成 `default`，因此用户不移动选项直接按 Enter 时可能覆盖已保存的选择。OpenTUI 还会回显裸选择器命令，而 Ink 会隐藏它。

## Reviewer 测试计划

### 如何验证

1. 配置 `Concise` 输出样式，使用 `--system-prompt` 或 `QWEN_SYSTEM_MD` 启动 OpenTUI，然后打开 `/output-style`。确认 `Concise` 已选中，按 Enter 后设置仍为 `Concise`，同时提示该覆盖使它在当前会话不生效。
2. 从 `default` 开始移动到 `Concise` 并按 Enter。确认设置被持久化、应用到当前会话并刷新系统指令。再移回 `default`，确认只有明确选择 `default` 才会清除已配置样式。
3. 按 Esc，确认对话框关闭且不修改设置。模拟设置写入失败，确认错误会展示且当前运行样式不会改变。
4. 调用裸 `/output-style`，确认转写记录中不会新增用户调用项。调用 `/output-style Concise`，确认带参数的调用仍然可见。

### 证据（Before 与 After）

| 场景 | Before | After |
| --- | --- | --- |
| 已配置 `Concise` 且系统提示词被覆盖 | 选择器高亮 `default`；按 Enter 可能持久化 `default` | 选择器高亮 `Concise`；按 Enter 保留 `Concise`，并解释覆盖使其在本会话不生效 |
| 裸 `/output-style` | 调用出现在 OpenTUI 转写记录中 | 调用被隐藏，与 Ink 一致；带参数调用仍然可见 |

在隔离设置目录下使用 Bun 执行了原生 OpenTUI 交互验证：系统提示词覆盖生效时，`Concise` 仍保持选中并持久化。聚焦回归测试共 109 个，全部通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

macOS 本地验证使用 Node.js 25.9.0 运行聚焦测试、lint、完整 build 和 typecheck，并使用 Bun 1.3.13 做原生 OpenTUI 交互验证。

## 风险与范围

- 主要风险或权衡：改动只影响 OpenTUI 选择器的初始选中状态以及 `/output-style` 的转写记录管理；直接组件测试和命令分发器测试固定了这两个行为。
- 未验证 / 不在范围内：未在本地运行 Windows 和 Linux 交互验证。用户和项目自定义样式目录集成仍由 #10761 负责；该工作合入时应消费其已按优先级解析的样式目录。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

修复 #10767。

</details>
