### PR TITLE
test(integration): make BOM reads deterministic

### DIFF
--- a/integration-tests/cli/utf-bom-encoding.test.ts
+++ b/integration-tests/cli/utf-bom-encoding.test.ts
@@ -4,10 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  vi,
+} from 'vitest';
 import { writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { TestRig } from '../test-helper.js';
+import { runForcedToolCallScenario, TestRig } from '../test-helper.js';
+import { fakeToolCall } from '../fake-openai-server.js';
 
 // Windows skip (Option A: avoid infra scope)
 const d = process.platform === 'win32' ? describe.skip : describe;
@@ -64,15 +73,25 @@ d('BOM end-to-end integration', () => {
     await rig.cleanup();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   async function runAndAssert(
     filename: string,
     content: Buffer,
     expectedText: string | null,
   ) {
-    writeFileSync(join(dir, filename), content);
+    const filePath = join(dir, filename);
+    writeFileSync(filePath, content);
     const prompt = `read the file ${filename} and output its exact contents`;
-    const output = await rig.run(prompt);
-    await rig.waitForToolCall('read_file');
+    const requests = await runForcedToolCallScenario({
+      rig,
+      toolCall: fakeToolCall('read_file', { file_path: filePath }),
+      prompt,
+      finalResponse: 'Done.',
+    });
+    const output = JSON.stringify(requests.at(-1)?.['messages'] ?? '');
     const lower = output.toLowerCase();
     if (expectedText === null) {
       expect(


### PR DESCRIPTION
## What this PR does

Routes the five BOM read scenarios through the existing local fake OpenAI server. The fake response requests `read_file`, and each scenario checks the decoded tool result sent back on the following model request.

## Why it's needed

Release run 34018769561 failed twice on the UTF-32 BE scenario because all three attempts received the same transient model-serving internal error. A later release run passed the identical scenario without any relevant encoding or test changes, so model availability—not BOM decoding—was gating a deterministic assertion. Other integration tests continue to exercise the live model path.

## Reviewer Test Plan

### How to verify

Run the five BOM read scenarios without provider credentials and confirm that all five encodings, including UTF-32 BE, pass while still executing `read_file` through the CLI.

### Evidence (Before & After)

N/A — test-only change.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

`QWEN_SANDBOX=false npx vitest run cli/utf-bom-encoding.test.ts -t 'UTF-(8|16|32)( LE| BE)? BOM$'`: 5 passed. Integration typecheck, Prettier, ESLint, and the repository build also passed. Docker was not run locally because the daemon was unavailable; CI covers that lane.

## Risk & Scope

- Main risk or tradeoff: these encoding assertions no longer depend on live-model instruction following; the CLI tool round trip and decoded payload remain covered.
- Not validated / out of scope: live provider reliability and the Docker lane are unchanged.
- Breaking changes / migration notes: none.

## Linked Issues

- Failed release evidence: https://github.com/QwenLM/qwen-code/actions/runs/34018769561
- Successful control run: https://github.com/QwenLM/qwen-code/actions/runs/34022919438

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将 5 个 BOM 读取场景切换到仓库现有的本地假 OpenAI 服务。假响应会要求调用 `read_file`，每个场景再检查下一次模型请求中携带的已解码工具结果。

## 为什么需要

Release run 34018769561 有两次在 UTF-32 BE 场景失败，三次尝试都收到了相同的模型服务瞬时内部错误。之后的另一个 release run 在没有相关编码或测试改动的情况下通过了完全相同的场景，因此阻塞确定性断言的是模型可用性，而不是 BOM 解码。其他集成测试仍会覆盖真实模型链路。

## Reviewer 测试计划

### 如何验证

在不提供模型服务凭证的情况下运行 5 个 BOM 读取场景，确认包括 UTF-32 BE 在内的全部编码都能通过，同时仍然通过 CLI 执行 `read_file`。

### 前后证据

N/A，仅测试改动。

### 已测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

`QWEN_SANDBOX=false npx vitest run cli/utf-bom-encoding.test.ts -t 'UTF-(8|16|32)( LE| BE)? BOM$'`：5 个用例通过。集成测试类型检查、Prettier、ESLint 和仓库构建也已通过。本地 Docker daemon 不可用，因此未本地执行 Docker lane，由 CI 覆盖。

## 风险与范围

- 主要风险或取舍：这些编码断言不再依赖真实模型的指令遵循；CLI 工具调用链路和解码后的 payload 仍然有覆盖。
- 未验证或范围外：真实模型服务可靠性和 Docker lane 均未改动。
- 破坏性变更或迁移说明：无。

## 关联信息

- 失败 release 证据：https://github.com/QwenLM/qwen-code/actions/runs/34018769561
- 成功对照 run：https://github.com/QwenLM/qwen-code/actions/runs/34022919438

</details>
