### PR TITLE
fix(core): demote balanced content-only thinking blocks to thought parts (#10791)

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -552,13 +552,19 @@ describe('OpenAIContentConverter', () => {
       );
 
       expect(opening.candidates?.[0]?.content?.parts).toEqual([]);
-      expect(repeatedOpening.candidates?.[0]?.content?.parts).toEqual([]);
+      // The leading balanced block is demoted to a thought part (issue
+      // #10791); only visible text parts must stay suppressed here.
+      expect(repeatedOpening.candidates?.[0]?.content?.parts).toEqual([
+        { text: '\n\n', thought: true },
+      ]);
       const nestedOpening = converter.convertOpenAIChunkToLlm(
         streamChunk('nested-opening', { content: 'nk>9<think>-3' }),
         stream,
       );
 
-      expect(nestedOpening.candidates?.[0]?.content?.parts).toEqual([]);
+      expect(nestedOpening.candidates?.[0]?.content?.parts).toEqual([
+        { text: '9<think>-3', thought: true },
+      ]);
       expect(() => finishStream(stream)).toThrowError(
         expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }),
       );
@@ -591,10 +597,9 @@ describe('OpenAIContentConverter', () => {
       );
     });
 
-    it('holds a long confirmed opening tag until its closing tag arrives', () => {
+    it('holds an unbalanced opening tag and demotes the block once balanced', () => {
       const stream = withStreamParser();
       stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
-      const text = `<thinking>${'x'.repeat(200)}</thinking>`;
 
       const opening = converter.convertOpenAIChunkToLlm(
         streamChunk('long-balanced', {
@@ -607,8 +612,13 @@ describe('OpenAIContentConverter', () => {
         stream,
       );
 
+      // The unclosed prefix stays held (no visible leak); once the closing
+      // tag balances the block it is demoted to a thought part (issue #10791)
+      // instead of being released as literal text.
       expect(opening.candidates?.[0]?.content?.parts).toEqual([]);
-      expect(closing.candidates?.[0]?.content?.parts).toEqual([{ text }]);
+      expect(closing.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'x'.repeat(200), thought: true },
+      ]);
     });
 
     it('leaks the production <thinking> shape without provider provenance', () => {
@@ -636,14 +646,23 @@ describe('OpenAIContentConverter', () => {
     });
 
     it.each([
-      ['split literal block', ['<thi', 'nk>literal</think>']],
-      ['empty block with a separate finish chunk', ['<think>\n\n</think>', '']],
+      ['split literal block', ['<thi', 'nk>literal</think>'], 'literal'],
+      [
+        'empty block with a separate finish chunk',
+        ['<think>\n\n</think>', ''],
+        '\n\n',
+      ],
       [
         'two split valid blocks',
         ['<think>\n\n', '</think><thi', 'nk>literal</think>'],
+        '\n\nliteral',
       ],
-      ['long empty block', [`<thinking>${' '.repeat(128)}</thinking>`, '']],
-    ])('preserves content-only %s', (_name, chunks) => {
+      [
+        'long empty block',
+        [`<thinking>${' '.repeat(128)}</thinking>`, ''],
+        ' '.repeat(128),
+      ],
+    ])('demotes content-only %s to thought parts', (_name, chunks, thought) => {
       const stream = withStreamParser();
       stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
       const parts = chunks.flatMap((content, index) => {
@@ -658,8 +677,145 @@ describe('OpenAIContentConverter', () => {
         return response.candidates?.[0]?.content?.parts ?? [];
       });
 
-      expect(parts.map((part) => part.text).join('')).toBe(chunks.join(''));
-      expect(parts.every((part) => part.thought !== true)).toBe(true);
+      // Balanced content-only blocks are leaked chain-of-thought in
+      // production (issue #10791): the block text is demoted to the hidden
+      // thought channel and never reaches user-visible output.
+      expect(parts.map((part) => part.text).join('')).toBe(thought);
+      expect(parts.every((part) => part.thought === true)).toBe(true);
+      expect(parts.join('')).not.toContain('<think');
+    });
+
+    it('demotes a balanced content-only thinking block with trailing answer (issue #10791)', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'balanced-leak',
+          {
+            content:
+              '<thinking>\nThe user asks about project 10088.\n</thinking>\n\nHere is the answer.',
+          },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        {
+          text: '\nThe user asks about project 10088.\n',
+          thought: true,
+        },
+        { text: '\n\nHere is the answer.' },
+      ]);
+    });
+
+    it('demotes a balanced content-only thinking block split across chunks with trailing answer', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+      const chunks = [
+        '<thi',
+        'nking>plan the query',
+        '</thinking>',
+        'The visible answer.',
+      ];
+      const parts = chunks.flatMap((content, index) => {
+        const response = converter.convertOpenAIChunkToLlm(
+          streamChunk(
+            `balanced-split-${index}`,
+            { content },
+            index === chunks.length - 1 ? 'stop' : null,
+          ),
+          stream,
+        );
+        return response.candidates?.[0]?.content?.parts ?? [];
+      });
+
+      expect(parts).toEqual([
+        { text: 'plan the query', thought: true },
+        { text: 'The visible answer.' },
+      ]);
+    });
+
+    it('demotes a thinking-only content-only turn without leaking visible text', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'thinking-only',
+          { content: '<think>reasoning with no answer</think>' },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'reasoning with no answer', thought: true },
+      ]);
+    });
+
+    it('keeps demoting follow-up blocks after the leading demotion', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'second-block',
+          { content: '<think>first</think>ok<think>second</think>done' },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'first', thought: true },
+        { text: 'ok' },
+        { text: 'second', thought: true },
+        { text: 'done' },
+      ]);
+    });
+
+    it('fails closed when a thinking block opened after demotion never closes', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk('unclosed-after-demote', {
+          content: '<think>a</think>ok<think>oops',
+        }),
+        stream,
+      );
+
+      // The unclosed tail only reaches the hidden thought channel (the parser
+      // streams thinking incrementally); the turn still fails closed below.
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'a', thought: true },
+        { text: 'ok' },
+        { text: 'oops', thought: true },
+      ]);
+      expect(() => finishStream(stream, 'stop')).toThrowError(
+        expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }),
+      );
+    });
+
+    it('leaks a balanced content-only block without provider provenance', () => {
+      // Control for the demotion tests above: the defense stays gated on
+      // contentOnlyThinkingTagLeaks, so endpoints whose provider does not
+      // opt in keep seeing the literal tags verbatim.
+      const stream = withStreamParser();
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'literal',
+          { content: '<thinking>reasoning</thinking>answer' },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: '<thinking>reasoning</thinking>answer' },
+      ]);
     });
 
     it('releases a long unconfirmed prefix before the stream finishes', () => {
@@ -702,21 +858,41 @@ describe('OpenAIContentConverter', () => {
       expect(response.candidates?.[0]?.content?.parts).toEqual([{ text }]);
     });
 
-    it.each([
-      [
-        'at the start of the stream',
-        ['<think></think><think>outer <think>literal', '</think></think>'],
-      ],
-      [
-        'after visible content',
-        [
-          'Explanation: ',
-          '<think></think><think>outer <think>literal</think></think>',
-        ],
-      ],
-    ])('preserves balanced nested literals %s', (_name, chunks) => {
+    it('demotes the leading balanced nested literal at the start of the stream', () => {
+      // The leading <think></think> balances, so the block is demoted and the
+      // remainder flows through the tagged-thinking parser's documented
+      // binary toggle (issue #10791) instead of being preserved verbatim.
       const stream = withStreamParser();
       stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+      const chunks = [
+        '<think></think><think>outer <think>literal',
+        '</think></think>',
+      ];
+      const parts = chunks.flatMap((content, index) => {
+        const response = converter.convertOpenAIChunkToLlm(
+          streamChunk(
+            `balanced-${index}`,
+            { content },
+            index === chunks.length - 1 ? 'stop' : null,
+          ),
+          stream,
+        );
+        return response.candidates?.[0]?.content?.parts ?? [];
+      });
+
+      expect(parts).toEqual([
+        { text: 'outer <think>literal', thought: true },
+        { text: '</think>' },
+      ]);
+    });
+
+    it('preserves balanced nested literals after visible content', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+      const chunks = [
+        'Explanation: ',
+        '<think></think><think>outer <think>literal</think></think>',
+      ];
       const parts = chunks.flatMap((content, index) => {
         const response = converter.convertOpenAIChunkToLlm(
           streamChunk(
@@ -760,7 +936,12 @@ describe('OpenAIContentConverter', () => {
         stream,
       );
 
-      expect(response.candidates?.[0]?.content?.parts).toEqual([]);
+      // The leading balanced <think></think> activates the demotion parser
+      // (issue #10791), which buffers the unclosed tail in the hidden
+      // thought channel; the turn still fails closed at stream finish.
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: '9<think>' + 'x'.repeat(257), thought: true },
+      ]);
       expect(() => finishStream(stream, 'stop')).toThrowError(
         expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }),
       );
@@ -5385,7 +5566,7 @@ describe('OpenAIContentConverter', () => {
       ]);
     });
 
-    it('should leave tags visible when tagged thinking parsing is disabled', () => {
+    it('demotes a balanced leading block on content-only non-streaming turns', () => {
       const response = converter.convertOpenAIResponseToLlm(
         {
           object: 'chat.completion',
@@ -5397,7 +5578,7 @@ describe('OpenAIContentConverter', () => {
               index: 0,
               message: {
                 role: 'assistant',
-                content: '<think>visible xml example</think>',
+                content: '<thinking>visible xml example</thinking>answer',
               },
               finish_reason: 'stop',
               logprobs: null,
@@ -5410,8 +5591,74 @@ describe('OpenAIContentConverter', () => {
         },
       );
 
+      // Non-streaming completions get the same treatment as streams
+      // (issue #10791): the balanced leading block is demoted to a thought
+      // part and only the trailing answer stays user-visible.
       expect(response.candidates?.[0]?.content?.parts).toEqual([
-        { text: '<think>visible xml example</think>' },
+        { text: 'visible xml example', thought: true },
+        { text: 'answer' },
+      ]);
+    });
+
+    it('keeps non-streaming tags visible without contentOnlyThinkingTagLeaks provenance', () => {
+      const response = converter.convertOpenAIResponseToLlm(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-openai-2',
+          created: 123,
+          model: 'gpt-test',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: '<think>literal example</think>answer',
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: '<think>literal example</think>answer' },
+      ]);
+    });
+
+    it('keeps a non-streaming leading block untouched on structured-reasoning turns', () => {
+      const response = converter.convertOpenAIResponseToLlm(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-openai-3',
+          created: 123,
+          model: 'gpt-test',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: '<think>second phase</think>answer',
+                reasoning_content: 'first phase',
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        {
+          ...requestContext,
+          responseParsingOptions: { contentOnlyThinkingTagLeaks: true },
+        },
+      );
+
+      // The content-only demotion only covers turns with no structured
+      // reasoning channel; reasoning turns keep the inline-block handling
+      // of the streaming path unchanged for now.
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'first phase', thought: true },
+        { text: '<think>second phase</think>answer' },
       ]);
     });
 

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1204,6 +1204,31 @@ function classifyContentOnlyThinkingTagPrefix(
   return streamFinished ? 'leaked' : 'suspicious';
 }
 
+/**
+ * Whether the text starts with an opening thinking tag whose block is fully
+ * balanced by a closing tag (counting nesting), i.e. the leading
+ * `<think>/<thinking> ... </think>/</thinking>` shape production captures
+ * showed as leaked chain-of-thought (issues #6666, #10791). False for a
+ * leading closing tag, no leading tag, or a block that has not balanced yet.
+ * Shares the depth-counting semantics of classifyContentOnlyThinkingTagPrefix.
+ */
+function hasLeadingBalancedThinkingBlock(text: string): boolean {
+  const candidate = text.trimStart();
+  const opening = LEADING_THINKING_TAG_PATTERN.exec(candidate)?.[0];
+  if (!opening || opening.trimStart().startsWith('</')) return false;
+
+  let rest = candidate.slice(opening.length);
+  let depth = 1;
+  for (;;) {
+    const nextTag = THINKING_TAG_PATTERN.exec(rest);
+    if (!nextTag) return false;
+
+    depth += nextTag[0].startsWith('</') ? -1 : 1;
+    if (depth === 0) return true;
+    rest = rest.slice(nextTag.index + nextTag[0].length);
+  }
+}
+
 function throwProtocolTagLeak(requestContext: RequestContext): never {
   requestContext.pendingThinkingTagCandidate = undefined;
   requestContext.pendingUntrustedResponseParts = undefined;
@@ -1227,9 +1252,21 @@ export function convertOpenAIResponseToLlm(
 
   if (choice) {
     const parts: Part[] = [];
-    const textParts = choice.message.content
-      ? convertOpenAITextToParts(choice.message.content, requestContext)
-      : [];
+    let textParts: Part[] = [];
+    if (choice.message.content) {
+      // Balanced leading thinking blocks leak to user-visible output on
+      // content-only turns of non-streaming completions too (issue #10791):
+      // with no structured reasoning channel, demote the block through the
+      // same tagged-thinking parser the streaming path uses instead of
+      // passing the raw tags through verbatim.
+      textParts =
+        requestContext.responseParsingOptions?.contentOnlyThinkingTagLeaks ===
+          true &&
+        !reasoningText &&
+        hasLeadingBalancedThinkingBlock(choice.message.content)
+          ? parseTaggedThinkingText(choice.message.content)
+          : convertOpenAITextToParts(choice.message.content, requestContext);
+    }
 
     // Handle reasoning content (thoughts).
     // Tagged thinking providers may put thoughts in content, while other
@@ -1404,12 +1441,27 @@ export function convertOpenAIChunkToLlm(
       const taggedThinkingCandidate =
         (requestContext.pendingThinkingTagCandidate?.text ?? '') +
         normalizedContent;
+      // A content-only turn (no structured reasoning yet, nothing visible
+      // emitted) whose leading <think>/<thinking> block is fully balanced is
+      // demoted exactly like the structured-reasoning inline blocks above:
+      // production captures (issues #6666, #10791) show this shape is leaked
+      // chain-of-thought the model wrote into content, not legitimate literal
+      // text. Unclosed blocks keep flowing through the hold/reject classifier
+      // below so their fail-closed behavior is unchanged.
+      const contentOnlyBalancedThinkingBlock =
+        requestContext.responseParsingOptions?.contentOnlyThinkingTagLeaks ===
+          true &&
+        !requestContext.hasStructuredReasoningContent &&
+        !reasoningText &&
+        requestContext.hasVisibleContent !== true &&
+        hasLeadingBalancedThinkingBlock(taggedThinkingCandidate);
       if (
-        requestContext.responseParsingOptions
+        (requestContext.responseParsingOptions
           ?.taggedThinkingTagsAfterReasoning &&
-        (requestContext.hasStructuredReasoningContent || reasoningText) &&
-        LEADING_THINKING_TAG_PATTERN.test(taggedThinkingCandidate) &&
-        !taggedThinkingCandidate.trimStart().startsWith('</')
+          (requestContext.hasStructuredReasoningContent || reasoningText) &&
+          LEADING_THINKING_TAG_PATTERN.test(taggedThinkingCandidate) &&
+          !taggedThinkingCandidate.trimStart().startsWith('</')) ||
+        contentOnlyBalancedThinkingBlock
       ) {
         requestContext.taggedThinkingParser ??= new TaggedThinkingParser();
         requestContext.pendingThinkingTagCandidate = undefined;
@@ -1433,7 +1485,9 @@ export function convertOpenAIChunkToLlm(
 
     if (
       choice.finish_reason &&
-      requestContext.responseParsingOptions?.taggedThinkingTagsAfterReasoning &&
+      (requestContext.responseParsingOptions
+        ?.taggedThinkingTagsAfterReasoning ||
+        requestContext.responseParsingOptions?.contentOnlyThinkingTagLeaks) &&
       requestContext.taggedThinkingParser?.hasUnclosedThought()
     ) {
       throwProtocolTagLeak(requestContext);


### PR DESCRIPTION
## What this PR does

Extends the content-only thinking-tag leak defense to **balanced** leading `<thinking>...</thinking>` blocks, closing the gap identified in the issue's triage:

- `packages/core/src/core/openaiContentGenerator/converter.ts`:
  - New `hasLeadingBalancedThinkingBlock()` helper (same depth-scan semantics as the existing classifier) detects when a content-only turn *starts* with a balanced thinking block.
  - **Streaming path**: a new `contentOnlyBalancedThinkingBlock` condition (`contentOnlyThinkingTagLeaks` enabled + no structured reasoning + no visible content yet + leading balanced block) feeds the same `TaggedThinkingParser` demotion that #9607 added — the block becomes a `thought` part and the remaining prose is released normally. Unclosed blocks keep the existing hold/reject classification, unchanged.
  - **Finish**: the unclosed-throw condition now also applies after `contentOnlyThinkingTagLeaks` demotion, so a block opened after demotion and never closed still fails closed with `PROTOCOL_TAG_LEAK`.
  - **Non-streaming path** (`convertOpenAIResponseToLlm`): content-only responses with a leading balanced block are demoted via `parseTaggedThinkingText` — closing the "non-streaming responses are not classified at all" gap the triage called out.
- `converter.test.ts`: 8 existing cases updated (they pinned the old leak-through behavior), 10 new regression/contrast cases added: the issue's main shape (single chunk), cross-chunk spans, thinking-only message, a follow-up block after demotion, fail-closed on post-demotion unclosed, option-disabled contrast, and three non-streaming contrasts (with prose / option disabled / with `reasoning_content`).

## Why it's needed

Fixes #10791. When a hybrid-thinking model bypasses the reasoning channel and emits thinking as literal tags inside `content`, the current defenses only catch the **unclosed** shape (#8818) or balanced **inline** blocks on structured-reasoning turns (#9607). A properly balanced block on a **content-only turn** is classified `clean` and reaches the user verbatim — four production sessions in the issue show exactly this shape. The triage on the issue proposed precisely this direction: reclassify the balanced leading block as a leak, demote it to a thought part behind the existing `contentOnlyThinkingTagLeaks` option, and cover non-streaming too. Literal-tag ambiguity is accepted per production evidence and stays behind the option gate.

## Reviewer Test Plan

### How to verify

1. `npx vitest run packages/core/src/core/openaiContentGenerator/` — 21 files, 904 tests pass, including the 10 new cases.
2. Regression sweep: `npx vitest run packages/core/src/core/llm-chat.test.ts packages/core/src/core/anthropicContentGenerator/` — 558 tests pass.
3. `tsc --noEmit`, eslint, prettier all clean.
4. Behavioral spot-check via the new tests: a content-only turn whose content starts with `<thinking>...</thinking>` followed by prose now yields a thought part + prose part instead of one verbatim content blob; with the option disabled, behavior is unchanged.

### Evidence (Before & After)

Before: balanced content-only leading block classified `clean` → whole `<thinking>…</thinking>` text visible to the user (see the four production sessions cited in the issue).
After: block demoted to a thought part, prose released; post-demotion unclosed blocks still throw `PROTOCOL_TAG_LEAK` (fail-closed preserved). N/A for screenshots — no visual surface changed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  ⚠️    |
|  🐧 Linux  |  ⚠️    |
