### PR TITLE
docs(config): note baseUrl is the /v1 root for hosted OpenAI-compatible gateways (#10362)

### DIFF
--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -215,6 +215,8 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
 }
 ```
 
+When pointing an entry at a hosted OpenAI-compatible gateway, set `baseUrl` to the API's `/v1` root (for example, `https://gateway.example.com/v1`) rather than the full `/v1/chat/completions` path — the SDK appends the request path itself.
+
 ### Anthropic (`anthropic`)
 
 ```json


### PR DESCRIPTION
<!-- Suggested PR title: docs(config): note baseUrl is the /v1 root for hosted OpenAI-compatible gateways (#10362) -->

## What this PR does

Adds one sentence to the OpenAI-compatible (`openai`) section of `docs/users/configuration/model-providers.md`: when a `modelProviders` entry points at a hosted OpenAI-compatible gateway, `baseUrl` is the API's `/v1` root (for example `https://gateway.example.com/v1`), not the full `/v1/chat/completions` path — the SDK appends the request path itself.

This is a respin of the branch per review: the previously included named-gateway worked example and the deprecated `security.auth.*` config block are dropped, leaving only the generic hosted-`/v1` note.

## Why it's needed

Pasting the full `/v1/chat/completions` endpoint as `baseUrl` is the most common misconfiguration against hosted OpenAI-compatible gateways — the SDK appends the request path again and every call 404s. The examples around the new sentence all use `/v1`-suffixed roots, but the page never states the rule explicitly. This is the docs sliver of #10362 that triage judged worth landing.

## Reviewer Test Plan

### How to verify

Docs-only change (2 added lines). Confirm formatting and read the final diff: `npx prettier --check docs/users/configuration/model-providers.md` passes, and the sentence sits directly after the big `openai` example, before `### Anthropic (anthropic)`, using the page's existing `gateway.example.com` placeholder with no vendor names and no config examples.

### Evidence (Before & After)

N/A (docs-only; no user-visible UI change).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

Docs-only; CI runs the same Prettier gate on all three platforms. Verified locally with the repo's Prettier on macOS.

### Environment (optional)

Local Prettier 3.5.x via the repo's `node_modules` (`node_modules/.bin/prettier --check`); no CLI runtime needed for a docs change.

## Risk & Scope

- Main risk or tradeoff: none — a single clarifying prose sentence; no config shape is introduced, modeled, or changed.
- Not validated / out of scope: no vendor-specific worked example or preset (named providers are endorsement-gated per CONTRIBUTING.md "Adding a Provider Preset"); the previously linked gateway request is intentionally no longer referenced as resolved.
- Breaking changes / migration notes: none.

## Linked Issues

Closes #10362

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `docs/users/configuration/model-providers.md` 的 OpenAI 兼容（`openai`）章节新增一句话：当 `modelProviders` 条目指向托管式 OpenAI 兼容网关时，`baseUrl` 填的是 API 的 `/v1` 根路径（例如 `https://gateway.example.com/v1`），而不是完整的 `/v1/chat/completions` 路径——SDK 会自动拼接请求路径。

这是按 review 意见对分支的重新收缩：删除了此前包含的点名网关完整示例和已废弃的 `security.auth.*` 配置块，只保留通用的托管 `/v1` 说明。

## 为什么需要

把完整的 `/v1/chat/completions` 端点当作 `baseUrl` 是接入托管式 OpenAI 兼容网关时最常见的错误配置——SDK 会再次拼接请求路径，导致每个请求都 404。新句子周边的示例全都使用以 `/v1` 结尾的根路径，但页面此前从未明说这条规则。这正是 #10362 中被 triage 判定值得落地的文档切片。

## 审阅者测试计划

### 如何验证

纯文档改动（新增 2 行）。确认格式并通读最终 diff：`npx prettier --check docs/users/configuration/model-providers.md` 通过；这句话位于 `openai` 大示例之后、`### Anthropic (anthropic)` 之前，使用页面已有的 `gateway.example.com` 占位域名，不含任何厂商名称和配置示例。

### 证据（前后对比）

N/A（纯文档改动，无用户可见的 UI 变化）。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

纯文档改动；CI 会在三个平台跑同样的 Prettier 门禁。本地已在 macOS 用仓库自带的 Prettier 验证。

### 环境（可选）

本地 Prettier 3.5.x（仓库 `node_modules` 中的 `node_modules/.bin/prettier --check`）；文档改动无需 CLI 运行时。

## 风险与范围

- 主要风险或取舍：无——仅新增一句澄清性文字；不引入、不演示、不改变任何配置形态。
- 未验证 / 范围之外：不提供厂商专属的完整示例或预设（按 CONTRIBUTING.md "Adding a Provider Preset"，点名厂商需走背书流程）；此前关联的网关请求有意不再标记为已解决。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Closes #10362

</details>