### PR TITLE
fix(web-shell): make the 30 s overview-poll e2e deterministic

### DIFF
--- a/packages/web-shell/client/e2e/web-shell.workspace-overview.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.workspace-overview.spec.ts
@@ -174,6 +174,38 @@ function overviewRequests(
     .map((request) => request.path.slice(prefix.length));
 }
 
+/**
+ * Waits until `count()` reports the same value for a quiet window of real
+ * time, then returns it. Startup fires several request bursts that the fake
+ * clock cannot gate (the StrictMode double mount, the composer skill loader,
+ * and one more facet round when the connection settles), so the polling
+ * baseline must be taken after those bursts have landed.
+ */
+async function waitForStableOverviewCount(
+  count: () => number,
+  quietWindowMs = 2_000,
+): Promise<number> {
+  const deadline = Date.now() + 15_000;
+  let last = count();
+  let quietSince = Date.now();
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const now = Date.now();
+    const current = count();
+    if (current !== last) {
+      last = current;
+      quietSince = now;
+    } else if (now - quietSince >= quietWindowMs) {
+      return current;
+    }
+    if (now > deadline) {
+      throw new Error(
+        `overview request count never stabilised (last count: ${current})`,
+      );
+    }
+  }
+}
+
 test('shows workspace details on hover and no counts in the header', async ({
   page,
 }, testInfo) => {
@@ -332,22 +364,37 @@ test('opens the workspace menu with management entries on the primary workspace 
   await expect(page.getByRole('region', { name: 'MCP Servers' })).toBeVisible();
 });
 
-test('polls an expanded workspace once per 30 s tick and not faster', async ({
+test('polls an expanded workspace once per 30 s tick and not faster @smoke', async ({
   page,
 }, testInfo) => {
   const scenario = createScenario();
   const daemon = await installScenario(page, scenario, testInfo);
   // A fake clock lets the spec observe the 30 s cadence without waiting.
+  // Pausing it keeps startup (StrictMode double mount, the composer skill
+  // loader, any connection-settle re-fetch) from eating into the interval
+  // the assertions measure: every startup timer is pinned to one fake
+  // instant, and nothing fires until runFor below.
   await page.clock.install();
+  await page.clock.pauseAt(Date.now());
   await gotoSession(page, scenario, daemon);
   const facets = (cwd: string) =>
     [...new Set(overviewRequests(daemon, cwd))].sort();
   await expect
     .poll(() => facets(PRIMARY_CWD))
     .toEqual(['channels', 'extensions', 'mcp', 'memory', 'skills']);
-  const settled = overviewRequests(daemon, PRIMARY_CWD).length;
+  // Let the real-time startup bursts land before counting.
+  await waitForStableOverviewCount(
+    () => overviewRequests(daemon, PRIMARY_CWD).length,
+  );
+  // Flush everything the paused startup scheduled below one cadence,
+  // including the first poll tick itself, so the baseline sits on a known
+  // interval phase.
+  await page.clock.runFor(30_500);
+  const settled = await waitForStableOverviewCount(
+    () => overviewRequests(daemon, PRIMARY_CWD).length,
+  );
 
-  // Just short of a tick: no new facet requests.
+  // Just short of the next tick: no new facet requests.
   await page.clock.runFor(29_000);
   await page.waitForTimeout(200);
   expect(overviewRequests(daemon, PRIMARY_CWD)).toHaveLength(settled);


### PR DESCRIPTION
## What this PR does

Makes the web-shell e2e case "polls an expanded workspace once per 30 s tick and not faster" deterministic and tags it `@smoke`. The spec now pauses the fake clock across startup, waits for the real-time startup request bursts to settle, then flushes the fake clock up to and including the first poll tick so the baseline sits on a known interval phase, and only then asserts the cadence (no new requests just short of the next tick, exactly one round past it). No product code changes; the rest of the spec file is untouched.

## Why it's needed

The nightly `web-shell Browser Regression` job has been red in every run since #10407 introduced this case (e.g. runs [33590493339](https://github.com/QwenLM/qwen-code/actions/runs/33590493339) and [33702961416](https://github.com/QwenLM/qwen-code/actions/runs/33702961416)), always failing with `Expected 11 / Received 16`. Two intertwined races, both confirmed by local instrumentation:

1. The `settled` baseline snapshot was taken as soon as the five distinct facets first appeared, while the startup bursts — the StrictMode double mount (two facet rounds), the composer skill loader's stray `GET .../skills` (counted because it shares the workspace route), and one more facet round when the connection settles — kept landing in real time afterwards, so the count kept climbing after the snapshot.
2. Even after waiting those bursts out, `page.clock.install()` keeps advancing fake time in lockstep with real time while the spec waits ~2 s for startup to settle. The overview interval is anchored at mount, so its first tick deadline lies ~28 s into the fake 29 s "quiet" window and always fires inside it.

So the case never actually measured "polling faster than 30 s"; it measured the phase offset between mount and the first `runFor`, which is never zero in a real browser. The 30 s timer itself behaves correctly. This PR is the deterministic-equivalent path of the issue's acceptance criteria.

## Reviewer Test Plan

### How to verify

From `packages/web-shell` (full config, not the `@smoke` subset):

`npm run test:e2e -- --grep "30 s tick"`

Before: fails reliably with the exact CI signature (`Expected 11 / Received 16` at the "just short of a tick" assertion). After: 5 consecutive local runs pass, and the whole spec file stays green:

```
run 1: 1 passed (18.1s)
run 2: 1 passed (19.9s)
run 3: 1 passed (18.3s)
run 4: 1 passed (18.5s)
run 5: 1 passed (17.8s)
full spec file: 4 passed (37.4s)
```

Why it is deterministic: with the clock paused, every startup timer is pinned to one fake instant; the flush then consumes exactly one interval tick (the following deadline is a full 30 s away), so the 29 s quiet window and the 2 s tick window keep a fixed phase relationship to the interval regardless of real startup duration.

### Evidence (Before & After)

N/A (e2e spec-only change; the failing/passing output is inline above)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Local vite dev server + Playwright chromium (headless) via the package's `test:e2e` script; `tsc -p tsconfig.json --noEmit`, `eslint` and `prettier --check` all clean for the package.

## Risk & Scope

- Main risk or tradeoff: the case now exercises a paused-then-flushed clock rather than a purely advancing one; that matches what the case name promises (cadence after startup settles) and costs ~4 extra real seconds per run.
- Not validated / out of scope: the optional product-side follow-up from the issue (stabilising client identity / skipping an immediate re-fetch right after a completed round) is deliberately not done here; the nightly leg remains the long-term watch for this job.
- Breaking changes / migration notes: none.

**`@smoke` decision (asked by the issue):** added. This job only runs on schedule/workflow_dispatch, and the case merged without the pre-merge leg ever executing it — which is exactly how it stayed red unnoticed. The pre-merge `web-shell browser smoke` job already boots the same vite + mock-daemon harness for other `@smoke` cases, so the marginal cost is this case's ~18 s runtime.

## Linked Issues

Fixes #10903

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 web-shell e2e 用例 "polls an expanded workspace once per 30 s tick and not faster" 变为确定性通过，并给它加上 `@smoke` 标记。现在 spec 会在启动阶段暂停假时钟，等真实时间里的启动请求突发全部落定，再把假时钟快进“冲刷”到（含）第一次轮询 tick 为止，使基线落在已知的区间相位上，然后才断言节奏（下一个 tick 到来前没有新请求，过 tick 后恰好一轮）。不改任何产品代码，spec 文件其余部分不动。

## 为什么需要

自 #10407 引入该用例后，nightly 的 `web-shell Browser Regression` 任务每次运行都红（例如 run [33590493339](https://github.com/QwenLM/qwen-code/actions/runs/33590493339) 和 [33702961416](https://github.com/QwenLM/qwen-code/actions/runs/33702961416)），失败签名始终是 `Expected 11 / Received 16`。这是两个交织的竞争，均已通过本地埋点确认：

1. `settled` 基线快照在五个 facet 首次全部出现时就被取走，而启动突发——StrictMode 双挂载（两轮 facet 请求）、composer 技能加载器的单独 `GET .../skills`（因为同路由被计入）、连接收敛后的又一轮 facet——之后仍在真实时间里陆续到达，计数在快照之后持续上涨。
2. 即使等这些突发落定，`page.clock.install()` 在 spec 等待启动的约 2 秒真实时间里仍让假时钟与真实时间同步前进。overview 轮询定时器锚定在挂载时刻，其首个 tick 截止点恰好落在假时钟 29 秒“静默”窗口内（约第 28 秒），因此必然在窗口内触发。

所以该用例实际测的从来不是“轮询快于 30 秒”，而是挂载时刻与首次 `runFor` 之间的相位差——在真实浏览器里这个差值永远不为零。30 秒定时器本身行为正确。本 PR 走 issue 验收标准里“确定性等价物”这条路径。

## 审阅者测试计划

### 如何验证

在 `packages/web-shell` 下（全量 config，不是 `@smoke` 子集）：

`npm run test:e2e -- --grep "30 s tick"`

修复前：稳定复现 CI 签名（“差一点到一个 tick”断言处 `Expected 11 / Received 16`）。修复后：本地连续 5 次通过，整个 spec 文件保持全绿：

```
第 1 次: 1 passed (18.1s)
第 2 次: 1 passed (19.9s)
第 3 次: 1 passed (18.3s)
第 4 次: 1 passed (18.5s)
第 5 次: 1 passed (17.8s)
整个 spec 文件: 4 passed (37.4s)
```

为什么是确定性的：时钟暂停期间，所有启动定时器都钉在同一个假时刻；随后的冲刷恰好消耗掉一次区间 tick（下一个截止点在整整 30 秒之后），因此 29 秒静默窗口和 2 秒过 tick 窗口与区间保持固定相位关系，与真实启动耗时无关。

### 前后证据

N/A（仅 e2e spec 改动；失败/通过输出已在上文贴出）

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

本地 vite dev server + Playwright chromium（headless），走包内 `test:e2e` 脚本；`tsc -p tsconfig.json --noEmit`、`eslint`、`prettier --check` 对该包均干净。

## 风险与范围

- 主要风险或取舍：用例现在走“暂停后冲刷”的时钟，而不是纯前进时钟；这与用例名承诺的语义（启动稳定后的节奏）一致，每次运行多花约 4 秒真实时间。
- 未验证 / 不在范围内：issue 中可选的产品侧跟进（稳定 client 身份 / 跳过刚完成一轮后的立即重取）本次刻意不做；该任务的 nightly leg 仍是长期观察手段。
- 破坏性变更 / 迁移说明：无。

**`@smoke` 决定（issue 点名要回答）**：加。该任务只在 schedule/workflow_dispatch 运行，用例合入时合入前 leg 从未执行过它——这正是它一直红却无人发现的原因。合入前的 `web-shell browser smoke` 任务本来就会为其它 `@smoke` 用例启动同一套 vite + mock-daemon 基建，边际成本只是该用例约 18 秒的运行时间。

## 关联 Issue

Fixes #10903

</details>
