### PR TITLE
fix(web-shell): Reload models for repeated new tasks

### DIFF
--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
@@ -1126,7 +1126,7 @@ describe('DaemonSessionProvider', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('hydrates models for a deferred standalone session without creating it', async () => {
+  it('rehydrates models after repeatedly clearing a deferred standalone session', async () => {
     sdkMocks.capabilities.mockResolvedValue({
       workspaceCwd: '/primary',
       features: ['standalone_sessions_v1', 'standalone_session_options_v1'],
@@ -1155,9 +1155,11 @@ describe('DaemonSessionProvider', () => {
         },
       ],
     });
+    let actions: DaemonSessionActions | undefined;
     let connection: DaemonConnectionState | undefined;
 
     function Harness() {
+      actions = useDaemonActions();
       connection = useDaemonConnection();
       return null;
     }
@@ -1192,6 +1194,29 @@ describe('DaemonSessionProvider', () => {
     expect(sdkMocks.workspaceProviders).not.toHaveBeenCalled();
     expect(sdkMocks.workspaceSkills).not.toHaveBeenCalled();
     expect(sdkMocks.workspaceByCwd).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await actions?.clearSession();
+    });
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(sdkMocks.getStandaloneSessionOptions).toHaveBeenCalledTimes(2);
+        expect(connection?.currentModel).toBe('qwen3.8-max(USE_OPENAI)');
+        expect(connection?.models).toHaveLength(1);
+      });
+    });
+
+    await act(async () => {
+      await actions?.clearSession();
+    });
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(sdkMocks.getStandaloneSessionOptions).toHaveBeenCalledTimes(3);
+        expect(connection?.currentModel).toBe('qwen3.8-max(USE_OPENAI)');
+        expect(connection?.models).toHaveLength(1);
+      });
+    });
+
     expect(
       sdkMocks.MockDaemonSessionClient.createStandalone,
     ).not.toHaveBeenCalled();

--- a/packages/web-shell/client/daemon/session/actions.ts
+++ b/packages/web-shell/client/daemon/session/actions.ts
@@ -1753,11 +1753,16 @@ export function createDaemonSessionActions({
         await pendingPersistedReasoningAction.catch(() => undefined);
       }
       if (sessionRef.current === session) {
+        const refreshStandaloneOptions =
+          getConnection().sessionContext?.kind === 'standalone';
         clearActiveSessionState();
         sessionRef.current = undefined;
         setConnection((current) =>
           getConnectionAfterSessionClear(current, session?.sessionId),
         );
+        if (refreshStandaloneOptions) {
+          setRestoreSessionNonce((nonce) => nonce + 1);
+        }
       }
       if (session) {
         try {


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

When a standalone draft is cleared by New task, this change invalidates the existing session restore cycle so the deferred connection reloads standalone model options. The refresh is limited to standalone context and keeps lazy session creation intact. Regression coverage clears the same deferred draft twice and verifies that each clear restores the model list without creating a session.

## Why it's needed

In a fresh standalone draft, the first New task click reloaded models only because the restore context changed. The second click left the effective context unchanged, so the provider effect did not run again after clear removed the non-workspace model state. As a result, the model picker disappeared. This fixes the user-visible regression tracked in #10821.

## Reviewer Test Plan

### How to verify

Open Web Shell on a standalone draft and wait for the model picker. Click New task, wait for the draft to settle, then click New task again. After each click, confirm that `GET /standalone/session-options` returns 200, the same models remain available, and no standalone session is created before sending a prompt.

```bash
npm run build
npm run typecheck
cd packages/web-shell
npx vitest run client/daemon/session/DaemonSessionProvider.test.tsx
npx vitest run client/daemon/session/actions.test.ts
```

The exact rebased head passed the full repository build and typecheck, 279 provider tests, 144 action tests, targeted ESLint, and Prettier.

### Evidence (Before & After)

| Before | After |
| --- | --- |
| On the reported reproduction, the second New task click cleared the model list and hid the model picker because no options refresh ran. | Each New task click sends one successful options request, and the picker remains visible with the same 9 models. |

Manual macOS E2E on the rebased head confirmed one 200 options response after each click, no session-create POST before a prompt, and no related network or console error.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

macOS, Node.js v22.22.3, local Vite Web Shell proxying a local Qwen Code daemon.

## Risk & Scope

- Main risk or tradeoff: Each standalone New task action now performs a fresh capabilities/options hydration; this is intentional so the draft cannot retain an empty or stale model list.
- Not validated / out of scope: Windows and Linux browser E2E were not run; CI provides cross-platform build and test coverage.
- Breaking changes / migration notes: None. There are no daemon route, SDK contract, or persisted data changes.

## Linked Issues

Closes #10821

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当用户通过 New task 清空独立草稿时，本次修改会使现有会话恢复周期失效，从而让延迟连接重新加载独立会话的模型选项。刷新仅限于独立会话上下文，并保留会话按需创建的行为。回归测试会连续两次清空同一个延迟创建的草稿，并验证每次清空后模型列表都会恢复，同时不会提前创建会话。

## 为什么需要

在新的独立草稿中，第一次点击 New task 之所以会重新加载模型，只是因为恢复上下文发生了变化。第二次点击时有效上下文保持不变，因此清空操作移除非工作区模型状态后，Provider effect 不会再次执行，最终导致模型选择器消失。本次修复解决 #10821 跟踪的用户可见回归。

## 审阅者测试计划

### 如何验证

在独立草稿页面打开 Web Shell，等待模型选择器出现。点击一次 New task，等待草稿状态稳定后，再点击一次 New task。每次点击后都应确认 `GET /standalone/session-options` 返回 200、相同的模型仍然可用，并且在发送提示词之前不会创建独立会话。

```bash
npm run build
npm run typecheck
cd packages/web-shell
npx vitest run client/daemon/session/DaemonSessionProvider.test.tsx
npx vitest run client/daemon/session/actions.test.ts
```

重基后的精确提交已通过完整仓库构建和类型检查、279 个 Provider 测试、144 个 Action 测试、目标 ESLint 检查以及 Prettier 检查。

### 前后证据

| 修复前 | 修复后 |
| --- | --- |
| 在报告的复现场景中，第二次点击 New task 后不会刷新选项，模型列表被清空且模型选择器消失。 | 每次点击 New task 都会发送一次成功的选项请求，模型选择器持续显示相同的 9 个模型。 |

在重基后提交上进行的 macOS 手工 E2E 验证确认：每次点击后均有一次返回 200 的选项请求；发送提示词前没有会话创建 POST；没有相关网络或控制台错误。

### 测试平台

|     操作系统     | 状态 |
| :--------------: | :--: |
|      🍏 macOS     | ✅ 已测试 |
|     🪟 Windows    | ⚠️ 未测试 |
|      🐧 Linux     | ⚠️ 未测试 |

### 环境（可选）

macOS、Node.js v22.22.3、本地 Vite Web Shell 代理到本地 Qwen Code daemon。

## 风险与范围

- 主要风险或权衡：每次独立会话 New task 操作现在都会重新加载 capabilities/options；这是有意为之，确保草稿不会保留空的或过期的模型列表。
- 未验证 / 范围之外：未执行 Windows 和 Linux 浏览器 E2E；CI 会提供跨平台构建和测试覆盖。
- 破坏性变更 / 迁移说明：无。没有 daemon 路由、SDK 契约或持久化数据变更。

## 关联 Issue

Closes #10821

</details>
