### PR TITLE
fix(web-shell): close the four deferred #9812 review follow-ups

### DIFF
--- a/.github/scripts/ci/classify-platform-sensitivity.test.mjs
+++ b/.github/scripts/ci/classify-platform-sensitivity.test.mjs
@@ -111,11 +111,19 @@ test('platform-coupled subsystems match on segments, not substrings', () => {
 
   // The substring trap: these contain "shell", "pty", "os" or "platform"
   // inside a longer word and must NOT drag both lanes in.
+  //
+  // `Shellfish.tsx` is the one that pins the segment boundary itself: the
+  // keyword is the HEAD of the stem, not buried mid-word, so a rule that
+  // accepts a keyword prefix followed by anything would classify every
+  // `Shell*.tsx` component as sensitive and summon both expensive lanes on
+  // each change. The case above covers the sibling trap — `web-shell` as a
+  // compound — which a different loosening breaks.
   for (const file of [
     'packages/core/src/utils/cryptic.ts',
     'packages/cli/src/ui/emptyState.ts',
     'packages/core/src/telemetry/uploader.ts',
     'packages/cli/src/services/plateauDetector.ts',
+    'packages/web-shell/client/components/Shellfish.tsx',
   ]) {
     assert.equal(classifyChangedFiles([file]), PLATFORM_INSENSITIVE, file);
   }

--- a/docs/verification/11076-webui-retirement-followups/README.md
+++ b/docs/verification/11076-webui-retirement-followups/README.md
@@ -1,0 +1,117 @@
+# Verification: #11076 WebUI-retirement follow-ups
+
+Every claim below is **unverified on the authoring machine** except where this
+file says otherwise. That machine cannot run vitest (small RAM; running suites
+there has OOM'd it before), so the two vitest-backed items ship on static
+reasoning plus a direct module probe, and this brief is the handoff.
+
+What was actually run here, and what it proves, is stated per item. Nothing
+else was executed.
+
+## What to run
+
+| #   | Command                                                                                                                        | Covers                                                      |
+| --- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| 1   | `npx vitest run client/daemon/session/clientLifecycle.test.ts` (from `packages/web-shell`)                                     | Historical sessionStorage key                               |
+| 2   | `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/export-html-from-chatrecord-jsonl.test.js` (repo root) | Legacy-JSONL rejection + ChatRecord happy path              |
+| 3   | `node --test --test-concurrency=1 .github/scripts/ci/classify-platform-sensitivity.test.mjs`                                   | Classifier word boundary — **already run here, 12/12 pass** |
+| 4   | —                                                                                                                              | Comment-only; nothing to run                                |
+
+Item 2's suite is part of `npm run test:ci` (via `npm run test:scripts`), and
+item 3's file is in `HELPER_TESTS` in `ci.yml`, so both lanes cover these on
+their own. Item 1 rides the `packages/web-shell` suite.
+
+## Item 1 — historical sessionStorage key
+
+Three assertions added to `clientLifecycle.test.ts`. The point of all three is
+that the key is **spelled as a literal**, never imported: every pre-existing
+test round-trips through `SESSION_CLIENT_ID_STORAGE_PREFIX`, so renaming that
+constant moves the read and the write together and the suite stays green.
+
+Expected: all pass.
+
+**Mutation to prove they bite** — change `clientLifecycle.ts:8` to
+`'qwen-code-web-shell-client-id:session:'` and re-run. Expected: the two
+literal-key tests go red (`writes under the historical WebUI key`, `reads an
+id a WebUI-era tab left under the historical key`); the third
+(`percent-encodes the session id in the key`) goes red too, since it also
+spells the prefix. Every other test in the file stays green — that contrast is
+the whole point, and the review that asked for this measured the same thing
+(15/15 green under the mutant before, 15 pass / 1 fail after).
+
+_Not run here._ The assertion shape is taken verbatim from the review thread's
+own suggested fix, and `encodeURIComponent('work/space:1') === 'work%2Fspace%3A1'`
+was checked by hand, not by running the suite.
+
+## Item 2 — export-html-from-chatrecord-jsonl.js
+
+The script had no exports and ran `main()` at import, so it could not be
+imported by a test at all. Two changes make it testable without changing what
+the CLI does:
+
+- the input gate is now `selectChatRecords(objects)` and the render is
+  `renderHtmlFromObjects(objects, api)`, with `api` passed in — the real one
+  still comes from `loadExportApi()`, which needs built CLI output;
+- `main()` runs only when the file is the process entry point.
+
+**Run here, and it passed:** a standalone `node` script that imports the real
+module and asserts every behaviour the vitest file asserts — legacy rejection
+message verbatim, first-line-only rejection, non-record filtering, the two
+distinct error messages for empty vs unrecognized input, both predicates,
+`readJsonlObjects` blank-line skipping and its invalid-line error, the happy
+path's earliest-timestamp `startTime`, and that the renderer is never reached
+on the legacy path. All passed. **What that does not cover** is the vitest
+file itself — its imports, `vi.fn()` usage, and whether the suite picks the
+file up. That is what run 2 above is for.
+
+Also confirmed here: importing the module executes nothing, and invoking the
+script directly still runs `main()` (it exits 1 on the missing export API,
+which is pre-existing — `loadExportApi()` is awaited before argument parsing,
+so even `--help` needs a build. Left alone; out of scope).
+
+**Mutation to prove the test bites** — delete the `throw` in
+`selectChatRecords`'s `looksLikeExportJsonl` branch. Expected: `rejects legacy
+exported JSONL with the exact message` and `never reaches the renderer for
+legacy exported JSONL` go red. Note the failure is _not_ an absence of an
+error: with the throw gone, a legacy-only input falls through to the filter
+and raises `Unrecognized JSONL format` instead, so the test must be asserting
+the exact message — it is — or the mutant survives.
+
+## Item 3 — classifier word boundary
+
+**Run here in full, including the mutation.** Fixture added:
+`packages/web-shell/client/components/Shellfish.tsx`, expected
+`PLATFORM_INSENSITIVE`.
+
+```
+intact tree + new fixture                    → 12 pass, 0 fail
+mutant (SUBSYSTEM_STEM_HEAD `[-_]` → `[^/]*`) + new fixture   → 11 pass, 1 fail
+mutant + original test file (fixture absent) → 12 pass, 0 fail   ← mutant survived before
+```
+
+The middle and bottom rows are the pair that matters: the fixture is what kills
+the mutant. Nothing else in the file did.
+
+Note this is a _different_ trap from the `packages/web-shell/client/App.tsx`
+case already in the suite. That one guards the compound (`web-shell` as a
+dashed segment); this one guards the keyword being the **head of a stem**
+(`Shellfish`), which a different loosening breaks.
+
+## Item 4 — hook documentation
+
+`InputForm` was deleted with `packages/webui`; the public hook's docblock still
+told integrators to render it. Replaced with `ChatEditor`, which declares the
+three props (`ChatEditor.tsx:271-273`, typed from
+`UseDaemonFollowupSuggestionReturn`), and a note that `ChatPane` and `App` are
+the two in-tree hosts that call the hook and thread them down.
+
+`grep -c InputForm packages/web-shell/client/daemon/useDaemonFollowupSuggestion.ts`
+returns 0. Comment-only.
+
+## What to report back
+
+1. Whether runs 1 and 2 are green, with the failing output if not.
+2. Whether the two mutations above go red as described. If a mutation does
+   **not** go red, that is the important result — say so, because it means the
+   test does not pin what this PR claims it pins.
+3. Anything in the PR description contradicted by what you saw.

--- a/integration-tests/concurrent-runner/export-html-from-chatrecord-jsonl.js
+++ b/integration-tests/concurrent-runner/export-html-from-chatrecord-jsonl.js
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
 
 async function loadExportApi() {
   try {
@@ -53,7 +54,7 @@ function parseArgs(argv) {
   return { input: args[0] ?? null, output };
 }
 
-async function readJsonlObjects(inputPath) {
+export async function readJsonlObjects(inputPath) {
   const input =
     inputPath === '-'
       ? process.stdin
@@ -75,7 +76,7 @@ async function readJsonlObjects(inputPath) {
   return objects;
 }
 
-function looksLikeChatRecord(value) {
+export function looksLikeChatRecord(value) {
   return (
     value !== null &&
     typeof value === 'object' &&
@@ -89,7 +90,7 @@ function looksLikeChatRecord(value) {
   );
 }
 
-function looksLikeExportJsonl(objects) {
+export function looksLikeExportJsonl(objects) {
   const first = objects[0];
   return (
     first !== null &&
@@ -132,12 +133,14 @@ function defaultOutPath(inputPath) {
   return path.resolve(directory, `${basename}.html`);
 }
 
-async function main() {
-  const { collectSessionMetadata, toHtml } = await loadExportApi();
-  const { input, output } = parseArgs(process.argv);
-  if (!input) printUsage(1);
-
-  const objects = await readJsonlObjects(input);
+/**
+ * The input gate. Legacy exported JSONL is rejected rather than rendered: it
+ * has already been through a renderer once, so feeding it back in would put
+ * previously-rendered markup on the page without passing the export API's
+ * document allowlist. Source ChatRecords are the only shape that goes through
+ * that allowlist, so they are the only shape accepted.
+ */
+export function selectChatRecords(objects) {
   if (objects.length === 0) throw new Error('Input JSONL is empty.');
 
   if (looksLikeExportJsonl(objects)) {
@@ -151,19 +154,45 @@ async function main() {
       'Unrecognized JSONL format (expected ChatRecord-per-line).',
     );
   }
+  return records;
+}
+
+/**
+ * Render accepted records to HTML. `api` is the `@qwen-code/qwen-code/export`
+ * module, taken as an argument so a caller can supply it — the real one comes
+ * from `loadExportApi()`, which needs built CLI output.
+ */
+export async function renderHtmlFromObjects(objects, api) {
+  const records = selectChatRecords(objects);
   const sessionData = await buildProductSessionData(
     records,
-    collectSessionMetadata,
+    api.collectSessionMetadata,
   );
+  return api.toHtml(sessionData, records);
+}
 
-  const html = toHtml(sessionData, records);
+async function main() {
+  const api = await loadExportApi();
+  const { input, output } = parseArgs(process.argv);
+  if (!input) printUsage(1);
+
+  const objects = await readJsonlObjects(input);
+  const html = await renderHtmlFromObjects(objects, api);
   const outputPath = output ? path.resolve(output) : defaultOutPath(input);
   await fsp.mkdir(path.dirname(outputPath), { recursive: true });
   await fsp.writeFile(outputPath, html, 'utf8');
   console.log(`Wrote HTML export to: ${outputPath}`);
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+// Only run when invoked as the CLI. Importing this module (the test does)
+// must not execute a render or touch process state.
+const invokedDirectly =
+  typeof process.argv[1] === 'string' &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/packages/web-shell/client/daemon/session/clientLifecycle.test.ts
+++ b/packages/web-shell/client/daemon/session/clientLifecycle.test.ts
@@ -82,6 +82,45 @@ describe('persistStableClientId', () => {
       window.sessionStorage.getItem('qwen-code-webui-client-id'),
     ).toBeNull();
   });
+
+  // The key below is spelled out instead of imported on purpose. Every other
+  // test here round-trips through `SESSION_CLIENT_ID_STORAGE_PREFIX`, so
+  // renaming that constant moves the read and the write together and leaves
+  // the suite green — while a tab that persisted its id under the historical
+  // WebUI key loses it across the migration, and the daemon then sees a fresh
+  // `X-Qwen-Client-Id` for the same controller. These two assertions are the
+  // only thing that goes red on a rename.
+  it('writes under the historical WebUI key', () => {
+    persistStableClientId('client-a', 'session-a');
+
+    expect(
+      window.sessionStorage.getItem(
+        'qwen-code-webui-client-id:session:session-a',
+      ),
+    ).toBe('client-a');
+  });
+
+  it('reads an id a WebUI-era tab left under the historical key', () => {
+    window.sessionStorage.setItem(
+      'qwen-code-webui-client-id:session:session-a',
+      'legacy-client',
+    );
+
+    expect(getStableClientId(undefined, 'session-a')).toBe('legacy-client');
+    expect(getPersistedClientId('session-a')).toBe('legacy-client');
+  });
+
+  it('percent-encodes the session id in the key', () => {
+    // The suffix is part of the persisted shape too: a session id carrying `/`
+    // or `:` would otherwise collide with the prefix's own separator.
+    persistStableClientId('client-slash', 'work/space:1');
+
+    expect(
+      window.sessionStorage.getItem(
+        'qwen-code-webui-client-id:session:work%2Fspace%3A1',
+      ),
+    ).toBe('client-slash');
+  });
 });
 
 describe('getPersistedClientId', () => {

--- a/packages/web-shell/client/daemon/useDaemonFollowupSuggestion.ts
+++ b/packages/web-shell/client/daemon/useDaemonFollowupSuggestion.ts
@@ -192,12 +192,13 @@ function createDaemonFollowupController(options: {
 export interface UseDaemonFollowupSuggestionReturn {
   /**
    * Current follow-up suggestion display state — pass directly to
-   * `<InputForm followupState={...} />`. Reflects the controller's
+   * `<ChatEditor followupState={...} />`. Reflects the controller's
    * post-debounce visible state, not the raw daemon push.
    */
   followupState: FollowupState;
   /**
-   * Accept the visible suggestion. Wire to `<InputForm onAcceptFollowup={...} />`.
+   * Accept the visible suggestion. Wire to
+   * `<ChatEditor onAcceptFollowup={...} />`.
    * Calls the underlying controller's accept (which invokes the
    * consumer-provided `onAccept` from options) AND clears the daemon
    * store's `lastFollowupSuggestion` so the same suggestion does not
@@ -208,7 +209,8 @@ export interface UseDaemonFollowupSuggestionReturn {
     options?: { skipOnAccept?: boolean },
   ) => void;
   /**
-   * Dismiss the visible suggestion. Wire to `<InputForm onDismissFollowup={...} />`.
+   * Dismiss the visible suggestion. Wire to
+   * `<ChatEditor onDismissFollowup={...} />`.
    * Same store-clear semantics as `onAcceptFollowup`.
    */
   onDismissFollowup: () => void;
@@ -226,8 +228,11 @@ export interface UseDaemonFollowupSuggestionReturn {
  * Wire the daemon's server-pushed `followup_suggestion` event into the
  * Web Shell's composer. Consumers:
  *
- *   1. Render `<InputForm followupState={...} onAcceptFollowup={...}
+ *   1. Render `<ChatEditor followupState={...} onAcceptFollowup={...}
  *      onDismissFollowup={...} />` with the three values returned here.
+ *      `ChatEditor` declares exactly these three props, typed from this
+ *      interface; `ChatPane` and `App` are the two in-tree hosts that call
+ *      this hook and thread them down.
  *   2. Call `clear()` from the hook just before `actions.sendPrompt(...)`
  *      so the prior turn's ghost-text disappears immediately.
  *

--- a/scripts/tests/export-html-from-chatrecord-jsonl.test.js
+++ b/scripts/tests/export-html-from-chatrecord-jsonl.test.js
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  looksLikeChatRecord,
+  looksLikeExportJsonl,
+  readJsonlObjects,
+  renderHtmlFromObjects,
+  selectChatRecords,
+} from '../../integration-tests/concurrent-runner/export-html-from-chatrecord-jsonl.js';
+
+const LEGACY_REJECTION =
+  'Legacy exported JSONL cannot be rendered safely; provide source ChatRecord JSONL.';
+
+function chatRecord(overrides = {}) {
+  return {
+    uuid: 'rec-1',
+    parentUuid: null,
+    sessionId: 'sess-1',
+    timestamp: '2026-01-02T03:04:05.000Z',
+    type: 'user',
+    cwd: '/work',
+    version: '0.1.0',
+    ...overrides,
+  };
+}
+
+function legacyMetadata(overrides = {}) {
+  return {
+    type: 'session_metadata',
+    sessionId: 'sess-1',
+    startTime: '2026-01-02T03:04:05.000Z',
+    ...overrides,
+  };
+}
+
+/** Stand-in for `@qwen-code/qwen-code/export`, which needs built CLI output. */
+function stubExportApi() {
+  return {
+    collectSessionMetadata: vi.fn(async (conversation) => ({
+      sessionId: conversation.sessionId,
+      messageCount: conversation.messages.length,
+    })),
+    toHtml: vi.fn(() => '<html>rendered</html>'),
+  };
+}
+
+const tempDirs = [];
+function writeJsonl(lines) {
+  const dir = mkdtempSync(join(tmpdir(), 'chatrecord-jsonl-'));
+  tempDirs.push(dir);
+  const file = join(dir, 'input.jsonl');
+  writeFileSync(file, lines.join('\n'), 'utf8');
+  return file;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe('selectChatRecords', () => {
+  it('rejects legacy exported JSONL with the exact message', () => {
+    // The behaviour this pins is a deliberate flip: legacy exports used to be
+    // rendered through a separate path. Dropping the throw, or letting
+    // looksLikeExportJsonl stop matching the legacy shape, must not pass
+    // silently — that would put already-rendered markup back on the page
+    // without the export API's document allowlist ever seeing it.
+    expect(() => selectChatRecords([legacyMetadata()])).toThrow(
+      LEGACY_REJECTION,
+    );
+  });
+
+  it('rejects on the first line alone, even with real records behind it', () => {
+    expect(() => selectChatRecords([legacyMetadata(), chatRecord()])).toThrow(
+      LEGACY_REJECTION,
+    );
+  });
+
+  it('accepts ChatRecords and drops entries that are not one', () => {
+    const keep = chatRecord({ uuid: 'rec-keep' });
+    const records = selectChatRecords([keep, { note: 'not a record' }]);
+
+    expect(records).toEqual([keep]);
+  });
+
+  it('reports an empty input distinctly from an unrecognized one', () => {
+    expect(() => selectChatRecords([])).toThrow('Input JSONL is empty.');
+    expect(() => selectChatRecords([{ note: 'nope' }])).toThrow(
+      'Unrecognized JSONL format (expected ChatRecord-per-line).',
+    );
+  });
+});
+
+describe('renderHtmlFromObjects', () => {
+  it('renders the ChatRecord happy path through the export API', async () => {
+    const api = stubExportApi();
+    const records = [
+      chatRecord({ uuid: 'rec-1', timestamp: '2026-01-02T03:04:05.000Z' }),
+      chatRecord({ uuid: 'rec-2', timestamp: '2026-01-02T02:00:00.000Z' }),
+    ];
+
+    const html = await renderHtmlFromObjects(records, api);
+
+    expect(html).toBe('<html>rendered</html>');
+    // startTime is the earliest record, not the first one in file order.
+    expect(api.collectSessionMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess-1',
+        startTime: '2026-01-02T02:00:00.000Z',
+        messages: records,
+      }),
+      expect.anything(),
+    );
+    const [sessionData, passedRecords] = api.toHtml.mock.calls[0];
+    expect(passedRecords).toEqual(records);
+    expect(sessionData).toEqual(
+      expect.objectContaining({
+        sessionId: 'sess-1',
+        messages: [],
+        metadata: { sessionId: 'sess-1', messageCount: 2 },
+      }),
+    );
+  });
+
+  it('never reaches the renderer for legacy exported JSONL', async () => {
+    const api = stubExportApi();
+
+    await expect(
+      renderHtmlFromObjects([legacyMetadata()], api),
+    ).rejects.toThrow(LEGACY_REJECTION);
+    expect(api.collectSessionMetadata).not.toHaveBeenCalled();
+    expect(api.toHtml).not.toHaveBeenCalled();
+  });
+});
+
+describe('looksLikeExportJsonl', () => {
+  it('matches only the legacy metadata header shape', () => {
+    expect(looksLikeExportJsonl([legacyMetadata()])).toBe(true);
+    expect(looksLikeExportJsonl([chatRecord()])).toBe(false);
+    expect(looksLikeExportJsonl([legacyMetadata({ type: 'user' })])).toBe(
+      false,
+    );
+    expect(
+      looksLikeExportJsonl([legacyMetadata({ startTime: undefined })]),
+    ).toBe(false);
+  });
+});
+
+describe('looksLikeChatRecord', () => {
+  it('requires every field the renderer reads', () => {
+    expect(looksLikeChatRecord(chatRecord())).toBe(true);
+    expect(looksLikeChatRecord(null)).toBe(false);
+    // parentUuid may be null, but the key has to be present.
+    const { parentUuid: _dropped, ...withoutParent } = chatRecord();
+    expect(looksLikeChatRecord(withoutParent)).toBe(false);
+    expect(looksLikeChatRecord(chatRecord({ sessionId: 7 }))).toBe(false);
+  });
+});
+
+describe('readJsonlObjects', () => {
+  it('parses one object per line and skips blank lines', async () => {
+    const file = writeJsonl([
+      JSON.stringify(chatRecord({ uuid: 'rec-1' })),
+      '',
+      JSON.stringify(chatRecord({ uuid: 'rec-2' })),
+      '',
+    ]);
+
+    const objects = await readJsonlObjects(file);
+
+    expect(objects.map((o) => o.uuid)).toEqual(['rec-1', 'rec-2']);
+  });
+
+  it('names the offending line when JSON is invalid', async () => {
+    const file = writeJsonl([JSON.stringify(chatRecord()), '{ not json']);
+
+    await expect(readJsonlObjects(file)).rejects.toThrow(
+      /Invalid JSONL line[\s\S]*\{ not json/,
+    );
+  });
+});


### PR DESCRIPTION
## What this PR does

Closes the four review suggestions deferred out of #9812 and tracked in #11076. Each one protects a behaviour that had nothing pinning it, so each could regress silently.

- **Historical sessionStorage key.** `clientLifecycle.test.ts` only ever round-tripped through `SESSION_CLIENT_ID_STORAGE_PREFIX`, so renaming that constant moved the read and the write together and left every test green — while a tab that persisted its client id under the WebUI-era key lost it across the migration, and the daemon then saw a fresh `X-Qwen-Client-Id` for the same controller. Three assertions now spell the key literally, including its percent-encoded session suffix.
- **ChatRecord export script.** The legacy-JSONL rejection is a behaviour flip #9812 introduced, and it had no test because the script had no exports and ran `main()` at import. The input gate is now `selectChatRecords`, the render is `renderHtmlFromObjects(objects, api)` with the export API passed in, and `main()` runs only as the process entry point. The CLI behaves exactly as before. A new suite covers the rejection and the happy path.
- **Substring-trap fixture.** The retirement deleted `packages/webui/src/components/Shellfish.tsx` from the platform-sensitivity classifier's fixtures without replacement. Restored under a live path.
- **Hook documentation.** `InputForm` was deleted with `packages/webui`, but the publicly exported hook's docblock still told integrators to render it.

## Why it's needed

These are not theoretical. #9812's review confirmed each with a mutation witness, and #11076 has carried them since. The two behaviours worth stating plainly:

The key rename is invisible to the suite by construction — that is what makes it worth a literal assertion rather than another round-trip. And removing the legacy-JSONL `throw` does not produce *no* error; it falls through to the neighbouring `Unrecognized JSONL format` path, so a test that merely expects a rejection would pass. The new test asserts the message verbatim and that the renderer is never reached, which is what makes the mutant die.

The `Shellfish.tsx` case is a **different** trap from the `packages/web-shell/client/App.tsx` fixture already in that suite. That one guards the compound (`web-shell` as a dashed segment); this one guards the keyword being the head of a stem. A loosening that breaks one leaves the other green — measured below.

## Reviewer Test Plan

### How to verify

A verification brief ships with the branch at `docs/verification/11076-webui-retirement-followups/README.md`, with the exact commands, the two mutations to apply, and what each should turn red.

- `cd packages/web-shell && npx vitest run client/daemon/session/clientLifecycle.test.ts`
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/export-html-from-chatrecord-jsonl.test.js`
- `node --test --test-concurrency=1 .github/scripts/ci/classify-platform-sensitivity.test.mjs`
- `grep -c InputForm packages/web-shell/client/daemon/useDaemonFollowupSuggestion.ts` → `0`

Both new suites are already reached by CI on their own: the scripts test via `npm run test:scripts` (part of `test:ci`), the classifier via `HELPER_TESTS` in `ci.yml`.

### Evidence (Before & After)

N/A — no user-visible surface. Tests, a docblock, and a testability refactor with no behaviour change.

The classifier item was run locally, mutation included:

```
intact tree + new fixture                                  → 12 pass, 0 fail
mutant (SUBSYSTEM_STEM_HEAD `[-_]` → `[^/]*`) + fixture    → 11 pass, 1 fail
mutant + original test file (fixture absent)               → 12 pass, 0 fail   ← survived before
```

The export module was exercised by a standalone `node` script asserting every behaviour the vitest file asserts — all passed. That validates the module, not the vitest wiring.

### Tested on

|     OS     |          Status          |
| :--------: | :----------------------: |
|  🍏 macOS  |      ⚠️ not tested       |
| 🪟 Windows |      ⚠️ not tested       |
|  🐧 Linux  | ✅ items 3 and 4 only |

### Environment (optional)

Prettier clean (3.6.1, matching the lockfile). **The two vitest suites were not run** — the authoring machine cannot run vitest without OOM risk, which is why the brief and the module probe exist. CI is the authority on items 1 and 2.

## Risk & Scope

- **Main risk or tradeoff:** the export script gained exports and an entry guard purely for testability. The CLI path is unchanged — `main()` still runs when the file is the process entry point, verified — but it is a real edit to a script no suite previously touched, which is precisely why it previously had no test.
- **Not validated / out of scope:** `--help` on that script still needs built CLI output, because `loadExportApi()` is awaited before argument parsing. Pre-existing, untouched. The two vitest suites are unrun locally (see above).
- **Breaking changes / migration notes:** none.

## Linked Issues

Closes #11076. Refs #9812.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

完成 #9812 延后、并由 #11076 跟踪的四条评审建议。每一条保护的行为此前都没有任何东西钉住，因此都可能悄悄回归。

- **历史 sessionStorage 键。** `clientLifecycle.test.ts` 一直只通过 `SESSION_CLIENT_ID_STORAGE_PREFIX` 做往返测试，因此重命名该常量会让读写两端一起移动、所有测试仍为绿——而用 WebUI 时期的键持久化过 client id 的标签页会在迁移中丢失它，守护进程随后为同一个控制器看到全新的 `X-Qwen-Client-Id`。现在有三条断言以字面量拼出该键，包括其百分号编码的 session 后缀。
- **ChatRecord 导出脚本。** 遗留 JSONL 的拒绝是 #9812 引入的行为翻转，此前没有测试，因为该脚本没有任何导出、且在 import 时就执行 `main()`。现在输入闸门是 `selectChatRecords`，渲染是 `renderHtmlFromObjects(objects, api)`（导出 API 作为参数传入），`main()` 仅在该文件是进程入口时运行。CLI 行为与此前完全一致。新增测试覆盖拒绝路径与正常路径。
- **子串陷阱夹具。** 退役操作把 `packages/webui/src/components/Shellfish.tsx` 从平台敏感度分类器的夹具中删除且无替代，现以存活路径补回。
- **Hook 文档。** `InputForm` 随 `packages/webui` 一并删除，但公开导出的 hook 的文档注释仍在指示集成方渲染它。

## 为什么需要

这些都不是理论问题。#9812 的评审为每一条都给出了变异见证，#11076 一直挂着它们。两点值得直说：

常量重命名对测试套件在构造上就是不可见的——正因如此才值得用字面量断言，而不是再加一个往返测试。而删掉遗留 JSONL 的 `throw` 并不会导致「没有错误」：它会落到相邻的 `Unrecognized JSONL format` 分支，因此只断言「会抛错」的测试仍会通过。新测试逐字断言错误文案、并断言渲染器从未被触达，这才是变异体致死的原因。

`Shellfish.tsx` 与该套件中已有的 `packages/web-shell/client/App.tsx` 夹具是**两种不同**的陷阱：后者防的是复合词（`web-shell` 作为带连字符的分段），前者防的是关键词位于词干开头。破坏其中一条的放宽不会让另一条变红——下方有实测。

## 评审者验证计划

### 如何验证

分支中附带验证说明：`docs/verification/11076-webui-retirement-followups/README.md`，内含确切命令、两个待施加的变异，以及各自应当变红的位置。

- `cd packages/web-shell && npx vitest run client/daemon/session/clientLifecycle.test.ts`
- `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/export-html-from-chatrecord-jsonl.test.js`
- `node --test --test-concurrency=1 .github/scripts/ci/classify-platform-sensitivity.test.mjs`
- `grep -c InputForm packages/web-shell/client/daemon/useDaemonFollowupSuggestion.ts` → `0`

两个新增套件本身已被 CI 覆盖：scripts 测试经 `npm run test:scripts`（属于 `test:ci`），分类器经 `ci.yml` 中的 `HELPER_TESTS`。

### 证据（改前 / 改后）

不适用——无用户可见面。改动为测试、一处文档注释，以及一次不改变行为的可测试性重构。

分类器一项已在本地运行，含变异（数据见上方英文代码块）。

导出模块由一个独立 `node` 脚本逐条断言了 vitest 文件所断言的全部行为，全部通过。这验证的是模块本身，不是 vitest 接线。

### 测试环境

|    系统    |       状态       |
| :--------: | :--------------: |
|  🍏 macOS  |    ⚠️ 未测试     |
| 🪟 Windows |    ⚠️ 未测试     |
|  🐧 Linux  | ✅ 仅第 3、4 项 |

### 运行环境（可选）

Prettier 通过（3.6.1，与 lockfile 一致）。**两个 vitest 套件未运行**——编写这些改动的机器运行 vitest 有 OOM 风险，这正是验证说明与模块探针存在的原因。第 1、2 项以 CI 为准。

## 风险与范围

- **主要风险或权衡：** 导出脚本为可测试性新增了导出与入口守卫。CLI 路径未变——该文件作为进程入口时 `main()` 仍会运行，已验证——但这确实是对一个此前无任何套件触及的脚本的真实改动，而这正是它此前没有测试的原因。
- **未验证 / 不在范围：** 该脚本的 `--help` 仍需构建产物，因为 `loadExportApi()` 在参数解析之前被 await。此为既有行为，未改动。两个 vitest 套件在本地未运行（见上）。
- **破坏性变更 / 迁移说明：** 无。

## 关联 Issue

Closes #11076. Refs #9812.

</details>
