### PR TITLE
fix(core): catch tool-result scaffolding and system-reminder echo leaks (#10797)

### DIFF
--- a/packages/core/src/core/llm-chat.test.ts
+++ b/packages/core/src/core/llm-chat.test.ts
@@ -13118,6 +13118,286 @@ describe('LlmChat', async () => {
     expect(chat.getLastModelMessageText()).toBe(response);
   });
 
+  it('retries a response that opens with tool-result scaffolding tags (#10797)', async () => {
+    vi.mocked(mockContentGenerator.generateContentStream)
+      .mockImplementationOnce(async () =>
+        (async function* () {
+          yield {
+            candidates: [
+              {
+                content: {
+                  parts: [
+                    { text: 'planning the edit', thought: true },
+                    {
+                      text:
+                        '<file_path>/tmp/app.ts</file_path>' +
+                        '<action>saved</action>' +
+                        '<summary>Wrote the file.</summary>' +
+                        '</tool_result>' +
+                        '\n\nI saved the file.',
+                    },
+                  ],
+                },
+                finishReason: 'STOP',
+              },
+            ],
+          } as unknown as GenerateContentResponse;
+        })(),
+      )
+      .mockImplementationOnce(async () =>
+        streamResponse(stopResponse([{ text: 'Saved the file cleanly.' }])),
+      );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-tool-result-scaffolding-leak',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(2);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      true,
+    );
+    const emittedText = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? [])
+      .map((part) => part.text ?? '')
+      .join('');
+    expect(emittedText).toBe('Saved the file cleanly.');
+    expect(emittedText).not.toContain('file_path');
+    expect(chat.getLastModelMessageText()).toBe('Saved the file cleanly.');
+  });
+
+  it('holds a split tool-result scaffolding prefix across chunks and still retries (#10797)', async () => {
+    vi.mocked(mockContentGenerator.generateContentStream)
+      .mockImplementationOnce(async () =>
+        (async function* () {
+          yield {
+            candidates: [{ content: { parts: [{ text: '<file_pa' }] } }],
+          } as unknown as GenerateContentResponse;
+          yield stopResponse([
+            {
+              text:
+                'th>/tmp/app.ts</file_path>' +
+                '<action>saved</action>' +
+                '</tool_result>' +
+                '\n\nDone.',
+            },
+          ]);
+        })(),
+      )
+      .mockImplementationOnce(async () =>
+        streamResponse(stopResponse([{ text: 'All set.' }])),
+      );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-split-tool-result-scaffolding-leak',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(2);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      true,
+    );
+    const emittedText = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? [])
+      .map((part) => part.text ?? '')
+      .join('');
+    expect(emittedText).toBe('All set.');
+  });
+
+  it('does not reject tool-result scaffolding tag names in mid-prose (#10797)', async () => {
+    const response =
+      'Pass <file_path> in the schema and mark the <action> field optional.';
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      streamResponse(stopResponse([{ text: response }])),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-tool-result-tags-in-prose',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(chat.getLastModelMessageText()).toBe(response);
+  });
+
+  it('strips a backtick-wrapped system-reminder echo without retrying (#10797)', async () => {
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      (async function* () {
+        yield {
+          candidates: [{ content: { parts: [{ text: '`<system-remi' }] } }],
+        } as unknown as GenerateContentResponse;
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text:
+                      'nder>\nThe current task still has unfinished todo items:\n' +
+                      '- [ ] write tests\n' +
+                      '</system-reminder>`',
+                  },
+                ],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+        yield stopResponse([
+          { text: '\n\nUpdating the todo list now.' },
+          {
+            functionCall: {
+              id: 'call-1',
+              name: 'todo_write',
+              args: { todos: [] },
+            },
+          },
+        ]);
+      })(),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-system-reminder-echo-strip',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    const emittedParts = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? []);
+    const emittedText = emittedParts.map((part) => part.text ?? '').join('');
+    expect(emittedText).toBe('\n\nUpdating the todo list now.');
+    expect(emittedText).not.toContain('system-reminder');
+    expect(emittedParts).toContainEqual({
+      functionCall: {
+        id: 'call-1',
+        name: 'todo_write',
+        args: { todos: [] },
+      },
+    });
+    const recordedText = (chat.getHistory().at(-1)?.parts ?? [])
+      .map((part) => part.text ?? '')
+      .join('');
+    expect(recordedText).toBe('\n\nUpdating the todo list now.');
+  });
+
+  it('strips a fenced system-reminder echo between paragraphs (#10797)', async () => {
+    const response =
+      'First paragraph.\n\n```\n<system-reminder>\nstale todos\n</system-reminder>\n```\nLast paragraph.';
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      streamResponse(stopResponse([{ text: response }])),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-fenced-system-reminder-echo',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(chat.getLastModelMessageText()).toBe(
+      'First paragraph.\n\nLast paragraph.',
+    );
+  });
+
+  it('keeps a line-start code-span mention of the system-reminder tag intact (#10797)', async () => {
+    const response =
+      'Line one\n`<system-reminder>` tags and `code` spans are kept verbatim.';
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      streamResponse(stopResponse([{ text: response }])),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-inline-system-reminder-mention',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(chat.getLastModelMessageText()).toBe(response);
+  });
+
+  it('releases an unterminated backtick-wrapped reminder echo verbatim (#10797)', async () => {
+    const response =
+      '`<system-reminder>\nThe current task still has unfinished todo items:';
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      streamResponse(stopResponse([{ text: response }])),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-unterminated-reminder-echo',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(chat.getLastModelMessageText()).toBe(response);
+  });
+
+  it('does not strip an unwrapped system-reminder mention (#10797)', async () => {
+    const response =
+      'Reminders arrive as <system-reminder> blocks in the conversation.';
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      streamResponse(stopResponse([{ text: response }])),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-unwrapped-system-reminder-mention',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(chat.getLastModelMessageText()).toBe(response);
+  });
+
   it('retries leaked JSON before a structured tool call', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/core/llm-chat.test.ts
+++ b/packages/core/src/core/llm-chat.test.ts
@@ -13474,6 +13474,74 @@ describe('LlmChat', async () => {
     expect(chat.getLastModelMessageText()).toBe('All done.');
   });
 
+  it('keeps sibling text when an empty part follows released text in one chunk (#10797)', async () => {
+    // Regression: the empty-text guard used to withdraw earlier parts of the
+    // same chunk whenever the echo filter was idle, parking text that had
+    // already been released past every buffer; the stripped flush then
+    // dropped it ('Hello ' vanished and only 'world' reached the user).
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      streamResponse(
+        stopResponse([{ text: 'Hello ' }, { text: '' }, { text: 'world' }]),
+      ),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-empty-part-between-text',
+    );
+    const events: StreamEvent[] = [];
+    let emittedText = '';
+    for await (const event of stream) {
+      events.push(event);
+      if (event.type === StreamEventType.CHUNK) {
+        // Snapshot the text as each chunk arrives: history consolidation
+        // later merges text parts by mutating the yielded part objects, so
+        // aggregating after the loop would double-count merged text.
+        emittedText += (event.value.candidates?.[0]?.content?.parts ?? [])
+          .map((part) => part.text ?? '')
+          .join('');
+      }
+    }
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(emittedText).toBe('Hello world');
+    expect(chat.getLastModelMessageText()).toBe('Hello world');
+  });
+
+  it('keeps the whole reply when a trailing empty part ends the chunk (#10797)', async () => {
+    // Regression: with the echo filter idle, a trailing empty part withdrew
+    // the already-released 'Hello world' into the pending buffer and the
+    // stripped finish dropped it — the entire reply went missing and the
+    // turn burned an avoidable NO_RESPONSE_TEXT retry.
+    vi.mocked(mockContentGenerator.generateContentStream)
+      .mockImplementationOnce(async () =>
+        streamResponse(stopResponse([{ text: 'Hello world' }, { text: '' }])),
+      )
+      .mockImplementationOnce(async () =>
+        streamResponse(stopResponse([{ text: 'RETRY REPLY' }])),
+      );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-trailing-empty-part',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    expect(chat.getLastModelMessageText()).toBe('Hello world');
+  });
+
   it('retries leaked JSON before a structured tool call', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/core/llm-chat.test.ts
+++ b/packages/core/src/core/llm-chat.test.ts
@@ -13398,6 +13398,82 @@ describe('LlmChat', async () => {
     expect(chat.getLastModelMessageText()).toBe(response);
   });
 
+  it('strips two consecutive echoed reminder lines without leaking the second (#10797)', async () => {
+    const response =
+      '`<system-reminder>\nThe current task still has unfinished todo items:\n' +
+      '- [ ] write tests\n' +
+      '</system-reminder>`\n' +
+      '`<system-reminder>\nAnother stale reminder arrived meanwhile.\n' +
+      '</system-reminder>`\n' +
+      'Now updating the todo list.';
+    vi.mocked(
+      mockContentGenerator.generateContentStream,
+    ).mockImplementationOnce(async () =>
+      streamResponse(stopResponse([{ text: response }])),
+    );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-consecutive-system-reminder-echo-strip',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(1);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      false,
+    );
+    const emittedText = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? [])
+      .map((part) => part.text ?? '')
+      .join('');
+    expect(emittedText).toBe('Now updating the todo list.');
+    expect(emittedText).not.toContain('system-reminder');
+    expect(chat.getLastModelMessageText()).toBe('Now updating the todo list.');
+  });
+
+  it('retries an echo-only reply that strips to empty instead of leaking it (#10797)', async () => {
+    // An echo-only reply (no tool call, no thought part) strips to an empty
+    // response, fails closed through NO_RESPONSE_TEXT, and burns one
+    // transient retry — pinned here because the PR description's
+    // "never retries the turn" only holds for echoes paired with a tool
+    // call. Failing closed with a retry is the intended behaviour.
+    const echo =
+      '`<system-reminder>\nThe current task still has unfinished todo items:\n' +
+      '- [ ] write tests\n' +
+      '</system-reminder>`\n';
+    vi.mocked(mockContentGenerator.generateContentStream)
+      .mockImplementationOnce(async () =>
+        streamResponse(stopResponse([{ text: echo }])),
+      )
+      .mockImplementationOnce(async () =>
+        streamResponse(stopResponse([{ text: 'All done.' }])),
+      );
+
+    const stream = await chat.sendMessageStream(
+      'test-model',
+      { message: 'test' },
+      'prompt-id-echo-only-reply-empty-strip',
+    );
+    const events: StreamEvent[] = [];
+    for await (const event of stream) events.push(event);
+
+    expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(2);
+    expect(events.some((event) => event.type === StreamEventType.RETRY)).toBe(
+      true,
+    );
+    const emittedText = events
+      .filter((event) => event.type === StreamEventType.CHUNK)
+      .flatMap((event) => event.value.candidates?.[0]?.content?.parts ?? [])
+      .map((part) => part.text ?? '')
+      .join('');
+    expect(emittedText).toBe('All done.');
+    expect(emittedText).not.toContain('system-reminder');
+    expect(chat.getLastModelMessageText()).toBe('All done.');
+  });
+
   it('retries leaked JSON before a structured tool call', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/core/src/core/llm-chat.ts
+++ b/packages/core/src/core/llm-chat.ts
@@ -119,6 +119,8 @@ import {
 import {
   getStartupContextLength,
   isSystemReminderContent,
+  SYSTEM_REMINDER_CLOSE,
+  SYSTEM_REMINDER_OPEN,
 } from './environmentContext.js';
 import type { SessionStartSource } from '../hooks/types.js';
 import {
@@ -1413,6 +1415,13 @@ const PROTOCOL_TAG_PREFIXES = [
   '</analysis',
   '<summary',
   '</summary',
+  // Harness-style tool-result scaffolding that some models emit as raw XML
+  // before their real reply (#10797 Shape A): a fake `<file_path>` /
+  // `<action>` block closed by a dangling `</tool_result>`. qwen-code never
+  // generates these tags itself, so a response opening with one is a leak.
+  '<file_path',
+  '<action',
+  '</tool_result',
 ] as const;
 const LEAKED_TOOL_CALL_TAGS = /[}\]]\s*<\/parameter>\s*<\/function>/iy;
 
@@ -1512,6 +1521,248 @@ class LeadingProtocolTagLeakDetector {
 
   get blockingOutput(): boolean {
     return this.state !== 'clean';
+  }
+}
+
+/**
+ * Cap on how many bytes an unresolved echo candidate may buffer before the
+ * filter gives up and releases it verbatim (fail-open). Real reminder echoes
+ * are a few hundred bytes; the cap only guards against a pathological
+ * unterminated candidate starving the visible stream.
+ */
+const SYSTEM_REMINDER_ECHO_MAX_BUFFER = 16_000;
+
+/**
+ * Strips `<system-reminder>…</system-reminder>` blocks that the model echoes
+ * back verbatim inside a backtick code span or fence (#10797 Shape B).
+ *
+ * Injected reminders (stale-todo nudges, ACP context) never belong in
+ * user-visible model output, but such an echo is nearly indistinguishable
+ * from a legitimately quoted example, so this filter is deliberately
+ * conservative and fails open:
+ *
+ *   - only blocks whose opening backtick run (1-3 ticks) sits at stream start
+ *     or at the start of a line are candidates — an inline mid-sentence
+ *     mention never triggers;
+ *   - the block must be COMPLETE: `</system-reminder>` followed (after
+ *     optional gap whitespace) by a backtick run at least as long as the
+ *     opener. Anything else — unterminated block, early-closing code span,
+ *     oversized candidate — is released unchanged;
+ *   - a backtick run before the close tag means the code span closed early
+ *     (an inline mention like "`<system-reminder>`"), which also releases
+ *     everything unchanged.
+ *
+ * Unlike the leading protocol-tag detector this never retries the turn: the
+ * echo is stripped in place and the surrounding reply is preserved, because
+ * the reported shape pairs the echo with a real tool call that must survive.
+ */
+class SystemReminderEchoFilter {
+  private holding = false;
+  private buffer = '';
+  private carry = '';
+  private carryAnchored = false;
+  private atStreamStart = true;
+  private openingTicks = 0;
+  private openingRunEnd = 0;
+
+  /**
+   * Evaluate `s`, which starts at a candidate line start, against the echo
+   * trigger grammar: `[ \t]* (`{1,3}) [ \t]* (\r?\n)? [ \t]* <system-reminder>`.
+   * Returns undefined when `s` can no longer become a trigger.
+   */
+  private static matchTrigger(
+    s: string,
+  ): { ticks: number; triggered: boolean } | undefined {
+    let i = 0;
+    while (i < s.length && (s[i] === ' ' || s[i] === '\t')) i++;
+    let ticks = 0;
+    while (i < s.length && s[i] === '`' && ticks < 3) {
+      ticks++;
+      i++;
+    }
+    if (ticks === 0) {
+      return i === s.length ? { ticks: 0, triggered: false } : undefined;
+    }
+    if (i === s.length) return { ticks, triggered: false };
+    let j = i;
+    while (j < s.length && (s[j] === ' ' || s[j] === '\t')) j++;
+    if (j < s.length && s[j] === '\r') {
+      j++;
+      if (j < s.length && s[j] === '\n') j++;
+    } else if (j < s.length && s[j] === '\n') {
+      j++;
+    }
+    while (j < s.length && (s[j] === ' ' || s[j] === '\t')) j++;
+    if (j === s.length) return { ticks, triggered: false };
+    const tag = s.slice(j);
+    if (tag.startsWith(SYSTEM_REMINDER_OPEN)) {
+      return { ticks, triggered: true };
+    }
+    if (SYSTEM_REMINDER_OPEN.startsWith(tag)) {
+      return { ticks, triggered: false };
+    }
+    return undefined;
+  }
+
+  /** Longest backtick run of length ≥ minTicks inside [from, to), or -1. */
+  private static findTickRun(
+    text: string,
+    from: number,
+    to: number,
+    minTicks: number,
+  ): number {
+    let run = 0;
+    for (let i = from; i < to; i++) {
+      run = text[i] === '`' ? run + 1 : 0;
+      if (run >= minTicks) return i - minTicks + 1;
+    }
+    return -1;
+  }
+
+  accept(text: string): string {
+    if (this.holding) {
+      this.buffer += text;
+      return this.resolveHeld();
+    }
+    return this.scan(this.carry + text);
+  }
+
+  /** True while the filter withholds unresolved bytes (held block or carry). */
+  get pending(): boolean {
+    return this.holding || this.carry !== '';
+  }
+
+  finish(): string {
+    if (this.holding) return this.resolveHeld(true) + this.flushCarry();
+    return this.flushCarry();
+  }
+
+  private flushCarry(): string {
+    const out = this.carry;
+    this.carry = '';
+    this.carryAnchored = false;
+    return out;
+  }
+
+  /**
+   * Passthrough scan: emit everything that cannot be part of a trigger and
+   * keep an ambiguous tail in `carry` for the next chunk.
+   */
+  private scan(text: string): string {
+    if (!text) return '';
+    // `text` may begin with the previous carry, which was held precisely
+    // because it starts at a line start (or at the absolute stream start).
+    const startIsLineStart = this.atStreamStart || this.carryAnchored;
+    this.carry = '';
+    this.carryAnchored = false;
+    let emit = '';
+    let lineStart: number | null = startIsLineStart ? 0 : null;
+    for (;;) {
+      if (lineStart === null) {
+        const nl = text.indexOf('\n');
+        if (nl === -1) break;
+        lineStart = nl + 1;
+      }
+      const candidate = text.slice(lineStart);
+      const match = SystemReminderEchoFilter.matchTrigger(candidate);
+      if (match === undefined) {
+        if (lineStart === 0) this.atStreamStart = false;
+        // A candidate may itself start with '\n' (empty line), so advance
+        // from `lineStart`, not `lineStart + 1`, or the next line start
+        // would be skipped.
+        const nl = text.indexOf('\n', lineStart);
+        if (nl === -1) break;
+        lineStart = nl + 1;
+        continue;
+      }
+      if (match.triggered) {
+        emit += text.slice(0, lineStart);
+        this.atStreamStart = false;
+        this.holding = true;
+        this.buffer = candidate;
+        this.openingTicks = match.ticks;
+        this.openingRunEnd = candidate.indexOf('`') + match.ticks;
+        return emit + this.resolveHeld();
+      }
+      // Still ambiguous: hold from this line start onward.
+      emit += text.slice(0, lineStart);
+      this.carry = candidate;
+      this.carryAnchored = true;
+      this.atStreamStart = false;
+      return emit;
+    }
+    // No resolved anchor; hold back a trailing partial line that could still
+    // grow into one (e.g. "\n  `<system-rem").
+    const nl = text.lastIndexOf('\n');
+    const tail = nl === -1 ? text : text.slice(nl + 1);
+    const holdable = SystemReminderEchoFilter.matchTrigger(tail);
+    if (nl >= 0 && holdable !== undefined) {
+      this.carry = text.slice(nl + 1);
+      this.carryAnchored = true;
+      emit += text.slice(0, nl + 1);
+    } else if (this.atStreamStart && holdable !== undefined) {
+      this.carry = text;
+      this.carryAnchored = true;
+    } else {
+      emit += text;
+      if (text.length > 0) this.atStreamStart = false;
+    }
+    return emit;
+  }
+
+  /** Resolve the held candidate: strip complete echoes, release otherwise. */
+  private resolveHeld(final = false): string {
+    let emitted = '';
+    for (;;) {
+      if (!this.holding) return emitted;
+      const closeIdx = this.buffer.indexOf(SYSTEM_REMINDER_CLOSE);
+      const searchEnd = closeIdx === -1 ? this.buffer.length : closeIdx;
+      const earlyClose =
+        SystemReminderEchoFilter.findTickRun(
+          this.buffer,
+          this.openingRunEnd,
+          searchEnd,
+          this.openingTicks,
+        ) !== -1;
+      if (closeIdx !== -1) {
+        const after = closeIdx + SYSTEM_REMINDER_CLOSE.length;
+        const gap = /^[ \t]*\r?\n?[ \t]*/.exec(this.buffer.slice(after))![0];
+        let ticksAfter = 0;
+        const ticksAt = after + gap.length;
+        while (
+          ticksAt + ticksAfter < this.buffer.length &&
+          this.buffer[ticksAt + ticksAfter] === '`'
+        ) {
+          ticksAfter++;
+        }
+        if (ticksAfter >= this.openingTicks) {
+          let end = ticksAt + ticksAfter;
+          if (this.buffer[end] === '\r' && this.buffer[end + 1] === '\n') {
+            end += 2;
+          } else if (this.buffer[end] === '\n' || this.buffer[end] === '\r') {
+            end += 1;
+          }
+          const remainder = this.buffer.slice(end);
+          this.holding = false;
+          this.buffer = '';
+          emitted += this.scan(remainder);
+          continue;
+        }
+      }
+      if (
+        earlyClose ||
+        this.buffer.length > SYSTEM_REMINDER_ECHO_MAX_BUFFER ||
+        final
+      ) {
+        // Fail-open: release the candidate verbatim.
+        const release = this.buffer;
+        this.holding = false;
+        this.buffer = '';
+        emitted += this.scan(release);
+        continue;
+      }
+      return emitted;
+    }
   }
 }
 
@@ -5253,6 +5504,38 @@ export class LlmChat {
       return released;
     };
     let protocolTextWasSuppressed = false;
+    // #10797 Shape B: strips backtick-wrapped <system-reminder> echoes from
+    // user-visible text. Strip-only (never retries), so mid-stream holds do
+    // not need the whole-chunk atomicity that a leak-retry requires.
+    const systemReminderEchoFilter = new SystemReminderEchoFilter();
+    // True once any text has been released by the leading detector (i.e. the
+    // pending text parts' bytes now live in a detector/filter buffer rather
+    // than only in the parts themselves). Flush sites use this to decide
+    // between verbatim part replay (leading detector still owns the text)
+    // and the stripped rebuild below.
+    let textReleasedThroughDetectors = false;
+    const takePendingProtocolPartsStripped = (): Part[] => {
+      const parts = pendingProtocolParts;
+      pendingProtocolParts = [];
+      const released: Part[] = [];
+      for (const part of parts) {
+        // Pure text parts routed here while a detector held them; their text
+        // re-enters through the filter's released string instead.
+        if (isValidNonThoughtTextPart(part)) continue;
+        released.push(part);
+      }
+      return released;
+    };
+    const finishEchoFilterAndTakePending = (): Part[] => {
+      const tail = systemReminderEchoFilter.finish();
+      if (!textReleasedThroughDetectors) {
+        // The leading detector never released: pending parts still carry the
+        // full text verbatim and the echo filter saw no bytes.
+        return takePendingProtocolParts();
+      }
+      const released = takePendingProtocolPartsStripped();
+      return tail ? [...released, { text: tail }] : released;
+    };
     const currentUserTurn = this.history[this.history.length - 1];
     const isToolResultContinuation =
       currentUserTurn?.role === 'user' &&
@@ -5297,7 +5580,7 @@ export class LlmChat {
             if (protocolTagDetector.leaked) {
               pendingProtocolParts = [];
             } else {
-              const parts = takePendingProtocolParts();
+              const parts = finishEchoFilterAndTakePending();
               if (parts.length > 0) {
                 content = {
                   ...content,
@@ -5331,14 +5614,42 @@ export class LlmChat {
               }
               const text = protocolTagDetector.accept(part.text);
               if (text) {
-                if (pendingProtocolParts.length > 0) {
-                  outputParts.push(...takePendingProtocolParts(), part);
-                } else {
-                  outputParts.push({ ...part, text });
+                textReleasedThroughDetectors = true;
+                const filteredText = systemReminderEchoFilter.accept(text);
+                if (filteredText) {
+                  if (pendingProtocolParts.length > 0) {
+                    // Held parts' text flowed through the detector buffers
+                    // and is represented by `filteredText`; keep only their
+                    // non-text payloads (thoughts, tool calls, ...).
+                    outputParts.push(...takePendingProtocolPartsStripped(), {
+                      ...part,
+                      text: filteredText,
+                    });
+                  } else {
+                    outputParts.push({ ...part, text: filteredText });
+                  }
+                  continue;
                 }
+                // The echo filter is holding mid-stream: park the part (its
+                // text re-enters through a later filter release). Unlike a
+                // leading-tag hold this never retries the turn, so parts of
+                // this chunk that already resolved stay in `outputParts` and
+                // remain yieldable — no whole-chunk withdrawal.
+                pendingProtocolParts.push(part);
+                protocolTextWasSuppressed ||= part.text.length > 0;
                 continue;
               }
-              pendingProtocolParts.push(...outputParts.splice(0), part);
+              if (
+                protocolTagDetector.blockingOutput ||
+                !systemReminderEchoFilter.pending
+              ) {
+                pendingProtocolParts.push(...outputParts.splice(0), part);
+              } else {
+                // Empty text while only the echo filter withholds bytes: a
+                // withdrawal would park already-released parts whose bytes
+                // are no longer in any buffer, so park just this part.
+                pendingProtocolParts.push(part);
+              }
               protocolTextWasSuppressed ||= part.text.length > 0;
             }
             content.parts = outputParts;
@@ -5347,7 +5658,7 @@ export class LlmChat {
               if (protocolTagDetector.leaked) {
                 pendingProtocolParts = [];
               } else {
-                content.parts.push(...takePendingProtocolParts());
+                content.parts.push(...finishEchoFilterAndTakePending());
               }
             }
             content.parts = normalizeModelToolCallIds(
@@ -5493,7 +5804,7 @@ export class LlmChat {
         pendingProtocolParts = [];
       } else {
         const parts = normalizeModelToolCallIds(
-          takePendingProtocolParts(),
+          finishEchoFilterAndTakePending(),
           usedToolCallIds,
           rawToolCallIdsInCurrentTurn,
           reservedToolCallIds,

--- a/packages/core/src/core/llm-chat.ts
+++ b/packages/core/src/core/llm-chat.ts
@@ -5654,15 +5654,21 @@ export class LlmChat {
                 protocolTextWasSuppressed ||= part.text.length > 0;
                 continue;
               }
-              if (
-                protocolTagDetector.blockingOutput ||
-                !systemReminderEchoFilter.pending
-              ) {
+              if (protocolTagDetector.blockingOutput) {
+                // Withdrawal is only correct while the leading detector
+                // blocks: it has not released anything yet, so
+                // `textReleasedThroughDetectors` stays false, the flush
+                // replays these parts verbatim, and whole-chunk atomicity
+                // survives a potential leak-retry.
                 pendingProtocolParts.push(...outputParts.splice(0), part);
               } else {
-                // Empty text while only the echo filter withholds bytes: a
-                // withdrawal would park already-released parts whose bytes
-                // are no longer in any buffer, so park just this part.
+                // Empty text with the detector clean and terminal (no retry
+                // can follow, so chunk atomicity is moot): a withdrawal would
+                // park parts whose bytes were already released past every
+                // buffer, and the stripped flush would drop their text with
+                // nothing re-entering through a later filter release. Park
+                // just this part instead — whether or not the echo filter is
+                // still holding earlier bytes.
                 pendingProtocolParts.push(part);
               }
               protocolTextWasSuppressed ||= part.text.length > 0;

--- a/packages/core/src/core/llm-chat.ts
+++ b/packages/core/src/core/llm-chat.ts
@@ -1647,12 +1647,24 @@ class SystemReminderEchoFilter {
   /**
    * Passthrough scan: emit everything that cannot be part of a trigger and
    * keep an ambiguous tail in `carry` for the next chunk.
+   *
+   * `startsAtLineStart` re-anchors `text` at a line start when the anchor
+   * would otherwise be lost — the caller has already consumed the newline
+   * that made it one. The post-strip rescan in `resolveHeld` needs it:
+   * everything this filter consumed sits ahead of the outer scan's
+   * bookkeeping (`atStreamStart`/`carryAnchored`), so without the flag a
+   * remainder that begins exactly at a line start is scanned as mid-line and
+   * a second consecutive echoed reminder line leaks verbatim. The fail-open
+   * release path must NOT pass it: the released buffer begins with the very
+   * candidate we just decided to emit, and re-anchoring it would re-trigger
+   * a hold-release loop over the same bytes.
    */
-  private scan(text: string): string {
+  private scan(text: string, startsAtLineStart = false): string {
     if (!text) return '';
     // `text` may begin with the previous carry, which was held precisely
     // because it starts at a line start (or at the absolute stream start).
-    const startIsLineStart = this.atStreamStart || this.carryAnchored;
+    const startIsLineStart =
+      startsAtLineStart || this.atStreamStart || this.carryAnchored;
     this.carry = '';
     this.carryAnchored = false;
     let emit = '';
@@ -1745,7 +1757,10 @@ class SystemReminderEchoFilter {
           const remainder = this.buffer.slice(end);
           this.holding = false;
           this.buffer = '';
-          emitted += this.scan(remainder);
+          // The consumed newline leaves `remainder` at a line start; carry
+          // that anchor into the rescan or a following echoed reminder line
+          // would be scanned as mid-line and leak.
+          emitted += this.scan(remainder, true);
           continue;
         }
       }


### PR DESCRIPTION
## What this PR does

This PR closes the two remaining user-visible scaffolding-leak shapes from #10797, both of which currently escape every existing leak defense on `main`:

- **Shape A — tool-result scaffolding tags.** Some replies open with harness-style tool-result XML (`<file_path>/tmp/app.ts</file_path><action>read</action>` closed by a dangling `</tool_result>`) before any real prose, and that raw scaffolding flows straight into user-visible output. The leading protocol-tag detector (#6603 machinery) only knew `<analysis`/`<summary` open/close forms, so this shape was never held. This PR extends `PROTOCOL_TAG_PREFIXES` with the three tool-result tags (`<file_path`, `<action`, `</tool_result`), so a response opening with one is suppressed and the turn is retried through the existing detect-retry path — no new mechanism, just widening the prefix list the detector already consults. Tag names appearing mid-prose are unaffected (the detector only matches at release-start).
- **Shape B — `<system-reminder>` echo.** An injected reminder (e.g. the stale-todo nudge) sometimes gets echoed back verbatim inside a backtick code span or fence. That shape is invisible to the leading detector (the backtick run releases first) and to the thinking-tag machines. This PR adds a conservative streaming `SystemReminderEchoFilter` that strips only complete backtick-wrapped `<system-reminder>…</system-reminder>` blocks: the opening backtick run (1–3 ticks) must sit at stream start or at the start of a line, and the close tag must be followed (after optional gap whitespace) by a backtick run at least as long as the opener. Everything else fails open and is released verbatim: inline mid-sentence mentions, an early-closing code span (an inline `` `<system-reminder>` `` mention), unterminated blocks at stream end, and candidates exceeding a 16 KB hold buffer. Unlike Shape A this filter is strip-only, so a real tool call paired with the echo in the same stream survives without a retry. One exception, matching the code: a reply that is *only* an echo (no tool call, no thought part) strips to empty and falls into the existing empty-response gate (`NO_RESPONSE_TEXT`), which consumes the transient retry budget and fails closed with an error if it persists — deliberate fail-closed behavior rather than a silent empty turn, and now pinned by a test.

## Why it's needed

#10797 (P2, triage-confirmed `welcome-pr`) documents both leak shapes with no existing defense for either: on current `main` the four-entry `PROTOCOL_TAG_PREFIXES` list still lacks the three tool-result tags, and no system-reminder echo filter exists. Both shapes put internal protocol scaffolding directly in front of the user, which is the same class of defect as the leaks #6603 and #8818 already fixed — this PR extends those defenses to the two shapes that slipped between them.

### History: prior version of this change

A previous version of this change (#10992, head `567c11257`) was closed in error during a CI infra outage (the triage model API was failing at the time), not for any code concern. The issue remains open with no other PR claiming it, and the approach — reusing the #6603 suppress-retry machinery for Shape A and a conservative fail-open strip filter for Shape B — matches the direction triage confirmed as `welcome-pr`. This PR respins that exact implementation on current `main`. The respin is a clean rebase onto `main`@`00fe69048` (zero conflicts; the only intervening change to `llm-chat.ts` was the unrelated HTTP-413 compaction work in #10408), and the applied patch is line-for-line identical to the reviewed version — no behavioral changes were introduced.

## Reviewer Test Plan

### How to verify

- `cd packages/core && npx vitest run src/core/llm-chat.test.ts -t "10797" --coverage.enabled=false` — the 8 new cases covering both shapes.
- `cd packages/core && npx vitest run src/core/llm-chat.test.ts src/core/environmentContext.test.ts --coverage.enabled=false` — full detector/filter regression.
- `npm run typecheck`

### Evidence (Before & After)

- Before (Shape A): a reply streaming `` <file_path>/tmp/app.ts</file_path><action>read</action></tool_result>`` plus prose rendered the raw XML to the user. After: the turn is detected as a leading protocol-tag leak, suppressed, and retried (test `retries a response that opens with tool-result scaffolding tags (#10797)`; split-across-chunks prefix covered too).
- Before (Shape B): a reply echoing `` ` ``+`<system-reminder>…</system-reminder>`+`` ` `` alongside a tool call rendered the reminder body to the user. After: the backtick-wrapped block is stripped in place and the surrounding reply and tool call are preserved with no retry (test `strips a backtick-wrapped system-reminder echo without retrying (#10797)`); fenced variants between paragraphs are stripped as well.
- Fail-open negatives verified: scaffolding tag names mid-prose are not rejected; a line-start inline code-span mention of the tag is kept intact; an unterminated backtick-wrapped echo is released verbatim at stream end; an unwrapped `<system-reminder>` mention is untouched.

| Check | Command | Result |
| :-- | :-- | :-- |
| #10797 shape tests (8) | `npx vitest run src/core/llm-chat.test.ts -t "10797"` | PASS (8/8) |
| Full llm-chat + environmentContext suites | `npx vitest run src/core/llm-chat.test.ts src/core/environmentContext.test.ts` | PASS (467/467) |
| Typecheck | `npm run typecheck` | PASS (no errors) |

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ⚠️    |

### Environment (optional)

Local `npm run build` + `npx vitest run` on macOS (arm64); unit tests only.

## Risk & Scope

- Main risk or tradeoff: (Shape A) a legitimate reply that truly opens with literal `<file_path`/`<action`/`</tool_result` text would now be suppressed and retried once before failing closed — qwen-code never generates these tags itself, and the same tradeoff already applies to the existing `<analysis`/`<summary` prefixes. (Shape B) the filter could strip a legitimately quoted backtick-wrapped reminder block; it is deliberately restricted to line-anchored 1–3-tick runs closing with a matching run, and fails open on anything ambiguous.
- Not validated / out of scope: no live-model E2E run locally (shapes are covered by streaming unit tests with chunk-split delivery); Windows/Linux runtime not tested locally (CI covers).
- Breaking changes / migration notes: none. Existing detector behavior for `<analysis`/`<summary` and the thinking-tag classifiers is unchanged (full llm-chat suite passes).

## Linked Issues

Fixes #10797

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

本 PR 修复 #10797 中剩余的两个用户可见的脚手架泄漏形态，二者目前都能穿透 `main` 上的全部现有防线：

- **形态 A —— tool-result 脚手架标签。** 部分回复以 harness 风格的 tool-result XML 开头（`<file_path>/tmp/app.ts</file_path><action>read</action>`，再悬一个 `</tool_result>` 收尾），然后才是正文，这些原始脚手架直接流入用户可见输出。前导协议标签检测器（#6603 机制）只认识 `<analysis`/`<summary` 的开闭形式，所以这个形态从未被拦截。本 PR 向 `PROTOCOL_TAG_PREFIXES` 增加这三个 tool-result 标签（`<file_path`、`<action`、`</tool_result`），使以它们开头的回复被抑制并走现有的检测-重试路径——没有引入新机制，只是拓宽了检测器已有的前缀清单。标签名出现在正文中段不受影响（检测器只在释放起点匹配）。
- **形态 B —— `<system-reminder>` 回显。** 注入的提醒（例如 stale-todo 提示）有时被模型逐字回显在反引号代码 span 或 fence 里。该形态对前导检测器不可见（反引号先释放了），对 thinking-tag 机器也不可见。本 PR 新增一个保守的流式 `SystemReminderEchoFilter`，只剥离完整的反引号包裹的 `<system-reminder>…</system-reminder>` 块：起始反引号 run（1–3 个）必须位于流起点或行首，闭合标签之后（允许间隔空白）必须跟一个不短于起始 run 的反引号 run。其余情形一律 fail-open、原样释放：句中内联提及、提前闭合的代码 span（内联的 `` `<system-reminder>` `` 提及）、流结束时未闭合的块、超过 16 KB 持有缓冲的候选。与形态 A 不同，该 filter 只剥离，因此与回显同流的真实 tool call 无需重试即得以保留。一个与代码一致的例外：若回复*只有*回显（无 tool call、无 thought part），剥空后落入既有的空响应门（`NO_RESPONSE_TEXT`），会消耗 transient 重试额度、持续则 fail closed 报错——这是刻意选择的 fail-closed 行为而非静默空回合，现已有测试钉住。

## 为什么需要

#10797（P2，triage 确认 `welcome-pr`）记录了两个泄漏形态，且均无现有防线：当前 `main` 上四项的 `PROTOCOL_TAG_PREFIXES` 仍然缺少这三个 tool-result 标签，也不存在 system-reminder 回显 filter。两个形态都把内部协议脚手架直接暴露给用户，与 #6603、#8818 已修复的泄漏同属一类——本 PR 把这些防线扩展到漏网的两个形态。

### 历史：本变更的前一版本

前一版本（#10992，head `567c11257`）是在 CI infra 故障（当时 triage model API 报错）期间被误关的，并非代码问题。issue 至今保持 open、无他人认领；方案方向（形态 A 复用 #6603 suppress-retry 机制、形态 B 保守 fail-open 剥离 filter）与 triage 确认的 `welcome-pr` 方向一致。本 PR 在当前 `main` 上原样重提该实现：rebase 到 `main`@`00fe69048` 零冲突（其间 `llm-chat.ts` 唯一的相关变更是不相干的 #10408 HTTP-413 压缩工作），补丁与被审阅版本逐行一致，未引入任何行为变化。

## 审阅者测试计划

### 如何验证

- `cd packages/core && npx vitest run src/core/llm-chat.test.ts -t "10797" --coverage.enabled=false` —— 覆盖两个形态的 8 个新用例。
- `cd packages/core && npx vitest run src/core/llm-chat.test.ts src/core/environmentContext.test.ts --coverage.enabled=false` —— 检测器/filter 全量回归。
- `npm run typecheck`

### 证据（前后对比）

- 前（形态 A）：流式输出 `` <file_path>/tmp/app.ts</file_path><action>read</action></tool_result>`` 加正文时，原始 XML 直接渲染给用户。后：该回合被识别为前导协议标签泄漏，被抑制并重试（测试 `retries a response that opens with tool-result scaffolding tags (#10797)`；跨 chunk 拆分的前缀也有覆盖）。
- 前（形态 B）：回复在携带 tool call 的同时回显 `` ` ``+`<system-reminder>…</system-reminder>`+`` ` ``，提醒正文渲染给用户。后：反引号包裹块被就地剥离，周边回复与 tool call 保留、不重试（测试 `strips a backtick-wrapped system-reminder echo without retrying (#10797)`）；段落间的 fence 变体同样被剥离。
- fail-open 负例已验证：正文中段的脚手架标签名不被拒绝；行首内联代码 span 的标签提及原样保留；未闭合的反引号回显在流结束时原样释放；未包裹的 `<system-reminder>` 提及不受影响。

| 检查 | 命令 | 结果 |
| :-- | :-- | :-- |
| #10797 形态测试（8 个） | `npx vitest run src/core/llm-chat.test.ts -t "10797"` | PASS（8/8） |
| llm-chat + environmentContext 全量 | `npx vitest run src/core/llm-chat.test.ts src/core/environmentContext.test.ts` | PASS（467/467） |
| 类型检查 | `npm run typecheck` | PASS（无错误） |

### 测试环境

|     系统   | 状态  |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   ⚠️    |
|  🐧 Linux  |   ⚠️    |

### 环境（可选）

macOS（arm64）本地 `npm run build` + `npx vitest run`；仅单元测试。

## 风险与范围

- 主要风险或取舍：（形态 A）确实以字面 `<file_path`/`<action`/`</tool_result` 文本开头的合法回复现在会被抑制并重试一次，之后才 fail closed——qwen-code 自身从不生成这些标签，且现有 `<analysis`/`<summary` 前缀已是同样的取舍。（形态 B）filter 可能剥离合法引用的反引号包裹提醒块；它被刻意限制为行锚定的 1–3 个反引号 run 且需匹配长度的闭合 run，任何歧义情形均 fail-open。
- 未验证 / 范围外：本地未做真实模型 E2E（流式单元测试已按 chunk 拆分覆盖各形态）；Windows/Linux 运行时未本地测试（CI 覆盖）。
- 破坏性变更 / 迁移说明：无。`<analysis`/`<summary` 的现有检测行为与 thinking-tag 分类器不变（llm-chat 全量测试通过）。

## 关联 Issue

Fixes #10797

</details>
