### PR TITLE
chore(deps): bump fast-uri to 3.1.7 to clear the high-severity audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15877,9 +15877,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What this PR does

Bumps the resolved version of a transitive production dependency, `fast-uri`, from 3.1.5 to 3.1.7 in the root lockfile. Three lines change — the version, the tarball URL, and the integrity hash. No source code, no dependency range, and no direct dependency is touched: 3.1.7 already satisfies the `^3.0.1` range that `ajv` asks for, so this is purely a re-resolution of the lockfile.

## Why it's needed

The dependency audit in the Security Checks workflow is a hard gate on high-severity findings, on the assumption that the high-severity baseline is clean. That assumption broke on 2026-09-02 when four advisories were published against `fast-uri` 3.0.0 through 3.1.5, one of them rated high:

- GHSA-5jgf-p345-68v8 — host confusion via skipped IDN canonicalization on scheme-relative references
- GHSA-f65p-4m7j-42xc — server-side request forgery via malformed IPv6 normalization
- GHSA-fph4-wmhf-6fwf — server-side request forgery via repeated hostname percent-decoding
- GHSA-jqff-g426-hqxp — host confusion via percent-encoded scheme normalization

`fast-uri` reaches the production tree through `ajv`, which is pulled in by the MCP SDK, by `ajv-formats`, and by the core package. Because the exposure is in the committed lockfile rather than in any one change, the gate went red for the whole repository at once — every open PR and every push to main, regardless of what they touch. On main the check was still green at 14:23 UTC and failing by 19:50 UTC on 2026-09-02, with no dependency change in between.

This PR restores the clean baseline so the gate can do its actual job again: flagging newly introduced high-severity findings instead of a stale one.

## Reviewer Test Plan

### How to verify

Run the exact command the gate runs, from the repository root, and check the real exit code rather than a piped one:

```
npm audit --omit=dev --audit-level=high > /tmp/audit.txt 2>&1; echo "EXIT=$?"
```

Before this PR the exit code is `1` and the report contains `fast-uri  3.0.0 - 3.1.5` with `Severity: high`, alongside `4 vulnerabilities (1 low, 2 moderate, 1 high)`. After this PR the exit code is `0`, `fast-uri` no longer appears, and the report reads `3 vulnerabilities (1 low, 2 moderate)` — the `diff`, `qs`, and `uuid` findings sit below the gate's threshold and are unchanged by this PR.

The lockfile also still installs: `npm ci --ignore-scripts --dry-run` succeeds and reports exactly one relevant change, `change fast-uri 3.1.5 => 3.1.7`.

The authoritative confirmation is the Security Checks workflow on this PR itself going green, and then main going green on the next push.

### Evidence (Before & After)

N/A — dependency lockfile change with no user-visible or TUI surface. The audit exit codes above are the evidence.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

The audit resolves against the committed lockfile, so its result is platform-independent; the Linux Security Checks job is the authoritative gate.

### Environment (optional)

N/A — no runtime exercised. Verification was `npm audit` and `npm ci --dry-run` against the lockfile.

## Risk & Scope

- Main risk or tradeoff: a patch-level bump of a URL parser. `fast-uri` 3.1.6 and 3.1.7 are the upstream fixes for these advisories, so the behavioural delta is the corrected host and scheme normalization itself. Anything that relied on the previous, more permissive parsing of malformed hosts could in principle observe a change; the range stays within `^3.0.1`, so no dependent needs to move.
- Not validated / out of scope: the three remaining sub-threshold findings are deliberately left alone. `qs` (moderate) does have a non-breaking in-range fix, but it sits below the gate's threshold, so bundling it would widen a three-line gate fix; `diff` (low) and `uuid` (moderate) would need `npm audit fix --force` and a breaking major bump. Also out of scope: `packages/mobile-mcp` carries its own self-contained vendored lockfile that still pins `fast-uri@3.1.5` as a production dependency. The audit step skips that lockfile, but the mobile-mcp release workflow does install from it and publishes the result, so the skip rationale no longer matches reality. That needs its own change rather than being folded into a three-line gate fix, and is tracked separately.
- Breaking changes / migration notes: none.

## Linked Issues

Reported in #10850, which tracks the repo-wide audit failure. This PR clears the single high-severity finding that actually trips the gate, so the check goes green again; it deliberately does not use a closing keyword, because #10850 also lists the moderate `qs` and `uuid` findings, which stay open here. The same failure is visible on main runs 33675732009 and 33675704735, and on unrelated open PRs such as #10861.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把根 lockfile 里一个传递性生产依赖 `fast-uri` 的解析版本从 3.1.5 提升到 3.1.7。改动只有三行——版本号、tarball URL 和 integrity 哈希。没有动任何源码、没有动依赖 range、也没有动直接依赖：3.1.7 本身就满足 `ajv` 要求的 `^3.0.1`，所以这只是 lockfile 的重新解析。

## 为什么需要

Security Checks 工作流里的依赖审计是一道针对高危发现的硬门，前提是「高危基线是干净的」。这个前提在 2026-09-02 被打破了：针对 `fast-uri` 3.0.0 到 3.1.5 的四条公告被发布，其中一条评级为 high：

- GHSA-5jgf-p345-68v8 —— 对 scheme-relative 引用跳过 IDN 规范化导致 host 混淆
- GHSA-f65p-4m7j-42xc —— IPv6 规范化处理不当导致 SSRF
- GHSA-fph4-wmhf-6fwf —— 重复的 hostname 百分号解码导致 SSRF
- GHSA-jqff-g426-hqxp —— 百分号编码的 scheme 规范化导致 host 混淆

`fast-uri` 是通过 `ajv` 进入生产依赖树的，而 `ajv` 由 MCP SDK、`ajv-formats` 和 core 包引入。由于暴露点在已提交的 lockfile 里、而不在某个具体改动里，这道门是整个仓库同时变红的——所有开着的 PR 和所有推到 main 的提交都一样，与它们改了什么无关。在 main 上，这个检查在 2026-09-02 14:23 UTC 还是绿的，到 19:50 UTC 就已经失败，而这段时间里没有任何依赖变更。

这个 PR 恢复干净基线，让这道门重新能干它本该干的事：标记新引入的高危发现，而不是一条陈旧的高危发现。

## Reviewer 测试计划

### 如何验证

在仓库根目录跑这道门跑的原始命令，并检查真实退出码而不是管道之后的退出码：

```
npm audit --omit=dev --audit-level=high > /tmp/audit.txt 2>&1; echo "EXIT=$?"
```

在这个 PR 之前，退出码是 `1`，报告里含 `fast-uri  3.0.0 - 3.1.5` 且 `Severity: high`，总计 `4 vulnerabilities (1 low, 2 moderate, 1 high)`。在这个 PR 之后，退出码是 `0`，`fast-uri` 不再出现，报告为 `3 vulnerabilities (1 low, 2 moderate)`——`diff`、`qs`、`uuid` 三条都在这道门的阈值之下，本 PR 不改变它们。

lockfile 也依然可以正常安装：`npm ci --ignore-scripts --dry-run` 成功，并且只报告一处相关变化，即 `change fast-uri 3.1.5 => 3.1.7`。

权威的确认是这个 PR 自己的 Security Checks 工作流转绿，以及随后 main 上第一次 push 转绿。

### 证据（Before & After）

N/A——依赖 lockfile 改动，没有用户可见或 TUI 层面的表现。上面的审计退出码就是证据。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

审计是针对已提交的 lockfile 做解析的，因此结果与平台无关；Linux 上的 Security Checks job 才是权威门。

### 环境（可选）

N/A——没有运行任何运行时。验证手段是针对 lockfile 的 `npm audit` 与 `npm ci --dry-run`。

## 风险与范围

- 主要风险或取舍：这是一个 URL 解析库的 patch 级提升。`fast-uri` 3.1.6 与 3.1.7 正是上游针对这些公告的修复版本，所以行为差异就是被修正后的 host 与 scheme 规范化本身。原则上，任何依赖此前那种对畸形 host 更宽松解析的代码都可能观察到变化；range 保持在 `^3.0.1` 内，所以没有哪个依赖方需要跟着动。
- 未验证 / 不在范围内：剩下的三条低于阈值的发现刻意不处理。`qs`（moderate）确实有一个非破坏性、range 内的修复版本，但它在门的阈值之下，捆进来会让一个三行的门修复变宽；`diff`（low）与 `uuid`（moderate）则需要 `npm audit fix --force` 和一次 breaking 的大版本提升。同样不在范围内：`packages/mobile-mcp` 带着自己那份自包含的 vendored lockfile，其中 `fast-uri@3.1.5` 仍是生产依赖。审计步骤会跳过那份 lockfile，但 mobile-mcp 的发布工作流确实会从它安装并把结果发布出去，所以那条跳过理由已经与现实不符。这需要单独一个改动，而不是塞进一个三行的门修复里，已另行跟踪。
- Breaking changes / 迁移说明：无。

## 关联 Issue

由 #10850 报告，该 issue 跟踪的是这次仓库范围内的审计失败。本 PR 清掉的是唯一一条真正触发这道门的高危发现，因此检查会重新转绿；这里刻意不使用自动关闭关键字，因为 #10850 还列了 moderate 级的 `qs` 与 `uuid`，这两条在本 PR 中仍然是未解决状态。同样的失败在 main 的 run 33675732009 与 33675704735 上可见，也在与依赖无关的开放 PR（例如 #10861）上可见。

</details>
