### PR TITLE
fix(cli): submit exact OpenTUI slash commands from live input

### DIFF
--- a/packages/cli/src/ui/opentui/input-prompt.test.tsx
+++ b/packages/cli/src/ui/opentui/input-prompt.test.tsx
@@ -933,6 +933,58 @@ describe('OpenTuiInputPrompt Enter accepts completions (G-13)', () => {
     expect(submitted).toEqual(['/help']);
   });
 
+  it('submits an exact command from the live editor when completion is stale', async () => {
+    const submitted: string[] = [];
+    await renderWithCommands(
+      [
+        {
+          name: 'quit',
+          description: 'Exit the CLI',
+          kind: 'built-in',
+          action: () => undefined,
+        },
+      ],
+      (text) => submitted.push(text),
+    );
+    const editor = currentEditor();
+    await typeText('/qui');
+
+    await act(async () => {
+      // OpenTUI can deliver the final character and Enter in one React frame.
+      const handler = lastKeyboardHandler();
+      handler(baseKeyEvent({ name: 't', sequence: 't' }));
+      handler(baseKeyEvent({ name: 'return', sequence: '\r' }));
+    });
+
+    expect(submitted).toEqual(['/quit']);
+    expect(editor.plainText).toBe('');
+  });
+
+  it('does not submit a partial command from stale perfect-match state', async () => {
+    const submitted: string[] = [];
+    await renderWithCommands(
+      [
+        {
+          name: 'quit',
+          description: 'Exit the CLI',
+          kind: 'built-in',
+          action: () => undefined,
+        },
+      ],
+      (text) => submitted.push(text),
+    );
+    const editor = currentEditor();
+    await typeText('/quit');
+
+    editor.setText('/qui');
+    await act(async () => {
+      lastKeyboardHandler()(baseKeyEvent({ name: 'return', sequence: '\r' }));
+    });
+
+    expect(submitted).toEqual([]);
+    expect(editor.plainText).toBe('/quit ');
+  });
+
   it('after navigating, Enter fills the highlighted sub-command', async () => {
     const submitted: string[] = [];
     await renderWithCommands(

--- a/packages/cli/src/ui/opentui/input-prompt.tsx
+++ b/packages/cli/src/ui/opentui/input-prompt.tsx
@@ -270,7 +270,6 @@ export function OpenTuiInputPrompt(props: InputPromptProps) {
   // exactly (Enter then submits instead of accepting a suggestion).
   const slashStateRef = useRef<{
     range: { start: number; end: number };
-    perfect: boolean;
   } | null>(null);
   // Sequence guard for async argument completion (drops stale results).
   const slashSearchSeqRef = useRef(0);
@@ -380,7 +379,6 @@ export function OpenTuiInputPrompt(props: InputPromptProps) {
       const parsed = parseSlashCommandQuery(target.query, pool);
       slashStateRef.current = {
         range: slashCompletionPositions(target.query, parsed),
-        perfect: isPerfectSlashMatch(parsed),
       };
 
       // Argument completion: the leaf command's async completion() supplies
@@ -697,9 +695,28 @@ export function OpenTuiInputPrompt(props: InputPromptProps) {
       // command match submits directly; if the user navigated away from the
       // highlighted default, Enter fills the navigated suggestion instead.
       const showing = suggestions.length > 0;
+      // The editor mutates synchronously, while completion state is refreshed
+      // by a React effect. Re-parse the live buffer so Enter immediately after
+      // the final character of an exact command submits instead of accepting a
+      // stale suggestion.
+      const lines = el.plainText.split('\n');
+      const cursor = el.logicalCursor;
+      const target = detectCompletionTarget(
+        lines,
+        cursor.row,
+        displayColToCodePointIndex(lines[cursor.row] ?? '', cursor.col),
+        el.plainText,
+        displayOffsetToCodePointIndex(el.plainText, cursor.offset),
+        commandsRef.current,
+      );
       const isPerfectMatch =
-        completionModeRef.current === CompletionMode.SLASH &&
-        (slashStateRef.current?.perfect ?? false);
+        target?.mode === CompletionMode.SLASH &&
+        isPerfectSlashMatch(
+          parseSlashCommandQuery(
+            target.query,
+            slashCommandPool(target, commandsRef.current),
+          ),
+        );
       if (showing && (!isPerfectMatch || suggestionNavigatedRef.current)) {
         key.preventDefault();
         acceptSuggestion(activeIndex, true);


### PR DESCRIPTION
## What this PR does

This change makes OpenTUI decide whether Enter should submit an exact slash command from the editor's current text instead of completion state produced by the previous React render. It also adds regression coverage for both stale-state directions: an exact `/quit` must submit, while a partial command must not be dispatched as an old exact match.

## Why it's needed

The main-branch OpenTUI E2E job repeatedly failed because the final `t` in `/quit` and Enter can arrive in the same React frame. The editor already contains `/quit`, but the completion state can still describe `/qui`, so Enter accepts the stale suggestion instead of submitting the command. The input remains on screen and the process never reaches the already-correct interrupt and exit path. The stale Enter path originated in the OpenTUI input batch from #10368. The same job's bare `exit` case succeeds because it does not enter slash completion. This is the OpenTUI counterpart of the stale completion race fixed for Ink by #10929.

Failing job: https://github.com/QwenLM/qwen-code/actions/runs/33820259657/job/100861214441

## Reviewer Test Plan

### How to verify

1. Hold a model response after its first streamed chunk, type `/quit`, and press Enter immediately after the final character. The active response should be interrupted and the CLI should exit with code 0 without waiting for the held stream.
2. Type a partial slash command while completion state still reflects a previous exact match. Enter should accept completion rather than dispatching the partial command.
3. Confirm the existing OpenTUI mid-turn submit E2E and the focused composer unit tests pass.

### Evidence (Before & After)

Before: the linked main-branch job retried the `/quit` case three times; each attempt timed out after 30 seconds while the input and completion menu remained visible. The bare `exit` case completed in 3.7 seconds.

After: the regression test sends the final `t` and Enter in one React frame and expects `/quit` to be submitted and the editor to clear. Standard PR CI remains the authoritative OpenTUI runtime verification because the isolated local worktree did not have the newly required `@opentui/react` package installed.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Focused ESLint and Prettier checks passed. The focused Vitest file could not be collected in the isolated worktree because its dependency snapshot predates the OpenTUI packages; no full dependency installation or broad build was run locally.

## Risk & Scope

- Main risk or tradeoff: Enter now performs a small synchronous parse of the current slash-command token before deciding between submit and autocomplete.
- Not validated / out of scope: unrelated OpenTUI command rendering work in #10947 and other E2E lanes.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #10976

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

本改动让 OpenTUI 在按下 Enter 时直接依据编辑器当前文本判断是否为完整 slash command，不再依赖上一次 React 渲染产生的补全状态。同时增加两个方向的回归覆盖：完整的 `/quit` 必须提交，而部分命令不能因为旧状态曾经是完整匹配就被错误执行。

## 为什么需要

main 分支的 OpenTUI E2E 反复失败，是因为 `/quit` 最后的 `t` 和 Enter 可能在同一个 React frame 内到达。此时编辑器已经是 `/quit`，但补全状态仍可能停留在 `/qui`，Enter 因而接受旧补全项而不是提交命令。输入内容继续留在界面上，进程也没有进入本来已经正确的中断和退出路径。这个使用旧状态的 Enter 路径最初由 OpenTUI 输入批次 #10368 引入。同一 job 中裸 `exit` 能成功，是因为它不会进入 slash 补全。这是 #10929 已为 Ink 修复的补全状态竞态在 OpenTUI 中的对应问题。

失败 job：https://github.com/QwenLM/qwen-code/actions/runs/33820259657/job/100861214441

## Reviewer Test Plan

### 如何验证

1. 在模型响应输出第一个流式片段后保持流不结束，输入 `/quit`，并在最后一个字符后立即按 Enter。活动响应应被中断，CLI 应以退出码 0 结束，不等待被保持的响应流。
2. 当补全状态仍记录着之前的完整匹配时输入部分 slash command。Enter 应接受补全，而不是执行这个部分命令。
3. 确认现有 OpenTUI mid-turn submit E2E 和聚焦的 composer 单元测试通过。

### 前后证据

改动前：链接中的 main 分支 job 对 `/quit` case 重试三次，每次都在 30 秒后超时，输入和补全菜单仍留在屏幕上；裸 `exit` case 在 3.7 秒内完成。

改动后：回归测试在同一个 React frame 中发送最后的 `t` 和 Enter，并断言 `/quit` 被提交且编辑器被清空。由于隔离的本地 worktree 没有安装新要求的 `@opentui/react` 包，标准 PR CI 是 OpenTUI 运行时的权威验证。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

聚焦的 ESLint 和 Prettier 检查已通过。隔离 worktree 的依赖快照早于 OpenTUI 包，因此无法收集聚焦的 Vitest 文件；本地没有执行全量依赖安装或整仓构建。

## 风险与范围

- 主要风险或取舍：Enter 在决定提交还是补全之前，会对当前 slash command token 做一次小型同步解析。
- 未验证或范围外：#10947 中无关的 OpenTUI 命令渲染工作以及其他 E2E lane。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #10976

</details>
