### PR TITLE
fix(cli): rate-limit interim monitor notification turns (#10818)

### DIFF
--- a/packages/cli/src/ui/hooks/use-llm-stream.test.tsx
+++ b/packages/cli/src/ui/hooks/use-llm-stream.test.tsx
@@ -8,7 +8,10 @@
 import type { Mock, MockInstance } from 'vitest';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useLlmStream } from './use-llm-stream.js';
+import {
+  INTERIM_MONITOR_MIN_TURN_INTERVAL_MS,
+  useLlmStream,
+} from './use-llm-stream.js';
 import * as atCommandProcessor from './atCommandProcessor.js';
 import type {
   TrackedToolCall,
@@ -12163,6 +12166,107 @@ describe('useLlmStream', () => {
           type: SendMessageType.Notification,
           todoWorkChainId: 'chain-2',
         });
+      });
+
+      // Reproduction of #10818: a monitor whose command prints on every poll
+      // emits one interim notification per line; without a session-level
+      // minimum interval each pulse starts its own model turn, so a ~0.5 Hz
+      // pulse stream keeps the session permanently busy — Esc cancels the
+      // in-flight turn but the next pulse immediately starts another, and
+      // typed input never finds a clean idle edge.
+      it('rate-limits interim monitor pulses to one turn per interval', async () => {
+        vi.useFakeTimers();
+        try {
+          renderTestHook();
+          const callback = mockMonitorRegistry.setNotificationCallback.mock
+            .calls[0][0] as (
+            displayText: string,
+            modelText: string,
+            meta: { monitorId: string; status: string },
+          ) => void;
+          mockSendMessageStream.mockClear();
+
+          await act(async () => {
+            callback(
+              'Monitor "checks" event #1',
+              '<task-notification>pulse-1</task-notification>',
+              { monitorId: 'mon_1', status: 'running' },
+            );
+            // Let the first turn finish so the session is idle again.
+            await vi.advanceTimersByTimeAsync(100);
+          });
+          // The first pulse drains immediately (no prior notification turn).
+          expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+
+          await act(async () => {
+            callback(
+              'Monitor "checks" event #2',
+              '<task-notification>pulse-2</task-notification>',
+              { monitorId: 'mon_1', status: 'running' },
+            );
+            callback(
+              'Monitor "checks" event #3',
+              '<task-notification>pulse-3</task-notification>',
+              { monitorId: 'mon_1', status: 'running' },
+            );
+            await vi.advanceTimersByTimeAsync(100);
+          });
+          // Inside the cooldown window the pulses must queue instead of each
+          // starting its own turn (pre-fix this is 3: one turn per pulse).
+          expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+
+          await act(async () => {
+            await vi.advanceTimersByTimeAsync(
+              INTERIM_MONITOR_MIN_TURN_INTERVAL_MS,
+            );
+          });
+          // When the window elapses the accumulated pulses batch into a
+          // single catch-up turn — no update is lost.
+          expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+          const catchUp = mockSendMessageStream.mock.calls[1];
+          expect(JSON.stringify(catchUp[0])).toContain('pulse-2');
+          expect(JSON.stringify(catchUp[0])).toContain('pulse-3');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('does not delay terminal notifications behind the interim cooldown', async () => {
+        vi.useFakeTimers();
+        try {
+          renderTestHook();
+          const callback = mockMonitorRegistry.setNotificationCallback.mock
+            .calls[0][0] as (
+            displayText: string,
+            modelText: string,
+            meta: { monitorId: string; status: string },
+          ) => void;
+          mockSendMessageStream.mockClear();
+
+          await act(async () => {
+            callback(
+              'Monitor "checks" event #1',
+              '<task-notification>pulse-1</task-notification>',
+              { monitorId: 'mon_1', status: 'running' },
+            );
+            await vi.advanceTimersByTimeAsync(100);
+          });
+          expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+
+          await act(async () => {
+            callback(
+              'Monitor "checks" finished',
+              '<task-notification>done</task-notification>',
+              { monitorId: 'mon_1', status: 'completed' },
+            );
+            await vi.advanceTimersByTimeAsync(100);
+          });
+          // Terminal notifications are one-off signals and stay prompt even
+          // inside the interim-pulse cooldown window.
+          expect(mockSendMessageStream).toHaveBeenCalledTimes(2);
+        } finally {
+          vi.useRealTimers();
+        }
       });
 
       // Regression for #7156: progress setState calls issued from inside a

--- a/packages/cli/src/ui/hooks/use-llm-stream.ts
+++ b/packages/cli/src/ui/hooks/use-llm-stream.ts
@@ -401,6 +401,19 @@ const STREAM_PENDING_COMMIT_RESERVE_ROWS = 5;
 const STREAM_PENDING_COMPOSER_RESERVE_ROWS = 12;
 const LOADING_THOUGHT_DESCRIPTION_MAX_CHARS = 4_096;
 
+/**
+ * Minimum interval between model turns triggered by interim (status
+ * 'running') monitor notifications (#10818). A monitor whose command prints on
+ * every poll emits one <task-notification> per line; without a session-level
+ * minimum interval each pulse starts its own model turn, so a ~0.5 Hz pulse
+ * stream keeps the session permanently busy — Esc cancels the in-flight turn
+ * but the next pulse starts another immediately, and typed input never finds
+ * a clean idle edge. Only interim monitor pulses are gated; terminal
+ * notifications and cron fires stay prompt. Queued pulses still batch-drain
+ * into a single catch-up turn once the window elapses, so no update is lost.
+ */
+export const INTERIM_MONITOR_MIN_TURN_INTERVAL_MS = 10_000;
+
 type BufferedStreamEvent =
   | { kind: 'content'; value: string }
   | { kind: 'image'; value: InlineImageData }
@@ -5941,6 +5954,9 @@ export const useLlmStream = (
     }>
   >([]);
   const [notificationTrigger, setNotificationTrigger] = useState(0);
+  // Last time an interim-monitor-led notification batch started a model turn
+  // (#10818 cooldown).
+  const lastInterimMonitorTurnAtRef = useRef(0);
   const goalQueuePendingCount =
     goalQueueRef?.current?.getPendingSubmissionCount?.() ?? 0;
   const claimSystemGoalTurn = useCallback((): {
@@ -6165,10 +6181,38 @@ export const useLlmStream = (
   // intact and the effect will re-fire when streamingState returns to Idle.
   useEffect(() => {
     if (
-      streamingState === StreamingState.Idle &&
-      !isSubmittingQueryRef.current &&
-      notificationQueueRef.current.length > 0
+      streamingState !== StreamingState.Idle ||
+      isSubmittingQueryRef.current ||
+      notificationQueueRef.current.length === 0
     ) {
+      return undefined;
+    }
+    {
+      // #10818: interim monitor pulses arrive at whatever rate the monitored
+      // command prints; without a session-level minimum interval each pulse
+      // starts its own model turn and the session never returns to idle (Esc
+      // cancels the in-flight turn, the next pulse starts another). Gate only
+      // interim (status 'running') monitor-led batches; terminal notifications
+      // and cron fires stay prompt. Checking queue[0] before the cancelled-
+      // monitor prune inside is conservative in the right direction.
+      const leading = notificationQueueRef.current[0]!;
+      if (
+        leading.sendMessageType === SendMessageType.Notification &&
+        leading.monitor?.status === 'running'
+      ) {
+        const elapsed = Date.now() - lastInterimMonitorTurnAtRef.current;
+        if (elapsed < INTERIM_MONITOR_MIN_TURN_INTERVAL_MS) {
+          // Re-fire this effect when the window elapses so queued pulses
+          // still batch into a single catch-up turn even if the monitor
+          // goes quiet in the meantime.
+          const timer = setTimeout(
+            () => setNotificationTrigger((n) => n + 1),
+            INTERIM_MONITOR_MIN_TURN_INTERVAL_MS - elapsed,
+          );
+          return () => clearTimeout(timer);
+        }
+      }
+
       // Consumer-side guard for #7156: this effect can run on a render pass
       // that React batched together with progress setState calls issued from
       // INSIDE a subagent's AsyncLocalStorage frame, in which case the whole
@@ -6238,6 +6282,9 @@ export const useLlmStream = (
           splitIdx++;
         }
         const batch = queue.splice(0, splitIdx);
+        if (batch[0]?.monitor?.status === 'running') {
+          lastInterimMonitorTurnAtRef.current = Date.now();
+        }
 
         const now = Date.now();
         for (const item of batch) {
@@ -6267,6 +6314,7 @@ export const useLlmStream = (
           debugLogger.warn('Failed to admit background notification', error);
         });
       });
+      return undefined;
     }
   }, [
     streamingState,


### PR DESCRIPTION
## What this PR does

Adds a session-level minimum interval (10s, `INTERIM_MONITOR_MIN_TURN_INTERVAL_MS`) between model turns triggered by **interim** (`status: running`) monitor notifications in the interactive CLI's idle-edge drain (`packages/cli/src/ui/hooks/use-llm-stream.ts`). Queued pulses are not dropped: they accumulate and batch-drain into a single catch-up turn when the window elapses, and a short timer re-fires the drain effect so a monitor that goes quiet mid-window cannot stall its queued updates. Terminal notifications (`completed`/`failed`), cron fires, and loop wakeups are not gated and stay prompt.

## Why it's needed

A monitor whose command prints on every poll emits one `<task-notification>` per line, and the drain started a new model turn per pulse. At the reported ~0.5 Hz pulse rate the session never returns to idle: `Esc` only aborts the in-flight turn (`cancelOngoingRequest` never touches the notification queue) so the next pulse starts another turn within seconds, and typed input never finds a clean idle edge to win the queue race. With the cooldown, clean idle windows exist again — Esc regains control, and queued user input wins the next idle edge via the existing `hasQueuedUserMessages` priority gate. Token burn from pulse turns is capped at one turn per interval.

## Reviewer Test Plan

### How to verify

- Repro (pre-fix): `npx vitest run src/ui/hooks/use-llm-stream.test.tsx -t "rate-limits interim"` in `packages/cli` against `main` fails with `expected sendMessageStream to be called 1 time, got 2` — the second interim pulse starts its own model turn immediately, demonstrating the pulse→turn mechanism behind the DoS.
- Post-fix: same command passes — pulses inside the 10s window queue, then batch into one catch-up turn when the window elapses; both pulse payloads are present in that single turn.
- Regression: `npx vitest run src/ui/hooks/use-llm-stream.test.tsx` — all 257 tests pass (covers: first notification drains immediately, batching, per-chain separation, terminal notifications, cron/loop paths). A dedicated test asserts terminal monitor notifications are not delayed behind the interim cooldown.
- `npx tsc --noEmit` (packages/cli) and prettier/eslint on changed files: clean.

### Evidence (Before & After)

Before: new test fails on unpatched code (`expected "spy" to be called 1 times, but got 2 times`). After: 257/257 pass. TUI behavior change is timing-only (notification turns spaced ≥10s apart during a pulse storm); no visual/UX surface changed, verified at the harness level rather than terminal-capture (headless Linux box, no TTY).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ✅ tested |

### Environment (optional)

N/A — unit tests (vitest) only.

## Risk & Scope

- Main risk or tradeoff: during a pulse storm, interim monitor updates reach the model with up to 10s delay (they are coalesced, not lost). One-off terminal notifications are unaffected.
- Not validated / out of scope: end-to-end TUI capture on a real terminal; Esc UX copy changes; per-monitor coalescing inside the queue (the batch drain already merges queued pulses into one turn).
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #10818

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在交互式 CLI 的空闲边界通知排空逻辑里（`packages/cli/src/ui/hooks/use-llm-stream.ts`），为**进行中**（`status: running`）的 monitor 通知触发的模型轮次增加会话级最小间隔（10 秒，`INTERIM_MONITOR_MIN_TURN_INTERVAL_MS`）。排队中的脉冲不会被丢弃：它们会在窗口结束后合并成一次补充轮次批量送达，另有一个短定时器重新触发排空 effect，保证 monitor 在窗口期内安静下来时队列不会卡死。终态通知（`completed`/`failed`）、cron 触发和 loop 唤醒不受限流，保持即时。

## 为什么需要

每轮 poll 都打印输出的 monitor 会为每行 stdout 发出一条 `<task-notification>`，排空逻辑此前为每个脉冲各开一次模型轮次。按报告中约 0.5 Hz 的脉冲频率，会话永远回不到空闲：`Esc` 只能中止当前轮次（`cancelOngoingRequest` 不触碰通知队列），下一个脉冲几秒内又开新一轮，用户键入的输入永远等不到干净的空闲边界。加了冷却后出现干净的空闲窗口——Esc 重新生效，已排队的用户输入通过现有的 `hasQueuedUserMessages` 优先门控赢得下一个空闲边界。脉冲轮次的 token 消耗也被限制在每窗口一次。

## 审查者验证

- 复现（修复前）：在 `main` 上于 `packages/cli` 跑 `npx vitest run src/ui/hooks/use-llm-stream.test.tsx -t "rate-limits interim"`，失败：`expected sendMessageStream to be called 1 time, got 2`——第二个进行中脉冲立即开启了新的模型轮次，证实 DoS 背后的脉冲→轮次机制。
- 修复后：同一命令通过——窗口期内的脉冲排队，窗口结束后合并为一次补充轮次，两条脉冲内容都在其中。
- 回归：`npx vitest run src/ui/hooks/use-llm-stream.test.tsx` 全部 257 个测试通过（覆盖：首条通知立即送达、批量合并、按 work chain 分组、终态通知、cron/loop 路径）。另有专门测试断言终态 monitor 通知不被冷却延迟。
- `npx tsc --noEmit`（packages/cli）与变更文件的 prettier/eslint：全部干净。

证据：修复前新测试在未打补丁代码上失败（`expected "spy" to be called 1 times, but got 2 times`）；修复后 257/257 通过。TUI 行为变化仅限时序（脉冲风暴期间通知轮次间隔 ≥10 秒），无视觉/交互界面改动，在无 TTY 的 Linux 机器上以 harness 级验证代替终端录屏。

风险与范围：脉冲风暴期间进行中的 monitor 更新最多延迟 10 秒到达模型（被合并而非丢失）；终态一次性通知不受影响。未覆盖：真实终端端到端录屏、Esc 文案调整、队列内按 monitor 合并（批量排空已把排队脉冲合并为一轮）。无破坏性变更。

关联 issue：Fixes #10818

</details>
