### PR TITLE
fix(channels): clean up owned workers after config loss

### DIFF
--- a/docs/developers/daemon/15-channel-adapters.md
+++ b/docs/developers/daemon/15-channel-adapters.md
@@ -184,6 +184,8 @@ If a replacement fails, newly started workers are stopped and old workers are re
 
 Adapter `connect()` failures are reported separately from worker lifecycle errors. The worker sends each bounded, credential-redacted failure over startup IPC and waits for a supervisor acknowledgement before trying the next adapter. A partially connected worker remains running and exposes `startupFailures` in its snapshot. If every adapter in a dynamic attempt fails, the `502 channel_worker_start_failed` response carries workspace-annotated attempted failures while `state` reflects the rollback result; subsequent GET responses do not retain the attempt. Daemon boot with no connected adapter remains fail-fast. The optional adapter `code` is diagnostic only, and the current `phase` is `connect`.
 
+An explicit `DELETE /workspaces/:workspace/channels/:name` can also converge a missing-config Channel when the manager still confirms exactly one committed Worker owner in the selected Workspace. It stops that owner before removing persisted startup selection; unknown, ambiguous, uncommitted or foreign runtime ownership is rejected. Revision checks and Worker stop failures still apply. If both configuration and runtime are absent, deletion is idempotent. Reading a missing configuration does not trigger cleanup. Remaining committed Channels must still resolve through the existing manager reconciliation; if another selected Channel also lost its configuration, deletion can fail without converging the target.
+
 ## Dependencies
 
 - `packages/channels/base/` — `ChannelBase`, `PollingChannelBase`, `DaemonChannelBridge`, `types.ts` (`ChannelConfig`, `Envelope`, `SessionScope`, `ChannelPlugin`).

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -569,6 +569,111 @@ describe('createChannelManagementService', () => {
     expect(manager.setChannelEnabled).not.toHaveBeenCalled();
   });
 
+  it('converges an explicitly deleted owned worker after its config disappears', async () => {
+    const { service, store, manager } = setup({
+      snapshot: settingsSnapshot({ channels: {} }),
+      committedNames: ['old-bot'],
+    });
+    expect((await service.list()).instances).toEqual({});
+    expect(manager.state().workers).toHaveLength(1);
+
+    await expect(
+      service.remove('old-bot', { expectedRevision: 'rev-1' }),
+    ).resolves.toMatchObject({ snapshot: { instances: {} } });
+
+    expect(manager.setChannelEnabled).toHaveBeenCalledWith(
+      { name: 'old-bot', workspaceCwd: WORKSPACE },
+      false,
+    );
+    expect(manager.state().workers).toEqual([]);
+    expect(manager.state().selection).toBeNull();
+    expect(store.remove).toHaveBeenCalledOnce();
+  });
+
+  it('rejects stale missing-config deletion before stopping its worker', async () => {
+    const { service, store, manager } = setup({
+      snapshot: settingsSnapshot({ channels: {} }),
+      committedNames: ['bot'],
+    });
+
+    await expect(
+      service.remove('bot', { expectedRevision: 'stale' }),
+    ).rejects.toMatchObject({ code: 'channel_settings_conflict' });
+    expect(manager.setChannelEnabled).not.toHaveBeenCalled();
+    expect(store.remove).not.toHaveBeenCalled();
+  });
+
+  it('propagates missing-config worker stop failure without persisting deletion', async () => {
+    const { service, store, manager } = setup({
+      snapshot: settingsSnapshot({ channels: {}, startupNames: ['bot'] }),
+      committedNames: ['bot'],
+    });
+    manager.setChannelEnabled.mockRejectedValueOnce(
+      Object.assign(new Error('stop unconfirmed'), {
+        code: 'channel_worker_stop_failed',
+      }),
+    );
+
+    await expect(
+      service.remove('bot', { expectedRevision: 'rev-1' }),
+    ).rejects.toMatchObject({ code: 'channel_worker_stop_failed' });
+    expect(store.remove).not.toHaveBeenCalled();
+    expect(manager.committedChannelNames()).toEqual(['bot']);
+  });
+
+  it.each(['foreign', 'ambiguous', 'unknown', 'uncommitted'])(
+    'rejects missing-config deletion with %s runtime ownership',
+    async (ownership) => {
+      const { service, store, manager } = setup({
+        snapshot: settingsSnapshot({ channels: {} }),
+        committedNames: ['bot'],
+      });
+      const state = manager.state();
+      const worker = state.workers[0]!;
+      vi.mocked(manager.state).mockReturnValue({
+        ...state,
+        workers:
+          ownership === 'unknown'
+            ? []
+            : ownership === 'ambiguous'
+              ? [worker, { ...worker, workspaceCwd: '/ws/other' }]
+              : [
+                  {
+                    ...worker,
+                    workspaceCwd:
+                      ownership === 'foreign' ? '/ws/other' : WORKSPACE,
+                  },
+                ],
+      });
+      if (ownership === 'uncommitted') {
+        vi.mocked(manager.committedChannelNames).mockReturnValue([]);
+      }
+
+      await expect(
+        service.remove('bot', { expectedRevision: 'rev-1' }),
+      ).rejects.toMatchObject({ code: 'channel_runtime_owner_mismatch' });
+      expect(manager.setChannelEnabled).not.toHaveBeenCalled();
+      expect(store.remove).not.toHaveBeenCalled();
+    },
+  );
+
+  it('makes repeated missing-config deletion idempotent and clears stale startup names', async () => {
+    const { service, manager, persisted } = setup({
+      snapshot: settingsSnapshot({ channels: {}, startupNames: ['bot'] }),
+      committedNames: ['bot'],
+    });
+    const first = await service.remove('bot', { expectedRevision: 'rev-1' });
+    const second = await service.remove('bot', {
+      expectedRevision: first.snapshot.revision,
+    });
+
+    expect(second.snapshot.instances).toEqual({});
+    expect(second.instance.runtime.state).toBe('stopped');
+    expect(persisted().startupNames).toEqual([]);
+    expect(manager.setChannelEnabled).toHaveBeenCalledTimes(1);
+    expect(manager.state().workers).toEqual([]);
+  });
+
   it('delegates starts and stops to the manager atomic mutation lane', async () => {
     const { service, store, manager } = setup({
       committedNames: ['first', 'second'],
@@ -890,7 +995,7 @@ describe('createChannelManagementService', () => {
     expect(manager.setChannelEnabled).not.toHaveBeenCalled();
   });
 
-  it('rejects lifecycle operations for a nonexistent channel', async () => {
+  it('rejects start, stop and restart for a nonexistent channel', async () => {
     const { service, manager } = setup({ committedNames: [] });
 
     await expect(service.restart('nonexistent')).rejects.toMatchObject({
@@ -899,9 +1004,6 @@ describe('createChannelManagementService', () => {
     await expect(service.start('nonexistent')).rejects.toMatchObject({
       code: 'channel_instance_not_found',
     });
-    await expect(
-      service.remove('nonexistent', { expectedRevision: 'rev-1' }),
-    ).rejects.toMatchObject({ code: 'channel_instance_not_found' });
     await expect(service.stop('nonexistent')).rejects.toMatchObject({
       code: 'channel_instance_not_found',
     });

--- a/packages/cli/src/serve/channel-management-service.test.ts
+++ b/packages/cli/src/serve/channel-management-service.test.ts
@@ -571,10 +571,13 @@ describe('createChannelManagementService', () => {
 
   it('converges an explicitly deleted owned worker after its config disappears', async () => {
     const { service, store, manager } = setup({
-      snapshot: settingsSnapshot({ channels: {} }),
+      snapshot: settingsSnapshot({ channels: {}, startupNames: ['old-bot'] }),
       committedNames: ['old-bot'],
     });
     expect((await service.list()).instances).toEqual({});
+    expect(manager.setChannelEnabled).not.toHaveBeenCalled();
+    expect(store.remove).not.toHaveBeenCalled();
+    expect(store.snapshot().startupNames).toEqual(['old-bot']);
     expect(manager.state().workers).toHaveLength(1);
 
     await expect(
@@ -621,9 +624,14 @@ describe('createChannelManagementService', () => {
     expect(manager.committedChannelNames()).toEqual(['bot']);
   });
 
-  it.each(['foreign', 'ambiguous', 'unknown', 'uncommitted'])(
+  it.each([
+    ['foreign', 'The only worker belongs to another workspace.'],
+    ['ambiguous', '2 workers claim this channel.'],
+    ['unknown', 'Committed selection has no observed worker.'],
+    ['uncommitted', 'A worker exists but the channel is not committed.'],
+  ])(
     'rejects missing-config deletion with %s runtime ownership',
-    async (ownership) => {
+    async (ownership, reason) => {
       const { service, store, manager } = setup({
         snapshot: settingsSnapshot({ channels: {} }),
         committedNames: ['bot'],
@@ -651,7 +659,10 @@ describe('createChannelManagementService', () => {
 
       await expect(
         service.remove('bot', { expectedRevision: 'rev-1' }),
-      ).rejects.toMatchObject({ code: 'channel_runtime_owner_mismatch' });
+      ).rejects.toMatchObject({
+        code: 'channel_runtime_owner_mismatch',
+        message: expect.stringContaining(reason),
+      });
       expect(manager.setChannelEnabled).not.toHaveBeenCalled();
       expect(store.remove).not.toHaveBeenCalled();
     },

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -444,14 +444,24 @@ export function createChannelManagementService(
     async remove(name, request) {
       assertManageableInstanceName(name);
       const current = opts.store.snapshot();
-      if (!Object.hasOwn(current.channels, name)) {
-        throw new ChannelManagementError(
-          'channel_instance_not_found',
-          `Channel "${name}" is not configured in this workspace.`,
-        );
-      }
-      assertWorkspaceConfig(current.channels[name]!);
+      const configured = Object.hasOwn(current.channels, name);
+      if (configured) assertWorkspaceConfig(current.channels[name]!);
       assertExpectedRevision(current, request.expectedRevision);
+      if (!configured) {
+        const workers = workerFor(name);
+        const committed = opts.manager.committedChannelNames().includes(name);
+        if (
+          (committed || workers.length > 0) &&
+          (!committed ||
+            workers.length !== 1 ||
+            workers[0]!.workspaceCwd !== opts.workspaceCwd)
+        ) {
+          throw new ChannelManagementError(
+            'channel_runtime_owner_mismatch',
+            `Channel "${name}" does not have one confirmed runtime owner in this workspace.`,
+          );
+        }
+      }
       if (workspaceCommittedNames().includes(name)) {
         assertOwnedRuntime(name);
         await stopChannel(name);

--- a/packages/cli/src/serve/channel-management-service.ts
+++ b/packages/cli/src/serve/channel-management-service.ts
@@ -225,17 +225,39 @@ export function createChannelManagementService(
         workerFor(name).some((w) => w.workspaceCwd === opts.workspaceCwd),
       );
 
+  const runtimeOwnerMismatch = (name: string, reason?: string) =>
+    new ChannelManagementError(
+      'channel_runtime_owner_mismatch',
+      `Channel "${name}" does not have one confirmed runtime owner in this workspace.${reason ? ` ${reason}` : ''}`,
+    );
+
   const assertOwnedRuntime = (name: string): void => {
     if (!workspaceCommittedNames().includes(name)) return;
     const workers = workerFor(name).filter(
       (worker) => worker.workspaceCwd === opts.workspaceCwd,
     );
     if (workers.length !== 1) {
-      throw new ChannelManagementError(
-        'channel_runtime_owner_mismatch',
-        `Channel "${name}" does not have one confirmed runtime owner in this workspace.`,
-      );
+      throw runtimeOwnerMismatch(name);
     }
+  };
+
+  const assertConvergeableRuntimeOwner = (name: string): void => {
+    const workers = workerFor(name);
+    const committed = opts.manager.committedChannelNames().includes(name);
+    if (!committed && workers.length === 0) return;
+    const owned =
+      committed &&
+      workers.length === 1 &&
+      workers[0]!.workspaceCwd === opts.workspaceCwd;
+    if (owned) return;
+    const reason = !committed
+      ? 'A worker exists but the channel is not committed.'
+      : workers.length === 0
+        ? 'Committed selection has no observed worker.'
+        : workers.length !== 1
+          ? `${workers.length} workers claim this channel.`
+          : 'The only worker belongs to another workspace.';
+    throw runtimeOwnerMismatch(name, reason);
   };
 
   const runtimeFor = (name: string): ChannelRuntimeState => {
@@ -447,21 +469,7 @@ export function createChannelManagementService(
       const configured = Object.hasOwn(current.channels, name);
       if (configured) assertWorkspaceConfig(current.channels[name]!);
       assertExpectedRevision(current, request.expectedRevision);
-      if (!configured) {
-        const workers = workerFor(name);
-        const committed = opts.manager.committedChannelNames().includes(name);
-        if (
-          (committed || workers.length > 0) &&
-          (!committed ||
-            workers.length !== 1 ||
-            workers[0]!.workspaceCwd !== opts.workspaceCwd)
-        ) {
-          throw new ChannelManagementError(
-            'channel_runtime_owner_mismatch',
-            `Channel "${name}" does not have one confirmed runtime owner in this workspace.`,
-          );
-        }
-      }
+      if (!configured) assertConvergeableRuntimeOwner(name);
       if (workspaceCommittedNames().includes(name)) {
         assertOwnedRuntime(name);
         await stopChannel(name);

--- a/packages/cli/src/serve/channel-settings-store.test.ts
+++ b/packages/cli/src/serve/channel-settings-store.test.ts
@@ -1853,6 +1853,55 @@ describe('WorkspaceChannelSettingsStore', () => {
     });
   });
 
+  it('does not rewrite legacy all startup when deleting an absent name', async () => {
+    writeWorkspaceSettings(`{
+  "$version": 4,
+  "channels": { "all": { "type": "telegram", "token": "$ALL_TOKEN" } },
+  "serve": { "channels": ["all"] }
+}\n`);
+    const store = new WorkspaceChannelSettingsStore(workspace);
+    const before = fs.readFileSync(settingsPath, 'utf8');
+    const current = store.snapshot();
+
+    await expect(
+      store.remove('missing', { expectedRevision: 'stale' }),
+    ).rejects.toMatchObject({ code: 'channel_settings_conflict' });
+    const next = await store.remove('missing', {
+      expectedRevision: current.revision,
+    });
+
+    expect(next).toEqual(current);
+    expect(fs.readFileSync(settingsPath, 'utf8')).toBe(before);
+  });
+
+  it.each([['other'], ['all']])(
+    'removes only the absent channel startup name while preserving %s',
+    async (remaining) => {
+      writeWorkspaceSettings(
+        JSON.stringify({
+          $version: 4,
+          channels: { [remaining]: { type: 'telegram', token: '$TEST_TOKEN' } },
+          serve: { channels: [remaining, 'missing'] },
+        }),
+      );
+      const store = new WorkspaceChannelSettingsStore(workspace);
+      const current = store.snapshot();
+
+      const next = await store.remove('missing', {
+        expectedRevision: current.revision,
+      });
+      const repeated = await store.remove('missing', {
+        expectedRevision: next.revision,
+      });
+
+      expect(next.channels).toEqual(current.channels);
+      expect(next.startupNames).toEqual([remaining]);
+      expect(repeated).toEqual(next);
+      const persisted = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(persisted.serve.channels).toEqual([remaining]);
+    },
+  );
+
   it('preserves the all sentinel when removing a legacy all config beside other instances', async () => {
     writeWorkspaceSettings(`{
   "$version": 4,

--- a/packages/cli/src/serve/channel-settings-store.ts
+++ b/packages/cli/src/serve/channel-settings-store.ts
@@ -596,9 +596,12 @@ export class WorkspaceChannelSettingsStore {
   ): Promise<ChannelSettingsSnapshot> {
     assertSafeChannelName(name);
     const current = this.assertRevision(options.expectedRevision);
+    const configured = Object.hasOwn(current.channels, name);
+    if (!configured && !current.startupNames.includes(name)) return current;
     const channels = { ...current.channels };
     delete channels[name];
-    const hasAllSentinel = current.startupNames.some(isAllStartupName);
+    const hasAllSentinel =
+      configured && current.startupNames.some(isAllStartupName);
     const startupNames = hasAllSentinel
       ? Object.keys(channels).some(
           (channelName) => !isAllStartupName(channelName),

--- a/packages/cli/src/serve/channel-worker-manager.test.ts
+++ b/packages/cli/src/serve/channel-worker-manager.test.ts
@@ -132,6 +132,41 @@ function setup(group = fakeGroup()) {
 }
 
 describe('createChannelWorkerManager', () => {
+  it('preserves committed workers when disabling cannot resolve a remaining channel', async () => {
+    const group = fakeGroup({
+      snapshots: () => [
+        workerSnapshot({
+          channels: ['telegram', 'other'],
+          requestedChannels: ['telegram', 'other'],
+        }),
+      ],
+    });
+    const test = setup(group);
+    await test.manager.startInitial({
+      mode: 'names',
+      names: ['telegram', 'other'],
+    });
+    test.resolveGroups.mockRejectedValueOnce(
+      new Error('remaining channel config is missing'),
+    );
+
+    await expect(
+      test.manager.setChannelEnabled(
+        { name: 'telegram', workspaceCwd: PRIMARY },
+        false,
+      ),
+    ).rejects.toThrow('remaining channel config is missing');
+
+    expect(test.resolveGroups).toHaveBeenLastCalledWith(
+      { mode: 'names', names: ['other'] },
+      'set',
+    );
+    expect(test.manager.committedChannelNames()).toEqual(['telegram', 'other']);
+    expect(group.stop).not.toHaveBeenCalled();
+    expect(group.reconcile).not.toHaveBeenCalled();
+    expect(test.releaseLease).not.toHaveBeenCalled();
+  });
+
   it('exposes committed channel names in selection order', async () => {
     const test = setup();
     const selection: ServeChannelSelection = {


### PR DESCRIPTION
## What this PR does

Allows explicit workspace-scoped Channel deletion to stop a confirmed owned Worker even when its persisted configuration has disappeared. Missing-config deletion rejects unknown, ambiguous, foreign or uncommitted runtime ownership, retains revision checks and stop-failure propagation, and removes stale startup selection after stopping the target. Repeating deletion with the current revision succeeds once both configuration and runtime are absent. An absent name with no startup entry is a true settings no-op, preserving unrelated legacy `all` startup configuration.

## Why it's needed

Previously, deleting a Channel whose configuration was already gone immediately returned `channel_instance_not_found`, leaving its Worker running and its name selected. Repeating DELETE could not converge that state. This follows up the missing-config case in #10782; #10796 already fixed permanent Workspace removal, which is a different path.

## Reviewer Test Plan

### How to verify

1. Start Channels in two separate Workspaces, then remove only one Channel's persisted configuration while its Worker remains running.
2. Explicitly delete that Channel with the current settings revision. Confirm its Worker exits, its selection and startup entry disappear, and the other Workspace retains the same running Worker.
3. Repeat deletion with the current revision and confirm success without affecting the remaining Channel.
4. Try a stale revision, uncertain or foreign ownership, and an unconfirmed Worker stop. Confirm failure is reported before persistent deletion and unrelated runtime is preserved.
5. Confirm normal deletion and permanent Workspace removal still work. Listing missing configuration alone must not trigger cleanup.

### Evidence (Before & After)

Before: the independent reproduction on base `e3d26283e63c19b17e00862addae86c2ecdd86a4` failed with `channel_instance_not_found` despite a confirmed owned Worker. After: the unchanged reproduction passes; three targeted suites pass 169 tests. Full build, bundle, typecheck, changed-TypeScript lint and diff checks pass.

The same isolated bundled HTTP harness passed 4/4 on macOS and Linux: normal deletion, missing-config deletion, repeated deletion preserving another Workspace's exact live PID, and permanent Workspace removal followed by a new start. All fixture processes, ports and temporary directories were cleaned up. The harness uses real HTTP routes, settings persistence, registry, manager and worker group, with test-double adapter supervisors spawning real child processes. This is not a live messaging-provider test.

Dev Qwen Code review completed with 0 Critical, 3 Suggestions and 1 Nice to have; verdict: Comment. The medium tier does not run reverse audit, so this is not an approval. The initial review led to three test/documentation improvements. Following GitHub review, the ownership checks now have distinct names with a shared error constructor; missing-config errors identify the rejection mode, and the passive-read test asserts no stop or persisted removal. Four inline suggestions are addressed. The foreign-owner persisted-only cleanup proposal remains deferred as a contract extension. Final tests, build, typecheck, bundle, lint and isolated HTTP verification are repeated for this revision. The reviewer also ran the wider CLI suite: 28,592 passed, 12 failed and 72 skipped; it attributed the 12 failures to the dev machine’s pre-push hook rejecting temporary fixture repositories. Those broader tests are not reported as green.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | ✅ Build, typecheck, focused unit tests and bundled HTTP regression |
| Windows | ⚠️ Not tested locally |
| Linux | ✅ Built bundle and the same isolated HTTP regression on dev |

### Environment

Node 22.23.1; Qwen Code 0.23.0. Tests use isolated temporary state and loopback ports.

## Risk & Scope

- Main risk or tradeoff: DELETE of an entirely absent Channel now succeeds with a current revision. Missing-config cleanup requires confirmed selected-Workspace ownership; the existing manager rechecks ownership in its mutation lane.
- Not validated / out of scope: live DingTalk transport, deployment, Channel-owned conversation cleanup and broader Workspace lifecycle changes. No background sweep or global manager shutdown is introduced. If another committed Channel also lost its configuration, existing reconciliation may still reject deletion; rebuilding partially configured shared Workers is outside this fix.
- Breaking changes / migration notes: callers should accept idempotent success where DELETE previously returned 404; authentication and revision requirements are unchanged.

## Linked Issues

Addresses #11063 (the single missing-config owner case; see Risk & Scope)
Related: #10782, #10796

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

允许显式 Workspace 级 Channel 删除在持久化配置缺失时，停止归属已确认的 Worker。配置缺失删除会拒绝未知、歧义、其他 Workspace 或未提交的运行态归属，保留 revision 校验和停止失败传播，并在目标停止后清理残留 startup 选择。当配置与运行态都不存在时，携带当前 revision 重复删除可幂等成功。配置及 startup 项都不存在时，settings 不做写入，避免误改无关的旧格式 `all` 启动配置。

## 为什么需要

此前，Channel 配置已消失时，删除直接返回 `channel_instance_not_found`，Worker 与 selection 均可能残留；重复 DELETE 无法收敛。本 PR 跟进 #10782 中的配置缺失场景；#10796 已修复的永久 Workspace 删除属于另一条路径。

## Reviewer 测试计划

### 如何验证

1. 在两个不同 Workspace 中分别启动 Channel，只移除其中一个的持久化配置，保留运行中的 Worker。
2. 使用当前 settings revision 显式删除该 Channel，确认目标 Worker 退出、selection 和 startup 项消失，同时另一 Workspace 保持原来的 Worker 进程。
3. 使用当前 revision 再次删除，确认成功且另一 Channel 不受影响。
4. 分别尝试过期 revision、归属不明或跨 Workspace 归属、Worker 停止未确认，确认如实失败、不继续持久化删除，也不影响无关运行态。
5. 确认正常删除、永久 Workspace 删除仍可用；仅查询发现配置缺失不能触发清理。

### 前后对比证据

修复前：基线 `e3d26283e63c19b17e00862addae86c2ecdd86a4` 的独立复现因 `channel_instance_not_found` 失败，尽管 Worker 归属明确。修复后：相同复现测试通过，三组定向测试共 169 项通过；完整构建、bundle、typecheck、变更 TypeScript lint 和 diff 检查通过。

同一个隔离 bundled HTTP 脚本在 macOS 与 Linux 均通过 4/4：正常删除、配置缺失删除、重复删除且另一 Workspace 保持原 PID 存活、永久 Workspace 删除后启动新 Channel。全部测试进程、端口及临时目录已清理。脚本使用真实 HTTP 路由、settings 持久化、registry、manager 和 worker group，仅 adapter supervisor 使用生成真实子进程的替身；这不是真实消息平台收发测试。

dev 上 Qwen Code 评审已完成：0 条 Critical、3 条 Suggestion、1 条 Nice to have，结论为 Comment。medium 档不执行 reverse audit，因此不代表 Approve。初次评审已采纳三项测试与文档建议。线上评审后，已将两种归属检查分别命名并共用错误构造，配置缺失错误区分拒绝原因，读取测试明确断言未停止、未持久化删除。四条行内建议已处理；foreign owner 的仅持久化清理作为契约扩展暂缓。本次修订重新执行最终定向测试、构建、typecheck、bundle、lint 与隔离 HTTP 验证。评审另运行了更广的 CLI 测试：28,592 项通过、12 项失败、72 项跳过；评审将这 12 项失败归因于 dev 机器 pre-push hook 拒绝临时测试仓库推送，不将该广泛测试结果标记为全绿。

### 测试平台

| OS | 状态 |
| :-- | :-- |
| macOS | ✅ 构建、typecheck、定向单测与 bundled HTTP 回归 |
| Windows | ⚠️ 未本地验证 |
| Linux | ✅ dev 机器构建包及同一隔离 HTTP 回归 |

### 环境

Node 22.23.1、Qwen Code 0.23.0，测试使用独立临时状态和 loopback 端口。

## 风险与范围

- 主要风险或取舍：携带当前 revision 删除完全不存在的 Channel 现在会成功。配置缺失清理要求确认 selected Workspace 的运行态归属，现有 Manager 在其 mutation lane 内再次校验。
- 未验证或范围外：真实钉钉传输、部署、Channel 自有对话清理及其他 Workspace 生命周期改动。不增加后台扫描，也不引入全局 Manager 停止操作。若另一个 committed Channel 也丢失了配置，现有 reconciliation 仍可能拒绝删除；重建配置不完整的共享 Worker 不在本次范围内。
- 行为兼容说明：调用方应接受过去返回 404 的 DELETE 现在返回幂等成功；认证和 revision 要求不变。

## 关联 Issue

处理 #11063 的单个配置缺失 owner 场景（限制见风险与范围），关联 #10782、#10796；不自动关闭 Issue。

</details>

