### PR TITLE
fix(test): give the serve routes daemon a CI-sized ACP handshake budget

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -58,6 +58,15 @@ const CLI_BIN =
   process.env['TEST_CLI_PATH'] ??
   path.resolve(__dirname, '../../packages/cli/dist/index.js');
 const TOKEN = 'integration-test-token';
+// The ACP child's `initialize` handshake gets 10s by default, which is a
+// budget for an interactive desktop, not for a shard sharing a 128-core ECS
+// host with ~30 other jobs. Run 33633418567 lost `honors and reserves a
+// normalized caller-supplied session ID` to three ~10s
+// `AcpSessionBridge initialize timed out` attempts and a 504 on the
+// sandbox:docker leg while the same commit's sandbox:none shards passed —
+// the same signature #10605 diagnosed in run 33351032808. Nothing here
+// asserts the handshake budget, so raise it for the spawned daemon only.
+const ACP_INITIALIZE_TIMEOUT_MS = 60_000;
 const REPO_ROOT = path.resolve(__dirname, '../..');
 
 let daemon: ChildProcess;
@@ -148,6 +157,8 @@ beforeAll(async () => {
       // / IDE-launcher environments.
       '--workspace',
       REPO_ROOT,
+      '--initialize-timeout-ms',
+      String(ACP_INITIALIZE_TIMEOUT_MS),
     ],
     {
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## What this PR does

This PR raises the ACP `initialize` handshake budget for the daemon that `integration-tests/cli/qwen-serve-routes.test.ts` spawns, from the 10-second product default to 60 seconds, by passing `--initialize-timeout-ms` on the harness's `qwen serve` command line. No assertion in the file depends on that budget, and the product default is untouched.

## Why it's needed

Run [33633418567](https://github.com/QwenLM/qwen-code/actions/runs/33633418567) on `76c32fd5` turned main red on one shard: `E2E Test (Linux) - sandbox:docker - shard 3/3`, `cli/qwen-serve-routes.test.ts > qwen serve — POST /session validation + concurrent coalescing > honors and reserves a normalized caller-supplied session ID`, `AssertionError: expected 504 to be 200` at line 685.

The 504 is not a route defect. The underlying error is `DaemonHttpError: POST /session: AcpSessionBridge initialize timed out after 9993ms`, and the test burned 36.5s across three attempts (`retry x2`) — three consecutive ~10s handshake timeouts against `DEFAULT_INIT_TIMEOUT_MS = 10_000` in `packages/acp-bridge/src/bridge.ts`. The same commit's three `sandbox:none` shards all passed.

This is the second occurrence of that exact signature, and both landed on the `sandbox:docker` leg: #10605's investigation attributed run [33351032808](https://github.com/QwenLM/qwen-code/actions/runs/33351032808) to "three 10-second ACP channel initialization timeouts" (it surfaced as HTTP 500 back then; #10404 has since reclassified initialization timeouts to 504). The daemon has to spawn a Node child that loads the CLI bundle and answer `initialize` within 10s, on a shard that shares a 128-core ECS host with roughly 30 other logical runners. Ten seconds is a budget for an interactive desktop; under that contention it is a coin flip, and vitest's two retries make it a triple coin flip rather than a fix.

The alternative — treating a slow subprocess handshake on an oversubscribed shared runner as a product bug — is not supported by the evidence: nothing in the failure points at the route, the session-ID normalization it exercises, or the daemon's behavior once the child answers.

## Reviewer Test Plan

### How to verify

1. Read the diff: the spawned daemon gains `--initialize-timeout-ms 60000`. `packages/cli/src/commands/serve.ts` defines the flag as a number and `run-qwen-serve.ts` only rejects values above the maximum JS timer delay, so 60000 is accepted and validated. The value is not part of `/capabilities`, so the file's exact-equality capabilities baseline is unchanged.
2. `npm run build && npm run bundle`, then `npx vitest run --root ./integration-tests cli/qwen-serve-routes.test.ts` — the suite passes with the daemon booting normally; the raised budget only changes how long a handshake may take before it is abandoned.
3. Watch the `sandbox:docker` shard that owns this file over the next few main runs and expect no `AcpSessionBridge initialize timed out` failure.

### Evidence (Before & After)

Before: `expected 504 to be 200` at `cli/qwen-serve-routes.test.ts:685`, cause `AcpSessionBridge initialize timed out after 9993ms`, 36534ms across three attempts, shard duration 1061.93s, on `ecs-qwen-hk5-30`.

After: not reproducible locally — the failure needs the shared ECS host's contention. The change is confined to the harness's command line and is covered by the run above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Prettier and source inspection only; the E2E leg that exhibits the failure runs post-merge on `main`.

## Risk & Scope

- Main risk or tradeoff: `--initialize-timeout-ms` raises every ACP child request timeout in that daemon, not just the handshake, so a genuinely hung child in this file would now take 60s to surface instead of 10s. No test here asserts a timeout, and the file's slowest case is bounded by vitest's own timeouts.
- Not validated / out of scope: the other integration tests that spawn `qwen serve` (`_daemon-harness.ts` and its callers) keep the 10s default — they have not shown this signature, and widening the change without evidence would be speculative. If the same failure appears there, the harness is the place to fix it once.
- Breaking changes / migration notes: none. The product default stays 10s; only this test's daemon is configured.

## Linked Issues

Fixes #10833

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 把 `integration-tests/cli/qwen-serve-routes.test.ts` 启动的 daemon 的 ACP `initialize` 握手预算，从产品默认的 10 秒提高到 60 秒，方式是在 harness 的 `qwen serve` 命令行上传入 `--initialize-timeout-ms`。该文件中没有任何断言依赖这个预算，产品默认值也未改动。

## 为什么需要

`76c32fd5` 上的 run [33633418567](https://github.com/QwenLM/qwen-code/actions/runs/33633418567) 让 main 变红，失败的是一个 shard：`E2E Test (Linux) - sandbox:docker - shard 3/3`，用例 `cli/qwen-serve-routes.test.ts > qwen serve — POST /session validation + concurrent coalescing > honors and reserves a normalized caller-supplied session ID`，报错 `AssertionError: expected 504 to be 200`（第 685 行）。

504 并不是路由缺陷。底层错误是 `DaemonHttpError: POST /session: AcpSessionBridge initialize timed out after 9993ms`，该用例在三次尝试（`retry x2`）中共耗时 36.5 秒 —— 即针对 `packages/acp-bridge/src/bridge.ts` 中 `DEFAULT_INIT_TIMEOUT_MS = 10_000` 的三次连续约 10 秒握手超时。同一 commit 的三个 `sandbox:none` shard 全部通过。

这是该特征第二次出现，且两次都落在 `sandbox:docker` 通道上：#10605 的排查曾把 run [33351032808](https://github.com/QwenLM/qwen-code/actions/runs/33351032808) 归因为"三次 10 秒的 ACP channel 初始化超时"（当时表现为 HTTP 500，#10404 之后把初始化超时重新分类为 504）。daemon 需要派生一个加载 CLI bundle 的 Node 子进程，并在 10 秒内回应 `initialize`，而这个 shard 与大约 30 个其它逻辑 runner 共享一台 128 核 ECS 宿主。10 秒是给交互式桌面场景的预算；在这种争抢下它就是抛硬币，而 vitest 的两次重试只是把它变成抛三次硬币，并不是修复。

另一种解释 —— 把超载共享 runner 上子进程握手变慢当作产品缺陷 —— 没有证据支持：失败信息里没有任何一处指向该路由、它验证的 session ID 归一化，或子进程回应之后 daemon 的行为。

## Reviewer Test Plan

### 如何验证

1. 阅读 diff：被派生的 daemon 增加了 `--initialize-timeout-ms 60000`。`packages/cli/src/commands/serve.ts` 将该 flag 定义为 number，`run-qwen-serve.ts` 只拒绝超过 JS 定时器最大延迟的值，因此 60000 会被接受并通过校验。该值不属于 `/capabilities`，所以该文件的 capabilities 精确相等断言不受影响。
2. `npm run build && npm run bundle`，然后 `npx vitest run --root ./integration-tests cli/qwen-serve-routes.test.ts` —— daemon 正常启动、用例通过；提高的预算只改变握手在被放弃前允许的时长。
3. 观察后续几次 main run 中承载该文件的 `sandbox:docker` shard，预期不再出现 `AcpSessionBridge initialize timed out` 失败。

### Evidence（修复前后）

修复前：`cli/qwen-serve-routes.test.ts:685` 报 `expected 504 to be 200`，原因为 `AcpSessionBridge initialize timed out after 9993ms`，三次尝试共 36534ms，shard 总时长 1061.93s，运行于 `ecs-qwen-hk5-30`。

修复后：本地无法复现 —— 该失败依赖共享 ECS 宿主的争抢。改动仅限于 harness 的命令行，由上述 run 提供依据。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment（可选）

仅做了 Prettier 与源码检查；出现该失败的 E2E 通道在合入 `main` 后才运行。

## 风险与范围

- 主要风险或取舍：`--initialize-timeout-ms` 会提高该 daemon 中所有 ACP 子进程请求的超时，而不只是握手，因此该文件中若真的出现子进程挂死，暴露时间会从 10 秒变为 60 秒。这里没有任何用例断言超时行为，且该文件最慢的情形受 vitest 自身超时约束。
- 未验证 / 不在范围内：其它派生 `qwen serve` 的集成测试（`_daemon-harness.ts` 及其调用方）保持 10 秒默认值 —— 它们没有出现过该特征，在没有证据的情况下扩大改动属于臆测。如果同样的失败出现在那里，harness 才是一次性修好的地方。
- 破坏性变更 / 迁移说明：无。产品默认值仍为 10 秒，只有这个测试的 daemon 被显式配置。

## 关联 Issue

Fixes #10833

</details>

https://claude.ai/code/session_01MCE9CXnMVrX4fUxHpQoUr8
