### PR TITLE
fix(core): defer background task notifications instead of silently dropping them

### DIFF
--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -532,6 +532,16 @@ export class BackgroundTaskRegistry {
   // global cap is enforced.
   private readonly maxConcurrentBackgroundAgentsByModel: Map<string, number>;
   private notificationCallback?: BackgroundNotificationCallback;
+  /**
+   * Tracks whether a notification callback was ever installed on this
+   * registry instance. When true and the callback is later cleared
+   * (session runtime recycle), terminal notifications are deferred
+   * rather than discarded so reconciliation can deliver them when the
+   * next subscriber arrives. When false (isolated/test usage with no
+   * session wiring), entries are marked notified immediately because
+   * there is no subscriber to reconcile to (#11119).
+   */
+  private hadNotificationSubscriber = false;
   private registerCallback?: BackgroundRegisterCallback;
   private statusChangeCallback?: BackgroundStatusChangeCallback;
   private activityChangeCallback?: BackgroundActivityChangeCallback;
@@ -1627,6 +1637,23 @@ export class BackgroundTaskRegistry {
     cb: BackgroundNotificationCallback | undefined,
   ): void {
     this.notificationCallback = cb;
+    if (cb) this.hadNotificationSubscriber = true;
+    // Reconciliation: when a new callback is installed (e.g. after a
+    // session runtime generation swap), re-emit notifications for any
+    // terminal background entries whose delivery was missed while no
+    // callback was registered (#11119).
+    if (cb) {
+      for (const entry of this.agents.values()) {
+        if (
+          entry.status !== 'running' &&
+          entry.status !== 'paused' &&
+          !entry.notified &&
+          entry.isBackgrounded
+        ) {
+          this.emitNotification(entry);
+        }
+      }
+    }
   }
 
   setRegisterCallback(cb: BackgroundRegisterCallback | undefined): void {
@@ -1693,19 +1720,41 @@ export class BackgroundTaskRegistry {
   }
 
   private emitNotification(entry: AgentTask): void {
-    // Mark notified *before* invoking the callback so that a re-entrant
-    // terminal call inside the callback chain (cancel → complete race)
-    // sees the flag and short-circuits, rather than firing twice.
     if (entry.notified) return;
-    entry.notified = true;
 
     // Foreground entries return their result through the parent's normal
     // tool-result channel (the `returnDisplay` field on the synchronous
     // tool-call). Emitting the XML envelope on top would feed the parent
     // model the same payload twice.
-    if (!entry.isBackgrounded) return;
+    if (!entry.isBackgrounded) {
+      entry.notified = true;
+      return;
+    }
 
-    if (!this.notificationCallback) return;
+    if (!this.notificationCallback) {
+      if (this.hadNotificationSubscriber) {
+        // A callback was previously installed and then cleared (session
+        // runtime recycle). Do NOT mark notified — leave the entry
+        // eligible for reconciliation when the next subscriber registers
+        // its callback. Before this fix the flag was set unconditionally,
+        // permanently losing the notification if the runtime recycled
+        // between the task settling and the new generation wiring up
+        // (#11119).
+        debugLogger.warn(
+          `Notification deferred for agent ${entry.agentId}: no callback registered (will reconcile on next subscriber)`,
+        );
+        return;
+      }
+      // No callback was ever installed (isolated/test usage). Mark
+      // notified so pruning and finalization gates behave normally.
+      entry.notified = true;
+      return;
+    }
+
+    // Mark notified *after* confirming a callback exists so a re-entrant
+    // terminal call inside the callback chain (cancel → complete race)
+    // sees the flag and short-circuits, rather than firing twice.
+    entry.notified = true;
 
     const statusText =
       entry.status === 'completed'

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -243,6 +243,16 @@ export class BackgroundShellRegistry {
 
   private registerCallback: BackgroundShellRegisterCallback | undefined;
   private notificationCallback: BackgroundShellNotificationCallback | undefined;
+  /**
+   * Tracks whether a notification callback was ever installed on this
+   * registry instance. When true and the callback is later cleared
+   * (session runtime recycle), terminal notifications are deferred
+   * rather than discarded so reconciliation can deliver them when the
+   * next subscriber arrives. When false (isolated/test usage with no
+   * session wiring), entries are marked notified immediately because
+   * there is no subscriber to reconcile to (#11119).
+   */
+  private hadNotificationSubscriber = false;
   private statusChangeCallback: BackgroundShellStatusChangeCallback | undefined;
 
   /**
@@ -259,6 +269,20 @@ export class BackgroundShellRegistry {
     cb: BackgroundShellNotificationCallback | undefined,
   ): void {
     this.notificationCallback = cb;
+    if (cb) this.hadNotificationSubscriber = true;
+    // Reconciliation: when a new callback is installed (e.g. after a
+    // session runtime generation swap), re-emit notifications for any
+    // terminal entries whose delivery was missed while no callback was
+    // registered. This makes the silent-drop state structurally
+    // impossible — a notification is either delivered immediately or
+    // deferred until the next subscriber arrives (#11119).
+    if (cb) {
+      for (const entry of this.entries.values()) {
+        if (entry.status !== 'running' && !entry.notified) {
+          this.emitNotification(entry);
+        }
+      }
+    }
   }
 
   /**
@@ -476,14 +500,28 @@ export class BackgroundShellRegistry {
 
   private emitNotification(entry: ShellTask): void {
     if (entry.notified) return;
-    entry.notified = true;
 
     if (!this.notificationCallback) {
-      debugLogger.debug(
-        `Notification dropped for shell ${entry.shellId}: no callback registered`,
-      );
+      if (this.hadNotificationSubscriber) {
+        // A callback was previously installed and then cleared (session
+        // runtime recycle). Do NOT mark notified — leave the entry
+        // eligible for reconciliation when the next subscriber registers
+        // its callback (#11119).
+        debugLogger.warn(
+          `Notification deferred for shell ${entry.shellId}: no callback registered (will reconcile on next subscriber)`,
+        );
+        return;
+      }
+      // No callback was ever installed (isolated/test usage). Mark
+      // notified so pruning and finalization gates behave normally.
+      entry.notified = true;
       return;
     }
+
+    // Mark notified *after* confirming a callback exists so a re-entrant
+    // terminal call inside the callback chain (cancel → complete race)
+    // sees the flag and short-circuits, rather than firing twice.
+    entry.notified = true;
 
     const statusText =
       entry.status === 'completed'

--- a/packages/core/src/services/monitorRegistry.ts
+++ b/packages/core/src/services/monitorRegistry.ts
@@ -168,6 +168,14 @@ export class MonitorRegistry {
     MonitorOwnerLifecycleCallback
   >();
   private notificationCallback?: MonitorNotificationCallback;
+  /**
+   * Tracks whether a notification callback was ever installed on this
+   * registry instance. When true and the callback is later cleared
+   * (session runtime recycle), terminal notifications are deferred
+   * rather than discarded so reconciliation can deliver them when the
+   * next subscriber arrives (#11119).
+   */
+  private hadNotificationSubscriber = false;
   private registerCallback?: MonitorRegisterCallback;
   private statusChangeCallback?: MonitorStatusChangeCallback;
 
@@ -343,6 +351,18 @@ export class MonitorRegistry {
 
   setNotificationCallback(cb: MonitorNotificationCallback | undefined): void {
     this.notificationCallback = cb;
+    if (cb) this.hadNotificationSubscriber = true;
+    // Reconciliation: when a new callback is installed (e.g. after a
+    // session runtime generation swap), re-emit terminal notifications
+    // for any entries whose delivery was missed while no callback was
+    // registered (#11119).
+    if (cb) {
+      for (const entry of this.monitors.values()) {
+        if (entry.status !== 'running' && !entry.notified) {
+          this.emitTerminalNotification(entry);
+        }
+      }
+    }
   }
 
   setAgentNotificationCallback(
@@ -536,6 +556,27 @@ export class MonitorRegistry {
   /** Emit a terminal notification (completed/failed/cancelled). */
   private emitTerminalNotification(entry: MonitorTask, detail?: string): void {
     if (entry.notified) return;
+
+    // Check whether a callback is available before marking notified.
+    // If none exists (session runtime recycled), leave the entry
+    // eligible for reconciliation when the next subscriber arrives
+    // (#11119).
+    const callback = entry.ownerAgentId
+      ? this.agentNotificationCallbacks.get(entry.ownerAgentId)
+      : this.notificationCallback;
+    if (!callback) {
+      if (this.hadNotificationSubscriber) {
+        debugLogger.warn(
+          `Notification deferred for monitor ${entry.monitorId}: no callback registered (will reconcile on next subscriber)`,
+        );
+        return;
+      }
+      // No callback was ever installed (isolated/test usage). Mark
+      // notified so pruning and finalization gates behave normally.
+      entry.notified = true;
+      return;
+    }
+
     entry.notified = true;
 
     const statusText =


### PR DESCRIPTION
## What this PR does

When the session runtime recycles (generation swap), notification callbacks on the BackgroundShellRegistry, BackgroundTaskRegistry, and MonitorRegistry are cleared. Previously, any task settling during that window had its notification permanently lost: the `notified` flag was set unconditionally before checking whether a callback existed, so the notification could never be re-emitted even after a new subscriber registered.

This fix:
1. Only marks `notified=true` after confirming a callback exists (or when no callback was ever installed, preserving isolated/test semantics).
2. Adds reconciliation in `setNotificationCallback`: when a new callback is installed, scans for terminal entries with pending notifications and re-emits them.
3. Tracks `hadNotificationSubscriber` to distinguish the runtime-recycle case (defer) from isolated usage (mark immediately).

The silent-drop state is now structurally impossible: a notification is either delivered immediately or deferred until the next subscriber arrives.

## Why it's needed

In daemon-hosted (`qwen serve`) Web Shell sessions, a background shell that keeps running across a runtime lifecycle transition silently wedges the session: output is drained and discarded, the turn pump is never woken, the transcript freezes, and the UI shows a forever-spinner. The failure is completely silent — no log, no error, no notification — because the drop is a missing table entry rather than an explicit refusal.

## Reviewer Test Plan

### How to verify

1. `npm run build --workspace=packages/core`
2. `npx vitest run packages/core/src/services/backgroundShellRegistry.test.ts packages/core/src/agents/background-tasks.test.ts packages/core/src/services/monitorRegistry.test.ts` — all 268 tests pass.
3. `npx tsc --noEmit --project packages/core/tsconfig.json` — no type errors.
4. Conceptual: register a callback → clear it → complete a task → verify `notified` stays `false` → register a new callback → verify reconciliation fires the deferred notification.

### Evidence (Before & After)

N/A — internal registry behavior, no user-visible UI change in this PR.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

## Risk & Scope

- Main risk or tradeoff: entries that settle while no callback is registered are now retained longer (until reconciliation). The retention cap still applies once the notification is delivered.
- Not validated / out of scope: the full 6-part architectural proposal in #11119 (durable on-disk ledger, flow watchdog, live-state extension, todo rendering gate). This PR addresses the core silent-drop mechanism only.
- Breaking changes / migration notes: none.

## Linked Issues

Fixes #11119

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

当会话 runtime 经历生命周期切换（generation swap）时，BackgroundShellRegistry、BackgroundTaskRegistry 和 MonitorRegistry 上的通知回调会被清除。此前，在该窗口期内结算的任务通知会被永久丢失：`notified` 标志在检查回调是否存在之前就被无条件设置为 true，因此即使新的订阅者注册后也无法重新发出通知。

本修复：
1. 仅在确认回调存在后才标记 `notified=true`（若从未安装过回调则立即标记，保持隔离/测试语义）。
2. 在 `setNotificationCallback` 中添加对账机制：安装新回调时，扫描有待发通知的终态条目并重新发出。
3. 通过 `hadNotificationSubscriber` 标志区分 runtime 回收场景（延迟）和隔离使用场景（立即标记）。

静默丢弃状态现在在结构上不可能发生：通知要么立即投递，要么延迟到下一个订阅者到达。

## 为什么需要

在 daemon 托管的 `qwen serve` Web Shell 会话中，跨 runtime 生命周期切换仍在运行的后台 shell 会静默卡死会话：输出被排空并丢弃，turn pump 永不被唤醒，transcript 冻结，UI 显示永转的 spinner。故障完全静默——无日志、无报错、无通知——因为断点是"路由表缺条目"而非显式拒绝。

## 风险与范围

- 主要风险/权衡：在无回调期间结算的条目现在会被保留更久（直到对账投递）。投递后保留上限仍然生效。
- 未验证/超出范围：#11119 中完整的六部分架构提案（磁盘持久化台账、流量看门狗、live-state 扩展、todo 渲染门控）。本 PR 仅解决核心静默丢弃机制。
- 破坏性变更/迁移说明：无。

</details>
