### PR TITLE
fix(ci): Take the OpenTUI interactive e2e leg out of CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -258,7 +258,9 @@ jobs:
             fi
           fi
           # QWEN_E2E_RENDERER=ink pins the baseline leg of the renderer
-          # matrix; the opentui leg runs in e2e-interactive-opentui below.
+          # matrix; the OpenTUI counterpart has no CI leg. Run it locally
+          # with npm run test:integration:interactive:opentui:sandbox:none
+          # (parity gaps tracked in issue #8662).
           # The docker leg runs vitest directly instead of through
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
@@ -368,71 +370,6 @@ jobs:
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
         run: 'npx cross-env QWEN_E2E_RENDERER=ink VERBOSE=true KEEP_OUTPUT=true QWEN_SANDBOX=false vitest run --root ./integration-tests --exclude "**/interactive/cron-interactive.test.ts" --exclude "**/channel-plugin.test.ts" --shard="${{ matrix.shard }}"'
-
-  e2e-interactive-opentui:
-    name: 'E2E Interactive - OpenTUI renderer (bun)'
-    runs-on: 'ubuntu-latest'
-    # Same rationale as e2e-test-linux: a wedged run must free the runner.
-    timeout-minutes: 60
-    # Skip on fork PRs (no secrets) — see e2e-test-linux above.
-    if: |-
-      ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
-
-      - name: 'Set up Node.js'
-        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e' # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          cache-dependency-path: 'package-lock.json'
-          registry-url: 'https://registry.npmjs.org/'
-
-      # The opentui renderer leg runs the CLI bundle under bun: the locked
-      # @opentui/core loads its native renderer through bun:ffi, and the CI
-      # node build cannot load node:ffi. The renderer matrix also pins
-      # QWEN_TUI_RENDERER=opentui (plus QWEN_TUI_RENDERER_STRICT) for every
-      # spawned CLI, so a boot that silently fell back to ink fails the leg
-      # instead of passing as a false green. The version matches
-      # DEFAULT_BUN_VERSION in scripts/build-standalone-release.js (the
-      # --runtime=bun archive flavor) and is pinned, not 'latest', so an
-      # upstream Bun release cannot flip this gating leg red on its own.
-      - name: 'Set up Bun'
-        uses: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6' # v2.2.0
-        with:
-          bun-version: '1.3.14'
-
-      - name: 'Configure npm for rate limiting'
-        run: |-
-          npm config set fetch-retry-mintimeout 20000
-          npm config set fetch-retry-maxtimeout 120000
-          npm config set fetch-retries 5
-          npm config set fetch-timeout 300000
-
-      - name: 'Install dependencies'
-        env:
-          QWEN_SKIP_PREPARE: '1'
-        run: |-
-          npm ci --prefer-offline --no-audit --progress=false
-
-      - name: 'Build project'
-        run: |-
-          npm run build
-
-      - name: 'Bundle CLI for E2E tests'
-        run: |-
-          npm run bundle
-
-      - name: 'Run interactive E2E tests (OpenTUI)'
-        env:
-          OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
-          OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
-          OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
-          KEEP_OUTPUT: 'true'
-          VERBOSE: 'true'
-        run: |-
-          npx cross-env QWEN_E2E_RENDERER=opentui QWEN_SANDBOX=false vitest run --root ./integration-tests interactive --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts'
 
   isolated-nightly:
     name: '${{ matrix.label }} (nightly)'

--- a/docs/design/2026-08-28-opentui-migration-design.md
+++ b/docs/design/2026-08-28-opentui-migration-design.md
@@ -159,8 +159,8 @@ The pieces, in landing order:
   own (#8662 U-10). The runtime fixes this batch used to carry — the Bun
   memory flags and the goal-runtime startup wait — landed early in #10128.
 - **Build & CI.** Bundle asset pipeline for the OpenTUI runtime assets, the
-  CI legs (e2e, tui-parity), renderer-matrix integration tests, and the
-  parity tooling (codemod, PTY harness).
+  tui-parity CI gate, renderer-matrix integration tests and the env pinning
+  the e2e legs carry, and the parity tooling (codemod, PTY harness).
 
 ### Renderer selection and runtime gate
 
@@ -252,8 +252,12 @@ safe to run before its owners exist, and the activation batch inherits them:
   vitest suite green; the default (ink) path byte-for-byte unchanged — the
   batches landed so far touch zero reachable ink code paths because nothing
   outside `src/ui/opentui/` imports them. The activation batch additionally
-  smoke-tests the flag under Bun (boot, dialog, live turn, exit drain); the
-  build/CI batch runs the OpenTUI e2e leg green on CI.
+  smoke-tests the flag under Bun (boot, dialog, live turn, exit drain). The
+  build/CI batch wired the renderer matrix into the existing e2e legs and
+  added the tui-parity gate; its own OpenTUI interactive e2e leg ran on
+  `main`, reported three real gaps (approval-mode indicator never drawn,
+  `@file` expansion absent, `submitted_prompt` dropped), and has since come
+  out of CI until those close (#8662).
 - **1:1 parity audits** — screen-by-screen comparison against ink, plus a
   reverse audit pass, with surviving differences landing as tracked gaps
   (G-series) rather than silent drift.


### PR DESCRIPTION
<!--Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.-->

## What this PR does

Removes the OpenTUI interactive end-to-end job that the Batch 7 CI work added to the E2E workflow, and fixes the two places that described it as a live gate. No test file is deleted and no test is excluded: every interactive file keeps running under the ink renderer, so this removes a job that reports failures rather than results.

## Why it's needed

That job triggers only on pushes to `main`, the nightly schedule and manual dispatch, so it never ran on its own pull request and its first executions were on `main`. There it fails deterministically — the same four files have failed across three consecutive `main` commits (runs 33609632018, 33615039100, 33621485985), which keeps `main` red for everyone.

Three of the four failures are not test fragility. They are real parity gaps the OpenTUI renderer still has, and the leg did its job by surfacing them:

- The approval-mode indicator is never drawn, so a user who starts with `--yolo` cannot see which approval mode they are in.
- The raw submitted text is dropped at the submit seam, so the prompt-submission hook input loses its `submitted_prompt` field and the external-context auto-recall path silently does nothing.
- `@file` expansion does not work under this renderer at all, because its turn loop skips the pipeline that prepares a query for the model.

The fourth failure, the context-compression case, is not yet explained: it reproduces on `main` and locally, but the code path still looks correct on inspection, so it needs a credentialed reproduction to diagnose.

These are being registered against the migration tracking issue #8662, and a version of this leg that passes is a Phase 3 gate rather than something to restore opportunistically. In the meantime, keeping `main` green is what lets everyone else's post-merge E2E signal mean something.

## Reviewer Test Plan

### How to verify

- The job is gone and nothing dangles: searching the workflow directory for its job name and display name returns only the renderer pins that the surviving legs carry, plus the comment updated here to point at the local run path.
- Coverage is not silently lost: the ink legs still run all ten interactive files, and the renderer-matrix harness stays in use — its tests pin which renderer a spawned CLI must boot.
- The OpenTUI side is still runnable by a developer through the existing integration-test npm script.

### Evidence (Before & After)

Before — on `main`, the leg's summary is `Test Files 4 failed | 4 passed | 1 skipped (9)`, with five failing tests: two context-compression, one auto-recall, one provenance, one protocol-tag retry.

After — the leg does not exist, so the workflow reports only legs that pass. Locally the workflow file parses, `prettier --check` is clean, the size ratchet script exits 0, `node scripts/lint.js --actionlint` exits 0, and the unit tests that parse this workflow plus the size script pass 226/226; the renderer-matrix harness passes 6/6.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

<!-- macOS: YAML/actionlint/size-ratchet/prettier/unit checks. Windows: no workflow change affects that lane. Linux: not run locally — the removed leg executes only on ubuntu under Bun with model credentials, which is precisely what this PR takes out of CI. -->

### Environment (optional)

Repo checks only (no CLI boot): `bash .github/scripts/check-workflow-size.sh`, `node scripts/lint.js --actionlint`, `npx prettier --check`, `npx vitest run scripts/tests/e2e-workflow.test.js scripts/tests/e2e-shard-retry.test.js scripts/tests/workflow-size.test.js`, `integration-tests` `npx vitest run renderer-matrix.test.ts`.

## Risk & Scope

- Main risk or tradeoff: while this leg is out of CI, the automated OpenTUI signal is only the parity-snapshot and no-flicker gate, so a new interactive-renderer regression can land unnoticed. A permanently red `main` was judged the worse of the two, and this is one reversible commit.
- Not validated / out of scope: whether the removed job is a required check — branch-protection details return 404 for me, so if it is required, the requirement needs dropping separately. This PR fixes none of the three gaps; it stops the alarm while they are worked.
- Breaking changes / migration notes: none for users.

## Linked Issues

Refs #8662

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

移除了 Batch 7 在 E2E workflow 中新增的 OpenTUI 交互式端到端 job，并同步修正了两处把它描述成"在跑的 CI 门禁"的文字。没有删除任何测试文件，也没有排除任何用例：所有交互式文件继续在 ink 渲染器下运行，本 PR 只是撤掉一个只产出失败、不产出结论的 job。

## 为什么需要

这个 job 只在 push 到 `main`、每晚定时任务和手动 dispatch 时触发，因此它在自己的 PR 上从未执行过，第一批运行就落在 `main` 上。它是确定性失败的 —— 连续三个 `main` 提交都是同样四个文件失败（run 33609632018、33615039100、33621485985），会把 `main` 一直挂红，影响所有人。

四个失败里有三个不是测试脆弱，而是 OpenTUI 渲染器真实的对齐缺口，这个 job 的价值恰恰是把它们暴露出来：

- 审批模式指示完全没绘制，用 `--yolo` 启动的用户看不见自己当前处于哪种审批模式；
- 提交口丢掉了用户原始输入，prompt 提交钩子的入参少了 `submitted_prompt`，导致外部上下文自动召回静默地什么都不做；
- `@file` 展开在该渲染器下根本不工作，因为它的回合循环绕过了"为模型准备请求"的整条管线。

第四个失败（上下文压缩用例）目前还解释不了：`main` 和本地都能复现，但按代码路径审查看不出问题，需要带凭证的复现才能定位。

以上都已登记到迁移跟踪 issue #8662，而"这条腿能跑绿"是 Phase 3 的门禁之一，不应顺手恢复。在此之前，先让 `main` 回到绿色，才能让其他人 merge 后的 E2E 信号有意义的。

## 验证者测试计划

### 如何验证

- job 已删除且没有悬挂引用：在 workflow 目录搜索其 job 名与显示名，只剩下各条保留腿自带的渲染器 pin，以及本 PR 改写的、指向本地运行方式的注释。
- 覆盖没有被静默削掉：ink 腿仍然跑全部十个交互式文件；渲染器矩阵脚手架仍在使用，其测试会 pin 住被启动的 CLI 必须以哪个渲染器起来。
- 开发者仍可通过既有的 integration-test npm 脚本在本地跑 OpenTUI 侧。

### 前后证据

之前 —— `main` 上这条腿的汇总是 `Test Files 4 failed | 4 passed | 1 skipped (9)`，5 个失败用例：context-compression 2 个、auto-recall 1 个、provenance 1 个、protocol-tag 重试 1 个。

之后 —— 这条腿不存在，workflow 只报告能通过的腿。本地该 workflow 文件可解析、`prettier --check` 干净、体积棘轮脚本退出 0、`node scripts/lint.js --actionlint` 退出 0；解析该 workflow 与体积脚本的单测 226/226 通过；渲染器矩阵脚手架 6/6 通过。

### 各系统测试情况

macOS ✅（YAML/actionlint/体积/prettier/单测检查）；Windows N/A（不涉及该系统lane）；Linux ⚠️ 未在本地运行 —— 被删除的腿只在 ubuntu + Bun + 模型凭证下执行，这正是本 PR 撤出 CI 的东西。

### 风险与范围

- 主要权衡：这条腿撤出 CI 期间，OpenTUI 的自动化信号只剩 parity 快照与 no-flicker 门禁，交互式渲染器的新回归有可能不被自动捕获。两害相权，长期挂红的 `main` 更糟，而这是单个可回滚提交。
- 未验证 / 不在范围内：该 job 是否为必需检查 —— 我拿到的分支保护详情是 404，如果它确实是必需检查，需要另外移除该要求。本 PR 不修三个缺口中的任何一个，只是在修复期间先把警报停掉。
- 破坏性变更 / 迁移说明：对用户无。

关联：#8662（未用关闭关键字）

</details>