### PR TITLE
fix(web-shell): remove pasted image and file chips with Backspace/Delete

### DIFF
--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -3278,3 +3278,29 @@ describe('ChatEditor file upload gating', () => {
     });
   });
 });
+
+describe('ChatEditor attachment strip order', () => {
+  it('renders the image strip before the attachments strip', () => {
+    // The Backspace-last / Delete-first chip semantics in useComposerCore
+    // depend on this DOM order (both strips are column flex children, so DOM
+    // order is visual order); a layout change that flips it must turn red.
+    const container = renderChatEditor({
+      pastedImages: [{ data: 'aGVsbG8=', media_type: 'image/png' }],
+      pastedFiles: [
+        { name: 'notes.log', media_type: 'text/plain', text: 'log' },
+      ],
+      visibleToolbarActions: [],
+    });
+    const images = container.querySelector('[data-web-shell-composer-images]')!;
+    const attachments = container.querySelector(
+      '[data-web-shell-composer-attachments]',
+    )!;
+
+    expect(images).toBeTruthy();
+    expect(attachments).toBeTruthy();
+    expect(
+      images.compareDocumentPosition(attachments) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/packages/web-shell/client/components/ChatEditor.test.tsx
+++ b/packages/web-shell/client/components/ChatEditor.test.tsx
@@ -3281,9 +3281,11 @@ describe('ChatEditor file upload gating', () => {
 
 describe('ChatEditor attachment strip order', () => {
   it('renders the image strip before the attachments strip', () => {
-    // The Backspace-last / Delete-first chip semantics in useComposerCore
-    // depend on this DOM order (both strips are column flex children, so DOM
-    // order is visual order); a layout change that flips it must turn red.
+    // Pins the JSX/DOM order the chip-deletion key semantics in
+    // useComposerCore rely on: the images strip must stay before the
+    // attachments strip. jsdom has no layout engine, so CSS `order` or
+    // `flex-direction` flips are not observable here; the rendered visual
+    // order is asserted in the e2e smoke spec.
     const container = renderChatEditor({
       pastedImages: [{ data: 'aGVsbG8=', media_type: 'image/png' }],
       pastedFiles: [

--- a/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
+++ b/packages/web-shell/client/e2e/web-shell.smoke.spec.ts
@@ -1848,6 +1848,19 @@ for (const viewportHeight of COMPOSER_VIEWPORT_HEIGHTS) {
     await expect
       .poll(async () => (await attachments.boundingBox())?.height ?? 0)
       .toBeLessThanOrEqual(136);
+
+    // The chip-deletion key semantics in useComposerCore assume the images
+    // strip renders above the attachments strip; jsdom cannot observe CSS
+    // ordering, so pin the rendered visual order here where layout is real.
+    const imagesStrip = page.locator('[data-web-shell-composer-images]');
+    await expect
+      .poll(async () => {
+        const imagesBox = await imagesStrip.boundingBox();
+        const attachmentsBox = await attachments.boundingBox();
+        if (!imagesBox || !attachmentsBox) return null;
+        return imagesBox.y <= attachmentsBox.y;
+      })
+      .toBe(true);
     await expect
       .poll(() =>
         attachments.evaluate(

--- a/packages/web-shell/client/hooks/useComposerCore.android.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.android.dom.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+//
+// Regression pin for the Android Chrome half of the attachment-chip deletion
+// keys (issue #10794 follow-up). On Android Chrome the composer mounts the
+// CodeMirror backend, which swallows the real Backspace keydown and
+// re-dispatches a synthetic event carrying only `{key, keyCode}` — the
+// repeat flag and every modifier are stripped, so the fallback's guards are
+// undeliverable there and the fallback must stay platform-disabled
+// (`isAndroidCodeMirrorComposer`). Without that gate, a held key drains
+// every pasted chip (~30/s, no undo) and a single Ctrl+Backspace destroys
+// one.
+//
+// The user-agent override must land before the imports below: CodeMirror
+// samples it once at module load (`browser.android`) to pick this input
+// path. Only the gate signal is pinned here on purpose — with the Android
+// input path active, the React harness's commits become nondeterministic in
+// jsdom (ingestion settles in ~2s to never), so an end-to-end scenario in
+// this file would be flaky rather than guarding. The desktop behavior of
+// every guard flag is pinned by useComposerCore.dom.test.tsx.
+import { vi } from 'vitest';
+
+vi.hoisted(() => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value:
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36',
+    configurable: true,
+  });
+});
+
+import { describe, expect, it } from 'vitest';
+import { isAndroidCodeMirrorComposer } from './useComposerCore';
+
+describe('useComposerCore attachment fallback on Android Chrome', () => {
+  it('arms the platform gate under an Android Chrome user agent', () => {
+    expect(isAndroidCodeMirrorComposer).toBe(true);
+  });
+});

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -2459,4 +2459,70 @@ describe('useComposerCore attachment chip deletion keys', () => {
     expect(latest!.composerTags).toHaveLength(1);
     expect(latest!.pastedImages).toHaveLength(0);
   });
+
+  it('removes a removable composer tag before pasted attachments with Delete', async () => {
+    // Delete twin of the Backspace tag-precedence test: weakening the named
+    // Delete handler's tag scan must turn red instead of destroying the image.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
+    act(() => {
+      latest!.addTags([{ id: 'orders', value: 'orders' }]);
+    });
+    expect(latest!.composerTags).toHaveLength(1);
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+      );
+    });
+
+    expect(latest!.composerTags).toHaveLength(0);
+    expect(latest!.pastedImages).toHaveLength(1);
+  });
+
+  it('removes the last pasted file with Backspace when only files are attached', async () => {
+    // Two files pin the file-side index: Backspace removes the visually last
+    // file, so 'a.log' must survive.
+    await mount();
+    const files = [
+      new File(['a'], 'a.log', { type: 'text/plain' }),
+      new File(['b'], 'b.log', { type: 'text/plain' }),
+    ];
+
+    await ingestAttachmentsAndWait(files, { images: 0, files: 2 });
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+    });
+
+    expect(latest!.pastedFiles).toMatchObject([{ name: 'a.log' }]);
+  });
+
+  it('removes the first pasted file with Delete when only files are attached', async () => {
+    // Delete twin of the file-side index pin: Delete removes the visually
+    // first file, so 'b.log' must survive. This also exercises the Delete
+    // wrapper's file branch, which no other test reaches.
+    await mount();
+    const files = [
+      new File(['a'], 'a.log', { type: 'text/plain' }),
+      new File(['b'], 'b.log', { type: 'text/plain' }),
+    ];
+
+    await ingestAttachmentsAndWait(files, { images: 0, files: 2 });
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+      );
+    });
+
+    expect(latest!.pastedFiles).toMatchObject([{ name: 'b.log' }]);
+  });
 });

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -2268,4 +2268,49 @@ describe('useComposerCore attachment chip deletion keys', () => {
     // proving Delete removed the first one.
     expect(atob(latest!.pastedImages[0].data as string)).toBe('png2');
   });
+
+  it('keeps normal Delete editing when text is present with an image attached', async () => {
+    // Review follow-up on the #10794 fix: the attachment fallback must fire
+    // only on an empty composer, so Delete at position 0 still deletes the
+    // character after the caret instead of eating the first chip.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await act(async () => {
+      expect(latest!.ingestFiles([file])).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    const view = latest!.viewRef.current!;
+    act(() => {
+      latest!.setText('abc');
+      view.dispatch({ selection: { anchor: 0 } });
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+      );
+    });
+
+    expect(view.state.doc.toString()).toBe('bc');
+    expect(latest!.pastedImages).toHaveLength(1);
+  });
+
+  it('keeps Backspace a no-op at position 0 when text is present with an image attached', async () => {
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await act(async () => {
+      expect(latest!.ingestFiles([file])).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    const view = latest!.viewRef.current!;
+    act(() => {
+      latest!.setText('abc');
+      view.dispatch({ selection: { anchor: 0 } });
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+    });
+
+    expect(view.state.doc.toString()).toBe('abc');
+    expect(latest!.pastedImages).toHaveLength(1);
+  });
 });

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -2241,18 +2241,21 @@ describe('useComposerCore attachment chip deletion keys', () => {
     });
   }
 
-  function pressChipKey(key: string, init?: KeyboardEventInit) {
+  function pressChipKey(key: string, init?: KeyboardEventInit): KeyboardEvent {
     const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key,
-          code: key,
-          bubbles: true,
-          ...init,
-        }),
-      );
+    // Real keydowns are cancelable; tests observe `defaultPrevented` to tell
+    // "handled (swallowed)" from "fell through".
+    const event = new KeyboardEvent('keydown', {
+      key,
+      code: key,
+      bubbles: true,
+      cancelable: true,
+      ...init,
     });
+    act(() => {
+      view.contentDOM.dispatchEvent(event);
+    });
+    return event;
   }
   it('removes the last pasted image with Backspace when the composer has no text or tags', async () => {
     // Regression for issue #10794: Backspace used to return false when no
@@ -2490,8 +2493,10 @@ describe('useComposerCore attachment chip deletion keys', () => {
   });
 
   it('ignores modified Backspace/Delete so editing chords cannot destroy attachment chips', async () => {
-    // Ctrl+Backspace (delete-to-line-start) and Shift+Delete (cut) are
-    // ordinary editing chords; the fallback must never fire for them.
+    // Every modifier disjunct in the fallback's guard is witnessed here:
+    // Ctrl/Cmd+Backspace (delete-to-line-start), Shift+Delete (cut), and
+    // Alt+Backspace (delete-word) are ordinary editing chords that must
+    // reach their own bindings, not destroy the chip.
     await mount();
     const file = new File(['png'], 'photo.png', { type: 'image/png' });
 
@@ -2499,6 +2504,10 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     pressChipKey('Backspace', { ctrlKey: true });
     pressChipKey('Delete', { metaKey: true });
+    pressChipKey('Backspace', { shiftKey: true });
+    pressChipKey('Delete', { shiftKey: true });
+    pressChipKey('Backspace', { altKey: true });
+    pressChipKey('Delete', { altKey: true });
 
     expect(latest!.pastedImages).toHaveLength(1);
   });
@@ -2511,8 +2520,11 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
 
-    pressChipKey('x');
+    const event = pressChipKey('x');
 
+    // The fallback must neither remove the chip nor consume the keystroke:
+    // a swallowing handler would silently block typing into the composer.
+    expect(event.defaultPrevented).toBe(false);
     expect(latest!.pastedImages).toHaveLength(1);
   });
 });

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -2240,6 +2240,20 @@ describe('useComposerCore attachment chip deletion keys', () => {
       expect(latest!.pastedFiles).toHaveLength(expected.files);
     });
   }
+
+  function pressChipKey(key: string, init?: KeyboardEventInit) {
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key,
+          code: key,
+          bubbles: true,
+          ...init,
+        }),
+      );
+    });
+  }
   it('removes the last pasted image with Backspace when the composer has no text or tags', async () => {
     // Regression for issue #10794: Backspace used to return false when no
     // removable @-tag existed, so image-only composers ignored the key.
@@ -2251,12 +2265,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     await ingestAttachmentsAndWait(files, { images: 2, files: 0 });
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
-      );
-    });
+    pressChipKey('Backspace');
 
     expect(latest!.pastedImages).toHaveLength(1);
     // data is stored base64-encoded: 'png' identifies the *first* image,
@@ -2273,12 +2282,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     await ingestAttachmentsAndWait(files, { images: 2, files: 0 });
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
-      );
-    });
+    pressChipKey('Delete');
 
     expect(latest!.pastedImages).toHaveLength(1);
     // data is stored base64-encoded: 'png2' identifies the *second* image,
@@ -2298,10 +2302,8 @@ describe('useComposerCore attachment chip deletion keys', () => {
     act(() => {
       latest!.setText('abc');
       view.dispatch({ selection: { anchor: 0 } });
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
-      );
     });
+    pressChipKey('Delete');
 
     expect(view.state.doc.toString()).toBe('bc');
     expect(latest!.pastedImages).toHaveLength(1);
@@ -2316,10 +2318,8 @@ describe('useComposerCore attachment chip deletion keys', () => {
     act(() => {
       latest!.setText('abc');
       view.dispatch({ selection: { anchor: 0 } });
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
-      );
     });
+    pressChipKey('Backspace');
 
     expect(view.state.doc.toString()).toBe('abc');
     expect(latest!.pastedImages).toHaveLength(1);
@@ -2333,23 +2333,8 @@ describe('useComposerCore attachment chip deletion keys', () => {
     const file = new File(['png'], 'photo.png', { type: 'image/png' });
 
     await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Backspace',
-          bubbles: true,
-          repeat: true,
-        }),
-      );
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Backspace',
-          bubbles: true,
-          repeat: true,
-        }),
-      );
-    });
+    pressChipKey('Backspace', { repeat: true });
+    pressChipKey('Backspace', { repeat: true });
 
     expect(latest!.pastedImages).toHaveLength(1);
   });
@@ -2361,12 +2346,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
     await ingestAttachmentsAndWait([file], { images: 0, files: 1 });
     expect(latest!.pastedFiles).toHaveLength(1);
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
-      );
-    });
+    pressChipKey('Backspace');
 
     expect(latest!.pastedFiles).toHaveLength(0);
   });
@@ -2381,12 +2361,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     await ingestAttachmentsAndWait(files, { images: 1, files: 1 });
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
-      );
-    });
+    pressChipKey('Backspace');
 
     expect(latest!.pastedFiles).toHaveLength(0);
     expect(latest!.pastedImages).toHaveLength(1);
@@ -2402,12 +2377,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     await ingestAttachmentsAndWait(files, { images: 1, files: 1 });
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
-      );
-    });
+    pressChipKey('Delete');
 
     expect(latest!.pastedImages).toHaveLength(0);
     expect(latest!.pastedFiles).toMatchObject([{ name: 'notes.log' }]);
@@ -2425,12 +2395,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
     });
     expect(latest!.composerTags).toHaveLength(1);
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
-      );
-    });
+    pressChipKey('Backspace');
 
     expect(latest!.composerTags).toHaveLength(0);
     expect(latest!.pastedImages).toHaveLength(1);
@@ -2449,12 +2414,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
     });
     expect(latest!.composerTags).toHaveLength(1);
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
-      );
-    });
+    pressChipKey('Backspace');
 
     expect(latest!.composerTags).toHaveLength(1);
     expect(latest!.pastedImages).toHaveLength(0);
@@ -2472,12 +2432,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
     });
     expect(latest!.composerTags).toHaveLength(1);
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
-      );
-    });
+    pressChipKey('Delete');
 
     expect(latest!.composerTags).toHaveLength(0);
     expect(latest!.pastedImages).toHaveLength(1);
@@ -2494,12 +2449,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     await ingestAttachmentsAndWait(files, { images: 0, files: 2 });
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
-      );
-    });
+    pressChipKey('Backspace');
 
     expect(latest!.pastedFiles).toMatchObject([{ name: 'a.log' }]);
   });
@@ -2516,13 +2466,53 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     await ingestAttachmentsAndWait(files, { images: 0, files: 2 });
 
-    const view = latest!.viewRef.current!;
-    act(() => {
-      view.contentDOM.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
-      );
-    });
+    pressChipKey('Delete');
 
     expect(latest!.pastedFiles).toMatchObject([{ name: 'b.log' }]);
+  });
+
+  it('keeps a non-removable composer tag and falls through to the pasted attachment with Delete', async () => {
+    // Delete twin of the pinned-tag test: Delete scans composerTags with its
+    // own predicate, so only *removable* tags may block the fallback here too.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
+    act(() => {
+      latest!.addTags([{ id: 'pinned', value: 'pinned', removable: false }]);
+    });
+    expect(latest!.composerTags).toHaveLength(1);
+
+    pressChipKey('Delete');
+
+    expect(latest!.composerTags).toHaveLength(1);
+    expect(latest!.pastedImages).toHaveLength(0);
+  });
+
+  it('ignores modified Backspace/Delete so editing chords cannot destroy attachment chips', async () => {
+    // Ctrl+Backspace (delete-to-line-start) and Shift+Delete (cut) are
+    // ordinary editing chords; the fallback must never fire for them.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
+
+    pressChipKey('Backspace', { ctrlKey: true });
+    pressChipKey('Delete', { metaKey: true });
+
+    expect(latest!.pastedImages).toHaveLength(1);
+  });
+
+  it('ignores non-deletion keys so ordinary typing cannot destroy attachment chips', async () => {
+    // The fallback must match the two deletion keys exactly; swallowing any
+    // other keydown would both remove a chip and eat the keystroke.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
+
+    pressChipKey('x');
+
+    expect(latest!.pastedImages).toHaveLength(1);
   });
 });

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -2221,17 +2221,35 @@ describe('useComposerCore tags', () => {
 });
 
 describe('useComposerCore attachment chip deletion keys', () => {
+  // Deterministic ingestion wait: `waitForImageIngestion` drains the batch
+  // lane, but the committed attachment state can lag the batch count by one
+  // render, so assert the expected state itself before touching the keymap.
+  async function ingestAttachmentsAndWait(
+    files: readonly File[],
+    expected: { images: number; files: number },
+  ) {
+    await act(async () => {
+      expect(latest!.ingestFiles(files)).toBe(true);
+      await waitForImageIngestion();
+    });
+    await vi.waitFor(async () => {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      expect(latest!.pastedImages).toHaveLength(expected.images);
+      expect(latest!.pastedFiles).toHaveLength(expected.files);
+    });
+  }
   it('removes the last pasted image with Backspace when the composer has no text or tags', async () => {
     // Regression for issue #10794: Backspace used to return false when no
     // removable @-tag existed, so image-only composers ignored the key.
     await mount();
-    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+    const files = [
+      new File(['png'], 'photo.png', { type: 'image/png' }),
+      new File(['png2'], 'photo2.png', { type: 'image/png' }),
+    ];
 
-    await act(async () => {
-      expect(latest!.ingestFiles([file])).toBe(true);
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
-    expect(latest!.pastedImages).toHaveLength(1);
+    await ingestAttachmentsAndWait(files, { images: 2, files: 0 });
 
     const view = latest!.viewRef.current!;
     act(() => {
@@ -2240,7 +2258,10 @@ describe('useComposerCore attachment chip deletion keys', () => {
       );
     });
 
-    expect(latest!.pastedImages).toHaveLength(0);
+    expect(latest!.pastedImages).toHaveLength(1);
+    // data is stored base64-encoded: 'png' identifies the *first* image,
+    // proving Backspace removed the last one.
+    expect(atob(latest!.pastedImages[0].data as string)).toBe('png');
   });
 
   it('removes the first pasted image with Delete when the composer has no text or tags', async () => {
@@ -2250,11 +2271,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
       new File(['png2'], 'photo2.png', { type: 'image/png' }),
     ];
 
-    await act(async () => {
-      expect(latest!.ingestFiles(files)).toBe(true);
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
-    expect(latest!.pastedImages).toHaveLength(2);
+    await ingestAttachmentsAndWait(files, { images: 2, files: 0 });
 
     const view = latest!.viewRef.current!;
     act(() => {
@@ -2276,10 +2293,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
     await mount();
     const file = new File(['png'], 'photo.png', { type: 'image/png' });
 
-    await act(async () => {
-      expect(latest!.ingestFiles([file])).toBe(true);
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
     const view = latest!.viewRef.current!;
     act(() => {
       latest!.setText('abc');
@@ -2297,10 +2311,7 @@ describe('useComposerCore attachment chip deletion keys', () => {
     await mount();
     const file = new File(['png'], 'photo.png', { type: 'image/png' });
 
-    await act(async () => {
-      expect(latest!.ingestFiles([file])).toBe(true);
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
     const view = latest!.viewRef.current!;
     act(() => {
       latest!.setText('abc');
@@ -2312,5 +2323,140 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     expect(view.state.doc.toString()).toBe('abc');
     expect(latest!.pastedImages).toHaveLength(1);
+  });
+
+  it('ignores auto-repeat Backspace so a held key cannot destroy attachment chips', async () => {
+    // A held Backspace clears the text and would then remove one chip per
+    // repeat event (~30/s) with no way back; repeats must never fire the
+    // fallback.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Backspace',
+          bubbles: true,
+          repeat: true,
+        }),
+      );
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Backspace',
+          bubbles: true,
+          repeat: true,
+        }),
+      );
+    });
+
+    expect(latest!.pastedImages).toHaveLength(1);
+  });
+
+  it('removes a pasted file with Backspace when the composer has no text or tags', async () => {
+    await mount();
+    const file = new File(['log'], 'a.log', { type: 'text/plain' });
+
+    await ingestAttachmentsAndWait([file], { images: 0, files: 1 });
+    expect(latest!.pastedFiles).toHaveLength(1);
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+    });
+
+    expect(latest!.pastedFiles).toHaveLength(0);
+  });
+
+  it('removes the pasted file before the image with Backspace for mixed attachments', async () => {
+    // Files render after images, so the visually last chip is the file.
+    await mount();
+    const files = [
+      new File(['png'], 'photo.png', { type: 'image/png' }),
+      new File(['log'], 'notes.log', { type: 'text/plain' }),
+    ];
+
+    await ingestAttachmentsAndWait(files, { images: 1, files: 1 });
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+    });
+
+    expect(latest!.pastedFiles).toHaveLength(0);
+    expect(latest!.pastedImages).toHaveLength(1);
+  });
+
+  it('removes the pasted image before the file with Delete for mixed attachments', async () => {
+    // Images render before files, so the visually first chip is the image.
+    await mount();
+    const files = [
+      new File(['png'], 'photo.png', { type: 'image/png' }),
+      new File(['log'], 'notes.log', { type: 'text/plain' }),
+    ];
+
+    await ingestAttachmentsAndWait(files, { images: 1, files: 1 });
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+      );
+    });
+
+    expect(latest!.pastedImages).toHaveLength(0);
+    expect(latest!.pastedFiles).toMatchObject([{ name: 'notes.log' }]);
+  });
+
+  it('removes a removable composer tag before pasted attachments with Backspace', async () => {
+    // The tag scan exists to give tags precedence over the attachment
+    // fallback; a later reorder that lets the fallback win must turn red.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
+    act(() => {
+      latest!.addTags([{ id: 'orders', value: 'orders' }]);
+    });
+    expect(latest!.composerTags).toHaveLength(1);
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+    });
+
+    expect(latest!.composerTags).toHaveLength(0);
+    expect(latest!.pastedImages).toHaveLength(1);
+  });
+
+  it('keeps a non-removable composer tag and falls through to the pasted attachment with Backspace', async () => {
+    // A pinned (removable: false) tag cannot be removed by the key scan, so
+    // the attachment fallback still fires on an empty composer. This pins the
+    // intended reading: only *removable* tags block the fallback.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await ingestAttachmentsAndWait([file], { images: 1, files: 0 });
+    act(() => {
+      latest!.addTags([{ id: 'pinned', value: 'pinned', removable: false }]);
+    });
+    expect(latest!.composerTags).toHaveLength(1);
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+    });
+
+    expect(latest!.composerTags).toHaveLength(1);
+    expect(latest!.pastedImages).toHaveLength(0);
   });
 });

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -2219,3 +2219,53 @@ describe('useComposerCore tags', () => {
     expect(editor.textContent).not.toContain(serialized);
   });
 });
+
+describe('useComposerCore attachment chip deletion keys', () => {
+  it('removes the last pasted image with Backspace when the composer has no text or tags', async () => {
+    // Regression for issue #10794: Backspace used to return false when no
+    // removable @-tag existed, so image-only composers ignored the key.
+    await mount();
+    const file = new File(['png'], 'photo.png', { type: 'image/png' });
+
+    await act(async () => {
+      expect(latest!.ingestFiles([file])).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(latest!.pastedImages).toHaveLength(1);
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Backspace', bubbles: true }),
+      );
+    });
+
+    expect(latest!.pastedImages).toHaveLength(0);
+  });
+
+  it('removes the first pasted image with Delete when the composer has no text or tags', async () => {
+    await mount();
+    const files = [
+      new File(['png'], 'photo.png', { type: 'image/png' }),
+      new File(['png2'], 'photo2.png', { type: 'image/png' }),
+    ];
+
+    await act(async () => {
+      expect(latest!.ingestFiles(files)).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(latest!.pastedImages).toHaveLength(2);
+
+    const view = latest!.viewRef.current!;
+    act(() => {
+      view.contentDOM.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+      );
+    });
+
+    expect(latest!.pastedImages).toHaveLength(1);
+    // data is stored base64-encoded: 'png2' identifies the *second* image,
+    // proving Delete removed the first one.
+    expect(atob(latest!.pastedImages[0].data as string)).toBe('png2');
+  });
+});

--- a/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.dom.test.tsx
@@ -2243,8 +2243,11 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
   function pressChipKey(key: string, init?: KeyboardEventInit): KeyboardEvent {
     const view = latest!.viewRef.current!;
-    // Real keydowns are cancelable; tests observe `defaultPrevented` to tell
-    // "handled (swallowed)" from "fell through".
+    // Real keydowns are cancelable so `defaultPrevented` is observable at
+    // all. Note it only discriminates for keys CodeMirror does not bind with
+    // `preventDefault` — the default keymap prevents Backspace/Delete
+    // unconditionally, so the flag is meaningful here only for other keys
+    // (e.g. the printable-key test below).
     const event = new KeyboardEvent('keydown', {
       key,
       code: key,
@@ -2493,10 +2496,11 @@ describe('useComposerCore attachment chip deletion keys', () => {
   });
 
   it('ignores modified Backspace/Delete so editing chords cannot destroy attachment chips', async () => {
-    // Every modifier disjunct in the fallback's guard is witnessed here:
-    // Ctrl/Cmd+Backspace (delete-to-line-start), Shift+Delete (cut), and
-    // Alt+Backspace (delete-word) are ordinary editing chords that must
-    // reach their own bindings, not destroy the chip.
+    // Every modifier disjunct in the fallback's guard is witnessed against
+    // both keys: Ctrl/Cmd+Backspace (delete-to-line-start), Cmd/Ctrl+Delete
+    // (delete-group), Shift+Delete (cut), and Alt+Backspace (delete-word)
+    // are ordinary editing chords that must reach their own bindings, not
+    // destroy the chip.
     await mount();
     const file = new File(['png'], 'photo.png', { type: 'image/png' });
 
@@ -2504,6 +2508,8 @@ describe('useComposerCore attachment chip deletion keys', () => {
 
     pressChipKey('Backspace', { ctrlKey: true });
     pressChipKey('Delete', { metaKey: true });
+    pressChipKey('Backspace', { metaKey: true });
+    pressChipKey('Delete', { ctrlKey: true });
     pressChipKey('Backspace', { shiftKey: true });
     pressChipKey('Delete', { shiftKey: true });
     pressChipKey('Backspace', { altKey: true });

--- a/packages/web-shell/client/hooks/useComposerCore.ios.dom.test.tsx
+++ b/packages/web-shell/client/hooks/useComposerCore.ios.dom.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+//
+// Regression pin for the iOS half of the attachment-chip deletion keys
+// (issue #10794 follow-up, round-6 review). On iOS the composer can mount
+// the CodeMirror backend, which defers bare Backspace/Delete keydowns into
+// PendingKeys and replays them ~250ms later via flushIOSKey as synthetic
+// events built from the static PendingKeys entry — the replayed event never
+// carries the repeat flag, so a held key drains every pasted chip and the
+// fallback's auto-repeat guard is undeliverable. The fallback must stay
+// platform-disabled on iOS (`isIosCodeMirrorComposer`); without the widened
+// gate a held key drains both chips.
+//
+// The user-agent override must land before the imports below: CodeMirror
+// samples it once at module load (`browser.ios`) to pick this input path.
+// Only the UA needs overriding: jsdom's own navigator.vendor already
+// contains "Apple Computer", which satisfies the vendor half of the
+// detection. (navigator.maxTouchPoints is not redefinable in jsdom, so the
+// iPadOS 13+ maxTouchPoints disjunct is not exercised here — the mobile-UA
+// disjunct is.)
+//
+// Only the gate signal is pinned here on purpose: with a mobile input path
+// active, the React harness's commits become nondeterministic in jsdom
+// (ingestion settles in ~2s to never), so a full behavioral scenario in this
+// file would be flaky rather than guarding. The desktop behavior of every
+// guard flag is pinned by useComposerCore.dom.test.tsx.
+import { vi } from 'vitest';
+
+vi.hoisted(() => {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value:
+      'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+    configurable: true,
+  });
+});
+
+import { describe, expect, it } from 'vitest';
+import { isIosCodeMirrorComposer } from './useComposerCore';
+
+describe('useComposerCore attachment fallback on iOS', () => {
+  it('arms the platform gate under an iPadOS user agent with touch points', () => {
+    expect(isIosCodeMirrorComposer).toBe(true);
+  });
+});

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -113,28 +113,26 @@ import {
   type ExtractedFileTransfer,
 } from '../utils/imageIngestion';
 
-// On Android Chrome the composer mounts the CodeMirror backend whenever the
-// `(hover: none) and (pointer: coarse)` media query does not match (tablets,
-// DeX with a mouse) or via the `?composer=codemirror` escape hatch. There,
-// CodeMirror swallows the real Backspace/Enter keydown and re-dispatches a
-// synthetic event carrying only `{key, keyCode}`: no repeat flag and no
-// modifier state survive (@codemirror/view InputState.keydown +
-// delayAndroidKey). Every guard in the attachment fallback below would see a
-// plain Backspace there, so a held key would drain every chip (~30/s, no
-// undo) and a single Ctrl+Backspace would destroy one. The flags are
-// undeliverable on that platform, so the keyboard fallback stays off and the
-// chips remain removable through their close buttons.
-// On Android Chrome the composer mounts the CodeMirror backend whenever the
-// `(hover: none) and (pointer: coarse)` media query does not match (tablets,
-// DeX with a mouse) or via the `?composer=codemirror` escape hatch. There,
-// CodeMirror swallows the real Backspace/Enter keydown and re-dispatches a
-// synthetic event carrying only `{key, keyCode}`: no repeat flag and no
-// modifier state survive (@codemirror/view InputState.keydown +
-// delayAndroidKey). Every guard in the attachment fallback below would see a
-// plain Backspace there, so a held key would drain every chip (~30/s, no
-// undo) and a single Ctrl+Backspace would destroy one. The flags are
-// undeliverable on that platform, so the keyboard fallback stays off and the
-// chips remain removable through their close buttons.
+// On Android Chrome and iOS, the composer can mount the CodeMirror backend
+// (Android: whenever `(hover: none) and (pointer: coarse)` does not match —
+// tablets, DeX with a mouse — or via the `?composer=codemirror` escape
+// hatch; iOS: the same escape hatch, and iPadOS 13+ with a pointer, which
+// reports a desktop user agent). There, CodeMirror swallows the real
+// Backspace keydown and re-dispatches a synthetic event that does not
+// carry the information the guards below rely on (@codemirror/view
+// delayAndroidKey on Android strips the repeat flag and every modifier;
+// flushIOSKey on iOS defers bare Backspace/Delete and replays them without
+// the repeat flag). A held key would drain every chip (~30/s, no undo), and
+// on Android a single Ctrl+Backspace would destroy one. The flags are
+// undeliverable on those platforms, so the keyboard fallback stays off and
+// the chips remain removable through their close buttons.
+// Mirrors @codemirror/view's own browser.ios detection (vendor + mobile UA
+// or iPadOS 13+ maxTouchPoints).
+// Mirrors @codemirror/view's own browser.ios detection (vendor + mobile UA
+// or iPadOS 13+ maxTouchPoints).
+export const isIosCodeMirrorComposer =
+  /Apple Computer/.test(navigator.vendor) &&
+  (/Mobile\/\w+/.test(navigator.userAgent) || navigator.maxTouchPoints > 2);
 export const isAndroidCodeMirrorComposer = /\bAndroid\b/.test(
   navigator.userAgent,
 );
@@ -2995,7 +2993,8 @@ export function useComposerCore(
         // only on an otherwise-empty composer: with text present, Backspace
         // at position 0 stays a no-op and Delete keeps deleting characters.
         any: (view, event) => {
-          if (isAndroidCodeMirrorComposer) return false;
+          if (isAndroidCodeMirrorComposer || isIosCodeMirrorComposer)
+            return false;
           if (!event || (event.key !== 'Backspace' && event.key !== 'Delete')) {
             return false;
           }

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -2906,7 +2906,19 @@ export function useComposerCore(
               break;
             }
           }
-          if (removableIndex < 0) return false;
+          if (removableIndex < 0) {
+            // No @-tags to remove: fall back to the last pasted attachment
+            // (files render after images) so Backspace still deletes a chip.
+            if (pastedFilesRef.current.length > 0) {
+              removeFile(pastedFilesRef.current.length - 1);
+              return true;
+            }
+            if (pastedImagesRef.current.length > 0) {
+              removeImage(pastedImagesRef.current.length - 1);
+              return true;
+            }
+            return false;
+          }
           setComposerTags((current) =>
             current.filter((_, index) => index !== removableIndex),
           );
@@ -2926,7 +2938,19 @@ export function useComposerCore(
           const removableIndex = composerTagsRef.current.findIndex(
             (tag) => tag.removable !== false,
           );
-          if (removableIndex < 0) return false;
+          if (removableIndex < 0) {
+            // No @-tags to remove: fall back to the first pasted attachment
+            // (images render before files) so Delete still deletes a chip.
+            if (pastedImagesRef.current.length > 0) {
+              removeImage(0);
+              return true;
+            }
+            if (pastedFilesRef.current.length > 0) {
+              removeFile(0);
+              return true;
+            }
+            return false;
+          }
           setComposerTags((current) =>
             current.filter((_, index) => index !== removableIndex),
           );

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -113,6 +113,31 @@ import {
   type ExtractedFileTransfer,
 } from '../utils/imageIngestion';
 
+// On Android Chrome the composer mounts the CodeMirror backend whenever the
+// `(hover: none) and (pointer: coarse)` media query does not match (tablets,
+// DeX with a mouse) or via the `?composer=codemirror` escape hatch. There,
+// CodeMirror swallows the real Backspace/Enter keydown and re-dispatches a
+// synthetic event carrying only `{key, keyCode}`: no repeat flag and no
+// modifier state survive (@codemirror/view InputState.keydown +
+// delayAndroidKey). Every guard in the attachment fallback below would see a
+// plain Backspace there, so a held key would drain every chip (~30/s, no
+// undo) and a single Ctrl+Backspace would destroy one. The flags are
+// undeliverable on that platform, so the keyboard fallback stays off and the
+// chips remain removable through their close buttons.
+// On Android Chrome the composer mounts the CodeMirror backend whenever the
+// `(hover: none) and (pointer: coarse)` media query does not match (tablets,
+// DeX with a mouse) or via the `?composer=codemirror` escape hatch. There,
+// CodeMirror swallows the real Backspace/Enter keydown and re-dispatches a
+// synthetic event carrying only `{key, keyCode}`: no repeat flag and no
+// modifier state survive (@codemirror/view InputState.keydown +
+// delayAndroidKey). Every guard in the attachment fallback below would see a
+// plain Backspace there, so a held key would drain every chip (~30/s, no
+// undo) and a single Ctrl+Backspace would destroy one. The flags are
+// undeliverable on that platform, so the keyboard fallback stays off and the
+// chips remain removable through their close buttons.
+export const isAndroidCodeMirrorComposer = /\bAndroid\b/.test(
+  navigator.userAgent,
+);
 const TOOLTIP_STYLE_ID = 'web-shell-tooltip-styles';
 const TOOLTIP_STYLES = `
 [data-web-shell-tooltip-portal] {
@@ -2970,6 +2995,7 @@ export function useComposerCore(
         // only on an otherwise-empty composer: with text present, Backspace
         // at position 0 stays a no-op and Delete keeps deleting characters.
         any: (view, event) => {
+          if (isAndroidCodeMirrorComposer) return false;
           if (!event || (event.key !== 'Backspace' && event.key !== 'Delete')) {
             return false;
           }

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -129,11 +129,11 @@ import {
 // Mirrors @codemirror/view's own browser.ios detection (vendor + mobile UA
 // or iPadOS 13+ maxTouchPoints).
 export const isIosCodeMirrorComposer =
+  typeof navigator !== 'undefined' &&
   /Apple Computer/.test(navigator.vendor) &&
   (/Mobile\/\w+/.test(navigator.userAgent) || navigator.maxTouchPoints > 2);
-export const isAndroidCodeMirrorComposer = /\bAndroid\b/.test(
-  navigator.userAgent,
-);
+export const isAndroidCodeMirrorComposer =
+  typeof navigator !== 'undefined' && /\bAndroid\b/.test(navigator.userAgent);
 const TOOLTIP_STYLE_ID = 'web-shell-tooltip-styles';
 const TOOLTIP_STYLES = `
 [data-web-shell-tooltip-portal] {

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -2909,6 +2909,9 @@ export function useComposerCore(
           if (removableIndex < 0) {
             // No @-tags to remove: fall back to the last pasted attachment
             // (files render after images) so Backspace still deletes a chip.
+            // Only on an otherwise-empty composer: with text present, Backspace
+            // at position 0 is a no-op and must stay one.
+            if (view.state.doc.length !== 0) return false;
             if (pastedFilesRef.current.length > 0) {
               removeFile(pastedFilesRef.current.length - 1);
               return true;
@@ -2941,6 +2944,9 @@ export function useComposerCore(
           if (removableIndex < 0) {
             // No @-tags to remove: fall back to the first pasted attachment
             // (images render before files) so Delete still deletes a chip.
+            // Only on an otherwise-empty composer: with text present, Delete at
+            // position 0 must keep deleting the character after the caret.
+            if (view.state.doc.length !== 0) return false;
             if (pastedImagesRef.current.length > 0) {
               removeImage(0);
               return true;

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -128,8 +128,6 @@ import {
 // the chips remain removable through their close buttons.
 // Mirrors @codemirror/view's own browser.ios detection (vendor + mobile UA
 // or iPadOS 13+ maxTouchPoints).
-// Mirrors @codemirror/view's own browser.ios detection (vendor + mobile UA
-// or iPadOS 13+ maxTouchPoints).
 export const isIosCodeMirrorComposer =
   /Apple Computer/.test(navigator.vendor) &&
   (/Mobile\/\w+/.test(navigator.userAgent) || navigator.maxTouchPoints > 2);

--- a/packages/web-shell/client/hooks/useComposerCore.ts
+++ b/packages/web-shell/client/hooks/useComposerCore.ts
@@ -2888,6 +2888,33 @@ export function useComposerCore(
       return true;
     };
 
+    // Attachment fallback for the Backspace/Delete handlers below (issue
+    // #10794). Files render after images in the composer, so the visually
+    // last chip is a file when one exists and the visually first chip is an
+    // image — matching how the same keys already treat composer tags.
+    const removeLastAttachment = (): boolean => {
+      if (pastedFilesRef.current.length > 0) {
+        removeFile(pastedFilesRef.current.length - 1);
+        return true;
+      }
+      if (pastedImagesRef.current.length > 0) {
+        removeImage(pastedImagesRef.current.length - 1);
+        return true;
+      }
+      return false;
+    };
+    const removeFirstAttachment = (): boolean => {
+      if (pastedImagesRef.current.length > 0) {
+        removeImage(0);
+        return true;
+      }
+      if (pastedFilesRef.current.length > 0) {
+        removeFile(0);
+        return true;
+      }
+      return false;
+    };
+
     const submitKeymap = keymap.of([
       {
         key: 'Backspace',
@@ -2906,22 +2933,7 @@ export function useComposerCore(
               break;
             }
           }
-          if (removableIndex < 0) {
-            // No @-tags to remove: fall back to the last pasted attachment
-            // (files render after images) so Backspace still deletes a chip.
-            // Only on an otherwise-empty composer: with text present, Backspace
-            // at position 0 is a no-op and must stay one.
-            if (view.state.doc.length !== 0) return false;
-            if (pastedFilesRef.current.length > 0) {
-              removeFile(pastedFilesRef.current.length - 1);
-              return true;
-            }
-            if (pastedImagesRef.current.length > 0) {
-              removeImage(pastedImagesRef.current.length - 1);
-              return true;
-            }
-            return false;
-          }
+          if (removableIndex < 0) return false;
           setComposerTags((current) =>
             current.filter((_, index) => index !== removableIndex),
           );
@@ -2941,26 +2953,39 @@ export function useComposerCore(
           const removableIndex = composerTagsRef.current.findIndex(
             (tag) => tag.removable !== false,
           );
-          if (removableIndex < 0) {
-            // No @-tags to remove: fall back to the first pasted attachment
-            // (images render before files) so Delete still deletes a chip.
-            // Only on an otherwise-empty composer: with text present, Delete at
-            // position 0 must keep deleting the character after the caret.
-            if (view.state.doc.length !== 0) return false;
-            if (pastedImagesRef.current.length > 0) {
-              removeImage(0);
-              return true;
-            }
-            if (pastedFilesRef.current.length > 0) {
-              removeFile(0);
-              return true;
-            }
-            return false;
-          }
+          if (removableIndex < 0) return false;
           setComposerTags((current) =>
             current.filter((_, index) => index !== removableIndex),
           );
           return true;
+        },
+      },
+      {
+        // Attachment-chip fallback for the two keys above. Lives in the `any`
+        // slot — the only keymap slot that receives the KeyboardEvent — so it
+        // can skip OS auto-repeat (a held key must not destroy every chip,
+        // one per event, with no way back) and match only the bare,
+        // unmodified keys, exactly like the named bindings above. It runs
+        // after those named bindings returned false (no removable tag), and
+        // only on an otherwise-empty composer: with text present, Backspace
+        // at position 0 stays a no-op and Delete keeps deleting characters.
+        any: (view, event) => {
+          if (!event || (event.key !== 'Backspace' && event.key !== 'Delete')) {
+            return false;
+          }
+          if (
+            event.repeat ||
+            event.altKey ||
+            event.ctrlKey ||
+            event.metaKey ||
+            event.shiftKey
+          ) {
+            return false;
+          }
+          if (view.state.doc.length !== 0) return false;
+          return event.key === 'Backspace'
+            ? removeLastAttachment()
+            : removeFirstAttachment();
         },
       },
       {


### PR DESCRIPTION
## What this PR does

Lets the composer's Backspace and Delete keys remove pasted image and file chips on an otherwise-empty composer: Backspace removes the visually last chip (a file, since files render after images) and Delete removes the visually first (an image), mirroring how the same keys already remove composer tags. The fallback only fires for bare, unmodified, non-auto-repeat keydowns, and only when the composer holds no text; with text present, Backspace at position 0 stays a no-op and Delete keeps deleting characters. On Android Chrome and iOS — where CodeMirror re-dispatches Backspace keydowns as synthetic events without the repeat flag or modifier state — the keyboard fallback is intentionally platform-disabled, and chips remain removable through their ✕ buttons as before.

## Why it's needed

The keymap handlers only scanned `composerTagsRef` for a removable tag and returned false otherwise, so a composer holding only pasted images or files ignored Backspace and Delete entirely — the chips could only be removed by clicking each ✕ button. This is issue #10794; the triage on that issue confirms the same root cause and fix direction.

## Reviewer Test Plan

### How to verify

Paste an image into the web-shell composer so it shows only the image chip (no text, no `@`-tag), then press Backspace: the chip is removed (on `main` the key does nothing). Repeat with Delete: the first chip is removed. With mixed images and files, Backspace removes the rightmost chip and Delete the leftmost, matching the on-screen order. With text present the keys keep their normal editing behavior. Holding Backspace never drains chips, and modified chords (Ctrl/Cmd+Backspace, Shift/Ctrl/Cmd+Delete) are ignored by the fallback.

### Evidence (Before & After)

Before: composer with only a pasted image — pressing Backspace or Delete does nothing and the chip stays until clicked.

After: Backspace removes the last chip and Delete removes the first chip; the pasted-attachments state shrinks accordingly.

Automated evidence: 18 new regression tests across `useComposerCore.dom.test.tsx` (behavior matrix: chip identity, ordering, text-present no-ops, auto-repeat, modified chords, non-deletion keys, tag precedence, non-removable tags), plus per-platform gate pins in `useComposerCore.android.dom.test.tsx` and `useComposerCore.ios.dom.test.tsx`. Running `npx vitest run` in `packages/web-shell` gives 268 files / 6035 tests passed on this branch; typecheck and ESLint are clean on the touched files (lint-staged prettier + eslint --fix also pass via the repo pre-commit hook).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |   ✅   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — unit-level verification only (jsdom component tests driving the real hook and CodeMirror editor).

## Risk & Scope

- Main risk or tradeoff: behavior changes only in the no-tag fallback branch of the two keymap handlers; for mixed image/file composers the Backspace removal order (files before images) is a judgment call that can be flipped in review if maintainers prefer images-first.
- Not validated / out of scope: on Android Chrome and iOS the keyboard fallback is deliberately disabled (CodeMirror's input paths strip the repeat flag and/or modifiers from the events the keymap sees, so the guards cannot be trusted there); no full visual/manual browser run was performed; no changes to tag handling, attachment ingestion, or submit paths.
- Breaking changes / migration notes: none.

## Linked Issues

Addresses #10794 — the reported desktop symptom is fixed. On Android Chrome and iOS CodeMirror composers the keyboard fallback is intentionally left off because the platform strips the event flags the guards rely on; chips there remain removable via their ✕ buttons (same as before this PR). Happy to flip to a closing keyword if maintainers consider the desktop scope sufficient.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 composer 的 Backspace / Delete 键在"只有附件的空输入框"上删除粘贴的图片/文件芯片：Backspace 删除视觉上最后一个芯片（文件渲染在图片之后），Delete 删除视觉上第一个（图片渲染在文件之前），与现有 tag 删除语义保持镜像。回退只对"无修饰键、非自动重复的裸按键"生效，且仅当输入框没有文字；有文字时，位置 0 的 Backspace 保持无操作，Delete 继续删除字符。在 Android Chrome 和 iOS 上——CodeMirror 会把 Backspace keydown 重派发为不含 repeat 标志和修饰键状态的合成事件——键盘回退有意按平台关闭，芯片照旧通过 ✕ 按钮删除。

## 为什么需要

原 keymap 处理器只遍历 composerTagsRef，找不到可删 tag 就直接返回 false，因此输入框只有粘贴图片/文件时按 Backspace/Delete 完全无响应，只能逐个点击 ✕ 删除。这是 issue #10794，该 issue 的官方 triage 给出了相同的根因定位和修复方向。

## 审阅测试计划

### 如何验证

在 web-shell 输入框只粘贴一张图片（无文字、无 @tag），按 Backspace：芯片被删除（main 上按键无响应）；按 Delete 则删除第一个芯片。混合图片和文件时，Backspace 删最右、Delete 删最左，与屏幕顺序一致。有文字时按键保持原生编辑行为。长按 Backspace 不会连续清空芯片，修饰键组合（Ctrl/Cmd+Backspace、Shift/Ctrl/Cmd+Delete）不会被回退处理。

### 证据（前后对比）

Before：只有一张粘贴图片的 composer，按 Backspace / Delete 无任何反应，芯片保留。

After：Backspace 删除最后一个芯片，Delete 删除第一个芯片，粘贴附件状态相应减少。

自动化证据：在 `useComposerCore.dom.test.tsx` 新增 18 个回归测试（行为矩阵：芯片身份、顺序、有文字时的无操作、自动重复、修饰键组合、非删除键、tag 优先级、不可删 tag），并在 `useComposerCore.android.dom.test.tsx` 与 `useComposerCore.ios.dom.test.tsx` 各自钉住平台门控信号。在 `packages/web-shell` 运行 `npx vitest run`：本分支 268 文件 / 6035 测试全部通过；所改文件 typecheck、ESLint 干净（仓库 pre-commit 钩子的 prettier + eslint --fix 也通过）。

### 测试平台

Windows ✅；macOS / Linux 未测（N/A）。

## 风险与范围

- 主要风险：仅两个 keymap 处理器的"无 tag"分支新增回退；混合内容时 Backspace 的删除顺序（文件优先）如维护者偏好图片优先可在 review 时一行对调。
- 未验证 / 范围外：Android Chrome 与 iOS 上键盘回退有意按平台关闭（对应平台的 CodeMirror 输入路径会剥离守卫依赖的事件标志）；未做完整浏览器可视化手测；未改动 tag 处理、附件上传与提交路径。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Addresses #10794——issue 报告的桌面症状已修复。Android Chrome 与 iOS 的 CodeMirror composer 上键盘回退有意保持关闭（对应平台会剥离守卫依赖的事件标志，芯片仍可通过 ✕ 按钮删除，与本 PR 之前一致）。如维护者认为桌面范围足够，可以改回关闭关键词。
</details>
