### PR TITLE
fix(core): replay retained shell notifications after transient unbind

### DIFF
--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -724,6 +724,68 @@ describe('BackgroundShellRegistry', () => {
       expect(reg.get('a')!.notified).toBe(false);
       expect(reg.get('b')!.notified).toBe(false);
     });
+
+    it('defers a terminal notification dropped with no callback and redelivers it on rebind (#11119)', () => {
+      const reg = new BackgroundShellRegistry();
+      const outputPath = makeOutputFile('done\n');
+      reg.register(
+        makeEntry({ shellId: 'a', command: 'npm test', outputPath }),
+      );
+
+      // The shell finishes while no consumer is bound — the owning Session
+      // was disposed/recycled. Previously this was consumed and lost forever.
+      reg.complete('a', 0, 2000);
+
+      const dropped = reg.get('a')!;
+      expect(dropped.notified).toBe(false);
+      expect(dropped.notificationPending).toBe(true);
+
+      // A new Session re-registers a callback (resume / new runtime
+      // generation). The deferred notification must be replayed exactly once
+      // instead of silently planting the session.
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [displayText, modelText, meta] = callback.mock.calls[0];
+      expect(displayText).toBe('Background shell "npm test" completed.');
+      expect(modelText).toContain('<task-id>a</task-id>');
+      expect(modelText).toContain('<status>completed</status>');
+      expect(meta).toEqual({
+        shellId: 'a',
+        status: 'completed',
+        exitCode: 0,
+      });
+
+      const healed = reg.get('a')!;
+      expect(healed.notified).toBe(true);
+      expect(healed.notificationPending).toBe(false);
+    });
+
+    it('redelivers deferred notifications once and never resurrects abortAll cancellations (#11119)', () => {
+      const reg = new BackgroundShellRegistry();
+      // 'a' finishes while unbound → deferred. 'b' is settled by shutdown
+      // cleanup (abortAll), which intentionally emits no notification.
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.register(makeEntry({ shellId: 'b' }));
+      reg.complete('a', 0, 2000);
+      reg.abortAll();
+
+      expect(reg.get('a')!.notificationPending).toBe(true);
+      expect(reg.get('b')!.notificationPending).toBeFalsy();
+
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+
+      // Only the deferred 'a' replays; the suppressed 'b' stays silent.
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback.mock.calls[0][2]).toMatchObject({ shellId: 'a' });
+
+      // Rebinding a second time must not double-deliver the consumed 'a'.
+      const callback2 = vi.fn();
+      reg.setNotificationCallback(callback2);
+      expect(callback2).not.toHaveBeenCalled();
+    });
   });
 
   describe('requestCancel', () => {

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -760,24 +760,24 @@ describe('BackgroundShellRegistry', () => {
       expect(reg.get('a')!.notified).toBe(true);
     });
 
-    it('redelivers retained terminal states once and suppresses shutdown cancellations', () => {
+    it('redelivers retained terminal states in settle order once and suppresses shutdown cancellations', () => {
       const reg = new BackgroundShellRegistry();
       reg.register(makeEntry({ shellId: 'a' }));
       reg.register(makeEntry({ shellId: 'b' }));
       reg.register(makeEntry({ shellId: 'c' }));
       reg.register(makeEntry({ shellId: 'shutdown' }));
-      reg.complete('a', 0, 2000);
+      reg.cancel('c', 2000);
       reg.fail('b', 'boom', 2001);
-      reg.cancel('c', 2002);
+      reg.complete('a', 0, 2002);
       reg.abortAll();
 
       const callback = vi.fn();
       reg.setNotificationCallback(callback);
 
       expect(callback.mock.calls.map((call) => call[2])).toEqual([
-        { shellId: 'a', status: 'completed', exitCode: 0 },
-        { shellId: 'b', status: 'failed' },
         { shellId: 'c', status: 'cancelled' },
+        { shellId: 'b', status: 'failed' },
+        { shellId: 'a', status: 'completed', exitCode: 0 },
       ]);
       expect(reg.get('shutdown')!.notified).toBe(true);
 

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -673,6 +673,15 @@ describe('BackgroundShellRegistry', () => {
       expect(() => reg.fail('b', 'boom', 3000)).not.toThrow();
       expect(reg.get('a')!.status).toBe('completed');
       expect(reg.get('b')!.status).toBe('failed');
+
+      // Consume-before-invoke: a throwing subscriber must not leave the entry
+      // eligible, or the next bind replays the same terminal notification.
+      expect(reg.get('a')!.notified).toBe(true);
+      expect(reg.get('b')!.notified).toBe(true);
+
+      const rebound = vi.fn();
+      reg.setNotificationCallback(rebound);
+      expect(rebound).not.toHaveBeenCalled();
     });
 
     it('does not emit more than once for late terminal transitions', () => {
@@ -721,8 +730,8 @@ describe('BackgroundShellRegistry', () => {
       reg.abortAll();
 
       expect(callback).not.toHaveBeenCalled();
-      expect(reg.get('a')!.notified).toBe(false);
-      expect(reg.get('b')!.notified).toBe(false);
+      expect(reg.get('a')!.notified).toBe(true);
+      expect(reg.get('b')!.notified).toBe(true);
     });
 
     it('redelivers a retained terminal notification when the same registry is rebound', () => {
@@ -770,11 +779,32 @@ describe('BackgroundShellRegistry', () => {
         { shellId: 'b', status: 'failed' },
         { shellId: 'c', status: 'cancelled' },
       ]);
-      expect(reg.get('shutdown')!.notified).toBe(false);
+      expect(reg.get('shutdown')!.notified).toBe(true);
 
       const callback2 = vi.fn();
       reg.setNotificationCallback(callback2);
       expect(callback2).not.toHaveBeenCalled();
+    });
+
+    it('does not replay a still-running shell and still delivers its real terminal notification', () => {
+      const reg = new BackgroundShellRegistry();
+      reg.register(makeEntry({ shellId: 'running' }));
+      reg.register(makeEntry({ shellId: 'done' }));
+      reg.complete('done', 0, 2000);
+
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback.mock.calls[0][2]).toMatchObject({ shellId: 'done' });
+      expect(reg.get('running')!.notified).toBe(false);
+
+      reg.complete('running', 0, 3000);
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback.mock.calls[1][2]).toMatchObject({
+        shellId: 'running',
+        status: 'completed',
+      });
     });
   });
 

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -725,24 +725,16 @@ describe('BackgroundShellRegistry', () => {
       expect(reg.get('b')!.notified).toBe(false);
     });
 
-    it('defers a terminal notification dropped with no callback and redelivers it on rebind (#11119)', () => {
+    it('redelivers a retained terminal notification when the same registry is rebound', () => {
       const reg = new BackgroundShellRegistry();
       const outputPath = makeOutputFile('done\n');
       reg.register(
         makeEntry({ shellId: 'a', command: 'npm test', outputPath }),
       );
 
-      // The shell finishes while no consumer is bound — the owning Session
-      // was disposed/recycled. Previously this was consumed and lost forever.
       reg.complete('a', 0, 2000);
+      expect(reg.get('a')!.notified).toBe(false);
 
-      const dropped = reg.get('a')!;
-      expect(dropped.notified).toBe(false);
-      expect(dropped.notificationPending).toBe(true);
-
-      // A new Session re-registers a callback (resume / new runtime
-      // generation). The deferred notification must be replayed exactly once
-      // instead of silently planting the session.
       const callback = vi.fn();
       reg.setNotificationCallback(callback);
 
@@ -756,32 +748,30 @@ describe('BackgroundShellRegistry', () => {
         status: 'completed',
         exitCode: 0,
       });
-
-      const healed = reg.get('a')!;
-      expect(healed.notified).toBe(true);
-      expect(healed.notificationPending).toBe(false);
+      expect(reg.get('a')!.notified).toBe(true);
     });
 
-    it('redelivers deferred notifications once and never resurrects abortAll cancellations (#11119)', () => {
+    it('redelivers retained terminal states once and suppresses shutdown cancellations', () => {
       const reg = new BackgroundShellRegistry();
-      // 'a' finishes while unbound → deferred. 'b' is settled by shutdown
-      // cleanup (abortAll), which intentionally emits no notification.
       reg.register(makeEntry({ shellId: 'a' }));
       reg.register(makeEntry({ shellId: 'b' }));
+      reg.register(makeEntry({ shellId: 'c' }));
+      reg.register(makeEntry({ shellId: 'shutdown' }));
       reg.complete('a', 0, 2000);
+      reg.fail('b', 'boom', 2001);
+      reg.cancel('c', 2002);
       reg.abortAll();
-
-      expect(reg.get('a')!.notificationPending).toBe(true);
-      expect(reg.get('b')!.notificationPending).toBeFalsy();
 
       const callback = vi.fn();
       reg.setNotificationCallback(callback);
 
-      // Only the deferred 'a' replays; the suppressed 'b' stays silent.
-      expect(callback).toHaveBeenCalledTimes(1);
-      expect(callback.mock.calls[0][2]).toMatchObject({ shellId: 'a' });
+      expect(callback.mock.calls.map((call) => call[2])).toEqual([
+        { shellId: 'a', status: 'completed', exitCode: 0 },
+        { shellId: 'b', status: 'failed' },
+        { shellId: 'c', status: 'cancelled' },
+      ]);
+      expect(reg.get('shutdown')!.notified).toBe(false);
 
-      // Rebinding a second time must not double-deliver the consumed 'a'.
       const callback2 = vi.fn();
       reg.setNotificationCallback(callback2);
       expect(callback2).not.toHaveBeenCalled();

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -179,6 +179,17 @@ export interface ShellTask extends TaskBase {
    * window; always equals `outputFile`.
    */
   outputPath: string;
+  /**
+   * Set when a terminal notification could not be delivered because no
+   * notification callback was bound at emit time (e.g. the owning Session
+   * was disposed/recycled). Unlike `notified`, this is a *deferral*, not a
+   * consumption: the entry stays eligible for redelivery when a callback
+   * re-registers on session resume/rebind, so a background shell that
+   * finishes during a runtime transition can never silently plant its
+   * session (#11119). Entries settled by `abortAll()` shutdown cleanup
+   * never set this — those notifications are intentionally suppressed.
+   */
+  notificationPending?: boolean;
 }
 
 /**
@@ -259,6 +270,27 @@ export class BackgroundShellRegistry {
     cb: BackgroundShellNotificationCallback | undefined,
   ): void {
     this.notificationCallback = cb;
+    // Rebinding a consumer (session resume / new runtime generation) heals a
+    // deferred-notification wedge: replay any terminal notifications that
+    // were dropped while no callback was bound so a background shell that
+    // finished during a runtime transition still wakes its session (#11119).
+    if (cb) this.drainPendingNotifications();
+  }
+
+  /**
+   * Re-emit terminal notifications that were deferred by
+   * {@link emitNotification} because no callback was bound at the time. Each
+   * replayed entry is consumed exactly once (emitNotification flips
+   * `notified`), so this can never double-deliver. Entries settled by
+   * `abortAll()` never carry `notificationPending`, so suppressed shutdown
+   * cancellations are not resurrected here.
+   */
+  private drainPendingNotifications(): void {
+    for (const entry of Array.from(this.entries.values())) {
+      if (entry.notificationPending && entry.status !== 'running') {
+        this.emitNotification(entry);
+      }
+    }
   }
 
   /**
@@ -294,6 +326,7 @@ export class BackgroundShellRegistry {
     entry.outputFile = registration.outputPath;
     entry.outputOffset = 0;
     entry.notified = false;
+    entry.notificationPending = false;
     entry.todoWorkChainId ??= todoWorkChainContext.getStore();
     this.entries.set(entry.shellId, entry);
     this.writeStatusFile(entry);
@@ -476,14 +509,28 @@ export class BackgroundShellRegistry {
 
   private emitNotification(entry: ShellTask): void {
     if (entry.notified) return;
-    entry.notified = true;
 
     if (!this.notificationCallback) {
-      debugLogger.debug(
-        `Notification dropped for shell ${entry.shellId}: no callback registered`,
+      // No consumer is bound (the owning Session was disposed/recycled, or
+      // has not re-registered yet). Do NOT mark `notified`: consumption here
+      // would make the drop permanent — a later callback could never re-emit
+      // it, wedging the session silently (#11119). Defer instead so the
+      // notification is redelivered when a callback re-registers, and log at
+      // `warn` (not `debug`) so the break is observable rather than silent.
+      entry.notificationPending = true;
+      debugLogger.warn(
+        `No notification callback registered for shell ${entry.shellId}; ` +
+          `deferring terminal notification for redelivery on rebind`,
       );
       return;
     }
+
+    // A consumer is bound: consume the notification exactly once. Delivery
+    // itself is best-effort below — a throwing callback must not poison the
+    // registry, and we deliberately do not retry a callback that was reached
+    // but threw (matches the pre-existing fire-once semantics).
+    entry.notified = true;
+    entry.notificationPending = false;
 
     const statusText =
       entry.status === 'completed'

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -265,13 +265,18 @@ export class BackgroundShellRegistry {
     // this serves out-of-tree consumers of the exported class. The terminal
     // retention cap bounds what can be replayed.
     if (!cb) return;
-    for (const entry of this.entries.values()) {
-      if (entry.status !== 'running' && !entry.notified) {
-        debugLogger.debug(
-          `Redelivering retained terminal notification for shell ${entry.shellId}`,
-        );
-        this.emitNotification(entry);
-      }
+    const replayableEntries = Array.from(this.entries.values())
+      .filter((entry) => entry.status !== 'running' && !entry.notified)
+      .sort(
+        (a, b) =>
+          (a.endTime ?? a.startTime) - (b.endTime ?? b.startTime) ||
+          a.startTime - b.startTime,
+      );
+    for (const entry of replayableEntries) {
+      debugLogger.debug(
+        `Redelivering retained terminal notification for shell ${entry.shellId}`,
+      );
+      this.emitNotification(entry);
     }
   }
 

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -240,7 +240,6 @@ export type BackgroundShellStatusChangeCallback = (entry?: ShellTask) => void;
 
 export class BackgroundShellRegistry {
   private readonly entries = new Map<string, ShellTask>();
-  private readonly notificationSuppressed = new WeakSet<ShellTask>();
 
   private registerCallback: BackgroundShellRegisterCallback | undefined;
   private notificationCallback: BackgroundShellNotificationCallback | undefined;
@@ -260,15 +259,14 @@ export class BackgroundShellRegistry {
     cb: BackgroundShellNotificationCallback | undefined,
   ): void {
     this.notificationCallback = cb;
-    // Best-effort replay for a transient unbind on this registry instance.
-    // Config replacement owns a different registry; the terminal cap applies.
+    // Best-effort replay for a transient unbind of THIS instance. No in-tree
+    // caller rebinds a registry that already holds entries — Session and the
+    // TUI hook each bind once against their own Config's fresh registry — so
+    // this serves out-of-tree consumers of the exported class. The terminal
+    // retention cap bounds what can be replayed.
     if (!cb) return;
     for (const entry of this.entries.values()) {
-      if (
-        entry.status !== 'running' &&
-        !entry.notified &&
-        !this.notificationSuppressed.has(entry)
-      ) {
+      if (entry.status !== 'running' && !entry.notified) {
         debugLogger.debug(
           `Redelivering retained terminal notification for shell ${entry.shellId}`,
         );
@@ -310,7 +308,6 @@ export class BackgroundShellRegistry {
     entry.outputFile = registration.outputPath;
     entry.outputOffset = 0;
     entry.notified = false;
-    this.notificationSuppressed.delete(entry);
     entry.todoWorkChainId ??= todoWorkChainContext.getStore();
     this.entries.set(entry.shellId, entry);
     this.writeStatusFile(entry);
@@ -624,7 +621,10 @@ export class BackgroundShellRegistry {
     for (const entry of Array.from(this.entries.values())) {
       if (entry.status !== 'running') continue;
       this.settleAsCancelled(entry, endTime);
-      this.notificationSuppressed.add(entry);
+      // Suppressed, not deferred: marking the entry notified is what keeps a
+      // later rebind from replaying a shutdown cancellation, and matches the
+      // sibling registries' `abortAll({ notify: false })` handling.
+      entry.notified = true;
       lastCancelled = entry;
     }
     if (!lastCancelled) return;

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -179,17 +179,6 @@ export interface ShellTask extends TaskBase {
    * window; always equals `outputFile`.
    */
   outputPath: string;
-  /**
-   * Set when a terminal notification could not be delivered because no
-   * notification callback was bound at emit time (e.g. the owning Session
-   * was disposed/recycled). Unlike `notified`, this is a *deferral*, not a
-   * consumption: the entry stays eligible for redelivery when a callback
-   * re-registers on session resume/rebind, so a background shell that
-   * finishes during a runtime transition can never silently plant its
-   * session (#11119). Entries settled by `abortAll()` shutdown cleanup
-   * never set this — those notifications are intentionally suppressed.
-   */
-  notificationPending?: boolean;
 }
 
 /**
@@ -251,6 +240,7 @@ export type BackgroundShellStatusChangeCallback = (entry?: ShellTask) => void;
 
 export class BackgroundShellRegistry {
   private readonly entries = new Map<string, ShellTask>();
+  private readonly notificationSuppressed = new WeakSet<ShellTask>();
 
   private registerCallback: BackgroundShellRegisterCallback | undefined;
   private notificationCallback: BackgroundShellNotificationCallback | undefined;
@@ -270,24 +260,18 @@ export class BackgroundShellRegistry {
     cb: BackgroundShellNotificationCallback | undefined,
   ): void {
     this.notificationCallback = cb;
-    // Rebinding a consumer (session resume / new runtime generation) heals a
-    // deferred-notification wedge: replay any terminal notifications that
-    // were dropped while no callback was bound so a background shell that
-    // finished during a runtime transition still wakes its session (#11119).
-    if (cb) this.drainPendingNotifications();
-  }
-
-  /**
-   * Re-emit terminal notifications that were deferred by
-   * {@link emitNotification} because no callback was bound at the time. Each
-   * replayed entry is consumed exactly once (emitNotification flips
-   * `notified`), so this can never double-deliver. Entries settled by
-   * `abortAll()` never carry `notificationPending`, so suppressed shutdown
-   * cancellations are not resurrected here.
-   */
-  private drainPendingNotifications(): void {
-    for (const entry of Array.from(this.entries.values())) {
-      if (entry.notificationPending && entry.status !== 'running') {
+    // Best-effort replay for a transient unbind on this registry instance.
+    // Config replacement owns a different registry; the terminal cap applies.
+    if (!cb) return;
+    for (const entry of this.entries.values()) {
+      if (
+        entry.status !== 'running' &&
+        !entry.notified &&
+        !this.notificationSuppressed.has(entry)
+      ) {
+        debugLogger.debug(
+          `Redelivering retained terminal notification for shell ${entry.shellId}`,
+        );
         this.emitNotification(entry);
       }
     }
@@ -326,7 +310,7 @@ export class BackgroundShellRegistry {
     entry.outputFile = registration.outputPath;
     entry.outputOffset = 0;
     entry.notified = false;
-    entry.notificationPending = false;
+    this.notificationSuppressed.delete(entry);
     entry.todoWorkChainId ??= todoWorkChainContext.getStore();
     this.entries.set(entry.shellId, entry);
     this.writeStatusFile(entry);
@@ -511,26 +495,13 @@ export class BackgroundShellRegistry {
     if (entry.notified) return;
 
     if (!this.notificationCallback) {
-      // No consumer is bound (the owning Session was disposed/recycled, or
-      // has not re-registered yet). Do NOT mark `notified`: consumption here
-      // would make the drop permanent — a later callback could never re-emit
-      // it, wedging the session silently (#11119). Defer instead so the
-      // notification is redelivered when a callback re-registers, and log at
-      // `warn` (not `debug`) so the break is observable rather than silent.
-      entry.notificationPending = true;
-      debugLogger.warn(
-        `No notification callback registered for shell ${entry.shellId}; ` +
-          `deferring terminal notification for redelivery on rebind`,
+      debugLogger.debug(
+        `Notification left eligible for shell ${entry.shellId}: no callback registered`,
       );
       return;
     }
 
-    // A consumer is bound: consume the notification exactly once. Delivery
-    // itself is best-effort below — a throwing callback must not poison the
-    // registry, and we deliberately do not retry a callback that was reached
-    // but threw (matches the pre-existing fire-once semantics).
     entry.notified = true;
-    entry.notificationPending = false;
 
     const statusText =
       entry.status === 'completed'
@@ -589,7 +560,10 @@ export class BackgroundShellRegistry {
     try {
       this.notificationCallback(displayText, xmlParts.join('\n'), meta);
     } catch (error) {
-      debugLogger.error('Failed to emit shell notification:', error);
+      debugLogger.error(
+        `Failed to emit shell notification for shell ${entry.shellId}:`,
+        error,
+      );
     }
   }
 
@@ -650,6 +624,7 @@ export class BackgroundShellRegistry {
     for (const entry of Array.from(this.entries.values())) {
       if (entry.status !== 'running') continue;
       this.settleAsCancelled(entry, endTime);
+      this.notificationSuppressed.add(entry);
       lastCancelled = entry;
     }
     if (!lastCancelled) return;


### PR DESCRIPTION
## What this PR does

A terminal background-shell notification is no longer marked consumed when the registry has no callback. If the same `BackgroundShellRegistry` instance is rebound before the retained terminal entry is pruned, it replays each eligible completion, failure, or cancellation once.

Shutdown cancellations remain silent and are excluded from replay.

## Scope

This is an in-memory, bounded repair for transient callback unbinds on one registry instance. It does not cross `Config` replacement or daemon process restart: a replacement `Config` owns a fresh registry. Durable cross-generation shell reconciliation remains follow-up work in #11119.

The terminal-entry retention cap remains 32, so an unbound registry stays bounded; entries evicted beyond that cap are not replayed. The diagnostic remains debug-file-only and is not presented as default daemon observability.

## Reviewer test plan

From `packages/core`:

```sh
npx vitest run src/services/backgroundShellRegistry.test.ts
npm run typecheck
npx eslint src/services/backgroundShellRegistry.ts src/services/backgroundShellRegistry.test.ts
npx prettier --check src/services/backgroundShellRegistry.ts src/services/backgroundShellRegistry.test.ts
```

The tests cover:

- one retained completion replayed on same-instance rebind;
- multiple retained completed, failed, and cancelled entries replayed once;
- shutdown cancellations never replayed;
- existing terminal retention-cap behavior.

## Verification

- 64 targeted tests passed
- typecheck passed
- eslint passed
- prettier check passed

## Related

Related to #11119, but does not close it.
