### PR TITLE
ci(release): drop the redundant Format Project step that verifies nothing (#11109)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,10 +421,6 @@ jobs:
           npm run postinstall
           npm run generate
 
-      - name: 'Format Project'
-        run: |-
-          npm run format
-
       - name: 'Run Lint'
         run: |-
           npm run lint:ci


### PR DESCRIPTION
## What this PR does

Deletes the `Format Project` step (`npm run format`, i.e. `prettier --write .`) from the `quality_static` job in `release.yml`. That step spent 14–21 minutes rewriting every tracked file in place on each release run and then verified nothing: no `git diff --exit-code`, no `git status --porcelain`, no artifact upload followed it, and the runner's workspace is discarded when the job ends. `prettier --write` also exits 0 whether or not anything changed, so the step could not have failed a release over a formatting problem even in principle. This is option A from the issue, verbatim: two lines of workflow, zero behaviour change.

## Why it's needed

- The step's output has no consumer. The only step after it in the job is `Run Lint` (`npm run lint:ci`), which is pure ESLint — it does not read, require, or benefit from the prettier rewrites. Formatting as a gate does not exist anywhere in this repo's CI: `scripts/lint.js`'s `runPrettier()` also uses `--write` (not `--check`), and the only formatting enforcement is the bypassable husky pre-commit hook + lint-staged. So nothing downstream changes behaviour when this step goes away.
- It cost real releases. The issue measures the step at 13m58s on a quiet hk4 runner and 20m45s on a contended one, and release runs 33957952281 and 33963757913 died at their `timeout-minutes` caps while every step was green — reported through #11098 and #11104 as "Failed job(s): quality" with no indication a timeout was the cause. The `quality_static` timeout comment in this same file (the 30 -> 60 bump) already cites "one `npm run format` alone took 21 minutes — run 33963757913 lost this lane".
- Removing it drops `quality_static` toward ~10 minutes against its cap, which is headroom the lane currently does not have while #10879 (host contention) is open.

## Reviewer Test Plan

### How to verify

1. `git diff origin/main` shows exactly one hunk in `.github/workflows/release.yml`: the `Format Project` step (3 lines + separator) removed from `quality_static`, nothing else touched.
2. Confirm nothing consumed the step: `rg "Format Project"` across the repo matches only `release.yml` itself; no test, script, or sibling workflow references the step name.
3. Ratchet and workflow tests: `WORKFLOW_SIZE_BASE_SHA=$(git rev-parse origin/main) npx vitest run scripts/tests/workflow-size.test.js` and `npx vitest run scripts/tests/release-workflow.test.js`.
4. YAML sanity: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`.

### Evidence (Before & After)

N/A (CI-only change; no user-visible surface).

- workflow-size ratchet: 202/202 passed. `release.yml` shrinks 75392 -> 75319 bytes, 73 bytes under its recorded baseline — far inside the 4096-byte allowance and nowhere near the 20 KB slack-reclaim warning, so `.size-baseline` needs no update.
- release-workflow.test.js: 47 passed, 1 skipped. One test (`names which failure this is, and never changes the exit code`) times out at its 5s limit on this machine — reproduced identically on an unmodified `origin/main` checkout (same 1 failed | 47 passed | 1 skipped with and without this change), so it is a local-environment timeout in a `workspace_tests`-job test, unrelated to this PR.
- YAML parse of the edited file succeeds; the `quality_static` step list reads: Restore workspace ownership, Report timeout budget, Checkout, Set up Node.js (hosted), Use pre-installed Node.js (self-hosted), Install Dependencies, Run Lint.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅    |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)

N/A — vitest script tests and YAML parsing only; CI validates the workflow file itself on all three platforms.

## Risk & Scope

- Main risk or tradeoff: none identified. The step's only possible effects were (a) mutating files nobody read afterwards and (b) consuming 14–21 minutes of a capped lane. Its removal cannot change the exit status of any other step: the following `Run Lint` is ESLint-only, and no CI path in this repo treats prettier output as a gate (`--check` appears nowhere in CI; `scripts/lint.js` itself uses `--write`).
- Not validated / out of scope: option B from the issue (turn `runPrettier()` into `prettier --check .` plus a one-time formatting commit across ~35 tracked files) — a deliberate, larger change kept separate so this zero-risk removal can land first. Option C (deduplicating the five full builds of the same SHA per release run) is explicitly deferred in the issue. The `quality_static` timeout-comment still citing the 21-minute `npm run format` run is left as-is: it is the historical justification for the 30 -> 60 budget bump and remains accurate as a record of what happened, even though the step is now gone.
- Breaking changes / migration notes: none. Release behaviour is identical except the lane is ~14–21 minutes shorter.

## Linked Issues

Refs #11109

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

删除 `release.yml` 中 `quality_static` job 的 `Format Project` 步骤（`npm run format`，即 `prettier --write .`）。该步骤在每次 release run 里花 14–21 分钟把所有被跟踪的文件原地重写一遍，然后什么也不验证：后面没有 `git diff --exit-code`、没有 `git status --porcelain`、没有 artifact 上传，而 runner 的工作区在 job 结束时就被丢弃。`prettier --write` 无论文件是否被改动都以 0 退出，所以这个步骤原则上就不可能因为格式问题让 release 失败。这就是 issue 里的方案 A，原样落地：两行 workflow 改动，零行为变化。

## 为什么需要

- 该步骤的输出没有任何消费者。job 里它后面唯一的步骤是 `Run Lint`（`npm run lint:ci`），那是纯 ESLint——它不读取、不依赖、也不会从 prettier 的重写中受益。格式化作为门禁在本仓库的 CI 里根本不存在：`scripts/lint.js` 的 `runPrettier()` 同样用 `--write`（不是 `--check`），唯一的格式化强制点是可被绕过的 husky pre-commit 钩子 + lint-staged。因此这个步骤消失后，下游没有任何行为改变。
- 它拖垮过真实的 release。issue 实测该步骤在空闲的 hk4 runner 上 13m58s、在争抢的 runner 上 20m45s，release run 33957952281 和 33963757913 在所有步骤全绿的情况下死于 `timeout-minutes` 上限——通过 #11098 和 #11104 报告为 "Failed job(s): quality"，且没有任何超时指示。本文件里 `quality_static` 的超时注释（30 -> 60 的那次调整）已经引用过"一个 `npm run format` 就跑了 21 分钟——run 33963757913 的这条 lane 就这么丢的"。
- 删除后 `quality_static` 向 ~10 分钟回落，在 #10879（宿主机争抢）仍然 open 期间，给这条 lane 留出它现在没有的余量。

## 审阅者测试计划

### 如何验证

1. `git diff origin/main` 只显示 `.github/workflows/release.yml` 的一个 hunk：`quality_static` 里的 `Format Project` 步骤（3 行 + 分隔空行）被删除，其他一概未动。
2. 确认无人消费该步骤：全仓库 `rg "Format Project"` 只命中 `release.yml` 自身；没有任何测试、脚本或兄弟 workflow 引用这个步骤名。
3. ratchet 与 workflow 测试：`WORKFLOW_SIZE_BASE_SHA=$(git rev-parse origin/main) npx vitest run scripts/tests/workflow-size.test.js` 和 `npx vitest run scripts/tests/release-workflow.test.js`。
4. YAML 健全性：`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`。

### 证据（前后对比）

N/A（纯 CI 改动，无用户可见界面）。

- workflow-size ratchet：202/202 通过。`release.yml` 从 75392 缩到 75319 字节，比记录的 baseline 低 73 字节——远在 4096 字节 allowance 之内，也远够不到 20 KB 的 slack 回收警告，因此无需更新 `.size-baseline`。
- release-workflow.test.js：47 通过、1 跳过。有一个测试（`names which failure this is, and never changes the exit code`）在本机超过其 5 秒限制——在未改动的 `origin/main` 上复现完全相同（有无本改动都是 1 failed | 47 passed | 1 skipped），属于 `workspace_tests` job 相关测试在本机环境的超时，与本 PR 无关。
- 编辑后文件的 YAML 解析成功；`quality_static` 的步骤列表为：Restore workspace ownership、Report timeout budget、Checkout、Set up Node.js (hosted)、Use pre-installed Node.js (self-hosted)、Install Dependencies、Run Lint。

### 测试平台

|    操作系统    | 状态 |
| :----------: | :--: |
|  🍏 macOS    |  ✅  |
| 🪟 Windows   | N/A  |
|  🐧 Linux    | N/A  |

### 环境（可选）

N/A——仅 vitest 脚本测试与 YAML 解析；CI 会在三个平台上验证 workflow 文件本身。

## 风险与范围

- 主要风险或取舍：未发现。该步骤仅有的可能影响是 (a) 重写之后没人读的文件、(b) 消耗一条有上限 lane 的 14–21 分钟。删除它不可能改变任何其他步骤的退出状态：后面的 `Run Lint` 只有 ESLint，且本仓库没有任何 CI 路径把 prettier 输出当作门禁（CI 里任何地方都没有 `--check`；`scripts/lint.js` 自己用的就是 `--write`）。
- 未验证 / 范围之外：issue 的方案 B（把 `runPrettier()` 改成 `prettier --check .`，外加一次覆盖约 35 个被跟踪文件的格式化 commit）——刻意的更大改动，保持分离，让这个零风险删除先落地。方案 C（对同一次 release run 里同一 SHA 的五次完整构建去重）在 issue 里被明确推迟。`quality_static` 的超时注释仍引用那次 21 分钟的 `npm run format`：按原样保留——它是 30 -> 60 预算调整的历史论证，作为发生过什么的记录仍然准确，尽管该步骤现在已经移除。
- 破坏性变更 / 迁移说明：无。release 行为完全一致，只是这条 lane 短了约 14–21 分钟。

## 关联 Issue

Refs #11109

</details>