### PR TITLE
test(e2e): split model latency from the cron fire budget in cron-interactive

### DIFF
--- a/integration-tests/interactive/cron-interactive.test.ts
+++ b/integration-tests/interactive/cron-interactive.test.ts
@@ -50,7 +50,7 @@ function makeEnv(): NodeJS.ProcessEnv {
     }
   });
 
-  it('loop fires inline in conversation', { timeout: 180_000 }, async () => {
+  it('loop fires inline in conversation', { timeout: 300_000 }, async () => {
     session = await InteractiveSession.start({
       env: makeEnv(),
       args: ['--approval-mode', 'yolo'],
@@ -60,10 +60,19 @@ function makeEnv(): NodeJS.ProcessEnv {
       'Call cron_create with expression "*/1 * * * *" and prompt "PONG7742" and recurring true. Confirm briefly.',
     );
 
+    // Wait for the tool confirmation before budgeting for the fire: the first
+    // model turn takes as long as it takes on a loaded runner, while the fire
+    // itself only needs the test-seam delay (5s) plus render slack. Folding
+    // both into one 30s budget is what made this suite flaky (#10904).
+    await session.waitForScreen(
+      (scr) => scr.includes('Scheduled'),
+      'cron_create confirmation',
+    );
+
     await session.waitForScreen(
       (scr) => scr.includes('Cron: PONG7742'),
       'cron notification "Cron: PONG7742"',
-      30_000,
+      60_000,
     );
 
     await session.idle(5000);
@@ -74,7 +83,7 @@ function makeEnv(): NodeJS.ProcessEnv {
     expect(afterPrompt).toContain('◆');
   });
 
-  it('user input takes priority over cron', { timeout: 180_000 }, async () => {
+  it('user input takes priority over cron', { timeout: 300_000 }, async () => {
     session = await InteractiveSession.start({
       env: makeEnv(),
       args: ['--approval-mode', 'yolo'],
@@ -85,9 +94,14 @@ function makeEnv(): NodeJS.ProcessEnv {
     );
 
     await session.waitForScreen(
+      (scr) => scr.includes('Scheduled'),
+      'cron_create confirmation',
+    );
+
+    await session.waitForScreen(
       (scr) => scr.includes('Cron: CRONTICK99'),
       'first cron fire "Cron: CRONTICK99"',
-      30_000,
+      60_000,
     );
 
     await session.idle(5000);
@@ -103,7 +117,7 @@ function makeEnv(): NodeJS.ProcessEnv {
 
   it(
     'error during cron turn does not kill the loop',
-    { timeout: 180_000 },
+    { timeout: 300_000 },
     async () => {
       session = await InteractiveSession.start({
         env: makeEnv(),
@@ -115,15 +129,28 @@ function makeEnv(): NodeJS.ProcessEnv {
       );
 
       await session.waitForScreen(
-        (scr) => scr.includes('FILEERR88'),
+        (scr) => scr.includes('Scheduled'),
+        'cron_create confirmation',
+      );
+
+      // FILEERR88 must show up three times before the model's cron turn is
+      // proven: once from this typed prompt echo, once from the fired cron
+      // prompt rendering, and once from the model's reply. A bare includes()
+      // would pass on the echo alone and never observe the fire. This assumes
+      // the cron notification renders the full prompt text (test 1 above
+      // relies on the same for PONG7742); if a long prompt ever gets
+      // truncated there, this count needs adjusting, not the budget.
+      await session.waitForScreen(
+        (scr) => (scr.match(/FILEERR88/g) ?? []).length >= 3,
         'model reporting FILEERR88 from cron prompt',
-        30_000,
       );
 
       await session.idle(5000);
       await session.send('Reply with exactly ALIVE99 nothing else');
+      // Same echo discipline as USERPRIORITY77 above: the marker must appear
+      // in the reply, not only in the typed prompt.
       await session.waitForScreen(
-        (scr) => scr.includes('ALIVE99'),
+        (scr) => scr.indexOf('ALIVE99') !== scr.lastIndexOf('ALIVE99'),
         'model response ALIVE99',
       );
     },

--- a/packages/core/src/tools/cron-create.test.ts
+++ b/packages/core/src/tools/cron-create.test.ts
@@ -61,6 +61,9 @@ describe('CronCreateTool', () => {
     expect(result.llmContent).toContain('Auto-expires after 7 days');
     expect(result.llmContent).toContain('Session-only');
     expect(config._scheduler.list()).toHaveLength(1);
+    // The interactive cron E2E gates on this confirmation text appearing on
+    // screen, so pin the session-only recurring shape of it here.
+    expect(result.returnDisplay).toMatch(/^Scheduled \S+ \(/);
   });
 
   it('reports a configured recurring max age in days', async () => {


### PR DESCRIPTION
## What this PR does

Addresses the budget half of #10904 (the continue-on-error signal question stays with maintainer policy there). Each of the three cron-interactive cases now waits for the scheduling confirmation first (with the harness's default 120s budget), and only then starts the clock on the cron fire itself, which gets 60s. The existing test seam auto-fires session-only jobs five seconds after creation, so once the job exists the fire is quick and 60s is generous without masking a never-fire. Case-level timeouts go from 180s to 300s so the longer wait chain still fits on a slow runner. As a side effect the next failure is self-diagnosing: no confirmation line on screen means model latency, a `[durable]` suffix means the model left the session-only path the seam covers.

## Why it's needed

The old single 30s wait after sending the prompt folded two very different clocks into one budget: the model's first-turn latency (unbounded on a loaded runner) and the actual cron fire latency. The 09-03 dispatch run's screen dump settles it: at timeout the spinner still shows the first turn in progress (28s, no tool result rendered), so the job had not been created and no cron behavior was being measured. That is what produced the intermittent first-fire timeouts on the nightly lane.

## Reviewer Test Plan

### How to verify

Read the failing run's screen dump (https://github.com/QwenLM/qwen-code/actions/runs/33702961416, job cron-interactive E2E) next to the new wait chain: the confirmation wait absorbs model latency, the fire wait only has to cover the seam delay plus render. I could not execute this suite locally (the interactive legs need model credentials this environment lacks), so verification here is static: prettier is clean on the changed file, the wait budgets and anchors were checked against the harness defaults, and the nightly lane itself is the real test bed.

### Evidence (Before & After)

N/A (test-only change, no UI surface). The failure evidence lives in the linked run log.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

⚠️ prettier verified locally; the suite itself needs CI (model credentials).

### Environment (optional)

N/A

## Risk & Scope

- Main risk or tradeoff: a genuinely broken cron path now takes longer to report (up to the 300s case cap). Acceptable for a nightly-only lane.
- Not validated / out of scope: the suite was not executed locally; the `continue-on-error` visibility half of #10904 is left to maintainer policy.
- Breaking changes / migration notes: none.

