### PR TITLE
fix(cli): submit container slash commands on Enter again

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1437,8 +1437,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           slashCommands,
         );
         const commandPartCount = buffer.text.slice(1).split(/\s+/).length;
+        // Container commands (subcommands but no default action, e.g.
+        // /memory) are exact matches too: Enter must submit them, as it did
+        // before #10929. Requiring an `action` here made Enter autocomplete
+        // the first subcommand instead of submitting the command.
         isLiveSlashCommand =
-          commandToExecute?.action !== undefined &&
+          commandToExecute !== undefined &&
           args.length === 0 &&
           canonicalPath.length === commandPartCount;
       }
@@ -1953,6 +1957,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       categoryTabsVisible,
       voiceInput,
       targetDir,
+      slashCommands,
     ],
   );
 


### PR DESCRIPTION
## What this PR does

Restores Enter-to-submit for slash commands that are containers: commands that have subcommands but no default action of their own, such as the memory command. Since the change that made Enter resolve exact slash commands against the live input buffer, pressing Enter on an exactly typed container command no longer submitted it; the keystroke fell through to the completion popup and autocompleted the first subcommand instead, so the command the user typed never ran.

The fix treats a buffer that resolves to an exact command path, with no arguments, as an exact match whether or not that command carries a default action. The stale-completion behaviour introduced alongside the live-buffer resolution is preserved: a partial buffer still resolves to no command and therefore autocompletes, and a completion that is stale-true no longer submits a buffer that is no longer an exact match.

It also adds a missing dependency to the input key handler's memoized callback. The slash command list is component state that changes only when the command list changes, so the callback is recreated exactly when the handler needs to see a new list, and never per render.

## Why it's needed

The regression is on `main` and red in CI: two long-standing input tests fail on it, and the repository's zero-warning lint gate rejects the missing dependency. Every PR currently inherits both failures. Container commands are common (memory, and any command that only groups subcommands), so the user-visible symptom is that typing such a command in full and pressing Enter silently does the wrong thing.

## Reviewer Test Plan

### How to verify

In the TUI, with the completion popup visible:

1. Type a container command in full, for example `/memory`, and press Enter. Expected: the command submits and its dialog or output appears. Observed before this change: the first subcommand was autocompleted into the input instead, and nothing was submitted.
2. Type a partial command, for example `/mem`, and press Enter. Expected: unchanged behaviour, the highlighted suggestion is accepted into the input and nothing is submitted.
3. Type an exact leaf command, for example `/quit`, while the popup is showing an unrelated suggestion. Expected: unchanged behaviour from the live-buffer fix, the typed command submits rather than the popup's suggestion.
4. Navigate with the down arrow, backspace, retype to the exact command, then Enter. Expected: submits the typed command, not the navigated suggestion.

### Evidence (Before & After)

Before: the two exact-match tests fail with the submit spy called zero times, and Enter autocompletes instead. After: the input test file passes in full, 215 tests, including the two restored cases and the two cases added by the live-buffer fix. The lint gate passes with zero warnings on the touched file.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local TUI plus the package's unit tests for the input component.

## Risk & Scope

- Main risk or tradeoff: submitting a container command runs whatever its no-argument behaviour is (typically opening its dialog or printing help), which is the behaviour before the live-buffer change and what the long-standing tests assert. If product intent were instead to autocomplete container commands on Enter, those tests would need to change rather than this code.
- Not validated / out of scope: four cursor-rendering tests in the same package fail on this machine both with and without this change; they pass in CI and are unrelated to input handling, so they are left alone here.
- Breaking changes / migration notes: none.

## Linked Issues

Related to #10929, whose live-buffer resolution this completes. Does not close it.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

恢复"容器型" slash command 的 Enter 直接提交：即那些只有子命令、自身没有默认 action 的命令，例如 memory 命令。自从"Enter 依据实时输入缓冲解析精确 slash command"的改动合入后，完整输入一个容器命令再按 Enter 不再提交，而是落进补全弹层、自动补全第一个子命令，用户输入的命令根本没有执行。

修复把"缓冲能解析到精确命令路径且无参数"视为精确匹配，不再要求该命令带默认 action。同时保留与实时解析一同引入的防过期补全行为：部分输入仍然解析不到命令、因此走自动补全；过期为 true 的补全也不会再提交一个已不精确的缓冲。

另外补上输入按键处理回调缺失的依赖。slash command 列表是组件状态，只在命令列表变化时变化，因此回调只在该时刻重建、而不是每次渲染重建。

## 为什么需要

该回归在 main 上且 CI 红：两个长期存在的输入测试因此失败，仓库的零警告 lint 门禁也拒绝这个缺失依赖。当前每个 PR 都继承这两个失败。容器命令很常见（memory，以及任何只分组子命令的命令），所以用户可见的症状是：完整输入这样一个命令并按 Enter，静默地做了错误的事。

## 审阅测试计划

### 如何验证

在 TUI 中、补全弹层可见时：

1. 完整输入一个容器命令，例如 `/memory`，按 Enter。预期：命令提交，出现其对话框或输出。改动前观察到：第一个子命令被自动补全进输入框，没有任何提交。
2. 输入部分命令，例如 `/mem`，按 Enter。预期：行为不变，接受高亮建议进输入框，不提交。
3. 在弹层显示无关建议时输入精确的叶子命令，例如 `/quit`。预期：实时解析修复的行为不变，提交输入的命令而非弹层建议。
4. 下箭头导航、退格、重新输入到精确命令，再按 Enter。预期：提交输入的命令，而非导航过的建议。

### 证据（前后对比）

改动前：两个精确匹配测试失败，submit spy 调用次数为 0，且 Enter 走了自动补全。改动后：输入组件测试文件全绿，215 个测试，含两个恢复的用例与实时解析修复新增的两个用例。lint 门禁在该文件上零警告通过。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

本地 TUI，加上该输入组件的包内单元测试。

## 风险与范围

- 主要风险或取舍：提交容器命令会执行它无参数时的行为（通常是打开对话框或打印帮助），这正是实时解析改动之前、也是长期测试所断言的行为。如果产品意图其实是容器命令按 Enter 走自动补全，那么该改的是那些测试而不是这段代码。
- 未验证 / 范围之外：同包内四个光标渲染测试在本机无论有无本改动都失败；它们在 CI 上通过且与输入处理无关，故此处不动。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

与 #10929 相关（本 PR 补全其引入的实时缓冲解析）。不关闭该 issue。

</details>
