### PR TITLE
refactor(core): explain resident continuation outcomes

### DIFF
--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -3339,7 +3339,7 @@ describe('BackgroundAgentResumeService', () => {
     );
 
     expect(registry.continueResidentAgent(agentId, 'tighten the summary')).toBe(
-      true,
+      'continued',
     );
     expect(registry.get(agentId)?.status).toBe('running');
     await vi.waitFor(() => {
@@ -3355,7 +3355,9 @@ describe('BackgroundAgentResumeService', () => {
     registry.reset();
 
     expect(dispose).toHaveBeenCalledTimes(1);
-    expect(registry.continueResidentAgent(agentId, 'again')).toBe(false);
+    expect(registry.continueResidentAgent(agentId, 'again')).toBe(
+      'not_completed',
+    );
   });
 
   it("clears the previous incarnation's stats and activities when cold-reviving", async () => {
@@ -3660,7 +3662,7 @@ describe('BackgroundAgentResumeService', () => {
     });
 
     expect(subagentManager.createAgentHeadless).toHaveBeenCalledOnce();
-    expect(registry.continueResidentAgent(agentId, 'again')).toBe(false);
+    expect(registry.continueResidentAgent(agentId, 'again')).toBe('fallback');
     expect(dispose).toHaveBeenCalledOnce();
   });
 

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -1418,11 +1418,15 @@ export class BackgroundAgentResumeService {
       const residentController: ResidentBackgroundAgent = {
         continue: (message) => {
           if (!canStayResident || disposeRequested || runtimeDisposed) {
-            return false;
+            return 'fallback';
           }
           if (needsAutoPermissionLease()) {
             requestRuntimeDisposal();
-            return false;
+            return 'fallback';
+          }
+
+          if (!registry.canStartBackgroundAgent(meta.model)) {
+            return 'capacity_wait';
           }
 
           const nextAbortController = new AbortController();
@@ -1438,7 +1442,9 @@ export class BackgroundAgentResumeService {
                 meta.agentId
               }: ${error instanceof Error ? error.message : String(error)}`,
             );
-            return false;
+            return registry.canStartBackgroundAgent(meta.model)
+              ? 'fallback'
+              : 'capacity_wait';
           }
           if (
             !restarted ||
@@ -1447,7 +1453,7 @@ export class BackgroundAgentResumeService {
             registry.get(meta.agentId) !== restarted ||
             restarted.status !== 'running'
           ) {
-            return false;
+            return 'fallback';
           }
 
           liveToolCallCount = 0;
@@ -1479,7 +1485,7 @@ export class BackgroundAgentResumeService {
               );
             });
           currentTurnPromise.catch(reportUnexpectedBackgroundError);
-          return true;
+          return 'continued';
         },
         dispose: requestRuntimeDisposal,
       };

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -900,6 +900,24 @@ describe('BackgroundTaskRegistry', () => {
       expect(registry.get('bg-2')?.status).toBe('running');
     });
 
+    it('does not count idle resident runtimes as claimed slots', () => {
+      registry = new BackgroundTaskRegistry({
+        maxConcurrentBackgroundAgents: 1,
+      });
+
+      for (const agentId of ['resident-1', 'resident-2', 'resident-3']) {
+        registry.register(makeRegistration(agentId));
+        registry.complete(agentId, 'done');
+        registry.registerResidentAgent(agentId, {
+          continue: vi.fn(() => 'continued' as const),
+          dispose: vi.fn(),
+        });
+      }
+
+      expect(registry.canStartBackgroundAgent()).toBe(true);
+      expect(() => registry.register(makeRegistration('next'))).not.toThrow();
+    });
+
     it('queues waiters until a background slot is released', async () => {
       registry = new BackgroundTaskRegistry({
         maxConcurrentBackgroundAgents: 1,

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -15,6 +15,7 @@ import {
   type AgentTaskRegistration,
   type BackgroundApproval,
   type BackgroundTaskEntry,
+  type ResidentAgentContinuationResult,
   type ResidentBackgroundAgent,
 } from './background-tasks.js';
 import {
@@ -297,7 +298,7 @@ describe('BackgroundTaskRegistry', () => {
       overrides: Partial<ResidentBackgroundAgent> = {},
     ): ResidentBackgroundAgent {
       return {
-        continue: vi.fn(() => true),
+        continue: vi.fn(() => 'continued' as const),
         dispose: vi.fn(),
         ...overrides,
       };
@@ -309,12 +310,12 @@ describe('BackgroundTaskRegistry', () => {
       registry.registerResidentAgent('resident-1', resident);
 
       expect(registry.continueResidentAgent('resident-1', 'too early')).toBe(
-        false,
+        'not_completed',
       );
 
       registry.complete('resident-1', 'first result');
       expect(registry.continueResidentAgent('resident-1', 'keep going')).toBe(
-        true,
+        'continued',
       );
       expect(resident.continue).toHaveBeenCalledWith('keep going');
 
@@ -328,7 +329,7 @@ describe('BackgroundTaskRegistry', () => {
       expect(resident.dispose).not.toHaveBeenCalled();
       expect(
         registry.continueResidentAgent('resident-1', 'after unregister'),
-      ).toBe(false);
+      ).toBe('fallback');
     });
 
     it('disposes a replaced resident without letting its stale handle remove the replacement', () => {
@@ -477,7 +478,7 @@ describe('BackgroundTaskRegistry', () => {
       registry.register(makeRegistration('cancelled-completion'));
       const resident = makeResident();
       registry.registerResidentAgent('cancelled-completion', resident);
-      let continuation: boolean | undefined;
+      let continuation: ResidentAgentContinuationResult | undefined;
       registry.setNotificationCallback(() => {
         continuation = registry.continueResidentAgent(
           'cancelled-completion',
@@ -488,7 +489,7 @@ describe('BackgroundTaskRegistry', () => {
       registry.cancel('cancelled-completion');
       registry.complete('cancelled-completion', 'finished while cancelling');
 
-      expect(continuation).toBe(false);
+      expect(continuation).toBe('fallback');
       expect(resident.continue).not.toHaveBeenCalled();
       expect(resident.dispose).toHaveBeenCalledOnce();
     });
@@ -1867,7 +1868,7 @@ describe('BackgroundTaskRegistry', () => {
     it('disposes a resident runtime when its terminal entry is evicted', () => {
       registry.register(makeRegisteredEntry('resident-oldest', 0));
       const resident = {
-        continue: vi.fn(() => true),
+        continue: vi.fn(() => 'continued' as const),
         dispose: vi.fn(),
       };
       registry.registerResidentAgent('resident-oldest', resident);

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -450,13 +450,19 @@ export type BackgroundActivityChangeCallback = (entry: AgentTask) => void;
  */
 export type BackgroundApprovalChangeCallback = (entry: AgentTask) => void;
 
+export type ResidentAgentContinuationResult =
+  | 'continued'
+  | 'fallback'
+  | 'capacity_wait'
+  | 'not_completed';
+
 /**
  * Session-scoped handle for a background agent whose runtime remains alive
  * after a completed turn. The handle is deliberately not part of AgentTask:
  * task state is serializable, while the live runtime is process-local.
  */
 export interface ResidentBackgroundAgent {
-  continue(message: string): boolean;
+  continue(message: string): ResidentAgentContinuationResult;
   dispose(): void;
 }
 
@@ -787,10 +793,14 @@ export class BackgroundTaskRegistry {
     this.residentAgents.set(agentId, resident);
   }
 
-  continueResidentAgent(agentId: string, message: string): boolean {
+  continueResidentAgent(
+    agentId: string,
+    message: string,
+  ): ResidentAgentContinuationResult {
     const entry = this.agents.get(agentId);
     const resident = this.residentAgents.get(agentId);
-    if (!resident || entry?.status !== 'completed') return false;
+    if (entry?.status !== 'completed') return 'not_completed';
+    if (!resident) return 'fallback';
     return resident.continue(message);
   }
 

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -6377,10 +6377,10 @@ describe('AgentTool', () => {
       });
 
       const resident = mockRegistry.registerResidentAgent.mock.calls[0]?.[1] as
-        | { continue: (message: string) => boolean }
+        | { continue: (message: string) => string }
         | undefined;
       expect(resident).toBeDefined();
-      expect(resident?.continue('Now inspect the helper')).toBe(true);
+      expect(resident?.continue('Now inspect the helper')).toBe('continued');
 
       await vi.waitFor(() => {
         expect(mockAgent.execute).toHaveBeenCalledTimes(2);
@@ -6424,10 +6424,10 @@ describe('AgentTool', () => {
       });
 
       const resident = mockRegistry.registerResidentAgent.mock.calls[0]?.[1] as
-        | { continue: (message: string) => boolean }
+        | { continue: (message: string) => string }
         | undefined;
       expect(resident).toBeDefined();
-      expect(resident?.continue('Now inspect the helper')).toBe(true);
+      expect(resident?.continue('Now inspect the helper')).toBe('continued');
 
       // The hot continuation patch must clear run N-1's terminal summary —
       // mirroring the cold-resume patch — so a crash mid-continuation cannot
@@ -6445,6 +6445,29 @@ describe('AgentTool', () => {
         expect(mockRegistry.complete).toHaveBeenCalledTimes(2);
       });
       patchMetaSpy.mockRestore();
+    });
+
+    it('reports capacity before restarting a resident runtime', async () => {
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation({
+        description: 'Start monitor',
+        prompt: 'Watch for changes',
+        subagent_type: 'monitor',
+      });
+
+      await invocation.execute();
+      await vi.waitFor(() => {
+        expect(mockRegistry.complete).toHaveBeenCalledTimes(1);
+      });
+
+      mockRegistry.canStartBackgroundAgent.mockReturnValue(false);
+      const resident = mockRegistry.registerResidentAgent.mock.calls[0]?.[1] as
+        | { continue: (message: string) => string }
+        | undefined;
+
+      expect(resident?.continue('Continue')).toBe('capacity_wait');
+      expect(mockRegistry.restartCompletedAgent).not.toHaveBeenCalled();
     });
 
     it('claims finishing-window input before publishing completion', async () => {
@@ -6570,13 +6593,13 @@ describe('AgentTool', () => {
         expect(mockRegistry.complete).toHaveBeenCalled();
       });
       const resident = mockRegistry.registerResidentAgent.mock.calls[0]?.[1] as
-        | { continue: (message: string) => boolean }
+        | { continue: (message: string) => string }
         | undefined;
       expect(resident).toBeDefined();
       expect(mockSubagentDispose).not.toHaveBeenCalled();
 
       vi.mocked(config.getApprovalMode).mockReturnValue(ApprovalMode.DEFAULT);
-      expect(resident?.continue('Continue')).toBe(false);
+      expect(resident?.continue('Continue')).toBe('fallback');
 
       expect(mockRegistry.unregisterResidentAgent).toHaveBeenCalled();
       expect(mockSubagentDispose).toHaveBeenCalledOnce();

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -3773,11 +3773,16 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         const residentController: ResidentBackgroundAgent = {
           continue: (message) => {
             if (!canStayResident || disposeRequested || runtimeDisposed) {
-              return false;
+              return 'fallback';
             }
             if (needsAutoPermissionLease()) {
               requestRuntimeDisposal();
-              return false;
+              return 'fallback';
+            }
+
+            const currentEntry = registry.get(hookOpts.agentId);
+            if (!registry.canStartBackgroundAgent(currentEntry?.model)) {
+              return 'capacity_wait';
             }
 
             const nextAbortController = new AbortController();
@@ -3791,7 +3796,9 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
               debugLogger.warn(
                 `[Agent] Could not continue resident background agent ${hookOpts.agentId}: ${error instanceof Error ? error.message : String(error)}`,
               );
-              return false;
+              return registry.canStartBackgroundAgent(currentEntry?.model)
+                ? 'fallback'
+                : 'capacity_wait';
             }
             if (
               !restarted ||
@@ -3800,7 +3807,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
               registry.get(hookOpts.agentId) !== restarted ||
               restarted.status !== 'running'
             ) {
-              return false;
+              return 'fallback';
             }
 
             liveToolCallCount = 0;
@@ -3835,7 +3842,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
                 );
               });
             currentTurnPromise.catch(reportUnexpectedBackgroundError);
-            return true;
+            return 'continued';
           },
           dispose: requestRuntimeDisposal,
         };

--- a/packages/core/src/tools/send-message.test.ts
+++ b/packages/core/src/tools/send-message.test.ts
@@ -481,7 +481,7 @@ describe('SendMessageTool — background-task mode', () => {
       outputFile: '/tmp/test.jsonl',
       metaPath: '/tmp/test.meta.json',
     });
-    const continueResident = vi.fn().mockReturnValue(true);
+    const continueResident = vi.fn().mockReturnValue('continued');
     registry.registerResidentAgent('agent-1', {
       continue: continueResident,
       dispose: vi.fn(),
@@ -498,6 +498,32 @@ describe('SendMessageTool — background-task mode', () => {
     expect(result.error).toBeUndefined();
     expect(result.llmContent).toContain('existing runtime');
     expect(result.returnDisplay).toContain('Continued');
+  });
+
+  it('reports resident capacity without attempting a cold revive', async () => {
+    registry.register({
+      agentId: 'agent-1',
+      description: 'test agent',
+      status: 'completed',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      isBackgrounded: true,
+      outputFile: '/tmp/test.jsonl',
+      metaPath: '/tmp/test.meta.json',
+    });
+    registry.registerResidentAgent('agent-1', {
+      continue: vi.fn().mockReturnValue('capacity_wait'),
+      dispose: vi.fn(),
+    });
+
+    const result = await tool.validateBuildAndExecute(
+      { task_id: 'agent-1', message: 'now refactor the helper' },
+      new AbortController().signal,
+    );
+
+    expect(reviveCompletedBackgroundAgent).not.toHaveBeenCalled();
+    expect(result.error?.type).toBe(ToolErrorType.SEND_MESSAGE_NOT_RUNNING);
+    expect(result.llmContent).toContain('capacity');
   });
 
   it('revives a completed task when no resident runtime is available', async () => {

--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -293,14 +293,24 @@ class SendMessageInvocation extends BaseToolInvocation<
       // compatible runtime is not retained across session restore, so the
       // persisted transcript remains the cold fallback for resumable agents.
       if (entry.status === 'completed') {
-        const continued = registry.continueResidentAgent(
+        const continuation = registry.continueResidentAgent(
           this.params.task_id,
           this.params.message,
         );
-        if (continued) {
+        if (continuation === 'continued') {
           return {
             llmContent: `Background task "${this.params.task_id}" continued on its existing runtime with your message as the next instruction.`,
             returnDisplay: `Continued ${entry.description}`,
+          };
+        }
+        if (continuation === 'capacity_wait') {
+          return {
+            llmContent: `Error: Background task "${this.params.task_id}" is waiting for background-agent capacity.`,
+            returnDisplay: 'Task is waiting for capacity.',
+            error: {
+              message: `Background-agent capacity unavailable: ${this.params.task_id}`,
+              type: ToolErrorType.SEND_MESSAGE_NOT_RUNNING,
+            },
           };
         }
 


### PR DESCRIPTION
## What this PR does

Replaces the resident-agent continuation boolean with a small typed outcome: continued, cold-fallback, capacity-wait, or wrong-state. Both resident runtime implementations report capacity before mutation, and the existing message tool no longer mistakes capacity pressure for a missing resident runtime.

## Why it's needed

A dispatcher must decide whether to keep a durable run queued, fall back to transcript-based revival, or treat it as already dispatched. A boolean collapsed those distinct actions and could trigger a cold revive while the background-agent cap was full.

## Reviewer Test Plan

### How to verify

Run the four named registry, resume, agent-tool, and message-tool test files. Confirm a resident continuation succeeds normally, falls back when its runtime is unavailable, reports capacity without mutating or cold-reviving, and rejects a non-completed entry distinctly.

### Evidence (Before & After)

Before: every failed hot continuation returned `false` and the caller attempted a cold revive. After: capacity returns `capacity_wait`, no cold revive is attempted, and other failures retain the existing fallback behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   N/A  |
|  🐧 Linux  |   N/A  |

### Environment (optional)

Named Vitest files with existing workspace dependencies; core TypeScript check also passed.

## Risk & Scope

- Main risk or tradeoff: the process-local resident continuation interface now returns a string union instead of a boolean.
- Not validated / out of scope: durable mesh queueing and restart recovery.
- Breaking changes / migration notes: internal callers and tests are updated together; no public command schema changes.

## Linked Issues

Follow-up for the multi-agent shared-thread design.

<details>
<summary>中文说明</summary>

## 本 PR 做什么

把 resident Agent 续跑的 boolean 返回值替换为一个小型类型化结果：已继续、冷恢复 fallback、容量等待、状态不允许。两个 resident runtime 都会在修改状态前报告容量，现有消息工具也不再把容量不足误判成 resident runtime 缺失。

## 为什么需要

dispatcher 必须判断持久 run 应继续排队、回退到基于 transcript 的冷恢复，还是已经成功派发。boolean 把这些动作压成一个值，会在后台 Agent 容量已满时错误尝试冷恢复。

## Reviewer Test Plan

### 如何验证

运行四个命名的 registry、resume、agent-tool 和 message-tool 测试文件。确认 resident 续跑正常成功；runtime 不可用时 fallback；容量不足时不修改状态也不冷恢复；非 completed 状态有独立结果。

### 证据（修复前后）

修复前：所有 hot continuation 失败都返回 `false`，调用方随后尝试冷恢复。修复后：容量不足返回 `capacity_wait`，不会尝试冷恢复；其他失败保留原有 fallback 行为。

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows | N/A  |
|  🐧 Linux  | N/A  |

### 环境（可选）

使用现有 workspace 依赖运行命名 Vitest 文件；core TypeScript 检查也已通过。

## 风险与范围

- 主要风险或取舍：进程内 resident continuation 接口由 boolean 改为 string union。
- 未验证 / 范围外：持久 mesh 排队与重启恢复。
- 破坏性变更 / 迁移说明：内部调用方和测试同步更新；公共命令 schema 不变。

## 关联 Issue

multi-agent shared-thread 设计的后续修正。

</details>
