### PR TITLE
fix(docs): correct DaemonSessionProvider path in architecture diagram

### DIFF
--- a/docs/developers/daemon/01-architecture.md
+++ b/docs/developers/daemon/01-architecture.md
@@ -98,7 +98,7 @@ flowchart TB
     end
 
     subgraph adapters["Adapters"]
-        WUIP["web-shell/client/daemon/<br/>DaemonSessionProvider.tsx"]
+        WUIP["web-shell/client/daemon/session/<br/>DaemonSessionProvider.tsx"]
         TUIA["cli/src/ui/daemon/<br/>daemon-tui-adapter.ts"]
         CHB["channels/base/<br/>DaemonChannelBridge.ts"]
         DT["channels/dingtalk"]


### PR DESCRIPTION
## What this PR does

Corrects one node label in the Mermaid package map in `docs/developers/daemon/01-architecture.md`: the daemon session provider is shown one directory too high, so the label gains the `session/` segment it has on disk.

Docs-only, one line.

## Why it's needed

The package map is the first page an integrator reads, and a wrong path sends them to a directory that does not contain the file. The same folder already spells the path correctly — `14-cli-tui-adapter.md:193` reads `packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx` — so the diagram was the odd one out, and a reader who trusts the diagram over the prose ends up in the wrong place.

The two other doc regressions raised in the #9812 review are already gone from `main` and are deliberately not touched here: `web-ui.md` no longer exists and nothing links to it, and the `ACPAdapter` paragraph at `14-cli-tui-adapter.md:147` was rewritten to describe the retirement rather than the removed `postMessage` path.

Scope note: `docs/design/` and `docs/plans/` still contain `packages/webui` paths, and they stay. Those are dated design records describing the tree as it was when they were written; rewriting their paths would falsify the record. Only living documentation under `docs/developers/` is corrected, and a scan of `docs/developers`, `docs/users` and `README.md` finds no remaining `packages/webui` or `@qwen-code/webui` reference.

## Reviewer Test Plan

### How to verify

- Confirm the target exists at the new path and not the old one: `git ls-files 'packages/web-shell/client/daemon/**/DaemonSessionProvider.tsx'` returns `packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx`.
- Confirm the diagram now agrees with its neighbour: `git grep -n 'DaemonSessionProvider.tsx' docs/developers/daemon/` shows the same `daemon/session/` segment in `01-architecture.md` and `14-cli-tui-adapter.md`.
- Optional, if you want the whole diagram checked rather than the one edited node: every other path in that `flowchart TB` block also resolves on `main` — `serve/`, `acp-bridge/src/`, `core/src/tools/`, `sdk-typescript/src/daemon/`, `channels/base/src/DaemonChannelBridge.ts`, `vscode-ide-companion/src/services/daemonIdeConnection.ts`. The subgraph labels give the package and the nodes give the file, so the shorter forms are the diagram's convention, not further staleness.

### Evidence (Before & After)

N/A — docs-only, no user-visible or runtime surface.

### Tested on

|     OS     |    Status     |
| :--------: | :-----------: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  |      ✅       |

### Environment (optional)

N/A — no build or test run; the diff contains no executable code. Mermaid renders in GitHub's Markdown preview unchanged apart from the label text.

## Risk & Scope

- **Main risk or tradeoff:** the path can go stale again if the provider moves. Nothing in CI checks paths inside Mermaid labels, so this is a manual correction that a future move would silently break — the same way it broke here.
- **Not validated / out of scope:** the historical `packages/webui` paths in `docs/design/` and `docs/plans/`, left intact on purpose (see above). No behaviour, no code.
- **Breaking changes / migration notes:** none.

## Linked Issues

Relates to #11076. Follows the doc regressions raised in the #9812 review.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修正 `docs/developers/daemon/01-architecture.md` 中 Mermaid 包结构图里的一个节点标签：daemon session provider 的路径少了一层，补上磁盘上实际存在的 `session/`。

纯文档，一行。

## 为什么需要

这张包结构图是接入方读到的第一页，路径写错会把人指向一个并不包含该文件的目录。同一个目录下的文档其实已经写对了——`14-cli-tui-adapter.md:193` 写的是 `packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx`——所以出错的只有这张图；读者若更相信图而不是正文，就会找错地方。

#9812 评审中提出的另外两处文档回归在 `main` 上已经不存在，这里刻意不动：`web-ui.md` 已被删除且无任何链接指向它；`14-cli-tui-adapter.md:147` 的 `ACPAdapter` 段落已改写为描述该路径的退役，而不是描述已被移除的 `postMessage` 机制。

范围说明：`docs/design/` 与 `docs/plans/` 中仍存在 `packages/webui` 路径，且保持不动。那些是带日期的设计记录，描述的是撰写当时的代码树，改写其路径等于篡改记录。这里只修正 `docs/developers/` 下的活文档；对 `docs/developers`、`docs/users` 与 `README.md` 的扫描显示已无任何 `packages/webui` 或 `@qwen-code/webui` 引用。

## 评审者验证计划

### 如何验证

- 确认目标文件在新路径而非旧路径：`git ls-files 'packages/web-shell/client/daemon/**/DaemonSessionProvider.tsx'` 返回 `packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx`。
- 确认该图与同目录文档一致：`git grep -n 'DaemonSessionProvider.tsx' docs/developers/daemon/` 显示 `01-architecture.md` 与 `14-cli-tui-adapter.md` 使用相同的 `daemon/session/` 层级。
- 可选，若想核查整张图而不只是被改的这个节点：该 `flowchart TB` 块中其余路径在 `main` 上均可解析——`serve/`、`acp-bridge/src/`、`core/src/tools/`、`sdk-typescript/src/daemon/`、`channels/base/src/DaemonChannelBridge.ts`、`vscode-ide-companion/src/services/daemonIdeConnection.ts`。subgraph 标签给出包名、节点给出文件名，因此那些较短的写法是这张图的表达约定，不是新的过期路径。

### 证据（改前 / 改后）

不适用——纯文档，无用户可见行为与运行时面。

### 测试环境

|    系统    |   状态    |
| :--------: | :-------: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  |    ✅     |

### 运行环境（可选）

不适用——未执行构建或测试；diff 中不含可执行代码。除标签文本外，Mermaid 在 GitHub Markdown 预览中的渲染不变。

## 风险与范围

- **主要风险或权衡：** 若该 provider 再次移动，路径会再次过期。CI 不检查 Mermaid 标签内的路径，因此这是一处人工修正，将来的移动同样会悄悄破坏它——正如这次发生的一样。
- **未验证 / 不在范围：** `docs/design/` 与 `docs/plans/` 中的历史 `packages/webui` 路径，刻意保留（见上）。无行为改动、无代码改动。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

Relates to #11076。承接 #9812 评审中提出的文档回归。

</details>
