### PR TITLE
fix(ci): keep worker tests responsive under ECS contention

### DIFF
--- a/packages/core/src/agents/team/TeamManager.initial-result.test.ts
+++ b/packages/core/src/agents/team/TeamManager.initial-result.test.ts
@@ -17,6 +17,7 @@ import { TeamCoordinationHarness } from './test-utils/coordination-harness.js';
 import { Storage } from '../../config/storage.js';
 import { AgentStatus } from '../runtime/agent-types.js';
 import { AgentEventType } from '../runtime/agent-events.js';
+import { TeamEventType, type MessageSentEvent } from './team-events.js';
 
 vi.mock('../../config/storage.js', async (importOriginal) => {
   const original =
@@ -47,6 +48,33 @@ async function settleAsyncWork(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 50));
 }
 
+async function runUntilLeaderMessages(
+  h: TeamCoordinationHarness,
+  expectedCount: number,
+  action: () => Promise<unknown>,
+) {
+  const emitter = h.teamManager.getEventEmitter();
+  let observedCount = 0;
+  let resolveMessages!: () => void;
+  const messagesSent = new Promise<void>((resolve) => {
+    resolveMessages = resolve;
+  });
+  const onMessageSent = (event: MessageSentEvent) => {
+    if (event.to !== 'leader') return;
+    observedCount += 1;
+    if (observedCount === expectedCount) resolveMessages();
+  };
+  emitter.on(TeamEventType.MESSAGE_SENT, onMessageSent);
+
+  try {
+    await action();
+    await messagesSent;
+    return h.teamManager.getLeaderMessages();
+  } finally {
+    emitter.off(TeamEventType.MESSAGE_SENT, onMessageSent);
+  }
+}
+
 describe('initial teammate result before event bridge attachment (#10211)', () => {
   let harness: TeamCoordinationHarness | undefined;
 
@@ -69,28 +97,28 @@ describe('initial teammate result before event bridge attachment (#10211)', () =
     // TeamManager.setupEventBridge() subscribes. Emits the final round
     // text and settles IDLE while spawnAgent() is still resolving —
     // the in-process race from the issue.
-    await h.spawnTeammate('worker', {
-      onStart: (agent) => {
-        agent.setStatus(AgentStatus.RUNNING);
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 1,
-          text: 'initial result',
-          thoughtText: '',
-          timestamp: Date.now(),
-        });
-        agent.setStatus(AgentStatus.IDLE);
-      },
-    });
+    const messages = await runUntilLeaderMessages(h, 1, () =>
+      h.spawnTeammate('worker', {
+        onStart: (agent) => {
+          agent.setStatus(AgentStatus.RUNNING);
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 1,
+            text: 'initial result',
+            thoughtText: '',
+            timestamp: Date.now(),
+          });
+          agent.setStatus(AgentStatus.IDLE);
+        },
+      }),
+    );
 
-    await vi.waitFor(async () => {
-      expect(await h.teamManager.getLeaderMessages()).toEqual([
-        expect.objectContaining({
-          from: 'worker',
-          text: 'initial result',
-        }),
-      ]);
-    });
+    expect(messages).toEqual([
+      expect.objectContaining({
+        from: 'worker',
+        text: 'initial result',
+      }),
+    ]);
 
     // Exactly once: after coordination settles, no duplicate report
     // for the same round may arrive.
@@ -101,45 +129,44 @@ describe('initial teammate result before event bridge attachment (#10211)', () =
   it('does not re-report the initial result when a later round completes live', async () => {
     const h = await createHarness();
 
-    await h.spawnTeammate('worker', {
-      onStart: (agent) => {
-        agent.setStatus(AgentStatus.RUNNING);
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 1,
-          text: 'initial result',
-          thoughtText: '',
-          timestamp: Date.now(),
-        });
-        agent.setStatus(AgentStatus.IDLE);
-      },
-      onMessage: (_message, agent) => {
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 2,
-          text: 'follow-up result',
-          thoughtText: '',
-          timestamp: Date.now(),
-        });
-      },
-    });
+    const initialMessages = await runUntilLeaderMessages(h, 1, () =>
+      h.spawnTeammate('worker', {
+        onStart: (agent) => {
+          agent.setStatus(AgentStatus.RUNNING);
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 1,
+            text: 'initial result',
+            thoughtText: '',
+            timestamp: Date.now(),
+          });
+          agent.setStatus(AgentStatus.IDLE);
+        },
+        onMessage: (_message, agent) => {
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 2,
+            text: 'follow-up result',
+            thoughtText: '',
+            timestamp: Date.now(),
+          });
+        },
+      }),
+    );
 
-    await vi.waitFor(async () => {
-      expect(await h.teamManager.getLeaderMessages()).toEqual([
-        expect.objectContaining({ text: 'initial result' }),
-      ]);
-    });
+    expect(initialMessages).toEqual([
+      expect.objectContaining({ text: 'initial result' }),
+    ]);
 
-    await h.teamManager.sendMessage('worker', 'next task', 'leader');
-    await h.waitForStatus('worker', AgentStatus.IDLE);
+    const followUpMessages = await runUntilLeaderMessages(h, 1, () =>
+      h.teamManager.sendMessage('worker', 'next task', 'leader'),
+    );
 
     // The live second round reports its own text exactly once; the
     // pre-attach initial result must not be reported again.
-    await vi.waitFor(async () => {
-      expect(await h.teamManager.getLeaderMessages()).toEqual([
-        expect.objectContaining({ text: 'follow-up result' }),
-      ]);
-    });
+    expect(followUpMessages).toEqual([
+      expect.objectContaining({ text: 'follow-up result' }),
+    ]);
 
     await settleAsyncWork();
     expect(await h.teamManager.getLeaderMessages()).toEqual([]);
@@ -157,17 +184,16 @@ describe('initial teammate result before event bridge attachment (#10211)', () =
     expect(await h.teamManager.getLeaderMessages()).toEqual([]);
 
     // The live path still works afterwards.
-    await h.teamManager.sendMessage('worker', 'task', 'leader');
-    await h.waitForStatus('worker', AgentStatus.IDLE);
-    await vi.waitFor(async () => {
-      expect(await h.teamManager.getLeaderMessages()).toEqual([
-        expect.objectContaining({
-          text: expect.stringContaining(
-            'completed a turn without a model-visible final answer',
-          ),
-        }),
-      ]);
-    });
+    const messages = await runUntilLeaderMessages(h, 1, () =>
+      h.teamManager.sendMessage('worker', 'task', 'leader'),
+    );
+    expect(messages).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining(
+          'completed a turn without a model-visible final answer',
+        ),
+      }),
+    ]);
   });
 
   it('still reports the recovered result when the teammate sent an explicit leader message pre-attach', async () => {
@@ -180,27 +206,27 @@ describe('initial teammate result before event bridge attachment (#10211)', () =
     // clear that flag exactly like the live onRoundText handler does,
     // or the replayed IDLE settlement skips the recovered answer and
     // the leader receives zero automatic reports of the initial result.
-    await h.spawnTeammate('worker', {
-      onStart: async (agent) => {
-        agent.setStatus(AgentStatus.RUNNING);
-        await h.teamManager.sendMessage('leader', 'progress note', 'worker');
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 1,
-          text: 'initial result',
-          thoughtText: '',
-          timestamp: Date.now(),
-        });
-        agent.setStatus(AgentStatus.IDLE);
-      },
-    });
+    const messages = await runUntilLeaderMessages(h, 2, () =>
+      h.spawnTeammate('worker', {
+        onStart: async (agent) => {
+          agent.setStatus(AgentStatus.RUNNING);
+          await h.teamManager.sendMessage('leader', 'progress note', 'worker');
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 1,
+            text: 'initial result',
+            thoughtText: '',
+            timestamp: Date.now(),
+          });
+          agent.setStatus(AgentStatus.IDLE);
+        },
+      }),
+    );
 
-    await vi.waitFor(async () => {
-      expect(await h.teamManager.getLeaderMessages()).toEqual([
-        expect.objectContaining({ from: 'worker', text: 'progress note' }),
-        expect.objectContaining({ from: 'worker', text: 'initial result' }),
-      ]);
-    });
+    expect(messages).toEqual([
+      expect.objectContaining({ from: 'worker', text: 'progress note' }),
+      expect.objectContaining({ from: 'worker', text: 'initial result' }),
+    ]);
 
     // Exactly once: the explicit note plus one automatic forwarding.
     await settleAsyncWork();
@@ -213,35 +239,35 @@ describe('initial teammate result before event bridge attachment (#10211)', () =
     // A multi-turn pre-attach round emits several ROUND_TEXT events;
     // the recovery scan must walk the history backwards so the most
     // recent non-empty visible answer wins, not the earliest one.
-    await h.spawnTeammate('worker', {
-      onStart: (agent) => {
-        agent.setStatus(AgentStatus.RUNNING);
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 1,
-          text: 'early turn answer',
-          thoughtText: '',
-          timestamp: Date.now(),
-        });
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 1,
-          text: 'final turn answer',
-          thoughtText: '',
-          timestamp: Date.now(),
-        });
-        agent.setStatus(AgentStatus.IDLE);
-      },
-    });
+    const messages = await runUntilLeaderMessages(h, 1, () =>
+      h.spawnTeammate('worker', {
+        onStart: (agent) => {
+          agent.setStatus(AgentStatus.RUNNING);
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 1,
+            text: 'early turn answer',
+            thoughtText: '',
+            timestamp: Date.now(),
+          });
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 1,
+            text: 'final turn answer',
+            thoughtText: '',
+            timestamp: Date.now(),
+          });
+          agent.setStatus(AgentStatus.IDLE);
+        },
+      }),
+    );
 
-    await vi.waitFor(async () => {
-      expect(await h.teamManager.getLeaderMessages()).toEqual([
-        expect.objectContaining({
-          from: 'worker',
-          text: 'final turn answer',
-        }),
-      ]);
-    });
+    expect(messages).toEqual([
+      expect.objectContaining({
+        from: 'worker',
+        text: 'final turn answer',
+      }),
+    ]);
 
     // The earlier turn text must never be reported on its own.
     await settleAsyncWork();
@@ -255,32 +281,32 @@ describe('initial teammate result before event bridge attachment (#10211)', () =
     // non-empty, so a trailing thought-only event is a reachable
     // pre-attach shape. The recovery must skip thought messages and
     // never surface internal reasoning as the round's final answer.
-    await h.spawnTeammate('worker', {
-      onStart: (agent) => {
-        agent.setStatus(AgentStatus.RUNNING);
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 1,
-          text: 'visible answer',
-          thoughtText: '',
-          timestamp: Date.now(),
-        });
-        agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
-          subagentId: agent.agentId,
-          round: 1,
-          text: '',
-          thoughtText: 'internal reasoning about the task',
-          timestamp: Date.now(),
-        });
-        agent.setStatus(AgentStatus.IDLE);
-      },
-    });
+    const messages = await runUntilLeaderMessages(h, 1, () =>
+      h.spawnTeammate('worker', {
+        onStart: (agent) => {
+          agent.setStatus(AgentStatus.RUNNING);
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 1,
+            text: 'visible answer',
+            thoughtText: '',
+            timestamp: Date.now(),
+          });
+          agent.getEventEmitter().emit(AgentEventType.ROUND_TEXT, {
+            subagentId: agent.agentId,
+            round: 1,
+            text: '',
+            thoughtText: 'internal reasoning about the task',
+            timestamp: Date.now(),
+          });
+          agent.setStatus(AgentStatus.IDLE);
+        },
+      }),
+    );
 
-    await vi.waitFor(async () => {
-      expect(await h.teamManager.getLeaderMessages()).toEqual([
-        expect.objectContaining({ from: 'worker', text: 'visible answer' }),
-      ]);
-    });
+    expect(messages).toEqual([
+      expect.objectContaining({ from: 'worker', text: 'visible answer' }),
+    ]);
 
     // Nothing else — in particular no thought content — may arrive.
     await settleAsyncWork();

--- a/packages/node-repl/src/node-repl.napi.test.ts
+++ b/packages/node-repl/src/node-repl.napi.test.ts
@@ -35,6 +35,7 @@ beforeAll(async () => {
     );
     await execFileAsync(nodeGyp, ['rebuild'], {
       cwd: fixtureDir,
+      timeout: 110_000,
     });
     const candidate = path.join(
       fixtureDir,

--- a/packages/node-repl/src/node-repl.napi.test.ts
+++ b/packages/node-repl/src/node-repl.napi.test.ts
@@ -7,8 +7,9 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { NodeReplKernelManager } from './kernel-manager.js';
 import { NodeReplSecurityPolicy } from './security-policy.js';
@@ -22,18 +23,18 @@ import { NodeReplSecurityPolicy } from './security-policy.js';
 // test is skipped with a logged reason (the fixture is real, not synthesized).
 
 const fixtureDir = fileURLToPath(new URL('./fixtures/napi', import.meta.url));
+const execFileAsync = promisify(execFile);
 let builtAddonPath: string | null = null;
 let buildError: string | null = null;
 let manager: NodeReplKernelManager | null = null;
 
-beforeAll(() => {
+beforeAll(async () => {
   try {
     const nodeGyp = fileURLToPath(
       new URL('../../../node_modules/.bin/node-gyp', import.meta.url),
     );
-    execFileSync(nodeGyp, ['rebuild'], {
+    await execFileAsync(nodeGyp, ['rebuild'], {
       cwd: fixtureDir,
-      stdio: 'pipe',
     });
     const candidate = path.join(
       fixtureDir,

--- a/packages/node-repl/src/node-repl.napi.test.ts
+++ b/packages/node-repl/src/node-repl.napi.test.ts
@@ -7,7 +7,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import { execFile, type ChildProcess } from 'node:child_process';
+import { execFile, spawn, type ChildProcess } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { NodeReplKernelManager } from './kernel-manager.js';
@@ -53,20 +53,35 @@ function terminateBuild(child: ChildProcess): void {
 
 function rebuildAddon(nodeGyp: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = execFile(
-      nodeGyp,
-      ['rebuild'],
-      {
-        cwd: fixtureDir,
-        detached: process.platform !== 'win32',
-      },
-      (error) => {
-        clearTimeout(timeout);
-        if (error) reject(error);
-        else resolve();
-      },
-    );
+    const child = spawn(nodeGyp, ['rebuild'], {
+      cwd: fixtureDir,
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      stderr = `${stderr}${chunk}`.slice(-16_384);
+    });
     const timeout = setTimeout(() => terminateBuild(child), 110_000);
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(timeout);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const reason = signal ? `signal ${signal}` : `exit ${code ?? 'unknown'}`;
+      const detail = stderr.trim();
+      reject(
+        new Error(
+          `node-gyp rebuild failed (${reason})${detail ? `: ${detail}` : ''}`,
+        ),
+      );
+    });
   });
 }
 

--- a/packages/node-repl/src/node-repl.napi.test.ts
+++ b/packages/node-repl/src/node-repl.napi.test.ts
@@ -7,9 +7,8 @@
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
-import { execFile } from 'node:child_process';
+import { execFile, type ChildProcess } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { NodeReplKernelManager } from './kernel-manager.js';
 import { NodeReplSecurityPolicy } from './security-policy.js';
@@ -23,20 +22,60 @@ import { NodeReplSecurityPolicy } from './security-policy.js';
 // test is skipped with a logged reason (the fixture is real, not synthesized).
 
 const fixtureDir = fileURLToPath(new URL('./fixtures/napi', import.meta.url));
-const execFileAsync = promisify(execFile);
+const windowsTaskkill = `${process.env['SystemRoot'] || 'C:\\Windows'}\\System32\\taskkill.exe`;
 let builtAddonPath: string | null = null;
 let buildError: string | null = null;
 let manager: NodeReplKernelManager | null = null;
+
+function terminateBuild(child: ChildProcess): void {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  if (!child.pid) {
+    child.kill('SIGKILL');
+    return;
+  }
+  if (process.platform === 'win32') {
+    execFile(
+      windowsTaskkill,
+      ['/f', '/t', '/pid', String(child.pid)],
+      { timeout: 5_000 },
+      (error) => {
+        if (error) child.kill('SIGKILL');
+      },
+    );
+    return;
+  }
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+  } catch {
+    child.kill('SIGKILL');
+  }
+}
+
+function rebuildAddon(nodeGyp: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      nodeGyp,
+      ['rebuild'],
+      {
+        cwd: fixtureDir,
+        detached: process.platform !== 'win32',
+      },
+      (error) => {
+        clearTimeout(timeout);
+        if (error) reject(error);
+        else resolve();
+      },
+    );
+    const timeout = setTimeout(() => terminateBuild(child), 110_000);
+  });
+}
 
 beforeAll(async () => {
   try {
     const nodeGyp = fileURLToPath(
       new URL('../../../node_modules/.bin/node-gyp', import.meta.url),
     );
-    await execFileAsync(nodeGyp, ['rebuild'], {
-      cwd: fixtureDir,
-      timeout: 110_000,
-    });
+    await rebuildAddon(nodeGyp);
     const candidate = path.join(
       fixtureDir,
       'build',


### PR DESCRIPTION
## What this PR does

This change makes two contention-sensitive unit-test paths deterministic. Leader mailbox assertions now wait for the delivery event before consuming messages, and the native-addon fixture builds asynchronously so the Vitest worker can continue servicing its control-plane RPCs. A stalled native build is bounded and its full process tree is terminated before fixture cleanup.

## Why it's needed

Main CI run [33605419022](https://github.com/QwenLM/qwen-code/actions/runs/33605419022), specifically the [Linux test job](https://github.com/QwenLM/qwen-code/actions/runs/33605419022/job/100175179229), failed under heavy load on `ecs-qwen-hk5-13`. Two leader-message assertions exhausted Vitest's default polling window and observed an empty mailbox, while the N-API fixture's synchronous build blocked a worker for 68 seconds and caused `[vitest-worker]: Timeout calling "onTaskUpdate"` even though all 152 package tests passed. Neither failure came from the merged commit under test. This change removes both timing dependencies without increasing test timeouts, weakening assertions, changing production behavior, or reducing test concurrency.

## Reviewer Test Plan

### How to verify

- Run the initial teammate-result suite and confirm all six cases receive exactly the expected leader messages without destructively polling the mailbox.
- Run the native-addon loading test and confirm the addon still compiles and returns `42`, with no `onTaskUpdate` or unhandled worker error.
- Confirm a native build that exceeds its bound terminates the process tree before fixture cleanup rather than leaving compiler processes behind.

### Evidence (Before & After)

N/A — test and CI reliability changes only; no user-visible UI.

Before: the failing Linux job reported two empty-mailbox assertion failures and one Vitest worker RPC timeout after the native build stretched to 68 seconds.

After: the teammate-result suite passes 6/6, and the native-addon suite passes 1/1 without an unhandled worker error.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22.22.0 and Vitest 3.2.7. Linux and Windows coverage is delegated to PR CI.

## Risk & Scope

- Main risk or tradeoff: The native fixture now owns explicit process-tree cleanup on its 110-second build bound; normal successful builds keep the same compile-and-load behavior.
- Not validated / out of scope: This does not change ECS fleet sizing or Vitest's internal 60-second RPC budget. It removes the synchronous worker blockage and mailbox timing race observed in the linked failure.
- Breaking changes / migration notes: None. Production code is unchanged.

## Linked Issues

Fixes #10798

<details>
<summary>中文说明</summary>

## 本 PR 的改动

本改动让两条容易受资源竞争影响的单元测试路径变得确定。Leader mailbox 断言会先等待消息投递事件，再消费消息；原生扩展 fixture 改为异步构建，让 Vitest worker 在编译期间仍能处理控制面 RPC。原生构建如果卡住，会在限定时间内终止整个进程树，并在清理 fixture 前完成回收。

## 为什么需要

Main CI 运行 [33605419022](https://github.com/QwenLM/qwen-code/actions/runs/33605419022) 中的 [Linux 测试任务](https://github.com/QwenLM/qwen-code/actions/runs/33605419022/job/100175179229) 在 `ecs-qwen-hk5-13` 高负载时失败。两个 leader 消息断言耗尽了 Vitest 默认轮询窗口，只读到空 mailbox；同时 N-API fixture 的同步构建阻塞 worker 68 秒，导致 `[vitest-worker]: Timeout calling "onTaskUpdate"`，尽管该 package 的 152 个测试断言全部通过。这两个失败都不是被测合入提交引入的。本改动不提高测试超时、不弱化断言、不改变生产行为，也不降低测试并发，而是消除这两个时间依赖。

## Reviewer 测试计划

### 如何验证

- 运行 initial teammate-result 测试集，确认六个 case 都能收到且只收到预期的 leader 消息，不再通过破坏性轮询消费 mailbox。
- 运行原生扩展加载测试，确认扩展仍能成功编译并返回 `42`，且不再出现 `onTaskUpdate` 或其他未处理的 worker 错误。
- 确认原生构建超过限制时，会在清理 fixture 前终止整个进程树，不会遗留编译进程。

### 证据（Before & After）

N/A —— 仅涉及测试与 CI 稳定性，没有用户可见 UI。

Before：失败的 Linux 任务出现两个 mailbox 为空的断言失败，以及原生构建耗时 68 秒后触发的一次 Vitest worker RPC 超时。

After：teammate-result 测试 6/6 通过，原生扩展测试 1/1 通过，并且没有未处理的 worker 错误。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22.22.0、Vitest 3.2.7。Linux 与 Windows 验证交给 PR CI。

## 风险与范围

- 主要风险或权衡：原生 fixture 现在会在 110 秒构建上限到达时显式清理进程树；正常成功构建仍保持原有编译和加载行为。
- 未验证 / 范围外：本改动不调整 ECS 集群容量，也不修改 Vitest 内部 60 秒 RPC 限制；它解决了关联失败中实际出现的同步 worker 阻塞与 mailbox 时间竞态。
- 破坏性变更 / 迁移说明：无。生产代码没有改动。

## 关联 Issue

Fixes #10798

</details>
