### PR TITLE
test(web-shell): stop the pagination scroll test racing the auto-scroll driver

### DIFF
--- a/packages/web-shell/client/components/MessageList.dom.test.tsx
+++ b/packages/web-shell/client/components/MessageList.dom.test.tsx
@@ -529,6 +529,26 @@ const waitForFrames = async (predicate: () => boolean) => {
     await nextFrame();
   }
 };
+// `handleScroll` only paginates while the reader is at the top
+// (MessageList.tsx:4862, `curr <= LOAD_OLDER_HISTORY_THRESHOLD_PX`), and the
+// auto-scroll driver keeps snapping the container back to the bottom for as
+// long as it is following (MessageList.tsx:5542 -> 4123). jsdom stores
+// `scrollTop` rather than recomputing it, so a single commit landing after the
+// one-frame `scrollCooldown` releases (4119/4148) parks the list at the bottom
+// and silently swallows every later scroll dispatch — and because that position
+// reads back as "near bottom", it re-arms the driver, so the state absorbs
+// instead of recovering. Whether the cooldown has released by then is a race
+// between jsdom's ~16.7ms rAF interval and React `act`'s macrotask yield, which
+// an idle host wins and a contended one (load 218-270) loses deterministically.
+// Re-assert the reader's position inside the same `act` as the dispatch so no
+// commit can slip a re-follow in between.
+const dispatchTopScroll = async (list: HTMLElement) => {
+  await act(async () => {
+    list.scrollTop = 0;
+    list.dispatchEvent(new Event('scroll'));
+    await Promise.resolve();
+  });
+};
 const mockMessageListWidth = (width: number) =>
   vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
     width,
@@ -1417,8 +1437,6 @@ describe('MessageList — turn collapse (DOM)', () => {
       hasOlderHistory: true,
       onLoadOlderHistory,
     });
-    const waitForLoadCount = (count: number) =>
-      waitForFrames(() => onLoadOlderHistory.mock.calls.length >= count);
     const list = c.querySelector(
       '[data-web-shell-message-list]',
     ) as HTMLElement;
@@ -1427,13 +1445,34 @@ describe('MessageList — turn collapse (DOM)', () => {
       writable: true,
       value: 0,
     });
+    // Re-drives rather than only ticking frames: when a commit has parked the
+    // list at the bottom, the dispatch meant to start this page never reached
+    // `loadOlderHistory`, and no number of frames recovers it. Idempotent by
+    // construction — `loadOlderHistory` rejects a duplicate at its own
+    // in-flight guard (MessageList.tsx:4596), and this page's promise stays
+    // pending until the test calls `resolveLoad()`, so re-driving cannot
+    // inflate the exact counts asserted below. Exhaustion throws naming the
+    // position that caused it, instead of falling through to an assertion that
+    // reads like a product bug.
+    const waitForLoadCount = async (count: number) => {
+      const deadline = Date.now() + FLUSH_DEADLINE_MS;
+      while (onLoadOlderHistory.mock.calls.length < count) {
+        await dispatchTopScroll(list);
+        if (onLoadOlderHistory.mock.calls.length >= count) return;
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `waitForLoadCount(${count}) exhausted ${FLUSH_DEADLINE_MS}ms at ` +
+              `${onLoadOlderHistory.mock.calls.length} call(s), ` +
+              `scrollTop=${list.scrollTop}`,
+          );
+        }
+        await nextFrame();
+      }
+    };
 
     try {
       // Page 1 completes the split turn's head: the keep-open expands it.
-      await act(async () => {
-        list.dispatchEvent(new Event('scroll'));
-        await Promise.resolve();
-      });
+      await dispatchTopScroll(list);
       rerenderMessages(c, completed, {
         hasOlderHistory: true,
         onLoadOlderHistory,
@@ -1447,10 +1486,7 @@ describe('MessageList — turn collapse (DOM)', () => {
       expect(has(c, 't1')).toBe(true);
 
       // Page 2 anchors on the now-visible t1 row while the fetch is in flight.
-      await act(async () => {
-        list.dispatchEvent(new Event('scroll'));
-        await Promise.resolve();
-      });
+      await dispatchTopScroll(list);
       await waitForLoadCount(2);
       expect(onLoadOlderHistory).toHaveBeenCalledTimes(2);
 
@@ -1469,10 +1505,7 @@ describe('MessageList — turn collapse (DOM)', () => {
       expect(isCollapsed(c, 't1')).toBe(true);
 
       // ...and pagination is not stuck: a third load still fires.
-      await act(async () => {
-        list.dispatchEvent(new Event('scroll'));
-        await Promise.resolve();
-      });
+      await dispatchTopScroll(list);
       await waitForLoadCount(3);
       expect(onLoadOlderHistory).toHaveBeenCalledTimes(3);
 
@@ -1489,14 +1522,10 @@ describe('MessageList — turn collapse (DOM)', () => {
       await nextFrame();
       await nextFrame();
       // ...page 4 then completes that turn's head while its tail is already
-      // on screen, so it stays expanded.
-      // Re-top the container: re-renders snap it to the bottom while
-      // following; the scroll event must start near the top to trigger.
-      list.scrollTop = 0;
-      await act(async () => {
-        list.dispatchEvent(new Event('scroll'));
-        await Promise.resolve();
-      });
+      // on screen, so it stays expanded. This dispatch already re-topped the
+      // container before the other three did; `dispatchTopScroll` is that
+      // workaround promoted to the only way this test scrolls.
+      await dispatchTopScroll(list);
       await waitForLoadCount(4);
       expect(onLoadOlderHistory).toHaveBeenCalledTimes(4);
       rerenderMessages(


### PR DESCRIPTION
## What this PR does

Makes one web-shell pagination test stop depending on a macrotask-ordering race. It adds a file-scoped `dispatchTopScroll(list)` helper that re-asserts `scrollTop = 0` inside the same `act` as the scroll dispatch, routes the four dispatches in `drops the anchor instead of re-expanding when the user collapsed the anchored turn` through it, and turns that test's `waitForLoadCount` from a frame-ticker into a re-driver that throws on exhaustion instead of falling through to a misleading assertion.

## Why it's needed

That case has been red on the shared `ecs-qwen` pool with `expected "spy" to be called 2 times, but got 1 times` — three attempts out of three, on three runners and three branches, **`main` included**:

| run | runner | branch |
| --- | --- | --- |
| [33947916462](https://github.com/QwenLM/qwen-code/actions/runs/33947916462) | `ecs-qwen-hk3-17` | **main** |
| [33952837177](https://github.com/QwenLM/qwen-code/actions/runs/33952837177/job/101270751814) | `ecs-qwen-hk5-2` | #11080 (a CI-scripts-only diff) |
| [33952335901](https://github.com/QwenLM/qwen-code/actions/runs/33952335901) | `ecs-qwen-hk5-22` | `fix/auto-dialog-gutter` |

**It is not a budget that is too short, so raising one cannot fix it.** The chain:

1. `handleScroll` only paginates while the reader is at the top — `MessageList.tsx:4862`, `curr <= LOAD_OLDER_HISTORY_THRESHOLD_PX` (160).
2. The auto-scroll driver snaps the container to the bottom while it is following — `5542` → `4123`, `el.scrollTop = el.scrollHeight`.
3. jsdom *stores* `scrollTop` rather than recomputing it, so that write sticks.
4. The only thing holding the driver off is `scrollCooldown`, whose lifetime is a single `requestAnimationFrame` — `4119` sets it, `4148` releases it.
5. `shouldFollow.current` is never set false in this case: page 1's `handleScroll` returns at the cooldown guard (`4866`→`4868`) before reaching the rules that would clear it, and `loadOlderHistory` only sets `followPausedByUserRef` (`4677`), not `setShouldFollow(false)`.

So one commit landing after that single frame releases parks the list at the bottom. That position then reads back as near-bottom (`distanceFromBottom = 1200 - 1200 - 600 = -600`), which re-arms the driver — **the state absorbs instead of recovering**, and every later dispatch is swallowed at step 1. `waitForFrames` only ticks rAF; it never re-tops or re-dispatches, so its predicate can never become true.

The CI log records exactly that: `31085ms` across `retry x2` is ~10.36s per attempt, i.e. the 10s ECS `FLUSH_DEADLINE_MS` burned in full and then a silent return, with the failure reported by the following `expect` — which is why it reads like a product bug rather than an exhausted wait.

Whether the cooldown has released is a race between jsdom's ~16.7ms rAF interval and React `act`'s macrotask yield (`enqueueTask` → `setImmediate`/`MessageChannel`). An idle host yields in well under a frame and passes; a host at load 218–270 yields in tens to hundreds of milliseconds and loses **deterministically** — which is why all nine attempts failed identically instead of flaking.

The test already knew about this. Its fourth page carried `list.scrollTop = 0;` under the comment *"Re-top the container: re-renders snap it to the bottom while following; the scroll event must start near the top to trigger."* Pages 2 and 3 did not. This promotes that workaround to all four.

**The budget axis has already been tried twice, and escalated.** This case was introduced by `3ca906ba7f` (#10086) on 2026-08-27. Since then two dedicated hardening passes touched it, both along the "give it more room" axis:

| date | commit | what it changed here |
| --- | --- | --- |
| 2026-08-31 | `be5f00eb80` (#10615) *test: harden release timing-sensitive waits* | added four bare `await nextFrame()` calls — the entire diff to this file |
| 2026-09-03 | `38fae41ddc` (#10842) *fix(release): stop one flaky test from failing a stable release* | replaced `waitForLoadCount`'s fixed **32-frame** budget with the wall-clock `waitForFrames` + `FLUSH_DEADLINE_MS` (10s on `ecs-qwen-*`, 4s elsewhere), reasoning *"A fixed frame budget expires early on a loaded CI host… Poll frames against a wall-clock deadline instead, so the wait stretches with the machine rather than with a frame count."* |

Four extra frames, then thirty-two, then a ten-second machine-adaptive wall clock — and on 2026-09-05 the case still fails nine attempts out of nine with the identical assertion, `main` included. #10842's own reasoning was correct about frames versus wall clock; it just was not the axis this failure lives on. That is the evidence for the claim at the top of this section, that no budget fixes it — and it is why this PR changes ordering instead of a number.

## Reviewer Test Plan

### How to verify

The race is reproducible on an idle machine by inserting one macrotask delay before the page-1 re-render commit, which is what contention does naturally. In `drops the anchor instead of re-expanding…`, immediately before `rerenderMessages(c, completed, {`:

```ts
await new Promise((resolveDelay) => setTimeout(resolveDelay, 60));
```

Then `cd packages/web-shell && npx vitest run --config vitest.config.ts client/components/MessageList.dom.test.tsx`.

Measured on this branch, same machine, same command:

| injected delay | `origin/main` version | this PR |
| --- | --- | --- |
| none | 163 passed | 163 passed |
| 10ms | 163 passed | — |
| 20ms | **1 failed** | — |
| 60ms | **1 failed** — `expected "spy" to be called 2 times, but got 1 times` | **163 passed** |
| 200ms | — | **163 passed** |

The threshold sits between 10ms and 20ms, i.e. on jsdom's ~16.7ms frame interval. That is the mechanism, not a tuning artifact — and it is why the fix is ordering rather than a larger number.

No assertion is weakened. The exact `toHaveBeenCalledTimes(2/3/4)` counts stay, and re-driving cannot inflate them: `loadOlderHistory` rejects a duplicate at its own in-flight guard (`MessageList.tsx:4596`), and the page's promise stays pending until the test calls `resolveLoad()`. `FLUSH_DEADLINE_MS` is untouched.

No cost on a healthy host either — the `while` condition is false on entry, so the loop body never runs:

```
origin/main:  ✓ … drops the anchor instead of re-expanding …  112ms
this PR:      ✓ … drops the anchor instead of re-expanding …  113ms
```

Full package, after `npm run build` for `acp-bridge`, `sdk-typescript` and `web-shell`:

```
 Test Files  266 passed (266)
      Tests  6013 passed (6013)
```

`prettier --check`, `eslint`, and `npm run typecheck --workspace=packages/web-shell` all clean.

Exhaustion is now diagnosable: instead of an assertion that reads like a product bug, `waitForLoadCount` throws `waitForLoadCount(2) exhausted 10000ms at 1 call(s), scrollTop=1200` — naming the position that swallowed the trigger.

### Evidence (Before & After)

N/A — no user-visible surface. Test output above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Verified on macOS against the real Linux CI logs. The mechanism is jsdom + React `act` scheduling, not host-specific, and the reproduction above does not need a contended host — which is the point of it. Linux and Windows legs will confirm through this PR's own CI.

### Environment (optional)

Unit tests only, in a local `npm ci` checkout. `packages/acp-bridge`, `packages/sdk-typescript` and `packages/web-shell` need `npm run build` first, or `build-artifact.test.ts` fails on a missing `dist/` — unrelated to this change, and the reason the full-package run above is quoted post-build. No daemon, sandbox or browser involved.

## Risk & Scope

- **Main risk or tradeoff:** `dispatchTopScroll` makes the test re-assert a precondition it previously left to chance, so the case now exercises "the reader is at the top and scrolls" rather than "the reader happens still to be at the top". That is a slightly narrower scenario, and it is the scenario the four `toHaveBeenCalledTimes` assertions were always about. The sharper cost is what it stops covering: re-topping before every dispatch is exactly what removes "a scroll event arrives while the container is wherever the auto-scroll driver left it" — the real-browser contention the product-side note below describes. After this PR nothing in the file covers pagination-versus-driver ordering, so that fragility has no regression net either. Defensible for a test whose subject is turn-collapse anchoring, but it is a real reduction in coverage, not a free win. The offsetting risk — that re-driving could mask a genuine failure to trigger — is bounded by the condition-checked loop, the exact-count assertions, and the in-flight guard at `MessageList.tsx:4596`; exhaustion throws with the `scrollTop` that caused it rather than passing.
- **Not validated / out of scope:** **headroom under real contention is reasoned about, not measured.** The table above injects a delay on an otherwise idle host, which pins the mechanism but says nothing about a box at load 218–270. `FLUSH_DEADLINE_MS` is `10_000` on `ecs-qwen-*` and only `4_000` everywhere else, and each re-drive iteration costs one `act` plus one `nextFrame()`, so under the very contention described the iterations that fit inside the deadline shrink by the same factor as the frames do. What makes me expect the first iteration to land regardless of load is that `handleScroll` is synchronous and `loadOlderHistory` has no `await` before it calls `onLoadOlderHistory` — so re-topping makes the condition *reachable* on the first drive rather than merely retrying an unreachable one, and the loop should exit without consuming budget at all. That is an argument from the code path, not a measurement on a saturated host; this PR's own Linux CI run is the first real evidence either way. Also out of scope: 36 other bare `dispatchEvent(new Event('scroll'))` sites remain in this file (37 total, one is inside the new helper). Single-load cases are safe today because the cooldown has not released yet, but any case sequencing two or more loads carries the same hazard — the near-neighbour clusters are `1615/1628/1650`, `1734/1755`, `1824/1840/1864`, `2738/2752`, `5072/5073`, `5237/5246`, `5294/5308`. I have not confirmed per site whether each actually sequences two loads, and none is currently red, so sweeping all 36 would bury a one-mechanism fix. Also out of scope: the product-side fragility this exposed — `loadOlderHistory` sets `followPausedByUserRef.current = true` (`4677`) but never `setShouldFollow(false)`, so across the whole pagination window the driver's condition at `5535-5539` stays true on `shouldFollow.current` alone, held off only by that one-frame cooldown. In a real browser the anchor restore (`4320-4328`, which writes `current.scrollTop`) and the auto-scroll driver contend inside the same frame window, decided by rAF registration order. Changing that is a behaviour change needing its own reasoning and regression pass; it should not ride in on a CI red. It deserves its own issue, and given the coverage loss in the first bullet, that issue is now the only thing standing between this fragility and total silence — worth linking from `## Linked Issues` once filed.
- **Breaking changes / migration notes:** none. Test-only; no product code, no public API, no config.

## Linked Issues

Non-closing references; this PR resolves none of them.

- #10490 — parent tracker for contention-driven CI failures; this is one concrete mechanism under it.
- #10892 — `vi.waitFor` budgets. A **different** mechanism: this file has zero `vi.waitFor` calls and uses a hand-rolled poller that already had the fleet-sized budget #10892 proposes. Commented there with this case as a counterexample to "just raise the budget".
- #10879 — the pool over-capacity that made the race lose deterministically. Fixing it would hide this bug rather than fix it.
- #11103 — the sibling change for the other mechanism in the same thirteen-run sample (starved worker RPC exiting an all-green suite non-zero).

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 web-shell 的一个分页测试不再依赖宏任务顺序竞态。新增一个文件作用域的 `dispatchTopScroll(list)` helper，在与 scroll dispatch 同一个 `act` 内重新断言 `scrollTop = 0`；把 `drops the anchor instead of re-expanding when the user collapsed the anchored turn` 里的四处 dispatch 都改为经过它；并把该测试的 `waitForLoadCount` 从「只 tick 帧」改成「重新驱动」，在等待耗尽时抛错，而不是继续往下走到一条会误导人的断言。

## 为什么需要

这个用例在共享的 `ecs-qwen` 池上一直以 `expected "spy" to be called 2 times, but got 1 times` 变红——三次尝试全挂，跨三个 runner、三个分支，**包括 `main`**：run 33947916462（`ecs-qwen-hk3-17`，main）、33952837177（`ecs-qwen-hk5-2`，#11080，一个只改 CI 脚本的 diff）、33952335901（`ecs-qwen-hk5-22`，`fix/auto-dialog-gutter`）。

**这不是预算太短的问题，所以调大预算修不了它。** 链路如下：

1. `handleScroll` 只在阅读者位于顶部时才分页——`MessageList.tsx:4862`，`curr <= LOAD_OLDER_HISTORY_THRESHOLD_PX`（160）。
2. 自动滚动驱动在跟随状态下会把容器拍到底部——`5542` → `4123`，`el.scrollTop = el.scrollHeight`。
3. jsdom 是**存储** `scrollTop` 而不是重新计算，所以这次写入会粘住。
4. 唯一能拦住驱动器的是 `scrollCooldown`，而它的寿命只有一个 `requestAnimationFrame`——`4119` 置位，`4148` 释放。
5. 本用例中 `shouldFollow.current` 从未被置为 false：page 1 的 `handleScroll` 在 cooldown 护栏处（`4866`→`4868`）就提前 return，根本没走到会清除它的规则；而 `loadOlderHistory` 只设 `followPausedByUserRef`（`4677`），不设 `setShouldFollow(false)`。

于是只要有一次提交落在这一帧释放之后，列表就被停在底部。而这个位置回读时又表现为「接近底部」（`distanceFromBottom = 1200 - 1200 - 600 = -600`），从而重新武装驱动器——**状态是吸收的，不会自行恢复**，之后每一次 dispatch 都在第 1 步被吞掉。`waitForFrames` 只 tick rAF，从不重新置顶、也从不重发事件，所以它的 predicate 永远不可能变真。

CI 日志精确记录了这一点：`retry x2` 下的 `31085ms` 折合每次尝试约 10.36 秒，也就是 10 秒的 ECS `FLUSH_DEADLINE_MS` 被烧满后静默返回，失败由后面那行 `expect` 报出——这正是它读起来像产品 bug 而不像等待耗尽的原因。

cooldown 有没有释放，取决于 jsdom 约 16.7ms 的 rAF 周期与 React `act` 的宏任务让出（`enqueueTask` → `setImmediate`/`MessageChannel`）之间的竞速。空闲主机的让出远小于一帧，因此通过；load 218–270 的主机让出是几十到几百毫秒，因此**确定性**地输——这也解释了为什么九次尝试以完全相同的方式失败，而不是表现为偶发 flake。

这个测试其实早就知道这件事。它的第四页带着 `list.scrollTop = 0;`，注释写着「Re-top the container: re-renders snap it to the bottom while following; the scroll event must start near the top to trigger.」而第 2、3 页没有。本 PR 把这个 workaround 提升到全部四页。

**「调大预算」这条路已经被走过两次，而且是逐级加码的。** 该用例由 `3ca906ba7f`（#10086）于 2026-08-27 引入。此后有两次专门的加固改动碰过它，两次都走在「给它更多余量」这条轴上：2026-08-31 的 `be5f00eb80`（#10615，*test: harden release timing-sensitive waits*）对该文件的全部改动就是加了四个裸的 `await nextFrame()`；2026-09-03 的 `38fae41ddc`（#10842，*fix(release): stop one flaky test from failing a stable release*）把 `waitForLoadCount` 原本**固定 32 帧**的预算换成墙钟式的 `waitForFrames` + `FLUSH_DEADLINE_MS`（`ecs-qwen-*` 上 10 秒，其他地方 4 秒），其理由写的是「固定帧预算在负载高的 CI 主机上会提前耗尽……改为按墙钟 deadline 轮询帧，让等待随机器伸缩而不是随帧数伸缩」。

先是多给 4 帧，然后是 32 帧，然后是 10 秒的机器自适应墙钟——而到 2026-09-05，这个用例仍然以完全相同的断言九次尝试全挂，包括 `main`。#10842 关于「帧 vs 墙钟」的推理本身是对的，只是这个失败不在那条轴上。这正是本节开头那个判断（任何预算都修不了它）的证据，也是本 PR 改顺序而不改数字的原因。

## 评审测试计划

### 如何验证

这个竞态在空闲机器上就能复现：在 page-1 的 re-render 提交之前插入一个宏任务延迟即可，而这正是争抢 naturally 会造成的效果。在 `drops the anchor instead of re-expanding…` 里，紧挨 `rerenderMessages(c, completed, {` 之前加入 `await new Promise((resolveDelay) => setTimeout(resolveDelay, 60));`，然后 `cd packages/web-shell && npx vitest run --config vitest.config.ts client/components/MessageList.dom.test.tsx`。

在同一台机器、同一条命令下测得：不注入延迟时两版都是 163 passed；注入 10ms 时 `origin/main` 版本 163 passed；注入 20ms 时 `origin/main` 版本 1 failed；注入 60ms 时 `origin/main` 版本 1 failed（`expected "spy" to be called 2 times, but got 1 times`），而本 PR 版本 163 passed；注入 200ms 时本 PR 版本仍 163 passed。

阈值落在 10ms 与 20ms 之间，也就是 jsdom 约 16.7ms 的帧周期上。这就是机制本身，不是调参调出来的结果——也正因如此，修法是顺序，而不是更大的数字。

没有弱化任何断言。精确的 `toHaveBeenCalledTimes(2/3/4)` 计数原样保留，而重新驱动不会把计数抬高：`loadOlderHistory` 会在自己的 in-flight 护栏处（`MessageList.tsx:4596`）拒绝重复调用，且该页的 promise 一直保持 pending 直到测试自己调用 `resolveLoad()`。`FLUSH_DEADLINE_MS` 一个字节都没改。

健康主机上也没有额外开销——`while` 的条件在入口处就为假，循环体一次都不执行：`origin/main` 该用例 112ms，本 PR 113ms。

整包测试（先对 `acp-bridge`、`sdk-typescript`、`web-shell` 执行 `npm run build`）：266 个测试文件全过、6013 个测试全过。`prettier --check`、`eslint`、`npm run typecheck --workspace=packages/web-shell` 均干净。

等待耗尽现在可诊断了：不再是一条读起来像产品 bug 的断言，`waitForLoadCount` 会抛出 `waitForLoadCount(2) exhausted 10000ms at 1 call(s), scrollTop=1200`——直接点名吞掉触发的那个位置。

### 前后对比证据

不适用——没有用户可见界面。测试输出见上。

### 测试平台

macOS ✅；Windows ⚠️ 未测；Linux ⚠️ 未测。

在 macOS 上针对真实的 Linux CI 日志验证。该机制是 jsdom + React `act` 的调度问题，与宿主平台无关，而且上面那个复现方法并不需要一台争抢中的主机——这正是它的价值所在。Linux 与 Windows leg 会由本 PR 自己的 CI 确认。

### 环境（可选）

只涉及单测，在本地 `npm ci` 检出上进行。需要先对 `packages/acp-bridge`、`packages/sdk-typescript`、`packages/web-shell` 执行 `npm run build`，否则 `build-artifact.test.ts` 会因为缺 `dist/` 而失败——这与本次改动无关，也是上面整包结果标注为「构建后」的原因。不涉及 daemon、sandbox 或浏览器。

## 风险与范围

- **主要风险或取舍：** `dispatchTopScroll` 让测试重新断言一个此前听凭运气的 precondition，因此该用例现在验证的是「阅读者在顶部并滚动」，而不是「阅读者恰好还在顶部」。这是一个略窄的场景，而那四条 `toHaveBeenCalledTimes` 断言本来要验证的就是这个场景。更尖锐的代价是它不再覆盖的东西：每次 dispatch 前都重新置顶，恰恰就移除了「scroll 事件到达时，容器正停在自动滚动驱动器留下的位置」这一情形——也就是下面那条产品侧备注所描述的真实浏览器争抢。本 PR 之后，这个文件里没有任何东西覆盖 pagination 与 driver 之间的顺序，因此那个脆弱性也失去了回归网。对一个主题是 turn-collapse anchoring 的测试来说这是可辩护的取舍，但它确实是覆盖面的真实收缩，不是白赚。相对的风险——重新驱动可能掩盖一次真实的「未能触发」——由「先判条件再驱动」的循环、精确计数断言、以及 `MessageList.tsx:4596` 的 in-flight 护栏共同约束；耗尽时会带着导致它的 `scrollTop` 抛错，而不是放行。
- **未验证 / 超出范围：** **真实争抢下的余量是推理出来的，不是测出来的。** 上面那张表是在一台其他方面空闲的主机上注入延迟，它钉住了机制，但对一台 load 218–270 的机器什么也没说。`FLUSH_DEADLINE_MS` 在 `ecs-qwen-*` 上是 `10_000`，在其他地方只有 `4_000`；而每一次重新驱动迭代要花掉一个 `act` 加一个 `nextFrame()`，所以在正是本文描述的那种争抢下，能塞进 deadline 的迭代次数会与帧数按同一比例缩水。让我预期「第一次迭代无论负载如何都会命中」的依据是：`handleScroll` 是同步的，且 `loadOlderHistory` 在调用 `onLoadOlderHistory` 之前没有任何 `await`——所以重新置顶让条件在第一次驱动时就变得**可达**，而不是去重试一个不可达的条件，循环应当在不消耗任何预算的情况下退出。这是从代码路径得出的论证，不是在饱和主机上的实测；本 PR 自己的 Linux CI 运行才是任一方向上的第一份真实证据。同样超出范围：该文件里还留着 36 处裸的 `dispatchEvent(new Event('scroll'))`（共 37 处，其中 1 处在新 helper 内部）。单次 load 的用例今天是安全的，因为 cooldown 还没释放；但任何顺序做两次及以上 load 的用例都有同样的隐患——相邻成簇的位置是 `1615/1628/1650`、`1734/1755`、`1824/1840/1864`、`2738/2752`、`5072/5073`、`5237/5246`、`5294/5308`。我没有逐处确认它们是否真的顺序做了两次 load，而且它们目前都不红，所以一次扫掉 36 处会把一个单机制的修复埋掉。同样超出范围：本次暴露出的产品侧脆弱性——`loadOlderHistory` 设了 `followPausedByUserRef.current = true`（`4677`）却从不设 `setShouldFollow(false)`，于是在整个分页窗口里，`5535-5539` 的驱动器条件仅靠 `shouldFollow.current` 就恒真，唯一拦着它的只有那一帧的 cooldown。在真实浏览器里，anchor 恢复（`4320-4328`，会写 `current.scrollTop`）与自动滚动驱动会在同一个帧窗口内对打，胜负由 rAF 注册顺序决定。改它属于行为变更，需要独立的推理和独立的回归验证，不应该搭着一个 CI 红灯混进来。它值得单开一个 issue；而鉴于第一条里提到的覆盖收缩，那个 issue 现在是这个脆弱性与「彻底无人知晓」之间唯一的东西——建好之后值得从 `## Linked Issues` 链过来。
- **破坏性变更 / 迁移说明：** 无。纯测试改动；不涉及产品代码、公开 API 或配置。

## 关联 Issue

均为非关闭式引用；本 PR 不解决其中任何一个。

- #10490 —— 争抢导致的 CI 失败的父级追踪 issue；本 PR 是它下面的一个具体机制。
- #10892 —— `vi.waitFor` 预算问题。属于**不同**机制：本文件 `vi.waitFor` 调用数为零，用的是一个手搓轮询器，而且它早已具备 #10892 所提议的、按 fleet 调过的预算。已在那边留言，把本用例作为「只调大预算就够了」的反例。
- #10879 —— 让这个竞态确定性输掉的池子超容量问题。修好它会**掩盖**这个 bug，而不是修好它。
- #11103 —— 同一批 13 次运行样本里另一种机制的姊妹改动（worker RPC 饿死导致全绿套件非零退出）。

</details>
