### PR TITLE
feat(web-shell): add turn navigation phase 2 client data layer

### DIFF
--- a/packages/web-shell/client/adapters/messageTypes.ts
+++ b/packages/web-shell/client/adapters/messageTypes.ts
@@ -90,6 +90,14 @@ export interface DaemonMessageMeta {
   timestamp?: number;
   /** Stable transcript blocks folded into this rendered message. */
   sourceBlockIds?: string[];
+  /**
+   * Persisted transcript record ids backing this message, carried from the
+   * block's `sourceRecordIds`. This is the message layer's canonical
+   * persisted identity — the turn-navigation locator keys on it.
+   */
+  sourceRecordIds?: readonly string[];
+  /** Persisted prompt id of the turn this message belongs to, when known. */
+  promptId?: string;
 }
 
 export interface DaemonUserMessage extends DaemonMessageMeta {

--- a/packages/web-shell/client/adapters/transcriptToMessages.test.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.test.ts
@@ -4861,3 +4861,67 @@ describe('transcriptBlocksToDaemonMessages', () => {
     expect(agentB!.subContent).toBeUndefined();
   });
 });
+
+describe('Persisted identity on messages', () => {
+  it('carries sourceRecordIds and promptId from the backing block', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('u1', 'user', 'hello', 1, false, {
+        sourceRecordIds: ['rec-1'],
+        promptId: 'prompt-1',
+      }),
+    ]);
+
+    expect(messages[0]).toMatchObject({
+      role: 'user',
+      sourceRecordIds: ['rec-1'],
+      promptId: 'prompt-1',
+    });
+  });
+
+  it('survives source-identity stripping', () => {
+    const messages = transcriptBlocksToDaemonMessages(
+      [
+        textBlock('u1', 'user', 'hello', 1, false, {
+          sourceRecordIds: ['rec-1'],
+          promptId: 'prompt-1',
+        }),
+      ],
+      { includeSourceIdentity: false },
+    );
+
+    expect(messages[0]).not.toHaveProperty('sourceBlockIds');
+    expect(messages[0]).toMatchObject({
+      sourceRecordIds: ['rec-1'],
+      promptId: 'prompt-1',
+    });
+  });
+
+  it('omits both fields when the block carries no persisted identity', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('u1', 'user', 'hello', 1),
+    ]);
+
+    expect(messages[0]).not.toHaveProperty('sourceRecordIds');
+    expect(messages[0]).not.toHaveProperty('promptId');
+  });
+
+  it('unions record ids across blocks merged into one message', () => {
+    const messages = transcriptBlocksToDaemonMessages([
+      textBlock('a1', 'assistant', 'part one ', 1, false, {
+        sourceRecordIds: ['rec-1'],
+        promptId: 'prompt-1',
+      }),
+      textBlock('a2', 'assistant', 'part two', 2, false, {
+        sourceRecordIds: ['rec-2'],
+        promptId: 'prompt-1',
+      }),
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      role: 'assistant',
+      sourceRecordIds: ['rec-1', 'rec-2'],
+      promptId: 'prompt-1',
+    });
+  });
+});

--- a/packages/web-shell/client/adapters/transcriptToMessages.ts
+++ b/packages/web-shell/client/adapters/transcriptToMessages.ts
@@ -1023,8 +1023,53 @@ export function transcriptBlocksToDaemonMessages(
   }
 
   synchronizeToolGroupSourceIdentity(messages);
+  applyPersistedIdentity(messages, blocks);
   if (!retainSourceIdentity) stripSourceIdentity(messages);
   return messages;
+}
+
+/**
+ * Carry the blocks' persisted identity (`sourceRecordIds` / `promptId`)
+ * onto the rendered messages. Runs after tool-group identity
+ * synchronization so folded blocks contribute their record ids through the
+ * unioned `sourceBlockIds`, and before `stripSourceIdentity` so the
+ * persisted identity survives regardless of `includeSourceIdentity`.
+ */
+function applyPersistedIdentity(
+  messages: DaemonMessage[],
+  blocks: readonly DaemonTranscriptBlock[],
+): void {
+  const identityByBlockId = new Map<
+    string,
+    { sourceRecordIds?: readonly string[]; promptId?: string }
+  >();
+  for (const block of blocks) {
+    if (block.sourceRecordIds === undefined && block.promptId === undefined) {
+      continue;
+    }
+    identityByBlockId.set(block.id, {
+      sourceRecordIds: block.sourceRecordIds,
+      promptId: block.promptId,
+    });
+  }
+  if (identityByBlockId.size === 0) return;
+  for (const message of messages) {
+    const recordIds: string[] = [];
+    const seen = new Set<string>();
+    let promptId: string | undefined;
+    for (const blockId of message.sourceBlockIds ?? []) {
+      const identity = identityByBlockId.get(blockId);
+      if (identity === undefined) continue;
+      for (const recordId of identity.sourceRecordIds ?? []) {
+        if (seen.has(recordId)) continue;
+        seen.add(recordId);
+        recordIds.push(recordId);
+      }
+      promptId ??= identity.promptId;
+    }
+    if (recordIds.length > 0) message.sourceRecordIds = recordIds;
+    if (promptId !== undefined) message.promptId = promptId;
+  }
 }
 
 function synchronizeToolGroupSourceIdentity(messages: DaemonMessage[]): void {

--- a/packages/web-shell/client/constants/sessions.ts
+++ b/packages/web-shell/client/constants/sessions.ts
@@ -14,6 +14,7 @@ export const SESSION_ORGANIZATION_FEATURE = 'session_organization';
 export const SESSION_LIVE_STATE_FEATURE = 'workspace_session_live_state';
 export const SESSION_TRANSCRIPT_PAGINATION_FEATURE =
   'session_transcript_pagination';
+export const SESSION_TURN_NAVIGATION_FEATURE = 'session_turn_navigation';
 export const SESSION_MONITOR_TOOL_CORRELATION_FEATURE =
   'session_monitor_tool_correlation';
 export const SESSION_SIDE_TASK_FEATURE = 'session_side_task';

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.test.tsx
@@ -37,8 +37,10 @@ import {
   useDaemonStreamingState,
   useDaemonTranscriptBlocks,
   useDaemonTranscriptHistory,
+  useDaemonTranscriptLedger,
   useDaemonTranscriptState,
   useDaemonTranscriptStore,
+  useDaemonTurnIndex,
   useDaemonWorkspaceEventSignals,
   type DaemonSessionProviderProps,
   type DaemonConnectionState,
@@ -113,6 +115,24 @@ interface MockSession {
     nextCursor?: string;
     partial?: true;
     replayError?: string;
+    targetRecordId?: string;
+    hasOlder?: boolean;
+  }>;
+  getTurnIndexPage: (opts: unknown) => Promise<{
+    v: 1;
+    sessionId: string;
+    snapshot: string;
+    totalTurns: number;
+    start: number;
+    turns: Array<{
+      ordinal: number;
+      turnId: string;
+      kind: 'prompt' | 'realtime' | 'scheduled';
+      promptId?: string;
+      timestamp?: string;
+      label: string;
+      detail?: string;
+    }>;
   }>;
   replaySnapshot: {
     compactedReplay: DaemonEvent[];
@@ -195,6 +215,10 @@ interface MockClient {
     sessionId: string,
     opts: unknown,
   ) => Promise<unknown>;
+  getSessionTurnIndexPage: (
+    sessionId: string,
+    opts: unknown,
+  ) => Promise<unknown>;
 }
 
 const sdkMocks = vi.hoisted(() => {
@@ -239,6 +263,7 @@ const sdkMocks = vi.hoisted(() => {
   const removeMidTurnMessage = vi.fn();
   const branchSession = vi.fn();
   const getSessionTranscriptPage = vi.fn();
+  const getSessionTurnIndexPage = vi.fn();
 
   class MockDaemonClient {
     constructor(opts: unknown) {
@@ -281,6 +306,7 @@ const sdkMocks = vi.hoisted(() => {
     removeMidTurnMessage = removeMidTurnMessage;
     branchSession = branchSession;
     getSessionTranscriptPage = getSessionTranscriptPage;
+    getSessionTurnIndexPage = getSessionTurnIndexPage;
     dispose = vi.fn();
   }
 
@@ -358,6 +384,7 @@ const sdkMocks = vi.hoisted(() => {
     removeMidTurnMessage,
     branchSession,
     getSessionTranscriptPage,
+    getSessionTurnIndexPage,
     reset() {
       sessions.length = 0;
       daemonClientOptions.length = 0;
@@ -513,6 +540,7 @@ const sdkMocks = vi.hoisted(() => {
         displayName: 'Branch Session',
       });
       getSessionTranscriptPage.mockReset();
+      getSessionTurnIndexPage.mockReset();
       MockDaemonSessionClient.createOrAttach.mockReset();
       MockDaemonSessionClient.createOrAttach.mockImplementation(
         async (client: unknown, _req: unknown): Promise<MockSession> =>
@@ -17684,6 +17712,466 @@ describe('DaemonSessionProvider', () => {
     );
   });
 
+  describe('turn navigation (Phase 2)', () => {
+    const turnNavigationFeatures = ['session_turn_navigation'];
+
+    function assistantChunkEvent(
+      id: number,
+      text: string,
+      recordId: string,
+    ): DaemonEvent {
+      return {
+        id,
+        v: 1,
+        type: 'session_update',
+        data: {
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text },
+            _meta: {
+              'qwen.session.recordId': recordId,
+              qwenTranscript: { sourceRecordIds: [recordId] },
+            },
+          },
+        },
+      } as DaemonEvent;
+    }
+
+    function turnIndexTailPage(
+      sessionId: string,
+      turnCount: number,
+      snapshot = 'snap-1',
+    ) {
+      return {
+        v: 1 as const,
+        sessionId,
+        snapshot,
+        totalTurns: turnCount,
+        start: 0,
+        turns: Array.from({ length: turnCount }, (_, ordinal) => ({
+          ordinal,
+          turnId: `turn-${ordinal}`,
+          kind: 'prompt' as const,
+          label: `turn ${ordinal}`,
+        })),
+      };
+    }
+
+    async function renderTurnNavSession(input?: {
+      features?: string[];
+      replayEvents?: DaemonEvent[];
+      turnCount?: number;
+      providerProps?: Partial<DaemonSessionProviderProps>;
+    }) {
+      const features = input?.features ?? turnNavigationFeatures;
+      const turnCount = input?.turnCount ?? 3;
+      sdkMocks.capabilities.mockResolvedValue({
+        workspaceCwd: '/mock-workspace',
+        features,
+      });
+      const session = createMockSession({
+        replaySnapshot: {
+          compactedReplay: input?.replayEvents ?? [
+            assistantChunkEvent(1, 'live reply', 'record-live'),
+          ],
+          liveJournal: [],
+        },
+      });
+      sdkMocks.sessions.push(session);
+      sdkMocks.getSessionTurnIndexPage.mockResolvedValue(
+        turnIndexTailPage(session.sessionId, turnCount),
+      );
+      let actions: DaemonSessionActions | undefined;
+      let blocks: readonly DaemonTranscriptBlock[] = [];
+      let turnIndex: ReturnType<typeof useDaemonTurnIndex>;
+      let ledger: ReturnType<typeof useDaemonTranscriptLedger>;
+
+      function Harness() {
+        actions = useDaemonActions();
+        blocks = useDaemonTranscriptBlocks();
+        turnIndex = useDaemonTurnIndex();
+        ledger = useDaemonTranscriptLedger();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, {
+        autoConnect: true,
+        historyPageSize: 25,
+        ...input?.providerProps,
+      });
+      await act(async () => {
+        await flushPromises();
+      });
+      return {
+        session,
+        getActions: () => requireActions(actions),
+        getBlocks: () => blocks,
+        getTurnIndex: () => turnIndex,
+        getLedger: () => ledger,
+      };
+    }
+
+    it('seeds the turn index on attach when the capability is advertised', async () => {
+      const { session, getTurnIndex } = await renderTurnNavSession();
+      expect(sdkMocks.getSessionTurnIndexPage).toHaveBeenCalledWith(
+        session.sessionId,
+        { limit: 200, clientId: session.clientId },
+      );
+      expect(getTurnIndex()).toMatchObject({
+        sessionId: session.sessionId,
+        status: 'ready',
+        snapshot: 'snap-1',
+        totalTurns: 3,
+      });
+    });
+
+    it('keeps the index disabled without the capability', async () => {
+      const { getTurnIndex } = await renderTurnNavSession({ features: [] });
+      expect(sdkMocks.getSessionTurnIndexPage).not.toHaveBeenCalled();
+      expect(getTurnIndex()?.status).toBe('disabled');
+    });
+
+    it('lands an anchored page at a persisted turn without disturbing the live tail', async () => {
+      const { session, getActions, getBlocks, getLedger } =
+        await renderTurnNavSession();
+      sdkMocks.getSessionTranscriptPage.mockResolvedValue({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [assistantChunkEvent(10, 'anchored reply', 'record-1')],
+        hasMore: false,
+        hasOlder: true,
+        targetRecordId: 'turn-1',
+      });
+
+      let result: unknown;
+      await act(async () => {
+        result = await getActions().openTranscriptAtTurn('turn-1');
+      });
+      expect(result).toEqual({ ok: true, targetRecordId: 'turn-1' });
+      expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledWith(
+        session.sessionId,
+        {
+          atRecordId: 'turn-1',
+          snapshot: 'snap-1',
+          limit: 25,
+          clientId: session.clientId,
+        },
+      );
+      const texts = getBlocks().map(
+        (block) => (block as { text?: string }).text,
+      );
+      expect(texts).toContain('anchored reply');
+      expect(texts).toContain('live reply');
+      const ledger = getLedger();
+      expect(ledger?.entries).toHaveLength(2);
+      expect(ledger?.entries[0]).toMatchObject({
+        source: 'anchored',
+        snapshot: 'snap-1',
+        firstRecordId: 'record-1',
+      });
+      expect(ledger?.entries[1]?.source).toBe('load');
+      expect(ledger?.gaps[0]).toEqual({
+        older: { beforeRecordId: 'record-1', snapshot: 'snap-1' },
+      });
+    });
+
+    it('rejects an anchor missing from the index without fetching', async () => {
+      const { getActions } = await renderTurnNavSession();
+      let result: unknown;
+      await act(async () => {
+        result = await getActions().openTranscriptAtTurn('turn-999');
+      });
+      expect(result).toEqual({ ok: false, reason: 'invalid_anchor' });
+      expect(sdkMocks.getSessionTranscriptPage).not.toHaveBeenCalled();
+    });
+
+    it('reports unsupported when the capability is absent', async () => {
+      const { getActions } = await renderTurnNavSession({ features: [] });
+      let result: unknown;
+      await act(async () => {
+        result = await getActions().openTranscriptAtTurn('turn-1');
+      });
+      expect(result).toEqual({ ok: false, reason: 'unsupported' });
+    });
+
+    it('distinguishes window_full (retryable) from window_impossible (terminal)', async () => {
+      // maxBlocks 2 with 2 retained blocks: a 1-block page no longer fits
+      // (1+2 > 2) but could fit after eviction → retryable window_full.
+      const full = await renderTurnNavSession({
+        replayEvents: [
+          assistantChunkEvent(1, 'live reply one', 'record-live-1'),
+          assistantChunkEvent(2, 'live reply two', 'record-live-2'),
+        ],
+        providerProps: { maxBlocks: 2 },
+      });
+      sdkMocks.getSessionTranscriptPage.mockResolvedValue({
+        v: 1,
+        sessionId: full.session.sessionId,
+        events: [assistantChunkEvent(10, 'anchored reply', 'record-1')],
+        hasMore: false,
+        hasOlder: false,
+        targetRecordId: 'turn-1',
+      });
+      let fullResult: unknown;
+      await act(async () => {
+        fullResult = await full.getActions().openTranscriptAtTurn('turn-1');
+      });
+      expect(fullResult).toEqual({ ok: false, reason: 'window_full' });
+
+      // maxBlocks 1: a 1-block page alone fills the window → terminal.
+      const impossible = await renderTurnNavSession({
+        providerProps: { maxBlocks: 1 },
+      });
+      sdkMocks.getSessionTranscriptPage.mockResolvedValue({
+        v: 1,
+        sessionId: impossible.session.sessionId,
+        events: [assistantChunkEvent(10, 'anchored reply', 'record-1')],
+        hasMore: false,
+        hasOlder: false,
+        targetRecordId: 'turn-1',
+      });
+      let impossibleResult: unknown;
+      await act(async () => {
+        impossibleResult = await impossible
+          .getActions()
+          .openTranscriptAtTurn('turn-1');
+      });
+      expect(impossibleResult).toEqual({
+        ok: false,
+        reason: 'window_impossible',
+      });
+    });
+
+    it('maps server refusals to distinct reasons', async () => {
+      const { session, getActions } = await renderTurnNavSession();
+      const cases: Array<[DaemonHttpError, string]> = [
+        [
+          new DaemonHttpError(
+            409,
+            { code: 'transcript_snapshot_unavailable' },
+            'gone',
+          ),
+          'snapshot_gone',
+        ],
+        [
+          new DaemonHttpError(400, { code: 'invalid_turn_anchor' }, 'anchor'),
+          'invalid_anchor',
+        ],
+        [
+          new DaemonHttpError(
+            413,
+            { code: 'transcript_page_too_large' },
+            'large',
+          ),
+          'page_too_large',
+        ],
+      ];
+      for (const [error, reason] of cases) {
+        sdkMocks.getSessionTranscriptPage.mockRejectedValueOnce(error);
+        const result = await act(async () =>
+          getActions().openTranscriptAtTurn('turn-1'),
+        );
+        expect(result).toEqual({ ok: false, reason });
+        // Recovery paths re-fetch the index (refresh / re-seed).
+        await act(async () => {
+          await flushPromises();
+        });
+      }
+      expect(sdkMocks.getSessionTranscriptPage).toHaveBeenCalledTimes(3);
+      void session;
+    });
+
+    it('dedupes an anchored page against retained records', async () => {
+      const { session, getActions, getBlocks } = await renderTurnNavSession();
+      sdkMocks.getSessionTranscriptPage.mockResolvedValue({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [assistantChunkEvent(10, 'live reply', 'record-live')],
+        hasMore: false,
+        hasOlder: true,
+        targetRecordId: 'turn-1',
+      });
+      let result: unknown;
+      await act(async () => {
+        result = await getActions().openTranscriptAtTurn('turn-1');
+      });
+      expect(result).toEqual({ ok: true, targetRecordId: 'turn-1' });
+      const liveBlocks = getBlocks().filter(
+        (block) => (block as { text?: string }).text === 'live reply',
+      );
+      expect(liveBlocks).toHaveLength(1);
+    });
+
+    it('continues newer with the stored cursor sent alone', async () => {
+      const { session, getActions, getBlocks, getLedger } =
+        await renderTurnNavSession();
+      sdkMocks.getSessionTranscriptPage.mockResolvedValueOnce({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [assistantChunkEvent(10, 'anchored reply', 'record-1')],
+        hasMore: true,
+        hasOlder: true,
+        nextCursor: 'cursor-1',
+        targetRecordId: 'turn-1',
+      });
+      await act(async () => {
+        await getActions().openTranscriptAtTurn('turn-1');
+      });
+      const anchoredEntryId = getLedger()?.entries[0]?.id;
+      expect(anchoredEntryId).toBeDefined();
+      expect(getLedger()?.entries[0]?.nextCursor).toBe('cursor-1');
+
+      sdkMocks.getSessionTranscriptPage.mockResolvedValueOnce({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [assistantChunkEvent(11, 'continuation reply', 'record-2')],
+        hasMore: false,
+      });
+      let result: unknown;
+      await act(async () => {
+        result = await getActions().continueTranscriptNewer(anchoredEntryId!);
+      });
+      expect(result).toEqual({ ok: true });
+      expect(sdkMocks.getSessionTranscriptPage).toHaveBeenLastCalledWith(
+        session.sessionId,
+        { cursor: 'cursor-1', limit: 25, clientId: session.clientId },
+      );
+      const texts = getBlocks().map(
+        (block) => (block as { text?: string }).text,
+      );
+      expect(texts).toContain('continuation reply');
+      const entries = getLedger()?.entries ?? [];
+      expect(entries).toHaveLength(3);
+      expect(entries[1]).toMatchObject({
+        source: 'continuation',
+        snapshot: 'snap-1',
+      });
+    });
+
+    it('continues older with beforeRecordId plus the entry snapshot', async () => {
+      const { session, getActions, getLedger } = await renderTurnNavSession();
+      sdkMocks.getSessionTranscriptPage.mockResolvedValueOnce({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [assistantChunkEvent(10, 'anchored reply', 'record-1')],
+        hasMore: false,
+        hasOlder: true,
+        targetRecordId: 'turn-1',
+      });
+      await act(async () => {
+        await getActions().openTranscriptAtTurn('turn-1');
+      });
+      const anchoredEntryId = getLedger()?.entries[0]?.id;
+      expect(anchoredEntryId).toBeDefined();
+
+      sdkMocks.getSessionTranscriptPage.mockResolvedValueOnce({
+        v: 1,
+        sessionId: session.sessionId,
+        events: [assistantChunkEvent(9, 'older reply', 'record-0')],
+        hasMore: false,
+        hasOlder: false,
+      });
+      let result: unknown;
+      await act(async () => {
+        result = await getActions().continueTranscriptOlder(anchoredEntryId!);
+      });
+      expect(result).toEqual({ ok: true });
+      expect(sdkMocks.getSessionTranscriptPage).toHaveBeenLastCalledWith(
+        session.sessionId,
+        {
+          beforeRecordId: 'record-1',
+          snapshot: 'snap-1',
+          limit: 25,
+          clientId: session.clientId,
+        },
+      );
+      const entries = getLedger()?.entries ?? [];
+      expect(entries).toHaveLength(3);
+      expect(entries[0]).toMatchObject({
+        source: 'continuation',
+        firstRecordId: 'record-0',
+      });
+      // The older continuation butts against the anchored page.
+      expect(getLedger()?.gaps[1]).toEqual({});
+    });
+
+    it('appends a live provisional when a prompt is admitted', async () => {
+      const { getActions, getTurnIndex } = await renderTurnNavSession();
+      await act(async () => {
+        await getActions().submitPrompt('queued hello');
+      });
+      expect(getTurnIndex()?.liveEntries).toEqual([
+        {
+          id: 'live:prompt-1',
+          kind: 'prompt',
+          promptId: 'prompt-1',
+          label: 'queued hello',
+        },
+      ]);
+    });
+
+    it('refreshes the tail on prompt terminal', async () => {
+      sdkMocks.capabilities.mockResolvedValue({
+        workspaceCwd: '/mock-workspace',
+        features: turnNavigationFeatures,
+      });
+      const turnComplete = createDeferred<void>();
+      const events = vi.fn(async function* terminalRefreshEvents(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        await Promise.race([
+          turnComplete.promise,
+          new Promise<void>((resolve) =>
+            opts.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          ),
+        ]);
+        if (opts.signal?.aborted) return;
+        yield {
+          v: 1,
+          id: 1,
+          type: 'turn_complete',
+          data: { promptId: 'prompt-1', stopReason: 'end_turn' },
+        } satisfies DaemonEvent;
+      });
+      const session = createMockSession({ events });
+      sdkMocks.sessions.push(session);
+      sdkMocks.getSessionTurnIndexPage.mockResolvedValue(
+        turnIndexTailPage(session.sessionId, 3),
+      );
+      let actions: DaemonSessionActions | undefined;
+
+      function Harness() {
+        actions = useDaemonActions();
+        return null;
+      }
+
+      await renderWithProvider(<Harness />, { autoConnect: true });
+      expect(sdkMocks.getSessionTurnIndexPage).toHaveBeenCalledTimes(1);
+
+      let prompt: Promise<unknown> | undefined;
+      await act(async () => {
+        prompt = requireActions(actions).sendPrompt('hello');
+        await flushPromises();
+      });
+      turnComplete.resolve();
+      const pendingPrompt = prompt;
+      if (!pendingPrompt) throw new Error('prompt was not started');
+      await act(async () => {
+        await pendingPrompt;
+        await flushPromises();
+      });
+      // The terminal triggered the coalesced tail refresh (validation
+      // fetch without a snapshot).
+      expect(sdkMocks.getSessionTurnIndexPage).toHaveBeenCalledTimes(2);
+      expect(sdkMocks.getSessionTurnIndexPage).toHaveBeenLastCalledWith(
+        session.sessionId,
+        { limit: 200, clientId: session.clientId },
+      );
+    });
+  });
+
   async function renderWithProvider(
     children: ReactNode,
     props: Partial<DaemonSessionProviderProps> = {},
@@ -17909,6 +18397,32 @@ function createMockSession(opts: Partial<MockSession> = {}): MockSession {
           nextCursor?: string;
           partial?: true;
           replayError?: string;
+          targetRecordId?: string;
+          hasOlder?: boolean;
+        };
+      }),
+    getTurnIndexPage:
+      opts.getTurnIndexPage ??
+      vi.fn(async (pageOpts: unknown) => {
+        if (!session.client) throw new Error('Session client is unavailable');
+        return (await session.client.getSessionTurnIndexPage(
+          session.sessionId,
+          pageOpts,
+        )) as {
+          v: 1;
+          sessionId: string;
+          snapshot: string;
+          totalTurns: number;
+          start: number;
+          turns: Array<{
+            ordinal: number;
+            turnId: string;
+            kind: 'prompt' | 'realtime' | 'scheduled';
+            promptId?: string;
+            timestamp?: string;
+            label: string;
+            detail?: string;
+          }>;
         };
       }),
     replaySnapshot: opts.replaySnapshot ?? {

--- a/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/web-shell/client/daemon/session/DaemonSessionProvider.tsx
@@ -38,6 +38,7 @@ import {
   type DaemonApprovalMode,
   type DaemonEvent,
   type DaemonSseConnectReason,
+  type DaemonSessionTranscriptPage,
   type DaemonStandaloneSessionOptions,
   type DaemonTranscriptBlock,
   type DaemonTranscriptState,
@@ -67,6 +68,16 @@ import {
   persistStableClientId,
 } from './clientLifecycle.js';
 import { extractHttpStatus, isRecord } from './httpErrors.js';
+import {
+  ledgerEntryFromBlocks,
+  TranscriptPageLedger,
+  type TranscriptGap,
+  type TranscriptPageLedgerEntry,
+} from './transcriptPageLedger.js';
+import {
+  SessionTurnIndexStore,
+  type SessionTurnIndexState,
+} from './turnIndexStore.js';
 import {
   getDaemonErrorCode,
   getStandaloneConnectionState,
@@ -123,6 +134,7 @@ import {
 import type {
   ActivePrompt,
   AddDaemonSessionNotice,
+  ContinueTranscriptWindowResult,
   DaemonConnectionState,
   DaemonPromptStatus,
   DaemonSessionActions,
@@ -132,8 +144,10 @@ import type {
   DaemonSessionProviderProps,
   DaemonProductSessionContext,
   DaemonWorkspaceEventSignals,
+  OpenTranscriptAtTurnResult,
   PendingSessionLoad,
   SettledPrompt,
+  TranscriptWindowFailure,
 } from './types.js';
 
 export type {
@@ -202,6 +216,7 @@ type TranscriptHistoryAdmission =
     };
 
 const SESSION_TRANSCRIPT_PAGINATION_FEATURE = 'session_transcript_pagination';
+const SESSION_TURN_NAVIGATION_FEATURE = 'session_turn_navigation';
 const CLIENT_IDENTITY_FEATURE = 'client_identity';
 const WORKSPACE_ACP_PREHEAT_FEATURE = 'workspace_acp_preheat';
 const WORKSPACE_ACP_STATUS_FEATURE = 'workspace_acp_status';
@@ -314,6 +329,21 @@ function materializeTranscriptHistory(
   current: DaemonTranscriptState,
   events: DaemonUiEvent[],
   maxBlocks: number,
+  options?: {
+    /**
+     * The prepend-only boundary-echo dedup compares the page's newest user
+     * block against the window's OLDEST block; it is meaningless (and can
+     * false-positive) for pages landing mid-window, so anchored and
+     * continuation reads disable it. Prompt-id matching subsumes the echo
+     * case whenever both sides carry identity.
+     */
+    boundaryEchoDedup?: boolean;
+    /**
+     * Anchored-path dedup: drop events whose promptId is already displayed.
+     * Never applied to the legacy prepend path.
+     */
+    promptIdDedup?: boolean;
+  },
 ): TranscriptHistoryAdmission {
   // Drop fetched events whose source records are already displayed.
   // `beforeRecordId` pagination is exclusive of the anchor but the anchor
@@ -358,18 +388,36 @@ function materializeTranscriptHistory(
   };
   const oldestRetainedBlock = current.blocks[0];
   const boundaryEchoKey =
+    options?.boundaryEchoDedup !== false &&
     (oldestRetainedBlock?.sourceRecordIds?.length ?? 0) === 0
       ? userBlockBoundaryKey(oldestRetainedBlock)
       : undefined;
-  const freshEvents =
-    displayedRecordIds.size === 0
-      ? events
-      : events.filter(
-          (event) =>
-            !event.sourceRecordIds?.some((recordId) =>
-              displayedRecordIds.has(recordId),
-            ),
-        );
+  const displayedPromptIds =
+    options?.promptIdDedup === true
+      ? new Set(
+          current.blocks
+            .map((block) => block.promptId)
+            .filter((promptId): promptId is string => promptId !== undefined),
+        )
+      : undefined;
+  const freshEvents = events.filter((event) => {
+    if (
+      displayedRecordIds.size > 0 &&
+      event.sourceRecordIds?.some((recordId) =>
+        displayedRecordIds.has(recordId),
+      )
+    ) {
+      return false;
+    }
+    if (
+      displayedPromptIds !== undefined &&
+      event.promptId !== undefined &&
+      displayedPromptIds.has(event.promptId)
+    ) {
+      return false;
+    }
+    return true;
+  });
   const historyStore = createDaemonTranscriptStore({
     maxBlocks: Number.MAX_SAFE_INTEGER,
     // Trim-free by intent: a media-heavy page would otherwise cross the
@@ -456,6 +504,35 @@ function applyTranscriptHistory(
   current: DaemonTranscriptState,
   history: TranscriptHistoryMaterialization,
 ): DaemonTranscriptState {
+  return mergeTranscriptPage(current, history, [
+    ...history.blocks,
+    ...current.blocks,
+  ]);
+}
+
+/**
+ * Insert-at-ledger-position admission for pages that are neither
+ * older-than-window nor live (anchored opens, newer-direction
+ * continuations): the flat store keeps its `[pages…, liveTail]` layout
+ * with the page spliced in at `insertBlockIndex`.
+ */
+function applyTranscriptPageInsert(
+  current: DaemonTranscriptState,
+  history: TranscriptHistoryMaterialization,
+  insertBlockIndex: number,
+): DaemonTranscriptState {
+  return mergeTranscriptPage(current, history, [
+    ...current.blocks.slice(0, insertBlockIndex),
+    ...history.blocks,
+    ...current.blocks.slice(insertBlockIndex),
+  ]);
+}
+
+function mergeTranscriptPage(
+  current: DaemonTranscriptState,
+  history: TranscriptHistoryMaterialization,
+  blocks: readonly DaemonTranscriptBlock[],
+): DaemonTranscriptState {
   // A page-resurrected real block mapping must win over the current window's
   // TRIMMED sentinel for the same callId — otherwise the resurrected block is
   // orphaned and every later live update for that tool hits the sentinel
@@ -502,7 +579,7 @@ function applyTranscriptHistory(
   }
   return {
     ...current,
-    blocks: [...history.blocks, ...current.blocks],
+    blocks,
     retainedBytes: current.retainedBytes + history.retainedBytes,
     nextOrdinal: history.nextOrdinal,
     toolBlockByCallId,
@@ -515,6 +592,81 @@ function applyTranscriptHistory(
       ...current.unrecognizedDiagnostics,
     ].slice(-UNRECOGNIZED_DIAGNOSTICS_LIMIT),
   };
+}
+
+/**
+ * Ledger position for an anchored page: the first entry whose minimum
+ * index-known ordinal sits past the target. Entries without index-known
+ * turn ids are live-tail-adjacent and count as newer than everything.
+ */
+function computeLedgerInsertIndex(
+  ledger: TranscriptPageLedger,
+  ordinalByTurnId: ReadonlyMap<string, number>,
+  targetOrdinal: number,
+): number {
+  const entries = ledger.getEntries();
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index]!;
+    let minOrdinal: number | undefined;
+    for (const turnId of entry.turnIds) {
+      const ordinal = ordinalByTurnId.get(turnId);
+      if (ordinal === undefined) continue;
+      minOrdinal =
+        minOrdinal === undefined ? ordinal : Math.min(minOrdinal, ordinal);
+    }
+    if (minOrdinal === undefined || minOrdinal > targetOrdinal) return index;
+  }
+  return entries.length;
+}
+
+/**
+ * Flat-store block index at which a page inserted at ledger `insertIndex`
+ * lands: the next entry's first block, or the live-tail start (one past
+ * the newest entry's last block) when appending after the newest page.
+ */
+function computeInsertBlockIndex(
+  state: DaemonTranscriptState,
+  ledger: TranscriptPageLedger,
+  insertIndex: number,
+): number {
+  const entries = ledger.getEntries();
+  const nextEntry = entries[insertIndex];
+  if (nextEntry !== undefined) {
+    return state.blockIndexById[nextEntry.firstBlockId] ?? state.blocks.length;
+  }
+  const newest = entries[entries.length - 1];
+  if (newest === undefined) return state.blocks.length;
+  const lastIndex = state.blockIndexById[newest.lastBlockId];
+  return lastIndex === undefined ? state.blocks.length : lastIndex + 1;
+}
+
+/** Map a transcript-window fetch failure to its distinct client reason. */
+function transcriptWindowFailureReason(
+  error: unknown,
+): TranscriptWindowFailure['reason'] | undefined {
+  if (!(error instanceof DaemonHttpError)) return undefined;
+  const code =
+    isRecord(error.body) && typeof error.body['code'] === 'string'
+      ? error.body['code']
+      : undefined;
+  if (error.status === 400 && code === 'invalid_turn_anchor') {
+    return 'invalid_anchor';
+  }
+  // Snapshot-bound failures after replacement/rewind are expected
+  // invalidation, not a retryable error storm.
+  if (
+    (error.status === 409 && code === 'transcript_snapshot_unavailable') ||
+    (error.status === 400 && code === 'invalid_transcript_cursor')
+  ) {
+    return 'snapshot_gone';
+  }
+  if (error.status === 413 && code === 'transcript_page_too_large') {
+    return 'page_too_large';
+  }
+  if (error.status === 413 && code === 'transcript_too_large') {
+    return 'unsupported';
+  }
+  return undefined;
 }
 
 function boundedString(value: unknown, maxLength: number): string | undefined {
@@ -657,6 +809,17 @@ const DaemonActionsContext = createContext<DaemonSessionActions | undefined>(
 );
 const DaemonTranscriptHistoryContext = createContext<
   DaemonTranscriptHistory | undefined
+>(undefined);
+const DaemonTurnIndexContext = createContext<SessionTurnIndexState | undefined>(
+  undefined,
+);
+/** Read model over the provider-owned transcript page ledger. */
+export interface DaemonTranscriptLedgerView {
+  entries: readonly TranscriptPageLedgerEntry[];
+  gaps: readonly TranscriptGap[];
+}
+const DaemonTranscriptLedgerContext = createContext<
+  DaemonTranscriptLedgerView | undefined
 >(undefined);
 const DaemonPromptStatusContext = createContext<DaemonPromptStatus | undefined>(
   undefined,
@@ -868,6 +1031,21 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
   // moved mid-fetch, so a stale page can never advance the anchor below the
   // evicted band.
   const paginationGenerationRef = useRef(0);
+  // Page ledger over the flat transcript store: records which block ranges
+  // arrived as which fetched page plus the explicit gaps between them, so
+  // eviction leaves re-fetchable locators instead of untracked holes.
+  const transcriptPageLedgerRef = useRef(new TranscriptPageLedger());
+  // Per-session turn-index store (capability-gated). Created on session
+  // attach; disposed and recreated when the session identity changes.
+  const turnIndexStoreRef = useRef<SessionTurnIndexStore | undefined>(
+    undefined,
+  );
+  const [turnIndexState, setTurnIndexState] = useState<
+    SessionTurnIndexState | undefined
+  >(undefined);
+  // Bumped after every provider-side ledger mutation so the read model
+  // re-derives (the ledger itself is a mutable ref, not a store).
+  const [ledgerVersion, setLedgerVersion] = useState(0);
   const store = useMemo(
     () =>
       createDaemonTranscriptStore({
@@ -890,6 +1068,44 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           // re-based after the blocks it points past are evicted). A rewind
           // (`evictedOldest === false`) drops the newest blocks and leaves
           // the oldest anchor intact, so it must not trigger re-anchoring.
+          // Reconcile the page ledger with the trim/rewind. The callback
+          // fires mid-reduce while `store.getSnapshot()` is still pre-trim,
+          // which is exactly the state the ledger needs to locate the
+          // evicted prefix (trim) or dropped suffix (rewind).
+          if (detail.evictedOldest !== false) {
+            transcriptPageLedgerRef.current.applyPrefixTrim(
+              store.getSnapshot(),
+              detail,
+            );
+          } else {
+            transcriptPageLedgerRef.current.applyRewind(
+              store.getSnapshot(),
+              detail,
+            );
+            // A rewind invalidates snapshot-bound index pages and prompt
+            // provisionals; the store re-seeds from a fresh tail request.
+            void turnIndexStoreRef.current?.handleRewind();
+          }
+          setLedgerVersion((version) => version + 1);
+          // Shell overlays die with their live block. The store snapshot is
+          // still pre-trim inside this callback, so the sweep is deferred
+          // to a microtask — it runs after the dispatch completes, while
+          // the batcher (≥16ms macrotask) cannot have dispatched again.
+          {
+            const indexStore = turnIndexStoreRef.current;
+            if (indexStore !== undefined) {
+              queueMicrotask(() => {
+                const retained = store.getSnapshot().blockIndexById;
+                for (const entry of indexStore.getState().liveEntries) {
+                  if (entry.kind !== 'shell') continue;
+                  const blockId = entry.id.slice('shell:'.length);
+                  if (retained[blockId] === undefined) {
+                    indexStore.removeLiveShell(blockId);
+                  }
+                }
+              });
+            }
+          }
           if (detail.evictedOldest !== false) {
             if (detail.oldestRetainedRecordId !== undefined) {
               history.beforeRecordId = detail.oldestRetainedRecordId;
@@ -1260,6 +1476,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       // Swallow a reducer throw (log it) so it cannot escape as an uncaught
       // timer error or — via flushTranscriptSync — abort the catch block's
       // error recovery and the unmount cleanup.
+      const tailBlockIdBefore = store.getSnapshot().blocks.at(-1)?.id;
       try {
         store.dispatch(batch);
       } catch (error) {
@@ -1267,6 +1484,33 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           '[DaemonSessionProvider] batched transcript dispatch failed',
           { eventCount: batch.length, error },
         );
+      }
+      // Feed the turn-index store: reconcile prompt provisionals against
+      // freshly admitted blocks and register shell-command overlays. The
+      // pre-dispatch tail block anchors the scan so a trim inside the same
+      // dispatch cannot skew a length-based slice; if the anchor itself
+      // was trimmed away, skip this flush — reconciliation retries on the
+      // next refresh.
+      const indexStore = turnIndexStoreRef.current;
+      if (indexStore !== undefined) {
+        const committedBlocks = store.getSnapshot().blocks;
+        const anchorIndex =
+          tailBlockIdBefore === undefined
+            ? -1
+            : (store.getSnapshot().blockIndexById[tailBlockIdBefore] ?? -2);
+        const newBlocks =
+          anchorIndex === -2 ? [] : committedBlocks.slice(anchorIndex + 1);
+        if (newBlocks.length > 0) {
+          indexStore.observeAdmittedBlocks(newBlocks);
+          for (const block of newBlocks) {
+            if (block.kind === 'user_shell') {
+              indexStore.addLiveShell({
+                blockId: block.id,
+                label: (block as { command?: string }).command ?? block.id,
+              });
+            }
+          }
+        }
       }
     };
     const cancelTranscriptFlush = () => {
@@ -2171,6 +2415,11 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           // (firstPersistedRecordId, replayHistoryWasTruncated) recompute
           // empty on delta-resume reconnects; keep the history state that
           // the original injection initialized instead of clobbering it.
+          const ledgerSessionReinit =
+            !repairingEpisode &&
+            (replayInjected ||
+              transcriptHistoryRef.current.sessionId !==
+                activeSession.sessionId);
           if (
             !repairingEpisode &&
             (replayInjected ||
@@ -2202,6 +2451,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               firstPersistedRecordId;
             transcriptHistoryRef.current.cursor = undefined;
           }
+          let replayCommittedRebuild = false;
           if (needsStoreReset && !replayInjected) {
             // Reset needed but no replay data (e.g. fresh session) — reset
             // immediately since there is no dispatch to batch with.
@@ -2338,6 +2588,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
               needsStoreReset ||
               store.getSnapshot().blocks.length === 0;
             if (rebuildReplay) {
+              replayCommittedRebuild = true;
               // Ordinary replay rebuilds under the same cap as live growth:
               // a session loaded mid-turn can carry a live journal with tens
               // of thousands of events, and retaining it all (the previous
@@ -2544,6 +2795,79 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             // so dropping it unpins busy-session snapshots that can reach
             // tens of MiB after adaptive journal growth.
             activeSession.consumeReplaySnapshot();
+          }
+          // Create (or replace) the per-session turn-index store once the
+          // session attaches. The fetch closure routes through sessionRef
+          // so a reconnect rebinds the session client without recreating
+          // the store; a same-session delta-resume keeps the existing
+          // store and its cached pages.
+          if (
+            ledgerSessionReinit ||
+            turnIndexStoreRef.current === undefined ||
+            turnIndexStoreRef.current.getState().sessionId !==
+              activeSession.sessionId
+          ) {
+            turnIndexStoreRef.current?.dispose();
+            const turnNavigationSupported =
+              Array.isArray(capabilities?.features) &&
+              capabilities.features.includes(SESSION_TURN_NAVIGATION_FEATURE);
+            const indexStore = new SessionTurnIndexStore({
+              sessionId: activeSession.sessionId,
+              enabled: turnNavigationSupported,
+              fetchPage: (opts) => {
+                const current = sessionRef.current;
+                if (
+                  current === undefined ||
+                  current.sessionId !== activeSession.sessionId
+                ) {
+                  return Promise.reject(
+                    new Error('Turn index fetch after session change'),
+                  );
+                }
+                return current.getTurnIndexPage({
+                  ...opts,
+                  clientId: current.clientId,
+                });
+              },
+            });
+            indexStore.subscribe(() =>
+              setTurnIndexState(indexStore.getState()),
+            );
+            turnIndexStoreRef.current = indexStore;
+            setTurnIndexState(indexStore.getState());
+            // Seeding is fire-and-forget: index failures never fail the
+            // session load, prompt streaming, or retained history.
+            void indexStore.seed();
+          }
+          // Record the committed window as the ledger's first page. A full
+          // rebuild (ordinary replay, repair rebuild, or a fresh-session
+          // reset) replaces the store wholesale, so any earlier entries are
+          // void; a delta-resume append keeps both store and ledger. The
+          // older gap mirrors the reconciled pagination anchor — including
+          // the capacity reconciliation above, which can re-anchor or close
+          // the affordance after a replay trim.
+          if (ledgerSessionReinit || replayCommittedRebuild) {
+            const committedBlocks = store.getSnapshot().blocks;
+            const loadEntry = ledgerEntryFromBlocks('load', committedBlocks);
+            const ledger = transcriptPageLedgerRef.current;
+            if (loadEntry !== undefined) {
+              ledger.recordInitialLoad(loadEntry);
+            } else {
+              ledger.clear();
+            }
+            turnIndexStoreRef.current?.observeAdmittedBlocks(committedBlocks);
+            const committedHistory = transcriptHistoryRef.current;
+            ledger.setOlderGap(
+              committedHistory.hasMore &&
+                committedHistory.beforeRecordId !== undefined
+                ? {
+                    older: {
+                      beforeRecordId: committedHistory.beforeRecordId,
+                    },
+                  }
+                : undefined,
+            );
+            setLedgerVersion((version) => version + 1);
           }
           setConnection((current) => ({
             ...current,
@@ -2895,6 +3219,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
             setPromptStatus('idle');
             clearPendingTranscriptEvents();
             store.reset();
+            transcriptPageLedgerRef.current.clear();
+            setLedgerVersion((version) => version + 1);
             activeSession.setLastEventId(0);
             reconnectSessionId = activeSession.sessionId;
             resyncRequested = true;
@@ -3062,6 +3388,14 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   setPromptStatus('idle');
                 }
               }
+              // Prompt terminal: coalesced tail refresh of the turn index.
+              // Fire-and-forget — index failures never affect streaming.
+              if (
+                event.type === 'turn_complete' ||
+                event.type === 'turn_error'
+              ) {
+                void turnIndexStoreRef.current?.refreshTail();
+              }
               const hasBlockPathDebugEvent = uiEvents.some(
                 (e) =>
                   e.type === 'debug' &&
@@ -3211,6 +3545,8 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   }
                   clearPendingTranscriptEvents();
                   store.reset();
+                  transcriptPageLedgerRef.current.clear();
+                  setLedgerVersion((version) => version + 1);
                   // Ring eviction means the SSE replay window has a real gap.
                   // Resetting and continuing on the same stream can only replay
                   // the surviving tail; reload the session snapshot instead so
@@ -3958,7 +4294,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     heartbeatIntervalMs,
   ]);
 
-  const actions = useMemo<DaemonSessionActions>(
+  const baseActions = useMemo(
     () =>
       createDaemonSessionActions({
         store,
@@ -4081,6 +4417,12 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
           liveJournalRepairRef.current?.controller?.abort();
           liveJournalRepairRef.current = undefined;
         },
+        onPromptAdmitted: ({ promptId, label }) => {
+          turnIndexStoreRef.current?.addLivePrompt({
+            promptId,
+            label: label.slice(0, 160),
+          });
+        },
       }),
     [
       addNotice,
@@ -4091,7 +4433,7 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       store,
     ],
   );
-  repairReloadRef.current = actions.reloadSession;
+  repairReloadRef.current = baseActions.reloadSession;
   useEffect(() => {
     if (promptStatus !== 'idle') return;
     queueMicrotask(() => tryLiveJournalRepairRef.current?.());
@@ -4287,6 +4629,24 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
         history.beforeRecordId = nextBeforeRecordId;
         history.hasMore = page.hasMore && hasCapacity;
         history.loading = false;
+        if (historyMaterialization) {
+          const prependEntry = ledgerEntryFromBlocks(
+            'prepend',
+            historyMaterialization.blocks,
+          );
+          if (prependEntry !== undefined) {
+            transcriptPageLedgerRef.current.recordPrepend(
+              prependEntry,
+              history.hasMore && history.beforeRecordId !== undefined
+                ? { older: { beforeRecordId: history.beforeRecordId } }
+                : undefined,
+            );
+          }
+          turnIndexStoreRef.current?.observeAdmittedBlocks(
+            historyMaterialization.blocks,
+          );
+          setLedgerVersion((version) => version + 1);
+        }
         setTranscriptHistoryState({
           hasMore: history.hasMore,
           loading: false,
@@ -4351,6 +4711,389 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
     },
     [addNotice, dismissNotice, maxBlocks, store],
   );
+  // Monotonic selection counter for transcript-window requests: only the
+  // newest anchored open / continuation may commit.
+  const anchoredSelectionRef = useRef(0);
+  // Shared normalization for fetched transcript-window pages (anchored
+  // opens and continuations), mirroring the load-older pipeline.
+  const normalizeTranscriptWindowEvents = useCallback(
+    (
+      events: DaemonEvent[],
+      activeSession: DaemonSessionClient,
+    ): DaemonUiEvent[] => {
+      const replayOpts = {
+        ...eventOptionsRef.current,
+        suppressOwnUserEcho: false,
+      };
+      const uiEvents: DaemonUiEvent[] = [];
+      for (const replayEvent of events) {
+        try {
+          const transcriptEvents = filterDaemonUiEventsForTranscript(
+            replayEvent,
+            normalizeAndFilterEvent(
+              replayEvent,
+              activeSession.clientId,
+              replayOpts,
+              setConnection,
+              { updateConnection: false },
+            ),
+            addNotice,
+            dismissNotice,
+          );
+          uiEvents.push(
+            ...(subagentTranscriptModeRef.current === 'summary'
+              ? projectMainTranscriptEvents(transcriptEvents)
+              : transcriptEvents),
+          );
+        } catch (error) {
+          addNotice({
+            severity: 'warning',
+            category: 'protocol',
+            operation: 'normalize_event',
+            code: 'daemon.replay_event_malformed',
+            message: 'Skipped malformed history event',
+            debugMessage:
+              error instanceof Error ? error.message : String(error),
+            recoverable: true,
+          });
+        }
+      }
+      return uiEvents;
+    },
+    [addNotice, dismissNotice],
+  );
+  // Atomic admission for anchored/continuation pages: materialize against
+  // the window budget (record-id then prompt-id dedup; the prepend-only
+  // boundary-echo comparison is disabled), splice at the ledger position,
+  // and record the ledger entry. A failed admission leaves the window
+  // unchanged.
+  const admitTranscriptWindowPage = useCallback(
+    (args: {
+      page: DaemonSessionTranscriptPage;
+      uiEvents: DaemonUiEvent[];
+      source: 'anchored' | 'continuation';
+      insertIndex: number;
+      snapshot?: string;
+      gapOlderSnapshot?: string;
+      /**
+       * Only forward reads (anchored opens, newer continuations) mint a
+       * forward `nextCursor` on the ledger entry; a backward read's cursor
+       * continues backward and must never be stored as one.
+       */
+      mintForwardCursor?: boolean;
+      /**
+       * Continuations butt against their neighbor and close the displaced
+       * gap; an anchored open preserves it (its locator still backfills
+       * the range between the new page and the next entry).
+       */
+      buttAfter?: boolean;
+    }):
+      | { ok: true }
+      | { ok: false; reason: 'window_full' | 'window_impossible' } => {
+      const admission = materializeTranscriptHistory(
+        store.getSnapshot(),
+        args.uiEvents,
+        maxBlocks,
+        { boundaryEchoDedup: false, promptIdDedup: true },
+      );
+      if (!admission.admitted) {
+        return {
+          ok: false,
+          reason: admission.impossible ? 'window_impossible' : 'window_full',
+        };
+      }
+      const ledger = transcriptPageLedgerRef.current;
+      const state = store.getSnapshot();
+      store.reset(
+        applyTranscriptPageInsert(
+          state,
+          admission.materialization,
+          computeInsertBlockIndex(state, ledger, args.insertIndex),
+        ),
+      );
+      const entryInput = ledgerEntryFromBlocks(
+        args.source,
+        admission.materialization.blocks,
+        {
+          ...(args.snapshot !== undefined ? { snapshot: args.snapshot } : {}),
+          ...(args.mintForwardCursor === true &&
+          args.page.hasMore &&
+          args.page.nextCursor !== undefined
+            ? { nextCursor: args.page.nextCursor }
+            : {}),
+        },
+      );
+      if (entryInput !== undefined) {
+        const gapBefore: TranscriptGap | undefined =
+          args.gapOlderSnapshot !== undefined &&
+          args.page.hasOlder === true &&
+          entryInput.firstRecordId !== undefined
+            ? {
+                older: {
+                  beforeRecordId: entryInput.firstRecordId,
+                  snapshot: args.gapOlderSnapshot,
+                },
+              }
+            : undefined;
+        ledger.insertEntry(
+          entryInput,
+          args.insertIndex,
+          gapBefore,
+          args.buttAfter === true ? {} : undefined,
+        );
+      }
+      turnIndexStoreRef.current?.observeAdmittedBlocks(
+        admission.materialization.blocks,
+      );
+      setLedgerVersion((version) => version + 1);
+      return { ok: true };
+    },
+    [maxBlocks, store],
+  );
+  const openTranscriptAtTurn = useCallback(
+    async (turnId: string): Promise<OpenTranscriptAtTurnResult> => {
+      const activeSession = sessionRef.current;
+      const indexStore = turnIndexStoreRef.current;
+      if (activeSession === undefined || indexStore === undefined) {
+        return { ok: false, reason: 'unavailable' };
+      }
+      const indexStatus = indexStore.getState().status;
+      if (indexStatus === 'disabled' || indexStatus === 'unsupported') {
+        return { ok: false, reason: 'unsupported' };
+      }
+      // Jumps require the seeded index; anything else is a temporary
+      // unavailability (seed in flight, transient error), not a bad anchor.
+      if (indexStatus !== 'ready') {
+        return { ok: false, reason: 'unavailable' };
+      }
+      const located = indexStore.findTurn(turnId);
+      if (located === undefined) {
+        return { ok: false, reason: 'invalid_anchor' };
+      }
+      const selection = ++anchoredSelectionRef.current;
+      const fetchPaginationGeneration = paginationGenerationRef.current;
+      try {
+        const page = await activeSession.getTranscriptPage({
+          atRecordId: turnId,
+          snapshot: located.snapshot,
+          limit: historyPageSizeRef.current ?? 100,
+          clientId: activeSession.clientId,
+        });
+        if (
+          sessionRef.current !== activeSession ||
+          turnIndexStoreRef.current !== indexStore ||
+          anchoredSelectionRef.current !== selection ||
+          paginationGenerationRef.current !== fetchPaginationGeneration
+        ) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        if (page.partial || page.replayError) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        const uiEvents = normalizeTranscriptWindowEvents(
+          page.events,
+          activeSession,
+        );
+        if (uiEvents.length === 0) {
+          return { ok: true, targetRecordId: page.targetRecordId ?? turnId };
+        }
+        const ordinalByTurnId = new Map<string, number>();
+        for (const indexPage of indexStore.getState().pages.values()) {
+          for (const entry of indexPage.turns) {
+            ordinalByTurnId.set(entry.turnId, entry.ordinal);
+          }
+        }
+        const insertIndex = computeLedgerInsertIndex(
+          transcriptPageLedgerRef.current,
+          ordinalByTurnId,
+          located.entry.ordinal,
+        );
+        const admitted = admitTranscriptWindowPage({
+          page,
+          uiEvents,
+          source: 'anchored',
+          insertIndex,
+          snapshot: located.snapshot,
+          gapOlderSnapshot: located.snapshot,
+          mintForwardCursor: true,
+        });
+        if (!admitted.ok) return admitted;
+        return { ok: true, targetRecordId: page.targetRecordId ?? turnId };
+      } catch (error) {
+        if (
+          sessionRef.current !== activeSession ||
+          turnIndexStoreRef.current !== indexStore
+        ) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        const reason = transcriptWindowFailureReason(error);
+        // Snapshot-bound failures after invalidation events are expected;
+        // refresh or re-seed the index instead of error-storming.
+        if (reason === 'invalid_anchor') {
+          void indexStore.refreshTail();
+        } else if (reason === 'snapshot_gone') {
+          void indexStore.invalidateAndReseed();
+        } else if (reason === 'unsupported') {
+          indexStore.markUnsupported();
+        }
+        return { ok: false, reason: reason ?? 'unavailable' };
+      }
+    },
+    [admitTranscriptWindowPage, normalizeTranscriptWindowEvents],
+  );
+  const continueTranscriptOlder = useCallback(
+    async (entryId: string): Promise<ContinueTranscriptWindowResult> => {
+      const activeSession = sessionRef.current;
+      const ledger = transcriptPageLedgerRef.current;
+      const entry = ledger.getEntry(entryId);
+      if (
+        activeSession === undefined ||
+        entry === undefined ||
+        entry.snapshot === undefined ||
+        entry.firstRecordId === undefined
+      ) {
+        return { ok: false, reason: 'unavailable' };
+      }
+      const selection = ++anchoredSelectionRef.current;
+      const fetchPaginationGeneration = paginationGenerationRef.current;
+      try {
+        const page = await activeSession.getTranscriptPage({
+          beforeRecordId: entry.firstRecordId,
+          snapshot: entry.snapshot,
+          limit: historyPageSizeRef.current ?? 100,
+          clientId: activeSession.clientId,
+        });
+        if (
+          sessionRef.current !== activeSession ||
+          anchoredSelectionRef.current !== selection ||
+          paginationGenerationRef.current !== fetchPaginationGeneration
+        ) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        if (page.partial || page.replayError) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        const uiEvents = normalizeTranscriptWindowEvents(
+          page.events,
+          activeSession,
+        );
+        if (uiEvents.length === 0) {
+          return { ok: true };
+        }
+        const insertIndex = ledger
+          .getEntries()
+          .findIndex((item) => item.id === entryId);
+        if (insertIndex < 0) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        return admitTranscriptWindowPage({
+          page,
+          uiEvents,
+          source: 'continuation',
+          insertIndex,
+          snapshot: entry.snapshot,
+          gapOlderSnapshot: entry.snapshot,
+          buttAfter: true,
+        });
+      } catch (error) {
+        if (sessionRef.current !== activeSession) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        const reason = transcriptWindowFailureReason(error);
+        if (reason === 'snapshot_gone') {
+          void turnIndexStoreRef.current?.invalidateAndReseed();
+        } else if (reason === 'unsupported') {
+          turnIndexStoreRef.current?.markUnsupported();
+        }
+        return { ok: false, reason: reason ?? 'unavailable' };
+      }
+    },
+    [admitTranscriptWindowPage, normalizeTranscriptWindowEvents],
+  );
+  const continueTranscriptNewer = useCallback(
+    async (entryId: string): Promise<ContinueTranscriptWindowResult> => {
+      const activeSession = sessionRef.current;
+      const ledger = transcriptPageLedgerRef.current;
+      const entry = ledger.getEntry(entryId);
+      if (
+        activeSession === undefined ||
+        entry === undefined ||
+        entry.nextCursor === undefined
+      ) {
+        return { ok: false, reason: 'unavailable' };
+      }
+      const selection = ++anchoredSelectionRef.current;
+      const fetchPaginationGeneration = paginationGenerationRef.current;
+      try {
+        // The signed cursor is sent alone: it already encodes the frozen
+        // file identity, byte size, leaf, and position; pairing it with a
+        // snapshot or record anchor is a 400.
+        const page = await activeSession.getTranscriptPage({
+          cursor: entry.nextCursor,
+          limit: historyPageSizeRef.current ?? 100,
+          clientId: activeSession.clientId,
+        });
+        if (
+          sessionRef.current !== activeSession ||
+          anchoredSelectionRef.current !== selection ||
+          paginationGenerationRef.current !== fetchPaginationGeneration
+        ) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        if (page.partial || page.replayError) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        const uiEvents = normalizeTranscriptWindowEvents(
+          page.events,
+          activeSession,
+        );
+        if (uiEvents.length === 0) {
+          return { ok: true };
+        }
+        const entryIndex = ledger
+          .getEntries()
+          .findIndex((item) => item.id === entryId);
+        if (entryIndex < 0) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        return admitTranscriptWindowPage({
+          page,
+          uiEvents,
+          source: 'continuation',
+          insertIndex: entryIndex + 1,
+          snapshot: entry.snapshot,
+          mintForwardCursor: true,
+          buttAfter: true,
+        });
+      } catch (error) {
+        if (sessionRef.current !== activeSession) {
+          return { ok: false, reason: 'unavailable' };
+        }
+        const reason = transcriptWindowFailureReason(error);
+        if (reason === 'snapshot_gone') {
+          void turnIndexStoreRef.current?.invalidateAndReseed();
+        } else if (reason === 'unsupported') {
+          turnIndexStoreRef.current?.markUnsupported();
+        }
+        return { ok: false, reason: reason ?? 'unavailable' };
+      }
+    },
+    [admitTranscriptWindowPage, normalizeTranscriptWindowEvents],
+  );
+  const actions = useMemo<DaemonSessionActions>(
+    () => ({
+      ...baseActions,
+      openTranscriptAtTurn,
+      continueTranscriptOlder,
+      continueTranscriptNewer,
+    }),
+    [
+      baseActions,
+      openTranscriptAtTurn,
+      continueTranscriptOlder,
+      continueTranscriptNewer,
+    ],
+  );
   const transcriptHistoryValue = useMemo<DaemonTranscriptHistory>(() => {
     const active =
       connection.sessionId === transcriptHistoryRef.current.sessionId &&
@@ -4363,6 +5106,34 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
       loadMore: loadMoreTranscript,
     };
   }, [connection.sessionId, loadMoreTranscript, transcriptHistoryState]);
+  // The turn-index state is only exposed while it describes the attached
+  // session; a store created for a previous session must never leak its
+  // snapshot-bound pages into the new session's consumers.
+  const turnIndexValue = useMemo<SessionTurnIndexState | undefined>(() => {
+    if (
+      turnIndexState === undefined ||
+      connection.sessionId !== turnIndexState.sessionId ||
+      sessionRef.current?.sessionId !== turnIndexState.sessionId
+    ) {
+      return undefined;
+    }
+    return turnIndexState;
+  }, [connection.sessionId, turnIndexState]);
+  // Read model over the page ledger, gated to the attached session like the
+  // transcript-history value above. `ledgerVersion` re-derives the snapshot
+  // after every provider-side ledger mutation.
+  const transcriptLedgerValue = useMemo<
+    DaemonTranscriptLedgerView | undefined
+  >(() => {
+    void ledgerVersion;
+    const active =
+      connection.sessionId !== undefined &&
+      connection.sessionId === transcriptHistoryRef.current.sessionId &&
+      sessionRef.current?.sessionId === transcriptHistoryRef.current.sessionId;
+    if (!active) return undefined;
+    const ledger = transcriptPageLedgerRef.current;
+    return { entries: ledger.getEntries(), gaps: ledger.getGaps() };
+  }, [connection.sessionId, ledgerVersion]);
   const lastHandledSessionIdRef = useRef<
     string | undefined | typeof UNHANDLED_SESSION
   >(UNHANDLED_SESSION);
@@ -4455,7 +5226,13 @@ export function DaemonSessionProvider(props: DaemonSessionProviderProps) {
                   <DaemonTranscriptHistoryContext.Provider
                     value={transcriptHistoryValue}
                   >
-                    {children}
+                    <DaemonTurnIndexContext.Provider value={turnIndexValue}>
+                      <DaemonTranscriptLedgerContext.Provider
+                        value={transcriptLedgerValue}
+                      >
+                        {children}
+                      </DaemonTranscriptLedgerContext.Provider>
+                    </DaemonTurnIndexContext.Provider>
                   </DaemonTranscriptHistoryContext.Provider>
                 </DaemonSessionOwnerGuardContext.Provider>
               </DaemonActionsContext.Provider>
@@ -4752,6 +5529,29 @@ export function useDaemonTranscriptHistory(): DaemonTranscriptHistory {
     );
   }
   return history;
+}
+
+/**
+ * Session-wide turn-index state for turn navigation. Returns undefined
+ * whenever random access is unavailable for the attached session — the
+ * daemon did not advertise `session_turn_navigation`, the store has not
+ * been created yet, or the state describes another session — so consumers
+ * must keep a loaded-messages fallback.
+ */
+export function useDaemonTurnIndex(): SessionTurnIndexState | undefined {
+  return useContext(DaemonTurnIndexContext);
+}
+
+/**
+ * Read model over the transcript page ledger: which block ranges arrived as
+ * which fetched page, plus the explicit gaps between them. Undefined while
+ * no session is attached. Phase 3's render path interleaves gap sentinel
+ * rows from this; Phase 2 consumers are the window actions and tests.
+ */
+export function useDaemonTranscriptLedger():
+  | DaemonTranscriptLedgerView
+  | undefined {
+  return useContext(DaemonTranscriptLedgerContext);
 }
 
 export function useDaemonTranscriptState(): DaemonTranscriptState {

--- a/packages/web-shell/client/daemon/session/actions.ts
+++ b/packages/web-shell/client/daemon/session/actions.ts
@@ -78,7 +78,7 @@ import type {
   DaemonNoticeOperation,
   DaemonPromptFile,
   DaemonPromptStatus,
-  DaemonSessionActions,
+  DaemonSessionCoreActions,
   SettledPrompt,
   PendingSessionLoad,
   DaemonProductSessionContext,
@@ -213,6 +213,11 @@ export interface CreateDaemonSessionActionsArgs {
   setAttachSessionNonce: Dispatch<SetStateAction<number>>;
   setNewSessionNonce: Dispatch<SetStateAction<number>>;
   clearLiveJournalRepair?: () => void;
+  /**
+   * Fired when a prompt is admitted to the session (daemon-accepted). Used
+   * by the provider to append a turn-index live provisional entry.
+   */
+  onPromptAdmitted?: (info: { promptId: string; label: string }) => void;
 }
 
 export function getWorkspaceModelsAfterSessionClear(
@@ -357,7 +362,8 @@ export function createDaemonSessionActions({
   setAttachSessionNonce,
   setNewSessionNonce,
   clearLiveJournalRepair = () => undefined,
-}: CreateDaemonSessionActionsArgs): DaemonSessionActions {
+  onPromptAdmitted,
+}: CreateDaemonSessionActionsArgs): DaemonSessionCoreActions {
   const silentHardFailureNoticeKeys = new Set<string>();
   let noticeOwner = sessionRef.current;
   let reasoningActionToken = 0;
@@ -984,6 +990,7 @@ export function createDaemonSessionActions({
         // The prompt is admitted to the session here — signal it before we wait
         // out the (possibly long) turn, so an admission-only caller can proceed.
         options?.onAdmitted?.();
+        onPromptAdmitted?.({ promptId: accepted.promptId, label: text });
         return await waitForAcceptedPromptCompletion(
           activePromptsRef.current,
           settledPromptsRef.current,
@@ -1154,6 +1161,7 @@ export function createDaemonSessionActions({
           options.signal.reason ?? new DOMException('Aborted', 'AbortError')
         );
       }
+      onPromptAdmitted?.({ promptId: accepted.promptId, label: text });
       return { promptId: accepted.promptId };
     },
 

--- a/packages/web-shell/client/daemon/session/transcriptPageLedger.test.ts
+++ b/packages/web-shell/client/daemon/session/transcriptPageLedger.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  DaemonTranscriptBlock,
+  DaemonTranscriptState,
+} from '@qwen-code/sdk/daemon';
+import {
+  buildTurnLocator,
+  TranscriptPageLedger,
+  type TranscriptPageLedgerEntryInput,
+} from './transcriptPageLedger.js';
+
+function makeBlock(id: string, recordId?: string): DaemonTranscriptBlock {
+  return {
+    id,
+    kind: 'user',
+    text: `text-${id}`,
+    ...(recordId !== undefined ? { sourceRecordIds: [recordId] } : {}),
+    clientReceivedAt: 0,
+    updatedAt: 0,
+  } as DaemonTranscriptBlock;
+}
+
+function makeState(blocks: DaemonTranscriptBlock[]): DaemonTranscriptState {
+  const blockIndexById: Record<string, number> = {};
+  blocks.forEach((block, index) => {
+    blockIndexById[block.id] = index;
+  });
+  return { blocks, blockIndexById } as unknown as DaemonTranscriptState;
+}
+
+function pageInput(
+  overrides: Partial<TranscriptPageLedgerEntryInput> & {
+    firstBlockId: string;
+    lastBlockId: string;
+  },
+): TranscriptPageLedgerEntryInput {
+  return {
+    source: 'prepend',
+    byteSize: 100,
+    turnIds: [],
+    ...overrides,
+  };
+}
+
+describe('TranscriptPageLedger', () => {
+  it('records the initial load as the first ledger entry with no gaps', () => {
+    const ledger = new TranscriptPageLedger();
+    ledger.recordInitialLoad(
+      pageInput({
+        source: 'load',
+        firstBlockId: 'b-1',
+        lastBlockId: 'b-10',
+        firstRecordId: 'r-1',
+        lastRecordId: 'r-10',
+      }),
+    );
+    const entries = ledger.getEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      source: 'load',
+      firstBlockId: 'b-1',
+      lastBlockId: 'b-10',
+      firstRecordId: 'r-1',
+      lastRecordId: 'r-10',
+    });
+    expect(ledger.getGaps()).toEqual([{}, {}]);
+  });
+
+  it('records prepends in order, butt-joined, carrying the remaining older gap', () => {
+    const ledger = new TranscriptPageLedger();
+    ledger.recordInitialLoad(
+      pageInput({ source: 'load', firstBlockId: 'b-11', lastBlockId: 'b-20' }),
+    );
+    ledger.setOlderGap({ older: { beforeRecordId: 'r-11' } });
+    ledger.recordPrepend(
+      pageInput({ firstBlockId: 'b-1', lastBlockId: 'b-10' }),
+      { older: { beforeRecordId: 'r-1' } },
+    );
+    const entries = ledger.getEntries();
+    expect(entries.map((entry) => entry.firstBlockId)).toEqual(['b-1', 'b-11']);
+    // Gap before the new oldest entry is the remaining older range; the
+    // prepend butts against the previous oldest entry with an empty gap.
+    expect(ledger.getGaps()).toEqual([
+      { older: { beforeRecordId: 'r-1' } },
+      {},
+      {},
+    ]);
+  });
+
+  it('records a closed older gap when the prepend reaches the transcript start', () => {
+    const ledger = new TranscriptPageLedger();
+    ledger.recordInitialLoad(
+      pageInput({ source: 'load', firstBlockId: 'b-11', lastBlockId: 'b-20' }),
+    );
+    ledger.setOlderGap({ older: { beforeRecordId: 'r-11' } });
+    ledger.recordPrepend(
+      pageInput({ firstBlockId: 'b-1', lastBlockId: 'b-10' }),
+    );
+    expect(ledger.getGaps()[0]).toEqual({});
+  });
+
+  describe('applyPrefixTrim', () => {
+    it('drops fully evicted entries and records an older gap', () => {
+      const ledger = new TranscriptPageLedger();
+      const preTrim = makeState([
+        makeBlock('b-0a', 'r-0a'),
+        makeBlock('b-0b', 'r-0b'),
+        makeBlock('b-1', 'r-1'),
+        makeBlock('b-2', 'r-2'),
+        makeBlock('b-3', 'r-3'),
+        makeBlock('b-4', 'r-4'),
+      ]);
+      ledger.recordInitialLoad(
+        pageInput({
+          source: 'load',
+          firstBlockId: 'b-1',
+          lastBlockId: 'b-4',
+          firstRecordId: 'r-1',
+          lastRecordId: 'r-4',
+        }),
+      );
+      ledger.recordPrepend(
+        pageInput({ firstBlockId: 'b-0a', lastBlockId: 'b-0b' }),
+      );
+      // Trim evicts the two oldest blocks (the whole prepend page).
+      ledger.applyPrefixTrim(preTrim, {
+        blockCount: 4,
+        oldestRetainedRecordId: 'r-1',
+      });
+      const entries = ledger.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.firstBlockId).toBe('b-1');
+      expect(ledger.getGaps()[0]).toEqual({
+        older: { beforeRecordId: 'r-1' },
+      });
+    });
+
+    it('shrinks a straddling entry to the oldest retained block', () => {
+      const ledger = new TranscriptPageLedger();
+      const preTrim = makeState([
+        makeBlock('b-1', 'r-1'),
+        makeBlock('b-2', 'r-2'),
+        makeBlock('b-3', 'r-3'),
+        makeBlock('b-4', 'r-4'),
+      ]);
+      ledger.recordInitialLoad(
+        pageInput({
+          source: 'load',
+          firstBlockId: 'b-1',
+          lastBlockId: 'b-3',
+          firstRecordId: 'r-1',
+          lastRecordId: 'r-3',
+          nextCursor: 'cursor-fwd',
+          byteSize: 1,
+        }),
+      );
+      // Evict b-1 only: the load page straddles the cut.
+      ledger.applyPrefixTrim(preTrim, {
+        blockCount: 3,
+        oldestRetainedRecordId: 'r-2',
+      });
+      const entry = ledger.getEntries()[0];
+      expect(entry?.firstBlockId).toBe('b-2');
+      expect(entry?.firstRecordId).toBe('r-2');
+      expect(entry?.lastBlockId).toBe('b-3');
+      // The forward cursor pointed past evicted content and must not survive.
+      expect(entry?.nextCursor).toBeUndefined();
+      // byteSize was recomputed over the retained slice, not the stale 1.
+      expect(entry?.byteSize).toBeGreaterThan(1);
+      expect(ledger.getGaps()[0]).toEqual({
+        older: { beforeRecordId: 'r-2' },
+      });
+      // The gaps array always has entries.length + 1 elements: the older
+      // gap plus the trailing gap toward the live tail.
+      expect(ledger.getGaps()).toHaveLength(2);
+    });
+
+    it('preserves the previous gap snapshot on the re-anchored older gap', () => {
+      const ledger = new TranscriptPageLedger();
+      const preTrim = makeState([makeBlock('b-1', 'r-1'), makeBlock('b-2')]);
+      ledger.recordInitialLoad(
+        pageInput({
+          source: 'load',
+          firstBlockId: 'b-1',
+          lastBlockId: 'b-2',
+        }),
+      );
+      ledger.setOlderGap({
+        older: { beforeRecordId: 'r-1', snapshot: 'snap-1' },
+      });
+      ledger.applyPrefixTrim(preTrim, {
+        blockCount: 1,
+        oldestRetainedRecordId: 'r-1',
+      });
+      expect(ledger.getGaps()[0]).toEqual({
+        older: { beforeRecordId: 'r-1', snapshot: 'snap-1' },
+      });
+    });
+
+    it('closes the older gap empty when no retained record carries an id', () => {
+      const ledger = new TranscriptPageLedger();
+      const preTrim = makeState([makeBlock('b-1', 'r-1'), makeBlock('b-2')]);
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-1' }),
+      );
+      ledger.setOlderGap({ older: { beforeRecordId: 'r-1' } });
+      ledger.applyPrefixTrim(preTrim, { blockCount: 1 });
+      expect(ledger.getGaps()[0]).toEqual({});
+    });
+
+    it('is a no-op when the trim does not reach the oldest entry', () => {
+      const ledger = new TranscriptPageLedger();
+      const preTrim = makeState([
+        makeBlock('b-1', 'r-1'),
+        makeBlock('b-2', 'r-2'),
+        makeBlock('b-3'),
+      ]);
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-2' }),
+      );
+      // Only the tail block b-3 is evicted — impossible for oldest-first
+      // trim while pages exist, so cut=1 would straddle; use cut=0 shape:
+      ledger.applyPrefixTrim(preTrim, { blockCount: 3 });
+      expect(ledger.getEntries()).toHaveLength(1);
+      expect(ledger.getGaps()).toEqual([{}, {}]);
+    });
+  });
+
+  describe('applyRewind', () => {
+    it('drops entries past the rewind point and closes trailing gaps', () => {
+      const ledger = new TranscriptPageLedger();
+      const preRewind = makeState([
+        makeBlock('b-1', 'r-1'),
+        makeBlock('b-2', 'r-2'),
+        makeBlock('b-3', 'r-3'),
+        makeBlock('b-4', 'r-4'),
+      ]);
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-2' }),
+      );
+      ledger.recordPrepend(
+        pageInput({ firstBlockId: 'b-3', lastBlockId: 'b-4' }),
+      );
+      // Order entries oldest-first manually: initial load is b-1..b-2, and
+      // the "prepend" here actually represents a newer page for the test.
+      ledger.clear();
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-2' }),
+      );
+      ledger.insertEntry(
+        pageInput({
+          source: 'continuation',
+          firstBlockId: 'b-3',
+          lastBlockId: 'b-4',
+          nextCursor: 'cursor-fwd',
+        }),
+        1,
+      );
+      ledger.applyRewind(preRewind, { blockCount: 2 });
+      const entries = ledger.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.lastBlockId).toBe('b-2');
+      expect(ledger.getGaps()).toEqual([{}, {}]);
+    });
+
+    it('shrinks a straddling newest entry and clears its forward cursor', () => {
+      const ledger = new TranscriptPageLedger();
+      const preRewind = makeState([
+        makeBlock('b-1', 'r-1'),
+        makeBlock('b-2', 'r-2'),
+        makeBlock('b-3', 'r-3'),
+      ]);
+      ledger.recordInitialLoad(
+        pageInput({
+          source: 'load',
+          firstBlockId: 'b-1',
+          lastBlockId: 'b-3',
+          lastRecordId: 'r-3',
+          nextCursor: 'cursor-fwd',
+          byteSize: 1,
+        }),
+      );
+      ledger.applyRewind(preRewind, { blockCount: 2 });
+      const entry = ledger.getEntries()[0];
+      expect(entry?.lastBlockId).toBe('b-2');
+      expect(entry?.lastRecordId).toBe('r-2');
+      expect(entry?.nextCursor).toBeUndefined();
+      expect(entry?.byteSize).toBeGreaterThan(1);
+    });
+
+    it('is a no-op when the rewind stays inside the live tail', () => {
+      const ledger = new TranscriptPageLedger();
+      const preRewind = makeState([
+        makeBlock('b-1', 'r-1'),
+        makeBlock('b-2'),
+        makeBlock('b-3'),
+      ]);
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-1' }),
+      );
+      ledger.applyRewind(preRewind, { blockCount: 2 });
+      const entries = ledger.getEntries();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.lastBlockId).toBe('b-1');
+    });
+  });
+
+  describe('insertEntry / updateEntry', () => {
+    it('inserts an anchored page between entries with explicit side gaps', () => {
+      const ledger = new TranscriptPageLedger();
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-2' }),
+      );
+      const entry = ledger.insertEntry(
+        pageInput({
+          source: 'anchored',
+          firstBlockId: 'b-9',
+          lastBlockId: 'b-10',
+          snapshot: 'snap-1',
+        }),
+        1,
+        { older: { beforeRecordId: 'r-9', snapshot: 'snap-1' } },
+        { newer: { cursor: 'cursor-fwd' } },
+      );
+      expect(entry.source).toBe('anchored');
+      expect(ledger.getEntries().map((item) => item.firstBlockId)).toEqual([
+        'b-1',
+        'b-9',
+      ]);
+      expect(ledger.getGaps()).toEqual([
+        {},
+        { older: { beforeRecordId: 'r-9', snapshot: 'snap-1' } },
+        { newer: { cursor: 'cursor-fwd' } },
+      ]);
+    });
+
+    it('preserves the displaced gap when no explicit gapAfter is given', () => {
+      const ledger = new TranscriptPageLedger();
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-2' }),
+      );
+      ledger.setOlderGap({ older: { beforeRecordId: 'r-1' } });
+      // An anchored page landing above everything: the previous older gap
+      // now describes the range between the anchored page and the load
+      // page — its locator must survive the insertion.
+      ledger.insertEntry(
+        pageInput({
+          source: 'anchored',
+          firstBlockId: 'b-9',
+          lastBlockId: 'b-10',
+        }),
+        0,
+        { older: { beforeRecordId: 'r-9' } },
+      );
+      expect(ledger.getGaps()).toEqual([
+        { older: { beforeRecordId: 'r-9' } },
+        { older: { beforeRecordId: 'r-1' } },
+        {},
+      ]);
+    });
+
+    it('patches an entry in place', () => {
+      const ledger = new TranscriptPageLedger();
+      ledger.recordInitialLoad(
+        pageInput({ source: 'load', firstBlockId: 'b-1', lastBlockId: 'b-2' }),
+      );
+      const id = ledger.getEntries()[0]!.id;
+      ledger.updateEntry(id, { nextCursor: 'cursor-fwd' });
+      expect(ledger.getEntry(id)?.nextCursor).toBe('cursor-fwd');
+      ledger.updateEntry('missing', { nextCursor: 'nope' });
+      expect(ledger.getEntries()).toHaveLength(1);
+    });
+  });
+});
+
+describe('buildTurnLocator', () => {
+  it('maps known turn ids to the first block carrying them', () => {
+    const blocks = [
+      makeBlock('b-1', 'r-1'),
+      makeBlock('b-2', 'r-2'),
+      makeBlock('b-3', 'r-2'),
+    ];
+    const locator = buildTurnLocator(blocks, new Set(['r-1', 'r-2']));
+    expect(locator.get('r-1')).toBe('b-1');
+    // First carrier wins; later blocks repeating the record are ignored.
+    expect(locator.get('r-2')).toBe('b-2');
+    expect(locator.size).toBe(2);
+  });
+
+  it('ignores record ids the index does not know', () => {
+    const blocks = [makeBlock('b-1', 'r-1'), makeBlock('b-2', 'r-2')];
+    const locator = buildTurnLocator(blocks, new Set(['r-2']));
+    expect(locator.has('r-1')).toBe(false);
+    expect(locator.get('r-2')).toBe('b-2');
+  });
+
+  it('picks the index-known id among several source records of one block', () => {
+    const block = {
+      ...makeBlock('b-1', 'r-not-a-turn'),
+      sourceRecordIds: ['r-not-a-turn', 'r-turn'],
+    } as DaemonTranscriptBlock;
+    const locator = buildTurnLocator([block], new Set(['r-turn']));
+    expect(locator.get('r-turn')).toBe('b-1');
+    expect(locator.has('r-not-a-turn')).toBe(false);
+  });
+});

--- a/packages/web-shell/client/daemon/session/transcriptPageLedger.ts
+++ b/packages/web-shell/client/daemon/session/transcriptPageLedger.ts
@@ -1,0 +1,378 @@
+import {
+  estimateDaemonTranscriptBlockBytes,
+  type DaemonTranscriptBlock,
+  type DaemonTranscriptState,
+} from '@qwen-code/sdk/daemon';
+
+/**
+ * Provider-owned page ledger for the flat daemon transcript store.
+ *
+ * The store stays the single render source; the ledger records which block
+ * ranges arrived as which fetched page, plus the explicit gaps between them,
+ * so historical pages can be evicted and re-fetched without conflating
+ * non-contiguous ranges. See
+ * `docs/design/web-shell/web-shell-global-turn-navigation-phase2.md`.
+ */
+export interface TranscriptPageLedgerEntry {
+  id: string;
+  source: 'load' | 'prepend' | 'anchored' | 'continuation';
+  /** Inclusive boundary block ids within the flat store. */
+  firstBlockId: string;
+  lastBlockId: string;
+  /** Persisted record ids at the page boundaries, when known. */
+  firstRecordId?: string;
+  lastRecordId?: string;
+  /**
+   * Forward continuation minted by this page's fetch; present only on
+   * forward reads with `hasMore` (load / anchored / forward continuation —
+   * never on backward prepends).
+   */
+  nextCursor?: string;
+  byteSize: number;
+  /** Persisted record ids present on the page (from `sourceRecordIds`). */
+  turnIds: readonly string[];
+  /** Turn-index snapshot that produced an anchored page. */
+  snapshot?: string;
+}
+
+export interface TranscriptGap {
+  /** Direction in which the gap can be resolved. */
+  older?: { beforeRecordId: string; snapshot?: string };
+  /** Self-bound signed cursor, sent alone — never paired with a snapshot. */
+  newer?: { cursor: string };
+}
+
+export type TranscriptPageLedgerEntryInput = Omit<
+  TranscriptPageLedgerEntry,
+  'id'
+>;
+
+/**
+ * Build a ledger entry from a page's materialized blocks. Returns undefined
+ * for an empty page. `turnIds` collects every persisted record id present
+ * on the page (a superset of navigation turn ids until the turn-index
+ * store narrows it).
+ */
+export function ledgerEntryFromBlocks(
+  source: TranscriptPageLedgerEntry['source'],
+  blocks: readonly DaemonTranscriptBlock[],
+  extra?: Partial<
+    Pick<TranscriptPageLedgerEntryInput, 'nextCursor' | 'snapshot'>
+  >,
+): TranscriptPageLedgerEntryInput | undefined {
+  const first = blocks[0];
+  const last = blocks[blocks.length - 1];
+  if (first === undefined || last === undefined) return undefined;
+  const turnIds: string[] = [];
+  const seen = new Set<string>();
+  for (const block of blocks) {
+    for (const recordId of block.sourceRecordIds ?? []) {
+      if (seen.has(recordId)) continue;
+      seen.add(recordId);
+      turnIds.push(recordId);
+    }
+  }
+  return {
+    source,
+    firstBlockId: first.id,
+    lastBlockId: last.id,
+    firstRecordId: firstRecordIdOf(blocks),
+    lastRecordId: lastRecordIdOf(blocks),
+    byteSize: byteSizeOf(blocks),
+    turnIds,
+    ...extra,
+  };
+}
+
+function firstRecordIdOf(
+  blocks: readonly DaemonTranscriptBlock[],
+): string | undefined {
+  for (const block of blocks) {
+    const recordId = block.sourceRecordIds?.[0];
+    if (recordId !== undefined) return recordId;
+  }
+  return undefined;
+}
+
+function lastRecordIdOf(
+  blocks: readonly DaemonTranscriptBlock[],
+): string | undefined {
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const recordId = blocks[index]?.sourceRecordIds?.[0];
+    if (recordId !== undefined) return recordId;
+  }
+  return undefined;
+}
+
+function byteSizeOf(blocks: readonly DaemonTranscriptBlock[]): number {
+  let total = 0;
+  for (const block of blocks) {
+    total += estimateDaemonTranscriptBlockBytes(block);
+  }
+  return total;
+}
+
+/**
+ * Per-session canonical locator: persisted turn id → first block carrying
+ * it. Only record ids the turn-index store knows as navigation turns
+ * qualify; when a block lists several source records, the ids present in
+ * the index win — the first array element is not assumed to be the turn
+ * head. Existing presentation-layer `turnId` usages (reducer message ids)
+ * are unrelated to this map.
+ */
+export function buildTurnLocator(
+  blocks: readonly DaemonTranscriptBlock[],
+  knownTurnIds: ReadonlySet<string>,
+): ReadonlyMap<string, string> {
+  const locator = new Map<string, string>();
+  for (const block of blocks) {
+    for (const recordId of block.sourceRecordIds ?? []) {
+      if (!knownTurnIds.has(recordId) || locator.has(recordId)) continue;
+      locator.set(recordId, block.id);
+    }
+  }
+  return locator;
+}
+
+export class TranscriptPageLedger {
+  private entries: TranscriptPageLedgerEntry[] = [];
+  /**
+   * `gaps[i]` is the unloaded range immediately before `entries[i]`;
+   * `gaps[entries.length]` is the range between the newest entry and the
+   * live tail. An empty object means contiguous.
+   */
+  private gaps: TranscriptGap[] = [{}];
+  private nextPageOrdinal = 1;
+
+  getEntries(): readonly TranscriptPageLedgerEntry[] {
+    return [...this.entries];
+  }
+
+  getGaps(): readonly TranscriptGap[] {
+    return this.gaps.map((gap) => ({ ...gap }));
+  }
+
+  getEntry(id: string): TranscriptPageLedgerEntry | undefined {
+    return this.entries.find((entry) => entry.id === id);
+  }
+
+  clear(): void {
+    this.entries = [];
+    this.gaps = [{}];
+  }
+
+  private createEntry(
+    input: TranscriptPageLedgerEntryInput,
+  ): TranscriptPageLedgerEntry {
+    const entry: TranscriptPageLedgerEntry = {
+      ...input,
+      id: `page-${this.nextPageOrdinal}`,
+    };
+    this.nextPageOrdinal += 1;
+    return entry;
+  }
+
+  recordInitialLoad(page: TranscriptPageLedgerEntryInput): void {
+    this.entries = [this.createEntry(page)];
+    this.gaps = [{}, {}];
+  }
+
+  /**
+   * A backward prepend butts exactly against the previous oldest entry;
+   * `remainingOlder` becomes the gap before the new oldest entry.
+   */
+  recordPrepend(
+    page: TranscriptPageLedgerEntryInput,
+    remainingOlder?: TranscriptGap,
+  ): void {
+    this.entries.unshift(this.createEntry(page));
+    this.gaps = [remainingOlder ?? {}, {}, ...this.gaps.slice(1)];
+  }
+
+  setOlderGap(gap?: TranscriptGap): void {
+    this.gaps[0] = gap ?? {};
+  }
+
+  /**
+   * Insert a page at a ledger position (anchored open, newer-direction
+   * continuation). `index` is the position in the oldest-first entries
+   * order; `gapBefore` describes the unresolved range above the new page.
+   * The gap the insertion displaces (the range between the old neighbors)
+   * becomes the gap after the new page — pass an explicit `gapAfter` only
+   * when the new page resolves it (a butted continuation), otherwise the
+   * displaced gap's locator is preserved.
+   */
+  insertEntry(
+    page: TranscriptPageLedgerEntryInput,
+    index: number,
+    gapBefore?: TranscriptGap,
+    gapAfter?: TranscriptGap,
+  ): TranscriptPageLedgerEntry {
+    const entry = this.createEntry(page);
+    this.entries.splice(index, 0, entry);
+    this.gaps.splice(index, 0, gapBefore ?? {});
+    if (gapAfter !== undefined) this.gaps[index + 1] = gapAfter;
+    return entry;
+  }
+
+  updateEntry(
+    id: string,
+    patch: Partial<TranscriptPageLedgerEntryInput>,
+  ): void {
+    const index = this.entries.findIndex((entry) => entry.id === id);
+    const current = this.entries[index];
+    if (current === undefined) return;
+    this.entries[index] = { ...current, ...patch };
+  }
+
+  /**
+   * Reconcile after the store's oldest-first trim. The truncation callback
+   * fires mid-reduce while `store.getSnapshot()` is still pre-trim, so the
+   * pre-trim state plus the detail's post-trim `blockCount` together
+   * identify the evicted prefix `[0, cut)`.
+   */
+  applyPrefixTrim(
+    preTrim: DaemonTranscriptState,
+    detail: {
+      blockCount?: number;
+      oldestRetainedRecordId?: string;
+    },
+  ): void {
+    if (this.entries.length === 0) return;
+    const postCount = detail.blockCount ?? preTrim.blocks.length;
+    const cut = preTrim.blocks.length - postCount;
+    if (cut <= 0) return;
+
+    let droppedAny = false;
+    let straddled = false;
+    const kept: Array<{
+      entry: TranscriptPageLedgerEntry;
+      gapBefore: TranscriptGap;
+    }> = [];
+    for (let index = 0; index < this.entries.length; index += 1) {
+      const entry = this.entries[index]!;
+      const firstIndex = preTrim.blockIndexById[entry.firstBlockId];
+      const lastIndex = preTrim.blockIndexById[entry.lastBlockId];
+      if (firstIndex === undefined || lastIndex === undefined) {
+        kept.push({ entry, gapBefore: this.gaps[index] ?? {} });
+        continue;
+      }
+      if (lastIndex < cut) {
+        droppedAny = true;
+        continue;
+      }
+      if (firstIndex < cut) {
+        straddled = true;
+        const retainedSlice = preTrim.blocks.slice(cut, lastIndex + 1);
+        const newFirst = retainedSlice[0];
+        if (newFirst === undefined) {
+          droppedAny = true;
+          continue;
+        }
+        kept.push({
+          entry: {
+            ...entry,
+            firstBlockId: newFirst.id,
+            firstRecordId:
+              detail.oldestRetainedRecordId ?? firstRecordIdOf(retainedSlice),
+            byteSize: byteSizeOf(retainedSlice),
+            nextCursor: undefined,
+          },
+          gapBefore: this.gaps[index] ?? {},
+        });
+        continue;
+      }
+      kept.push({ entry, gapBefore: this.gaps[index] ?? {} });
+    }
+    if (!droppedAny && !straddled) return;
+
+    // The evicted band collapses into the older gap: it stays persisted
+    // daemon-side and is re-fetchable from the oldest retained record.
+    // When no retained record carries an id the band is unreachable
+    // (mirroring the provider's fail-closed anchor drop), so the gap
+    // closes empty instead of offering an unresolvable locator.
+    const previousOlder = this.gaps[0]?.older;
+    const olderGap: TranscriptGap =
+      detail.oldestRetainedRecordId !== undefined
+        ? {
+            older: {
+              beforeRecordId: detail.oldestRetainedRecordId,
+              ...(previousOlder?.snapshot !== undefined
+                ? { snapshot: previousOlder.snapshot }
+                : {}),
+            },
+          }
+        : {};
+    this.entries = kept.map((item) => item.entry);
+    if (kept.length === 0) {
+      this.gaps = [olderGap];
+    } else {
+      // The gap after the newest entry (toward the live tail) is
+      // unaffected by a prefix trim and carries over.
+      const trailing = this.gaps[this.gaps.length - 1] ?? {};
+      this.gaps = [
+        olderGap,
+        ...kept.slice(1).map((item) => item.gapBefore),
+        trailing,
+      ];
+    }
+  }
+
+  /**
+   * Reconcile after a rewind, which drops the NEWEST blocks. Entries past
+   * the rewind point are dropped; a straddling newest entry is shrunk and
+   * loses its forward cursor (it points past rewound content).
+   */
+  applyRewind(
+    preRewind: DaemonTranscriptState,
+    detail: { blockCount?: number },
+  ): void {
+    if (this.entries.length === 0) return;
+    const postCount = detail.blockCount ?? preRewind.blocks.length;
+    if (postCount >= preRewind.blocks.length) return;
+
+    const kept: Array<{
+      entry: TranscriptPageLedgerEntry;
+      gapBefore: TranscriptGap;
+    }> = [];
+    let changed = false;
+    for (let index = 0; index < this.entries.length; index += 1) {
+      const entry = this.entries[index]!;
+      const firstIndex = preRewind.blockIndexById[entry.firstBlockId];
+      const lastIndex = preRewind.blockIndexById[entry.lastBlockId];
+      if (firstIndex === undefined || lastIndex === undefined) {
+        kept.push({ entry, gapBefore: this.gaps[index] ?? {} });
+        continue;
+      }
+      if (firstIndex >= postCount) {
+        changed = true;
+        continue;
+      }
+      if (lastIndex >= postCount) {
+        changed = true;
+        const retainedSlice = preRewind.blocks.slice(firstIndex, postCount);
+        const newLast = retainedSlice[retainedSlice.length - 1];
+        if (newLast === undefined) {
+          continue;
+        }
+        kept.push({
+          entry: {
+            ...entry,
+            lastBlockId: newLast.id,
+            lastRecordId: lastRecordIdOf(retainedSlice),
+            byteSize: byteSizeOf(retainedSlice),
+            nextCursor: undefined,
+          },
+          gapBefore: this.gaps[index] ?? {},
+        });
+        continue;
+      }
+      kept.push({ entry, gapBefore: this.gaps[index] ?? {} });
+    }
+    if (!changed) return;
+    this.entries = kept.map((item) => item.entry);
+    // Ranges beyond the rewind point no longer exist; gaps that pointed
+    // into them close empty rather than resolve into a rewritten chain.
+    this.gaps = [...kept.map((item) => item.gapBefore), {}];
+  }
+}

--- a/packages/web-shell/client/daemon/session/turnIndexStore.test.ts
+++ b/packages/web-shell/client/daemon/session/turnIndexStore.test.ts
@@ -1,0 +1,634 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DaemonHttpError,
+  type DaemonSessionTurnIndexEntry,
+  type DaemonSessionTurnIndexPage,
+  type DaemonTranscriptBlock,
+} from '@qwen-code/sdk/daemon';
+import {
+  SessionTurnIndexStore,
+  type TurnIndexPageFetcher,
+} from './turnIndexStore.js';
+
+function turn(
+  ordinal: number,
+  turnId = `turn-${ordinal}`,
+  promptId?: string,
+): DaemonSessionTurnIndexEntry {
+  return {
+    ordinal,
+    turnId,
+    kind: 'prompt',
+    ...(promptId !== undefined ? { promptId } : {}),
+    label: `label-${ordinal}`,
+  };
+}
+
+function page(input: {
+  start: number;
+  count: number;
+  snapshot?: string;
+  totalTurns?: number;
+  firstOrdinal?: number;
+  promptIds?: ReadonlyMap<number, string | undefined>;
+}): DaemonSessionTurnIndexPage {
+  const turns: DaemonSessionTurnIndexEntry[] = [];
+  for (let index = 0; index < input.count; index += 1) {
+    const ordinal = (input.firstOrdinal ?? input.start) + index;
+    const promptId = input.promptIds?.get(ordinal);
+    turns.push(turn(ordinal, `turn-${ordinal}`, promptId));
+  }
+  return {
+    v: 1,
+    sessionId: 'session-1',
+    snapshot: input.snapshot ?? 'snap-1',
+    totalTurns: input.totalTurns ?? input.start + input.count,
+    start: input.start,
+    turns,
+  };
+}
+
+function makeStore(input?: {
+  fetchPage?: TurnIndexPageFetcher;
+  enabled?: boolean;
+  pageSize?: number;
+  maxPages?: number;
+  maxPageBytes?: number;
+  scheduled?: Array<{ fn: () => void; delayMs: number }>;
+}) {
+  const fetchPage =
+    input?.fetchPage ?? vi.fn<TurnIndexPageFetcher>(() => Promise.reject());
+  const scheduled = input?.scheduled ?? [];
+  const store = new SessionTurnIndexStore({
+    sessionId: 'session-1',
+    fetchPage,
+    enabled: input?.enabled,
+    pageSize: input?.pageSize,
+    maxPages: input?.maxPages,
+    maxPageBytes: input?.maxPageBytes,
+    scheduleRetry: (fn, delayMs) => scheduled.push({ fn, delayMs }),
+  });
+  return { store, fetchPage, scheduled };
+}
+
+function seedPageOf(count: number, total = count) {
+  return page({ start: Math.max(0, total - count), count, totalTurns: total });
+}
+
+async function seededStore(
+  input?: Parameters<typeof makeStore>[0] & {
+    seedCount?: number;
+    total?: number;
+  },
+) {
+  const harness = makeStore({
+    ...input,
+    fetchPage: input?.fetchPage,
+  });
+  if (input?.fetchPage === undefined) {
+    (harness.fetchPage as ReturnType<typeof vi.fn>).mockResolvedValue(
+      seedPageOf(input?.seedCount ?? 3, input?.total ?? 3),
+    );
+  }
+  await harness.store.seed();
+  return harness;
+}
+
+describe('SessionTurnIndexStore', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('capability gate', () => {
+    it('latches disabled when the capability is absent', async () => {
+      const { store, fetchPage } = makeStore({ enabled: false });
+      await store.seed();
+      expect(store.getState().status).toBe('disabled');
+      expect(fetchPage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('seed', () => {
+    it('loads the newest page first and adopts snapshot/totalTurns', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValue(
+          page({ start: 8, count: 2, totalTurns: 10, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      expect(fetchPage).toHaveBeenCalledWith({ limit: 200 });
+      const state = store.getState();
+      expect(state.status).toBe('ready');
+      expect(state.snapshot).toBe('snap-a');
+      expect(state.totalTurns).toBe(10);
+      expect([...state.pages.keys()]).toEqual([8]);
+    });
+
+    it('latches unsupported on 413 transcript_too_large', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockRejectedValue(
+          new DaemonHttpError(413, { code: 'transcript_too_large' }, 'big'),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      expect(store.getState().status).toBe('unsupported');
+      // Latched for the session: later seeds/refresh are no-ops.
+      await store.seed();
+      await store.refreshTail();
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+    });
+
+    it('enters error and retries bounded on transient failure', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockRejectedValue(new Error('boom'));
+      const { store, scheduled } = makeStore({ fetchPage });
+      await store.seed();
+      expect(store.getState().status).toBe('error');
+      expect(scheduled).toHaveLength(1);
+      // Retry keeps failing: attempts are bounded.
+      for (let index = 0; index < 5; index += 1) {
+        const task = scheduled.shift();
+        if (task === undefined) break;
+        await task.fn();
+        await Promise.resolve();
+      }
+      expect(fetchPage).toHaveBeenCalledTimes(4); // initial + 3 retries
+      expect(scheduled).toHaveLength(0);
+      expect(store.getState().status).toBe('error');
+    });
+  });
+
+  describe('older pages', () => {
+    it('requests start=max(0,boundary-limit) with a clamped, butted limit', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 5, count: 5, totalTurns: 10, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 2, count: 3, totalTurns: 10, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 3 });
+      await store.seed();
+      await store.loadOlder();
+      // boundary=5, pageSize=3 → start=2, limit=3 (butts against 5).
+      expect(fetchPage).toHaveBeenNthCalledWith(2, {
+        snapshot: 'snap-a',
+        start: 2,
+        limit: 3,
+      });
+      expect([...store.getState().pages.keys()].sort((a, b) => a - b)).toEqual([
+        2, 5,
+      ]);
+    });
+
+    it('sends no request when boundary == 0', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValue(page({ start: 0, count: 2, totalTurns: 2 }));
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      await store.loadOlder();
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+    });
+
+    it('clamps the older request to ordinal 0 with a shrunk limit', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 2, count: 3, totalTurns: 10, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 10, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 5 });
+      await store.seed();
+      await store.loadOlder();
+      // boundary=2, pageSize=5 → start=0, limit=2 (never 0/negative).
+      expect(fetchPage).toHaveBeenNthCalledWith(2, {
+        snapshot: 'snap-a',
+        start: 0,
+        limit: 2,
+      });
+    });
+  });
+
+  describe('ensurePage', () => {
+    it('is a no-op when the ordinal is already covered', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValue(page({ start: 0, count: 3, totalTurns: 3 }));
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      await store.ensurePage(1);
+      expect(fetchPage).toHaveBeenCalledTimes(1);
+    });
+
+    it('requests the largest non-overlapping slice of the uncovered interval', async () => {
+      // Retained: [8,9]; then loadOlder admits [4..7]; ensurePage(1) must
+      // fetch the remaining uncovered interval [0..3] in one slice.
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 8, count: 2, totalTurns: 10, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 4, count: 4, totalTurns: 10, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 4, totalTurns: 10, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 4 });
+      await store.seed();
+      await store.loadOlder();
+      await store.ensurePage(1);
+      // loadOlder: boundary=8, pageSize 4 → start=4, limit=4.
+      expect(fetchPage).toHaveBeenNthCalledWith(2, {
+        snapshot: 'snap-a',
+        start: 4,
+        limit: 4,
+      });
+      // ensurePage(1): uncovered interval [0..3], pageSize 4 → start=0, limit=4.
+      expect(fetchPage).toHaveBeenNthCalledWith(3, {
+        snapshot: 'snap-a',
+        start: 0,
+        limit: 4,
+      });
+    });
+
+    it('re-seeds when the response snapshot does not match the request', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 5, count: 5, totalTurns: 10, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 2, count: 3, totalTurns: 10, snapshot: 'snap-b' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 6, count: 4, totalTurns: 10, snapshot: 'snap-c' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 3 });
+      await store.seed();
+      await store.loadOlder();
+      // Mismatched snapshot → invalidate and re-seed from a fresh tail request.
+      expect(fetchPage).toHaveBeenNthCalledWith(3, { limit: 3 });
+      const state = store.getState();
+      expect(state.snapshot).toBe('snap-c');
+      expect([...state.pages.keys()]).toEqual([6]);
+    });
+  });
+
+  describe('tail refresh (two-step merge)', () => {
+    it('skips the fill when no new navigation turn arrived, adopting the new snapshot', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 3, totalTurns: 3, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 3, totalTurns: 3, snapshot: 'snap-b' }),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      const pagesBefore = store.getState().pages;
+      await store.refreshTail();
+      // Validation response never admitted: retained pages are untouched.
+      expect(store.getState().pages).toBe(pagesBefore);
+      expect(store.getState().snapshot).toBe('snap-b');
+      expect(fetchPage).toHaveBeenCalledTimes(2);
+    });
+
+    it('lands a clamped fill on the grid for an append-only tail', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 3, totalTurns: 3, snapshot: 'snap-a' }),
+        )
+        // validation: newest window [2..4] under snap-b, total 5
+        .mockResolvedValueOnce(
+          page({ start: 2, count: 3, totalTurns: 5, snapshot: 'snap-b' }),
+        )
+        // fill: start = largestCovered+1 = 3, limit = 5-3 = 2
+        .mockResolvedValueOnce(
+          page({ start: 3, count: 2, totalTurns: 5, snapshot: 'snap-b' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 3 });
+      await store.seed();
+      await store.refreshTail();
+      expect(fetchPage).toHaveBeenNthCalledWith(3, {
+        snapshot: 'snap-b',
+        start: 3,
+        limit: 2,
+      });
+      const state = store.getState();
+      expect(state.snapshot).toBe('snap-b');
+      expect(state.totalTurns).toBe(5);
+      expect([...state.pages.keys()].sort((a, b) => a - b)).toEqual([0, 3]);
+      // Ordinals 2 appears in both the old page and the validation response;
+      // the fill starts at 3, so no overlap is admitted.
+      const ordinals = [...state.pages.values()].flatMap((p) =>
+        p.turns.map((t) => t.ordinal),
+      );
+      expect(ordinals).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('chunks the fill when the uncovered tail exceeds one page', async () => {
+      // The validation window overlaps retained coverage ({0,1}) but the
+      // uncovered tail (ordinals 2..4) exceeds the page size of 2, so the
+      // fill iterates in page-sized chunks.
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 5, snapshot: 'snap-b' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 2, count: 2, totalTurns: 5, snapshot: 'snap-b' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 4, count: 1, totalTurns: 5, snapshot: 'snap-b' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 2 });
+      await store.seed();
+      await store.refreshTail();
+      // largestCovered=1, totalTurns-1=4 → fill start=2 limit=2, then start=4 limit=1.
+      expect(fetchPage).toHaveBeenNthCalledWith(3, {
+        snapshot: 'snap-b',
+        start: 2,
+        limit: 2,
+      });
+      expect(fetchPage).toHaveBeenNthCalledWith(4, {
+        snapshot: 'snap-b',
+        start: 4,
+        limit: 1,
+      });
+      expect(store.getState().totalTurns).toBe(5);
+      expect([...store.getState().pages.keys()].sort((a, b) => a - b)).toEqual([
+        0, 2, 4,
+      ]);
+    });
+
+    it('treats a shrunk chain (largest covered > totalTurns-1) as divergent', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 5, totalTurns: 5, snapshot: 'snap-a' }),
+        )
+        // Another client rewound: chain now has 2 turns.
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-b' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 5 });
+      await store.seed();
+      await store.refreshTail();
+      const state = store.getState();
+      expect(state.snapshot).toBe('snap-b');
+      expect(state.totalTurns).toBe(2);
+      expect([...state.pages.keys()]).toEqual([0]);
+      expect(state.pages.get(0)?.turns).toHaveLength(2);
+    });
+
+    it('treats a turnId mismatch on overlapping ordinals as divergent', async () => {
+      const mismatching = page({
+        start: 0,
+        count: 3,
+        totalTurns: 3,
+        snapshot: 'snap-b',
+      });
+      mismatching.turns[1]!.turnId = 'rewritten';
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 3, totalTurns: 3, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(mismatching);
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      await store.refreshTail();
+      const state = store.getState();
+      expect(state.snapshot).toBe('snap-b');
+      expect(state.pages.get(0)?.turns[1]?.turnId).toBe('rewritten');
+    });
+
+    it('treats zero overlap as divergent and resets to the validation page', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 8, count: 2, totalTurns: 10, snapshot: 'snap-b' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 2 });
+      await store.seed();
+      await store.refreshTail();
+      const state = store.getState();
+      expect([...state.pages.keys()]).toEqual([8]);
+      expect(state.snapshot).toBe('snap-b');
+      expect(state.totalTurns).toBe(10);
+    });
+
+    it('re-seeds on 409 transcript_snapshot_unavailable', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-a' }),
+        )
+        .mockRejectedValueOnce(
+          new DaemonHttpError(
+            409,
+            { code: 'transcript_snapshot_unavailable' },
+            'gone',
+          ),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-c' }),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      await store.refreshTail();
+      // The recovery is a fresh tail request without a snapshot.
+      expect(fetchPage).toHaveBeenNthCalledWith(3, { limit: 200 });
+      expect(store.getState().snapshot).toBe('snap-c');
+      expect(store.getState().status).toBe('ready');
+    });
+  });
+
+  describe('LRU eviction', () => {
+    it('bounds the page map, keeps totalTurns, and pins the newest page', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 6, count: 2, totalTurns: 8, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 2, maxPages: 2 });
+      await store.seed();
+      // Admit older pages [4..5], [2..3], [0..1] — exceeds maxPages=2.
+      for (const start of [4, 2, 0]) {
+        fetchPage.mockResolvedValueOnce(
+          page({ start, count: 2, totalTurns: 8, snapshot: 'snap-a' }),
+        );
+        await store.loadOlder();
+      }
+      const state = store.getState();
+      const starts = [...state.pages.keys()].sort((a, b) => a - b);
+      expect(starts.length).toBeLessThanOrEqual(2);
+      // The newest page (start 6) is pinned for refresh validation.
+      expect(starts).toContain(6);
+      // Evicting metadata never changes totalTurns.
+      expect(state.totalTurns).toBe(8);
+    });
+  });
+
+  describe('reconciliation', () => {
+    it('removes a live prompt provisional when its promptId appears in the index', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({
+            start: 1,
+            count: 2,
+            totalTurns: 3,
+            snapshot: 'snap-b',
+            promptIds: new Map([[2, 'prompt-x']]),
+          }),
+        )
+        .mockResolvedValueOnce(
+          page({
+            start: 2,
+            count: 1,
+            totalTurns: 3,
+            snapshot: 'snap-b',
+            promptIds: new Map([[2, 'prompt-x']]),
+          }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 2 });
+      await store.seed();
+      store.addLivePrompt({ promptId: 'prompt-x', label: 'hello' });
+      expect(store.getState().liveEntries).toHaveLength(1);
+      await store.refreshTail();
+      expect(store.getState().liveEntries).toHaveLength(0);
+    });
+
+    it('reconciles a legacy no-prompt-id provisional by record UUID', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      store.addLivePrompt({ promptId: 'prompt-legacy', label: 'legacy' });
+      // The persisted echo lands without a promptId match in the index but
+      // the block links the provisional to record turn-1's UUID.
+      const echoBlock = {
+        id: 'b-1',
+        promptId: 'prompt-legacy',
+        sourceRecordIds: ['turn-1'],
+      } as DaemonTranscriptBlock;
+      store.observeAdmittedBlocks([echoBlock]);
+      expect(store.getState().liveEntries).toHaveLength(0);
+    });
+
+    it('never reconciles by label or timestamp', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      // The index entry label is "label-0"/"label-1"; a provisional with the
+      // same label but an unmatched promptId must persist.
+      store.addLivePrompt({ promptId: 'prompt-y', label: 'label-0' });
+      await store.refreshTail();
+      expect(store.getState().liveEntries).toHaveLength(1);
+    });
+
+    it('keeps unmatched provisionals across refreshes', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValue(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-a' }),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      store.addLivePrompt({ promptId: 'prompt-z', label: 'pending' });
+      await store.refreshTail();
+      expect(store.getState().liveEntries).toHaveLength(1);
+    });
+
+    it('manages shell overlays as live-only entries', async () => {
+      const { store } = await seededStore();
+      store.addLiveShell({ blockId: 'blk-1', label: 'ls -la' });
+      expect(store.getState().liveEntries).toEqual([
+        { id: 'shell:blk-1', kind: 'shell', label: 'ls -la' },
+      ]);
+      // Shell overlays never affect totalTurns.
+      expect(store.getState().totalTurns).toBe(3);
+      store.removeLiveShell('blk-1');
+      expect(store.getState().liveEntries).toHaveLength(0);
+    });
+  });
+
+  describe('rewind', () => {
+    it('clears pages and provisionals, then re-seeds', async () => {
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValue(
+          page({ start: 0, count: 2, totalTurns: 2, snapshot: 'snap-r' }),
+        );
+      const { store } = makeStore({ fetchPage });
+      await store.seed();
+      store.addLivePrompt({ promptId: 'prompt-w', label: 'gone' });
+      await store.handleRewind();
+      const state = store.getState();
+      expect(state.liveEntries).toHaveLength(0);
+      expect(state.snapshot).toBe('snap-r');
+      // Seed + reseed = two tail requests.
+      expect(fetchPage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('findTurn', () => {
+    it('returns the entry with its own page snapshot', async () => {
+      // Pages minted by different snapshots legitimately coexist after an
+      // append-only refresh: the seed page keeps snap-a, the fill page
+      // carries snap-b.
+      const fetchPage = vi
+        .fn<TurnIndexPageFetcher>()
+        .mockResolvedValueOnce(
+          page({ start: 4, count: 2, totalTurns: 6, snapshot: 'snap-a' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 5, count: 2, totalTurns: 7, snapshot: 'snap-b' }),
+        )
+        .mockResolvedValueOnce(
+          page({ start: 6, count: 1, totalTurns: 7, snapshot: 'snap-b' }),
+        );
+      const { store } = makeStore({ fetchPage, pageSize: 2 });
+      await store.seed();
+      await store.refreshTail();
+      expect(store.findTurn('turn-4')).toEqual({
+        entry: expect.objectContaining({ ordinal: 4 }),
+        snapshot: 'snap-a',
+      });
+      expect(store.findTurn('turn-6')?.snapshot).toBe('snap-b');
+      expect(store.findTurn('missing')).toBeUndefined();
+    });
+
+    it('exposes known turn ids for the locator map', async () => {
+      const { store } = await seededStore({ seedCount: 2, total: 4 });
+      expect([...store.getKnownTurnIds()].sort()).toEqual(['turn-2', 'turn-3']);
+    });
+  });
+});

--- a/packages/web-shell/client/daemon/session/turnIndexStore.ts
+++ b/packages/web-shell/client/daemon/session/turnIndexStore.ts
@@ -1,0 +1,640 @@
+import {
+  DaemonHttpError,
+  type DaemonSessionTurnIndexEntry,
+  type DaemonSessionTurnIndexPage,
+  type DaemonTranscriptBlock,
+} from '@qwen-code/sdk/daemon';
+import { isRecord } from './httpErrors.js';
+
+/**
+ * Client-side session-wide turn-index store for Web Shell turn navigation.
+ * Loads the newest metadata page first and pages older metadata
+ * independently of transcript blocks. See
+ * `docs/design/web-shell/web-shell-global-turn-navigation-phase2.md`.
+ */
+export type SessionTurnIndexStatus =
+  | 'disabled'
+  | 'idle'
+  | 'loading'
+  | 'ready'
+  | 'error'
+  | 'unsupported';
+
+export type LiveTurnEntry =
+  | { id: `live:${string}`; kind: 'prompt'; promptId: string; label: string }
+  | { id: `shell:${string}`; kind: 'shell'; label: string };
+
+export interface TurnIndexPageCacheEntry {
+  /** The snapshot that minted this page — the read authority for it. */
+  snapshot: string;
+  turns: readonly DaemonSessionTurnIndexEntry[];
+}
+
+export interface SessionTurnIndexState {
+  sessionId: string;
+  status: SessionTurnIndexStatus;
+  /** Newest snapshot; authority for seed/older-page requests only. */
+  snapshot?: string;
+  totalTurns: number;
+  /** Key = page start ordinal. Pages never overlap in stable state. */
+  pages: ReadonlyMap<number, TurnIndexPageCacheEntry>;
+  /** Tail-only provisional entries not yet persisted. */
+  liveEntries: readonly LiveTurnEntry[];
+}
+
+export type TurnIndexPageFetcher = (opts: {
+  snapshot?: string;
+  start?: number;
+  limit?: number;
+}) => Promise<DaemonSessionTurnIndexPage>;
+
+export interface SessionTurnIndexStoreOptions {
+  sessionId: string;
+  fetchPage: TurnIndexPageFetcher;
+  /** Capability gate: false latches `disabled` and turns fetches into no-ops. */
+  enabled?: boolean;
+  pageSize?: number;
+  /** LRU bounds over the page map; the newest page is pinned. */
+  maxPages?: number;
+  maxPageBytes?: number;
+  /** Injectable retry scheduler; defaults to setTimeout. */
+  scheduleRetry?: (fn: () => void, delayMs: number) => void;
+}
+
+const DEFAULT_PAGE_SIZE = 200;
+const DEFAULT_MAX_PAGES = 8;
+const DEFAULT_MAX_PAGE_BYTES = 2 * 1024 * 1024;
+const MAX_RETRY_ATTEMPTS = 3;
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
+
+interface RetainedPage extends TurnIndexPageCacheEntry {
+  lastUsed: number;
+  bytes: number;
+}
+
+function estimatePageBytes(
+  turns: readonly DaemonSessionTurnIndexEntry[],
+): number {
+  let total = 0;
+  for (const turn of turns) {
+    total +=
+      turn.turnId.length +
+      turn.label.length +
+      (turn.promptId?.length ?? 0) +
+      (turn.detail?.length ?? 0) +
+      16;
+  }
+  return total;
+}
+
+function daemonErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof DaemonHttpError) || !isRecord(error.body)) {
+    return undefined;
+  }
+  const code = error.body['code'];
+  return typeof code === 'string' ? code : undefined;
+}
+
+export class SessionTurnIndexStore {
+  private readonly sessionId: string;
+  private readonly fetchPage: TurnIndexPageFetcher;
+  private readonly enabled: boolean;
+  private readonly pageSize: number;
+  private readonly maxPages: number;
+  private readonly maxPageBytes: number;
+  private readonly scheduleRetry: (fn: () => void, delayMs: number) => void;
+
+  private status: SessionTurnIndexStatus;
+  private snapshot: string | undefined;
+  private totalTurns = 0;
+  private pages = new Map<number, RetainedPage>();
+  private liveEntries: LiveTurnEntry[] = [];
+  /** prompt provisional id → persisted record ids observed on its echo block. */
+  private readonly linkedRecordIds = new Map<string, readonly string[]>();
+
+  private lruClock = 0;
+  private generation = 0;
+  private retryAttempts = 0;
+  private seeding: Promise<void> | undefined;
+  private tailRefresh: Promise<void> | undefined;
+  private readonly inFlightPages = new Map<number, Promise<void>>();
+  private readonly listeners = new Set<() => void>();
+  private stateCache: SessionTurnIndexState | undefined;
+
+  constructor(options: SessionTurnIndexStoreOptions) {
+    this.sessionId = options.sessionId;
+    this.fetchPage = options.fetchPage;
+    this.enabled = options.enabled !== false;
+    this.pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+    this.maxPages = options.maxPages ?? DEFAULT_MAX_PAGES;
+    this.maxPageBytes = options.maxPageBytes ?? DEFAULT_MAX_PAGE_BYTES;
+    this.scheduleRetry =
+      options.scheduleRetry ?? ((fn, delayMs) => setTimeout(fn, delayMs));
+    this.status = this.enabled ? 'idle' : 'disabled';
+  }
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  getState = (): SessionTurnIndexState => {
+    if (this.stateCache === undefined) {
+      this.stateCache = {
+        sessionId: this.sessionId,
+        status: this.status,
+        snapshot: this.snapshot,
+        totalTurns: this.totalTurns,
+        pages: this.pages,
+        liveEntries: this.liveEntries,
+      };
+    }
+    return this.stateCache;
+  };
+
+  private notify(): void {
+    this.stateCache = undefined;
+    for (const listener of this.listeners) listener();
+  }
+
+  dispose(): void {
+    this.generation += 1;
+    this.listeners.clear();
+  }
+
+  /** Persisted turn ids across retained pages; keys the locator map. */
+  getKnownTurnIds(): ReadonlySet<string> {
+    const known = new Set<string>();
+    for (const page of this.pages.values()) {
+      for (const turn of page.turns) known.add(turn.turnId);
+    }
+    return known;
+  }
+
+  /**
+   * Locate a persisted turn for anchored reads. The returned snapshot is
+   * the entry's OWN page snapshot — the protocol's read authority for
+   * anchored transcript fetches at that entry.
+   */
+  findTurn(
+    turnId: string,
+  ): { entry: DaemonSessionTurnIndexEntry; snapshot: string } | undefined {
+    for (const page of this.pages.values()) {
+      const entry = page.turns.find((turn) => turn.turnId === turnId);
+      if (entry !== undefined) {
+        return { entry, snapshot: page.snapshot };
+      }
+    }
+    return undefined;
+  }
+
+  private coveredIntervals(): Array<[number, number]> {
+    const intervals: Array<[number, number]> = [];
+    for (const [start, page] of this.pages) {
+      if (page.turns.length > 0) {
+        intervals.push([start, start + page.turns.length - 1]);
+      }
+    }
+    intervals.sort((a, b) => a[0] - b[0]);
+    return intervals;
+  }
+
+  private isCovered(ordinal: number): boolean {
+    for (const [start, page] of this.pages) {
+      if (ordinal >= start && ordinal < start + page.turns.length) {
+        page.lastUsed = ++this.lruClock;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Smallest covered ordinal, or undefined when no page is retained. */
+  private boundary(): number | undefined {
+    let min: number | undefined;
+    for (const [start, page] of this.pages) {
+      if (page.turns.length === 0) continue;
+      if (min === undefined || start < min) min = start;
+    }
+    return min;
+  }
+
+  async seed(): Promise<void> {
+    if (!this.enabled || this.status === 'unsupported') return;
+    if (this.seeding !== undefined) return this.seeding;
+    const generation = this.generation;
+    this.seeding = (async () => {
+      this.status = 'loading';
+      this.notify();
+      try {
+        const page = await this.fetchPage({ limit: this.pageSize });
+        if (generation !== this.generation) return;
+        this.pages = new Map([[page.start, this.retain(page)]]);
+        this.snapshot = page.snapshot;
+        this.totalTurns = page.totalTurns;
+        this.status = 'ready';
+        this.retryAttempts = 0;
+        this.afterAdmission();
+      } catch (error) {
+        if (generation !== this.generation) return;
+        this.handleFetchError(error, () => this.invalidateAndReseed());
+      } finally {
+        if (generation === this.generation) this.seeding = undefined;
+      }
+    })();
+    return this.seeding;
+  }
+
+  /** Re-seed from a fresh tail request after snapshot invalidation. */
+  async invalidateAndReseed(): Promise<void> {
+    this.pages = new Map();
+    this.snapshot = undefined;
+    this.totalTurns = 0;
+    this.generation += 1;
+    this.seeding = undefined;
+    this.tailRefresh = undefined;
+    this.inFlightPages.clear();
+    await this.seed();
+  }
+
+  /** Latch `unsupported` (indexing-ceiling exceeded) for the session. */
+  markUnsupported(): void {
+    if (this.status === 'unsupported') return;
+    this.status = 'unsupported';
+    this.pages = new Map();
+    this.snapshot = undefined;
+    // Drop in-flight responses too: nothing may be admitted after the latch.
+    this.generation += 1;
+    this.seeding = undefined;
+    this.tailRefresh = undefined;
+    this.inFlightPages.clear();
+    this.notify();
+  }
+
+  /**
+   * Ensure the page covering `ordinal` is retained. No-op when already
+   * covered; otherwise requests the largest non-overlapping slice of the
+   * uncovered interval containing the ordinal.
+   */
+  async ensurePage(ordinal: number): Promise<void> {
+    if (!this.enabled || this.status === 'unsupported') return;
+    if (this.snapshot === undefined) return;
+    if (ordinal < 0 || ordinal >= this.totalTurns) return;
+    if (this.isCovered(ordinal)) return;
+    const intervals = this.coveredIntervals();
+    let lo = 0;
+    let hi = this.totalTurns - 1;
+    for (const [start, end] of intervals) {
+      if (ordinal < start) {
+        hi = start - 1;
+        break;
+      }
+      lo = end + 1;
+    }
+    if (lo > hi) return;
+    const start = Math.max(lo, Math.min(ordinal, hi - this.pageSize + 1));
+    const limit = Math.min(this.pageSize, hi - start + 1);
+    if (limit < 1) return;
+    await this.fetchOlderSlice(start, limit);
+  }
+
+  /**
+   * Fetch the metadata page immediately older than the retained coverage.
+   * `boundary == 0` means the oldest turn is already retained — the
+   * clamped limit would be 0 (a 400), so no request is sent.
+   */
+  async loadOlder(): Promise<void> {
+    if (!this.enabled || this.status === 'unsupported') return;
+    if (this.snapshot === undefined) return;
+    const boundary = this.boundary();
+    if (boundary === undefined || boundary === 0) return;
+    const start = Math.max(0, boundary - this.pageSize);
+    await this.fetchOlderSlice(start, boundary - start);
+  }
+
+  private async fetchOlderSlice(start: number, limit: number): Promise<void> {
+    const snapshot = this.snapshot;
+    if (snapshot === undefined) return;
+    const inFlight = this.inFlightPages.get(start);
+    if (inFlight !== undefined) return inFlight;
+    const generation = this.generation;
+    const request = (async () => {
+      try {
+        const page = await this.fetchPage({ snapshot, start, limit });
+        if (generation !== this.generation) return;
+        // Admission-time snapshot rule: a page returned for a
+        // store-snapshot request must carry that same snapshot.
+        if (page.snapshot !== snapshot) {
+          await this.invalidateAndReseed();
+          return;
+        }
+        const next = new Map(this.pages);
+        next.set(page.start, this.retain(page));
+        this.pages = next;
+        this.afterAdmission();
+      } catch (error) {
+        if (generation !== this.generation) return;
+        this.handleFetchError(error, () => this.fetchOlderSlice(start, limit));
+      } finally {
+        if (generation === this.generation) {
+          this.inFlightPages.delete(start);
+        }
+      }
+    })();
+    this.inFlightPages.set(start, request);
+    return request;
+  }
+
+  /**
+   * Two-step tail merge on prompt terminal. The validation fetch omits the
+   * snapshot by design, so it always covers the server-computed newest
+   * window and is never admitted itself (it overlaps retained coverage by
+   * construction); only the clamped fill pages land on the grid.
+   */
+  async refreshTail(): Promise<void> {
+    if (!this.enabled || this.status === 'unsupported') return;
+    if (this.snapshot === undefined) return this.seed();
+    if (this.tailRefresh !== undefined) return this.tailRefresh;
+    const generation = this.generation;
+    this.tailRefresh = (async () => {
+      try {
+        const validation = await this.fetchPage({ limit: this.pageSize });
+        if (generation !== this.generation) return;
+        const retainedByOrdinal = new Map<number, string>();
+        for (const page of this.pages.values()) {
+          for (const turn of page.turns) {
+            retainedByOrdinal.set(turn.ordinal, turn.turnId);
+          }
+        }
+        let overlap = 0;
+        let mismatch = false;
+        for (const turn of validation.turns) {
+          const known = retainedByOrdinal.get(turn.ordinal);
+          if (known === undefined) continue;
+          overlap += 1;
+          if (known !== turn.turnId) {
+            mismatch = true;
+            break;
+          }
+        }
+        let largestCovered = -1;
+        for (const ordinal of retainedByOrdinal.keys()) {
+          if (ordinal > largestCovered) largestCovered = ordinal;
+        }
+        const divergent =
+          mismatch ||
+          overlap === 0 ||
+          // The store holds ordinals the chain no longer has (a rewind or
+          // truncation this client has not processed yet).
+          largestCovered > validation.totalTurns - 1;
+        if (divergent) {
+          // Deliberately conservative: drop every snapshot-bound page and
+          // admit the validation response as the new tail page.
+          this.pages = new Map([[validation.start, this.retain(validation)]]);
+          this.snapshot = validation.snapshot;
+          this.totalTurns = validation.totalTurns;
+          this.retryAttempts = 0;
+          this.afterAdmission();
+          return;
+        }
+        if (largestCovered === validation.totalTurns - 1) {
+          // No new navigation turn — adopt the fresh snapshot/total only.
+          this.snapshot = validation.snapshot;
+          this.totalTurns = validation.totalTurns;
+          this.retryAttempts = 0;
+          this.afterAdmission();
+          return;
+        }
+        // Append-only with new turns: clamped fill against the new
+        // snapshot, chunked when the uncovered tail exceeds one page.
+        const newSnapshot = validation.snapshot;
+        let start = largestCovered + 1;
+        while (start <= validation.totalTurns - 1) {
+          const limit = Math.min(this.pageSize, validation.totalTurns - start);
+          const fill = await this.fetchPage({
+            snapshot: newSnapshot,
+            start,
+            limit,
+          });
+          if (generation !== this.generation) return;
+          if (fill.snapshot !== newSnapshot || fill.turns.length === 0) {
+            await this.invalidateAndReseed();
+            return;
+          }
+          const next = new Map(this.pages);
+          next.set(fill.start, this.retain(fill));
+          this.pages = next;
+          start = fill.start + fill.turns.length;
+        }
+        this.snapshot = newSnapshot;
+        this.totalTurns = validation.totalTurns;
+        this.retryAttempts = 0;
+        this.afterAdmission();
+      } catch (error) {
+        if (generation !== this.generation) return;
+        this.handleFetchError(error, () => {
+          this.tailRefresh = undefined;
+          return this.refreshTail();
+        });
+      } finally {
+        if (generation === this.generation) this.tailRefresh = undefined;
+      }
+    })();
+    return this.tailRefresh;
+  }
+
+  private retain(page: DaemonSessionTurnIndexPage): RetainedPage {
+    return {
+      snapshot: page.snapshot,
+      turns: page.turns,
+      lastUsed: ++this.lruClock,
+      bytes: estimatePageBytes(page.turns),
+    };
+  }
+
+  private afterAdmission(): void {
+    this.reconcileLiveEntries();
+    this.evictLru();
+    this.notify();
+  }
+
+  /** LRU eviction; the newest page is pinned so tail refreshes keep overlap. */
+  private evictLru(): void {
+    let totalBytes = 0;
+    let newestStart = -1;
+    for (const [start, page] of this.pages) {
+      totalBytes += page.bytes;
+      if (start > newestStart) newestStart = start;
+    }
+    const next = new Map(this.pages);
+    while (next.size > 1) {
+      const overCount = next.size > this.maxPages;
+      const overBytes = totalBytes > this.maxPageBytes;
+      if (!overCount && !overBytes) break;
+      let victimStart: number | undefined;
+      let victimUsed = Infinity;
+      for (const [start, page] of next) {
+        if (start === newestStart) continue;
+        if (page.lastUsed < victimUsed) {
+          victimUsed = page.lastUsed;
+          victimStart = start;
+        }
+      }
+      if (victimStart === undefined) break;
+      totalBytes -= next.get(victimStart)?.bytes ?? 0;
+      next.delete(victimStart);
+    }
+    // Keep map identity stable when nothing was evicted: refresh paths
+    // that admitted nothing must leave retained pages untouched.
+    if (next.size !== this.pages.size) this.pages = next;
+  }
+
+  /**
+   * A `live:` prompt provisional is removed exactly when an index entry
+   * appears with the same `promptId`, or (legacy records without a prompt
+   * id) when its persisted record UUID — linked from the admitted echo
+   * block — appears as an index turn. Label/timestamp matching is
+   * forbidden by design.
+   */
+  private reconcileLiveEntries(): void {
+    if (!this.liveEntries.some((entry) => entry.kind === 'prompt')) return;
+    const promptIds = new Set<string>();
+    const turnIds = new Set<string>();
+    for (const page of this.pages.values()) {
+      for (const turn of page.turns) {
+        turnIds.add(turn.turnId);
+        if (turn.promptId !== undefined) promptIds.add(turn.promptId);
+      }
+    }
+    const kept: LiveTurnEntry[] = [];
+    let changed = false;
+    for (const entry of this.liveEntries) {
+      if (entry.kind !== 'prompt') {
+        kept.push(entry);
+        continue;
+      }
+      if (promptIds.has(entry.promptId)) {
+        this.linkedRecordIds.delete(entry.id);
+        changed = true;
+        continue;
+      }
+      const linked = this.linkedRecordIds.get(entry.id);
+      if (linked !== undefined && linked.some((id) => turnIds.has(id))) {
+        this.linkedRecordIds.delete(entry.id);
+        changed = true;
+        continue;
+      }
+      kept.push(entry);
+    }
+    if (changed) this.liveEntries = kept;
+  }
+
+  addLivePrompt(input: { promptId: string; label: string }): void {
+    if (!this.enabled || this.status === 'unsupported') return;
+    if (
+      this.liveEntries.some(
+        (entry) => entry.kind === 'prompt' && entry.promptId === input.promptId,
+      )
+    ) {
+      return;
+    }
+    this.liveEntries = [
+      ...this.liveEntries,
+      {
+        id: `live:${input.promptId}`,
+        kind: 'prompt',
+        promptId: input.promptId,
+        label: input.label,
+      },
+    ];
+    this.notify();
+  }
+
+  addLiveShell(input: { blockId: string; label: string }): void {
+    if (!this.enabled || this.status === 'unsupported') return;
+    const id = `shell:${input.blockId}` as const;
+    if (this.liveEntries.some((entry) => entry.id === id)) return;
+    this.liveEntries = [
+      ...this.liveEntries,
+      { id, kind: 'shell', label: input.label },
+    ];
+    this.notify();
+  }
+
+  /** `shell:` overlays are live-only; removed when their live block is evicted. */
+  removeLiveShell(blockId: string): void {
+    const id = `shell:${blockId}`;
+    if (!this.liveEntries.some((entry) => entry.id === id)) return;
+    this.liveEntries = this.liveEntries.filter((entry) => entry.id !== id);
+    this.notify();
+  }
+
+  /**
+   * Link prompt provisionals to their persisted record UUID once the
+   * persisted echo lands in admitted blocks (the legacy no-prompt-id
+   * reconciliation path), then reconcile against the index.
+   */
+  observeAdmittedBlocks(blocks: readonly DaemonTranscriptBlock[]): void {
+    if (!this.liveEntries.some((entry) => entry.kind === 'prompt')) return;
+    for (const block of blocks) {
+      if (block.promptId === undefined) continue;
+      const recordIds = block.sourceRecordIds;
+      if (recordIds === undefined || recordIds.length === 0) continue;
+      const provisional = this.liveEntries.find(
+        (entry) => entry.kind === 'prompt' && entry.promptId === block.promptId,
+      );
+      if (provisional !== undefined) {
+        this.linkedRecordIds.set(provisional.id, recordIds);
+      }
+    }
+    const before = this.liveEntries;
+    this.reconcileLiveEntries();
+    if (before !== this.liveEntries) this.notify();
+  }
+
+  /** Rewind: drop snapshot-bound pages and provisionals, then re-seed. */
+  async handleRewind(): Promise<void> {
+    if (!this.enabled || this.status === 'unsupported') return;
+    this.liveEntries = this.liveEntries.filter(
+      (entry) => entry.kind !== 'prompt',
+    );
+    this.linkedRecordIds.clear();
+    await this.invalidateAndReseed();
+  }
+
+  private handleFetchError(error: unknown, retry: () => Promise<void>): void {
+    const code = daemonErrorCode(error);
+    if (code === 'transcript_too_large') {
+      // The transcript exceeds the daemon's indexing ceiling; the rail
+      // falls back to loaded messages for the rest of the session.
+      this.markUnsupported();
+      return;
+    }
+    if (
+      code === 'transcript_snapshot_unavailable' ||
+      code === 'invalid_transcript_cursor'
+    ) {
+      // Expected invalidation after snapshot replacement/rewind, not a
+      // retryable error storm: drop the snapshot and re-seed the tail.
+      this.generation += 1;
+      void this.invalidateAndReseed();
+      return;
+    }
+    // Anything else — including an index-path 413
+    // `transcript_page_too_large`, which is structurally unreachable — is a
+    // generic transient index failure: surface `error` and retry bounded.
+    this.status = 'error';
+    this.notify();
+    if (this.retryAttempts >= MAX_RETRY_ATTEMPTS) return;
+    const attempt = this.retryAttempts;
+    this.retryAttempts += 1;
+    const generation = this.generation;
+    this.scheduleRetry(
+      () => {
+        if (generation !== this.generation) return;
+        void retry();
+      },
+      RETRY_DELAYS_MS[attempt] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!,
+    );
+  }
+}

--- a/packages/web-shell/client/daemon/session/types.ts
+++ b/packages/web-shell/client/daemon/session/types.ts
@@ -407,6 +407,37 @@ export interface SubmitPromptResult {
   removedAfterAbort?: true;
 }
 
+/** Failure surface shared by the anchored-open and continuation actions. */
+export type TranscriptWindowFailure = {
+  ok: false;
+  reason:
+    | 'unsupported'
+    | 'invalid_anchor'
+    | 'snapshot_gone'
+    | 'page_too_large'
+    | 'window_full'
+    | 'window_impossible'
+    | 'unavailable';
+};
+
+export type OpenTranscriptAtTurnResult =
+  | { ok: true; targetRecordId: string }
+  | TranscriptWindowFailure;
+
+export type ContinueTranscriptWindowResult =
+  | { ok: true }
+  | TranscriptWindowFailure;
+
+/**
+ * Actions implemented by the `createDaemonSessionActions` factory. The
+ * provider layers the transcript-window actions (which need provider-owned
+ * stores) on top to form the full `DaemonSessionActions`.
+ */
+export type DaemonSessionCoreActions = Omit<
+  DaemonSessionActions,
+  'openTranscriptAtTurn' | 'continueTranscriptOlder' | 'continueTranscriptNewer'
+>;
+
 export interface DaemonSessionActions {
   sendPrompt(text: string, options?: SendPromptOptions): Promise<PromptResult>;
   /**
@@ -458,6 +489,30 @@ export interface DaemonSessionActions {
     signal: AbortSignal,
     options?: { replaySource?: 'configured' | 'memory' },
   ): Promise<void>;
+  /**
+   * Open a random-access transcript window at a persisted navigation turn
+   * (Phase 2 of Web Shell turn navigation; the rail lands in Phase 3). The
+   * anchored page is admitted without disturbing the connected live tail.
+   * The failure reasons are deliberately distinct: `page_too_large` is the
+   * daemon's whole-response refusal, `window_full` is a retryable client
+   * window rejection, `window_impossible` is terminal for that turn.
+   */
+  openTranscriptAtTurn(turnId: string): Promise<OpenTranscriptAtTurnResult>;
+  /**
+   * Continue a ledger page in the older direction: `beforeRecordId` on the
+   * entry's first persisted record, sent with the entry's own snapshot.
+   */
+  continueTranscriptOlder(
+    entryId: string,
+  ): Promise<ContinueTranscriptWindowResult>;
+  /**
+   * Continue a ledger page in the newer direction: the entry's stored
+   * `nextCursor`, sent alone (the signed cursor carries its frozen
+   * binding), toward the same frozen tail.
+   */
+  continueTranscriptNewer(
+    entryId: string,
+  ): Promise<ContinueTranscriptWindowResult>;
   resumeSession(
     sessionId: string,
     options?: {


### PR DESCRIPTION
## What this PR does

Implements the Phase 2 client data layer of the Web Shell global turn navigation design (`docs/design/web-shell/web-shell-global-turn-navigation-phase2.md`, merged in #11020) on top of the Phase 1 daemon/SDK protocol (#10968, #11047).

The change introduces three cooperating pieces, all gated behind the `session_turn_navigation` capability and invisible when the daemon does not advertise it. First, a provider-owned page ledger over the flat transcript store records which block ranges arrived as which fetched page, plus the explicit gaps between them, so that trimming or rewinding the window leaves re-fetchable locators instead of untracked holes. Second, a session-wide turn-index store loads the newest metadata page first, pages older metadata independently of transcript blocks, keeps the tail fresh with a two-step merge on prompt terminal (append-only fast path, conservative reset on any divergence), bounds memory with an LRU that never shrinks the advertised turn count, and latches an explicit `unsupported` state when the daemon reports its indexing ceiling. Third, rendered messages now carry their persisted identity (`sourceRecordIds` / `promptId`), which feeds a canonical turn locator and record-id/prompt-id deduplication.

On top of those, the session actions gain an anchored open (`openTranscriptAtTurn`) and two continuations (older via `beforeRecordId` + snapshot, newer via the stored signed cursor sent alone). An anchored page is materialized, deduplicated, and admitted atomically at its ledger position without disturbing the connected live tail, with deliberately distinct failure reasons — daemon-side whole-response refusal, retryable client-window rejection, terminal window overflow, snapshot invalidation, and missing anchor — so the Phase 3 UI can react to each appropriately.

Existing behavior is unchanged: the load-older path, pagination anchoring, capacity handling, and rendering all work exactly as before, which the full provider test suite confirms.

## Why it's needed

Long-running daemon sessions are the norm in the Web Shell, but today the transcript window can only grow sequentially from the newest edge: reaching an early turn means paging through everything in between, and once the window evicts old content there is no way back. Issue #10750 tracks making turns randomly addressable. Phase 1 shipped the daemon-side turn-index and anchored-read protocol; this PR lands the client-side data layer that consumes it — the page ledger, the turn-index store, and the anchored-admission actions that Phase 3's navigation rail will be built on.

## Reviewer Test Plan

### How to verify

This is a data-layer change with no UI surface of its own; verification is unit tests plus confirming existing transcript behavior is untouched.

1. `cd packages/web-shell && npx vitest run` — the full client suite passes (6072 tests, including 56 new ones covering the ledger, the turn-index store, and the anchored-open/continuation actions).
2. `npx vitest run client/daemon/session/DaemonSessionProvider.test.tsx` — the 295-test provider suite passes unmodified apart from the new `turn navigation (Phase 2)` describe block, demonstrating the load-older path, capacity handling, trimming, and session lifecycle are behavior-preserving.
3. Optionally, open any Web Shell session against a current daemon and use it normally (scroll, load older history, send prompts, rewind): nothing in the visible behavior should change, because the new stores only observe and record alongside the existing flows.

Key behaviors a reviewer can spot-check in the new tests: older-page requests clamp to a butted limit and never fire when the boundary is 0; the tail validation response is never admitted while clamped fill pages land on the grid; a shrunk or rewritten chain resets conservatively; the `unsupported` latch sticks for the session; anchored opens leave the live tail untouched and dedupe by record id then prompt id; continuation requests send exactly the locator the protocol allows (snapshot pair vs. standalone cursor).

### Evidence (Before & After)

N/A — no user-visible UI change in this phase (the navigation rail lands in Phase 3).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`vitest` under `packages/web-shell`), plus `npm run build` and `npm run typecheck` from the repository root.

## Risk & Scope

- Main risk or tradeoff: two new provider-owned stores now live alongside the transcript store and are reconciled on every trim/rewind/admission; a reconciliation bug could desync the ledger from the rendered window. The blast radius is contained to Phase 3 consumers — nothing in the current render path reads the new state — and the reconciliation invariants are pinned by dedicated tests (gap alignment, gaps-length invariant, displaced-gap preservation).
- Not validated / out of scope: the navigation rail UI, App-level capability wiring, and gap sentinel row rendering are explicitly Phase 3 and intentionally absent. A known heuristic limitation: an anchored page containing no navigation turns uses an insertion-position heuristic that can misplace it visually; noted for Phase 3. The chunked tail-fill loop is defensive and unreachable in production conditions.
- Breaking changes / migration notes: none. Daemons without `session_turn_navigation` get byte-identical behavior; the new session actions return `unsupported` without issuing requests.

## Linked Issues

Part of #10750 (Phase 2 of 3; does not close the tracking issue). Design docs: #11020, #10968. Protocol: #11047.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

按照已合并的 Phase 2 设计文档（`docs/design/web-shell/web-shell-global-turn-navigation-phase2.md`，#11020 并入），在 Phase 1 的 daemon/SDK 协议（#10968、#11047）之上实现 Web Shell 全局 turn 导航的客户端数据层。

改动由三部分协作完成，全部由 `session_turn_navigation` 能力门控，daemon 未声明该能力时完全不可见。其一，provider 持有的页台账记录在扁平 transcript store 上哪些 block 区间来自哪一次抓取，以及区间之间的显式 gap，使窗口裁剪或 rewind 后留下的是可重新抓取的定位器而不是无法追踪的空洞。其二，会话级 turn-index store 优先加载最新元数据页，独立于 transcript block 向前翻页，在 prompt 终态用两步合并保持尾部新鲜（仅追加走快速路径，任何分歧都保守重置），用永不缩减通告 turn 总数的 LRU 限制内存，并在 daemon 报告索引上限时闩锁为显式 `unsupported` 状态。其三，渲染消息现在携带其持久身份（`sourceRecordIds` / `promptId`），支撑规范的 turn 定位器和按 record id / prompt id 的去重。

在此之上，会话动作新增锚定打开（`openTranscriptAtTurn`）和两个方向的 continuation（older 用 `beforeRecordId` + 快照，newer 用单独发送的存储签名游标）。锚定页经物化、去重后按台账位置原子入账，不扰动已连接的实时尾部；失败原因刻意区分——daemon 整页拒绝、可重试的客户端窗口拒绝、终态窗口溢出、快照失效、锚点缺失——便于 Phase 3 的 UI 分别处理。

现有行为不变：load-older 路径、分页锚定、容量处理与渲染均与之前完全一致，完整的 provider 测试套件证实了这一点。

## 为什么需要

长时间运行的 daemon 会话在 Web Shell 中是常态，但目前 transcript 窗口只能从最新边缘顺序增长：要到达早期 turn 必须逐页翻完中间所有内容，而窗口一旦驱逐旧内容就无法回头。issue #10750 跟踪让 turn 可随机寻址的目标。Phase 1 交付了 daemon 侧 turn-index 与锚定读协议；本 PR 落地消费该协议的客户端数据层——页台账、turn-index store，以及 Phase 3 导航条将构建其上的锚定入账动作。

## 评审者测试计划

### 如何验证

这是没有自身 UI 的数据层改动；验证手段为单元测试加上确认现有 transcript 行为未受影响。

1. `cd packages/web-shell && npx vitest run` — 客户端全套测试通过（6072 项，含覆盖台账、turn-index store 与锚定打开/continuation 动作的 56 项新增）。
2. `npx vitest run client/daemon/session/DaemonSessionProvider.test.tsx` — 295 项 provider 套件除新增 `turn navigation (Phase 2)` 分组外未经修改即通过，证明 load-older 路径、容量处理、裁剪与会话生命周期保持行为不变。
3. 可选：对着当前 daemon 打开任意 Web Shell 会话并正常使用（滚动、加载更早历史、发送 prompt、rewind）：可见行为不应有任何变化，因为新 store 只是伴随现有流程做观察与记录。

评审者可在新测试中抽查的关键行为：older 页请求会 clamp 到贴合的 limit，边界为 0 时不发请求；尾部 validate 响应永不被入账，而 clamped fill 页落在网格上；链缩短或被改写时保守重置；`unsupported` 闩锁在会话内持续生效；锚定打开不扰动实时尾部，并按 record id 然后 prompt id 去重；continuation 请求只发送协议允许的定位器（快照配对 vs 独立游标）。

### 证据（前后对比）

N/A —— 本阶段没有用户可见的 UI 变化（导航条在 Phase 3 落地）。

### 测试平台

Linux 已测试；macOS、Windows 未测试。

### 环境（可选）

仅单元测试（`packages/web-shell` 下的 `vitest`），外加仓库根目录的 `npm run build` 与 `npm run typecheck`。

## 风险与范围

- 主要风险或取舍：两个新的 provider 持有的 store 与 transcript store 并存，并在每次裁剪/rewind/入账时对账；对账缺陷可能使台账与渲染窗口失同步。爆炸半径仅限 Phase 3 的消费者——当前渲染路径不读取新状态——且对账不变量由专门测试锁定（gap 对齐、gaps 长度不变量、被挤位 gap 保留）。
- 未验证 / 超出范围：导航条 UI、App 层能力接线与 gap 哨兵行渲染明确属于 Phase 3，有意缺席。已知启发式限制：不含导航 turn 的锚定页使用插入位置启发式，可能造成视觉错位，已记录留待 Phase 3。分块尾部填充循环为防御性代码，生产条件下不可达。
- 破坏性变更 / 迁移说明：无。未声明 `session_turn_navigation` 的 daemon 获得逐字节一致的行为；新会话动作返回 `unsupported` 且不发出请求。

## 关联 Issue

属于 #10750 的一部分（三阶段中的 Phase 2，不关闭该跟踪 issue）。设计文档：#11020、#10968。协议：#11047。

</details>
