### PR TITLE
fix(serve): bound and diagnose a session reclaim that can never succeed

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -145,6 +145,9 @@ import {
   PROMPT_CANCEL_METHOD,
   TODO_STOP_GUARD_CONTINUATION_CLAIM_METHOD,
   TODO_STOP_GUARD_QUEUE_RELEASE_METHOD,
+  ACTIVE_WORK_CLOSE_RETRY_BASE_MS,
+  ACTIVE_WORK_CLOSE_RETRY_CEILING_MS,
+  activeWorkCloseRetryDelayMs,
   sessionCloseDrainBudgetMs,
 } from './bridgeTypes.js';
 
@@ -173,6 +176,37 @@ describe('sessionCloseDrainBudgetMs', () => {
     for (const outer of [2, 3, 7, 100, 1_000, 30_000]) {
       expect(sessionCloseDrainBudgetMs(outer)).toBeGreaterThanOrEqual(1);
       expect(sessionCloseDrainBudgetMs(outer)).toBeLessThan(outer);
+    }
+  });
+});
+
+describe('activeWorkCloseRetryDelayMs', () => {
+  it('keeps the first retry immediate, then backs off to a ceiling', () => {
+    // Literal pin: one unanswered probe must stay immediately retryable,
+    // because that single deferral is the documented recovery for a lost
+    // close response — `recovers a lost close response once nothing local
+    // holds the session` depends on the retry running on the very next
+    // snapshot. A grace of 0 would break that recovery.
+    expect(activeWorkCloseRetryDelayMs(0)).toBeNull();
+    expect(activeWorkCloseRetryDelayMs(1)).toBeNull();
+    expect(activeWorkCloseRetryDelayMs(2)).toBe(
+      ACTIVE_WORK_CLOSE_RETRY_BASE_MS,
+    );
+    expect(activeWorkCloseRetryDelayMs(3)).toBe(
+      ACTIVE_WORK_CLOSE_RETRY_BASE_MS * 2,
+    );
+    // Geometric growth must saturate at the ceiling, not overflow past it.
+    for (const failures of [12, 40, 1_000]) {
+      expect(activeWorkCloseRetryDelayMs(failures)).toBe(
+        ACTIVE_WORK_CLOSE_RETRY_CEILING_MS,
+      );
+    }
+    // A longer run of failures never shortens the deferral.
+    let previous = 0;
+    for (let failures = 0; failures <= 30; failures++) {
+      const delay = activeWorkCloseRetryDelayMs(failures) ?? 0;
+      expect(delay).toBeGreaterThanOrEqual(previous);
+      previous = delay;
     }
   });
 });
@@ -841,6 +875,166 @@ describe('createAcpSessionBridge', () => {
       expect(bridge.sessionCount).toBe(1);
       // The refusal's hold set is adopted, so the daemon now agrees it is busy.
       expect(bridge.activeWork).toBe(true);
+
+      await bridge.shutdown();
+    });
+
+    it('logs the child error detail when a conditional close fails', async () => {
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          // Mirrors the child's drain deadline: a bare Error, which the ACP
+          // SDK turns into a JSON-RPC `-32603` carrying the text in
+          // `data.details` — a plain object on this side, not an Error.
+          throw new Error('Session close timed out after 8000ms');
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        await sendActiveWorkSnapshot(handle, 1, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await bridge.detachClient(session.sessionId, session.clientId);
+
+        await vi.waitFor(() => {
+          expect(stderrSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'did not resolve (Session close timed out after 8000ms)',
+            ),
+          );
+        });
+        // A non-answer still never authorizes teardown.
+        expect(bridge.sessionCount).toBe(1);
+      } finally {
+        stderrSpy.mockRestore();
+      }
+
+      await bridge.shutdown();
+    });
+
+    it('defers further probes after a run of unanswered conditional closes', async () => {
+      let closeAttempts = 0;
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          if (params?.[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] !== true) {
+            return { closed: true, holds: [] };
+          }
+          closeAttempts++;
+          throw new Error('Session close timed out after 8000ms');
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        await sendActiveWorkSnapshot(handle, 1, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await bridge.detachClient(session.sessionId, session.clientId);
+        // The detach probes once; the next snapshot probes again, because one
+        // deferral is the documented recovery for a lost close response.
+        await sendActiveWorkSnapshot(handle, 2, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        // Wait on the daemon's own log rather than `closeAttempts`: the counter
+        // moves when the child is asked, while the backoff is armed only once
+        // the failure has been recorded on this side.
+        await vi.waitFor(() => {
+          const failures = stderrSpy.mock.calls.filter((call) =>
+            String(call[0]).includes('did not resolve'),
+          ).length;
+          expect(failures).toBe(2);
+        });
+        expect(closeAttempts).toBe(2);
+
+        for (const seq of [3, 4, 5]) {
+          await sendActiveWorkSnapshot(handle, seq, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+        }
+        // The deferral is far longer than this settle window, so reaching the
+        // child again here would mean the backoff is not applied at all.
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(closeAttempts).toBe(2);
+        expect(bridge.sessionCount).toBe(1);
+      } finally {
+        stderrSpy.mockRestore();
+      }
+
+      await bridge.shutdown();
+    });
+
+    it('probes again at once once the child reports held work', async () => {
+      let closeAttempts = 0;
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          if (params?.[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] !== true) {
+            return { closed: true, holds: [] };
+          }
+          closeAttempts++;
+          throw new Error('Session close timed out after 8000ms');
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        await sendActiveWorkSnapshot(handle, 1, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await bridge.detachClient(session.sessionId, session.clientId);
+        await sendActiveWorkSnapshot(handle, 2, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await vi.waitFor(() => {
+          const failures = stderrSpy.mock.calls.filter((call) =>
+            String(call[0]).includes('did not resolve'),
+          ).length;
+          expect(failures).toBe(2);
+        });
+
+        // A report of held work is an answer, so the run of failures is over.
+        await sendActiveWorkSnapshot(handle, 3, [
+          { sessionId: session.sessionId, holds: [agentHold('a1')] },
+        ]);
+        expect(bridge.activeWork).toBe(true);
+
+        // Going idle again must probe on the very next snapshot rather than
+        // waiting out a deferral earned against a different state of the
+        // world — a transient wedge is never stranded.
+        await sendActiveWorkSnapshot(handle, 4, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await vi.waitFor(() => expect(closeAttempts).toBe(3));
+        expect(bridge.sessionCount).toBe(1);
+      } finally {
+        stderrSpy.mockRestore();
+      }
 
       await bridge.shutdown();
     });

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -1039,6 +1039,75 @@ describe('createAcpSessionBridge', () => {
       await bridge.shutdown();
     });
 
+    it('still reclaims through a condemned channel while a deferral is armed', async () => {
+      // The deferral backs off a child that cannot answer; it is not a reason
+      // to keep holding a Session in a channel the daemon has already given up
+      // on. `confirmChildUnheld` skips the round trip entirely for a condemned
+      // channel because that teardown is the only thing able to release a
+      // request nobody will answer — so deferring here would leave the Session
+      // registered and the channel unable to drain.
+      vi.useFakeTimers();
+      const lateRestore = deferred<LoadSessionResponse>();
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        loadSessionImpl: () => lateRestore.promise,
+        // The wedged child answers no close at all.
+        extMethodImpl: (method) =>
+          method === SERVE_CONTROL_EXT_METHODS.sessionClose
+            ? new Promise<Record<string, unknown>>(() => {})
+            : Promise.resolve({}),
+      });
+      const bridge = makeBridge({
+        sessionScope: 'thread',
+        maxSessions: 5,
+        sessionRestoreTimeoutMs: 20,
+        channelIdleTimeoutMs: 60_000,
+        channelFactory: async () => handle.channel,
+      });
+      try {
+        const wedged = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+        await sendActiveWorkSnapshot(handle, 1, [
+          { sessionId: wedged.sessionId, holds: [] },
+        ]);
+
+        // Two unanswered probes arm the deferral; the first retry is immediate
+        // by design, so it takes two failures to reach a non-null delay. The
+        // detach cannot be awaited directly: it waits on a close this child
+        // never answers, so the timers have to move first.
+        const detached = bridge.detachClient(wedged.sessionId, wedged.clientId);
+        await vi.advanceTimersByTimeAsync(ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000);
+        await detached;
+        await sendActiveWorkSnapshot(handle, 2, [
+          { sessionId: wedged.sessionId, holds: [] },
+        ]);
+        await vi.advanceTimersByTimeAsync(ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000);
+        expect(handle.killed).toBe(false);
+        expect(bridge.sessionCount).toBe(1);
+
+        // Condemn the channel through the abandoned-restore bound.
+        const timedOut = bridge
+          .loadSession({ sessionId: 'wedged-restore', workspaceCwd: WS_A })
+          .catch((error: unknown) => error);
+        await advanceRestoreDeadline(20);
+        expect(await timedOut).toBeInstanceOf(SessionRestoreTimeoutError);
+        await vi.advanceTimersByTimeAsync(20);
+
+        // The still-armed deferral must not suppress the condemned path: the
+        // next trigger closes locally, and the bounded agent close expiring
+        // kills the channel — the drain this bound exists to force.
+        await sendActiveWorkSnapshot(handle, 3, [
+          { sessionId: wedged.sessionId, holds: [] },
+        ]);
+        await vi.advanceTimersByTimeAsync(ACTIVE_WORK_CLOSE_TIMEOUT_MS);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(handle.killed).toBe(true);
+      } finally {
+        lateRestore.reject(new Error('channel torn down'));
+        await bridge.shutdown();
+        vi.useRealTimers();
+      }
+    });
+
     it.each([
       {
         count: ACTIVE_WORK_MAX_SESSION_HOLDS,

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -1076,6 +1076,81 @@ describe('createAcpSessionBridge', () => {
       }
     });
 
+    it('reconciles a dropped session at once rather than waiting out the deferral', async () => {
+      // The probe is how the daemon reconciles a Session the child has already
+      // destroyed, and the deferral suppresses the probe. A child that finishes
+      // the close one beat late would therefore leave a ghost entry retained
+      // for the whole rung: one `maxSessions` slot, a channel that cannot
+      // retire, and a Session `spawnOrAttach`'s single-scope fast path hands to
+      // the next client because that path checks only daemon-side liveness.
+      //
+      // Absence from the snapshot is the one recovery signal that cannot be
+      // misread, and acting on it is free — the child answers an unknown id
+      // from `closeStoredSession`'s early return without entering the drain. A
+      // wedged child still *lists* the Session with no holds, so the deferral
+      // the wedge needs is untouched, as the suppressed snapshot below shows.
+      let closeAttempts = 0;
+      let wedged = true;
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          if (params?.[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] !== true) {
+            return { closed: true, holds: [] };
+          }
+          closeAttempts++;
+          if (wedged) throw new Error('Session close timed out after 8000ms');
+          return { closed: true, holds: [] };
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        await sendActiveWorkSnapshot(handle, 1, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await bridge.detachClient(session.sessionId, session.clientId);
+        await sendActiveWorkSnapshot(handle, 2, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await vi.waitFor(() => {
+          const failures = stderrSpy.mock.calls.filter((call) =>
+            String(call[0]).includes('did not resolve'),
+          ).length;
+          expect(failures).toBe(2);
+        });
+        expect(closeAttempts).toBe(2);
+
+        // Still listed, still deferred: the backoff is armed and biting.
+        await sendActiveWorkSnapshot(handle, 3, [
+          { sessionId: session.sessionId, holds: [] },
+        ]);
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(closeAttempts).toBe(2);
+        expect(bridge.sessionCount).toBe(1);
+
+        // The wedge clears and the child destroys the Session, so the next
+        // snapshot omits it. That reconciles now, not when the rung expires.
+        wedged = false;
+        await sendActiveWorkSnapshot(handle, 4, []);
+        await vi.waitFor(() => {
+          expect(bridge.sessionCount).toBe(0);
+        });
+        expect(closeAttempts).toBe(3);
+      } finally {
+        stderrSpy.mockRestore();
+      }
+
+      await bridge.shutdown();
+    });
+
     it('keeps the deferred-close detail readable and the failure run reset', async () => {
       // A close the child grants can still fail its own local teardown:
       // `closeSessionImpl` asks the agent with `throwOnFailure`, a definitive

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -912,6 +912,19 @@ describe('createAcpSessionBridge', () => {
             ),
           );
         });
+        // One failure is inside the grace window, so the line must take the
+        // immediate-retry arm. The error detail alone is shared by both arms,
+        // so asserting only that would let them be swapped — telling oncall a
+        // deferral was armed when the retry is in fact immediate — while the
+        // suite stayed green.
+        expect(stderrSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'leaving it in place for the next snapshot to settle',
+          ),
+        );
+        for (const call of stderrSpy.mock.calls) {
+          expect(String(call[0])).not.toContain('deferring the next probe by');
+        }
         // A non-answer still never authorizes teardown.
         expect(bridge.sessionCount).toBe(1);
       } finally {
@@ -963,6 +976,14 @@ describe('createAcpSessionBridge', () => {
           expect(failures).toBe(2);
         });
         expect(closeAttempts).toBe(2);
+        // The second failure is past the grace window, so the line must name
+        // the deferral it actually armed — the rung and the run length — and
+        // not the immediate-retry wording.
+        expect(stderrSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `deferring the next probe by ${ACTIVE_WORK_CLOSE_RETRY_BASE_MS}ms after 2 consecutive failures`,
+          ),
+        );
 
         for (const seq of [3, 4, 5]) {
           await sendActiveWorkSnapshot(handle, seq, [
@@ -979,6 +1000,251 @@ describe('createAcpSessionBridge', () => {
       }
 
       await bridge.shutdown();
+    });
+
+    it('probes again once the deferral expires', async () => {
+      // The gate compares a timestamp, so the deferral has to end. Reducing it
+      // to "a non-null deferral suppresses the probe" would turn the bounded
+      // backoff into a permanent per-session give-up, and nothing else in the
+      // suite would notice: the suppression test passes either way, and the
+      // reset test clears the field through a different branch.
+      let closeAttempts = 0;
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          if (params?.[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] !== true) {
+            return { closed: true, holds: [] };
+          }
+          closeAttempts++;
+          throw new Error('Session close timed out after 8000ms');
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      try {
+        vi.useFakeTimers();
+        try {
+          await sendActiveWorkSnapshot(handle, 1, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          const detached = bridge.detachClient(
+            session.sessionId,
+            session.clientId,
+          );
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          await detached;
+          expect(closeAttempts).toBe(1);
+
+          // A second consecutive failure arms the first rung.
+          await sendActiveWorkSnapshot(handle, 2, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          expect(closeAttempts).toBe(2);
+
+          // Inside the rung the probe is suppressed.
+          await sendActiveWorkSnapshot(handle, 3, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(1_000);
+          expect(closeAttempts).toBe(2);
+
+          // Past the rung it is not: the backoff defers, it never gives up.
+          await vi.advanceTimersByTimeAsync(ACTIVE_WORK_CLOSE_RETRY_BASE_MS);
+          await sendActiveWorkSnapshot(handle, 4, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          expect(closeAttempts).toBe(3);
+          expect(bridge.sessionCount).toBe(1);
+        } finally {
+          vi.useRealTimers();
+        }
+      } finally {
+        await bridge.shutdown();
+      }
+    });
+
+    it('keeps the deferred-close detail readable and the failure run reset', async () => {
+      // A close the child grants can still fail its own local teardown:
+      // `closeSessionImpl` asks the agent with `throwOnFailure`, a definitive
+      // refusal restores `closing = false` and rethrows, and `closeIfChildUnheld`
+      // swallows it — so the entry stays registered and usable. Two things have
+      // to survive that, and neither had a witness:
+      //
+      //   - the log line naming why the teardown failed must carry the child's
+      //     detail. The inner notifier logs the same error as `[object Object]`
+      //     (#11123), so this asserts on the deferred-close line specifically.
+      //   - the child answered, so the run of *unanswered* probes is over. The
+      //     reset has to happen before the `closed === true` early return, or a
+      //     stale count makes the next single failure skip a rung and defer by
+      //     120s instead of retrying at once.
+      let grantConditional = false;
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          const conditional =
+            params?.[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] === true;
+          if (conditional && grantConditional)
+            return { closed: true, holds: [] };
+          if (conditional) {
+            throw new Error('Session close timed out after 8000ms');
+          }
+          throw new Error('agent close exploded');
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        vi.useFakeTimers();
+        try {
+          // Two unanswered probes arm the first rung.
+          await sendActiveWorkSnapshot(handle, 1, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          const detached = bridge.detachClient(
+            session.sessionId,
+            session.clientId,
+          );
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          await detached;
+          await sendActiveWorkSnapshot(handle, 2, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          expect(stderrSpy).toHaveBeenCalledWith(
+            expect.stringContaining('after 2 consecutive failures'),
+          );
+
+          // Past the rung the child grants, then the local teardown fails.
+          grantConditional = true;
+          await vi.advanceTimersByTimeAsync(ACTIVE_WORK_CLOSE_RETRY_BASE_MS);
+          await sendActiveWorkSnapshot(handle, 3, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(ACTIVE_WORK_CLOSE_TIMEOUT_MS);
+          expect(stderrSpy).toHaveBeenCalledWith(
+            expect.stringMatching(
+              /deferred close \([^)]*\) failed for .*agent close exploded/s,
+            ),
+          );
+          expect(bridge.sessionCount).toBe(1);
+
+          // The answer ended the run, so one more unanswered probe must retry
+          // at once rather than reporting a third consecutive failure.
+          grantConditional = false;
+          await sendActiveWorkSnapshot(handle, 4, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          expect(stderrSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining('after 3 consecutive failures'),
+          );
+        } finally {
+          vi.useRealTimers();
+        }
+      } finally {
+        stderrSpy.mockRestore();
+        await bridge.shutdown();
+      }
+    });
+
+    it('quiets the reaper while a deferral is armed', async () => {
+      // The gate sits in `entryIsAutoCloseCandidate`, ahead of every automatic
+      // trigger, rather than inside the probe. Moving it into
+      // `closeIfChildUnheld` would suppress the round trip just the same and
+      // keep every snapshot-driven test green, but the reaper would keep
+      // finding the entry, keep logging `reaping idle session`, and keep
+      // scheduling a teardown it then declines — exactly the noise the
+      // deferral exists to stop. Only a reaper-enabled run can see that.
+      let closeAttempts = 0;
+      vi.useFakeTimers();
+      try {
+        const handle = makeChannel({
+          initializeImpl: () => activeWorkInitializeResponse(),
+          extMethodImpl: async (method, params) => {
+            if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+            if (params?.[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] !== true) {
+              return { closed: true, holds: [] };
+            }
+            closeAttempts++;
+            throw new Error('Session close timed out after 8000ms');
+          },
+        });
+        const bridge = makeBridge({
+          channelFactory: async () => handle.channel,
+          sessionReapIntervalMs: 1_000,
+          sessionIdleTimeoutMs: 1,
+        });
+        const stderrSpy = vi
+          .spyOn(process.stderr, 'write')
+          .mockImplementation(() => true);
+        const reapLines = () =>
+          stderrSpy.mock.calls.filter((call) =>
+            String(call[0]).includes('reaping idle session'),
+          ).length;
+        try {
+          const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+          await sendActiveWorkSnapshot(handle, 1, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          // The detach triggers the first probe and the reaper's next tick the
+          // second, which arms the rung. The child answers with a throw rather
+          // than by stalling, so both failures land inside the first ticks and
+          // the rung is what bounds the rest of the timeline.
+          const detached = bridge.detachClient(
+            session.sessionId,
+            session.clientId,
+          );
+          await vi.advanceTimersByTimeAsync(2_000);
+          await detached;
+          expect(closeAttempts).toBe(2);
+          expect(reapLines()).toBe(1);
+
+          // Thirty reaper ticks inside the rung: no probe and no reap line.
+          await vi.advanceTimersByTimeAsync(30_000);
+          expect(closeAttempts).toBe(2);
+          expect(reapLines()).toBe(1);
+          expect(bridge.sessionCount).toBe(1);
+
+          // Past the rung the reaper picks the session up again — the
+          // deferral bounds the retries, it does not retire the session.
+          await vi.advanceTimersByTimeAsync(ACTIVE_WORK_CLOSE_RETRY_BASE_MS);
+          expect(closeAttempts).toBe(3);
+          expect(reapLines()).toBe(2);
+          expect(bridge.sessionCount).toBe(1);
+        } finally {
+          stderrSpy.mockRestore();
+          await bridge.shutdown();
+        }
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('probes again at once once the child reports held work', async () => {

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -1026,6 +1026,9 @@ describe('createAcpSessionBridge', () => {
       });
       const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
 
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
       try {
         vi.useFakeTimers();
         try {
@@ -1068,10 +1071,25 @@ describe('createAcpSessionBridge', () => {
           );
           expect(closeAttempts).toBe(3);
           expect(bridge.sessionCount).toBe(1);
+          // Rung 2, not rung 1 again: the ladder has to grow at bridge level,
+          // not only in the pure unit test, which feeds
+          // `activeWorkCloseRetryDelayMs` its own inputs. Capping the failure
+          // counter at two, or flattening the ladder call to a constant, keeps
+          // the whole package green while a Session the child can never settle
+          // is re-probed every 60s for the daemon's lifetime instead of backing
+          // off toward the ceiling — the bound this PR exists to add.
+          expect(stderrSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+              `deferring the next probe by ${
+                ACTIVE_WORK_CLOSE_RETRY_BASE_MS * 2
+              }ms after 3 consecutive failures`,
+            ),
+          );
         } finally {
           vi.useRealTimers();
         }
       } finally {
+        stderrSpy.mockRestore();
         await bridge.shutdown();
       }
     });
@@ -1378,6 +1396,104 @@ describe('createAcpSessionBridge', () => {
       }
 
       await bridge.shutdown();
+    });
+
+    it('clears the failure run on a refusal answer, not only on a grant', async () => {
+      // The hoisted reset is documented as covering an answer "granted or
+      // refused", but its other witness drives the granted side only — a close
+      // the child grants whose local teardown then fails. Narrowing the reset
+      // back inside the `closed === true` branch keeps the whole package green,
+      // and a Session whose wedge demonstrably cleared then carries a stale
+      // count: its next single failure skips a rung and defers by 120s instead
+      // of retrying at once. `probes again at once once the child reports held
+      // work` does not cover this, because it clears the run through the
+      // snapshot hold-report branch in `applyActiveWorkSnapshot` and never
+      // through a refusal answer to the probe itself.
+      let closeAttempts = 0;
+      let refuseWithHold = false;
+      const handle = makeChannel({
+        initializeImpl: () => activeWorkInitializeResponse(),
+        extMethodImpl: async (method, params) => {
+          if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+          if (params?.[ACTIVE_WORK_CLOSE_IF_UNHELD_PARAM] !== true) {
+            return { closed: true, holds: [] };
+          }
+          closeAttempts++;
+          if (refuseWithHold) {
+            return { closed: false, holds: [agentHold('a1')] };
+          }
+          throw new Error('Session close timed out after 8000ms');
+        },
+      });
+      const bridge = makeBridge({
+        channelFactory: async () => handle.channel,
+        sessionReapIntervalMs: 0,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        vi.useFakeTimers();
+        try {
+          // Two unanswered probes arm the first rung.
+          await sendActiveWorkSnapshot(handle, 1, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          const detached = bridge.detachClient(
+            session.sessionId,
+            session.clientId,
+          );
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          await detached;
+          await sendActiveWorkSnapshot(handle, 2, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          expect(closeAttempts).toBe(2);
+
+          // Past the rung the child answers with a definitive refusal carrying
+          // a hold. That is an answer, so the run of unanswered probes is over.
+          refuseWithHold = true;
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_RETRY_BASE_MS + 1_000,
+          );
+          await sendActiveWorkSnapshot(handle, 3, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          expect(closeAttempts).toBe(3);
+
+          // The hold then clears on a snapshot that still names the Session, so
+          // it takes the `child_idle` path, which deliberately does not reset.
+          // The wedge is back and the next failure must be the first of a new
+          // run, not the third of the old one.
+          refuseWithHold = false;
+          await sendActiveWorkSnapshot(handle, 4, [
+            { sessionId: session.sessionId, holds: [] },
+          ]);
+          await vi.advanceTimersByTimeAsync(
+            ACTIVE_WORK_CLOSE_TIMEOUT_MS + 1_000,
+          );
+          expect(closeAttempts).toBe(4);
+          expect(stderrSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining('after 3 consecutive failures'),
+          );
+          expect(bridge.sessionCount).toBe(1);
+        } finally {
+          vi.useRealTimers();
+        }
+      } finally {
+        stderrSpy.mockRestore();
+        await bridge.shutdown();
+      }
     });
 
     it('still reclaims through a condemned channel while a deferral is armed', async () => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -1165,9 +1165,13 @@ interface SessionEntry {
   activeWorkCloseInFlight: boolean;
   /**
    * Consecutive conditional-close probes that produced no answer. A run
-   * counter, not a lifetime total: it resets to 0 as soon as the child answers
-   * either way, so a Session that recovers is probed on the next snapshot with
-   * no memory of the earlier failures.
+   * counter, not a lifetime total. Cleared whenever the daemon learns the
+   * world moved on — the child answering a probe either way, a snapshot
+   * reporting held work, or a snapshot omitting the Session because the child
+   * has let go of it — so a Session that recovers visibly is probed again on
+   * the next snapshot with no memory of the earlier failures. One that
+   * recovers silently produces none of those and is probed again when the
+   * rung expires instead; see `activeWorkCloseRetryAt`.
    */
   activeWorkCloseFailures: number;
   /**
@@ -3184,9 +3188,11 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // would otherwise be re-probed at the report cadence for the lifetime of
     // the daemon, each probe spending a full drain budget and each one holding
     // this Session closed to admission while it runs. The delay is derived
-    // from a run of consecutive failures and cleared the moment the child
-    // answers, so a transient wedge costs one deferral rather than being
-    // stranded.
+    // from a run of consecutive failures and cleared whenever the daemon
+    // learns the Session moved on — an answer, a hold report, or the child
+    // dropping it from a snapshot — so a wedge that resolves visibly costs one
+    // deferral rather than being stranded. One that resolves silently is
+    // re-probed when the delay expires, bounded by the ladder's ceiling.
     //
     // A condemned channel is exempt, and so is one that reports no active-work
     // capability — both are cases where `confirmChildUnheld` authorizes the
@@ -3571,6 +3577,21 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         touchActivity();
       }
       if (holds.size === 0) {
+        // Absence is the one recovery signal that cannot be misread: the child
+        // has let go of the Session entirely, so a probe can only answer
+        // `closed`, and it answers an unknown id from `closeStoredSession`'s
+        // early return without ever entering the drain. A backoff earned
+        // against a Session the child was still holding no longer applies, and
+        // keeping it would suppress exactly the reconciliation described above
+        // and strand a ghost entry the child has already destroyed.
+        //
+        // Deliberately not extended to `child_idle`: named with no holds is the
+        // wedge the backoff exists for, and clearing there pins the run at a
+        // single failure forever.
+        if (!reported.has(sessionId)) {
+          entry.activeWorkCloseFailures = 0;
+          entry.activeWorkCloseRetryAt = null;
+        }
         void maybeCloseIdleSession(
           entry,
           reported.has(sessionId) ? 'child_idle' : 'child_dropped',

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -181,6 +181,7 @@ import {
   SESSION_INITIALIZATION_TIMEOUT_ERROR_KIND,
   TODO_STOP_GUARD_QUEUE_RELEASE_METHOD,
   WORKTREE_MCP_DEFER_META_KEY,
+  activeWorkCloseRetryDelayMs,
   isValidTrustedModelPrompt,
   sessionCloseDrainBudgetMs,
 } from './bridgeTypes.js';
@@ -1162,6 +1163,21 @@ interface SessionEntry {
    * snapshot settle the question.
    */
   activeWorkCloseInFlight: boolean;
+  /**
+   * Consecutive conditional-close probes that produced no answer. A run
+   * counter, not a lifetime total: it resets to 0 as soon as the child answers
+   * either way, so a Session that recovers is probed on the next snapshot with
+   * no memory of the earlier failures.
+   */
+  activeWorkCloseFailures: number;
+  /**
+   * Epoch ms before which `entryIsAutoCloseCandidate` suppresses a probe.
+   * Derived from `activeWorkCloseFailures` via `activeWorkCloseRetryDelayMs`;
+   * `null` while probing stays immediate. Gated at the candidacy check rather
+   * than inside the probe so the reaper's own log line stops firing too —
+   * a suppressed probe that still announced itself would read as progress.
+   */
+  activeWorkCloseRetryAt: number | null;
   /**
    * Detailed list of prompts accepted into the FIFO queue. Each entry
    * carries its `promptId`, summary, and an `abortController` so the
@@ -3163,6 +3179,20 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     ) {
       return false;
     }
+    // A probe the child could not answer is retried on the next snapshot, but
+    // not on every snapshot forever: a Session the child can never settle
+    // would otherwise be re-probed at the report cadence for the lifetime of
+    // the daemon, each probe spending a full drain budget and each one holding
+    // this Session closed to admission while it runs. The delay is derived
+    // from a run of consecutive failures and cleared the moment the child
+    // answers, so a transient wedge costs one deferral rather than being
+    // stranded.
+    if (
+      entry.activeWorkCloseRetryAt !== null &&
+      Date.now() < entry.activeWorkCloseRetryAt
+    ) {
+      return false;
+    }
     // DAEMON-005: hold the session open during the prompt-settled grace
     // window so a poll-based client can reconnect without forcing a
     // session-rebuild epoch_reset resync.
@@ -3457,12 +3487,25 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         entry.childHolds = adopted;
         entry.childHoldsAt = Date.now();
       }
+      // The child answered, so the run of unanswered probes is over: whatever
+      // it said, the next snapshot is allowed to ask again immediately.
+      entry.activeWorkCloseFailures = 0;
+      entry.activeWorkCloseRetryAt = null;
       return false;
     } catch (err) {
+      entry.activeWorkCloseFailures++;
+      const delayMs = activeWorkCloseRetryDelayMs(
+        entry.activeWorkCloseFailures,
+      );
+      entry.activeWorkCloseRetryAt =
+        delayMs === null ? null : Date.now() + delayMs;
       writeStderrLine(
         `qwen serve: close-if-unheld for session ${JSON.stringify(entry.sessionId)} ` +
-          `did not resolve (${err instanceof Error ? err.message : String(err)}); ` +
-          `leaving it in place for the next snapshot to settle`,
+          `did not resolve (${extractErrorMessage(err)}); ` +
+          (delayMs === null
+            ? `leaving it in place for the next snapshot to settle`
+            : `leaving it in place and deferring the next probe by ${delayMs}ms ` +
+              `after ${entry.activeWorkCloseFailures} consecutive failures`),
       );
       return false;
     }
@@ -3520,6 +3563,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
           entry,
           reported.has(sessionId) ? 'child_idle' : 'child_dropped',
         );
+      } else {
+        // Reporting held work is an answer, so a run of unanswered close
+        // probes is over: once this Session goes idle again the daemon may
+        // probe it on the next snapshot instead of waiting out a backoff that
+        // was earned against a different state of the world.
+        entry.activeWorkCloseFailures = 0;
+        entry.activeWorkCloseRetryAt = null;
       }
     }
   }
@@ -6927,6 +6977,8 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       childHolds: null,
       childHoldsAt: null,
       activeWorkCloseInFlight: false,
+      activeWorkCloseFailures: 0,
+      activeWorkCloseRetryAt: null,
       retryAllowed: false,
       promptSettledAt: null,
       promptSettledCloseTimer: undefined,

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3176,7 +3176,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     const capability = owner?.activeWork;
     if (
       capability &&
-      !channelIsCondemned(owner) &&
+      childCloseNeedsRoundTrip(owner) &&
       ACTIVE_WORK_HOLD_CATEGORIES.some(
         (category) => !capability.categories.includes(category),
       )
@@ -3194,16 +3194,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // deferral rather than being stranded. One that resolves silently is
     // re-probed when the delay expires, bounded by the ladder's ceiling.
     //
-    // A condemned channel is exempt, and so is one that reports no active-work
-    // capability — both are cases where `confirmChildUnheld` authorizes the
-    // close locally without any child round trip, because that teardown is the
-    // only thing that can release a request nobody is going to answer. There
-    // is no probe to back off from, and deferring would leave the escape hatch
-    // unreachable while the retained Session keeps the channel non-empty, so a
-    // channel already given up on could never drain.
+    // A channel that needs no round trip is exempt: there is no probe to back
+    // off from, and deferring would leave the escape hatch unreachable while
+    // the retained Session keeps the channel non-empty, so a channel already
+    // given up on could never drain.
     if (
-      capability &&
-      !channelIsCondemned(owner) &&
+      childCloseNeedsRoundTrip(owner) &&
       entry.activeWorkCloseRetryAt !== null &&
       Date.now() < entry.activeWorkCloseRetryAt
     ) {
@@ -3858,6 +3854,31 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       ci.overdueAbandonedRestores.size > 0 ||
       ci.newSessionCleanupFailed ||
       ci.overdueAbandonedNewSessions.size > 0
+    );
+  }
+
+  /**
+   * Whether a conditional close on this channel has to ask the child at all.
+   *
+   * The mirror of `confirmChildUnheld`'s two authorize-locally short-circuits:
+   * a channel that never negotiated active-work, and one the session lifecycle
+   * has condemned, are both closed locally with no round trip. Guards that back
+   * off a *probe* must consult this rather than re-derive the pair by hand, or
+   * they keep deferring an entry whose teardown needs nobody's permission — and
+   * for a condemned channel that teardown is the only thing that can release a
+   * request nobody is going to answer, while the retained Session is what keeps
+   * the channel non-empty and its drain from ever completing.
+   *
+   * `confirmChildUnheld`'s third non-round-trip exit, `isDying`, deliberately
+   * does not belong here: it retains the Session rather than authorizing its
+   * close, and it sits ahead of the condemned check, so folding it in would
+   * flip a dying-and-condemned channel from retain to authorize.
+   */
+  function childCloseNeedsRoundTrip(owner: ChannelInfo | undefined): boolean {
+    return (
+      owner !== undefined &&
+      owner.activeWork !== undefined &&
+      !channelIsCondemned(owner)
     );
   }
 

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3410,7 +3410,7 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       }).catch((err) => {
         writeStderrLine(
           `qwen serve: deferred close (${opts.trigger}) failed for ` +
-            `${JSON.stringify(entry.sessionId)}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+            `${JSON.stringify(entry.sessionId)}: ${err instanceof Error ? (err.stack ?? err.message) : extractErrorMessage(err)}`,
         );
       });
     } finally {
@@ -3467,6 +3467,12 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         ACTIVE_WORK_CLOSE_TIMEOUT_MS,
         SERVE_CONTROL_EXT_METHODS.sessionClose,
       );
+      // The child answered, so the run of unanswered probes is over — granted
+      // or refused. Hoisted above the `closed` branch because a granted close
+      // can still fail its local teardown and leave the entry registered and
+      // usable, and it must not carry a stale count into the next probe.
+      entry.activeWorkCloseFailures = 0;
+      entry.activeWorkCloseRetryAt = null;
       if (response['closed'] === true) {
         // The child is done with it; only local teardown remains.
         return true;
@@ -3497,10 +3503,6 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
         entry.childHolds = adopted;
         entry.childHoldsAt = Date.now();
       }
-      // The child answered, so the run of unanswered probes is over: whatever
-      // it said, the next snapshot is allowed to ask again immediately.
-      entry.activeWorkCloseFailures = 0;
-      entry.activeWorkCloseRetryAt = null;
       return false;
     } catch (err) {
       entry.activeWorkCloseFailures++;

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3187,7 +3187,17 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
     // from a run of consecutive failures and cleared the moment the child
     // answers, so a transient wedge costs one deferral rather than being
     // stranded.
+    //
+    // A condemned channel is exempt, and so is one that reports no active-work
+    // capability — both are cases where `confirmChildUnheld` authorizes the
+    // close locally without any child round trip, because that teardown is the
+    // only thing that can release a request nobody is going to answer. There
+    // is no probe to back off from, and deferring would leave the escape hatch
+    // unreachable while the retained Session keeps the channel non-empty, so a
+    // channel already given up on could never drain.
     if (
+      capability &&
+      !channelIsCondemned(owner) &&
       entry.activeWorkCloseRetryAt !== null &&
       Date.now() < entry.activeWorkCloseRetryAt
     ) {

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -326,6 +326,40 @@ export const ACTIVE_WORK_CLOSE_TIMEOUT_MS = 10_000;
 export function sessionCloseDrainBudgetMs(outerWaitMs: number): number {
   return Math.max(1, Math.floor(outerWaitMs * 0.8));
 }
+
+/**
+ * Backoff for a conditional close that keeps failing.
+ *
+ * One deferral is the documented recovery for a lost close response: the next
+ * snapshot asks again, and a child that already closed answers `closed` for a
+ * Session it no longer has. That first retry therefore stays immediate. What
+ * is not recoverable is the same probe failing on every snapshot forever — a
+ * Session the child can never settle would otherwise be re-probed at the
+ * report cadence for the lifetime of the daemon, spending a full drain budget
+ * each time. Past `GRACE` consecutive failures the next probe is deferred
+ * geometrically up to `CEILING`.
+ *
+ * The count resets whenever the child answers, so a transient wedge is never
+ * stranded: the Session goes back to being probed on the next snapshot exactly
+ * as it was before the run of failures began.
+ */
+export const ACTIVE_WORK_CLOSE_RETRY_GRACE = 1;
+export const ACTIVE_WORK_CLOSE_RETRY_BASE_MS = 60_000;
+export const ACTIVE_WORK_CLOSE_RETRY_CEILING_MS = 3_600_000;
+
+/**
+ * How long to defer the next conditional-close probe after `failures`
+ * consecutive unanswered probes; `null` while probing stays immediate.
+ */
+export function activeWorkCloseRetryDelayMs(failures: number): number | null {
+  if (failures <= ACTIVE_WORK_CLOSE_RETRY_GRACE) return null;
+  const exponent = failures - ACTIVE_WORK_CLOSE_RETRY_GRACE - 1;
+  return Math.min(
+    ACTIVE_WORK_CLOSE_RETRY_BASE_MS * 2 ** exponent,
+    ACTIVE_WORK_CLOSE_RETRY_CEILING_MS,
+  );
+}
+
 /** Bounds on a single snapshot. Generous next to any real deployment — it
  *  exists so a version-skewed or buggy child cannot make the daemon walk an
  *  unbounded Session list per report. An oversized packet is discarded whole. */

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -339,9 +339,15 @@ export function sessionCloseDrainBudgetMs(outerWaitMs: number): number {
  * each time. Past `GRACE` consecutive failures the next probe is deferred
  * geometrically up to `CEILING`.
  *
- * The count resets whenever the child answers, so a transient wedge is never
- * stranded: the Session goes back to being probed on the next snapshot exactly
- * as it was before the run of failures began.
+ * The count resets on any evidence that the world moved on — the child
+ * answering a probe either way, a snapshot reporting held work, or a snapshot
+ * omitting the Session because the child has let go of it — so a wedge that
+ * resolves visibly is never stranded, and goes back to being probed on the
+ * next snapshot exactly as it was before the run of failures began. A wedge
+ * that resolves silently is not: work of a kind the child cannot report as a
+ * hold (see #11118) produces none of those signals, so such a Session is
+ * probed again when the rung expires instead, and `CEILING` is what bounds
+ * that rather than any reset.
  */
 export const ACTIVE_WORK_CLOSE_RETRY_GRACE = 1;
 export const ACTIVE_WORK_CLOSE_RETRY_BASE_MS = 60_000;

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -4109,6 +4109,26 @@ describe('Session', () => {
     await session.waitForActiveTurnsToSettle();
   });
 
+  it('polls rather than spins when the active turn publishes no completion', async () => {
+    // `historyMutationActive` blocks `#hasActiveTurn()` without publishing a
+    // completion promise, so the wait has nothing to await. Yielding on
+    // `setImmediate` alone would cycle the event loop as fast as it can turn
+    // and burn a core for the whole wait — on the conditional-close path that
+    // is the full drain budget. Counting the yields is the observable proxy:
+    // the polled wait makes none from this path.
+    const releaseMutation = session.beginHistoryMutation();
+    const immediateSpy = vi.spyOn(globalThis, 'setImmediate');
+    try {
+      const waiting = session.waitForActiveTurnsToSettle();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      releaseMutation();
+      await waiting;
+      expect(immediateSpy).toHaveBeenCalledTimes(0);
+    } finally {
+      immediateSpy.mockRestore();
+    }
+  });
+
   it('rejects a prompt when the close gate starts during writer admission', async () => {
     let resolveAdmission!: () => void;
     const admission = new Promise<void>((resolve) => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -4118,14 +4118,32 @@ describe('Session', () => {
     // the polled wait makes none from this path.
     const releaseMutation = session.beginHistoryMutation();
     const immediateSpy = vi.spyOn(globalThis, 'setImmediate');
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     try {
-      const waiting = session.waitForActiveTurnsToSettle();
+      let settled = false;
+      const waiting = session.waitForActiveTurnsToSettle().then(() => {
+        settled = true;
+      });
+      // The hold is still up, so the wait must still be waiting. Without this
+      // a `#hasActiveTurn()` that stopped consulting `historyMutationActive`
+      // would resolve at once and both yield counts below would be vacuously
+      // zero — the test would pass while pinning nothing.
       await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(settled).toBe(false);
       releaseMutation();
       await waiting;
+      expect(settled).toBe(true);
       expect(immediateSpy).toHaveBeenCalledTimes(0);
+      // The poll has to be a real interval, and the constant is module-local
+      // so the literal has to be spelled here. A 0ms `setTimeout` still hands
+      // back a macrotask, so the count above stays green while the loop
+      // re-arms as fast as the event loop turns — the same spin, one level
+      // down. Two re-arms is the floor: 50ms of holding at 10ms allows ~5.
+      const polls = timeoutSpy.mock.calls.filter((call) => call[1] === 10);
+      expect(polls.length).toBeGreaterThanOrEqual(2);
     } finally {
       immediateSpy.mockRestore();
+      timeoutSpy.mockRestore();
     }
   });
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1035,6 +1035,13 @@ const MID_TURN_QUEUE_DRAIN_TIMEOUT_MS = 2_000;
 // into an unrelated turn's context.
 const MID_TURN_QUEUE_RECOVERY_TIMEOUT_MS = 30_000;
 const MID_TURN_QUEUE_RESOLVE_TIMEOUT_MS = 10_000;
+// `waitForActiveTurnsToSettle` polls at this interval when the active turn
+// publishes no completion promise to await — `goalProcessing` and
+// `historyMutationActive` both block `#hasActiveTurn()` without one. Yielding
+// on `setImmediate` alone would cycle the event loop as fast as it can turn and
+// burn a core for the whole wait, which on the conditional-close path is the
+// full drain budget.
+const ACTIVE_TURN_POLL_INTERVAL_MS = 10;
 const MAX_MID_TURN_DRAIN_ITEMS = 10;
 const MID_TURN_ATTACHMENT_PROCESSING_FAILURE_TEXT =
   '[Attachment could not be processed]';
@@ -4153,8 +4160,15 @@ export class Session implements SessionContext {
       );
       if (pending.length > 0) {
         await Promise.allSettled(pending);
+        // Yield a macrotask, not just microtasks: these flags can be cleared by
+        // work queued behind this loop, and re-reading them before that runs
+        // would miss the settle.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      } else {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, ACTIVE_TURN_POLL_INTERVAL_MS),
+        );
       }
-      await new Promise<void>((resolve) => setImmediate(resolve));
     }
   }
 


### PR DESCRIPTION
## What this PR does

A daemon session that is doing certain kinds of work can end up in a state where automatic reclaim asks the child process to close it, the child cannot, and the daemon then asks again on every report for as long as it runs. This PR does not make that session reclaimable — it makes the repeated failure cheap, bounded, and readable, and it removes a CPU burn that accompanies one variant of it.

Three changes:

A conditional close that the child could not answer was retried on every active-work snapshot with no backoff, no bound, and no terminal state. It is now deferred geometrically after the first retry, capped at an hour. The first retry deliberately stays immediate, because one deferral is the documented recovery for a lost close response and an existing test pins that behaviour. The deferral is cleared the moment the child answers in either direction, so a session that recovers is probed on the next snapshot with no memory of the earlier failures and is never stranded. The gate sits in the auto-close candidacy check rather than inside the probe, so the reaper also stops announcing a reclaim it is no longer attempting — a suppressed probe that still logged `reaping idle session` would read as progress to an operator.

The daemon's log line for a failed probe interpolated the caught value behind an `instanceof Error` check. A JSON-RPC error crosses the channel as a plain object, so the line printed `[object Object]` and discarded the code, the message, and the detail that actually named the failure. It now uses the error-extraction helper this file already exports for exactly that shape.

The settle wait that a conditional close blocks on had nothing to await whenever the active work publishes no completion promise, and degraded to a bare `setImmediate` loop. Measured at 17,162 event-loop cycles in a 50ms window — roughly 343k/s — which is a full core burned for the entire drain budget. It now polls on a short interval in that case, while keeping the macrotask yield on the branch that does have a promise to await, which a separate existing test pins.

## Why it's needed

This was found on a long-running daemon, not constructed. One session accumulated 973 consecutive failed reclaim rounds over roughly sixteen hours at a constant interval, in a strict 1:1:1 ratio with the reap attempts and the child-side close timeouts, with zero convergence. Each round spent a full drain budget on the child, and while a probe is outstanding the session is closed to admission — so for a large fraction of every cycle it could not be attached, prompted, branched, or rewound.

None of that was visible. `GET /health` returned `{"status":"ok"}` throughout, and the session's own status reported no active prompt, no pending interaction, and no turn error. The only evidence was log volume, and the daemon's own line explaining each failure printed `[object Object]` — so the one place that should have said why said nothing. Diagnosing this required reconstructing the cause from an unrelated multi-line dump the ACP SDK happens to print above it.

The root cause is that four kinds of in-flight work block a session from settling but cannot be expressed in the negotiated active-work hold categories, so such a session reports no held work while being impossible to close. That is a protocol-scope question with a real mixed-version cost and is filed as #11118 rather than decided here. These three changes are worth landing independently of that decision: they bound the damage for any deterministically failing close, whatever blocks it, and they make the next one diagnosable from the daemon's own log.

## Reviewer Test Plan

### How to verify

The behaviour is observable end to end without any source modification, by making a session's work un-settleable and watching the daemon try to reclaim it.

Start an isolated daemon on an ephemeral port with a short reap interval and a temporary workspace, pointed at a mock model endpoint. Have the mock answer one prompt with a call that schedules a cron job, then never answer any request belonging to that job. Leave the session with a registered client id and no subscribers, so only the reaper can trigger the close. Then detach and watch the daemon log.

Before this change the log repeats one identical block per reap interval forever, at a constant interval that never grows, and the daemon's own line reads `did not resolve ([object Object])`. After it, the first retry still happens promptly, subsequent ones are deferred by a growing interval, the deferral is stated in the log along with the consecutive-failure count, `reaping idle session` stops appearing while a deferral is armed, and the failure line names the real cause.

The anti-stranding guarantee is the part worth pressing on: once a deferral is armed, make the child report held work again and then let it go idle. The probe must come back on the next report rather than waiting out the remaining deferral. Two unit tests pin this from both directions — neutering the deferral gate makes a test observe five probes where it expects two, and neutering the reset makes a test fail to reach a third probe after the child has answered.

For the CPU burn, the reachable check is the unit test that counts `setImmediate` calls during a settle wait whose only blocking state publishes no completion promise. It observes 17,162 calls before the change and 0 after.

Verified end to end against a daemon built from this branch, with the spawned child process confirmed from its own command line to be the patched build rather than the installed release. Same un-settleable-cron-turn harness, plus a switch on the mock endpoint that makes the child report real held work on demand:

| # | reap at | drain | daemon verdict | Δ from previous reap |
| - | ------- | ----- | -------------- | -------------------- |
| 1 | 22:08:32.150 | 8.004s | immediate retry | — |
| 2 | 22:08:42.151 | 8.002s | `deferring … by 60000ms after 2` | 10.001s |
| 3 | 22:09:52.226 | 8.002s | `deferring … by 120000ms after 3` | 70.075s |
| 4 | 22:12:02.227 | 8.002s | `deferring … by 240000ms after 4` | 130.001s |

The gaps are the 8s drain plus the logged deferral plus alignment to the next reap tick, not the bare deferral — so 70s and 130s are the expected numbers rather than drift. `reaping idle session` goes silent through each deferral (62.1s, 122.0s, 141.6s of silence) while the tick itself is demonstrably live, which is the intended effect of gating at the candidacy check. The observation window was 7m41s covering three successive deferrals; the 480s step and the one-hour ceiling were not reached.

`[object Object]` occurrences across the whole run: **0**, against 24 of 24 rounds on the unpatched build. A corroborating shift in the same logs: the child's timeout detail now appears twice per round — once in the forwarded error block, once in the daemon's own line — where it previously appeared once, precisely because the daemon's line used to print `[object Object]`.

Anti-stranding, the sharpest result: attempt 4 armed a 240s deferral permitting no probe before 22:16:10.229. The mock was then switched so the child reported real held work and subsequently went idle. The probe fired at 22:14:31.873 — **98.36s earlier than the armed deferral allowed** — and succeeded, with the session removed. Caveat, stated plainly: the switch also unwedged the turn, so this demonstrates the deferral clearing and the recovery together. The narrower "deferral cleared but the close still fails" case is covered by the unit test, not end to end.

Happy path, in a separate run: first eligible tick, 7ms from reap to close, zero failures, zero deferrals.

Retention: mid-loop the session's status endpoint returned 200 and daemon status reported one active session, status ok, no issues. Across the run there were no deferred closes, no outer request timeouts, no channel kills, and a single child process throughout. Tally 5 reaps / 4 failures / 3 deferrals / 1 success, against 17/16/0/0 and 9/8/0/0 on the unpatched build, neither of which ever converged.

Not covered end to end: the polling fix. The reachable scenario publishes a completion promise and so never enters that branch, and there is no external way to construct the blocking state that does. The unit test above is its only evidence.

### Evidence (Before & After)

Non-UI change, but the behaviour is directly observable in the daemon log and in unit-test measurements.

Before — one round of the production loop, repeated 973 times over ~16h at a constant interval:

```console
qwen serve: reaping idle session "8ff8c48f-…" (idle for 209578s, threshold 1800s)
[serve pid=1204413 cwd=…] Error handling request { … method: 'qwen/control/session/close',
  params: { onlyIfUnheld: true, drainTimeoutMs: 8000 } } { code: -32603,
  message: 'Internal error', data: { details: 'Session close timed out after 8000ms' } }
qwen serve: close-if-unheld for session "8ff8c48f-…" did not resolve ([object Object]); leaving it in place for the next snapshot to settle
```

After — same failure, with the cause named and the retry deferred:

```console
qwen serve: close-if-unheld for session "…" did not resolve (Session close timed out after 8000ms); leaving it in place and deferring the next probe by 60000ms after 2 consecutive failures
```

Settle-wait `setImmediate` calls in a 50ms window, blocking work that publishes no completion promise: **17,162 → 0**.

Test suite: `packages/acp-bridge` 1949/1949 passing (35 files), including three new tests; `Session.test.ts` and `acpAgent.test.ts` 1432 passing with one failure that is pre-existing on the base commit — verified by stashing this branch's changes and reproducing the identical failure on a clean tree. That test scans a source file this PR does not touch.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Isolated git worktree at the current `origin/main`, dependencies installed from the lockfile rather than shared with another checkout. Unit tests via vitest inside each package. End-to-end verification via a real `qwen serve` daemon built from this branch and driven over its own HTTP API, with a throwaway mock model endpoint, an ephemeral port, a temporary workspace, and isolated `HOME`/`QWEN_HOME`/`QWEN_RUNTIME_DIR` so nothing was written into the developer's real config. The production daemon on this machine was left running and untouched throughout; its PID was verified unchanged before and after.

## Risk & Scope

- Main risk or tradeoff: the backoff means a session that would have closed on a later attempt is reclaimed later than it would have been. The first retry stays immediate and the deferral clears on any answer from the child, so the exposure is limited to work that is genuinely un-settleable — which today is retried forever anyway. The ceiling is one hour, after which probing resumes, so nothing is permanently abandoned.
- A second, narrower tradeoff: the deferral is cleared when the child answers, not when the session is used again. A session that was wedged, then served a prompt successfully, then went idle could wait out a deferral of up to an hour before being reclaimed. This is bounded and only delays cleanup; it was judged not worth a second reset hook and the additional state that would come with it.
- The exposure is not only reclaim. The gate sits in `entryIsAutoCloseCandidate`, which both the TTL reaper and `maybeCloseIdleSession` consult, so an armed deferral also delays a **client-driven close-on-last-detach**. Measured with the reaper disabled entirely and a 60s rung armed, an ordinary detach-triggered close landed 46.8s after the session became closable, against 6.8s on the base build. An explicit `DELETE /session/:id` is unaffected — it does not go through the candidacy check, and returned 204 in 72ms with a deferral armed — so nothing is stranded from a user's point of view. Figures from @wenshao's local verification on real daemons, both arms.
- Not validated / out of scope: the root cause. Sessions doing cron, goal, monitor-notification, or history-mutation work still cannot be reclaimed, because that work still cannot be reported as a hold. This PR bounds and diagnoses the failure; it does not remove it.
- Not validated / out of scope: a second site in the same file formats a caught ACP-boundary error the same way and also prints `[object Object]`, on the path shared by explicit close and kill. It is confirmed reachable — an existing test drives a real in-memory ACP channel whose child throws a genuine `RequestError`, and that is what emits the line — and is now filed as #11123. Left alone here to keep this change narrow: the pattern appears 21 times in the file across two spellings, 7 of them inside operator-visible log lines (narrow scope: counting every variable carrying the same shape, including the `(err.stack ?? err.message)` variant, gives 37/20 — both counts are correct for their own scope, see the scope note on #11123), and most of the remainder catch purely local errors where the fallback is harmless, so each site needs its own judgement rather than a blanket sweep.
- Not validated / out of scope: the CPU fix is not exercised end to end. The reachable scenario has a completion promise to await and so never enters the polling branch, and there is no external way to construct the blocking state that does. It is covered by a unit test only.
- Breaking changes / migration notes: none. No wire format, protocol, or public API changes. Two fields are added to an internal per-session record, and one new log wording appears only when a deferral is actually armed. The unchanged first-retry behaviour and the unchanged retained-on-non-answer guarantee are both pinned by pre-existing tests that still pass.

## Linked Issues

Does not close any issue. The root cause — in-flight work that blocks a session from settling but cannot be expressed in the negotiated active-work hold categories — is filed as #11118 and stays open after this PR.

Related: #8586 documents the deliberate exclusion of cron and similar work from the reported active-work field, and warns that a controller must not read the absence of reported work as "nothing is running". This PR does not widen that scope.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

一个正在做某些种类工作的 daemon session 会进入这样一种状态：自动回收请子进程关闭它，子进程关不掉，于是 daemon 在此后每一份上报里都再问一次，只要它还在跑就一直问下去。本 PR **不会**让这样的 session 变得可回收 —— 它让这种反复失败变得廉价、有界、可读，并消除其中一个变体伴随的 CPU 空转。

三处改动：

子进程无法回答的条件式 close，原本在每一份 active-work snapshot 上都被重试，没有退避、没有上界、也没有终止状态。现在从第一次重试之后开始按几何级数推迟，上限一小时。**第一次重试刻意保持即时**，因为一次性的推迟正是「close 响应丢失」的成文恢复路径，并且有一条既有测试钉住了这个行为。推迟会在子进程任一方向给出回答的那一刻立即清除，所以一个恢复过来的 session 会在下一份 snapshot 就被重新 probe，不记得之前的失败，也就永远不会被搁浅。这道门放在自动回收的 candidacy 检查里，而不是放在 probe 内部 —— 这样 reaper 也会停止宣告一个它其实已经不再尝试的回收；一个被抑制却仍打印 `reaping idle session` 的 probe，在运维看来就像是在推进。

daemon 记录 probe 失败的那行日志，原本在一个 `instanceof Error` 判断后面插值被捕获的值。JSON-RPC 错误跨通道传回来是普通对象，所以那行打出 `[object Object]`，把 code、message，以及真正点明失败的 detail 全部丢弃。现在改用这个文件本身已经为这种形状导出的错误提取 helper。

条件式 close 所阻塞的那个 settle 等待，在活跃工作不发布 completion promise 时没有任何东西可等，于是退化成裸 `setImmediate` 循环。实测 50ms 窗口内 17,162 次事件循环 —— 约 34.3 万次/秒 —— 即在整个 drain 预算里烧满一个核。现在这种情况下改为短间隔轮询，同时在**确实有 promise 可等**的那一支保留宏任务让出，因为另有一条既有测试钉住了它。

## 为什么需要

这是在一个长期运行的 daemon 上发现的，不是构造出来的。某个 session 在约十六小时内累计了 973 轮连续失败的回收尝试，间隔恒定，与 reap 尝试和子进程侧 close 超时严格保持 1:1:1，零收敛。每轮都在子进程上烧满一个 drain 预算，而 probe 在飞期间该 session 对 admission 关闭 —— 所以在每个周期里相当大的比例内，它无法被 attach、prompt、branch 或 rewind。

而这些全都不可见。`GET /health` 全程返回 `{"status":"ok"}`，该 session 自己的状态也报告没有活跃 prompt、没有待处理交互、没有 turn error。唯一的证据是日志量，而 daemon 自己那行解释失败原因的日志打的是 `[object Object]` —— 于是唯一本该说明原因的地方什么都没说。要诊断它，只能从 ACP SDK 恰好在上方打印的一段无关的多行转储里反推。

根因是：有四种正在进行的工作会阻止 session settle，却无法用协商好的 active-work hold 类别表达，所以这样的 session 一边报告「没有持有工作」、一边无法被关闭。那是一个带有真实混合版本代价的协议范围问题，已提交为 #11118，而不是在这里决定。这三处改动值得独立于那个决定先落地：它们为**任何**确定性失败的 close 封顶损害（不论阻塞物是什么），并让下一次故障能从 daemon 自己的日志里诊断出来。

## 评审测试计划

### 如何验证

无需修改任何源码即可端到端观察到该行为：让一个 session 的工作变得无法 settle，然后看着 daemon 尝试回收它。

在临时端口上起一个隔离 daemon，配置较短的 reap 间隔和临时 workspace，指向一个 mock 模型端点。让 mock 对某个 prompt 回一个「排定 cron 任务」的调用，此后凡属于该任务的请求一律不响应。让 session 保留一个已注册的 client id 且无订阅者，于是只有 reaper 能触发 close。然后 detach，观察 daemon 日志。

改动前，日志会以恒定的、从不增长的间隔永远重复同一个块，而 daemon 自己那行是 `did not resolve ([object Object])`。改动后，第一次重试仍然很快发生，后续的按递增间隔推迟，日志里会写明推迟时长与连续失败次数，`reaping idle session` 在推迟生效期间不再出现，失败行会点明真实原因。

**防搁浅保证是最值得施压的部分**：一旦推迟生效，让子进程重新报告持有工作，然后再让它变空闲。probe 必须在下一份上报就回来，而不是等剩下的推迟时间走完。有两条单测从两个方向钉住了这一点 —— 把推迟门打瘸，一条测试会观察到 5 次 probe 而它期望 2 次；把清零打瘸，一条测试会在子进程已经回答之后到不了第 3 次 probe。

至于 CPU 空转，可达的检查是那条统计 `setImmediate` 调用次数的单测：在一个「唯一阻塞状态不发布 completion promise」的 settle 等待期间，改动前观察到 17,162 次，改动后 0 次。

已用**由本分支构建出的 daemon** 做端到端验证，并从子进程自己的命令行确认它是打了补丁的构建、而非装机的发布版。仍是同一套「cron turn 无法 settle」装置，外加 mock 端点上一个开关，可按需让子进程报告真实的持有工作：

| # | reap 时刻 | drain | daemon 判定 | 与上一次 reap 的间隔 |
| - | ------- | ----- | -------------- | -------------------- |
| 1 | 22:08:32.150 | 8.004s | 立即重试 | — |
| 2 | 22:08:42.151 | 8.002s | `deferring … by 60000ms after 2` | 10.001s |
| 3 | 22:09:52.226 | 8.002s | `deferring … by 120000ms after 3` | 70.075s |
| 4 | 22:12:02.227 | 8.002s | `deferring … by 240000ms after 4` | 130.001s |

这些间隔是「8s drain + 日志里的推迟时长 + 对齐到下一个 reap tick」，而不是裸的推迟时长 —— 所以 70s 与 130s 是预期数字，不是漂移。每次推迟期间 `reaping idle session` 都会静默（分别静默 62.1s、122.0s、141.6s），而 tick 本身可证明仍在跳动 —— 这正是把门放在 candidacy 检查里的预期效果。观察窗口 7 分 41 秒，覆盖三次连续推迟；**未触及** 480s 那一档与一小时上限。

整轮运行中 `[object Object]` 出现次数：**0**，而未打补丁的构建是 24 轮全中。同一批日志里有一个相互印证的变化：子进程的超时详情现在每轮出现**两次** —— 一次在转发的错误块里，一次在 daemon 自己那行 —— 而此前只出现一次，原因恰恰是 daemon 那行以前打的是 `[object Object]`。

防搁浅，也是最锋利的一条结果：第 4 次尝试武装了一个 240s 推迟，允许下次 probe 的最早时刻是 22:16:10.229。随后切换 mock，让子进程报告真实的持有工作、之后再转为空闲。probe 在 22:14:31.873 触发 —— 比武装的推迟所允许的**早 98.36s** —— 并且成功，session 被移除。坦白说明其局限：这次切换同时也解开了那个 turn 的卡死，所以它一并展示了「推迟被清除」与「恢复」两件事。更窄的「推迟已清除但 close 仍然失败」那一情形由单测覆盖，未做端到端。

Happy path（另一次运行）：第一个符合条件的 tick，reap 到 close 7ms，零失败、零推迟。

保留性：循环中段该 session 的状态端点返回 200，daemon 状态报告一个 active session、status ok、issues 为空。整轮运行中没有 deferred close、没有外层请求超时、没有 channel kill，全程单一子进程。计数为 5 reap / 4 失败 / 3 推迟 / 1 成功，而未打补丁的构建是 17/16/0/0 与 9/8/0/0，两者都从未收敛。

**未做端到端覆盖**：轮询修复。可达的场景会发布 completion promise，因此从不进入那个分支，而没有外部手段能构造出会进入的阻塞状态。上面那条单测是它唯一的证据。

### 证据（改动前后）

非 UI 改动，但行为在 daemon 日志和单测度量里都可直接观察。

改动前 —— 生产循环的一轮，在约 16 小时内以恒定间隔重复了 973 次：

```console
qwen serve: reaping idle session "8ff8c48f-…" (idle for 209578s, threshold 1800s)
[serve pid=1204413 cwd=…] Error handling request { … method: 'qwen/control/session/close',
  params: { onlyIfUnheld: true, drainTimeoutMs: 8000 } } { code: -32603,
  message: 'Internal error', data: { details: 'Session close timed out after 8000ms' } }
qwen serve: close-if-unheld for session "8ff8c48f-…" did not resolve ([object Object]); leaving it in place for the next snapshot to settle
```

改动后 —— 同样的失败，但点明了原因且重试被推迟：

```console
qwen serve: close-if-unheld for session "…" did not resolve (Session close timed out after 8000ms); leaving it in place and deferring the next probe by 60000ms after 2 consecutive failures
```

settle 等待在 50ms 窗口内的 `setImmediate` 调用次数（阻塞工作不发布 completion promise 的情形）：**17,162 → 0**。

测试套件：`packages/acp-bridge` 1949/1949 通过（35 个文件），含三条新测试；`Session.test.ts` 与 `acpAgent.test.ts` 1432 通过、1 个失败，该失败在基线提交上**预存** —— 已通过 stash 掉本分支改动、在干净树上复现出完全相同的失败来验证。那条测试扫描的是本 PR 未触碰的源文件。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 环境（可选）

基于当前 `origin/main` 的隔离 git worktree，依赖从 lockfile 实装而非与另一个 checkout 共享。单测在各 package 内用 vitest 运行。端到端验证用一个由本分支构建出的真实 `qwen serve` daemon，通过它自己的 HTTP API 驱动，配一次性 mock 模型端点、临时端口、临时 workspace，以及隔离的 `HOME`/`QWEN_HOME`/`QWEN_RUNTIME_DIR`，因此没有任何东西被写进开发者真实的配置目录。本机的生产 daemon 全程保持运行且未被触碰，其 PID 在前后均已核实未变。

## 风险与范围

- 主要风险或取舍：退避意味着一个本来会在更晚某次尝试中关闭成功的 session，会比原先更晚被回收。第一次重试保持即时、且推迟会在子进程任何回答时清除，所以暴露面仅限于真正无法 settle 的工作 —— 而这类工作今天本来就被永远重试。上限是一小时，之后 probe 恢复，所以没有任何东西被永久放弃。
- 第二个更窄的取舍：推迟是在**子进程回答**时清除，而不是在 session 被再次使用时清除。一个先卡住、随后成功服务了一次 prompt、然后转为空闲的 session，可能要等最长一小时的推迟走完才被回收。这是有界的，且只延迟清理；判断下来不值得为它再加一个 reset 钩子及其带来的额外状态。
- 暴露面不只是回收。这道门位于 `entryIsAutoCloseCandidate`，而 TTL reaper 与 `maybeCloseIdleSession` 都会查询它，因此已武装的推迟同样会延迟**由客户端触发的 close-on-last-detach**。在完全关闭 reaper、并武装 60s 推迟的条件下实测：一次普通的 detach 触发的 close，在 session 变为可关闭之后 46.8s 才落地，而 base 构建是 6.8s。显式的 `DELETE /session/:id` 不受影响 —— 它不经过 candidacy 检查，在推迟已武装时 72ms 返回 204 —— 所以从用户视角看不存在任何搁浅。数据取自 @wenshao 在两个真实 daemon 上对两条臂做的本地验证。
- 未验证 / 范围外：**根因**。正在做 cron、goal、monitor 通知或历史改写工作的 session 仍然无法被回收，因为那些工作仍然无法被上报为 hold。本 PR 为失败封顶并使其可诊断，但没有消除它。
- 未验证 / 范围外：同一文件里还有第二处以同样方式格式化跨 ACP 边界错误、同样打出 `[object Object]` 的位置，在显式关闭与 kill 共用的那条路径上。它已确认可达 —— 有一条既有测试驱动真实 in-memory ACP 通道、其子进程抛出真正的 `RequestError`，那行就是它产生的 —— 现已提交为 #11123。这里没有动，是为了保持本改动窄：该模式在文件里以两种写法共出现 21 次，其中 7 次在运维可见的日志行内（窄口径：若把所有同一形状的变量都算进来，含 `(err.stack ?? err.message)` 变体，则为 37/20 —— 两个计数在各自口径下都正确，口径说明见 #11123），其余多数捕获的是纯本地错误、兜底无害，因此每一处都需要单独判断，而不是一刀切地扫。
- 未验证 / 范围外：CPU 修复未做端到端验证。可达的场景有 completion promise 可等，因此从不进入轮询分支，而没有外部手段能构造出那个会进入的阻塞状态。它只有单测覆盖。
- 破坏性变更 / 迁移说明：无。没有 wire format、协议或公共 API 变更。内部 per-session 记录增加两个字段，且只在推迟真正生效时才多一种日志措辞。「首次重试行为不变」与「非答案时仍保留 session」这两条保证都由既有测试钉住，且仍然通过。

## 关联 Issue

不关闭任何 issue。根因 —— 正在进行的工作会阻止 session settle 却无法用协商好的 active-work hold 类别表达 —— 已提交为 #11118，在本 PR 之后仍然是开放状态。

相关：#8586 记录了「cron 及类似工作被有意排除在上报的 active-work 字段之外」，并警告控制器不得把「没有上报工作」读成「什么都没在跑」。本 PR 不扩大该范围。

</details>



