### PR TITLE
fix(channels): keep DingTalk SDK credentials off stdout during connect (#10936)

### DIFF
--- a/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.test.ts
@@ -97,6 +97,20 @@ vi.mock('dingtalk-stream-sdk-nodejs', () => ({
       dingtalkSdkMock.nextConnect = undefined;
       return connect?.() ?? Promise.resolve();
     });
+    // Mirrors the real SDK's getEndpoint() (client.mjs): two unconditional
+    // credential console.logs that ignore the debug flag, plus one benign log.
+    getEndpoint = vi.fn(() => {
+      console.log(this.options);
+      console.log(
+        'res.data',
+        JSON.stringify({
+          endpoint: 'wss://api.dingtalk.com/ws',
+          ticket: 'stream-ticket',
+        }),
+      );
+      console.log('sdk connect log');
+      return Promise.resolve(this);
+    });
 
     onSystem = vi.fn();
     onEvent = vi.fn();
@@ -4940,6 +4954,87 @@ describe('DingtalkChannel quoted media', () => {
     expect(stderrSpy).toHaveBeenCalledWith(
       '[DingTalk] downloadMedia API failed: HTTP 503 unavailable\n',
     );
+  });
+});
+
+describe('DingtalkChannel SDK connect credential logging', () => {
+  it('drops the SDK client-config and gateway-ticket logs during getEndpoint', async () => {
+    createChannel();
+    const client = latestMockClient() as {
+      getEndpoint(): Promise<unknown>;
+    };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await client.getEndpoint();
+      const logged = logSpy.mock.calls
+        .map((call) =>
+          call
+            .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+            .join(' '),
+        )
+        .join('\n');
+      expect(logged).not.toContain('clientSecret');
+      expect(logged).not.toContain('client-secret');
+      expect(logged).not.toContain('res.data');
+      expect(logged).not.toContain('stream-ticket');
+      // Unrelated SDK output still reaches stdout.
+      expect(logSpy).toHaveBeenCalledWith('sdk connect log');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('restores console.log once the connect window closes', async () => {
+    createChannel();
+    const client = latestMockClient() as {
+      getEndpoint(): Promise<unknown>;
+    };
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logBefore = console.log;
+    try {
+      await client.getEndpoint();
+      expect(console.log).toBe(logBefore);
+      // After the window the filter is gone: even credential-shaped logs go
+      // straight through to the pre-existing console.log (the SDK only logs
+      // them from inside getEndpoint, so nothing leaks in practice).
+      console.log('res.data', '{"ticket":"after"}');
+      expect(logSpy).toHaveBeenCalledWith('res.data', '{"ticket":"after"}');
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('wraps every client the connection manager (re)creates', async () => {
+    const channel = createChannel();
+    const manager = (
+      channel as unknown as {
+        connectionManager?: { options: { createClient(): unknown } };
+      }
+    ).connectionManager;
+    expect(manager).toBeDefined();
+    const reconnectClient = manager!.options.createClient() as {
+      getEndpoint(): Promise<unknown>;
+    };
+    expect(reconnectClient).not.toBe(dingtalkSdkMock.instances[0]);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await reconnectClient.getEndpoint();
+      const logged = logSpy.mock.calls
+        .map((call) =>
+          call
+            .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+            .join(' '),
+        )
+        .join('\n');
+      expect(logged).not.toContain('client-secret');
+      expect(logged).not.toContain('stream-ticket');
+      expect(logSpy).toHaveBeenCalledWith('sdk connect log');
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -806,7 +806,64 @@ type DingTalkClientInternals = DWClient & {
   onSystem(message: DWClientDownStream): void;
   onEvent(message: DWClientDownStream): void;
   onCallback(message: DWClientDownStream): void;
+  getEndpoint(): Promise<DingTalkClientInternals>;
 };
+
+/**
+ * The SDK's getEndpoint() unconditionally console.log()s the DWClient config
+ * (clientId + clientSecret) and the gateway response (endpoint + ticket) to
+ * stdout — neither call goes through printDebug(), so the SDK debug flag
+ * cannot silence them (dingtalk-stream-sdk-nodejs@2.0.4, latest). While a
+ * connect is in flight, drop exactly those two log shapes; every other
+ * console.log passes through untouched, and qwen-code's own logging (stderr)
+ * never crosses this path. See issue #10936.
+ */
+function isSdkCredentialLog(args: unknown[]): boolean {
+  const [first, second] = args;
+  // console.log(this.config): the DWClient config always owns clientSecret
+  // (the SDK constructor refuses to build without it).
+  if (
+    typeof first === 'object' &&
+    first !== null &&
+    !Array.isArray(first) &&
+    Object.prototype.hasOwnProperty.call(first, 'clientSecret')
+  ) {
+    return true;
+  }
+  // console.log('res.data', JSON.stringify(res.data)): the gateway
+  // connection response carrying the live stream ticket.
+  return first === 'res.data' && typeof second === 'string';
+}
+
+let credentialLogSuppressionDepth = 0;
+let unsuppressedConsoleLog: ((...args: unknown[]) => void) | undefined;
+
+function suppressedConsoleLog(...args: unknown[]): void {
+  if (isSdkCredentialLog(args)) return;
+  unsuppressedConsoleLog?.(...args);
+}
+
+function beginCredentialLogSuppression(): void {
+  if (credentialLogSuppressionDepth === 0) {
+    unsuppressedConsoleLog = console.log;
+    console.log = suppressedConsoleLog;
+  }
+  credentialLogSuppressionDepth++;
+}
+
+function endCredentialLogSuppression(): void {
+  credentialLogSuppressionDepth = Math.max(
+    0,
+    credentialLogSuppressionDepth - 1,
+  );
+  if (
+    credentialLogSuppressionDepth === 0 &&
+    console.log === suppressedConsoleLog
+  ) {
+    console.log = unsuppressedConsoleLog!;
+    unsuppressedConsoleLog = undefined;
+  }
+}
 
 type DingtalkChannelConfig = ChannelConfig & {
   useConnectionManager?: unknown;
@@ -1014,6 +1071,27 @@ export class DingtalkChannel extends ChannelBase {
     // dispatch table and should be checked when upgrading the DingTalk SDK.
     client.onDownStream = (raw: unknown) => {
       this.onDownStream(raw, client);
+    };
+    this.quietSdkConnectLogging(client);
+  }
+
+  /**
+   * Shadow getEndpoint() (the SDK prototype method, like onDownStream above)
+   * with a wrapper that drops the SDK's unconditional credential console.logs
+   * for the duration of the call. Every (re)connect goes through
+   * createClient(), so initial connects, manager-driven reconnects, and the
+   * SDK's own auto-reconnect all inherit the wrapper.
+   */
+  private quietSdkConnectLogging(client: DingTalkClientInternals): void {
+    if (typeof client.getEndpoint !== 'function') return;
+    const sdkGetEndpoint = client.getEndpoint.bind(client);
+    client.getEndpoint = async (): Promise<DingTalkClientInternals> => {
+      beginCredentialLogSuppression();
+      try {
+        return await sdkGetEndpoint();
+      } finally {
+        endCredentialLogSuppression();
+      }
     };
   }
 


### PR DESCRIPTION
## What this PR does

Keeps the DingTalk SDK's credentials off stdout for the lifetime of a channel, including every reconnect, without patching the dependency:

`packages/channels/dingtalk/src/DingtalkAdapter.ts`:

- `installStructuredDownstreamHandler()` now also calls `quietSdkConnectLogging(client)`, which installs an instance-level shadow of `getEndpoint()` bound to the original method — the same shape the existing `onDownStream` override already uses. All connection paths funnel through `createClient()` (initial connect, connection-manager rebuilds, SDK auto-reconnect), so every client gets wrapped.
- The wrapper opens a **narrow, reference-counted `console.log` suppression window** only while the original `getEndpoint()` runs, and restores the real `console.log` (LIFO-safe) afterwards.
- The filter is deliberately conservative — it drops exactly two shapes: objects carrying the SDK config's own `clientSecret` key (the SDK constructor throws without one, so the key is always present), and the `'res.data'` + string pair that carries the stream ticket. Everything else passes through untouched. qwen-code's own logging goes through `process.stderr.write`, so it is unaffected.

Why not patch-package: qwen-code publishes to npm and `postinstall` doesn't propagate to end users, so a patched SDK would leak again in every user install. A runtime wrapper works regardless of how the dependency is installed. Why not rewrite `getEndpoint`: copying the SDK's network logic would drift on upgrade; the wrapper calls the original implementation.

`DingtalkAdapter.test.ts` gains a `DingTalkChannel SDK connect credential logging` suite (mocked `DWClient` faithfully emitting the two sensitive logs plus one unrelated one): credentials dropped during connect while the unrelated log passes; `console.log` restored exactly after the window closes; reconnect clients created by the connection manager are wrapped too.

## Why it's needed

Fixes #10936 (P1, credential security). `dingtalk-stream-sdk-nodejs@2.0.4` — the latest published version — unconditionally `console.log`s the full client config (including `clientSecret`) and the gateway response (including the live stream `ticket`) inside `getEndpoint()`, gated by neither the SDK's debug flag nor its `printDebug()` helper. Channel services run detached with stdout redirected to a log file, so credentials accumulate there on every reconnect. The triage on the issue confirmed the fix belongs in the adapter's connect path.

## Reviewer Test Plan

### How to verify

1. `npx vitest run` in `packages/channels/dingtalk` — 12 files / 499 tests pass, including the 3 new cases above.
2. `npx tsc --noEmit` in the same package — clean (after the standard base build).
3. Manual spot-check (optional): start a DingTalk channel with stdout captured and confirm neither `clientSecret` nor a stream ticket appears in the output, across a forced reconnect.

### Evidence (Before & After)

Before: every connect/reconnect prints the config object (with `clientSecret`) and `res.data {"endpoint":..., "ticket":...}` to stdout — exactly the shapes redacted in the issue.
After: those two shapes are dropped during the `getEndpoint()` window; all other stdout output is byte-identical, and the suppression window always closes. N/A for screenshots — log output only.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  ⚠️    |
|  🐧 Linux  |  ⚠️    |
