### PR TITLE
test(core): pin Config.initialize() join ordering so the await-drop mutant fails

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -5148,6 +5148,21 @@ describe('Server Config (config.ts)', () => {
       // Second call lands mid-flight → joins the first flight instead of
       // bouncing off the already-set flag.
       const second = config.initialize();
+
+      // Pin the ordering property this test is named for: while the first
+      // flight is still gated, the joining caller must remain unsettled — it
+      // awaits the in-flight promise instead of returning early. A join branch
+      // that drops the `await` resolves `second` immediately and still passes
+      // every other assertion here, yet it reproduces #11002 (the joiner
+      // proceeds before initialization completes and dies on "Chat not
+      // initialized"). Assert nothing has settled before the gate is released
+      // so that mutant goes red.
+      const settled: string[] = [];
+      first.then(() => settled.push('first'));
+      second.then(() => settled.push('second'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(settled).toEqual([]);
+
       release();
       await Promise.all([first, second]);
       expect(initializeInternal).toHaveBeenCalledOnce();


### PR DESCRIPTION
## What this PR does

Hardens the `makes a concurrent caller join the in-flight initialization` test in `packages/core/src/config/config.test.ts` so it actually pins the ordering property it is named for. The test previously released the gate before asserting anything and never checked that the joining caller was still pending while the first flight was in progress. This adds an ordering assertion: track settlement of both callers and assert nothing has settled before the gate is released.

Test-only change; no production code touched.

## Why it's needed

This closes the one remaining review finding from #11037 that #11075 did not cover (the post-merge review's §3, a test-quality gap).

A join branch that drops the `await` — `if (!this.initializationSettled) { return; }` instead of awaiting `this.initializationPromise` — passed the old test, because the test released the gate before asserting, so by the time it checked, the joiner had already (wrongly) resolved and `initializeInternal` had run exactly once. That mutant silently reproduces #11002: the joiner proceeds before initialization completes and dies on `Chat not initialized`. It was killed only incidentally by `shares a failed in-flight initialization`, for an unrelated reason (error-identity), so the test that names the join behavior never actually guarded it.

## Reviewer Test Plan

### How to verify

1. `cd packages/core && npx vitest run src/config/config.test.ts` — full suite green (621 passed locally).
2. Mutation witness: remove the `await this.initializationPromise;` line from the join branch in `config.ts`. The `makes a concurrent caller join the in-flight initialization` test now fails — the joiner settled while the gate was still held. Restore the line and it is green again.

### Evidence (Before & After)

Before (join branch with the `await` dropped, i.e. the #11002-restoring mutant):

```
FAIL  src/config/config.test.ts > Server Config (config.ts) > initialize > makes a concurrent caller join the in-flight initialization
AssertionError: expected [ 'second' ] to deeply equal []
```

After (await intact): `621 passed (621)`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

## Risk & Scope

- Main risk or tradeoff: none; the change adds one assertion to an existing test. The `setTimeout(0)` flush drains the microtask queue before the ordering check, so the assertion is deterministic rather than timing-dependent.
- Not validated / out of scope: the OpenTUI unbounded-and-silent join UX noted in the same review (§4) is left for a separate follow-up.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up to #11037 (review finding §3). Complements #11075, which resolved R1-1 through R1-4.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

加固 `packages/core/src/config/config.test.ts` 中的 `makes a concurrent caller join the in-flight initialization` 用例，让它真正钉住它所命名的顺序性质。此前该用例在断言任何内容之前就释放了门闩，也从未检查「加入方在第一次初始化仍在进行时是否仍未落定」。本改动新增一条顺序断言：跟踪两个调用方的落定情况，并在释放门闩之前断言没有任何一方落定。

仅测试改动，未触碰任何生产代码。

## 为什么需要它

这闭合了 #11037 中 #11075 未覆盖的那一条遗留评审发现（合并后评审的 §3，一处测试质量缺口）。

一个去掉 `await` 的 join 分支——`if (!this.initializationSettled) { return; }` 而非 await `this.initializationPromise`——在旧用例下会通过：因为用例在断言前就释放了门闩，等它检查时，加入方已经（错误地）resolve，且 `initializeInternal` 恰好运行一次。该变异体会悄悄重现 #11002：加入方在初始化完成前就继续执行，死于 `Chat not initialized`。它只是被 `shares a failed in-flight initialization` 因另一个无关理由（错误对象同一性）顺带杀掉，因此那个为 join 行为命名的用例从未真正守住它。

## 审阅者测试计划

### 如何验证

1. `cd packages/core && npx vitest run src/config/config.test.ts` —— 全套绿（本地 621 通过）。
2. 变异见证：从 `config.ts` 的 join 分支移除 `await this.initializationPromise;` 一行。`makes a concurrent caller join the in-flight initialization` 用例随即失败——加入方在门闩仍被挂起时就落定了。还原该行则重新变绿。

### 风险与范围

- 主要风险或取舍：无；本改动只为既有用例新增一条断言。`setTimeout(0)` 冲刷会在顺序检查前排空微任务队列，因此该断言是确定性的，而非依赖时序。
- 未验证 / 范围之外：同一评审指出的 OpenTUI「无界且无声」join 的 UX 问题（§4）留给单独的后续 PR。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

#11037 的后续（评审发现 §3）。与已解决 R1-1 ~ R1-4 的 #11075 互补。

</details>
