### PR TITLE
fix(cli): restore OpenTUI interactive E2E parity

### DIFF
--- a/integration-tests/interactive/context-compress-interactive.test.ts
+++ b/integration-tests/interactive/context-compress-interactive.test.ts
@@ -5,24 +5,82 @@
  */
 
 import { expect, describe, it, beforeEach, afterEach } from 'vitest';
-import { TestRig, type } from '../test-helper.js';
+import {
+  startFakeOpenAIServer,
+  type FakeOpenAIServer,
+} from '../fake-openai-server.js';
+import {
+  TestRig,
+  type,
+  applyContainerSandboxNoProxy,
+  fakeServerHostOptions,
+} from '../test-helper.js';
 
 describe('Interactive Mode', () => {
   let rig: TestRig;
+  let fakeServer: FakeOpenAIServer | undefined;
+  let restoreNoProxy: () => void;
 
   beforeEach(() => {
     rig = new TestRig();
+    restoreNoProxy = applyContainerSandboxNoProxy();
   });
 
   afterEach(async () => {
+    await fakeServer?.close();
+    fakeServer = undefined;
+    restoreNoProxy();
     await rig.cleanup();
   });
+
+  async function runInteractiveWithFakeModel() {
+    fakeServer = await startFakeOpenAIServer(
+      ({ requestIndex }) => ({
+        content:
+          requestIndex === 0
+            ? `SEED_TURN_DONE ${'deterministic history '.repeat(50)}einstein`
+            : 'COMPRESSED_SUMMARY_DONE',
+      }),
+      fakeServerHostOptions(),
+    );
+    return rig.runInteractive(
+      '--auth-type',
+      'openai',
+      '--openai-api-key',
+      'fake-key',
+      '--openai-base-url',
+      fakeServer.baseUrl,
+      '--model',
+      'fake-model',
+    );
+  }
+
+  async function waitForInteractiveOutputToSettle() {
+    let previousLength = rig._interactiveOutput.length;
+    let stableSince = Date.now();
+    return rig.poll(
+      () => {
+        const currentLength = rig._interactiveOutput.length;
+        if (currentLength !== previousLength) {
+          previousLength = currentLength;
+          stableSince = Date.now();
+        }
+        return Date.now() - stableSince >= 1000;
+      },
+      25_000,
+      100,
+    );
+  }
 
   it.skipIf(process.platform === 'win32')(
     'should trigger chat compression with /compress command',
     async () => {
       await rig.setup('interactive-compress-test', {
         settings: {
+          memory: {
+            enableManagedAutoMemory: false,
+            enableManagedAutoDream: false,
+          },
           security: {
             auth: {
               selectedType: 'openai',
@@ -31,38 +89,47 @@ describe('Interactive Mode', () => {
         },
       });
 
-      const { ptyProcess } = rig.runInteractive();
+      const { ptyProcess, promise } = await runInteractiveWithFakeModel();
 
-      let fullOutput = '';
-      ptyProcess.onData((data: string) => (fullOutput += data));
+      try {
+        const isReady = await rig.waitForText('Type your message', 15000);
+        expect(
+          isReady,
+          'CLI did not start up in interactive mode correctly',
+        ).toBe(true);
 
-      // Wait for the app to be ready
-      const isReady = await rig.waitForText('Type your message', 15000);
-      expect(
-        isReady,
-        'CLI did not start up in interactive mode correctly',
-      ).toBe(true);
+        await type(ptyProcess, 'Seed deterministic history for compression.');
+        await type(ptyProcess, '\r');
 
-      const longPrompt =
-        'Dont do anything except returning a 1000 token long paragragh with the <name of the scientist who discovered theory of relativity> at the end to indicate end of response. This is a moderately long sentence.';
+        expect(
+          await rig.waitForText('SEED_TURN_DONE', 25_000),
+          'Fake model seed turn did not complete',
+        ).toBe(true);
+        expect(
+          await rig.waitForTelemetryEvent('api_response', 25_000),
+          'Seed turn API response telemetry was not recorded',
+        ).toBe(true);
+        expect(
+          await waitForInteractiveOutputToSettle(),
+          'Interactive output did not settle after the seed turn',
+        ).toBe(true);
 
-      await type(ptyProcess, longPrompt);
-      await type(ptyProcess, '\r');
+        await type(ptyProcess, '/compress');
+        await type(ptyProcess, '\r');
+        await type(ptyProcess, '\r');
 
-      await rig.waitForText('einstein', 25000);
-
-      await type(ptyProcess, '/compress');
-      // A small delay to allow React to re-render the command list.
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      await type(ptyProcess, '\r');
-
-      const foundEvent = await rig.waitForTelemetryEvent(
-        'chat_compression',
-        90000,
-      );
-      expect(foundEvent, 'chat_compression telemetry event was not found').toBe(
-        true,
-      );
+        const foundEvent = await rig.waitForTelemetryEvent(
+          'chat_compression',
+          90000,
+        );
+        expect(
+          foundEvent,
+          'chat_compression telemetry event was not found',
+        ).toBe(true);
+      } finally {
+        ptyProcess.kill();
+        await promise;
+      }
     },
   );
 
@@ -111,6 +178,10 @@ describe('Interactive Mode', () => {
     async () => {
       await rig.setup('interactive-compress-instructions-test', {
         settings: {
+          memory: {
+            enableManagedAutoMemory: false,
+            enableManagedAutoDream: false,
+          },
           security: {
             auth: {
               selectedType: 'openai',
@@ -119,42 +190,47 @@ describe('Interactive Mode', () => {
         },
       });
 
-      const { ptyProcess } = rig.runInteractive();
+      const { ptyProcess, promise } = await runInteractiveWithFakeModel();
 
-      let fullOutput = '';
-      ptyProcess.onData((data: string) => (fullOutput += data));
+      try {
+        const isReady = await rig.waitForText('Type your message', 15000);
+        expect(
+          isReady,
+          'CLI did not start up in interactive mode correctly',
+        ).toBe(true);
 
-      const isReady = await rig.waitForText('Type your message', 15000);
-      expect(
-        isReady,
-        'CLI did not start up in interactive mode correctly',
-      ).toBe(true);
+        await type(ptyProcess, 'Seed deterministic history for compression.');
+        await type(ptyProcess, '\r');
 
-      // Seed history so /compress has material to summarize.
-      const seedPrompt =
-        'Dont do anything except returning a 1000 token long paragragh with the <name of the scientist who discovered theory of relativity> at the end to indicate end of response. This is a moderately long sentence.';
+        expect(
+          await rig.waitForText('SEED_TURN_DONE', 25_000),
+          'Fake model seed turn did not complete',
+        ).toBe(true);
+        expect(
+          await rig.waitForTelemetryEvent('api_response', 25_000),
+          'Seed turn API response telemetry was not recorded',
+        ).toBe(true);
+        expect(
+          await waitForInteractiveOutputToSettle(),
+          'Interactive output did not settle after the seed turn',
+        ).toBe(true);
 
-      await type(ptyProcess, seedPrompt);
-      await type(ptyProcess, '\r');
+        await type(ptyProcess, '/compress focus on the scientist mentioned');
+        await type(ptyProcess, '\r');
+        await type(ptyProcess, '\r');
 
-      await rig.waitForText('einstein', 25000);
-
-      // Fire /compress with a trailing instruction. We are not asserting on
-      // summary CONTENT (model behaviour) — only that the wiring runs
-      // end-to-end and the compression telemetry event lands. Earlier unit
-      // tests cover the prompt-composition path; this is the smoke test that
-      // the args plumbing reaches the side-query.
-      await type(ptyProcess, '/compress focus on the scientist mentioned');
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      await type(ptyProcess, '\r');
-
-      const foundEvent = await rig.waitForTelemetryEvent(
-        'chat_compression',
-        90000,
-      );
-      expect(foundEvent, 'chat_compression telemetry event was not found').toBe(
-        true,
-      );
+        const foundEvent = await rig.waitForTelemetryEvent(
+          'chat_compression',
+          90000,
+        );
+        expect(
+          foundEvent,
+          'chat_compression telemetry event was not found',
+        ).toBe(true);
+      } finally {
+        ptyProcess.kill();
+        await promise;
+      }
     },
   );
 });

--- a/integration-tests/interactive/protocol-tags-interactive.test.ts
+++ b/integration-tests/interactive/protocol-tags-interactive.test.ts
@@ -95,11 +95,7 @@ describe('Interactive protocol tag retry guard', () => {
       );
 
       try {
-        const isReady = await rig.poll(
-          () => /YOLO (模式|mode)/i.test(stripAnsi(rig._interactiveOutput)),
-          30000,
-          200,
-        );
+        const isReady = await rig.waitForText('Type your message', 30_000);
         expect(isReady, 'CLI did not start up in interactive mode').toBe(true);
 
         await type(ptyProcess, 'Return the deterministic retry response.');

--- a/packages/cli/src/ui/opentui/live-session.test.ts
+++ b/packages/cli/src/ui/opentui/live-session.test.ts
@@ -263,6 +263,40 @@ describe('livePromptEvents', () => {
     });
   });
 
+  it('passes submittedPrompt only on the initial user query', async () => {
+    let calls = 0;
+    const sendMessageStream = vi.fn(function* (): Generator<{
+      type: string;
+      value?: unknown;
+    }> {
+      calls += 1;
+      if (calls === 1) {
+        yield {
+          type: 'tool_call_request',
+          value: { callId: 't1', name: 'test_tool', args: {} },
+        };
+        return;
+      }
+      yield { type: 'finished', value: {} };
+    });
+    const config = createFakeConfig(sendMessageStream);
+
+    await drain(
+      livePromptEvents(config, [{ text: 'expanded prompt' }], undefined, {
+        submittedPrompt: '@context.txt review this',
+      }),
+    );
+
+    expect(sendMessageStream).toHaveBeenCalledTimes(2);
+    expect((sendMessageStream.mock.calls[0] as unknown[])[3]).toEqual({
+      type: SendMessageType.UserQuery,
+      submittedPrompt: '@context.txt review this',
+    });
+    expect((sendMessageStream.mock.calls[1] as unknown[])[3]).toEqual({
+      type: SendMessageType.ToolResult,
+    });
+  });
+
   it('appends drained steering texts after tool responses at the boundary', async () => {
     let calls = 0;
     const sendMessageStream = vi.fn(function* (): Generator<{

--- a/packages/cli/src/ui/opentui/live-session.ts
+++ b/packages/cli/src/ui/opentui/live-session.ts
@@ -60,6 +60,8 @@ interface LooseCompletedCall {
 export interface LivePromptOptions {
   /** Per-turn model override (submit_prompt's modelOverride parity). */
   modelOverride?: string;
+  /** Raw composer text before @-file expansion, for UserPromptSubmit hooks. */
+  submittedPrompt?: string;
   /**
    * "Enter to steer" parity: called at each tool boundary (after tools ran,
    * before their results go back to the model). Returned texts are appended
@@ -264,10 +266,15 @@ export async function* livePromptEvents(
   const waitingSeen = new Set<string>();
   for (;;) {
     const sendOptions = first
-      ? options?.modelOverride
+      ? options?.modelOverride || options?.submittedPrompt
         ? {
             type: SendMessageType.UserQuery,
-            modelOverride: options.modelOverride,
+            ...(options.modelOverride
+              ? { modelOverride: options.modelOverride }
+              : {}),
+            ...(options.submittedPrompt
+              ? { submittedPrompt: options.submittedPrompt }
+              : {}),
           }
         : undefined
       : {

--- a/packages/cli/src/ui/opentui/live-turn.test.ts
+++ b/packages/cli/src/ui/opentui/live-turn.test.ts
@@ -13,8 +13,30 @@
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it, expect } from 'vitest';
-import { foldBatch, imagePathsToParts } from './live-turn.js';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { Config } from '@qwen-code/qwen-code-core';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { livePromptEvents } from './live-session.js';
+import {
+  foldBatch,
+  imagePathsToParts,
+  useOpenTuiLiveTurn,
+} from './live-turn.js';
+
+vi.mock('./live-session.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./live-session.js')>();
+  return {
+    ...original,
+    livePromptEvents: vi.fn(),
+    nextLivePromptId: vi.fn(() => 'prompt-id'),
+  };
+});
+
+const mockedLivePromptEvents = vi.mocked(livePromptEvents);
+
+beforeEach(() => {
+  mockedLivePromptEvents.mockReset();
+});
 
 describe('imagePathsToParts', () => {
   const dir = mkdtempSync(join(tmpdir(), 'opentui-live-turn-'));
@@ -69,5 +91,47 @@ describe('foldBatch', () => {
 
   it('returns an empty transcript for an empty batch', () => {
     expect(foldBatch([])).toEqual([]);
+  });
+});
+
+describe('useOpenTuiLiveTurn', () => {
+  it('preserves raw submitted text when an expanded prompt is queued', async () => {
+    let finishFirstTurn: () => void = () => {};
+    const firstTurnFinished = new Promise<void>((resolve) => {
+      finishFirstTurn = resolve;
+    });
+    mockedLivePromptEvents
+      .mockImplementationOnce(async function* () {
+        await firstTurnFinished;
+      })
+      .mockImplementationOnce(async function* () {});
+
+    const { result } = renderHook(() =>
+      useOpenTuiLiveTurn({ config: {} as Config }),
+    );
+
+    act(() => result.current.submit('first prompt'));
+    await waitFor(() => expect(result.current.streaming).toBe(true));
+
+    act(() =>
+      result.current.submit('expanded file contents', undefined, {
+        submittedPrompt: '@context.txt summarize',
+      }),
+    );
+    expect(result.current.queueLength).toBe(1);
+
+    await act(async () => {
+      finishFirstTurn();
+      await firstTurnFinished;
+    });
+    await waitFor(() =>
+      expect(mockedLivePromptEvents).toHaveBeenCalledTimes(2),
+    );
+
+    const queuedTurn = mockedLivePromptEvents.mock.calls[1];
+    expect(queuedTurn?.[1]).toBe('expanded file contents');
+    expect(queuedTurn?.[3]).toMatchObject({
+      submittedPrompt: '@context.txt summarize',
+    });
   });
 });

--- a/packages/cli/src/ui/opentui/live-turn.ts
+++ b/packages/cli/src/ui/opentui/live-turn.ts
@@ -93,6 +93,11 @@ export interface OpenTuiSubmitOptions {
   onComplete?: () => Promise<void>;
 }
 
+interface QueuedPrompt {
+  text: string;
+  submittedPrompt?: string;
+}
+
 export interface OpenTuiLiveTurn {
   items: readonly LiveHistoryItem[];
   streaming: boolean;
@@ -139,7 +144,7 @@ export function useOpenTuiLiveTurn(
   const [waitingCalls, setWaitingCalls] = useState<readonly WaitingCallInfo[]>(
     [],
   );
-  const queueRef = useRef<string[]>([]);
+  const queueRef = useRef<QueuedPrompt[]>([]);
   const [queueLength, setQueueLength] = useState(0);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -162,12 +167,12 @@ export function useOpenTuiLiveTurn(
     setItems((prev) => foldLiveEvent(prev, ev));
   }, []);
 
-  const pushQueue = useCallback((text: string) => {
-    queueRef.current.push(text);
+  const pushQueue = useCallback((prompt: QueuedPrompt) => {
+    queueRef.current.push(prompt);
     setQueueLength(queueRef.current.length);
   }, []);
 
-  const drainQueue = useCallback((): string[] => {
+  const drainQueue = useCallback((): QueuedPrompt[] => {
     const drained = queueRef.current;
     queueRef.current = [];
     setQueueLength(0);
@@ -190,7 +195,7 @@ export function useOpenTuiLiveTurn(
           modelOverride: turnOptions?.modelOverride,
           submittedPrompt: turnOptions?.submittedPrompt,
           refreshContextFilesOnWrite: turnOptions?.refreshContextFilesOnWrite,
-          drainSteering: drainQueue,
+          drainSteering: () => drainQueue().map(({ text }) => text),
           onWaitingCall: (call) => {
             if (seq !== turnSeqRef.current) return;
             setWaitingCalls((prev) =>
@@ -227,11 +232,14 @@ export function useOpenTuiLiveTurn(
           // Whatever survived the tool-boundary drain becomes the next turn.
           const rest = queueRef.current;
           if (rest.length > 0) {
-            const text = drainQueue().join('\n');
+            const queued = drainQueue();
+            const text = queued.map(({ text }) => text).join('\n');
             if (text.trim()) {
               apply({ type: 'user', text });
               void runTurn(text, nextLivePromptId(config), {
-                submittedPrompt: text,
+                submittedPrompt: queued
+                  .map(({ text, submittedPrompt }) => submittedPrompt ?? text)
+                  .join('\n'),
               });
             }
           }
@@ -261,7 +269,9 @@ export function useOpenTuiLiveTurn(
             text: 'Image attachments cannot be queued mid-turn and were dropped.',
           });
         }
-        if (text.trim()) pushQueue(text);
+        if (text.trim()) {
+          pushQueue({ text, submittedPrompt: options?.submittedPrompt });
+        }
         return;
       }
       const { parts, notices } = imagePathsToParts(imagePaths ?? []);
@@ -314,7 +324,9 @@ export function useOpenTuiLiveTurn(
 
   const popQueue = useCallback((): string | null => {
     if (queueRef.current.length === 0) return null;
-    return drainQueue().join('\n');
+    return drainQueue()
+      .map(({ text }) => text)
+      .join('\n');
   }, [drainQueue]);
 
   useEffect(() => () => abortRef.current?.abort(), []);

--- a/packages/cli/src/ui/opentui/live-turn.ts
+++ b/packages/cli/src/ui/opentui/live-turn.ts
@@ -88,6 +88,7 @@ export interface UseOpenTuiLiveTurnOptions {
  */
 export interface OpenTuiSubmitOptions {
   modelOverride?: string;
+  submittedPrompt?: string;
   refreshContextFilesOnWrite?: boolean;
   onComplete?: () => Promise<void>;
 }
@@ -187,6 +188,7 @@ export function useOpenTuiLiveTurn(
         for await (const ev of livePromptEvents(config, prompt, abort.signal, {
           promptId,
           modelOverride: turnOptions?.modelOverride,
+          submittedPrompt: turnOptions?.submittedPrompt,
           refreshContextFilesOnWrite: turnOptions?.refreshContextFilesOnWrite,
           drainSteering: drainQueue,
           onWaitingCall: (call) => {
@@ -228,7 +230,9 @@ export function useOpenTuiLiveTurn(
             const text = drainQueue().join('\n');
             if (text.trim()) {
               apply({ type: 'user', text });
-              void runTurn(text, nextLivePromptId(config));
+              void runTurn(text, nextLivePromptId(config), {
+                submittedPrompt: text,
+              });
             }
           }
         }

--- a/packages/cli/src/ui/opentui/opentui-app-shell.test.tsx
+++ b/packages/cli/src/ui/opentui/opentui-app-shell.test.tsx
@@ -267,6 +267,7 @@ describe('OpenTuiApp shell wiring', () => {
         modelOverride: undefined,
         onComplete: undefined,
         refreshContextFilesOnWrite: undefined,
+        submittedPrompt: '/rewind apply',
       },
     );
   });
@@ -289,6 +290,7 @@ describe('OpenTuiApp shell wiring', () => {
       modelOverride: 'qwen3-max',
       refreshContextFilesOnWrite: true,
       onComplete,
+      submittedPrompt: '/model summarize',
     });
   });
 
@@ -316,6 +318,7 @@ describe('OpenTuiApp shell wiring', () => {
     expect(onSubmitPrompt).toHaveBeenCalledWith(
       'summarize the diff',
       undefined,
+      { submittedPrompt: 'summarize the diff' },
     );
   });
 
@@ -328,10 +331,11 @@ describe('OpenTuiApp shell wiring', () => {
     await submit('what is in these', ['a.png', 'b.png']);
     // The shell has no business choosing an image encoding: the entry layer
     // builds the real parts (ink: attachments), so the paths stay separate.
-    expect(onSubmitPrompt).toHaveBeenCalledWith('what is in these', [
-      'a.png',
-      'b.png',
-    ]);
+    expect(onSubmitPrompt).toHaveBeenCalledWith(
+      'what is in these',
+      ['a.png', 'b.png'],
+      { submittedPrompt: 'what is in these' },
+    );
   });
 
   it('reports a not-wired notice for a plain prompt when no seam is provided', async () => {

--- a/packages/cli/src/ui/opentui/opentui-app-shell.tsx
+++ b/packages/cli/src/ui/opentui/opentui-app-shell.tsx
@@ -46,6 +46,8 @@ import type { ExtensionRefreshState } from '../../config/extension-refresh-state
 import type { SlashCommand } from '../commands/types.js';
 import type { SessionStatsState } from '../contexts/SessionContext.js';
 import type { HistoryItem } from '../types.js';
+import { handleAtCommand } from '../hooks/atCommandProcessor.js';
+import { isAtCommand } from '../utils/commandUtils.js';
 import type { OpenTuiRuntime } from './opentui-runtime.js';
 import type { OpenTuiDialogRequest } from './commands-registry.js';
 import type { OpenTuiStreamEvent } from './event-adapter.js';
@@ -329,7 +331,7 @@ export function OpenTuiApp(props: OpenTuiAppProps) {
   ]);
 
   const applyOutcome = useCallback(
-    (outcome: OpenTuiDispatchOutcome) => {
+    (outcome: OpenTuiDispatchOutcome, submittedPrompt: string) => {
       switch (outcome.kind) {
         case 'handled':
           return;
@@ -340,6 +342,7 @@ export function OpenTuiApp(props: OpenTuiAppProps) {
           if (onSubmitPrompt)
             onSubmitPrompt(outcome.content, undefined, {
               modelOverride: outcome.modelOverride,
+              submittedPrompt,
               refreshContextFilesOnWrite: outcome.refreshContextFilesOnWrite,
               onComplete: outcome.onComplete,
             });
@@ -369,13 +372,30 @@ export function OpenTuiApp(props: OpenTuiAppProps) {
         return;
       }
       if (settlement.outcome === false) {
-        if (onSubmitPrompt) onSubmitPrompt(text, imagePaths);
-        else notify('The live prompt turn is not wired in this shell.');
+        if (!onSubmitPrompt) {
+          notify('The live prompt turn is not wired in this shell.');
+          return;
+        }
+        let content: PartListUnion = text;
+        if (isAtCommand(text)) {
+          const resolved = await handleAtCommand({
+            query: text,
+            config,
+            onDebugMessage: () => {},
+            messageId: Date.now(),
+            signal: new AbortController().signal,
+            addItem: host.addItem,
+          });
+          if (!resolved.shouldProceed || resolved.processedQuery === null)
+            return;
+          content = resolved.processedQuery;
+        }
+        onSubmitPrompt(content, imagePaths, { submittedPrompt: text });
         return;
       }
-      applyOutcome(settlement.outcome);
+      applyOutcome(settlement.outcome, text);
     },
-    [gateway, onSubmitPrompt, applyOutcome, notify],
+    [gateway, onSubmitPrompt, applyOutcome, notify, config, host],
   );
 
   const userMessages = useMemo(

--- a/packages/cli/src/ui/opentui/start-opentui-ui.test.tsx
+++ b/packages/cli/src/ui/opentui/start-opentui-ui.test.tsx
@@ -138,6 +138,7 @@ import type { InitializationResult } from '../../core/initializer.js';
 
 function buildConfig(): Config {
   return {
+    initialize: vi.fn(async () => {}),
     getSessionId: () => 'test-session-id',
     getTargetDir: () => '/tmp/project',
     getApprovalMode: () => 'default',
@@ -210,6 +211,10 @@ describe('startOpenTuiUI fallback contract', () => {
       {} as InitializationResult,
     );
     expect(started).toBe(true);
+    expect(config.initialize).toHaveBeenCalledOnce();
+    expect(
+      vi.mocked(config.initialize).mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.state.root.render.mock.invocationCallOrder[0]!);
     expect(mocks.state.stderrLines).toHaveLength(0);
     expect(mocks.state.cleanups.length).toBeGreaterThanOrEqual(3);
     expect(config.trackSessionRegistration).toHaveBeenCalled();

--- a/packages/cli/src/ui/opentui/start-opentui-ui.tsx
+++ b/packages/cli/src/ui/opentui/start-opentui-ui.tsx
@@ -330,6 +330,10 @@ export async function startOpenTuiUI(
     await runtime.writeRuntimeSidecar();
     runtime.startPressureMonitor();
 
+    profileCheckpoint('config_initialize_start');
+    await config.initialize();
+    profileCheckpoint('config_initialize_end');
+
     // Drain the early-captured input exactly once, before the renderer takes
     // over stdin; the decoded text is injected into the composer after mount.
     const capturedText = drainCapturedInputAsText();
@@ -353,6 +357,7 @@ export async function startOpenTuiUI(
       }),
     );
     profileCheckpoint('first_paint');
+    profileCheckpoint('input_enabled');
 
     startPostRenderPrefetches(config, settings, {
       connectIde: options.postRenderConnectIde ?? false,


### PR DESCRIPTION
## What this PR does

This restores behavioral parity for the OpenTUI interactive lane: configuration finishes initializing before input is enabled, `@file` prompts are expanded for the model while the original submitted text is preserved for hooks, and queued prompts keep those two representations separate. It also makes the protocol-tag and context-compression E2E synchronization renderer-neutral and deterministic.

## Why it's needed

[Main E2E run 33621485985, job 100219267217](https://github.com/QwenLM/qwen-code/actions/runs/33621485985/job/100219267217) failed in four OpenTUI scenarios. The external-context and prompt-provenance cases were missing OpenTUI's `@file` expansion/original-prompt propagation, the protocol test waited for an Ink-only UI marker, and the compression test could send `/compress` before the previous streamed response had actually completed. These are separate OpenTUI parity and test-synchronization gaps exposed by the same lane.

## Reviewer Test Plan

### How to verify

Run the four affected interactive scenarios with the OpenTUI renderer and confirm external context is recalled, submitted-prompt hooks receive the original `@file` text without expanded file contents, protocol tags remain hidden from the terminal, and `/compress` completes against deterministic model responses. Also submit an `@file` prompt while another turn is streaming and confirm the queued turn sends expanded content to the model while hooks still receive only the original text.

### Evidence (Before & After)

Before: the linked main job failed the context-compression, protocol-tags, external-context-auto-recall, and submitted-prompt-provenance scenarios.

After: the exact four-file OpenTUI E2E run passes 4 files and 5 tests, with 1 pre-existing skipped test. Focused unit runs pass 40 tests across the submission/initialization coverage and 26 tests across the live-session/queued-prompt coverage.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local macOS checkout with the OpenTUI renderer and sandbox disabled, matching the affected interactive lane.

## Risk & Scope

- Main risk or tradeoff: OpenTUI now waits for configuration initialization before accepting input, matching the initialized state required by submission handling.
- Not validated / out of scope: Windows and Linux runner behavior; unrelated Ink renderer behavior.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #10804
Fixes #10811

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 恢复 OpenTUI 交互测试通道的行为一致性：配置初始化完成后才允许输入；`@file` 提示会展开后发送给模型，同时保留原始输入供 hook 使用；排队提示也会分别保存这两种内容。此外，protocol-tag 和上下文压缩 E2E 改为与渲染器无关且确定性的同步方式。

## 为什么需要

[Main E2E run 33621485985, job 100219267217](https://github.com/QwenLM/qwen-code/actions/runs/33621485985/job/100219267217) 中有四个 OpenTUI 场景失败。external-context 和 prompt-provenance 场景缺少 OpenTUI 的 `@file` 展开和原始提示传递；protocol 测试等待了只存在于 Ink 的 UI 标记；compression 测试可能在上一条流式响应真正结束前就发送 `/compress`。这些是同一测试通道暴露出的多个 OpenTUI 行为一致性和测试同步缺口。

## Reviewer 测试计划

### 如何验证

使用 OpenTUI 渲染器运行四个受影响的交互场景，确认 external context 能够召回，submitted-prompt hook 收到原始 `@file` 文本且不会收到展开后的文件内容，protocol tag 不会显示在终端中，并且 `/compress` 能在确定性的模型响应下完成。另外，在一个 turn 正在流式输出时提交 `@file` 提示，确认下一轮发送给模型的是展开内容，而 hook 仍然只收到原始文本。

### 证据（修复前后）

修复前：链接中的 main job 在 context-compression、protocol-tags、external-context-auto-recall 和 submitted-prompt-provenance 场景失败。

修复后：精确运行这四个 OpenTUI E2E 文件，4 个文件和 5 个测试通过，1 个原有测试保持跳过。针对提交/初始化路径的单元测试共 40 个通过，针对 live-session/排队提示路径的单元测试共 26 个通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

本地 macOS checkout，使用 OpenTUI 渲染器并关闭 sandbox，与受影响的交互测试通道一致。

## 风险与范围

- 主要风险或取舍：OpenTUI 现在会等待配置初始化完成后再接受输入，与提交处理所需的初始化状态保持一致。
- 未验证/范围外：Windows 和 Linux runner 行为；无关的 Ink 渲染器行为。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #10804
Fixes #10811

</details>
