### PR TITLE
test(integration): make compress E2E deterministic

### DIFF
--- a/integration-tests/interactive/context-compress-interactive.test.ts
+++ b/integration-tests/interactive/context-compress-interactive.test.ts
@@ -5,18 +5,55 @@
  */
 
 import { expect, describe, it, beforeEach, afterEach } from 'vitest';
-import { TestRig, type } from '../test-helper.js';
+import {
+  startFakeOpenAIServer,
+  type FakeOpenAIServer,
+} from '../fake-openai-server.js';
+import {
+  TestRig,
+  type,
+  applyContainerSandboxNoProxy,
+  fakeServerHostOptions,
+} from '../test-helper.js';
 
 describe('Interactive Mode', () => {
   let rig: TestRig;
+  let fakeServer: FakeOpenAIServer | undefined;
+  let restoreNoProxy: () => void;
 
   beforeEach(() => {
     rig = new TestRig();
+    restoreNoProxy = applyContainerSandboxNoProxy();
   });
 
   afterEach(async () => {
+    await fakeServer?.close();
+    fakeServer = undefined;
+    restoreNoProxy();
     await rig.cleanup();
   });
+
+  async function runInteractiveWithFakeModel() {
+    fakeServer = await startFakeOpenAIServer(
+      ({ requestIndex }) => ({
+        content:
+          requestIndex === 0
+            ? `${'history '.repeat(1000)} Einstein`
+            : '<state_snapshot>Compressed history focused on Einstein.</state_snapshot>',
+      }),
+      fakeServerHostOptions(),
+    );
+    return rig.runInteractive(
+      '--auth-type',
+      'openai',
+      '--openai-api-key',
+      'fake-key',
+      '--openai-base-url',
+      fakeServer.baseUrl,
+      '--model',
+      'fake-model',
+    );
+  }
 
   it.skipIf(process.platform === 'win32')(
     'should trigger chat compression with /compress command',
@@ -31,13 +68,16 @@ describe('Interactive Mode', () => {
         },
       });
 
-      const { ptyProcess } = rig.runInteractive();
+      const { ptyProcess } = await runInteractiveWithFakeModel();
 
       let fullOutput = '';
       ptyProcess.onData((data: string) => (fullOutput += data));
 
       // Wait for the app to be ready
-      const isReady = await rig.waitForText('Type your message', 15000);
+      const isReady = await rig.waitForText(
+        'Type your message',
+        rig.getDefaultTimeout(),
+      );
       expect(
         isReady,
         'CLI did not start up in interactive mode correctly',
@@ -49,7 +89,8 @@ describe('Interactive Mode', () => {
       await type(ptyProcess, longPrompt);
       await type(ptyProcess, '\r');
 
-      await rig.waitForText('einstein', 25000);
+      const seedCompleted = await rig.waitForText('einstein');
+      expect(seedCompleted, 'seed response did not complete').toBe(true);
 
       await type(ptyProcess, '/compress');
       // A small delay to allow React to re-render the command list.
@@ -119,12 +160,15 @@ describe('Interactive Mode', () => {
         },
       });
 
-      const { ptyProcess } = rig.runInteractive();
+      const { ptyProcess } = await runInteractiveWithFakeModel();
 
       let fullOutput = '';
       ptyProcess.onData((data: string) => (fullOutput += data));
 
-      const isReady = await rig.waitForText('Type your message', 15000);
+      const isReady = await rig.waitForText(
+        'Type your message',
+        rig.getDefaultTimeout(),
+      );
       expect(
         isReady,
         'CLI did not start up in interactive mode correctly',
@@ -137,7 +181,8 @@ describe('Interactive Mode', () => {
       await type(ptyProcess, seedPrompt);
       await type(ptyProcess, '\r');
 
-      await rig.waitForText('einstein', 25000);
+      const seedCompleted = await rig.waitForText('einstein');
+      expect(seedCompleted, 'seed response did not complete').toBe(true);
 
       // Fire /compress with a trailing instruction. We are not asserting on
       // summary CONTENT (model behaviour) — only that the wiring runs


### PR DESCRIPTION
## What this PR does

Makes the interactive `/compress` integration tests use the repository's fake OpenAI server instead of a live model. The tests now wait for a deterministic seed response before sending `/compress`, and use the integration-test timeout for CLI startup.

## Why it's needed

The Docker job in [release run 34018769561](https://github.com/QwenLM/qwen-code/actions/runs/34018769561/job/101457345139) timed out waiting for the live seed response, but the test ignored that timeout and sent `/compress` anyway. The expected `chat_compression` event was then never emitted; retries also used a fixed 15-second startup timeout. The test file itself had not changed since June 3, so this was a latent timing dependency exposed by a slower runner/model response rather than a reproduced `/compress` product regression.

## Reviewer Test Plan

### How to verify

Run `QWEN_CODE_LANG=en QWEN_SANDBOX=false npx vitest run --root ./integration-tests interactive/context-compress-interactive.test.ts`. Both active tests should pass using only the local fake server, and the skipped token-inflation case should remain skipped.

### Evidence (Before & After)

N/A — test-only change. The original live-model test took 90.3 seconds locally; the deterministic version completed both active cases in 11.96 seconds.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

macOS local, no sandbox. The Linux container path is left to CI because Docker is unavailable locally.

## Risk & Scope

- Main risk or tradeoff: The integration test no longer exercises live-model latency or output variability; those are not part of the `/compress` plumbing contract.
- Not validated / out of scope: Local Docker execution.
- Breaking changes / migration notes: None.

## Linked Issues

Related failure: https://github.com/QwenLM/qwen-code/actions/runs/34018769561/job/101457345139

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让交互式 `/compress` 集成测试改用仓库现有的假 OpenAI 服务，不再调用真实模型。测试现在会先确认可预期的初始回复已经完成，再发送 `/compress`，并使用集成测试的统一启动超时时间。

## 为什么需要

[release run 34018769561](https://github.com/QwenLM/qwen-code/actions/runs/34018769561/job/101457345139) 的 Docker 任务在等待真实模型的初始回复时超时，但测试忽略了这个结果，继续发送 `/compress`，因此没有产生预期的 `chat_compression` 事件；重试时又受到固定 15 秒启动超时限制。这个测试文件自 6 月 3 日以来没有改过，所以这是较慢的 runner/模型响应暴露出的时序依赖，而不是已复现的 `/compress` 产品回归。

## Reviewer Test Plan

### 如何验证

运行 `QWEN_CODE_LANG=en QWEN_SANDBOX=false npx vitest run --root ./integration-tests interactive/context-compress-interactive.test.ts`。两个启用的测试应只使用本地假服务并通过，已跳过的 token inflation 用例应保持跳过。

### 证据（修复前后）

不适用——仅测试变更。原始真实模型测试在本地耗时 90.3 秒；改为确定性测试后，两个启用的用例共耗时 11.96 秒。

### 测试平台

|     系统     | 状态 |
| :----------: | :--: |
|  🍏 macOS   |  ✅   |
| 🪟 Windows  | N/A  |
|  🐧 Linux   |  ⚠️   |

### 环境（可选）

macOS 本地、无 sandbox。由于本地不可用 Docker，Linux 容器路径留给 CI 验证。

## 风险与范围

- 主要风险或取舍：集成测试不再覆盖真实模型的延迟和输出波动；这些不属于 `/compress` 链路的测试契约。
- 未验证 / 范围外：本地 Docker 执行。
- 破坏性变更 / 迁移说明：无。

## 关联问题

相关失败：https://github.com/QwenLM/qwen-code/actions/runs/34018769561/job/101457345139

</details>
