### PR TITLE
fix(cli): keep full-turn tool cancellation out of the error path

### DIFF
--- a/packages/cli/src/ui/hooks/useReactToolScheduler.ts
+++ b/packages/cli/src/ui/hooks/useReactToolScheduler.ts
@@ -245,6 +245,40 @@ export function useReactToolScheduler(
             });
           await scheduler.schedule(request, signal, runtimeView);
         } catch (error) {
+          const requests = Array.isArray(request) ? request : [request];
+          if (signal.aborted) {
+            // The busy scheduler rejects a queued request once its signal
+            // aborts, which is a cancellation rather than a scheduling
+            // failure. Completing it as `cancelled` — instead of returning
+            // early — still runs the caller's completion path, the only place
+            // that releases the batch and continuation ownership registered
+            // for these callIds.
+            const reason =
+              '[Operation Cancelled] Reason: Tool call cancelled before execution.';
+            const cancelledCalls: CompletedToolCall[] = requests.map(
+              (toolRequest) => ({
+                status: 'cancelled',
+                request: toolRequest,
+                response: {
+                  callId: toolRequest.callId,
+                  responseParts: convertToFunctionErrorResponse(
+                    toolRequest.name,
+                    toolRequest.callId,
+                    reason,
+                    reason,
+                  ),
+                  resultDisplay: undefined,
+                  error: undefined,
+                  errorType: undefined,
+                  executionStatus: 'not_started',
+                  contentLength: reason.length,
+                },
+                durationMs: 0,
+              }),
+            );
+            await allToolCallsCompleteHandler(cancelledCalls);
+            return;
+          }
           debugLogger.error(
             `Full-turn tool scheduling failed: ${
               error instanceof Error ? error.message : String(error)
@@ -252,7 +286,6 @@ export function useReactToolScheduler(
           );
           const message =
             'Full-turn tool scheduling failed. The tool was not executed.';
-          const requests = Array.isArray(request) ? request : [request];
           const completedCalls: CompletedToolCall[] = requests.map(
             (toolRequest) => {
               const toolError = new Error(message);

--- a/packages/cli/src/ui/hooks/useToolScheduler.test.ts
+++ b/packages/cli/src/ui/hooks/useToolScheduler.test.ts
@@ -34,6 +34,7 @@ import {
   CoreToolScheduler,
   getRuntimeContentGenerator,
   MockTool,
+  ToolErrorType,
 } from '@qwen-code/qwen-code-core';
 import { ToolCallStatus } from '../types.js';
 
@@ -453,6 +454,7 @@ describe('useReactToolScheduler', () => {
             message: expect.stringContaining('tool was not executed'),
           }),
           executionStatus: 'not_started',
+          errorType: ToolErrorType.UNHANDLED_EXCEPTION,
         }),
       }),
     ]);
@@ -501,6 +503,143 @@ describe('useReactToolScheduler', () => {
           error: expect.objectContaining({
             message: expect.stringContaining('tool was not executed'),
           }),
+          executionStatus: 'not_started',
+          errorType: ToolErrorType.UNHANDLED_EXCEPTION,
+        }),
+      }),
+    ]);
+    scheduleSpy.mockRestore();
+  });
+
+  it('keeps a full-turn cancellation when the signal aborts while the request is queued', async () => {
+    mockToolRegistry.getTool.mockReturnValue(mockTool);
+    const runtimeView = {
+      contentGenerator: {},
+      contentGeneratorConfig: {
+        model: 'vision-agent',
+        authType: 'openai',
+      },
+      model: 'vision-agent',
+    };
+    (mockConfig.getBaseLlmClient as Mock).mockReturnValue({
+      resolveForModel: vi.fn().mockResolvedValue(runtimeView),
+    });
+    // Mirrors the busy-scheduler branch of CoreToolScheduler.schedule: the
+    // request parks in the queue and its abort listener rejects with the
+    // queue-cancellation error.
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockImplementation(
+        (_request, signal) =>
+          new Promise<void>((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => reject(new Error('Tool call cancelled while in queue.')),
+              { once: true },
+            );
+          }),
+      );
+    const { result } = renderScheduler();
+    const request = {
+      callId: 'queued-full-turn-call',
+      name: 'mockTool',
+      args: {},
+    } as ToolCallRequestInfo;
+    const abortController = new AbortController();
+
+    act(() => {
+      result.current[1]([request], abortController.signal, 'vision-agent\0');
+    });
+    // Let resolveForModel settle so the request is queued before the abort.
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(scheduleSpy).toHaveBeenCalled();
+
+    act(() => {
+      abortController.abort();
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(mockTool.execute).not.toHaveBeenCalled();
+    expect(result.current[0]).toEqual([]);
+    expect(
+      onComplete.mock.calls
+        .flat(Infinity)
+        .filter(
+          (toolCall: any) =>
+            toolCall?.status === 'error' ||
+            toolCall?.response?.errorType === ToolErrorType.UNHANDLED_EXCEPTION,
+        ),
+    ).toEqual([]);
+    // The cancelled call still travels the completion path so the caller
+    // releases the batch and continuation ownership it registered.
+    expect(onComplete).toHaveBeenCalledWith([
+      expect.objectContaining({
+        status: 'cancelled',
+        request,
+        response: expect.objectContaining({
+          callId: request.callId,
+          errorType: undefined,
+          executionStatus: 'not_started',
+        }),
+      }),
+    ]);
+    scheduleSpy.mockRestore();
+  });
+
+  it('keeps a full-turn cancellation when the signal is already aborted before scheduling', async () => {
+    mockToolRegistry.getTool.mockReturnValue(mockTool);
+    const runtimeView = {
+      contentGenerator: {},
+      contentGeneratorConfig: {
+        model: 'vision-agent',
+        authType: 'openai',
+      },
+      model: 'vision-agent',
+    };
+    (mockConfig.getBaseLlmClient as Mock).mockReturnValue({
+      resolveForModel: vi.fn().mockResolvedValue(runtimeView),
+    });
+    const scheduleSpy = vi
+      .spyOn(CoreToolScheduler.prototype, 'schedule')
+      .mockRejectedValueOnce(new Error('Tool call cancelled while in queue.'));
+    const { result } = renderScheduler();
+    const request = {
+      callId: 'pre-aborted-full-turn-call',
+      name: 'mockTool',
+      args: {},
+    } as ToolCallRequestInfo;
+    const abortController = new AbortController();
+    abortController.abort();
+
+    act(() => {
+      result.current[1]([request], abortController.signal, 'vision-agent\0');
+    });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(mockTool.execute).not.toHaveBeenCalled();
+    expect(result.current[0]).toEqual([]);
+    expect(
+      onComplete.mock.calls
+        .flat(Infinity)
+        .filter(
+          (toolCall: any) =>
+            toolCall?.status === 'error' ||
+            toolCall?.response?.errorType === ToolErrorType.UNHANDLED_EXCEPTION,
+        ),
+    ).toEqual([]);
+    expect(onComplete).toHaveBeenCalledWith([
+      expect.objectContaining({
+        status: 'cancelled',
+        request,
+        response: expect.objectContaining({
+          callId: request.callId,
+          errorType: undefined,
           executionStatus: 'not_started',
         }),
       }),


### PR DESCRIPTION
## What this PR does

Makes the React full-turn tool path classify an aborted scheduling attempt as a cancellation instead of a failure. `useReactToolScheduler`'s full-turn branch now checks `signal.aborted` in its catch block and, when the signal is aborted, completes the batch as `status: 'cancelled'` through the same `allToolCallsCompleteHandler` the scheduler already uses. It no longer builds synthetic `status: 'error'` / `ToolErrorType.UNHANDLED_EXCEPTION` calls, and no longer appends them to the active tool list.

Genuine failures keep their existing behaviour: when the signal is not aborted, a runtime-resolution failure or a scheduling rejection still produces `UNHANDLED_EXCEPTION` with `executionStatus: 'not_started'`, exactly as before.

## Why it's needed

The two scheduling branches in `useReactToolScheduler` disagreed. The normal branch swallows a rejected `schedule()` when `signal.aborted` is true (`if (signal.aborted) return;`). The full-turn branch awaited `resolveForModel()` and then treated every rejection as a genuine failure, with no `signal.aborted` check anywhere in its catch.

When the shared `CoreToolScheduler` is busy, `schedule()` parks the request in `requestQueue` and registers an abort listener that rejects with `new Error('Tool call cancelled while in queue.')`. That is a cancellation, but the full-turn catch converted it into a synthetic error group and called `allToolCallsCompleteHandler`. Downstream that is worse than a stray UI card: `use-llm-stream.ts` commits the group to history via `addItem` before dispatching completed tools, `recordToolResult` runs for every ordered response before the `continuationWasCancelled()` and `allToolsCancelled` checks, and `allToolsCancelled` tests `status === 'cancelled'` while the synthetic call was `'error'` — so that escape hatch never fired. Net effect: a user pressing Esc was persisted to the chat recording and submitted to the model as a genuine `UNHANDLED_EXCEPTION` tool result.

Routing the cancellation through the completion handler (rather than an early `return`) is the part that matters beyond suppressing the error. The three per-call ownership maps are released only on the completion path — `toolBatchIdByCallIdRef` in `onComplete`'s `finally`, and `interactionOwnersByToolCallIdRef` / `continuationOwnersByToolCallIdRef` in `handleCompletedTools`. `handleCompletedTools` admits `status === 'cancelled'` calls into `completedAndReadyToSubmitTools`, and `CompletedToolCall` already includes `CancelledToolCall`, so a bare early `return` would have leaked all three entries for the cancelled callIds. This is the single cancellation cleanup path the report asked for, and it also makes `allToolsCancelled` fire so nothing is submitted as a tool error.

## Reviewer Test Plan

### How to verify

Reproduced first against unmodified `main` @ `1b604721b053da4e104ff610e1a925fe8c9ca488` (the commit in the report), then re-run with the fix.

Two new tests in `packages/cli/src/ui/hooks/useToolScheduler.test.ts`, one per cancellation timing named in the report:

- `keeps a full-turn cancellation when the signal aborts while the request is queued` — resolves a valid full-turn runtime view, replaces `CoreToolScheduler.prototype.schedule` with the busy-scheduler behaviour (request parked, abort listener rejecting with `Tool call cancelled while in queue.`), lets `resolveForModel()` settle so the request is genuinely queued, then aborts.
- `keeps a full-turn cancellation when the signal is already aborted before scheduling` — aborts the controller first, then schedules against a `schedule()` that rejects with the same queue-cancellation error.

Both assert: the tool never executes, the active tool list stays empty, no completion carries `status: 'error'` or `errorType: UNHANDLED_EXCEPTION`, and a `status: 'cancelled'` completion with `errorType: undefined` / `executionStatus: 'not_started'` is still emitted (that emission is what releases the ownership metadata).

Before the fix both failed:

```text
FAIL  src/ui/hooks/useToolScheduler.test.ts > useReactToolScheduler > keeps a full-turn cancellation when the signal aborts while the request is queued
AssertionError: expected [ { status: 'error', …(2) } ] to deeply equal []

- []
+ [
+   {
+     "request": { "args": {}, "callId": "queued-full-turn-call", "name": "mockTool" },
+     "response": {
+       "callId": "queued-full-turn-call",
+       "error": Error { "message": "Full-turn tool scheduling failed. The tool was not executed." },
+       "errorType": "unhandled_exception",
+       "executionStatus": "not_started",
+       "resultDisplay": "Full-turn tool scheduling failed. The tool was not executed.",
+     },
+     "status": "error",
+   },
+ ]

 ❯ src/ui/hooks/useToolScheduler.test.ts:565:31
    565|     expect(result.current[0]).toEqual([]);
```

The pre-aborted variant failed identically on `pre-aborted-full-turn-call`.

The two existing fail-closed tests were left in place and now assert `errorType: ToolErrorType.UNHANDLED_EXCEPTION` explicitly, so the fail-closed contract the report asks to preserve is locked rather than implied:

- `fails closed when the full-turn tool runtime cannot be resolved`
- `fails closed when full-turn tool scheduling rejects`

Commands:

```bash
npx vitest run src/ui/hooks/useToolScheduler.test.ts --root packages/cli --reporter=verbose
npm run typecheck --workspace=packages/cli
npx eslint packages/cli/src/ui/hooks/useReactToolScheduler.ts packages/cli/src/ui/hooks/useToolScheduler.test.ts
npx prettier --check packages/cli/src/ui/hooks/useReactToolScheduler.ts packages/cli/src/ui/hooks/useToolScheduler.test.ts
```

Results:

```text
 ✓ fails closed when the full-turn tool runtime cannot be resolved 3ms
 ✓ fails closed when full-turn tool scheduling rejects 3ms
 ✓ keeps a full-turn cancellation when the signal aborts while the request is queued 4ms
 ✓ keeps a full-turn cancellation when the signal is already aborted before scheduling 3ms
 Test Files  1 passed (1)
      Tests  26 passed (26)
```

eslint: no findings. prettier: `All matched files use Prettier code style!`

typecheck: clean apart from a pre-existing local baseline. `npm run typecheck --workspace=packages/cli` reports exactly two `TS6305` errors, both in `src/ui/voice/native-audio-recorder.ts`, both about `packages/audio-capture/dist/index.d.ts` not being built. That package cannot be built on this machine (node-gyp failure) and the errors are unrelated to this change — no error names a file this PR touches.

### Evidence (Before & After)

N/A for interactive capture — see the note below; the before/after evidence is the failing/passing hook test output above.

No interactive TUI capture was produced, deliberately. Reaching this path in a live session needs a narrow conjunction: a skill or subagent pinning a model via `modelOverride` ending in `\0`, the shared `CoreToolScheduler` busy enough to queue the call, and an abort landing inside that window. That is not something a scripted tmux session can trigger reliably, and a hand-drawn or staged capture would be worse evidence than the deterministic hook test, which drives the real `useReactToolScheduler` against the real queue-cancellation error. Flagging it explicitly rather than implying it was done.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### Environment (optional)

Unit tests only (`npx vitest run ... --root packages/cli`), no live runtime.

## Risk & Scope

- Main risk or tradeoff: an aborted full-turn batch now completes as `cancelled` instead of `error`, so it travels the completion path — `addItem` commits a cancelled tool group to history and `recordToolResult` records `status: 'cancelled'`. That is the same treatment every other cancelled tool call gets, and `allToolsCancelled` then short-circuits submission, but it is a behaviour change on the cancellation path rather than a pure suppression.
- Not validated / out of scope: `packages/core/src/core/coreToolScheduler.ts` is intentionally untouched. The related #11146 (a busy scheduler not rejecting a signal that was already aborted before queue registration) is the core request-queue half and stays a separate change — moving a pre-abort rejection to the top of `schedule()` would alter the idle-scheduler completion contract that AgentCore, OpenTUI and non-interactive execution rely on. No interactive/TUI capture, as noted above. Only `useToolScheduler.test.ts` was run, not the whole `packages/cli` suite.
- Breaking changes / migration notes: none. No public API or type change; `CompletedToolCall` already includes `CancelledToolCall`.
- Review note: PR #8357 also modifies `useReactToolScheduler.ts` (and `coreToolScheduler.ts`), though not this cancellation catch path — same-file overlap only, flagged in case the two need sequencing.

## Linked Issues

Fixes #11148

Related (not closed by this PR): #11146

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让 React full-turn 工具路径把"已 abort 的调度尝试"判定为取消，而不是失败。`useReactToolScheduler` 的 full-turn 分支现在会在 catch 里检查 `signal.aborted`；一旦 signal 已 abort，就通过调度器原本就在用的 `allToolCallsCompleteHandler`，以 `status: 'cancelled'` 完成这一批调用。它不再合成 `status: 'error'` / `ToolErrorType.UNHANDLED_EXCEPTION` 的调用，也不再把这些调用塞进活跃工具列表。

真实失败的行为保持不变：signal 未 abort 时，运行时解析失败或调度 rejection 仍然照旧产出带 `executionStatus: 'not_started'` 的 `UNHANDLED_EXCEPTION`。

## 为什么需要

`useReactToolScheduler` 里两个调度分支的行为原本不一致。普通分支在 `signal.aborted` 为真时会吞掉 `schedule()` 的 rejection（`if (signal.aborted) return;`）；full-turn 分支先 await `resolveForModel()`，然后把任何 rejection 都当成真实失败，catch 里完全没有对 `signal.aborted` 的判断。

当共享的 `CoreToolScheduler` 忙碌时，`schedule()` 会把请求停进 `requestQueue`，并注册一个 abort 监听器，以 `new Error('Tool call cancelled while in queue.')` reject。这是*取消*，但 full-turn 的 catch 把它合成为错误组并调用了 `allToolCallsCompleteHandler`。下游的影响比多一张 UI 卡片严重：`use-llm-stream.ts` 在派发已完成工具之前就通过 `addItem` 把该组写入历史；`recordToolResult` 对每个 ordered response 都会执行，且早于 `continuationWasCancelled()` 和 `allToolsCancelled` 两个检查；而 `allToolsCancelled` 判断的是 `status === 'cancelled'`，合成调用却是 `'error'`，所以这条兜底永不触发。最终结果：用户按 Esc 会被持久化进聊天记录，并作为一个真实的 `UNHANDLED_EXCEPTION` tool result 提交给模型。

把取消走进完成回调（而不是直接 early `return`）才是这个修复超出"压掉错误"的关键部分。三个 per-call 归属映射只在完成路径上释放——`toolBatchIdByCallIdRef` 在 `onComplete` 的 `finally` 里，`interactionOwnersByToolCallIdRef` 和 `continuationOwnersByToolCallIdRef` 在 `handleCompletedTools` 里。`handleCompletedTools` 会把 `status === 'cancelled'` 的调用纳入 `completedAndReadyToSubmitTools`，而 `CompletedToolCall` 本身已经包含 `CancelledToolCall`，所以裸的 early `return` 会让这三个条目对被取消的 callId 泄漏。这正是 issue 要求的"统一的取消清理路径"，同时它也让 `allToolsCancelled` 得以触发，从而不会把取消当成工具错误提交出去。

## Reviewer 测试计划

### 如何验证

先在未修改的 `main` @ `1b604721b053da4e104ff610e1a925fe8c9ca488`（即 issue 中给出的提交）上复现，再带修复重跑。

`packages/cli/src/ui/hooks/useToolScheduler.test.ts` 中新增两个测试，分别对应 issue 列出的两种取消时机：

- `keeps a full-turn cancellation when the signal aborts while the request is queued`——解析出有效的 full-turn runtime view，把 `CoreToolScheduler.prototype.schedule` 替换为忙碌调度器的行为（请求入队、abort 监听器以 `Tool call cancelled while in queue.` reject），先让 `resolveForModel()` 落定以确保请求确实已入队，然后再 abort。
- `keeps a full-turn cancellation when the signal is already aborted before scheduling`——先 abort controller，再对一个以同样队列取消错误 reject 的 `schedule()` 发起调度。

两者都断言：工具从未执行、活跃工具列表保持为空、没有任何 completion 携带 `status: 'error'` 或 `errorType: UNHANDLED_EXCEPTION`，并且仍然发出一个 `status: 'cancelled'`、`errorType: undefined`、`executionStatus: 'not_started'` 的 completion（正是这次发出释放了归属元数据）。

修复前两个测试都失败（原始输出见上方英文部分的代码块），pre-aborted 那个以同样方式在 `pre-aborted-full-turn-call` 上失败。

两个已有的 fail-closed 测试保留，并显式补上了 `errorType: ToolErrorType.UNHANDLED_EXCEPTION` 断言，使 issue 要求保持的 fail-closed 契约被锁定而不仅是隐含：

- `fails closed when the full-turn tool runtime cannot be resolved`
- `fails closed when full-turn tool scheduling rejects`

命令与结果见上方英文部分：`useToolScheduler.test.ts` 26 个测试全部通过（1 个测试文件通过）；eslint 无发现；prettier 全部符合。

typecheck：除本机既有基线外干净。`npm run typecheck --workspace=packages/cli` 报出恰好两个 `TS6305` 错误，都在 `src/ui/voice/native-audio-recorder.ts`，都是关于 `packages/audio-capture/dist/index.d.ts` 未构建。该包在本机无法构建（node-gyp 失败），与本改动无关——没有任何错误指向本 PR 修改的文件。

### 证据（Before & After）

交互式捕获不适用——见下方说明；before/after 证据即上面的测试失败/通过输出。

本 PR 刻意没有提供交互式 TUI 捕获。要在真实会话里走到这条路径，需要多个条件同时成立：技能或子代理通过以 `\0` 结尾的 `modelOverride` 指定模型、共享的 `CoreToolScheduler` 忙到需要排队、并且 abort 恰好落在这个窗口内。脚本化的 tmux 会话无法可靠触发这个组合，而手绘或摆拍的捕获比确定性 hook 测试更差——后者驱动的是真实的 `useReactToolScheduler` 和真实的队列取消错误。这里明确说明，而不是暗示已经做过。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

### 运行环境（可选）

仅单元测试（`npx vitest run ... --root packages/cli`），未启动真实运行时。

## 风险与范围

- 主要风险或取舍：被 abort 的 full-turn 批次现在以 `cancelled` 而非 `error` 完成，因此会走完成路径——`addItem` 会把一个 cancelled 工具组写入历史，`recordToolResult` 会记录 `status: 'cancelled'`。这与其它所有被取消的工具调用得到的处理一致，且随后 `allToolsCancelled` 会短路提交；但这仍是取消路径上的行为变化，而非单纯的错误抑制。
- 未验证 / 范围之外：`packages/core/src/core/coreToolScheduler.ts` 刻意未改动。相关的 #11146（忙碌调度器未对"入队前就已 abort"的 signal 直接 reject）属于 core 请求队列那一半，保持为独立改动——把 pre-abort rejection 提到 `schedule()` 开头会改变 AgentCore、OpenTUI 和非交互执行所依赖的空闲调度器完成契约。如上所述，没有交互式/TUI 捕获。只跑了 `useToolScheduler.test.ts`，没有跑整个 `packages/cli` 测试套件。
- 破坏性变更 / 迁移说明：无。没有公开 API 或类型变更；`CompletedToolCall` 本来就包含 `CancelledToolCall`。
- Review 提示：PR #8357 同样修改了 `useReactToolScheduler.ts`（以及 `coreToolScheduler.ts`），但不涉及这里的取消 catch 路径——仅是同文件重叠，标注出来以便必要时安排合并顺序。

## 关联 Issue

Fixes #11148

相关（本 PR 不关闭）：#11146

</details>
