### PR TITLE
fix(cli): remove duplicate folder trust mock

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -4290,7 +4290,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       setWorkflowsEnabled: vi.fn(),
       getBareMode: vi.fn().mockReturnValue(false),
       getFolderTrustFeature: vi.fn().mockReturnValue(false),
-      getFolderTrust: vi.fn().mockReturnValue(true),
       isTrustedFolder: vi.fn().mockReturnValue(true),
     };
   }


### PR DESCRIPTION
## What this PR does

Removes the conflicting duplicate folder-trust value from the ACP test configuration. The shared test configuration now keeps the intended default-disabled value, while session-specific tests continue to override it from their workspace settings.

## Why it's needed

The duplicate property introduced by #10470 makes TypeScript fail with `TS1117: An object literal cannot have multiple properties with the same name`. The failure happens during the CLI build, so Qwen Code CI, SDK Java, and every E2E matrix job stop before their tests run. This restores the build without changing production behavior.

Failing run: https://github.com/QwenLM/qwen-code/actions/runs/33713769442

## Reviewer Test Plan

### How to verify

- Run the CLI TypeScript build and confirm it no longer reports `TS1117` for the ACP test configuration.
- Run the ACP agent test suite and confirm session-specific folder-trust cases still use their workspace setting.

### Evidence (Before & After)

Before: a targeted TypeScript diagnostic against `main` reports one `TS1117` duplicate-property error. After: the same diagnostic reports zero.

UI verification: N/A — this only repairs a test mock that blocks compilation.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ targeted TypeScript diagnostic, Prettier, and diff check |
| 🪟 Windows |   ⚠️ CI pending |
|  🐧 Linux  |   ⚠️ CI pending |

### Environment (optional)

macOS, Node.js 22.22.0. The full CLI build was also attempted with a reused local dependency snapshot, but that snapshot was missing unrelated OpenTelemetry packages; the original `TS1117` no longer appeared. Clean-environment validation is left to PR CI.

## Risk & Scope

- Main risk or tradeoff: Minimal; the change removes an unreachable conflicting property from a test-only object.
- Not validated / out of scope: Full local CLI build because the reused dependency snapshot was incomplete; production behavior is unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #10873

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

删除 ACP 测试配置中相互冲突的重复 folder-trust 值。共享测试配置保留预期的默认关闭值，各 session 测试仍会根据对应 workspace 设置覆盖该值。

## 为什么需要

#10470 引入的重复属性导致 TypeScript 报错：`TS1117: An object literal cannot have multiple properties with the same name`。错误发生在 CLI 构建阶段，因此 Qwen Code CI、SDK Java 和全部 E2E matrix job 都在真正执行测试前终止。本 PR 恢复构建，不改变生产行为。

失败 run：https://github.com/QwenLM/qwen-code/actions/runs/33713769442

## Reviewer 测试计划

### 验证方式

- 执行 CLI TypeScript 构建，确认 ACP 测试配置不再出现 `TS1117`。
- 执行 ACP agent 测试，确认 session 级 folder-trust 用例仍使用各自 workspace 的设置。

### 证据（修改前后）

修改前：针对 `main` 的 TypeScript 定向诊断报告一个 `TS1117` 重复属性错误。修改后：相同诊断报告零个。

UI 验证：N/A——本 PR 仅修复阻塞编译的测试 mock。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ TypeScript 定向诊断、Prettier 和 diff check |
| 🪟 Windows | ⚠️ 等待 CI |
|  🐧 Linux  | ⚠️ 等待 CI |

### 环境（可选）

macOS，Node.js 22.22.0。也尝试用复用的本地依赖快照执行完整 CLI build，但该快照缺少与本改动无关的 OpenTelemetry 包；原 `TS1117` 已不再出现。干净环境验证交由 PR CI 完成。

## 风险与范围

- 主要风险或取舍：极低；只删除测试对象中不可达的冲突属性。
- 未验证/范围外：由于复用的依赖快照不完整，未完成本地完整 CLI build；生产行为没有变化。
- 破坏性变更/迁移说明：无。

## 关联 Issue

Fixes #10873

</details>
