### PR TITLE
fix(ci): stop the scripts-suite timeout knob from failing open on an empty value

### DIFF
--- a/scripts/tests/qwen-autofix-workflow.test.js
+++ b/scripts/tests/qwen-autofix-workflow.test.js
@@ -2064,7 +2064,7 @@ describe('qwen-autofix workflow', () => {
         head: H,
       }).stale,
     ).toBe(false);
-  }, 30000);
+  });
 
   it('behaviorally replays the eligibility recheck across lifecycle and label states', () => {
     // Extract the recheck VERBATIM (drift fails the test) and run it with a
@@ -12643,7 +12643,7 @@ exit 1
       /then\n\s+echo "📊 milestone digest posted/,
     );
     expect(pushAndReportStep).toContain('milestone digest failed to post');
-  }, 30000);
+  });
 
   it('salvages a race-lost push by merging the moved head instead of discarding the run', () => {
     // A one-shot push dies `fetch first` whenever anything pushes to the PR
@@ -13674,7 +13674,7 @@ exit 1
     const fuzz = run(crossWorkspace, { enforce: 'terminate' });
     expect(fuzz.out).toContain('SURVIVED');
     expect(fuzz.advisory).toContain('outside the PR footprint');
-  }, 30000);
+  });
 
   it('upserts deferred findings into a per-PR issue that survives the merge', () => {
     // Wiring: the upsert runs after both shared resolve/reply call sites
@@ -17513,7 +17513,7 @@ exit 1
     expect(ciWorkflow).toContain(
       '.github/scripts/autofix-status-heartbeat.test.mjs',
     );
-  }, 30000);
+  });
 
   it('renders the whole managed fleet into the run summary', () => {
     // Diagnosing a stall used to mean listing bot PRs, regexing each one's eval
@@ -21277,7 +21277,7 @@ exit 0
       expect(runAddressReview(dir, stub).status).not.toBe(0);
       expect(existsSync(join(dir, 'agent-api-error'))).toBe(false);
     });
-  }, 30000);
+  });
 
   it('classifies permanent API failures terminal and records the cause class', () => {
     // A permanent 400 whose text happens to carry a 3-digit number in 500-599
@@ -23960,10 +23960,10 @@ describe('review verification gate: baseline A/B on deterministic rejection', ()
     expect(neutralized.stdout).toContain(';;error;;forged');
     expect(neutralized.stdout).not.toContain('::error::forged');
     // Eight runGate arms, each a fixture repo plus a full gate-script
-    // replay under bash — this outgrows the 5s default on slow runners
-    // (it timed out at ~6.4s on the PR head); the suite's convention is
-    // an explicit per-test budget for tests that spawn subprocesses.
-  }, 30000);
+    // replay under bash — this outgrows vitest's 5s default on slow runners
+    // (it timed out at ~6.4s on the PR head), so it runs on the suite
+    // ceiling in scripts/tests/vitest.config.ts rather than a per-test one.
+  });
 
   it('rejects a handoff written over a dirty workspace, non-retryably', () => {
     // A handoff claims the round deliberately changed NOTHING; dirt beside

--- a/scripts/tests/unit-vitest-configs.test.ts
+++ b/scripts/tests/unit-vitest-configs.test.ts
@@ -229,19 +229,27 @@ describe('scripts suite timeout', () => {
     // heaviest case measures ~14s idle, and acp-serve-boundary-guard — neither
     // slow, both past 30s under contention. A per-file `vi.setConfig` cannot
     // fix it: these cases register their timeout at collection.
+    // The `''` arm is the one that matters and the one this pin used to
+    // discard: it stubbed the empty string and then immediately called
+    // `vi.unstubAllEnvs()`, so the assertion that followed measured the unset
+    // path twice and never saw an empty value at all. `''` is not a hypothetical
+    // spelling — `${{ cond && 'x' || '' }}` renders exactly that whenever the
+    // condition is false, so a workflow wiring this knob that way would ship 0
+    // here, and vitest reads 0 as no timeout at all.
     for (const [stub, expected] of [
       [undefined, 90_000],
+      ['', 90_000],
+      ['abc', 90_000],
+      ['0', 90_000],
       ['5000', 5_000],
     ] as const) {
-      if (stub === undefined) {
-        vi.stubEnv('QWEN_SCRIPTS_TEST_TIMEOUT_MS', '');
-        vi.unstubAllEnvs();
-      } else {
-        vi.stubEnv('QWEN_SCRIPTS_TEST_TIMEOUT_MS', stub);
-      }
+      vi.stubEnv('QWEN_SCRIPTS_TEST_TIMEOUT_MS', stub);
       vi.resetModules();
       const mod = await import('./vitest.config.js');
-      expect(mod.default.test?.testTimeout, `stub=${stub}`).toBe(expected);
+      expect(
+        mod.default.test?.testTimeout,
+        `stub=${stub === undefined ? '<unset>' : JSON.stringify(stub)}`,
+      ).toBe(expected);
       vi.unstubAllEnvs();
     }
   });

--- a/scripts/tests/vitest.config.ts
+++ b/scripts/tests/vitest.config.ts
@@ -41,7 +41,12 @@ export default defineConfig({
     // and acp-serve-boundary-guard.test.js — neither of them slow, both past
     // 30s under contention. Per-test `vi.setConfig` does not help: these
     // cases register their timeout at collection, before it runs.
-    testTimeout: Number(process.env['QWEN_SCRIPTS_TEST_TIMEOUT_MS'] ?? 90_000),
+    // `||`, not `??`: `??` only catches `undefined`, and the value this repo
+    // actually plants is `''` — that is what `${{ cond && 'x' || '' }}` renders
+    // when the condition is false. `Number('')` is 0, and vitest reads 0 as
+    // "no timeout at all", so the empty spelling would silently disarm every
+    // ceiling in this suite. `NaN` from a typo falls back the same way.
+    testTimeout: Number(process.env['QWEN_SCRIPTS_TEST_TIMEOUT_MS']) || 90_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## What this PR does

Fixes a knob in the scripts test lane that silently disarmed the very timeout it exists to set, and removes six per-test ceilings that now work against the suite-wide ceiling they predate. Both are follow-ups to #10870.

## Why it's needed

#10870 gave the scripts suite a 90s ceiling with an environment override, written as `Number(process.env['QWEN_SCRIPTS_TEST_TIMEOUT_MS'] ?? 90_000)`. `??` only catches `undefined`, so an empty value produces `Number('')` — which is `0` — and vitest reads `0` as *no timeout at all*. The knob whose entire purpose is to *raise* the ceiling would instead remove it, and a genuinely hung test would run until the job cap rather than failing in 90 seconds. A typo takes the same path through `NaN`.

`''` is not a hypothetical spelling. It is exactly what this repo's `${{ cond && 'x' || '' }}` idiom renders when the condition is false, and that is how the sibling `QWEN_SKIP_LATENCY_BUDGETS` knob — added by #10870 one line away in `ci.yml` — is wired today. Nothing sets this variable in a workflow yet, so the fault is latent rather than live; that is why this is a normal follow-up and not a hotfix.

The pin that was supposed to catch this could not. It stubbed `''` and then called `vi.unstubAllEnvs()` on the very next line, so both of its arms measured the unset path and the one value that would have failed was discarded before the assertion ran.

Separately, six cases in `qwen-autofix-workflow.test.js` still carry `}, 30000)`. Those predate the suite-wide ceiling and now shadow it, pinning exactly the bash-spawning tests that the 90s default exists to protect back down to the old flat 30s — on the same contended pool that caused #10853 in the first place. None of the six asserts a duration property; each is a "give this subprocess-spawning test room" budget, and the last one says so in its own comment.

## Reviewer Test Plan

### How to verify

The fix replaces `??` with `||`, so every non-positive spelling falls back to the default. The one thing it gives up is passing `0` to mean "no timeout", which is a footgun rather than a feature and which no caller uses.

`scripts/tests/unit-vitest-configs.test.ts` cannot be run outside CI: it imports every workspace vitest config, and `packages/webui/vite.config.ts` needs `vite-plugin-dts`, which a root-only install does not have. That limitation predates this PR and is unrelated to it. The evidence below therefore comes from an equivalent standalone probe that imports only `scripts/tests/vitest.config.ts` and asserts the same five arms as the rewritten pin, run against both the old expression and the new one.

A reviewer should confirm three things: that `Number('')` is `0` and that vitest treats `testTimeout: 0` as unbounded; that the rewritten pin fails against the expression this PR replaces and passes against the new one; and that the six removed ceilings were raising vitest's 5s default rather than asserting a performance property.

### Evidence (Before & After)

Coercion behaviour of the expression being replaced:

    Number(undefined ?? 90000) = 90000     Number('' ?? 90000) = 0     Number('abc' ?? 90000) = NaN     Number('5000' ?? 90000) = 5000

**Before** — the rewritten pin run against the old `??` expression fails on the arm the old pin discarded:

    stub=<unset> -> 90000 (want 90000)
    stub=""      -> 0     (want 90000)
    AssertionError: expected +0 to be 90000
    Tests  1 failed (1)

**After** — the same pin against the new `||` expression:

    stub=<unset> -> 90000 (want 90000)
    stub=""      -> 90000 (want 90000)
    stub="abc"   -> 90000 (want 90000)
    stub="0"     -> 90000 (want 90000)
    stub="5000"  -> 5000  (want 5000)
    Tests  1 passed (1)

The `vi.stubEnv(k, undefined)` form used to drop the old pin's `if`/`else` is confirmed against the installed vitest: `else if (value === void 0) delete process.env[name]`, and `QWEN_SCRIPTS_TEST_TIMEOUT_MS` is not in vitest's `_envBooleans` special-case list, so `''` is stored verbatim.

On the six removed ceilings: the three `timeout: 30_000` values that remain in the file are `spawnSync` bounds and are deliberately left, because spawnSync blocks the event loop where vitest's async timeout cannot fire — their own comment records this. Also worth noting for the reviewer: the test that actually broke release run [33676423730](https://github.com/QwenLM/qwen-code/actions/runs/33676423730), `upserts deferred findings into a per-PR issue that survives the merge`, is *not* among the six. It already runs on the suite ceiling, so #10870 did fix the reported failure; these six are the remainder.

`prettier --check` and `eslint` are clean on all three changed files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only, via the standalone probe described above (Node 22, vitest 3.2.4).

## Risk & Scope

- Main risk or tradeoff: test-infrastructure only, with no production code and no assertion changes. The worst case from the second half is that a genuinely hung case among the six now takes 90s instead of 30s to be called — which is precisely the trade the suite ceiling was chosen for. The `||` fix gives up the ability to pass `0` for "no timeout"; no caller does.
- Not validated / out of scope: no workflow wires `QWEN_SCRIPTS_TEST_TIMEOUT_MS` yet, so the empty-value path is latent and cannot be exercised end-to-end here; and `unit-vitest-configs.test.ts` itself only runs in CI, for the `vite-plugin-dts` reason above, so the rewritten pin's own green run comes from CI rather than from this machine.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #10870, where the empty-value fault was raised by @doudouOUC (S1) and @chiga0 (R3-1) and confirmed post-merge against a real build by @wenshao. The six ceiling removals were first proposed by @qwen-code-dev-bot in #10858, which now conflicts with the knob that landed in #10870 and is superseded here. Original contended-host failure: #10853.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 scripts 测试通道里一个旋钮 —— 它会静默解除自己本要设置的超时上限；并移除六处 per-test 上限，它们现在反过来压低了后来才有的套件级上限。两者都是 #10870 的后续。

## 为什么需要

#10870 给 scripts 套件设了 90 秒上限并带一个环境变量覆盖，写法是 `Number(process.env['QWEN_SCRIPTS_TEST_TIMEOUT_MS'] ?? 90_000)`。`??` 只捕获 `undefined`，所以空值会得到 `Number('')` —— 即 `0` —— 而 vitest 把 `0` 理解为*完全不设超时*。这个本意是*抬高*上限的旋钮，反而会把上限整个移除，真正卡死的测试将一直跑到 job 上限而不是在 90 秒时失败。拼写错误经由 `NaN` 走同一条路径。

`''` 不是假想的写法。它正是本仓库 `${{ cond && 'x' || '' }}` 惯用法在条件为假时渲染出的值，而这正是 #10870 在 `ci.yml` 里相邻一行新增的 `QWEN_SKIP_LATENCY_BUDGETS` 旋钮今天的接线方式。目前还没有任何 workflow 设置这个变量，所以该缺陷是潜伏而非活跃的 —— 这也是本 PR 作为常规后续而非热修的原因。

本该抓住它的那条 pin 抓不住。它先 stub `''`，紧接着在下一行调用 `vi.unstubAllEnvs()`，于是两个分支量的都是未设置路径，唯一会失败的取值在断言运行前就被丢弃了。

另外，`qwen-autofix-workflow.test.js` 中仍有六处 `}, 30000)`。它们早于套件级上限，如今反过来遮蔽了它，把恰恰是 90 秒默认值要保护的那批 spawn 子进程的测试压回旧的固定 30 秒 —— 就在最初导致 #10853 的同一批争抢主机上。六处没有一处把时长当作被测属性，每一处都只是「给这个 spawn 子进程的测试留余量」，最后一处在它自己的注释里就是这么写的。

## 评审验证方案

### 如何验证

修复用 `||` 替换 `??`，使一切非正数写法都回落到默认值。唯一放弃的是用 `0` 表示「不设超时」的能力，这是个坑而非特性，且没有调用方使用。

`scripts/tests/unit-vitest-configs.test.ts` 无法在 CI 之外运行：它导入所有工作区的 vitest 配置，而 `packages/webui/vite.config.ts` 需要 `vite-plugin-dts`，仅根目录安装并不包含它。该限制早于本 PR 且与之无关。因此下面的证据来自一个等价的独立探针，它只导入 `scripts/tests/vitest.config.ts`，并断言与重写后 pin 相同的五个分支，分别对旧表达式和新表达式各跑一次。

评审者应确认三点：`Number('')` 为 `0` 且 vitest 把 `testTimeout: 0` 当作无上限；重写后的 pin 对本 PR 替换掉的表达式失败、对新表达式通过；以及被移除的六处上限是在抬高 vitest 的 5 秒默认值，而不是在断言某个性能属性。

### 证据（前后对比）

被替换表达式的强制转换行为：

    Number(undefined ?? 90000) = 90000     Number('' ?? 90000) = 0     Number('abc' ?? 90000) = NaN     Number('5000' ?? 90000) = 5000

**修改前** —— 重写后的 pin 对旧的 `??` 表达式运行，在旧 pin 丢弃掉的那个分支上失败：

    stub=<unset> -> 90000 (want 90000)
    stub=""      -> 0     (want 90000)
    AssertionError: expected +0 to be 90000
    Tests  1 failed (1)

**修改后** —— 同一条 pin 对新的 `||` 表达式：

    stub=<unset> -> 90000 (want 90000)
    stub=""      -> 90000 (want 90000)
    stub="abc"   -> 90000 (want 90000)
    stub="0"     -> 90000 (want 90000)
    stub="5000"  -> 5000  (want 5000)
    Tests  1 passed (1)

用来去掉旧 pin 中 `if`/`else` 的 `vi.stubEnv(k, undefined)` 写法已对照已安装的 vitest 源码确认：`else if (value === void 0) delete process.env[name]`，且 `QWEN_SCRIPTS_TEST_TIMEOUT_MS` 不在 vitest 的 `_envBooleans` 特例表内，因此 `''` 会被原样存储。

关于移除的六处上限：文件中保留的三个 `timeout: 30_000` 是 `spawnSync` 的边界，刻意保留，因为 spawnSync 阻塞事件循环，vitest 的异步超时无法在那里触发 —— 它们自己的注释就记录了这一点。另外值得向评审者说明：真正导致 release run [33676423730](https://github.com/QwenLM/qwen-code/actions/runs/33676423730) 失败的那个用例 `upserts deferred findings into a per-PR issue that survives the merge` **不在**这六处之中。它已经跑在套件上限上，所以 #10870 确实修复了报告的那次失败；这六处是余下的部分。

三个改动文件的 `prettier --check` 与 `eslint` 均干净。

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元测试，通过上述独立探针运行（Node 22、vitest 3.2.4）。

## 风险与范围

- 主要风险或权衡：仅涉及测试基础设施，无生产代码、无断言改动。后半部分最坏的情况是六处中若真有卡死用例，现在需要 90 秒而非 30 秒才被判定 —— 而这正是选择套件级上限时所做的权衡。`||` 的修复放弃了用 `0` 表示「不设超时」的能力，没有调用方这样用。
- 未验证 / 范围之外：目前没有 workflow 接线 `QWEN_SCRIPTS_TEST_TIMEOUT_MS`，因此空值路径是潜伏的、无法在此做端到端验证；另外 `unit-vitest-configs.test.ts` 本身因上述 `vite-plugin-dts` 原因只能在 CI 中运行，所以重写后 pin 自身的绿色结果来自 CI 而非本机。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#10870 的后续，空值缺陷由 @doudouOUC（S1）与 @chiga0（R3-1）在该 PR 上提出，并由 @wenshao 在合并后对真实构建验证确认。六处上限的移除最早由 @qwen-code-dev-bot 在 #10858 中提出，该 PR 现与 #10870 落地的旋钮冲突，由本 PR 取代。最初的争抢主机失败：#10853。

</details>
