### PR TITLE
fix: restore ACP-related main CI checks

### DIFF
--- a/integration-tests/cli/_daemon-harness.ts
+++ b/integration-tests/cli/_daemon-harness.ts
@@ -118,6 +118,8 @@ export async function spawnDaemon(
     '127.0.0.1',
     '--workspace',
     workspaceCwd,
+    '--initialize-timeout-ms',
+    '60000',
     ...extraArgs,
   ];
 


### PR DESCRIPTION
## What this PR does

Raises the ACP initialization budget from 10 seconds to 60 seconds only for daemons launched by the shared E2E harness. It also routes the concurrently added session turn-index reader through the existing per-request runtime-root helper. The production `qwen serve` default and turn-index behavior remain unchanged.

## Why it's needed

[Main E2E run 33884903785](https://github.com/QwenLM/qwen-code/actions/runs/33884903785) failed in two macOS shards before either affected test body ran. Both failures were ACP initialization timeouts at roughly 10 seconds, while the same run recorded successful handshakes taking 10.43 and 13.12 seconds. This gives process-heavy hosted-runner tests the same CI-sized handshake budget already used by the serve-routes E2E suite in #10846.

The first PR CI run then exposed a deterministic main-branch integration gap: #10751 added the turn-index reader after #10988's branch point, while #10988 later introduced the invariant that every caller-supplied-cwd runtime-root pin must use the shared helper. Because required checks were not strict against the latest base, each PR passed independently and their merged result did not. This PR completes the behavior-equivalent delegation intended by #10988 rather than weakening its AST guard.

## Reviewer Test Plan

### How to verify

Confirm that the baseline session-creation paths and qwen-live prewarm path can complete when ACP initialization takes more than 10 seconds but less than 60 seconds on a loaded macOS runner. Confirm that `qwen serve` outside the E2E harness still uses its 10-second default. Confirm that the turn-index reader resolves the request cwd through the shared runtime-root helper and preserves its existing flush, read, and error behavior.

### Evidence (Before & After)

Before: the linked main run failed at 9.7–10.0 seconds in the ACP initialize phase before the affected assertions ran.

After: static tracing confirms both failed E2E paths use the shared harness and that its explicit value reaches the ACP bridge. Replaying the failed unit test's TypeScript AST check leaves exactly the one permitted helper delegation. `git diff --check` and Prettier both pass. [Manual E2E run 33897680630](https://github.com/QwenLM/qwen-code/actions/runs/33897680630) provides the hosted-runner verification.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

N/A — the failure depends on hosted-runner contention.

## Risk & Scope

- Main risk or tradeoff: A genuinely stuck ACP operation in shared-harness E2E tests can take up to 50 seconds longer to fail. The runtime-root change delegates the same cwd, settings, callback, and Promise through the existing helper.
- Not validated / out of scope: No local E2E or build was run; PR CI and the manual E2E run provide the relevant validation.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #11030

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

仅将共享 E2E harness 启动的 daemon 的 ACP 初始化预算从 10 秒提高到 60 秒，同时让并发新增的 session turn-index reader 经过现有的 per-request runtime-root helper。生产环境中的 `qwen serve` 默认值和 turn-index 行为都保持不变。

## 为什么需要

[main E2E run 33884903785](https://github.com/QwenLM/qwen-code/actions/runs/33884903785) 的两个 macOS 分片都在受影响测试的正文运行前失败。两处都是约 10 秒触发 ACP 初始化超时，而同一次运行中也记录到了耗时 10.43 秒和 13.12 秒但成功的握手。本修复让进程负载较重的托管 runner 测试使用与 #10846 中 serve-routes E2E 套件相同的 CI 级握手预算。

第一次 PR CI 随后暴露了一个确定性的 main 分支集成缺口：#10751 在 #10988 的分支基线之后新增了 turn-index reader，而 #10988 后来加入了“所有 caller-supplied-cwd runtime-root pin 都必须经过共享 helper”的约束。由于 required checks 没有强制基于最新 base 运行，两个 PR 单独都通过，但合并后的结果没有通过。本 PR 补齐 #10988 原本要求的等价委托，而不是放宽其 AST 约束。

## Reviewer Test Plan

### 如何验证

确认在高负载 macOS runner 上，baseline 的 session 创建路径与 qwen-live 预热路径在 ACP 初始化超过 10 秒但少于 60 秒时可以完成；同时确认 E2E harness 之外的 `qwen serve` 仍使用默认的 10 秒预算。确认 turn-index reader 通过共享 runtime-root helper 解析请求 cwd，并保留现有的 flush、读取和错误处理行为。

### 证据（修改前后）

修改前：链接中的 main 运行在 ACP initialize 阶段约 9.7–10.0 秒时失败，尚未执行受影响的断言。

修改后：静态调用链确认两条 E2E 失败路径都经过共享 harness，显式预算会传递到 ACP bridge。复刻失败单测的 TypeScript AST 检查后，只剩唯一允许的 helper 委托。`git diff --check` 与 Prettier 均通过；[手动 E2E 运行 33897680630](https://github.com/QwenLM/qwen-code/actions/runs/33897680630) 将提供托管 runner 环境的验证。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ⚠️  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

N/A —— 该失败依赖托管 runner 的资源争用。

## 风险与范围

- 主要风险或取舍：共享 harness E2E 中真正卡死的 ACP 操作，报错时间最多会延后 50 秒。runtime-root 改动只是让相同的 cwd、settings、callback 和 Promise 经过现有 helper。
- 未验证 / 不在范围内：未在本地运行 E2E 或 build；PR CI 与手动 E2E 运行提供相关验证。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #11030

</details>
