### PR TITLE
Keep API leaders and local workers on separate credentials

### DIFF
--- a/docs/design/local-worker-credentials.md
+++ b/docs/design/local-worker-credentials.md
@@ -1,0 +1,53 @@
+# API leader with local workers
+
+## Scope
+
+Reuse native subagents and Agent Team model routing. A leader stays on its API
+provider while a named worker selects a separately registered local model.
+No new orchestrator, account switching, OAuth integration, or terminal backend.
+
+## Credential boundary
+
+An auth type identifies a protocol, not an endpoint or account. Two `openai`
+models can address unrelated services.
+
+- A model's explicit `envKey` is authoritative. If unset or empty, the worker
+  must fail validation instead of inheriting the leader's key.
+- An explicit per-agent key takes precedence over the model's `envKey`.
+- Changing endpoints must not carry the leader's key or custom headers into
+  the worker. A worker needs its own credential configuration.
+- Preserve implicit credential inheritance for workers on the same endpoint
+  and auth type with no separate credential declaration.
+- Keep the leader's configuration unchanged. Model-specific request options
+  for a different endpoint come from the worker's registered configuration.
+
+Local servers without authentication still use a dedicated dummy key through
+their own environment variable. This is explicit configuration, not a special
+case that disables validation for localhost.
+
+## Existing consumers
+
+The shared content-generator builder is used by ordinary subagents,
+InProcessBackend (Agent Team and Arena), forked agents, and BaseLlmClient's
+per-model requests. Tests must cover both the shared builder and actual
+leader/worker requests. InProcessBackend rejects failed generator creation
+before starting a worker. BaseLlmClient's optional fallback for auxiliary model
+queries is unchanged; it is not the named-worker execution path.
+
+## Verification
+
+Use two loopback mock servers and fictional keys. Check independent model IDs,
+endpoints and authorization headers, successful delegation and return, missing
+worker credentials, and an unchanged leader. No real inference is required.
+Include regression coverage for explicit keys, custom headers, same-endpoint
+inheritance, and registered versus explicit endpoint overrides.
+
+## Limitations and review
+
+Use distinct model IDs for local and remote registrations: the current agent
+selector contains auth type and model ID, not the endpoint. Endpoint-qualified
+selectors and Codex OAuth are separate work.
+
+This is a small core credential change and requires the maintainer review gate
+described in AGENTS.md. It does not claim complete isolation of arbitrary
+process environment, proxies, tools, or external provider SDKs.

--- a/docs/users/features/sub-agents.md
+++ b/docs/users/features/sub-agents.md
@@ -268,6 +268,76 @@ When the selector resolves to another auth type, Qwen Code creates a dedicated
 runtime provider for that subagent request and sends the provider only the bare
 model ID.
 
+#### API leader with a local worker
+
+Keep your existing API login and selected leader model. Add a local model entry
+to the existing `modelProviders.openai` array in `settings.json`, preserving
+other providers and entries:
+
+```json
+{
+  "env": {
+    "OLLAMA_API_KEY": "ollama"
+  },
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "qwen2.5-coder:7b",
+        "envKey": "OLLAMA_API_KEY",
+        "baseUrl": "http://localhost:11434/v1",
+        "generationConfig": {
+          "contextWindowSize": 8192,
+          "timeout": 300000
+        }
+      }
+    ]
+  }
+}
+```
+
+Replace the model ID with the exact ID served by your local server. Select a
+model that supports tool calls and configure the context window to match the
+server. The placeholder key is only for servers that do not require
+authentication; protected endpoints need their own real key. Do not put the
+leader's key in `OLLAMA_API_KEY`.
+
+Create `.qwen/agents/local-reviewer.md`:
+
+```markdown
+---
+name: local-reviewer
+description: Reviews code using the local model
+model: openai:qwen2.5-coder:7b
+tools:
+  - read_file
+  - grep_search
+  - glob
+---
+
+Review the assigned code and return findings with file references. Do not edit.
+```
+
+Restart Qwen Code and ask: "Delegate a review of this change to local-reviewer,
+then summarize its findings." The leader stays on its current API provider;
+only the delegated worker uses the local endpoint. No `/auth` or `/model`
+switch is needed. This also works when the leader uses Gemini.
+
+An explicitly configured worker `envKey` must be set. Missing credentials stop
+the worker rather than borrowing the leader's key. A different endpoint does
+not inherit the leader's custom headers or model-specific request options;
+configure those on the local entry if needed.
+
+Use distinct IDs for local and remote models: agent selectors identify the auth
+type and model ID, not the endpoint. Local workers still consume memory; start
+with one worker and a model that fits your machine.
+
+With [Agent Team](./multi-agent-coordination.md) enabled, the same definition
+can be selected for a named teammate. Ordinary delegation does not require
+Agent Team. Neither path starts a separate Ollama CLI: Ollama must already be
+serving the configured model.
+
+#### Built-in Explore model
+
 The built-in Explore agent inherits the main session model by default. To
 select a different model for only that built-in agent, configure
 `agents.builtin.exploreModel` in `settings.json` and restart Qwen Code:

--- a/packages/core/src/agents/backends/InProcessBackend.test.ts
+++ b/packages/core/src/agents/backends/InProcessBackend.test.ts
@@ -1125,28 +1125,44 @@ describe('InProcessBackend', () => {
       expect(mockCreate).not.toHaveBeenCalled();
     });
 
-    it('should fall back to parent ContentGenerator if per-agent creation fails', async () => {
-      const mockCreate = createContentGenerator as ReturnType<typeof vi.fn>;
-      mockCreate.mockRejectedValueOnce(new Error('Auth failed'));
+    it.each(['Auth failed', ''])(
+      'does not start an agent on the parent after generator failure (%s)',
+      async (message) => {
+        const mockCreate = createContentGenerator as ReturnType<typeof vi.fn>;
+        mockCreate.mockRejectedValueOnce(new Error(message));
+        vi.mocked(AgentCore).mockClear();
+        const registry = createMockToolRegistry();
+        const parent = createMockConfig() as Config;
+        vi.mocked(parent.createToolRegistry).mockResolvedValueOnce(
+          registry as never,
+        );
+        backend = new InProcessBackend(parent);
 
-      await backend.init();
+        await backend.init();
 
-      const config = createSpawnConfig('agent-1');
-      config.inProcess!.authOverrides = {
-        authType: 'anthropic',
-        apiKey: 'bad-key',
-      };
+        const config = createSpawnConfig('agent-1');
+        config.inProcess!.authOverrides = {
+          authType: 'anthropic',
+          apiKey: 'bad-key',
+        };
 
-      // Should not throw — falls back gracefully
-      await expect(backend.spawnAgent(config)).resolves.toBeUndefined();
+        await expect(backend.spawnAgent(config)).rejects.toThrow(message);
 
-      const MockAgentCore = AgentCore as unknown as ReturnType<typeof vi.fn>;
-      const lastCall = MockAgentCore.mock.calls.at(-1);
+        expect(AgentCore).not.toHaveBeenCalled();
+        expect(runReasoningLoopMock).not.toHaveBeenCalled();
+        expect(backend.getAgent('agent-1')).toBeUndefined();
+        expect(backend.getAgentContentGenerator('agent-1')).toBeUndefined();
+        expect(backend.getActiveAgentId()).toBeNull();
+        expect(registry.stop).toHaveBeenCalledTimes(1);
+        expect(backend.getAgentContentGeneratorError('agent-1')).toBe(message);
 
-      // No runtimeView when per-agent creation failed; agent inherits parent.
-      expect(destructureAgentCoreCall(lastCall!).runtimeView).toBeUndefined();
-      expect(backend.getAgentContentGenerator('agent-1')).toBeUndefined();
-    });
+        await backend.spawnAgent(config);
+        expect(backend.getAgent('agent-1')).toBeDefined();
+        expect(
+          backend.getAgentContentGeneratorError('agent-1'),
+        ).toBeUndefined();
+      },
+    );
 
     it('should give different agents different ContentGenerators', async () => {
       const gen1 = { generateContentStream: vi.fn() };

--- a/packages/core/src/agents/backends/InProcessBackend.ts
+++ b/packages/core/src/agents/backends/InProcessBackend.ts
@@ -58,9 +58,7 @@ export class InProcessBackend implements Backend {
   private readonly agents = new Map<string, AgentInteractive>();
   private readonly agentContentGenerators = new Map<string, ContentGenerator>();
   // Why a dedicated per-agent ContentGenerator could not be created,
-  // keyed by agentId. The creation failure is swallowed into a debug
-  // log (fallback to the parent generator); spawn callers verifying a
-  // requested route need the cause to fail with a useful message.
+  // keyed by agentId. Spawn callers can inspect the cause of a rejected route.
   private readonly agentContentGeneratorErrors = new Map<string, string>();
   // Per-agent tool registries keyed by agentId so `stopAgent` can
   // dispose just that agent's registry (releasing tool listeners on
@@ -154,7 +152,8 @@ export class InProcessBackend implements Backend {
         perAgent.contentGenerator,
       );
     }
-    if (perAgent.contentGeneratorError) {
+    this.agentContentGeneratorErrors.delete(config.agentId);
+    if (perAgent.contentGeneratorError !== undefined) {
       this.agentContentGeneratorErrors.set(
         config.agentId,
         perAgent.contentGeneratorError,
@@ -163,6 +162,11 @@ export class InProcessBackend implements Backend {
 
     this.agentRegistries.set(config.agentId, agentContext.getToolRegistry());
     this.agentApprovalCleanups.set(config.agentId, perAgent.cleanup);
+
+    if (perAgent.contentGeneratorError !== undefined) {
+      this.releaseAgentResources(config.agentId);
+      throw new Error(perAgent.contentGeneratorError);
+    }
 
     const core = new AgentCore(
       inProcessConfig.agentName,
@@ -646,7 +650,7 @@ async function createPerAgentConfig(
         );
       } catch (error) {
         debugLogger.error(
-          'Failed to create per-agent ContentGenerator, falling back to parent:',
+          'Failed to create per-agent ContentGenerator:',
           error,
         );
         // The debug log above is a no-op unless QWEN_DEBUG_LOG_FILE is

--- a/packages/core/src/agents/team/TeamManager.model-routing.test.ts
+++ b/packages/core/src/agents/team/TeamManager.model-routing.test.ts
@@ -379,10 +379,8 @@ describe('TeamManager teammate model routing (#10071)', () => {
 
   it('fails loudly when the dedicated route generator cannot be created', async () => {
     // The definition selects a route but the generator for it cannot be
-    // created (e.g. missing API key). InProcessBackend swallows that
-    // failure and falls back to the leader's generator; the spawn path
-    // must detect the missing dedicated generator and fail into the
-    // rollback instead of letting the teammate join misrouted (#10071).
+    // created (e.g. missing API key). The backend must reject before
+    // starting the agent, not run it on the leader while awaiting rollback.
     await writeAgentDefinition(projectDir, 'unroutable-worker.md', {
       name: 'unroutable-worker',
       description: 'A worker whose route cannot be created',
@@ -403,20 +401,12 @@ describe('TeamManager teammate model routing (#10071)', () => {
         agentType: 'unroutable-worker',
         cwd: projectDir,
       }),
-    ).rejects.toThrow(
-      /could not create a dedicated ContentGenerator for model "claude-worker" \(anthropic\): The API key for Anthropic is not set/,
-    );
+    ).rejects.toThrow('The API key for Anthropic is not set');
 
-    // Rollback must run: no member persisted, and the rolled-back id
-    // must stay respawnable — otherwise every retry dies with 'Agent
-    // "X" already exists.' masking this route failure. The stopped
-    // handle itself stays readable for post-stop inspection (Arena
-    // reads transcripts through it on the timeout path); the backend
-    // tracks the stop separately so the respawn gate still clears, as
-    // pinned by the retry test below.
+    // No member or running agent is created; the same name can retry.
     expect(teamManager.getTeamFile().members).toHaveLength(0);
     const agentId = formatAgentId('w6', TEAM_NAME);
-    expect(backend.getAgent(agentId)?.getStatus()).toBe(AgentStatus.CANCELLED);
+    expect(backend.getAgent(agentId)).toBeUndefined();
   });
 
   it('releases a rolled-back teammate name so the same spawn can retry', async () => {
@@ -443,9 +433,7 @@ describe('TeamManager teammate model routing (#10071)', () => {
         agentType: 'retry-worker',
         cwd: projectDir,
       }),
-    ).rejects.toThrow(
-      /could not create a dedicated ContentGenerator for model "claude-worker" \(anthropic\)/,
-    );
+    ).rejects.toThrow('The API key for Anthropic is not set');
     expect(teamManager.getTeamFile().members).toHaveLength(0);
 
     // Same-name respawn must succeed once the route is creatable.

--- a/packages/core/src/models/content-generator-config.test.ts
+++ b/packages/core/src/models/content-generator-config.test.ts
@@ -10,7 +10,8 @@ import {
   createRuntimeContentGeneratorView,
   resolveCredentialField,
 } from './content-generator-config.js';
-import { createContentGenerator } from '../core/contentGenerator.js';
+import { AuthType, createContentGenerator } from '../core/contentGenerator.js';
+import { ModelRegistry } from './modelRegistry.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import type { Config } from '../config/config.js';
 import type { ResolvedModelConfig } from './types.js';
@@ -37,7 +38,7 @@ function createMockConfig(
 }
 
 describe('buildAgentContentGeneratorConfig', () => {
-  const parentConfig: ContentGeneratorConfig = {
+  const parentConfig = {
     model: 'parent-model',
     authType: 'openai' as ContentGeneratorConfig['authType'],
     apiKey: 'parent-key',
@@ -50,7 +51,7 @@ describe('buildAgentContentGeneratorConfig', () => {
     maxRetries: 3,
     contextWindowSize: 128000,
     extra_body: { custom: 'value' },
-  };
+  } satisfies ContentGeneratorConfig;
 
   describe('same-provider, bare model ID, no registry match', () => {
     it('should override the model but keep parent generation config', () => {
@@ -323,6 +324,256 @@ describe('buildAgentContentGeneratorConfig', () => {
       expect(result.proxy).toBe('http://proxy.example.com');
       expect(result.userAgent).toBe('custom-agent/1.0');
     });
+  });
+
+  describe('local worker credential isolation', () => {
+    const localModel: ResolvedModelConfig = {
+      id: 'local-worker',
+      name: 'Local worker',
+      authType: 'openai' as ResolvedModelConfig['authType'],
+      baseUrl: 'http://127.0.0.1:11434/v1',
+      registryBaseUrl: 'http://127.0.0.1:11434/v1',
+      envKey: 'LOCAL_WORKER_KEY',
+      generationConfig: {},
+      capabilities: {},
+    };
+
+    beforeEach(() => {
+      vi.stubEnv('LOCAL_WORKER_KEY', undefined);
+      vi.stubEnv('OPENAI_API_KEY', 'global-cloud-key');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it.each([undefined, ''])(
+      'does not replace a missing worker key (%s)',
+      (key) => {
+        vi.stubEnv('LOCAL_WORKER_KEY', key);
+        const result = buildAgentContentGeneratorConfig(
+          createMockConfig(parentConfig, localModel),
+          localModel.id,
+          { authType: 'openai' },
+        );
+
+        expect(result.apiKey).toBe(key);
+        expect(result.apiKeyEnvKey).toBe('LOCAL_WORKER_KEY');
+        expect(result.baseUrl).toBe(localModel.baseUrl);
+      },
+    );
+
+    it('honors a missing explicit envKey even on the leader endpoint', () => {
+      const result = buildAgentContentGeneratorConfig(
+        createMockConfig(parentConfig, {
+          ...localModel,
+          baseUrl: parentConfig.baseUrl,
+        }),
+        localModel.id,
+        { authType: 'openai' },
+      );
+
+      expect(result.apiKey).toBeUndefined();
+      expect(result.apiKeyEnvKey).toBe('LOCAL_WORKER_KEY');
+    });
+
+    it.each([true, false])(
+      'does not use parent or global keys for another endpoint (registered=%s)',
+      (registered) => {
+        const result = buildAgentContentGeneratorConfig(
+          createMockConfig(
+            parentConfig,
+            registered ? { ...localModel, envKey: undefined } : undefined,
+          ),
+          localModel.id,
+          { authType: 'openai', baseUrl: localModel.baseUrl },
+        );
+
+        expect(result.apiKey).toBeUndefined();
+        expect(result.apiKeyEnvKey).toBeUndefined();
+        expect(result.baseUrl).toBe(localModel.baseUrl);
+      },
+    );
+
+    it.each([true, false])(
+      'accepts an explicit worker key (registered=%s)',
+      (registered) => {
+        const result = buildAgentContentGeneratorConfig(
+          createMockConfig(parentConfig, registered ? localModel : undefined),
+          localModel.id,
+          {
+            authType: 'openai',
+            baseUrl: localModel.baseUrl,
+            apiKey: 'explicit-worker-key',
+          },
+        );
+
+        expect(result.apiKey).toBe('explicit-worker-key');
+        expect(result.baseUrl).toBe(localModel.baseUrl);
+      },
+    );
+
+    it('keeps the leader unchanged while applying only worker request options', () => {
+      vi.stubEnv('LOCAL_WORKER_KEY', 'ollama');
+      const leader = {
+        ...parentConfig,
+        customHeaders: { Authorization: 'Bearer leader-header' },
+      };
+      const before = structuredClone(leader);
+      const result = buildAgentContentGeneratorConfig(
+        createMockConfig(leader, {
+          ...localModel,
+          generationConfig: { contextWindowSize: 8192, timeout: 60000 },
+        }),
+        localModel.id,
+        { authType: 'openai' },
+      );
+
+      expect(result.apiKey).toBe('ollama');
+      expect(result.customHeaders).toBeUndefined();
+      expect(result.reasoning).toBeUndefined();
+      expect(result.samplingParams).toBeUndefined();
+      expect(result.extra_body).toBeUndefined();
+      expect(result.contextWindowSize).toBe(8192);
+      expect(result.timeout).toBe(60000);
+      expect(leader).toEqual(before);
+    });
+
+    it('does not inherit custom headers when the credential declaration changes', () => {
+      vi.stubEnv('LOCAL_WORKER_KEY', 'worker-key');
+      const result = buildAgentContentGeneratorConfig(
+        createMockConfig(
+          { ...parentConfig, customHeaders: { 'X-Api-Key': 'leader-header' } },
+          { ...localModel, baseUrl: parentConfig.baseUrl },
+        ),
+        localModel.id,
+        { authType: 'openai' },
+      );
+
+      expect(result.apiKey).toBe('worker-key');
+      expect(result.customHeaders).toBeUndefined();
+    });
+
+    it('applies the local model own custom headers', () => {
+      vi.stubEnv('LOCAL_WORKER_KEY', 'ollama');
+      const headers = { 'X-Worker': 'local' };
+      const result = buildAgentContentGeneratorConfig(
+        createMockConfig(parentConfig, {
+          ...localModel,
+          generationConfig: { customHeaders: headers },
+        }),
+        localModel.id,
+        { authType: 'openai' },
+      );
+
+      expect(result.customHeaders).toEqual(headers);
+    });
+
+    it.each([true, false])(
+      'isolates a Gemini leader from a local worker (key=%s)',
+      (hasKey) => {
+        if (hasKey) vi.stubEnv('LOCAL_WORKER_KEY', 'ollama');
+        const result = buildAgentContentGeneratorConfig(
+          createMockConfig(
+            {
+              ...parentConfig,
+              authType: 'gemini' as ContentGeneratorConfig['authType'],
+            },
+            { ...localModel, envKey: hasKey ? 'LOCAL_WORKER_KEY' : undefined },
+          ),
+          localModel.id,
+          { authType: 'openai' },
+        );
+
+        expect(result.apiKey).toBe(hasKey ? 'ollama' : undefined);
+        expect(result.baseUrl).toBe(localModel.baseUrl);
+        expect(result.authType).toBe('openai');
+      },
+    );
+
+    it('drops parent headers when an explicit key changes on the same endpoint', () => {
+      const result = buildAgentContentGeneratorConfig(
+        createMockConfig({
+          ...parentConfig,
+          customHeaders: { Authorization: 'Bearer parent-header' },
+        }),
+        'other-model',
+        { authType: 'openai', apiKey: 'worker-key' },
+      );
+
+      expect(result.apiKey).toBe('worker-key');
+      expect(result.customHeaders).toBeUndefined();
+      expect(result.baseUrl).toBe(parentConfig.baseUrl);
+    });
+
+    it('preserves same-endpoint inheritance without a separate credential', () => {
+      const result = buildAgentContentGeneratorConfig(
+        createMockConfig(parentConfig, {
+          ...localModel,
+          baseUrl: parentConfig.baseUrl,
+          envKey: undefined,
+        }),
+        localModel.id,
+        { authType: 'openai' },
+      );
+
+      expect(result.apiKey).toBe(parentConfig.apiKey);
+      expect(result.apiKeyEnvKey).toBe(parentConfig.apiKeyEnvKey);
+      expect(result.reasoning).toEqual(parentConfig.reasoning);
+    });
+
+    it.each([
+      [AuthType.USE_GEMINI, 'GEMINI_API_KEY'],
+      [AuthType.USE_ANTHROPIC, 'ANTHROPIC_API_KEY'],
+      [AuthType.USE_OPENAI, 'OPENAI_API_KEY'],
+    ])(
+      'preserves provider-default credentials for registered %s workers',
+      (authType, key) => {
+        vi.stubEnv(key, 'worker-default-key');
+        const registry = new ModelRegistry({
+          [authType]: [{ id: 'default-worker' }],
+        });
+        const resolved = registry.getModel(authType, 'default-worker');
+        expect(resolved).toBeDefined();
+        const config = createMockConfig(
+          {
+            ...parentConfig,
+            authType:
+              authType === AuthType.USE_OPENAI
+                ? AuthType.USE_GEMINI
+                : AuthType.USE_OPENAI,
+          },
+          resolved,
+        );
+
+        for (const baseUrl of [undefined, resolved!.baseUrl]) {
+          const result = buildAgentContentGeneratorConfig(
+            config,
+            'default-worker',
+            { authType, baseUrl },
+          );
+          expect(result.apiKey).toBe('worker-default-key');
+        }
+      },
+    );
+
+    it.each([AuthType.USE_GEMINI, AuthType.USE_OPENAI])(
+      'requires a local credential in the real registry with a %s leader',
+      (authType) => {
+        const registry = new ModelRegistry({
+          openai: [{ id: localModel.id, baseUrl: localModel.baseUrl }],
+        });
+        const resolved = registry.getModel(AuthType.USE_OPENAI, localModel.id);
+        expect(resolved).toBeDefined();
+        const result = buildAgentContentGeneratorConfig(
+          createMockConfig({ ...parentConfig, authType }, resolved),
+          localModel.id,
+          { authType: AuthType.USE_OPENAI, baseUrl: localModel.baseUrl },
+        );
+        expect(result.apiKey).toBeUndefined();
+        expect(result.baseUrl).toBe(localModel.baseUrl);
+      },
+    );
   });
 });
 

--- a/packages/core/src/models/content-generator-config.ts
+++ b/packages/core/src/models/content-generator-config.ts
@@ -23,7 +23,6 @@ import {
   AUTH_ENV_MAPPINGS,
   MODEL_GENERATION_CONFIG_FIELDS,
 } from './constants.js';
-import type { ResolvedModelConfig } from './types.js';
 
 export interface AuthOverrides {
   authType: string;
@@ -33,13 +32,13 @@ export interface AuthOverrides {
 
 /**
  * Build a ContentGeneratorConfig for a per-agent ContentGenerator.
- * Inherits operational settings (timeout, retries, proxy, sampling, etc.)
- * from the parent's config and overlays the agent-specific auth fields.
+ * Inherits model options only within the same endpoint and auth type, while
+ * retaining process-level options such as proxy and logging.
  *
  * For cross-provider agents the parent's API key / base URL are invalid,
- * so we resolve credentials from the provider-specific environment
- * variables (e.g. ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL). This mirrors
- * what a PTY subprocess does during its own initialization.
+ * so independently configured endpoints require their own credentials.
+ * Default provider environment variables are used only without an explicit
+ * endpoint or credential declaration.
  */
 export function buildAgentContentGeneratorConfig(
   base: Config,
@@ -64,50 +63,71 @@ export function buildAgentContentGeneratorConfig(
 
   const nextConfig: ContentGeneratorConfig = {
     ...parentConfig,
-    model: modelId ?? parentConfig.model,
+    model: resolvedModel?.id ?? modelId ?? parentConfig.model,
     authType: authOverrides.authType as AuthType,
+    baseUrl:
+      authOverrides.baseUrl ??
+      resolvedModel?.baseUrl ??
+      resolveCredentialField(
+        undefined,
+        sameProvider ? parentConfig.baseUrl : undefined,
+        authOverrides.authType,
+        'baseUrl',
+      ),
   };
+  const sameEndpoint =
+    sameProvider && nextConfig.baseUrl === parentConfig.baseUrl;
+  const envKey = resolvedModel?.envKey;
 
-  // When switching providers, clear generation config fields so parent
-  // settings (samplingParams, reasoning, extra_body, etc.) don't leak.
-  if (!sameProvider) {
+  // A declared key variable is authoritative. Protocol compatibility alone
+  // must not send a cloud credential to an unrelated (including local) URL.
+  const useDefaultCredentials =
+    sameEndpoint ||
+    (!sameProvider &&
+      resolvedModel?.registryBaseUrl === undefined &&
+      (authOverrides.baseUrl === undefined ||
+        authOverrides.baseUrl === resolvedModel?.baseUrl));
+  nextConfig.apiKey =
+    authOverrides.apiKey ??
+    (envKey
+      ? process.env[envKey]
+      : useDefaultCredentials
+        ? resolveCredentialField(
+            undefined,
+            sameEndpoint ? parentConfig.apiKey : undefined,
+            authOverrides.authType,
+            'apiKey',
+          )
+        : undefined);
+  nextConfig.apiKeyEnvKey =
+    envKey ?? (sameEndpoint ? parentConfig.apiKeyEnvKey : undefined);
+
+  // Different endpoints may share a protocol but not request options.
+  if (!sameEndpoint) {
     for (const field of MODEL_GENERATION_CONFIG_FIELDS) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (nextConfig as any)[field] = undefined;
     }
   }
+  if (
+    (envKey && envKey !== parentConfig.apiKeyEnvKey) ||
+    (authOverrides.apiKey !== undefined &&
+      authOverrides.apiKey !== parentConfig.apiKey)
+  ) {
+    nextConfig.customHeaders = undefined;
+  }
 
   if (resolvedModel) {
-    applyResolvedModelConfig(
-      nextConfig,
-      resolvedModel,
-      parentConfig,
-      authOverrides,
-    );
-    return nextConfig;
-  }
-
-  if (modelId && modelId !== parentConfig.model) {
+    for (const field of MODEL_GENERATION_CONFIG_FIELDS) {
+      const registryValue = resolvedModel.generationConfig[field];
+      if (registryValue !== undefined || field === 'thinkingMandatory') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (nextConfig as any)[field] = registryValue;
+      }
+    }
+  } else if (modelId && modelId !== parentConfig.model) {
     nextConfig.thinkingMandatory = undefined;
   }
-
-  nextConfig.apiKey = resolveCredentialField(
-    authOverrides.apiKey,
-    sameProvider ? parentConfig.apiKey : undefined,
-    authOverrides.authType,
-    'apiKey',
-  );
-  nextConfig.baseUrl =
-    authOverrides.baseUrl ??
-    resolveCredentialField(
-      undefined,
-      sameProvider ? parentConfig.baseUrl : undefined,
-      authOverrides.authType,
-      'baseUrl',
-    );
-  nextConfig.apiKeyEnvKey = sameProvider
-    ? parentConfig.apiKeyEnvKey
-    : undefined;
 
   return nextConfig;
 }
@@ -138,50 +158,6 @@ export async function createRuntimeContentGeneratorView(
     contentGeneratorOwner,
   );
   return { contentGenerator, contentGeneratorConfig };
-}
-
-function applyResolvedModelConfig(
-  targetConfig: ContentGeneratorConfig,
-  resolvedModel: ResolvedModelConfig,
-  parentConfig: ContentGeneratorConfig,
-  authOverrides: AuthOverrides,
-): void {
-  const sameProvider = authOverrides.authType === parentConfig.authType;
-  targetConfig.model = resolvedModel.id;
-  targetConfig.authType = resolvedModel.authType;
-  targetConfig.baseUrl =
-    authOverrides.baseUrl ??
-    resolvedModel.baseUrl ??
-    (sameProvider ? parentConfig.baseUrl : undefined);
-
-  if (resolvedModel.envKey) {
-    targetConfig.apiKey =
-      authOverrides.apiKey ??
-      process.env[resolvedModel.envKey] ??
-      (sameProvider ? parentConfig.apiKey : undefined);
-    targetConfig.apiKeyEnvKey = resolvedModel.envKey;
-  } else {
-    targetConfig.apiKey = resolveCredentialField(
-      authOverrides.apiKey,
-      sameProvider ? parentConfig.apiKey : undefined,
-      authOverrides.authType,
-      'apiKey',
-    );
-    targetConfig.apiKeyEnvKey = sameProvider
-      ? parentConfig.apiKeyEnvKey
-      : undefined;
-  }
-
-  // Cross-provider fields are cleared by buildAgentContentGeneratorConfig.
-  // Same-provider fields inherit unless the registry overrides them, except
-  // model capabilities such as thinkingMandatory, which must not leak.
-  for (const field of MODEL_GENERATION_CONFIG_FIELDS) {
-    const registryValue = resolvedModel.generationConfig[field];
-    if (registryValue !== undefined || field === 'thinkingMandatory') {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (targetConfig as any)[field] = registryValue;
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
## What this PR does

Makes existing native subagents and Agent Team safer to use with an API-backed leader and separately configured local workers, including Ollama. Adds setup documentation without introducing another orchestrator.

## Why it's needed

Sharing the OpenAI-compatible protocol must not imply sharing credentials. A missing worker key could otherwise fall back to the leader's key or run the worker on the leader's provider.

## Reviewer Test Plan

### How to verify

Keep the leader on its API model and delegate to a separately registered local model. With its own key, the worker should respond while the leader keeps its original endpoint and credentials. Remove the worker's declared key: delegation should fail before any worker request, without borrowing leader credentials or headers.

### Evidence (Before & After)

Before: a missing worker key could send the leader's credential to another endpoint. After: missing credentials stop the worker; explicit credentials preserve independent routing. The contributor also tested the feature locally and confirmed it works.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | Tested |
| Windows | Not tested locally |
| Linux | Not tested locally |

### Environment (optional)

Node.js, deterministic loopback endpoints and fictional credentials. See the separate verification report for automated results.

## Risk & Scope

- Maintainer review required: shared core credential resolution changes.
- Cross-endpoint workers now require their own credentials. Unauthenticated local servers use a dedicated placeholder key.
- No OAuth integration, new terminal UI, or full process isolation. Auxiliary-model fallback behavior is unchanged.

## Linked Issues

None.

<details>
<summary>中文说明</summary>

## 此 PR 的变更

让现有原生子代理和 Agent Team 更安全地组合 API 主代理与单独配置的本地工作代理（包括 Ollama）。补充配置文档，不引入新的编排器。

## 为什么需要

使用相同的 OpenAI 兼容协议不意味着应该共享凭据。工作代理缺少密钥时，之前可能回退到主代理密钥，或者使用主代理的提供商运行。

## 审查者测试计划

### 如何验证

保持主代理使用 API 模型，并委派给单独注册的本地模型。工作代理使用自己的密钥时应正常返回，主代理保持原端点和凭据。删除工作代理声明的密钥后，委派应在任何工作代理请求之前失败，不借用主代理的凭据或请求头。

### 变更前后证据

之前：工作代理缺少密钥可能导致主代理凭据被发送到另一个端点。之后：缺少凭据会停止工作代理；显式凭据保持独立路由。贡献者也已在本地测试并确认功能正常。

### 测试平台

| 系统 | 状态 |
| :-- | :-- |
| macOS | 已测试 |
| Windows | 未在本地测试 |
| Linux | 未在本地测试 |

### 环境

Node.js、确定性回环端点和虚构凭据。自动化测试结果见单独的验证报告。

## 风险与范围

- 需要维护者审查：修改共享核心凭据解析逻辑。
- 跨端点工作代理现在需要自己的凭据。无需认证的本地服务器使用专用占位密钥。
- 不涉及 OAuth 集成、新终端界面或完整进程隔离。辅助模型的回退行为不变。

## 关联议题

无。

</details>
