### PR TITLE
test(review): stamp the ledger entries when the test runs, not when it loads

### DIFF
--- a/packages/cli/src/commands/review/lib/run-ledger.test.ts
+++ b/packages/cli/src/commands/review/lib/run-ledger.test.ts
@@ -136,9 +136,15 @@ describe('ledgerResumeCount — entries past the original, no double subtraction
   // entry, so subtracting the original again counts one resume short: the
   // exact backstop shape (a deleted marker, the original session resuming)
   // passed a cap it had already exhausted.
-  const now = Date.now();
-
+  // Stamped at call time, not when this block is COLLECTED. Entries are
+  // fenced against the plan file's mtime with RUN_EPOCH_SLACK_MS (2s) of
+  // slack, and `beforeEach` writes that file — so a stamp taken at collection
+  // is stale by however long collection took, and the fence drops the entries
+  // as a previous run's. Release run 33713579913 collected for 2260s on a
+  // contended host; this block then read 1, then 0, then 0 across its three
+  // attempts, against an expected 2.
   function threeSessions(): void {
+    const now = Date.now();
     appendRunSession(plan, envOf('S0'), now);
     appendRunSession(plan, envOf('S1'), now + 1000);
     appendRunSession(plan, envOf('S2'), now + 2000);
@@ -164,7 +170,7 @@ describe('ledgerResumeCount — entries past the original, no double subtraction
   });
 
   it('is zero on a fresh ledger, whatever excludes', () => {
-    appendRunSession(plan, envOf('S0'), now);
+    appendRunSession(plan, envOf('S0'), Date.now());
     expect(ledgerResumeCount(plan)).toBe(0);
     expect(ledgerResumeCount(plan, { excludeSessionId: 'S0' })).toBe(0);
     expect(ledgerResumeCount(plan, { excludeSessionId: 'S9' })).toBe(0);


### PR DESCRIPTION
## What this PR does

This PR moves one `Date.now()` in `run-ledger.test.ts` out of the `describe` body and into the helper that uses it, so the ledger entries are stamped when the test runs rather than when the file is collected.

## Why it's needed

`ledgerResumeCount` reads entries through a fence:

```
epoch  = statSync(planPath).mtimeMs - RUN_EPOCH_SLACK_MS   // 2000 ms
kept   = entries.filter(e => e.atMs >= epoch && e.atMs <= ceiling)
```

The block stamped its three entries from a `Date.now()` evaluated in the `describe` body — at **collection** — while `beforeEach` writes the plan file at **execution**. The entries are therefore older than the file they are fenced against by however long collection took, and once that exceeds the 2-second slack the fence drops them as a previous run's.

Collection is normally a few hundred milliseconds, so the gap stayed inside the slack and the bug stayed latent. Release run [33713579913](https://github.com/QwenLM/qwen-code/actions/runs/33713579913) collected for 2260 seconds on a contended host, and the block read 1, then 0, then 0 across its three `--retry=2` attempts against an expected 2 — three different wrong answers, because the gap kept growing between attempts.

Reproduced against the real module, bundled standalone so it runs without the workspace build:

| gap between stamp and execution | `ledgerResumeCount` | expected |
| --- | --- | --- |
| 0 ms | 2 | 2 ✅ |
| 1.5 s | 2 | 2 ✅ |
| **3 s** | **1** | 2 ❌ |
| 60 s | 0 | 2 ❌ |
| 2260 s (this release run) | 0 | 2 ❌ |

The boundary sits exactly at `RUN_EPOCH_SLACK_MS`, and the 2 → 1 → 0 progression is the one CI reported.

The fence itself is correct — an entry older than the plan file it claims to have seen *is* from a previous run. The test was asserting against a stamp it took too early.

## Reviewer Test Plan

### How to verify

1. `cd packages/cli && npx vitest run src/commands/review/lib/run-ledger.test.ts` — the `ledgerResumeCount — entries past the original` block passes, as it did before on a fast machine.
2. Confirm the failure mode is gone by construction: the stamp and the plan file's mtime are now both taken inside the same `it()`, so their gap is milliseconds regardless of how long collection took.
3. The other two `const now = Date.now()` in this file (lines 108 and 818) are already inside `it()` bodies and are left alone — only the `describe`-level one was evaluated at collection.

### Evidence (Before & After)

Before: `expected 1 to be 2`, then `expected +0 to be 2`, then `expected +0 to be 1` at `run-ledger.test.ts:149`, in `Workspace Tests (3/3)` of release run 33713579913, alongside 10,611 passing tests.

After: the stamp is taken at call time; the table above shows the count holds at 2 for any gap when the stamp is current.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

The suite itself was not run here — this worktree has no built workspace `dist/`, and building it is what this machine cannot do. The mechanism was verified instead by bundling `run-ledger.ts` standalone with esbuild (its only cross-package import stubbed) and driving `appendRunSession` / `ledgerResumeCount` directly at the gaps in the table. The file parses under esbuild and Prettier.

## Risk & Scope

- Main risk or tradeoff: none identified. The change is one statement's position; the entries' relative offsets (`now`, `now + 1000`, `now + 2000`) and every assertion are unchanged.
- Not validated / out of scope: this fixes the test, not the two infrastructure failures in the same release run — a `[vitest-worker]: Timeout calling "onTaskUpdate"` unhandled error, which `--retry` does not cover, and shard 2/3 exhausting the job's 45-minute cap. Both are being handled separately.
- Breaking changes / migration notes: none.

## Linked Issues

Split out of #10870, which covers the wall-clock budget assertions. This one is a defect rather than a tradeoff, so it stands alone.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 `run-ledger.test.ts` 中的一处 `Date.now()` 从 `describe` 体移入使用它的辅助函数，使 ledger 条目在**测试执行时**打时间戳，而不是在文件被收集时。

## 为什么需要

`ledgerResumeCount` 通过一道围栏读取条目：

```
epoch  = statSync(planPath).mtimeMs - RUN_EPOCH_SLACK_MS   // 2000 毫秒
kept   = entries.filter(e => e.atMs >= epoch && e.atMs <= ceiling)
```

该代码块用一个在 `describe` 体中求值的 `Date.now()` 给三个条目打戳 —— 也就是在**收集阶段** —— 而 `beforeEach` 是在**执行阶段**写 plan 文件。因此条目比它们所对照的那个文件旧了「收集耗时」那么多，一旦超过 2 秒的容差，围栏就会把它们当作上一次 run 的数据丢弃。

收集通常只有几百毫秒，差距落在容差内，所以这个缺陷一直潜伏。release run [33713579913](https://github.com/QwenLM/qwen-code/actions/runs/33713579913) 在一台被争抢的宿主上收集了 2260 秒，该代码块在 `--retry=2` 的三次尝试中分别读到 1、0、0，而期望值是 2 —— 三个不同的错误答案，因为尝试之间差距还在扩大。

针对真实模块复现（单独打包，无需 workspace 构建）：

| 打戳与执行的间隔 | `ledgerResumeCount` | 期望 |
| --- | --- | --- |
| 0 毫秒 | 2 | 2 ✅ |
| 1.5 秒 | 2 | 2 ✅ |
| **3 秒** | **1** | 2 ❌ |
| 60 秒 | 0 | 2 ❌ |
| 2260 秒（本次 release） | 0 | 2 ❌ |

拐点正好落在 `RUN_EPOCH_SLACK_MS` 上，而 2 → 1 → 0 的递减正是 CI 报告的那一组。

围栏本身是正确的 —— 一个比它声称见过的 plan 文件还旧的条目，确实来自上一次 run。是测试拿了一个取得过早的时间戳去断言。

## Reviewer Test Plan

### 如何验证

1. `cd packages/cli && npx vitest run src/commands/review/lib/run-ledger.test.ts` —— `ledgerResumeCount — entries past the original` 代码块通过，与它此前在快机器上的表现一致。
2. 从构造上确认失败模式已消失：时间戳与 plan 文件的 mtime 现在都在同一个 `it()` 内取得，无论收集耗时多久，两者差距都是毫秒级。
3. 该文件另外两处 `const now = Date.now()`（第 108、818 行）本就在 `it()` 体内，未做改动 —— 只有 `describe` 级那一处是在收集阶段求值的。

### Evidence（修复前后）

修复前：release run 33713579913 的 `Workspace Tests (3/3)` 中，`run-ledger.test.ts:149` 报 `expected 1 to be 2`、`expected +0 to be 2`、`expected +0 to be 1`，同时另有 10611 个测试通过。

修复后：时间戳在调用时取得；上表显示只要戳是当前的，计数恒为 2。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment（可选）

本地没有跑该测试套件 —— 这个 worktree 没有构建产物 `dist/`，而构建正是这台机器做不到的事。改为用 esbuild 将 `run-ledger.ts` 单独打包（其唯一的跨包导入用 stub 替代），直接驱动 `appendRunSession` / `ledgerResumeCount` 在上表各个间隔下验证机制。该文件通过 esbuild 解析与 Prettier 检查。

## 风险与范围

- 主要风险或取舍：未发现。改动只是一条语句的位置；条目之间的相对偏移（`now`、`now + 1000`、`now + 2000`）与所有断言均未改变。
- 未验证 / 不在范围内：本 PR 修的是测试，不涉及同一次 release 中的两个基础设施故障 —— 一个 `[vitest-worker]: Timeout calling "onTaskUpdate"` 的 unhandled error（`--retry` 覆盖不到），以及 shard 2/3 耗尽 job 的 45 分钟上限。两者另行处理。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

从 #10870 拆分而出，那个 PR 处理的是挂钟预算断言。本 PR 是一个缺陷而非取舍，因此单独成 PR。

</details>

https://claude.ai/code/session_01MCE9CXnMVrX4fUxHpQoUr8
