### PR TITLE
fix(cli): restore prompt provenance and @-expansion in the OpenTUI turn

### DIFF
--- a/integration-tests/interactive/context-compress-interactive.test.ts
+++ b/integration-tests/interactive/context-compress-interactive.test.ts
@@ -51,6 +51,17 @@ describe('Interactive Mode', () => {
 
       await rig.waitForText('einstein', 25000);
 
+      // The marker text can render mid-turn (OpenTUI streams reasoning
+      // content before the final answer). Typing `/compress` while the turn
+      // is still in flight queues the text as a follow-up prompt instead of
+      // executing it as a slash command — wait for the turn's api_response
+      // telemetry so the command reaches an idle composer.
+      const sawTurnEnd = await rig.waitForTelemetryEvent('api_response', 90000);
+      expect(
+        sawTurnEnd,
+        'turn did not complete (no api_response telemetry)',
+      ).toBe(true);
+
       await type(ptyProcess, '/compress');
       // A small delay to allow React to re-render the command list.
       await new Promise((resolve) => setTimeout(resolve, 100));
@@ -138,6 +149,13 @@ describe('Interactive Mode', () => {
       await type(ptyProcess, '\r');
 
       await rig.waitForText('einstein', 25000);
+
+      // Same mid-turn race as the first case: wait for the turn's
+      // api_response telemetry so /compress is not queued as model input.
+      expect(
+        await rig.waitForTelemetryEvent('api_response', 90000),
+        'turn did not complete (no api_response telemetry)',
+      ).toBe(true);
 
       // Fire /compress with a trailing instruction. We are not asserting on
       // summary CONTENT (model behaviour) — only that the wiring runs

--- a/integration-tests/interactive/protocol-tags-interactive.test.ts
+++ b/integration-tests/interactive/protocol-tags-interactive.test.ts
@@ -95,11 +95,11 @@ describe('Interactive protocol tag retry guard', () => {
       );
 
       try {
-        const isReady = await rig.poll(
-          () => /YOLO (模式|mode)/i.test(stripAnsi(rig._interactiveOutput)),
-          30000,
-          200,
-        );
+        // Renderer-agnostic readiness: the ink footer carries the
+        // approval-mode label (e.g. "YOLO mode"), the OpenTUI prompt chrome
+        // only shows its prefix glyph — the placeholder is the only text
+        // both renderers put on screen once the composer is up.
+        const isReady = await rig.waitForText('Type your message', 30000);
         expect(isReady, 'CLI did not start up in interactive mode').toBe(true);
 
         await type(ptyProcess, 'Return the deterministic retry response.');

--- a/packages/cli/src/ui/opentui/live-session.test.ts
+++ b/packages/cli/src/ui/opentui/live-session.test.ts
@@ -25,6 +25,13 @@ import {
 } from './live-session.js';
 import type { OpenTuiStreamEvent } from './event-adapter.js';
 
+// @-command expansion is stubbed: the tests assert the wiring (expanded
+// prompt to the model, raw text as submittedPrompt), not the resolver.
+const handleAtCommandMock = vi.hoisted(() => vi.fn());
+vi.mock('../hooks/atCommandProcessor.js', () => ({
+  handleAtCommand: handleAtCommandMock,
+}));
+
 // The steering test drives one full tool round-trip; replace the scheduler
 // with a stub that completes the pending calls immediately.
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
@@ -261,6 +268,79 @@ describe('livePromptEvents', () => {
       type: SendMessageType.UserQuery,
       modelOverride: 'fast-x',
     });
+  });
+
+  it('carries submittedPrompt on the first UserQuery and omits it on tool continuation', async () => {
+    let calls = 0;
+    const sendMessageStream = vi.fn(function* (): Generator<{
+      type: string;
+      value?: unknown;
+    }> {
+      calls += 1;
+      if (calls === 1) {
+        yield {
+          type: 'tool_call_request',
+          value: { callId: 't1', name: 'test_tool', args: {} },
+        };
+        return;
+      }
+      yield { type: 'finished', value: {} };
+    });
+    const config = createFakeConfig(sendMessageStream);
+
+    await drain(
+      livePromptEvents(config, 'go', undefined, {
+        submittedPrompt: 'raw composer text',
+      }),
+    );
+
+    expect(sendMessageStream).toHaveBeenCalledTimes(2);
+    const [, , , firstOptions] = sendMessageStream.mock.calls[0] as unknown[];
+    expect(firstOptions).toEqual({
+      type: SendMessageType.UserQuery,
+      submittedPrompt: 'raw composer text',
+    });
+    const [, , , secondOptions] = sendMessageStream.mock.calls[1] as unknown[];
+    expect(secondOptions).toEqual({ type: SendMessageType.ToolResult });
+  });
+
+  it('expands @-commands in the model prompt while submittedPrompt stays raw', async () => {
+    const expanded = [{ text: 'expanded @file.txt content' }];
+    handleAtCommandMock.mockResolvedValue({
+      shouldProceed: true,
+      processedQuery: expanded,
+    });
+    const sendMessageStream = vi.fn(function* () {});
+    const config = createFakeConfig(sendMessageStream);
+
+    await drain(
+      livePromptEvents(config, '@file.txt do it', undefined, {
+        submittedPrompt: '@file.txt do it',
+      }),
+    );
+
+    expect(handleAtCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ query: '@file.txt do it', config }),
+    );
+    const [prompt, , , options] = sendMessageStream.mock.calls[0] as unknown[];
+    expect(prompt).toBe(expanded);
+    expect(options).toEqual({
+      type: SendMessageType.UserQuery,
+      submittedPrompt: '@file.txt do it',
+    });
+  });
+
+  it('skips the LLM call when @-command handling aborts the turn', async () => {
+    handleAtCommandMock.mockResolvedValue({
+      shouldProceed: false,
+      processedQuery: null,
+    });
+    const sendMessageStream = vi.fn(function* () {});
+    const config = createFakeConfig(sendMessageStream);
+
+    await drain(livePromptEvents(config, '@missing.txt try', undefined));
+
+    expect(sendMessageStream).not.toHaveBeenCalled();
   });
 
   it('appends drained steering texts after tool responses at the boundary', async () => {

--- a/packages/cli/src/ui/opentui/live-session.ts
+++ b/packages/cli/src/ui/opentui/live-session.ts
@@ -45,6 +45,8 @@ import {
   renderResultDisplay,
   type OpenTuiStreamEvent,
 } from './event-adapter.js';
+import { isAtCommand } from '../utils/commandUtils.js';
+import { handleAtCommand } from '../hooks/atCommandProcessor.js';
 
 interface LooseCompletedCall {
   request: { callId: string; name?: string; args?: unknown };
@@ -93,6 +95,13 @@ export interface LivePromptOptions {
    * is minted here (first turn of a session, …).
    */
   promptId?: string;
+  /**
+   * Raw composer text for this turn (ink SendMessageOptions.submittedPrompt
+   * parity): forwarded on the first UserQuery so UserPromptSubmit hooks and
+   * the agent-input recording see the text projection, never the
+   * @-expanded model-bound prompt. ToolResult continuations never carry it.
+   */
+  submittedPrompt?: string;
 }
 
 /**
@@ -254,20 +263,45 @@ export async function* livePromptEvents(
   const abort = signal ?? new AbortController().signal;
   const dbg = process.env['QWEN_OPENTUI_DEBUG'];
 
+  // ink useGeminiStream parity: expand `@<path>` / `@server:uri` commands in
+  // the first model-bound prompt. The composer/turn driver still echoes the
+  // raw text and forwards it as `submittedPrompt`, so the expansion must
+  // happen here, after provenance has been captured — otherwise the model
+  // never sees the file/resource contents (provenance + auto-recall E2E).
+  let modelPrompt: PartListUnion = prompt;
+  if (typeof modelPrompt === 'string' && isAtCommand(modelPrompt)) {
+    const atCommandResult = await handleAtCommand({
+      query: modelPrompt,
+      config,
+      onDebugMessage: () => {},
+      messageId: Date.now(),
+      signal: abort,
+    });
+    if (!atCommandResult.shouldProceed || !atCommandResult.processedQuery) {
+      return;
+    }
+    modelPrompt = atCommandResult.processedQuery;
+  }
+
   // The ink app drives tool EXECUTION via useReactToolScheduler: the client
   // only yields `tool_call_request` and ends the turn, then the UI schedules
   // the tool and submits the functionResponses to continue. Replicate that
   // loop here so tools actually run under OpenTUI (drain -> schedule ->
   // submit results -> drain again).
-  let nextPrompt: PartListUnion = prompt;
+  let nextPrompt: PartListUnion = modelPrompt;
   let first = true;
   const waitingSeen = new Set<string>();
   for (;;) {
     const sendOptions = first
-      ? options?.modelOverride
+      ? options?.modelOverride || options?.submittedPrompt
         ? {
             type: SendMessageType.UserQuery,
-            modelOverride: options.modelOverride,
+            ...(options.modelOverride
+              ? { modelOverride: options.modelOverride }
+              : {}),
+            ...(options.submittedPrompt
+              ? { submittedPrompt: options.submittedPrompt }
+              : {}),
           }
         : undefined
       : {

--- a/packages/cli/src/ui/opentui/live-turn.ts
+++ b/packages/cli/src/ui/opentui/live-turn.ts
@@ -90,6 +90,11 @@ export interface OpenTuiSubmitOptions {
   modelOverride?: string;
   refreshContextFilesOnWrite?: boolean;
   onComplete?: () => Promise<void>;
+  /**
+   * Raw composer text (ink submittedPrompt provenance parity): forwarded to
+   * the UserPromptSubmit hook, never the @-expanded model-bound prompt.
+   */
+  submittedPrompt?: string;
 }
 
 export interface OpenTuiLiveTurn {
@@ -188,6 +193,7 @@ export function useOpenTuiLiveTurn(
           promptId,
           modelOverride: turnOptions?.modelOverride,
           refreshContextFilesOnWrite: turnOptions?.refreshContextFilesOnWrite,
+          submittedPrompt: turnOptions?.submittedPrompt,
           drainSteering: drainQueue,
           onWaitingCall: (call) => {
             if (seq !== turnSeqRef.current) return;
@@ -228,7 +234,9 @@ export function useOpenTuiLiveTurn(
             const text = drainQueue().join('\n');
             if (text.trim()) {
               apply({ type: 'user', text });
-              void runTurn(text, nextLivePromptId(config));
+              void runTurn(text, nextLivePromptId(config), {
+                submittedPrompt: text,
+              });
             }
           }
         }
@@ -266,7 +274,9 @@ export function useOpenTuiLiveTurn(
         parts.length > 0 ? [{ text }, ...parts] : content;
       const promptId = nextLivePromptId(config);
       apply({ type: 'user', text, promptId, sentToModel: true });
-      void runTurn(prompt, promptId, options);
+      const submittedPrompt =
+        options?.submittedPrompt ?? (text.trim().length > 0 ? text : undefined);
+      void runTurn(prompt, promptId, { ...options, submittedPrompt });
     },
     [config, apply, pushQueue, runTurn],
   );


### PR DESCRIPTION
## What this PR does

This PR fixes the `E2E Interactive - OpenTUI renderer (bun)` leg, which has been red on every main-branch run since the leg was introduced (#10770, cd1ac728). It addresses the three distinct root causes behind the four consistently failing interactive tests:

1. The OpenTUI live-turn pipeline never forwarded the raw composer text as `submittedPrompt`, so every `UserPromptSubmit` hook fired without `submitted_prompt`. Hook consumers that require the supported text projection silently misfired — most visibly the managed external-context auto-recall hook, which skipped its recall query entirely (external context never reached the model), and any hook test asserting provenance.
2. The OpenTUI live-turn pipeline never ran `@<path>` / `@server:uri` command expansion. The model received the literal `@file` text and never saw the file or MCP-resource contents the user referenced. Expansion now runs on the first model-bound prompt of a turn — after the raw text has been captured as `submittedPrompt` — with the same `handleAtCommand` machinery the ink pipeline uses, and stays skipped for `ToolResult` continuations.
3. Two interactive tests encoded ink-only assumptions: the protocol-tag guard waited for the ink footer's "YOLO mode" label (the OpenTUI prompt chrome shows only the colored prefix glyph), and the `/compress` cases typed the command while the turn was still streaming (OpenTUI renders reasoning content that can contain the completion marker long before the final answer), which queues the text as a follow-up prompt instead of executing the slash command. The tests now wait on renderer-agnostic signals — the composer placeholder and the turn's `api_response` telemetry, respectively.

Unit tests cover the new provenance threading (present on the first `UserQuery`, absent on tool continuations) and the `@`-expansion wiring (expanded parts reach the model, raw text stays the provenance, aborted expansion skips the LLM call).

## Why it's needed

The OpenTUI renderer is the tracked destination for the TUI migration (#8662), but two pieces of the turn pipeline silently dropped behavior the ink renderer and the non-interactive path both provide: hook provenance and `@`-command expansion. Users running the OpenTUI flavor today get no external-context auto recall and no file-content injection from `@path` references. The new CI leg caught exactly these regressions — but the leg has never been green, which also trains everyone to ignore every E2E failure on main. Fixing the product gaps lives in the turn pipeline; fixing the two test assumptions makes the leg's signal meaningful.

## Reviewer Test Plan

### How to verify

Reproduce the failures on `main` (all four fail consistently), then confirm they pass with this change. Requires `bun` on PATH, `npm run build && npm run bundle` first:

```bash
# 1. Failing tests on main, under the OpenTUI (bun) renderer:
QWEN_E2E_RENDERER=opentui QWEN_SANDBOX=false npx vitest run --root ./integration-tests \
  interactive/protocol-tags-interactive.test.ts \
  interactive/submitted-prompt-provenance.test.ts \
  interactive/external-context-auto-recall.test.ts
# Before: 3 failed. After: 3 passed (~25s).

# 2. /compress needs real model credentials:
OPENAI_API_KEY=... OPENAI_BASE_URL=... OPENAI_MODEL=... \
  QWEN_E2E_RENDERER=opentui QWEN_SANDBOX=false npx vitest run --root ./integration-tests \
  interactive/context-compress-interactive.test.ts
# Before: both cases time out waiting for the chat_compression telemetry event
# (the command is queued mid-turn as plain model input). After: 2 passed | 1 skipped.

# 3. Unit tests:
cd packages/cli && npx vitest run src/ui/opentui/live-session.test.ts
# 22 passed, including the three new provenance/expansion cases.

# 4. Ink leg unaffected — the shared test edits keep working under the default renderer:
QWEN_E2E_RENDERER=ink QWEN_SANDBOX=false npx vitest run --root ./integration-tests \
  interactive/protocol-tags-interactive.test.ts \
  interactive/context-compress-interactive.test.ts
```

Expected: the OpenTUI interactive leg of `E2E Tests` goes green on this PR's commit; every other E2E job is unchanged.

### Evidence (Before & After)

Before (main, run 33621485985 on d50b0283 — identical set also on cd1ac728 and 5dc7547d):

- `external context auto recall > retrieves...` — provider received no query at all (`expected [] to deeply equal [ … ]`).
- `submitted prompt provenance` — first `UserPromptSubmit` hook input missing `submitted_prompt`.
- `Interactive protocol tag retry guard` — `CLI did not start up in interactive mode` (the "YOLO mode" footer text never renders under OpenTUI).
- `should trigger chat compression` — `chat_compression telemetry event was not found` (`/compress` queued mid-turn instead of executing).

After (local, same commands):

```text
Test Files  3 passed (3)      # protocol-tags + provenance + auto-recall, OpenTUI/bun
✓ Interactive Mode > should trigger chat compression with /compress command  60781ms
✓ Interactive Mode > should forward /compress instructions through to the side-query  136767ms
Test Files  1 passed (1)      # context-compress, real model, OpenTUI/bun
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   CI   |

### Environment (optional)

Local runs used `QWEN_E2E_RENDERER=opentui` with Bun 1.4.0 on macOS arm64 (CI pins 1.3.14); `/compress` verification used a real OpenAI-compatible endpoint. Ink-renderer variants were re-run for every edited test.

## Risk & Scope

- Main risk or tradeoff: the `@`-expansion call site mirrors ink's ordering (raw text → provenance → expansion), but inline image attachments still skip expansion (text-part-only), matching the pre-existing OpenTUI limitation, not ink's vision bridge.
- Not validated / out of scope: queued mid-turn slash commands still submit as model text rather than executing (pre-existing semantic, unchanged); the `/compress` tests are now made race-safe through the turn-end telemetry instead. Windows E2E was not run locally (CI covers it; the affected tests skip win32).
- Breaking changes / migration notes: none — the ink and non-interactive pipelines are untouched; only the OpenTUI live turn gains parity behavior.

## Linked Issues

Closes #10811
Closes #10804
Refs #8662

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 修复了 `E2E Interactive - OpenTUI renderer (bun)` 这条 CI 腿——它自引入（#10770，cd1ac728）以来在 main 分支上每次运行都是红的。根因有三个，对应四个持续失败的交互测试：

1. OpenTUI 的 live-turn 管线从未把原始输入文本作为 `submittedPrompt` 透传，导致每次 `UserPromptSubmit` 钩子都缺少 `submitted_prompt` 字段。依赖该文本投影的钩子消费方静默失效——最明显的是受管外部上下文 auto-recall 钩子，它直接跳过了召回查询（外部上下文从未进入模型请求），以及所有断言 provenance 的钩子测试。
2. OpenTUI 的 live-turn 管线从未执行 `@<path>` / `@server:uri` 命令展开，模型收到的只是字面 `@file` 文本，永远看不到用户引用的文件或 MCP 资源内容。现在展开在回合的首个模型侧提示上进行——在原文已被捕获为 `submittedPrompt` 之后——使用与 ink 管线相同的 `handleAtCommand` 机制，并且 `ToolResult` 续传回合不做展开。
3. 两个交互测试内嵌了 ink 专属假设：协议标签用例等待 ink 页脚的 "YOLO mode" 文本（OpenTUI 的输入框只显示彩色前缀符号），两个 `/compress` 用例在回合仍在流式输出时键入命令（OpenTUI 会渲染包含完成标记词的推理内容，远早于最终答案），导致文本被排队成后续提示而非执行斜杠命令。测试改为等待渲染器无关的信号——分别是输入框占位文本和回合的 `api_response` 遥测事件。

单元测试覆盖了新的 provenance 透传（首个 `UserQuery` 携带、`ToolResult` 续传不携带）和 `@` 展开接线（展开后的部分进入模型、原文保持 provenance、展开中止时跳过 LLM 调用）。

## 为什么需要

OpenTUI 渲染器是 TUI 迁移（#8662）的目标形态，但回合管线中两块行为在 OpenTUI 下静默丢失，而 ink 渲染器和非交互路径都提供：钩子 provenance 与 `@` 命令展开。当前 OpenTUI 用户没有任何外部上下文自动召回，也没有 `@path` 文件内容注入。新增的 CI 腿恰好捕获了这些回归——但它从未转绿，这会让所有人习惯性忽略 main 上的任何 E2E 红灯。修复产品缺口落在回合管线上；修复两个测试假设让这条腿的信号重新有意义。

## 评审验证计划

在 `main` 上复现失败（四个测试都会确定性失败），再确认本改动后通过。需要 PATH 中有 `bun`，先执行 `npm run build && npm run bundle`：复现与验证命令同英文正文；期望本 PR 提交后 `E2E Tests` 的 OpenTUI 交互腿转绿，其余 E2E 任务不受影响。

### 环境

本地验证为 macOS arm64、Bun 1.4.0（CI 锚定 1.3.14）；`/compress` 用真实 OpenAI 兼容端点验证；所有被编辑的测试也用 ink 渲染器重跑通过。

## 风险与范围

- 主要风险/取舍：`@` 展开的调用点对齐 ink 的顺序（原文 → provenance → 展开)，但内联图片附件仍跳过展开(仅文本部分)，这延续的是 OpenTUI 现存限制，与 ink 的 vision bridge 无差异。
- 未验证/范围外：中途排队的斜杠命令仍按模型文本提交而非执行(既有语义未变)；`/compress` 测试通过等待回合结束遥测消除了竞态。Windows E2E 未在本地运行(CI 覆盖；受影响测试在 win32 上本就跳过)。
- 破坏性变更/迁移说明：无——ink 与非交互管线均未触碰，仅 OpenTUI 的 live 回合获得对齐行为。

</details>
