### PR TITLE
fix(ci): read the CI patrol's status rollup one PR at a time

### DIFF
--- a/.github/scripts/ci-flaky-rerun.mjs
+++ b/.github/scripts/ci-flaky-rerun.mjs
@@ -12,6 +12,9 @@ const TARGET_WORKFLOW = 'Qwen Code CI';
 const MARKER = 'qwen-ci-flaky-rerun';
 const DEFAULT_STALE_MINUTES = 30;
 const DEFAULT_ACTIVE_DAYS = 7;
+// How many PR detail reads run at once. Five keeps a 66-PR scan near ten
+// seconds without turning the patrol into a burst against the API.
+const PR_DETAIL_CONCURRENCY = 5;
 const DEFAULT_MAX_CANDIDATES = 5;
 const MAX_ACTIONS = 3;
 const ACTIONS = new Set(['rerun', 'comment', 'no_action']);
@@ -609,28 +612,40 @@ export class GhClient {
     // scheduled scans, while the same search without it answers in a second.
     // A PR whose rollup cannot be read is skipped rather than failing the
     // scan — the next run picks it up.
-    const detailed = [];
-    for (const pr of prs) {
-      try {
-        const { statusCheckRollup } = JSON.parse(
-          await this.gh([
-            'pr',
-            'view',
-            String(pr.number),
-            '--repo',
-            this.repo,
-            '--json',
-            'statusCheckRollup',
-          ]),
-        );
-        detailed.push({ ...pr, statusCheckRollup });
-      } catch (error) {
-        process.stderr.write(
-          `prList: skipping PR ${pr.number}: ${error.message}\n`,
-        );
+    // Bounded fan-out: one call per PR is fine, 66 of them in series is not.
+    // The patrol job has a ten-minute budget and this cost grows with the
+    // open-PR count — the same growth that broke the single bulk query.
+    const detailed = new Array(prs.length);
+    let next = 0;
+    const worker = async () => {
+      for (let i = next++; i < prs.length; i = next++) {
+        const pr = prs[i];
+        try {
+          const { statusCheckRollup } = JSON.parse(
+            await this.gh([
+              'pr',
+              'view',
+              String(pr.number),
+              '--repo',
+              this.repo,
+              '--json',
+              'statusCheckRollup',
+            ]),
+          );
+          detailed[i] = { ...pr, statusCheckRollup };
+        } catch (error) {
+          process.stderr.write(
+            `prList: skipping PR ${pr.number}: ${error.message}\n`,
+          );
+        }
       }
-    }
-    return detailed;
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(PR_DETAIL_CONCURRENCY, prs.length) }, () =>
+        worker(),
+      ),
+    );
+    return detailed.filter(Boolean);
   }
 
   async comments(prNumber) {

--- a/.github/scripts/ci-flaky-rerun.mjs
+++ b/.github/scripts/ci-flaky-rerun.mjs
@@ -584,7 +584,7 @@ export class GhClient {
   }
 
   async prList(search) {
-    return JSON.parse(
+    const prs = JSON.parse(
       await this.gh([
         'pr',
         'list',
@@ -597,11 +597,40 @@ export class GhClient {
         '--search',
         search,
         '--json',
-        'number,isDraft,baseRefName,headRefOid,statusCheckRollup',
+        'number,isDraft,baseRefName,headRefOid',
         '--limit',
         '1000',
       ]),
     );
+    // The rollup is fetched one PR at a time. Asking for it inside the list
+    // query makes a single GraphQL call whose cost grows with matched PRs
+    // times their check runs, and this repo outgrew it: with the rollup the
+    // search returns HTTP 504 above ~30 matches and failed 100 consecutive
+    // scheduled scans, while the same search without it answers in a second.
+    // A PR whose rollup cannot be read is skipped rather than failing the
+    // scan — the next run picks it up.
+    const detailed = [];
+    for (const pr of prs) {
+      try {
+        const { statusCheckRollup } = JSON.parse(
+          await this.gh([
+            'pr',
+            'view',
+            String(pr.number),
+            '--repo',
+            this.repo,
+            '--json',
+            'statusCheckRollup',
+          ]),
+        );
+        detailed.push({ ...pr, statusCheckRollup });
+      } catch (error) {
+        process.stderr.write(
+          `prList: skipping PR ${pr.number}: ${error.message}\n`,
+        );
+      }
+    }
+    return detailed;
   }
 
   async comments(prNumber) {

--- a/scripts/tests/ci-flaky-rerun.test.js
+++ b/scripts/tests/ci-flaky-rerun.test.js
@@ -272,6 +272,34 @@ describe('ci flaky rerun patrol', () => {
     ]);
   });
 
+  it('keeps the status rollup out of the PR search query', async () => {
+    // With statusCheckRollup in the list query, the search is one GraphQL
+    // call costing matched PRs times their check runs. It began returning
+    // HTTP 504 above ~30 matches and failed 100 consecutive scheduled scans;
+    // the same search without the rollup answers in a second. Reading the
+    // rollup per PR keeps every call small.
+    const api = new GhClient('QwenLM/qwen-code');
+    const calls = [];
+    api.gh = async (args) => {
+      calls.push(args);
+      if (args[1] === 'list') {
+        return JSON.stringify([{ number: 7 }, { number: 8 }]);
+      }
+      if (args[2] === '8') {
+        throw new Error('HTTP 502');
+      }
+      return JSON.stringify({ statusCheckRollup: [run()] });
+    };
+    await expect(api.prList('status:failure')).resolves.toEqual([
+      { number: 7, statusCheckRollup: [run()] },
+    ]);
+    const listArgs = calls[0];
+    expect(listArgs[listArgs.indexOf('--json') + 1].split(',')).not.toContain(
+      'statusCheckRollup',
+    );
+    expect(calls).toHaveLength(3);
+  });
+
   it('requests the PR number when refreshing current PR state', async () => {
     const api = new GhClient('QwenLM/qwen-code');
     let args = [];

--- a/scripts/tests/ci-flaky-rerun.test.js
+++ b/scripts/tests/ci-flaky-rerun.test.js
@@ -300,6 +300,34 @@ describe('ci flaky rerun patrol', () => {
     expect(calls).toHaveLength(3);
   });
 
+  it('bounds how many PR detail reads run at once', async () => {
+    // The patrol job has a ten-minute budget and this cost grows with the
+    // open-PR count, so the fan-out is capped rather than unbounded.
+    const api = new GhClient('QwenLM/qwen-code');
+    let inFlight = 0;
+    let peak = 0;
+    api.gh = async (args) => {
+      if (args[1] === 'list') {
+        return JSON.stringify(
+          Array.from({ length: 12 }, (_, i) => ({ number: i + 1 })),
+        );
+      }
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+      return JSON.stringify({ statusCheckRollup: [run()] });
+    };
+    const result = await api.prList('status:failure');
+    expect(result).toHaveLength(12);
+    // Order survives the fan-out: the caller pairs rollups with PR numbers.
+    expect(result.map((pr) => pr.number)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ]);
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(5);
+  });
+
   it('requests the PR number when refreshing current PR state', async () => {
     const api = new GhClient('QwenLM/qwen-code');
     let args = [];


### PR DESCRIPTION
## What this PR does

This PR stops the CI Failure Patrol from asking GitHub for every matched PR's status rollup in one query. The PR search now returns only the cheap fields, and `statusCheckRollup` is read per PR afterwards. A PR whose rollup cannot be read is skipped with a note on stderr instead of failing the whole scan — the next run picks it up.

## Why it's needed

`Qwen CI Failure Patrol` has failed **100 consecutive scheduled runs** (every run in the last ~22 hours; the most recent is [33699092403](https://github.com/QwenLM/qwen-code/actions/runs/33699092403)). Every one dies the same way, before doing any work:

```
Command failed: gh pr list --repo QwenLM/qwen-code --base main --state open \
  --search status:failure updated:>=2026-08-27 \
  --json number,isDraft,baseRefOid,headRefOid,statusCheckRollup --limit 1000
HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)
```

`statusCheckRollup` expands every check run of every matched PR, so the list query is a single GraphQL call costing matched PRs × check runs. That is what times out, not the page size. Measured against the live API just now — 66 PRs currently match the search, and each carries 34–86 check runs:

| query | result |
| --- | --- |
| search + rollup, `--limit 1000` / `200` / `100` / `50` | HTTP 504 (~11s each) |
| search + rollup, `--limit 40` | HTTP 504 |
| search + rollup, `--limit 30` / `20` / `10` | OK |
| search, no rollup, `--limit 100` | OK, instant |
| rollup per PR (`gh pr view N --json statusCheckRollup`) | OK, ~0.7s each |

Lowering `--limit` is not a fix: it fails at 40 and would silently drop matched PRs below that. The threshold moves with the repo's open-PR count and each PR's check count, so the query was always going to cross it — it has now.

The patrol is what reruns CI jobs that failed on a flake, so while it is down every flaky red PR stays red until someone reruns it by hand.

## Reviewer Test Plan

### How to verify

1. `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/ci-flaky-rerun.test.js scripts/tests/ci-flaky-rerun-workflow.test.js` — 42 passing, including the new contract that pins `statusCheckRollup` out of the list query, merges the per-PR rollups, and skips a PR whose rollup read throws.
2. Reproduce the failure against the live API — `gh pr list --repo QwenLM/qwen-code --base main --state open --search "status:failure updated:>=$(date -u -d '7 days ago' +%F)" --json number,isDraft,baseRefName,headRefOid,statusCheckRollup --limit 50` returns HTTP 504; drop `statusCheckRollup` and the same search answers immediately.
3. After merge, watch the next scheduled `Qwen CI Failure Patrol` run reach `Act on classified PR failures` instead of dying in `Classify stale PR failures`.

### Evidence (Before & After)

Before: 100/100 scheduled runs failed at `Classify stale PR failures` with HTTP 504 from the GraphQL endpoint; the `Act on classified PR failures` job never ran.

After: the list query drops the rollup and each rollup is a separate small read. At the current 66 matched PRs the scan makes 1 + 66 calls at ~0.7s each, about 45 seconds, well inside the job.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Script contract tests plus live `gh` queries against this repository.

## Risk & Scope

- Main risk or tradeoff: the scan now makes one API call per matched PR instead of one for all of them — 67 calls at today's 66 matches, against a 5000/hour limit, for a job that runs a few times an hour. In exchange no single call's cost scales with the repo.
- Not validated / out of scope: `prsWithMarkers()` shares `prList` and gets the same treatment; it was not the query that failed. Nothing else in the patrol's classification or rerun logic changes.
- Breaking changes / migration notes: none. `prList` returns the same shape, minus PRs whose rollup could not be read.

## Linked Issues

None — found while auditing red workflows on `main`.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 让 CI Failure Patrol 不再在一次查询里向 GitHub 索取所有匹配 PR 的 status rollup。PR 搜索现在只返回廉价字段，`statusCheckRollup` 改为随后逐个 PR 读取。读取失败的 PR 会被跳过并在 stderr 记录一行，而不是让整次扫描失败 —— 下一次运行会重新处理它。

## 为什么需要

`Qwen CI Failure Patrol` 已经**连续 100 次定时运行全部失败**（最近约 22 小时内的每一次；最新一次是 [33699092403](https://github.com/QwenLM/qwen-code/actions/runs/33699092403)）。每一次都在开始干活之前以同样的方式失败：

```
Command failed: gh pr list --repo QwenLM/qwen-code --base main --state open \
  --search status:failure updated:>=2026-08-27 \
  --json number,isDraft,baseRefOid,headRefOid,statusCheckRollup --limit 1000
HTTP 504: 504 Gateway Timeout (https://api.github.com/graphql)
```

`statusCheckRollup` 会展开每个匹配 PR 的每一个 check run，因此这个 list 查询是一次 GraphQL 调用，其代价等于「匹配 PR 数 × 各自的 check run 数」。超时的是它，而不是分页大小。刚刚针对线上 API 的实测 —— 当前有 66 个 PR 匹配该搜索，每个带有 34–86 个 check run：

| 查询 | 结果 |
| --- | --- |
| 搜索 + rollup，`--limit 1000` / `200` / `100` / `50` | HTTP 504（各约 11 秒） |
| 搜索 + rollup，`--limit 40` | HTTP 504 |
| 搜索 + rollup，`--limit 30` / `20` / `10` | 正常 |
| 搜索，不带 rollup，`--limit 100` | 正常，瞬时返回 |
| 逐个 PR 取 rollup（`gh pr view N --json statusCheckRollup`） | 正常，每个约 0.7 秒 |

调小 `--limit` 不是修复：它在 40 就失败，而且会静默丢弃阈值以下的匹配 PR。这个阈值随仓库未关闭 PR 数量和每个 PR 的 check 数量移动，所以这个查询迟早会越过它 —— 现在越过了。

Patrol 正是负责对因 flake 失败的 CI job 重跑的组件，所以它停摆期间，每一个 flake 变红的 PR 都会一直红着，直到有人手工重跑。

## Reviewer Test Plan

### 如何验证

1. `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/ci-flaky-rerun.test.js scripts/tests/ci-flaky-rerun-workflow.test.js` —— 42 个通过，其中包含新增契约：`statusCheckRollup` 不出现在 list 查询里、逐个 PR 的 rollup 会被合并、读取抛错的 PR 会被跳过。
2. 针对线上 API 复现该失败 —— `gh pr list --repo QwenLM/qwen-code --base main --state open --search "status:failure updated:>=$(date -u -d '7 days ago' +%F)" --json number,isDraft,baseRefName,headRefOid,statusCheckRollup --limit 50` 返回 HTTP 504；去掉 `statusCheckRollup` 后同样的搜索立即返回。
3. 合入后观察下一次定时的 `Qwen CI Failure Patrol`，预期它能进入 `Act on classified PR failures`，而不是死在 `Classify stale PR failures`。

### Evidence（修复前后）

修复前：100/100 次定时运行在 `Classify stale PR failures` 处以 GraphQL 端点的 HTTP 504 失败；`Act on classified PR failures` 从未运行。

修复后：list 查询不再带 rollup，每个 rollup 是一次独立的小请求。按当前 66 个匹配 PR 计算，一次扫描发出 1 + 66 次调用，每次约 0.7 秒，合计约 45 秒，远在 job 时限之内。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

### Environment（可选）

脚本契约测试，以及针对本仓库的线上 `gh` 查询。

## 风险与范围

- 主要风险或取舍：扫描现在对每个匹配 PR 发一次 API 调用，而不是所有 PR 合成一次 —— 按今天的 66 个匹配算是 67 次，对应每小时 5000 次的限额，而该 job 每小时只运行数次。换来的是不再有任何单次调用的代价随仓库规模增长。
- 未验证 / 不在范围内：`prsWithMarkers()` 共用 `prList`，因此同样受益；它不是失败的那个查询。Patrol 的分类与重跑逻辑没有任何改动。
- 破坏性变更 / 迁移说明：无。`prList` 返回结构不变，只是不再包含 rollup 读取失败的 PR。

## 关联 Issue

无 —— 在排查 `main` 上变红的 workflow 时发现。

</details>

https://claude.ai/code/session_01MCE9CXnMVrX4fUxHpQoUr8
