### PR TITLE
test(cli): pin the negative side of the follow-up suggestion stop-reason gate (#11159)

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -44478,5 +44478,98 @@ describe('Session', () => {
       await session.cancelPendingPrompt();
       expect(capturedSignal!.aborted).toBe(true);
     });
+
+    it('suppresses the suggestion when the turn ends on a non-end_turn stop reason', async () => {
+      // The stop-reason gate in #maybeEmitFollowupSuggestion
+      // (`if (result.stopReason !== 'end_turn') return;`) is the only line
+      // keeping an interrupted or token-capped turn from firing a wasted
+      // generatePromptSuggestion call. The published contract
+      // (docs/users/features/features/followup-suggestions.md, #11101)
+      // suppresses on every non-end_turn member of the ACP StopReason union:
+      // cancelled / refusal / max_tokens / max_turn_requests. The gate is a
+      // single `!== 'end_turn'` check, and of those four only cancelled and
+      // max_tokens have return sites in Session.ts (refusal and
+      // max_turn_requests are never produced by the daemon send path), so
+      // driving those two pins the whole union (#11159). Every other test in
+      // this block reaches the generator through a mocked end_turn stream, so
+      // deleting the gate line left the suite green.
+      generateMock.mockResolvedValue({ suggestion: 'Run the tests next?' });
+      const suggestionCalls = () =>
+        (
+          mockClient.extNotification as ReturnType<typeof vi.fn>
+        ).mock.calls.filter(
+          ([method]) => method === 'qwen/notify/session/prompt-suggestion',
+        );
+
+      // Control: the same session and mocks, a cleanly finished turn — the
+      // suggestion fires exactly once (pinned by the test above; restated
+      // here so the negative assertions below are self-contained).
+      await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'hello' }],
+      });
+      await vi.waitFor(() => {
+        expect(generateMock).toHaveBeenCalledTimes(1);
+        expect(suggestionCalls()).toHaveLength(1);
+      });
+
+      // cancelled: abort the turn while the model stream is pending. The
+      // abort-aware send loop settles the turn as cancelled and the result
+      // still flows through #maybeEmitFollowupSuggestion.
+      let releaseStream!: () => void;
+      const streamGate = new Promise<void>((resolve) => {
+        releaseStream = resolve;
+      });
+      mockChat.sendMessageStream = vi.fn().mockImplementation(
+        async () =>
+          (async function* () {
+            await streamGate;
+          })(),
+      );
+      const cancellation = new AbortController();
+      const cancelledTurn = session.prompt(
+        {
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'abort me' }],
+        },
+        undefined,
+        cancellation.signal,
+      );
+      await vi.waitFor(() =>
+        expect(mockChat.sendMessageStream).toHaveBeenCalled(),
+      );
+      cancellation.abort();
+      releaseStream();
+      await expect(cancelledTurn).resolves.toEqual({
+        stopReason: 'cancelled',
+      });
+
+      // Give the (suppressed) fire-and-forget IIFE a chance to run.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(generateMock).toHaveBeenCalledTimes(1);
+      expect(suggestionCalls()).toHaveLength(1);
+
+      // max_tokens: the session token-limit gate drops the send before the
+      // model is ever called.
+      mockConfig.getSessionTokenLimit = vi.fn().mockReturnValue(100);
+      mockLlmClient.tryCompressChat.mockResolvedValue({
+        originalTokenCount: 999,
+        newTokenCount: 999,
+        compressionStatus: core.CompressionStatus.NOOP,
+      });
+      mockChat.sendMessageStream = vi
+        .fn()
+        .mockResolvedValue(createEmptyStream());
+
+      const maxTokensTurn = await session.prompt({
+        sessionId: 'test-session-id',
+        prompt: [{ type: 'text', text: 'hit the limit' }],
+      });
+      expect(maxTokensTurn).toEqual({ stopReason: 'max_tokens' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(generateMock).toHaveBeenCalledTimes(1);
+      expect(suggestionCalls()).toHaveLength(1);
+    });
   });
 });

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -44484,7 +44484,7 @@ describe('Session', () => {
       // (`if (result.stopReason !== 'end_turn') return;`) is the only line
       // keeping an interrupted or token-capped turn from firing a wasted
       // generatePromptSuggestion call. The published contract
-      // (docs/users/features/features/followup-suggestions.md, #11101)
+      // (docs/users/features/followup-suggestions.md, #11101)
       // suppresses on every non-end_turn member of the ACP StopReason union:
       // cancelled / refusal / max_tokens / max_turn_requests. The gate is a
       // single `!== 'end_turn'` check, and of those four only cancelled and
@@ -44524,6 +44524,7 @@ describe('Session', () => {
         async () =>
           (async function* () {
             await streamGate;
+            yield* createEmptyStream();
           })(),
       );
       const cancellation = new AbortController();


### PR DESCRIPTION
## What this PR does

Adds one focused regression test to the `follow-up suggestion (daemon assist push)` describe block in `packages/cli/src/acp-integration/session/Session.test.ts` that pins the negative side of the stop-reason gate in `#maybeEmitFollowupSuggestion` (`if (result.stopReason !== 'end_turn') return;` in `packages/cli/src/acp-integration/session/Session.ts`). The test drives a turn that ends on a non-`end_turn` stop reason and asserts both that `generatePromptSuggestion` is never called and that no `qwen/notify/session/prompt-suggestion` extNotification is emitted.

Within a single case it covers an `end_turn` control turn (the suggestion fires exactly once), a `cancelled` turn (aborted while the model stream is pending, settling through the abort-aware send loop), and a `max_tokens` turn (the session token-limit gate drops the send). The gate is a single `!== 'end_turn'` check, and `cancelled` / `max_tokens` are the two non-`end_turn` members of the ACP `StopReason` union that the daemon send path can actually produce — `refusal` and `max_turn_requests` have no return site in `Session.ts` — so driving those two pins the whole union.

## Why it's needed

Nothing pinned the gate's negative side: every existing case in that describe block reaches `#maybeEmitFollowupSuggestion` through the mocked stream's `end_turn`, and the string `stopReason` did not appear anywhere in the block. Deleting the gate line kept the suite green, and the shipped behaviour would have been an extra `generatePromptSuggestion` LLM call after every interrupted or `max_tokens` turn, plus a suggestion pushed for a turn that never finished — exactly the per-turn cost `docs/users/features/followup-suggestions.md` (added by #11101) publishes to integrators. The gate the doc now publishes should not stay unpinned (#11159).

## Reviewer Test Plan

### How to verify

From `packages/cli`:

```
LC_ALL=en_US.UTF-8 npx vitest run src/acp-integration/session/Session.test.ts -t "follow-up suggestion"
```

All cases in the block pass, including the new `suppresses the suggestion when the turn ends on a non-end_turn stop reason`.

Mutation check (the acceptance bar from #11159): comment out the gate line in `#maybeEmitFollowupSuggestion` in `packages/cli/src/acp-integration/session/Session.ts`:

```diff
  #maybeEmitFollowupSuggestion(result: PromptResponse): void {
-   if (result.stopReason !== 'end_turn') return;
```

Re-run the command above — the new case must FAIL (the deleted gate lets the fire-and-forget IIFE reach `generatePromptSuggestion` after the `cancelled` and `max_tokens` turns, so the call-count assertion trips). Restore the line and it passes again.

### Evidence (Before & After)

N/A (test-only change, no user-visible behaviour)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |   N/A   |
|  🐧 Linux  |   N/A   |

### Environment (optional)

N/A — unit tests only (`npm ci` at repo root, then the vitest command above; `npm run build` first on a fresh worktree so workspace `dist/` prerequisites exist).

## Risk & Scope

- Main risk or tradeoff: none — no production code is touched; the change is a single additive test case in an existing describe block.
- Not validated / out of scope: `refusal` / `max_turn_requests` are not driven end-to-end because the daemon send path never produces them (no return site in `Session.ts`); they fall under the same single `!== 'end_turn'` check that the `cancelled` / `max_tokens` turns exercise.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #11159

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `packages/cli/src/acp-integration/session/Session.test.ts` 的 `follow-up suggestion (daemon assist push)` describe 块中新增一个聚焦的回归测试，钉住 `#maybeEmitFollowupSuggestion`（位于 `packages/cli/src/acp-integration/session/Session.ts`）中 stop-reason 抑制门（`if (result.stopReason !== 'end_turn') return;`）的负侧。测试驱动一个以非 `end_turn` stop reason 结束的 turn，并断言两点：`generatePromptSuggestion` 从未被调用，且没有发出 `qwen/notify/session/prompt-suggestion` extNotification。

在同一个用例里覆盖：一个 `end_turn` 对照 turn（建议恰好产出一次）、一个 `cancelled` turn（在模型流挂起期间 abort，经 abort-aware send loop 以 cancelled 收尾）、一个 `max_tokens` turn（session token limit 门在发送前丢弃请求）。门控行是单点 `!== 'end_turn'` 判断，而 `cancelled` / `max_tokens` 是 ACP `StopReason` union 中 daemon 发送路径实际能产生的两个非 `end_turn` 值——`refusal` 和 `max_turn_requests` 在 `Session.ts` 中没有产生路径——所以驱动这两个值即钉住了整个 union。

## 为什么需要它

此前没有任何测试钉住门控的负侧：该 describe 块中所有既有用例都经由 mock 流的 `end_turn` 到达 `#maybeEmitFollowupSuggestion`，块内完全没出现过 `stopReason` 字符串。删掉门控行后测试套件依然全绿，而线上行为会变成：每个被中断或 `max_tokens` 的 turn 之后多一次 `generatePromptSuggestion` LLM 调用，还会为一个从未正常完成的 turn 推送建议——这正是 `docs/users/features/followup-suggestions.md`（#11101 引入）向集成方发布的每 turn 成本。文档已发布的门槛不应持续无测试锚定（#11159）。

## Reviewer 测试计划

### 如何验证

在 `packages/cli` 下执行：

```
LC_ALL=en_US.UTF-8 npx vitest run src/acp-integration/session/Session.test.ts -t "follow-up suggestion"
```

块内所有用例通过，包括新增的 `suppresses the suggestion when the turn ends on a non-end_turn stop reason`。

Mutation 检查（#11159 的验收标准）：注释掉 `packages/cli/src/acp-integration/session/Session.ts` 中 `#maybeEmitFollowupSuggestion` 的门控行：

```diff
  #maybeEmitFollowupSuggestion(result: PromptResponse): void {
-   if (result.stopReason !== 'end_turn') return;
```

重新执行上面的命令——新用例必须失败（门被删后 fire-and-forget IIFE 会在 `cancelled` 和 `max_tokens` turn 之后到达 `generatePromptSuggestion`，调用次数断言被触发）。恢复该行后重新通过。

### 证据（Before & After）

N/A（纯测试改动，无用户可见行为变化）

### 测试环境

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

N/A——仅单元测试（仓库根 `npm ci`，然后执行上面的 vitest 命令；全新 worktree 需先 `npm run build` 以生成 workspace `dist/` 前置产物）。

## 风险与范围

- 主要风险或权衡：无——不触碰任何产品代码；改动仅是在既有 describe 块中新增一个测试用例。
- 未验证 / 范围之外：`refusal` / `max_turn_requests` 未做端到端驱动，因为 daemon 发送路径从不产生它们（`Session.ts` 中无产生路径）；它们与 `cancelled` / `max_tokens` 落在同一处单点 `!== 'end_turn'` 判断上。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Refs #11159

</details>