### PR TITLE
feat(web-shell): expose Agent management in sidebar

### DIFF
--- a/docs/design/agent-navigation-web-shell.md
+++ b/docs/design/agent-navigation-web-shell.md
@@ -1,0 +1,28 @@
+# First-class Agent navigation in WebShell
+
+## Problem
+
+WebShell already has a complete Agent definition manager for workspace and global Agents, including prompts, models, tools, MCP servers, and permissions. It is reachable through `/agents` and as a nested Plugins tab, but it has no primary-sidebar entry. Users therefore cannot discover Agent management or see that Agent definitions can participate in Agent Team collaboration.
+
+## Design
+
+- Add `Agents` to the existing configurable primary-sidebar navigation and open the existing Agent manager. Do not create a second manager or route.
+- Keep the entry workspace-scoped, matching the manager's daemon API and the existing Plugins, Channels, Workflows, and Goals entries.
+- Add one persistent sentence under the Agent manager title explaining that specialized Agents can be coordinated in an Agent Team.
+- Preserve host customization: embedders can omit `agents` from `primaryNav.items`, and callers that use the sidebar component directly are not forced to provide an Agent callback.
+
+## Scope
+
+Included: discoverable sidebar navigation, accessible collapsed label, existing manager routing, and collaboration-oriented copy.
+
+Excluded: a second Agent definition UI, durable Team Run history, remote Agent hosts, a Team creation form, or changes to Agent Team runtime behavior. Live Team execution remains owned by the parent PR.
+
+## Affected areas
+
+- WebShell sidebar navigation and App routing.
+- Agent manager title copy and English/Chinese localization.
+- Focused navigation and browser acceptance coverage.
+
+## Open questions
+
+None for this slice. A future Team Runs page should be added only after the daemon has persistent Run identity rather than presenting current-session state as durable management.

--- a/packages/web-shell/client/App.test.tsx
+++ b/packages/web-shell/client/App.test.tsx
@@ -1234,6 +1234,7 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
     WebShellSidebar: (props: {
       collapsed?: boolean;
       onOpenPlugins?: () => void;
+      onOpenAgents?: () => void;
       onOpenChannels?: () => void;
       onOpenDaemonStatus?: () => void;
       onOpenSessions?: () => void;
@@ -1384,6 +1385,15 @@ vi.mock('./components/sidebar/WebShellSidebar', async () => {
             onClick: props.onOpenPlugins,
           },
           'plugins',
+        ),
+        React.createElement(
+          'button',
+          {
+            'data-testid': 'open-agents',
+            type: 'button',
+            onClick: props.onOpenAgents,
+          },
+          'agents',
         ),
         React.createElement(
           'button',
@@ -23874,6 +23884,24 @@ describe('App session callbacks', () => {
         ?.querySelectorAll<HTMLButtonElement>('button[role="tab"]')[2]
         ?.getAttribute('aria-selected'),
     ).toBe('true');
+  });
+
+  it('opens Agent management from the sidebar', async () => {
+    const { container } = renderApp();
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="open-agents"]')
+        ?.click();
+      await Promise.resolve();
+    });
+
+    expect(
+      container
+        .querySelector('[data-testid="inline-panel"]')
+        ?.getAttribute('aria-label'),
+    ).toBe('Agents');
   });
 
   it('restores composer interaction after closing Plugins on the MCP tab', async () => {

--- a/packages/web-shell/client/App.tsx
+++ b/packages/web-shell/client/App.tsx
@@ -16272,6 +16272,11 @@ export function App({
                     closeMobileDrawer();
                     openPanel('settings');
                   }}
+                  onOpenAgents={() => {
+                    closeMobileDrawer();
+                    setAgentsCreateScope(null);
+                    openPanel('agents');
+                  }}
                   onOpenPlugins={() => {
                     closeMobileDrawer();
                     openPanel('plugins');

--- a/packages/web-shell/client/components/agents/AgentsManagerPage.tsx
+++ b/packages/web-shell/client/components/agents/AgentsManagerPage.tsx
@@ -610,6 +610,9 @@ export function AgentsManagerPage({
               {t('agents.title')}
             </h1>
             <p className="mt-1 text-sm text-muted-foreground tabular-nums">
+              {t('agents.description')}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground tabular-nums">
               {t('agent.count', { count: agents.length })}
             </p>
           </div>

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.tsx
@@ -30,6 +30,7 @@ import type {
 import {
   FolderKanbanIcon,
   ActivityIcon,
+  BotIcon,
   BlocksIcon,
   CalendarClockIcon,
   ChevronDownIcon,
@@ -236,6 +237,7 @@ export interface WebShellSidebarLockedWorkspace {
 
 export type WebShellSidebarPrimaryNavItem =
   | 'newTask'
+  | 'agents'
   | 'plugins'
   | 'channels'
   | 'scheduledTasks'
@@ -268,6 +270,7 @@ const DEFAULT_FOOTER_ITEMS: readonly WebShellSidebarFooterItem[] = [
 
 const DEFAULT_PRIMARY_NAV_ITEMS: readonly WebShellSidebarPrimaryNavItem[] = [
   'newTask',
+  'agents',
   'plugins',
   'channels',
   'scheduledTasks',
@@ -374,6 +377,7 @@ interface WebShellSidebarProps {
   collapsed: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
   onOpenSettings: () => void;
+  onOpenAgents?: () => void;
   onOpenPlugins: () => void;
   onOpenChannels: () => void;
   onOpenDaemonStatus: () => void;
@@ -877,6 +881,7 @@ export function WebShellSidebar({
   collapsed,
   onCollapsedChange,
   onOpenSettings,
+  onOpenAgents,
   onOpenPlugins,
   onOpenChannels,
   onOpenDaemonStatus,
@@ -939,6 +944,7 @@ export function WebShellSidebar({
   const hasScrollingPrimaryNav =
     (projectFeaturesEnabled &&
       (primaryNavItems.has('plugins') ||
+        (primaryNavItems.has('agents') && Boolean(onOpenAgents)) ||
         primaryNavItems.has('channels') ||
         primaryNavItems.has('scheduledTasks') ||
         primaryNavItems.has('workflows') ||
@@ -5289,6 +5295,22 @@ export function WebShellSidebar({
         >
           {hasScrollingPrimaryNav && (
             <div className={styles.primaryNav}>
+              {projectFeaturesEnabled &&
+                onOpenAgents &&
+                primaryNavItems.has('agents') && (
+                  <button
+                    className={styles.pluginButton}
+                    type="button"
+                    title={t('agents.title')}
+                    aria-label={t('agents.title')}
+                    onClick={onOpenAgents}
+                  >
+                    <span className={styles.navIcon}>
+                      <BotIcon size={16} strokeWidth={1.2} />
+                    </span>
+                    {!collapsed && <span>{t('agents.title')}</span>}
+                  </button>
+                )}
               {projectFeaturesEnabled && primaryNavItems.has('plugins') && (
                 <button
                   className={styles.pluginButton}

--- a/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
+++ b/packages/web-shell/client/components/sidebar/WebShellSidebar.workspace-removal.test.tsx
@@ -400,6 +400,7 @@ function renderSidebar(
     onSelectWorkspace?: (cwd: string | undefined) => void;
     onError?: (error: unknown, message: string) => void;
     onOpenGoals?: () => void;
+    onOpenAgents?: () => void;
     onOpenWorkflows?: () => void;
     onOpenWorkspaceManagement?: (
       target: WorkspaceManagementTarget,
@@ -430,6 +431,7 @@ function renderSidebar(
       render?: (workspace: DaemonWorkspaceCapability) => ReactNode;
     };
     showSessionSourceSwitch?: boolean;
+    primaryNav?: Parameters<typeof WebShellSidebar>[0]['primaryNav'];
     projectFeaturesEnabled?: boolean;
     sessionActions?: {
       items?: readonly (
@@ -456,6 +458,7 @@ function renderSidebar(
           onOpenScheduledTasks={() => {}}
           onOpenWorkflows={overrides.onOpenWorkflows ?? (() => {})}
           onOpenGoals={overrides.onOpenGoals ?? (() => {})}
+          onOpenAgents={overrides.onOpenAgents}
           onOpenSessions={() => {}}
           onOpenSplitView={() => {}}
           onNewSession={overrides.onNewSession ?? (() => false)}
@@ -474,6 +477,7 @@ function renderSidebar(
           lockedWorkspaceCwd={overrides.lockedWorkspaceCwd}
           lockedWorkspace={overrides.lockedWorkspace}
           showSessionSourceSwitch={overrides.showSessionSourceSwitch}
+          primaryNav={overrides.primaryNav}
           projectFeaturesEnabled={overrides.projectFeaturesEnabled}
           sessionActions={overrides.sessionActions}
         />
@@ -1652,6 +1656,7 @@ describe('WebShellSidebar workspace removal', () => {
     }));
     renderSidebar({
       projectFeaturesEnabled: false,
+      onOpenAgents: vi.fn(),
       onOpenAddWorkspace: vi.fn(),
       onOpenWorkspacesOverview: vi.fn(),
       onOpenGitDiff: vi.fn(),
@@ -1662,6 +1667,7 @@ describe('WebShellSidebar workspace removal', () => {
     });
 
     expect(container.querySelector('button[aria-label="Plugins"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Agents"]')).toBeNull();
     expect(container.querySelector('button[aria-label="Channels"]')).toBeNull();
     expect(container.querySelector('button[aria-label="Settings"]')).toBeNull();
     // These open a project panel or dialog that only renders inside a
@@ -4450,6 +4456,30 @@ describe('WebShellSidebar goals entry', () => {
     expect(button).not.toBeNull();
     click(button!);
     expect(onOpenGoals).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WebShellSidebar Agents entry', () => {
+  it('opens Agent management from primary navigation by default', () => {
+    const onOpenAgents = vi.fn();
+    renderSidebar({ onOpenAgents });
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Agents"]',
+    );
+    expect(button).not.toBeNull();
+
+    click(button!);
+
+    expect(onOpenAgents).toHaveBeenCalledOnce();
+  });
+
+  it('can be hidden through primary navigation customization', () => {
+    renderSidebar({
+      onOpenAgents: vi.fn(),
+      primaryNav: { items: ['plugins'] },
+    });
+
+    expect(container.querySelector('button[aria-label="Agents"]')).toBeNull();
   });
 });
 

--- a/packages/web-shell/client/i18n.tsx
+++ b/packages/web-shell/client/i18n.tsx
@@ -372,6 +372,8 @@ const EN: Messages = {
   'agent.view': 'View',
   'agents.closed': 'Agents panel closed.',
   'agents.title': 'Agents',
+  'agents.description':
+    'Create specialized agents and let Qwen coordinate them in an Agent Team.',
   'subagent.result': 'Result',
   'subagent.tools': (v) => `Tools (${v?.count ?? 0})`,
   'subagent.toolsCount': (v) => `${v?.count ?? 0} tools`,
@@ -3911,6 +3913,8 @@ const ZH: Messages = {
   'agent.view': '查看',
   'agents.closed': '智能体面板已关闭。',
   'agents.title': '智能体',
+  'agents.description':
+    '创建专业智能体，并让 Qwen 通过 Agent Team 协调它们共同完成任务。',
   'subagent.result': '结果',
   'subagent.tools': (v) => `工具 (${v?.count ?? 0})`,
   'subagent.toolsCount': (v) => `${v?.count ?? 0} 个工具`,


### PR DESCRIPTION
## What this PR does

This stacked PR adds a first-class Agents entry to the WebShell primary sidebar. The entry opens the existing Agent definition manager instead of introducing another management surface. The manager now also explains that Qwen can coordinate specialized Agents in an Agent Team.

## Why it's needed

WebShell already supports creating and managing real Agent definitions, but the manager is only discoverable through `/agents` or a nested Plugins tab. A visible workspace-level entry makes the capability understandable without implying durable Team Run management that the daemon does not yet provide.

## Reviewer Test Plan

### How to verify

Start WebShell for a workspace and confirm that Agents appears between New Task and Plugins. Select it and verify that the existing Agent manager loads, lists Agent definitions, shows the Agent Team collaboration explanation, and opens the existing creation form. Disable workspace project features or omit `agents` from the configured primary navigation and confirm that the entry is hidden.

### Evidence (Before & After)

Before: the primary sidebar exposed New Task, Plugins, Channels, Scheduled Tasks, and Goals; Agent management required `/agents` or Plugins > Agents.

After: the primary sidebar exposes Agents, selecting it opens the existing manager, and Create opens the established Agent editor with Basic Information, System Prompt, Tools, MCP, and Hooks sections.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Built and bundled locally, then started with `node dist/cli.js serve` in an isolated tmux session and exercised through Chrome. Full WebShell App tests passed (746/746), full sidebar tests passed (119/119), and build, typecheck, bundle, Prettier, and focused ESLint passed.

## Risk & Scope

- Main risk or tradeoff: the default primary navigation gains one item; embedders can omit it through the existing navigation customization.
- Not validated / out of scope: durable Team Run history, remote Agent hosts, Team creation, and runtime orchestration changes remain out of scope.
- Breaking changes / migration notes: none; the new sidebar callback is optional.

## Linked Issues

Depends on #11072. This PR is intentionally based on `codex/agent-team-roster-web-shell`; merge #11072 first, then retarget this PR to `main` if GitHub does not do so automatically.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

这个堆叠 PR 在 WebShell 一级侧栏中增加了“智能体”入口。它直接打开现有智能体定义管理器，没有再造一个管理界面。管理页还增加了一句说明，让用户明确知道 Qwen 可以通过 Agent Team 协调专业智能体。

## 为什么需要

WebShell 已经支持创建和管理真实的智能体定义，但此前只能通过 `/agents` 或“插件”中的二级标签发现。工作空间级的可见入口能让用户直接理解这项能力，同时不会暗示 Daemon 已经提供尚不存在的持久化 Team Run 管理。

## Reviewer 验证计划

### 如何验证

为一个工作空间启动 WebShell，确认“智能体”显示在“新建任务”和“插件”之间。点击后确认现有智能体管理器能够加载和列出定义，显示 Agent Team 协作说明，并能打开现有创建表单。关闭工作空间项目能力，或从一级导航配置中省略 `agents`，确认该入口会隐藏。

### 前后对比证据

之前：一级侧栏只显示新建任务、插件、频道、定时任务和目标；智能体管理需要使用 `/agents` 或进入“插件 > 智能体”。

之后：一级侧栏直接显示“智能体”；点击后打开现有管理器，“创建”会进入已有的智能体编辑器，其中包含基本信息、系统提示词、工具、MCP 和 Hooks。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   |  ⚠️  |
|  🐧 Linux    |  ⚠️  |

### 环境（可选）

本地完成 build 和 bundle 后，在隔离的 tmux 会话中使用 `node dist/cli.js serve` 启动，并通过 Chrome 操作。WebShell App 全量测试 746/746、侧栏全量测试 119/119 通过；build、typecheck、bundle、Prettier 和定向 ESLint 均通过。

## 风险与范围

- 主要风险或权衡：默认一级导航增加一个入口；嵌入方仍可通过现有导航定制将其省略。
- 未验证 / 不在范围内：持久化 Team Run 历史、远程 Agent Host、Team 创建和运行时编排逻辑。
- 破坏性变更 / 迁移说明：无；新增侧栏回调为可选项。

## 关联事项

依赖 #11072。本 PR 有意基于 `codex/agent-team-roster-web-shell`；请先合并 #11072，之后如果 GitHub 没有自动调整 base，再将本 PR 改为 `main`。

</details>
