### PR TITLE
fix(ci): retry a registry-side npm audit failure instead of reporting it as a CVE

### DIFF
--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -27,11 +27,14 @@ jobs:
   dependency-cve:
     name: 'Dependency CVE audit'
     runs-on: 'ubuntu-latest'
-    # A healthy run finishes in ~4 minutes. The ceiling covers the audit retry
-    # below at its worst — two audit sites, two attempts each, every attempt
-    # capped at 300s — so a registry outage ends in a reported verdict rather
-    # than a job cancel.
-    timeout-minutes: 25
+    # A healthy run finishes in ~4-6 minutes. The ceiling covers the audit
+    # retry below at its worst: three audit sites (the root call plus the two
+    # vendored lockfiles the loop does not skip), two attempts each, every
+    # attempt capped at 300s with a 15s backoff between them — 3 x 615s = 1845s
+    # of audit work — plus checkout, setup and the installs. A ceiling below
+    # that cancels the job mid-outage, so the `not a CVE finding` verdict below
+    # would never be emitted and the run would surface as a bare cancel.
+    timeout-minutes: 40
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -27,7 +27,11 @@ jobs:
   dependency-cve:
     name: 'Dependency CVE audit'
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 15
+    # A healthy run finishes in ~4 minutes. The ceiling covers the audit retry
+    # below at its worst — two audit sites, two attempts each, every attempt
+    # capped at 300s — so a registry outage ends in a reported verdict rather
+    # than a job cancel.
+    timeout-minutes: 25
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6.0.3
@@ -49,10 +53,55 @@ jobs:
       # Hard gate: the high-severity baseline is clean, so any new high CVE
       # fails the check. Keep scripts/tests/security-workflows.test.js in
       # sync with this policy.
+      #
+      # A registry-side audit failure is not a CVE finding, so `audit` retries
+      # it once and then reports it as its own error. npm's retired
+      # `security/audits/quick` route intermittently answers HTTP 400 ("Invalid
+      # package tree") for a tree it accepted minutes earlier — sometimes after
+      # hanging for 6+ minutes — and that used to reach the same `exit 1` as a
+      # real advisory, reading as a CVE failure on branches that changed no
+      # dependency at all. A persistent outage still fails the job; the gate
+      # must not fail open.
+      #
+      # Two details this wrapper depends on:
+      # - Output is captured, not piped. Reading npm's status out of a pipeline
+      #   would tie the verdict to `defaults.run.shell` still implying
+      #   `-o pipefail`; without it a real high-severity finding exits 0.
+      # - Every attempt is capped by `timeout`, which is what keeps the job
+      #   ceiling above reachable only in a real outage.
       - name: 'Audit production dependencies'
         run: |
+          audit() {
+            local attempt=1 out rc retryable
+            while :; do
+              rc=0
+              retryable=0
+              out="$(timeout 300 "$@" 2>&1)" || rc=$?
+              printf '%s\n' "$out"
+              if [ "$rc" -eq 0 ]; then
+                return 0
+              fi
+              case "$out" in
+                *'audit endpoint returned an error'*) retryable=1 ;;
+              esac
+              # 124 = `timeout` killed a stalled audit.
+              if [ "$rc" -eq 124 ]; then
+                retryable=1
+              fi
+              if [ "$retryable" -eq 1 ] && [ "$attempt" -lt 2 ]; then
+                echo "::warning::npm audit returned no verdict (attempt $attempt/2), retrying"
+                attempt=$((attempt + 1))
+                sleep 15
+                continue
+              fi
+              if [ "$retryable" -eq 1 ]; then
+                echo "::error::npm audit returned no verdict after $attempt attempts (registry endpoint error or timeout). This is an audit-infrastructure failure, not a CVE finding - re-run this job."
+              fi
+              return "$rc"
+            done
+          }
           status=0
-          npm audit --omit=dev --audit-level=high || status=$?
+          audit npm audit --omit=dev --audit-level=high || status=$?
           for lockfile in packages/*/package-lock.json; do
             [ -f "$lockfile" ] || continue
             # Covered by the root workspace audit; this vendored lockfile is not installed directly.
@@ -61,7 +110,7 @@ jobs:
             (
               cd "$package_dir"
               npm ci --ignore-scripts --no-audit --progress=false --workspaces=false &&
-                npm audit --omit=dev --audit-level=high --workspaces=false
+                audit npm audit --omit=dev --audit-level=high --workspaces=false
             ) || status=$?
           done
           exit "$status"

--- a/scripts/tests/security-checks-audit-retry.test.js
+++ b/scripts/tests/security-checks-audit-retry.test.js
@@ -44,15 +44,19 @@ describe('security-checks audit step endpoint-error retry', () => {
   const ENDPOINT_ERROR = 'npm error audit endpoint returned an error';
   const NO_VERDICT = '::error::npm audit returned no verdict after 2 attempts';
 
-  // One vendored lockfile, so a full pass audits twice: once at the root and
-  // once inside the per-package loop. The loop keeps going after a root failure
-  // (`|| status=$?` accumulates rather than aborts), so a persistent failure is
-  // audited and retried at both sites.
+  // Three audit sites, matching the real tree: the root `npm audit` plus the
+  // two vendored lockfiles the per-package loop does not skip. The loop keeps
+  // going after a root failure (`|| status=$?` accumulates rather than aborts),
+  // so a persistent failure is audited and retried at all three.
   function runAuditStep({ auditMode, pipefail = true }) {
     const dir = mkdtempSync(join(tmpdir(), 'qwen-cve-audit-'));
     try {
-      mkdirSync(join(dir, 'packages/live-host'), { recursive: true });
-      writeFileSync(join(dir, 'packages/live-host/package-lock.json'), '{}');
+      // mobile-mcp is the one lockfile the loop skips. Including it means
+      // deleting that skip line changes the counts below instead of passing.
+      for (const pkg of ['desktop-shell', 'live-host', 'mobile-mcp']) {
+        mkdirSync(join(dir, 'packages', pkg), { recursive: true });
+        writeFileSync(join(dir, 'packages', pkg, 'package-lock.json'), '{}');
+      }
 
       const counters = {
         audit: join(dir, 'audit-calls'),
@@ -169,7 +173,8 @@ describe('security-checks audit step endpoint-error retry', () => {
   it('passes a clean audit through unchanged, without retrying', () => {
     const { status, auditCalls, sleeps } = runAuditStep({ auditMode: 'clean' });
     expect(status).toBe(0);
-    expect(auditCalls).toBe(2);
+    // Root plus the two vendored lockfiles; mobile-mcp is skipped.
+    expect(auditCalls).toBe(3);
     expect(sleeps).toBe(0);
   });
 
@@ -178,9 +183,9 @@ describe('security-checks audit step endpoint-error retry', () => {
       auditMode: 'endpoint-error-then-clean',
     });
     expect(status).toBe(0);
-    // Root audit fails once and is retried; the vendored lockfile then audits
-    // clean on its first attempt.
-    expect(auditCalls).toBe(3);
+    // The root audit fails once and is retried; the two vendored lockfiles then
+    // audit clean on their first attempt.
+    expect(auditCalls).toBe(4);
     expect(sleeps).toBe(1);
     expect(output).toContain(
       '::warning::npm audit returned no verdict (attempt 1/2), retrying',
@@ -192,10 +197,10 @@ describe('security-checks audit step endpoint-error retry', () => {
       auditMode: 'timeout-then-clean',
     });
     expect(status).toBe(0);
-    // The killed attempt never reached npm; the retry and the vendored lockfile
-    // both did.
-    expect(timeoutCalls).toBe(3);
-    expect(auditCalls).toBe(2);
+    // The killed attempt never reached npm; the retry and both vendored
+    // lockfiles did.
+    expect(timeoutCalls).toBe(4);
+    expect(auditCalls).toBe(3);
     expect(sleeps).toBe(1);
   });
 
@@ -204,9 +209,11 @@ describe('security-checks audit step endpoint-error retry', () => {
       auditMode: 'endpoint-error-always',
     });
     expect(status).not.toBe(0);
-    // Two attempts at each of the two audit sites, sleeping between them.
-    expect(auditCalls).toBe(4);
-    expect(sleeps).toBe(2);
+    // Two attempts at each of the three audit sites, sleeping between them.
+    // These counts are what the job ceiling is sized from: 3 x (300s + 15s +
+    // 300s) = 1845s of audit work in a persistent outage.
+    expect(auditCalls).toBe(6);
+    expect(sleeps).toBe(3);
     expect(output).toContain(NO_VERDICT);
     expect(output).toContain('not a CVE finding');
   });
@@ -216,9 +223,9 @@ describe('security-checks audit step endpoint-error retry', () => {
       auditMode: 'timeout-always',
     });
     expect(status).not.toBe(0);
-    expect(timeoutCalls).toBe(4);
+    expect(timeoutCalls).toBe(6);
     expect(auditCalls).toBe(0);
-    expect(sleeps).toBe(2);
+    expect(sleeps).toBe(3);
     expect(output).toContain(NO_VERDICT);
     expect(output).toContain('not a CVE finding');
   });
@@ -228,9 +235,9 @@ describe('security-checks audit step endpoint-error retry', () => {
       auditMode: 'cve-found',
     });
     expect(status).not.toBe(0);
-    // Both audit sites report the finding once each; neither is retried, and
+    // All three audit sites report the finding once each; none is retried, and
     // the loop still runs after the root failure.
-    expect(auditCalls).toBe(2);
+    expect(auditCalls).toBe(3);
     expect(sleeps).toBe(0);
     expect(output).toContain('1 vulnerability (1 high)');
     expect(output).not.toContain('retrying');

--- a/scripts/tests/security-checks-audit-retry.test.js
+++ b/scripts/tests/security-checks-audit-retry.test.js
@@ -1,0 +1,254 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+// Executes the Security Checks audit step under the shell GitHub actually gives
+// it — security-checks.yml sets `defaults.run.shell: bash`, which on Linux is
+// `bash --noprofile --norc -e -o pipefail {0}` — with `npm`, `timeout` and
+// `sleep` stubbed. Three properties of this gate cannot be witnessed by the
+// shape assertions in security-workflows.test.js:
+//
+//   1. a registry-side failure is retried instead of being reported as a CVE;
+//   2. a real high-severity finding is never retried away or swallowed;
+//   3. the verdict does not depend on `-o pipefail` staying in the step shell —
+//      a wrapper that read npm's status out of a pipeline would exit 0 on a real
+//      finding the moment that flag went away.
+//
+// Bash-driven, so it is excluded from the Windows lanes in vitest.config.ts.
+describe('security-checks audit step endpoint-error retry', () => {
+  const yml = parse(
+    readFileSync('.github/workflows/security-checks.yml', 'utf8'),
+  );
+  const steps = yml.jobs['dependency-cve'].steps;
+  const auditStep = steps.find(
+    (step) => step.name === 'Audit production dependencies',
+  );
+  const script = auditStep.run;
+
+  const ENDPOINT_ERROR = 'npm error audit endpoint returned an error';
+  const NO_VERDICT = '::error::npm audit returned no verdict after 2 attempts';
+
+  // One vendored lockfile, so a full pass audits twice: once at the root and
+  // once inside the per-package loop. The loop keeps going after a root failure
+  // (`|| status=$?` accumulates rather than aborts), so a persistent failure is
+  // audited and retried at both sites.
+  function runAuditStep({ auditMode, pipefail = true }) {
+    const dir = mkdtempSync(join(tmpdir(), 'qwen-cve-audit-'));
+    try {
+      mkdirSync(join(dir, 'packages/live-host'), { recursive: true });
+      writeFileSync(join(dir, 'packages/live-host/package-lock.json'), '{}');
+
+      const counters = {
+        audit: join(dir, 'audit-calls'),
+        timeout: join(dir, 'timeout-calls'),
+        sleep: join(dir, 'sleeps'),
+      };
+      for (const file of Object.values(counters)) writeFileSync(file, '0');
+
+      // Bumps a counter file and leaves the running total in `$n`.
+      const bump = (varName) =>
+        [
+          `n=$(( $(cat "$${varName}") + 1 ))`,
+          `printf "%s" "$n" > "$${varName}"`,
+        ].join('\n');
+
+      const binDir = join(dir, 'bin');
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, 'npm'),
+        [
+          '#!/usr/bin/env bash',
+          '# `npm ci` always succeeds; only the audit is under test.',
+          '[ "$1" = "audit" ] || exit 0',
+          bump('AUDIT_CALLS_FILE'),
+          'case "$AUDIT_MODE" in',
+          '  clean) exit 0 ;;',
+          '  endpoint-error-then-clean)',
+          '    if [ "$n" -lt 2 ]; then',
+          `      printf '%s\\n' '${ENDPOINT_ERROR}'`,
+          '      exit 1',
+          '    fi',
+          '    ;;',
+          '  endpoint-error-always)',
+          `    printf '%s\\n' '${ENDPOINT_ERROR}'`,
+          '    exit 1',
+          '    ;;',
+          '  cve-found)',
+          "    printf '%s\\n' '# npm audit report' 'pkg  1.0.0' 'Severity: high'",
+          "    printf '%s\\n' '1 vulnerability (1 high)'",
+          '    exit 1',
+          '    ;;',
+          'esac',
+          'exit 0',
+        ].join('\n'),
+      );
+      // Stands in for coreutils `timeout`, absent on macOS: it either simulates
+      // the 124 a killed attempt returns, or drops the duration and execs the
+      // command so npm's own status survives.
+      writeFileSync(
+        join(binDir, 'timeout'),
+        [
+          '#!/usr/bin/env bash',
+          bump('TIMEOUT_CALLS_FILE'),
+          'case "$AUDIT_MODE" in',
+          '  timeout-always) exit 124 ;;',
+          '  timeout-then-clean)',
+          '    if [ "$n" -lt 2 ]; then',
+          '      exit 124',
+          '    fi',
+          '    ;;',
+          'esac',
+          'shift',
+          'exec "$@"',
+        ].join('\n'),
+      );
+      writeFileSync(
+        join(binDir, 'sleep'),
+        ['#!/usr/bin/env bash', bump('SLEEPS_FILE'), 'exit 0'].join('\n'),
+      );
+      for (const stub of ['npm', 'timeout', 'sleep']) {
+        chmodSync(join(binDir, stub), 0o755);
+      }
+
+      const scriptFile = join(dir, 'step.sh');
+      writeFileSync(scriptFile, script);
+
+      const run = spawnSync(
+        'bash',
+        [
+          '--noprofile',
+          '--norc',
+          '-e',
+          ...(pipefail ? ['-o', 'pipefail'] : []),
+          scriptFile,
+        ],
+        {
+          cwd: dir,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${binDir}:${process.env.PATH}`,
+            AUDIT_MODE: auditMode,
+            AUDIT_CALLS_FILE: counters.audit,
+            TIMEOUT_CALLS_FILE: counters.timeout,
+            SLEEPS_FILE: counters.sleep,
+          },
+        },
+      );
+      const count = (file) => Number(readFileSync(file, 'utf8'));
+      return {
+        status: run.status,
+        // Read both streams, as an Actions log does: the wrapper echoes npm's
+        // report to stdout, and a bash error would land on stderr.
+        output: `${run.stdout ?? ''}${run.stderr ?? ''}`,
+        auditCalls: count(counters.audit),
+        timeoutCalls: count(counters.timeout),
+        sleeps: count(counters.sleep),
+      };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('passes a clean audit through unchanged, without retrying', () => {
+    const { status, auditCalls, sleeps } = runAuditStep({ auditMode: 'clean' });
+    expect(status).toBe(0);
+    expect(auditCalls).toBe(2);
+    expect(sleeps).toBe(0);
+  });
+
+  it('retries a registry endpoint error and passes once the registry recovers', () => {
+    const { status, output, auditCalls, sleeps } = runAuditStep({
+      auditMode: 'endpoint-error-then-clean',
+    });
+    expect(status).toBe(0);
+    // Root audit fails once and is retried; the vendored lockfile then audits
+    // clean on its first attempt.
+    expect(auditCalls).toBe(3);
+    expect(sleeps).toBe(1);
+    expect(output).toContain(
+      '::warning::npm audit returned no verdict (attempt 1/2), retrying',
+    );
+  });
+
+  it('retries an audit that stalled until `timeout` killed it', () => {
+    const { status, auditCalls, timeoutCalls, sleeps } = runAuditStep({
+      auditMode: 'timeout-then-clean',
+    });
+    expect(status).toBe(0);
+    // The killed attempt never reached npm; the retry and the vendored lockfile
+    // both did.
+    expect(timeoutCalls).toBe(3);
+    expect(auditCalls).toBe(2);
+    expect(sleeps).toBe(1);
+  });
+
+  it('still fails the gate when the endpoint never recovers, and says it is not a CVE', () => {
+    const { status, output, auditCalls, sleeps } = runAuditStep({
+      auditMode: 'endpoint-error-always',
+    });
+    expect(status).not.toBe(0);
+    // Two attempts at each of the two audit sites, sleeping between them.
+    expect(auditCalls).toBe(4);
+    expect(sleeps).toBe(2);
+    expect(output).toContain(NO_VERDICT);
+    expect(output).toContain('not a CVE finding');
+  });
+
+  it('still fails the gate when every attempt stalls, rather than waiting on npm forever', () => {
+    const { status, output, auditCalls, timeoutCalls, sleeps } = runAuditStep({
+      auditMode: 'timeout-always',
+    });
+    expect(status).not.toBe(0);
+    expect(timeoutCalls).toBe(4);
+    expect(auditCalls).toBe(0);
+    expect(sleeps).toBe(2);
+    expect(output).toContain(NO_VERDICT);
+    expect(output).toContain('not a CVE finding');
+  });
+
+  it('reports a real high-severity finding as-is, with no retry', () => {
+    const { status, output, auditCalls, sleeps } = runAuditStep({
+      auditMode: 'cve-found',
+    });
+    expect(status).not.toBe(0);
+    // Both audit sites report the finding once each; neither is retried, and
+    // the loop still runs after the root failure.
+    expect(auditCalls).toBe(2);
+    expect(sleeps).toBe(0);
+    expect(output).toContain('1 vulnerability (1 high)');
+    expect(output).not.toContain('retrying');
+    expect(output).not.toContain('not a CVE finding');
+  });
+
+  it('reaches the same verdict without pipefail, so the gate cannot fail open on a shell change', () => {
+    // A wrapper that read npm's status out of a pipeline would report exit 0
+    // for both of these under plain `bash -e` — silently passing a real
+    // high-severity finding, and silently passing an unreachable registry.
+    for (const auditMode of ['cve-found', 'endpoint-error-always']) {
+      const withPipefail = runAuditStep({ auditMode });
+      const withoutPipefail = runAuditStep({ auditMode, pipefail: false });
+      expect(withoutPipefail.status, auditMode).not.toBe(0);
+      expect(withoutPipefail.status, auditMode).toBe(withPipefail.status);
+      expect(withoutPipefail.auditCalls, auditMode).toBe(
+        withPipefail.auditCalls,
+      );
+    }
+  });
+});

--- a/scripts/tests/security-workflows.test.js
+++ b/scripts/tests/security-workflows.test.js
@@ -106,11 +106,17 @@ describe('security workflows', () => {
       'audit npm audit --omit=dev --audit-level=high --workspaces=false',
     );
     expect(auditStep).not.toContain('|| true');
-    // The retry is bounded on both axes: every attempt is capped, and the job
-    // ceiling covers the worst case (2 audit sites x 2 attempts x 300s). Drop
-    // either and a registry outage turns a reported verdict into a job cancel.
+    // Every factor of the worst-case arithmetic is pinned, because the job
+    // ceiling is only safe while none of them drifts: the per-attempt cap, the
+    // backoff between attempts, and the ceiling itself — three audit sites
+    // (root plus the two vendored lockfiles the loop does not skip), two
+    // attempts each, 300s + 15s + 300s per site = 1845s of audit work. The
+    // attempt count is pinned behaviourally by the call counters in
+    // security-checks-audit-retry.test.js. Loosen any of these and a registry
+    // outage turns a reported verdict into a bare job cancel.
     expect(auditStep).toContain('timeout 300 "$@"');
-    expect(dependencyJob).toContain('timeout-minutes: 25');
+    expect(auditStep).toContain('sleep 15');
+    expect(dependencyJob).toContain('timeout-minutes: 40');
     expect(trufflehogStep).not.toContain('continue-on-error');
     const trufflehogPin = trufflehogStep.match(
       /trufflesecurity\/trufflehog@[0-9a-f]{40}' # v([\d.]+)/,

--- a/scripts/tests/security-workflows.test.js
+++ b/scripts/tests/security-workflows.test.js
@@ -94,6 +94,23 @@ describe('security workflows', () => {
     expect(auditStep).toContain(
       'npm audit --omit=dev --audit-level=high --workspaces=false',
     );
+    // A registry-side audit failure is retried and then reported as its own
+    // error, never swallowed: an endpoint outage must not read as a CVE
+    // finding, and must not pass the gate either. Witnessed by bash in
+    // security-checks-audit-retry.test.js.
+    expect(auditStep).toContain('audit endpoint returned an error');
+    expect(auditStep).toContain(
+      'audit npm audit --omit=dev --audit-level=high || status=$?',
+    );
+    expect(auditStep).toContain(
+      'audit npm audit --omit=dev --audit-level=high --workspaces=false',
+    );
+    expect(auditStep).not.toContain('|| true');
+    // The retry is bounded on both axes: every attempt is capped, and the job
+    // ceiling covers the worst case (2 audit sites x 2 attempts x 300s). Drop
+    // either and a registry outage turns a reported verdict into a job cancel.
+    expect(auditStep).toContain('timeout 300 "$@"');
+    expect(dependencyJob).toContain('timeout-minutes: 25');
     expect(trufflehogStep).not.toContain('continue-on-error');
     const trufflehogPin = trufflehogStep.match(
       /trufflesecurity\/trufflehog@[0-9a-f]{40}' # v([\d.]+)/,

--- a/scripts/tests/vitest.config.ts
+++ b/scripts/tests/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
         ? [
             ...configDefaults.exclude,
             'scripts/tests/e2e-shard-retry.test.js',
+            'scripts/tests/security-checks-audit-retry.test.js',
             'scripts/tests/pr-self-report-label.test.js',
             // Bash-driven workflow suites cannot run on Windows; pure
             // YAML-parse workflow suites still do.


### PR DESCRIPTION
## What this PR does

The Dependency CVE audit cannot currently tell "this branch pulled in a high-severity advisory" apart from "the npm registry refused to answer the request". `npm audit` exits 1 for both, and the step folds either into the same accumulated status, so the check goes red with no way to tell from the summary which one happened.

This classifies the two. A registry-side failure is retried once; if it persists, the job still fails, but says out loud that it is an audit-infrastructure failure and not a CVE finding. A real advisory is reported exactly as before, on the first attempt, with no retry.

## Why it's needed

Between 02:32Z and 03:49Z today, eleven runs of this workflow failed across unrelated branches, all in the same place. npm's audit call gets an HTTP 400 from the registry:

```
npm warn audit 400 Bad Request - POST https://registry.npmjs.org/-/npm/v1/security/audits/quick - Bad Request
  message: 'Invalid package tree, run  npm install  to rebuild your package-lock.json'
npm error audit endpoint returned an error
```

The same log carries npm's own `This endpoint is being retired. Use the bulk advisory endpoint instead.`

The cleanest single proof that this is not the branches: #10963 and #10945 carry byte-identical `packages/live-host/package.json` (blob `152bd4f0a42e`) and `packages/live-host/package-lock.json` (blob `cfea05122791`), neither branch touches either file, and the same step audited that exact tree clean two minutes before it failed on it.

| Run | Audit step | `live-host` iteration | Result |
| --- | --- | --- | --- |
| [#10945 — job 100894183912](https://github.com/QwenLM/qwen-code/actions/runs/33830736318/job/100894183912) | 02:53:20 → 02:57:23 | `found 0 vulnerabilities` | success |
| [#10963 — job 100894571938](https://github.com/QwenLM/qwen-code/actions/runs/33830030733/job/100894571938) | 02:55:26 → 03:01:59 | HTTP 400 `Invalid package tree` | failure |

Each of those reds costs someone a dig through the logs to establish it is not their diff, and the dig is not trivial: the advisories the root audit *does* report (`diff` low, `uuid` moderate) sit below this step's `--audit-level=high` gate and appear identically in passing runs, so they are a plausible-looking but wrong explanation. I wrote one up on #10963 before realising the failure mode was the endpoint rather than any advisory.

The step durations also matter for the design below. A healthy run takes about four minutes; the failing ones took 6m33s, 7m14s, 11m22s and 7m26s, because a single stalled audit call can burn four to seven minutes before the 400 arrives.

## Reviewer Test Plan

### How to verify

`npm run test:scripts` runs a new bash-driven suite alongside the existing shape assertions. It extracts this step's `run:` block from the YAML and executes it under the shell GitHub actually gives it — `bash --noprofile --norc -e -o pipefail`, since the workflow sets `defaults.run.shell: bash` — with `npm`, `timeout` and `sleep` stubbed and a one-package fixture tree. Seven cases:

```
✓ passes a clean audit through unchanged, without retrying
✓ retries a registry endpoint error and passes once the registry recovers
✓ retries an audit that stalled until `timeout` killed it
✓ still fails the gate when the endpoint never recovers, and says it is not a CVE
✓ still fails the gate when every attempt stalls, rather than waiting on npm forever
✓ reports a real high-severity finding as-is, with no retry
✓ reaches the same verdict without pipefail, so the gate cannot fail open on a shell change
```

Both security suites pass 9/9 locally, and `prettier --check` and `eslint` are clean on all four changed files.

I mutation-checked the suite rather than trusting green. Dropping the retry (attempt ceiling 2 → 1) turns 4 of the 7 red. Removing `-o pipefail` from the harness is the more interesting one: against my first draft of this change, which read npm's status out of a `| tee /dev/stderr` pipeline so the report would stream live, that mutation made a **real high-severity finding exit 0** — the gate failed open, because tee's status masked npm's. The wrapper now captures output instead of piping it, and the last case pins that the verdict is identical with and without pipefail, so the gate no longer depends on a `defaults:` key nobody would think of as security-relevant.

Two things I could not verify locally and am flagging rather than implying:

- The step itself only runs on `ubuntu-latest`. `timeout` is coreutils and present there, but the suite stubs it because macOS has no `timeout`. This PR's own Security Checks run exercises the new happy path on a real runner.
- In a full local `test:scripts` run I saw three failures in files this PR does not touch, all attributable to my setup rather than the diff: `unit-vitest-configs.test.ts` failed collection on a missing `vite-plugin-dts` because the tree I symlinked `node_modules` from had an incomplete install — that package is declared in `packages/webui/package.json` and present in both lockfiles, and CI installs it fine, which is why `Test (ubuntu-latest)` passes on this PR, `install-script.test.js > does not package audio-capture test artifacts` fails identically on a branch without this change, and `qwen-autofix-workflow.test.js > auto-reruns a check that died on infrastructure` passes in 6.4s in isolation both with and without this change but hit its own 20s timeout at 29s under full-suite contention.

### Evidence (Before & After)

N/A — CI-only change, no user-visible surface. The CI evidence is the table above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

The new suite is bash-driven and is added to the same Windows exclusion list the existing bash-driven workflow suites use. Linux is where the step actually runs, and this PR's own run has now executed it: `Dependency CVE audit` passed in 6m31s, the rewritten `Audit production dependencies` step taking 06:03:48 -> 06:09:40 on a GitHub-hosted runner.

### Environment

Local `npm run test:scripts` (vitest, `scripts/tests/vitest.config.ts`).

## Risk & Scope

- Main risk or tradeoff: the job ceiling goes from 15 to 40 minutes. A healthy run is untouched at ~4-6 minutes, and the cap on each attempt (300s) is what makes the higher ceiling reachable only in a real outage — three audit sites (the root call plus the two vendored lockfiles the loop does not skip), two attempts each, 300s worst case per attempt with a 15s backoff between them, so 3 x 615s = 1845s of audit work. Without the cap, an uncapped retry could stall 6-7 minutes per attempt and end as a job cancel, which is a worse outcome than the red it replaces: it burns the full budget and reports nothing.
- Not validated / out of scope: the retry matches the string npm throws for audit-endpoint failures (`audit endpoint returned an error`) plus `timeout`'s 124. Sandboxed verification measured that npm funnels every audit-endpoint exception into that one thrown string (npm/lib/utils/audit-error.js), so the retry in practice covers most failure shapes — `ECONNRESET`, 5xx and a corrupt lockfile included, and with them deterministic misconfigurations (401/403/404/DNS failure), which are retried once and then still fail the gate with an annotation. Narrowing the retry to only genuinely transient shapes would need a classifier npm does not expose at this seam; a payload-shape classifier exists in `scripts/audit-runtime-critical.js` and wiring it here is a candidate follow-up. Moving the audit off the retired quick endpoint onto the bulk advisory route is the durable fix and is a larger change than this one; npm exposes no flag to choose the route.
- Breaking changes / migration notes: none. The gate's pass/fail policy for real advisories is unchanged, and `security-workflows.test.js` still pins `status=0`, `exit "$status"` and the absence of `continue-on-error`.

## Linked Issues

Related to #10850, which is a different failure mode: that one is real high-severity advisories in main's lockfile, this one is the registry refusing to answer. Neither closes the other.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

Dependency CVE audit 目前分不清「这个分支引入了高危 advisory」和「npm registry 拒绝响应请求」。两种情况 `npm audit` 都返回 exit 1，而这个 step 把它们折进同一个累积状态里，所以检查变红时无法从摘要判断到底是哪一种。

这个改动把两者区分开：registry 侧的失败重试一次；如果仍然失败，job 依然失败，但会明确说出这是 audit 基础设施故障、不是 CVE。真实的 advisory 则完全照旧——第一次尝试就上报，不重试。

## 为什么需要

今天 02:32Z 到 03:49Z 之间，这个 workflow 有 11 次运行在互不相关的分支上失败，位置完全相同。npm 的 audit 调用从 registry 拿到 HTTP 400（见上方日志），而同一份日志里 npm 自己就写了 `This endpoint is being retired. Use the bulk advisory endpoint instead.`

最能说明问题不是分支的证据：#10963 和 #10945 的 `packages/live-host/package.json`（blob `152bd4f0a42e`）与 `packages/live-host/package-lock.json`（blob `cfea05122791`）字节完全相同，两个分支都没有碰这两个文件，而同一个 step 在失败前两分钟刚把这棵树审干净过。

每一次这样的红，都要有人去翻日志才能确认不是自己的 diff 造成的，而且这个坑不好填：root audit 确实会报的那两条 advisory（`diff` low、`uuid` moderate）低于本 step 的 `--audit-level=high` 门槛，在通过的 run 里也一模一样地出现，所以它们是个看着很像、其实错误的解释。我在 #10963 上就先写过一版这样的归因，后来才发现失败模式是 endpoint 而不是任何 advisory。

step 耗时对下面的设计也很关键：健康的 run 大约 4 分钟，而失败的几次是 6m33s、7m14s、11m22s、7m26s——因为单次 stall 的 audit 调用能烧掉 4 到 7 分钟才吐出那个 400。

## 评审测试计划

### 如何验证

`npm run test:scripts` 会在原有的字符串断言之外跑一个新的 bash 驱动套件。它从 YAML 里抽出这个 step 的 `run:` 块，用 GitHub 实际给的 shell 执行——`bash --noprofile --norc -e -o pipefail`（因为 workflow 设了 `defaults.run.shell: bash`）——并 stub 掉 `npm`、`timeout`、`sleep`，配一个单包 fixture 树。七个用例见上方列表。

两个 security 套件本地 9/9 通过，四个改动文件的 `prettier --check` 和 `eslint` 都干净。

我没有直接相信绿灯，而是做了变异检查：把重试次数上限从 2 改成 1，7 条里 4 条变红。去掉 harness 里的 `-o pipefail` 更有意思——针对我这个改动的**第一版**（当时用 `| tee /dev/stderr` 管道读 npm 状态，好让报告实时输出），那个变异会让**真实高危 finding 变成 exit 0**：tee 的状态盖掉了 npm 的状态，安全门直接 fail open。所以现在 wrapper 改成捕获输出而不用管道，最后一条用例钉住「有无 pipefail 结论一致」，让这个门不再依赖一个没人会当成安全相关的 `defaults:` 配置项。

有两件事我本地无法验证，明确说明而不是含糊带过：

- 这个 step 只在 `ubuntu-latest` 上跑。`timeout` 是 coreutils，那里有；但 macOS 没有 `timeout`，所以套件里 stub 了它。本 PR 自己的 Security Checks run 会在真实 runner 上走到新的正常路径。
- 本地跑完整 `test:scripts` 时，有 3 个本 PR 没碰的文件失败，都能归因到我的环境而不是这个 diff：`unit-vitest-configs.test.ts` 收集阶段就挂在缺 `vite-plugin-dts`，原因是我软链过去的那棵树本身装得不全——该包在 `packages/webui/package.json` 里有声明、两个 lockfile 里都在，CI 装得出来，这也是本 PR 的 `Test (ubuntu-latest)` 能通过的原因；`install-script.test.js > does not package audio-capture test artifacts` 在没有本改动的分支上一模一样地失败；`qwen-autofix-workflow.test.js > auto-reruns a check that died on infrastructure` 单独跑时有没有本改动都是 6.4s 通过，但在全量套件并发下 29s 撞上它自己的 20s 超时。

### 前后对比证据

N/A——纯 CI 改动，没有用户可见界面。CI 证据就是上方那张表。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ✅   |

新套件是 bash 驱动的，已加入现有 bash 驱动 workflow 套件所用的同一份 Windows 排除列表。Linux 才是这个 step 真正运行的地方，而本 PR 自己的 run 已经执行过它：`Dependency CVE audit` 6m31s 通过，重写后的 `Audit production dependencies` step 在 GitHub 托管 runner 上耗时 06:03:48 -> 06:09:40。

### 环境

本地 `npm run test:scripts`（vitest，`scripts/tests/vitest.config.ts`）。

## 风险与范围

- 主要风险或取舍：job 上限从 15 分钟提到 40 分钟。健康的 run 不受影响，仍是约 4-6 分钟；而每次尝试的 300s 上限，正是让这个更高上限只在真实故障时才可能被触及的原因——三个审计点（根目录调用，加上循环未跳过的两个 vendored lockfile）、每点两次尝试、每次最坏 300s、之间 15s 退避，即 3 x 615s = 1845s 的审计耗时。没有这个上限，无界重试每次可能 stall 6-7 分钟，最终以 job cancel 收场，那比它想替代的红更糟：烧满预算且什么结论都不给。
- 未验证 / 范围外：重试匹配的是 npm 在 audit endpoint 失败时抛出的那句话（`audit endpoint returned an error`）加上 `timeout` 的 124。沙箱验证实测：npm 会把所有 audit endpoint 异常归并进这同一句抛出的字符串（npm/lib/utils/audit-error.js），因此重试实际覆盖大多数失败形态——包括 `ECONNRESET`、5xx、真正损坏的 lockfile，以及确定性配置错误（401/403/404/DNS 失败）；后者会被重试一次，然后仍然让门失败并给出注解。若要把重试收窄到只剩真正瞬时的形态，需要 npm 在此处未暴露的分类能力；仓库已有 `scripts/audit-runtime-critical.js` 里的载荷形态分类器，接入这里可作为后续项。把 audit 从退役的 quick endpoint 迁到 bulk advisory 路线才是根治，但那是比这个改动大得多的工程；npm 没有提供选择路线的 flag。
- 破坏性变更 / 迁移说明：无。对真实 advisory 的通过/失败策略没有变化，`security-workflows.test.js` 依然钉住 `status=0`、`exit "$status"` 以及不存在 `continue-on-error`。

## 关联 Issue

与 #10850 相关，但那是另一种失败模式：那个是 main 的 lockfile 里真实存在的高危 advisory，这个是 registry 拒绝响应。两者互不关闭。

</details>