### PR TITLE
fix(cli): finalize dangling turns and barrier live transcript reads

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17110,6 +17110,73 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('does not barrier cursor or record-anchor transcript pages', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    const recording = innerConfig.getChatRecordingService();
+    recording.runWithWriteBarrier.mockRejectedValue(
+      new Error('recorder not accepting writes'),
+    );
+    const readPage = vi.fn().mockResolvedValue({
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      startTime: 'start',
+      lastUpdated: 'end',
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+        sessionId: VALID_SESSION_ID,
+        cursor: 'cursor-1',
+        limit: 50,
+      }),
+    ).resolves.toMatchObject({ hasMore: false });
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+        sessionId: VALID_SESSION_ID,
+        beforeRecordId: 'record-1',
+        limit: 50,
+      }),
+    ).resolves.toMatchObject({ hasMore: false });
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+        sessionId: VALID_SESSION_ID,
+        atRecordId: 'u1',
+        snapshot: 'snapshot-1',
+      }),
+    ).resolves.toMatchObject({ hasMore: false });
+
+    expect(recording.runWithWriteBarrier).not.toHaveBeenCalled();
+    expect(recording.flush).not.toHaveBeenCalled();
+    expect(readPage).toHaveBeenNthCalledWith(1, VALID_SESSION_ID, {
+      cursor: 'cursor-1',
+      limit: 50,
+      maxBytes: 4 * 1024 * 1024,
+    });
+    expect(readPage).toHaveBeenNthCalledWith(2, VALID_SESSION_ID, {
+      beforeRecordId: 'record-1',
+      limit: 50,
+      maxBytes: 4 * 1024 * 1024,
+    });
+    expect(readPage).toHaveBeenNthCalledWith(3, VALID_SESSION_ID, {
+      atRecordId: 'u1',
+      snapshot: 'snapshot-1',
+      maxBytes: 4 * 1024 * 1024,
+    });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('flushes latest but not frozen turn-index pages', async () => {
     const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
     const recording = innerConfig.getChatRecordingService();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -1069,6 +1069,7 @@ import {
   SessionTranscriptSnapshotUnavailableError,
   SessionTranscriptTooLargeError,
   SessionTranscriptPageTooLargeError,
+  SessionWriterUnavailableError,
   encodeSessionTranscriptCursor,
   unregisterGoalHook,
   getActiveGoal,
@@ -17177,6 +17178,98 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('falls back to a direct latest transcript page when the recorder is only lifecycle-unavailable', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    const recording = innerConfig.getChatRecordingService();
+    Object.assign(recording, {
+      acceptingWrites: false,
+      state: 'closing',
+    });
+    recording.runWithWriteBarrier.mockRejectedValue(
+      new SessionWriterUnavailableError(),
+    );
+    const readPage = vi.fn().mockResolvedValue({
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      startTime: 'start',
+      lastUpdated: 'end',
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+        sessionId: VALID_SESSION_ID,
+        direction: 'backward',
+        limit: 1,
+      }),
+    ).resolves.toMatchObject({ hasMore: false });
+
+    expect(recording.runWithWriteBarrier).toHaveBeenCalledOnce();
+    expect(recording.flush).not.toHaveBeenCalled();
+    expect(readPage).toHaveBeenCalledWith(VALID_SESSION_ID, {
+      direction: 'backward',
+      limit: 1,
+      maxBytes: 4 * 1024 * 1024,
+    });
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('propagates a latest transcript page refusal when the recorder has a writeFailure', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    const recording = innerConfig.getChatRecordingService();
+    const writeFailure = new SessionWriterUnavailableError();
+    Object.assign(recording, {
+      writeFailure,
+      acceptingWrites: false,
+      state: 'integrity_failed',
+    });
+    recording.runWithWriteBarrier.mockRejectedValue(writeFailure);
+    const readPage = vi.fn().mockResolvedValue({
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      startTime: 'start',
+      lastUpdated: 'end',
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+        sessionId: VALID_SESSION_ID,
+        direction: 'backward',
+        limit: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: -32023,
+      data: { errorKind: 'session_writer_unavailable' },
+    });
+
+    expect(recording.runWithWriteBarrier).toHaveBeenCalledOnce();
+    expect(readPage).not.toHaveBeenCalled();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('flushes latest but not frozen turn-index pages', async () => {
     const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
     const recording = innerConfig.getChatRecordingService();
@@ -17418,6 +17511,45 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.anything(),
       [],
       expect.objectContaining({ finalizeDangling: true }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('keeps a dangling transcript call pending when a turn starts during the read', async () => {
+    await setupSessionMocks(VALID_SESSION_ID);
+    const page = {
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      startTime: 'start',
+      lastUpdated: 'end',
+    };
+    const readPage = vi.fn().mockResolvedValue(page);
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    lastSessionMock!.isTurnIdle.mockReturnValue(true);
+    readPage.mockImplementationOnce(async () => {
+      lastSessionMock!.isTurnIdle.mockReturnValue(false);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      return page;
+    });
+
+    await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+      sessionId: VALID_SESSION_ID,
+    });
+    expect(mockHistoryReplayPage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      [],
+      expect.objectContaining({ finalizeDangling: false }),
     );
 
     mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -421,6 +421,9 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => ({
     Buffer.from(JSON.stringify(state), 'utf8').toString('base64url'),
   ),
   SessionTranscriptReader: vi.fn(),
+  ChatRecordingService: (
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
+  ).ChatRecordingService,
   isReplayTurnStartType: (
     await importOriginal<typeof import('@qwen-code/qwen-code-core')>()
   ).isReplayTurnStartType,
@@ -1064,6 +1067,7 @@ import {
   applyProviderInstallPlan,
   Storage,
   SessionTranscriptReader,
+  ChatRecordingService,
   InvalidSessionTranscriptCursorError,
   InvalidSessionTranscriptTurnAnchorError,
   SessionTranscriptSnapshotUnavailableError,
@@ -2193,6 +2197,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         noteExternalWorkflowDeletion: ReturnType<typeof vi.fn>;
         isIdle: ReturnType<typeof vi.fn>;
         isTurnIdle: ReturnType<typeof vi.fn>;
+        hasActiveTurn: ReturnType<typeof vi.fn>;
         getCreatedAt: ReturnType<typeof vi.fn>;
         getTurnCount: ReturnType<typeof vi.fn>;
       }
@@ -4799,6 +4804,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
           releaseTodoStopGuardQueuedPromptWait: vi.fn().mockReturnValue(true),
           isIdle: vi.fn().mockReturnValue(true),
           isTurnIdle: vi.fn().mockReturnValue(true),
+          hasActiveTurn: vi.fn().mockReturnValue(false),
           getCreatedAt: vi.fn().mockReturnValue(1_700_000_000_000),
           getTurnCount: vi.fn().mockReturnValue(3),
           prompt: vi.fn().mockResolvedValue({ stopReason: 'end_turn' }),
@@ -17052,7 +17058,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
-  it('serializes live transcript reads behind in-flight tool-result writes', async () => {
+  it('runs the live transcript read as the write-barrier operation', async () => {
     const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
     const recording = innerConfig.getChatRecordingService();
     let releaseBarrier!: () => void;
@@ -17106,6 +17112,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     releaseBarrier();
     await transcriptPromise;
     expect(readPage).toHaveBeenCalledOnce();
+    const barrierResult = await recording.runWithWriteBarrier.mock.results[0]!
+      .value;
+    expect(barrierResult).toEqual(
+      expect.objectContaining({ sessionId: VALID_SESSION_ID }),
+    );
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -17178,7 +17189,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
-  it('falls back to a direct latest transcript page when the recorder is only lifecycle-unavailable', async () => {
+  it('falls back to a drained latest transcript page when the recorder is only lifecycle-unavailable', async () => {
     const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
     const recording = innerConfig.getChatRecordingService();
     Object.assign(recording, {
@@ -17188,13 +17199,86 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     recording.runWithWriteBarrier.mockRejectedValue(
       new SessionWriterUnavailableError(),
     );
-    const readPage = vi.fn().mockResolvedValue({
-      sessionId: VALID_SESSION_ID,
-      records: [],
-      hasMore: false,
-      startTime: 'start',
-      lastUpdated: 'end',
+    let queuedVisible = false;
+    let readStarted = false;
+    let releaseFlush!: () => void;
+    let markFlushEntered!: () => void;
+    const flushEntered = new Promise<void>((resolve) => {
+      markFlushEntered = resolve;
     });
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    recording.flush.mockImplementation(async () => {
+      markFlushEntered();
+      await flushGate;
+      queuedVisible = true;
+    });
+    const readPage = vi.fn().mockImplementation(async () => {
+      readStarted = true;
+      return {
+        sessionId: VALID_SESSION_ID,
+        records: queuedVisible ? [{ uuid: 'queued-tool-result' }] : [],
+        hasMore: false,
+        startTime: 'start',
+        lastUpdated: 'end',
+      };
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    const transcriptPromise = agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.sessionTranscript,
+      {
+        sessionId: VALID_SESSION_ID,
+        direction: 'backward',
+        limit: 1,
+      },
+    );
+    await flushEntered;
+    expect(readStarted).toBe(false);
+
+    releaseFlush();
+    await expect(transcriptPromise).resolves.toMatchObject({ hasMore: false });
+
+    expect(recording.runWithWriteBarrier).toHaveBeenCalledOnce();
+    expect(recording.flush).toHaveBeenCalledOnce();
+    expect(readPage).toHaveBeenCalledOnce();
+    expect(readPage).toHaveBeenCalledWith(VALID_SESSION_ID, {
+      direction: 'backward',
+      limit: 1,
+      maxBytes: 4 * 1024 * 1024,
+    });
+    expect(await readPage.mock.results[0]!.value).toEqual(
+      expect.objectContaining({
+        records: [{ uuid: 'queued-tool-result' }],
+      }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('does not retry a latest transcript page when the barriered read itself fails', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    const recording = innerConfig.getChatRecordingService();
+    Object.assign(recording, {
+      acceptingWrites: false,
+      state: 'closing',
+    });
+    recording.runWithWriteBarrier.mockImplementation(
+      async <T>(operation: () => Promise<T>): Promise<T> => operation(),
+    );
+    const readPage = vi
+      .fn()
+      .mockRejectedValue(new Error('EMFILE: too many open files'));
     vi.mocked(SessionTranscriptReader).mockImplementation(
       () =>
         ({
@@ -17211,15 +17295,11 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
         direction: 'backward',
         limit: 1,
       }),
-    ).resolves.toMatchObject({ hasMore: false });
+    ).rejects.toThrow('EMFILE: too many open files');
 
     expect(recording.runWithWriteBarrier).toHaveBeenCalledOnce();
     expect(recording.flush).not.toHaveBeenCalled();
-    expect(readPage).toHaveBeenCalledWith(VALID_SESSION_ID, {
-      direction: 'backward',
-      limit: 1,
-      maxBytes: 4 * 1024 * 1024,
-    });
+    expect(readPage).toHaveBeenCalledOnce();
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -17264,6 +17344,89 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     });
 
     expect(recording.runWithWriteBarrier).toHaveBeenCalledOnce();
+    expect(recording.flush).not.toHaveBeenCalled();
+    expect(readPage).not.toHaveBeenCalled();
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('falls back after a real recorder beginClose and refuses a latched writeFailure', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    const recorder = new ChatRecordingService(
+      {
+        getSessionId: () => VALID_SESSION_ID,
+        getProjectRoot: () => '/tmp',
+        getCliVersion: () => '1.0.0',
+        getResumedSessionData: () => undefined,
+        storage: { getProjectDir: () => '/tmp' },
+      } as unknown as Config,
+      undefined,
+      false,
+    );
+    innerConfig.getChatRecordingService = vi.fn().mockReturnValue(recorder);
+    const readPage = vi.fn().mockResolvedValue({
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      startTime: 'start',
+      lastUpdated: 'end',
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    recorder.beginClose();
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+        sessionId: VALID_SESSION_ID,
+        direction: 'backward',
+        limit: 1,
+      }),
+    ).resolves.toMatchObject({ hasMore: false });
+    expect(readPage).toHaveBeenCalledOnce();
+
+    const { SessionWriterUnavailableError: RealWriterUnavailable } =
+      await vi.importActual<typeof import('@qwen-code/qwen-code-core')>(
+        '@qwen-code/qwen-code-core',
+      );
+    const failedRecorder = new ChatRecordingService(
+      {
+        getSessionId: () => VALID_SESSION_ID,
+        getProjectRoot: () => '/tmp',
+        getCliVersion: () => '1.0.0',
+        getResumedSessionData: () => undefined,
+        storage: { getProjectDir: () => '/tmp' },
+      } as unknown as Config,
+      undefined,
+      false,
+    );
+    await expect(
+      failedRecorder.runWithWriteBarrier(async () => {
+        throw new RealWriterUnavailable();
+      }),
+    ).rejects.toBeInstanceOf(RealWriterUnavailable);
+    innerConfig.getChatRecordingService = vi
+      .fn()
+      .mockReturnValue(failedRecorder);
+    readPage.mockClear();
+
+    await expect(
+      agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+        sessionId: VALID_SESSION_ID,
+        direction: 'backward',
+        limit: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: -32023,
+      data: { errorKind: 'session_writer_unavailable' },
+    });
     expect(readPage).not.toHaveBeenCalled();
 
     mockConnectionState.resolve();
@@ -17488,9 +17651,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
     const { agent, agentPromise } = await bootAcpAgent();
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    lastSessionMock!.isTurnIdle.mockReturnValue(false);
+    lastSessionMock!.hasActiveTurn.mockReturnValue(true);
     readPage.mockImplementationOnce(async () => {
-      lastSessionMock!.isTurnIdle.mockReturnValue(true);
+      lastSessionMock!.hasActiveTurn.mockReturnValue(false);
       await new Promise<void>((resolve) => setImmediate(resolve));
       return page;
     });
@@ -17536,9 +17699,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
     const { agent, agentPromise } = await bootAcpAgent();
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    lastSessionMock!.isTurnIdle.mockReturnValue(true);
+    lastSessionMock!.hasActiveTurn.mockReturnValue(false);
     readPage.mockImplementationOnce(async () => {
-      lastSessionMock!.isTurnIdle.mockReturnValue(false);
+      lastSessionMock!.hasActiveTurn.mockReturnValue(true);
       await new Promise<void>((resolve) => setImmediate(resolve));
       return page;
     });
@@ -17550,6 +17713,41 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.anything(),
       [],
       expect.objectContaining({ finalizeDangling: false }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('finalizes dangling transcript calls when the session is closing with no active turn', async () => {
+    await setupSessionMocks(VALID_SESSION_ID);
+    const page = {
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      startTime: 'start',
+      lastUpdated: 'end',
+    };
+    const readPage = vi.fn().mockResolvedValue(page);
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    lastSessionMock!.isTurnIdle.mockReturnValue(false);
+    lastSessionMock!.hasActiveTurn.mockReturnValue(false);
+
+    await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+      sessionId: VALID_SESSION_ID,
+    });
+    expect(mockHistoryReplayPage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      [],
+      expect.objectContaining({ finalizeDangling: true }),
     );
 
     mockConnectionState.resolve();

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17009,7 +17009,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
-  it('flushes the live recording before reading the latest persisted page', async () => {
+  it('reads the live transcript page through the owner write barrier', async () => {
     const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
     const recording = innerConfig.getChatRecordingService();
     const readPage = vi.fn().mockResolvedValue({
@@ -17038,13 +17038,73 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       },
     );
 
-    expect(recording?.flush).toHaveBeenCalledOnce();
+    expect(recording?.runWithWriteBarrier).toHaveBeenCalledOnce();
+    expect(recording?.flush).not.toHaveBeenCalled();
     expect(readPage).toHaveBeenCalledWith(VALID_SESSION_ID, {
       direction: 'backward',
       limit: 100,
       maxBytes: 4 * 1024 * 1024,
     });
     expect(result['hasMore']).toBe(false);
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
+  it('serializes live transcript reads behind in-flight tool-result writes', async () => {
+    const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
+    const recording = innerConfig.getChatRecordingService();
+    let releaseBarrier!: () => void;
+    let markBarrierEntered!: () => void;
+    const barrierEntered = new Promise<void>((resolve) => {
+      markBarrierEntered = resolve;
+    });
+    const barrierGate = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    recording.runWithWriteBarrier.mockImplementation(
+      async <T>(operation: () => Promise<T>): Promise<T> => {
+        markBarrierEntered();
+        await barrierGate;
+        return operation();
+      },
+    );
+
+    let readStarted = false;
+    const readPage = vi.fn().mockImplementation(async () => {
+      readStarted = true;
+      return {
+        sessionId: VALID_SESSION_ID,
+        records: [],
+        hasMore: false,
+        startTime: 'start',
+        lastUpdated: 'end',
+      };
+    });
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+
+    const transcriptPromise = agent.extMethod(
+      SERVE_STATUS_EXT_METHODS.sessionTranscript,
+      {
+        sessionId: VALID_SESSION_ID,
+        direction: 'backward',
+        limit: 1,
+      },
+    );
+    await barrierEntered;
+    expect(readStarted).toBe(false);
+
+    releaseBarrier();
+    await transcriptPromise;
+    expect(readPage).toHaveBeenCalledOnce();
 
     mockConnectionState.resolve();
     await agentPromise;
@@ -17249,7 +17309,7 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
-  it('does not finalize dangling transcript calls when a prompt settles during the read', async () => {
+  it('does not finalize dangling transcript calls when a turn settles during the read', async () => {
     await setupSessionMocks(VALID_SESSION_ID);
     const page = {
       sessionId: VALID_SESSION_ID,
@@ -17268,18 +17328,9 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
     const { agent, agentPromise } = await bootAcpAgent();
     await agent.newSession({ cwd: '/tmp', mcpServers: [] });
-    let finishPrompt: ((value: unknown) => void) | undefined;
-    lastSessionMock!.prompt.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          finishPrompt = resolve;
-        }),
-    );
-
-    const prompt = agent.prompt({ sessionId: VALID_SESSION_ID, prompt: [] });
-    await vi.waitFor(() => expect(lastSessionMock!.prompt).toHaveBeenCalled());
+    lastSessionMock!.isTurnIdle.mockReturnValue(false);
     readPage.mockImplementationOnce(async () => {
-      finishPrompt?.({ stopReason: 'end_turn' });
+      lastSessionMock!.isTurnIdle.mockReturnValue(true);
       await new Promise<void>((resolve) => setImmediate(resolve));
       return page;
     });
@@ -17293,7 +17344,6 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
       expect.objectContaining({ finalizeDangling: false }),
     );
 
-    await prompt;
     await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
       sessionId: VALID_SESSION_ID,
     });

--- a/packages/cli/src/acp-integration/acpAgent.test.ts
+++ b/packages/cli/src/acp-integration/acpAgent.test.ts
@@ -17754,6 +17754,135 @@ describe('QwenAgent MCP SSE/HTTP support', () => {
     await agentPromise;
   });
 
+  it('does not finalize dangling transcript calls while a prompt is waiting at admission', async () => {
+    await setupSessionMocks(VALID_SESSION_ID);
+    const page = {
+      sessionId: VALID_SESSION_ID,
+      records: [],
+      hasMore: false,
+      startTime: 'start',
+      lastUpdated: 'end',
+    };
+    const readPage = vi.fn().mockResolvedValue(page);
+    vi.mocked(SessionTranscriptReader).mockImplementation(
+      () =>
+        ({
+          readPage,
+        }) as unknown as InstanceType<typeof SessionTranscriptReader>,
+    );
+    mockHistoryReplayPage.mockResolvedValue({ pendingToolCalls: [] });
+    const { agent, agentPromise } = await bootAcpAgent();
+    await agent.newSession({ cwd: '/tmp', mcpServers: [] });
+    // Admission window: registered in activePromptCalls, Session turn idle.
+    lastSessionMock!.hasActiveTurn.mockReturnValue(false);
+
+    let finishPrompt: ((value: unknown) => void) | undefined;
+    lastSessionMock!.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishPrompt = resolve;
+        }),
+    );
+
+    const gatedPrompt = agent.prompt({
+      sessionId: VALID_SESSION_ID,
+      prompt: [],
+    });
+    await vi.waitFor(() => expect(lastSessionMock!.prompt).toHaveBeenCalled());
+
+    await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+      sessionId: VALID_SESSION_ID,
+      direction: 'backward',
+      limit: 1,
+    });
+    expect(mockHistoryReplayPage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      [],
+      expect.objectContaining({ finalizeDangling: false }),
+    );
+
+    finishPrompt?.({ stopReason: 'end_turn' });
+    await gatedPrompt;
+
+    lastSessionMock!.prompt.mockClear();
+    lastSessionMock!.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishPrompt = resolve;
+        }),
+    );
+    const settlingPrompt = agent.prompt({
+      sessionId: VALID_SESSION_ID,
+      prompt: [],
+    });
+    await vi.waitFor(() => expect(lastSessionMock!.prompt).toHaveBeenCalled());
+    readPage.mockImplementationOnce(async () => {
+      finishPrompt?.({ stopReason: 'end_turn' });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      return page;
+    });
+
+    await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+      sessionId: VALID_SESSION_ID,
+      direction: 'backward',
+      limit: 1,
+    });
+    expect(mockHistoryReplayPage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      [],
+      expect.objectContaining({ finalizeDangling: false }),
+    );
+
+    await settlingPrompt;
+
+    lastSessionMock!.prompt.mockClear();
+    lastSessionMock!.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishPrompt = resolve;
+        }),
+    );
+    let startedDuringRead: Promise<unknown> | undefined;
+    readPage.mockImplementationOnce(async () => {
+      startedDuringRead = agent.prompt({
+        sessionId: VALID_SESSION_ID,
+        prompt: [],
+      });
+      await vi.waitFor(() =>
+        expect(lastSessionMock!.prompt).toHaveBeenCalled(),
+      );
+      return page;
+    });
+
+    await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+      sessionId: VALID_SESSION_ID,
+      direction: 'backward',
+      limit: 1,
+    });
+    expect(mockHistoryReplayPage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      [],
+      expect.objectContaining({ finalizeDangling: false }),
+    );
+
+    finishPrompt?.({ stopReason: 'end_turn' });
+    await startedDuringRead;
+
+    await agent.extMethod(SERVE_STATUS_EXT_METHODS.sessionTranscript, {
+      sessionId: VALID_SESSION_ID,
+      direction: 'backward',
+      limit: 1,
+    });
+    expect(mockHistoryReplayPage).toHaveBeenLastCalledWith(
+      expect.anything(),
+      [],
+      expect.objectContaining({ finalizeDangling: true }),
+    );
+
+    mockConnectionState.resolve();
+    await agentPromise;
+  });
+
   it('live session load finalizes dangling calls because the restore gate drains active turns', async () => {
     const innerConfig = await setupSessionMocks(VALID_SESSION_ID);
     innerConfig.getSessionRuntimeBaseDir = vi

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4649,12 +4649,23 @@ class QwenAgent implements Agent {
    * turns, blocks new ones, and reports closing=true — so isTurnIdle()
    * there is structurally false and would keep genuinely abandoned calls
    * pending forever.
+   *
+   * qwen/status/session/transcript is also ungated and can be served while
+   * another request holds the close gate, or after dispose before the
+   * session leaves this.sessions. Pass ignoreClosing so that path samples
+   * hasActiveTurn() rather than isTurnIdle(): a closing session with no
+   * active turn must still finalize abandoned trailing calls. loadUpdates
+   * keeps the isTurnIdle() sample. isTurnIdle() itself is unchanged — it
+   * remains the busy-check for turn admission.
    */
   private finalizeDanglingForRestore(
     session: Session | undefined,
     turnIdleBeforeRead: boolean,
+    options?: { ignoreClosing?: boolean },
   ): boolean {
-    const idleAtReplay = session?.isTurnIdle() ?? true;
+    const idleAtReplay = options?.ignoreClosing
+      ? !(session?.hasActiveTurn() ?? false)
+      : (session?.isTurnIdle() ?? true);
     const finalize = turnIdleBeforeRead && idleAtReplay;
     // Template literal, not printf-style placeholders: createDebugLogger's
     // formatArgs does no util.format substitution, it space-joins the args.
@@ -9050,8 +9061,12 @@ class QwenAgent implements Agent {
             const recording = liveSession
               ?.getConfig()
               .getChatRecordingService();
-            const turnIdleBeforeRead = liveSession?.isTurnIdle() ?? true;
+            const turnIdleBeforeRead = liveSession
+              ? !liveSession.hasActiveTurn()
+              : true;
+            let readAttempted = false;
             const readPersistedPage = async () => {
+              readAttempted = true;
               const reader = new SessionTranscriptReader(cwd);
               return await reader.readPage(sessionId, {
                 ...(typeof rawCursor === 'string' ? { cursor: rawCursor } : {}),
@@ -9071,20 +9086,34 @@ class QwenAgent implements Agent {
                 maxBytes: SESSION_TRANSCRIPT_MAX_PAGE_BYTES,
               });
             };
-            // Barrier the request's backward/latest page (#9704). The
-            // request direction, not the resolved page direction, is the
-            // gate. Cursor/anchor pages never consulted writer health.
-            // The barrier still waits for in-flight writes. A recorder
-            // that is only lifecycle-unavailable falls back to a direct
-            // disk read; a latched writeFailure still fails the read.
+            // Barrier the request's backward/latest page so queued
+            // appends drain before the disk read. Request direction,
+            // not the resolved page direction, is the gate.
+            // Cursor/anchor pages never consulted writer health.
+            // The barrier refuses before touching the tail when the
+            // recorder is lifecycle-inactive, so that fallback drains
+            // via flush().catch then reads. A latched writeFailure
+            // still fails the read. The #9704 dangling placeholder is
+            // decided below by finalizeDanglingForRestore (active-turn
+            // sample), not by this drain — tool results are recorded
+            // only after the batch ends.
             const page =
               recording !== undefined && rawDirection === 'backward'
                 ? await recording
                     .runWithWriteBarrier(readPersistedPage)
-                    .catch((error: unknown) => {
-                      if (!isWriterLifecycleUnavailable(recording)) {
+                    .catch(async (error: unknown) => {
+                      if (
+                        readAttempted ||
+                        !isWriterLifecycleUnavailable(recording)
+                      ) {
                         throw error;
                       }
+                      const reason =
+                        error instanceof Error ? error.message : String(error);
+                      debugLogger.debug(
+                        `[ACP] sessionTranscript lifecycle fallback session=${sessionId} error=${reason}`,
+                      );
+                      await recording.flush().catch(() => undefined);
                       return readPersistedPage();
                     })
                 : await readPersistedPage();
@@ -9096,6 +9125,7 @@ class QwenAgent implements Agent {
               finalizeDangling: this.finalizeDanglingForRestore(
                 liveSession,
                 turnIdleBeforeRead,
+                { ignoreClosing: true },
               ),
               encodeCursor: (state) =>
                 encodeSessionTranscriptCursor(state, cwd),

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -4657,6 +4657,13 @@ class QwenAgent implements Agent {
    * active turn must still finalize abandoned trailing calls. loadUpdates
    * keeps the isTurnIdle() sample. isTurnIdle() itself is unchanged — it
    * remains the busy-check for turn admission.
+   *
+   * That transcript path also ANDs the agent-level activePromptCalls
+   * sample (taken before the read and again at replay). A prompt already
+   * registered but still waiting at Session admission has no pendingPrompt
+   * yet, so hasActiveTurn() is false across that window; without the
+   * extra sample a backward page would finalize a trailing call the
+   * prompt is about to resume.
    */
   private finalizeDanglingForRestore(
     session: Session | undefined,
@@ -9061,6 +9068,7 @@ class QwenAgent implements Agent {
             const recording = liveSession
               ?.getConfig()
               .getChatRecordingService();
+            const promptCallBeforeRead = this.activePromptCalls.has(sessionId);
             const turnIdleBeforeRead = liveSession
               ? !liveSession.hasActiveTurn()
               : true;
@@ -9094,7 +9102,8 @@ class QwenAgent implements Agent {
             // recorder is lifecycle-inactive, so that fallback drains
             // via flush().catch then reads. A latched writeFailure
             // still fails the read. The #9704 dangling placeholder is
-            // decided below by finalizeDanglingForRestore (active-turn
+            // decided below by ANDing the activePromptCalls sample with
+            // finalizeDanglingForRestore (ignoreClosing active-turn
             // sample), not by this drain — tool results are recorded
             // only after the batch ends.
             const page =
@@ -9122,11 +9131,14 @@ class QwenAgent implements Agent {
               sessionId,
               page,
               config,
-              finalizeDangling: this.finalizeDanglingForRestore(
-                liveSession,
-                turnIdleBeforeRead,
-                { ignoreClosing: true },
-              ),
+              finalizeDangling:
+                !promptCallBeforeRead &&
+                !this.activePromptCalls.has(sessionId) &&
+                this.finalizeDanglingForRestore(
+                  liveSession,
+                  turnIdleBeforeRead,
+                  { ignoreClosing: true },
+                ),
               encodeCursor: (state) =>
                 encodeSessionTranscriptCursor(state, cwd),
               logger: debugLogger,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -756,6 +756,27 @@ function mapSessionWriterRequestError(error: unknown): unknown {
     : error;
 }
 
+/**
+ * A write-barrier refusal is only a lifecycle miss when the recorder has
+ * stopped accepting writes and has not latched a writeFailure. Do not key
+ * this on `instanceof SessionWriterUnavailableError`: the barrier rethrows
+ * writeFailure first, and that failure can itself be that class.
+ */
+function isWriterLifecycleUnavailable(recording: object): boolean {
+  const writer = recording as {
+    writeFailure?: unknown;
+    acceptingWrites?: boolean;
+    state?: string;
+  };
+  if (writer.writeFailure != null) {
+    return false;
+  }
+  return (
+    writer.acceptingWrites === false ||
+    (writer.state !== undefined && writer.state !== 'active')
+  );
+}
+
 async function shutdownSessionConfig(config: Config): Promise<void> {
   await config.shutdown({ shutdownTelemetry: false });
   if (config.hasSessionWriteOwnership()) {
@@ -9050,12 +9071,22 @@ class QwenAgent implements Agent {
                 maxBytes: SESSION_TRANSCRIPT_MAX_PAGE_BYTES,
               });
             };
-            // Barrier only the latest tail (#9704). Cursor/anchor pages
-            // never consulted writer health; the barrier would 503 them
-            // after a write failure or during handoff.
+            // Barrier the request's backward/latest page (#9704). The
+            // request direction, not the resolved page direction, is the
+            // gate. Cursor/anchor pages never consulted writer health.
+            // The barrier still waits for in-flight writes. A recorder
+            // that is only lifecycle-unavailable falls back to a direct
+            // disk read; a latched writeFailure still fails the read.
             const page =
               recording !== undefined && rawDirection === 'backward'
-                ? await recording.runWithWriteBarrier(readPersistedPage)
+                ? await recording
+                    .runWithWriteBarrier(readPersistedPage)
+                    .catch((error: unknown) => {
+                      if (!isWriterLifecycleUnavailable(recording)) {
+                        throw error;
+                      }
+                      return readPersistedPage();
+                    })
                 : await readPersistedPage();
             const config = await this.getTranscriptReplayConfig(cwd, settings);
             const replay = await replayTranscriptRecordPage({

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -9050,8 +9050,11 @@ class QwenAgent implements Agent {
                 maxBytes: SESSION_TRANSCRIPT_MAX_PAGE_BYTES,
               });
             };
+            // Barrier only the latest tail (#9704). Cursor/anchor pages
+            // never consulted writer health; the barrier would 503 them
+            // after a write failure or during handoff.
             const page =
-              recording !== undefined
+              recording !== undefined && rawDirection === 'backward'
                 ? await recording.runWithWriteBarrier(readPersistedPage)
                 : await readPersistedPage();
             const config = await this.getTranscriptReplayConfig(cwd, settings);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -9025,41 +9025,44 @@ class QwenAgent implements Agent {
 
         try {
           const readTranscriptPage = async (settings: LoadedSettings) => {
-            if (rawDirection === 'backward') {
-              await this.sessions
-                .get(sessionId)
-                ?.getConfig()
-                .getChatRecordingService()
-                ?.flush();
-            }
-            const reader = new SessionTranscriptReader(cwd);
-            const activePromptBeforeRead =
-              this.activePromptCalls.has(sessionId);
-            const page = await reader.readPage(sessionId, {
-              ...(typeof rawCursor === 'string' ? { cursor: rawCursor } : {}),
-              ...(typeof rawBeforeRecordId === 'string'
-                ? { beforeRecordId: rawBeforeRecordId }
-                : {}),
-              ...(typeof rawAtRecordId === 'string'
-                ? { atRecordId: rawAtRecordId }
-                : {}),
-              ...(typeof rawSnapshot === 'string'
-                ? { snapshot: rawSnapshot }
-                : {}),
-              ...(rawDirection === 'backward'
-                ? { direction: rawDirection }
-                : {}),
-              ...(typeof rawLimit === 'number' ? { limit: rawLimit } : {}),
-              maxBytes: SESSION_TRANSCRIPT_MAX_PAGE_BYTES,
-            });
+            const liveSession = this.sessions.get(sessionId);
+            const recording = liveSession
+              ?.getConfig()
+              .getChatRecordingService();
+            const turnIdleBeforeRead = liveSession?.isTurnIdle() ?? true;
+            const readPersistedPage = async () => {
+              const reader = new SessionTranscriptReader(cwd);
+              return await reader.readPage(sessionId, {
+                ...(typeof rawCursor === 'string' ? { cursor: rawCursor } : {}),
+                ...(typeof rawBeforeRecordId === 'string'
+                  ? { beforeRecordId: rawBeforeRecordId }
+                  : {}),
+                ...(typeof rawAtRecordId === 'string'
+                  ? { atRecordId: rawAtRecordId }
+                  : {}),
+                ...(typeof rawSnapshot === 'string'
+                  ? { snapshot: rawSnapshot }
+                  : {}),
+                ...(rawDirection === 'backward'
+                  ? { direction: rawDirection }
+                  : {}),
+                ...(typeof rawLimit === 'number' ? { limit: rawLimit } : {}),
+                maxBytes: SESSION_TRANSCRIPT_MAX_PAGE_BYTES,
+              });
+            };
+            const page =
+              recording !== undefined
+                ? await recording.runWithWriteBarrier(readPersistedPage)
+                : await readPersistedPage();
             const config = await this.getTranscriptReplayConfig(cwd, settings);
             const replay = await replayTranscriptRecordPage({
               sessionId,
               page,
               config,
-              finalizeDangling:
-                !activePromptBeforeRead &&
-                !this.activePromptCalls.has(sessionId),
+              finalizeDangling: this.finalizeDanglingForRestore(
+                liveSession,
+                turnIdleBeforeRead,
+              ),
               encodeCursor: (state) =>
                 encodeSessionTranscriptCursor(state, cwd),
               logger: debugLogger,

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -4163,6 +4163,31 @@ describe('Session', () => {
     expect(session.isTurnIdle()).toBe(true);
   });
 
+  it('reports an active turn from a non-prompt source under the close gate', async () => {
+    const internals = session as unknown as {
+      notificationProcessing: boolean;
+      notificationCompletion: Promise<void> | null;
+    };
+    let resolveNotification!: () => void;
+    internals.notificationProcessing = true;
+    internals.notificationCompletion = new Promise<void>((resolve) => {
+      resolveNotification = resolve;
+    });
+
+    expect(session.hasActiveTurn()).toBe(true);
+    const releaseClose = session.beginClose();
+    expect(session.hasActiveTurn()).toBe(true);
+    expect(session.isTurnIdle()).toBe(false);
+
+    releaseClose();
+    resolveNotification();
+    internals.notificationProcessing = false;
+    internals.notificationCompletion = null;
+
+    expect(session.hasActiveTurn()).toBe(false);
+    expect(session.isTurnIdle()).toBe(true);
+  });
+
   it('rejects a prompt when a history mutation begins during writer admission', async () => {
     let resolveAdmission!: () => void;
     const admission = new Promise<void>((resolve) => {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -4113,6 +4113,7 @@ describe('Session', () => {
   it('rejects a prompt while an exclusive history mutation is active', async () => {
     const releaseMutation = session.beginHistoryMutation();
 
+    expect(session.hasActiveTurn()).toBe(true);
     expect(session.isIdle()).toBe(false);
     expect(session.isTurnIdle()).toBe(false);
     await expect(
@@ -4136,6 +4137,29 @@ describe('Session', () => {
     expect(session.hasActiveTurn()).toBe(false);
     expect(session.isTurnIdle()).toBe(false);
     releaseClose();
+    expect(session.isTurnIdle()).toBe(true);
+  });
+
+  it('reports an active turn while a prompt is in flight', async () => {
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>((resolve) => {
+      resolveStream = resolve;
+    });
+    mockChat.sendMessageStream = vi.fn().mockImplementation(async () => {
+      await streamGate;
+      return createEmptyStream();
+    });
+
+    const prompt = session.prompt({
+      sessionId: 'test-session-id',
+      prompt: [{ type: 'text', text: 'hello' }],
+    });
+    await vi.waitFor(() => expect(session.hasActiveTurn()).toBe(true));
+    expect(session.isTurnIdle()).toBe(false);
+
+    resolveStream();
+    await prompt;
+    expect(session.hasActiveTurn()).toBe(false);
     expect(session.isTurnIdle()).toBe(true);
   });
 

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -4126,6 +4126,17 @@ describe('Session', () => {
     releaseMutation();
     expect(session.isIdle()).toBe(true);
     expect(session.isTurnIdle()).toBe(true);
+    expect(session.hasActiveTurn()).toBe(false);
+  });
+
+  it('reports no active turn while the close gate is held', () => {
+    expect(session.hasActiveTurn()).toBe(false);
+    expect(session.isTurnIdle()).toBe(true);
+    const releaseClose = session.beginClose();
+    expect(session.hasActiveTurn()).toBe(false);
+    expect(session.isTurnIdle()).toBe(false);
+    releaseClose();
+    expect(session.isTurnIdle()).toBe(true);
   });
 
   it('rejects a prompt when a history mutation begins during writer admission', async () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -3928,6 +3928,10 @@ export class Session implements SessionContext {
     return !this.closing && !this.#hasActiveTurn();
   }
 
+  hasActiveTurn(): boolean {
+    return this.#hasActiveTurn();
+  }
+
   isIdle(): boolean {
     return this.isTurnIdle() && this.collectActiveWorkHolds().length === 0;
   }


### PR DESCRIPTION
## What this PR does

Routes restore cleanup through the shared `finalizeDanglingForRestore` helper and samples `isTurnIdle()` / `hasActiveTurn()` so concurrent session loads do not report a false dangling tool while a turn is still active — this is the mechanism that changes the #9704 replay outcome.

Also barriers live `sessionTranscript` disk reads behind in-flight tool-result writes on the ACP agent path for the latest/backward read (`direction === 'backward'`). Cursor, `beforeRecordId`, and snapshot/anchor pages still read the persisted transcript directly. The barrier alone cannot close the #9704 window (tool results are recorded only after the batch completes, so `operationTail` is empty mid-execution).


## Why it's needed

During a live session, loading the transcript while a turn is still active can show: "Tool result missing from saved history; the previous run likely ended before this tool completed." The tool result is written shortly after, but the race makes the UI/CLI report a false dangling tool. Issue #9704 describes this TOCTOU on concurrent session load.

`runWithWriteBarrier` is not a drop-in for the old `flush()`: it also throws `SessionWriterUnavailableError` when the recorder is not `active`/`acceptingWrites`. Web UI history pagination never sends `direction` (only `cursor`/`beforeRecordId`), so those pages must not go through the barrier.

## Reviewer Test Plan

### How to verify

1. Start a session that runs a slow tool.
2. While the tool is still executing, trigger a concurrent session transcript load (ACP restore / Web UI load of the same session).
3. Before this change: the load can report the missing-tool-result placeholder even though the write completes moments later.
4. After this change: the latest/backward load waits for the tool-result write barrier, then reads a consistent transcript (or finalizes dangling turns via the shared helper).
5. Scroll older history via cursor/`beforeRecordId` after a recording write failure or during managed shutdown/handoff: the page still returns. That path does not consult writer health.

Unit coverage: `packages/cli/src/acp-integration/acpAgent.test.ts` covers barrier ordering on the backward/latest path, and asserts cursor/anchor pages skip the barrier even when the recorder would refuse writes.

### Evidence (Before & After)

Before: concurrent load during an in-flight tool write can surface "Tool result missing from saved history" even though the result lands on disk soon after.
After: latest/backward live transcript reads are sequenced behind tool-result writes; cursor/anchor pagination stays a direct disk read. Unit tests assert both.
N/A for Before/After screenshots (non-TUI, race fix + unit tests).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   N/A  |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests via the package test runner for `packages/cli`.

## Risk & Scope
Ungated `sessionTranscript` finalize ANDs the agent-level `activePromptCalls` sample (a prompt already registered but still waiting at Session admission) with the ignore-closing active-turn sample, so a close-gate hold still finalizes abandoned calls while an admission-waiting continuation is not certified as failed.


## Linked Issues

Fixes #9704

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 ACP agent 路径上，把实时 `sessionTranscript` 磁盘读取挡在进行中的 tool-result 写入之后，并通过共享的 `finalizeDanglingForRestore` 做恢复清理，避免并发加载读到半写入的 tool turn。

写入屏障只作用于最新/backward 读取（`direction === 'backward'`）。带 cursor、`beforeRecordId` 或 snapshot/anchor 的分页直接读已落盘的 transcript。

## 为什么需要

实会话中若在 tool 仍在写结果时加载 transcript，会出现 "Tool result missing from saved history…"。结果稍后会写入，但这是竞态导致的误报。#9704 描述了该 TOCTOU。

`runWithWriteBarrier` 不能直接替换原来的 `flush()`：它还会在 recorder 非 `active`/`acceptingWrites` 时抛出 `SessionWriterUnavailableError`。Web UI 历史分页从不发送 `direction`（只传 `cursor`/`beforeRecordId`），因此这些页不能走 barrier。

## 评审人验证计划

### 如何验证

1. 启动会跑慢 tool 的会话。
2. tool 仍在执行时并发加载同一会话 transcript。
3. 修复前：可能误报缺失 tool result。
4. 修复后：最新/backward 读取会等待写入屏障，或经共享 finalize 一致化。
5. 在录制写入失败或托管关闭/handoff 期间，用 cursor/`beforeRecordId` 向前翻历史仍应返回页面，该路径不查询 writer 健康状态。

单测：`acpAgent.test.ts` 覆盖 backward/latest 的 barrier 顺序，并断言 cursor/anchor 分页在 recorder 拒绝写入时仍直接读取。

### 证据（前后对比）

前：并发加载可误报缺失；后：最新/backward 读写有序，cursor/anchor 分页仍直接读盘。单测覆盖两者。非 TUI，截图 N/A。

### 测试平台

Linux ✅；macOS/Windows N/A（单测）。

## 风险与范围

- 主要权衡：recorder 允许 barrier 时，最新/backward 读取仍等待进行中的 tool-result 写入。若仅生命周期不可用且**没有** `writeFailure`，先 `await recording.flush().catch(() => undefined)` drain 排队尾部再读盘，避免关闭/handoff 窗口丢掉已排队记录；`flush` 上的 latched `writeFailure` 被吞掉以免把尽力而为路径打回硬拒绝。barrier 准入时已锁定的 `writeFailure` 仍使读取失败。
- 不对非最新页加 barrier：Web UI 历史分页只传 `cursor`/`beforeRecordId`，直接读盘。
- 未加 gate 的 `sessionTranscript` finalize 按 active-turn 采样（忽略 `Session.closing`），避免 close gate 把已放弃的 tool call 永远留作 pending。
- 未覆盖：fork CI 需维护者 Approve；其它 session 后端。
- 破坏性变更：无。

## 关联 Issue

Fixes #9704

</details>
