### PR TITLE
refactor(cli): route every per-request runtime-root pin through runWithPinnedRuntimeBaseDir

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -14,6 +14,7 @@ import {
   afterAll,
   type MockInstance,
 } from 'vitest';
+import { readFileSync } from 'node:fs';
 import type { Stats } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
@@ -20203,7 +20204,7 @@ describe('QwenAgent sessionIdContext binding', () => {
   });
 });
 
-describe('QwenAgent extMethod renameSession routing', () => {
+describe('QwenAgent session-management routing (rename / delete / list / branch / close)', () => {
   type AgentSideConnectionLike = { closed: Promise<void> };
   type AgentLike = {
     initialize: (args: Record<string, unknown>) => Promise<unknown>;
@@ -29914,5 +29915,24 @@ describe('createManagedExternalToolGuard', () => {
 
     await expect(pending).rejects.toThrow('aborted');
     expect(extMethod).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('QwenAgent runtime-root pinning choke point', () => {
+  it('routes every per-request runtime-root pin through runWithPinnedRuntimeBaseDir', () => {
+    // #10095 fixed handlers that composed `loadSettingsCached` →
+    // `runWithAcpRuntimeOutputDir` by hand and picked up the stale
+    // `this.settings` cache. The private helper is the one place that
+    // decision is made, so a handler calling `runWithAcpRuntimeOutputDir`
+    // directly is exactly the shape that regressed. No behavioral test can
+    // see the difference (both spellings reach the same function), so pin
+    // the source: the only call left is the helper's own delegation.
+    const source = readFileSync(
+      new URL('./acpAgent.ts', import.meta.url),
+      'utf8',
+    );
+    const directCalls = source.match(/\brunWithAcpRuntimeOutputDir\(/g) ?? [];
+    expect(directCalls).toHaveLength(1);
+    expect(source).toContain('private runWithPinnedRuntimeBaseDir<T>(');
   });
 });

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -15071,6 +15071,68 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('resolves sessionTurnStatus settings per request, not from the this.settings cache', async () => {
+    const sessionId = '11111111-1111-1111-1111-111111111111';
+    await setupSessionMocks(sessionId);
+    const readPage = vi.fn().mockResolvedValue({
+      sessionId,
+      records: [],
+      hasMore: false,
+      gaps: [],
+      startTime: 'start',
+      lastUpdated: 'end',
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+
+    const agentPromise = runAcpAgent(
+      mockConfig,
+      makeSessionSettings(),
+      mockArgv,
+    );
+    await vi.waitFor(() => expect(capturedAgentFactory).toBeDefined());
+    const agent = capturedAgentFactory!({
+      get closed() {
+        return mockConnectionState.promise;
+      },
+    }) as AgentLike;
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    // Multi-workspace daemon shape: the live session and `this.settings`
+    // belong to the boot workspace; the status request names another cwd
+    // whose own settings (and therefore advanced.runtimeOutputDir) must pin
+    // the transcript read. Routing through the stale cache would scan the
+    // wrong runtime root.
+    const perRequestSettings = makeSessionSettings();
+    vi.mocked(loadSettings).mockClear();
+    vi.mocked(loadSettings).mockReturnValue(perRequestSettings);
+    vi.mocked(runWithAcpRuntimeOutputDir).mockClear();
+
+    await expect(
+      agent.extMethod(SERVE_CONTROL_EXT_METHODS.sessionTurnStatus, {
+        cwd: '/tmp/workspace-a',
+        sessionId,
+        promptId: 'prompt-1',
+      }),
+    ).resolves.toEqual({ v: 1, sessionId, turnResult: null });
+
+    expect(loadSettings).toHaveBeenCalledWith('/tmp/workspace-a');
+    expect(runWithAcpRuntimeOutputDir).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runWithAcpRuntimeOutputDir).mock.calls[0]![0]).toBe(
+      perRequestSettings,
+    );
+    expect(vi.mocked(runWithAcpRuntimeOutputDir).mock.calls[0]![1]).toBe(
+      '/tmp/workspace-a',
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('still scans the transcript when the pre-read flush fails', async () => {
     const sessionId = '11111111-1111-1111-1111-111111111111';
     const innerConfig = await setupSessionMocks(sessionId);
@@ -16636,6 +16698,66 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       skipSkillManager: true,
       skipFileCheckpointing: true,
       lenientToolWarmup: true,
+    });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('resolves qwen/status/session/transcript settings per request, not from the this.settings cache', async () => {
+    const settings = makeCoreSettings();
+    mockRunExitCleanup.mockResolvedValue(undefined);
+    const transcriptConfig = {
+      ...makeInnerConfig(),
+      enableFileCheckpointing: vi.fn(),
+    };
+    vi.mocked(loadCliConfig).mockResolvedValue(
+      transcriptConfig as unknown as Config,
+    );
+    const readPage = vi.fn().mockResolvedValue({
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      gaps: [],
+      startTime: 'start',
+      lastUpdated: 'end',
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootCoreSettingsAgent(settings);
+
+    // Multi-workspace daemon shape: `this.settings` holds the boot
+    // workspace's settings; the transcript request names another cwd whose
+    // own settings must pin the read (and seed the replay config).
+    // A different outputLanguage makes the request's settings distinguishable
+    // from the boot settings by content, not just by identity.
+    const perRequestSettings = makeCoreSettings('French');
+    vi.mocked(loadSettings).mockClear();
+    vi.mocked(loadSettings).mockReturnValue(perRequestSettings);
+    vi.mocked(runWithAcpRuntimeOutputDir).mockClear();
+
+    await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+      cwd: '/tmp/workspace-a',
+      sessionId: VALID_SESSION_ID,
+    });
+
+    expect(loadSettings).toHaveBeenCalledWith('/tmp/workspace-a');
+    // The outer pin is the handler's; the replay-config build inside it may
+    // pin again with the same settings. Every pin must carry the request's.
+    const pins = vi.mocked(runWithAcpRuntimeOutputDir).mock.calls;
+    expect(pins.length).toBeGreaterThanOrEqual(1);
+    expect(pins[0]![0]).toBe(perRequestSettings);
+    expect(pins[0]![1]).toBe('/tmp/workspace-a');
+    expect(pins.every(([s]) => s === perRequestSettings)).toBe(true);
+    // The replay config built inside the pinned scope was seeded from the
+    // request's settings (the operation receives them), not this.settings.
+    expect(vi.mocked(loadCliConfig).mock.calls.at(-1)?.[0]).toMatchObject({
+      general: { outputLanguage: 'French' },
     });
 
     mockConnectionState.resolve();
@@ -29920,20 +30042,25 @@ describe('createManagedExternalToolGuard', () => {
 
 describe('QwenAgent runtime-root pinning choke point', () => {
   it('routes every per-request runtime-root pin through runWithPinnedRuntimeBaseDir', () => {
-    // #10095 fixed handlers that composed `loadSettingsCached` →
-    // `runWithAcpRuntimeOutputDir` by hand and picked up the stale
-    // `this.settings` cache. The private helper is the one place that
-    // decision is made, so a handler calling `runWithAcpRuntimeOutputDir`
-    // directly is exactly the shape that regressed. No behavioral test can
-    // see the difference (both spellings reach the same function), so pin
-    // the source: the only call left is the helper's own delegation.
+    // #10095 fixed handlers that composed the runtime-root routing by hand
+    // and picked up the stale `this.settings` cache. Per-request handlers now
+    // go through `runWithPinnedRuntimeBaseDirForRequest`, which resolves the
+    // settings from the request cwd itself, and everything else through the
+    // shared helper. A handler naming `runWithAcpRuntimeOutputDir` directly —
+    // as a call or via an alias — is exactly the shape that regressed, and
+    // no behavioral test can see the difference (both spellings reach the
+    // same function), so pin the source: outside imports and comments the
+    // only mention left is the shared helper's own delegation. The per-request
+    // handlers themselves are pinned behaviorally (settings/cwd reaching the
+    // mock) by the routing tests above.
     const source = readFileSync('src/acp-integration/acpAgent.ts', 'utf8');
     const directCalls = source
       .split('\n')
       .map((line, index) => ({ line: index + 1, text: line.trim() }))
       .filter(
         ({ text }) =>
-          /\brunWithAcpRuntimeOutputDir\(/.test(text) &&
+          /\brunWithAcpRuntimeOutputDir\b/.test(text) &&
+          !text.startsWith('import ') &&
           !text.startsWith('//') &&
           !text.startsWith('*') &&
           !text.startsWith('/*'),

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -20895,6 +20895,46 @@ describe('QwenAgent session-management routing (rename / delete / list / branch 
     await agentPromise;
   });
 
+  it('resolves non-live qwen/session/loadUpdates settings per request, not from the this.settings cache', async () => {
+    const innerConfig = makeLiveSessionInnerConfig(null);
+    const { agent, agentPromise } = await bootAgent(innerConfig);
+
+    // No newSession: the target is not live in this process, so loadUpdates
+    // takes the disk-only SessionService branch. `this.settings` holds the
+    // boot workspace's settings; the request names another cwd whose own
+    // settings must pin the read.
+    const perRequestSettings = makeAcpSettings();
+    vi.mocked(loadSettings).mockReturnValue(perRequestSettings);
+    const loadSession = vi.fn().mockResolvedValue(null);
+    vi.mocked(SessionService).mockImplementation(
+      () => ({ loadSession }) as unknown as InstanceType<typeof SessionService>,
+    );
+    vi.mocked(runWithAcpRuntimeOutputDir).mockClear();
+
+    await expect(
+      agent.extMethod('qwen/session/loadUpdates', {
+        cwd: '/tmp/workspace-a',
+        sessionId: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+      }),
+    ).resolves.toEqual({ updates: [] });
+
+    expect(SessionService).toHaveBeenCalledWith('/tmp/workspace-a');
+    expect(loadSession).toHaveBeenCalledWith(
+      '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    );
+    expect(loadSettings).toHaveBeenCalledWith('/tmp/workspace-a');
+    expect(runWithAcpRuntimeOutputDir).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runWithAcpRuntimeOutputDir).mock.calls[0]![0]).toBe(
+      perRequestSettings,
+    );
+    expect(vi.mocked(runWithAcpRuntimeOutputDir).mock.calls[0]![1]).toBe(
+      '/tmp/workspace-a',
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('returns success=false when the live ChatRecordingService rejects the title (I/O error)', async () => {
     const recording = makeRecordingService();
     recording.recordCustomTitle.mockResolvedValue(false);
@@ -30049,8 +30089,9 @@ describe('QwenAgent runtime-root pinning choke point', () => {
     // shared helper. A handler naming `runWithAcpRuntimeOutputDir` directly —
     // as a call or via an alias — is exactly the shape that regressed, and
     // no behavioral test can see the difference (both spellings reach the
-    // same function), so pin the source: outside imports and comments the
-    // only mention left is the shared helper's own delegation. The per-request
+    // same function), so pin the source: outside the canonical import line
+    // and comments, the only mention left is the shared helper's own
+    // delegation (an aliased import would be a second mention). The per-request
     // handlers themselves are pinned behaviorally (settings/cwd reaching the
     // mock) by the routing tests above.
     const source = readFileSync('src/acp-integration/acpAgent.ts', 'utf8');
@@ -30060,7 +30101,9 @@ describe('QwenAgent runtime-root pinning choke point', () => {
       .filter(
         ({ text }) =>
           /\brunWithAcpRuntimeOutputDir\b/.test(text) &&
-          !text.startsWith('import ') &&
+          !text.startsWith(
+            "import { runWithAcpRuntimeOutputDir } from './runtimeOutputDirContext.js';",
+          ) &&
           !text.startsWith('//') &&
           !text.startsWith('*') &&
           !text.startsWith('/*'),
@@ -30068,7 +30111,7 @@ describe('QwenAgent runtime-root pinning choke point', () => {
     const located = directCalls.map(({ line, text }) => `${line}: ${text}`);
     expect(
       located,
-      `acpAgent.ts must not call runWithAcpRuntimeOutputDir directly; route the operation through this.runWithPinnedRuntimeBaseDir (see #10095). Direct calls at:\n${located.join('\n')}`,
+      `acpAgent.ts must not name runWithAcpRuntimeOutputDir directly. Handlers serving a caller-supplied cwd route through this.runWithPinnedRuntimeBaseDirForRequest; only callers holding deliberately scoped settings may use this.runWithPinnedRuntimeBaseDir (see #10095). Direct mentions at:\n${located.join('\n')}`,
     ).toEqual([
       expect.stringMatching(
         /^\d+: return runWithAcpRuntimeOutputDir\(settings, cwd, operation\);$/,

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -16,6 +16,7 @@ import {
 } from 'vitest';
 import { readFileSync } from 'node:fs';
 import type { Stats } from 'node:fs';
+import * as ts from 'typescript';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -30087,31 +30088,47 @@ describe('QwenAgent runtime-root pinning choke point', () => {
     // go through `runWithPinnedRuntimeBaseDirForRequest`, which resolves the
     // settings from the request cwd itself, and everything else through the
     // shared helper. A handler naming `runWithAcpRuntimeOutputDir` directly —
-    // as a call or via an alias — is exactly the shape that regressed, and
-    // no behavioral test can see the difference (both spellings reach the
-    // same function), so pin the source: outside the canonical import line
-    // and comments, the only mention left is the shared helper's own
-    // delegation (an aliased import would be a second mention). The per-request
-    // handlers themselves are pinned behaviorally (settings/cwd reaching the
-    // mock) by the routing tests above.
-    const source = readFileSync('src/acp-integration/acpAgent.ts', 'utf8');
-    const directCalls = source
-      .split('\n')
-      .map((line, index) => ({ line: index + 1, text: line.trim() }))
-      .filter(
-        ({ text }) =>
-          /\brunWithAcpRuntimeOutputDir\b/.test(text) &&
-          !text.startsWith(
-            "import { runWithAcpRuntimeOutputDir } from './runtimeOutputDirContext.js';",
-          ) &&
-          !text.startsWith('//') &&
-          !text.startsWith('*') &&
-          !text.startsWith('/*'),
-      );
-    const located = directCalls.map(({ line, text }) => `${line}: ${text}`);
+    // as a call, via an alias, or via an aliased import — is exactly the
+    // shape that regressed, and no behavioral test can see the difference
+    // (both spellings reach the same function), so pin the source. Walk the
+    // AST rather than lines: comments, string literals and import formatting
+    // cannot false-positive, the canonical un-aliased import specifier is the
+    // one exempt mention, and the only other mention must be the shared
+    // helper's own delegation. The per-request handlers themselves are pinned
+    // behaviorally (settings/cwd reaching the mock) by the routing tests above.
+    const sourcePath = 'src/acp-integration/acpAgent.ts';
+    const source = readFileSync(sourcePath, 'utf8');
+    const lines = source.split('\n');
+    const sourceFile = ts.createSourceFile(
+      sourcePath,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const mentions: string[] = [];
+    const visit = (node: ts.Node): void => {
+      if (ts.isIdentifier(node) && node.text === 'runWithAcpRuntimeOutputDir') {
+        // `import { runWithAcpRuntimeOutputDir } from …` binds the name
+        // without an alias (`propertyName` is unset). An aliased specifier
+        // (`runWithAcpRuntimeOutputDir as pin`) keeps this identifier under
+        // `propertyName` and is reported like any other mention.
+        const isCanonicalImport =
+          ts.isImportSpecifier(node.parent) &&
+          node.parent.propertyName === undefined;
+        if (!isCanonicalImport) {
+          const { line } = sourceFile.getLineAndCharacterOfPosition(
+            node.getStart(sourceFile),
+          );
+          mentions.push(`${line + 1}: ${lines[line]!.trim()}`);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
     expect(
-      located,
-      `acpAgent.ts must not name runWithAcpRuntimeOutputDir directly. Handlers serving a caller-supplied cwd route through this.runWithPinnedRuntimeBaseDirForRequest; only callers holding deliberately scoped settings may use this.runWithPinnedRuntimeBaseDir (see #10095). Direct mentions at:\n${located.join('\n')}`,
+      mentions,
+      `acpAgent.ts must not name runWithAcpRuntimeOutputDir directly. Handlers serving a caller-supplied cwd route through this.runWithPinnedRuntimeBaseDirForRequest; only callers holding deliberately scoped settings may use this.runWithPinnedRuntimeBaseDir (see #10095). Direct mentions at:\n${mentions.join('\n')}`,
     ).toEqual([
       expect.stringMatching(
         /^\d+: return runWithAcpRuntimeOutputDir\(settings, cwd, operation\);$/,

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -29927,12 +29927,25 @@ describe('QwenAgent runtime-root pinning choke point', () => {
     // directly is exactly the shape that regressed. No behavioral test can
     // see the difference (both spellings reach the same function), so pin
     // the source: the only call left is the helper's own delegation.
-    const source = readFileSync(
-      new URL('./acpAgent.ts', import.meta.url),
-      'utf8',
-    );
-    const directCalls = source.match(/\brunWithAcpRuntimeOutputDir\(/g) ?? [];
-    expect(directCalls).toHaveLength(1);
-    expect(source).toContain('private runWithPinnedRuntimeBaseDir<T>(');
+    const source = readFileSync('src/acp-integration/acpAgent.ts', 'utf8');
+    const directCalls = source
+      .split('\n')
+      .map((line, index) => ({ line: index + 1, text: line.trim() }))
+      .filter(
+        ({ text }) =>
+          /\brunWithAcpRuntimeOutputDir\(/.test(text) &&
+          !text.startsWith('//') &&
+          !text.startsWith('*') &&
+          !text.startsWith('/*'),
+      );
+    const located = directCalls.map(({ line, text }) => `${line}: ${text}`);
+    expect(
+      located,
+      `acpAgent.ts must not call runWithAcpRuntimeOutputDir directly; route the operation through this.runWithPinnedRuntimeBaseDir (see #10095). Direct calls at:\n${located.join('\n')}`,
+    ).toEqual([
+      expect.stringMatching(
+        /^\d+: return runWithAcpRuntimeOutputDir\(settings, cwd, operation\);$/,
+      ),
+    ]);
   });
 });

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4556,13 +4556,15 @@ class QwenAgent implements Agent {
   }
 
   /**
-   * Single choke point for pinning the runtime root of a per-request
-   * operation to the settings loaded for THAT request's cwd. Every handler
-   * that resolves session storage for a caller-supplied cwd goes through
-   * here rather than calling `runWithAcpRuntimeOutputDir` directly, so the
-   * "which settings pin this operation" decision lives in one place — the
-   * bug class fixed in #10095 was handlers composing the routing by hand
-   * with the stale `this.settings` cache.
+   * Single choke point for pinning the runtime root of an operation to a
+   * settings object and a cwd. Every caller in this class goes through here
+   * rather than calling `runWithAcpRuntimeOutputDir` directly, so the routing
+   * is composed in exactly one place. Which settings to pin with is still the
+   * caller's decision at this level: callers that already hold deliberately
+   * scoped settings (workspace MCP discovery, live-session scope checks,
+   * session creation) pass them in. Handlers that serve a caller-supplied cwd
+   * must not make that decision themselves — they use
+   * `runWithPinnedRuntimeBaseDirForRequest` below.
    */
   private runWithPinnedRuntimeBaseDir<T>(
     settings: LoadedSettings,
@@ -4570,6 +4572,26 @@ class QwenAgent implements Agent {
     operation: () => T,
   ): T {
     return runWithAcpRuntimeOutputDir(settings, cwd, operation);
+  }
+
+  /**
+   * Per-request form of `runWithPinnedRuntimeBaseDir` for handlers that act
+   * on a caller-supplied cwd. It resolves the settings for THAT cwd itself,
+   * so the "which settings pin this operation" decision is made here, once,
+   * and a handler cannot reach the pin with the process-wide `this.settings`
+   * cache — the bug class fixed in #10095 (three handlers composed the
+   * routing by hand and pinned another workspace's runtime root). The
+   * operation receives the resolved settings for handlers that also need
+   * them inside the pinned scope.
+   */
+  private runWithPinnedRuntimeBaseDirForRequest<T>(
+    cwd: string,
+    operation: (settings: LoadedSettings) => T,
+  ): T {
+    const settings = loadSettingsCached(cwd);
+    return this.runWithPinnedRuntimeBaseDir(settings, cwd, () =>
+      operation(settings),
+    );
   }
 
   /**
@@ -5782,8 +5804,7 @@ class QwenAgent implements Agent {
     // a multi-workspace daemon it may hold another workspace's
     // advanced.runtimeOutputDir and this listing would scan the wrong runtime
     // root (returning an empty/foreign list for this cwd).
-    const settings = loadSettingsCached(cwd);
-    const result = await this.runWithPinnedRuntimeBaseDir(settings, cwd, () => {
+    const result = await this.runWithPinnedRuntimeBaseDirForRequest(cwd, () => {
       const sessionService = new SessionService(cwd);
       return sessionService.listSessions({
         cursor: numericCursor,
@@ -8869,8 +8890,7 @@ class QwenAgent implements Agent {
         }
 
         try {
-          const settings = loadSettingsCached(cwd);
-          const readTranscriptPage = async () => {
+          const readTranscriptPage = async (settings: LoadedSettings) => {
             if (rawDirection === 'backward') {
               await this.sessions
                 .get(sessionId)
@@ -8923,8 +8943,7 @@ class QwenAgent implements Agent {
                 : {}),
             } as Record<string, unknown>;
           };
-          return await this.runWithPinnedRuntimeBaseDir(
-            settings,
+          return await this.runWithPinnedRuntimeBaseDirForRequest(
             cwd,
             readTranscriptPage,
           );
@@ -11799,7 +11818,6 @@ class QwenAgent implements Agent {
           );
         }
         const session = this.sessionOrThrow(sessionId);
-        const settings = loadSettingsCached(cwd);
         const readSettledTurnResult = async () => {
           try {
             await session.getConfig().getChatRecordingService()?.flush();
@@ -11874,8 +11892,7 @@ class QwenAgent implements Agent {
             throw error;
           }
         };
-        return await this.runWithPinnedRuntimeBaseDir(
-          settings,
+        return await this.runWithPinnedRuntimeBaseDirForRequest(
           cwd,
           readSettledTurnResult,
         );
@@ -12096,8 +12113,7 @@ class QwenAgent implements Agent {
         // destructive lookup at the wrong runtime root — silently returning
         // success:false for a session that exists, or deleting a stale
         // same-id copy under the wrong root.
-        const success = await this.runWithPinnedRuntimeBaseDir(
-          loadSettingsCached(cwd),
+        const success = await this.runWithPinnedRuntimeBaseDirForRequest(
           cwd,
           async () => {
             const sessionService = new SessionService(cwd);
@@ -12147,8 +12163,7 @@ class QwenAgent implements Agent {
           return { success: ok };
         }
         // Per-request settings for the same reason as deleteSession above.
-        const success = await this.runWithPinnedRuntimeBaseDir(
-          loadSettingsCached(cwd),
+        const success = await this.runWithPinnedRuntimeBaseDirForRequest(
           cwd,
           async () => {
             const sessionService = new SessionService(cwd);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4562,9 +4562,13 @@ class QwenAgent implements Agent {
    * is composed in exactly one place. Which settings to pin with is still the
    * caller's decision at this level: callers that already hold deliberately
    * scoped settings (workspace MCP discovery, live-session scope checks,
-   * session creation) pass them in. Handlers that serve a caller-supplied cwd
-   * must not make that decision themselves — they use
-   * `runWithPinnedRuntimeBaseDirForRequest` below.
+   * session creation) pass them in. Per-request session-management handlers
+   * (list, delete, rename, transcript page, settled turn status, and the
+   * non-live branch of loadUpdates) must not make that decision themselves —
+   * they use `runWithPinnedRuntimeBaseDirForRequest` below. Session load and
+   * resume resolve the request's settings at the call site deliberately,
+   * under profiler instrumentation, because they adopt those settings for
+   * the session afterwards.
    */
   private runWithPinnedRuntimeBaseDir<T>(
     settings: LoadedSettings,
@@ -12394,9 +12398,7 @@ class QwenAgent implements Agent {
             : await loadAuthoritative();
           replayConfig = config;
         } else {
-          const settings = loadSettingsCached(cwd);
-          sessionData = await this.runWithPinnedRuntimeBaseDir(
-            settings,
+          sessionData = await this.runWithPinnedRuntimeBaseDirForRequest(
             cwd,
             async () => {
               const sessionService = new SessionService(cwd);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4555,6 +4555,15 @@ class QwenAgent implements Agent {
     }
   }
 
+  /**
+   * Single choke point for pinning the runtime root of a per-request
+   * operation to the settings loaded for THAT request's cwd. Every handler
+   * that resolves session storage for a caller-supplied cwd goes through
+   * here rather than calling `runWithAcpRuntimeOutputDir` directly, so the
+   * "which settings pin this operation" decision lives in one place — the
+   * bug class fixed in #10095 was handlers composing the routing by hand
+   * with the stale `this.settings` cache.
+   */
   private runWithPinnedRuntimeBaseDir<T>(
     settings: LoadedSettings,
     cwd: string,
@@ -5774,7 +5783,7 @@ class QwenAgent implements Agent {
     // advanced.runtimeOutputDir and this listing would scan the wrong runtime
     // root (returning an empty/foreign list for this cwd).
     const settings = loadSettingsCached(cwd);
-    const result = await runWithAcpRuntimeOutputDir(settings, cwd, () => {
+    const result = await this.runWithPinnedRuntimeBaseDir(settings, cwd, () => {
       const sessionService = new SessionService(cwd);
       return sessionService.listSessions({
         cursor: numericCursor,
@@ -8861,7 +8870,7 @@ class QwenAgent implements Agent {
 
         try {
           const settings = loadSettingsCached(cwd);
-          return await runWithAcpRuntimeOutputDir(settings, cwd, async () => {
+          const readTranscriptPage = async () => {
             if (rawDirection === 'backward') {
               await this.sessions
                 .get(sessionId)
@@ -8913,7 +8922,12 @@ class QwenAgent implements Agent {
                 ? { partial: true, replayError: replay.replayError }
                 : {}),
             } as Record<string, unknown>;
-          });
+          };
+          return await this.runWithPinnedRuntimeBaseDir(
+            settings,
+            cwd,
+            readTranscriptPage,
+          );
         } catch (error) {
           if (
             error instanceof InvalidSessionTranscriptCursorError ||
@@ -11786,7 +11800,7 @@ class QwenAgent implements Agent {
         }
         const session = this.sessionOrThrow(sessionId);
         const settings = loadSettingsCached(cwd);
-        return await runWithAcpRuntimeOutputDir(settings, cwd, async () => {
+        const readSettledTurnResult = async () => {
           try {
             await session.getConfig().getChatRecordingService()?.flush();
           } catch {
@@ -11859,7 +11873,12 @@ class QwenAgent implements Agent {
             }
             throw error;
           }
-        });
+        };
+        return await this.runWithPinnedRuntimeBaseDir(
+          settings,
+          cwd,
+          readSettledTurnResult,
+        );
       }
       case SERVE_CONTROL_EXT_METHODS.sessionContinue: {
         const sessionId = params['sessionId'];
@@ -12077,7 +12096,7 @@ class QwenAgent implements Agent {
         // destructive lookup at the wrong runtime root — silently returning
         // success:false for a session that exists, or deleting a stale
         // same-id copy under the wrong root.
-        const success = await runWithAcpRuntimeOutputDir(
+        const success = await this.runWithPinnedRuntimeBaseDir(
           loadSettingsCached(cwd),
           cwd,
           async () => {
@@ -12128,7 +12147,7 @@ class QwenAgent implements Agent {
           return { success: ok };
         }
         // Per-request settings for the same reason as deleteSession above.
-        const success = await runWithAcpRuntimeOutputDir(
+        const success = await this.runWithPinnedRuntimeBaseDir(
           loadSettingsCached(cwd),
           cwd,
           async () => {


### PR DESCRIPTION
## What this PR does

Makes the agent's runtime-root pinning go through one documented seam instead of five hand-composed copies, and puts the "which settings pin this operation" decision inside that seam for per-request handlers. The existing private three-argument helper stays as the single place that composes the routing (every caller in the class goes through it; nothing else names the underlying context function). On top of it, a per-request variant takes only the request's cwd, resolves that cwd's settings itself, and hands them to the operation — so a handler serving a caller-supplied cwd has no settings argument it could fill with the process-wide cache. The six per-request sites (session listing, delete, rename, status transcript page, settled turn status, and the non-live branch of session loadUpdates) all use the variant; callers that hold deliberately scoped settings (workspace MCP discovery, live-session scope checks, session creation) keep the three-argument form. The helper bodies are one-line delegations, so runtime behavior is unchanged; the two wide call sites name their inline callbacks so the reroute does not re-indent two 60-line bodies.

Three tests pin this. A source-level test walks the file's TypeScript AST and asserts that the only mention of the underlying context function, other than the un-aliased import specifier, is the shared helper's own delegation — so comments, string literals and import formatting cannot false-positive, while an alias, an aliased import, or a direct call is reported with its line. Three behavioral tests cover the rerouted handlers that had none (settled turn status, status transcript page, non-live loadUpdates): each asserts the settings and cwd reaching the mocked context function are the request's, and the transcript test also checks the replay config built inside the pinned scope was seeded from the request's settings. The test describe block holding #10095's three regression tests is renamed to match what it actually covers.

## Why it's needed

Follow-up to #10095, closing the two non-blocking items recorded there: the round-2 review's deferred D2-1 (the near-miss helper already existed, the fix hand-pasted the routing three more times) and the maintainer's nit that the three regression tests were reported under a `renameSession routing` describe. Hand-composed routing is exactly the shape that regressed in #10095 — each handler made its own "which settings pin this operation" decision and three of them made it wrong. Round 1 of this PR's own review showed that merely routing through a pass-through helper does not remove that decision from the call sites; the per-request variant does, and the mutation matrix below shows the seam is now load-bearing for every handler that uses it.

The choke-point invariant needs a source pin rather than a behavioral test because both spellings reach the same function. The pin follows the precedent in `serve/fast-path.test.ts` (TypeScript AST walk over a source file read with a package-relative path).

## Reviewer Test Plan

### How to verify

1. `grep -n 'runWithAcpRuntimeOutputDir' packages/cli/src/acp-integration/acpAgent.ts` — outside the canonical import line and comments, expect exactly one hit: the shared helper's delegation. On `main` there are six call sites. `grep -c 'runWithPinnedRuntimeBaseDirForRequest(' …` — expect 6 call sites (the definition line carries a type parameter and does not match).
2. `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts` — 605/605 (601 existing + the source pin + three behavioral pins). #10095's three regression tests report under `QwenAgent session-management routing (rename / delete / list / branch / close) > …`.
3. Mutation matrix, one mutant at a time (each restored before the next), whole file each run:
   - **`deleteSession` reverted to the three-argument helper with `this.settings`** → 1 failed / 603 passed: only `resolves deleteSession settings per request`; the source pin stays green (it is not the test that guards this).
   - **`sessionTranscript` handed `this.settings`** → 3 failed / 601: the new transcript pin plus the two existing replay-config tests.
   - **`sessionTurnStatus` handed `this.settings`** → 1 failed / 603: only the new turn-status pin (this handler had no coverage before).
   - **Non-live `loadUpdates` handed `this.settings`** → 1 failed / 604: only the new loadUpdates pin (on the round-1 head this mutant was invisible, 605/605).
   - **Alias probe (`const pin = runWithAcpRuntimeOutputDir; return pin(…)`) inside the helper** → 1 failed / 603: the source pin, whose message lists the alias line next to the delegation line.
   - **Aliased import (`import { runWithAcpRuntimeOutputDir as pinDirect }`) used by the helper with `this.settings`** → 7 failed / 598: the source pin lists the import line, and the six handler pins catch the settings half.
   - **Benign shapes the pin must ignore** (multi-line reformat of the canonical import; a trailing comment or a string literal naming the function) → green each time, on the pin test alone.
   - **The per-request helper itself reads `this.settings`** → 7 failed / 597: all five per-request handler pins plus the two replay-config tests. This is the row that shows the seam is load-bearing.
4. `git diff -w --stat main` equals `git diff --stat main` (+272 / −16 over the two files): no whitespace-only churn hides in the diff.

### Evidence (Before & After)

N/A — refactor with no runtime behavior change. Evidence is the grep count in step 1 (six direct call sites → one) and the mutation matrix in step 3.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit tests only (`vitest`, `tsc --noEmit` on `packages/cli` with zero diagnostics under `acp-integration/*`, `eslint` and `prettier --check` on both files clean). Core and acp-bridge `dist` rebuilt from this branch's merge-base before running.

## Risk & Scope

- Main risk or tradeoff: none at runtime — both helpers are one-line delegations to the same function the sites called directly, and the per-request variant calls the same `loadSettingsCached(cwd)` the sites called themselves. The source-pin test parses the file with the TypeScript compiler API already used by `fast-path.test.ts`; if a second legitimate direct mention is ever introduced, the failure names its line and the assertion is a one-line update.
- Not validated / out of scope: wenshao's other observation on #10095 (nothing in the agent enforces that a directly-spawned `qwen --acp` client's cwd matches the workspace it asks about) is a separate topic and not touched here. Session load / resume keep resolving the request's settings at the call site on purpose (profiler-instrumented, and the settings are adopted for the session afterwards); they and the other three-argument callers are unchanged.
- Breaking changes / migration notes: none. No public API, protocol, or settings change.

## Linked Issues

Relates to #10095 (closes its deferred round-2 item D2-1 and the maintainer's describe-block nit; no standalone issue was filed since both findings live in that PR's review thread). Same follow-through shape as #10465 for #9930.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把 agent 的运行时根目录钉定收拢到一个有注释的入口，取代五处手写的复制，并把"用哪份 settings 钉这次操作"的决定放进这个入口（针对按请求处理器）。原有的私有三参数辅助方法仍然是唯一组合路由的地方（类内所有调用方都经过它，此外没有任何地方直接引用底层的 context 函数）。在它之上新增一个按请求变体：只接收请求的 cwd，自己解析该 cwd 的 settings 并交给操作回调，这样服务于调用方指定 cwd 的处理器就没有可以被进程级缓存填错的 settings 参数。六处按请求调用点（会话列表、删除、重命名、status transcript 分页、settled turn status、以及 session loadUpdates 的非 live 分支）全部改用该变体；持有明确作用域 settings 的调用方（workspace MCP 发现、live session 作用域检查、会话创建）保留三参数形式。两个辅助方法的本体都是一行委托，运行时行为不变；两处较宽的调用点给内联回调起了名字，避免重排两段 60 行函数体。

三类测试钉住这些。一条源码级测试遍历该文件的 TypeScript AST，断言除未加别名的 import 说明符外，对底层 context 函数的唯一引用是共享辅助方法自己的委托——因此注释、字符串字面量和 import 的排版不会误报，而别名、别名 import 或直接调用都会连同行号被报出。三条行为测试覆盖此前没有覆盖的改道处理器（settled turn status、status transcript 分页、非 live 的 loadUpdates）：各自断言到达被 mock 的 context 函数的 settings 与 cwd 是本次请求的；transcript 测试还检查在钉定作用域内构建的 replay config 是由请求的 settings 生成的。承载 #10095 三条回归测试的 describe 块改名为它实际覆盖的内容。

## 为什么需要

#10095 的跟进，关闭那里记录的两条非阻塞项：第 2 轮评审延后的 D2-1（近似的辅助方法已存在，修复却又手工粘贴了三遍路由），以及维护者指出三条回归测试被报在 `renameSession routing` 这个 describe 下。手写路由正是 #10095 里出问题的形态——每个处理器各自决定"用哪份 settings 钉这次操作"，其中三个决定错了。本 PR 自己的第 1 轮评审表明：仅仅经过一个透传的辅助方法并不能把这个决定从调用点移走；按请求变体做到了，下面的变异矩阵显示这个入口对每个使用它的处理器都是承重的。

唯一入口这个不变量需要源码级钉住而不是行为测试，因为两种写法最终到达同一个函数。做法沿用 `serve/fast-path.test.ts` 的先例（用包内相对路径读源码后遍历 TypeScript AST）。

## 审阅者验证方案

### 如何验证

1. `grep -n 'runWithAcpRuntimeOutputDir' packages/cli/src/acp-integration/acpAgent.ts`——除规范 import 行和注释外应恰好命中一处：共享辅助方法的委托。`main` 上有六处调用。`grep -c 'runWithPinnedRuntimeBaseDirForRequest(' …`——应为 6 处调用（定义行带类型参数，不匹配）。
2. `cd packages/cli && npx vitest run src/acp-integration/acpAgent.test.ts`——605/605（601 条原有 + 源码钉 + 三条行为钉）。#10095 的三条回归测试报在 `QwenAgent session-management routing (rename / delete / list / branch / close) > …` 下。
3. 逐点变异（每次恢复后再做下一个，每次跑整个文件）：
   - **`deleteSession` 还原为三参数形式并传 `this.settings`**→1 失败 / 603 通过：只有 `resolves deleteSession settings per request`；源码钉保持绿色（它不是守这一点的测试）。
   - **`sessionTranscript` 传 `this.settings`**→3 失败 / 601：新 transcript 钉加两条已有的 replay-config 测试。
   - **`sessionTurnStatus` 传 `this.settings`**→1 失败 / 603：只有新的 turn-status 钉（该处理器此前没有覆盖）。
   - **非 live 的 `loadUpdates` 传 `this.settings`**→1 失败 / 604：只有新的 loadUpdates 钉（在第 1 轮的 head 上这个变异不可见，605/605）。
   - **在辅助方法里加别名探针（`const pin = runWithAcpRuntimeOutputDir; return pin(…)`）**→1 失败 / 603：源码钉，报错信息把别名行与委托行并列列出。
   - **别名 import（`import { runWithAcpRuntimeOutputDir as pinDirect }`）并在辅助方法里用它传 `this.settings`**→7 失败 / 598：源码钉列出该 import 行，六个处理器的钉抓住 settings 那一半。
   - **钉必须忽略的良性形状**（规范 import 被拆成多行；行尾注释或字符串字面量里出现该函数名）→单跑钉测试，每次都绿。
   - **按请求辅助方法自己读 `this.settings`**→7 失败 / 597：五个按请求处理器的钉全部失败，加两条 replay-config 测试。这一行说明入口是承重的。
4. `git diff -w --stat main` 与 `git diff --stat main` 一致（两个文件 +272 / −16）：diff 里没有藏着纯空白改动。

### 前后对比证据

N/A——无运行时行为变化的重构。证据是第 1 步的 grep 计数（六处直接调用→一处）和第 3 步的变异矩阵。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

仅本地单元测试（`vitest`；`packages/cli` 的 `tsc --noEmit` 在 `acp-integration/*` 下零报错；两个文件的 `eslint` 与 `prettier --check` 干净）。运行前从本分支的 merge-base 重建了 core 与 acp-bridge 的 `dist`。

## 风险与范围

- 主要风险或权衡：运行时无——两个辅助方法都是对各调用点原本直接调用的同一函数的一行委托，按请求变体调用的也是各调用点原本自己调用的 `loadSettingsCached(cwd)`。源码钉测试用的是 `fast-path.test.ts` 已在用的 TypeScript 编译器 API 解析文件；若将来引入第二处合理的直接引用，失败信息会指出行号，改一行断言即可。
- 未验证 / 超出范围：wenshao 在 #10095 里的另一个观察（agent 里没有任何东西强制直接 spawn 的 `qwen --acp` 客户端的 cwd 与被查询的 workspace 一致）是独立话题，本 PR 不涉及。session load / resume 有意保留在调用点解析请求的 settings（有 profiler 埋点，且解析出的 settings 随后被会话采用）；它们和其余三参数调用方均未改动。
- 破坏性变更 / 迁移说明：无。不涉及公共 API、协议或 settings 变更。

## 关联 Issue

关联 #10095（关闭其第 2 轮延后项 D2-1 与维护者的 describe 块小建议；两条发现都在该 PR 的评审线程里，未另开 issue）。与 #10465 之于 #9930 是同一种跟进形态。

</details>
