### PR TITLE
fix(bridge): preserve child error detail on session explicit-close and kill paths (#11123)

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -667,6 +667,59 @@ describe('createAcpSessionBridge', () => {
       }
     });
 
+    it('logs the child close-refusal detail on the explicit-close and kill paths', async () => {
+      // The child's refusal crosses the ACP wire as a JSON-RPC error
+      // record (a plain object with `code`/`message`, not an `Error`
+      // instance). Both the explicit-close and kill notification-failure
+      // logs must carry that real detail — a raw `String()` interpolation
+      // collapses it to `[object Object]`.
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        const handle = makeChannel({
+          extMethodImpl: async (method) => {
+            if (method !== SERVE_CONTROL_EXT_METHODS.sessionClose) return {};
+            throw new RequestError(
+              -32603,
+              'Session close is already in progress',
+            );
+          },
+        });
+        const bridge = makeBridge({
+          channelFactory: async () => handle.channel,
+          sessionReapIntervalMs: 0,
+        });
+        try {
+          const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+          const second = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+          // Explicit close: the definitive refusal rethrows after logging.
+          await expect(bridge.closeSession(first.sessionId)).rejects.toThrow();
+          // Kill: the definitive refusal spares the channel.
+          await expect(bridge.killSession(second.sessionId)).resolves.toBe(
+            false,
+          );
+
+          const logged = stderrSpy.mock.calls
+            .map((call) => String(call[0]))
+            .join('\n');
+          expect(logged).toContain(
+            'closeSession ACP session close notification failed',
+          );
+          expect(logged).toContain(
+            'killSession ACP session close notification failed',
+          );
+          expect(logged).toContain('Session close is already in progress');
+          expect(logged).not.toContain('[object Object]');
+        } finally {
+          await bridge.shutdown();
+        }
+      } finally {
+        stderrSpy.mockRestore();
+      }
+    });
+
     it('accepts the aggregate shell hold as active work', async () => {
       const handle = makeChannel({
         initializeImpl: () => activeWorkInitializeResponse(),
@@ -17025,6 +17078,62 @@ describe('createAcpSessionBridge', () => {
         bridge.branchSession(session.sessionId, {}),
       ).rejects.toBeInstanceOf(SessionBusyError);
       await bridge.shutdown();
+    });
+
+    it('logs the child close-refusal detail when branchSession cleanup fails', async () => {
+      // The restore of a committed branch fails, and the child then also
+      // refuses the live-state cleanup close with a RequestError. The
+      // cleanup log must carry the child's real detail — the refusal
+      // crosses the ACP wire as a plain JSON-RPC error record, which raw
+      // template interpolation collapses to `[object Object]`.
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        const handle = makeChannel({
+          loadSessionImpl: () => {
+            throw new Error('branch restore exploded');
+          },
+          extMethodImpl: async (method) => {
+            if (method === SERVE_CONTROL_EXT_METHODS.sessionBranch) {
+              return {
+                newSessionId: 'branch-restore-fail',
+                title: 'Branch',
+              };
+            }
+            if (method === SERVE_CONTROL_EXT_METHODS.sessionClose) {
+              throw new RequestError(
+                -32603,
+                'Session close is already in progress',
+              );
+            }
+            return {};
+          },
+        });
+        const bridge = makeBridge({
+          channelFactory: async () => handle.channel,
+          sessionReapIntervalMs: 0,
+        });
+        try {
+          const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+          await expect(
+            bridge.branchSession(session.sessionId, {}),
+          ).rejects.toThrow();
+
+          const logged = stderrSpy.mock.calls
+            .map((call) => String(call[0]))
+            .join('\n');
+          expect(logged).toContain(
+            'branchSession live-state close for branch-restore-fail failed',
+          );
+          expect(logged).toContain('Session close is already in progress');
+          expect(logged).not.toContain('[object Object]');
+        } finally {
+          await bridge.shutdown();
+        }
+      } finally {
+        stderrSpy.mockRestore();
+      }
     });
 
     it('dispatches a historical branch on the source channel without restoring it', async () => {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -6549,10 +6549,13 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
       ]);
       return response['closed'] === true;
     } catch (err) {
+      // The child's close refusal crosses the ACP wire as a JSON-RPC
+      // error record (plain object with `code`/`message`), not an `Error`
+      // instance — `String()` would collapse it to `[object Object]`.
       writeStderrLine(
         `qwen serve: ${label} ACP session close notification failed ` +
-          `for session ${JSON.stringify(entry.sessionId)}: ${String(
-            err instanceof Error ? err.message : err,
+          `for session ${JSON.stringify(entry.sessionId)}: ${extractErrorMessage(
+            err,
           )}`,
       );
       if (opts?.throwOnFailure === true) {
@@ -11087,8 +11090,10 @@ export function createAcpSessionBridge(opts: BridgeOptions): AcpSessionBridge {
                 );
               }
             } catch (cleanupErr) {
+              // Same wire-shape hazard as `notifyAgentSessionClose`: a
+              // child refusal arrives as a plain JSON-RPC error record.
               writeStderrLine(
-                `qwen serve: branchSession live-state close for ${result.newSessionId} failed: ${cleanupErr instanceof Error ? cleanupErr.message : cleanupErr}`,
+                `qwen serve: branchSession live-state close for ${result.newSessionId} failed: ${extractErrorMessage(cleanupErr)}`,
               );
             }
             throw restoreErr;


### PR DESCRIPTION
# fix(serve): preserve child error detail on explicit-close and kill paths

Fixes #11123
Refs #11120

## What this PR does

- `notifyAgentSessionClose` in `packages/acp-bridge/src/bridge.ts` logs the failure of the `session/close` notification for **both** the explicit-close (`closeSession`) and kill (`killSession`) paths. Its `catch` serialized the rejection with `String(err instanceof Error ? err.message : err)`. A child-side close refusal (e.g. a `RequestError` thrown because "Session close is already in progress") crosses the ACP wire as a JSON-RPC error record — a plain object with `code`/`message`, not an `Error` instance — so the log printed `[object Object]` and the child's real failure reason was lost.
- The same log now goes through the existing `extractErrorMessage()` helper (same file), which understands both shapes: `Error` instances, JSON-RPC error objects, and plain objects with a `message` property. This is the exact remedy already applied by #11120 to the sibling conditional-close-probe site.
- One directly-adjacent site of the same defect class is fixed in passing: the `branchSession` live-state cleanup close (`qwen serve: branchSession live-state close for ... failed`) calls the **same** `session/close` wire method, and its template interpolation printed the same `[object Object]` for a refused cleanup close. Switched to `extractErrorMessage()` as well.
- No other call sites are touched: per the triage note on #11123, the remaining `instanceof Error ? message : String(err)` interpolations in this file catch purely local errors (`Error` instances from FS/bus/persist paths) where `String()` is harmless. Sites were audited individually rather than blanket-replaced.

## Why it's needed

- The daemon's close/kill escalation logic (`isDefinitiveAcpRequestError`) already reasons over the wire-shaped error (integer `code` + string `message`), which is exactly why sessions behave correctly while the log is garbage — the operator-facing log lagged behind the code's own understanding of the two error shapes.
- From #11118: conditional closes can fail repeatedly (~1000 rounds) and every failure line carried `[object Object]` instead of the child's reason, making the log unusable for diagnosing exactly the class of failure it exists to record.
- This is the third confirmed instance of the pattern (after #10570 and #10564, both closed as completed).

## Reviewer Test Plan

1. `npm -w packages/acp-bridge run test -- src/bridge.test.ts -t 'close-refusal detail'` — the two new tests:
   - `logs the child close-refusal detail on the explicit-close and kill paths` drives a real in-memory ACP channel whose child side refuses `session/close` with `RequestError(-32603, 'Session close is already in progress')`; it asserts the operator log now contains `closeSession ACP session close notification failed ...` and `killSession ACP session close notification failed ...` lines carrying `Session close is already in progress`, and contains no `[object Object]`.
   - `logs the child close-refusal detail when branchSession cleanup fails` makes a committed branch's restore fail and the child refuse the subsequent cleanup close; it asserts the `branchSession live-state close ... failed` line carries the real refusal message.
2. On the pre-fix tree the same tests fail with the `[object Object]` assertion (the reproduction the issue describes is visible today in the existing `spares the channel when a kill meets a definitive close refusal` test run).
3. `npm run typecheck` passes.

## Tested on

| Platform | Test / Build | Result |
| --- | --- | --- |
| macOS 26.0 (arm64), Node v22.23.1 | `npx vitest run src/bridge.test.ts` (packages/acp-bridge) | PASS — 905/905 tests |
| macOS 26.0 (arm64), Node v22.23.1 | `npx vitest run` (full packages/acp-bridge suite) | PASS — 1951/1951 tests, 35 files |
| macOS 26.0 (arm64), Node v22.23.1 | `npm run typecheck` (repo root, all workspaces) | PASS |
| macOS 26.0 (arm64), Node v22.23.1 | `npx prettier --check` on both changed files | PASS |
| macOS 26.0 (arm64), Node v22.23.1 | Red-light check: with only `bridge.ts` reverted, the two new tests fail with `expected ... to contain 'Session close is already in progress'` | CONFIRMED (tests reproduce the pre-fix `[object Object]` behavior) |

## Risk & Scope

- **Scope**: 2 log-line changes + 2 new tests, all inside `packages/acp-bridge`. No behavior change beyond the logged string: the caught error is still rethrown (`throwOnFailure`) / still returns `false` exactly as before; `isDefinitiveAcpRequestError` escalation logic is untouched.
- **Behavior for `Error` inputs is unchanged**: `extractErrorMessage(new Error('x'))` returns `'x'` (same as `err.message`), so local timeouts/transport errors log identically to before. The only visible difference is for wire-shaped plain objects, which previously printed `[object Object]`.
- **Risk**: minimal — logging-only. The helper is an existing exported function in the same file with 25+ unit tests of its own (`describe('extractErrorMessage')`).

## Linked Issues

- Fixes #11123
- Refs #11120 (sibling site precedent, merged)
- Refs #11118 (upstream conditional-close failure loop that made the unreadable logs costly)
- Refs #10570, #10564 (same defect class, already fixed)

---

## 中文说明（details 全译）

### 这个 PR 做了什么

- `packages/acp-bridge/src/bridge.ts` 中的 `notifyAgentSessionClose` 负责 explicit-close（`closeSession`）和 kill（`killSession`）两条路径共用的 `session/close` 通知失败日志。其 `catch` 用 `String(err instanceof Error ? err.message : err)` 序列化 rejection。child 侧的 close 拒绝（例如因 "Session close is already in progress" 抛出的 `RequestError`）跨 ACP wire 后是 JSON-RPC 错误记录——一个带 `code`/`message` 的 plain object，不是 `Error` 实例——于是日志打出 `[object Object]`，child 的真实失败原因被丢弃。
- 该日志现在改走同文件已有的 `extractErrorMessage()` helper，它能同时处理两种形状：`Error` 实例、JSON-RPC 错误对象、带 `message` 属性的 plain object。这正是 #11120 对 sibling conditional-close-probe 站点采用过的修法。
- 顺手修复同类缺陷中直接相邻的一处：`branchSession` 的 live-state 清理 close（`qwen serve: branchSession live-state close for ... failed`）调用**同一个** `session/close` wire 方法，模板插值对被拒绝的清理 close 同样输出 `[object Object]`。一并换成 `extractErrorMessage()`。
- 未触碰其他调用点：按 #11123 triage 的范围警示，文件中其余 `instanceof Error ? message : String(err)` 插值捕获的都是纯本地错误（FS/总线/持久化路径的 `Error` 实例），`String()` 无害。各站点逐一审计过，而非批量替换。

### 为什么需要

- daemon 的 close/kill 升级逻辑（`isDefinitiveAcpRequestError`）早已按 wire 形状（整数 `code` + 字符串 `message`）处理这类错误——这正是会话行为正确而日志是垃圾的原因：operator 日志落后于代码自己对两种错误形状的认知。
- 来自 #11118：conditional close 可能反复失败（约 1000 轮），每一行失败日志都是 `[object Object]` 而非 child 的原因，导致日志对其本应记录的这类故障完全失去诊断价值。
- 这是该模式第三个确认实例（#10570 与 #10564 之后，前两个已修复关闭）。

### 评审验证步骤

1. `npm -w packages/acp-bridge run test -- src/bridge.test.ts -t 'close-refusal detail'`——两个新测试：
   - `logs the child close-refusal detail on the explicit-close and kill paths` 用真实 in-memory ACP channel 驱动，child 侧以 `RequestError(-32603, 'Session close is already in progress')` 拒绝 `session/close`；断言 operator 日志中 `closeSession ACP session close notification failed ...` 与 `killSession ACP session close notification failed ...` 两行都携带 `Session close is already in progress`，且不含 `[object Object]`。
   - `logs the child close-refusal detail when branchSession cleanup fails` 让已提交分支的 restore 失败、随后 child 拒绝清理 close；断言 `branchSession live-state close ... failed` 行携带真实拒绝消息。
2. 在修复前的树上，同样的测试会在 `[object Object]` 断言处失败（issue 描述的复现今天就能在既有的 `spares the channel when a kill meets a definitive close refusal` 测试运行中看到）。
3. `npm run typecheck` 通过。

### 风险与范围

- **范围**：2 处日志行改动 + 2 个新测试，全部在 `packages/acp-bridge` 内。除日志字符串外无行为变化：捕获的错误仍照原样 rethrow（`throwOnFailure`）/ 返回 `false`；`isDefinitiveAcpRequestError` 升级逻辑未动。
- **`Error` 输入的行为不变**：`extractErrorMessage(new Error('x'))` 返回 `'x'`（与 `err.message` 相同），本地超时/传输错误的日志与之前完全一致。唯一可见差异是 wire 形状的 plain object——它们之前打的是 `[object Object]`。
- **风险**：极小——仅日志。该 helper 是同文件已导出的函数，自身有 25+ 个单测（`describe('extractErrorMessage')`）。