### PR TITLE
refactor(rewind): unify the ACP and TUI user-prompt classifiers

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -114,8 +114,9 @@ import {
   getOutputStyleTurnReminder,
   resolveMainSessionOutputStyle,
   wrapSystemReminder,
-  getStartupContextLength,
   isSystemReminderContent,
+  findApiRewindCutPoint,
+  countApiUserPrompts,
   buildSessionRecoveryPlanFromApiHistory,
   TURN_INTERRUPTION_HISTORY_TAIL_COUNT,
   evaluatePermissionFlow,
@@ -488,6 +489,23 @@ function isTodoStopGuardPromptText(text: unknown): text is string {
     remainder === body + TODO_STOP_GUARD_FINAL_PROMPT_SUFFIX
   );
 }
+
+/**
+ * ACP rewind's binding of the shared user-prompt classifier
+ * (`isApiUserPrompt` in core). The two deltas from the TUI binding are
+ * deliberate:
+ *
+ * - The todo-stop-guard's synthetic continuation prompts are injected as user
+ *   entries but are not turns a client can rewind to, so they must not
+ *   consume an ordinal.
+ * - Microcompaction media-clear placeholders stay COUNTED here, unlike the
+ *   TUI binding. ACP rewind maps against per-prompt file-history snapshots,
+ *   which ARE created for media-only prompts, so a cleared entry still owns
+ *   an ordinal on this surface.
+ */
+const ACP_API_USER_PROMPT_OPTIONS = {
+  excludeTextPart: isTodoStopGuardPromptText,
+};
 
 /** Finalizes preparations without allowing ACP cleanup to change the stream outcome. */
 async function finalizeToolCallPreparations(
@@ -4333,19 +4351,10 @@ export class Session implements SessionContext {
   }
 
   getRewindableUserTurnCount(): number {
-    const apiHistory = this.captureHistorySnapshot();
-    const startIndex = getStartupContextLength(apiHistory, {
-      includeCompressed: true,
-    });
-    let count = 0;
-
-    for (let i = startIndex; i < apiHistory.length; i++) {
-      if (this.#isUserTextContent(apiHistory[i]!)) {
-        count += 1;
-      }
-    }
-
-    return count;
+    return countApiUserPrompts(
+      this.captureHistorySnapshot(),
+      ACP_API_USER_PROMPT_OPTIONS,
+    );
   }
 
   restoreHistory(history: Content[]): void {
@@ -4365,63 +4374,11 @@ export class Session implements SessionContext {
     apiHistory: Content[],
     targetTurnIndex: number,
   ): number {
-    const startIndex = getStartupContextLength(apiHistory, {
-      includeCompressed: true,
-    });
-
-    if (targetTurnIndex === 0) {
-      return startIndex;
-    }
-
-    let realUserPromptCount = 0;
-    for (let i = startIndex; i < apiHistory.length; i++) {
-      if (!this.#isUserTextContent(apiHistory[i]!)) {
-        continue;
-      }
-
-      if (realUserPromptCount === targetTurnIndex) {
-        return i;
-      }
-
-      realUserPromptCount += 1;
-    }
-
-    return -1;
-  }
-
-  #isUserTextContent(content: Content): boolean {
-    if (content.role !== 'user') return false;
-    if (!content.parts || content.parts.length === 0) return false;
-
-    const hasFunctionResponse = content.parts.some(
-      (part) => 'functionResponse' in part,
+    return findApiRewindCutPoint(
+      apiHistory,
+      targetTurnIndex,
+      ACP_API_USER_PROMPT_OPTIONS,
     );
-    if (hasFunctionResponse) return false;
-
-    // Exclude pure <system-reminder> entries (the startup prelude and the
-    // mid-history MCP added-tool reminders). They are structural, not real
-    // user prompts; counting them would shift the rewind truncation index and
-    // silently drop a real turn. A genuine user turn that merely has a
-    // per-turn reminder prepended still has a non-reminder prompt part, so it
-    // is NOT excluded.
-    if (isSystemReminderContent(content)) return false;
-
-    if (
-      content.parts.some(
-        (part) => 'text' in part && isTodoStopGuardPromptText(part.text),
-      )
-    ) {
-      return false;
-    }
-
-    // Deliberate twin divergence: the TUI twin (isUserTextContent in
-    // packages/cli/src/ui/utils/historyMapping.ts) excludes microcompaction
-    // media-clear placeholders ('[Old inline media cleared: ...]') from the
-    // rewind prompt count because a cleared media-only entry never produced
-    // a TUI user turn. Here the placeholders MUST stay counted: ACP rewind
-    // maps against per-prompt file-history snapshots, which ARE created for
-    // media-only prompts. Do not mirror that exclusion into this twin.
-    return content.parts.some((part) => 'text' in part && part.text);
   }
 
   async cancelPendingPrompt(): Promise<void> {

--- a/packages/cli/src/ui/utils/historyMapping.ts
+++ b/packages/cli/src/ui/utils/historyMapping.ts
@@ -6,13 +6,21 @@
 
 import type { HistoryItem, HistoryItemUser } from '../types.js';
 import type { Content } from '@google/genai';
+import type { ApiUserPromptOptions } from '@qwen-code/qwen-code-core';
 import {
   CompressionStatus,
   getStartupContextLength,
-  isClearedMediaPlaceholder,
-  isSystemReminderContent,
+  isApiUserPrompt,
 } from '@qwen-code/qwen-code-core';
 import { isSlashCommand } from './commandUtils.js';
+
+/**
+ * TUI rewind's binding of the shared user-prompt classifier. Exported so the
+ * OpenTUI parity path counts prompts under the exact same rule.
+ */
+export const TUI_API_USER_PROMPT_OPTIONS: ApiUserPromptOptions = {
+  excludeClearedMediaPlaceholders: true,
+};
 
 /**
  * Returns true when the history item represents a real user prompt that was
@@ -39,64 +47,18 @@ export function isRealUserTurn(
 /**
  * Checks if a Content entry is a user-initiated text prompt
  * as opposed to a tool result (functionResponse).
+ *
+ * Thin binding of the shared classifier: TUI rewind excludes microcompaction
+ * media-clear placeholders because a cleared media-only entry never produced
+ * a visible user turn, so counting it would desynchronize the API prompt
+ * count from the UI turn count and truncate one turn early. See
+ * `ApiUserPromptOptions` in core for why that exclusion is an option rather
+ * than part of the shared rule (ACP must keep those entries counted), and for
+ * the exact-match collision this leaves behind — which is what prompt
+ * identity resolves.
  */
 export function isUserTextContent(content: Content): boolean {
-  if (content.role !== 'user') return false;
-  if (!content.parts || content.parts.length === 0) return false;
-
-  const hasFunctionResponse = content.parts.some(
-    (part) => 'functionResponse' in part,
-  );
-  if (hasFunctionResponse) return false;
-
-  // Exclude pure <system-reminder> entries (the startup prelude and the
-  // mid-history MCP added-tool reminders). They are structural, not real user
-  // prompts; counting them here would shift the rewind truncation index and
-  // silently drop a real turn's context. A genuine user turn that merely has
-  // a per-turn reminder prepended still has a non-reminder prompt part, so it
-  // is NOT excluded.
-  if (isSystemReminderContent(content)) return false;
-
-  // Exclude microcompaction media-clear placeholders. `/compress-fast`'s
-  // microcompaction replaces the top-level inlineData/fileData parts of
-  // user entries with text placeholders. A media-only user entry never
-  // produced a UI user turn, but once cleared it carries a text part;
-  // counting it here desynchronizes the API prompt count from the UI turn
-  // count and makes the walk below truncate one turn early, silently
-  // dropping a turn the UI still shows. Match the FULL generated
-  // placeholder shape, not just its prefix: microcompaction never rewrites
-  // text parts, so a user prompt that merely begins with the prefix (e.g.
-  // a pasted placeholder) is genuine and must keep counting. An entry that
-  // mixes placeholders with real prompt text still counts (it IS a real
-  // turn).
-  //
-  // Known limitation (exact-match collision): a genuine prompt whose ENTIRE
-  // text equals a generated placeholder shape is indistinguishable from a
-  // cleared media-only entry once serialized — both carry the identical
-  // text. Such a prompt is excluded here, leaving the API prompt count one
-  // behind the UI turn count. Every rewind target AFTER the colliding turn
-  // then returns -1 and AppContainer surfaces a loud "Cannot rewind to a
-  // turn that was compressed" abort. Rewinding TO the colliding turn itself
-  // depends on position: as the first post-compression turn it works via
-  // the uiUserTurnCount === 0 shortcut; mid-history the walk lands on the
-  // next counted prompt and truncates one turn LATE, so the colliding
-  // turn's prompt+response stays in model context while the UI removes the
-  // turn (under-deletion of context, not loss of context the UI keeps).
-  // Disambiguating any of this durably needs a structural sentinel on
-  // cleared parts, which changes the persisted API history shape and is out
-  // of scope for this fix; see the pinned tests in historyMapping.test.ts.
-  //
-  // The ACP session's private `#isUserTextContent`
-  // (packages/cli/src/acp-integration/session/Session.ts) deliberately
-  // keeps the bare text-presence check (`'text' in part && part.text`),
-  // which counts these placeholders: ACP rewind maps against per-prompt
-  // file-history snapshots, which ARE created for media-only prompts, so
-  // cleared placeholders must stay counted there. Do not mirror this
-  // exclusion into that twin.
-  return content.parts.some(
-    (part) =>
-      'text' in part && !!part.text && !isClearedMediaPlaceholder(part.text),
-  );
+  return isApiUserPrompt(content, TUI_API_USER_PROMPT_OPTIONS);
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -303,6 +303,12 @@ export {
   type ResolvedSlimmingConfig,
 } from './services/compactionInputSlimming.js';
 export { isClearedMediaPlaceholder } from './services/microcompaction/microcompact.js';
+export {
+  isApiUserPrompt,
+  findApiRewindCutPoint,
+  countApiUserPrompts,
+  type ApiUserPromptOptions,
+} from './services/api-user-prompt.js';
 export * from './services/chatRecordingService.js';
 export * from './services/branch-points.js';
 export * from './services/cronScheduler.js';

--- a/packages/core/src/services/api-user-prompt.test.ts
+++ b/packages/core/src/services/api-user-prompt.test.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Content } from '@google/genai';
+import {
+  countApiUserPrompts,
+  findApiRewindCutPoint,
+  isApiUserPrompt,
+} from './api-user-prompt.js';
+import {
+  SYSTEM_REMINDER_OPEN,
+  SYSTEM_REMINDER_CLOSE,
+} from '../core/environmentContext.js';
+
+const user = (text: string): Content => ({
+  role: 'user',
+  parts: [{ text }],
+});
+const model = (text: string): Content => ({
+  role: 'model',
+  parts: [{ text }],
+});
+const reminder = (text: string): Content => ({
+  role: 'user',
+  parts: [{ text: `${SYSTEM_REMINDER_OPEN}${text}${SYSTEM_REMINDER_CLOSE}` }],
+});
+const toolResult = (): Content => ({
+  role: 'user',
+  parts: [{ functionResponse: { name: 'x', response: { output: 'ok' } } }],
+});
+
+const CLEARED_MEDIA = '[Old inline media cleared: image/png]';
+const TODO_GUARD = '[Todo Stop Guard] continue';
+const isTodoGuard = (text: string) => text.startsWith('[Todo Stop Guard] ');
+
+describe('isApiUserPrompt', () => {
+  it('accepts a plain user prompt and rejects non-prompt entries', () => {
+    expect(isApiUserPrompt(user('hello'))).toBe(true);
+    expect(isApiUserPrompt(model('hi'))).toBe(false);
+    expect(isApiUserPrompt(toolResult())).toBe(false);
+    expect(isApiUserPrompt(reminder('startup'))).toBe(false);
+    expect(isApiUserPrompt({ role: 'user', parts: [] })).toBe(false);
+  });
+
+  it('keeps a genuine turn that merely carries a prepended reminder', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [
+        { text: `${SYSTEM_REMINDER_OPEN}ctx${SYSTEM_REMINDER_CLOSE}` },
+        { text: 'the real prompt' },
+      ],
+    };
+    expect(isApiUserPrompt(content)).toBe(true);
+  });
+
+  it('rejects an entry mixing a tool result with prompt text', () => {
+    const content: Content = {
+      role: 'user',
+      parts: [
+        { functionResponse: { name: 'x', response: { output: 'ok' } } },
+        { text: 'trailing text' },
+      ],
+    };
+    expect(isApiUserPrompt(content)).toBe(false);
+  });
+
+  describe('excludeClearedMediaPlaceholders (the TUI binding)', () => {
+    it('drops a placeholder-only entry only when the option is set', () => {
+      expect(isApiUserPrompt(user(CLEARED_MEDIA))).toBe(true);
+      expect(
+        isApiUserPrompt(user(CLEARED_MEDIA), {
+          excludeClearedMediaPlaceholders: true,
+        }),
+      ).toBe(false);
+    });
+
+    it('keeps a prompt that merely begins with the placeholder prefix', () => {
+      const prefixed = user('[Old inline media cleared: what does this mean?');
+      expect(
+        isApiUserPrompt(prefixed, { excludeClearedMediaPlaceholders: true }),
+      ).toBe(true);
+    });
+
+    it('keeps an entry that mixes a placeholder with real prompt text', () => {
+      const mixed: Content = {
+        role: 'user',
+        parts: [{ text: CLEARED_MEDIA }, { text: 'and my question' }],
+      };
+      expect(
+        isApiUserPrompt(mixed, { excludeClearedMediaPlaceholders: true }),
+      ).toBe(true);
+    });
+  });
+
+  describe('excludeTextPart (the ACP binding)', () => {
+    it('drops an entry carrying a matching text part', () => {
+      expect(isApiUserPrompt(user(TODO_GUARD))).toBe(true);
+      expect(
+        isApiUserPrompt(user(TODO_GUARD), { excludeTextPart: isTodoGuard }),
+      ).toBe(false);
+    });
+
+    it('is not applied unless the caller opts in', () => {
+      // The two bindings differ here by design: the TUI binding does not
+      // exclude guard prompts, the ACP binding does.
+      expect(
+        isApiUserPrompt(user(TODO_GUARD), {
+          excludeClearedMediaPlaceholders: true,
+        }),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('findApiRewindCutPoint', () => {
+  const history: Content[] = [
+    reminder('startup'),
+    user('A'),
+    model('ra'),
+    user('B'),
+    model('rb'),
+    user('C'),
+  ];
+
+  it('rewinding to the first turn keeps only the startup prefix', () => {
+    expect(findApiRewindCutPoint(history, 0)).toBe(1);
+    expect(findApiRewindCutPoint(history, -1)).toBe(1);
+  });
+
+  it('cuts immediately before the target turn prompt', () => {
+    expect(findApiRewindCutPoint(history, 1)).toBe(3);
+    expect(findApiRewindCutPoint(history, 2)).toBe(5);
+  });
+
+  it('returns -1 when the history holds fewer prompts than requested', () => {
+    expect(findApiRewindCutPoint(history, 3)).toBe(-1);
+  });
+
+  it('skips tool results rather than counting them as turns', () => {
+    const withTools: Content[] = [
+      user('A'),
+      model('call'),
+      toolResult(),
+      model('ra'),
+      user('B'),
+    ];
+    expect(findApiRewindCutPoint(withTools, 1)).toBe(4);
+  });
+
+  it('shifts the boundary when the two bindings disagree', () => {
+    // The same history yields different cut points under the TUI and ACP
+    // bindings — which is why the divergence is an explicit option instead
+    // of a copy that can drift.
+    const withPlaceholder: Content[] = [
+      user('A'),
+      model('ra'),
+      user(CLEARED_MEDIA),
+      model('rb'),
+      user('C'),
+    ];
+    expect(
+      findApiRewindCutPoint(withPlaceholder, 1, {
+        excludeClearedMediaPlaceholders: true,
+      }),
+    ).toBe(4);
+    expect(findApiRewindCutPoint(withPlaceholder, 1)).toBe(2);
+  });
+});
+
+describe('countApiUserPrompts', () => {
+  it('counts prompts after the startup prefix', () => {
+    const history: Content[] = [
+      reminder('startup'),
+      user('A'),
+      model('ra'),
+      toolResult(),
+      model('rb'),
+      user('B'),
+    ];
+    expect(countApiUserPrompts(history)).toBe(2);
+    expect(countApiUserPrompts([])).toBe(0);
+  });
+
+  it('honours the binding options', () => {
+    const history: Content[] = [user('A'), user(TODO_GUARD), user('B')];
+    expect(countApiUserPrompts(history)).toBe(3);
+    expect(countApiUserPrompts(history, { excludeTextPart: isTodoGuard })).toBe(
+      2,
+    );
+  });
+});

--- a/packages/core/src/services/api-user-prompt.ts
+++ b/packages/core/src/services/api-user-prompt.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content } from '@google/genai';
+import {
+  getStartupContextLength,
+  isSystemReminderContent,
+} from '../core/environmentContext.js';
+import { isClearedMediaPlaceholder } from './microcompaction/microcompact.js';
+
+/**
+ * Options for {@link isApiUserPrompt}.
+ *
+ * Rewind works by counting user prompts in the model history and cutting at
+ * the n-th one. Each rewind surface used to carry its own copy of that
+ * classifier, and the copies drifted: the ACP twin grew a todo-stop-guard
+ * exclusion the TUI twin never got, and the TUI twin grew a cleared-media
+ * exclusion the ACP twin must not have. Drift between them is its own
+ * regression class — a boundary counted under one rule and applied under
+ * another silently truncates the wrong turn.
+ *
+ * The two surviving differences are real, so they live here as options rather
+ * than as separate implementations: a change to the shared part cannot land on
+ * one surface only, and each divergence has to be opted into by name.
+ */
+export interface ApiUserPromptOptions {
+  /**
+   * Exclude entries whose only text is a microcompaction media-clear
+   * placeholder (`[Old inline media cleared: …]`).
+   *
+   * TUI rewind sets this: `/compress-fast` rewrites a media-only user entry's
+   * inlineData parts into text placeholders, and a media-only entry never
+   * produced a visible TUI user turn, so counting it desynchronizes the API
+   * prompt count from the UI turn count and truncates one turn early.
+   *
+   * ACP rewind must NOT set it: ACP maps against per-prompt file-history
+   * snapshots, which ARE created for media-only prompts, so a cleared entry
+   * still occupies an ordinal on that surface.
+   *
+   * Matching is on the FULL generated placeholder shape, so a genuine prompt
+   * that merely begins with the prefix keeps counting. A prompt whose entire
+   * text equals a generated placeholder is indistinguishable from a cleared
+   * entry once serialized; resolving that collision is what prompt identity
+   * (`findApiHistoryPromptIndex`) is for.
+   */
+  excludeClearedMediaPlaceholders?: boolean;
+
+  /**
+   * Exclude entries carrying a text part this predicate accepts.
+   *
+   * ACP rewind passes its todo-stop-guard classifier: the guard's synthetic
+   * continuation prompts are injected as user entries but are not turns a
+   * client can rewind to, so counting them would shift every ordinal.
+   */
+  excludeTextPart?: (text: string) => boolean;
+}
+
+/**
+ * The single classifier for "this API history entry is a user prompt", shared
+ * by every rewind surface (TUI, OpenTUI, ACP).
+ *
+ * A user prompt is a `user` entry that is neither a tool result
+ * (`functionResponse`) nor a structural `<system-reminder>` entry. A genuine
+ * user turn that merely has a per-turn reminder prepended still has a
+ * non-reminder prompt part, so it is NOT excluded.
+ */
+export function isApiUserPrompt(
+  content: Content,
+  options?: ApiUserPromptOptions,
+): boolean {
+  if (content.role !== 'user') return false;
+  if (!content.parts || content.parts.length === 0) return false;
+
+  if (content.parts.some((part) => 'functionResponse' in part)) return false;
+
+  // Structural, not real user prompts: the startup prelude and the
+  // mid-history MCP added-tool reminders. Counting them would shift the
+  // truncation index and silently drop a real turn's context.
+  if (isSystemReminderContent(content)) return false;
+
+  const excludeTextPart = options?.excludeTextPart;
+  if (
+    excludeTextPart &&
+    content.parts.some(
+      (part) =>
+        'text' in part &&
+        typeof part.text === 'string' &&
+        excludeTextPart(part.text),
+    )
+  ) {
+    return false;
+  }
+
+  return content.parts.some((part) => {
+    if (!('text' in part) || !part.text) return false;
+    return !(
+      options?.excludeClearedMediaPlaceholders &&
+      isClearedMediaPlaceholder(part.text)
+    );
+  });
+}
+
+/**
+ * Model-history cut point for rewinding to `turnIndex` (0-based): the index of
+ * the entry that starts that turn, so truncating to it keeps everything
+ * before the turn's prompt.
+ *
+ * `turnIndex <= 0` returns the end of the startup context — rewinding to the
+ * first turn keeps only the prelude. Returns -1 when the history holds fewer
+ * user prompts than requested, e.g. the target turn was absorbed by chat
+ * compression.
+ */
+export function findApiRewindCutPoint(
+  apiHistory: Content[],
+  turnIndex: number,
+  options?: ApiUserPromptOptions,
+): number {
+  const startIndex = getStartupContextLength(apiHistory, {
+    includeCompressed: true,
+  });
+  if (turnIndex <= 0) return startIndex;
+
+  let seen = 0;
+  for (let index = startIndex; index < apiHistory.length; index++) {
+    if (!isApiUserPrompt(apiHistory[index]!, options)) continue;
+    if (seen === turnIndex) return index;
+    seen += 1;
+  }
+  return -1;
+}
+
+/**
+ * How many user prompts `apiHistory` holds after the startup context — the
+ * number of turns a client may rewind to.
+ */
+export function countApiUserPrompts(
+  apiHistory: Content[],
+  options?: ApiUserPromptOptions,
+): number {
+  const startIndex = getStartupContextLength(apiHistory, {
+    includeCompressed: true,
+  });
+  let count = 0;
+  for (let index = startIndex; index < apiHistory.length; index++) {
+    if (isApiUserPrompt(apiHistory[index]!, options)) count += 1;
+  }
+  return count;
+}

--- a/packages/core/src/tools/agent/fork-subagent.ts
+++ b/packages/core/src/tools/agent/fork-subagent.ts
@@ -173,7 +173,26 @@ function isSystemReminderPart(content: Content, partIndex: number): boolean {
     : false;
 }
 
-function isRealUserTurn(content: Content): boolean {
+/**
+ * Whether `content` starts a fork window.
+ *
+ * Deliberately NOT the rewind classifier (`isApiUserPrompt` in
+ * services/api-user-prompt.ts), despite answering a similar-sounding
+ * question. Two differences are load-bearing here:
+ *
+ * - A media-only user entry (inlineData with no text) starts a fork window;
+ *   the rewind classifier requires a text part, because a media-only entry
+ *   produces no visible UI turn to rewind to.
+ * - Exclusions apply per part, not per entry: an entry mixing a
+ *   functionResponse or a reminder with real prompt content still starts a
+ *   window, whereas rewind drops any entry carrying a functionResponse
+ *   because such an entry is a tool result, not a turn boundary.
+ *
+ * Named apart from `isRealUserTurn` so the two are not read as copies of one
+ * rule that drifted — that drift is exactly the regression class #9437
+ * tracks.
+ */
+function startsForkWindow(content: Content): boolean {
   if (content.role !== 'user' || !content.parts?.length) return false;
   return content.parts.some((part, index) => {
     if (part.functionResponse || isSystemReminderPart(content, index)) {
@@ -240,7 +259,7 @@ export function selectForkHistory(
     const realUserTurnIndexes: number[] = [];
     for (let index = syntheticPrefixLength; index < history.length; index++) {
       const content = history[index]!;
-      if (isRealUserTurn(content)) {
+      if (startsForkWindow(content)) {
         realUserTurnIndexes.push(index);
       }
     }


### PR DESCRIPTION
## What this PR does

Rewind works by counting user prompts in the model history and cutting at the n-th
one. Every rewind surface carried its own copy of that classifier. This PR replaces
the copies with one implementation in core, `isApiUserPrompt`, and expresses the two
surviving differences as named options instead of separate code.

It also folds in the positional walk, which was duplicated the same way:
`findApiRewindCutPoint` and `countApiUserPrompts` replace ACP's
`#computeApiTruncationIndexForUserTurn` and the hand-rolled loop in
`getRewindableUserTurnCount`.

Independent of #9466 — this is the other half of #9437 and applies directly to `main`.

## Why it's needed

#9437's R5-1 names the drift itself as the regression class, and the copies had
already drifted:

| | TUI `isUserTextContent` | ACP `#isUserTextContent` |
| --- | --- | --- |
| excludes `functionResponse` entries | ✅ | ✅ |
| excludes pure `<system-reminder>` entries | ✅ | ✅ |
| excludes todo-stop-guard prompts | ❌ | ✅ |
| excludes cleared-media placeholders | ✅ | ❌ |

Both differences are *correct* — but only two of the four rows should differ, and
nothing enforced that. A boundary counted under one rule and applied under another
silently truncates the wrong turn, and each copy's comment could only ask the other
not to drift ("Do not mirror this exclusion into that twin"). Turning the two real
differences into `ApiUserPromptOptions` fields means a change to the shared part
cannot land on one surface only, and each divergence has to be opted into by name:

- `excludeClearedMediaPlaceholders` — TUI only. `/compress-fast` rewrites a media-only
  user entry's inlineData parts into text placeholders; that entry never produced a
  visible UI turn, so counting it desynchronizes the API prompt count from the UI turn
  count and truncates one turn early. ACP must **not** set it: ACP maps against
  per-prompt file-history snapshots, which ARE created for media-only prompts, so a
  cleared entry still owns an ordinal there.
- `excludeTextPart` — ACP passes its todo-stop-guard classifier. The guard's synthetic
  continuation prompts are injected as user entries but are not turns a client can
  rewind to, so counting them would shift every ordinal.

The third variant #9437 mentions, `isRealUserTurn` in `fork-subagent.ts`, is **not**
merged. It answers a different question: a media-only entry *starts a fork window* but
is not a rewindable turn, and its exclusions apply per part rather than per entry.
Merging it would change fork behavior. It is renamed to `startsForkWindow` and
documented as deliberately apart, so it can no longer be read as a third copy of one
rule that drifted. No behavior change.

## Reviewer Test Plan

### How to verify

1. `vitest run packages/core/src/services/api-user-prompt.test.ts` — the shared
   classifier, both bindings, and the case where they legitimately disagree
   (*shifts the boundary when the two bindings disagree*: the same history yields cut
   point 4 under the TUI binding and 2 under the ACP binding).
2. `vitest run packages/cli/src/acp-integration/session/Session.test.ts` — ACP rewind
   is unchanged; the suite is the behavioral pin for `rewindToTurn` and
   `getRewindableUserTurnCount`.
3. `vitest run packages/cli/src/ui/utils/historyMapping.test.ts` and
   `packages/cli/src/ui/opentui/session-rewind.test.ts` — the TUI binding and the
   OpenTUI parity path both still resolve the same boundaries.

### Evidence

Behavior-preserving by construction: the ACP walk's `targetTurnIndex === 0 → startIndex`
shortcut and its `seen === turnIndex` check-before-increment ordering are carried over
verbatim into `findApiRewindCutPoint`, so every existing ordinal resolves to the same
index. The suites above are the pin.

| suite | result |
| --- | --- |
| `core` api-user-prompt (new) · fork-subagent | 36 passed |
| `cli` acp-integration/session/Session | 811 passed |
| `cli` ui/utils/historyMapping · ui/opentui/session-rewind | 63 passed |

Run locally on named files only; typecheck and build were not run here and are CI's to
confirm. Prettier and ESLint clean on all touched files.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🐧 Linux  |   ✅   |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |

## Risk & Scope

- Main risk or tradeoff: this is a pure refactor of a correctness-critical mapping. The
  risk is a silent off-by-one in the extracted walk; it is mitigated by carrying the
  loop over verbatim rather than rewriting it, and by the 811-test ACP suite.
- Not validated / out of scope: `rewindApiCutPoint` in the OpenTUI model is left alone
  — it already shares the predicate, has no production caller, and its 1-based
  no-shortcut contract differs (folding it in would change its empty-history result
  from -1 to 0). ACP rewind's own semantics are unchanged; this PR does not touch
  edit rollback, recording checkpoints, or snapshot alignment.
- Breaking changes / migration notes: none. No persisted shape changes; three new core
  exports.

## Linked Issues

Refs #9437

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

rewind 的做法是数模型历史里的用户提示词，然后在第 n 个处截断。每个 rewind 入口各自带着一份这个分类器的拷贝。本 PR 用 core 中的唯一实现 `isApiUserPrompt` 取代这些拷贝，并把仅存的两处差异表达为具名选项，而不是各写一份代码。

同样被重复的位置遍历也一并收拢：`findApiRewindCutPoint` 与 `countApiUserPrompts` 取代 ACP 的 `#computeApiTruncationIndexForUserTurn` 以及 `getRewindableUserTurnCount` 里手写的循环。

与 #9466 独立——这是 #9437 的另一半，直接基于 `main`。

## 为什么需要它

#9437 的 R5-1 把"漂移"本身列为回归类别，而两份拷贝确实已经分叉：ACP 侧多了 todo-stop-guard 排除，TUI 侧从未同步；TUI 侧多了 cleared-media 排除，而 ACP 必须不能有。四条规则里只有两条应该不同，却没有任何机制保证这一点。按一套规则数出来的边界、用另一套规则去应用，会静默截错轮次；而两份拷贝的注释只能"请求"对方不要漂移。

把两处真实差异变成 `ApiUserPromptOptions` 字段之后，共享部分的改动不可能只落在一个入口上，且每处差异都必须具名显式开启：

- `excludeClearedMediaPlaceholders` —— 仅 TUI。`/compress-fast` 会把纯媒体用户条目的 inlineData 改写成文本占位符；该条目从未产生可见 UI 轮次，计入它会让 API 提示词计数与 UI 轮次计数错位、提前截断一轮。ACP **不能**开启：ACP 是对照每个提示词的文件历史快照做映射，而纯媒体提示词**是**会创建快照的，所以被清空的条目在该入口上仍占一个序号。
- `excludeTextPart` —— ACP 传入自己的 todo-stop-guard 判别函数。守卫注入的合成续跑提示词是 user 条目，但不是客户端可以 rewind 的轮次，计入会让所有序号偏移。

#9437 提到的第三个变体、`fork-subagent.ts` 里的 `isRealUserTurn`，**没有**合并。它回答的是另一个问题：纯媒体条目**可以开启一个 fork 窗口**，但不是可 rewind 的轮次；而且它的排除是逐 part 而非逐条目。合并会改变 fork 行为。它被改名为 `startsForkWindow` 并注明是有意区分，这样就不会再被读成"同一规则漂移出的第三份拷贝"。无行为变更。

## 风险与范围

- 主要风险或取舍：这是对一段正确性敏感映射的纯重构。风险是抽取出的遍历出现静默 off-by-one；缓解方式是把循环逐行搬过来而不是重写，并由 811 个 ACP 测试兜底。
- 未验证 / 范围外：OpenTUI model 里的 `rewindApiCutPoint` 保持不动——它已经共用谓词、没有生产调用方，且契约是 1-based 且无短路（合并会把它的空历史结果从 -1 变成 0）。ACP rewind 自身语义不变；本 PR 不触碰编辑回滚、录制检查点或快照对齐。
- 破坏性变更 / 迁移说明：无。无持久化结构变更；新增三个 core 导出。

## 验证

本地只跑了具名测试文件；typecheck 与 build 未在本地执行，交由 CI 确认。所有改动文件 Prettier 与 ESLint 干净。

| 套件 | 结果 |
| --- | --- |
| `core` api-user-prompt（新增）· fork-subagent | 36 passed |
| `cli` acp-integration/session/Session | 811 passed |
| `cli` ui/utils/historyMapping · ui/opentui/session-rewind | 63 passed |

</details>

https://claude.ai/code/session_01NcCCaJ7heyd7kSupskeTC3
