### PR TITLE
fix(ci): stop sandbox image prep from waiting on another run's tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -201,40 +201,52 @@ jobs:
               npm run build:sandbox -- -s --no-prune -i "$sandbox_image"
             }
 
-            acquire_daemon_write_lock() {
-              lock_deadline=$((SECONDS + 1800))
-              until flock --nonblock 9; do
-                if (( SECONDS >= lock_deadline )); then
-                  echo "::error::docker daemon write lock not acquired within 30 minutes"
-                  exit 1
-                fi
-                sleep 1
-              done
-            }
-
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
               mkdir -p "${HOME}/.cache/qwen-code-ci"
-              exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-e2e-${GITHUB_SHA}.lock"
-              if ! flock --wait 1800 8; then
-                echo "::error::docker build coordinator lock not acquired within 30 minutes"
-                exit 1
-              fi
+              # Host daemon lock, shared for the whole step and never
+              # upgraded: it only keeps the age-based prune (which takes it
+              # exclusively, non-blocking) off a daemon with Docker work in
+              # flight. #10605 upgraded it to exclusive to build an image,
+              # which starves that shard behind the test-phase readers of
+              # every other run on the host: in run 33637097713 shard 1/3
+              # gave up on the write lock after 30 minutes while a shard of
+              # run 33638984513 held the shared lock through its tests, and
+              # shard 2/3 then timed out on the coordinator lock shard 1/3
+              # was still holding.
               exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
               if ! flock --shared --wait 1800 9; then
                 echo "::error::docker daemon read lock not acquired within 30 minutes"
+                exit 1
+              fi
+              # Per-commit coordinator: one shard per host builds the image,
+              # its siblings wait here and then find it present.
+              exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-e2e-${GITHUB_SHA}.lock"
+              if ! flock --wait 1800 8; then
+                echo "::error::docker build coordinator lock not acquired within 30 minutes"
                 exit 1
               fi
             fi
 
             if ! docker image inspect "$sandbox_image" > /dev/null 2>&1; then
               if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
-                flock --unlock 9
-                acquire_daemon_write_lock
+                # Host build mutex: keeps concurrent image builds off one
+                # daemon. Held only while an image is prepared, never while
+                # tests run, so the wait is bounded by a build.
+                exec 7>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build.lock"
+                if ! flock --wait 1800 7; then
+                  echo "::error::docker build lock not acquired within 30 minutes"
+                  exit 1
+                fi
               fi
+              # Label- and age-filtered, so it cannot touch the image a
+              # concurrent shard is testing.
               docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
               if ! build_image; then
                 echo "::warning::sandbox image build failed; retrying once"
                 build_image
+              fi
+              if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+                flock --unlock 7
               fi
             else
               echo "Reusing sandbox image for ${GITHUB_SHA}"
@@ -243,7 +255,6 @@ jobs:
             sandbox_image_id="$(docker image inspect --format '{{.Id}}' "$sandbox_image")"
             export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
-              flock --shared 9
               flock --unlock 8
             fi
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -197,8 +197,13 @@ jobs:
           if [ '${{ matrix.sandbox }}' = 'sandbox:docker' ]; then
             sandbox_image="$(node -p "require('./packages/cli/package.json').config.sandboxImageUri")-e2e-${GITHUB_SHA}"
 
+            # 7>&- 8>&- 9>&- here and on the test command below: a lock
+            # lives on the open file description, so a descendant that
+            # inherits the descriptor and outlives this job keeps holding it.
+            # Closing it in the child costs nothing — this shell keeps the
+            # lock — and leaves no way to leak one onto the host.
             build_image() {
-              npm run build:sandbox -- -s --no-prune -i "$sandbox_image"
+              npm run build:sandbox -- -s --no-prune -i "$sandbox_image" 7>&- 8>&- 9>&-
             }
 
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
@@ -247,6 +252,7 @@ jobs:
               fi
               if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
                 flock --unlock 7
+                exec 7>&-
               fi
             else
               echo "Reusing sandbox image for ${GITHUB_SHA}"
@@ -256,6 +262,7 @@ jobs:
             export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
               flock --unlock 8
+              exec 8>&-
             fi
           fi
 
@@ -276,7 +283,7 @@ jobs:
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
+            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}' 9>&-
           else
             run_shard() {
               QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
@@ -320,8 +327,8 @@ jobs:
           mkdir -p "${HOME}/.cache/qwen-code-ci"
           exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
           if flock --nonblock 9; then
-            docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
-            docker image prune --force --filter 'until=24h' || echo "::warning::docker image prune failed on ${RUNNER_NAME:-this runner}; dangling images may accumulate"
+            docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' 9>&- || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
+            docker image prune --force --filter 'until=24h' 9>&- || echo "::warning::docker image prune failed on ${RUNNER_NAME:-this runner}; dangling images may accumulate"
           else
             echo "Docker cleanup skipped because the shared daemon is active"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -711,43 +711,43 @@ jobs:
           sandbox_revision="$(git rev-parse HEAD)"
           sandbox_image="$(node -p "require('./packages/cli/package.json').config.sandboxImageUri")-release-${sandbox_revision}"
 
-          acquire_daemon_write_lock() {
-            lock_deadline=$((SECONDS + 1800))
-            until flock --nonblock 9; do
-              if (( SECONDS >= lock_deadline )); then
-                echo "::error::docker daemon write lock not acquired within 30 minutes"
-                exit 1
-              fi
-              sleep 1
-            done
-          }
-
           if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
             mkdir -p "${HOME}/.cache/qwen-code-ci"
-            exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-release-${sandbox_revision}.lock"
-            if ! flock --wait 1800 8; then
-              echo "::error::docker build coordinator lock not acquired within 30 minutes"
-              exit 1
-            fi
+            # Same protocol as e2e.yml: the host daemon lock is held shared
+            # for the whole step and never upgraded, so preparing an image
+            # cannot be starved by the test phase of a run already on the
+            # host (run 33637097713).
             exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
             if ! flock --shared --wait 1800 9; then
               echo "::error::docker daemon read lock not acquired within 30 minutes"
+              exit 1
+            fi
+            exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-release-${sandbox_revision}.lock"
+            if ! flock --wait 1800 8; then
+              echo "::error::docker build coordinator lock not acquired within 30 minutes"
               exit 1
             fi
           fi
 
           if ! docker image inspect "$sandbox_image" > /dev/null 2>&1; then
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
-              flock --unlock 9
-              acquire_daemon_write_lock
+              # Host build mutex, shared with the E2E lane and held only
+              # while an image is prepared.
+              exec 7>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build.lock"
+              if ! flock --wait 1800 7; then
+                echo "::error::docker build lock not acquired within 30 minutes"
+                exit 1
+              fi
             fi
             docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
             npm run build:sandbox -- -s --no-prune -i "$sandbox_image"
+            if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+              flock --unlock 7
+            fi
           fi
           sandbox_image_id="$(docker image inspect --format '{{.Id}}' "$sandbox_image")"
           export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
           if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
-            flock --shared 9
             flock --unlock 8
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -740,21 +740,25 @@ jobs:
               fi
             fi
             docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
-            npm run build:sandbox -- -s --no-prune -i "$sandbox_image"
+            # See e2e.yml: closing the lock descriptors in the child keeps
+            # a descendant that outlives this job from holding the lock.
+            npm run build:sandbox -- -s --no-prune -i "$sandbox_image" 7>&- 8>&- 9>&-
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
               flock --unlock 7
+              exec 7>&-
             fi
           fi
           sandbox_image_id="$(docker image inspect --format '{{.Id}}' "$sandbox_image")"
           export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
           if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
             flock --unlock 8
+            exec 8>&-
           fi
 
           # The package.json docker test scripts each rebuild the sandbox image.
           # Run vitest directly here so this job reuses the image built above.
-          QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli
-          QWEN_SANDBOX=docker npx vitest run --root ./integration-tests interactive
+          QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli 9>&-
+          QWEN_SANDBOX=docker npx vitest run --root ./integration-tests interactive 9>&-
 
   audio_capture_prebuilds:
     name: 'Audio Capture Prebuilds'

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -112,6 +112,21 @@ describe('e2e workflow', () => {
         yml.jobs['e2e-test-linux'].strategy['max-parallel'],
       ).toBeUndefined();
     });
+
+    it('closes the lock descriptors in every child process', () => {
+      // A flock lives on the open file description, so a descendant that
+      // inherits the descriptor and outlives its job keeps holding the lock
+      // on the host. This shell keeps its own copy of the descriptor, so
+      // closing it in children costs nothing.
+      expect(runStep.run).toContain('-i "$sandbox_image" 7>&- 8>&- 9>&-');
+      expect(runStep.run).toContain("--shard='${{ matrix.shard }}' 9>&-");
+      expect(runStep.run).toContain('exec 7>&-');
+      expect(runStep.run).toContain('exec 8>&-');
+      const cleanupStep = steps.find(
+        (step) => step.name === 'Prune dangling docker images',
+      );
+      expect(cleanupStep.run).toContain("--filter 'until=24h' 9>&-");
+    });
   });
 
   describe('sandbox:none shard retry', () => {

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -53,6 +53,10 @@ describe('e2e workflow', () => {
       );
       expect(runStep.run).toContain('flock --shared --wait 1800 9');
       expect(runStep.run).toContain(
+        'exec 7>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build.lock"',
+      );
+      expect(runStep.run).toContain('flock --wait 1800 7');
+      expect(runStep.run).toContain(
         'if [ "$RUNNER_ENVIRONMENT" = \'self-hosted\' ]',
       );
     });
@@ -86,14 +90,24 @@ describe('e2e workflow', () => {
       expect(runStep.env.VERBOSE).toBe('true');
     });
 
-    it('keeps the shared lock continuously through concurrent tests', () => {
-      const imageIdIndex = runStep.run.indexOf('sandbox_image_id=');
-      const downgradeIndex = runStep.run.indexOf('flock --shared 9');
+    it('never waits on a lock another run holds through its tests', () => {
+      // Run 33637097713 lost two Docker shards to the #10605 protocol on one
+      // host: shard 1/3 held the per-commit coordinator lock and polled 30
+      // minutes for an exclusive daemon lock that a shard of run 33638984513
+      // kept shared through its whole test phase, then shard 2/3 timed out
+      // behind the coordinator lock shard 1/3 was still holding. Image
+      // preparation may only ever wait on locks bounded by a build.
+      const sharedIndex = runStep.run.indexOf('flock --shared --wait 1800 9');
+      const buildLockIndex = runStep.run.indexOf('flock --wait 1800 7');
+      const releaseIndex = runStep.run.indexOf('flock --unlock 7');
       const testIndex = runStep.run.indexOf('vitest run');
-      expect(imageIdIndex).toBeGreaterThanOrEqual(0);
-      expect(downgradeIndex).toBeGreaterThan(imageIdIndex);
-      expect(testIndex).toBeGreaterThan(downgradeIndex);
-      expect(runStep.run).toContain('until flock --nonblock 9');
+      expect(sharedIndex).toBeGreaterThanOrEqual(0);
+      expect(buildLockIndex).toBeGreaterThan(sharedIndex);
+      expect(releaseIndex).toBeGreaterThan(buildLockIndex);
+      expect(testIndex).toBeGreaterThan(releaseIndex);
+      expect(runStep.run).not.toContain('acquire_daemon_write_lock');
+      expect(runStep.run).not.toContain('flock --unlock 9');
+      expect(runStep.run).not.toContain('flock --nonblock 9');
       expect(
         yml.jobs['e2e-test-linux'].strategy['max-parallel'],
       ).toBeUndefined();

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -1270,8 +1270,17 @@ describe('release workflow', () => {
       'export QWEN_SANDBOX_IMAGE="$sandbox_image_id"',
     );
     expect(testStep.run).toContain('flock --shared --wait 1800 9');
-    expect(testStep.run).toContain('flock --shared 9');
-    expect(testStep.run).toContain('until flock --nonblock 9');
+    // The daemon lock stays shared for the whole step: upgrading it to
+    // exclusive to build an image starves the build behind the test phase of
+    // any run already on the host (run 33637097713). Builds serialize on a
+    // separate host mutex that no test phase holds.
+    expect(testStep.run).toContain(
+      'exec 7>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build.lock"',
+    );
+    expect(testStep.run).toContain('flock --wait 1800 7');
+    expect(testStep.run).not.toContain('acquire_daemon_write_lock');
+    expect(testStep.run).not.toContain('flock --unlock 9');
+    expect(testStep.run).not.toContain('flock --nonblock 9');
     expect(testStep.run).toContain('integration-tests cli');
     expect(testStep.run).toContain('integration-tests interactive');
   });

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -1281,8 +1281,13 @@ describe('release workflow', () => {
     expect(testStep.run).not.toContain('acquire_daemon_write_lock');
     expect(testStep.run).not.toContain('flock --unlock 9');
     expect(testStep.run).not.toContain('flock --nonblock 9');
-    expect(testStep.run).toContain('integration-tests cli');
-    expect(testStep.run).toContain('integration-tests interactive');
+    // A flock lives on the open file description: a descendant inheriting
+    // the descriptor past the job would keep the lock on the host.
+    expect(testStep.run).toContain('-i "$sandbox_image" 7>&- 8>&- 9>&-');
+    expect(testStep.run).toContain('exec 7>&-');
+    expect(testStep.run).toContain('exec 8>&-');
+    expect(testStep.run).toContain('integration-tests cli 9>&-');
+    expect(testStep.run).toContain('integration-tests interactive 9>&-');
   });
 
   it('digest-pins every sandbox base image', () => {


### PR DESCRIPTION
## What this PR does

This PR changes how the shared-ECS Docker lanes coordinate sandbox image preparation, so that preparing an image never waits on a lock that another run holds for the whole duration of its tests.

The host-wide daemon lock is now taken shared once, before the image check, and is never upgraded to exclusive. Builds serialize on a separate host-wide build mutex that is held only while an image is being prepared and is released before any test starts. The per-commit coordinator lock still deduplicates builds of the same image on a host, and it is now taken after the shared daemon lock so every participant acquires locks in the same order. The pre-build cleanup keeps its label and age filters, so it cannot touch an image a concurrent shard is testing.

`release.yml`'s Docker validation follows the same protocol and shares the same build mutex, so a release build and an E2E build on one host still do not run against the daemon at the same time.

## Why it's needed

Run [33637097713](https://github.com/QwenLM/qwen-code/actions/runs/33637097713) on `867bb94a` lost two Docker shards before a single test executed:

- shard 1/3 on `ecs-qwen-hk4-8` failed with `docker daemon write lock not acquired within 30 minutes`
- shard 2/3 on `ecs-qwen-hk4-4` failed with `docker build coordinator lock not acquired within 30 minutes`

Both runners are logical runners on the same physical host `hk4`, so they share `$HOME` and therefore the lock files. The blocking party was neither of them and was not a same-commit sibling: shard 1/3 of run [33638984513](https://github.com/QwenLM/qwen-code/actions/runs/33638984513) (a different commit) was on `ecs-qwen-hk4-23`, entered `Run E2E tests` at 14:11:15 and was still inside that step at 14:58 — holding the host daemon lock shared for its entire test phase.

That is the flaw in the protocol added by #10605. A shard that must build an image takes the per-commit coordinator lock first, then drops its shared daemon lock and polls for the exclusive one in a `flock --nonblock` loop. An exclusive `flock` can only be granted when no shared holder is left, and on a busy host the test phases of other runs overlap continuously, so the poll never finds a gap. Our shard 1/3 burned its full 30 minutes there, and shard 2/3 — blocked on the coordinator lock shard 1/3 was still holding — timed out behind it. Both failures are lock-protocol failures, not test failures, and neither is attributable to the commit under test.

The 30-minute budgets are not the problem, so raising them is not the fix: the wait is unbounded by construction as long as image preparation needs a lock that a test phase holds. Removing that dependency is. Exclusivity was only ever needed for the age-based prune, and #10605 already removed the two things that made concurrent builds unsafe — per-shard Buildx builders and the mutable shared tag — so a build no longer needs the daemon quiesced, only kept off other builds.

This is the first occurrence: no Docker E2E job failed with a lock-timeout error between #10605 merging on 2026-08-31 and this run. It needed a host with two docker shards of one commit plus a long-running docker shard from another run, which is now routine as main merges land every ~18 minutes.

## Reviewer Test Plan

### How to verify

1. `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/e2e-workflow.test.js scripts/tests/release-workflow.test.js` — 64 passing, 1 pre-existing skip. The contracts now pin the new invariant: the shared daemon lock is acquired before the image check and never unlocked or polled for exclusively inside the step, the build mutex is acquired and released before `vitest run`, and the release lane participates in the same protocol.
2. Read the lock order in both workflows: shared daemon lock (fd 9) → per-commit coordinator (fd 8) → build mutex (fd 7), released 7 → 8. Every participant acquires in that order, and no exclusive lock is held across a test phase, so neither deadlock nor writer starvation is reachable.
3. Inspect the first post-merge E2E run that lands two docker shards of one commit on a host already running docker tests from another run. Expect one build per commit per host, siblings logging image reuse, and no `lock not acquired` error.

### Evidence (Before & After)

Before: run 33637097713 shard 1/3 exits at 14:52:50 with `docker daemon write lock not acquired within 30 minutes`, shard 2/3 exits at 14:45:13 with `docker build coordinator lock not acquired within 30 minutes`, while run 33638984513's shard on the same host is still inside `Run E2E tests` (started 14:11:15) holding the shared daemon lock.

After: workflow contract tests, extracted shell syntax check (`bash -n` over both rendered run blocks), and Prettier pass locally. The live behavior needs the first post-merge run on the shared pool.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local workflow contract tests only; no access to the shared ECS Docker daemon.

## Risk & Scope

- Main risk or tradeoff: image builds on one host now serialize on the build mutex instead of on exclusive daemon access, so N concurrent distinct commits on a host queue N builds. That wait is bounded by build time (minutes) instead of by another run's test phase (tens of minutes), and the 30-minute budget is unchanged. Concurrent builds on one daemon are still prevented; concurrent build-and-test on one daemon is now allowed, which is what the commit-qualified tags and image-ID pinning from #10605 made safe.
- Not validated / out of scope: live shared-ECS behavior cannot be reproduced locally and needs the first post-merge run. The long-running shard that triggered this (46+ minutes in `Run E2E tests`) is a separate question about docker shard duration and is not addressed here.
- Breaking changes / migration notes: none. GitHub-hosted fallback lanes are untouched, the matrix and its parallelism are unchanged, and the `Prune dangling docker images` cleanup step keeps its non-blocking exclusive lock.

## Linked Issues

Fixes #10840

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 修改共享 ECS 上 Docker 通道准备 sandbox 镜像时的协调方式，使镜像准备不再需要等待另一个 run 在整个测试阶段持有的锁。

宿主级 daemon 锁现在在镜像检查之前一次性以共享模式获取，并且永不升级为独占。构建改为在一把独立的宿主级构建互斥锁上串行，该锁只在准备镜像期间持有，并在任何测试开始前释放。按 commit 划分的 coordinator 锁仍然负责在同一宿主上对同一镜像去重构建，现在改到共享 daemon 锁之后获取，因此所有参与者的加锁顺序一致。构建前的清理保留 label 与时间过滤条件，不会删除其他 shard 正在测试的镜像。

`release.yml` 的 Docker 验证使用同一协议并共享同一把构建互斥锁，因此同一宿主上的 release 构建与 E2E 构建仍然不会同时压向 daemon。

## 为什么需要

`867bb94a` 上的 run [33637097713](https://github.com/QwenLM/qwen-code/actions/runs/33637097713) 在执行任何测试之前就丢掉了两个 Docker shard：

- `ecs-qwen-hk4-8` 上的 shard 1/3 失败于 `docker daemon write lock not acquired within 30 minutes`
- `ecs-qwen-hk4-4` 上的 shard 2/3 失败于 `docker build coordinator lock not acquired within 30 minutes`

两个 runner 是同一台物理宿主 `hk4` 上的逻辑 runner，共享 `$HOME`，因此也共享锁文件。真正的阻塞方不是它们，也不是同 commit 的兄弟 shard：另一个 commit 的 run [33638984513](https://github.com/QwenLM/qwen-code/actions/runs/33638984513) 的 shard 1/3 运行在 `ecs-qwen-hk4-23`，14:11:15 进入 `Run E2E tests`，直到 14:58 仍停留在该 step —— 在其整个测试阶段一直共享持有宿主 daemon 锁。

这正是 #10605 引入的协议的缺陷。需要构建镜像的 shard 会先取得按 commit 的 coordinator 锁，然后释放共享 daemon 锁，并在 `flock --nonblock` 循环里轮询独占锁。独占 `flock` 只有在没有任何共享持有者时才可能被授予，而在繁忙宿主上其他 run 的测试阶段是连续重叠的，因此轮询永远等不到空档。我们的 shard 1/3 在这里耗尽了 30 分钟，shard 2/3 则因为 coordinator 锁仍被 shard 1/3 持有而随之超时。两者都是锁协议失败，不是测试失败，也与被测 commit 无关。

30 分钟的上限不是问题所在，所以调大它并不是修复：只要镜像准备依赖一把测试阶段会持有的锁，这个等待在设计上就是无界的。正确做法是去掉这个依赖。独占只对按时间清理镜像是必要的，而 #10605 已经移除了让并发构建不安全的两个因素 —— 每个 shard 各自的 Buildx builder 和可变共享 tag —— 因此构建不再需要让 daemon 静默，只需要与其他构建互斥。

这是首次出现：从 #10605 于 2026-08-31 合入到本次 run，没有任何 Docker E2E job 因锁超时失败。它需要同一宿主上同时存在同一 commit 的两个 docker shard，以及另一个 run 的长时间 docker shard，而在 main 每约 18 分钟合入一次的节奏下，这种情况已经很常见。

## Reviewer Test Plan

### 如何验证

1. `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/e2e-workflow.test.js scripts/tests/release-workflow.test.js` —— 64 passing，1 个既有 skip。契约测试现在锁定新的不变量：共享 daemon 锁在镜像检查之前获取，并且在 step 内不再解锁或轮询独占；构建互斥锁在 `vitest run` 之前获取并释放；release 通道参与同一协议。
2. 阅读两个 workflow 中的加锁顺序：共享 daemon 锁（fd 9）→ 按 commit 的 coordinator（fd 8）→ 构建互斥锁（fd 7），释放顺序为 7 → 8。所有参与者顺序一致，且没有任何独占锁跨越测试阶段，因此既不会死锁也不会出现写者饥饿。
3. 观察第一个满足以下条件的 post-merge E2E run：同一 commit 的两个 docker shard 落在一台已经在跑另一个 run 的 docker 测试的宿主上。预期每个 commit 在每台宿主只构建一次、兄弟 shard 记录镜像复用、且没有 `lock not acquired` 错误。

### Evidence（修复前后）

修复前：run 33637097713 的 shard 1/3 在 14:52:50 以 `docker daemon write lock not acquired within 30 minutes` 退出，shard 2/3 在 14:45:13 以 `docker build coordinator lock not acquired within 30 minutes` 退出，而同一宿主上 run 33638984513 的 shard 仍停留在 `Run E2E tests`（14:11:15 开始），持有共享 daemon 锁。

修复后：workflow 契约测试、对两个 run 代码块提取后的 shell 语法检查（`bash -n`）以及 Prettier 在本地全部通过。线上行为需要合入后的第一个 run 验证。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment（可选）

仅本地 workflow 契约测试；没有共享 ECS Docker daemon 的访问权限。

## 风险与范围

- 主要风险或取舍：同一宿主上的镜像构建现在在构建互斥锁上串行，而不是靠独占 daemon 访问，因此 N 个并发的不同 commit 会排队 N 次构建。该等待由构建耗时（分钟级）而不是另一个 run 的测试阶段（几十分钟）决定，30 分钟上限保持不变。同一 daemon 上的并发构建仍被阻止；现在允许的是同一 daemon 上「构建与测试并发」，而这正是 #10605 的 commit 限定 tag 与 image ID 固定所保证安全的部分。
- 未验证 / 不在范围内：共享 ECS 的线上行为无法在本地复现，需要合入后的第一个 run。触发本次问题的那个长时间 shard（`Run E2E tests` 超过 46 分钟）属于 docker shard 时长的另一个问题，本 PR 不处理。
- 破坏性变更 / 迁移说明：无。GitHub-hosted fallback 通道未改动，矩阵及其并行度不变，`Prune dangling docker images` 清理步骤仍使用非阻塞独占锁。

## 关联 Issue

Fixes #10840

</details>

https://claude.ai/code/session_01MCE9CXnMVrX4fUxHpQoUr8
