### PR TITLE
feat(serve): Fence Conversations writers with mandatory session leases

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -34,6 +34,8 @@ import {
   DAEMON_TRACESTATE_META_KEY,
   INVOCATION_CONTEXT_META_KEY,
   PRIVATE_ACP_CAPABILITY_ENV,
+  PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
+  PRIVATE_CONVERSATIONS_RUNTIME_ENV,
   PRIVATE_PARENT_CAPABILITY_META_KEY,
   SESSION_ARTIFACT_PERSISTENCE_VERSION,
   SESSION_PR_LIST_LIMIT,
@@ -52,6 +54,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import type { ShellCommandResult } from './bridgeTypes.js';
 import type { AcpChannel, AcpChannelTransportGuard } from './channel.js';
+import { channelFactoryForwardsChildEnv } from './child-env-forwarding.js';
 import {
   EventBus,
   DEFAULT_RING_SIZE,
@@ -2858,6 +2861,16 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     opts.childEnvOverrides
       ? Object.freeze({ ...opts.childEnvOverrides })
       : Object.freeze({});
+  // The mandatory-lease attestation is conjunctive: the frozen overrides must
+  // offer the exact Conversations marker AND the configured factory must be
+  // attested to forward overrides into the spawned child's environment. A
+  // marker-shaped override map paired with a factory that ignores its second
+  // argument does not attest, because the child would run unleased while the
+  // daemon believes the transcripts are fenced.
+  const mandatoryLeaseAttested =
+    childEnvOverrides[PRIVATE_CONVERSATIONS_RUNTIME_ENV] ===
+      PRIVATE_CONVERSATIONS_RUNTIME_ENABLE &&
+    channelFactoryForwardsChildEnv(channelFactory);
   const initTimeoutMs = opts.initializeTimeoutMs ?? DEFAULT_INIT_TIMEOUT_MS;
   if (!Number.isInteger(initTimeoutMs) || initTimeoutMs <= 0) {
     throw new TypeError(
@@ -9039,6 +9052,9 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     { dispatched: boolean }
   >();
   const bridgeApi: AcpSessionBridge = {
+    // Derived once from the frozen overrides and the configured channel
+    // factory; immutable for the bridge's lifetime.
+    mandatoryLeaseAttested,
     setLiveScreenContextCaptureHandler(handler) {
       liveScreenContextCaptureHandler = handler;
     },

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -1368,6 +1368,15 @@ export interface WorkspaceEventBridge extends WorkspaceEventPublisher {
 }
 
 export interface AcpSessionBridge extends WorkspaceEventBridge {
+  /**
+   * Immutable proof derived at construction: this bridge's frozen
+   * child-environment overrides carry the exact Conversations provenance
+   * marker AND its configured channel factory is attested to forward those
+   * overrides into the spawned child. The daemon requires this before it
+   * enables mandatory-lease-dependent behavior for the Conversations runtime.
+   */
+  readonly mandatoryLeaseAttested: boolean;
+
   /** Read-only daemon diagnostics for status endpoints. */
   getDaemonStatusSnapshot(): BridgeDaemonStatusSnapshot;
 

--- a/packages/acp-bridge/src/child-env-forwarding.test.ts
+++ b/packages/acp-bridge/src/child-env-forwarding.test.ts
@@ -1,0 +1,107 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
+  PRIVATE_CONVERSATIONS_RUNTIME_ENV,
+} from '@qwen-code/qwen-code-core';
+import type { ChannelFactory } from './channel.js';
+import { channelFactoryForwardsChildEnv } from './child-env-forwarding.js';
+import {
+  createSpawnChannelFactory,
+  defaultSpawnChannelFactory,
+} from './spawnChannel.js';
+import { createAcpSessionBridge } from './bridge.js';
+import { attestChannelFactoryForwardsChildEnv } from './internal/testUtils.js';
+
+const MARKER_OVERRIDES = {
+  [PRIVATE_CONVERSATIONS_RUNTIME_ENV]: PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
+} as const;
+
+const neverSpawns: ChannelFactory = async () => {
+  throw new Error('never spawned');
+};
+
+describe('child-env forwarding capability', () => {
+  it('marks every factory produced by createSpawnChannelFactory', () => {
+    expect(channelFactoryForwardsChildEnv(createSpawnChannelFactory())).toBe(
+      true,
+    );
+    expect(
+      channelFactoryForwardsChildEnv(
+        createSpawnChannelFactory({ onDiagnosticLine: () => undefined }),
+      ),
+    ).toBe(true);
+  });
+
+  it('marks the default factory because the same helper creates it', () => {
+    expect(channelFactoryForwardsChildEnv(defaultSpawnChannelFactory)).toBe(
+      true,
+    );
+  });
+
+  it('does not mark an arbitrary factory shape', () => {
+    expect(channelFactoryForwardsChildEnv(neverSpawns)).toBe(false);
+  });
+
+  it('lets a test fake attest deliberately through the test seam', () => {
+    const fake: ChannelFactory = async () => {
+      throw new Error('never spawned');
+    };
+    expect(channelFactoryForwardsChildEnv(fake)).toBe(false);
+    attestChannelFactoryForwardsChildEnv(fake);
+    expect(channelFactoryForwardsChildEnv(fake)).toBe(true);
+  });
+});
+
+describe('bridge mandatory-lease attestation', () => {
+  it('attests when the exact marker meets a forwarding factory', () => {
+    const bridge = createAcpSessionBridge({
+      boundWorkspace: '/work/conversations',
+      childEnvOverrides: { ...MARKER_OVERRIDES },
+    });
+    expect(bridge.mandatoryLeaseAttested).toBe(true);
+  });
+
+  it('does not attest a marker-shaped map with an unattested factory', () => {
+    const bridge = createAcpSessionBridge({
+      boundWorkspace: '/work/conversations',
+      childEnvOverrides: { ...MARKER_OVERRIDES },
+      channelFactory: neverSpawns,
+    });
+    expect(bridge.mandatoryLeaseAttested).toBe(false);
+  });
+
+  it('does not attest a forwarding factory without the exact marker', () => {
+    expect(
+      createAcpSessionBridge({
+        boundWorkspace: '/work/conversations',
+      }).mandatoryLeaseAttested,
+    ).toBe(false);
+    expect(
+      createAcpSessionBridge({
+        boundWorkspace: '/work/conversations',
+        childEnvOverrides: {
+          [PRIVATE_CONVERSATIONS_RUNTIME_ENV]: 'yes',
+        },
+      }).mandatoryLeaseAttested,
+    ).toBe(false);
+  });
+
+  it('attests a deliberately marked test factory carrying the marker', () => {
+    const fake: ChannelFactory = async () => {
+      throw new Error('never spawned');
+    };
+    attestChannelFactoryForwardsChildEnv(fake);
+    const bridge = createAcpSessionBridge({
+      boundWorkspace: '/work/conversations',
+      childEnvOverrides: { ...MARKER_OVERRIDES },
+      channelFactory: fake,
+    });
+    expect(bridge.mandatoryLeaseAttested).toBe(true);
+  });
+});

--- a/packages/acp-bridge/src/child-env-forwarding.ts
+++ b/packages/acp-bridge/src/child-env-forwarding.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ChannelFactory } from './channel.js';
+
+/**
+ * Package-owned attestation that a channel factory merges its
+ * `childEnvOverrides` argument into the spawned child's environment.
+ *
+ * The Conversations runtime's mandatory writer lease depends on a private
+ * provenance marker reaching the ACP child, and only the factory decides
+ * whether the bridge's overrides are forwarded. Membership is therefore
+ * granted solely by `createSpawnChannelFactory` (the production path that
+ * performs the merge through `scrubChildEnv`) or, for tests, by the
+ * deliberate `internal/testUtils` seam. This is a contract against
+ * accidental same-process miswiring, not a security boundary: embedding
+ * code can already construct arbitrary runtime objects.
+ */
+const forwardingFactories = new WeakSet<ChannelFactory>();
+
+export function markChannelFactoryForwardsChildEnv(
+  factory: ChannelFactory,
+): void {
+  forwardingFactories.add(factory);
+}
+
+export function channelFactoryForwardsChildEnv(
+  factory: ChannelFactory,
+): boolean {
+  return forwardingFactories.has(factory);
+}

--- a/packages/acp-bridge/src/internal/testUtils.ts
+++ b/packages/acp-bridge/src/internal/testUtils.ts
@@ -79,6 +79,15 @@ export const WS_B = path.resolve(path.sep, 'work', 'b');
 export const SESS_A = `sess:${WS_A}`;
 
 /**
+ * Deliberately attest that a test-fake channel factory forwards its
+ * `childEnvOverrides` argument into the child. Production factories receive
+ * this mark from `createSpawnChannelFactory`; test fakes must opt in
+ * explicitly so a shape-resembling but non-forwarding fake fails the
+ * bridge's mandatory-lease attestation.
+ */
+export { markChannelFactoryForwardsChildEnv as attestChannelFactoryForwardsChildEnv } from '../child-env-forwarding.js';
+
+/**
  * Convenience wrapper: `createAcpSessionBridge` requires the workspace owned
  * by this bridge. Tests that only ever talk
  * to `WS_A` would otherwise repeat `boundWorkspace: WS_A` everywhere;

--- a/packages/acp-bridge/src/spawnChannel.test.ts
+++ b/packages/acp-bridge/src/spawnChannel.test.ts
@@ -203,6 +203,27 @@ describe('createSpawnChannelFactory env policy', () => {
     expect(spawnOptions?.env?.['QWEN_CODE_NO_RELAUNCH']).toBe('true');
   });
 
+  it('merges non-scrubbed overrides into the spawned child env', async () => {
+    // Pins the behavior the forwarding attestation claims: the factory's
+    // second argument actually reaches the child. Dropping the overrides
+    // argument from the `scrubChildEnv` call must turn this red. The key must
+    // sit outside SCRUBBED_CHILD_ENV_KEYS — a scrubbed key would assert
+    // absence rather than forwarding.
+    mockSpawn.mockReturnValue(createFakeChildProcess());
+
+    const factory = createSpawnChannelFactory();
+    await factory('/tmp/project', {
+      QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME: '1',
+    });
+
+    const spawnOptions = mockSpawn.mock.calls[0]?.[2] as
+      | { env?: NodeJS.ProcessEnv }
+      | undefined;
+    expect(spawnOptions?.env?.['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME']).toBe(
+      '1',
+    );
+  });
+
   it('marks the spawned ACP child as daemon-spawned for telemetry', async () => {
     mockSpawn.mockReturnValue(createFakeChildProcess());
 

--- a/packages/acp-bridge/src/spawnChannel.ts
+++ b/packages/acp-bridge/src/spawnChannel.ts
@@ -24,6 +24,7 @@ import {
 } from '@agentclientprotocol/sdk/dist/schema/zod.gen.js';
 /* eslint-enable import/no-internal-modules */
 import type { ChannelFactory } from './channel.js';
+import { markChannelFactoryForwardsChildEnv } from './child-env-forwarding.js';
 import { redactLogCredentials } from './logRedaction.js';
 import {
   NdJsonQueueLimitError,
@@ -436,7 +437,11 @@ export function createSpawnChannelFactory(
 ): ChannelFactory {
   if (options.pipeLimits) validateNdJsonStreamLimits(options.pipeLimits);
   const processRegistry = options.processRegistry ?? new ProcessRegistry();
-  return async (workspaceCwd, childEnvOverrides, signal) => {
+  const factory: ChannelFactory = async (
+    workspaceCwd,
+    childEnvOverrides,
+    signal,
+  ) => {
     if (signal?.aborted) {
       throw signal.reason instanceof Error
         ? signal.reason
@@ -625,6 +630,8 @@ export function createSpawnChannelFactory(
       exited: trackedChild.exited,
     };
   };
+  markChannelFactoryForwardsChildEnv(factory);
+  return factory;
 }
 
 /**

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -3689,6 +3689,161 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     },
   );
 
+  it('forces the session writer lease for a Conversations-marked child regardless of the setting', async () => {
+    const innerConfig = await setupSessionMocks('session-writer-lease-marked');
+    innerConfig.getCronScheduler = vi
+      .fn()
+      .mockReturnValue({ setSkipDurableFire: vi.fn() });
+    mockConfig.isSessionWriterLeaseEnabled = vi.fn().mockReturnValue(false);
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+      {
+        privateParentCapability: 'expected-capability',
+        conversationsRuntimeProvenance: true,
+      },
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    await agent.initialize({
+      clientCapabilities: {},
+      _meta: {
+        'qwen-code/private-parent-capability': 'expected-capability',
+      },
+    });
+
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    const sessionSettings = vi.mocked(loadCliConfig).mock.calls[0]?.[0];
+    expect(sessionSettings?.experimental?.sessionWriterLease).toBe(true);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('selects the hardened local reclaim policy for a Conversations-marked managed child', async () => {
+    const innerConfig = await setupSessionMocks('managed-marked-session');
+    const scheduler = { setSkipDurableFire: vi.fn() };
+    innerConfig.getCronScheduler = vi.fn().mockReturnValue(scheduler);
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+      {
+        privateParentCapability: 'expected-capability',
+        conversationsRuntimeProvenance: true,
+      },
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    await agent.initialize({
+      clientCapabilities: {},
+      _meta: {
+        'qwen-code/private-parent-capability': 'expected-capability',
+      },
+    });
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    expect(innerConfig.setSessionWriterReclaimPolicy).toHaveBeenCalledWith(
+      'local',
+    );
+    expect(innerConfig.setSessionWriterTakeoverPolicy).toHaveBeenCalledWith(
+      'certified',
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('installs the unbound-durable-task skip before the scheduler starts for a marked child', async () => {
+    const innerConfig = await setupSessionMocks('managed-cron-skip-session');
+    const scheduler = { setSkipDurableFire: vi.fn() };
+    innerConfig.getCronScheduler = vi.fn().mockReturnValue(scheduler);
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+      {
+        privateParentCapability: 'expected-capability',
+        conversationsRuntimeProvenance: true,
+      },
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    await agent.initialize({
+      clientCapabilities: {},
+      _meta: {
+        'qwen-code/private-parent-capability': 'expected-capability',
+      },
+    });
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    expect(scheduler.setSkipDurableFire).toHaveBeenCalledOnce();
+    const predicate = scheduler.setSkipDurableFire.mock.calls[0]?.[0] as (job: {
+      boundSessionId?: string;
+    }) => boolean;
+    expect(predicate({ boundSessionId: undefined })).toBe(true);
+    expect(predicate({ boundSessionId: 'session-1' })).toBe(false);
+    const startCronScheduler = (
+      lastSessionMock as unknown as {
+        startCronScheduler: ReturnType<typeof vi.fn>;
+      }
+    ).startCronScheduler;
+    expect(
+      scheduler.setSkipDurableFire.mock.invocationCallOrder[0]!,
+    ).toBeLessThan(startCronScheduler.mock.invocationCallOrder[0]!);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('does not install the skip predicate for an unmarked managed child', async () => {
+    const innerConfig = await setupSessionMocks('managed-unmarked-session');
+    const scheduler = { setSkipDurableFire: vi.fn() };
+    innerConfig.getCronScheduler = vi.fn().mockReturnValue(scheduler);
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+      { privateParentCapability: 'expected-capability' },
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    await agent.initialize({
+      clientCapabilities: {},
+      _meta: {
+        'qwen-code/private-parent-capability': 'expected-capability',
+      },
+    });
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    expect(innerConfig.setSessionWriterReclaimPolicy).toHaveBeenCalledWith(
+      'never',
+    );
+    expect(scheduler.setSkipDurableFire).not.toHaveBeenCalled();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it.each([
     ['channel', 'channel', false],
     ['scheduled task', 'scheduled_task', true],
@@ -4228,6 +4383,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       setSessionWriterReclaimPolicy: vi.fn(),
       setSessionWriterTakeoverPolicy: vi.fn(),
       setSessionSource: vi.fn(),
+      getCronScheduler: vi.fn(),
       getSessionSourceType: vi.fn().mockReturnValue(undefined),
       waitForMcpReady: vi.fn().mockResolvedValue(undefined),
       getModelsConfig: vi.fn().mockReturnValue({

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2690,17 +2690,24 @@ export async function runAcpAgent(
   argv: CliArgs,
   options?: {
     privateParentCapability?: string;
+    conversationsRuntimeProvenance?: boolean;
     externalToolGuardRequired?: boolean;
     externalToolGuardProviderAttached?: boolean;
   },
 ) {
+  // Conversations-runtime provenance, accepted by the CLI entry point only in
+  // ACP mode with the private parent capability present. Frozen for the
+  // process lifetime alongside the writer-lease snapshot.
+  const conversationsRuntimeProvenance =
+    options?.conversationsRuntimeProvenance === true;
   // Freeze the restart-required writer protocol before the first await.
   // Per-request settings reloads must not mix leased and legacy writers
   // within one ACP process lifetime.
   const sessionWriterLeaseEnabledAtStartup =
-    typeof config.isSessionWriterLeaseEnabled === 'function'
+    conversationsRuntimeProvenance ||
+    (typeof config.isSessionWriterLeaseEnabled === 'function'
       ? config.isSessionWriterLeaseEnabled()
-      : settings.merged.experimental?.sessionWriterLease === true;
+      : settings.merged.experimental?.sessionWriterLease === true);
   const privateParentCapability =
     options === undefined
       ? process.env[PRIVATE_ACP_CAPABILITY_ENV]
@@ -2855,6 +2862,7 @@ export async function runAcpAgent(
         sessionWriterLeaseEnabledAtStartup,
         managedToolInvocationGuard,
         externalToolGuardProviderAttached,
+        conversationsRuntimeProvenance,
       );
       return agentInstance;
     }, stream);
@@ -4515,6 +4523,7 @@ class QwenAgent implements Agent {
     private readonly sessionWriterLeaseEnabledAtStartup = false,
     private readonly managedToolInvocationGuard?: ToolInvocationGuard,
     private readonly externalToolGuardProviderAttached = false,
+    private readonly conversationsRuntimeProvenance = false,
   ) {
     // Pool kill switch via env var so operators can A/B compare or
     // roll back without rebuilding. `run-qwen-serve.ts` sets this when
@@ -13434,7 +13443,13 @@ class QwenAgent implements Agent {
     try {
       this.assertManagedSessionAdmission();
       if (this.isTrustedManagedParent()) {
-        config.setSessionWriterReclaimPolicy('never');
+        // A child carrying the Conversations provenance marker writes through
+        // the mandatory session writer lease and may reclaim a provably dead
+        // same-domain writer; ordinary managed children keep the container
+        // contract.
+        config.setSessionWriterReclaimPolicy(
+          this.conversationsRuntimeProvenance ? 'local' : 'never',
+        );
         config.setSessionWriterTakeoverPolicy('certified');
       }
     } catch (error) {
@@ -14014,6 +14029,14 @@ class QwenAgent implements Agent {
 
       // After replay and resume-state restoration so a durable cron fire can't
       // interleave with either.
+      if (this.conversationsRuntimeProvenance) {
+        // A Conversations session never fires an unbound durable task; the
+        // daemon keepalive commits exactly one controller binding through the
+        // cross-process task-file transaction first.
+        config
+          .getCronScheduler()
+          .setSkipDurableFire((job) => job.boundSessionId === undefined);
+      }
       session.startCronScheduler();
 
       setTimeout(() => {

--- a/packages/cli/src/config/environment.test.ts
+++ b/packages/cli/src/config/environment.test.ts
@@ -820,6 +820,9 @@ describe('loadEnvironment', () => {
     expect(
       process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'],
     ).toBeUndefined();
+    expect(
+      process.env['qwen_code_private_conversations_runtime'],
+    ).toBeUndefined();
     expect(process.env['RUNTIME_DOTENV']).toBe('allowed');
   });
 

--- a/packages/cli/src/config/environment.test.ts
+++ b/packages/cli/src/config/environment.test.ts
@@ -797,6 +797,32 @@ describe('loadEnvironment', () => {
     expect(process.env['RUNTIME_DOTENV']).toBe('allowed');
   });
 
+  // The private Conversations provenance marker is a fixed constant rather
+  // than a per-spawn nonce, so the home-scoped exemption from
+  // PROJECT_ENV_HARDCODED_EXCLUSIONS must not apply to it: a home `.env`
+  // could otherwise forge Conversations provenance onto an ordinary session.
+  it('never applies the private Conversations marker from user-level .env files', () => {
+    const workspace = makeWorkspace();
+    const qwenHome = makeWorkspace();
+    process.env['QWEN_HOME'] = qwenHome;
+    fs.writeFileSync(
+      path.join(qwenHome, '.env'),
+      [
+        'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME=1',
+        'qwen_code_private_conversations_runtime=1',
+        'RUNTIME_DOTENV=allowed',
+        '',
+      ].join('\n'),
+    );
+
+    loadEnvironment(testSettings({}), workspace);
+
+    expect(
+      process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'],
+    ).toBeUndefined();
+    expect(process.env['RUNTIME_DOTENV']).toBe('allowed');
+  });
+
   it('never applies loader-affecting keys from settings.env, including reload', () => {
     resetEnvironmentTrackingForTesting();
     const workspace = makeWorkspace();

--- a/packages/cli/src/config/environment.ts
+++ b/packages/cli/src/config/environment.ts
@@ -15,6 +15,7 @@ import {
   HOME_ENV_BOOTSTRAP_KEYS,
   isHardcodedProjectEnvExclusion,
   isLoaderEnvKey,
+  isPrivateProvenanceEnvKey,
   PROJECT_ENV_HARDCODED_EXCLUSIONS,
   reportRejectedLoaderKeys,
   resetLoaderKeyRejectionReportingForTesting,
@@ -458,6 +459,11 @@ function canApplyParsedEnvKey(
   // repopulate the slots scrubInheritedLoaderEnv() emptied and reopen the
   // #8653 cross-workspace vector.
   if (isLoaderEnvKey(key)) return false;
+  // Private daemon→child provenance markers are fixed constants, so unlike the
+  // hardcoded project tier they are rejected at every scope — a home `.env`
+  // must not be able to forge Conversations provenance onto an ordinary
+  // session either.
+  if (isPrivateProvenanceEnvKey(key)) return false;
   if (options.reload && isReloadExcludedKey(key)) return false;
   if (!envFile.isHomeScopedEnvFile && isHardcodedProjectEnvExclusion(key)) {
     return false;

--- a/packages/cli/src/config/shared-env-keys.test.ts
+++ b/packages/cli/src/config/shared-env-keys.test.ts
@@ -91,6 +91,20 @@ describe('PROJECT_ENV_HARDCODED_EXCLUSIONS', () => {
     expect(PROJECT_ENV_HARDCODED_EXCLUSIONS).toContain('DEV');
   });
 
+  // QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME is the private daemon-to-child
+  // Conversations provenance marker. A project `.env` or settings.env setting
+  // it would mark ordinary workspace children as Conversations-hosted,
+  // forcing the writer lease and the unbound-durable-task skip onto sessions
+  // the contract does not cover.
+  it('excludes the Conversations provenance marker from project env files', () => {
+    expect(PROJECT_ENV_HARDCODED_EXCLUSIONS).toContain(
+      'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME',
+    );
+    expect(
+      isHardcodedProjectEnvExclusion('qwen_code_private_conversations_runtime'),
+    ).toBe(true);
+  });
+
   // QWEN_SERVE_NEW_FILE_MODE sets the daemon-wide creation mode for
   // agent-written NEW files. A project `.env` flipping it to `system` would
   // silently widen file visibility (0600 -> umask-derived) for every

--- a/packages/cli/src/config/shared-env-keys.ts
+++ b/packages/cli/src/config/shared-env-keys.ts
@@ -7,7 +7,7 @@ import {
   QWEN_CODE_DESKTOP_ENV,
   QWEN_CODE_SERVE_ENV,
 } from './acp-channel-fallback.js';
-import { PRIVATE_CONVERSATIONS_RUNTIME_ENV } from '@qwen-code/qwen-code-core';
+import { PRIVATE_CONVERSATIONS_RUNTIME_ENV } from '@qwen-code/qwen-code-core/conversationsRuntimeMarker';
 
 import { writeStderrLineSafe } from '../utils/stdioHelpers.js';
 

--- a/packages/cli/src/config/shared-env-keys.ts
+++ b/packages/cli/src/config/shared-env-keys.ts
@@ -7,6 +7,7 @@ import {
   QWEN_CODE_DESKTOP_ENV,
   QWEN_CODE_SERVE_ENV,
 } from './acp-channel-fallback.js';
+import { PRIVATE_CONVERSATIONS_RUNTIME_ENV } from '@qwen-code/qwen-code-core';
 
 import { writeStderrLineSafe } from '../utils/stdioHelpers.js';
 
@@ -218,6 +219,11 @@ export const PROJECT_ENV_HARDCODED_EXCLUSIONS = [
   // distributed to every workspace's session children — reopening the #8653
   // vector for any repo whose .env happens to carry DEV=true.
   'DEV',
+  // The Conversations provenance marker is a private daemon-to-child signal:
+  // a project `.env` or settings.env must never mark an ordinary workspace
+  // child as Conversations-hosted (it would force the writer lease and the
+  // unbound-durable-task skip onto sessions the contract does not cover).
+  PRIVATE_CONVERSATIONS_RUNTIME_ENV,
 ];
 
 // Windows env lookup is case-insensitive, so exact-case membership would let

--- a/packages/cli/src/config/shared-env-keys.ts
+++ b/packages/cli/src/config/shared-env-keys.ts
@@ -259,6 +259,20 @@ export function isHardcodedProjectEnvExclusion(key: string): boolean {
   );
 }
 
+// Private daemon→child provenance markers. Unlike the private ACP capability
+// (a random per-spawn nonce), these are fixed constants, so a home-scoped
+// `.env` could forge one — and home-scoped files are deliberately exempt from
+// the hardcoded project exclusions above. No env file at any scope may set
+// them: the only legitimate carrier is the spawner's child env, which the CLI
+// entry point captures and deletes before any environment-file load.
+const PRIVATE_PROVENANCE_ENV_KEYS: ReadonlySet<string> = new Set([
+  PRIVATE_CONVERSATIONS_RUNTIME_ENV.toLowerCase(),
+]);
+
+export function isPrivateProvenanceEnvKey(key: string): boolean {
+  return PRIVATE_PROVENANCE_ENV_KEYS.has(key.toLowerCase());
+}
+
 export const HOME_ENV_BOOTSTRAP_KEYS = [
   'QWEN_HOME',
   'QWEN_RUNTIME_DIR',

--- a/packages/cli/src/llm.test.tsx
+++ b/packages/cli/src/llm.test.tsx
@@ -498,6 +498,181 @@ describe('llm.tsx main function', () => {
     processExitSpy.mockRestore();
   });
 
+  it('carries the Conversations marker through the relaunch only with the private capability', async () => {
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { relaunchAppInChildProcess } = await import('./utils/relaunch.js');
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(parseArguments).mockResolvedValue({ acp: true } as CliArgs);
+    vi.stubEnv('QWEN_CODE_PRIVATE_ACP_CAPABILITY', 'private-capability');
+    vi.stubEnv('QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME', '1');
+    vi.stubEnv('QWEN_CODE_NO_RELAUNCH', '');
+
+    vi.mocked(relaunchAppInChildProcess).mockImplementation(
+      async (_memoryArgs, _extraArgs, options) => {
+        expect(
+          process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'],
+        ).toBeUndefined();
+        expect(options?.childEnv).toEqual({
+          QWEN_CODE_PRIVATE_ACP_CAPABILITY: 'private-capability',
+          QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME: '1',
+        });
+      },
+    );
+    vi.mocked(loadCliConfig).mockImplementation(async () => {
+      // A user-level .env must not reintroduce the marker after settings and
+      // environment loading; the accepted value already lives in the relaunch
+      // payload.
+      expect(
+        process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'],
+      ).toBeUndefined();
+      return {
+        isInteractive: () => false,
+        getQuestion: () => '',
+        getSandbox: () => false,
+        getApprovalMode: () => ApprovalMode.DEFAULT,
+        getDebugMode: () => false,
+        getListExtensions: () => false,
+        getMcpServers: () => ({}),
+        getTopTierMcpServers: () => undefined,
+        getModelProvidersConfig: () => undefined,
+        initialize: vi.fn(),
+        waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+        getIdeMode: () => false,
+        getExperimentalZedIntegration: () => false,
+        getScreenReader: () => false,
+        getMemoryFileCount: () => 0,
+        getProjectRoot: () => '/',
+        getOutputFormat: () => OutputFormat.TEXT,
+        getWarnings: () => [],
+        isSafeMode: () => false,
+        getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+        getSessionId: () => 'test-session-id',
+      } as unknown as Config;
+    });
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: { autoConfigureMemory: true },
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    try {
+      try {
+        await main();
+      } catch (e) {
+        // Mocked process exit throws an error.
+        if (!(e instanceof MockProcessExitError)) throw e;
+      }
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(relaunchAppInChildProcess).toHaveBeenCalledWith(
+      expect.any(Array),
+      [],
+      expect.objectContaining({
+        childEnv: {
+          QWEN_CODE_PRIVATE_ACP_CAPABILITY: 'private-capability',
+          QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME: '1',
+        },
+        onUpdateRelaunch: expect.any(Function),
+      }),
+    );
+    processExitSpy.mockRestore();
+  });
+
+  it('does not accept the Conversations marker without the private capability', async () => {
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { relaunchAppInChildProcess } = await import('./utils/relaunch.js');
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(parseArguments).mockResolvedValue({ acp: true } as CliArgs);
+    vi.stubEnv('QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME', '1');
+    vi.stubEnv('QWEN_CODE_NO_RELAUNCH', '');
+
+    vi.mocked(relaunchAppInChildProcess).mockImplementation(
+      async (_memoryArgs, _extraArgs, options) => {
+        expect(options?.childEnv ?? {}).not.toHaveProperty(
+          'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME',
+        );
+      },
+    );
+    vi.mocked(loadCliConfig).mockImplementation(
+      async () =>
+        ({
+          isInteractive: () => false,
+          getQuestion: () => '',
+          getSandbox: () => false,
+          getApprovalMode: () => ApprovalMode.DEFAULT,
+          getDebugMode: () => false,
+          getListExtensions: () => false,
+          getMcpServers: () => ({}),
+          getTopTierMcpServers: () => undefined,
+          getModelProvidersConfig: () => undefined,
+          initialize: vi.fn(),
+          waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+          getIdeMode: () => false,
+          getExperimentalZedIntegration: () => false,
+          getScreenReader: () => false,
+          getMemoryFileCount: () => 0,
+          getProjectRoot: () => '/',
+          getOutputFormat: () => OutputFormat.TEXT,
+          getWarnings: () => [],
+          isSafeMode: () => false,
+          getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+          getSessionId: () => 'test-session-id',
+        }) as unknown as Config,
+    );
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: { autoConfigureMemory: true },
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    try {
+      try {
+        await main();
+      } catch (e) {
+        if (!(e instanceof MockProcessExitError)) throw e;
+      }
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(relaunchAppInChildProcess).toHaveBeenCalled();
+    processExitSpy.mockRestore();
+  });
+
   it('handles --list-extensions before sandbox and app config startup', async () => {
     vi.clearAllMocks();
     const processExitSpy = vi

--- a/packages/cli/src/llm.test.tsx
+++ b/packages/cli/src/llm.test.tsx
@@ -918,6 +918,73 @@ describe('llm.tsx main function', () => {
     );
   });
 
+  // The accepted path through the sandbox handoff: `serve/sandbox.ts` merges
+  // `{ ...process.env, ...childEnv }` with childEnv last, so an accepted
+  // marker must ride in the childEnv argument — the pre-spawn scrub keeps it
+  // out of process.env by design.
+  it('carries the Conversations marker into the sandbox handoff when provenance is accepted', async () => {
+    const originalArgv = process.argv;
+    process.argv = ['node', 'script.js', '--acp'];
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    const { start_sandbox } = await import('./serve/sandbox.js');
+    vi.mocked(start_sandbox).mockClear();
+    vi.mocked(parseArguments).mockResolvedValue({ acp: true } as CliArgs);
+    vi.stubEnv('QWEN_CODE_PRIVATE_ACP_CAPABILITY', 'private-capability');
+    vi.stubEnv('QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME', '1');
+
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: { advanced: {}, security: { auth: {} }, ui: {} },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadSandboxConfig).mockResolvedValue({
+      command: 'sandbox-exec',
+      image: 'ghcr.io/qwenlm/qwen-code:1.0.0',
+    });
+    vi.mocked(loadCliConfig).mockImplementation(
+      async () =>
+        ({
+          getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+          getSessionId: () => '123e4567-e89b-12d3-a456-426614174000',
+        }) as unknown as Config,
+    );
+    vi.mocked(start_sandbox).mockImplementation(
+      (async () => 0) as unknown as typeof start_sandbox,
+    );
+
+    try {
+      try {
+        await main();
+      } catch (e) {
+        if (!(e instanceof MockProcessExitError)) throw e;
+      }
+    } finally {
+      process.argv = originalArgv;
+      delete process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'];
+      vi.unstubAllEnvs();
+      processExitSpy.mockRestore();
+    }
+
+    expect(start_sandbox).toHaveBeenCalledOnce();
+    expect(vi.mocked(start_sandbox).mock.calls[0]?.[4]).toEqual({
+      QWEN_CODE_PRIVATE_ACP_CAPABILITY: 'private-capability',
+      QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME: '1',
+    });
+  });
+
   it('handles --list-extensions before sandbox and app config startup', async () => {
     vi.clearAllMocks();
     const processExitSpy = vi

--- a/packages/cli/src/llm.test.tsx
+++ b/packages/cli/src/llm.test.tsx
@@ -673,6 +673,251 @@ describe('llm.tsx main function', () => {
     processExitSpy.mockRestore();
   });
 
+  it('rejects a Conversations marker whose value is not the exact enable value', async () => {
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { relaunchAppInChildProcess } = await import('./utils/relaunch.js');
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(parseArguments).mockResolvedValue({ acp: true } as CliArgs);
+    vi.stubEnv('QWEN_CODE_PRIVATE_ACP_CAPABILITY', 'private-capability');
+    // A stray marker exported while debugging the daemon must not be accepted.
+    vi.stubEnv('QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME', 'yes');
+    vi.stubEnv('QWEN_CODE_NO_RELAUNCH', '');
+
+    vi.mocked(relaunchAppInChildProcess).mockImplementation(
+      async (_memoryArgs, _extraArgs, options) => {
+        expect(options?.childEnv).toEqual({
+          QWEN_CODE_PRIVATE_ACP_CAPABILITY: 'private-capability',
+        });
+      },
+    );
+    vi.mocked(loadCliConfig).mockImplementation(
+      async () =>
+        ({
+          isInteractive: () => false,
+          getQuestion: () => '',
+          getSandbox: () => false,
+          getApprovalMode: () => ApprovalMode.DEFAULT,
+          getDebugMode: () => false,
+          getListExtensions: () => false,
+          getMcpServers: () => ({}),
+          getTopTierMcpServers: () => undefined,
+          getModelProvidersConfig: () => undefined,
+          initialize: vi.fn(),
+          waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+          getIdeMode: () => false,
+          getExperimentalZedIntegration: () => false,
+          getScreenReader: () => false,
+          getMemoryFileCount: () => 0,
+          getProjectRoot: () => '/',
+          getOutputFormat: () => OutputFormat.TEXT,
+          getWarnings: () => [],
+          isSafeMode: () => false,
+          getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+          getSessionId: () => 'test-session-id',
+        }) as unknown as Config,
+    );
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: { autoConfigureMemory: true },
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    try {
+      try {
+        await main();
+      } catch (e) {
+        if (!(e instanceof MockProcessExitError)) throw e;
+      }
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    expect(relaunchAppInChildProcess).toHaveBeenCalled();
+    processExitSpy.mockRestore();
+  });
+
+  it('scrubs a marker re-introduced by environment loading before the relaunch', async () => {
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { relaunchAppInChildProcess } = await import('./utils/relaunch.js');
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(parseArguments).mockResolvedValue({ acp: true } as CliArgs);
+    // No marker at entry: this is an ordinary ACP session, so provenance is
+    // denied and `privateAcpChildEnv` carries only the capability.
+    delete process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'];
+    vi.stubEnv('QWEN_CODE_NO_RELAUNCH', '');
+
+    vi.mocked(loadSettings).mockImplementation(() => {
+      // A home-scoped `.env` is applied during settings/environment loading,
+      // after the entry-point capture. The relaunch env is
+      // `{ ...process.env, ...childEnv }`, so scrubbing process.env is the
+      // only defense on this branch.
+      process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'] = '1';
+      return {
+        errors: [],
+        merged: {
+          advanced: { autoConfigureMemory: true },
+          security: { auth: {} },
+          ui: {},
+        },
+        setValue: vi.fn(),
+        forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+        migrationWarnings: [],
+        getUserHooks: () => undefined,
+        getProjectHooks: () => undefined,
+      } as never;
+    });
+    vi.mocked(relaunchAppInChildProcess).mockImplementation(
+      async (_memoryArgs, _extraArgs, options) => {
+        expect(
+          process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'],
+        ).toBeUndefined();
+        expect(options?.childEnv ?? {}).not.toHaveProperty(
+          'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME',
+        );
+      },
+    );
+    vi.mocked(loadCliConfig).mockImplementation(
+      async () =>
+        ({
+          isInteractive: () => false,
+          getQuestion: () => '',
+          getSandbox: () => false,
+          getApprovalMode: () => ApprovalMode.DEFAULT,
+          getDebugMode: () => false,
+          getListExtensions: () => false,
+          getMcpServers: () => ({}),
+          getTopTierMcpServers: () => undefined,
+          getModelProvidersConfig: () => undefined,
+          initialize: vi.fn(),
+          waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+          getIdeMode: () => false,
+          getExperimentalZedIntegration: () => false,
+          getScreenReader: () => false,
+          getMemoryFileCount: () => 0,
+          getProjectRoot: () => '/',
+          getOutputFormat: () => OutputFormat.TEXT,
+          getWarnings: () => [],
+          isSafeMode: () => false,
+          getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+          getSessionId: () => 'test-session-id',
+        }) as unknown as Config,
+    );
+    try {
+      try {
+        await main();
+      } catch (e) {
+        if (!(e instanceof MockProcessExitError)) throw e;
+      }
+    } finally {
+      delete process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'];
+      vi.unstubAllEnvs();
+    }
+
+    expect(relaunchAppInChildProcess).toHaveBeenCalled();
+    processExitSpy.mockRestore();
+  });
+
+  it('scrubs a re-injected Conversations marker before the sandbox handoff', async () => {
+    const originalArgv = process.argv;
+    process.argv = ['node', 'script.js', '--acp', '-p', 'hello'];
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    const { start_sandbox } = await import('./serve/sandbox.js');
+    vi.mocked(start_sandbox).mockClear();
+    vi.mocked(parseArguments).mockResolvedValue({
+      acp: true,
+      prompt: 'hello',
+    } as unknown as CliArgs);
+    vi.stubEnv('QWEN_CODE_PRIVATE_ACP_CAPABILITY', 'private-capability');
+    // No marker at entry, so the parent denies Conversations provenance.
+    delete process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'];
+
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: { advanced: {}, security: { auth: {} }, ui: {} },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadSandboxConfig).mockResolvedValue({
+      command: 'sandbox-exec',
+      image: 'ghcr.io/qwenlm/qwen-code:1.0.0',
+    });
+    vi.mocked(loadCliConfig).mockImplementation(async () => {
+      // Auth validation re-runs the environment load after the post-settings
+      // scrub; a home-scoped `.env` re-applies the marker here.
+      process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'] = '1';
+      return {
+        getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+        getSessionId: () => '123e4567-e89b-12d3-a456-426614174000',
+      } as unknown as Config;
+    });
+
+    let markerAtSpawn: string | undefined;
+    vi.mocked(start_sandbox).mockImplementation((async () => {
+      markerAtSpawn = process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'];
+      return 0;
+    }) as unknown as typeof start_sandbox);
+
+    try {
+      try {
+        await main();
+      } catch (e) {
+        if (!(e instanceof MockProcessExitError)) throw e;
+      }
+    } finally {
+      process.argv = originalArgv;
+      delete process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'];
+      vi.unstubAllEnvs();
+      processExitSpy.mockRestore();
+    }
+
+    // The seatbelt spawn merges `{ ...process.env, ...childEnv }`, so a marker
+    // left in process.env would reach a child that also inherits the
+    // capability and `--acp` — accepting provenance the parent denied.
+    expect(start_sandbox).toHaveBeenCalledOnce();
+    expect(markerAtSpawn).toBeUndefined();
+    const childEnv = vi.mocked(start_sandbox).mock.calls[0]?.[4];
+    expect(childEnv ?? {}).not.toHaveProperty(
+      'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME',
+    );
+  });
+
   it('handles --list-extensions before sandbox and app config startup', async () => {
     vi.clearAllMocks();
     const processExitSpy = vi

--- a/packages/cli/src/llm.tsx
+++ b/packages/cli/src/llm.tsx
@@ -19,6 +19,8 @@ import {
   createDebugLogger,
   persistSessionUsage,
   PRIVATE_ACP_CAPABILITY_ENV,
+  PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
+  PRIVATE_CONVERSATIONS_RUNTIME_ENV,
   uiTelemetryService,
 } from '@qwen-code/qwen-code-core';
 import {
@@ -384,6 +386,14 @@ export async function main() {
 
   const privateAcpParentCapability = process.env[PRIVATE_ACP_CAPABILITY_ENV];
   delete process.env[PRIVATE_ACP_CAPABILITY_ENV];
+  // Captured beside the private parent capability so a Conversations
+  // provenance marker can never be introduced or withdrawn later by settings
+  // or environment files; acceptance below additionally requires ACP mode and
+  // the capability.
+  const conversationsRuntimeMarkerSeen =
+    process.env[PRIVATE_CONVERSATIONS_RUNTIME_ENV] ===
+    PRIVATE_CONVERSATIONS_RUNTIME_ENABLE;
+  delete process.env[PRIVATE_CONVERSATIONS_RUNTIME_ENV];
   const privateExternalToolGuard =
     process.env[PRIVATE_EXTERNAL_TOOL_GUARD_ENV] ===
     EXTERNAL_TOOL_GUARD_REQUIRED_VALUE
@@ -415,10 +425,20 @@ export async function main() {
   markAcpStartup('argsParseEnd');
   profileCheckpoint('after_parse_arguments');
   const isAcpMode = argv.acp || argv.experimentalAcp;
+  const conversationsRuntimeProvenance =
+    isAcpMode &&
+    privateAcpParentCapability !== undefined &&
+    conversationsRuntimeMarkerSeen;
   const privateAcpChildEnv =
     isAcpMode && privateAcpParentCapability !== undefined
       ? {
           [PRIVATE_ACP_CAPABILITY_ENV]: privateAcpParentCapability,
+          ...(conversationsRuntimeProvenance
+            ? {
+                [PRIVATE_CONVERSATIONS_RUNTIME_ENV]:
+                  PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
+              }
+            : {}),
           ...(privateExternalToolGuard
             ? {
                 [PRIVATE_EXTERNAL_TOOL_GUARD_ENV]: privateExternalToolGuard,
@@ -453,6 +473,9 @@ export async function main() {
     ? createMinimalSettings()
     : loadSettings();
   markAcpStartup('settingsLoadEnd');
+  // A user-level .env or settings reload may have reintroduced the marker;
+  // the accepted value already lives in immutable local state.
+  delete process.env[PRIVATE_CONVERSATIONS_RUNTIME_ENV];
 
   // Propagate corruption state to child process via env vars so
   // relaunchAppInChildProcess() doesn't lose the marker.
@@ -1119,6 +1142,7 @@ export async function main() {
           privateParentCapability: isAcpMode
             ? privateAcpParentCapability
             : undefined,
+          conversationsRuntimeProvenance,
           externalToolGuardRequired:
             isAcpMode &&
             privateAcpParentCapability !== undefined &&

--- a/packages/cli/src/llm.tsx
+++ b/packages/cli/src/llm.tsx
@@ -705,6 +705,12 @@ export async function main() {
           )
         : injectStdinIntoArgs(process.argv, stdinData);
 
+      // The seatbelt spawn merges `{ ...process.env, ...childEnv }`, so the
+      // marker must not be sitting in process.env at the handoff: auth
+      // validation above re-runs the environment load, and the accepted
+      // provenance travels in `privateAcpChildEnv`, which is spread last.
+      delete process.env[PRIVATE_CONVERSATIONS_RUNTIME_ENV];
+
       await relaunchOnExitCode(
         () =>
           start_sandbox(

--- a/packages/cli/src/serve/conversations/conversation-runtime-manager.test.ts
+++ b/packages/cli/src/serve/conversations/conversation-runtime-manager.test.ts
@@ -28,8 +28,9 @@ const root = {
   inodeVerifiable: true,
 };
 
-function createBridge() {
+function createBridge(mandatoryLeaseAttested = true) {
   return {
+    mandatoryLeaseAttested,
     preheat: vi.fn(async () => undefined),
     setLiveScreenContextCaptureHandler: vi.fn(),
     setLiveTaskToolRequestHandler: vi.fn(),
@@ -452,6 +453,66 @@ describe('ConversationRuntimeManager', () => {
       retryable: false,
     });
     expect(publishRuntime).not.toHaveBeenCalled();
+  });
+
+  it('rejects and does not publish a candidate missing the mandatory-lease attestation', async () => {
+    const candidate = createOwnedRuntime(createBridge(false));
+    const registry = createRegistry();
+    const publishRuntime = vi.fn(
+      async (_cwd: string, validate: (runtime: WorkspaceRuntime) => void) => {
+        await validate(candidate);
+        throw new Error('unreachable: validation must reject the candidate');
+      },
+    );
+    const manager = createManager({
+      workspace: createWorkspace(),
+      registry,
+      publishRuntime,
+    });
+
+    await expect(manager.ensure()).rejects.toMatchObject({
+      code: 'conversation_root_compromised',
+      retryable: false,
+    });
+    expect(publishRuntime).toHaveBeenCalledOnce();
+    expect(
+      registry.getManagedEntryByWorkspaceCwd(root.canonicalRoot),
+    ).toBeUndefined();
+  });
+
+  it('terminally quarantines a registered runtime missing the mandatory-lease attestation', async () => {
+    const candidate = createOwnedRuntime(createBridge(false));
+    const registry = createRegistry(candidate);
+    const quarantineRuntime = vi.fn(async () => undefined);
+    const onTerminalQuarantine = vi.fn();
+    const publishRuntime = vi.fn();
+    const manager = createManager({
+      workspace: createWorkspace(),
+      registry,
+      publishRuntime,
+      quarantineRuntime,
+      onTerminalQuarantine,
+    });
+
+    await expect(manager.ensure()).rejects.toMatchObject({
+      code: 'conversation_root_compromised',
+      retryable: false,
+    });
+    expect(quarantineRuntime).toHaveBeenCalledWith(
+      candidate,
+      'missing_mandatory_lease_attestation',
+    );
+    expect(publishRuntime).not.toHaveBeenCalled();
+    // The static contract violation keeps its non-retryable classification on
+    // every later access instead of degrading to retryable
+    // `conversation_runtime_unavailable`.
+    await expect(manager.ensure()).rejects.toMatchObject({
+      code: 'conversation_root_compromised',
+      retryable: false,
+    });
+    expect(() => manager.assertCurrent(candidate)).toThrowError(
+      expect.objectContaining({ code: 'conversation_root_compromised' }),
+    );
   });
 
   it.each(['draining', 'blocked'] as const)(

--- a/packages/cli/src/serve/conversations/conversation-runtime-manager.ts
+++ b/packages/cli/src/serve/conversations/conversation-runtime-manager.ts
@@ -18,7 +18,8 @@ import type {
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 
 export type ConversationRuntimeQuarantineReason =
-  'standalone_session_containment_failed';
+  | 'standalone_session_containment_failed'
+  | 'missing_mandatory_lease_attestation';
 
 export interface ConversationRuntimeManagerOptions {
   ownership: ConversationRuntimeOwnership;
@@ -42,13 +43,16 @@ export class ConversationRuntimeManager {
   private runtime?: WorkspaceRuntime;
   private pending?: Promise<WorkspaceRuntime>;
   private terminalRuntime?: WorkspaceRuntime;
+  private terminalError?: ConversationRuntimeOwnershipError;
   private quarantinePromise?: Promise<void>;
 
   constructor(private readonly options: ConversationRuntimeManagerOptions) {}
 
   ensure(): Promise<WorkspaceRuntime> {
     if (this.terminalRuntime) {
-      return Promise.reject(conversationRuntimeUnavailableError());
+      return Promise.reject(
+        this.terminalError ?? conversationRuntimeUnavailableError(),
+      );
     }
     if (this.pending) return this.pending;
     const pending = this.ensureOnce().finally(() => {
@@ -74,12 +78,20 @@ export class ConversationRuntimeManager {
     if (this.terminalRuntime === expectedRuntime && this.quarantinePromise) {
       return this.quarantinePromise;
     }
-    if (this.terminalRuntime) throw conversationRuntimeUnavailableError();
+    if (this.terminalRuntime) {
+      throw this.terminalError ?? conversationRuntimeUnavailableError();
+    }
     if (this.runtime !== expectedRuntime) {
       throw conversationRuntimeUnavailableError();
     }
     this.assertActiveRuntime(expectedRuntime.workspaceCwd, expectedRuntime);
     this.terminalRuntime = expectedRuntime;
+    if (reason === 'missing_mandatory_lease_attestation') {
+      // A static runtime contract violation never heals in place; keep every
+      // later access on the same non-retryable classification instead of
+      // degrading to retryable `conversation_runtime_unavailable`.
+      this.terminalError = conversationRootCompromisedError();
+    }
     try {
       this.options.onTerminalQuarantine?.(expectedRuntime, reason);
     } catch {
@@ -123,6 +135,17 @@ export class ConversationRuntimeManager {
       await this.assertExactRoot(existing.workspaceCwd);
       this.assertActiveRuntime(root.canonicalRoot, existing);
       this.runtime = existing;
+      try {
+        this.assertMandatoryLeaseAttestation(existing);
+      } catch (error) {
+        // An equivalent registered runtime that cannot prove the mandatory
+        // lease reaches its children is terminally quarantined, never served.
+        await this.quarantine(
+          existing,
+          'missing_mandatory_lease_attestation',
+        ).catch(() => undefined);
+        throw error;
+      }
       this.assertNotTerminal();
       return existing;
     }
@@ -134,6 +157,7 @@ export class ConversationRuntimeManager {
         async (candidate) => {
           await this.assertExactRoot(candidate.workspaceCwd);
           this.assertOwnedRuntime(candidate);
+          this.assertMandatoryLeaseAttestation(candidate);
         },
       );
     } catch (error) {
@@ -147,7 +171,9 @@ export class ConversationRuntimeManager {
   }
 
   private assertNotTerminal(): void {
-    if (this.terminalRuntime) throw conversationRuntimeUnavailableError();
+    if (this.terminalRuntime) {
+      throw this.terminalError ?? conversationRuntimeUnavailableError();
+    }
   }
 
   private async revalidateRoot(): Promise<
@@ -189,6 +215,12 @@ export class ConversationRuntimeManager {
       !runtime.trusted ||
       runtime.removable !== false
     ) {
+      throw conversationRootCompromisedError();
+    }
+  }
+
+  private assertMandatoryLeaseAttestation(runtime: WorkspaceRuntime): void {
+    if (runtime.bridge.mandatoryLeaseAttested !== true) {
       throw conversationRootCompromisedError();
     }
   }

--- a/packages/cli/src/serve/conversations/standalone-session-service.test.ts
+++ b/packages/cli/src/serve/conversations/standalone-session-service.test.ts
@@ -704,6 +704,16 @@ describe('StandaloneSessionService', () => {
     );
     expect(lease.assertOwnedAndUnchanged).toHaveBeenCalledOnce();
     expect(ordinaryRename).not.toHaveBeenCalled();
+    // Parent-side lifecycle acquisitions on the Conversations runtime use the
+    // hardened local reclaim policy shared with the ACP writer they fence.
+    expect(
+      vi.mocked(SessionService.prototype.acquireSessionWriterLease).mock
+        .calls[0]?.[1],
+    ).toEqual({
+      processKind: 'daemon',
+      reclaimPolicy: 'local',
+      takeoverPolicy: 'certified',
+    });
   });
 
   it.each(['', '   ', 'bad\nname', 'x'.repeat(257)])(
@@ -823,7 +833,7 @@ describe('StandaloneSessionService', () => {
       errors: [
         {
           sessionId,
-          code: 'standalone_session_operation_failed',
+          code: 'session_writer_lost',
         },
       ],
     });
@@ -856,7 +866,7 @@ describe('StandaloneSessionService', () => {
         errors: [
           {
             sessionId,
-            code: 'standalone_session_operation_failed',
+            code: 'session_writer_lost',
           },
         ],
       },
@@ -2586,6 +2596,155 @@ describe('StandaloneSessionService', () => {
       harness.bridge.releaseManagedConversationBinding,
     ).toHaveBeenCalledOnce();
     expect(harness.restoreReservation.release).toHaveBeenCalledOnce();
+  });
+
+  it('adopts a safely recreated directory once the local generation is gone', async () => {
+    mockActiveStandalone();
+    const harness = createHarness();
+    await harness.service.load(sessionId);
+
+    // Idle reap: the bridge forgets the session. Another participant may then
+    // legitimately recreate the directory with a fresh identity.
+    harness.bridge.getSessionSummary.mockImplementationOnce(() => {
+      throw new SessionNotFoundError(sessionId);
+    });
+    harness.bridge.getSessionEventEpoch.mockImplementationOnce(() => {
+      throw new SessionNotFoundError(sessionId);
+    });
+    const recreated = { ...identity, inode: identity.inode + 1 };
+    harness.inspectStandaloneDirectory.mockClear();
+    harness.inspectStandaloneDirectory.mockResolvedValueOnce({
+      status: 'ready',
+      identity: recreated,
+    });
+
+    await expect(harness.service.load(sessionId)).resolves.toMatchObject({
+      sessionId,
+      currentCwd: recreated.canonicalPath,
+      workingDirectory: { state: 'ready' },
+    });
+    // The orphaned pin was discarded before the directory was inspected:
+    // no stale `expected` identity condemned the recreated directory.
+    expect(harness.inspectStandaloneDirectory.mock.calls[0]).toEqual([
+      sessionId,
+      undefined,
+    ]);
+  });
+
+  it('fails closed when the directory identity changes while its generation is resident', async () => {
+    mockActiveStandalone();
+    const harness = createHarness();
+    await harness.service.load(sessionId);
+
+    harness.inspectStandaloneDirectory.mockClear();
+    harness.inspectStandaloneDirectory.mockResolvedValueOnce({
+      status: 'compromised',
+    });
+
+    await expect(harness.service.load(sessionId)).rejects.toMatchObject({
+      code: 'working_directory_compromised',
+      sessionId,
+    });
+    // The resident generation's pin remains authoritative as `expected`.
+    expect(harness.inspectStandaloneDirectory.mock.calls[0]).toEqual([
+      sessionId,
+      identity,
+    ]);
+  });
+
+  it('discards the pin when the resident generation was replaced', async () => {
+    mockActiveStandalone();
+    const harness = createHarness();
+    await harness.service.load(sessionId);
+
+    harness.bridge.getSessionEventEpoch.mockReturnValue('epoch-2');
+    const recreated = { ...identity, inode: identity.inode + 1 };
+    harness.inspectStandaloneDirectory.mockClear();
+    harness.inspectStandaloneDirectory.mockResolvedValueOnce({
+      status: 'ready',
+      identity: recreated,
+    });
+    harness.bridge.restoreStandaloneSession.mockResolvedValue({
+      sessionId,
+      workspaceCwd: root.canonicalRoot,
+      currentCwd: recreated.canonicalPath,
+      attached: true,
+      clientId: 'attached-client',
+      sourceType: 'standalone',
+      state: {},
+    });
+
+    await expect(harness.service.load(sessionId)).resolves.toMatchObject({
+      attached: true,
+    });
+    expect(harness.inspectStandaloneDirectory.mock.calls[0]).toEqual([
+      sessionId,
+      undefined,
+    ]);
+  });
+
+  it('fails closed when the bridge probe of the resident generation is indeterminate', async () => {
+    mockActiveStandalone();
+    const harness = createHarness();
+    await harness.service.load(sessionId);
+
+    const probeFailure = new Error('bridge probe failed');
+    harness.bridge.getSessionSummary.mockImplementationOnce(() => {
+      throw new SessionNotFoundError(sessionId);
+    });
+    harness.bridge.getSessionEventEpoch.mockImplementationOnce(() => {
+      throw probeFailure;
+    });
+
+    await expect(harness.service.load(sessionId)).rejects.toBe(probeFailure);
+  });
+
+  it('inspects the directory fresh when deleting after the local generation exited', async () => {
+    mockActiveStandalone();
+    const harness = createHarness();
+    await harness.service.load(sessionId);
+
+    // The session is then closed or reaped: nothing resident remains.
+    let live = true;
+    harness.bridge.getSessionSummary.mockImplementation(() => {
+      if (!live) throw new SessionNotFoundError(sessionId);
+      return {
+        sessionId,
+        workspaceCwd: root.canonicalRoot,
+        createdAt: '2026-08-24T00:00:00.000Z',
+        sourceType: 'standalone',
+        clientCount: 0,
+        hasActivePrompt: false,
+      };
+    });
+    harness.bridge.killSession.mockImplementation(async () => {
+      live = false;
+      return true;
+    });
+    harness.bridge.getSessionEventEpoch.mockImplementation(() => {
+      throw new SessionNotFoundError(sessionId);
+    });
+    const lease = mockWriterLease();
+    vi.spyOn(
+      SessionService.prototype,
+      'removeSessionTranscriptForLifecycle',
+    ).mockResolvedValue(true);
+    vi.spyOn(
+      SessionService.prototype,
+      'cleanupRemovedSessionStateForLifecycle',
+    ).mockResolvedValue();
+
+    await expect(harness.service.delete([sessionId])).resolves.toMatchObject({
+      removed: [sessionId],
+      errors: [],
+    });
+    // The lifecycle lease was held before the inspection, and no orphaned pin
+    // was supplied as the expected identity.
+    expect(lease.assertOwnedAndUnchanged).toHaveBeenCalled();
+    expect(harness.inspectStandaloneDeletionPaths).toHaveBeenCalledWith(
+      sessionId,
+      undefined,
+    );
   });
 
   it('does not recreate a missing directory under an active live entry', async () => {

--- a/packages/cli/src/serve/conversations/standalone-session-service.ts
+++ b/packages/cli/src/serve/conversations/standalone-session-service.ts
@@ -35,6 +35,7 @@ import {
   type SessionArchiveState,
   type SessionListItem,
   type SessionService,
+  type SessionWriterErrorKind,
   type SessionWriterLease,
 } from '@qwen-code/qwen-code-core';
 import {
@@ -140,7 +141,7 @@ export interface StandaloneSessionMetadataResult {
 
 export interface StandaloneBatchError {
   sessionId: string;
-  code: StandaloneSessionServiceErrorCode;
+  code: StandaloneSessionServiceErrorCode | SessionWriterErrorKind;
   message: string;
 }
 
@@ -1394,9 +1395,12 @@ export class StandaloneSessionService {
         message: 'A previous session writer lease is still being released.',
       });
     }
+    // Parent-side lifecycle and maintenance acquisitions on the
+    // Conversations runtime share the ACP writer's hardened local policy so a
+    // provably dead same-domain writer does not fence recovery forever.
     const leaseOptions = {
       processKind: 'daemon' as const,
-      reclaimPolicy: 'never' as const,
+      reclaimPolicy: 'local' as const,
       takeoverPolicy: 'certified' as const,
     };
     try {
@@ -1554,6 +1558,11 @@ export class StandaloneSessionService {
   private batchError(sessionId: string, error: unknown): StandaloneBatchError {
     if (error instanceof StandaloneSessionServiceError) {
       return { sessionId, code: error.code, message: error.message };
+    }
+    // Preserve the session-writer protocol kind so a batch caller can
+    // distinguish a fenced same-session conflict from a storage failure.
+    if (error instanceof SessionWriterError) {
+      return { sessionId, code: error.errorKind, message: error.message };
     }
     const mapped = serviceError(
       'standalone_session_operation_failed',
@@ -1898,7 +1907,10 @@ export class StandaloneSessionService {
           await service.getSessionTranscriptParentIdentityForLifecycle(
             locked.location,
           );
-        const pinned = this.directoryStates.get(sessionId)?.pinned;
+        // The local session was closed above and the lifecycle lease is now
+        // held, so capture the directory identity fresh rather than trusting
+        // a pin that may predate another participant's legitimate recreation.
+        const pinned = this.effectiveDirectoryPin(runtime, sessionId);
         const paths =
           await this.options.workspace.inspectStandaloneDeletionPaths(
             sessionId,
@@ -2242,6 +2254,7 @@ export class StandaloneSessionService {
               throw serviceError('standalone_session_conflict', sessionId);
             }
             const prepared = await this.prepareRestoreDirectory(
+              runtime,
               sessionId,
               async () => {
                 if (!existing) return;
@@ -2865,20 +2878,57 @@ export class StandaloneSessionService {
     return result;
   }
 
+  /**
+   * A pin is authoritative only while its matching local bridge session
+   * generation remains resident. A bare pin left by a terminal close, an
+   * entry whose session an idle reap dropped, or a replaced event epoch is
+   * daemon-local history: discard it rather than condemning a directory
+   * another participant may have legitimately recreated. An indeterminate
+   * bridge probe fails closed by propagating.
+   */
+  private effectiveDirectoryPin(
+    runtime: WorkspaceRuntime,
+    sessionId: string,
+  ): ConversationDirectoryIdentity | undefined {
+    const state = this.directoryStates.get(sessionId);
+    if (!state) return undefined;
+    const bound = state.agentBound;
+    if (!bound) {
+      this.directoryStates.delete(sessionId);
+      return undefined;
+    }
+    let eventEpoch: string;
+    try {
+      eventEpoch = runtime.bridge.getSessionEventEpoch(sessionId);
+    } catch (error) {
+      if (error instanceof SessionNotFoundError) {
+        this.directoryStates.delete(sessionId);
+        return undefined;
+      }
+      throw error;
+    }
+    if (eventEpoch !== bound.eventEpoch) {
+      this.directoryStates.delete(sessionId);
+      return undefined;
+    }
+    return state.pinned;
+  }
+
   private async prepareRestoreDirectory(
+    runtime: WorkspaceRuntime,
     sessionId: string,
     beforeRecreate?: () => Promise<void>,
   ): Promise<PreparedRestoreDirectory> {
-    const previous = this.directoryStates.get(sessionId);
+    const expected = this.effectiveDirectoryPin(runtime, sessionId);
     const inspected = await this.options.workspace.inspectStandaloneDirectory(
       sessionId,
-      previous?.pinned,
+      expected,
     );
     if (inspected.status === 'compromised') {
       throw serviceError('working_directory_compromised', sessionId);
     }
     if (inspected.status === 'ready') {
-      if (!previous) {
+      if (!this.directoryStates.get(sessionId)) {
         this.directoryStates.set(sessionId, { pinned: inspected.identity });
       }
       return { identity: inspected.identity, state: 'ready' };
@@ -2887,7 +2937,7 @@ export class StandaloneSessionService {
     await beforeRecreate?.();
     const ensured = await this.options.workspace.ensureStandaloneDirectory(
       sessionId,
-      previous?.pinned,
+      expected,
     );
     if (ensured.status === 'compromised') {
       throw serviceError('working_directory_compromised', sessionId);

--- a/packages/cli/src/serve/fast-path-settings.ts
+++ b/packages/cli/src/serve/fast-path-settings.ts
@@ -15,6 +15,7 @@ import {
   HOME_ENV_BOOTSTRAP_KEYS,
   isHardcodedProjectEnvExclusion,
   isLoaderEnvKey,
+  isPrivateProvenanceEnvKey,
   reportRejectedLoaderKeys,
 } from '../config/shared-env-keys.js';
 import {
@@ -283,6 +284,11 @@ export function loadServeFastPathEnvironment(
       for (const key in parsedEnv) {
         if (!Object.hasOwn(parsedEnv, key)) continue;
         if (isLoaderEnvKey(key)) continue;
+        // Home-scoped files are exempt from the hardcoded exclusions below,
+        // so the private Conversations provenance marker — which the daemon
+        // would otherwise freeze into daemonRuntimeBaseEnv and hand to every
+        // spawned session — needs its own every-scope rejection here.
+        if (isPrivateProvenanceEnvKey(key)) continue;
         if (!isHomeScopedEnvFile && isHardcodedProjectEnvExclusion(key)) {
           continue;
         }

--- a/packages/cli/src/serve/fast-path.test.ts
+++ b/packages/cli/src/serve/fast-path.test.ts
@@ -1895,6 +1895,60 @@ describe('serve fast path environment bootstrap', () => {
     }
   });
 
+  // The private Conversations provenance marker is listed in
+  // PROJECT_ENV_HARDCODED_EXCLUSIONS, so a project .env is already rejected —
+  // but home-scoped files are exempt from that list, and the serve fast path
+  // dispatches before llm.tsx's capture-and-delete ever runs. Without its own
+  // gate here the marker would be frozen into daemonRuntimeBaseEnv and handed
+  // to every spawned session child.
+  it('never applies the private Conversations marker from user-level .env files', () => {
+    const trackedKeys = [
+      'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME',
+      'qwen_code_private_conversations_runtime',
+    ] as const;
+    const previous: Record<string, string | undefined> = {};
+    for (const key of trackedKeys) {
+      previous[key] = process.env[key];
+      delete process.env[key];
+    }
+
+    const qwenHome = useTempQwenHome();
+    tempWorkspace = realpathSync(
+      mkdtempSync(join(os.tmpdir(), 'qws-fast-path-marker-home-')),
+    );
+    writeFileSync(
+      join(qwenHome, '.env'),
+      [
+        'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME=1',
+        // Windows env lookup is case-insensitive, so the gate must reject
+        // case variants too.
+        'qwen_code_private_conversations_runtime=1',
+        'FASTPATH_HOME_MARKER_ALLOWED=allowed',
+        '',
+      ].join('\n'),
+    );
+
+    try {
+      loadServeFastPathEnvironment({}, tempWorkspace);
+      expect(
+        process.env['QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME'],
+      ).toBeUndefined();
+      expect(
+        process.env['qwen_code_private_conversations_runtime'],
+      ).toBeUndefined();
+      expect(process.env['FASTPATH_HOME_MARKER_ALLOWED']).toBe('allowed');
+    } finally {
+      for (const key of trackedKeys) {
+        if (previous[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previous[key];
+        }
+      }
+      delete process.env['FASTPATH_HOME_MARKER_ALLOWED'];
+    }
+  });
+
   // QWEN_CLI_ENTRY is the spawned session-process entrypoint: a start-dir
   // .env fixing it turns `qwen serve` in an untrusted repo into arbitrary
   // script execution for every workspace's sessions. The fast path consults

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -482,6 +482,9 @@ describe('createBoundChannelDeliveryHandler', () => {
 
 function makeRuntimeBridge(): HttpAcpBridge {
   return {
+    // The fake stands in for production bridges built through
+    // `createSpawnChannelFactory`, which carry the forwarding attestation.
+    mandatoryLeaseAttested: true,
     spawnOrAttach: vi.fn(),
     shutdown: vi.fn().mockResolvedValue(undefined),
     killAllSync: vi.fn(),
@@ -7289,6 +7292,13 @@ describe('runQwenServe runtime startup failures', () => {
       // the guard plumbing marker but NOT the provider-attached marker.
       expect(bridgeOptions?.childEnvOverrides).toHaveProperty(
         'QWEN_CODE_PRIVATE_EXTERNAL_TOOL_GUARD_PROVIDER',
+        undefined,
+      );
+      // The Conversations provenance marker stays explicitly removed for an
+      // ordinary workspace child; only the live-conversation runtime replaces
+      // it with the enable value.
+      expect(bridgeOptions?.childEnvOverrides).toHaveProperty(
+        'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME',
         undefined,
       );
       expect(createBridge.mock.calls.length).toBeGreaterThan(0);

--- a/packages/cli/src/serve/run-qwen-serve.test.ts
+++ b/packages/cli/src/serve/run-qwen-serve.test.ts
@@ -616,6 +616,123 @@ it('restores the Conversations runtime for a persisted scheduled task', async ()
   }
 });
 
+it('marks only the live-conversation bridge with the Conversations provenance env', async () => {
+  delete process.env['QWEN_RUNTIME_DIR'];
+  const tempRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'qws-conversations-marker-')),
+  );
+  const workspace = path.join(tempRoot, 'workspace');
+  const physicalHome = path.join(tempRoot, 'home');
+  const linkedHome = path.join(tempRoot, 'home-link');
+  const runtimeDir = path.join(tempRoot, 'runtime');
+  fs.mkdirSync(workspace);
+  fs.mkdirSync(physicalHome);
+  fs.symlinkSync(
+    physicalHome,
+    linkedHome,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  );
+  const liveConversationWorkspace = new ConversationWorkspace({
+    homeDir: linkedHome,
+  });
+  const { canonicalRoot } = await liveConversationWorkspace.getRoot();
+  fs.mkdirSync(path.join(canonicalRoot, '.qwen'));
+  fs.writeFileSync(
+    path.join(canonicalRoot, '.qwen', 'settings.json'),
+    JSON.stringify({ advanced: { runtimeOutputDir: runtimeDir } }),
+  );
+  await qwenCore.Storage.runWithResolvedRuntimeBaseDir(runtimeDir, () =>
+    qwenCore.updateCronTasks(canonicalRoot, () => [
+      {
+        id: 'live-task',
+        cron: '0 9 * * *',
+        prompt: 'p',
+        recurring: true,
+        createdAt: 1_700_000_000_000,
+        lastFiredAt: null,
+        sessionId: 'live-session',
+        sessionOwnedByTask: false,
+      },
+    ]),
+  );
+  vi.spyOn(
+    scheduledTaskKeepalive,
+    'startScheduledTaskKeepalive',
+  ).mockReturnValue({
+    stop: vi.fn(),
+    tick: vi.fn().mockResolvedValue(undefined),
+  });
+  const createBridge = vi
+    .spyOn(acpBridge, 'createAcpSessionBridge')
+    .mockImplementation(
+      () =>
+        ({
+          ...makeRuntimeBridge(),
+          recordHeartbeat: vi.fn(),
+          resumeSession: vi.fn().mockResolvedValue({}),
+          setLiveScreenContextCaptureHandler: vi.fn(),
+          setLiveTaskToolRequestHandler: vi.fn(),
+          setLiveSpeakToUserHandler: vi.fn(),
+        }) as ReturnType<typeof acpBridge.createAcpSessionBridge>,
+    );
+  const overridesOf = (
+    call: Parameters<typeof acpBridge.createAcpSessionBridge>,
+  ): Record<string, string | undefined> | undefined =>
+    (call[0] as { childEnvOverrides?: Record<string, string | undefined> })
+      .childEnvOverrides;
+  const MARKER = 'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME';
+  let handle: RunHandle | undefined;
+
+  try {
+    handle = await runQwenServe(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        mode: 'http-bridge',
+        workspace,
+        maxSessions: 1,
+        serveWebShell: false,
+      },
+      {
+        bridge: makeRuntimeBridge(),
+        liveConversationWorkspace,
+        liveDiscoveryStableBaseDir: path.join(tempRoot, 'stable'),
+        resolveOnListen: true,
+      },
+    );
+    await handle.runtimeReady;
+
+    // The Conversations runtime is the only runtime this boot creates through
+    // the bridge factory (the primary uses the injected bridge). Replacing the
+    // provenance ternary with the plain shared overrides leaves it unmarked,
+    // which would make the publication gate quarantine the runtime.
+    await vi.waitFor(() => {
+      expect(
+        createBridge.mock.calls.filter(
+          (call) => overridesOf(call)?.[MARKER] === '1',
+        ),
+      ).toHaveLength(1);
+    });
+    const marked = createBridge.mock.calls.find(
+      (call) => overridesOf(call)?.[MARKER] === '1',
+    );
+    expect((marked?.[0] as { boundWorkspace?: string }).boundWorkspace).toBe(
+      canonicalRoot,
+    );
+    for (const call of createBridge.mock.calls) {
+      const overrides = overridesOf(call);
+      if (overrides?.[MARKER] === '1') continue;
+      // Any other runtime keeps the shared overrides' explicit removal, so its
+      // children cannot inherit a marker from the daemon environment.
+      expect(overrides).toHaveProperty(MARKER, undefined);
+    }
+  } finally {
+    await handle?.close();
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  }
+});
+
 function writeWebShellFixture(workspaceDir: string): string {
   const shellDir = path.join(workspaceDir, 'web-shell');
   fs.mkdirSync(path.join(shellDir, 'assets'), { recursive: true });

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -80,6 +80,10 @@ import type {
   TelemetryRuntimeConfig,
   TelemetrySettings,
 } from '@qwen-code/qwen-code-core';
+import {
+  PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
+  PRIVATE_CONVERSATIONS_RUNTIME_ENV,
+} from '@qwen-code/qwen-code-core';
 import { MEMORY_PROJECT_SCOPES } from '@qwen-code/qwen-code-core/memoryScopes';
 import { createBridgeFileSystemAdapter } from './bridge-file-system-adapter.js';
 // Dynamic-imported below (not at module scope) so the serve fast-path bundle
@@ -4207,6 +4211,10 @@ async function runQwenServeImpl(
         : undefined,
     QWEN_SERVE_MCP_BUDGET_MODE: opts.mcpBudgetMode,
     QWEN_SERVE_CDP_TUNNEL_OVER_WS: opts.cdpTunnelOverWs ? '1' : undefined,
+    // The Conversations marker is enable-only and scoped to the
+    // live-conversation bridge below; every other runtime's child must not
+    // inherit it from the daemon's own environment.
+    [PRIVATE_CONVERSATIONS_RUNTIME_ENV]: undefined,
     [PRIVATE_EXTERNAL_TOOL_GUARD_ENV]: EXTERNAL_TOOL_GUARD_REQUIRED_VALUE,
     [PRIVATE_EXTERNAL_TOOL_GUARD_PROVIDER_ENV]: externalToolGuardHandler
       ? EXTERNAL_TOOL_GUARD_PROVIDER_ATTACHED_VALUE
@@ -6823,7 +6831,17 @@ async function runQwenServeImpl(
                 ),
               }),
           sessionShellCommandEnabled,
-          childEnvOverrides,
+          // Only the Conversations runtime's children carry the private
+          // provenance marker; every other workspace keeps the shared
+          // overrides' explicit removal.
+          childEnvOverrides:
+            provenance === 'live-conversation'
+              ? {
+                  ...childEnvOverrides,
+                  [PRIVATE_CONVERSATIONS_RUNTIME_ENV]:
+                    PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
+                }
+              : childEnvOverrides,
           channelFactory: wsChannelFactory,
           externalToolGuard: daemonToolGuardHandler,
           onDiagnosticLine: diagnosticSink,

--- a/packages/cli/src/serve/run-qwen-serve.ts
+++ b/packages/cli/src/serve/run-qwen-serve.ts
@@ -83,7 +83,7 @@ import type {
 import {
   PRIVATE_CONVERSATIONS_RUNTIME_ENABLE,
   PRIVATE_CONVERSATIONS_RUNTIME_ENV,
-} from '@qwen-code/qwen-code-core';
+} from '@qwen-code/qwen-code-core/conversationsRuntimeMarker';
 import { MEMORY_PROJECT_SCOPES } from '@qwen-code/qwen-code-core/memoryScopes';
 import { createBridgeFileSystemAdapter } from './bridge-file-system-adapter.js';
 // Dynamic-imported below (not at module scope) so the serve fast-path bundle

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -2053,6 +2053,10 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       sessions: [],
     }));
   return {
+    // The fake stands in for production bridges built through
+    // `createSpawnChannelFactory`, which carry the forwarding attestation
+    // the Conversations runtime publication gate requires.
+    mandatoryLeaseAttested: true,
     // F3 Commit 6 — `AcpSessionBridge.permissionPolicy` is required so
     // `/capabilities` can expose `policy.permission`. Tests don't
     // exercise mediation; pin to the pre-F3 default ('first-responder')

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
         __dirname,
         '../core/src/utils/envVarResolver.ts',
       ),
+      '@qwen-code/qwen-code-core/conversationsRuntimeMarker': path.resolve(
+        __dirname,
+        '../core/src/utils/conversations-runtime-marker.ts',
+      ),
       '@qwen-code/qwen-code-core': path.resolve(__dirname, '../core/index.ts'),
       // cli's daemon-status-provider.test.ts imports `FakeAgent` /
       // `makeChannel` from acp-bridge's package-private

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,10 @@
       "types": "./dist/src/utils/no-follow-open.d.ts",
       "import": "./dist/src/utils/no-follow-open.js"
     },
+    "./conversationsRuntimeMarker": {
+      "types": "./dist/src/utils/conversations-runtime-marker.d.ts",
+      "import": "./dist/src/utils/conversations-runtime-marker.js"
+    },
     "./package.json": "./package.json",
     "./dist/*": "./dist/*",
     "./src/*": "./src/*"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -638,6 +638,7 @@ export * from './utils/github-prs.js';
 export * from './utils/github-pr-issues.js';
 export * from './utils/ignorePatterns.js';
 export * from './utils/invocation-context.js';
+export * from './utils/conversations-runtime-marker.js';
 export {
   DEFAULT_QWEN_CUSTOM_IGNORE_FILE_NAMES,
   QwenIgnoreParser,

--- a/packages/core/src/services/session-writer-lease.test.ts
+++ b/packages/core/src/services/session-writer-lease.test.ts
@@ -33,6 +33,7 @@ import {
   ChatRecordingService,
   type ChatRecord,
 } from './chatRecordingService.js';
+import { readPidNamespaceId } from '../utils/process-liveness.js';
 import { SessionService } from './sessionService.js';
 import {
   getSessionWriterLockPath,
@@ -467,6 +468,40 @@ async function waitForClose(child: ChildProcess): Promise<void> {
   // almost always means a reused PID, not a leaked child; do not turn that
   // teardown observation into a test failure.
   console.warn(`Process ${pid} remained live after close`);
+}
+
+/**
+ * Acquires a lease in a helper process, kills it with SIGKILL, and rewrites
+ * the orphaned record through `mutate`, so Linux identity-domain cases can
+ * craft missing or foreign boot/namespace identities from a real record.
+ */
+async function deadOwnerRecord(
+  mutate?: (record: Record<string, unknown>) => void,
+): Promise<{
+  options: AcquireSessionWriterLeaseOptions;
+  lockPath: string;
+}> {
+  const fixture = await createFixture();
+  const deadOwner = startLeaseProcess();
+  expect(
+    await requestChild(deadOwner, {
+      type: 'acquire',
+      options: fixture.options,
+    }),
+  ).toMatchObject({ ok: true });
+  deadOwner.kill('SIGKILL');
+  await waitForClose(deadOwner);
+  const lockPath = getSessionWriterLockPath(
+    fixture.runtimeBaseDir,
+    fixture.options.sessionId,
+  );
+  const record = JSON.parse(await fs.readFile(lockPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  mutate?.(record);
+  await fs.writeFile(lockPath, JSON.stringify(record));
+  return { options: fixture.options, lockPath };
 }
 
 function record(
@@ -986,6 +1021,54 @@ describe('SessionWriterLease', () => {
         `linux:${bootId.trim()}:${startTicks}`,
       );
       await lease.release();
+    },
+  );
+
+  it.runIf(process.platform === 'linux')(
+    'records the PID namespace identity on Linux',
+    async () => {
+      const fixture = await createFixture();
+      const lease = await SessionWriterLease.acquire(fixture.options);
+      const lockPath = getSessionWriterLockPath(
+        fixture.runtimeBaseDir,
+        fixture.options.sessionId,
+      );
+      const lockRecord = JSON.parse(await fs.readFile(lockPath, 'utf8')) as {
+        pid_namespace_id?: number;
+      };
+      expect(lockRecord.pid_namespace_id).toBe(readPidNamespaceId());
+      await lease.release();
+    },
+  );
+
+  it.runIf(process.platform === 'linux')(
+    'reclaims a dead writer only inside the same Linux identity domain',
+    async () => {
+      const reclaimable = await deadOwnerRecord();
+      const reclaimed = await SessionWriterLease.acquire(reclaimable.options);
+      await reclaimed.release();
+
+      const missingNamespace = await deadOwnerRecord((record) => {
+        delete record['pid_namespace_id'];
+      });
+      await expect(
+        SessionWriterLease.acquire(missingNamespace.options),
+      ).rejects.toBeInstanceOf(SessionWriterConflictError);
+
+      const foreignNamespace = await deadOwnerRecord((record) => {
+        record['pid_namespace_id'] = (record['pid_namespace_id'] as number) + 1;
+      });
+      await expect(
+        SessionWriterLease.acquire(foreignNamespace.options),
+      ).rejects.toBeInstanceOf(SessionWriterConflictError);
+
+      const foreignBoot = await deadOwnerRecord((record) => {
+        record['process_start_identity'] =
+          'linux:00000000-0000-0000-0000-000000000000:1';
+      });
+      await expect(
+        SessionWriterLease.acquire(foreignBoot.options),
+      ).rejects.toBeInstanceOf(SessionWriterConflictError);
     },
   );
 

--- a/packages/core/src/services/session-writer-lease.test.ts
+++ b/packages/core/src/services/session-writer-lease.test.ts
@@ -33,7 +33,7 @@ import {
   ChatRecordingService,
   type ChatRecord,
 } from './chatRecordingService.js';
-import { readPidNamespaceId } from '../utils/process-liveness.js';
+import * as processLiveness from '../utils/process-liveness.js';
 import { SessionService } from './sessionService.js';
 import {
   getSessionWriterLockPath,
@@ -1036,7 +1036,9 @@ describe('SessionWriterLease', () => {
       const lockRecord = JSON.parse(await fs.readFile(lockPath, 'utf8')) as {
         pid_namespace_id?: number;
       };
-      expect(lockRecord.pid_namespace_id).toBe(readPidNamespaceId());
+      expect(lockRecord.pid_namespace_id).toBe(
+        processLiveness.readPidNamespaceId(),
+      );
       await lease.release();
     },
   );
@@ -1068,6 +1070,47 @@ describe('SessionWriterLease', () => {
       });
       await expect(
         SessionWriterLease.acquire(foreignBoot.options),
+      ).rejects.toBeInstanceOf(SessionWriterConflictError);
+    },
+  );
+
+  it.runIf(process.platform === 'linux').each([
+    ['an unparseable identity', () => 'linux:zz'],
+    [
+      'an identity truncated before the start ticks',
+      () => `linux:${processLiveness.readLocalBootId()}`,
+    ],
+    [
+      'a darwin identity read by a Linux reader',
+      () => 'darwin:Tue Sep 1 00:00:00 2026',
+    ],
+    [
+      'a win32 identity read by a Linux reader',
+      () => 'win32:638000000000000000',
+    ],
+  ])('fences a dead writer carrying %s', async (_label, identity) => {
+    const fenced = await deadOwnerRecord((record) => {
+      record['process_start_identity'] = identity();
+    });
+    await expect(
+      SessionWriterLease.acquire(fenced.options),
+    ).rejects.toBeInstanceOf(SessionWriterConflictError);
+  });
+
+  it.runIf(process.platform === 'linux')(
+    'fences a dead writer when the local identity domain is indeterminate',
+    async () => {
+      const bootFenced = await deadOwnerRecord();
+      vi.spyOn(processLiveness, 'readLocalBootId').mockReturnValue(null);
+      await expect(
+        SessionWriterLease.acquire(bootFenced.options),
+      ).rejects.toBeInstanceOf(SessionWriterConflictError);
+      vi.restoreAllMocks();
+
+      const namespaceFenced = await deadOwnerRecord();
+      vi.spyOn(processLiveness, 'readPidNamespaceId').mockReturnValue(null);
+      await expect(
+        SessionWriterLease.acquire(namespaceFenced.options),
       ).rejects.toBeInstanceOf(SessionWriterConflictError);
     },
   );

--- a/packages/core/src/services/session-writer-lease.ts
+++ b/packages/core/src/services/session-writer-lease.ts
@@ -14,6 +14,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { hasVerifiableInode } from '../utils/file-identity.js';
+import {
+  readLocalBootId,
+  readPidNamespaceId,
+} from '../utils/process-liveness.js';
 
 const LEGACY_LOCK_SCHEMA_VERSION = 1;
 const LOCK_SCHEMA_VERSION = 2;
@@ -235,6 +239,7 @@ interface SessionWriterOwnerRecord {
   owner_id: string;
   pid: number;
   process_start_identity?: string;
+  pid_namespace_id?: number;
   hostname: string;
   process_kind: SessionWriterProcessKind;
   acquired_at: string;
@@ -417,6 +422,9 @@ function hasValidOwnerFields(
     (record['process_start_identity'] === undefined ||
       (typeof record['process_start_identity'] === 'string' &&
         record['process_start_identity'].length > 0)) &&
+    (record['pid_namespace_id'] === undefined ||
+      (Number.isSafeInteger(record['pid_namespace_id']) &&
+        (record['pid_namespace_id'] as number) > 0)) &&
     typeof record['hostname'] === 'string' &&
     record['hostname'].length > 0 &&
     typeof processKind === 'string' &&
@@ -480,11 +488,38 @@ function isActiveLockRecord(
   );
 }
 
+function parseLinuxProcessStartBootId(
+  identity: string | undefined,
+): string | null {
+  if (!identity) return null;
+  const match = /^linux:([0-9a-f-]+):\d+$/i.exec(identity);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
 async function lockStateForRecord(
   record: ActiveLockRecord,
   raw: string,
 ): Promise<ExistingLockState> {
   if (record.hostname !== os.hostname()) return { kind: 'live', record, raw };
+  if (process.platform === 'linux') {
+    // Reclaim only inside the same local identity domain. The boot ID and
+    // PID namespace must both be recorded and match this reader: a record
+    // without them, or from another boot or namespace, may belong to a live
+    // writer sharing this filesystem (same-hostname machines, mounted homes,
+    // sibling containers), so it is fenced rather than reclaimed.
+    const localBootId = readLocalBootId()?.toLowerCase() ?? null;
+    const localNamespaceId = readPidNamespaceId();
+    if (
+      localBootId === null ||
+      localNamespaceId === null ||
+      parseLinuxProcessStartBootId(record.process_start_identity) !==
+        localBootId ||
+      record.pid_namespace_id === undefined ||
+      record.pid_namespace_id !== localNamespaceId
+    ) {
+      return { kind: 'live', record, raw };
+    }
+  }
   if (!isProcessAlive(record.pid)) return { kind: 'stale', record, raw };
   if (!record.process_start_identity) return { kind: 'live', record, raw };
   const currentStartIdentity = await readProcessStartIdentity(record.pid);
@@ -1661,6 +1696,7 @@ export class SessionWriterLease {
     }
 
     const processStartIdentity = await readProcessStartIdentity(process.pid);
+    const pidNamespaceId = readPidNamespaceId();
     const lockRecord: ActiveSessionWriterLockRecord = {
       schema_version: LOCK_SCHEMA_VERSION,
       state: 'active',
@@ -1670,6 +1706,7 @@ export class SessionWriterLease {
       ...(processStartIdentity
         ? { process_start_identity: processStartIdentity }
         : {}),
+      ...(pidNamespaceId !== null ? { pid_namespace_id: pidNamespaceId } : {}),
       hostname: os.hostname(),
       process_kind: normalizedOptions.processKind ?? 'unknown',
       acquired_at: new Date().toISOString(),

--- a/packages/core/src/utils/conversations-runtime-marker.ts
+++ b/packages/core/src/utils/conversations-runtime-marker.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Private provenance marker for ACP children hosted by the daemon's
+ * Conversations runtime.
+ *
+ * The marker forces the session writer lease for every writer that runtime
+ * hosts, independent of the experimental user setting. It is enable-only,
+ * captured and deleted by the CLI entry point before any environment-file
+ * load, excluded from project `.env` files, and never a user-facing setting.
+ *
+ * Kept in its own leaf module — and exported through a package subpath — so
+ * serve fast-path modules can read the constant without pulling the core
+ * barrel into their static import closure.
+ */
+export const PRIVATE_CONVERSATIONS_RUNTIME_ENV =
+  'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME';
+export const PRIVATE_CONVERSATIONS_RUNTIME_ENABLE = '1';

--- a/packages/core/src/utils/invocation-context.ts
+++ b/packages/core/src/utils/invocation-context.ts
@@ -10,13 +10,6 @@ export const INVOCATION_CONTEXT_META_KEY = 'qwen-code/invocation';
 export const PRIVATE_PARENT_CAPABILITY_META_KEY =
   'qwen-code/private-parent-capability';
 export const PRIVATE_ACP_CAPABILITY_ENV = 'QWEN_CODE_PRIVATE_ACP_CAPABILITY';
-// Marks an ACP child as hosted by the daemon's Conversations runtime so it
-// participates in the mandatory session writer lease. Private enable-only
-// provenance signal: captured and deleted by the CLI entry point, never a
-// user-facing setting.
-export const PRIVATE_CONVERSATIONS_RUNTIME_ENV =
-  'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME';
-export const PRIVATE_CONVERSATIONS_RUNTIME_ENABLE = '1';
 
 export interface InvocationContextV1 {
   readonly version: 1;

--- a/packages/core/src/utils/invocation-context.ts
+++ b/packages/core/src/utils/invocation-context.ts
@@ -10,6 +10,13 @@ export const INVOCATION_CONTEXT_META_KEY = 'qwen-code/invocation';
 export const PRIVATE_PARENT_CAPABILITY_META_KEY =
   'qwen-code/private-parent-capability';
 export const PRIVATE_ACP_CAPABILITY_ENV = 'QWEN_CODE_PRIVATE_ACP_CAPABILITY';
+// Marks an ACP child as hosted by the daemon's Conversations runtime so it
+// participates in the mandatory session writer lease. Private enable-only
+// provenance signal: captured and deleted by the CLI entry point, never a
+// user-facing setting.
+export const PRIVATE_CONVERSATIONS_RUNTIME_ENV =
+  'QWEN_CODE_PRIVATE_CONVERSATIONS_RUNTIME';
+export const PRIVATE_CONVERSATIONS_RUNTIME_ENABLE = '1';
 
 export interface InvocationContextV1 {
   readonly version: 1;


### PR DESCRIPTION
## What this PR does

This PR implements the additive fence half of the merged relaxed standalone daemon ownership design ([docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md](docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md)), ahead of the cutover that removes the process-global Conversations ownership gate. Every writer hosted by the daemon's Conversations runtime — standalone sessions, Live sessions, and scheduled-task controller or run sessions — now acquires the existing cross-process session writer lease before it can write, independent of the experimental user setting. The daemon marks only the Conversations runtime's ACP children with a private, enable-only provenance marker, and the runtime is accepted or published only when its bridge attests to the conjunction of the exact marker in its frozen child-environment overrides and a channel factory proven to forward those overrides into the spawned child; a violation rejects and disposes a new candidate, terminally quarantines an existing runtime, and keeps every later access on the non-retryable `conversation_root_compromised` classification. Local stale-writer recovery is hardened to reclaim only a record proven to come from a dead or PID-reused process in the same local identity domain — the same hostname and, on Linux, the same boot and PID namespace, the latter recorded as an optional schema-version-2 field — while matching live, stalled, foreign, or identity-less records stay fenced. Standalone batch lifecycle responses now preserve the session-writer error kind on the affected item instead of collapsing it into a generic failure code, parent-side lifecycle and maintenance acquisitions on the Conversations runtime share the hardened local policy, and a working-directory identity pin is authoritative only while its matching local bridge session generation remains resident, so a directory legitimately recreated after a close or idle reap is adopted on the next open rather than condemned as compromised. Conversations sessions also refuse to fire an unbound durable scheduled task until the daemon keepalive commits exactly one controller binding through the existing cross-process task-file transaction.

## Why it's needed

The merged design lets multiple updated daemons serve the shared Conversations root concurrently, partitioned by session. That cutover is only safe once every Conversations writer participates in the per-session writer lease, the provenance of the marking is verifiable, and stale-writer recovery is identity-qualified; this PR lands exactly those fences while the outer ownership gate still stands, so the **ownership model is unchanged** and no concurrency is unlocked until the follow-up cutover PR removes that gate. This is not a zero-delta change: the fences themselves are live now — Conversations standalone sessions produce writer-lock files where they previously produced none, parent-side lifecycle acquisitions moved from `reclaimPolicy: 'never'` to `'local'`, and the fail-closed cost under "Main risk" below is reachable today. It also fixes two defects the design review uncovered that become reachable as soon as more than one daemon may touch the shared root: batch lifecycle responses discarded the writer-conflict kind that clients need to distinguish a fenced session, and a daemon-local directory pin could outlive its session and turn a healthy recreated directory into a terminal `working_directory_compromised`.

## Reviewer Test Plan

### How to verify

1. Confirm a daemon-spawned Conversations ACP child always runs the writer lease with the hardened local reclaim policy while an ordinary managed child keeps `never`: the marker is captured and deleted at the entry point before any environment-file load, accepted only in ACP mode with the private parent capability at the exact enable value, carried through a sandbox relaunch, and cannot be reintroduced by a workspace or user `.env`.
2. Confirm publication now requires the attestation conjunction: a bridge built with the exact marker and a factory produced by the spawning helper attests, a marker-shaped override map paired with an override-ignoring factory does not, a new non-conforming candidate is rejected and disposed, and a registered non-conforming runtime is terminally quarantined with every later access returning the same non-retryable `conversation_root_compromised` instead of degrading to a retryable error.
3. Confirm the standalone surface changes: a batch archive or delete keeps its `200` envelope but carries `session_writer_conflict`-family codes on the affected item; opening a session whose directory was legitimately recreated after its local generation exited adopts the fresh identity, while a replacement observed while the matching generation is resident still fails closed with `working_directory_compromised`; parent-side lifecycle acquisitions request the hardened local reclaim policy.
4. Confirm the hardened reclaim on Linux: a record from a provably dead process in the same hostname, boot, and PID namespace is reclaimed, while a record missing either identity or carrying a foreign boot or namespace stays fenced with `session_writer_conflict`.
5. Confirm a marked Conversations session does not fire an unbound durable scheduled task, and does once the task is bound to a session.

Suggested checks: `npm run build && npm run typecheck`; `cd packages/core && npx vitest run src/services/session-writer-lease.test.ts`; `cd packages/acp-bridge && npx vitest run src/child-env-forwarding.test.ts src/spawnChannel.test.ts src/bridge.test.ts`; `cd packages/cli && npx vitest run src/serve/conversations/conversation-runtime-manager.test.ts src/serve/conversations/standalone-session-service.test.ts src/serve/run-qwen-serve.test.ts src/serve/server.test.ts src/acp-integration/acpAgent.test.ts src/llm.test.tsx src/config/shared-env-keys.test.ts src/serve/routes/standalone-sessions.test.ts`.

### Evidence (Before & After)

N/A for TUI — there is no terminal-UI surface here. There are runtime deltas, listed under "Why it's needed" and "Risk & Scope".

Unit suites pass: acp-bridge 947, cli side including server 1175/1175 and run-qwen-serve 378/378, standalone-session-service 98/98, conversation-runtime-manager 32/32, llm 84, environment 33, shared-env-keys 49; `npm run check:serve-fast-path-bundle` reports "Startup bundle closure checks passed". Local failures on this machine (four Config-level writer-lease cases, one MCP budget env-parsing case) reproduce identically on the base commit via stash comparison and are unrelated.

Independently verified by @wenshao on a real Linux daemon (Linux 6.12.63, Node 22.22.2, real HTTP, real spawned ACP children, real kernel namespaces), A/B against merge base `93e1597b7e` with a mutation matrix on the shipped bundle: marker delivery read from `/proc/<pid>/environ`, all four env-forgery surfaces rejected, both attestation conjuncts proven load-bearing, the five reclaim scenarios (`S1`–`S5`, including a writer in a separate PID namespace via `unshare`) fenced or reclaimed exactly as specified, and both directions of the directory-pin rule. acp-bridge 947/947 and cli 1300/1300 on that host.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  CI (Linux-gated reclaim tests added)  |

### Environment (optional)

macOS 26.4.1, local vitest runs per package; Linux identity-domain coverage runs in CI.

## Risk & Scope

- Main risk or tradeoff: The mandatory lease and identity-qualified reclaim become active for Conversations writers while the process-global ownership gate still stands, so a regression would surface within the existing single-owner model. Two fail-closed costs ship with this PR, both measured by @wenshao's Linux E2E. (a) On Linux, records written by older versions lack the namespace identity and stay fenced rather than auto-reclaimed. (b) An `active` (unsealed) record whose boot ID or PID namespace no longer matches is fenced **permanently**: the lease has no TTL and no heartbeat and there is no API or UI that clears a writer lock, so the only recovery is deleting `<runtimeBase>/tmp/session-writer-locks/<id>.lock` by hand — and the `409` text ("This session is already open in another Qwen process.") is untrue in that state. It is reachable through power loss, kernel panic, or an OOM kill followed by a restart, and with no reboot at all when a containerized daemon is killed and restarted into a new PID namespace against a mounted home. Graceful shutdown is **not** affected: `SIGTERM`/`SIGINT` seals the record, and certified takeover runs before the identity-domain check. This is an open decision (bounded recovery path such as machine-id or lease TTL, versus an explicit release affordance, versus diagnostics and documentation only); @wenshao recommends closing it before the cutover PR removes the ownership gate, since more than one daemon may then leave `active` records behind.
- Not validated / out of scope: The ownership-gate removal, legacy-owner compatibility check, deletion-journal bootstrap move, Live-start publisher admission with pending-intent linearization, and the Web Shell degradation land in the follow-up PRs; the backend and Web Shell work must ship in the same release. Two-daemon E2E coverage arrives with the cutover PR.
- Breaking changes / migration notes: No API shape changes. Batch lifecycle items may now carry `session_writer_conflict`-family codes, which the SDK already accepts as unconstrained strings.

## Linked Issues

Refs #10810

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本 PR 实现了已合并的 relaxed standalone daemon ownership 设计（[docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md](docs/design/2026-09-02-relaxed-standalone-daemon-ownership.md)）中纯增量的围栏部分，先于移除进程全局 Conversations ownership gate 的 cutover 落地。此后由 daemon 的 Conversations runtime 承载的所有 writer——standalone 会话、Live 会话、scheduled-task controller 与 run 会话——在写入前都必须获取现有的跨进程 session writer lease，不再依赖实验性用户设置。daemon 只给 Conversations runtime 的 ACP 子进程注入私有的 enable-only provenance marker；只有当 runtime 的 bridge 同时证明其冻结的 child-environment overrides 携带精确 marker、且所选 channel factory 被证明会把这些 overrides 合并进所 spawn 的子进程环境时，runtime 才会被接受或发布；违反者对新候选拒绝并销毁，对已有 runtime 终态隔离，且此后每次访问都保持不可重试的 `conversation_root_compromised` 分类。本地 stale-writer 恢复被强化为：只回收被证明来自同一本地身份域（同 hostname，Linux 上同 boot 与同 PID namespace，后者以可选的 schema-version-2 字段记录）中已死亡或 PID 被复用进程的 record；匹配的存活、卡死、外部或缺身份的 record 一律保持围栏。standalone 批量生命周期响应现在在受影响项上保留 session-writer 错误 kind，不再塌缩为通用失败码；Conversations runtime 上父侧 lifecycle 与 maintenance 获取同样选用强化后的 local 策略；工作目录 identity pin 仅在匹配的本地 bridge session generation 仍存活时有效，因此在 close 或 idle reap 之后被合法重建的目录会在下次打开时被采用，而不再被误判为终态 `working_directory_compromised`。Conversations 会话还会拒绝执行尚未绑定的 durable 定时任务，直到 daemon keepalive 通过现有跨进程任务文件事务提交唯一的 controller 绑定。

## 为什么需要

已合并的设计允许多个更新后的 daemon 按 session 分区并发服务共享的 Conversations root。该 cutover 只有在所有 Conversations writer 都参与 per-session writer lease、标记来源可验证、且 stale-writer 恢复具备身份限定之后才安全；本 PR 恰好落地这些围栏，而旧的全局 ownership gate 仍然存在，因此 **ownership 模型未变**，在后续 cutover PR 拆门之前不会解锁任何并发。但这不是零差异改动：围栏本身现在就已生效——Conversations standalone 会话开始产生此前不存在的 writer 锁文件，父侧 lifecycle 获取从 `reclaimPolicy: 'never'` 改为 `'local'`，且下方「主要风险」中的 fail-closed 代价今天即可触达。它还修复了设计评审发现的两个缺陷——只要多于一个 daemon 可能触碰共享 root 就会触达：批量生命周期响应丢弃了客户端区分被围栏会话所需的 writer-conflict kind；daemon 本地目录 pin 可能比其会话存活更久，把健康的重建目录误判为终态 `working_directory_compromised`。

## Reviewer 测试计划

### 如何验证

1. 确认 daemon spawn 的 Conversations ACP 子进程总是以强化 local reclaim 策略运行 writer lease，而普通 managed 子进程保持 `never`：marker 在入口点、任何环境文件加载之前被捕获并删除，仅在 ACP 模式、持有私有父 capability 且为精确 enable 值时被接受，经 sandbox relaunch 传递，且不能被 workspace 或用户 `.env` 重新引入。
2. 确认发布现在要求 attestation 合取：携带精确 marker 且 factory 由 spawn helper 产出的 bridge 通过；marker 形状的 override map 搭配忽略 overrides 的 factory 不通过；不合规新候选被拒绝并销毁；不合规的已注册 runtime 被终态隔离，且此后每次访问都返回同一个不可重试的 `conversation_root_compromised`，不会降级为可重试错误。
3. 确认 standalone 面的变化：批量 archive 或 delete 保留 `200` envelope，但在受影响项上携带 `session_writer_conflict` 系列错误码；打开一个其本地 generation 退出后目录被合法重建的会话会采用新 identity，而在匹配 generation 仍存活期间发生的替换仍然以 `working_directory_compromised` fail closed；父侧 lifecycle 获取请求强化 local reclaim 策略。
4. 确认 Linux 上的强化 reclaim：来自同 hostname、同 boot、同 PID namespace 中已证明死亡进程的 record 被回收；缺任一身份或携带外部 boot、namespace 的 record 保持围栏并返回 `session_writer_conflict`。
5. 确认带标记的 Conversations 会话不会执行未绑定的 durable 定时任务，绑定到会话后恢复执行。

建议检查命令：`npm run build && npm run typecheck`；`cd packages/core && npx vitest run src/services/session-writer-lease.test.ts`；`cd packages/acp-bridge && npx vitest run src/child-env-forwarding.test.ts src/spawnChannel.test.ts src/bridge.test.ts`；`cd packages/cli && npx vitest run src/serve/conversations/conversation-runtime-manager.test.ts src/serve/conversations/standalone-session-service.test.ts src/serve/run-qwen-serve.test.ts src/serve/server.test.ts src/acp-integration/acpAgent.test.ts src/llm.test.tsx src/config/shared-env-keys.test.ts src/serve/routes/standalone-sessions.test.ts`。

### 前后对比证据

TUI 部分 N/A——本 PR 没有终端 UI 面。运行时差异确实存在，见「为什么需要」与「风险与范围」。

单测通过：acp-bridge 947，cli 侧含 server 1175/1175、run-qwen-serve 378/378，standalone-session-service 98/98，conversation-runtime-manager 32/32，llm 84，environment 33，shared-env-keys 49；`npm run check:serve-fast-path-bundle` 报告 "Startup bundle closure checks passed"。本机既有失败（4 个 Config 级 writer-lease 用例、1 个 MCP 预算 env 解析用例）通过 stash 对照在 base 提交上同样复现，与本改动无关。

已由 @wenshao 在真实 Linux daemon 上独立验证（Linux 6.12.63、Node 22.22.2，真实 HTTP、真实 spawn 的 ACP 子进程、真实内核 namespace），与 merge base `93e1597b7e` 做 A/B 并对发布产物做变异矩阵：marker 投递从 `/proc/<pid>/environ` 读取，四个 env 伪造面全部被拒，attestation 的两个合取项均被证明承重，五个 reclaim 场景（`S1`–`S5`，含通过 `unshare` 置于独立 PID namespace 的 writer）按规定围栏或回收，目录 pin 规则正反两向均成立。该主机上 acp-bridge 947/947、cli 1300/1300。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  CI（新增 Linux 门控 reclaim 用例）  |

### 环境（可选）

macOS 26.4.1，按包本地运行 vitest；Linux 身份域覆盖在 CI 运行。

## 风险与范围

- 主要风险或取舍：强制 lease 与身份限定 reclaim 在进程全局 ownership gate 仍存在期间对 Conversations writer 生效，因此若有回归会先暴露在现有的单 owner 模型内。本 PR 交付两项 fail-closed 代价，均由 @wenshao 的 Linux E2E 实测确认。（a）在 Linux 上，旧版本写入的 record 缺少 namespace 身份，将保持围栏而不会被自动回收。（b）boot ID 或 PID namespace 不再匹配的 `active`（未 sealed）record 会被**永久**围栏：lease 既无 TTL 也无心跳，且没有任何 API 或 UI 能清除 writer 锁，唯一恢复手段是手工删除 `<runtimeBase>/tmp/session-writer-locks/<id>.lock`——而此时 `409` 文案（"This session is already open in another Qwen process."）是不成立的。触发路径包括掉电、内核 panic、OOM kill 后重启，以及**完全不需要重启**的一种：容器内 daemon 被 kill 后在挂载同一 home 的新 PID namespace 中重启。优雅停机**不受影响**：`SIGTERM`/`SIGINT` 会 seal 记录，而 certified takeover 发生在身份域检查之前。该项为开放决策（有界恢复路径如 machine-id 或 lease TTL／显式释放入口／仅补诊断与文档三选）；@wenshao 建议在 cutover PR 拆掉 ownership gate 之前解决它，因为届时会有多于一个 daemon 可能留下 `active` 记录。
- 未验证或范围外：ownership gate 的移除、legacy owner 兼容检查、deletion-journal 自举搬迁、带 pending-intent 线性化的 Live 启动 publisher admission、以及 Web Shell 降级都在后续 PR 中落地；backend 与 Web Shell 工作必须在同一 release 交付。双进程 E2E 覆盖随 cutover PR 到来。
- 破坏性变更或迁移说明：无 API 结构变化。批量生命周期项现在可能携带 `session_writer_conflict` 系列错误码，SDK 本就将其作为无约束字符串接受。

## 关联 Issue

Refs #10810

</details>

