### PR TITLE
fix(web-shell): keep the auto-sized dialog's gutter on a phone

### DIFF
--- a/packages/web-shell/client/components/dialogs/DialogShell.test.tsx
+++ b/packages/web-shell/client/components/dialogs/DialogShell.test.tsx
@@ -187,7 +187,13 @@ describe('DialogShell', () => {
     // stays full-width and never tracks the content.
     expect(panel.className).toContain('w-max');
     expect(panel.className).not.toContain('w-full');
-    expect(panel.className).toContain('min-w-[min(100%,560px)]');
+    // The floor has to subtract the same gutter the surviving base ceiling
+    // (`max-w-[calc(100%-2rem)]`) reserves. twMerge keeps both classes, and
+    // below `sm:` a bare `min(100%,560px)` floor outranks that ceiling, so the
+    // panel would render flush to both screen edges on a phone.
+    expect(panel.className).toContain('min-w-[min(calc(100%-2rem),560px)]');
+    expect(panel.className).not.toContain('min-w-[min(100%,560px)]');
+    expect(panel.className).toContain('max-w-[calc(100%-2rem)]');
     expect(panel.className).toContain(
       'sm:max-w-[min(calc(100vw-2rem),1120px)]',
     );

--- a/packages/web-shell/client/components/dialogs/DialogShell.tsx
+++ b/packages/web-shell/client/components/dialogs/DialogShell.tsx
@@ -43,7 +43,12 @@ const sizeClass: Record<DialogSize, string> = {
   // room. `w-max` wins over DialogContent's base `w-full` through
   // tailwind-merge. The floor keeps small graphs from collapsing to a narrow
   // panel; the ceiling keeps large ones from spanning a wide monitor.
-  auto: 'w-max min-w-[min(100%,560px)] sm:max-w-[min(calc(100vw-2rem),1120px)]',
+  // The floor uses the same 2rem gutter the base ceiling
+  // (`max-w-[calc(100%-2rem)]`) reserves: twMerge keeps both classes, and
+  // below `sm:` a bare `min(100%,560px)` floor outranks that ceiling, so the
+  // panel rendered flush to both screen edges on a phone while every fixed
+  // size kept its gutter.
+  auto: 'w-max min-w-[min(calc(100%-2rem),560px)] sm:max-w-[min(calc(100vw-2rem),1120px)]',
 };
 
 const FOCUSABLE_SELECTOR = [


### PR DESCRIPTION
## What this PR does

Floors the `size="auto"` dialog at the same 1rem gutter its ceiling already reserves, so it stops rendering flush to both screen edges on a narrow viewport.

## Why it's needed

`auto` floors the panel at `min-w-[min(100%,560px)]` so a small plan graph does not collapse to a narrow column. tailwind-merge keeps that class alongside the base ceiling `max-w-[calc(100%-2rem)]` — they are different modifier groups, so neither wins the merge — and below the `sm:` breakpoint min-width takes precedence over max-width. At 390px the used width is therefore 390px against a 358px ceiling, and the Plan & tasks dialog draws its rounded, ringed panel edge-to-edge while every fixed size (sm/md/lg/xl) keeps its gutter at that same width.

Split out of #10938, where it was one small fix behind a much larger visual change. It is independent of everything else on that branch.

## Reviewer Test Plan

### How to verify

- Open a `size="auto"` dialog (Plan & tasks is the one that motivated this) at a 390px viewport. Expect a 1rem gutter on both sides, matching what `size="md"` does at the same width.
- Confirm a wide viewport is unchanged: the panel still tracks its content up to the `sm:max-w-[min(calc(100vw-2rem),1120px)]` ceiling and does not collapse to a narrow column.

### Evidence (Before & After)

Before: at 390px the panel's used width is 390px — `min-w-[min(100%,560px)]` resolves to 390px and outranks the 358px ceiling, so the panel touches both screen edges.

After: the floor resolves to 358px, the ceiling holds, and the gutter survives.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  |      ✅       |

### Environment (optional)

`client/components/dialogs/DialogShell.test.tsx` — 7/7 locally.

## Risk & Scope

- **Main risk or tradeoff:** `DialogShell` is shared, so this reaches every `size="auto"` dialog. That is the intent — the gutter is what every other size already does — but it is the reason the test now pins the new floor, the absence of the old one, and the surviving base ceiling together rather than just the new class.
- **Not validated / out of scope:** no visual capture; the change is a single Tailwind arbitrary value and is asserted on the merged class list.
- **Breaking changes / migration notes:** none.

## Linked Issues

Refs #10938.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `size="auto"` 对话框的宽度下限，改为减去它的上限本来就预留的那 1rem 边距，使它在窄视口下不再紧贴屏幕两边。

## 为什么需要

`auto` 用 `min-w-[min(100%,560px)]` 作为下限，以免小的 plan 图坍缩成窄条。tailwind-merge 会把这个类和基础上限 `max-w-[calc(100%-2rem)]` 同时保留——两者属于不同的修饰符组，谁也不会被合并掉——而在 `sm:` 断点以下，min-width 的优先级高于 max-width。于是在 390px 时实际宽度是 390px、上限是 358px，Plan & tasks 对话框会把它带圆角和描边的面板一直画到屏幕两边，而所有固定尺寸（sm/md/lg/xl）在同样宽度下都保住了边距。

从 #10938 拆出：它原本是一个小修复，却压在一个大得多的视觉改动后面，且与该分支上的其他内容互不依赖。

## 评审者验证计划

### 如何验证

- 在 390px 视口下打开一个 `size="auto"` 的对话框（促成本次修复的是 Plan & tasks）。两侧应有 1rem 边距，与同宽度下的 `size="md"` 一致。
- 确认宽视口行为不变：面板仍随内容变宽，直到 `sm:max-w-[min(calc(100vw-2rem),1120px)]` 上限，且不会坍缩成窄条。

### 证据（改前 / 改后）

改前：390px 下面板实际宽度为 390px——`min-w-[min(100%,560px)]` 解析为 390px 并压过 358px 的上限，面板贴到屏幕两边。

改后：下限解析为 358px，上限生效，边距得以保留。

### 测试环境

|    系统    |   状态    |
| :--------: | :-------: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  |    ✅     |

### 运行环境（可选）

`client/components/dialogs/DialogShell.test.tsx` —— 本地 7/7 通过。

## 风险与范围

- **主要风险或权衡：** `DialogShell` 是共享组件，因此改动会作用到每一个 `size="auto"` 对话框。这正是意图——边距本来就是其他所有尺寸的既有行为——也正因如此，测试现在同时钉住新的下限、旧下限的消失、以及幸存的基础上限，而不只是断言新类存在。
- **未验证 / 不在范围：** 没有视觉截图；本改动只是一个 Tailwind 任意值，验证方式是断言合并后的类名列表。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

Refs #10938.

</details>
