### PR TITLE
fix(cli): allow quit before slash commands load

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -391,39 +391,42 @@ describe('useSlashCommandProcessor', () => {
   });
 
   describe('Command Execution Logic', () => {
-    it('should handle /quit while slash commands are still loading', async () => {
-      const commandsNeverLoad = new Promise<readonly SlashCommand[]>(
-        () => undefined,
-      );
-      const result = setupProcessorHook(
-        [],
-        [],
-        [],
-        vi.fn(),
-        mockSettings,
-        undefined,
-        { current: true },
-        commandsNeverLoad,
-      );
+    it.each(['/quit', '/exit'])(
+      'should handle %s while slash commands are still loading',
+      async (input) => {
+        const commandsNeverLoad = new Promise<readonly SlashCommand[]>(
+          () => undefined,
+        );
+        const result = setupProcessorHook(
+          [],
+          [],
+          [],
+          vi.fn(),
+          mockSettings,
+          undefined,
+          { current: true },
+          commandsNeverLoad,
+        );
 
-      await act(async () => {
-        await result.current.handleSlashCommand('/quit');
-      });
+        await act(async () => {
+          await result.current.handleSlashCommand(input);
+        });
 
-      expect(mockSetQuittingMessages).toHaveBeenCalledWith([
-        expect.objectContaining({ type: 'user', text: '/quit' }),
-        expect.objectContaining({ type: 'quit' }),
-      ]);
-      expect(mockAddItem).not.toHaveBeenCalledWith(
-        expect.objectContaining({ text: 'Unknown command: /quit' }),
-        expect.any(Number),
-      );
-    });
+        expect(mockSetQuittingMessages).toHaveBeenCalledWith([
+          expect.objectContaining({ type: 'user', text: '/quit' }),
+          expect.objectContaining({ type: 'quit' }),
+        ]);
+        expect(mockAddItem).not.toHaveBeenCalledWith(
+          expect.objectContaining({ text: `Unknown command: ${input}` }),
+          expect.any(Number),
+        );
+      },
+    );
 
     it('should respect disabled commands while slash commands are loading', async () => {
       mockConfig.getDisabledSlashCommands = vi
         .fn()
-        .mockReturnValue(['quit']);
+        .mockReturnValue(['exit']);
       const commandsNeverLoad = new Promise<readonly SlashCommand[]>(
         () => undefined,
       );

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -106,7 +106,9 @@ vi.mock('../../services/McpPromptLoader.js', () => ({
 }));
 
 vi.mock('../contexts/SessionContext.js', () => ({
-  useSessionStats: vi.fn(() => ({ stats: {} })),
+  useSessionStats: vi.fn(() => ({
+    stats: { sessionStartTime: new Date(0) },
+  })),
 }));
 
 const { mockRunExitCleanup } = vi.hoisted(() => ({
@@ -220,6 +222,7 @@ describe('useSlashCommandProcessor', () => {
     mockOpenMemoryDialog.mockClear();
     mockFireUserPromptExpansionEvent.mockResolvedValue(undefined);
     vi.mocked(refreshExtensionContentRuntime).mockResolvedValue(undefined);
+    mockConfig.getDisabledSlashCommands = vi.fn().mockReturnValue([]);
     mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
     mockConfig.hasHooksForEvent = vi.fn().mockReturnValue(true);
     mockConfig.getHookSystem = vi.fn().mockReturnValue({
@@ -237,8 +240,13 @@ describe('useSlashCommandProcessor', () => {
     settings: LoadedSettings = mockSettings,
     extensionRefreshState?: ExtensionRefreshState,
     isIdleRef = { current: true },
+    builtinCommandsPromise?: Promise<readonly SlashCommand[]>,
   ) => {
-    mockBuiltinLoadCommands.mockResolvedValue(Object.freeze(builtinCommands));
+    if (builtinCommandsPromise) {
+      mockBuiltinLoadCommands.mockReturnValue(builtinCommandsPromise);
+    } else {
+      mockBuiltinLoadCommands.mockResolvedValue(Object.freeze(builtinCommands));
+    }
     mockFileLoadCommands.mockResolvedValue(Object.freeze(fileCommands));
     mockMcpLoadCommands.mockResolvedValue(Object.freeze(mcpCommands));
 
@@ -383,6 +391,64 @@ describe('useSlashCommandProcessor', () => {
   });
 
   describe('Command Execution Logic', () => {
+    it('should handle /quit while slash commands are still loading', async () => {
+      const commandsNeverLoad = new Promise<readonly SlashCommand[]>(
+        () => undefined,
+      );
+      const result = setupProcessorHook(
+        [],
+        [],
+        [],
+        vi.fn(),
+        mockSettings,
+        undefined,
+        { current: true },
+        commandsNeverLoad,
+      );
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/quit');
+      });
+
+      expect(mockSetQuittingMessages).toHaveBeenCalledWith([
+        expect.objectContaining({ type: 'user', text: '/quit' }),
+        expect.objectContaining({ type: 'quit' }),
+      ]);
+      expect(mockAddItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'Unknown command: /quit' }),
+        expect.any(Number),
+      );
+    });
+
+    it('should respect disabled commands while slash commands are loading', async () => {
+      mockConfig.getDisabledSlashCommands = vi
+        .fn()
+        .mockReturnValue(['quit']);
+      const commandsNeverLoad = new Promise<readonly SlashCommand[]>(
+        () => undefined,
+      );
+      const result = setupProcessorHook(
+        [],
+        [],
+        [],
+        vi.fn(),
+        mockSettings,
+        undefined,
+        { current: true },
+        commandsNeverLoad,
+      );
+
+      await act(async () => {
+        await result.current.handleSlashCommand('/quit');
+      });
+
+      expect(mockSetQuittingMessages).not.toHaveBeenCalled();
+      expect(mockAddItem).toHaveBeenLastCalledWith(
+        { type: MessageType.ERROR, text: 'Unknown command: /quit' },
+        expect.any(Number),
+      );
+    });
+
     it('should display an error for an unknown command', async () => {
       const result = setupProcessorHook();
       await waitFor(() => expect(result.current.slashCommands).toBeDefined());

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -80,6 +80,7 @@ import {
 import { clearScreen } from '../../utils/stdioHelpers.js';
 import { useKeypress } from './useKeypress.js';
 import { isPickerOnlyModelInvocation } from '../commands/modelCommand.js';
+import { quitCommand } from '../commands/quitCommand.js';
 import {
   type ExtensionUpdateAction,
   type ExtensionUpdateStatus,
@@ -891,11 +892,23 @@ export const useSlashCommandProcessor = (
         return false;
       }
 
-      const {
+      let {
         commandToExecute,
         args,
         canonicalPath: resolvedCommandPath,
       } = parseSlashCommand(trimmed, commands);
+
+      if (
+        !commandToExecute &&
+        (trimmed === '/quit' || trimmed === '/exit') &&
+        !(config?.getDisabledSlashCommands() ?? []).some((name) =>
+          ['quit', 'exit'].includes(name.trim().toLowerCase()),
+        )
+      ) {
+        commandToExecute = quitCommand;
+        args = '';
+        resolvedCommandPath = ['quit'];
+      }
 
       const recordedItems: HistoryItemWithoutId[] = [];
       const recordItem = (item: HistoryItemWithoutId) => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -129,6 +129,10 @@ const BARE_SLASH_COMMANDS_HIDE_INVOCATION = new Set([
   'statusline',
 ]);
 const MAX_EXTENSION_CONTENT_REFRESH_PASSES = 5;
+const QUIT_COMMAND_NAMES = [
+  quitCommand.name,
+  ...(quitCommand.altNames ?? []),
+];
 
 function shouldHideSlashCommandInvocation(
   command: SlashCommand | undefined,
@@ -898,16 +902,18 @@ export const useSlashCommandProcessor = (
         canonicalPath: resolvedCommandPath,
       } = parseSlashCommand(trimmed, commands);
 
-      if (
-        !commandToExecute &&
-        (trimmed === '/quit' || trimmed === '/exit') &&
-        !(config?.getDisabledSlashCommands() ?? []).some((name) =>
-          ['quit', 'exit'].includes(name.trim().toLowerCase()),
-        )
-      ) {
-        commandToExecute = quitCommand;
-        args = '';
-        resolvedCommandPath = ['quit'];
+      if (!commandToExecute) {
+        const fallback = parseSlashCommand(trimmed, [quitCommand]);
+        if (
+          fallback.commandToExecute &&
+          !(config?.getDisabledSlashCommands() ?? []).some((name) =>
+            QUIT_COMMAND_NAMES.includes(name.trim().toLowerCase()),
+          )
+        ) {
+          commandToExecute = fallback.commandToExecute;
+          args = fallback.args;
+          resolvedCommandPath = fallback.canonicalPath;
+        }
       }
 
       const recordedItems: HistoryItemWithoutId[] = [];


### PR DESCRIPTION
## What this PR does

This PR lets `/quit` and its `/exit` alias execute while the asynchronous slash-command registry is still loading. The fallback only applies when normal command lookup misses, and it continues to honor `slashCommands.disabled`.

## Why it is needed

Main CI run 33878852518 repeatedly submitted `/quit` during a held response stream, rendered `Unknown command: /quit`, and then timed out waiting for the process to exit. The slash-command processor starts with an empty command list and waits for all command loaders, so runner pressure can expose a startup race even though the application already recognizes quit-family input.

The complete admin-visible job log also shows `cli/qwen-serve-baseline.test.ts` passing in 470490ms. PR #11004 addresses a separate shared-runner prompt-latency failure class, but it does not address the named failure in this run.

## Reviewer Test Plan

### How to verify

Run the slash-command processor unit test suite. Confirm that `/quit` exits when the command loader never resolves, and that disabling `quit` still produces the normal unknown-command result.

### Evidence (Before & After)

Before: the Linux E2E job reproduced `Unknown command: /quit` six times across the test retry and shard retry.

After: `src/ui/hooks/slashCommandProcessor.test.ts` passes all 130 tests, including the loading-race and disabled-command regression cases.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ unit tests |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ pending CI |

### Environment (optional)

Node.js 22.22.0, Ink slash-command processor tests.

## Risk & Scope

- Main risk or tradeoff: an exact `/quit` or `/exit` lookup miss can use the built-in quit action before other commands finish loading.
- Not validated / out of scope: unrelated main-branch CI failures and local full-build infrastructure.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11027

Related: #11004 addresses the separate shared-runner prompt-latency class.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让 `/quit` 及其别名 `/exit` 在异步斜杠命令注册表仍在加载时也能执行。兜底只会在正常命令查找失败时生效，并且仍然遵守 `slashCommands.disabled` 配置。

## 为什么需要这个改动

main 分支 CI run 33878852518 在响应流被保持时多次提交 `/quit`，界面显示 `Unknown command: /quit`，随后等待进程退出超时。斜杠命令处理器以空命令列表启动，并等待所有命令加载器完成，因此 runner 压力会暴露启动时序竞争，即使应用层已经识别退出命令输入。

管理员可见的完整 job 日志同时显示 `cli/qwen-serve-baseline.test.ts` 已在 470490ms 内通过。PR #11004 处理的是另一类共享 runner prompt-latency 失败，但不能解决本次运行中明确命名的失败。

## Reviewer 测试计划

### 如何验证

运行斜杠命令处理器单元测试。确认命令加载器永不完成时 `/quit` 仍能退出，同时禁用 `quit` 后仍返回正常的未知命令结果。

### 前后证据

改动前：Linux E2E job 在测试重试和 shard 重试中共六次复现 `Unknown command: /quit`。

改动后：`src/ui/hooks/slashCommandProcessor.test.ts` 的 130 个测试全部通过，包括加载竞争和禁用命令两个回归用例。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  | ✅ 单元测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 等待 CI |

### 环境

Node.js 22.22.0，Ink 斜杠命令处理器测试。

## 风险与范围

- 主要风险或取舍：当精确的 `/quit` 或 `/exit` 查找失败时，可以在其他命令完成加载前使用内置退出动作。
- 未验证或范围外：main 分支上无关的 CI 失败以及本地全量构建基础设施。
- 破坏性变更或迁移说明：无。

## 关联 Issue

Fixes #11027

相关：#11004 处理另一类共享 runner prompt-latency 问题。

</details>
