### PR TITLE
ci: size two job caps for a contended install, not a quiet one

### DIFF
--- a/.github/workflows/npm-cache.yml
+++ b/.github/workflows/npm-cache.yml
@@ -32,7 +32,13 @@ jobs:
       image: 'node:22-bookworm'
       # Match the host runner UID/GID so bind-mounted files stay writable.
       options: '--init --user node'
-    timeout-minutes: 15
+    # This producer always cold-downloads -- RUNNER_TEMP is fresh per job and
+    # there is no cache/restore step here -- so its cost is a full registry
+    # fetch every time, and on the shared pool that is what varies. 22 green
+    # runs took 4.5-11.8 min, already within 3.2 min of the old 15; five more
+    # were cancelled at 15.2-16.8, i.e. at the cap. 30 covers the same ~4x
+    # contention factor measured on the pool's other npm ci steps.
+    timeout-minutes: 30
     steps:
       - uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
         with:

--- a/.github/workflows/sdk-java.yml
+++ b/.github/workflows/sdk-java.yml
@@ -156,7 +156,14 @@ jobs:
   daemon-e2e:
     name: 'Real daemon E2E / Java 11'
     runs-on: '${{ (github.repository == ''QwenLM/qwen-code'' && vars.MAINTAINER_ECS_RUNNER_DISABLED != ''true'' && (github.event_name == ''push'' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJSON(''["OWNER","MEMBER","COLLABORATOR"]''), github.event.pull_request.author_association))) && fromJSON(''["self-hosted", "linux", "x64", "ecs-qwen"]'') || ''ubuntu-latest'' }}'
-    timeout-minutes: 30
+    # 45, not 30: this job is ~90% setup. A quiet run is 12.2 min end to end --
+    # npm ci 5.9 + build 5.2 -- and the Java daemon E2E it exists for costs
+    # about a minute. On the shared pool that setup is what stretches: npm ci
+    # measured 4.0-5.9 min across 11 green runs and 19.9/22.6 min on the two
+    # that died, which is the whole difference between them. At that factor the
+    # setup alone needs ~44 min, so 30 cancelled the job before a single
+    # assertion ran. Matches the 45 tier release.yml's quality_build uses.
+    timeout-minutes: 45
     steps:
       - name: 'Restore workspace ownership'
         if: "${{ runner.environment == 'self-hosted' }}"


### PR DESCRIPTION
## What this PR does

Raises the job timeout on two self-hosted jobs whose caps were sized for their quiet-host cost rather than their cost on the shared ECS pool: `sdk-java`'s `daemon-e2e` from 30 to 45 minutes, and `npm-cache`'s `save` producer from 15 to 30. Both are currently dying at the cap rather than on anything they test.

## Why it's needed

### sdk-java / daemon-e2e

This job is about 90% setup. A green run is **12.2 minutes end to end** — `npm ci` 5.9, `npm run build` 5.2 — and the Java daemon E2E it exists for costs roughly a minute of that. On the shared pool the setup is what stretches, and it is the only thing separating a green run from a dead one:

| | `npm ci` duration |
| --- | --- |
| 11 green runs | 4.0 · 4.3 · 4.5 · 4.8 · 4.8 · 5.2 · 5.3 · 5.3 · 5.9 min |
| the 2 cancelled runs | **19.9 · 22.6 min** |

Perfectly bimodal, perfectly correlated — the two runs that died are exactly the two where install ran 4–5x long. Both were killed at **30.7 and 30.6 minutes**, inside `npm run build`, so the Java E2E never executed a single assertion. [Run 33750252633](https://github.com/QwenLM/qwen-code/actions/runs/33750252633) is one of them; its whole log is checkout → 22m38s of `npm ci` → 7 minutes of build → `##[error]The operation was canceled.`

At that contention factor the setup alone needs ~44 minutes (22.6 + 5.2×4), so **45 is the smallest cap that lets a contended run finish**. It matches the tier `release.yml`'s `quality_build` already uses.

### npm-cache / save

This producer **always cold-downloads by construction**: `RUNNER_TEMP` is fresh per job and the job has no `cache/restore` step, only `cache/save`. Its cost is a full registry fetch every time, so it is maximally exposed to pool contention. Across 30 runs:

| outcome | count | duration |
| --- | ---: | --- |
| success | 22 | 4.5 – 11.8 min |
| **cancelled at the cap** | **5** | 15.2 – 16.8 min |
| failed inside `npm ci` | 3 | 1.6 / 3.8 / 10.4 min |

The top of the *successful* range was already within 3.2 minutes of the old 15-minute cap. 27% of producer runs therefore save no cache. 30 covers the same ~4x factor measured on the pool's other installs.

The three `failure` runs died inside the `Populate npm cache` step itself. That is a different fault — a registry error, not a timeout — and is not addressed here.

## Reviewer Test Plan

### How to verify

This is a two-line change to `timeout-minutes` values, so the verification is the measurement rather than a test run. A reviewer should confirm three things.

First, that the cancelled `daemon-e2e` runs died at the cap and not on an assertion — the step timeline of run 33750252633 shows `npm ci` at 22m38s and `npm run build` cancelled 7 minutes in, with `Run Java daemon E2E` never reached. Second, that the bimodal `npm ci` split above is the actual discriminator, which it is: every green run is under 6 minutes and both dead runs are over 19. Third, that the sibling matrix jobs in `sdk-java.yml` do not need the same change — they run 0.6–2.5 minutes against the same 30-minute cap, which is why line 58 is left untouched.

The workflow-size ratchet passes locally, which matters because both files are under it.

### Evidence (Before & After)

N/A for user-visible behaviour — CI configuration only.

**Before**, `daemon-e2e` on a contended host:

    11:33:13  job starts                      timeout-minutes: 30
    11:33:35  npm ci ─────────────────────── 22m38s
    11:56:13  npm run build ──────────────── 7min, unfinished
    12:03:12  ##[error]The operation was canceled.     ← exactly 30:00

**After**, the same shape fits: 22.6 + ~21 (build at the same factor) + ~1 of actual E2E ≈ 45.

Workflow-size gate on this branch:

    ✅ every workflow file is under the 470000-byte gate and within 4096 bytes of its recorded baseline

(`sdk-java.yml` +1237 bytes and `npm-cache.yml` +451 against their baselines, both inside the 4096 allowance, so no `.size-baseline` bump is needed.)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment (optional)

N/A — no local runtime involved; the evidence is GitHub Actions run and job timings read through `gh`.

## Risk & Scope

- Main risk or tradeoff: raising a cap costs runner-minutes when a job is genuinely hung. That is the trade being made deliberately — today those minutes are spent anyway, and spent losing the run. Nothing else in either workflow changes.
- Not validated / out of scope: `qwen-autofix`'s `build-cli` has the same shape (30 minutes, `npm ci` + `build` + `bundle` on the pool) but is **skipped in every recent run**, so there is nothing to size it against and it is left alone. `release.yml`'s `prepare` and `quality_static` share the 30-minute cap but measured 3.2 and 3.8 minutes in the v0.23.0 run, leaving ample headroom even at 4x — and `release.yml` is CODEOWNERS-gated, so touching it here would gate this PR on a review it does not need. The three `npm-cache` runs that failed *inside* `npm ci` are a registry fault, not a timeout, and are not fixed here.
- Breaking changes / migration notes: none.

### An alternative considered for npm-cache

The cause-level fix would be to let the producer warm-start from its own previous cache via `actions/cache/restore` with `restore-keys: 'npm-ci-'`, which would cut its runtime rather than widen its budget. It is not done here because it changes what the saved entry contains — an npm cache directory seeded from an older one accumulates entries for dependencies no longer in the lockfile, and that grows without a bound anyone is watching. Worth doing deliberately, with a size check, rather than as a side effect of a timeout fix.

## Linked Issues

Same shared-pool contention as #10490 and the prerequisite work in #10915; this is the `timeout-minutes` face of it rather than the vitest `testTimeout` face. Observed on #10912's CI, where `Real daemon E2E / Java 11` was cancelled this way.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

抬高两个自托管 job 的超时上限 —— 它们的 cap 是按静态主机成本设的，而非共享 ECS 池上的实际成本：`sdk-java` 的 `daemon-e2e` 由 30 分钟改为 45，`npm-cache` 的 `save` 生产者由 15 改为 30。目前这两个 job 都是死在 cap 上，而不是死在它们所测试的任何东西上。

## 为什么需要

### sdk-java / daemon-e2e

这个 job 约 90% 的时间在装环境。一次绿色运行端到端为 **12.2 分钟** —— `npm ci` 5.9、`npm run build` 5.2 —— 而它存在的意义所在（Java daemon E2E）只占其中约一分钟。在共享池上，被拉长的正是这段装配，而且它是绿色运行与死亡运行之间唯一的区别：

| | `npm ci` 时长 |
| --- | --- |
| 11 次绿色运行 | 4.0 · 4.3 · 4.5 · 4.8 · 4.8 · 5.2 · 5.3 · 5.3 · 5.9 分钟 |
| 2 次被取消的运行 | **19.9 · 22.6 分钟** |

完美双峰、完美相关 —— 死掉的两次，恰恰就是安装耗时 4~5 倍的那两次。两次都在 **30.7 与 30.6 分钟**被杀，且都停在 `npm run build` 之中，因此 Java E2E 一个断言都没有执行。[Run 33750252633](https://github.com/QwenLM/qwen-code/actions/runs/33750252633) 就是其中之一，它的整份日志就是：checkout → 22 分 38 秒的 `npm ci` → 7 分钟的 build → `##[error]The operation was canceled.`

在该争抢倍数下，单是装配就需要约 44 分钟（22.6 + 5.2×4），因此 **45 是能让一次争抢运行跑完的最小 cap**，并且与 `release.yml` 的 `quality_build` 已在使用的档位一致。

### npm-cache / save

这个生产者在构造上**总是冷下载**：`RUNNER_TEMP` 每个 job 都是新的，且该 job 没有 `cache/restore` 步骤，只有 `cache/save`。它的成本因此每次都是一次完整的 registry 拉取，对池争抢的暴露是最大的。30 次运行中：

| 结果 | 次数 | 时长 |
| --- | ---: | --- |
| 成功 | 22 | 4.5 – 11.8 分钟 |
| **在 cap 上被取消** | **5** | 15.2 – 16.8 分钟 |
| 在 `npm ci` 内部失败 | 3 | 1.6 / 3.8 / 10.4 分钟 |

*成功*那一批的上沿已经距旧的 15 分钟 cap 只剩 3.2 分钟。也就是说 27% 的生产运行没有存下任何缓存。30 覆盖了在池上其它安装步骤实测到的同一个约 4 倍因子。

那 3 次 `failure` 死在 `Populate npm cache` 步骤内部。那是另一类故障 —— registry 错误而非超时 —— 本 PR 不处理。

## 评审验证方案

### 如何验证

这是对 `timeout-minutes` 的两行改动，因此验证依据是测量而非某次测试运行。评审者应确认三点。

其一，被取消的 `daemon-e2e` 运行死于 cap 而非断言 —— run 33750252633 的步骤时间线显示 `npm ci` 为 22 分 38 秒、`npm run build` 在第 7 分钟被取消，而 `Run Java daemon E2E` 从未被触及。其二，上表的双峰分布确实是判别变量：每一次绿色运行都在 6 分钟以内，两次死亡运行都超过 19 分钟。其三，`sdk-java.yml` 中的同级矩阵 job 不需要同样的改动 —— 它们在同样的 30 分钟 cap 下只跑 0.6–2.5 分钟，这就是第 58 行未被触碰的原因。

workflow 体积棘轮在本地通过，这一点重要，因为两个文件都受它管辖。

### 证据（前后对比）

用户可见行为方面为 N/A —— 仅 CI 配置。

**修改前**，`daemon-e2e` 在争抢主机上：

    11:33:13  job 开始                        timeout-minutes: 30
    11:33:35  npm ci ─────────────────────── 22m38s
    11:56:13  npm run build ──────────────── 7 分钟，未完成
    12:03:12  ##[error]The operation was canceled.     ← 正好 30:00

**修改后**，同样的形状可以装下：22.6 + 约 21（build 按同一倍数）+ 约 1 分钟的实际 E2E ≈ 45。

本分支上的体积门禁：

    ✅ every workflow file is under the 470000-byte gate and within 4096 bytes of its recorded baseline

（`sdk-java.yml` 相对基线 +1237 字节、`npm-cache.yml` +451，均在 4096 的允许增幅内，因此无需更新 `.size-baseline`。）

### 测试平台

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

N/A —— 不涉及本地运行时；证据是通过 `gh` 读取的 GitHub Actions run 与 job 时间数据。

## 风险与范围

- 主要风险或权衡：抬高 cap 会在 job 真正卡死时多消耗 runner 分钟数。这是刻意做出的取舍 —— 今天这些分钟同样会被消耗掉，而且是在赔掉整次运行的前提下消耗的。两个 workflow 中没有其它任何改动。
- 未验证 / 范围之外：`qwen-autofix` 的 `build-cli` 形状相同（30 分钟，池上的 `npm ci` + `build` + `bundle`），但在最近所有运行中都是 skipped，因此没有任何可据以定值的数据，予以保留不动。`release.yml` 的 `prepare` 与 `quality_static` 同为 30 分钟 cap，但在 v0.23.0 那次运行中分别只用了 3.2 与 3.8 分钟，即便按 4 倍计算也仍有充足余量 —— 而且 `release.yml` 受 CODEOWNERS 管控，在此改动会让本 PR 卡在一次它并不需要的评审上。`npm-cache` 那 3 次死在 `npm ci` *内部*的运行属于 registry 故障而非超时，本 PR 不修。
- 破坏性变更 / 迁移说明：无。

### 关于 npm-cache 考虑过的另一种方案

在成因层面的修法是让生产者通过 `actions/cache/restore` 配合 `restore-keys: 'npm-ci-'` 从自己上一次的缓存热启动，这样是缩短它的运行时间而非放宽它的预算。此处没有采用，是因为它会改变所保存条目的内容 —— 一个由旧缓存播种而来的 npm 缓存目录会不断累积已不在 lockfile 中的依赖条目，而这种增长目前没有任何人在盯。这件事值得单独、带上体积检查地去做，而不是作为一次超时修复的副作用。

## 关联 Issue

与 #10490 及 #10915 的前置工作是同一个共享池争抢问题；本 PR 是它的 `timeout-minutes` 一面，而非 vitest `testTimeout` 一面。在 #10912 的 CI 上观测到 `Real daemon E2E / Java 11` 正是以这种方式被取消。

</details>
