### PR TITLE
docs: add OrcaReplay to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Then follow the instructions inside to install, authenticate, and use Qwen Code 
 ```
 
 - [**Aliyun Model Studio CLI**](https://github.com/modelstudioai/cli) — Official CLI for Aliyun's AI platform (`bailian-cli`). Extends Qwen Code with image/video generation, knowledge retrieval, app orchestration, and model deployment
+- [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) — Record a Qwen Code run, replay it offline byte-for-byte, or fork it from any step onto a different model
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Then follow the instructions inside to install, authenticate, and use Qwen Code 
 ```
 
 - [**Aliyun Model Studio CLI**](https://github.com/modelstudioai/cli) — Official CLI for Aliyun's AI platform (`bailian-cli`). Extends Qwen Code with image/video generation, knowledge retrieval, app orchestration, and model deployment
-- [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) — Record a Qwen Code run, replay it offline byte-for-byte, or fork it from any step onto a different model
+- [**OrcaReplay**](https://github.com/Continuum-AI-Corp/OrcaReplay) — Record a Qwen Code run, replay it offline with the network off, or fork it from any step onto a different model
 
 ## Contributing
 


### PR DESCRIPTION
One line added to `## Ecosystem`.

## What it is

[OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) records a Qwen Code run, then replays it with the network off and reproduces it byte-for-byte, or forks it from a chosen step so the model is the only thing that changed.

```console
orca record generic-openai -- qwen -p "…"
orca replay last                          # same run again, no network, no tokens
orca replay last --from 4 --model <other>
```

## Why Qwen Code was easy, and why that is the interesting part

Qwen Code reads its OpenAI-compatible endpoint straight from the environment, which is exactly what the `generic-openai` adapter redirects — so there is no config to rewrite and no TLS to terminate. That is unusual and worth saying out loud: opencode needed TLS interception because its provider origin lives in `opencode.json`, and a Codex CLI on a ChatGPT login has no base URL to point anywhere at all. Qwen Code needs neither.

The capture is committed, not hypothetical: [`prompt/QWENCODE/gpt-5-6-sol-system-prompt.md`](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/prompt/QWENCODE/gpt-5-6-sol-system-prompt.md) is the system prompt Qwen Code actually sent on the wire, recorded through the proxy, and reproducible with one command:

```console
node capture/capture.mjs qwen --model gpt-5.6-sol
```

## Something the capture turned up, in case it is useful

The harness identity is fixed regardless of which model sits behind it. Running Qwen Code against `gpt-5.6-sol` through a gateway, the prompt still opens *"You are Qwen Code, a non-interactive CLI agent developed by Alibaba Group"* — 28,285 characters with 23 tool definitions. Same model through Codex CLI gets a completely different 23,377-character prompt with 9 tools, and through opencode a third one with 9. The [captures are here](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/prompt) if anyone wants to diff them.

## Notes

- Apache-2.0, Node 20+, npm `orcareplay`. The trace format is a separately published spec (CC BY 4.0) so readers can be reimplemented in other languages.
- Alongside the model traffic a run also records shell exit codes and timing, per-turn file changes, and MCP calls, all on one timeline ordered by when things actually happened.
- Searched the README for `orcareplay` first: 0 hits, no duplicate.

Disclosure: I work on OrcaReplay.
