### PR TITLE
docs(design): Define relaxed standalone daemon ownership

### DIFF
--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -172,6 +172,12 @@ unsafe, or uncertain state preserves the current compromised or unavailable
 failure. The check never writes a new owner record and does not participate in
 Live discovery handoff.
 
+The check is one-shot for that daemon generation. It is not repeated after the
+Conversations runtime is published and therefore cannot detect a legacy owner
+record created later. This proposal accepts that limitation under the
+drain-and-cutover requirement below rather than adding owner polling or runtime
+read-only degradation.
+
 `createServeApp` constructs only that compatibility checker; it does not attach
 a Conversations owner to `ServeAppLifecycleController`. The lifecycle
 controller therefore has no Conversations ownership to release after shutdown;
@@ -237,10 +243,21 @@ runtime can host, including standalone, Live, scheduled-task controller, and
 scheduled-task run sessions. A source-based override would miss background
 sessions whose persisted source is not `standalone`.
 
-The default `runQwenServe` runtime factory owns this wiring. An embedded runtime
-factory supplied through `createServeApp` must honor the same
-`live-conversation` provenance contract when it creates the bridge; test fakes
-may model the resulting behavior without spawning a child.
+The default `runQwenServe` runtime factory owns this wiring.
+`createAcpSessionBridge` exposes one private immutable attestation derived from
+its frozen child-environment overrides. The attestation is true only when the
+bridge will inject both the private parent capability and the exact
+Conversations marker into every ACP child it creates.
+`ConversationRuntimeManager` includes that attestation in its owned-runtime
+validation before it accepts an existing registered runtime or publishes a new
+candidate. A missing or false attestation rejects and disposes or quarantines
+the runtime as `conversation_runtime_unavailable`; it is never exposed to
+standalone, Live, scheduled-task, lifecycle, or maintenance callers.
+
+An embedded runtime factory supplied through `createServeApp` must construct a
+bridge with the same attestation. Setting `provenance: 'live-conversation'`
+alone is insufficient. Test fakes may expose the attestation directly without
+spawning a child, but publication tests must still exercise the same check.
 
 The ACP session must acquire the lease during config initialization before it
 reports successful creation or restore. It retains the lease until session
@@ -314,11 +331,13 @@ authoritative external writer fence before manual cleanup.
 
 Forcing the lease also makes graceful managed shutdown seal and hash every
 active Conversations transcript. The implementation does not silently lengthen
-the existing child-termination deadline. Delivery therefore requires proving
-that representative maximum active-session and transcript sizes finish within
-that budget. If the timeout ends in process death while the primary record is
-still a well-formed active record, the qualified successor can recover it; a
-residual claim or uncertain transition continues to fail closed.
+the existing child-termination deadline. Measure representative maximum
+active-session and transcript sizes against that budget as a performance
+observation. If the timeout ends in process death while the primary record is
+still a well-formed active record, qualified-successor reclaim is the recovery
+path. Delivery must still prove that timeout and cancellation do not leave a
+residual claim or uncertain transition, because those states continue to fail
+closed.
 
 ### Retire owner writes without removing migration or state-directory safety
 
@@ -475,6 +494,7 @@ mixed-mode compatibility problem without serving the requested default.
 | The writer record is malformed or non-regular, or a transition claim remains     | `503 session_writer_unavailable` for that session                                                    |
 | A valid sealed record has matching transcript proof                              | Certified takeover, authoritative reload, then continue                                              |
 | A sealed record's transcript proof no longer matches                             | `409 session_transcript_changed` for that session                                                    |
+| A Conversations bridge lacks the mandatory-lease attestation                     | Reject and dispose or quarantine the runtime; `503 conversation_runtime_unavailable`                 |
 | A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                        |
 | Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response |
 
@@ -506,12 +526,13 @@ initialization removes the stale exact record and proceeds without a restart.
 This compatibility guard reduces the failure mode but does not make a rolling
 mixed-version deployment supported.
 
-The reverse direction remains unsafe: an old daemon started after updated
-daemons have mounted Conversations finds no owner record, writes one, and may
-run an unleased ACP writer beside leased writers. All daemons sharing one
-Conversations root must therefore be upgraded together. The owner-record format
-is not extended with a lease-aware marker because older strict readers would
-reject the new shape as compromised.
+The compatibility check is not repeated after runtime publication, so it cannot
+detect the reverse direction: an old daemon started after updated daemons have
+mounted Conversations finds no owner record, writes one, and may run an
+unleased ACP writer beside leased writers. All daemons sharing one Conversations
+root must therefore be upgraded together. The owner-record format is not
+extended with a lease-aware marker because older strict readers would reject
+the new shape as compromised.
 
 The writer-lock schema-version-2 owner record accepts the optional
 `pid_namespace_id`; updated Linux writers populate it when available and
@@ -546,8 +567,9 @@ Release notes must state that:
 - a provably dead same-domain active writer is recovered automatically; on
   Linux that requires the same hostname, boot, and PID namespace, while a live
   or unverifiable writer stays fenced;
-- a live old-version runtime owner still causes a transitional 503 and all
-  daemons sharing a root must be upgraded together;
+- a live old-version runtime owner present at first runtime creation still causes
+  a transitional 503, but the one-shot check cannot detect an old daemon started
+  later, so all daemons sharing a root require drain-and-cutover together;
 - the lease provides a same-session conflict fence, not multi-master support.
 
 ## Verification
@@ -567,11 +589,15 @@ for an ordinary runtime, and on for all runtimes; Conversations selects
 rejection without a private parent capability, capture before environment-file
 loading, user-level and project-level environment scrubbing, sandbox
 propagation, and isolation between primary, secondary, and Conversations bridge
-child environments. Standalone parent lifecycle and maintenance acquisitions
-must select the same `local` policy. Scheduler coverage verifies that the
-captured Conversations marker installs the unbound-durable-task skip before
-loading or catch-up detection, allows a task after it is bound to that session,
-and leaves ordinary workspace lock-owner behavior unchanged.
+child environments. Runtime-publication coverage accepts the default
+Conversations bridge and a conforming test fake, rejects and disposes a new
+`live-conversation` candidate whose bridge does not attest to the mandatory
+marker, and rejects and quarantines an equivalent existing registered runtime.
+Standalone parent lifecycle and maintenance acquisitions must select the same
+`local` policy. Scheduler coverage verifies that the captured Conversations
+marker installs the unbound-durable-task skip before loading or catch-up
+detection, allows a task after it is bound to that session, and leaves ordinary
+workspace lock-owner behavior unchanged.
 
 Core lease coverage records and validates the Linux PID namespace, treats a
 missing reclaim identity as live, reclaims dead and PID-reused owners only in
@@ -582,12 +608,13 @@ hostname and process-start rules. Existing concurrent-reclaimer, exact-record,
 transcript-proof, and crashed-reclaimer tests remain in force.
 
 Managed-shutdown coverage uses representative high active-session counts and
-large transcripts to verify that parallel sealing finishes before the existing
-termination deadline. It also verifies that a forced timeout retains the exact
-active lock while the writer process is still live and preserves the existing
-observable unclean-shutdown outcome rather than releasing ownership ambiguously.
-After that exact process exits, only a same-identity-domain contender may
-recover a well-formed active record; an uncertain transition remains fenced.
+large transcripts to measure parallel sealing against the existing termination
+deadline. It also verifies that a forced timeout retains the exact active lock
+while the writer process is still live, never leaves a residual claim or
+uncertain transition, and preserves the existing observable unclean-shutdown
+outcome rather than releasing ownership ambiguously. After that exact process
+exits, only a same-identity-domain contender may recover a well-formed active
+record.
 
 A two-process daemon integration test uses the same home, runtime base, and
 Conversations root and verifies:

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -113,6 +113,15 @@ boundary.
 - Daemons share persisted standalone sessions only when they resolve the same
   Conversations root and runtime base. Custom runtime bases retain the same
   storage separation they have for ordinary workspaces.
+- The supported topology is several daemons on one machine under one OS user.
+  Sharing the stable state base that holds the Live locator, the legacy owner
+  artifacts, and the deletion journal, or sharing a runtime base that holds
+  transcripts and session writer locks, across different physical machines is
+  outside this contract. That boundary is load-bearing rather than cosmetic: a
+  stable base reachable from more than one machine would turn the
+  single-publisher Live locator from a machine-global election into a
+  filesystem-global one, and the Darwin and Windows reclaim rule below carries
+  no boot or namespace component to separate two hosts that share a hostname.
 - Cross-process catalog changes are eventually visible through the existing
   persisted-session cache. Live state is merged only from the receiving
   daemon, so daemon B may list a session active in daemon A as persisted but
@@ -402,6 +411,12 @@ a supported identity probe, the record remains live for reclaim purposes. PID
 reuse may therefore cause a safe false conflict but never permits an unproven
 takeover.
 
+These two platforms therefore depend on the single-machine topology stated in
+the behavioral contract. With no boot or namespace component, an exact hostname
+is the whole identity domain, so two hosts that share both a hostname and a
+runtime base could each classify the other host's live writer as a locally
+absent PID. Linux is additionally separated by boot ID and PID namespace.
+
 A PID with a matching live start identity remains `session_writer_conflict`,
 including when its event loop is stalled. Foreign-host, foreign-boot,
 foreign-namespace, identity-less, malformed, non-regular, and uncertain records
@@ -688,6 +703,10 @@ Release notes must state that:
 
 - multiple daemons may expose standalone sessions for the same user;
 - active sessions are daemon-local;
+- the supported topology is several daemons on one machine under one OS user;
+  sharing the stable state base or a runtime base across physical machines is
+  unsupported, and on Darwin and Windows the stale-writer recovery rule depends
+  on that boundary;
 - different session IDs may be active concurrently across updated daemons,
   while a second writer or lifecycle mutation for the same session is fenced;
 - a safe working directory recreated after its local session generation exits

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -10,10 +10,11 @@ other isolation, persistence, and lifecycle requirements remain in force. The
 current implementation still enforces process-global Conversations ownership
 until the source changes in this design are delivered.
 
-This decision adopts Issue #10810's identity-qualified stale-writer recovery
-and legacy-owner migration guard. It intentionally narrows the issue's Web
-Shell packaging: inline conflict presentation remains an independent follow-up
-because it changes no storage or wire-safety guarantee.
+This decision adopts Issue #10810's session-keyed concurrency boundary,
+identity-qualified stale-writer recovery, legacy-owner migration guard, and
+minimum Web Shell degradation. Backend and Web Shell implementation may land in
+separate pull requests, but both are required in the same release. A proactive
+`activeElsewhere` listing hint remains a follow-up.
 
 ## Decision
 
@@ -35,22 +36,25 @@ multiple daemons may point at the same persistent workspace, while each daemon
 keeps its own ACP bridge, child process, live-session index, caches, and runtime
 generation.
 
-This is a serialized-use contract, not multi-master support. Cross-daemon
-concurrent access to the Conversations root is unsupported and is not detected
-or fully coordinated by this change. The writer lease only fences competing
-writers for the same session.
+This is a session-partitioned concurrent-use contract, not unrestricted
+multi-master support. Updated daemons may concurrently list the shared catalog,
+create sessions, and host different session IDs. Competing writers and
+lifecycle mutations for the same session remain serialized by that session's
+writer lease. The change does not add cross-daemon routing, a shared live-state
+index, atomic multi-session operations, or distributed cache invalidation.
 
 ## Motivation
 
 The current user-global owner record makes the first daemon that touches
 standalone or Live block standalone access from every other live daemon. A Web
 Shell connected to a second daemon therefore receives
-`503 conversation_runtime_in_use` even when the two daemons are never used for
-standalone at the same time.
+`503 conversation_runtime_in_use` even when it only needs the shared catalog, a
+new chat, or a different session.
 
 Ordinary workspaces do not impose a process-global runtime owner. The simpler
-and more consistent policy is to let the operator choose a daemon endpoint and
-accept the same cross-process usage constraints for standalone.
+and more consistent policy is to let each daemon serve independent sessions
+while the existing session writer protocol protects the actual shared-write
+boundary.
 
 ## Behavioral contract
 
@@ -60,17 +64,27 @@ accept the same cross-process usage constraints for standalone.
 - Another updated daemon no longer causes `conversation_runtime_in_use`. During
   migration, a live legacy runtime-owner record still returns that error until
   the old daemon exits.
+- If daemon A has session S loaded, daemon B may still list the shared catalog,
+  create a new standalone session, and create, restore, or use a different
+  session that is not held by another writer. Different session IDs may remain
+  active in different daemons at the same time.
 - A client remains attached to the daemon on which it created or restored an
   active session. Prompt, cancel, permission, status, heartbeat, detach, and
   SSE event routes are not forwarded to another daemon.
 - Creating or restoring a standalone session acquires its session writer lease
   regardless of the user's `experimental.sessionWriterLease` setting. A second
   daemon attempting to open the same active session receives the existing
-  `409 session_writer_conflict` response.
+  `409 session_writer_conflict` response. Single-session rename or repair uses
+  the same top-level response. Batch lifecycle routes keep their existing `200`
+  result envelope but preserve any session-writer error kind in the affected
+  item's `errors[]` entry. No new active-elsewhere error kind is added.
 - Every other session hosted by the Conversations runtime, including Live and
   scheduled-task sessions, uses the same mandatory lease. This prevents
   background keepalive or task rehydration from silently restoring an already
   active transcript through a non-standalone source.
+- Live discovery remains single-publisher, but a Live session on its elected
+  daemon may coexist with different standalone sessions on another daemon.
+  Standalone routes continue to reject Live records.
 - An unsealed active lock left by a non-cooperative process exit is reclaimed
   only when the new daemon can prove that the record belongs to the same local
   identity domain and that the recorded process has exited or its PID has been
@@ -101,12 +115,16 @@ accept the same cross-process usage constraints for standalone.
   `session_writer_conflict` treats the entry as being handled by another daemon,
   skips that UUID, and continues without converting contention into a
   compromised-record result.
-- Concurrent use by multiple daemons, including concurrent standalone and Live
-  use of the same Conversations root, is outside the supported contract.
+- If two daemons simultaneously rehydrate the same scheduled-task-bound
+  session, the mandatory writer lease admits exactly one resident session. The
+  losing rehydration records the restore failure through the existing
+  rehydration result and error-reporting path, then follows the existing
+  keepalive backoff without firing that session's task.
 
-"Not concurrent" applies to the complete active-session lifetime, not only to
-overlapping HTTP requests. A session that remains loaded in daemon A must not be
-continued through daemon B merely because daemon A is idle between requests.
+Same-session exclusivity applies to the complete active-session lifetime, not
+only to overlapping HTTP requests. A session that remains loaded in daemon A
+cannot be continued or mutated through daemon B merely because daemon A is idle
+between requests.
 
 ## Safety retained
 
@@ -124,12 +142,15 @@ ordinary user-selected workspace. The implementation retains:
 - the legacy runtime-owner compatibility check during migration;
 - Live discovery's own single-publisher record and validation.
 
-These mechanisms can reject some accidental overlap, but they do not make the
-new contract safe for general concurrent use. In particular, create admission,
-live owner indexes, lifecycle coordinators, directory state, reconciliation
-singleflight, and cache invalidation remain process-local. Only the
-per-journal-entry writer lease crosses the process boundary during deletion
-reconciliation.
+Daemon-local create admission, live owner indexes, lifecycle coordinators,
+directory state, reconciliation singleflight, and cache invalidation are not
+cross-process authorities. They may make remote live state appear inactive or
+delay catalog freshness, but they do not decide write ownership. The
+cross-process writer lease remains authoritative for each transcript and its
+lifecycle, scheduled-task file mutations retain their existing cross-process
+file lock, and deletion reconciliation acquires the affected session's lease.
+The contract does not promise globally fresh live state, cross-daemon event
+routing, or atomic operations spanning multiple session IDs.
 
 ## Implementation
 
@@ -181,6 +202,11 @@ was accepted or the user's startup setting enabled the lease. Per-request
 settings reloads continue to use that frozen value, so one ACP process never
 mixes leased and legacy writers.
 
+The accepted marker remains an immutable Conversations-runtime provenance
+signal inside the ACP process. The same captured boolean drives both mandatory
+writer leasing and the scheduled-task eligibility rule below; no second
+environment marker or public setting is added.
+
 For a trusted managed child carrying the Conversations marker, `runAcpAgent`
 sets `reclaimPolicy: 'local'` and keeps `takeoverPolicy: 'certified'`. Other
 trusted managed workspace children keep `reclaimPolicy: 'never'`; the marker
@@ -228,10 +254,11 @@ reconciliation. This lets archive, unarchive, delete, repair, and recovery make
 the same stale-owner decision as the ACP writer they fence. Generic workspace
 lifecycle routes and other managed runtimes keep their existing `never` policy.
 
-The lease protects one transcript. It does not coordinate session-list reads,
-random-ID creation admission, managed-directory state, deletion-journal scans,
-SSE routing, or Live discovery. Those remain governed by the serialized-use
-contract and existing daemon-local checks.
+The lease protects one transcript and its lifecycle. It does not coordinate
+session-list reads, random-ID generation, daemon-local managed-directory state,
+SSE routing, or Live discovery. Those paths keep their existing persistence,
+identity, and source-isolation checks; their daemon-local observations are not
+used as proof that a remote writer is absent.
 
 The fence covers only updated, cooperating writers hosted by the marked
 Conversations runtime. A legacy daemon or another process that writes the same
@@ -355,34 +382,75 @@ validated handoff before publication. An active foreign Live owner still blocks
 publication, and failure to publish Live discovery does not disable standalone
 routes on that daemon.
 
-This deliberately does not solve concurrent Live and standalone access from
-different daemons. Operators relying on the serialized-use contract must keep
-Live inactive on other daemons while standalone is in use.
+Live discovery remains single-publisher, while the Conversations writer lease
+is session-scoped. A Live session on the elected publisher may therefore run at
+the same time as a different standalone session on another daemon. If another
+daemon reaches the same transcript, the writer lease rejects it; standalone
+routes continue to reject Live-owned records regardless of lease availability.
 
-### Keep scheduled-task logic unchanged
+### Harden scheduled-task activation without adding another lease
 
-Do not change scheduled-task persistence, cron execution, keepalive, or boot
-rehydration. Scheduled-task controller and run sessions inherit the mandatory
-writer lease from the Conversations runtime before restore succeeds. A daemon
-that loses the lease cannot make that bound session resident; boot rehydration
-records the failure, and keepalive uses its existing retry backoff.
+Keep scheduled-task persistence, keepalive, and boot rehydration. Scheduled-task
+controller and run sessions inherit the mandatory writer lease from the
+Conversations runtime before restore succeeds. A daemon that loses the lease
+cannot make that bound session resident; boot rehydration records the failure,
+and keepalive uses its existing retry backoff.
+
+Multiple daemons may read the same scheduled-task file and simultaneously try
+to restore the same bound session while otherwise idle. Lease acquisition
+occurs before that session's scheduler can activate, so exactly one restore may
+become resident and fire bound tasks. The losing restore must not execute or
+book the task. Its conflict is retained in the existing rehydration result and
+`onError` path, not appended as a scheduled-task run. Existing cross-process
+task-file mutation locking and persisted `lastFiredAt` state remain unchanged.
+
+This prevents duplication caused solely by concurrent restore. It does not
+upgrade the scheduler to exactly-once delivery: the existing at-least-once
+window after a prompt is dispatched but before its fired state is durably
+persisted remains unchanged, including across a subsequent owner crash.
+
+Unbound durable tasks need a separate admission rule because two keepalive
+workers may initially mint different controller session IDs, so a session
+writer lease cannot elect between them yet. In the marked Conversations ACP
+runtime, install a scheduler eligibility predicate before durable loading that
+refuses to fire any unbound durable task. The daemon keepalive remains the only
+component that binds such a task. Its existing `updateCronTasks` transaction
+rechecks the unbound state under the cross-process task-file lock, commits one
+controller session ID, and tears down a losing orphan. Once that binding is
+visible, only the matching bound session is eligible to fire the task. Ordinary
+workspace schedulers retain the existing unbound lock-owner behavior.
+
+The default `runQwenServe` path enables the daemon-managed binding worker. An
+embedded host that opts into the Conversations marker without enabling that
+worker leaves unbound Conversations tasks dormant; it must not fall back to
+legacy lock-owner execution. Bound tasks continue to use their recorded session
+ID and the session writer lease in either host shape.
 
 Keep the existing product boundaries: durable cron jobs remain unsupported in
 standalone sessions, and generic scheduled-task routes cannot create a new
 session in the Conversations workspace. This change only fences existing
 background writers; it does not add standalone scheduling functionality.
 
-### Keep the Web Shell contract unchanged
+### Ship minimum Web Shell degradation in the same release
 
 Do not add an `activeElsewhere` list field or a new client-side owner-discovery
 protocol. Every daemon can list persisted standalone sessions after the outer
 gate is removed, while an attempt to restore a session held by another daemon
-continues to return the existing `409 session_writer_conflict`. The Web Shell
-may surface that real attach conflict through its existing error path.
+continues to return the existing `409 session_writer_conflict`.
 
-A quieter inline conflict treatment can be delivered independently as product
-polish. It is not required for storage safety and does not belong in the
-backend ownership change.
+The backend and Web Shell work may land as separate pull requests, but the
+release is incomplete until the client presents the resulting states locally:
+
+- standalone list failures and the transitional
+  `conversation_runtime_in_use` response render once in the Recents section,
+  not through the global error toast on every navigation-triggered refetch;
+- `session_writer_conflict` and `session_writer_unavailable` from opening a
+  session render on the affected row or section with a retry action rather than
+  as a global toast.
+
+An `activeElsewhere` hint remains deferred because listing has no authoritative
+cross-daemon live-state index. The client reacts to the existing attach-time
+error contract instead.
 
 ### Do not add routing or coordination
 
@@ -399,7 +467,9 @@ mixed-mode compatibility problem without serving the requested default.
 
 | Condition                                                                        | Result                                                                                               |
 | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Another updated daemon has the session loaded                                    | `409 session_writer_conflict` for that session                                                       |
+| Another updated daemon has a different session loaded                            | Listing, new-session creation, and operations on the different session continue                      |
+| Another updated daemon has the session loaded for open, rename, or repair        | `409 session_writer_conflict` for that session                                                       |
+| A batch archive or delete includes a session loaded by another updated daemon    | Existing `200` batch envelope with that item's `errors[].code` set to `session_writer_conflict`      |
 | A well-formed active owner is provably dead in the same local identity domain    | Reclaim, authoritative transcript reload, then continue                                              |
 | The active owner is live, stalled, foreign, or missing required reclaim identity | `409 session_writer_conflict` for that session                                                       |
 | The writer record is malformed or non-regular, or a transition claim remains     | `503 session_writer_unavailable` for that session                                                    |
@@ -408,11 +478,23 @@ mixed-mode compatibility problem without serving the requested default.
 | A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                        |
 | Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response |
 
+For every writer-state row, a batch lifecycle route preserves the same error
+kind in its existing `200` per-item result rather than changing the batch's
+transport status.
+
+The Web Shell renders list-level failures and the transitional runtime-owner
+error in the Recents section. It renders same-session writer errors on the
+affected session or section with retry, without sending navigation-triggered
+refetch failures through the global toast path.
+
 ## Compatibility and rollout
 
-The REST and SDK shapes are unchanged. `standalone_sessions_v1` and
-`standalone_session_options_v1` continue to describe API support; no capability
-is added for a weaker concurrency guarantee.
+The REST and SDK object shapes are unchanged. The daemon batch serializer must
+stop collapsing session-writer errors into
+`standalone_session_operation_failed` and preserve the existing writer error
+kind in the affected item's string `code`; the SDK already accepts string batch
+codes. `standalone_sessions_v1` and `standalone_session_options_v1` continue to
+describe API support, and no capability is added for the concurrency guarantee.
 
 Rollout is a drain-and-cutover, not a rolling mixed-version upgrade. Stop every
 daemon version that can host standalone sessions without the mandatory lease,
@@ -447,10 +529,20 @@ Release notes must state that:
 
 - multiple daemons may expose standalone sessions for the same user;
 - active sessions are daemon-local;
-- callers are responsible for avoiding cross-daemon concurrent use;
+- different session IDs may be active concurrently across updated daemons,
+  while a second writer or lifecycle mutation for the same session is fenced;
+- same-session conflicts reuse `session_writer_conflict`, including in the
+  existing per-item error of a batch lifecycle response;
 - standalone sessions always use the writer lease, even when the experimental
   setting is absent or false;
 - Live and scheduled-task writers in the Conversations runtime use it as well;
+- simultaneous scheduled-task rehydration admits only one resident owner and
+  does not provide exactly-once delivery beyond the scheduler's existing
+  persistence semantics;
+- an unbound task cannot fire from a Conversations session until the
+  cross-process task-file transaction has committed its controller binding;
+- standalone list and attach failures use the inline Web Shell treatment above
+  instead of repeated global navigation toasts;
 - a provably dead same-domain active writer is recovered automatically; on
   Linux that requires the same hostname, boot, and PID namespace, while a live
   or unverifiable writer stays fenced;
@@ -476,7 +568,10 @@ rejection without a private parent capability, capture before environment-file
 loading, user-level and project-level environment scrubbing, sandbox
 propagation, and isolation between primary, secondary, and Conversations bridge
 child environments. Standalone parent lifecycle and maintenance acquisitions
-must select the same `local` policy.
+must select the same `local` policy. Scheduler coverage verifies that the
+captured Conversations marker installs the unbound-durable-task skip before
+loading or catch-up detection, allows a task after it is bound to that session,
+and leaves ordinary workspace lock-owner behavior unchanged.
 
 Core lease coverage records and validates the Linux PID namespace, treats a
 missing reclaim identity as live, reclaims dead and PID-reused owners only in
@@ -504,26 +599,40 @@ Conversations root and verifies:
 3. a live legacy runtime-owner record returns
    `503 conversation_runtime_in_use`, and after its process exits the next
    request retires the stale record and returns `200` without restarting;
-4. while daemon A keeps a standalone session active, daemon B receives
-   `409 session_writer_conflict` when it tries to restore that session;
-5. after an explicit close releases A's lease, B restores that session through
+4. while daemon A keeps standalone session S active, daemon B can still list
+   the catalog, create a new chat T, and restore and use a different persisted
+   session without closing S;
+5. while A keeps S active, B receives `409 session_writer_conflict` when it
+   tries to restore, rename, or repair S; archive and delete keep their `200`
+   batch envelope and report `session_writer_conflict` for S without inventing
+   a new error kind;
+6. after an explicit close releases A's lease, B restores S through
    ordinary acquisition; independently, after graceful shutdown seals another
    session owned by A, B restores it through certified takeover;
-6. after A's lock-owning ACP writer is killed in a steady active state, B in the
+7. after A's lock-owning ACP writer is killed in a steady active state, B in the
    same local identity domain reclaims the lock, authoritatively reloads the
    transcript, and continues it without manual cleanup; killing only A's parent
    while that writer remains live still returns a conflict;
-7. a matching live or stalled A, and records from a foreign host, boot, or PID
+8. a matching live or stalled A, and records from a foreign host, boot, or PID
    namespace, remain `409 session_writer_conflict`; identity-less and residual
    claim states remain fail closed;
-8. shutting down either daemon does not remove or invalidate the other's local
+9. shutting down either daemon does not remove or invalidate the other's local
    runtime;
-9. a scheduled-task session active in A cannot be rehydrated in B, and only A's
-   scheduler fires its bound task;
-10. two daemons reconciling the same prepared deletion elect one lease holder;
+10. two otherwise idle daemons that simultaneously rehydrate the same
+    scheduled-task-bound session elect one resident session through the writer
+    lease; the loser records a restore failure and backs off, and only the
+    winner fires the bound task for that slot;
+11. two keepalive workers that observe the same unbound task may mint competing
+    controller sessions, but no Conversations session fires it while unbound;
+    the task-file transaction commits exactly one binding, cleans up the losing
+    orphan, and only the bound controller becomes eligible to fire;
+12. two daemons reconciling the same prepared deletion elect one lease holder;
     the contender skips that UUID without failing the unrelated triggering
     operation or reporting journal compromise;
-11. root compromise and unavailable generations still fail closed without
+13. a Live session on the elected Live daemon and a different standalone
+    session on the other daemon remain usable concurrently, while standalone
+    routes continue to reject the Live record;
+14. root compromise and unavailable generations still fail closed without
     falling back to the primary workspace.
 
 Live regression coverage verifies that Live discovery still has at most one
@@ -531,11 +640,20 @@ publisher, that the publication path performs the existing validated handoff
 for the stable base as well as custom bases, and that a stale stable-base record
 can be reclaimed after its previous owner exits. Standalone availability
 remains independent of discovery publication failure and of which daemon
-published the record.
+published the record. It also covers a Live-enabled daemon and a second daemon
+serving a different standalone session at the same time.
 
-No test may treat the same-session conflict as proof of general cross-daemon
-safety. Different-session lifecycle and catalog operations remain outside the
-concurrent-use contract.
+Web Shell regression coverage verifies that switching sessions does not emit a
+toast when standalone listing fails, that a transitional
+`conversation_runtime_in_use` response appears once in the Recents section,
+and that `session_writer_conflict` and `session_writer_unavailable` on open are
+attached to the affected session or section with a retry action. It does not
+require an `activeElsewhere` list field.
+
+Tests must prove both sides of the boundary: different session IDs can be used
+concurrently across updated daemons, while the same session remains exclusive
+for its complete loaded lifetime. They must not imply globally fresh live
+state, cross-daemon event routing, or atomic multi-session operations.
 
 ## Rejected alternatives
 
@@ -552,13 +670,14 @@ concurrent-use contract.
 - **Enabling the lease only for `sourceType=standalone`:** misses Live and
   scheduled-task sources hosted by the same Conversations runtime, including
   background rehydration that occurs without a standalone API request.
-- **Bundling new Web Shell ownership UI:** an `activeElsewhere` hint or inline
-  conflict state requires a new product contract but does not strengthen the
-  storage fence. Keep the backend decision independently reviewable and handle
-  that optional presentation change separately.
-- **Cross-process multi-master coordination:** would require durable create,
-  lifecycle, recovery, owner-routing, and cache protocols. That is a different
-  reliability contract and is unnecessary for serialized use.
+- **Adding `activeElsewhere` to listings now:** requires an authoritative shared
+  live-state index or owner-discovery protocol. The minimum Web Shell behavior
+  can use the existing attach-time error contract without adding that backend
+  coordination.
+- **A shared routing or global transaction plane:** daemon-to-daemon event
+  routing, globally fresh live state, and atomic operations spanning sessions
+  are different reliability contracts. They are unnecessary for concurrent
+  use partitioned by the existing session writer lease.
 - **Unqualified stale-writer reclaim:** PID, hostname, age, or inactivity alone
   cannot prove that a managed writer on shared storage is dead. Automatic
   recovery is limited to a matching local identity domain and stable process

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -243,21 +243,44 @@ runtime can host, including standalone, Live, scheduled-task controller, and
 scheduled-task run sessions. A source-based override would miss background
 sessions whose persisted source is not `standalone`.
 
-The default `runQwenServe` runtime factory owns this wiring.
-`createAcpSessionBridge` exposes one private immutable attestation derived from
-its frozen child-environment overrides. The attestation is true only when the
-bridge will inject both the private parent capability and the exact
-Conversations marker into every ACP child it creates.
-`ConversationRuntimeManager` includes that attestation in its owned-runtime
-validation before it accepts an existing registered runtime or publishes a new
-candidate. A missing or false attestation rejects and disposes or quarantines
-the runtime as `conversation_runtime_unavailable`; it is never exposed to
-standalone, Live, scheduled-task, lifecycle, or maintenance callers.
+The default `runQwenServe` runtime factory owns this wiring. Its per-runtime
+channel factory is produced by `createSpawnChannelFactory`, which merges the
+factory's second argument into the actual child environment through
+`scrubChildEnv`. `createSpawnChannelFactory` marks every returned factory with
+a package-owned, immutable child-environment-forwarding capability;
+`defaultSpawnChannelFactory` carries the same capability because that helper
+creates it. The check uses the capability, not reference equality with the
+default factory, because `runQwenServe` supplies a separately configured
+factory to every runtime.
 
-An embedded runtime factory supplied through `createServeApp` must construct a
-bridge with the same attestation. Setting `provenance: 'live-conversation'`
-alone is insufficient. Test fakes may expose the attestation directly without
-spawning a child, but publication tests must still exercise the same check.
+`createAcpSessionBridge` derives one private immutable mandatory-lease
+attestation from the conjunction of two conditions: the frozen child-environment
+overrides carry the exact Conversations marker, and the selected
+`channelFactory` carries the forwarding capability. Immediately before each
+spawn, the bridge combines the frozen overrides with the fresh private parent
+capability in the factory-argument map, so an attested factory forwards both
+values to the child. A marker-shaped override map paired with an unattested
+custom factory that ignores the second argument does not attest.
+
+`ConversationRuntimeManager` includes the bridge attestation in its
+owned-runtime validation before it accepts an existing registered runtime or
+publishes a new candidate. A missing or false attestation is a static runtime
+contract violation: it rejects and disposes or quarantines the runtime as the
+existing non-retryable `conversation_root_compromised`, and the runtime is never
+exposed to standalone, Live, scheduled-task, lifecycle, or maintenance callers.
+
+An embedded runtime factory supplied through `createServeApp` must either use a
+factory returned by `createSpawnChannelFactory` or explicitly attest an
+equivalent custom factory at the factory level through the trusted embedding
+seam, then construct its bridge with the exact marker. An unattested custom
+factory remains valid for ordinary bridges but fails Conversations publication;
+setting `provenance: 'live-conversation'` or supplying a marker-shaped override
+map alone is insufficient. A test fake may deliberately attest its factory
+through the dedicated test seam without spawning a child, but publication tests
+must still exercise the conjunction rather than infer it from the bridge
+options' shape. This is a contract against accidental same-process miswiring,
+not a security boundary against embedding code that already has authority to
+construct arbitrary runtime objects.
 
 The ACP session must acquire the lease during config initialization before it
 reports successful creation or restore. It retains the lease until session
@@ -494,7 +517,7 @@ mixed-mode compatibility problem without serving the requested default.
 | The writer record is malformed or non-regular, or a transition claim remains     | `503 session_writer_unavailable` for that session                                                    |
 | A valid sealed record has matching transcript proof                              | Certified takeover, authoritative reload, then continue                                              |
 | A sealed record's transcript proof no longer matches                             | `409 session_transcript_changed` for that session                                                    |
-| A Conversations bridge lacks the mandatory-lease attestation                     | Reject and dispose or quarantine the runtime; `503 conversation_runtime_unavailable`                 |
+| A Conversations bridge lacks the mandatory-lease attestation                     | Reject and dispose or quarantine the runtime; non-retryable `503 conversation_root_compromised`      |
 | A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                        |
 | Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response |
 
@@ -589,15 +612,21 @@ for an ordinary runtime, and on for all runtimes; Conversations selects
 rejection without a private parent capability, capture before environment-file
 loading, user-level and project-level environment scrubbing, sandbox
 propagation, and isolation between primary, secondary, and Conversations bridge
-child environments. Runtime-publication coverage accepts the default
-Conversations bridge and a conforming test fake, rejects and disposes a new
-`live-conversation` candidate whose bridge does not attest to the mandatory
-marker, and rejects and quarantines an equivalent existing registered runtime.
-Standalone parent lifecycle and maintenance acquisitions must select the same
-`local` policy. Scheduler coverage verifies that the captured Conversations
-marker installs the unbound-durable-task skip before loading or catch-up
-detection, allows a task after it is bound to that session, and leaves ordinary
-workspace lock-owner behavior unchanged.
+child environments. Factory coverage verifies that both the default factory
+and each configured factory returned by `createSpawnChannelFactory` carry the
+forwarding capability and merge the bridge's second argument through
+`scrubChildEnv`. Bridge-attestation coverage accepts the exact marker with such
+a factory or a deliberately attested test fake, rejects the marker with an
+unattested factory that ignores its second argument, and rejects a capable
+factory when the marker is absent or wrong. Runtime-publication coverage accepts
+the conforming Conversations bridge, rejects and disposes a non-conforming new
+`live-conversation` candidate, and rejects and quarantines an equivalent
+existing registered runtime with non-retryable
+`conversation_root_compromised`. Standalone parent lifecycle and maintenance
+acquisitions must select the same `local` policy. Scheduler coverage verifies
+that the captured Conversations marker installs the unbound-durable-task skip
+before loading or catch-up detection, allows a task after it is bound to that
+session, and leaves ordinary workspace lock-owner behavior unchanged.
 
 Core lease coverage records and validates the Linux PID namespace, treats a
 missing reclaim identity as live, reclaims dead and PID-reused owners only in

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -265,9 +265,13 @@ custom factory that ignores the second argument does not attest.
 `ConversationRuntimeManager` includes the bridge attestation in its
 owned-runtime validation before it accepts an existing registered runtime or
 publishes a new candidate. A missing or false attestation is a static runtime
-contract violation: it rejects and disposes or quarantines the runtime as the
-existing non-retryable `conversation_root_compromised`, and the runtime is never
-exposed to standalone, Live, scheduled-task, lifecycle, or maintenance callers.
+contract violation. A new candidate is rejected and disposed; an equivalent
+existing registered runtime is terminally quarantined. The manager retains the
+non-retryable `conversation_root_compromised` error as that quarantine's
+terminal reason, and every later `ensure()` or current-runtime assertion
+rethrows the same error instead of degrading it to retryable
+`conversation_runtime_unavailable`. The runtime is never exposed to standalone,
+Live, scheduled-task, lifecycle, or maintenance callers.
 
 An embedded runtime factory supplied through `createServeApp` must either use a
 factory returned by `createSpawnChannelFactory` or explicitly attest an
@@ -378,6 +382,14 @@ journal derives its state parent directly and retains private-directory
 creation, identity validation, and durability checks; it has no owner record,
 process liveness check, lock, grace period, acquire, or release operation.
 
+Preserve the existing directory-permission asymmetry when moving that logic.
+On POSIX systems, the `conversations/` leaf and its journal subtree require
+mode `0700`, and newly created directories use that mode. The stable state root
+and any existing ancestors must still be owned, non-symlink directories whose
+canonical identity remains stable, but their historical mode is not required
+to be `0700` and is not changed. In particular, an existing mode-`0755`
+`~/.qwen` remains valid.
+
 `StandaloneDeletionJournal` validates that parent before entering its journal
 subtree on every read, recovery, clear, and write path. Reads treat a missing
 state directory as empty; the first write safely creates it. An existing unsafe
@@ -418,6 +430,17 @@ to the Live publication path: immediately before `writeLiveDiscoveryFile()`,
 call `handoffLiveDiscoveryOwner()` for every target base, including the stable
 base. Conversations runtime initialization itself no longer participates in
 Live discovery ownership.
+
+The publication path uses the existing custom-base handoff semantics for every
+target: it passes a no-op `commitOwner` callback because there is no longer a
+Conversations owner record to commit, and it leaves `waitForHandoffGrace` at
+its default. On stale-owner reclaim, `handoffLiveDiscoveryOwner()` removes the
+validated dead locator while holding the Live lock, releases that lock, and
+then performs the existing handoff grace before returning. Publication then
+calls `writeLiveDiscoveryFile()`, which reacquires the Live lock and rejects a
+competing live publisher. The no-op deliberately removes the old cross-record
+ordering dependency; the post-lock Live grace is preserved rather than moved
+under the lock or retired.
 
 A stale discovery record can therefore still be reclaimed through the existing
 validated handoff before publication. An active foreign Live owner still blocks
@@ -507,19 +530,19 @@ mixed-mode compatibility problem without serving the requested default.
 
 ## Error contract
 
-| Condition                                                                        | Result                                                                                               |
-| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Another updated daemon has a different session loaded                            | Listing, new-session creation, and operations on the different session continue                      |
-| Another updated daemon has the session loaded for open, rename, or repair        | `409 session_writer_conflict` for that session                                                       |
-| A batch archive or delete includes a session loaded by another updated daemon    | Existing `200` batch envelope with that item's `errors[].code` set to `session_writer_conflict`      |
-| A well-formed active owner is provably dead in the same local identity domain    | Reclaim, authoritative transcript reload, then continue                                              |
-| The active owner is live, stalled, foreign, or missing required reclaim identity | `409 session_writer_conflict` for that session                                                       |
-| The writer record is malformed or non-regular, or a transition claim remains     | `503 session_writer_unavailable` for that session                                                    |
-| A valid sealed record has matching transcript proof                              | Certified takeover, authoritative reload, then continue                                              |
-| A sealed record's transcript proof no longer matches                             | `409 session_transcript_changed` for that session                                                    |
-| A Conversations bridge lacks the mandatory-lease attestation                     | Reject and dispose or quarantine the runtime; non-retryable `503 conversation_root_compromised`      |
-| A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                        |
-| Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response |
+| Condition                                                                        | Result                                                                                                                                                    |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Another updated daemon has a different session loaded                            | Listing, new-session creation, and operations on the different session continue                                                                           |
+| Another updated daemon has the session loaded for open, rename, or repair        | `409 session_writer_conflict` for that session                                                                                                            |
+| A batch archive or delete includes a session loaded by another updated daemon    | Existing `200` batch envelope with that item's `errors[].code` set to `session_writer_conflict`                                                           |
+| A well-formed active owner is provably dead in the same local identity domain    | Reclaim, authoritative transcript reload, then continue                                                                                                   |
+| The active owner is live, stalled, foreign, or missing required reclaim identity | `409 session_writer_conflict` for that session                                                                                                            |
+| The writer record is malformed or non-regular, or a transition claim remains     | `503 session_writer_unavailable` for that session                                                                                                         |
+| A valid sealed record has matching transcript proof                              | Certified takeover, authoritative reload, then continue                                                                                                   |
+| A sealed record's transcript proof no longer matches                             | `409 session_transcript_changed` for that session                                                                                                         |
+| A Conversations bridge lacks the mandatory-lease attestation                     | Reject and dispose a new candidate, or terminally quarantine an existing runtime; every request remains non-retryable `503 conversation_root_compromised` |
+| A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                                                                             |
+| Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response                                                      |
 
 For every writer-state row, a batch lifecycle route preserves the same error
 kind in its existing `200` per-item result rather than changing the batch's
@@ -601,10 +624,11 @@ Unit tests cover server bootstrap without a long-lived legacy owner, live and
 stale legacy-owner compatibility checks, strict malformed-owner failures,
 runtime initialization without lifetime ownership, shutdown without owner
 release, retained root/generation/quarantine failures, deletion-journal
-state-parent creation and compromise detection, journal bootstrap without owner
-acquisition, parent revalidation on journal read/recovery/write paths,
-contention-as-skip during background reconciliation, and runtime-provenance
-writer-lease selection.
+state-parent creation and compromise detection, acceptance of a historical
+non-`0700` state root alongside rejection of a non-private `conversations/`
+leaf, journal bootstrap without owner acquisition, parent revalidation on
+journal read/recovery/write paths, contention-as-skip during background
+reconciliation, and runtime-provenance writer-lease selection.
 
 The writer matrix covers the user setting off for a Conversations runtime, off
 for an ordinary runtime, and on for all runtimes; Conversations selects
@@ -621,12 +645,13 @@ unattested factory that ignores its second argument, and rejects a capable
 factory when the marker is absent or wrong. Runtime-publication coverage accepts
 the conforming Conversations bridge, rejects and disposes a non-conforming new
 `live-conversation` candidate, and rejects and quarantines an equivalent
-existing registered runtime with non-retryable
-`conversation_root_compromised`. Standalone parent lifecycle and maintenance
-acquisitions must select the same `local` policy. Scheduler coverage verifies
-that the captured Conversations marker installs the unbound-durable-task skip
-before loading or catch-up detection, allows a task after it is bound to that
-session, and leaves ordinary workspace lock-owner behavior unchanged.
+existing registered runtime while preserving non-retryable
+`conversation_root_compromised` on every later access. Standalone parent
+lifecycle and maintenance acquisitions must select the same `local` policy.
+Scheduler coverage verifies that the captured Conversations marker installs the
+unbound-durable-task skip before loading or catch-up detection, allows a task
+after it is bound to that session, and leaves ordinary workspace lock-owner
+behavior unchanged.
 
 Core lease coverage records and validates the Linux PID namespace, treats a
 missing reclaim identity as live, reclaims dead and PID-reused owners only in
@@ -694,7 +719,10 @@ Conversations root and verifies:
 Live regression coverage verifies that Live discovery still has at most one
 publisher, that the publication path performs the existing validated handoff
 for the stable base as well as custom bases, and that a stale stable-base record
-can be reclaimed after its previous owner exits. Standalone availability
+can be reclaimed after its previous owner exits. It verifies the no-op
+`commitOwner` handoff, that the existing grace runs after the handoff lock is
+released and before publication, and that a competing publisher during that
+gap is rejected by the publication lock. Standalone availability
 remains independent of discovery publication failure and of which daemon
 published the record. It also covers a Live-enabled daemon and a second daemon
 serving a different standalone session at the same time.

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -549,6 +549,23 @@ microphone capture, or Appshot capture. No production start caller may bypass
 this seam; stop and mute remain daemon-local operations on an already admitted
 call.
 
+Because the seam is asynchronous while the Host action dispatcher and the HTTP
+routes are not, a pending admission must linearize with later start-or-stop
+intents. Admission captures a coordinator action generation when a start enters
+the seam; every later Host `stop`, `toggle`, or `new` action and every later
+`/live/start`, `/live/new`, or `/live/stop` request advances that generation,
+whether or not a call exists at that moment. The seam rechecks the generation
+immediately before `LiveHostCoordinator.start()` and drops a superseded start
+without creating a session or activating capture: a stop that arrives while a
+start admission is still pending must not be followed by a call starting when
+that admission resolves. The coordinator's existing action epoch cannot express
+this ordering because it advances only when a call is created, so the
+generation lives beside the epoch and covers the pre-start window. The deferred
+`startCall()` continuation of an admitted `start('new')` is not a separate
+start caller: it carries the admission and generation captured by the
+originating request, and the existing teardown and disable paths already clear
+it.
+
 Live discovery and activation remain single-publisher, while the Conversations
 writer lease is session-scoped. A Live session on the elected publisher may
 therefore run at the same time as a different standalone session on another
@@ -860,7 +877,11 @@ nonce, rejects a valid different publisher with the existing retryable error,
 and fails missing, malformed, unsafe, or unreadable locator state closed without
 quarantining standalone.
 Both HTTP start routes and both Host-originated start actions use the same
-admission and perform no session or capture work on rejection. Standalone
+admission and perform no session or capture work on rejection. Admission
+linearization coverage proves that a start superseded while its admission is
+pending — by a later stop, toggle, or new intent through either entry family —
+performs no session or capture work once that admission resolves, and only the
+latest intent may activate a call. Standalone
 availability remains independent of discovery publication failure and of which
 daemon published the record. It also covers the elected daemon running Live
 while a second Live-enabled daemon serves a different standalone session.

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -12,9 +12,11 @@ until the source changes in this design are delivered.
 
 This decision adopts Issue #10810's session-keyed concurrency boundary,
 identity-qualified stale-writer recovery, legacy-owner migration guard, and
-minimum Web Shell degradation. Backend and Web Shell implementation may land in
-separate pull requests, but both are required in the same release. A proactive
-`activeElsewhere` listing hint remains a follow-up.
+minimum Web Shell degradation. It corrects the issue's Live assumption: the
+locator record gates publication but not activation today, so the same release
+must add a Live-start publisher gate. Backend and Web Shell implementation may
+land in separate pull requests, but both are required in the same release. A
+proactive `activeElsewhere` listing hint remains a follow-up.
 
 ## Decision
 
@@ -43,6 +45,13 @@ lifecycle mutations for the same session remain serialized by that session's
 writer lease. The change does not add cross-daemon routing, a shared live-state
 index, atomic multi-session operations, or distributed cache invalidation.
 
+Live activation remains a machine-global exception. Only the daemon whose PID
+and instance nonce exactly match the stable Live discovery record may start or
+replace a Live call. Other updated daemons may still serve standalone sessions,
+but their `/live/start` and `/live/new` requests return the existing retryable
+`503 conversation_runtime_in_use`; host-originated toggle and new actions are
+also rejected before call activation.
+
 ## Motivation
 
 The current user-global owner record makes the first daemon that touches
@@ -61,9 +70,9 @@ boundary.
 - `GET /standalone/session-options` and every `/standalone/sessions` route may
   initialize the local daemon's Conversations runtime even when another updated
   daemon process is alive.
-- Another updated daemon no longer causes `conversation_runtime_in_use`. During
-  migration, a live legacy runtime-owner record still returns that error until
-  the old daemon exits.
+- Another updated daemon no longer causes `conversation_runtime_in_use` on the
+  standalone surface. During migration, a live legacy runtime-owner record
+  still returns that error until the old daemon exits.
 - If daemon A has session S loaded, daemon B may still list the shared catalog,
   create a new standalone session, and create, restore, or use a different
   session that is not held by another writer. Different session IDs may remain
@@ -82,9 +91,11 @@ boundary.
   scheduled-task sessions, uses the same mandatory lease. This prevents
   background keepalive or task rehydration from silently restoring an already
   active transcript through a non-standalone source.
-- Live discovery remains single-publisher, but a Live session on its elected
-  daemon may coexist with different standalone sessions on another daemon.
-  Standalone routes continue to reject Live records.
+- Live discovery and Live activation remain single-publisher. `/live/start`,
+  `/live/new`, and host-originated start actions succeed only on the daemon
+  whose PID and instance nonce match the stable Live discovery record. A Live
+  session on that daemon may coexist with different standalone sessions on
+  another daemon. Standalone routes continue to reject Live records.
 - An unsealed active lock left by a non-cooperative process exit is reclaimed
   only when the new daemon can prove that the record belongs to the same local
   identity domain and that the recorded process has exited or its PID has been
@@ -140,7 +151,8 @@ ordinary user-selected workspace. The implementation retains:
 - mandatory active-session writer leases throughout the Conversations runtime;
 - identity-qualified recovery of provably stale same-domain active locks;
 - the legacy runtime-owner compatibility check during migration;
-- Live discovery's own single-publisher record and validation.
+- Live discovery's single-publisher record and validation;
+- Live-start admission that accepts only the exact stable locator publisher.
 
 Daemon-local create admission, live owner indexes, lifecycle coordinators,
 directory state, reconciliation singleflight, and cache invalidation are not
@@ -148,11 +160,26 @@ cross-process authorities. They may make remote live state appear inactive or
 delay catalog freshness, but they do not decide write ownership. The
 cross-process writer lease remains authoritative for each transcript and its
 lifecycle, scheduled-task file mutations retain their existing cross-process
-file lock, and deletion reconciliation acquires the affected session's lease.
-The contract does not promise globally fresh live state, cross-daemon event
-routing, or atomic operations spanning multiple session IDs.
+file lock, deletion reconciliation acquires the affected session's lease, and
+the stable locator record remains authoritative for Live publication,
+discovery, and machine-global activation, but not transcript ownership. The
+contract does not promise globally fresh live state, cross-daemon event routing,
+or atomic operations spanning multiple session IDs.
 
 ## Implementation
+
+The long-lived Conversations acquire currently supplies three behavioral gates.
+Removing it is complete only when every consumer has an explicit replacement:
+
+| Consumer                                | Replacement                                                                                                |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Standalone access to the shared runtime | No process-global gate; session writers and lifecycle operations use the mandatory writer lease            |
+| Scheduled-task activation               | Mandatory writer lease for bound sessions, plus the unbound-task eligibility and binding transaction below |
+| Machine-global Live activation          | Exact stable-locator publisher admission before every Live start path                                      |
+
+The acquire's state-directory bootstrap and stable Live handoff side effects are
+separately moved to the deletion journal and Live publication paths below. No
+consumer continues to rely on the removed lifetime owner implicitly.
 
 ### Replace the outer owner with a legacy compatibility check
 
@@ -414,15 +441,20 @@ record is durably removed. The lock remains a transient guard for this
 compatibility operation and is not held for the runtime lifetime.
 
 The server retains `conversation_runtime_in_use` only for this old-version
-migration case and for existing Live-specific mappings. Updated daemons do not
-emit it merely because another updated daemon has mounted Conversations.
+migration case and for Live-start admission on a non-publisher. Updated daemons
+do not emit it merely because another updated daemon has mounted Conversations.
 `conversation_runtime_unavailable`, `conversation_root_compromised`, and
 daemon-local runtime-invariant failures remain unchanged.
 
 ### Keep Live discovery separate
 
 Keep the ownership protocol in `live/discovery.ts` unchanged. Its owner record
-selects one discoverable Live host and protects publication of that endpoint.
+selects one discoverable Live host and protects publication of that endpoint;
+publication alone does not currently gate activation through `/live/start`,
+`/live/new`, or Host shortcut actions. Today the removed Conversations acquire
+indirectly supplies that activation gate. The replacement must therefore cover
+both publication and every start path.
+
 The removed Conversations owner currently performs the stable-base discovery
 handoff as a side effect of runtime acquisition, while the publication path
 performs that handoff only for non-stable target bases. Move that responsibility
@@ -447,11 +479,34 @@ validated handoff before publication. An active foreign Live owner still blocks
 publication, and failure to publish Live discovery does not disable standalone
 routes on that daemon.
 
-Live discovery remains single-publisher, while the Conversations writer lease
-is session-scoped. A Live session on the elected publisher may therefore run at
-the same time as a different standalone session on another daemon. If another
-daemon reaches the same transcript, the writer lease rejects it; standalone
-routes continue to reject Live-owned records regardless of lease availability.
+Add a read-only Live-start admission using the same stable-base directory
+identity checks, lock, safe record parser, and exact owner comparison. After
+awaiting publication and immediately before call activation, it rereads the
+stable locator and requires the current protocol version plus a
+`{ pid, instanceNonce }` match with the local daemon. It never creates,
+replaces, removes, or reclaims a record. A valid different publisher maps to
+the existing retryable
+`conversation_runtime_in_use`; a missing or transiently unreadable locator is
+`conversation_runtime_unavailable`, and malformed or unsafe state remains
+non-retryable `conversation_runtime_ownership_compromised`. These failures are
+Live-local and do not quarantine the Conversations runtime or disable
+standalone routes.
+
+Route-originated `/live/start` and `/live/new` requests and Host-originated
+`toggle` and `new` actions must enter one asynchronous admission seam before
+`LiveHostCoordinator.start()`. The HTTP routes retain their existing structured
+503 serialization. A rejected Host action publishes the existing non-secret
+Live unavailable/error state and must not invoke the Live session coordinator,
+microphone capture, or Appshot capture. No production start caller may bypass
+this seam; stop and mute remain daemon-local operations on an already admitted
+call.
+
+Live discovery and activation remain single-publisher, while the Conversations
+writer lease is session-scoped. A Live session on the elected publisher may
+therefore run at the same time as a different standalone session on another
+daemon. If another daemon reaches the same transcript, the writer lease rejects
+it; standalone routes continue to reject Live-owned records regardless of lease
+availability.
 
 ### Harden scheduled-task activation without adding another lease
 
@@ -543,6 +598,8 @@ mixed-mode compatibility problem without serving the requested default.
 | A Conversations bridge lacks the mandatory-lease attestation                     | Reject and dispose a new candidate, or terminally quarantine an existing runtime; every request remains non-retryable `503 conversation_root_compromised` |
 | A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                                                                             |
 | Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response                                                      |
+| A daemon that is not the stable Live locator publisher attempts to start Live    | `503 conversation_runtime_in_use` for `/live/start` or `/live/new`; standalone remains available                                                          |
+| Stable Live locator state is missing, unreadable, malformed, or unsafe at start  | Fail Live start closed with the existing unavailable or ownership-compromised mapping; standalone remains available                                       |
 
 For every writer-state row, a batch lifecycle route preserves the same error
 kind in its existing `200` per-item result rather than changing the batch's
@@ -603,6 +660,8 @@ Release notes must state that:
 - standalone sessions always use the writer lease, even when the experimental
   setting is absent or false;
 - Live and scheduled-task writers in the Conversations runtime use it as well;
+- only the exact stable Live locator publisher may activate Live; another daemon
+  continues to serve standalone but receives the existing 503 on Live start;
 - simultaneous scheduled-task rehydration admits only one resident owner and
   does not provide exactly-once delivery beyond the scheduler's existing
   persistence semantics;
@@ -675,8 +734,8 @@ Conversations root and verifies:
 
 1. daemon A and daemon B both return `200` from
    `GET /standalone/session-options` and `GET /standalone/sessions`;
-2. neither daemon returns `conversation_runtime_in_use` merely because the
-   other process is alive;
+2. neither daemon's standalone routes return `conversation_runtime_in_use`
+   merely because the other process is alive;
 3. a live legacy runtime-owner record returns
    `503 conversation_runtime_in_use`, and after its process exits the next
    request retires the stale record and returns `200` without restarting;
@@ -710,9 +769,11 @@ Conversations root and verifies:
 12. two daemons reconciling the same prepared deletion elect one lease holder;
     the contender skips that UUID without failing the unrelated triggering
     operation or reporting journal compromise;
-13. a Live session on the elected Live daemon and a different standalone
-    session on the other daemon remain usable concurrently, while standalone
-    routes continue to reject the Live record;
+13. with Live enabled on both daemons, only the exact stable locator publisher
+    can activate a call: the other daemon's `/live/start`, `/live/new`, Host
+    toggle, and Host new paths fail before the Live session coordinator or
+    capture devices start; that daemon still serves a different standalone
+    session, and standalone routes continue to reject the Live record;
 14. root compromise and unavailable generations still fail closed without
     falling back to the primary workspace.
 
@@ -722,10 +783,16 @@ for the stable base as well as custom bases, and that a stale stable-base record
 can be reclaimed after its previous owner exits. It verifies the no-op
 `commitOwner` handoff, that the existing grace runs after the handoff lock is
 released and before publication, and that a competing publisher during that
-gap is rejected by the publication lock. Standalone availability
-remains independent of discovery publication failure and of which daemon
-published the record. It also covers a Live-enabled daemon and a second daemon
-serving a different standalone session at the same time.
+gap is rejected by the publication lock. Start-admission coverage accepts only
+the current protocol version and an exact stable-locator PID and instance
+nonce, rejects a valid different publisher with the existing retryable error,
+and fails missing, malformed, unsafe, or unreadable locator state closed without
+quarantining standalone.
+Both HTTP start routes and both Host-originated start actions use the same
+admission and perform no session or capture work on rejection. Standalone
+availability remains independent of discovery publication failure and of which
+daemon published the record. It also covers the elected daemon running Live
+while a second Live-enabled daemon serves a different standalone session.
 
 Web Shell regression coverage verifies that switching sessions does not emit a
 toast when standalone listing fails, that a transitional
@@ -754,6 +821,10 @@ state, cross-daemon event routing, or atomic multi-session operations.
 - **Enabling the lease only for `sourceType=standalone`:** misses Live and
   scheduled-task sources hosted by the same Conversations runtime, including
   background rehydration that occurs without a standalone API request.
+- **Treating single-publisher discovery as an activation fence:** publication
+  and activation are separate paths today. Without explicit admission before
+  every start path, a client connected directly to a non-publisher daemon can
+  start a second Live host despite the locator remaining single-publisher.
 - **Adding `activeElsewhere` to listings now:** requires an authoritative shared
   live-state index or owner-discovery protocol. The minimum Web Shell behavior
   can use the existing attach-time error contract without adding that backend

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -10,14 +10,25 @@ other isolation, persistence, and lifecycle requirements remain in force. The
 current implementation still enforces process-global Conversations ownership
 until the source changes in this design are delivered.
 
+This decision adopts Issue #10810's identity-qualified stale-writer recovery
+and legacy-owner migration guard. It intentionally narrows the issue's Web
+Shell packaging: inline conflict presentation remains an independent follow-up
+because it changes no storage or wire-safety guarantee.
+
 ## Decision
 
-Allow every `qwen serve` process to lazily create its own Conversations runtime
-for the shared Conversations root. The daemon no longer acquires a user-global
-process owner before serving standalone APIs. Every standalone session instead
-acquires the existing cross-process session writer lease before it can write.
-The lease is forced for every writer hosted by the Conversations runtime so
-Live and scheduled-task sessions cannot bypass the same-session fence.
+Allow every updated `qwen serve` process to lazily create its own Conversations
+runtime for the shared Conversations root after the legacy compatibility check
+passes. The daemon no longer acquires a user-global process owner before serving
+standalone APIs. Every standalone session instead acquires the existing
+cross-process session writer lease before it can write. The lease is forced for
+every writer hosted by the Conversations runtime so Live and scheduled-task
+sessions cannot bypass the same-session fence.
+Conversations writers and standalone lifecycle operations use a hardened local
+reclaim policy that recovers only an active record proven to come from a dead
+or PID-reused process in the same local identity domain: the same hostname and,
+on Linux, the same boot and PID namespace. A matching live process, including a
+stalled process, remains fenced.
 
 This intentionally aligns standalone startup with ordinary workspace startup:
 multiple daemons may point at the same persistent workspace, while each daemon
@@ -44,10 +55,11 @@ accept the same cross-process usage constraints for standalone.
 ## Behavioral contract
 
 - `GET /standalone/session-options` and every `/standalone/sessions` route may
-  initialize the local daemon's Conversations runtime even when another daemon
-  process is alive.
-- An active foreign daemon no longer causes
-  `conversation_runtime_in_use`.
+  initialize the local daemon's Conversations runtime even when another updated
+  daemon process is alive.
+- Another updated daemon no longer causes `conversation_runtime_in_use`. During
+  migration, a live legacy runtime-owner record still returns that error until
+  the old daemon exits.
 - A client remains attached to the daemon on which it created or restored an
   active session. Prompt, cancel, permission, status, heartbeat, detach, and
   SSE event routes are not forwarded to another daemon.
@@ -59,11 +71,20 @@ accept the same cross-process usage constraints for standalone.
   scheduled-task sessions, uses the same mandatory lease. This prevents
   background keepalive or task rehydration from silently restoring an already
   active transcript through a non-standalone source.
-- Switching a persisted session to another daemon requires a cooperative
-  writer handoff. An explicit per-session close or normal idle reap releases
-  the lease; graceful managed-daemon shutdown seals it so the replacement can
-  use the existing certified-takeover protocol. This is cold restore, not hot
-  migration.
+- An unsealed active lock left by a non-cooperative process exit is reclaimed
+  only when the new daemon can prove that the record belongs to the same local
+  identity domain and that the recorded process has exited or its PID has been
+  reused. Foreign or incomplete identity remains fenced. A process with a
+  matching live identity is never reclaimed based on age or inactivity.
+- The lease owner is the ACP writer process, not merely its daemon parent. If a
+  daemon parent dies but its child remains alive with the matching identity,
+  other daemons remain fenced until that writer exits or is terminated.
+- Normal switching of a persisted session to another daemon requires a
+  cooperative writer handoff. An explicit per-session close or normal idle reap
+  releases the lease; graceful managed-daemon shutdown seals it so the
+  replacement can use the existing certified-takeover protocol. A
+  non-cooperative exit is the narrow identity-qualified recovery exception.
+  Both paths perform a cold restore, not hot migration.
 - Daemons share persisted standalone sessions only when they resolve the same
   Conversations root and runtime base. Custom runtime bases retain the same
   storage separation they have for ordinary workspaces.
@@ -75,6 +96,11 @@ accept the same cross-process usage constraints for standalone.
 - Source isolation remains unchanged. Standalone listing, restore, and lifecycle
   routes accept only top-level standalone records and continue to fail closed
   for Live-owned or otherwise foreign records.
+- Concurrent background reconciliation of one deletion-journal entry is
+  serialized by that session's lifecycle writer lease. A sweep that encounters
+  `session_writer_conflict` treats the entry as being handled by another daemon,
+  skips that UUID, and continues without converting contention into a
+  compromised-record result.
 - Concurrent use by multiple daemons, including concurrent standalone and Live
   use of the same Conversations root, is outside the supported contract.
 
@@ -94,26 +120,43 @@ ordinary user-selected workspace. The implementation retains:
 - durable standalone deletion journals and recovery checks;
 - existing writer leases for lifecycle mutations;
 - mandatory active-session writer leases throughout the Conversations runtime;
+- identity-qualified recovery of provably stale same-domain active locks;
+- the legacy runtime-owner compatibility check during migration;
 - Live discovery's own single-publisher record and validation.
 
 These mechanisms can reject some accidental overlap, but they do not make the
 new contract safe for general concurrent use. In particular, create admission,
 live owner indexes, lifecycle coordinators, directory state, reconciliation
-singleflight, and cache invalidation remain process-local.
+singleflight, and cache invalidation remain process-local. Only the
+per-journal-entry writer lease crosses the process boundary during deletion
+reconciliation.
 
 ## Implementation
 
-### Remove the outer owner gate
+### Replace the outer owner with a legacy compatibility check
 
-`ConversationRuntimeManager` no longer accepts a
+`ConversationRuntimeManager` no longer accepts a long-lived
 `ConversationRuntimeOwnership` dependency and no longer calls `acquire()` in
-`ensure()`. Runtime creation continues to revalidate the exact root before
+`ensure()`. Before creating its first local Conversations runtime, it instead
+invokes an inspect-only compatibility check for the legacy runtime-owner
+record. Runtime creation continues to revalidate the exact root before
 publishing the daemon-local managed runtime.
 
-`createServeApp` no longer creates a file-backed Conversations owner, attaches
-it to `ServeAppLifecycleController`, or passes it to the runtime manager.
-`ServeAppLifecycleController` no longer releases Conversations ownership after
-shutdown; its listener, app, host, and runtime drains remain unchanged.
+The compatibility check reuses the existing owner-directory identity checks,
+directory lock, strict version-1 record parser, PID liveness rule, exact-record
+cleanup, durability sync, and handoff grace. A valid record whose PID is still
+live returns `conversation_runtime_in_use`. A valid stale record is removed
+under the directory lock and rechecked before the daemon proceeds. Malformed,
+unsafe, or uncertain state preserves the current compromised or unavailable
+failure. The check never writes a new owner record and does not participate in
+Live discovery handoff.
+
+`createServeApp` constructs only that compatibility checker; it does not attach
+a Conversations owner to `ServeAppLifecycleController`. The lifecycle
+controller therefore has no Conversations ownership to release after shutdown;
+its listener, app, host, and runtime drains remain unchanged. Once legacy
+versions that write the record are outside the supported upgrade window, the
+inspect-only check and owner artifacts may be removed in a follow-up.
 
 ### Require the writer lease for the Conversations runtime
 
@@ -137,6 +180,13 @@ snapshot. The effective value is true when either the trusted runtime marker
 was accepted or the user's startup setting enabled the lease. Per-request
 settings reloads continue to use that frozen value, so one ACP process never
 mixes leased and legacy writers.
+
+For a trusted managed child carrying the Conversations marker, `runAcpAgent`
+sets `reclaimPolicy: 'local'` and keeps `takeoverPolicy: 'certified'`. Other
+trusted managed workspace children keep `reclaimPolicy: 'never'`; the marker
+does not relax their container-safety contract. Before the Conversations path
+selects `local`, Core hardens that policy with the host, boot, and PID-namespace
+checks below.
 
 The ACP bootstrap `Config` remains recording-disabled and is not a transcript
 writer. The frozen value is merged into settings before each real session's
@@ -172,6 +222,12 @@ shutdown and uses the existing `session_writer_conflict`,
 `session_writer_lost`, `session_transcript_changed`, and
 `session_writer_unavailable` mappings.
 
+`StandaloneSessionService` selects the same hardened `local` policy for its
+parent-side lifecycle and maintenance acquisitions, including deletion-journal
+reconciliation. This lets archive, unarchive, delete, repair, and recovery make
+the same stale-owner decision as the ACP writer they fence. Generic workspace
+lifecycle routes and other managed runtimes keep their existing `never` policy.
+
 The lease protects one transcript. It does not coordinate session-list reads,
 random-ID creation admission, managed-directory state, deletion-journal scans,
 SSE routing, or Live discovery. Those remain governed by the serialized-use
@@ -182,40 +238,69 @@ Conversations runtime. A legacy daemon or another process that writes the same
 transcript without acquiring the protocol lease can still bypass it. The lease
 is an integrity protocol, not an operating-system access-control boundary.
 
-### Keep abnormal-exit recovery fail closed
+### Reclaim only provably stale local active writers
 
-Do not change the managed writer's existing `reclaimPolicy: 'never'` or its
-`takeoverPolicy: 'certified'`. A normal per-session close removes its exact
-active record. Graceful managed shutdown durably seals the record, and another
-managed daemon can take it over only after verifying the transcript proof.
+Strengthen the existing `local` reclaim policy before selecting it for a
+managed Conversations writer. On Linux, an active schema-version-2 record adds
+an optional `pid_namespace_id` beside the existing hostname and
+`process_start_identity`; the latter already contains the boot ID and process
+start ticks. Writers record both identities when the platform exposes them. A
+reader treats an older or newly written record without either identity as live
+and never automatically reclaims it.
 
-A process crash, SIGKILL, event-loop stall, or storage failure before sealing
-can leave an unsealed active record. A replacement then continues to return
-`409 session_writer_conflict`; it does not infer death from PID visibility,
-hostname, age, or inactivity. Recovery requires an authoritative external
-writer fence and explicit operator cleanup after confirming that the previous
-writer cannot still append.
+Reuse Core's `readPidNamespaceId()`, `readLocalBootId()`, and conservative PID
+liveness behavior while preserving the writer lease's existing persisted
+`process_start_identity` format. `EPERM` or `EACCES` remains live; only a PID
+proved absent, a validated zombie, or a readable start-identity mismatch can
+support the stale verdict after the identity-domain checks pass.
 
-This availability tradeoff is intentional. Automatically reclaiming a stale
-record would turn the small ownership change into a new failure-detection and
-split-brain protocol. It is unnecessary for the requested normal serialized
-use and would weaken the transcript-integrity guarantee supplied by the lease.
+An active Linux record is eligible for stale recovery only when its hostname,
+boot ID, and PID namespace exactly match the contender and one of these
+conditions is proven inside that namespace: the PID no longer exists, or the
+PID exists with a different process-start identity. The implementation reuses
+the existing reclaim guard, exact-record reread, atomic stale-record move, and
+transcript verification after that verdict. It never decides from lock age,
+acquisition time, heartbeat absence, or daemon responsiveness.
+
+Darwin and Windows keep their existing platform process-start probes and
+require an exact hostname and a recorded start identity for managed local
+recovery. A definitely absent PID with that recorded identity is stale; a live
+PID is stale only when its current start identity is readable and differs. If
+an identity needed for either verdict is unavailable, and on platforms without
+a supported identity probe, the record remains live for reclaim purposes. PID
+reuse may therefore cause a safe false conflict but never permits an unproven
+takeover.
+
+A PID with a matching live start identity remains `session_writer_conflict`,
+including when its event loop is stalled. Foreign-host, foreign-boot,
+foreign-namespace, identity-less, malformed, non-regular, and uncertain records
+remain fail closed. The `local` policy applies only to unsealed active records;
+sealed records still require certified transcript takeover. Any transition
+claim, including a residual one, is never reclaimed based on process liveness.
+
+A normal per-session close removes its exact active record. Graceful managed
+shutdown durably seals the record, and another managed daemon can take it over
+only after verifying the transcript proof. A non-cooperative exit from a
+steady active state becomes recoverable on the next qualified local
+acquisition. Ambiguous transition and storage failures still require an
+authoritative external writer fence before manual cleanup.
 
 Forcing the lease also makes graceful managed shutdown seal and hash every
 active Conversations transcript. The implementation does not silently lengthen
 the existing child-termination deadline. Delivery therefore requires proving
 that representative maximum active-session and transcript sizes finish within
-that budget; a timeout remains an unclean shutdown with retained locks, not an
-automatic release.
+that budget. If the timeout ends in process death while the primary record is
+still a well-formed active record, the qualified successor can recover it; a
+residual claim or uncertain transition continues to fail closed.
 
-### Detach ownership storage without removing state-directory safety
+### Retire owner writes without removing migration or state-directory safety
 
-The behavior change stops constructing, acquiring, releasing, or otherwise
-depending on the file-owner implementation, but does not delete that
-implementation and its focused tests in the same change. Keeping dormant code
-for the first patch avoids mixing the ownership-policy change with a large
-cleanup. A follow-up may remove it after the new behavior has shipped and been
-validated.
+The behavior change stops constructing, acquiring, and releasing a long-lived
+file owner, but retains the minimal inspect-and-retire path needed for old
+versions. It does not delete the remaining owner implementation and focused
+tests in the same change. Keeping that code for the first patch avoids mixing
+the ownership-policy change with a large cleanup. A follow-up may remove it
+after the migration window has closed and the new behavior has been validated.
 
 Move the small subset of path creation and validation logic needed by
 `StandaloneDeletionJournal` into that class. Do not add a replacement
@@ -233,15 +318,24 @@ This preserves the trust and bootstrap responsibilities that the old ownership
 `acquire()` performed implicitly instead of accidentally making deletion
 depend on Live discovery having run first.
 
-New daemons ignore existing `conversations/runtime-owner.json` and
-`conversations/.runtime-owner.lock` artifacts. They do not delete, rewrite, or
-acquire them: the record or lock may still belong to a running older daemon,
-and touching it would falsify that daemon's safety contract. Once all older
-daemons have exited, the artifacts are harmless legacy state.
+The existing reconciliation singleflight remains daemon-local. Each journal
+UUID still enters its session lifecycle lease before reading or mutating the
+transcript. If a background sweep loses that acquisition to another daemon, it
+skips the UUID and continues the triggering operation; it does not classify
+ordinary lease contention as journal compromise. A direct lifecycle request
+for that same session keeps the normal structured conflict response.
 
-The server no longer emits `conversation_runtime_in_use`. The wire value may be
-retained temporarily in compatibility types, but it has no new-daemon emission
-path. `conversation_runtime_unavailable`, `conversation_root_compromised`, and
+New daemons never create or replace
+`conversations/runtime-owner.json`. They inspect it under the existing
+`conversations/.runtime-owner.lock`: a live old-version owner keeps the current
+`conversation_runtime_in_use` response, while an exactly revalidated stale
+record is durably removed. The lock remains a transient guard for this
+compatibility operation and is not held for the runtime lifetime.
+
+The server retains `conversation_runtime_in_use` only for this old-version
+migration case and for existing Live-specific mappings. Updated daemons do not
+emit it merely because another updated daemon has mounted Conversations.
+`conversation_runtime_unavailable`, `conversation_root_compromised`, and
 daemon-local runtime-invariant failures remain unchanged.
 
 ### Keep Live discovery separate
@@ -301,6 +395,19 @@ No new setting or command-line flag is introduced. Supporting both exclusive
 and relaxed ownership modes would retain the full old subsystem and create a
 mixed-mode compatibility problem without serving the requested default.
 
+## Error contract
+
+| Condition                                                                        | Result                                                                                               |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Another updated daemon has the session loaded                                    | `409 session_writer_conflict` for that session                                                       |
+| A well-formed active owner is provably dead in the same local identity domain    | Reclaim, authoritative transcript reload, then continue                                              |
+| The active owner is live, stalled, foreign, or missing required reclaim identity | `409 session_writer_conflict` for that session                                                       |
+| The writer record is malformed or non-regular, or a transition claim remains     | `503 session_writer_unavailable` for that session                                                    |
+| A valid sealed record has matching transcript proof                              | Certified takeover, authoritative reload, then continue                                              |
+| A sealed record's transcript proof no longer matches                             | `409 session_transcript_changed` for that session                                                    |
+| A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                        |
+| Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response |
+
 ## Compatibility and rollout
 
 The REST and SDK shapes are unchanged. `standalone_sessions_v1` and
@@ -310,13 +417,31 @@ is added for a weaker concurrency guarantee.
 Rollout is a drain-and-cutover, not a rolling mixed-version upgrade. Stop every
 daemon version that can host standalone sessions without the mandatory lease,
 confirm its sessions have closed, and only then start daemons with this change.
-Mixed old/new versions are unsupported: an old daemon still believes its owner
-record is exclusive and may write without a lease, while a new daemon
-intentionally ignores that owner record. Rollback must explicitly close or
-drain all new Conversations writers and confirm that no active, sealed, or
-claim record from the writer protocol remains before an older non-participating
-daemon starts; graceful process exit alone may intentionally leave sealed
-handoff records.
+If this order is violated in the old-to-new direction, the new daemon honors a
+live legacy runtime-owner record and returns
+`503 conversation_runtime_in_use`; after the old daemon exits, the next runtime
+initialization removes the stale exact record and proceeds without a restart.
+This compatibility guard reduces the failure mode but does not make a rolling
+mixed-version deployment supported.
+
+The reverse direction remains unsafe: an old daemon started after updated
+daemons have mounted Conversations finds no owner record, writes one, and may
+run an unleased ACP writer beside leased writers. All daemons sharing one
+Conversations root must therefore be upgraded together. The owner-record format
+is not extended with a lease-aware marker because older strict readers would
+reject the new shape as compromised.
+
+The writer-lock schema-version-2 owner record accepts the optional
+`pid_namespace_id`; updated Linux writers populate it when available and
+updated reclaimers require it together with the existing start identity. A
+pre-existing or new active record without the complete identity is compatible
+for conflict detection but cannot be reclaimed automatically. The upgrade
+preflight must drain those writers or, after an authoritative external writer
+fence, clear residual records explicitly. Rollback must close or drain all
+updated Conversations writers and confirm that no active, sealed, claim, or
+identity-extended record remains before an older non-participating daemon
+starts; graceful process exit alone may intentionally leave sealed handoff
+records.
 
 Release notes must state that:
 
@@ -326,27 +451,48 @@ Release notes must state that:
 - standalone sessions always use the writer lease, even when the experimental
   setting is absent or false;
 - Live and scheduled-task writers in the Conversations runtime use it as well;
+- a provably dead same-domain active writer is recovered automatically; on
+  Linux that requires the same hostname, boot, and PID namespace, while a live
+  or unverifiable writer stays fenced;
+- a live old-version runtime owner still causes a transitional 503 and all
+  daemons sharing a root must be upgraded together;
 - the lease provides a same-session conflict fence, not multi-master support.
 
 ## Verification
 
-Unit tests cover server bootstrap without constructing or acquiring the legacy
-owner, runtime initialization without an ownership dependency, shutdown without
-owner release, retained root/generation/quarantine failures, deletion-journal
-state-parent creation and compromise detection, journal bootstrap without an
-owner acquisition, parent revalidation on journal read/recovery/write paths,
-and runtime-provenance writer-lease selection. The writer matrix covers the
-user setting off for a Conversations runtime, off for an ordinary runtime, and
-on for all runtimes, plus marker rejection without a private parent capability,
-capture before environment-file loading, user-level and project-level
-environment scrubbing, sandbox propagation, and isolation between primary,
-secondary, and Conversations bridge child environments.
+Unit tests cover server bootstrap without a long-lived legacy owner, live and
+stale legacy-owner compatibility checks, strict malformed-owner failures,
+runtime initialization without lifetime ownership, shutdown without owner
+release, retained root/generation/quarantine failures, deletion-journal
+state-parent creation and compromise detection, journal bootstrap without owner
+acquisition, parent revalidation on journal read/recovery/write paths,
+contention-as-skip during background reconciliation, and runtime-provenance
+writer-lease selection.
+
+The writer matrix covers the user setting off for a Conversations runtime, off
+for an ordinary runtime, and on for all runtimes; Conversations selects
+`local` while ordinary managed children retain `never`. It also covers marker
+rejection without a private parent capability, capture before environment-file
+loading, user-level and project-level environment scrubbing, sandbox
+propagation, and isolation between primary, secondary, and Conversations bridge
+child environments. Standalone parent lifecycle and maintenance acquisitions
+must select the same `local` policy.
+
+Core lease coverage records and validates the Linux PID namespace, treats a
+missing reclaim identity as live, reclaims dead and PID-reused owners only in
+the same hostname, boot, and namespace, and rejects matching live, stalled,
+foreign-host, foreign-boot, foreign-namespace, legacy identity-less, malformed,
+sealed, and residual-claim states. Darwin and Windows cover their corresponding
+hostname and process-start rules. Existing concurrent-reclaimer, exact-record,
+transcript-proof, and crashed-reclaimer tests remain in force.
 
 Managed-shutdown coverage uses representative high active-session counts and
 large transcripts to verify that parallel sealing finishes before the existing
 termination deadline. It also verifies that a forced timeout retains the exact
-active lock and preserves the existing observable unclean-shutdown outcome
-rather than releasing ownership ambiguously.
+active lock while the writer process is still live and preserves the existing
+observable unclean-shutdown outcome rather than releasing ownership ambiguously.
+After that exact process exits, only a same-identity-domain contender may
+recover a well-formed active record; an uncertain transition remains fenced.
 
 A two-process daemon integration test uses the same home, runtime base, and
 Conversations root and verifies:
@@ -355,20 +501,30 @@ Conversations root and verifies:
    `GET /standalone/session-options` and `GET /standalone/sessions`;
 2. neither daemon returns `conversation_runtime_in_use` merely because the
    other process is alive;
-3. stale legacy owner and owner-lock artifacts do not block either new daemon;
+3. a live legacy runtime-owner record returns
+   `503 conversation_runtime_in_use`, and after its process exits the next
+   request retires the stale record and returns `200` without restarting;
 4. while daemon A keeps a standalone session active, daemon B receives
    `409 session_writer_conflict` when it tries to restore that session;
 5. after an explicit close releases A's lease, B restores that session through
    ordinary acquisition; independently, after graceful shutdown seals another
    session owned by A, B restores it through certified takeover;
-6. shutting down either daemon does not remove or invalidate the other's local
+6. after A's lock-owning ACP writer is killed in a steady active state, B in the
+   same local identity domain reclaims the lock, authoritatively reloads the
+   transcript, and continues it without manual cleanup; killing only A's parent
+   while that writer remains live still returns a conflict;
+7. a matching live or stalled A, and records from a foreign host, boot, or PID
+   namespace, remain `409 session_writer_conflict`; identity-less and residual
+   claim states remain fail closed;
+8. shutting down either daemon does not remove or invalidate the other's local
    runtime;
-7. killing A without a cooperative writer terminal leaves the session fenced,
-   and B receives `409 session_writer_conflict` rather than reclaiming it;
-8. a scheduled-task session active in A cannot be rehydrated in B, and only A's
+9. a scheduled-task session active in A cannot be rehydrated in B, and only A's
    scheduler fires its bound task;
-9. root compromise and unavailable generations still fail closed without
-   falling back to the primary workspace.
+10. two daemons reconciling the same prepared deletion elect one lease holder;
+    the contender skips that UUID without failing the unrelated triggering
+    operation or reporting journal compromise;
+11. root compromise and unavailable generations still fail closed without
+    falling back to the primary workspace.
 
 Live regression coverage verifies that Live discovery still has at most one
 publisher, that the publication path performs the existing validated handoff
@@ -403,6 +559,13 @@ concurrent-use contract.
 - **Cross-process multi-master coordination:** would require durable create,
   lifecycle, recovery, owner-routing, and cache protocols. That is a different
   reliability contract and is unnecessary for serialized use.
-- **Automatic stale-writer reclaim:** PID, hostname, age, or inactivity cannot
-  prove that a managed writer on shared storage is dead. Keep explicit recovery
-  rather than introduce a partial failure detector.
+- **Unqualified stale-writer reclaim:** PID, hostname, age, or inactivity alone
+  cannot prove that a managed writer on shared storage is dead. Automatic
+  recovery is limited to a matching local identity domain and stable process
+  identity; every uncertain state remains fenced.
+- **Keeping managed `never` plus manual unlock:** makes an ordinary
+  non-cooperative writer death leave every loaded session unavailable until an
+  operator discovers and removes internal lock files. Identity-qualified local
+  recovery handles the common safe case automatically; manual recovery remains
+  only for ambiguous transition or storage state after an external writer
+  fence.

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -155,9 +155,16 @@ ordinary user-selected workspace. The implementation retains:
 - Live-start admission that accepts only the exact stable locator publisher.
 
 Daemon-local create admission, live owner indexes, lifecycle coordinators,
-directory state, reconciliation singleflight, and cache invalidation are not
-cross-process authorities. They may make remote live state appear inactive or
-delay catalog freshness, but they do not decide write ownership. The
+reconciliation singleflight, and cache invalidation are not cross-process
+authorities. They may make remote live state appear inactive or delay catalog
+freshness, but they do not decide write ownership. A working-directory identity
+pin is authoritative only while its matching local bridge session generation
+remains resident, or for one lifecycle mutation after that mutation acquires
+the session lease. A pin with no matching local generation is discarded before
+the directory is inspected again; it cannot turn a directory safely recreated
+by another daemon into `working_directory_compromised`. An identity change
+while the matching generation is resident, or after a leased lifecycle
+operation captures its operation-local identity, still fails closed. The
 cross-process writer lease remains authoritative for each transcript and its
 lifecycle, scheduled-task file mutations retain their existing cross-process
 file lock, deletion reconciliation acquires the affected session's lease, and
@@ -318,6 +325,32 @@ reports successful creation or restore. It retains the lease until session
 shutdown and uses the existing `session_writer_conflict`,
 `session_writer_lost`, `session_transcript_changed`, and
 `session_writer_unavailable` mappings.
+
+Scope each `StandaloneSessionService` working-directory identity pin to one
+locally resident bridge session generation. Use the existing
+`agentBound.eventEpoch` to reuse a pin as an `expected` identity only while the
+bridge still reports the same standalone session and epoch. A bare `{ pinned }`
+entry left by a terminal close, an absent session after idle reap, or a
+different epoch is orphaned and must be removed before restore, repair,
+deletion inspection, or another maintenance path inspects the directory. A
+detach that leaves the same generation resident keeps its pin. Check this
+lazily before each reuse rather than adding another bridge-close callback. A
+foreign session summary or an indeterminate bridge probe keeps the existing
+conflict or fail-closed result; only definite local-generation absence or
+replacement invalidates the old pin.
+
+When no matching local generation remains, open and repair apply the existing
+exact-root, direct-child, ownership, non-symlink, and permission checks without
+the stale `expected` identity and adopt the current safe directory identity.
+The ACP child must then acquire the writer lease, and the existing managed-CWD
+binding and identity rechecks must still confirm that adopted identity before
+restore succeeds. A lifecycle operation that closes a local session drops the
+session pin, acquires the parent-side lifecycle lease, and only then captures a
+fresh operation-local directory identity for any filesystem mutation. A change
+to either a still-resident generation's pin or that operation-local identity
+remains `working_directory_compromised`; only an orphaned daemon-local pin may
+be replaced. This keeps replacement detection for live work without treating a
+past daemon observation as proof against a later cooperating writer.
 
 `StandaloneSessionService` selects the same hardened `local` policy for its
 parent-side lifecycle and maintenance acquisitions, including deletion-journal
@@ -585,21 +618,23 @@ mixed-mode compatibility problem without serving the requested default.
 
 ## Error contract
 
-| Condition                                                                        | Result                                                                                                                                                    |
-| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Another updated daemon has a different session loaded                            | Listing, new-session creation, and operations on the different session continue                                                                           |
-| Another updated daemon has the session loaded for open, rename, or repair        | `409 session_writer_conflict` for that session                                                                                                            |
-| A batch archive or delete includes a session loaded by another updated daemon    | Existing `200` batch envelope with that item's `errors[].code` set to `session_writer_conflict`                                                           |
-| A well-formed active owner is provably dead in the same local identity domain    | Reclaim, authoritative transcript reload, then continue                                                                                                   |
-| The active owner is live, stalled, foreign, or missing required reclaim identity | `409 session_writer_conflict` for that session                                                                                                            |
-| The writer record is malformed or non-regular, or a transition claim remains     | `503 session_writer_unavailable` for that session                                                                                                         |
-| A valid sealed record has matching transcript proof                              | Certified takeover, authoritative reload, then continue                                                                                                   |
-| A sealed record's transcript proof no longer matches                             | `409 session_transcript_changed` for that session                                                                                                         |
-| A Conversations bridge lacks the mandatory-lease attestation                     | Reject and dispose a new candidate, or terminally quarantine an existing runtime; every request remains non-retryable `503 conversation_root_compromised` |
-| A live legacy runtime-owner record exists                                        | `503 conversation_runtime_in_use` for the standalone surface during migration                                                                             |
-| Legacy ownership state is malformed, unsafe, or uncertain                        | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response                                                      |
-| A daemon that is not the stable Live locator publisher attempts to start Live    | `503 conversation_runtime_in_use` for `/live/start` or `/live/new`; standalone remains available                                                          |
-| Stable Live locator state is missing, unreadable, malformed, or unsafe at start  | Fail Live start closed with the existing unavailable or ownership-compromised mapping; standalone remains available                                       |
+| Condition                                                                                                                           | Result                                                                                                                                                    |
+| ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Another updated daemon has a different session loaded                                                                               | Listing, new-session creation, and operations on the different session continue                                                                           |
+| Another updated daemon has the session loaded for open, rename, or repair                                                           | `409 session_writer_conflict` for that session                                                                                                            |
+| A batch archive or delete includes a session loaded by another updated daemon                                                       | Existing `200` batch envelope with that item's `errors[].code` set to `session_writer_conflict`                                                           |
+| A well-formed active owner is provably dead in the same local identity domain                                                       | Reclaim, authoritative transcript reload, then continue                                                                                                   |
+| The active owner is live, stalled, foreign, or missing required reclaim identity                                                    | `409 session_writer_conflict` for that session                                                                                                            |
+| The writer record is malformed or non-regular, or a transition claim remains                                                        | `503 session_writer_unavailable` for that session                                                                                                         |
+| A valid sealed record has matching transcript proof                                                                                 | Certified takeover, authoritative reload, then continue                                                                                                   |
+| A sealed record's transcript proof no longer matches                                                                                | `409 session_transcript_changed` for that session                                                                                                         |
+| A Conversations bridge lacks the mandatory-lease attestation                                                                        | Reject and dispose a new candidate, or terminally quarantine an existing runtime; every request remains non-retryable `503 conversation_root_compromised` |
+| A safe working directory has a new identity and no matching local session generation remains                                        | Discard the orphaned pin, adopt the current identity, and continue through the normal writer or lifecycle lease                                           |
+| A working-directory identity changes while its local generation remains resident, or after a leased lifecycle operation captures it | Existing `working_directory_compromised` response                                                                                                         |
+| A live legacy runtime-owner record exists                                                                                           | `503 conversation_runtime_in_use` for the standalone surface during migration                                                                             |
+| Legacy ownership state is malformed, unsafe, or uncertain                                                                           | Existing `conversation_runtime_ownership_compromised` or `conversation_runtime_unavailable` response                                                      |
+| A daemon that is not the stable Live locator publisher attempts to start Live                                                       | `503 conversation_runtime_in_use` for `/live/start` or `/live/new`; standalone remains available                                                          |
+| Stable Live locator state is missing, unreadable, malformed, or unsafe at start                                                     | Fail Live start closed with the existing unavailable or ownership-compromised mapping; standalone remains available                                       |
 
 For every writer-state row, a batch lifecycle route preserves the same error
 kind in its existing `200` per-item result rather than changing the batch's
@@ -655,6 +690,9 @@ Release notes must state that:
 - active sessions are daemon-local;
 - different session IDs may be active concurrently across updated daemons,
   while a second writer or lifecycle mutation for the same session is fenced;
+- a safe working directory recreated after its local session generation exits
+  is adopted on the next open, while replacement during a resident generation
+  still fails closed;
 - same-session conflicts reuse `session_writer_conflict`, including in the
   existing per-item error of a batch lifecycle response;
 - standalone sessions always use the writer lease, even when the experimental
@@ -749,33 +787,47 @@ Conversations root and verifies:
 6. after an explicit close releases A's lease, B restores S through
    ordinary acquisition; independently, after graceful shutdown seals another
    session owned by A, B restores it through certified takeover;
-7. after A's lock-owning ACP writer is killed in a steady active state, B in the
+7. after A closes S or S is idle-reaped, B can safely recreate its working
+   directory with a new identity and release S, after which A can open, repair,
+   or delete S without treating A's orphaned pin as compromise; replacing the
+   directory while A's matching session generation remains resident still
+   fails closed;
+8. after A's lock-owning ACP writer is killed in a steady active state, B in the
    same local identity domain reclaims the lock, authoritatively reloads the
    transcript, and continues it without manual cleanup; killing only A's parent
    while that writer remains live still returns a conflict;
-8. a matching live or stalled A, and records from a foreign host, boot, or PID
+9. a matching live or stalled A, and records from a foreign host, boot, or PID
    namespace, remain `409 session_writer_conflict`; identity-less and residual
    claim states remain fail closed;
-9. shutting down either daemon does not remove or invalidate the other's local
-   runtime;
-10. two otherwise idle daemons that simultaneously rehydrate the same
+10. shutting down either daemon does not remove or invalidate the other's local
+    runtime;
+11. two otherwise idle daemons that simultaneously rehydrate the same
     scheduled-task-bound session elect one resident session through the writer
     lease; the loser records a restore failure and backs off, and only the
     winner fires the bound task for that slot;
-11. two keepalive workers that observe the same unbound task may mint competing
+12. two keepalive workers that observe the same unbound task may mint competing
     controller sessions, but no Conversations session fires it while unbound;
     the task-file transaction commits exactly one binding, cleans up the losing
     orphan, and only the bound controller becomes eligible to fire;
-12. two daemons reconciling the same prepared deletion elect one lease holder;
+13. two daemons reconciling the same prepared deletion elect one lease holder;
     the contender skips that UUID without failing the unrelated triggering
     operation or reporting journal compromise;
-13. with Live enabled on both daemons, only the exact stable locator publisher
+14. with Live enabled on both daemons, only the exact stable locator publisher
     can activate a call: the other daemon's `/live/start`, `/live/new`, Host
     toggle, and Host new paths fail before the Live session coordinator or
     capture devices start; that daemon still serves a different standalone
     session, and standalone routes continue to reject the Live record;
-14. root compromise and unavailable generations still fail closed without
+15. root compromise and unavailable generations still fail closed without
     falling back to the primary workspace.
+
+Focused `StandaloneSessionService` coverage verifies that terminal close leaves
+no reusable generation pin, detach retains the same generation's pin, an
+idle-reaped or replaced event epoch is discarded lazily before reuse, and
+deletion reconciliation never supplies an orphaned pin. The same tests retain
+`working_directory_compromised` for a replacement observed while the matching
+local generation is resident and for an identity change after a leased
+lifecycle operation captures its fresh identity; a foreign summary or
+indeterminate bridge probe never authorizes re-pinning.
 
 Live regression coverage verifies that Live discovery still has at most one
 publisher, that the publication path performs the existing validated handoff

--- a/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
+++ b/docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md
@@ -1,0 +1,408 @@
+# Relaxed Standalone Daemon Ownership
+
+## Status
+
+Proposed for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810).
+Once accepted, this decision supersedes the process-global cross-daemon
+ownership requirement in the [standalone daemon sessions
+contract](./standalone-daemon-sessions.md), which accompanies Issue #8908. All
+other isolation, persistence, and lifecycle requirements remain in force. The
+current implementation still enforces process-global Conversations ownership
+until the source changes in this design are delivered.
+
+## Decision
+
+Allow every `qwen serve` process to lazily create its own Conversations runtime
+for the shared Conversations root. The daemon no longer acquires a user-global
+process owner before serving standalone APIs. Every standalone session instead
+acquires the existing cross-process session writer lease before it can write.
+The lease is forced for every writer hosted by the Conversations runtime so
+Live and scheduled-task sessions cannot bypass the same-session fence.
+
+This intentionally aligns standalone startup with ordinary workspace startup:
+multiple daemons may point at the same persistent workspace, while each daemon
+keeps its own ACP bridge, child process, live-session index, caches, and runtime
+generation.
+
+This is a serialized-use contract, not multi-master support. Cross-daemon
+concurrent access to the Conversations root is unsupported and is not detected
+or fully coordinated by this change. The writer lease only fences competing
+writers for the same session.
+
+## Motivation
+
+The current user-global owner record makes the first daemon that touches
+standalone or Live block standalone access from every other live daemon. A Web
+Shell connected to a second daemon therefore receives
+`503 conversation_runtime_in_use` even when the two daemons are never used for
+standalone at the same time.
+
+Ordinary workspaces do not impose a process-global runtime owner. The simpler
+and more consistent policy is to let the operator choose a daemon endpoint and
+accept the same cross-process usage constraints for standalone.
+
+## Behavioral contract
+
+- `GET /standalone/session-options` and every `/standalone/sessions` route may
+  initialize the local daemon's Conversations runtime even when another daemon
+  process is alive.
+- An active foreign daemon no longer causes
+  `conversation_runtime_in_use`.
+- A client remains attached to the daemon on which it created or restored an
+  active session. Prompt, cancel, permission, status, heartbeat, detach, and
+  SSE event routes are not forwarded to another daemon.
+- Creating or restoring a standalone session acquires its session writer lease
+  regardless of the user's `experimental.sessionWriterLease` setting. A second
+  daemon attempting to open the same active session receives the existing
+  `409 session_writer_conflict` response.
+- Every other session hosted by the Conversations runtime, including Live and
+  scheduled-task sessions, uses the same mandatory lease. This prevents
+  background keepalive or task rehydration from silently restoring an already
+  active transcript through a non-standalone source.
+- Switching a persisted session to another daemon requires a cooperative
+  writer handoff. An explicit per-session close or normal idle reap releases
+  the lease; graceful managed-daemon shutdown seals it so the replacement can
+  use the existing certified-takeover protocol. This is cold restore, not hot
+  migration.
+- Daemons share persisted standalone sessions only when they resolve the same
+  Conversations root and runtime base. Custom runtime bases retain the same
+  storage separation they have for ordinary workspaces.
+- Cross-process catalog changes are eventually visible through the existing
+  persisted-session cache. Live state is merged only from the receiving
+  daemon, so daemon B may list a session active in daemon A as persisted but
+  inactive until a restore attempt returns `session_writer_conflict`. No
+  cross-daemon cache or live-state invalidation is added.
+- Source isolation remains unchanged. Standalone listing, restore, and lifecycle
+  routes accept only top-level standalone records and continue to fail closed
+  for Live-owned or otherwise foreign records.
+- Concurrent use by multiple daemons, including concurrent standalone and Live
+  use of the same Conversations root, is outside the supported contract.
+
+"Not concurrent" applies to the complete active-session lifetime, not only to
+overlapping HTTP requests. A session that remains loaded in daemon A must not be
+continued through daemon B merely because daemon A is idle between requests.
+
+## Safety retained
+
+Removing process ownership does not turn the Conversations root into an
+ordinary user-selected workspace. The implementation retains:
+
+- exact Conversations-root validation and directory identity checks;
+- internal-runtime isolation and the prohibition on primary-runtime fallback;
+- per-daemon runtime generation, activity drain, and terminal quarantine;
+- per-session lifecycle coordination inside each daemon;
+- durable standalone deletion journals and recovery checks;
+- existing writer leases for lifecycle mutations;
+- mandatory active-session writer leases throughout the Conversations runtime;
+- Live discovery's own single-publisher record and validation.
+
+These mechanisms can reject some accidental overlap, but they do not make the
+new contract safe for general concurrent use. In particular, create admission,
+live owner indexes, lifecycle coordinators, directory state, reconciliation
+singleflight, and cache invalidation remain process-local.
+
+## Implementation
+
+### Remove the outer owner gate
+
+`ConversationRuntimeManager` no longer accepts a
+`ConversationRuntimeOwnership` dependency and no longer calls `acquire()` in
+`ensure()`. Runtime creation continues to revalidate the exact root before
+publishing the daemon-local managed runtime.
+
+`createServeApp` no longer creates a file-backed Conversations owner, attaches
+it to `ServeAppLifecycleController`, or passes it to the runtime manager.
+`ServeAppLifecycleController` no longer releases Conversations ownership after
+shutdown; its listener, app, host, and runtime drains remain unchanged.
+
+### Require the writer lease for the Conversations runtime
+
+Force the existing writer protocol at the runtime-provenance boundary, not at
+the session-source boundary. When the daemon builds a workspace runtime whose
+validated provenance is `live-conversation`, its bridge adds one private,
+enable-only marker to that runtime's ACP child environment. Primary, secondary,
+scratch, and other ordinary workspace bridges do not receive it.
+
+The CLI entry point captures and deletes the private marker beside the existing
+private parent capability before its first await or any environment-file load.
+It accepts the marker only for ACP mode, only when that capability is present,
+and only at the exact enable value. A sandbox relaunch carries the accepted
+marker together with the private capability through the existing private child
+environment; an ordinary relaunch does not. The entry point passes the result
+to `runAcpAgent` as an internal boolean rather than asking the agent to read the
+mutable process environment.
+
+`runAcpAgent` folds that boolean into the existing process-start writer
+snapshot. The effective value is true when either the trusted runtime marker
+was accepted or the user's startup setting enabled the lease. Per-request
+settings reloads continue to use that frozen value, so one ACP process never
+mixes leased and legacy writers.
+
+The ACP bootstrap `Config` remains recording-disabled and is not a transcript
+writer. The frozen value is merged into settings before each real session's
+`loadCliConfig` call. This preserves the existing restore ordering that defers
+transcript projection until writer acquisition and prevents a forced lease
+from being applied only after a session has already read mutable state.
+
+The daemon's shared child-environment overrides explicitly remove the marker by
+default, then the `live-conversation` bridge replaces that undefined value with
+the enable value. Add the key to the existing hard-coded project-environment
+exclusions so a workspace `.env` or settings reload cannot reintroduce it. The
+CLI entry point also deletes the key again immediately after initial settings
+and environment loading so a user-level `.env` value cannot leak to tools or
+later child processes. Together these rules prevent inherited shell and
+file-loaded environments from marking primary and secondary runtimes while
+retaining the accepted value only in immutable local state.
+
+This makes standalone independent of user configuration without introducing a
+public setting or command-line flag. Scoping the marker to one bridge preserves
+ordinary workspace behavior and also covers every source that the dedicated
+runtime can host, including standalone, Live, scheduled-task controller, and
+scheduled-task run sessions. A source-based override would miss background
+sessions whose persisted source is not `standalone`.
+
+The default `runQwenServe` runtime factory owns this wiring. An embedded runtime
+factory supplied through `createServeApp` must honor the same
+`live-conversation` provenance contract when it creates the bridge; test fakes
+may model the resulting behavior without spawning a child.
+
+The ACP session must acquire the lease during config initialization before it
+reports successful creation or restore. It retains the lease until session
+shutdown and uses the existing `session_writer_conflict`,
+`session_writer_lost`, `session_transcript_changed`, and
+`session_writer_unavailable` mappings.
+
+The lease protects one transcript. It does not coordinate session-list reads,
+random-ID creation admission, managed-directory state, deletion-journal scans,
+SSE routing, or Live discovery. Those remain governed by the serialized-use
+contract and existing daemon-local checks.
+
+The fence covers only updated, cooperating writers hosted by the marked
+Conversations runtime. A legacy daemon or another process that writes the same
+transcript without acquiring the protocol lease can still bypass it. The lease
+is an integrity protocol, not an operating-system access-control boundary.
+
+### Keep abnormal-exit recovery fail closed
+
+Do not change the managed writer's existing `reclaimPolicy: 'never'` or its
+`takeoverPolicy: 'certified'`. A normal per-session close removes its exact
+active record. Graceful managed shutdown durably seals the record, and another
+managed daemon can take it over only after verifying the transcript proof.
+
+A process crash, SIGKILL, event-loop stall, or storage failure before sealing
+can leave an unsealed active record. A replacement then continues to return
+`409 session_writer_conflict`; it does not infer death from PID visibility,
+hostname, age, or inactivity. Recovery requires an authoritative external
+writer fence and explicit operator cleanup after confirming that the previous
+writer cannot still append.
+
+This availability tradeoff is intentional. Automatically reclaiming a stale
+record would turn the small ownership change into a new failure-detection and
+split-brain protocol. It is unnecessary for the requested normal serialized
+use and would weaken the transcript-integrity guarantee supplied by the lease.
+
+Forcing the lease also makes graceful managed shutdown seal and hash every
+active Conversations transcript. The implementation does not silently lengthen
+the existing child-termination deadline. Delivery therefore requires proving
+that representative maximum active-session and transcript sizes finish within
+that budget; a timeout remains an unclean shutdown with retained locks, not an
+automatic release.
+
+### Detach ownership storage without removing state-directory safety
+
+The behavior change stops constructing, acquiring, releasing, or otherwise
+depending on the file-owner implementation, but does not delete that
+implementation and its focused tests in the same change. Keeping dormant code
+for the first patch avoids mixing the ownership-policy change with a large
+cleanup. A follow-up may remove it after the new behavior has shipped and been
+validated.
+
+Move the small subset of path creation and validation logic needed by
+`StandaloneDeletionJournal` into that class. Do not add a replacement
+ownership service or a standalone abstraction with only this one consumer. The
+journal derives its state parent directly and retains private-directory
+creation, identity validation, and durability checks; it has no owner record,
+process liveness check, lock, grace period, acquire, or release operation.
+
+`StandaloneDeletionJournal` validates that parent before entering its journal
+subtree on every read, recovery, clear, and write path. Reads treat a missing
+state directory as empty; the first write safely creates it. An existing unsafe
+or replaced parent fails the journal operation closed, and the existing
+journal-directory identity checks continue around each filesystem mutation.
+This preserves the trust and bootstrap responsibilities that the old ownership
+`acquire()` performed implicitly instead of accidentally making deletion
+depend on Live discovery having run first.
+
+New daemons ignore existing `conversations/runtime-owner.json` and
+`conversations/.runtime-owner.lock` artifacts. They do not delete, rewrite, or
+acquire them: the record or lock may still belong to a running older daemon,
+and touching it would falsify that daemon's safety contract. Once all older
+daemons have exited, the artifacts are harmless legacy state.
+
+The server no longer emits `conversation_runtime_in_use`. The wire value may be
+retained temporarily in compatibility types, but it has no new-daemon emission
+path. `conversation_runtime_unavailable`, `conversation_root_compromised`, and
+daemon-local runtime-invariant failures remain unchanged.
+
+### Keep Live discovery separate
+
+Keep the ownership protocol in `live/discovery.ts` unchanged. Its owner record
+selects one discoverable Live host and protects publication of that endpoint.
+The removed Conversations owner currently performs the stable-base discovery
+handoff as a side effect of runtime acquisition, while the publication path
+performs that handoff only for non-stable target bases. Move that responsibility
+to the Live publication path: immediately before `writeLiveDiscoveryFile()`,
+call `handoffLiveDiscoveryOwner()` for every target base, including the stable
+base. Conversations runtime initialization itself no longer participates in
+Live discovery ownership.
+
+A stale discovery record can therefore still be reclaimed through the existing
+validated handoff before publication. An active foreign Live owner still blocks
+publication, and failure to publish Live discovery does not disable standalone
+routes on that daemon.
+
+This deliberately does not solve concurrent Live and standalone access from
+different daemons. Operators relying on the serialized-use contract must keep
+Live inactive on other daemons while standalone is in use.
+
+### Keep scheduled-task logic unchanged
+
+Do not change scheduled-task persistence, cron execution, keepalive, or boot
+rehydration. Scheduled-task controller and run sessions inherit the mandatory
+writer lease from the Conversations runtime before restore succeeds. A daemon
+that loses the lease cannot make that bound session resident; boot rehydration
+records the failure, and keepalive uses its existing retry backoff.
+
+Keep the existing product boundaries: durable cron jobs remain unsupported in
+standalone sessions, and generic scheduled-task routes cannot create a new
+session in the Conversations workspace. This change only fences existing
+background writers; it does not add standalone scheduling functionality.
+
+### Keep the Web Shell contract unchanged
+
+Do not add an `activeElsewhere` list field or a new client-side owner-discovery
+protocol. Every daemon can list persisted standalone sessions after the outer
+gate is removed, while an attempt to restore a session held by another daemon
+continues to return the existing `409 session_writer_conflict`. The Web Shell
+may surface that real attach conflict through its existing error path.
+
+A quieter inline conflict treatment can be delivered independently as product
+polish. It is not required for storage safety and does not belong in the
+backend ownership change.
+
+### Do not add routing or coordination
+
+The change adds no daemon-to-daemon proxy, redirect, shared owner index,
+heartbeat, global lifecycle lock, or distributed cache invalidation. Existing
+session routes continue to resolve owners only among runtimes inside the
+receiving daemon.
+
+No new setting or command-line flag is introduced. Supporting both exclusive
+and relaxed ownership modes would retain the full old subsystem and create a
+mixed-mode compatibility problem without serving the requested default.
+
+## Compatibility and rollout
+
+The REST and SDK shapes are unchanged. `standalone_sessions_v1` and
+`standalone_session_options_v1` continue to describe API support; no capability
+is added for a weaker concurrency guarantee.
+
+Rollout is a drain-and-cutover, not a rolling mixed-version upgrade. Stop every
+daemon version that can host standalone sessions without the mandatory lease,
+confirm its sessions have closed, and only then start daemons with this change.
+Mixed old/new versions are unsupported: an old daemon still believes its owner
+record is exclusive and may write without a lease, while a new daemon
+intentionally ignores that owner record. Rollback must explicitly close or
+drain all new Conversations writers and confirm that no active, sealed, or
+claim record from the writer protocol remains before an older non-participating
+daemon starts; graceful process exit alone may intentionally leave sealed
+handoff records.
+
+Release notes must state that:
+
+- multiple daemons may expose standalone sessions for the same user;
+- active sessions are daemon-local;
+- callers are responsible for avoiding cross-daemon concurrent use;
+- standalone sessions always use the writer lease, even when the experimental
+  setting is absent or false;
+- Live and scheduled-task writers in the Conversations runtime use it as well;
+- the lease provides a same-session conflict fence, not multi-master support.
+
+## Verification
+
+Unit tests cover server bootstrap without constructing or acquiring the legacy
+owner, runtime initialization without an ownership dependency, shutdown without
+owner release, retained root/generation/quarantine failures, deletion-journal
+state-parent creation and compromise detection, journal bootstrap without an
+owner acquisition, parent revalidation on journal read/recovery/write paths,
+and runtime-provenance writer-lease selection. The writer matrix covers the
+user setting off for a Conversations runtime, off for an ordinary runtime, and
+on for all runtimes, plus marker rejection without a private parent capability,
+capture before environment-file loading, user-level and project-level
+environment scrubbing, sandbox propagation, and isolation between primary,
+secondary, and Conversations bridge child environments.
+
+Managed-shutdown coverage uses representative high active-session counts and
+large transcripts to verify that parallel sealing finishes before the existing
+termination deadline. It also verifies that a forced timeout retains the exact
+active lock and preserves the existing observable unclean-shutdown outcome
+rather than releasing ownership ambiguously.
+
+A two-process daemon integration test uses the same home, runtime base, and
+Conversations root and verifies:
+
+1. daemon A and daemon B both return `200` from
+   `GET /standalone/session-options` and `GET /standalone/sessions`;
+2. neither daemon returns `conversation_runtime_in_use` merely because the
+   other process is alive;
+3. stale legacy owner and owner-lock artifacts do not block either new daemon;
+4. while daemon A keeps a standalone session active, daemon B receives
+   `409 session_writer_conflict` when it tries to restore that session;
+5. after an explicit close releases A's lease, B restores that session through
+   ordinary acquisition; independently, after graceful shutdown seals another
+   session owned by A, B restores it through certified takeover;
+6. shutting down either daemon does not remove or invalidate the other's local
+   runtime;
+7. killing A without a cooperative writer terminal leaves the session fenced,
+   and B receives `409 session_writer_conflict` rather than reclaiming it;
+8. a scheduled-task session active in A cannot be rehydrated in B, and only A's
+   scheduler fires its bound task;
+9. root compromise and unavailable generations still fail closed without
+   falling back to the primary workspace.
+
+Live regression coverage verifies that Live discovery still has at most one
+publisher, that the publication path performs the existing validated handoff
+for the stable base as well as custom bases, and that a stale stable-base record
+can be reclaimed after its previous owner exits. Standalone availability
+remains independent of discovery publication failure and of which daemon
+published the record.
+
+No test may treat the same-session conflict as proof of general cross-daemon
+safety. Different-session lifecycle and catalog operations remain outside the
+concurrent-use contract.
+
+## Rejected alternatives
+
+- **Daemon-to-daemon proxying:** preserves a single runtime owner but requires
+  authenticated forwarding for all standalone and owner-routed session APIs,
+  including SSE and permissions.
+- **Client redirect to the owner:** introduces discovery, token, origin, and
+  reconnect behavior and keeps the global owner that this change removes.
+- **Per-daemon standalone storage:** is simple but prevents daemons from seeing
+  the same persisted conversation catalog.
+- **Relying on the user setting for writer leases:** permits one daemon with the
+  setting disabled to bypass the fence, so it cannot protect shared standalone
+  persistence.
+- **Enabling the lease only for `sourceType=standalone`:** misses Live and
+  scheduled-task sources hosted by the same Conversations runtime, including
+  background rehydration that occurs without a standalone API request.
+- **Bundling new Web Shell ownership UI:** an `activeElsewhere` hint or inline
+  conflict state requires a new product contract but does not strengthen the
+  storage fence. Keep the backend decision independently reviewable and handle
+  that optional presentation change separately.
+- **Cross-process multi-master coordination:** would require durable create,
+  lifecycle, recovery, owner-routing, and cache protocols. That is a different
+  reliability contract and is unnecessary for serialized use.
+- **Automatic stale-writer reclaim:** PID, hostname, age, or inactivity cannot
+  prove that a managed writer on shared storage is dead. Keep explicit recovery
+  rather than introduce a partial failure detector.

--- a/docs/design/certified-session-writer-handoff.md
+++ b/docs/design/certified-session-writer-handoff.md
@@ -5,7 +5,10 @@
 > for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) proposes
 > enabling this protocol for every writer hosted by the Conversations runtime,
 > which would supersede this document's exclusion of standalone ACP writers. Its
-> certified handoff and fail-closed abnormal-exit semantics remain unchanged.
+> certified handoff remains unchanged. A hardened local policy would additionally
+> reclaim only a provably dead writer in the same local identity domain, including
+> the same boot and PID namespace on Linux; sealed, foreign, identity-less, and
+> ambiguous states remain fail closed.
 
 ## Problem
 

--- a/docs/design/certified-session-writer-handoff.md
+++ b/docs/design/certified-session-writer-handoff.md
@@ -1,5 +1,12 @@
 # Certified session writer handoff
 
+> **Proposed standalone update (2026-09-02):**
+> [Relaxed Standalone Daemon Ownership](./2026-09-02-relaxed-standalone-daemon-ownership.md)
+> for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) proposes
+> enabling this protocol for every writer hosted by the Conversations runtime,
+> which would supersede this document's exclusion of standalone ACP writers. Its
+> certified handoff and fail-closed abnormal-exit semantics remain unchanged.
+
 ## Problem
 
 Cooperative managed shutdown currently releases each session writer lock before

--- a/docs/design/daemon-session-maintenance-writer-lease.md
+++ b/docs/design/daemon-session-maintenance-writer-lease.md
@@ -1,5 +1,13 @@
 # Daemon Session Maintenance Writer Lease
 
+> **Proposed Conversations-runtime update (2026-09-02):**
+> [Relaxed Standalone Daemon Ownership](./2026-09-02-relaxed-standalone-daemon-ownership.md)
+> for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) would
+> supersede this document's always-`reclaimPolicy: 'never'` rule for standalone
+> lifecycle and maintenance acquisitions on the Conversations runtime. Those
+> acquisitions would use the hardened `local` policy; daemon maintenance for
+> ordinary workspaces and other managed runtimes keeps `never`.
+
 ## Problem
 
 The daemon can delete, archive, or unarchive a persisted transcript after its

--- a/docs/design/managed-session-writer-shutdown.md
+++ b/docs/design/managed-session-writer-shutdown.md
@@ -1,5 +1,15 @@
 # Managed session writer shutdown
 
+> **Proposed Conversations-runtime update (2026-09-02):**
+> [Relaxed Standalone Daemon Ownership](./2026-09-02-relaxed-standalone-daemon-ownership.md)
+> for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) proposes
+> selecting a hardened local reclaim policy for Conversations ACP writers and
+> standalone lifecycle operations. This supersedes the no-SIGKILL-recovery rule
+> only for a well-formed active record proved stale in the same local identity
+> domain, including the same boot and PID namespace on Linux. Foreign, sealed,
+> identity-less, transition, and uncertain states keep this document's
+> fail-closed behavior.
+
 ## Problem
 
 A managed `qwen serve` replacement can start on a new hostname while the

--- a/docs/design/session-writer-lease-p0a.md
+++ b/docs/design/session-writer-lease-p0a.md
@@ -1,5 +1,14 @@
 # Session writer lease P0a
 
+> **Proposed Conversations-runtime update (2026-09-02):**
+> [Relaxed Standalone Daemon Ownership](./2026-09-02-relaxed-standalone-daemon-ownership.md)
+> for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) proposes
+> forcing this lease for every writer hosted by the Conversations runtime,
+> independent of the experimental setting. It also hardens stale recovery to the
+> same local identity domain, including boot and PID-namespace identity on Linux,
+> before selecting that policy for managed Conversations writers. Other ACP,
+> interactive, and headless gates remain unchanged.
+
 ## Problem
 
 A persisted session can currently be loaded by a second Qwen process while the original process is still producing and recording a turn. Both recorders cache the same parent UUID. When they append independently, the JSONL transcript gains two unmarked children from that parent. Resume follows the physical tail and can therefore hide the first process's complete answer.

--- a/docs/design/standalone-daemon-sessions.md
+++ b/docs/design/standalone-daemon-sessions.md
@@ -4,8 +4,9 @@
 > [Relaxed Standalone Daemon Ownership](./2026-09-02-relaxed-standalone-daemon-ownership.md)
 > for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) would
 > supersede this document's process-global ownership requirement and related
-> `conversation_runtime_in_use` behavior. Other isolation, persistence, and
-> lifecycle requirements remain in force.
+> `conversation_runtime_in_use` behavior between updated daemons. A live legacy
+> owner retains that response during migration. Other isolation, persistence,
+> and lifecycle requirements remain in force.
 
 ## Status
 

--- a/docs/design/standalone-daemon-sessions.md
+++ b/docs/design/standalone-daemon-sessions.md
@@ -5,8 +5,10 @@
 > for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) would
 > supersede this document's process-global ownership requirement and related
 > `conversation_runtime_in_use` behavior between updated daemons. A live legacy
-> owner retains that response during migration. Other isolation, persistence,
-> and lifecycle requirements remain in force.
+> owner retains that response during migration. Updated daemons may host
+> different sessions concurrently, while the same session remains fenced by
+> its writer lease. Other isolation, persistence, and lifecycle requirements
+> remain in force.
 
 ## Status
 

--- a/docs/design/standalone-daemon-sessions.md
+++ b/docs/design/standalone-daemon-sessions.md
@@ -1,5 +1,12 @@
 # Standalone Daemon Sessions
 
+> **Proposed cross-daemon update (2026-09-02):**
+> [Relaxed Standalone Daemon Ownership](./2026-09-02-relaxed-standalone-daemon-ownership.md)
+> for [Issue #10810](https://github.com/QwenLM/qwen-code/issues/10810) would
+> supersede this document's process-global ownership requirement and related
+> `conversation_runtime_in_use` behavior. Other isolation, persistence, and
+> lifecycle requirements remain in force.
+
 ## Status
 
 This document is the versioned architecture companion to


### PR DESCRIPTION
## What this PR does

This PR records the proposed architecture for allowing every updated daemon to mount the shared Conversations runtime instead of enforcing a process-global runtime owner. It defines the supported concurrency boundary by session ID: daemons may concurrently list the catalog, create chats, and host different sessions, while competing writers and lifecycle mutations for the same session use the existing session writer lease and preserve the existing writer-conflict kind. Open, rename, and repair return the existing 409 response; batch archive and delete retain their 200 envelope and carry `session_writer_conflict` on the affected item.

The proposal forces that lease for every writer hosted by the Conversations runtime, requires the Conversations bridge to attest to the conjunction of the exact private marker and its configured channel factory's child-environment-forwarding capability before an existing runtime is accepted or a new candidate is published, preserves that non-retryable classification after an existing runtime is terminally quarantined, adds identity-qualified local recovery for provably dead active writers, preserves certified handoff and fail-closed handling for live, foreign, or ambiguous state, retains a transitional 503 guard for live legacy owners, preserves historical state-root modes while requiring private Conversations and journal leaves, treats deletion-journal lease contention as another daemon handling the entry, and moves stable-base Live discovery handoff into the publication path with the existing no-op commit callback and post-lock grace. It also gates every Live activation entry point on the exact stable locator publisher: a non-publisher keeps serving standalone sessions, but its HTTP and Host-originated starts fail before call or capture activation. Working-directory identity pins are scoped to the matching resident bridge session generation, so a safely recreated directory is adopted after that generation exits while replacement during active work still fails closed.

Scheduled tasks use the same session boundary without adding another lease. Concurrent restoration of one bound controller session elects one resident writer before its scheduler activates. Conversations sessions also refuse to fire unbound durable tasks until the existing cross-process task-file transaction commits one controller binding, so competing keepalive workers can clean up a losing orphan without producing two executions. The default daemon runs that binding worker; an embedded host that opts into the Conversations marker without it leaves unbound tasks dormant. This closes duplication caused by concurrent restore or binding but deliberately retains the scheduler's existing at-least-once window after dispatch and before durable fired-state persistence.

The Web Shell minimum degradation is a same-release requirement even if it lands in a separate implementation PR: standalone list failures and the transitional runtime-owner response render once in the Recents section, while writer conflicts and unavailable states render on the affected session or section with retry instead of a global toast. An `activeElsewhere` list hint remains deferred because no authoritative cross-daemon live-state index is added.

## Why it's needed

The current outer ownership gate lets the first daemon that touches standalone or Live block every standalone endpoint on another daemon with a runtime-in-use response, including the shared list, New Chat, and unrelated sessions. The actual transcript-integrity hazard is narrower: two writers appending to or mutating the same session. Applying the existing per-session writer protocol at the trusted Conversations-runtime boundary removes the unnecessarily broad availability gate while retaining an explicit same-session fence.

Documenting the complete boundary before implementation also exposes the shared background paths that a simple owner removal would miss. Both daemons can read the scheduled-task file, both can reconcile one deletion journal, and the sidebar refetches the standalone list on navigation. The proposal assigns each case an existing narrow authority or a minimal eligibility rule instead of introducing daemon routing, a shared live-state service, a new task lease, or unrestricted multi-session coordination.

## Reviewer Test Plan

### How to verify

1. Confirm the contract allows daemon A to keep session S loaded while daemon B lists standalone sessions, creates New Chat T, and uses a different unowned session; restoring, renaming, or repairing S from B remains fenced by `409 session_writer_conflict` for S's complete loaded lifetime, while batch archive and delete retain their 200 envelope and preserve that same code on S's error item.
2. Confirm every writer hosted by the Conversations runtime, including standalone, Live, scheduled-task controller, and scheduled-task run sessions, must acquire the existing session writer lease before creation or restore succeeds, while ordinary workspace runtimes keep their current behavior. Confirm runtime publication accepts only a bridge with both the exact marker and an attested child-environment-forwarding factory; a marker-shaped map paired with an unattested factory is rejected, a new candidate is disposed, and an existing runtime is terminally quarantined while every later access preserves non-retryable `conversation_root_compromised`.
3. Confirm Conversations writers and standalone lifecycle or reconciliation operations select the hardened local policy, which reclaims only a well-formed active record from a dead or PID-reused process in the same local identity domain; on Linux this requires the same hostname, boot, and PID namespace, while a matching live or stalled process and every foreign or uncertain state remain fenced.
4. Confirm concurrent deletion-journal reconciliation treats a lease conflict as another daemon handling that UUID, skips it, and does not fail the unrelated triggering operation or classify the entry as compromised. Confirm historical state-root modes remain accepted while the `conversations/` leaf and journal subtree still require `0700` on POSIX systems. Confirm a working-directory pin is reused only for the same resident bridge event epoch: terminal close, idle reap, or generation replacement permits a safely recreated directory to be adopted, while replacement during the matching resident generation and every foreign or indeterminate bridge probe remain fail closed.
5. Confirm simultaneous restoration of one scheduled-task-bound session admits one resident scheduler through the session writer lease, and that a Conversations session cannot fire an unbound durable task until the existing task-file transaction commits exactly one controller binding. Confirm the default daemon runs the binding worker, an embed without it leaves unbound tasks dormant, and the document retains the existing at-least-once crash window instead of promising exactly-once delivery.
6. Confirm Live keeps its independent discovery owner and relocates stable-base handoff to publication with a no-op `commitOwner` callback and the existing grace after the handoff lock is released but before publication. Confirm `/live/start`, `/live/new`, and Host toggle/new all require the current protocol version plus the exact stable locator PID and instance nonce before call activation; a non-publisher returns the existing 503 for HTTP starts, performs no session or capture work, and still serves standalone while the elected daemon runs Live.
7. Confirm Web Shell list and transitional runtime-owner failures are required to render in the Recents section without navigation-triggered global toasts, writer errors render on the affected session or section with retry, and `activeElsewhere` remains out of scope.
8. Confirm the compatibility section requires draining old writers before cutover or rollback, preserves `503 conversation_runtime_in_use` for a live legacy owner present at first runtime creation, explicitly states that the one-shot check cannot detect an older daemon started later, and does not claim rolling mixed-version safety.
9. Run `git diff --check origin/main...HEAD` and `npx prettier --check docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md docs/design/certified-session-writer-handoff.md docs/design/daemon-session-maintenance-writer-lease.md docs/design/managed-session-writer-shutdown.md docs/design/session-writer-lease-p0a.md docs/design/standalone-daemon-sessions.md`; both should complete without errors.

### Evidence (Before & After)

N/A — documentation-only change with no user-visible or runtime behavior change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

macOS 26.4.1, Node.js 22.22.3, npm 10.9.8. Verified the complete diff, source references, relative document links, Markdown formatting, and whitespace checks locally.

## Risk & Scope

- Main risk or tradeoff: The supported concurrency boundary depends on every Conversations writer participating in the per-session lease, the parent rejecting a Conversations bridge unless both the exact marker and the configured factory's child-environment-forwarding capability are attested, unbound tasks remaining ineligible until their controller binding commits, and every HTTP or Host Live start path using exact stable-locator publisher admission. Safe automatic recovery also depends on correctly matching the local identity domain and process-start identity; unverifiable state intentionally remains unavailable. Working-directory replacement detection also depends on distinguishing the matching resident bridge generation from an orphaned daemon-local pin. The proposal does not provide globally fresh live state, cross-daemon event routing, atomic multi-session operations, or exactly-once scheduled-task delivery.
- Not validated / out of scope: This documentation PR does not implement or execute the runtime, two-process E2E, scheduled-task race, or Web Shell behavior it specifies. It also excludes an `activeElsewhere` list field, proxy or redirect behavior, unqualified stale-writer reclaim, and mixed-version operation.
- Breaking changes / migration notes: This PR changes no runtime behavior or API shape. A future implementation removes the process-wide rejection between updated daemons, retains a transitional 503 for live legacy owners, strengthens local writer identity, and requires a drain-and-cutover deployment before old non-participating writers can coexist with mandatory leased writers.

## Linked Issues

Refs #10810

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 记录一套待评审的架构方案：允许每个更新后的 daemon 挂载共享的 Conversations runtime，不再强制进程全局 runtime owner。方案按 session ID 定义支持的并发边界：多个 daemon 可以并发读取会话目录、创建聊天并承载不同 session；同一 session 的竞争 writer 和 lifecycle mutation 则使用现有 session writer lease，并保留现有 writer-conflict kind。打开、改名和修复返回现有 409 响应；batch archive 和 delete 保留 200 envelope，并在受影响项上携带 `session_writer_conflict`。

方案对 Conversations runtime 承载的所有 writer 强制启用该 lease，要求 Conversations bridge 在已有 runtime 被接受或新 candidate 发布前同时证明已配置精确私有 marker，且所选 channel factory 已声明会把 overrides 合并进实际 child environment，并在已有 runtime 被终态隔离后持续保留同一不可重试错误，为可证明已经死亡的 active writer 增加带身份约束的本地恢复，保留 certified handoff 以及对存活、外部或不确定状态的 fail-closed 处理，为存活的旧版本 owner 保留过渡期 503 保护，在保持 Conversations 与 journal 叶目录私有的同时兼容历史 state-root 权限，将 deletion-journal lease 冲突视为另一个 daemon 正在处理该条目，并使用现有 no-op commit 回调和锁外 grace 将稳定 runtime base 的 Live discovery 交接移入发布路径。方案还要求每个 Live 激活入口校验当前 daemon 是否为稳定 locator 的精确 publisher：非 publisher 仍可服务 standalone，但 HTTP 与 Host 发起的启动都会在 call 或 capture 激活前失败。工作目录 identity pin 仅对匹配的 resident bridge session generation 有效，因此该 generation 退出后会采用合法重建的目录，而运行期间发生的目录替换仍然 fail closed。

Scheduled task 复用同一个 session 边界，不再增加另一套 lease。同一 bound controller session 的并发恢复会在 scheduler 激活前选出唯一 resident writer。Conversations session 也会拒绝执行尚未绑定的 durable task，直到现有跨进程 task-file transaction 提交唯一 controller binding，因此竞争 keepalive worker 可以清理失败方产生的 orphan，而不会形成两次执行。默认 daemon 会运行该 binding worker；选择 Conversations 标记却不运行它的嵌入式宿主会让 unbound task 保持 dormant。这消除了并发恢复或绑定本身导致的重复，但明确保留 scheduler 在 prompt 已投递而 fired state 尚未持久化期间现有的 at-least-once 窗口。

Web Shell 的最小降级行为是同版本交付要求，即使实现拆到单独 PR：standalone 列表失败和过渡期 runtime-owner 响应在 Recents 区域只展示一次；writer conflict 和 unavailable 状态在受影响的 session 或区域内展示并提供重试，不再弹全局 toast。`activeElsewhere` 列表提示继续延期，因为方案不增加权威的跨 daemon live-state 索引。

## 为什么需要

当前外层 ownership gate 会让第一个触发 standalone 或 Live 的 daemon 阻塞另一个 daemon 的全部 standalone 接口并返回 runtime-in-use，包括共享列表、New Chat 和无关 session。真正的 transcript 完整性风险更窄，即两个 writer 同时追加或修改同一个 session。在可信的 Conversations-runtime 边界应用现有的 session 级 writer 协议，可以移除过宽的可用性限制，同时保留明确的同 session 围栏。

在实现前记录完整边界，也能暴露仅删除 owner 容易遗漏的共享后台路径：两个 daemon 都会读取 scheduled-task 文件，都可能对账同一 deletion journal，sidebar 也会在导航时重新拉取 standalone 列表。方案为每条路径指定现有的窄粒度权威或最小 eligibility 规则，不引入 daemon 间路由、共享 live-state 服务、新的 task lease 或无限制的多 session 协调。

## Reviewer 测试计划

### 如何验证

1. 确认契约允许 daemon A 持续加载 session S，同时 daemon B 可以列出 standalone session、创建 New Chat T，并使用另一个未被其他 writer 持有的 session；B 恢复、改名或修复 S 时，在 S 的完整 loaded 生命周期内继续由 `409 session_writer_conflict` 阻止，batch archive 和 delete 保留 200 envelope，并在 S 的 error item 上保留同一 code。
2. 确认 Conversations runtime 承载的每个 writer（包括 standalone、Live、scheduled-task controller 和 scheduled-task run session）都必须在创建或恢复成功前获取现有 session writer lease，而普通 workspace runtime 保持现有行为。确认只有精确 marker 与带 child-environment-forwarding capability 的 factory 同时存在时 runtime publication 才会接受 bridge；marker-shaped map 搭配未 attested factory 时会拒绝，新 candidate 会被 dispose，已有 runtime 会被终态 quarantine，且其后每次访问都保持不可重试的 `conversation_root_compromised`。
3. 确认 Conversations writer 以及 standalone lifecycle 或 reconciliation 操作选择强化后的 local 策略；它只回收同一本地身份域中已经死亡或 PID 被复用的进程留下的格式正确 active record；在 Linux 上这要求 hostname、boot 和 PID namespace 均相同，而匹配的存活或卡死进程以及所有外部或不确定状态仍被栅栏阻止。
4. 确认并发 deletion-journal reconciliation 将 lease 冲突视为另一个 daemon 正在处理该 UUID，跳过该项，并且不会让无关的触发操作失败，也不会把条目判为 compromised。确认历史 state-root 权限仍被接受，而 POSIX 上的 `conversations/` 叶目录与 journal 子树仍要求 `0700`。确认 working-directory pin 只会对同一 resident bridge event epoch 复用：terminal close、idle reap 或 generation 替换后可以采用合法重建的目录；在匹配 generation 仍 resident 时发生的替换，以及 foreign 或 indeterminate bridge probe，仍然 fail closed。
5. 确认同一 scheduled-task-bound session 的并发恢复通过 session writer lease 只允许一个 resident scheduler，并且 Conversations session 在现有 task-file transaction 提交唯一 controller binding 前不能执行未绑定的 durable task。确认默认 daemon 运行 binding worker，没有它的 embed 会让 unbound task 保持 dormant，并确认文档保留现有 at-least-once 崩溃窗口，没有承诺 exactly-once delivery。
6. 确认 Live 保留独立 discovery owner，并用 no-op `commitOwner` 回调把稳定 runtime base 的 handoff 移到发布路径，现有 grace 在 handoff 锁释放后、发布前执行。确认 `/live/start`、`/live/new` 以及 Host toggle/new 都会在 call 激活前校验当前协议版本与稳定 locator 的精确 PID 和 instance nonce；非 publisher 的 HTTP 启动返回现有 503，不执行 session 或 capture 工作，并且在被选举 daemon 运行 Live 时仍可服务 standalone。
7. 确认 Web Shell 列表失败和过渡期 runtime-owner 失败必须在 Recents 区域展示，不产生导航触发的全局 toast；writer 错误在受影响的 session 或区域展示并提供重试；`activeElsewhere` 仍不在范围内。
8. 确认兼容性章节要求在切换或回滚前排空旧 writer，为首次 runtime 创建时已经存活的旧版本 owner 保留 `503 conversation_runtime_in_use`，明确一次性检查无法发现之后启动的旧 daemon，并且没有宣称滚动混合版本是安全的。
9. 运行 `git diff --check origin/main...HEAD` 和 `npx prettier --check docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md docs/design/certified-session-writer-handoff.md docs/design/daemon-session-maintenance-writer-lease.md docs/design/managed-session-writer-shutdown.md docs/design/session-writer-lease-p0a.md docs/design/standalone-daemon-sessions.md`；两条命令都应无错误完成。

### 前后对比证据

N/A — 仅文档变更，没有用户可见或 runtime 行为变更。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

macOS 26.4.1、Node.js 22.22.3、npm 10.9.8。本地已核对完整 diff、源码引用、相对文档链接、Markdown 格式和空白检查。

## 风险与范围

- 主要风险或取舍：受支持的并发边界依赖 Conversations 的所有 writer 都参与 per-session lease、父侧拒绝未同时证明精确 marker 与 factory child-environment-forwarding capability 的 Conversations bridge、unbound task 在 controller binding 提交前保持不可执行，并依赖每个 HTTP 或 Host Live 启动路径执行稳定 locator 的精确 publisher admission。安全自动恢复还依赖正确匹配本地身份域和进程启动身份；无法验证的状态会有意保持不可用。工作目录替换检测还依赖正确区分匹配的 resident bridge generation 与孤立的 daemon-local pin。方案不提供全局实时 live state、跨 daemon event routing、原子的多 session 操作或 exactly-once scheduled-task delivery。
- 未验证或范围外：本次文档 PR 不实现或执行其描述的 runtime、双进程 E2E、scheduled-task race 或 Web Shell 行为。它也不包含 `activeElsewhere` 列表字段、代理或重定向、无身份约束的 stale-writer 回收和混合版本运行。
- 破坏性变更或迁移说明：本 PR 不改变任何 runtime 行为或 API 结构。未来实现将移除更新后 daemon 之间的进程级拒绝，为存活的旧版本 owner 保留过渡期 503，强化本地 writer 身份，并要求在旧的非 lease writer 可能与强制 lease writer 共存前采用 drain-and-cutover 发布。

## 关联 Issue

Refs #10810

</details>
