### PR TITLE
feat(dingtalk): support outbound file delivery

### DIFF
--- a/docs/users/features/channels/dingtalk.md
+++ b/docs/users/features/channels/dingtalk.md
@@ -172,6 +172,8 @@ You can send photos and documents to the bot, not just text.
 
 **Files:** Send a PDF, code file, or any document. The bot downloads it from DingTalk's servers and saves it locally so the agent can read it with its file tools. Audio and video files are also supported. This works with any model.
 
+**Generated files:** Ask the agent explicitly to send a completed local file and it can return the file as a native DingTalk attachment. Files must be non-empty, no larger than 20 MB, and located inside the configured workspace or the system temporary directory. One response can send at most five files. Outbound file attachments are unavailable when `blockStreaming` is set to `"on"`; upload or delivery failures are reported in the final text instead.
+
 ## Forwarded Chat Records
 
 You can merge-forward a run of messages from another chat to the bot (DingTalk's "combined forward"), either as a message of its own or as the message you are replying to. The bot expands the record into text for the agent: the record's title and summary become a header line, and each forwarded message is listed under `[Chat record messages]` as `Sender: message`. A forwarded message whose body is not text is shown as a placeholder — `[image]`, `[file: <name>]`, `[audio]`, `[video]`.

--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -47,6 +47,13 @@ function createTempPng(): { dir: string; path: string } {
   return { dir, path };
 }
 
+function createTempFile(name = 'report.txt'): { dir: string; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'dingtalk-outbound-file-'));
+  const path = join(dir, name);
+  writeFileSync(path, 'report');
+  return { dir, path };
+}
+
 vi.mock('dingtalk-stream-sdk-nodejs', () => ({
   DWClient: class {
     debug = true;
@@ -315,7 +322,7 @@ it('rejects a non-boolean useConnectionManager value', () => {
   );
 });
 
-it('adds outbound image instructions without replacing custom instructions', () => {
+it('adds outbound media instructions without replacing custom instructions', () => {
   const channel = createChannel({ instructions: 'Keep the answer concise.' });
   const instructions = (
     channel as unknown as { config: { instructions: string } }
@@ -323,6 +330,16 @@ it('adds outbound image instructions without replacing custom instructions', () 
 
   expect(instructions).toContain('Keep the answer concise.');
   expect(instructions).toContain('[IMAGE: /absolute/path/to/file.png]');
+  expect(instructions).toContain('[FILE: /absolute/path/to/file]');
+});
+
+it('does not advertise file delivery in block streaming', () => {
+  const channel = createChannel({ blockStreaming: 'on' });
+  const instructions = (
+    channel as unknown as { config: { instructions: string } }
+  ).config.instructions;
+
+  expect(instructions).not.toContain('[FILE:');
 });
 
 it('validates interactive card config in the adapter', () => {
@@ -2020,6 +2037,75 @@ describe('DingtalkChannel status cards', () => {
     expect(body.markdown.text).toContain('final answer');
     expect(body.markdown.text).toContain('[File delivery unavailable]');
     expect(body.markdown.text).not.toContain('/workspace/a.txt');
+  });
+
+  it('delivers a projected file before finalizing the status card', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid-1');
+      const order: string[] = [];
+      const closeOutput = vi.fn(async () => {
+        order.push('finalize');
+        return true;
+      });
+      const appendOutput = vi.fn();
+      (
+        channel as unknown as {
+          interactionPresenter: {
+            appendOutput: typeof appendOutput;
+            closeOutput: typeof closeOutput;
+          };
+        }
+      ).interactionPresenter = { appendOutput, closeOutput };
+      const context = {
+        channelName: 'dingtalk',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        segmentId: 'segment-1',
+        owner: { kind: 'channel_user', id: 'owner-1' },
+        target: {
+          channelName: 'dingtalk',
+          chatId: 'cid-1',
+          senderId: 'owner-1',
+          isGroup: true,
+        },
+      } as ChannelOutputSegmentContext;
+      vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+        const url = String(input);
+        if (url.includes('/gettoken?')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                errcode: 0,
+                access_token: 'proactive-token',
+                expires_in: 7200,
+              }),
+            ),
+          );
+        }
+        if (url.includes('/media/upload')) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ errcode: 0, media_id: '@file-media-id' }),
+            ),
+          );
+        }
+        const body = JSON.parse(String(init?.body)) as { msgtype: string };
+        if (body.msgtype === 'file') order.push('file');
+        return Promise.resolve(new Response('{}'));
+      });
+      const response = `before\n[FILE: ${file.path}]\nafter`;
+
+      getChunkHook(channel)('cid-1', response, 'session-1', context);
+      await getCompleteHook(channel)('cid-1', response, 'session-1', context);
+
+      expect(appendOutput).toHaveBeenCalledWith(context, 'before\n\nafter');
+      expect(closeOutput.mock.calls[0]?.[1]).toBe('before\n\nafter');
+      expect(order).toEqual(['file', 'finalize']);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
   });
 
   it('uploads a final status card image before closing output', async () => {
@@ -6360,7 +6446,7 @@ describe('DingtalkChannel outbound image delivery', () => {
   });
 });
 
-describe('DingtalkChannel outbound file projection', () => {
+describe('DingtalkChannel outbound file delivery', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -6381,25 +6467,180 @@ describe('DingtalkChannel outbound file projection', () => {
     };
   }
 
-  it('redacts reserved file output from plain replies', async () => {
+  it('sends a local file attachment and path-free text reply', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation((input) => {
+          const url = String(input);
+          if (url.includes('/gettoken?')) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  errcode: 0,
+                  access_token: 'proactive-token',
+                  expires_in: 7200,
+                }),
+              ),
+            );
+          }
+          if (url.includes('/media/upload')) {
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({ errcode: 0, media_id: '@file-media-id' }),
+              ),
+            );
+          }
+          return Promise.resolve(new Response('{}'));
+        });
+
+      await channel.sendMessage(
+        'cid123',
+        `before\n[FILE: ${file.path}]\nafter`,
+      );
+
+      const webhookCalls = fetchSpy.mock.calls.filter((call) =>
+        String(call[0]).includes('/robot/send?'),
+      );
+      expect(webhookCalls).toHaveLength(2);
+      const fileBody = JSON.parse(
+        String((webhookCalls[0]![1] as RequestInit).body),
+      );
+      expect(fileBody).toEqual({
+        msgtype: 'file',
+        file: {
+          mediaId: '@file-media-id',
+          fileName: 'report.txt',
+          fileType: 'txt',
+        },
+      });
+      expect((webhookCalls[0]![1] as RequestInit).redirect).toBe('error');
+      const textBody = JSON.parse(
+        String((webhookCalls[1]![1] as RequestInit).body),
+      ) as { markdown: { text: string } };
+      expect(textBody.markdown.text).toContain('before\n\nafter');
+      expect(textBody.markdown.text).not.toContain('[FILE:');
+      expect(textBody.markdown.text).not.toContain(file.path);
+
+      fetchSpy.mockClear();
+      await channel.sendMessage('cid123', `[FILE: ${file.path}]`);
+
+      const pureFileWebhookCalls = fetchSpy.mock.calls.filter((call) =>
+        String(call[0]).includes('/robot/send?'),
+      );
+      expect(pureFileWebhookCalls).toHaveLength(1);
+      expect(
+        JSON.parse(String((pureFileWebhookCalls[0]![1] as RequestInit).body)),
+      ).toMatchObject({ msgtype: 'file' });
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshes the token and retries one expired file upload', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      seedWebhook(channel, 'cid123');
+      let uploadCall = 0;
+      let tokenCall = 0;
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation((input) => {
+          const url = String(input);
+          if (url.includes('/gettoken?')) {
+            tokenCall++;
+            return Promise.resolve(
+              new Response(
+                JSON.stringify({
+                  errcode: 0,
+                  access_token: `proactive-token-${tokenCall}`,
+                  expires_in: 7200,
+                }),
+              ),
+            );
+          }
+          if (url.includes('/media/upload')) {
+            return Promise.resolve(
+              uploadCall++ === 0
+                ? new Response(
+                    JSON.stringify({
+                      errcode: 42001,
+                      errmsg: 'token expired',
+                    }),
+                  )
+                : new Response(
+                    JSON.stringify({
+                      errcode: 0,
+                      media_id: '@file-media-id',
+                    }),
+                  ),
+            );
+          }
+          return Promise.resolve(new Response('{}'));
+        });
+
+      await channel.sendMessage('cid123', `[FILE: ${file.path}]`);
+
+      expect(
+        fetchSpy.mock.calls.filter((call) =>
+          String(call[0]).includes('/media/upload'),
+        ),
+      ).toHaveLength(2);
+      expect(
+        fetchSpy.mock.calls.filter((call) =>
+          String(call[0]).includes('/gettoken?'),
+        ),
+      ).toHaveLength(2);
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports an invalid local file without exposing its path', async () => {
     const channel = createChannel();
     seedWebhook(channel, 'cid123');
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(new Response('{}'));
 
-    await channel.sendMessage(
-      'cid123',
-      'before\n[FILE: /workspace/report.txt]\nafter',
-    );
+    await channel.sendMessage('cid123', `[FILE: ${process.execPath}]`);
 
+    expect(fetchSpy).toHaveBeenCalledOnce();
     const body = JSON.parse(
       String((fetchSpy.mock.calls[0]![1] as RequestInit).body),
     ) as { markdown: { text: string } };
-    expect(body.markdown.text).toContain('before\n\nafter');
-    expect(body.markdown.text).toContain('[File delivery unavailable]');
-    expect(body.markdown.text).not.toContain('[FILE:');
-    expect(body.markdown.text).not.toContain('/workspace/report.txt');
+    expect(body.markdown.text).toContain('[File delivery failed:');
+    expect(body.markdown.text).not.toContain(process.execPath);
+  });
+
+  it('does not upload a file for an untrusted session webhook', async () => {
+    const file = createTempFile();
+    try {
+      const channel = createChannel({ cwd: file.dir });
+      (channel as unknown as { webhooks: Map<string, string> }).webhooks.set(
+        'cid123',
+        'https://oapi.dingtalk.com.evil.test/robot/send',
+      );
+      vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const prepare = (
+        channel as unknown as {
+          prepareReplyOutput(chatId: string, text: string): Promise<string>;
+        }
+      ).prepareReplyOutput.bind(channel);
+
+      await expect(prepare('cid123', `[FILE: ${file.path}]`)).resolves.toBe(
+        '[File delivery failed: report.txt]',
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
   });
 
   it.each([
@@ -6723,7 +6964,7 @@ describe('DingtalkChannel outbound file projection', () => {
 
     expect(projected.join('')).toBe('before\n\nafter');
     expect(closeOutput.mock.calls[0]?.[1]).toBe(
-      'before\n\nafter\n[File delivery unavailable]',
+      'before\n\nafter\n[File delivery failed: report.txt]',
     );
     expect(JSON.stringify(closeOutput.mock.calls)).not.toContain(
       '/workspace/report.txt',
@@ -7004,15 +7245,16 @@ describe('DingtalkChannel outbound file projection', () => {
     const channel = createChannel();
     const prepare = (
       channel as unknown as {
-        prepareOutgoingText(text: string): Promise<string>;
+        prepareReplyOutput(chatId: string, text: string): Promise<string>;
       }
-    ).prepareOutgoingText.bind(channel);
+    ).prepareReplyOutput.bind(channel);
 
     const out = await prepare(
+      'cid123',
       'before\n[FILE: /workspace/report.txt]\n[IMAGE: /workspace/missing.png]\nafter',
     );
 
-    expect(out).toContain('[File delivery unavailable]');
+    expect(out).toContain('[File delivery failed: report.txt]');
     expect(out).not.toContain('[FILE:');
     expect(out).not.toContain('/workspace/report.txt');
     expect(out).toContain('[Image delivery failed: missing.png]');
@@ -7257,6 +7499,66 @@ describe('DingtalkChannel proactive send', () => {
       rmSync(image.dir, { recursive: true, force: true });
     }
   });
+
+  it.each([
+    ['group', groupTarget],
+    ['direct', directTarget],
+  ])('sends proactive %s files with sampleFile', async (_name, target) => {
+    const file = createTempFile('report.pdf');
+    try {
+      const channel = proactive(createChannel({ cwd: file.dir }));
+      const { sendCalls, directSendCalls, mediaCalls } = stubProactiveFetch(
+        () =>
+          new Response(JSON.stringify({ processQueryKey: 'message-key' }), {
+            status: 200,
+          }),
+      );
+
+      await channel.pushProactive(target, `[FILE: ${file.path}]`);
+
+      expect(mediaCalls()).toHaveLength(1);
+      expect(String(mediaCalls()[0]![0])).toContain('type=file');
+      const sends = target.isGroup ? sendCalls() : directSendCalls();
+      expect(sends).toHaveLength(1);
+      const body = JSON.parse(String((sends[0]![1] as RequestInit).body)) as {
+        msgKey: string;
+        msgParam: string;
+      };
+      expect(body.msgKey).toBe('sampleFile');
+      expect(JSON.parse(body.msgParam)).toEqual({
+        mediaId: '@lAL-proactive-media-id',
+        fileName: 'report.pdf',
+        fileType: 'pdf',
+      });
+    } finally {
+      rmSync(file.dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ['group', groupTarget],
+    ['direct', directTarget],
+  ])(
+    'reports a proactive %s file response without a delivery verdict',
+    async (_name, target) => {
+      const file = createTempFile('report.pdf');
+      try {
+        const channel = proactive(createChannel({ cwd: file.dir }));
+        vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        const { sendCalls, directSendCalls } = stubProactiveFetch();
+
+        await channel.pushProactive(target, `[FILE: ${file.path}]`);
+
+        const sends = target.isGroup ? sendCalls() : directSendCalls();
+        expect(sends).toHaveLength(2);
+        expect(msgParamOf(sends[1]!).text).toBe(
+          '[File delivery failed: report.pdf]',
+        );
+      } finally {
+        rmSync(file.dir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it('rejects direct messages when DingTalk reports an invalid recipient', async () => {
     const channel = proactive(createChannel());

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -33,9 +33,14 @@ import {
   uploadDingTalkImage,
 } from './outbound-image.js';
 import {
+  FILE_UNAVAILABLE_NOTICE,
   OutboundFileProjector,
   projectFileText,
+  readValidatedFile,
+  safeFileName,
+  uploadDingTalkFile,
   withFileUnavailableNotice,
+  type ValidatedFile,
 } from './outbound-file.js';
 import {
   DingtalkConnectionManager,
@@ -595,8 +600,10 @@ const GROUP_MSG_API = 'https://api.dingtalk.com/v1.0/robot/groupMessages/send';
 const DIRECT_MSG_API =
   'https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend';
 const PROACTIVE_MSG_KEY = 'sampleMarkdown'; // DingTalk's built-in {title, text} markdown template key
+const PROACTIVE_FILE_MSG_KEY = 'sampleFile';
 const TOKEN_API = 'https://oapi.dingtalk.com/gettoken';
 const PROACTIVE_FETCH_TIMEOUT_MS = 15_000;
+const ROBOT_MESSAGE_HOSTS = new Set(['api.dingtalk.com', 'oapi.dingtalk.com']);
 /**
  * gettoken business errors a retry cannot fix: an invalid appkey/secret or a
  * missing app. Any other errcode (-1 system busy, 88 throttled, ...) is
@@ -739,6 +746,15 @@ const IMAGE_INSTRUCTIONS = [
   '',
   'Only use a real image file inside the workspace or system temporary directory.',
 ].join('\n');
+const FILE_INSTRUCTIONS = [
+  '',
+  'When the user explicitly asks for a completed local file, send it by writing this on its own line:',
+  '`[FILE: /absolute/path/to/file]` (without the backticks)',
+  '',
+  'Use at most five non-empty files inside the workspace or system temporary directory.',
+  'File paths containing ] are not supported.',
+  'Do not claim delivery succeeded; DingTalk shows successful files separately and reports failures in the final text.',
+].join('\n');
 
 type MentionTargetEnvelope = Envelope & {
   [mentionTarget]?: string;
@@ -781,6 +797,7 @@ interface DingTalkTokenResponse {
 interface DingTalkDirectMessageResponse {
   flowControlledStaffIdList?: string[];
   invalidStaffIdList?: string[];
+  processQueryKey?: string;
 }
 
 type DingTalkClientInternals = DWClient & {
@@ -871,6 +888,12 @@ export class DingtalkChannel extends ChannelBase {
       ].join('\n');
     } else if (!this.config.instructions.includes('[IMAGE:')) {
       this.config.instructions += IMAGE_INSTRUCTIONS;
+    }
+    if (
+      config.blockStreaming !== 'on' &&
+      !this.config.instructions.includes('[FILE:')
+    ) {
+      this.config.instructions += FILE_INSTRUCTIONS;
     }
     this.interactiveCardConfig = parseDingtalkInteractiveCardConfig(
       (config as DingtalkChannelConfig).interactiveCards,
@@ -1203,35 +1226,184 @@ export class DingtalkChannel extends ChannelBase {
     return isGroup && !conversationId;
   }
 
-  private projectOutgoingFileText(
-    text: string,
-    streamed?: OutboundFileProjector,
-  ): string {
-    const projection = projectFileText(text);
-    // Markers are counted when their opening bytes arrive, so the streamed
-    // count also fails closed when the final text no longer carries a marker
-    // the stream already delivered. Whole-turn hash comparison is NOT
-    // viable: the bridges return only post-last-boundary chunks as the final
-    // text, so any routine multi-tool turn would diverge by construction.
-    const streamedMarkers = streamed ? streamed.result('').markerCount : 0;
-    if (projection.markerCount === 0 && streamedMarkers === 0) {
-      return projection.text;
+  private resolveSessionWebhook(chatId: string): string | undefined {
+    const value = this.webhooks.get(chatId);
+    if (!value) return undefined;
+    try {
+      const url = new URL(value);
+      return url.protocol === 'https:' &&
+        url.port === '' &&
+        ROBOT_MESSAGE_HOSTS.has(url.hostname)
+        ? url.toString()
+        : undefined;
+    } catch {
+      return undefined;
     }
-    // Counts only — never paths — so a redaction event stays debuggable
-    // without leaking what was redacted.
-    process.stderr.write(
-      `[DingTalk:${this.name}] file markers redacted (final=${projection.markerCount}, streamed=${streamedMarkers})\n`,
-    );
-    return withFileUnavailableNotice(projection.text);
   }
 
-  private async prepareOutgoingText(
+  private async uploadOutboundFile(
+    filePath: string,
+  ): Promise<{ file: ValidatedFile; mediaId: string }> {
+    const file = readValidatedFile(filePath, this.config.cwd);
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const token = await this.getProactiveToken();
+      try {
+        return { file, mediaId: await uploadDingTalkFile(file, token) };
+      } catch (error) {
+        if (
+          error instanceof DingTalkMediaUploadError &&
+          error.authFailure &&
+          attempt === 0
+        ) {
+          this.proactiveToken = undefined;
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error('DingTalk file upload returned no MediaID');
+  }
+
+  private async deliverFiles(
+    paths: readonly string[],
+    send: (file: ValidatedFile, mediaId: string) => Promise<void>,
+    preflight?: () => void,
+  ): Promise<string[]> {
+    const notices: string[] = [];
+    for (const filePath of paths) {
+      const displayName = safeFileName(filePath);
+      try {
+        preflight?.();
+        const { file, mediaId } = await this.uploadOutboundFile(filePath);
+        await send(file, mediaId);
+      } catch (error) {
+        process.stderr.write(
+          `[DingTalk:${this.name}] outbound file delivery failed (${sanitizeLogText(displayName, 200)}): ${sanitizeLogText(
+            error instanceof Error ? error.message : String(error),
+            300,
+          )}\n`,
+        );
+        notices.push(`[File delivery failed: ${displayName}]`);
+      }
+    }
+    return notices;
+  }
+
+  private async sendSessionFile(
+    chatId: string,
+    file: ValidatedFile,
+    mediaId: string,
+  ): Promise<void> {
+    const webhook = this.resolveSessionWebhook(chatId);
+    if (!webhook) throw new Error('DingTalk session webhook unavailable');
+
+    let response: Response;
+    try {
+      response = await fetch(webhook, {
+        method: 'POST',
+        redirect: 'error',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          msgtype: 'file',
+          file: {
+            mediaId,
+            fileName: file.fileName,
+            fileType: file.fileType,
+          },
+        }),
+        signal: AbortSignal.timeout(REPLY_FETCH_TIMEOUT_MS),
+      });
+    } catch {
+      throw new Error('DingTalk file delivery failed: network request failed');
+    }
+    const body = await response.text().catch(() => '');
+    if (!response.ok) {
+      throw new Error(`DingTalk file delivery failed: HTTP ${response.status}`);
+    }
+    if (!body.trim()) return;
+
+    let data: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(body) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+        return;
+      data = parsed as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    const code = data['errcode'] ?? data['code'];
+    if (code !== undefined && String(code) !== '0') {
+      throw new Error(`DingTalk file delivery failed: API code ${code}`);
+    }
+  }
+
+  private appendFileNotices(text: string, notices: readonly string[]): string {
+    if (notices.length === 0) return text;
+    const prefix = text.trimEnd();
+    return `${prefix}${prefix ? '\n' : ''}${notices.join('\n')}`;
+  }
+
+  private async prepareReplyOutput(
+    chatId: string,
     text: string,
     streamed?: OutboundFileProjector,
   ): Promise<string> {
-    const fileSafeText = this.projectOutgoingFileText(text, streamed);
-    const markers = findImageMarkers(fileSafeText);
-    if (markers.length === 0) return fileSafeText;
+    return this.prepareFileOutput(
+      text,
+      (file, mediaId) => this.sendSessionFile(chatId, file, mediaId),
+      streamed,
+      () => {
+        if (!this.resolveSessionWebhook(chatId)) {
+          throw new Error('DingTalk session webhook unavailable');
+        }
+      },
+    );
+  }
+
+  private async prepareFileOutput(
+    text: string,
+    send: (file: ValidatedFile, mediaId: string) => Promise<void>,
+    streamed?: OutboundFileProjector,
+    preflight?: () => void,
+  ): Promise<string> {
+    const projection = projectFileText(text);
+    const streamedMarkers = streamed ? streamed.result('').markerCount : 0;
+    if (projection.markerCount > 0 || streamedMarkers > 0) {
+      process.stderr.write(
+        `[DingTalk:${this.name}] file markers projected (final=${projection.markerCount}, streamed=${streamedMarkers})\n`,
+      );
+    }
+
+    if (
+      this.config.blockStreaming === 'on' &&
+      (projection.markerCount > 0 || streamedMarkers > 0)
+    ) {
+      return this.prepareOutgoingText(
+        withFileUnavailableNotice(projection.text),
+      );
+    }
+
+    const notices: string[] = [];
+    if (projection.invalidMarkers > 0) {
+      notices.push('[File delivery failed: invalid marker]');
+    }
+    if (projection.excessMarkers > 0) {
+      notices.push('[File delivery failed: response file limit exceeded]');
+    }
+    if (streamedMarkers > projection.markerCount) {
+      notices.push(FILE_UNAVAILABLE_NOTICE);
+    }
+    notices.push(
+      ...(await this.deliverFiles(projection.paths, send, preflight)),
+    );
+    return this.prepareOutgoingText(
+      this.appendFileNotices(projection.text, notices),
+    );
+  }
+
+  private async prepareOutgoingText(text: string): Promise<string> {
+    const markers = findImageMarkers(text);
+    if (markers.length === 0) return text;
 
     const replacements: string[] = [];
     for (const marker of markers) {
@@ -1279,7 +1451,7 @@ export class DingtalkChannel extends ChannelBase {
       }
     }
 
-    return replaceImageMarkers(fileSafeText, markers, replacements);
+    return replaceImageMarkers(text, markers, replacements);
   }
 
   private async sendReply(
@@ -1287,8 +1459,9 @@ export class DingtalkChannel extends ChannelBase {
     text: string,
     atUserId?: string,
     sourceLabel?: string,
+    prepared = false,
   ): Promise<void> {
-    // chatId is a conversationId — resolve to the latest sessionWebhook
+    // chatId is a conversationId — resolve to the latest sessionWebhook.
     const webhook = this.webhooks.get(chatId);
     if (!webhook) {
       process.stderr.write(
@@ -1297,7 +1470,10 @@ export class DingtalkChannel extends ChannelBase {
       return;
     }
 
-    const outgoingText = await this.prepareOutgoingText(text);
+    const outgoingText = prepared
+      ? text
+      : await this.prepareReplyOutput(chatId, text);
+    if (!outgoingText.trim()) return;
     const mentionPrefix = atUserId ? `@${atUserId}\n\n` : '';
     const sourcePrefix =
       sourceLabel && outgoingText.trim().length > 0
@@ -1430,7 +1606,10 @@ export class DingtalkChannel extends ChannelBase {
   ): Promise<void> {
     if (!text.trim()) return;
 
-    const outgoingText = await this.prepareOutgoingText(text);
+    const outgoingText = await this.prepareFileOutput(text, (file, mediaId) =>
+      this.sendProactiveFile(target, file, mediaId),
+    );
+    if (!outgoingText.trim()) return;
     const sourcePrefix = sourceLabel
       ? `${escapeDingTalkMarkdown(sourceLabel)}\n\n`
       : '';
@@ -1527,6 +1706,33 @@ export class DingtalkChannel extends ChannelBase {
     text: string,
     chunkLabel: string,
   ): Promise<void> {
+    return this.sendProactivePayload(
+      target,
+      PROACTIVE_MSG_KEY,
+      { title, text },
+      chunkLabel,
+    );
+  }
+
+  private async sendProactiveFile(
+    target: SessionTarget,
+    file: ValidatedFile,
+    mediaId: string,
+  ): Promise<void> {
+    return this.sendProactivePayload(
+      target,
+      PROACTIVE_FILE_MSG_KEY,
+      { mediaId, fileName: file.fileName, fileType: file.fileType },
+      `file ${file.fileName}`,
+    );
+  }
+
+  private async sendProactivePayload(
+    target: SessionTarget,
+    msgKey: string,
+    msgParam: Record<string, string>,
+    chunkLabel: string,
+  ): Promise<void> {
     const targetKind = target.isGroup === true ? 'group' : 'dm';
     for (let attempt = 0; ; attempt++) {
       const token = await this.getProactiveToken();
@@ -1547,8 +1753,8 @@ export class DingtalkChannel extends ChannelBase {
             body: JSON.stringify({
               robotCode: this.config.clientId!,
               ...targetBody,
-              msgKey: PROACTIVE_MSG_KEY,
-              msgParam: JSON.stringify({ title, text }),
+              msgKey,
+              msgParam: JSON.stringify(msgParam),
             }),
             signal: AbortSignal.timeout(PROACTIVE_FETCH_TIMEOUT_MS),
           },
@@ -1577,6 +1783,37 @@ export class DingtalkChannel extends ChannelBase {
           `DingTalk proactive send failed: HTTP ${resp.status}${detail ? ` ${detail}` : ''}`,
         );
       }
+      if (target.isGroup === true) {
+        if (msgKey !== PROACTIVE_FILE_MSG_KEY) {
+          await resp.body?.cancel();
+          return;
+        }
+        let data: Record<string, unknown>;
+        try {
+          const parsed = (await resp.json()) as unknown;
+          data =
+            parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+              ? (parsed as Record<string, unknown>)
+              : {};
+        } catch {
+          throw new Error(
+            'DingTalk file delivery failed: invalid JSON response',
+          );
+        }
+        const code = data['errcode'] ?? data['code'];
+        if (code !== undefined && String(code) !== '0') {
+          throw new Error(`DingTalk file delivery failed: API code ${code}`);
+        }
+        if (
+          typeof data['processQueryKey'] !== 'string' ||
+          !data['processQueryKey'].trim()
+        ) {
+          throw new Error(
+            'DingTalk file delivery failed: missing processQueryKey',
+          );
+        }
+        return;
+      }
       if (target.isGroup === false) {
         let data: DingTalkDirectMessageResponse;
         try {
@@ -1603,6 +1840,14 @@ export class DingtalkChannel extends ChannelBase {
           );
           throw new Error(
             'DingTalk proactive send failed: direct recipient rate limited',
+          );
+        }
+        if (
+          msgKey === PROACTIVE_FILE_MSG_KEY &&
+          !data.processQueryKey?.trim()
+        ) {
+          throw new Error(
+            'DingTalk file delivery failed: missing processQueryKey',
           );
         }
         return;
@@ -2053,6 +2298,7 @@ export class DingtalkChannel extends ChannelBase {
     text: string,
     sessionId: string,
     sourceLabel?: string,
+    prepared = false,
   ): Promise<void> {
     let outgoingText = text;
     let consumesMention = true;
@@ -2074,6 +2320,7 @@ export class DingtalkChannel extends ChannelBase {
       outgoingText,
       atUserId,
       sourceLabel ?? this.getResponseSourceLabel(sessionId),
+      prepared,
     );
   }
 
@@ -2127,7 +2374,7 @@ export class DingtalkChannel extends ChannelBase {
       ? this.fileProjectors.get(segment.runId)?.projector
       : undefined;
     if (segment) this.fileProjectors.delete(segment.runId);
-    const outgoingText = await this.prepareOutgoingText(text, streamed);
+    const outgoingText = await this.prepareReplyOutput(chatId, text, streamed);
     if (segment && this.interactionPresenter) {
       if (
         await this.interactionPresenter.closeOutput(
@@ -2145,6 +2392,7 @@ export class DingtalkChannel extends ChannelBase {
       outgoingText,
       sessionId,
       segment?.sourceLabel,
+      true,
     );
   }
 

--- a/packages/channels/dingtalk/src/outbound-file.test.ts
+++ b/packages/channels/dingtalk/src/outbound-file.test.ts
@@ -1,8 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import {
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  truncateSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   MAX_FILES_PER_RESPONSE,
   OutboundFileProjector,
   projectFileText,
+  readValidatedFile,
+  safeFileName,
+  uploadDingTalkFile,
 } from './outbound-file.js';
 
 describe('OutboundFileProjector', () => {
@@ -80,5 +92,115 @@ describe('OutboundFileProjector', () => {
     expect(projected.invalidMarkers).toBe(1);
     expect(projected.text).not.toContain('/tmp/');
     expect(projected.text).not.toContain('x'.repeat(100));
+  });
+});
+
+describe('outbound file validation and upload', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reads a non-empty regular file under the workspace', () => {
+    const workspace = process.cwd();
+    const file = readValidatedFile(join(workspace, 'package.json'), workspace);
+    expect(file).toMatchObject({
+      fileName: 'package.json',
+      fileType: 'json',
+    });
+    expect(file.data.length).toBeGreaterThan(0);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'reads a file from the POSIX /tmp directory',
+    () => {
+      const dir = mkdtempSync('/tmp/dingtalk-outbound-file-');
+      const path = join(dir, '0902test.md');
+      writeFileSync(path, 'caosini');
+      try {
+        expect(readValidatedFile(path, process.cwd())).toMatchObject({
+          fileName: '0902test.md',
+          fileType: 'md',
+        });
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each([
+    ['relative path', 'report.txt', 'File path must be absolute'],
+    ['outside root', process.execPath, 'outside allowed directories'],
+  ])('rejects a %s', (_name, path, message) => {
+    expect(() => readValidatedFile(path, tmpdir())).toThrow(message);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'rejects a symlink that escapes an allowed directory',
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), 'dingtalk-file-symlink-'));
+      const link = join(dir, 'outside');
+      symlinkSync(process.execPath, link);
+      try {
+        expect(() => readValidatedFile(link, dir)).toThrow(
+          'outside allowed directories',
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it('rejects empty, directory, and oversized files', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dingtalk-file-bounds-'));
+    const empty = join(dir, 'empty.txt');
+    const large = join(dir, 'large.bin');
+    writeFileSync(empty, '');
+    writeFileSync(large, 'x');
+    truncateSync(large, 20 * 1024 * 1024 + 1);
+    try {
+      expect(() => readValidatedFile(empty, dir)).toThrow('File is empty');
+      expect(() => readValidatedFile(dir, dir)).toThrow('Not a regular file');
+      expect(() => readValidatedFile(large, dir)).toThrow('File is too large');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('sanitizes file names used in receipts and payloads', () => {
+    expect(safeFileName('/tmp/repor\nt].txt')).toBe('repor_t_.txt');
+  });
+
+  it('uploads as file media and returns the media id', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ errcode: 0, media_id: '@file-id' })),
+      );
+
+    await expect(
+      uploadDingTalkFile(
+        { data: Buffer.from('x'), fileName: 'a.txt', fileType: 'txt' },
+        'secret',
+      ),
+    ).resolves.toBe('@file-id');
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain('type=file');
+  });
+
+  it('redacts the access token from upload errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({ errcode: 40014, errmsg: 'bad secret-token' }),
+      ),
+    );
+
+    await expect(
+      uploadDingTalkFile(
+        { data: Buffer.from('x'), fileName: 'a.txt', fileType: 'txt' },
+        'secret-token',
+      ),
+    ).rejects.toMatchObject({
+      authFailure: true,
+      message: expect.not.stringContaining('secret-token'),
+    });
   });
 });

--- a/packages/channels/dingtalk/src/outbound-file.ts
+++ b/packages/channels/dingtalk/src/outbound-file.ts
@@ -1,5 +1,22 @@
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, extname, isAbsolute, relative, sep } from 'node:path';
+import { DingTalkMediaUploadError } from './outbound-image.js';
+
 const FILE_OPENING = '[FILE:';
+const MEDIA_UPLOAD_API = 'https://oapi.dingtalk.com/media/upload';
+const MEDIA_UPLOAD_TIMEOUT_MS = 30_000;
 const MAX_FILE_PATH_CHARS = 4096;
+const MAX_FILE_BYTES = 20 * 1024 * 1024;
+const AUTH_ERROR_CODES = new Set([40014, 42001]);
 export const MAX_FILES_PER_RESPONSE = 5;
 export const FILE_UNAVAILABLE_NOTICE = '[File delivery unavailable]';
 
@@ -9,6 +26,12 @@ export interface FileProjection {
   invalidMarkers: number;
   excessMarkers: number;
   markerCount: number;
+}
+
+export interface ValidatedFile {
+  data: Buffer;
+  fileName: string;
+  fileType: string;
 }
 
 export class OutboundFileProjector {
@@ -104,10 +127,10 @@ export class OutboundFileProjector {
 }
 
 /**
- * Redacts [FILE: ...] markers from one complete outbound text. Detection
- * deliberately scans the RAW text, unlike the image path's maskCode scan:
- * FILE performs no upload, so a FILE-shaped example inside a code fence is
- * over-redacted rather than risking a leaked path — security over fidelity.
+ * Redacts [FILE: ...] markers from one complete outbound text and returns
+ * accepted paths separately. Detection deliberately scans the RAW text,
+ * unlike the image path's maskCode scan, so a FILE-shaped example inside a
+ * code fence is over-redacted rather than risking a leaked path.
  */
 export function projectFileText(text: string): FileProjection {
   const projector = new OutboundFileProjector();
@@ -118,4 +141,155 @@ export function projectFileText(text: string): FileProjection {
 export function withFileUnavailableNotice(text: string): string {
   const safe = text.trimEnd();
   return `${safe}${safe ? '\n' : ''}${FILE_UNAVAILABLE_NOTICE}`;
+}
+
+export function safeFileName(filePath: string): string {
+  return (
+    basename(filePath)
+      .replace(/[\p{Cc}\p{Cf}[\]]+/gu, '_')
+      .slice(0, 200) || 'file'
+  );
+}
+
+function isInside(filePath: string, directory: string): boolean {
+  const child = relative(directory, filePath);
+  return (
+    child === '' ||
+    (!isAbsolute(child) && child !== '..' && !child.startsWith(`..${sep}`))
+  );
+}
+
+export function readValidatedFile(
+  filePath: string,
+  workspaceDir: string,
+): ValidatedFile {
+  if (!isAbsolute(filePath)) throw new Error('File path must be absolute');
+
+  let realPath: string;
+  try {
+    realPath = realpathSync(filePath);
+  } catch {
+    throw new Error('File not found');
+  }
+  const roots = [
+    workspaceDir,
+    tmpdir(),
+    ...(process.platform === 'win32' ? [] : ['/tmp']),
+  ].map((root) => realpathSync(root));
+  if (!roots.some((root) => isInside(realPath, root))) {
+    throw new Error('File path outside allowed directories');
+  }
+  if (!statSync(realPath).isFile()) throw new Error('Not a regular file');
+
+  const descriptor = openSync(
+    realPath,
+    constants.O_RDONLY | constants.O_NONBLOCK | (constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const stats = fstatSync(descriptor);
+    if (!stats.isFile()) throw new Error('Not a regular file');
+    if (stats.size === 0) throw new Error('File is empty');
+    if (stats.size > MAX_FILE_BYTES) throw new Error('File is too large');
+
+    const data = Buffer.allocUnsafe(stats.size + 1);
+    let bytesRead = 0;
+    while (bytesRead < data.length) {
+      const count = readSync(
+        descriptor,
+        data,
+        bytesRead,
+        data.length - bytesRead,
+        bytesRead,
+      );
+      if (count === 0) break;
+      bytesRead += count;
+    }
+    if (bytesRead !== stats.size) throw new Error('File changed while read');
+
+    const fileName = safeFileName(realPath);
+    return {
+      data: data.subarray(0, bytesRead),
+      fileName,
+      fileType: extname(fileName).slice(1).toLowerCase() || 'file',
+    };
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function sanitizeApiMessage(message: unknown, accessToken: string): string {
+  const value = String(message ?? '');
+  return (accessToken ? value.replaceAll(accessToken, '[redacted]') : value)
+    .replace(/[\r\n\t]+/g, ' ')
+    .slice(0, 200);
+}
+
+export async function uploadDingTalkFile(
+  file: ValidatedFile,
+  accessToken: string,
+): Promise<string> {
+  const form = new FormData();
+  form.append(
+    'media',
+    new Blob([file.data], { type: 'application/octet-stream' }),
+    file.fileName,
+  );
+
+  let response: Response;
+  try {
+    const url = new URL(MEDIA_UPLOAD_API);
+    url.searchParams.set('access_token', accessToken);
+    url.searchParams.set('type', 'file');
+    response = await fetch(url, {
+      method: 'POST',
+      body: form,
+      signal: AbortSignal.timeout(MEDIA_UPLOAD_TIMEOUT_MS),
+    });
+  } catch {
+    throw new DingTalkMediaUploadError(
+      'DingTalk file upload failed: network request failed',
+      false,
+    );
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    const parsed = (await response.json()) as unknown;
+    payload =
+      parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+  } catch {
+    throw new DingTalkMediaUploadError(
+      `DingTalk file upload failed: HTTP ${response.status} invalid JSON response`,
+      response.status === 401,
+    );
+  }
+
+  const errcode =
+    typeof payload['errcode'] === 'number' ? payload['errcode'] : undefined;
+  if (!response.ok || (errcode !== undefined && errcode !== 0)) {
+    const detail = sanitizeApiMessage(payload['errmsg'], accessToken);
+    throw new DingTalkMediaUploadError(
+      `DingTalk file upload failed: HTTP ${response.status}${
+        errcode === undefined ? '' : ` errcode=${errcode}`
+      }${detail ? ` ${detail}` : ''}`,
+      response.status === 401 ||
+        (errcode !== undefined && AUTH_ERROR_CODES.has(errcode)),
+    );
+  }
+
+  const mediaId =
+    typeof payload['media_id'] === 'string'
+      ? payload['media_id']
+      : typeof payload['mediaId'] === 'string'
+        ? payload['mediaId']
+        : undefined;
+  if (!mediaId) {
+    throw new DingTalkMediaUploadError(
+      'DingTalk file upload failed: response did not include a MediaID',
+      false,
+    );
+  }
+  return mediaId;
 }


### PR DESCRIPTION
## What this PR does

The DingTalk channel can now turn an explicit whole-line `[FILE: /absolute/path]` instruction in model output into a native file attachment for session replies, proactive group messages, and proactive direct messages. Each response is bounded to five files, and every file is resolved inside the active workspace or a system temporary directory, opened without following symlinks, required to be a non-empty regular file, and limited to 20 MiB before upload.

File markers and local paths are removed from streamed text and terminal status cards. Native delivery completes before a status card is finalized, pure-file responses do not emit an empty Markdown message, expired upload tokens are refreshed once, and upload or delivery failures produce path-free failure text instead of a false success claim.

## Why it's needed

DingTalk users can currently receive text and images, but generated reports, archives, source files, and other non-image artifacts are pasted as text or described as sent without a downloadable attachment. This change adds a bounded DingTalk-only delivery path while preserving the existing behavior for ordinary text, images, and block-streaming configurations.

## Reviewer Test Plan

### How to verify

1. Configure a DingTalk Stream bot with block streaming disabled, ask it to send an existing non-empty file from the workspace or system temporary directory, and confirm that DingTalk receives a native downloadable attachment without exposing the marker or local path.
2. Repeat with a session reply, a proactive group target, and a proactive direct target. Confirm that a pure-file response sends only the attachment and that a response containing text plus a file preserves the text.
3. Try a missing file, an empty file, a file larger than 20 MiB, a symlink that escapes an allowed root, and more than five markers. Confirm that no invalid file is uploaded and that the response contains only bounded, path-free failure text.
4. Exercise the status-card path and confirm that file delivery finishes before terminal card finalization. Enable block streaming and confirm that markers remain redacted while native file delivery stays disabled.

### Evidence (Before & After)

Before: a live DingTalk request for `/tmp/0902test.md` returned the file body as Markdown text and said that native `.md` file delivery was unsupported.

After: the same 8-byte fixture was delivered by a real DingTalk Stream bot as a native downloadable `0902test.md` attachment. The requester confirmed receipt, and the test channel was stopped afterward.

Automated verification on the rebased commit: all 496 DingTalk package tests passed, including 273 outbound-file-focused and adapter tests; ESLint, Prettier, the full repository build, and the full repository typecheck also passed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Built local branch on macOS, then exercised a real DingTalk Stream bot with block streaming disabled and existing bot configuration. No credentials are included in this PR or its test evidence.

## Risk & Scope

- Main risk or tradeoff: Native delivery depends on DingTalk media-upload permissions and API availability; file delivery is intentionally completed before the terminal status card so a failed upload cannot be presented as success.
- Not validated / out of scope: Inbound files, implicit file discovery, block-streaming attachment delivery, and manual Windows or Linux channel runs are out of scope. CI remains responsible for cross-platform automated coverage.
- Breaking changes / migration notes: None. Existing channel configuration remains valid, and ordinary text and image delivery are unchanged.

## Linked Issues

Fixes #9166.

This is the reduced-scope replacement discussed when #9350 was closed; #9167 and #9350 remain closed.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

钉钉 Channel 现在可以把模型输出中独占一行的显式 `[FILE: /absolute/path]` 指令转换为原生文件附件，支持会话回复、主动群消息和主动单聊消息。每次回复最多处理 5 个文件；上传前，每个文件都必须解析到当前工作区或系统临时目录内，以不跟随符号链接的方式打开，并且必须是非空普通文件，大小不超过 20 MiB。

流式文本和终态状态卡中不会展示文件标记或本地路径。原生文件会在状态卡结束前完成投递；纯文件回复不会额外发送空 Markdown；上传令牌过期时会刷新一次；上传或投递失败时只返回不包含路径的失败提示，不会错误宣称文件已经发送成功。

## 为什么需要这个改动

钉钉用户目前可以接收文本和图片，但生成的报告、压缩包、源码文件以及其他非图片产物只能被粘贴成文本，或者机器人声称已发送却没有可下载附件。本改动增加了一条有明确边界、仅作用于钉钉的文件投递路径，同时保留普通文本、图片和 block streaming 配置的现有行为。

## Reviewer 测试计划

### 如何验证

1. 配置一个关闭 block streaming 的钉钉 Stream 机器人，让它发送工作区或系统临时目录中一个已存在的非空文件，确认钉钉收到原生可下载附件，并且消息中不泄露文件标记或本地路径。
2. 分别验证会话回复、主动群消息和主动单聊消息。确认纯文件回复只发送附件，文本加文件的回复仍保留文本。
3. 分别尝试不存在的文件、空文件、超过 20 MiB 的文件、逃逸允许目录的符号链接，以及超过 5 个文件标记。确认无效文件不会上传，并且回复只包含有界且不带路径的失败提示。
4. 验证状态卡路径，确认文件投递在终态卡结束前完成。开启 block streaming 后，确认文件标记仍会被隐藏，同时原生文件投递保持禁用。

### 证据（改动前与改动后）

改动前：在真实钉钉中请求 `/tmp/0902test.md` 时，机器人把文件正文作为 Markdown 文本返回，并说明不支持原生 `.md` 文件投递。

改动后：同一个 8 字节测试文件通过真实钉钉 Stream 机器人以原生可下载的 `0902test.md` 附件送达。请求方确认收到附件，测试结束后机器人 Channel 已停止。

rebase 后提交的自动化验证结果：钉钉包 496 个测试全部通过，其中包含 273 个出站文件与适配器相关测试；ESLint、Prettier、全仓 build 和全仓 typecheck 也全部通过。

### 已测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

在 macOS 上构建本地分支，然后使用已有机器人配置和关闭 block streaming 的真实钉钉 Stream 机器人完成验证。本 PR 及测试证据不包含任何凭据。

## 风险与范围

- 主要风险或权衡：原生投递依赖钉钉媒体上传权限和 API 可用性；文件投递会有意在终态状态卡结束前完成，避免上传失败却展示为成功。
- 未验证或不在范围内：入站文件、隐式文件发现、block streaming 下的附件投递，以及 Windows 或 Linux 的人工 Channel 验证不在本次范围内；跨平台自动化覆盖由 CI 继续验证。
- 破坏性变更或迁移说明：无。现有 Channel 配置保持有效，普通文本和图片投递行为不变。

## 关联 Issue

修复 #9166。

这是关闭 #9350 时讨论的收敛范围替代实现；#9167 和 #9350 保持关闭。

</details>
