### PR TITLE
fix(core): keep agent usage rounds cumulative

### DIFF
--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -1207,7 +1207,7 @@ export class AgentCore {
 
         // Update token usage if available
         if (lastUsage) {
-          this.recordTokenUsage(lastUsage, turnCounter, roundStreamStart);
+          this.recordTokenUsage(lastUsage, cumulativeRounds, roundStreamStart);
         }
 
         if (functionCalls.length > 0) {

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -51,6 +51,7 @@ import {
   type AgentStreamTextEvent,
   type AgentToolCallEvent,
   type AgentToolResultEvent,
+  type AgentUsageEvent,
 } from './agent-events.js';
 import type {
   ModelConfig,
@@ -659,6 +660,42 @@ describe('subagent.ts', () => {
           { kind: 'notification', text: 'monitor fired' },
         ]);
         expect(scope.getExecutionSummary()).toMatchObject({ rounds: 2 });
+      });
+
+      it('should keep usage rounds unique across finishing input segments', async () => {
+        const { config } = await createMockConfig();
+        mockSendMessageStream.mockImplementation(async () =>
+          (async function* () {
+            yield {
+              type: 'chunk',
+              value: {
+                candidates: [{ content: { parts: [{ text: 'Done.' }] } }],
+                usageMetadata: { totalTokenCount: 1 },
+              },
+            };
+          })(),
+        );
+
+        const scope = await AgentHeadless.create(
+          'test-agent',
+          config,
+          { systemPrompt: 'You are a test agent.' },
+          defaultModelConfig,
+          defaultRunConfig,
+        );
+        const usageRounds: number[] = [];
+        scope
+          .getEventEmitter()
+          .on(AgentEventType.USAGE_METADATA, (event: AgentUsageEvent) => {
+            usageRounds.push(event.round);
+          });
+
+        await scope.execute(new ContextState());
+        await scope.executeExternalInputs(['late correction'], undefined, {
+          resetStats: false,
+        });
+
+        expect(usageRounds).toEqual([1, 2]);
       });
 
       it('should preserve statistics for continuation work in the same logical turn', async () => {


### PR DESCRIPTION
## What this PR does

Keeps background-agent usage event round numbers cumulative when one logical run enters a second reasoning-loop segment to consume late external input.

## Why it's needed

The runtime already preserves cumulative execution statistics across the final-drain segment, but usage events still restarted at round 1. Consumers using the run and round as an idempotency key could silently discard the second segment's token usage.

## Reviewer Test Plan

### How to verify

Run the named headless-agent test and confirm that two segments in one logical execution emit usage rounds 1 and 2, while the existing continuation and statistics tests remain green.

### Evidence (Before & After)

Before: the regression test observed `[1, 1]`. After: it observes `[1, 2]`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Named Vitest file with the existing workspace dependencies.

## Risk & Scope

- Main risk or tradeoff: downstream consumers now see cumulative rather than segment-local usage round numbers.
- Not validated / out of scope: provider-level token completeness outside emitted usage events.
- Breaking changes / migration notes: none.

## Linked Issues

Follow-up for the multi-agent shared-thread design.

<details>
<summary>中文说明</summary>

## 本 PR 做什么

当同一个后台 Agent 逻辑 run 为消费迟到的外部输入而进入第二个推理循环段时，保持 usage 事件的轮次编号连续递增。

## 为什么需要

运行时已经在最终 drain 段保留累计执行统计，但 usage 事件仍从第 1 轮重新编号。以 run 和 round 作为幂等键的消费者会静默丢弃第二段的 token 用量。

## Reviewer Test Plan

### 如何验证

运行命名的 headless-agent 测试，确认同一逻辑执行的两个分段依次发出第 1、2 轮 usage，同时已有续跑与统计测试仍通过。

### 证据（修复前后）

修复前：回归测试观测为 `[1, 1]`。修复后：观测为 `[1, 2]`。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

使用现有 workspace 依赖运行命名 Vitest 文件。

## 风险与范围

- 主要风险或取舍：下游消费者现在看到累计 usage 轮次，而不是分段局部轮次。
- 未验证 / 范围外：usage 事件之外的 provider token 完整性。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

multi-agent shared-thread 设计的后续修正。

</details>
