### PR TITLE
fix(core): demote balanced content-only thinking blocks to thought parts (#10791)

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -859,10 +859,14 @@ describe('OpenAIContentConverter', () => {
       expect(response.candidates?.[0]?.content?.parts).toEqual([{ text }]);
     });
 
-    it('demotes the leading balanced nested literal at the start of the stream', () => {
+    it('demotes the leading balanced nested literal without releasing a stray closing tag', () => {
       // The leading <think></think> balances, so the block is demoted and the
       // remainder flows through the tagged-thinking parser's documented
       // binary toggle (issue #10791) instead of being preserved verbatim.
+      // The depth-counted tail closes one tag earlier than the binary parser
+      // does; the leftover </think> is a protocol remnant, not the visible
+      // answer, so it must be stripped (review finding 2) instead of being
+      // released as the whole user-facing output.
       const stream = withStreamParser();
       stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
       const chunks = [
@@ -881,10 +885,77 @@ describe('OpenAIContentConverter', () => {
         return response.candidates?.[0]?.content?.parts ?? [];
       });
 
-      expect(parts).toEqual([
-        { text: 'outer <think>literal', thought: true },
-        { text: '</think>' },
-      ]);
+      expect(parts).toEqual([{ text: 'outer <think>literal', thought: true }]);
+    });
+
+    it('strips a stray closing tag split across chunks after demotion', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+      const chunks = ['<think></think>ok</thi', 'nk>more'];
+      const parts = chunks.flatMap((content, index) => {
+        const response = converter.convertOpenAIChunkToLlm(
+          streamChunk(
+            `stray-split-${index}`,
+            { content },
+            index === chunks.length - 1 ? 'stop' : null,
+          ),
+          stream,
+        );
+        return response.candidates?.[0]?.content?.parts ?? [];
+      });
+
+      // Partial closing tags are buffered inside the parser, so the remnant
+      // is stripped even when the chunk boundary splits it. Part boundaries
+      // follow chunk boundaries; the concatenated visible text is what the
+      // user sees.
+      expect(parts.map((part) => part.text).join('')).toBe('okmore');
+      expect(parts.every((part) => part.thought !== true)).toBe(true);
+    });
+
+    it('fails closed for a closing tag with inner whitespace on streaming demotion', () => {
+      // THINKING_TAG_PATTERN tolerates whitespace before '>' but the
+      // parser's exact tag literals do not: the demoted block never closes,
+      // so the turn fails closed exactly like any other unclosed block
+      // instead of hiding the tail (review finding 1, streaming side).
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      expect(() =>
+        converter.convertOpenAIChunkToLlm(
+          streamChunk(
+            'whitespace-close',
+            { content: '<think>plan</think >answer' },
+            'stop',
+          ),
+          stream,
+        ),
+      ).toThrowError(expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }));
+    });
+
+    it('does not demote a streaming leading block on structured-reasoning turns', () => {
+      // Streaming pin for the load-bearing scoping condition (review
+      // finding 3): once structured reasoning has been seen the content-only
+      // demotion stays off, and a leading tag in content keeps failing
+      // closed through the structured-reasoning leak guard rather than
+      // being silently demoted to a thought part.
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      converter.convertOpenAIChunkToLlm(
+        streamChunk('reasoning', { reasoning_content: 'structured phase' }),
+        stream,
+      );
+
+      expect(() =>
+        converter.convertOpenAIChunkToLlm(
+          streamChunk(
+            'content',
+            { content: '<think>second phase</think>answer' },
+            'stop',
+          ),
+          stream,
+        ),
+      ).toThrowError(expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }));
     });
 
     it('preserves balanced nested literals after visible content', () => {
@@ -5660,6 +5731,73 @@ describe('OpenAIContentConverter', () => {
       expect(response.candidates?.[0]?.content?.parts).toEqual([
         { text: 'first phase', thought: true },
         { text: '<think>second phase</think>answer' },
+      ]);
+    });
+
+    it('fails closed for a closing tag with inner whitespace on non-streaming turns', () => {
+      // The tolerant balance detector counts </think > as closing, but the
+      // parser's exact tag literals never leave thought mode. The
+      // non-streaming demotion must fail closed like the streaming path
+      // (review finding 1 / #10982) instead of silently hiding the whole
+      // message — including the visible answer — in the thought channel.
+      expect(() =>
+        converter.convertOpenAIResponseToLlm(
+          {
+            object: 'chat.completion',
+            id: 'chatcmpl-whitespace-close',
+            created: 123,
+            model: 'gpt-test',
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: 'assistant',
+                  content: '<think>plan</think >answer',
+                },
+                finish_reason: 'stop',
+                logprobs: null,
+              },
+            ],
+          } as unknown as OpenAI.Chat.ChatCompletion,
+          {
+            ...requestContext,
+            responseParsingOptions: { contentOnlyThinkingTagLeaks: true },
+          },
+        ),
+      ).toThrowError(expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }));
+    });
+
+    it('strips stray closing tags after a nested leading demotion on non-streaming turns', () => {
+      // Non-streaming mirror of the streaming nested-demotion test (review
+      // finding 2): the depth-nested tail must not surface a dangling
+      // </think> as the user-visible answer.
+      const response = converter.convertOpenAIResponseToLlm(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-nested-demotion',
+          created: 123,
+          model: 'gpt-test',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content:
+                  '<think></think><think>outer <think>literal</think></think>',
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        {
+          ...requestContext,
+          responseParsingOptions: { contentOnlyThinkingTagLeaks: true },
+        },
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'outer <think>literal', thought: true },
       ]);
     });
 

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -553,13 +553,19 @@ describe('OpenAIContentConverter', () => {
       );
 
       expect(opening.candidates?.[0]?.content?.parts).toEqual([]);
-      expect(repeatedOpening.candidates?.[0]?.content?.parts).toEqual([]);
+      // The leading balanced block is demoted to a thought part (issue
+      // #10791); only visible text parts must stay suppressed here.
+      expect(repeatedOpening.candidates?.[0]?.content?.parts).toEqual([
+        { text: '\n\n', thought: true },
+      ]);
       const nestedOpening = converter.convertOpenAIChunkToLlm(
         streamChunk('nested-opening', { content: 'nk>9<think>-3' }),
         stream,
       );
 
-      expect(nestedOpening.candidates?.[0]?.content?.parts).toEqual([]);
+      expect(nestedOpening.candidates?.[0]?.content?.parts).toEqual([
+        { text: '9<think>-3', thought: true },
+      ]);
       expect(() => finishStream(stream)).toThrowError(
         expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }),
       );
@@ -592,10 +598,9 @@ describe('OpenAIContentConverter', () => {
       );
     });
 
-    it('holds a long confirmed opening tag until its closing tag arrives', () => {
+    it('holds an unbalanced opening tag and demotes the block once balanced', () => {
       const stream = withStreamParser();
       stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
-      const text = `<thinking>${'x'.repeat(200)}</thinking>`;
 
       const opening = converter.convertOpenAIChunkToLlm(
         streamChunk('long-balanced', {
@@ -608,8 +613,13 @@ describe('OpenAIContentConverter', () => {
         stream,
       );
 
+      // The unclosed prefix stays held (no visible leak); once the closing
+      // tag balances the block it is demoted to a thought part (issue #10791)
+      // instead of being released as literal text.
       expect(opening.candidates?.[0]?.content?.parts).toEqual([]);
-      expect(closing.candidates?.[0]?.content?.parts).toEqual([{ text }]);
+      expect(closing.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'x'.repeat(200), thought: true },
+      ]);
     });
 
     it('leaks the production <thinking> shape without provider provenance', () => {
@@ -637,14 +647,23 @@ describe('OpenAIContentConverter', () => {
     });
 
     it.each([
-      ['split literal block', ['<thi', 'nk>literal</think>']],
-      ['empty block with a separate finish chunk', ['<think>\n\n</think>', '']],
+      ['split literal block', ['<thi', 'nk>literal</think>'], 'literal'],
+      [
+        'empty block with a separate finish chunk',
+        ['<think>\n\n</think>', ''],
+        '\n\n',
+      ],
       [
         'two split valid blocks',
         ['<think>\n\n', '</think><thi', 'nk>literal</think>'],
+        '\n\nliteral',
       ],
-      ['long empty block', [`<thinking>${' '.repeat(128)}</thinking>`, '']],
-    ])('preserves content-only %s', (_name, chunks) => {
+      [
+        'long empty block',
+        [`<thinking>${' '.repeat(128)}</thinking>`, ''],
+        ' '.repeat(128),
+      ],
+    ])('demotes content-only %s to thought parts', (_name, chunks, thought) => {
       const stream = withStreamParser();
       stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
       const parts = chunks.flatMap((content, index) => {
@@ -659,8 +678,145 @@ describe('OpenAIContentConverter', () => {
         return response.candidates?.[0]?.content?.parts ?? [];
       });
 
-      expect(parts.map((part) => part.text).join('')).toBe(chunks.join(''));
-      expect(parts.every((part) => part.thought !== true)).toBe(true);
+      // Balanced content-only blocks are leaked chain-of-thought in
+      // production (issue #10791): the block text is demoted to the hidden
+      // thought channel and never reaches user-visible output.
+      expect(parts.map((part) => part.text).join('')).toBe(thought);
+      expect(parts.every((part) => part.thought === true)).toBe(true);
+      expect(parts.join('')).not.toContain('<think');
+    });
+
+    it('demotes a balanced content-only thinking block with trailing answer (issue #10791)', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'balanced-leak',
+          {
+            content:
+              '<thinking>\nThe user asks about project 10088.\n</thinking>\n\nHere is the answer.',
+          },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        {
+          text: '\nThe user asks about project 10088.\n',
+          thought: true,
+        },
+        { text: '\n\nHere is the answer.' },
+      ]);
+    });
+
+    it('demotes a balanced content-only thinking block split across chunks with trailing answer', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+      const chunks = [
+        '<thi',
+        'nking>plan the query',
+        '</thinking>',
+        'The visible answer.',
+      ];
+      const parts = chunks.flatMap((content, index) => {
+        const response = converter.convertOpenAIChunkToLlm(
+          streamChunk(
+            `balanced-split-${index}`,
+            { content },
+            index === chunks.length - 1 ? 'stop' : null,
+          ),
+          stream,
+        );
+        return response.candidates?.[0]?.content?.parts ?? [];
+      });
+
+      expect(parts).toEqual([
+        { text: 'plan the query', thought: true },
+        { text: 'The visible answer.' },
+      ]);
+    });
+
+    it('demotes a thinking-only content-only turn without leaking visible text', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'thinking-only',
+          { content: '<think>reasoning with no answer</think>' },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'reasoning with no answer', thought: true },
+      ]);
+    });
+
+    it('keeps demoting follow-up blocks after the leading demotion', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'second-block',
+          { content: '<think>first</think>ok<think>second</think>done' },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'first', thought: true },
+        { text: 'ok' },
+        { text: 'second', thought: true },
+        { text: 'done' },
+      ]);
+    });
+
+    it('fails closed when a thinking block opened after demotion never closes', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk('unclosed-after-demote', {
+          content: '<think>a</think>ok<think>oops',
+        }),
+        stream,
+      );
+
+      // The unclosed tail only reaches the hidden thought channel (the parser
+      // streams thinking incrementally); the turn still fails closed below.
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'a', thought: true },
+        { text: 'ok' },
+        { text: 'oops', thought: true },
+      ]);
+      expect(() => finishStream(stream, 'stop')).toThrowError(
+        expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }),
+      );
+    });
+
+    it('leaks a balanced content-only block without provider provenance', () => {
+      // Control for the demotion tests above: the defense stays gated on
+      // contentOnlyThinkingTagLeaks, so endpoints whose provider does not
+      // opt in keep seeing the literal tags verbatim.
+      const stream = withStreamParser();
+      const response = converter.convertOpenAIChunkToLlm(
+        streamChunk(
+          'literal',
+          { content: '<thinking>reasoning</thinking>answer' },
+          'stop',
+        ),
+        stream,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: '<thinking>reasoning</thinking>answer' },
+      ]);
     });
 
     it('releases a long unconfirmed prefix before the stream finishes', () => {
@@ -703,21 +859,41 @@ describe('OpenAIContentConverter', () => {
       expect(response.candidates?.[0]?.content?.parts).toEqual([{ text }]);
     });
 
-    it.each([
-      [
-        'at the start of the stream',
-        ['<think></think><think>outer <think>literal', '</think></think>'],
-      ],
-      [
-        'after visible content',
-        [
-          'Explanation: ',
-          '<think></think><think>outer <think>literal</think></think>',
-        ],
-      ],
-    ])('preserves balanced nested literals %s', (_name, chunks) => {
+    it('demotes the leading balanced nested literal at the start of the stream', () => {
+      // The leading <think></think> balances, so the block is demoted and the
+      // remainder flows through the tagged-thinking parser's documented
+      // binary toggle (issue #10791) instead of being preserved verbatim.
       const stream = withStreamParser();
       stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+      const chunks = [
+        '<think></think><think>outer <think>literal',
+        '</think></think>',
+      ];
+      const parts = chunks.flatMap((content, index) => {
+        const response = converter.convertOpenAIChunkToLlm(
+          streamChunk(
+            `balanced-${index}`,
+            { content },
+            index === chunks.length - 1 ? 'stop' : null,
+          ),
+          stream,
+        );
+        return response.candidates?.[0]?.content?.parts ?? [];
+      });
+
+      expect(parts).toEqual([
+        { text: 'outer <think>literal', thought: true },
+        { text: '</think>' },
+      ]);
+    });
+
+    it('preserves balanced nested literals after visible content', () => {
+      const stream = withStreamParser();
+      stream.responseParsingOptions = { contentOnlyThinkingTagLeaks: true };
+      const chunks = [
+        'Explanation: ',
+        '<think></think><think>outer <think>literal</think></think>',
+      ];
       const parts = chunks.flatMap((content, index) => {
         const response = converter.convertOpenAIChunkToLlm(
           streamChunk(
@@ -761,7 +937,12 @@ describe('OpenAIContentConverter', () => {
         stream,
       );
 
-      expect(response.candidates?.[0]?.content?.parts).toEqual([]);
+      // The leading balanced <think></think> activates the demotion parser
+      // (issue #10791), which buffers the unclosed tail in the hidden
+      // thought channel; the turn still fails closed at stream finish.
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: '9<think>' + 'x'.repeat(257), thought: true },
+      ]);
       expect(() => finishStream(stream, 'stop')).toThrowError(
         expect.objectContaining({ type: 'PROTOCOL_TAG_LEAK' }),
       );
@@ -5386,7 +5567,7 @@ describe('OpenAIContentConverter', () => {
       ]);
     });
 
-    it('should leave tags visible when tagged thinking parsing is disabled', () => {
+    it('demotes a balanced leading block on content-only non-streaming turns', () => {
       const response = converter.convertOpenAIResponseToLlm(
         {
           object: 'chat.completion',
@@ -5398,7 +5579,7 @@ describe('OpenAIContentConverter', () => {
               index: 0,
               message: {
                 role: 'assistant',
-                content: '<think>visible xml example</think>',
+                content: '<thinking>visible xml example</thinking>answer',
               },
               finish_reason: 'stop',
               logprobs: null,
@@ -5411,8 +5592,74 @@ describe('OpenAIContentConverter', () => {
         },
       );
 
+      // Non-streaming completions get the same treatment as streams
+      // (issue #10791): the balanced leading block is demoted to a thought
+      // part and only the trailing answer stays user-visible.
       expect(response.candidates?.[0]?.content?.parts).toEqual([
-        { text: '<think>visible xml example</think>' },
+        { text: 'visible xml example', thought: true },
+        { text: 'answer' },
+      ]);
+    });
+
+    it('keeps non-streaming tags visible without contentOnlyThinkingTagLeaks provenance', () => {
+      const response = converter.convertOpenAIResponseToLlm(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-openai-2',
+          created: 123,
+          model: 'gpt-test',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: '<think>literal example</think>answer',
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        requestContext,
+      );
+
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: '<think>literal example</think>answer' },
+      ]);
+    });
+
+    it('keeps a non-streaming leading block untouched on structured-reasoning turns', () => {
+      const response = converter.convertOpenAIResponseToLlm(
+        {
+          object: 'chat.completion',
+          id: 'chatcmpl-openai-3',
+          created: 123,
+          model: 'gpt-test',
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: 'assistant',
+                content: '<think>second phase</think>answer',
+                reasoning_content: 'first phase',
+              },
+              finish_reason: 'stop',
+              logprobs: null,
+            },
+          ],
+        } as unknown as OpenAI.Chat.ChatCompletion,
+        {
+          ...requestContext,
+          responseParsingOptions: { contentOnlyThinkingTagLeaks: true },
+        },
+      );
+
+      // The content-only demotion only covers turns with no structured
+      // reasoning channel; reasoning turns keep the inline-block handling
+      // of the streaming path unchanged for now.
+      expect(response.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'first phase', thought: true },
+        { text: '<think>second phase</think>answer' },
       ]);
     });
 

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1227,6 +1227,31 @@ function classifyContentOnlyThinkingTagPrefix(
   return streamFinished ? 'leaked' : 'suspicious';
 }
 
+/**
+ * Whether the text starts with an opening thinking tag whose block is fully
+ * balanced by a closing tag (counting nesting), i.e. the leading
+ * `<think>/<thinking> ... </think>/</thinking>` shape production captures
+ * showed as leaked chain-of-thought (issues #6666, #10791). False for a
+ * leading closing tag, no leading tag, or a block that has not balanced yet.
+ * Shares the depth-counting semantics of classifyContentOnlyThinkingTagPrefix.
+ */
+function hasLeadingBalancedThinkingBlock(text: string): boolean {
+  const candidate = text.trimStart();
+  const opening = LEADING_THINKING_TAG_PATTERN.exec(candidate)?.[0];
+  if (!opening || opening.trimStart().startsWith('</')) return false;
+
+  let rest = candidate.slice(opening.length);
+  let depth = 1;
+  for (;;) {
+    const nextTag = THINKING_TAG_PATTERN.exec(rest);
+    if (!nextTag) return false;
+
+    depth += nextTag[0].startsWith('</') ? -1 : 1;
+    if (depth === 0) return true;
+    rest = rest.slice(nextTag.index + nextTag[0].length);
+  }
+}
+
 function throwProtocolTagLeak(requestContext: RequestContext): never {
   requestContext.pendingThinkingTagCandidate = undefined;
   requestContext.pendingUntrustedResponseParts = undefined;
@@ -1250,9 +1275,21 @@ export function convertOpenAIResponseToLlm(
 
   if (choice) {
     const parts: Part[] = [];
-    const textParts = choice.message.content
-      ? convertOpenAITextToParts(choice.message.content, requestContext)
-      : [];
+    let textParts: Part[] = [];
+    if (choice.message.content) {
+      // Balanced leading thinking blocks leak to user-visible output on
+      // content-only turns of non-streaming completions too (issue #10791):
+      // with no structured reasoning channel, demote the block through the
+      // same tagged-thinking parser the streaming path uses instead of
+      // passing the raw tags through verbatim.
+      textParts =
+        requestContext.responseParsingOptions?.contentOnlyThinkingTagLeaks ===
+          true &&
+        !reasoningText &&
+        hasLeadingBalancedThinkingBlock(choice.message.content)
+          ? parseTaggedThinkingText(choice.message.content)
+          : convertOpenAITextToParts(choice.message.content, requestContext);
+    }
 
     // Handle reasoning content (thoughts).
     // Tagged thinking providers may put thoughts in content, while other
@@ -1427,12 +1464,27 @@ export function convertOpenAIChunkToLlm(
       const taggedThinkingCandidate =
         (requestContext.pendingThinkingTagCandidate?.text ?? '') +
         normalizedContent;
+      // A content-only turn (no structured reasoning yet, nothing visible
+      // emitted) whose leading <think>/<thinking> block is fully balanced is
+      // demoted exactly like the structured-reasoning inline blocks above:
+      // production captures (issues #6666, #10791) show this shape is leaked
+      // chain-of-thought the model wrote into content, not legitimate literal
+      // text. Unclosed blocks keep flowing through the hold/reject classifier
+      // below so their fail-closed behavior is unchanged.
+      const contentOnlyBalancedThinkingBlock =
+        requestContext.responseParsingOptions?.contentOnlyThinkingTagLeaks ===
+          true &&
+        !requestContext.hasStructuredReasoningContent &&
+        !reasoningText &&
+        requestContext.hasVisibleContent !== true &&
+        hasLeadingBalancedThinkingBlock(taggedThinkingCandidate);
       if (
-        requestContext.responseParsingOptions
+        (requestContext.responseParsingOptions
           ?.taggedThinkingTagsAfterReasoning &&
-        (requestContext.hasStructuredReasoningContent || reasoningText) &&
-        LEADING_THINKING_TAG_PATTERN.test(taggedThinkingCandidate) &&
-        !taggedThinkingCandidate.trimStart().startsWith('</')
+          (requestContext.hasStructuredReasoningContent || reasoningText) &&
+          LEADING_THINKING_TAG_PATTERN.test(taggedThinkingCandidate) &&
+          !taggedThinkingCandidate.trimStart().startsWith('</')) ||
+        contentOnlyBalancedThinkingBlock
       ) {
         requestContext.taggedThinkingParser ??= new TaggedThinkingParser();
         requestContext.pendingThinkingTagCandidate = undefined;
@@ -1456,7 +1508,9 @@ export function convertOpenAIChunkToLlm(
 
     if (
       choice.finish_reason &&
-      requestContext.responseParsingOptions?.taggedThinkingTagsAfterReasoning &&
+      (requestContext.responseParsingOptions
+        ?.taggedThinkingTagsAfterReasoning ||
+        requestContext.responseParsingOptions?.contentOnlyThinkingTagLeaks) &&
       requestContext.taggedThinkingParser?.hasUnclosedThought()
     ) {
       throwProtocolTagLeak(requestContext);

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1162,6 +1162,33 @@ function canBeStandaloneThinkingTagPrefix(text: string): boolean {
   });
 }
 
+/**
+ * Scan the text following a consumed opening thinking tag and report whether
+ * a later tag returns the nesting depth to zero, plus whether any nested
+ * opening tag was seen along the way. Single shared depth-counting
+ * implementation for the hold/reject classifier
+ * (classifyContentOnlyThinkingTagPrefix) and the leading-block demotion
+ * detector (hasLeadingBalancedThinkingBlock) so the two scanners can never
+ * drift apart on what "balanced" means.
+ */
+function scanThinkingTagBalance(rest: string): {
+  balanced: boolean;
+  hasNestedOpening: boolean;
+} {
+  let depth = 1;
+  let hasNestedOpening = false;
+  for (;;) {
+    const nextTag = THINKING_TAG_PATTERN.exec(rest);
+    if (!nextTag) return { balanced: false, hasNestedOpening };
+
+    const closing = nextTag[0].startsWith('</');
+    depth += closing ? -1 : 1;
+    if (depth === 0) return { balanced: true, hasNestedOpening };
+    hasNestedOpening ||= !closing;
+    rest = rest.slice(nextTag.index + nextTag[0].length);
+  }
+}
+
 function classifyContentOnlyThinkingTagPrefix(
   text: string,
   streamFinished: boolean,
@@ -1210,19 +1237,8 @@ function classifyContentOnlyThinkingTagPrefix(
     }
   }
 
-  let depth = 1;
-  let hasNestedOpening = false;
-  for (;;) {
-    const nextTag = THINKING_TAG_PATTERN.exec(rest);
-    if (!nextTag) break;
-
-    const closing = nextTag[0].startsWith('</');
-    depth += closing ? -1 : 1;
-    if (depth === 0) return 'clean';
-    hasNestedOpening ||= !closing;
-    rest = rest.slice(nextTag.index + nextTag[0].length);
-  }
-
+  const { balanced, hasNestedOpening } = scanThinkingTagBalance(rest);
+  if (balanced) return 'clean';
   if (!hasNestedOpening) return 'pending';
   return streamFinished ? 'leaked' : 'suspicious';
 }
@@ -1233,23 +1249,16 @@ function classifyContentOnlyThinkingTagPrefix(
  * `<think>/<thinking> ... </think>/</thinking>` shape production captures
  * showed as leaked chain-of-thought (issues #6666, #10791). False for a
  * leading closing tag, no leading tag, or a block that has not balanced yet.
- * Shares the depth-counting semantics of classifyContentOnlyThinkingTagPrefix.
+ * Delegates to the same depth-counting scan as
+ * classifyContentOnlyThinkingTagPrefix so detector and classifier share one
+ * source of truth for balance.
  */
 function hasLeadingBalancedThinkingBlock(text: string): boolean {
   const candidate = text.trimStart();
   const opening = LEADING_THINKING_TAG_PATTERN.exec(candidate)?.[0];
   if (!opening || opening.trimStart().startsWith('</')) return false;
 
-  let rest = candidate.slice(opening.length);
-  let depth = 1;
-  for (;;) {
-    const nextTag = THINKING_TAG_PATTERN.exec(rest);
-    if (!nextTag) return false;
-
-    depth += nextTag[0].startsWith('</') ? -1 : 1;
-    if (depth === 0) return true;
-    rest = rest.slice(nextTag.index + nextTag[0].length);
-  }
+  return scanThinkingTagBalance(candidate.slice(opening.length)).balanced;
 }
 
 function throwProtocolTagLeak(requestContext: RequestContext): never {
@@ -1282,13 +1291,33 @@ export function convertOpenAIResponseToLlm(
       // with no structured reasoning channel, demote the block through the
       // same tagged-thinking parser the streaming path uses instead of
       // passing the raw tags through verbatim.
-      textParts =
+      const demoteLeadingContentOnlyBlock =
         requestContext.responseParsingOptions?.contentOnlyThinkingTagLeaks ===
           true &&
         !reasoningText &&
-        hasLeadingBalancedThinkingBlock(choice.message.content)
-          ? parseTaggedThinkingText(choice.message.content)
-          : convertOpenAITextToParts(choice.message.content, requestContext);
+        hasLeadingBalancedThinkingBlock(choice.message.content);
+      if (demoteLeadingContentOnlyBlock) {
+        // Parse with a real TaggedThinkingParser and fail closed when the
+        // closing tag never arrives, mirroring the streaming finish guard:
+        // the tolerant balance detector accepts whitespace like
+        // `</think >` that the parser's exact tag literals do not, and the
+        // old throwaway parse would silently hide the whole message —
+        // including the visible answer — in the thought channel (review
+        // finding 1 / #10982). Stray closing tags left by depth-nested
+        // input are stripped as protocol remnants (review finding 2).
+        const parser = new TaggedThinkingParser({
+          stripStrayClosingTags: true,
+        });
+        textParts = parser.parse(choice.message.content, true);
+        if (parser.hasUnclosedThought()) {
+          throwProtocolTagLeak(requestContext);
+        }
+      } else {
+        textParts = convertOpenAITextToParts(
+          choice.message.content,
+          requestContext,
+        );
+      }
     }
 
     // Handle reasoning content (thoughts).
@@ -1486,7 +1515,15 @@ export function convertOpenAIChunkToLlm(
           !taggedThinkingCandidate.trimStart().startsWith('</')) ||
         contentOnlyBalancedThinkingBlock
       ) {
-        requestContext.taggedThinkingParser ??= new TaggedThinkingParser();
+        // The content-only demotion detector counts nesting depth while the
+        // parser is a binary toggle, so depth-nested input can return the
+        // parser to text mode one tag early and leak a stray closing tag as
+        // the visible answer — strip those remnants on the demotion path
+        // (review finding 2). The after-reasoning branch keeps the default
+        // parser so its literal-tag behavior is unchanged.
+        requestContext.taggedThinkingParser ??= contentOnlyBalancedThinkingBlock
+          ? new TaggedThinkingParser({ stripStrayClosingTags: true })
+          : new TaggedThinkingParser();
         requestContext.pendingThinkingTagCandidate = undefined;
         contentParts = requestContext.taggedThinkingParser.parse(
           taggedThinkingCandidate,

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -25,6 +25,7 @@ import {
 import { OpenAIContentConverter } from './converter.js';
 import { openaiRequestCaptureContext } from './requestCaptureContext.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
+import { TaggedThinkingParser } from './taggedThinkingParser.js';
 import type { Config } from '../../config/config.js';
 import { AuthType, type ContentGeneratorConfig } from '../contentGenerator.js';
 import type { OpenAICompatibleProvider } from './provider/index.js';
@@ -3036,6 +3037,67 @@ describe('ContentGenerationPipeline', () => {
           return emptyResponse;
         },
       );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue(
+        mockStream,
+      );
+
+      const resultGenerator = await pipeline.executeStream(
+        request,
+        'test-prompt-id',
+      );
+
+      await expect(async () => {
+        for await (const _ of resultGenerator) {
+          // Consume until EOF validation runs.
+        }
+      }).rejects.toMatchObject({ type: 'PROTOCOL_TAG_LEAK' });
+      expect(logProtocolTagSanitized).not.toHaveBeenCalled();
+    });
+
+    it('rejects an unclosed thinking block at clean stream EOF after content-only demotion', async () => {
+      // Review finding 4: the converter's finish-reason guard only runs when
+      // a chunk carries finish_reason. When the stream ends without one
+      // (truncated connection, provider quirk), the post-loop pipeline guard
+      // is the only fail-closed backstop — so it must also cover the
+      // contentOnlyThinkingTagLeaks demotion path, not just
+      // taggedThinkingTagsAfterReasoning.
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            id: 'response-id',
+            choices: [
+              {
+                delta: { content: '<think>a</think>ok<think>oops' },
+                finish_reason: null,
+              },
+            ],
+          } as OpenAI.Chat.ChatCompletionChunk;
+        },
+      };
+      const emptyResponse = new GenerateContentResponse();
+      emptyResponse.candidates = [
+        { content: { parts: [], role: 'model' }, index: 0 },
+      ];
+
+      (mockConverter.convertLlmRequestToOpenAI as Mock).mockReturnValue([]);
+      (mockConverter.convertOpenAIChunkToLlm as Mock).mockImplementation(
+        (_chunk, context) => {
+          // Simulate the post-demotion converter state (PR #11188): the
+          // content-only demotion installed a tagged-thinking parser whose
+          // thought block never closed, and no finish_reason chunk ever
+          // reached the converter guard.
+          context.taggedThinkingParser ??= new TaggedThinkingParser();
+          context.taggedThinkingParser.parse('<think>a</think>ok<think>oops');
+          return emptyResponse;
+        },
+      );
+      mockProvider.getResponseParsingOptions = vi.fn().mockReturnValue({
+        contentOnlyThinkingTagLeaks: true,
+      });
       (mockClient.chat.completions.create as Mock).mockResolvedValue(
         mockStream,
       );

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -674,7 +674,13 @@ export class ContentGenerationPipeline {
         }
       } else if (
         context.pendingThinkingTagCandidate ||
-        (context.responseParsingOptions?.taggedThinkingTagsAfterReasoning &&
+        // Mirrors the converter's finish-reason guard: a demotion-installed
+        // parser with an unclosed thought must fail closed at stream end
+        // even when no chunk ever carried finish_reason (truncated
+        // connection, provider quirk) — for both the after-reasoning and
+        // the content-only demotion options.
+        ((context.responseParsingOptions?.taggedThinkingTagsAfterReasoning ||
+          context.responseParsingOptions?.contentOnlyThinkingTagLeaks) &&
           context.taggedThinkingParser?.hasUnclosedThought())
       ) {
         throw new InvalidStreamError(

--- a/packages/core/src/core/openaiContentGenerator/taggedThinkingParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/taggedThinkingParser.ts
@@ -61,9 +61,25 @@ function findMatchingTag(
   return tags.find((tag) => lower.startsWith(tag, offset));
 }
 
+export interface TaggedThinkingParserOptions {
+  /**
+   * Drop closing tags encountered while in text mode instead of releasing
+   * them as visible text. The parser is a binary toggle while the demotion
+   * detector counts nesting depth, so depth-nested input (e.g.
+   * `<think></think><think>outer <think>x</think></think>`) returns the
+   * parser to text mode one tag early and the leftover closing tags are
+   * protocol remnants, not user-facing content. Only the content-only
+   * demotion path opts in; providers that expect literal tags keep the
+   * default so literal text is still preserved.
+   */
+  stripStrayClosingTags?: boolean;
+}
+
 export class TaggedThinkingParser {
   private mode: ParserMode = 'text';
   private buffer = '';
+
+  constructor(private readonly options: TaggedThinkingParserOptions = {}) {}
 
   hasUnclosedThought(): boolean {
     return this.mode === 'thought';
@@ -95,7 +111,30 @@ export class TaggedThinkingParser {
         continue;
       }
 
-      if (!final && isPrefixOfAnyTag(lower, index, activeTags)) {
+      // A closing tag while already in text mode can only be a stray
+      // remnant of depth-nested input: strip it instead of leaking it into
+      // the visible channel. The surrounding segment keeps accumulating,
+      // so `ok</think>more` collapses to a single `okmore` part.
+      if (this.options.stripStrayClosingTags && this.mode === 'text') {
+        const strayClosingTag = findMatchingTag(lower, index, CLOSE_TAGS);
+        if (strayClosingTag) {
+          debugLogger.debug(
+            `taggedThinking: stripped stray closing tag "${strayClosingTag}" at offset ${index}`,
+          );
+          index += strayClosingTag.length;
+          continue;
+        }
+      }
+
+      if (
+        !final &&
+        (isPrefixOfAnyTag(lower, index, activeTags) ||
+          // Hold partial closing-tag prefixes mid-stream (strip mode only)
+          // so a stray tag split across chunks is still recognized.
+          (this.options.stripStrayClosingTags &&
+            this.mode === 'text' &&
+            isPrefixOfAnyTag(lower, index, CLOSE_TAGS)))
+      ) {
         break;
       }
 


### PR DESCRIPTION
## What this PR does

Hybrid-thinking models occasionally bypass the structured reasoning channel and write their thinking as a literal, properly balanced `<think>/<thinking> ... </think>/</thinking>` block at the very start of `content`. This PR demotes such a leading balanced block to a hidden thought part instead of letting it flow to user-visible output:

- On streaming turns (no structured reasoning seen yet, nothing visible emitted), a leading balanced block is routed through the same `TaggedThinkingParser` the structured-reasoning path already uses; the block becomes a thought part and any trailing answer text is released normally.
- On non-streaming completions (`convertOpenAIResponseToLlm`), the same balanced-leading-block demotion applies, closing the parallel gap where a balanced block in a non-streaming completion passed through verbatim.
- Both demotions stay gated on the existing `contentOnlyThinkingTagLeaks` parsing option (enabled by the default provider), so providers that expect literal tagged text are unaffected.
- Unclosed/unbalanced blocks keep flowing through the existing hold/reject classifier: after a demotion, a block that opens but never closes still fails closed with `PROTOCOL_TAG_LEAK` at stream finish.

## Why it's needed

Fixes the user-visible thinking leak in #10791. The protocol-tag whitelist (`PROTOCOL_TAG_PREFIXES`) does not include `<thinking`, so the leading-tag leak detector cannot catch this shape, and the content-only leak classifier (issue #8818) only rejected the unclosed form: once the leading block balanced, `classifyContentOnlyThinkingTagPrefix` returned `clean` and the entire chain-of-thought block reached user-visible output. #9607's demotion covered only structured-reasoning turns, and non-streaming completions never consulted the leak options at all. Production captures (issues #6666, #10791) show the balanced shape is leaked chain-of-thought the model wrote into content, not legitimate literal text.

### History: prior verified version of this change

A previous version of this change (#10982) received a full A/B verification review from maintainer @wenshao with verdict "works, recommend merge" (see #10982 review), but was closed by the author during a CI infra outage (triage model API failures on 09-04) — a self-close made on the mistaken belief that two red infra checks (triage + npm audit) invalidated the PR; they were later confirmed to be transient infrastructure failures, and no maintainer had asked for the PR to be closed. The approvals on a closed PR do not carry over, hence this respin. This PR respins that exact implementation on current main. The diff vs the verified version is a pure rebase/migration: no behavioral changes were made, so the earlier A/B verification review applies directly to this code.

Differences from #10982: none in implementation semantics — the verified commit was cherry-picked onto current `main` (the surrounding file had only unrelated schema-validation drift, and merged cleanly with zero conflicts); the applied patch is line-for-line identical to the one @wenshao reviewed. The non-blocking F1/F2 follow-up ideas from the #10982 review thread were intentionally not folded in, to keep this respin exactly comparable to the verified version; they can be addressed in separate PRs.

## Reviewer Test Plan

### How to verify

- `npx vitest run packages/core/src/core/openaiContentGenerator/converter.test.ts packages/core/src/core/openaiContentGenerator/taggedThinkingParser.test.ts packages/core/src/core/openaiContentGenerator/pipeline.test.ts packages/core/src/core/openaiContentGenerator/provider/default.test.ts packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts packages/core/src/core/llm-chat.test.ts`
- `npm run typecheck`
- Manual shape check: a content-only stream beginning with `<thinking>\n...reasoning...\n</thinking>\n\nHere is the answer.` now yields a thought part for the block and a normal text part for the answer; an unbalanced opening tag still ends the stream with `PROTOCOL_TAG_LEAK`.

### Evidence (Before & After)

- Before: balanced leading `<thinking>...</thinking>` block passed through as literal user-visible text (classifier returned `clean` once balanced). After: block demoted to `thought: true` part, trailing answer released normally; `PROTOCOL_TAG_LEAK` still thrown for unclosed blocks. See unit tests `demotes a balanced content-only thinking block with trailing answer (issue #10791)` and the non-streaming regressions in `converter.test.ts`. Full log table below.

| Check | Command | Result |
| :-- | :-- | :-- |
| Converter unit tests (241, incl. streaming + non-streaming demotion, gate controls, regressions) | `npx vitest run packages/core/src/core/openaiContentGenerator/converter.test.ts` | PASS |
| TaggedThinkingParser + pipeline tests (27 + 170) | `npx vitest run packages/core/src/core/openaiContentGenerator/taggedThinkingParser.test.ts packages/core/src/core/openaiContentGenerator/pipeline.test.ts` | PASS (197) |
| Provider gate tests (default, dashscope) + llm-chat detector tests | `npx vitest run packages/core/src/core/openaiContentGenerator/provider/default.test.ts packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts packages/core/src/core/llm-chat.test.ts` | PASS (594) |
| Typecheck | `npm run typecheck` | PASS (no errors) |

Total: 1032 unit tests passed across the six suites; `tsc --noEmit` clean for all workspace packages.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ⚠️    |

### Environment (optional)

Local `npm run build` + `npx vitest run` on macOS (arm64); unit tests only.

## Risk & Scope

- Main risk or tradeoff: models that legitimately intend a literal balanced `<think>` block as user-visible text would now have it hidden as a thought. This is gated on `contentOnlyThinkingTagLeaks` (set by the default provider for the qwen-code chat path) and matches the shape of every production capture so far (#6666, #10791); external/custom providers are unaffected.
- Not validated / out of scope: manual E2E against a live hybrid-thinking model was covered by the #10982 A/B review; not repeated locally here. Windows/Linux runtime not tested locally (CI covers).
- Breaking changes / migration notes: none. Fail-closed behavior for unclosed blocks is unchanged.

## Linked Issues

Fixes #10791

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

混合思考模型偶尔会绕过结构化推理通道，把思考内容以字面量形式写进 `content` 开头——一个完整闭合的 `<think>/<thinking> ... </think>/</thinking>` 块。本 PR 把这种位于开头且已闭合的思考块降级为隐藏的 thought part，而不是让它流入用户可见输出：

- 流式回合（尚无结构化推理、尚未输出任何可见内容）中，开头的闭合思考块走结构化推理路径已在用的同一个 `TaggedThinkingParser`：块变成 thought part，其后的正文正常输出。
- 非流式补全（`convertOpenAIResponseToLlm`）应用同样的闭合块降级，堵住"非流式补全里的闭合块被原样透传"的对称缺口。
- 两处降级都由既有的 `contentOnlyThinkingTagLeaks` 解析选项门控（默认 provider 已开启），期望收到字面量标签文本的其他 provider 不受影响。
- 未闭合/未配平的块仍走既有的 hold/reject 分类器：降级之后若块只开不闭，流结束时依旧以 `PROTOCOL_TAG_LEAK` 失败关闭。

## 为什么需要

修复 #10791 中用户可见的思考内容泄漏。协议标签白名单（`PROTOCOL_TAG_PREFIXES`）不含 `<thinking`，开头的泄漏检测器抓不住这个形态；而 content-only 泄漏分类器（issue #8818）只拒绝未闭合形态：一旦开头块配平，`classifyContentOnlyThinkingTagPrefix` 返回 `clean`，整段思维链就到达了用户可见输出。#9607 的降级只覆盖结构化推理回合，非流式补全则完全没有参考泄漏选项。生产抓包（issues #6666、#10791）表明这种闭合形态是模型写进 content 的泄漏思维链，不是合法字面文本。

### 历史：本改动的上一版已通过验证

本改动上一版（#10982）曾获 maintainer @wenshao 的完整 A/B 验证 review，结论为 "works, recommend merge"（见 #10982 review），但作者在 CI infra 故障期间（09-04 的 triage model API failures）自行关闭了该 PR——当时误以为两个红 check（triage + npm audit）使 PR 失效，事后确认均为瞬时基础设施故障，且没有任何 maintainer 要求关闭。已关闭 PR 上的 approval 不会延续，因此有了本 respin。本 PR 将那份实现原样 respin 到当前 main。与已验证版本相比是纯 rebase/迁移，无任何行为改动，旧的 A/B 验证 review 可直接适用于本代码。

与 #10982 的差异：实现语义零差异——已验证 commit 直接 cherry-pick 到当前 `main`（周边文件只有无关的 schema 校验漂移，零冲突干净合并），所应用 patch 与 @wenshao 当年 review 的版本逐行一致。#10982 review 里提出的 non-blocking F1/F2 follow-up 有意未并入，以保持本 respin 与已验证版本完全可比；它们可在后续独立 PR 中处理。

## Reviewer 验证计划

### 如何验证

- `npx vitest run packages/core/src/core/openaiContentGenerator/converter.test.ts packages/core/src/core/openaiContentGenerator/taggedThinkingParser.test.ts packages/core/src/core/openaiContentGenerator/pipeline.test.ts packages/core/src/core/openaiContentGenerator/provider/default.test.ts packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts packages/core/src/core/llm-chat.test.ts`
- `npm run typecheck`
- 手工形态检查：以 `<thinking>\n...推理...\n</thinking>\n\nHere is the answer.` 开头的 content-only 流，现在块产出 thought part、正文正常输出；未配平的开标签仍以 `PROTOCOL_TAG_LEAK` 结束流。

### 证据（改造前后）

- 改造前：开头闭合的 `<thinking>...</thinking>` 块作为字面文本透传到用户可见输出（块一旦配平分类器即返回 `clean`）。改造后：块降级为 `thought: true` part，其后正文正常输出；未闭合块仍抛 `PROTOCOL_TAG_LEAK`。见 `converter.test.ts` 中的回归用例 `demotes a balanced content-only thinking block with trailing answer (issue #10791)` 及非流式回归。完整日志表见上方英文段。

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

## 风险与范围

- 主要风险或取舍：若某模型真的想让闭合的 `<think>` 块作为用户可见字面文本，现在会被隐藏为 thought。该行为由 `contentOnlyThinkingTagLeaks` 门控（默认 provider 在 qwen-code 聊天路径上开启），且与迄今所有生产抓包形态一致（#6666、#10791）；外部/自定义 provider 不受影响。
- 未验证/范围外：对真实混合思考模型的手工 E2E 已由 #10982 的 A/B review 覆盖，本次未在本地重复；Windows/Linux 未本地验证（CI 覆盖）。
- 破坏性变更/迁移说明：无。未闭合块的失败关闭行为不变。

## 关联 Issue

Fixes #10791

</details>
