### PR TITLE
chore(codeowners): add release-lane owners to the npm release workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,8 +6,14 @@
 /.github/CODEOWNERS    @pomelo-nwu @wenshao
 
 # --- Primary npm release workflows require core maintainer approval ---
-/.github/workflows/release.yml          @pomelo-nwu @wenshao
-/.github/workflows/finalize-release.yml @pomelo-nwu @wenshao
+# @yiliang114 and @qqqys are already owners of /packages/core/ and carry the
+# release lane day to day. Adding them here keeps the gate on these files
+# while removing the single-pair bottleneck: every push to a release-lane PR
+# dismisses the prior approval, so a two-owner list turned routine fixes into
+# a wait. The CODEOWNERS file itself and the security gate are deliberately
+# NOT widened.
+/.github/workflows/release.yml          @pomelo-nwu @wenshao @yiliang114 @qqqys
+/.github/workflows/finalize-release.yml @pomelo-nwu @wenshao @yiliang114 @qqqys
 
 # --- Security gate workflows require core maintainer approval ---
 /.github/workflows/security-checks.yml  @pomelo-nwu @wenshao


### PR DESCRIPTION
## What this PR does

Adds `@yiliang114` and `@qqqys` as owners of the two npm release workflows, `release.yml` and `finalize-release.yml`, taking each from a two-owner list to a four-owner list. The CODEOWNERS file itself and the security gate `security-checks.yml` are deliberately left on the original two-owner list.

This is a request to widen the list, not a way around it: `/.github/CODEOWNERS` is owned by `@pomelo-nwu` and `@wenshao`, so this PR needs one of them to approve. That is intentional and unchanged.

## Why it's needed

The gate is not the problem — the arithmetic behind it is. Branch protection dismisses stale approvals on every push, so a release-lane PR that needs follow-up commits re-enters the queue for one of two people each time, and the release stays red in between.

Today's release lane is the worked example. #10805 carries the fix for the current blocker — a Vitest worker-to-main RPC timeout that exits an all-green run non-zero — and it touches `release.yml`, so it requires a core-maintainer approval. `@wenshao` reviewed it at 19:52 on 09-02 against `c183dd45`; that approval was dismissed by subsequent commits, and the PR has since taken several more, including the two that actually unblock the release: `3f7a995b` (raise the workspace-test timeout to 75 minutes) and `7ea2bc1b` (pass a run whose only unhandled error is the transport timing out). Each push reopened the wait. Release run 33713579913 stayed red throughout.

Both people added here already own `/packages/core/`, so this extends an existing trust boundary rather than opening a new one, and both run the release lane day to day.

## Reviewer Test Plan

### How to verify

1. Confirm the diff is ownership-only: `git diff main -- .github/CODEOWNERS` touches no path other than the two release workflow lines, plus a comment block recording the rationale.
2. Confirm the file still parses and every named owner is valid — GitHub rejects an owner that does not exist or lacks write access: `gh api "repos/QwenLM/qwen-code/codeowners/errors?ref=chore/codeowners-release-workflows"` returns `{"errors":[]}`, matching `main`.
3. Confirm the gate is intact by inspection: both release workflow paths still list `@pomelo-nwu` and `@wenshao`; `/.github/CODEOWNERS` and `/.github/workflows/security-checks.yml` are byte-identical to `main`.
4. Confirm this PR is itself gated by the rule it proposes to change: GitHub requested review from `wenshao` and `pomelo-nwu` on it automatically, because `/.github/CODEOWNERS` remains theirs.

### Evidence (Before & After)

Before:

```
/.github/workflows/release.yml          @pomelo-nwu @wenshao
/.github/workflows/finalize-release.yml @pomelo-nwu @wenshao
```

After:

```
/.github/workflows/release.yml          @pomelo-nwu @wenshao @yiliang114 @qqqys
/.github/workflows/finalize-release.yml @pomelo-nwu @wenshao @yiliang114 @qqqys
```

Unchanged, on both `main` and this branch:

```
/.github/CODEOWNERS                     @pomelo-nwu @wenshao
/.github/workflows/security-checks.yml  @pomelo-nwu @wenshao
```

CODEOWNERS validation, this branch and `main` alike:

```
$ gh api "repos/QwenLM/qwen-code/codeowners/errors?ref=chore/codeowners-release-workflows"
{"errors":[]}
$ gh api "repos/QwenLM/qwen-code/codeowners/errors?ref=main"
{"errors":[]}
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

A CODEOWNERS change is evaluated by GitHub, not by any runner, so there is no per-OS behaviour to test. The validation above is server-side.

### Environment (optional)

N/A — no local runtime involved.

## Risk & Scope

- Main risk or tradeoff: this widens who can approve the two files that publish to npm. The gate itself is not removed — these paths still require a listed owner, there are now four rather than two — and the two places where a two-person bar does distinct work are untouched: `security-checks.yml` guards the security posture, and `/.github/CODEOWNERS` guards this list.
- Not validated / out of scope: the change only takes effect once merged, so the new owners cannot be exercised on this PR. Branch protection settings are not touched — in particular, dismiss-stale-reviews stays on, so approvals will continue to be dismissed on push; this PR reduces how long that costs, it does not remove the behaviour. Widening `security-checks.yml` or the CODEOWNERS file itself is explicitly out of scope.
- Breaking changes / migration notes: none. No workflow, script, or product code changes.

## Linked Issues

Context for the motivation, not closed by this PR: #10805.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `@yiliang114` 和 `@qqqys` 加为两个 npm 发版工作流 `release.yml` 和 `finalize-release.yml` 的 owner，使这两条从两人名单变为四人名单。CODEOWNERS 文件本身以及安全门禁 `security-checks.yml` 有意保持原来的两人名单不变。

这是一次「请求扩权」，而不是「绕开权限」：`/.github/CODEOWNERS` 归 `@pomelo-nwu` 和 `@wenshao` 所有，因此本 PR 需要他们其中一位批准。这是有意为之，未做改动。

## 为什么需要

门禁本身不是问题，问题是它背后的算术。分支保护会在每次 push 后作废既有批准，因此一个需要跟进提交的发版相关 PR，每次都要重新排队等待那两人之一，而在此期间发版一直是红的。

今天的发版链路就是现成的例子。#10805 承载着当前阻塞的修复——一个 Vitest worker 到主进程的 RPC 超时，会让全部通过的 run 以非零码退出——而它改动了 `release.yml`，因此需要核心维护者批准。`@wenshao` 于 09-02 19:52 针对 `c183dd45` 做过评审；该批准被后续提交作废，此后该 PR 又推入了若干提交，其中两个正是真正解封发版的：`3f7a995b`（将 workspace 测试超时提高到 75 分钟）与 `7ea2bc1b`（当唯一的未处理错误是 transport 超时时判为通过）。每一次推送都重新开启了等待。发版运行 33713579913 全程保持红色。

此处新增的两人已经是 `/packages/core/` 的 owner，因此这是延伸既有的信任边界，而不是开辟新的口子，且两人日常都在负责发版链路。

## 评审者测试计划

### 如何验证

1. 确认改动仅涉及所有权：`git diff main -- .github/CODEOWNERS` 除两行发版工作流所有权、以及一段记录理由的注释外，未触及任何其他路径。
2. 确认文件仍可解析且每个具名 owner 均有效——GitHub 会对不存在或无写权限的 owner 报错：`gh api "repos/QwenLM/qwen-code/codeowners/errors?ref=chore/codeowners-release-workflows"` 返回 `{"errors":[]}`，与 `main` 一致。
3. 通过检视确认门禁完好：两条发版工作流路径仍然列有 `@pomelo-nwu` 与 `@wenshao`；`/.github/CODEOWNERS` 与 `/.github/workflows/security-checks.yml` 与 `main` 逐字节相同。
4. 确认本 PR 自身受它所提议修改的规则约束：GitHub 已自动向 `wenshao` 与 `pomelo-nwu` 请求评审，因为 `/.github/CODEOWNERS` 仍归他们所有。

### 证据（前后对比）

变更前：

```
/.github/workflows/release.yml          @pomelo-nwu @wenshao
/.github/workflows/finalize-release.yml @pomelo-nwu @wenshao
```

变更后：

```
/.github/workflows/release.yml          @pomelo-nwu @wenshao @yiliang114 @qqqys
/.github/workflows/finalize-release.yml @pomelo-nwu @wenshao @yiliang114 @qqqys
```

在 `main` 与本分支上均保持不变：

```
/.github/CODEOWNERS                     @pomelo-nwu @wenshao
/.github/workflows/security-checks.yml  @pomelo-nwu @wenshao
```

CODEOWNERS 校验，本分支与 `main` 同样结果：

```
$ gh api "repos/QwenLM/qwen-code/codeowners/errors?ref=chore/codeowners-release-workflows"
{"errors":[]}
$ gh api "repos/QwenLM/qwen-code/codeowners/errors?ref=main"
{"errors":[]}
```

### 测试环境

|    操作系统    |  状态  |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

CODEOWNERS 的改动由 GitHub 评估，而非由任何 runner 执行，因此不存在按操作系统区分的行为需要测试。上述校验是服务端进行的。

### 运行环境（可选）

N/A —— 不涉及任何本地运行时。

## 风险与范围

- 主要风险或权衡：这扩大了可以批准这两个发往 npm 的文件的人员范围。门禁本身并未移除——这些路径仍然需要名单内 owner 的批准，只是从两人变为四人——且两处「两人门槛各自承担独立作用」的地方未被触及：`security-checks.yml` 守护安全姿态，`/.github/CODEOWNERS` 守护这份名单本身。
- 未验证 / 超出范围：该改动仅在合并后生效，因此新增 owner 无法在本 PR 上被实际行使。分支保护设置未被触及——特别是 dismiss-stale-reviews 仍然开启，批准仍会在 push 后被作废；本 PR 减少的是这件事的代价时长，而非消除该行为。扩大 `security-checks.yml` 或 CODEOWNERS 文件本身明确不在范围内。
- 破坏性变更 / 迁移说明：无。未改动任何工作流、脚本或产品代码。

## 关联 Issue

作为动机的背景引用，本 PR 不会关闭它：#10805。

</details>

https://claude.ai/code/session_012797rgiteWJxLT9TLkKq8G
