### PR TITLE
fix(core): retain local usage for background API events

### DIFF
--- a/docs/design/background-usage-accounting.md
+++ b/docs/design/background-usage-accounting.md
@@ -1,0 +1,80 @@
+# Local accounting for background API events
+
+## Problem
+
+Internal prompt IDs suppress transcript recording so auxiliary requests do not
+appear as conversation turns. The same condition currently suppresses local token
+usage persistence. Successful prompt suggestions, forked queries, speculation and
+side queries consequently disappear from the monthly usage history.
+
+Error and cancellation telemetry also lack local accounting records. Treating
+those missing records as zero usage would conflate unavailable usage with a
+reported measurement.
+
+## Success records
+
+Keep the existing usage-statistics opt-out and transcript suppression independent.
+Persist internal successful responses through the existing monthly token-usage
+writer when usage statistics are enabled.
+
+Add optional fields to version 1 records:
+
+- `feature`: `main`, `subagent`, `prompt_suggestion`, `forked_query`,
+  `speculation` or `side_query`. Recognized internal IDs take precedence over a
+  subagent name. A side-query suffix is never persisted.
+- `usageStatus`: `reported` when at least one normalized token counter is
+  positive, otherwise `unknown`. The telemetry event has already replaced missing
+  counters with zeros, so this deliberately does not infer a known zero charge.
+
+Use a supplied request-session snapshot for persistence, falling back to the
+configuration session only when no snapshot was supplied. Preserve a safe
+subagent source identifier when present; otherwise use the feature label instead
+of attributing an internal request to `main`.
+
+Legacy records without these optional fields remain readable. Validate the new
+enums and reject contradictory status/counter combinations. Summary JSON adds
+`usageCoverage` counts for `reported`, `unknown` and `legacy` success records.
+Existing numeric totals and CSV columns remain unchanged. `requests` continues to
+count accepted success rows, not HTTP attempts. Numeric zeros on unknown rows are
+compatibility placeholders; totals are not complete billing measurements.
+
+## Error and cancellation records
+
+Write these existing telemetry events to `usage-events-YYYY-MM.jsonl` in the
+existing runtime usage directory. Each record has its own schema version,
+`recordType: usage_outcome`, a generated local ID, timestamp/local date/month,
+session, model, auth type, feature, status, scope, `usageStatus: unknown` and
+literal `tokens: null`. They never enter success totals or CSV output.
+
+An API error has `scope: telemetry_event`. The current cancellation producer is
+the interaction cancellation handler and may run during tool execution; its
+record therefore has `scope: interaction`. This is not a complete ledger of
+individual HTTP attempts or background aborts. No new outcome reader or UI is
+introduced. Writes are best effort and a failed outcome sink must not prevent
+successful usage recording.
+
+## Privacy and compatibility
+
+Read event metadata through own data-property descriptors, without invoking
+accessors. Persist only bounded identity strings matching an identifier character
+allowlist, rejecting URL syntax and explicit path prefixes. Unsafe model/auth
+values become `unknown`; unsafe subagent identifiers fall back to the feature.
+This can coarsen grouping for non-identifier custom names.
+
+Do not persist prompt IDs, side-query suffixes, provider response IDs, task names,
+request/response bodies, raw error messages, or content fingerprints. Existing
+local record IDs and captured session IDs are not gateway request IDs and do not
+establish provider billing or fallback attribution.
+
+There are no changes to model selection, outbound requests, background feature
+switches, telemetry consent, or transcript visibility. No historical backfill or
+data migration is performed.
+
+## Verification
+
+Collocated logger and usage-service tests cover internal response recording,
+opt-out, unchanged transcript suppression, session snapshots, feature precedence,
+legacy reads, status consistency, identifier filtering and companion records.
+Existing stats command tests cover downstream summary/export behavior. Synthetic
+bundle checks additionally exercise real JSONL writes and an unavailable outcome
+file without making model requests.

--- a/packages/core/src/services/tokenUsageService.test.ts
+++ b/packages/core/src/services/tokenUsageService.test.ts
@@ -12,7 +12,11 @@ import type { GenerateContentResponseUsageMetadata } from '@google/genai';
 import { AuthType } from '../core/contentGenerator.js';
 import { Storage } from '../config/storage.js';
 import { makeFakeConfig } from '../test-utils/config.js';
-import { ApiResponseEvent } from '../telemetry/types.js';
+import {
+  ApiCancelEvent,
+  ApiErrorEvent,
+  ApiResponseEvent,
+} from '../telemetry/types.js';
 import { setDebugLogSession } from '../utils/debugLogger.js';
 import * as jsonl from '../utils/jsonl-utils.js';
 import {
@@ -22,6 +26,7 @@ import {
   formatTokenUsageSummaryAsCsv,
   getTokenUsageFilePath,
   queryTokenUsage,
+  recordTokenUsageOutcomeBestEffort,
   recordTokenUsageFromApiResponse,
   recordTokenUsageFromApiResponseBestEffort,
   resetTokenUsageFailureLogging,
@@ -162,6 +167,121 @@ describe('tokenUsageService', () => {
     expect(missingTimestampRecord.timestamp).toBe('2026-05-25T10:00:00.000Z');
     expect(missingTimestampRecord.localDate).toBe('2026-05-25');
     expect(missingTimestampRecord.localMonth).toBe('2026-05');
+  });
+
+  it('classifies internal usage and preserves a captured request session', () => {
+    const config = makeFakeConfig({
+      sessionId: 'config-session',
+      targetDir: path.join(tempDir, 'project'),
+    });
+    const event = createEvent(
+      'qwen-model',
+      'prompt_suggestion',
+      {
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+      },
+      { subagentName: 'Explore' },
+    );
+
+    const record = apiResponseEventToTokenUsageRecord(
+      config,
+      event,
+      'request-session',
+    );
+
+    expect(record).toMatchObject({
+      sessionId: 'request-session',
+      source: 'Explore',
+      feature: 'prompt_suggestion',
+      usageStatus: 'reported',
+    });
+
+    const internalOnly = apiResponseEventToTokenUsageRecord(
+      config,
+      createEvent('qwen-model', 'side-query:session-title', {
+        promptTokenCount: 0,
+        candidatesTokenCount: 0,
+      }),
+    );
+    expect(internalOnly).toMatchObject({
+      source: 'side_query',
+      feature: 'side_query',
+      usageStatus: 'unknown',
+    });
+  });
+
+  it('uses safe fallbacks without invoking event getters', () => {
+    const config = makeFakeConfig({
+      sessionId: 'session-1',
+      targetDir: path.join(tempDir, 'project'),
+    });
+    const event = createEvent('model-a', 'prompt-1', {
+      promptTokenCount: 0,
+      candidatesTokenCount: 0,
+    });
+    Object.defineProperties(event, {
+      model: {
+        configurable: true,
+        get: () => {
+          throw new Error('model getter invoked');
+        },
+      },
+      auth_type: {
+        configurable: true,
+        get: () => {
+          throw new Error('auth getter invoked');
+        },
+      },
+      prompt_id: {
+        configurable: true,
+        get: () => {
+          throw new Error('prompt getter invoked');
+        },
+      },
+    });
+
+    expect(apiResponseEventToTokenUsageRecord(config, event)).toMatchObject({
+      model: 'unknown',
+      authType: 'unknown',
+      source: 'main',
+      feature: 'main',
+      usageStatus: 'unknown',
+    });
+  });
+
+  it('keeps long side-query IDs private while retaining their feature', () => {
+    const config = makeFakeConfig({
+      sessionId: 'session-1',
+      targetDir: path.join(tempDir, 'project'),
+    });
+    const event = createEvent(
+      'qwen-model',
+      `side-query:${'x'.repeat(200)}`,
+      { promptTokenCount: 1 },
+      { subagentName: 'https://subagent.invalid' },
+    );
+
+    expect(apiResponseEventToTokenUsageRecord(config, event)).toMatchObject({
+      source: 'side_query',
+      feature: 'side_query',
+    });
+  });
+
+  it('omits structured fragments and embedded URLs from identity fields', () => {
+    const config = makeFakeConfig({
+      sessionId: 'session-1',
+      targetDir: path.join(tempDir, 'project'),
+    });
+    const event = createEvent('{"error":"secret"}', 'user_query', {
+      promptTokenCount: 1,
+    });
+    event.auth_type = 'provider://secret';
+
+    expect(apiResponseEventToTokenUsageRecord(config, event)).toMatchObject({
+      model: 'unknown',
+      authType: 'unknown',
+    });
   });
 
   it('persists API usage to monthly JSONL and aggregates daily totals', async () => {
@@ -655,25 +775,140 @@ describe('tokenUsageService', () => {
     expect(summary.totals.requests).toBe(1);
   });
 
-  it('exports summaries as JSON and escaped CSV', async () => {
+  it('reports usage coverage while accepting legacy rows', async () => {
+    const filePath = getTokenUsageFilePath('2026-05');
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(
+      filePath,
+      [
+        '{"schemaVersion":1,"id":"legacy","timestamp":"2026-05-25T00:00:00.000Z","localDate":"2026-05-25","localMonth":"2026-05","sessionId":"s","model":"model-a","authType":"gemini","source":"main","inputTokens":1,"outputTokens":0,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":1,"apiDurationMs":4}',
+        '{"schemaVersion":1,"id":"unknown","timestamp":"2026-05-25T00:00:00.000Z","localDate":"2026-05-25","localMonth":"2026-05","sessionId":"s","model":"model-a","authType":"gemini","source":"main","feature":"main","usageStatus":"unknown","inputTokens":0,"outputTokens":0,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":0,"apiDurationMs":4}',
+        '{"schemaVersion":1,"id":"reported","timestamp":"2026-05-25T00:00:00.000Z","localDate":"2026-05-25","localMonth":"2026-05","sessionId":"s","model":"model-a","authType":"gemini","source":"main","feature":"main","usageStatus":"reported","inputTokens":2,"outputTokens":3,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":5,"apiDurationMs":4}',
+        '{"schemaVersion":1,"id":"reported-zero","timestamp":"2026-05-25T00:00:00.000Z","localDate":"2026-05-25","localMonth":"2026-05","sessionId":"s","model":"model-a","authType":"gemini","source":"main","feature":"main","usageStatus":"reported","inputTokens":0,"outputTokens":0,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":0,"apiDurationMs":4}',
+        '{"schemaVersion":1,"id":"unknown-positive","timestamp":"2026-05-25T00:00:00.000Z","localDate":"2026-05-25","localMonth":"2026-05","sessionId":"s","model":"model-a","authType":"gemini","source":"main","feature":"main","usageStatus":"unknown","inputTokens":1,"outputTokens":0,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":1,"apiDurationMs":4}',
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const summary = await queryTokenUsage({
+      period: 'day',
+      value: '2026-05-25',
+    });
+
+    expect(summary.usageCoverage).toEqual({
+      reported: 1,
+      unknown: 1,
+      legacy: 1,
+    });
+    expect(summary.totals).toMatchObject({
+      requests: 3,
+      totalTokens: 6,
+    });
+  });
+
+  it('writes safe error and cancellation outcomes to a companion file', async () => {
     const config = makeFakeConfig({
       sessionId: 'session-1',
       targetDir: path.join(tempDir, 'project'),
     });
-    await recordTokenUsageFromApiResponse(
+    const error = new ApiErrorEvent({
+      model: 'https://provider.invalid/model',
+      authType: '/private/auth',
+      promptId: 'prompt_suggestion',
+      subagentName: 'raw subagent/path',
+      durationMs: 10,
+      errorMessage: 'do not persist this',
+      errorType: 'secret-error',
+      responseId: 'provider-response-id',
+    });
+    error['event.timestamp'] = '2026-05-25T10:00:00.000Z';
+    const cancel = new ApiCancelEvent(
+      'model-a',
+      'user_query',
+      AuthType.USE_GEMINI,
+    );
+    cancel['event.timestamp'] = '2026-05-25T11:00:00.000Z';
+
+    recordTokenUsageOutcomeBestEffort(
       config,
-      createEvent(
-        '=cmd|quoted',
-        'prompt-1',
-        {
-          promptTokenCount: 1,
-          candidatesTokenCount: 2,
-          totalTokenCount: 3,
-        },
-        {
-          authType: 'auth"quoted',
-        },
-      ),
+      error,
+      'error',
+      'request-session',
+    );
+    recordTokenUsageOutcomeBestEffort(config, cancel, 'cancelled');
+
+    const eventsPath = path.join(
+      path.dirname(getTokenUsageFilePath('2026-05')),
+      'usage-events-2026-05.jsonl',
+    );
+    const lines = await vi.waitFor(async () => {
+      const content = await readFile(eventsPath, 'utf-8');
+      const records = content.trim().split('\n');
+      expect(records).toHaveLength(2);
+      return records;
+    });
+    const errorRecord = JSON.parse(lines[0]!);
+    expect(errorRecord).toMatchObject({
+      schemaVersion: 1,
+      recordType: 'usage_outcome',
+      status: 'error',
+      scope: 'telemetry_event',
+      usageStatus: 'unknown',
+      tokens: null,
+      sessionId: 'request-session',
+      model: 'unknown',
+      authType: 'unknown',
+      feature: 'prompt_suggestion',
+      localDate: '2026-05-25',
+      localMonth: '2026-05',
+    });
+    for (const forbiddenKey of [
+      'errorMessage',
+      'errorType',
+      'responseId',
+      'subagentName',
+      'promptId',
+    ]) {
+      expect(errorRecord).not.toHaveProperty(forbiddenKey);
+    }
+    expect(JSON.stringify(errorRecord)).not.toContain('do not persist this');
+    expect(JSON.stringify(errorRecord)).not.toContain('secret-error');
+    expect(JSON.stringify(errorRecord)).not.toContain('provider-response-id');
+    expect(JSON.stringify(errorRecord)).not.toContain('raw subagent/path');
+    expect(JSON.parse(lines[1]!)).toMatchObject({
+      status: 'cancelled',
+      scope: 'interaction',
+      model: 'model-a',
+      authType: AuthType.USE_GEMINI,
+      feature: 'main',
+      sessionId: 'session-1',
+    });
+  });
+
+  it('normalizes accepted event timestamps before writing records', () => {
+    const config = makeFakeConfig({
+      sessionId: 'session-1',
+      targetDir: path.join(tempDir, 'project'),
+    });
+    const event = createEvent(
+      'model-a',
+      'user_query',
+      { promptTokenCount: 1 },
+      { timestamp: '2026-05-25T12:00:00+02:00' },
+    );
+
+    expect(apiResponseEventToTokenUsageRecord(config, event).timestamp).toBe(
+      '2026-05-25T10:00:00.000Z',
+    );
+  });
+
+  it('exports summaries as JSON and escaped CSV', async () => {
+    const filePath = getTokenUsageFilePath('2026-05');
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(
+      filePath,
+      String.raw`{"schemaVersion":1,"id":"legacy-csv","timestamp":"2026-05-25T10:00:00.000Z","localDate":"2026-05-25","localMonth":"2026-05","sessionId":"session-1","model":"=cmd|quoted","authType":"auth\"quoted","source":"main","inputTokens":1,"outputTokens":2,"cachedTokens":0,"thoughtsTokens":0,"totalTokens":3,"apiDurationMs":100}`,
+      'utf-8',
     );
 
     const json = await exportTokenUsageSummary({

--- a/packages/core/src/services/tokenUsageService.ts
+++ b/packages/core/src/services/tokenUsageService.ts
@@ -10,7 +10,11 @@ import type { Config } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import * as jsonl from '../utils/jsonl-utils.js';
-import type { ApiResponseEvent } from '../telemetry/types.js';
+import type {
+  ApiCancelEvent,
+  ApiErrorEvent,
+  ApiResponseEvent,
+} from '../telemetry/types.js';
 import { MAIN_SOURCE } from '../utils/subagentNameContext.js';
 
 const debugLogger = createDebugLogger('TOKEN_USAGE');
@@ -18,7 +22,88 @@ const USAGE_DIR_NAME = 'usage';
 const FILE_PREFIX = 'token-usage-';
 const FILE_EXTENSION = '.jsonl';
 const SCHEMA_VERSION = 1;
+const OUTCOME_SCHEMA_VERSION = 1;
 const UNKNOWN_AUTH_TYPE = 'unknown';
+const USAGE_EVENTS_FILE_PREFIX = 'usage-events-';
+const UNKNOWN_USAGE_STATUS = 'unknown';
+const SAFE_STRING_MAX_LENGTH = 128;
+
+export type TokenUsageFeature =
+  | 'main'
+  | 'subagent'
+  | 'prompt_suggestion'
+  | 'forked_query'
+  | 'speculation'
+  | 'side_query';
+export type TokenUsageStatus = 'reported' | 'unknown';
+
+const INTERNAL_FEATURES: ReadonlyMap<string, TokenUsageFeature> = new Map([
+  ['prompt_suggestion', 'prompt_suggestion'],
+  ['forked_query', 'forked_query'],
+  ['speculation', 'speculation'],
+]);
+const VALID_FEATURES: ReadonlySet<TokenUsageFeature> = new Set([
+  'main',
+  'subagent',
+  'prompt_suggestion',
+  'forked_query',
+  'speculation',
+  'side_query',
+]);
+
+function readOwnProperty(value: object, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+}
+
+function readBoundedString(value: object, key: string): string | undefined {
+  const candidate = readOwnProperty(value, key);
+  if (
+    typeof candidate !== 'string' ||
+    candidate.length === 0 ||
+    candidate.length > SAFE_STRING_MAX_LENGTH ||
+    [...candidate].some((character) => {
+      const code = character.charCodeAt(0);
+      return code < 32 || code === 127;
+    })
+  ) {
+    return undefined;
+  }
+  return candidate;
+}
+
+function readSafeIdentity(value: object, key: string): string | undefined {
+  const candidate = readBoundedString(value, key);
+  if (
+    !candidate ||
+    !/^[A-Za-z0-9._:@+/-]+$/.test(candidate) ||
+    candidate.includes('://') ||
+    /\s/.test(candidate) ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:\/\//i.test(candidate) ||
+    /^(?:[A-Za-z]:[\\/]|[\\/]|~[\\/]|\.\.?[\\/])/.test(candidate)
+  ) {
+    return undefined;
+  }
+  return candidate;
+}
+
+function getFeature(event: object): TokenUsageFeature {
+  const promptIdValue = readOwnProperty(event, 'prompt_id');
+  const promptId =
+    typeof promptIdValue === 'string' ? promptIdValue : undefined;
+  const internalFeature = promptId
+    ? (INTERNAL_FEATURES.get(promptId) ??
+      (promptId.startsWith('side-query:') ? 'side_query' : undefined))
+    : undefined;
+  if (internalFeature) return internalFeature;
+  return readBoundedString(event, 'subagent_name') ? 'subagent' : 'main';
+}
+
+function getSource(event: object, feature: TokenUsageFeature): string {
+  const subagentName = readSafeIdentity(event, 'subagent_name');
+  if (subagentName) return subagentName;
+  return feature === 'main' ? MAIN_SOURCE : feature;
+}
 
 export type TokenUsagePeriod = 'day' | 'month';
 export type TokenUsageExportFormat = 'json' | 'csv';
@@ -41,6 +126,8 @@ export interface TokenUsageRecord {
   model: string;
   authType: string;
   source: string;
+  feature?: TokenUsageFeature;
+  usageStatus?: TokenUsageStatus;
   inputTokens: number;
   outputTokens: number;
   cachedTokens: number;
@@ -70,6 +157,12 @@ export interface TokenUsageGroupSummary extends TokenUsageTotals {
   source?: string;
 }
 
+export interface TokenUsageCoverage {
+  reported: number;
+  unknown: number;
+  legacy: number;
+}
+
 export interface TokenUsageSummary {
   period: TokenUsagePeriod;
   value: string;
@@ -79,6 +172,7 @@ export interface TokenUsageSummary {
   byAuthType: TokenUsageGroupSummary[];
   byModelAndAuthType: TokenUsageGroupSummary[];
   bySource: TokenUsageGroupSummary[];
+  usageCoverage?: TokenUsageCoverage;
 }
 
 export interface TokenUsageQuery {
@@ -123,6 +217,14 @@ function getLocalDateParts(date: Date): { date: string; month: string } {
     date: `${year}-${monthNumber}-${day}`,
     month: `${year}-${monthNumber}`,
   };
+}
+
+function getSafeTimestamp(value: object): string {
+  const supplied = readBoundedString(value, 'event.timestamp');
+  if (supplied && !Number.isNaN(new Date(supplied).getTime())) {
+    return new Date(supplied).toISOString();
+  }
+  return new Date().toISOString();
 }
 
 function currentPeriodValue(period: TokenUsagePeriod): string {
@@ -206,53 +308,82 @@ function toNonNegativeInteger(value: number | undefined): number {
   return Math.trunc(value);
 }
 
-function calculateInputTokens(event: ApiResponseEvent): number {
-  const inputTokens = toNonNegativeInteger(event.input_token_count);
+function calculateInputTokens(event: object): number {
+  const inputTokens = toNonNegativeInteger(
+    readOwnNumber(event, 'input_token_count'),
+  );
   if (inputTokens > 0) {
     return inputTokens;
   }
   // When the API omits prompt tokens, cached tokens are only a lower-bound
   // proxy for input usage and can undercount the actual input.
-  return toNonNegativeInteger(event.cached_content_token_count);
+  return toNonNegativeInteger(
+    readOwnNumber(event, 'cached_content_token_count'),
+  );
 }
 
-function calculateTotalTokens(event: ApiResponseEvent): number {
-  const total = toNonNegativeInteger(event.total_token_count);
+function calculateTotalTokens(event: object): number {
+  const total = toNonNegativeInteger(readOwnNumber(event, 'total_token_count'));
   if (total > 0) {
     return total;
   }
   return (
     calculateInputTokens(event) +
-    toNonNegativeInteger(event.output_token_count) +
-    toNonNegativeInteger(event.thoughts_token_count)
+    toNonNegativeInteger(readOwnNumber(event, 'output_token_count')) +
+    toNonNegativeInteger(readOwnNumber(event, 'thoughts_token_count'))
   );
+}
+
+function readOwnNumber(value: object, key: string): number | undefined {
+  const candidate = readOwnProperty(value, key);
+  return typeof candidate === 'number' ? candidate : undefined;
+}
+
+function hasReportedUsage(event: object): boolean {
+  return [
+    'input_token_count',
+    'output_token_count',
+    'cached_content_token_count',
+    'thoughts_token_count',
+    'total_token_count',
+  ].some((key) => toNonNegativeInteger(readOwnNumber(event, key)) > 0);
 }
 
 export function apiResponseEventToTokenUsageRecord(
   config: Config,
   event: ApiResponseEvent,
+  sessionId?: string,
 ): TokenUsageRecord {
-  const timestamp = event['event.timestamp'] || new Date().toISOString();
+  const timestamp = getSafeTimestamp(event);
   const date = new Date(timestamp);
   const localParts = getLocalDateParts(
     Number.isNaN(date.getTime()) ? new Date() : date,
   );
+  const feature = getFeature(event);
   return {
     schemaVersion: SCHEMA_VERSION,
     id: randomUUID(),
     timestamp,
     localDate: localParts.date,
     localMonth: localParts.month,
-    sessionId: config.getSessionId(),
-    model: event.model || 'unknown',
-    authType: event.auth_type || UNKNOWN_AUTH_TYPE,
-    source: event.subagent_name || MAIN_SOURCE,
+    sessionId: sessionId === undefined ? config.getSessionId() : sessionId,
+    model: readSafeIdentity(event, 'model') ?? 'unknown',
+    authType: readSafeIdentity(event, 'auth_type') ?? UNKNOWN_AUTH_TYPE,
+    source: getSource(event, feature),
+    feature,
+    usageStatus: hasReportedUsage(event) ? 'reported' : UNKNOWN_USAGE_STATUS,
     inputTokens: calculateInputTokens(event),
-    outputTokens: toNonNegativeInteger(event.output_token_count),
-    cachedTokens: toNonNegativeInteger(event.cached_content_token_count),
-    thoughtsTokens: toNonNegativeInteger(event.thoughts_token_count),
+    outputTokens: toNonNegativeInteger(
+      readOwnNumber(event, 'output_token_count'),
+    ),
+    cachedTokens: toNonNegativeInteger(
+      readOwnNumber(event, 'cached_content_token_count'),
+    ),
+    thoughtsTokens: toNonNegativeInteger(
+      readOwnNumber(event, 'thoughts_token_count'),
+    ),
     totalTokens: calculateTotalTokens(event),
-    apiDurationMs: toNonNegativeInteger(event.duration_ms),
+    apiDurationMs: toNonNegativeInteger(readOwnNumber(event, 'duration_ms')),
   };
 }
 
@@ -261,6 +392,15 @@ function isTokenUsageRecord(value: unknown): value is TokenUsageRecord {
     return false;
   }
   const record = value as Partial<TokenUsageRecord>;
+  const feature = readOwnProperty(record, 'feature');
+  const usageStatus = readOwnProperty(record, 'usageStatus');
+  const hasPositiveTokens = [
+    record.inputTokens,
+    record.outputTokens,
+    record.cachedTokens,
+    record.thoughtsTokens,
+    record.totalTokens,
+  ].some((counter) => toNonNegativeInteger(counter) > 0);
   return (
     typeof record.id === 'string' &&
     typeof record.sessionId === 'string' &&
@@ -279,7 +419,13 @@ function isTokenUsageRecord(value: unknown): value is TokenUsageRecord {
     typeof record.cachedTokens === 'number' &&
     typeof record.thoughtsTokens === 'number' &&
     typeof record.totalTokens === 'number' &&
-    typeof record.apiDurationMs === 'number'
+    typeof record.apiDurationMs === 'number' &&
+    (feature === undefined ||
+      (typeof feature === 'string' &&
+        VALID_FEATURES.has(feature as TokenUsageFeature))) &&
+    (usageStatus === undefined ||
+      (usageStatus === 'reported' && hasPositiveTokens) ||
+      (usageStatus === 'unknown' && !hasPositiveTokens))
   );
 }
 
@@ -315,6 +461,11 @@ function summarizeRecords(
   const byAuthType = new Map<string, TokenUsageGroupSummary>();
   const byModelAndAuthType = new Map<string, TokenUsageGroupSummary>();
   const bySource = new Map<string, TokenUsageGroupSummary>();
+  const usageCoverage: TokenUsageCoverage = {
+    reported: 0,
+    unknown: 0,
+    legacy: 0,
+  };
 
   const getGroup = (
     map: Map<string, TokenUsageGroupSummary>,
@@ -334,6 +485,14 @@ function summarizeRecords(
   };
 
   for (const record of records) {
+    const usageStatus = readOwnProperty(record, 'usageStatus');
+    if (usageStatus === undefined) {
+      usageCoverage.legacy++;
+    } else if (usageStatus === 'reported') {
+      usageCoverage.reported++;
+    } else {
+      usageCoverage.unknown++;
+    }
     addRecordToTotals(totals, record);
     addRecordToTotals(
       getGroup(byModel, record.model, { model: record.model }),
@@ -375,15 +534,95 @@ function summarizeRecords(
     byAuthType: sortGroups(byAuthType.values()),
     byModelAndAuthType: sortGroups(byModelAndAuthType.values()),
     bySource: sortGroups(bySource.values()),
+    usageCoverage,
   };
 }
 
 export async function recordTokenUsageFromApiResponse(
   config: Config,
   event: ApiResponseEvent,
+  sessionId?: string,
 ): Promise<void> {
-  const record = apiResponseEventToTokenUsageRecord(config, event);
+  const record = apiResponseEventToTokenUsageRecord(config, event, sessionId);
   await jsonl.writeLine(getTokenUsageFilePath(record.localMonth), record);
+}
+
+type TokenUsageOutcomeStatus = 'error' | 'cancelled';
+type TokenUsageOutcomeEvent = ApiErrorEvent | ApiCancelEvent;
+interface TokenUsageOutcomeRecord {
+  schemaVersion: typeof OUTCOME_SCHEMA_VERSION;
+  recordType: 'usage_outcome';
+  id: string;
+  timestamp: string;
+  localDate: string;
+  localMonth: string;
+  sessionId: string;
+  model: string;
+  authType: string;
+  feature: TokenUsageFeature;
+  status: TokenUsageOutcomeStatus;
+  scope: 'telemetry_event' | 'interaction';
+  usageStatus: 'unknown';
+  tokens: null;
+}
+
+function getTokenUsageEventsFilePath(month: string): string {
+  return path.join(
+    path.dirname(getTokenUsageFilePath(month)),
+    `${USAGE_EVENTS_FILE_PREFIX}${month}${FILE_EXTENSION}`,
+  );
+}
+
+function createTokenUsageOutcomeRecord(
+  config: Config,
+  event: TokenUsageOutcomeEvent,
+  status: TokenUsageOutcomeStatus,
+  sessionId?: string,
+): TokenUsageOutcomeRecord {
+  const timestamp = getSafeTimestamp(event);
+  const date = new Date(timestamp);
+  const localParts = getLocalDateParts(
+    Number.isNaN(date.getTime()) ? new Date() : date,
+  );
+  return {
+    schemaVersion: OUTCOME_SCHEMA_VERSION,
+    recordType: 'usage_outcome',
+    id: randomUUID(),
+    timestamp,
+    localDate: localParts.date,
+    localMonth: localParts.month,
+    sessionId: sessionId === undefined ? config.getSessionId() : sessionId,
+    model: readSafeIdentity(event, 'model') ?? 'unknown',
+    authType: readSafeIdentity(event, 'auth_type') ?? UNKNOWN_AUTH_TYPE,
+    feature: getFeature(event),
+    status,
+    scope: status === 'error' ? 'telemetry_event' : 'interaction',
+    usageStatus: UNKNOWN_USAGE_STATUS,
+    tokens: null,
+  };
+}
+
+export function recordTokenUsageOutcomeBestEffort(
+  config: Config,
+  event: TokenUsageOutcomeEvent,
+  status: TokenUsageOutcomeStatus,
+  sessionId?: string,
+): void {
+  try {
+    const record = createTokenUsageOutcomeRecord(
+      config,
+      event,
+      status,
+      sessionId,
+    );
+    void jsonl
+      .writeLine(getTokenUsageEventsFilePath(record.localMonth), record)
+      .catch(() => {
+        debugLogger.warn('Failed to record token usage outcome.');
+      });
+  } catch {
+    debugLogger.warn('Failed to record token usage outcome.');
+  }
 }
 
 const lastLoggedTimeByCode = new Map<string, number>();
@@ -433,9 +672,10 @@ export function resetTokenUsageFailureLogging(): void {
 export function recordTokenUsageFromApiResponseBestEffort(
   config: Config,
   event: ApiResponseEvent,
+  sessionId?: string,
 ): void {
   try {
-    const record = apiResponseEventToTokenUsageRecord(config, event);
+    const record = apiResponseEventToTokenUsageRecord(config, event, sessionId);
     void jsonl
       .writeLine(getTokenUsageFilePath(record.localMonth), record)
       .catch(logTokenUsageWriteFailure);

--- a/packages/core/src/telemetry/loggers.test.ts
+++ b/packages/core/src/telemetry/loggers.test.ts
@@ -48,6 +48,7 @@ import {
 } from './constants.js';
 import {
   logApiRequest,
+  logApiCancel,
   logApiResponse,
   logStartSession,
   logSessionEnd,
@@ -82,6 +83,7 @@ import * as tokenUsageService from '../services/tokenUsageService.js';
 import { ToolCallDecision } from './tool-call-decision.js';
 import {
   ApiRequestEvent,
+  ApiCancelEvent,
   ApiResponseEvent,
   FlashFallbackEvent,
   StartSessionEvent,
@@ -128,6 +130,10 @@ describe('loggers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(
+      tokenUsageService,
+      'recordTokenUsageOutcomeBestEffort',
+    ).mockImplementation(() => undefined);
     vi.spyOn(sdk, 'isTelemetrySdkInitialized').mockReturnValue(true);
     vi.spyOn(logs, 'getLogger').mockReturnValue(mockLogger);
     vi.spyOn(uiTelemetry.uiTelemetryService, 'addEvent').mockImplementation(
@@ -761,6 +767,9 @@ describe('loggers', () => {
           }),
         }),
       );
+      expect(
+        tokenUsageService.recordTokenUsageFromApiResponseBestEffort,
+      ).toHaveBeenCalledWith(mockConfig, event, 'request-session-id');
     });
 
     it('keeps task identity local to UI telemetry', () => {
@@ -800,7 +809,7 @@ describe('loggers', () => {
       'forked_query',
       'speculation',
       'side-query:session-title',
-    ])('does not record token usage for internal prompt_id %s', (promptId) => {
+    ])('records token usage for internal prompt_id %s', (promptId) => {
       const event = new ApiResponseEvent(
         'test-response-id',
         'test-model',
@@ -817,7 +826,7 @@ describe('loggers', () => {
 
       expect(
         tokenUsageService.recordTokenUsageFromApiResponseBestEffort,
-      ).not.toHaveBeenCalled();
+      ).toHaveBeenCalledWith(mockConfig, event);
     });
 
     it('does not record token usage when usage statistics are disabled', () => {
@@ -943,6 +952,43 @@ describe('loggers', () => {
       expect(mockRecordUiTelemetryEvent).not.toHaveBeenCalled();
       expect(mockUiEvent.addEvent).toHaveBeenCalled();
     });
+  });
+
+  it('records error and cancellation outcomes only when usage statistics are enabled', () => {
+    const config = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getTelemetryEnabled: () => true,
+      getTelemetryLogPromptsEnabled: () => true,
+      getChatRecordingService: () => undefined,
+    } as unknown as Config;
+    const event = new ApiErrorEvent({
+      model: 'test-model',
+      durationMs: 100,
+      promptId: 'user_query',
+      errorMessage: 'test error',
+    });
+    const cancel = new ApiCancelEvent('test-model', 'user_query');
+
+    logApiError(config, event, 'request-session-id');
+    logApiCancel(config, cancel);
+
+    expect(
+      tokenUsageService.recordTokenUsageOutcomeBestEffort,
+    ).toHaveBeenNthCalledWith(1, config, event, 'error', 'request-session-id');
+    expect(
+      tokenUsageService.recordTokenUsageOutcomeBestEffort,
+    ).toHaveBeenNthCalledWith(2, config, cancel, 'cancelled');
+
+    const disabledConfig = {
+      ...config,
+      getUsageStatisticsEnabled: () => false,
+    } as unknown as Config;
+    logApiError(disabledConfig, event);
+    logApiCancel(disabledConfig, cancel);
+    expect(
+      tokenUsageService.recordTokenUsageOutcomeBestEffort,
+    ).toHaveBeenCalledTimes(2);
   });
 
   describe('logApiError skips chatRecordingService for internal prompt IDs', () => {

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -139,7 +139,10 @@ import type { HookCallEvent } from './types.js';
 import type { UiEvent, UiSubagentIdentity } from './uiTelemetry.js';
 import { uiTelemetryService } from './uiTelemetry.js';
 import { apiActivityTracker } from './api-activity-tracker.js';
-import { recordTokenUsageFromApiResponseBestEffort } from '../services/tokenUsageService.js';
+import {
+  recordTokenUsageFromApiResponseBestEffort,
+  recordTokenUsageOutcomeBestEffort,
+} from '../services/tokenUsageService.js';
 import { isChatRecordingSuppressed } from '../utils/chat-recording-suppression-context.js';
 import { ToolErrorType } from '../tools/tool-error.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -537,6 +540,13 @@ export function logApiError(
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent, config.getSessionId());
+  if (config.getUsageStatisticsEnabled()) {
+    if (sessionId === undefined) {
+      recordTokenUsageOutcomeBestEffort(config, event, 'error');
+    } else {
+      recordTokenUsageOutcomeBestEffort(config, event, 'error', sessionId);
+    }
+  }
   // Feed the daemon-status model-API-health charts: one model API error per
   // failed attempt, drained per live model round by the ACP MessageEmitter.
   apiActivityTracker.recordError();
@@ -584,6 +594,9 @@ export function logApiCancel(config: Config, event: ApiCancelEvent): void {
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent, config.getSessionId());
+  if (config.getUsageStatisticsEnabled()) {
+    recordTokenUsageOutcomeBestEffort(config, event, 'cancelled');
+  }
   QwenLogger.getInstance(config)?.logApiCancelEvent(event);
   if (!isTelemetrySdkInitialized()) return;
 
@@ -622,10 +635,14 @@ export function logApiResponse(
     'event.timestamp': new Date().toISOString(),
   } as UiEvent;
   uiTelemetryService.addEvent(uiEvent, config.getSessionId());
-  if (!isInternalPromptId(event.prompt_id)) {
-    if (config.getUsageStatisticsEnabled()) {
+  if (config.getUsageStatisticsEnabled()) {
+    if (sessionId === undefined) {
       recordTokenUsageFromApiResponseBestEffort(config, event);
+    } else {
+      recordTokenUsageFromApiResponseBestEffort(config, event, sessionId);
     }
+  }
+  if (!isInternalPromptId(event.prompt_id)) {
     recordUiTelemetryEventToChat(config, uiEvent);
   }
   QwenLogger.getInstance(config)?.logApiResponseEvent(event);


### PR DESCRIPTION
## What this PR does

Includes successful prompt suggestions, forked queries, speculation, and side queries in local token usage history while keeping those internal events out of conversation transcripts. Success records gain optional feature and usage-status metadata, and persistence uses the captured request session when available. Existing error and interaction-cancellation telemetry produces separate local outcome records with unknown usage and null tokens, outside success totals.

## Why it's needed

The transcript filter currently also skips local usage persistence for internal requests. A background response can report tokens yet contribute nothing to local history. Missing token counters are also normalized to zero before accounting, so zero-valued records cannot establish a measured zero charge. The added metadata distinguishes positive reported counters, unknown usage, and legacy rows without changing existing token arithmetic.

## Reviewer Test Plan

### How to verify

With usage statistics enabled, provide successful telemetry for each of the four internal features and confirm that each produces one local success row without adding a conversation turn. A supplied request-session snapshot should survive a change in the configuration session. A normal response should continue to be recorded as before.

Confirm that a response with no positive normalized token counters is marked unknown, legacy version-1 rows remain readable, and JSON summaries distinguish reported, unknown, and legacy rows. Existing CSV columns and numeric aggregation rules should remain unchanged. Contradictory status/counter combinations should be rejected when reading records.

Provide an API error and an interaction cancellation: each should produce a separate outcome with null tokens and should not increase success totals. Disable usage statistics and confirm that none of the three event types writes a new usage row. An unavailable outcome sink should not block a later success write. Synthetic content, raw errors, response IDs, prompt IDs, and side-query suffixes should not appear in accounting output; unsafe identity metadata should fall back to coarse labels without invoking getters.

### Evidence (Before & After)

N/A for visual evidence: this changes local accounting, with no TUI or transcript presentation change. Before, the existing internal-response tests explicitly expected no usage write. After, the regression tests require those writes while preserving transcript suppression.

Validated against upstream main `87270610a7993e23fd2a9c76aeecb2f4ad9e0a7d`: `npm run build`, `npm run typecheck`, and `npm run bundle` passed. The two focused core suites passed 112 tests, and the existing stats-command suite passed 39 tests (151 total). Targeted ESLint, Prettier, and `git diff --check` passed. Reproducible test commands, each run from the indicated package directory:

```sh
# packages/core
npx vitest run src/services/tokenUsageService.test.ts src/telemetry/loggers.test.ts --coverage.enabled=false
# packages/cli
npx vitest run src/ui/commands/statsCommand.test.ts --coverage.enabled=false
```

A separate synthetic built-bundle integration check produced four internal success rows, one normal reported row, one unknown-usage row, and two null-token outcome rows. An intentionally unavailable outcome sink did not prevent a seventh success row. Transcript suppression, captured sessions, opt-out, and private-marker exclusion passed. This is a script-based integration fallback, not a live provider or interactive E2E run; it made zero model and network requests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ Build, focused tests, synthetic bundle integration |
| 🪟 Windows | ⚠️ Not tested locally |
|  🐧 Linux  | ⚠️ Not tested locally |

### Environment (optional)

macOS arm64, Node.js 26.7.0, npm 11.19.0. Tests use synthetic telemetry and isolated temporary usage directories; no model requests are required.

## Risk & Scope

- Main risk or tradeoff: local totals will now include previously omitted background responses. Bounded identity filtering can coarsen grouping for custom names containing non-identifier characters. Unknown rows retain numeric zero placeholders for compatibility; totals are not complete billing measurements.
- Not validated / out of scope: live provider billing, live worker or interactive acceptance, Windows/Linux execution, complete HTTP-attempt or background-abort coverage, historical backfill, and an outcome reader/UI. Cancellation is interaction-scoped and may occur during tool execution. No changes to model selection, outbound requests, background-feature switches, or telemetry consent.
- Breaking changes / migration notes: no migration required. Version-1 success records remain readable, added record fields are optional, JSON adds usage-coverage counts, and CSV columns remain unchanged. Outcome records use a separate versioned JSONL stream and do not enter success aggregations.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 本 PR 的变更

将提示建议、分叉查询、推测请求和旁路查询的成功响应纳入本地 token 用量历史，同时继续将这些内部事件排除在会话记录之外。成功记录新增可选的功能分类和用量状态元数据，并在可用时使用请求发起时捕获的会话标识。现有的错误和交互取消遥测会生成独立的本地结果记录，其用量为未知、token 为 null，不计入成功请求汇总。

## 为什么需要

目前，会话记录的过滤条件也跳过了内部请求的本地用量持久化。后台响应即使报告了 token，也可能完全不计入本地历史。缺失的 token 计数还会在进入计量逻辑前被归一化为零，因此零值记录不能证明实际计费为零。新增元数据在保留现有 token 计算规则的同时，区分包含正数计量值的记录、用量未知的记录和旧版记录。

## 审查者测试计划

### 如何验证

开启用量统计后，为四类内部功能分别提供成功响应遥测，确认每个响应都生成一条本地成功记录，同时不新增会话轮次。传入的请求会话快照应在配置中的会话发生变化后仍然保留。普通响应应继续按原有方式记录。

确认不存在正数归一化 token 计数的响应被标为未知，旧版 version-1 记录仍可读取，JSON 汇总能区分已报告、未知和旧版记录。现有 CSV 列和数值汇总规则应保持不变。读取记录时，应拒绝用量状态与计数矛盾的记录。

提供一个 API 错误和一次交互取消：两者都应生成 token 为 null 的独立结果记录，不应增加成功请求汇总。关闭用量统计，确认成功、错误、取消这三类事件均不新增用量记录。结果记录写入位置不可用时，不应阻塞后续成功用量写入。计量输出中不应出现合成测试正文、原始错误、响应标识、提示标识或旁路查询后缀；不安全的身份元数据应回退到粗粒度标签，且不调用 getter。

### 变更前后证据

视觉证据不适用：此次修改涉及本地计量，没有 TUI 或会话展示变更。修改前，已有的内部响应测试明确要求不写入用量。修改后，回归测试要求写入这些用量，同时保留会话记录抑制行为。

已基于上游 main `87270610a7993e23fd2a9c76aeecb2f4ad9e0a7d` 完成验证：`npm run build`、`npm run typecheck` 和 `npm run bundle` 均通过。两个相关核心测试套件共通过 112 项测试，已有的 stats 命令套件通过 39 项测试，合计 151 项。相关文件的 ESLint、Prettier 和 `git diff --check` 均通过。以下命令可复现单元测试，请分别在注明的包目录执行：

```sh
# packages/core
npx vitest run src/services/tokenUsageService.test.ts src/telemetry/loggers.test.ts --coverage.enabled=false
# packages/cli
npx vitest run src/ui/commands/statsCommand.test.ts --coverage.enabled=false
```

独立的构建产物合成集成检查生成了四条内部成功记录、一条普通且已报告用量的记录、一条用量未知的记录，以及两条 token 为 null 的结果记录。故意使结果记录写入位置不可用后，第七条成功记录仍然写入。会话记录抑制、请求会话快照、关闭统计和私密标记排除均通过。这是脚本形式的集成替代验证，并非真实提供商或交互式端到端运行；模型和网络请求均为零。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 构建、相关单元测试、合成构建产物集成验证 |
| 🪟 Windows | ⚠️ 未在本地测试 |
|  🐧 Linux  | ⚠️ 未在本地测试 |

### 环境（可选）

macOS arm64，Node.js 26.7.0，npm 11.19.0。测试使用合成遥测和隔离的临时用量目录，无需模型请求。

## 风险与范围

- 主要风险或取舍：本地汇总将开始纳入此前遗漏的后台响应。对身份字段的长度和字符过滤可能使包含非标识符字符的自定义名称归入更粗的分组。未知用量记录保留数值零作为兼容占位，汇总不等于完整计费测量。
- 未验证或范围之外：真实提供商计费、真实 worker 或交互验收、Windows/Linux 执行、完整 HTTP 尝试或后台中止覆盖、历史回填，以及结果记录读取器或 UI。取消事件属于交互范围，也可能发生在工具执行期间。模型选择、出站请求、后台功能开关和遥测同意设置均无变更。
- 破坏性变更或迁移说明：无需迁移。Version-1 成功记录仍可读取，新增记录字段为可选，JSON 新增用量覆盖计数，CSV 列保持不变。结果记录使用独立版本的 JSONL 数据流，不进入成功用量汇总。

## 关联 Issue

无。

</details>
