### PR TITLE
docs(auth): document Token Plan setup (endpoint, regions, env key, settings.json example)

### DIFF
--- a/docs/users/configuration/auth.md
+++ b/docs/users/configuration/auth.md
@@ -103,7 +103,76 @@ If you prefer to skip the interactive `/auth` flow, add the following to `~/.qwe
 >
 > The Coding Plan uses a dedicated endpoint (`https://coding.dashscope.aliyuncs.com/v1`) that is different from the standard Dashscope endpoint. Make sure to use the correct `baseUrl`.
 
-## 🚀 Option 3: API Key (flexible)
+## 🪙 Option 3: Alibaba Cloud Token Plan
+
+Use this if your team or company prefers usage-based billing on a dedicated ModelStudio endpoint.
+
+- **How it works**: Subscribe to the Token Plan in Alibaba Cloud ModelStudio, then configure Qwen Code to use the region-specific Token Plan endpoint and your API key. You are billed for actual token usage instead of a fixed monthly fee.
+- **Requirements**: Obtain a Token Plan API key from [Alibaba Cloud ModelStudio(Beijing)](https://bailian.console.aliyun.com/cn-beijing?tab=doc#/doc/?type=model&url=3028856) or [Alibaba Cloud ModelStudio(intl)](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model), depending on the region of your account.
+- **Benefits**: Usage-based billing for teams and companies, dedicated region-specific endpoints, access to a wide range of models (Qwen, DeepSeek, GLM, Kimi, Minimax and more).
+- **Cost & quota**: View Alibaba Cloud ModelStudio Token Plan documentation [Beijing](https://bailian.console.aliyun.com/cn-beijing?tab=doc#/doc/?type=model&url=3028856) [intl](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model).
+
+Token Plan is available in two regions, each with its own dedicated endpoint:
+
+| Region                    | Endpoint                                                                 | Console URL                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| China (Beijing)           | `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`     | [bailian.console.aliyun.com](https://bailian.console.aliyun.com/cn-beijing)                         |
+| Singapore (International) | `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` | [modelstudio.console.alibabacloud.com](https://modelstudio.console.alibabacloud.com/ap-southeast-1) |
+
+### Interactive setup
+
+Enter `qwen` in the terminal to launch Qwen Code, then run the `/auth` command, select **Alibaba ModelStudio**, and choose **Token Plan** from the sub-menu. Choose your region (**China (Beijing)** or **Singapore (International)**), then enter your API key. Token Plan API keys have no prefix requirement (unlike Coding Plan keys, which start with `sk-sp-`).
+
+After authentication, use the `/model` command to browse and switch between the models included in your Token Plan. The model lineup evolves over time, so it is intentionally not listed here; the `/model` picker discovers the models directly from the endpoint and always shows what your plan currently supports.
+
+### Headless or scripted setup
+
+For CI, containers, or scripts, configure Token Plan with environment variables or `settings.json` instead of the interactive `/auth` flow.
+
+```bash
+export BAILIAN_TOKEN_PLAN_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+export OPENAI_MODEL="qwen3.7-plus"
+```
+
+Use `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` for the China (Beijing) endpoint, or `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` for the international (Singapore) endpoint. Replace `qwen3.7-plus` with any model included in your plan.
+
+### Alternative: configure via `settings.json`
+
+If you prefer to skip the interactive `/auth` flow, add the following to `~/.qwen/settings.json`:
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "qwen3.7-plus",
+        "name": "qwen3.7-plus (Token Plan)",
+        "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        "description": "qwen3.7-plus from Alibaba Cloud Token Plan",
+        "envKey": "BAILIAN_TOKEN_PLAN_API_KEY"
+      }
+    ]
+  },
+  "env": {
+    "BAILIAN_TOKEN_PLAN_API_KEY": "your-api-key"
+  },
+  "security": {
+    "auth": {
+      "selectedType": "openai"
+    }
+  },
+  "model": {
+    "name": "qwen3.7-plus"
+  }
+}
+```
+
+> [!note]
+>
+> The Token Plan uses dedicated, region-specific endpoints (`*.maas.aliyuncs.com`) that are different from the standard DashScope endpoint. Make sure the `baseUrl` matches the region of your subscription.
+
+## 🚀 Option 4: API Key (flexible)
 
 Use this if you want to connect to third-party providers such as OpenAI, Anthropic, Google, Azure OpenAI, OpenRouter, Requesty, ModelScope, or a self-hosted endpoint. Supports multiple protocols and providers.
 
@@ -315,15 +384,16 @@ qwen --model "qwen3.5-plus"
 
 The standalone `qwen auth` CLI command has been removed. Use these replacements instead:
 
-| Previous use case                | Replacement                                                                                 |
-| -------------------------------- | ------------------------------------------------------------------------------------------- |
-| Interactive authentication setup | Run `qwen`, then use `/auth`                                                                |
-| Coding Plan setup                | Use `/auth`, or set `BAILIAN_CODING_PLAN_API_KEY` with the Coding Plan base URL             |
-| OpenRouter setup                 | Use `/auth`, or set `OPENROUTER_API_KEY` and `OPENAI_BASE_URL=https://openrouter.ai/api/v1` |
-| Requesty setup                   | Use `/auth`, or set `REQUESTY_API_KEY` and `OPENAI_BASE_URL=https://router.requesty.ai/v1`  |
-| API-key or custom provider setup | Configure `~/.qwen/settings.json`, `.env`, or provider-specific environment variables       |
-| Check current authentication     | Run `/doctor` inside Qwen Code                                                              |
-| OAuth browser flow               | Run `qwen` interactively and use `/auth`; OAuth cannot be configured with env vars alone    |
+| Previous use case                | Replacement                                                                                   |
+| -------------------------------- | --------------------------------------------------------------------------------------------- |
+| Interactive authentication setup | Run `qwen`, then use `/auth`                                                                  |
+| Coding Plan setup                | Use `/auth`, or set `BAILIAN_CODING_PLAN_API_KEY` with the Coding Plan base URL               |
+| Token Plan setup                 | Use `/auth`, or set `BAILIAN_TOKEN_PLAN_API_KEY` with the Token Plan base URL for your region |
+| OpenRouter setup                 | Use `/auth`, or set `OPENROUTER_API_KEY` and `OPENAI_BASE_URL=https://openrouter.ai/api/v1`   |
+| Requesty setup                   | Use `/auth`, or set `REQUESTY_API_KEY` and `OPENAI_BASE_URL=https://router.requesty.ai/v1`    |
+| API-key or custom provider setup | Configure `~/.qwen/settings.json`, `.env`, or provider-specific environment variables         |
+| Check current authentication     | Run `/doctor` inside Qwen Code                                                                |
+| OAuth browser flow               | Run `qwen` interactively and use `/auth`; OAuth cannot be configured with env vars alone      |
 
 Legacy invocations such as `qwen auth status` now print a removal notice with these migration paths.
 

--- a/docs/users/configuration/auth.md
+++ b/docs/users/configuration/auth.md
@@ -121,9 +121,9 @@ Token Plan is available in two regions, each with its own dedicated endpoint:
 
 ### Interactive setup
 
-Enter `qwen` in the terminal to launch Qwen Code, then run the `/auth` command, select **Alibaba ModelStudio**, and choose **Token Plan** from the sub-menu. Choose your region (**China (Beijing)** or **Singapore (International)**), then enter your API key. Token Plan API keys have no prefix requirement (unlike Coding Plan keys, which start with `sk-sp-`).
+Enter `qwen` in the terminal to launch Qwen Code, then run the `/auth` command, select **Alibaba ModelStudio**, and choose **Token Plan** from the sub-menu. Choose your region (**China (Beijing)** or **Singapore (International)**), then enter your API key. The wizard then shows its final step (Step 3/3 · Model IDs), where you pick the model IDs to configure: the models served by your endpoint are offered there and are applied only when you explicitly select them. Token Plan API keys have no prefix requirement (unlike Coding Plan keys, which start with `sk-sp-`).
 
-After authentication, use the `/model` command to browse and switch between the models included in your Token Plan. The model lineup evolves over time, so it is intentionally not listed here; the `/model` picker discovers the models directly from the endpoint and always shows what your plan currently supports.
+After authentication, use the `/model` command to browse and switch between the models configured for your Token Plan. The model lineup evolves over time, so it is intentionally not listed here; model discovery from the endpoint happens during the `/auth` setup step above (the endpoint's own list is offered there and must be selected explicitly), and `/model` then shows the models configured for your plan.
 
 ### Headless or scripted setup
 
@@ -136,6 +136,8 @@ export OPENAI_MODEL="qwen3.7-plus"
 ```
 
 Use `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1` for the China (Beijing) endpoint, or `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` for the international (Singapore) endpoint. Replace `qwen3.7-plus` with any model included in your plan.
+
+Note that `BAILIAN_TOKEN_PLAN_API_KEY` is a provider-specific key: it takes effect once the `settings.json` provider entry in the next section exists, because that entry declares it as the `envKey`. To select OpenAI-compatible auth with environment variables alone, export `OPENAI_API_KEY` instead — provider-specific keys do not select the auth type by themselves.
 
 ### Alternative: configure via `settings.json`
 
@@ -395,7 +397,7 @@ The standalone `qwen auth` CLI command has been removed. Use these replacements 
 | Check current authentication     | Run `/doctor` inside Qwen Code                                                                |
 | OAuth browser flow               | Run `qwen` interactively and use `/auth`; OAuth cannot be configured with env vars alone      |
 
-Legacy invocations such as `qwen auth status` now print a removal notice with these migration paths.
+Legacy invocations such as `qwen auth status` print a removal notice that summarizes these migration paths, including a Token Plan entry with the base URLs for both regions.
 
 ## Security notes
 


### PR DESCRIPTION
## What this PR does

Adds a dedicated **Alibaba Cloud Token Plan** setup section to `docs/users/configuration/auth.md`, mirroring the existing Coding Plan section: how to select and configure Token Plan interactively via `/auth`, a region table (China/Beijing vs Singapore/International endpoints), headless setup via environment variables, and a complete `settings.json` example. It also adds a Token Plan row to the "Removed `qwen auth` CLI command" migration table.

All endpoints, env keys, and protocol details were verified against the codebase preset `packages/core/src/providers/presets/alibaba-token-plan.ts` — nothing is hardcoded from memory:

- Env key: `BAILIAN_TOKEN_PLAN_API_KEY`
- China (Beijing): `https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`
- Singapore (International): `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1`
- OpenAI-compatible protocol → `settings.json` example uses `modelProviders.openai`
- Model list intentionally **not** hardcoded (per the #8432 drift concern): the section points users to the `/model` picker and endpoint model discovery, since the preset has `supportsModelDiscovery: true` / `modelsEditable: true`
- Notes that Token Plan keys have no `sk-sp-` prefix requirement, unlike Coding Plan keys

## Why it's needed

Closes #10620. Coding Plan has a full end-to-end setup section while Token Plan was only mentioned in a one-line list entry, leaving Token Plan users without endpoint/region/env-var guidance. The triage on the issue confirmed the gap and the proposed scope.

## Reviewer Test Plan

### How to verify

Docs-only change. Confirm the new section renders correctly and its facts match the preset source:

1. Open `docs/users/configuration/auth.md` and check the new `## 🪙 Option 3: Alibaba Cloud Token Plan` section (structure parallels the Coding Plan section; "API Key (flexible)" became Option 4).
2. Cross-check endpoints/env key against `packages/core/src/providers/presets/alibaba-token-plan.ts`.
3. Check the migration table near `qwen auth` now includes the Token Plan row.

### Evidence (Before & After)

N/A (docs-only; no behavior change)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

Validation: `npx prettier --check` passes on the modified file.
