### PR TITLE
fix(cli): keep the tmux IME composition cell free of a fixed background (#8177)

### DIFF
--- a/packages/cli/src/ui/utils/software-cursor.test.ts
+++ b/packages/cli/src/ui/utils/software-cursor.test.ts
@@ -7,6 +7,7 @@
 import chalk from 'chalk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  compositionOverlaysSoftwareCursor,
   getSoftwareCursorBackground,
   renderSoftwareCursor,
 } from './software-cursor.js';
@@ -22,6 +23,7 @@ describe('renderSoftwareCursor', () => {
   afterEach(() => {
     chalk.level = originalChalkLevel;
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('uses a dark cursor background on light themes', () => {
@@ -43,6 +45,7 @@ describe('renderSoftwareCursor', () => {
 
   it('uses an explicit background instead of reverse-video styling', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+    vi.stubEnv('TMUX', undefined);
     const rendered = renderSoftwareCursor('x');
 
     expect(rendered).toContain('x');
@@ -59,6 +62,38 @@ describe('renderSoftwareCursor', () => {
     expect(rendered).not.toContain('\u001b[7m');
   });
 
+  it('keeps the tmux IME composition cell free of a fixed background (#8177)', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,4242,0');
+    const rendered = renderSoftwareCursor('x');
+
+    // tmux cannot apply frames atomically (no DECSET 2026 support in
+    // tmux <= 3.6), so the preedit string is repainted on the cursor cell
+    // mid-composition; a fixed background there corrupts the composition
+    // overlay. Underline leaves the cell's background untouched.
+    expect(rendered).toBe('\u001b[4mx\u001b[24m');
+    expect(rendered).not.toContain('\u001b[48;');
+    expect(rendered).not.toContain('\u001b[7m');
+  });
+
+  it('restores the block cursor under tmux when synchronized output is forced on', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,4242,0');
+    vi.stubEnv('QWEN_CODE_SYNCHRONIZED_OUTPUT', '1');
+    const rendered = renderSoftwareCursor('x');
+
+    // Atomic frames protect the preedit cell, so the high-contrast block
+    // cursor is safe again (future tmux releases with 2026 support).
+    expect(rendered).toContain('\u001b[48;2;');
+    expect(rendered).not.toContain('\u001b[4m');
+  });
+
+  it('renders an empty tmux cursor cell as an underlined space', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,4242,0');
+    expect(renderSoftwareCursor('')).toBe('\u001b[4m \u001b[24m');
+  });
+
   it('does not reset the surrounding foreground color', () => {
     const rendered = renderSoftwareCursor('x');
 
@@ -68,6 +103,53 @@ describe('renderSoftwareCursor', () => {
   it('renders an empty cursor cell as a space', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
     expect(renderSoftwareCursor('')).toBe('\u001b[4m \u001b[24m');
+  });
+});
+
+describe('compositionOverlaysSoftwareCursor', () => {
+  it('is always true on Windows (terminal composition highlight)', () => {
+    expect(compositionOverlaysSoftwareCursor({}, 'win32')).toBe(true);
+  });
+
+  it('is false outside tmux on macOS/Linux', () => {
+    expect(compositionOverlaysSoftwareCursor({}, 'darwin')).toBe(false);
+    expect(compositionOverlaysSoftwareCursor({}, 'linux')).toBe(false);
+  });
+
+  it('is true inside tmux sessions', () => {
+    expect(
+      compositionOverlaysSoftwareCursor(
+        { TMUX: '/tmp/tmux-1000/default,4242,0' },
+        'darwin',
+      ),
+    ).toBe(true);
+    expect(
+      compositionOverlaysSoftwareCursor(
+        { TMUX: '/tmp/tmux-1000/default,4242,0' },
+        'linux',
+      ),
+    ).toBe(true);
+  });
+
+  it('is false inside tmux when synchronized output is forced on', () => {
+    expect(
+      compositionOverlaysSoftwareCursor(
+        {
+          TMUX: '/tmp/tmux-1000/default,4242,0',
+          QWEN_CODE_SYNCHRONIZED_OUTPUT: '1',
+        },
+        'darwin',
+      ),
+    ).toBe(false);
+    expect(
+      compositionOverlaysSoftwareCursor(
+        {
+          TMUX: '/tmp/tmux-1000/default,4242,0',
+          QWEN_CODE_FORCE_SYNCHRONIZED_OUTPUT: '1',
+        },
+        'darwin',
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/cli/src/ui/utils/software-cursor.ts
+++ b/packages/cli/src/ui/utils/software-cursor.ts
@@ -66,9 +66,47 @@ export function getSoftwareCursorBackground(
   return luminance >= 128 ? DARK_CURSOR_BACKGROUND : LIGHT_CURSOR_BACKGROUND;
 }
 
+/**
+ * Whether the IME composition overlay can land on the software cursor cell
+ * while frames are being redrawn.
+ *
+ * Terminals render the IME preedit string at the hardware cursor, which Ink
+ * positions on the software cursor cell of the active input (see
+ * `useCursor()` in BaseTextInput). When output frames cannot be applied
+ * atomically (DECSET 2026 synchronized output), every redraw repaints that
+ * cell mid-composition and the fixed cursor background SGR corrupts the
+ * composition overlay:
+ *  - Windows terminals style IME text with their own composition highlight
+ *    (#9666, fixed by #9803).
+ *  - tmux sessions disable synchronized output (`TMUX` guard in
+ *    synchronizedOutput.ts) and tmux <= 3.6 lacks application-side 2026
+ *    support entirely, so each Ink frame clears and repaints the preedit
+ *    cell, displacing the cursor and mixing pinyin fragments into the
+ *    rendered input (#8177).
+ * In those environments the cursor uses an underline style that leaves the
+ * composition cell's background untouched.
+ */
+export function compositionOverlaysSoftwareCursor(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform === 'win32') {
+    return true;
+  }
+  if (!env['TMUX']) {
+    return false;
+  }
+  // With synchronized output forced on, frames apply atomically again, so
+  // the block cursor is safe (e.g. future tmux releases with 2026 support).
+  return !(
+    env['QWEN_CODE_SYNCHRONIZED_OUTPUT'] === '1' ||
+    env['QWEN_CODE_FORCE_SYNCHRONIZED_OUTPUT'] === '1'
+  );
+}
+
 export function renderSoftwareCursor(text: string): string {
   const cursorText = text || ' ';
-  return process.platform === 'win32'
+  return compositionOverlaysSoftwareCursor()
     ? chalk.underline(cursorText)
     : chalk.bgHex(getSoftwareCursorBackground())(cursorText);
 }


### PR DESCRIPTION
## What this PR does

Keeps the IME composition cell free of a fixed background under tmux, mirroring what #9803 did for Windows:

- `packages/core` — no changes.
- `packages/cli/src/ui/utils/software-cursor.ts` — new exported `compositionOverlaysSoftwareCursor(env, platform)`: true on win32, or when `TMUX` is set and synchronized output isn't force-enabled. When true, `renderSoftwareCursor` emits `chalk.underline` instead of the fixed gray background block. The function is the single convergence point — all callers (BaseTextInput, InputPrompt, shared/TextInput, SettingInputPrompt, SettingsDialog) pick it up automatically.
- Setting `QWEN_CODE_SYNCHRONIZED_OUTPUT=1` restores the block cursor under tmux — a deliberate forward path for when tmux ships DECSET 2026 support (see boundary below), aligned with the retest suggestion in the issue thread.
- `software-cursor.test.ts` — 7 new cases (underline + no `48;` background under tmux, escape hatch restoring the block, empty-cell handling, helper truth table) and one determinism fix: existing linux-branch cases now stub `TMUX` to undefined so the suite is stable when vitest itself runs inside tmux.

## Why it's needed

Addresses #8177 (P2, CJK input on macOS). Root cause chain:

- ink's `useCursor()` places the hardware cursor on the software-cursor cell (its own docs: "composing character is displayed at the cursor location"), so the IME preedit renders exactly on qwen's software cursor.
- On the mac branch that cell carries a fixed `bgHex` truecolor background; under tmux (which lacks app-level DECSET 2026 until unreleased commit `1c7e164c`, and where `synchronizedOutput.ts:51` deliberately disables 2026), ink's per-frame erase/redraw/relocate replays non-atomically. The terminal's preedit overlay — anchored at the hardware cursor — gets repeatedly cleared and shifted, producing the misplaced/ghost cursors, pinyin-fragment pollution, and the worse corruption where the candidate window overlaps text (symptom ③) reported in the issue.

#9803 fixed this same composition-cell/background clash for win32 only; the mac/tmux branch kept the background block.

## Scope & honest boundary

This is a **partial fix by design**: it removes the SGR/background pollution of the composition cell (the direct cause of symptom ③) and reduces the visual severity of redraw interleaving. Symptoms ①② that stem from tmux 3.6a lacking synchronized output cannot be fully fixed from qwen's side; once tmux ships 2026 support, `QWEN_CODE_SYNCHRONIZED_OUTPUT=1` re-enables the block cursor for retesting. The tmux-conservative-rendering approach follows existing precedents (`RespondingSpinner` throttles under tmux; `terminal-image-renderer` disables images there). Non-tmux macOS/Linux behavior is unchanged.

## Reviewer Test Plan

### How to verify

1. `npx vitest run packages/cli/src/ui/utils/software-cursor.test.ts` — 18/18 pass, including the 7 new cases.
2. All software-cursor callers' suites pass: BaseTextInput / shared/TextInput / SettingInputPrompt / SettingsDialog — 108/108; the broader InputPrompt suites — 268 passing.
3. `tsc --noEmit -p packages/cli` — error list identical before/after this change (pre-existing ink typing noise only, zero new).
4. Manual (macOS + tmux): start qwen in tmux, type CJK input — the composition text now sits on an underlined cell with no background block; candidate-window overlap no longer smears the row. Non-tmux terminals look exactly as before. `QWEN_CODE_SYNCHRONIZED_OUTPUT=1` brings the block cursor back.

### Evidence (Before & After)

Before: composition text rendered on the fixed gray background block; under tmux the non-atomic redraw cycles clear/shift the preedit overlay (see the screenshots in #8177).
After: composition cell is background-free under tmux, matching the win32 treatment from #9803. N/A for automated screenshots — TUI change; manual repro steps above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  ✅ (win32 path unchanged, covered by tests) |
|  🐧 Linux  |  ⚠️ (non-tmux behavior unchanged by construction) |
