### PR TITLE
test(sdk): pin the skills entry in the transcript compactor keep-set

### DIFF
--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -9162,6 +9162,7 @@ describe('parallel subAgent text interleaving fix', () => {
           result: 'large result',
           taskPrompt: 'large prompt',
           toolCalls: [{ callId: 'child-tool' }],
+          skills: ['repo-ops'],
           executionSummary: {
             inputTokens: 100,
             outputTokens: 20,
@@ -9179,6 +9180,13 @@ describe('parallel subAgent text interleaving fix', () => {
       taskPrompt: expect.anything(),
       toolCalls: expect.anything(),
     });
+    // The keep-set is what survives compaction. This pins `skills`
+    // specifically — not the whole set — because dropping it from that list
+    // otherwise ships green and a session restored from a persisted
+    // transcript silently loses the skill list the live run recorded.
+    expect(
+      (state.blocks[1] as { rawOutput?: Record<string, unknown> }).rawOutput,
+    ).toMatchObject({ skills: ['repo-ops'] });
     expect(state.blocks[1]).not.toHaveProperty('content');
   });
 


### PR DESCRIPTION
## What this PR does

Pins `skills` in `compactTaskExecutionOutput`'s keep-set, by adding it to the existing compaction fixture and asserting it survives.

Test-only. Eight added lines, no production change.

## Why it's needed

`compactTaskExecutionOutput` keeps an allowlist of `task_execution` fields when it drops the bulky ones (`result`, `taskPrompt`, `toolCalls`). Its neighbours in that list — `executionSummary`, `tokenCount` — are already exercised by the reducer tests. `skills` was not, so removing it from the keep-set left the whole suite green while a session restored from a persisted transcript silently lost the skill list the live run recorded.

Split out of #10938, where it was unrelated to the rest of that branch.

## Reviewer Test Plan

### How to verify

- `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts` — expect 355/355.
- Mutation-check it earns its place: delete `'skills'` from the keep-set in `src/daemon/ui/transcript.ts` and re-run. Expect exactly one failure, this assertion. Restore and expect 355/355 again.

### Evidence (Before & After)

N/A — test-only, no user-visible change.

Locally on this head: 355/355 passed; with `'skills'` removed from the keep-set, 1 failed | 354 passed.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  |      ✅       |

### Environment (optional)

`packages/sdk-typescript` vitest only.

## Risk & Scope

- **Main risk or tradeoff:** none meaningful — the change adds one field to an existing fixture and one assertion beside the assertions already there.
- **Not validated / out of scope:** the other keep-set entries are still pinned only where they already were; this does not attempt to cover the whole list.
- **Breaking changes / migration notes:** none.

Worth noting for review: this was **reapplied onto current `main`** rather than carried over from the branch it was written on. That file has moved by roughly 630 lines since the branch point, so taking the whole file across would have reverted the difference. The diff here is eight insertions and no deletions.

## Linked Issues

Refs #10938.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把 `skills` 钉进 `compactTaskExecutionOutput` 的 keep-set：在既有的压缩 fixture 中加入该字段，并断言它在压缩后仍然存在。

纯测试。新增八行，无生产代码改动。

## 为什么需要

`compactTaskExecutionOutput` 在丢弃体积大的字段（`result`、`taskPrompt`、`toolCalls`）时，会保留一份 `task_execution` 字段的允许列表。该列表中它相邻的条目——`executionSummary`、`tokenCount`——已经被 reducer 测试覆盖，唯独 `skills` 没有：把它从 keep-set 中移除，整个测试套件依然全绿，而从持久化 transcript 还原的 session 会静默丢失本次运行记录下来的 skill 列表。

从 #10938 拆出：它与该分支上的其余内容无关。

## 评审者验证计划

### 如何验证

- `cd packages/sdk-typescript && npx vitest run test/unit/daemonUi.test.ts` —— 应为 355/355。
- 做变异验证以确认该断言确有价值：在 `src/daemon/ui/transcript.ts` 中删除 keep-set 里的 `'skills'` 并重跑，应恰好有一个失败，即本次新增的断言；恢复后应重新回到 355/355。

### 证据（改前 / 改后）

不适用——纯测试，无用户可见变化。

本地在此 head 上：355/355 通过；将 `'skills'` 从 keep-set 移除后，1 失败 | 354 通过。

### 测试环境

|    系统    |   状态    |
| :--------: | :-------: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  |    ✅     |

### 运行环境（可选）

仅 `packages/sdk-typescript` 的 vitest。

## 风险与范围

- **主要风险或权衡：** 基本没有——本改动只是在既有 fixture 上增加一个字段，并在既有断言旁增加一条断言。
- **未验证 / 不在范围：** keep-set 中其他条目仍只在它们原本被覆盖的地方被钉住；本 PR 不尝试覆盖整个列表。
- **破坏性变更 / 迁移说明：** 无。

供评审注意：本改动是**重新贴到当前 `main`** 上的，而不是从它最初编写的分支整份搬运过来。该文件自分支点以来已变动约 630 行，整份搬运会把这些差异回退掉。此处的 diff 是八行插入、零删除。

## 关联 Issue

Refs #10938.

</details>
