### PR TITLE
chore(vscode): refresh NOTICES for the fast-uri bump

### DIFF
--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -4356,7 +4356,7 @@ SOFTWARE.
 
 
 ============================================================
-fast-uri@3.1.5
+fast-uri@3.1.7
 (git+https://github.com/fastify/fast-uri.git)
 
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae


### PR DESCRIPTION
## What this PR does

Updates the VS Code companion's `NOTICES.txt` header line for `fast-uri` from `3.1.5` to `3.1.7`, matching the lockfile bump that #10862 landed on main.

## Why it's needed

The companion's notices carry a version on each dependency's header line, and CI regenerates the file and diffs it ("Check VS Code companion notices are up-to-date"). After the lockfile bump landed without this file, that check is red on main and fails every PR merge-ref run until fixed.

## Reviewer Test Plan

### How to verify

The change is one line produced by the same derivation #10842 used, which came out byte-identical to a full regeneration of the file. CI's notices check going green on this PR is the end-to-end confirmation.

### Evidence (Before & After)

N/A — generated metadata file, no user-visible output.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

Verified by the CI notices check on this PR (Linux lane).

### Environment (optional)

N/A (metadata file).

## Risk & Scope

- Main risk or tradeoff: none — one generated header line.
- Not validated / out of scope: nothing beyond the single version string.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #10862 (the lockfile bump landed without the companion notices).

<details>
<summary>中文说明</summary>

本 PR 把 VS Code companion 的 `NOTICES.txt` 中 `fast-uri` 的头部版本行从 `3.1.5` 更新为 `3.1.7`，与 #10862 合入 main 的 lockfile 升级保持一致。

原因：companion 的 notices 在每个依赖的头部行携带版本号，CI 会重新生成该文件并 diff。lockfile 升级合入时未带上此文件，导致 main 上该检查变红，并在修复前拖红所有 PR 的 merge-ref 检查。

验证：单行改动采用与 #10842 相同的推导方式（该推导与完整重新生成的结果逐字节一致），以本 PR 的 CI notices 检查变绿作为端到端确认。无用户可见变化。风险与范围：无——仅一行生成的头部文本；无破坏性变更。关联：#10862 的后续修复。

</details>