### PR TITLE
docs: record where a background agent shows up, and who owns it

### DIFF
--- a/docs/plans/2026-09-04-background-agent-surfaces.md
+++ b/docs/plans/2026-09-04-background-agent-surfaces.md
@@ -1,0 +1,57 @@
+# Where a background agent shows up
+
+> Status: decision recorded, one surface unbuilt
+> Baseline: `678ac2e1ec` (`origin/main`, 2026-09-03)
+> Implements the CLI half in #10942, #10943, #10949. The Web Shell half is the open part.
+
+## 0. The decision, first
+
+**The Agent View roster is the authority on background agents. Every other surface reads it.**
+
+The alternative — letting the daemon keep its own idea of what is running in the background — is what produced the situation in §1, and adding a Web Shell panel on top of the daemon's model would make it permanent.
+
+One consequence to state plainly, because it is the part that costs work: the daemon does not read the roster today and will need to. That is a reader, not a new model.
+
+## 1. Three things already answer "what is running"
+
+Measured at `678ac2e1ec`.
+
+| Model                     | Written by                                                                | Stored at                                                                   | Read by                                                                |
+| ------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Live-process registry** | every interactive session, unconditionally (`startInteractiveUI.tsx:421`) | `~/.qwen/sessions/<pid>.json`                                               | `qwen sessions ps`, peer messaging discovery (`ipc/peer-directory.ts`) |
+| **Agent View roster**     | the supervisor (`supervisor-store.ts`)                                    | `~/.qwen/daemon/roster.json` + `~/.qwen/jobs/`                              | `qwen sessions ps` (#10942), `peek`/`answer`/`stop` (#10949)           |
+| **Daemon sessions**       | `qwen serve`                                                              | daemon process memory (`serve/conversations/standalone-session-service.ts`) | Web Shell                                                              |
+
+The third does not know about the first two: `rg 'listLiveSessions|session-registry' packages/cli/src/serve` returns nothing across 94,136 lines.
+
+Only the roster carries a background agent's _semantic_ state — `needs_input`, `working`, `failed` — because only the supervisor is told by the worker. The registry knows a process is alive. The daemon's model knows a conversation exists. Neither can answer "is it stuck waiting for me", which is the only question a background agent surface exists to answer.
+
+That is the whole argument for the decision in §0.
+
+## 2. What the CLI half already does
+
+- `qwen --bg "<prompt>"` records a session and a supervisor spawns it (#10943).
+- `qwen sessions ps` lists managed sessions beside interactive ones, deduplicated by session id, each with its real state (#10942).
+- `qwen sessions peek | answer | stop <id>` reads the question, answers it, ends the session (#10949).
+
+**A background session is peer-addressable for free.** The worker is launched as `qwen --session-id <id> --prompt-interactive=<prompt>` (`supervisor-dispatch.ts:196`), which is a full interactive session, so it registers in the live-process registry and — when `agents.crossSessionMessaging` is on — binds a peer inbox. It therefore appears in another session's `list_agents` and can be addressed with `send_message`, with no code that makes it so.
+
+This is worth naming because it decides what the Web Shell should _not_ build: a background agent is already reachable by the messaging tier. The Web Shell needs to show it, not to invent a second way to talk to it.
+
+## 3. The unbuilt surface
+
+A Web Shell panel that lists background agents and lets one be answered. Concretely:
+
+1. A daemon route that reads the roster — `listAgentViewSessionSnapshots()` plus `deriveAgentViewPresentation`, which is exactly what `managed-rows.ts` does for the CLI. Same source, same labels, no third vocabulary.
+2. A panel that renders the rows and posts an answer back through the supervisor's existing `answer` operation.
+
+Two rules for whoever builds it:
+
+- **Do not add a fourth model.** If the daemon needs to remember something about a background agent, it belongs in the roster.
+- **Label by task state, not by display group.** The roster's group folds `ready`, `stopped` and `failed` into `completed`; the roster UI can afford that because it also paints an icon tone. Any surface without a second channel must not print "completed" beside a session that failed — see `managed-rows.ts`.
+
+## 4. Left to a human
+
+**Should daemon-owned sessions adopt into the roster?** `qwen serve` starts sessions of its own (scheduled tasks, channel workers). They are background agents by any user's definition, and under §0 they would be visible in `qwen sessions ps` too. The supervisor already has an `adopt` operation for exactly this shape. Doing it means the daemon writes to the roster as well as reads it, which is a larger change than the panel and should be decided on its own.
+
+Not proposed here: moving the live-process registry or the daemon's session model under the roster. They answer different questions and both have consumers.

--- a/docs/plans/2026-09-04-background-agent-surfaces.md
+++ b/docs/plans/2026-09-04-background-agent-surfaces.md
@@ -50,6 +50,21 @@ Two rules for whoever builds it:
 - **Do not add a fourth model.** If the daemon needs to remember something about a background agent, it belongs in the roster.
 - **Label by task state, not by display group.** The roster's group folds `ready`, `stopped` and `failed` into `completed`; the roster UI can afford that because it also paints an icon tone. Any surface without a second channel must not print "completed" beside a session that failed — see `managed-rows.ts`.
 
+## 3.1 Two terminal channels, and which one is which
+
+Attaching to a background agent is a surface too, and there are currently two ways to put an agent on a terminal:
+
+|                                    | Owner                     | Status                                                                                        |
+| ---------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------- |
+| `TmuxBackend` (`agents/backends/`) | Agent Arena               | opt-in via `agents.displayMode: "tmux"`, falls back to in-process when tmux is missing or old |
+| `pty-host` (`agent-view/`)         | the Agent View supervisor | merged, and the thing `attach` will use                                                       |
+
+**Keep both, and keep them apart.** Arena's tmux path is small, opt-in, and degrades safely; it puts _arena competitors_ side by side in one terminal the user is already looking at. The supervisor's PTY host owns terminals for sessions that outlive the shell that started them — a different lifetime and a different owner.
+
+What must not happen is a third one. If Agent View attach ever wants tmux panes, it should drive them through the supervisor's PTY host rather than reaching into the Arena backend, whose `Backend` interface is a display abstraction with a semantic handle bolted on (`backends/types.ts`) and whose only wired implementation no-ops most of it.
+
+`ITermBackend` is the counter-example already in the tree: it exists, has never had a consumer, and `detectBackend` now reports it as unsupported rather than handing anyone an untested path.
+
 ## 4. Left to a human
 
 **Should daemon-owned sessions adopt into the roster?** `qwen serve` starts sessions of its own (scheduled tasks, channel workers). They are background agents by any user's definition, and under §0 they would be visible in `qwen sessions ps` too. The supervisor already has an `adopt` operation for exactly this shape. Doing it means the daemon writes to the roster as well as reads it, which is a larger change than the panel and should be decided on its own.


### PR DESCRIPTION
## What this PR does

Adds one design doc, `docs/plans/2026-09-04-background-agent-surfaces.md`. No code.

It records a decision the CLI half of this work already implements — **the Agent View roster is the authority on background agents, and every other surface reads it** — together with the measurement that forced the decision, and the one question it deliberately leaves open.

## Why it's needed

Three separate things already answer "what is running": the live-process registry (`~/.qwen/sessions/<pid>.json`), the Agent View roster (`~/.qwen/daemon/roster.json`), and the daemon's own in-memory session model. The daemon reads neither of the other two — `rg 'listLiveSessions|session-registry' packages/cli/src/serve` returns nothing across 94,136 lines.

That matters right now because the obvious next step is a Web Shell panel showing background agents, and the obvious way to build it — on the daemon's existing session model — would make the split permanent and give the product a fourth idea of what a session is.

The argument for the roster is not preference. Only the roster carries a background agent's semantic state (`needs_input`, `working`, `failed`), because only the supervisor is told by the worker. The registry knows a process is alive; the daemon knows a conversation exists. Neither can answer "is it stuck waiting for me", which is the only question a background-agent surface exists to answer.

The doc also records a consequence that decides what the Web Shell should *not* build: a `--bg` session is launched as a full interactive session (`supervisor-dispatch.ts:196`), so it registers in the live-process registry and binds a peer inbox when cross-session messaging is on. It is already addressable with `send_message` from another session, with no code that makes it so. The panel needs to show a background agent, not invent a second way to talk to one.

It is short on purpose. Two previous designs in this area (#8719, #9399) were closed unmerged, and neither failed on its reasoning; a third grand plan is not what is missing. This one records a decision and names the next concrete piece of code.

## Reviewer Test Plan

### How to verify

Documentation only. The three measurements it rests on are each one command:

- `rg 'listLiveSessions|session-registry' packages/cli/src/serve` → no matches.
- `startInteractiveUI.tsx:421` — `registerSession` is called unconditionally, so every interactive session (a background worker included) registers.
- `supervisor-dispatch.ts:196` — the worker argv is `--session-id <id> --prompt-interactive=<prompt>`.

`prettier --check` is clean on the file.

### Evidence (Before & After)

N/A — documentation.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A.

## Risk & Scope

- **Main risk or tradeoff:** the decision itself. Making the roster authoritative means the daemon grows a reader it does not have; the alternative was cheaper today and worse permanently. If a maintainer disagrees, this is the cheap place to say so — before a panel exists.
- **Not validated / out of scope:** the Web Shell panel is described, not built. This PR adds no code and changes no behaviour.
- **Breaking changes / migration notes:** none.

## Linked Issues

Records the decision behind #10942, #10943 and #10949. Supersedes nothing; #8719 and #9399 stay closed.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增一份设计文档 `docs/plans/2026-09-04-background-agent-surfaces.md`。无代码。

它记录了本工作 CLI 一侧已经在实现的一个决定 —— **Agent View roster 是后台 agent 的权威，其他所有界面都读它** —— 以及促成该决定的实测数据，和它有意留下未答的那个问题。

## 为什么需要

现在已经有三样东西在回答「什么在运行」：live-process registry（`~/.qwen/sessions/<pid>.json`）、Agent View roster（`~/.qwen/daemon/roster.json`），以及 daemon 自己的进程内 session 模型。而 daemon 既不读前者也不读中者 —— `rg 'listLiveSessions|session-registry' packages/cli/src/serve` 在 94,136 行中零命中。

这件事此刻重要，是因为下一步显而易见是做一个展示后台 agent 的 Web Shell 面板，而显而易见的做法 —— 基于 daemon 已有的 session 模型 —— 会把这个割裂固化下来，并让产品拥有第四种「session 是什么」的理解。

选择 roster 并非偏好。只有 roster 承载后台 agent 的语义状态（`needs_input`、`working`、`failed`），因为只有 supervisor 会被 worker 告知。registry 知道某个进程活着；daemon 知道某个会话存在。两者都无法回答「它是不是卡住在等我」—— 而这正是一个后台 agent 界面存在的唯一理由。

文档还记录了一个决定「Web Shell 不该建什么」的结论：`--bg` session 是以完整交互式 session 启动的（`supervisor-dispatch.ts:196`），因此它会注册进 live-process registry，并在跨 session 通信打开时绑定 peer inbox。它已经可以被另一个 session 用 `send_message` 寻址，无需任何专门代码。面板需要的是把后台 agent 显示出来，而不是再发明第二种与之对话的方式。

文档刻意写得短。这个方向上此前的两份设计（#8719、#9399）都被关闭且未合并，而它们都不是败在论证上；缺的不是第三份宏大计划。这一份只记录一个决定，并点名下一块具体的代码。

## 评审者测试计划

### 如何验证

纯文档。它依据的三处测量各是一条命令：

- `rg 'listLiveSessions|session-registry' packages/cli/src/serve` → 无匹配。
- `startInteractiveUI.tsx:421` —— `registerSession` 是无条件调用，因此每个交互式 session（包括后台 worker）都会注册。
- `supervisor-dispatch.ts:196` —— worker 的 argv 是 `--session-id <id> --prompt-interactive=<prompt>`。

该文件的 `prettier --check` 干净。

### 证据（前后对比）

N/A —— 纯文档。

### 测试环境

|    操作系统    | 状态 |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### 运行环境（可选）

N/A。

## 风险与范围

- **主要风险或取舍：** 就是这个决定本身。让 roster 成为权威，意味着 daemon 要长出一个它目前没有的读取方；另一种做法今天更便宜、长期更糟。如果维护者不同意，这里是最便宜的反对时机 —— 在面板还不存在之前。
- **未验证 / 范围之外：** Web Shell 面板只被描述，没有被实现。本 PR 不含代码，不改变任何行为。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

记录 #10942、#10943、#10949 背后的决定。不取代任何文档；#8719 与 #9399 保持关闭。

</details>
