### PR TITLE
fix(ci): record the release.yml size drift two in-allowance PRs accumulated

### DIFF
--- a/.github/workflows/.size-baseline
+++ b/.github/workflows/.size-baseline
@@ -47,7 +47,7 @@
 22037 release-sdk-python.yml
 19094 release-sdk.yml
 14546 release-vscode-companion.yml
-70232 release.yml
+75392 release.yml
 43717 repo-hygiene.yml
 1079 scorecard-monthly.yml
 10691 sdk-java.yml


### PR DESCRIPTION
## What this PR does

Records the release workflow's actual current byte size (75392, measured with `wc -c` on main) in the workflow-size ratchet's baseline file, replacing the stale 70232. One line, no workflow behavior changes.

## Why it's needed

The size ratchet lets a PR grow a workflow by up to 4096 bytes over its recorded baseline without bumping the number, so small growth lands frictionlessly and only real drift becomes a reviewed line. Two consecutive release-workflow PRs (#11127, #10902) each grew the file by roughly 2.5 KB — each individually inside the allowance, so neither was forced to touch the baseline — and the sum (5160 bytes) sailed past it. That is precisely the invisible-accumulation failure the ratchet's own header comment describes.

The drift is already biting: every strict gate run now fails on `release.yml` — any local run without a PR base SHA, and (once the #9904 leniency no longer applies) any future PR that touches the release workflow gets red-walled by growth it did not author. The gate's error message itself prescribes this fix: "update .size-baseline on main (a one-line PR saying why)".

## Reviewer Test Plan

### How to verify

- On main (before): `bash .github/scripts/check-workflow-size.sh` fails with `::error file=.github/workflows/release.yml:: … grew to 75392 bytes, 5160 over its recorded 70232 (allowance 4096)`; the vitest mirror `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/workflow-size.test.js` fails its "release.yml is within its baseline allowance" case for the same reason (the mirror fails closed when no base SHA is set).
- On this branch (after): both pass — gate exit 0, mirror 179 passed / 23 skipped. Measured locally on macOS.
- Sanity: `wc -c .github/workflows/release.yml` equals the new recorded number exactly.

### Evidence (Before & After)

N/A (CI metadata change; no user-visible surface).

### Tested on

|     OS     | Status                                  |
| :--------: | :-------------------------------------- |
|  🍏 macOS  | ✅ gate + vitest mirror, strict mode     |
| 🪟 Windows | ⚠️ not tested locally — CI lanes cover   |
|  🐧 Linux  | ⚠️ not tested locally — CI lanes cover   |

### Environment (optional)

N/A — shell gate and vitest only.

## Risk & Scope

- Main risk or tradeoff: none — recording a size that already exists on main; the ratchet resumes tracking from the true value and the next real growth is measured against it.
- Not validated / out of scope: other baseline entries were checked by the same strict run and are all within allowance; only release.yml had drifted past it.
- Breaking changes / migration notes: none.

## Linked Issues

N/A — discovered by the gate output during #11124's merge-conflict resolution.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

把工作流体积棘轮基线文件中 release 工作流的记录值更新为其当前实际字节数（75392，在 main 上用 `wc -c` 实测），替换过期的 70232。一行改动，不影响任何工作流行为。

## 为什么需要

体积棘轮允许一个 PR 在记录基线之上增长至多 4096 字节而无需更新数字，让小幅增长无摩擦落地、只有真正的漂移才成为一行被评审的记录。两个连续的 release 工作流 PR（#11127、#10902）各自增长了约 2.5 KB —— 单独看都在容差之内，因此都没有被要求动基线 —— 而总和（5160 字节）越过了容差。这正是棘轮文件头注释自己描述的"隐形累积"失效模式。

漂移已经开始产生实际影响：现在每一次严格模式的门禁都会在 `release.yml` 上失败 —— 任何本地不带 PR base SHA 的运行都会报错；而一旦 #9904 的宽容分支不再适用，未来任何触碰 release 工作流的 PR 都会被它没有造成的增长红墙拦住。门禁的报错信息本身就给出了修法："update .size-baseline on main (a one-line PR saying why)"。

## 评审测试计划

### 如何验证

- main 上（改前）：`bash .github/scripts/check-workflow-size.sh` 报 `::error file=.github/workflows/release.yml:: … grew to 75392 bytes, 5160 over its recorded 70232 (allowance 4096)`；vitest 镜像 `npx vitest run --config ./scripts/tests/vitest.config.ts scripts/tests/workflow-size.test.js` 的 "release.yml is within its baseline allowance" 用例同样失败（无 base SHA 时镜像 fail-closed）。
- 本分支上（改后）：两者均通过 —— 门禁退出码 0，镜像 179 通过 / 23 跳过。均在 macOS 本地实测。
- 交叉核对：`wc -c .github/workflows/release.yml` 与新记录值完全一致。

### 证据（前后对比）

N/A（CI 元数据改动，无用户可见面）。

### 测试环境

|     OS     | 状态                                |
| :--------: | :---------------------------------- |
|  🍏 macOS  | ✅ 严格模式门禁 + vitest 镜像        |
| 🪟 Windows | ⚠️ 本地未测 —— 由 CI 通道覆盖        |
|  🐧 Linux  | ⚠️ 本地未测 —— 由 CI 通道覆盖        |

### 环境（可选）

N/A —— 仅 shell 门禁与 vitest。

## 风险与范围

- 主要风险或取舍：无 —— 只是记录一个 main 上已经存在的体积；棘轮从真实值恢复追踪，下一次真实增长以它为基准。
- 未验证 / 超出范围：其余基线条目已被同一次严格运行检查过，全部在容差之内；只有 release.yml 漂移超限。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A —— 在 #11124 解决合并冲突时由门禁输出发现。

</details>
