### PR TITLE
test(integration): make spaced-path write deterministic

### DIFF
--- a/integration-tests/cli/file-system.test.ts
+++ b/integration-tests/cli/file-system.test.ts
@@ -4,14 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { join } from 'node:path';
 import {
+  runForcedToolCallScenario,
   TestRig,
   printDebugInfo,
   validateModelOutput,
 } from '../test-helper.js';
+import { fakeToolCall } from '../fake-openai-server.js';
 
 describe('file-system', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('should be able to read a file', async () => {
     const rig = new TestRig();
     await rig.setup('should be able to read a file');
@@ -95,15 +102,19 @@ describe('file-system', () => {
     const rig = new TestRig();
     await rig.setup('should correctly handle file paths with spaces');
     const fileName = 'my test file.txt';
+    const filePath = join(rig.testDir!, fileName);
 
-    const result = await rig.run(
-      `Use write_file to write exactly "hello" to "${fileName}".`,
-    );
+    await runForcedToolCallScenario({
+      rig,
+      toolCall: fakeToolCall('write_file', {
+        file_path: filePath,
+        content: 'hello',
+      }),
+      prompt: `Use write_file to write exactly "hello" to "${fileName}".`,
+      finalResponse: 'Done.',
+    });
 
     const foundToolCall = await rig.waitForToolCall('write_file');
-    if (!foundToolCall) {
-      printDebugInfo(rig, result);
-    }
     expect(
       foundToolCall,
       'Expected to find a write_file tool call',


### PR DESCRIPTION
## What this PR does

Makes the spaced-path write integration test drive a deterministic `write_file` tool call through the existing fake OpenAI server. The CLI and filesystem operation remain real; only the model decision is scripted.

## Why it's needed

Release run 34018769561 failed this test three times because the configured model service returned an internal serving error before `write_file` ran. The same test passed in the previous attempt, so the failure came from an unrelated live-model dependency rather than spaced-path handling.

## Reviewer Test Plan

### How to verify

Run the spaced-path test without model credentials. It should create a file whose name contains spaces, record a successful `write_file` call, and leave the exact content `hello`.

### Evidence (Before & After)

N/A — test-only change. Before: the test could fail on a model-provider error. After: the targeted test passes locally in 2.98 seconds without a live model.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js 22, no sandbox. The local Docker daemon was unavailable; the same fake-server helper and absolute workspace-path pattern passed in `cli/list_directory.test.ts` in the cited Docker release job.

## Risk & Scope

- Main risk or tradeoff: This test no longer checks whether a live model chooses `write_file`; it checks the CLI-to-tool-to-filesystem path deterministically.
- Not validated / out of scope: Other integration tests that intentionally use the configured live model remain unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

Related to https://github.com/QwenLM/qwen-code/actions/runs/34018769561.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

让带空格路径的写文件集成测试通过现有 fake OpenAI server 发出确定性的 `write_file` 工具调用。CLI 和文件系统操作仍然真实执行，只固定了模型决策。

## 为什么需要

Release run 34018769561 中，这条测试连续三次因为配置的模型服务返回内部服务错误而失败，`write_file` 尚未执行。相同测试在前一次尝试中通过，因此故障来自与测试目标无关的线上模型依赖，而不是带空格路径处理。

## Reviewer Test Plan

### 如何验证

在没有模型凭据的情况下运行带空格路径测试。测试应创建文件名包含空格的文件，记录一次成功的 `write_file` 调用，并留下精确内容 `hello`。

### 证据（修改前后）

不适用——仅测试改动。修改前：测试可能因模型服务错误失败。修改后：目标测试在本地不使用线上模型，2.98 秒通过。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

Node.js 22、无 sandbox。本机 Docker daemon 不可用；相同 fake-server helper 和绝对工作区路径模式已在上述 Docker release job 的 `cli/list_directory.test.ts` 中通过。

## 风险与范围

- 主要风险或取舍：这条测试不再检查线上模型是否选择 `write_file`，而是确定性地检查 CLI、工具调用和文件系统链路。
- 未验证 / 不在范围内：其他有意使用配置线上模型的集成测试保持不变。
- 破坏性变更 / 迁移说明：无。

## 关联问题

关联 https://github.com/QwenLM/qwen-code/actions/runs/34018769561。

</details>
