### PR TITLE
perf(cli): run the suites that never touch a DOM under node

### DIFF
--- a/packages/cli/src/acp-integration/active-work-reporter.test.ts
+++ b/packages/cli/src/acp-integration/active-work-reporter.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   ACTIVE_WORK_HEARTBEAT_VERSION,

--- a/packages/cli/src/acp-integration/authMethods.test.ts
+++ b/packages/cli/src/acp-integration/authMethods.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { AuthType } from '@qwen-code/qwen-code-core';
 import {

--- a/packages/cli/src/acp-integration/child-heap-probe.test.ts
+++ b/packages/cli/src/acp-integration/child-heap-probe.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import type * as v8 from 'node:v8';
 import { constants as perfConstants } from 'node:perf_hooks';

--- a/packages/cli/src/acp-integration/extension-skills.test.ts
+++ b/packages/cli/src/acp-integration/extension-skills.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import type { Config, SkillConfig } from '@qwen-code/qwen-code-core';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/cli/src/acp-integration/generation.test.ts
+++ b/packages/cli/src/acp-integration/generation.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import type { Config } from '@qwen-code/qwen-code-core';
 import type { GenerateContentParameters } from '@google/genai';

--- a/packages/cli/src/acp-integration/live/capture-screen-context.test.ts
+++ b/packages/cli/src/acp-integration/live/capture-screen-context.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/cli/src/acp-integration/live/live-backend-instructions.test.ts
+++ b/packages/cli/src/acp-integration/live/live-backend-instructions.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { LIVE_BACKEND_START_INSTRUCTIONS } from './live-backend-instructions.js';
 

--- a/packages/cli/src/acp-integration/live/live-speak-to-user.test.ts
+++ b/packages/cli/src/acp-integration/live/live-speak-to-user.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import {
   SPEAK_TO_USER_TOOL_NAME,

--- a/packages/cli/src/acp-integration/live/live-task-tools.test.ts
+++ b/packages/cli/src/acp-integration/live/live-task-tools.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import {
   createLiveTaskTools,

--- a/packages/cli/src/acp-integration/model-configuration.test.ts
+++ b/packages/cli/src/acp-integration/model-configuration.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import type { Config, ContentGeneratorConfig } from '@qwen-code/qwen-code-core';
 import { describe, expect, it } from 'vitest';
 import {

--- a/packages/cli/src/acp-integration/service/filesystem.test.ts
+++ b/packages/cli/src/acp-integration/service/filesystem.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockDebugLogger = vi.hoisted(() => ({

--- a/packages/cli/src/acp-integration/session-model-persistence.test.ts
+++ b/packages/cli/src/acp-integration/session-model-persistence.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import { AuthType } from '@qwen-code/qwen-code-core';
 import type {

--- a/packages/cli/src/acp-integration/session/acp-tool-result-text-projection.test.ts
+++ b/packages/cli/src/acp-integration/session/acp-tool-result-text-projection.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { Buffer } from 'node:buffer';
 import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import { describe, expect, it } from 'vitest';

--- a/packages/cli/src/acp-integration/session/daemon-todo-stop-guard.test.ts
+++ b/packages/cli/src/acp-integration/session/daemon-todo-stop-guard.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   DaemonTodoStopGuard,

--- a/packages/cli/src/acp-integration/session/permissionUtils.test.ts
+++ b/packages/cli/src/acp-integration/session/permissionUtils.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import { ToolConfirmationOutcome } from '@qwen-code/qwen-code-core';
 import {

--- a/packages/cli/src/acp-integration/session/repeated-tool-failure-guard.test.ts
+++ b/packages/cli/src/acp-integration/session/repeated-tool-failure-guard.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import {
   ToolErrorType,
   type ToolExecutionStatus,

--- a/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/LlmRewriter.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/packages/cli/src/acp-integration/session/rewrite/TurnBuffer.test.ts
+++ b/packages/cli/src/acp-integration/session/rewrite/TurnBuffer.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TurnBuffer } from './TurnBuffer.js';
 

--- a/packages/cli/src/acp-integration/session/tasksSnapshot.test.ts
+++ b/packages/cli/src/acp-integration/session/tasksSnapshot.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import type {
   AgentTask,

--- a/packages/cli/src/acp-integration/skill-management.test.ts
+++ b/packages/cli/src/acp-integration/skill-management.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import {
   Storage,
   type Config,

--- a/packages/cli/src/acp-integration/skill-source-download.test.ts
+++ b/packages/cli/src/acp-integration/skill-source-download.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { gzipSync } from 'node:zlib';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {

--- a/packages/cli/src/agent-view/attach-lease.test.ts
+++ b/packages/cli/src/agent-view/attach-lease.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   AgentViewAttachLeaseManager,

--- a/packages/cli/src/agent-view/current-cli-argv.test.ts
+++ b/packages/cli/src/agent-view/current-cli-argv.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/agent-view/managed-detach.test.ts
+++ b/packages/cli/src/agent-view/managed-detach.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { detachCurrentSessionToAgentView } from './managed-detach.js';

--- a/packages/cli/src/agent-view/presentation.test.ts
+++ b/packages/cli/src/agent-view/presentation.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import type {
   AgentViewActivityFile,

--- a/packages/cli/src/agent-view/pty-host.test.ts
+++ b/packages/cli/src/agent-view/pty-host.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import type { AgentViewLaunchFile } from './protocol.js';
 import { PTY_HOST_AUTH_TOKEN_ENV, PTY_HOST_ID_ENV } from './pty-host-env.js';

--- a/packages/cli/src/agent-view/supervisor-dispatch.test.ts
+++ b/packages/cli/src/agent-view/supervisor-dispatch.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/agent-view/supervisor-process.test.ts
+++ b/packages/cli/src/agent-view/supervisor-process.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import * as fsSync from 'node:fs';
 import type { Socket } from 'node:net';

--- a/packages/cli/src/agent-view/supervisor-runner.test.ts
+++ b/packages/cli/src/agent-view/supervisor-runner.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs/promises';

--- a/packages/cli/src/agent-view/supervisor-server.test.ts
+++ b/packages/cli/src/agent-view/supervisor-server.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import * as net from 'node:net';
 import * as os from 'node:os';

--- a/packages/cli/src/agent-view/supervisor-store.test.ts
+++ b/packages/cli/src/agent-view/supervisor-store.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/agent-view/terminal-bridge.test.ts
+++ b/packages/cli/src/agent-view/terminal-bridge.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { Readable, Writable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 import {

--- a/packages/cli/src/agent-view/worker-sideband.test.ts
+++ b/packages/cli/src/agent-view/worker-sideband.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AGENT_VIEW_WORKER_ENV_KEYS,

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import yargs from 'yargs';
 import { authCommand, buildRemovalNotice, printRemovalNotice } from './auth.js';

--- a/packages/cli/src/commands/channel/channel-btw-wire-key.test.ts
+++ b/packages/cli/src/commands/channel/channel-btw-wire-key.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import { SERVE_CONTROL_EXT_METHODS } from '@qwen-code/acp-bridge/status';
 import { CHANNEL_BTW_METHOD } from '@qwen-code/channel-base';

--- a/packages/cli/src/commands/channel/channel-cwd.test.ts
+++ b/packages/cli/src/commands/channel/channel-cwd.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/packages/cli/src/commands/channel/channel-descriptor-sdk-mirror.test.ts
+++ b/packages/cli/src/commands/channel/channel-descriptor-sdk-mirror.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import type {
   ChannelConfigFieldDescriptor,

--- a/packages/cli/src/commands/channel/channel-prompt-wire-key.test.ts
+++ b/packages/cli/src/commands/channel/channel-prompt-wire-key.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import { CHANNEL_PROMPT_META_KEY } from '@qwen-code/channel-base';
 import { CHANNEL_PROMPT_META_KEY as BRIDGE_CHANNEL_PROMPT_META_KEY } from '@qwen-code/acp-bridge/bridgeTypes';

--- a/packages/cli/src/commands/channel/channel-registry-builtins.test.ts
+++ b/packages/cli/src/commands/channel/channel-registry-builtins.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 import type { ChannelPlugin } from '@qwen-code/channel-base';
 

--- a/packages/cli/src/commands/channel/channel-registry.test.ts
+++ b/packages/cli/src/commands/channel/channel-registry.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 import type { ChannelPlugin } from '@qwen-code/channel-base';
 import {

--- a/packages/cli/src/commands/channel/config-utils.test.ts
+++ b/packages/cli/src/commands/channel/config-utils.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/packages/cli/src/commands/channel/display-text-wire-key.test.ts
+++ b/packages/cli/src/commands/channel/display-text-wire-key.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import { CHANNEL_PROMPT_DISPLAY_TEXT_META_KEY } from '@qwen-code/channel-base';
 import { DAEMON_PROMPT_DISPLAY_TEXT_META_KEY } from '@qwen-code/acp-bridge/bridgeTypes';

--- a/packages/cli/src/commands/channel/memory-intent-classifier.test.ts
+++ b/packages/cli/src/commands/channel/memory-intent-classifier.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 import type { ChannelAgentBridge } from '@qwen-code/channel-base';
 import { BridgeChannelMemoryIntentClassifier } from './memory-intent-classifier.js';

--- a/packages/cli/src/commands/channel/observed-contact-store.test.ts
+++ b/packages/cli/src/commands/channel/observed-contact-store.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/cli/src/commands/channel/pairing.test.ts
+++ b/packages/cli/src/commands/channel/pairing.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/commands/channel/pidfile.test.ts
+++ b/packages/cli/src/commands/channel/pidfile.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join } from 'node:path';
 

--- a/packages/cli/src/commands/channel/private-parent-capability-wire-key.test.ts
+++ b/packages/cli/src/commands/channel/private-parent-capability-wire-key.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import {
   ACP_PRIVATE_PARENT_CAPABILITY_ENV,

--- a/packages/cli/src/commands/channel/reload.test.ts
+++ b/packages/cli/src/commands/channel/reload.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReloadChannelWorker = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/channel/set.test.ts
+++ b/packages/cli/src/commands/channel/set.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSetSelection = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/channel/startup-failure-format.test.ts
+++ b/packages/cli/src/commands/channel/startup-failure-format.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   channelStartupFailureBody,

--- a/packages/cli/src/commands/channel/status.test.ts
+++ b/packages/cli/src/commands/channel/status.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReadServiceInfo = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/channel/stop.test.ts
+++ b/packages/cli/src/commands/channel/stop.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockReadServiceInfo = vi.hoisted(() => vi.fn());

--- a/packages/cli/src/commands/extensions/new.test.ts
+++ b/packages/cli/src/commands/extensions/new.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { newCommand } from './new.js';
 import yargs from 'yargs';

--- a/packages/cli/src/commands/review/extract-step.test.ts
+++ b/packages/cli/src/commands/review/extract-step.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // The risk is silent wrongness, not crashes: extracting the same-named step
 // from the wrong job, dropping the env that changes the script's behaviour —
 // including the two levels, job and workflow, that the step's own text does not

--- a/packages/cli/src/commands/review/lib/agent-identity.test.ts
+++ b/packages/cli/src/commands/review/lib/agent-identity.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // One parser for the identity line `agent-prompt` bakes into every launch —
 // shared by cost-ledger (row labels) and coverage (disclosure labels), which
 // previously each carried their own copy of this grammar.

--- a/packages/cli/src/commands/review/lib/assets.test.ts
+++ b/packages/cli/src/commands/review/lib/assets.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   ASSET_EXTENSIONS,

--- a/packages/cli/src/commands/review/lib/budget.test.ts
+++ b/packages/cli/src/commands/review/lib/budget.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   MAX_INLINE_ANGLES,

--- a/packages/cli/src/commands/review/lib/build-budget.test.ts
+++ b/packages/cli/src/commands/review/lib/build-budget.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';

--- a/packages/cli/src/commands/review/lib/deadline.test.ts
+++ b/packages/cli/src/commands/review/lib/deadline.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
 // The real fs, wrapped so the claim-write fault below is injectable

--- a/packages/cli/src/commands/review/lib/diff-flags.test.ts
+++ b/packages/cli/src/commands/review/lib/diff-flags.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // The pinned knobs are a contract with every parser downstream, and each one
 // is here because its default breaks one of them. A pin deleted as
 // "redundant" fails nothing else in the suite — the handler tests mock the

--- a/packages/cli/src/commands/review/lib/gh.test.ts
+++ b/packages/cli/src/commands/review/lib/gh.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import type { MockInstance } from 'vitest';
 

--- a/packages/cli/src/commands/review/lib/import-graph.test.ts
+++ b/packages/cli/src/commands/review/lib/import-graph.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // The widening heuristic's contract is directional: a false positive costs one
 // extra review, a false negative keeps the pre-widening floor. These tests pin
 // the resolution rules (ESM-TS `.js` → `.ts`, index forms, workspace names)

--- a/packages/cli/src/commands/review/lib/inline-counts.test.ts
+++ b/packages/cli/src/commands/review/lib/inline-counts.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   carriedClaimLine,

--- a/packages/cli/src/commands/review/lib/ledger.test.ts
+++ b/packages/cli/src/commands/review/lib/ledger.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // The marker rides inside a posted review body — another account's writable
 // surface — so the parse half is tested as an untrusted-input boundary: every
 // malformation contributes nothing, and nothing throws.

--- a/packages/cli/src/commands/review/lib/md-field.test.ts
+++ b/packages/cli/src/commands/review/lib/md-field.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { mdField } from './md-field.js';
 import { parseLedger, stripLedgerMarker } from './ledger.js';

--- a/packages/cli/src/commands/review/lib/merge-base.test.ts
+++ b/packages/cli/src/commands/review/lib/merge-base.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { resolveMergeBase, type GitProbe } from './merge-base.js';
 

--- a/packages/cli/src/commands/review/lib/paths.test.ts
+++ b/packages/cli/src/commands/review/lib/paths.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { basename, dirname, join, resolve } from 'node:path';
 import { mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs';

--- a/packages/cli/src/commands/review/lib/platform/aone-client.test.ts
+++ b/packages/cli/src/commands/review/lib/platform/aone-client.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 

--- a/packages/cli/src/commands/review/lib/platform/github.test.ts
+++ b/packages/cli/src/commands/review/lib/platform/github.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // githubReader.composeUrl is pure assembly — no API call — so its whole
 // surface is the PR-page grammar and the host precedence: the routed gh
 // host, else an operator-exported GH_HOST, else FAIL CLOSED with ''. gh's

--- a/packages/cli/src/commands/review/lib/prompt-record.test.ts
+++ b/packages/cli/src/commands/review/lib/prompt-record.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // The delivery check, and the two ways it was wrong.
 //
 // It began as a straight substring test — "the built prompt must appear in the

--- a/packages/cli/src/commands/review/lib/receipt.test.ts
+++ b/packages/cli/src/commands/review/lib/receipt.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { parseReceiptCommentIds, parseReceiptIds } from './receipt.js';
 

--- a/packages/cli/src/commands/review/lib/remote-match.test.ts
+++ b/packages/cli/src/commands/review/lib/remote-match.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   parseRemoteUrl,

--- a/packages/cli/src/commands/review/lib/review-digest-covers-only-bundled.test.ts
+++ b/packages/cli/src/commands/review/lib/review-digest-covers-only-bundled.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // The digest must cover exactly the review sources the bundle contains.
 //
 // Deciding that by filename has now been wrong four times: `.test.ts` files,

--- a/packages/cli/src/commands/review/lib/round-model.test.ts
+++ b/packages/cli/src/commands/review/lib/round-model.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { certifierMatchesRound, roundModelIdFrom } from './round-model.js';
 

--- a/packages/cli/src/commands/review/lib/same-file.test.ts
+++ b/packages/cli/src/commands/review/lib/same-file.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   linkSync,

--- a/packages/cli/src/commands/review/lib/stale-bundle.test.ts
+++ b/packages/cli/src/commands/review/lib/stale-bundle.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   mkdirSync,

--- a/packages/cli/src/commands/review/lib/workspace-scope.test.ts
+++ b/packages/cli/src/commands/review/lib/workspace-scope.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { isInertLicense, resolveTestScope } from './workspace-scope.js';
 import type { WorkspacePackage } from './workspaces.js';

--- a/packages/cli/src/commands/review/lib/workspaces.test.ts
+++ b/packages/cli/src/commands/review/lib/workspaces.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   mkdtempSync,

--- a/packages/cli/src/commands/review/lib/worktree-reader.test.ts
+++ b/packages/cli/src/commands/review/lib/worktree-reader.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // Real filesystem. The bug this locks down lives in the kernel's path
 // resolution, and a mocked `fs` would happily "pass" against a fiction —
 // which is exactly how the lexically-inside form got through the first gate.

--- a/packages/cli/src/commands/review/mock-provider.test.ts
+++ b/packages/cli/src/commands/review/mock-provider.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // The fixture half of 94 hand-written mock servers: SSE framing (93%), a
 // `[DONE]` terminator (92%), `/v1/chat/completions` (73%), a usage block (69%),
 // a request log (62%). Driven here over real HTTP, because a mock asserted

--- a/packages/cli/src/commands/review/workflow-script.test.ts
+++ b/packages/cli/src/commands/review/workflow-script.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import * as vm from 'node:vm';
 import { REVIEW_BUILTIN_SUBAGENT_TYPE } from '@qwen-code/qwen-code-core';

--- a/packages/cli/src/commands/sessions/ps.test.ts
+++ b/packages/cli/src/commands/sessions/ps.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import stringWidth from 'string-width';
 import type { SessionRegistryRecord } from '@qwen-code/qwen-code-core';

--- a/packages/cli/src/config/acp-channel-fallback.test.ts
+++ b/packages/cli/src/config/acp-channel-fallback.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   QWEN_CODE_DESKTOP_ENV,

--- a/packages/cli/src/config/extension-file-watcher.test.ts
+++ b/packages/cli/src/config/extension-file-watcher.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as path from 'node:path';
 import type { Config, ExtensionMutationEvent } from '@qwen-code/qwen-code-core';

--- a/packages/cli/src/config/extension-refresh-state.test.ts
+++ b/packages/cli/src/config/extension-refresh-state.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ExtensionRefreshState } from './extension-refresh-state.js';
 import { AppEvent } from '../utils/events.js';

--- a/packages/cli/src/config/extension-runtime-reload.test.ts
+++ b/packages/cli/src/config/extension-runtime-reload.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import type { Config } from '@qwen-code/qwen-code-core';
 import {

--- a/packages/cli/src/config/keyBindings.test.ts
+++ b/packages/cli/src/config/keyBindings.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import type { KeyBindingConfig } from './keyBindings.js';
 import { Command, defaultKeyBindings } from './keyBindings.js';

--- a/packages/cli/src/config/lsp-config-watcher.test.ts
+++ b/packages/cli/src/config/lsp-config-watcher.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/config/mcpApprovals.test.ts
+++ b/packages/cli/src/config/mcpApprovals.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/config/mcpJson.test.ts
+++ b/packages/cli/src/config/mcpJson.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/config/mcpServers.test.ts
+++ b/packages/cli/src/config/mcpServers.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/config/migration/scheduler.test.ts
+++ b/packages/cli/src/config/migration/scheduler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 import { MigrationScheduler } from './scheduler.js';
 

--- a/packages/cli/src/config/migration/versions/v5-to-v4.test.ts
+++ b/packages/cli/src/config/migration/versions/v5-to-v4.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { V5ToV4Migration } from './v5-to-v4.js';
 

--- a/packages/cli/src/config/normalizeDisabledTools.test.ts
+++ b/packages/cli/src/config/normalizeDisabledTools.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { normalizeDisabledToolList } from './normalizeDisabledTools.js';
 

--- a/packages/cli/src/config/session-id.test.ts
+++ b/packages/cli/src/config/session-id.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   isValidSessionId,

--- a/packages/cli/src/config/shared-env-keys.test.ts
+++ b/packages/cli/src/config/shared-env-keys.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   acquireInheritedLoaderEnvScrub,

--- a/packages/cli/src/config/top-level-options.test.ts
+++ b/packages/cli/src/config/top-level-options.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   APPROVAL_MODE_INFO,

--- a/packages/cli/src/config/trust-precedence.test.ts
+++ b/packages/cli/src/config/trust-precedence.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { getPathComparisonVariants } from './path-comparison.js';
 import {

--- a/packages/cli/src/core/auth.test.ts
+++ b/packages/cli/src/core/auth.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { performInitialAuth } from './auth.js';
 

--- a/packages/cli/src/i18n/languageUtils.test.ts
+++ b/packages/cli/src/i18n/languageUtils.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/packages/cli/src/nonInteractive/io/StreamJsonInputReader.test.ts
+++ b/packages/cli/src/nonInteractive/io/StreamJsonInputReader.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { PassThrough } from 'node:stream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {

--- a/packages/cli/src/nonInteractive/tool-result-boundary-diagnostics.test.ts
+++ b/packages/cli/src/nonInteractive/tool-result-boundary-diagnostics.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SessionUpdate } from '@agentclientprotocol/sdk';
 import { LOAD_REPLAY_META_KEY } from '@qwen-code/acp-bridge/bridgeTypes';

--- a/packages/cli/src/peerMessaging/peer-messaging.test.ts
+++ b/packages/cli/src/peerMessaging/peer-messaging.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 /**
  * End-to-end over a real socket: a frame written by the client comes out
  * of the gate and lands in the submit function, wrapped and attributed.

--- a/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
+++ b/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/runtime/channel-delivery-ipc.test.ts
+++ b/packages/cli/src/runtime/channel-delivery-ipc.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   CHANNEL_DELIVERY_IPC_TIMEOUT_MS,

--- a/packages/cli/src/runtime/channel-delivery.test.ts
+++ b/packages/cli/src/runtime/channel-delivery.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   MAX_CHANNEL_DELIVERY_TEXT_LENGTH,

--- a/packages/cli/src/runtime/live-session-source.test.ts
+++ b/packages/cli/src/runtime/live-session-source.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   classifyTopLevelConversationSource,

--- a/packages/cli/src/runtime/scheduled-task-run.test.ts
+++ b/packages/cli/src/runtime/scheduled-task-run.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   buildScheduledTaskRunPrompt,

--- a/packages/cli/src/runtime/workspace-remember-errors.test.ts
+++ b/packages/cli/src/runtime/workspace-remember-errors.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   extractRememberErrorCode,

--- a/packages/cli/src/serve/acp-child-extra-args.test.ts
+++ b/packages/cli/src/serve/acp-child-extra-args.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { acpChildExtraArgs } from './acp-child-extra-args.js';
 

--- a/packages/cli/src/serve/acp-http/client-mcp-sender-registry.test.ts
+++ b/packages/cli/src/serve/acp-http/client-mcp-sender-registry.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import {

--- a/packages/cli/src/serve/acp-http/json-rpc.test.ts
+++ b/packages/cli/src/serve/acp-http/json-rpc.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   isNotification,

--- a/packages/cli/src/serve/acp-http/pre-attach-budget.test.ts
+++ b/packages/cli/src/serve/acp-http/pre-attach-budget.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { AcpPreAttachBudget } from './pre-attach-budget.js';
 

--- a/packages/cli/src/serve/acp-http/safe-ws-send.test.ts
+++ b/packages/cli/src/serve/acp-http/safe-ws-send.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 import type { WebSocket } from 'ws';
 import { safeWsSend } from './safe-ws-send.js';

--- a/packages/cli/src/serve/acp-http/sse-stream.test.ts
+++ b/packages/cli/src/serve/acp-http/sse-stream.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Response } from 'express';

--- a/packages/cli/src/serve/acp-http/ws-stream.test.ts
+++ b/packages/cli/src/serve/acp-http/ws-stream.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { WsStream } from './ws-stream.js';

--- a/packages/cli/src/serve/auth.test.ts
+++ b/packages/cli/src/serve/auth.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { createServer } from 'node:http';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import { describe, expect, it } from 'vitest';

--- a/packages/cli/src/serve/capabilities-docs-contract.test.ts
+++ b/packages/cli/src/serve/capabilities-docs-contract.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/packages/cli/src/serve/cdp-tunnel/acceptance/acceptance-helpers.test.ts
+++ b/packages/cli/src/serve/cdp-tunnel/acceptance/acceptance-helpers.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import { spawn } from 'node:child_process';
 import {

--- a/packages/cli/src/serve/cdp-tunnel/cdp-browser-emulator.test.ts
+++ b/packages/cli/src/serve/cdp-tunnel/cdp-browser-emulator.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 import { CdpBrowserEmulator, type CdpFrame } from './cdp-browser-emulator.js';
 

--- a/packages/cli/src/serve/cdp-tunnel/cdp-reverse-link.test.ts
+++ b/packages/cli/src/serve/cdp-tunnel/cdp-reverse-link.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 import {
   CdpReverseLink,

--- a/packages/cli/src/serve/cdp-tunnel/cdp-tunnel-registry.test.ts
+++ b/packages/cli/src/serve/cdp-tunnel/cdp-tunnel-registry.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 import {
   CdpTunnelRegistry,

--- a/packages/cli/src/serve/cdp-tunnel/cdp-ws.test.ts
+++ b/packages/cli/src/serve/cdp-tunnel/cdp-ws.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 import type { WebSocket } from 'ws';
 import { attachCdpClient } from './cdp-ws.js';

--- a/packages/cli/src/serve/channel-delivery-authorization.test.ts
+++ b/packages/cli/src/serve/channel-delivery-authorization.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { ChannelDeliveryAuthorizationStore } from './channel-delivery-authorization.js';
 

--- a/packages/cli/src/serve/channel-loop-mcp-ipc.test.ts
+++ b/packages/cli/src/serve/channel-loop-mcp-ipc.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import {
   ChannelLoopMcpWorkerHost,

--- a/packages/cli/src/serve/channel-selection.test.ts
+++ b/packages/cli/src/serve/channel-selection.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import {
   channelSelectionNames,

--- a/packages/cli/src/serve/channel-worker-diagnostics.test.ts
+++ b/packages/cli/src/serve/channel-worker-diagnostics.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   createWorkerDiagnosticRedactor,

--- a/packages/cli/src/serve/channel-worker-startup-ipc.test.ts
+++ b/packages/cli/src/serve/channel-worker-startup-ipc.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   isChannelStartupFailure,

--- a/packages/cli/src/serve/channel-worker-supervisor.test.ts
+++ b/packages/cli/src/serve/channel-worker-supervisor.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { EventEmitter } from 'node:events';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/serve/channel-workspace-grouping.test.ts
+++ b/packages/cli/src/serve/channel-workspace-grouping.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/packages/cli/src/serve/conversations/conversation-runtime-ownership.test.ts
+++ b/packages/cli/src/serve/conversations/conversation-runtime-ownership.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/serve/conversations/conversation-workspace.test.ts
+++ b/packages/cli/src/serve/conversations/conversation-workspace.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { realpathSync } from 'node:fs';
 import {
   chmod,

--- a/packages/cli/src/serve/conversations/standalone-deletion-journal.test.ts
+++ b/packages/cli/src/serve/conversations/standalone-deletion-journal.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import type { PathLike } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/packages/cli/src/serve/daemon-git-worktree-guard.test.ts
+++ b/packages/cli/src/serve/daemon-git-worktree-guard.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { mkdirSync, mkdtempSync } from 'node:fs';
 import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';

--- a/packages/cli/src/serve/daemon-git-worktree-guard.win32-lane.test.ts
+++ b/packages/cli/src/serve/daemon-git-worktree-guard.win32-lane.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // Runs the committed guard suite the way the Windows merge lane executes it
 // (win32 + cmd.exe, no Git-Bash markers), so a lane-red defect is caught on
 // every platform instead of first going red inside the merge queue. The

--- a/packages/cli/src/serve/daemon-logger.test.ts
+++ b/packages/cli/src/serve/daemon-logger.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as os from 'node:os';
 import * as path from 'node:path';
 import {

--- a/packages/cli/src/serve/daemon-memory-pressure.test.ts
+++ b/packages/cli/src/serve/daemon-memory-pressure.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { getHeapStatistics } from 'node:v8';
 import { describe, expect, it } from 'vitest';
 import {

--- a/packages/cli/src/serve/env-snapshot.test.ts
+++ b/packages/cli/src/serve/env-snapshot.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import os from 'node:os';
 import {

--- a/packages/cli/src/serve/extension-operation-scheduler.test.ts
+++ b/packages/cli/src/serve/extension-operation-scheduler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import { createFifoTaskQueue } from './extension-operation-scheduler.js';
 

--- a/packages/cli/src/serve/external-tool-guard-provider.test.ts
+++ b/packages/cli/src/serve/external-tool-guard-provider.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import * as http from 'node:http';
 import type { AddressInfo } from 'node:net';

--- a/packages/cli/src/serve/fs/errors.test.ts
+++ b/packages/cli/src/serve/fs/errors.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   FsError,

--- a/packages/cli/src/serve/large-pipe-frame-observer.test.ts
+++ b/packages/cli/src/serve/large-pipe-frame-observer.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import { LOAD_REPLAY_META_KEY } from '@qwen-code/acp-bridge/bridgeTypes';
 import {

--- a/packages/cli/src/serve/live/discovery.test.ts
+++ b/packages/cli/src/serve/live/discovery.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/serve/live/live-host-coordinator.test.ts
+++ b/packages/cli/src/serve/live/live-host-coordinator.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { EventEmitter } from 'node:events';
 import { WebSocket } from 'ws';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/packages/cli/src/serve/live/live-host-installer.test.ts
+++ b/packages/cli/src/serve/live/live-host-installer.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { createHash } from 'node:crypto';
 import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';

--- a/packages/cli/src/serve/live/qwen-realtime-session.test.ts
+++ b/packages/cli/src/serve/live/qwen-realtime-session.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it, vi } from 'vitest';
 import {
   deriveQwenOmniRealtimeUrl,

--- a/packages/cli/src/serve/local-bind-addresses.test.ts
+++ b/packages/cli/src/serve/local-bind-addresses.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { networkInterfaces, type NetworkInterfaceInfo } from 'node:os';
 import {

--- a/packages/cli/src/serve/local-control/lan-interfaces.test.ts
+++ b/packages/cli/src/serve/local-control/lan-interfaces.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import type { NetworkInterfaceInfo } from 'node:os';
 import { describe, expect, it } from 'vitest';
 import { listLanCandidates } from './lan-interfaces.js';

--- a/packages/cli/src/serve/local-control/service.test.ts
+++ b/packages/cli/src/serve/local-control/service.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import express from 'express';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';

--- a/packages/cli/src/serve/managed-scratch-workspace.test.ts
+++ b/packages/cli/src/serve/managed-scratch-workspace.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import {
   chmod,
   lstat,

--- a/packages/cli/src/serve/model-providers-edit.test.ts
+++ b/packages/cli/src/serve/model-providers-edit.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   isActiveModelSelection,

--- a/packages/cli/src/serve/native-directory-picker.test.ts
+++ b/packages/cli/src/serve/native-directory-picker.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/cli/src/serve/open-with-auth.test.ts
+++ b/packages/cli/src/serve/open-with-auth.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ServeOptions } from './types.js';
 import { applyOpenWithAuth } from './open-with-auth.js';

--- a/packages/cli/src/serve/pem-certificate-blocks-legacy.test.ts
+++ b/packages/cli/src/serve/pem-certificate-blocks-legacy.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { rootCertificates } from 'node:tls';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/cli/src/serve/pem-certificate-blocks-oracle.test.ts
+++ b/packages/cli/src/serve/pem-certificate-blocks-oracle.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { rootCertificates } from 'node:tls';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/cli/src/serve/pem-certificate-blocks.test.ts
+++ b/packages/cli/src/serve/pem-certificate-blocks.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/serve/permission-audit.test.ts
+++ b/packages/cli/src/serve/permission-audit.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   createPermissionAuditPublisher,

--- a/packages/cli/src/serve/process-env-guard.test.ts
+++ b/packages/cli/src/serve/process-env-guard.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/cli/src/serve/routes/usage-stats.test.ts
+++ b/packages/cli/src/serve/routes/usage-stats.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import express from 'express';
 import fs from 'node:fs';
 import os from 'node:os';

--- a/packages/cli/src/serve/routes/workspace-local-control.test.ts
+++ b/packages/cli/src/serve/routes/workspace-local-control.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import express from 'express';

--- a/packages/cli/src/serve/scheduled-task-session-lifecycle.test.ts
+++ b/packages/cli/src/serve/scheduled-task-session-lifecycle.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { promises as fsp } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/serve/serve-app-lifecycle.test.ts
+++ b/packages/cli/src/serve/serve-app-lifecycle.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { createServer, get } from 'node:http';
 import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/packages/cli/src/serve/serve-token.test.ts
+++ b/packages/cli/src/serve/serve-token.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { resolveServeToken } from './serve-token.js';
 

--- a/packages/cli/src/serve/server/access-log.test.ts
+++ b/packages/cli/src/serve/server/access-log.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { EventEmitter } from 'node:events';
 import { context, ROOT_CONTEXT } from '@opentelemetry/api';
 import type { Application, RequestHandler } from 'express';

--- a/packages/cli/src/serve/server/activity-timestamp.test.ts
+++ b/packages/cli/src/serve/server/activity-timestamp.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { laterActivityTimestamp } from './activity-timestamp.js';
 

--- a/packages/cli/src/serve/server/aone-mrs.test.ts
+++ b/packages/cli/src/serve/server/aone-mrs.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 // `vi.mock('node:child_process')` cannot intercept in this package (see
 // git-branch-ops.test.ts), so detection runs the real git binary against
 // throwaway repositories, the a1 body parsing is exercised through its

--- a/packages/cli/src/serve/server/git-branch-ops.test.ts
+++ b/packages/cli/src/serve/server/git-branch-ops.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/serve/server/persisted-session-list-cache.test.ts
+++ b/packages/cli/src/serve/server/persisted-session-list-cache.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   PersistedSessionListCache,

--- a/packages/cli/src/serve/session-attachments-root.test.ts
+++ b/packages/cli/src/serve/session-attachments-root.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { tmpdir, homedir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/packages/cli/src/serve/skill-details-redaction.test.ts
+++ b/packages/cli/src/serve/skill-details-redaction.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import {

--- a/packages/cli/src/serve/sse-last-event-id.test.ts
+++ b/packages/cli/src/serve/sse-last-event-id.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const stdioMocks = vi.hoisted(() => ({

--- a/packages/cli/src/serve/total-session-admission.test.ts
+++ b/packages/cli/src/serve/total-session-admission.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   TotalSessionLimitExceededError,

--- a/packages/cli/src/serve/web-shell-static.test.ts
+++ b/packages/cli/src/serve/web-shell-static.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   buildWebShellCsp,

--- a/packages/cli/src/serve/workflow-session-gate.test.ts
+++ b/packages/cli/src/serve/workflow-session-gate.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from 'vitest';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import {

--- a/packages/cli/src/serve/workspace-generation.test.ts
+++ b/packages/cli/src/serve/workspace-generation.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import express from 'express';
 import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';

--- a/packages/cli/src/serve/workspace-inputs.test.ts
+++ b/packages/cli/src/serve/workspace-inputs.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/serve/workspace-registration-store.test.ts
+++ b/packages/cli/src/serve/workspace-registration-store.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';

--- a/packages/cli/src/serve/workspace-skill-management.test.ts
+++ b/packages/cli/src/serve/workspace-skill-management.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/services/command-migration-tool.test.ts
+++ b/packages/cli/src/services/command-migration-tool.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';

--- a/packages/cli/src/services/insight/dates.test.ts
+++ b/packages/cli/src/services/insight/dates.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { dayKey, hourOfDay, parseDayKey, todayKey } from './dates.js';
 

--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { DataProcessor } from './DataProcessor.js';
 import { dayKey } from '../dates.js';

--- a/packages/cli/src/services/markdown-command-parser.test.ts
+++ b/packages/cli/src/services/markdown-command-parser.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   parseMarkdownCommand,

--- a/packages/cli/src/services/notificationService.test.ts
+++ b/packages/cli/src/services/notificationService.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { sendNotification } from './notificationService.js';
 import type { TerminalNotification } from '../ui/hooks/useTerminalNotification.js';

--- a/packages/cli/src/services/prompt-processors/injectionParser.test.ts
+++ b/packages/cli/src/services/prompt-processors/injectionParser.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { extractInjections } from './injectionParser.js';
 

--- a/packages/cli/src/services/prompt-stash.test.ts
+++ b/packages/cli/src/services/prompt-stash.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/services/review-worktree-lease.test.ts
+++ b/packages/cli/src/services/review-worktree-lease.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Copyright 2026 Qwen Team
 // SPDX-License-Identifier: Apache-2.0
 

--- a/packages/cli/src/services/setup-github.test.ts
+++ b/packages/cli/src/services/setup-github.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { promises as fsp } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/services/skill-args-file.test.ts
+++ b/packages/cli/src/services/skill-args-file.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   mkdtempSync,

--- a/packages/cli/src/services/tips/tipHistory.test.ts
+++ b/packages/cli/src/services/tips/tipHistory.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/cli/src/services/tips/tipRegistry.test.ts
+++ b/packages/cli/src/services/tips/tipRegistry.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { tipRegistry, type TipContext } from './tipRegistry.js';
 

--- a/packages/cli/src/services/tips/tipScheduler.test.ts
+++ b/packages/cli/src/services/tips/tipScheduler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/packages/cli/src/startup/worktreeStartup.test.ts
+++ b/packages/cli/src/startup/worktreeStartup.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';

--- a/packages/cli/src/test-utils/latency-budget.test.ts
+++ b/packages/cli/src/test-utils/latency-budget.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { expectWithinLatencyBudget } from './latency-budget.js';

--- a/packages/cli/src/utils/acp-startup-profiler.test.ts
+++ b/packages/cli/src/utils/acp-startup-profiler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { performance } from 'node:perf_hooks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {

--- a/packages/cli/src/utils/acpModelUtils.test.ts
+++ b/packages/cli/src/utils/acpModelUtils.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { AuthType, type Config } from '@qwen-code/qwen-code-core';
 import {

--- a/packages/cli/src/utils/apiPreconnect.test.ts
+++ b/packages/cli/src/utils/apiPreconnect.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   preconnectApi,

--- a/packages/cli/src/utils/classify-api-error.test.ts
+++ b/packages/cli/src/utils/classify-api-error.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { classifyApiError } from './classify-api-error.js';
 

--- a/packages/cli/src/utils/cleanup.test.ts
+++ b/packages/cli/src/utils/cleanup.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { vi } from 'vitest';
 import {
   _resetCleanupFunctionsForTest,

--- a/packages/cli/src/utils/conversation-directory-identity.test.ts
+++ b/packages/cli/src/utils/conversation-directory-identity.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { realpathSync, type Stats } from 'node:fs';
 import {
   chmod,

--- a/packages/cli/src/utils/costCalculator.test.ts
+++ b/packages/cli/src/utils/costCalculator.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { calculateCost } from './costCalculator.js';
 

--- a/packages/cli/src/utils/cpuProfiler.test.ts
+++ b/packages/cli/src/utils/cpuProfiler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';

--- a/packages/cli/src/utils/deepMerge.test.ts
+++ b/packages/cli/src/utils/deepMerge.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { customDeepMerge, MergeStrategy } from './deepMerge.js';
 

--- a/packages/cli/src/utils/earlyInputCapture.test.ts
+++ b/packages/cli/src/utils/earlyInputCapture.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   startEarlyInputCapture,

--- a/packages/cli/src/utils/errors.test.ts
+++ b/packages/cli/src/utils/errors.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { vi, type Mock, type MockInstance } from 'vitest';
 import type { Config } from '@qwen-code/qwen-code-core';
 import {

--- a/packages/cli/src/utils/gitUtils.test.ts
+++ b/packages/cli/src/utils/gitUtils.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { vi, describe, expect, it, afterEach, beforeEach } from 'vitest';
 import * as child_process from 'node:child_process';
 import {

--- a/packages/cli/src/utils/headlessSafetyWarnings.test.ts
+++ b/packages/cli/src/utils/headlessSafetyWarnings.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import {

--- a/packages/cli/src/utils/housekeeping/cleanup.test.ts
+++ b/packages/cli/src/utils/housekeeping/cleanup.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';

--- a/packages/cli/src/utils/housekeeping/throttledOnce.test.ts
+++ b/packages/cli/src/utils/housekeeping/throttledOnce.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';

--- a/packages/cli/src/utils/installationInfo.test.ts
+++ b/packages/cli/src/utils/installationInfo.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   formatUpdateInstructions,

--- a/packages/cli/src/utils/json-string-byte-projection.test.ts
+++ b/packages/cli/src/utils/json-string-byte-projection.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { Buffer } from 'node:buffer';
 import { describe, expect, it } from 'vitest';
 import {

--- a/packages/cli/src/utils/jsonc-editor.test.ts
+++ b/packages/cli/src/utils/jsonc-editor.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';

--- a/packages/cli/src/utils/load-undici.test.ts
+++ b/packages/cli/src/utils/load-undici.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 
 const makeModule = (

--- a/packages/cli/src/utils/managed-npm-update.test.ts
+++ b/packages/cli/src/utils/managed-npm-update.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';

--- a/packages/cli/src/utils/midTurnUserMessage.test.ts
+++ b/packages/cli/src/utils/midTurnUserMessage.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import type { Part } from '@google/genai';
 import {

--- a/packages/cli/src/utils/normalize-part-list.test.ts
+++ b/packages/cli/src/utils/normalize-part-list.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import type { Part } from '@google/genai';
 import { normalizePartList } from './normalize-part-list.js';

--- a/packages/cli/src/utils/osc.test.ts
+++ b/packages/cli/src/utils/osc.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   detectTerminal,

--- a/packages/cli/src/utils/paths.test.ts
+++ b/packages/cli/src/utils/paths.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { safeTarget } from './paths.js';
 

--- a/packages/cli/src/utils/processUtils.test.ts
+++ b/packages/cli/src/utils/processUtils.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, vi } from 'vitest';
 import {
   RELAUNCH_EXIT_CODE,

--- a/packages/cli/src/utils/readStdin.test.ts
+++ b/packages/cli/src/utils/readStdin.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { vi, describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { readStdin } from './readStdin.js';
 

--- a/packages/cli/src/utils/relaunch.test.ts
+++ b/packages/cli/src/utils/relaunch.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import {
   vi,
   describe,

--- a/packages/cli/src/utils/resolvePath.test.ts
+++ b/packages/cli/src/utils/resolvePath.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/packages/cli/src/utils/runBudget.test.ts
+++ b/packages/cli/src/utils/runBudget.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   RunBudgetEnforcer,

--- a/packages/cli/src/utils/shell-args.test.ts
+++ b/packages/cli/src/utils/shell-args.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { tokenizeArgs } from './shell-args.js';
 

--- a/packages/cli/src/utils/standalone-update-verify.test.ts
+++ b/packages/cli/src/utils/standalone-update-verify.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { verifySignature } from './standalone-update-verify.js';
 

--- a/packages/cli/src/utils/startupProfiler.test.ts
+++ b/packages/cli/src/utils/startupProfiler.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import {

--- a/packages/cli/src/utils/startupWarnings.test.ts
+++ b/packages/cli/src/utils/startupWarnings.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { getStartupWarnings } from './startupWarnings.js';
 import * as fs from 'node:fs/promises';

--- a/packages/cli/src/utils/stdioHelpers.test.ts
+++ b/packages/cli/src/utils/stdioHelpers.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   writeStderrLine,

--- a/packages/cli/src/utils/terminalSequence.test.ts
+++ b/packages/cli/src/utils/terminalSequence.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   parseAllowedTerminalSequences,

--- a/packages/cli/src/utils/userPromptExpansionHook.test.ts
+++ b/packages/cli/src/utils/userPromptExpansionHook.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import {
   appendUserPromptExpansionAdditionalContext,

--- a/packages/cli/src/utils/userStartupWarnings.test.ts
+++ b/packages/cli/src/utils/userStartupWarnings.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { getUserStartupWarnings } from './userStartupWarnings.js';
 import * as os from 'node:os';

--- a/packages/cli/src/utils/warningHandler.test.ts
+++ b/packages/cli/src/utils/warningHandler.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   initializeWarningHandler,

--- a/packages/cli/src/utils/writeWithBackup.test.ts
+++ b/packages/cli/src/utils/writeWithBackup.test.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';


### PR DESCRIPTION
## What this PR does

Marks 233 cli test files to run under the node environment instead of jsdom. Nothing but the environment comment changes.

## Why it's needed

The cli package sets jsdom for all thousand-odd of its test files, but most of them test argument parsing, config loading, process management or HTTP routing and never reach for a browser global. Standing up jsdom costs roughly two seconds per file — on the release lane the workspace reported 639s of environment setup in a single shard — and for these files it buys nothing.

This is independent of the import work in #10917 and its stack; it is a separate cost in the same measurement, and it branches from main so neither has to wait for the other.

## How the files were chosen

Each test's import graph was walked, and a file is excluded if anything it reaches so much as mentions a DOM global, React, ink, a testing-library import, or a browser type. Every `.tsx` file is excluded outright, and so is everything under `ui/`, which leaves the selection to server- and command-side suites.

The check is deliberately pessimistic, and the failure mode is in our favour: a file that needs a DOM and is wrongly listed fails on the first global it reaches, loudly, rather than passing while testing something subtly different.

## Reviewer Test Plan

### How to verify

A green cli suite is the signal — a wrong entry throws a ReferenceError at the point of use rather than failing quietly. Worth a reviewer's eye is whether the exclusion list is the right shape: it rejects on any mention anywhere in the graph, so it will have left some genuinely DOM-free suites on jsdom, but it should not have moved anything that needs one.

The environment comment is read from anywhere in the file rather than only a leading docblock, so its placement after the license header is not significant.

### Evidence (Before & After)

N/A — no user-visible behavior changes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Not run locally; relying on CI.

## Risk & Scope

- Main risk or tradeoff: a suite that touches a browser global indirectly, through a path the import walk did not follow — a dynamic import, say. It fails loudly if so.
- Not validated / out of scope: the 59 DOM-free candidates under `ui/`, held back because that tree is where an indirect dependency is most likely; and the actual time saved, which needs a CI run to measure rather than the per-file figure quoted above.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #10908

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 233 个 cli 测试文件标记为在 node 环境下运行，而不是 jsdom。除环境注释外没有任何改动。

## 为什么需要

cli 包给它一千多个测试文件统一设了 jsdom，但其中大多数测的是参数解析、配置加载、进程管理或 HTTP 路由，从不使用任何浏览器全局对象。启动一个 jsdom 实例每个文件约需两秒——release lane 上单个分片就报告了 639s 的环境搭建时间——对这些文件而言毫无收益。

本 PR 独立于 #10917 那条链：它是同一份测量里的另一项成本，且直接基于 main，两边互不阻塞。

## 文件是怎么挑的

遍历每个测试的导入图，只要其可达范围内**提到**任何 DOM 全局、React、ink、testing-library 导入或浏览器类型，就排除。所有 `.tsx` 文件一律排除，`ui/` 目录下的全部排除，最终只剩服务端与命令行侧的用例。

这个判定刻意偏保守，且失效方向对我们有利：若某文件确实需要 DOM 却被误列，它会在首次访问全局对象时**大声报错**，而不是悄悄通过却在测别的东西。

## 风险与范围

- 主要风险或权衡：某个用例通过导入图未跟踪的路径（例如动态导入）间接触到浏览器全局。若如此会大声失败。
- 未验证 / 超出范围：`ui/` 下另外 59 个无 DOM 迹象的候选，因该目录最可能存在间接依赖而暂未纳入；以及实际节省的时间——上文的每文件数字需要一次 CI 运行来验证。
- 破坏性变更 / 迁移说明：无。

</details>