### PR TITLE
fix(ci): Prevent sandbox descendants from leaking Docker locks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -214,12 +214,13 @@ jobs:
 
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
               mkdir -p "${HOME}/.cache/qwen-code-ci"
+              daemon_lock="${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon-v2.lock"
               exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-e2e-${GITHUB_SHA}.lock"
               if ! flock --wait 1800 8; then
                 echo "::error::docker build coordinator lock not acquired within 30 minutes"
                 exit 1
               fi
-              exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
+              exec 9>"$daemon_lock"
               if ! flock --shared --wait 1800 9; then
                 echo "::error::docker daemon read lock not acquired within 30 minutes"
                 exit 1
@@ -243,8 +244,10 @@ jobs:
             sandbox_image_id="$(docker image inspect --format '{{.Id}}' "$sandbox_image")"
             export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
             if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
-              flock --shared 9
+              flock --unlock 9
+              exec 9>&-
               flock --unlock 8
+              exec 8>&-
             fi
           fi
 
@@ -265,7 +268,21 @@ jobs:
           # test:integration:sandbox:docker: that script would rebuild the image
           # the step above just built.
           if [[ "${{ matrix.sandbox }}" == "sandbox:docker" ]]; then
-            npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
+            run_docker_shard() {
+              npx cross-env QWEN_E2E_RENDERER=ink QWEN_SANDBOX=docker vitest run --root ./integration-tests --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
+            }
+            if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+              export -f run_docker_shard
+              set +e
+              flock --conflict-exit-code 75 --shared --wait 1800 --close "$daemon_lock" bash -c run_docker_shard
+              test_rc=$?
+              set -e
+              if [ "$test_rc" -eq 75 ]; then
+                echo "::error::docker daemon read lock not acquired within 30 minutes"
+              fi
+              exit "$test_rc"
+            fi
+            run_docker_shard
           else
             run_shard() {
               QWEN_E2E_RENDERER=ink npm run test:integration:sandbox:none -- --exclude '**/interactive/cron-interactive.test.ts' --exclude '**/channel-plugin.test.ts' --shard='${{ matrix.shard }}'
@@ -307,10 +324,14 @@ jobs:
           ${{ always() && matrix.sandbox == 'sandbox:docker' && runner.environment == 'self-hosted' }}
         run: |-
           mkdir -p "${HOME}/.cache/qwen-code-ci"
-          exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
-          if flock --nonblock 9; then
+          daemon_lock="${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon-v2.lock"
+          prune_images() {
             docker image prune --all --force --filter 'label=org.qwen-code.ci.sandbox=true' --filter 'until=24h' || echo "::warning::old CI sandbox image cleanup failed on ${RUNNER_NAME:-this runner}"
             docker image prune --force --filter 'until=24h' || echo "::warning::docker image prune failed on ${RUNNER_NAME:-this runner}; dangling images may accumulate"
+          }
+          export -f prune_images
+          if flock --nonblock --close "$daemon_lock" bash -c prune_images; then
+            :
           else
             echo "Docker cleanup skipped because the shared daemon is active"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -724,12 +724,13 @@ jobs:
 
           if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
             mkdir -p "${HOME}/.cache/qwen-code-ci"
+            daemon_lock="${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon-v2.lock"
             exec 8>"${HOME}/.cache/qwen-code-ci/docker-sandbox-build-release-${sandbox_revision}.lock"
             if ! flock --wait 1800 8; then
               echo "::error::docker build coordinator lock not acquired within 30 minutes"
               exit 1
             fi
-            exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"
+            exec 9>"$daemon_lock"
             if ! flock --shared --wait 1800 9; then
               echo "::error::docker daemon read lock not acquired within 30 minutes"
               exit 1
@@ -747,14 +748,30 @@ jobs:
           sandbox_image_id="$(docker image inspect --format '{{.Id}}' "$sandbox_image")"
           export QWEN_SANDBOX_IMAGE="$sandbox_image_id"
           if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
-            flock --shared 9
+            flock --unlock 9
+            exec 9>&-
             flock --unlock 8
+            exec 8>&-
           fi
 
           # The package.json docker test scripts each rebuild the sandbox image.
           # Run vitest directly here so this job reuses the image built above.
-          QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli
-          QWEN_SANDBOX=docker npx vitest run --root ./integration-tests interactive
+          run_docker_tests() {
+            QWEN_SANDBOX=docker npx vitest run --root ./integration-tests cli
+            QWEN_SANDBOX=docker npx vitest run --root ./integration-tests interactive
+          }
+          if [ "$RUNNER_ENVIRONMENT" = 'self-hosted' ]; then
+            export -f run_docker_tests
+            set +e
+            flock --conflict-exit-code 75 --shared --wait 1800 --close "$daemon_lock" bash -c run_docker_tests
+            test_rc=$?
+            set -e
+            if [ "$test_rc" -eq 75 ]; then
+              echo "::error::docker daemon read lock not acquired within 30 minutes"
+            fi
+            exit "$test_rc"
+          fi
+          run_docker_tests
 
   audio_capture_prebuilds:
     name: 'Audio Capture Prebuilds'

--- a/scripts/tests/e2e-workflow.test.js
+++ b/scripts/tests/e2e-workflow.test.js
@@ -49,7 +49,7 @@ describe('e2e workflow', () => {
       );
       expect(runStep.run).toContain('flock --wait 1800 8');
       expect(runStep.run).toContain(
-        'exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"',
+        'daemon_lock="${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon-v2.lock"',
       );
       expect(runStep.run).toContain('flock --shared --wait 1800 9');
       expect(runStep.run).toContain(
@@ -86,14 +86,25 @@ describe('e2e workflow', () => {
       expect(runStep.env.VERBOSE).toBe('true');
     });
 
-    it('keeps the shared lock continuously through concurrent tests', () => {
+    it('keeps the shared lock out of test descendants', () => {
       const imageIdIndex = runStep.run.indexOf('sandbox_image_id=');
-      const downgradeIndex = runStep.run.indexOf('flock --shared 9');
-      const testIndex = runStep.run.indexOf('vitest run');
+      const releaseIndex = runStep.run.indexOf('exec 9>&-');
+      const testLockIndex = runStep.run.indexOf(
+        'flock --conflict-exit-code 75 --shared --wait 1800 --close "$daemon_lock"',
+      );
+      const testIndex = runStep.run.indexOf('bash -c run_docker_shard');
       expect(imageIdIndex).toBeGreaterThanOrEqual(0);
-      expect(downgradeIndex).toBeGreaterThan(imageIdIndex);
-      expect(testIndex).toBeGreaterThan(downgradeIndex);
+      expect(releaseIndex).toBeGreaterThan(imageIdIndex);
+      expect(testLockIndex).toBeGreaterThan(releaseIndex);
+      expect(testIndex).toBeGreaterThan(testLockIndex);
       expect(runStep.run).toContain('until flock --nonblock 9');
+      expect(runStep.run).toContain('exec 8>&-');
+      const cleanupStep = steps.find(
+        (step) => step.name === 'Prune dangling docker images',
+      );
+      expect(cleanupStep.run).toContain(
+        'flock --nonblock --close "$daemon_lock"',
+      );
       expect(
         yml.jobs['e2e-test-linux'].strategy['max-parallel'],
       ).toBeUndefined();
@@ -201,21 +212,14 @@ describe('e2e workflow', () => {
       expect(runStep.run.match(/QWEN_SANDBOX=docker vitest run/g)).toHaveLength(
         1,
       );
-      // Structure, not just count: wrapping the docker command in a
-      // function and calling it twice keeps the literal count at one. The
-      // docker leg defines its own helper functions, so match by brace
-      // depth rather than any earlier definition: every `${...}` brace in
-      // the script is balanced, leaving the command at depth zero unless
-      // something wraps it.
-      const commandIndex = runStep.run.indexOf(
-        'QWEN_SANDBOX=docker vitest run',
+      const lockedCallIndex = runStep.run.indexOf(
+        'bash -c run_docker_shard',
       );
-      let depth = 0;
-      for (const ch of runStep.run.slice(0, commandIndex)) {
-        if (ch === '{') depth += 1;
-        if (ch === '}') depth -= 1;
-      }
-      expect(depth).toBe(0);
+      const selfHostedExitIndex = runStep.run.indexOf('exit "$test_rc"');
+      const hostedCallIndex = runStep.run.lastIndexOf('\n  run_docker_shard');
+      expect(lockedCallIndex).toBeGreaterThanOrEqual(0);
+      expect(selfHostedExitIndex).toBeGreaterThan(lockedCallIndex);
+      expect(hostedCallIndex).toBeGreaterThan(selfHostedExitIndex);
     });
   });
 

--- a/scripts/tests/release-workflow.test.js
+++ b/scripts/tests/release-workflow.test.js
@@ -1262,7 +1262,7 @@ describe('release workflow', () => {
     );
     expect(testStep.run).toContain('flock --wait 1800 8');
     expect(testStep.run).toContain(
-      'exec 9>"${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon.lock"',
+      'daemon_lock="${HOME}/.cache/qwen-code-ci/docker-sandbox-daemon-v2.lock"',
     );
     expect(testStep.run).toContain('-release-${sandbox_revision}');
     expect(testStep.run).toContain('--no-prune -i "$sandbox_image"');
@@ -1270,7 +1270,11 @@ describe('release workflow', () => {
       'export QWEN_SANDBOX_IMAGE="$sandbox_image_id"',
     );
     expect(testStep.run).toContain('flock --shared --wait 1800 9');
-    expect(testStep.run).toContain('flock --shared 9');
+    expect(testStep.run).toContain('exec 9>&-');
+    expect(testStep.run).toContain('exec 8>&-');
+    expect(testStep.run).toContain(
+      'flock --conflict-exit-code 75 --shared --wait 1800 --close "$daemon_lock"',
+    );
     expect(testStep.run).toContain('until flock --nonblock 9');
     expect(testStep.run).toContain('integration-tests cli');
     expect(testStep.run).toContain('integration-tests interactive');


### PR DESCRIPTION
## What this PR does

This PR prevents self-hosted sandbox test processes from retaining the shared Docker daemon lock after their owning GitHub Actions job has finished.

- Image preparation now closes its coordinator and daemon lock descriptors before starting tests.
- E2E and release tests acquire the shared daemon lock through a dedicated `flock --close` parent. The parent holds the lock for the test lifetime, while Vitest and every daemon it spawns are prevented from inheriting the lock descriptor.
- The daemon lock namespace moves to `v2`, so existing descriptors leaked by completed jobs cannot block the first repaired run.
- Docker test concurrency, immutable image IDs, serialized image preparation, and the existing 30-minute acquisition bounds remain unchanged.

## Why it's needed

The failing main run is [E2E Tests 33637097713](https://github.com/QwenLM/qwen-code/actions/runs/33637097713). On the shared `hk4` ECS host, [Docker shard 2/3](https://github.com/QwenLM/qwen-code/actions/runs/33637097713/job/100278372961) waited for the per-commit build coordinator and failed after 30 minutes. The coordinator owner, [Docker shard 1/3](https://github.com/QwenLM/qwen-code/actions/runs/33637097713/job/100278372499), then failed because it could not acquire the daemon write lock within 30 minutes.

The overlapping release Docker job on the same host completed at 14:39 UTC, but the waiting E2E writer was still blocked when it failed at 14:52 UTC. The lock therefore outlived the job that was meant to own it. The protocol introduced in #10605 opened the shared lock as a shell file descriptor and then launched Vitest without closing that descriptor in child processes. Long-lived daemon descendants could keep the underlying open file description, and therefore the shared `flock`, alive after the workflow shell exited.

Increasing the timeout would only delay this failure. Keeping the lock in the `flock` parent and closing it in the executed test process preserves host-level build/test exclusion without allowing descendants to leak ownership.

## Reviewer Test Plan

### How to verify

1. Inspect a self-hosted Docker E2E run and confirm image preparation remains serialized while all three test shards can overlap after the image is ready.
2. Confirm a release Docker job can finish while a later E2E image writer acquires the `v2` daemon lock instead of timing out on ownership retained by release test descendants.
3. Confirm hosted runners still execute the same Docker tests without `flock`, and Docker test failures still propagate their original exit status.

### Evidence (Before & After)

Before: the linked main run had no failing test assertion. Two shards failed before Vitest could start with `docker build coordinator lock not acquired within 30 minutes` and `docker daemon write lock not acquired within 30 minutes`.

After: the focused E2E and release workflow contracts pass (64 passed, 1 existing skip), and the E2E retry execution contracts pass (6 passed). `git diff --check` is clean. A live shared-ECS run is required to validate host process lifetime behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Workflow parsing and execution-contract tests ran locally on macOS. The shared ECS Docker host is only available through GitHub Actions.

## Risk & Scope

- Main risk or tradeoff: the first `v2` run intentionally does not coordinate with an already-running `v1` job; this one-time transition is necessary to escape descriptors already retained under the old lock name.
- Not validated / out of scope: this does not change Docker build duration or reduce the E2E matrix. Live validation requires the PR and subsequent main runs on the shared ECS pool.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10840

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 防止 self-hosted sandbox 测试进程在所属 GitHub Actions job 结束后继续持有共享 Docker daemon 锁。

- 镜像准备完成后，在启动测试前显式关闭 coordinator 和 daemon 锁描述符。
- E2E 和 release 测试改为由独立的 `flock --close` 父进程持有共享 daemon 锁。父进程在测试期间持续持锁，但 Vitest 及其启动的所有 daemon 都无法继承锁描述符。
- daemon 锁命名空间切换为 `v2`，避免已结束 job 泄漏的旧描述符继续阻塞第一轮修复后的运行。
- Docker 测试并发、不可变 image ID、串行镜像准备以及既有的 30 分钟获取上限保持不变。

## 为什么需要

失败的 main run 是 [E2E Tests 33637097713](https://github.com/QwenLM/qwen-code/actions/runs/33637097713)。在共享的 `hk4` ECS 宿主机上，[Docker shard 2/3](https://github.com/QwenLM/qwen-code/actions/runs/33637097713/job/100278372961) 等待同 commit 的构建协调锁，并在 30 分钟后失败。持有协调锁的 [Docker shard 1/3](https://github.com/QwenLM/qwen-code/actions/runs/33637097713/job/100278372499) 随后也因为 30 分钟内无法获取 daemon 写锁而失败。

同一宿主机上重叠执行的 release Docker job 已于 UTC 14:39 结束，但等待中的 E2E writer 到 UTC 14:52 失败时仍然被阻塞。这说明锁的存活时间超过了原本应持有它的 job。#10605 引入的协议通过 shell 文件描述符打开共享锁，随后在不关闭子进程描述符的情况下启动 Vitest。长期存活的 daemon 子进程因此可能继续持有底层 open file description，使共享 `flock` 在 workflow shell 退出后仍不释放。

增加超时时间只会推迟失败。改为由 `flock` 父进程持锁，并在被执行的测试进程中关闭锁描述符，可以保留宿主机级的构建/测试互斥，同时防止子进程泄漏锁所有权。

## Reviewer Test Plan

### 如何验证

1. 检查一轮 self-hosted Docker E2E，确认镜像准备仍然串行，而镜像就绪后三个测试 shard 可以重叠执行。
2. 确认 release Docker job 结束后，后续 E2E 镜像 writer 能获取 `v2` daemon 锁，不再被 release 测试子进程遗留的锁阻塞至超时。
3. 确认 hosted runner 仍在不使用 `flock` 的情况下执行相同 Docker 测试，且测试失败仍保留原始退出状态。

### 证据（修复前/后）

修复前：关联的 main run 没有任何失败测试断言。两个 shard 在 Vitest 启动前分别以 `docker build coordinator lock not acquired within 30 minutes` 和 `docker daemon write lock not acquired within 30 minutes` 失败。

修复后：E2E 与 release workflow 聚焦契约测试通过（64 passed，保留 1 个既有 skip），E2E retry 执行契约通过（6 passed），`git diff --check` 无错误。宿主机进程生命周期行为仍需真实 shared-ECS run 验证。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

Workflow 解析与执行契约测试在 macOS 本地完成。共享 ECS Docker 宿主机只能通过 GitHub Actions 验证。

## 风险与范围

- 主要风险或权衡：第一轮 `v2` 运行会刻意不与仍在执行的 `v1` job 协调；这是绕过已被遗留描述符占用的旧锁所需的一次性迁移。
- 未验证 / 超出范围：本 PR 不改变 Docker 构建耗时，也不降低 E2E matrix 并发。需要通过 PR 及后续 main 的 shared-ECS run 完成真实验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #10840

</details>
